### PR TITLE
Fix: only count distance traveled in vehicles for cargo payment

### DIFF
--- a/src/cargoaction.cpp
+++ b/src/cargoaction.cpp
@@ -120,7 +120,7 @@ bool CargoLoad::operator()(CargoPacket *cp)
 {
 	CargoPacket *cp_new = this->Preprocess(cp);
 	if (cp_new == nullptr) return false;
-	cp_new->SetSourceXY(this->current_tile);
+	cp_new->UpdateLoadingTile(this->current_tile);
 	this->source->RemoveFromCache(cp_new, cp_new->Count());
 	this->destination->Append(cp_new, VehicleCargoList::MTA_KEEP);
 	return cp_new == cp;
@@ -135,7 +135,7 @@ bool CargoReservation::operator()(CargoPacket *cp)
 {
 	CargoPacket *cp_new = this->Preprocess(cp);
 	if (cp_new == nullptr) return false;
-	cp_new->SetSourceXY(this->current_tile);
+	cp_new->UpdateLoadingTile(this->current_tile);
 	this->source->reserved_count += cp_new->Count();
 	this->source->RemoveFromCache(cp_new, cp_new->Count());
 	this->destination->Append(cp_new, VehicleCargoList::MTA_LOAD);
@@ -152,6 +152,7 @@ bool CargoReturn::operator()(CargoPacket *cp)
 	CargoPacket *cp_new = this->Preprocess(cp);
 	if (cp_new == nullptr) cp_new = cp;
 	assert(cp_new->Count() <= this->destination->reserved_count);
+	cp_new->UpdateUnloadingTile(this->current_tile);
 	this->source->RemoveFromMeta(cp_new, VehicleCargoList::MTA_LOAD, cp_new->Count());
 	this->destination->reserved_count -= cp_new->Count();
 	this->destination->Append(cp_new, this->next);
@@ -167,6 +168,7 @@ bool CargoTransfer::operator()(CargoPacket *cp)
 {
 	CargoPacket *cp_new = this->Preprocess(cp);
 	if (cp_new == nullptr) return false;
+	cp_new->UpdateUnloadingTile(this->current_tile);
 	this->source->RemoveFromMeta(cp_new, VehicleCargoList::MTA_TRANSFER, cp_new->Count());
 	/* No transfer credits here as they were already granted during Stage(). */
 	this->destination->Append(cp_new, cp_new->GetNextHop());

--- a/src/cargoaction.h
+++ b/src/cargoaction.h
@@ -70,9 +70,11 @@ public:
 
 /** Action of transferring cargo from a vehicle to a station. */
 class CargoTransfer : public CargoMovement<VehicleCargoList, StationCargoList> {
+protected:
+	TileIndex current_tile; ///< Current tile cargo unloading is happening.
 public:
-	CargoTransfer(VehicleCargoList *source, StationCargoList *destination, uint max_move) :
-			CargoMovement<VehicleCargoList, StationCargoList>(source, destination, max_move) {}
+	CargoTransfer(VehicleCargoList *source, StationCargoList *destination, uint max_move, TileIndex current_tile) :
+			CargoMovement<VehicleCargoList, StationCargoList>(source, destination, max_move), current_tile(current_tile) {}
 	bool operator()(CargoPacket *cp);
 };
 
@@ -96,10 +98,12 @@ public:
 
 /** Action of returning previously reserved cargo from the vehicle to the station. */
 class CargoReturn : public CargoMovement<VehicleCargoList, StationCargoList> {
+protected:
+	TileIndex current_tile; ///< Current tile cargo unloading is happening.
 	StationID next;
 public:
-	CargoReturn(VehicleCargoList *source, StationCargoList *destination, uint max_move, StationID next) :
-			CargoMovement<VehicleCargoList, StationCargoList>(source, destination, max_move), next(next) {}
+	CargoReturn(VehicleCargoList *source, StationCargoList *destination, uint max_move, StationID next, TileIndex current_tile) :
+			CargoMovement<VehicleCargoList, StationCargoList>(source, destination, max_move), current_tile(current_tile), next(next) {}
 	bool operator()(CargoPacket *cp);
 };
 

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -39,14 +39,26 @@ extern SaveLoadTable GetCargoPacketDesc();
  */
 struct CargoPacket : CargoPacketPool::PoolItem<&_cargopacket_pool> {
 private:
+	/* A mathematical vector from (0,0). */
+	struct Vector {
+		int16_t x;
+		int16_t y;
+	};
+
 	uint16_t count{0}; ///< The amount of cargo in this packet.
 	uint16_t periods_in_transit{0}; ///< Amount of cargo aging periods this packet has been in transit.
 
 	Money feeder_share{0}; ///< Value of feeder pickup to be paid for on delivery of cargo.
 
 	TileIndex source_xy{INVALID_TILE}; ///< The origin of the cargo.
+	Vector travelled{0, 0}; ///< If cargo is in station: the vector from the unload tile to the source tile. If in vehicle: an intermediate value.
+
 	SourceID source_id{INVALID_SOURCE}; ///< Index of industry/town/HQ, INVALID_SOURCE if unknown/invalid.
 	SourceType source_type{SourceType::Industry}; ///< Type of \c source_id.
+
+#ifdef WITH_ASSERT
+	bool in_vehicle{false}; ///< NOSAVE: Whether this cargo is in a vehicle or not.
+#endif /* WITH_ASSERT */
 
 	StationID first_station{INVALID_STATION}; ///< The station where the cargo came from first.
 	StationID next_hop{INVALID_STATION}; ///< Station where the cargo wants to go next.
@@ -83,22 +95,51 @@ public:
 	}
 
 	/**
-	 * Set the origin of the packet.
+	 * Update for the cargo being loaded on this tile.
 	 *
-	 * Can only be set once.
+	 * When a CargoPacket is created, it is moved to a station. But at that
+	 * moment in time it is not known yet at which tile the cargo will be
+	 * picked up. As this tile is used for payment information, we delay
+	 * setting the source_xy till first pickup, getting a better idea where
+	 * a cargo started from.
 	 *
-	 * When a packet is created, it is moved to a station. But at that moment
-	 * in time it is not known yet at which tile the cargo will be picked up.
-	 * As this tile is used for payment information, we delay setting the
-	 * source_xy till first pickup.
+	 * Further more, we keep track of the amount of tiles the cargo moved
+	 * inside a vehicle. This is used in GetDistance() below.
 	 *
 	 * @param tile Tile the cargo is being picked up from.
 	 */
-	void SetSourceXY(TileIndex tile)
+	void UpdateLoadingTile(TileIndex tile)
 	{
 		if (this->source_xy == INVALID_TILE) {
 			this->source_xy = tile;
 		}
+
+#ifdef WITH_ASSERT
+		assert(!this->in_vehicle);
+		this->in_vehicle = true;
+#endif /* WITH_ASSERT */
+
+		/* We want to calculate the vector from tile-unload to tile-load. As
+		 * we currently only know the latter, add it. When we know where we unload,
+		 * we subtract is, giving us our vector (unload - load). */
+		this->travelled.x += TileX(tile);
+		this->travelled.y += TileY(tile);
+	}
+
+	/**
+	 * Update for the cargo being unloaded on this tile.
+	 *
+	 * @param tile Tile the cargo is being dropped off at.
+	 */
+	void UpdateUnloadingTile(TileIndex tile)
+	{
+#ifdef WITH_ASSERT
+		assert(this->in_vehicle);
+		this->in_vehicle = false;
+#endif /* WITH_ASSERT */
+
+		this->travelled.x -= TileX(tile);
+		this->travelled.y -= TileY(tile);
 	}
 
 	/**
@@ -188,7 +229,36 @@ public:
 	inline uint GetDistance(TileIndex current_tile) const
 	{
 		assert(this->source_xy != INVALID_TILE);
-		return DistanceManhattan(this->source_xy, current_tile);
+#ifdef WITH_ASSERT
+		assert(this->in_vehicle);
+#endif /* WITH_ASSERT */
+
+		/* Distance is always requested when the cargo is still inside the
+		 * vehicle. So first finish the calculation for travelled to
+		 * become a vector. */
+		auto local_travelled = travelled;
+		local_travelled.x -= TileX(current_tile);
+		local_travelled.y -= TileY(current_tile);
+
+		/* Cargo-movement is a vector that indicates how much the cargo has
+		 * actually traveled in a vehicle. This is the distance you get paid
+		 * for. However, one could construct a route where this vector would
+		 * be really long. To not overpay the player, cap out at the distance
+		 * between source and destination.
+		 *
+		 * This way of calculating is to counter people moving cargo for free
+		 * and instantly in stations, where you deliver it in one part of the
+		 * station and pick it up in another. By using the actual distance
+		 * traveled in a vehicle, using this trick doesn't give you more money.
+		 *
+		 * However, especially in large networks with large transfer station,
+		 * etc, one could actually make the route a lot longer. In that case,
+		 * use the actual distance between source and destination.
+		 */
+
+		uint distance_travelled = abs(local_travelled.x) + abs(local_travelled.y);
+		uint distance_source_dest = DistanceManhattan(this->source_xy, current_tile);
+		return std::min(distance_travelled, distance_source_dest);
 	}
 
 	/**
@@ -427,7 +497,7 @@ public:
 
 	template<MoveToAction Tfrom, MoveToAction Tto>
 	uint Reassign(uint max_move);
-	uint Return(uint max_move, StationCargoList *dest, StationID next_station);
+	uint Return(uint max_move, StationCargoList *dest, StationID next_station, TileIndex current_tile);
 	uint Unload(uint max_move, StationCargoList *dest, CargoPayment *payment, TileIndex current_tile);
 	uint Shift(uint max_move, VehicleCargoList *dest);
 	uint Truncate(uint max_move = UINT_MAX);

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1438,7 +1438,7 @@ struct ReturnCargoAction
 	 */
 	bool operator()(Vehicle *v)
 	{
-		v->cargo.Return(UINT_MAX, &this->st->goods[v->cargo_type].cargo, this->next_hop);
+		v->cargo.Return(UINT_MAX, &this->st->goods[v->cargo_type].cargo, this->next_hop, v->tile);
 		return true;
 	}
 };
@@ -1698,7 +1698,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 					uint new_remaining = v->cargo.RemainingCount() + v->cargo.ActionCount(VehicleCargoList::MTA_DELIVER);
 					if (v->cargo_cap < new_remaining) {
 						/* Return some of the reserved cargo to not overload the vehicle. */
-						v->cargo.Return(new_remaining - v->cargo_cap, &ge->cargo, INVALID_STATION);
+						v->cargo.Return(new_remaining - v->cargo_cap, &ge->cargo, INVALID_STATION, v->tile);
 					}
 
 					/* Keep instead of delivering. This may lead to no cargo being unloaded, so ...*/

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -360,6 +360,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_PERIODS_IN_TRANSIT_RENAME,          ///< 316  PR#11112 Rename days in transit to (cargo) periods in transit.
 	SLV_NEWGRF_LAST_SERVICE,                ///< 317  PR#11124 Added stable date_of_last_service to avoid NewGRF trouble.
 	SLV_REMOVE_LOADED_AT_XY,                ///< 318  PR#11276 Remove loaded_at_xy variable from CargoPacket.
+	SLV_CARGO_TRAVELLED,                    ///< 319  PR#11283 CargoPacket now tracks how far it travelled inside a vehicle.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2241,7 +2241,7 @@ void Vehicle::CancelReservation(StationID next, Station *st)
 		VehicleCargoList &cargo = v->cargo;
 		if (cargo.ActionCount(VehicleCargoList::MTA_LOAD) > 0) {
 			Debug(misc, 1, "cancelling cargo reservation");
-			cargo.Return(UINT_MAX, &st->goods[v->cargo_type].cargo, next);
+			cargo.Return(UINT_MAX, &st->goods[v->cargo_type].cargo, next, v->tile);
 		}
 		cargo.KeepAll();
 	}


### PR DESCRIPTION
## Motivation / Problem

Given this map:
![image](https://github.com/OpenTTD/OpenTTD/assets/1663690/0c138042-2999-4ac6-8941-97b21ef99849)

Where most stations are like this:
![image](https://github.com/OpenTTD/OpenTTD/assets/1663690/05e0caaf-b26e-44f8-85ee-2c55b7cc6f2e)

One can abuse the fact that cargo in stations are instantly (and free of charge) moved between tiles. What happens here is this:

- Cargo is picked up from the coal mine
- It is delivered in the first station. The first station is station-spread connected to the second.
- The second station is right next to the first station. So the truck goes from the first to the second station by driving 4 tiles (2 station tiles + 2 road tiles)
- This continues all the way down to close by the destination
- There it is picked up and delivered

Now something really funny happens here: the incoming per vehiclechain is the same as having a single truck drive all the way. As the loading/unloading takes about as long the travel time. But: the throughput increases by a lot. So you can make a lot more money this way .. about ten times as much in this setup.

This PR sets out to address that, and is basically #11274 implemented on top of #11281. It only contains a lot more documentation and description, to make much more clear what is going on. Also, I picked a few things differently. The end result is the same: after this PR, you can no longer misuse the free labour given to you by station workers.

[teleport-profit.zip](https://github.com/OpenTTD/OpenTTD/files/12569699/teleport-profit.zip)

Closes #11274.

## Description

To combat this misuse, #11274 found a clever approach: create a vector of distance moved in vehicles, and use that for payment. This boils down to:

- Get the vector of each leg the cargo traveled
- Add those vectors up
- Get the Manhattan distance of this total vector
- This is your distance traveled.

This works really well to resolve this teleportation. However, there is an edgecase: big networks might take the cargo the wrong way first to bring it back in, using a lot of this station teleportation along the way. It can be that the vector ends up much larger than the actual distance between source and destination. For that reason, the smallest of these two is used: either the (Manhattan) size of the vector, or the Manhattan distance between source and destination.

To cheap out on variables (and struct-size), `cargo_movement` is a vector in station, but it is a virtual point when in a vehicle. As we have to calculate the vector of a leg, which is A - B, we add A to the vector when leaving a station, and remove B when entering a station. That way, `cargo_movement` is only a vector when in a station. When it is in a vehicle, it doesn't actually have a meaning.

The variable `in_vehicle` is introduced purely to run `assert` on. As such, it is only compiled in when `WITH_ASSERT` is enabled. It is not meant to be used otherwise. It is just there to ensure `cargo_movement` is in the right state.

For loading older savegames, choices have to be made. I picked one, but you sure can have another. I am open for that dialog.

Although 5 bytes are added to CargoPacket, the actual size (on a 64-bit machine) isn't changed, as there were 5 bytes free to be used: 27 used. Now 32 used. As we still need access to `source_xy`, so we can calculate the Manhattan distance between source and destination, `cargo_movement` is added as extra field.

## Limitations

None that I know of, although this could use some extra testing etc. I did a lot of testing with all kind of different savegames, and all seem to be good. The attached savegame also shows the teleport problem is solved.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
