### PR TITLE
Fix #11026: Use real engine name instead of default name for filtering

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1370,7 +1370,8 @@ struct BuildVehicleWindow : Window {
 
 		/* Filter engine name */
 		this->string_filter.ResetState();
-		this->string_filter.AddLine(GetString(e->info.string_id));
+		SetDParam(0, PackEngineNameDParam(e->index, EngineNameContext::PurchaseList));
+		this->string_filter.AddLine(GetString(STR_ENGINE_NAME));
 
 		/* Filter NewGRF extra text */
 		auto text = GetNewGRFAdditionalText(e->index);


### PR DESCRIPTION
## Motivation / Problem

Fixes #11026.

Additionally, when an engine type was renamed in the vehicle list, the filtering still used the default name. This is also fixed.


## Description

Instead of fetching the default name of the engine using `e->info.string_id`, use the `STR_ENGINE_NAME` string which takes into account the NewGRF callbacks and renaming of engine by user.


## Limitations

I don't know?


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
