### PR TITLE
Fix: marked text was not updated during text deletion

### DIFF
--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -247,14 +247,21 @@ void Textbuf::DeleteText(uint16_t from, uint16_t to, bool update)
 	this->bytes -= to - from;
 	this->chars -= c;
 
-	/* Fixup caret if needed. */
-	if (this->caretpos > from) {
-		if (this->caretpos <= to) {
-			this->caretpos = from;
+	auto fixup = [&](uint16_t &pos) {
+		if (pos <= from) return;
+		if (pos <= to) {
+			pos = from;
 		} else {
-			this->caretpos -= to - from;
+			pos -= to - from;
 		}
-	}
+	};
+
+	/* Fixup caret if needed. */
+	fixup(this->caretpos);
+
+	/* Fixup marked text if needed. */
+	fixup(this->markpos);
+	fixup(this->markend);
 
 	if (update) {
 		this->UpdateStringIter();


### PR DESCRIPTION
## Motivation / Problem
* open the console
* switch keyboard to japanese IME
* enter non latin text
* trigger https://github.com/OpenTTD/OpenTTD/blob/master/src/gfx.cpp#L883

It crashes because `markend` can be outside of the string after text deletion.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Properly update marked text start and end during text deletion, like it was already done for caret.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
