### PR TITLE
Change: [Win32] unify the crashlog handler with the other OSes

### DIFF
--- a/src/os/macosx/crashlog_osx.cpp
+++ b/src/os/macosx/crashlog_osx.cpp
@@ -174,9 +174,10 @@ public:
 			"A serious fault condition occurred in the game. The game will shut down.";
 
 		std::string message = fmt::format(
-				 "Please send the generated crash information and the last (auto)save to the developers. "
-				 "This will greatly help debugging. The correct place to do this is https://github.com/OpenTTD/OpenTTD/issues.\n\n"
-				 "Generated file(s):\n{}\n{}\n{}\n{}",
+				 "Please send crash.log, crash.dmp, and crash.sav to the developers. "
+				 "This will greatly help debugging.\n\n"
+				 "https://github.com/OpenTTD/OpenTTD/issues.\n\n"
+				 "{}\n{}\n{}\n{}",
 				 this->crashlog_filename, this->crashdump_filename, this->savegame_filename, this->screenshot_filename);
 
 		ShowMacDialog(crash_title, message.c_str(), "Quit");

--- a/src/os/windows/ottdres.rc.in
+++ b/src/os/windows/ottdres.rc.in
@@ -50,7 +50,6 @@ CAPTION "Fatal Application Failure"
 FONT 8, "MS Sans Serif"
 BEGIN
     PUSHBUTTON      "&Close",12,7,82,60,14
-    PUSHBUTTON      "&Emergency save",13,158,82,60,14
     PUSHBUTTON      "",15,238,82,60,14
     EDITTEXT        11,7,103,291,118,ES_MULTILINE | ES_READONLY | WS_VSCROLL |
                     WS_HSCROLL | NOT WS_TABSTOP


### PR DESCRIPTION
## Motivation / Problem

Windows didn't use the base crashlog handler for most part, and does everything itself. This is a bit annoying when we want to change things, as you have to remember to change it in two places. So while working on #11232 this was a real pita.

So, in this PR I set out to fix that discrepancy, and make sure Windows is much more like the rest.

## Description

The main difference is that Windows delayed creating a `crash.sav`. This is the only OS that does so, both MacOS and Linux create a `crash.sav` immediately. Otherwise, other PRs before this PR already made sure Windows is much more like the rest.

While at it, make the crash text a bit more readable, and sync this with MacOS. It just read a bit awkward.

## Limitations

There is an argument to be made that a `crash.sav` should not be made when a crashlog is generated, but only on demand. As it is not unlikely creating a savegame causes other problems. After all, we are in a broken state. But we also noticed this often leads to users not having a `crash.sav` to add to a ticket, as they simply didn't read the dialog, or didn't understand what it was saying.

In the long run, I rather focus on something JGRPP did, and detect if we crash during the crash handler, and handle that case more proper. That will be done in a follow-up PR, for all OSes (and not only for Windows).

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
