### PR TITLE
Change: make nlohmann a mandatory library to build OpenTTD

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -77,20 +77,20 @@ jobs:
         - name: Clang
           compiler: clang
           cxxcompiler: clang++
-          libraries: libsdl2-dev nlohmann-json3-dev
+          libraries: libsdl2-dev
         - name: GCC - SDL2
           compiler: gcc
           cxxcompiler: g++
-          libraries: libsdl2-dev nlohmann-json3-dev
+          libraries: libsdl2-dev
         - name: GCC - SDL1.2
           compiler: gcc
           cxxcompiler: g++
-          libraries: libsdl1.2-dev nlohmann-json3-dev
+          libraries: libsdl1.2-dev
         - name: GCC - Dedicated
           compiler: gcc
           cxxcompiler: g++
           extra-cmake-parameters: -DOPTION_DEDICATED=ON -DCMAKE_CXX_FLAGS_INIT="-DRANDOM_DEBUG" -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
-          # Compile without SDL / SDL2 / nlohmann-json, as that should compile fine too.
+          # Compile without SDL / SDL2, as that should compile fine too.
 
     name: Linux (${{ matrix.name }})
 
@@ -118,6 +118,7 @@ jobs:
           libicu-dev \
           liblzma-dev \
           liblzo2-dev \
+          nlohmann-json3-dev \
           ${{ matrix.libraries }} \
           zlib1g-dev \
           # EOF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,12 +119,13 @@ endif()
 set(CMAKE_THREAD_PREFER_PTHREAD YES)
 # Make sure we have Threads available.
 find_package(Threads REQUIRED)
+# nlohmann is used for all our JSON needs.
+find_package(nlohmann_json REQUIRED)
 
 find_package(ZLIB)
 find_package(LibLZMA)
 find_package(LZO)
 find_package(PNG)
-find_package(nlohmann_json)
 
 if(WIN32 OR EMSCRIPTEN)
     # Windows uses WinHttp for HTTP requests.
@@ -309,7 +310,7 @@ link_package(PNG TARGET PNG::PNG ENCOURAGED)
 link_package(ZLIB TARGET ZLIB::ZLIB ENCOURAGED)
 link_package(LIBLZMA TARGET LibLZMA::LibLZMA ENCOURAGED)
 link_package(LZO)
-link_package(nlohmann_json ENCOURAGED)
+link_package(nlohmann_json)
 
 if(NOT WIN32 AND NOT EMSCRIPTEN)
     link_package(CURL ENCOURAGED)

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -4,7 +4,7 @@
 
 OpenTTD makes use of the following external libraries:
 
-- (encouraged) nlohmann-json: JSON handling
+- (required) nlohmann-json: JSON handling
 - (encouraged) breakpad: creates minidumps on crash
 - (encouraged) zlib: (de)compressing of old (0.3.0-1.0.5) savegames, content downloads,
    heightmaps

--- a/src/network/network_survey.cpp
+++ b/src/network/network_survey.cpp
@@ -31,17 +31,13 @@
 #include "../base_media_base.h"
 #include "../blitter/factory.hpp"
 
-#ifdef WITH_NLOHMANN_JSON
 #include <nlohmann/json.hpp>
-#endif /* WITH_NLOHMANN_JSON */
 
 #include "../safeguards.h"
 
 extern std::string _savegame_id;
 
 NetworkSurveyHandler _survey = {};
-
-#ifdef WITH_NLOHMANN_JSON
 
 NLOHMANN_JSON_SERIALIZE_ENUM(NetworkSurveyHandler::Reason, {
 	{NetworkSurveyHandler::Reason::PREVIEW, "preview"},
@@ -319,8 +315,6 @@ std::string SurveyMemoryToText(uint64_t memory)
 	return fmt::format("{} MiB", Ceil(memory, 4));
 }
 
-#endif /* WITH_NLOHMANN_JSON */
-
 /**
  * Create the payload for the survey.
  *
@@ -330,9 +324,6 @@ std::string SurveyMemoryToText(uint64_t memory)
  */
 std::string NetworkSurveyHandler::CreatePayload(Reason reason, bool for_preview)
 {
-#ifndef WITH_NLOHMANN_JSON
-	return "";
-#else
 	nlohmann::json survey;
 
 	survey["schema"] = NETWORK_SURVEY_VERSION;
@@ -367,7 +358,6 @@ std::string NetworkSurveyHandler::CreatePayload(Reason reason, bool for_preview)
 	/* For preview, we indent with 4 whitespaces to make things more readable. */
 	int indent = for_preview ? 4 : -1;
 	return survey.dump(indent);
-#endif /* WITH_NLOHMANN_JSON */
 }
 
 /**

--- a/src/network/network_survey.h
+++ b/src/network/network_survey.h
@@ -36,12 +36,7 @@ public:
 
 	constexpr static bool IsSurveyPossible()
 	{
-#ifndef WITH_NLOHMANN_JSON
-		/* Without JSON library, we cannot send a payload; so we disable the survey. */
-		return false;
-#else
 		return true;
-#endif /* WITH_NLOHMANN_JSON */
 	}
 
 private:

--- a/src/os/macosx/survey_osx.cpp
+++ b/src/os/macosx/survey_osx.cpp
@@ -7,8 +7,6 @@
 
 /** @file survey_osx.cpp OSX implementation of OS-specific survey information. */
 
-#ifdef WITH_NLOHMANN_JSON
-
 #include "../../stdafx.h"
 
 #include "../../3rdparty/fmt/format.h"
@@ -38,5 +36,3 @@ void SurveyOS(nlohmann::json &json)
 	json["memory"] = SurveyMemoryToText(MacOSGetPhysicalMemory());
 	json["hardware_concurrency"] = std::thread::hardware_concurrency();
 }
-
-#endif /* WITH_NLOHMANN_JSON */

--- a/src/os/unix/survey_unix.cpp
+++ b/src/os/unix/survey_unix.cpp
@@ -7,8 +7,6 @@
 
 /** @file survey_unix.cpp Unix implementation of OS-specific survey information. */
 
-#ifdef WITH_NLOHMANN_JSON
-
 #include "../../stdafx.h"
 
 #include <nlohmann/json.hpp>
@@ -38,5 +36,3 @@ void SurveyOS(nlohmann::json &json)
 	json["memory"] = SurveyMemoryToText(pages * page_size);
 	json["hardware_concurrency"] = std::thread::hardware_concurrency();
 }
-
-#endif /* WITH_NLOHMANN_JSON */

--- a/src/os/windows/survey_win.cpp
+++ b/src/os/windows/survey_win.cpp
@@ -7,8 +7,6 @@
 
 /** @file survey_win.cpp Windows implementation of OS-specific survey information. */
 
-#ifdef WITH_NLOHMANN_JSON
-
 #include "../../stdafx.h"
 
 #include "../../3rdparty/fmt/format.h"
@@ -37,5 +35,3 @@ void SurveyOS(nlohmann::json &json)
 	json["memory"] = SurveyMemoryToText(status.ullTotalPhys);
 	json["hardware_concurrency"] = std::thread::hardware_concurrency();
 }
-
-#endif /* WITH_NLOHMANN_JSON */


### PR DESCRIPTION
## Motivation / Problem

In several places we currently have a custom JSON dumper (like in the admin-protocol); we intent to replace this with nlohmann. To make that possible, we need to make the library mandatory, instead of encouraged.

Given all OSes have a good way to install the library (it is in Debian, most other Linux distros, and vcpkg), there shouldn't be a real problem with having it mandatory. And in return we can more easily make use of JSON for all our (internal) wishes.

## Description

This has been talk ever since we added the library: should it be optional. With the current use, that was pretty simple. But looking over other places we roll our custom JSON dumper, that no longer will be the case. 

Take for example this part of our code:
https://github.com/OpenTTD/OpenTTD/blob/f2841e62d91f5d207ff34e765f5466a65e3896d3/src/script/api/script_event_types.cpp#L146

It deal with reading a JSON string from the admin port. This really should just be replaced with nlohmann.

Additionally, there is a PR pending to load a JSON file next to a heightmap for additional information, like placement of towns. 

## Limitations

Although this PR doesn't show the need for making it mandatory, a follow-up PR will. And to keep discussions separated, I went this route. I have no issues with waiting for that follow-up PR (like #11232) to show it is now mandatory.

Additionally, one can always argue that it is not required to make such library mandatory; the game in its essence will work fine without it (in contrast to things like SDL). For similar reason libpng still is only encouraged, and not mandatory. And so the argument: why is JSON more important than libpng, is a solid one. Just it argues on the wrong side: we should consider making libpng also mandatory, as it is just silly to save screenshots in BMP, and not being able to load heightmaps, etc.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
