### PR TITLE
Feature: [NewGRF] Related Act2 objects for airports and airport tiles.

### DIFF
--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -14,6 +14,7 @@
 #include "newgrf_text.h"
 #include "station_base.h"
 #include "newgrf_class_func.h"
+#include "town.h"
 
 #include "safeguards.h"
 
@@ -208,6 +209,26 @@ uint32_t AirportResolverObject::GetDebugID() const
 		this->st->airport.psa = new PersistentStorage(grfid, GSF_AIRPORTS, this->st->airport.tile);
 	}
 	this->st->airport.psa->StoreValue(pos, value);
+}
+
+/**
+ * Get the town scope associated with a station, if it exists.
+ * On the first call, the town scope is created (if possible).
+ * @return Town scope, if available.
+ */
+TownScopeResolver *AirportResolverObject::GetTown()
+{
+	if (!this->town_scope) {
+		Town *t = nullptr;
+		if (this->airport_scope.st != nullptr) {
+			t = this->airport_scope.st->town;
+		} else if (this->airport_scope.tile != INVALID_TILE) {
+			t = ClosestTownFromTile(this->airport_scope.tile, UINT_MAX);
+		}
+		if (t == nullptr) return nullptr;
+		this->town_scope.reset(new TownScopeResolver(*this, t, this->airport_scope.st == nullptr));
+	}
+	return this->town_scope.get();
 }
 
 /**

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -17,50 +17,6 @@
 
 #include "safeguards.h"
 
-/** Resolver for the airport scope. */
-struct AirportScopeResolver : public ScopeResolver {
-	struct Station *st; ///< Station of the airport for which the callback is run, or \c nullptr for build gui.
-	byte airport_id;    ///< Type of airport for which the callback is run.
-	byte layout;        ///< Layout of the airport to build.
-	TileIndex tile;     ///< Tile for the callback, only valid for airporttile callbacks.
-
-	/**
-	 * Constructor of the scope resolver for an airport.
-	 * @param ro Surrounding resolver.
-	 * @param tile %Tile for the callback, only valid for airporttile callbacks.
-	 * @param st %Station of the airport for which the callback is run, or \c nullptr for build gui.
-	 * @param airport_id Type of airport for which the callback is run.
-	 * @param layout Layout of the airport to build.
-	 */
-	AirportScopeResolver(ResolverObject &ro, TileIndex tile, Station *st, byte airport_id, byte layout)
-			: ScopeResolver(ro), st(st), airport_id(airport_id), layout(layout), tile(tile)
-	{
-	}
-
-	uint32_t GetRandomBits() const override;
-	uint32_t GetVariable(byte variable, uint32_t parameter, bool *available) const override;
-	void StorePSA(uint pos, int32_t value) override;
-};
-
-/** Resolver object for airports. */
-struct AirportResolverObject : public ResolverObject {
-	AirportScopeResolver airport_scope;
-
-	AirportResolverObject(TileIndex tile, Station *st, byte airport_id, byte layout,
-			CallbackID callback = CBID_NO_CALLBACK, uint32_t callback_param1 = 0, uint32_t callback_param2 = 0);
-
-	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0) override
-	{
-		switch (scope) {
-			case VSG_SCOPE_SELF: return &this->airport_scope;
-			default: return ResolverObject::GetScope(scope, relative);
-		}
-	}
-
-	GrfSpecFeature GetFeature() const override;
-	uint32_t GetDebugID() const override;
-};
-
 /**
  * Reset airport classes to their default state.
  * This includes initialising the defaults classes with an empty

--- a/src/newgrf_airport.h
+++ b/src/newgrf_airport.h
@@ -15,6 +15,7 @@
 #include "newgrf_class.h"
 #include "newgrf_commons.h"
 #include "newgrf_spritegroup.h"
+#include "newgrf_town.h"
 #include "tilearea_type.h"
 
 /** Copy from station_map.h */
@@ -173,14 +174,23 @@ struct AirportScopeResolver : public ScopeResolver {
 /** Resolver object for airports. */
 struct AirportResolverObject : public ResolverObject {
 	AirportScopeResolver airport_scope;
+	std::unique_ptr<TownScopeResolver> town_scope; ///< The town scope resolver (created on the first call).
 
 	AirportResolverObject(TileIndex tile, Station *st, byte airport_id, byte layout,
 			CallbackID callback = CBID_NO_CALLBACK, uint32_t callback_param1 = 0, uint32_t callback_param2 = 0);
+
+	TownScopeResolver *GetTown();
 
 	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0) override
 	{
 		switch (scope) {
 			case VSG_SCOPE_SELF: return &this->airport_scope;
+			case VSG_SCOPE_PARENT:
+			{
+				TownScopeResolver *tsr = this->GetTown();
+				if (tsr != nullptr) return tsr;
+				FALLTHROUGH;
+			}
 			default: return ResolverObject::GetScope(scope, relative);
 		}
 	}

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -214,7 +214,9 @@ static uint32_t GetAirportTileIDAtOffset(TileIndex tile, const Station *st, uint
  */
 AirportTileResolverObject::AirportTileResolverObject(const AirportTileSpec *ats, TileIndex tile, Station *st,
 		CallbackID callback, uint32_t callback_param1, uint32_t callback_param2)
-	: ResolverObject(ats->grf_prop.grffile, callback, callback_param1, callback_param2), tiles_scope(*this, ats, tile, st)
+	: ResolverObject(ats->grf_prop.grffile, callback, callback_param1, callback_param2),
+		tiles_scope(*this, ats, tile, st),
+		airport_scope(*this, tile, st, st != nullptr ? st->airport.type : (byte)AT_DUMMY, st != nullptr ? st->airport.layout : 0)
 {
 	this->root_spritegroup = ats->grf_prop.spritegroup[0];
 }

--- a/src/newgrf_airporttiles.h
+++ b/src/newgrf_airporttiles.h
@@ -44,6 +44,7 @@ struct AirportTileScopeResolver : public ScopeResolver {
 /** Resolver for tiles of an airport. */
 struct AirportTileResolverObject : public ResolverObject {
 	AirportTileScopeResolver tiles_scope; ///< Scope resolver for the tiles.
+	AirportScopeResolver airport_scope;   ///< Scope resolver for the airport owning the tile.
 
 	AirportTileResolverObject(const AirportTileSpec *ats, TileIndex tile, Station *st,
 			CallbackID callback = CBID_NO_CALLBACK, uint32_t callback_param1 = 0, uint32_t callback_param2 = 0);
@@ -52,6 +53,7 @@ struct AirportTileResolverObject : public ResolverObject {
 	{
 		switch (scope) {
 			case VSG_SCOPE_SELF: return &tiles_scope;
+			case VSG_SCOPE_PARENT: return &airport_scope;
 			default: return ResolverObject::GetScope(scope, relative);
 		}
 	}

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -28,6 +28,7 @@
 #include "train.h"
 #include "roadveh.h"
 
+#include "newgrf_airport.h"
 #include "newgrf_airporttiles.h"
 #include "newgrf_debug.h"
 #include "newgrf_object.h"

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -494,7 +494,7 @@ static const NICallback _nic_airporttiles[] = {
 
 class NIHAirportTile : public NIHelper {
 	bool IsInspectable(uint index) const override        { return AirportTileSpec::Get(GetAirportGfx(index))->grf_prop.grffile != nullptr; }
-	uint GetParent(uint index) const override            { return GetInspectWindowNumber(GSF_FAKE_TOWNS, Station::GetByTile(index)->town->index); }
+	uint GetParent(uint index) const override            { return GetInspectWindowNumber(GSF_AIRPORTS, GetStationIndex(index)); }
 	const void *GetInstance(uint index)const override    { return nullptr; }
 	const void *GetSpec(uint index) const override       { return AirportTileSpec::Get(GetAirportGfx(index)); }
 	void SetStringParameters(uint index) const override  { this->SetObjectAtStringParameters(STR_STATION_NAME, GetStationIndex(index), index); }
@@ -512,6 +512,57 @@ static const NIFeature _nif_airporttile = {
 	_nic_airporttiles,
 	_niv_industrytiles, // Yes, they share this (at least now)
 	new NIHAirportTile(),
+};
+
+
+/*** NewGRF airports ***/
+
+static const NIVariable _niv_airports[] = {
+	NIV(0x40, "Layout number"),
+	NIV(0x48, "bitmask of accepted cargoes"),
+	NIV(0x60, "amount of cargo waiting"),
+	NIV(0x61, "time since last cargo pickup"),
+	NIV(0x62, "rating of cargo"),
+	NIV(0x63, "time spent on route"),
+	NIV(0x64, "information about last vehicle picking cargo up"),
+	NIV(0x65, "amount of cargo acceptance"),
+	NIV(0x69, "information about cargo accepted in the past"),
+	NIV(0xF1, "type of the airport"),
+	NIV(0xF6, "airport block status"),
+	NIV(0xFA, "built date"),
+	NIV_END()
+};
+
+class NIHAiport : public NIHelper {
+	bool IsInspectable(uint index) const override        { return AirportSpec::Get(Station::Get(index)->airport.type)->grf_prop.grffile != nullptr; }
+	uint GetParent(uint index) const override            { return GetInspectWindowNumber(GSF_FAKE_TOWNS, Station::Get(index)->town->index); }
+	const void *GetInstance(uint index)const override    { return Station::Get(index); }
+	const void *GetSpec(uint index) const override       { return AirportSpec::Get(Station::Get(index)->airport.type); }
+	void SetStringParameters(uint index) const override  { this->SetObjectAtStringParameters(STR_STATION_NAME, index, Station::Get(index)->airport.tile); }
+	uint32_t GetGRFID(uint index) const override         { return (this->IsInspectable(index)) ? AirportSpec::Get(Station::Get(index)->airport.type)->grf_prop.grffile->grfid : 0; }
+
+	uint Resolve(uint index, uint var, uint param, bool *avail) const override
+	{
+		Station *st = Station::Get(index);
+		AirportResolverObject ro(st->airport.tile, st, st->airport.type, st->airport.layout);
+		return ro.GetScope(VSG_SCOPE_SELF)->GetVariable(var, param, avail);
+	}
+
+	uint GetPSASize(uint index, uint32_t grfid) const override { return cpp_lengthof(PersistentStorage, storage); }
+
+	const int32_t *GetPSAFirstPosition(uint index, uint32_t grfid) const override
+	{
+		const Station *st = (const Station *)this->GetInstance(index);
+		if (st->airport.psa == nullptr) return nullptr;
+		return (int32_t *)(&st->airport.psa->storage);
+	}
+};
+
+static const NIFeature _nif_airport = {
+	nullptr,
+	nullptr,
+	_niv_airports,
+	new NIHAiport(),
 };
 
 
@@ -680,7 +731,7 @@ static const NIFeature * const _nifeatures[] = {
 	&_nif_industry,     // GSF_INDUSTRIES
 	nullptr,               // GSF_CARGOES (has no "physical" objects)
 	nullptr,               // GSF_SOUNDFX (has no "physical" objects)
-	nullptr,               // GSF_AIRPORTS (feature not implemented)
+	&_nif_airport,      // GSF_AIRPORTS
 	nullptr,               // GSF_SIGNALS (feature not implemented)
 	&_nif_object,       // GSF_OBJECTS
 	&_nif_railtype,     // GSF_RAILTYPES


### PR DESCRIPTION
## Motivation / Problem


NewGRF airports are made out of airport tiles to control on-map appearance, similar to the industry <-> industry tile relation.

Unfortunately, airport tiles don't have a related Act2 object, so it is not possible to reuse tiles between different airports in one GRF. Airports itself don't have a related object either, even though most other similar features (rail stations, industries, towns) refer to the town.


## Description

There's no indication neither in the source code nor in the specs wiki that leaving out the related object was a deliberate design decision.

As such, this PR adds the airport as the related object of the airport tile and the town as the related object of the airport. This mirrors the structure for industries and industry tiles.

While we're at it, also add the missing NewGRF inspection window for airports, which can be reached from the existing inspection window for airport tiles. As the station window is not specific just to airports, I opted not to add a direct inspection button there.


## Limitations

No test GRF was made.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
