### PR TITLE
Codechange: keep how we convert string <-> JSON private

### DIFF
--- a/src/script/api/script_admin.cpp
+++ b/src/script/api/script_admin.cpp
@@ -14,9 +14,22 @@
 #include "../script_instance.hpp"
 #include "../../string_func.h"
 
+#include <nlohmann/json.hpp>
+
 #include "../../safeguards.h"
 
-/* static */ bool ScriptAdmin::MakeJSON(nlohmann::json &json, HSQUIRRELVM vm, SQInteger index, int depth)
+/**
+ * Convert a Squirrel structure into a JSON object.
+ *
+ * This function is not "static", so it can be tested in unittests.
+ *
+ * @param json The resulting JSON object.
+ * @param vm The VM to operate on.
+ * @param index The index we are currently working for.
+ * @param depth The current depth in the squirrel struct.
+ * @return True iff the conversion was successful.
+ */
+bool ScriptAdminMakeJSON(nlohmann::json &json, HSQUIRRELVM vm, SQInteger index, int depth = 0)
 {
 	if (depth == SQUIRREL_MAX_DEPTH) {
 		ScriptLog::Error("Send parameters can only be nested to 25 deep. No data sent."); // SQUIRREL_MAX_DEPTH = 25
@@ -47,7 +60,7 @@
 			while (SQ_SUCCEEDED(sq_next(vm, index - 1))) {
 				nlohmann::json tmp;
 
-				bool res = MakeJSON(tmp, vm, -1, depth + 1);
+				bool res = ScriptAdminMakeJSON(tmp, vm, -1, depth + 1);
 				sq_pop(vm, 2);
 				if (!res) {
 					sq_pop(vm, 1);
@@ -72,7 +85,7 @@
 				std::string key = std::string(buf);
 
 				nlohmann::json value;
-				bool res = MakeJSON(value, vm, -1, depth + 1);
+				bool res = ScriptAdminMakeJSON(value, vm, -1, depth + 1);
 				sq_pop(vm, 2);
 				if (!res) {
 					sq_pop(vm, 1);
@@ -113,7 +126,7 @@
 	}
 
 	nlohmann::json json;
-	if (!ScriptAdmin::MakeJSON(json, vm, -1)) {
+	if (!ScriptAdminMakeJSON(json, vm, -1)) {
 		sq_pushinteger(vm, 0);
 		return 1;
 	}

--- a/src/script/api/script_admin.hpp
+++ b/src/script/api/script_admin.hpp
@@ -11,7 +11,6 @@
 #define SCRIPT_ADMIN_HPP
 
 #include "script_object.hpp"
-#include <nlohmann/json.hpp>
 
 /**
  * Class that handles communication with the AdminPort.
@@ -36,17 +35,6 @@ public:
 	 */
 	static bool Send(void *table);
 #endif /* DOXYGEN_API */
-
-protected:
-	/**
-	 * Convert a Squirrel structure into a JSON object.
-	 * @param json The resulting JSON object.
-	 * @param vm The VM to operate on.
-	 * @param index The index we are currently working for.
-	 * @param depth The current depth in the squirrel struct.
-	 * @return True iff the conversion was successful.
-	 */
-	static bool MakeJSON(nlohmann::json &data, HSQUIRRELVM vm, SQInteger index, int depth = 0);
 };
 
 #endif /* SCRIPT_ADMIN_HPP */

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -14,8 +14,6 @@
 #include "script_goal.hpp"
 #include "script_window.hpp"
 
-#include <nlohmann/json.hpp>
-
 /**
  * Event Vehicle Crash, indicating a vehicle of yours is crashed.
  *  It contains the crash site, the crashed vehicle and the reason for the crash.
@@ -912,13 +910,6 @@ public:
 
 private:
 	std::string json; ///< The JSON string.
-
-	/**
-	 * Convert a JSON part fo Squirrel.
-	 * @param vm The VM used.
-	 * @param json The JSON part to convert to Squirrel.
-	 */
-	bool ReadValue(HSQUIRRELVM vm, nlohmann::json &json);
 };
 
 /**


### PR DESCRIPTION
## Motivation / Problem

In most of the Script API it was chosen to not use any (static) local functions, but always make them private members. Although perfectly fine OO approach to coding, it does mean often information leaks to the outside world how internals work, for no real reason other than .. to follow OO.

This, in this case, meant that everyone can see, and needs to know about, that nlohmann-json was used for string <-> JSON conversion. This is bad, as replacing how we do that should be transparent for the rest of the world.

## Description

Stop leaking internal information about how we do conversion.

## Limitations

For testing, the MakeJSON function is not made static, so the test can drag it in via an `extern` declaration. Sadly, we can't test compile-time if we are building for testing, as we first build a library that is reused by both the tests as the actual game. So we leak a symbol here, just for testing.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
