### PR TITLE
Feature: Mode to display timetable in seconds

### DIFF
--- a/src/base_consist.h
+++ b/src/base_consist.h
@@ -18,8 +18,8 @@ struct BaseConsist {
 	std::string name;                   ///< Name of vehicle
 
 	/* Used for timetabling. */
-	uint32_t current_order_time;               ///< How many ticks have passed since this order started.
-	int32_t lateness_counter;                  ///< How many ticks late (or early if negative) this vehicle is.
+	TimerGameTick::Ticks current_order_time;    ///< How many ticks have passed since this order started.
+	TimerGameTick::Ticks lateness_counter;      ///< How many ticks late (or early if negative) this vehicle is.
 	TimerGameTick::TickCounter timetable_start; ///< At what tick of TimerGameTick::counter the vehicle should start its timetable.
 
 	uint16_t service_interval;            ///< The interval for (automatic) servicing; either in days or %.

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1872,7 +1872,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 		/* We loaded less cargo than possible for all cargo types and it's not full
 		 * load and we're not supposed to wait any longer: stop loading. */
 		if (!anything_unloaded && full_load_amount == 0 && reservation_left == 0 && !(front->current_order.GetLoadType() & OLFB_FULL_LOAD) &&
-				front->current_order_time >= (uint)std::max(front->current_order.GetTimetabledWait() - front->lateness_counter, 0)) {
+				front->current_order_time >= std::max(front->current_order.GetTimetabledWait() - front->lateness_counter, 0)) {
 			SetBit(front->vehicle_flags, VF_STOP_LOADING);
 		}
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -255,6 +255,10 @@ STR_UNITS_HEIGHT_IMPERIAL                                       :{DECIMAL}{NBSP}
 STR_UNITS_HEIGHT_METRIC                                         :{DECIMAL}{NBSP}m
 STR_UNITS_HEIGHT_SI                                             :{DECIMAL}{NBSP}m
 
+STR_UNITS_DAYS                                                  :{COMMA}{NBSP}day{P "" s}
+STR_UNITS_SECONDS                                               :{COMMA}{NBSP}second{P "" s}
+STR_UNITS_TICKS                                                 :{COMMA}{NBSP}tick{P "" s}
+
 # Common window strings
 STR_LIST_FILTER_TITLE                                           :{BLACK}Filter:
 STR_LIST_FILTER_OSKTITLE                                        :{BLACK}Enter one or more keywords to filter the list for
@@ -1656,8 +1660,12 @@ STR_CONFIG_SETTING_ADVANCED_VEHICLE_LISTS_HELPTEXT              :Enable usage of
 STR_CONFIG_SETTING_LOADING_INDICATORS                           :Use loading indicators: {STRING2}
 STR_CONFIG_SETTING_LOADING_INDICATORS_HELPTEXT                  :Select whether loading indicators are displayed above loading or unloading vehicles
 
-STR_CONFIG_SETTING_TIMETABLE_IN_TICKS                           :Show timetable in ticks rather than days: {STRING2}
-STR_CONFIG_SETTING_TIMETABLE_IN_TICKS_HELPTEXT                  :Show travel times in time tables in game ticks instead of days
+STR_CONFIG_SETTING_TIMETABLE_MODE                               :Time units for timetables: {STRING2}
+STR_CONFIG_SETTING_TIMETABLE_MODE_HELPTEXT                      :Select the time units used for vehicle timetables
+###length 3
+STR_CONFIG_SETTING_TIMETABLE_MODE_DAYS                          :Days
+STR_CONFIG_SETTING_TIMETABLE_MODE_SECONDS                       :Seconds
+STR_CONFIG_SETTING_TIMETABLE_MODE_TICKS                         :Ticks
 
 STR_CONFIG_SETTING_TIMETABLE_SHOW_ARRIVAL_DEPARTURE             :Show arrival and departure in timetables: {STRING2}
 STR_CONFIG_SETTING_TIMETABLE_SHOW_ARRIVAL_DEPARTURE_HELPTEXT    :Display anticipated arrival and departure times in timetables
@@ -4566,8 +4574,6 @@ STR_TIMETABLE_STAY_FOR_ESTIMATED                                :(stay for {STRI
 STR_TIMETABLE_AND_TRAVEL_FOR_ESTIMATED                          :(travel for {STRING1}, not timetabled)
 STR_TIMETABLE_STAY_FOR                                          :and stay for {STRING1}
 STR_TIMETABLE_AND_TRAVEL_FOR                                    :and travel for {STRING1}
-STR_TIMETABLE_DAYS                                              :{COMMA}{NBSP}day{P "" s}
-STR_TIMETABLE_TICKS                                             :{COMMA}{NBSP}tick{P "" s}
 
 STR_TIMETABLE_TOTAL_TIME                                        :{BLACK}This timetable will take {STRING1} to complete
 STR_TIMETABLE_TOTAL_TIME_INCOMPLETE                             :{BLACK}This timetable will take at least {STRING1} to complete (not all timetabled)
@@ -4576,10 +4582,13 @@ STR_TIMETABLE_STATUS_ON_TIME                                    :{BLACK}This veh
 STR_TIMETABLE_STATUS_LATE                                       :{BLACK}This vehicle is currently running {STRING1} late
 STR_TIMETABLE_STATUS_EARLY                                      :{BLACK}This vehicle is currently running {STRING1} early
 STR_TIMETABLE_STATUS_NOT_STARTED                                :{BLACK}This timetable has not yet started
-STR_TIMETABLE_STATUS_START_AT                                   :{BLACK}This timetable will start at {STRING1}
+STR_TIMETABLE_STATUS_START_AT_DATE                              :{BLACK}This timetable will start at {STRING1}
+STR_TIMETABLE_STATUS_START_IN_SECONDS                           :{BLACK}This timetable will start in {COMMA} seconds
 
-STR_TIMETABLE_STARTING_DATE                                     :{BLACK}Start date
-STR_TIMETABLE_STARTING_DATE_TOOLTIP                             :{BLACK}Select a date as starting point of this timetable. Ctrl+Click distributes all vehicles sharing this order evenly from the given date based on their relative order, if the order is completely timetabled
+STR_TIMETABLE_START                                             :{BLACK}Start Timetable
+STR_TIMETABLE_START_TOOLTIP                                     :{BLACK}Select when this timetable starts. Ctrl+Click evenly distributes the start of all vehicles sharing this order based on their relative order, if the order is completely timetabled
+
+STR_TIMETABLE_START_SECONDS_QUERY                               :Seconds until timetable starts
 
 STR_TIMETABLE_CHANGE_TIME                                       :{BLACK}Change Time
 STR_TIMETABLE_WAIT_TIME_TOOLTIP                                 :{BLACK}Change the amount of time that the highlighted order should take. Ctrl+Click sets the time for all orders
@@ -4603,8 +4612,10 @@ STR_TIMETABLE_EXPECTED                                          :{BLACK}Expected
 STR_TIMETABLE_SCHEDULED                                         :{BLACK}Scheduled
 STR_TIMETABLE_EXPECTED_TOOLTIP                                  :{BLACK}Switch between expected and scheduled
 
-STR_TIMETABLE_ARRIVAL                                           :A: {COLOUR}{DATE_TINY}
-STR_TIMETABLE_DEPARTURE                                         :D: {COLOUR}{DATE_TINY}
+STR_TIMETABLE_ARRIVAL_DATE                                      :A: {COLOUR}{DATE_TINY}
+STR_TIMETABLE_DEPARTURE_DATE                                    :D: {COLOUR}{DATE_TINY}
+STR_TIMETABLE_ARRIVAL_SECONDS_IN_FUTURE                         :A: {COLOUR}{COMMA} sec
+STR_TIMETABLE_DEPARTURE_SECONDS_IN_FUTURE                       :D: {COLOUR}{COMMA} sec
 
 
 # Date window (for timetable)

--- a/src/linkgraph/refresh.cpp
+++ b/src/linkgraph/refresh.cpp
@@ -233,8 +233,7 @@ void LinkRefresher::RefreshStats(const Order *cur, const Order *next)
 			 * probably far off and we'd greatly overestimate the capacity by increasing.*/
 			if (this->is_full_loading && this->vehicle->orders != nullptr &&
 					st->index == vehicle->last_station_visited &&
-					this->vehicle->orders->GetTotalDuration() >
-					(TimerGameTick::Ticks)this->vehicle->current_order_time) {
+					this->vehicle->orders->GetTotalDuration() > this->vehicle->current_order_time) {
 				uint effective_capacity = cargo_quantity * this->vehicle->load_unload_ticks;
 				if (effective_capacity > (uint)this->vehicle->orders->GetTotalDuration()) {
 					IncreaseStats(st, c, next_station, effective_capacity /

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -365,6 +365,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_STATION_RATING_CHEAT,               ///< 320  PR#11346 Add cheat to fix station ratings at 100%.
 	SLV_TIMETABLE_START_TICKS,              ///< 321  PR#11468 Convert timetable start from a date to ticks.
 	SLV_TIMETABLE_START_TICKS_FIX,          ///< 322  PR#11557 Fix for missing convert timetable start from a date to ticks.
+	SLV_TIMETABLE_TICKS_TYPE,               ///< 323  PR#11435 Convert timetable current order time to ticks.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -720,7 +720,8 @@ public:
 		SLE_CONDREF(Vehicle, next_shared,           REF_VEHICLE,                  SLV_2, SL_MAX_VERSION),
 		SLE_CONDVAR(Vehicle, group_id,              SLE_UINT16,                  SLV_60, SL_MAX_VERSION),
 
-		SLE_CONDVAR(Vehicle, current_order_time,    SLE_UINT32,                  SLV_67, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, current_order_time,    SLE_FILE_U32 | SLE_VAR_I32,  SLV_67, SLV_TIMETABLE_TICKS_TYPE),
+		SLE_CONDVAR(Vehicle, current_order_time,    SLE_INT32,                   SLV_TIMETABLE_TICKS_TYPE, SL_MAX_VERSION),
 		SLE_CONDVAR(Vehicle, last_loading_tick,     SLE_UINT64,                   SLV_LAST_LOADING_TICK, SL_MAX_VERSION),
 		SLE_CONDVAR(Vehicle, lateness_counter,      SLE_INT32,                   SLV_67, SL_MAX_VERSION),
 	};

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1803,7 +1803,7 @@ static SettingsContainer &GetSettingsTree()
 			interface->Add(new SettingEntry("gui.statusbar_pos"));
 			interface->Add(new SettingEntry("gui.prefer_teamchat"));
 			interface->Add(new SettingEntry("gui.advanced_vehicle_list"));
-			interface->Add(new SettingEntry("gui.timetable_in_ticks"));
+			interface->Add(new SettingEntry("gui.timetable_mode"));
 			interface->Add(new SettingEntry("gui.timetable_arrival_departure"));
 			interface->Add(new SettingEntry("gui.show_newgrf_name"));
 			interface->Add(new SettingEntry("gui.show_cargo_in_vehicle_lists"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -22,6 +22,7 @@
 #include "openttd.h"
 #include "rail_gui.h"
 #include "signal_type.h"
+#include "timetable.h"
 
 /* Used to validate sizes of "max" value in settings. */
 const size_t MAX_SLE_UINT8 = UINT8_MAX;
@@ -167,7 +168,7 @@ struct GUISettings {
 	SignalCycleSettings cycle_signal_types;  ///< Which signal types to cycle with the build signal tool.
 	SignalType default_signal_type;          ///< The default signal type, which is set automatically by the last signal used. Not available in Settings.
 	TimerGameCalendar::Year coloured_news_year; ///< when does newspaper become coloured?
-	bool   timetable_in_ticks;               ///< whether to show the timetable in ticks rather than days
+	TimetableMode timetable_mode;            ///< Time units for timetables: days, seconds, or ticks
 	bool   quick_goto;                       ///< Allow quick access to 'goto button' in vehicle orders window
 	bool   auto_euro;                        ///< automatically switch to euro in 2002
 	byte   drag_signals_density;             ///< many signals density

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -420,14 +420,18 @@ str      = STR_CONFIG_SETTING_ADVANCED_VEHICLE_LISTS
 strhelp  = STR_CONFIG_SETTING_ADVANCED_VEHICLE_LISTS_HELPTEXT
 strval   = STR_CONFIG_SETTING_COMPANIES_OFF
 
-[SDTC_BOOL]
-var      = gui.timetable_in_ticks
-flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
-def      = false
-str      = STR_CONFIG_SETTING_TIMETABLE_IN_TICKS
-strhelp  = STR_CONFIG_SETTING_TIMETABLE_IN_TICKS_HELPTEXT
+[SDTC_VAR]
+var      = gui.timetable_mode
+type     = SLE_UINT8
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
+def      = 0
+min      = 0
+max      = 2
+str      = STR_CONFIG_SETTING_TIMETABLE_MODE
+strhelp  = STR_CONFIG_SETTING_TIMETABLE_MODE_HELPTEXT
+strval   = STR_CONFIG_SETTING_TIMETABLE_MODE_DAYS
 post_cb  = [](auto) { InvalidateWindowClassesData(WC_VEHICLE_TIMETABLE, VIWD_MODIFY_ORDERS); }
-cat      = SC_EXPERT
+cat      = SC_ADVANCED
 
 [SDTC_BOOL]
 var      = gui.timetable_arrival_departure

--- a/src/timetable.h
+++ b/src/timetable.h
@@ -16,6 +16,12 @@
 
 static const TimerGameCalendar::Year MAX_TIMETABLE_START_YEARS = 15; ///< The maximum start date offset, in years.
 
+enum class TimetableMode : uint8_t {
+	Days,
+	Seconds,
+	Ticks,
+};
+
 TimerGameTick::TickCounter GetStartTickFromDate(TimerGameCalendar::Date start_date);
 TimerGameCalendar::Date GetDateFromStartTick(TimerGameTick::TickCounter start_tick);
 

--- a/src/timetable_cmd.cpp
+++ b/src/timetable_cmd.cpp
@@ -264,7 +264,7 @@ CommandCost CmdSetVehicleOnTime(DoCommandFlag flags, VehicleID veh, bool apply_t
 
 	if (flags & DC_EXEC) {
 		if (apply_to_group) {
-			int32_t most_late = 0;
+			TimerGameTick::Ticks most_late = 0;
 			for (Vehicle *u = v->FirstShared(); u != nullptr; u = u->NextShared()) {
 				/* A vehicle can't be late if its timetable hasn't started. */
 				if (!HasBit(v->vehicle_flags, VF_TIMETABLE_STARTED)) continue;
@@ -454,7 +454,7 @@ CommandCost CmdAutofillTimetable(DoCommandFlag flags, VehicleID veh, bool autofi
  */
 void UpdateVehicleTimetable(Vehicle *v, bool travelling)
 {
-	uint time_taken = v->current_order_time;
+	TimerGameTick::Ticks time_taken = v->current_order_time;
 
 	v->current_order_time = 0;
 
@@ -514,7 +514,7 @@ void UpdateVehicleTimetable(Vehicle *v, bool travelling)
 		 * the timetable entry like is done for road vehicles/ships.
 		 * Thus always make sure at least one tick is used between the
 		 * processing of different orders when filling the timetable. */
-		uint time_to_set = CeilDiv(std::max(time_taken, 1U), Ticks::DAY_TICKS) * Ticks::DAY_TICKS;
+		uint time_to_set = CeilDiv(std::max(time_taken, 1), Ticks::DAY_TICKS) * Ticks::DAY_TICKS;
 
 		if (travelling && (autofilling || !real_current_order->IsTravelTimetabled())) {
 			ChangeTimetable(v, v->cur_real_order_index, time_to_set, MTF_TRAVEL_TIME, autofilling);
@@ -533,7 +533,7 @@ void UpdateVehicleTimetable(Vehicle *v, bool travelling)
 
 	if (autofilling) return;
 
-	uint timetabled = travelling ? real_current_order->GetTimetabledTravel() :
+	TimerGameTick::Ticks timetabled = travelling ? real_current_order->GetTimetabledTravel() :
 			real_current_order->GetTimetabledWait();
 
 	/* Vehicles will wait at stations if they arrive early even if they are not
@@ -548,7 +548,7 @@ void UpdateVehicleTimetable(Vehicle *v, bool travelling)
 	 * shorter than the amount of ticks we are late we reduce the lateness by the
 	 * length of a full cycle till lateness is less than the length of a timetable
 	 * cycle. When the timetable isn't fully filled the cycle will be Ticks::INVALID_TICKS. */
-	if (v->lateness_counter > (int)timetabled) {
+	if (v->lateness_counter > timetabled) {
 		TimerGameTick::Ticks cycle = v->orders->GetTimetableTotalDuration();
 		if (cycle != Ticks::INVALID_TICKS && v->lateness_counter > cycle) {
 			v->lateness_counter %= cycle;

--- a/src/timetable_cmd.cpp
+++ b/src/timetable_cmd.cpp
@@ -505,16 +505,15 @@ void UpdateVehicleTimetable(Vehicle *v, bool travelling)
 	/* Before modifying waiting times, check whether we want to preserve bigger ones. */
 	if (!real_current_order->IsType(OT_CONDITIONAL) &&
 			(travelling || time_taken > real_current_order->GetWaitTime() || remeasure_wait_time)) {
-		/* Round the time taken up to the nearest day, as this will avoid
-		 * confusion for people who are timetabling in days, and can be
-		 * adjusted later by people who aren't.
+		/* Round up to the smallest unit of time commonly shown in the GUI (seconds) to avoid confusion.
+		 * Players timetabling in Ticks can adjust later.
 		 * For trains/aircraft multiple movement cycles are done in one
 		 * tick. This makes it possible to leave the station and process
 		 * e.g. a depot order in the same tick, causing it to not fill
 		 * the timetable entry like is done for road vehicles/ships.
 		 * Thus always make sure at least one tick is used between the
 		 * processing of different orders when filling the timetable. */
-		uint time_to_set = CeilDiv(std::max(time_taken, 1), Ticks::DAY_TICKS) * Ticks::DAY_TICKS;
+		uint time_to_set = CeilDiv(std::max(time_taken, 1), Ticks::TICKS_PER_SECOND) * Ticks::TICKS_PER_SECOND;
 
 		if (travelling && (autofilling || !real_current_order->IsTravelTimetabled())) {
 			ChangeTimetable(v, v->cur_real_order_index, time_to_set, MTF_TRAVEL_TIME, autofilling);

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2333,7 +2333,7 @@ void Vehicle::HandleLoading(bool mode)
 {
 	switch (this->current_order.GetType()) {
 		case OT_LOADING: {
-			uint wait_time = std::max(this->current_order.GetTimetabledWait() - this->lateness_counter, 0);
+			TimerGameTick::Ticks wait_time = std::max(this->current_order.GetTimetabledWait() - this->lateness_counter, 0);
 
 			/* Not the first call for this tick, or still loading */
 			if (mode || !HasBit(this->vehicle_flags, VF_LOADING_FINISHED) || this->current_order_time < wait_time) return;


### PR DESCRIPTION
## Motivation / Problem

In OpenTTD, timetables use calendar dates for arrival and departures, as well as the timetable start date. This makes no sense when the calendar date never changes (and we never show players the economy date). Instead, in Real-Time Mode (#11341) we display these as an offset in seconds from the current time.

This feature can actually be implemented separately and used outside Real-Time Mode, to be useful to more people and to make the PR smaller and easier to review.

## Description

Replace the boolean "timetable in ticks" setting with a drop-down to select days, seconds, or ticks.

With NotDaylength, the calendar date never changes (and we never show players the economy date) so we will force this new setting to show seconds.

For what it's worth, I am a regular user of timetables in both in vanilla OpenTTD and JGRPP using Scheduled Dispatch and the Wall Clock feature. So as I'm working on this feature, I'm thinking about my ideal use case, not just shrugging off timetables entirely as broken and not worthy of attention.

## Limitations

* When timetabling in Ticks, arrival/departure times and start date use dates. This is unchanged from current behavior but there's no way to set travel time in Ticks and show arrival/departure times in seconds. I don't expect this to be a problem for many people.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
