### PR TITLE
Codechange: Use proper date type in ClickChangeDateCheat

### DIFF
--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -104,12 +104,12 @@ extern void EnginesMonthlyLoop();
 static int32_t ClickChangeDateCheat(int32_t new_value, int32_t change_direction)
 {
 	/* Don't allow changing to an invalid year, or the current year. */
-	new_value = Clamp(new_value, MIN_YEAR, MAX_YEAR);
-	if (new_value == TimerGameCalendar::year) return TimerGameCalendar::year;
+	auto new_year = Clamp(TimerGameCalendar::Year(new_value), MIN_YEAR, MAX_YEAR);
+	if (new_year == TimerGameCalendar::year) return TimerGameCalendar::year;
 
 	TimerGameCalendar::YearMonthDay ymd;
 	TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date, &ymd);
-	TimerGameCalendar::Date new_date = TimerGameCalendar::ConvertYMDToDate(new_value, ymd.month, ymd.day);
+	TimerGameCalendar::Date new_date = TimerGameCalendar::ConvertYMDToDate(new_year, ymd.month, ymd.day);
 
 	/* Shift cached dates before we change the date. */
 	for (auto v : Vehicle::Iterate()) v->ShiftDates(new_date - TimerGameCalendar::date);


### PR DESCRIPTION
## Motivation / Problem

`ClickChangeDateCheat()` uses its `new_value` parameter to do stuff, but it's not really a `TimerGameCalendar::Year` type. 

## Description

Let's make a new variable of the correct type to play with.

This is more code picked from #10761, that should be changed anyway.

## Limitations

Does `Clamp()` actually return a `TimerGameCalendar::Year` variable, or does it need templating?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
