### PR TITLE
Codechange: set the type correctly when resolving parameter data

### DIFF
--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -66,6 +66,7 @@ class StringParameters {
 public:
 	uint offset;              ///< Current offset in the data/type arrays.
 	uint num_param;           ///< Length of the data array.
+	WChar next_type = 0; ///< The type of the next data that is retrieved.
 
 	/** Create a new StringParameters instance. */
 	StringParameters(uint64 *data, uint num_param, WChar *type) :
@@ -115,12 +116,12 @@ public:
 
 	void ClearTypeInformation();
 
-	int64 GetInt64(WChar type = 0);
+	int64 GetInt64();
 
 	/** Read an int32 from the argument array. @see GetInt64. */
-	int32 GetInt32(WChar type = 0)
+	int32 GetInt32()
 	{
-		return (int32)this->GetInt64(type);
+		return (int32)this->GetInt64();
 	}
 
 	/**


### PR DESCRIPTION
## Motivation / Problem

Inconsistent/incorrect parameter setting for `StringParameters`' `GetInt64` and `GetInt32`.


## Description

Make it consistent/correct, by just setting them automatically.

The "type" in this context is the `StringControlCode` that is required to resolve the string for resolving the gender. Long ago the type was deduced by `strgen`, but when referencing parameters within substrings this impossible for `strgen` to always figure out correctly. So essentially, it could occasionally be wrong. Especially when NewGRFs are involved!

r21444 the "type" got added to OpenTTD and in r21445 the "type" got removed from strgen. Since then everybody seems to be doing something differently, but not always what is required for the gender to be determined correctly.

So... for every `SCC_XYZ` switch case in `FormatString` the first `GetInt32/64` must get the `SCC` that is being formatted passed as type, whereas all the others must not get anything passed (effectively passing zero). That way, after the dry run, when the gender needs to be determined, the right control code can be encoded to get formatted to determine the gender.


## Limitations

Does not update the internal documentation or naming of the parameter; that is for the further refactor of the string parameter code.

Technically something like `SCC_COMMA` does not need to set the "type" as it cannot resolve to a gender (yet). But the question is... how to ensure that decision is always taken instead of just being overlooked? That's why I changed it to do it automatically, so it cannot be forgotten. Although it does mean that sometimes it will attempt to resolve the gender even when that is not required. However, the chance of that happening is generally pretty low as usually.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
