### PR TITLE
Remove: [Win32] (pointer-only) stack trace in crash.log

### DIFF
--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -307,25 +307,7 @@ static void PrintModuleInfo(std::back_insert_iterator<std::string> &output_itera
 /* virtual */ void CrashLogWindows::LogStacktrace(std::back_insert_iterator<std::string> &output_iterator) const
 {
 	fmt::format_to(output_iterator, "Stack trace:\n");
-#ifdef _M_AMD64
-	uint32_t *b = (uint32_t*)ep->ContextRecord->Rsp;
-#elif defined(_M_IX86)
-	uint32_t *b = (uint32_t*)ep->ContextRecord->Esp;
-#elif defined(_M_ARM64)
-	uint32_t *b = (uint32_t*)ep->ContextRecord->Sp;
-#endif
-	for (int j = 0; j != 24; j++) {
-		for (int i = 0; i != 8; i++) {
-			if (IsBadReadPtr(b, sizeof(uint32_t))) {
-				fmt::format_to(output_iterator, " ????????"); // OCR: WAS - , 0);
-			} else {
-				fmt::format_to(output_iterator, " {:08X}", *b);
-			}
-			b++;
-		}
-		fmt::format_to(output_iterator, "\n");
-	}
-	fmt::format_to(output_iterator, "\n");
+	fmt::format_to(output_iterator, " Not supported.\n");
 }
 
 #if defined(_MSC_VER)


### PR DESCRIPTION


## Motivation / Problem

MingW stack trace only contains pointers, which nobody can decipher anyway. 

## Description

So instead, just report "Not supported", like other targets do when they can't print a sane stack trace.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
