### PR TITLE
Fix e2425b7: Missing initialization of WidgetDimensions and depot block sizes.

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1980,7 +1980,7 @@ bool AdjustGUIZoom(bool automatic)
 	ZoomLevel old_font_zoom = _font_zoom;
 	int old_scale = _gui_scale;
 	UpdateGUIZoom();
-	if (old_scale == _gui_scale) return false;
+	if (old_scale == _gui_scale && old_gui_zoom == _gui_zoom) return false;
 
 	/* Reload sprites if sprite zoom level has changed. */
 	if (old_gui_zoom != _gui_zoom) {

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -265,11 +265,7 @@ static void ZoomMinMaxChanged(int32_t)
 {
 	ConstrainAllViewportsZoom();
 	GfxClearSpriteCache();
-	if (_settings_client.gui.zoom_min > _gui_zoom) {
-		/* Restrict GUI zoom if it is no longer available. */
-		_gui_zoom = _settings_client.gui.zoom_min;
-		UpdateCursorSize();
-		LoadStringWidthTable();
+	if (AdjustGUIZoom(false)) {
 		ReInitAllWindows(true);
 	}
 }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1807,8 +1807,11 @@ void InitWindowSystem()
 	_scrolling_viewport = false;
 	_mouse_hovering = false;
 
+	SetupWidgetDimensions();
 	NWidgetLeaf::InvalidateDimensionCache(); // Reset cached sizes of several widgets.
 	NWidgetScrollbar::InvalidateDimensionCache();
+
+	InitDepotWindowBlockSizes();
 
 	ShowFirstError();
 }


### PR DESCRIPTION
## Motivation / Problem

e2425b7 stopped `LoadStringWidthTable()` from performing a window ReInit.

It turns out that this means that some critical initialization is no longer performed on start up, because that's precisely what a function called `LoadStringWidthTable()` should be doing...

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/8ae68c9c-d135-4f16-b801-13104ebecbfb)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Call `SetupWidgetDimensions()` and `InitDepotWindowBlockSizes()` from `InitWindowSystem()`, which is always called on start up, several times...

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
