### PR TITLE
Add: Dedicated server heightmap support

### DIFF
--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -517,7 +517,7 @@ void FiosGetSavegameList(SaveLoadOperation fop, FileList &file_list)
  * @see FiosGetFileList
  * @see FiosGetScenarioList
  */
-static FiosType FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last)
+FiosType FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last)
 {
 	/* Show scenario files
 	 * .SCN OpenTTD style scenario file
@@ -558,7 +558,7 @@ void FiosGetScenarioList(SaveLoadOperation fop, FileList &file_list)
 	FiosGetFileList(fop, &FiosGetScenarioListCallback, subdir, file_list);
 }
 
-static FiosType FiosGetHeightmapListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last)
+FiosType FiosGetHeightmapListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last)
 {
 	/* Show heightmap files
 	 * .PNG PNG Based heightmap files

--- a/src/fios.h
+++ b/src/fios.h
@@ -124,6 +124,8 @@ std::string FiosMakeHeightmapName(const char *name);
 std::string FiosMakeSavegameName(const char *name);
 
 FiosType FiosGetSavegameListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last);
+FiosType FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last);
+FiosType FiosGetHeightmapListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last);
 
 /**
  * A savegame name automatically numbered.

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -1093,7 +1093,7 @@ void StartScenarioEditor()
 }
 
 /**
- * Start a normal game without the GUI.
+ * Start a normal/heightmap game without the GUI.
  * @param seed The seed of the new game.
  */
 void StartNewGameWithoutGUI(uint32 seed)
@@ -1101,7 +1101,20 @@ void StartNewGameWithoutGUI(uint32 seed)
 	/* GenerateWorld takes care of the possible GENERATE_NEW_SEED value in 'seed' */
 	_settings_newgame.game_creation.generation_seed = seed;
 
-	StartGeneratingLandscape(GLWM_GENERATE);
+
+	GenerateLandscapeWindowMode mode = GLWM_GENERATE;
+
+	if(_file_to_saveload.abstract_ftype == FT_HEIGHTMAP) {
+		uint x = 0;
+		uint y = 0;
+
+		/* If the function returns false, it means there was a problem loading the heightmap */
+		if (!GetHeightmapDimensions(_file_to_saveload.detail_ftype, _file_to_saveload.name.c_str(), &x, &y)) return;
+
+		mode = GLWM_HEIGHTMAP;
+	}
+
+	StartGeneratingLandscape(mode);
 }
 
 struct CreateScenarioWindow : public Window

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -185,7 +185,7 @@ static void ShowHelp()
 		"  -t year             = Set starting year\n"
 		"  -d [[fac=]lvl[,...]]= Debug mode\n"
 		"  -e                  = Start Editor\n"
-		"  -g [savegame]       = Start new/save game immediately\n"
+		"  -g [file/name/title] = Load savegame/scenario/heightmap immediately\n"
 		"  -G seed             = Set random seed\n"
 		"  -n [ip:port#company]= Join network game\n"
 		"  -p password         = Password to join server\n"
@@ -595,19 +595,84 @@ int openttd_main(int argc, char *argv[])
 				if (mgo.opt != nullptr) SetDebugString(mgo.opt, ShowInfo);
 				break;
 			}
-		case 'e': _switch_mode = (_switch_mode == SM_LOAD_GAME || _switch_mode == SM_LOAD_SCENARIO ? SM_LOAD_SCENARIO : SM_EDITOR); break;
+		case 'e':
+			_switch_mode = (_switch_mode == SM_LOAD_GAME || _switch_mode == SM_LOAD_SCENARIO ? SM_LOAD_SCENARIO : ((_switch_mode == SM_LOAD_HEIGHTMAP || _switch_mode == SM_START_HEIGHTMAP) ? SM_LOAD_HEIGHTMAP : SM_EDITOR));
+			break;
 		case 'g':
 			if (mgo.opt != nullptr) {
 				_file_to_saveload.SetName(mgo.opt);
-				bool is_scenario = _switch_mode == SM_EDITOR || _switch_mode == SM_LOAD_SCENARIO;
-				_switch_mode = is_scenario ? SM_LOAD_SCENARIO : SM_LOAD_GAME;
-				_file_to_saveload.SetMode(SLO_LOAD, is_scenario ? FT_SCENARIO : FT_SAVEGAME, DFT_GAME_FILE);
+				bool is_editor = _switch_mode == SM_EDITOR || _switch_mode == SM_LOAD_SCENARIO || _switch_mode == SM_LOAD_HEIGHTMAP;
+				_switch_mode = is_editor ? (_switch_mode == SM_LOAD_HEIGHTMAP ? SM_LOAD_HEIGHTMAP : SM_LOAD_SCENARIO) : SM_LOAD_GAME;
 
-				/* if the file doesn't exist or it is not a valid savegame, let the saveload code show an error */
+				/* Unfortunately, initializing file type to being invalid breaks the SafeLoad function which expects SLO_LOAD operation: initializing to dummy value */
+				/*_file_to_saveload.SetMode(FIOS_TYPE_INVALID);
+				_file_to_saveload.SetMode(SLO_INVALID, FT_INVALID, DFT_INVALID);*/
+				_file_to_saveload.SetMode(SLO_LOAD, FT_SAVEGAME, DFT_GAME_FILE);
+
+				/* If supplied file does not exist or is not a valid savegame/scenario/heightmap, let the saveload code show an error */
 				auto t = _file_to_saveload.name.find_last_of('.');
 				if (t != std::string::npos) {
-					FiosType ft = FiosGetSavegameListCallback(SLO_LOAD, _file_to_saveload.name, _file_to_saveload.name.substr(t).c_str(), nullptr, nullptr);
-					if (ft != FIOS_TYPE_INVALID) _file_to_saveload.SetMode(ft);
+					FiosType ft;
+					ft = FiosGetSavegameListCallback(SLO_LOAD, _file_to_saveload.name, _file_to_saveload.name.substr(t).c_str(), nullptr, nullptr);
+					if (ft != FIOS_TYPE_INVALID) {
+						_file_to_saveload.SetMode(ft);
+						_switch_mode = is_editor ? SM_LOAD_SCENARIO : SM_LOAD_GAME;
+						break;
+					}
+					ft = FiosGetScenarioListCallback(SLO_LOAD, _file_to_saveload.name, _file_to_saveload.name.substr(t).c_str(), nullptr, nullptr);
+					if (ft != FIOS_TYPE_INVALID) {
+						_file_to_saveload.SetMode(ft);
+						_switch_mode = is_editor ? SM_LOAD_SCENARIO : SM_LOAD_GAME;
+						break;
+					}
+					ft = FiosGetHeightmapListCallback(SLO_LOAD, _file_to_saveload.name, _file_to_saveload.name.substr(t).c_str(), nullptr, nullptr);
+					if (ft != FIOS_TYPE_INVALID) {
+						_file_to_saveload.SetMode(ft);
+						_switch_mode = is_editor ? SM_LOAD_HEIGHTMAP : SM_START_HEIGHTMAP;
+						break;
+					}
+				}
+
+				/* If supplied value was not recognized as a valid resource, attempt to find a matching title */
+				DeterminePaths(argv[0], only_local_path);
+				TarScanner::DoScan(TarScanner::SCENARIO);
+				FileList _my_file_list;
+				const FiosItem *item;
+
+				_my_file_list.BuildFileList(FT_SAVEGAME, SLO_LOAD);
+				item = _my_file_list.FindItem(mgo.opt);
+				if (item != nullptr) {
+					if (GetAbstractFileType(item->type) == FT_SAVEGAME) {
+						_file_to_saveload.SetMode(item->type);
+						_file_to_saveload.SetName(FiosBrowseTo(item));
+						_file_to_saveload.SetTitle(item->title);
+					}
+					_switch_mode = is_editor ? SM_LOAD_SCENARIO : SM_LOAD_GAME;
+					break;
+				}
+
+				_my_file_list.BuildFileList(FT_SCENARIO, SLO_LOAD);
+				item = _my_file_list.FindItem(mgo.opt);
+				if (item != nullptr) {
+					if (GetAbstractFileType(item->type) == FT_SCENARIO) {
+						_file_to_saveload.SetMode(item->type);
+						_file_to_saveload.SetName(FiosBrowseTo(item));
+						_file_to_saveload.SetTitle(item->title);
+					}
+					_switch_mode = is_editor ? SM_LOAD_SCENARIO : SM_LOAD_GAME;
+					break;
+				}
+
+				_my_file_list.BuildFileList(FT_HEIGHTMAP, SLO_LOAD);
+				item = _my_file_list.FindItem(mgo.opt);
+				if (item != nullptr) {
+					if (GetAbstractFileType(item->type) == FT_HEIGHTMAP) {
+						_file_to_saveload.SetMode(item->type);
+						_file_to_saveload.SetName(FiosBrowseTo(item));
+						_file_to_saveload.SetTitle(item->title);
+					}
+					_switch_mode = is_editor ? SM_LOAD_HEIGHTMAP : SM_START_HEIGHTMAP;
+					break;
 				}
 
 				break;
@@ -970,6 +1035,17 @@ bool SafeLoad(const std::string &filename, SaveLoadOperation fop, DetailedFileTy
 	SaveOrLoadResult result = (lf == nullptr) ? SaveOrLoad(filename, fop, dft, subdir) : LoadWithFilter(lf);
 	if (result == SL_OK) return true;
 
+	if (_network_dedicated && _switch_mode == SM_START_HEIGHTMAP) {
+		auto t = _file_to_saveload.name.find_last_of('.');
+		if (t != std::string::npos) {
+			FiosType ft = FiosGetHeightmapListCallback(SLO_LOAD, filename, filename.substr(t).c_str(), nullptr, nullptr);
+			if (ft != FIOS_TYPE_INVALID) {
+				_file_to_saveload.SetMode(ft);
+				return true;
+			}
+		}
+	}
+
 	if (_network_dedicated && ogm == GM_MENU) {
 		/*
 		 * If we are a dedicated server *and* we just were in the menu, then we
@@ -1020,7 +1096,7 @@ void SwitchToMode(SwitchMode new_mode)
 	if (new_mode != SM_SAVE_GAME) {
 		/* If the network is active, make it not-active */
 		if (_networking) {
-			if (_network_server && (new_mode == SM_LOAD_GAME || new_mode == SM_NEWGAME || new_mode == SM_RESTARTGAME)) {
+			if (_network_server && (new_mode == SM_LOAD_GAME || new_mode == SM_START_HEIGHTMAP || new_mode == SM_NEWGAME || new_mode == SM_RESTARTGAME)) {
 				NetworkReboot();
 			} else {
 				NetworkDisconnect();

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -249,7 +249,7 @@ void VideoDriver_Dedicated::MainLoop()
 	_current_company = _local_company = COMPANY_SPECTATOR;
 
 	/* If SwitchMode is SM_LOAD_GAME, it means that the user used the '-g' options */
-	if (_switch_mode != SM_LOAD_GAME) {
+	if (_switch_mode != SM_LOAD_GAME && _switch_mode != SM_START_HEIGHTMAP) {
 		StartNewGameWithoutGUI(GENERATE_NEW_SEED);
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Heightmap maps aren't loadable by dedicated servers.
Furthermore, once such a map is loaded, on game end a normal, procedurally generated map takes turn.

## Description

Somehow related to #7285 & #7286.
Add heightmap maps support for dedicated servers:
* CLI switch
* Heightmap map reload on game end

## Limitations

Works wonders for my needs.
As noted long ago, there might be unoticed side-effects for others game modes (client ,editor), for which your expertise would be valuable.

Those changes have been adapted to the partial network code rework operated in the latest major version.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
