### PR TITLE
Change: [Actions] Use notarytool for notarization instead of gon

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -162,19 +162,19 @@ jobs:
         rm -f bundles/*.sha256
         echo "::endgroup::"
 
-    - name: Install gon
-      env:
-        HOMEBREW_NO_AUTO_UPDATE: 1
-        HOMEBREW_NO_INSTALL_CLEANUP: 1
-      run: |
-        brew tap mitchellh/gon
-        brew install mitchellh/gon/gon
-
     - name: Notarize
       env:
         AC_USERNAME: ${{ secrets.APPLE_DEVELOPER_APP_USERNAME }}
         AC_PASSWORD: ${{ secrets.APPLE_DEVELOPER_APP_PASSWORD }}
+        AC_TEAM_ID: ${{ secrets.APPLE_DEVELOPER_TEAM_ID }}
       run: |
+        if [ -z "${AC_USERNAME}" ]; then
+            # We may be running on a fork that doesn't have notarization secrets set up; skip this step
+            echo No notarization secrets set up, skipping.
+            exit 0
+        fi
+
+        xcrun notarytool store-credentials --apple-id "${AC_USERNAME}" --password "${AC_PASSWORD}" --team-id "${AC_TEAM_ID}" openttd
         cd build-x64
         ../os/macosx/notarize.sh
 


### PR DESCRIPTION
## Motivation / Problem

We are currently using `gon` to handle notarization of OpenTTD. Apple has sent us an e-mail instructing us that `altool` (which `gon` currently uses) will no longer be supported from November 2023.

Fortunately, Apple released a new notarization tool a while ago which is quite straightforward to use, so use that instead.

## Description

Removes dependency on `gon`, uses the built in `notarytool` provided by Xcode. I've tested this on my own fork with our real Apple details and notarization appears to have been successful.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
