### PR TITLE
Doc: Add more hyperlinks within the included documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,16 @@ There is no single source for OpenTTD development docs. It's a complex project w
 A good entry point is [Development](https://wiki.openttd.org/en/Development/) on the OpenTTD wiki; this provides links to wiki documentation and other sources.
 
 The GitHub repo also includes some non-comprehensive documentation in [/docs](./docs).
+These include:
+- When to [change other languages and when not to](./docs/eints.md).
+- The [savegame format](./docs/savegame_format.md).
+- The [release process](./docs/releasing_openttd.md).
+- Some [notes on the link graph algorithm](./docs/linkgraph.md).
+- The [network game coordinator](./docs/game_coordinator.md).
+- How to use [the admin port for network games](./docs/admin_network.md), also useful for multiplayer server hosts.
+- The [performance metrics and logging features](./docs/logging_and_performance_metrics.md), also useful for add-on developers.
+- How [symbol server and analysis works](./docs/symbol_server.md).
+- And several miscellaneous files detailing internal data structures and graphics measurements and palettes.
 
 You may also want the guide to [compiling OpenTTD](./COMPILING.md).
 

--- a/COPYING.md
+++ b/COPYING.md
@@ -1,5 +1,5 @@
 This is the license which applies to OpenTTD with the exception of some
-3rd party modules. See [./README.md](./README.md) for details
+3rd party modules. See [our readme](./README.md) for details
 
 GNU General Public License
 ==========================

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@
     - 1.6) [OpenTTD directories](#16-openttd-directories)
     - 1.7) [Compiling OpenTTD](#17-compiling-openttd)
 - 2.0) [Contact and community](#20-contact-and-community)
-    - 2.1) [Contributing to OpenTTD](#21-contributing-to-openttd)
-    - 2.2) [Reporting bugs](#22-reporting-bugs)
-    - 2.3) [Translating](#23-translating)
+    - 2.1) [Multiplayer games](#21-multiplayer-games)
+    - 2.2) [Contributing to OpenTTD](#22-contributing-to-openttd)
+    - 2.3) [Reporting bugs](#23-reporting-bugs)
+    - 2.4) [Translating](#24-translating)
 - 3.0) [Licensing](#30-licensing)
 - 4.0) [Credits](#40-credits)
 
@@ -144,12 +145,19 @@ If you want to compile OpenTTD from source, instructions can be found in [COMPIL
 - the OpenTTD wiki has a [page listing OpenTTD communities](https://wiki.openttd.org/en/Community/Community) including some in languages other than English
 
 
-### 2.1) Contributing to OpenTTD
+### 2.1) Multiplayer games
+
+You can play OpenTTD with others, either cooperatively or competitively.
+
+See the [multiplayer documentation](./docs/multiplayer.md) for more details.
+
+
+### 2.2) Contributing to OpenTTD
 
 We welcome contributors to OpenTTD.  More information for contributors can be found in [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 
-### 2.2) Reporting bugs
+### 2.3) Reporting bugs
 
 Good bug reports are very helpful.  We have a [guide to reporting bugs](./CONTRIBUTING.md#bug-reports) to help with this.
 
@@ -157,7 +165,7 @@ Desyncs in multiplayer are complex to debug and report (some software developmen
 Instructions can be found in [debugging and reporting desyncs](./docs/debugging_desyncs.md).
 
 
-### 2.3) Translating
+### 2.4) Translating
 
 OpenTTD is translated into many languages.  Translations are added and updated via the [online translation tool](https://translator.openttd.org).
 

--- a/docs/debugging_desyncs.md
+++ b/docs/debugging_desyncs.md
@@ -53,4 +53,7 @@ Do NOT remove the dmp_cmds savegames of a desync you have reported until the
 desync has been fixed; if you, by accident, send us the wrong savegames we
 will not be able to reproduce the desync and thus will be unable to fix it.
 
+## More information
 
+You can find more theory on the causes and debugging of desyncs in the
+[desync documentation](./desync.md).

--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -193,6 +193,9 @@ If it is, and your server still isn't showing up, start OpenTTD with
 `-d net=4` as extra argument. This will show debug message related to the
 network, including communication to/from the Game Coordinator.
 
+See the [Game Coordinator documentation](./game_coordinator.md) for more
+technical information about the Game Coordinator service.
+
 ### My server warns a lot about getaddrinfo taking N seconds
 
 This could be a transient issue with your (local) DNS server, but if the


### PR DESCRIPTION
## Motivation / Problem

As requested in #7786, split off the documentation improvements from the Help Window PR.

This introduces several more references to other documentation in our repository. Hopefully making it a bit easier for people to navigate, to find and to be found.

## Description

Mostly the work of @nielsmh . I did make some stylistic changes, and added documentation added after his commit.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
