### PR TITLE
Codechange: Don't use bit-field in Yapf rail node.

### DIFF
--- a/src/pathfinder/yapf/yapf_node_rail.hpp
+++ b/src/pathfinder/yapf/yapf_node_rail.hpp
@@ -127,9 +127,9 @@ struct CYapfRailNodeT
 	union {
 		uint32_t          m_inherited_flags;
 		struct {
-			bool          m_targed_seen : 1;
-			bool          m_choice_seen : 1;
-			bool          m_last_signal_was_red : 1;
+			bool          m_targed_seen;
+			bool          m_choice_seen;
+			bool          m_last_signal_was_red;
 		} flags_s;
 	} flags_u;
 	SignalType        m_last_red_signal_type;


### PR DESCRIPTION
## Motivation / Problem

A struct involved in Yapf uses bitfields. We don't normally use these, so this stood out...

Compacting 3 booleans into 3 bits could save memory allocation, however this data is inside a union which also contains a 4-byte integer. As such this gives the cost penalty of a bit-field without any benefit.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Remove use of bitfield. Simple benchmarking of a RelWithDebInfo build was performed with:

`time ./openttd -s null -m null -v null -g ~/.local/share/openttd/save/wentbourne.sav`

| Run | With bitfield | Without bitfield | Benefit |
| -- | -- | -- | -- |
Run 1 | 47.235 | 45.751 | |
Run 2 | 46.855 | 45.347 | |
Run 3 | 46.272 | 45.151 | |
Avg | 46.787 | 45.416 | 2.93% |

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
