### PR TITLE
Change: Allow aqueduct to use foundation

### DIFF
--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -408,7 +408,7 @@ CommandCost CmdBuildBridge(DoCommandFlag flags, TileIndex tile_end, TileIndex ti
 	} else {
 		/* Build a new bridge. */
 
-		bool allow_on_slopes = (_settings_game.construction.build_on_slopes && transport_type != TRANSPORT_WATER);
+		bool allow_on_slopes = (_settings_game.construction.build_on_slopes );
 
 		/* Try and clear the start landscape */
 		CommandCost ret = Command<CMD_LANDSCAPE_CLEAR>::Do(flags, tile_start);


### PR DESCRIPTION
## Motivation / Problem

fix #10995 

## Description

Removes aqueduct restriction, allowing automatic slope correction while constructing aqueducts.

## Limitations

I don't know the side effects, because I don't know why they disabled this functionality for aqueducts.


