### PR TITLE
Codechange: use TimerGameCalendar::Date for variables in linkgraph that are dates

### DIFF
--- a/src/linkgraph/linkgraph.cpp
+++ b/src/linkgraph/linkgraph.cpp
@@ -50,7 +50,7 @@ LinkGraph::BaseEdge::BaseEdge(NodeID dest_node)
  * This is useful if the date has been modified with the cheat menu.
  * @param interval Number of days to be added or subtracted.
  */
-void LinkGraph::ShiftDates(int interval)
+void LinkGraph::ShiftDates(TimerGameCalendar::Date interval)
 {
 	this->last_compression += interval;
 	for (NodeID node1 = 0; node1 < this->Size(); ++node1) {

--- a/src/linkgraph/linkgraph.h
+++ b/src/linkgraph/linkgraph.h
@@ -171,10 +171,10 @@ public:
 	static const uint MIN_TIMEOUT_DISTANCE = 32;
 
 	/** Number of days before deleting links served only by vehicles stopped in depot. */
-	static const uint STALE_LINK_DEPOT_TIMEOUT = 1024;
+	static constexpr TimerGameCalendar::Date STALE_LINK_DEPOT_TIMEOUT = 1024;
 
 	/** Minimum number of days between subsequent compressions of a LG. */
-	static const uint COMPRESSION_INTERVAL = 256;
+	static constexpr TimerGameCalendar::Date COMPRESSION_INTERVAL = 256;
 
 	/**
 	 * Scale a value from a link graph of age orig_age for usage in one of age
@@ -184,7 +184,7 @@ public:
 	 * @param orig_age Age of the original link graph.
 	 * @return scaled value.
 	 */
-	inline static uint Scale(uint val, uint target_age, uint orig_age)
+	inline static uint Scale(uint val, TimerGameCalendar::Date target_age, TimerGameCalendar::Date orig_age)
 	{
 		return val > 0 ? std::max(1U, val * target_age / orig_age) : 0;
 	}
@@ -198,7 +198,7 @@ public:
 	LinkGraph(CargoID cargo) : cargo(cargo), last_compression(TimerGameCalendar::date) {}
 
 	void Init(uint size);
-	void ShiftDates(int interval);
+	void ShiftDates(TimerGameCalendar::Date interval);
 	void Compress();
 	void Merge(LinkGraph *other);
 

--- a/src/linkgraph/linkgraphjob.h
+++ b/src/linkgraph/linkgraphjob.h
@@ -223,7 +223,7 @@ public:
 	 * Change the join date on date cheating.
 	 * @param interval Number of days to add.
 	 */
-	inline void ShiftJoinDate(int interval) { this->join_date += interval; }
+	inline void ShiftJoinDate(TimerGameCalendar::Date interval) { this->join_date += interval; }
 
 	/**
 	 * Get the link graph settings for this component.

--- a/src/linkgraph/linkgraphschedule.cpp
+++ b/src/linkgraph/linkgraphschedule.cpp
@@ -132,7 +132,7 @@ void LinkGraphSchedule::SpawnAll()
  * graph jobs by the number of days given.
  * @param interval Number of days to be added or subtracted.
  */
-void LinkGraphSchedule::ShiftDates(int interval)
+void LinkGraphSchedule::ShiftDates(TimerGameCalendar::Date interval)
 {
 	for (LinkGraph *lg : LinkGraph::Iterate()) lg->ShiftDates(interval);
 	for (LinkGraphJob *lgj : LinkGraphJob::Iterate()) lgj->ShiftJoinDate(interval);

--- a/src/linkgraph/linkgraphschedule.h
+++ b/src/linkgraph/linkgraphschedule.h
@@ -58,7 +58,7 @@ public:
 	bool IsJoinWithUnfinishedJobDue() const;
 	void JoinNext();
 	void SpawnAll();
-	void ShiftDates(int interval);
+	void ShiftDates(TimerGameCalendar::Date interval);
 
 	/**
 	 * Queue a link graph for execution.

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3806,8 +3806,8 @@ void DeleteStaleLinks(Station *from)
 			Station *to = Station::Get((*lg)[edge.dest_node].station);
 			assert(to->goods[c].node == edge.dest_node);
 			assert(TimerGameCalendar::date >= edge.LastUpdate());
-			uint timeout = LinkGraph::MIN_TIMEOUT_DISTANCE + (DistanceManhattan(from->xy, to->xy) >> 3);
-			if ((uint)(TimerGameCalendar::date - edge.LastUpdate()) > timeout) {
+			auto timeout = TimerGameCalendar::Date(LinkGraph::MIN_TIMEOUT_DISTANCE + (DistanceManhattan(from->xy, to->xy) >> 3));
+			if (TimerGameCalendar::date - edge.LastUpdate() > timeout) {
 				bool updated = false;
 
 				if (auto_distributed) {
@@ -3835,8 +3835,7 @@ void DeleteStaleLinks(Station *from)
 					while (iter != vehicles.end()) {
 						Vehicle *v = *iter;
 						/* Do not refresh links of vehicles that have been stopped in depot for a long time. */
-						if (!v->IsStoppedInDepot() || static_cast<uint>(TimerGameCalendar::date - v->date_of_last_service) <=
-								LinkGraph::STALE_LINK_DEPOT_TIMEOUT) {
+						if (!v->IsStoppedInDepot() || TimerGameCalendar::date - v->date_of_last_service <= LinkGraph::STALE_LINK_DEPOT_TIMEOUT) {
 							LinkRefresher::Run(v, false); // Don't allow merging. Otherwise lg might get deleted.
 						}
 						if (edge.LastUpdate() == TimerGameCalendar::date) {
@@ -3862,11 +3861,11 @@ void DeleteStaleLinks(Station *from)
 					ge.flows.DeleteFlows(to->index);
 					RerouteCargo(from, c, to->index, from->index);
 				}
-			} else if (edge.last_unrestricted_update != INVALID_DATE && (uint)(TimerGameCalendar::date - edge.last_unrestricted_update) > timeout) {
+			} else if (edge.last_unrestricted_update != INVALID_DATE && TimerGameCalendar::date - edge.last_unrestricted_update > timeout) {
 				edge.Restrict();
 				ge.flows.RestrictFlows(to->index);
 				RerouteCargo(from, c, to->index, from->index);
-			} else if (edge.last_restricted_update != INVALID_DATE && (uint)(TimerGameCalendar::date - edge.last_restricted_update) > timeout) {
+			} else if (edge.last_restricted_update != INVALID_DATE && TimerGameCalendar::date - edge.last_restricted_update > timeout) {
 				edge.Release();
 			}
 		}
@@ -3874,7 +3873,7 @@ void DeleteStaleLinks(Station *from)
 		for (NodeID r : to_remove) (*lg)[ge.node].RemoveEdge(r);
 
 		assert(TimerGameCalendar::date >= lg->LastCompression());
-		if ((uint)(TimerGameCalendar::date - lg->LastCompression()) > LinkGraph::COMPRESSION_INTERVAL) {
+		if (TimerGameCalendar::date - lg->LastCompression() > LinkGraph::COMPRESSION_INTERVAL) {
 			lg->Compress();
 		}
 	}

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -759,7 +759,7 @@ uint32_t Vehicle::GetGRFID() const
  * This is useful if the date has been modified with the cheat menu.
  * @param interval Number of days to be added or substracted.
  */
-void Vehicle::ShiftDates(int interval)
+void Vehicle::ShiftDates(TimerGameCalendar::Date interval)
 {
 	this->date_of_last_service = std::max(this->date_of_last_service + interval, 0);
 	/* date_of_last_service_newgrf is not updated here as it must stay stable

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -575,7 +575,7 @@ public:
 	 */
 	virtual void OnNewDay() {};
 
-	void ShiftDates(int interval);
+	void ShiftDates(TimerGameCalendar::Date interval);
 
 	/**
 	 * Crash the (whole) vehicle chain.


### PR DESCRIPTION
## Motivation / Problem

While working on #10761 I ran into the problem that `ShiftDates` was not expecting a date.

## Description

The comments clearly state it is a date, so change the type to a date. With #10761 that also brings type-safety into the mix.

This also cleans up the bits in `station_cmd.cpp` a bit.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
