### PR TITLE
Fix #11297: SCC_GENDER_LIST tried to determine the gender from the wrong sub-string.

### DIFF
--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -129,7 +129,7 @@ public:
 	 */
 	StringParameters GetRemainingParameters(size_t offset)
 	{
-		return StringParameters(this->parameters.subspan(this->offset, GetDataLeft()));
+		return StringParameters(this->parameters.subspan(offset, GetDataLeft()));
 	}
 
 	/** Return the amount of elements which can still be read. */


### PR DESCRIPTION
## Motivation / Problem

#11297

## Description

#11050 added a `this->`, when there should be none.
No idea why no "unused parameter" warning was issued by the compiler.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
