### PR TITLE
Codechange: Invalid depot value is unrelated to invalid station value.

### DIFF
--- a/src/depot_type.h
+++ b/src/depot_type.h
@@ -10,12 +10,10 @@
 #ifndef DEPOT_TYPE_H
 #define DEPOT_TYPE_H
 
-#include "station_type.h"
-
 typedef uint16_t DepotID; ///< Type for the unique identifier of depots.
 struct Depot;
 
-static const DepotID INVALID_DEPOT = (DepotID)INVALID_STATION;
+static const DepotID INVALID_DEPOT = UINT16_MAX;
 
 static const uint MAX_LENGTH_DEPOT_NAME_CHARS = 32; ///< The maximum length of a depot name in characters including '\0'
 


### PR DESCRIPTION
## Motivation / Problem
Depot indexes and Station indexes are unrelated although both of them are represented with UINT16 (and UINT16_MAX being used as the invalid value for both of them).
