### PR TITLE
Codechange: Use proper date types in various places

### DIFF
--- a/src/currency.h
+++ b/src/currency.h
@@ -14,8 +14,9 @@
 #include "string_func.h"
 #include "strings_type.h"
 
-static const int CF_NOEURO = 0; ///< Currency never switches to the Euro (as far as known).
-static const int CF_ISEURO = 1; ///< Currency _is_ the Euro.
+static constexpr TimerGameCalendar::Year CF_NOEURO = 0; ///< Currency never switches to the Euro (as far as known).
+static constexpr TimerGameCalendar::Year CF_ISEURO = 1; ///< Currency _is_ the Euro.
+static constexpr TimerGameCalendar::Year MIN_EURO_YEAR = 2000; ///< The earliest year custom currencies may switch to the Euro.
 
 /**
  * This enum gives the currencies a unique id which must be maintained for

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -582,7 +582,7 @@ public:
 		}
 
 		int mo = (TimerGameCalendar::month / 3 - nums) * 3;
-		int yr = TimerGameCalendar::year;
+		auto yr = TimerGameCalendar::year;
 		while (mo < 0) {
 			yr--;
 			mo += 12;

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -6512,7 +6512,7 @@ bool GetGlobalVariable(byte param, uint32_t *value, const GRFFile *grffile)
 {
 	switch (param) {
 		case 0x00: // current date
-			*value = std::max(TimerGameCalendar::date - DAYS_TILL_ORIGINAL_BASE_YEAR, 0);
+			*value = std::max(TimerGameCalendar::date - DAYS_TILL_ORIGINAL_BASE_YEAR, TimerGameCalendar::Date(0));
 			return true;
 
 		case 0x01: // current year

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1944,7 +1944,7 @@ VehicleOrderID ProcessConditionalOrder(const Order *order, const Vehicle *v)
 		case OCV_AGE:                skip_order = OrderConditionCompare(occ, DateToYear(v->age),                value); break;
 		case OCV_REQUIRES_SERVICE:   skip_order = OrderConditionCompare(occ, v->NeedsServicing(),               value); break;
 		case OCV_UNCONDITIONALLY:    skip_order = true; break;
-		case OCV_REMAINING_LIFETIME: skip_order = OrderConditionCompare(occ, std::max(DateToYear(v->max_age - v->age + DAYS_IN_LEAP_YEAR - 1), 0), value); break;
+		case OCV_REMAINING_LIFETIME: skip_order = OrderConditionCompare(occ, std::max(DateToYear(v->max_age - v->age + DAYS_IN_LEAP_YEAR - 1), TimerGameCalendar::Date(0)), value); break;
 		default: NOT_REACHED();
 	}
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2844,13 +2844,13 @@ struct CustomCurrencyWindow : Window {
 				break;
 
 			case WID_CC_YEAR_DOWN:
-				_custom_currency.to_euro = (_custom_currency.to_euro <= 2000) ? CF_NOEURO : _custom_currency.to_euro - 1;
+				_custom_currency.to_euro = (_custom_currency.to_euro <= MIN_EURO_YEAR) ? CF_NOEURO : _custom_currency.to_euro - 1;
 				if (_custom_currency.to_euro == CF_NOEURO) this->DisableWidget(WID_CC_YEAR_DOWN);
 				this->EnableWidget(WID_CC_YEAR_UP);
 				break;
 
 			case WID_CC_YEAR_UP:
-				_custom_currency.to_euro = Clamp(_custom_currency.to_euro + 1, 2000, MAX_YEAR);
+				_custom_currency.to_euro = Clamp(_custom_currency.to_euro + 1, MIN_EURO_YEAR, MAX_YEAR);
 				if (_custom_currency.to_euro == MAX_YEAR) this->DisableWidget(WID_CC_YEAR_UP);
 				this->EnableWidget(WID_CC_YEAR_DOWN);
 				break;
@@ -2895,9 +2895,9 @@ struct CustomCurrencyWindow : Window {
 				break;
 
 			case WID_CC_YEAR: { // Year to switch to euro
-				int val = atoi(str);
+				TimerGameCalendar::Year val = atoi(str);
 
-				_custom_currency.to_euro = (val < 2000 ? CF_NOEURO : std::min(val, MAX_YEAR));
+				_custom_currency.to_euro = (val < MIN_EURO_YEAR ? CF_NOEURO : std::min(val, MAX_YEAR));
 				break;
 			}
 		}

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2505,7 +2505,7 @@ struct ScenarioEditorToolbarWindow : Window {
 		/* Was 'cancel' pressed? */
 		if (str == nullptr) return;
 
-		int32_t value;
+		TimerGameCalendar::Year value;
 		if (!StrEmpty(str)) {
 			value = atoi(str);
 		} else {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -761,7 +761,7 @@ uint32_t Vehicle::GetGRFID() const
  */
 void Vehicle::ShiftDates(int interval)
 {
-	this->date_of_last_service = std::max(this->date_of_last_service + interval, 0);
+	this->date_of_last_service = std::max(this->date_of_last_service + interval, TimerGameCalendar::Date(0));
 	/* date_of_last_service_newgrf is not updated here as it must stay stable
 	 * for vehicles outside of a depot. */
 }


### PR DESCRIPTION
## Motivation / Problem / Description

Code picked from #10761 that needs to be changed anyway.

## Limitations

`int mo` in `graph_gui.cpp`, just above a change I made to `yr` is weird and probably shouldn't be a `TimerGameCalendar::Month`, so I left that alone (same as in #10761).

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
