### PR TITLE
Add: [Script] Game script control of industry production level.

### DIFF
--- a/src/command_type.h
+++ b/src/command_type.h
@@ -246,6 +246,7 @@ enum Commands : uint16_t {
 	CMD_INDUSTRY_SET_FLAGS,           ///< change industry control flags
 	CMD_INDUSTRY_SET_EXCLUSIVITY,     ///< change industry exclusive consumer/supplier
 	CMD_INDUSTRY_SET_TEXT,            ///< change additional text for the industry
+	CMD_INDUSTRY_SET_PRODUCTION,      ///< change industry production
 
 	CMD_SET_COMPANY_MANAGER_FACE,     ///< set the manager's face of the company
 	CMD_SET_COMPANY_COLOUR,           ///< set the colour of the company

--- a/src/industry.h
+++ b/src/industry.h
@@ -51,8 +51,10 @@ enum IndustryControlFlags : byte {
 	 * Industry can not close regardless of production level or time since last delivery.
 	 * This does not prevent a closure already announced. */
 	INDCTL_NO_CLOSURE             = 1 << 2,
+	/** Indicates that the production level of the industry is externally controlled. */
+	INDCTL_EXTERNAL_PROD_LEVEL    = 1 << 3,
 	/** Mask of all flags set */
-	INDCTL_MASK = INDCTL_NO_PRODUCTION_DECREASE | INDCTL_NO_PRODUCTION_INCREASE | INDCTL_NO_CLOSURE,
+	INDCTL_MASK = INDCTL_NO_PRODUCTION_DECREASE | INDCTL_NO_PRODUCTION_INCREASE | INDCTL_NO_CLOSURE | INDCTL_EXTERNAL_PROD_LEVEL,
 };
 DECLARE_ENUM_AS_BIT_SET(IndustryControlFlags);
 

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2123,9 +2123,10 @@ CommandCost CmdIndustrySetFlags(DoCommandFlag flags, IndustryID ind_id, Industry
  * @param ind_id IndustryID
  * @param prod_level Production level.
  * @param show_news Show a news message on production change.
+ * @param custom_news Custom news message text.
  * @return Empty cost or an error.
  */
-CommandCost CmdIndustrySetProduction(DoCommandFlag flags, IndustryID ind_id, byte prod_level, bool show_news)
+CommandCost CmdIndustrySetProduction(DoCommandFlag flags, IndustryID ind_id, byte prod_level, bool show_news, const std::string &custom_news)
 {
 	if (_current_company != OWNER_DEITY) return CMD_ERROR;
 	if (prod_level < PRODLEVEL_MINIMUM || prod_level > PRODLEVEL_MAXIMUM) return CMD_ERROR;
@@ -2140,6 +2141,7 @@ CommandCost CmdIndustrySetProduction(DoCommandFlag flags, IndustryID ind_id, byt
 		} else if (prod_level < ind->prod_level) {
 			str = GetIndustrySpec(ind->type)->production_down_text;
 		}
+		if (prod_level != ind->prod_level && !custom_news.empty()) str = STR_NEWS_CUSTOM_ITEM;
 
 		ind->ctlflags |= INDCTL_EXTERNAL_PROD_LEVEL;
 		ind->prod_level = prod_level;
@@ -2156,14 +2158,18 @@ CommandCost CmdIndustrySetProduction(DoCommandFlag flags, IndustryID ind_id, byt
 			}
 
 			/* Set parameters of news string */
-			if (str > STR_LAST_STRINGID) {
+			NewsAllocatedData *data = nullptr;
+			if (str == STR_NEWS_CUSTOM_ITEM) {
+				NewsStringData *news = new NewsStringData(custom_news);
+				SetDParamStr(0, news->string);
+			} else if (str > STR_LAST_STRINGID) {
 				SetDParam(0, STR_TOWN_NAME);
 				SetDParam(1, ind->town->index);
 				SetDParam(2, GetIndustrySpec(ind->type)->name);
 			} else {
 				SetDParam(0, ind->index);
 			}
-			AddIndustryNewsItem(str, nt, ind->index);
+			AddIndustryNewsItem(str, nt, ind->index, data);
 		}
 	}
 

--- a/src/industry_cmd.h
+++ b/src/industry_cmd.h
@@ -20,11 +20,13 @@ CommandCost CmdBuildIndustry(DoCommandFlag flags, TileIndex tile, IndustryType i
 CommandCost CmdIndustrySetFlags(DoCommandFlag flags, IndustryID ind_id, IndustryControlFlags ctlflags);
 CommandCost CmdIndustrySetExclusivity(DoCommandFlag flags, IndustryID ind_id, Owner company_id, bool consumer);
 CommandCost CmdIndustrySetText(DoCommandFlag flags, IndustryID ind_id, const std::string &text);
+CommandCost CmdIndustrySetProduction(DoCommandFlag flags, IndustryID ind_id, byte prod_level, bool show_news);
 
 DEF_CMD_TRAIT(CMD_BUILD_INDUSTRY, CmdBuildIndustry, CMD_DEITY, CMDT_LANDSCAPE_CONSTRUCTION)
 DEF_CMD_TRAIT(CMD_INDUSTRY_SET_FLAGS, CmdIndustrySetFlags, CMD_DEITY, CMDT_OTHER_MANAGEMENT)
 DEF_CMD_TRAIT(CMD_INDUSTRY_SET_EXCLUSIVITY, CmdIndustrySetExclusivity, CMD_DEITY, CMDT_OTHER_MANAGEMENT)
 DEF_CMD_TRAIT(CMD_INDUSTRY_SET_TEXT, CmdIndustrySetText, CMD_DEITY | CMD_STR_CTRL, CMDT_OTHER_MANAGEMENT)
+DEF_CMD_TRAIT(CMD_INDUSTRY_SET_PRODUCTION, CmdIndustrySetProduction, CMD_DEITY, CMDT_OTHER_MANAGEMENT)
 
 void CcBuildIndustry(Commands cmd, const CommandCost &result, TileIndex tile, IndustryType indtype, uint32_t, bool, uint32_t);
 

--- a/src/industry_cmd.h
+++ b/src/industry_cmd.h
@@ -20,7 +20,7 @@ CommandCost CmdBuildIndustry(DoCommandFlag flags, TileIndex tile, IndustryType i
 CommandCost CmdIndustrySetFlags(DoCommandFlag flags, IndustryID ind_id, IndustryControlFlags ctlflags);
 CommandCost CmdIndustrySetExclusivity(DoCommandFlag flags, IndustryID ind_id, Owner company_id, bool consumer);
 CommandCost CmdIndustrySetText(DoCommandFlag flags, IndustryID ind_id, const std::string &text);
-CommandCost CmdIndustrySetProduction(DoCommandFlag flags, IndustryID ind_id, byte prod_level, bool show_news);
+CommandCost CmdIndustrySetProduction(DoCommandFlag flags, IndustryID ind_id, byte prod_level, bool show_news, const std::string &text);
 
 DEF_CMD_TRAIT(CMD_BUILD_INDUSTRY, CmdBuildIndustry, CMD_DEITY, CMDT_LANDSCAPE_CONSTRUCTION)
 DEF_CMD_TRAIT(CMD_INDUSTRY_SET_FLAGS, CmdIndustrySetFlags, CMD_DEITY, CMDT_OTHER_MANAGEMENT)

--- a/src/news_func.h
+++ b/src/news_func.h
@@ -47,9 +47,9 @@ static inline void AddTileNewsItem(StringID string, NewsType type, TileIndex til
 	AddNewsItem(string, type, NF_NO_TRANSPARENT | NF_SHADE | NF_THIN, NR_TILE, static_cast<uint32_t>(tile), station == INVALID_STATION ? NR_NONE : NR_STATION, station, data);
 }
 
-static inline void AddIndustryNewsItem(StringID string, NewsType type, IndustryID industry)
+static inline void AddIndustryNewsItem(StringID string, NewsType type, IndustryID industry, const NewsAllocatedData *data = nullptr)
 {
-	AddNewsItem(string, type, NF_NO_TRANSPARENT | NF_SHADE | NF_THIN, NR_INDUSTRY, industry);
+	AddNewsItem(string, type, NF_NO_TRANSPARENT | NF_SHADE | NF_THIN, NR_INDUSTRY, industry, NR_NONE, UINT32_MAX, data);
 }
 
 void NewsLoop();

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -78,6 +78,8 @@
  * \li GSVehicleList_DefaultGroup
  * \li GSGoal::IsValidGoalDestination
  * \li GSGoal::SetDestination
+ * \li GSIndustry::GetProductionLevel
+ * \li GSIndustry::SetProductionLevel
  *
  * API removals:
  * \li GSError::ERR_PRECONDITION_TOO_MANY_PARAMETERS, that error is never returned anymore.

--- a/src/script/api/script_industry.cpp
+++ b/src/script/api/script_industry.cpp
@@ -294,3 +294,19 @@
 	::Owner owner = (company == ScriptCompany::COMPANY_INVALID ? ::INVALID_OWNER : (::Owner)company);
 	return ScriptObject::Command<CMD_INDUSTRY_SET_EXCLUSIVITY>::Do(industry_id, owner, true);
 }
+
+/* static */ SQInteger ScriptIndustry::GetProductionLevel(IndustryID industry_id)
+{
+	Industry *i = Industry::GetIfValid(industry_id);
+	if (i == nullptr) return 0;
+	return i->prod_level;
+}
+
+/* static */ bool ScriptIndustry::SetProductionLevel(IndustryID industry_id, SQInteger prod_level, bool show_news)
+{
+	EnforceDeityMode(false);
+	EnforcePrecondition(false, IsValidIndustry(industry_id));
+	EnforcePrecondition(false, prod_level >= PRODLEVEL_MINIMUM && prod_level <= PRODLEVEL_MAXIMUM);
+
+	return ScriptObject::Command<CMD_INDUSTRY_SET_PRODUCTION>::Do(industry_id, prod_level, show_news);
+}

--- a/src/script/api/script_industry.cpp
+++ b/src/script/api/script_industry.cpp
@@ -302,11 +302,13 @@
 	return i->prod_level;
 }
 
-/* static */ bool ScriptIndustry::SetProductionLevel(IndustryID industry_id, SQInteger prod_level, bool show_news)
+/* static */ bool ScriptIndustry::SetProductionLevel(IndustryID industry_id, SQInteger prod_level, bool show_news, Text *custom_news)
 {
+	CCountedPtr<Text> counter(custom_news);
+
 	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidIndustry(industry_id));
 	EnforcePrecondition(false, prod_level >= PRODLEVEL_MINIMUM && prod_level <= PRODLEVEL_MAXIMUM);
 
-	return ScriptObject::Command<CMD_INDUSTRY_SET_PRODUCTION>::Do(industry_id, prod_level, show_news);
+	return ScriptObject::Command<CMD_INDUSTRY_SET_PRODUCTION>::Do(industry_id, prod_level, show_news, custom_news != nullptr ? custom_news->GetEncodedText() : std::string{});
 }

--- a/src/script/api/script_industry.hpp
+++ b/src/script/api/script_industry.hpp
@@ -341,13 +341,14 @@ public:
 	 * @param industry_id The index of the industry.
 	 * @param prod_level The production level to set.
 	 * @param show_news If set to true and the production changed, generate a production change news message. If set to false, no news message is shown.
+	 * @param custom_news Custom news message text to override the default news text with. Pass null to use the default text. Only used if \c show_news is set to true.
 	 * @pre IsValidIndustry(industry_id).
 	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre prod_level >= 4 && prod_level <= 128.
 	 * @return True if the action succeeded.
 	 * @api -ai
 	 */
-	static bool SetProductionLevel(IndustryID industry_id, SQInteger prod_level, bool show_news);
+	static bool SetProductionLevel(IndustryID industry_id, SQInteger prod_level, bool show_news, Text *custom_news);
 };
 
 #endif /* SCRIPT_INDUSTRY_HPP */

--- a/src/script/api/script_industry.hpp
+++ b/src/script/api/script_industry.hpp
@@ -47,6 +47,10 @@ public:
 		 * This does not prevent a closure already announced.
 		 */
 		INDCTL_NO_CLOSURE             = ::INDCTL_NO_CLOSURE,
+		/**
+		 * Indicates that the production level of the industry is controlled by a game script.
+		 */
+		INDCTL_EXTERNAL_PROD_LEVEL    = ::INDCTL_EXTERNAL_PROD_LEVEL,
 	};
 
 	/**
@@ -323,6 +327,27 @@ public:
 	 */
 	static bool SetExclusiveConsumer(IndustryID industry_id, ScriptCompany::CompanyID company_id);
 
+	/**
+	 * Gets the current production level of an industry.
+	 * @param industry_id The index of the industry.
+	 * @api -ai
+	 */
+	static SQInteger GetProductionLevel(IndustryID industry_id);
+
+	/**
+	 * Sets the current production level of an industry.
+	 * @note Setting the production level automatically sets the control flag INDCTL_EXTERNAL_PROD_LEVEL if it wasn't already set.
+	 *     Normal production behaviour can be restored by clearing the control flag.
+	 * @param industry_id The index of the industry.
+	 * @param prod_level The production level to set.
+	 * @param show_news If set to true and the production changed, generate a production change news message. If set to false, no news message is shown.
+	 * @pre IsValidIndustry(industry_id).
+	 * @pre ScriptCompanyMode::IsDeity().
+	 * @pre prod_level >= 4 && prod_level <= 128.
+	 * @return True if the action succeeded.
+	 * @api -ai
+	 */
+	static bool SetProductionLevel(IndustryID industry_id, SQInteger prod_level, bool show_news);
 };
 
 #endif /* SCRIPT_INDUSTRY_HPP */


### PR DESCRIPTION
## Motivation / Problem

Game scripts can override industry production in a limited way. They can prohibit production increases and/or decreases and prevent closure. But they can't actually change production, just hold it in place.

This half-way control isn't very useful if a GS wants to implement custom industry production rules.

## Description

This PR adds GS API methods to get and set the production multiplier of an industry. NewGRFs are notified by a new flag in var 47 (GameScript control status). Setting the production multiplier does not prohibit industry closure, GS can use the existing control flag for this.

A script can optionally let OTTD generate a production change news message if needed.

## Limitations

I'm not sure about the actual GS API. Maybe it would be better to use a magic prod_level value to restore the default production behaviour instead of the need to clear the control flag.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
