### PR TITLE
Fix cda6f24f: don't ignore binary-dir if it happens to be working-dir

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -87,6 +87,8 @@ static void FillValidSearchPaths(bool only_local_path)
 
 	std::set<std::string> seen{};
 	for (Searchpath sp = SP_FIRST_DIR; sp < NUM_SEARCHPATHS; sp++) {
+		if (sp == SP_WORKING_DIR) continue;
+
 		if (only_local_path) {
 			switch (sp) {
 				case SP_WORKING_DIR:      // Can be influence by "-c" option.
@@ -104,6 +106,13 @@ static void FillValidSearchPaths(bool only_local_path)
 			seen.insert(_searchpaths[sp]);
 			_valid_searchpaths.emplace_back(sp);
 		}
+	}
+
+	/* The working-directory is special, as it is controlled by _do_scan_working_directory.
+	 * Only add the search path if it isn't already in the set. To preserve the same order
+	 * as the enum, insert it in the front. */
+	if (IsValidSearchPath(SP_WORKING_DIR) && seen.count(_searchpaths[SP_WORKING_DIR]) == 0) {
+		_valid_searchpaths.insert(_valid_searchpaths.begin(), SP_WORKING_DIR);
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem

Emscripten (previews) broke with cda6f24f.

## Description

Some of our code ignores the `SP_WORKING_DIR` for some actions, which means that if, for example, your `SP_BINARY_DIR` is the same as your `SP_WORKING_DIR`, neither is scanned.

Instead, only add `SP_WORKING_DIR` if it is unique.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
