### PR TITLE
Codechange: Use town zone constants instead of magic numbers

### DIFF
--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -51,16 +51,16 @@
 		case 0x8A: return this->t->grow_counter / Ticks::TOWN_GROWTH_TICKS;
 		case 0x92: return this->t->flags;  // In original game, 0x92 and 0x93 are really one word. Since flags is a byte, this is to adjust
 		case 0x93: return 0;
-		case 0x94: return ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[0]);
-		case 0x95: return GB(ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[0]), 8, 8);
-		case 0x96: return ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[1]);
-		case 0x97: return GB(ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[1]), 8, 8);
-		case 0x98: return ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[2]);
-		case 0x99: return GB(ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[2]), 8, 8);
-		case 0x9A: return ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[3]);
-		case 0x9B: return GB(ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[3]), 8, 8);
-		case 0x9C: return ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[4]);
-		case 0x9D: return GB(ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[4]), 8, 8);
+		case 0x94: return ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[HZB_TOWN_EDGE]);
+		case 0x95: return GB(ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[HZB_TOWN_EDGE]), 8, 8);
+		case 0x96: return ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[HZB_TOWN_OUTSKIRT]);
+		case 0x97: return GB(ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[HZB_TOWN_OUTSKIRT]), 8, 8);
+		case 0x98: return ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[HZB_TOWN_OUTER_SUBURB]);
+		case 0x99: return GB(ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[HZB_TOWN_OUTER_SUBURB]), 8, 8);
+		case 0x9A: return ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[HZB_TOWN_INNER_SUBURB]);
+		case 0x9B: return GB(ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[HZB_TOWN_INNER_SUBURB]), 8, 8);
+		case 0x9C: return ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[HZB_TOWN_CENTRE]);
+		case 0x9D: return GB(ClampTo<uint16_t>(this->t->cache.squared_town_zone_radius[HZB_TOWN_CENTRE]), 8, 8);
 		case 0x9E: return this->t->ratings[0];
 		case 0x9F: return GB(this->t->ratings[0], 8, 8);
 		case 0xA0: return this->t->ratings[1];

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1937,6 +1937,8 @@ static const Roadside _town_road_types[][2] = {
 	{ ROADSIDE_STREET_LIGHTS, ROADSIDE_PAVED }
 };
 
+static_assert(lengthof(_town_road_types) == HZB_END);
+
 static const Roadside _town_road_types_2[][2] = {
 	{ ROADSIDE_GRASS,         ROADSIDE_GRASS },
 	{ ROADSIDE_PAVED,         ROADSIDE_PAVED },
@@ -1944,6 +1946,8 @@ static const Roadside _town_road_types_2[][2] = {
 	{ ROADSIDE_STREET_LIGHTS, ROADSIDE_PAVED },
 	{ ROADSIDE_STREET_LIGHTS, ROADSIDE_PAVED }
 };
+
+static_assert(lengthof(_town_road_types_2) == HZB_END);
 
 
 static void TileLoop_Road(TileIndex tile)

--- a/src/script/api/script_town.cpp
+++ b/src/script/api/script_town.cpp
@@ -206,7 +206,7 @@
 	if (!IsValidTown(town_id)) return false;
 
 	const Town *t = ::Town::Get(town_id);
-	return ((uint32_t)GetDistanceSquareToTile(town_id, tile) <= t->cache.squared_town_zone_radius[0]);
+	return ((uint32_t)GetDistanceSquareToTile(town_id, tile) <= t->cache.squared_town_zone_radius[HZB_TOWN_EDGE]);
 }
 
 /* static */ bool ScriptTown::HasStatue(TownID town_id)

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1819,7 +1819,7 @@ static bool GrowTown(Town *t)
  */
 void UpdateTownRadius(Town *t)
 {
-	static const uint32_t _town_squared_town_zone_radius_data[23][5] = {
+	static const uint32_t _town_squared_town_zone_radius_data[23][HZB_END] = {
 		{  4,  0,  0,  0,  0}, // 0
 		{ 16,  0,  0,  0,  0},
 		{ 25,  0,  0,  0,  0},
@@ -1852,11 +1852,11 @@ void UpdateTownRadius(Town *t)
 		/* Actually we are proportional to sqrt() but that's right because we are covering an area.
 		 * The offsets are to make sure the radii do not decrease in size when going from the table
 		 * to the calculated value.*/
-		t->cache.squared_town_zone_radius[0] = mass * 15 - 40;
-		t->cache.squared_town_zone_radius[1] = mass * 9 - 15;
-		t->cache.squared_town_zone_radius[2] = 0;
-		t->cache.squared_town_zone_radius[3] = mass * 5 - 5;
-		t->cache.squared_town_zone_radius[4] = mass * 3 + 5;
+		t->cache.squared_town_zone_radius[HZB_TOWN_EDGE] = mass * 15 - 40;
+		t->cache.squared_town_zone_radius[HZB_TOWN_OUTSKIRT] = mass * 9 - 15;
+		t->cache.squared_town_zone_radius[HZB_TOWN_OUTER_SUBURB] = 0;
+		t->cache.squared_town_zone_radius[HZB_TOWN_INNER_SUBURB] = mass * 5 - 5;
+		t->cache.squared_town_zone_radius[HZB_TOWN_CENTRE] = mass * 3 + 5;
 	}
 }
 
@@ -3482,9 +3482,9 @@ static void ForAllStationsNearTown(Town *t, Func func)
 	 * The true radius is not stored or calculated anywhere, only the squared radius. */
 	/* The efficiency of this search might be improved for large towns and many stations on the map,
 	 * by using an integer square root approximation giving a value not less than the true square root. */
-	uint search_radius = t->cache.squared_town_zone_radius[0] / 2;
+	uint search_radius = t->cache.squared_town_zone_radius[HZB_TOWN_EDGE] / 2;
 	ForAllStationsRadius(t->xy, search_radius, [&](const Station * st) {
-		if (DistanceSquare(st->xy, t->xy) <= t->cache.squared_town_zone_radius[0]) {
+		if (DistanceSquare(st->xy, t->xy) <= t->cache.squared_town_zone_radius[HZB_TOWN_EDGE]) {
 			func(st);
 		}
 	});


### PR DESCRIPTION
## Motivation / Problem
Numbers are being used for town zones, but they already have names associated.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Use town zone constants instead of magic numbers.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
