### PR TITLE
Fix #11087: Disable base graphics/sound dropdown outside main menu (and change tooltips)

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1059,12 +1059,12 @@ STR_GAME_OPTIONS_REFRESH_RATE_ITEM                              :{NUM}Hz
 STR_GAME_OPTIONS_REFRESH_RATE_WARNING                           :{WHITE}Refresh rates higher than 60Hz might impact performance.
 
 STR_GAME_OPTIONS_BASE_GRF                                       :{BLACK}Base graphics set
-STR_GAME_OPTIONS_BASE_GRF_TOOLTIP                               :{BLACK}Select the base graphics set to use
+STR_GAME_OPTIONS_BASE_GRF_TOOLTIP                               :{BLACK}Select the base graphics set to use (cannot be changed in-game, only from the main menu)
 STR_GAME_OPTIONS_BASE_GRF_STATUS                                :{RED}{NUM} missing/corrupted file{P "" s}
 STR_GAME_OPTIONS_BASE_GRF_DESCRIPTION_TOOLTIP                   :{BLACK}Additional information about the base graphics set
 
 STR_GAME_OPTIONS_BASE_SFX                                       :{BLACK}Base sounds set
-STR_GAME_OPTIONS_BASE_SFX_TOOLTIP                               :{BLACK}Select the base sounds set to use
+STR_GAME_OPTIONS_BASE_SFX_TOOLTIP                               :{BLACK}Select the base sounds set to use (cannot be changed in-game, only from the main menu)
 STR_GAME_OPTIONS_BASE_SFX_DESCRIPTION_TOOLTIP                   :{BLACK}Additional information about the base sounds set
 
 STR_GAME_OPTIONS_BASE_MUSIC                                     :{BLACK}Base music set

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -577,7 +577,7 @@ struct MusicTrackSelectionWindow : public Window {
 
 			case WID_MTS_MUSICSET: {
 				int selected = 0;
-				ShowDropDownList(this, BuildMusicSetDropDownList(&selected), selected, widget);
+				ShowDropDownList(this, BuildSetDropDownList<BaseMusic>(&selected), selected, widget);
 				break;
 			}
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -74,25 +74,6 @@ static uint GetCurrentResolutionIndex()
 
 static void ShowCustCurrency();
 
-template <class T>
-static DropDownList BuildSetDropDownList(int *selected_index, bool allow_selection)
-{
-	int n = T::GetNumSets();
-	*selected_index = T::GetIndexOfUsedSet();
-
-	DropDownList list;
-	for (int i = 0; i < n; i++) {
-		list.emplace_back(new DropDownListStringItem(T::GetSet(i)->name, i, !allow_selection && (*selected_index != i)));
-	}
-
-	return list;
-}
-
-DropDownList BuildMusicSetDropDownList(int *selected_index)
-{
-	return BuildSetDropDownList<BaseMusic>(selected_index, true);
-}
-
 /** Window for displaying the textfile of a BaseSet. */
 template <class TBaseSet>
 struct BaseSetTextfileWindow : public TextfileWindow {
@@ -291,15 +272,15 @@ struct GameOptionsWindow : Window {
 				break;
 
 			case WID_GO_BASE_GRF_DROPDOWN:
-				list = BuildSetDropDownList<BaseGraphics>(selected_index, (_game_mode == GM_MENU));
+				list = BuildSetDropDownList<BaseGraphics>(selected_index);
 				break;
 
 			case WID_GO_BASE_SFX_DROPDOWN:
-				list = BuildSetDropDownList<BaseSounds>(selected_index, (_game_mode == GM_MENU));
+				list = BuildSetDropDownList<BaseSounds>(selected_index);
 				break;
 
 			case WID_GO_BASE_MUSIC_DROPDOWN:
-				list = BuildMusicSetDropDownList(selected_index);
+				list = BuildSetDropDownList<BaseMusic>(selected_index);
 				break;
 		}
 
@@ -739,6 +720,9 @@ struct GameOptionsWindow : Window {
 
 		this->SetWidgetLoweredState(WID_GO_GUI_SCALE_AUTO, _gui_scale_cfg == -1);
 		this->SetWidgetLoweredState(WID_GO_GUI_SCALE_BEVEL_BUTTON, _settings_client.gui.scale_bevels);
+
+		this->SetWidgetDisabledState(WID_GO_BASE_GRF_DROPDOWN, _game_mode != GM_MENU);
+		this->SetWidgetDisabledState(WID_GO_BASE_SFX_DROPDOWN, _game_mode != GM_MENU);
 
 		bool missing_files = BaseGraphics::GetUsedSet()->GetNumMissing() == 0;
 		this->GetWidget<NWidgetCore>(WID_GO_BASE_GRF_STATUS)->SetDataTip(missing_files ? STR_EMPTY : STR_GAME_OPTIONS_BASE_GRF_STATUS, STR_NULL);

--- a/src/settings_gui.h
+++ b/src/settings_gui.h
@@ -22,7 +22,18 @@ void DrawArrowButtons(int x, int y, Colours button_colour, byte state, bool clic
 void DrawDropDownButton(int x, int y, Colours button_colour, bool state, bool clickable);
 void DrawBoolButton(int x, int y, bool state, bool clickable);
 
-DropDownList BuildMusicSetDropDownList(int *selected_index);
+template <class T>
+DropDownList BuildSetDropDownList(int *selected_index)
+{
+	int n = T::GetNumSets();
+	*selected_index = T::GetIndexOfUsedSet();
+	DropDownList list;
+	for (int i = 0; i < n; i++) {
+		list.emplace_back(new DropDownListStringItem(T::GetSet(i)->name, i, false));
+	}
+	return list;
+}
+
 
 /* Actually implemented in music_gui.cpp */
 void ChangeMusicSet(int index);


### PR DESCRIPTION
## Motivation / Problem

Fixes #11087, which applies to base graphics as well as sounds. Also, adds a note in tooltips that those settings can be changed only in the main menu, to avoid confusing players.

## Description
As suggested by @LordAro in #11087:
- Disables the dropdown for base graphics and base sound set selection, outside the main menu.
- Adds a note to the tooltip about the reason.
- The disabling of individual items is no longer needed, so is removed.
- This allows us to remove a redundant parameter of `BuildSetDropDownList`. After doing that, `BuildMusicSetDropDownList` just becomes an alias of `BuildSetDropDownList<BaseMusic>` so the former is also removed.


## Limitations

Players can't see a list of the installed base graphic/sound sets during a game anymore.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
