### PR TITLE
Do not merge! Disabled vcpkg cache to highlight problem

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -41,14 +41,6 @@ jobs:
     - name: Enable Rust cache
       uses: Swatinem/rust-cache@v2
 
-    - name: Enable vcpkg cache
-      uses: actions/cache@v3
-      with:
-        path: /vcpkg/installed
-        key: ubuntu-20.04-vcpkg-release-1 # Increase the number whenever dependencies are modified
-        restore-keys: |
-          ubuntu-20.04-vcpkg-release
-
     - name: Install dependencies
       run: |
         echo "::group::Install system dependencies"


### PR DESCRIPTION
## WARNING: DO NOT MERGE THIS PR!
*(it was created for demonstration purposes only)*

## Motivation / Problem

Please use this PR to observe  #11356 issue. I believe if you run "Release" action it should reproduce *Linux(Generic)* job failure.
