### PR TITLE
Fix: Cargo payment can no longer be exploited by "teleportation".

### DIFF
--- a/src/cargoaction.h
+++ b/src/cargoaction.h
@@ -39,9 +39,10 @@ public:
 class CargoDelivery : public CargoRemoval<VehicleCargoList> {
 protected:
 	CargoPayment *payment; ///< Payment object where payments will be registered.
+	TileIndex location;
 public:
-	CargoDelivery(VehicleCargoList *source, uint max_move, CargoPayment *payment) :
-			CargoRemoval<VehicleCargoList>(source, max_move), payment(payment) {}
+	CargoDelivery(VehicleCargoList *source, uint max_move, CargoPayment *payment, TileIndex location) :
+			CargoRemoval<VehicleCargoList>(source, max_move), payment(payment), location(location) {}
 	bool operator()(CargoPacket *cp);
 };
 
@@ -69,33 +70,39 @@ public:
 
 /** Action of transferring cargo from a vehicle to a station. */
 class CargoTransfer : public CargoMovement<VehicleCargoList, StationCargoList> {
+protected:
+	TileIndex location;
 public:
-	CargoTransfer(VehicleCargoList *source, StationCargoList *destination, uint max_move) :
-			CargoMovement<VehicleCargoList, StationCargoList>(source, destination, max_move) {}
+	CargoTransfer(VehicleCargoList *source, StationCargoList *destination, uint max_move, TileIndex location) :
+			CargoMovement<VehicleCargoList, StationCargoList>(source, destination, max_move), location(location) {}
 	bool operator()(CargoPacket *cp);
 };
 
 /** Action of loading cargo from a station onto a vehicle. */
 class CargoLoad : public CargoMovement<StationCargoList, VehicleCargoList> {
+protected:
+	TileIndex location;
 public:
-	CargoLoad(StationCargoList *source, VehicleCargoList *destination, uint max_move) :
-			CargoMovement<StationCargoList, VehicleCargoList>(source, destination, max_move) {}
+	CargoLoad(StationCargoList *source, VehicleCargoList *destination, uint max_move, TileIndex location) :
+			CargoMovement<StationCargoList, VehicleCargoList>(source, destination, max_move), location(location) {}
 	bool operator()(CargoPacket *cp);
 };
 
 /** Action of reserving cargo from a station to be loaded onto a vehicle. */
 class CargoReservation : public CargoLoad {
 public:
-	CargoReservation(StationCargoList *source, VehicleCargoList *destination, uint max_move) :
-			CargoLoad(source, destination, max_move) {}
+	CargoReservation(StationCargoList *source, VehicleCargoList *destination, uint max_move, TileIndex location) :
+			CargoLoad(source, destination, max_move, location) {}
 	bool operator()(CargoPacket *cp);
 };
 
 /** Action of returning previously reserved cargo from the vehicle to the station. */
 class CargoReturn : public CargoMovement<VehicleCargoList, StationCargoList> {
+protected:
+	TileIndex location;
 	StationID next;
 public:
-	CargoReturn(VehicleCargoList *source, StationCargoList *destination, uint max_move, StationID next) :
+	CargoReturn(VehicleCargoList *source, StationCargoList *destination, uint max_move, StationID next, TileIndex location) :
 			CargoMovement<VehicleCargoList, StationCargoList>(source, destination, max_move), next(next) {}
 	bool operator()(CargoPacket *cp);
 };

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1096,7 +1096,7 @@ static uint DeliverGoodsToIndustry(const Station *st, CargoID cargo_type, uint n
  * @param num_pieces amount of cargo delivered
  * @param cargo_type the type of cargo that is delivered
  * @param dest Station the cargo has been unloaded
- * @param source_tile The origin of the cargo for distance calculation
+ * @param distance The distance cargo travelled
  * @param periods_in_transit Travel time in cargo aging periods
  * @param company The company delivering the cargo
  * @param src_type Type of source of cargo (industry, town, headquarters)
@@ -1104,7 +1104,7 @@ static uint DeliverGoodsToIndustry(const Station *st, CargoID cargo_type, uint n
  * @return Revenue for delivering cargo
  * @note The cargo is just added to the stockpile of the industry. It is due to the caller to trigger the industry's production machinery
  */
-static Money DeliverGoods(int num_pieces, CargoID cargo_type, StationID dest, TileIndex source_tile, uint16_t periods_in_transit, Company *company, SourceType src_type, SourceID src)
+static Money DeliverGoods(int num_pieces, CargoID cargo_type, StationID dest, uint distance, uint16_t periods_in_transit, Company *company, SourceType src_type, SourceID src)
 {
 	assert(num_pieces > 0);
 
@@ -1131,7 +1131,7 @@ static Money DeliverGoods(int num_pieces, CargoID cargo_type, StationID dest, Ti
 	st->town->received[cs->town_effect].new_act += accepted_total;
 
 	/* Determine profit */
-	Money profit = GetTransportedGoodsIncome(accepted_total, DistanceManhattan(source_tile, st->xy), periods_in_transit, cargo_type);
+	Money profit = GetTransportedGoodsIncome(accepted_total, distance, periods_in_transit, cargo_type);
 
 	/* Update the cargo monitor. */
 	AddCargoDelivery(cargo_type, company->index, accepted_total - accepted_ind, src_type, src, st);
@@ -1225,15 +1225,16 @@ CargoPayment::~CargoPayment()
  * Handle payment for final delivery of the given cargo packet.
  * @param cp The cargo packet to pay for.
  * @param count The number of packets to pay for.
+ * @param distance The distance cargo travelled.
  */
-void CargoPayment::PayFinalDelivery(const CargoPacket *cp, uint count)
+void CargoPayment::PayFinalDelivery(const CargoPacket *cp, uint count, uint distance)
 {
 	if (this->owner == nullptr) {
 		this->owner = Company::Get(this->front->owner);
 	}
 
 	/* Handle end of route payment */
-	Money profit = DeliverGoods(count, this->ct, this->current_station, cp->GetSourceXY(), cp->GetPeriodsInTransit(), this->owner, cp->GetSourceType(), cp->GetSourceID());
+	Money profit = DeliverGoods(count, this->ct, this->current_station, distance, cp->GetPeriodsInTransit(), this->owner, cp->GetSourceType(), cp->GetSourceID());
 	this->route_profit += profit;
 
 	/* The vehicle's profit is whatever route profit there is minus feeder shares. */
@@ -1244,15 +1245,16 @@ void CargoPayment::PayFinalDelivery(const CargoPacket *cp, uint count)
  * Handle payment for transfer of the given cargo packet.
  * @param cp The cargo packet to pay for; actual payment won't be made!.
  * @param count The number of packets to pay for.
+ * @param location TileIndex if the point packet is unloaded at.
  * @return The amount of money paid for the transfer.
  */
-Money CargoPayment::PayTransfer(const CargoPacket *cp, uint count)
+Money CargoPayment::PayTransfer(const CargoPacket *cp, uint count, TileIndex location)
 {
 	Money profit = -cp->GetFeederShare(count) + GetTransportedGoodsIncome(
 			count,
 			/* pay transfer vehicle the difference between the payment for the journey from
 			 * the source to the current point, and the sum of the previous transfer payments */
-			DistanceManhattan(cp->GetSourceXY(), Station::Get(this->current_station)->xy),
+			DistanceManhattan(cp->GetMovement(), location),
 			cp->GetPeriodsInTransit(),
 			this->ct);
 
@@ -1294,7 +1296,8 @@ void PrepareUnload(Vehicle *front_v)
 						HasBit(ge->status, GoodsEntry::GES_ACCEPTANCE),
 						front_v->last_station_visited, next_station,
 						front_v->current_order.GetUnloadType(), ge,
-						front_v->cargo_payment);
+						front_v->cargo_payment,
+						v->tile);
 				if (v->cargo.UnloadCount() > 0) SetBit(v->vehicle_flags, VF_CARGO_UNLOADING);
 			}
 		}
@@ -1434,7 +1437,7 @@ struct ReturnCargoAction
 	 */
 	bool operator()(Vehicle *v)
 	{
-		v->cargo.Return(UINT_MAX, &this->st->goods[v->cargo_type].cargo, this->next_hop);
+		v->cargo.Return(UINT_MAX, &this->st->goods[v->cargo_type].cargo, this->next_hop, v->tile);
 		return true;
 	}
 };
@@ -1469,7 +1472,7 @@ struct FinalizeRefitAction
 	{
 		if (this->do_reserve) {
 			this->st->goods[v->cargo_type].cargo.Reserve(v->cargo_cap - v->cargo.RemainingCount(),
-					&v->cargo, this->next_station);
+					&v->cargo, this->next_station, v->tile);
 		}
 		this->consist_capleft[v->cargo_type] += v->cargo_cap - v->cargo.RemainingCount();
 		return true;
@@ -1560,7 +1563,7 @@ struct ReserveCargoAction {
 	{
 		if (v->cargo_cap > v->cargo.RemainingCount() && MayLoadUnderExclusiveRights(st, v)) {
 			st->goods[v->cargo_type].cargo.Reserve(v->cargo_cap - v->cargo.RemainingCount(),
-					&v->cargo, *next_station);
+					&v->cargo, *next_station, v->tile);
 		}
 
 		return true;
@@ -1694,7 +1697,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 					uint new_remaining = v->cargo.RemainingCount() + v->cargo.ActionCount(VehicleCargoList::MTA_DELIVER);
 					if (v->cargo_cap < new_remaining) {
 						/* Return some of the reserved cargo to not overload the vehicle. */
-						v->cargo.Return(new_remaining - v->cargo_cap, &ge->cargo, INVALID_STATION);
+						v->cargo.Return(new_remaining - v->cargo_cap, &ge->cargo, INVALID_STATION, v->tile);
 					}
 
 					/* Keep instead of delivering. This may lead to no cargo being unloaded, so ...*/
@@ -1721,7 +1724,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 				}
 			}
 
-			amount_unloaded = v->cargo.Unload(amount_unloaded, &ge->cargo, payment);
+			amount_unloaded = v->cargo.Unload(amount_unloaded, &ge->cargo, payment, v->tile);
 			remaining = v->cargo.UnloadCount() > 0;
 			if (amount_unloaded > 0) {
 				dirty_vehicle = true;
@@ -1791,7 +1794,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 				if (v->cargo.StoredCount() == 0) TriggerVehicle(v, VEHICLE_TRIGGER_NEW_CARGO);
 				if (_settings_game.order.gradual_loading) cap_left = std::min(cap_left, GetLoadAmount(v));
 
-				uint loaded = ge->cargo.Load(cap_left, &v->cargo, next_station);
+				uint loaded = ge->cargo.Load(cap_left, &v->cargo, next_station, v->tile);
 				if (v->cargo.ActionCount(VehicleCargoList::MTA_LOAD) > 0) {
 					/* Remember if there are reservations left so that we don't stop
 					 * loading before they're loaded. */

--- a/src/economy_base.h
+++ b/src/economy_base.h
@@ -37,8 +37,8 @@ struct CargoPayment : CargoPaymentPool::PoolItem<&_cargo_payment_pool> {
 	CargoPayment(Vehicle *front);
 	~CargoPayment();
 
-	Money PayTransfer(const CargoPacket *cp, uint count);
-	void PayFinalDelivery(const CargoPacket *cp, uint count);
+	Money PayTransfer(const CargoPacket *cp, uint count, TileIndex location);
+	void PayFinalDelivery(const CargoPacket *cp, uint count, uint distance);
 
 	/**
 	 * Sets the currently handled cargo type.

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3241,6 +3241,24 @@ bool AfterLoadGame()
 		}
 	}
 
+	if (IsSavegameVersionBefore(SLV_UNPAID_TELEPORTATION)) {
+		/* Convert source location into a movement vector by calling TrackUnload.
+		 * This emulates transportation by the vehicle from stored source location to the current station.
+		 * Cargo packets in vehicles don't need conversion as movement vector is equivalent
+		 * to the source location when in the vehicle.
+		 */
+		for (Station *st : Station::Iterate()) {
+			for (size_t i = 0; i < NUM_CARGO; i++) {
+				GoodsEntry *ge = &st->goods[i];
+				for (auto it = ge->cargo.Packets()->begin(); it != ge->cargo.Packets()->end(); it++) {
+					for (CargoPacket *cp : it->second) {
+						cp->TrackUnload(cp->GetMovement());
+					}
+				}
+			}
+		}
+	}
+
 	AfterLoadLabelMaps();
 	AfterLoadCompanyStats();
 	AfterLoadStoryBook();

--- a/src/saveload/cargopacket_sl.cpp
+++ b/src/saveload/cargopacket_sl.cpp
@@ -24,7 +24,7 @@
 {
 	if (IsSavegameVersionBefore(SLV_44)) {
 		/* If we remove a station while cargo from it is still en route, payment calculation will assume
-		 * 0, 0 to be the source of the cargo, resulting in very high payments usually. v->source_xy
+		 * 0, 0 to be the source of the cargo, resulting in very high payments usually. v->source_position
 		 * stores the coordinates, preserving them even if the station is removed. However, if a game is loaded
 		 * where this situation exists, the cargo-source information is lost. in this case, we set the source
 		 * to the current tile of the vehicle to prevent excessive profits
@@ -33,7 +33,7 @@
 			const CargoPacketList *packets = v->cargo.Packets();
 			for (VehicleCargoList::ConstIterator it(packets->begin()); it != packets->end(); it++) {
 				CargoPacket *cp = *it;
-				cp->source_xy = Station::IsValidID(cp->first_station) ? Station::Get(cp->first_station)->xy : v->tile;
+				cp->movement = Station::IsValidID(cp->first_station) ? Station::Get(cp->first_station)->xy : v->tile;
 			}
 		}
 
@@ -49,7 +49,7 @@
 				const StationCargoPacketMap *packets = ge->cargo.Packets();
 				for (StationCargoList::ConstIterator it(packets->begin()); it != packets->end(); it++) {
 					CargoPacket *cp = *it;
-					cp->source_xy = Station::IsValidID(cp->first_station) ? Station::Get(cp->first_station)->xy : st->xy;
+					cp->movement = Station::IsValidID(cp->first_station) ? Station::Get(cp->first_station)->xy : st->xy;
 				}
 			}
 		}
@@ -87,7 +87,7 @@ SaveLoadTable GetCargoPacketDesc()
 {
 	static const SaveLoad _cargopacket_desc[] = {
 		SLE_VARNAME(CargoPacket, first_station, "source", SLE_UINT16),
-		SLE_VAR(CargoPacket, source_xy,       SLE_UINT32),
+		SLE_VARNAME(CargoPacket, movement, "source_xy", SLE_UINT32),
 		SLE_VAR(CargoPacket, count,           SLE_UINT16),
 		SLE_CONDVARNAME(CargoPacket, periods_in_transit, "days_in_transit", SLE_FILE_U8 | SLE_VAR_U16, SL_MIN_VERSION, SLV_MORE_CARGO_AGE),
 		SLE_CONDVARNAME(CargoPacket, periods_in_transit, "days_in_transit", SLE_UINT16, SLV_MORE_CARGO_AGE, SLV_PERIODS_IN_TRANSIT_RENAME),

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -360,6 +360,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_PERIODS_IN_TRANSIT_RENAME,          ///< 316  PR#11112 Rename days in transit to (cargo) periods in transit.
 	SLV_NEWGRF_LAST_SERVICE,                ///< 317  PR#11124 Added stable date_of_last_service to avoid NewGRF trouble.
 	SLV_REMOVE_LOADED_AT_XY,                ///< 318  PR#11276 Remove loaded_at_xy variable from CargoPacket.
+	SLV_UNPAID_TELEPORTATION,               ///< 319  PR#11274 Don't pay for cargo movement outside of the vehicle (teleportation).
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4039,7 +4039,7 @@ static uint UpdateStationWaiting(Station *st, CargoID type, uint amount, SourceT
 	if (amount == 0) return 0;
 
 	StationID next = ge.GetVia(st->index);
-	ge.cargo.Append(new CargoPacket(st->index, st->xy, amount, source_type, source_id), next);
+	ge.cargo.Append(new CargoPacket(st->index, 0, amount, source_type, source_id), next);
 	LinkGraph *lg = nullptr;
 	if (ge.link_graph == INVALID_LINK_GRAPH) {
 		if (LinkGraph::CanAllocateItem()) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2241,7 +2241,7 @@ void Vehicle::CancelReservation(StationID next, Station *st)
 		VehicleCargoList &cargo = v->cargo;
 		if (cargo.ActionCount(VehicleCargoList::MTA_LOAD) > 0) {
 			Debug(misc, 1, "cancelling cargo reservation");
-			cargo.Return(UINT_MAX, &st->goods[v->cargo_type].cargo, next);
+			cargo.Return(UINT_MAX, &st->goods[v->cargo_type].cargo, next, v->tile);
 		}
 		cargo.KeepAll();
 	}


### PR DESCRIPTION
## Motivation / Problem

Cargo payment is calculated between station signs, but it can freely move within (and with) the station enabling various exploits.
- Station sign manipulation.
![Screenshot from 2023-09-09 00-57-21](https://github.com/OpenTTD/OpenTTD/assets/413570/c9ef4d30-991e-4927-bd82-50570fe0292e)
- Station spreading abuse
![Screenshot from 2023-09-09 00-49-56](https://github.com/OpenTTD/OpenTTD/assets/413570/cb233704-bc3f-45a5-a467-1676b6dbe7de)
- Station walking abuse. (Move station by building and removing parts. Cargo keeps the source location.)

## Description

This pr makes it so that only cargo movement with the vehicle is counted toward the payment. It is achieved by storing source position as a direction(vector) when on station. Thus it is the same regardless of where it was loaded in the vehicle and keeps the same accumulated distance. When in the vehicle it's still stored as location so is not affected by vehicle path. Conversion between location and direction is happening when loading and unloading using position of the vehicle as a reference point. Distance to the industry is not taken into account and station sign position no longer has any effect.

Another way to view the accumulated value is as a sum of vectors for each vehicle route (between loading and unloading tile). And it's calculated along the vehicle route: `start1 - end1 + start2 - end2 +...` so each `+ start` makes location(point), each `- end` makes direction(vector).

Should not have any significant effect on regular games that don't abuse station spread.

Save I used to test exploits: [teleport-exploit.zip](https://github.com/OpenTTD/OpenTTD/files/12567985/teleport-exploit.zip)

## Limitations

- There is still some minor abusing possible by reversing long trains in place.
- Cheesing the distance between industries is still possible by placing stations further than they need to be.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* ~~The bug fix is important enough to be backported? (label: 'backport requested')~~
* ~~This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)~~
* **This PR affects the save game format? (label 'savegame upgrade')**
* ~~This PR affects the GS/AI API? (label 'needs review: Script API')~~
    * ~~ai_changelog.hpp, game_changelog.hpp need updating.~~
    * ~~The compatibility wrappers (compat_*.nut) need updating.~~
* ~~This PR affects the NewGRF API? (label 'needs review: NewGRF')~~
    * ~~newgrf_debug_data.h may need updating.~~
    * ~~[PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)~~
