### PR TITLE
Fix d5a72193: [CI] GOG and Steam also depend on the source itself

### DIFF
--- a/.github/workflows/upload-gog.yml
+++ b/.github/workflows/upload-gog.yml
@@ -14,6 +14,11 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Download source
+      uses: actions/download-artifact@v3
+      with:
+        name: internal-source
+
     - name: Download bundle (Windows x86)
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/upload-steam.yml
+++ b/.github/workflows/upload-steam.yml
@@ -17,6 +17,11 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Download source
+      uses: actions/download-artifact@v3
+      with:
+        name: internal-source
+
     - name: Download bundle (Windows x86)
       uses: actions/download-artifact@v3
       with:


### PR DESCRIPTION
## Motivation / Problem

Made a boo-boo in d5a72193: GOG and Steam also need the source blob for some platform specific files.


## Description

Fix this oversight.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
