### PR TITLE
Codechange: replace StrMakeValidInPlace with StrValid

### DIFF
--- a/src/script/api/script_text.cpp
+++ b/src/script/api/script_text.cpp
@@ -138,10 +138,11 @@ SQInteger ScriptText::_set(HSQUIRRELVM vm)
 	if (sq_gettype(vm, 2) == OT_STRING) {
 		const SQChar *key_string;
 		sq_getstring(vm, 2, &key_string);
-		StrMakeValidInPlace(const_cast<char *>(key_string));
 
-		if (strncmp(key_string, "param_", 6) != 0 || strlen(key_string) > 8) return SQ_ERROR;
-		k = atoi(key_string + 6);
+		std::string str = StrMakeValid(key_string);
+		if (!StrStartsWith(str, "param_") || str.size() > 8) return SQ_ERROR;
+
+		k = stoi(str.substr(6));
 	} else if (sq_gettype(vm, 2) == OT_INTEGER) {
 		SQInteger key;
 		sq_getinteger(vm, 2, &key);

--- a/src/script/script_info.cpp
+++ b/src/script/script_info.cpp
@@ -90,11 +90,11 @@ SQInteger ScriptInfo::AddSetting(HSQUIRRELVM vm)
 	/* Read the table, and find all properties we care about */
 	sq_pushnull(vm);
 	while (SQ_SUCCEEDED(sq_next(vm, -2))) {
-		const SQChar *key;
-		if (SQ_FAILED(sq_getstring(vm, -2, &key))) return SQ_ERROR;
-		StrMakeValidInPlace(const_cast<char *>(key));
+		const SQChar *key_string;
+		if (SQ_FAILED(sq_getstring(vm, -2, &key_string))) return SQ_ERROR;
+		std::string key = StrMakeValid(key_string);
 
-		if (strcmp(key, "name") == 0) {
+		if (key == "name") {
 			const SQChar *sqvalue;
 			if (SQ_FAILED(sq_getstring(vm, -1, &sqvalue))) return SQ_ERROR;
 
@@ -104,51 +104,51 @@ SQInteger ScriptInfo::AddSetting(HSQUIRRELVM vm)
 			config.name = StrMakeValid(sqvalue);
 			std::replace_if(config.name.begin(), config.name.end(), replace_with_underscore, '_');
 			items |= 0x001;
-		} else if (strcmp(key, "description") == 0) {
+		} else if (key == "description") {
 			const SQChar *sqdescription;
 			if (SQ_FAILED(sq_getstring(vm, -1, &sqdescription))) return SQ_ERROR;
 			config.description = StrMakeValid(sqdescription);
 			items |= 0x002;
-		} else if (strcmp(key, "min_value") == 0) {
+		} else if (key == "min_value") {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
 			config.min_value = ClampTo<int32_t>(res);
 			items |= 0x004;
-		} else if (strcmp(key, "max_value") == 0) {
+		} else if (key == "max_value") {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
 			config.max_value = ClampTo<int32_t>(res);
 			items |= 0x008;
-		} else if (strcmp(key, "easy_value") == 0) {
+		} else if (key == "easy_value") {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
 			config.easy_value = ClampTo<int32_t>(res);
 			items |= 0x010;
-		} else if (strcmp(key, "medium_value") == 0) {
+		} else if (key == "medium_value") {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
 			config.medium_value = ClampTo<int32_t>(res);
 			items |= 0x020;
-		} else if (strcmp(key, "hard_value") == 0) {
+		} else if (key == "hard_value") {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
 			config.hard_value = ClampTo<int32_t>(res);
 			items |= 0x040;
-		} else if (strcmp(key, "random_deviation") == 0) {
+		} else if (key == "random_deviation") {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
 			config.random_deviation = ClampTo<int32_t>(abs(res));
 			items |= 0x200;
-		} else if (strcmp(key, "custom_value") == 0) {
+		} else if (key == "custom_value") {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
 			config.custom_value = ClampTo<int32_t>(res);
 			items |= 0x080;
-		} else if (strcmp(key, "step_size") == 0) {
+		} else if (key == "step_size") {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
 			config.step_size = ClampTo<int32_t>(res);
-		} else if (strcmp(key, "flags") == 0) {
+		} else if (key == "flags") {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
 			config.flags = (ScriptConfigFlags)res;
@@ -184,9 +184,9 @@ SQInteger ScriptInfo::AddSetting(HSQUIRRELVM vm)
 
 SQInteger ScriptInfo::AddLabels(HSQUIRRELVM vm)
 {
-	const SQChar *setting_name;
-	if (SQ_FAILED(sq_getstring(vm, -2, &setting_name))) return SQ_ERROR;
-	StrMakeValidInPlace(const_cast<char *>(setting_name));
+	const SQChar *setting_name_str;
+	if (SQ_FAILED(sq_getstring(vm, -2, &setting_name_str))) return SQ_ERROR;
+	std::string setting_name = StrMakeValid(setting_name_str);
 
 	ScriptConfigItem *config = nullptr;
 	for (auto &item : this->config_list) {
@@ -216,9 +216,7 @@ SQInteger ScriptInfo::AddLabels(HSQUIRRELVM vm)
 			key_string++;
 		}
 		int key = atoi(key_string) * sign;
-		StrMakeValidInPlace(const_cast<char *>(label));
-
-		config->labels[key] = label;
+		config->labels[key] = StrMakeValid(label);
 
 		sq_pop(vm, 2);
 	}


### PR DESCRIPTION
## Motivation / Problem

Usage of C-style `StrMakeValidInPlace` variant that internally uses `strlen`.


## Description

Replace it with `StrMakeValid`.
Either because it makes comparing many strings easier to read `strcmp(key, "some value") == 0` vs `key == "some value"`, or because it is converted to `std::string` later anyway, or to use `StrStartsWith`.


## Limitations

None that I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
