### PR TITLE
Codechange: Redundant use of char * and c_str().

### DIFF
--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -106,19 +106,19 @@ struct BaseSet {
 	 * @param isocode the isocode to search for
 	 * @return the description
 	 */
-	const char *GetDescription(const std::string &isocode) const
+	const std::string &GetDescription(const std::string &isocode) const
 	{
 		if (!isocode.empty()) {
 			/* First the full ISO code */
 			auto desc = this->description.find(isocode);
-			if (desc != this->description.end()) return desc->second.c_str();
+			if (desc != this->description.end()) return desc->second;
 
 			/* Then the first two characters */
 			desc = this->description.find(isocode.substr(0, 2));
-			if (desc != this->description.end()) return desc->second.c_str();
+			if (desc != this->description.end()) return desc->second;
 		}
 		/* Then fall back */
-		return this->description.at(std::string{}).c_str();
+		return this->description.at(std::string{});
 	}
 
 	/**

--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -125,11 +125,11 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 	 */
 	virtual void UpdateVirtCoord() = 0;
 
-	inline const char *GetCachedName() const
+	inline const std::string &GetCachedName() const
 	{
-		if (!this->name.empty()) return this->name.c_str();
+		if (!this->name.empty()) return this->name;
 		if (this->cached_name.empty()) this->FillCachedName();
-		return this->cached_name.c_str();
+		return this->cached_name;
 	}
 
 	virtual void MoveSign(TileIndex new_xy)

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -326,7 +326,7 @@ void LoadCoreTextFont(FontSize fs)
 			path.reset(CFStringCreateWithCString(kCFAllocatorDefault, settings->font.c_str(), kCFStringEncodingUTF8));
 		} else {
 			/* Scan the search-paths to see if it can be found. */
-			std::string full_font = FioFindFullPath(BASE_DIR, settings->font.c_str());
+			std::string full_font = FioFindFullPath(BASE_DIR, settings->font);
 			if (!full_font.empty()) {
 				path.reset(CFStringCreateWithCString(kCFAllocatorDefault, full_font.c_str(), kCFStringEncodingUTF8));
 			}

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -46,7 +46,7 @@ ScriptStorage::~ScriptStorage()
 static void PrintFunc(bool error_msg, const std::string &message)
 {
 	/* Convert to OpenTTD internal capable string */
-	ScriptController::Print(error_msg, message.c_str());
+	ScriptController::Print(error_msg, message);
 }
 
 ScriptInstance::ScriptInstance(const char *APIName) :

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1552,7 +1552,7 @@ void DeleteGRFPresetFromConfig(const char *config_name)
 	section += config_name;
 
 	ConfigIniFile ini(_config_file);
-	ini.RemoveGroup(section.c_str());
+	ini.RemoveGroup(section);
 	ini.SaveToDisk(_config_file);
 }
 

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -79,7 +79,7 @@ struct FileStringReader : StringReader {
 	 * @param translation Are we reading a translation?
 	 */
 	FileStringReader(StringData &data, const std::filesystem::path &file, bool master, bool translation) :
-			StringReader(data, file.generic_string().c_str(), master, translation)
+			StringReader(data, file.generic_string(), master, translation)
 	{
 		this->input_stream.open(file, std::ifstream::binary);
 	}


### PR DESCRIPTION
## Motivation / Problem

Now that `std::string` conversion is well on its way, some intermediate functions use `c_str()` when it is no longer necessary.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Removing the redundant `c_str()`, and change signature where necessary.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
