### PR TITLE
Codechange: remove a number of unneeded c_str() calls

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1173,7 +1173,7 @@ static void PrintLineByLine(const std::string &full_string)
 	std::istringstream in(full_string);
 	std::string line;
 	while (std::getline(in, line)) {
-		IConsolePrint(CC_DEFAULT, line.c_str());
+		IConsolePrint(CC_DEFAULT, line);
 	}
 }
 

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -96,7 +96,7 @@ void DriverFactoryBase::SelectDriver(const std::string &name, Driver::Type type)
 	if (!DriverFactoryBase::SelectDriverImpl(name, type)) {
 		name.empty() ?
 			UserError("Failed to autoprobe {} driver", GetDriverTypeName(type)) :
-			UserError("Failed to select requested {} driver '{}'", GetDriverTypeName(type), name.c_str());
+			UserError("Failed to select requested {} driver '{}'", GetDriverTypeName(type), name);
 	}
 }
 

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -673,7 +673,7 @@ public:
 					}
 					if (this->fop == SLO_SAVE) {
 						/* Copy clicked name to editbox */
-						this->filename_editbox.text.Assign(file->title.c_str());
+						this->filename_editbox.text.Assign(file->title);
 						this->SetWidgetDirty(WID_SL_SAVE_OSK_TITLE);
 					}
 				} else if (!_load_check_data.HasErrors()) {

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -455,7 +455,7 @@ public:
 					/* Measure the accepted cargoes, if any. */
 					GetAllCargoSuffixes(CARGOSUFFIX_IN, CST_FUND, nullptr, indtype, indsp, indsp->accepts_cargo, cargo_suffix);
 					std::string cargostring = this->MakeCargoListString(indsp->accepts_cargo, cargo_suffix, lengthof(indsp->accepts_cargo), STR_INDUSTRY_VIEW_REQUIRES_N_CARGO);
-					Dimension strdim = GetStringBoundingBox(cargostring.c_str());
+					Dimension strdim = GetStringBoundingBox(cargostring);
 					if (strdim.width > max_minwidth) {
 						extra_lines_req = std::max(extra_lines_req, strdim.width / max_minwidth + 1);
 						strdim.width = max_minwidth;
@@ -465,7 +465,7 @@ public:
 					/* Measure the produced cargoes, if any. */
 					GetAllCargoSuffixes(CARGOSUFFIX_OUT, CST_FUND, nullptr, indtype, indsp, indsp->produced_cargo, cargo_suffix);
 					cargostring = this->MakeCargoListString(indsp->produced_cargo, cargo_suffix, lengthof(indsp->produced_cargo), STR_INDUSTRY_VIEW_PRODUCES_N_CARGO);
-					strdim = GetStringBoundingBox(cargostring.c_str());
+					strdim = GetStringBoundingBox(cargostring);
 					if (strdim.width > max_minwidth) {
 						extra_lines_prd = std::max(extra_lines_prd, strdim.width / max_minwidth + 1);
 						strdim.width = max_minwidth;

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -480,7 +480,7 @@ public:
 		this->FinishInitNested(WN_NETWORK_WINDOW_GAME);
 
 		this->querystrings[WID_NG_CLIENT] = &this->name_editbox;
-		this->name_editbox.text.Assign(_settings_client.network.client_name.c_str());
+		this->name_editbox.text.Assign(_settings_client.network.client_name);
 
 		this->querystrings[WID_NG_FILTER] = &this->filter_editbox;
 		this->filter_editbox.cancel_button = QueryString::ACTION_CLEAR;
@@ -1036,7 +1036,7 @@ struct NetworkStartServerWindow : public Window {
 		this->InitNested(WN_NETWORK_WINDOW_START);
 
 		this->querystrings[WID_NSS_GAMENAME] = &this->name_editbox;
-		this->name_editbox.text.Assign(_settings_client.network.server_name.c_str());
+		this->name_editbox.text.Assign(_settings_client.network.server_name);
 
 		this->SetFocusedWidget(WID_NSS_GAMENAME);
 	}

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1874,7 +1874,7 @@ void NetworkServerShowStatusToConsole()
 
 		status = (cs->status < (ptrdiff_t)lengthof(stat_str) ? stat_str[cs->status] : "unknown");
 		IConsolePrint(CC_INFO, "Client #{}  name: '{}'  status: '{}'  frame-lag: {}  company: {}  IP: {}",
-			cs->client_id, ci->client_name.c_str(), status, lag,
+			cs->client_id, ci->client_name, status, lag,
 			ci->client_playas + (Company::IsValidID(ci->client_playas) ? 1 : 0),
 			cs->GetClientIP());
 	}

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -7727,7 +7727,7 @@ static void FeatureTownName(ByteReader *buf)
 			const char *name = buf->ReadString();
 
 			std::string lang_name = TranslateTTDPatchCodes(grfid, lang, false, name);
-			GrfMsg(6, "FeatureTownName: lang 0x{:X} -> '{}'", lang, lang_name.c_str());
+			GrfMsg(6, "FeatureTownName: lang 0x{:X} -> '{}'", lang, lang_name);
 
 			style = AddGRFString(grfid, id, lang, new_scheme, false, name, STR_UNDEFINED);
 
@@ -7766,7 +7766,7 @@ static void FeatureTownName(ByteReader *buf)
 			} else {
 				const char *text = buf->ReadString();
 				part.text = TranslateTTDPatchCodes(grfid, 0, false, text);
-				GrfMsg(6, "FeatureTownName: part {}, text {}, '{}' (with probability {})", partnum, textnum, part.text.c_str(), part.prob);
+				GrfMsg(6, "FeatureTownName: part {}, text {}, '{}' (with probability {})", partnum, textnum, part.text, part.prob);
 			}
 			partlist.maxprob += GB(part.prob, 0, 7);
 		}

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1459,7 +1459,7 @@ private:
 	{
 		filter.ResetState();
 		filter.AddLine((*a)->GetName());
-		filter.AddLine((*a)->filename.c_str());
+		filter.AddLine((*a)->filename);
 		filter.AddLine((*a)->GetDescription());
 		return filter.GetState();;
 	}
@@ -2101,7 +2101,7 @@ struct SavePresetWindow : public Window {
 				resize->height = FONT_HEIGHT_NORMAL;
 				size->height = 0;
 				for (uint i = 0; i < this->presets.size(); i++) {
-					Dimension d = GetStringBoundingBox(this->presets[i].c_str());
+					Dimension d = GetStringBoundingBox(this->presets[i]);
 					size->width = std::max(size->width, d.width + padding.width);
 					resize->height = std::max(resize->height, d.height);
 				}
@@ -2127,8 +2127,7 @@ struct SavePresetWindow : public Window {
 				for (uint i = min_index; i < max_index; i++) {
 					if ((int)i == this->selected) GfxFillRect(br.left, tr.top, br.right, tr.top + step_height - 1, PC_DARK_BLUE);
 
-					const char *text = this->presets[i].c_str();
-					DrawString(tr.left, tr.right, tr.top + offset_y, text, ((int)i == this->selected) ? TC_WHITE : TC_SILVER);
+					DrawString(tr.left, tr.right, tr.top + offset_y, this->presets[i], ((int)i == this->selected) ? TC_WHITE : TC_SILVER);
 					tr.top += step_height;
 				}
 				break;
@@ -2143,7 +2142,7 @@ struct SavePresetWindow : public Window {
 				auto it = this->vscroll->GetScrolledItemFromWidget(this->presets, pt.y, this, WID_SVP_PRESET_LIST);
 				if (it != this->presets.end()) {
 					this->selected = it - this->presets.begin();
-					this->presetname_editbox.text.Assign(it->c_str());
+					this->presetname_editbox.text.Assign(*it);
 					this->SetWidgetDirty(WID_SVP_PRESET_LIST);
 					this->SetWidgetDirty(WID_SVP_EDITBOX);
 				}

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -583,7 +583,7 @@ StringID AddGRFString(uint32 grfid, uint16 stringid, byte langid_to_add, bool ne
 	}
 	AddGRFTextToList(_grf_text[id].textholder, langid_to_add, newtext);
 
-	GrfMsg(3, "Added 0x{:X} grfid {:08X} string 0x{:X} lang 0x{:X} string '{}' ({:X})", id, grfid, stringid, langid_to_add, newtext.c_str(), MakeStringID(TEXT_TAB_NEWGRF_START, id));
+	GrfMsg(3, "Added 0x{:X} grfid {:08X} string 0x{:X} lang 0x{:X} string '{}' ({:X})", id, grfid, stringid, langid_to_add, newtext, MakeStringID(TEXT_TAB_NEWGRF_START, id));
 
 	return MakeStringID(TEXT_TAB_NEWGRF_START, id);
 }

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -723,7 +723,7 @@ int openttd_main(int argc, char *argv[])
 		if (BlitterFactory::SelectBlitter(blitter) == nullptr) {
 			blitter.empty() ?
 				UserError("Failed to autoprobe blitter") :
-				UserError("Failed to select requested blitter '{}'; does it exist?", blitter.c_str());
+				UserError("Failed to select requested blitter '{}'; does it exist?", blitter);
 		}
 	}
 

--- a/src/script/api/script_text.cpp
+++ b/src/script/api/script_text.cpp
@@ -193,7 +193,7 @@ void ScriptText::_GetEncodedText(std::back_insert_iterator<std::string> &output,
 			/* The previous substring added more parameters than expected, means we will consume them but can't properly validate them. */
 			for (int i = 0; i < cur_param.consumes; i++) {
 				if (prev_idx < prev_count) {
-					ScriptLog::Warning(fmt::format("{}: Parameter {} uses parameter {} from substring {} and cannot be validated", name, param_count + i, prev_idx++, prev_string).c_str());
+					ScriptLog::Warning(fmt::format("{}: Parameter {} uses parameter {} from substring {} and cannot be validated", name, param_count + i, prev_idx++, prev_string));
 				} else {
 					/* No more extra parameters, assume SQInteger are expected. */
 					if (cur_idx >= this->paramc) throw Script_FatalError(fmt::format("{}: Not enough parameters", name));
@@ -218,7 +218,7 @@ void ScriptText::_GetEncodedText(std::back_insert_iterator<std::string> &output,
 					fmt::format_to(output, ":");
 					std::get<ScriptTextRef>(this->param[cur_idx++])->_GetEncodedText(output, count, seen_ids);
 					if (++count != cur_param.consumes) {
-						ScriptLog::Error(fmt::format("{}: Parameter {} substring consumes {}, but expected {} to be consumed", name, param_count, count - 1, cur_param.consumes - 1).c_str());
+						ScriptLog::Error(fmt::format("{}: Parameter {} substring consumes {}, but expected {} to be consumed", name, param_count, count - 1, cur_param.consumes - 1));
 						/* Fill missing params if needed. */
 						for (int i = count; i < cur_param.consumes; i++) fmt::format_to(output, ":0");
 						/* Disable validation for the extra params if any. */

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -99,7 +99,7 @@ struct SignList {
 		const std::string &a_name = (*a)->name.empty() ? SignList::default_name : (*a)->name;
 
 		filter.ResetState();
-		filter.AddLine(a_name.c_str());
+		filter.AddLine(a_name);
 		return filter.GetState();
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Calling `.c_str()` for functions that accept `std::string` directly.


## Description

Remove the `.c_str()`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
