### PR TITLE
Fix 8c9ecde9: actually remove autosave_interval from setting window

### DIFF
--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1814,7 +1814,6 @@ static SettingsContainer &GetSettingsTree()
 			}
 
 			interface->Add(new SettingEntry("gui.fast_forward_speed_limit"));
-			interface->Add(new SettingEntry("gui.autosave_interval"));
 			interface->Add(new SettingEntry("gui.toolbar_pos"));
 			interface->Add(new SettingEntry("gui.statusbar_pos"));
 			interface->Add(new SettingEntry("gui.prefer_teamchat"));


### PR DESCRIPTION
## Motivation / Problem

In 8c9ecde9 (and #11218) the intention was to remove the setting from the settings window (it is already in the game options). But an essential line was not removed.

## Description

Actually remove the autosave-interval from the settings. Otherwise you see this:

![image](https://github.com/OpenTTD/OpenTTD/assets/1663690/c02b2c50-87c3-41f1-924f-263b3e0ca73c)

Clearly nobody actually tested #11218 :D :)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
