### PR TITLE
Fix 96d98d0: Crash in text layouter determining height of zero-width widget.

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -693,6 +693,7 @@ int DrawString(int left, int right, int top, StringID str, TextColour colour, St
  */
 int GetStringHeight(std::string_view str, int maxw, FontSize fontsize)
 {
+	assert(maxw > 0);
 	Layouter layout(str, maxw, TC_FROMSTRING, fontsize);
 	return layout.GetBounds().height;
 }

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -297,33 +297,21 @@ struct SelectGameWindow : public Window {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void OnResize() override
 	{
-		StringID str = 0;
-		switch (widget) {
-			case WID_SGI_BASESET:
-				SetDParam(0, _missing_extra_graphics);
-				str = STR_INTRO_BASESET;
-				break;
+		bool changed = false;
 
-			case WID_SGI_TRANSLATION:
-				SetDParam(0, _current_language->missing);
-				str = STR_INTRO_TRANSLATION;
-				break;
+		if (NWidgetResizeBase *wid = this->GetWidget<NWidgetResizeBase>(WID_SGI_BASESET); wid != nullptr && wid->current_x > 0) {
+			SetDParam(0, _missing_extra_graphics);
+			changed |= wid->UpdateMultilineWidgetSize(GetString(STR_INTRO_BASESET), 3);
 		}
 
-		if (str != 0) {
-			int height = GetStringHeight(str, size->width);
-			if (height > 3 * FONT_HEIGHT_NORMAL) {
-				/* Don't let the window become too high. */
-				Dimension textdim = GetStringBoundingBox(str);
-				textdim.height *= 3;
-				textdim.width -= textdim.width / 2;
-				*size = maxdim(*size, textdim);
-			} else {
-				size->height = height + padding.height;
-			}
+		if (NWidgetResizeBase *wid = this->GetWidget<NWidgetResizeBase>(WID_SGI_TRANSLATION); wid != nullptr && wid->current_x > 0) {
+			SetDParam(0, _current_language->missing);
+			changed |= wid->UpdateMultilineWidgetSize(GetString(STR_INTRO_TRANSLATION), 3);
 		}
+
+		if (changed) this->ReInit(0, 0, this->flags & WF_CENTERED);
 	}
 
 	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1158,6 +1158,22 @@ void NWidgetResizeBase::SetResize(uint resize_x, uint resize_y)
 
 /**
  * Set absolute (post-scaling) minimal size of the widget.
+ * The window will need to be reinited if the size is changed.
+ * @param min_x Horizontal minimal size of the widget.
+ * @param min_y Vertical minimal size of the widget.
+ * @return true iff the widget minimum size has changed.
+ */
+bool NWidgetResizeBase::UpdateSize(uint min_x, uint min_y)
+{
+	if (min_x == this->min_x && min_y == this->min_y) return false;
+	this->min_x = min_x;
+	this->min_y = min_y;
+	return true;
+}
+
+/**
+ * Set absolute (post-scaling) minimal size of the widget.
+ * The window will need to be reinited if the size is changed.
  * @param min_y Vertical minimal size of the widget.
  * @return true iff the widget minimum size has changed.
  */

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1157,6 +1157,26 @@ void NWidgetResizeBase::SetResize(uint resize_x, uint resize_y)
 }
 
 /**
+ * Try to set optimum widget size for a multiline text widget.
+ * The window will need to be reinited if the size is changed.
+ * @param str Multiline string contents that will fill the widget.
+ * @param max_line Maximum number of lines.
+ * @return true iff the widget minimum size has changed.
+ */
+bool NWidgetResizeBase::UpdateMultilineWidgetSize(const std::string &str, int max_lines)
+{
+	int y = GetStringHeight(str, this->current_x);
+	if (y > max_lines * FONT_HEIGHT_NORMAL) {
+		/* Text at the current width is too tall, so try to guess a better width. */
+		Dimension d = GetStringBoundingBox(str);
+		d.height *= max_lines;
+		d.width /= 2;
+		return this->UpdateSize(d.width, d.height);
+	}
+	return this->UpdateVerticalSize(y);
+}
+
+/**
  * Set absolute (post-scaling) minimal size of the widget.
  * The window will need to be reinited if the size is changed.
  * @param min_x Horizontal minimal size of the widget.

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -262,6 +262,7 @@ public:
 	void SetFill(uint fill_x, uint fill_y);
 	void SetResize(uint resize_x, uint resize_y);
 
+	bool UpdateSize(uint min_x, uint min_y);
 	bool UpdateVerticalSize(uint min_y);
 
 	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -262,6 +262,7 @@ public:
 	void SetFill(uint fill_x, uint fill_y);
 	void SetResize(uint resize_x, uint resize_y);
 
+	bool UpdateMultilineWidgetSize(const std::string &str, int max_lines);
 	bool UpdateSize(uint min_x, uint min_y);
 	bool UpdateVerticalSize(uint min_y);
 


### PR DESCRIPTION
## Motivation / Problem

Before #11475 a hardcoded minimum size was assigned to the intro menu's warning messages, but these were removed in favour of dynamic calculation. However...

Determining the height of a multiline string when we don't yet know the widget's width can crash the text layouters, and doesn't make sense to do, and we cannot know the calculated width of the widget until the window layout is completely sized.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

## Description

Therefore, we take a 2-stage approach as used by the Game Options window. Once the window is initially sized, we can then determine the height of the multiline text widgets during OnResize(), and ReInit() as appropriate.



<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This is perhaps a bit more complex and convoluted than the alternative solution of undoing the change and using a hardcoded minimum width... but hardcoding is bad.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
