### PR TITLE
Fix #8846: When upgrading NewGRF presets, copy NewGRF parameters only if the NewGRF are compatible.

### DIFF
--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -73,7 +73,6 @@ GRFConfig::GRFConfig(const GRFConfig &config) :
 void GRFConfig::CopyParams(const GRFConfig &src)
 {
 	this->num_params = src.num_params;
-	this->num_valid_params = src.num_valid_params;
 	this->param = src.param;
 }
 

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -67,6 +67,14 @@ GRFConfig::GRFConfig(const GRFConfig &config) :
 }
 
 /**
+ * Return whether this NewGRF can replace an older version of the same NewGRF.
+ */
+bool GRFConfig::IsCompatible(uint32_t old_version) const
+{
+	return this->min_loadable_version <= old_version && old_version <= this->version;
+}
+
+/**
  * Copy the parameter information from the \a src config.
  * @param src Source config.
  */
@@ -685,7 +693,7 @@ const GRFConfig *FindGRFConfig(uint32_t grfid, FindGRFConfigMode mode, const MD5
 		/* Skip incompatible stuff, unless explicitly allowed */
 		if (mode != FGCM_NEWEST && HasBit(c->flags, GCF_INVALID)) continue;
 		/* check version compatibility */
-		if (mode == FGCM_COMPATIBLE && (c->version < desired_version || c->min_loadable_version > desired_version)) continue;
+		if (mode == FGCM_COMPATIBLE && !c->IsCompatible(desired_version)) continue;
 		/* remember the newest one as "the best" */
 		if (best == nullptr || c->version > best->version) best = c;
 	}

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -173,6 +173,7 @@ struct GRFConfig : ZeroedMemoryAllocator {
 
 	struct GRFConfig *next; ///< NOSAVE: Next item in the linked list
 
+	bool IsCompatible(uint32_t old_version) const;
 	void CopyParams(const GRFConfig &src);
 
 	std::optional<std::string> GetTextfile(TextfileType type) const;

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -723,7 +723,11 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 			while (*c != iter->second) c = &(*c)->next;
 			GRFConfig *d = new GRFConfig(*a);
 			d->next = (*c)->next;
-			d->CopyParams(**c);
+			if (d->IsCompatible((*c)->version)) {
+				d->CopyParams(**c);
+			} else {
+				d->SetParameterDefaults();
+			}
 			if (this->active_sel == *c) {
 				CloseWindowByClass(WC_GRF_PARAMETERS);
 				CloseWindowByClass(WC_TEXTFILE);


### PR DESCRIPTION
## Motivation / Problem

#8846

## Description

When upgrading NewGRF the old parameters do not necessarily fit to the new version.
* NewGRF specify a version and minimum-compatible-version for savegame-compatibility.
* If a NewGRF changes or adds parameters with non-zero defaults, this is (currently) always a savegame-incompatible change. (parameters are not changed, when loading savegames/scenarios with compatible NewGRF)
* However, there are other savegame-incompatible changes, which do not invalidate parameters.

As such, this PR is on the "annoying, but safe" side. When upgrading NewGRF:
* parameters are only copied, if they are definitely compatible. (no false negatives)
* parameters are reset to defaults, if they are potentially incompatible. (false positives exist)

## Limitations

This PR does not implement #10549:
* Upgrading NewGRFs in presets uses the same logic as finding compatible NewGRF for savegames/scenarios.
* Detecting "new parameters" is not possible in all cases, if the original NewGRF is not present. (only if they use new registers at the end)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
