### PR TITLE
Fix: when a string consumes more parameters than allowed, nullptr is attempted to be formatted

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1074,7 +1074,9 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 
 			case SCC_RAW_STRING_POINTER: { // {RAW_STRING}
 				const char *raw_string = (const char *)(size_t)args->GetInt64(SCC_RAW_STRING_POINTER);
-				if (game_script && std::find(_game_script_raw_strings.begin(), _game_script_raw_strings.end(), raw_string) == _game_script_raw_strings.end()) {
+				/* raw_string can be(come) nullptr when the parameter is out of range and 0 is returned instead. */
+				if (raw_string == nullptr ||
+						(game_script && std::find(_game_script_raw_strings.begin(), _game_script_raw_strings.end(), raw_string) == _game_script_raw_strings.end())) {
 					builder += "(invalid RAW_STRING parameter)";
 					break;
 				}


### PR DESCRIPTION
## Motivation / Problem

When the enforcement of `{STRING}` to not take any parameters is enabled, `0` aka `nullptr` is returned for any `{RAW_STRING}` within that string.
Most common case is `STR_JUST_STRING` that includes e.g. `STR_AI_DEBUG_NAME_AND_VERSION`.


## Description

Go into the '(invalid RAW_STRING parameter)' branch of formatting when that happens, instead of SIG_SEGV.


## Limitations

Doesn't solve the issue that `STR_JUST_STRING` gets used in this way. However, in any case not crashing out is the better solution. Even when the underlying issues get solved. That also allows us to actually enable checking that `{STRING}` does not consume any parameters.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
