### PR TITLE
Change: Allow DEL key to close windows when focused on a textbox

### DIFF
--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -476,6 +476,7 @@ HandleKeyPressResult Textbuf::HandleKeyPress(WChar key, uint16 keycode)
 		case WKC_BACKSPACE: case WKC_DELETE:
 		case WKC_CTRL | WKC_BACKSPACE: case WKC_CTRL | WKC_DELETE:
 			edited = this->DeleteChar(keycode);
+			if (!edited) return HKPR_NOT_HANDLED;
 			break;
 
 		case WKC_LEFT: case WKC_RIGHT: case WKC_END: case WKC_HOME:


### PR DESCRIPTION
## Motivation / Problem

The feature to close all windows using the DEL key is great. I found that it's especially helpful for new players. If they get a bit overwhelmed by the amount of menu's then you can panic-press DEL to get back to the main viewport.

However, when you are focused on a textbox, the keypress event of the DEL key is "stolen" and the hotkey corresponding to DEL does not work. It makes sense because deleting characters is more important, but it does make the user experience a bit less consistent.

## Description

After my changes the DEL will delete a character if this is possible, i.e. if there is at least one character after the caret. If not the keypress action "passes through" the function which triggers the hotkey associated with the DEL key (close all windows by default).

**I am aware that the hotkey can be changed to a key that doesn't get swallowed by the textbox. But I'm used to the DEL key now and I am stubborn.**

## Limitations

- Pressing and holding DEL will cause the entire string to be deleted one character at a time, and then the window suddenly closes.
- Right now this only works for DEL and BACKSPACE. For consistency we probably want something similar for other keys. First I want to see what the general opinion on this is.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
