### PR TITLE
Fix #11067, ed83c4b: Don't start competitors during map generation

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -617,14 +617,6 @@ void StartupCompanies()
 {
 	/* Ensure the timeout is aborted, so it doesn't fire based on information of the last game. */
 	_new_competitor_timeout.Abort();
-
-	/* If there is no delay till the start of the next competitor, start all competitors at the start of the game. */
-	if (_settings_game.difficulty.competitors_interval == 0 && _game_mode != GM_MENU && AI::CanStartNew()) {
-		for (auto i = 0; i < _settings_game.difficulty.max_no_competitors; i++) {
-			if (_networking && Company::GetNumItems() >= _settings_client.network.max_companies) break;
-			Command<CMD_COMPANY_CTRL>::Post(CCA_NEW_AI, INVALID_COMPANY, CRR_NONE, INVALID_CLIENT_ID);
-		}
-	}
 }
 
 /** Initialize the pool of companies. */
@@ -726,9 +718,14 @@ void OnTick_Companies()
 
 	if (_new_competitor_timeout.HasFired() && _game_mode != GM_MENU && AI::CanStartNew()) {
 		int32_t timeout = _settings_game.difficulty.competitors_interval * 60 * TICKS_PER_SECOND;
-		/* If the interval is zero, check every ~10 minutes if a company went bankrupt and needs replacing. */
-		if (timeout == 0) timeout = 10 * 60 * TICKS_PER_SECOND;
-
+		/* If the interval is zero, start as many competitors as needed then check every ~10 minutes if a company went bankrupt and needs replacing. */
+		if (timeout == 0) {
+			for (auto i = 0; i < _settings_game.difficulty.max_no_competitors; i++) {
+				if (_networking && Company::GetNumItems() >= _settings_client.network.max_companies) break;
+				Command<CMD_COMPANY_CTRL>::Post(CCA_NEW_AI, INVALID_COMPANY, CRR_NONE, INVALID_CLIENT_ID);
+			}
+			timeout = 10 * 60 * TICKS_PER_SECOND;
+		}
 		/* Randomize a bit when the AI is actually going to start; ranges from 87.5% .. 112.5% of indicated value. */
 		timeout += ScriptObject::GetRandomizer(OWNER_NONE).Next(timeout / 4) - timeout / 8;
 


### PR DESCRIPTION
Fixes #11067.

## Motivation / Problem
When "Interval between starting of competitors" is 0, competitors are started during map generation while human company is started after map generation.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Start the competitors after map generation, and after human company startup.
I put the start in `OnTick_Companies()` because when game is just created the timer is fired which will immediately start as many AIs as needed and reset the timer for ~10 minutes. Then on timeout a new AI is started if needed and `OnTick_Companies()` will start the remaining as needed if more than one disappeared during the delay.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
