### PR TITLE
Codechange: always allocate types for StringParameters

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -58,9 +58,7 @@ TextDirection _current_text_dir; ///< Text direction of the currently selected l
 std::unique_ptr<icu::Collator> _current_collator;    ///< Collator for the language currently in use.
 #endif /* WITH_ICU_I18N */
 
-static uint64 _global_string_params_data[20];     ///< Global array of string parameters. To access, use #SetDParam.
-static WChar _global_string_params_type[20];      ///< Type of parameters stored in #_global_string_params
-StringParameters _global_string_params(_global_string_params_data, 20, _global_string_params_type);
+AllocatedStringParameters _global_string_params(20);
 
 /**
  * Prepare the string parameters for the next formatting run. This means
@@ -905,12 +903,8 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 		args.SetTypeOfNextParameter(b);
 		switch (b) {
 			case SCC_ENCODED: {
-				uint64 sub_args_data[20];
-				WChar sub_args_type[20];
 				bool sub_args_need_free[20];
-				StringParameters sub_args(sub_args_data, 20, sub_args_type);
-
-				sub_args.PrepareForNextRun(); // Needed to reset the currently undefined types
+				AllocatedStringParameters sub_args(20);
 				memset(sub_args_need_free, 0, sizeof(sub_args_need_free));
 
 				char *p;
@@ -1400,9 +1394,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 			case SCC_DEPOT_NAME: { // {DEPOT}
 				VehicleType vt = (VehicleType)args.GetInt32();
 				if (vt == VEH_AIRCRAFT) {
-					uint64 args_array[] = {(uint64)args.GetInt32()};
-					WChar types_array[] = {SCC_STATION_NAME};
-					StringParameters tmp_params(args_array, 1, types_array);
+					StringParameters tmp_params = StringParameters(args, 1);
 					GetStringWithArgs(builder, STR_FORMAT_DEPOT_NAME_AIRCRAFT, tmp_params);
 					break;
 				}
@@ -1437,9 +1429,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 						assert(grffile != nullptr);
 
 						StartTextRefStackUsage(grffile, 6);
-						uint64 tmp_dparam[6] = { 0 };
-						WChar tmp_type[6] = { 0 };
-						StringParameters tmp_params(tmp_dparam, 6, tmp_type);
+						AllocatedStringParameters tmp_params(6);
 						GetStringWithArgs(builder, GetGRFStringID(grffile->grfid, 0xD000 + callback), tmp_params);
 						StopTextRefStackUsage();
 
@@ -1536,9 +1526,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 						}
 					}
 
-					uint64 args_array[] = {STR_TOWN_NAME, st->town->index, st->index};
-					WChar types_array[] = {0, SCC_TOWN_NAME, SCC_NUM};
-					StringParameters tmp_params(args_array, 3, types_array);
+					auto tmp_params = MakeParameters(STR_TOWN_NAME, st->town->index, st->index);
 					GetStringWithArgs(builder, string_id, tmp_params);
 				}
 				break;

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -187,7 +187,7 @@ void CopyOutDParam(uint64 *dst, const char **strings, StringID string, int num)
 
 	MemCpyT(dst, _global_string_params.GetPointerToOffset(0), num);
 	for (int i = 0; i < num; i++) {
-		if (_global_string_params.HasTypeInformation() && _global_string_params.GetTypeAtOffset(i) == SCC_RAW_STRING_POINTER) {
+		if (_global_string_params.GetTypeAtOffset(i) == SCC_RAW_STRING_POINTER) {
 			strings[i] = stredup((const char *)(size_t)_global_string_params.GetParam(i));
 			dst[i] = (size_t)strings[i];
 		} else {
@@ -851,12 +851,14 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 {
 	size_t orig_offset = args.GetOffset();
 
-	if (!dry_run && args.HasTypeInformation()) {
+	if (!dry_run) {
 		/*
-		 * FormatString was called without `dry_run` set, however `args` has
-		 * space allocated for type information and thus wants type checks on
-		 * the parameters. So, we need to gather the type information via the
-		 * dry run first, before we can continue formatting the string.
+		 * This function is normally called with `dry_run` false, then we call this function again
+		 * with `dry_run` being true. The dry run is required for the gender formatting. For the
+		 * gender determination we need to format a sub string to get the gender, but for that we
+		 * need to know as what string control code type the specific parameter is encoded. Since
+		 * gendered words can be before the "parameter" words, this needs to be determined before
+		 * the actual formatting.
 		 */
 		std::string buffer;
 		StringBuilder dry_run_builder(buffer);

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -15,23 +15,22 @@
 
 class StringParameters {
 protected:
-	StringParameters *parent; ///< If not nullptr, this instance references data from this parent instance.
+	StringParameters *parent = nullptr; ///< If not nullptr, this instance references data from this parent instance.
 	uint64 *data;             ///< Array with the actual data.
 	WChar *type;              ///< Array with type information about the data. Can be nullptr when no type information is needed. See #StringControlCode.
 
 	WChar next_type = 0; ///< The type of the next data that is retrieved.
 	size_t offset = 0; ///< Current offset in the data/type arrays.
 
-public:
-	size_t num_param; ///< Length of the data array.
-
 	/** Create a new StringParameters instance. */
 	StringParameters(uint64 *data, size_t num_param, WChar *type) :
-		parent(nullptr),
 		data(data),
 		type(type),
 		num_param(num_param)
 	{ }
+
+public:
+	size_t num_param; ///< Length of the data array.
 
 	/**
 	 * Create a new StringParameters instance that can reference part of the data of
@@ -169,11 +168,13 @@ public:
  */
 class AllocatedStringParameters : public StringParameters {
 	std::vector<uint64_t> params; ///< The actual parameters
+	std::vector<WChar> types; ///< The actual types.
 
 public:
-	AllocatedStringParameters(size_t parameters = 0) : StringParameters(nullptr, parameters, nullptr), params(parameters)
+	AllocatedStringParameters(size_t parameters = 0) : StringParameters(nullptr, parameters, nullptr), params(parameters), types(parameters)
 	{
 		this->data = params.data();
+		this->type = types.data();
 	}
 };
 

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -17,7 +17,7 @@ class StringParameters {
 protected:
 	StringParameters *parent = nullptr; ///< If not nullptr, this instance references data from this parent instance.
 	uint64 *data;             ///< Array with the actual data.
-	WChar *type;              ///< Array with type information about the data. Can be nullptr when no type information is needed. See #StringControlCode.
+	WChar *type;              ///< Array with type information about the data. See #StringControlCode.
 
 	WChar next_type = 0; ///< The type of the next data that is retrieved.
 	size_t offset = 0; ///< Current offset in the data/type arrays.
@@ -114,8 +114,7 @@ public:
 	 */
 	StringParameters GetRemainingParameters(size_t offset)
 	{
-		return StringParameters(&this->data[offset], GetDataLeft(),
-			this->type == nullptr ? nullptr : &this->type[offset]);
+		return StringParameters(&this->data[offset], GetDataLeft(), &this->type[offset]);
 	}
 
 	/** Return the amount of elements which can still be read. */
@@ -131,17 +130,10 @@ public:
 		return &this->data[offset];
 	}
 
-	/** Does this instance store information about the type of the parameters. */
-	bool HasTypeInformation() const
-	{
-		return this->type != nullptr;
-	}
-
 	/** Get the type of a specific element. */
 	WChar GetTypeAtOffset(size_t offset) const
 	{
 		assert(offset < this->num_param);
-		assert(this->HasTypeInformation());
 		return this->type[offset];
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Unclear logic when to allocate and when not to allocate types.
Since the type is (currently) used to determine which parameters are raw string parameters, always having it will prevent issues. It furthermore simplifies decision making within the formatting.

Final goal is that data and type become a single object that can be (easily) copied around, together with a copy of the string when that's needed, like for backups or temporary strings. But that is not achieved in this PR.


## Description

Add types to the `AllocatedStringParameters`, and use this in the cases where type parameters were already allocated. 
It makes the constructor used by `AllocatedStringParameters` protected, so it's not (easily) used without actually setting the types.
Remove some of the now unnecessary "has type information" checks.

It does remove some of the manually set types, as those aren't needed anymore.


## Limitations

Not aware of any.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
