### PR TITLE
Feature: Count the number of towns and cities in town directory

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3510,7 +3510,9 @@ STR_TOWN_DIRECTORY_NONE                                         :{ORANGE}- None 
 STR_TOWN_DIRECTORY_TOWN                                         :{ORANGE}{TOWN}{BLACK} ({COMMA})
 STR_TOWN_DIRECTORY_CITY                                         :{ORANGE}{TOWN}{YELLOW} (City){BLACK} ({COMMA})
 STR_TOWN_DIRECTORY_LIST_TOOLTIP                                 :{BLACK}Town names - click on name to centre main view on town. Ctrl+Click opens a new viewport on town location
-STR_TOWN_POPULATION                                             :{BLACK}World population: {COMMA}
+STR_NUM_TOWNS                                                   :{BLACK}Towns: {ORANGE}{COMMA}
+STR_NUM_CITIES                                                  :{BLACK}Cities: {ORANGE}{COMMA}
+STR_TOWN_POPULATION                                             :{BLACK}World population: {ORANGE}{COMMA}
 
 # Town view window
 STR_TOWN_VIEW_TOWN_CAPTION                                      :{WHITE}{TOWN}

--- a/src/town.h
+++ b/src/town.h
@@ -143,6 +143,7 @@ private:
 	void FillCachedName() const;
 };
 
+uint CountTowns(bool cities);
 uint32_t GetWorldPopulation();
 
 void UpdateAllTownVirtCoords();

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -457,6 +457,20 @@ uint32_t GetWorldPopulation()
 }
 
 /**
+ * Get the number of towns or cities on the map.
+ * @param cities Count cities instead of towns.
+ * @return The number of towns or cities.
+ */
+uint CountTowns(bool cities)
+{
+	uint total = 0;
+	for (const Town *t : Town::Iterate()) {
+		if (cities == t->larger_town) total++;
+	}
+	return total;
+}
+
+/**
  * Remove stations from nearby station list if a town is no longer in the catchment area of each.
  * To improve performance only checks stations that cover the provided house area (doesn't need to contain an actual house).
  * @param t Town to work on

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -692,7 +692,9 @@ static const NWidgetPart _nested_town_directory_widgets[] = {
 			NWidget(WWT_PANEL, COLOUR_BROWN, WID_TD_LIST), SetDataTip(0x0, STR_TOWN_DIRECTORY_LIST_TOOLTIP),
 							SetFill(1, 0), SetResize(1, 1), SetScrollbar(WID_TD_SCROLLBAR), EndContainer(),
 			NWidget(WWT_PANEL, COLOUR_BROWN),
-				NWidget(WWT_TEXT, COLOUR_BROWN, WID_TD_WORLD_POPULATION), SetPadding(2, 0, 2, 2), SetMinimalTextLines(1, 0), SetFill(1, 0), SetResize(1, 0), SetDataTip(STR_TOWN_POPULATION, STR_NULL),
+				NWidget(WWT_TEXT, COLOUR_BROWN, WID_TD_NUM_TOWNS), SetPadding(2, 0, 0, 2), SetMinimalTextLines(1, 0), SetFill(1, 0), SetResize(1, 0), SetDataTip(STR_NUM_TOWNS, STR_NULL),
+				NWidget(WWT_TEXT, COLOUR_BROWN, WID_TD_NUM_CITIES), SetPadding(0, 0, 0, 2), SetMinimalTextLines(1, 0), SetFill(1, 0), SetResize(1, 0), SetDataTip(STR_NUM_CITIES, STR_NULL),
+				NWidget(WWT_TEXT, COLOUR_BROWN, WID_TD_WORLD_POPULATION), SetPadding(0, 0, 2, 2), SetMinimalTextLines(1, 0), SetFill(1, 0), SetResize(1, 0), SetDataTip(STR_TOWN_POPULATION, STR_NULL),
 			EndContainer(),
 		EndContainer(),
 		NWidget(NWID_VERTICAL),
@@ -801,6 +803,14 @@ public:
 	void SetStringParameters(int widget) const override
 	{
 		switch (widget) {
+			case WID_TD_NUM_TOWNS:
+				SetDParam(0, CountTowns(false));
+				break;
+
+			case WID_TD_NUM_CITIES:
+				SetDParam(0, CountTowns(true));
+				break;
+
 			case WID_TD_WORLD_POPULATION:
 				SetDParam(0, GetWorldPopulation());
 				break;
@@ -904,6 +914,22 @@ public:
 				d.height = std::max(d.height, icon_size.height);
 				resize->height = d.height;
 				d.height *= 5;
+				d.width += padding.width;
+				d.height += padding.height;
+				*size = maxdim(*size, d);
+				break;
+			}
+			case WID_TD_NUM_TOWNS: {
+				SetDParamMaxDigits(0, 5);
+				Dimension d = GetStringBoundingBox(STR_NUM_TOWNS);
+				d.width += padding.width;
+				d.height += padding.height;
+				*size = maxdim(*size, d);
+				break;
+			}
+			case WID_TD_NUM_CITIES: {
+				SetDParamMaxDigits(0, 5);
+				Dimension d = GetStringBoundingBox(STR_NUM_CITIES);
 				d.width += padding.width;
 				d.height += padding.height;
 				*size = maxdim(*size, d);

--- a/src/widgets/town_widget.h
+++ b/src/widgets/town_widget.h
@@ -17,6 +17,8 @@ enum TownDirectoryWidgets {
 	WID_TD_FILTER,           ///< Filter of name.
 	WID_TD_LIST,             ///< List of towns.
 	WID_TD_SCROLLBAR,        ///< Scrollbar for the town list.
+	WID_TD_NUM_TOWNS,        ///< Total number of towns.
+	WID_TD_NUM_CITIES,       ///< Total number of cities.
 	WID_TD_WORLD_POPULATION, ///< The world's population.
 };
 


### PR DESCRIPTION
## Motivation / Problem

There is no way to see how many towns and/or cities are on a map. The town directory only lists the total population.

I've seen this feature requested several times on Discord.

## Description

![directory](https://github.com/OpenTTD/OpenTTD/assets/55058389/e9540d14-f687-4de6-827f-994b76f7a18d)

List the number of towns and cities above the total population.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
