### PR TITLE
Change: recover when possible from crashes during a crash

### DIFF
--- a/src/crashlog.h
+++ b/src/crashlog.h
@@ -52,6 +52,17 @@ protected:
 
 	std::string CreateFileName(const char *ext, bool with_dir = true) const;
 
+	/**
+	 * Execute the func() and return its value. If any exception / signal / crash happens,
+	 * catch it and return false. This function should, in theory, never not return, even
+	 * in the worst conditions.
+	 *
+	 * @param section_name The name of the section to be executed. Printed when a crash happens.
+	 * @param func The function to call.
+	 * @return true iff the function returned true.
+	 */
+	virtual bool TryExecute(std::string_view section_name, std::function<bool()> &&func) = 0;
+
 public:
 	/** Stub destructor to silence some compilers. */
 	virtual ~CrashLog() = default;
@@ -65,7 +76,7 @@ public:
 	void FillCrashLog(std::back_insert_iterator<std::string> &output_iterator) const;
 	bool WriteCrashLog();
 
-	virtual int WriteCrashDump();
+	virtual bool WriteCrashDump();
 	bool WriteSavegame();
 	bool WriteScreenshot();
 


### PR DESCRIPTION
## Motivation / Problem

When, for example, creating of a savegame fails during the crash handler, everything stops and the user is presented with what-ever the OS decides. But in most cases, we don't actually mind that much that the savegame or, for example, the screenshot failed to be created. These issues should just be ignored and the crashlog should do as much as possible.

## Description

By clever use of `setjmp` and Windows SEH, we can protect certain blocks, that if they cause a segfault or something, we capture that, clean it up, and return in the crashlog process.

I went with the function name `TryExecute`, which takes a `std::function` that should return a boolean. The function itself should also return a boolean. Now the rules are simple:

If the function returns true and caused no problem, `TryExecute` returns true.
If the function returns false and caused no problem, `TryExecute` returns false (indicating that the function failed).
If the function caused an exception, `TryExecute` returns false (indicating that the function failed).

This way, if the `TryExecute` return true, it means everything was fine. This allows for the caller to handle what he wants to be done with problems.

This solution is heavily inspired by the work of @JGRennison in JGRPP; the main difference is that there a `char *` is returned, and there is a checkpoint system to ensure it is reset to a known-good-state if an exception happens. Here however I made it a bit more generic that I could also attach `WriteSavegame` to it, and leave the handling of the buffer to the caller. Otherwise, the implementation and idea behind it is very similar, although I did clean up some things, named things slightly different, etc, to hopefully pass easier in our review process.

## Limitations

I did not invest time in adding this functionality to `FillCrashLog`, because with #11232 that is going to change significantly enough that it was not worth my time and effort. In other words: I couldn't find a simple way to remember and restore a `back_insert_iterator`, which made that change blow up in my face. So postponing till #11232 :) This PR was mostly to prevent issues with savegames anyway (as #11236 took that away from the Windows users).

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
