### PR TITLE
Codechange: pass string parameters by reference

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2433,7 +2433,7 @@ void Industry::FillCachedName() const
 {
 	int64 args_array[] = { this->index };
 	StringParameters tmp_params(args_array);
-	this->cached_name = GetStringWithArgs(STR_INDUSTRY_NAME, &tmp_params);
+	this->cached_name = GetStringWithArgs(STR_INDUSTRY_NAME, tmp_params);
 }
 
 void ClearAllIndustryCachedNames()

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -463,7 +463,7 @@ void BaseStation::FillCachedName() const
 {
 	int64 args_array[] = { this->index };
 	StringParameters tmp_params(args_array);
-	this->cached_name = GetStringWithArgs(Waypoint::IsExpected(this) ? STR_WAYPOINT_NAME : STR_STATION_NAME, &tmp_params);
+	this->cached_name = GetStringWithArgs(Waypoint::IsExpected(this) ? STR_WAYPOINT_NAME : STR_STATION_NAME, tmp_params);
 }
 
 void ClearAllStationCachedNames()

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -179,7 +179,7 @@ public:
 extern StringParameters _global_string_params;
 
 std::string GetString(StringID string);
-std::string GetStringWithArgs(StringID string, StringParameters *args);
+std::string GetStringWithArgs(StringID string, StringParameters &args);
 const char *GetStringPtr(StringID string);
 
 uint ConvertKmhishSpeedToDisplaySpeed(uint speed, VehicleType type);

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -112,7 +112,7 @@ public:
 	}
 };
 
-void GetStringWithArgs(StringBuilder &builder, StringID string, StringParameters *args, uint case_index = 0, bool game_script = false);
+void GetStringWithArgs(StringBuilder &builder, StringID string, StringParameters &args, uint case_index = 0, bool game_script = false);
 
 /* Do not leak the StringBuilder to everywhere. */
 void GenerateTownNameString(StringBuilder &builder, size_t lang, uint32_t seed);

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -50,7 +50,7 @@ static void GetTownName(StringBuilder &builder, const TownNameParams *par, uint3
 	if (par->grfid == 0) {
 		int64 args_array[1] = { townnameparts };
 		StringParameters tmp_params(args_array);
-		GetStringWithArgs(builder, par->type, &tmp_params);
+		GetStringWithArgs(builder, par->type, tmp_params);
 		return;
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Passing `StringParameters` by pointer means sprinkling `*` and `&` around in the code where that's not needed when it's a reference.


## Description

Simply pass by reference.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
