### PR TITLE
Fix #11164: Duplicate town names when using the many random towns function

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2256,6 +2256,11 @@ bool GenerateTowns(TownLayout layout)
 
 	SetGeneratingWorldProgress(GWP_TOWN, total);
 
+	/* Pre-populate the town names list with the names of any towns already on the map */
+	for (const Town *town : Town::Iterate()) {
+		town_names.insert(town->GetCachedName());
+	}
+
 	/* First attempt will be made at creating the suggested number of towns.
 	 * Note that this is really a suggested value, not a required one.
 	 * We would not like the system to lock up just because the user wanted 100 cities on a 64*64 map, would we? */


### PR DESCRIPTION
## Motivation / Problem

#11164

## Description

Fix #11164

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
