### PR TITLE
Add hotkey to focus filter box on town and industry directories

### DIFF
--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -44,6 +44,7 @@
 #include "stringfilter_type.h"
 #include "timer/timer.h"
 #include "timer/timer_window.h"
+#include "hotkeys.h"
 
 #include "table/strings.h"
 
@@ -1302,7 +1303,10 @@ static bool CDECL CargoFilter(const Industry * const *industry, const std::pair<
 
 static GUIIndustryList::FilterFunction * const _filter_funcs[] = { &CargoFilter };
 
-
+/** Enum referring to the Hotkeys in the industry directory window */
+enum IndustryDirectoryHotkeys {
+	IDHK_FOCUS_FILTER_BOX, ///< Focus the filter box
+};
 /**
  * The list of industries.
  */
@@ -1866,6 +1870,23 @@ public:
 				break;
 		}
 	}
+
+	EventState OnHotkey(int hotkey) override
+	{
+		switch (hotkey) {
+			case IDHK_FOCUS_FILTER_BOX:
+				this->SetFocusedWidget(WID_ID_FILTER);
+				SetFocusedWindow(this); // The user has asked to give focus to the text box, so make sure this window is focused.
+				break;
+			default:
+				return ES_NOT_HANDLED;
+		}
+		return ES_HANDLED;
+	}
+
+	static inline HotkeyList hotkeys {"industrydirectory", {
+		Hotkey('F', "focus_filter_box", IDHK_FOCUS_FILTER_BOX),
+	}};
 };
 
 Listing IndustryDirectoryWindow::last_sorting = {false, 0};
@@ -1895,7 +1916,8 @@ static WindowDesc _industry_directory_desc(__FILE__, __LINE__,
 	WDP_AUTO, "list_industries", 428, 190,
 	WC_INDUSTRY_DIRECTORY, WC_NONE,
 	0,
-	std::begin(_nested_industry_directory_widgets), std::end(_nested_industry_directory_widgets)
+	std::begin(_nested_industry_directory_widgets), std::end(_nested_industry_directory_widgets),
+	&IndustryDirectoryWindow::hotkeys
 );
 
 void ShowIndustryDirectory()

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -38,6 +38,7 @@
 #include "timer/timer_game_calendar.h"
 #include "timer/timer_window.h"
 #include "zoom_func.h"
+#include "hotkeys.h"
 
 #include "widgets/town_widget.h"
 
@@ -694,6 +695,11 @@ static const NWidgetPart _nested_town_directory_widgets[] = {
 	EndContainer(),
 };
 
+/** Enum referring to the Hotkeys in the town directory window */
+enum TownDirectoryHotkeys {
+	TDHK_FOCUS_FILTER_BOX, ///< Focus the filter box
+};
+
 /** Town directory window class. */
 struct TownDirectoryWindow : public Window {
 private:
@@ -1006,6 +1012,23 @@ public:
 				this->towns.ForceResort();
 		}
 	}
+
+	EventState OnHotkey(int hotkey) override
+	{
+		switch (hotkey) {
+			case TDHK_FOCUS_FILTER_BOX:
+				this->SetFocusedWidget(WID_TD_FILTER);
+				SetFocusedWindow(this); // The user has asked to give focus to the text box, so make sure this window is focused.
+				break;
+			default:
+				return ES_NOT_HANDLED;
+		}
+		return ES_HANDLED;
+	}
+
+	static inline HotkeyList hotkeys {"towndirectory", {
+		Hotkey('F', "focus_filter_box", TDHK_FOCUS_FILTER_BOX),
+	}};
 };
 
 Listing TownDirectoryWindow::last_sorting = {false, 0};
@@ -1029,7 +1052,8 @@ static WindowDesc _town_directory_desc(__FILE__, __LINE__,
 	WDP_AUTO, "list_towns", 208, 202,
 	WC_TOWN_DIRECTORY, WC_NONE,
 	0,
-	std::begin(_nested_town_directory_widgets), std::end(_nested_town_directory_widgets)
+	std::begin(_nested_town_directory_widgets), std::end(_nested_town_directory_widgets),
+	&TownDirectoryWindow::hotkeys
 );
 
 void ShowTownDirectory()


### PR DESCRIPTION
## Motivation / Problem


Brings town and industry directory functionality in line with other GUI elements where the 'f' hotkey can be used to focus on the filter box.



## Description


Adds hotkey functionality similar to #8908 to the town and industry directory windows.

closes #10886 



## Limitations

none


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
