### PR TITLE
Codechange: let ReadLine return a string instead of passing a buffer

### DIFF
--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -102,14 +102,10 @@ struct StringListReader : StringReader {
 	{
 	}
 
-	char *ReadLine(char *buffer, const char *last) override
+	std::optional<std::string> ReadLine() override
 	{
-		if (this->p == this->end) return nullptr;
-
-		strecpy(buffer, this->p->c_str(), last);
-		this->p++;
-
-		return buffer;
+		if (this->p == this->end) return std::nullopt;
+		return *this->p++;
 	}
 };
 

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -84,9 +84,11 @@ struct FileStringReader : StringReader {
 		this->input_stream.open(file, std::ifstream::binary);
 	}
 
-	char *ReadLine(char *buffer, const char *last) override
+	std::optional<std::string> ReadLine() override
 	{
-		return this->input_stream.getline(buffer, last - buffer) ? buffer : nullptr;
+		std::string result;
+		if (!std::getline(this->input_stream, result)) return std::nullopt;
+		return result;
 	}
 
 	void HandlePragma(char *str) override;

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -67,11 +67,9 @@ struct StringReader {
 
 	/**
 	 * Read a single line from the source of strings.
-	 * @param buffer The buffer to read the data in to.
-	 * @param last   The last element in the buffer.
-	 * @return The buffer, or nullptr if at the end of the file.
+	 * @return The line, or std::nullopt if at the end of the file.
 	 */
-	virtual char *ReadLine(char *buffer, const char *last) = 0;
+	virtual std::optional<std::string> ReadLine() = 0;
 
 	/**
 	 * Handle the pragma of the file.

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -739,16 +739,13 @@ void StringReader::HandlePragma(char *str)
 	}
 }
 
-static void rstrip(char *buf)
+static void StripTrailingWhitespace(std::string &str)
 {
-	size_t i = strlen(buf);
-	while (i > 0 && (buf[i - 1] == '\r' || buf[i - 1] == '\n' || buf[i - 1] == ' ')) i--;
-	buf[i] = '\0';
+	str.erase(str.find_last_not_of("\r\n ") + 1);
 }
 
 void StringReader::ParseFile()
 {
-	char buf[2048];
 	_warnings = _errors = 0;
 
 	_translation = this->translation;
@@ -765,9 +762,12 @@ void StringReader::ParseFile()
 	strecpy(_lang.digit_decimal_separator, ".", lastof(_lang.digit_decimal_separator));
 
 	_cur_line = 1;
-	while (this->data.next_string_id < this->data.max_strings && this->ReadLine(buf, lastof(buf)) != nullptr) {
-		rstrip(buf);
-		this->HandleString(buf);
+	while (this->data.next_string_id < this->data.max_strings) {
+		std::optional<std::string> line = this->ReadLine();
+		if (!line.has_value()) return;
+
+		StripTrailingWhitespace(line.value());
+		this->HandleString(line.value().data());
 		_cur_line++;
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Use of `strecpy`.


## Description

Instead of `strecpy`, just return the `std::string` as it.
Instead of C-style buffers for `ReadLine` return `std::optioanl<std::string>`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
