### PR TITLE
Codechange: use std::filesystem::path for the language file's path

### DIFF
--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -34,6 +34,7 @@
 #include "company_base.h"
 #include "company_func.h"
 #include "3rdparty/fmt/chrono.h"
+#include "3rdparty/fmt/std.h"
 
 #ifdef WITH_ALLEGRO
 #	include <allegro.h>
@@ -167,7 +168,7 @@ void CrashLog::LogConfiguration(std::back_insert_iterator<std::string> &output_i
 			BlitterFactory::GetCurrentBlitter() == nullptr ? "none" : BlitterFactory::GetCurrentBlitter()->GetName(),
 			BaseGraphics::GetUsedSet() == nullptr ? "none" : BaseGraphics::GetUsedSet()->name,
 			BaseGraphics::GetUsedSet() == nullptr ? UINT32_MAX : BaseGraphics::GetUsedSet()->version,
-			_current_language == nullptr ? "none" : _current_language->file,
+			_current_language == nullptr ? "none" : _current_language->file.filename(),
 			MusicDriver::GetInstance() == nullptr ? "none" : MusicDriver::GetInstance()->GetName(),
 			BaseMusic::GetUsedSet() == nullptr ? "none" : BaseMusic::GetUsedSet()->name,
 			BaseMusic::GetUsedSet() == nullptr ? UINT32_MAX : BaseMusic::GetUsedSet()->version,

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -384,19 +384,7 @@ void ReconsiderGameScriptLanguage()
 {
 	if (_current_data == nullptr) return;
 
-	char temp[MAX_PATH];
-	strecpy(temp, _current_language->file, lastof(temp));
-
-	/* Remove the extension */
-	char *l = strrchr(temp, '.');
-	assert(l != nullptr);
-	*l = '\0';
-
-	/* Skip the path */
-	char *language = strrchr(temp, PATHSEPCHAR);
-	assert(language != nullptr);
-	language++;
-
+	std::string language = _current_language->file.stem().string();
 	for (auto &p : _current_data->compiled_strings) {
 		if (p.language == language) {
 			_current_data->cur_language = &p;

--- a/src/language.h
+++ b/src/language.h
@@ -14,6 +14,7 @@
 #include <unicode/coll.h>
 #endif /* WITH_ICU_I18N */
 #include "strings_type.h"
+#include <filesystem>
 
 static const uint8 CASE_GENDER_LEN = 16; ///< The (maximum) length of a case/gender string.
 static const uint8 MAX_NUM_GENDERS =  8; ///< Maximum number of supported genders.
@@ -90,7 +91,7 @@ static_assert(sizeof(LanguagePackHeader) % 4 == 0);
 
 /** Metadata about a single language. */
 struct LanguageMetadata : public LanguagePackHeader {
-	char file[MAX_PATH]; ///< Name of the file we read this data from.
+	std::filesystem::path file; ///< Name of the file we read this data from.
 };
 
 /** Type for the list of language meta data. */

--- a/src/network/network_survey.cpp
+++ b/src/network/network_survey.cpp
@@ -176,13 +176,7 @@ static void SurveyConfiguration(nlohmann::json &survey)
 {
 	survey["network"] = _networking ? (_network_server ? "server" : "client") : "no";
 	if (_current_language != nullptr) {
-		std::string_view language_basename(_current_language->file);
-		auto e = language_basename.rfind(PATHSEPCHAR);
-		if (e != std::string::npos) {
-			language_basename = language_basename.substr(e + 1);
-		}
-
-		survey["language"]["filename"] = language_basename;
+		survey["language"]["filename"] = _current_language->file.filename().string();
 		survey["language"]["name"] = _current_language->name;
 		survey["language"]["isocode"] = _current_language->isocode;
 	}


### PR DESCRIPTION
## Motivation / Problem

Initially due to `seprintf` that I wanted to replace with `std::string`. Then figuring out quite a lot of places only want the filename or stem (filename without extension), with their own implementations using `strrchr`. That would be quite complicated to write with `std::string` but trivial with `std::filesystem::path`.


## Description

Replace the char buffer for the language metadata with `std::filesystem::path`.
Replace C-style string logic to get the filename with `.filename()`.
Replace C-style string logic to get the filename without extension with `.stem()`.
Remove the full path from the filename in the crashlog.


## Limitations

Having difficulty with Windows. `path.c_str()` is probably `wchar_t *`, so using that around it troublesome. It also means that we require `path.string()` to convert to `std::string` which happens automatically on other platforms.
Furthermore regression fails because it seems to pick another language for some weird reason... but only on Windows?!?


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
