### PR TITLE
NRT: Change: Do not allow mixing road/tram types in powered road type list

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -4484,7 +4484,13 @@ static ChangeInfoResult RoadTypeChangeInfo(uint id, int numinfo, int prop, ByteR
 					RoadType resolved_rt = GetRoadTypeByLabel(BSWAP32(label), false);
 					if (resolved_rt != INVALID_ROADTYPE) {
 						switch (prop) {
-							case 0x0F: SetBit(rti->powered_roadtypes, resolved_rt);               break;
+							case 0x0F:
+								if (GetRoadTramType(resolved_rt) == rtt) {
+									SetBit(rti->powered_roadtypes, resolved_rt);
+								} else {
+									GrfMsg(1, "RoadTypeChangeInfo: Powered road type list: Road type {} road/tram type does not match road type {}, ignoring", resolved_rt, rt);
+								}
+								break;
 							case 0x18: SetBit(rti->introduction_required_roadtypes, resolved_rt); break;
 							case 0x19: SetBit(rti->introduces_roadtypes, resolved_rt);            break;
 						}


### PR DESCRIPTION
## Motivation / Problem

Road/tram property 0F

Do not allow adding tram types to the powered road type list of road types, or vice versa.
Doing so leads to to significant number of NRT-related failure paths.

## Description

Attempting to add a tram type to the powered road type list of a road type, or vice versa, is ignored, and a suitable message is printed at debug level grf >= 1.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
