### PR TITLE
Codechange: introduce week/quarter triggers for TimerGameCalendar

### DIFF
--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1822,6 +1822,15 @@ static IntervalTimer<TimerGameCalendar> _network_yearly({TimerGameCalendar::YEAR
 	NetworkAdminUpdate(ADMIN_FREQUENCY_ANUALLY);
 });
 
+/** Quarterly "callback". Called whenever the quarter changes. */
+static IntervalTimer<TimerGameCalendar> _network_quarterly({TimerGameCalendar::QUARTER, TimerGameCalendar::Priority::NONE}, [](auto)
+{
+	if (!_network_server) return;
+
+	NetworkAutoCleanCompanies();
+	NetworkAdminUpdate(ADMIN_FREQUENCY_QUARTERLY);
+});
+
 /** Monthly "callback". Called whenever the month changes. */
 static IntervalTimer<TimerGameCalendar> _network_monthly({TimerGameCalendar::MONTH, TimerGameCalendar::Priority::NONE}, [](auto)
 {
@@ -1829,7 +1838,14 @@ static IntervalTimer<TimerGameCalendar> _network_monthly({TimerGameCalendar::MON
 
 	NetworkAutoCleanCompanies();
 	NetworkAdminUpdate(ADMIN_FREQUENCY_MONTHLY);
-	if ((TimerGameCalendar::month % 3) == 0) NetworkAdminUpdate(ADMIN_FREQUENCY_QUARTERLY);
+});
+
+/** Weekly "callback". Called whenever the week changes. */
+static IntervalTimer<TimerGameCalendar> _network_weekly({TimerGameCalendar::WEEK, TimerGameCalendar::Priority::NONE}, [](auto)
+{
+	if (!_network_server) return;
+
+	NetworkAdminUpdate(ADMIN_FREQUENCY_WEEKLY);
 });
 
 /** Daily "callback". Called whenever the date changes. */
@@ -1838,7 +1854,6 @@ static IntervalTimer<TimerGameCalendar> _network_daily({TimerGameCalendar::DAY, 
 	if (!_network_server) return;
 
 	NetworkAdminUpdate(ADMIN_FREQUENCY_DAILY);
-	if ((TimerGameCalendar::date % 7) == 3) NetworkAdminUpdate(ADMIN_FREQUENCY_WEEKLY);
 });
 
 /**

--- a/src/timer/timer_game_calendar.cpp
+++ b/src/timer/timer_game_calendar.cpp
@@ -215,9 +215,21 @@ void TimerManager<TimerGameCalendar>::Elapsed(TimerGameCalendar::TElapsed delta)
 		timer->Elapsed(TimerGameCalendar::DAY);
 	}
 
+	if ((TimerGameCalendar::date % 7) == 3) {
+		for (auto timer : timers) {
+			timer->Elapsed(TimerGameCalendar::WEEK);
+		}
+	}
+
 	if (new_month) {
 		for (auto timer : timers) {
 			timer->Elapsed(TimerGameCalendar::MONTH);
+		}
+
+		if ((TimerGameCalendar::month % 3) == 0) {
+			for (auto timer : timers) {
+				timer->Elapsed(TimerGameCalendar::QUARTER);
+			}
 		}
 	}
 

--- a/src/timer/timer_game_calendar.h
+++ b/src/timer/timer_game_calendar.h
@@ -34,7 +34,9 @@ class TimerGameCalendar {
 public:
 	enum Trigger {
 		DAY,
+		WEEK,
 		MONTH,
+		QUARTER,
 		YEAR,
 	};
 	enum Priority {


### PR DESCRIPTION
## Motivation / Problem

The network-admin-update code has some complicated code to have triggers on week/quarter transitions. To keep code a bit simpler, I moved this to the timer itself, so all the trigger logic is contained in a single place.

## Description

This simplifies code that triggers on these periods. Also makes #10761 easier, as there is no longer any need for modulo based on date.

## Limitations

I have absolutely no clue why the network-admin-update decided to consider "the next week" when the days module 7 are equal to three. That feels a bit random. But I also didn't want to change behaviour .. so year.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
