### PR TITLE
Fix #11181: attempting to read string as int triggers assertion

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -196,8 +196,11 @@ bool HaveDParamChanged(const std::vector<StringParameterBackup> &backup)
 {
 	bool changed = false;
 	for (size_t i = 0; !changed && i < backup.size(); i++) {
-		if (backup[i].string.has_value()) {
-			changed = backup[i].string.value() != (const char *)(size_t)_global_string_params.GetParam(i);
+		bool global_has_string = _global_string_params.GetParamStr(i) != nullptr;
+		if (global_has_string != backup[i].string.has_value()) return true;
+
+		if (global_has_string) {
+			changed = backup[i].string.value() != _global_string_params.GetParamStr(i);
 		} else {
 			changed = backup[i].data != _global_string_params.GetParam(i);
 		}

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -2,5 +2,6 @@ add_test_files(
     landscape_partial_pixel_z.cpp
     math_func.cpp
     string_func.cpp
+    strings_func.cpp
     test_main.cpp
 )

--- a/src/tests/strings_func.cpp
+++ b/src/tests/strings_func.cpp
@@ -1,0 +1,52 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file strings_func.cpp Test functionality from strings_func. */
+
+#include "../stdafx.h"
+
+#include "../3rdparty/catch2/catch.hpp"
+
+#include "../strings_func.h"
+
+TEST_CASE("HaveDParamChanged")
+{
+	SetDParam(0, 0);
+	SetDParamStr(1, "some string");
+
+	std::vector<StringParameterBackup> backup;
+	CopyOutDParam(backup, 2);
+
+	CHECK(HaveDParamChanged(backup) == false);
+
+	/* A different parameter 0 (both string and numeric). */
+	SetDParam(0, 1);
+	CHECK(HaveDParamChanged(backup) == true);
+
+	SetDParamStr(0, "some other string");
+	CHECK(HaveDParamChanged(backup) == true);
+
+	/* Back to the original state, nothing should have changed. */
+	SetDParam(0, 0);
+	CHECK(HaveDParamChanged(backup) == false);
+
+	/* A different parameter 1 (both string and numeric). */
+	SetDParamStr(1, "some other string");
+	CHECK(HaveDParamChanged(backup) == true);
+
+	SetDParam(1, 0);
+	CHECK(HaveDParamChanged(backup) == true);
+
+	/* Back to the original state, nothing should have changed. */
+	SetDParamStr(1, "some string");
+	CHECK(HaveDParamChanged(backup) == false);
+
+	/* Changing paramter 2 should not have any effect, as the backup is only 2 long. */
+	SetDParam(2, 3);
+	CHECK(HaveDParamChanged(backup) == false);
+
+}


### PR DESCRIPTION
## Motivation / Problem

Fixing #11181.


## Description

The validation of `GetParam` is quite pedantic in that it asserts that the parameter is not a string. This breaks `HaveDParamChanged` when the type of the parameter changes.
Now it first checks whether there is a difference in "string" type, and if that's the case it bails out saying that it has changed.

Added a simple unit test because it's hard to test this code in the game, as you need to reliably trigger some string to be put onto the global buffer just before the text effect gets updated. Since this has been the first report I have heard of crashing the game, it's quite unlikely that it happens.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
