### PR TITLE
Fix b0e73277: cargodist information got lost when splitting of cargo

### DIFF
--- a/src/cargopacket.cpp
+++ b/src/cargopacket.cpp
@@ -57,6 +57,7 @@ CargoPacket::CargoPacket(StationID first_station, TileIndex source_xy, uint16_t 
  * @param count              Number of cargo entities to put in this packet.
  * @param periods_in_transit Number of cargo aging periods the cargo has been in transit.
  * @param first_station      Station the cargo was initially loaded.
+ * @param next_station       Next station the cargo wants to go.
  * @param source_xy          Station location the cargo was initially loaded.
  * @param feeder_share       Feeder share the packet has already accumulated.
  * @param source_type        'Type' of source the packet comes from (for subsidies).
@@ -64,14 +65,15 @@ CargoPacket::CargoPacket(StationID first_station, TileIndex source_xy, uint16_t 
  * @note We have to zero memory ourselves here because we are using a 'new'
  * that, in contrary to all other pools, does not memset to 0.
  */
-CargoPacket::CargoPacket(uint16_t count, uint16_t periods_in_transit, StationID first_station, TileIndex source_xy, Money feeder_share, SourceType source_type, SourceID source_id) :
+CargoPacket::CargoPacket(uint16_t count, uint16_t periods_in_transit, StationID first_station, StationID next_station, TileIndex source_xy, Money feeder_share, SourceType source_type, SourceID source_id) :
 		count(count),
 		periods_in_transit(periods_in_transit),
 		feeder_share(feeder_share),
 		source_xy(source_xy),
 		source_id(source_id),
 		source_type(source_type),
-		first_station(first_station)
+		first_station(first_station),
+		next_station(next_station)
 {
 	assert(count != 0);
 }
@@ -86,7 +88,7 @@ CargoPacket *CargoPacket::Split(uint new_size)
 	if (!CargoPacket::CanAllocateItem()) return nullptr;
 
 	Money fs = this->GetFeederShare(new_size);
-	CargoPacket *cp_new = new CargoPacket(new_size, this->periods_in_transit, this->first_station, this->source_xy,  fs, this->source_type, this->source_id);
+	CargoPacket *cp_new = new CargoPacket(new_size, this->periods_in_transit, this->first_station, this->next_station, this->source_xy, fs, this->source_type, this->source_id);
 	this->feeder_share -= fs;
 	this->count -= new_size;
 	return cp_new;

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -63,7 +63,7 @@ public:
 
 	CargoPacket();
 	CargoPacket(StationID first_station, TileIndex source_xy, uint16_t count, SourceType source_type, SourceID source_id);
-	CargoPacket(uint16_t count, uint16_t periods_in_transit, StationID source, TileIndex source_xy, Money feeder_share = 0, SourceType source_type = SourceType::Industry, SourceID source_id = INVALID_SOURCE);
+	CargoPacket(uint16_t count, uint16_t periods_in_transit, StationID first_station, StationID next_station, TileIndex source_xy, Money feeder_share = 0, SourceType source_type = SourceType::Industry, SourceID source_id = INVALID_SOURCE);
 
 	/** Destroy the packet. */
 	~CargoPacket() { }
@@ -422,6 +422,7 @@ public:
 		return cp1->source_xy == cp2->source_xy &&
 				cp1->periods_in_transit == cp2->periods_in_transit &&
 				cp1->source_type == cp2->source_type &&
+				cp1->next_station == cp2->next_station &&
 				cp1->source_id == cp2->source_id;
 	}
 };
@@ -536,6 +537,7 @@ public:
 		return cp1->source_xy == cp2->source_xy &&
 				cp1->periods_in_transit == cp2->periods_in_transit &&
 				cp1->source_type == cp2->source_type &&
+				cp1->next_station == cp2->next_station &&
 				cp1->source_id == cp2->source_id;
 	}
 };

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -1353,7 +1353,7 @@ bool LoadOldVehicle(LoadgameState *ls, int num)
 		if (_cargo_count != 0 && CargoPacket::CanAllocateItem()) {
 			StationID source =    (_cargo_source == 0xFF) ? INVALID_STATION : _cargo_source;
 			TileIndex source_xy = (source != INVALID_STATION) ? Station::Get(source)->xy : (TileIndex)0;
-			v->cargo.Append(new CargoPacket(_cargo_count, _cargo_periods, source, source_xy));
+			v->cargo.Append(new CargoPacket(_cargo_count, _cargo_periods, source, INVALID_STATION, source_xy));
 		}
 	}
 

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -449,7 +449,7 @@ public:
 					assert(CargoPacket::CanAllocateItem());
 
 					/* Don't construct the packet with station here, because that'll fail with old savegames */
-					CargoPacket *cp = new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, source, _cargo_source_xy, _cargo_feeder_share);
+					CargoPacket *cp = new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, source, INVALID_STATION, _cargo_source_xy, _cargo_feeder_share);
 					ge->cargo.Append(cp, INVALID_STATION);
 					SB(ge->status, GoodsEntry::GES_RATING, 1, 1);
 				}

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -1041,7 +1041,7 @@ struct VEHSChunkHandler : ChunkHandler {
 
 			if (_cargo_count != 0 && IsCompanyBuildableVehicleType(v) && CargoPacket::CanAllocateItem()) {
 				/* Don't construct the packet with station here, because that'll fail with old savegames */
-				CargoPacket *cp = new CargoPacket(_cargo_count, _cargo_periods, _cargo_source, _cargo_source_xy, _cargo_feeder_share);
+				CargoPacket *cp = new CargoPacket(_cargo_count, _cargo_periods, _cargo_source, INVALID_STATION, _cargo_source_xy, _cargo_feeder_share);
 				v->cargo.Append(cp);
 			}
 


### PR DESCRIPTION
## Motivation / Problem

During b0e73277 we removed loaded_at_xy, but I kinda forgot that it was a union with next_station. Now next_station wasn't copied anymore, or checked in AreMergable.

## Description

Fix the above mentioned issue by reintroducing `next_station` in places where `loaded_at_xy` used to be.

There are a few places where it is set to `INVALID_STATION`:

- When loading TT(D) games: cargodist didn't exist back then.
- When loading games from between 51 and 68. With loaded_at_xy it used to load in the next_station variable too. But cargodist (and next_station) was only introduced around 180. So no need to still load in a clearly illegal value for next_station.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
