### PR TITLE
Change: Enable "Forbid 90 degree turns" setting by default

### DIFF
--- a/src/table/settings/pathfinding_settings.ini
+++ b/src/table/settings/pathfinding_settings.ini
@@ -38,7 +38,7 @@ startup  = false
 
 [SDT_BOOL]
 var      = pf.forbid_90_deg
-def      = false
+def      = true
 str      = STR_CONFIG_SETTING_FORBID_90_DEG
 strhelp  = STR_CONFIG_SETTING_FORBID_90_DEG_HELPTEXT
 post_cb  = InvalidateShipPathCache

--- a/src/table/settings/pathfinding_settings.ini
+++ b/src/table/settings/pathfinding_settings.ini
@@ -41,7 +41,6 @@ var      = pf.forbid_90_deg
 def      = true
 str      = STR_CONFIG_SETTING_FORBID_90_DEG
 strhelp  = STR_CONFIG_SETTING_FORBID_90_DEG_HELPTEXT
-post_cb  = InvalidateShipPathCache
 cat      = SC_EXPERT
 
 [SDT_BOOL]


### PR DESCRIPTION
## Motivation / Problem

Trains making 90 degree turns look strange and cause unexpected behavior by turning around at X junctions. I commonly see new players advised to enable the "Forbid 90 degree turns" setting.

Also remove a post-setting-change callback that doesn't do anything. 😄 

## Description

Change the setting default to true.

As with all default setting changes, this does not affect savegames or existing players who have made their own choice. Just new installations of OpenTTD.

## Limitations

TTD allowed 90 degree turns.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
