### PR TITLE
Codechange: Add compile-time saveload entry variable size check.

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1475,7 +1475,7 @@ static IntervalTimer<TimerGameRealtime> _autosave_interval({std::chrono::millise
  */
 void ChangeAutosaveFrequency(bool reset)
 {
-	_autosave_interval.SetInterval({_settings_client.gui.autosave_interval, TimerGameRealtime::AUTOSAVE}, reset);
+	_autosave_interval.SetInterval({std::chrono::minutes(_settings_client.gui.autosave_interval), TimerGameRealtime::AUTOSAVE}, reset);
 }
 
 /**

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1513,54 +1513,8 @@ size_t SlCalcObjMemberLength(const void *object, const SaveLoad &sld)
 	return 0;
 }
 
-/**
- * Check whether the variable size of the variable in the saveload configuration
- * matches with the actual variable size.
- * @param sld The saveload configuration to test.
- */
-[[maybe_unused]] static bool IsVariableSizeRight(const SaveLoad &sld)
-{
-	if (GetVarMemType(sld.conv) == SLE_VAR_NULL) return true;
-
-	switch (sld.cmd) {
-		case SL_VAR:
-			switch (GetVarMemType(sld.conv)) {
-				case SLE_VAR_BL:
-					return sld.size == sizeof(bool);
-				case SLE_VAR_I8:
-				case SLE_VAR_U8:
-					return sld.size == sizeof(int8_t);
-				case SLE_VAR_I16:
-				case SLE_VAR_U16:
-					return sld.size == sizeof(int16_t);
-				case SLE_VAR_I32:
-				case SLE_VAR_U32:
-					return sld.size == sizeof(int32_t);
-				case SLE_VAR_I64:
-				case SLE_VAR_U64:
-					return sld.size == sizeof(int64_t);
-				case SLE_VAR_NAME:
-					return sld.size == sizeof(std::string);
-				default:
-					return sld.size == sizeof(void *);
-			}
-		case SL_REF:
-			/* These should all be pointer sized. */
-			return sld.size == sizeof(void *);
-
-		case SL_STDSTR:
-			/* These should be all pointers to std::string. */
-			return sld.size == sizeof(std::string);
-
-		default:
-			return true;
-	}
-}
-
 static bool SlObjectMember(void *object, const SaveLoad &sld)
 {
-	assert(IsVariableSizeRight(sld));
-
 	if (!SlIsObjectValidInSavegame(sld)) return false;
 
 	VarType conv = GB(sld.conv, 0, 8);

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -710,6 +710,38 @@ struct SaveLoadCompat {
 };
 
 /**
+ * Get the NumberType of a setting. This describes the integer type
+ * as it is represented in memory
+ * @param type VarType holding information about the variable-type
+ * @return the SLE_VAR_* part of a variable-type description
+ */
+static inline constexpr VarType GetVarMemType(VarType type)
+{
+	return GB(type, 4, 4) << 4;
+}
+
+/**
+ * Get the FileType of a setting. This describes the integer type
+ * as it is represented in a savegame/file
+ * @param type VarType holding information about the file-type
+ * @return the SLE_FILE_* part of a variable-type description
+ */
+static inline constexpr VarType GetVarFileType(VarType type)
+{
+	return GB(type, 0, 4);
+}
+
+/**
+ * Check if the given saveload type is a numeric type.
+ * @param conv the type to check
+ * @return True if it's a numeric type.
+ */
+static inline constexpr bool IsNumericType(VarType conv)
+{
+	return GetVarMemType(conv) <= SLE_VAR_U64;
+}
+
+/**
  * Storage of simple variables, references (pointers), and arrays.
  * @param cmd      Load/save type. @see SaveLoadType
  * @param name     Field name for table chunks.
@@ -1131,38 +1163,6 @@ static inline bool SlIsObjectCurrentlyValid(SaveLoadVersion version_from, SaveLo
 {
 	extern const SaveLoadVersion SAVEGAME_VERSION;
 	return version_from <= SAVEGAME_VERSION && SAVEGAME_VERSION < version_to;
-}
-
-/**
- * Get the NumberType of a setting. This describes the integer type
- * as it is represented in memory
- * @param type VarType holding information about the variable-type
- * @return the SLE_VAR_* part of a variable-type description
- */
-static inline VarType GetVarMemType(VarType type)
-{
-	return GB(type, 4, 4) << 4;
-}
-
-/**
- * Get the FileType of a setting. This describes the integer type
- * as it is represented in a savegame/file
- * @param type VarType holding information about the file-type
- * @return the SLE_FILE_* part of a variable-type description
- */
-static inline VarType GetVarFileType(VarType type)
-{
-	return GB(type, 0, 4);
-}
-
-/**
- * Check if the given saveload type is a numeric type.
- * @param conv the type to check
- * @return True if it's a numeric type.
- */
-static inline bool IsNumericType(VarType conv)
-{
-	return GetVarMemType(conv) <= SLE_VAR_U64;
 }
 
 /**

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1397,11 +1397,11 @@ void LoadFromConfig(bool startup)
 			auto old_value = OneOfManySettingDesc::ParseSingleValue(old_item->value->c_str(), old_item->value->size(), _old_autosave_interval);
 
 			switch (old_value) {
-				case 0: _settings_client.gui.autosave_interval = std::chrono::minutes::zero(); break;
-				case 1: _settings_client.gui.autosave_interval = std::chrono::minutes(10); break;
-				case 2: _settings_client.gui.autosave_interval = std::chrono::minutes(30); break;
-				case 3: _settings_client.gui.autosave_interval = std::chrono::minutes(60); break;
-				case 4: _settings_client.gui.autosave_interval = std::chrono::minutes(120); break;
+				case 0: _settings_client.gui.autosave_interval = 0; break;
+				case 1: _settings_client.gui.autosave_interval = 10; break;
+				case 2: _settings_client.gui.autosave_interval = 30; break;
+				case 3: _settings_client.gui.autosave_interval = 60; break;
+				case 4: _settings_client.gui.autosave_interval = 120; break;
 				default: break;
 			}
 		}

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -60,12 +60,12 @@ static const StringID _autosave_dropdown[] = {
 };
 
 /** Available settings for autosave intervals. */
-static const std::chrono::minutes _autosave_dropdown_to_minutes[] = {
-	std::chrono::minutes::zero(), ///< never
-	std::chrono::minutes(10),
-	std::chrono::minutes(30),
-	std::chrono::minutes(60),
-	std::chrono::minutes(120),
+static const uint32_t _autosave_dropdown_to_minutes[] = {
+	0, ///< never
+	10,
+	30,
+	60,
+	120,
 };
 
 static Dimension _circle_size; ///< Dimension of the circle +/- icon. This is here as not all users are within the class of the settings window.

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -64,14 +64,14 @@ enum IndustryDensity {
 };
 
 /** Possible values for "use_relay_service" setting. */
-enum UseRelayService {
+enum UseRelayService : uint8_t {
 	URS_NEVER = 0,
 	URS_ASK,
 	URS_ALLOW,
 };
 
 /** Possible values for "participate_survey" setting. */
-enum ParticipateSurvey {
+enum ParticipateSurvey : uint8_t {
 	PS_ASK = 0,
 	PS_NO,
 	PS_YES,

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -149,7 +149,7 @@ struct GUISettings {
 	ZoomLevel zoom_min;                      ///< minimum zoom out level
 	ZoomLevel zoom_max;                      ///< maximum zoom out level
 	ZoomLevel sprite_zoom_min;               ///< maximum zoom level at which higher-resolution alternative sprites will be used (if available) instead of scaling a lower resolution sprite
-	std::chrono::minutes autosave_interval;  ///< how often should we do autosaves?
+	uint32_t autosave_interval;              ///< how often should we do autosaves?
 	bool   threaded_saves;                   ///< should we do threaded saves?
 	bool   keep_all_autosave;                ///< name the autosave in a different way
 	bool   autosave_on_exit;                 ///< save an autosave when you quit the game, but do not ask "Do you really want to quit?"


### PR DESCRIPTION
## Motivation / Problem

Mismatch of SaveLoad entry and its variable size is currently only detected at runtime. This means it is easily possible for a mismatch to go undetected.

This is clear by the first commit :-)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add a compile-time static_assert() that uses constexpr functions to determine if the SaveLoad entry matches the variable size. This allows mismatches to be detected and prevented during compilation.

And fix a few existing settings saveload errors. SaveLoad of std::chrono::minutes may want reworking...

This PR will fail until #11557 is merged and this is rebased on top of it.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
