### PR TITLE
Change: [CMake] Use explicit list for grf source files

### DIFF
--- a/cmake/CreateGrfCommand.cmake
+++ b/cmake/CreateGrfCommand.cmake
@@ -1,16 +1,13 @@
 # Macro which contains all bits and pieces to create a single grf file based
 # on NFO and PNG files.
 #
-# create_grf_command()
+# create_grf_command(NFO_SOURCE_FILES nfo_file1 ... PNG_SOURCE_FILES png_file1 ...)
 #
 function(create_grf_command)
-    set(EXTRA_PNG_SOURCE_FILES ${ARGV})
+    cmake_parse_arguments(GRF "" "" "NFO_SOURCE_FILES;PNG_SOURCE_FILES" ${ARGN})
 
     get_filename_component(GRF_SOURCE_FOLDER_NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
     get_filename_component(GRF_BINARY_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../${GRF_SOURCE_FOLDER_NAME}.grf ABSOLUTE)
-    file(GLOB_RECURSE GRF_PNG_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.png)
-    file(GLOB_RECURSE GRF_NFO_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.nfo)
-    set(GRF_PNG_SOURCE_FILES ${GRF_PNG_SOURCE_FILES} ${EXTRA_PNG_SOURCE_FILES})
 
     # Copy over all the PNG files to the correct folder
     foreach(GRF_PNG_SOURCE_FILE IN LISTS GRF_PNG_SOURCE_FILES)

--- a/media/baseset/openttd/CMakeLists.txt
+++ b/media/baseset/openttd/CMakeLists.txt
@@ -5,5 +5,47 @@
 # working on it / have the tools installed.
 if(GRFCODEC_FOUND)
     include(CreateGrfCommand)
-    create_grf_command()
+    create_grf_command(
+        NFO_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/airports.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/airport_preview.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/aqueduct.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/autorail.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/canals.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/chars.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/elrails.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/foundations.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/mono.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/oneway.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/openttd.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/openttdgui.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/palette.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/roadstops.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/signals.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/sloped_tracks.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/tramtracks.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/tunnel_portals.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/2ccmap.nfo
+        PNG_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/airports.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/airport_preview.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/aqueduct.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/autorail.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/canals.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/canal_locks.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/chars.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/elrails.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/foundations.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/mono.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/oneway.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/openttdgui.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/openttdgui_build_tram.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/openttdgui_convert_road.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/openttdgui_convert_tram.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/openttdgui_group_livery.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/roadstops.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/signals.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/sloped_tracks.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/tramtracks.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/tramtracks_bare_depot.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/tunnel_portals.png
+    )
 endif()

--- a/media/baseset/orig_extra/CMakeLists.txt
+++ b/media/baseset/orig_extra/CMakeLists.txt
@@ -6,9 +6,32 @@
 if(GRFCODEC_FOUND)
     include(CreateGrfCommand)
     create_grf_command(
-        # We share some files with 'openttd' grf
-        ${CMAKE_CURRENT_SOURCE_DIR}/../openttd/airports.png
-        ${CMAKE_CURRENT_SOURCE_DIR}/../openttd/canals.png
-        ${CMAKE_CURRENT_SOURCE_DIR}/../openttd/chars.png
+        NFO_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/rivers/arctic.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/rivers/rapids.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/rivers/temperate.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/rivers/toyland.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/rivers/tropic.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/airports_orig_extra.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/canals_extra.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/chars_orig_extra.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/fix_graphics.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/fix_gui_icons.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/orig_extra.nfo
+                         ${CMAKE_CURRENT_SOURCE_DIR}/shore.nfo
+        PNG_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/rivers/arctic_brown.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/rivers/arctic_snowy.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/rivers/rapids.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/rivers/rapids_shading.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/rivers/temperate.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/rivers/toyland.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/rivers/tropic_desert.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/rivers/tropic_forest.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/fix_graphics.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/fix_gui_icons.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/shore.png
+                         # We share some files with 'openttd' grf
+                         ${CMAKE_CURRENT_SOURCE_DIR}/../openttd/airports.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/../openttd/canals.png
+                         ${CMAKE_CURRENT_SOURCE_DIR}/../openttd/chars.png
     )
 endif()


### PR DESCRIPTION
## Motivation / Problem
When a file is added in sources for a grf, it's not detected by cmake (https://github.com/OpenTTD/OpenTTD/pull/11523#issuecomment-1834639693).
This is because we use `file(GLOB_RECURSE...)` to get the list when configuring but adding a file without explicit reference doesn't trigger a reconfigure.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Use explicit list, that way adding a file needs to be done in CMakeLists.txt and that will trigger a reconfigure.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
