### PR TITLE
Doc: minor changes to documentation

### DIFF
--- a/CODINGSTYLE.md
+++ b/CODINGSTYLE.md
@@ -416,9 +416,7 @@ There is a check-script on the git server (also available for clients, see below
 
 The first line of a message must match:
 ```
-<pre>
 <keyword>( #<issue>| <commit>(, (<keyword> #<issue>|<commit>))*)?: ([<section])? <Details>
-</pre>
 ```
 Keywords are:
 * Add, Feature: Adding new stuff. Difference between "Feature" and "Add" is somewhat subjective. "Feature" for user-point-of-view stuff, "Add" for other.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ In return, they should reciprocate that respect in addressing your issue or asse
 The [issue tracker](https://github.com/OpenTTD/OpenTTD/issues) is the preferred channel for [bug reports](#bug-reports), but please respect the following restrictions:
 
 * Please **do not** use the issue tracker for help playing or using OpenTTD.
-Please try [irc](https://wiki.openttd.org/en/Development/IRC%20channel), or the [forums](https://www.tt-forums.net/)
+Please try [irc](https://wiki.openttd.org/en/Development/IRC%20channel), [Discord](https://discord.gg/openttd), or the [forums](https://www.tt-forums.net/)
 
 * Please **do not** derail or troll issues. Keep the discussion on topic and respect the opinions of others.
 
@@ -23,7 +23,7 @@ Use [GitHub's "reactions" feature](https://github.com/blog/2119-add-reactions-to
 We reserve the right to delete comments which violate this rule.
 
 * Please **do not** open issues or pull requests regarding add-on content in NewGRF, GameScripts, AIs, etc.
-These are created by third-parties.  Please try [irc](https://wiki.openttd.org/en/Development/IRC%20channel) or the [forums](https://www.tt-forums.net/) to discuss these.
+These are created by third-parties.  Please try [irc](https://wiki.openttd.org/en/Development/IRC%20channel), [Discord](https://discord.gg/openttd), or the [forums](https://www.tt-forums.net/) to discuss these.
 
 * Please use [the web translator](https://translator.openttd.org/) to submit corrections and improvements to translations of the game.
 
@@ -108,7 +108,7 @@ Pull requests should fit with the [goals of the project](./CONTRIBUTING.md#proje
 
 Every pull request should have a clear scope, with no unrelated commits.
 
-[Code style](https://wiki.openttd.org/en/Development/Coding%20style) must be complied with for pull requests to be accepted; this also includes [commit message format](https://wiki.openttd.org/en/Development/Coding%20style#commit-message).
+[Code style](./CODINGSTYLE.md) must be complied with for pull requests to be accepted; this also includes [commit message format](./CODINGSTYLE.md#commit-message).
 
 Adhering to the following process is the best way to get your work included in the project:
 
@@ -136,7 +136,7 @@ contain your feature, change, or fix:
 git checkout upstream/master -b <topic-branch-name>
 ```
 
-4. Commit your changes in logical chunks. Please adhere to these [git commit message guidelines](https://wiki.openttd.org/en/Development/Coding%20style#commit-message) or your code is unlikely to be merged into the main project.
+4. Commit your changes in logical chunks. Please adhere to these [git commit message guidelines](./CODINGSTYLE.md#commit-message) or your code is unlikely to be merged into the main project.
 Use Git's [interactive rebase](https://docs.github.com/en/get-started/using-git/about-git-rebase) feature to tidy up your commits before making them public.
 
 5. Locally rebase the upstream development branch into your topic branch:
@@ -172,7 +172,7 @@ The results of the CI tests will show on your pull request.
 By clicking on Details you can further zoom in; in case of a failure it will show you why it failed.
 In case of success it will report how awesome you were.
 
-Tip: [commit message format](https://wiki.openttd.org/en/Development/Coding%20style#commit-message) is a common reason for pull requests to fail validation.
+Tip: [commit message format](./CODINGSTYLE.md#commit-message) is a common reason for pull requests to fail validation.
 
 
 ### Are there any development docs?


### PR DESCRIPTION
## Motivation / Problem
- Ugly extra `<pre>` in `CODINGSTYLE.md`
- Discord not linked in some places `CONTRIBUTING.md` which is arguably a more used forum than IRC (though both are bridged)
- `CONTRIBUTING.md` links to Wiki for coding style and commit format. These are available in the git repository itself since #10512, and it is nicer to link to that, since there appeared to be a consensus in #10512 to make this version the authoritative one rather than the Wiki.


## Description
- Unncecessary formatting removed.
- Linked Discord where it was missed.
- Linked to `CODINGSTYLE.md` instead of Wiki.

## Limitations
Unknown.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
