### PR TITLE
Add: [CI] Create and store breakpad symbols for releases

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -28,6 +28,19 @@ jobs:
       run: |
         tar -xf source.tar.gz --strip-components=1
 
+    # dtolnay/rust-toolchain uses a curl argument (--retry-connrefused) that the curl shipped with our container doesn't support.
+    # So we need to do one part ourselves; the action takes over the rest and prepares the setup further.
+    - name: Prepare Rust toolchain
+      run: |
+        curl --proto '=https' --tlsv1.2 --retry 10 --location --silent --show-error --fail "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+        echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Enable Rust cache
+      uses: Swatinem/rust-cache@v2
+
     - name: Enable vcpkg cache
       uses: actions/cache@v3
       with:
@@ -124,6 +137,10 @@ jobs:
         )
         echo "::endgroup::"
 
+        echo "::group::Install breakpad dependencies"
+        cargo install dump_syms
+        echo "::endgroup::"
+
     - name: Install GCC problem matcher
       uses: ammaraskar/gcc-problem-matcher@master
 
@@ -146,6 +163,11 @@ jobs:
         cmake --build . -j $(nproc) --target openttd
         echo "::endgroup::"
 
+    - name: Create breakpad symbols
+      run: |
+        cd build
+        dump_syms ./openttd --inlines --store symbols
+
     - name: Create bundles
       run: |
         cd ${GITHUB_WORKSPACE}/build
@@ -164,4 +186,11 @@ jobs:
       with:
         name: openttd-linux-generic
         path: build/bundles
+        retention-days: 5
+
+    - name: Store symbols
+      uses: actions/upload-artifact@v3
+      with:
+        name: symbols-linux-generic
+        path: build/symbols
         retention-days: 5

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -26,15 +26,27 @@ jobs:
       run: |
         tar -xf source.tar.gz --strip-components=1
 
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Enable Rust cache
+      uses: Swatinem/rust-cache@v2
+
     - name: Install dependencies
       env:
         HOMEBREW_NO_AUTO_UPDATE: 1
         HOMEBREW_NO_INSTALL_CLEANUP: 1
       run: |
+        echo "::group::Install brew dependencies"
         brew install \
           pandoc \
           pkg-config \
           # EOF
+        echo "::endgroup::"
+
+        echo "::group::Install breakpad dependencies"
+        cargo install dump_syms
+        echo "::endgroup::"
 
     - name: Prepare cache key
       id: key
@@ -144,6 +156,18 @@ jobs:
         cmake --build . -j $(sysctl -n hw.logicalcpu) --target openttd
         echo "::endgroup::"
 
+    - name: Create breakpad symbols
+      run: |
+        cd build-x64
+        mkdir dSYM
+        dsymutil ./openttd -o dSYM/openttd
+        dump_syms ./dSYM/openttd --inlines --store symbols
+
+        cd ../build-arm64
+        mkdir dSYM
+        dsymutil ./openttd -o dSYM/openttd
+        dump_syms ./dSYM/openttd --inlines --store ../build-x64/symbols
+
     - name: Create bundles
       run: |
         cd build-x64
@@ -208,4 +232,11 @@ jobs:
       with:
         name: openttd-macos-universal
         path: build-x64/bundles
+        retention-days: 5
+
+    - name: Store symbols
+      uses: actions/upload-artifact@v3
+      with:
+        name: symbols-macos-universal
+        path: build-x64/symbols
         retention-days: 5

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -39,10 +39,22 @@ jobs:
       run: |
         tar -xf source.tar.gz --strip-components=1
 
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Enable Rust cache
+      uses: Swatinem/rust-cache@v2
+
     - name: Install dependencies
       shell: bash
       run: |
+        echo "::group::Install choco dependencies"
         choco install pandoc
+        echo "::endgroup::"
+
+        echo "::group::Install breakpad dependencies"
+        cargo install dump_syms
+        echo "::endgroup::"
 
     - name: Prepare cache key
       id: key
@@ -176,6 +188,12 @@ jobs:
       env:
         WINDOWS_CERTIFICATE_COMMON_NAME: ${{ secrets.WINDOWS_CERTIFICATE_COMMON_NAME }}
 
+    - name: Create breakpad symbols
+      shell: bash
+      run: |
+        cd build
+        dump_syms openttd.pdb --inlines --store symbols
+
     - name: Create bundles
       shell: bash
       run: |
@@ -184,10 +202,13 @@ jobs:
         cpack
         echo "::endgroup::"
 
-        echo "::group::Prepare PDB to be bundled"
-        PDB=$(ls bundles/*.zip | cut -d/ -f2 | sed 's/.zip$/.pdb/')
-        cp openttd.pdb bundles/${PDB}
-        xz -9 bundles/${PDB}
+        echo "::group::Move PDB and exe to symbols"
+        PDB_FOLDER=$(find symbols -mindepth 2 -type d)
+        cp openttd.pdb ${PDB_FOLDER}/
+
+        EXE_FOLDER=symbols/openttd.exe/$(grep "INFO CODE_ID" symbols/*/*/openttd.sym | cut -d\  -f3)
+        mkdir -p ${EXE_FOLDER}
+        cp openttd.exe ${EXE_FOLDER}/
         echo "::endgroup::"
 
         echo "::group::Cleanup"
@@ -212,4 +233,11 @@ jobs:
       with:
         name: openttd-windows-${{ matrix.arch }}
         path: build/bundles
+        retention-days: 5
+
+    - name: Store symbols
+      uses: actions/upload-artifact@v3
+      with:
+        name: symbols-windows-${{ matrix.arch }}
+        path: build/symbols
         retention-days: 5

--- a/.github/workflows/upload-cdn.yml
+++ b/.github/workflows/upload-cdn.yml
@@ -54,6 +54,21 @@ jobs:
           done
         fi
 
+    - name: Merge symbols
+      run: |
+        mkdir symbols
+        cp -R symbols-*/* symbols/
+
+        # Compress all files as gzip, to reduce cost of storage on the CDN.
+        for i in $(find symbols -mindepth 2 -type f); do
+          gzip ${i}
+        done
+
+        # Leave a mark in each folder what version actually created the symbol file.
+        for i in $(find symbols -mindepth 2 -type d); do
+          touch ${i}/.${{ inputs.version }}.txt
+        done
+
     - name: Store bundles
       uses: actions/upload-artifact@v3
       with:
@@ -61,11 +76,18 @@ jobs:
         path: bundles/*
         retention-days: 5
 
-  publish:
+    - name: Store breakpad symbols
+      uses: actions/upload-artifact@v3
+      with:
+        name: cdn-symbols
+        path: symbols/*
+        retention-days: 5
+
+  publish-bundles:
     needs:
     - prepare
 
-    name: Publish
+    name: Publish bundles
     uses: OpenTTD/actions/.github/workflows/rw-cdn-upload.yml@v4
     secrets:
       CDN_SIGNING_KEY: ${{ secrets.CDN_SIGNING_KEY }}
@@ -76,10 +98,22 @@ jobs:
       folder: ${{ inputs.folder }}
       version: ${{ inputs.version }}
 
+  publish-symbols:
+    needs:
+    - prepare
+
+    name: Publish symbols
+    uses: OpenTTD/actions/.github/workflows/rw-symbols-upload.yml@v4
+    secrets:
+      SYMBOLS_SIGNING_KEY: ${{ secrets.SYMBOLS_SIGNING_KEY }}
+    with:
+      artifact-name: cdn-symbols
+      repository: OpenTTD
+
   docs:
     if: ${{ inputs.trigger_type == 'new-master' }}
     needs:
-    - publish
+    - publish-bundles
 
     name: Publish docs
 

--- a/docs/symbol_server.md
+++ b/docs/symbol_server.md
@@ -1,0 +1,34 @@
+# OpenTTD's Symbol Server
+
+For all official releases, OpenTTD collects the Breakpad Symbols (SYM-files) and Microsoft's Symbols (PDB-files), and publishes them on our own Symbol Server (https://symbols.openttd.org).
+
+These symbol files are needed to analyze `crash.dmp` files as attached to issues by users.
+A `crash.dmp` is created on Windows, Linux, and MacOS when a crash happens.
+This combined with the `crash.log` should give a pretty good indication what was going on at the moment the game crashed.
+
+## Analyzing a crash.dmp
+
+### MSVC
+
+In MSVC you can add the above URL as Symbol Server (and please enable MSVC's for all other libraries), allowing you to analyze `crash.dmp`.
+
+Now simply open up the `crash.dmp`, and start debugging.
+
+### All other platforms
+
+The best tool to use is `minidump-stackwalk` as published in the Rust's cargo index:
+
+```bash
+cargo install minidump-stackwalk
+```
+
+For how to install Rust, please see [here](https://doc.rust-lang.org/cargo/getting-started/installation.html).
+
+Now run the tool like:
+
+```bash
+minidump-stackwalk <crash.dmp> --symbols-url https://symbols.openttd.org
+```
+
+For convenience, the above Symbol Server also check with Mozilla's Symbol Server in case any other library but OpenTTD is requested.
+This means files like `libc`, `kernel32.dll`, etc are all available on the above mentioned Symbol Server.


### PR DESCRIPTION
## Motivation / Problem

Currently there are two flows for nightlies / releases:

- If you have a `crash.dmp` for MacOS or Linux, you have nothing useful. As the debug symbols are lost. PS: only recent nightlies generate `crash.dmp` on these platforms.
- If you have a `crash.dmp` for Windows, you have to do several steps: find the correct version that generated the `crash.dmp`, find the `.pdb` and `.exe` that belongs to that, put them in the same folder, and you can start analyzing it in MSVC. `minidump-stackwalk` cannot be used.

This PR sets out to address these issues by uploading the breakpad symbols and pdb/exe to our own Symbol Server.

## Description

- Export the breakpad symbols via the rust project `dump_syms` (Mozilla uses the same tool) in a `symbols` folder.
- Move `.pdb` and `.exe` to the right folder inside the same `symbols` folder.
- Compress all files in the `symbols` folder with gzip (to pay less money for storage).
- Add a `.<version>.txt` file to each folder, as folders inside the `symbols` folder have identifiers; for pruning symbol-files we no longer need, that is impractical.
- Upload all these files to the Symbol Server. This is very identical to our CDN: it is a Cloudflare R2 in the backend, with a Cloudflare Worker before it to upload files to it. You need a signing key to upload files; you need to sign the folder you are uploading to, so the Cloudflare Worker can validate you are authorized to actually upload files to the Symbol Server.

Now you can use the symbol server https://symbols.openttd.org to get the right symbols for the different tools.
- In MSVC you can just add this URL to the list of Symbol Servers. Also enable the MSVC one please; we are not servering those 
files.
- In `minidump-stackwalk` (the Rust project, here too Mozilla uses the same) you can add `--symbols-url` pointing to the above URL. To make live a tiny bit easier here: if we don't know the symbol you request (that isn't an `openttd` symbol), we proxy the request to Mozilla's Symbol Server (https://symbols.mozilla.org), and serve that. This means you actually don't need to add that symbols-url yourself. Mozilla's Symbol Server is full of breakpad symbols for all kinds of different libraries and versions of them. So pretty good odds they have the symbols you are looking for.

In short, this will make debugging `crash.dmp` a lot easier; not only don't we need @glx22 to tell us the stacktrace, we can also navigate it ourselves to check the value for variables, register content, thread information, etc etc.

On this note, @glx22 , tnx a lot for telling us the stracktrace in so many issues over the years. I don't want to put you out of a job, so please continue doing so. But I hope this change makes that a lot easier for you too. And others don't have an excuse anymore to not help out :D

PS: yes, I wrote documentation how to use this in `docs/symbol_server.md`, as LordAro will ask about that :P I will also make a blog-post when this is all done about how crashes and analysis of those has changed.

To give an idea of files stored, here is an overview of a single release:

```
openttd.exe/64EF51EA190D000/openttd.exe.gz 4.63 MB
openttd.exe/64EF53C82406000/openttd.exe.gz 5.44 MB
openttd.exe/64EF53E72561000/openttd.exe.gz 4.97 MB
openttd.pdb/2C5857866F014B2E92120C54F8DA4DED1/openttd.pdb.gz 39.33 MB
openttd.pdb/2C5857866F014B2E92120C54F8DA4DED1/openttd.sym.gz 10.82 MB
openttd.pdb/38D2C59A71764C37AB1186DF9DD0127A1/openttd.pdb.gz 40.34 MB
openttd.pdb/38D2C59A71764C37AB1186DF9DD0127A1/openttd.sym.gz 11.15 MB
openttd.pdb/E4E5AE3F3DBE450C82CD409E0322E59E1/openttd.pdb.gz 39.21 MB
openttd.pdb/E4E5AE3F3DBE450C82CD409E0322E59E1/openttd.sym.gz 10.36 MB
openttd/258559FF5C5A3AD9A72D15461B090EC10/openttd.sym.gz 7.12 MB
openttd/5F2A5739DE303489AE2F601B4982E0E20/openttd.sym.gz 6.43 MB
openttd/DF356502271D79EE9DFD584E1FF8F9BF0/openttd.sym.gz 10.97 MB
```

## Limitations

Of course storing symbols costs money. Our current infrastructure partner (Cloudflare) charges 0.015 USD per GB stored each month. A single release takes ~250MB in storage. This means that each release costs us ~0.004 USD for every month we keep it. This means that if we keep three months worth of nightly symbols (and remove everything older), it costs ~0.5 USD per month.

As we now store the PDBs on the Symbol Server, these files will no longer be published on the CDN. A note will be added on the website that debug-symbols can be found on the Symbol Server, under `Developer Files` on https://www.openttd.org/downloads/openttd-nightlies/latest (and other similar pages).

I currently have no plans to fill the Symbol Server with the PDBs of existing releases. This means that `crash.dmp` created before 14.0 will still need to be done the @glx22 -as-a-service way :) But as our users tend to update pretty quickly, I suspect that once 14.0 is released, the demand for the GaaS will become very low.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
