### PR TITLE
Codechange: improve name of method and reduce casting

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -72,26 +72,28 @@ void StringParameters::PrepareForNextRun()
 
 
 /**
- * Read an int64 from the argument array. The offset is increased
- * so the next time GetInt64 is called the next value is read.
+ * Get the next parameter from our parameters.
+ * This updates the offset, so the next time this is called the next parameter
+ * will be read.
+ * @return The pointer to the next parameter.
  */
-int64 StringParameters::GetInt64()
+StringParameter *StringParameters::GetNextParameterPointer()
 {
 	assert(this->next_type == 0 || (SCC_CONTROL_START <= this->next_type && this->next_type <= SCC_CONTROL_END));
 	if (this->offset >= this->parameters.size()) {
 		Debug(misc, 0, "Trying to read invalid string parameter");
-		return 0;
+		return nullptr;
 	}
 
 	auto &param = this->parameters[this->offset++];
 	if (param.type != 0 && param.type != this->next_type) {
 		Debug(misc, 0, "Trying to read string parameter with wrong type");
 		this->next_type = 0;
-		return 0;
+		return nullptr;
 	}
-	param.type = next_type;
+	param.type = this->next_type;
 	this->next_type = 0;
-	return param.data;
+	return &param;
 }
 
 

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -32,6 +32,8 @@ protected:
 		parameters(parameters)
 	{}
 
+	StringParameter *GetNextParameterPointer();
+
 public:
 	/**
 	 * Create a new StringParameters instance that can reference part of the data of
@@ -77,12 +79,28 @@ public:
 		this->offset = offset;
 	}
 
-	int64 GetInt64();
+	/**
+	 * Get the next parameter from our parameters.
+	 * This updates the offset, so the next time this is called the next parameter
+	 * will be read.
+	 * @return The next parameter's value.
+	 */
+	template <typename T>
+	T GetNextParameter()
+	{
+		auto ptr = GetNextParameterPointer();
+		return static_cast<T>(ptr == nullptr ? 0 : ptr->data);
+	}
+
+	int64 GetInt64()
+	{
+		return GetNextParameter<int64_t>();
+	}
 
 	/** Read an int32 from the argument array. @see GetInt64. */
 	int32 GetInt32()
 	{
-		return (int32)this->GetInt64();
+		return GetNextParameter<int32_t>();
 	}
 
 	/**

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -92,17 +92,6 @@ public:
 		return static_cast<T>(ptr == nullptr ? 0 : ptr->data);
 	}
 
-	int64 GetInt64()
-	{
-		return GetNextParameter<int64_t>();
-	}
-
-	/** Read an int32 from the argument array. @see GetInt64. */
-	int32 GetInt32()
-	{
-		return GetNextParameter<int32_t>();
-	}
-
 	/**
 	 * Get a new instance of StringParameters that is a "range" into the
 	 * remaining existing parameters. Upon destruction the offset in the parent


### PR DESCRIPTION
## Motivation / Problem

There is a `GetInt64` and `GetInt32` function in `StringParameters`. From the name it's immediately not obvious that it changes the state within the object. Also many places cast to another type after calling either `GetInt32` or `GetInt64`.


## Description

Split the offset updating and type validation from the actual returning of the data, so only the actual returning of the data needs to be duplicated.

Rename `GetInt64`/`GetInt32` to `GetNextParameter` to more clearly show it has side effects, but also template the expected return type so there is no need to cast after calling `GetNextParameter`. Something which happened relatively often.
While doing this, also improve the returned types to what is actually used.

Remove the old `GetInt64`/`GetInt32`.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
