### PR TITLE
Fix f92cf38: Reduce graduation of town noise tolerance distance multiplier for permissive towns

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -2288,7 +2288,8 @@ uint8_t GetAirportNoiseLevelForDistance(const AirportSpec *as, uint distance)
 	 * adding the town_council_tolerance 4 times, as a way to graduate, depending of the tolerance.
 	 * Basically, it says that the less tolerant a town is, the bigger the distance before
 	 * an actual decrease can be granted */
-	uint8_t town_tolerance_distance = 8 + (_settings_game.difficulty.town_council_tolerance * 4);
+	uint8_t town_tolerance_distance = 8;
+	if (_settings_game.difficulty.town_council_tolerance != TownCouncilAttitudes::TOWN_COUNCIL_PERMISSIVE) town_tolerance_distance += _settings_game.difficulty.town_council_tolerance * 4;
 
 	/* now, we want to have the distance segmented using the distance judged bareable by town
 	 * This will give us the coefficient of reduction the distance provides. */


### PR DESCRIPTION
## Motivation / Problem
TownCouncilAttitudes::TOWN_COUNCIL_PERMISSIVE has a value of 3, but considering this comment...
```
	/* The steps for measuring noise reduction are based on the "magical" (and arbitrary) 8 base distance
	 * adding the town_council_tolerance 4 times, as a way to graduate, depending of the tolerance.
	 * Basically, it says that the less tolerant a town is, the bigger the distance before
	 * an actual decrease can be granted */
```
... the result was actually making TOWN_COUNCIL_PERMISSIVE towns the least tolerant of all available TownCouncilAttitudes

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
I was undecided between 8/2 or 8. The scaling seems to be based on multiples of 4, but I'm unsure whether 4 would be alright, I'm uncertain of the intention.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Towns will still deny placing noisy airports with TOWN_COUNCIL_PERMISSIVE, but the distance graduation is now equal to that of TOWN_COUNCIL_LENIENT.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
