### PR TITLE
Codechange: cleanup CargoPacket in terms of variable/function names 

### DIFF
--- a/src/aircraft_gui.cpp
+++ b/src/aircraft_gui.cpp
@@ -56,10 +56,10 @@ void DrawAircraftDetails(const Aircraft *v, const Rect &r)
 				/* Cargo names (fix pluralness) */
 				SetDParam(0, u->cargo_type);
 				SetDParam(1, cargo_count);
-				SetDParam(2, u->cargo.Source());
+				SetDParam(2, u->cargo.GetFirstStation());
 				DrawString(r.left, r.right, y, STR_VEHICLE_DETAILS_CARGO_FROM);
 				y += FONT_HEIGHT_NORMAL;
-				feeder_share += u->cargo.FeederShare();
+				feeder_share += u->cargo.GetFeederShare();
 			}
 		}
 	}

--- a/src/cargoaction.cpp
+++ b/src/cargoaction.cpp
@@ -167,7 +167,7 @@ bool CargoTransfer::operator()(CargoPacket *cp)
 	if (cp_new == nullptr) return false;
 	this->source->RemoveFromMeta(cp_new, VehicleCargoList::MTA_TRANSFER, cp_new->Count());
 	/* No transfer credits here as they were already granted during Stage(). */
-	this->destination->Append(cp_new, cp_new->NextStation());
+	this->destination->Append(cp_new, cp_new->GetNextStation());
 	return cp_new == cp;
 }
 
@@ -194,7 +194,7 @@ bool StationCargoReroute::operator()(CargoPacket *cp)
 {
 	CargoPacket *cp_new = this->Preprocess(cp);
 	if (cp_new == nullptr) cp_new = cp;
-	StationID next = this->ge->GetVia(cp_new->SourceStation(), this->avoid, this->avoid2);
+	StationID next = this->ge->GetVia(cp_new->GetFirstStation(), this->avoid, this->avoid2);
 	assert(next != this->avoid && next != this->avoid2);
 	if (this->source != this->destination) {
 		this->source->RemoveFromCache(cp_new, cp_new->Count());
@@ -217,8 +217,8 @@ bool VehicleCargoReroute::operator()(CargoPacket *cp)
 {
 	CargoPacket *cp_new = this->Preprocess(cp);
 	if (cp_new == nullptr) cp_new = cp;
-	if (cp_new->NextStation() == this->avoid || cp_new->NextStation() == this->avoid2) {
-		cp->SetNextStation(this->ge->GetVia(cp_new->SourceStation(), this->avoid, this->avoid2));
+	if (cp_new->GetNextStation() == this->avoid || cp_new->GetNextStation() == this->avoid2) {
+		cp->SetNextStation(this->ge->GetVia(cp_new->GetFirstStation(), this->avoid, this->avoid2));
 	}
 	if (this->source != this->destination) {
 		this->source->RemoveFromMeta(cp_new, VehicleCargoList::MTA_TRANSFER, cp_new->Count());

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1233,11 +1233,11 @@ void CargoPayment::PayFinalDelivery(const CargoPacket *cp, uint count)
 	}
 
 	/* Handle end of route payment */
-	Money profit = DeliverGoods(count, this->ct, this->current_station, cp->SourceStationXY(), cp->PeriodsInTransit(), this->owner, cp->SourceSubsidyType(), cp->SourceSubsidyID());
+	Money profit = DeliverGoods(count, this->ct, this->current_station, cp->GetSourceXY(), cp->GetPeriodsInTransit(), this->owner, cp->GetSourceType(), cp->GetSourceID());
 	this->route_profit += profit;
 
 	/* The vehicle's profit is whatever route profit there is minus feeder shares. */
-	this->visual_profit += profit - cp->FeederShare(count);
+	this->visual_profit += profit - cp->GetFeederShare(count);
 }
 
 /**
@@ -1248,12 +1248,12 @@ void CargoPayment::PayFinalDelivery(const CargoPacket *cp, uint count)
  */
 Money CargoPayment::PayTransfer(const CargoPacket *cp, uint count)
 {
-	Money profit = -cp->FeederShare(count) + GetTransportedGoodsIncome(
+	Money profit = -cp->GetFeederShare(count) + GetTransportedGoodsIncome(
 			count,
 			/* pay transfer vehicle the difference between the payment for the journey from
 			 * the source to the current point, and the sum of the previous transfer payments */
-			DistanceManhattan(cp->SourceStationXY(), Station::Get(this->current_station)->xy),
-			cp->PeriodsInTransit(),
+			DistanceManhattan(cp->GetSourceXY(), Station::Get(this->current_station)->xy),
+			cp->GetPeriodsInTransit(),
 			this->ct);
 
 	profit = profit * _settings_game.economy.feeder_payment_share / 100;

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -823,7 +823,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 		case 0x3B: return GB(v->cargo_cap, 8, 8);
 		case 0x3C: return ClampTo<uint16_t>(v->cargo.StoredCount());
 		case 0x3D: return GB(ClampTo<uint16_t>(v->cargo.StoredCount()), 8, 8);
-		case 0x3E: return v->cargo.Source();
+		case 0x3E: return v->cargo.GetFirstStation();
 		case 0x3F: return ClampTo<uint8_t>(v->cargo.PeriodsInTransit());
 		case 0x40: return ClampTo<uint16_t>(v->age);
 		case 0x41: return GB(ClampTo<uint16_t>(v->age), 8, 8);

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -445,7 +445,7 @@ uint32_t Station::GetNewGRFVariable(const ResolverObject &object, byte variable,
 			case 1: return GB(std::min(g->cargo.TotalCount(), 4095u), 0, 4) | (GB(g->status, GoodsEntry::GES_ACCEPTANCE, 1) << 7);
 			case 2: return g->time_since_pickup;
 			case 3: return g->rating;
-			case 4: return g->cargo.Source();
+			case 4: return g->cargo.GetFirstStation();
 			case 5: return g->cargo.PeriodsInTransit();
 			case 6: return g->last_speed;
 			case 7: return g->last_age;

--- a/src/roadveh_gui.cpp
+++ b/src/roadveh_gui.cpp
@@ -81,9 +81,9 @@ void DrawRoadVehDetails(const Vehicle *v, const Rect &r)
 			if (u->cargo.StoredCount() > 0) {
 				SetDParam(0, u->cargo_type);
 				SetDParam(1, u->cargo.StoredCount());
-				SetDParam(2, u->cargo.Source());
+				SetDParam(2, u->cargo.GetFirstStation());
 				str = STR_VEHICLE_DETAILS_CARGO_FROM;
-				feeder_share += u->cargo.FeederShare();
+				feeder_share += u->cargo.GetFeederShare();
 			}
 			DrawString(r.left, r.right, y, str);
 			y += FONT_HEIGHT_NORMAL;
@@ -100,9 +100,9 @@ void DrawRoadVehDetails(const Vehicle *v, const Rect &r)
 		if (v->cargo.StoredCount() > 0) {
 			SetDParam(0, v->cargo_type);
 			SetDParam(1, v->cargo.StoredCount());
-			SetDParam(2, v->cargo.Source());
+			SetDParam(2, v->cargo.GetFirstStation());
 			str = STR_VEHICLE_DETAILS_CARGO_FROM;
-			feeder_share += v->cargo.FeederShare();
+			feeder_share += v->cargo.GetFeederShare();
 		}
 		DrawString(r.left, r.right, y, str);
 		y += FONT_HEIGHT_NORMAL + WidgetDimensions::scaled.vsep_normal;

--- a/src/saveload/cargopacket_sl.cpp
+++ b/src/saveload/cargopacket_sl.cpp
@@ -33,7 +33,7 @@
 			const CargoPacketList *packets = v->cargo.Packets();
 			for (VehicleCargoList::ConstIterator it(packets->begin()); it != packets->end(); it++) {
 				CargoPacket *cp = *it;
-				cp->source_xy = Station::IsValidID(cp->source) ? Station::Get(cp->source)->xy : v->tile;
+				cp->source_xy = Station::IsValidID(cp->first_station) ? Station::Get(cp->first_station)->xy : v->tile;
 			}
 		}
 
@@ -49,7 +49,7 @@
 				const StationCargoPacketMap *packets = ge->cargo.Packets();
 				for (StationCargoList::ConstIterator it(packets->begin()); it != packets->end(); it++) {
 					CargoPacket *cp = *it;
-					cp->source_xy = Station::IsValidID(cp->source) ? Station::Get(cp->source)->xy : st->xy;
+					cp->source_xy = Station::IsValidID(cp->first_station) ? Station::Get(cp->first_station)->xy : st->xy;
 				}
 			}
 		}
@@ -58,7 +58,7 @@
 	if (IsSavegameVersionBefore(SLV_120)) {
 		/* CargoPacket's source should be either INVALID_STATION or a valid station */
 		for (CargoPacket *cp : CargoPacket::Iterate()) {
-			if (!Station::IsValidID(cp->source)) cp->source = INVALID_STATION;
+			if (!Station::IsValidID(cp->first_station)) cp->first_station = INVALID_STATION;
 		}
 	}
 
@@ -86,7 +86,7 @@
 SaveLoadTable GetCargoPacketDesc()
 {
 	static const SaveLoad _cargopacket_desc[] = {
-		SLE_VAR(CargoPacket, source,          SLE_UINT16),
+		SLE_VARNAME(CargoPacket, first_station, "source", SLE_UINT16),
 		SLE_VAR(CargoPacket, source_xy,       SLE_UINT32),
 		SLE_VAR(CargoPacket, count,           SLE_UINT16),
 		SLE_CONDVARNAME(CargoPacket, periods_in_transit, "days_in_transit", SLE_FILE_U8 | SLE_VAR_U16, SL_MIN_VERSION, SLV_MORE_CARGO_AGE),

--- a/src/script/api/script_station.cpp
+++ b/src/script/api/script_station.cpp
@@ -69,7 +69,7 @@ template<bool Tfrom, bool Tvia>
 						StationCargoList::ConstIterator(cargo_list.Packets()->end()));
 	for (StationCargoList::ConstIterator it = range.first; it != range.second; it++) {
 		const CargoPacket *cp = *it;
-		if (!Tfrom || cp->SourceStation() == from_station_id) cargo_count += cp->Count();
+		if (!Tfrom || cp->GetFirstStation() == from_station_id) cargo_count += cp->Count();
 	}
 
 	return cargo_count;

--- a/src/script/api/script_stationlist.cpp
+++ b/src/script/api/script_stationlist.cpp
@@ -179,7 +179,7 @@ void ScriptStationList_CargoWaiting::Add(StationID station_id, CargoID cargo, St
 	StationCargoList::ConstIterator iter = collector.GE()->cargo.Packets()->begin();
 	StationCargoList::ConstIterator end = collector.GE()->cargo.Packets()->end();
 	for (; iter != end; ++iter) {
-		collector.Update<Tselector>((*iter)->SourceStation(), iter.GetKey(), (*iter)->Count());
+		collector.Update<Tselector>((*iter)->GetFirstStation(), iter.GetKey(), (*iter)->Count());
 	}
 }
 
@@ -218,7 +218,7 @@ ScriptStationList_CargoWaitingViaByFrom::ScriptStationList_CargoWaitingViaByFrom
 	std::pair<StationCargoList::ConstIterator, StationCargoList::ConstIterator> range =
 			collector.GE()->cargo.Packets()->equal_range(via);
 	for (StationCargoList::ConstIterator iter = range.first; iter != range.second; ++iter) {
-		collector.Update<CS_VIA_BY_FROM>((*iter)->SourceStation(), iter.GetKey(), (*iter)->Count());
+		collector.Update<CS_VIA_BY_FROM>((*iter)->GetFirstStation(), iter.GetKey(), (*iter)->Count());
 	}
 }
 

--- a/src/ship_gui.cpp
+++ b/src/ship_gui.cpp
@@ -79,13 +79,13 @@ void DrawShipDetails(const Vehicle *v, const Rect &r)
 	if (v->cargo.StoredCount() > 0) {
 		SetDParam(0, v->cargo_type);
 		SetDParam(1, v->cargo.StoredCount());
-		SetDParam(2, v->cargo.Source());
+		SetDParam(2, v->cargo.GetFirstStation());
 		str = STR_VEHICLE_DETAILS_CARGO_FROM;
 	}
 	DrawString(r.left, r.right, y, str);
 	y += FONT_HEIGHT_NORMAL + WidgetDimensions::scaled.vsep_normal;
 
 	/* Draw Transfer credits text */
-	SetDParam(0, v->cargo.FeederShare());
+	SetDParam(0, v->cargo.GetFeederShare());
 	DrawString(r.left, r.right, y, STR_VEHICLE_INFO_FEEDER_CARGO_VALUE);
 }

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -1591,15 +1591,15 @@ struct StationViewWindow : public Window {
 			const CargoPacket *cp = *it;
 			StationID next = it.GetKey();
 
-			const CargoDataEntry *source_entry = source_dest->Retrieve(cp->SourceStation());
+			const CargoDataEntry *source_entry = source_dest->Retrieve(cp->GetFirstStation());
 			if (source_entry == nullptr) {
-				this->ShowCargo(cargo, i, cp->SourceStation(), next, INVALID_STATION, cp->Count());
+				this->ShowCargo(cargo, i, cp->GetFirstStation(), next, INVALID_STATION, cp->Count());
 				continue;
 			}
 
 			const CargoDataEntry *via_entry = source_entry->Retrieve(next);
 			if (via_entry == nullptr) {
-				this->ShowCargo(cargo, i, cp->SourceStation(), next, INVALID_STATION, cp->Count());
+				this->ShowCargo(cargo, i, cp->GetFirstStation(), next, INVALID_STATION, cp->Count());
 				continue;
 			}
 
@@ -1620,7 +1620,7 @@ struct StationViewWindow : public Window {
 					val = std::min<uint>(remaining, DivideApprox(cp->Count() * dest_entry->GetCount(), via_entry->GetCount()));
 					remaining -= val;
 				}
-				this->ShowCargo(cargo, i, cp->SourceStation(), next, dest_entry->GetStation(), val);
+				this->ShowCargo(cargo, i, cp->GetFirstStation(), next, dest_entry->GetStation(), val);
 			}
 		}
 		this->ShowCargo(cargo, i, NEW_STATION, NEW_STATION, NEW_STATION, packets.ReservedCount());

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -291,7 +291,7 @@ static void GetCargoSummaryOfArticulatedVehicle(const Train *v, CargoSummary *su
 
 		item->capacity += v->cargo_cap;
 		item->amount += v->cargo.StoredCount();
-		if (item->source == INVALID_STATION) item->source = v->cargo.Source();
+		if (item->source == INVALID_STATION) item->source = v->cargo.GetFirstStation();
 	} while ((v = v->Next()) != nullptr && v->IsArticulatedPart());
 }
 
@@ -440,7 +440,7 @@ void DrawTrainDetails(const Train *v, const Rect &r, int vscroll_pos, uint16_t v
 		for (const Vehicle *u = v; u != nullptr; u = u->Next()) {
 			act_cargo[u->cargo_type] += u->cargo.StoredCount();
 			max_cargo[u->cargo_type] += u->cargo_cap;
-			feeder_share             += u->cargo.FeederShare();
+			feeder_share             += u->cargo.GetFeederShare();
 		}
 
 		/* draw total cargo tab */


### PR DESCRIPTION
## Motivation / Problem

While looking at #11274 it became clear that CargoPacket had some outdated wording for its variables and function names. This makes reviewing a PR like #11274 a lot harder, as the context is constantly lost on the reviewer. To address that somewhat, I took some time to name things to be a bit more to their actual meaning.

## Description

A few things here, I could split them out in separate commits if that is wanted:

- The getter functions didn't start with `Get`, which made it somewhat unclear what they were doing. Not for all, but to keep things consistently, prefixed them all with `Get`. (as example, it was `SetNextStation` vs `NextStation` .. the latter should ofc be `GetNextStation`).
- There were two `source` variables: the actual source (an industry, town, or HQ), and the station the cargo started at. This made for some confusing statements. Fixed that by renaming `source` to `first_station`, better indicating what the variable actually is.
- Use class-member initialization when possible, avoiding the trouble of sometimes having a variable set to zero, and sometimes not. And that should be okay? Dunno .. can't promise it was. Now it is \o/
- `source_id` and `source_type` were referred to as `subsidy`. This was once true, but these days it is also used for cargo monitoring and others.
- `CargoList` called it `SourceStation`, `CargoPacket` called the same thing `Source`. It is now called `GetFirstStation` in both, indicating they are the same.

And I removed / added some spaces for better alignment.

## Limitations

This purely was renaming of functions / variables. No functional change was introduced.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
