### PR TITLE
Codechange: use StringParameters for remapping the NewGRF string control codes

### DIFF
--- a/src/newgrf_text.h
+++ b/src/newgrf_text.h
@@ -49,7 +49,6 @@ void RewindTextRefStack();
 bool UsingNewGRFTextStack();
 struct TextRefStack *CreateTextRefStackBackup();
 void RestoreTextRefStackBackup(struct TextRefStack *backup);
-uint RemapNewGRFStringControlCode(uint scc, const char **str, int64 *argv, uint argv_size, bool modify_argv);
 
 /** Mapping of language data between a NewGRF and OpenTTD. */
 struct LanguageMap {

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -868,8 +868,8 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 
 		if (SCC_NEWGRF_FIRST <= b && b <= SCC_NEWGRF_LAST) {
 			/* We need to pass some stuff as it might be modified. */
-			//todo: should argve be passed here too?
-			b = RemapNewGRFStringControlCode(b, &str, (int64 *)args->GetDataPointer(), args->GetDataLeft(), dry_run);
+			StringParameters remaining = args->GetRemainingParameters();
+			b = RemapNewGRFStringControlCode(b, &str, remaining, dry_run);
 			if (b == 0) continue;
 		}
 

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -129,6 +129,20 @@ public:
 		return &this->data[this->offset];
 	}
 
+	/**
+	 * Get a new instance of StringParameters that is a "range" into the
+	 * parameters existing parameters. Upon destruction the offset in the parent
+	 * is not updated. However, calls to SetDParam do update the parameters.
+	 *
+	 * The returned StringParameters must not outlive this StringParameters.
+	 * @return A "range" of the string parameters.
+	 */
+	StringParameters GetRemainingParameters()
+	{
+		return StringParameters(&this->data[this->offset], GetDataLeft(),
+			this->type == nullptr ? nullptr : &this->type[this->offset]);
+	}
+
 	/** Return the amount of elements which can still be read. */
 	uint GetDataLeft() const
 	{

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -119,4 +119,6 @@ void GenerateTownNameString(StringBuilder &builder, size_t lang, uint32_t seed);
 void GetTownName(StringBuilder &builder, const struct Town *t);
 void GRFTownNameGenerate(StringBuilder &builder, uint32 grfid, uint16 gen, uint32 seed);
 
+uint RemapNewGRFStringControlCode(uint scc, const char **str, StringParameters &parameters, bool modify_parameters);
+
 #endif /* STRINGS_INTERNAL_H */


### PR DESCRIPTION
## Motivation / Problem

Passing a pointer and a size, instead of a reference to a structure that contains both.
And further down the line... to make it possible to change the underlying value type for the container.


## Description

Replace the `uint64 *argv, uint argv_size` with `StringParameters &parameters` in the NewGRF remap function, and map the `*argv =`/`argv[0] =`/`argv[1] = ` to the appropriate `SetParam` call.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
