### PR TITLE
Codechange: replace size() == 0 with .empty()

### DIFF
--- a/src/3rdparty/catch2/catch.hpp
+++ b/src/3rdparty/catch2/catch.hpp
@@ -5922,7 +5922,7 @@ namespace Catch {
         }
         void testCaseEnded(TestCaseStats const& testCaseStats) override {
             auto node = std::make_shared<TestCaseNode>(testCaseStats);
-            assert(m_sectionStack.size() == 0);
+            assert(m_sectionStack.empty());
             node->children.push_back(m_rootSection);
             m_testCases.push_back(node);
             m_rootSection.reset();

--- a/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
@@ -763,7 +763,7 @@ static SQInteger closure_getinfos(HSQUIRRELVM v) {
 		res->NewSlot(SQString::Create(_ss(v),"name",-1),nc->_name);
 		res->NewSlot(SQString::Create(_ss(v),"paramscheck",-1),nc->_nparamscheck);
 		SQObjectPtr typecheck;
-		if(nc->_typecheck.size() > 0) {
+		if(!nc->_typecheck.empty()) {
 			typecheck =
 				SQArray::Create(_ss(v), nc->_typecheck.size());
 			for(SQUnsignedInteger n = 0; n<nc->_typecheck.size(); n++) {

--- a/src/3rdparty/squirrel/squirrel/sqfuncstate.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqfuncstate.cpp
@@ -564,7 +564,7 @@ void SQFuncState::PopChildState()
 
 SQFuncState::~SQFuncState()
 {
-	while(_childstates.size() > 0)
+	while(!_childstates.empty())
 	{
 		PopChildState();
 	}

--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -280,7 +280,7 @@ struct AIConfigWindow : public Window {
 		this->SetWidgetDisabledState(WID_AIC_DECREASE_INTERVAL, GetGameSettings().difficulty.competitors_interval == MIN_COMPETITORS_INTERVAL);
 		this->SetWidgetDisabledState(WID_AIC_INCREASE_INTERVAL, GetGameSettings().difficulty.competitors_interval == MAX_COMPETITORS_INTERVAL);
 		this->SetWidgetDisabledState(WID_AIC_CHANGE, this->selected_slot == INVALID_COMPANY);
-		this->SetWidgetDisabledState(WID_AIC_CONFIGURE, this->selected_slot == INVALID_COMPANY || AIConfig::GetConfig(this->selected_slot)->GetConfigList()->size() == 0);
+		this->SetWidgetDisabledState(WID_AIC_CONFIGURE, this->selected_slot == INVALID_COMPANY || AIConfig::GetConfig(this->selected_slot)->GetConfigList()->empty());
 		this->SetWidgetDisabledState(WID_AIC_MOVE_UP, this->selected_slot == INVALID_COMPANY || !IsEditable((CompanyID)(this->selected_slot - 1)));
 		this->SetWidgetDisabledState(WID_AIC_MOVE_DOWN, this->selected_slot == INVALID_COMPANY || !IsEditable((CompanyID)(this->selected_slot + 1)));
 

--- a/src/ai/ai_scanner.cpp
+++ b/src/ai/ai_scanner.cpp
@@ -94,7 +94,7 @@ AIInfo *AIScannerInfo::SelectRandomAI() const
 
 AIInfo *AIScannerInfo::FindInfo(const std::string &name, int version, bool force_exact_match)
 {
-	if (this->info_list.size() == 0) return nullptr;
+	if (this->info_list.empty()) return nullptr;
 	if (name.empty()) return nullptr;
 
 	if (version == -1) {

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -222,7 +222,7 @@ class ReplaceVehicleWindow : public Window {
 			/* We need to rebuild the left engines list */
 			this->GenerateReplaceVehList(true);
 			this->vscroll[0]->SetCount(this->engines[0].size());
-			if (this->reset_sel_engine && this->sel_engine[0] == INVALID_ENGINE && this->engines[0].size() != 0) {
+			if (this->reset_sel_engine && this->sel_engine[0] == INVALID_ENGINE && !this->engines[0].empty()) {
 				this->sel_engine[0] = this->engines[0][0].engine_id;
 			}
 		}

--- a/src/blitter/factory.hpp
+++ b/src/blitter/factory.hpp
@@ -120,7 +120,7 @@ public:
 #else
 		const char *default_blitter = "8bpp-optimized";
 #endif
-		if (GetBlitters().size() == 0) return nullptr;
+		if (GetBlitters().empty()) return nullptr;
 		const char *bname = name.empty() ? default_blitter : name.c_str();
 
 		for (auto &it : GetBlitters()) {

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -1008,7 +1008,7 @@ public:
 					this->groups.ForceRebuild();
 					this->BuildGroupList((CompanyID)this->window_number);
 
-					if (this->groups.size() > 0) {
+					if (!this->groups.empty()) {
 						this->sel = this->groups[0]->index;
 					}
 				}
@@ -1095,7 +1095,7 @@ public:
 
 				if (!Group::IsValidID(this->sel)) {
 					this->sel = INVALID_GROUP;
-					if (this->groups.size() > 0) this->sel = this->groups[0]->index;
+					if (!this->groups.empty()) this->sel = this->groups[0]->index;
 				}
 
 				this->SetDirty();

--- a/src/core/kdtree.hpp
+++ b/src/core/kdtree.hpp
@@ -53,7 +53,7 @@ class Kdtree {
 	/** Create one new node in the tree, return its index in the pool */
 	size_t AddNode(const T &element)
 	{
-		if (this->free_list.size() == 0) {
+		if (this->free_list.empty()) {
 			this->nodes.emplace_back(element);
 			return this->nodes.size() - 1;
 		} else {

--- a/src/core/pool_func.cpp
+++ b/src/core/pool_func.cpp
@@ -20,7 +20,7 @@
 {
 	PoolVector *pools = PoolBase::GetPools();
 	pools->erase(std::find(pools->begin(), pools->end(), this));
-	if (pools->size() == 0) delete pools;
+	if (pools->empty()) delete pools;
 }
 
 /**

--- a/src/core/span_type.hpp
+++ b/src/core/span_type.hpp
@@ -84,7 +84,7 @@ public:
 
 	constexpr size_t size() const noexcept { return static_cast<size_t>( last - first ); }
 	constexpr std::ptrdiff_t ssize() const noexcept { return static_cast<std::ptrdiff_t>( last - first ); }
-	constexpr bool empty() const noexcept { return size() == 0; }
+	constexpr bool empty() const noexcept { return this->size() == 0; }
 
 	constexpr iterator begin() const noexcept { return iterator(first); }
 	constexpr iterator end() const noexcept { return iterator(last); }

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -810,7 +810,7 @@ struct DepotWindow : Window {
 
 			case WID_D_SELL_ALL:
 				/* Only open the confirmation window if there are anything to sell */
-				if (this->vehicle_list.size() != 0 || this->wagon_list.size() != 0) {
+				if (!this->vehicle_list.empty() || !this->wagon_list.empty()) {
 					SetDParam(0, this->type);
 					SetDParam(1, this->GetDepotIndex());
 					ShowQuery(

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -109,7 +109,7 @@ void DriverFactoryBase::SelectDriver(const std::string &name, Driver::Type type)
  */
 bool DriverFactoryBase::SelectDriverImpl(const std::string &name, Driver::Type type)
 {
-	if (GetDrivers().size() == 0) return false;
+	if (GetDrivers().empty()) return false;
 
 	if (name.empty()) {
 		/* Probe for this driver, but do not fall back to dedicated/null! */

--- a/src/game/game_scanner.cpp
+++ b/src/game/game_scanner.cpp
@@ -35,7 +35,7 @@ void GameScannerInfo::RegisterAPI(class Squirrel *engine)
 
 GameInfo *GameScannerInfo::FindInfo(const std::string &name, int version, bool force_exact_match)
 {
-	if (this->info_list.size() == 0) return nullptr;
+	if (this->info_list.empty()) return nullptr;
 	if (name.empty()) return nullptr;
 
 	if (version == -1) {

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -658,7 +658,7 @@ int DrawString(int left, int right, int top, std::string_view str, TextColour co
 	}
 
 	Layouter layout(str, INT32_MAX, colour, fontsize);
-	if (layout.size() == 0) return 0;
+	if (layout.empty()) return 0;
 
 	return DrawLayoutLine(*layout.front(), top, left, right, align, underline, true);
 }

--- a/src/gfx_layout_fallback.cpp
+++ b/src/gfx_layout_fallback.cpp
@@ -155,7 +155,7 @@ int FallbackParagraphLayout::FallbackLine::GetLeading() const
  */
 int FallbackParagraphLayout::FallbackLine::GetWidth() const
 {
-	if (this->size() == 0) return 0;
+	if (this->empty()) return 0;
 
 	/*
 	 * The last X position of a run contains is the end of that run.
@@ -293,7 +293,7 @@ std::unique_ptr<const ParagraphLayouter::Line> FallbackParagraphLayout::NextLine
 		this->buffer++;
 	}
 
-	if (l->size() == 0 || last_char - begin > 0) {
+	if (l->empty() || last_char - begin > 0) {
 		int w = l->GetWidth();
 		l->emplace_back(iter->second, begin, last_char - begin, begin - this->buffer_begin, w);
 	}

--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -132,7 +132,7 @@ ICUParagraphLayout::ICUVisualRun::ICUVisualRun(const ICURun &run, int x) :
 	glyphs(run.glyphs), glyph_to_char(run.glyph_to_char), total_advance(run.total_advance), font(run.font)
 {
 	/* If there are no positions, the ICURun was not Shaped; that should never happen. */
-	assert(run.positions.size() != 0);
+	assert(!run.positions.empty());
 	this->positions.reserve(run.positions.size());
 
 	/* "positions" is an array of x/y. So we need to alternate. */

--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -380,7 +380,7 @@ std::vector<ICURun> ItemizeStyle(std::vector<ICURun> &runs_current, FontMap &fon
 	runs = ItemizeScript(buff, length, runs);
 	runs = ItemizeStyle(runs, font_mapping);
 
-	if (runs.size() == 0) return nullptr;
+	if (runs.empty()) return nullptr;
 
 	for (auto &run : runs) {
 		run.Shape(buff, length);

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -510,13 +510,13 @@ public:
 		this->vscroll->SetCount(this->vehgroups.size());
 
 		/* The drop down menu is out, *but* it may not be used, retract it. */
-		if (this->vehicles.size() == 0 && this->IsWidgetLowered(WID_GL_MANAGE_VEHICLES_DROPDOWN)) {
+		if (this->vehicles.empty() && this->IsWidgetLowered(WID_GL_MANAGE_VEHICLES_DROPDOWN)) {
 			this->RaiseWidget(WID_GL_MANAGE_VEHICLES_DROPDOWN);
 			this->CloseChildWindows(WC_DROPDOWN_MENU);
 		}
 
 		/* Disable all lists management button when the list is empty */
-		this->SetWidgetsDisabledState(this->vehicles.size() == 0 || _local_company != this->vli.company,
+		this->SetWidgetsDisabledState(this->vehicles.empty() || _local_company != this->vli.company,
 				WID_GL_STOP_ALL,
 				WID_GL_START_ALL,
 				WID_GL_MANAGE_VEHICLES_DROPDOWN);

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -960,7 +960,7 @@ public:
 				break;
 
 			case WID_GL_MANAGE_VEHICLES_DROPDOWN:
-				assert(this->vehicles.size() != 0);
+				assert(!this->vehicles.empty());
 
 				switch (index) {
 					case ADI_REPLACE: // Replace window

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2683,7 +2683,7 @@ static void CanCargoServiceIndustry(CargoID cargo, Industry *ind, bool *c_accept
  */
 int WhoCanServiceIndustry(Industry *ind)
 {
-	if (ind->stations_near.size() == 0) return 0; // No stations found at all => nobody services
+	if (ind->stations_near.empty()) return 0; // No stations found at all => nobody services
 
 	int result = 0;
 	for (const Vehicle *v : Vehicle::Iterate()) {

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1670,7 +1670,7 @@ public:
 			case WID_ID_INDUSTRY_LIST: {
 				int n = 0;
 				Rect ir = r.Shrink(WidgetDimensions::scaled.framerect);
-				if (this->industries.size() == 0) {
+				if (this->industries.empty()) {
 					DrawString(ir, STR_INDUSTRY_DIRECTORY_NONE);
 					break;
 				}

--- a/src/misc/dbg_helpers.cpp
+++ b/src/misc/dbg_helpers.cpp
@@ -139,7 +139,7 @@ void DumpTarget::BeginStruct(size_t type_id, const std::string &name, const void
 {
 	/* make composite name */
 	std::string cur_name = GetCurrentStructName();
-	if (cur_name.size() > 0) {
+	if (!cur_name.empty()) {
 		/* add name delimiter (we use structured names) */
 		cur_name += ".";
 	}

--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -873,7 +873,7 @@ static const char *LoadDefaultDLSFile(const char *user_dls)
 			}
 
 			/* If we couldn't load the file from the registry, try again at the default install path of the GM DLS file. */
-			if (dls_file.instruments.size() == 0) {
+			if (dls_file.instruments.empty()) {
 				static const wchar_t *DLS_GM_FILE = L"%windir%\\System32\\drivers\\gm.dls";
 				wchar_t path[MAX_PATH];
 				ExpandEnvironmentStrings(DLS_GM_FILE, path, lengthof(path));

--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -939,14 +939,14 @@ static const char *LoadDefaultDLSFile(const char *user_dls)
 
 			/* Calculate download size for the instrument. */
 			size_t i_size = sizeof(DMUS_DOWNLOADINFO) + sizeof(DMUS_INSTRUMENT);
-			if (dls_file.instruments[i].articulators.size() > 0) {
+			if (!dls_file.instruments[i].articulators.empty()) {
 				/* Articulations are stored as two chunks, one containing meta data and one with the actual articulation data. */
 				offsets += 2;
 				i_size += sizeof(DMUS_ARTICULATION2) + sizeof(CONNECTIONLIST) + sizeof(CONNECTION) * dls_file.instruments[i].articulators.size();
 			}
 
 			for (std::vector<DLSFile::DLSRegion>::iterator rgn = dls_file.instruments[i].regions.begin(); rgn != dls_file.instruments[i].regions.end(); rgn++) {
-				if (rgn->articulators.size() > 0) {
+				if (!rgn->articulators.empty()) {
 					offsets += 2;
 					i_size += sizeof(DMUS_ARTICULATION2) + sizeof(CONNECTIONLIST) + sizeof(CONNECTION) * rgn->articulators.size();
 				}
@@ -999,7 +999,7 @@ static const char *LoadDefaultDLSFile(const char *user_dls)
 			instrument = inst_data + 1;
 
 			/* Write global articulations. */
-			if (dls_file.instruments[i].articulators.size() > 0) {
+			if (!dls_file.instruments[i].articulators.empty()) {
 				inst_data->ulGlobalArtIdx = last_offset;
 				offset_table[last_offset++] = (char *)instrument - inst_base;
 				offset_table[last_offset++] = (char *)instrument + sizeof(DMUS_ARTICULATION2) - inst_base;
@@ -1028,18 +1028,18 @@ static const char *LoadDefaultDLSFile(const char *user_dls)
 				/* The wave sample data will be taken from the region, if defined, otherwise from the wave itself. */
 				if (rgn.wave_sample.cbSize != 0) {
 					inst_region->WSMP = rgn.wave_sample;
-					if (rgn.wave_loops.size() > 0) MemCpyT(inst_region->WLOOP, &rgn.wave_loops.front(), rgn.wave_loops.size());
+					if (!rgn.wave_loops.empty()) MemCpyT(inst_region->WLOOP, &rgn.wave_loops.front(), rgn.wave_loops.size());
 
 					instrument = (char *)(inst_region + 1) - sizeof(DMUS_REGION::WLOOP) + sizeof(WLOOP) * rgn.wave_loops.size();
 				} else {
 					inst_region->WSMP = rgn.wave_sample;
-					if (dls_file.waves[wave_id].wave_loops.size() > 0) MemCpyT(inst_region->WLOOP, &dls_file.waves[wave_id].wave_loops.front(), dls_file.waves[wave_id].wave_loops.size());
+					if (!dls_file.waves[wave_id].wave_loops.empty()) MemCpyT(inst_region->WLOOP, &dls_file.waves[wave_id].wave_loops.front(), dls_file.waves[wave_id].wave_loops.size());
 
 					instrument = (char *)(inst_region + 1) - sizeof(DMUS_REGION::WLOOP) + sizeof(WLOOP) * dls_file.waves[wave_id].wave_loops.size();
 				}
 
 				/* Write local articulator data. */
-				if (rgn.articulators.size() > 0) {
+				if (!rgn.articulators.empty()) {
 					inst_region->ulRegionArtIdx = last_offset;
 					offset_table[last_offset++] = (char *)instrument - inst_base;
 					offset_table[last_offset++] = (char *)instrument + sizeof(DMUS_ARTICULATION2) - inst_base;
@@ -1168,7 +1168,7 @@ void MusicDriver_DMusic::Stop()
 	}
 
 	/* Unloaded any instruments we loaded. */
-	if (_dls_downloads.size() > 0) {
+	if (!_dls_downloads.empty()) {
 		IDirectMusicPortDownload *download_port = nullptr;
 		_port->QueryInterface(IID_IDirectMusicPortDownload, (LPVOID *)&download_port);
 

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -347,7 +347,7 @@ static bool FixupMidiData(MidiFile &target)
 	std::sort(target.tempos.begin(), target.tempos.end(), TicktimeAscending<MidiFile::TempoChange>);
 	std::sort(target.blocks.begin(), target.blocks.end(), TicktimeAscending<MidiFile::DataBlock>);
 
-	if (target.tempos.size() == 0) {
+	if (target.tempos.empty()) {
 		/* No tempo information, assume 120 bpm (500,000 microseconds per beat */
 		target.tempos.push_back(MidiFile::TempoChange(0, 500000));
 	}
@@ -359,9 +359,9 @@ static bool FixupMidiData(MidiFile &target)
 	uint32_t last_ticktime = 0;
 	for (size_t i = 0; i < target.blocks.size(); i++) {
 		MidiFile::DataBlock &block = target.blocks[i];
-		if (block.data.size() == 0) {
+		if (block.data.empty()) {
 			continue;
-		} else if (block.ticktime > last_ticktime || merged_blocks.size() == 0) {
+		} else if (block.ticktime > last_ticktime || merged_blocks.empty()) {
 			merged_blocks.push_back(block);
 			last_ticktime = block.ticktime;
 		} else {

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -87,7 +87,7 @@ public:
 	 */
 	bool IsValid() const
 	{
-		return this->buf.size() > 0;
+		return !this->buf.empty();
 	}
 
 	/**

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -203,7 +203,7 @@ void TCPConnecter::OnResolved(addrinfo *ai)
 	}
 
 	if (_debug_net_level >= 6) {
-		if (this->addresses.size() == 0) {
+		if (this->addresses.empty()) {
 			Debug(net, 6, "{} did not resolve", this->connection_string);
 		} else {
 			Debug(net, 6, "{} resolved in:", this->connection_string);

--- a/src/network/core/tcp_listen.h
+++ b/src/network/core/tcp_listen.h
@@ -142,7 +142,7 @@ public:
 	 */
 	static bool Listen(uint16_t port)
 	{
-		assert(sockets.size() == 0);
+		assert(sockets.empty());
 
 		NetworkAddressList addresses;
 		GetBindAddresses(&addresses, port);
@@ -151,7 +151,7 @@ public:
 			address.Listen(SOCK_STREAM, &sockets);
 		}
 
-		if (sockets.size() == 0) {
+		if (sockets.empty()) {
 			Debug(net, 0, "Could not start network: could not create listening socket");
 			ShowNetworkError(STR_NETWORK_ERROR_SERVER_START);
 			return false;

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -73,7 +73,7 @@ void NetworkUDPSocketHandler::CloseSocket()
  */
 void NetworkUDPSocketHandler::SendPacket(Packet *p, NetworkAddress *recv, bool all, bool broadcast)
 {
-	if (this->sockets.size() == 0) this->Listen();
+	if (this->sockets.empty()) this->Listen();
 
 	for (auto &s : this->sockets) {
 		/* Make a local copy because if we resolve it we cannot

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -50,7 +50,7 @@ bool NetworkUDPSocketHandler::Listen()
 		addr.Listen(SOCK_DGRAM, &this->sockets);
 	}
 
-	return this->sockets.size() != 0;
+	return !this->sockets.empty();
 }
 
 /**

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -703,7 +703,7 @@ void GetBindAddresses(NetworkAddressList *addresses, uint16_t port)
 	}
 
 	/* No address, so bind to everything. */
-	if (addresses->size() == 0) {
+	if (addresses->empty()) {
 		addresses->emplace_back("", port);
 	}
 }

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -67,7 +67,7 @@ static uint8_t *_chatmessage_backup = nullptr; ///< Backup in case text is moved
  */
 static inline bool HaveChatMessages(bool show_all)
 {
-	if (show_all) return _chatmsg_list.size() != 0;
+	if (show_all) return !_chatmsg_list.empty();
 
 	auto now = std::chrono::steady_clock::now();
 	for (auto &cmsg : _chatmsg_list) {

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -824,7 +824,7 @@ public:
 			case WID_NCL_NAME:
 				if (this->content.SortType() == widget - WID_NCL_CHECKBOX) {
 					this->content.ToggleSortOrder();
-					if (this->content.size() > 0) this->list_pos = (int)this->content.size() - this->list_pos - 1;
+					if (!this->content.empty()) this->list_pos = (int)this->content.size() - this->list_pos - 1;
 				} else {
 					this->content.SetSortType(widget - WID_NCL_CHECKBOX);
 					this->content.ForceResort();

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -899,7 +899,7 @@ public:
 			}
 		}
 
-		if (this->content.size() == 0) {
+		if (this->content.empty()) {
 			if (this->UpdateFilterState()) {
 				this->content.ForceRebuild();
 				this->InvalidateData();

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -9069,7 +9069,7 @@ static void CalculateRefitMasks()
 			/* Figure out which CTT to use for the default cargo, if it is 'first refittable'. */
 			const GRFFile *file = _gted[engine].defaultcargo_grf;
 			if (file == nullptr) file = e->GetGRF();
-			if (file != nullptr && file->grf_version >= 8 && file->cargo_list.size() != 0) {
+			if (file != nullptr && file->grf_version >= 8 && !file->cargo_list.empty()) {
 				/* Use first refittable cargo from cargo translation table */
 				byte best_local_slot = UINT8_MAX;
 				for (CargoID cargo_type : SetCargoBitIterator(ei->refit_mask)) {

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1192,7 +1192,7 @@ static ChangeInfoResult RailVehicleChangeInfo(uint engine, int numinfo, int prop
 					break;
 				}
 
-				if (_cur.grffile->railtype_list.size() == 0) {
+				if (_cur.grffile->railtype_list.empty()) {
 					/* Use traction type to select between normal and electrified
 					 * rail only when no translation list is in place. */
 					if (_gted[e->index].railtypelabel == RAILTYPE_RAIL_LABEL     && engclass >= EC_ELECTRIC) _gted[e->index].railtypelabel = RAILTYPE_ELECTRIC_LABEL;
@@ -5242,7 +5242,7 @@ static void NewSpriteGroup(ByteReader *buf)
 			group->default_group = GetGroupFromGroupID(setid, type, buf->ReadWord());
 			group->error_group = ranges.size() > 0 ? ranges[0].group : group->default_group;
 			/* nvar == 0 is a special case -- we turn our value into a callback result */
-			group->calculated_result = ranges.size() == 0;
+			group->calculated_result = ranges.empty();
 
 			/* Sort ranges ascending. When ranges overlap, this may required clamping or splitting them */
 			std::vector<uint32_t> bounds;
@@ -5511,7 +5511,7 @@ static CargoID TranslateCargo(uint8_t feature, uint8_t ctype)
 	if ((feature == GSF_STATIONS || feature == GSF_ROADSTOPS) && ctype == 0xFE) return CT_DEFAULT_NA;
 	if (ctype == 0xFF) return CT_PURCHASE;
 
-	if (_cur.grffile->cargo_list.size() == 0) {
+	if (_cur.grffile->cargo_list.empty()) {
 		/* No cargo table, so use bitnum values */
 		if (ctype >= 32) {
 			GrfMsg(1, "TranslateCargo: Cargo bitnum {} out of range (max 31), skipping.", ctype);
@@ -8855,7 +8855,7 @@ static void BuildCargoTranslationMap()
 	for (const CargoSpec *cs : CargoSpec::Iterate()) {
 		if (!cs->IsValid()) continue;
 
-		if (_cur.grffile->cargo_list.size() == 0) {
+		if (_cur.grffile->cargo_list.empty()) {
 			/* Default translation table, so just a straight mapping to bitnum */
 			_cur.grffile->cargo_map[cs->Index()] = cs->bitnum;
 		} else {

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -5240,7 +5240,7 @@ static void NewSpriteGroup(ByteReader *buf)
 			}
 
 			group->default_group = GetGroupFromGroupID(setid, type, buf->ReadWord());
-			group->error_group = ranges.size() > 0 ? ranges[0].group : group->default_group;
+			group->error_group = ranges.empty() ? group->default_group : ranges[0].group;
 			/* nvar == 0 is a special case -- we turn our value into a callback result */
 			group->calculated_result = ranges.empty();
 

--- a/src/newgrf_cargo.cpp
+++ b/src/newgrf_cargo.cpp
@@ -86,7 +86,7 @@ CargoID GetCargoTranslation(uint8_t cargo, const GRFFile *grffile, bool usebit)
 
 	/* Other cases use (possibly translated) cargobits */
 
-	if (grffile->cargo_list.size() > 0) {
+	if (!grffile->cargo_list.empty()) {
 		/* ...and the cargo is in bounds, then get the cargo ID for
 		 * the label */
 		if (cargo < grffile->cargo_list.size()) return GetCargoIDByLabel(grffile->cargo_list[cargo]);

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1578,7 +1578,7 @@ void ShowMissingContentWindow(const GRFConfig *list)
 		ci->md5sum = HasBit(c->flags, GCF_COMPATIBLE) ? c->original_md5sum : c->ident.md5sum;
 		cv.push_back(ci);
 	}
-	ShowNetworkContentListWindow(cv.size() == 0 ? nullptr : &cv, CONTENT_TYPE_NEWGRF);
+	ShowNetworkContentListWindow(cv.empty() ? nullptr : &cv, CONTENT_TYPE_NEWGRF);
 }
 
 Listing NewGRFWindow::last_sorting     = {false, 0};

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -163,7 +163,7 @@ struct NewGRFParametersWindow : public Window {
 		clicked_row(UINT_MAX),
 		editable(editable)
 	{
-		this->action14present = (c->num_valid_params != c->param.size() || c->param_info.size() != 0);
+		this->action14present = (c->num_valid_params != c->param.size() || !c->param_info.empty());
 
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_NP_SCROLLBAR);

--- a/src/newgrf_railtype.cpp
+++ b/src/newgrf_railtype.cpp
@@ -140,7 +140,7 @@ SpriteID GetCustomSignalSprite(const RailTypeInfo *rti, TileIndex tile, SignalTy
  */
 RailType GetRailTypeTranslation(uint8_t railtype, const GRFFile *grffile)
 {
-	if (grffile == nullptr || grffile->railtype_list.size() == 0) {
+	if (grffile == nullptr || grffile->railtype_list.empty()) {
 		/* No railtype table present. Return railtype as-is (if valid), so it works for original railtypes. */
 		if (railtype >= RAILTYPE_END || GetRailTypeInfo(static_cast<RailType>(railtype))->label == 0) return INVALID_RAILTYPE;
 
@@ -163,7 +163,7 @@ RailType GetRailTypeTranslation(uint8_t railtype, const GRFFile *grffile)
 uint8_t GetReverseRailTypeTranslation(RailType railtype, const GRFFile *grffile)
 {
 	/* No rail type table present, return rail type as-is */
-	if (grffile == nullptr || grffile->railtype_list.size() == 0) return railtype;
+	if (grffile == nullptr || grffile->railtype_list.empty()) return railtype;
 
 	/* Look for a matching rail type label in the table */
 	RailTypeLabel label = GetRailTypeInfo(railtype)->label;

--- a/src/newgrf_roadtype.cpp
+++ b/src/newgrf_roadtype.cpp
@@ -156,7 +156,7 @@ uint8_t GetReverseRoadTypeTranslation(RoadType roadtype, const GRFFile *grffile)
 	if (grffile == nullptr) return roadtype;
 
 	const std::vector<RoadTypeLabel> *list = RoadTypeIsRoad(roadtype) ? &grffile->roadtype_list : &grffile->tramtype_list;
-	if (list->size() == 0) return roadtype;
+	if (list->empty()) return roadtype;
 
 	/* Look for a matching road type label in the table */
 	RoadTypeLabel label = GetRoadTypeInfo(roadtype)->label;

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -276,7 +276,7 @@ int CoreTextParagraphLayout::CoreTextLine::GetLeading() const
  */
 int CoreTextParagraphLayout::CoreTextLine::GetWidth() const
 {
-	if (this->size() == 0) return 0;
+	if (this->empty()) return 0;
 
 	int total_width = 0;
 	for (const auto &run : *this) {

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -367,7 +367,7 @@ int MacOSStringCompare(std::string_view s1, std::string_view s2)
 	/* Query CoreText for word and cluster break information. */
 	this->str_info.resize(utf16_to_utf8.size());
 
-	if (utf16_str.size() > 0) {
+	if (!utf16_str.empty()) {
 		CFAutoRelease<CFStringRef> str(CFStringCreateWithCharactersNoCopy(kCFAllocatorDefault, &utf16_str[0], utf16_str.size(), kCFAllocatorNull));
 
 		/* Get cluster breaks. */

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -291,7 +291,7 @@ static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutF
 
 	/* Itemize text. */
 	std::vector<SCRIPT_ITEM> items = UniscribeItemizeString(buff, length);
-	if (items.size() == 0) return nullptr;
+	if (items.empty()) return nullptr;
 
 	/* Build ranges from the items and the font map. A range is a run of text
 	 * that is part of a single item and formatted using a single font style. */

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -550,11 +550,11 @@ const int *UniscribeParagraphLayout::UniscribeVisualRun::GetGlyphToCharMap() con
 	/* Query Uniscribe for word and cluster break information. */
 	this->str_info.resize(utf16_to_utf8.size());
 
-	if (utf16_str.size() > 0) {
+	if (!utf16_str.empty()) {
 		/* Itemize string into language runs. */
 		std::vector<SCRIPT_ITEM> runs = UniscribeItemizeString(&utf16_str[0], (int32_t)utf16_str.size());
 
-		for (std::vector<SCRIPT_ITEM>::const_iterator run = runs.begin(); runs.size() > 0 && run != runs.end() - 1; run++) {
+		for (std::vector<SCRIPT_ITEM>::const_iterator run = runs.begin(); !runs.empty() && run != runs.end() - 1; run++) {
 			/* Get information on valid word and character break.s */
 			int len = (run + 1)->iCharPos - run->iCharPos;
 			std::vector<SCRIPT_LOGATTR> attr(len);

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2384,7 +2384,7 @@ DropDownList GetRailTypeDropDownList(bool for_replacement, bool all_option)
 		}
 	}
 
-	if (list.size() == 0) {
+	if (list.empty()) {
 		/* Empty dropdowns are not allowed */
 		list.push_back(std::make_unique<DropDownListStringItem>(STR_NONE, INVALID_RAILTYPE, true));
 	}

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1845,7 +1845,7 @@ DropDownList GetRoadTypeDropDownList(RoadTramTypes rtts, bool for_replacement, b
 		}
 	}
 
-	if (list.size() == 0) {
+	if (list.empty()) {
 		/* Empty dropdowns are not allowed */
 		list.push_back(std::make_unique<DropDownListStringItem>(STR_NONE, INVALID_ROADTYPE, true));
 	}
@@ -1885,7 +1885,7 @@ DropDownList GetScenRoadTypeDropDownList(RoadTramTypes rtts)
 		list.push_back(std::move(item));
 	}
 
-	if (list.size() == 0) {
+	if (list.empty()) {
 		/* Empty dropdowns are not allowed */
 		list.push_back(std::make_unique<DropDownListStringItem>(STR_NONE, -1, true));
 	}

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -172,7 +172,7 @@ struct GSTRChunkHandler : ChunkHandler {
 		}
 
 		/* If there were no strings in the savegame, set GameStrings to nullptr */
-		if (_current_data->raw_strings.size() == 0) {
+		if (_current_data->raw_strings.empty()) {
 			delete _current_data;
 			_current_data = nullptr;
 			return;

--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -197,7 +197,7 @@ SaveLoadTable GetLinkGraphJobDesc()
 	static SaveLoadAddrProc * const proc = [](void *b, size_t extra) -> void * { return const_cast<void *>(static_cast<const void *>(reinterpret_cast<const char *>(std::addressof(static_cast<LinkGraphJob *>(b)->settings)) + extra)); };
 
 	/* Build the SaveLoad array on first call and don't touch it later on */
-	if (saveloads.size() == 0) {
+	if (saveloads.empty()) {
 		GetSaveLoadFromSettingTable(_linkgraph_settings, saveloads);
 
 		for (auto &sl : saveloads) {

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -172,7 +172,7 @@ struct ScriptAllocator {
 	~ScriptAllocator()
 	{
 #ifdef SCRIPT_DEBUG_ALLOCATIONS
-		assert(this->allocations.size() == 0);
+		assert(this->allocations.empty());
 #endif
 	}
 };

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -309,7 +309,7 @@ static void DifficultyNoiseChange(int32_t)
 static void MaxNoAIsChange(int32_t)
 {
 	if (GetGameSettings().difficulty.max_no_competitors != 0 &&
-			AI::GetInfoList()->size() == 0 &&
+			AI::GetInfoList()->empty() &&
 			(!_networking || _network_server)) {
 		ShowErrorMessage(STR_WARNING_NO_SUITABLE_AI, INVALID_STRING_ID, WL_CRITICAL);
 	}

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -253,7 +253,7 @@ void Station::MarkTilesDirty(bool cargo_change) const
 		/* Don't waste time updating if there are no custom station graphics
 		 * that might change. Even if there are custom graphics, they might
 		 * not change. Unfortunately we have no way of telling. */
-		if (this->speclist.size() == 0) return;
+		if (this->speclist.empty()) return;
 	}
 
 	for (h = 0; h < train_station.h; h++) {

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -877,7 +877,7 @@ public:
 			if (!_story_page_pool.IsValidID(this->selected_page_id)) {
 				this->selected_page_id = INVALID_STORY_PAGE;
 			}
-			if (this->selected_page_id == INVALID_STORY_PAGE && this->story_pages.size() > 0) {
+			if (this->selected_page_id == INVALID_STORY_PAGE && !this->story_pages.empty()) {
 				/* No page is selected, but there exist at least one available.
 				 * => Select first page.
 				 */

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -622,8 +622,8 @@ public:
 	 */
 	void UpdatePrevNextDisabledState()
 	{
-		this->SetWidgetDisabledState(WID_SB_PREV_PAGE, story_pages.size() == 0 || this->IsFirstPageSelected());
-		this->SetWidgetDisabledState(WID_SB_NEXT_PAGE, story_pages.size() == 0 || this->IsLastPageSelected());
+		this->SetWidgetDisabledState(WID_SB_PREV_PAGE, story_pages.empty() || this->IsFirstPageSelected());
+		this->SetWidgetDisabledState(WID_SB_NEXT_PAGE, story_pages.empty() || this->IsLastPageSelected());
 		this->SetWidgetDirty(WID_SB_PREV_PAGE);
 		this->SetWidgetDirty(WID_SB_NEXT_PAGE);
 	}
@@ -869,7 +869,7 @@ public:
 			this->BuildStoryPageList();
 
 			/* Was the last page removed? */
-			if (this->story_pages.size() == 0) {
+			if (this->story_pages.empty()) {
 				this->selected_generic_title.clear();
 			}
 
@@ -884,7 +884,7 @@ public:
 				this->SetSelectedPage(this->story_pages[0]->index);
 			}
 
-			this->SetWidgetDisabledState(WID_SB_SEL_PAGE, this->story_pages.size() == 0);
+			this->SetWidgetDisabledState(WID_SB_SEL_PAGE, this->story_pages.empty());
 			this->SetWidgetDirty(WID_SB_SEL_PAGE);
 			this->UpdatePrevNextDisabledState();
 		} else if (data >= 0 && this->selected_page_id == data) {

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -594,7 +594,7 @@ char *strcasestr(const char *haystack, const char *needle)
  */
 static std::string_view SkipGarbage(std::string_view str)
 {
-	while (str.size() != 0 && (str[0] < '0' || IsInsideMM(str[0], ';', '@' + 1) || IsInsideMM(str[0], '[', '`' + 1) || IsInsideMM(str[0], '{', '~' + 1))) str.remove_prefix(1);
+	while (!str.empty() && (str[0] < '0' || IsInsideMM(str[0], ';', '@' + 1) || IsInsideMM(str[0], '[', '`' + 1) || IsInsideMM(str[0], '{', '~' + 1))) str.remove_prefix(1);
 	return str;
 }
 

--- a/src/stringfilter_type.h
+++ b/src/stringfilter_type.h
@@ -56,7 +56,7 @@ public:
 	 * Check whether any filter words were entered.
 	 * @return true if no words were entered.
 	 */
-	bool IsEmpty() const { return this->word_index.size() == 0; }
+	bool IsEmpty() const { return this->word_index.empty(); }
 
 	void ResetState();
 	void AddLine(const char *str);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2044,7 +2044,7 @@ void InitializeLanguagePacks()
 	for (Searchpath sp : _valid_searchpaths) {
 		FillLanguageList(FioGetDirectory(sp, LANG_DIR));
 	}
-	if (_languages.size() == 0) UserError("No available language packs (invalid versions?)");
+	if (_languages.empty()) UserError("No available language packs (invalid versions?)");
 
 	/* Acquire the locale of the current system */
 	const char *lang = GetCurrentLocale("LC_MESSAGES");

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -122,7 +122,7 @@ uint TextfileWindow::ReflowContent()
 
 uint TextfileWindow::GetContentHeight()
 {
-	if (this->lines.size() == 0) return 0;
+	if (this->lines.empty()) return 0;
 	return this->lines.back().bottom;
 }
 

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -823,7 +823,7 @@ public:
 			case WID_TD_LIST: {
 				int n = 0;
 				Rect tr = r.Shrink(WidgetDimensions::scaled.framerect);
-				if (this->towns.size() == 0) { // No towns available.
+				if (this->towns.empty()) { // No towns available.
 					DrawString(tr, STR_TOWN_DIRECTORY_NONE);
 					break;
 				}

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -854,7 +854,7 @@ static void MakeTrainBackup(TrainList &list, Train *t)
 static void RestoreTrainBackup(TrainList &list)
 {
 	/* No train, nothing to do. */
-	if (list.size() == 0) return;
+	if (list.empty()) return;
 
 	Train *prev = nullptr;
 	/* Iterate over the list and rebuild it. */

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -349,7 +349,7 @@ void BaseVehicleListWindow::SetCargoFilterArray()
 void BaseVehicleListWindow::FilterVehicleList()
 {
 	this->vehgroups.Filter(this->cargo_filter[this->cargo_filter_criteria]);
-	if (this->vehicles.size() == 0) {
+	if (this->vehicles.empty()) {
 		/* No vehicle passed through the filter, invalidate the previously selected vehicle */
 		this->vehicle_sel = INVALID_VEHICLE;
 	} else if (this->vehicle_sel != INVALID_VEHICLE && std::find(this->vehicles.begin(), this->vehicles.end(), Vehicle::Get(this->vehicle_sel)) == this->vehicles.end()) { // previously selected engine didn't pass the filter, remove selection
@@ -668,7 +668,7 @@ struct RefitWindow : public Window {
 				if (!HasBit(cmask, cid)) continue;
 
 				auto &list = this->refit_list[cid];
-				bool first_vehicle = list.size() == 0;
+				bool first_vehicle = list.empty();
 				if (first_vehicle) {
 					/* Keeping the current subtype is always an option. It also serves as the option in case of no subtypes */
 					list.push_back({cid, UINT8_MAX, STR_EMPTY});
@@ -1949,7 +1949,7 @@ public:
 		this->BuildVehicleList();
 		this->SortVehicleList();
 
-		if (this->vehicles.size() == 0 && this->IsWidgetLowered(WID_VL_MANAGE_VEHICLES_DROPDOWN)) {
+		if (this->vehicles.empty() && this->IsWidgetLowered(WID_VL_MANAGE_VEHICLES_DROPDOWN)) {
 			this->CloseChildWindows(WC_DROPDOWN_MENU);
 		}
 
@@ -1963,7 +1963,7 @@ public:
 		}
 		if (this->owner == _local_company) {
 			this->SetWidgetDisabledState(WID_VL_AVAILABLE_VEHICLES, this->vli.type != VL_STANDARD);
-			this->SetWidgetsDisabledState(this->vehicles.size() == 0,
+			this->SetWidgetsDisabledState(this->vehicles.empty(),
 				WID_VL_MANAGE_VEHICLES_DROPDOWN,
 				WID_VL_STOP_ALL,
 				WID_VL_START_ALL);

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2080,7 +2080,7 @@ public:
 				break;
 
 			case WID_VL_MANAGE_VEHICLES_DROPDOWN:
-				assert(this->vehicles.size() != 0);
+				assert(!this->vehicles.empty());
 
 				switch (index) {
 					case ADI_REPLACE: // Replace window

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -476,7 +476,7 @@ byte GetBestFittingSubType(Vehicle *v_from, Vehicle *v_for, CargoID dest_cargo_t
 
 	byte ret_refit_cyc = 0;
 	bool success = false;
-	if (subtypes.size() > 0) {
+	if (!subtypes.empty()) {
 		/* Check whether any articulated part is refittable to 'dest_cargo_type' with a subtype listed in 'subtypes' */
 		for (Vehicle *v = v_for; v != nullptr; v = v->HasArticulatedPart() ? v->GetNextArticulatedPart() : nullptr) {
 			const Engine *e = v->GetEngine();

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1747,7 +1747,7 @@ void ViewportDoDraw(const Viewport *vp, int left, int top, int right, int bottom
 
 	DrawTextEffects(&_vd.dpi);
 
-	if (_vd.tile_sprites_to_draw.size() != 0) ViewportDrawTileSprites(&_vd.tile_sprites_to_draw);
+	if (!_vd.tile_sprites_to_draw.empty()) ViewportDrawTileSprites(&_vd.tile_sprites_to_draw);
 
 	for (auto &psd : _vd.parent_sprites_to_draw) {
 		_vd.parent_sprites_to_sort.push_back(&psd);
@@ -1773,7 +1773,7 @@ void ViewportDoDraw(const Viewport *vp, int left, int top, int right, int bottom
 		vp->overlay->Draw(&dp);
 	}
 
-	if (_vd.string_sprites_to_draw.size() != 0) {
+	if (!_vd.string_sprites_to_draw.empty()) {
 		/* translate to world coordinates */
 		dp.left = UnScaleByZoom(_vd.dpi.left, zoom);
 		dp.top = UnScaleByZoom(_vd.dpi.top, zoom);

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -134,7 +134,7 @@ struct DropdownWindow : Window {
 	DropdownWindow(Window *parent, DropDownList &&list, int selected, int button, bool instant_close, const Point &position, const Dimension &size, Colours wi_colour, bool scroll)
 			: Window(&_dropdown_desc), list(std::move(list))
 	{
-		assert(this->list.size() > 0);
+		assert(!this->list.empty());
 
 		this->position = position;
 

--- a/src/widgets/slider.cpp
+++ b/src/widgets/slider.cpp
@@ -29,7 +29,7 @@ static const int SLIDER_WIDTH = 3;
 void DrawSliderWidget(Rect r, int min_value, int max_value, int value, const std::map<int, StringID> &labels)
 {
 	/* Allow space for labels. We assume they are in the small font. */
-	if (labels.size() > 0) r.bottom -= FONT_HEIGHT_SMALL + WidgetDimensions::scaled.hsep_normal;
+	if (!labels.empty()) r.bottom -= FONT_HEIGHT_SMALL + WidgetDimensions::scaled.hsep_normal;
 
 	max_value -= min_value;
 


### PR DESCRIPTION
## Motivation / Problem

`.empty()` describes the intent better than comparing `.size()`.


## Description

Just simple replacements of `x.size() == 0` to `x.empty()`, `x.size() > 0` and `x.size() != 0` to `!x.empty()`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
