### PR TITLE
Codechange: replace WIDGET_LIST_END with more specific variants

### DIFF
--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -87,7 +87,7 @@ struct BuildAirToolbarWindow : Window {
 		this->InitNested(window_number);
 		this->OnInvalidateData();
 		if (_settings_client.gui.link_terraform_toolbar) ShowTerraformToolbar(this);
-		this->last_user_action = WIDGET_LIST_END;
+		this->last_user_action = INVALID_WID_AT;
 	}
 
 	void Close() override

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -414,7 +414,7 @@ struct BuildRailToolbarWindow : Window {
 		this->InitNested(TRANSPORT_RAIL);
 		this->SetupRailToolbar(railtype);
 		this->DisableWidget(WID_RAT_REMOVE);
-		this->last_user_action = WIDGET_LIST_END;
+		this->last_user_action = INVALID_WID_RAT;
 
 		if (_settings_client.gui.link_terraform_toolbar) ShowTerraformToolbar(this);
 	}

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -324,7 +324,7 @@ struct BuildRoadToolbarWindow : Window {
 		}
 
 		this->OnInvalidateData();
-		this->last_started_action = WIDGET_LIST_END;
+		this->last_started_action = INVALID_WID_ROT;
 
 		if (_settings_client.gui.link_terraform_toolbar) ShowTerraformToolbar(this);
 	}

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -161,7 +161,7 @@ struct TerraformToolbarWindow : Window {
 		/* This is needed as we like to have the tree available on OnInit. */
 		this->CreateNestedTree();
 		this->FinishInitNested(window_number);
-		this->last_user_action = WIDGET_LIST_END;
+		this->last_user_action = INVALID_WID_TT;
 	}
 
 	~TerraformToolbarWindow()
@@ -542,7 +542,7 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 		NWidgetStacked *show_desert = this->GetWidget<NWidgetStacked>(WID_ETT_SHOW_PLACE_DESERT);
 		show_desert->SetDisplayedPlane(_settings_game.game_creation.landscape == LT_TROPIC ? 0 : SZSP_NONE);
 		this->FinishInitNested(window_number);
-		this->last_user_action = WIDGET_LIST_END;
+		this->last_user_action = INVALID_WID_ETT;
 	}
 
 	void OnPaint() override

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2616,8 +2616,7 @@ struct VehicleDetailsWindow : Window {
 		/* Disable service-scroller when interval is set to disabled */
 		this->SetWidgetsDisabledState(!IsVehicleServiceIntervalEnabled(v->type, v->owner),
 			WID_VD_INCREASE_SERVICING_INTERVAL,
-			WID_VD_DECREASE_SERVICING_INTERVAL,
-			WIDGET_LIST_END);
+			WID_VD_DECREASE_SERVICING_INTERVAL);
 
 		StringID str = v->ServiceIntervalIsCustom() ?
 			(v->ServiceIntervalIsPercent() ? STR_VEHICLE_DETAILS_PERCENT : STR_VEHICLE_DETAILS_DAYS) :
@@ -2657,9 +2656,7 @@ struct VehicleDetailsWindow : Window {
 					WID_VD_DETAILS_CARGO_CARRIED,
 					WID_VD_DETAILS_TRAIN_VEHICLES,
 					WID_VD_DETAILS_CAPACITY_OF_EACH,
-					WID_VD_DETAILS_TOTAL_CARGO,
-					widget,
-					WIDGET_LIST_END);
+					WID_VD_DETAILS_TOTAL_CARGO);
 
 				this->tab = (TrainDetailsWindowTabs)(widget - WID_VD_DETAILS_CARGO_CARRIED);
 				this->SetDirty();

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -17,8 +17,6 @@
 #include "gfx_type.h"
 #include "window_type.h"
 
-static const int WIDGET_LIST_END = -1; ///< indicate the end of widgets' list for vararg functions
-
 /** Bits of the #WWT_MATRIX widget data. */
 enum MatrixWidgetValues {
 	/* Number of column bits of the WWT_MATRIX widget data. */

--- a/src/widgets/airport_widget.h
+++ b/src/widgets/airport_widget.h
@@ -14,6 +14,8 @@
 enum AirportToolbarWidgets {
 	WID_AT_AIRPORT,  ///< Build airport button.
 	WID_AT_DEMOLISH, ///< Demolish button.
+
+	INVALID_WID_AT = -1,
 };
 
 /** Widgets of the #BuildAirportWindow class. */

--- a/src/widgets/rail_widget.h
+++ b/src/widgets/rail_widget.h
@@ -28,6 +28,8 @@ enum RailToolbarWidgets {
 	WID_RAT_BUILD_TUNNEL,   ///< Build a tunnel.
 	WID_RAT_REMOVE,         ///< Bulldozer to remove rail.
 	WID_RAT_CONVERT_RAIL,   ///< Convert other rail to this type.
+
+	INVALID_WID_RAT = -1,
 };
 
 /** Widgets of the #BuildRailStationWindow class. */

--- a/src/widgets/road_widget.h
+++ b/src/widgets/road_widget.h
@@ -26,6 +26,8 @@ enum RoadToolbarWidgets {
 	WID_ROT_BUILD_TUNNEL,   ///< Build tunnel.
 	WID_ROT_REMOVE,         ///< Remove road.
 	WID_ROT_CONVERT_ROAD,   ///< Convert road.
+
+	INVALID_WID_ROT = -1,
 };
 
 /** Widgets of the #BuildRoadDepotWindow class. */

--- a/src/widgets/terraform_widget.h
+++ b/src/widgets/terraform_widget.h
@@ -22,6 +22,8 @@ enum TerraformToolbarWidgets {
 	WID_TT_PLANT_TREES,                       ///< Plant trees button (note: opens separate window, no place-push-button).
 	WID_TT_PLACE_SIGN,                        ///< Place sign button.
 	WID_TT_PLACE_OBJECT,                      ///< Place object button.
+
+	INVALID_WID_TT = -1,
 };
 
 /** Widgets of the #ScenarioEditorLandscapeGenerationWindow class. */
@@ -42,6 +44,8 @@ enum EditorTerraformToolbarWidgets {
 	WID_ETT_DECREASE_SIZE,                       ///< Downwards arrow button to decrease terraforming size.
 	WID_ETT_NEW_SCENARIO,                        ///< Button for generating a new scenario.
 	WID_ETT_RESET_LANDSCAPE,                     ///< Button for removing all company-owned property.
+
+	INVALID_WID_ETT = -1,
 };
 
 #endif /* WIDGETS_TERRAFORM_WIDGET_H */


### PR DESCRIPTION
## Motivation / Problem

Primarily that `WIDGET_LIST_END` is documented to be the sentinel value for the last element of a vararg list, but it is used as sentinel value for the clicked widget in a window.


## Description

Two `WIDGET_LIST_END` removals that were forgotten in a previous commit.

Add `INVALID_WID_XXX` values to the appropriate widgets enumerations, and use that as sentinel value for the last action/clicked widget.


## Limitations

I attempted to make `last_user_action` of the appropriate widget enumeration type, but that causes many many warnings about missing cast. That is because the widget parameter of the functions in the window class is just `int` and not the actual widget enumeration.
In a perfecter world, the widget (index) parameters would be of the appropriate type. However, that'll require templating which is far beyond the scope of this story.

These `INVALID_WID_XXX` sentinel enumerators end up in the GS API. I doubt it is really worth the effort to not add these there.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
