### PR TITLE
Codechange: simplify the type of loaded_at_xy / next_station

### DIFF
--- a/src/cargopacket.cpp
+++ b/src/cargopacket.cpp
@@ -75,7 +75,7 @@ CargoPacket::CargoPacket(uint16_t count, uint16_t periods_in_transit, StationID 
 		source_id(source_id),
 		source(source),
 		source_xy(source_xy),
-		loaded_at_xy(loaded_at_xy.value)
+		loaded_at_xy(loaded_at_xy)
 {
 	assert(count != 0);
 	this->source_type = source_type;
@@ -553,7 +553,7 @@ void VehicleCargoList::InvalidateCache()
  * @return Amount of cargo actually reassigned.
  */
 template<VehicleCargoList::MoveToAction Tfrom, VehicleCargoList::MoveToAction Tto>
-uint VehicleCargoList::Reassign(uint max_move, TileOrStationID)
+uint VehicleCargoList::Reassign(uint max_move, StationID)
 {
 	static_assert(Tfrom != MTA_TRANSFER && Tto != MTA_TRANSFER);
 	static_assert(Tfrom - Tto == 1 || Tto - Tfrom == 1);
@@ -571,7 +571,7 @@ uint VehicleCargoList::Reassign(uint max_move, TileOrStationID)
  * @return Amount of cargo actually reassigned.
  */
 template<>
-uint VehicleCargoList::Reassign<VehicleCargoList::MTA_DELIVER, VehicleCargoList::MTA_TRANSFER>(uint max_move, TileOrStationID next_station)
+uint VehicleCargoList::Reassign<VehicleCargoList::MTA_DELIVER, VehicleCargoList::MTA_TRANSFER>(uint max_move, StationID next_station)
 {
 	max_move = std::min(this->action_counts[MTA_DELIVER], max_move);
 
@@ -866,4 +866,4 @@ uint StationCargoList::Reroute(uint max_move, StationCargoList *dest, StationID 
  */
 template class CargoList<VehicleCargoList, CargoPacketList>;
 template class CargoList<StationCargoList, StationCargoPacketMap>;
-template uint VehicleCargoList::Reassign<VehicleCargoList::MTA_DELIVER, VehicleCargoList::MTA_KEEP>(uint, TileOrStationID);
+template uint VehicleCargoList::Reassign<VehicleCargoList::MTA_DELIVER, VehicleCargoList::MTA_KEEP>(uint, StationID);

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -34,7 +34,12 @@ template <class Tinst, class Tcont> class CargoList;
 class StationCargoList; // forward-declare, so we can use it in VehicleCargoList.
 extern SaveLoadTable GetCargoPacketDesc();
 
-typedef uint32_t TileOrStationID;
+/**
+ * To make alignment in the union in CargoPacket a bit easier, create a new type
+ * that is a StationID, but stored as 32bit.
+ */
+typedef uint32_t StationID_32bit;
+static_assert(sizeof(TileIndex) == sizeof(StationID_32bit));
 
 /**
  * Container for cargo from the same location and time.
@@ -49,8 +54,8 @@ private:
 	StationID source;       ///< The station where the cargo came from first.
 	TileIndex source_xy;    ///< The origin of the cargo (first station in feeder chain).
 	union {
-		TileOrStationID loaded_at_xy; ///< Location where this cargo has been loaded into the vehicle.
-		TileOrStationID next_station; ///< Station where the cargo wants to go next.
+		TileIndex loaded_at_xy;       ///< Location where this cargo has been loaded into the vehicle.
+		StationID_32bit next_station; ///< Station where the cargo wants to go next.
 	};
 
 	/** The CargoList caches, thus needs to know about it. */
@@ -416,7 +421,7 @@ public:
 	 * applicable), return value is amount of cargo actually moved. */
 
 	template<MoveToAction Tfrom, MoveToAction Tto>
-	uint Reassign(uint max_move, TileOrStationID update = INVALID_TILE);
+	uint Reassign(uint max_move, StationID update = INVALID_STATION);
 	uint Return(uint max_move, StationCargoList *dest, StationID next_station);
 	uint Unload(uint max_move, StationCargoList *dest, CargoPayment *payment);
 	uint Shift(uint max_move, VehicleCargoList *dest);


### PR DESCRIPTION
## Motivation / Problem

Noticed while working on making a more generic StrongTypeDef.

## Description

It was TileOrStationID, most likely to make sure both types in the union are identical. But as TileIndex is a StrongTypeDef that becomes a bit weird. So instead, still make sure they are of equal size, but define their individual types better.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
