### PR TITLE
Doc: Improve the example given for fall throughs.

### DIFF
--- a/CODINGSTYLE.md
+++ b/CODINGSTYLE.md
@@ -180,7 +180,7 @@ switch (a) {
 
 	case 1:
 		DoSomething();
-		/* FALL THROUGH */
+		FALLTHROUGH;
 
 	case 2:
 		DoMore();
@@ -191,7 +191,7 @@ switch (a) {
 		int r = 2;
 
 		DoEvenMore(a);
-		/* FALL THROUGH */
+		FALLTHROUGH;
 	}
 
 	case 4: {


### PR DESCRIPTION
## Motivation / Problem

In CODYNGSTYLE.md it states that "All fall throughs must be documented, using a FALLTHROUGH define/macro", but in the code provided they are missing.

## Description

Add `FALLTHROUGH;` in the given code and remove the unnecessary comments.