### PR TITLE
Codechange: includes must be before 'safeguards.h'

### DIFF
--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -12,10 +12,10 @@
 #include <atomic>
 #include "core/math_func.hpp"
 #include "framerate_type.h"
+#include "mixer.h"
 #include "settings_type.h"
 
 #include "safeguards.h"
-#include "mixer.h"
 
 struct MixerChannel {
 	/* pointer to allocated buffer memory */

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -13,9 +13,9 @@
 /** The type of set we're replacing */
 #define SET_TYPE "music"
 #include "base_media_func.h"
+#include "random_access_file_type.h"
 
 #include "safeguards.h"
-#include "random_access_file_type.h"
 
 
 /**

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -44,10 +44,9 @@
 #include "network/core/config.h"
 #include "network/network_gui.h"
 #include "network/network_survey.h"
-
+#include "video/video_driver.hpp"
 
 #include "safeguards.h"
-#include "video/video_driver.hpp"
 
 
 static const StringID _autosave_dropdown[] = {

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -37,13 +37,13 @@
 #include "timer/timer.h"
 #include "timer/timer_game_calendar.h"
 #include "timer/timer_window.h"
+#include "zoom_func.h"
 
 #include "widgets/town_widget.h"
 
 #include "table/strings.h"
 
 #include "safeguards.h"
-#include "zoom_func.h"
 
 TownKdtree _town_local_authority_kdtree(&Kdtree_TownXYFunc);
 

--- a/src/waypoint_gui.cpp
+++ b/src/waypoint_gui.cpp
@@ -21,13 +21,13 @@
 #include "window_func.h"
 #include "waypoint_base.h"
 #include "waypoint_cmd.h"
+#include "zoom_func.h"
 
 #include "widgets/waypoint_widget.h"
 
 #include "table/strings.h"
 
 #include "safeguards.h"
-#include "zoom_func.h"
 
 /** GUI for accessing waypoints and buoys. */
 struct WaypointWindow : Window {


### PR DESCRIPTION
## Motivation / Problem

`#include "safeguards.h"` not being the last include.


## Description

Move includes above it.


## Limitations

In some places there are includes way later in the file, but guarded by `#ifdef`. As long as these headers do not use anything we safeguard against that is fine as it has been for a while.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
