### PR TITLE
Codechange: [CMake] detect source files with duplicate names

### DIFF
--- a/cmake/SourceList.cmake
+++ b/cmake/SourceList.cmake
@@ -1,12 +1,4 @@
-# Add a file to be compiled.
-#
-# add_files([file1 ...] CONDITION condition [condition ...])
-#
-# CONDITION is a complete statement that can be evaluated with if().
-# If it evaluates true, the source files will be added; otherwise not.
-# For example: ADD_IF SDL_FOUND AND Allegro_FOUND
-#
-function(add_files)
+function(_add_files_tgt tgt)
     cmake_parse_arguments(PARAM "" "" "CONDITION" ${ARGN})
     set(PARAM_FILES "${PARAM_UNPARSED_ARGUMENTS}")
 
@@ -21,6 +13,18 @@ function(add_files)
     endforeach()
 endfunction()
 
+# Add a file to be compiled.
+#
+# add_files([file1 ...] CONDITION condition [condition ...])
+#
+# CONDITION is a complete statement that can be evaluated with if().
+# If it evaluates true, the source files will be added; otherwise not.
+# For example: ADD_IF SDL_FOUND AND Allegro_FOUND
+#
+function(add_files)
+    _add_files_tgt(openttd_lib ${ARGV})
+endfunction()
+
 # Add a test file to be compiled.
 #
 # add_test_files([file1 ...] CONDITION condition [condition ...])
@@ -30,18 +34,7 @@ endfunction()
 # For example: ADD_IF SDL_FOUND AND Allegro_FOUND
 #
 function(add_test_files)
-    cmake_parse_arguments(PARAM "" "" "CONDITION" ${ARGN})
-    set(PARAM_FILES "${PARAM_UNPARSED_ARGUMENTS}")
-
-    if(PARAM_CONDITION)
-        if(NOT (${PARAM_CONDITION}))
-            return()
-        endif()
-    endif()
-
-    foreach(FILE IN LISTS PARAM_FILES)
-        target_sources(openttd_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/${FILE})
-    endforeach()
+    _add_files_tgt(openttd_test ${ARGV})
 endfunction()
 
 # This function works around an 'issue' with CMake, where

--- a/cmake/SourceList.cmake
+++ b/cmake/SourceList.cmake
@@ -9,7 +9,17 @@ function(_add_files_tgt tgt)
     endif()
 
     foreach(FILE IN LISTS PARAM_FILES)
-        target_sources(openttd_lib PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/${FILE})
+        # Some IDEs are not happy with duplicated filenames, so we detect that before adding the file.
+        get_target_property(${tgt}_FILES ${tgt} SOURCES)
+        if(${tgt}_FILES MATCHES "/${FILE}(;|$)")
+            string(REGEX REPLACE "(^|.+;)([^;]+/${FILE})(;.+|$)" "\\2" RES "${${tgt}_FILES}")
+            # Ignore header files duplicates in 3rdparty.
+            if(NOT (${FILE} MATCHES "\.h" AND (${RES} MATCHES "3rdparty" OR ${CMAKE_CURRENT_SOURCE_DIR} MATCHES "3rdparty")))
+                message(FATAL_ERROR "${tgt}: ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} filename is a duplicate of ${RES}")
+            endif()
+        endif()
+
+        target_sources(${tgt} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/${FILE})
     endforeach()
 endfunction()
 


### PR DESCRIPTION
## Motivation / Problem
It's another version of #11198 doing the check in CMake so duplicates can be detected before opening a PR.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
