### PR TITLE
Fix: Don't produce invalid cargo.

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1169,9 +1169,10 @@ static void TriggerIndustryProduction(Industry *i)
 		}
 	} else {
 		for (auto ita = std::begin(i->accepted); ita != std::end(i->accepted); ++ita) {
-			if (ita->waiting == 0) continue;
+			if (ita->waiting == 0 || !IsValidCargoID(ita->cargo)) continue;
 
 			for (auto itp = std::begin(i->produced); itp != std::end(i->produced); ++itp) {
+				if (!IsValidCargoID(itp->cargo)) continue;
 				itp->waiting = ClampTo<uint16_t>(itp->waiting + (ita->waiting * indspec->input_cargo_multiplier[ita - std::begin(i->accepted)][itp - std::begin(i->produced)] / 256));
 			}
 

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1122,6 +1122,9 @@ static bool SearchLumberMillTrees(TileIndex tile, void *user_data)
  */
 static void ChopLumberMillTrees(Industry *i)
 {
+	/* Skip production if cargo slot is invalid. */
+	if (!IsValidCargoID(i->produced[0].cargo)) return;
+
 	/* We only want to cut trees if all tiles are completed. */
 	for (TileIndex tile_cur : i->location) {
 		if (i->TileBelongsToIndustry(tile_cur)) {
@@ -1160,6 +1163,7 @@ static void ProduceIndustryGoods(Industry *i)
 
 		IndustryBehaviour indbehav = indsp->behaviour;
 		for (auto &p : i->produced) {
+			if (!IsValidCargoID(p.cargo)) continue;
 			p.waiting = ClampTo<uint16_t>(p.waiting + p.rate);
 		}
 

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -643,9 +643,11 @@ void IndustryProductionCallback(Industry *ind, int reason)
 		if (group->version < 2) {
 			/* Callback parameters map directly to industry cargo slot indices */
 			for (uint i = 0; i < group->num_input; i++) {
+				if (!IsValidCargoID(ind->accepted[i].cargo)) continue;
 				ind->accepted[i].waiting = ClampTo<uint16_t>(ind->accepted[i].waiting - DerefIndProd(group->subtract_input[i], deref) * multiplier);
 			}
 			for (uint i = 0; i < group->num_output; i++) {
+				if (!IsValidCargoID(ind->produced[i].cargo)) continue;
 				ind->produced[i].waiting = ClampTo<uint16_t>(ind->produced[i].waiting + std::max(DerefIndProd(group->add_output[i], deref), 0) * multiplier);
 			}
 		} else {


### PR DESCRIPTION
## Motivation / Problem

Production for secondary industries did not always check that the produced cargo type isn't valid -- it was only checked for some NewGRF industries using callback-based production.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Check if cargo is valid for all (I think) industry cargo production. This does not check that the cargo is the correct type that the industry is expecting, only that it is not an invalid cargo type.

This also disables the tropical lumber mill from chopping trees if the industry's first cargo slot is invalid -- it may be preferable to continue chopping trees.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

The issue of producing invalid cargo is mostly theoretical, and these checks don't really add much to a normal game. I don't have any sample savegames where it occurs, but I believe I have seen it in the past.

Issues could probably only be caused by changes to NewGRFs (either by the user (in which case who cares) or the author) or perhaps loading incompatible NewGRFs concurrently.

However this change has more impact if (the to-be-updated) #10726 PR is applied.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
