### PR TITLE
Fix #10975: Clear a non-head engine's name

### DIFF
--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -1327,6 +1327,7 @@ CommandCost CmdMoveRailVehicle(DoCommandFlag flags, VehicleID src_veh, VehicleID
 			/* Remove stuff not valid anymore for non-front engines. */
 			DeleteVehicleOrders(src);
 			src->unitnumber = 0;
+			src->name.clear();
 		}
 
 		/* We weren't a front engine but are becoming one. So


### PR DESCRIPTION
## Motivation / Problem

Fixes #10975.


## Description
When reconfiguring a vehicle such that it is no longer the head of the rake, clear the name of such a vehicle. This allows other trains to use that name. Anyway, only whole trains (not parts of them) should have a name.


## Limitations
In earlier behaviour, when you joined two trains, both having a name, into one train, the non-head engine still retained its name in a hidden way, and if you separated that engine again, it would show its old name again. Now, it just shows the train number. I believe this is acceptable, because anyway the orders of such an engine have been cleared.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
