### PR TITLE
Fix: asserts unintentially being partially disabled in release-builds

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -394,6 +394,10 @@ void NORETURN AssertFailedError(int line, const char *file, const char *expressi
 #	define assert(expression) if (unlikely(!(expression))) AssertFailedError(__LINE__, __FILE__, #expression);
 #endif
 
+/* Define JSON_ASSERT, which is used by nlohmann-json. Otherwise the header-file
+ * will re-include assert.h, and reset the assert macro. */
+#define JSON_ASSERT(x) assert(x)
+
 #if defined(MAX_PATH)
 	/* It's already defined, no need to override */
 #elif defined(PATH_MAX) && PATH_MAX > 0


### PR DESCRIPTION
## Motivation / Problem

The nlohmann-json header file includes assert.h, which rudely resets
the assert macro to what that header thinks is right. As we set the
assert macro to be active with release builds when WITH_ASSERT is
active, this means that every file including nlohmann-json has their
asserts disabled (for release-builds) but files that don't do no.

## Description

Let's avoid this issue, by telling nlohmann to not include assert.h.

And why all this? Well, the start of `/usr/include/assert.h`:

```
#ifdef  _ASSERT_H

# undef _ASSERT_H
# undef assert
```

Nuff said. Why have header guards if you are just going to use them to fuck people over? I dunno .. those headers irritate me. But it is a system header, so nothing we can do about it :(

Fixes #11267.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
