### PR TITLE
Fix b1fb209: build failure due to removed parameter

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1625,7 +1625,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 			}
 
 			case SCC_COLOUR: { // {COLOUR}
-				StringControlCode scc = (StringControlCode)(SCC_BLUE + args.GetInt32(SCC_COLOUR));
+				StringControlCode scc = (StringControlCode)(SCC_BLUE + args.GetInt32());
 				if (IsInsideMM(scc, SCC_BLUE, SCC_COLOUR)) builder.Utf8Encode(scc);
 				break;
 			}


### PR DESCRIPTION
## Motivation / Problem

Me removing the type parameter from `GetInt32`/`GetInt64`, and b1fb209 providing that parameter.

Both PRs that eventually caused this branched from some version, one removing the parameter from the function and the other adding another call to the function with parameter. Both compiled just fine separately, but after merging one the other PR would technically been broken without the CI noticing that.


## Description

Remove the parameter.


## Limitations

No solution to prevent such issues in the future.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
