### PR TITLE
Codechange: [Script] use nlohmann for Squirrel <-> JSON conversion

### DIFF
--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -60,7 +60,7 @@ static const uint NETWORK_REVISION_LENGTH           =   33;           ///< The m
 static const uint NETWORK_PASSWORD_LENGTH           =   33;           ///< The maximum length of the password, in bytes including '\0' (must be >= NETWORK_SERVER_ID_LENGTH)
 static const uint NETWORK_CLIENT_NAME_LENGTH        =   25;           ///< The maximum length of a client's name, in bytes including '\0'
 static const uint NETWORK_RCONCOMMAND_LENGTH        =  500;           ///< The maximum length of a rconsole command, in bytes including '\0'
-static const uint NETWORK_GAMESCRIPT_JSON_LENGTH    = COMPAT_MTU - 3; ///< The maximum length of a gamescript json string, in bytes including '\0'. Must not be longer than COMPAT_MTU including header (3 bytes)
+static const uint NETWORK_GAMESCRIPT_JSON_LENGTH    = 9000;           ///< The maximum length of a receiving gamescript json string, in bytes including '\0'.
 static const uint NETWORK_CHAT_LENGTH               =  900;           ///< The maximum length of a chat message, in bytes including '\0'
 static const uint NETWORK_CONTENT_FILENAME_LENGTH   =   48;           ///< The maximum length of a content's filename, in bytes including '\0'.
 static const uint NETWORK_CONTENT_NAME_LENGTH       =   32;           ///< The maximum length of a content's name, in bytes including '\0'.

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -557,11 +557,6 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendConsole(const std::string
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendGameScript(const std::string_view json)
 {
-	/* At the moment we cannot transmit anything larger than MTU. So we limit
-	 *  the maximum amount of json data that can be sent. Account also for
-	 *  the trailing \0 of the string */
-	if (json.size() + 1 >= NETWORK_GAMESCRIPT_JSON_LENGTH) return NETWORK_RECV_STATUS_OKAY;
-
 	Packet *p = new Packet(ADMIN_PACKET_SERVER_GAMESCRIPT);
 
 	p->Send_string(json);

--- a/src/script/api/script_admin.hpp
+++ b/src/script/api/script_admin.hpp
@@ -11,6 +11,7 @@
 #define SCRIPT_ADMIN_HPP
 
 #include "script_object.hpp"
+#include <nlohmann/json.hpp>
 
 /**
  * Class that handles communication with the AdminPort.
@@ -38,13 +39,14 @@ public:
 
 protected:
 	/**
-	 * Convert a Squirrel structure into a JSON string.
+	 * Convert a Squirrel structure into a JSON object.
+	 * @param json The resulting JSON object.
 	 * @param vm The VM to operate on.
 	 * @param index The index we are currently working for.
-	 * @param max_depth The maximal depth to follow the squirrel struct.
-	 * @param data The resulting json string.
+	 * @param depth The current depth in the squirrel struct.
+	 * @return True iff the conversion was successful.
 	 */
-	static bool MakeJSON(HSQUIRRELVM vm, SQInteger index, int max_depth, std::string &data);
+	static bool MakeJSON(nlohmann::json &data, HSQUIRRELVM vm, SQInteger index, int depth = 0);
 };
 
 #endif /* SCRIPT_ADMIN_HPP */

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -14,6 +14,8 @@
 #include "script_goal.hpp"
 #include "script_window.hpp"
 
+#include <nlohmann/json.hpp>
+
 /**
  * Event Vehicle Crash, indicating a vehicle of yours is crashed.
  *  It contains the crash site, the crashed vehicle and the reason for the crash.
@@ -912,25 +914,11 @@ private:
 	std::string json; ///< The JSON string.
 
 	/**
-	 * Read a table from a JSON string.
+	 * Convert a JSON part fo Squirrel.
 	 * @param vm The VM used.
-	 * @param p The (part of the) JSON string reading.
+	 * @param json The JSON part to convert to Squirrel.
 	 */
-	const char *ReadTable(HSQUIRRELVM vm, const char *p);
-
-	/**
-	 * Read a value from a JSON string.
-	 * @param vm The VM used.
-	 * @param p The (part of the) JSON string reading.
-	 */
-	const char *ReadValue(HSQUIRRELVM vm, const char *p);
-
-	/**
-	 * Read a string from a JSON string.
-	 * @param vm The VM used.
-	 * @param p The (part of the) JSON string reading.
-	 */
-	const char *ReadString(HSQUIRRELVM vm, const char *p);
+	bool ReadValue(HSQUIRRELVM vm, nlohmann::json &json);
 };
 
 /**


### PR DESCRIPTION
## Motivation / Problem

We rolled our custom JSON generator for `GSAdmin.Send` / `ScriptEventAdminPort`. Now we have nlohmann, switch to that.

## Description

A relative straight-forward conversion. Few things worth nothing:

- `max_depth` was a bit weird, counting down. Instead, it is now `depth`, counting up. That way a backtrace shows better at what depth we were.
- GSAdmin.Send() couldn't send more than ~1400 bytes of JSON. This was a (rather old) limitation that each packet couldn't consume more than one packet. This limitation has been solved a long time ago, but never made it into GSAdmin.Send(). So while at it, also removed that restriction. For incoming JSON there is still a restriction, but increased the value of that to 9000. Just a random number. Open for better suggestions.
- There was a restriction that a string was not allowed to exceed 254 characters. I am not sure where this restriction comes from, or why it was there. I just removed it. Felt like a weird limitation for not actual reason.
- The custom JSON generator added spaces in all kinds of places. nlohmann doesn't (unless told to). The spaces makes no sense to me, as you want this to be as compact as possible. It doesn't have to be human readable. That is something for the other side of the admin-port to handle / do.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
