### PR TITLE
Codechange: Reorder some high-use structs to reduce their size.

### DIFF
--- a/src/cargopacket.cpp
+++ b/src/cargopacket.cpp
@@ -42,16 +42,16 @@ CargoPacket::CargoPacket()
  * that, in contrary to all other pools, does not memset to 0.
  */
 CargoPacket::CargoPacket(StationID source, TileIndex source_xy, uint16_t count, SourceType source_type, SourceID source_id) :
-	feeder_share(0),
 	count(count),
 	periods_in_transit(0),
+	feeder_share(0),
+	source_xy(source_xy),
+	loaded_at_xy(0),
 	source_id(source_id),
 	source(source),
-	source_xy(source_xy),
-	loaded_at_xy(0)
+	source_type(source_type)
 {
 	assert(count != 0);
-	this->source_type  = source_type;
 }
 
 /**
@@ -69,16 +69,16 @@ CargoPacket::CargoPacket(StationID source, TileIndex source_xy, uint16_t count, 
  * that, in contrary to all other pools, does not memset to 0.
  */
 CargoPacket::CargoPacket(uint16_t count, uint16_t periods_in_transit, StationID source, TileIndex source_xy, TileIndex loaded_at_xy, Money feeder_share, SourceType source_type, SourceID source_id) :
-		feeder_share(feeder_share),
 		count(count),
 		periods_in_transit(periods_in_transit),
+		feeder_share(feeder_share),
+		source_xy(source_xy),
+		loaded_at_xy(loaded_at_xy),
 		source_id(source_id),
 		source(source),
-		source_xy(source_xy),
-		loaded_at_xy(loaded_at_xy)
+		source_type(source_type)
 {
 	assert(count != 0);
-	this->source_type = source_type;
 }
 
 /**

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -46,17 +46,17 @@ static_assert(sizeof(TileIndex) == sizeof(StationID_32bit));
  */
 struct CargoPacket : CargoPacketPool::PoolItem<&_cargopacket_pool> {
 private:
-	Money feeder_share;     ///< Value of feeder pickup to be paid for on delivery of cargo.
 	uint16_t count;           ///< The amount of cargo in this packet.
 	uint16_t periods_in_transit; ///< Amount of cargo aging periods this packet has been in transit.
-	SourceType source_type; ///< Type of \c source_id.
-	SourceID source_id;     ///< Index of source, INVALID_SOURCE if unknown/invalid.
-	StationID source;       ///< The station where the cargo came from first.
+	Money feeder_share;     ///< Value of feeder pickup to be paid for on delivery of cargo.
 	TileIndex source_xy;    ///< The origin of the cargo (first station in feeder chain).
 	union {
 		TileIndex loaded_at_xy;       ///< Location where this cargo has been loaded into the vehicle.
 		StationID_32bit next_station; ///< Station where the cargo wants to go next.
 	};
+	SourceID source_id;     ///< Index of source, INVALID_SOURCE if unknown/invalid.
+	StationID source;       ///< The station where the cargo came from first.
+	SourceType source_type; ///< Type of \c source_id.
 
 	/** The CargoList caches, thus needs to know about it. */
 	template <class Tinst, class Tcont> friend class CargoList;

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -206,28 +206,23 @@ struct GoodsEntry {
 		GES_ACCEPTED_BIGTICK,
 	};
 
-	GoodsEntry() :
-		status(0),
-		time_since_pickup(255),
-		rating(INITIAL_STATION_RATING),
-		last_speed(0),
-		last_age(255),
-		amount_fract(0),
-		link_graph(INVALID_LINK_GRAPH),
-		node(INVALID_NODE),
-		max_waiting_cargo(0)
-	{}
+	StationCargoList cargo{}; ///< The cargo packets of cargo waiting in this station
+	FlowStatMap flows{}; ///< Planned flows through this station.
 
-	byte status; ///< Status of this cargo, see #GoodsEntryStatus.
+	uint max_waiting_cargo{0}; ///< Max cargo from this station waiting at any station.
+	NodeID node{INVALID_NODE}; ///< ID of node in link graph referring to this goods entry.
+	LinkGraphID link_graph{INVALID_LINK_GRAPH}; ///< Link graph this station belongs to.
+
+	byte status{0}; ///< Status of this cargo, see #GoodsEntryStatus.
 
 	/**
 	 * Number of rating-intervals (up to 255) since the last vehicle tried to load this cargo.
 	 * The unit used is STATION_RATING_TICKS.
 	 * This does not imply there was any cargo to load.
 	 */
-	byte time_since_pickup;
+	uint8_t time_since_pickup{255};
 
-	byte rating;            ///< %Station rating for this cargo.
+	uint8_t rating{INITIAL_STATION_RATING}; ///< %Station rating for this cargo.
 
 	/**
 	 * Maximum speed (up to 255) of the last vehicle that tried to load this cargo.
@@ -238,21 +233,15 @@ struct GoodsEntry {
 	 *  - Ships: 0.5 * km-ish/h
 	 *  - Aircraft: 8 * mph
 	 */
-	byte last_speed;
+	uint8_t last_speed{0};
 
 	/**
 	 * Age in years (up to 255) of the last vehicle that tried to load this cargo.
 	 * This does not imply there was any cargo to load.
 	 */
-	byte last_age;
+	uint8_t last_age{255};
 
-	byte amount_fract;      ///< Fractional part of the amount in the cargo list
-	StationCargoList cargo; ///< The cargo packets of cargo waiting in this station
-
-	LinkGraphID link_graph; ///< Link graph this station belongs to.
-	NodeID node;            ///< ID of node in link graph referring to this goods entry.
-	FlowStatMap flows;      ///< Planned flows through this station.
-	uint max_waiting_cargo; ///< Max cargo from this station waiting at any station.
+	uint8_t amount_fract{0}; ///< Fractional part of the amount in the cargo list
 
 	/**
 	 * Reports whether a vehicle has ever tried to load the cargo at this station.


### PR DESCRIPTION
## Motivation / Problem

Alignment of struct members can create gaps in structs, so that the memory required for each is larger than necessary.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Manually reorder some high use structs to reduce padding:

| Struct | Old size | New Size |
| ------- | --------- | ---------- |
| GoodsEntry | 144 | 136 |
| CargoPacket | 40 | 32 |

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
