### PR TITLE
Fix: [MacOS] screen looks blue-ish when using newer SDKs

### DIFF
--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -64,13 +64,6 @@
  * Read http://developer.apple.com/releasenotes/Cocoa/Objective-C++.html for more information.
  */
 
-/* On some old versions of MAC OS this may not be defined.
- * Those versions generally only produce code for PPC. So it should be safe to
- * set this to 0. */
-#ifndef kCGBitmapByteOrder32Host
-#define kCGBitmapByteOrder32Host 0
-#endif
-
 bool _cocoa_video_started = false;
 static Palette _local_palette; ///< Current palette to use for drawing.
 


### PR DESCRIPTION
## Motivation / Problem

As reported by #10251, accidentally I had the same issue on my local dev setup. So .. I went cracking to find out what was causing it. A lot of compiling and experiments later .....

What do you mean with blue-ish?

![image](https://github.com/OpenTTD/OpenTTD/assets/1663690/b48da5cc-0cb1-4eb9-8082-c8c26ee70b6c)

Nuff said? :D

## Description

The define `kCGBitmapByteOrder32Host` changed (around SDK 12?) into an enum, which means an old `#ifndef` was triggering, overwriting the value to 0. Sadly, 0 means Order16Big, causing RGBA to become GRAB, which results in strange colours.

As we no longer support PPC*, drop that piece of code completely.

(*) the last SDK with PPC support was (unofficially) 10.5 (officially it ended before that). Our Cocoa driver needs at least 10.7 for [at least 3 years now](https://github.com/OpenTTD/OpenTTD/commit/a61a7416836ec021f522720940265d2b67dedb08). In result, it hasn't been possible to use Cocoa driver on PPC for at least as long; I consider that, "no longer supported".

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
