### PR TITLE
Codechange: use string_view to chop off country code from language code

### DIFF
--- a/src/os/unix/font_unix.cpp
+++ b/src/os/unix/font_unix.cpp
@@ -112,13 +112,11 @@ bool SetFallbackFont(FontCacheSettings *settings, const char *language_isocode, 
 	/* Fontconfig doesn't handle full language isocodes, only the part
 	 * before the _ of e.g. en_GB is used, so "remove" everything after
 	 * the _. */
-	char lang[16];
-	seprintf(lang, lastof(lang), ":lang=%s", language_isocode);
-	char *split = strchr(lang, '_');
-	if (split != nullptr) *split = '\0';
+	std::string_view isocode_view(language_isocode);
+	std::string lang = fmt::format(":lang={}", isocode_view.substr(0, isocode_view.find_first_of('_')));
 
 	/* First create a pattern to match the wanted language. */
-	FcPattern *pat = FcNameParse((FcChar8 *)lang);
+	FcPattern *pat = FcNameParse((FcChar8 *)lang.data());
 	/* We only want to know the filename. */
 	FcObjectSet *os = FcObjectSetBuild(FC_FILE, FC_SPACING, FC_SLANT, FC_WEIGHT, nullptr);
 	/* Get the list of filenames matching the wanted language. */


### PR DESCRIPTION
## Motivation / Problem

Usage of `seprintf`.


## Description

Replace `seprintf` with `fmt::format`.
Replace postformat trimming of the string, with preformat trimming of a view.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
