### PR TITLE
Codechange: replace C-style string backing of StringBuilder with std::string

### DIFF
--- a/src/string.cpp
+++ b/src/string.cpp
@@ -672,6 +672,11 @@ size_t Utf8Encode(std::ostreambuf_iterator<char> &buf, WChar c)
 	return Utf8Encode<std::ostreambuf_iterator<char> &>(buf, c);
 }
 
+size_t Utf8Encode(std::back_insert_iterator<std::string> &buf, WChar c)
+{
+	return Utf8Encode<std::back_insert_iterator<std::string> &>(buf, c);
+}
+
 /**
  * Properly terminate an UTF8 string to some maximum length
  * @param s string to check if it needs additional trimming

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -94,6 +94,7 @@ bool IsValidChar(WChar key, CharSetFilter afilter);
 size_t Utf8Decode(WChar *c, const char *s);
 size_t Utf8Encode(char *buf, WChar c);
 size_t Utf8Encode(std::ostreambuf_iterator<char> &buf, WChar c);
+size_t Utf8Encode(std::back_insert_iterator<std::string> &buf, WChar c);
 size_t Utf8TrimString(char *s, size_t maxlen);
 
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -303,11 +303,10 @@ std::string GetString(StringID string)
  */
 std::string GetStringWithArgs(StringID string, StringParameters *args)
 {
-	char buffer[DRAW_STRING_BUFFER];
-	char *state = buffer;
-	StringBuilder builder(&state, lastof(buffer));
+	std::string result;
+	StringBuilder builder(result);
 	GetStringWithArgs(builder, string, args);
-	return std::string(buffer, builder.GetEnd());
+	return result;
 }
 
 /**
@@ -838,9 +837,8 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 		 * the parameters. So, we need to gather the type information via the
 		 * dry run first, before we can continue formatting the string.
 		 */
-		char buffer[DRAW_STRING_BUFFER];
-		char *state = buffer;
-		StringBuilder dry_run_builder(&state, lastof(buffer));
+		std::string buffer;
+		StringBuilder dry_run_builder(buffer);
 		if (UsingNewGRFTextStack()) {
 			/* Values from the NewGRF text stack are only copied to the normal
 			 * argv array at the time they are encountered. That means that if
@@ -1004,21 +1002,17 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 					char *p = input + Utf8Encode(input, args->GetTypeAtOffset(offset));
 					*p = '\0';
 
-					/* The gender is stored at the start of the formatted string.
-					 * So to determine the gender after formatting we only need
-					 * enough space for the gender index token, one character
-					 * for the actual gender and one character for '\0'. */
-					char buf[MAX_CHAR_LENGTH + 1 + 1];
-					char *state = buf;
+					/* The gender is stored at the start of the formatted string. */
 					bool old_sgd = _scan_for_gender_data;
 					_scan_for_gender_data = true;
-					StringBuilder tmp_builder(&state, lastof(buf));
+					std::string buffer;
+					StringBuilder tmp_builder(buffer);
 					StringParameters tmp_params(args->GetPointerToOffset(offset), args->num_param - offset, nullptr);
 					FormatString(tmp_builder, input, &tmp_params);
 					_scan_for_gender_data = old_sgd;
 
 					/* And determine the string. */
-					const char *s = buf;
+					const char *s = buffer.c_str();
 					WChar c = Utf8Consume(&s);
 					/* Does this string have a gender, if so, set it */
 					if (c == SCC_GENDER_INDEX) gender = (byte)s[0];

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -475,8 +475,8 @@ static void FormatGenericCurrency(StringBuilder &builder, const CurrencySpec *sp
 
 	/* convert from negative */
 	if (number < 0) {
-		if (!builder.Utf8Encode(SCC_PUSH_COLOUR)) return;
-		if (!builder.Utf8Encode(SCC_RED)) return;
+		builder.Utf8Encode(SCC_PUSH_COLOUR);
+		builder.Utf8Encode(SCC_RED);
 		builder += '-';
 		number = -number;
 	}
@@ -1224,8 +1224,6 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 
 				for (const auto &cs : _sorted_cargo_specs) {
 					if (!HasBit(cmask, cs->Index())) continue;
-
-					if (builder.Remaining() < 2) break; // ", "
 
 					if (first) {
 						first = false;

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -15,9 +15,6 @@
 /**
  * Equivalent to the std::back_insert_iterator in function, with some
  * convenience helpers for string concatenation.
- *
- * The formatter is currently backed by an external char buffer, and has some
- * extra functions to ease the migration from char buffers to std::string.
  */
 class StringBuilder {
 	std::string *string;
@@ -80,11 +77,10 @@ public:
 	 * Encode the given Utf8 character into the output buffer.
 	 * @param c The character to encode.
 	 */
-	bool Utf8Encode(WChar c)
+	void Utf8Encode(WChar c)
 	{
 		auto iterator = std::back_inserter(*this->string);
 		::Utf8Encode(iterator, c);
-		return true;
 	}
 
 	/**
@@ -95,15 +91,6 @@ public:
 	void RemoveElementsFromBack(size_t amount)
 	{
 		this->string->erase(this->string->size() - std::min(amount, this->string->size()));
-	}
-
-	/**
-	 * Get the remaining number of characters that can be placed.
-	 * @return The number of characters.
-	 */
-	ptrdiff_t Remaining()
-	{
-		return 42; // Just something big-ish, as there's always space (until allocation fails)
 	}
 
 	/**

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -65,11 +65,10 @@ static void GetTownName(StringBuilder &builder, const TownNameParams *par, uint3
  */
 std::string GetTownName(const TownNameParams *par, uint32 townnameparts)
 {
-	char buffer[DRAW_STRING_BUFFER];
-	char *state = buffer;
-	StringBuilder builder(&state, lastof(buffer));
+	std::string result;
+	StringBuilder builder(result);
 	GetTownName(builder, par, townnameparts);
-	return std::string(buffer, builder.GetEnd());
+	return result;
 }
 
 /**
@@ -1024,19 +1023,6 @@ void GenerateTownNameString(StringBuilder &builder, size_t lang, uint32 seed)
 {
 	assert(lang < lengthof(_town_name_generators));
 
-	/* Some generators need at least 9 bytes in buffer.  English generators need 5 for
-	 * string replacing, others use constructions like strlen(buf)-3 and so on.
-	 * Finnish generator needs to fit all strings from _name_finnish_1.
-	 * Czech generator needs to fit almost whole town name...
-	 * These would break. Using another temporary buffer results in ~40% slower code,
-	 * so use it only when really needed. */
 	const TownNameGeneratorParams *par = &_town_name_generators[lang];
-	if (builder.Remaining() >= par->min) return par->proc(builder, seed);
-
-	std::string buffer(par->min + 1, '\0');
-	char *state = buffer.data();
-	StringBuilder buffer_builder(&state, buffer.data() + par->min);
-	par->proc(buffer_builder, seed);
-
-	builder += buffer;
+	return par->proc(builder, seed);
 }

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -974,42 +974,34 @@ static void MakeCatalanTownName(StringBuilder &builder, uint32_t seed)
 
 /**
  * Type for all town name generator functions.
- * @param buf  The buffer to write the name to.
- * @param last The last element of the buffer.
+ * @param builder The builder to write the name to.
  * @param seed The seed of the town name.
- * @return The end of the filled buffer.
  */
 typedef void TownNameGenerator(StringBuilder &builder, uint32 seed);
 
-/** Contains pointer to generator and minimum buffer size (not incl. terminating '\0') */
-struct TownNameGeneratorParams {
-	byte min; ///< minimum number of characters that need to be printed for generator to work correctly
-	TownNameGenerator *proc; ///< generator itself
-};
-
 /** Town name generators */
-static const TownNameGeneratorParams _town_name_generators[] = {
-	{  4, MakeEnglishOriginalTownName},  // replaces first 4 characters of name
-	{  0, MakeFrenchTownName},
-	{  0, MakeGermanTownName},
-	{  4, MakeEnglishAdditionalTownName}, // replaces first 4 characters of name
-	{  0, MakeSpanishTownName},
-	{  0, MakeSillyTownName},
-	{  0, MakeSwedishTownName},
-	{  0, MakeDutchTownName},
-	{  8, MakeFinnishTownName}, // _name_finnish_1
-	{  0, MakePolishTownName},
-	{  0, MakeSlovakTownName},
-	{  0, MakeNorwegianTownName},
-	{  0, MakeHungarianTownName},
-	{  0, MakeAustrianTownName},
-	{  0, MakeRomanianTownName},
-	{ 28, MakeCzechTownName}, // _name_czech_adj + _name_czech_patmod + 1 + _name_czech_subst_stem + _name_czech_subst_postfix
-	{  0, MakeSwissTownName},
-	{  0, MakeDanishTownName},
-	{  0, MakeTurkishTownName},
-	{  0, MakeItalianTownName},
-	{  0, MakeCatalanTownName},
+static TownNameGenerator *_town_name_generators[] = {
+	MakeEnglishOriginalTownName,  // replaces first 4 characters of name
+	MakeFrenchTownName,
+	MakeGermanTownName,
+	MakeEnglishAdditionalTownName, // replaces first 4 characters of name
+	MakeSpanishTownName,
+	MakeSillyTownName,
+	MakeSwedishTownName,
+	MakeDutchTownName,
+	MakeFinnishTownName, // _name_finnish_1
+	MakePolishTownName,
+	MakeSlovakTownName,
+	MakeNorwegianTownName,
+	MakeHungarianTownName,
+	MakeAustrianTownName,
+	MakeRomanianTownName,
+	MakeCzechTownName, // _name_czech_adj + _name_czech_patmod + 1 + _name_czech_subst_stem + _name_czech_subst_postfix
+	MakeSwissTownName,
+	MakeDanishTownName,
+	MakeTurkishTownName,
+	MakeItalianTownName,
+	MakeCatalanTownName,
 };
 
 
@@ -1022,7 +1014,5 @@ static const TownNameGeneratorParams _town_name_generators[] = {
 void GenerateTownNameString(StringBuilder &builder, size_t lang, uint32 seed)
 {
 	assert(lang < lengthof(_town_name_generators));
-
-	const TownNameGeneratorParams *par = &_town_name_generators[lang];
-	return par->proc(builder, seed);
+	return _town_name_generators[lang](builder, seed);
 }


### PR DESCRIPTION
## Motivation / Problem

C-style processing of strings.


## Description

Replace the backing of the StringBuilder, as well as all the checks for reaching the end of the buffer.


## Limitations

Currently also contains #10947.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
