### PR TITLE
Fix: Crash when failing to load a game into a dedicated server at startup

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1511,6 +1511,7 @@ void GameLoop()
 	if (_switch_mode != SM_NONE && !HasModalProgress()) {
 		SwitchToMode(_switch_mode);
 		_switch_mode = SM_NONE;
+		if (_exit_game) return;
 	}
 
 	IncreaseSpriteLRU();


### PR DESCRIPTION
## Motivation / Problem

Fix the crash which occurs when failing to load a game into a dedicated server at startup.

e.g. when running `./openttd -D -g doesntexist.sav`

## Description

Handle the case where SwitchToMode sets _exit_game.
Don't try to soldier on into NetworkGameLoop/StateGameLoop when there is no game state to loop on. 

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
