### PR TITLE
Fix f49ffaa: Use DateAtStartOfYear() to calculate max timetable start date

### DIFF
--- a/src/timetable_cmd.cpp
+++ b/src/timetable_cmd.cpp
@@ -305,7 +305,7 @@ CommandCost CmdSetTimetableStart(DoCommandFlag flags, VehicleID veh_id, bool tim
 
 	/* Don't let a timetable start more than 15 years into the future or 1 year in the past. */
 	if (start_date < 0 || start_date > CalendarTime::MAX_DATE) return CMD_ERROR;
-	if (start_date - TimerGameCalendar::date > static_cast<int32_t>(MAX_TIMETABLE_START_YEARS) * CalendarTime::DAYS_IN_LEAP_YEAR) return CMD_ERROR;
+	if (start_date - TimerGameCalendar::date > TimerGameCalendar::DateAtStartOfYear(MAX_TIMETABLE_START_YEARS)) return CMD_ERROR;
 	if (TimerGameCalendar::date - start_date > CalendarTime::DAYS_IN_LEAP_YEAR) return CMD_ERROR;
 	if (timetable_all && !v->orders->IsCompleteTimetable()) return CommandCost(STR_ERROR_TIMETABLE_INCOMPLETE);
 	if (timetable_all && start_date + total_duration / Ticks::DAY_TICKS > CalendarTime::MAX_DATE) return CMD_ERROR;


### PR DESCRIPTION
## Motivation / Problem

In #11372 I reverted a change to how vehicle ages were calculated.

Another file snuck in somehow and I also accidentally reverted an improvement to how the max timetable start date was calculated.

## Description

Un-revert the reversion, so that timetable start date uses `DateAtStartOfYear()` instead of multiplying by DAYS_IN_LEAP_YEAR. This is calculating the current date plus 15 years in the future, so the leap year precision error does not matter.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
