### PR TITLE
Fix: [Emscripten] actually link against nlohmann_json

### DIFF
--- a/os/emscripten/cmake/Findnlohmann_json.cmake
+++ b/os/emscripten/cmake/Findnlohmann_json.cmake
@@ -15,6 +15,7 @@ if (nlohmann_json_FOUND)
                 INTERFACE_COMPILE_OPTIONS "-sUSE_NLOHMANN_JSON=1"
                 INTERFACE_LINK_LIBRARIES "-sUSE_NLOHMANN_JSON=1"
         )
+        set(nlohmann_json_LIBRARY "nlohmann_json")
 else()
         message(WARNING "You are using an emscripten SDK without nlohmann-json support. Please apply 'emsdk-nlohmann_json.patch' to your local emsdk installation.")
 endif()


### PR DESCRIPTION
## Motivation / Problem

We fake a plain (non-scoped) library, but we don't actually set the library to anything valid. In result, it is never actually linked.

## Description

This happened to work by accident, as CMake installed nlohmann. How emscripten works, libraries don't actually exists in that sense, more in that if the port is installed, emscripten will take care of it.

But if you started your docker after the cmake run, it was never installed, as it was actually not linked in properly. After this PR, it is.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
