### PR TITLE
Codechange: use SetDParam for tooltips

### DIFF
--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -717,11 +717,10 @@ public:
 		if (widget != WID_RV_TRAIN_WAGONREMOVE_TOGGLE) return false;
 
 		if (Group::IsValidID(this->sel_group)) {
-			uint64 params[1];
-			params[0] = STR_REPLACE_REMOVE_WAGON_HELP;
-			GuiShowTooltips(this, STR_REPLACE_REMOVE_WAGON_GROUP_HELP, 1, params, close_cond);
+			SetDParam(0, STR_REPLACE_REMOVE_WAGON_HELP);
+			GuiShowTooltips(this, STR_REPLACE_REMOVE_WAGON_GROUP_HELP, close_cond, 1);
 		} else {
-			GuiShowTooltips(this, STR_REPLACE_REMOVE_WAGON_HELP, 0, nullptr, close_cond);
+			GuiShowTooltips(this, STR_REPLACE_REMOVE_WAGON_HELP, close_cond);
 		}
 		return true;
 	}

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -889,10 +889,9 @@ struct DepotWindow : Window {
 		}
 
 		/* Show tooltip window */
-		uint64 args[2];
-		args[0] = (whole_chain ? num : v->engine_type);
-		args[1] = (uint64)(size_t)details.c_str();
-		GuiShowTooltips(this, whole_chain ? STR_DEPOT_VEHICLE_TOOLTIP_CHAIN : STR_DEPOT_VEHICLE_TOOLTIP, 2, args, TCC_RIGHT_CLICK);
+		SetDParam(0, whole_chain ? num : v->engine_type);
+		SetDParamStr(1, details);
+		GuiShowTooltips(this, whole_chain ? STR_DEPOT_VEHICLE_TOOLTIP_CHAIN : STR_DEPOT_VEHICLE_TOOLTIP, TCC_RIGHT_CLICK, 2);
 
 		return true;
 	}

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -3129,7 +3129,7 @@ struct IndustryCargoesWindow : public Window {
 
 			case CFT_INDUSTRY:
 				if (fld->u.industry.ind_type < NUM_INDUSTRYTYPES && (this->ind_cargo >= NUM_INDUSTRYTYPES || fieldxy.x != 2)) {
-					GuiShowTooltips(this, STR_INDUSTRY_CARGOES_INDUSTRY_TOOLTIP, 0, nullptr, close_cond);
+					GuiShowTooltips(this, STR_INDUSTRY_CARGOES_INDUSTRY_TOOLTIP, close_cond);
 				}
 				return true;
 
@@ -3138,9 +3138,8 @@ struct IndustryCargoesWindow : public Window {
 		}
 		if (IsValidCargoID(cid) && (this->ind_cargo < NUM_INDUSTRYTYPES || cid != this->ind_cargo - NUM_INDUSTRYTYPES)) {
 			const CargoSpec *csp = CargoSpec::Get(cid);
-			uint64 params[5];
-			params[0] = csp->name;
-			GuiShowTooltips(this, STR_INDUSTRY_CARGOES_CARGO_TOOLTIP, 1, params, close_cond);
+			SetDParam(0, csp->name);
+			GuiShowTooltips(this, STR_INDUSTRY_CARGOES_CARGO_TOOLTIP, close_cond, 1);
 			return true;
 		}
 

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -404,12 +404,12 @@ bool LinkGraphOverlay::ShowTooltip(Point pt, TooltipCloseCondition close_cond)
 				SetDParam(3, j->first);
 				SetDParam(4, link.Usage() * 100 / (link.capacity + 1));
 				SetDParamStr(5, tooltip_extension);
-				GuiShowTooltips(this->window, STR_LINKGRAPH_STATS_TOOLTIP, 7, nullptr, close_cond);
+				GuiShowTooltips(this->window, STR_LINKGRAPH_STATS_TOOLTIP, close_cond, 7);
 				return true;
 			}
 		}
 	}
-	GuiShowTooltips(this->window, STR_NULL, 0, nullptr, close_cond);
+	GuiShowTooltips(this->window, STR_NULL, close_cond);
 	return false;
 }
 
@@ -642,19 +642,17 @@ bool LinkGraphLegendWindow::OnTooltip(Point pt, int widget, TooltipCloseConditio
 {
 	if (IsInsideMM(widget, WID_LGL_COMPANY_FIRST, WID_LGL_COMPANY_LAST + 1)) {
 		if (this->IsWidgetDisabled(widget)) {
-			GuiShowTooltips(this, STR_LINKGRAPH_LEGEND_SELECT_COMPANIES, 0, nullptr, close_cond);
+			GuiShowTooltips(this, STR_LINKGRAPH_LEGEND_SELECT_COMPANIES, close_cond);
 		} else {
-			uint64 params[2];
-			CompanyID cid = (CompanyID)(widget - WID_LGL_COMPANY_FIRST);
-			params[0] = STR_LINKGRAPH_LEGEND_SELECT_COMPANIES;
-			params[1] = cid;
-			GuiShowTooltips(this, STR_LINKGRAPH_LEGEND_COMPANY_TOOLTIP, 2, params, close_cond);
+			SetDParam(0, STR_LINKGRAPH_LEGEND_SELECT_COMPANIES);
+			SetDParam(1, (CompanyID)(widget - WID_LGL_COMPANY_FIRST));
+			GuiShowTooltips(this, STR_LINKGRAPH_LEGEND_COMPANY_TOOLTIP, close_cond, 2);
 		}
 		return true;
 	}
 	if (IsInsideMM(widget, WID_LGL_CARGO_FIRST, WID_LGL_CARGO_LAST + 1)) {
 		const CargoSpec *cargo = _sorted_cargo_specs[widget - WID_LGL_CARGO_FIRST];
-		GuiShowTooltips(this, cargo->name, 0, nullptr, close_cond);
+		GuiShowTooltips(this, cargo->name, close_cond);
 		return true;
 	}
 	return false;

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -666,17 +666,13 @@ struct TooltipsWindow : public Window
 	uint64 params[8];                 ///< The string parameters.
 	TooltipCloseCondition close_cond; ///< Condition for closing the window.
 
-	TooltipsWindow(Window *parent, StringID str, uint paramcount, const uint64 params[], TooltipCloseCondition close_tooltip) : Window(&_tool_tips_desc)
+	TooltipsWindow(Window *parent, StringID str, uint paramcount, TooltipCloseCondition close_tooltip) : Window(&_tool_tips_desc)
 	{
 		this->parent = parent;
 		this->string_id = str;
-		static_assert(sizeof(this->params[0]) == sizeof(params[0]));
 		assert(paramcount <= lengthof(this->params));
-		if (params == nullptr) {
-			params = _global_string_params.GetPointerToOffset(0);
-		}
-		if (paramcount > 0) memcpy(this->params, params, sizeof(this->params[0]) * paramcount);
 		this->paramcount = paramcount;
+		if (paramcount > 0) CopyOutDParam(this->params, this->paramcount);
 		this->close_cond = close_tooltip;
 
 		this->InitNested();
@@ -757,17 +753,16 @@ struct TooltipsWindow : public Window
  * Shows a tooltip
  * @param parent The window this tooltip is related to.
  * @param str String to be displayed
+ * @param close_tooltip the condition under which the tooltip closes
  * @param paramcount number of params to deal with
- * @param params (optional) up to 5 pieces of additional information that may be added to a tooltip
- * @param close_tooltip when the left (true) or right (false) mouse button is released
  */
-void GuiShowTooltips(Window *parent, StringID str, uint paramcount, const uint64 params[], TooltipCloseCondition close_tooltip)
+void GuiShowTooltips(Window *parent, StringID str, TooltipCloseCondition close_tooltip, uint paramcount)
 {
 	CloseWindowById(WC_TOOLTIPS, 0);
 
 	if (str == STR_NULL || !_cursor.in_window) return;
 
-	new TooltipsWindow(parent, str, paramcount, params, close_tooltip);
+	new TooltipsWindow(parent, str, paramcount, close_tooltip);
 }
 
 void QueryString::HandleEditBox(Window *w, int wid)

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1849,10 +1849,10 @@ public:
 
 				if (IsInsideMM(pt.x, player_icon_x, player_icon_x + d2.width)) {
 					if (index == this->player_self_index) {
-						GuiShowTooltips(this, STR_NETWORK_CLIENT_LIST_PLAYER_ICON_SELF_TOOLTIP, 0, nullptr, close_cond);
+						GuiShowTooltips(this, STR_NETWORK_CLIENT_LIST_PLAYER_ICON_SELF_TOOLTIP, close_cond);
 						return true;
 					} else if (index == this->player_host_index) {
-						GuiShowTooltips(this, STR_NETWORK_CLIENT_LIST_PLAYER_ICON_HOST_TOOLTIP, 0, nullptr, close_cond);
+						GuiShowTooltips(this, STR_NETWORK_CLIENT_LIST_PLAYER_ICON_HOST_TOOLTIP, close_cond);
 						return true;
 					}
 				}
@@ -1860,7 +1860,7 @@ public:
 				ButtonCommon *button = this->GetButtonAtPoint(pt);
 				if (button == nullptr) return false;
 
-				GuiShowTooltips(this, button->tooltip, 0, nullptr, close_cond);
+				GuiShowTooltips(this, button->tooltip, close_cond);
 				return true;
 			};
 		}

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -2640,13 +2640,11 @@ void UpdateTileSelection()
  * Displays the measurement tooltips when selecting multiple tiles
  * @param str String to be displayed
  * @param paramcount number of params to deal with
- * @param params (optional) up to 5 pieces of additional information that may be added to a tooltip
- * @param close_cond Condition for closing this tooltip.
  */
-static inline void ShowMeasurementTooltips(StringID str, uint paramcount, const uint64 params[], TooltipCloseCondition close_cond = TCC_EXIT_VIEWPORT)
+static inline void ShowMeasurementTooltips(StringID str, uint paramcount)
 {
 	if (!_settings_client.gui.measure_tooltip) return;
-	GuiShowTooltips(_thd.GetCallbackWnd(), str, paramcount, params, close_cond);
+	GuiShowTooltips(_thd.GetCallbackWnd(), str, paramcount, nullptr, TCC_EXIT_VIEWPORT);
 }
 
 static void HideMeasurementTooltips()
@@ -2722,7 +2720,8 @@ void VpSetPresizeRange(TileIndex from, TileIndex to)
 
 	/* show measurement only if there is any length to speak of */
 	if (distance > 1) {
-		ShowMeasurementTooltips(STR_MEASURE_LENGTH, 1, &distance);
+		SetDParam(0, distance);
+		ShowMeasurementTooltips(STR_MEASURE_LENGTH, 1);
 	} else {
 		HideMeasurementTooltips();
 	}
@@ -3110,7 +3109,6 @@ static void CalcRaildirsDrawstyle(int x, int y, int method)
 		TileIndex t1 = TileVirtXY(x, y);
 		uint distance = DistanceManhattan(t0, t1) + 1;
 		byte index = 0;
-		uint64 params[2];
 
 		if (distance != 1) {
 			int heightdiff = CalcHeightdiff(b, distance, t0, t1);
@@ -3121,11 +3119,11 @@ static void CalcRaildirsDrawstyle(int x, int y, int method)
 				distance = CeilDiv(distance, 2);
 			}
 
-			params[index++] = distance;
-			if (heightdiff != 0) params[index++] = heightdiff;
+			SetDParam(index++, distance);
+			if (heightdiff != 0) SetDParam(index++, heightdiff);
 		}
 
-		ShowMeasurementTooltips(measure_strings_length[index], index, params);
+		ShowMeasurementTooltips(measure_strings_length[index], index);
 	}
 
 	_thd.selend.x = x;
@@ -3207,7 +3205,6 @@ calc_heightdiff_single_direction:;
 				TileIndex t1 = TileVirtXY(x, y);
 				uint distance = DistanceManhattan(t0, t1) + 1;
 				byte index = 0;
-				uint64 params[2];
 
 				if (distance != 1) {
 					/* With current code passing a HT_LINE style to calculate the height
@@ -3217,11 +3214,11 @@ calc_heightdiff_single_direction:;
 					 * new_style := (_thd.next_drawstyle & HT_RECT) ? HT_LINE | style : _thd.next_drawstyle; */
 					int heightdiff = CalcHeightdiff(HT_LINE | style, 0, t0, t1);
 
-					params[index++] = distance;
-					if (heightdiff != 0) params[index++] = heightdiff;
+					SetDParam(index++, distance);
+					if (heightdiff != 0) SetDParam(index++, heightdiff);
 				}
 
-				ShowMeasurementTooltips(measure_strings_length[index], index, params);
+				ShowMeasurementTooltips(measure_strings_length[index], index);
 			}
 			break;
 
@@ -3242,7 +3239,6 @@ calc_heightdiff_single_direction:;
 				uint dx = Delta(TileX(t0), TileX(t1)) + 1;
 				uint dy = Delta(TileY(t0), TileY(t1)) + 1;
 				byte index = 0;
-				uint64 params[3];
 
 				/* If dragging an area (eg dynamite tool) and it is actually a single
 				 * row/column, change the type to 'line' to get proper calculation for height */
@@ -3287,12 +3283,12 @@ calc_heightdiff_single_direction:;
 				if (dx != 1 || dy != 1) {
 					int heightdiff = CalcHeightdiff(style, 0, t0, t1);
 
-					params[index++] = dx - (style & HT_POINT ? 1 : 0);
-					params[index++] = dy - (style & HT_POINT ? 1 : 0);
-					if (heightdiff != 0) params[index++] = heightdiff;
+					SetDParam(index++, dx - (style & HT_POINT ? 1 : 0));
+					SetDParam(index++, dy - (style & HT_POINT ? 1 : 0));
+					if (heightdiff != 0) SetDParam(index++, heightdiff);
 				}
 
-				ShowMeasurementTooltips(measure_strings_area[index], index, params);
+				ShowMeasurementTooltips(measure_strings_area[index], index);
 			}
 			break;
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -2644,7 +2644,7 @@ void UpdateTileSelection()
 static inline void ShowMeasurementTooltips(StringID str, uint paramcount)
 {
 	if (!_settings_client.gui.measure_tooltip) return;
-	GuiShowTooltips(_thd.GetCallbackWnd(), str, paramcount, nullptr, TCC_EXIT_VIEWPORT);
+	GuiShowTooltips(_thd.GetCallbackWnd(), str, TCC_EXIT_VIEWPORT, paramcount);
 }
 
 static void HideMeasurementTooltips()

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -823,7 +823,7 @@ static void DispatchRightClickEvent(Window *w, int x, int y)
 	if (_settings_client.gui.right_mouse_wnd_close && (w->window_desc->flags & WDF_NO_CLOSE) == 0) {
 		w->Close();
 	} else if (_settings_client.gui.hover_delay_ms == 0 && !w->OnTooltip(pt, wid->index, TCC_RIGHT_CLICK) && wid->tool_tip != 0) {
-		GuiShowTooltips(w, wid->tool_tip, 0, nullptr, TCC_RIGHT_CLICK);
+		GuiShowTooltips(w, wid->tool_tip, TCC_RIGHT_CLICK);
 	}
 }
 
@@ -844,7 +844,7 @@ static void DispatchHoverEvent(Window *w, int x, int y)
 
 	/* Show the tooltip if there is any */
 	if (!w->OnTooltip(pt, wid->index, TCC_HOVER) && wid->tool_tip != 0) {
-		GuiShowTooltips(w, wid->tool_tip);
+		GuiShowTooltips(w, wid->tool_tip, TCC_HOVER);
 		return;
 	}
 

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -898,7 +898,7 @@ Wcls *AllocateWindowDescFront(WindowDesc *desc, int window_number, bool return_e
 
 void RelocateAllWindows(int neww, int newh);
 
-void GuiShowTooltips(Window *parent, StringID str, uint paramcount = 0, const uint64 params[] = nullptr, TooltipCloseCondition close_tooltip = TCC_HOVER);
+void GuiShowTooltips(Window *parent, StringID str, TooltipCloseCondition close_tooltip, uint paramcount = 0);
 
 /* widget.cpp */
 int GetWidgetFromPos(const Window *w, int x, int y);


### PR DESCRIPTION
## Motivation / Problem

The tooltip code has code to manually set parameters for its strings, which yields things like `params[1] = (size_t)details.c_str();`, but it also allows using `SetDParam`/`SetDParamStr` but then has a custom implementation for copying the data.
So why not unify it to `SetDParam`/`SetDParamStr` and `CopyOutDParam`, like the other functions handling string formatting parameters?


## Description

Replace the `params` with `SetDParam`/`SetDParamStr`.
Remove the unneeded `params` parameter.
Replace customer parameter copying with `CopyOutDParam`.
Reorder arguments to tooltip function, because the close condition is essentially always set whereas the number of parameters is way more often just 0.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
