### PR TITLE
Fix b0e73277: save/load next_station for CargoPacket again 

### DIFF
--- a/src/cargoaction.cpp
+++ b/src/cargoaction.cpp
@@ -167,7 +167,7 @@ bool CargoTransfer::operator()(CargoPacket *cp)
 	if (cp_new == nullptr) return false;
 	this->source->RemoveFromMeta(cp_new, VehicleCargoList::MTA_TRANSFER, cp_new->Count());
 	/* No transfer credits here as they were already granted during Stage(). */
-	this->destination->Append(cp_new, cp_new->GetNextStation());
+	this->destination->Append(cp_new, cp_new->GetNextHop());
 	return cp_new == cp;
 }
 
@@ -217,8 +217,8 @@ bool VehicleCargoReroute::operator()(CargoPacket *cp)
 {
 	CargoPacket *cp_new = this->Preprocess(cp);
 	if (cp_new == nullptr) cp_new = cp;
-	if (cp_new->GetNextStation() == this->avoid || cp_new->GetNextStation() == this->avoid2) {
-		cp->SetNextStation(this->ge->GetVia(cp_new->GetFirstStation(), this->avoid, this->avoid2));
+	if (cp_new->GetNextHop() == this->avoid || cp_new->GetNextHop() == this->avoid2) {
+		cp->SetNextHop(this->ge->GetVia(cp_new->GetFirstStation(), this->avoid, this->avoid2));
 	}
 	if (this->source != this->destination) {
 		this->source->RemoveFromMeta(cp_new, VehicleCargoList::MTA_TRANSFER, cp_new->Count());

--- a/src/cargopacket.cpp
+++ b/src/cargopacket.cpp
@@ -533,7 +533,7 @@ void VehicleCargoList::InvalidateCache()
  * @return Amount of cargo actually reassigned.
  */
 template<VehicleCargoList::MoveToAction Tfrom, VehicleCargoList::MoveToAction Tto>
-uint VehicleCargoList::Reassign(uint max_move, StationID)
+uint VehicleCargoList::Reassign(uint max_move)
 {
 	static_assert(Tfrom != MTA_TRANSFER && Tto != MTA_TRANSFER);
 	static_assert(Tfrom - Tto == 1 || Tto - Tfrom == 1);
@@ -547,11 +547,10 @@ uint VehicleCargoList::Reassign(uint max_move, StationID)
  * Reassign cargo from MTA_DELIVER to MTA_TRANSFER and take care of the next
  * station the cargo wants to visit.
  * @param max_move Maximum amount of cargo to reassign.
- * @param next_station Station to record as next hop in the reassigned packets.
  * @return Amount of cargo actually reassigned.
  */
 template<>
-uint VehicleCargoList::Reassign<VehicleCargoList::MTA_DELIVER, VehicleCargoList::MTA_TRANSFER>(uint max_move, StationID next_station)
+uint VehicleCargoList::Reassign<VehicleCargoList::MTA_DELIVER, VehicleCargoList::MTA_TRANSFER>(uint max_move)
 {
 	max_move = std::min(this->action_counts[MTA_DELIVER], max_move);
 
@@ -565,7 +564,7 @@ uint VehicleCargoList::Reassign<VehicleCargoList::MTA_DELIVER, VehicleCargoList:
 			sum -= cp_split->Count();
 			this->packets.insert(it, cp_split);
 		}
-		cp->next_station = next_station;
+		cp->next_station = INVALID_STATION;
 	}
 
 	this->action_counts[MTA_DELIVER] -= max_move;
@@ -844,4 +843,4 @@ uint StationCargoList::Reroute(uint max_move, StationCargoList *dest, StationID 
  */
 template class CargoList<VehicleCargoList, CargoPacketList>;
 template class CargoList<StationCargoList, StationCargoPacketMap>;
-template uint VehicleCargoList::Reassign<VehicleCargoList::MTA_DELIVER, VehicleCargoList::MTA_KEEP>(uint, StationID);
+template uint VehicleCargoList::Reassign<VehicleCargoList::MTA_DELIVER, VehicleCargoList::MTA_KEEP>(uint);

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -403,7 +403,7 @@ public:
 	 * applicable), return value is amount of cargo actually moved. */
 
 	template<MoveToAction Tfrom, MoveToAction Tto>
-	uint Reassign(uint max_move, StationID update = INVALID_STATION);
+	uint Reassign(uint max_move);
 	uint Return(uint max_move, StationCargoList *dest, StationID next_station);
 	uint Unload(uint max_move, StationCargoList *dest, CargoPayment *payment);
 	uint Shift(uint max_move, VehicleCargoList *dest);

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -422,7 +422,6 @@ public:
 		return cp1->source_xy == cp2->source_xy &&
 				cp1->periods_in_transit == cp2->periods_in_transit &&
 				cp1->source_type == cp2->source_type &&
-				cp1->next_station == cp2->next_station &&
 				cp1->source_id == cp2->source_id;
 	}
 };
@@ -537,7 +536,6 @@ public:
 		return cp1->source_xy == cp2->source_xy &&
 				cp1->periods_in_transit == cp2->periods_in_transit &&
 				cp1->source_type == cp2->source_type &&
-				cp1->next_station == cp2->next_station &&
 				cp1->source_id == cp2->source_id;
 	}
 };

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -49,7 +49,7 @@ private:
 	SourceType source_type{SourceType::Industry}; ///< Type of \c source_id.
 
 	StationID first_station{INVALID_STATION}; ///< The station where the cargo came from first.
-	StationID next_station{INVALID_STATION}; ///< Station where the cargo wants to go next.
+	StationID next_hop{INVALID_STATION}; ///< Station where the cargo wants to go next.
 
 	/** The CargoList caches, thus needs to know about it. */
 	template <class Tinst, class Tcont> friend class CargoList;
@@ -74,11 +74,11 @@ public:
 
 	/**
 	 * Sets the station where the packet is supposed to go next.
-	 * @param next_station Next station the packet should go to.
+	 * @param next_hop Next station the packet should go to.
 	 */
-	void SetNextStation(StationID next_station)
+	void SetNextHop(StationID next_hop)
 	{
-		this->next_station = next_station;
+		this->next_hop = next_hop;
 	}
 
 	/**
@@ -172,9 +172,9 @@ public:
 	 * Gets the ID of station the cargo wants to go next.
 	 * @return Next station for this packets.
 	 */
-	inline StationID GetNextStation() const
+	inline StationID GetNextHop() const
 	{
-		return this->next_station;
+		return this->next_hop;
 	}
 
 	static void InvalidateAllFrom(SourceType src_type, SourceID src);

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1689,7 +1689,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 				if (front->current_order.GetUnloadType() & (OUFB_TRANSFER | OUFB_UNLOAD)) {
 					/* Transfer instead of delivering. */
 					v->cargo.Reassign<VehicleCargoList::MTA_DELIVER, VehicleCargoList::MTA_TRANSFER>(
-							v->cargo.ActionCount(VehicleCargoList::MTA_DELIVER), INVALID_STATION);
+							v->cargo.ActionCount(VehicleCargoList::MTA_DELIVER));
 				} else {
 					uint new_remaining = v->cargo.RemainingCount() + v->cargo.ActionCount(VehicleCargoList::MTA_DELIVER);
 					if (v->cargo_cap < new_remaining) {

--- a/src/saveload/cargopacket_sl.cpp
+++ b/src/saveload/cargopacket_sl.cpp
@@ -88,6 +88,8 @@ SaveLoadTable GetCargoPacketDesc()
 	static const SaveLoad _cargopacket_desc[] = {
 		SLE_VARNAME(CargoPacket, first_station, "source", SLE_UINT16),
 		SLE_VAR(CargoPacket, source_xy,       SLE_UINT32),
+		SLE_CONDVARNAME(CargoPacket, next_hop, "loaded_at_xy", SLE_FILE_U32 | SLE_VAR_U16, SL_MIN_VERSION, SLV_REMOVE_LOADED_AT_XY),
+		SLE_CONDVARNAME(CargoPacket, next_hop, "loaded_at_xy", SLE_UINT16, SLV_REMOVE_LOADED_AT_XY, SL_MAX_VERSION),
 		SLE_VAR(CargoPacket, count,           SLE_UINT16),
 		SLE_CONDVARNAME(CargoPacket, periods_in_transit, "days_in_transit", SLE_FILE_U8 | SLE_VAR_U16, SL_MIN_VERSION, SLV_MORE_CARGO_AGE),
 		SLE_CONDVARNAME(CargoPacket, periods_in_transit, "days_in_transit", SLE_UINT16, SLV_MORE_CARGO_AGE, SLV_PERIODS_IN_TRANSIT_RENAME),

--- a/src/saveload/compat/cargopacket_sl_compat.h
+++ b/src/saveload/compat/cargopacket_sl_compat.h
@@ -16,7 +16,7 @@
 const SaveLoadCompat _cargopacket_sl_compat[] = {
 	SLC_VAR("source"),
 	SLC_VAR("source_xy"),
-	SLC_NULL(4, SL_MIN_VERSION, SLV_REMOVE_LOADED_AT_XY),
+	SLC_VAR("loaded_at_xy"),
 	SLC_VAR("count"),
 	SLC_VAR("days_in_transit"),
 	SLC_VAR("feeder_share"),

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -710,7 +710,7 @@ static bool LoadOldGood(LoadgameState *ls, int num)
 	SB(ge->status, GoodsEntry::GES_ACCEPTANCE, 1, HasBit(_waiting_acceptance, 15));
 	SB(ge->status, GoodsEntry::GES_RATING, 1, _cargo_source != 0xFF);
 	if (GB(_waiting_acceptance, 0, 12) != 0 && CargoPacket::CanAllocateItem()) {
-		ge->cargo.Append(new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, (_cargo_source == 0xFF) ? INVALID_STATION : _cargo_source, 0, 0),
+		ge->cargo.Append(new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, (_cargo_source == 0xFF) ? INVALID_STATION : _cargo_source, INVALID_STATION, 0),
 				INVALID_STATION);
 	}
 


### PR DESCRIPTION
## Motivation / Problem

@JGRennison rightfully noticed that `next_station` was no longer stored. It used to be a union with `loaded_at_xy`, and as such, got stored. But now that is gone, it was left unsaved.

This is only a problem when a save happens during the transfer of cargo to a station when cargodist is enabled. After loading the game, the transfer continues but without a next-station set, and as such, it ends up in the wrong bucket. This can result in cargo being routed poorly, till the bucket is reorganised. Mainly: it most likely desyncs multiplayer games.

This shows how confusing using unions like this is, but okay. I should have been more careful.

## Description

While at it, I kept wondering: what does `next_station` actually do, and why does it need storing? Especially as loading now creates sometimes invalid values on `next_station`, as it was an old `loaded_at_xy`.

But, don't be afraid, it is only used during transfers. Basically, when a transfer happens, the next hop is calculated. This is stored in the cargo-packet, as transfers is calculated once, but unloading takes a long time, a few cargo-count at the time.

This next-hop is used in the station storage, to index cargo-packets per next-hop. So it is a rather temporary variable, but as unloading takes time, needs saving.

Wile at it, also cleaned up the code a bit:
- `next_station` was also used for related-but-different `StationIDStack`. So renamed our `next_station` to `next_hop`, so searching the code becomes easier.
- `VehicleCargoList::Reassign` took `next_hop` as parameter, but it was always set to `INVALID_STATION`. So now it just always sets `next_hop` to `INVALID_STATION` directly. I think this statement could be removed, but not 100% sure, so I left it in.
- `VehicleCargoList` also compared the value of `next_hop`, but this was wrong. In a vehicle, this is irrelevant, and packets can be merged freely.
- `StationCargoList` also compared the value, but this is pointless, as they are already in their own queue. Before b0e73277 this was already the case too, and only `loaded_at_xy` was compared in `VehicleCargoList`.
- As `0` is also a `StationID`, and `CargoPacket` has some optional parameters in its constructor, one case of `CargoPacket` initialize was missed in a previous commit. This meant it read `0` instead of `INVALID_STATION` for `next_hop`, which felt wrong. Fixed the issue.

## Limitations

I reused the previous bump done by b0e73277. All savegames load fine, from before b0e73277 and even after. But by not bumping, you cannot see based on the savegame if it was made during this short period where this was broken.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
