### PR TITLE
Changing exclusive transport rights

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3539,8 +3539,8 @@ STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_LARGE_ADVERTISING            :{PUSH_COLOUR}{Y
 STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_ROAD_RECONSTRUCTION          :{PUSH_COLOUR}{YELLOW}Fund the reconstruction of the urban road network.{}Causes considerable disruption to road traffic for up to 6 months.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
 STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_STATUE_OF_COMPANY            :{PUSH_COLOUR}{YELLOW}Build a statue in honour of your company.{}Provides a permanent boost to station rating in this town.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
 STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_NEW_BUILDINGS                :{PUSH_COLOUR}{YELLOW}Fund the construction of new buildings in the town.{}Provides a temporary boost to town growth in this town.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
-STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_EXCLUSIVE_TRANSPORT          :{PUSH_COLOUR}{YELLOW}Buy 1 year's exclusive transport rights in town.{}Town authority will not allow passengers and cargo to use your competitors' stations.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
-STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_BRIBE                        :{PUSH_COLOUR}{YELLOW}Bribe the local authority to increase your rating, at the risk of a severe penalty if caught.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
+STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_EXCLUSIVE_TRANSPORT          :{PUSH_COLOUR}{YELLOW}Buy 1 year's exclusive transport rights in town.{}Town authority will not allow passengers and cargo to use your competitors' stations. A successful bribe from a competitor will cancel this contract.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
+STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_BRIBE                        :{PUSH_COLOUR}{YELLOW}Bribe the local authority to increase your rating and abort a competitor's exclusive transport rights, at the risk of a severe penalty if caught.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
 
 # Goal window
 STR_GOALS_CAPTION                                               :{WHITE}{COMPANY} Goals

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -3242,6 +3242,7 @@ static CommandCost TownActionBuyRights(Town *t, DoCommandFlag flags)
 {
 	/* Check if it's allowed to buy the rights */
 	if (!_settings_game.economy.exclusive_rights) return CMD_ERROR;
+	if (t->exclusivity != INVALID_COMPANY) return CMD_ERROR;
 
 	if (flags & DC_EXEC) {
 		t->exclusive_counter = 12;
@@ -3292,6 +3293,10 @@ static CommandCost TownActionBribe(Town *t, DoCommandFlag flags)
 			}
 		} else {
 			ChangeTownRating(t, RATING_BRIBE_UP_STEP, RATING_BRIBE_MAXIMUM, DC_EXEC);
+			if (t->exclusivity != _current_company && t->exclusivity != INVALID_COMPANY) {
+				t->exclusivity = INVALID_COMPANY;
+				t->exclusive_counter = 0;
+			}
 		}
 	}
 	return CommandCost();
@@ -3334,7 +3339,7 @@ TownActions GetMaskOfTownActions(CompanyID cid, const Town *t)
 			if (cur == TACT_BRIBE && (!_settings_game.economy.bribe || t->ratings[cid] >= RATING_BRIBE_MAXIMUM)) continue;
 
 			/* Is the company not able to buy exclusive rights ? */
-			if (cur == TACT_BUY_RIGHTS && !_settings_game.economy.exclusive_rights) continue;
+			if (cur == TACT_BUY_RIGHTS && (!_settings_game.economy.exclusive_rights || t->exclusive_counter != 0)) continue;
 
 			/* Is the company not able to fund buildings ? */
 			if (cur == TACT_FUND_BUILDINGS && !_settings_game.economy.fund_buildings) continue;


### PR DESCRIPTION
## Motivation / Problem

As a relatively new player myself and in talks with very new players it's become evident that buying exclusive transport rights works very differently from the player expectation. The current behaviour is that exclusive rights can be bought while another company already has them, causing that company to lose them. The expectation is that buying exclusive transport rights for 12 months will ensure that your company indeed does have exclusive transport rights for 12 months.

In multiplayer games where exclusive rights are disabled, or where a social contract restricts this abuse, this change will have no impact. However, in more competitively inclined multiplayer games this change makes exclusive transport rights a more dynamic and balanced tool for both defensive and offensive play.

## Description

Two changes are made here:
* When a company has bought exclusive transport rights they can neither be extended by that company nor purchased by any other until the 12 month period is over.
* If a company currently own exclusive transport rights and some *other* company successfully bribes the local authority then the exclusive rights contract becomes void, making them available for purchase again.

In the current state a smaller company can never keep exclusive transport rights if a bigger company decides to have them. The bigger company will buy them back until the smaller company either gives up or becomes bankrupt. This means that buying exclusive transport rights is not a viable option for the smaller company neither to protect its own business nor to sabotage for a larger company.

With this change the smaller company can pre-emptively buy exclusive transport rights in its favoured town(s) knowing that the bigger company has to take the risk of being discovered paying bribes in order to gain a foothold in the market. The smaller company may also have an actual chance to inconvenience the larger company in towns where the latter has much business.

This new way of doing it also -- maybe most importantly -- makes the Buy exclusive transport rights functionality more intuitive. When you buy the rights you can expect to have the contract for 12 months. It doesn't make sense that the local authority would sign a deal with one actor and then wave that deal away and sign the same with some other actor the next moment; that's just not how contracts work. Unless foul play (i.e. bribery) is involved, of course.

## Limitations

Exclusive transport rights could work in a thousand different ways. This is one way of doing it. I stand by that this is a big improvement over the current functionality, but I don't believe it to be a perfect solution. Such a thing probably doesn't exist.

The descriptions for buying rights or bribing have not been updated. This should be done, but as the current description of the former already fails to set the correct expectation with players I haven't spent time on it for now.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
