### PR TITLE
Change: Don't change music track when toggling shuffle mode.

### DIFF
--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -197,6 +197,7 @@ void MusicSystem::Shuffle()
 
 	if (_settings_client.music.playing) this->Play();
 
+	InvalidateWindowData(WC_MUSIC_TRACK_SELECTION, 0);
 	InvalidateWindowData(WC_MUSIC_WINDOW, 0);
 }
 
@@ -208,6 +209,7 @@ void MusicSystem::Unshuffle()
 
 	if (_settings_client.music.playing) this->Play();
 
+	InvalidateWindowData(WC_MUSIC_TRACK_SELECTION, 0);
 	InvalidateWindowData(WC_MUSIC_WINDOW, 0);
 }
 


### PR DESCRIPTION
## Motivation / Problem

Toggling shuffle mode instantly changes the currently playing music track.

I think it is better for toggling shuffle mode to only affect the playlist order, with no other side effects.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead of restarting play back when toggling shuffle, remember the current playlist song and update the playlist position.

Additionally, fix an oversight that meant the playlist window itself is not refreshed when toggling shuffle mode.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
