### PR TITLE
Codechange: use std::string for Windows' ISO code mangling

### DIFF
--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -541,23 +541,21 @@ const char *GetCurrentLocale(const char *)
 
 static WCHAR _cur_iso_locale[16] = L"";
 
-void Win32SetCurrentLocaleName(const char *iso_code)
+void Win32SetCurrentLocaleName(std::string iso_code)
 {
 	/* Convert the iso code into the format that windows expects. */
-	char iso[16];
-	if (strcmp(iso_code, "zh_TW") == 0) {
-		strecpy(iso, "zh-Hant", lastof(iso));
-	} else if (strcmp(iso_code, "zh_CN") == 0) {
-		strecpy(iso, "zh-Hans", lastof(iso));
+	if (iso_code == "zh_TW") {
+		iso_code = "zh-Hant";
+	} else if (iso_code == "zh_CN") {
+		iso_code = "zh-Hans";
 	} else {
 		/* Windows expects a '-' between language and country code, but we use a '_'. */
-		strecpy(iso, iso_code, lastof(iso));
-		for (char *c = iso; *c != '\0'; c++) {
-			if (*c == '_') *c = '-';
+		for (char &c : iso_code) {
+			if (c == '_') c = '-';
 		}
 	}
 
-	MultiByteToWideChar(CP_UTF8, 0, iso, -1, _cur_iso_locale, lengthof(_cur_iso_locale));
+	MultiByteToWideChar(CP_UTF8, 0, iso_code.c_str(), -1, _cur_iso_locale, lengthof(_cur_iso_locale));
 }
 
 int OTTDStringCompare(std::string_view s1, std::string_view s2)

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1887,7 +1887,7 @@ bool ReadLanguagePack(const LanguageMetadata *lang)
 	SetCurrentGrfLangID(_current_language->newgrflangid);
 
 #ifdef _WIN32
-	extern void Win32SetCurrentLocaleName(const char *iso_code);
+	extern void Win32SetCurrentLocaleName(std::string iso_code);
 	Win32SetCurrentLocaleName(_current_language->isocode);
 #endif
 


### PR DESCRIPTION
## Motivation / Problem

Use of strecpy.


## Description

Pass ISO code as std::string, replace `strecpy` with `=` and `strcmp` with `==`.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
