### PR TITLE
Fix dec7ff6: Dropdowns couldn't be closed by pressing the parent button.

### DIFF
--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -295,6 +295,7 @@ enum NWidgetDisplay {
 	NDB_SCROLLBAR_DOWN  = 7, ///< Down-button is lowered bit.
 	/* Generic. */
 	NDB_HIGHLIGHT       = 8, ///< Highlight of widget is on.
+	NDB_DROPDOWN_CLOSED = 9, ///< Dropdown menu of the dropdown widget has closed.
 
 	ND_LOWERED  = 1 << NDB_LOWERED,                ///< Bit value of the lowered flag.
 	ND_DISABLED = 1 << NDB_DISABLED,               ///< Bit value of the disabled flag.
@@ -306,6 +307,7 @@ enum NWidgetDisplay {
 	ND_SCROLLBAR_UP    = 1 << NDB_SCROLLBAR_UP,    ///< Bit value of the 'scrollbar up' flag.
 	ND_SCROLLBAR_DOWN  = 1 << NDB_SCROLLBAR_DOWN,  ///< Bit value of the 'scrollbar down' flag.
 	ND_SCROLLBAR_BTN   = ND_SCROLLBAR_UP | ND_SCROLLBAR_DOWN, ///< Bit value of the 'scrollbar up' or 'scrollbar down' flag.
+	ND_DROPDOWN_CLOSED = 1 << NDB_DROPDOWN_CLOSED, ///< Bit value of the 'dropdown closed' flag.
 };
 DECLARE_ENUM_AS_BIT_SET(NWidgetDisplay)
 

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -191,6 +191,10 @@ struct DropdownWindow : Window {
 		pt.x -= this->parent->left;
 		pt.y -= this->parent->top;
 		this->parent->OnDropdownClose(pt, this->parent_button, this->selected_index, this->instant_close);
+
+		/* Set flag on parent widget to indicate that we have just closed. */
+		NWidgetCore *nwc = this->parent->GetWidget<NWidgetCore>(this->parent_button);
+		if (nwc != nullptr) SetBit(nwc->disp_flags, NDB_DROPDOWN_CLOSED);
 	}
 
 	void OnFocusLost() override
@@ -471,25 +475,3 @@ void ShowDropDownMenu(Window *w, const StringID *strings, int selected, int butt
 
 	if (!list.empty()) ShowDropDownList(w, std::move(list), selected, button, width);
 }
-
-/**
- * Delete the drop-down menu from window \a pw
- * @param pw Parent window of the drop-down menu window
- * @return Parent widget number if the drop-down was found and closed, \c -1 if the window was not found.
- */
-int HideDropDownMenu(Window *pw)
-{
-	for (Window *w : Window::Iterate()) {
-		if (w->parent != pw) continue;
-		if (w->window_class != WC_DROPDOWN_MENU) continue;
-
-		DropdownWindow *dw = dynamic_cast<DropdownWindow*>(w);
-		assert(dw != nullptr);
-		int parent_button = dw->parent_button;
-		dw->Close();
-		return parent_button;
-	}
-
-	return -1;
-}
-

--- a/src/widgets/dropdown_func.h
+++ b/src/widgets/dropdown_func.h
@@ -15,7 +15,4 @@
 /* Show drop down menu containing a fixed list of strings */
 void ShowDropDownMenu(Window *w, const StringID *strings, int selected, int button, uint32 disabled_mask, uint32 hidden_mask, uint width = 0);
 
-/* Hide drop down menu of a parent window */
-int HideDropDownMenu(Window *pw);
-
 #endif /* WIDGETS_DROPDOWN_FUNC_H */

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -22,7 +22,6 @@
 #include "tilehighlight_func.h"
 #include "network/network.h"
 #include "querystring_gui.h"
-#include "widgets/dropdown_func.h"
 #include "strings_func.h"
 #include "settings_type.h"
 #include "settings_func.h"
@@ -679,6 +678,9 @@ static void DispatchLeftClickEvent(Window *w, int x, int y, int click_count)
 	NWidgetCore *nw = w->nested_root->GetWidgetFromPos(x, y);
 	WidgetType widget_type = (nw != nullptr) ? nw->type : WWT_EMPTY;
 
+	/* Allow dropdown close flag detection to work. */
+	if (nw != nullptr) ClrBit(nw->disp_flags, NDB_DROPDOWN_CLOSED);
+
 	bool focused_widget_changed = false;
 	/* If clicked on a window that previously did not have focus */
 	if (_focused_window != w &&                 // We already have focus, right?
@@ -711,9 +713,8 @@ static void DispatchLeftClickEvent(Window *w, int x, int y, int click_count)
 		focused_widget_changed |= w->SetFocusedWidget(widget_index);
 	}
 
-	/* Close any child drop down menus. If the button pressed was the drop down
-	 * list's own button, then we should not process the click any further. */
-	if (HideDropDownMenu(w) == widget_index && widget_index >= 0) return;
+	/* Dropdown window of this widget was closed so don't process click this time. */
+	if (HasBit(nw->disp_flags, NDB_DROPDOWN_CLOSED)) return;
 
 	if ((widget_type & ~WWB_PUSHBUTTON) < WWT_LAST && (widget_type & WWB_PUSHBUTTON)) w->HandleButtonClick(widget_index);
 


### PR DESCRIPTION
## Motivation / Problem

Since dropdowns self-close, the detection of re-clicking a dropdown button no longer worked, as the dropdown is already closed.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead set (and then test) a flag on the parent widget to indicate that the dropdown closed. This method avoids looping windows on every click.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Use a "display flag" for this purpose is a bit wrong but seems better than adding a flag or global variable just for this.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
