### PR TITLE
Add: calendar date for Survey results

### DIFF
--- a/src/network/network_survey.cpp
+++ b/src/network/network_survey.cpp
@@ -249,6 +249,21 @@ static void SurveyCompanies(nlohmann::json &survey)
 }
 
 /**
+ * Convert timer information to JSON.
+ *
+ * @param survey The JSON object.
+ */
+static void SurveyTimers(nlohmann::json &survey)
+{
+	survey["ticks"] = TimerGameTick::counter;
+	survey["seconds"] = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - _switch_mode_time).count();
+
+	TimerGameCalendar::YearMonthDay ymd;
+	TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date, &ymd);
+	survey["calendar"] = fmt::format("{:04}-{:02}-{:02} ({})", ymd.year, ymd.month + 1, ymd.day, TimerGameCalendar::date_fract);
+}
+
+/**
  * Convert GRF information to JSON.
  *
  * @param survey The JSON object.
@@ -356,8 +371,7 @@ std::string NetworkSurveyHandler::CreatePayload(Reason reason, bool for_preview)
 
 	{
 		auto &game = survey["game"];
-		game["ticks"] = TimerGameTick::counter;
-		game["time"] = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - _switch_mode_time).count();
+		SurveyTimers(game["timers"]);
 		SurveyCompanies(game["companies"]);
 		SurveySettings(game["settings"]);
 		SurveyGrfs(game["grfs"]);


### PR DESCRIPTION
## Motivation / Problem

This means no heuristics is possible on around which date people play the game.

This came up while working on #11232, where the crashlog does contain this information. Which made me realise we were missing out in the survey results.

## Description

While at it, also refactored how we store the timers a bit. A bit more reusable now.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
