### PR TITLE
Remove: support for not having getifaddrs

### DIFF
--- a/src/network/core/host.cpp
+++ b/src/network/core/host.cpp
@@ -21,25 +21,7 @@
  */
 static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast);
 
-#if defined(HAVE_GETIFADDRS)
-static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // GETIFADDRS implementation
-{
-	struct ifaddrs *ifap, *ifa;
-
-	if (getifaddrs(&ifap) != 0) return;
-
-	for (ifa = ifap; ifa != nullptr; ifa = ifa->ifa_next) {
-		if (!(ifa->ifa_flags & IFF_BROADCAST)) continue;
-		if (ifa->ifa_broadaddr == nullptr) continue;
-		if (ifa->ifa_broadaddr->sa_family != AF_INET) continue;
-
-		NetworkAddress addr(ifa->ifa_broadaddr, sizeof(sockaddr));
-		if (std::none_of(broadcast->begin(), broadcast->end(), [&addr](NetworkAddress const& elem) -> bool { return elem == addr; })) broadcast->push_back(addr);
-	}
-	freeifaddrs(ifap);
-}
-
-#elif defined(_WIN32)
+#ifdef _WIN32
 static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // Win32 implementation
 {
 	SOCKET sock = socket(AF_INET, SOCK_DGRAM, 0);
@@ -77,48 +59,22 @@ static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // Wi
 	closesocket(sock);
 }
 
-#else /* not HAVE_GETIFADDRS */
-
-#include "../../string_func.h"
-
-static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // !GETIFADDRS implementation
+#else /* not WIN32 */
+static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast)
 {
-	SOCKET sock = socket(AF_INET, SOCK_DGRAM, 0);
-	if (sock == INVALID_SOCKET) return;
+	struct ifaddrs *ifap, *ifa;
 
-	char buf[4 * 1024]; // Arbitrary buffer size
-	struct ifconf ifconf;
+	if (getifaddrs(&ifap) != 0) return;
 
-	ifconf.ifc_len = sizeof(buf);
-	ifconf.ifc_buf = buf;
-	if (ioctl(sock, SIOCGIFCONF, &ifconf) == -1) {
-		closesocket(sock);
-		return;
+	for (ifa = ifap; ifa != nullptr; ifa = ifa->ifa_next) {
+		if (!(ifa->ifa_flags & IFF_BROADCAST)) continue;
+		if (ifa->ifa_broadaddr == nullptr) continue;
+		if (ifa->ifa_broadaddr->sa_family != AF_INET) continue;
+
+		NetworkAddress addr(ifa->ifa_broadaddr, sizeof(sockaddr));
+		if (std::none_of(broadcast->begin(), broadcast->end(), [&addr](NetworkAddress const& elem) -> bool { return elem == addr; })) broadcast->push_back(addr);
 	}
-
-	const char *buf_end = buf + ifconf.ifc_len;
-	for (const char *p = buf; p < buf_end;) {
-		const struct ifreq *req = (const struct ifreq*)p;
-
-		if (req->ifr_addr.sa_family == AF_INET) {
-			struct ifreq r;
-
-			strecpy(r.ifr_name, req->ifr_name, lastof(r.ifr_name));
-			if (ioctl(sock, SIOCGIFFLAGS, &r) != -1 &&
-					(r.ifr_flags & IFF_BROADCAST) &&
-					ioctl(sock, SIOCGIFBRDADDR, &r) != -1) {
-				NetworkAddress addr(&r.ifr_broadaddr, sizeof(sockaddr));
-				if (std::none_of(broadcast->begin(), broadcast->end(), [&addr](NetworkAddress const& elem) -> bool { return elem == addr; })) broadcast->push_back(addr);
-			}
-		}
-
-		p += sizeof(struct ifreq);
-#if defined(AF_LINK) && !defined(SUNOS)
-		p += req->ifr_addr.sa_len - sizeof(struct sockaddr);
-#endif
-	}
-
-	closesocket(sock);
+	freeifaddrs(ifap);
 }
 #endif /* all NetworkFindBroadcastIPsInternals */
 

--- a/src/network/core/os_abstraction.h
+++ b/src/network/core/os_abstraction.h
@@ -78,15 +78,7 @@ typedef unsigned long in_addr_t;
 #	include <netinet/tcp.h>
 #	include <arpa/inet.h>
 #	include <net/if.h>
-/* According to glibc/NEWS, <ifaddrs.h> appeared in glibc-2.3. */
-#	if !defined(__sgi__) && !defined(SUNOS) \
-	   && !(defined(__GLIBC__) && (__GLIBC__ <= 2) && (__GLIBC_MINOR__ <= 2)) && !defined(__dietlibc__) && !defined(HPUX)
-/* If for any reason ifaddrs.h does not exist on your system, comment out
- *   the following two lines and an alternative way will be used to fetch
- *   the list of IPs from the system. */
-#		include <ifaddrs.h>
-#		define HAVE_GETIFADDRS
-#	endif
+#	include <ifaddrs.h>
 #	if !defined(INADDR_NONE)
 #		define INADDR_NONE 0xffffffff
 #	endif


### PR DESCRIPTION
## Motivation / Problem

The existence of `strecpy` that I would like to get rid of motivated me to look into the need for the alternative for `getifaddrs`.

According to the code `getifaddrs` is not supported:
* on `__sgi__`: does not exist since 2009? Since 2012 not supported by GCC, so doubtful there is any C++17 support;
* on SUNOS (i.e. Solaris): is supported since 11.0 (2011); Sun/Oracle's compiler doesn't support any C++17;
* with glibc < 2.3: so supported since 2004; 2.16 adding C11 support, which libstdc++ for C++17 seems to require;
* on HP-UX: cmake does not support HP-UX since 3.10 since HP-UX does not support C++11;
* with dietlibc: does not support the C++ part of the library we need.

So... the code seems totally redundant unless we want to go back to pre-C11.


## Description

Remove the `#ifdef`-branch for not having `getifaddrs`. To make the `#ifdef` sane I had to swap the `#ifdef _WIN32` and the 'has getifaddrs' branch.


## Limitations

None that I can think of. Though arguably more can be removed in other places, but that's in my opinion out of scope for what I'm trying to achieve here.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
