### PR TITLE
Fix d5a72193: [CI] downloading single artifact doesn't add folder to it

### DIFF
--- a/.github/workflows/upload-gog.yml
+++ b/.github/workflows/upload-gog.yml
@@ -18,26 +18,31 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: internal-source
+        path: internal-source
 
     - name: Download bundle (Windows x86)
       uses: actions/download-artifact@v3
       with:
         name: openttd-windows-x86
+        path: openttd-windows-x86
 
     - name: Download bundle (Windows x64)
       uses: actions/download-artifact@v3
       with:
         name: openttd-windows-x64
+        path: openttd-windows-x64
 
     - name: Download bundle (MacOS)
       uses: actions/download-artifact@v3
       with:
         name: openttd-macos-universal
+        path: openttd-macos-universal
 
     - name: Download bundle (Linux)
       uses: actions/download-artifact@v3
       with:
         name: openttd-linux-generic
+        path: openttd-linux-generic
 
     - name: Install GOG Galaxy Build Creator
       run: |

--- a/.github/workflows/upload-steam.yml
+++ b/.github/workflows/upload-steam.yml
@@ -21,26 +21,31 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: internal-source
+        path: internal-source
 
     - name: Download bundle (Windows x86)
       uses: actions/download-artifact@v3
       with:
         name: openttd-windows-x86
+        path: openttd-windows-x86
 
     - name: Download bundle (Windows x64)
       uses: actions/download-artifact@v3
       with:
         name: openttd-windows-x64
+        path: openttd-windows-x64
 
     - name: Download bundle (MacOS)
       uses: actions/download-artifact@v3
       with:
         name: openttd-macos-universal
+        path: openttd-macos-universal
 
     - name: Download bundle (Linux)
       uses: actions/download-artifact@v3
       with:
         name: openttd-linux-generic
+        path: openttd-linux-generic
 
     - name: Setup steamcmd
       uses: CyberAndrii/setup-steamcmd@v1


### PR DESCRIPTION
## Motivation / Problem

The download-artifact action has two modes: download all or download one.

In the first mode, it downloads all artifacts prefixed with their artifact name.
In the second mode, it doesn't do this.

These differences .. owh well .. but in result the Steam/GOG release failed, as they assumed the artifacts are in the folder.

## Description

There are two choices: remove the assumption the artifacts are in the folder, or add the folder. I did the latter, as the first can be a bit tricky. Say, by accident, one of the targets outputs a file with the same name as another target. It would now overwrite this. We can't have that! So, put artifacts in their own folder.

## Limitations

Still untested, so we will see tomorrow night if this works :)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
