### PR TITLE
Fix 11585: Crash when cleaning up AI/GS with nested AsyncMode.

### DIFF
--- a/src/saveload/misc_sl.cpp
+++ b/src/saveload/misc_sl.cpp
@@ -37,11 +37,18 @@ ZoomLevel _saved_scrollpos_zoom;
 
 void SaveViewportBeforeSaveGame()
 {
-	const Window *w = GetMainWindow();
-
-	_saved_scrollpos_x = w->viewport->scrollpos_x;
-	_saved_scrollpos_y = w->viewport->scrollpos_y;
-	_saved_scrollpos_zoom = w->viewport->zoom;
+	/* Don't use GetMainWindow() in case the window does not exist. */
+	const Window *w = FindWindowById(WC_MAIN_WINDOW, 0);
+	if (w == nullptr || w->viewport == nullptr) {
+		/* Ensure saved position is clearly invalid. */
+		_saved_scrollpos_x = INT_MAX;
+		_saved_scrollpos_y = INT_MAX;
+		_saved_scrollpos_zoom = ZOOM_LVL_END;
+	} else {
+		_saved_scrollpos_x = w->viewport->scrollpos_x;
+		_saved_scrollpos_y = w->viewport->scrollpos_y;
+		_saved_scrollpos_zoom = w->viewport->zoom;
+	}
 }
 
 void ResetViewportAfterLoadGame()

--- a/src/script/api/script_asyncmode.cpp
+++ b/src/script/api/script_asyncmode.cpp
@@ -48,8 +48,8 @@ ScriptAsyncMode::ScriptAsyncMode(HSQUIRRELVM vm)
 void ScriptAsyncMode::FinalRelease()
 {
 	if (this->GetDoCommandAsyncModeInstance() != this) {
-		/* Ignore this error if the script already died. */
-		if (!ScriptObject::GetActiveInstance()->IsDead()) {
+		/* Ignore this error if the script is not alive. */
+		if (ScriptObject::GetActiveInstance()->IsAlive()) {
 			throw Script_FatalError("Asyncmode object was removed while it was not the latest *Mode object created.");
 		}
 	}

--- a/src/script/api/script_execmode.cpp
+++ b/src/script/api/script_execmode.cpp
@@ -31,8 +31,8 @@ ScriptExecMode::ScriptExecMode()
 void ScriptExecMode::FinalRelease()
 {
 	if (this->GetDoCommandModeInstance() != this) {
-		/* Ignore this error if the script already died. */
-		if (!ScriptObject::GetActiveInstance()->IsDead()) {
+		/* Ignore this error if the script is not alive. */
+		if (ScriptObject::GetActiveInstance()->IsAlive()) {
 			throw Script_FatalError("ScriptExecMode object was removed while it was not the latest *Mode object created.");
 		}
 	}

--- a/src/script/api/script_testmode.cpp
+++ b/src/script/api/script_testmode.cpp
@@ -31,8 +31,8 @@ ScriptTestMode::ScriptTestMode()
 void ScriptTestMode::FinalRelease()
 {
 	if (this->GetDoCommandModeInstance() != this) {
-		/* Ignore this error if the script already died. */
-		if (!ScriptObject::GetActiveInstance()->IsDead()) {
+		/* Ignore this error if the script is not alive. */
+		if (ScriptObject::GetActiveInstance()->IsAlive()) {
 			throw Script_FatalError("Testmode object was removed while it was not the latest *Mode object created.");
 		}
 	}

--- a/src/script/script_instance.hpp
+++ b/src/script/script_instance.hpp
@@ -153,6 +153,11 @@ public:
 	inline bool IsDead() const { return this->is_dead; }
 
 	/**
+	 * Return whether the script is alive.
+	 */
+	inline bool IsAlive() const { return !this->IsDead() && !this->in_shutdown; }
+
+	/**
 	 * Call the script Save function and save all data in the savegame.
 	 */
 	void Save();


### PR DESCRIPTION
## Motivation / Problem

As per #11585 with the provided scenario and gamescript, using "reload" on the console will crash OpenTTD.

This is due to AsyncMode performing a sanity check for out-of-order destructor, which only matters if the script is still running.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This is resolved by checking for both IsDead() and the in_shutdown member before performing the sanity check.

This is also done for ExecMode and TestMode as they follow the same pattern, although I've not confirmed if they are suspectable -- seems likely though.

Additionally... fix an error in saveload that is triggered when making a crash save.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
