### PR TITLE
Codechange: Use MakeParameters with GetNextParameter in FormatString instead of StringParameters subspan

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1231,7 +1231,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 					}
 
 					default: {
-						StringParameters tmp_params(args, 1);
+						auto tmp_params = MakeParameters(args.GetNextParameter<int64_t>());
 						GetStringWithArgs(builder, cargo_str, tmp_params);
 						break;
 					}
@@ -1245,7 +1245,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 				if (IsValidCargoID(cargo) && cargo >= CargoSpec::GetArraySize()) break;
 
 				StringID cargo_str = !IsValidCargoID(cargo) ? STR_QUANTITY_N_A : CargoSpec::Get(cargo)->quantifier;
-				StringParameters tmp_args(args, 1);
+				auto tmp_args = MakeParameters(args.GetNextParameter<int64_t>());
 				GetStringWithArgs(builder, cargo_str, tmp_args);
 				break;
 			}
@@ -1405,7 +1405,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 			case SCC_DEPOT_NAME: { // {DEPOT}
 				VehicleType vt = args.GetNextParameter<VehicleType>();
 				if (vt == VEH_AIRCRAFT) {
-					StringParameters tmp_params = StringParameters(args, 1);
+					auto tmp_params = MakeParameters(args.GetNextParameter<StationID>());
 					GetStringWithArgs(builder, STR_FORMAT_DEPOT_NAME_AIRCRAFT, tmp_params);
 					break;
 				}


### PR DESCRIPTION
## Motivation / Problem

This is primarily to avoid GS strings via SCC_ENCODED being able to trigger the span `offset + count <= size()` bounds assertion via StringParameter's `StringParameters(StringParameters &parent, size_t size)` constructor when args is too short.
GetNextParameter handles this gracefully.

These would otherwise each need a `game_script && size > args.GetDataLeft()` type guard, as used in SCC_STRINGn.

An example way to trigger this is to use the GS: "Neighbours are important" v16, and look in a town window.

## Description

Use MakeParameters with GetNextParameter instead of unguarded use of StringParameters subspan constructor.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
