### PR TITLE
Feature: Cheat to fix station ratings at 100%

### DIFF
--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -163,6 +163,7 @@ enum CheatNumbers {
 	CHT_CROSSINGTUNNELS, ///< Allow tunnels to cross each other.
 	CHT_NO_JETCRASH,     ///< Disable jet-airplane crashes.
 	CHT_SETUP_PROD,      ///< Allow manually editing of industry production.
+	CHT_STATION_RATING,  ///< Fix station ratings at 100%.
 	CHT_EDIT_MAX_HL,     ///< Edit maximum allowed heightlevel
 	CHT_CHANGE_DATE,     ///< Do time traveling.
 
@@ -196,6 +197,7 @@ static const CheatEntry _cheats_ui[] = {
 	{SLE_BOOL,  STR_CHEAT_CROSSINGTUNNELS, &_cheats.crossing_tunnels.value,               &_cheats.crossing_tunnels.been_used, nullptr                  },
 	{SLE_BOOL,  STR_CHEAT_NO_JETCRASH,     &_cheats.no_jetcrash.value,                    &_cheats.no_jetcrash.been_used,      nullptr                  },
 	{SLE_BOOL,  STR_CHEAT_SETUP_PROD,      &_cheats.setup_prod.value,                     &_cheats.setup_prod.been_used,       &ClickSetProdCheat       },
+	{SLE_BOOL,  STR_CHEAT_STATION_RATING,  &_cheats.station_rating.value,                 &_cheats.station_rating.been_used,   nullptr                  },
 	{SLE_UINT8, STR_CHEAT_EDIT_MAX_HL,     &_settings_game.construction.map_height_limit, &_cheats.edit_max_hl.been_used,      &ClickChangeMaxHlCheat   },
 	{SLE_INT32, STR_CHEAT_CHANGE_DATE,     &TimerGameCalendar::year,                      &_cheats.change_date.been_used,      &ClickChangeDateCheat    },
 };

--- a/src/cheat_type.h
+++ b/src/cheat_type.h
@@ -32,6 +32,7 @@ struct Cheats {
 	Cheat change_date;      ///< changes date ingame
 	Cheat setup_prod;       ///< setup raw-material production in game
 	Cheat edit_max_hl;      ///< edit the maximum heightlevel; this is a cheat because of the fact that it needs to reset NewGRF game state and doing so as a simple configuration breaks the expectation of many
+	Cheat station_rating;   ///< Fix station ratings at 100%
 };
 
 extern Cheats _cheats;

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2196,6 +2196,7 @@ STR_CHEAT_EDIT_MAX_HL_QUERY_CAPT                                :{WHITE}Edit the
 STR_CHEAT_CHANGE_DATE                                           :{LTBLUE}Change date: {ORANGE}{DATE_SHORT}
 STR_CHEAT_CHANGE_DATE_QUERY_CAPT                                :{WHITE}Change current year
 STR_CHEAT_SETUP_PROD                                            :{LTBLUE}Enable modifying production values: {ORANGE}{STRING1}
+STR_CHEAT_STATION_RATING                                        :{LTBLUE}Fix station ratings at 100%: {ORANGE}{STRING1}
 
 # Livery window
 STR_LIVERY_CAPTION                                              :{WHITE}{COMPANY} - Colour Scheme

--- a/src/saveload/cheat_sl.cpp
+++ b/src/saveload/cheat_sl.cpp
@@ -33,6 +33,8 @@ static const SaveLoad _cheats_desc[] = {
 	SLE_VAR(Cheats, setup_prod.value, SLE_BOOL),
 	SLE_VAR(Cheats, edit_max_hl.been_used, SLE_BOOL),
 	SLE_VAR(Cheats, edit_max_hl.value, SLE_BOOL),
+	SLE_CONDVAR(Cheats, station_rating.been_used, SLE_BOOL, SLV_STATION_RATING_CHEAT, SL_MAX_VERSION),
+	SLE_CONDVAR(Cheats, station_rating.value, SLE_BOOL, SLV_STATION_RATING_CHEAT, SL_MAX_VERSION),
 };
 
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -362,6 +362,8 @@ enum SaveLoadVersion : uint16_t {
 	SLV_REMOVE_LOADED_AT_XY,                ///< 318  PR#11276 Remove loaded_at_xy variable from CargoPacket.
 	SLV_CARGO_TRAVELLED,                    ///< 319  PR#11283 CargoPacket now tracks how far it travelled inside a vehicle.
 
+	SLV_STATION_RATING_CHEAT,               ///< 320  PR#11346 Add cheat to fix station ratings at 100%.
+
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
 

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -19,7 +19,8 @@
 #include "newgrf_storage.h"
 #include "bitmap_type.h"
 
-static const byte INITIAL_STATION_RATING = 175;
+static const uint8_t INITIAL_STATION_RATING = 175;
+static const uint8_t MAX_STATION_RATING = 255;
 
 /**
  * Flow statistics telling how much flow should be sent along a link. This is

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -64,6 +64,7 @@
 #include "timer/timer.h"
 #include "timer/timer_game_calendar.h"
 #include "timer/timer_game_tick.h"
+#include "cheat_type.h"
 
 #include "table/strings.h"
 
@@ -3678,7 +3679,10 @@ static void UpdateStationRating(Station *st)
 			 */
 			uint waiting_avg = waiting / (num_dests + 1);
 
-			if (HasBit(cs->callback_mask, CBM_CARGO_STATION_RATING_CALC)) {
+			if (_cheats.station_rating.value) {
+				ge->rating = rating = MAX_STATION_RATING;
+				skip = true;
+			} else if (HasBit(cs->callback_mask, CBM_CARGO_STATION_RATING_CALC)) {
 				/* Perform custom station rating. If it succeeds the speed, days in transit and
 				 * waiting cargo ratings must not be executed. */
 


### PR DESCRIPTION
## Motivation / Problem

Station Ratings are generally considered to be a Bad Feature that prevent some gameplay styles, like running infrequent services with a low economy scale (#10606) to simulate a slower game, especially once we have configurable calendar speed.

## Description

Upstream a JGRPP cheat to fix station ratings at 100%.

## Limitations

* I considered the thorny issue of "Cheats are just another Settings menu", especially considering in #9833 we added the ability to disable local authorities using an existing Setting. However, that was an existing setting. I welcome discussion about where this should go. 😄 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
