### PR TITLE
Fix #11407: Don't steal focus from dropdown menus.

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1393,10 +1393,9 @@ void Window::InitializeData(WindowNumber window_number)
 	this->resize.step_width  = this->nested_root->resize_x;
 	this->resize.step_height = this->nested_root->resize_y;
 
-	/* Give focus to the opened window unless a text box
-	 * of focused window has focus (so we don't interrupt typing). But if the new
-	 * window has a text box, then take focus anyway. */
-	if (!EditBoxInGlobalFocus() || this->nested_root->GetWidgetOfType(WWT_EDITBOX) != nullptr) SetFocusedWindow(this);
+	/* Give focus to the opened window unless a dropdown menu has focus or a text box of the focused window has focus
+	 * (so we don't interrupt typing) unless the new window has a text box. */
+	if ((_focused_window == nullptr || _focused_window->window_class != WC_DROPDOWN_MENU) && (!EditBoxInGlobalFocus() || this->nested_root->GetWidgetOfType(WWT_EDITBOX) != nullptr)) SetFocusedWindow(this);
 
 	/* Insert the window into the correct location in the z-ordering. */
 	BringWindowToFront(this, false);

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1395,7 +1395,9 @@ void Window::InitializeData(WindowNumber window_number)
 
 	/* Give focus to the opened window unless a dropdown menu has focus or a text box of the focused window has focus
 	 * (so we don't interrupt typing) unless the new window has a text box. */
-	if ((_focused_window == nullptr || _focused_window->window_class != WC_DROPDOWN_MENU) && (!EditBoxInGlobalFocus() || this->nested_root->GetWidgetOfType(WWT_EDITBOX) != nullptr)) SetFocusedWindow(this);
+	bool dropdown_active = _focused_window != nullptr && _focused_window->window_class == WC_DROPDOWN_MENU;
+	bool editbox_active = EditBoxInGlobalFocus() && this->nested_root->GetWidgetOfType(WWT_EDITBOX) == nullptr;
+	if (!dropdown_active && !editbox_active) SetFocusedWindow(this);
 
 	/* Insert the window into the correct location in the z-ordering. */
 	BringWindowToFront(this, false);


### PR DESCRIPTION
## Motivation / Problem

News messages (and any other window) steals focus from the drop down menu which causes it to close This is because I changed drop down menu behaviour, and of course I have news messages off so it wasn't quite so noticeable.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

When opening a new window, don't steal focus if the currently focused window is a drop down menu.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
