### PR TITLE
Fix: Deleting towns did not check for waypoints referencing the town

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -17,6 +17,7 @@
 #include "command_func.h"
 #include "industry.h"
 #include "station_base.h"
+#include "waypoint_base.h"
 #include "station_kdtree.h"
 #include "company_base.h"
 #include "news_func.h"
@@ -3038,6 +3039,11 @@ CommandCost CmdDeleteTown(DoCommandFlag flags, TownID town_id)
 			CommandCost ret = Command<CMD_LANDSCAPE_CLEAR>::Do(flags, st->airport.tile);
 			if (ret.Failed()) return ret;
 		}
+	}
+
+	/* Waypoints refer to towns. */
+	for (const Waypoint *wp : Waypoint::Iterate()) {
+		if (wp->town == t) return CMD_ERROR;
 	}
 
 	/* Depots refer to towns. */


### PR DESCRIPTION
## Motivation / Problem

Deleting a town with a waypoint by using the scenario editor could leave the waypoint dangling.
This could result in the scenario being unloadable if it was saved after this occurred.

## Description

Disallow deleting towns which are referenced by waypoints.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
