### PR TITLE
Fix: crash when opening a damaged base-graphics

### DIFF
--- a/src/random_access_file.cpp
+++ b/src/random_access_file.cpp
@@ -146,9 +146,10 @@ void RandomAccessFile::ReadBlock(void *ptr, size_t size)
  * Skip \a n bytes ahead in the file.
  * @param n Number of bytes to skip reading.
  */
-void RandomAccessFile::SkipBytes(int n)
+void RandomAccessFile::SkipBytes(size_t n)
 {
-	int remaining = this->buffer_end - this->buffer;
+	assert(this->buffer_end >= this->buffer);
+	size_t remaining = this->buffer_end - this->buffer;
 	if (n <= remaining) {
 		this->buffer += n;
 	} else {

--- a/src/random_access_file_type.h
+++ b/src/random_access_file_type.h
@@ -51,7 +51,7 @@ public:
 	uint32_t ReadDword();
 
 	void ReadBlock(void *ptr, size_t size);
-	void SkipBytes(int n);
+	void SkipBytes(size_t n);
 };
 
 #endif /* RANDOM_ACCESS_FILE_TYPE_H */


### PR DESCRIPTION
## Motivation / Problem

Fixes #10950.

## Description

So this is a bit of a funny one ... `RandomAccessFile::SkipBytes` had `int` as parameter, but all calls use `uint`. Which brings us the delightful possibility that some code reads some random garbage from a file, and does a `SkipBytes(1 << 31 + n)`, which is translated to a negative number in `SkipBytes`, which changes `buffer` to a random pointer far far far before the actual buffer.

And this can result in crashes. Or even more random garbage. It depends. Who knows. Hard to tell. Broken? Yes.

Resolve this by changing the type of the parameter to `size_t`, similar to the other functions on `RandomAccessFile` like `SeekTo`.

I checked all callers of `SkipBytes`, and they are always unsigned. Sometimes 16-bit, sometimes 32-bit, but always unsigned. So `size_t` will do fine here.

PS: added an assert to confirm `buffer` is smaller (or equal) to `buffer_end`, just for good measure. But the current code doesn't allow for any other possibility.

## Limitations

The original ticket ran into this issue, and by pure luck I could reproduce it easily. But you really need to hit a large number for `SkipBytes` (so it becomes negative) to hit this one. The rest of the code deals with very large `SkipBytes` just fine, and all `ReadNNN` start to poop out zeros. Some code eventually will decide that is bad, and an error is printed to the user.
A far nicer solution is added by NewGRF's `ReadByte`, which throws an exception when it reads past the end of buffer/file. But I wanted to address the segfault; not rework the whole `RandomAccessFile` :)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
