### PR TITLE
Fix: Closing network relay popup without pressing a button left connection in limbo.

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -99,7 +99,7 @@ struct AIConfigWindow : public Window {
 		this->OnInvalidateData(0);
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		CloseWindowByClass(WC_SCRIPT_LIST);
 		CloseWindowByClass(WC_SCRIPT_SETTINGS);

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -90,7 +90,7 @@ struct BuildAirToolbarWindow : Window {
 		this->last_user_action = INVALID_WID_AT;
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		if (this->IsWidgetLowered(WID_AT_AIRPORT)) SetViewportCatchmentStation(nullptr, true);
 		if (_settings_client.gui.link_terraform_toolbar) CloseWindowById(WC_SCEN_LAND_GEN, 0, false);
@@ -285,7 +285,7 @@ public:
 		if (selectFirstAirport) this->SelectFirstAvailableAirport(true);
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		CloseWindowById(WC_SELECT_STATION, 0);
 		this->PickerWindowBase::Close();

--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -92,7 +92,7 @@ public:
 		this->InitNested(1);
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		_exit_game = true;
 		this->Window::Close();
@@ -150,7 +150,7 @@ public:
 	{
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		/* If we are not set to exit the game, it means the bootstrap failed. */
 		if (!_exit_game) {
@@ -208,7 +208,7 @@ public:
 	}
 
 	/** Stop listening to the content client events. */
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		_network_content_client.RemoveCallback(this);
 		this->Window::Close();

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -129,7 +129,7 @@ struct IConsoleWindow : Window
 		this->line_offset = GetStringBoundingBox("] ").width + WidgetDimensions::scaled.frametext.left;
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		_iconsole_mode = ICONSOLE_CLOSED;
 		VideoDriver::GetInstance()->EditBoxLostFocus();

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -294,7 +294,7 @@ struct DepotWindow : Window {
 		OrderBackup::Reset();
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		CloseWindowById(WC_BUILD_VEHICLE, this->window_number);
 		CloseWindowById(GetWindowClassForVehicleType(this->type), VehicleListIdentifier(VL_DEPOT_LIST, this->type, this->owner, this->GetDepotIndex()).Pack(), false);

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -108,7 +108,7 @@ struct BuildDocksToolbarWindow : Window {
 		if (_settings_client.gui.link_terraform_toolbar) ShowTerraformToolbar(this);
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		if (_game_mode == GM_NORMAL && this->IsWidgetLowered(WID_DT_STATION)) SetViewportCatchmentStation(nullptr, true);
 		if (_settings_client.gui.link_terraform_toolbar) CloseWindowById(WC_SCEN_LAND_GEN, 0, false);
@@ -422,7 +422,7 @@ public:
 		this->LowerWidget(_settings_client.gui.station_show_coverage + BDSW_LT_OFF);
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		CloseWindowById(WC_SELECT_STATION, 0);
 		this->PickerWindowBase::Close();

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -313,7 +313,7 @@ public:
 		if (_right_button_down && !this->is_critical) this->Close();
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		SetRedErrorSquare(INVALID_TILE);
 		if (_window_system_initialized) ShowFirstError();

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -399,7 +399,7 @@ public:
 		}
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		/* pause is only used in single-player, non-editor mode, non menu mode */
 		if (!_networking && _game_mode != GM_EDITOR && _game_mode != GM_MENU) {

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -105,7 +105,7 @@ struct GSConfigWindow : public Window {
 		this->RebuildVisibleSettings();
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		CloseWindowByClass(WC_SCRIPT_LIST);
 		this->Window::Close();

--- a/src/highscore_gui.cpp
+++ b/src/highscore_gui.cpp
@@ -125,7 +125,7 @@ struct EndGameWindow : EndGameHighScoreBaseWindow {
 		MarkWholeScreenDirty();
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		if (!_networking) Command<CMD_PAUSE>::Post(PM_PAUSED_NORMAL, false); // unpause
 		if (_game_mode != GM_MENU) ShowHighscoreTable(this->window_number, this->rank);
@@ -173,7 +173,7 @@ struct HighScoreWindow : EndGameHighScoreBaseWindow {
 		this->rank = ranking;
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		if (_game_mode != GM_MENU) ShowVitalWindows();
 

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -1036,7 +1036,7 @@ struct QueryStringWindow : public Window
 		}
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		if (!this->editbox.handled && this->parent != nullptr) {
 			Window *parent = this->parent;
@@ -1109,7 +1109,7 @@ struct QueryWindow : public Window {
 		this->FinishInitNested(WN_CONFIRM_POPUP_QUERY);
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		if (this->proc != nullptr) this->proc(this->parent, false);
 		this->Window::Close();

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -302,7 +302,7 @@ struct NetworkChatWindow : public Window {
 		PositionNetworkChatWindow(this);
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		InvalidateWindowData(WC_NEWS_WINDOW, 0, 0);
 		this->Window::Close();

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -108,7 +108,7 @@ BaseNetworkContentDownloadStatusWindow::BaseNetworkContentDownloadStatusWindow(W
 	this->InitNested(WN_NETWORK_STATUS_WINDOW_CONTENT_DOWNLOAD);
 }
 
-void BaseNetworkContentDownloadStatusWindow::Close()
+void BaseNetworkContentDownloadStatusWindow::Close([[maybe_unused]] int data)
 {
 	_network_content_client.RemoveCallback(this);
 	this->Window::Close();
@@ -200,7 +200,7 @@ public:
 		this->parent = FindWindowById(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_CONTENT_LIST);
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		TarScanner::Mode mode = TarScanner::NONE;
 		for (auto ctype : this->receivedTypes) {
@@ -570,7 +570,7 @@ public:
 		this->InvalidateData();
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		_network_content_client.RemoveCallback(this);
 		this->Window::Close();

--- a/src/network/network_content_gui.h
+++ b/src/network/network_content_gui.h
@@ -32,7 +32,7 @@ public:
 	 */
 	BaseNetworkContentDownloadStatusWindow(WindowDesc *desc);
 
-	void Close() override;
+	void Close([[maybe_unused]] int data = 0) override;
 	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override;
 	void DrawWidget(const Rect &r, int widget) const override;
 	void OnDownloadProgress(const ContentInfo *ci, int bytes) override;

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -648,7 +648,7 @@ void ClientNetworkCoordinatorSocketHandler::CloseStunHandler(const std::string &
  */
 void ClientNetworkCoordinatorSocketHandler::CloseTurnHandler(const std::string &token)
 {
-	CloseWindowByClass(WC_NETWORK_ASK_RELAY);
+	CloseWindowByClass(WC_NETWORK_ASK_RELAY, NRWCD_HANDLED);
 
 	auto turn_it = this->turn_handlers.find(token);
 	if (turn_it == this->turn_handlers.end()) return;

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -2413,6 +2413,12 @@ struct NetworkAskRelayWindow : public Window {
 		this->InitNested(0);
 	}
 
+	void Close(int data = 0) override
+	{
+		if (data == NRWCD_UNHANDLED) _network_coordinator_client.ConnectFailure(this->token, 0);
+		this->Window::Close();
+	}
+
 	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget == WID_NAR_TEXT) {
@@ -2452,18 +2458,18 @@ struct NetworkAskRelayWindow : public Window {
 		switch (widget) {
 			case WID_NAR_NO:
 				_network_coordinator_client.ConnectFailure(this->token, 0);
-				this->Close();
+				this->Close(NRWCD_HANDLED);
 				break;
 
 			case WID_NAR_YES_ONCE:
 				_network_coordinator_client.StartTurnConnection(this->token);
-				this->Close();
+				this->Close(NRWCD_HANDLED);
 				break;
 
 			case WID_NAR_YES_ALWAYS:
 				_settings_client.network.use_relay_service = URS_ALLOW;
 				_network_coordinator_client.StartTurnConnection(this->token);
-				this->Close();
+				this->Close(NRWCD_HANDLED);
 				break;
 		}
 	}
@@ -2499,7 +2505,7 @@ static WindowDesc _network_ask_relay_desc(
  */
 void ShowNetworkAskRelay(const std::string &server_connection_string, const std::string &relay_connection_string, const std::string &token)
 {
-	CloseWindowByClass(WC_NETWORK_ASK_RELAY);
+	CloseWindowByClass(WC_NETWORK_ASK_RELAY, NRWCD_HANDLED);
 
 	Window *parent = GetMainWindow();
 	new NetworkAskRelayWindow(&_network_ask_relay_desc, parent, server_connection_string, relay_connection_string, token);

--- a/src/network/network_gui.h
+++ b/src/network/network_gui.h
@@ -39,5 +39,9 @@ struct NetworkCompanyInfo : NetworkCompanyStats {
 	std::string clients;      ///< The clients that control this company (Name1, name2, ..)
 };
 
+enum NetworkRelayWindowCloseData {
+	NRWCD_UNHANDLED = 0, ///< Relay request is unhandled.
+	NRWCD_HANDLED = 1, ///< Relay request is handled, either by user or by timeout.
+};
 
 #endif /* NETWORK_GUI_H */

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -672,7 +672,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		this->OnInvalidateData(GOID_NEWGRF_CURRENT_LOADED);
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		CloseWindowByClass(WC_GRF_PARAMETERS);
 		CloseWindowByClass(WC_TEXTFILE);

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -419,7 +419,7 @@ struct BuildRailToolbarWindow : Window {
 		if (_settings_client.gui.link_terraform_toolbar) ShowTerraformToolbar(this);
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		if (this->IsWidgetLowered(WID_RAT_BUILD_STATION)) SetViewportCatchmentStation(nullptr, true);
 		if (this->IsWidgetLowered(WID_RAT_BUILD_WAYPOINT)) SetViewportCatchmentWaypoint(nullptr, true);
@@ -1031,7 +1031,7 @@ public:
 		this->InvalidateData();
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		CloseWindowById(WC_SELECT_STATION, 0);
 		this->PickerWindowBase::Close();
@@ -1694,7 +1694,7 @@ public:
 		this->OnInvalidateData();
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		_convert_signal_button = false;
 		this->PickerWindowBase::Close();
@@ -2018,7 +2018,7 @@ struct BuildRailWaypointWindow : PickerWindowBase {
 		this->BuildPickerList();
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		CloseWindowById(WC_SELECT_STATION, 0);
 		this->PickerWindowBase::Close();

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -327,7 +327,7 @@ struct BuildRoadToolbarWindow : Window {
 		if (_settings_client.gui.link_terraform_toolbar) ShowTerraformToolbar(this);
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		if (_game_mode == GM_NORMAL && (this->IsWidgetLowered(WID_ROT_BUS_STATION) || this->IsWidgetLowered(WID_ROT_TRUCK_STATION))) SetViewportCatchmentStation(nullptr, true);
 		if (_settings_client.gui.link_terraform_toolbar) CloseWindowById(WC_SCEN_LAND_GEN, 0, false);
@@ -1223,7 +1223,7 @@ public:
 		}
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		CloseWindowById(WC_SELECT_STATION, 0);
 		this->PickerWindowBase::Close();

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -186,7 +186,7 @@ struct GameOptionsWindow : Window {
 		if constexpr (!NetworkSurveyHandler::IsSurveyPossible()) this->GetWidget<NWidgetStacked>(WID_GO_SURVEY_SEL)->SetDisplayedPlane(SZSP_NONE);
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		CloseWindowById(WC_CUSTOM_CURRENCY, 0);
 		CloseWindowByClass(WC_TEXTFILE);

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -1096,7 +1096,7 @@ SmallMapWindow::~SmallMapWindow()
 	delete this->overlay;
 }
 
-/* virtual */ void SmallMapWindow::Close()
+/* virtual */ void SmallMapWindow::Close([[maybe_unused]] int data)
 {
 	this->BreakIndustryChainLink();
 	this->Window::Close();

--- a/src/smallmap_gui.h
+++ b/src/smallmap_gui.h
@@ -199,7 +199,7 @@ public:
 	void SmallMapCenterOnCurrentPos();
 	Point GetStationMiddle(const Station *st) const;
 
-	void Close() override;
+	void Close([[maybe_unused]] int data = 0) override;
 	void SetStringParameters(int widget) const override;
 	void OnInit() override;
 	void OnPaint() override;

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -1325,7 +1325,7 @@ struct StationViewWindow : public Window {
 		this->owner = Station::Get(window_number)->owner;
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		CloseWindowById(WC_TRAINS_LIST,   VehicleListIdentifier(VL_STATION_LIST, VEH_TRAIN,    this->owner, this->window_number).Pack(), false);
 		CloseWindowById(WC_ROADVEH_LIST,  VehicleListIdentifier(VL_STATION_LIST, VEH_ROAD,     this->owner, this->window_number).Pack(), false);
@@ -2287,7 +2287,7 @@ struct SelectStationWindow : Window {
 		_thd.freeze = true;
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		SetViewportCatchmentSpecializedStation<T>(nullptr, true);
 

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -364,7 +364,7 @@ public:
 		this->SetWidgetDisabledState(WID_TV_CHANGE_NAME, _networking && !_network_server);
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		SetViewportCatchmentTown(Town::Get(this->window_number), false);
 		this->Window::Close();

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2935,7 +2935,7 @@ public:
 		this->UpdateButtonStatus();
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		CloseWindowById(WC_VEHICLE_ORDERS, this->window_number, false);
 		CloseWindowById(WC_VEHICLE_REFIT, this->window_number, false);

--- a/src/waypoint_gui.cpp
+++ b/src/waypoint_gui.cpp
@@ -76,7 +76,7 @@ public:
 		this->OnInvalidateData(0);
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		CloseWindowById(GetWindowClassForVehicleType(this->vt), VehicleListIdentifier(VL_STATION_LIST, this->vt, this->owner, this->window_number).Pack(), false);
 		SetViewportCatchmentWaypoint(Waypoint::Get(this->window_number), false);

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -173,7 +173,7 @@ struct DropdownWindow : Window {
 		this->instant_close    = instant_close;
 	}
 
-	void Close() override
+	void Close([[maybe_unused]] int data = 0) override
 	{
 		/* Finish closing the dropdown, so it doesn't affect new window placement.
 		 * Also mark it dirty in case the callback deals with the screen. (e.g. screenshots). */

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1045,7 +1045,7 @@ void Window::CloseChildWindows(WindowClass wc) const
 /**
  * Hide the window and all its child windows, and mark them for a later deletion.
  */
-void Window::Close()
+void Window::Close([[maybe_unused]] int data)
 {
 	/* Don't close twice. */
 	if (*this->z_position == nullptr) return;
@@ -1141,11 +1141,11 @@ Window *GetMainWindow()
  * @param number Number of the window within the window class
  * @param force force closing; if false don't close when stickied
  */
-void CloseWindowById(WindowClass cls, WindowNumber number, bool force)
+void CloseWindowById(WindowClass cls, WindowNumber number, bool force, int data)
 {
 	Window *w = FindWindowById(cls, number);
 	if (w != nullptr && (force || (w->flags & WF_STICKY) == 0)) {
-		w->Close();
+		w->Close(data);
 	}
 }
 
@@ -1153,12 +1153,12 @@ void CloseWindowById(WindowClass cls, WindowNumber number, bool force)
  * Close all windows of a given class
  * @param cls Window class of windows to delete
  */
-void CloseWindowByClass(WindowClass cls)
+void CloseWindowByClass(WindowClass cls, int data)
 {
 	/* Note: the container remains stable, even when deleting windows. */
 	for (Window *w : Window::Iterate()) {
 		if (w->window_class == cls) {
-			w->Close();
+			w->Close(data);
 		}
 	}
 }
@@ -3486,7 +3486,7 @@ void RelocateAllWindows(int neww, int newh)
  * Hide the window and all its child windows, and mark them for a later deletion.
  * Always call ResetObjectToPlace() when closing a PickerWindow.
  */
-void PickerWindowBase::Close()
+void PickerWindowBase::Close([[maybe_unused]] int data)
 {
 	ResetObjectToPlace();
 	this->Window::Close();

--- a/src/window_func.h
+++ b/src/window_func.h
@@ -73,13 +73,13 @@ void SetWindowDirty(WindowClass cls, T number)
 	SetWindowDirty(cls, static_cast<typename T::BaseType>(number));
 }
 
-void CloseWindowById(WindowClass cls, WindowNumber number, bool force = true);
-void CloseWindowByClass(WindowClass cls);
+void CloseWindowById(WindowClass cls, WindowNumber number, bool force = true, int data = 0);
+void CloseWindowByClass(WindowClass cls, int data = 0);
 
 template<typename T, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value, int> = 0>
-void CloseWindowById(WindowClass cls, T number, bool force = true)
+void CloseWindowById(WindowClass cls, T number, bool force = true, int data = 0)
 {
-	CloseWindowById(cls, static_cast<typename T::BaseType>(number), force);
+	CloseWindowById(cls, static_cast<typename T::BaseType>(number), force, data);
 }
 
 bool EditBoxInGlobalFocus();

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -488,7 +488,7 @@ public:
 	static int SortButtonWidth();
 
 	void CloseChildWindows(WindowClass wc = WC_INVALID) const;
-	virtual void Close();
+	virtual void Close(int data = 0);
 	static void DeleteClosedWindows();
 
 	void SetDirty() const;
@@ -922,7 +922,7 @@ public:
 		this->parent = parent;
 	}
 
-	void Close() override;
+	void Close([[maybe_unused]] int data = 0) override;
 };
 
 Window *BringWindowToFrontById(WindowClass cls, WindowNumber number);


### PR DESCRIPTION
## Motivation / Problem

When connecting to a server that requires a relay, a popup is shown to the user, if this popup is closed without pressing an action button (e.g. by clicking on the X or right-click close) this leaves the game connection in limbo, as it cannot proceed. It will eventually time out.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Treat closing the window the same as clicking on "No".

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
