### PR TITLE
Add: Dedicated server heightmap support

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1129,6 +1129,52 @@ DEF_CONSOLE_CMD(ConNewGame)
 	return true;
 }
 
+DEF_CONSOLE_CMD(ConNewHeightMapGame)
+{
+	if (argc == 0) {
+		IConsolePrint(CC_HELP, "Load a game by name or index. Usage: 'newheightmapgame [<file | number> [seed]]'");
+		IConsolePrint(CC_HELP, "The server can force a new game using 'newheightmapgame'; any client joined will rejoin after the server is done generating the new game.");
+		return true;
+	}
+
+	if (argc > 3) return false;
+
+	bool heightmap_loaded = true;
+	std::string_view file;
+
+	if (argc == 1) {
+		file = _file_to_saveload.title;
+	}
+
+	if (argc >= 2) {
+		file = argv[1];
+	}
+
+	/* ConLoad command actually uses
+	_console_file_list.ValidateFileList()
+	here, but for this procedure build a file list for mere savegames, instead of merely validating */
+	_console_file_list.BuildFileList(FT_HEIGHTMAP, SLO_LOAD);
+	const FiosItem *item = _console_file_list.FindItem(file);
+	if (item != NULL) {
+		if (GetAbstractFileType(item->type) == FT_HEIGHTMAP) {
+			_switch_mode = SM_LOAD_HEIGHTMAP;
+			_file_to_saveload.SetMode(item->type);
+			_file_to_saveload.name = FiosBrowseTo(item);
+			_file_to_saveload.title = item->title;
+
+			StartNewGameWithoutGUI((argc == 3) ? strtoul(argv[2], NULL, 10) : GENERATE_NEW_SEED);
+		} else {
+			IConsolePrint(CC_ERROR, "{}: Not a heightmap.", file);
+		}
+	} else {
+		IConsolePrint(CC_ERROR, "{}: No such file or directory.", file);
+	}
+
+	_console_file_list.InvalidateFileList();
+
+	return heightmap_loaded;
+}
+
 DEF_CONSOLE_CMD(ConRestart)
 {
 	if (argc == 0) {
@@ -2518,6 +2564,7 @@ void IConsoleStdLibRegister()
 	IConsole::CmdRegister("list_cmds",               ConListCommands);
 	IConsole::CmdRegister("list_aliases",            ConListAliases);
 	IConsole::CmdRegister("newgame",                 ConNewGame);
+	IConsole::CmdRegister("newheightmapgame",        ConNewHeightMapGame);
 	IConsole::CmdRegister("restart",                 ConRestart);
 	IConsole::CmdRegister("reload",                  ConReload);
 	IConsole::CmdRegister("getseed",                 ConGetSeed);

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -490,7 +490,7 @@ void FiosGetSavegameList(SaveLoadOperation fop, FileList &file_list)
  * @see FiosGetFileList
  * @see FiosGetScenarioList
  */
-static std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext)
+std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext)
 {
 	/* Show scenario files
 	 * .SCN OpenTTD style scenario file
@@ -530,7 +530,7 @@ void FiosGetScenarioList(SaveLoadOperation fop, FileList &file_list)
 	FiosGetFileList(fop, &FiosGetScenarioListCallback, subdir, file_list);
 }
 
-static std::tuple<FiosType, std::string> FiosGetHeightmapListCallback(SaveLoadOperation, const std::string &file, const std::string_view ext)
+std::tuple<FiosType, std::string> FiosGetHeightmapListCallback(SaveLoadOperation, const std::string &file, const std::string_view ext)
 {
 	/* Show heightmap files
 	 * .PNG PNG Based heightmap files

--- a/src/fios.h
+++ b/src/fios.h
@@ -117,6 +117,8 @@ std::string FiosMakeHeightmapName(const char *name);
 std::string FiosMakeSavegameName(const char *name);
 
 std::tuple<FiosType, std::string> FiosGetSavegameListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext);
+std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext);
+std::tuple<FiosType, std::string> FiosGetHeightmapListCallback(SaveLoadOperation, const std::string &file, const std::string_view ext);
 
 void ScanScenarios();
 const char *FindScenario(const ContentInfo *ci, bool md5sum);

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -1075,7 +1075,7 @@ void StartScenarioEditor()
 }
 
 /**
- * Start a normal game without the GUI.
+ * Start a normal/heightmap game without the GUI.
  * @param seed The seed of the new game.
  */
 void StartNewGameWithoutGUI(uint32_t seed)
@@ -1083,7 +1083,20 @@ void StartNewGameWithoutGUI(uint32_t seed)
 	/* GenerateWorld takes care of the possible GENERATE_NEW_SEED value in 'seed' */
 	_settings_newgame.game_creation.generation_seed = seed;
 
-	StartGeneratingLandscape(GLWM_GENERATE);
+
+	GenerateLandscapeWindowMode mode = GLWM_GENERATE;
+
+	if(_file_to_saveload.abstract_ftype == FT_HEIGHTMAP) {
+		uint x = 0;
+		uint y = 0;
+
+		/* If the function returns false, it means there was a problem loading the heightmap */
+		if (!GetHeightmapDimensions(_file_to_saveload.detail_ftype, _file_to_saveload.name.c_str(), &x, &y)) return;
+
+		mode = GLWM_HEIGHTMAP;
+	}
+
+	StartGeneratingLandscape(mode);
 }
 
 struct CreateScenarioWindow : public Window

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -205,7 +205,7 @@ void VideoDriver_Dedicated::MainLoop()
 	_current_company = _local_company = COMPANY_SPECTATOR;
 
 	/* If SwitchMode is SM_LOAD_GAME, it means that the user used the '-g' options */
-	if (_switch_mode != SM_LOAD_GAME) {
+	if (_switch_mode != SM_LOAD_GAME && _switch_mode != SM_START_HEIGHTMAP) {
 		StartNewGameWithoutGUI(GENERATE_NEW_SEED);
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Heightmap maps aren't loadable by dedicated servers.
Furthermore, once such a map is loaded, on game end a normal, procedurally generated map takes turn.

## Description

Closes #11303
Somehow related to #7285 & #7286.
Add heightmap maps support for dedicated servers:
* CLI switch
* Heightmap map reload on game end

## Limitations

Worked wonders for my needs in #11303.
As noted long ago, there might be unoticed side-effects for others game modes (client ,editor), for which your expertise would be valuable.

Those changes have been adapted to the partial network code rework operated in the latest major version.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
