### PR TITLE
Change: [Actions] Upgrade import-codesign-certs dependency in macOS b…

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -79,7 +79,7 @@ jobs:
         echo "::endgroup::"
 
     - name: Import code signing certificates
-      uses: Apple-Actions/import-codesign-certs@v1
+      uses: Apple-Actions/import-codesign-certs@v2
       with:
         # The certificates in a PKCS12 file encoded as a base64 string
         p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}


### PR DESCRIPTION
## Description
Backport of all closed Pull Requests labeled as 'backport requested' into `release/13`.
- https://github.com/OpenTTD/OpenTTD/pull/10724
<!-- Backported: 10724 -->