### PR TITLE
Change: Add window description flag to disallow interactive window closing.

### DIFF
--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -42,7 +42,7 @@ static const struct NWidgetPart _background_widgets[] = {
 static WindowDesc _background_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_BOOTSTRAP, WC_NONE,
-	0,
+	WDF_NO_CLOSE,
 	_background_widgets, lengthof(_background_widgets)
 );
 
@@ -80,7 +80,7 @@ static const NWidgetPart _nested_bootstrap_errmsg_widgets[] = {
 static WindowDesc _bootstrap_errmsg_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_BOOTSTRAP, WC_NONE,
-	WDF_MODAL,
+	WDF_MODAL | WDF_NO_CLOSE,
 	_nested_bootstrap_errmsg_widgets, lengthof(_nested_bootstrap_errmsg_widgets)
 );
 
@@ -137,7 +137,7 @@ static const NWidgetPart _nested_bootstrap_download_status_window_widgets[] = {
 static WindowDesc _bootstrap_download_status_window_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_NETWORK_STATUS_WINDOW, WC_NONE,
-	WDF_MODAL,
+	WDF_MODAL | WDF_NO_CLOSE,
 	_nested_bootstrap_download_status_window_widgets, lengthof(_nested_bootstrap_download_status_window_widgets)
 );
 
@@ -191,7 +191,7 @@ static const NWidgetPart _bootstrap_query_widgets[] = {
 static WindowDesc _bootstrap_query_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_CONFIRM_POPUP_QUERY, WC_NONE,
-	0,
+	WDF_NO_CLOSE,
 	_bootstrap_query_widgets, lengthof(_bootstrap_query_widgets)
 );
 

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -494,7 +494,7 @@ static const NWidgetPart _nested_select_game_widgets[] = {
 static WindowDesc _select_game_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_SELECT_GAME, WC_NONE,
-	0,
+	WDF_NO_CLOSE,
 	_nested_select_game_widgets, lengthof(_nested_select_game_widgets)
 );
 

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -510,7 +510,7 @@ struct MainWindow : Window
 static WindowDesc _main_window_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_MAIN_WINDOW, WC_NONE,
-	0,
+	WDF_NO_CLOSE,
 	_nested_main_window_widgets, lengthof(_nested_main_window_widgets),
 	&MainWindow::hotkeys
 );

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -654,7 +654,7 @@ static const NWidgetPart _nested_tooltips_widgets[] = {
 static WindowDesc _tool_tips_desc(
 	WDP_MANUAL, nullptr, 0, 0, // Coordinates and sizes are not used,
 	WC_TOOLTIPS, WC_NONE,
-	WDF_NO_FOCUS,
+	WDF_NO_FOCUS | WDF_NO_CLOSE,
 	_nested_tooltips_widgets, lengthof(_nested_tooltips_widgets)
 );
 

--- a/src/statusbar_gui.cpp
+++ b/src/statusbar_gui.cpp
@@ -230,7 +230,7 @@ static const NWidgetPart _nested_main_status_widgets[] = {
 static WindowDesc _main_status_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_STATUS_BAR, WC_NONE,
-	WDF_NO_FOCUS,
+	WDF_NO_FOCUS | WDF_NO_CLOSE,
 	_nested_main_status_widgets, lengthof(_nested_main_status_widgets)
 );
 

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2251,7 +2251,7 @@ static const NWidgetPart _nested_toolbar_normal_widgets[] = {
 static WindowDesc _toolb_normal_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_MAIN_TOOLBAR, WC_NONE,
-	WDF_NO_FOCUS,
+	WDF_NO_FOCUS | WDF_NO_CLOSE,
 	_nested_toolbar_normal_widgets, lengthof(_nested_toolbar_normal_widgets),
 	&MainToolbarWindow::hotkeys
 );
@@ -2591,7 +2591,7 @@ static const NWidgetPart _nested_toolb_scen_widgets[] = {
 static WindowDesc _toolb_scen_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_MAIN_TOOLBAR, WC_NONE,
-	WDF_NO_FOCUS,
+	WDF_NO_FOCUS | WDF_NO_CLOSE,
 	_nested_toolb_scen_widgets, lengthof(_nested_toolb_scen_widgets),
 	&ScenarioEditorToolbarWindow::hotkeys
 );

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -820,7 +820,7 @@ static void DispatchRightClickEvent(Window *w, int x, int y)
 	}
 
 	/* Right-click close is enabled and there is a closebox */
-	if (_settings_client.gui.right_mouse_wnd_close && w->nested_root->GetWidgetOfType(WWT_CLOSEBOX)) {
+	if (_settings_client.gui.right_mouse_wnd_close && (w->window_desc->flags & WDF_NO_CLOSE) == 0) {
 		w->Close();
 	} else if (_settings_client.gui.hover_delay_ms == 0 && !w->OnTooltip(pt, wid->index, TCC_RIGHT_CLICK) && wid->tool_tip != 0) {
 		GuiShowTooltips(w, wid->tool_tip, 0, nullptr, TCC_RIGHT_CLICK);
@@ -3293,11 +3293,7 @@ void CloseNonVitalWindows()
 {
 	/* Note: the container remains stable, even when deleting windows. */
 	for (Window *w : Window::Iterate()) {
-		if (w->window_class != WC_MAIN_WINDOW &&
-				w->window_class != WC_SELECT_GAME &&
-				w->window_class != WC_MAIN_TOOLBAR &&
-				w->window_class != WC_STATUS_BAR &&
-				w->window_class != WC_TOOLTIPS &&
+		if ((w->window_desc->flags & WDF_NO_CLOSE) == 0 &&
 				(w->flags & WF_STICKY) == 0) { // do not delete windows which are 'pinned'
 
 			w->Close();
@@ -3314,12 +3310,9 @@ void CloseNonVitalWindows()
  */
 void CloseAllNonVitalWindows()
 {
-	/* Close every window except for stickied ones, then sticky ones as well */
-	CloseNonVitalWindows();
-
 	/* Note: the container remains stable, even when closing windows. */
 	for (Window *w : Window::Iterate()) {
-		if (w->flags & WF_STICKY) {
+		if ((w->window_desc->flags & WDF_NO_CLOSE) == 0) {
 			w->Close();
 		}
 	}

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -138,6 +138,7 @@ enum WindowDefaultFlag {
 	WDF_CONSTRUCTION    =   1 << 0, ///< This window is used for construction; close it whenever changing company.
 	WDF_MODAL           =   1 << 1, ///< The window is a modal child of some other window, meaning the parent is 'inactive'
 	WDF_NO_FOCUS        =   1 << 2, ///< This window won't get focus/make any other window lose focus when click
+	WDF_NO_CLOSE        =   1 << 3, ///< This window can't be interactively closed
 };
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Some windows cannot be closed using the right-click-to-close functionality, because that functionality requires a window to have a closebox. This affects dropdown menus and the highscore table.

Of course, some windows without a closebox really shouldn't be closable in this way.

## Description

This is resolved by adding an explicit window description flag to disallow interactive (right-click-close or hotkey close) window closing.

This replaces/simplifies testing for a closebox to allow closing a window with right-click, and testing for specific window classes when closing all windows by hotkey.

This allows right-click closing of dropdowns and the high-score window.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
