### PR TITLE
Codechange: replace StringParameters' GetDataPointer

### DIFF
--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -673,8 +673,7 @@ struct TooltipsWindow : public Window
 		static_assert(sizeof(this->params[0]) == sizeof(params[0]));
 		assert(paramcount <= lengthof(this->params));
 		if (params == nullptr) {
-			_global_string_params.offset = 0;
-			params = _global_string_params.GetDataPointer();
+			params = _global_string_params.GetPointerToOffset(0);
 		}
 		if (paramcount > 0) memcpy(this->params, params, sizeof(this->params[0]) * paramcount);
 		this->paramcount = paramcount;

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1087,10 +1087,8 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 			case SCC_STRING: {// {STRING}
 				StringID string_id = args->GetInt32(SCC_STRING);
 				if (game_script && GetStringTab(string_id) != TEXT_TAB_GAMESCRIPT_START) break;
-				/* WARNING. It's prohibited for the included string to consume any arguments.
-				 * For included strings that consume argument, you should use STRING1, STRING2 etc.
-				 * To debug stuff you can set argv to nullptr and it will tell you */
-				StringParameters tmp_params(args->GetDataPointer(), args->GetDataLeft(), nullptr);
+				/* It's prohibited for the included string to consume any arguments. */
+				StringParameters tmp_params(*args, 0);
 				GetStringWithArgs(builder, string_id, &tmp_params, next_substr_case_index, game_script);
 				next_substr_case_index = 0;
 				break;

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -123,12 +123,6 @@ public:
 		return (int32)this->GetInt64(type);
 	}
 
-	/** Get a pointer to the current element in the data array. */
-	uint64 *GetDataPointer() const
-	{
-		return &this->data[this->offset];
-	}
-
 	/**
 	 * Get a new instance of StringParameters that is a "range" into the
 	 * parameters existing parameters. Upon destruction the offset in the parent


### PR DESCRIPTION
## Motivation / Problem

`StringParameters`' `GetDataPointer` gives direct access to an array of data. This makes it harder to replace the underlying container.


## Description

Replace manually setting the offset to 0 and then calling `GetDataPointer` to `GetPointerToOffset(0)`.

Replace a custom copy of all remaining parameters with just a `StringParameters` of size 0 for `{STRING}`. Those must not have any parameters, so just enforce that.

Remove the now unused `GetDataPointer`.


## Limitations

Without #11003 there are a few (common) places that will not show the right data, and debug-spam that an "invalid string parameter" is tried to be read.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
