### PR TITLE
Codechange: make size and offset size_t

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -99,7 +99,7 @@ int64 StringParameters::GetInt64()
  * @param n Index of the string parameter.
  * @param v Value of the string parameter.
  */
-void SetDParam(uint n, uint64_t v)
+void SetDParam(size_t n, uint64_t v)
 {
 	_global_string_params.SetParam(n, v);
 }
@@ -109,7 +109,7 @@ void SetDParam(uint n, uint64_t v)
  * @param n Index of the string parameter.
  * @return Value of the requested string parameter.
  */
-uint64_t GetDParam(uint n)
+uint64_t GetDParam(size_t n)
 {
 	return _global_string_params.GetParam(n);
 }
@@ -122,7 +122,7 @@ uint64_t GetDParam(uint n)
  * @param min_count Minimum number of digits independent of \a max.
  * @param size  Font of the number
  */
-void SetDParamMaxValue(uint n, uint64_t max_value, uint min_count, FontSize size)
+void SetDParamMaxValue(size_t n, uint64_t max_value, uint min_count, FontSize size)
 {
 	uint num_digits = 1;
 	while (max_value >= 10) {
@@ -138,7 +138,7 @@ void SetDParamMaxValue(uint n, uint64_t max_value, uint min_count, FontSize size
  * @param count Number of digits which shall be displayable.
  * @param size  Font of the number
  */
-void SetDParamMaxDigits(uint n, uint count, FontSize size)
+void SetDParamMaxDigits(size_t n, uint count, FontSize size)
 {
 	uint front = 0;
 	uint next = 0;
@@ -337,7 +337,7 @@ std::string GetStringWithArgs(StringID string, StringParameters &args)
  * @param n slot of the string
  * @param str string to bind
  */
-void SetDParamStr(uint n, const char *str)
+void SetDParamStr(size_t n, const char *str)
 {
 	SetDParam(n, (uint64)(size_t)str);
 }
@@ -348,7 +348,7 @@ void SetDParamStr(uint n, const char *str)
  * @param n slot of the string
  * @param str string to bind
  */
-void SetDParamStr(uint n, const std::string &str)
+void SetDParamStr(size_t n, const std::string &str)
 {
 	SetDParamStr(n, str.c_str());
 }
@@ -851,7 +851,7 @@ static std::vector<const char *> _game_script_raw_strings;
  */
 static void FormatString(StringBuilder &builder, const char *str_arg, StringParameters &args, uint case_index, bool game_script, bool dry_run)
 {
-	uint orig_offset = args.offset;
+	size_t orig_offset = args.offset;
 
 	if (!dry_run && args.HasTypeInformation()) {
 		/*
@@ -1021,7 +1021,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 
 			case SCC_GENDER_LIST: { // {G 0 Der Die Das}
 				/* First read the meta data from the language file. */
-				uint offset = orig_offset + (byte)*str++;
+				size_t offset = orig_offset + (byte)*str++;
 				int gender = 0;
 				if (!dry_run && args.GetTypeAtOffset(offset) != 0) {
 					/* Now we need to figure out what text to resolve, i.e.
@@ -1063,7 +1063,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 
 			case SCC_PLURAL_LIST: { // {P}
 				int plural_form = *str++;          // contains the plural form for this string
-				uint offset = orig_offset + (byte)*str++;
+				size_t offset = orig_offset + (byte)*str++;
 				int64 v = args.GetParam(offset); // contains the number that determines plural
 				str = ParseStringChoice(str, DeterminePluralForm(v, plural_form), builder);
 				break;

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -77,19 +77,19 @@ static inline int64 PackVelocity(uint speed, VehicleType type)
 	return speed | (static_cast<uint64>(type) << 56);
 }
 
-void SetDParam(uint n, uint64_t v);
-void SetDParamMaxValue(uint n, uint64_t max_value, uint min_count = 0, FontSize size = FS_NORMAL);
-void SetDParamMaxDigits(uint n, uint count, FontSize size = FS_NORMAL);
+void SetDParam(size_t n, uint64_t v);
+void SetDParamMaxValue(size_t n, uint64_t max_value, uint min_count = 0, FontSize size = FS_NORMAL);
+void SetDParamMaxDigits(size_t n, uint count, FontSize size = FS_NORMAL);
 
-void SetDParamStr(uint n, const char *str);
-void SetDParamStr(uint n, const std::string &str);
-void SetDParamStr(uint n, std::string &&str) = delete; // block passing temporaries to SetDParamStr
+void SetDParamStr(size_t n, const char *str);
+void SetDParamStr(size_t n, const std::string &str);
+void SetDParamStr(size_t n, std::string &&str) = delete; // block passing temporaries to SetDParamStr
 
 void CopyInDParam(const uint64 *src, int num);
 void CopyOutDParam(uint64 *dst, int num);
 void CopyOutDParam(uint64 *dst, const char **strings, StringID string, int num);
 
-uint64_t GetDParam(uint n);
+uint64_t GetDParam(size_t n);
 
 extern TextDirection _current_text_dir; ///< Text direction of the currently selected language
 

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -19,16 +19,15 @@ class StringParameters {
 	WChar *type;              ///< Array with type information about the data. Can be nullptr when no type information is needed. See #StringControlCode.
 
 public:
-	uint offset;              ///< Current offset in the data/type arrays.
-	uint num_param;           ///< Length of the data array.
+	size_t offset = 0; ///< Current offset in the data/type arrays.
+	size_t num_param; ///< Length of the data array.
 	WChar next_type = 0; ///< The type of the next data that is retrieved.
 
 	/** Create a new StringParameters instance. */
-	StringParameters(uint64 *data, uint num_param, WChar *type) :
+	StringParameters(uint64 *data, size_t num_param, WChar *type) :
 		parent(nullptr),
 		data(data),
 		type(type),
-		offset(0),
 		num_param(num_param)
 	{ }
 
@@ -48,10 +47,9 @@ public:
 	 * Create a new StringParameters instance that can reference part of the data of
 	 * the given partent instance.
 	 */
-	StringParameters(StringParameters &parent, uint size) :
+	StringParameters(StringParameters &parent, size_t size) :
 		parent(&parent),
 		data(parent.data + parent.offset),
-		offset(0),
 		num_param(size)
 	{
 		assert(size <= parent.GetDataLeft());
@@ -106,13 +104,13 @@ public:
 	}
 
 	/** Return the amount of elements which can still be read. */
-	uint GetDataLeft() const
+	size_t GetDataLeft() const
 	{
 		return this->num_param - this->offset;
 	}
 
 	/** Get a pointer to a specific element in the data array. */
-	uint64 *GetPointerToOffset(uint offset) const
+	uint64 *GetPointerToOffset(size_t offset) const
 	{
 		assert(offset < this->num_param);
 		return &this->data[offset];
@@ -125,20 +123,20 @@ public:
 	}
 
 	/** Get the type of a specific element. */
-	WChar GetTypeAtOffset(uint offset) const
+	WChar GetTypeAtOffset(size_t offset) const
 	{
 		assert(offset < this->num_param);
 		assert(this->HasTypeInformation());
 		return this->type[offset];
 	}
 
-	void SetParam(uint n, uint64 v)
+	void SetParam(size_t n, uint64 v)
 	{
 		assert(n < this->num_param);
 		this->data[n] = v;
 	}
 
-	uint64 GetParam(uint n) const
+	uint64 GetParam(size_t n) const
 	{
 		assert(n < this->num_param);
 		return this->data[n];


### PR DESCRIPTION
## Motivation / Problem

`uint` used for `num_params` (size) and `offset` (index into array). So when `num_params` becomes a `size()` of a container, offset and size comparisons will get some warnings.


## Description

Replace `uint` with `size_t`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
