### PR TITLE
Doc: Fix spelling in ScriptTileList::RemoveRectangle

### DIFF
--- a/src/script/api/script_tilelist.hpp
+++ b/src/script/api/script_tilelist.hpp
@@ -37,7 +37,7 @@ public:
 	void AddTile(TileIndex tile);
 
 	/**
-	 * Remove the tiles inside the rectangle between tile_from and tile_to form the list.
+	 * Remove the tiles inside the rectangle between tile_from and tile_to from the list.
 	 * @param tile_from One corner of the tiles to remove.
 	 * @param tile_to The other corner of the files to remove.
 	 * @pre ScriptMap::IsValidTile(tile_from).


### PR DESCRIPTION
## Motivation / Problem

Doxygen comment has a spelling mistake.  This appears in the generated NoAI docs.


## Description

See above.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
