### PR TITLE
Fix: base cargo payment on load/unload tile, instead of station sign location

### DIFF
--- a/src/cargoaction.cpp
+++ b/src/cargoaction.cpp
@@ -107,7 +107,7 @@ bool CargoDelivery::operator()(CargoPacket *cp)
 {
 	uint remove = this->Preprocess(cp);
 	this->source->RemoveFromMeta(cp, VehicleCargoList::MTA_DELIVER, remove);
-	this->payment->PayFinalDelivery(cp, remove);
+	this->payment->PayFinalDelivery(cp, remove, this->current_tile);
 	return this->Postprocess(cp, remove);
 }
 

--- a/src/cargoaction.cpp
+++ b/src/cargoaction.cpp
@@ -120,6 +120,7 @@ bool CargoLoad::operator()(CargoPacket *cp)
 {
 	CargoPacket *cp_new = this->Preprocess(cp);
 	if (cp_new == nullptr) return false;
+	cp_new->SetSourceXY(this->current_tile);
 	this->source->RemoveFromCache(cp_new, cp_new->Count());
 	this->destination->Append(cp_new, VehicleCargoList::MTA_KEEP);
 	return cp_new == cp;
@@ -134,6 +135,7 @@ bool CargoReservation::operator()(CargoPacket *cp)
 {
 	CargoPacket *cp_new = this->Preprocess(cp);
 	if (cp_new == nullptr) return false;
+	cp_new->SetSourceXY(this->current_tile);
 	this->source->reserved_count += cp_new->Count();
 	this->source->RemoveFromCache(cp_new, cp_new->Count());
 	this->destination->Append(cp_new, VehicleCargoList::MTA_LOAD);

--- a/src/cargoaction.h
+++ b/src/cargoaction.h
@@ -38,10 +38,11 @@ public:
 /** Action of final delivery of cargo. */
 class CargoDelivery : public CargoRemoval<VehicleCargoList> {
 protected:
+	TileIndex current_tile; ///< Current tile cargo delivery is happening.
 	CargoPayment *payment; ///< Payment object where payments will be registered.
 public:
-	CargoDelivery(VehicleCargoList *source, uint max_move, CargoPayment *payment) :
-			CargoRemoval<VehicleCargoList>(source, max_move), payment(payment) {}
+	CargoDelivery(VehicleCargoList *source, uint max_move, CargoPayment *payment, TileIndex current_tile) :
+			CargoRemoval<VehicleCargoList>(source, max_move), current_tile(current_tile), payment(payment) {}
 	bool operator()(CargoPacket *cp);
 };
 

--- a/src/cargoaction.h
+++ b/src/cargoaction.h
@@ -78,17 +78,19 @@ public:
 
 /** Action of loading cargo from a station onto a vehicle. */
 class CargoLoad : public CargoMovement<StationCargoList, VehicleCargoList> {
+protected:
+	TileIndex current_tile; ///< Current tile cargo loading is happening.
 public:
-	CargoLoad(StationCargoList *source, VehicleCargoList *destination, uint max_move) :
-			CargoMovement<StationCargoList, VehicleCargoList>(source, destination, max_move) {}
+	CargoLoad(StationCargoList *source, VehicleCargoList *destination, uint max_move, TileIndex current_tile) :
+			CargoMovement<StationCargoList, VehicleCargoList>(source, destination, max_move), current_tile(current_tile) {}
 	bool operator()(CargoPacket *cp);
 };
 
 /** Action of reserving cargo from a station to be loaded onto a vehicle. */
 class CargoReservation : public CargoLoad {
 public:
-	CargoReservation(StationCargoList *source, VehicleCargoList *destination, uint max_move) :
-			CargoLoad(source, destination, max_move) {}
+	CargoReservation(StationCargoList *source, VehicleCargoList *destination, uint max_move, TileIndex current_tile) :
+			CargoLoad(source, destination, max_move, current_tile) {}
 	bool operator()(CargoPacket *cp);
 };
 

--- a/src/cargopacket.cpp
+++ b/src/cargopacket.cpp
@@ -34,15 +34,13 @@ CargoPacket::CargoPacket()
  * Creates a new cargo packet.
  *
  * @param first_station Source station of the packet.
- * @param source_xy     Source location of the packet.
  * @param count         Number of cargo entities to put in this packet.
  * @param source_type   'Type' of source the packet comes from (for subsidies).
  * @param source_id     Actual source of the packet (for subsidies).
  * @pre count != 0
  */
-CargoPacket::CargoPacket(StationID first_station, TileIndex source_xy, uint16_t count, SourceType source_type, SourceID source_id) :
+CargoPacket::CargoPacket(StationID first_station,uint16_t count, SourceType source_type, SourceID source_id) :
 		count(count),
-		source_xy(source_xy),
 		source_id(source_id),
 		source_type(source_type),
 		first_station(first_station)
@@ -808,11 +806,12 @@ uint StationCargoList::Truncate(uint max_move, StationCargoAmountMap *cargo_per_
  * @param max_move Maximum amount of cargo to reserve.
  * @param dest VehicleCargoList to reserve for.
  * @param next_station Next station(s) the loading vehicle will visit.
+ * @param current_tile Current tile the cargo handling is happening on.
  * @return Amount of cargo actually reserved.
  */
-uint StationCargoList::Reserve(uint max_move, VehicleCargoList *dest, StationIDStack next_station)
+uint StationCargoList::Reserve(uint max_move, VehicleCargoList *dest, StationIDStack next_station, TileIndex current_tile)
 {
-	return this->ShiftCargo(CargoReservation(this, dest, max_move), next_station, true);
+	return this->ShiftCargo(CargoReservation(this, dest, max_move, current_tile), next_station, true);
 }
 
 /**
@@ -821,12 +820,13 @@ uint StationCargoList::Reserve(uint max_move, VehicleCargoList *dest, StationIDS
  * @param max_move Amount of cargo to load.
  * @param dest Vehicle cargo list where the cargo resides.
  * @param next_station Next station(s) the loading vehicle will visit.
+ * @param current_tile Current tile the cargo handling is happening on.
  * @return Amount of cargo actually loaded.
  * @note Vehicles may or may not reserve, depending on their orders. The two
  *       modes of loading are exclusive, though. If cargo is reserved we don't
  *       need to load unreserved cargo.
  */
-uint StationCargoList::Load(uint max_move, VehicleCargoList *dest, StationIDStack next_station)
+uint StationCargoList::Load(uint max_move, VehicleCargoList *dest, StationIDStack next_station, TileIndex current_tile)
 {
 	uint move = std::min(dest->ActionCount(VehicleCargoList::MTA_LOAD), max_move);
 	if (move > 0) {
@@ -834,7 +834,7 @@ uint StationCargoList::Load(uint max_move, VehicleCargoList *dest, StationIDStac
 		dest->Reassign<VehicleCargoList::MTA_LOAD, VehicleCargoList::MTA_KEEP>(move);
 		return move;
 	} else {
-		return this->ShiftCargo(CargoLoad(this, dest, max_move), next_station, true);
+		return this->ShiftCargo(CargoLoad(this, dest, max_move, current_tile), next_station, true);
 	}
 }
 

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -44,7 +44,7 @@ private:
 
 	Money feeder_share{0}; ///< Value of feeder pickup to be paid for on delivery of cargo.
 
-	TileIndex source_xy{0}; ///< The origin of the cargo.
+	TileIndex source_xy{INVALID_TILE}; ///< The origin of the cargo.
 	SourceID source_id{INVALID_SOURCE}; ///< Index of industry/town/HQ, INVALID_SOURCE if unknown/invalid.
 	SourceType source_type{SourceType::Industry}; ///< Type of \c source_id.
 
@@ -62,7 +62,7 @@ public:
 	static const uint16_t MAX_COUNT = UINT16_MAX;
 
 	CargoPacket();
-	CargoPacket(StationID first_station, TileIndex source_xy, uint16_t count, SourceType source_type, SourceID source_id);
+	CargoPacket(StationID first_station, uint16_t count, SourceType source_type, SourceID source_id);
 	CargoPacket(uint16_t count, uint16_t periods_in_transit, StationID first_station, TileIndex source_xy, Money feeder_share);
 	CargoPacket(uint16_t count, Money feeder_share, CargoPacket &original);
 
@@ -80,6 +80,25 @@ public:
 	void SetNextHop(StationID next_hop)
 	{
 		this->next_hop = next_hop;
+	}
+
+	/**
+	 * Set the origin of the packet.
+	 *
+	 * Can only be set once.
+	 *
+	 * When a packet is created, it is moved to a station. But at that moment
+	 * in time it is not known yet at which tile the cargo will be picked up.
+	 * As this tile is used for payment information, we delay setting the
+	 * source_xy till first pickup.
+	 *
+	 * @param tile Tile the cargo is being picked up from.
+	 */
+	void SetSourceXY(TileIndex tile)
+	{
+		if (this->source_xy == INVALID_TILE) {
+			this->source_xy = tile;
+		}
 	}
 
 	/**
@@ -168,6 +187,7 @@ public:
 	 */
 	inline uint GetDistance(TileIndex current_tile) const
 	{
+		assert(this->source_xy != INVALID_TILE);
 		return DistanceManhattan(this->source_xy, current_tile);
 	}
 
@@ -425,6 +445,7 @@ public:
 		return cp1->source_xy == cp2->source_xy &&
 				cp1->periods_in_transit == cp2->periods_in_transit &&
 				cp1->source_type == cp2->source_type &&
+				cp1->first_station == cp2->first_station &&
 				cp1->source_id == cp2->source_id;
 	}
 };
@@ -522,8 +543,8 @@ public:
 	 * amount of cargo to be moved. Second parameter is destination (if
 	 * applicable), return value is amount of cargo actually moved. */
 
-	uint Reserve(uint max_move, VehicleCargoList *dest, StationIDStack next);
-	uint Load(uint max_move, VehicleCargoList *dest, StationIDStack next);
+	uint Reserve(uint max_move, VehicleCargoList *dest, StationIDStack next, TileIndex current_tile);
+	uint Load(uint max_move, VehicleCargoList *dest, StationIDStack next, TileIndex current_tile);
 	uint Truncate(uint max_move = UINT_MAX, StationCargoAmountMap *cargo_per_source = nullptr);
 	uint Reroute(uint max_move, StationCargoList *dest, StationID avoid, StationID avoid2, const GoodsEntry *ge);
 
@@ -539,6 +560,7 @@ public:
 		return cp1->source_xy == cp2->source_xy &&
 				cp1->periods_in_transit == cp2->periods_in_transit &&
 				cp1->source_type == cp2->source_type &&
+				cp1->first_station == cp2->first_station &&
 				cp1->source_id == cp2->source_id;
 	}
 };

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -161,12 +161,14 @@ public:
 	}
 
 	/**
-	 * Gets the coordinates of the cargo's source.
-	 * @return Source coordinates of cargo.
+	 * Get the current distance the cargo has traveled.
+	 *
+	 * @param current_tile Current tile of the cargo.
+	 * @return uint The distance (in tiles) traveled.
 	 */
-	inline TileIndex GetSourceXY() const
+	inline uint GetDistance(TileIndex current_tile) const
 	{
-		return this->source_xy;
+		return DistanceManhattan(this->source_xy, current_tile);
 	}
 
 	/**
@@ -386,7 +388,7 @@ public:
 
 	void InvalidateCache();
 
-	bool Stage(bool accepted, StationID current_station, StationIDStack next_station, uint8_t order_flags, const GoodsEntry *ge, CargoPayment *payment);
+	bool Stage(bool accepted, StationID current_station, StationIDStack next_station, uint8_t order_flags, const GoodsEntry *ge, CargoPayment *payment, TileIndex current_tile);
 
 	/**
 	 * Marks all cargo in the vehicle as to be kept. This is mostly useful for
@@ -406,7 +408,7 @@ public:
 	template<MoveToAction Tfrom, MoveToAction Tto>
 	uint Reassign(uint max_move);
 	uint Return(uint max_move, StationCargoList *dest, StationID next_station);
-	uint Unload(uint max_move, StationCargoList *dest, CargoPayment *payment);
+	uint Unload(uint max_move, StationCargoList *dest, CargoPayment *payment, TileIndex current_tile);
 	uint Shift(uint max_move, VehicleCargoList *dest);
 	uint Truncate(uint max_move = UINT_MAX);
 	uint Reroute(uint max_move, VehicleCargoList *dest, StationID avoid, StationID avoid2, const GoodsEntry *ge);

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1096,7 +1096,7 @@ static uint DeliverGoodsToIndustry(const Station *st, CargoID cargo_type, uint n
  * @param num_pieces amount of cargo delivered
  * @param cargo_type the type of cargo that is delivered
  * @param dest Station the cargo has been unloaded
- * @param source_tile The origin of the cargo for distance calculation
+ * @param distance The distance the cargo has traveled.
  * @param periods_in_transit Travel time in cargo aging periods
  * @param company The company delivering the cargo
  * @param src_type Type of source of cargo (industry, town, headquarters)
@@ -1104,7 +1104,7 @@ static uint DeliverGoodsToIndustry(const Station *st, CargoID cargo_type, uint n
  * @return Revenue for delivering cargo
  * @note The cargo is just added to the stockpile of the industry. It is due to the caller to trigger the industry's production machinery
  */
-static Money DeliverGoods(int num_pieces, CargoID cargo_type, StationID dest, TileIndex source_tile, uint16_t periods_in_transit, Company *company, SourceType src_type, SourceID src)
+static Money DeliverGoods(int num_pieces, CargoID cargo_type, StationID dest, uint distance, uint16_t periods_in_transit, Company *company, SourceType src_type, SourceID src)
 {
 	assert(num_pieces > 0);
 
@@ -1131,7 +1131,7 @@ static Money DeliverGoods(int num_pieces, CargoID cargo_type, StationID dest, Ti
 	st->town->received[cs->town_effect].new_act += accepted_total;
 
 	/* Determine profit */
-	Money profit = GetTransportedGoodsIncome(accepted_total, DistanceManhattan(source_tile, st->xy), periods_in_transit, cargo_type);
+	Money profit = GetTransportedGoodsIncome(accepted_total, distance, periods_in_transit, cargo_type);
 
 	/* Update the cargo monitor. */
 	AddCargoDelivery(cargo_type, company->index, accepted_total - accepted_ind, src_type, src, st);
@@ -1225,15 +1225,16 @@ CargoPayment::~CargoPayment()
  * Handle payment for final delivery of the given cargo packet.
  * @param cp The cargo packet to pay for.
  * @param count The number of packets to pay for.
+ * @param current_tile Current tile the payment is happening on.
  */
-void CargoPayment::PayFinalDelivery(const CargoPacket *cp, uint count)
+void CargoPayment::PayFinalDelivery(const CargoPacket *cp, uint count, TileIndex current_tile)
 {
 	if (this->owner == nullptr) {
 		this->owner = Company::Get(this->front->owner);
 	}
 
 	/* Handle end of route payment */
-	Money profit = DeliverGoods(count, this->ct, this->current_station, cp->GetSourceXY(), cp->GetPeriodsInTransit(), this->owner, cp->GetSourceType(), cp->GetSourceID());
+	Money profit = DeliverGoods(count, this->ct, this->current_station, cp->GetDistance(current_tile), cp->GetPeriodsInTransit(), this->owner, cp->GetSourceType(), cp->GetSourceID());
 	this->route_profit += profit;
 
 	/* The vehicle's profit is whatever route profit there is minus feeder shares. */
@@ -1244,15 +1245,16 @@ void CargoPayment::PayFinalDelivery(const CargoPacket *cp, uint count)
  * Handle payment for transfer of the given cargo packet.
  * @param cp The cargo packet to pay for; actual payment won't be made!.
  * @param count The number of packets to pay for.
+ * @param current_tile Current tile the payment is happening on.
  * @return The amount of money paid for the transfer.
  */
-Money CargoPayment::PayTransfer(const CargoPacket *cp, uint count)
+Money CargoPayment::PayTransfer(const CargoPacket *cp, uint count, TileIndex current_tile)
 {
+	/* Pay transfer vehicle the difference between the payment for the journey from
+	 * the source to the current point, and the sum of the previous transfer payments */
 	Money profit = -cp->GetFeederShare(count) + GetTransportedGoodsIncome(
 			count,
-			/* pay transfer vehicle the difference between the payment for the journey from
-			 * the source to the current point, and the sum of the previous transfer payments */
-			DistanceManhattan(cp->GetSourceXY(), Station::Get(this->current_station)->xy),
+			cp->GetDistance(current_tile),
 			cp->GetPeriodsInTransit(),
 			this->ct);
 
@@ -1294,7 +1296,8 @@ void PrepareUnload(Vehicle *front_v)
 						HasBit(ge->status, GoodsEntry::GES_ACCEPTANCE),
 						front_v->last_station_visited, next_station,
 						front_v->current_order.GetUnloadType(), ge,
-						front_v->cargo_payment);
+						front_v->cargo_payment,
+						v->tile);
 				if (v->cargo.UnloadCount() > 0) SetBit(v->vehicle_flags, VF_CARGO_UNLOADING);
 			}
 		}
@@ -1721,7 +1724,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 				}
 			}
 
-			amount_unloaded = v->cargo.Unload(amount_unloaded, &ge->cargo, payment);
+			amount_unloaded = v->cargo.Unload(amount_unloaded, &ge->cargo, payment, v->tile);
 			remaining = v->cargo.UnloadCount() > 0;
 			if (amount_unloaded > 0) {
 				dirty_vehicle = true;

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1472,7 +1472,7 @@ struct FinalizeRefitAction
 	{
 		if (this->do_reserve) {
 			this->st->goods[v->cargo_type].cargo.Reserve(v->cargo_cap - v->cargo.RemainingCount(),
-					&v->cargo, this->next_station);
+					&v->cargo, this->next_station, v->tile);
 		}
 		this->consist_capleft[v->cargo_type] += v->cargo_cap - v->cargo.RemainingCount();
 		return true;
@@ -1563,7 +1563,7 @@ struct ReserveCargoAction {
 	{
 		if (v->cargo_cap > v->cargo.RemainingCount() && MayLoadUnderExclusiveRights(st, v)) {
 			st->goods[v->cargo_type].cargo.Reserve(v->cargo_cap - v->cargo.RemainingCount(),
-					&v->cargo, *next_station);
+					&v->cargo, *next_station, v->tile);
 		}
 
 		return true;
@@ -1794,7 +1794,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 				if (v->cargo.StoredCount() == 0) TriggerVehicle(v, VEHICLE_TRIGGER_NEW_CARGO);
 				if (_settings_game.order.gradual_loading) cap_left = std::min(cap_left, GetLoadAmount(v));
 
-				uint loaded = ge->cargo.Load(cap_left, &v->cargo, next_station);
+				uint loaded = ge->cargo.Load(cap_left, &v->cargo, next_station, v->tile);
 				if (v->cargo.ActionCount(VehicleCargoList::MTA_LOAD) > 0) {
 					/* Remember if there are reservations left so that we don't stop
 					 * loading before they're loaded. */

--- a/src/economy_base.h
+++ b/src/economy_base.h
@@ -37,8 +37,8 @@ struct CargoPayment : CargoPaymentPool::PoolItem<&_cargo_payment_pool> {
 	CargoPayment(Vehicle *front);
 	~CargoPayment();
 
-	Money PayTransfer(const CargoPacket *cp, uint count);
-	void PayFinalDelivery(const CargoPacket *cp, uint count);
+	Money PayTransfer(const CargoPacket *cp, uint count, TileIndex current_tile);
+	void PayFinalDelivery(const CargoPacket *cp, uint count, TileIndex current_tile);
 
 	/**
 	 * Sets the currently handled cargo type.

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4039,7 +4039,7 @@ static uint UpdateStationWaiting(Station *st, CargoID type, uint amount, SourceT
 	if (amount == 0) return 0;
 
 	StationID next = ge.GetVia(st->index);
-	ge.cargo.Append(new CargoPacket(st->index, st->xy, amount, source_type, source_id), next);
+	ge.cargo.Append(new CargoPacket(st->index, amount, source_type, source_id), next);
 	LinkGraph *lg = nullptr;
 	if (ge.link_graph == INVALID_LINK_GRAPH) {
 		if (LinkGraph::CanAllocateItem()) {


### PR DESCRIPTION
## Motivation / Problem

Cargo payment is based on the location of a station, which is the same as the location of the sign of the station. The problem with this approach is that the location of the sign can be manipulated in such way you get a nice advantage when moving cargo around.

This can happen both on the loading side, as on the unloading side. To put it in an image (savegames also attached):

![image](https://user-images.githubusercontent.com/1663690/266832977-eabed6eb-4e06-47fd-bc6d-8de981a1052f.png)
![image](https://user-images.githubusercontent.com/1663690/266835131-4579b0d5-9f9f-450a-aa09-e2bdf1f01342.png)

In both images, the vehicles made a single delivery. As you can see, one of the two made far more money than the other. Why? Well, we have to zoom out a bit:

![image](https://user-images.githubusercontent.com/1663690/266832995-fb2451ba-fe6f-4a04-b24b-7f4d8aa9807d.png)
![image](https://user-images.githubusercontent.com/1663690/266835143-39956663-a4e8-450b-a05c-cd0a943c3ce3.png)

These savegames were made with a much higher than normal station-spread value, but this just to show the effect better. On the default value of 12, it is already noticable: you can get 2x 12 tiles "free" movement, for which you get paid.

The Pull Request #11274 set out to address this and other problems, but the PR is very hard to read / review. So while looking into what is actually going on, I decided to roll my own PR. Initially I did request the author of #11274 to make this PR, but I have seen no sign of this happening. And well .. sometimes it is just easier to not bother, and do it yourself. Mostly as doing it yourself means a bit better understanding of what is going on.

[Sign-payment-unload.zip](https://github.com/OpenTTD/OpenTTD/files/12568193/Sign-payment-unload.zip)
[Sign-payment-load.zip](https://github.com/OpenTTD/OpenTTD/files/12568194/Sign-payment-load.zip)

PS: just to be clear, this fixes the issue where station location is used for payment. It does not address teleportation at all. And yes, #11274 can be applied on top of this PR to mitigate that issue. I deliberately left that out of this PR, to ease up review. This PR is basically a part of #11274 (although I made some other choices to increase readability and understandably of the code; for example, I went with `current_tile` instead of `location`, as the former is used a lot more in our code than the latter.).

PPS: I go here from the assumption people deliberately were abusing this mechanism, but of course the inverse is also true: there might be people that got paid less than they were due, because the station sign was closer to the destination. In those cases, this PR also fixes their game, giving them more money for their routes.

## Description

There are two fixes in this PR, and as such, two commits. But I will squash this into master, as from a user perspective it fixes the same thing. In other words: the commits are purely to ease up review.

The first commit fixes the issue for the destination. This is very easy, as all we need is the actual location we are dropping off the cargo, instead of the station location. To make things a bit more readable and understandable, I decided to move the `GetDistance` inside the CargoPacket, meaning `source_xy` no longer has to be announced to the outside world. This makes future additions, like #11274 etc, a bit easier.

The second commit fixes the issue for the source. This is less trivial, as when a CargoPacket is created, it is moved to the station. But at that moment we don't know what tile will be used for loading. As such, on creation of a CargoPacket the source tile is now kept as INVALID_TILE. And on first load, the actual tile used for loading is set. After this the value is never changed again, meaning we can track distance as normal.

## Limitations

Initially I assumed having different `source_xy` for a single station would increase the amount of CargoPackets drastically. But after some testing with various of scenarios and savegames, I can only conclude that this isn't really noticeable. On very big games there is a slight increase (of about 5%), but not a huge amount (which I expected). For example, one of the openttdcoop games uses ~950 cargopackets before this PR, and ~1000 after.
I think this is due to cargo aging (but I haven't verified that): when the first piece of cargo is loaded, it also ages. So when the next piece of cargo is loaded, it can't be merged. So having another `source_xy` doesn't actually matter.

No savegame conversions are needed; current cargo will just use their current source_xy, which might still be based on the station location. But new cargo that is generated will have the fixes, so slowly, over the next few game-months, the old cargo is replaced by the new, and payment will be fixed. This PR (deliberately, as it is non-trivial code that might break) takes no attempt to retroactively fix the issue for older savegames. That said, in theory, one could walk all existing CargoPackets, and see if they are still in their first station, and reset source_xy. If someone wants to, I can make it happen. But I rather say: let's give older savegames the pleasure of still getting higher payment till new cargo is generated.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
