### PR TITLE
Remove: last remnants of SunOS

### DIFF
--- a/src/os/unix/crashlog_unix.cpp
+++ b/src/os/unix/crashlog_unix.cpp
@@ -19,9 +19,6 @@
 #if defined(__GLIBC__)
 /* Execinfo (and thus making stacktraces) is a GNU extension */
 #	include <execinfo.h>
-#elif defined(SUNOS)
-#	include <ucontext.h>
-#	include <dlfcn.h>
 #endif
 
 #if defined(__NetBSD__)
@@ -70,38 +67,6 @@ class CrashLogUnix : public CrashLog {
 		);
 	}
 
-#if defined(SUNOS)
-	/** Data needed while walking up the stack */
-	struct StackWalkerParams {
-		std::back_insert_iterator<std::string> *output_iterator; ///< Buffer
-		int counter; ///< We are at counter-th stack level
-	};
-
-	/**
-	 * Callback used while walking up the stack.
-	 * @param pc program counter
-	 * @param sig 'active' signal (unused)
-	 * @param params parameters
-	 * @return always 0, continue walking up the stack
-	 */
-	static int SunOSStackWalker(uintptr_t pc, int sig, void *params)
-	{
-		StackWalkerParams *wp = (StackWalkerParams *)params;
-
-		/* Resolve program counter to file and nearest symbol (if possible) */
-		Dl_info dli;
-		if (dladdr((void *)pc, &dli) != 0) {
-			fmt::format_to(*wp->output_iterator, " [{:02}] {}({}+0x{:x}) [0x{:x}]\n",
-					wp->counter, dli.dli_fname, dli.dli_sname, (int)((byte *)pc - (byte *)dli.dli_saddr), (uint)pc);
-		} else {
-			fmt::format_to(*wp->output_iterator, " [{:02}] [0x{:x}]\n", wp->counter, (uint)pc);
-		}
-		wp->counter++;
-
-		return 0;
-	}
-#endif
-
 	void LogStacktrace(std::back_insert_iterator<std::string> &output_iterator) const override
 	{
 		fmt::format_to(output_iterator, "Stacktrace:\n");
@@ -114,15 +79,6 @@ class CrashLogUnix : public CrashLog {
 			fmt::format_to(output_iterator, " [{:02}] {}\n", i, messages[i]);
 		}
 		free(messages);
-#elif defined(SUNOS)
-		ucontext_t uc;
-		if (getcontext(&uc) != 0) {
-			fmt::format_to(output_iterator, " getcontext() failed\n\n");
-			return buffer;
-		}
-
-		StackWalkerParams wp = { &output_iterator, 0 };
-		walkcontext(&uc, &CrashLogUnix::SunOSStackWalker, &wp);
 #else
 		fmt::format_to(output_iterator, " Not supported.\n");
 #endif

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -42,14 +42,8 @@
  * does not have stdint.h.
  * For OSX the inclusion is already done in osx_stdafx.h. */
 #if !defined(__APPLE__) && (!defined(_MSC_VER) || _MSC_VER >= 1600)
-#	if defined(SUNOS)
-		/* SunOS/Solaris does not have stdint.h, but inttypes.h defines everything
-		 * stdint.h defines and we need. */
-#		include <inttypes.h>
-#	else
-#		define __STDC_LIMIT_MACROS
-#		include <stdint.h>
-#	endif
+#	define __STDC_LIMIT_MACROS
+#	include <stdint.h>
 #endif
 
 #include <algorithm>


### PR DESCRIPTION
## Motivation / Problem

We have no evidence SunOS has been tried in the last few years, and the code is awkward enough to just remove.

## Description

If someone strongly disagrees, feel free to revert this PR and show it actually still works and is used on SunOS. We are not against having code for SunOS around, but we do against untested code :)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
