### PR TITLE
Change: Always allow expanding towns in Scenario Editor to build new roads

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4866,7 +4866,6 @@ STR_ERROR_TOO_CLOSE_TO_EDGE_OF_MAP_SUB                          :{WHITE}... too 
 STR_ERROR_TOO_CLOSE_TO_ANOTHER_TOWN                             :{WHITE}... too close to another town
 STR_ERROR_TOO_MANY_TOWNS                                        :{WHITE}... too many towns
 STR_ERROR_NO_SPACE_FOR_TOWN                                     :{WHITE}... there is no more space on the map
-STR_ERROR_TOWN_EXPAND_WARN_NO_ROADS                             :{WHITE}The town will not build roads. You can enable building of roads via Settings->Environment->Towns
 STR_ERROR_ROAD_WORKS_IN_PROGRESS                                :{WHITE}Road works in progress
 STR_ERROR_TOWN_CAN_T_DELETE                                     :{WHITE}Can't delete this town...{}A station or depot is referring to the town or a town owned tile can't be removed
 STR_ERROR_STATUE_NO_SUITABLE_PLACE                              :{WHITE}... there is no suitable place for a statue in the centre of this town

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1375,6 +1375,15 @@ static bool TownCanGrowRoad(TileIndex tile)
 }
 
 /**
+ * Check if the town is allowed to build roads.
+ * @return true If the town is allowed to build roads.
+ */
+static inline bool TownAllowedToBuildRoads()
+{
+	return _settings_game.economy.allow_town_roads || _generating_world || _game_mode == GM_EDITOR;
+}
+
+/**
  * Grows the given town.
  * There are at the moment 3 possible way's for
  * the town expansion:
@@ -1403,7 +1412,7 @@ static void GrowTownInTile(TileIndex *tile_ptr, RoadBits cur_rb, DiagDirection t
 		 * to say that this is the last iteration. */
 		_grow_town_result = GROWTH_SEARCH_STOPPED;
 
-		if (!_settings_game.economy.allow_town_roads && !_generating_world) return;
+		if (!TownAllowedToBuildRoads()) return;
 		if (!_settings_game.economy.allow_town_level_crossings && IsTileType(tile, MP_RAILWAY)) return;
 
 		/* Remove hills etc */
@@ -1457,7 +1466,7 @@ static void GrowTownInTile(TileIndex *tile_ptr, RoadBits cur_rb, DiagDirection t
 		 * the fitting RoadBits */
 		_grow_town_result = GROWTH_SEARCH_STOPPED;
 
-		if (!_settings_game.economy.allow_town_roads && !_generating_world) return;
+		if (!TownAllowedToBuildRoads()) return;
 
 		switch (t1->layout) {
 			default: NOT_REACHED();
@@ -1528,7 +1537,7 @@ static void GrowTownInTile(TileIndex *tile_ptr, RoadBits cur_rb, DiagDirection t
 
 		if (!IsValidTile(house_tile)) return;
 
-		if (target_dir != DIAGDIR_END && (_settings_game.economy.allow_town_roads || _generating_world)) {
+		if (target_dir != DIAGDIR_END && TownAllowedToBuildRoads()) {
 			switch (t1->layout) {
 				default: NOT_REACHED();
 
@@ -1606,7 +1615,7 @@ static bool CanFollowRoad(TileIndex tile, DiagDirection dir)
 	if (HasTileWaterGround(target_tile)) return false;
 
 	RoadBits target_rb = GetTownRoadBits(target_tile);
-	if (_settings_game.economy.allow_town_roads || _generating_world) {
+	if (TownAllowedToBuildRoads()) {
 		/* Check whether a road connection exists or can be build. */
 		switch (GetTileType(target_tile)) {
 			case MP_ROAD:
@@ -1773,7 +1782,7 @@ static bool GrowTown(Town *t)
 
 	/* No road available, try to build a random road block by
 	 * clearing some land and then building a road there. */
-	if (_settings_game.economy.allow_town_roads || _generating_world) {
+	if (TownAllowedToBuildRoads()) {
 		tile = t->xy;
 		for (ptr = _town_coord_mod; ptr != endof(_town_coord_mod); ++ptr) {
 			/* Only work with plain land that not already has a house */
@@ -2437,7 +2446,7 @@ static bool CheckFree2x2Area(TileIndex tile, int z, bool noslope)
 static inline bool TownLayoutAllowsHouseHere(Town *t, TileIndex tile)
 {
 	/* Allow towns everywhere when we don't build roads */
-	if (!_settings_game.economy.allow_town_roads && !_generating_world) return true;
+	if (!TownAllowedToBuildRoads()) return true;
 
 	TileIndexDiffC grid_pos = TileIndexToTileIndexDiffC(t->xy, tile);
 
@@ -2468,7 +2477,7 @@ static inline bool TownLayoutAllowsHouseHere(Town *t, TileIndex tile)
 static inline bool TownLayoutAllows2x2HouseHere(Town *t, TileIndex tile)
 {
 	/* Allow towns everywhere when we don't build roads */
-	if (!_settings_game.economy.allow_town_roads && !_generating_world) return true;
+	if (!TownAllowedToBuildRoads()) return true;
 
 	/* Compute relative position of tile. (Positive offsets are towards north) */
 	TileIndexDiffC grid_pos = TileIndexToTileIndexDiffC(t->xy, tile);

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -500,14 +500,6 @@ public:
 				break;
 
 			case WID_TV_EXPAND: { // expand town - only available on Scenario editor
-				/* Warn the user if towns are not allowed to build roads, but do this only once per OpenTTD run. */
-				static bool _warn_town_no_roads = false;
-
-				if (!_settings_game.economy.allow_town_roads && !_warn_town_no_roads) {
-					ShowErrorMessage(STR_ERROR_TOWN_EXPAND_WARN_NO_ROADS, INVALID_STRING_ID, WL_WARNING);
-					_warn_town_no_roads = true;
-				}
-
 				Command<CMD_EXPAND_TOWN>::Post(STR_ERROR_CAN_T_EXPAND_TOWN, this->window_number, 0);
 				break;
 			}


### PR DESCRIPTION
## Motivation / Problem

As described in #11374, the setting `Towns are allowed to build roads` blocks expansion in Scenario Editor and shows a warning about this behavior. The setting documentation says it doesn't apply in Scenario Editor.

## Description

Change the behavior to match the documentation, so that the Expand button in Scenario Editor constructs roads regardless of the `Towns are allowed to build roads` setting.

Closes #11374.

## Limitations

[Spacebar heating](https://xkcd.com/1172/), etc.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
