### PR TITLE
Doc: Link 3rdparty licenses from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ See the comments in the source files in `src/3rdparty/md5` for the complete lice
 The fmt implementation in `src/3rdparty/fmt` is licensed under the MIT license.
 See `src/3rdparty/fmt/LICENSE.rst` for the complete license text.
 
+The nlohmann json implementation in `src/3rdparty/nlohmann` is licensed under the MIT license.
+See `src/3rdparty/nlohmann/LICENSE.MIT` for the complete license text.
+
+The OpenGL API in `src/3rdparty/opengl` is licensed under the MIT license.
+See `src/3rdparty/opengl/khrplatform.h` for the complete license text.
+
 The catch2 implementation in `src/3rdparty/catch2` is licensed under the Boost Software License, Version 1.0.
 See `src/3rdparty/catch2/LICENSE.txt` for the complete license text.
 


### PR DESCRIPTION
## Motivation / Problem

The readme lists and links the licenses of included 3rdparty content.
But the list is incomplete.

## Description

* nlohmann has a license file, which can be linked.
* The OpenGL API headers (is there any official name for them?) are a bit more complicated:
    * One of the headers includes the license text as comment.
    * The remaining two headers only reference the license by name.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
