### PR TITLE
Codechange: move saveload string fixing code to saveload

### DIFF
--- a/src/string.cpp
+++ b/src/string.cpp
@@ -116,30 +116,6 @@ std::string FormatArrayAsHex(span<const byte> data)
 	return str;
 }
 
-/**
- * Scan the string for old values of SCC_ENCODED and fix it to
- * it's new, static value.
- * @param str the string to scan
- * @param last the last valid character of str
- */
-void str_fix_scc_encoded(char *str, const char *last)
-{
-	while (str <= last && *str != '\0') {
-		size_t len = Utf8EncodedCharLen(*str);
-		if ((len == 0 && str + 4 > last) || str + len > last) break;
-
-		WChar c;
-		Utf8Decode(&c, str);
-		if (c == '\0') break;
-
-		if (c == 0xE028 || c == 0xE02A) {
-			c = SCC_ENCODED;
-		}
-		str += Utf8Encode(str, c);
-	}
-	*str = '\0';
-}
-
 
 template <class T>
 static void StrMakeValidInPlace(T &dst, const char *str, const char *last, StringValidationSettings settings)

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -41,7 +41,6 @@ void StrMakeValidInPlace(char *str, const char *last, StringValidationSettings s
 [[nodiscard]] std::string StrMakeValid(std::string_view str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 void StrMakeValidInPlace(char *str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 
-void str_fix_scc_encoded(char *str, const char *last) NOACCESS(2);
 bool strtolower(std::string &str, std::string::size_type offs = 0);
 
 [[nodiscard]] bool StrValid(const char *str, const char *last) NOACCESS(2);


### PR DESCRIPTION
## Motivation / Problem

Looking at `str_fix_scc_encoded` and wondering how that is somehow generic, primarily because it still works using C-style string logic when working on a `std::string`.


## Description

Move the code, rename the function and pass the `std::string`. Then simplify the code where applicable, although it's still not free of C-style logic but that's a bit of a catch 22.
When the string is corrupt, just bail out and let the later call to `StrMakeValid` handle that.
Only overwrite the characters where needed.
Do not try to '\0' terminate the string, as that is already the case due to it being `std::string`.


## Limitations

Still some C-style Utf8 character messing, but that's likely going to be tricky to solve and definitely out of scope.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
