### PR TITLE
Change: Allow vehicles in the build-vehicle-window to be filtered based on their cargo type

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1366,7 +1366,7 @@ struct BuildVehicleWindow : Window {
 		return CargoAndEngineFilter(&item, filter_type);
 	}
 
-	/** Filter by name and NewGRF extra text */
+	/** Filter by name, cargo type and NewGRF extra text */
 	bool FilterByText(const Engine *e)
 	{
 		/* Do not filter if the filter text box is empty */
@@ -1376,6 +1376,12 @@ struct BuildVehicleWindow : Window {
 		this->string_filter.ResetState();
 		SetDParam(0, PackEngineNameDParam(e->index, EngineNameContext::PurchaseList));
 		this->string_filter.AddLine(GetString(STR_ENGINE_NAME));
+
+		/* Filter by cargo type. This includes cargo types that the engine can be refitted to. */
+		const CargoTypes refit_mask = GetUnionOfArticulatedRefitMasks(e->index, true) &_standard_cargo_mask;
+		for (CargoID cargo = 0; cargo < NUM_CARGO; cargo++) {
+			if (HasBit(refit_mask, cargo)) this->string_filter.AddLine(GetString(CargoSpec::Get(cargo)->name));
+		}
 
 		/* Filter NewGRF extra text */
 		auto text = GetNewGRFAdditionalText(e->index);
@@ -1408,7 +1414,7 @@ struct BuildVehicleWindow : Window {
 			/* Filter now! So num_engines and num_wagons is valid */
 			if (!FilterSingleEngine(eid)) continue;
 
-			/* Filter by name or NewGRF extra text */
+			/* Filter by name, cargo or NewGRF extra text */
 			if (!FilterByText(e)) continue;
 
 			list.emplace_back(eid, e->info.variant_id, e->display_flags, 0);
@@ -1457,7 +1463,7 @@ struct BuildVehicleWindow : Window {
 			if (!IsEngineBuildable(eid, VEH_ROAD, _local_company)) continue;
 			if (this->filter.roadtype != INVALID_ROADTYPE && !HasPowerOnRoad(e->u.road.roadtype, this->filter.roadtype)) continue;
 
-			/* Filter by name or NewGRF extra text */
+			/* Filter by name, cargo or NewGRF extra text */
 			if (!FilterByText(e)) continue;
 
 			this->eng_list.emplace_back(eid, e->info.variant_id, e->display_flags, 0);
@@ -1478,7 +1484,7 @@ struct BuildVehicleWindow : Window {
 			EngineID eid = e->index;
 			if (!IsEngineBuildable(eid, VEH_SHIP, _local_company)) continue;
 
-			/* Filter by name or NewGRF extra text */
+			/* Filter by name, cargo or NewGRF extra text */
 			if (!FilterByText(e)) continue;
 
 			this->eng_list.emplace_back(eid, e->info.variant_id, e->display_flags, 0);
@@ -1508,7 +1514,7 @@ struct BuildVehicleWindow : Window {
 			/* First VEH_END window_numbers are fake to allow a window open for all different types at once */
 			if (!this->listview_mode && !CanVehicleUseStation(eid, st)) continue;
 
-			/* Filter by name or NewGRF extra text */
+			/* Filter by name, cargo or NewGRF extra text */
 			if (!FilterByText(e)) continue;
 
 			this->eng_list.emplace_back(eid, e->info.variant_id, e->display_flags, 0);


### PR DESCRIPTION
## Motivation / Problem

With large train sets it can be annoying to switch back and forth between filters to find vehicles that support the cargo you are interested in. I often find myself switching between different sorting methods / filters which can get tedious.

## Description

Thanks to @2TallTyler we have a filter textbox in the build vehicle window. It already supported filtering by name and newgrf text, and cargo types have now been added as well. This includes cargo types that can be refitted to.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
