### PR TITLE
Add enum items for magic values

### DIFF
--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -239,7 +239,7 @@ public:
 
 	void DrawWidget(const Rect &r, int widget) const override
 	{
-		if (widget != 0) return;
+		if (widget != WID_BAFD_QUESTION) return;
 
 		DrawStringMultiLine(r.Shrink(WidgetDimensions::scaled.frametext), STR_MISSING_GRAPHICS_SET_MESSAGE, TC_FROMSTRING, SA_CENTER);
 	}

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -314,7 +314,7 @@ struct GSConfigWindow : public Window {
 								list.emplace_back(new DropDownListStringItem(config_item.labels.find(i)->second, i, false));
 							}
 
-							ShowDropDownListAt(this, std::move(list), old_val, -1, wi_rect, COLOUR_ORANGE);
+							ShowDropDownListAt(this, std::move(list), old_val, WID_GSC_SETTING_DROPDOWN, wi_rect, COLOUR_ORANGE);
 						}
 					}
 				} else if (IsInsideMM(x, 0, SETTING_BUTTON_WIDTH)) {
@@ -367,14 +367,14 @@ struct GSConfigWindow : public Window {
 
 	void OnDropdownSelect(int widget, int index) override
 	{
-		if (widget >= 0) return;
+		if (widget != WID_GSC_SETTING_DROPDOWN) return;
 		assert(this->clicked_dropdown);
 		SetValue(index);
 	}
 
 	void OnDropdownClose(Point, int widget, int, bool) override
 	{
-		if (widget >= 0) return;
+		if (widget != WID_GSC_SETTING_DROPDOWN) return;
 		/* We cannot raise the dropdown button just yet. OnClick needs some hint, whether
 		 * the same dropdown button was clicked again, and then not open the dropdown again.
 		 * So, we only remember that it was closed, and process it on the next OnPaint, which is

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -395,7 +395,7 @@ struct NewGRFParametersWindow : public Window {
 								list.emplace_back(new DropDownListStringItem(GetGRFStringFromGRFText(par_info.value_names.find(i)->second), i, false));
 							}
 
-							ShowDropDownListAt(this, std::move(list), old_val, -1, wi_rect, COLOUR_ORANGE);
+							ShowDropDownListAt(this, std::move(list), old_val, WID_NP_SETTING_DROPDOWN, wi_rect, COLOUR_ORANGE);
 						}
 					}
 				} else if (IsInsideMM(x, 0, SETTING_BUTTON_WIDTH)) {
@@ -453,7 +453,7 @@ struct NewGRFParametersWindow : public Window {
 
 	void OnDropdownSelect(int widget, int index) override
 	{
-		if (widget >= 0) return;
+		if (widget != WID_NP_SETTING_DROPDOWN) return;
 		assert(this->clicked_dropdown);
 		GRFParameterInfo &par_info = this->GetParameterInfo(this->clicked_row);
 		par_info.SetValue(this->grf_config, index);
@@ -462,7 +462,7 @@ struct NewGRFParametersWindow : public Window {
 
 	void OnDropdownClose(Point, int widget, int, bool) override
 	{
-		if (widget >= 0) return;
+		if (widget != WID_NP_SETTING_DROPDOWN) return;
 		/* We cannot raise the dropdown button just yet. OnClick needs some hint, whether
 		 * the same dropdown button was clicked again, and then not open the dropdown again.
 		 * So, we only remember that it was closed, and process it on the next OnPaint, which is

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1171,7 +1171,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 
 	void OnDropdownSelect(int widget, int index) override
 	{
-		if (widget >= 0) return;
+		if (widget != WID_NS_PRESET_LIST) return;
 		if (!this->editable) return;
 
 		ClearGRFConfigList(&this->actives);

--- a/src/screenshot_gui.cpp
+++ b/src/screenshot_gui.cpp
@@ -29,10 +29,9 @@ struct ScreenshotWindow : Window {
 
 	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
 	{
-		if (widget < 0) return;
 		ScreenshotType st;
 		switch (widget) {
-			default:
+			default: return;
 			case WID_SC_TAKE:             st = SC_VIEWPORT;    break;
 			case WID_SC_TAKE_ZOOMIN:      st = SC_ZOOMEDIN;    break;
 			case WID_SC_TAKE_DEFAULTZOOM: st = SC_DEFAULTZOOM; break;

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -472,7 +472,7 @@ struct ScriptSettingsWindow : public Window {
 								list.emplace_back(new DropDownListStringItem(config_item.labels.find(i)->second, i, false));
 							}
 
-							ShowDropDownListAt(this, std::move(list), old_val, -1, wi_rect, COLOUR_ORANGE);
+							ShowDropDownListAt(this, std::move(list), old_val, WID_SCRS_SETTING_DROPDOWN, wi_rect, COLOUR_ORANGE);
 						}
 					}
 				} else if (IsInsideMM(x, 0, SETTING_BUTTON_WIDTH)) {
@@ -526,14 +526,14 @@ struct ScriptSettingsWindow : public Window {
 
 	void OnDropdownSelect(int widget, int index) override
 	{
-		if (widget >= 0) return;
+		if (widget != WID_SCRS_SETTING_DROPDOWN) return;
 		assert(this->clicked_dropdown);
 		SetValue(index);
 	}
 
 	void OnDropdownClose(Point, int widget, int, bool) override
 	{
-		if (widget >= 0) return;
+		if (widget != WID_SCRS_SETTING_DROPDOWN) return;
 		/* We cannot raise the dropdown button just yet. OnClick needs some hint, whether
 		 * the same dropdown button was clicked again, and then not open the dropdown again.
 		 * So, we only remember that it was closed, and process it on the next OnPaint, which is

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2394,7 +2394,7 @@ struct GameSettingsWindow : Window {
 						list.emplace_back(new DropDownListStringItem(sd->str_val + i - sd->min, i, false));
 					}
 
-					ShowDropDownListAt(this, std::move(list), value, -1, wi_rect, COLOUR_ORANGE);
+					ShowDropDownListAt(this, std::move(list), value, WID_GS_SETTING_DROPDOWN, wi_rect, COLOUR_ORANGE);
 				}
 			}
 			this->SetDirty();
@@ -2526,23 +2526,21 @@ struct GameSettingsWindow : Window {
 				this->InvalidateData();
 				break;
 
-			default:
-				if (widget < 0) {
-					/* Deal with drop down boxes on the panel. */
-					assert(this->valuedropdown_entry != nullptr);
-					const IntSettingDesc *sd = this->valuedropdown_entry->setting;
-					assert(sd->flags & SF_GUI_DROPDOWN);
+			case WID_GS_SETTING_DROPDOWN:
+				/* Deal with drop down boxes on the panel. */
+				assert(this->valuedropdown_entry != nullptr);
+				const IntSettingDesc *sd = this->valuedropdown_entry->setting;
+				assert(sd->flags & SF_GUI_DROPDOWN);
 
-					SetSettingValue(sd, index);
-					this->SetDirty();
-				}
+				SetSettingValue(sd, index);
+				this->SetDirty();
 				break;
 		}
 	}
 
 	void OnDropdownClose(Point pt, int widget, int index, bool instant_close) override
 	{
-		if (widget >= 0) {
+		if (widget != WID_GS_SETTING_DROPDOWN) {
 			/* Normally the default implementation of OnDropdownClose() takes care of
 			 * a few things. We want that behaviour here too, but only for
 			 * "normal" dropdown boxes. The special dropdown boxes added for every

--- a/src/widgets/game_widget.h
+++ b/src/widgets/game_widget.h
@@ -23,6 +23,8 @@ enum GSConfigWidgets {
 	WID_GSC_CONTENT_DOWNLOAD = WID_GSC_TEXTFILE + TFT_CONTENT_END, ///< Download content button.
 	WID_GSC_ACCEPT,           ///< Accept ("Close") button
 	WID_GSC_RESET,            ///< Reset button.
+
+	WID_GSC_SETTING_DROPDOWN = -1, ///< Dynamically created dropdown for changing setting value.
 };
 
 #endif /* WIDGETS_GS_WIDGET_H */

--- a/src/widgets/newgrf_widget.h
+++ b/src/widgets/newgrf_widget.h
@@ -26,6 +26,8 @@ enum NewGRFParametersWidgets {
 	WID_NP_RESET,            ///< Reset button.
 	WID_NP_SHOW_DESCRIPTION, ///< #NWID_SELECTION to optionally display parameter descriptions.
 	WID_NP_DESCRIPTION,      ///< Multi-line description of a parameter.
+
+	WID_NP_SETTING_DROPDOWN = -1, ///< Dynamically created dropdown for changing setting value.
 };
 
 /** Widgets of the #NewGRFWindow class. */

--- a/src/widgets/script_widget.h
+++ b/src/widgets/script_widget.h
@@ -29,6 +29,8 @@ enum ScriptSettingsWidgets {
 	WID_SCRS_SCROLLBAR,  ///< Scrollbar to scroll through all settings.
 	WID_SCRS_ACCEPT,     ///< Accept button.
 	WID_SCRS_RESET,      ///< Reset button.
+
+	WID_SCRS_SETTING_DROPDOWN = -1, ///< Dynamically created dropdown for changing setting value.
 };
 
 /** Widgets of the #ScriptDebugWindow class. */

--- a/src/widgets/settings_widget.h
+++ b/src/widgets/settings_widget.h
@@ -64,6 +64,8 @@ enum GameSettingsWidgets {
 	WID_GS_RESTRICT_TYPE,      ///< Label upfront to the type drop-down box to restrict the list of settings to show
 	WID_GS_RESTRICT_DROPDOWN,  ///< The drop down box to restrict the list of settings
 	WID_GS_TYPE_DROPDOWN,      ///< The drop down box to choose client/game/company/all settings
+
+	WID_GS_SETTING_DROPDOWN = -1, ///< Dynamically created dropdown for changing setting value.
 };
 
 /** Widgets of the #CustomCurrencyWindow class. */


### PR DESCRIPTION
## Motivation / Problem

@rubidium42 suggested in #11306 to add enum items for a number of -1 constants.
There were a few more places using plain numbers for widgets.


## Description

Replace raw numbers with:
* Existing widget enum items.
* Newly added widget enum items.

Bonus: #11306 actually broke the NewGRF preset dropdown. Fixed here.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
