### PR TITLE
Codechange: Reword rail/road type label constants

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1056,9 +1056,9 @@ static ChangeInfoResult RailVehicleChangeInfo(uint engine, int numinfo, int prop
 				}
 
 				switch (tracktype) {
-					case 0: _gted[e->index].railtypelabel = rvi->engclass >= 2 ? RAILTYPE_ELECTRIC_LABEL : RAILTYPE_RAIL_LABEL; break;
-					case 1: _gted[e->index].railtypelabel = RAILTYPE_MONO_LABEL; break;
-					case 2: _gted[e->index].railtypelabel = RAILTYPE_MAGLEV_LABEL; break;
+					case 0: _gted[e->index].railtypelabel = rvi->engclass >= 2 ? RAILTYPE_LABEL_ELECTRIC : RAILTYPE_LABEL_RAIL; break;
+					case 1: _gted[e->index].railtypelabel = RAILTYPE_LABEL_MONO; break;
+					case 2: _gted[e->index].railtypelabel = RAILTYPE_LABEL_MAGLEV; break;
 					default:
 						GrfMsg(1, "RailVehicleChangeInfo: Invalid track type {} specified, ignoring", tracktype);
 						break;
@@ -1195,8 +1195,8 @@ static ChangeInfoResult RailVehicleChangeInfo(uint engine, int numinfo, int prop
 				if (_cur.grffile->railtype_list.empty()) {
 					/* Use traction type to select between normal and electrified
 					 * rail only when no translation list is in place. */
-					if (_gted[e->index].railtypelabel == RAILTYPE_RAIL_LABEL     && engclass >= EC_ELECTRIC) _gted[e->index].railtypelabel = RAILTYPE_ELECTRIC_LABEL;
-					if (_gted[e->index].railtypelabel == RAILTYPE_ELECTRIC_LABEL && engclass  < EC_ELECTRIC) _gted[e->index].railtypelabel = RAILTYPE_RAIL_LABEL;
+					if (_gted[e->index].railtypelabel == RAILTYPE_LABEL_RAIL     && engclass >= EC_ELECTRIC) _gted[e->index].railtypelabel = RAILTYPE_LABEL_ELECTRIC;
+					if (_gted[e->index].railtypelabel == RAILTYPE_LABEL_ELECTRIC && engclass  < EC_ELECTRIC) _gted[e->index].railtypelabel = RAILTYPE_LABEL_RAIL;
 				}
 
 				rvi->engclass = engclass;

--- a/src/rail_type.h
+++ b/src/rail_type.h
@@ -14,10 +14,10 @@
 
 typedef uint32_t RailTypeLabel;
 
-static const RailTypeLabel RAILTYPE_RAIL_LABEL     = 'RAIL';
-static const RailTypeLabel RAILTYPE_ELECTRIC_LABEL = 'ELRL';
-static const RailTypeLabel RAILTYPE_MONO_LABEL     = 'MONO';
-static const RailTypeLabel RAILTYPE_MAGLEV_LABEL   = 'MGLV';
+static const RailTypeLabel RAILTYPE_LABEL_RAIL     = 'RAIL';
+static const RailTypeLabel RAILTYPE_LABEL_ELECTRIC = 'ELRL';
+static const RailTypeLabel RAILTYPE_LABEL_MONO     = 'MONO';
+static const RailTypeLabel RAILTYPE_LABEL_MAGLEV   = 'MGLV';
 
 /**
  * Enumeration for all possible railtypes.

--- a/src/road_type.h
+++ b/src/road_type.h
@@ -14,8 +14,8 @@
 
 typedef uint32_t RoadTypeLabel;
 
-static const RoadTypeLabel ROADTYPE_ROAD_LABEL = 'ROAD';
-static const RoadTypeLabel ROADTYPE_TRAM_LABEL = 'ELRL';
+static const RoadTypeLabel ROADTYPE_LABEL_ROAD = 'ROAD';
+static const RoadTypeLabel ROADTYPE_LABEL_TRAM = 'ELRL';
 
 /**
  * The different roadtypes we support

--- a/src/table/railtypes.h
+++ b/src/table/railtypes.h
@@ -90,7 +90,7 @@ static const RailTypeInfo _original_railtypes[] = {
 		0,
 
 		/* rail type label */
-		RAILTYPE_RAIL_LABEL,
+		RAILTYPE_LABEL_RAIL,
 
 		/* alternate labels */
 		RailTypeLabelList(),
@@ -191,7 +191,7 @@ static const RailTypeInfo _original_railtypes[] = {
 		0,
 
 		/* rail type label */
-		RAILTYPE_ELECTRIC_LABEL,
+		RAILTYPE_LABEL_ELECTRIC,
 
 		/* alternate labels */
 		RailTypeLabelList(),
@@ -288,7 +288,7 @@ static const RailTypeInfo _original_railtypes[] = {
 		0,
 
 		/* rail type label */
-		RAILTYPE_MONO_LABEL,
+		RAILTYPE_LABEL_MONO,
 
 		/* alternate labels */
 		RailTypeLabelList(),
@@ -385,7 +385,7 @@ static const RailTypeInfo _original_railtypes[] = {
 		0,
 
 		/* rail type label */
-		RAILTYPE_MAGLEV_LABEL,
+		RAILTYPE_LABEL_MAGLEV,
 
 		/* alternate labels */
 		RailTypeLabelList(),

--- a/src/table/roadtypes.h
+++ b/src/table/roadtypes.h
@@ -73,7 +73,7 @@ static const RoadTypeInfo _original_roadtypes[] = {
 		0,
 
 		/* road type label */
-		ROADTYPE_ROAD_LABEL,
+		ROADTYPE_LABEL_ROAD,
 
 		/* alternate labels */
 		RoadTypeLabelList(),
@@ -153,7 +153,7 @@ static const RoadTypeInfo _original_roadtypes[] = {
 		0,
 
 		/* road type label */
-		ROADTYPE_TRAM_LABEL,
+		ROADTYPE_LABEL_TRAM,
 
 		/* alternate labels */
 		RoadTypeLabelList(),


### PR DESCRIPTION
## Motivation / Problem

In #11450, I noticed that the constants we use for roadtype and railtype label literals are worded funny.

`RAILTYPE_RAIL_LABEL` sounds like it should be `RAILTYPE_LABEL_RAIL`, and similar for the other railtype and roadtype constants.

## Description

Make it so.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
