### PR TITLE
Fix: Nightly build failures for macos and linux

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -17,6 +17,11 @@ jobs:
       # manylinux2014 is based on CentOS 7, but already has a lot of things
       # installed and preconfigured. It makes it easier to build OpenTTD.
       image: quay.io/pypa/manylinux2014_x86_64
+      volumes:
+      - /usr/local/share/vcpkg:/vcpkg
+      env:
+        ImageOS: ${{ env.ImageOS }}
+        ImageVersion: ${{ env.ImageVersion }}
 
     steps:
     - name: Download source
@@ -41,13 +46,18 @@ jobs:
     - name: Enable Rust cache
       uses: Swatinem/rust-cache@v2
 
+    - name: Prepare cache key
+      id: key
+      run: |
+        echo "image=$ImageOS-$ImageVersion" >> $GITHUB_OUTPUT
+
     - name: Enable vcpkg cache
       uses: actions/cache@v3
       with:
         path: /vcpkg/installed
-        key: ubuntu-20.04-vcpkg-release-1 # Increase the number whenever dependencies are modified
+        key: ${{ steps.key.outputs.image }}-vcpkg-release-1 # Increase the number whenever dependencies are modified
         restore-keys: |
-          ubuntu-20.04-vcpkg-release
+          ${{ steps.key.outputs.image }}-vcpkg-release
 
     - name: Install dependencies
       run: |
@@ -103,40 +113,23 @@ jobs:
         # We use vcpkg for our dependencies, to get more up-to-date version.
         echo "::group::Install vcpkg and dependencies"
 
-        # We do a little dance to make sure we copy the cached install folder
-        # into our new clone.
-        git clone --depth=1 https://github.com/microsoft/vcpkg /vcpkg-clone
-        if [ -e /vcpkg/installed ]; then
-          mv /vcpkg/installed /vcpkg-clone/
-          rm -rf /vcpkg
-        fi
-        mv /vcpkg-clone /vcpkg
+        # Make Python3 available for other packages.
+        /vcpkg/vcpkg install python3
+        ln -sf /vcpkg/installed/x64-linux/tools/python3/python3.[0-9][0-9] /usr/bin/python3
 
-        (
-          cd /vcpkg
-          ./bootstrap-vcpkg.sh -disableMetrics
-
-          # Once installed (and cached) a package will never be upgraded unless we do it ourselves.
-          ./vcpkg upgrade --no-dry-run
-
-          # Make Python3 available for other packages.
-          ./vcpkg install python3
-          ln -sf $(pwd)/installed/x64-linux/tools/python3/python3.[0-9][0-9] /usr/bin/python3
-
-          ./vcpkg install \
-            breakpad \
-            curl[http2] \
-            fontconfig \
-            freetype \
-            harfbuzz \
-            icu \
-            liblzma \
-            libpng \
-            lzo \
-            sdl2 \
-            zlib \
-            # EOF
-        )
+        /vcpkg/vcpkg install \
+          breakpad \
+          curl[http2] \
+          fontconfig \
+          freetype \
+          harfbuzz \
+          icu \
+          liblzma \
+          libpng \
+          lzo \
+          sdl2 \
+          zlib \
+          # EOF
         echo "::endgroup::"
 
         echo "::group::Install breakpad dependencies"

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -12,7 +12,7 @@ jobs:
   macos:
     name: MacOS
 
-    runs-on: macos-11
+    runs-on: macos-12
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.13
 


### PR DESCRIPTION
## Motivation / Problem
For a week now, macos and linux nightlies fail to build.
For both it happens during the "Install dependencies" step.
For macos the error is
```
  Error: You are using macOS 11.
  We (and Apple) do not provide support for this old version.
  It is expected behaviour that some formulae will fail to build in this old version.
  It is expected behaviour that Homebrew will be buggy and slow.
  Do not create any issues about this on Homebrew's GitHub repositories.
  Do not create any issues even if you think this message is unrelated.
  Any opened issues will be immediately closed without response.
  Do not ask for help from Homebrew or its maintainers on social media.
  You may ask for help in Homebrew's discussions but are unlikely to receive a response.
  Try to figure out the problem yourself and submit a fix as a pull request.
  We will review it but may or may not accept it.
```
For linux it's during vcpkg run (upstream may have changed stuff again)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
For macos just switch runner from `macos-11` to `macos-12`.

For linux I reworked our vcpkg flow. We used to clone vcpkg repo into our container, and manually upgrade packages, as a way to always get up-to-date version of our dependencies, but that comes with the risk of having broken stuff from upstream. And the cache was not updated with the upgraded version, making it quite useless anyway.
So I decided to instead use vcpkg from the runner, it changes only when runner image is updated (like our other release workflows) so we don't need to manually update the packages as a new cache is created when a new image is released, and still get frequent enough upgrades of our dependencies.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
