### PR TITLE
Codechange: Don't access cargo filter before it is initialized.

### DIFF
--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -358,9 +358,6 @@ public:
 		this->group_rename = INVALID_GROUP;
 		this->group_over = INVALID_GROUP;
 
-		this->BuildVehicleList();
-		this->SortVehicleList();
-
 		this->groups.ForceRebuild();
 		this->groups.NeedResort();
 		this->BuildGroupList(vli.company);
@@ -377,6 +374,9 @@ public:
 
 		this->FinishInitNested(window_number);
 		this->owner = vli.company;
+
+		this->BuildVehicleList();
+		this->SortVehicleList();
 	}
 
 	~VehicleGroupWindow()

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1624,9 +1624,10 @@ public:
 		this->industries.SetListing(this->last_sorting);
 		this->industries.SetSortFuncs(IndustryDirectoryWindow::sorter_funcs);
 		this->industries.ForceRebuild();
-		this->BuildSortIndustriesList();
 
 		this->FinishInitNested(0);
+
+		this->BuildSortIndustriesList();
 
 		this->querystrings[WID_ID_FILTER] = &this->industry_editbox;
 		this->industry_editbox.cancel_button = QueryString::ACTION_CLEAR;

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1842,9 +1842,6 @@ public:
 
 		this->vscroll = this->GetScrollbar(WID_VL_SCROLLBAR);
 
-		this->BuildVehicleList();
-		this->SortVehicleList();
-
 		/* Set up the window widgets */
 		this->GetWidget<NWidgetCore>(WID_VL_LIST)->tool_tip = STR_VEHICLE_LIST_TRAIN_LIST_TOOLTIP + this->vli.vtype;
 
@@ -1863,6 +1860,9 @@ public:
 
 		this->FinishInitNested(window_number);
 		if (this->vli.company != OWNER_NONE) this->owner = this->vli.company;
+
+		this->BuildVehicleList();
+		this->SortVehicleList();
 	}
 
 	~VehicleListWindow()


### PR DESCRIPTION
## Motivation / Problem

Industry list, build vehicle list, grouped vehicle list and vehicle list windows all access their cargo filter arrays before they are populated.

The cargo filter list is initialized during window OnInit, but the first build of the filtered list occurred before this.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Defer building each window's filtered list til after OnInit is called (via FinishInitNested), so that the cargo filter list is populated and the filter functions are in place.

Because the cargo filter lists are fixed arrays, this access did not cause harm.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
