### PR TITLE
Codechange: use SignalObjectAndWait since we do not support older than Windows XP

### DIFF
--- a/src/sound/win32_s.cpp
+++ b/src/sound/win32_s.cpp
@@ -98,8 +98,7 @@ void SoundDriver_Win32::Stop()
 
 	/* Stop the sound thread. */
 	_waveout = nullptr;
-	SetEvent(_event);
-	WaitForSingleObject(_thread, INFINITE);
+	SignalObjectAndWait(_event, _thread, INFINITE, FALSE);
 
 	/* Close the sound device. */
 	waveOutReset(waveout);

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -64,10 +64,8 @@ static void WINAPI CheckForConsoleInput()
 		if (nb >= lengthof(_win_console_thread_buffer)) nb = lengthof(_win_console_thread_buffer) - 1;
 		_win_console_thread_buffer[nb] = '\0';
 
-		/* Signal input waiting that input is read and wait for it being handled
-		 * SignalObjectAndWait() should be used here, but it's unsupported in Win98< */
-		SetEvent(_hInputReady);
-		WaitForSingleObject(_hWaitForInputHandling, INFINITE);
+		/* Signal input waiting that input is read and wait for it being handled. */
+		SignalObjectAndWait(_hInputReady, _hWaitForInputHandling, INFINITE, FALSE);
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem

Reading `SignalObjectAndWait() should be used here, but it's unsupported in Win98<` and thinking... we do not even support old Windows XPs, so why would we need to retain support for Win9x?


## Description

Apply suggestion.


## Limitations

None that I am aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
