### PR TITLE
Fix: Road stops should not draw a ground sprite of 0

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3174,8 +3174,10 @@ draw_default_foundation:
 			SpriteID image = t->ground.sprite;
 			PaletteID pal  = t->ground.pal;
 			image += HasBit(image, SPRITE_MODIFIER_CUSTOM_SPRITE) ? ground_relocation : total_offset;
-			if (HasBit(pal, SPRITE_MODIFIER_CUSTOM_SPRITE)) pal += ground_relocation;
-			DrawGroundSprite(image, GroundSpritePaletteTransform(image, pal, palette));
+			if (GB(image, 0, SPRITE_WIDTH) != 0) {
+				if (HasBit(pal, SPRITE_MODIFIER_CUSTOM_SPRITE)) pal += ground_relocation;
+				DrawGroundSprite(image, GroundSpritePaletteTransform(image, pal, palette));
+			}
 		}
 
 		if (IsDriveThroughStopTile(ti->tile)) {


### PR DESCRIPTION
## Motivation / Problem

According to [The Specification](https://newgrf-specs.tt-wiki.net/wiki/Action2/Sprite_Layout#Sprite_definition_for_ground_and_building_sprites), setting the ground sprite to 0 should result in no sprite being drawn.

## Description

If the road stop's ground sprite is 0, do not draw it on the map.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
