### PR TITLE
Codechange: make next_type and offset internal variables of StringParameters

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -62,11 +62,15 @@ static uint64 _global_string_params_data[20];     ///< Global array of string pa
 static WChar _global_string_params_type[20];      ///< Type of parameters stored in #_global_string_params
 StringParameters _global_string_params(_global_string_params_data, 20, _global_string_params_type);
 
-/** Reset the type array. */
-void StringParameters::ClearTypeInformation()
+/**
+ * Prepare the string parameters for the next formatting run. This means
+ * resetting the type information and resetting the offset to the begin.
+ */
+void StringParameters::PrepareForNextRun()
 {
 	assert(this->type != nullptr);
 	MemSetT(this->type, 0, this->num_param);
+	this->offset = 0;
 }
 
 
@@ -313,8 +317,7 @@ void GetStringWithArgs(StringBuilder &builder, StringID string, StringParameters
  */
 std::string GetString(StringID string)
 {
-	_global_string_params.ClearTypeInformation();
-	_global_string_params.offset = 0;
+	_global_string_params.PrepareForNextRun();
 	return GetStringWithArgs(string, _global_string_params);
 }
 
@@ -910,7 +913,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 				bool sub_args_need_free[20];
 				StringParameters sub_args(sub_args_data, 20, sub_args_type);
 
-				sub_args.ClearTypeInformation();
+				sub_args.PrepareForNextRun(); // Needed to reset the currently undefined types
 				memset(sub_args_need_free, 0, sizeof(sub_args_need_free));
 
 				char *p;

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -902,7 +902,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 			continue;
 		}
 
-		args.next_type = b;
+		args.SetTypeOfNextParameter(b);
 		switch (b) {
 			case SCC_ENCODED: {
 				uint64 sub_args_data[20];

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -854,7 +854,7 @@ static std::vector<const char *> _game_script_raw_strings;
  */
 static void FormatString(StringBuilder &builder, const char *str_arg, StringParameters &args, uint case_index, bool game_script, bool dry_run)
 {
-	size_t orig_offset = args.offset;
+	size_t orig_offset = args.GetOffset();
 
 	if (!dry_run && args.HasTypeInformation()) {
 		/*
@@ -879,7 +879,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 			FormatString(dry_run_builder, str_arg, args, case_index, game_script, true);
 		}
 		/* We have to restore the original offset here to to read the correct values. */
-		args.offset = orig_offset;
+		args.SetOffset(orig_offset);
 	}
 	WChar b = '\0';
 	uint next_substr_case_index = 0;
@@ -1073,7 +1073,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 			}
 
 			case SCC_ARG_INDEX: { // Move argument pointer
-				args.offset = orig_offset + (byte)*str++;
+				args.SetOffset(orig_offset + (byte)*str++);
 				break;
 			}
 

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -68,7 +68,7 @@ public:
 		}
 	}
 
-	void ClearTypeInformation();
+	void PrepareForNextRun();
 	void SetTypeOfNextParameter(WChar type) { this->next_type = type; }
 
 	int64 GetInt64();

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -19,9 +19,9 @@ class StringParameters {
 	WChar *type;              ///< Array with type information about the data. Can be nullptr when no type information is needed. See #StringControlCode.
 
 	WChar next_type = 0; ///< The type of the next data that is retrieved.
+	size_t offset = 0; ///< Current offset in the data/type arrays.
 
 public:
-	size_t offset = 0; ///< Current offset in the data/type arrays.
 	size_t num_param; ///< Length of the data array.
 
 	/** Create a new StringParameters instance. */
@@ -70,6 +70,31 @@ public:
 
 	void PrepareForNextRun();
 	void SetTypeOfNextParameter(WChar type) { this->next_type = type; }
+
+	/**
+	 * Get the current offset, so it can be backed up for certain processing
+	 * steps, or be used to offset the argument index within sub strings.
+	 * @return The current offset.
+	 */
+	size_t GetOffset() { return this->offset; }
+
+	/**
+	 * Set the offset within the string from where to return the next result of
+	 * \c GetInt64 or \c GetInt32.
+	 * @param offset The offset.
+	 */
+	void SetOffset(size_t offset)
+	{
+		/*
+		 * The offset must be fewer than the number of parameters when it is
+		 * being set. Unless restoring a backup, then the original value is
+		 * correct as well as long as the offset was not changed. In other
+		 * words, when the offset was already at the end of the parameters and
+		 * the string did not consume any parameters.
+		 */
+		assert(offset < this->num_param || this->offset == offset);
+		this->offset = offset;
+	}
 
 	int64 GetInt64();
 

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -18,10 +18,11 @@ class StringParameters {
 	uint64 *data;             ///< Array with the actual data.
 	WChar *type;              ///< Array with type information about the data. Can be nullptr when no type information is needed. See #StringControlCode.
 
+	WChar next_type = 0; ///< The type of the next data that is retrieved.
+
 public:
 	size_t offset = 0; ///< Current offset in the data/type arrays.
 	size_t num_param; ///< Length of the data array.
-	WChar next_type = 0; ///< The type of the next data that is retrieved.
 
 	/** Create a new StringParameters instance. */
 	StringParameters(uint64 *data, size_t num_param, WChar *type) :
@@ -68,6 +69,7 @@ public:
 	}
 
 	void ClearTypeInformation();
+	void SetTypeOfNextParameter(WChar type) { this->next_type = type; }
 
 	int64 GetInt64();
 


### PR DESCRIPTION
## Motivation / Problem

Everyone can read/write `next_type`/`offset`, when there are only specific use cases for that. The direct access also makes it harder to modify the internals of `StringParameters`.


## Description

Add helper functions where needed, and add assertions to make sure only expected values are inserted (for non-release builds).


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
