### PR TITLE
Fix: Using MIN_YEAR for a date is probably wrong, Use MIN_DATE instead.

### DIFF
--- a/src/table/roadtypes.h
+++ b/src/table/roadtypes.h
@@ -82,7 +82,7 @@ static const RoadTypeInfo _original_roadtypes[] = {
 		0x01,
 
 		/* introduction date */
-		static_cast<int32_t>(CalendarTime::MIN_YEAR),
+		CalendarTime::MIN_DATE,
 
 		/* roadtypes required for this to be introduced */
 		ROADTYPES_NONE,

--- a/src/timer/timer_game_calendar.h
+++ b/src/timer/timer_game_calendar.h
@@ -178,6 +178,9 @@ public:
 	/** The date of the first day of the original base year. */
 	static constexpr TimerGameCalendar::Date DAYS_TILL_ORIGINAL_BASE_YEAR = TimerGameCalendar::DateAtStartOfYear(ORIGINAL_BASE_YEAR);
 
+	/** The absolute minimum date. */
+	static constexpr TimerGameCalendar::Date MIN_DATE = 0;
+
 	/** The date of the last day of the max year. */
 	static constexpr TimerGameCalendar::Date MAX_DATE = TimerGameCalendar::DateAtStartOfYear(CalendarTime::MAX_YEAR + 1) - 1;
 


### PR DESCRIPTION
## Motivation / Problem

Default road introduction date was defined as MIN_YEAR, but it actually takes a date.

Even with strong types ...

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add a MIN_DATE value and use it instead of MIN_YEAR. They both equal 0 so nothing really changes, except correctness.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
