### PR TITLE
Codechange: be more type-specific about types in NPFs queue

### DIFF
--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1286,7 +1286,7 @@ static const uint RIVER_HASH_SIZE = 8; ///< The number of bits the hash for rive
  * @param dir The unused direction.
  * @return The hash for the tile.
  */
-static uint River_Hash(uint tile, uint dir)
+static uint River_Hash(TileIndex tile, Trackdir dir)
 {
 	return GB(TileHash(TileX(tile), TileY(tile)), 0, RIVER_HASH_SIZE);
 }

--- a/src/pathfinder/npf/npf.cpp
+++ b/src/pathfinder/npf/npf.cpp
@@ -132,20 +132,20 @@ static uint NPFDistanceTrack(TileIndex t0, TileIndex t1)
 
 /**
  * Calculates a hash value for use in the NPF.
- * @param key1 The TileIndex of the tile to hash
- * @param key2 The Trackdir of the track on the tile.
+ * @param tile The TileIndex of the tile to hash
+ * @param dir The Trackdir of the track on the tile.
  *
  * @todo Think of a better hash.
  */
-static uint NPFHash(uint key1, uint key2)
+static uint NPFHash(TileIndex tile, Trackdir dir)
 {
 	/* TODO: think of a better hash? */
-	uint part1 = TileX(key1) & NPF_HASH_HALFMASK;
-	uint part2 = TileY(key1) & NPF_HASH_HALFMASK;
+	uint part1 = TileX(tile) & NPF_HASH_HALFMASK;
+	uint part2 = TileY(tile) & NPF_HASH_HALFMASK;
 
-	assert(IsValidTrackdir((Trackdir)key2));
-	assert(IsValidTile((TileIndex)key1));
-	return ((part1 << NPF_HASH_HALFBITS | part2) + (NPF_HASH_SIZE * key2 / TRACKDIR_END)) % NPF_HASH_SIZE;
+	assert(IsValidTrackdir(dir));
+	assert(IsValidTile(tile));
+	return ((part1 << NPF_HASH_HALFBITS | part2) + (NPF_HASH_SIZE * dir / TRACKDIR_END)) % NPF_HASH_SIZE;
 }
 
 static int32_t NPFCalcZero(AyStar *as, AyStarNode *current, OpenListNode *parent)

--- a/src/pathfinder/npf/queue.cpp
+++ b/src/pathfinder/npf/queue.cpp
@@ -366,9 +366,9 @@ void Hash::Clear(bool free_values)
  * bucket, or nullptr if it is empty. prev can also be nullptr, in which case it is
  * not used for output.
  */
-HashNode *Hash::FindNode(uint key1, uint key2, HashNode** prev_out) const
+HashNode *Hash::FindNode(TileIndex tile, Trackdir dir, HashNode** prev_out) const
 {
-	uint hash = this->hash(key1, key2);
+	uint hash = this->hash(tile, dir);
 	HashNode *result = nullptr;
 
 	/* Check if the bucket is empty */
@@ -376,7 +376,7 @@ HashNode *Hash::FindNode(uint key1, uint key2, HashNode** prev_out) const
 		if (prev_out != nullptr) *prev_out = nullptr;
 		result = nullptr;
 	/* Check the first node specially */
-	} else if (this->buckets[hash].key1 == key1 && this->buckets[hash].key2 == key2) {
+	} else if (this->buckets[hash].tile == tile && this->buckets[hash].dir == dir) {
 		/* Save the value */
 		result = this->buckets + hash;
 		if (prev_out != nullptr) *prev_out = nullptr;
@@ -386,7 +386,7 @@ HashNode *Hash::FindNode(uint key1, uint key2, HashNode** prev_out) const
 		HashNode *node;
 
 		for (node = prev->next; node != nullptr; node = node->next) {
-			if (node->key1 == key1 && node->key2 == key2) {
+			if (node->tile == tile && node->dir == dir) {
 				/* Found it */
 				result = node;
 				break;
@@ -403,11 +403,11 @@ HashNode *Hash::FindNode(uint key1, uint key2, HashNode** prev_out) const
  * that value. Returns nullptr when the value was not present. The value returned
  * is _not_ free()'d!
  */
-void *Hash::DeleteValue(uint key1, uint key2)
+void *Hash::DeleteValue(TileIndex tile, Trackdir dir)
 {
 	void *result;
 	HashNode *prev; // Used as output var for below function call
-	HashNode *node = this->FindNode(key1, key2, &prev);
+	HashNode *node = this->FindNode(tile, dir, &prev);
 
 	if (node == nullptr) {
 		/* not found */
@@ -426,7 +426,7 @@ void *Hash::DeleteValue(uint key1, uint key2)
 		} else {
 			/* This was the last in this bucket
 			 * Mark it as empty */
-			uint hash = this->hash(key1, key2);
+			uint hash = this->hash(tile, dir);
 			this->buckets_in_use[hash] = false;
 		}
 	} else {
@@ -446,10 +446,10 @@ void *Hash::DeleteValue(uint key1, uint key2)
  * Sets the value associated with the given key pair to the given value.
  * Returns the old value if the value was replaced, nullptr when it was not yet present.
  */
-void *Hash::Set(uint key1, uint key2, void *value)
+void *Hash::Set(TileIndex tile, Trackdir dir, void *value)
 {
 	HashNode *prev;
-	HashNode *node = this->FindNode(key1, key2, &prev);
+	HashNode *node = this->FindNode(tile, dir, &prev);
 
 	if (node != nullptr) {
 		/* Found it */
@@ -461,7 +461,7 @@ void *Hash::Set(uint key1, uint key2, void *value)
 	/* It is not yet present, let's add it */
 	if (prev == nullptr) {
 		/* The bucket is still empty */
-		uint hash = this->hash(key1, key2);
+		uint hash = this->hash(tile, dir);
 		this->buckets_in_use[hash] = true;
 		node = this->buckets + hash;
 	} else {
@@ -470,8 +470,8 @@ void *Hash::Set(uint key1, uint key2, void *value)
 		prev->next = node;
 	}
 	node->next = nullptr;
-	node->key1 = key1;
-	node->key2 = key2;
+	node->tile = tile;
+	node->dir = dir;
 	node->value = value;
 	this->size++;
 	return nullptr;
@@ -481,9 +481,9 @@ void *Hash::Set(uint key1, uint key2, void *value)
  * Gets the value associated with the given key pair, or nullptr when it is not
  * present.
  */
-void *Hash::Get(uint key1, uint key2) const
+void *Hash::Get(TileIndex tile, Trackdir dir) const
 {
-	HashNode *node = this->FindNode(key1, key2, nullptr);
+	HashNode *node = this->FindNode(tile, dir, nullptr);
 
 	return (node != nullptr) ? node->value : nullptr;
 }

--- a/src/pathfinder/npf/queue.h
+++ b/src/pathfinder/npf/queue.h
@@ -10,6 +10,9 @@
 #ifndef QUEUE_H
 #define QUEUE_H
 
+#include "../../tile_type.h"
+#include "../../track_type.h"
+
 //#define HASH_STATS
 
 
@@ -58,8 +61,8 @@ struct BinaryHeap {
  * Hash
  */
 struct HashNode {
-	uint key1;
-	uint key2;
+	TileIndex tile;
+	Trackdir dir;
 	void *value;
 	HashNode *next;
 };
@@ -67,7 +70,7 @@ struct HashNode {
  * Generates a hash code from the given key pair. You should make sure that
  * the resulting range is clearly defined.
  */
-typedef uint Hash_HashProc(uint key1, uint key2);
+typedef uint Hash_HashProc(TileIndex tile, Trackdir dir);
 struct Hash {
 	/* The hash function used */
 	Hash_HashProc *hash;
@@ -83,10 +86,10 @@ struct Hash {
 
 	void Init(Hash_HashProc *hash, uint num_buckets);
 
-	void *Get(uint key1, uint key2) const;
-	void *Set(uint key1, uint key2, void *value);
+	void *Get(TileIndex tile, Trackdir dir) const;
+	void *Set(TileIndex tile, Trackdir dir, void *value);
 
-	void *DeleteValue(uint key1, uint key2);
+	void *DeleteValue(TileIndex tile, Trackdir dir);
 
 	void Clear(bool free_values);
 	void Delete(bool free_values);
@@ -103,7 +106,7 @@ protected:
 #ifdef HASH_STATS
 	void PrintStatistics() const;
 #endif
-	HashNode *FindNode(uint key1, uint key2, HashNode** prev_out) const;
+	HashNode *FindNode(TileIndex tile, Trackdir dir, HashNode** prev_out) const;
 };
 
 #endif /* QUEUE_H */


### PR DESCRIPTION
## Motivation / Problem

While working on #11190 the compiler (rightfully) complained a `TileIndex` was shoved in an `uint32_t`, and it didn't like that.

## Description

Turns out, all `key1` references are in fact always a `TileIndex`, and this is assumed in several places. So be more correct, and make it in fact a `TileIndex`. `key2` is always `Trackdir`. Also rename `key1` and `key2`, as .. weird names.

And just to be clear, this queue stuff in NPF is also used by rivers. Explaining the one change in `landscape.cpp`.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
