### PR TITLE
Remove: ZOOM_LVL_COUNT

### DIFF
--- a/src/blitter/32bpp_optimized.cpp
+++ b/src/blitter/32bpp_optimized.cpp
@@ -277,7 +277,7 @@ template <bool Tpal_to_rgb> Sprite *Blitter_32bppOptimized::EncodeInternal(const
 	/* streams of pixels (a, r, g, b channels)
 	 *
 	 * stored in separated stream so data are always aligned on 4B boundary */
-	Colour *dst_px_orig[ZOOM_LVL_COUNT];
+	Colour *dst_px_orig[ZOOM_LVL_END];
 
 	/* interleaved stream of 'm' channel and 'n' channel
 	 * 'n' is number of following pixels with the same alpha channel class
@@ -285,10 +285,10 @@ template <bool Tpal_to_rgb> Sprite *Blitter_32bppOptimized::EncodeInternal(const
 	 *
 	 * it has to be stored in one stream so fewer registers are used -
 	 * x86 has problems with register allocation even with this solution */
-	uint16_t *dst_n_orig[ZOOM_LVL_COUNT];
+	uint16_t *dst_n_orig[ZOOM_LVL_END];
 
 	/* lengths of streams */
-	uint32_t lengths[ZOOM_LVL_COUNT][2];
+	uint32_t lengths[ZOOM_LVL_END][2];
 
 	ZoomLevel zoom_min;
 	ZoomLevel zoom_max;

--- a/src/blitter/32bpp_optimized.hpp
+++ b/src/blitter/32bpp_optimized.hpp
@@ -17,7 +17,7 @@ class Blitter_32bppOptimized : public Blitter_32bppSimple {
 public:
 	/** Data stored about a (single) sprite. */
 	struct SpriteData {
-		uint32_t offset[ZOOM_LVL_COUNT][2]; ///< Offsets (from .data) to streams for different zoom levels, and the normal and remap image information.
+		uint32_t offset[ZOOM_LVL_END][2]; ///< Offsets (from .data) to streams for different zoom levels, and the normal and remap image information.
 		byte data[];                      ///< Data, all zoomlevels.
 	};
 

--- a/src/blitter/32bpp_sse2.hpp
+++ b/src/blitter/32bpp_sse2.hpp
@@ -72,7 +72,7 @@ public:
 	};
 	struct SpriteData {
 		SpriteFlags flags;
-		SpriteInfo infos[ZOOM_LVL_COUNT];
+		SpriteInfo infos[ZOOM_LVL_END];
 		byte data[]; ///< Data, all zoomlevels.
 	};
 

--- a/src/blitter/8bpp_optimized.hpp
+++ b/src/blitter/8bpp_optimized.hpp
@@ -18,7 +18,7 @@ class Blitter_8bppOptimized FINAL : public Blitter_8bppBase {
 public:
 	/** Data stored about a (single) sprite. */
 	struct SpriteData {
-		uint32_t offset[ZOOM_LVL_COUNT]; ///< Offsets (from .data) to streams for different zoom levels.
+		uint32_t offset[ZOOM_LVL_END]; ///< Offsets (from .data) to streams for different zoom levels.
 		byte data[];                   ///< Data, all zoomlevels.
 	};
 

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -195,7 +195,7 @@ static void StartSound(SoundID sound_id, float pan, uint volume)
 
 
 static const byte _vol_factor_by_zoom[] = {255, 255, 255, 190, 134, 87};
-static_assert(lengthof(_vol_factor_by_zoom) == ZOOM_LVL_COUNT);
+static_assert(lengthof(_vol_factor_by_zoom) == ZOOM_LVL_END);
 
 static const byte _sound_base_vol[] = {
 	128,  90, 128, 128, 128, 128, 128, 128,
@@ -258,7 +258,7 @@ static void SndPlayScreenCoordFx(SoundID sound, int left, int right, int top, in
 			StartSound(
 				sound,
 				panning,
-				_vol_factor_by_zoom[vp->zoom - ZOOM_LVL_BEGIN]
+				_vol_factor_by_zoom[vp->zoom]
 			);
 			return;
 		}

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -457,7 +457,7 @@ static void *ReadSprite(const SpriteCache *sc, SpriteID id, SpriteType sprite_ty
 
 	Debug(sprite, 9, "Load sprite {}", id);
 
-	SpriteLoader::Sprite sprite[ZOOM_LVL_COUNT];
+	SpriteLoader::Sprite sprite[ZOOM_LVL_END];
 	uint8_t sprite_avail = 0;
 	sprite[ZOOM_LVL_NORMAL].type = sprite_type;
 
@@ -1051,4 +1051,4 @@ void GfxClearFontSpriteCache()
 	}
 }
 
-/* static */ ReusableBuffer<SpriteLoader::CommonPixel> SpriteLoader::Sprite::buffer[ZOOM_LVL_COUNT];
+/* static */ ReusableBuffer<SpriteLoader::CommonPixel> SpriteLoader::Sprite::buffer[ZOOM_LVL_END];

--- a/src/spriteloader/spriteloader.hpp
+++ b/src/spriteloader/spriteloader.hpp
@@ -62,7 +62,7 @@ public:
 		void AllocateData(ZoomLevel zoom, size_t size) { this->data = Sprite::buffer[zoom].ZeroAllocate(size); }
 	private:
 		/** Allocated memory to pass sprite data around */
-		static ReusableBuffer<SpriteLoader::CommonPixel> buffer[ZOOM_LVL_COUNT];
+		static ReusableBuffer<SpriteLoader::CommonPixel> buffer[ZOOM_LVL_END];
 	};
 
 	/**

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -1270,10 +1270,10 @@ void OpenGLBackend::ReleaseAnimBuffer(const Rect &update_rect)
 	Sprite *dest_sprite = (Sprite *)allocator(sizeof(*dest_sprite) + sizeof(OpenGLSprite));
 
 	OpenGLSprite *gl_sprite = (OpenGLSprite *)dest_sprite->data;
-	new (gl_sprite) OpenGLSprite(sprite->width, sprite->height, sprite->type == SpriteType::Font ? 1 : ZOOM_LVL_COUNT, sprite->colours);
+	new (gl_sprite) OpenGLSprite(sprite->width, sprite->height, sprite->type == SpriteType::Font ? 1 : ZOOM_LVL_END, sprite->colours);
 
 	/* Upload texture data. */
-	for (int i = 0; i < (sprite->type == SpriteType::Font ? 1 : ZOOM_LVL_COUNT); i++) {
+	for (int i = 0; i < (sprite->type == SpriteType::Font ? 1 : ZOOM_LVL_END); i++) {
 		gl_sprite->Update(sprite[i].width, sprite[i].height, i, sprite[i].data);
 	}
 
@@ -1323,7 +1323,7 @@ void OpenGLBackend::RenderOglSprite(OpenGLSprite *gl_sprite, PaletteID pal, int 
 	Dimension dim = gl_sprite->GetSize(zoom);
 	_glUseProgram(this->sprite_program);
 	_glUniform4f(this->sprite_sprite_loc, (float)x, (float)y, (float)dim.width, (float)dim.height);
-	_glUniform1f(this->sprite_zoom_loc, (float)(zoom - ZOOM_LVL_BEGIN));
+	_glUniform1f(this->sprite_zoom_loc, (float)zoom);
 	_glUniform2f(this->sprite_screen_loc, (float)_screen.width, (float)_screen.height);
 	_glUniform1i(this->sprite_rgb_loc, rgb ? 1 : 0);
 	_glUniform1i(this->sprite_crash_loc, pal == PALETTE_CRASH ? 1 : 0);

--- a/src/video/opengl.h
+++ b/src/video/opengl.h
@@ -108,7 +108,7 @@ public:
 	/* SpriteEncoder */
 
 	bool Is32BppSupported() override { return true; }
-	uint GetSpriteAlignment() override { return 1u << (ZOOM_LVL_COUNT - 1); }
+	uint GetSpriteAlignment() override { return 1u << (ZOOM_LVL_END - 1); }
 	Sprite *Encode(const SpriteLoader::Sprite *sprite, AllocatorProc *allocator) override;
 };
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1477,7 +1477,7 @@ void ViewportSign::UpdatePosition(int center, int top, StringID str, StringID st
  */
 void ViewportSign::MarkDirty(ZoomLevel maxzoom) const
 {
-	Rect zoomlevels[ZOOM_LVL_COUNT];
+	Rect zoomlevels[ZOOM_LVL_END];
 
 	for (ZoomLevel zoom = ZOOM_LVL_BEGIN; zoom != ZOOM_LVL_END; zoom++) {
 		/* FIXME: This doesn't switch to width_small when appropriate. */

--- a/src/zoom_type.h
+++ b/src/zoom_type.h
@@ -27,8 +27,6 @@ enum ZoomLevel : byte {
 	ZOOM_LVL_OUT_32X,    ///< Zoomed 32 times out.
 	ZOOM_LVL_END,        ///< End for iteration.
 
-	ZOOM_LVL_COUNT = ZOOM_LVL_END - ZOOM_LVL_BEGIN, ///< Number of zoom levels.
-
 	/* Here we define in which zoom viewports are */
 	ZOOM_LVL_VIEWPORT = ZOOM_LVL_OUT_4X, ///< Default zoom level for viewports.
 	ZOOM_LVL_NEWS     = ZOOM_LVL_OUT_4X, ///< Default zoom level for the news messages.


### PR DESCRIPTION
## Motivation / Problem

Looking at #11518 and falling in a rabbit hole.

`ZoomLevel` is the only enumeration with a COUNT and END. The logic of the COUNT implies that BEGIN could be non-zero, but all but two uses of zoom level assume that BEGIN is zero, making the separate count only confusing.


## Description

Replace `ZOOM_LVL_COUNT` with `ZOOM_LVL_END`, and remove the ` - ZOOM_LVL_BEGIN` from the two cases where it existed.


## Limitations

Changing `ZOOM_LVL_BEGIN` to be non-zero will be slightly more work, but having code that looks like it should work but doesn't is in my opinion worse than having code that doesn't imply that changing `ZOOM_LVL_BEGIN` is fine.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
