### PR TITLE
Fix: [CI] preview flow can't install latest version of npm

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -91,7 +91,8 @@ jobs:
 
         # Ensure we use the latest version of npm; the one we get with current
         # emscripten doesn't allow running "npx wrangler" as root.
-        npm install -g npm
+        # Current emscripten can't install npm>=10.0.0 because node is too old.
+        npm install -g npm@9
 
     - name: Publish preview
       uses: cloudflare/pages-action@v1


### PR DESCRIPTION
## Motivation / Problem
Lastest version of `npm` is currently 10.0.0 (released on August 31st) and it requires `node` '^18.17.0 || >=20.5.0' but emscripten/emsdk node version is v16.20.0 (they updated to this version in June).
Because of that we can't publish preview builds.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
As it used to work before the release of npm 10.0.0, I decided to force use of previous npm version (9.8.1) which is still better than the emscripten/emsdk provided one (8.19.4).
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
