### PR TITLE
Codechange: Use member initalisers

### DIFF
--- a/src/network/core/tcp_game.cpp
+++ b/src/network/core/tcp_game.cpp
@@ -26,7 +26,7 @@ static std::vector<std::unique_ptr<NetworkGameSocketHandler>> _deferred_deletion
  * Create a new socket for the game connection.
  * @param s The socket to connect with.
  */
-NetworkGameSocketHandler::NetworkGameSocketHandler(SOCKET s) : info(nullptr), client_id(INVALID_CLIENT_ID),
+NetworkGameSocketHandler::NetworkGameSocketHandler(SOCKET s, ClientID client_id) : info(nullptr), client_id(client_id),
 		last_frame(_frame_counter), last_frame_server(_frame_counter)
 {
 	this->sock = s;

--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -504,7 +504,7 @@ protected:
 
 	NetworkRecvStatus HandlePacket(Packet *p);
 
-	NetworkGameSocketHandler(SOCKET s);
+	NetworkGameSocketHandler(SOCKET s, ClientID client_id = INVALID_CLIENT_ID);
 public:
 	ClientID client_id;          ///< Client identifier
 	uint32 last_frame;           ///< Last frame we have executed

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -556,8 +556,7 @@ NetworkAddress ParseConnectionString(const std::string &connection_string, uint1
 	/* Register the login */
 	_network_clients_connected++;
 
-	ServerNetworkGameSocketHandler *cs = new ServerNetworkGameSocketHandler(s);
-	cs->client_address = address; // Save the IP of the client
+	new ServerNetworkGameSocketHandler(s, address);
 
 	InvalidateWindowData(WC_CLIENT_LIST, 0);
 }

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -207,12 +207,8 @@ struct PacketWriter : SaveFilter {
  * Create a new socket for the server side of the game connection.
  * @param s The socket to connect with.
  */
-ServerNetworkGameSocketHandler::ServerNetworkGameSocketHandler(SOCKET s) : NetworkGameSocketHandler(s)
+ServerNetworkGameSocketHandler::ServerNetworkGameSocketHandler(SOCKET s, NetworkAddress client_address) : NetworkGameSocketHandler(s, _network_client_id++), status(STATUS_INACTIVE), receive_limit(_settings_client.network.bytes_per_frame_burst), client_address(client_address)
 {
-	this->status = STATUS_INACTIVE;
-	this->client_id = _network_client_id++;
-	this->receive_limit = _settings_client.network.bytes_per_frame_burst;
-
 	/* The Socket and Info pools need to be the same in size. After all,
 	 * each Socket will be associated with at most one Info object. As
 	 * such if the Socket was allocated the Info object can as well. */

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -72,7 +72,7 @@ public:
 	struct PacketWriter *savegame; ///< Writer used to write the savegame.
 	NetworkAddress client_address; ///< IP-address of the client (so they can be banned)
 
-	ServerNetworkGameSocketHandler(SOCKET s);
+	ServerNetworkGameSocketHandler(SOCKET s, NetworkAddress client_address);
 	~ServerNetworkGameSocketHandler();
 
 	virtual Packet *ReceivePacket() override;


### PR DESCRIPTION
## Motivation / Problem

Looking at the code, I saw several occasions in which member initialisation could be done directly.

## Description

Use member initialisers

## Limitations

Definitely partial changes, but maybe a step in a good direction?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
