### PR TITLE
Codechange: Use ticks for timetable start date

### DIFF
--- a/src/base_consist.h
+++ b/src/base_consist.h
@@ -11,7 +11,7 @@
 #define BASE_CONSIST_H
 
 #include "order_type.h"
-#include "timer/timer_game_calendar.h"
+#include "timer/timer_game_tick.h"
 
 /** Various front vehicle properties that are preserved when autoreplacing, using order-backup or switching front engines within a consist. */
 struct BaseConsist {
@@ -20,7 +20,7 @@ struct BaseConsist {
 	/* Used for timetabling. */
 	uint32_t current_order_time;               ///< How many ticks have passed since this order started.
 	int32_t lateness_counter;                  ///< How many ticks late (or early if negative) this vehicle is.
-	TimerGameCalendar::Date timetable_start; ///< When the vehicle is supposed to start the timetable.
+	TimerGameTick::TickCounter timetable_start; ///< At what tick of TimerGameTick::counter the vehicle should start its timetable.
 
 	uint16_t service_interval;            ///< The interval for (automatic) servicing; either in days or %.
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -363,6 +363,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_CARGO_TRAVELLED,                    ///< 319  PR#11283 CargoPacket now tracks how far it travelled inside a vehicle.
 
 	SLV_STATION_RATING_CHEAT,               ///< 320  PR#11346 Add cheat to fix station ratings at 100%.
+	SLV_TIMETABLE_START_TICKS,              ///< 321  PR#11468 Convert timetable start from a date to ticks.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -17,6 +17,7 @@
 #include "../roadveh.h"
 #include "../ship.h"
 #include "../aircraft.h"
+#include "../timetable.h"
 #include "../station_base.h"
 #include "../effectvehicle_base.h"
 #include "../company_base.h"
@@ -373,6 +374,16 @@ void AfterLoadVehicles(bool part_of_load)
 				s->rotation_y_pos = s->y_pos;
 			}
 		}
+
+		if (IsSavegameVersionBefore(SLV_TIMETABLE_START_TICKS)) {
+			/* Convert timetable start from a date to an absolute tick in TimerGameTick::counter. */
+			for (Vehicle *v : Vehicle::Iterate()) {
+				/* If the start date is 0, the vehicle is not waiting to start and can be ignored. */
+				if (v->timetable_start == 0) continue;
+
+				v->timetable_start = GetStartTickFromDate(v->timetable_start);
+			}
+		}
 	}
 
 	CheckValidVehicles();
@@ -663,7 +674,8 @@ public:
 		SLE_CONDVAR(Vehicle, current_order.wait_time,     SLE_UINT16,            SLV_67, SL_MAX_VERSION),
 		SLE_CONDVAR(Vehicle, current_order.travel_time,   SLE_UINT16,            SLV_67, SL_MAX_VERSION),
 		SLE_CONDVAR(Vehicle, current_order.max_speed,     SLE_UINT16,           SLV_174, SL_MAX_VERSION),
-		SLE_CONDVAR(Vehicle, timetable_start,       SLE_INT32,                  SLV_129, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, timetable_start,       SLE_FILE_I32 | SLE_VAR_U64, SLV_129, SLV_TIMETABLE_START_TICKS),
+		SLE_CONDVAR(Vehicle, timetable_start,       SLE_UINT64,                 SLV_TIMETABLE_START_TICKS, SL_MAX_VERSION),
 
 		SLE_CONDREF(Vehicle, orders,                REF_ORDER,                    SL_MIN_VERSION, SLV_105),
 		SLE_CONDREF(Vehicle, orders,                REF_ORDERLIST,              SLV_105, SL_MAX_VERSION),

--- a/src/timer/timer_game_tick.cpp
+++ b/src/timer/timer_game_tick.cpp
@@ -16,7 +16,7 @@
 
 #include "../safeguards.h"
 
-uint64_t TimerGameTick::counter = 0;
+TimerGameTick::TickCounter TimerGameTick::counter = 0;
 
 template<>
 void IntervalTimer<TimerGameTick>::Elapsed(TimerGameTick::TElapsed delta)

--- a/src/timer/timer_game_tick.h
+++ b/src/timer/timer_game_tick.h
@@ -22,6 +22,7 @@
 class TimerGameTick {
 public:
 	using Ticks = int32_t; ///< The type to store ticks in
+	using TickCounter = uint64_t; ///< The type that the tick counter is stored in
 
 	using TPeriod = uint;
 	using TElapsed = uint;
@@ -29,7 +30,7 @@ public:
 		uint elapsed;
 	};
 
-	static uint64_t counter; ///< Monotonic counter, in ticks, since start of game.
+	static TickCounter counter; ///< Monotonic counter, in ticks, since start of game.
 };
 
 /**

--- a/src/timetable.h
+++ b/src/timetable.h
@@ -16,6 +16,9 @@
 
 static const TimerGameCalendar::Year MAX_TIMETABLE_START_YEARS = 15; ///< The maximum start date offset, in years.
 
+TimerGameTick::TickCounter GetStartTickFromDate(TimerGameCalendar::Date start_date);
+TimerGameCalendar::Date GetDateFromStartTick(TimerGameTick::TickCounter start_tick);
+
 void ShowTimetableWindow(const Vehicle *v);
 void UpdateVehicleTimetable(Vehicle *v, bool travelling);
 void SetTimetableParams(int param1, int param2, TimerGameTick::Ticks ticks);

--- a/src/timetable_cmd.h
+++ b/src/timetable_cmd.h
@@ -11,13 +11,13 @@
 #define TIMETABLE_CMD_H
 
 #include "command_type.h"
-#include "timer/timer_game_calendar.h"
+#include "timer/timer_game_tick.h"
 
 CommandCost CmdChangeTimetable(DoCommandFlag flags, VehicleID veh, VehicleOrderID order_number, ModifyTimetableFlags mtf, uint16_t data);
 CommandCost CmdBulkChangeTimetable(DoCommandFlag flags, VehicleID veh, ModifyTimetableFlags mtf, uint16_t data);
 CommandCost CmdSetVehicleOnTime(DoCommandFlag flags, VehicleID veh, bool apply_to_group);
 CommandCost CmdAutofillTimetable(DoCommandFlag flags, VehicleID veh, bool autofill, bool preserve_wait_time);
-CommandCost CmdSetTimetableStart(DoCommandFlag flags, VehicleID veh_id, bool timetable_all, TimerGameCalendar::Date start_date);
+CommandCost CmdSetTimetableStart(DoCommandFlag flags, VehicleID veh_id, bool timetable_all, TimerGameTick::TickCounter start_tick);
 
 DEF_CMD_TRAIT(CMD_CHANGE_TIMETABLE,      CmdChangeTimetable,     0, CMDT_ROUTE_MANAGEMENT)
 DEF_CMD_TRAIT(CMD_BULK_CHANGE_TIMETABLE, CmdBulkChangeTimetable, 0, CMDT_ROUTE_MANAGEMENT)

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -145,7 +145,7 @@ static void FillTimetableArrivalDepartureTable(const Vehicle *v, VehicleOrderID 
  */
 static void ChangeTimetableStartCallback(const Window *w, TimerGameCalendar::Date date, void *data)
 {
-	Command<CMD_SET_TIMETABLE_START>::Post(STR_ERROR_CAN_T_TIMETABLE_VEHICLE, (VehicleID)w->window_number, reinterpret_cast<std::uintptr_t>(data) != 0, date);
+	Command<CMD_SET_TIMETABLE_START>::Post(STR_ERROR_CAN_T_TIMETABLE_VEHICLE, (VehicleID)w->window_number, reinterpret_cast<std::uintptr_t>(data) != 0, GetStartTickFromDate(date));
 }
 
 
@@ -494,7 +494,7 @@ struct TimetableWindow : Window {
 			/* We are running towards the first station so we can start the
 			 * timetable at the given time. */
 			SetDParam(0, STR_JUST_DATE_TINY);
-			SetDParam(1, v->timetable_start);
+			SetDParam(1, GetDateFromStartTick(v->timetable_start));
 			DrawString(tr, STR_TIMETABLE_STATUS_START_AT);
 		} else if (!HasBit(v->vehicle_flags, VF_TIMETABLE_STARTED)) {
 			/* We aren't running on a timetable yet, so how can we be "on time"

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -331,7 +331,7 @@ public:
 
 	StationID last_station_visited;     ///< The last station we stopped at.
 	StationID last_loading_station;     ///< Last station the vehicle has stopped at and could possibly leave from with any cargo loaded.
-	uint64_t last_loading_tick;         ///< Last time (based on TimerGameTick counter) the vehicle has stopped at a station and could possibly leave with any cargo loaded.
+	TimerGameTick::TickCounter last_loading_tick; ///< Last TimerGameTick::counter tick that the vehicle has stopped at a station and could possibly leave with any cargo loaded.
 
 	CargoID cargo_type;                 ///< type of cargo this vehicle is carrying
 	byte cargo_subtype;                 ///< Used for livery refits (NewGRF variations)


### PR DESCRIPTION
## Motivation / Problem

In OpenTTD, days are two seconds long. In #11435, we show timetables in seconds, so unless we want to restrict players to using multiples of two, we can't use days for timetable-related things.

Currently, timetables use ticks for everything except the start date, mostly avoiding this problem.

## Description

We use the tick counter to set an absolute tick when the timetable starts. For clarity, I've created a new TickCounter type for this and converted the other use of an absolute tick (this can be a separate PR if we like the approach).

We convert `BaseConsist->timetable_start` from a date to this absolute tick, and handle saveload conversion.

The player sees no changes with this PR, with the user interface continuing to use a date. I also kept the validation in `CmdSetTimetableStart()` using days. We don't need to worry about invalid dates in the command, but they still show up in the GUI so they must continue to be valid dates.

## Limitations

There is an existing rounding error (confirmed in 13.4) when a vehicle reaches its first order and the timetable GUI shows "This vehicle is currently running N days early" -- it fails to account for `TimerGameCalendar::date_fract` and rounds down. Fixing this is out of scope for this PR.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
