### PR TITLE
Cleanup: [MacOS] Remove unneeded WITH_SDL checks

### DIFF
--- a/src/os/macosx/macos.mm
+++ b/src/os/macosx/macos.mm
@@ -93,21 +93,7 @@ void GetMacOSVersion(int *return_major, int *return_minor, int *return_bugfix)
 #endif
 }
 
-#ifdef WITH_SDL
-
-/**
- * Show the system dialogue message (SDL on MacOSX).
- *
- * @param title Window title.
- * @param message Message text.
- * @param buttonLabel Button text.
- */
-void ShowMacDialog(const char *title, const char *message, const char *buttonLabel)
-{
-	NSRunAlertPanel([ NSString stringWithUTF8String:title ], [ NSString stringWithUTF8String:message ], [ NSString stringWithUTF8String:buttonLabel ], nil, nil);
-}
-
-#elif defined WITH_COCOA
+#ifdef WITH_COCOA
 
 extern void CocoaDialog(const char *title, const char *message, const char *buttonLabel);
 

--- a/src/os/macosx/osx_main.cpp
+++ b/src/os/macosx/osx_main.cpp
@@ -16,10 +16,6 @@
 #include <time.h>
 #include <signal.h>
 
-#if defined(WITH_SDL)
-/* the mac implementation needs this file included in the same file as main() */
-#	include <SDL.h>
-#endif
 #include "macos.h"
 
 #include "../../safeguards.h"


### PR DESCRIPTION
## Motivation / Problem
MacOS builds don't use SDL, but some MacOS specific code still does some WITH_SDL checks.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Remove the useless checks.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
