### PR TITLE
Fix #11577: Extra viewport opened in wrong location.

### DIFF
--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -242,11 +242,22 @@ void InitializeWindowViewport(Window *w, int x, int y,
 		veh = Vehicle::Get(vp->follow_vehicle);
 		pt = MapXYZToViewport(vp, veh->x_pos, veh->y_pos, veh->z_pos);
 	} else {
-		x = TileX(std::get<TileIndex>(focus)) * TILE_SIZE;
-		y = TileY(std::get<TileIndex>(focus)) * TILE_SIZE;
+		TileIndex tile = std::get<TileIndex>(focus);
+		if (tile == INVALID_TILE) {
+			/* No tile? Use center of main viewport. */
+			const Window *mw = GetMainWindow();
 
+			/* center on same place as main window (zoom is maximum, no adjustment needed) */
+			pt.x = mw->viewport->scrollpos_x + mw->viewport->virtual_width / 2;
+			pt.x -= vp->virtual_width / 2;
+			pt.y = mw->viewport->scrollpos_y + mw->viewport->virtual_height / 2;
+			pt.y -= vp->virtual_height / 2;
+		} else {
+			x = TileX(tile) * TILE_SIZE;
+			y = TileY(tile) * TILE_SIZE;
+			pt = MapXYZToViewport(vp, x, y, GetSlopePixelZ(x, y));
+		}
 		vp->follow_vehicle = INVALID_VEHICLE;
-		pt = MapXYZToViewport(vp, x, y, GetSlopePixelZ(x, y));
 	}
 
 	vp->scrollpos_x = pt.x;

--- a/src/viewport_gui.cpp
+++ b/src/viewport_gui.cpp
@@ -57,25 +57,8 @@ public:
 		this->InitNested(window_number);
 
 		NWidgetViewport *nvp = this->GetWidget<NWidgetViewport>(WID_EV_VIEWPORT);
-		nvp->InitializeViewport(this, 0, ScaleZoomGUI(ZOOM_LVL_VIEWPORT));
+		nvp->InitializeViewport(this, tile, ScaleZoomGUI(ZOOM_LVL_VIEWPORT));
 		if (_settings_client.gui.zoom_min == viewport->zoom) this->DisableWidget(WID_EV_ZOOM_IN);
-
-		Point pt;
-		if (tile == INVALID_TILE) {
-			/* No tile? Use center of main viewport. */
-			const Window *w = GetMainWindow();
-
-			/* center on same place as main window (zoom is maximum, no adjustment needed) */
-			pt.x = w->viewport->scrollpos_x + w->viewport->virtual_width / 2;
-			pt.y = w->viewport->scrollpos_y + w->viewport->virtual_height / 2;
-		} else {
-			pt = RemapCoords(TileX(tile) * TILE_SIZE + TILE_SIZE / 2, TileY(tile) * TILE_SIZE + TILE_SIZE / 2, TilePixelHeight(tile));
-		}
-
-		this->viewport->scrollpos_x = pt.x - this->viewport->virtual_width / 2;
-		this->viewport->scrollpos_y = pt.y - this->viewport->virtual_height / 2;
-		this->viewport->dest_scrollpos_x = this->viewport->scrollpos_x;
-		this->viewport->dest_scrollpos_y = this->viewport->scrollpos_y;
 	}
 
 	void SetStringParameters(int widget) const override


### PR DESCRIPTION
## Motivation / Problem

As per #11577, ExtraViewportWindow calls IninitializeViewport() with focus as 0, which is invalid as focus should be either a TileIndex or a VehicleID.

This appears to work on some systems and not others, so seems to be undefined behaviour.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, pass the tile, and let InitializeViewport() set handle all the coordinates.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
