### PR TITLE
Fix: Layouter::GetCharAtPosition counting wrong

### DIFF
--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -255,9 +255,9 @@ Point Layouter::GetCharPosition(std::string_view::const_iterator ch) const
 }
 
 /**
- * Get the character that is at a position.
+ * Get the character that is at a pixel position in the first line of the layouted text.
  * @param x Position in the string.
- * @return Index of the position or -1 if no character is at the position.
+ * @return String offset of the position (bytes) or -1 if no character is at the position.
  */
 ptrdiff_t Layouter::GetCharAtPosition(int x) const
 {
@@ -278,9 +278,8 @@ ptrdiff_t Layouter::GetCharAtPosition(int x) const
 				size_t index = run.GetGlyphToCharMap()[i];
 
 				size_t cur_idx = 0;
-				int char_index = 0;
-				for (auto str = this->string.begin(); str != this->string.end(); char_index++) {
-					if (cur_idx == index) return char_index;
+				for (auto str = this->string.begin(); str != this->string.end();) {
+					if (cur_idx == index) return str - this->string.begin();
 
 					WChar c = Utf8Consume(str);
 					cur_idx += line->GetInternalCharLength(c);


### PR DESCRIPTION


## Motivation / Problem

Commit 60399e17bd1571943f67e52ff694021cf1270c8e introduced a bug in Layouter::GetCharAtPosition. It should return the string offset/byte position of a character, but it instead counts Unicode codepoints.

## Description

Fix the algorithm, and improve documentation a bit too.

## Limitations

As far as I can tell, this function is used only in `src/video/cocoa/cocoa_wnd.mm` (transitively) so does not get exercised a lot. Discovered while working on #7786 where the function gets expanded a bit too. Testing from that PR indicates it works correctly now.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
