### PR TITLE
Codechange: only one '\0' is required

### DIFF
--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -915,9 +915,8 @@ static void SlStdString(void *ptr, VarType conv)
 				return;
 			}
 
-			str->resize(len + 1);
+			str->resize(len);
 			SlCopyBytes(str->data(), len);
-			(*str)[len] = '\0'; // properly terminate the string
 
 			StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK;
 			if ((conv & SLF_ALLOW_CONTROL) != 0) {


### PR DESCRIPTION
## Motivation / Problem

`str` is a `std::string`. This implicitly allocates 1 byte extra to place the `\0`, so `c_str()` can actually function. There is no need for us to add yet another `\0` to the string. 
This also affects the `size()` returned by the string; if you save "Hi", it's `size()` would be 3. Luckily `StrMakeValid` fixes that later on.


## Description

Remove the unneeded manual extra allocation and assignment for `\0`.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
