### PR TITLE
Fix: [Script] GSAdmin.Send() could generate invalid JSON

### DIFF
--- a/src/script/api/script_admin.cpp
+++ b/src/script/api/script_admin.cpp
@@ -129,7 +129,10 @@
 	}
 
 	std::string json;
-	ScriptAdmin::MakeJSON(vm, -1, SQUIRREL_MAX_DEPTH, json);
+	if (!ScriptAdmin::MakeJSON(vm, -1, SQUIRREL_MAX_DEPTH, json)) {
+		sq_pushinteger(vm, 0);
+		return 1;
+	}
 
 	if (json.length() > NETWORK_GAMESCRIPT_JSON_LENGTH) {
 		ScriptLog::Error("You are trying to send a table that is too large to the AdminPort. No data sent.");


### PR DESCRIPTION
## Motivation / Problem

Given the following script-snippet:

```
GSAdmin.Send({ test = GSAdmin });
```

This would send over the Admin Port: `{ `.

## Description

A bit of a silly bug: not checking the return value.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
