### PR TITLE
Codechange: Add 'changed' return value to SetDisplayedPlane, and simplify callers.

### DIFF
--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -2259,54 +2259,24 @@ struct CompanyWindow : Window
 			bool reinit = false;
 
 			/* Button bar selection. */
-			int plane = local ? 0 : SZSP_NONE;
-			NWidgetStacked *wi = this->GetWidget<NWidgetStacked>(WID_C_SELECT_BUTTONS);
-			if (plane != wi->shown_plane) {
-				wi->SetDisplayedPlane(plane);
-				this->InvalidateData();
-				reinit = true;
-			}
+			reinit |= this->GetWidget<NWidgetStacked>(WID_C_SELECT_BUTTONS)->SetDisplayedPlane(local ? 0 : SZSP_NONE);
 
 			/* Build HQ button handling. */
-			plane = (local && c->location_of_HQ == INVALID_TILE) ? CWP_VB_BUILD : CWP_VB_VIEW;
-			wi = this->GetWidget<NWidgetStacked>(WID_C_SELECT_VIEW_BUILD_HQ);
-			if (plane != wi->shown_plane) {
-				wi->SetDisplayedPlane(plane);
-				reinit = true;
-			}
+			reinit |= this->GetWidget<NWidgetStacked>(WID_C_SELECT_VIEW_BUILD_HQ)->SetDisplayedPlane((local && c->location_of_HQ == INVALID_TILE) ? CWP_VB_BUILD : CWP_VB_VIEW);
 
 			this->SetWidgetDisabledState(WID_C_VIEW_HQ, c->location_of_HQ == INVALID_TILE);
 
 			/* Enable/disable 'Relocate HQ' button. */
-			plane = (!local || c->location_of_HQ == INVALID_TILE) ? CWP_RELOCATE_HIDE : CWP_RELOCATE_SHOW;
-			wi = this->GetWidget<NWidgetStacked>(WID_C_SELECT_RELOCATE);
-			if (plane != wi->shown_plane) {
-				wi->SetDisplayedPlane(plane);
-				reinit = true;
-			}
+			reinit |= this->GetWidget<NWidgetStacked>(WID_C_SELECT_RELOCATE)->SetDisplayedPlane((!local || c->location_of_HQ == INVALID_TILE) ? CWP_RELOCATE_HIDE : CWP_RELOCATE_SHOW);
 			/* Enable/disable 'Give money' button. */
-			plane = ((local || _local_company == COMPANY_SPECTATOR || !_settings_game.economy.give_money) ? SZSP_NONE : 0);
-			wi = this->GetWidget<NWidgetStacked>(WID_C_SELECT_GIVE_MONEY);
-			if (plane != wi->shown_plane) {
-				wi->SetDisplayedPlane(plane);
-				reinit = true;
-			}
+			reinit |= this->GetWidget<NWidgetStacked>(WID_C_SELECT_GIVE_MONEY)->SetDisplayedPlane((local || _local_company == COMPANY_SPECTATOR || !_settings_game.economy.give_money) ? SZSP_NONE : 0);
 			/* Enable/disable 'Hostile Takeover' button. */
-			plane = ((local || _local_company == COMPANY_SPECTATOR || !c->is_ai || _networking) ? SZSP_NONE : 0);
-			wi = this->GetWidget<NWidgetStacked>(WID_C_SELECT_HOSTILE_TAKEOVER);
-			if (plane != wi->shown_plane) {
-				wi->SetDisplayedPlane(plane);
-				reinit = true;
-			}
+			reinit |= this->GetWidget<NWidgetStacked>(WID_C_SELECT_HOSTILE_TAKEOVER)->SetDisplayedPlane((local || _local_company == COMPANY_SPECTATOR || !c->is_ai || _networking) ? SZSP_NONE : 0);
 
 			/* Multiplayer buttons. */
-			plane = ((!_networking) ? (int)SZSP_NONE : (int)(local ? CWP_MP_C_PWD : CWP_MP_C_JOIN));
-			wi = this->GetWidget<NWidgetStacked>(WID_C_SELECT_MULTIPLAYER);
-			if (plane != wi->shown_plane) {
-				wi->SetDisplayedPlane(plane);
-				reinit = true;
-			}
-			this->SetWidgetDisabledState(WID_C_COMPANY_JOIN,   c->is_ai);
+			reinit |= this->GetWidget<NWidgetStacked>(WID_C_SELECT_MULTIPLAYER)->SetDisplayedPlane((!_networking) ? (int)SZSP_NONE : (int)(local ? CWP_MP_C_PWD : CWP_MP_C_JOIN));
+
+			this->SetWidgetDisabledState(WID_C_COMPANY_JOIN, c->is_ai);
 
 			if (reinit) {
 				this->ReInit();

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -403,16 +403,13 @@ public:
 
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_DPI_SCROLLBAR);
+		/* Show scenario editor tools in editor. */
+		if (_game_mode != GM_EDITOR) {
+			this->GetWidget<NWidgetStacked>(WID_DPI_SCENARIO_EDITOR_PANE)->SetDisplayedPlane(SZSP_HORIZONTAL);
+		}
 		this->FinishInitNested(0);
 
 		this->SetButtons();
-
-		/* Show scenario editor tools in editor. */
-		if (_game_mode != GM_EDITOR) {
-			auto *se_tools = this->GetWidget<NWidgetStacked>(WID_DPI_SCENARIO_EDITOR_PANE);
-			se_tools->SetDisplayedPlane(SZSP_HORIZONTAL);
-			this->ReInit();
-		}
 	}
 
 	void OnInit() override

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -974,14 +974,10 @@ public:
 		_railstation.newstations = newstation;
 
 		this->CreateNestedTree();
-		NWidgetStacked *newst_additions = this->GetWidget<NWidgetStacked>(WID_BRAS_SHOW_NEWST_ADDITIONS);
-		newst_additions->SetDisplayedPlane(newstation ? 0 : SZSP_NONE);
-		newst_additions = this->GetWidget<NWidgetStacked>(WID_BRAS_SHOW_NEWST_MATRIX);
-		newst_additions->SetDisplayedPlane(newstation ? 0 : SZSP_NONE);
-		newst_additions = this->GetWidget<NWidgetStacked>(WID_BRAS_SHOW_NEWST_DEFSIZE);
-		newst_additions->SetDisplayedPlane(newstation ? 0 : SZSP_NONE);
-		newst_additions = this->GetWidget<NWidgetStacked>(WID_BRAS_SHOW_NEWST_RESIZE);
-		newst_additions->SetDisplayedPlane(newstation ? 0 : SZSP_NONE);
+		this->GetWidget<NWidgetStacked>(WID_BRAS_SHOW_NEWST_ADDITIONS)->SetDisplayedPlane(newstation ? 0 : SZSP_NONE);
+		this->GetWidget<NWidgetStacked>(WID_BRAS_SHOW_NEWST_MATRIX)->SetDisplayedPlane(newstation ? 0 : SZSP_NONE);
+		this->GetWidget<NWidgetStacked>(WID_BRAS_SHOW_NEWST_DEFSIZE)->SetDisplayedPlane(newstation ? 0 : SZSP_NONE);
+		this->GetWidget<NWidgetStacked>(WID_BRAS_SHOW_NEWST_RESIZE)->SetDisplayedPlane(newstation ? 0 : SZSP_NONE);
 		/* Hide the station class filter if no stations other than the default one are available. */
 		this->GetWidget<NWidgetStacked>(WID_BRAS_FILTER_CONTAINER)->SetDisplayedPlane(newstation ? 0 : SZSP_NONE);
 		if (newstation) {

--- a/src/tree_gui.cpp
+++ b/src/tree_gui.cpp
@@ -141,17 +141,15 @@ class BuildTreesWindow : public Window
 public:
 	BuildTreesWindow(WindowDesc *desc, WindowNumber window_number) : Window(desc), tree_to_plant(-1), mode(PM_NORMAL)
 	{
-		this->InitNested(window_number);
+		this->CreateNestedTree();
 		ResetObjectToPlace();
 
 		this->LowerWidget(WID_BT_MODE_NORMAL);
-
 		/* Show scenario editor tools in editor */
-		auto *se_tools = this->GetWidget<NWidgetStacked>(WID_BT_SE_PANE);
 		if (_game_mode != GM_EDITOR) {
-			se_tools->SetDisplayedPlane(SZSP_HORIZONTAL);
-			this->ReInit();
+			this->GetWidget<NWidgetStacked>(WID_BT_SE_PANE)->SetDisplayedPlane(SZSP_HORIZONTAL);
 		}
+		this->FinishInitNested(window_number);
 	}
 
 	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1492,10 +1492,13 @@ NWidgetCore *NWidgetStacked::GetWidgetFromPos(int x, int y)
 /**
  * Select which plane to show (for #NWID_SELECTION only).
  * @param plane Plane number to display.
+ * @return true iff the shown plane changed.
  */
-void NWidgetStacked::SetDisplayedPlane(int plane)
+bool NWidgetStacked::SetDisplayedPlane(int plane)
 {
+	if (this->shown_plane == plane) return false;
 	this->shown_plane = plane;
+	return true;
 }
 
 NWidgetPIPContainer::NWidgetPIPContainer(WidgetType tp, NWidContainerFlags flags) : NWidgetContainer(tp)

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -461,7 +461,7 @@ public:
 	void Draw(const Window *w) override;
 	NWidgetCore *GetWidgetFromPos(int x, int y) override;
 
-	void SetDisplayedPlane(int plane);
+	bool SetDisplayedPlane(int plane);
 
 	int shown_plane; ///< Plane being displayed (for #NWID_SELECTION only).
 	int index;       ///< If non-negative, index in the #Window::nested_array.


### PR DESCRIPTION
## Motivation / Problem

* Repetitive code to get a widget, get its current plane, then change the plane if it's changed, and record that it's changed.
* Completing widget initialization, and then calling SetDisplayedPlane and forcing a ReInit again in the constructor.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

* Make SetDisplayedPlane return whether the plane changed or not. This means callers don't need to refer to the widget more than once not remember the old value.
* Call SetDisplayPlace between 2-part widget initialization instead.


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
