### PR TITLE
Codechange: use vector with struct for string parameter backups

### DIFF
--- a/src/error.h
+++ b/src/error.h
@@ -31,8 +31,7 @@ enum WarningLevel {
 class ErrorMessageData {
 protected:
 	bool is_critical;               ///< Whether the error message is critical.
-	uint64 decode_params[20];       ///< Parameters of the message strings.
-	const char *strings[20];        ///< Copies of raw strings that were used.
+	std::vector<StringParameterBackup> params; ///< Backup of parameters of the message strings.
 	const GRFFile *textref_stack_grffile; ///< NewGRF that filled the #TextRefStack for the error message.
 	uint textref_stack_size;        ///< Number of uint32 values to put on the #TextRefStack for the error message.
 	uint32 textref_stack[16];       ///< Values to put on the #TextRefStack for the error message.
@@ -44,7 +43,6 @@ protected:
 
 public:
 	ErrorMessageData(const ErrorMessageData &data);
-	~ErrorMessageData();
 	ErrorMessageData(StringID summary_msg, StringID detailed_msg, bool is_critical = false, int x = 0, int y = 0, const GRFFile *textref_stack_grffile = nullptr, uint textref_stack_size = 0, const uint32 *textref_stack = nullptr, StringID extra_msg = INVALID_STRING_ID);
 
 	/* Remove the copy assignment, as the default implementation will not do the right thing. */

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -280,7 +280,7 @@ struct NewsWindow : Window {
 		this->CreateNestedTree();
 
 		/* For company news with a face we have a separate headline in param[0] */
-		if (desc == &_company_news_desc) this->GetWidget<NWidgetCore>(WID_N_TITLE)->widget_data = this->ni->params[0];
+		if (desc == &_company_news_desc) this->GetWidget<NWidgetCore>(WID_N_TITLE)->widget_data = this->ni->params[0].data;
 
 		NWidgetCore *nwid = this->GetWidget<NWidgetCore>(WID_N_SHOW_GROUP);
 		if (ni->reftype1 == NR_VEHICLE && nwid != nullptr) {
@@ -361,7 +361,7 @@ struct NewsWindow : Window {
 				break;
 
 			case WID_N_MESSAGE:
-				CopyInDParam(this->ni->params, lengthof(this->ni->params));
+				CopyInDParam(this->ni->params);
 				str = this->ni->string_id;
 				break;
 
@@ -429,7 +429,7 @@ struct NewsWindow : Window {
 				break;
 
 			case WID_N_MESSAGE:
-				CopyInDParam(this->ni->params, lengthof(this->ni->params));
+				CopyInDParam(this->ni->params);
 				DrawStringMultiLine(r.left, r.right, r.top, r.bottom, this->ni->string_id, TC_FROMSTRING, SA_CENTER);
 				break;
 
@@ -582,8 +582,8 @@ private:
 	StringID GetCompanyMessageString() const
 	{
 		/* Company news with a face have a separate headline, so the normal message is shifted by two params */
-		CopyInDParam(this->ni->params + 2, lengthof(this->ni->params) - 2);
-		return this->ni->params[1];
+		CopyInDParam(span(this->ni->params.data() + 2, this->ni->params.size() - 2));
+		return this->ni->params[1].data;
 	}
 
 	StringID GetNewVehicleMessageString(int widget) const
@@ -804,7 +804,7 @@ NewsItem::NewsItem(StringID string_id, NewsType type, NewsFlag flags, NewsRefere
 {
 	/* show this news message in colour? */
 	if (TimerGameCalendar::year >= _settings_client.gui.coloured_news_year) this->flags |= NF_INCOLOUR;
-	CopyOutDParam(this->params, lengthof(this->params));
+	CopyOutDParam(this->params, 10);
 }
 
 /**
@@ -998,7 +998,7 @@ void ChangeVehicleNews(VehicleID from_index, VehicleID to_index)
 	for (NewsItem *ni = _oldest_news; ni != nullptr; ni = ni->next) {
 		if (ni->reftype1 == NR_VEHICLE && ni->ref1 == from_index) ni->ref1 = to_index;
 		if (ni->reftype2 == NR_VEHICLE && ni->ref2 == from_index) ni->ref2 = to_index;
-		if (ni->flags & NF_VEHICLE_PARAM0 && ni->params[0] == from_index) ni->params[0] = to_index;
+		if (ni->flags & NF_VEHICLE_PARAM0 && ni->params[0].data == from_index) ni->params[0] = to_index;
 	}
 }
 
@@ -1099,7 +1099,7 @@ void ShowLastNewsMessage()
  */
 static void DrawNewsString(uint left, uint right, int y, TextColour colour, const NewsItem *ni)
 {
-	CopyInDParam(ni->params, lengthof(ni->params));
+	CopyInDParam(ni->params);
 
 	/* Get the string, replaces newlines with spaces and remove control codes from the string. */
 	std::string message = StrMakeValid(GetString(ni->string_id), SVS_REPLACE_TAB_CR_NL_WITH_SPACE);

--- a/src/news_type.h
+++ b/src/news_type.h
@@ -138,7 +138,7 @@ struct NewsItem {
 
 	std::unique_ptr<const NewsAllocatedData> data; ///< Custom data for the news item that will be deallocated (deleted) when the news item has reached its end.
 
-	uint64 params[10]; ///< Parameters for string resolving.
+	std::vector<StringParameterBackup> params; ///< Parameters for string resolving.
 
 	NewsItem(StringID string_id, NewsType type, NewsFlag flags, NewsReferenceType reftype1, uint32 ref1, NewsReferenceType reftype2, uint32 ref2, const NewsAllocatedData *data);
 };

--- a/src/statusbar_gui.cpp
+++ b/src/statusbar_gui.cpp
@@ -39,7 +39,7 @@
 
 static bool DrawScrollingStatusText(const NewsItem *ni, int scroll_pos, int left, int right, int top, int bottom)
 {
-	CopyInDParam(ni->params, lengthof(ni->params));
+	CopyInDParam(ni->params);
 
 	/* Replace newlines and the likes with spaces. */
 	std::string message = StrMakeValid(GetString(ni->string_id), SVS_REPLACE_TAB_CR_NL_WITH_SPACE);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -197,6 +197,56 @@ void CopyOutDParam(uint64 *dst, const char **strings, StringID string, int num)
 	}
 }
 
+/**
+ * Copy the parameters from the backup into the global string parameter array.
+ * @param backup The backup to copy from.
+ */
+void CopyInDParam(const span<const StringParameterBackup> backup)
+{
+	for (size_t i = 0; i < backup.size(); i++) {
+		auto &value = backup[i];
+		if (value.string.has_value()) {
+			_global_string_params.SetParam(i, value.string.value());
+		} else {
+			_global_string_params.SetParam(i, value.data);
+		}
+	}
+}
+
+/**
+ * Copy \a num string parameters from the global string parameter array to the \a backup.
+ * @param backup The backup to write to.
+ * @param num Number of string parameters to copy.
+ */
+void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num)
+{
+	backup.resize(num);
+	for (size_t i = 0; i < backup.size(); i++) {
+		backup[i] = _global_string_params.GetParam(i);
+	}
+}
+
+/**
+ * Copy \a num string parameters from the global string parameter array to the \a backup.
+ * @param backup The backup to write to.
+ * @param num Number of string parameters to copy.
+ * @param string The string used to determine where raw strings are and where there are no raw strings.
+ */
+void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num, StringID string)
+{
+	/* Just get the string to extract the type information. */
+	GetString(string);
+
+	backup.resize(num);
+	for (size_t i = 0; i < backup.size(); i++) {
+		if (_global_string_params.GetTypeAtOffset(i) == SCC_RAW_STRING_POINTER) {
+			backup[i] = (const char *)(size_t)_global_string_params.GetParam(i);
+		} else {
+			backup[i] = _global_string_params.GetParam(i);
+		}
+	}
+}
+
 static void StationGetSpecialString(StringBuilder &builder, StationFacility x);
 static void GetSpecialTownNameString(StringBuilder &builder, int ind, uint32 seed);
 static void GetSpecialNameString(StringBuilder &builder, int ind, StringParameters &args);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -154,50 +154,6 @@ void SetDParamMaxDigits(size_t n, uint count, FontSize size)
 }
 
 /**
- * Copy \a num string parameters from array \a src into the global string parameter array.
- * @param src  Source array of string parameters.
- * @param num  Number of string parameters to copy.
- */
-void CopyInDParam(const uint64 *src, int num)
-{
-	for (int i = 0; i < num; i++) SetDParam(i, src[i]);
-}
-
-/**
- * Copy \a num string parameters from the global string parameter array to the \a dst array.
- * @param dst  Destination array of string parameters.
- * @param num  Number of string parameters to copy.
- */
-void CopyOutDParam(uint64 *dst, int num)
-{
-	for (int i = 0; i < num; i++) dst[i] = GetDParam(i);
-}
-
-/**
- * Copy \a num string parameters from the global string parameter array to the \a dst array.
- * Furthermore clone raw string parameters into \a strings and amend the data in \a dst.
- * @param dst     Destination array of string parameters.
- * @param strings Destination array for clone of the raw strings. Must be of same length as dst. Deallocation left to the caller.
- * @param string  The string used to determine where raw strings are and where there are no raw strings.
- * @param num     Number of string parameters to copy.
- */
-void CopyOutDParam(uint64 *dst, const char **strings, StringID string, int num)
-{
-	/* Just get the string to extract the type information. */
-	GetString(string);
-
-	for (int i = 0; i < num; i++) {
-		if (_global_string_params.GetTypeAtOffset(i) == SCC_RAW_STRING_POINTER) {
-			strings[i] = stredup((const char *)(size_t)_global_string_params.GetParam(i));
-			dst[i] = (size_t)strings[i];
-		} else {
-			strings[i] = nullptr;
-			dst[i] = _global_string_params.GetParam(i);
-		}
-	}
-}
-
-/**
  * Copy the parameters from the backup into the global string parameter array.
  * @param backup The backup to copy from.
  */

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -86,10 +86,6 @@ void SetDParamStr(size_t n, const char *str);
 void SetDParamStr(size_t n, const std::string &str);
 void SetDParamStr(size_t n, std::string &&str) = delete; // block passing temporaries to SetDParamStr
 
-void CopyInDParam(const uint64 *src, int num);
-void CopyOutDParam(uint64 *dst, int num);
-void CopyOutDParam(uint64 *dst, const char **strings, StringID string, int num);
-
 void CopyInDParam(const span<const StringParameterBackup> backup);
 void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num);
 void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num, StringID string);

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -14,6 +14,7 @@
 #include "string_type.h"
 #include "gfx_type.h"
 #include "core/bitmath_func.hpp"
+#include "core/span_type.hpp"
 #include "vehicle_type.h"
 
 /**
@@ -88,6 +89,10 @@ void SetDParamStr(size_t n, std::string &&str) = delete; // block passing tempor
 void CopyInDParam(const uint64 *src, int num);
 void CopyOutDParam(uint64 *dst, int num);
 void CopyOutDParam(uint64 *dst, const char **strings, StringID string, int num);
+
+void CopyInDParam(const span<const StringParameterBackup> backup);
+void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num);
+void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num, StringID string);
 
 uint64_t GetDParam(size_t n);
 

--- a/src/strings_type.h
+++ b/src/strings_type.h
@@ -88,4 +88,34 @@ enum SpecialStrings {
 	SPECSTR_PRESIDENT_NAME     = 0x70E7,
 };
 
+/** Data that is to be stored when backing up StringParameters. */
+struct StringParameterBackup {
+	uint64_t data; ///< The data field; valid *when* string has no value.
+	std::optional<std::string> string; ///< The string value.
+
+	/**
+	 * Assign the numeric data with the given value, while clearing the stored string.
+	 * @param data The new value of the data field.
+	 * @return This object.
+	 */
+	StringParameterBackup &operator=(uint64_t data)
+	{
+		this->string.reset();
+		this->data = data;
+		return *this;
+	}
+
+	/**
+	 * Assign a copy of the given string to the string field, while clearing the data field.
+	 * @param string The new value of the string.
+	 * @return This object.
+	 */
+	StringParameterBackup &operator=(const std::string_view string)
+	{
+		this->data = 0;
+		this->string.emplace(string);
+		return *this;
+	}
+};
+
 #endif /* STRINGS_TYPE_H */


### PR DESCRIPTION
## Motivation / Problem

Use of two or three parameters to retain the backup, and as such making it harder to generalize.
Furthermore the use of `stredup` and the associated manual memory management.


## Description

Add StringParameterBackup struct that contains either a `uint64_t` or `std::string`, a `std::vector` for it and the needed functions for it to create a backup or restore it.
Convert the different users of the parameter backups to the new type/functions.
Remove the old functions.


## Limitations

None that I can think of, except a bit more memory usage. But in the end, when next PRs get merged safer and simpler code differentiating between strings and integers.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
