### PR TITLE
Add: [GitHub] also test if release builds without asserts are warning-free

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -73,10 +73,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: Clang
+        - name: Clang - Debug
           compiler: clang
           cxxcompiler: clang++
           libraries: libsdl2-dev
+        - name: Clang - Release
+          compiler: clang
+          cxxcompiler: clang++
+          libraries: libsdl2-dev
+          extra-cmake-parameters: -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPTION_USE_ASSERTS=OFF
         - name: GCC - SDL2
           compiler: gcc
           cxxcompiler: g++


### PR DESCRIPTION
## Motivation / Problem

#11306 has the intention to re-enable warnings for stable builds where asserts are disabled. But currently we have nothing that tests for warnings in such builds, which can lead to release issues (and worse: very late in the release process).

## Description

So, instead, be pro-active, and test for warnings on release builds without asserts during CI runs.

## Limitations

We only test release builds without asserts on Linux. Strictly seen Windows and MacOS could also produce warnings during release, but the likelihood has been reduced significantly with this PR. Also testing Windows and MacOS is problemetic; not code-wise, but more in the amount of time the CI will take to finish. It is already absurd how long it needs, and adding those two targets will significantly add to that time.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
