### PR TITLE
Fix: select wants a count, not FD of STDIN + 1

### DIFF
--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -162,7 +162,7 @@ static bool InputWaiting()
 	FD_SET(STDIN, &readfds);
 
 	/* don't care about writefds and exceptfds: */
-	return select(STDIN + 1, &readfds, nullptr, nullptr, &tv) > 0;
+	return select(1, &readfds, nullptr, nullptr, &tv) > 0;
 }
 
 #else


### PR DESCRIPTION
## Motivation / Problem

Looking at code and wondering why `select` should get `STDIN + 1`.

It coincidentally works because `STDIN` is defined as `0`, but `select` specifies the parameter as number of file descriptors. But if someone were to change it to any other file descriptor, this would not work anymore.


## Description

Just pass `1` instead of `STDIN + 1`.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
