### PR TITLE
Codechange: use C++ style methods to combine a Utf8Encoded character and a formatted string

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -248,7 +248,6 @@ void NetworkTextMessage(NetworkAction action, TextColour colour, bool self_send,
 		default:                            strid = STR_NETWORK_CHAT_ALL; break;
 	}
 
-	char message[1024];
 	SetDParamStr(0, name);
 	SetDParamStr(1, str);
 	SetDParam(2, data);
@@ -258,8 +257,10 @@ void NetworkTextMessage(NetworkAction action, TextColour colour, bool self_send,
 	 * right-to-left characters depending on the context. As the next text might be an user's name, the
 	 * user name's characters will influence the direction of the "***" instead of the language setting
 	 * of the game. Manually set the direction of the "***" by inserting a text-direction marker. */
-	char *msg_ptr = message + Utf8Encode(message, _current_text_dir == TD_LTR ? CHAR_TD_LRM : CHAR_TD_RLM);
-	GetString(msg_ptr, strid, lastof(message));
+	std::ostringstream stream;
+	std::ostreambuf_iterator<char> iterator(stream);
+	Utf8Encode(iterator, _current_text_dir == TD_LTR ? CHAR_TD_LRM : CHAR_TD_RLM);
+	std::string message = stream.str() + GetString(strid);
 
 	Debug(desync, 1, "msg: {:08x}; {:02x}; {}", TimerGameCalendar::date, TimerGameCalendar::date_fract, message);
 	IConsolePrint(colour, message);


### PR DESCRIPTION
## Motivation / Problem

Last remnants of `strecpy`-esque `GetString` variant calls.


## Description

Use an std::ostringstream, like in newgrf_text and string validation, to get the `std::string` version of the encoded LTR character and then concatenate the `std::string` from `GetString` to that.

After this and #10923, all `strecpy`-esque calls of `GetString` are gone and the `StringBuilder` can be converted to be backed by `std::string`.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
