### PR TITLE
Codechange: remove loaded_at_xy from CargoPacket as it was unused

### DIFF
--- a/src/cargoaction.cpp
+++ b/src/cargoaction.cpp
@@ -120,7 +120,6 @@ bool CargoLoad::operator()(CargoPacket *cp)
 {
 	CargoPacket *cp_new = this->Preprocess(cp);
 	if (cp_new == nullptr) return false;
-	cp_new->SetLoadPlace(this->load_place);
 	this->source->RemoveFromCache(cp_new, cp_new->Count());
 	this->destination->Append(cp_new, VehicleCargoList::MTA_KEEP);
 	return cp_new == cp;
@@ -135,7 +134,6 @@ bool CargoReservation::operator()(CargoPacket *cp)
 {
 	CargoPacket *cp_new = this->Preprocess(cp);
 	if (cp_new == nullptr) return false;
-	cp_new->SetLoadPlace(this->load_place);
 	this->source->reserved_count += cp_new->Count();
 	this->source->RemoveFromCache(cp_new, cp_new->Count());
 	this->destination->Append(cp_new, VehicleCargoList::MTA_LOAD);

--- a/src/cargoaction.h
+++ b/src/cargoaction.h
@@ -77,19 +77,17 @@ public:
 
 /** Action of loading cargo from a station onto a vehicle. */
 class CargoLoad : public CargoMovement<StationCargoList, VehicleCargoList> {
-protected:
-	TileIndex load_place; ///< TileIndex to be saved in the packets' loaded_at_xy.
 public:
-	CargoLoad(StationCargoList *source, VehicleCargoList *destination, uint max_move, TileIndex load_place) :
-			CargoMovement<StationCargoList, VehicleCargoList>(source, destination, max_move), load_place(load_place) {}
+	CargoLoad(StationCargoList *source, VehicleCargoList *destination, uint max_move) :
+			CargoMovement<StationCargoList, VehicleCargoList>(source, destination, max_move) {}
 	bool operator()(CargoPacket *cp);
 };
 
 /** Action of reserving cargo from a station to be loaded onto a vehicle. */
 class CargoReservation : public CargoLoad {
 public:
-	CargoReservation(StationCargoList *source, VehicleCargoList *destination, uint max_move, TileIndex load_place) :
-			CargoLoad(source, destination, max_move, load_place) {}
+	CargoReservation(StationCargoList *source, VehicleCargoList *destination, uint max_move) :
+			CargoLoad(source, destination, max_move) {}
 	bool operator()(CargoPacket *cp);
 };
 

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -35,13 +35,6 @@ class StationCargoList; // forward-declare, so we can use it in VehicleCargoList
 extern SaveLoadTable GetCargoPacketDesc();
 
 /**
- * To make alignment in the union in CargoPacket a bit easier, create a new type
- * that is a StationID, but stored as 32bit.
- */
-typedef uint32_t StationID_32bit;
-static_assert(sizeof(TileIndex) == sizeof(StationID_32bit));
-
-/**
  * Container for cargo from the same location and time.
  */
 struct CargoPacket : CargoPacketPool::PoolItem<&_cargopacket_pool> {
@@ -50,10 +43,7 @@ private:
 	uint16_t periods_in_transit; ///< Amount of cargo aging periods this packet has been in transit.
 	Money feeder_share;     ///< Value of feeder pickup to be paid for on delivery of cargo.
 	TileIndex source_xy;    ///< The origin of the cargo (first station in feeder chain).
-	union {
-		TileIndex loaded_at_xy;       ///< Location where this cargo has been loaded into the vehicle.
-		StationID_32bit next_station; ///< Station where the cargo wants to go next.
-	};
+	StationID next_station; ///< Station where the cargo wants to go next.
 	SourceID source_id;     ///< Index of source, INVALID_SOURCE if unknown/invalid.
 	StationID source;       ///< The station where the cargo came from first.
 	SourceType source_type; ///< Type of \c source_id.
@@ -70,7 +60,7 @@ public:
 
 	CargoPacket();
 	CargoPacket(StationID source, TileIndex source_xy, uint16_t count, SourceType source_type, SourceID source_id);
-	CargoPacket(uint16_t count, uint16_t periods_in_transit, StationID source, TileIndex source_xy, TileIndex loaded_at_xy, Money feeder_share = 0, SourceType source_type = SourceType::Industry, SourceID source_id = INVALID_SOURCE);
+	CargoPacket(uint16_t count, uint16_t periods_in_transit, StationID source, TileIndex source_xy, Money feeder_share = 0, SourceType source_type = SourceType::Industry, SourceID source_id = INVALID_SOURCE);
 
 	/** Destroy the packet. */
 	~CargoPacket() { }
@@ -78,12 +68,6 @@ public:
 	CargoPacket *Split(uint new_size);
 	void Merge(CargoPacket *cp);
 	void Reduce(uint count);
-
-	/**
-	 * Sets the tile where the packet was loaded last.
-	 * @param load_place Tile where the packet was loaded last.
-	 */
-	void SetLoadPlace(TileIndex load_place) { this->loaded_at_xy = load_place; }
 
 	/**
 	 * Sets the station where the packet is supposed to go next.
@@ -173,15 +157,6 @@ public:
 	inline TileIndex SourceStationXY() const
 	{
 		return this->source_xy;
-	}
-
-	/**
-	 * Gets the coordinates of the cargo's last loading station.
-	 * @return Last loading station's coordinates.
-	 */
-	inline TileIndex LoadedAtXY() const
-	{
-		return this->loaded_at_xy;
 	}
 
 	/**
@@ -401,8 +376,6 @@ public:
 
 	void InvalidateCache();
 
-	void SetTransferLoadPlace(TileIndex xy);
-
 	bool Stage(bool accepted, StationID current_station, StationIDStack next_station, uint8_t order_flags, const GoodsEntry *ge, CargoPayment *payment);
 
 	/**
@@ -440,8 +413,7 @@ public:
 		return cp1->source_xy == cp2->source_xy &&
 				cp1->periods_in_transit == cp2->periods_in_transit &&
 				cp1->source_type == cp2->source_type &&
-				cp1->source_id == cp2->source_id &&
-				cp1->loaded_at_xy == cp2->loaded_at_xy;
+				cp1->source_id == cp2->source_id;
 	}
 };
 
@@ -538,8 +510,8 @@ public:
 	 * amount of cargo to be moved. Second parameter is destination (if
 	 * applicable), return value is amount of cargo actually moved. */
 
-	uint Reserve(uint max_move, VehicleCargoList *dest, TileIndex load_place, StationIDStack next);
-	uint Load(uint max_move, VehicleCargoList *dest, TileIndex load_place, StationIDStack next);
+	uint Reserve(uint max_move, VehicleCargoList *dest, StationIDStack next);
+	uint Load(uint max_move, VehicleCargoList *dest, StationIDStack next);
 	uint Truncate(uint max_move = UINT_MAX, StationCargoAmountMap *cargo_per_source = nullptr);
 	uint Reroute(uint max_move, StationCargoList *dest, StationID avoid, StationID avoid2, const GoodsEntry *ge);
 

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1469,7 +1469,7 @@ struct FinalizeRefitAction
 	{
 		if (this->do_reserve) {
 			this->st->goods[v->cargo_type].cargo.Reserve(v->cargo_cap - v->cargo.RemainingCount(),
-					&v->cargo, st->xy, this->next_station);
+					&v->cargo, this->next_station);
 		}
 		this->consist_capleft[v->cargo_type] += v->cargo_cap - v->cargo.RemainingCount();
 		return true;
@@ -1560,7 +1560,7 @@ struct ReserveCargoAction {
 	{
 		if (v->cargo_cap > v->cargo.RemainingCount() && MayLoadUnderExclusiveRights(st, v)) {
 			st->goods[v->cargo_type].cargo.Reserve(v->cargo_cap - v->cargo.RemainingCount(),
-					&v->cargo, st->xy, *next_station);
+					&v->cargo, *next_station);
 		}
 
 		return true;
@@ -1791,7 +1791,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 				if (v->cargo.StoredCount() == 0) TriggerVehicle(v, VEHICLE_TRIGGER_NEW_CARGO);
 				if (_settings_game.order.gradual_loading) cap_left = std::min(cap_left, GetLoadAmount(v));
 
-				uint loaded = ge->cargo.Load(cap_left, &v->cargo, st->xy, next_station);
+				uint loaded = ge->cargo.Load(cap_left, &v->cargo, next_station);
 				if (v->cargo.ActionCount(VehicleCargoList::MTA_LOAD) > 0) {
 					/* Remember if there are reservations left so that we don't stop
 					 * loading before they're loaded. */

--- a/src/saveload/cargopacket_sl.cpp
+++ b/src/saveload/cargopacket_sl.cpp
@@ -34,7 +34,6 @@
 			for (VehicleCargoList::ConstIterator it(packets->begin()); it != packets->end(); it++) {
 				CargoPacket *cp = *it;
 				cp->source_xy = Station::IsValidID(cp->source) ? Station::Get(cp->source)->xy : v->tile;
-				cp->loaded_at_xy = cp->source_xy;
 			}
 		}
 
@@ -51,7 +50,6 @@
 				for (StationCargoList::ConstIterator it(packets->begin()); it != packets->end(); it++) {
 					CargoPacket *cp = *it;
 					cp->source_xy = Station::IsValidID(cp->source) ? Station::Get(cp->source)->xy : st->xy;
-					cp->loaded_at_xy = cp->source_xy;
 				}
 			}
 		}
@@ -90,7 +88,6 @@ SaveLoadTable GetCargoPacketDesc()
 	static const SaveLoad _cargopacket_desc[] = {
 		SLE_VAR(CargoPacket, source,          SLE_UINT16),
 		SLE_VAR(CargoPacket, source_xy,       SLE_UINT32),
-		SLE_VAR(CargoPacket, loaded_at_xy,    SLE_UINT32),
 		SLE_VAR(CargoPacket, count,           SLE_UINT16),
 		SLE_CONDVARNAME(CargoPacket, periods_in_transit, "days_in_transit", SLE_FILE_U8 | SLE_VAR_U16, SL_MIN_VERSION, SLV_MORE_CARGO_AGE),
 		SLE_CONDVARNAME(CargoPacket, periods_in_transit, "days_in_transit", SLE_UINT16, SLV_MORE_CARGO_AGE, SLV_PERIODS_IN_TRANSIT_RENAME),

--- a/src/saveload/compat/cargopacket_sl_compat.h
+++ b/src/saveload/compat/cargopacket_sl_compat.h
@@ -16,7 +16,7 @@
 const SaveLoadCompat _cargopacket_sl_compat[] = {
 	SLC_VAR("source"),
 	SLC_VAR("source_xy"),
-	SLC_VAR("loaded_at_xy"),
+	SLC_NULL(4, SL_MIN_VERSION, SLV_REMOVE_LOADED_AT_XY),
 	SLC_VAR("count"),
 	SLC_VAR("days_in_transit"),
 	SLC_VAR("feeder_share"),

--- a/src/saveload/compat/vehicle_sl_compat.h
+++ b/src/saveload/compat/vehicle_sl_compat.h
@@ -82,7 +82,7 @@ const SaveLoadCompat _vehicle_common_sl_compat[] = {
 	SLC_VAR("profit_this_year"),
 	SLC_VAR("profit_last_year"),
 	SLC_VAR("cargo_feeder_share"),
-	SLC_VAR("cargo_loaded_at_xy"),
+	SLC_NULL(4, SLV_51, SLV_68),
 	SLC_VAR("value"),
 	SLC_VAR("random_bits"),
 	SLC_VAR("waiting_triggers"),

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -1353,7 +1353,7 @@ bool LoadOldVehicle(LoadgameState *ls, int num)
 		if (_cargo_count != 0 && CargoPacket::CanAllocateItem()) {
 			StationID source =    (_cargo_source == 0xFF) ? INVALID_STATION : _cargo_source;
 			TileIndex source_xy = (source != INVALID_STATION) ? Station::Get(source)->xy : (TileIndex)0;
-			v->cargo.Append(new CargoPacket(_cargo_count, _cargo_periods, source, source_xy, source_xy));
+			v->cargo.Append(new CargoPacket(_cargo_count, _cargo_periods, source, source_xy));
 		}
 	}
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -359,6 +359,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_INDUSTRY_CARGO_REORGANISE,          ///< 315  PR#10853 Industry accepts/produced data reorganised.
 	SLV_PERIODS_IN_TRANSIT_RENAME,          ///< 316  PR#11112 Rename days in transit to (cargo) periods in transit.
 	SLV_NEWGRF_LAST_SERVICE,                ///< 317  PR#11124 Added stable date_of_last_service to avoid NewGRF trouble.
+	SLV_REMOVE_LOADED_AT_XY,                ///< 318  PR#11276 Remove loaded_at_xy variable from CargoPacket.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -449,7 +449,7 @@ public:
 					assert(CargoPacket::CanAllocateItem());
 
 					/* Don't construct the packet with station here, because that'll fail with old savegames */
-					CargoPacket *cp = new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, source, _cargo_source_xy, _cargo_source_xy, _cargo_feeder_share);
+					CargoPacket *cp = new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, source, _cargo_source_xy, _cargo_feeder_share);
 					ge->cargo.Append(cp, INVALID_STATION);
 					SB(ge->status, GoodsEntry::GES_RATING, 1, 1);
 				}

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -577,7 +577,6 @@ static uint32_t _cargo_source_xy;
 static uint16_t _cargo_count;
 static uint16_t _cargo_paid_for;
 static Money  _cargo_feeder_share;
-static uint32_t _cargo_loaded_at_xy;
 
 class SlVehicleCommon : public DefaultSaveLoadHandler<SlVehicleCommon, Vehicle> {
 public:
@@ -699,7 +698,6 @@ public:
 		SLE_CONDVAR(Vehicle, profit_last_year,      SLE_INT64,                   SLV_65, SL_MAX_VERSION),
 		SLEG_CONDVAR("cargo_feeder_share", _cargo_feeder_share, SLE_FILE_I32 | SLE_VAR_I64,  SLV_51,  SLV_65),
 		SLEG_CONDVAR("cargo_feeder_share", _cargo_feeder_share, SLE_INT64,                   SLV_65,  SLV_68),
-		SLEG_CONDVAR("cargo_loaded_at_xy", _cargo_loaded_at_xy, SLE_UINT32,                  SLV_51,  SLV_68),
 		SLE_CONDVAR(Vehicle, value,                 SLE_FILE_I32 | SLE_VAR_I64,   SL_MIN_VERSION,  SLV_65),
 		SLE_CONDVAR(Vehicle, value,                 SLE_INT64,                   SLV_65, SL_MAX_VERSION),
 
@@ -1043,7 +1041,7 @@ struct VEHSChunkHandler : ChunkHandler {
 
 			if (_cargo_count != 0 && IsCompanyBuildableVehicleType(v) && CargoPacket::CanAllocateItem()) {
 				/* Don't construct the packet with station here, because that'll fail with old savegames */
-				CargoPacket *cp = new CargoPacket(_cargo_count, _cargo_periods, _cargo_source, _cargo_source_xy, _cargo_loaded_at_xy, _cargo_feeder_share);
+				CargoPacket *cp = new CargoPacket(_cargo_count, _cargo_periods, _cargo_source, _cargo_source_xy, _cargo_feeder_share);
 				v->cargo.Append(cp);
 			}
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2242,7 +2242,6 @@ void Vehicle::CancelReservation(StationID next, Station *st)
 		if (cargo.ActionCount(VehicleCargoList::MTA_LOAD) > 0) {
 			Debug(misc, 1, "cancelling cargo reservation");
 			cargo.Return(UINT_MAX, &st->goods[v->cargo_type].cargo, next);
-			cargo.SetTransferLoadPlace(st->xy);
 		}
 		cargo.KeepAll();
 	}


### PR DESCRIPTION
## Motivation / Problem

In 2fee030a26996a167adbf28f96fca8c4fd749005 the last usage of `LoadedAtXY` was removed, and unbeknown to the author, left for a whole strain of code that can be removed from our codebase.

## Description

Removing `LoadedAtXY` leads to removing a lot of `loaded_at_xy` (or sometimes called `load_place`) throughout the code. This also cleans up a very odd `union` in `CargoPacket`, which should make everyone really happy.


## Limitations

This PR doesn't need a savegame bump, although for simplicity I did do it anyway:

- Savegames are header-based: if you present a savegame which still has `loaded_at_xy`, it is just ignored by this PR.
- If you load a savegame made after this PR in an older OpenTTD, it will not find `loaded_at_xy`, and as such not set it. Sadly, it was never explicitly set, so it will get some random value. But as it isn't used, that doesn't matter.

The only place that is a bit of an argument, is the compatibility loader. As before we had headers, we did need to tell the system when fields needed to be skipped. So that could be pinned to the version that changed the savegame to contain headers.

But, the second reason above was enough reason for me to say: no, let's just bump the savegame. Versions are cheap, and we prevent someone in a few weeks / months go: when I load this game in an older OpenTTD, I have uninitialized memory!!! or something. Simplicity comes first. But you can disagree on this, so let me know if you do :)


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
