### PR TITLE
Cleanup: missing spaces before continuation * in some comments

### DIFF
--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -457,7 +457,7 @@ void IConsoleGUIPrint(TextColour colour_code, const std::string &str)
  * all lines in the buffer are aged by one. When a line exceeds both the maximum position
  * and also the maximum age, it gets removed.
  * @return true if any lines were removed
-*/
+ */
 static bool TruncateBuffer()
 {
 	bool need_truncation = false;

--- a/src/core/bitmath_func.hpp
+++ b/src/core/bitmath_func.hpp
@@ -324,7 +324,7 @@ static inline T ROR(const T x, const uint8_t n)
  * Iterable ensemble of each set bit in a value.
  * @tparam Tbitpos Type of the position variable.
  * @tparam Tbitset Type of the bitset value.
-*/
+ */
 template <typename Tbitpos = uint, typename Tbitset = uint>
 struct SetBitIterator {
 	struct Iterator {

--- a/src/core/kdtree.hpp
+++ b/src/core/kdtree.hpp
@@ -447,14 +447,14 @@ public:
 	}
 
 	/**
-	* Find all items contained within the given rectangle.
-	* @note Start coordinates are inclusive, end coordinates are exclusive. x1<x2 && y1<y2 is a precondition.
-	* @param x1 Start first coordinate, points found are greater or equals to this.
-	* @param y1 Start second coordinate, points found are greater or equals to this.
-	* @param x2 End first coordinate, points found are less than this.
-	* @param y2 End second coordinate, points found are less than this.
-	* @param outputter Callback used to return values from the search.
-	*/
+	 * Find all items contained within the given rectangle.
+	 * @note Start coordinates are inclusive, end coordinates are exclusive. x1<x2 && y1<y2 is a precondition.
+	 * @param x1 Start first coordinate, points found are greater or equals to this.
+	 * @param y1 Start second coordinate, points found are greater or equals to this.
+	 * @param x2 End first coordinate, points found are less than this.
+	 * @param y2 End second coordinate, points found are less than this.
+	 * @param outputter Callback used to return values from the search.
+	 */
 	template <typename Outputter>
 	void FindContained(CoordT x1, CoordT y1, CoordT x2, CoordT y2, const Outputter &outputter) const
 	{

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -719,7 +719,7 @@ void ScanScenarios()
 /**
  * Constructs FiosNumberedSaveName. Initial number is the most recent save, or -1 if not found.
  * @param prefix The prefix to use to generate a filename.
-*/
+ */
 FiosNumberedSaveName::FiosNumberedSaveName(const std::string &prefix) : prefix(prefix), number(-1)
 {
 	static std::optional<std::string> _autosave_path;
@@ -756,7 +756,7 @@ FiosNumberedSaveName::FiosNumberedSaveName(const std::string &prefix) : prefix(p
 /**
  * Generate a savegame name and number according to _settings_client.gui.max_num_autosaves.
  * @return A filename in format "<prefix><number>.sav".
-*/
+ */
 std::string FiosNumberedSaveName::Filename()
 {
 	if (++this->number >= _settings_client.gui.max_num_autosaves) this->number = 0;
@@ -766,7 +766,7 @@ std::string FiosNumberedSaveName::Filename()
 /**
  * Generate an extension for a savegame name.
  * @return An extension in format "-<prefix>.sav".
-*/
+ */
 std::string FiosNumberedSaveName::Extension()
 {
 	return fmt::format("-{}.sav", this->prefix);

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -1,9 +1,9 @@
 /*
-* This file is part of OpenTTD.
-* OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
-* OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-* See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
-*/
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 /** @file framerate_gui.cpp GUI for displaying framerate/game speed information. */
 
@@ -802,7 +802,7 @@ struct FrametimeGraphWindow : Window {
 	void SelectHorizontalScale(TimingMeasurement range)
 	{
 		/* Determine horizontal scale based on period covered by 60 points
-		* (slightly less than 2 seconds at full game speed) */
+		 * (slightly less than 2 seconds at full game speed) */
 		struct ScaleDef { TimingMeasurement range; int scale; };
 		static const ScaleDef hscales[] = {
 			{ 120, 60 },

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -1,9 +1,9 @@
 /*
-* This file is part of OpenTTD.
-* OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
-* OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-* See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
-*/
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 /** @file framerate_type.h
  * Types for recording game performance data.

--- a/src/music/midi.h
+++ b/src/music/midi.h
@@ -1,9 +1,9 @@
 /*
-* This file is part of OpenTTD.
-* OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
-* OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-* See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
-*/
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 /* @file midi.h Declarations for MIDI data */
 

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -1,9 +1,9 @@
 /*
-* This file is part of OpenTTD.
-* OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
-* OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-* See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
-*/
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 /* @file midifile.cpp Parser for standard MIDI files */
 

--- a/src/music/midifile.hpp
+++ b/src/music/midifile.hpp
@@ -1,9 +1,9 @@
 /*
-* This file is part of OpenTTD.
-* OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
-* OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-* See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
-*/
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 /* @file midifile.hpp Parser for standard MIDI files */
 

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -171,9 +171,9 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::CloseConnection(NetworkRecvSta
 		this->SendPackets(true);
 
 		/* Wait a number of ticks so our leave message can reach the server.
-		* This is especially needed for Windows servers as they seem to get
-		* the "socket is closed" message before receiving our leave message,
-		* which would trigger the server to close the connection as well. */
+		 * This is especially needed for Windows servers as they seem to get
+		 * the "socket is closed" message before receiving our leave message,
+		 * which would trigger the server to close the connection as well. */
 		CSleep(3 * MILLISECONDS_PER_TICK);
 	}
 

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -219,7 +219,7 @@ void ClientNetworkContentSocketHandler::RequestContentList(ContentType type)
 	p->Send_string("patchpack"); // Or what-ever the name of your patchpack is.
 	p->Send_string(_openttd_content_version_patchpack);
 
-	*/
+	 */
 
 	this->SendPacket(p);
 }

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -3591,12 +3591,12 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 							it.ti.y = (int8_t)GB(it.ti.y, 0, 8);
 
 							/* When there were only 256x256 maps, TileIndex was a uint16_t and
-								* it.ti was just a TileIndexDiff that was added to it.
-								* As such negative "x" values were shifted into the "y" position.
-								*   x = -1, y = 1 -> x = 255, y = 0
-								* Since GRF version 8 the position is interpreted as pair of independent int8.
-								* For GRF version < 8 we need to emulate the old shifting behaviour.
-								*/
+							 * it.ti was just a TileIndexDiff that was added to it.
+							 * As such negative "x" values were shifted into the "y" position.
+							 *   x = -1, y = 1 -> x = 255, y = 0
+							 * Since GRF version 8 the position is interpreted as pair of independent int8.
+							 * For GRF version < 8 we need to emulate the old shifting behaviour.
+							 */
 							if (_cur.grffile->grf_version < 8 && it.ti.x < 0) it.ti.y += 1;
 						}
 					}
@@ -9348,8 +9348,8 @@ static void FinaliseIndustriesArray()
 
 			StringID strid;
 			/* process the conversion of text at the end, so to be sure everything will be fine
-				* and available.  Check if it does not return undefind marker, which is a very good sign of a
-				* substitute industry who has not changed the string been examined, thus using it as such */
+			 * and available.  Check if it does not return undefind marker, which is a very good sign of a
+			 * substitute industry who has not changed the string been examined, thus using it as such */
 			strid = GetGRFStringID(indsp->grf_prop.grffile->grfid, indsp->name);
 			if (strid != STR_UNDEFINED) indsp->name = strid;
 
@@ -9367,7 +9367,7 @@ static void FinaliseIndustriesArray()
 
 			if (indsp->station_name != STR_NULL) {
 				/* STR_NULL (0) can be set by grf.  It has a meaning regarding assignation of the
-					* station's name. Don't want to lose the value, therefore, do not process. */
+				 * station's name. Don't want to lose the value, therefore, do not process. */
 				strid = GetGRFStringID(indsp->grf_prop.grffile->grfid, indsp->station_name);
 				if (strid != STR_UNDEFINED) indsp->station_name = strid;
 			}

--- a/src/newgrf_roadtype.h
+++ b/src/newgrf_roadtype.h
@@ -21,12 +21,12 @@ struct RoadTypeScopeResolver : public ScopeResolver {
 	const RoadTypeInfo *rti;
 
 	/**
-	* Constructor of the roadtype scope resolvers.
-	* @param ro Surrounding resolver.
-	* @param rti Associated RoadTypeInfo.
-	* @param tile %Tile containing the track. For track on a bridge this is the southern bridgehead.
-	* @param context Are we resolving sprites for the upper halftile, or on a bridge?
-	*/
+	 * Constructor of the roadtype scope resolvers.
+	 * @param ro Surrounding resolver.
+	 * @param rti Associated RoadTypeInfo.
+	 * @param tile %Tile containing the track. For track on a bridge this is the southern bridgehead.
+	 * @param context Are we resolving sprites for the upper halftile, or on a bridge?
+	 */
 	RoadTypeScopeResolver(ResolverObject &ro, const RoadTypeInfo *rti, TileIndex tile, TileContext context)
 		: ScopeResolver(ro), tile(tile), context(context), rti(rti)
 	{

--- a/src/os/unix/font_unix.cpp
+++ b/src/os/unix/font_unix.cpp
@@ -79,8 +79,8 @@ FT_Error GetFontByFaceName(const char *font_name, FT_Face *face)
 				if (!font_style.empty() && !StrEqualsIgnoreCase(font_style, (char *)style)) continue;
 
 				/* Font config takes the best shot, which, if the family name is spelled
-					* wrongly a 'random' font, so check whether the family name is the
-					* same as the supplied name */
+				 * wrongly a 'random' font, so check whether the family name is the
+				 * same as the supplied name */
 				if (StrEqualsIgnoreCase(font_family, (char *)family)) {
 					err = FT_New_Face(_library, (char *)file, index, face);
 				}

--- a/src/os/windows/string_uniscribe.h
+++ b/src/os/windows/string_uniscribe.h
@@ -28,21 +28,21 @@ public:
 	static const bool SUPPORTS_RTL = true;
 
 	/**
-	* Get the actual ParagraphLayout for the given buffer.
-	* @param buff The begin of the buffer.
-	* @param buff_end The location after the last element in the buffer.
-	* @param fontMapping THe mapping of the fonts.
-	* @return The ParagraphLayout instance.
-	*/
+	 * Get the actual ParagraphLayout for the given buffer.
+	 * @param buff The begin of the buffer.
+	 * @param buff_end The location after the last element in the buffer.
+	 * @param fontMapping THe mapping of the fonts.
+	 * @return The ParagraphLayout instance.
+	 */
 	static ParagraphLayouter *GetParagraphLayout(CharType *buff, CharType *buff_end, FontMap &fontMapping);
 
 	/**
-	* Append a wide character to the internal buffer.
-	* @param buff        The buffer to append to.
-	* @param buffer_last The end of the buffer.
-	* @param c           The character to add.
-	* @return The number of buffer spaces that were used.
-	*/
+	 * Append a wide character to the internal buffer.
+	 * @param buff        The buffer to append to.
+	 * @param buffer_last The end of the buffer.
+	 * @param c           The character to add.
+	 * @return The number of buffer spaces that were used.
+	 */
 	static size_t AppendToBuffer(CharType *buff, const CharType *buffer_last, char32_t c)
 	{
 		assert(buff < buffer_last);

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -31,7 +31,7 @@
  * If changing the call paths into the scripting engine, define this symbol to enable full debugging of allocations.
  * This lets you track whether the allocator context is being switched correctly in all call paths.
 #define SCRIPT_DEBUG_ALLOCATIONS
-*/
+ */
 
 struct ScriptAllocator {
 	size_t allocated_size;   ///< Sum of allocated data size

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -413,7 +413,7 @@ size_t OneOfManySettingDesc::ParseValue(const char *str) const
 {
 	size_t r = OneOfManySettingDesc::ParseSingleValue(str, strlen(str), this->many);
 	/* if the first attempt of conversion from string to the appropriate value fails,
-		* look if we have defined a converter from old value to new value. */
+	 * look if we have defined a converter from old value to new value. */
 	if (r == (size_t)-1 && this->many_cnvt != nullptr) r = this->many_cnvt(str);
 	if (r != (size_t)-1) return r; // and here goes converted value
 

--- a/src/sound/xaudio2_s.cpp
+++ b/src/sound/xaudio2_s.cpp
@@ -41,9 +41,9 @@ typedef HRESULT(__stdcall *API_XAudio2Create)(_Outptr_ IXAudio2** ppXAudio2, UIN
 static FSoundDriver_XAudio2 iFSoundDriver_XAudio2;
 
 /**
-* Implementation of the IXAudio2VoiceCallback interface.
-* Provides buffered audio to XAudio2 from the OpenTTD mixer.
-*/
+ * Implementation of the IXAudio2VoiceCallback interface.
+ * Provides buffered audio to XAudio2 from the OpenTTD mixer.
+ */
 class StreamingVoiceContext : public IXAudio2VoiceCallback
 {
 private:
@@ -132,12 +132,12 @@ static HRESULT CreateXAudio(API_XAudio2Create xAudio2Create)
 }
 
 /**
-* Initialises the XAudio2 driver.
-*
-* @param parm Driver parameters.
-* @return An error message if unsuccessful, or nullptr otherwise.
-*
-*/
+ * Initialises the XAudio2 driver.
+ *
+ * @param parm Driver parameters.
+ * @return An error message if unsuccessful, or nullptr otherwise.
+ *
+ */
 const char *SoundDriver_XAudio2::Start(const StringList &parm)
 {
 	HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
@@ -261,8 +261,8 @@ const char *SoundDriver_XAudio2::Start(const StringList &parm)
 }
 
 /**
-* Terminates the XAudio2 driver.
-*/
+ * Terminates the XAudio2 driver.
+ */
 void SoundDriver_XAudio2::Stop()
 {
 	// Clean up XAudio2

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -279,7 +279,7 @@ struct TerraformToolbarWindow : Window {
 				case DDSP_BUILD_OBJECT:
 					if (!_settings_game.construction.freeform_edges) {
 						/* When end_tile is MP_VOID, the error tile will not be visible to the
-							* user. This happens when terraforming at the southern border. */
+						 * user. This happens when terraforming at the southern border. */
 						if (TileX(end_tile) == Map::MaxX()) end_tile += TileDiffXY(-1, 0);
 						if (TileY(end_tile) == Map::MaxY()) end_tile += TileDiffXY(0, -1);
 					}

--- a/src/tests/test_script_admin.cpp
+++ b/src/tests/test_script_admin.cpp
@@ -51,7 +51,7 @@ static std::optional<std::string> TestScriptAdminMakeJSON(std::string_view squir
 {
 	auto vm = sq_open(1024);
 	/* sq_compile creates a closure with our snipper, which is a table.
-		* Add "return " to get the table on the stack. */
+	 * Add "return " to get the table on the stack. */
 	std::string buffer = fmt::format("return {}", squirrel);
 
 	/* Insert an (empty) class for testing. */

--- a/src/timer/timer_game_calendar.h
+++ b/src/timer/timer_game_calendar.h
@@ -106,10 +106,10 @@ public:
 	static void SetDate(Date date, DateFract fract);
 
 	/**
-	* Calculate the year of a given date.
-	* @param date The date to consider.
-	* @return the year.
-	*/
+	 * Calculate the year of a given date.
+	 * @param date The date to consider.
+	 * @return the year.
+	 */
 	static constexpr Year DateToYear(Date date)
 	{
 		/* Hardcode the number of days in a year because we can't access CalendarTime from here. */
@@ -117,10 +117,10 @@ public:
 	}
 
 	/**
-	* Calculate the date of the first day of a given year.
-	* @param year the year to get the first day of.
-	* @return the date.
-	*/
+	 * Calculate the date of the first day of a given year.
+	 * @param year the year to get the first day of.
+	 * @return the date.
+	 */
 	static constexpr Date DateAtStartOfYear(Year year)
 	{
 		int32_t year_as_int = static_cast<int32_t>(year);

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1609,7 +1609,7 @@ void Vehicle::UpdatePosition()
 /**
  * Update the bounding box co-ordinates of the vehicle
  * @param update_cache Update the cached values for previous co-ordinate values
-*/
+ */
 void Vehicle::UpdateBoundingBoxCoordinates(bool update_cache) const
 {
 	Rect new_coord;

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -336,7 +336,7 @@ void VideoDriver_Cocoa::GameSizeChanged()
 	::GameSizeChanged();
 
 	/* We need to store the window size as non-Retina size in
-	* the config file to get same windows size on next start. */
+	 * the config file to get same windows size on next start. */
 	_cur_resolution.width = [ this->cocoaview frame ].size.width;
 	_cur_resolution.height = [ this->cocoaview frame ].size.height;
 }

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1391,8 +1391,8 @@ static void ViewportAddKdtreeSigns(DrawPixelInfo *dpi)
 				const Sign *si = Sign::Get(item.id.sign);
 
 				/* Don't draw if sign is owned by another company and competitor signs should be hidden.
-				* Note: It is intentional that also signs owned by OWNER_NONE are hidden. Bankrupt
-				* companies can leave OWNER_NONE signs after them. */
+				 * Note: It is intentional that also signs owned by OWNER_NONE are hidden. Bankrupt
+				 * companies can leave OWNER_NONE signs after them. */
 				if (!show_competitors && _local_company != si->owner && si->owner != OWNER_DEITY) break;
 
 				signs.push_back(si);

--- a/src/viewport_kdtree.h
+++ b/src/viewport_kdtree.h
@@ -1,9 +1,9 @@
 /*
-* This file is part of OpenTTD.
-* OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
-* OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-* See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
-*/
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 /** @file town_kdtree.h Declarations for accessing the k-d tree of towns */
 


### PR DESCRIPTION
## Motivation / Problem

Reviewing 11412 i saw some coding style mishap that happens often when re-indenting. The missing space before the continuation '*' is multi line comments.


## Description

Add the space, or occasionally replace a tab with a space.
Practically it makes sure that `grep -n -P -R "^\t*\*[ /]" src|grep -P -v "3rdparty/(fmt|opengl|nlohmann)"` returns nothing.

## Limitations

The commit checker does not check for this (yet?)


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
