### PR TITLE
Change: Add separate setting for server sent commands per frame limit

### DIFF
--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -392,6 +392,10 @@ static void DistributeQueue(CommandQueue *queue, const NetworkClientSocket *owne
 	int to_go = UINT16_MAX;
 #else
 	int to_go = _settings_client.network.commands_per_frame;
+	if (owner == nullptr) {
+		/* This is the server, use the commands_per_frame_server setting if higher */
+		to_go = std::max<int>(to_go, _settings_client.network.commands_per_frame_server);
+	}
 #endif
 
 	CommandPacket *cp;

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -279,6 +279,7 @@ struct NetworkSettings {
 	uint16      sync_freq;                                ///< how often do we check whether we are still in-sync
 	uint8       frame_freq;                               ///< how often do we send commands to the clients
 	uint16      commands_per_frame;                       ///< how many commands may be sent each frame_freq frames?
+	uint16      commands_per_frame_server;                ///< how many commands may be sent each frame_freq frames? (server-originating commands)
 	uint16      max_commands_in_queue;                    ///< how many commands may there be in the incoming queue before dropping the connection?
 	uint16      bytes_per_frame;                          ///< how many bytes may, over a long period, be received per frame?
 	uint16      bytes_per_frame_burst;                    ///< how many bytes may, over a short period, be received?

--- a/src/table/settings/network_settings.ini
+++ b/src/table/settings/network_settings.ini
@@ -67,6 +67,15 @@ max      = 65535
 cat      = SC_EXPERT
 
 [SDTC_VAR]
+var      = network.commands_per_frame_server
+type     = SLE_UINT16
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
+def      = 16
+min      = 1
+max      = 65535
+cat      = SC_EXPERT
+
+[SDTC_VAR]
 var      = network.max_commands_in_queue
 type     = SLE_UINT16
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY


### PR DESCRIPTION
## Motivation / Problem

This is the follow-on to #10913.

Currently the server and all clients are limited to 2 commands per frame by default.
However a server may be running a GS, multiple AIs, and/or have an attached user.
The GS may use GSAsyncMode from #10913.
2 commands per frame is therefore unnecessarily limiting for the server, which is in a privileged position anyway.

Server operators can't be expected to know what to do with any of these types of settings, so the defaults should be reasonable and they shouldn't need to try to change the existing commands_per_frame setting.

It is not necessary to change the commands per frame limit for clients.

## Description

Add separate setting for server sent commands per frame limit

Set a higher default value for this setting.
Use the higher of this and existing commands per frame limit setting for server-originating commands.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
