### PR TITLE
Codechange: hint in all branches of ClampTo to resolve compile-time

### DIFF
--- a/src/core/math_func.hpp
+++ b/src/core/math_func.hpp
@@ -168,12 +168,12 @@ constexpr To ClampTo(From value)
 	static_assert(std::numeric_limits<To>::is_integer, "Do not clamp from non-integer values");
 	static_assert(std::numeric_limits<From>::is_integer, "Do not clamp to non-integer values");
 
-	if (sizeof(To) >= sizeof(From) && std::numeric_limits<To>::is_signed == std::numeric_limits<From>::is_signed) {
+	if constexpr (sizeof(To) >= sizeof(From) && std::numeric_limits<To>::is_signed == std::numeric_limits<From>::is_signed) {
 		/* Same signedness and To type is larger or equal than From type, no clamping is required. */
 		return static_cast<To>(value);
 	}
 
-	if (sizeof(To) > sizeof(From) && std::numeric_limits<To>::is_signed) {
+	if constexpr (sizeof(To) > sizeof(From) && std::numeric_limits<To>::is_signed) {
 		/* Signed destination and a larger To type, no clamping is required. */
 		return static_cast<To>(value);
 	}


### PR DESCRIPTION
## Motivation / Problem

During some unrelated work I noticed that the `ClampTo` function applies `constexpr` nicely, except for two if-calls. Now I assume the compiler will do the right thing here, but making it explicit helps the human to understand they all should resolve compile-time.

## Description

Add the `constexpr` to make the function look more pretty!

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
