### PR TITLE
Codechange: Use std::optional for GRFConfig::GRFError

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -447,12 +447,11 @@ static GRFError *DisableGrf(StringID message = STR_NULL, GRFConfig *config = nul
 	if (file != nullptr) ClearTemporaryNewGRFData(file);
 	if (config == _cur.grfconfig) _cur.skip_sprites = -1;
 
-	if (message != STR_NULL) {
-		config->error = std::make_unique<GRFError>(STR_NEWGRF_ERROR_MSG_FATAL, message);
-		if (config == _cur.grfconfig) config->error->param_value[0] = _cur.nfo_line;
-	}
+	if (message == STR_NULL) return nullptr;
 
-	return config->error.get();
+	config->error = {STR_NEWGRF_ERROR_MSG_FATAL, message};
+	if (config == _cur.grfconfig) config->error->param_value[0] = _cur.nfo_line;
+	return &config->error.value();
 }
 
 /**
@@ -7154,10 +7153,10 @@ static void GRFLoadError(ByteReader *buf)
 	}
 
 	/* For now we can only show one message per newgrf file. */
-	if (_cur.grfconfig->error != nullptr) return;
+	if (_cur.grfconfig->error.has_value()) return;
 
-	_cur.grfconfig->error = std::make_unique<GRFError>(sevstr[severity]);
-	GRFError *error = _cur.grfconfig->error.get();
+	_cur.grfconfig->error = {sevstr[severity]};
+	GRFError *error = &_cur.grfconfig->error.value();
 
 	if (message_id == 0xFF) {
 		/* This is a custom error message. */
@@ -10006,7 +10005,7 @@ void LoadNewGRF(uint load_index, uint num_baseset)
 				if (num_non_static == NETWORK_MAX_GRF_COUNT) {
 					Debug(grf, 0, "'{}' is not loaded as the maximum number of non-static GRFs has been reached", c->filename);
 					c->status = GCS_DISABLED;
-					c->error  = std::make_unique<GRFError>(STR_NEWGRF_ERROR_MSG_FATAL, STR_NEWGRF_ERROR_TOO_MANY_NEWGRFS_LOADED);
+					c->error  = {STR_NEWGRF_ERROR_MSG_FATAL, STR_NEWGRF_ERROR_TOO_MANY_NEWGRFS_LOADED};
 					continue;
 				}
 				num_non_static++;

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -51,6 +51,7 @@ GRFConfig::GRFConfig(const GRFConfig &config) :
 	name(config.name),
 	info(config.info),
 	url(config.url),
+	error(config.error),
 	version(config.version),
 	min_loadable_version(config.min_loadable_version),
 	flags(config.flags & ~(1 << GCF_COPY)),
@@ -63,7 +64,6 @@ GRFConfig::GRFConfig(const GRFConfig &config) :
 	param_info(config.param_info),
 	has_param_defaults(config.has_param_defaults)
 {
-	if (config.error != nullptr) this->error = std::make_unique<GRFError>(*config.error);
 }
 
 /**
@@ -495,7 +495,7 @@ compatible_grf:
 				c->ident.md5sum = f->ident.md5sum;
 				c->name = f->name;
 				c->info = f->name;
-				c->error = nullptr;
+				c->error.reset();
 				c->version = f->version;
 				c->min_loadable_version = f->min_loadable_version;
 				c->num_valid_params = f->num_valid_params;

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -109,11 +109,11 @@ struct GRFIdentifier {
 struct GRFError {
 	GRFError(StringID severity, StringID message = 0);
 
-	std::string custom_message; ///< Custom message (if present)
-	std::string data;           ///< Additional data for message and custom_message
-	StringID message;           ///< Default message
-	StringID severity;          ///< Info / Warning / Error / Fatal
-	std::array<uint32_t, 2> param_value; ///< Values of GRF parameters to show for message and custom_message
+	std::string custom_message{}; ///< Custom message (if present)
+	std::string data{}; ///< Additional data for message and custom_message
+	StringID message{}; ///< Default message
+	StringID severity{}; ///< Info / Warning / Error / Fatal
+	std::array<uint32_t, 2> param_value{}; ///< Values of GRF parameters to show for message and custom_message
 };
 
 /** The possible types of a newgrf parameter. */
@@ -157,7 +157,7 @@ struct GRFConfig : ZeroedMemoryAllocator {
 	GRFTextWrapper name; ///< NOSAVE: GRF name (Action 0x08)
 	GRFTextWrapper info; ///< NOSAVE: GRF info (author, copyright, ...) (Action 0x08)
 	GRFTextWrapper url; ///< NOSAVE: URL belonging to this GRF.
-	std::unique_ptr<GRFError> error; ///< NOSAVE: Error/Warning during GRF loading (Action 0x0B)
+	std::optional<GRFError> error; ///< NOSAVE: Error/Warning during GRF loading (Action 0x0B)
 
 	uint32 version; ///< NOSAVE: Version a NewGRF can set so only the newest NewGRF is shown
 	uint32 min_loadable_version; ///< NOSAVE: Minimum compatible version a NewGRF can define

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -48,7 +48,7 @@ void ShowNewGRFError()
 
 	for (const GRFConfig *c = _grfconfig; c != nullptr; c = c->next) {
 		/* Only show Fatal and Error level messages */
-		if (c->error == nullptr || (c->error->severity != STR_NEWGRF_ERROR_MSG_FATAL && c->error->severity != STR_NEWGRF_ERROR_MSG_ERROR)) continue;
+		if (!c->error.has_value() || (c->error->severity != STR_NEWGRF_ERROR_MSG_FATAL && c->error->severity != STR_NEWGRF_ERROR_MSG_ERROR)) continue;
 
 		SetDParamStr(0, c->GetName());
 		SetDParam   (1, c->error->message != STR_NULL ? c->error->message : STR_JUST_RAW_STRING);
@@ -70,7 +70,7 @@ void ShowNewGRFError()
 static void ShowNewGRFInfo(const GRFConfig *c, const Rect &r, bool show_params)
 {
 	Rect tr = r.Shrink(WidgetDimensions::scaled.frametext);
-	if (c->error != nullptr) {
+	if (c->error.has_value()) {
 		SetDParamStr(0, c->error->custom_message); // is skipped by built-in messages
 		SetDParamStr(1, c->filename);
 		SetDParamStr(2, c->error->data);
@@ -886,8 +886,8 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 							}
 						}
 						DrawSprite(SPR_SQUARE, pal, square_left, tr.top + square_offset_y);
-						if (c->error != nullptr) DrawSprite(SPR_WARNING_SIGN, 0, warning_left, tr.top + warning_offset_y);
-						uint txtoffset = c->error == nullptr ? 0 : warning.width;
+						if (c->error.has_value()) DrawSprite(SPR_WARNING_SIGN, 0, warning_left, tr.top + warning_offset_y);
+						uint txtoffset = !c->error.has_value() ? 0 : warning.width;
 						DrawString(text_left + (rtl ? 0 : txtoffset), text_right - (rtl ? txtoffset : 0), tr.top + offset_y, text, h ? TC_WHITE : TC_ORANGE);
 						tr.top += step_height;
 					}


### PR DESCRIPTION
## Motivation / Problem

Copying a std::unique_ptr requires fiddly code to check if it is set, and then making a new copy.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Replace GRFConfig's `std::unique_ptr<GRFError>` with `std::optional<GRFError>`.

This changes the semantics from "object pointer ownership" to "optional object", and simplifies copies.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
