### PR TITLE
Fix: [CI] Installed (and cached) vcpkg packages are never upgraded in release-linux workflow

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -116,6 +116,9 @@ jobs:
           cd /vcpkg
           ./bootstrap-vcpkg.sh -disableMetrics
 
+          # Once installed (and cached) a package will never be upgraded unless we do it ourselves.
+          ./vcpkg upgrade --no-dry-run
+
           # Make Python3 available for other packages.
           ./vcpkg install python3
           ln -sf $(pwd)/installed/x64-linux/tools/python3/python3.[0-9][0-9] /usr/bin/python3


### PR DESCRIPTION
## Motivation / Problem
Once installed (and cached) a vcpkg package will never be upgraded.
This is not an issue for most workflows as their cache is keyed on the runner image, and the vcpkg clone never changes inside an image.
But for `release-linux` it's a different story because we always clone the latest vcpkg repository, which may have package upgrades.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Force upgrade of already installed packages before installing new ones, but only for `release-linux` workflow.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Build might fail when vcpkg "breaks" a package (happens sometimes)
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
