### PR TITLE
Cleanup: unused NO_THREADS #ifdefs

### DIFF
--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -20,6 +20,7 @@
 #include <sys/stat.h>
 #include <time.h>
 #include <signal.h>
+#include <pthread.h>
 
 #ifdef WITH_SDL2
 #include <SDL.h>
@@ -45,10 +46,6 @@
 
 #ifdef HAS_SYSCTL
 #include <sys/sysctl.h>
-#endif
-
-#ifndef NO_THREADS
-#include <pthread.h>
 #endif
 
 #if defined(__APPLE__)
@@ -258,11 +255,9 @@ void OSOpenBrowser(const char *url)
 #endif /* __APPLE__ */
 
 void SetCurrentThreadName(const char *threadName) {
-#if !defined(NO_THREADS) && defined(__GLIBC__)
-#if __GLIBC_PREREQ(2, 12)
+#if defined(__GLIBC__)
 	if (threadName) pthread_setname_np(pthread_self(), threadName);
-#endif /* __GLIBC_PREREQ(2, 12) */
-#endif /* !defined(NO_THREADS) && defined(__GLIBC__) */
+#endif /* defined(__GLIBC__) */
 #if defined(__APPLE__)
 	MacOSSetThreadName(threadName);
 #endif /* defined(__APPLE__) */

--- a/src/thread.h
+++ b/src/thread.h
@@ -45,7 +45,6 @@ void SetCurrentThreadName(const char *name);
 template<class TFn, class... TArgs>
 inline bool StartNewThread(std::thread *thr, const char *name, TFn&& _Fx, TArgs&&... _Ax)
 {
-#ifndef NO_THREADS
 	try {
 		static std::mutex thread_startup_mutex;
 		std::lock_guard<std::mutex> lock(thread_startup_mutex);
@@ -79,7 +78,6 @@ inline bool StartNewThread(std::thread *thr, const char *name, TFn&& _Fx, TArgs&
 		/* Something went wrong, the system we are running on might not support threads. */
 		Debug(misc, 1, "Can't create thread '{}': {}", name, e.what());
 	}
-#endif
 
 	return false;
 }


### PR DESCRIPTION
## Motivation / Problem

There are some NO_THREADS ifdefs that are never actually set. Furthermore I think the platforms without thread support that actually support C++17 are essentially non-existent.


## Description

Remove the NO_THREAD ifdefs, as well as the glibc > 2.12 check as glibc only supports C11 (and thus C++17) since after 2.16.
It does not touch the fallback to single-threadedness when creating a thread fails, nor does it touch the video driver parameters to use no threads.


## Limitations

People without thread support cannot build OpenTTD anymore, though std::thread is required for C++17 so it doesn't actually support C++17. They can just replace the `StartNewThread` function to just return `false` and still run without threads.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
