### PR TITLE
Codechange: support string temporaries as DParam/Remove: stredup

### DIFF
--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -377,8 +377,7 @@ static void FiosGetFileList(SaveLoadOperation fop, FiosGetTypeAndNameProc *callb
 				fios->type = FIOS_TYPE_DIR;
 				fios->mtime = 0;
 				fios->name = d_name;
-				std::string dirname = fios->name + PATHSEP;
-				SetDParamStr(0, dirname);
+				SetDParamStr(0, fios->name + PATHSEP);
 				fios->title = GetString(STR_SAVELOAD_DIRECTORY);
 			}
 		}

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -208,12 +208,11 @@ public:
 		/* Location */
 		std::stringstream tile_ss;
 		tile_ss << "0x" << std::setfill('0') << std::setw(4) << std::hex << std::uppercase << tile; // 0x%.4X
-		std::string tile_str = tile_ss.str(); // Can't pass it directly to SetDParamStr as the string is only a temporary and would be destructed before the GetString call.
 
 		SetDParam(0, TileX(tile));
 		SetDParam(1, TileY(tile));
 		SetDParam(2, GetTileZ(tile));
-		SetDParamStr(3, tile_str);
+		SetDParamStr(3, tile_ss.str());
 		this->landinfo_data.push_back(GetString(STR_LAND_AREA_INFORMATION_LANDINFO_COORDS));
 
 		/* Local authority */

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -641,8 +641,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_ERROR(Packet *p
 	if (error < (ptrdiff_t)lengthof(network_error_strings)) err = network_error_strings[error];
 	/* In case of kicking a client, we assume there is a kick message in the packet if we can read one byte */
 	if (error == NETWORK_ERROR_KICKED && p->CanReadFromPacket(1)) {
-		std::string kick_msg = p->Recv_string(NETWORK_CHAT_LENGTH);
-		SetDParamStr(0, kick_msg);
+		SetDParamStr(0, p->Recv_string(NETWORK_CHAT_LENGTH));
 		ShowErrorMessage(err, STR_NETWORK_ERROR_KICK_MESSAGE, WL_CRITICAL);
 	} else {
 		ShowErrorMessage(err, INVALID_STRING_ID, WL_CRITICAL);

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -77,9 +77,8 @@ static void ShowNewGRFInfo(const GRFConfig *c, const Rect &r, bool show_params)
 		for (uint i = 0; i < c->error->param_value.size(); i++) {
 			SetDParam(3 + i, c->error->param_value[i]);
 		}
-		std::string message = GetString(c->error->message != STR_NULL ? c->error->message : STR_JUST_RAW_STRING);
 
-		SetDParamStr(0, message);
+		SetDParamStr(0, GetString(c->error->message != STR_NULL ? c->error->message : STR_JUST_RAW_STRING));
 		tr.top = DrawStringMultiLine(tr, c->error->severity);
 	}
 
@@ -90,8 +89,7 @@ static void ShowNewGRFInfo(const GRFConfig *c, const Rect &r, bool show_params)
 	}
 
 	/* Prepare and draw GRF ID */
-	std::string tmp = fmt::format("{:08X}", BSWAP32(c->ident.grfid));
-	SetDParamStr(0, tmp);
+	SetDParamStr(0, fmt::format("{:08X}", BSWAP32(c->ident.grfid)));
 	tr.top = DrawStringMultiLine(tr, STR_NEWGRF_SETTINGS_GRF_ID);
 
 	if ((_settings_client.gui.newgrf_developer_tools || _settings_client.gui.newgrf_show_old_versions) && c->version != 0) {
@@ -104,17 +102,14 @@ static void ShowNewGRFInfo(const GRFConfig *c, const Rect &r, bool show_params)
 	}
 
 	/* Prepare and draw MD5 sum */
-	tmp = FormatArrayAsHex(c->ident.md5sum);
-	SetDParamStr(0, tmp);
+	SetDParamStr(0, FormatArrayAsHex(c->ident.md5sum));
 	tr.top = DrawStringMultiLine(tr, STR_NEWGRF_SETTINGS_MD5SUM);
 
 	/* Show GRF parameter list */
 	if (show_params) {
-		std::string params;
 		if (c->num_params > 0) {
-			params = GRFBuildParamList(c);
 			SetDParam(0, STR_JUST_RAW_STRING);
-			SetDParamStr(1, params);
+			SetDParamStr(1, GRFBuildParamList(c));
 		} else {
 			SetDParam(0, STR_NEWGRF_SETTINGS_PARAMETER_NONE);
 		}

--- a/src/safeguards.h
+++ b/src/safeguards.h
@@ -28,7 +28,7 @@
 /* Use ReallocT instead. */
 #define realloc   SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
-/* Use stredup instead. */
+/* Use std::string instead. */
 #define strdup    SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define strndup   SAFEGUARD_DO_NOT_USE_THIS_METHOD
 

--- a/src/script/api/script_goal.cpp
+++ b/src/script/api/script_goal.cpp
@@ -48,7 +48,7 @@
 
 	EnforceDeityMode(GOAL_INVALID);
 	EnforcePrecondition(GOAL_INVALID, goal != nullptr);
-	const std::string &text = goal->GetEncodedText();
+	std::string text = goal->GetEncodedText();
 	EnforcePreconditionEncodedText(GOAL_INVALID, text);
 	EnforcePrecondition(GOAL_INVALID, company == ScriptCompany::COMPANY_INVALID || ScriptCompany::ResolveCompanyID(company) != ScriptCompany::COMPANY_INVALID);
 	EnforcePrecondition(GOAL_INVALID, IsValidGoalDestination(company, type, destination));
@@ -84,7 +84,7 @@
 	EnforcePrecondition(false, IsValidGoal(goal_id));
 	EnforceDeityMode(false);
 	EnforcePrecondition(false, goal != nullptr);
-	const std::string &text = goal->GetEncodedText();
+	std::string text = goal->GetEncodedText();
 	EnforcePreconditionEncodedText(false, text);
 
 	return ScriptObject::Command<CMD_SET_GOAL_TEXT>::Do(goal_id, text);
@@ -123,7 +123,7 @@
 
 	EnforceDeityMode(false);
 	EnforcePrecondition(false, question != nullptr);
-	const std::string &text = question->GetEncodedText();
+	std::string text = question->GetEncodedText();
 	EnforcePreconditionEncodedText(false, text);
 	uint min_buttons = (type == QT_QUESTION ? 1 : 0);
 	EnforcePrecondition(false, CountBits(buttons) >= min_buttons && CountBits(buttons) <= 3);

--- a/src/script/api/script_league.cpp
+++ b/src/script/api/script_league.cpp
@@ -32,11 +32,11 @@
 
 	EnforceDeityMode(LEAGUE_TABLE_INVALID);
 	EnforcePrecondition(LEAGUE_TABLE_INVALID, title != nullptr);
-	const std::string &encoded_title = title->GetEncodedText();
+	std::string encoded_title = title->GetEncodedText();
 	EnforcePreconditionEncodedText(LEAGUE_TABLE_INVALID, encoded_title);
 
-	const std::string &encoded_header = (header != nullptr ? header->GetEncodedText() : std::string{});
-	const std::string &encoded_footer = (footer != nullptr ? footer->GetEncodedText() : std::string{});
+	std::string encoded_header = (header != nullptr ? header->GetEncodedText() : std::string{});
+	std::string encoded_footer = (footer != nullptr ? footer->GetEncodedText() : std::string{});
 
 	if (!ScriptObject::Command<CMD_CREATE_LEAGUE_TABLE>::Do(&ScriptInstance::DoCommandReturnLeagueTableID, encoded_title, encoded_header, encoded_footer)) return LEAGUE_TABLE_INVALID;
 
@@ -63,11 +63,11 @@
 	if (company == ScriptCompany::COMPANY_INVALID) c = INVALID_COMPANY;
 
 	EnforcePrecondition(LEAGUE_TABLE_ELEMENT_INVALID, text != nullptr);
-	const std::string &encoded_text = text->GetEncodedText();
+	std::string encoded_text = text->GetEncodedText();
 	EnforcePreconditionEncodedText(LEAGUE_TABLE_ELEMENT_INVALID, encoded_text);
 
 	EnforcePrecondition(LEAGUE_TABLE_ELEMENT_INVALID, score != nullptr);
-	const std::string &encoded_score = score->GetEncodedText();
+	std::string encoded_score = score->GetEncodedText();
 	EnforcePreconditionEncodedText(LEAGUE_TABLE_ELEMENT_INVALID, encoded_score);
 
 	EnforcePrecondition(LEAGUE_TABLE_ELEMENT_INVALID, IsValidLink(Link((::LinkType)link_type, link_target)));
@@ -90,7 +90,7 @@
 	if (company == ScriptCompany::COMPANY_INVALID) c = INVALID_COMPANY;
 
 	EnforcePrecondition(false, text != nullptr);
-	const std::string &encoded_text = text->GetEncodedText();
+	std::string encoded_text = text->GetEncodedText();
 	EnforcePreconditionEncodedText(false, encoded_text);
 
 	EnforcePrecondition(false, IsValidLink(Link((::LinkType)link_type, link_target)));
@@ -106,7 +106,7 @@
 	EnforcePrecondition(false, IsValidLeagueTableElement(element));
 
 	EnforcePrecondition(false, score != nullptr);
-	const std::string &encoded_score = score->GetEncodedText();
+	std::string encoded_score = score->GetEncodedText();
 	EnforcePreconditionEncodedText(false, encoded_score);
 
 	return ScriptObject::Command<CMD_UPDATE_LEAGUE_TABLE_ELEMENT_SCORE>::Do(element, rating, encoded_score);

--- a/src/script/api/script_news.cpp
+++ b/src/script/api/script_news.cpp
@@ -26,7 +26,7 @@
 
 	EnforceDeityMode(false);
 	EnforcePrecondition(false, text != nullptr);
-	const std::string &encoded = text->GetEncodedText();
+	std::string encoded = text->GetEncodedText();
 	EnforcePreconditionEncodedText(false, encoded);
 	EnforcePrecondition(false, type == NT_ECONOMY || type == NT_SUBSIDIES || type == NT_GENERAL);
 	EnforcePrecondition(false, company == ScriptCompany::COMPANY_INVALID || ScriptCompany::ResolveCompanyID(company) != ScriptCompany::COMPANY_INVALID);

--- a/src/script/api/script_text.cpp
+++ b/src/script/api/script_text.cpp
@@ -248,8 +248,6 @@ void ScriptText::_GetEncodedText(std::back_insert_iterator<std::string> &output,
 
 const std::string Text::GetDecodedText()
 {
-	const std::string &encoded_text = this->GetEncodedText();
-
-	::SetDParamStr(0, encoded_text);
+	::SetDParamStr(0, this->GetEncodedText());
 	return ::GetString(STR_JUST_RAW_STRING);
 }

--- a/src/script/api/script_text.cpp
+++ b/src/script/api/script_text.cpp
@@ -158,7 +158,7 @@ SQInteger ScriptText::_set(HSQUIRRELVM vm)
 	return this->_SetParam(k, vm);
 }
 
-const std::string ScriptText::GetEncodedText()
+std::string ScriptText::GetEncodedText()
 {
 	static StringIDList seen_ids;
 	int param_count = 0;

--- a/src/script/api/script_text.hpp
+++ b/src/script/api/script_text.hpp
@@ -26,7 +26,7 @@ public:
 	 * @return A string.
 	 * @api -all
 	 */
-	virtual const std::string GetEncodedText() = 0;
+	virtual std::string GetEncodedText() = 0;
 
 	/**
 	 * Convert a #ScriptText into a decoded normal string.
@@ -44,7 +44,7 @@ class RawText : public Text {
 public:
 	RawText(const std::string &text);
 
-	const std::string GetEncodedText() override { return this->text; }
+	std::string GetEncodedText() override { return this->text; }
 private:
 	const std::string text;
 };
@@ -125,7 +125,7 @@ public:
 	/**
 	 * @api -all
 	 */
-	virtual const std::string GetEncodedText();
+	virtual std::string GetEncodedText();
 
 private:
 	using ScriptTextRef = ScriptObjectRef<ScriptText>;

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -81,21 +81,6 @@ char *strecpy(char *dst, const char *src, const char *last)
 }
 
 /**
- * Create a duplicate of the given string.
- * @param s    The string to duplicate.
- * @param last The last character that is safe to duplicate. If nullptr, the whole string is duplicated.
- * @note The maximum length of the resulting string might therefore be last - s + 1.
- * @return The duplicate of the string.
- */
-char *stredup(const char *s, const char *last)
-{
-	size_t len = last == nullptr ? strlen(s) : ttd_strnlen(s, last - s + 1);
-	char *tmp = CallocT<char>(len + 1);
-	memcpy(tmp, s, len);
-	return tmp;
-}
-
-/**
  * Format a byte array into a continuous hex string.
  * @param data Array to format
  * @return Converted string.

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -19,7 +19,6 @@
 #include "string_type.h"
 
 char *strecpy(char *dst, const char *src, const char *last) NOACCESS(3);
-char *stredup(const char *src, const char *last = nullptr) NOACCESS(2);
 
 std::string FormatArrayAsHex(span<const byte> data);
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -364,6 +364,18 @@ void SetDParamStr(size_t n, const std::string &str)
 }
 
 /**
+ * This function is used to "bind" the std::string to a OpenTTD dparam slot.
+ * Contrary to the other \c SetDParamStr functions, this moves the string into
+ * the parameter slot.
+ * @param n slot of the string
+ * @param str string to bind
+ */
+void SetDParamStr(size_t n, std::string &&str)
+{
+	_global_string_params.SetParam(n, std::move(str));
+}
+
+/**
  * Format a number into a string.
  * @param builder   the string builder to write to
  * @param number    the number to write down

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -84,7 +84,7 @@ void SetDParamMaxDigits(size_t n, uint count, FontSize size = FS_NORMAL);
 
 void SetDParamStr(size_t n, const char *str);
 void SetDParamStr(size_t n, const std::string &str);
-void SetDParamStr(size_t n, std::string &&str) = delete; // block passing temporaries to SetDParamStr
+void SetDParamStr(size_t n, std::string &&str);
 
 void CopyInDParam(const span<const StringParameterBackup> backup);
 void CopyOutDParam(std::vector<StringParameterBackup> &backup, size_t num);


### PR DESCRIPTION
## Motivation / Problem

Having to keep local variables around to prevent string temporaries with the string parameter system.
The existence of `stredup`/manual memory management, especially to validate whether a game string parameter is valid.


## Description

Add a `std::unique_ptr<std::string>` to retain a copy of a string in the `StringParameter`. Not directly a `std::string`, as we need a mechanism to know whether the value is used and given temporaries are rarely used the overhead of `std::unique_ptr` over `std::optional` is negligable compared to the memory usage.

Use this new support for temporaries to not have to `stredup` string parameters, and to not have to maintain an array of fields to `free` later.

Remove `stredup`.

Use this new support for temporaries to remove the local variables in callers of `SetDParamStr`.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
