### PR TITLE
Backport master into release/13

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -23,29 +23,69 @@ jobs:
       run: |
         tar -xf source.tar.gz --strip-components=1
 
+    - name: Enable vcpkg cache
+      uses: actions/cache@v3
+      with:
+        path: /vcpkg/installed
+        key: ubuntu-20.04-vcpkg-release-0 # Increase the number whenever dependencies are modified
+        restore-keys: |
+          ubuntu-20.04-vcpkg-release
+
     - name: Install dependencies
       run: |
-        echo "::group::Install dependencies"
+        echo "::group::Install system dependencies"
+        # ICU is used as vcpkg fails to install ICU. Other dependencies
+        # are needed either for vcpkg or for the packages installed with
+        # vcpkg.
         yum install -y \
-          fontconfig-devel \
-          freetype-devel \
           libicu-devel \
-          libpng-devel \
-          lzo-devel \
-          SDL2-devel \
+          perl-IPC-Cmd \
           wget \
-          xz-devel \
-          zlib-devel \
+          zip \
           # EOF
+        echo "::endgroup::"
+
+        # We use vcpkg for our dependencies, to get more up-to-date version.
+        echo "::group::Install vcpkg and dependencies"
+
+        # We do a little dance to make sure we copy the cached install folder
+        # into our new clone.
+        git clone --depth=1 https://github.com/microsoft/vcpkg /vcpkg-clone
+        if [ -e /vcpkg/installed ]; then
+          mv /vcpkg/installed /vcpkg-clone/
+          rm -rf /vcpkg
+        fi
+        mv /vcpkg-clone /vcpkg
+
+        (
+          cd /vcpkg
+          ./bootstrap-vcpkg.sh -disableMetrics
+
+          # Make Python3 available for other packages.
+          ./vcpkg install python3
+          ln -sf $(pwd)/installed/x64-linux/tools/python3/python3.[0-9][0-9] /usr/bin/python3
+
+          ./vcpkg install \
+            curl[http2] \
+            fontconfig \
+            freetype \
+            liblzma \
+            libpng \
+            lzo \
+            sdl2 \
+            zlib \
+            # EOF
+        )
         echo "::endgroup::"
 
         # The yum variant of fluidsynth depends on all possible audio drivers,
         # like jack, ALSA, pulseaudio, etc. This is not really useful for us,
         # as we route the output of fluidsynth back via our sound driver, and
-        # as such do not use these audio driver outputs at all. So instead,
-        # we compile fluidsynth ourselves, with as little dependencies as
-        # possible. This currently means it picks up SDL2, but this is fine,
-        # as we need SDL2 anyway.
+        # as such do not use these audio driver outputs at all.
+        # The vcpkg variant of fluidsynth depends on ALSA. Similar issue here.
+        # So instead, we compile fluidsynth ourselves, with as few
+        # dependencies as possible. This currently means it picks up SDL2, but
+        # this is fine, as we need SDL2 anyway.
         echo "::group::Install fluidsynth"
         wget https://github.com/FluidSynth/fluidsynth/archive/v2.1.6.tar.gz
         tar xf v2.1.6.tar.gz
@@ -69,6 +109,7 @@ jobs:
 
         echo "::group::CMake"
         cmake ${GITHUB_WORKSPACE} \
+          -DCMAKE_TOOLCHAIN_FILE=/vcpkg/scripts/buildsystems/vcpkg.cmake \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DOPTION_PACKAGE_DEPENDENCIES=ON \
           # EOF

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -45,6 +45,38 @@ jobs:
           # EOF
         echo "::endgroup::"
 
+        # The yum variant of fluidsynth depends on all possible audio drivers,
+        # like jack, ALSA, pulseaudio, etc. This is not really useful for us,
+        # as we route the output of fluidsynth back via our sound driver, and
+        # as such do not use these audio driver outputs at all.
+        # The vcpkg variant of fluidsynth depends on ALSA. Similar issue here.
+        # So instead, we compile fluidsynth ourselves, with as few
+        # dependencies as possible. We do it before anything else is installed,
+        # to make sure it doesn't pick up on any of the drivers.
+        echo "::group::Install fluidsynth"
+        wget https://github.com/FluidSynth/fluidsynth/archive/v2.3.3.tar.gz
+        tar xf v2.3.3.tar.gz
+        (
+          cd fluidsynth-2.3.3
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr
+          cmake --build . -j $(nproc)
+          cmake --install .
+        )
+        echo "::endgroup::"
+
+        echo "::group::Install audio drivers"
+        # These audio libs are to make sure the SDL version of vcpkg adds
+        # sound-support; these libraries are not added to the resulting
+        # binary, but the headers are used to enable them in SDL.
+        yum install -y \
+          alsa-lib-devel \
+          jack-audio-connection-kit-devel \
+          pulseaudio-libs-devel \
+          # EOF
+        echo "::endgroup::"
+
         # We use vcpkg for our dependencies, to get more up-to-date version.
         echo "::group::Install vcpkg and dependencies"
 
@@ -75,27 +107,6 @@ jobs:
             sdl2 \
             zlib \
             # EOF
-        )
-        echo "::endgroup::"
-
-        # The yum variant of fluidsynth depends on all possible audio drivers,
-        # like jack, ALSA, pulseaudio, etc. This is not really useful for us,
-        # as we route the output of fluidsynth back via our sound driver, and
-        # as such do not use these audio driver outputs at all.
-        # The vcpkg variant of fluidsynth depends on ALSA. Similar issue here.
-        # So instead, we compile fluidsynth ourselves, with as few
-        # dependencies as possible. This currently means it picks up SDL2, but
-        # this is fine, as we need SDL2 anyway.
-        echo "::group::Install fluidsynth"
-        wget https://github.com/FluidSynth/fluidsynth/archive/v2.1.6.tar.gz
-        tar xf v2.1.6.tar.gz
-        (
-          cd fluidsynth-2.1.6
-          mkdir build
-          cd build
-          cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr
-          cmake --build . -j $(nproc)
-          cmake --install .
         )
         echo "::endgroup::"
 

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -151,19 +151,19 @@ jobs:
         rm -f bundles/*.sha256
         echo "::endgroup::"
 
-    - name: Install gon
-      env:
-        HOMEBREW_NO_AUTO_UPDATE: 1
-        HOMEBREW_NO_INSTALL_CLEANUP: 1
-      run: |
-        brew tap mitchellh/gon
-        brew install mitchellh/gon/gon
-
     - name: Notarize
       env:
         AC_USERNAME: ${{ secrets.APPLE_DEVELOPER_APP_USERNAME }}
         AC_PASSWORD: ${{ secrets.APPLE_DEVELOPER_APP_PASSWORD }}
+        AC_TEAM_ID: ${{ secrets.APPLE_DEVELOPER_TEAM_ID }}
       run: |
+        if [ -z "${AC_USERNAME}" ]; then
+            # We may be running on a fork that doesn't have notarization secrets set up; skip this step
+            echo No notarization secrets set up, skipping.
+            exit 0
+        fi
+
+        xcrun notarytool store-credentials --apple-id "${AC_USERNAME}" --password "${AC_PASSWORD}" --team-id "${AC_TEAM_ID}" openttd
         cd build-x64
         ../os/macosx/notarize.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,8 @@ jobs:
     with:
       version: ${{ needs.source.outputs.version }}
 
-  upload-aws:
-    name: Upload (AWS)
+  upload-cdn:
+    name: Upload (CDN)
     needs:
     - source
     - docs
@@ -83,7 +83,7 @@ jobs:
     # The always() makes sure the rest is always evaluated.
     if: always() && needs.source.result == 'success' && needs.docs.result == 'success' && needs.linux.result == 'success' && needs.macos.result == 'success' && needs.windows.result == 'success' && (needs.windows-store.result == 'success' || needs.windows-store.result == 'skipped')
 
-    uses: ./.github/workflows/upload-aws.yml
+    uses: ./.github/workflows/upload-cdn.yml
     secrets: inherit
 
     with:

--- a/.github/workflows/upload-cdn.yml
+++ b/.github/workflows/upload-cdn.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Trigger 'Publish Docs'
       uses: peter-evans/repository-dispatch@v2
       with:
-        token: ${{ secrets.DEPLOYMENT_TOKEN }}
+        token: ${{ steps.generate_token.outputs.token }}
         repository: OpenTTD/workflows
         event-type: publish-docs
         client-payload: '{"version": "${{ inputs.version }}", "folder": "${{ inputs.folder }}"}'

--- a/.github/workflows/upload-cdn.yml
+++ b/.github/workflows/upload-cdn.yml
@@ -1,4 +1,4 @@
-name: Upload (AWS)
+name: Upload (CDN)
 
 on:
   workflow_call:
@@ -14,10 +14,10 @@ on:
         type: string
 
 jobs:
-  upload:
-    name: Upload (AWS)
+  prepare:
+    name: Prepare
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Download all bundles
@@ -54,23 +54,50 @@ jobs:
           done
         fi
 
-    - name: Upload bundles to AWS
-      run: |
-        aws s3 cp --recursive --only-show-errors bundles/ s3://${{ secrets.CDN_S3_BUCKET }}/${{ inputs.folder }}/${{ inputs.version }}/
+    - name: Store bundles
+      uses: actions/upload-artifact@v3
+      with:
+        name: cdn-bundles
+        path: bundles/*
+        retention-days: 5
 
-        # We do not invalidate the CloudFront distribution here. The trigger
-        # for "New OpenTTD release" first updated the manifest files and
-        # creates an index.html. We invalidate after that, so everything
-        # becomes visible at once.
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+  publish:
+    needs:
+    - prepare
 
-    - name: Trigger 'New OpenTTD release'
+    name: Publish
+    uses: OpenTTD/actions/.github/workflows/rw-cdn-upload.yml@v4
+    secrets:
+      CDN_SIGNING_KEY: ${{ secrets.CDN_SIGNING_KEY }}
+      DEPLOYMENT_APP_ID: ${{ secrets.DEPLOYMENT_APP_ID }}
+      DEPLOYMENT_APP_PRIVATE_KEY: ${{ secrets.DEPLOYMENT_APP_PRIVATE_KEY }}
+    with:
+      artifact-name: cdn-bundles
+      folder: ${{ inputs.folder }}
+      version: ${{ inputs.version }}
+
+  docs:
+    if: ${{ inputs.trigger_type == 'new-master' }}
+    needs:
+    - publish
+
+    name: Publish docs
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Generate access token
+      id: generate_token
+      uses: tibdex/github-app-token@v1
+      with:
+        app_id: ${{ secrets.DEPLOYMENT_APP_ID }}
+        private_key: ${{ secrets.DEPLOYMENT_APP_PRIVATE_KEY }}
+        repository: OpenTTD/workflows
+
+    - name: Trigger 'Publish Docs'
       uses: peter-evans/repository-dispatch@v2
       with:
         token: ${{ secrets.DEPLOYMENT_TOKEN }}
         repository: OpenTTD/workflows
-        event-type: ${{ inputs.trigger_type }}
+        event-type: publish-docs
         client-payload: '{"version": "${{ inputs.version }}", "folder": "${{ inputs.folder }}"}'

--- a/.github/workflows/upload-gog.yml
+++ b/.github/workflows/upload-gog.yml
@@ -14,8 +14,25 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - name: Download all bundles
+    - name: Download bundle (Windows x86)
       uses: actions/download-artifact@v3
+      with:
+        name: openttd-windows-x86
+
+    - name: Download bundle (Windows x64)
+      uses: actions/download-artifact@v3
+      with:
+        name: openttd-windows-x64
+
+    - name: Download bundle (MacOS)
+      uses: actions/download-artifact@v3
+      with:
+        name: openttd-macos-universal
+
+    - name: Download bundle (Linux)
+      uses: actions/download-artifact@v3
+      with:
+        name: openttd-linux-generic
 
     - name: Install GOG Galaxy Build Creator
       run: |

--- a/.github/workflows/upload-gog.yml
+++ b/.github/workflows/upload-gog.yml
@@ -18,26 +18,31 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: internal-source
+        path: internal-source
 
     - name: Download bundle (Windows x86)
       uses: actions/download-artifact@v3
       with:
         name: openttd-windows-x86
+        path: openttd-windows-x86
 
     - name: Download bundle (Windows x64)
       uses: actions/download-artifact@v3
       with:
         name: openttd-windows-x64
+        path: openttd-windows-x64
 
     - name: Download bundle (MacOS)
       uses: actions/download-artifact@v3
       with:
         name: openttd-macos-universal
+        path: openttd-macos-universal
 
     - name: Download bundle (Linux)
       uses: actions/download-artifact@v3
       with:
         name: openttd-linux-generic
+        path: openttd-linux-generic
 
     - name: Install GOG Galaxy Build Creator
       run: |

--- a/.github/workflows/upload-gog.yml
+++ b/.github/workflows/upload-gog.yml
@@ -14,6 +14,11 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Download source
+      uses: actions/download-artifact@v3
+      with:
+        name: internal-source
+
     - name: Download bundle (Windows x86)
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/upload-steam.yml
+++ b/.github/workflows/upload-steam.yml
@@ -17,6 +17,11 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Download source
+      uses: actions/download-artifact@v3
+      with:
+        name: internal-source
+
     - name: Download bundle (Windows x86)
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/upload-steam.yml
+++ b/.github/workflows/upload-steam.yml
@@ -17,8 +17,25 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - name: Download all bundles
+    - name: Download bundle (Windows x86)
       uses: actions/download-artifact@v3
+      with:
+        name: openttd-windows-x86
+
+    - name: Download bundle (Windows x64)
+      uses: actions/download-artifact@v3
+      with:
+        name: openttd-windows-x64
+
+    - name: Download bundle (MacOS)
+      uses: actions/download-artifact@v3
+      with:
+        name: openttd-macos-universal
+
+    - name: Download bundle (Linux)
+      uses: actions/download-artifact@v3
+      with:
+        name: openttd-linux-generic
 
     - name: Setup steamcmd
       uses: CyberAndrii/setup-steamcmd@v1

--- a/.github/workflows/upload-steam.yml
+++ b/.github/workflows/upload-steam.yml
@@ -21,26 +21,31 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: internal-source
+        path: internal-source
 
     - name: Download bundle (Windows x86)
       uses: actions/download-artifact@v3
       with:
         name: openttd-windows-x86
+        path: openttd-windows-x86
 
     - name: Download bundle (Windows x64)
       uses: actions/download-artifact@v3
       with:
         name: openttd-windows-x64
+        path: openttd-windows-x64
 
     - name: Download bundle (MacOS)
       uses: actions/download-artifact@v3
       with:
         name: openttd-macos-universal
+        path: openttd-macos-universal
 
     - name: Download bundle (Linux)
       uses: actions/download-artifact@v3
       with:
         name: openttd-linux-generic
+        path: openttd-linux-generic
 
     - name: Setup steamcmd
       uses: CyberAndrii/setup-steamcmd@v1


### PR DESCRIPTION
## Description
Release workflow of release/13 branch needs to be updated to the new CDN.

Backport of all closed Pull Requests labeled as 'backport requested' into `release/13`.
- https://github.com/OpenTTD/OpenTTD/pull/10484
- https://github.com/OpenTTD/OpenTTD/pull/11010
- https://github.com/OpenTTD/OpenTTD/pull/11051
- https://github.com/OpenTTD/OpenTTD/pull/11093
- https://github.com/OpenTTD/OpenTTD/pull/11095
- https://github.com/OpenTTD/OpenTTD/pull/11107
- https://github.com/OpenTTD/OpenTTD/pull/11128
- All language changes
<!-- Backported: 10484,11010,11051,11093,11095,11107,11128 -->


Not sure it's fully working yet, but I'm testing it on https://github.com/glx22/OpenTTD/actions/runs/5702673158