### PR TITLE
Cleanup: remove references to DRAW_STRING_BUFFER

### DIFF
--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -82,9 +82,6 @@ void GameSizeChanged();
 bool AdjustGUIZoom(bool automatic);
 void UndrawMouseCursor();
 
-/** Size of the buffer used for drawing strings. */
-static const int DRAW_STRING_BUFFER = 2048;
-
 void RedrawScreenRect(int left, int top, int right, int bottom);
 void GfxScroll(int left, int top, int width, int height, int xo, int yo);
 

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -64,8 +64,8 @@ static inline void GetLayouter(Layouter::LineCacheItem &line, std::string_view s
 {
 	if (line.buffer != nullptr) free(line.buffer);
 
-	typename T::CharType *buff_begin = MallocT<typename T::CharType>(DRAW_STRING_BUFFER);
-	const typename T::CharType *buffer_last = buff_begin + DRAW_STRING_BUFFER;
+	typename T::CharType *buff_begin = MallocT<typename T::CharType>(str.size() + 1);
+	const typename T::CharType *buffer_last = buff_begin + str.size() + 1;
 	typename T::CharType *buff = buff_begin;
 	FontMap &fontMapping = line.runs;
 	Font *f = Layouter::GetFont(state.fontsize, state.cur_colour);

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -30,10 +30,6 @@
 
 #include "../safeguards.h"
 
-/** The draw buffer must be able to contain the chat message, client name and the "[All]" message,
- * some spaces and possible translations of [All] to other languages. */
-static_assert((int)DRAW_STRING_BUFFER >= (int)NETWORK_CHAT_LENGTH + NETWORK_NAME_LENGTH + 40);
-
 /** Spacing between chat lines. */
 static const uint NETWORK_CHAT_LINE_SPACING = 3;
 

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -741,8 +741,7 @@ public:
 
 		if (!this->selected->dependencies.empty()) {
 			/* List dependencies */
-			char buf[DRAW_STRING_BUFFER] = "";
-			char *p = buf;
+			std::string buf;
 			for (auto &cid : this->selected->dependencies) {
 				/* Try to find the dependency */
 				ConstContentIterator iter = _network_content_client.Begin();
@@ -750,7 +749,8 @@ public:
 					const ContentInfo *ci = *iter;
 					if (ci->id != cid) continue;
 
-					p += seprintf(p, lastof(buf), p == buf ? "%s" : ", %s", (*iter)->name.c_str());
+					if (!buf.empty()) buf += ", ";
+					buf += (*iter)->name;
 					break;
 				}
 			}
@@ -760,10 +760,10 @@ public:
 
 		if (!this->selected->tags.empty()) {
 			/* List all tags */
-			char buf[DRAW_STRING_BUFFER] = "";
-			char *p = buf;
+			std::string buf;
 			for (auto &tag : this->selected->tags) {
-				p += seprintf(p, lastof(buf), p == buf ? "%s" : ", %s", tag.c_str());
+				if (!buf.empty()) buf += ", ";
+				buf += tag;
 			}
 			SetDParamStr(0, buf);
 			tr.top = DrawStringMultiLine(tr, STR_CONTENT_DETAIL_TAGS);
@@ -774,14 +774,14 @@ public:
 			ConstContentVector tree;
 			_network_content_client.ReverseLookupTreeDependency(tree, this->selected);
 
-			char buf[DRAW_STRING_BUFFER] = "";
-			char *p = buf;
+			std::string buf;
 			for (const ContentInfo *ci : tree) {
 				if (ci == this->selected || ci->state != ContentInfo::SELECTED) continue;
 
-				p += seprintf(p, lastof(buf), buf == p ? "%s" : ", %s", ci->name.c_str());
+				if (!buf.empty()) buf += ", ";
+				buf += ci->name;
 			}
-			if (p != buf) {
+			if (!buf.empty()) {
 				SetDParamStr(0, buf);
 				tr.top = DrawStringMultiLine(tr, STR_CONTENT_DETAIL_SELECTED_BECAUSE_OF);
 			}


### PR DESCRIPTION
## Motivation / Problem

Remnants of the time when there was constant limit on the number of bytes in formatted strings.


## Description

Replace some `seprintf` to buffer of DRAW_STRING_BUFFER length to `std::string` and `fmt::format`.
Replace DRAW_STRING_BUFFER with the actual string length (+1) for the layouter.
Remove DRAW_STRING_BUFFER global constant.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
