### PR TITLE
Codechange: Use DateAtStartOfYear() instead of multiplying by DAYS_IN_LEAP_YEAR

### DIFF
--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -1388,7 +1388,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   75
     GetMaxSpeed():      64
     GetPrice():         8203
-    GetMaxAge():        5490
+    GetMaxAge():        5479
     GetRunningCost():   820
     GetPower():         300
     GetWeight():        47
@@ -1532,7 +1532,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   80
     GetMaxSpeed():      112
     GetPrice():         15234
-    GetMaxAge():        7686
+    GetMaxAge():        7671
     GetRunningCost():   1968
     GetPower():         1000
     GetWeight():        131
@@ -1550,7 +1550,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   84
     GetMaxSpeed():      128
     GetPrice():         22265
-    GetMaxAge():        7320
+    GetMaxAge():        7305
     GetRunningCost():   2296
     GetPower():         1200
     GetWeight():        162
@@ -3476,7 +3476,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   78
     GetMaxSpeed():      56
     GetPrice():         4921
-    GetMaxAge():        4392
+    GetMaxAge():        4383
     GetRunningCost():   426
     GetPower():         90
     GetWeight():        10
@@ -3602,7 +3602,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   77
     GetMaxSpeed():      48
     GetPrice():         4429
-    GetMaxAge():        5490
+    GetMaxAge():        5479
     GetRunningCost():   421
     GetPower():         120
     GetWeight():        9
@@ -3656,7 +3656,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   92
     GetMaxSpeed():      48
     GetPrice():         4716
-    GetMaxAge():        5490
+    GetMaxAge():        5479
     GetRunningCost():   421
     GetPower():         120
     GetWeight():        9
@@ -3764,7 +3764,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   98
     GetMaxSpeed():      48
     GetPrice():         4511
-    GetMaxAge():        5490
+    GetMaxAge():        5479
     GetRunningCost():   421
     GetPower():         120
     GetWeight():        9
@@ -3818,7 +3818,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   97
     GetMaxSpeed():      48
     GetPrice():         4306
-    GetMaxAge():        5490
+    GetMaxAge():        5479
     GetRunningCost():   421
     GetPower():         120
     GetWeight():        9
@@ -3872,7 +3872,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   87
     GetMaxSpeed():      48
     GetPrice():         4388
-    GetMaxAge():        5490
+    GetMaxAge():        5479
     GetRunningCost():   421
     GetPower():         120
     GetWeight():        9
@@ -3926,7 +3926,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   97
     GetMaxSpeed():      48
     GetPrice():         4675
-    GetMaxAge():        5490
+    GetMaxAge():        5479
     GetRunningCost():   421
     GetPower():         120
     GetWeight():        9
@@ -3980,7 +3980,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   98
     GetMaxSpeed():      48
     GetPrice():         4839
-    GetMaxAge():        5490
+    GetMaxAge():        5479
     GetRunningCost():   421
     GetPower():         120
     GetWeight():        9
@@ -4034,7 +4034,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   97
     GetMaxSpeed():      48
     GetPrice():         4962
-    GetMaxAge():        5490
+    GetMaxAge():        5479
     GetRunningCost():   421
     GetPower():         120
     GetWeight():        9
@@ -4088,7 +4088,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   82
     GetMaxSpeed():      48
     GetPrice():         4593
-    GetMaxAge():        5490
+    GetMaxAge():        5479
     GetRunningCost():   421
     GetPower():         120
     GetWeight():        9
@@ -4142,7 +4142,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   76
     GetMaxSpeed():      48
     GetPrice():         5947
-    GetMaxAge():        5490
+    GetMaxAge():        5479
     GetRunningCost():   421
     GetPower():         120
     GetWeight():        9
@@ -5060,7 +5060,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   99
     GetMaxSpeed():      24
     GetPrice():         30468
-    GetMaxAge():        10980
+    GetMaxAge():        10958
     GetRunningCost():   2296
     GetPower():         -1
     GetWeight():        -1
@@ -5096,7 +5096,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   88
     GetMaxSpeed():      32
     GetPrice():         18281
-    GetMaxAge():        10980
+    GetMaxAge():        10958
     GetRunningCost():   1476
     GetPower():         -1
     GetWeight():        -1
@@ -5186,7 +5186,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   81
     GetMaxSpeed():      24
     GetPrice():         24375
-    GetMaxAge():        10980
+    GetMaxAge():        10958
     GetRunningCost():   2460
     GetPower():         -1
     GetWeight():        -1
@@ -5258,7 +5258,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   58
     GetMaxSpeed():      236
     GetPrice():         28710
-    GetMaxAge():        7320
+    GetMaxAge():        7305
     GetRunningCost():   2390
     GetPower():         -1
     GetWeight():        -1
@@ -5276,7 +5276,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   95
     GetMaxSpeed():      236
     GetPrice():         30761
-    GetMaxAge():        8784
+    GetMaxAge():        8766
     GetRunningCost():   2812
     GetPower():         -1
     GetWeight():        -1
@@ -5330,7 +5330,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetReliability():   77
     GetMaxSpeed():      236
     GetPrice():         30761
-    GetMaxAge():        10980
+    GetMaxAge():        10958
     GetRunningCost():   2756
     GetPower():         -1
     GetWeight():        -1
@@ -9323,8 +9323,8 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetEngineType():     153
     GetUnitNumber():     1
     GetAge():            1
-    GetMaxAge():         5490
-    GetAgeLeft():        5489
+    GetMaxAge():         5479
+    GetAgeLeft():        5478
     GetCurrentSpeed():   7
     GetRunningCost():    421
     GetProfitThisYear(): -1
@@ -9416,17 +9416,17 @@ ERROR: IsEnd() is invalid as Begin() is never called
     14 => 0
     13 => 0
   MaxAge ListDump:
-    16 => 10980
-    14 => 10980
-    17 => 7320
-    13 => 5490
-    12 => 5490
+    16 => 10958
+    14 => 10958
+    17 => 7305
+    13 => 5479
+    12 => 5479
   AgeLeft ListDump:
-    16 => 10980
-    14 => 10980
-    17 => 7320
-    13 => 5490
-    12 => 5489
+    16 => 10958
+    14 => 10958
+    17 => 7305
+    13 => 5479
+    12 => 5478
   CurrentSpeed ListDump:
     12 => 27
     17 => 0

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -437,8 +437,7 @@ uint Engine::GetDisplayMaxTractiveEffort() const
  */
 TimerGameCalendar::Date Engine::GetLifeLengthInDays() const
 {
-	/* Assume leap years; this gives the player a bit more than the given amount of years, but never less. */
-	return (this->info.lifelength + _settings_game.vehicle.extend_vehicle_life) * DAYS_IN_LEAP_YEAR;
+	return DateAtStartOfYear(this->info.lifelength + _settings_game.vehicle.extend_vehicle_life);
 }
 
 /**
@@ -663,7 +662,7 @@ void SetYearEngineAgingStops()
 
 		/* Base year ending date on half the model life */
 		TimerGameCalendar::YearMonthDay ymd;
-		TimerGameCalendar::ConvertDateToYMD(ei->base_intro + (ei->lifelength * DAYS_IN_LEAP_YEAR) / 2, &ymd);
+		TimerGameCalendar::ConvertDateToYMD(ei->base_intro + DateAtStartOfYear(ei->lifelength) / 2, &ymd);
 
 		_year_engine_aging_stops = std::max(_year_engine_aging_stops, ymd.year);
 	}

--- a/src/timetable_cmd.cpp
+++ b/src/timetable_cmd.cpp
@@ -304,7 +304,7 @@ CommandCost CmdSetTimetableStart(DoCommandFlag flags, VehicleID veh_id, bool tim
 
 	/* Don't let a timetable start more than 15 years into the future or 1 year in the past. */
 	if (start_date < 0 || start_date > MAX_DATE) return CMD_ERROR;
-	if (start_date - TimerGameCalendar::date > MAX_TIMETABLE_START_YEARS * DAYS_IN_LEAP_YEAR) return CMD_ERROR;
+	if (start_date - TimerGameCalendar::date > DateAtStartOfYear(MAX_TIMETABLE_START_YEARS)) return CMD_ERROR;
 	if (TimerGameCalendar::date - start_date > DAYS_IN_LEAP_YEAR) return CMD_ERROR;
 	if (timetable_all && !v->orders->IsCompleteTimetable()) return CommandCost(STR_ERROR_TIMETABLE_INCOMPLETE);
 	if (timetable_all && start_date + total_duration / DAY_TICKS > MAX_DATE) return CMD_ERROR;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1377,9 +1377,11 @@ void AgeVehicle(Vehicle *v)
 	if (!v->IsPrimaryVehicle() && (v->type != VEH_TRAIN || !Train::From(v)->IsEngine())) return;
 
 	int age = v->age - v->max_age;
-	if (age == DAYS_IN_LEAP_YEAR * 0 || age == DAYS_IN_LEAP_YEAR * 1 ||
-			age == DAYS_IN_LEAP_YEAR * 2 || age == DAYS_IN_LEAP_YEAR * 3 || age == DAYS_IN_LEAP_YEAR * 4) {
-		v->reliability_spd_dec <<= 1;
+	for (int32_t i = 0; i <= 4; i++) {
+		if (age == DateAtStartOfYear(i)) {
+			v->reliability_spd_dec <<= 1;
+			break;
+		}
 	}
 
 	SetWindowDirty(WC_VEHICLE_DETAILS, v->index);


### PR DESCRIPTION
## Motivation / Problem

We do a lot of math with dates, so https://github.com/OpenTTD/OpenTTD/pull/10761 needs to do a lot of casting.

## Description

Instead of multiplying by DAYS_IN_LEAP_YEAR in multiple places, use the existing function that gets the date. Also clean up some...interesting code by using a loop instead.

## Limitations

Calculations are more accurate since we actually check for leap years instead of assuming all years are leap years. This makes vehicles last every so slightly less time.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
