### PR TITLE
Change: Use sensible default settings for Cargo Distribution

### DIFF
--- a/src/table/settings/linkgraph_settings.ini
+++ b/src/table/settings/linkgraph_settings.ini
@@ -64,7 +64,7 @@ var      = linkgraph.distribution_pax
 type     = SLE_UINT8
 from     = SLV_183
 flags    = SF_GUI_DROPDOWN
-def      = DT_MANUAL
+def      = DT_SYMMETRIC
 min      = DT_MIN
 max      = DT_MAX
 interval = 1
@@ -72,13 +72,14 @@ str      = STR_CONFIG_SETTING_DISTRIBUTION_PAX
 strval   = STR_CONFIG_SETTING_DISTRIBUTION_MANUAL
 strhelp  = STR_CONFIG_SETTING_DISTRIBUTION_PAX_HELPTEXT
 extra    = offsetof(LinkGraphSettings, distribution_pax)
+cat      = SC_BASIC
 
 [SDT_VAR]
 var      = linkgraph.distribution_mail
 type     = SLE_UINT8
 from     = SLV_183
 flags    = SF_GUI_DROPDOWN
-def      = DT_MANUAL
+def      = DT_ASYMMETRIC
 min      = DT_MIN
 max      = DT_MAX
 interval = 1
@@ -86,13 +87,14 @@ str      = STR_CONFIG_SETTING_DISTRIBUTION_MAIL
 strval   = STR_CONFIG_SETTING_DISTRIBUTION_MANUAL
 strhelp  = STR_CONFIG_SETTING_DISTRIBUTION_MAIL_HELPTEXT
 extra    = offsetof(LinkGraphSettings, distribution_mail)
+cat      = SC_BASIC
 
 [SDT_VAR]
 var      = linkgraph.distribution_armoured
 type     = SLE_UINT8
 from     = SLV_183
 flags    = SF_GUI_DROPDOWN
-def      = DT_MANUAL
+def      = DT_ASYMMETRIC
 min      = DT_MIN
 max      = DT_MAX
 interval = 1
@@ -100,6 +102,7 @@ str      = STR_CONFIG_SETTING_DISTRIBUTION_ARMOURED
 strval   = STR_CONFIG_SETTING_DISTRIBUTION_MANUAL
 strhelp  = STR_CONFIG_SETTING_DISTRIBUTION_ARMOURED_HELPTEXT
 extra    = offsetof(LinkGraphSettings, distribution_armoured)
+cat      = SC_BASIC
 
 [SDT_VAR]
 var      = linkgraph.distribution_default
@@ -114,6 +117,7 @@ str      = STR_CONFIG_SETTING_DISTRIBUTION_DEFAULT
 strval   = STR_CONFIG_SETTING_DISTRIBUTION_MANUAL
 strhelp  = STR_CONFIG_SETTING_DISTRIBUTION_DEFAULT_HELPTEXT
 extra    = offsetof(LinkGraphSettings, distribution_default)
+cat      = SC_BASIC
 
 [SDT_VAR]
 var      = linkgraph.accuracy


### PR DESCRIPTION
## Motivation / Problem

On the OpenTTD Discord, new players ask how to give passengers destinations on a near-daily basis. We have a pinned message showing them how to change cargo distribution settings to do this. This currently requires showing advanced settings.

I have not played a modern transport game where passengers do not have destinations. Even Railroad Tycoon 3 (2003) had this feature.

Some longtime OpenTTD and TTD players hate cargo distribution. These are the players most able to tweak settings to their liking, and they already have OpenTTD installs with their configuration files set accordingly, so this would not affect them.

## Description

Change the default settings, for first-time installations of OpenTTD, to enable cargo distribution for passengers, mail, and valuables. Specifically:
- Passengers: Symmetric
- Mail: Asymmetric
- Armoured: Asymmetric
- Others: Manual

Also, change the setting visibility to Basic so these settings can be found more easily.

## Limitations

It's getting cold where I live, so a flamewar would keep me warm. 😛 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
