### PR TITLE
Codechange: use std::string to build ScriptText's encoded text

### DIFF
--- a/src/script/api/script_text.hpp
+++ b/src/script/api/script_text.hpp
@@ -138,13 +138,11 @@ private:
 	/**
 	 * Internal function for recursive calling this function over multiple
 	 *  instances, while writing in the same buffer.
-	 * @param p The current position in the buffer.
-	 * @param lastofp The last position valid in the buffer.
+	 * @param output The output to write the encoded text to.
 	 * @param param_count The number of parameters that are in the string.
 	 * @param seen_ids The list of seen StringID.
-	 * @return The new current position in the buffer.
 	 */
-	char *_GetEncodedText(char *p, char *lastofp, int &param_count, StringIDList &seen_ids);
+	void _GetEncodedText(std::back_insert_iterator<std::string> &output, int &param_count, StringIDList &seen_ids);
 
 	/**
 	 * Set a parameter, where the value is the first item on the stack.


### PR DESCRIPTION
## Motivation / Problem

C-style string, `strecpy` and `seprintf`.


## Description

Replace them with `fmt::format_to` and `std::string`.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
