### PR TITLE
Fix: extmidi did not move on to next song after playing ends.

### DIFF
--- a/src/music/extmidi.cpp
+++ b/src/music/extmidi.cpp
@@ -125,7 +125,7 @@ void MusicDriver_ExtMidi::DoPlay()
 			FALLTHROUGH;
 
 		default:
-			this->song[0] = '\0';
+			this->song.clear();
 			break;
 	}
 }


### PR DESCRIPTION
## Motivation / Problem

extmidi does not move from one song to the next automatically.

extmidi writes a NUL character to its song name when it has finished playing, which tells it to move on to the next song. This worked for C-style strings, but does not make a C++ string as empty.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use `.clear()` to properly clear a std::string.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
