### PR TITLE
Codechange: remove offsets from CopyIn/OutDParam

### DIFF
--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -210,7 +210,7 @@ public:
 	{
 		switch (widget) {
 			case WID_EM_MESSAGE: {
-				CopyInDParam(0, this->decode_params, lengthof(this->decode_params));
+				CopyInDParam(this->decode_params, lengthof(this->decode_params));
 				if (this->textref_stack_size > 0) StartTextRefStackUsage(this->textref_stack_grffile, this->textref_stack_size, this->textref_stack);
 
 				this->height_summary = GetStringHeight(this->summary_msg, size->width);
@@ -279,7 +279,7 @@ public:
 
 	void SetStringParameters(int widget) const override
 	{
-		if (widget == WID_EM_CAPTION) CopyInDParam(0, this->decode_params, lengthof(this->decode_params));
+		if (widget == WID_EM_CAPTION) CopyInDParam(this->decode_params, lengthof(this->decode_params));
 	}
 
 	void DrawWidget(const Rect &r, int widget) const override
@@ -292,7 +292,7 @@ public:
 			}
 
 			case WID_EM_MESSAGE:
-				CopyInDParam(0, this->decode_params, lengthof(this->decode_params));
+				CopyInDParam(this->decode_params, lengthof(this->decode_params));
 				if (this->textref_stack_size > 0) StartTextRefStackUsage(this->textref_stack_grffile, this->textref_stack_size, this->textref_stack);
 
 				if (this->detailed_msg == INVALID_STRING_ID) {

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -1106,19 +1106,19 @@ struct QueryWindow : public Window {
 	QueryCallbackProc *proc; ///< callback function executed on closing of popup. Window* points to parent, bool is true if 'yes' clicked, false otherwise
 	uint64 params[10];       ///< local copy of #_global_string_params
 	StringID message;        ///< message shown for query window
-	StringID caption;        ///< title of window
 
 	QueryWindow(WindowDesc *desc, StringID caption, StringID message, Window *parent, QueryCallbackProc *callback) : Window(desc)
 	{
 		/* Create a backup of the variadic arguments to strings because it will be
 		 * overridden pretty often. We will copy these back for drawing */
 		CopyOutDParam(this->params, 0, lengthof(this->params));
-		this->caption = caption;
 		this->message = message;
 		this->proc    = callback;
 		this->parent  = parent;
 
-		this->InitNested(WN_CONFIRM_POPUP_QUERY);
+		this->CreateNestedTree();
+		this->GetWidget<NWidgetCore>(WID_Q_CAPTION)->SetDataTip(caption, STR_NULL);
+		this->FinishInitNested(WN_CONFIRM_POPUP_QUERY);
 	}
 
 	void Close() override
@@ -1139,10 +1139,6 @@ struct QueryWindow : public Window {
 	{
 		switch (widget) {
 			case WID_Q_CAPTION:
-				CopyInDParam(1, this->params, lengthof(this->params));
-				SetDParam(0, this->caption);
-				break;
-
 			case WID_Q_TEXT:
 				CopyInDParam(0, this->params, lengthof(this->params));
 				break;
@@ -1213,7 +1209,7 @@ struct QueryWindow : public Window {
 static const NWidgetPart _nested_query_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_RED),
-		NWidget(WWT_CAPTION, COLOUR_RED, WID_Q_CAPTION), SetDataTip(STR_JUST_STRING, STR_NULL),
+		NWidget(WWT_CAPTION, COLOUR_RED, WID_Q_CAPTION), // The caption's string is set in the constructor
 	EndContainer(),
 	NWidget(WWT_PANEL, COLOUR_RED),
 		NWidget(NWID_VERTICAL), SetPIP(0, WidgetDimensions::unscaled.vsep_wide, 0), SetPadding(WidgetDimensions::unscaled.modalpopup),

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -1111,7 +1111,7 @@ struct QueryWindow : public Window {
 	{
 		/* Create a backup of the variadic arguments to strings because it will be
 		 * overridden pretty often. We will copy these back for drawing */
-		CopyOutDParam(this->params, 0, lengthof(this->params));
+		CopyOutDParam(this->params, lengthof(this->params));
 		this->message = message;
 		this->proc    = callback;
 		this->parent  = parent;
@@ -1140,7 +1140,7 @@ struct QueryWindow : public Window {
 		switch (widget) {
 			case WID_Q_CAPTION:
 			case WID_Q_TEXT:
-				CopyInDParam(0, this->params, lengthof(this->params));
+				CopyInDParam(this->params, lengthof(this->params));
 				break;
 		}
 	}

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -361,7 +361,7 @@ struct NewsWindow : Window {
 				break;
 
 			case WID_N_MESSAGE:
-				CopyInDParam(0, this->ni->params, lengthof(this->ni->params));
+				CopyInDParam(this->ni->params, lengthof(this->ni->params));
 				str = this->ni->string_id;
 				break;
 
@@ -429,7 +429,7 @@ struct NewsWindow : Window {
 				break;
 
 			case WID_N_MESSAGE:
-				CopyInDParam(0, this->ni->params, lengthof(this->ni->params));
+				CopyInDParam(this->ni->params, lengthof(this->ni->params));
 				DrawStringMultiLine(r.left, r.right, r.top, r.bottom, this->ni->string_id, TC_FROMSTRING, SA_CENTER);
 				break;
 
@@ -582,7 +582,7 @@ private:
 	StringID GetCompanyMessageString() const
 	{
 		/* Company news with a face have a separate headline, so the normal message is shifted by two params */
-		CopyInDParam(0, this->ni->params + 2, lengthof(this->ni->params) - 2);
+		CopyInDParam(this->ni->params + 2, lengthof(this->ni->params) - 2);
 		return this->ni->params[1];
 	}
 
@@ -804,7 +804,7 @@ NewsItem::NewsItem(StringID string_id, NewsType type, NewsFlag flags, NewsRefere
 {
 	/* show this news message in colour? */
 	if (TimerGameCalendar::year >= _settings_client.gui.coloured_news_year) this->flags |= NF_INCOLOUR;
-	CopyOutDParam(this->params, 0, lengthof(this->params));
+	CopyOutDParam(this->params, lengthof(this->params));
 }
 
 /**
@@ -1099,7 +1099,7 @@ void ShowLastNewsMessage()
  */
 static void DrawNewsString(uint left, uint right, int y, TextColour colour, const NewsItem *ni)
 {
-	CopyInDParam(0, ni->params, lengthof(ni->params));
+	CopyInDParam(ni->params, lengthof(ni->params));
 
 	/* Get the string, replaces newlines with spaces and remove control codes from the string. */
 	std::string message = StrMakeValid(GetString(ni->string_id), SVS_REPLACE_TAB_CR_NL_WITH_SPACE);

--- a/src/statusbar_gui.cpp
+++ b/src/statusbar_gui.cpp
@@ -39,7 +39,7 @@
 
 static bool DrawScrollingStatusText(const NewsItem *ni, int scroll_pos, int left, int right, int top, int bottom)
 {
-	CopyInDParam(0, ni->params, lengthof(ni->params));
+	CopyInDParam(ni->params, lengthof(ni->params));
 
 	/* Replace newlines and the likes with spaces. */
 	std::string message = StrMakeValid(GetString(ni->string_id), SVS_REPLACE_TAB_CR_NL_WITH_SPACE);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -128,24 +128,22 @@ void SetDParamMaxDigits(uint n, uint count, FontSize size)
 
 /**
  * Copy \a num string parameters from array \a src into the global string parameter array.
- * @param offs Index in the global array to copy the first string parameter to.
  * @param src  Source array of string parameters.
  * @param num  Number of string parameters to copy.
  */
-void CopyInDParam(int offs, const uint64 *src, int num)
+void CopyInDParam(const uint64 *src, int num)
 {
-	MemCpyT(_global_string_params.GetPointerToOffset(offs), src, num);
+	MemCpyT(_global_string_params.GetPointerToOffset(0), src, num);
 }
 
 /**
  * Copy \a num string parameters from the global string parameter array to the \a dst array.
  * @param dst  Destination array of string parameters.
- * @param offs Index in the global array to copy the first string parameter from.
  * @param num  Number of string parameters to copy.
  */
-void CopyOutDParam(uint64 *dst, int offs, int num)
+void CopyOutDParam(uint64 *dst, int num)
 {
-	MemCpyT(dst, _global_string_params.GetPointerToOffset(offs), num);
+	MemCpyT(dst, _global_string_params.GetPointerToOffset(0), num);
 }
 
 /**

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -218,8 +218,8 @@ void SetDParamStr(uint n, const char *str);
 void SetDParamStr(uint n, const std::string &str);
 void SetDParamStr(uint n, std::string &&str) = delete; // block passing temporaries to SetDParamStr
 
-void CopyInDParam(int offs, const uint64 *src, int num);
-void CopyOutDParam(uint64 *dst, int offs, int num);
+void CopyInDParam(const uint64 *src, int num);
+void CopyOutDParam(uint64 *dst, int num);
 void CopyOutDParam(uint64 *dst, const char **strings, StringID string, int num);
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Offets aren't used, except for one situation, and make any replacement of the current DParam system more complicated than it needs to be.


## Description

Replace the `STR_JUST_STRING` string from the caption of the query window, and just inject the required string into the appropriate place in the widget tree. Reducing the need to store a duplicate StringID, and removing one level of indirection in formatting the caption string. This the drops the offset to where to copy the other parameters by one to zero.

Remove the offsets parameters from `CopyInDParam` and `CopyOutDParam` as it is always `0`.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
