### PR TITLE
Codechange: do not make a string valid in place, to then copy it

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -2651,12 +2651,9 @@ static ChangeInfoResult LoadTranslationTable(uint gvid, int numinfo, ByteReader 
  */
 static std::string ReadDWordAsString(ByteReader *reader)
 {
-	char output[5];
-	for (int i = 0; i < 4; i++) output[i] = reader->ReadByte();
-	output[4] = '\0';
-	StrMakeValidInPlace(output, lastof(output));
-
-	return std::string(output);
+	std::string output;
+	for (int i = 0; i < 4; i++) output.push_back(reader->ReadByte());
+	return StrMakeValid(output);
 }
 
 /**

--- a/src/saveload/gamelog_sl.cpp
+++ b/src/saveload/gamelog_sl.cpp
@@ -68,8 +68,7 @@ public:
 		SlObject(lc, this->GetLoadDescription());
 
 		if (IsSavegameVersionBefore(SLV_STRING_GAMELOG)) {
-			StrMakeValidInPlace(SlGamelogRevision::revision_text, lastof(SlGamelogRevision::revision_text));
-			static_cast<LoggedChangeRevision *>(lc)->text = SlGamelogRevision::revision_text;
+			static_cast<LoggedChangeRevision *>(lc)->text = StrMakeValid(std::string_view(SlGamelogRevision::revision_text, lengthof(SlGamelogRevision::revision_text)));
 		}
 	}
 

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -573,8 +573,7 @@ bool ScriptInstance::IsPaused()
 			SlObject(nullptr, _script_byte);
 			static char buf[std::numeric_limits<decltype(_script_sl_byte)>::max()];
 			SlCopy(buf, _script_sl_byte, SLE_CHAR);
-			StrMakeValidInPlace(buf, buf + _script_sl_byte);
-			if (data != nullptr) data->push_back(std::string(buf));
+			if (data != nullptr) data->push_back(StrMakeValid(std::string_view(buf, _script_sl_byte)));
 			return true;
 		}
 


### PR DESCRIPTION
## Motivation / Problem

Calling `StrMakeValidInPlace` and then converting the result to a `std::string` is a waste of resources. `StrMakeValidInPlace` does already iterate/copy through the data to make it valid, so just write it to the new string directly.


## Description

Just replace `StrMakeValidInPlace` with `StrMakeValid` when converting to `std::string` afterwards.


## Limitations

Spacebar heating might get broken.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
