### PR TITLE
Fix #11521, e404ba0: size for remaining span determined incorrectly

### DIFF
--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -129,7 +129,7 @@ public:
 	 */
 	StringParameters GetRemainingParameters(size_t offset)
 	{
-		return StringParameters(this->parameters.subspan(offset, GetDataLeft()));
+		return StringParameters(this->parameters.subspan(offset, this->parameters.size() - offset));
 	}
 
 	/** Return the amount of elements which can still be read. */


### PR DESCRIPTION
## Motivation / Problem

Fixes #11521.


## Description

Before e404ba0 things were right, in that commit the offset was added as parameter to `GetRemainingParameters`, but it still called `GetDataLeft` which used the original offset to determine the remaining size instead of the offset passed as the parameter.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
