### PR TITLE
Fix #11043: Don't choose toolbar dropdown option if focus is lost.

### DIFF
--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -199,7 +199,10 @@ struct DropdownWindow : Window {
 
 	void OnFocusLost(bool closing) override
 	{
-		if (!closing) this->Close();
+		if (!closing) {
+			this->instant_close = false;
+			this->Close();
+		}
 	}
 
 	Point OnInitialPosition(int16 sm_width, int16 sm_height, int window_number) override


### PR DESCRIPTION
## Motivation / Problem

As per #11043, the game may crash if a window pops up while using the rail type toolbar menu.

## Description

Since dropdown menus now get closed if they lose focus, 'instant close' dropdowns (i.e. the toolbar dropdowns) should no longer execute their action to avoid unintended actions.


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Possibly the dropdown menu should not lose focus if other windows popup without user interation, but that is another thing.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
