### PR TITLE
Codechange: unify the formatting of the game's caption

### DIFF
--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -18,7 +18,6 @@
 #include "../openttd.h"
 #include "../error_func.h"
 #include "../gfx_func.h"
-#include "../rev.h"
 #include "../blitter/factory.hpp"
 #include "../core/random_func.hpp"
 #include "../core/math_func.hpp"
@@ -216,9 +215,8 @@ static bool CreateMainSurface(uint w, uint h)
 
 	InitPalette();
 
-	char caption[32];
-	seprintf(caption, lastof(caption), "OpenTTD %s", _openttd_revision);
-	set_window_title(caption);
+	std::string caption = VideoDriver::GetCaption();
+	set_window_title(caption.c_str());
 
 	enable_hardware_cursor();
 	select_mouse_cursor(MOUSE_CURSOR_ARROW);

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -24,7 +24,6 @@
 
 #include "../../openttd.h"
 #include "../../debug.h"
-#include "../../rev.h"
 #include "cocoa_v.h"
 #include "cocoa_wnd.h"
 #include "../../settings_type.h"
@@ -456,7 +455,7 @@ void CocoaDialog(const char *title, const char *message, const char *buttonLabel
 
 		[ self setContentMinSize:NSMakeSize(64.0f, 64.0f) ];
 
-		std::string caption = std::string{"OpenTTD "} + _openttd_revision;
+		std::string caption = VideoDriver::GetCaption();
 		NSString *nsscaption = [ [ NSString alloc ] initWithUTF8String:caption.c_str() ];
 		[ self setTitle:nsscaption ];
 		[ self setMiniwindowTitle:nsscaption ];

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -10,7 +10,6 @@
 #include "../stdafx.h"
 #include "../openttd.h"
 #include "../gfx_func.h"
-#include "../rev.h"
 #include "../blitter/factory.hpp"
 #include "../thread.h"
 #include "../progress.h"
@@ -149,10 +148,9 @@ bool VideoDriver_SDL_Base::CreateMainWindow(uint w, uint h, uint flags)
 		y = r.y + std::max(0, r.h - static_cast<int>(h)) / 4; // decent desktops have taskbars at the bottom
 	}
 
-	char caption[50];
-	seprintf(caption, lastof(caption), "OpenTTD %s", _openttd_revision);
+	std::string caption = VideoDriver::GetCaption();
 	this->sdl_window = SDL_CreateWindow(
-		caption,
+		caption.c_str(),
 		x, y,
 		w, h,
 		flags);

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -13,7 +13,6 @@
 #include "../openttd.h"
 #include "../error_func.h"
 #include "../gfx_func.h"
-#include "../rev.h"
 #include "../blitter/factory.hpp"
 #include "../thread.h"
 #include "../progress.h"
@@ -226,7 +225,6 @@ static void GetAvailableVideoMode(uint *w, uint *h)
 bool VideoDriver_SDL::CreateMainSurface(uint w, uint h)
 {
 	SDL_Surface *newscreen, *icon;
-	char caption[50];
 	int bpp = BlitterFactory::GetCurrentBlitter()->GetScreenDepth();
 	bool want_hwpalette;
 
@@ -360,8 +358,8 @@ bool VideoDriver_SDL::CreateMainSurface(uint w, uint h)
 
 	InitPalette();
 
-	seprintf(caption, lastof(caption), "OpenTTD %s", _openttd_revision);
-	SDL_WM_SetCaption(caption, caption);
+	std::string caption = VideoDriver::GetCaption();
+	SDL_WM_SetCaption(caption.c_str(), caption.c_str());
 
 	GameSizeChanged();
 

--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -17,6 +17,7 @@
 #include "../gfx_func.h"
 #include "../gfxinit.h"
 #include "../progress.h"
+#include "../rev.h"
 #include "../thread.h"
 #include "../window_func.h"
 #include "video_driver.hpp"
@@ -179,4 +180,13 @@ void VideoDriver::SleepTillNextTick()
 	if (next_tick > now) {
 		std::this_thread::sleep_for(next_tick - now);
 	}
+}
+
+/**
+ * Get the caption to use for the game's title bar.
+ * @return The caption.
+ */
+/* static */ std::string VideoDriver::GetCaption()
+{
+	return fmt::format("OpenTTD {}", _openttd_revision);
 }

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -201,6 +201,8 @@ public:
 		return static_cast<VideoDriver*>(*DriverFactoryBase::GetActiveDriver(Driver::DT_VIDEO));
 	}
 
+	static std::string GetCaption();
+
 	/**
 	 * Helper struct to ensure the video buffer is locked and ready for drawing. The destructor
 	 * will make sure the buffer is unlocked no matter how the scope is exited.

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -12,7 +12,6 @@
 #include "../error_func.h"
 #include "../gfx_func.h"
 #include "../os/windows/win32.h"
-#include "../rev.h"
 #include "../blitter/factory.hpp"
 #include "../core/geometry_func.hpp"
 #include "../core/math_func.hpp"
@@ -221,10 +220,8 @@ bool VideoDriver_Win32Base::MakeWindow(bool full_screen, bool resize)
 			int x = (mi.rcWork.right - mi.rcWork.left - w) / 2;
 			int y = (mi.rcWork.bottom - mi.rcWork.top - h) / 2;
 
-			char window_title[64];
-			seprintf(window_title, lastof(window_title), "OpenTTD %s", _openttd_revision);
-
-			this->main_wnd = CreateWindow(L"OTTD", OTTD2FS(window_title).c_str(), style, x, y, w, h, 0, 0, GetModuleHandle(nullptr), this);
+			std::string caption = VideoDriver::GetCaption();
+			this->main_wnd = CreateWindow(L"OTTD", OTTD2FS(caption).c_str(), style, x, y, w, h, 0, 0, GetModuleHandle(nullptr), this);
 			if (this->main_wnd == nullptr) UserError("CreateWindow failed");
 			ShowWindow(this->main_wnd, showstyle);
 		}


### PR DESCRIPTION
## Motivation / Problem

Some `seprintf` and some string concatenation to make the caption that is to be shown in the title bar of the game.


## Description

Introduce one function, in video driver, that constructs the caption and use that in the video drivers that set a window caption.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
