### PR TITLE
Fix #10983: [AdminPort] Correct order of messages

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -888,6 +888,11 @@ CommandCost CmdCompanyCtrl(DoCommandFlag flags, CompanyCtrlAction cca, CompanyID
 				break;
 			}
 
+			/* Send new companies, before potentially setting the password. Otherwise,
+			 * the password update could be sent when the company is not yet known. */
+			NetworkAdminCompanyNew(c);
+			NetworkServerNewCompany(c, ci);
+
 			/* This is the client (or non-dedicated server) who wants a new company */
 			if (client_id == _network_own_client_id) {
 				assert(_local_company == COMPANY_SPECTATOR);
@@ -906,8 +911,6 @@ CommandCost CmdCompanyCtrl(DoCommandFlag flags, CompanyCtrlAction cca, CompanyID
 
 				MarkWholeScreenDirty();
 			}
-
-			NetworkServerNewCompany(c, ci);
 			break;
 		}
 
@@ -923,7 +926,10 @@ CommandCost CmdCompanyCtrl(DoCommandFlag flags, CompanyCtrlAction cca, CompanyID
 			assert(company_id == INVALID_COMPANY || !Company::IsValidID(company_id));
 
 			Company *c = DoStartupNewCompany(true, company_id);
-			if (c != nullptr) NetworkServerNewCompany(c, nullptr);
+			if (c != nullptr) {
+				NetworkAdminCompanyNew(c);
+				NetworkServerNewCompany(c, nullptr);
+			}
 			break;
 		}
 

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -853,11 +853,10 @@ void NetworkAdminClientError(ClientID client_id, NetworkErrorCode error_code)
 }
 
 /**
- * Notify the admin network of company details.
+ * Notify the admin network of a new company.
  * @param company the company of which details will be sent into the admin network.
- * @param new_company whether this is a new company or not.
  */
-void NetworkAdminCompanyInfo(const Company *company, bool new_company)
+void NetworkAdminCompanyNew(const Company *company)
 {
 	if (company == nullptr) {
 		Debug(net, 1, "[admin] Empty company given for update");
@@ -867,10 +866,8 @@ void NetworkAdminCompanyInfo(const Company *company, bool new_company)
 	for (ServerNetworkAdminSocketHandler *as : ServerNetworkAdminSocketHandler::IterateActive()) {
 		if (as->update_frequency[ADMIN_UPDATE_COMPANY_INFO] != ADMIN_FREQUENCY_AUTOMATIC) continue;
 
+		as->SendCompanyNew(company->index);
 		as->SendCompanyInfo(company);
-		if (new_company) {
-			as->SendCompanyNew(company->index);
-		}
 	}
 }
 

--- a/src/network/network_admin.h
+++ b/src/network/network_admin.h
@@ -103,7 +103,7 @@ void NetworkAdminClientInfo(const NetworkClientSocket *cs, bool new_client = fal
 void NetworkAdminClientUpdate(const NetworkClientInfo *ci);
 void NetworkAdminClientQuit(ClientID client_id);
 void NetworkAdminClientError(ClientID client_id, NetworkErrorCode error_code);
-void NetworkAdminCompanyInfo(const Company *company, bool new_company);
+void NetworkAdminCompanyNew(const Company *company);
 void NetworkAdminCompanyUpdate(const Company *company);
 void NetworkAdminCompanyRemove(CompanyID company_id, AdminCompanyRemoveReason bcrr);
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -2198,9 +2198,6 @@ void NetworkServerNewCompany(const Company *c, NetworkClientInfo *ci)
 		Command<CMD_RENAME_PRESIDENT>::SendNet(STR_NULL, c->index, ci->client_name);
 	}
 
-	/* Announce new company on network. */
-	NetworkAdminCompanyInfo(c, true);
-
 	if (ci != nullptr) {
 		/* ci is nullptr when replaying, or for AIs. In neither case there is a client.
 		   We need to send Admin port update here so that they first know about the new company


### PR DESCRIPTION
## Motivation / Problem

This pull request would close #10983 .
It solves problem of admin port messages arriving in un-logical order. 

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

The only logical order in my opinion when it comes to receiving admin port messages about company is as follows:

- ADMIN_PACKET_SERVER_COMPANY_NEW (once)
- ADMIN_PACKET_SERVER_COMPANY_INFO (once)
- ADMIN_PACKET_SERVER_COMPANY_UPDATE ( can be received many times afterwards)

Before this PR order could look like this for *newly* created company:

- ADMIN_PACKET_SERVER_COMPANY_UPDATE (0-2 times)
- ADMIN_PACKET_SERVER_COMPANY_INFO (once)
- ADMIN_PACKET_SERVER_COMPANY_NEW (once)
- ADMIN_PACKET_SERVER_COMPANY_UPDATE (many)

In my opinion that order does not make any sense at all. This PR solves it.

Additionally second parameter to `NetworkAdminCompanyInfo` function was removed due to it always being `true`. We are always creating new company when sending company info.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

From my personal tests it seems that problem is solved.
Additionally I think that ADMIN_PACKET_SERVER_COMPANY_NEW  and ADMIN_PACKET_SERVER_COMPANY_INFO  should be merged. They are always sent together and `NEW` packet does not provide any other information that `INFO` would not provide.

Order of messages for admin port is changed. It is logical change in my opinion, however this change might have unforseen consequences to any admin port client which expects unlogical messages order. Maybe upping `NETWORK_GAME_ADMIN_VERSION` to 5 would be a good idea?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)


I messed my branch and I needed to recreate PR #11092