### PR TITLE
Fix 07add7a9: [Win32] use full monitor resolution for fullscreen

### DIFF
--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -212,13 +212,18 @@ bool VideoDriver_Win32Base::MakeWindow(bool full_screen, bool resize)
 		if (this->main_wnd != nullptr) {
 			if (!_window_maximize && resize) SetWindowPos(this->main_wnd, 0, 0, 0, w, h, SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOZORDER | SWP_NOMOVE);
 		} else {
-			/* Center on the workspace of the primary display. */
-			MONITORINFO mi;
-			mi.cbSize = sizeof(mi);
-			GetMonitorInfo(MonitorFromWindow(0, MONITOR_DEFAULTTOPRIMARY), &mi);
+			int x = 0;
+			int y = 0;
 
-			int x = (mi.rcWork.right - mi.rcWork.left - w) / 2;
-			int y = (mi.rcWork.bottom - mi.rcWork.top - h) / 2;
+			/* For windowed mode, center on the workspace of the primary display. */
+			if (!this->fullscreen) {
+				MONITORINFO mi;
+				mi.cbSize = sizeof(mi);
+				GetMonitorInfo(MonitorFromWindow(0, MONITOR_DEFAULTTOPRIMARY), &mi);
+
+				x = (mi.rcWork.right - mi.rcWork.left - w) / 2;
+				y = (mi.rcWork.bottom - mi.rcWork.top - h) / 2;
+			}
 
 			std::string caption = VideoDriver::GetCaption();
 			this->main_wnd = CreateWindow(L"OTTD", OTTD2FS(caption).c_str(), style, x, y, w, h, 0, 0, GetModuleHandle(nullptr), this);


### PR DESCRIPTION
## Motivation / Problem

On Windows in fullscreen you cannot reach the top with the cursor for the halve of the height of your toolbar.
Additionally, on Win10 in fullscreen you can see the actual toolbar.

## Description

It is kinda funny. With 07add7a9 the offset of the location of the window is based on the workspace, and not the monitor size. But as a result, in fullscreen, we also offset it. But rendering still happens in a fullscreen kinda way .. kinda. It just starts to act all weird.

Anyway, fix this by simply not setting an offset for fullscreen. The old code is kinda misleading by the fact that because the game and display have the same resolution, it is zero. By making it more explicit that for fullscreen it should be zero, we avoid future problems with this.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
