### PR TITLE
Fix #10763, Fix #11168: Display variant groups that consist only of unavailable sub-groups

### DIFF
--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -179,7 +179,13 @@ class ReplaceVehicleWindow : public Window {
 			if (side == 1 && eid == this->sel_engine[0]) flags |= EngineDisplayFlags::Shaded;
 			list.emplace_back(eid, e->info.variant_id, flags, 0);
 
-			if (side == 1 && e->info.variant_id != INVALID_ENGINE) variants.push_back(e->info.variant_id);
+			if (side == 1) {
+				EngineID parent = e->info.variant_id;
+				while (parent != INVALID_ENGINE) {
+					variants.push_back(parent);
+					parent = Engine::Get(parent)->info.variant_id;
+				}
+			}
 			if (eid == this->sel_engine[side]) selected_engine = eid; // The selected engine is still in the list
 		}
 

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1422,7 +1422,14 @@ struct BuildVehicleWindow : Window {
 			list.emplace_back(eid, e->info.variant_id, e->display_flags, 0);
 
 			if (rvi->railveh_type != RAILVEH_WAGON) num_engines++;
-			if (e->info.variant_id != INVALID_ENGINE) variants.push_back(e->info.variant_id);
+
+			/* Add all parent variants of this engine to the variant list */
+			EngineID parent = e->info.variant_id;
+			while (parent != INVALID_ENGINE) {
+				variants.push_back(parent);
+				parent = Engine::Get(parent)->info.variant_id;
+			}
+
 			if (eid == this->sel_engine) sel_id = eid;
 		}
 
@@ -1563,8 +1570,13 @@ struct BuildVehicleWindow : Window {
 		/* ensure primary engine of variant group is in list after filtering */
 		std::vector<EngineID> variants;
 		for (const auto &item : this->eng_list) {
-			if (item.engine_id != item.variant_id && item.variant_id != INVALID_ENGINE) variants.push_back(item.variant_id);
+			EngineID parent = item.variant_id;
+			while (parent != INVALID_ENGINE) {
+				variants.push_back(parent);
+				parent = Engine::Get(parent)->info.variant_id;
+			}
 		}
+
 		for (const auto &variant : variants) {
 			if (std::find(this->eng_list.begin(), this->eng_list.end(), variant) == this->eng_list.end()) {
 				const Engine *e = Engine::Get(variant);


### PR DESCRIPTION
## Motivation / Problem
Fixes #10763 and fixes #11168.

Essentially, the code added the immediate parent of a variant vehicle to the list, but not higher levels.

## Description

Loop through and add all the parents of every variant vehicle up to the top level, so that even when a group consists only of unavailable sub-groups, the top-level group is still displayed when its second-level children are available.

The example provided by @George-VB in #11168 now produces the following list when game is started in 1.1.1970 with default settings.
![image](https://github.com/OpenTTD/OpenTTD/assets/66267867/68c18107-7e2d-4b76-8b23-8431dad93222)

And the example in #10763:
![image](https://github.com/OpenTTD/OpenTTD/assets/66267867/4c50459e-91b2-4e77-b3ad-91489346055a)


## Limitations
Not well tested as I cannot write NewGRF nor do I know the actual intended output. Perhaps @George-VB could help with testing.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
