### PR TITLE
Codechange: simplify console printing

### DIFF
--- a/src/console.cpp
+++ b/src/console.cpp
@@ -47,13 +47,13 @@ void IConsoleInit()
 	IConsoleStdLibRegister();
 }
 
-static void IConsoleWriteToLogFile(const char *string)
+static void IConsoleWriteToLogFile(const std::string &string)
 {
 	if (_iconsole_output_file != nullptr) {
 		/* if there is an console output file ... also print it there */
 		const char *header = GetLogPrefix();
 		if ((strlen(header) != 0 && fwrite(header, strlen(header), 1, _iconsole_output_file) != 1) ||
-				fwrite(string, strlen(string), 1, _iconsole_output_file) != 1 ||
+				fwrite(string.c_str(), string.size(), 1, _iconsole_output_file) != 1 ||
 				fwrite("\n", 1, 1, _iconsole_output_file) != 1) {
 			fclose(_iconsole_output_file);
 			_iconsole_output_file = nullptr;
@@ -104,23 +104,20 @@ void IConsolePrint(TextColour colour_code, const std::string &string)
 		return;
 	}
 
-	/* Create a copy of the string, strip if of colours and invalid
+	/* Create a copy of the string, strip it of colours and invalid
 	 * characters and (when applicable) assign it to the console buffer */
-	char *str = stredup(string.c_str());
-	StrMakeValidInPlace(str);
+	std::string str = StrMakeValid(string);
 
 	if (_network_dedicated) {
 		NetworkAdminConsole("console", str);
 		fmt::print("{}{}\n", GetLogPrefix(), str);
 		fflush(stdout);
 		IConsoleWriteToLogFile(str);
-		free(str); // free duplicated string since it's not used anymore
 		return;
 	}
 
 	IConsoleWriteToLogFile(str);
 	IConsoleGUIPrint(colour_code, str);
-	free(str);
 }
 
 /**

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -107,7 +107,6 @@ void IConsolePrint(TextColour colour_code, const std::string &string)
 	/* Create a copy of the string, strip if of colours and invalid
 	 * characters and (when applicable) assign it to the console buffer */
 	char *str = stredup(string.c_str());
-	str_strip_colours(str);
 	StrMakeValidInPlace(str);
 
 	if (_network_dedicated) {

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -462,7 +462,7 @@ static void IConsoleHistoryNavigate(int direction)
  * @param colour_code the colour of the command. Red in case of errors, etc.
  * @param str the message entered or output on the console (notice, error, etc.)
  */
-void IConsoleGUIPrint(TextColour colour_code, char *str)
+void IConsoleGUIPrint(TextColour colour_code, const std::string &str)
 {
 	_iconsole_buffer.push_front(IConsoleLine(str, colour_code));
 	SetWindowDirty(WC_CONSOLE, 0);

--- a/src/console_internal.h
+++ b/src/console_internal.h
@@ -86,6 +86,6 @@ bool GetArgumentInteger(uint32 *value, const char *arg);
 
 void IConsoleGUIInit();
 void IConsoleGUIFree();
-void IConsoleGUIPrint(TextColour colour_code, char *string);
+void IConsoleGUIPrint(TextColour colour_code, const std::string &string);
 
 #endif /* CONSOLE_INTERNAL_H */

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -423,29 +423,6 @@ bool StrEqualsIgnoreCase(const std::string_view str1, const std::string_view str
 	return StrCompareIgnoreCase(str1, str2) == 0;
 }
 
-/** Scans the string for colour codes and strips them */
-void str_strip_colours(char *str)
-{
-	char *dst = str;
-	WChar c;
-	size_t len;
-
-	for (len = Utf8Decode(&c, str); c != '\0'; len = Utf8Decode(&c, str)) {
-		if (c < SCC_BLUE || c > SCC_BLACK) {
-			/* Copy the character back. Even if dst is current the same as str
-			 * (i.e. no characters have been changed) this is quicker than
-			 * moving the pointers ahead by len */
-			do {
-				*dst++ = *str++;
-			} while (--len != 0);
-		} else {
-			/* Just skip (strip) the colour codes */
-			str += len;
-		}
-	}
-	*dst = '\0';
-}
-
 /**
  * Get the length of an UTF-8 encoded string in number of characters
  * and thus not the number of bytes that the encoded string contains.

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -42,7 +42,6 @@ void StrMakeValidInPlace(char *str, const char *last, StringValidationSettings s
 void StrMakeValidInPlace(char *str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 
 void str_fix_scc_encoded(char *str, const char *last) NOACCESS(2);
-void str_strip_colours(char *str);
 bool strtolower(std::string &str, std::string::size_type offs = 0);
 
 [[nodiscard]] bool StrValid(const char *str, const char *last) NOACCESS(2);


### PR DESCRIPTION
## Motivation / Problem

Printing has manual memory management (`stredup`) of string. Then it removes the colors, before making the string valid. However, making the string valid also removes the characters.


## Description

Replace `stredup`/`free` with `std::string`.
Replace `StrMakeValidInPlace(stredup(str.c_str())` with `StrMakeValid(str)` .
Completely remove `scc_strip_colours`


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
