### PR TITLE
Codechange: Use correct type for max timetable start years constant

### DIFF
--- a/src/timetable.h
+++ b/src/timetable.h
@@ -11,9 +11,10 @@
 #define TIMETABLE_H
 
 #include "date_type.h"
+#include "timer/timer_game_calendar.h"
 #include "vehicle_type.h"
 
-static const uint8_t MAX_TIMETABLE_START_YEARS = 15; ///< The maximum start date offset, in years.
+static const TimerGameCalendar::Year MAX_TIMETABLE_START_YEARS = 15; ///< The maximum start date offset, in years.
 
 void ShowTimetableWindow(const Vehicle *v);
 void UpdateVehicleTimetable(Vehicle *v, bool travelling);


### PR DESCRIPTION
## Motivation / Problem

`MAX_TIMETABLE_START_YEARS` is stored as a `uint8_t` when it should be a `TimerGameCalendar::Year`.

## Description

Change it.

It'll be an economy year soon, but that's a different PR. 😃 

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
