### PR TITLE
Feature: Transparency option for cost and income indicators

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2650,7 +2650,7 @@ STR_TRANSPARENT_BUILDINGS_TOOLTIP                               :{BLACK}Toggle t
 STR_TRANSPARENT_BRIDGES_TOOLTIP                                 :{BLACK}Toggle transparency for bridges. Ctrl+Click to lock
 STR_TRANSPARENT_STRUCTURES_TOOLTIP                              :{BLACK}Toggle transparency for structures like lighthouses and antennas. Ctrl+Click to lock
 STR_TRANSPARENT_CATENARY_TOOLTIP                                :{BLACK}Toggle transparency for catenary. Ctrl+Click to lock
-STR_TRANSPARENT_LOADING_TOOLTIP                                 :{BLACK}Toggle transparency for loading indicators. Ctrl+Click to lock
+STR_TRANSPARENT_TEXT_TOOLTIP                                    :{BLACK}Toggle transparency for loading and cost/income text. Ctrl+Click to lock
 STR_TRANSPARENT_INVISIBLE_TOOLTIP                               :{BLACK}Set objects invisible instead of transparent
 
 # Linkgraph legend window

--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -118,10 +118,10 @@ void DrawTextEffects(DrawPixelInfo *dpi)
 {
 	/* Don't draw the text effects when zoomed out a lot */
 	if (dpi->zoom > ZOOM_LVL_OUT_8X) return;
-
+	if (IsTransparencySet(TO_TEXT)) return;
 	for (TextEffect &te : _text_effects) {
 		if (te.string_id == INVALID_STRING_ID) continue;
-		if (te.mode == TE_RISING || (_settings_client.gui.loading_indicators && !IsTransparencySet(TO_LOADING))) {
+		if (te.mode == TE_RISING || _settings_client.gui.loading_indicators) {
 			CopyInDParam(te.params);
 			ViewportAddString(dpi, ZOOM_LVL_OUT_8X, &te, te.string_id, te.string_id - 1, STR_NULL);
 		}

--- a/src/transparency.h
+++ b/src/transparency.h
@@ -28,7 +28,7 @@ enum TransparencyOption {
 	TO_BRIDGES,    ///< bridges
 	TO_STRUCTURES, ///< other objects such as transmitters and lighthouses
 	TO_CATENARY,   ///< catenary
-	TO_LOADING,    ///< loading indicators
+	TO_TEXT,       ///< loading and cost/income text
 	TO_END,
 	TO_INVALID,    ///< Invalid transparency option
 };

--- a/src/transparency_gui.cpp
+++ b/src/transparency_gui.cpp
@@ -50,7 +50,7 @@ public:
 			case WID_TT_BRIDGES:
 			case WID_TT_STRUCTURES:
 			case WID_TT_CATENARY:
-			case WID_TT_LOADING: {
+			case WID_TT_TEXT: {
 				uint i = widget - WID_TT_BEGIN;
 				if (HasBit(_transparency_lock, i)) DrawSprite(SPR_LOCK, PAL_NONE, r.left + WidgetDimensions::scaled.fullbevel.left, r.top + WidgetDimensions::scaled.fullbevel.top);
 				break;
@@ -58,7 +58,7 @@ public:
 			case WID_TT_BUTTONS: {
 				const Rect fr = r.Shrink(WidgetDimensions::scaled.framerect);
 				for (uint i = WID_TT_BEGIN; i < WID_TT_END; i++) {
-					if (i == WID_TT_LOADING) continue; // Do not draw button for invisible loading indicators.
+					if (i == WID_TT_TEXT) continue; // Loading and cost/income text has no invisibility button.
 
 					const Rect wr = this->GetWidget<NWidgetBase>(i)->GetCurrentRect().Shrink(WidgetDimensions::scaled.fullbevel);
 					DrawFrameRect(wr.left, fr.top, wr.right, fr.bottom, COLOUR_PALE_GREEN,
@@ -90,7 +90,7 @@ public:
 					break;
 				}
 			}
-			if (i == WID_TT_LOADING || i == WID_TT_END) return;
+			if (i == WID_TT_TEXT|| i == WID_TT_END) return;
 
 			ToggleInvisibility((TransparencyOption)(i - WID_TT_BEGIN));
 			if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
@@ -140,7 +140,7 @@ static const NWidgetPart _nested_transparency_widgets[] = {
 		NWidget(WWT_IMGBTN, COLOUR_DARK_GREEN, WID_TT_BRIDGES), SetMinimalSize(43, 22), SetFill(0, 1), SetDataTip(SPR_IMG_BRIDGE, STR_TRANSPARENT_BRIDGES_TOOLTIP),
 		NWidget(WWT_IMGBTN, COLOUR_DARK_GREEN, WID_TT_STRUCTURES), SetMinimalSize(22, 22), SetFill(0, 1), SetDataTip(SPR_IMG_TRANSMITTER, STR_TRANSPARENT_STRUCTURES_TOOLTIP),
 		NWidget(WWT_IMGBTN, COLOUR_DARK_GREEN, WID_TT_CATENARY), SetMinimalSize(22, 22), SetFill(0, 1), SetDataTip(SPR_BUILD_X_ELRAIL, STR_TRANSPARENT_CATENARY_TOOLTIP),
-		NWidget(WWT_IMGBTN, COLOUR_DARK_GREEN, WID_TT_LOADING), SetMinimalSize(22, 22), SetFill(0, 1), SetDataTip(SPR_IMG_TRAINLIST, STR_TRANSPARENT_LOADING_TOOLTIP),
+		NWidget(WWT_IMGBTN, COLOUR_DARK_GREEN, WID_TT_TEXT), SetMinimalSize(22, 22), SetFill(0, 1), SetDataTip(SPR_IMG_TRAINLIST, STR_TRANSPARENT_TEXT_TOOLTIP),
 		NWidget(WWT_PANEL, COLOUR_DARK_GREEN), SetFill(1, 1), EndContainer(),
 	EndContainer(),
 	/* Panel with 'invisibility' buttons. */

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -2316,7 +2316,7 @@ void NWidgetViewport::Draw(const Window *w)
 
 	if (this->disp_flags & ND_NO_TRANSPARENCY) {
 		TransparencyOptionBits to_backup = _transparency_opt;
-		_transparency_opt &= (1 << TO_SIGNS) | (1 << TO_LOADING); // Disable all transparency, except textual stuff
+		_transparency_opt &= (1 << TO_SIGNS) | (1 << TO_TEXT); // Disable all transparency, except textual stuff
 		w->DrawViewport();
 		_transparency_opt = to_backup;
 	} else {

--- a/src/widgets/transparency_widget.h
+++ b/src/widgets/transparency_widget.h
@@ -22,7 +22,7 @@ enum TransparencyToolbarWidgets {
 	WID_TT_BRIDGES,                  ///< Bridges transparency toggle button.
 	WID_TT_STRUCTURES,               ///< Object structure transparency toggle button.
 	WID_TT_CATENARY,                 ///< Catenary transparency toggle button.
-	WID_TT_LOADING,                  ///< Loading indicators transparency toggle button.
+	WID_TT_TEXT,                     ///< Loading and cost/income text transparency toggle button.
 	WID_TT_END,                      ///< End of toggle buttons.
 
 	/* Panel with buttons for invisibility */


### PR DESCRIPTION
## Motivation / Problem
The cost and income indicators (the rising red and green text) from vehicle income, construction costs, vehicle purchase, etc. are always visible.

This can become problematic. All other signs/text/labels can be hidden, either by transparency options (invisible signs, vehicle loading indicators) or the settings dropdown (notably town names). As far as I could tell, there was no way to hide the cost and income indicators - therefore added it as a transparency option.

This option is particularly for players who want clean interfaces or beauty screenshots. It is also useful for late game construction where (especially on fast forward) you can end up building in a cloud of green vehicle income text.

## Description

This feature adds a show/hide of cost and income indicators as a transparency option, as another transparency toggle button to the transparency control window. When transparent, no cost/income text. When not transparent, normal cost/income text. It toggles along with all other transparency with the normal `X` transparency hotkey. It can be locked, like the other transparency options, with `Ctrl+click`.

This implementation imitates handling of the loading/unloading indicators via a transparency button.

Now we can have beautiful screenshots and clean, text free, viewports!

## Limitations

I believe this is a fully functional minimal feature, however:

There is no dedicated hotkey. `Ctrl+<number>` is used for transparency toggling of individual features, but `1`-`9` are already in use. `Ctrl+0` could be used, but I thought was unintuitive.

`x` toggles transparency of all features including the cost and income indicators. This is a change in behaviour, which might be undesirable? eg. for a new player when building in transparent mode, no cost would be shown.

It is not addressed here, but a setting, similar to the loading/unloading indicators, could be added. Alternatively, cost and income indicator transparency could default to locked.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
