### PR TITLE
Feature: Randomize direction of rail vehicle on build based on probability callback.

### DIFF
--- a/src/newgrf_callbacks.h
+++ b/src/newgrf_callbacks.h
@@ -282,6 +282,9 @@ enum CallbackID {
 
 	/** Called to determine the engine name to show. */
 	CBID_VEHICLE_NAME                    = 0x161, // 15 bit callback
+
+	/** Called to determine probability during build. */
+	CBID_VEHICLE_BUILD_PROBABILITY       = 0x162, // 15 bit callback
 };
 
 /**

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1192,6 +1192,20 @@ int GetEngineProperty(EngineID engine, PropertyID property, int orig_value, cons
 	return orig_value;
 }
 
+/**
+ * Test for vehicle build probablity type.
+ * @param v Vehicle whose build probability to test.
+ * @param type Build probability type to test for.
+ * @returns True iff the probability result says so.
+ */
+bool TestVehicleBuildProbability(Vehicle *v, EngineID engine, BuildProbabilityType type)
+{
+	uint16_t p = GetVehicleCallback(CBID_VEHICLE_BUILD_PROBABILITY, std::underlying_type<BuildProbabilityType>::type(type), 0, engine, v);
+	if (p == CALLBACK_FAILED) return false;
+
+	const uint16_t PROBABILITY_RANGE = 100;
+	return p + RandomRange(PROBABILITY_RANGE) >= PROBABILITY_RANGE;
+}
 
 static void DoTriggerVehicle(Vehicle *v, VehicleTrigger trigger, uint16_t base_random_bits, bool first)
 {

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -103,6 +103,12 @@ bool UsesWagonOverride(const Vehicle *v);
 int GetVehicleProperty(const Vehicle *v, PropertyID property, int orig_value, bool is_signed = false);
 int GetEngineProperty(EngineID engine, PropertyID property, int orig_value, const Vehicle *v = nullptr, bool is_signed = false);
 
+enum class BuildProbabilityType {
+	Reversed = 0,
+};
+
+bool TestVehicleBuildProbability(Vehicle *v, EngineID engine, BuildProbabilityType type);
+
 enum VehicleTrigger {
 	VEHICLE_TRIGGER_NEW_CARGO     = 0x01,
 	/* Externally triggered only for the first vehicle in chain */

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -661,6 +661,7 @@ static CommandCost CmdBuildRailWagon(DoCommandFlag flags, TileIndex tile, const 
 
 		v->group_id = DEFAULT_GROUP;
 
+		if (TestVehicleBuildProbability(v, v->engine_type, BuildProbabilityType::Reversed)) SetBit(v->flags, VRF_REVERSE_DIRECTION);
 		AddArticulatedParts(v);
 
 		v->UpdatePosition();
@@ -728,6 +729,7 @@ static void AddRearEngineToMultiheadedTrain(Train *v)
 	v->SetMultiheaded();
 	u->SetMultiheaded();
 	v->SetNext(u);
+	if (TestVehicleBuildProbability(u, u->engine_type, BuildProbabilityType::Reversed)) SetBit(u->flags, VRF_REVERSE_DIRECTION);
 	u->UpdatePosition();
 
 	/* Now we need to link the front and rear engines together */
@@ -799,6 +801,7 @@ CommandCost CmdBuildRailVehicle(DoCommandFlag flags, TileIndex tile, const Engin
 		v->SetFrontEngine();
 		v->SetEngine();
 
+		if (TestVehicleBuildProbability(v, v->engine_type, BuildProbabilityType::Reversed)) SetBit(v->flags, VRF_REVERSE_DIRECTION);
 		v->UpdatePosition();
 
 		if (rvi->railveh_type == RAILVEH_MULTIHEAD) {


### PR DESCRIPTION
## Motivation / Problem

NewGRF authors have be known to implement randomisation of engine direction for variety. An engine may be built facing forward or backward.

Unfortunately this requires using a random bit to record whether the vehicle is reverse, and it requires duplicating the sprites to be drawn, along with probably duplicating act3/2/1 chains.

This is quite a lot of complexity, considering the game already has the ability to let uses flip engines in the depot manually.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

<s>Implement automatic randomization using 2 bits of the ExtraFlags property.</s>

Implement automatic randomization using a new callback, CBID_VEHICLE_BUILD_PROBABILITY.

To use this callback, test for var 0C = 0x0162 and var 10 = 0x00, and return a value between 0...100 decimal to indicate the probability of being reversed.

This allows NewGRF authors to indicate that the game should randomly flip rail vehicles on build, without needing to use random bits nor duplicate sprites to handle it themselves.

<s>Bits 4 and 5 of ExtraFlags are used to create a 2-bit value ranging from 0-3, resulting a random probability of 0%, 16%, 33% and 50%.</s>

If said randomization decides the vehicle should be reverse, then the appropriate VRF_REVERSE_DIRECTION bit is set. This can still be toggled by the player.

Authors do not need to use a random bit to store this state as it is a built-in flag, and importantly they do not need to duplicate sprites.

<s>This is effective only if the vehicle is built as a single unit.</s>

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/739aab66-9ad7-4e34-a493-fa35c0eee851)


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This uses 2 bits from ExtraFlags, which could possibly be considered abuse, However adding a new property would prevent compatibility with previous game versions which will simply ignore these flags.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
