### PR TITLE
Remove: officially mark Vista as no longer supported

### DIFF
--- a/docs/directory_structure.md
+++ b/docs/directory_structure.md
@@ -19,14 +19,14 @@ your operating system:
     - Windows:
         - `C:\My Documents\OpenTTD` (95, 98, ME)
         - `C:\Documents and Settings\<username>\My Documents\OpenTTD` (2000, XP)
-        - `C:\Users\<username>\Documents\OpenTTD` (Vista, 7, 8.1, 10, 11)
+        - `C:\Users\<username>\Documents\OpenTTD` (7, 8.1, 10, 11)
     - macOS: `~/Documents/OpenTTD`
     - Linux: `$XDG_DATA_HOME/openttd` which is usually `~/.local/share/openttd`
        when built with XDG base directory support, otherwise `~/.openttd`
 3. The shared directory
     - Windows:
         - `C:\Documents and Settings\All Users\Shared Documents\OpenTTD` (2000, XP)
-        - `C:\Users\Public\Documents\OpenTTD` (Vista, 7, 8.1, 10, 11)
+        - `C:\Users\Public\Documents\OpenTTD` (7, 8.1, 10, 11)
     - macOS: `/Library/Application Support/OpenTTD`
     - Linux: not available
 4. The binary directory (where the OpenTTD executable is)

--- a/os/windows/openttd.manifest
+++ b/os/windows/openttd.manifest
@@ -15,8 +15,6 @@
   </application>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <!--This Id value indicates the application supports Windows Vista functionality -->
-      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
       <!--This Id value indicates the application supports Windows 7 functionality-->
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
       <!--This Id value indicates the application supports Windows 8 functionality-->

--- a/src/sound/win32_s.cpp
+++ b/src/sound/win32_s.cpp
@@ -70,7 +70,7 @@ const char *SoundDriver_Win32::Start(const StringList &parm)
 	wfex.nAvgBytesPerSec = wfex.nSamplesPerSec * wfex.nBlockAlign;
 
 	/* Limit buffer size to prevent overflows. */
-	_bufsize = GetDriverParamInt(parm, "bufsize", IsWindowsVistaOrGreater() ? 8192 : 4096);
+	_bufsize = GetDriverParamInt(parm, "bufsize", 8192);
 	_bufsize = std::min<int>(_bufsize, UINT16_MAX);
 
 	try {

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1258,7 +1258,7 @@ static const char *SelectPixelFormat(HDC dc)
 		0, 0, 0, 0                     // Ignored/reserved.
 	};
 
-	if (IsWindowsVistaOrGreater()) pfd.dwFlags |= PFD_SUPPORT_COMPOSITION; // Make OpenTTD compatible with Aero.
+	pfd.dwFlags |= PFD_SUPPORT_COMPOSITION; // Make OpenTTD compatible with Aero.
 
 	/* Choose a suitable pixel format. */
 	int format = ChoosePixelFormat(dc, &pfd);


### PR DESCRIPTION
## Motivation / Problem

#11529 reports Vista is no longer working. Vista has been EoL for over 11 years. And as it goes, we tend to not deliberately break old OSes, but if they no longer work (as we updated tools, MSVC no longer targets it, etc etc) we drop support for it to.

Closes #11529.

## Description

It is very likely Vista hasn't been working for years, but the amount of users that use an OS that has been EoL for over 11 years is very small, so reports happen rarely.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
