### PR TITLE
Codechange: use std::string and concatenation when combining multiple formatted strings

### DIFF
--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -875,9 +875,8 @@ struct DepotWindow : Window {
 		}
 
 		/* Build tooltipstring */
-		static char details[1024];
-		details[0] = '\0';
-		char *pos = details;
+		static std::string details;
+		details.clear();
 
 		for (CargoID cargo_type = 0; cargo_type < NUM_CARGO; cargo_type++) {
 			if (capacity[cargo_type] == 0) continue;
@@ -886,13 +885,13 @@ struct DepotWindow : Window {
 			SetDParam(1, loaded[cargo_type]);   // {CARGO} #2
 			SetDParam(2, cargo_type);           // {SHORTCARGO} #1
 			SetDParam(3, capacity[cargo_type]); // {SHORTCARGO} #2
-			pos = GetString(pos, STR_DEPOT_VEHICLE_TOOLTIP_CARGO, lastof(details));
+			details += GetString(STR_DEPOT_VEHICLE_TOOLTIP_CARGO);
 		}
 
 		/* Show tooltip window */
 		uint64 args[2];
 		args[0] = (whole_chain ? num : v->engine_type);
-		args[1] = (uint64)(size_t)details;
+		args[1] = (uint64)(size_t)details.c_str();
 		GuiShowTooltips(this, whole_chain ? STR_DEPOT_VEHICLE_TOOLTIP_CHAIN : STR_DEPOT_VEHICLE_TOOLTIP, 2, args, TCC_RIGHT_CLICK);
 
 		return true;

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -414,23 +414,22 @@ void ShowErrorMessage(StringID summary_msg, StringID detailed_msg, WarningLevel 
 
 	if (wl != WL_INFO) {
 		/* Print message to console */
-		char buf[DRAW_STRING_BUFFER];
 
 		if (textref_stack_size > 0) StartTextRefStackUsage(textref_stack_grffile, textref_stack_size, textref_stack);
 
-		char *b = GetString(buf, summary_msg, lastof(buf));
+		std::string message = GetString(summary_msg);
 		if (detailed_msg != INVALID_STRING_ID) {
-			b += seprintf(b, lastof(buf), " ");
-			GetString(b, detailed_msg, lastof(buf));
+			message += " ";
+			message += GetString(detailed_msg);
 		}
 		if (extra_msg != INVALID_STRING_ID) {
-			b += seprintf(b, lastof(buf), " ");
-			GetString(b, extra_msg, lastof(buf));
+			message += " ";
+			message += GetString(extra_msg);
 		}
 
 		if (textref_stack_size > 0) StopTextRefStackUsage();
 
-		IConsolePrint(wl == WL_WARNING ? CC_WARNING : CC_ERROR, buf);
+		IConsolePrint(wl == WL_WARNING ? CC_WARNING : CC_ERROR, message);
 	}
 
 	bool is_critical = wl == WL_CRITICAL;

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -377,9 +377,8 @@ bool LinkGraphOverlay::ShowTooltip(Point pt, TooltipCloseCondition close_cond)
 					pt.x - 2 <= std::max(pta.x, ptb.x) &&
 					pt.y + 2 >= std::min(pta.y, ptb.y) &&
 					pt.y - 2 <= std::max(pta.y, ptb.y)) {
-				static char buf[1024];
-				char *buf_end = buf;
-				buf[0] = 0;
+				static std::string tooltip_extension;
+				tooltip_extension.clear();
 				/* Fill buf with more information if this is a bidirectional link. */
 				uint32 back_time = 0;
 				auto k = this->cached_links[j->first].find(i->first);
@@ -390,21 +389,21 @@ bool LinkGraphOverlay::ShowTooltip(Point pt, TooltipCloseCondition close_cond)
 						SetDParam(0, back.cargo);
 						SetDParam(1, back.Usage());
 						SetDParam(2, back.Usage() * 100 / (back.capacity + 1));
-						buf_end = GetString(buf, STR_LINKGRAPH_STATS_TOOLTIP_RETURN_EXTENSION, lastof(buf));
+						tooltip_extension = GetString(STR_LINKGRAPH_STATS_TOOLTIP_RETURN_EXTENSION);
 					}
 				}
 				/* Add information about the travel time if known. */
 				const auto time = link.time ? back_time ? ((link.time + back_time) / 2) : link.time : back_time;
 				if (time > 0) {
 					SetDParam(0, time);
-					buf_end = GetString(buf_end, STR_LINKGRAPH_STATS_TOOLTIP_TIME_EXTENSION, lastof(buf));
+					tooltip_extension += GetString(STR_LINKGRAPH_STATS_TOOLTIP_TIME_EXTENSION);
 				}
 				SetDParam(0, link.cargo);
 				SetDParam(1, link.Usage());
 				SetDParam(2, i->first);
 				SetDParam(3, j->first);
 				SetDParam(4, link.Usage() * 100 / (link.capacity + 1));
-				SetDParamStr(5, buf);
+				SetDParamStr(5, tooltip_extension);
 				GuiShowTooltips(this->window, STR_LINKGRAPH_STATS_TOOLTIP, 7, nullptr, close_cond);
 				return true;
 			}


### PR DESCRIPTION
## Motivation / Problem

Usage of `strecpy`-esque `GetString`.


## Description

Replace `strecpy`-esque variant with `std::string` returning variant of `GetString` and use concatenation to build the final string.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
