### PR TITLE
Codechange: [MacOS] use backtrace() instead of our custom variant

### DIFF
--- a/src/os/macosx/crashlog_osx.cpp
+++ b/src/os/macosx/crashlog_osx.cpp
@@ -20,6 +20,7 @@
 #include <mach-o/arch.h>
 #include <dlfcn.h>
 #include <cxxabi.h>
+#include <execinfo.h>
 
 #ifdef WITH_UNOFFICIAL_BREAKPAD
 #	include <client/mac/handler/exception_handler.h>
@@ -79,67 +80,16 @@ class CrashLogOSX : public CrashLog {
 
 	void LogStacktrace(std::back_insert_iterator<std::string> &output_iterator) const override
 	{
-		/* As backtrace() is only implemented in 10.5 or later,
-		 * we're rolling our own here. Mostly based on
-		 * http://stackoverflow.com/questions/289820/getting-the-current-stack-trace-on-mac-os-x
-		 * and some details looked up in the Darwin sources. */
 		fmt::format_to(output_iterator, "\nStacktrace:\n");
 
-		void **frame;
-#if defined(__ppc__) || defined(__ppc64__)
-		/* Apple says __builtin_frame_address can be broken on PPC. */
-		__asm__ volatile("mr %0, r1" : "=r" (frame));
-#else
-		frame = (void **)__builtin_frame_address(0);
-#endif
+		void *trace[64];
+		int trace_size = backtrace(trace, lengthof(trace));
 
-		for (int i = 0; frame != nullptr && i < MAX_STACK_FRAMES; i++) {
-			/* Get IP for current stack frame. */
-#if defined(__ppc__) || defined(__ppc64__)
-			void *ip = frame[2];
-#else
-			void *ip = frame[1];
-#endif
-			if (ip == nullptr) break;
-
-			/* Print running index. */
-			fmt::format_to(output_iterator, " [{:02}]", i);
-
-			Dl_info dli;
-			bool dl_valid = dladdr(ip, &dli) != 0;
-
-			const char *fname = "???";
-			if (dl_valid && dli.dli_fname) {
-				/* Valid image name? Extract filename from the complete path. */
-				const char *s = strrchr(dli.dli_fname, '/');
-				if (s != nullptr) {
-					fname = s + 1;
-				} else {
-					fname = dli.dli_fname;
-				}
-			}
-			/* Print image name and IP. */
-			fmt::format_to(output_iterator, " {:20s} {}", fname, (uintptr_t)ip);
-
-			/* Print function offset if information is available. */
-			if (dl_valid && dli.dli_sname != nullptr && dli.dli_saddr != nullptr) {
-				/* Try to demangle a possible C++ symbol. */
-				int status = -1;
-				char *func_name = abi::__cxa_demangle(dli.dli_sname, nullptr, 0, &status);
-
-				long int offset = (intptr_t)ip - (intptr_t)dli.dli_saddr;
-				fmt::format_to(output_iterator, " ({} + {})", func_name != nullptr ? func_name : dli.dli_sname, offset);
-
-				free(func_name);
-			}
-			fmt::format_to(output_iterator, "\n");
-
-			/* Get address of next stack frame. */
-			void **next = (void **)frame[0];
-			/* Frame address not increasing or not aligned? Broken stack, exit! */
-			if (next <= frame || !IS_ALIGNED(next)) break;
-			frame = next;
+		char **messages = backtrace_symbols(trace, trace_size);
+		for (int i = 0; i < trace_size; i++) {
+			fmt::format_to(output_iterator, "{}\n", messages[i]);
 		}
+		free(messages);
 
 		fmt::format_to(output_iterator, "\n");
 	}


### PR DESCRIPTION
## Motivation / Problem

As mentioned in the comment, we only did it ourselves as we once were compatible with versions before 10.5. But that time has long gone. So let's update the code to a bit more modern approach.

## Description

Remove custom backtrace code, and reuse the exact same code as Linux has been using.

## Limitations

The output is slightly different, but not in a way that should be any problem to any reader.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
