### PR TITLE
Increase the number of maximum cargoes there can be in a single game

### DIFF
--- a/src/cargo_type.h
+++ b/src/cargo_type.h
@@ -62,7 +62,7 @@ enum CargoType {
 	CT_FIZZY_DRINKS = 11,
 
 	NUM_ORIGINAL_CARGO = 12,
-	NUM_CARGO       = 64,   ///< Maximal number of cargo types in a game.
+	NUM_CARGO       = 128,   ///< Maximal number of cargo types in a game.
 
 	CT_AUTO_REFIT   = 0xFD, ///< Automatically choose cargo type when doing auto refitting.
 	CT_NO_REFIT     = 0xFE, ///< Do not refit cargo of a vehicle (used in vehicle orders and auto-replace/auto-new).
@@ -74,7 +74,7 @@ inline bool IsValidCargoType(CargoType t) { return t != CT_INVALID; }
 /** Test whether cargo type is not CT_INVALID */
 inline bool IsValidCargoID(CargoID t) { return t != CT_INVALID; }
 
-typedef uint64_t CargoTypes;
+typedef uint128_t CargoTypes;
 
 static const CargoTypes ALL_CARGOTYPES = (CargoTypes)UINT64_MAX;
 

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -165,7 +165,7 @@ struct ValuesInterval {
 
 struct BaseGraphWindow : Window {
 protected:
-	static const int GRAPH_MAX_DATASETS     =  64;
+	static const int GRAPH_MAX_DATASETS     =  128;
 	static const int GRAPH_BASE_COLOUR      =  GREY_SCALE(2);
 	static const int GRAPH_GRID_COLOUR      =  GREY_SCALE(3);
 	static const int GRAPH_AXIS_LINE_COLOUR =  GREY_SCALE(1);

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -178,7 +178,7 @@ protected:
 	static const int MIN_GRAPH_NUM_LINES_Y  =   9; ///< Minimal number of horizontal lines to draw.
 	static const int MIN_GRID_PIXEL_SIZE    =  20; ///< Minimum distance between graph lines.
 
-	uint64_t excluded_data; ///< bitmask of the datasets that shouldn't be displayed.
+	uint128_t excluded_data; ///< bitmask of the datasets that shouldn't be displayed.
 	byte num_dataset;
 	byte num_on_x_axis;
 	byte num_vert_lines;

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -328,7 +328,8 @@ public:
 
 		SLE_CONDVAR(CompanyEconomyEntry, delivered_cargo[NUM_CARGO - 1], SLE_INT32,       SL_MIN_VERSION, SLV_170),
 		SLE_CONDARR(CompanyEconomyEntry, delivered_cargo,     SLE_UINT32, 32,           SLV_170, SLV_EXTEND_CARGOTYPES),
-		SLE_CONDARR(CompanyEconomyEntry, delivered_cargo,     SLE_UINT32, NUM_CARGO,    SLV_EXTEND_CARGOTYPES, SL_MAX_VERSION),
+		SLE_CONDARR(CompanyEconomyEntry, delivered_cargo,     SLE_UINT32, 64,           SLV_EXTEND_CARGOTYPES, SLV_EXTEND_CARGOTYPES_2),
+		SLE_CONDARR(CompanyEconomyEntry, delivered_cargo,     SLE_UINT32, NUM_CARGO,    SLV_EXTEND_CARGOTYPES_2, SL_MAX_VERSION),
 		    SLE_VAR(CompanyEconomyEntry, performance_history, SLE_INT32),
 	};
 	inline const static SaveLoadCompatTable compat_description = _company_economy_compat;

--- a/src/saveload/economy_sl.cpp
+++ b/src/saveload/economy_sl.cpp
@@ -36,7 +36,7 @@ struct CAPRChunkHandler : ChunkHandler {
 
 	void Load() const override
 	{
-		uint num_cargo = IsSavegameVersionBefore(SLV_55) ? 12 : IsSavegameVersionBefore(SLV_EXTEND_CARGOTYPES) ? 32 : NUM_CARGO;
+		uint num_cargo = IsSavegameVersionBefore(SLV_55) ? 12 : IsSavegameVersionBefore(SLV_EXTEND_CARGOTYPES) ? 32 : IsSavegameVersionBefore(SLV_EXTEND_CARGOTYPES_2) ? 64 : NUM_CARGO;
 		int vt = IsSavegameVersionBefore(SLV_65) ? SLE_FILE_I32 : SLE_FILE_I64;
 		SlCopy(nullptr, num_cargo, vt | SLE_VAR_NULL);
 		SlCopy(nullptr, num_cargo, SLE_FILE_U16 | SLE_VAR_NULL);

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -359,6 +359,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_INDUSTRY_CARGO_REORGANISE,          ///< 315  PR#10853 Industry accepts/produced data reorganised.
 	SLV_PERIODS_IN_TRANSIT_RENAME,          ///< 316  PR#11112 Rename days in transit to (cargo) periods in transit.
 	SLV_NEWGRF_LAST_SERVICE,                ///< 317  PR#11124 Added stable date_of_last_service to avoid NewGRF trouble.
+	SLV_EXTEND_CARGOTYPES_2,                ///< 318  PR#NOPULLREQUESTYET Extend cargotypes to 128
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -359,7 +359,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_INDUSTRY_CARGO_REORGANISE,          ///< 315  PR#10853 Industry accepts/produced data reorganised.
 	SLV_PERIODS_IN_TRANSIT_RENAME,          ///< 316  PR#11112 Rename days in transit to (cargo) periods in transit.
 	SLV_NEWGRF_LAST_SERVICE,                ///< 317  PR#11124 Added stable date_of_last_service to avoid NewGRF trouble.
-	SLV_EXTEND_CARGOTYPES_2,                ///< 318  PR#NOPULLREQUESTYET Extend cargotypes to 128
+	SLV_EXTEND_CARGOTYPES_2,                ///< 318  PR#11243 Extend cargotypes to 128
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -659,7 +659,8 @@ public:
 		    SLE_VAR(Station, had_vehicle_of_type,        SLE_UINT8),
 		SLE_REFLIST(Station, loading_vehicles,           REF_VEHICLE),
 		SLE_CONDVAR(Station, always_accepted,            SLE_FILE_U32 | SLE_VAR_U64, SLV_127, SLV_EXTEND_CARGOTYPES),
-		SLE_CONDVAR(Station, always_accepted,            SLE_UINT64,                 SLV_EXTEND_CARGOTYPES, SL_MAX_VERSION),
+		SLE_CONDVAR(Station, always_accepted,            SLE_UINT64,                 SLV_EXTEND_CARGOTYPES, SL_EXTEND_CARGOTYPES_2),
+		SLE_CONDVAR(Station, always_accepted,            SLE_UINT128,                SLV_EXTEND_CARGOTYPES_2, SL_MAX_VERSION),
 		SLEG_CONDSTRUCTLIST("speclist", SlRoadStopTileData,                          SLV_NEWGRF_ROAD_STOPS, SL_MAX_VERSION),
 		SLEG_STRUCTLIST("goods", SlStationGoods),
 	};

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -461,7 +461,7 @@ public:
 	{
 		Station *st = Station::From(bst);
 
-		uint num_cargo = IsSavegameVersionBefore(SLV_55) ? 12 : IsSavegameVersionBefore(SLV_EXTEND_CARGOTYPES) ? 32 : NUM_CARGO;
+		uint num_cargo = IsSavegameVersionBefore(SLV_55) ? 12 : IsSavegameVersionBefore(SLV_EXTEND_CARGOTYPES) ? 32 : IsSavegameVersionBefore(SLV_EXTEND_CARGOTYPES_2) ? 64 : NUM_CARGO;
 		for (CargoID i = 0; i < num_cargo; i++) {
 			GoodsEntry *ge = &st->goods[i];
 			if (IsSavegameVersionBefore(SLV_183)) {


### PR DESCRIPTION
This feature shouldmake it easier to develop complex economy sets (notably AXIS) without going through the hassle of trying to know what supply chains shuld be let down in favor of others or merging cargoes that could have merit being split up.

Note that I didn't knpw what I was doing for half the time I was developing this feature 😞 .