### PR TITLE
Codechange: [Emscripten] remove "relative_mode" parameter from -vsdl as it doesn't exist

### DIFF
--- a/os/emscripten/pre.js
+++ b/os/emscripten/pre.js
@@ -1,4 +1,4 @@
-Module.arguments.push('-mnull', '-snull', '-vsdl:relative_mode');
+Module.arguments.push('-mnull', '-snull', '-vsdl');
 Module['websocket'] = { url: function(host, port, proto) {
     /* openttd.org hosts a WebSocket proxy for the content service. */
     if (host == "content.openttd.org" && port == 3978 && proto == "tcp") {


### PR DESCRIPTION
## Motivation / Problem

At the introduction of emscripten ( d15dc9f40f5a20bff452547a2dcb15231f9f969d ) this parameter was set. But I can't find any evidence it was ever implemented.

## Description

I suspect during the development of that commit it did exist, but got removed in favour of `#ifdef`. And then got lost in time. Anyway, we don't deal with relative mode anymore in the global sense, so forget about it.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
