### PR TITLE
Fix: Layouter reverse-mapping to characters

### DIFF
--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -207,6 +207,19 @@ Dimension Layouter::GetBounds()
 }
 
 /**
+ * Test whether a character is a non-printable formatting code
+ */
+static bool IsConsumedFormattingCode(WChar ch)
+{
+	if (ch >= SCC_BLUE && ch <= SCC_BLACK) return true;
+	if (ch == SCC_PUSH_COLOUR) return true;
+	if (ch == SCC_POP_COLOUR) return true;
+	if (ch >= SCC_FIRST_FONT && ch <= SCC_LAST_FONT) return true;
+	// All other characters defined in Unicode standard are assumed to be non-consumed.
+	return false;
+}
+
+/**
  * Get the position of a character in the layout.
  * @param ch Character to get the position of. Must be an iterator of the string passed to the constructor.
  * @return Upper left corner of the character relative to the start of the string.
@@ -228,7 +241,7 @@ Point Layouter::GetCharPosition(std::string_view::const_iterator ch) const
 	auto str = this->string.begin();
 	while (str < ch) {
 		WChar c = Utf8Consume(str);
-		index += line->GetInternalCharLength(c);
+		if (!IsConsumedFormattingCode(c)) index += line->GetInternalCharLength(c);
 	}
 
 	/* We couldn't find the code point index. */
@@ -282,7 +295,7 @@ ptrdiff_t Layouter::GetCharAtPosition(int x) const
 					if (cur_idx == index) return str - this->string.begin();
 
 					WChar c = Utf8Consume(str);
-					cur_idx += line->GetInternalCharLength(c);
+					if (!IsConsumedFormattingCode(c)) cur_idx += line->GetInternalCharLength(c);
 				}
 			}
 		}


### PR DESCRIPTION
## Motivation / Problem

Mapping back from a glyph to a character index in the source string should work, even with multiple run and when formatting codes are involved.

## Description

Have visual runs keep track of their offsets in the input text.
Count formatting codes the same way in both forward and reverse mapping.

## Limitations

Not thoroughly tested recently, but this fixed something when I was working on #7786 originally. (Reverse-mapping is relevant for hit-testing mouse clicks against individual character glyphs.)


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
