### PR TITLE
Fix #11516: Changing interface scale makes resizeable windows larger but not smaller.

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1391,8 +1391,6 @@ void LoadStringWidthTable(bool monospace)
 			_stringwidth_table[fs][i] = GetGlyphWidth(fs, i + 32);
 		}
 	}
-
-	ReInitAllWindows(false);
 }
 
 /**

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -270,6 +270,7 @@ static void ZoomMinMaxChanged(int32_t)
 		_gui_zoom = _settings_client.gui.zoom_min;
 		UpdateCursorSize();
 		LoadStringWidthTable();
+		ReInitAllWindows(true);
 	}
 }
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -958,8 +958,9 @@ void Window::ReInit(int rx, int ry, bool reposition)
 	this->SetDirty(); // Mark whole current window as dirty.
 
 	/* Save current size. */
-	int window_width  = this->width;
-	int window_height = this->height;
+	int window_width  = this->width * _gui_scale / this->scale;
+	int window_height = this->height * _gui_scale / this->scale;
+	this->scale = _gui_scale;
 
 	this->OnInit();
 	/* Re-initialize the window from the ground up. No need to change the nested_array, as all widgets stay where they are. */
@@ -1770,7 +1771,7 @@ void Window::InitNested(WindowNumber window_number)
  * Empty constructor, initialization has been moved to #InitNested() called from the constructor of the derived class.
  * @param desc The description of the window.
  */
-Window::Window(WindowDesc *desc) : window_desc(desc), mouse_capture_widget(-1)
+Window::Window(WindowDesc *desc) : window_desc(desc), scale(_gui_scale), mouse_capture_widget(-1)
 {
 	this->z_position = _z_windows.insert(_z_windows.end(), this);
 }

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -242,6 +242,8 @@ public:
 	WindowClass window_class;   ///< Window class
 	WindowNumber window_number; ///< Window number within the window class
 
+	int scale; ///< Scale of this window -- used to determine how to resize.
+
 	uint8_t timeout_timer;      ///< Timer value of the WF_TIMEOUT for flags.
 	uint8_t white_border_timer; ///< Timer value of the WF_WHITE_BORDER for flags.
 


### PR DESCRIPTION
## Motivation / Problem

As per #11516, changing interface scale make resizeable windows larger, but not smaller. This is because rather than special handling on scale change, the window size is constrained by its minimum size which necessarily makes it larger.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, explicitly scale window size by interface scale changes during window `ReInit()`. This requires the current scale to be stored and updated per window, as resizes can be nested and only the first pass should apply the scale change.

This also fixes a bug that `LoadStringWidthTable()` issues a `ReInit()` itself, so changing interface scale ended up doing two unnecessary passes. This was just wasteful before, but would now mean the scaling change is applied too early.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
