### PR TITLE
Fix #10993: Crash log when font caches not initialised

### DIFF
--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -183,10 +183,10 @@ void CrashLog::LogConfiguration(std::back_insert_iterator<std::string> &output_i
 			" Medium: {}\n"
 			" Large:  {}\n"
 			" Mono:   {}\n\n",
-			FontCache::Get(FS_SMALL)->GetFontName(),
-			FontCache::Get(FS_NORMAL)->GetFontName(),
-			FontCache::Get(FS_LARGE)->GetFontName(),
-			FontCache::Get(FS_MONO)->GetFontName()
+			FontCache::GetName(FS_SMALL),
+			FontCache::GetName(FS_NORMAL),
+			FontCache::GetName(FS_LARGE),
+			FontCache::GetName(FS_MONO)
 	);
 
 	fmt::format_to(output_iterator, "AI Configuration (local: {}) (current: {}):\n", _local_company, _current_company);

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -53,6 +53,21 @@ int FontCache::GetDefaultFontHeight(FontSize fs)
 	return _default_font_height[fs];
 }
 
+/**
+ * Get the font name of a given font size.
+ * @param fs The font size to look up.
+ * @return The font name.
+ */
+std::string FontCache::GetName(FontSize fs)
+{
+	FontCache *fc = FontCache::Get(fs);
+	if (fc != nullptr) {
+		return fc->GetFontName();
+	} else {
+		return "[NULL]";
+	}
+}
+
 
 /**
  * Get height of a character for a given font size.

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -147,6 +147,8 @@ public:
 		return FontCache::caches[fs];
 	}
 
+	static std::string GetName(FontSize fs);
+
 	/**
 	 * Check whether the font cache has a parent.
 	 */


### PR DESCRIPTION
## Motivation / Problem

#10993, the crash logger no longer works before font caches are initialised due to #10836.

## Description

Fix above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
