### PR TITLE
Codechange: introduce and use function to raise and dirty a set of widgets when they are lowered

### DIFF
--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -884,16 +884,10 @@ struct GenerateLandscapeWindow : public Window {
 
 	void OnTimeout() override
 	{
-		static const int newgame_raise_widgets[] = {WID_GL_START_DATE_DOWN, WID_GL_START_DATE_UP, WID_GL_SNOW_COVERAGE_UP, WID_GL_SNOW_COVERAGE_DOWN, WID_GL_DESERT_COVERAGE_UP, WID_GL_DESERT_COVERAGE_DOWN, WIDGET_LIST_END};
-		static const int heightmap_raise_widgets[] = {WID_GL_HEIGHTMAP_HEIGHT_DOWN, WID_GL_HEIGHTMAP_HEIGHT_UP, WID_GL_START_DATE_DOWN, WID_GL_START_DATE_UP, WID_GL_SNOW_COVERAGE_UP, WID_GL_SNOW_COVERAGE_DOWN, WID_GL_DESERT_COVERAGE_UP, WID_GL_DESERT_COVERAGE_DOWN, WIDGET_LIST_END};
-
-		const int *widget = (mode == GLWM_HEIGHTMAP) ? heightmap_raise_widgets : newgame_raise_widgets;
-
-		for (; *widget != WIDGET_LIST_END; widget++) {
-			if (this->IsWidgetLowered(*widget)) {
-				this->RaiseWidget(*widget);
-				this->SetWidgetDirty(*widget);
-			}
+		if (mode == GLWM_HEIGHTMAP) {
+			this->RaiseWidgetsWhenLowered(WID_GL_HEIGHTMAP_HEIGHT_DOWN, WID_GL_HEIGHTMAP_HEIGHT_UP, WID_GL_START_DATE_DOWN, WID_GL_START_DATE_UP, WID_GL_SNOW_COVERAGE_UP, WID_GL_SNOW_COVERAGE_DOWN, WID_GL_DESERT_COVERAGE_UP, WID_GL_DESERT_COVERAGE_DOWN);
+		} else {
+			this->RaiseWidgetsWhenLowered(WID_GL_START_DATE_DOWN, WID_GL_START_DATE_UP, WID_GL_SNOW_COVERAGE_UP, WID_GL_SNOW_COVERAGE_DOWN, WID_GL_DESERT_COVERAGE_UP, WID_GL_DESERT_COVERAGE_DOWN);
 		}
 	}
 
@@ -1232,13 +1226,7 @@ struct CreateScenarioWindow : public Window
 
 	void OnTimeout() override
 	{
-		static const int raise_widgets[] = {WID_CS_START_DATE_DOWN, WID_CS_START_DATE_UP, WID_CS_FLAT_LAND_HEIGHT_DOWN, WID_CS_FLAT_LAND_HEIGHT_UP, WIDGET_LIST_END};
-		for (const int *widget = raise_widgets; *widget != WIDGET_LIST_END; widget++) {
-			if (this->IsWidgetLowered(*widget)) {
-				this->RaiseWidget(*widget);
-				this->SetWidgetDirty(*widget);
-			}
-		}
+		this->RaiseWidgetsWhenLowered(WID_CS_START_DATE_DOWN, WID_CS_START_DATE_UP, WID_CS_FLAT_LAND_HEIGHT_DOWN, WID_CS_FLAT_LAND_HEIGHT_UP);
 	}
 
 	void OnDropdownSelect(int widget, int index) override

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -2922,10 +2922,7 @@ struct IndustryCargoesWindow : public Window {
 	{
 		if (!gui_scope) return;
 		if (data == NUM_INDUSTRYTYPES) {
-			if (this->IsWidgetLowered(WID_IC_NOTIFY)) {
-				this->RaiseWidget(WID_IC_NOTIFY);
-				this->SetWidgetDirty(WID_IC_NOTIFY);
-			}
+			this->RaiseWidgetWhenLowered(WID_IC_NOTIFY);
 			return;
 		}
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1180,13 +1180,7 @@ struct NetworkStartServerWindow : public Window {
 
 	void OnTimeout() override
 	{
-		static const int raise_widgets[] = {WID_NSS_CLIENTS_BTND, WID_NSS_CLIENTS_BTNU, WID_NSS_COMPANIES_BTND, WID_NSS_COMPANIES_BTNU, WIDGET_LIST_END};
-		for (const int *widget = raise_widgets; *widget != WIDGET_LIST_END; widget++) {
-			if (this->IsWidgetLowered(*widget)) {
-				this->RaiseWidget(*widget);
-				this->SetWidgetDirty(*widget);
-			}
-		}
+		this->RaiseWidgetsWhenLowered(WID_NSS_CLIENTS_BTND, WID_NSS_CLIENTS_BTNU, WID_NSS_COMPANIES_BTND, WID_NSS_COMPANIES_BTNU);
 	}
 
 	void OnQueryTextFinished(char *str) override

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -649,10 +649,7 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 	{
 		for (uint i = WID_ETT_START; i < this->nested_array_size; i++) {
 			if (i == WID_ETT_BUTTONS_START) i = WID_ETT_BUTTONS_END; // skip the buttons
-			if (this->IsWidgetLowered(i)) {
-				this->RaiseWidget(i);
-				this->SetWidgetDirty(i);
-			}
+			this->RaiseWidgetWhenLowered(i);
 		}
 	}
 

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2128,10 +2128,7 @@ struct MainToolbarWindow : Window {
 		/* We do not want to automatically raise the pause, fast forward and
 		 * switchbar buttons; they have to stay down when pressed etc. */
 		for (uint i = WID_TN_SETTINGS; i < WID_TN_SWITCH_BAR; i++) {
-			if (this->IsWidgetLowered(i)) {
-				this->RaiseWidget(i);
-				this->SetWidgetDirty(i);
-			}
+			this->RaiseWidgetWhenLowered(i);
 		}
 	}
 

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -414,6 +414,18 @@ public:
 	}
 
 	/**
+	 * Marks a widget as raised and dirty (redraw), when it is marked as lowered.
+	 * @param widget_index index of this widget in the window
+	 */
+	inline void RaiseWidgetWhenLowered(byte widget_index)
+	{
+		if (this->IsWidgetLowered(widget_index)) {
+			this->RaiseWidget(widget_index);
+			this->SetWidgetDirty(widget_index);
+		}
+	}
+
+	/**
 	 * Gets the lowered state of a widget.
 	 * @param widget_index index of this widget in the window
 	 * @return status of the widget ie: lowered = true, raised= false
@@ -458,6 +470,16 @@ public:
 	{
 		(SetWidgetLoweredState(widgets, lowered_stat), ...);
 	}
+
+	/**
+	 * Raises the widgets and sets widgets dirty that are lowered.
+	 * @param widgets list of widgets
+	 */
+	template<typename... Args>
+	void RaiseWidgetsWhenLowered(Args... widgets) {
+		(this->RaiseWidgetWhenLowered(widgets), ...);
+	}
+
 	void SetWidgetDirty(byte widget_index) const;
 
 	void DrawWidgets() const;


### PR DESCRIPTION
## Motivation / Problem

Same code exists in multiple locations, so why not introduce a function for that and reuse it.
Furthermore a sentinel value to denote end-of-list is a C-style construct.


## Description

Introduce `RaiseWidgetWhenLowered` and `RaiseWidgetsWhenLowered` to check and update multiple locations in one call.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
