### PR TITLE
Codechange: move to std::string over stredup + free

### DIFF
--- a/src/os/windows/win32_main.cpp
+++ b/src/os/windows/win32_main.cpp
@@ -58,10 +58,8 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 
 	CrashLog::InitialiseCrashLog();
 
-	/* Convert the command line to UTF-8. We need a dedicated buffer
-	 * for this because argv[] points into this buffer and this needs to
-	 * be available between subsequent calls to FS2OTTD(). */
-	char *cmdline = stredup(FS2OTTD(GetCommandLine()).c_str());
+	/* Convert the command line to UTF-8. */
+	std::string cmdline = FS2OTTD(GetCommandLine());
 
 	/* Set the console codepage to UTF-8. */
 	SetConsoleOutputCP(CP_UTF8);
@@ -76,7 +74,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	SetRandomSeed(GetTickCount());
 
 	char *argv[64]; // max 64 command line arguments
-	int argc = ParseCommandLine(cmdline, argv, lengthof(argv));
+	int argc = ParseCommandLine(cmdline.data(), argv, lengthof(argv));
 
 	/* Make sure our arguments contain only valid UTF-8 characters. */
 	for (int i = 0; i < argc; i++) StrMakeValidInPlace(argv[i]);
@@ -86,6 +84,5 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	/* Restore system timer resolution. */
 	timeEndPeriod(1);
 
-	free(cmdline);
 	return ret;
 }


### PR DESCRIPTION
## Motivation / Problem

Use of `stredup` + `free`.


## Description

`FS2OTTD` already returns a `std::string`, so just use that and pass its `.data()` to the command line parsing instead of `stredup`-ing the `.c_str()` of that string.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
