### PR TITLE
Change: Decouple town cargo production from cargo type.

### DIFF
--- a/src/cargotype.cpp
+++ b/src/cargotype.cpp
@@ -22,6 +22,7 @@
 #include "safeguards.h"
 
 CargoSpec CargoSpec::array[NUM_CARGO];
+std::array<std::vector<const CargoSpec *>, NUM_TPE> CargoSpec::town_production_cargoes{};
 
 /**
  * Bitmask of cargo types available. This includes phony cargoes like regearing cargoes.
@@ -192,6 +193,7 @@ static bool CargoSpecClassSorter(const CargoSpec * const &a, const CargoSpec * c
 /** Initialize the list of sorted cargo specifications. */
 void InitializeSortedCargoSpecs()
 {
+	for (auto &tpc : CargoSpec::town_production_cargoes) tpc.clear();
 	_sorted_cargo_specs.clear();
 	/* Add each cargo spec to the list, and determine the largest cargo icon size. */
 	for (const CargoSpec *cargo : CargoSpec::Iterate()) {
@@ -210,6 +212,8 @@ void InitializeSortedCargoSpecs()
 	_standard_cargo_mask = 0;
 	uint8_t nb_standard_cargo = 0;
 	for (const auto &cargo : _sorted_cargo_specs) {
+		assert(cargo->town_production_effect != INVALID_TPE);
+		CargoSpec::town_production_cargoes[cargo->town_production_effect].push_back(cargo);
 		if (cargo->classes & CC_SPECIAL) break;
 		nb_standard_cargo++;
 		SetBit(_standard_cargo_mask, cargo->Index());

--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -33,6 +33,20 @@ enum TownAcceptanceEffect : byte {
 	NUM_TAE = TAE_END, ///< Amount of town effects.
 };
 
+/** Town effect when producing cargo. */
+enum TownProductionEffect : byte {
+	TPE_NONE, ///< Town will not produce this cargo type.
+	TPE_PASSENGERS, ///< Cargo behaves passenger-like for production.
+	TPE_MAIL, ///< Cargo behaves mail-like for production.
+	NUM_TPE,
+
+	/**
+	 * Invalid town production effect. Used as a sentinel to indicate if a NewGRF has explicitly set an effect.
+	 * This does not 'exist' after cargo types are finalised.
+	 */
+	INVALID_TPE,
+};
+
 /** Cargo classes. */
 enum CargoClass {
 	CC_NOAVAILABLE  = 0,       ///< No cargo class has been specified
@@ -65,6 +79,7 @@ struct CargoSpec {
 
 	bool is_freight;                 ///< Cargo type is considered to be freight (affects train freight multiplier).
 	TownAcceptanceEffect town_acceptance_effect; ///< The effect that delivering this cargo type has on towns. Also affects destination of subsidies.
+	TownProductionEffect town_production_effect{INVALID_TPE}; ///< The effect on town cargo production.
 	uint8_t callback_mask;             ///< Bitmask of cargo callbacks that have to be called
 
 	StringID name;                   ///< Name of this type of cargo.
@@ -170,6 +185,9 @@ struct CargoSpec {
 	 * @return an iterable ensemble of all valid CargoSpec
 	 */
 	static IterateWrapper Iterate(size_t from = 0) { return IterateWrapper(from); }
+
+	/** List of cargo specs for each Town Product Effect. */
+	static std::array<std::vector<const CargoSpec *>, NUM_TPE> town_production_cargoes;
 
 private:
 	static CargoSpec array[NUM_CARGO]; ///< Array holding all CargoSpecs

--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -21,16 +21,16 @@
 typedef uint32_t CargoLabel;
 
 /** Town growth effect when delivering cargo. */
-enum TownEffect : byte {
-	TE_BEGIN = 0,
-	TE_NONE = TE_BEGIN, ///< Cargo has no effect.
-	TE_PASSENGERS,      ///< Cargo behaves passenger-like.
-	TE_MAIL,            ///< Cargo behaves mail-like.
-	TE_GOODS,           ///< Cargo behaves goods/candy-like.
-	TE_WATER,           ///< Cargo behaves water-like.
-	TE_FOOD,            ///< Cargo behaves food/fizzy-drinks-like.
-	TE_END,             ///< End of town effects.
-	NUM_TE = TE_END,    ///< Amount of town effects.
+enum TownAcceptanceEffect : byte {
+	TAE_BEGIN = 0,
+	TAE_NONE = TAE_BEGIN, ///< Cargo has no effect.
+	TAE_PASSENGERS, ///< Cargo behaves passenger-like.
+	TAE_MAIL, ///< Cargo behaves mail-like.
+	TAE_GOODS, ///< Cargo behaves goods/candy-like.
+	TAE_WATER, ///< Cargo behaves water-like.
+	TAE_FOOD, ///< Cargo behaves food/fizzy-drinks-like.
+	TAE_END, ///< End of town effects.
+	NUM_TAE = TAE_END, ///< Amount of town effects.
 };
 
 /** Cargo classes. */
@@ -64,7 +64,7 @@ struct CargoSpec {
 	uint8_t transit_periods[2];
 
 	bool is_freight;                 ///< Cargo type is considered to be freight (affects train freight multiplier).
-	TownEffect town_effect;          ///< The effect that delivering this cargo type has on towns. Also affects destination of subsidies.
+	TownAcceptanceEffect town_acceptance_effect; ///< The effect that delivering this cargo type has on towns. Also affects destination of subsidies.
 	uint8_t callback_mask;             ///< Bitmask of cargo callbacks that have to be called
 
 	StringID name;                   ///< Name of this type of cargo.

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1132,7 +1132,7 @@ static Money DeliverGoods(int num_pieces, CargoID cargo_type, StationID dest, ui
 
 	/* Increase town's counter for town effects */
 	const CargoSpec *cs = CargoSpec::Get(cargo_type);
-	st->town->received[cs->town_effect].new_act += accepted_total;
+	st->town->received[cs->town_acceptance_effect].new_act += accepted_total;
 
 	/* Determine profit */
 	Money profit = GetTransportedGoodsIncome(accepted_total, distance, periods_in_transit, cargo_type);

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -2428,10 +2428,11 @@ struct CargoesRow {
 				if (!IsValidCargoID(cargo_fld->u.cargo.supp_cargoes[i])) ind_fld->u.industry.other_produced[i] = others[--other_count];
 			}
 		} else {
-			/* Houses only display what is demanded. */
+			/* Houses only display cargo that towns produce. */
 			for (uint i = 0; i < cargo_fld->u.cargo.num_cargoes; i++) {
 				CargoID cid = cargo_fld->u.cargo.vertical_cargoes[i];
-				if (cid == CT_PASSENGERS || cid == CT_MAIL) cargo_fld->ConnectCargo(cid, true);
+				TownProductionEffect tpe = CargoSpec::Get(cid)->town_production_effect;
+				if (tpe == TPE_PASSENGERS || tpe == TPE_MAIL) cargo_fld->ConnectCargo(cid, true);
 			}
 		}
 	}
@@ -2683,8 +2684,10 @@ struct IndustryCargoesWindow : public Window {
 	static bool HousesCanSupply(const CargoID *cargoes, uint length)
 	{
 		for (uint i = 0; i < length; i++) {
-			if (!IsValidCargoID(cargoes[i])) continue;
-			if (cargoes[i] == CT_PASSENGERS || cargoes[i] == CT_MAIL) return true;
+			CargoID cid = cargoes[i];
+			if (!IsValidCargoID(cid)) continue;
+			TownProductionEffect tpe = CargoSpec::Get(cid)->town_production_effect;
+			if (tpe == TPE_PASSENGERS || tpe == TPE_MAIL) return true;
 		}
 		return false;
 	}

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -3066,15 +3066,15 @@ static ChangeInfoResult CargoChangeInfo(uint cid, int numinfo, int prop, ByteRea
 				uint8_t substitute_type = buf->ReadByte();
 
 				switch (substitute_type) {
-					case 0x00: cs->town_effect = TE_PASSENGERS; break;
-					case 0x02: cs->town_effect = TE_MAIL; break;
-					case 0x05: cs->town_effect = TE_GOODS; break;
-					case 0x09: cs->town_effect = TE_WATER; break;
-					case 0x0B: cs->town_effect = TE_FOOD; break;
+					case 0x00: cs->town_acceptance_effect = TAE_PASSENGERS; break;
+					case 0x02: cs->town_acceptance_effect = TAE_MAIL; break;
+					case 0x05: cs->town_acceptance_effect = TAE_GOODS; break;
+					case 0x09: cs->town_acceptance_effect = TAE_WATER; break;
+					case 0x0B: cs->town_acceptance_effect = TAE_FOOD; break;
 					default:
 						GrfMsg(1, "CargoChangeInfo: Unknown town growth substitute value {}, setting to none.", substitute_type);
 						FALLTHROUGH;
-					case 0xFF: cs->town_effect = TE_NONE; break;
+					case 0xFF: cs->town_acceptance_effect = TAE_NONE; break;
 				}
 				break;
 			}

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -9186,6 +9186,14 @@ static void FinaliseEngineArray()
 void FinaliseCargoArray()
 {
 	for (CargoSpec &cs : CargoSpec::array) {
+		if (cs.town_production_effect == INVALID_TPE) {
+			/* Set default town production effect by cargo label. */
+			switch (cs.label) {
+				case 'PASS': cs.town_production_effect = TPE_PASSENGERS; break;
+				case 'MAIL': cs.town_production_effect = TPE_MAIL; break;
+				default:     cs.town_production_effect = TPE_NONE; break;
+			}
+		}
 		if (!cs.IsValid()) {
 			cs.name = cs.name_single = cs.units_volume = STR_NEWGRF_INVALID_CARGO;
 			cs.quantifier = STR_NEWGRF_INVALID_CARGO_QUANTITY;

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -99,14 +99,14 @@
 		case 0xC9: return GB(ClampTo<uint16_t>(this->t->supplied[CT_MAIL].old_act), 8, 8);
 		case 0xCA: return this->t->GetPercentTransported(CT_PASSENGERS);
 		case 0xCB: return this->t->GetPercentTransported(CT_MAIL);
-		case 0xCC: return this->t->received[TE_FOOD].new_act;
-		case 0xCD: return GB(this->t->received[TE_FOOD].new_act, 8, 8);
-		case 0xCE: return this->t->received[TE_WATER].new_act;
-		case 0xCF: return GB(this->t->received[TE_WATER].new_act, 8, 8);
-		case 0xD0: return this->t->received[TE_FOOD].old_act;
-		case 0xD1: return GB(this->t->received[TE_FOOD].old_act, 8, 8);
-		case 0xD2: return this->t->received[TE_WATER].old_act;
-		case 0xD3: return GB(this->t->received[TE_WATER].old_act, 8, 8);
+		case 0xCC: return this->t->received[TAE_FOOD].new_act;
+		case 0xCD: return GB(this->t->received[TAE_FOOD].new_act, 8, 8);
+		case 0xCE: return this->t->received[TAE_WATER].new_act;
+		case 0xCF: return GB(this->t->received[TAE_WATER].new_act, 8, 8);
+		case 0xD0: return this->t->received[TAE_FOOD].old_act;
+		case 0xD1: return GB(this->t->received[TAE_FOOD].old_act, 8, 8);
+		case 0xD2: return this->t->received[TAE_WATER].old_act;
+		case 0xD3: return GB(this->t->received[TAE_WATER].old_act, 8, 8);
 		case 0xD4: return this->t->road_build_months;
 		case 0xD5: return this->t->fund_buildings_months;
 	}

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2225,15 +2225,15 @@ bool AfterLoadGame()
 				s->remaining = 12 - s->remaining; // convert "age" to "remaining"
 				s->awarded = INVALID_COMPANY; // not awarded to anyone
 				const CargoSpec *cs = CargoSpec::Get(s->cargo_type);
-				switch (cs->town_effect) {
-					case TE_PASSENGERS:
-					case TE_MAIL:
+				switch (cs->town_acceptance_effect) {
+					case TAE_PASSENGERS:
+					case TAE_MAIL:
 						/* Town -> Town */
 						s->src_type = s->dst_type = SourceType::Town;
 						if (Town::IsValidID(s->src) && Town::IsValidID(s->dst)) continue;
 						break;
-					case TE_GOODS:
-					case TE_FOOD:
+					case TAE_GOODS:
+					case TAE_FOOD:
 						/* Industry -> Town */
 						s->src_type = SourceType::Industry;
 						s->dst_type = SourceType::Town;
@@ -2251,9 +2251,9 @@ bool AfterLoadGame()
 				 * Town -> Town subsidies are converted using simple heuristic */
 				s->remaining = 24 - s->remaining; // convert "age of awarded subsidy" to "remaining"
 				const CargoSpec *cs = CargoSpec::Get(s->cargo_type);
-				switch (cs->town_effect) {
-					case TE_PASSENGERS:
-					case TE_MAIL: {
+				switch (cs->town_acceptance_effect) {
+					case TAE_PASSENGERS:
+					case TAE_MAIL: {
 						/* Town -> Town */
 						const Station *ss = Station::GetIfValid(s->src);
 						const Station *sd = Station::GetIfValid(s->dst);
@@ -2813,12 +2813,12 @@ bool AfterLoadGame()
 			/* Set the default cargo requirement for town growth */
 			switch (_settings_game.game_creation.landscape) {
 				case LT_ARCTIC:
-					if (FindFirstCargoWithTownEffect(TE_FOOD) != nullptr) t->goal[TE_FOOD] = TOWN_GROWTH_WINTER;
+					if (FindFirstCargoWithTownAcceptanceEffect(TAE_FOOD) != nullptr) t->goal[TAE_FOOD] = TOWN_GROWTH_WINTER;
 					break;
 
 				case LT_TROPIC:
-					if (FindFirstCargoWithTownEffect(TE_FOOD) != nullptr) t->goal[TE_FOOD] = TOWN_GROWTH_DESERT;
-					if (FindFirstCargoWithTownEffect(TE_WATER) != nullptr) t->goal[TE_WATER] = TOWN_GROWTH_DESERT;
+					if (FindFirstCargoWithTownAcceptanceEffect(TAE_FOOD) != nullptr) t->goal[TAE_FOOD] = TOWN_GROWTH_DESERT;
+					if (FindFirstCargoWithTownAcceptanceEffect(TAE_WATER) != nullptr) t->goal[TAE_WATER] = TOWN_GROWTH_DESERT;
 					break;
 			}
 		}

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -601,10 +601,10 @@ static const OldChunks town_chunk[] = {
 
 	OCL_NULL( 2 ),         ///< pct_pass_transported / pct_mail_transported, now computed on the fly
 
-	OCL_SVAR( OC_TTD | OC_UINT16, Town, received[TE_FOOD].new_act ),
-	OCL_SVAR( OC_TTD | OC_UINT16, Town, received[TE_WATER].new_act ),
-	OCL_SVAR( OC_TTD | OC_UINT16, Town, received[TE_FOOD].old_act ),
-	OCL_SVAR( OC_TTD | OC_UINT16, Town, received[TE_WATER].old_act ),
+	OCL_SVAR( OC_TTD | OC_UINT16, Town, received[TAE_FOOD].new_act ),
+	OCL_SVAR( OC_TTD | OC_UINT16, Town, received[TAE_WATER].new_act ),
+	OCL_SVAR( OC_TTD | OC_UINT16, Town, received[TAE_FOOD].old_act ),
+	OCL_SVAR( OC_TTD | OC_UINT16, Town, received[TAE_WATER].old_act ),
 
 	OCL_SVAR(  OC_UINT8, Town, road_build_months ),
 	OCL_SVAR(  OC_UINT8, Town, fund_buildings_months ),

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -174,7 +174,7 @@ public:
 
 	void Load(Town *t) const override
 	{
-		size_t length = IsSavegameVersionBefore(SLV_SAVELOAD_LIST_LENGTH) ? (size_t)TE_END : SlGetStructListLength(TE_END);
+		size_t length = IsSavegameVersionBefore(SLV_SAVELOAD_LIST_LENGTH) ? (size_t)TAE_END : SlGetStructListLength(TAE_END);
 		for (size_t i = 0; i < length; i++) {
 			SlObject(&t->received[i], this->GetLoadDescription());
 		}
@@ -239,12 +239,12 @@ static const SaveLoad _town_desc[] = {
 	SLE_CONDVAR(Town, supplied[CT_MAIL].new_act,       SLE_FILE_U16 | SLE_VAR_U32, SL_MIN_VERSION, SLV_9),
 	SLE_CONDVAR(Town, supplied[CT_MAIL].new_act,       SLE_UINT32,                 SLV_9, SLV_165),
 
-	SLE_CONDVAR(Town, received[TE_FOOD].old_act,       SLE_UINT16,                 SL_MIN_VERSION, SLV_165),
-	SLE_CONDVAR(Town, received[TE_WATER].old_act,      SLE_UINT16,                 SL_MIN_VERSION, SLV_165),
-	SLE_CONDVAR(Town, received[TE_FOOD].new_act,       SLE_UINT16,                 SL_MIN_VERSION, SLV_165),
-	SLE_CONDVAR(Town, received[TE_WATER].new_act,      SLE_UINT16,                 SL_MIN_VERSION, SLV_165),
+	SLE_CONDVARNAME(Town, received[TAE_FOOD].old_act,  "received[TE_FOOD].old_act",  SLE_UINT16,                 SL_MIN_VERSION, SLV_165),
+	SLE_CONDVARNAME(Town, received[TAE_WATER].old_act, "received[TE_WATER].old_act", SLE_UINT16,                 SL_MIN_VERSION, SLV_165),
+	SLE_CONDVARNAME(Town, received[TAE_FOOD].new_act,  "received[TE_FOOD].new_act",  SLE_UINT16,                 SL_MIN_VERSION, SLV_165),
+	SLE_CONDVARNAME(Town, received[TAE_WATER].new_act, "received[TE_WATER].new_act", SLE_UINT16,                 SL_MIN_VERSION, SLV_165),
 
-	SLE_CONDARR(Town, goal, SLE_UINT32, NUM_TE, SLV_165, SL_MAX_VERSION),
+	SLE_CONDARR(Town, goal, SLE_UINT32, NUM_TAE, SLV_165, SL_MAX_VERSION),
 
 	SLE_CONDSSTR(Town, text,                 SLE_STR | SLF_ALLOW_CONTROL, SLV_168, SL_MAX_VERSION),
 

--- a/src/script/api/script_cargo.cpp
+++ b/src/script/api/script_cargo.cpp
@@ -25,7 +25,7 @@
 
 /* static */ bool ScriptCargo::IsValidTownEffect(TownEffect towneffect_type)
 {
-	return (towneffect_type >= (TownEffect)TE_BEGIN && towneffect_type < (TownEffect)TE_END);
+	return (towneffect_type >= (TownEffect)TAE_BEGIN && towneffect_type < (TownEffect)TAE_END);
 }
 
 /* static */ std::optional<std::string> ScriptCargo::GetName(CargoID cargo_type)
@@ -67,7 +67,7 @@
 {
 	if (!IsValidCargo(cargo_type)) return TE_NONE;
 
-	return (ScriptCargo::TownEffect)::CargoSpec::Get(cargo_type)->town_effect;
+	return (ScriptCargo::TownEffect)::CargoSpec::Get(cargo_type)->town_acceptance_effect;
 }
 
 /* static */ Money ScriptCargo::GetCargoIncome(CargoID cargo_type, SQInteger distance, SQInteger days_in_transit)

--- a/src/script/api/script_cargo.hpp
+++ b/src/script/api/script_cargo.hpp
@@ -42,12 +42,12 @@ public:
 	 */
 	enum TownEffect {
 		/* Note: these values represent part of the in-game TownEffect enum */
-		TE_NONE       = ::TE_NONE,       ///< This cargo has no effect on a town
-		TE_PASSENGERS = ::TE_PASSENGERS, ///< This cargo supplies passengers to a town
-		TE_MAIL       = ::TE_MAIL,       ///< This cargo supplies mail to a town
-		TE_GOODS      = ::TE_GOODS,      ///< This cargo supplies goods to a town
-		TE_WATER      = ::TE_WATER,      ///< This cargo supplies water to a town
-		TE_FOOD       = ::TE_FOOD,       ///< This cargo supplies food to a town
+		TE_NONE       = ::TAE_NONE,       ///< This cargo has no effect on a town
+		TE_PASSENGERS = ::TAE_PASSENGERS, ///< This cargo supplies passengers to a town
+		TE_MAIL       = ::TAE_MAIL,       ///< This cargo supplies mail to a town
+		TE_GOODS      = ::TAE_GOODS,      ///< This cargo supplies goods to a town
+		TE_WATER      = ::TAE_WATER,      ///< This cargo supplies water to a town
+		TE_FOOD       = ::TAE_FOOD,       ///< This cargo supplies food to a town
 	};
 
 	/**

--- a/src/script/api/script_town.cpp
+++ b/src/script/api/script_town.cpp
@@ -133,7 +133,7 @@
 
 	goal = Clamp<SQInteger>(goal, 0, UINT32_MAX);
 
-	return ScriptObject::Command<CMD_TOWN_CARGO_GOAL>::Do(town_id, (::TownEffect)towneffect_id, goal);
+	return ScriptObject::Command<CMD_TOWN_CARGO_GOAL>::Do(town_id, (::TownAcceptanceEffect)towneffect_id, goal);
 }
 
 /* static */ SQInteger ScriptTown::GetCargoGoal(TownID town_id, ScriptCargo::TownEffect towneffect_id)

--- a/src/script/api/script_townlist.cpp
+++ b/src/script/api/script_townlist.cpp
@@ -20,7 +20,7 @@ ScriptTownList::ScriptTownList(HSQUIRRELVM vm)
 
 ScriptTownEffectList::ScriptTownEffectList()
 {
-	for (int i = TE_BEGIN; i < TE_END; i++) {
+	for (int i = TAE_BEGIN; i < TAE_END; i++) {
 		this->AddItem(i);
 	}
 }

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -286,9 +286,13 @@ bool FindSubsidyPassengerRoute()
 {
 	if (!Subsidy::CanAllocateItem()) return false;
 
+	/* Pick a random TPE_PASSENGER type */
+	uint32_t r = RandomRange(static_cast<uint>(CargoSpec::town_production_cargoes[TPE_PASSENGERS].size()));
+	CargoID cid = CargoSpec::town_production_cargoes[TPE_PASSENGERS][r]->Index();
+
 	const Town *src = Town::GetRandom();
 	if (src->cache.population < SUBSIDY_PAX_MIN_POPULATION ||
-			src->GetPercentTransported(CT_PASSENGERS) > SUBSIDY_MAX_PCT_TRANSPORTED) {
+			src->GetPercentTransported(cid) > SUBSIDY_MAX_PCT_TRANSPORTED) {
 		return false;
 	}
 
@@ -298,9 +302,9 @@ bool FindSubsidyPassengerRoute()
 	}
 
 	if (DistanceManhattan(src->xy, dst->xy) > SUBSIDY_MAX_DISTANCE) return false;
-	if (CheckSubsidyDuplicate(CT_PASSENGERS, SourceType::Town, src->index, SourceType::Town, dst->index)) return false;
+	if (CheckSubsidyDuplicate(cid, SourceType::Town, src->index, SourceType::Town, dst->index)) return false;
 
-	CreateSubsidy(CT_PASSENGERS, SourceType::Town, src->index, SourceType::Town, dst->index);
+	CreateSubsidy(cid, SourceType::Town, src->index, SourceType::Town, dst->index);
 
 	return true;
 }
@@ -332,7 +336,9 @@ bool FindSubsidyTownCargoRoute()
 	}
 
 	/* Passenger subsidies are not handled here. */
-	town_cargo_produced[CT_PASSENGERS] = 0;
+	for (const CargoSpec *cs : CargoSpec::town_production_cargoes[TPE_PASSENGERS]) {
+		town_cargo_produced[cs->Index()] = 0;
+	}
 
 	uint8_t cargo_count = town_cargo_produced.GetCount();
 

--- a/src/table/cargo_const.h
+++ b/src/table/cargo_const.h
@@ -36,62 +36,62 @@
  * @param td1          CargoSpec->transit_periods[0].
  * @param td2          CargoSpec->transit_periods[1].
  * @param freight      Cargo type is considered to be freight (affects train freight multiplier).
- * @param te           The effect that delivering this cargo type has on towns. Also affects destination of subsidies.
+ * @param tae          The effect that delivering this cargo type has on towns.
  * @param str_plural   The name suffix used to populate CargoSpec->name, CargoSpec->quantifier,
  *                     CargoSpec->abbrev and CargoSpec->sprite. See above for more detailed information.
  * @param str_singular The name suffix used to populate CargoSpec->name_single. See above for more information.
  * @param str_volume   Name of a single unit of cargo of this type.
  * @param classes      Classes of this cargo type. @see CargoClass
  */
-#define MK(bt, label, colour, weight, mult, ip, td1, td2, freight, te, str_plural, str_singular, str_volume, classes) \
-		{label, bt, colour, colour, weight, mult, classes, ip, {td1, td2}, freight, te, 0, \
+#define MK(bt, label, colour, weight, mult, ip, td1, td2, freight, tae, str_plural, str_singular, str_volume, classes) \
+		{label, bt, colour, colour, weight, mult, classes, ip, {td1, td2}, freight, tae, 0, \
 		MK_STR_CARGO_PLURAL(str_plural), MK_STR_CARGO_SINGULAR(str_singular), str_volume, MK_STR_QUANTITY(str_plural), MK_STR_ABBREV(str_plural), \
 		MK_SPRITE(str_plural), nullptr, nullptr, 0}
 
 /** Cargo types available by default. */
 static const CargoSpec _default_cargo[] = {
-	MK(   0, 'PASS', 152,  1, 0x400, 3185,  0,  24, false, TE_PASSENGERS,   PASSENGERS,    PASSENGER, STR_PASSENGERS, CC_PASSENGERS),
-	MK(   1, 'COAL',   6, 16, 0x100, 5916,  7, 255,  true,       TE_NONE,         COAL,         COAL,       STR_TONS, CC_BULK),
-	MK(   2, 'MAIL',  15,  4, 0x200, 4550, 20,  90, false,       TE_MAIL,         MAIL,         MAIL,       STR_BAGS, CC_MAIL),
+	MK(   0, 'PASS', 152,  1, 0x400, 3185,  0,  24, false, TAE_PASSENGERS,   PASSENGERS,    PASSENGER, STR_PASSENGERS, CC_PASSENGERS),
+	MK(   1, 'COAL',   6, 16, 0x100, 5916,  7, 255,  true,       TAE_NONE,         COAL,         COAL,       STR_TONS, CC_BULK),
+	MK(   2, 'MAIL',  15,  4, 0x200, 4550, 20,  90, false,       TAE_MAIL,         MAIL,         MAIL,       STR_BAGS, CC_MAIL),
 	/* Oil in temperate and arctic */
-	MK(   3, 'OIL_', 174, 16, 0x100, 4437, 25, 255,  true,       TE_NONE,          OIL,          OIL,     STR_LITERS, CC_LIQUID),
+	MK(   3, 'OIL_', 174, 16, 0x100, 4437, 25, 255,  true,       TAE_NONE,          OIL,          OIL,     STR_LITERS, CC_LIQUID),
 	/* Oil in subtropic */
-	MK(   3, 'OIL_', 174, 16, 0x100, 4892, 25, 255,  true,       TE_NONE,          OIL,          OIL,     STR_LITERS, CC_LIQUID),
-	MK(   4, 'LVST', 208,  3, 0x100, 4322,  4,  18,  true,       TE_NONE,    LIVESTOCK,    LIVESTOCK,      STR_ITEMS, CC_PIECE_GOODS),
-	MK(   5, 'GOOD', 194,  8, 0x200, 6144,  5,  28,  true,      TE_GOODS,        GOODS,        GOODS,     STR_CRATES, CC_EXPRESS),
-	MK(   6, 'GRAI', 191, 16, 0x100, 4778,  4,  40,  true,       TE_NONE,        GRAIN,        GRAIN,       STR_TONS, CC_BULK),
-	MK(   6, 'WHEA', 191, 16, 0x100, 4778,  4,  40,  true,       TE_NONE,        WHEAT,        WHEAT,       STR_TONS, CC_BULK),
-	MK(   6, 'MAIZ', 191, 16, 0x100, 4322,  4,  40,  true,       TE_NONE,        MAIZE,        MAIZE,       STR_TONS, CC_BULK),
+	MK(   3, 'OIL_', 174, 16, 0x100, 4892, 25, 255,  true,       TAE_NONE,          OIL,          OIL,     STR_LITERS, CC_LIQUID),
+	MK(   4, 'LVST', 208,  3, 0x100, 4322,  4,  18,  true,       TAE_NONE,    LIVESTOCK,    LIVESTOCK,      STR_ITEMS, CC_PIECE_GOODS),
+	MK(   5, 'GOOD', 194,  8, 0x200, 6144,  5,  28,  true,      TAE_GOODS,        GOODS,        GOODS,     STR_CRATES, CC_EXPRESS),
+	MK(   6, 'GRAI', 191, 16, 0x100, 4778,  4,  40,  true,       TAE_NONE,        GRAIN,        GRAIN,       STR_TONS, CC_BULK),
+	MK(   6, 'WHEA', 191, 16, 0x100, 4778,  4,  40,  true,       TAE_NONE,        WHEAT,        WHEAT,       STR_TONS, CC_BULK),
+	MK(   6, 'MAIZ', 191, 16, 0x100, 4322,  4,  40,  true,       TAE_NONE,        MAIZE,        MAIZE,       STR_TONS, CC_BULK),
 	/* Wood in temperate and arctic */
-	MK(   7, 'WOOD',  84, 16, 0x100, 5005, 15, 255,  true,       TE_NONE,         WOOD,         WOOD,       STR_TONS, CC_PIECE_GOODS),
+	MK(   7, 'WOOD',  84, 16, 0x100, 5005, 15, 255,  true,       TAE_NONE,         WOOD,         WOOD,       STR_TONS, CC_PIECE_GOODS),
 	/* Wood in subtropic */
-	MK(   7, 'WOOD',  84, 16, 0x100, 7964, 15, 255,  true,       TE_NONE,         WOOD,         WOOD,       STR_TONS, CC_PIECE_GOODS),
-	MK(   8, 'IORE', 184, 16, 0x100, 5120,  9, 255,  true,       TE_NONE,     IRON_ORE,     IRON_ORE,       STR_TONS, CC_BULK),
-	MK(   9, 'STEL',  10, 16, 0x100, 5688,  7, 255,  true,       TE_NONE,        STEEL,        STEEL,       STR_TONS, CC_PIECE_GOODS),
-	MK(  10, 'VALU', 202,  2, 0x100, 7509,  1,  32,  true,       TE_NONE,    VALUABLES,    VALUABLES,       STR_BAGS, CC_ARMOURED),
-	MK(  10, 'GOLD', 202,  8, 0x100, 5802, 10,  40,  true,       TE_NONE,         GOLD,         GOLD,       STR_BAGS, CC_ARMOURED),
-	MK(  10, 'DIAM', 202,  2, 0x100, 5802, 10, 255,  true,       TE_NONE,     DIAMONDS,      DIAMOND,       STR_BAGS, CC_ARMOURED),
-	MK(  11, 'PAPR',  10, 16, 0x100, 5461,  7,  60,  true,       TE_NONE,        PAPER,        PAPER,       STR_TONS, CC_PIECE_GOODS),
-	MK(  12, 'FOOD',  48, 16, 0x100, 5688,  0,  30,  true,       TE_FOOD,         FOOD,         FOOD,       STR_TONS, CC_EXPRESS | CC_REFRIGERATED),
-	MK(  13, 'FRUT', 208, 16, 0x100, 4209,  0,  15,  true,       TE_NONE,        FRUIT,        FRUIT,       STR_TONS, CC_BULK | CC_REFRIGERATED),
-	MK(  14, 'CORE', 184, 16, 0x100, 4892, 12, 255,  true,       TE_NONE,   COPPER_ORE,   COPPER_ORE,       STR_TONS, CC_BULK),
-	MK(  15, 'WATR',  10, 16, 0x100, 4664, 20,  80,  true,      TE_WATER,        WATER,        WATER,     STR_LITERS, CC_LIQUID),
-	MK(  16, 'RUBR',   6, 16, 0x100, 4437,  2,  20,  true,       TE_NONE,       RUBBER,       RUBBER,     STR_LITERS, CC_LIQUID),
-	MK(  17, 'SUGR',   6, 16, 0x100, 4437, 20, 255,  true,       TE_NONE,        SUGAR,        SUGAR,       STR_TONS, CC_BULK),
-	MK(  18, 'TOYS', 174,  2, 0x100, 5574, 25, 255,  true,       TE_NONE,         TOYS,          TOY,      STR_ITEMS, CC_PIECE_GOODS),
-	MK(  19, 'BATT', 208,  4, 0x100, 4322,  2,  30,  true,       TE_NONE,    BATTERIES,      BATTERY,      STR_ITEMS, CC_PIECE_GOODS),
-	MK(  20, 'SWET', 194,  5, 0x200, 6144,  8,  40,  true,      TE_GOODS,       SWEETS,       SWEETS,       STR_BAGS, CC_EXPRESS),
-	MK(  21, 'TOFF', 191, 16, 0x100, 4778, 14,  60,  true,       TE_NONE,       TOFFEE,       TOFFEE,       STR_TONS, CC_BULK),
-	MK(  22, 'COLA',  84, 16, 0x100, 4892,  5,  75,  true,       TE_NONE,         COLA,         COLA,     STR_LITERS, CC_LIQUID),
-	MK(  23, 'CTCD', 184, 16, 0x100, 5005, 10,  25,  true,       TE_NONE,   CANDYFLOSS,   CANDYFLOSS,       STR_TONS, CC_BULK),
-	MK(  24, 'BUBL',  10,  1, 0x100, 5077, 20,  80,  true,       TE_NONE,      BUBBLES,       BUBBLE,      STR_ITEMS, CC_PIECE_GOODS),
-	MK(  25, 'PLST', 202, 16, 0x100, 4664, 30, 255,  true,       TE_NONE,      PLASTIC,      PLASTIC,     STR_LITERS, CC_LIQUID),
-	MK(  26, 'FZDR',  48,  2, 0x100, 6250, 30,  50,  true,       TE_FOOD, FIZZY_DRINKS,  FIZZY_DRINK,      STR_ITEMS, CC_PIECE_GOODS),
+	MK(   7, 'WOOD',  84, 16, 0x100, 7964, 15, 255,  true,       TAE_NONE,         WOOD,         WOOD,       STR_TONS, CC_PIECE_GOODS),
+	MK(   8, 'IORE', 184, 16, 0x100, 5120,  9, 255,  true,       TAE_NONE,     IRON_ORE,     IRON_ORE,       STR_TONS, CC_BULK),
+	MK(   9, 'STEL',  10, 16, 0x100, 5688,  7, 255,  true,       TAE_NONE,        STEEL,        STEEL,       STR_TONS, CC_PIECE_GOODS),
+	MK(  10, 'VALU', 202,  2, 0x100, 7509,  1,  32,  true,       TAE_NONE,    VALUABLES,    VALUABLES,       STR_BAGS, CC_ARMOURED),
+	MK(  10, 'GOLD', 202,  8, 0x100, 5802, 10,  40,  true,       TAE_NONE,         GOLD,         GOLD,       STR_BAGS, CC_ARMOURED),
+	MK(  10, 'DIAM', 202,  2, 0x100, 5802, 10, 255,  true,       TAE_NONE,     DIAMONDS,      DIAMOND,       STR_BAGS, CC_ARMOURED),
+	MK(  11, 'PAPR',  10, 16, 0x100, 5461,  7,  60,  true,       TAE_NONE,        PAPER,        PAPER,       STR_TONS, CC_PIECE_GOODS),
+	MK(  12, 'FOOD',  48, 16, 0x100, 5688,  0,  30,  true,       TAE_FOOD,         FOOD,         FOOD,       STR_TONS, CC_EXPRESS | CC_REFRIGERATED),
+	MK(  13, 'FRUT', 208, 16, 0x100, 4209,  0,  15,  true,       TAE_NONE,        FRUIT,        FRUIT,       STR_TONS, CC_BULK | CC_REFRIGERATED),
+	MK(  14, 'CORE', 184, 16, 0x100, 4892, 12, 255,  true,       TAE_NONE,   COPPER_ORE,   COPPER_ORE,       STR_TONS, CC_BULK),
+	MK(  15, 'WATR',  10, 16, 0x100, 4664, 20,  80,  true,      TAE_WATER,        WATER,        WATER,     STR_LITERS, CC_LIQUID),
+	MK(  16, 'RUBR',   6, 16, 0x100, 4437,  2,  20,  true,       TAE_NONE,       RUBBER,       RUBBER,     STR_LITERS, CC_LIQUID),
+	MK(  17, 'SUGR',   6, 16, 0x100, 4437, 20, 255,  true,       TAE_NONE,        SUGAR,        SUGAR,       STR_TONS, CC_BULK),
+	MK(  18, 'TOYS', 174,  2, 0x100, 5574, 25, 255,  true,       TAE_NONE,         TOYS,          TOY,      STR_ITEMS, CC_PIECE_GOODS),
+	MK(  19, 'BATT', 208,  4, 0x100, 4322,  2,  30,  true,       TAE_NONE,    BATTERIES,      BATTERY,      STR_ITEMS, CC_PIECE_GOODS),
+	MK(  20, 'SWET', 194,  5, 0x200, 6144,  8,  40,  true,      TAE_GOODS,       SWEETS,       SWEETS,       STR_BAGS, CC_EXPRESS),
+	MK(  21, 'TOFF', 191, 16, 0x100, 4778, 14,  60,  true,       TAE_NONE,       TOFFEE,       TOFFEE,       STR_TONS, CC_BULK),
+	MK(  22, 'COLA',  84, 16, 0x100, 4892,  5,  75,  true,       TAE_NONE,         COLA,         COLA,     STR_LITERS, CC_LIQUID),
+	MK(  23, 'CTCD', 184, 16, 0x100, 5005, 10,  25,  true,       TAE_NONE,   CANDYFLOSS,   CANDYFLOSS,       STR_TONS, CC_BULK),
+	MK(  24, 'BUBL',  10,  1, 0x100, 5077, 20,  80,  true,       TAE_NONE,      BUBBLES,       BUBBLE,      STR_ITEMS, CC_PIECE_GOODS),
+	MK(  25, 'PLST', 202, 16, 0x100, 4664, 30, 255,  true,       TAE_NONE,      PLASTIC,      PLASTIC,     STR_LITERS, CC_LIQUID),
+	MK(  26, 'FZDR',  48,  2, 0x100, 6250, 30,  50,  true,       TAE_FOOD, FIZZY_DRINKS,  FIZZY_DRINK,      STR_ITEMS, CC_PIECE_GOODS),
 
 	/* Void slot in temperate */
-	MK(0xFF,      0,   1,  0, 0x100, 5688,  0,  30,  true,       TE_NONE,      NOTHING,      NOTHING,       STR_TONS, CC_NOAVAILABLE),
+	MK(0xFF,      0,   1,  0, 0x100, 5688,  0,  30,  true,       TAE_NONE,      NOTHING,      NOTHING,       STR_TONS, CC_NOAVAILABLE),
 	/* Void slot in arctic */
-	MK(0xFF,      0, 184,  0, 0x100, 5120,  9, 255,  true,       TE_NONE,      NOTHING,      NOTHING,       STR_TONS, CC_NOAVAILABLE),
+	MK(0xFF,      0, 184,  0, 0x100, 5120,  9, 255,  true,       TAE_NONE,      NOTHING,      NOTHING,       STR_TONS, CC_NOAVAILABLE),
 };
 
 

--- a/src/table/cargo_const.h
+++ b/src/table/cargo_const.h
@@ -44,7 +44,7 @@
  * @param classes      Classes of this cargo type. @see CargoClass
  */
 #define MK(bt, label, colour, weight, mult, ip, td1, td2, freight, tae, str_plural, str_singular, str_volume, classes) \
-		{label, bt, colour, colour, weight, mult, classes, ip, {td1, td2}, freight, tae, 0, \
+		{label, bt, colour, colour, weight, mult, classes, ip, {td1, td2}, freight, tae, INVALID_TPE, 0, \
 		MK_STR_CARGO_PLURAL(str_plural), MK_STR_CARGO_SINGULAR(str_singular), str_volume, MK_STR_QUANTITY(str_plural), MK_STR_ABBREV(str_plural), \
 		MK_SPRITE(str_plural), nullptr, nullptr, 0}
 

--- a/src/town.h
+++ b/src/town.h
@@ -73,8 +73,8 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 	int16_t ratings[MAX_COMPANIES];  ///< ratings of each company for this town
 
 	TransportedCargoStat<uint32_t> supplied[NUM_CARGO]; ///< Cargo statistics about supplied cargo.
-	TransportedCargoStat<uint16_t> received[NUM_TE];    ///< Cargo statistics about received cargotypes.
-	uint32_t goal[NUM_TE];                              ///< Amount of cargo required for the town to grow.
+	TransportedCargoStat<uint16_t> received[NUM_TAE]; ///< Cargo statistics about received cargotypes.
+	uint32_t goal[NUM_TAE]; ///< Amount of cargo required for the town to grow.
 
 	std::string text; ///< General text with additional information.
 
@@ -232,7 +232,7 @@ HouseZonesBits GetTownRadiusGroup(const Town *t, TileIndex tile);
 void SetTownRatingTestMode(bool mode);
 TownActions GetMaskOfTownActions(CompanyID cid, const Town *t);
 bool GenerateTowns(TownLayout layout);
-const CargoSpec *FindFirstCargoWithTownEffect(TownEffect effect);
+const CargoSpec *FindFirstCargoWithTownAcceptanceEffect(TownAcceptanceEffect effect);
 
 extern const byte _town_action_costs[TACT_COUNT];
 

--- a/src/town_cmd.h
+++ b/src/town_cmd.h
@@ -14,14 +14,14 @@
 #include "company_type.h"
 #include "town_type.h"
 
-enum TownEffect : byte;
+enum TownAcceptanceEffect : byte;
 
 std::tuple<CommandCost, Money, TownID> CmdFoundTown(DoCommandFlag flags, TileIndex tile, TownSize size, bool city, TownLayout layout, bool random_location, uint32_t townnameparts, const std::string &text);
 CommandCost CmdRenameTown(DoCommandFlag flags, TownID town_id, const std::string &text);
 CommandCost CmdDoTownAction(DoCommandFlag flags, TownID town_id, uint8_t action);
 CommandCost CmdTownGrowthRate(DoCommandFlag flags, TownID town_id, uint16_t growth_rate);
 CommandCost CmdTownRating(DoCommandFlag flags, TownID town_id, CompanyID company_id, int16_t rating);
-CommandCost CmdTownCargoGoal(DoCommandFlag flags, TownID town_id, TownEffect te, uint32_t goal);
+CommandCost CmdTownCargoGoal(DoCommandFlag flags, TownID town_id, TownAcceptanceEffect tae, uint32_t goal);
 CommandCost CmdTownSetText(DoCommandFlag flags, TownID town_id, const std::string &text);
 CommandCost CmdExpandTown(DoCommandFlag flags, TownID town_id, uint32_t grow_amount);
 CommandCost CmdDeleteTown(DoCommandFlag flags, TownID town_id);

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -421,7 +421,7 @@ public:
 		tr.top += GetCharacterHeight(FS_NORMAL);
 
 		bool first = true;
-		for (int i = TE_BEGIN; i < TE_END; i++) {
+		for (int i = TAE_BEGIN; i < TAE_END; i++) {
 			if (this->town->goal[i] == 0) continue;
 			if (this->town->goal[i] == TOWN_GROWTH_WINTER && (TileHeight(this->town->xy) < LowestSnowLine() || this->town->cache.population <= 90)) continue;
 			if (this->town->goal[i] == TOWN_GROWTH_DESERT && (GetTropicZone(this->town->xy) != TROPICZONE_DESERT || this->town->cache.population <= 60)) continue;
@@ -434,7 +434,7 @@ public:
 
 			bool rtl = _current_text_dir == TD_RTL;
 
-			const CargoSpec *cargo = FindFirstCargoWithTownEffect((TownEffect)i);
+			const CargoSpec *cargo = FindFirstCargoWithTownAcceptanceEffect((TownAcceptanceEffect)i);
 			assert(cargo != nullptr);
 
 			StringID string;
@@ -542,7 +542,7 @@ public:
 		uint aimed_height = 3 * GetCharacterHeight(FS_NORMAL);
 
 		bool first = true;
-		for (int i = TE_BEGIN; i < TE_END; i++) {
+		for (int i = TAE_BEGIN; i < TAE_END; i++) {
 			if (this->town->goal[i] == 0) continue;
 			if (this->town->goal[i] == TOWN_GROWTH_WINTER && (TileHeight(this->town->xy) < LowestSnowLine() || this->town->cache.population <= 90)) continue;
 			if (this->town->goal[i] == TOWN_GROWTH_DESERT && (GetTropicZone(this->town->xy) != TROPICZONE_DESERT || this->town->cache.population <= 60)) continue;

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -408,17 +408,17 @@ public:
 		tr.top += GetCharacterHeight(FS_NORMAL);
 
 		StringID str_last_period = TimerGameEconomy::UsingWallclockUnits() ? STR_TOWN_VIEW_CARGO_LAST_MINUTE_MAX : STR_TOWN_VIEW_CARGO_LAST_MONTH_MAX;
-		SetDParam(0, 1 << CT_PASSENGERS);
-		SetDParam(1, this->town->supplied[CT_PASSENGERS].old_act);
-		SetDParam(2, this->town->supplied[CT_PASSENGERS].old_max);
-		DrawString(tr, str_last_period);
-		tr.top += GetCharacterHeight(FS_NORMAL);
 
-		SetDParam(0, 1 << CT_MAIL);
-		SetDParam(1, this->town->supplied[CT_MAIL].old_act);
-		SetDParam(2, this->town->supplied[CT_MAIL].old_max);
-		DrawString(tr, str_last_period);
-		tr.top += GetCharacterHeight(FS_NORMAL);
+		for (auto tpe : {TPE_PASSENGERS, TPE_MAIL}) {
+			for (const CargoSpec *cs : CargoSpec::town_production_cargoes[tpe]) {
+				CargoID cid = cs->Index();
+				SetDParam(0, 1ULL << cid);
+				SetDParam(1, this->town->supplied[cid].old_act);
+				SetDParam(2, this->town->supplied[cid].old_max);
+				DrawString(tr, str_last_period);
+				tr.top += GetCharacterHeight(FS_NORMAL);
+			}
+		}
 
 		bool first = true;
 		for (int i = TAE_BEGIN; i < TAE_END; i++) {
@@ -539,7 +539,7 @@ public:
 	 */
 	uint GetDesiredInfoHeight(int width) const
 	{
-		uint aimed_height = 3 * GetCharacterHeight(FS_NORMAL);
+		uint aimed_height = static_cast<uint>(1 + CargoSpec::town_production_cargoes[TPE_PASSENGERS].size() + CargoSpec::town_production_cargoes[TPE_MAIL].size()) * GetCharacterHeight(FS_NORMAL);
 
 		bool first = true;
 		for (int i = TAE_BEGIN; i < TAE_END; i++) {


### PR DESCRIPTION
## Motivation / Problem

Towns are hardcoded to produce CT_PASSENGERS and CT_MAIL. If those cargo types are not available, weird things happen.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This change adds a Town Production Effect property that tells a town to produce a cargo as if it were passengers or mail. No adjustment is made in case of multiple candidate cargos, you will just get higher production.

This is distinct from Town Acceptance Effect (nee Town Effect) which controls what happens to cargo received by a town. This separating is necessary to not break existing NewGRFs, and to allow flexibility.

This is also applied for generating passenger subsidies, although instead of creating more subsidies, that simply picks one at random.

This means the game no longer particularly cares about CT_PASSENGERS or CT_MAIL and goes with the town production effect.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

The NewGRF variables for town production still deal only with CT_PASSENGERS/CT_MAIL, apparently these are meant to be avoided anyway.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
