### PR TITLE
Codechange: make SQString::Create that supports std::string and use that

### DIFF
--- a/src/3rdparty/squirrel/include/squirrel.h
+++ b/src/3rdparty/squirrel/include/squirrel.h
@@ -238,7 +238,7 @@ void sq_newclosure(HSQUIRRELVM v,SQFUNCTION func,SQUnsignedInteger nfreevars);
 SQRESULT sq_setparamscheck(HSQUIRRELVM v,SQInteger nparamscheck,const SQChar *typemask);
 SQRESULT sq_bindenv(HSQUIRRELVM v,SQInteger idx);
 void sq_pushstring(HSQUIRRELVM v,const SQChar *s,SQInteger len);
-static inline void sq_pushstring(HSQUIRRELVM v, const std::string &str, SQInteger len = -1) { sq_pushstring(v, str.c_str(), len == -1 ? str.size() : len); }
+static inline void sq_pushstring(HSQUIRRELVM v, const std::string &str, SQInteger len = -1) { sq_pushstring(v, str.data(), len == -1 ? str.size() : len); }
 void sq_pushfloat(HSQUIRRELVM v,SQFloat f);
 void sq_pushinteger(HSQUIRRELVM v,SQInteger n);
 void sq_pushbool(HSQUIRRELVM v,SQBool b);

--- a/src/3rdparty/squirrel/squirrel/sqcompiler.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqcompiler.cpp
@@ -187,7 +187,7 @@ public:
 				_ss(_vm)->_compilererrorhandler(_vm, compilererror.c_str(), type(_sourcename) == OT_STRING ? _stringval(_sourcename) : "unknown",
 					_lex._currentline, _lex._currentcolumn);
 			}
-			_vm->_lasterror = SQString::Create(_ss(_vm), compilererror.c_str(), -1);
+			_vm->_lasterror = SQString::Create(_ss(_vm), compilererror);
 			return false;
 		}
 	}

--- a/src/3rdparty/squirrel/squirrel/sqdebug.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqdebug.cpp
@@ -66,7 +66,7 @@ SQRESULT sq_stackinfos(HSQUIRRELVM v, SQInteger level, SQStackInfos *si)
 
 void SQVM::Raise_Error(const std::string &msg)
 {
-	_lasterror = SQString::Create(_ss(this),msg.c_str(),-1);
+	_lasterror = SQString::Create(_ss(this),msg);
 }
 
 void SQVM::Raise_Error(SQObjectPtr &desc)
@@ -79,9 +79,9 @@ SQString *SQVM::PrintObjVal(const SQObject &o)
 	switch(type(o)) {
 	case OT_STRING: return _string(o);
 	case OT_INTEGER:
-		return SQString::Create(_ss(this), fmt::format("{}", _integer(o)).c_str());
+		return SQString::Create(_ss(this), fmt::format("{}", _integer(o)));
 	case OT_FLOAT:
-		return SQString::Create(_ss(this), fmt::format("{:.14g}", _float(o)).c_str());
+		return SQString::Create(_ss(this), fmt::format("{:.14g}", _float(o)));
 	default:
 		return SQString::Create(_ss(this), GetTypeName(o));
 	}

--- a/src/3rdparty/squirrel/squirrel/sqstring.h
+++ b/src/3rdparty/squirrel/squirrel/sqstring.h
@@ -17,6 +17,7 @@ struct SQString : public SQRefCounted
 	~SQString(){}
 public:
 	static SQString *Create(SQSharedState *ss, const SQChar *, SQInteger len = -1 );
+	static SQString *Create(SQSharedState *ss, const std::string &str) { return Create(ss, str.data(), str.size()); }
 	SQInteger Next(const SQObjectPtr &refpos, SQObjectPtr &outkey, SQObjectPtr &outval);
 	void Release();
 	SQSharedState *_sharedstate;

--- a/src/3rdparty/squirrel/squirrel/sqvm.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqvm.cpp
@@ -291,7 +291,7 @@ void SQVM::ToString(const SQObjectPtr &o,SQObjectPtr &res)
 	default:
 		str = fmt::format("({} : 0x{:08X})",GetTypeName(o),(size_t)(void*)_rawval(o));
 	}
-	res = SQString::Create(_ss(this),str.c_str());
+	res = SQString::Create(_ss(this),str);
 }
 
 


### PR DESCRIPTION
## Motivation / Problem

Number of places doing `.c_str()` to then (implicitly) run `strlen` to determine the length within the Squirrel API.


## Description

Add `std::string` supporting function to create `SQString` that passes the string size to the function that actually creates the object.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
