### PR TITLE
Fix #10452: Limit river generation max_search_nodes

### DIFF
--- a/src/pathfinder/npf/aystar.cpp
+++ b/src/pathfinder/npf/aystar.cpp
@@ -301,4 +301,7 @@ void AyStar::Init(Hash_HashProc hash, uint num_buckets)
 	 *  When that one gets full it reserves another one, till this number
 	 *  That is why it can stay this high */
 	this->openlist_queue.Init(102400);
+
+	/* Set a reasonable default limit */
+	this->max_search_nodes = AYSTAR_DEF_MAX_SEARCH_NODES;
 }

--- a/src/pathfinder/npf/aystar.h
+++ b/src/pathfinder/npf/aystar.h
@@ -20,6 +20,8 @@
 #include "../../tile_type.h"
 #include "../../track_type.h"
 
+static const int AYSTAR_DEF_MAX_SEARCH_NODES = 10000; ///< Reference limit for #AyStar::max_search_nodes
+
 /** Return status of #AyStar methods. */
 enum AystarStatus {
 	AYSTAR_FOUND_END_NODE, ///< An end node was found.

--- a/src/pathfinder/pathfinder_type.h
+++ b/src/pathfinder/pathfinder_type.h
@@ -11,6 +11,7 @@
 #define PATHFINDER_TYPE_H
 
 #include "../tile_type.h"
+#include "npf/aystar.h"
 
 /** Length (penalty) of one tile with NPF */
 static const int NPF_TILE_LENGTH = 100;

--- a/src/table/settings/pathfinding_settings.ini
+++ b/src/table/settings/pathfinding_settings.ini
@@ -168,7 +168,7 @@ cat      = SC_EXPERT
 [SDT_VAR]
 var      = pf.npf.npf_max_search_nodes
 type     = SLE_UINT
-def      = 10000
+def      = AYSTAR_DEF_MAX_SEARCH_NODES
 min      = 500
 max      = 100000
 cat      = SC_EXPERT
@@ -325,7 +325,7 @@ cat      = SC_EXPERT
 var      = pf.yapf.max_search_nodes
 type     = SLE_UINT
 from     = SLV_28
-def      = 10000
+def      = AYSTAR_DEF_MAX_SEARCH_NODES
 min      = 500
 max      = 1000000
 cat      = SC_EXPERT


### PR DESCRIPTION
Prevent long stalls during river generation by capping the maximum search nodes to be the same as that defined in NPF.

## Motivation / Problem
See https://github.com/OpenTTD/OpenTTD/issues/10452#issuecomment-1432078250

Terraforming occurs during river generation which causes issues for the pathfinding. If the tile the pathfinder is working with is no longer flat, a long stall occurs due to the pathfinding doing an exhaustive search around that tile, trying to connect a river path to it and ultimately failing in the end, leaving a river disconnected somewhere along the way from the spring to the sea.

The stall can last up to 3-5 minutes until all paths are tried.
https://github.com/OpenTTD/OpenTTD/assets/43006711/cbb18259-51cc-4f18-9b4e-3248334f4f11


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
This PR fixes the stall, by preventing the pathfinder from initializing max_search_nodes as 0 (= infinite). Since AyStar is used, I created a constant with the default value equal to that of both NPF and YAPF and have it referred.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
This does not fix the river becoming disconnected due to terraforming.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
