### PR TITLE
Remove: [Win32] register values in crash.log

### DIFF
--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -99,11 +99,6 @@ void CrashLog::LogCompiler(std::back_insert_iterator<std::string> &output_iterat
 #endif
 }
 
-/* virtual */ void CrashLog::LogRegisters(std::back_insert_iterator<std::string> &output_iterator) const
-{
-	/* Stub implementation; not all OSes support this. */
-}
-
 /* virtual */ void CrashLog::LogModules(std::back_insert_iterator<std::string> &output_iterator) const
 {
 	/* Stub implementation; not all OSes support this. */
@@ -343,7 +338,6 @@ void CrashLog::FillCrashLog(std::back_insert_iterator<std::string> &output_itera
 
 	this->LogError(output_iterator, CrashLog::message);
 	this->LogOpenTTDVersion(output_iterator);
-	this->LogRegisters(output_iterator);
 	this->LogStacktrace(output_iterator);
 	this->LogOSVersion(output_iterator);
 	this->LogCompiler(output_iterator);

--- a/src/crashlog.h
+++ b/src/crashlog.h
@@ -45,13 +45,6 @@ protected:
 	virtual void LogStacktrace(std::back_insert_iterator<std::string> &output_iterator) const = 0;
 
 	/**
-	 * Writes information about the data in the registers, if there is
-	 * information about it available.
-	 * @param output_iterator Iterator to write the output to.
-	 */
-	virtual void LogRegisters(std::back_insert_iterator<std::string> &output_iterator) const;
-
-	/**
 	 * Writes the dynamically linked libraries/modules to the buffer, if there
 	 * is information about it available.
 	 * @param output_iterator Iterator to write the output to.

--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -35,7 +35,6 @@ class CrashLogWindows : public CrashLog {
 	void LogOSVersion(std::back_insert_iterator<std::string> &output_iterator) const override;
 	void LogError(std::back_insert_iterator<std::string> &output_iterator, const std::string_view message) const override;
 	void LogStacktrace(std::back_insert_iterator<std::string> &output_iterator) const override;
-	void LogRegisters(std::back_insert_iterator<std::string> &output_iterator) const override;
 	void LogModules(std::back_insert_iterator<std::string> &output_iterator) const override;
 public:
 #if defined(_MSC_VER)
@@ -194,114 +193,6 @@ static void PrintModuleInfo(std::back_insert_iterator<std::string> &output_itera
 	}
 	PrintModuleInfo(output_iterator, nullptr);
 	fmt::format_to(output_iterator, "\n");
-}
-
-/* virtual */ void CrashLogWindows::LogRegisters(std::back_insert_iterator<std::string> &output_iterator) const
-{
-	fmt::format_to(output_iterator, "Registers:\n");
-#ifdef _M_AMD64
-	fmt::format_to(output_iterator,
-		" RAX: {:016X} RBX: {:016X} RCX: {:016X} RDX: {:016X}\n"
-		" RSI: {:016X} RDI: {:016X} RBP: {:016X} RSP: {:016X}\n"
-		" R8:  {:016X} R9:  {:016X} R10: {:016X} R11: {:016X}\n"
-		" R12: {:016X} R13: {:016X} R14: {:016X} R15: {:016X}\n"
-		" RIP: {:016X} EFLAGS: {:08X}\n",
-		ep->ContextRecord->Rax,
-		ep->ContextRecord->Rbx,
-		ep->ContextRecord->Rcx,
-		ep->ContextRecord->Rdx,
-		ep->ContextRecord->Rsi,
-		ep->ContextRecord->Rdi,
-		ep->ContextRecord->Rbp,
-		ep->ContextRecord->Rsp,
-		ep->ContextRecord->R8,
-		ep->ContextRecord->R9,
-		ep->ContextRecord->R10,
-		ep->ContextRecord->R11,
-		ep->ContextRecord->R12,
-		ep->ContextRecord->R13,
-		ep->ContextRecord->R14,
-		ep->ContextRecord->R15,
-		ep->ContextRecord->Rip,
-		ep->ContextRecord->EFlags
-	);
-#elif defined(_M_IX86)
-	fmt::format_to(output_iterator,
-		" EAX: {:08X} EBX: {:08X} ECX: {:08X} EDX: {:08X}\n"
-		" ESI: {:08X} EDI: {:08X} EBP: {:08X} ESP: {:08X}\n"
-		" EIP: {:08X} EFLAGS: {:08X}\n",
-		(int)ep->ContextRecord->Eax,
-		(int)ep->ContextRecord->Ebx,
-		(int)ep->ContextRecord->Ecx,
-		(int)ep->ContextRecord->Edx,
-		(int)ep->ContextRecord->Esi,
-		(int)ep->ContextRecord->Edi,
-		(int)ep->ContextRecord->Ebp,
-		(int)ep->ContextRecord->Esp,
-		(int)ep->ContextRecord->Eip,
-		(int)ep->ContextRecord->EFlags
-	);
-#elif defined(_M_ARM64)
-	fmt::format_to(output_iterator,
-		" X0:  {:016X} X1:  {:016X} X2:  {:016X} X3:  {:016X}\n"
-		" X4:  {:016X} X5:  {:016X} X6:  {:016X} X7:  {:016X}\n"
-		" X8:  {:016X} X9:  {:016X} X10: {:016X} X11: {:016X}\n"
-		" X12: {:016X} X13: {:016X} X14: {:016X} X15: {:016X}\n"
-		" X16: {:016X} X17: {:016X} X18: {:016X} X19: {:016X}\n"
-		" X20: {:016X} X21: {:016X} X22: {:016X} X23: {:016X}\n"
-		" X24: {:016X} X25: {:016X} X26: {:016X} X27: {:016X}\n"
-		" X28: {:016X} Fp:  {:016X} Lr:  {:016X}\n",
-		ep->ContextRecord->X0,
-		ep->ContextRecord->X1,
-		ep->ContextRecord->X2,
-		ep->ContextRecord->X3,
-		ep->ContextRecord->X4,
-		ep->ContextRecord->X5,
-		ep->ContextRecord->X6,
-		ep->ContextRecord->X7,
-		ep->ContextRecord->X8,
-		ep->ContextRecord->X9,
-		ep->ContextRecord->X10,
-		ep->ContextRecord->X11,
-		ep->ContextRecord->X12,
-		ep->ContextRecord->X13,
-		ep->ContextRecord->X14,
-		ep->ContextRecord->X15,
-		ep->ContextRecord->X16,
-		ep->ContextRecord->X17,
-		ep->ContextRecord->X18,
-		ep->ContextRecord->X19,
-		ep->ContextRecord->X20,
-		ep->ContextRecord->X21,
-		ep->ContextRecord->X22,
-		ep->ContextRecord->X23,
-		ep->ContextRecord->X24,
-		ep->ContextRecord->X25,
-		ep->ContextRecord->X26,
-		ep->ContextRecord->X27,
-		ep->ContextRecord->X28,
-		ep->ContextRecord->Fp,
-		ep->ContextRecord->Lr
-	);
-#endif
-
-	fmt::format_to(output_iterator, "\n Bytes at instruction pointer:\n");
-#ifdef _M_AMD64
-	byte *b = (byte*)ep->ContextRecord->Rip;
-#elif defined(_M_IX86)
-	byte *b = (byte*)ep->ContextRecord->Eip;
-#elif defined(_M_ARM64)
-	byte *b = (byte*)ep->ContextRecord->Pc;
-#endif
-	for (int i = 0; i != 24; i++) {
-		if (IsBadReadPtr(b, 1)) {
-			fmt::format_to(output_iterator, " ??"); // OCR: WAS: , 0);
-		} else {
-			fmt::format_to(output_iterator, " {:02X}", *b);
-		}
-		b++;
-	}
-	fmt::format_to(output_iterator, "\n\n");
 }
 
 /* virtual */ void CrashLogWindows::LogStacktrace(std::back_insert_iterator<std::string> &output_iterator) const


### PR DESCRIPTION
## Motivation / Problem

On crash, Windows prints out the current register values in the crash.log. This on its own doesn't really mean anything, and is also stored in the crash.dmp that comes with the log. Here it is easier to delve into the "why did it crash".

To unify how the crash.log looks between OSes, I had a choice: add registers to the other OSes, or remove it from Windows. But as the amount of value these registers add to debugging problems is so low, and a crash.dmp also contains all this, removing it is the easier way.

## Description

Removal of the register values.

This is part of my attempt to make crash.log and crash.dmp more useful and unified over all platforms.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
