### PR TITLE
Codechange: replace seprintf with fmt::format

### DIFF
--- a/src/3rdparty/squirrel/squirrel/sqapi.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqapi.cpp
@@ -48,9 +48,7 @@ SQInteger sq_aux_throwobject(HSQUIRRELVM v,SQObjectPtr &e)
 
 SQInteger sq_aux_invalidtype(HSQUIRRELVM v,SQObjectType type)
 {
-	char buf[100];
-	seprintf(buf, lastof(buf), "unexpected type %s", IdType2Name(type));
-	return sq_throwerror(v, buf);
+	return sq_throwerror(v, fmt::format("unexpected type {}", IdType2Name(type)));
 }
 
 HSQUIRRELVM sq_open(SQInteger initialstacksize)

--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -193,8 +193,7 @@ static void _GenerateWorld()
 		Debug(desync, 1, "new_map: {:08x}", _settings_game.game_creation.generation_seed);
 
 		if (_debug_desync_level > 0) {
-			char name[MAX_PATH];
-			seprintf(name, lastof(name), "dmp_cmds_%08x_%08x.sav", _settings_game.game_creation.generation_seed, TimerGameCalendar::date);
+			std::string name = fmt::format("dmp_cmds_{:08x}_{:08x}.sav", _settings_game.game_creation.generation_seed, TimerGameCalendar::date);
 			SaveOrLoad(name, SLO_SAVE, DFT_GAME_FILE, AUTOSAVE_DIR, false);
 		}
 	} catch (AbortGenerateWorldSignal&) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -82,14 +82,12 @@ TileIndex TileAdd(TileIndex tile, TileIndexDiff add,
 	y = TileY(tile) + dy;
 
 	if (x >= Map::SizeX() || y >= Map::SizeY()) {
-		char buf[512];
-
-		seprintf(buf, lastof(buf), "TILE_ADD(%s) when adding 0x%.4X and 0x%.4X failed",
+		std::string message = fmt::format("TILE_ADD({}) when adding 0x{:04X} and 0x{%04X} failed",
 			exp, (uint32)tile, add);
 #if !defined(_MSC_VER)
-		fmt::print(stderr, "{}:{} {}\n", file, line, buf);
+		fmt::print(stderr, "{}:{} {}\n", file, line, message);
 #else
-		_assert(buf, (char*)file, line);
+		_assert(message.data(), (char*)file, line);
 #endif
 	}
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1395,8 +1395,7 @@ void StateGameLoop()
 	} else {
 		if (_debug_desync_level > 2 && TimerGameCalendar::date_fract == 0 && (TimerGameCalendar::date & 0x1F) == 0) {
 			/* Save the desync savegame if needed. */
-			char name[MAX_PATH];
-			seprintf(name, lastof(name), "dmp_cmds_%08x_%08x.sav", _settings_game.game_creation.generation_seed, TimerGameCalendar::date);
+			std::string name = fmt::format("dmp_cmds_{:08x}_{:08x}.sav", _settings_game.game_creation.generation_seed, TimerGameCalendar::date);
 			SaveOrLoad(name, SLO_SAVE, DFT_GAME_FILE, AUTOSAVE_DIR, false);
 		}
 


### PR DESCRIPTION
## Motivation / Problem

Some instances of `seprintf`.


## Description

Replace `seprintf` with `fmt::format`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
