### PR TITLE
Codechange: use CopyIn/OutDParam for text effect parameters

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -203,6 +203,24 @@ void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num, Strin
 	}
 }
 
+/**
+ * Checks whether the global string parameters have changed compared to the given backup.
+ * @param backup The backup to check against.
+ * @return True when the parameters have changed, otherwise false.
+ */
+bool HaveDParamChanged(const std::vector<StringParameterBackup> &backup)
+{
+	bool changed = false;
+	for (size_t i = 0; !changed && i < backup.size(); i++) {
+		if (backup[i].string.has_value()) {
+			changed = backup[i].string.value() != (const char *)(size_t)_global_string_params.GetParam(i);
+		} else {
+			changed = backup[i].data != _global_string_params.GetParam(i);
+		}
+	}
+	return changed;
+}
+
 static void StationGetSpecialString(StringBuilder &builder, StationFacility x);
 static void GetSpecialTownNameString(StringBuilder &builder, int ind, uint32 seed);
 static void GetSpecialNameString(StringBuilder &builder, int ind, StringParameters &args);

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -89,6 +89,7 @@ void SetDParamStr(size_t n, std::string &&str) = delete; // block passing tempor
 void CopyInDParam(const span<const StringParameterBackup> backup);
 void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num);
 void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num, StringID string);
+bool HaveDParamChanged(const std::vector<StringParameterBackup> &backup);
 
 uint64_t GetDParam(size_t n);
 


### PR DESCRIPTION
## Motivation / Problem

For text effects there are two parameters that are "backed" up by manually copying data around, instead of using `CopyInDParam`/`CopyOutDParam`.


## Description

Let text effects use the `StringParameterBackup`, instead of manually copied parameters.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
