### PR TITLE
Codechange: make explicit when a TileIndex is cast to its basetype 

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1177,7 +1177,7 @@ struct BuildVehicleWindow : Window {
 	{
 		this->vehicle_type = type;
 		this->listview_mode = tile == INVALID_TILE;
-		this->window_number = this->listview_mode ? (int)type : (int)tile;
+		this->window_number = this->listview_mode ? (int)type : static_cast<uint32_t>(tile);
 
 		this->sel_engine = INVALID_ENGINE;
 
@@ -1212,7 +1212,11 @@ struct BuildVehicleWindow : Window {
 
 		this->details_height = ((this->vehicle_type == VEH_TRAIN) ? 10 : 9);
 
-		this->FinishInitNested(tile == INVALID_TILE ? (int)type : (int)tile);
+		if (tile == INVALID_TILE) {
+			this->FinishInitNested(type);
+		} else {
+			this->FinishInitNested(tile);
+		}
 
 		this->querystrings[WID_BV_FILTER] = &this->vehicle_editbox;
 		this->vehicle_editbox.cancel_button = QueryString::ACTION_CLEAR;
@@ -1891,7 +1895,7 @@ void ShowBuildVehicleWindow(TileIndex tile, VehicleType type)
 	 *  so if tile == INVALID_TILE (Available XXX Window), use 'type' as unique number.
 	 *  As it always is a low value, it won't collide with any real tile
 	 *  number. */
-	uint num = (tile == INVALID_TILE) ? (int)type : (int)tile;
+	uint num = (tile == INVALID_TILE) ? (int)type : static_cast<uint32_t>(tile);
 
 	assert(IsCompanyBuildableVehicleType(type));
 

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -389,7 +389,7 @@ set_name:;
 			SetDParam(1, STR_NEWS_COMPANY_LAUNCH_DESCRIPTION);
 			SetDParamStr(2, cni->company_name);
 			SetDParam(3, t->index);
-			AddNewsItem(STR_MESSAGE_NEWS_FORMAT, NT_COMPANY_INFO, NF_COMPANY, NR_TILE, c->last_build_coordinate, NR_NONE, UINT32_MAX, cni);
+			AddNewsItem(STR_MESSAGE_NEWS_FORMAT, NT_COMPANY_INFO, NF_COMPANY, NR_TILE, static_cast<uint32_t>(c->last_build_coordinate), NR_NONE, UINT32_MAX, cni);
 		}
 		return;
 	}

--- a/src/core/strong_typedef_type.hpp
+++ b/src/core/strong_typedef_type.hpp
@@ -133,33 +133,6 @@ namespace StrongType {
 	};
 
 	/**
-	 * Mix-in which makes the new Typedef implicitly convertible to its base type.
-	 *
-	 * Be careful: when allowing implicit conversion, you won't notice if this type is assigned to a compatible, but different, type.
-	 * For example:
-	 *
-	 *   StrongType::Typedef<int, struct MyTypeTag, Implicit> a = 1;
-	 *   StrongType::Typedef<int, struct MyTypeTag, Implicit> b = 2;
-	 *   a = b; // OK
-	 */
-	struct Implicit {
-		template <typename TType, typename TBaseType>
-		struct mixin {
-			constexpr operator TBaseType () const { return static_cast<const TType &>(*this).value; }
-		};
-	};
-
-	/**
-	 * Mix-in which makes the new Typedef explicitly convertible to its base type.
-	 */
-	struct Explicit {
-		template <typename TType, typename TBaseType>
-		struct mixin {
-			explicit constexpr operator TBaseType () const { return static_cast<const TType &>(*this).value; }
-		};
-	};
-
-	/**
 	 * Templated helper to make a type-safe 'typedef' representing a single POD value.
 	 * A normal 'typedef' is not distinct from its base type and will be treated as
 	 * identical in many contexts. This class provides a distinct type that can still
@@ -187,9 +160,10 @@ namespace StrongType {
 		constexpr Typedef &operator =(Typedef &&rhs) { this->value = std::move(rhs.value); return *this; }
 		constexpr Typedef &operator =(const TBaseType &rhs) { this->value = rhs; return *this; }
 
+		/* Only allow explicit conversions to BaseType. */
+		explicit constexpr operator TBaseType () const { return this->value; }
+
 		/* Only allow TProperties classes access to the internal value. Everyone else needs to do an explicit cast. */
-		friend struct Explicit;
-		friend struct Implicit;
 		friend struct Compare;
 		friend struct Integer;
 		template <typename TCompatibleType> friend struct Compatible;

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -358,7 +358,7 @@ static bool DisasterTick_Ufo(DisasterVehicle *v)
 		return true;
 	} else {
 		/* Target a vehicle */
-		RoadVehicle *u = RoadVehicle::Get(v->dest_tile);
+		RoadVehicle *u = RoadVehicle::Get(static_cast<uint32_t>(v->dest_tile));
 		assert(u != nullptr && u->type == VEH_ROAD && u->IsFrontEngine());
 
 		uint dist = Delta(v->x_pos, u->x_pos) + Delta(v->y_pos, u->y_pos);
@@ -437,7 +437,7 @@ static bool DisasterTick_Aircraft(DisasterVehicle *v, uint16_t image_override, b
 
 	if (v->state == 2) {
 		if (GB(v->tick_counter, 0, 2) == 0) {
-			Industry *i = Industry::Get(v->dest_tile); // Industry destructor calls ReleaseDisastersTargetingIndustry, so this is valid
+			Industry *i = Industry::Get(static_cast<uint32_t>(v->dest_tile)); // Industry destructor calls ReleaseDisastersTargetingIndustry, so this is valid
 			int x = TileX(i->location.tile) * TILE_SIZE;
 			int y = TileY(i->location.tile) * TILE_SIZE;
 			uint32_t r = Random();
@@ -455,7 +455,7 @@ static bool DisasterTick_Aircraft(DisasterVehicle *v, uint16_t image_override, b
 			v->state = 2;
 			v->age = 0;
 
-			Industry *i = Industry::Get(v->dest_tile); // Industry destructor calls ReleaseDisastersTargetingIndustry, so this is valid
+			Industry *i = Industry::Get(static_cast<uint32_t>(v->dest_tile)); // Industry destructor calls ReleaseDisastersTargetingIndustry, so this is valid
 			DestructIndustry(i);
 
 			SetDParam(0, i->town->index);

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -151,7 +151,7 @@ Industry::~Industry()
 	for (TileIndex tile_cur : this->location) {
 		if (IsTileType(tile_cur, MP_INDUSTRY)) {
 			if (GetIndustryIndex(tile_cur) == this->index) {
-				DeleteNewGRFInspectWindow(GSF_INDUSTRYTILES, tile_cur);
+				DeleteNewGRFInspectWindow(GSF_INDUSTRYTILES, static_cast<uint32_t>(tile_cur));
 
 				/* MakeWaterKeepingClass() can also handle 'land' */
 				MakeWaterKeepingClass(tile_cur, OWNER_NONE);

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -77,7 +77,7 @@ public:
 	/**
 	 * Implicit conversion to the uint for bounds checking.
 	 */
-	debug_inline constexpr operator uint() const { return tile; }
+	debug_inline constexpr operator uint() const { return static_cast<uint32_t>(tile); }
 
 	/**
 	 * The type (bits 4..7), bridges (2..3), rainforest/desert (0..1)
@@ -88,7 +88,7 @@ public:
 	 */
 	debug_inline byte &type()
 	{
-		return base_tiles[tile].type;
+		return base_tiles[static_cast<uint32_t>(tile)].type;
 	}
 
 	/**
@@ -100,7 +100,7 @@ public:
 	 */
 	debug_inline byte &height()
 	{
-		return base_tiles[tile].height;
+		return base_tiles[static_cast<uint32_t>(tile)].height;
 	}
 
 	/**
@@ -112,7 +112,7 @@ public:
 	 */
 	debug_inline byte &m1()
 	{
-		return base_tiles[tile].m1;
+		return base_tiles[static_cast<uint32_t>(tile)].m1;
 	}
 
 	/**
@@ -124,7 +124,7 @@ public:
 	 */
 	debug_inline uint16_t &m2()
 	{
-		return base_tiles[tile].m2;
+		return base_tiles[static_cast<uint32_t>(tile)].m2;
 	}
 
 	/**
@@ -136,7 +136,7 @@ public:
 	 */
 	debug_inline byte &m3()
 	{
-		return base_tiles[tile].m3;
+		return base_tiles[static_cast<uint32_t>(tile)].m3;
 	}
 
 	/**
@@ -148,7 +148,7 @@ public:
 	 */
 	debug_inline byte &m4()
 	{
-		return base_tiles[tile].m4;
+		return base_tiles[static_cast<uint32_t>(tile)].m4;
 	}
 
 	/**
@@ -160,7 +160,7 @@ public:
 	 */
 	debug_inline byte &m5()
 	{
-		return base_tiles[tile].m5;
+		return base_tiles[static_cast<uint32_t>(tile)].m5;
 	}
 
 	/**
@@ -172,7 +172,7 @@ public:
 	 */
 	debug_inline byte &m6()
 	{
-		return extended_tiles[tile].m6;
+		return extended_tiles[static_cast<uint32_t>(tile)].m6;
 	}
 
 	/**
@@ -184,7 +184,7 @@ public:
 	 */
 	debug_inline byte &m7()
 	{
-		return extended_tiles[tile].m7;
+		return extended_tiles[static_cast<uint32_t>(tile)].m7;
 	}
 
 	/**
@@ -196,7 +196,7 @@ public:
 	 */
 	debug_inline uint16_t &m8()
 	{
-		return extended_tiles[tile].m8;
+		return extended_tiles[static_cast<uint32_t>(tile)].m8;
 	}
 };
 
@@ -314,9 +314,9 @@ public:
 	 * It does this by masking the 'high' bits of.
 	 * @param tile the tile to 'wrap'
 	 */
-	static inline TileIndex WrapToMap(uint tile)
+	static inline TileIndex WrapToMap(TileIndex tile)
 	{
-		return tile & Map::tile_mask;
+		return static_cast<uint32_t>(tile) & Map::tile_mask;
 	}
 
 	/**

--- a/src/misc/dbg_helpers.cpp
+++ b/src/misc/dbg_helpers.cpp
@@ -63,7 +63,7 @@ std::string ValueStr(SignalType t)
 std::string TileStr(TileIndex tile)
 {
 	std::stringstream ss;
-	ss << "0x" << std::setfill('0') << std::setw(4) << std::hex << tile; // 0x%04X
+	ss << "0x" << std::setfill('0') << std::setw(4) << std::hex << static_cast<uint32_t>(tile); // 0x%04X
 	ss << " (" << TileX(tile) << ", " << TileY(tile) << ")";
 	return ss.str();
 }

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -207,7 +207,7 @@ public:
 
 		/* Location */
 		std::stringstream tile_ss;
-		tile_ss << "0x" << std::setfill('0') << std::setw(4) << std::hex << std::uppercase << tile; // 0x%.4X
+		tile_ss << "0x" << std::setfill('0') << std::setw(4) << std::hex << std::uppercase << static_cast<uint32_t>(tile); // 0x%.4X
 
 		SetDParam(0, TileX(tile));
 		SetDParam(1, TileY(tile));
@@ -331,12 +331,12 @@ public:
 
 	bool IsNewGRFInspectable() const override
 	{
-		return ::IsNewGRFInspectable(GetGrfSpecFeature(this->tile), this->tile);
+		return ::IsNewGRFInspectable(GetGrfSpecFeature(this->tile), static_cast<uint32_t>(this->tile));
 	}
 
 	void ShowNewGRFInspectWindow() const override
 	{
-		::ShowNewGRFInspectWindow(GetGrfSpecFeature(this->tile), this->tile);
+		::ShowNewGRFInspectWindow(GetGrfSpecFeature(this->tile), static_cast<uint32_t>(this->tile));
 	}
 
 	void OnClick(Point pt, int widget, int click_count) override

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -162,7 +162,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(byte param_setID, byte layo
 		/* Variables available during construction check. */
 
 		switch (variable) {
-			case 0x80: return this->tile;
+			case 0x80: return static_cast<uint32_t>(this->tile);
 			case 0x81: return GB(static_cast<uint32_t>(this->tile), 8, 8);
 
 			/* Pointer to the town the industry is associated with */
@@ -347,7 +347,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(byte param_setID, byte layo
 		case 0x7C: return (this->industry->psa != nullptr) ? this->industry->psa->GetValue(parameter) : 0;
 
 		/* Industry structure access*/
-		case 0x80: return this->industry->location.tile;
+		case 0x80: return static_cast<uint32_t>(this->industry->location.tile);
 		case 0x81: return GB(static_cast<uint32_t>(this->industry->location.tile), 8, 8);
 		/* Pointer to the town the industry is associated with */
 		case 0x82: return this->industry->town->index;

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -305,7 +305,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(byte local_id, uint32_t grf
 	switch (variable) {
 		/* Relative position. */
 		case 0x40: {
-			uint offset = this->tile - this->obj->location.tile;
+			TileIndex offset = this->tile - this->obj->location.tile;
 			uint offset_x = TileX(offset);
 			uint offset_y = TileY(offset);
 			return offset_y << 20 | offset_x << 16 | offset_y << 8 | offset_x;

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -649,7 +649,7 @@ uint16_t GetStationCallback(CallbackID callback, uint32_t param1, uint32_t param
  */
 CommandCost PerformStationTileSlopeCheck(TileIndex north_tile, TileIndex cur_tile, const StationSpec *statspec, Axis axis, byte plat_len, byte numtracks)
 {
-	TileIndexDiff diff = cur_tile - north_tile;
+	TileIndex diff = cur_tile - north_tile;
 	Slope slope = GetTileSlope(cur_tile);
 
 	StationResolverObject object(statspec, nullptr, cur_tile, CBID_STATION_LAND_SLOPE_CHECK,

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -43,7 +43,7 @@
 		}
 
 		/* Town properties */
-		case 0x80: return this->t->xy;
+		case 0x80: return static_cast<uint32_t>(this->t->xy);
 		case 0x81: return GB(static_cast<uint32_t>(this->t->xy), 8, 8);
 		case 0x82: return ClampTo<uint16_t>(this->t->cache.population);
 		case 0x83: return GB(ClampTo<uint16_t>(this->t->cache.population), 8, 8);

--- a/src/news_func.h
+++ b/src/news_func.h
@@ -44,7 +44,7 @@ static inline void AddVehicleAdviceNewsItem(StringID string, VehicleID vehicle)
 
 static inline void AddTileNewsItem(StringID string, NewsType type, TileIndex tile, const NewsAllocatedData *data = nullptr, StationID station = INVALID_STATION)
 {
-	AddNewsItem(string, type, NF_NO_TRANSPARENT | NF_SHADE | NF_THIN, NR_TILE, tile, station == INVALID_STATION ? NR_NONE : NR_STATION, station, data);
+	AddNewsItem(string, type, NF_NO_TRANSPARENT | NF_SHADE | NF_THIN, NR_TILE, static_cast<uint32_t>(tile), station == INVALID_STATION ? NR_NONE : NR_STATION, station, data);
 }
 
 static inline void AddIndustryNewsItem(StringID string, NewsType type, IndustryID industry)

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -511,7 +511,7 @@ static void ReallyClearObjectTile(Object *o)
 {
 	Object::DecTypeCount(o->type);
 	for (TileIndex tile_cur : o->location) {
-		DeleteNewGRFInspectWindow(GSF_OBJECTS, tile_cur);
+		DeleteNewGRFInspectWindow(GSF_OBJECTS, static_cast<uint32_t>(tile_cur));
 
 		MakeWaterKeepingClass(tile_cur, GetTileOwner(tile_cur));
 	}

--- a/src/pathfinder/yapf/yapf_node_rail.hpp
+++ b/src/pathfinder/yapf/yapf_node_rail.hpp
@@ -27,7 +27,7 @@ struct CYapfRailSegmentKey
 
 	inline void Set(const CYapfNodeKeyTrackDir &node_key)
 	{
-		m_value = (((int)node_key.m_tile) << 4) | node_key.m_td;
+		m_value = (static_cast<uint32_t>(node_key.m_tile) << 4) | node_key.m_td;
 	}
 
 	inline int32_t CalcHash() const

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -662,7 +662,7 @@ CommandCost CmdRemoveSingleRail(DoCommandFlag flags, TileIndex tile, Track track
 				Company::Get(owner)->infrastructure.rail[GetRailType(tile)] -= LEVELCROSSING_TRACKBIT_FACTOR;
 				DirtyCompanyInfrastructureWindows(owner);
 				MakeRoadNormal(tile, GetCrossingRoadBits(tile), GetRoadTypeRoad(tile), GetRoadTypeTram(tile), GetTownIndex(tile), GetRoadOwner(tile, RTT_ROAD), GetRoadOwner(tile, RTT_TRAM));
-				DeleteNewGRFInspectWindow(GSF_RAILTYPES, tile);
+				DeleteNewGRFInspectWindow(GSF_RAILTYPES, static_cast<uint32_t>(tile));
 			}
 			break;
 		}
@@ -720,7 +720,7 @@ CommandCost CmdRemoveSingleRail(DoCommandFlag flags, TileIndex tile, Track track
 					} else {
 						DoClearSquare(tile);
 					}
-					DeleteNewGRFInspectWindow(GSF_RAILTYPES, tile);
+					DeleteNewGRFInspectWindow(GSF_RAILTYPES, static_cast<uint32_t>(tile));
 				} else {
 					SetTrackBits(tile, present);
 					SetTrackReservation(tile, GetRailReservationTrackBits(tile) & present);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2143,7 +2143,7 @@ bool AfterLoadGame()
 		/* Delete small ufos heading for non-existing vehicles */
 		for (DisasterVehicle *v : DisasterVehicle::Iterate()) {
 			if (v->subtype == 2 /* ST_SMALL_UFO */ && v->state != 0) {
-				const Vehicle *u = Vehicle::GetIfValid(v->dest_tile);
+				const Vehicle *u = Vehicle::GetIfValid(static_cast<uint32_t>(v->dest_tile));
 				if (u == nullptr || u->type != VEH_ROAD || !RoadVehicle::From(u)->IsFrontEngine()) {
 					delete v;
 				}

--- a/src/saveload/map_sl.cpp
+++ b/src/saveload/map_sl.cpp
@@ -72,7 +72,7 @@ struct MAPTChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
@@ -83,7 +83,7 @@ struct MAPTChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
@@ -99,7 +99,7 @@ struct MAPHChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
@@ -110,7 +110,7 @@ struct MAPHChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
@@ -126,7 +126,7 @@ struct MAPOChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
@@ -137,7 +137,7 @@ struct MAPOChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
@@ -153,7 +153,7 @@ struct MAP2ChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<uint16_t, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE,
@@ -167,7 +167,7 @@ struct MAP2ChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<uint16_t, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		SlSetLength(static_cast<uint32_t>(size) * sizeof(uint16_t));
 		for (TileIndex i = 0; i != size;) {
@@ -183,7 +183,7 @@ struct M3LOChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
@@ -194,7 +194,7 @@ struct M3LOChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
@@ -210,7 +210,7 @@ struct M3HIChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
@@ -221,7 +221,7 @@ struct M3HIChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
@@ -237,7 +237,7 @@ struct MAP5ChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
@@ -248,7 +248,7 @@ struct MAP5ChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
@@ -264,7 +264,7 @@ struct MAPEChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		if (IsSavegameVersionBefore(SLV_42)) {
 			for (TileIndex i = 0; i != size;) {
@@ -288,7 +288,7 @@ struct MAPEChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
@@ -304,7 +304,7 @@ struct MAP7ChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
@@ -315,7 +315,7 @@ struct MAP7ChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
@@ -331,7 +331,7 @@ struct MAP8ChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<uint16_t, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT16);
@@ -342,7 +342,7 @@ struct MAP8ChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<uint16_t, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = Map::Size();
+		uint size = Map::Size();
 
 		SlSetLength(static_cast<uint32_t>(size) * sizeof(uint16_t));
 		for (TileIndex i = 0; i != size;) {

--- a/src/script/api/script_bridge.cpp
+++ b/src/script/api/script_bridge.cpp
@@ -83,8 +83,8 @@ static void _DoCommandReturnBuildBridge1(class ScriptInstance *instance)
 
 	switch (vehicle_type) {
 		case ScriptVehicle::VT_ROAD:
-			ScriptObject::SetCallbackVariable(0, start);
-			ScriptObject::SetCallbackVariable(1, end);
+			ScriptObject::SetCallbackVariable(0, static_cast<uint32_t>(start));
+			ScriptObject::SetCallbackVariable(1, static_cast<uint32_t>(end));
 			return ScriptObject::Command<CMD_BUILD_BRIDGE>::Do(&::_DoCommandReturnBuildBridge1, end, start, TRANSPORT_ROAD, bridge_id, ScriptRoad::GetCurrentRoadType());
 		case ScriptVehicle::VT_RAIL:
 			return ScriptObject::Command<CMD_BUILD_BRIDGE>::Do(end, start, TRANSPORT_RAIL, bridge_id, ScriptRail::GetCurrentRailType());

--- a/src/script/api/script_depotlist.cpp
+++ b/src/script/api/script_depotlist.cpp
@@ -30,7 +30,7 @@ ScriptDepotList::ScriptDepotList(ScriptTile::TransportType transport_type)
 			for (const Station *st : Station::Iterate()) {
 				if (st->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity()) {
 					for (uint i = 0; i < st->airport.GetNumHangars(); i++) {
-						this->AddItem(st->airport.GetHangarTile(i));
+						this->AddItem(static_cast<uint32_t>(st->airport.GetHangarTile(i)));
 					}
 				}
 			}
@@ -40,6 +40,6 @@ ScriptDepotList::ScriptDepotList(ScriptTile::TransportType transport_type)
 
 	/* Handle 'standard' depots. */
 	for (const Depot *depot : Depot::Iterate()) {
-		if ((::GetTileOwner(depot->xy) == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity()) && ::IsTileType(depot->xy, tile_type)) this->AddItem(depot->xy);
+		if ((::GetTileOwner(depot->xy) == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity()) && ::IsTileType(depot->xy, tile_type)) this->AddItem(static_cast<uint32_t>(depot->xy));
 	}
 }

--- a/src/script/api/script_map.hpp
+++ b/src/script/api/script_map.hpp
@@ -19,7 +19,7 @@
  */
 class ScriptMap : public ScriptObject {
 public:
-	static const int TILE_INVALID = (int)INVALID_TILE; ///< Invalid TileIndex.
+	static const int TILE_INVALID = static_cast<uint32_t>(INVALID_TILE); ///< Invalid TileIndex.
 
 	/**
 	 * Checks whether the given tile is valid.

--- a/src/script/api/script_road.cpp
+++ b/src/script/api/script_road.cpp
@@ -382,8 +382,8 @@ static bool NormaliseTileOffset(int32_t *tile)
 /* static */ SQInteger ScriptRoad::CanBuildConnectedRoadParts(ScriptTile::Slope slope_, Array<> &&existing, TileIndex start_, TileIndex end_)
 {
 	::Slope slope = (::Slope)slope_;
-	int32_t start = start_;
-	int32_t end = end_;
+	int32_t start = static_cast<uint32_t>(start_);
+	int32_t end = static_cast<uint32_t>(end_);
 
 	/* The start tile and end tile cannot be the same tile either. */
 	if (start == end) return -1;

--- a/src/script/api/script_tilelist.cpp
+++ b/src/script/api/script_tilelist.cpp
@@ -21,14 +21,14 @@ void ScriptTileList::AddRectangle(TileIndex t1, TileIndex t2)
 	if (!::IsValidTile(t2)) return;
 
 	TileArea ta(t1, t2);
-	for (TileIndex t : ta) this->AddItem(t);
+	for (TileIndex t : ta) this->AddItem(static_cast<uint32_t>(t));
 }
 
 void ScriptTileList::AddTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return;
 
-	this->AddItem(tile);
+	this->AddItem(static_cast<uint32_t>(tile));
 }
 
 void ScriptTileList::RemoveRectangle(TileIndex t1, TileIndex t2)
@@ -37,14 +37,14 @@ void ScriptTileList::RemoveRectangle(TileIndex t1, TileIndex t2)
 	if (!::IsValidTile(t2)) return;
 
 	TileArea ta(t1, t2);
-	for (TileIndex t : ta) this->RemoveItem(t);
+	for (TileIndex t : ta) this->RemoveItem(static_cast<uint32_t>(t));
 }
 
 void ScriptTileList::RemoveTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return;
 
-	this->RemoveItem(tile);
+	this->RemoveItem(static_cast<uint32_t>(tile));
 }
 
 /**

--- a/src/script/api/script_tunnel.cpp
+++ b/src/script/api/script_tunnel.cpp
@@ -93,7 +93,7 @@ static void _DoCommandReturnBuildTunnel1(class ScriptInstance *instance)
 		/* For rail we do nothing special */
 		return ScriptObject::Command<CMD_BUILD_TUNNEL>::Do(start, TRANSPORT_RAIL, ScriptRail::GetCurrentRailType());
 	} else {
-		ScriptObject::SetCallbackVariable(0, start);
+		ScriptObject::SetCallbackVariable(0, static_cast<uint32_t>(start));
 		return ScriptObject::Command<CMD_BUILD_TUNNEL>::Do(&::_DoCommandReturnBuildTunnel1, start, TRANSPORT_ROAD, ScriptRoad::GetCurrentRoadType());
 	}
 }

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1651,7 +1651,7 @@ CommandCost RemoveFromRailBaseStation(TileArea ta, std::vector<T *> &affected_st
 			if (!build_rail && !IsStationTileBlocked(tile)) Company::Get(owner)->infrastructure.rail[rt]--;
 
 			DoClearSquare(tile);
-			DeleteNewGRFInspectWindow(GSF_STATIONS, tile);
+			DeleteNewGRFInspectWindow(GSF_STATIONS, static_cast<uint32_t>(tile));
 			if (build_rail) MakeRailNormal(tile, owner, TrackToTrackBits(track), rt);
 			Company::Get(owner)->infrastructure.station--;
 			DirtyCompanyInfrastructureWindows(owner);
@@ -2149,7 +2149,7 @@ static CommandCost RemoveRoadStop(TileIndex tile, DoCommandFlag flags, int repla
 
 		uint specindex = GetCustomRoadStopSpecIndex(tile);
 
-		DeleteNewGRFInspectWindow(GSF_ROADSTOPS, tile);
+		DeleteNewGRFInspectWindow(GSF_ROADSTOPS, static_cast<uint32_t>(tile));
 
 		if (IsDriveThroughStopTile(tile)) {
 			/* Clears the tile for us */
@@ -2533,7 +2533,7 @@ static CommandCost RemoveAirport(TileIndex tile, DoCommandFlag flags)
 		if (flags & DC_EXEC) {
 			DeleteAnimatedTile(tile_cur);
 			DoClearSquare(tile_cur);
-			DeleteNewGRFInspectWindow(GSF_AIRPORTTILES, tile_cur);
+			DeleteNewGRFInspectWindow(GSF_AIRPORTTILES, static_cast<uint32_t>(tile_cur));
 		}
 	}
 

--- a/src/story.cpp
+++ b/src/story.cpp
@@ -99,7 +99,7 @@ static void UpdateElement(StoryPageElement &pe, TileIndex tile, uint32_t referen
 			break;
 		case SPET_LOCATION:
 			pe.text = text;
-			pe.referenced_id = tile;
+			pe.referenced_id = static_cast<uint32_t>(tile);
 			break;
 		case SPET_GOAL:
 			pe.referenced_id = (GoalID)reference;

--- a/src/tile_type.h
+++ b/src/tile_type.h
@@ -84,7 +84,7 @@ enum TropicZone {
  *
  * It is compatible with int32 / int64 for easy math throughout the code.
  */
-using TileIndex = StrongType::Typedef<uint32_t, struct TileIndexTag, StrongType::Implicit, StrongType::Compare, StrongType::Integer, StrongType::Compatible<int32_t>, StrongType::Compatible<int64_t>>;
+using TileIndex = StrongType::Typedef<uint32_t, struct TileIndexTag, StrongType::Compare, StrongType::Integer, StrongType::Compatible<int32_t>, StrongType::Compatible<int64_t>>;
 
 /* Make sure the size is as expected. */
 static_assert(sizeof(TileIndex) == 4);

--- a/src/timer/timer_game_calendar.h
+++ b/src/timer/timer_game_calendar.h
@@ -78,13 +78,13 @@ public:
 	};
 
 	/** The type to store our dates in. */
-	using Date = StrongType::Typedef<int32_t, struct DateTag, StrongType::Explicit, StrongType::Compare, StrongType::Integer>;
+	using Date = StrongType::Typedef<int32_t, struct DateTag, StrongType::Compare, StrongType::Integer>;
 
 	/** The fraction of a date we're in, i.e. the number of ticks since the last date changeover. */
 	using DateFract = uint16_t;
 
 	/** Type for the year, note: 0 based, i.e. starts at the year 0. */
-	using Year = StrongType::Typedef<int32_t, struct YearTag, StrongType::Explicit, StrongType::Compare, StrongType::Integer>;
+	using Year = StrongType::Typedef<int32_t, struct YearTag, StrongType::Compare, StrongType::Integer>;
 	/** Type for the month, note: 0 based, i.e. 0 = January, 11 = December. */
 	using Month = uint8_t;
 	/** Type for the day of the month, note: 1 based, first day of a month is 1. */

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2714,7 +2714,7 @@ static void DoClearTownHouseHelper(TileIndex tile, Town *t, HouseID house)
 	DoClearSquare(tile);
 	DeleteAnimatedTile(tile);
 
-	DeleteNewGRFInspectWindow(GSF_HOUSES, tile);
+	DeleteNewGRFInspectWindow(GSF_HOUSES, static_cast<uint32_t>(tile));
 }
 
 /**

--- a/src/window_func.h
+++ b/src/window_func.h
@@ -13,11 +13,18 @@
 #include "window_type.h"
 #include "company_type.h"
 #include "core/geometry_type.hpp"
+#include "core/strong_typedef_type.hpp"
 
 Window *FindWindowById(WindowClass cls, WindowNumber number);
 Window *FindWindowByClass(WindowClass cls);
 Window *GetMainWindow();
 void ChangeWindowOwner(Owner old_owner, Owner new_owner);
+
+template<typename T, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value, int> = 0>
+Window *FindWindowById(WindowClass cls, T number)
+{
+	return FindWindowById(cls, static_cast<typename T::BaseType>(number));
+}
 
 void ResizeWindow(Window *w, int x, int y, bool clamp_to_screen = true);
 int PositionMainToolbar(Window *w);
@@ -37,6 +44,12 @@ void InputLoop();
 void InvalidateWindowData(WindowClass cls, WindowNumber number, int data = 0, bool gui_scope = false);
 void InvalidateWindowClassesData(WindowClass cls, int data = 0, bool gui_scope = false);
 
+template<typename T, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value, int> = 0>
+void InvalidateWindowData(WindowClass cls, T number, int data = 0, bool gui_scope = false)
+{
+	InvalidateWindowData(cls, static_cast<typename T::BaseType>(number), data, gui_scope);
+}
+
 void CloseNonVitalWindows();
 void CloseAllNonVitalWindows();
 void DeleteAllMessages();
@@ -54,8 +67,20 @@ void SetWindowWidgetDirty(WindowClass cls, WindowNumber number, byte widget_inde
 void SetWindowDirty(WindowClass cls, WindowNumber number);
 void SetWindowClassesDirty(WindowClass cls);
 
+template<typename T, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value, int> = 0>
+void SetWindowDirty(WindowClass cls, T number)
+{
+	SetWindowDirty(cls, static_cast<typename T::BaseType>(number));
+}
+
 void CloseWindowById(WindowClass cls, WindowNumber number, bool force = true);
 void CloseWindowByClass(WindowClass cls);
+
+template<typename T, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value, int> = 0>
+void CloseWindowById(WindowClass cls, T number, bool force = true)
+{
+	CloseWindowById(cls, static_cast<typename T::BaseType>(number), force);
+}
 
 bool EditBoxInGlobalFocus();
 bool FocusedWindowIsConsole();

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -284,6 +284,12 @@ public:
 	void CreateNestedTree(bool fill_nested = true);
 	void FinishInitNested(WindowNumber window_number = 0);
 
+	template<typename T, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value, int> = 0>
+	void FinishInitNested(T number)
+	{
+		this->FinishInitNested(static_cast<typename T::BaseType>(number));
+	}
+
 	/**
 	 * Set the timeout flag of the window and initiate the timer.
 	 */
@@ -879,6 +885,12 @@ public:
 
 Window *BringWindowToFrontById(WindowClass cls, WindowNumber number);
 Window *FindWindowFromPt(int x, int y);
+
+template<typename T, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value, int> = 0>
+Window *BringWindowToFrontById(WindowClass cls, T number)
+{
+	return BringWindowToFrontById(cls, static_cast<typename T::BaseType>(number));
+}
 
 /**
  * Open a new window.


### PR DESCRIPTION
This PR includes #10761 as it depends on it.

## Motivation / Problem

StrongTypeDef allowed, before #10761 already, implicit conversion to `uint32_t` for `TileIndex`, because of the many many many cases this was needed. But because of #10761, the amount of places this is still happening is reduced by a lot. This is mostly because functions like `SetDParam` now accept a `StrongTypeDef`, and knows how to deal with it.

This made me wonder: can we make `TileIndex`'s conversion explicit, so we don't accidentally assign incompatible types to each other just because the compiler used an implicit conversion.

## Description

Turns out, the answer is: yes, we can. And this PR is the result of that.

`dest_tile` is misused by disasters to store an ID. Not part of this PR to ... "fix" that issue.

The `TileIndexDiff` is a bit weird; that is not normally how we calculate a `TileIndexDiff`. So changed it to what others do too.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
