### PR TITLE
Fix: allow same length server password in the UI

### DIFF
--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1037,7 +1037,7 @@ struct NetworkStartServerWindow : public Window {
 			case WID_NSS_SETPWD: // Set password button
 				this->widget_id = WID_NSS_SETPWD;
 				SetDParamStr(0, _settings_client.network.server_password);
-				ShowQueryString(STR_JUST_RAW_STRING, STR_NETWORK_START_SERVER_SET_PASSWORD, 20, this, CS_ALPHANUMERAL, QSF_NONE);
+				ShowQueryString(STR_JUST_RAW_STRING, STR_NETWORK_START_SERVER_SET_PASSWORD, NETWORK_PASSWORD_LENGTH, this, CS_ALPHANUMERAL, QSF_NONE);
 				break;
 
 			case WID_NSS_CONNTYPE_BTN: // Connection type


### PR DESCRIPTION
## Motivation / Problem

When starting a server through the UI, the maximum length of the password you can set in the dialogue is 19 characters.  However, the password via the settings or console may be 32 characters.


## Description

Replace `20` with `NETWORK_PASSWORD_LENGTH`.


## Limitations

It's still inconsistent when a message is shown to the user that the administrators might read the password. Now it is when setting a company password, or when being asked for the server's and company's password.
Adding the warning when setting the server's password used to be in this PR, but that seems to not be liked.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
