### PR TITLE
Codechange: use Textbuf directly, instead via several virtual functions in Window

### DIFF
--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -280,22 +280,9 @@ struct IConsoleWindow : Window
 		}
 	}
 
-	const char *GetFocusedText() const override
+	Textbuf *GetFocusedTextbuf() const override
 	{
-		return _iconsole_cmdline.buf;
-	}
-
-	const char *GetCaret() const override
-	{
-		return _iconsole_cmdline.buf + _iconsole_cmdline.caretpos;
-	}
-
-	const char *GetMarkedText(size_t *length) const override
-	{
-		if (_iconsole_cmdline.markend == 0) return nullptr;
-
-		*length = _iconsole_cmdline.markend - _iconsole_cmdline.markpos;
-		return _iconsole_cmdline.buf + _iconsole_cmdline.markpos;
+		return &_iconsole_cmdline;
 	}
 
 	Point GetCaretPosition() const override

--- a/src/querystring_gui.h
+++ b/src/querystring_gui.h
@@ -47,37 +47,6 @@ public:
 	Point GetCaretPosition(const Window *w, int wid) const;
 	Rect GetBoundingRect(const Window *w, int wid, const char *from, const char *to) const;
 	ptrdiff_t GetCharAtPosition(const Window *w, int wid, const Point &pt) const;
-
-	/**
-	 * Get the current text.
-	 * @return Current text.
-	 */
-	const char *GetText() const
-	{
-		return this->text.buf;
-	}
-
-	/**
-	 * Get the position of the caret in the text buffer.
-	 * @return Pointer to the caret in the text buffer.
-	 */
-	const char *GetCaret() const
-	{
-		return this->text.buf + this->text.caretpos;
-	}
-
-	/**
-	 * Get the currently marked text.
-	 * @param[out] length Length of the marked text.
-	 * @return Beginning of the marked area or nullptr if no text is marked.
-	 */
-	const char *GetMarkedText(size_t *length) const
-	{
-		if (this->text.markend == 0) return nullptr;
-
-		*length = this->text.markend - this->text.markpos;
-		return this->text.buf + this->text.markpos;
-	}
 };
 
 void ShowOnScreenKeyboard(Window *parent, int button);

--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -275,6 +275,15 @@ void Textbuf::DiscardMarkedText(bool update)
 	this->markpos = this->markend = this->markxoffs = this->marklength = 0;
 }
 
+/**
+ * Get the current text.
+ * @return Current text.
+ */
+const char *Textbuf::GetText() const
+{
+	return this->buf;
+}
+
 /** Update the character iter after the text has changed. */
 void Textbuf::UpdateStringIter()
 {

--- a/src/textbuf_type.h
+++ b/src/textbuf_type.h
@@ -65,6 +65,8 @@ struct Textbuf {
 
 	void DiscardMarkedText(bool update = true);
 
+	const char *GetText() const;
+
 private:
 	std::unique_ptr<StringIterator> char_iter;
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -365,40 +365,13 @@ void Window::UpdateQueryStringSize()
 }
 
 /**
- * Get the current input text if an edit box has the focus.
- * @return The currently focused input text or nullptr if no input focused.
+ * Get the current input text buffer.
+ * @return The currently focused input text buffer or nullptr if no input focused.
  */
-/* virtual */ const char *Window::GetFocusedText() const
+/* virtual */ const Textbuf *Window::GetFocusedTextbuf() const
 {
 	if (this->nested_focus != nullptr && this->nested_focus->type == WWT_EDITBOX) {
-		return this->GetQueryString(this->nested_focus->index)->GetText();
-	}
-
-	return nullptr;
-}
-
-/**
- * Get the string at the caret if an edit box has the focus.
- * @return The text at the caret or nullptr if no edit box is focused.
- */
-/* virtual */ const char *Window::GetCaret() const
-{
-	if (this->nested_focus != nullptr && this->nested_focus->type == WWT_EDITBOX) {
-		return this->GetQueryString(this->nested_focus->index)->GetCaret();
-	}
-
-	return nullptr;
-}
-
-/**
- * Get the range of the currently marked input text.
- * @param[out] length Length of the marked text.
- * @return Pointer to the start of the marked text or nullptr if no text is marked.
- */
-/* virtual */ const char *Window::GetMarkedText(size_t *length) const
-{
-	if (this->nested_focus != nullptr && this->nested_focus->type == WWT_EDITBOX) {
-		return this->GetQueryString(this->nested_focus->index)->GetMarkedText(length);
+		return &this->GetQueryString(this->nested_focus->index)->text;
 	}
 
 	return nullptr;

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -273,9 +273,7 @@ public:
 	QueryString *GetQueryString(uint widnum);
 	void UpdateQueryStringSize();
 
-	virtual const char *GetFocusedText() const;
-	virtual const char *GetCaret() const;
-	virtual const char *GetMarkedText(size_t *length) const;
+	virtual const struct Textbuf *GetFocusedTextbuf() const;
 	virtual Point GetCaretPosition() const;
 	virtual Rect GetTextBoundingRect(const char *from, const char *to) const;
 	virtual ptrdiff_t GetTextCharacterAtPosition(const Point &pt) const;


### PR DESCRIPTION
## Motivation / Problem

In the console and querystring GUI there are duplicated functions to get certain information from `Textbuf`. These functions are only called from the MacOS specific code. Why not just pass the `Textbuf` and use that directly?

Furthermore some of the functions are overly complicated for what they do. For example `GetMarkedText` returns a pointer (which could be `nullptr`) and a length (built from end - start offsets from the complete string). The in the MacOS code that pointer is taken and the length is added to is. So in essence: `char *end = (text + markpos) + (markpos - markend)`; this can be much simpler by just accessing the fields directly.


## Description

Change the `Window` functions to just one version that returns the `Textbuf`.
Move the `GetText()` to `Textbuf` from `Querystring` and `IConsoleWindow`.
Remove some unneeded indirections, but just getting `caretpos`, `markpos` and `markend` directly from `Textbuf` instead of the current (sometimes overly complex) functions.


## Limitations

I can't test it.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
