### PR TITLE
Codechange: Unnecessry ptr incrementation, max_sprite_size constant

### DIFF
--- a/src/spriteloader/grf.cpp
+++ b/src/spriteloader/grf.cpp
@@ -66,7 +66,8 @@ bool DecodeSingleSprite(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t f
 	 *
 	 * So, any sprite data more than 64 MiB is way larger that we would even expect; prevent allocating more memory!
 	 */
-	if (num < 0 || num > 64 * 1024 * 1024) return WarnCorruptSprite(file, file_pos, __LINE__);
+	constexpr int64 MAX_SPRITE_SIZE = 64 * 1024 * 1024;
+	if (num < 0 || num > MAX_SPRITE_SIZE) return WarnCorruptSprite(file, file_pos, __LINE__);
 
 	std::unique_ptr<byte[]> dest_orig(new byte[num]);
 	byte *dest = dest_orig.get();
@@ -207,7 +208,6 @@ bool DecodeSingleSprite(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t f
 				}
 				/* Magic blue. */
 				if (colour_fmt == SCC_PAL && *pixel == 0) sprite->data[i].a = 0x00;
-				pixel++;
 			}
 		}
 	}


### PR DESCRIPTION
## Motivation / Problem

remove unnecessary code


## Description

remove unnecessary pointer inc, as it was reassigned every iteration anyway. use constexpr max_sprite_size instead of computing it every time


## Limitations

none


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
