### PR TITLE
Change: Don't set vehicle on time if timetable not started

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -5189,6 +5189,7 @@ STR_ERROR_CAN_T_TIMETABLE_VEHICLE                               :{WHITE}Can't ti
 STR_ERROR_TIMETABLE_ONLY_WAIT_AT_STATIONS                       :{WHITE}Vehicles can only wait at stations
 STR_ERROR_TIMETABLE_NOT_STOPPING_HERE                           :{WHITE}This vehicle is not stopping at this station
 STR_ERROR_TIMETABLE_INCOMPLETE                                  :{WHITE}... timetable is incomplete
+STR_ERROR_TIMETABLE_NOT_STARTED                                 :{WHITE}... timetable has not started yet
 
 # Sign related errors
 STR_ERROR_TOO_MANY_SIGNS                                        :{WHITE}... too many signs


### PR DESCRIPTION
## Motivation / Problem

This is a change required for #11341, which can be a separate PR.

When a vehicle has not started its timetable, it cannot be late. Pressing the button currently has no effect on the vehicle's actions, and there is no effect visible to the player.

Under the hood, it sets `lateness_counter` which is then reset as soon as the vehicle gets to its first order and starts its timetable.

## Description

- If the current vehicle has not started its timetable, return a descriptive error message. This is an improvement over silently doing nothing without warning the player.
- If iterating through other vehicles in the group, ignore those which have not started their timetables, because their `lateness_counter` will always be a meaningless 0.

Again, this has no effect now besides not setting `lateness_counter` needlessly, but it matters in my current approach to #11341.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
