### PR TITLE
Fix: AirportGetNearestTown incorrectly assumed first TileIterator result was origin.

### DIFF
--- a/src/script/api/script_airport.cpp
+++ b/src/script/api/script_airport.cpp
@@ -139,7 +139,7 @@
 	if (_settings_game.economy.station_noise_level) {
 		AirportTileTableIterator it(as->table[0], tile);
 		uint dist;
-		AirportGetNearestTown(as, it, dist);
+		AirportGetNearestTown(as, tile, it, dist);
 		return GetAirportNoiseLevelForDistance(as, dist);
 	}
 
@@ -155,7 +155,7 @@
 	if (!as->IsWithinMapBounds(0, tile)) return INVALID_TOWN;
 
 	uint dist;
-	return AirportGetNearestTown(as, AirportTileTableIterator(as->table[0], tile), dist)->index;
+	return AirportGetNearestTown(as, tile, AirportTileTableIterator(as->table[0], tile), dist)->index;
 }
 
 /* static */ SQInteger ScriptAirport::GetMaintenanceCostFactor(AirportType type)

--- a/src/station_cmd.h
+++ b/src/station_cmd.h
@@ -16,7 +16,7 @@
 enum StationClassID : byte;
 enum RoadStopClassID : byte;
 
-extern Town *AirportGetNearestTown(const struct AirportSpec *as, const TileIterator &it, uint &mindist);
+extern Town *AirportGetNearestTown(const struct AirportSpec *as, TileIndex tile, const TileIterator &it, uint &mindist);
 extern uint8_t GetAirportNoiseLevelForDistance(const struct AirportSpec *as, uint distance);
 
 CommandCost CmdBuildAirport(DoCommandFlag flags, TileIndex tile, byte airport_type, byte layout, StationID station_to_join, bool allow_adjacent);


### PR DESCRIPTION
## Motivation / Problem

AirportGetNearestTown uses the first result of TileIterator and assumes it is the origin tile. However not all TileIterators are equal, and some do not start at the top-corner, so the perimeter check was wrong.

AirportTileTableIterator iterates the tiles in the airport spec, which is made up from a list of offsets. These can start anywhere within the layout.

As the perimeter is used to limit the range of tiles that are checked, if it is wrong then some tiles will be missed, which can result in the wrong town being returned. This then leads on to station noise level being applied/removed from the wrong town.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

As the caller already has the origin tile, pass that and use it to determine the perimeter instead.

This issue was found by asserting that TileX(cur_tile) and TileY(cur_tile) were within the perimeter bounds.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
