### PR TITLE
Fix ca1e34c: [Script] Wrong value printed for {RAW_STRING}

### DIFF
--- a/src/script/api/script_text.cpp
+++ b/src/script/api/script_text.cpp
@@ -209,7 +209,7 @@ void ScriptText::_GetEncodedText(std::back_insert_iterator<std::string> &output,
 			switch (cur_param.type) {
 				case StringParam::RAW_STRING:
 					if (!std::holds_alternative<std::string>(this->param[cur_idx])) throw Script_FatalError(fmt::format("{}: Parameter {} expects a raw string", name, param_count));
-					fmt::format_to(output, ":\"%s\"", std::get<std::string>(this->param[cur_idx++]));
+					fmt::format_to(output, ":\"{}\"", std::get<std::string>(this->param[cur_idx++]));
 					break;
 
 				case StringParam::STRING: {


### PR DESCRIPTION
## Motivation / Problem
I missed a missing `%s` -> `{}` conversion when reviewing #10956
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Apply the conversion.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
