### PR TITLE
Codechange: Replicate cursor screen backup to chat message display, removing explicit memory management

### DIFF
--- a/src/blitter/32bpp_anim.hpp
+++ b/src/blitter/32bpp_anim.hpp
@@ -48,7 +48,6 @@ public:
 	Blitter::PaletteAnimation UsePaletteAnimation() override;
 
 	const char *GetName() override { return "32bpp-anim"; }
-	int GetBytesPerPixel() override { return 6; }
 	void PostResize() override;
 
 	/**

--- a/src/blitter/32bpp_base.hpp
+++ b/src/blitter/32bpp_base.hpp
@@ -30,7 +30,6 @@ public:
 	size_t BufferSize(uint width, uint height) override;
 	void PaletteAnimate(const Palette &palette) override;
 	Blitter::PaletteAnimation UsePaletteAnimation() override;
-	int GetBytesPerPixel() override { return 4; }
 
 	/**
 	 * Look up the colour in the current palette.

--- a/src/blitter/40bpp_anim.hpp
+++ b/src/blitter/40bpp_anim.hpp
@@ -33,7 +33,6 @@ public:
 	bool NeedsAnimationBuffer() override;
 
 	const char *GetName()  override { return "40bpp-anim"; }
-	int GetBytesPerPixel()  override { return 5; }
 
 	template <BlitterMode mode> void Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom);
 

--- a/src/blitter/8bpp_base.hpp
+++ b/src/blitter/8bpp_base.hpp
@@ -28,7 +28,6 @@ public:
 	size_t BufferSize(uint width, uint height) override;
 	void PaletteAnimate(const Palette &palette) override;
 	Blitter::PaletteAnimation UsePaletteAnimation() override;
-	int GetBytesPerPixel() override { return 1; }
 };
 
 #endif /* BLITTER_8BPP_BASE_HPP */

--- a/src/blitter/base.hpp
+++ b/src/blitter/base.hpp
@@ -199,11 +199,6 @@ public:
 	virtual const char *GetName() = 0;
 
 	/**
-	 * Get how many bytes are needed to store a pixel.
-	 */
-	virtual int GetBytesPerPixel() = 0;
-
-	/**
 	 * Post resize event
 	 */
 	virtual void PostResize() { };

--- a/src/blitter/null.hpp
+++ b/src/blitter/null.hpp
@@ -32,7 +32,6 @@ public:
 	Blitter::PaletteAnimation UsePaletteAnimation() override { return Blitter::PALETTE_ANIMATION_NONE; };
 
 	const char *GetName() override { return "null"; }
-	int GetBytesPerPixel() override { return 0; }
 };
 
 /** Factory for the blitter that does nothing. */


### PR DESCRIPTION
## Motivation / Problem / Description / Limitations

Random stuff lying around.

There are currently two ways that a part of the screen is backed up. Chat message display uses one with explicit memory management, while e.g. cursor drawing uses already existing encapsulated helpers for memory management.
Switch chat message to this, removing a tiny bit more of explicit memory management. (And incidentally remove a single-use method.)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
