### PR TITLE
Fix #11392: Make neutral stations behave as industry-exclusivity company.

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1635,10 +1635,14 @@ static void LoadUnloadVehicle(Vehicle *front)
 	StationID last_visited = front->last_station_visited;
 	Station *st = Station::Get(last_visited);
 
+	/* If this is a neutral station, check its industry for exclusivity. */
+	bool can_load   = front->owner == st->GetExclusivityConsumer();
+	bool can_unload = front->owner == st->GetExclusivitySupplier();
+
 	StationIDStack next_station = front->GetNextStoppingStation();
 	bool use_autorefit = front->current_order.IsRefit() && front->current_order.GetRefitCargo() == CT_AUTO_REFIT;
 	CargoArray consist_capleft{};
-	if (_settings_game.order.improved_load && use_autorefit ?
+	if (can_load && _settings_game.order.improved_load && use_autorefit ?
 			front->cargo_payment == nullptr : (front->current_order.GetLoadType() & OLFB_FULL_LOAD) != 0) {
 		ReserveConsist(st, front,
 				(use_autorefit && front->load_unload_ticks != 0) ? &consist_capleft : nullptr,
@@ -1680,7 +1684,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 
 		GoodsEntry *ge = &st->goods[v->cargo_type];
 
-		if (HasBit(v->vehicle_flags, VF_CARGO_UNLOADING) && (front->current_order.GetUnloadType() & OUFB_NO_UNLOAD) == 0) {
+		if (can_unload && HasBit(v->vehicle_flags, VF_CARGO_UNLOADING) && (front->current_order.GetUnloadType() & OUFB_NO_UNLOAD) == 0) {
 			uint cargo_count = v->cargo.UnloadCount();
 			uint amount_unloaded = _settings_game.order.gradual_loading ? std::min(cargo_count, GetLoadAmount(v)) : cargo_count;
 			bool remaining = false; // Are there cargo entities in this vehicle that can still be unloaded here?
@@ -1747,7 +1751,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 		}
 
 		/* Do not pick up goods when we have no-load set or loading is stopped. */
-		if (front->current_order.GetLoadType() & OLFB_NO_LOAD || HasBit(front->vehicle_flags, VF_STOP_LOADING)) continue;
+		if (!can_load || front->current_order.GetLoadType() & OLFB_NO_LOAD || HasBit(front->vehicle_flags, VF_STOP_LOADING)) continue;
 
 		/* This order has a refit, if this is the first vehicle part carrying cargo and the whole vehicle is empty, try refitting. */
 		if (front->current_order.IsRefit() && artic_part == 1) {

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1073,7 +1073,7 @@ static uint DeliverGoodsToIndustry(const Station *st, CargoID cargo_type, uint n
 		/* Check if industry temporarily refuses acceptance */
 		if (IndustryTemporarilyRefusesCargo(ind, cargo_type)) continue;
 
-		if (ind->exclusive_supplier != INVALID_OWNER && ind->exclusive_supplier != st->owner) continue;
+		if (ind->exclusive_supplier != INVALID_OWNER && ind->exclusive_supplier != st->GetExclusivitySupplier()) continue;
 
 		/* Insert the industry into _cargo_delivery_destinations, if not yet contained */
 		include(_cargo_delivery_destinations, ind);

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -430,6 +430,16 @@ void Station::RemoveFromAllNearbyLists()
 	for (Industry *i : Industry::Iterate()) { i->stations_near.erase(this); }
 }
 
+Owner Station::GetExclusivityConsumer() const
+{
+	return this->industry == nullptr || this->industry->exclusive_consumer == INVALID_OWNER ? this->owner : this->industry->exclusive_consumer;
+}
+
+Owner Station::GetExclusivitySupplier() const
+{
+	return this->industry == nullptr || this->industry->exclusive_supplier == INVALID_OWNER ? this->owner : this->industry->exclusive_supplier;
+}
+
 /**
  * Test if the given town ID is covered by our catchment area.
  * This is used when removing a house tile to determine if it was the last house tile

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -499,6 +499,9 @@ public:
 	void RemoveIndustryToDeliver(Industry *ind);
 	void RemoveFromAllNearbyLists();
 
+	Owner GetExclusivityConsumer() const;
+	Owner GetExclusivitySupplier() const;
+
 	inline bool TileIsInCatchment(TileIndex tile) const
 	{
 		return this->catchment_tiles.HasTile(tile);

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4179,7 +4179,7 @@ uint MoveGoodsToStation(CargoID type, uint amount, SourceType source_type, Sourc
 	std::vector<StationInfo> used_stations;
 
 	for (Station *st : *all_stations) {
-		if (exclusivity != INVALID_OWNER && exclusivity != st->owner) continue;
+		if (exclusivity != INVALID_OWNER && exclusivity != st->GetExclusivityConsumer()) continue;
 		if (!CanMoveGoodsToStation(st, type)) continue;
 
 		/* Avoid allocating a vector if there is only one station to significantly


### PR DESCRIPTION
## Motivation / Problem

Industry exclusivity ignores neutral stations.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

When testing station ownership for exclusivity, pretend a neutral station's owner is the same as its exclusivity consumer/supplier.

This means that goods can still be transfer between station and industry when exclusivity is setup, but this doesn't actually check who is consuming or supplying.

So we also check during (un)load that the vehicle owner matches the exclusivity company too.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This is NOT TESTED.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
