### PR TITLE
Codechange: simplify string formatting for the viewport

### DIFF
--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -126,7 +126,9 @@ void DrawTextEffects(DrawPixelInfo *dpi)
 	for (TextEffect &te : _text_effects) {
 		if (te.string_id == INVALID_STRING_ID) continue;
 		if (te.mode == TE_RISING || (_settings_client.gui.loading_indicators && !IsTransparencySet(TO_LOADING))) {
-			ViewportAddString(dpi, ZOOM_LVL_OUT_8X, &te, te.string_id, te.string_id - 1, STR_NULL, te.params_1, te.params_2);
+			SetDParam(0, te.params_1);
+			SetDParam(1, te.params_2);
+			ViewportAddString(dpi, ZOOM_LVL_OUT_8X, &te, te.string_id, te.string_id - 1, STR_NULL);
 		}
 	}
 }

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1417,6 +1417,9 @@ static void ViewportAddKdtreeSigns(DrawPixelInfo *dpi)
 			t->index, t->cache.population);
 	}
 
+	/* Do not draw signs nor station names if they are set invisible */
+	if (IsInvisibilitySet(TO_SIGNS)) return;
+
 	for (const auto *si : signs) {
 		ViewportAddString(dpi, ZOOM_LVL_OUT_16X, &si->sign,
 			STR_WHITE_SIGN,
@@ -1701,9 +1704,6 @@ static void ViewportDrawStrings(ZoomLevel zoom, const StringSpriteToDrawVector *
 		SetDParam(1, ss.params[1]);
 
 		if (ss.colour != INVALID_COLOUR) {
-			/* Do not draw signs nor station names if they are set invisible */
-			if (IsInvisibilitySet(TO_SIGNS) && ss.string != STR_WHITE_SIGN) continue;
-
 			if (IsTransparencySet(TO_SIGNS) && ss.string != STR_WHITE_SIGN) {
 				/* Don't draw the rectangle.
 				 * Real colours need the TC_IS_PALETTE_COLOUR flag.

--- a/src/viewport_func.h
+++ b/src/viewport_func.h
@@ -53,7 +53,7 @@ void DrawGroundSprite(SpriteID image, PaletteID pal, const SubSprite *sub = null
 void DrawGroundSpriteAt(SpriteID image, PaletteID pal, int32 x, int32 y, int z, const SubSprite *sub = nullptr, int extra_offs_x = 0, int extra_offs_y = 0);
 void AddSortableSpriteToDraw(SpriteID image, PaletteID pal, int x, int y, int w, int h, int dz, int z, bool transparent = false, int bb_offset_x = 0, int bb_offset_y = 0, int bb_offset_z = 0, const SubSprite *sub = nullptr);
 void AddChildSpriteScreen(SpriteID image, PaletteID pal, int x, int y, bool transparent = false, const SubSprite *sub = nullptr, bool scale = true, bool relative = true);
-void ViewportAddString(const DrawPixelInfo *dpi, ZoomLevel small_from, const ViewportSign *sign, StringID string_normal, StringID string_small, StringID string_small_shadow, uint64 params_1, uint64 params_2 = 0, Colours colour = INVALID_COLOUR);
+void ViewportAddString(const DrawPixelInfo *dpi, ZoomLevel small_from, const ViewportSign *sign, StringID string_normal, StringID string_small, StringID string_small_shadow, Colours colour = INVALID_COLOUR);
 
 
 void StartSpriteCombine();


### PR DESCRIPTION
## Motivation / Problem

Passing `param_1` and `param_2` around through all kinds of functions to be able to draw something onto the viewport, instead of just resolving the string and drawing that when needed.
Trying to go through the string drawing for signs when signs are set to be invisible.


## Description

There is a function that loops through the signs and stations to see whether they are within the bounding box of the viewport, to add them to a collection of strings to draw on the viewport. When finally drawing it determines whether they should be drawn or not. Just move this check to just before looping through the signs and stations, thus preventing some calculations.

Instead of passing string parameters via `param_1` and `param_2` parameters, just set them via `SetDParam` and resolve the string when the determination is made that the string should be shown, and use that string to actually draw on the viewport. The allocation of the string doesn't impact the performance, because the `StringID` variant of the function just does `GetString` anyway, and as such it saves copying `param_1` and `param_2` around.

Doing it this way will also make it immediately possible to pass more parameters if needed, or pass string parameters as it's not custom code anymore but the main string formatting code that is used.


## Limitations

None that I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
