### PR TITLE
Fix ab1a4c6c: Crash if the "No Music" set is loaded because there is no current set_index.

### DIFF
--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -87,6 +87,7 @@ struct MusicSystem {
 	void PlaylistClear();
 
 private:
+	uint GetSetIndex();
 	void SetPositionBySetIndex(uint set_index);
 	void ChangePlaylistPosition(int ofs);
 	int playlist_position;
@@ -192,13 +193,24 @@ void MusicSystem::SetPositionBySetIndex(uint set_index)
 }
 
 /**
+ * Get set index from current playlist position.
+ * @return current set index, or UINT_MAX if nothing is selected.
+ */
+uint MusicSystem::GetSetIndex()
+{
+	return static_cast<size_t>(this->playlist_position) < this->active_playlist.size()
+		? this->active_playlist[this->playlist_position].set_index
+		: UINT_MAX;
+}
+
+/**
  * Enable shuffle mode.
  */
 void MusicSystem::Shuffle()
 {
 	_settings_client.music.shuffle = true;
 
-	uint set_index = this->active_playlist[this->playlist_position].set_index;
+	uint set_index = this->GetSetIndex();
 	this->active_playlist = this->displayed_playlist;
 	for (size_t i = 0; i < this->active_playlist.size(); i++) {
 		size_t shuffle_index = InteractiveRandom() % (this->active_playlist.size() - i);
@@ -217,7 +229,7 @@ void MusicSystem::Unshuffle()
 {
 	_settings_client.music.shuffle = false;
 
-	uint set_index = this->active_playlist[this->playlist_position].set_index;
+	uint set_index = this->GetSetIndex();
 	this->active_playlist = this->displayed_playlist;
 	this->SetPositionBySetIndex(set_index);
 


### PR DESCRIPTION
## Motivation / Problem

Crash if the "No Music" set is loaded because there is no current set_index.

`active_playlist` is empty in this case but I did not bounds check.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add a helper function to get the current set_index which which checks it is in range.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
