### PR TITLE
Fix: [Emscripten] switch to URL for content-service that supports WebSocket

### DIFF
--- a/os/emscripten/pre.js
+++ b/os/emscripten/pre.js
@@ -2,7 +2,7 @@ Module.arguments.push('-mnull', '-snull', '-vsdl:relative_mode');
 Module['websocket'] = { url: function(host, port, proto) {
     /* openttd.org hosts a WebSocket proxy for the content service. */
     if (host == "content.openttd.org" && port == 3978 && proto == "tcp") {
-        return "wss://content.openttd.org/";
+        return "wss://bananas-server.openttd.org/";
     }
 
     /* Everything else just tries to make a default WebSocket connection.
@@ -41,7 +41,7 @@ Module.preRun.push(function() {
         /* Check if the OpenGFX baseset is already downloaded. */
         if (!FS.analyzePath(content_download_dir + '/baseset/opengfx-0.6.0.tar').exists) {
             window.openttd_downloaded_opengfx = true;
-            FS.createPreloadedFile(content_download_dir + '/baseset', 'opengfx-0.6.0.tar', 'https://installer.cdn.openttd.org/emscripten/opengfx-0.6.0.tar', true, true);
+            FS.createPreloadedFile(content_download_dir + '/baseset', 'opengfx-0.6.0.tar', 'https://binaries.openttd.org/installer/emscripten/opengfx-0.6.0.tar', true, true);
         } else {
             /* Fake dependency increase, so the counter is stable. */
             Module.addRunDependency('opengfx');


### PR DESCRIPTION
## Motivation / Problem

In the old days, content.openttd.org and bananas-server.openttd.org ended up on the same route. But with a recent migration, they do not. content.openttd.org only serves the custom TCP protocol, and bananas-server.openttd.org only serves the HTTP(S).

Websockets use HTTPS, and as such, should be routed via the latter.

## Description

Update the URLs to work with new infra.

Additionally, `installer.cdn` is being deprecated, so move it to another URL that works (for now). But honestly, this part should be removed and the bootstrapping should be made functional instead. That would mean it would automatically pick up on new OpenGFX, instead of this custom work. Emscripten is the last target not supporting bootstrapping. But .. not for this PR!

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
