### PR TITLE
Codechange: Use std::array/std::unique_ptr for Persistent/TemporaryStorageArray.

### DIFF
--- a/src/newgrf_storage.h
+++ b/src/newgrf_storage.h
@@ -131,17 +131,12 @@ struct PersistentStorageArray : BasePersistentStorageArray {
  */
 template <typename TYPE, uint SIZE>
 struct TemporaryStorageArray {
-	TYPE storage[SIZE]; ///< Memory to for the storage array
-	uint16_t init[SIZE];  ///< Storage has been assigned, if this equals 'init_key'.
-	uint16_t init_key;    ///< Magic key to 'init'.
+	using StorageType = std::array<TYPE, SIZE>;
+	using StorageInitType = std::array<uint16_t, SIZE>;
 
-	/** Simply construct the array */
-	TemporaryStorageArray()
-	{
-		memset(this->storage, 0, sizeof(this->storage)); // not exactly needed, but makes code analysers happy
-		memset(this->init, 0, sizeof(this->init));
-		this->init_key = 1;
-	}
+	StorageType storage{}; ///< Memory for the storage array
+	StorageInitType init{}; ///< Storage has been assigned, if this equals 'init_key'.
+	uint16_t init_key{1}; ///< Magic key to 'init'.
 
 	/**
 	 * Stores some value at a given position.
@@ -181,7 +176,7 @@ struct TemporaryStorageArray {
 		this->init_key++;
 		if (this->init_key == 0) {
 			/* When init_key wraps around, we need to reset everything */
-			memset(this->init, 0, sizeof(this->init));
+			this->init = {};
 			this->init_key = 1;
 		}
 	}

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -246,7 +246,7 @@ struct INDYChunkHandler : ChunkHandler {
 				/* Store the old persistent storage. The GRFID will be added later. */
 				assert(PersistentStorage::CanAllocateItem());
 				i->psa = new PersistentStorage(0, 0, 0);
-				memcpy(i->psa->storage, _old_ind_persistent_storage.storage, sizeof(_old_ind_persistent_storage.storage));
+				std::copy(std::begin(_old_ind_persistent_storage.storage), std::end(_old_ind_persistent_storage.storage), std::begin(i->psa->storage));
 			}
 			if (IsSavegameVersionBefore(SLV_INDUSTRY_CARGO_REORGANISE)) LoadMoveAcceptsProduced(i);
 			Industry::IncIndustryTypeCount(i->type);

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -426,7 +426,7 @@ public:
 			/* Store the old persistent storage. The GRFID will be added later. */
 			assert(PersistentStorage::CanAllocateItem());
 			st->airport.psa = new PersistentStorage(0, 0, 0);
-			memcpy(st->airport.psa->storage, _old_st_persistent_storage.storage, sizeof(_old_st_persistent_storage.storage));
+			std::copy(std::begin(_old_st_persistent_storage.storage), std::end(_old_st_persistent_storage.storage), std::begin(st->airport.psa->storage));
 		}
 
 		size_t num_cargo = this->GetNumCargo();


### PR DESCRIPTION
## Motivation / Problem

Reducing use of C-style memory allocation and handling, memcpy, memset, sizeof, etc.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Replace the arrays/pointers in Persistent/TemporaryStorageArray with std::arrays instead. This allows for default blank initialization, and use of assignment operators to copy/reset the data. The constructors and destructors are no longer necessary.

Additionally the method "ResetToZero()" was never called, so is removed.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
