### PR TITLE
Change: for surveys capture more information about the OpenTTD version

### DIFF
--- a/src/network/network_survey.cpp
+++ b/src/network/network_survey.cpp
@@ -137,8 +137,12 @@ static void SurveySettings(nlohmann::json &survey)
  */
 static void SurveyOpenTTD(nlohmann::json &survey)
 {
-	survey["version"] = std::string(_openttd_revision);
-	survey["newgrf_version"] = _openttd_newgrf_version;
+	survey["version"]["revision"] = std::string(_openttd_revision);
+	survey["version"]["modified"] = _openttd_revision_modified;
+	survey["version"]["tagged"] = _openttd_revision_tagged;
+	survey["version"]["hash"] = std::string(_openttd_revision_hash);
+	survey["version"]["newgrf"] = fmt::format("{:X}", _openttd_newgrf_version);
+	survey["version"]["content"] = std::string(_openttd_content_version);
 	survey["build_date"] = std::string(_openttd_build_date);
 	survey["bits"] =
 #ifdef POINTER_IS_64BIT


### PR DESCRIPTION
## Motivation / Problem

While working on #11232 @glx22 mentioned that the "newgrf_version" in decimals wasn't all that useful. And that the content-version would be more useful, but we didn't add that yet.

While looking into that, I also noticed we don't even tell when a version was tagged, or which exact hash it is.

## Description

Address these issues all at once, and put them in a new `version` object. This means we now have all kinds of information about the OpenTTD version that was used for the survey.

The `hash` is always uniquely pointing to a single commit, so good to deduplicate on
The `revision` is the human-readable variant of `hash`.
The `tagged` and `modified` tells us if we should trust the survey result to begin with.
The `newgrf` and `content` gives us a rough estimation what kind of client it is, if it isn't a stable release. Not the most useful piece of information of this blob, but it might be useful some day.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
