### PR TITLE
Fix: [DorpsGek] report eints commits on Discord / IRC

### DIFF
--- a/.dorpsgek.yml
+++ b/.dorpsgek.yml
@@ -8,7 +8,7 @@ notifications:
     only:
     - master
     only-by:
-    - DorpsGek
+    - eints-sync[bot]
   commit-comment:
   discussion:
   pull-request:


### PR DESCRIPTION
## Motivation / Problem

Finally eints commits are not pushed with a PAT anymore, but via GitHub Apps. This also means the author changed, from `DorpsGek` to `eints-sync[bot]`.


## Description

Announce commits made by `eints-sync[bot]`.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
