### PR TITLE
Codechange: generify GetRemainingParameters to allow custom offsets

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1036,7 +1036,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 					_scan_for_gender_data = true;
 					std::string buffer;
 					StringBuilder tmp_builder(buffer);
-					StringParameters tmp_params(args.GetPointerToOffset(offset), args.num_param - offset, nullptr);
+					StringParameters tmp_params = args.GetRemainingParameters(offset);
 					FormatString(tmp_builder, input, tmp_params);
 					_scan_for_gender_data = old_sgd;
 

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -81,16 +81,28 @@ public:
 
 	/**
 	 * Get a new instance of StringParameters that is a "range" into the
-	 * parameters existing parameters. Upon destruction the offset in the parent
+	 * remaining existing parameters. Upon destruction the offset in the parent
 	 * is not updated. However, calls to SetDParam do update the parameters.
 	 *
 	 * The returned StringParameters must not outlive this StringParameters.
 	 * @return A "range" of the string parameters.
 	 */
-	StringParameters GetRemainingParameters()
+	StringParameters GetRemainingParameters() { return GetRemainingParameters(this->offset); }
+
+	/**
+	 * Get a new instance of StringParameters that is a "range" into the
+	 * remaining existing parameters from the given offset. Upon destruction the
+	 * offset in the parent is not updated. However, calls to SetDParam do
+	 * update the parameters.
+	 *
+	 * The returned StringParameters must not outlive this StringParameters.
+	 * @param offset The offset to get the remaining parameters for.
+	 * @return A "range" of the string parameters.
+	 */
+	StringParameters GetRemainingParameters(size_t offset)
 	{
-		return StringParameters(&this->data[this->offset], GetDataLeft(),
-			this->type == nullptr ? nullptr : &this->type[this->offset]);
+		return StringParameters(&this->data[offset], GetDataLeft(),
+			this->type == nullptr ? nullptr : &this->type[offset]);
 	}
 
 	/** Return the amount of elements which can still be read. */


### PR DESCRIPTION
## Motivation / Problem

Similar function implemented twice, just to pass a custom offset.


## Description

Add one parameter function of `GetRemainingParameters` that has offset as parameter. The zero parameter variant adds `this->offset`.
Use the new function within the gender lookup.


## Limitations

It's going to do type checking now, if types were provided. This isn't necessarily bad, as that is done in the normal run when building the strings in any case. So now it will be consistent in its behaviour.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
