### PR TITLE
Fix 0a8bcdd: Scaling non-sprite fonts does not depend on _font_zoom changing.

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1989,9 +1989,9 @@ bool AdjustGUIZoom(bool automatic)
 	}
 	if (old_font_zoom != _font_zoom) {
 		GfxClearFontSpriteCache();
-		ClearFontCache();
-		LoadStringWidthTable();
 	}
+	ClearFontCache();
+	LoadStringWidthTable();
 
 	UpdateAllVirtCoords();
 


### PR DESCRIPTION
## Motivation / Problem

#11576 reduced sprite reloading when changing interface, but forget that non-sprite fonts can change even if _font_zoom does.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Always clear font caches when interface scale is changed -- for sprite fonts this doesn't do much, and allows scalable fonts to be redrawn.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
