### PR TITLE
Codechange: use std::string over stredup/strecpy

### DIFF
--- a/src/music/extmidi.h
+++ b/src/music/extmidi.h
@@ -14,8 +14,8 @@
 
 class MusicDriver_ExtMidi : public MusicDriver {
 private:
-	char **params;
-	char song[MAX_PATH];
+	std::vector<std::string> command_tokens;
+	std::string song;
 	pid_t pid;
 
 	void DoPlay();


### PR DESCRIPTION
## Motivation / Problem

One of the last users of `stredup` and `strecpy`, and further using `CallocT` for manual memory management.


## Description

Replace `strecpy`/`stredup`/`CallocT` with `std::string`/`std::vector`.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
