### PR TITLE
Codechange: Add unit test to check that NWidgetPart lists are properly closed.

### DIFF
--- a/src/tests/test_window_desc.cpp
+++ b/src/tests/test_window_desc.cpp
@@ -47,3 +47,29 @@ TEST_CASE("WindowDesc - ini_key validity")
 
 	CHECK((has_widget == has_inikey));
 }
+
+/**
+ * Test if a NWidgetTree is properly closed, meaning the number of container-type parts matches the number of
+ * EndContainer() parts.
+ * @param nwid_begin Pointer to beginning of nested widget parts.
+ * @param nwid_end Pointer to ending of nested widget parts.
+ * @return True iff nested tree is properly closed.
+ */
+static bool IsNWidgetTreeClosed(const NWidgetPart *nwid_begin, const NWidgetPart *nwid_end)
+{
+	int depth = 0;
+	for (; nwid_begin < nwid_end; ++nwid_begin) {
+		if (IsContainerWidgetType(nwid_begin->type)) ++depth;
+		if (nwid_begin->type == WPT_ENDCONTAINER) --depth;
+	}
+	return depth == 0;
+}
+
+TEST_CASE("WindowDesc - NWidgetParts properly closed")
+{
+	const WindowDesc *window_desc = GENERATE(from_range(std::begin(*_window_descs), std::end(*_window_descs)));
+
+	INFO(fmt::format("{}:{}", window_desc->file, window_desc->line));
+
+	CHECK(IsNWidgetTreeClosed(window_desc->nwid_begin, window_desc->nwid_end));
+}

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -3234,6 +3234,17 @@ static const NWidgetPart *MakeNWidget(const NWidgetPart *nwid_begin, const NWidg
 }
 
 /**
+ * Test if WidgetType is a container widget.
+ * @param tp WidgetType to test.
+ * @return True iff WidgetType is a container widget.
+ */
+bool IsContainerWidgetType(WidgetType tp)
+{
+	return tp == NWID_HORIZONTAL || tp == NWID_HORIZONTAL_LTR || tp == NWID_VERTICAL || tp == NWID_MATRIX
+		|| tp == WWT_PANEL || tp == WWT_FRAME || tp == WWT_INSET || tp == NWID_SELECTION;
+}
+
+/**
  * Build a nested widget tree by recursively filling containers with nested widgets read from their parts.
  * @param nwid_begin Pointer to beginning of nested widget parts.
  * @param nwid_end Pointer to ending of nested widget parts.
@@ -3259,9 +3270,7 @@ static const NWidgetPart *MakeWidgetTree(const NWidgetPart *nwid_begin, const NW
 		if (sub_widget == nullptr) break;
 
 		/* If sub-widget is a container, recursively fill that container. */
-		WidgetType tp = sub_widget->type;
-		if (fill_sub && (tp == NWID_HORIZONTAL || tp == NWID_HORIZONTAL_LTR || tp == NWID_VERTICAL || tp == NWID_MATRIX
-							|| tp == WWT_PANEL || tp == WWT_FRAME || tp == WWT_INSET || tp == NWID_SELECTION)) {
+		if (fill_sub && IsContainerWidgetType(sub_widget->type)) {
 			NWidgetBase *sub_ptr = sub_widget;
 			nwid_begin = MakeWidgetTree(nwid_begin, nwid_end, &sub_ptr, biggest_index);
 		}

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -1294,6 +1294,7 @@ static inline NWidgetPart NWidgetFunction(NWidgetFunctionType *func_ptr)
 	return part;
 }
 
+bool IsContainerWidgetType(WidgetType tp);
 NWidgetContainer *MakeNWidgets(const NWidgetPart *nwid_begin, const NWidgetPart *nwid_end, int *biggest_index, NWidgetContainer *container);
 NWidgetContainer *MakeWindowNWidgetTree(const NWidgetPart *nwid_begin, const NWidgetPart *nwid_end, int *biggest_index, NWidgetStacked **shade_select);
 


### PR DESCRIPTION
## Motivation / Problem

Processing NWidgetParts into nested widget trees is quite forgiving in what it accepts, which means that layout errors can go unnoticed.

One simple error is the nested layout not being closed properly—i.e. not enough, or too many, EndContainer() parts.

This usually doesn't cause an issue but does indicate sloppiness on our part.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add a unit-test that checks NWidgetPart lists are properly closed. This is separate from processing the list into nested widgets, because it turns out to be a lot simpler to just loop through the list due to many widgets creating implied containers.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This unit-test currently fails...

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
