### PR TITLE
Fix #11402: Make string filter locale-aware.

### DIFF
--- a/src/os/macosx/string_osx.h
+++ b/src/os/macosx/string_osx.h
@@ -84,6 +84,7 @@ public:
 void MacOSResetScriptCache(FontSize size);
 void MacOSSetCurrentLocaleName(const char *iso_code);
 int MacOSStringCompare(std::string_view s1, std::string_view s2);
+int MacOSStringContains(const std::string_view str, const std::string_view value, bool case_insensitive);
 
 void MacOSRegisterExternalFont(const char *file_path);
 

--- a/src/os/windows/win32.h
+++ b/src/os/windows/win32.h
@@ -60,5 +60,6 @@ wchar_t *convert_to_fs(const std::string_view name, wchar_t *utf16_buf, size_t b
 
 void Win32SetCurrentLocaleName(const char *iso_code);
 int OTTDStringCompare(std::string_view s1, std::string_view s2);
+int Win32StringContains(const std::string_view str, const std::string_view value, bool case_insensitive);
 
 #endif /* WIN32_H */

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -1139,7 +1139,7 @@ CompanyID ScriptDebugWindow::script_debug_company = INVALID_COMPANY;
 std::string ScriptDebugWindow::break_string;
 bool ScriptDebugWindow::break_check_enabled = true;
 bool ScriptDebugWindow::case_sensitive_break_check = false;
-StringFilter ScriptDebugWindow::break_string_filter(&ScriptDebugWindow::case_sensitive_break_check);
+StringFilter ScriptDebugWindow::break_string_filter(&ScriptDebugWindow::case_sensitive_break_check, false);
 
 /** Make a number of rows with buttons for each company for the Script debug window. */
 NWidgetBase *MakeCompanyButtonRowsScriptDebug(int *biggest_index)

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -343,12 +343,12 @@ struct CaseInsensitiveCharTraits : public std::char_traits<char> {
 		return 0;
 	}
 
-	static const char *find(const char *s, int n, char a)
+	static const char *find(const char *s, size_t n, char a)
 	{
-		while (n-- > 0 && toupper(*s) != toupper(a)) {
-			++s;
+		for (; n > 0; --n, ++s) {
+			if (toupper(*s) == toupper(a)) return s;
 		}
-		return s;
+		return nullptr;
 	}
 };
 

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -39,6 +39,8 @@ void StrTrimInPlace(std::string &str);
 [[nodiscard]] int StrCompareIgnoreCase(const std::string_view str1, const std::string_view str2);
 [[nodiscard]] bool StrEqualsIgnoreCase(const std::string_view str1, const std::string_view str2);
 [[nodiscard]] int StrNaturalCompare(std::string_view s1, std::string_view s2, bool ignore_garbage_at_front = false);
+[[nodiscard]] bool StrNaturalContains(const std::string_view str, const std::string_view value);
+[[nodiscard]] bool StrNaturalContainsIgnoreCase(const std::string_view str, const std::string_view value);
 
 /** Case insensitive comparator for strings, for example for use in std::map. */
 struct CaseInsensitiveComparator {

--- a/src/stringfilter.cpp
+++ b/src/stringfilter.cpp
@@ -118,9 +118,16 @@ void StringFilter::AddLine(const char *str)
 	bool match_case = this->case_sensitive != nullptr && *this->case_sensitive;
 	for (WordState &ws : this->word_index) {
 		if (!ws.match) {
-			if ((match_case ? strstr(str, ws.start) : strcasestr(str, ws.start)) != nullptr) {
-				ws.match = true;
-				this->word_matches++;
+			if (this->locale_aware) {
+				if (match_case ? StrNaturalContains(str, ws.start) : StrNaturalContainsIgnoreCase(str, ws.start)) {
+					ws.match = true;
+					this->word_matches++;
+				}
+			} else {
+				if ((match_case ? strstr(str, ws.start) : strcasestr(str, ws.start)) != nullptr) {
+					ws.match = true;
+					this->word_matches++;
+				}
 			}
 		}
 	}

--- a/src/stringfilter_type.h
+++ b/src/stringfilter_type.h
@@ -40,13 +40,14 @@ private:
 	uint word_matches;                             ///< Summary of filter state: Number of words matched.
 
 	const bool *case_sensitive;                    ///< Match case-sensitively (usually a static variable).
+	bool locale_aware;                             ///< Match words using the current locale.
 
 public:
 	/**
 	 * Constructor for filter.
 	 * @param case_sensitive Pointer to a (usually static) variable controlling the case-sensitivity. nullptr means always case-insensitive.
 	 */
-	StringFilter(const bool *case_sensitive = nullptr) : filter_buffer(nullptr), word_matches(0), case_sensitive(case_sensitive) {}
+	StringFilter(const bool *case_sensitive = nullptr, bool locale_aware = true) : filter_buffer(nullptr), word_matches(0), case_sensitive(case_sensitive), locale_aware(locale_aware) {}
 	~StringFilter() { free(this->filter_buffer); }
 
 	void SetFilterTerm(const char *str);


### PR DESCRIPTION
## Motivation / Problem

String filters are currently not doing a locale-aware string match, which leads to issues as described in #11402 .

## Description

Use appropriate Win32/OSX/ICU functions to build a locale-aware `strstr` function, which then makes the string filter work as expected. Tested with the Russian example from the issue on all three platforms.

As locale-aware matching might not be suitable for every string filter usage, I've added an additional parameter to `StringFilter` to keep using the locale-unaware match. Currently, I've only enabled this for the script debug window break string filter.

## Limitations

There might be some other uses of `StringFilter` that should keep using the old matching.

I've only tested the Russian example from the issue report.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
