### PR TITLE
Fix #11203: [ICU] Glyph to char mapping and visual run splitting with multiple runs

### DIFF
--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -206,7 +206,7 @@ void ICURun::Shape(UChar *buff, size_t buff_length) {
 			x_advance = glyph_pos[i].x_advance / FONT_SCALE;
 		}
 
-		this->glyph_to_char.push_back(glyph_info[i].cluster - this->start);
+		this->glyph_to_char.push_back(glyph_info[i].cluster);
 		this->advance.push_back(x_advance);
 		advance += x_advance;
 	}
@@ -465,7 +465,7 @@ std::unique_ptr<const ICUParagraphLayout::Line> ICUParagraphLayout::NextLine(int
 			/* There is no suitable line-break and this is the only run on the
 			 * line. So we break at the cluster. This is not pretty, but the
 			 * best we can do. */
-			new_partial_length = char_pos - this->partial_offset;
+			new_partial_length = char_pos - overflow_run->start - this->partial_offset;
 		}
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Fixes: #11203
See also: #10790

## Description

`new_partial_length` was calculated incorrectly in ICUParagraphLayout::NextLine when splitting a run.
Replaces: #10791

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
