### PR TITLE
Fix #11108, e2f583a: missing argument for SCC_CARGO_SHORT formatting

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1213,15 +1213,17 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 				switch (cargo_str) {
 					case STR_TONS: {
 						assert(_settings_game.locale.units_weight < lengthof(_units_weight));
-						auto tmp_params = MakeParameters(_units_weight[_settings_game.locale.units_weight].c.ToDisplay(args.GetNextParameter<int64_t>()));
-						FormatString(builder, GetStringPtr(_units_weight[_settings_game.locale.units_weight].l), tmp_params);
+						const auto &x = _units_weight[_settings_game.locale.units_weight];
+						auto tmp_params = MakeParameters(x.c.ToDisplay(args.GetNextParameter<int64_t>()), x.decimal_places);
+						FormatString(builder, GetStringPtr(x.l), tmp_params);
 						break;
 					}
 
 					case STR_LITERS: {
 						assert(_settings_game.locale.units_volume < lengthof(_units_volume));
-						auto tmp_params = MakeParameters(_units_volume[_settings_game.locale.units_volume].c.ToDisplay(args.GetNextParameter<int64_t>()));
-						FormatString(builder, GetStringPtr(_units_volume[_settings_game.locale.units_volume].l), tmp_params);
+						const auto &x = _units_volume[_settings_game.locale.units_volume];
+						auto tmp_params = MakeParameters(x.c.ToDisplay(args.GetNextParameter<int64_t>()), x.decimal_places);
+						FormatString(builder, GetStringPtr(x.l), tmp_params);
 						break;
 					}
 


### PR DESCRIPTION
## Motivation / Problem

Fixes #11108.


## Description

Use similar code that is used for `SCC_FORCE` and the likes. In other words pass the number of decimal places as parameter too.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
