### PR TITLE
Codechange: let IConsoleCmdExec accept std::string

### DIFF
--- a/src/console.cpp
+++ b/src/console.cpp
@@ -225,7 +225,7 @@ static void IConsoleAliasExec(const IConsoleAlias *alias, byte tokencount, char 
 				break;
 
 			case ';': // Cmd separator; execute previous and start new command
-				IConsoleCmdExec(alias_buffer.c_str(), recurse_count);
+				IConsoleCmdExec(alias_buffer, recurse_count);
 
 				alias_buffer.clear();
 
@@ -283,15 +283,15 @@ static void IConsoleAliasExec(const IConsoleAlias *alias, byte tokencount, char 
 		}
 	}
 
-	IConsoleCmdExec(alias_buffer.c_str(), recurse_count);
+	IConsoleCmdExec(alias_buffer, recurse_count);
 }
 
 /**
  * Execute a given command passed to us. First chop it up into
  * individual tokens (separated by spaces), then execute it if possible
- * @param cmdstr string to be parsed and executed
+ * @param command_string string to be parsed and executed
  */
-void IConsoleCmdExec(const char *cmdstr, const uint recurse_count)
+void IConsoleCmdExec(const std::string &command_string, const uint recurse_count)
 {
 	const char *cmdptr;
 	char *tokens[ICON_TOKEN_COUNT], tokenstream[ICON_MAX_STREAMSIZE];
@@ -300,16 +300,16 @@ void IConsoleCmdExec(const char *cmdstr, const uint recurse_count)
 	bool longtoken = false;
 	bool foundtoken = false;
 
-	if (cmdstr[0] == '#') return; // comments
+	if (command_string[0] == '#') return; // comments
 
-	for (cmdptr = cmdstr; *cmdptr != '\0'; cmdptr++) {
+	for (cmdptr = command_string.c_str(); *cmdptr != '\0'; cmdptr++) {
 		if (!IsValidChar(*cmdptr, CS_ALPHANUMERAL)) {
-			IConsolePrint(CC_ERROR, "Command '{}' contains malformed characters.", cmdstr);
+			IConsolePrint(CC_ERROR, "Command '{}' contains malformed characters.", command_string);
 			return;
 		}
 	}
 
-	Debug(console, 4, "Executing cmdline: '{}'", cmdstr);
+	Debug(console, 4, "Executing cmdline: '{}'", command_string);
 
 	memset(&tokens, 0, sizeof(tokens));
 	memset(&tokenstream, 0, sizeof(tokenstream));
@@ -317,7 +317,7 @@ void IConsoleCmdExec(const char *cmdstr, const uint recurse_count)
 	/* 1. Split up commandline into tokens, separated by spaces, commands
 	 * enclosed in "" are taken as one token. We can only go as far as the amount
 	 * of characters in our stream or the max amount of tokens we can handle */
-	for (cmdptr = cmdstr, t_index = 0, tstream_i = 0; *cmdptr != '\0'; cmdptr++) {
+	for (cmdptr = command_string.c_str(), t_index = 0, tstream_i = 0; *cmdptr != '\0'; cmdptr++) {
 		if (tstream_i >= lengthof(tokenstream)) {
 			IConsolePrint(CC_ERROR, "Command line too long.");
 			return;

--- a/src/console_func.h
+++ b/src/console_func.h
@@ -47,7 +47,7 @@ static inline void IConsolePrint(TextColour colour_code, const T &format, A firs
 }
 
 /* Parser */
-void IConsoleCmdExec(const char *cmdstr, const uint recurse_count = 0);
+void IConsoleCmdExec(const std::string &command_string, const uint recurse_count = 0);
 
 bool IsValidConsoleColour(TextColour c);
 

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -501,7 +501,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_RCON(Packet *p)
 	Debug(net, 3, "[admin] Rcon command from '{}' ({}): {}", this->admin_name, this->admin_version, command);
 
 	_redirect_console_to_admin = this->index;
-	IConsoleCmdExec(command.c_str());
+	IConsoleCmdExec(command);
 	_redirect_console_to_admin = INVALID_ADMIN_ID;
 	return this->SendRconEnd(command);
 }

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1402,7 +1402,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_RCON(Packet *p)
 	Debug(net, 3, "[rcon] Client-id {} executed: {}", this->client_id, command);
 
 	_redirect_console_to_client = this->client_id;
-	IConsoleCmdExec(command.c_str());
+	IConsoleCmdExec(command);
 	_redirect_console_to_client = INVALID_CLIENT_ID;
 	return NETWORK_RECV_STATUS_OKAY;
 }


### PR DESCRIPTION
## Motivation / Problem

`.c_str()` in a few places when calling `IConsoleCmdExec`.


## Description

Change the parameter from `const char *` to `const std::string &`.


## Limitations

The internals of `IConsoleCmdExec` have not been updated to C++ string functions; that is something to do at a later moment. It does mean some `.c_str()`s within that function though. There is a net reduction in number of `.c_str()` calls in the code base though.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
