### PR TITLE
Add: per-use customisable cargo list separators

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -924,8 +924,8 @@ STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE_WITH_TYPE                    :{BLACK}New {STR
 
 STR_NEWS_SHOW_VEHICLE_GROUP_TOOLTIP                             :{BLACK}Open the group window focused on the vehicle's group
 
-STR_NEWS_STATION_NO_LONGER_ACCEPTS_CARGO_LIST                   :{WHITE}{STATION} no longer accepts: {CARGO_LIST}
-STR_NEWS_STATION_NOW_ACCEPTS_CARGO_LIST                         :{WHITE}{STATION} now accepts: {CARGO_LIST}
+STR_NEWS_STATION_NO_LONGER_ACCEPTS_CARGO_LIST                   :{WHITE}{STATION} no longer accepts: {CARGO_LIST " or "}
+STR_NEWS_STATION_NOW_ACCEPTS_CARGO_LIST                         :{WHITE}{STATION} now accepts: {CARGO_LIST " and "}
 
 STR_NEWS_OFFER_OF_SUBSIDY_EXPIRED                               :{BIG_FONT}{BLACK}Offer of subsidy expired:{}{}{STRING} from {STRING2} to {STRING2} will now not attract a subsidy
 STR_NEWS_SUBSIDY_WITHDRAWN_SERVICE                              :{BIG_FONT}{BLACK}Subsidy withdrawn:{}{}{STRING} service from {STRING2} to {STRING2} is no longer subsidised
@@ -2694,8 +2694,8 @@ STR_STATION_BUILD_COVERAGE_OFF                                  :{BLACK}Off
 STR_STATION_BUILD_COVERAGE_ON                                   :{BLACK}On
 STR_STATION_BUILD_COVERAGE_AREA_OFF_TOOLTIP                     :{BLACK}Don't highlight coverage area of proposed site
 STR_STATION_BUILD_COVERAGE_AREA_ON_TOOLTIP                      :{BLACK}Highlight coverage area of proposed site
-STR_STATION_BUILD_ACCEPTS_CARGO                                 :{BLACK}Accepts: {GOLD}{CARGO_LIST}
-STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Supplies: {GOLD}{CARGO_LIST}
+STR_STATION_BUILD_ACCEPTS_CARGO                                 :{BLACK}Accepts: {GOLD}{CARGO_LIST " and "}
+STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Supplies: {GOLD}{CARGO_LIST " and "}
 STR_STATION_BUILD_INFRASTRUCTURE_COST                           :{BLACK}Maintenance cost: {GOLD}{CURRENCY_SHORT}/yr
 
 # Join station window
@@ -3667,7 +3667,7 @@ STR_STATION_VIEW_RESERVED                                       :{YELLOW}({CARGO
 
 STR_STATION_VIEW_ACCEPTS_BUTTON                                 :{BLACK}Accepts
 STR_STATION_VIEW_ACCEPTS_TOOLTIP                                :{BLACK}Show list of accepted cargo
-STR_STATION_VIEW_ACCEPTS_CARGO                                  :{BLACK}Accepts: {WHITE}{CARGO_LIST}
+STR_STATION_VIEW_ACCEPTS_CARGO                                  :{BLACK}Accepts: {WHITE}{CARGO_LIST " and "}
 
 STR_STATION_VIEW_EXCLUSIVE_RIGHTS_SELF                          :{BLACK}This station has exclusive transport rights in this town.
 STR_STATION_VIEW_EXCLUSIVE_RIGHTS_COMPANY                       :{YELLOW}{COMPANY}{BLACK} bought exclusive transport rights in this town.
@@ -3897,7 +3897,7 @@ STR_VEHICLE_LIST_REPLACE_VEHICLES                               :Replace vehicle
 STR_VEHICLE_LIST_SEND_FOR_SERVICING                             :Send for servicing
 STR_VEHICLE_LIST_CREATE_GROUP                                   :Create group
 STR_VEHICLE_LIST_PROFIT_THIS_YEAR_LAST_YEAR                     :{TINY_FONT}{BLACK}Profit this year: {CURRENCY_LONG} (last year: {CURRENCY_LONG})
-STR_VEHICLE_LIST_CARGO                                          :[{CARGO_LIST}]
+STR_VEHICLE_LIST_CARGO                                          :[{CARGO_LIST " and "}]
 STR_VEHICLE_LIST_NAME_AND_CARGO                                 :{STRING1} {STRING1}
 
 STR_VEHICLE_LIST_SEND_TRAIN_TO_DEPOT                            :Send to depot
@@ -3985,7 +3985,8 @@ STR_PURCHASE_INFO_REFITTABLE_TO                                 :{BLACK}Refittab
 STR_PURCHASE_INFO_ALL_TYPES                                     :All cargo types
 STR_PURCHASE_INFO_NONE                                          :None
 STR_PURCHASE_INFO_ENGINES_ONLY                                  :Engines only
-STR_PURCHASE_INFO_ALL_BUT                                       :All but {CARGO_LIST}
+STR_PURCHASE_INFO_ALL_BUT                                       :All but {CARGO_LIST " and "}
+STR_PURCHASE_INFO_CARGO_LIST                                    :{CARGO_LIST " or "}
 STR_PURCHASE_INFO_MAX_TE                                        :{BLACK}Max. Tractive Effort: {GOLD}{FORCE}
 STR_PURCHASE_INFO_AIRCRAFT_RANGE                                :{BLACK}Range: {GOLD}{COMMA} tiles
 STR_PURCHASE_INFO_AIRCRAFT_TYPE                                 :{BLACK}Aircraft type: {GOLD}{STRING}

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1252,7 +1252,16 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 
 			case SCC_CARGO_LIST: { // {CARGO_LIST}
 				CargoTypes cmask = args.GetNextParameter<CargoTypes>();
+				/* After the SCC_CARGO_LIST character, there are two '\0' terminated strings with separators.
+				 * Get their pointers and advance str to beyond them.
+				 */
+				const char *separator = str;
+				str += strlen(str) + 1;
+				const char *last_separator = str;
+				str += strlen(str) + 1;
+
 				bool first = true;
+				int remaining = CountBits(cmask);
 
 				for (const auto &cs : _sorted_cargo_specs) {
 					if (!HasBit(cmask, cs->Index())) continue;
@@ -1261,8 +1270,9 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 						first = false;
 					} else {
 						/* Add a comma if this is not the first item */
-						builder += ", ";
+						builder += remaining == 1 ? last_separator : separator;
 					}
+					remaining--;
 
 					GetStringWithArgs(builder, cs->name, args, next_substr_case_index, game_script);
 				}

--- a/src/table/strgen_tables.h
+++ b/src/table/strgen_tables.h
@@ -30,6 +30,7 @@ struct CmdStruct {
 };
 
 extern void EmitSingleChar(Buffer *buffer, char *buf, int value);
+extern void EmitCargoList(Buffer *buffer, char *buf, int value);
 extern void EmitPlural(Buffer *buffer, char *buf, int value);
 extern void EmitGender(Buffer *buffer, char *buf, int value);
 
@@ -77,7 +78,7 @@ static const CmdStruct _cmd_structs[] = {
 	{"CARGO_LONG",        EmitSingleChar, SCC_CARGO_LONG,         2,  1, C_NONE | C_GENDER},
 	{"CARGO_SHORT",       EmitSingleChar, SCC_CARGO_SHORT,        2,  1, C_NONE | C_GENDER}, // short cargo description, only ### tons, or ### litres
 	{"CARGO_TINY",        EmitSingleChar, SCC_CARGO_TINY,         2,  1, C_NONE}, // tiny cargo description with only the amount, not a specifier for the amount or the actual cargo name
-	{"CARGO_LIST",        EmitSingleChar, SCC_CARGO_LIST,         1, -1, C_CASE},
+	{"CARGO_LIST",        EmitCargoList,  0,                      1, -1, C_CASE},
 	{"POWER",             EmitSingleChar, SCC_POWER,              1,  0, C_NONE},
 	{"POWER_TO_WEIGHT",   EmitSingleChar, SCC_POWER_TO_WEIGHT,    1,  0, C_NONE},
 	{"VOLUME_LONG",       EmitSingleChar, SCC_VOLUME_LONG,        1,  0, C_NONE},

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1258,7 +1258,7 @@ uint ShowRefitOptionsList(int left, int right, int y, EngineID engine)
 			cmask ^= lmask;
 			SetDParam(0, STR_PURCHASE_INFO_ALL_BUT);
 		} else {
-			SetDParam(0, STR_JUST_CARGO_LIST);
+			SetDParam(0, STR_PURCHASE_INFO_CARGO_LIST);
 		}
 		SetDParam(1, cmask);
 	}


### PR DESCRIPTION
## Motivation / Problem

#11379 removed the and/or in the translation for: "Station now accepts X and Y" or "Station no longer accepts X or Y", and replaced it with commas. This PR aims to reintroduce the possibility to use 'or' or 'and' by making the separator of the `{CARGO_LIST}` command configurable by the translator.


## Description

Changes `{CARGO_LIST}` to `{CARGO_LIST last_separator normal_separator}`. In this last_separator and normal_separator are by default ", " and can be overridden. If you want to override the normal_separator, you must also set the last_separator.

When building a list of cargoes, the last separator will be used between the last two cargoes. The normal separator will be used between any earlier pairs. So practically `Cargo 1 normal separator Cargo 2 normal separator Cargo 3 last separator Cargo 4`. When there is only one cargo, no separator is used.


## Limitations

Not sure whether this changes affects the translator in any way or form. I also do not have an idea how to fix that, so if that's needed any help would be greatly appreciated.
The linguistics of when to use 'and' or 'or' in the strings might not be 100% right. It depends a bit on the actual meaning.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
