### PR TITLE
Feature: Setting to automatically restart server based on hours played

### DIFF
--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -120,6 +120,7 @@ public:
 };
 
 void NetworkServer_Tick(bool send_frame);
+void ChangeNetworkRestartTime(bool reset);
 void NetworkServerSetCompanyPassword(CompanyID company_id, const std::string &password, bool already_hashed = true);
 void NetworkServerUpdateCompanyPassworded(CompanyID company_id, bool passworded);
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -34,6 +34,7 @@
 #include "console_func.h"
 #include "screenshot.h"
 #include "network/network.h"
+#include "network/network_server.h"
 #include "network/network_func.h"
 #include "ai/ai.hpp"
 #include "ai/ai_config.hpp"
@@ -917,7 +918,11 @@ static void MakeNewGameDone()
 	CheckIndustries();
 	MarkWholeScreenDirty();
 
-	if (_network_server && !_network_dedicated) ShowClientList();
+	if (_network_server) {
+		ChangeNetworkRestartTime(true);
+
+		if (!_network_dedicated) ShowClientList();
+	}
 }
 
 static void MakeNewGame(bool from_heightmap, bool reset_settings)

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -325,6 +325,7 @@ struct NetworkSettings {
 	uint8_t       max_companies;                            ///< maximum amount of companies
 	uint8_t       max_clients;                              ///< maximum amount of clients
 	TimerGameCalendar::Year restart_game_year;            ///< year the server restarts
+	uint16_t      restart_hours;                          ///< number of hours to run the server before automatic restart
 	uint8_t       min_active_clients;                       ///< minimum amount of active clients to unpause the game
 	bool        reload_cfg;                               ///< reload the config file before restarting
 	std::string last_joined;                              ///< Last joined server

--- a/src/table/settings/network_settings.ini
+++ b/src/table/settings/network_settings.ini
@@ -8,6 +8,7 @@
 
 [pre-amble]
 static void UpdateClientConfigValues();
+void ChangeNetworkRestartTime(bool reset);
 
 static constexpr std::initializer_list<const char*> _server_game_type{"local", "public", "invite-only"};
 
@@ -240,6 +241,16 @@ def      = 0
 min      = CalendarTime::MIN_YEAR
 max      = CalendarTime::MAX_YEAR
 interval = 1
+
+[SDTC_VAR]
+var      = network.restart_hours
+type     = SLE_UINT16
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_0_IS_SPECIAL | SF_NETWORK_ONLY
+def      = 0
+min      = 0
+max      = UINT16_MAX
+interval = 1
+post_cb  = [](auto) { ChangeNetworkRestartTime(false); }
 
 [SDTC_VAR]
 var      = network.min_active_clients


### PR DESCRIPTION
## Motivation / Problem

We have a setting for network games to automatically restart upon reaching a certain year. That will never happen if calendar time is frozen.

## Description

Add a new setting for a timer that counts down hours played, and resets after that.

## Limitations

This was originally a change before @TrueBrain suggested we have both, so blame him for more code to maintain. 😉 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
