### PR TITLE
Codechange: split string and integer in string parameters

### DIFF
--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -122,7 +122,7 @@ void ErrorMessageData::CopyOutDParams()
 
 	/* Get parameters using type information */
 	if (this->textref_stack_size > 0) StartTextRefStackUsage(this->textref_stack_grffile, this->textref_stack_size, this->textref_stack);
-	CopyOutDParam(this->params, 20, this->detailed_msg == INVALID_STRING_ID ? this->summary_msg : this->detailed_msg);
+	CopyOutDParam(this->params, 20);
 	if (this->textref_stack_size > 0) StopTextRefStackUsage();
 }
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -178,7 +178,12 @@ void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num)
 {
 	backup.resize(num);
 	for (size_t i = 0; i < backup.size(); i++) {
-		backup[i] = _global_string_params.GetParam(i);
+		const char *str = _global_string_params.GetParamStr(i);
+		if (str != nullptr) {
+			backup[i] = str;
+		} else {
+			backup[i] = _global_string_params.GetParam(i);
+		}
 	}
 }
 
@@ -190,17 +195,7 @@ void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num)
  */
 void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num, StringID string)
 {
-	/* Just get the string to extract the type information. */
-	GetString(string);
-
-	backup.resize(num);
-	for (size_t i = 0; i < backup.size(); i++) {
-		if (_global_string_params.GetTypeAtOffset(i) == SCC_RAW_STRING_POINTER) {
-			backup[i] = (const char *)(size_t)_global_string_params.GetParam(i);
-		} else {
-			backup[i] = _global_string_params.GetParam(i);
-		}
-	}
+	CopyOutDParam(backup, num);
 }
 
 /**
@@ -1124,7 +1119,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 				break;
 
 			case SCC_RAW_STRING_POINTER: { // {RAW_STRING}
-				const char *raw_string = (const char *)(size_t)args.GetNextParameter<size_t>();
+				const char *raw_string = args.GetNextParameterString();
 				/* raw_string can be(come) nullptr when the parameter is out of range and 0 is returned instead. */
 				if (raw_string == nullptr ||
 						(game_script && std::find(_game_script_raw_strings.begin(), _game_script_raw_strings.end(), raw_string) == _game_script_raw_strings.end())) {

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -188,17 +188,6 @@ void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num)
 }
 
 /**
- * Copy \a num string parameters from the global string parameter array to the \a backup.
- * @param backup The backup to write to.
- * @param num Number of string parameters to copy.
- * @param string The string used to determine where raw strings are and where there are no raw strings.
- */
-void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num, StringID string)
-{
-	CopyOutDParam(backup, num);
-}
-
-/**
  * Checks whether the global string parameters have changed compared to the given backup.
  * @param backup The backup to check against.
  * @return True when the parameters have changed, otherwise false.

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -88,7 +88,6 @@ void SetDParamStr(size_t n, std::string &&str) = delete; // block passing tempor
 
 void CopyInDParam(const span<const StringParameterBackup> backup);
 void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num);
-void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num, StringID string);
 bool HaveDParamChanged(const std::vector<StringParameterBackup> &backup);
 
 uint64_t GetDParam(size_t n);

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -17,6 +17,7 @@
 /** The data required to format and validate a single parameter of a string. */
 struct StringParameter {
 	uint64_t data; ///< The data of the parameter.
+	const char *string_view; ///< The string value, if it has any.
 	WChar type; ///< The #StringControlCode to interpret this data with when it's the first parameter, otherwise '\0'.
 };
 
@@ -93,6 +94,18 @@ public:
 	}
 
 	/**
+	 * Get the next string parameter from our parameters.
+	 * This updates the offset, so the next time this is called the next parameter
+	 * will be read.
+	 * @return The next parameter's value.
+	 */
+	const char *GetNextParameterString()
+	{
+		auto ptr = GetNextParameterPointer();
+		return ptr == nullptr ? nullptr : ptr->string_view;
+	}
+
+	/**
 	 * Get a new instance of StringParameters that is a "range" into the
 	 * remaining existing parameters. Upon destruction the offset in the parent
 	 * is not updated. However, calls to SetDParam do update the parameters.
@@ -134,16 +147,35 @@ public:
 	{
 		assert(n < this->parameters.size());
 		this->parameters[n].data = v;
+		this->parameters[n].string_view = nullptr;
 	}
 
-	void SetParam(size_t n, const char *str) { this->SetParam(n, (uint64_t)(size_t)str); }
+	void SetParam(size_t n, const char *str)
+	{
+		assert(n < this->parameters.size());
+		this->parameters[n].data = 0;
+		this->parameters[n].string_view = str;
+	}
+
 	void SetParam(size_t n, const std::string &str) { this->SetParam(n, str.c_str()); }
 	void SetParam(size_t n, std::string &&str) = delete; // block passing temporaries to SetDParam
 
 	uint64 GetParam(size_t n) const
 	{
 		assert(n < this->parameters.size());
+		assert(this->parameters[n].string_view == nullptr);
 		return this->parameters[n].data;
+	}
+
+	/**
+	 * Get the stored string of the parameter, or \c nullptr when there is none.
+	 * @param n The index into the parameters.
+	 * @return The stored string.
+	 */
+	const char *GetParamStr(size_t n) const
+	{
+		assert(n < this->parameters.size());
+		return this->parameters[n].string_view;
 	}
 };
 


### PR DESCRIPTION
## Motivation / Problem

Currently there is no way of knowing whether a `StringParameter` is actually a string or an integer, except by hoping the given string matches the parameters.
Furthermore there's some nasty `(uint64_t)(size_t)` and `(const char*)(size_t)` casting.


## Description

Split `data` into actual (integer) data and `const char *string_view`.
Add new function to get the next parameter that we expect to be a string, which returns the string or `nullptr` when it was not set as a string. When reading a string as a integer, a `0` is returned instead.
`GetParam` asserts when accessing a string parameters, `GetParamStr` is added to actually access the string.

The `CopyOutDParam` with string parameters is removed, since we can now just check `GetParamStr` to see whether a string has been set, and if so make a copy of the string into the backup.


## Limitations

Slightly more memory usage.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
