### PR TITLE
Fix: #10917 move interest payment before stat generation

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1977,12 +1977,12 @@ void LoadUnloadStation(Station *st)
  */
 static IntervalTimer<TimerGameCalendar> _companies_monthly({TimerGameCalendar::MONTH, TimerGameCalendar::Priority::COMPANY}, [](auto)
 {
+	CompaniesPayInterest();
 	CompaniesGenStatistics();
 	if (_settings_game.economy.inflation) {
 		AddInflation();
 		RecomputePrices();
 	}
-	CompaniesPayInterest();
 	HandleEconomyFluctuations();
 });
 


### PR DESCRIPTION
## Motivation / Problem

Loan interest payed in months at end of quarter is incorrectly accounted in the following quarter

closes #10917


## Description

Moved call to CompaniesPayInterest() ahead of call to CompaniesGenStatistics() causing interest to be paid prior to accounting for each month/quarter.


## Limitations

None

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
