### PR TITLE
Codechange: use std::string instead of a temporary buffer for iconv calls

### DIFF
--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -124,29 +124,30 @@ static const char *GetLocalCode()
  * Convert between locales, which from and which to is set in the calling
  * functions OTTD2FS() and FS2OTTD().
  */
-static const char *convert_tofrom_fs(iconv_t convd, const char *name, char *outbuf, size_t outlen)
+static std::string convert_tofrom_fs(iconv_t convd, const std::string &name)
 {
 	/* There are different implementations of iconv. The older ones,
 	 * e.g. SUSv2, pass a const pointer, whereas the newer ones, e.g.
 	 * IEEE 1003.1 (2004), pass a non-const pointer. */
 #ifdef HAVE_NON_CONST_ICONV
-	char *inbuf = const_cast<char*>(name);
+	char *inbuf = const_cast<char*>(name.data());
 #else
-	const char *inbuf = name;
+	const char *inbuf = name.data();
 #endif
 
-	size_t inlen  = strlen(name);
-	char *buf = outbuf;
+	/* If the output is UTF-32, then 1 ASCII character becomes 4 bytes. */
+	size_t inlen = name.size();
+	std::string buf(inlen * 4, '\0');
 
-	strecpy(outbuf, name, outbuf + outlen);
-
+	size_t outlen = buf.size();
+	char *outbuf = buf.data();
 	iconv(convd, nullptr, nullptr, nullptr, nullptr);
 	if (iconv(convd, &inbuf, &inlen, &outbuf, &outlen) == (size_t)(-1)) {
 		Debug(misc, 0, "[iconv] error converting '{}'. Errno {}", name, errno);
+		return name;
 	}
 
-	*outbuf = '\0';
-	/* FIX: invalid characters will abort conversion, but they shouldn't occur? */
+	buf.resize(outbuf - buf.data());
 	return buf;
 }
 
@@ -158,8 +159,6 @@ static const char *convert_tofrom_fs(iconv_t convd, const char *name, char *outb
 std::string OTTD2FS(const std::string &name)
 {
 	static iconv_t convd = (iconv_t)(-1);
-	char buf[1024] = {};
-
 	if (convd == (iconv_t)(-1)) {
 		const char *env = GetLocalCode();
 		convd = iconv_open(env, INTERNALCODE);
@@ -169,7 +168,7 @@ std::string OTTD2FS(const std::string &name)
 		}
 	}
 
-	return convert_tofrom_fs(convd, name.c_str(), buf, lengthof(buf));
+	return convert_tofrom_fs(convd, name);
 }
 
 /**
@@ -180,8 +179,6 @@ std::string OTTD2FS(const std::string &name)
 std::string FS2OTTD(const std::string &name)
 {
 	static iconv_t convd = (iconv_t)(-1);
-	char buf[1024] = {};
-
 	if (convd == (iconv_t)(-1)) {
 		const char *env = GetLocalCode();
 		convd = iconv_open(INTERNALCODE, env);
@@ -191,7 +188,7 @@ std::string FS2OTTD(const std::string &name)
 		}
 	}
 
-	return convert_tofrom_fs(convd, name.c_str(), buf, lengthof(buf));
+	return convert_tofrom_fs(convd, name);
 }
 
 #endif /* WITH_ICONV */


### PR DESCRIPTION
## Motivation / Problem

Noticing a weird `strecpy` in the `iconv` code. It is copying the input to the output buffer, and then runs iconv which modifies the output buffer again.
After that, the passed buffer is converted to `std::string` in the return.


## Description

Just directly allocate the `std::string` that is going to be returned, with a guess how much bytes will be needed.

If `iconv` fails, return just the input string. It might not be encoded correctly, but conversion failed anyhow so... do what the callers do and return the string that hasn't been converted yet.

Finally just resize the string to what was actually required.

All in all making `FS2OTTD` and `OTTD2FS` reentrant from our code's perspective; especially not reusing the same buffer when two calls are made to `FS2OTTD` at the same time.


## Limitations

None that I'm aware of regarding this code.

Though... glibc has it's own `iconv`, but we do not use it; we only use `iconv` for `APPLE`. Is that right/correct? Shouldn't we run `iconv` on other platforms as well? Or am I overlooking something? (Not that it really matters for me as my system is UTF-8).


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
