### PR TITLE
Add: workflow and script for checking ini_key issues in WindowDesc entries

### DIFF
--- a/.github/windowdesc-ini-key.py
+++ b/.github/windowdesc-ini-key.py
@@ -1,0 +1,50 @@
+"""
+Script to scan the OpenTTD source-tree for ini_key issues in WindowDesc entries.
+"""
+
+import glob
+import os
+import re
+import sys
+
+
+def scan_source_files(path, ini_keys=None):
+    if ini_keys is None:
+        ini_keys = set()
+
+    errors = []
+
+    for new_path in glob.glob(f"{path}/*.cpp"):
+        if os.path.isdir(new_path):
+            errors.append(scan_source_files(new_path, ini_keys))
+            continue
+
+        with open(new_path) as fp:
+            output = fp.read()
+
+        for (name, ini_key, widgets) in re.findall(r"^static WindowDesc ([a-zA-Z0-9_]*).*?, (?:\"(.*?)\")?.*?,(?:\s+(.*?),){6}", output, re.S|re.M):
+            if ini_key:
+                if ini_key in ini_keys:
+                    errors.append(f"{new_path}: {name} ini_key is a duplicate")
+                ini_keys.add(ini_key)
+            widget = re.findall("static const (?:struct )?NWidgetPart " + widgets + ".*?(?:WWT_(DEFSIZE|STICKY)BOX.*?)?;", output, re.S)[0]
+            if widget and not ini_key:
+                errors.append(f"{new_path}: {name} has WWT_DEFSIZEBOX/WWT_STICKYBOX without ini_key")
+            if ini_key and not widget:
+                errors.append(f"{new_path}: {name} has ini_key without WWT_DEFSIZEBOX/WWT_STICKYBOX")
+
+    return errors
+
+
+def main():
+    errors = scan_source_files("src")
+
+    if errors:
+        print("\n".join(errors))
+        sys.exit(1)
+
+    print("OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/windowdesc-ini-key.yml
+++ b/.github/workflows/windowdesc-ini-key.yml
@@ -1,0 +1,24 @@
+name: WindowDesc ini_key
+
+on:
+  pull_request:
+    branches:
+    - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  windowdesc-ini-key:
+    name: WindowDesc ini_key issues
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Check for ini_key issues in WindowDesc entries
+      shell: bash
+      run: |
+        python3 .github/windowdesc-ini-key.py

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -619,7 +619,7 @@ static const NWidgetPart _nested_build_airport_widgets[] = {
 };
 
 static WindowDesc _build_airport_desc(
-	WDP_AUTO, "build_station_air", 0, 0,
+	WDP_AUTO, nullptr, 0, 0,
 	WC_BUILD_STATION, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
 	_nested_build_airport_widgets, lengthof(_nested_build_airport_widgets)

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -1157,7 +1157,7 @@ static const NWidgetPart _nested_select_company_livery_widgets [] = {
 };
 
 static WindowDesc _select_company_livery_desc(
-	WDP_AUTO, "company_livery", 0, 0,
+	WDP_AUTO, nullptr, 0, 0,
 	WC_COMPANY_COLOUR, WC_NONE,
 	0,
 	_nested_select_company_livery_widgets, lengthof(_nested_select_company_livery_widgets)
@@ -1774,7 +1774,7 @@ public:
 
 /** Company manager face selection window description */
 static WindowDesc _select_company_manager_face_desc(
-	WDP_AUTO, "company_face", 0, 0,
+	WDP_AUTO, nullptr, 0, 0,
 	WC_COMPANY_MANAGER_FACE, WC_NONE,
 	WDF_CONSTRUCTION,
 	_nested_select_company_manager_face_widgets, lengthof(_nested_select_company_manager_face_widgets)

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -144,7 +144,7 @@ struct EnginePreviewWindow : Window {
 };
 
 static WindowDesc _engine_preview_desc(
-	WDP_CENTER, "engine_preview", 0, 0,
+	WDP_CENTER, nullptr, 0, 0,
 	WC_ENGINE_PREVIEW, WC_NONE,
 	WDF_CONSTRUCTION,
 	_nested_engine_preview_widgets, lengthof(_nested_engine_preview_widgets)

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -43,7 +43,7 @@ static const NWidgetPart _nested_errmsg_widgets[] = {
 };
 
 static WindowDesc _errmsg_desc(
-	WDP_MANUAL, "error", 0, 0,
+	WDP_MANUAL, nullptr, 0, 0,
 	WC_ERRMSG, WC_NONE,
 	0,
 	_nested_errmsg_widgets, lengthof(_nested_errmsg_widgets)
@@ -63,7 +63,7 @@ static const NWidgetPart _nested_errmsg_face_widgets[] = {
 };
 
 static WindowDesc _errmsg_face_desc(
-	WDP_MANUAL, "error_face", 0, 0,
+	WDP_MANUAL, nullptr, 0, 0,
 	WC_ERRMSG, WC_NONE,
 	0,
 	_nested_errmsg_face_widgets, lengthof(_nested_errmsg_face_widgets)

--- a/src/league_gui.cpp
+++ b/src/league_gui.cpp
@@ -197,7 +197,7 @@ static const NWidgetPart _nested_performance_league_widgets[] = {
 };
 
 static WindowDesc _performance_league_desc(
-	WDP_AUTO, "league", 0, 0,
+	WDP_AUTO, "performance_league", 0, 0,
 	WC_COMPANY_LEAGUE, WC_NONE,
 	0,
 	_nested_performance_league_widgets, lengthof(_nested_performance_league_widgets)
@@ -429,7 +429,7 @@ static const NWidgetPart _nested_script_league_widgets[] = {
 };
 
 static WindowDesc _script_league_desc(
-	WDP_AUTO, "league", 0, 0,
+	WDP_AUTO, "script_league", 0, 0,
 	WC_COMPANY_LEAGUE, WC_NONE,
 	0,
 	_nested_script_league_widgets, lengthof(_nested_script_league_widgets)

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -59,7 +59,7 @@ static const NWidgetPart _nested_land_info_widgets[] = {
 };
 
 static WindowDesc _land_info_desc(
-	WDP_AUTO, "land_info", 0, 0,
+	WDP_AUTO, nullptr, 0, 0,
 	WC_LAND_INFO, WC_NONE,
 	0,
 	_nested_land_info_widgets, lengthof(_nested_land_info_widgets)
@@ -1064,7 +1064,7 @@ static const NWidgetPart _nested_query_string_widgets[] = {
 };
 
 static WindowDesc _query_string_desc(
-	WDP_CENTER, "query_string", 0, 0,
+	WDP_CENTER, nullptr, 0, 0,
 	WC_QUERY_STRING, WC_NONE,
 	0,
 	_nested_query_string_widgets, lengthof(_nested_query_string_widgets)

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -642,7 +642,7 @@ static const NWidgetPart _nested_music_track_selection_widgets[] = {
 };
 
 static WindowDesc _music_track_selection_desc(
-	WDP_AUTO, "music_track", 0, 0,
+	WDP_AUTO, nullptr, 0, 0,
 	WC_MUSIC_TRACK_SELECTION, WC_NONE,
 	0,
 	_nested_music_track_selection_widgets, lengthof(_nested_music_track_selection_widgets)

--- a/src/osk_gui.cpp
+++ b/src/osk_gui.cpp
@@ -335,7 +335,7 @@ static const NWidgetPart _nested_osk_widgets[] = {
 };
 
 static WindowDesc _osk_desc(
-	WDP_CENTER, "query_osk", 0, 0,
+	WDP_CENTER, nullptr, 0, 0,
 	WC_OSK, WC_NONE,
 	0,
 	_nested_osk_widgets, lengthof(_nested_osk_widgets)

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1886,7 +1886,7 @@ static const NWidgetPart _nested_signal_builder_widgets[] = {
 
 /** Signal selection window description */
 static WindowDesc _signal_builder_desc(
-	WDP_AUTO, "build_signal", 0, 0,
+	WDP_AUTO, nullptr, 0, 0,
 	WC_BUILD_SIGNAL, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
 	_nested_signal_builder_widgets, lengthof(_nested_signal_builder_widgets)

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -899,7 +899,7 @@ static const NWidgetPart _nested_game_options_widgets[] = {
 };
 
 static WindowDesc _game_options_desc(
-	WDP_CENTER, "settings_game", 0, 0,
+	WDP_CENTER, nullptr, 0, 0,
 	WC_GAME_OPTIONS, WC_NONE,
 	0,
 	_nested_game_options_widgets, lengthof(_nested_game_options_widgets)

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -552,7 +552,7 @@ static const NWidgetPart _nested_query_sign_edit_widgets[] = {
 };
 
 static WindowDesc _query_sign_edit_desc(
-	WDP_CENTER, "query_sign", 0, 0,
+	WDP_CENTER, nullptr, 0, 0,
 	WC_QUERY_STRING, WC_NONE,
 	WDF_CONSTRUCTION,
 	_nested_query_sign_edit_widgets, lengthof(_nested_query_sign_edit_widgets)


### PR DESCRIPTION
## Motivation / Problem
WindowDesc::ini_key is used for saving prefered sticky state and size.
As #11126 showed, it's easy to forget to set WindowDesc::ini_key.
It's also easy to set it while not needed, and also to use duplicate ini_key values.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Make sure we catch potential issues before merge.
For each WindowDesc, the script gets name, ini_key (if any) and the nested widget array.
It validates uniqueness of ini_key value, then it checks if the nested widget array contains `WWT_DEFSIZEBOX` or `WWT_STICKYBOX` and validates ini_key is set only when required.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
~~Current source has issues and the script will find them. So they need to be fixed first.~~
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
