### PR TITLE
Codechange: wire "load" support into all OMANY and MMANY for settings

### DIFF
--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -218,7 +218,7 @@ struct OneOfManySettingDesc : IntSettingDesc {
 	std::vector<std::string> many; ///< possible values for this type
 	OnConvert *many_cnvt;          ///< callback procedure when loading value mechanism fails
 
-	static size_t ParseSingleValue(const char *str, size_t len, const std::vector<std::string> &many);
+	static size_t ParseSingleValue(const char *str, size_t len, const std::vector<std::string> &many, OnConvert *many_cnvt);
 	std::string FormatSingleValue(uint id) const;
 
 	size_t ParseValue(const char *str) const override;

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -343,7 +343,7 @@ static size_t ConvertLandscape(const char *value)
 {
 	/* try with the old values */
 	static std::vector<std::string> _old_landscape_values{"normal", "hilly", "desert", "candy"};
-	return OneOfManySettingDesc::ParseSingleValue(value, strlen(value), _old_landscape_values);
+	return OneOfManySettingDesc::ParseSingleValue(value, strlen(value), _old_landscape_values, nullptr);
 }
 
 static bool CheckFreeformEdges(int32 &new_value)

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -68,11 +68,11 @@ static size_t ConvertLandscape(const char *value);
 #define SDTG_SSTR(name, type, flags, var, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
 	NSD(String, SLEG_GENERAL(name, SL_STDSTR, var, type, sizeof(var), from, to, extra), flags, startup, def, max_length, pre_check, post_callback)
 
-#define SDTG_OMANY(name, type, flags, var, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
-	NSD(OneOfMany, SLEG_GENERAL(name, SL_VAR, var, type, 1, from, to, extra), flags, startup, def, max, str, strhelp, strval, cat, pre_check, post_callback, full, nullptr)
+#define SDTG_OMANY(name, type, flags, var, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, load, cat, extra, startup)\
+	NSD(OneOfMany, SLEG_GENERAL(name, SL_VAR, var, type, 1, from, to, extra), flags, startup, def, max, str, strhelp, strval, cat, pre_check, post_callback, full, load)
 
-#define SDTG_MMANY(name, type, flags, var, def, full, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
-	NSD(ManyOfMany, SLEG_GENERAL(name, SL_VAR, var, type, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, full, nullptr)
+#define SDTG_MMANY(name, type, flags, var, def, full, str, strhelp, strval, pre_check, post_callback, from, to, load, cat, extra, startup)\
+	NSD(ManyOfMany, SLEG_GENERAL(name, SL_VAR, var, type, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, full, load)
 
 /* Macros for various objects to go in the configuration file.
  * This section is for structures where their various members are saved */
@@ -94,8 +94,8 @@ static size_t ConvertLandscape(const char *value);
 #define SDT_OMANY(base, var, type, flags, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, load, cat, extra, startup)\
 	NSD(OneOfMany, SLE_GENERAL(SL_VAR, base, var, type, 1, from, to, extra), flags, startup, def, max, str, strhelp, strval, cat, pre_check, post_callback, full, load)
 
-#define SDT_MMANY(base, var, type, flags, def, full, str, pre_check, post_callback, strhelp, strval, from, to, cat, extra, startup)\
-	NSD(ManyOfMany, SLE_GENERAL(SL_VAR, base, var, type, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, full, nullptr)
+#define SDT_MMANY(base, var, type, flags, def, full, str, pre_check, post_callback, strhelp, strval, from, to, load, cat, extra, startup)\
+	NSD(ManyOfMany, SLE_GENERAL(SL_VAR, base, var, type, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, full, load)
 
 
 #define SDTC_VAR(var, type, flags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
@@ -110,5 +110,5 @@ static size_t ConvertLandscape(const char *value);
 #define SDTC_SSTR(var, type, flags, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
 	SDTG_SSTR(#var, type, flags, _settings_client.var, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
 
-#define SDTC_OMANY(var, type, flags, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
-	SDTG_OMANY(#var, type, flags, _settings_client.var, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)
+#define SDTC_OMANY(var, type, flags, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, load, cat, extra, startup)\
+	SDTG_OMANY(#var, type, flags, _settings_client.var, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, load, cat, extra, startup)

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -25,7 +25,7 @@ static const SettingVariant _gui_settings_table[] = {
 };
 [templates]
 SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
 SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]

--- a/src/table/settings/locale_settings.ini
+++ b/src/table/settings/locale_settings.ini
@@ -19,7 +19,7 @@ static const SettingVariant _locale_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDTG_OMANY = SDTG_OMANY($name,              $type, $flags, $var, $def,       $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_OMANY = SDTG_OMANY($name,              $type, $flags, $var, $def,       $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
 SDT_OMANY  =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
 SDT_SSTR   =   SDT_SSTR(GameSettings, $var, $type, $flags, $def,                                                       $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 

--- a/src/table/settings/misc_settings.ini
+++ b/src/table/settings/misc_settings.ini
@@ -24,12 +24,12 @@ static const SettingVariant _misc_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDTG_LIST  =  SDTG_LIST($name, $type, $flags, $var, $def,       $length,                                                            $from, $to, $cat, $extra, $startup),
-SDTG_MMANY = SDTG_MMANY($name, $type, $flags, $var, $def,                        $full, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDTG_OMANY = SDTG_OMANY($name, $type, $flags, $var, $def,       $max,            $full, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDTG_SSTR  =  SDTG_SSTR($name, $type, $flags, $var, $def,       0,                                               $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDTG_BOOL  =  SDTG_BOOL($name,        $flags, $var, $def,                               $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDTG_VAR   =   SDTG_VAR($name, $type, $flags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDTG_LIST  =  SDTG_LIST($name, $type, $flags, $var, $def,       $length,                                                            $from, $to,        $cat, $extra, $startup),
+SDTG_MMANY = SDTG_MMANY($name, $type, $flags, $var, $def,                        $full, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
+SDTG_OMANY = SDTG_OMANY($name, $type, $flags, $var, $def,       $max,            $full, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
+SDTG_SSTR  =  SDTG_SSTR($name, $type, $flags, $var, $def,       0,                                               $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_BOOL  =  SDTG_BOOL($name,        $flags, $var, $def,                               $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_VAR   =   SDTG_VAR($name, $type, $flags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");

--- a/src/table/settings/network_private_settings.ini
+++ b/src/table/settings/network_private_settings.ini
@@ -15,9 +15,8 @@ static const SettingVariant _network_private_settings_table[] = {
 };
 [templates]
 SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
 SDTC_SSTR  =  SDTC_SSTR(              $var, $type, $flags, $def,             $length,                                  $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTC_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");

--- a/src/table/settings/network_settings.ini
+++ b/src/table/settings/network_settings.ini
@@ -16,7 +16,7 @@ static const SettingVariant _network_settings_table[] = {
 };
 [templates]
 SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
 SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]

--- a/src/table/settings/news_display_settings.ini
+++ b/src/table/settings/news_display_settings.ini
@@ -13,7 +13,7 @@ static const SettingVariant _news_display_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
 
 [validation]
 SDTC_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");

--- a/src/table/settings/old_gameopt_settings.ini
+++ b/src/table/settings/old_gameopt_settings.ini
@@ -31,10 +31,10 @@ static const SettingVariant _old_gameopt_settings_table[] = {
 };
 [templates]
 SDTG_LIST    =  SDTG_LIST($name,              $type, $flags, $var, $def, $length, $from, $to, $cat, $extra, $startup),
-SDTG_VAR     =   SDTG_VAR($name,              $type, $flags, $var, $def, $min, $max, $interval,  $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDT_NULL     =   SDT_NULL(                                                          $length,                                                            $from, $to),
-SDTC_OMANY   = SDTC_OMANY(              $var, $type, $flags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTG_OMANY   = SDTG_OMANY($name,              $type, $flags, $var, $def, $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_VAR     =   SDTG_VAR($name,              $type, $flags, $var, $def, $min, $max, $interval,  $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDT_NULL     =   SDT_NULL(                                               $length,                                                            $from, $to),
+SDTC_OMANY   = SDTC_OMANY(              $var, $type, $flags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
+SDTG_OMANY   = SDTG_OMANY($name,              $type, $flags, $var, $def, $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
 SDT_OMANY    =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
 SDT_VAR      =    SDT_VAR(GameSettings, $var, $type, $flags, $def, $min, $max,        $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 


### PR DESCRIPTION
## Motivation / Problem

While working on #11143 I had some arguments with the code in respect to `load` and OMANY.

## Description

This PR fixes so that `load` works for all `OMANY` (and `MMANY`). Nobody actually uses it, so you can argue if this PR should be merged, but the current code was silly.

While at it, also reworked the logic slightly, that it first tries to use the lookup, next the conversion, and only after that check if it is a digit. The original code did the digit first, which meant you can't do a lookup starting with a number.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
