### PR TITLE
Cleanup: remove seprintf and vsnprintf

### DIFF
--- a/src/safeguards.h
+++ b/src/safeguards.h
@@ -40,7 +40,7 @@
 #define strcat    SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define strncat   SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
-/* Use seprintf instead. */
+/* Use fmt::format instead. */
 #define sprintf   SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define snprintf  SAFEGUARD_DO_NOT_USE_THIS_METHOD
 

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -90,10 +90,6 @@
 #if defined(__GNUC__) || (defined(__clang__) && !defined(_MSC_VER))
 #	define NORETURN __attribute__ ((noreturn))
 #	define CDECL
-#	define __int64 long long
-	/* Warn about functions using 'printf' format syntax. First argument determines which parameter
-	 * is the format string, second argument is start of values passed to printf. */
-#	define WARN_FORMAT(string, args) __attribute__ ((format (printf, string, args)))
 #	if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7)
 #		define FINAL final
 #	else
@@ -128,7 +124,6 @@
 #if defined(__WATCOMC__)
 #	define NORETURN
 #	define CDECL
-#	define WARN_FORMAT(string, args)
 #	define FINAL
 #	define FALLTHROUGH
 #	include <malloc.h>
@@ -170,7 +165,6 @@
 #	endif
 
 #	define CDECL _cdecl
-#	define WARN_FORMAT(string, args)
 #	define FINAL final
 
 	/* fallthrough attribute, VS 2017 */

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -7,18 +7,6 @@
 
 /**
  * @file string_func.h Functions related to low-level strings.
- *
- * @note Be aware of "dangerous" string functions; string functions that
- * have behaviour that could easily cause buffer overruns and such:
- * - strncpy: does not '\0' terminate when input string is longer than
- *   the size of the output string. Use strecpy instead.
- * - [v]snprintf: returns the length of the string as it would be written
- *   when the output is large enough, so it can be more than the size of
- *   the buffer and than can underflow size_t (uint-ish) which makes all
- *   subsequent snprintf alikes write outside of the buffer. Use
- *   [v]seprintf instead; it will return the number of bytes actually
- *   added so no [v]seprintf will cause outside of bounds writes.
- * - [v]sprintf: does not bounds checking: use [v]seprintf instead.
  */
 
 #ifndef STRING_FUNC_H
@@ -32,8 +20,6 @@
 
 char *strecpy(char *dst, const char *src, const char *last) NOACCESS(3);
 char *stredup(const char *src, const char *last = nullptr) NOACCESS(2);
-
-int CDECL seprintf(char *str, const char *last, const char *format, ...) WARN_FORMAT(3, 4) NOACCESS(2);
 
 std::string FormatArrayAsHex(span<const byte> data);
 


### PR DESCRIPTION
## Motivation / Problem

`seprintf` and `vsnprintf` are not used anymore.


## Description

Remove them.


## Limitations

Downstreams might still be using it...


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
