### PR TITLE
Codechange: Rename RoadType parameter of MakeRoadDepot

### DIFF
--- a/src/road_map.h
+++ b/src/road_map.h
@@ -689,9 +689,9 @@ static inline void SetRoadDepotExitDirection(Tile tile, DiagDirection dir)
  * @param owner     New owner of the depot.
  * @param depot_id  New depot ID.
  * @param dir       Direction of the depot exit.
- * @param rail_type Road type of the depot.
+ * @param rt        Road type of the depot.
  */
-static inline void MakeRoadDepot(Tile tile, Owner owner, DepotID depot_id, DiagDirection dir, RoadType rail_type)
+static inline void MakeRoadDepot(Tile tile, Owner owner, DepotID depot_id, DiagDirection dir, RoadType rt)
 {
 	SetTileType(tile, MP_ROAD);
 	SetTileOwner(tile, owner);
@@ -702,7 +702,7 @@ static inline void MakeRoadDepot(Tile tile, Owner owner, DepotID depot_id, DiagD
 	SB(tile.m6(), 2, 4, 0);
 	tile.m7() = owner;
 	tile.m8() = INVALID_ROADTYPE << 6;
-	SetRoadType(tile, GetRoadTramType(rail_type), rail_type);
+	SetRoadType(tile, GetRoadTramType(rt), rt);
 	SetRoadOwner(tile, RTT_TRAM, owner);
 }
 


### PR DESCRIPTION
## Motivation / Problem

A parameter of type `RoadType` named  `rail_type` is unnecessarily misleading.

## Description

Rename `RoadType` typed parameter of `MakeRoadDepot` back to `rt`, as in prior to #9642.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
