### PR TITLE
Codechange: make no assumptions on how the internals of TileIndex work

### DIFF
--- a/src/map_func.h
+++ b/src/map_func.h
@@ -426,7 +426,7 @@ debug_inline static TileIndex TileVirtXY(uint x, uint y)
  */
 debug_inline static uint TileX(TileIndex tile)
 {
-	return tile.value & Map::MaxX();
+	return static_cast<uint32_t>(tile) & Map::MaxX();
 }
 
 /**
@@ -436,7 +436,7 @@ debug_inline static uint TileX(TileIndex tile)
  */
 debug_inline static uint TileY(TileIndex tile)
 {
-	return tile.value >> Map::LogX();
+	return static_cast<uint32_t>(tile) >> Map::LogX();
 }
 
 /**

--- a/src/misc/endian_buffer.hpp
+++ b/src/misc/endian_buffer.hpp
@@ -53,7 +53,7 @@ public:
 		if constexpr (std::is_enum_v<T>) {
 			this->Write(static_cast<std::underlying_type_t<const T>>(data));
 		} else if constexpr (std::is_base_of_v<StrongTypedefBase, T>) {
-			this->Write(data.value);
+			this->Write(static_cast<typename T::Type>(data));
 		} else {
 			this->Write(data);
 		}
@@ -146,7 +146,7 @@ public:
 		if constexpr (std::is_enum_v<T>) {
 			data = static_cast<T>(this->Read<std::underlying_type_t<T>>());
 		} else if constexpr (std::is_base_of_v<StrongTypedefBase, T>) {
-			data.value = this->Read<decltype(data.value)>();
+			data = this->Read<typename T::Type>();
 		} else {
 			data = this->Read<T>();
 		}

--- a/src/script/squirrel_helper.hpp
+++ b/src/script/squirrel_helper.hpp
@@ -37,7 +37,7 @@ namespace SQConvert {
 	template <> struct Return<int32_t>        { static inline int Set(HSQUIRRELVM vm, int32_t res)       { sq_pushinteger(vm, res); return 1; } };
 	template <> struct Return<int64_t>        { static inline int Set(HSQUIRRELVM vm, int64_t res)       { sq_pushinteger(vm, res); return 1; } };
 	template <> struct Return<Money>        { static inline int Set(HSQUIRRELVM vm, Money res)       { sq_pushinteger(vm, res); return 1; } };
-	template <> struct Return<TileIndex>    { static inline int Set(HSQUIRRELVM vm, TileIndex res)   { sq_pushinteger(vm, (int32_t)res.value); return 1; } };
+	template <> struct Return<TileIndex>    { static inline int Set(HSQUIRRELVM vm, TileIndex res)   { sq_pushinteger(vm, (int32_t)static_cast<uint32_t>(res)); return 1; } };
 	template <> struct Return<bool>         { static inline int Set(HSQUIRRELVM vm, bool res)        { sq_pushbool   (vm, res); return 1; } };
 	template <> struct Return<char *>       { /* Do not use char *, use std::optional<std::string> instead. */ };
 	template <> struct Return<const char *> { /* Do not use const char *, use std::optional<std::string> instead. */ };


### PR DESCRIPTION


## Motivation / Problem

While working on making StrongTypeDef a bit more generic, I wanted to move `value` to `protected`, as in the generic case you don't want people to access `value`. Here I noticed only in a few places the TileIndex was being accessed by its `.value`.

## Description

Basically, avoid ".value", and just cast it to its original type if you want to retrieve this. This is done in most places anyway, except for these few.

Especially the endian-buffer was a bit weird, `decltype` was used, while the type is already available via `::Type`.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
