### PR TITLE
Change: mention in MacOS / Windows crashlog popup when files couldn't be generated

### DIFF
--- a/src/crashlog.h
+++ b/src/crashlog.h
@@ -82,7 +82,7 @@ public:
 
 	void SendSurvey() const;
 
-	bool MakeCrashLog();
+	void MakeCrashLog();
 
 	/**
 	 * Initialiser for crash logs; do the appropriate things so crashes are


### PR DESCRIPTION
## Motivation / Problem

On MacOS / Windows, you don't always see the console. As such, it might be unclear why a file doesn't exist while the dialog said it should been there.

This mostly happens when `crash.sav` causes a segfault (due to corruption as to why the crashlog is being created). This is trapped correctly, and on the console you can read it went wrong. But the file is still mentioned in the dialog. This can be confusing.

## Description

When a TryExcept block fails, update the filename to mention it failed. This is save, the filename is not used for any other purpose than to display the location to the user.

PS: as bonus, change the return value of MakeCrashLog a `void`, as nobody was actually monitoring the return value.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
