### PR TITLE
Codechange: pass std::string references to OpenBrowser

### DIFF
--- a/src/help_gui.cpp
+++ b/src/help_gui.cpp
@@ -145,16 +145,16 @@ struct HelpWindow : public Window {
 				new GameManualTextfileWindow(LICENSE_FILENAME);
 				break;
 			case WID_HW_WEBSITE:
-				OpenBrowser(WEBSITE_LINK.c_str());
+				OpenBrowser(WEBSITE_LINK);
 				break;
 			case WID_HW_WIKI:
-				OpenBrowser(WIKI_LINK.c_str());
+				OpenBrowser(WIKI_LINK);
 				break;
 			case WID_HW_BUGTRACKER:
-				OpenBrowser(BUGTRACKER_LINK.c_str());
+				OpenBrowser(BUGTRACKER_LINK);
 				break;
 			case WID_HW_COMMUNITY:
-				OpenBrowser(COMMUNITY_LINK.c_str());
+				OpenBrowser(COMMUNITY_LINK);
 				break;
 		}
 	}

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -384,7 +384,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 			}
 		}
 
-		OpenBrowser(url.c_str());
+		OpenBrowser(url);
 	}
 
 	/**
@@ -855,7 +855,7 @@ public:
 
 			case WID_NCL_OPEN_URL:
 				if (this->selected != nullptr) {
-					OpenBrowser(this->selected->url.c_str());
+					OpenBrowser(this->selected->url);
 				}
 				break;
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -2501,7 +2501,7 @@ struct NetworkAskSurveyWindow : public Window {
 				break;
 
 			case WID_NAS_LINK:
-				OpenBrowser(NETWORK_SURVEY_DETAILS_LINK.c_str());
+				OpenBrowser(NETWORK_SURVEY_DETAILS_LINK);
 				break;
 
 			case WID_NAS_NO:

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -94,7 +94,7 @@ bool HandleBootstrap();
 
 extern void AfterLoadCompanyStats();
 extern Company *DoStartupNewCompany(bool is_ai, CompanyID company = INVALID_COMPANY);
-extern void OSOpenBrowser(const char *url);
+extern void OSOpenBrowser(const std::string &url);
 extern void RebuildTownCaches();
 extern void ShowOSErrorBox(const char *buf, bool system);
 extern std::string _config_file;
@@ -370,7 +370,7 @@ void MakeNewgameSettingsLive()
 	}
 }
 
-void OpenBrowser(const char *url)
+void OpenBrowser(const std::string &url)
 {
 	/* Make sure we only accept urls that are sure to open a browser. */
 	if (StrStartsWith(url, "http://") || StrStartsWith(url, "https://")) {

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -90,7 +90,7 @@ void SwitchToMode(SwitchMode new_mode);
 bool RequestNewGRFScan(struct NewGRFScanCallback *callback = nullptr);
 void GenerateSavegameId();
 
-void OpenBrowser(const char *url);
+void OpenBrowser(const std::string &url);
 void ChangeAutosaveFrequency(bool reset);
 
 #endif /* OPENTTD_H */

--- a/src/os/macosx/macos.mm
+++ b/src/os/macosx/macos.mm
@@ -143,9 +143,9 @@ void ShowOSErrorBox(const char *buf, bool system)
 	}
 }
 
-void OSOpenBrowser(const char *url)
+void OSOpenBrowser(const std::string &url)
 {
-	[ [ NSWorkspace sharedWorkspace ] openURL:[ NSURL URLWithString:[ NSString stringWithUTF8String:url ] ] ];
+	[ [ NSWorkspace sharedWorkspace ] openURL:[ NSURL URLWithString:[ NSString stringWithUTF8String:url.c_str() ] ] ];
 }
 
 /**

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -230,20 +230,20 @@ std::optional<std::string> GetClipboardContents()
 
 
 #if defined(__EMSCRIPTEN__)
-void OSOpenBrowser(const char *url)
+void OSOpenBrowser(const std::string &url)
 {
 	/* Implementation in pre.js */
-	EM_ASM({ if(window["openttd_open_url"]) window.openttd_open_url($0, $1) }, url, strlen(url));
+	EM_ASM({ if (window["openttd_open_url"]) window.openttd_open_url($0, $1) }, url.c_str(), url.size());
 }
 #elif !defined( __APPLE__)
-void OSOpenBrowser(const char *url)
+void OSOpenBrowser(const std::string &url)
 {
 	pid_t child_pid = fork();
 	if (child_pid != 0) return;
 
 	const char *args[3];
 	args[0] = "xdg-open";
-	args[1] = url;
+	args[1] = url.c_str();
 	args[2] = nullptr;
 	execvp(args[0], const_cast<char * const *>(args));
 	Debug(misc, 0, "Failed to open url: {}", url);

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -52,7 +52,7 @@ void ShowOSErrorBox(const char *buf, bool)
 	MessageBox(GetActiveWindow(), OTTD2FS(buf).c_str(), L"Error!", MB_ICONSTOP | MB_TASKMODAL);
 }
 
-void OSOpenBrowser(const char *url)
+void OSOpenBrowser(const std::string &url)
 {
 	ShellExecute(GetActiveWindow(), L"open", OTTD2FS(url).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 }

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -495,7 +495,7 @@ struct GameOptionsWindow : Window {
 				break;
 
 			case WID_GO_SURVEY_LINK_BUTTON:
-				OpenBrowser(NETWORK_SURVEY_DETAILS_LINK.c_str());
+				OpenBrowser(NETWORK_SURVEY_DETAILS_LINK);
 				break;
 
 			case WID_GO_SURVEY_PREVIEW_BUTTON:

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -406,7 +406,7 @@ void TextfileWindow::NavigateHistory(int delta)
 		}
 
 		case HyperlinkType::Web:
-			OpenBrowser(link.destination.c_str());
+			OpenBrowser(link.destination);
 			break;
 
 		case HyperlinkType::File:


### PR DESCRIPTION
## Motivation / Problem

In #11512 I saw a lot of new `.c_str()`s getting added. I checked whether that made sense, or whether we should use a C++ type.


## Description

Given that for Windows we pass the URL it to `OTTD2FS` which converts it a `std::string`, for Windows it makes sense to always use `std::string`.
For all other platforms, only the NewGRF URL is actually a C-style string, so for most but the NewGRF URL using `std::string` won't have any effect.
All in all, for Windows you remove a lot of unneeded conversions to C-style string and back std::string, and for all others only the NewGRF URL gets a tiny penalty. So, I'd say: got for consistency and just use C++-style strings.


## Limitations

Not tested. I hope it even compiles...


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
