### PR TITLE
Change: move string validation (and assignment) to textbuf

### DIFF
--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -959,17 +959,7 @@ struct QueryStringWindow : public Window
 	QueryStringWindow(StringID str, StringID caption, uint max_bytes, uint max_chars, WindowDesc *desc, Window *parent, CharSetFilter afilter, QueryStringFlags flags) :
 			Window(desc), editbox(max_bytes, max_chars)
 	{
-		char *last_of = &this->editbox.text.buf[this->editbox.text.max_bytes - 1];
-		GetString(this->editbox.text.buf, str, last_of);
-		StrMakeValidInPlace(this->editbox.text.buf, last_of, SVS_NONE);
-
-		/* Make sure the name isn't too long for the text buffer in the number of
-		 * characters (not bytes). max_chars also counts the '\0' characters. */
-		while (Utf8StringLength(this->editbox.text.buf) + 1 > this->editbox.text.max_chars) {
-			*Utf8PrevChar(this->editbox.text.buf + strlen(this->editbox.text.buf)) = '\0';
-		}
-
-		this->editbox.text.UpdateSize();
+		this->editbox.text.Assign(str);
 
 		if ((flags & QSF_ACCEPT_UNCHANGED) == 0) this->editbox.orig = this->editbox.text.buf;
 

--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -388,8 +388,7 @@ Textbuf::~Textbuf()
  */
 void Textbuf::Assign(StringID string)
 {
-	GetString(this->buf, string, &this->buf[this->max_bytes - 1]);
-	this->UpdateSize();
+	this->Assign(GetString(string));
 }
 
 /**
@@ -398,7 +397,16 @@ void Textbuf::Assign(StringID string)
  */
 void Textbuf::Assign(const std::string_view text)
 {
-	strecpy(this->buf, text.data(), &this->buf[this->max_bytes - 1]);
+	const char *last_of = &this->buf[this->max_bytes - 1];
+	strecpy(this->buf, text.data(), last_of);
+	StrMakeValidInPlace(this->buf, last_of, SVS_NONE);
+
+	/* Make sure the name isn't too long for the text buffer in the number of
+	 * characters (not bytes). max_chars also counts the '\0' characters. */
+	while (Utf8StringLength(this->buf) + 1 > this->max_chars) {
+		*Utf8PrevChar(this->buf + strlen(this->buf)) = '\0';
+	}
+
 	this->UpdateSize();
 }
 


### PR DESCRIPTION
## Motivation / Problem

TextBuf and QueryStringWindow still using the `strecpy`-esque string formatting.
While working on it, figuring out that TextBuf does not ensure a valid string after the formatted string gets truncated, and furthermore not ensuring the maximum number of characters is exceeded.


## Description

Use `TextBuf::Assign` to assign the string from the `QueryStringWindow`.
Let the `StringID` variant of `TextBuf::Assign` call the `std::string_view` variant with just `GetString(stringid)` as parameter.
Move the validation and character limit checks from the QueryStringWindow to TextBuf.


## Limitations

None that I'm aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
