### PR TITLE
Fix #11115: Focus the abandon game/exit game windows

### DIFF
--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -517,7 +517,8 @@ void AskExitGame()
 		STR_QUIT_CAPTION,
 		STR_QUIT_ARE_YOU_SURE_YOU_WANT_TO_EXIT_OPENTTD,
 		nullptr,
-		AskExitGameCallback
+		AskExitGameCallback,
+		true
 	);
 }
 
@@ -536,6 +537,7 @@ void AskExitToGameMenu()
 		STR_ABANDON_GAME_CAPTION,
 		(_game_mode != GM_EDITOR) ? STR_ABANDON_GAME_QUERY : STR_ABANDON_SCENARIO_QUERY,
 		nullptr,
-		AskExitToGameMenuCallback
+		AskExitToGameMenuCallback,
+		true
 	);
 }

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -1218,15 +1218,16 @@ static WindowDesc _query_desc(
 );
 
 /**
- * Show a modal confirmation window with standard 'yes' and 'no' buttons
+ * Show a confirmation window with standard 'yes' and 'no' buttons
  * The window is aligned to the centre of its parent.
  * @param caption string shown as window caption
  * @param message string that will be shown for the window
  * @param parent pointer to parent window, if this pointer is nullptr the parent becomes
  * the main window WC_MAIN_WINDOW
  * @param callback callback function pointer to set in the window descriptor
+ * @param focus whether the window should be focussed (by default false)
  */
-void ShowQuery(StringID caption, StringID message, Window *parent, QueryCallbackProc *callback)
+void ShowQuery(StringID caption, StringID message, Window *parent, QueryCallbackProc *callback, bool focus)
 {
 	if (parent == nullptr) parent = GetMainWindow();
 
@@ -1240,5 +1241,6 @@ void ShowQuery(StringID caption, StringID message, Window *parent, QueryCallback
 		break;
 	}
 
-	new QueryWindow(&_query_desc, caption, message, parent, callback);
+	QueryWindow *q = new QueryWindow(&_query_desc, caption, message, parent, callback);
+	if (focus) SetFocusedWindow(q);
 }

--- a/src/textbuf_gui.h
+++ b/src/textbuf_gui.h
@@ -29,7 +29,7 @@ DECLARE_ENUM_AS_BIT_SET(QueryStringFlags)
 typedef void QueryCallbackProc(Window*, bool);
 
 void ShowQueryString(StringID str, StringID caption, uint max_len, Window *parent, CharSetFilter afilter, QueryStringFlags flags);
-void ShowQuery(StringID caption, StringID message, Window *w, QueryCallbackProc *callback);
+void ShowQuery(StringID caption, StringID message, Window *w, QueryCallbackProc *callback, bool focus = false);
 
 /** The number of 'characters' on the on-screen keyboard. */
 static const uint OSK_KEYBOARD_ENTRIES = 50;


### PR DESCRIPTION
## Motivation / Problem

Fixes #11115.

## Description

- Add a parameter to `ShowQuery` which gives focus to the query window created by the function. By default it is `false` to preserve current behaviour.
- Use that parameter to focus the "Abandon game" and "Exit game" confirmation queries.
- Also, the query created by `ShowQuery` is not modal even though it is described as modal by the comment. So that comment is fixed.

## Limitations

Opening the abandon/exit query windows will now remove focus on whatever window is currently focussed.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
