### PR TITLE
Change: Show empty string drop down entries as divider.

### DIFF
--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -48,10 +48,14 @@ uint DropDownListStringItem::Width() const
 	return GetStringBoundingBox(this->String()).width + WidgetDimensions::scaled.dropdowntext.Horizontal();
 }
 
-void DropDownListStringItem::Draw(const Rect &r, bool sel, Colours) const
+void DropDownListStringItem::Draw(const Rect &r, bool sel, Colours bg_colour) const
 {
-	Rect ir = r.Shrink(WidgetDimensions::scaled.dropdowntext);
-	DrawString(ir.left, ir.right, r.top, this->String(), sel ? TC_WHITE : TC_BLACK);
+	if (this->String().empty()) {
+		this->DropDownListItem::Draw(r, sel, bg_colour);
+	} else {
+		Rect ir = r.Shrink(WidgetDimensions::scaled.dropdowntext);
+		DrawString(ir.left, ir.right, r.top, this->String(), sel ? TC_WHITE : TC_BLACK);
+	}
 }
 
 /**

--- a/src/widgets/dropdown_type.h
+++ b/src/widgets/dropdown_type.h
@@ -42,7 +42,7 @@ public:
 	DropDownListStringItem(StringID string, int result, bool masked);
 	DropDownListStringItem(const std::string &string, int result, bool masked);
 
-	bool Selectable() const override { return true; }
+	bool Selectable() const override { return !this->String().empty(); }
 	uint Width() const override;
 	void Draw(const Rect &r, bool sel, Colours bg_colour) const override;
 	virtual const std::string &String() const { return this->string; }


### PR DESCRIPTION
## Motivation / Problem

Some drop down lists contain empty strings to separate sections of the list. We also have a specific way to create drop down list divider, but this is only used (afaik) in two places, the main tool bar settings menu and the currency units menu.

A blank string is used instead for the save menu and the help menu.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead of complicating drop down list item creation, make `DropDownListStringItem::Draw` call the base `DropDownListItem::Draw` (which handles the divider) if the string is empty, and make the item unselectable for good measure.

No screenshots as I can't show toolbar menus without holding a mouse button, and that stops my printscreen from working :)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
