### PR TITLE
Change: [CI] upload releases to new CDN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,8 @@ jobs:
     with:
       version: ${{ needs.source.outputs.version }}
 
-  upload-aws:
-    name: Upload (AWS)
+  upload-cdn:
+    name: Upload (CDN)
     needs:
     - source
     - docs
@@ -90,7 +90,7 @@ jobs:
     # The always() makes sure the rest is always evaluated.
     if: always() && needs.source.result == 'success' && needs.docs.result == 'success' && needs.linux.result == 'success' && needs.macos.result == 'success' && needs.windows.result == 'success' && (needs.windows-store.result == 'success' || needs.windows-store.result == 'skipped')
 
-    uses: ./.github/workflows/upload-aws.yml
+    uses: ./.github/workflows/upload-cdn.yml
     secrets: inherit
 
     with:

--- a/.github/workflows/upload-cdn.yml
+++ b/.github/workflows/upload-cdn.yml
@@ -1,4 +1,4 @@
-name: Upload (AWS)
+name: Upload (CDN)
 
 on:
   workflow_call:
@@ -14,10 +14,10 @@ on:
         type: string
 
 jobs:
-  upload:
-    name: Upload (AWS)
+  prepare:
+    name: Prepare
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Download all bundles
@@ -54,23 +54,50 @@ jobs:
           done
         fi
 
-    - name: Upload bundles to AWS
-      run: |
-        aws s3 cp --recursive --only-show-errors bundles/ s3://${{ secrets.CDN_S3_BUCKET }}/${{ inputs.folder }}/${{ inputs.version }}/
+    - name: Store bundles
+      uses: actions/upload-artifact@v3
+      with:
+        name: cdn-bundles
+        path: bundles/*
+        retention-days: 5
 
-        # We do not invalidate the CloudFront distribution here. The trigger
-        # for "New OpenTTD release" first updated the manifest files and
-        # creates an index.html. We invalidate after that, so everything
-        # becomes visible at once.
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+  publish:
+    needs:
+    - prepare
 
-    - name: Trigger 'New OpenTTD release'
+    name: Publish
+    uses: OpenTTD/actions/.github/workflows/rw-cdn-upload.yml@v4
+    secrets:
+      CDN_SIGNING_KEY: ${{ secrets.CDN_SIGNING_KEY }}
+      DEPLOYMENT_APP_ID: ${{ secrets.DEPLOYMENT_APP_ID }}
+      DEPLOYMENT_APP_PRIVATE_KEY: ${{ secrets.DEPLOYMENT_APP_PRIVATE_KEY }}
+    with:
+      artifact-name: cdn-bundles
+      folder: ${{ inputs.folder }}
+      version: ${{ inputs.version }}
+
+  docs:
+    if: ${{ inputs.trigger_type == 'new-master' }}
+    needs:
+    - publish
+
+    name: Publish docs
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Generate access token
+      id: generate_token
+      uses: tibdex/github-app-token@v1
+      with:
+        app_id: ${{ secrets.DEPLOYMENT_APP_ID }}
+        private_key: ${{ secrets.DEPLOYMENT_APP_PRIVATE_KEY }}
+        repository: OpenTTD/workflows
+
+    - name: Trigger 'Publish Docs'
       uses: peter-evans/repository-dispatch@v2
       with:
         token: ${{ secrets.DEPLOYMENT_TOKEN }}
         repository: OpenTTD/workflows
-        event-type: ${{ inputs.trigger_type }}
+        event-type: publish-docs
         client-payload: '{"version": "${{ inputs.version }}", "folder": "${{ inputs.folder }}"}'

--- a/.github/workflows/upload-gog.yml
+++ b/.github/workflows/upload-gog.yml
@@ -14,8 +14,25 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - name: Download all bundles
+    - name: Download bundle (Windows x86)
       uses: actions/download-artifact@v3
+      with:
+        name: openttd-windows-x86
+
+    - name: Download bundle (Windows x64)
+      uses: actions/download-artifact@v3
+      with:
+        name: openttd-windows-x64
+
+    - name: Download bundle (MacOS)
+      uses: actions/download-artifact@v3
+      with:
+        name: openttd-macos-universal
+
+    - name: Download bundle (Linux)
+      uses: actions/download-artifact@v3
+      with:
+        name: openttd-linux-generic
 
     - name: Install GOG Galaxy Build Creator
       run: |

--- a/.github/workflows/upload-steam.yml
+++ b/.github/workflows/upload-steam.yml
@@ -17,8 +17,25 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - name: Download all bundles
+    - name: Download bundle (Windows x86)
       uses: actions/download-artifact@v3
+      with:
+        name: openttd-windows-x86
+
+    - name: Download bundle (Windows x64)
+      uses: actions/download-artifact@v3
+      with:
+        name: openttd-windows-x64
+
+    - name: Download bundle (MacOS)
+      uses: actions/download-artifact@v3
+      with:
+        name: openttd-macos-universal
+
+    - name: Download bundle (Linux)
+      uses: actions/download-artifact@v3
+      with:
+        name: openttd-linux-generic
 
     - name: Setup steamcmd
       uses: CyberAndrii/setup-steamcmd@v1


### PR DESCRIPTION
## Motivation / Problem

To reduce cost, we are switching from AWS S3 to Cloudflare R2. This means another way of uploading binaries to our CDN.

## Description

Change the way we upload binaries to our CDN, and do this via a reusing-workflow. This means we have one place that defines how uploads needs to be done, which works for all other projects.

As the reusing workflow needs an artifact to know what to upload, another artifact is created. But by now we have so many artifacts that are unused by GOG and Steam, also change those two to be more specific in which artifacts they want.

It is really hard to test GOG / Steam; so I am going for a "it looks fine" review on those two.

Note: this work has to be merged together with https://github.com/OpenTTD/workflows/pull/34 and friends, while a change in the infra is pushed through.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
