### PR TITLE
Autorail / autoroad tools can start dragging from invalid tiles

### DIFF
--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -875,8 +875,8 @@ static CommandCost ValidateAutoDrag(Trackdir *trackdir, TileIndex start, TileInd
  * @param railtype railroad type normal/maglev (0 = normal, 1 = mono, 2 = maglev), only used for building
  * @param track track-orientation
  * @param remove remove tracks?
- * @param auto_remove_signals false = build up to an obstacle, true = fail if an obstacle is found (used for AIs), only used for building
- * @param fail_on_obstacle false = error on signal in the way, true = auto remove signals when in the way, only used for building
+ * @param auto_remove_signals false = error on signal in the way, true = auto remove signals when in the way, only used for building
+ * @param fail_on_obstacle false = build starting from and up to an obstacle, true = fail if an obstacle is found (used for AIs)
  * @return the cost of this operation or an error
  */
 static CommandCost CmdRailTrackHelper(DoCommandFlag flags, TileIndex tile, TileIndex end_tile, RailType railtype, Track track, bool remove, bool auto_remove_signals, bool fail_on_obstacle)
@@ -900,7 +900,7 @@ static CommandCost CmdRailTrackHelper(DoCommandFlag flags, TileIndex tile, TileI
 			last_error = ret;
 			if (last_error.GetErrorMessage() != STR_ERROR_ALREADY_BUILT && !remove) {
 				if (fail_on_obstacle) return last_error;
-				break;
+				if (had_success) break; // Keep going if we haven't constructed any rail yet, skipping the start of the drag
 			}
 
 			/* Ownership errors are more important. */

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1034,7 +1034,7 @@ CommandCost CmdBuildLongRoad(DoCommandFlag flags, TileIndex end_tile, TileIndex 
 			last_error = ret;
 			if (last_error.GetErrorMessage() != STR_ERROR_ALREADY_BUILT) {
 				if (is_ai) return last_error;
-				break;
+				if (had_success) break; // Keep going if we haven't constructed any road yet, skipping the start of the drag
 			}
 		} else {
 			had_success = true;


### PR DESCRIPTION
## Motivation / Problem

When you build a section of rail, that section will be built until you hit a tile that it can't build on. In that case the section will stop there, and the valid start of the rail section is still built. This is quite a nice feature especially if you are creating very long stretches of track, or if you accidentally release your mouse while hovering over say an industry tile.

Unfortunately this does not work the same when you start on a tile that can't be built on. It has happened to me more than once that I wanted to create a long stretch of track starting from a tile right next to a station, but I had accidentally clicked the station tile. You then get an error message and nothing is built.

The same problem applies for roads / trams.

## Description

This change fixes that. If the first x tiles can't be built on then those tiles will simply be skipped. The player will only see an error if the entire section is unbuildable. 

Here are some example cases where it can be helpful:
![openttd_SteYK7SXRb](https://github.com/OpenTTD/OpenTTD/assets/68320206/2243a12f-f1b0-480f-a69a-58437e220d07)


## Limitations

None

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
