### PR TITLE
Change: Only show platform stopping location in orders when other than default

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1383,7 +1383,7 @@ STR_CONFIG_SETTING_NONSTOP_BY_DEFAULT                           :New orders are 
 STR_CONFIG_SETTING_NONSTOP_BY_DEFAULT_HELPTEXT                  :Normally, a vehicle will stop at every station it passes. By enabling this setting, it will drive through all station on the way to its final destination without stopping. Note, that this setting only defines a default value for new orders. Individual orders can be set explicitly to either behaviour nevertheless
 
 STR_CONFIG_SETTING_STOP_LOCATION                                :New train orders stop by default at the {STRING2} of the platform
-STR_CONFIG_SETTING_STOP_LOCATION_HELPTEXT                       :Place where a train will stop at the platform by default. The 'near end' means close to the entry point, 'middle' means in the middle of the platform, and 'far end' means far away from the entry point. Note, that this setting only defines a default value for new orders. Individual orders can be set explicitly to either behaviour nevertheless
+STR_CONFIG_SETTING_STOP_LOCATION_HELPTEXT                       :Place where a train will stop at the platform by default. The 'near end' means close to the entry point, 'middle' means in the middle of the platform, and 'far end' means far away from the entry point. Note, that this setting only defines a default value for new orders. Individual orders can have their stop location set by clicking on the order text
 ###length 3
 STR_CONFIG_SETTING_STOP_LOCATION_NEAR_END                       :near end
 STR_CONFIG_SETTING_STOP_LOCATION_MIDDLE                         :middle

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -287,7 +287,12 @@ void DrawOrderString(const Vehicle *v, const Order *order, int order_index, int 
 					SetDParam(4, order->IsAutoRefit() ? STR_ORDER_AUTO_REFIT_ANY : CargoSpec::Get(order->GetRefitCargo())->name);
 				}
 				if (v->type == VEH_TRAIN && (order->GetNonStopType() & ONSF_NO_STOP_AT_DESTINATION_STATION) == 0) {
-					SetDParam(5, order->GetStopLocation() + STR_ORDER_STOP_LOCATION_NEAR_END);
+					/* Only show the stopping location if other than the default chosen by the player. */
+					if (order->GetStopLocation() != (OrderStopLocation)(_settings_client.gui.stop_location)) {
+						SetDParam(5, order->GetStopLocation() + STR_ORDER_STOP_LOCATION_NEAR_END);
+					} else {
+						SetDParam(5, STR_EMPTY);
+					}
 				}
 			}
 			break;

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -600,6 +600,7 @@ interval = 1
 str      = STR_CONFIG_SETTING_STOP_LOCATION
 strhelp  = STR_CONFIG_SETTING_STOP_LOCATION_HELPTEXT
 strval   = STR_CONFIG_SETTING_STOP_LOCATION_NEAR_END
+post_cb  = [](auto) { SetWindowClassesDirty(WC_VEHICLE_ORDERS); }
 cat      = SC_BASIC
 
 [SDTC_BOOL]


### PR DESCRIPTION
## Motivation / Problem

The order window has a lot of text.

## Description

We don't draw loading/unloading instructions unless they are different than the default `Load if available / Unload if accepted`. Let's do the same with the platform stopping location: only draw the text if it's different than the default chosen by the player in their GUI settings.

![stop_location](https://github.com/OpenTTD/OpenTTD/assets/55058389/4f46c971-d988-4f9c-9ee6-68d8e5ae0978)
(In this screenshot, the player default is middle.)

None of this inhibits the player cycling through the stopping locations by clicking the order text. I updated the Settings helptext to clarify this.

## Limitations

New players may not realize they can change the stopping location just from looking at the order window. The feature is purely cosmetic, so I don't see a problem with this.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
