### PR TITLE
Feature: Show cargo icon on cargo filter lists.

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1579,8 +1579,9 @@ struct BuildVehicleWindow : Window {
 		}
 
 		/* Add cargos */
+		Dimension d = GetLargestCargoIconSize();
 		for (const CargoSpec *cs : _sorted_standard_cargo_specs) {
-			list.push_back(std::make_unique<DropDownListStringItem>(cs->name, cs->Index(), false));
+			list.push_back(std::make_unique<DropDownListIconItem>(d, cs->GetCargoIcon(), PAL_NONE, cs->name, cs->Index(), false));
 		}
 
 		return list;

--- a/src/cargotype.cpp
+++ b/src/cargotype.cpp
@@ -9,6 +9,7 @@
 
 #include "stdafx.h"
 #include "cargotype.h"
+#include "core/geometry_func.hpp"
 #include "newgrf_cargo.h"
 #include "string_func.h"
 #include "strings_func.h"
@@ -68,6 +69,19 @@ void SetupCargoForClimate(LandscapeID l)
 
 	/* Reset and disable remaining cargo types. */
 	std::fill(insert, std::end(CargoSpec::array), CargoSpec{});
+}
+
+/**
+ * Get dimensions of largest cargo icon.
+ * @return Dimensions of largest cargo icon.
+ */
+Dimension GetLargestCargoIconSize()
+{
+	Dimension size = {0, 0};
+	for (const CargoSpec *cs : _sorted_cargo_specs) {
+		size = maxdim(size, GetSpriteSize(cs->GetCargoIcon()));
+	}
+	return size;
 }
 
 /**
@@ -179,7 +193,7 @@ static bool CargoSpecClassSorter(const CargoSpec * const &a, const CargoSpec * c
 void InitializeSortedCargoSpecs()
 {
 	_sorted_cargo_specs.clear();
-	/* Add each cargo spec to the list. */
+	/* Add each cargo spec to the list, and determine the largest cargo icon size. */
 	for (const CargoSpec *cargo : CargoSpec::Iterate()) {
 		_sorted_cargo_specs.push_back(cargo);
 	}

--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -185,6 +185,7 @@ void SetupCargoForClimate(LandscapeID l);
 CargoID GetCargoIDByLabel(CargoLabel cl);
 CargoID GetCargoIDByBitnum(uint8_t bitnum);
 CargoID GetDefaultCargoID(LandscapeID l, CargoType ct);
+Dimension GetLargestCargoIconSize();
 
 void InitializeSortedCargoSpecs();
 extern std::array<uint8_t, NUM_CARGO> _sorted_cargo_types;

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -575,36 +575,15 @@ static const LiveryClass _livery_class[LS_END] = {
 	LC_ROAD, LC_ROAD,
 };
 
-class DropDownListColourItem : public DropDownListStringItem {
+/**
+ * Colour selection list item, with icon and string components.
+ * @tparam TSprite Recolourable sprite to draw as icon.
+ */
+template <SpriteID TSprite = SPR_SQUARE>
+class DropDownListColourItem : public DropDownIcon<DropDownString<DropDownListItem>> {
 public:
-	DropDownListColourItem(int result, bool masked) : DropDownListStringItem(result >= COLOUR_END ? STR_COLOUR_DEFAULT : _colour_dropdown[result], result, masked) {}
-
-	uint Width() const override
+	DropDownListColourItem(int colour, bool masked) : DropDownIcon<DropDownString<DropDownListItem>>(TSprite, PALETTE_RECOLOUR_START + (colour % COLOUR_END), colour < COLOUR_END ? _colour_dropdown[colour] : STR_COLOUR_DEFAULT, colour, masked)
 	{
-		return ScaleGUITrad(28) + WidgetDimensions::scaled.hsep_normal + GetStringBoundingBox(this->String()).width + WidgetDimensions::scaled.dropdowntext.Horizontal();
-	}
-
-	uint Height() const override
-	{
-		return std::max(GetCharacterHeight(FS_NORMAL), ScaleGUITrad(12) + WidgetDimensions::scaled.vsep_normal);
-	}
-
-	bool Selectable() const override
-	{
-		return true;
-	}
-
-	void Draw(const Rect &r, bool sel, Colours) const override
-	{
-		bool rtl = _current_text_dir == TD_RTL;
-		int icon_y = CenterBounds(r.top, r.bottom, 0);
-		int text_y = CenterBounds(r.top, r.bottom, GetCharacterHeight(FS_NORMAL));
-		Rect tr = r.Shrink(WidgetDimensions::scaled.dropdowntext);
-		DrawSprite(SPR_VEH_BUS_SIDE_VIEW, PALETTE_RECOLOUR_START + (this->result % COLOUR_END),
-				   rtl ? tr.right - ScaleGUITrad(14) : tr.left + ScaleGUITrad(14),
-				   icon_y);
-		tr = tr.Indent(ScaleGUITrad(28) + WidgetDimensions::scaled.hsep_normal, rtl);
-		DrawString(tr.left, tr.right, text_y, this->String(), sel ? TC_WHITE : TC_BLACK);
 	}
 };
 
@@ -662,10 +641,10 @@ private:
 		if (default_livery != nullptr) {
 			/* Add COLOUR_END to put the colour out of range, but also allow us to show what the default is */
 			default_col = (primary ? default_livery->colour1 : default_livery->colour2) + COLOUR_END;
-			list.push_back(std::make_unique<DropDownListColourItem>(default_col, false));
+			list.push_back(std::make_unique<DropDownListColourItem<>>(default_col, false));
 		}
 		for (uint i = 0; i < lengthof(_colour_dropdown); i++) {
-			list.push_back(std::make_unique<DropDownListColourItem>(i, HasBit(used_colours, i)));
+			list.push_back(std::make_unique<DropDownListColourItem<>>(i, HasBit(used_colours, i)));
 		}
 
 		byte sel = (default_livery == nullptr || HasBit(livery->in_use, primary ? 0 : 1)) ? (primary ? livery->colour1 : livery->colour2) : default_col;

--- a/src/core/geometry_type.hpp
+++ b/src/core/geometry_type.hpp
@@ -28,7 +28,8 @@ struct Dimension {
 	uint width;
 	uint height;
 
-	Dimension(uint w = 0, uint h = 0) : width(w), height(h) {};
+	constexpr Dimension() : width(0), height(0) {}
+	constexpr Dimension(uint w, uint h) : width(w), height(h) {}
 
 	bool operator< (const Dimension &other) const
 	{

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -358,7 +358,7 @@ static DropDownList BuildTownNameDropDown()
 	size_t newgrf_size = list.size();
 	/* Insert newgrf_names at the top of the list */
 	if (newgrf_size > 0) {
-		list.push_back(std::make_unique<DropDownListItem>(-1, false)); // separator line
+		list.push_back(std::make_unique<DropDownListDividerItem>(-1, false)); // separator line
 		newgrf_size++;
 	}
 

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1753,8 +1753,9 @@ public:
 		list.push_back(std::make_unique<DropDownListStringItem>(this->GetCargoFilterLabel(CF_NONE), CF_NONE, false));
 
 		/* Add cargos */
+		Dimension d = GetLargestCargoIconSize();
 		for (const CargoSpec *cs : _sorted_standard_cargo_specs) {
-			list.push_back(std::make_unique<DropDownListStringItem>(cs->name, cs->Index(), false));
+			list.push_back(std::make_unique<DropDownListIconItem>(d, cs->GetCargoIcon(), PAL_NONE, cs->name, cs->Index(), false));
 		}
 
 		return list;
@@ -3091,8 +3092,9 @@ struct IndustryCargoesWindow : public Window {
 
 			case WID_IC_CARGO_DROPDOWN: {
 				DropDownList lst;
+				Dimension d = GetLargestCargoIconSize();
 				for (const CargoSpec *cs : _sorted_standard_cargo_specs) {
-					lst.push_back(std::make_unique<DropDownListStringItem>(cs->name, cs->Index(), false));
+					lst.push_back(std::make_unique<DropDownListIconItem>(d, cs->GetCargoIcon(), PAL_NONE, cs->name, cs->Index(), false));
 				}
 				if (!lst.empty()) {
 					int selected = (this->ind_cargo >= NUM_INDUSTRYTYPES) ? (int)(this->ind_cargo - NUM_INDUSTRYTYPES) : -1;

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2354,9 +2354,7 @@ DropDownList GetRailTypeDropDownList(bool for_replacement, bool all_option)
 			list.push_back(std::make_unique<DropDownListStringItem>(rti->strings.replace_text, rt, !HasBit(avail_railtypes, rt)));
 		} else {
 			StringID str = rti->max_speed > 0 ? STR_TOOLBAR_RAILTYPE_VELOCITY : STR_JUST_STRING;
-			auto iconitem = std::make_unique<DropDownListIconItem>(rti->gui_sprites.build_x_rail, PAL_NONE, str, rt, !HasBit(avail_railtypes, rt));
-			iconitem->SetDimension(d);
-			list.push_back(std::move(iconitem));
+			list.push_back(std::make_unique<DropDownListIconItem>(d, rti->gui_sprites.build_x_rail, PAL_NONE, str, rt, !HasBit(avail_railtypes, rt)));
 		}
 	}
 

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1828,9 +1828,7 @@ DropDownList GetRoadTypeDropDownList(RoadTramTypes rtts, bool for_replacement, b
 			list.push_back(std::make_unique<DropDownListStringItem>(rti->strings.replace_text, rt, !HasBit(avail_roadtypes, rt)));
 		} else {
 			StringID str = rti->max_speed > 0 ? STR_TOOLBAR_RAILTYPE_VELOCITY : STR_JUST_STRING;
-			auto iconitem = std::make_unique<DropDownListIconItem>(rti->gui_sprites.build_x_road, PAL_NONE, str, rt, !HasBit(avail_roadtypes, rt));
-			iconitem->SetDimension(d);
-			list.push_back(std::move(iconitem));
+			list.push_back(std::make_unique<DropDownListIconItem>(d, rti->gui_sprites.build_x_road, PAL_NONE, str, rt, !HasBit(avail_roadtypes, rt)));
 		}
 	}
 
@@ -1869,9 +1867,7 @@ DropDownList GetScenRoadTypeDropDownList(RoadTramTypes rtts)
 		SetDParam(0, rti->strings.menu_text);
 		SetDParam(1, rti->max_speed / 2);
 		StringID str = rti->max_speed > 0 ? STR_TOOLBAR_RAILTYPE_VELOCITY : STR_JUST_STRING;
-		auto item = std::make_unique<DropDownListIconItem>(rti->gui_sprites.build_x_road, PAL_NONE, str, rt, !HasBit(avail_roadtypes, rt));
-		item->SetDimension(d);
-		list.push_back(std::move(item));
+		list.push_back(std::make_unique<DropDownListIconItem>(d, rti->gui_sprites.build_x_road, PAL_NONE, str, rt, !HasBit(avail_roadtypes, rt)));
 	}
 
 	if (list.empty()) {

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -224,7 +224,7 @@ struct GameOptionsWindow : Window {
 				std::sort(list.begin(), list.end(), DropDownListStringItem::NatSortFunc);
 
 				/* Append custom currency at the end */
-				list.push_back(std::make_unique<DropDownListItem>(-1, false)); // separator line
+				list.push_back(std::make_unique<DropDownListDividerItem>(-1, false)); // separator line
 				list.push_back(std::make_unique<DropDownListStringItem>(STR_GAME_OPTIONS_CURRENCY_CUSTOM, CURRENCY_CUSTOM, HasBit(disabled, CURRENCY_CUSTOM)));
 				break;
 			}

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -383,8 +383,9 @@ DropDownList BaseVehicleListWindow::BuildCargoDropDownList() const
 	list.push_back(std::make_unique<DropDownListStringItem>(this->GetCargoFilterLabel(CF_NONE), CF_NONE, false));
 
 	/* Add cargos */
+	Dimension d = GetLargestCargoIconSize();
 	for (const CargoSpec *cs : _sorted_cargo_specs) {
-		list.push_back(std::make_unique<DropDownListStringItem>(cs->name, cs->Index(), false));
+		list.push_back(std::make_unique<DropDownListIconItem>(d, cs->GetCargoIcon(), PAL_NONE, cs->name, cs->Index(), false));
 	}
 
 	return list;

--- a/src/widgets/dropdown_type.h
+++ b/src/widgets/dropdown_type.h
@@ -149,6 +149,12 @@ public:
 		this->dbounds = this->dsprite;
 	}
 
+	template <typename... Args>
+	explicit DropDownIcon(const Dimension &dim, SpriteID sprite, PaletteID palette, Args&&... args) : TBase(std::forward<Args>(args)...), sprite(sprite), palette(palette), dbounds(dim)
+	{
+		this->dsprite = GetSpriteSize(this->sprite);
+	}
+
 	uint Height() const override { return std::max(this->dbounds.height, this->TBase::Height()); }
 	uint Width() const override { return this->dbounds.width + WidgetDimensions::scaled.hsep_normal + this->TBase::Width(); }
 
@@ -158,15 +164,6 @@ public:
 		Rect ir = r.WithWidth(this->dbounds.width, rtl);
 		DrawSprite(this->sprite, this->palette, CenterBounds(ir.left, ir.right, this->dsprite.width), CenterBounds(r.top, r.bottom, this->dsprite.height));
 		this->TBase::Draw(full, r.Indent(this->dbounds.width + WidgetDimensions::scaled.hsep_normal, rtl), sel, bg_colour);
-	}
-
-	/**
-	 * Override bounding box dimensions of sprite, to allow multiple options to have consistent spacing.
-	 * @param dim New bounding box to assign.
-	 */
-	void SetDimension(const Dimension &dim)
-	{
-		this->dbounds = dim;
 	}
 };
 


### PR DESCRIPTION
## Motivation / Problem

Cargo icons are only visible in the station view window, when stations have waiting cargo. Painstakingly drawn 10 pixel high pixel art masterpieces are being denied to us.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add cargo icons to cargo filter dropdown lists, and revel in beauty of them.

Cargo icons have various widths so we have a function to get the largest and make sure all items use the same width.
<s>Cargo icons have various widths so they are drawn at the end of the item. Other positions were tested and were less visually coherent.</s>

This also introduces the CRTP (Curiously Recursive Template Pattern) redesign for drop down list items, which allows them to be composed of various parts instead of to a fixed design, but unfortunately means they are templates to are implemented in the head filters.

<s>https://github.com/OpenTTD/OpenTTD/assets/639850/00fe6c55-118b-4eff-86a5-38de324e123e</s>

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/cc2247ed-a24f-4f34-bf90-4474442198c5)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
