### PR TITLE
Fix #11261: Set number of items correctly when choosing available airport class

### DIFF
--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -544,13 +544,14 @@ public:
 		}
 		if (change_class) {
 			/* If that fails, select the first available airport
-			 * from a random class. */
+			 * from the first class where airports are available. */
 			for (AirportClassID j = APC_BEGIN; j < APC_MAX; j++) {
 				AirportClass *apclass = AirportClass::Get(j);
 				for (uint i = 0; i < apclass->GetSpecCount(); i++) {
 					const AirportSpec *as = apclass->GetSpec(i);
 					if (as->IsAvailable()) {
 						_selected_airport_class = j;
+						this->vscroll->SetCount(apclass->GetSpecCount());
 						this->SelectOtherAirport(i);
 						return;
 					}


### PR DESCRIPTION
## Motivation / Problem
Fixes #11261.

When the airport building GUI is opened, the game tries to select an available airport in the current class, If not, it loops through classes in order trying to find an available airport, and selects the first available airport it finds and the corresponding class. However, it doesn't set the number of items in the list according to this new class. So only as many items as were in the previous class are clickable.

## Description
Set the number of items in the list when changing the airport class due to no airports being available in the selected class.

Also, change the comment to reflect the actual behaviour. It doesn't select a random class, but the first one in order where any airport is available.

## Limitations
None?


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
