### PR TITLE
Remove: [Win32] module-list from crash.log

### DIFF
--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -99,11 +99,6 @@ void CrashLog::LogCompiler(std::back_insert_iterator<std::string> &output_iterat
 #endif
 }
 
-/* virtual */ void CrashLog::LogModules(std::back_insert_iterator<std::string> &output_iterator) const
-{
-	/* Stub implementation; not all OSes support this. */
-}
-
 /**
  * Writes OpenTTD's version to the buffer.
  * @param output_iterator Iterator to write the output to.
@@ -343,7 +338,6 @@ void CrashLog::FillCrashLog(std::back_insert_iterator<std::string> &output_itera
 	this->LogCompiler(output_iterator);
 	this->LogConfiguration(output_iterator);
 	this->LogLibraries(output_iterator);
-	this->LogModules(output_iterator);
 	this->LogGamelog(output_iterator);
 	this->LogRecentNews(output_iterator);
 

--- a/src/crashlog.h
+++ b/src/crashlog.h
@@ -44,14 +44,6 @@ protected:
 	 */
 	virtual void LogStacktrace(std::back_insert_iterator<std::string> &output_iterator) const = 0;
 
-	/**
-	 * Writes the dynamically linked libraries/modules to the buffer, if there
-	 * is information about it available.
-	 * @param output_iterator Iterator to write the output to.
-	 */
-	virtual void LogModules(std::back_insert_iterator<std::string> &output_iterator) const;
-
-
 	void LogOpenTTDVersion(std::back_insert_iterator<std::string> &output_iterator) const;
 	void LogConfiguration(std::back_insert_iterator<std::string> &output_iterator) const;
 	void LogLibraries(std::back_insert_iterator<std::string> &output_iterator) const;


### PR DESCRIPTION
## Motivation / Problem

Only Windows implemented this, and it opens the files to read them to get a CRC. Doing this in a crash-handler is strange at best.

Lastly, nobody has actually ever used this information to come to some sort of conclusion. The module-list is used in combination with the crash.dmp, but this information is already embedded in there.

## Description

Remove the module-list from the crash.log.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
