### PR TITLE
Change: Replace fixed length _grf_text array with vector.

### DIFF
--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -636,7 +636,7 @@ const char *GetGRFStringFromGRFText(const GRFTextWrapper &text)
 /**
  * Get a C-string from a stringid set by a newgrf.
  */
-const char *GetGRFStringPtr(uint16_t stringid)
+const char *GetGRFStringPtr(uint32_t stringid)
 {
 	assert(stringid < _grf_text.size());
 	assert(_grf_text[stringid].grfid != 0);

--- a/src/newgrf_text.h
+++ b/src/newgrf_text.h
@@ -33,7 +33,7 @@ StringID AddGRFString(uint32_t grfid, uint16_t stringid, byte langid, bool new_s
 StringID GetGRFStringID(uint32_t grfid, StringID stringid);
 const char *GetGRFStringFromGRFText(const GRFTextList &text_list);
 const char *GetGRFStringFromGRFText(const GRFTextWrapper &text);
-const char *GetGRFStringPtr(uint16_t stringid);
+const char *GetGRFStringPtr(uint32_t stringid);
 void CleanUpStrings();
 void SetCurrentGrfLangID(byte language_id);
 std::string TranslateTTDPatchCodes(uint32_t grfid, uint8_t language_id, bool allow_newlines, const std::string &str, StringControlCode byte80 = SCC_NEWGRF_PRINT_WORD_STRING_ID);


### PR DESCRIPTION
## Motivation / Problem

On x86-64, `_grf_text` is a 20MB array. This was due to increasing the number of permitted IDs without realising the ID is used as an array index.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

IDs are allocated sequentially by OpenTTD, not by NewGRFs, so it is possible to replace the array with a vector and allocate as necessary. The limit is still enforced, though is unlikely to be reached.

Additionally reshuffle GRFTextEntry for better alignment. This only seems to help 32bit x86, but shouldn't hurt other architectures.


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

An assert has been added for out-of-bounds access. I have assumed the NewGRFs cannot interfere and pass IDs directly.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
