### PR TITLE
Codechange: use std::variant instead of using bitflags in the value

### DIFF
--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -308,7 +308,11 @@ struct NewsWindow : Window {
 		/* Initialize viewport if it exists. */
 		NWidgetViewport *nvp = this->GetWidget<NWidgetViewport>(WID_N_VIEWPORT);
 		if (nvp != nullptr) {
-			nvp->InitializeViewport(this, ni->reftype1 == NR_VEHICLE ? 0x80000000 | ni->ref1 : (uint32_t)GetReferenceTile(ni->reftype1, ni->ref1),ScaleZoomGUI(ZOOM_LVL_NEWS));
+			if (ni->reftype1 == NR_VEHICLE) {
+				nvp->InitializeViewport(this, GetReferenceTile(ni->reftype1, ni->ref1), ScaleZoomGUI(ZOOM_LVL_NEWS));
+			} else {
+				nvp->InitializeViewport(this, static_cast<VehicleID>(ni->ref1), ScaleZoomGUI(ZOOM_LVL_NEWS));
+			}
 			if (this->ni->flags & NF_NO_TRANSPARENT) nvp->disp_flags |= ND_NO_TRANSPARENCY;
 			if ((this->ni->flags & NF_INCOLOUR) == 0) {
 				nvp->disp_flags |= ND_SHADE_GREY;

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -80,6 +80,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <variant>
 #include <vector>
 
 #if defined(UNIX) || defined(__MINGW32__)

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2915,7 +2915,7 @@ public:
 		}
 		this->FinishInitNested(window_number);
 		this->owner = v->owner;
-		this->GetWidget<NWidgetViewport>(WID_VV_VIEWPORT)->InitializeViewport(this, this->window_number | (1 << 31), ScaleZoomGUI(_vehicle_view_zoom_levels[v->type]));
+		this->GetWidget<NWidgetViewport>(WID_VV_VIEWPORT)->InitializeViewport(this, static_cast<VehicleID>(this->window_number), ScaleZoomGUI(_vehicle_view_zoom_levels[v->type]));
 
 		this->GetWidget<NWidgetCore>(WID_VV_START_STOP)->tool_tip       = STR_VEHICLE_VIEW_TRAIN_STATUS_START_STOP_TOOLTIP + v->type;
 		this->GetWidget<NWidgetCore>(WID_VV_RENAME)->tool_tip           = STR_VEHICLE_DETAILS_TRAIN_RENAME + v->type;

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -213,13 +213,11 @@ void DeleteWindowViewport(Window *w)
  * @param y Offset of top edge of viewport with respect to top edge window \a w
  * @param width Width of the viewport
  * @param height Height of the viewport
- * @param follow_flags Flags controlling the viewport.
- *        - If bit 31 is set, the lower 20 bits are the vehicle that the viewport should follow.
- *        - If bit 31 is clear, it is a #TileIndex.
+ * @param focus Either the tile index or vehicle ID to focus.
  * @param zoom Zoomlevel to display
  */
 void InitializeWindowViewport(Window *w, int x, int y,
-	int width, int height, uint32_t follow_flags, ZoomLevel zoom)
+	int width, int height, std::variant<TileIndex, VehicleID> focus, ZoomLevel zoom)
 {
 	assert(w->viewport == nullptr);
 
@@ -237,15 +235,15 @@ void InitializeWindowViewport(Window *w, int x, int y,
 
 	Point pt;
 
-	if (follow_flags & 0x80000000) {
+	if (std::holds_alternative<VehicleID>(focus)) {
 		const Vehicle *veh;
 
-		vp->follow_vehicle = (VehicleID)(follow_flags & 0xFFFFF);
+		vp->follow_vehicle = std::get<VehicleID>(focus);
 		veh = Vehicle::Get(vp->follow_vehicle);
 		pt = MapXYZToViewport(vp, veh->x_pos, veh->y_pos, veh->z_pos);
 	} else {
-		x = TileX(follow_flags) * TILE_SIZE;
-		y = TileY(follow_flags) * TILE_SIZE;
+		x = TileX(std::get<TileIndex>(focus)) * TILE_SIZE;
+		y = TileY(std::get<TileIndex>(focus)) * TILE_SIZE;
 
 		vp->follow_vehicle = INVALID_VEHICLE;
 		pt = MapXYZToViewport(vp, x, y, GetSlopePixelZ(x, y));

--- a/src/viewport_func.h
+++ b/src/viewport_func.h
@@ -15,13 +15,14 @@
 #include "window_type.h"
 #include "tile_map.h"
 #include "station_type.h"
+#include "vehicle_type.h"
 
 static const int TILE_HEIGHT_STEP = 50; ///< One Z unit tile height difference is displayed as 50m.
 
 void SetSelectionRed(bool);
 
 void DeleteWindowViewport(Window *w);
-void InitializeWindowViewport(Window *w, int x, int y, int width, int height, uint32_t follow_flags, ZoomLevel zoom);
+void InitializeWindowViewport(Window *w, int x, int y, int width, int height, std::variant<TileIndex, VehicleID> focus, ZoomLevel zoom);
 Viewport *IsPtInWindowViewport(const Window *w, int x, int y);
 Point TranslateXYToTileCoord(const Viewport *vp, int x, int y, bool clamp_to_map = true);
 Point GetTileBelowCursor();

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -2333,12 +2333,12 @@ void NWidgetViewport::Draw(const Window *w)
 /**
  * Initialize the viewport of the window.
  * @param w            Window owning the viewport.
- * @param follow_flags Type of viewport, see #InitializeWindowViewport().
+ * @param focus        Either the tile index or vehicle ID to focus.
  * @param zoom         Zoom level.
  */
-void NWidgetViewport::InitializeViewport(Window *w, uint32_t follow_flags, ZoomLevel zoom)
+void NWidgetViewport::InitializeViewport(Window *w, std::variant<TileIndex, VehicleID> focus, ZoomLevel zoom)
 {
-	InitializeWindowViewport(w, this->pos_x, this->pos_y, this->current_x, this->current_y, follow_flags, zoom);
+	InitializeWindowViewport(w, this->pos_x, this->pos_y, this->current_x, this->current_y, focus, zoom);
 }
 
 /**

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -629,7 +629,7 @@ public:
 	void SetupSmallestSize(Window *w, bool init_array) override;
 	void Draw(const Window *w) override;
 
-	void InitializeViewport(Window *w, uint32_t follow_flags, ZoomLevel zoom);
+	void InitializeViewport(Window *w, std::variant<TileIndex, VehicleID> focus, ZoomLevel zoom);
 	void UpdateViewportCoordinates(Window *w);
 };
 


### PR DESCRIPTION
## Motivation / Problem

While working on #11190 I found that `InitializeViewport` used some weird tactics to support a Vehicle viewport and a Tile viewport. Let's modernize it a bit!


## Description

Use `std::variant` to know whether we want to see a Vehicle or a Tile. This works, as `TileIndex` is using `StrongTypeDef` and as such, is another type from `VehicleID` (which is just an integer).

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
