### PR TITLE
Codechange: use span of StringParameter within StringParameters

### DIFF
--- a/src/core/span_type.hpp
+++ b/src/core/span_type.hpp
@@ -96,6 +96,12 @@ public:
 
 	constexpr pointer data() const noexcept { return first; }
 
+	constexpr span<element_type> subspan(size_t offset, size_t count)
+	{
+		assert(offset + count <= size());
+		return span(this->data() + offset, count);
+	}
+
 private:
 	pointer first;
 	pointer last;

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -66,8 +66,7 @@ AllocatedStringParameters _global_string_params(20);
  */
 void StringParameters::PrepareForNextRun()
 {
-	assert(this->type != nullptr);
-	MemSetT(this->type, 0, this->num_param);
+	for (auto &param : this->parameters) param.type = 0;
 	this->offset = 0;
 }
 
@@ -79,20 +78,20 @@ void StringParameters::PrepareForNextRun()
 int64 StringParameters::GetInt64()
 {
 	assert(this->next_type == 0 || (SCC_CONTROL_START <= this->next_type && this->next_type <= SCC_CONTROL_END));
-	if (this->offset >= this->num_param) {
+	if (this->offset >= this->parameters.size()) {
 		Debug(misc, 0, "Trying to read invalid string parameter");
 		return 0;
 	}
-	if (this->type != nullptr) {
-		if (this->type[this->offset] != 0 && this->type[this->offset] != this->next_type) {
-			Debug(misc, 0, "Trying to read string parameter with wrong type");
-			this->next_type = 0;
-			return 0;
-		}
-		this->type[this->offset] = next_type;
+
+	auto &param = this->parameters[this->offset++];
+	if (param.type != 0 && param.type != this->next_type) {
+		Debug(misc, 0, "Trying to read string parameter with wrong type");
 		this->next_type = 0;
+		return 0;
 	}
-	return this->data[this->offset++];
+	param.type = next_type;
+	this->next_type = 0;
+	return param.data;
 }
 
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -159,7 +159,7 @@ void SetDParamMaxDigits(size_t n, uint count, FontSize size)
  */
 void CopyInDParam(const uint64 *src, int num)
 {
-	MemCpyT(_global_string_params.GetPointerToOffset(0), src, num);
+	for (int i = 0; i < num; i++) SetDParam(i, src[i]);
 }
 
 /**
@@ -169,7 +169,7 @@ void CopyInDParam(const uint64 *src, int num)
  */
 void CopyOutDParam(uint64 *dst, int num)
 {
-	MemCpyT(dst, _global_string_params.GetPointerToOffset(0), num);
+	for (int i = 0; i < num; i++) dst[i] = GetDParam(i);
 }
 
 /**
@@ -185,13 +185,13 @@ void CopyOutDParam(uint64 *dst, const char **strings, StringID string, int num)
 	/* Just get the string to extract the type information. */
 	GetString(string);
 
-	MemCpyT(dst, _global_string_params.GetPointerToOffset(0), num);
 	for (int i = 0; i < num; i++) {
 		if (_global_string_params.GetTypeAtOffset(i) == SCC_RAW_STRING_POINTER) {
 			strings[i] = stredup((const char *)(size_t)_global_string_params.GetParam(i));
 			dst[i] = (size_t)strings[i];
 		} else {
 			strings[i] = nullptr;
+			dst[i] = _global_string_params.GetParam(i);
 		}
 	}
 }

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -123,13 +123,6 @@ public:
 		return this->num_param - this->offset;
 	}
 
-	/** Get a pointer to a specific element in the data array. */
-	uint64 *GetPointerToOffset(size_t offset) const
-	{
-		assert(offset < this->num_param);
-		return &this->data[offset];
-	}
-
 	/** Get the type of a specific element. */
 	WChar GetTypeAtOffset(size_t offset) const
 	{


### PR DESCRIPTION
## Motivation / Problem

With a span iterating over the elements becomes easier, as it's essentially a standard STL type (or will be in C++20).
With a struct with the data and type, it becomes easier to copy the data belonging to eachother.


## Description

Add a `subspan` function with C++20's function signature.
Change the `CopyIn/OutDParam` functions to just iterate over the elements instead of `memcpy`.
Change the two pointers/vectors to a span/vector of `StringParameter`, which contains both values.

There is a behavioural change with `GetInt64/32`. If the type does not match, it will increase the offset whereas it did not in the past. This situation is a buggy situation in any case, but always increasing the offset seems to be better consistency wise.


## Limitations

The `CopyIn/OutDParam` code still needs love, but that is out of scope for this PR as it essentially should use a `StringParameters` instance that can also store strings. Adding that functionality is the next step, and only then these copy functions can get improved/simplified.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
