### PR TITLE
Change: Add extra padding to climate buttons to match pre-#11464.

### DIFF
--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -575,6 +575,12 @@ struct GenerateLandscapeWindow : public Window {
 		Dimension d{0, (uint)GetCharacterHeight(FS_NORMAL)};
 		const StringID *strs = nullptr;
 		switch (widget) {
+			case WID_GL_TEMPERATE: case WID_GL_ARCTIC:
+			case WID_GL_TROPICAL: case WID_GL_TOYLAND:
+				size->width += WidgetDimensions::scaled.fullbevel.Horizontal();
+				size->height += WidgetDimensions::scaled.fullbevel.Vertical();
+				break;
+
 			case WID_GL_HEIGHTMAP_HEIGHT_TEXT:
 				SetDParam(0, MAX_TILE_HEIGHT);
 				d = GetStringBoundingBox(STR_JUST_INT);
@@ -1118,6 +1124,12 @@ struct CreateScenarioWindow : public Window
 	{
 		StringID str = STR_JUST_INT;
 		switch (widget) {
+			case WID_CS_TEMPERATE: case WID_CS_ARCTIC:
+			case WID_CS_TROPICAL: case WID_CS_TOYLAND:
+				size->width += WidgetDimensions::scaled.fullbevel.Horizontal();
+				size->height += WidgetDimensions::scaled.fullbevel.Vertical();
+				break;
+
 			case WID_CS_START_DATE_TEXT:
 				SetDParam(0, TimerGameCalendar::ConvertYMDToDate(CalendarTime::MAX_YEAR, 0, 1));
 				str = STR_JUST_DATE_LONG;

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -297,6 +297,17 @@ struct SelectGameWindow : public Window {
 		}
 	}
 
+	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	{
+		switch (widget) {
+			case WID_SGI_TEMPERATE_LANDSCAPE: case WID_SGI_ARCTIC_LANDSCAPE:
+			case WID_SGI_TROPIC_LANDSCAPE: case WID_SGI_TOYLAND_LANDSCAPE:
+				size->width += WidgetDimensions::scaled.fullbevel.Horizontal();
+				size->height += WidgetDimensions::scaled.fullbevel.Vertical();
+				break;
+		}
+	}
+
 	void OnResize() override
 	{
 		bool changed = false;


### PR DESCRIPTION
## Motivation / Problem

Padding used to be included in the SetMinimalSize() part which was removed, but it also required specific sprite sizes.

This results in the climate buttons being a bit cramped on the intro gui. The padding was also inconsistent for different windows which use the climate buttons.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/68ae7f01-3d81-435e-bc1c-f9f4b6d6efb6)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This now adds padding on the already determined size, removing the need for hardcoding pixel dimensions and allowing the sprites to be any size, along with keeping it consistent for all windows.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/fada3249-28ea-4091-8dac-c894c797a286)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
