### PR TITLE
Fix: compilation failed on gcc 10.2 due to missing include.

### DIFF
--- a/src/os/unix/crashlog_unix.cpp
+++ b/src/os/unix/crashlog_unix.cpp
@@ -23,10 +23,6 @@
 #	include <execinfo.h>
 #endif
 
-#if defined(__NetBSD__)
-#include <unistd.h>
-#endif
-
 #ifdef WITH_UNOFFICIAL_BREAKPAD
 #	include <client/linux/handler/exception_handler.h>
 #endif
@@ -35,6 +31,8 @@
 #	include <emscripten.h>
 /* We avoid abort(), as it is a SIGBART, and use _exit() instead. But emscripten doesn't know _exit(). */
 #	define _exit emscripten_force_exit
+#else
+#include <unistd.h>
 #endif
 
 #include "../../safeguards.h"


### PR DESCRIPTION
## Motivation / Problem

When compiling on debian bullseye (yeah, I should have upgraded by now).
```
src/os/unix/crashlog_unix.cpp: In function ‘void HandleInternalCrash(int)’:
src/os/unix/crashlog_unix.cpp:175:3: error: ‘_exit’ was not declared in this scope; did you mean ‘_Exit’?
```

## Description

`_exit`  is declared in `unistd.h`.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
