### PR TITLE
Add: Horizontal scroll for script debug log

### DIFF
--- a/src/script/api/script_log_types.hpp
+++ b/src/script/api/script_log_types.hpp
@@ -32,6 +32,7 @@ namespace ScriptLogTypes {
 	struct LogLine {
 		std::string text; ///< The text
 		ScriptLogType type; ///< Text type
+		uint width; ///< The text width
 	};
 
 	/**

--- a/src/widgets/script_widget.h
+++ b/src/widgets/script_widget.h
@@ -41,7 +41,7 @@ enum ScriptDebugWidgets {
 	WID_SCRD_SCRIPT_GAME,          ///< Game Script button.
 	WID_SCRD_RELOAD_TOGGLE,        ///< Reload button.
 	WID_SCRD_LOG_PANEL,            ///< Panel where the log is in.
-	WID_SCRD_SCROLLBAR,            ///< Scrollbar of the log panel.
+	WID_SCRD_VSCROLLBAR,           ///< Vertical scrollbar of the log panel.
 	WID_SCRD_COMPANY_BUTTON_START, ///< Buttons in the VIEW.
 	WID_SCRD_COMPANY_BUTTON_END = WID_SCRD_COMPANY_BUTTON_START + MAX_COMPANIES - 1, ///< Last possible button in the VIEW.
 	WID_SCRD_BREAK_STRING_WIDGETS, ///< The panel to handle the breaking on string.
@@ -49,6 +49,7 @@ enum ScriptDebugWidgets {
 	WID_SCRD_BREAK_STR_EDIT_BOX,   ///< Edit box for the string to break on.
 	WID_SCRD_MATCH_CASE_BTN,       ///< Checkbox to use match caching or not.
 	WID_SCRD_CONTINUE_BTN,         ///< Continue button.
+	WID_SCRD_HSCROLLBAR,           ///< Horizontal scrollbar of the log panel.
 };
 
 #endif /* WIDGETS_SCRIPT_WIDGET_H */


### PR DESCRIPTION
## Motivation / Problem
Script log lines are cropped unless the window is manually resized.
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/cd26fd81-55fe-4050-8c34-a7e2c54f4255)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Added a scroll bar to be able to fully read the string without resizing the window.
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/bfa3918a-b264-4b33-9e8c-d87a2961d16b)

I placed the scrollbar under the break control because I think it looks better.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
