### PR TITLE
Fix: [CI] actually use the GitHub Apps token to trigger "Publish Docs"

### DIFF
--- a/.github/workflows/upload-cdn.yml
+++ b/.github/workflows/upload-cdn.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Trigger 'Publish Docs'
       uses: peter-evans/repository-dispatch@v2
       with:
-        token: ${{ secrets.DEPLOYMENT_TOKEN }}
+        token: ${{ steps.generate_token.outputs.token }}
         repository: OpenTTD/workflows
         event-type: publish-docs
         client-payload: '{"version": "${{ inputs.version }}", "folder": "${{ inputs.folder }}"}'


### PR DESCRIPTION
## Motivation / Problem

Humans make silly mistakes. Same humans also fix their own mistakes.

## Description

There was an attempt to no longer use `DEPLOYMENT_TOKEN`. The attempt failed.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
