### PR TITLE
Add: Use http_proxy environment variable for curl

### DIFF
--- a/src/network/core/http_curl.cpp
+++ b/src/network/core/http_curl.cpp
@@ -180,6 +180,16 @@ void HttpThread()
 		});
 		curl_easy_setopt(curl, CURLOPT_XFERINFODATA, request->callback);
 
+		/* Pass the proxy to curl explicitly. */
+		if (const char *proxy = std::getenv("http_proxy")) {
+			if (std::getenv("no_proxy") != NULL) {
+				Debug(net, 3, "no_proxy environment variable set, ignoring http_proxy");
+			} else {
+				Debug(net, 3, "Using proxy from environment http_proxy={}", proxy);
+				curl_easy_setopt(curl, CURLOPT_PROXY, proxy);
+			}
+		}
+
 		/* Perform the request. */
 		CURLcode res = curl_easy_perform(curl);
 


### PR DESCRIPTION
## Motivation / Problem

The content is attempted to be downloaded bypassing my proxy.

With the tweak, the proxy is used proper:
```
$ echo $http_proxy
http://proxy.loc:3128
$ strace -ff -econnect -- ./openttd -x -d net=9
...
dbg: [grf] No MD5 checksum specified for: game18.mid (in /home/b/.local/share/openttd/content_download/baseset/descent_soundtrack-1.2/descent.obm)
dbg: [grf] No MD5 checksum specified for: game18.mid (in /home/b/.local/share/openttd/content_download/baseset/descent_soundtrack-1.2/descent.obm)
...
dbg: [net] Network revision name: 20230904-master-m9d2920e9c5
dbg: [net] Using proxy from environment http_proxy=http://proxy.loc:3128
* processing: https://binaries.openttd.org/bananas
strace: Process 157709 attached
[pid 157709] +++ exited with 0 +++
*   Trying 192.168.3.46:3128...
[pid 157699] connect(45, {sa_family=AF_INET, sin_port=htons(3128), sin_addr=inet_addr("192.168.3.46")}, 16) = -1 EINPROGRESS (Operation now in progress)
* Connected to proxy.loc (192.168.3.46) port 3128
* CONNECT tunnel: HTTP/1.1 negotiated
* allocate connect buffer
* Establish HTTP proxy tunnel to binaries.openttd.org:443
> CONNECT binaries.openttd.org:443 HTTP/1.1
Host: binaries.openttd.org:443
User-Agent: OpenTTD/20230904-master-m9d2920e9c5
Proxy-Connection: Keep-Alive

< HTTP/1.1 200 Connection established

```

**# It looks odd that the descent soundtrack file seems to be checked twice?**
Is this something which could be optimized to just a single check? Entirely different thing though, didn't look..


## Description

curl supports using a proxy set in the environment variable "http_proxy". Let's use that for the content downloading IFF requested.

Older versions of OpenTTD (both UNIX and Windows) just hung when attempting to download content when the network BOFH did not allow direct HTTP connections but the windows system proxy was setup properly, since OpenTTD ignored the proxy settings.

## Limitations

Due to lack of a windows system, i did not check if the windows version handles HTTP(S) traffic properly by using the system's proxy settings.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)