### PR TITLE
Cleanup: remove stre-style GetString

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -281,15 +281,6 @@ void GetStringWithArgs(StringBuilder &builder, StringID string, StringParameters
 	FormatString(builder, GetStringPtr(string), args, case_index);
 }
 
-char *GetString(char *buffr, StringID string, const char *last)
-{
-	_global_string_params.ClearTypeInformation();
-	_global_string_params.offset = 0;
-	StringBuilder builder(&buffr, last);
-	GetStringWithArgs(builder, string, &_global_string_params);
-	return builder.GetEnd();
-}
-
 
 /**
  * Resolve the given StringID into a std::string with all the associated
@@ -299,9 +290,9 @@ char *GetString(char *buffr, StringID string, const char *last)
  */
 std::string GetString(StringID string)
 {
-	char buffer[DRAW_STRING_BUFFER];
-	GetString(buffer, string, lastof(buffer));
-	return buffer;
+	_global_string_params.ClearTypeInformation();
+	_global_string_params.offset = 0;
+	return GetStringWithArgs(string, &_global_string_params);
 }
 
 /**

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -170,7 +170,6 @@ public:
 };
 extern StringParameters _global_string_params;
 
-char *GetString(char *buffr, StringID string, const char *last);
 std::string GetString(StringID string);
 std::string GetStringWithArgs(StringID string, StringParameters *args);
 const char *GetStringPtr(StringID string);


### PR DESCRIPTION
## Motivation / Problem

C-style string support in the string formatting.


## Description

Remove the `strecpy`-esque `GetString` API.


## Limitations

Might break downstreams that are still using it.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
