### PR TITLE
Fix #11413: Sort industry list by production order was incorrect.

### DIFF
--- a/src/industry.h
+++ b/src/industry.h
@@ -150,23 +150,27 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 		return std::find_if(std::begin(this->accepted), std::end(this->accepted), [&cargo](const auto &a) { return a.cargo == cargo; });
 	}
 
-	/** Test if this industry accepts any cargo.
+	/**
+	 * Test if this industry accepts any cargo.
 	 * @return true iff the industry accepts any cargo.
 	 */
 	bool IsCargoAccepted() const { return std::any_of(std::begin(this->accepted), std::end(this->accepted), [](const auto &a) { return IsValidCargoID(a.cargo); }); }
 
-	/** Test if this industry produces any cargo.
+	/**
+	 * Test if this industry produces any cargo.
 	 * @return true iff the industry produces any cargo.
 	 */
 	bool IsCargoProduced() const { return std::any_of(std::begin(this->produced), std::end(this->produced), [](const auto &p) { return IsValidCargoID(p.cargo); }); }
 
-	/** Test if this industry accepts a specific cargo.
+	/**
+	 * Test if this industry accepts a specific cargo.
 	 * @param cargo Cargo type to test.
 	 * @return true iff the industry accepts the given cargo type.
 	 */
 	bool IsCargoAccepted(CargoID cargo) const { return std::any_of(std::begin(this->accepted), std::end(this->accepted), [&cargo](const auto &a) { return a.cargo == cargo; }); }
 
-	/** Test if this industry produces a specific cargo.
+	/**
+	 * Test if this industry produces a specific cargo.
 	 * @param cargo Cargo type to test.
 	 * @return true iff the industry produces the given cargo types.
 	 */

--- a/src/industry.h
+++ b/src/industry.h
@@ -138,12 +138,33 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 		return IsTileType(tile, MP_INDUSTRY) && GetIndustryIndex(tile) == this->index;
 	}
 
+	/**
+	 * Get produced cargo slot for a specific cargo type.
+	 * @param cargo CargoID to find.
+	 * @return Iterator pointing to produced cargo slot if it exists, or the end iterator.
+	 */
 	inline ProducedCargoArray::iterator GetCargoProduced(CargoID cargo)
 	{
 		if (!IsValidCargoID(cargo)) return std::end(this->produced);
 		return std::find_if(std::begin(this->produced), std::end(this->produced), [&cargo](const auto &p) { return p.cargo == cargo; });
 	}
 
+	/**
+	 * Get produced cargo slot for a specific cargo type (const-variant).
+	 * @param cargo CargoID to find.
+	 * @return Iterator pointing to produced cargo slot if it exists, or the end iterator.
+	 */
+	inline ProducedCargoArray::const_iterator GetCargoProduced(CargoID cargo) const
+	{
+		if (!IsValidCargoID(cargo)) return std::end(this->produced);
+		return std::find_if(std::begin(this->produced), std::end(this->produced), [&cargo](const auto &p) { return p.cargo == cargo; });
+	}
+
+	/**
+	 * Get accepted cargo slot for a specific cargo type.
+	 * @param cargo CargoID to find.
+	 * @return Iterator pointing to accepted cargo slot if it exists, or the end iterator.
+	 */
 	inline AcceptedCargoArray::iterator GetCargoAccepted(CargoID cargo)
 	{
 		if (!IsValidCargoID(cargo)) return std::end(this->accepted);

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1509,14 +1509,16 @@ protected:
 		if (filter == CF_NONE) return IndustryTypeSorter(a, b);
 
 		uint prod_a = 0, prod_b = 0;
-		for (auto ita = std::begin(a->produced), itb = std::begin(b->produced); ita != std::end(a->produced) && itb != std::end(b->produced); ++ita, ++itb) {
-			if (filter == CF_ANY) {
-				if (IsValidCargoID(ita->cargo)) prod_a += ita->history[LAST_MONTH].production;
-				if (IsValidCargoID(itb->cargo)) prod_b += ita->history[LAST_MONTH].production;
-			} else {
-				if (ita->cargo == filter) prod_a += ita->history[LAST_MONTH].production;
-				if (itb->cargo == filter) prod_b += itb->history[LAST_MONTH].production;
+		if (filter == CF_ANY) {
+			for (const auto &pa : a->produced) {
+				if (IsValidCargoID(pa.cargo)) prod_a += pa.history[LAST_MONTH].production;
 			}
+			for (const auto &pb : b->produced) {
+				if (IsValidCargoID(pb.cargo)) prod_b += pb.history[LAST_MONTH].production;
+			}
+		} else {
+			if (auto ita = a->GetCargoProduced(filter); ita != std::end(a->produced)) prod_a = ita->history[LAST_MONTH].production;
+			if (auto itb = b->GetCargoProduced(filter); itb != std::end(b->produced)) prod_b = itb->history[LAST_MONTH].production;
 		}
 		int r = prod_a - prod_b;
 


### PR DESCRIPTION
## Motivation / Problem

As per #11413, sorting the industry list by production order is incorrectly sorted.

This was due to a single incorrect character. Comparing a with a instead of a with b.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Fix by comparing a with b as intended.

Additionally the code is rewritten to no longer be prone to this mistake, and is more efficient when a cargo filter specified.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
