### PR TITLE
Fix: NewGRF house class mappings were not reset between games.

### DIFF
--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -25,7 +25,7 @@
 #include "safeguards.h"
 
 static BuildingCounts<uint32_t> _building_counts;
-static HouseClassMapping _class_mapping[HOUSE_CLASS_MAX];
+static std::array<HouseClassMapping, HOUSE_CLASS_MAX> _class_mapping;
 
 HouseOverrideManager _house_mngr(NEW_HOUSE_OFFSET, NUM_HOUSES, INVALID_HOUSE_ID);
 
@@ -70,6 +70,11 @@ GrfSpecFeature HouseResolverObject::GetFeature() const
 uint32_t HouseResolverObject::GetDebugID() const
 {
 	return HouseSpec::Get(this->house_scope.house_id)->grf_prop.local_id;
+}
+
+void ResetHouseClassIDs()
+{
+	_class_mapping = {};
 }
 
 HouseClassID AllocateHouseClassID(byte grf_class_id, uint32_t grfid)

--- a/src/newgrf_house.h
+++ b/src/newgrf_house.h
@@ -87,6 +87,7 @@ struct HouseClassMapping {
 	uint8_t  class_id;  ///< The class id within the grf file
 };
 
+void ResetHouseClassIDs();
 HouseClassID AllocateHouseClassID(byte grf_class_id, uint32_t grfid);
 
 void InitializeBuildingCounts();

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -3842,6 +3842,8 @@ HouseSpec _house_specs[NUM_HOUSES];
 
 void ResetHouses()
 {
+	ResetHouseClassIDs();
+
 	auto insert = std::copy(std::begin(_original_house_specs), std::end(_original_house_specs), std::begin(_house_specs));
 	std::fill(insert, std::end(_house_specs), HouseSpec{});
 


### PR DESCRIPTION
## Motivation / Problem

I noticed that NewGRF house class mappings is written to and read from, but never reset. This means that mappings are not cleared between games, so loading loading games with different house NewGRFs can affect the state of future games.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

## Description

This is fixed by resetting the house class mappings when performing initialization of the default houses.

The C-style array is changed to a std::array to simplify clearing it by assignment.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
