### PR TITLE
Change: Store station blocked/wires/pylons flags in map.

### DIFF
--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -989,8 +989,11 @@
        </tr>
       </table>
      </li>
+     <li>m6 bit 7: rail station / waypoint may have catenary pylons</li>
+     <li>m6 bit 6: rail station / waypoint may have catenary wires</li>
      <li>m6 bits 5..3: the station type (rail, airport, truck, bus, oilrig, dock, buoy, waypoint)</li>
      <li>m6 bit 2: pbs reservation state for railway stations/waypoints</li>
+     <li>m6 bit 0: rail station / waypoint is blocked</li>
 
      <li>m7 bits 4..0: <a href="#OwnershipInfo">owner</a> of road (road stops)</li>
      <li>m7: animation frame (railway stations/waypoints, airports)</li>

--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -188,7 +188,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits" rowspan=2><span class="used" title="Random bits">XXXX</span> <span class="free">OOOO</span></td>
       <td class="bits" rowspan=2><span class="used" title="Custom station specifications ID">XXXX XXXX</span></td>
       <td class="bits"><span class="used" title="Graphics index">XXXX XXXX</span></td>
-      <td class="bits" rowspan=2><span class="free">OO</span><span class="used" title="Station type">XXX</span> <span class="used" title="Reserved track">X</span><span class="free">OO</span></td>
+      <td class="bits" rowspan=2><span class="used" title="May have pylons">X</span><span class="used" title="May have wires">X</span><span class="used" title="Station type">XXX</span> <span class="used" title="Reserved track">X</span><span class="free">O</span><span class="used" title="Tile is blocked">X</span></td>
       <td class="bits" rowspan=2><span class="used" title="Animation frame">XXXX XXXX</span></td>
       <td class="bits" rowspan=2><span class="free">OOOO OOOO OO</span><span class="used" title="Railway type">XX XXXX</span></td>
     </tr>

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -840,46 +840,6 @@ const StationSpec *GetStationSpec(TileIndex t)
 	return specindex < st->speclist.size() ? st->speclist[specindex].spec : nullptr;
 }
 
-
-/**
- * Check whether a rail station tile is NOT traversable.
- * @param tile %Tile to test.
- * @return Station tile is blocked.
- * @note This could be cached (during build) in the map array to save on all the dereferencing.
- */
-bool IsStationTileBlocked(TileIndex tile)
-{
-	const StationSpec *statspec = GetStationSpec(tile);
-
-	return statspec != nullptr && HasBit(statspec->blocked, GetStationGfx(tile));
-}
-
-/**
- * Check if a rail station tile shall have pylons when electrified.
- * @param tile %Tile to test.
- * @return Tile shall have pylons.
- * @note This could be cached (during build) in the map array to save on all the dereferencing.
- */
-bool CanStationTileHavePylons(TileIndex tile)
-{
-	const StationSpec *statspec = GetStationSpec(tile);
-	uint gfx = GetStationGfx(tile);
-	/* Default stations do not draw pylons under roofs (gfx >= 4) */
-	return statspec != nullptr ? HasBit(statspec->pylons, gfx) : gfx < 4;
-}
-
-/**
- * Check if a rail station tile shall have wires when electrified.
- * @param tile %Tile to test.
- * @return Tile shall have wires.
- * @note This could be cached (during build) in the map array to save on all the dereferencing.
- */
-bool CanStationTileHaveWires(TileIndex tile)
-{
-	const StationSpec *statspec = GetStationSpec(tile);
-	return statspec == nullptr || !HasBit(statspec->wires, GetStationGfx(tile));
-}
-
 /** Wrapper for animation control, see GetStationCallback. */
 uint16_t GetAnimStationCallback(CallbackID callback, uint32_t param1, uint32_t param2, const StationSpec *statspec, BaseStation *st, TileIndex tile, int)
 {

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1466,7 +1466,18 @@ CommandCost CmdBuildRailStation(DoCommandFlag flags, TileIndex tile_org, RailTyp
 				SetStationTileRandomBits(tile, GB(Random(), 0, 4));
 				SetAnimationFrame(tile, 0);
 
-				if (!IsStationTileBlocked(tile)) c->infrastructure.rail[rt]++;
+				/* Should be the same as layout but axis component could be wrong... */
+				StationGfx gfx = GetStationGfx(tile);
+				bool blocked = statspec != nullptr && HasBit(statspec->blocked, gfx);
+				/* Default stations do not draw pylons under roofs (gfx >= 4) */
+				bool pylons = statspec != nullptr ? HasBit(statspec->pylons, gfx) : gfx < 4;
+				bool wires = statspec == nullptr || !HasBit(statspec->wires, gfx);
+
+				SetStationTileBlocked(tile, blocked);
+				SetStationTileHavePylons(tile, pylons);
+				SetStationTileHaveWires(tile, wires);
+
+				if (!blocked) c->infrastructure.rail[rt]++;
 				c->infrastructure.station++;
 
 				if (statspec != nullptr) {

--- a/src/station_func.h
+++ b/src/station_func.h
@@ -43,12 +43,6 @@ void UpdateStationDockingTiles(Station *st);
 void RemoveDockingTile(TileIndex t);
 void ClearDockingTilesCheckingNeighbours(TileIndex tile);
 
-/* Check if a rail station tile is traversable. */
-bool IsStationTileBlocked(TileIndex tile);
-
-bool CanStationTileHavePylons(TileIndex tile);
-bool CanStationTileHaveWires(TileIndex tile);
-
 void UpdateAirportsNoise();
 
 bool SplitGroundSpriteForOverlay(const TileInfo *ti, SpriteID *ground, RailTrackOffset *overlay_offset);

--- a/src/station_map.h
+++ b/src/station_map.h
@@ -330,6 +330,78 @@ static inline bool IsHangarTile(Tile t)
 }
 
 /**
+ * Is tile \a t a blocked tile?
+ * @pre HasStationRail(t)
+ * @param t Tile to check
+ * @return \c true if the tile is blocked
+ */
+static inline bool IsStationTileBlocked(Tile t)
+{
+	assert(HasStationRail(t));
+	return HasBit(t.m6(), 0);
+}
+
+/**
+ * Set the blocked state of the rail station
+ * @pre HasStationRail(t)
+ * @param t the station tile
+ * @param b the blocked state
+ */
+static inline void SetStationTileBlocked(Tile t, bool b)
+{
+	assert(HasStationRail(t));
+	SB(t.m6(), 0, 1, b ? 1 : 0);
+}
+
+/**
+ * Can tile \a t have catenary wires?
+ * @pre HasStationRail(t)
+ * @param t Tile to check
+ * @return \c true if the tile can have catenary wires
+ */
+static inline bool CanStationTileHaveWires(Tile t)
+{
+	assert(HasStationRail(t));
+	return HasBit(t.m6(), 6);
+}
+
+/**
+ * Set the catenary wires state of the rail station
+ * @pre HasStationRail(t)
+ * @param t the station tile
+ * @param b the catenary wires state
+ */
+static inline void SetStationTileHaveWires(Tile t, bool b)
+{
+	assert(HasStationRail(t));
+	SB(t.m6(), 6, 1, b ? 1 : 0);
+}
+
+/**
+ * Can tile \a t have catenary pylons?
+ * @pre HasStationRail(t)
+ * @param t Tile to check
+ * @return \c true if the tile can have catenary pylons
+ */
+static inline bool CanStationTileHavePylons(Tile t)
+{
+	assert(HasStationRail(t));
+	return HasBit(t.m6(), 7);
+}
+
+/**
+ * Set the catenary pylon state of the rail station
+ * @pre HasStationRail(t)
+ * @param t the station tile
+ * @param b the catenary pylons state
+ */
+static inline void SetStationTileHavePylons(Tile t, bool b)
+{
+	assert(HasStationRail(t));
+	SB(t.m6(), 7, 1, b ? 1 : 0);
+}
+
+/**
  * Get the rail direction of a rail station.
  * @param t Tile to query
  * @pre HasStationRail(t)
@@ -379,10 +451,10 @@ static inline TrackBits GetRailStationTrackBits(Tile t)
 static inline bool IsCompatibleTrainStationTile(Tile test_tile, Tile station_tile)
 {
 	assert(IsRailStationTile(station_tile));
-	return IsRailStationTile(test_tile) && IsCompatibleRail(GetRailType(test_tile), GetRailType(station_tile)) &&
+	return IsRailStationTile(test_tile) && !IsStationTileBlocked(test_tile) &&
+			IsCompatibleRail(GetRailType(test_tile), GetRailType(station_tile)) &&
 			GetRailStationAxis(test_tile) == GetRailStationAxis(station_tile) &&
-			GetStationIndex(test_tile) == GetStationIndex(station_tile) &&
-			!IsStationTileBlocked(test_tile);
+			GetStationIndex(test_tile) == GetStationIndex(station_tile);
 }
 
 /**

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -277,6 +277,18 @@ CommandCost CmdBuildRailWaypoint(DoCommandFlag flags, TileIndex start_tile, Axis
 					HasStationReservation(tile);
 			MakeRailWaypoint(tile, wp->owner, wp->index, axis, layout_ptr[i], GetRailType(tile));
 			SetCustomStationSpecIndex(tile, map_spec_index);
+
+			/* Should be the same as layout but axis component could be wrong... */
+			StationGfx gfx = GetStationGfx(tile);
+			bool blocked = spec != nullptr && HasBit(spec->blocked, gfx);
+			/* Default stations do not draw pylons under roofs (gfx >= 4) */
+			bool pylons = spec != nullptr ? HasBit(spec->pylons, gfx) : gfx < 4;
+			bool wires = spec == nullptr || !HasBit(spec->wires, gfx);
+
+			SetStationTileBlocked(tile, blocked);
+			SetStationTileHavePylons(tile, pylons);
+			SetStationTileHaveWires(tile, wires);
+
 			SetRailStationReservation(tile, reserved);
 			MarkTileDirtyByTile(tile);
 


### PR DESCRIPTION
## Motivation / Problem

Rail stations / waypoints have three flags that require looking up the custom station spec every time the game needs to know if a tile is blocked, or if should have catenary wires and pylons drawn.

Rail station / waypoints also have more than 3 bits of unused space in the map array.

And, the functions that are used to get this data include the comment:
> This could be cached (during build) in the map array to save on all the dereferencing.

Ergo...

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This stores three flags in unused map bits, and avoids having to look up station graphics and custom station specs to determine blocked/wires/pylons status.

This potentially affects rail pathfinding and rendering performance, but I've not benchmarked it.

Savegame version is not bumped, as the flags can just be updated every time. This means that, like currently, the flags are technically not persistent and depend on the current state of the NewGRF stations. This also means this change could be undone without requiring extra conversion if map bits are required for something else.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
