### PR TITLE
Codechange: convert C-style GetTownName API to std::string returning API

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -207,9 +207,7 @@ void Town::InitializeLayout(TownLayout layout)
 
 void Town::FillCachedName() const
 {
-	char buf[MAX_LENGTH_TOWN_NAME_CHARS * MAX_CHAR_LENGTH];
-	char *end = GetTownName(buf, this, lastof(buf));
-	this->cached_name.assign(buf, end);
+	this->cached_name.assign(GetTownName(this));
 }
 
 /**

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -207,7 +207,7 @@ void Town::InitializeLayout(TownLayout layout)
 
 void Town::FillCachedName() const
 {
-	this->cached_name.assign(GetTownName(this));
+	this->cached_name = GetTownName(this);
 }
 
 /**

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1159,8 +1159,7 @@ public:
 		if (!this->townnamevalid) {
 			this->townname_editbox.text.DeleteAll();
 		} else {
-			GetTownName(this->townname_editbox.text.buf, &this->params, this->townnameparts, &this->townname_editbox.text.buf[this->townname_editbox.text.max_bytes - 1]);
-			this->townname_editbox.text.UpdateSize();
+			this->townname_editbox.text.Assign(GetTownName(&this->params, this->townnameparts));
 		}
 		UpdateOSKOriginalText(this, WID_TF_TOWN_NAME_EDITBOX);
 
@@ -1198,9 +1197,8 @@ public:
 			name = this->townname_editbox.text.buf;
 		} else {
 			/* If user changed the name, send it */
-			char buf[MAX_LENGTH_TOWN_NAME_CHARS * MAX_CHAR_LENGTH];
-			GetTownName(buf, &this->params, this->townnameparts, lastof(buf));
-			if (strcmp(buf, this->townname_editbox.text.buf) != 0) name = this->townname_editbox.text.buf;
+			std::string original_name = GetTownName(&this->params, this->townnameparts);
+			if (original_name != this->townname_editbox.text.buf) name = this->townname_editbox.text.buf;
 		}
 
 		bool success = Command<CMD_FOUND_TOWN>::Post(errstr, cc,

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -116,7 +116,11 @@ bool VerifyTownName(uint32 r, const TownNameParams *par, TownNames *town_names)
 		for (const Town *t : Town::Iterate()) {
 			/* We can't just compare the numbers since
 			 * several numbers may map to a single name. */
-			if (name == (t->name.empty() ? GetTownName(t) : t->name)) return false;
+			if (t->name.empty()) {
+				if (name == GetTownName(t)) return false;
+			} else {
+				if (name == t->name) return false;
+			}
 		}
 	}
 

--- a/src/townname_func.h
+++ b/src/townname_func.h
@@ -13,8 +13,8 @@
 #include "core/random_func.hpp"
 #include "townname_type.h"
 
-char *GetTownName(char *buff, const TownNameParams *par, uint32 townnameparts, const char *last);
-char *GetTownName(char *buff, const Town *t, const char *last);
+std::string GetTownName(const TownNameParams *par, uint32 townnameparts);
+std::string GetTownName(const Town *t);
 bool VerifyTownName(uint32 r, const TownNameParams *par, TownNames *town_names = nullptr);
 bool GenerateTownName(Randomizer &randomizer, uint32 *townnameparts, TownNames *town_names = nullptr);
 


### PR DESCRIPTION
## Motivation / Problem

C-style string APIs.


## Description

Replace the `strecpy`-esque C-style API with one that returns `std::string`.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
