### PR TITLE
Codechange: Call Widget::SetDirty/SetLowered directly.

### DIFF
--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -438,9 +438,9 @@ void ShowDropDownList(Window *w, DropDownList &&list, int selected, int button, 
 	if ((nwi->type & WWT_MASK) == NWID_BUTTON_DROPDOWN) {
 		nwi->disp_flags |= ND_DROPDOWN_ACTIVE;
 	} else {
-		w->LowerWidget(button);
+		nwi->SetLowered(true);
 	}
-	w->SetWidgetDirty(button);
+	nwi->SetDirty(w);
 
 	if (width != 0) {
 		if (_current_text_dir == TD_RTL) {

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -228,7 +228,7 @@ void Window::DisableAllWidgetHighlight()
 
 		if (nwid->IsHighlighted()) {
 			nwid->SetHighlighted(TC_INVALID);
-			this->SetWidgetDirty(i);
+			nwid->SetDirty(this);
 		}
 	}
 
@@ -248,7 +248,7 @@ void Window::SetWidgetHighlight(byte widget_index, TextColour highlighted_colour
 	if (nwid == nullptr) return;
 
 	nwid->SetHighlighted(highlighted_colour);
-	this->SetWidgetDirty(widget_index);
+	nwid->SetDirty(this);
 
 	if (highlighted_colour != TC_INVALID) {
 		/* If we set a highlight, the window has a highlight */


### PR DESCRIPTION
## Motivation / Problem

In some places we have a widget object, but mark it dirty/lowered by index.

In these instances we already have the widget to hand, so don't need to look it up by index again.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Call Widget::SetDirty/SetLowered directly as appropriate.

This avoids a couple of steps of indirection.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
