### PR TITLE
Fix #9642: Keep infrastructure totals when overbuilding road depots.

### DIFF
--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1195,12 +1195,12 @@ CommandCost CmdBuildRoadDepot(DoCommandFlag flags, TileIndex tile, RoadType rt, 
 			dep->build_date = TimerGameCalendar::date;
 			MakeRoadDepot(tile, _current_company, dep->index, dir, rt);
 			MakeDefaultName(dep);
+
+			/* A road depot has two road bits. */
+			UpdateCompanyRoadInfrastructure(rt, _current_company, ROAD_DEPOT_TRACKBIT_FACTOR);
 		}
 
 		MarkTileDirtyByTile(tile);
-
-		/* A road depot has two road bits. */
-		UpdateCompanyRoadInfrastructure(rt, _current_company, ROAD_DEPOT_TRACKBIT_FACTOR);
 	}
 
 	cost.AddCost(_price[PR_BUILD_DEPOT_ROAD]);


### PR DESCRIPTION
## Motivation / Problem

If you overbuild a road depot, the company road infrastructure details are wrong, as each time you overbuild it, 2 more trackbits are added to the company totals.

As after loading a game those stats are recomputed, the problem didn't arise sooner and old savegames don't need to be modified to fix the bug. 

## Description

This PR fixes the incorrect behaviour: overbuilding a road depot doesn't add or remove to company road infrastructure totals.

## Limitations

None?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
