### PR TITLE
Fix: crash when not passing parameter for -n

### DIFF
--- a/docs/openttd.6
+++ b/docs/openttd.6
@@ -1,6 +1,6 @@
 .\"                                      Hey, EMACS: -*- nroff -*-
 .\" Please adjust this date whenever revising the manpage.
-.Dd October 13, 2014
+.Dd August 12, 2023
 .Dt OPENTTD 6
 .Os
 .Sh NAME
@@ -8,7 +8,7 @@
 .Nd open source clone of the Microprose game \(lqTransport Tycoon Deluxe\(rq
 .Sh SYNOPSIS
 .Nm
-.Op Fl efhx
+.Op Fl efhQxX
 .Op Fl b Ar blitter
 .Op Fl c Ar config_file
 .Op Fl d Op Ar level | Ar cat Ns = Ns Ar lvl Ns Op , Ns Ar ...
@@ -19,7 +19,7 @@
 .Op Fl l Ar host Ns Op : Ns Ar port
 .Op Fl m Ar driver
 .Op Fl M Ar musicset
-.Op Fl n Ar host Ns Oo : Ns Ar port Oc Ns Op # Ns Ar player
+.Op Fl n Ar host Ns Oo : Ns Ar port Oc Ns Op # Ns Ar company
 .Op Fl p Ar password
 .Op Fl P Ar password
 .Op Fl q Ar savegame
@@ -29,7 +29,7 @@
 .Op Fl t Ar year
 .Op Fl v Ar driver
 .Sh OPTIONS
-.Bl -tag -width "-n host[:port][#player]"
+.Bl -tag -width "-n host[:port][#company]"
 .It Fl b Ar blitter
 Select the blitter
 .Ar blitter ;
@@ -83,10 +83,8 @@ see
 .Fl h
 for a full list.
 .It Fl l Ar host Ns Op : Ns Ar port
-Redirect
-.Fn DEBUG
-output; see
-.Fl D .
+Redirect debug output; see
+.Fl d .
 .It Fl m Ar driver
 Select the music driver
 .Ar driver ;
@@ -99,8 +97,8 @@ Select the music set
 see
 .Fl h
 for a full list.
-.It Fl n Ar host Ns Oo : Ns Ar port Oc Ns Op # Ns Ar player
-Join a network game, optionally specifying a port to connect to and player to
+.It Fl n Ar host Ns Oo : Ns Ar port Oc Ns Op # Ns Ar company
+Join a network game, optionally specifying a port to connect to and company to
 play as.
 .It Fl p Ar password
 Password used to join server.
@@ -112,6 +110,14 @@ Only useful with
 .Fl n .
 .It Fl q Ar savegame
 Write some information about the specified savegame and exit.
+.It Fl Q
+Don't scan for/load NewGRF files on startup.
+.Pp
+Passing
+.Fl Q
+twice (so,
+.Fl QQ
+) will disable NewGRF scanning/loading entirely.
 .It Fl r Ar width Ns x Ns Ar height
 Set the resolution to
 .Ar width
@@ -141,6 +147,8 @@ see
 for a full list.
 .It Fl x
 Do not automatically save to config file on exit.
+.It Fl X
+Do not use global folders to search for files.
 .El
 .Sh SEE ALSO
 .Lk https://wiki.openttd.org "Wiki"

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -166,11 +166,11 @@ static void ShowHelp()
 		"  -e                  = Start Editor\n"
 		"  -g [savegame]       = Start new/save game immediately\n"
 		"  -G seed             = Set random seed\n"
-		"  -n ip[:port][#company]= Join network game\n"
+		"  -n host[:port][#company]= Join network game\n"
 		"  -p password         = Password to join server\n"
 		"  -P password         = Password to join company\n"
-		"  -D [ip][:port]      = Start dedicated server\n"
-		"  -l ip[:port]        = Redirect Debug()\n"
+		"  -D [host][:port]    = Start dedicated server\n"
+		"  -l host[:port]      = Redirect Debug()\n"
 #if !defined(_WIN32)
 		"  -f                  = Fork into the background (dedicated only)\n"
 #endif
@@ -548,7 +548,7 @@ int openttd_main(int argc, char *argv[])
 			break;
 		case 'f': _dedicated_forks = true; break;
 		case 'n':
-			scanner->connection_string = mgo.opt; // IP:port#company parameter
+			scanner->connection_string = mgo.opt; // host:port#company parameter
 			break;
 		case 'l':
 			debuglog_conn = mgo.opt;

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -166,7 +166,7 @@ static void ShowHelp()
 		"  -e                  = Start Editor\n"
 		"  -g [savegame]       = Start new/save game immediately\n"
 		"  -G seed             = Set random seed\n"
-		"  -n [ip:port#company]= Join network game\n"
+		"  -n ip[:port][#company]= Join network game\n"
 		"  -p password         = Password to join server\n"
 		"  -P password         = Password to join company\n"
 		"  -D [ip][:port]      = Start dedicated server\n"
@@ -473,7 +473,7 @@ static const OptionData _options[] = {
 	 GETOPT_SHORT_VALUE('v'),
 	 GETOPT_SHORT_VALUE('b'),
 	GETOPT_SHORT_OPTVAL('D'),
-	GETOPT_SHORT_OPTVAL('n'),
+	 GETOPT_SHORT_VALUE('n'),
 	 GETOPT_SHORT_VALUE('l'),
 	 GETOPT_SHORT_VALUE('p'),
 	 GETOPT_SHORT_VALUE('P'),
@@ -548,7 +548,7 @@ int openttd_main(int argc, char *argv[])
 			break;
 		case 'f': _dedicated_forks = true; break;
 		case 'n':
-			scanner->connection_string = mgo.opt; // optional IP:port#company parameter
+			scanner->connection_string = mgo.opt; // IP:port#company parameter
 			break;
 		case 'l':
 			debuglog_conn = mgo.opt;


### PR DESCRIPTION
## Motivation / Problem

Run `openttd -n` -> crash.


## Description

The crash happens for at least two years. However, practically this command line parameter has been broken since its introduction. It proclaimed to have an optional parameter, but later checking for it to be `nullptr` or not. Actually, in the begin it also set a boolean, which it checked first before checking for `nullptr` at the later location. In other words, even though it said the parameter is optional, it has never been optional if you wanted to get into that functionality.

So, I made the parameter non-optional (line 475).

Also looking at the comment/help message, there is no requirement for passing an IP-address, just a hostname is good enough. So I took the 'host' labelling from the man page.
Since the man page needed to be updated anyhow, I added the other missing parameters to it, renamed player to company (a change from a decade or more ago) and updated the date.


## Limitations

Not really. Unless you consider `openttd -n` now showing the help message and exiting as a deviation from the pre 12 behaviour. Since 12 it crashes to desktop though, so I do not think it's a real problem.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
