### PR TITLE
Change: Scale sprites to requested highest resolution level.

### DIFF
--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -397,6 +397,12 @@ static bool ResizeSprites(SpriteLoader::SpriteCollection &sprite, uint8_t sprite
 		if (!HasBit(sprite_avail, zoom)) ResizeSpriteOut(sprite, zoom);
 	}
 
+	/* Upscale to desired sprite_min_zoom if provided sprite only had zoomed in versions. */
+	if (first_avail < _settings_client.gui.sprite_zoom_min) {
+		if (_settings_client.gui.sprite_zoom_min >= ZOOM_LVL_OUT_4X) ResizeSpriteIn(sprite, ZOOM_LVL_OUT_4X, ZOOM_LVL_OUT_2X);
+		if (_settings_client.gui.sprite_zoom_min >= ZOOM_LVL_OUT_2X) ResizeSpriteIn(sprite, ZOOM_LVL_OUT_2X, ZOOM_LVL_NORMAL);
+	}
+
 	return  true;
 }
 


### PR DESCRIPTION
## Motivation / Problem

The setting "Highest resolution sprites to use" is ignored if a graphics set only has high resolution sprites. The high resolution sprites are loaded anyway and used as-is.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/b3a904a6-5a15-460a-9f5c-4930cf26be89)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Sprites from graphics sets which only provide high resolution sprites are now scaled up from scaled down versions, replacing the high resolution versions.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/cf8bad21-8417-45aa-81b9-336e1723dcf4)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Graphics sets that use "odd" offsets may end up with shifting sprites. This also happens when they're viewed at 2x or 4x zoomed out levels, but because they're zoomed out it's less noticeable.

Not sure if this is a rounding issue with offsets, or the sets are "doing it wrong."

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
