### PR TITLE
Fix: [MSVC] generate static libraries / executables correctly with vcpkg -static target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,14 @@ set_target_properties(openttd PROPERTIES OUTPUT_NAME "${BINARY_NAME}")
 if(MSVC)
     # Add DPI manifest to project; other WIN32 targets get this via ottdres.rc
     target_sources(openttd PRIVATE "${CMAKE_SOURCE_DIR}/os/windows/openttd.manifest")
+
+    # If target -static is used, switch our project to static (/MT) too.
+    # If the target ends on -static-md, it will remain dynamic (/MD).
+    if(VCPKG_TARGET_TRIPLET MATCHES "-static" AND NOT VCPKG_TARGET_TRIPLET MATCHES "-md")
+        set_property(TARGET openttd_lib PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+        set_property(TARGET openttd PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+        set_property(TARGET openttd_test PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+     endif()
 endif()
 
 target_precompile_headers(openttd_lib

--- a/cmake/CompileFlags.cmake
+++ b/cmake/CompileFlags.cmake
@@ -4,23 +4,6 @@
 #
 macro(compile_flags)
     if(MSVC)
-        if(VCPKG_TARGET_TRIPLET MATCHES "-static" AND NOT VCPKG_TARGET_TRIPLET MATCHES "-md")
-            # Switch to MT (static) instead of MD (dynamic) binary
-
-            # For MSVC two generators are available
-            # - a command line generator (Ninja) using CMAKE_BUILD_TYPE to specify the
-            #   configuration of the build tree
-            # - an IDE generator (Visual Studio) using CMAKE_CONFIGURATION_TYPES to
-            #   specify all configurations that will be available in the generated solution
-            list(APPEND MSVC_CONFIGS "${CMAKE_BUILD_TYPE}" "${CMAKE_CONFIGURATION_TYPES}")
-
-            # Set usage of static runtime for all configurations
-            foreach(MSVC_CONFIG ${MSVC_CONFIGS})
-                string(TOUPPER "CMAKE_CXX_FLAGS_${MSVC_CONFIG}" MSVC_FLAGS)
-                string(REPLACE "/MD" "/MT" ${MSVC_FLAGS} "${${MSVC_FLAGS}}")
-            endforeach()
-        endif()
-
         # "If /Zc:rvalueCast is specified, the compiler follows section 5.4 of the
         # C++11 standard". We need C++11 for the way we use threads.
         add_compile_options(/Zc:rvalueCast)


### PR DESCRIPTION
## Motivation / Problem

When building for MSVC I was often warned that `/MDd` (dynamic) was overwriting `/MT` (static), which surprised me, as we should be `/MT`. Now this was never the problem with our current libraries, and things were linked in statically anyway, but when adding `breakpad` for testing, it became apparent that we were actually compiling `/MDd`. But with the vcpkg target `x64-windows-static` I expected `/MTd`.

## Description

Since CMake 3.15 (our minimum is 3.16) there is a CMake variable https://cmake.org/cmake/help/latest/prop_tgt/MSVC_RUNTIME_LIBRARY.html to indicate whether `/MD` or `/MT` should be used. Seems in more recent MSVC and CMake this is finally handled properly, and MSVC was happily compiling the binary dynamic.

By setting it correctly, the `/MTd` is correctly added instead of the `/MDd` (well, it is `-MTd` and `-MDd`, but who is counting). The best way to validate this is to make an error in a file, and check the `cl.exe` line.

In case you wonder if it is actually the intention to build static, please see https://github.com/OpenTTD/OpenTTD/blob/master/cmake/CompileFlags.cmake#L8 . We already tried .. but that no longer works for the latest CMake / MSVC combo.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
