### PR TITLE
Add: [Emscripten] support for bootstrapping

### DIFF
--- a/os/emscripten/pre.js
+++ b/os/emscripten/pre.js
@@ -52,24 +52,26 @@ Module.preRun.push(function() {
     });
 
     window.openttd_syncfs_shown_warning = false;
-    window.openttd_syncfs = function() {
+    window.openttd_syncfs = function(callback) {
         /* Copy the virtual FS to the persistent storage. */
-        FS.syncfs(false, function (err) { });
+        FS.syncfs(false, function (err) {
+            /* On first time, warn the user about the volatile behaviour of
+             * persistent storage. */
+            if (!window.openttd_syncfs_shown_warning) {
+                window.openttd_syncfs_shown_warning = true;
+                Module.onWarningFs();
+            }
 
-        /* On first time, warn the user about the volatile behaviour of
-         * persistent storage. */
-        if (!window.openttd_syncfs_shown_warning) {
-            window.openttd_syncfs_shown_warning = true;
-            Module.onWarningFs();
-        }
+            if (callback) callback();
+        });
     }
 
     window.openttd_exit = function() {
-        Module.onExit();
+        window.openttd_syncfs(Module.onExit);
     }
 
     window.openttd_abort = function() {
-        Module.onAbort();
+        window.openttd_syncfs(Module.onAbort);
     }
 
     window.openttd_server_list = function() {

--- a/os/emscripten/shell.html
+++ b/os/emscripten/shell.html
@@ -75,7 +75,6 @@
       }
       #message {
         color: #101010;
-        height: 54px;
         padding: 4px 4px;
       }
 
@@ -144,6 +143,8 @@
         })(),
 
         setStatus: function(text) {
+          if (document.getElementById("canvas").style.display == "none") return;
+
           var m = text.match(/^([^(]+)\((\d+(\.\d+)?)\/(\d+)\)$/);
 
           if (m) {
@@ -169,6 +170,27 @@
 
           document.getElementById("title").innerHTML = "(" + doing + " / " + total + ") Loading ...";
           document.getElementById("message").innerHTML = "Preparing game ...";
+        },
+
+        onBootstrap: function(current, total) {
+          document.getElementById("canvas").style.display = "none";
+
+          document.getElementById("title").innerHTML = "Missing base graphics";
+          document.getElementById("message").innerHTML = "OpenTTD is downloading base graphics.<br/><br/>" + current + " / " + total + " bytes downloaded.";
+        },
+
+        onBootstrapFailed: function(current, total) {
+          document.getElementById("canvas").style.display = "none";
+
+          document.getElementById("title").innerHTML = "Missing base graphics";
+          document.getElementById("message").innerHTML = "Failed to download base graphics.<br/>The game cannot start without base graphics.<br/><br/>Please check your Internet connection and/or the console log.<br/>Reload your browser to try again.";
+        },
+
+        onBootstrapReload: function() {
+          document.getElementById("canvas").style.display = "none";
+
+          document.getElementById("title").innerHTML = "Missing base graphics";
+          document.getElementById("message").innerHTML = "Downloading base graphics done.<br/><br/>Your browser will reload to start the game.";
         },
 
         onExit: function() {

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -118,7 +118,6 @@ void UserErrorI(const std::string &str)
 	/* In effect, the game ends here. As emscripten_set_main_loop() caused
 	 * the stack to be unwound, the code after MainLoop() in
 	 * openttd_main() is never executed. */
-	EM_ASM(if (window["openttd_syncfs"]) openttd_syncfs());
 	EM_ASM(if (window["openttd_abort"]) openttd_abort());
 #endif
 

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -612,7 +612,11 @@ void VideoDriver_SDL_Base::LoopOnce()
 		/* In effect, the game ends here. As emscripten_set_main_loop() caused
 		 * the stack to be unwound, the code after MainLoop() in
 		 * openttd_main() is never executed. */
-		EM_ASM(if (window["openttd_exit"]) openttd_exit());
+		if (_game_mode == GM_BOOTSTRAP) {
+			EM_ASM(if (window["openttd_bootstrap_reload"]) openttd_bootstrap_reload());
+		} else {
+			EM_ASM(if (window["openttd_exit"]) openttd_exit());
+		}
 #endif
 		return;
 	}

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -612,7 +612,6 @@ void VideoDriver_SDL_Base::LoopOnce()
 		/* In effect, the game ends here. As emscripten_set_main_loop() caused
 		 * the stack to be unwound, the code after MainLoop() in
 		 * openttd_main() is never executed. */
-		EM_ASM(if (window["openttd_syncfs"]) openttd_syncfs());
 		EM_ASM(if (window["openttd_exit"]) openttd_exit());
 #endif
 		return;


### PR DESCRIPTION
## Motivation / Problem
Emscripten build comes with an outdated opengfx-0.6.0 baseset and as it gets it via the old installer method (which was since replaced by bootstrapping), it will never get a recent version (well user can update it manually via content download).
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Implement bootstrap mechanism for emscripten builds.
Doesn't show any confirmation window and just downloads a baseset if none was present.
A message is shown during the download and the page is reloaded once downloading is done.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
