### PR TITLE
Codechange: Pass by reference and use emplace-at-end for CargoSummary.

### DIFF
--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -280,8 +280,7 @@ static void GetCargoSummaryOfArticulatedVehicle(const Train *v, CargoSummary &su
 
 		auto item = std::find(std::begin(summary), std::end(summary), new_item);
 		if (item == std::end(summary)) {
-			summary.emplace_back();
-			item = std::end(summary) - 1;
+			item = summary.emplace(std::end(summary));
 			item->cargo = new_item.cargo;
 			item->subtype = new_item.subtype;
 			item->capacity = 0;

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -267,9 +267,9 @@ static void TrainDetailsCapacityTab(const CargoSummaryItem *item, int left, int 
  * @param v Vehicle to process
  * @param summary Space for the result
  */
-static void GetCargoSummaryOfArticulatedVehicle(const Train *v, CargoSummary *summary)
+static void GetCargoSummaryOfArticulatedVehicle(const Train *v, CargoSummary &summary)
 {
-	summary->clear();
+	summary.clear();
 	do {
 		if (!v->GetEngine()->CanCarryCargo()) continue;
 
@@ -278,10 +278,10 @@ static void GetCargoSummaryOfArticulatedVehicle(const Train *v, CargoSummary *su
 		new_item.subtype = GetCargoSubtypeText(v);
 		if (!IsValidCargoID(new_item.cargo) && new_item.subtype == STR_EMPTY) continue;
 
-		auto item = std::find(summary->begin(), summary->end(), new_item);
-		if (item == summary->end()) {
-			summary->emplace_back();
-			item = summary->end() - 1;
+		auto item = std::find(std::begin(summary), std::end(summary), new_item);
+		if (item == std::end(summary)) {
+			summary.emplace_back();
+			item = std::end(summary) - 1;
 			item->cargo = new_item.cargo;
 			item->subtype = new_item.subtype;
 			item->capacity = 0;
@@ -331,7 +331,7 @@ int GetTrainDetailsWndVScroll(VehicleID veh_id, TrainDetailsWindowTabs det_tab)
 		num++; // needs one more because first line is description string
 	} else {
 		for (const Train *v = Train::Get(veh_id); v != nullptr; v = v->GetNextVehicle()) {
-			GetCargoSummaryOfArticulatedVehicle(v, &_cargo_summary);
+			GetCargoSummaryOfArticulatedVehicle(v, _cargo_summary);
 			num += std::max(1u, (unsigned)_cargo_summary.size());
 
 			uint length = GetLengthOfArticulatedVehicle(v);
@@ -363,7 +363,7 @@ void DrawTrainDetails(const Train *v, const Rect &r, int vscroll_pos, uint16_t v
 		Direction dir = rtl ? DIR_E : DIR_W;
 		int x = rtl ? r.right : r.left;
 		for (; v != nullptr && vscroll_pos > -vscroll_cap; v = v->GetNextVehicle()) {
-			GetCargoSummaryOfArticulatedVehicle(v, &_cargo_summary);
+			GetCargoSummaryOfArticulatedVehicle(v, _cargo_summary);
 
 			/* Draw sprites */
 			uint dx = 0;


### PR DESCRIPTION
## Motivation / Problem

* Passing a pointer but not checking it's null.
* Using emplace_back() and then end() - 1 to get an iterator to a new element.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

* Replace pointer with reference, no need to check null.
* Use emplace(end()) pattern to directly get iterator to new element.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
