### PR TITLE
Codechange: use args.GetParam(offset) over *args.GetPointerToOffset(offset)

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1064,7 +1064,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 			case SCC_PLURAL_LIST: { // {P}
 				int plural_form = *str++;          // contains the plural form for this string
 				uint offset = orig_offset + (byte)*str++;
-				int64 v = *args.GetPointerToOffset(offset); // contains the number that determines plural
+				int64 v = args.GetParam(offset); // contains the number that determines plural
 				str = ParseStringChoice(str, DeterminePluralForm(v, plural_form), builder);
 				break;
 			}


### PR DESCRIPTION
## Motivation / Problem

Overly complicated way to get the value of a parameter.


## Description

Replace pointer dereferencing by `GetParam`.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
