### PR TITLE
Fix: [CI] Don't let SDL2 dependencies install too much stuff

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -117,6 +117,12 @@ jobs:
         /vcpkg/vcpkg install python3
         ln -sf /vcpkg/installed/x64-linux/tools/python3/python3.[0-9][0-9] /usr/bin/python3
 
+        # SDL2 needs dbus, but dbus default install comes with libsystemd
+        # and some of libsystemd deps fail to build on our quite old linux.
+        # So just install basic dbus without any extra deps.
+        /vcpkg/vcpkg install dbus[core]
+
+        # Now we can install OpenTTD dependencies
         /vcpkg/vcpkg install \
           breakpad \
           curl[http2] \


### PR DESCRIPTION
## Motivation / Problem
Since https://github.com/microsoft/vcpkg/commit/64a8686c41cad282d0a9e4021ea59d8c832f2974 installing `dbus` triggers installation of `libsystemd` (and its deps). And `dbus` installation is triggered when installing `sdl2`.

The issue is that installing `libsystemd` encounters errors.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
I used docker with the image we use to build linux releases.

The first error was during configuration of `libmount` (dependency of `libsystemd`), it could not find `autopoint`. A quick search in online packages listings told me I needed to install `gettext-devel` in the image, and that solved this error.

Then `libsystemd` failed to configure, it could not find `gperf`, again I installed `gperf` in the image and the error was solved. But `libsystemd` configuration was still failing, missing a python package this time. I installed it, it's not very easy with the python3 from vcpkg, requiring a venv but anyway that solved the error and configuration step passed. But compilation was now failing with `NFPROTO_NETDEV` being undeclared. A search told me it should be in a header provided by `kernel-headers`, which were already installed and they don't provide this symbol. Conclusion the image uses a too old linux version to be able to build `libsystemd`.

A new plan was needed.

As CI was able to build our dependencies before the `dbus` update, I decided to disable the automatic install `sdl2` triggers by pre-installing `dbus[core]` which is the basic `dbus` we used to get automatically before the update. And the problem is solved, this change should also prevent any future `dbus` update causing issues (not the first time we have issues with `dbus`).

After checking in a clean docker container, I tested a release with this PR on my fork and it passed (minus the uploads as expected).

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
