### PR TITLE
Change: Don't save industry history if cargo slot isn't used.

### DIFF
--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -67,6 +67,12 @@ public:
 
 	void Save(Industry::ProducedCargo *p) const override
 	{
+		if (!IsValidCargoID(p->cargo)) {
+			/* Don't save any history if cargo slot isn't used. */
+			SlSetStructListLength(0);
+			return;
+		}
+
 		SlSetStructListLength(p->history.size());
 
 		for (auto &h : p->history) {


### PR DESCRIPTION
## Motivation / Problem

Industries have 16 slots which may produce cargo, and we save two months of production/transported history for each slot for each industry.

In many cases (dependent on NewGRFs), 14 of the 16 slots won't actually ever be used as cargo slot is CT_INVALID.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Skip saving history if the slot is CT_INVALID by setting the saved length to 0.

This avoids saving history of 16 slots per industry when in many cases (NewGRF dependent) only a couple are used.

Does not need a saveload bump as the loading code is already told how much data there is.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

As savegames are compressed, this doesn't particularly save much space... on a 4096x4096 map with high industries the resultant file size difference is negli:ble.

Vanilla: 24,766,936 bytes
Patched: 24,760,648 bytes

This may be of more benefit with #10541, but... no idea.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
