### PR TITLE
Codechange: Split GetItem with GetOrCreateItem.

### DIFF
--- a/src/base_media_func.h
+++ b/src/base_media_func.h
@@ -23,7 +23,7 @@ extern void CheckExternalFiles();
  * @param name the name of the item to fetch.
  */
 #define fetch_metadata(name) \
-	item = metadata->GetItem(name, false); \
+	item = metadata->GetItem(name); \
 	if (item == nullptr || !item->value.has_value() || item->value->empty()) { \
 		Debug(grf, 0, "Base " SET_TYPE "set detail loading: {} field missing.", name); \
 		Debug(grf, 0, "  Is {} readable for the user running OpenTTD?", full_filename); \
@@ -65,7 +65,7 @@ bool BaseSet<T, Tnum_files, Tsearch_in_tars>::FillSetDetails(IniFile *ini, const
 	fetch_metadata("version");
 	this->version = atoi(item->value->c_str());
 
-	item = metadata->GetItem("fallback", false);
+	item = metadata->GetItem("fallback");
 	this->fallback = (item != nullptr && item->value && *item->value != "0" && *item->value != "false");
 
 	/* For each of the file types we want to find the file, MD5 checksums and warning messages. */
@@ -75,7 +75,7 @@ bool BaseSet<T, Tnum_files, Tsearch_in_tars>::FillSetDetails(IniFile *ini, const
 	for (uint i = 0; i < Tnum_files; i++) {
 		MD5File *file = &this->files[i];
 		/* Find the filename first. */
-		item = files->GetItem(BaseSet<T, Tnum_files, Tsearch_in_tars>::file_names[i], false);
+		item = files->GetItem(BaseSet<T, Tnum_files, Tsearch_in_tars>::file_names[i]);
 		if (item == nullptr || (!item->value.has_value() && !allow_empty_filename)) {
 			Debug(grf, 0, "No " SET_TYPE " file for: {} (in {})", BaseSet<T, Tnum_files, Tsearch_in_tars>::file_names[i], full_filename);
 			return false;
@@ -93,7 +93,7 @@ bool BaseSet<T, Tnum_files, Tsearch_in_tars>::FillSetDetails(IniFile *ini, const
 		file->filename = path + filename;
 
 		/* Then find the MD5 checksum */
-		item = md5s->GetItem(filename, false);
+		item = md5s->GetItem(filename);
 		if (item == nullptr || !item->value.has_value()) {
 			Debug(grf, 0, "No MD5 checksum specified for: {} (in {})", filename, full_filename);
 			return false;
@@ -119,8 +119,8 @@ bool BaseSet<T, Tnum_files, Tsearch_in_tars>::FillSetDetails(IniFile *ini, const
 		}
 
 		/* Then find the warning message when the file's missing */
-		item = origin->GetItem(filename, false);
-		if (item == nullptr) item = origin->GetItem("default", false);
+		item = origin->GetItem(filename);
+		if (item == nullptr) item = origin->GetItem("default");
 		if (item == nullptr || !item->value.has_value()) {
 			Debug(grf, 1, "No origin warning message specified for: {}", filename);
 			file->missing_warning.clear();

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -357,7 +357,7 @@ bool GraphicsSet::FillSetDetails(IniFile *ini, const std::string &path, const st
 		this->palette = ((*item->value)[0] == 'D' || (*item->value)[0] == 'd') ? PAL_DOS : PAL_WINDOWS;
 
 		/* Get optional blitter information. */
-		item = metadata->GetItem("blitter", false);
+		item = metadata->GetItem("blitter");
 		this->blitter = (item != nullptr && (*item->value)[0] == '3') ? BLT_32BPP : BLT_8BPP;
 	}
 	return ret;

--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -278,7 +278,7 @@ void HotkeyList::Load(IniFile *ini)
 {
 	IniGroup *group = ini->GetGroup(this->ini_group);
 	for (Hotkey &hotkey : this->items) {
-		IniItem *item = group->GetItem(hotkey.name, false);
+		IniItem *item = group->GetItem(hotkey.name);
 		if (item != nullptr) {
 			hotkey.keycodes.clear();
 			if (item->value.has_value()) ParseHotkeys(hotkey, item->value->c_str());
@@ -294,8 +294,8 @@ void HotkeyList::Save(IniFile *ini) const
 {
 	IniGroup *group = ini->GetGroup(this->ini_group);
 	for (const Hotkey &hotkey : this->items) {
-		IniItem *item = group->GetItem(hotkey.name, true);
-		item->SetValue(SaveKeycodes(hotkey));
+		IniItem &item = group->GetOrCreateItem(hotkey.name);
+		item.SetValue(SaveKeycodes(hotkey));
 	}
 }
 

--- a/src/ini_load.cpp
+++ b/src/ini_load.cpp
@@ -82,22 +82,32 @@ IniGroup::~IniGroup()
 }
 
 /**
- * Get the item with the given name, and if it doesn't exist
- * and create is true it creates a new item.
+ * Get the item with the given name.
  * @param name   name of the item to find.
- * @param create whether to create an item when not found or not.
  * @return the requested item or nullptr if not found.
  */
-IniItem *IniGroup::GetItem(const std::string &name, bool create)
+IniItem *IniGroup::GetItem(const std::string &name)
 {
 	for (IniItem *item = this->item; item != nullptr; item = item->next) {
 		if (item->name == name) return item;
 	}
 
-	if (!create) return nullptr;
+	return nullptr;
+}
 
-	/* otherwise make a new one */
-	return new IniItem(this, name);
+/**
+ * Get the item with the given name, and if it doesn't exist create a new item.
+ * @param name   name of the item to find.
+ * @return the requested item.
+ */
+IniItem &IniGroup::GetOrCreateItem(const std::string &name)
+{
+	for (IniItem *item = this->item; item != nullptr; item = item->next) {
+		if (item->name == name) return *item;
+	}
+
+	/* Item doesn't exist, make a new one. */
+	return *(new IniItem(this, name));
 }
 
 /**

--- a/src/ini_type.h
+++ b/src/ini_type.h
@@ -44,7 +44,8 @@ struct IniGroup {
 	IniGroup(struct IniLoadFile *parent, const std::string &name);
 	~IniGroup();
 
-	IniItem *GetItem(const std::string &name, bool create);
+	IniItem *GetItem(const std::string &name);
+	IniItem &GetOrCreateItem(const std::string &name);
 	void RemoveItem(const std::string &name);
 	void Clear();
 };

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -133,7 +133,7 @@ bool MusicSet::FillSetDetails(IniFile *ini, const std::string &path, const std::
 
 			this->songinfo[i].filename = filename; // non-owned pointer
 
-			IniItem *item = catindex->GetItem(_music_file_names[i], false);
+			IniItem *item = catindex->GetItem(_music_file_names[i]);
 			if (item != nullptr && item->value.has_value() && !item->value->empty()) {
 				/* Song has a CAT file index, assume it's MPS MIDI format */
 				this->songinfo[i].filetype = MTT_MPSMIDI;
@@ -158,7 +158,7 @@ bool MusicSet::FillSetDetails(IniFile *ini, const std::string &path, const std::
 				 * the beginning, so we don't start reading e.g. root. */
 				while (*trimmed_filename == PATHSEPCHAR) trimmed_filename++;
 
-				item = names->GetItem(trimmed_filename, false);
+				item = names->GetItem(trimmed_filename);
 				if (item != nullptr && item->value.has_value() && !item->value->empty()) break;
 			}
 
@@ -179,7 +179,7 @@ bool MusicSet::FillSetDetails(IniFile *ini, const std::string &path, const std::
 				this->songinfo[i].tracknr = tracknr++;
 			}
 
-			item = trimmed_filename != nullptr ? timingtrim->GetItem(trimmed_filename, false) : nullptr;
+			item = trimmed_filename != nullptr ? timingtrim->GetItem(trimmed_filename) : nullptr;
 			if (item != nullptr && item->value.has_value() && !item->value->empty()) {
 				auto endpos = item->value->find(':');
 				if (endpos != std::string::npos) {

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -229,8 +229,8 @@ static void DumpGroup(IniLoadFile *ifile, const char * const group_name)
  */
 static const char *FindItemValue(const char *name, IniGroup *grp, IniGroup *defaults)
 {
-	IniItem *item = grp->GetItem(name, false);
-	if (item == nullptr && defaults != nullptr) item = defaults->GetItem(name, false);
+	IniItem *item = grp->GetItem(name);
+	if (item == nullptr && defaults != nullptr) item = defaults->GetItem(name);
 	if (item == nullptr || !item->value.has_value()) return nullptr;
 	return item->value->c_str();
 }
@@ -321,14 +321,14 @@ static void DumpSections(IniLoadFile *ifile)
 		for (sgn = special_group_names; *sgn != nullptr; sgn++) if (grp->name == *sgn) break;
 		if (*sgn != nullptr) continue;
 
-		IniItem *template_item = templates_grp->GetItem(grp->name, false); // Find template value.
+		IniItem *template_item = templates_grp->GetItem(grp->name); // Find template value.
 		if (template_item == nullptr || !template_item->value.has_value()) {
 			FatalError("Cannot find template {}", grp->name);
 		}
 		DumpLine(template_item, grp, default_grp, _stored_output);
 
 		if (validation_grp != nullptr) {
-			IniItem *validation_item = validation_grp->GetItem(grp->name, false); // Find template value.
+			IniItem *validation_item = validation_grp->GetItem(grp->name); // Find template value.
 			if (validation_item != nullptr && validation_item->value.has_value()) {
 				DumpLine(validation_item, grp, default_grp, _post_amble_output);
 			}


### PR DESCRIPTION
## Motivation / Problem

As seen in #10951, `IniGroup::GetItem()` returns nullptr if the item does not exist, but does not if the create parameter is set to true. 

This causes a CodeQL warning as most callers need to check for nullptr, but some don't.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Resolve CodeQL warnings by creating a separate `GetOrCreateItem()` which returns a reference to the item instead.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
