### PR TITLE
Fix: store autosave settings under the new names

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -102,15 +102,6 @@ bool _save_config = false;
 bool _request_newgrf_scan = false;
 NewGRFScanCallback *_request_newgrf_scan_callback = nullptr;
 
-/** Available settings for autosave intervals. */
-static const std::chrono::milliseconds _autosave_ticks[] = {
-	std::chrono::minutes::zero(), ///< never
-	std::chrono::minutes(10),
-	std::chrono::minutes(30),
-	std::chrono::minutes(60),
-	std::chrono::minutes(120),
-};
-
 /**
  * Error handling for fatal user errors.
  * @param str the string to print.
@@ -1458,7 +1449,7 @@ static IntervalTimer<TimerGameRealtime> _autosave_interval({std::chrono::millise
  */
 void ChangeAutosaveFrequency(bool reset)
 {
-	_autosave_interval.SetInterval({_autosave_ticks[_settings_client.gui.autosave], TimerGameRealtime::AUTOSAVE}, reset);
+	_autosave_interval.SetInterval({_settings_client.gui.autosave_interval, TimerGameRealtime::AUTOSAVE}, reset);
 }
 
 /**

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -196,6 +196,8 @@ struct BoolSettingDesc : IntSettingDesc {
 		IntSettingDesc(save, flags, startup, def, 0, 1, 0, str, str_help, str_val, cat,
 			pre_check, post_callback) {}
 
+	static std::optional<bool> ParseSingleValue(const char *str);
+
 	bool IsBoolSetting() const override { return true; }
 	size_t ParseValue(const char *str) const override;
 	std::string FormatValue(const void *object) const override;

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -142,7 +142,7 @@ struct GUISettings {
 	ZoomLevel zoom_min;                      ///< minimum zoom out level
 	ZoomLevel zoom_max;                      ///< maximum zoom out level
 	ZoomLevel sprite_zoom_min;               ///< maximum zoom level at which higher-resolution alternative sprites will be used (if available) instead of scaling a lower resolution sprite
-	byte   autosave;                         ///< how often should we do autosaves?
+	std::chrono::minutes autosave_interval;  ///< how often should we do autosaves?
 	bool   threaded_saves;                   ///< should we do threaded saves?
 	bool   keep_all_autosave;                ///< name the autosave in a different way
 	bool   autosave_on_exit;                 ///< save an autosave when you quit the game, but do not ask "Do you really want to quit?"

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -16,7 +16,6 @@ static void InvalidateNewGRFChangeWindows(int32 new_value);
 static void ZoomMinMaxChanged(int32 new_value);
 static void SpriteZoomMinChanged(int32 new_value);
 
-static constexpr std::initializer_list<const char*> _autosave_interval{"off", "monthly", "quarterly", "half year", "yearly"};
 static constexpr std::initializer_list<const char*> _osk_activation{"disabled", "double", "single", "immediately"};
 static constexpr std::initializer_list<const char*> _savegame_date{"long", "short", "iso"};
 
@@ -48,16 +47,15 @@ extra    = 0
 startup  = false
 
 
-[SDTC_OMANY]
-var      = gui.autosave
-type     = SLE_UINT8
-flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
-def      = 1
-max      = 4
-full     = _autosave_interval
+[SDTC_VAR]
+var      = gui.autosave_interval
+type     = SLE_UINT32
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
+def      = 10
+min      = 0
+max      = 1440
 str      = STR_CONFIG_SETTING_AUTOSAVE
 strhelp  = STR_CONFIG_SETTING_AUTOSAVE_HELPTEXT
-strval   = STR_GAME_OPTIONS_AUTOSAVE_DROPDOWN_OFF
 cat      = SC_BASIC
 
 [SDTC_BOOL]

--- a/src/table/settings/old_gameopt_settings.ini
+++ b/src/table/settings/old_gameopt_settings.ini
@@ -142,15 +142,6 @@ min      = MIN_SNOWLINE_HEIGHT * TILE_HEIGHT
 max      = UINT8_MAX
 to       = SLV_22
 
-[SDTC_OMANY]
-var      = gui.autosave
-type     = SLE_UINT8
-flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
-def      = 1
-max      = 4
-full     = _autosave_interval
-cat      = SC_BASIC
-
 [SDT_OMANY]
 var      = vehicle.road_side
 type     = SLE_UINT8


### PR DESCRIPTION
## Motivation / Problem

While looking for a way to allow aliases for `OMANY`, I noticed autosave was storing the wrong settings values. And that we have a way to allow aliases.

## Description

Instead of storing the old `monthly`, `yearly`, etc, store it in minutes.

This keeps the original setting in tact, and renames the new one. This allows switching back between old and new versions without annoying warnings.

Based on comments and feedback, this PR grew a bit bigger to supply a framework for future conversions too. Also makes it a bit more readable :)

## Limitations

The GUI doesn't allow for anything between the predefined settings. This means if the user changes the value in the config to something other than 0/10/30/60/120, it will work, till the Game Options are opened again.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
