### PR TITLE
Fix: [CI] don't install breakpad on arm64-windows-static, as it is not supported (yet)

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -65,13 +65,19 @@ jobs:
       shell: bash
       run: |
         vcpkg install --triplet=${{ matrix.arch }}-windows-static \
-          breakpad \
           liblzma \
           libpng \
           lzo \
           nlohmann-json \
           zlib \
           # EOF
+
+        # arm64-windows-static is not (yet) supported for breakpad.
+        if [ "${{ matrix.arch }}" != "arm64" ]; then
+          vcpkg install --triplet=${{ matrix.arch }}-windows-static \
+            breakpad \
+            # EOF
+        fi
 
     - name: Install MSVC problem matcher
       uses: ammaraskar/msvc-problem-matcher@master


### PR DESCRIPTION
## Motivation / Problem

Nightlies currently fail, as breakpad doesn't support Windows ARM64. Sad times.

## Description

In theory we could fall back to dbghelp.dll, but honestly, I don't think there are many users of Windows ARM64 atm. So that is effort without any real possibility to test if it is functional. So currently, we just disable minidumps on Windows ARM64. The rest of the reporting still happens. Just no minidump.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
