### PR TITLE
Fix: Max road speed is doubled in buy menu dropdowns

### DIFF
--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1835,7 +1835,7 @@ DropDownList GetRoadTypeDropDownList(RoadTramTypes rtts, bool for_replacement, b
 		const RoadTypeInfo *rti = GetRoadTypeInfo(rt);
 
 		SetDParam(0, rti->strings.menu_text);
-		SetDParam(1, rti->max_speed);
+		SetDParam(1, rti->max_speed / 2);
 		if (for_replacement) {
 			list.emplace_back(new DropDownListStringItem(rti->strings.replace_text, rt, !HasBit(avail_roadtypes, rt)));
 		} else {
@@ -1879,7 +1879,7 @@ DropDownList GetScenRoadTypeDropDownList(RoadTramTypes rtts)
 		const RoadTypeInfo *rti = GetRoadTypeInfo(rt);
 
 		SetDParam(0, rti->strings.menu_text);
-		SetDParam(1, rti->max_speed);
+		SetDParam(1, rti->max_speed / 2);
 		StringID str = rti->max_speed > 0 ? STR_TOOLBAR_RAILTYPE_VELOCITY : STR_JUST_STRING;
 		DropDownListIconItem *item = new DropDownListIconItem(rti->gui_sprites.build_x_road, PAL_NONE, str, rt, !HasBit(avail_roadtypes, rt));
 		item->SetDimension(d);


### PR DESCRIPTION
## Motivation / Problem

Solves a display bug: road speed is doubled in the dropdown buy menu.

![Double Road Speed in Dropdown](https://github.com/OpenTTD/OpenTTD/assets/53194907/c795d621-4f91-4159-b73a-7c26d0196781)

## Description

The issue was introduced with #11063.
Before that, the speed was halved in the parameter, not after #11063. Most probably a copy/paste error.
The formula was corrected.

## Limitations

Problem is solved in game as well as in the scenario editor.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)


* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
