### PR TITLE
Codechange: remove SetDParamX/GetDParamX

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -285,14 +285,14 @@ void UpdateLandscapingLimits()
 }
 
 /**
- * Set the right DParams to get the name of an owner.
+ * Set the right DParams for STR_ERROR_OWNED_BY.
  * @param owner the owner to get the name of.
  * @param tile  optional tile to get the right town.
  * @pre if tile == 0, then owner can't be OWNER_TOWN.
  */
-void GetNameOfOwner(Owner owner, TileIndex tile)
+void SetDParamsForOwnedBy(Owner owner, TileIndex tile)
 {
-	SetDParam(2, owner);
+	SetDParam(OWNED_BY_OWNER_IN_PARAMETERS_OFFSET, owner);
 
 	if (owner != OWNER_TOWN) {
 		if (!Company::IsValidID(owner)) {
@@ -326,7 +326,7 @@ CommandCost CheckOwnership(Owner owner, TileIndex tile)
 
 	if (owner == _current_company) return CommandCost();
 
-	GetNameOfOwner(owner, tile);
+	SetDParamsForOwnedBy(owner, tile);
 	return_cmd_error(STR_ERROR_OWNED_BY);
 }
 
@@ -346,7 +346,7 @@ CommandCost CheckTileOwnership(TileIndex tile)
 	if (owner == _current_company) return CommandCost();
 
 	/* no need to get the name of the owner unless we're the local company (saves some time) */
-	if (IsLocalCompany()) GetNameOfOwner(owner, tile);
+	if (IsLocalCompany()) SetDParamsForOwnedBy(owner, tile);
 	return_cmd_error(STR_ERROR_OWNED_BY);
 }
 

--- a/src/company_func.h
+++ b/src/company_func.h
@@ -17,7 +17,8 @@
 
 bool MayCompanyTakeOver(CompanyID cbig, CompanyID small);
 void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner);
-void GetNameOfOwner(Owner owner, TileIndex tile);
+static const int OWNED_BY_OWNER_IN_PARAMETERS_OFFSET = 2; ///< The index in the parameters for the owner information.
+void SetDParamsForOwnedBy(Owner owner, TileIndex tile);
 void SetLocalCompany(CompanyID new_company);
 void ShowBuyCompanyDialog(CompanyID company, bool hostile_takeover);
 void CompanyAdminUpdate(const Company *company);

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -131,6 +131,12 @@ ErrorMessageData::ErrorMessageData(StringID summary_msg, StringID detailed_msg, 
  */
 void ErrorMessageData::CopyOutDParams()
 {
+	if (this->detailed_msg == STR_ERROR_OWNED_BY) {
+		/* The parameters are set by SetDParamsForOwnedBy. */
+		CompanyID company = (CompanyID)GetDParam(OWNED_BY_OWNER_IN_PARAMETERS_OFFSET);
+		if (company < MAX_COMPANIES) face = company;
+	}
+
 	/* Reset parameters */
 	for (size_t i = 0; i < lengthof(this->strings); i++) free(this->strings[i]);
 	memset(this->decode_params, 0, sizeof(this->decode_params));
@@ -140,11 +146,6 @@ void ErrorMessageData::CopyOutDParams()
 	if (this->textref_stack_size > 0) StartTextRefStackUsage(this->textref_stack_grffile, this->textref_stack_size, this->textref_stack);
 	CopyOutDParam(this->decode_params, this->strings, this->detailed_msg == INVALID_STRING_ID ? this->summary_msg : this->detailed_msg, lengthof(this->decode_params));
 	if (this->textref_stack_size > 0) StopTextRefStackUsage();
-
-	if (this->detailed_msg == STR_ERROR_OWNED_BY) {
-		CompanyID company = (CompanyID)GetDParamX(this->decode_params, OWNED_BY_OWNER_IN_PARAMETERS_OFFSET);
-		if (company < MAX_COMPANIES) face = company;
-	}
 }
 
 /**

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -16,6 +16,7 @@
 #include "gfx_func.h"
 #include "string_func.h"
 #include "company_base.h"
+#include "company_func.h"
 #include "company_manager_face.h"
 #include "strings_func.h"
 #include "zoom_func.h"
@@ -141,7 +142,7 @@ void ErrorMessageData::CopyOutDParams()
 	if (this->textref_stack_size > 0) StopTextRefStackUsage();
 
 	if (this->detailed_msg == STR_ERROR_OWNED_BY) {
-		CompanyID company = (CompanyID)GetDParamX(this->decode_params, 2);
+		CompanyID company = (CompanyID)GetDParamX(this->decode_params, OWNED_BY_OWNER_IN_PARAMETERS_OFFSET);
 		if (company < MAX_COMPANIES) face = company;
 	}
 }

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -476,7 +476,7 @@ static void GetTileDesc_Industry(TileIndex tile, TileDesc *td)
 	td->owner[0] = i->owner;
 	td->str = is->name;
 	if (!IsIndustryCompleted(tile)) {
-		SetDParamX(td->dparam, 0, td->str);
+		td->dparam = td->str;
 		td->str = STR_LAI_TOWN_INDUSTRY_DESCRIPTION_UNDER_CONSTRUCTION;
 	}
 

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -182,7 +182,7 @@ public:
 			if (td.owner_type[i] == STR_NULL) continue;
 
 			SetDParam(0, STR_LAND_AREA_INFORMATION_OWNER_N_A);
-			if (td.owner[i] != OWNER_NONE && td.owner[i] != OWNER_WATER) GetNameOfOwner(td.owner[i], tile);
+			if (td.owner[i] != OWNER_NONE && td.owner[i] != OWNER_WATER) SetDParamsForOwnedBy(td.owner[i], tile);
 			this->landinfo_data.push_back(GetString(td.owner_type[i]));
 		}
 

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -174,7 +174,7 @@ public:
 		this->landinfo_data.clear();
 
 		/* Tiletype */
-		SetDParam(0, td.dparam[0]);
+		SetDParam(0, td.dparam);
 		this->landinfo_data.push_back(GetString(td.str));
 
 		/* Up to four owners */

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -2463,8 +2463,8 @@ CommandCost CmdConvertRoad(DoCommandFlag flags, TileIndex tile, TileIndex area_s
 				}
 
 				if (rtt == RTT_ROAD && owner == OWNER_TOWN) {
+					SetDParamsForOwnedBy(OWNER_TOWN, tile);
 					error.MakeError(STR_ERROR_OWNED_BY);
-					GetNameOfOwner(OWNER_TOWN, tile);
 					continue;
 				}
 			}
@@ -2516,8 +2516,8 @@ CommandCost CmdConvertRoad(DoCommandFlag flags, TileIndex tile, TileIndex area_s
 				}
 
 				if (rtt == RTT_ROAD && owner == OWNER_TOWN) {
+					SetDParamsForOwnedBy(OWNER_TOWN, tile);
 					error.MakeError(STR_ERROR_OWNED_BY);
-					GetNameOfOwner(OWNER_TOWN, tile);
 					continue;
 				}
 			}

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -212,17 +212,6 @@ void CopyOutDParam(uint64 *dst, int num);
 void CopyOutDParam(uint64 *dst, const char **strings, StringID string, int num);
 
 /**
- * Get the current string parameter at index \a n from parameter array \a s.
- * @param s Array of string parameters.
- * @param n Index of the string parameter.
- * @return Value of the requested string parameter.
- */
-static inline uint64 GetDParamX(const uint64 *s, uint n)
-{
-	return s[n];
-}
-
-/**
  * Get the current string parameter at index \a n from the global string parameter array.
  * @param n Index of the string parameter.
  * @return Value of the requested string parameter.

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -191,17 +191,6 @@ static inline int64 PackVelocity(uint speed, VehicleType type)
 }
 
 /**
- * Set a string parameter \a v at index \a n in a given array \a s.
- * @param s Array of string parameters.
- * @param n Index of the string parameter.
- * @param v Value of the string parameter.
- */
-static inline void SetDParamX(uint64 *s, uint n, uint64 v)
-{
-	s[n] = v;
-}
-
-/**
  * Set a string parameter \a v at index \a n in the global string parameter array.
  * @param n Index of the string parameter.
  * @param v Value of the string parameter.

--- a/src/tile_cmd.h
+++ b/src/tile_cmd.h
@@ -51,6 +51,7 @@ struct TileInfo {
 /** Tile description for the 'land area information' tool */
 struct TileDesc {
 	StringID str;               ///< Description of the tile
+	uint64_t dparam;            ///< Parameter of the \a str string
 	Owner owner[4];             ///< Name of the owner(s)
 	StringID owner_type[4];     ///< Type of each owner
 	TimerGameCalendar::Date build_date; ///< Date of construction of tile contents
@@ -60,7 +61,6 @@ struct TileDesc {
 	StringID airport_name;      ///< Name of the airport
 	StringID airport_tile_name; ///< Name of the airport tile
 	const char *grf;            ///< newGRF used for the tile contents
-	uint64 dparam[2];           ///< Parameters of the \a str string
 	StringID railtype;          ///< Type of rail on the tile.
 	uint16 rail_speed;          ///< Speed limit of rail (bridges and track)
 	StringID roadtype;          ///< Type of road on the tile.

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -788,7 +788,7 @@ static void GetTileDesc_Town(TileIndex tile, TileDesc *td)
 	}
 
 	if (!house_completed) {
-		SetDParamX(td->dparam, 0, td->str);
+		td->dparam = td->str;
 		td->str = STR_LAI_TOWN_INDUSTRY_DESCRIPTION_UNDER_CONSTRUCTION;
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Existence of DParam accessor functions that do not work on the StringParameters, but rather directly one some random array.


## Description

`SetDParamX` was used to always set index 0 of an array of 2. The first index of the array would then be (manually) set to `SetDParam`. So, the whole array and indexing it is not needed. A single variable will suffice as well.

`GetNameOfOwner` has a misleading name, as it does not return something but rather sets the DParams for `STR_ERROR_OWNED_BY` and the owner strings of the land/tile info. Rename it to `SetDParamsForOwnedBy`.

The error UI creation reads a DParam to determine the owner (the one of those set by `SetDParamsForOwnedBy`) via it's copied buffer, however it can also just use the original `GetDParam` function.


## Limitations

The stuff the error UI does to get the owner is nasty. However, passing that around from `GetXXOwnedBy` through the errors seems like an even bigger hassle. And that definitely is the case for this PR. However, I made a global constant for the index so it is likely that a change of index will automatically prevent an issue due to the error UI mess.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
