### PR TITLE
Fix: Disable airport noise if local authority control is disabled.

### DIFF
--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -9,6 +9,7 @@
 
 #include "stdafx.h"
 #include "economy_func.h"
+#include "town.h"
 #include "window_gui.h"
 #include "station_gui.h"
 #include "terraform_gui.h"
@@ -427,7 +428,7 @@ public:
 			int rad = _settings_game.station.modified_catchment ? as->catchment : (uint)CA_UNMODIFIED;
 
 			/* only show the station (airport) noise, if the noise option is activated */
-			if (_settings_game.economy.station_noise_level) {
+			if (_settings_game.difficulty.town_council_tolerance != TOWN_COUNCIL_PERMISSIVE && _settings_game.economy.station_noise_level) {
 				/* show the noise of the selected airport */
 				SetDParam(0, as->noise_level);
 				DrawString(r.left, r.right, top, STR_STATION_BUILD_NOISE);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1883,7 +1883,7 @@ STR_CONFIG_SETTING_ALLOW_TOWN_LEVEL_CROSSINGS                   :Towns are allow
 STR_CONFIG_SETTING_ALLOW_TOWN_LEVEL_CROSSINGS_HELPTEXT          :Enabling this setting allows towns to build level crossings
 
 STR_CONFIG_SETTING_NOISE_LEVEL                                  :Limit airport placement based on noise level: {STRING2}
-STR_CONFIG_SETTING_NOISE_LEVEL_HELPTEXT                         :Allow towns to block airport construction based on their noise acceptance level, which is based on the town's population and airport size and distance. If this setting is disabled, towns allow only two airports unless the local authority attitude is set to "Permissive"
+STR_CONFIG_SETTING_NOISE_LEVEL_HELPTEXT                         :Allow towns to block airport construction based on their noise acceptance level, which is based on the town's population and airport size and distance. If this setting is disabled, towns allow only two airports unless the local authority attitude is set to "Permissive". This setting has no effect when the setting "Local authority attitude" is set to "permissive".
 
 STR_CONFIG_SETTING_TOWN_FOUNDING                                :Founding towns in game: {STRING2}
 STR_CONFIG_SETTING_TOWN_FOUNDING_HELPTEXT                       :Enabling this setting allows players to found new towns in the game

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -8579,7 +8579,8 @@ static void InitializeGRFSpecial()
 	                   |                                                       (1U << 0x1D)  // lowmemory
 	                   |                                                       (1U << 0x1E); // generalfixes
 
-	_ttdpatch_flags[1] =   ((_settings_game.economy.station_noise_level ? 1U : 0U) << 0x07)  // moreairports - based on units of noise
+	_ttdpatch_flags[1] = ((_settings_game.difficulty.town_council_tolerance != TOWN_COUNCIL_PERMISSIVE &&
+	                         _settings_game.economy.station_noise_level ? 1U : 0U) << 0x07)  // moreairports - based on units of noise
 	                   |                                                       (1U << 0x08)  // mammothtrains
 	                   |                                                       (1U << 0x09)  // trainrefit
 	                   |                                                       (0U << 0x0B)  // subsidiaries

--- a/src/script/api/script_airport.cpp
+++ b/src/script/api/script_airport.cpp
@@ -136,7 +136,7 @@
 	const AirportSpec *as = ::AirportSpec::Get(type);
 	if (!as->IsWithinMapBounds(0, tile)) return -1;
 
-	if (_settings_game.economy.station_noise_level) {
+	if (_settings_game.difficulty.town_council_tolerance != TOWN_COUNCIL_PERMISSIVE && _settings_game.economy.station_noise_level) {
 		AirportTileTableIterator it(as->table[0], tile);
 		uint dist;
 		AirportGetNearestTown(as, it, dist);

--- a/src/script/api/script_town.cpp
+++ b/src/script/api/script_town.cpp
@@ -368,7 +368,7 @@
 	if (!IsValidTown(town_id)) return -1;
 
 	const Town *t = ::Town::Get(town_id);
-	if (_settings_game.economy.station_noise_level) {
+	if (_settings_game.difficulty.town_council_tolerance != TOWN_COUNCIL_PERMISSIVE && _settings_game.economy.station_noise_level) {
 		return t->MaxTownNoise() - t->noise_reached;
 	}
 

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -546,7 +546,7 @@ struct EconomySettings {
 	bool   allow_town_roads;                 ///< towns are allowed to build roads (always allowed when generating world / in SE)
 	TownFounding found_town;                 ///< town founding.
 	bool   station_noise_level;              ///< build new airports when the town noise level is still within accepted limits
-	uint16_t town_noise_population[4];         ///< population to base decision on noise evaluation (@see town_council_tolerance)
+	uint16_t town_noise_population[3];         ///< population to base decision on noise evaluation (@see town_council_tolerance)
 	bool   allow_town_level_crossings;       ///< towns are allowed to build level crossings
 	bool   infrastructure_maintenance;       ///< enable monthly maintenance fee for owner infrastructure
 };

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -264,14 +264,6 @@ min      = 800
 max      = 65535
 cat      = SC_EXPERT
 
-[SDT_VAR]
-var      = economy.town_noise_population[3]
-type     = SLE_UINT16
-def      = 400
-min      = 100
-max      = 65535
-cat      = SC_EXPERT
-
 [SDT_BOOL]
 var      = economy.infrastructure_maintenance
 from     = SLV_166

--- a/src/town.h
+++ b/src/town.h
@@ -33,6 +33,14 @@ static const uint TOWN_GROWTH_DESERT = 0xFFFFFFFF; ///< The town needs the cargo
 static const uint16_t TOWN_GROWTH_RATE_NONE = 0xFFFF; ///< Special value for Town::growth_rate to disable town growth.
 static const uint16_t MAX_TOWN_GROWTH_TICKS = 930; ///< Max amount of original town ticks that still fit into uint16_t, about equal to UINT16_MAX / TOWN_GROWTH_TICKS but slightly less to simplify calculations
 
+/** Settings for town council attitudes. */
+enum TownCouncilAttitudes {
+	TOWN_COUNCIL_LENIENT    = 0,
+	TOWN_COUNCIL_TOLERANT   = 1,
+	TOWN_COUNCIL_HOSTILE    = 2,
+	TOWN_COUNCIL_PERMISSIVE = 3,
+};
+
 typedef Pool<Town, TownID, 64, 64000> TownPool;
 extern TownPool _town_pool;
 
@@ -116,6 +124,8 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 	 */
 	inline uint16_t MaxTownNoise() const
 	{
+		assert(_settings_game.difficulty.town_council_tolerance != TOWN_COUNCIL_PERMISSIVE);
+
 		if (this->cache.population == 0) return 0; // no population? no noise
 
 		/* 3 is added (the noise of the lowest airport), so the  user can at least build a small airfield. */
@@ -151,14 +161,6 @@ void ShowTownViewWindow(TownID town);
 void ExpandTown(Town *t);
 
 void RebuildTownKdtree();
-
-/** Settings for town council attitudes. */
-enum TownCouncilAttitudes {
-	TOWN_COUNCIL_LENIENT    = 0,
-	TOWN_COUNCIL_TOLERANT   = 1,
-	TOWN_COUNCIL_HOSTILE    = 2,
-	TOWN_COUNCIL_PERMISSIVE = 3,
-};
 
 /**
  * Action types that a company must ask permission for to a town authority.

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -462,7 +462,7 @@ public:
 		}
 
 		/* only show the town noise, if the noise option is activated. */
-		if (_settings_game.economy.station_noise_level) {
+		if (_settings_game.difficulty.town_council_tolerance != TOWN_COUNCIL_PERMISSIVE && _settings_game.economy.station_noise_level) {
 			SetDParam(0, this->town->noise_reached);
 			SetDParam(1, this->town->MaxTownNoise());
 			DrawString(tr, STR_TOWN_VIEW_NOISE_IN_TOWN);
@@ -541,7 +541,7 @@ public:
 		}
 		aimed_height += GetCharacterHeight(FS_NORMAL);
 
-		if (_settings_game.economy.station_noise_level) aimed_height += GetCharacterHeight(FS_NORMAL);
+		if (_settings_game.difficulty.town_council_tolerance != TOWN_COUNCIL_PERMISSIVE && _settings_game.economy.station_noise_level) aimed_height += GetCharacterHeight(FS_NORMAL);
 
 		if (!this->town->text.empty()) {
 			SetDParamStr(0, this->town->text);


### PR DESCRIPTION
## Motivation / Problem

#9833 Adds an extra option to disable local authority control, but does not handle station noise level properly.

An extra item is added to the array town_noise_population array, but it is not saved nor loaded, so could cause desyncs.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, disable station noise level if local authority is set to permissive.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
