### PR TITLE
Fix #10961, 52a7c69: incorrect order of parameters to gamelog revision constructor

### DIFF
--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -376,7 +376,7 @@ void Gamelog::Revision()
 	assert(this->action_type == GLAT_START || this->action_type == GLAT_LOAD);
 
 	this->Change(std::make_unique<LoggedChangeRevision>(
-		GetGamelogRevisionString(), SAVEGAME_VERSION, _openttd_revision_modified, _openttd_newgrf_version));
+		GetGamelogRevisionString(), _openttd_newgrf_version, SAVEGAME_VERSION, _openttd_revision_modified));
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Fixes #10961.


## Description

Order the constructor parameters correctly.


## Limitations

Does not fix the GameLog entry, although it could be done. It's essentially too much hassle for the few savegames that are affected by this. It is possible because the NewGRF version is stored in a smaller field, whereas the others are stored in a larger field... so only the NewGRF version is gone. But that is essentially constant between releases, so it can be set to the right value.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
