### PR TITLE
Fix: [CI] Allow release-flow to run in forks (while skipping survey-key)

### DIFF
--- a/.github/workflows/release-source.yml
+++ b/.github/workflows/release-source.yml
@@ -152,13 +152,18 @@ jobs:
     - name: Generate survey key
       id: survey_key
       run: |
-        PAYLOAD='{"version":"${{ steps.metadata.outputs.version }}","type":"${{ vars.SURVEY_TYPE }}"}'
+        if [ -z "${{ vars.SURVEY_TYPE }}" ]; then
+          echo "SURVEY_TYPE variable not found; most likely running in a fork. Skipping step."
+          SURVEY_KEY=""
+        else
+          PAYLOAD='{"version":"${{ steps.metadata.outputs.version }}","type":"${{ vars.SURVEY_TYPE }}"}'
 
-        echo "${{ secrets.SURVEY_SIGNING_KEY }}" > survey_signing_key.pem
-        SIGNATURE=$(echo -n "${PAYLOAD}" | openssl dgst -sha256 -sign survey_signing_key.pem | base64 -w0)
-        rm -f survey_signing_key.pem
+          echo "${{ secrets.SURVEY_SIGNING_KEY }}" > survey_signing_key.pem
+          SIGNATURE=$(echo -n "${PAYLOAD}" | openssl dgst -sha256 -sign survey_signing_key.pem | base64 -w0)
+          rm -f survey_signing_key.pem
 
-        SURVEY_KEY=$(curl -f -s -X POST -d "${PAYLOAD}" -H "Content-Type: application/json" -H "X-Signature: ${SIGNATURE}" https://survey-participate.openttd.org/create-survey-key/${{ vars.SURVEY_TYPE }})
+          SURVEY_KEY=$(curl -f -s -X POST -d "${PAYLOAD}" -H "Content-Type: application/json" -H "X-Signature: ${SIGNATURE}" https://survey-participate.openttd.org/create-survey-key/${{ vars.SURVEY_TYPE }})
+        fi
 
         echo "survey_key=${SURVEY_KEY}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Motivation / Problem

I was trying to test a release on my fork. CI said: no. I said: but I want to!

## Description

If the survey-key is not set, just silently ignore the issue. The binaries will produce fine. The only downside of this is, if we ever break the survey-key of the upstream CI for some reason, it might go undetected for a while that it is broken. But I rather have that than not being able to test release-flows on my fork.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
