### PR TITLE
Codechange: Simplify autoreplace rail/road types by using separate widget.

### DIFF
--- a/src/widgets/autoreplace_widget.h
+++ b/src/widgets/autoreplace_widget.h
@@ -32,12 +32,13 @@ enum ReplaceVehicleWidgets {
 	WID_RV_INFO_TAB,                 ///< Info tab.
 	WID_RV_STOP_REPLACE,             ///< Stop Replacing button.
 
-	/* Train/road only widgets */
-	WID_RV_RAIL_ROAD_TYPE_DROPDOWN,  ///< Dropdown menu about the rail/roadtype.
-
 	/* Train only widgets. */
+	WID_RV_RAIL_TYPE_DROPDOWN, ///< Dropdown to select railtype.
 	WID_RV_TRAIN_ENGINEWAGON_DROPDOWN, ///< Dropdown to select engines and/or wagons.
 	WID_RV_TRAIN_WAGONREMOVE_TOGGLE, ///< Button to toggle removing wagons.
+
+	/* Road only widgets. */
+	WID_RV_ROAD_TYPE_DROPDOWN, ///< Dropdown to select roadtype.
 };
 
 #endif /* WIDGETS_AUTOREPLACE_WIDGET_H */


### PR DESCRIPTION
## Motivation / Problem

The autoreplace window reuses one dropdown list widget index for rail and road type lists. This means the window needs to also check whether it is dealing with trains or road vehicles.

As the widget layout is different for each vehicle type, it is trivial to use a different widget index instead.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use a separate widget for rail and road type lists.

This avoids needing to determine which type of list to deal with by additionally checking the window number for VEH_TRAIN/VEH_ROAD.

Does not affect layout so no screenshots.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
