### PR TITLE
Codechange: Hide widgets with zero-width current_x instead of separate array.

### DIFF
--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -161,24 +161,6 @@ public:
 			}
 		}
 	}
-
-	void Draw(const Window *w) override
-	{
-		for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
-			child_wid->Draw(w);
-		}
-	}
-
-	NWidgetCore *GetWidgetFromPos(int x, int y) override
-	{
-		if (!IsInsideBS(x, this->pos_x, this->current_x) || !IsInsideBS(y, this->pos_y, this->current_y)) return nullptr;
-
-		for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
-			NWidgetCore *nwid = child_wid->GetWidgetFromPos(x, y);
-			if (nwid != nullptr) return nwid;
-		}
-		return nullptr;
-	}
 };
 
 class NetworkGameWindow : public Window {

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -1763,21 +1763,6 @@ public:
 		display->AssignSizePosition(ST_RESIZE, x, y, given_width, display_height, rtl);
 		bar->AssignSizePosition(ST_RESIZE, x, y + display_height, given_width, bar_height, rtl);
 	}
-
-	NWidgetCore *GetWidgetFromPos(int x, int y) override
-	{
-		if (!IsInsideBS(x, this->pos_x, this->current_x) || !IsInsideBS(y, this->pos_y, this->current_y)) return nullptr;
-		for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
-			NWidgetCore *widget = child_wid->GetWidgetFromPos(x, y);
-			if (widget != nullptr) return widget;
-		}
-		return nullptr;
-	}
-
-	void Draw(const Window *w) override
-	{
-		for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) child_wid->Draw(w);
-	}
 };
 
 /** Widget parts of the smallmap display. */

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -1477,21 +1477,7 @@ public:
 		GfxFillRect(this->pos_x, this->pos_y, this->pos_x + this->current_x - 1, this->pos_y + this->current_y - 1, PC_VERY_DARK_RED);
 		GfxFillRect(this->pos_x, this->pos_y, this->pos_x + this->current_x - 1, this->pos_y + this->current_y - 1, PC_DARK_RED, FILLRECT_CHECKER);
 
-		bool rtl = _current_text_dir == TD_RTL;
-		for (NWidgetBase *child_wid = rtl ? this->tail : this->head; child_wid != nullptr; child_wid = rtl ? child_wid->prev : child_wid->next) {
-			child_wid->Draw(w);
-		}
-	}
-
-	NWidgetCore *GetWidgetFromPos(int x, int y) override
-	{
-		if (!IsInsideBS(x, this->pos_x, this->current_x) || !IsInsideBS(y, this->pos_y, this->current_y)) return nullptr;
-
-		for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
-			NWidgetCore *nwid = child_wid->GetWidgetFromPos(x, y);
-			if (nwid != nullptr) return nwid;
-		}
-		return nullptr;
+		this->NWidgetContainer::Draw(w);
 	}
 
 	/**

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -1358,7 +1358,6 @@ static MenuClickedProc * const _menu_clicked_procs[] = {
 
 /** Full blown container to make it behave exactly as we want :) */
 class NWidgetToolbarContainer : public NWidgetContainer {
-	bool visible[WID_TN_END]; ///< The visible headers
 protected:
 	uint spacers;          ///< Number of spacer widgets in this toolbar
 
@@ -1420,16 +1419,13 @@ public:
 		this->current_y = given_height;
 
 		/* Figure out what are the visible buttons */
-		memset(this->visible, 0, sizeof(this->visible));
 		uint arrangable_count, button_count, spacer_count;
 		const byte *arrangement = GetButtonArrangement(given_width, arrangable_count, button_count, spacer_count);
-		for (uint i = 0; i < arrangable_count; i++) {
-			this->visible[arrangement[i]] = true;
-		}
 
 		/* Create us ourselves a quick lookup table */
 		NWidgetBase *widgets[WID_TN_END];
 		for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
+			child_wid->current_x = 0; /* Hide widget, it will be revealed in the next step. */
 			if (child_wid->type == NWID_SPACER) continue;
 			widgets[((NWidgetCore*)child_wid)->index] = child_wid;
 		}
@@ -1461,6 +1457,8 @@ public:
 				child_wid->current_x = button_space / (button_count - button_i);
 				button_space -= child_wid->current_x;
 				button_i++;
+			} else {
+				child_wid->current_x = child_wid->smallest_x;
 			}
 			child_wid->AssignSizePosition(sizing, x + position, y, child_wid->current_x, this->current_y, rtl);
 			position += child_wid->current_x;
@@ -1481,9 +1479,6 @@ public:
 
 		bool rtl = _current_text_dir == TD_RTL;
 		for (NWidgetBase *child_wid = rtl ? this->tail : this->head; child_wid != nullptr; child_wid = rtl ? child_wid->prev : child_wid->next) {
-			if (child_wid->type == NWID_SPACER) continue;
-			if (!this->visible[((NWidgetCore*)child_wid)->index]) continue;
-
 			child_wid->Draw(w);
 		}
 	}
@@ -1493,9 +1488,6 @@ public:
 		if (!IsInsideBS(x, this->pos_x, this->current_x) || !IsInsideBS(y, this->pos_y, this->current_y)) return nullptr;
 
 		for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
-			if (child_wid->type == NWID_SPACER) continue;
-			if (!this->visible[((NWidgetCore*)child_wid)->index]) continue;
-
 			NWidgetCore *nwid = child_wid->GetWidgetFromPos(x, y);
 			if (nwid != nullptr) return nwid;
 		}

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1303,6 +1303,24 @@ void NWidgetContainer::FillNestedArray(NWidgetBase **array, uint length)
 	}
 }
 
+void NWidgetContainer::Draw(const Window *w)
+{
+	for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
+		child_wid->Draw(w);
+	}
+}
+
+NWidgetCore *NWidgetContainer::GetWidgetFromPos(int x, int y)
+{
+	if (!IsInsideBS(x, this->pos_x, this->current_x) || !IsInsideBS(y, this->pos_y, this->current_y)) return nullptr;
+
+	for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
+		NWidgetCore *nwid = child_wid->GetWidgetFromPos(x, y);
+		if (nwid != nullptr) return nwid;
+	}
+	return nullptr;
+}
+
 /**
  * Widgets stacked on top of each other.
  */
@@ -1463,24 +1481,6 @@ void NWidgetPIPContainer::SetPIP(uint8_t pip_pre, uint8_t pip_inter, uint8_t pip
 	this->pip_pre = ScaleGUITrad(this->uz_pip_pre);
 	this->pip_inter = ScaleGUITrad(this->uz_pip_inter);
 	this->pip_post = ScaleGUITrad(this->uz_pip_post);
-}
-
-void NWidgetPIPContainer::Draw(const Window *w)
-{
-	for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
-		child_wid->Draw(w);
-	}
-}
-
-NWidgetCore *NWidgetPIPContainer::GetWidgetFromPos(int x, int y)
-{
-	if (!IsInsideBS(x, this->pos_x, this->current_x) || !IsInsideBS(y, this->pos_y, this->current_y)) return nullptr;
-
-	for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
-		NWidgetCore *nwid = child_wid->GetWidgetFromPos(x, y);
-		if (nwid != nullptr) return nwid;
-	}
-	return nullptr;
 }
 
 /** Horizontal container widget. */

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -412,6 +412,9 @@ public:
 	void Add(NWidgetBase *wid);
 	void FillNestedArray(NWidgetBase **array, uint length) override;
 
+	void Draw(const Window *w) override;
+	NWidgetCore *GetWidgetFromPos(int x, int y) override;
+
 	/** Return whether the container is empty. */
 	inline bool IsEmpty() { return head == nullptr; }
 
@@ -479,9 +482,6 @@ public:
 
 	void AdjustPaddingForZoom() override;
 	void SetPIP(uint8_t pip_pre, uint8_t pip_inter, uint8_t pip_post);
-
-	void Draw(const Window *w) override;
-	NWidgetCore *GetWidgetFromPos(int x, int y) override;
 
 protected:
 	NWidContainerFlags flags; ///< Flags of the container.

--- a/src/widgets/network_widget.h
+++ b/src/widgets/network_widget.h
@@ -19,7 +19,6 @@ enum NetworkGameWidgets {
 	WID_NG_FILTER_LABEL,       ///< Label in front of the filter/search edit box.
 	WID_NG_FILTER,             ///< Panel with the edit box to enter the search text.
 
-	WID_NG_HEADER,             ///< Header container of the matrix.
 	WID_NG_NAME,               ///< 'Name' button.
 	WID_NG_CLIENTS,            ///< 'Clients' button.
 	WID_NG_MAPSIZE,            ///< 'Map size' button.


### PR DESCRIPTION
## Motivation / Problem

The network server list and the main toolbars are both specialized container widgets that store whether certain child widgets are hidden or not in separate arrays.

This requires special handling and lookups when placing widgets, and when drawing or getting widget from click position.

It also requires the the array to be large enough, and for widget indices to be contiguous -- while that is the case it's not something that is easily enforceable.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

The widget system also treats a zero current_x or current_y value as a hidden widget. Therefore instead of storing this state in a separate fixed array, we can simply set the current_x of these hidden widgets to 0.

This automatically invokes the hidden behaviour, and means we don't need a separate lookup.

So we can therefore move the now common Draw and GetWidgetFromPos methods to NWidgetContainer to reduce duplication.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

NWidgetToolbarContainer previously drew the widgets in reverse order for RTL -- this seems an entirely unnecessary complication, and is dropped here.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
