### PR TITLE
Codechange: introduce new type and functions for StringParameter backups

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -197,6 +197,56 @@ void CopyOutDParam(uint64 *dst, const char **strings, StringID string, int num)
 	}
 }
 
+/**
+ * Copy the parameters from the backup into the global string parameter array.
+ * @param backup The backup to copy from.
+ */
+void CopyInDParam(const span<const StringParameterBackup> backup)
+{
+	for (size_t i = 0; i < backup.size(); i++) {
+		auto &value = backup[i];
+		if (value.string.has_value()) {
+			_global_string_params.SetParam(i, value.string.value());
+		} else {
+			_global_string_params.SetParam(i, value.data);
+		}
+	}
+}
+
+/**
+ * Copy \a num string parameters from the global string parameter array to the \a backup.
+ * @param backup The backup to write to.
+ * @param num Number of string parameters to copy.
+ */
+void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num)
+{
+	backup.resize(num);
+	for (size_t i = 0; i < backup.size(); i++) {
+		backup[i] = _global_string_params.GetParam(i);
+	}
+}
+
+/**
+ * Copy \a num string parameters from the global string parameter array to the \a backup.
+ * @param backup The backup to write to.
+ * @param num Number of string parameters to copy.
+ * @param string The string used to determine where raw strings are and where there are no raw strings.
+ */
+void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num, StringID string)
+{
+	/* Just get the string to extract the type information. */
+	GetString(string);
+
+	backup.resize(num);
+	for (size_t i = 0; i < backup.size(); i++) {
+		if (_global_string_params.GetTypeAtOffset(i) == SCC_RAW_STRING_POINTER) {
+			backup[i] = (const char *)(size_t)_global_string_params.GetParam(i);
+		} else {
+			backup[i] = _global_string_params.GetParam(i);
+		}
+	}
+}
+
 static void StationGetSpecialString(StringBuilder &builder, StationFacility x);
 static void GetSpecialTownNameString(StringBuilder &builder, int ind, uint32 seed);
 static void GetSpecialNameString(StringBuilder &builder, int ind, StringParameters &args);

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -14,6 +14,7 @@
 #include "string_type.h"
 #include "gfx_type.h"
 #include "core/bitmath_func.hpp"
+#include "core/span_type.hpp"
 #include "vehicle_type.h"
 
 /**
@@ -88,6 +89,10 @@ void SetDParamStr(size_t n, std::string &&str) = delete; // block passing tempor
 void CopyInDParam(const uint64 *src, int num);
 void CopyOutDParam(uint64 *dst, int num);
 void CopyOutDParam(uint64 *dst, const char **strings, StringID string, int num);
+
+void CopyInDParam(const span<const StringParameterBackup> backup);
+void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num);
+void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num, StringID string);
 
 uint64_t GetDParam(size_t n);
 

--- a/src/strings_type.h
+++ b/src/strings_type.h
@@ -88,4 +88,34 @@ enum SpecialStrings {
 	SPECSTR_PRESIDENT_NAME     = 0x70E7,
 };
 
+/** Data that is to be stored when backing up StringParameters. */
+struct StringParameterBackup {
+	uint64_t data; ///< The data field; valid *when* string has no value.
+	std::optional<std::string> string; ///< The string value.
+
+	/**
+	 * Assign the numeric data with the given value, while clearing the stored string.
+	 * @param data The new value of the data field.
+	 * @return This object.
+	 */
+	StringParameterBackup &operator=(uint64_t data)
+	{
+		this->string.reset();
+		this->data = data;
+		return *this;
+	}
+
+	/**
+	 * Assign a copy of the given string to the string field, while clearing the data field.
+	 * @param string The new value of the string.
+	 * @return This object.
+	 */
+	StringParameterBackup &operator=(const std::string_view string)
+	{
+		this->data = 0;
+		this->string.emplace(string);
+		return *this;
+	}
+};
+
 #endif /* STRINGS_TYPE_H */


### PR DESCRIPTION
## Motivation / Problem

The current way of storing backups of StringParameters is quite error prone, and requires manual management of memory. Especially in case strings are involved.


## Description

Introduce a new way of storing backups by just returning a vector with a structure containing the data or string value. This removes the need for manual memory management, and having to think about that all throughout the code.
The introduction of the vector also makes it possible to only allocate/copy the elements that are required, instead of some arbitrary amount.


## Limitations

The code is not used yet; there is #11052 that introduces the users, but that seems to be a too large change to get reviewed.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
