### PR TITLE
Feature: Convert 32bpp-only sprites to 8bpp for 8bpp blitters.

### DIFF
--- a/src/blitter/32bpp_anim.cpp
+++ b/src/blitter/32bpp_anim.cpp
@@ -114,7 +114,7 @@ inline void Blitter_32bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 							} else {
 								uint r = remap[GB(m, 0, 8)];
 								*anim = r | (m & 0xFF00);
-								if (r != 0) *dst = this->AdjustBrightness(this->LookupColourInPalette(r), GB(m, 8, 8));
+								if (r != 0) *dst = AdjustBrightness(this->LookupColourInPalette(r), GB(m, 8, 8));
 							}
 							anim++;
 							dst++;
@@ -130,7 +130,7 @@ inline void Blitter_32bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 							} else {
 								uint r = remap[GB(m, 0, 8)];
 								*anim = 0;
-								if (r != 0) *dst = ComposeColourPANoCheck(this->AdjustBrightness(this->LookupColourInPalette(r), GB(m, 8, 8)), src_px->a, *dst);
+								if (r != 0) *dst = ComposeColourPANoCheck(AdjustBrightness(this->LookupColourInPalette(r), GB(m, 8, 8)), src_px->a, *dst);
 							}
 							anim++;
 							dst++;
@@ -151,7 +151,7 @@ inline void Blitter_32bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 							} else {
 								uint r = remap[GB(m, 0, 8)];
 								*anim = r | (m & 0xFF00);
-								if (r != 0) *dst = this->AdjustBrightness(this->LookupColourInPalette(r), GB(m, 8, 8));
+								if (r != 0) *dst = AdjustBrightness(this->LookupColourInPalette(r), GB(m, 8, 8));
 							}
 							anim++;
 							dst++;
@@ -170,7 +170,7 @@ inline void Blitter_32bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 							} else {
 								uint r = remap[GB(m, 0, 8)];
 								*anim = 0;
-								if (r != 0) *dst = ComposeColourPANoCheck(this->AdjustBrightness(this->LookupColourInPalette(r), GB(m, 8, 8)), src_px->a, *dst);
+								if (r != 0) *dst = ComposeColourPANoCheck(AdjustBrightness(this->LookupColourInPalette(r), GB(m, 8, 8)), src_px->a, *dst);
 							}
 							anim++;
 							dst++;
@@ -237,7 +237,7 @@ inline void Blitter_32bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 							uint m = GB(*src_n, 0, 8);
 							/* Above PALETTE_ANIM_START is palette animation */
 							*anim++ = *src_n;
-							*dst++ = (m >= PALETTE_ANIM_START) ? this->AdjustBrightness(this->LookupColourInPalette(m), GB(*src_n, 8, 8)) : src_px->data;
+							*dst++ = (m >= PALETTE_ANIM_START) ? AdjustBrightness(this->LookupColourInPalette(m), GB(*src_n, 8, 8)) : src_px->data;
 							src_px++;
 							src_n++;
 						} while (--n != 0);
@@ -246,7 +246,7 @@ inline void Blitter_32bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 							uint m = GB(*src_n, 0, 8);
 							*anim++ = 0;
 							if (m >= PALETTE_ANIM_START) {
-								*dst = ComposeColourPANoCheck(this->AdjustBrightness(this->LookupColourInPalette(m), GB(*src_n, 8, 8)), src_px->a, *dst);
+								*dst = ComposeColourPANoCheck(AdjustBrightness(this->LookupColourInPalette(m), GB(*src_n, 8, 8)), src_px->a, *dst);
 							} else {
 								*dst = ComposeColourRGBANoCheck(src_px->r, src_px->g, src_px->b, src_px->a, *dst);
 							}
@@ -413,7 +413,7 @@ void Blitter_32bppAnim::CopyFromBuffer(void *video, const void *src, int width, 
 			uint colour = GB(*anim_pal, 0, 8);
 			if (colour >= PALETTE_ANIM_START) {
 				/* Update this pixel */
-				*dst_pal = this->AdjustBrightness(LookupColourInPalette(colour), GB(*anim_pal, 8, 8));
+				*dst_pal = AdjustBrightness(LookupColourInPalette(colour), GB(*anim_pal, 8, 8));
 			}
 			dst_pal++;
 			anim_pal++;
@@ -522,7 +522,7 @@ void Blitter_32bppAnim::PaletteAnimate(const Palette &palette)
 			uint8_t colour = GB(value, 0, 8);
 			if (colour >= PALETTE_ANIM_START) {
 				/* Update this pixel */
-				*dst = this->AdjustBrightness(LookupColourInPalette(colour), GB(value, 8, 8));
+				*dst = AdjustBrightness(LookupColourInPalette(colour), GB(value, 8, 8));
 			}
 			dst++;
 			anim++;

--- a/src/blitter/32bpp_anim_sse2.cpp
+++ b/src/blitter/32bpp_anim_sse2.cpp
@@ -40,7 +40,7 @@ void Blitter_32bppSSE2_Anim::PaletteAnimate(const Palette &palette)
 	const int screen_pitch = _screen.pitch;
 	const int anim_pitch = this->anim_buf_pitch;
 	__m128i anim_cmp = _mm_set1_epi16(PALETTE_ANIM_START - 1);
-	__m128i brightness_cmp = _mm_set1_epi16(Blitter_32bppBase::DEFAULT_BRIGHTNESS);
+	__m128i brightness_cmp = _mm_set1_epi16(DEFAULT_BRIGHTNESS);
 	__m128i colour_mask = _mm_set1_epi16(0xFF);
 	for (int y = this->anim_buf_height; y != 0 ; y--) {
 		Colour *next_dst_ln = dst + screen_pitch;

--- a/src/blitter/32bpp_anim_sse4.cpp
+++ b/src/blitter/32bpp_anim_sse4.cpp
@@ -343,7 +343,7 @@ bmcr_alpha_blend_single:
 						}
 					} else {
 						uint r = remap[src_mv->m];
-						if (r != 0) *dst = ComposeColourPANoCheck(this->AdjustBrightness(this->LookupColourInPalette(r), src_mv->v), src->a, *dst);
+						if (r != 0) *dst = ComposeColourPANoCheck(AdjustBrightness(this->LookupColourInPalette(r), src_mv->v), src->a, *dst);
 					}
 					src_mv++;
 					dst++;

--- a/src/blitter/32bpp_base.cpp
+++ b/src/blitter/32bpp_base.cpp
@@ -150,36 +150,6 @@ void Blitter_32bppBase::PaletteAnimate(const Palette &)
 	/* By default, 32bpp doesn't have palette animation */
 }
 
-Colour Blitter_32bppBase::ReallyAdjustBrightness(Colour colour, uint8_t brightness)
-{
-	assert(DEFAULT_BRIGHTNESS == 1 << 7);
-
-	uint64_t combined = (((uint64_t) colour.r) << 32) | (((uint64_t) colour.g) << 16) | ((uint64_t) colour.b);
-	combined *= brightness;
-
-	uint16_t r = GB(combined, 39, 9);
-	uint16_t g = GB(combined, 23, 9);
-	uint16_t b = GB(combined, 7, 9);
-
-	if ((combined & 0x800080008000L) == 0L) {
-		return Colour(r, g, b, colour.a);
-	}
-
-	uint16_t ob = 0;
-	/* Sum overbright */
-	if (r > 255) ob += r - 255;
-	if (g > 255) ob += g - 255;
-	if (b > 255) ob += b - 255;
-
-	/* Reduce overbright strength */
-	ob /= 2;
-	return Colour(
-		r >= 255 ? 255 : std::min(r + ob * (255 - r) / 256, 255),
-		g >= 255 ? 255 : std::min(g + ob * (255 - g) / 256, 255),
-		b >= 255 ? 255 : std::min(b + ob * (255 - b) / 256, 255),
-		colour.a);
-}
-
 Blitter::PaletteAnimation Blitter_32bppBase::UsePaletteAnimation()
 {
 	return Blitter::PALETTE_ANIMATION_NONE;

--- a/src/blitter/32bpp_base.hpp
+++ b/src/blitter/32bpp_base.hpp
@@ -11,9 +11,8 @@
 #define BLITTER_32BPP_BASE_HPP
 
 #include "base.hpp"
-#include "../core/bitmath_func.hpp"
-#include "../core/math_func.hpp"
 #include "../gfx_func.h"
+#include "../palette_func.h"
 
 /** Base for all 32bpp blitters. */
 class Blitter_32bppBase : public Blitter {
@@ -152,28 +151,6 @@ public:
 		uint grey = ((r * 19595) + (g * 38470) + (b * 7471)) / 65536;
 
 		return Colour(grey, grey, grey);
-	}
-
-	static const int DEFAULT_BRIGHTNESS = 128;
-
-	static Colour ReallyAdjustBrightness(Colour colour, uint8_t brightness);
-
-	static inline Colour AdjustBrightness(Colour colour, uint8_t brightness)
-	{
-		/* Shortcut for normal brightness */
-		if (brightness == DEFAULT_BRIGHTNESS) return colour;
-
-		return ReallyAdjustBrightness(colour, brightness);
-	}
-
-	static inline uint8_t GetColourBrightness(Colour colour)
-	{
-		uint8_t rgb_max = std::max(colour.r, std::max(colour.g, colour.b));
-
-		/* Black pixel (8bpp or old 32bpp image), so use default value */
-		if (rgb_max == 0) rgb_max = DEFAULT_BRIGHTNESS;
-
-		return rgb_max;
 	}
 };
 

--- a/src/blitter/32bpp_optimized.cpp
+++ b/src/blitter/32bpp_optimized.cpp
@@ -120,7 +120,7 @@ inline void Blitter_32bppOptimized::Draw(const Blitter::BlitterParams *bp, ZoomL
 								*dst = src_px->data;
 							} else {
 								uint r = remap[GB(m, 0, 8)];
-								if (r != 0) *dst = this->AdjustBrightness(this->LookupColourInPalette(r), GB(m, 8, 8));
+								if (r != 0) *dst = AdjustBrightness(this->LookupColourInPalette(r), GB(m, 8, 8));
 							}
 							dst++;
 							src_px++;
@@ -133,7 +133,7 @@ inline void Blitter_32bppOptimized::Draw(const Blitter::BlitterParams *bp, ZoomL
 								*dst = ComposeColourRGBANoCheck(src_px->r, src_px->g, src_px->b, src_px->a, *dst);
 							} else {
 								uint r = remap[GB(m, 0, 8)];
-								if (r != 0) *dst = ComposeColourPANoCheck(this->AdjustBrightness(this->LookupColourInPalette(r), GB(m, 8, 8)), src_px->a, *dst);
+								if (r != 0) *dst = ComposeColourPANoCheck(AdjustBrightness(this->LookupColourInPalette(r), GB(m, 8, 8)), src_px->a, *dst);
 							}
 							dst++;
 							src_px++;
@@ -151,7 +151,7 @@ inline void Blitter_32bppOptimized::Draw(const Blitter::BlitterParams *bp, ZoomL
 								*dst = ComposeColourRGBA(g, g, g, src_px->a, *dst);
 							} else {
 								uint r = remap[GB(m, 0, 8)];
-								if (r != 0) *dst = this->AdjustBrightness(this->LookupColourInPalette(r), GB(m, 8, 8));
+								if (r != 0) *dst = AdjustBrightness(this->LookupColourInPalette(r), GB(m, 8, 8));
 							}
 							dst++;
 							src_px++;
@@ -167,7 +167,7 @@ inline void Blitter_32bppOptimized::Draw(const Blitter::BlitterParams *bp, ZoomL
 								}
 							} else {
 								uint r = remap[GB(m, 0, 8)];
-								if (r != 0) *dst = ComposeColourPANoCheck(this->AdjustBrightness(this->LookupColourInPalette(r), GB(m, 8, 8)), src_px->a, *dst);
+								if (r != 0) *dst = ComposeColourPANoCheck(AdjustBrightness(this->LookupColourInPalette(r), GB(m, 8, 8)), src_px->a, *dst);
 							}
 							dst++;
 							src_px++;
@@ -224,7 +224,7 @@ inline void Blitter_32bppOptimized::Draw(const Blitter::BlitterParams *bp, ZoomL
 						do {
 							if (Tpal_to_rgb && *src_n != 0) {
 								/* Convert the mapping channel to a RGB value */
-								*dst = this->AdjustBrightness(this->LookupColourInPalette(GB(*src_n, 0, 8)), GB(*src_n, 8, 8)).data;
+								*dst = AdjustBrightness(this->LookupColourInPalette(GB(*src_n, 0, 8)), GB(*src_n, 8, 8)).data;
 							} else {
 								*dst = src_px->data;
 							}
@@ -236,7 +236,7 @@ inline void Blitter_32bppOptimized::Draw(const Blitter::BlitterParams *bp, ZoomL
 						do {
 							if (Tpal_to_rgb && *src_n != 0) {
 								/* Convert the mapping channel to a RGB value */
-								Colour colour = this->AdjustBrightness(this->LookupColourInPalette(GB(*src_n, 0, 8)), GB(*src_n, 8, 8));
+								Colour colour = AdjustBrightness(this->LookupColourInPalette(GB(*src_n, 0, 8)), GB(*src_n, 8, 8));
 								*dst = ComposeColourRGBANoCheck(colour.r, colour.g, colour.b, src_px->a, *dst);
 							} else {
 								*dst = ComposeColourRGBANoCheck(src_px->r, src_px->g, src_px->b, src_px->a, *dst);
@@ -366,7 +366,7 @@ template <bool Tpal_to_rgb> Sprite *Blitter_32bppOptimized::EncodeInternal(const
 
 						if (Tpal_to_rgb) {
 							/* Pre-convert the mapping channel to a RGB value */
-							Colour colour = this->AdjustBrightness(this->LookupColourInPalette(src->m), rgb_max);
+							Colour colour = AdjustBrightness(this->LookupColourInPalette(src->m), rgb_max);
 							dst_px->r = colour.r;
 							dst_px->g = colour.g;
 							dst_px->b = colour.b;

--- a/src/blitter/32bpp_simple.cpp
+++ b/src/blitter/32bpp_simple.cpp
@@ -42,7 +42,7 @@ void Blitter_32bppSimple::Draw(Blitter::BlitterParams *bp, BlitterMode mode, Zoo
 					if (src->m == 0) {
 						if (src->a != 0) *dst = ComposeColourRGBA(src->r, src->g, src->b, src->a, *dst);
 					} else {
-						if (bp->remap[src->m] != 0) *dst = ComposeColourPA(this->AdjustBrightness(this->LookupColourInPalette(bp->remap[src->m]), src->v), src->a, *dst);
+						if (bp->remap[src->m] != 0) *dst = ComposeColourPA(AdjustBrightness(this->LookupColourInPalette(bp->remap[src->m]), src->v), src->a, *dst);
 					}
 					break;
 
@@ -53,7 +53,7 @@ void Blitter_32bppSimple::Draw(Blitter::BlitterParams *bp, BlitterMode mode, Zoo
 							*dst = ComposeColourRGBA(g, g, g, src->a, *dst);
 						}
 					} else {
-						if (bp->remap[src->m] != 0) *dst = ComposeColourPA(this->AdjustBrightness(this->LookupColourInPalette(bp->remap[src->m]), src->v), src->a, *dst);
+						if (bp->remap[src->m] != 0) *dst = ComposeColourPA(AdjustBrightness(this->LookupColourInPalette(bp->remap[src->m]), src->v), src->a, *dst);
 					}
 					break;
 
@@ -145,7 +145,7 @@ Sprite *Blitter_32bppSimple::Encode(const SpriteLoader::SpriteCollection &sprite
 			dst[i].v = rgb_max;
 
 			/* Pre-convert the mapping channel to a RGB value */
-			Colour colour = this->AdjustBrightness(this->LookupColourInPalette(src->m), dst[i].v);
+			Colour colour = AdjustBrightness(this->LookupColourInPalette(src->m), dst[i].v);
 			dst[i].r = colour.r;
 			dst[i].g = colour.g;
 			dst[i].b = colour.b;

--- a/src/blitter/32bpp_sse2.cpp
+++ b/src/blitter/32bpp_sse2.cpp
@@ -81,7 +81,7 @@ Sprite *Blitter_32bppSSE_Base::Encode(const SpriteLoader::SpriteCollection &spri
 
 						/* Get brightest value (or default brightness if it's a black pixel). */
 						const uint8_t rgb_max = std::max({src->r, src->g, src->b});
-						dst_mv->v = (rgb_max == 0) ? Blitter_32bppBase::DEFAULT_BRIGHTNESS : rgb_max;
+						dst_mv->v = (rgb_max == 0) ? DEFAULT_BRIGHTNESS : rgb_max;
 
 						/* Pre-convert the mapping channel to a RGB value. */
 						const Colour colour = AdjustBrightneSSE(Blitter_32bppBase::LookupColourInPalette(src->m), dst_mv->v);
@@ -92,7 +92,7 @@ Sprite *Blitter_32bppSSE_Base::Encode(const SpriteLoader::SpriteCollection &spri
 						dst_rgba->r = src->r;
 						dst_rgba->g = src->g;
 						dst_rgba->b = src->b;
-						dst_mv->v = Blitter_32bppBase::DEFAULT_BRIGHTNESS;
+						dst_mv->v = DEFAULT_BRIGHTNESS;
 					}
 				} else {
 					dst_rgba->data = 0;

--- a/src/blitter/32bpp_sse_func.hpp
+++ b/src/blitter/32bpp_sse_func.hpp
@@ -123,7 +123,7 @@ INTERNAL_LINKAGE Colour ReallyAdjustBrightness(Colour colour, uint8_t brightness
 	uint64_t c16 = colour.b | (uint64_t) colour.g << 16 | (uint64_t) colour.r << 32;
 	c16 *= brightness;
 	uint64_t c16_ob = c16; // Helps out of order execution.
-	c16 /= Blitter_32bppBase::DEFAULT_BRIGHTNESS;
+	c16 /= DEFAULT_BRIGHTNESS;
 	c16 &= 0x01FF01FF01FFULL;
 
 	/* Sum overbright (maximum for each rgb is 508, 9 bits, -255 is changed in -256 so we just have to take the 8 lower bits into account). */
@@ -155,7 +155,7 @@ IGNORE_UNINITIALIZED_WARNING_STOP
 INTERNAL_LINKAGE inline Colour AdjustBrightneSSE(Colour colour, uint8_t brightness)
 {
 	/* Shortcut for normal brightness. */
-	if (brightness == Blitter_32bppBase::DEFAULT_BRIGHTNESS) return colour;
+	if (brightness == DEFAULT_BRIGHTNESS) return colour;
 
 	return ReallyAdjustBrightness(colour, brightness);
 }
@@ -171,7 +171,7 @@ INTERNAL_LINKAGE inline __m128i AdjustBrightnessOfTwoPixels([[maybe_unused]] __m
 	 * OK, not a 1 but DEFAULT_BRIGHTNESS to compensate the div.
 	 */
 	brightness &= 0xFF00FF00;
-	brightness += Blitter_32bppBase::DEFAULT_BRIGHTNESS;
+	brightness += DEFAULT_BRIGHTNESS;
 
 	__m128i colAB = _mm_unpacklo_epi8(from, _mm_setzero_si128());
 	__m128i briAB = _mm_cvtsi32_si128(brightness);
@@ -420,7 +420,7 @@ bmcr_alpha_blend_single:
 						}
 					} else {
 						uint r = remap[src_mv->m];
-						if (r != 0) *dst = ComposeColourPANoCheck(this->AdjustBrightness(this->LookupColourInPalette(r), src_mv->v), src->a, *dst);
+						if (r != 0) *dst = ComposeColourPANoCheck(AdjustBrightness(this->LookupColourInPalette(r), src_mv->v), src->a, *dst);
 					}
 					src_mv++;
 					dst++;

--- a/src/blitter/40bpp_anim.cpp
+++ b/src/blitter/40bpp_anim.cpp
@@ -243,7 +243,7 @@ inline void Blitter_40bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 							/* If the anim buffer contains a color value, the image composition will
 							 * only look at the RGB brightness value. As such, we can simply darken the
 							 * RGB value to darken the anim color. */
-							Colour b = *anim != 0 ? Colour(this->GetColourBrightness(*dst), 0, 0) : *dst;
+							Colour b = *anim != 0 ? Colour(GetColourBrightness(*dst), 0, 0) : *dst;
 							*dst = this->MakeTransparent(b, 3, 4);
 							anim++;
 							dst++;
@@ -365,7 +365,7 @@ void Blitter_40bppAnim::DrawColourMappingRect(void *dst, int width, int height, 
 		 * RGB value to darken the anim color. */
 		do {
 			for (int i = 0; i != width; i++) {
-				Colour b = *anim != 0 ? Colour(this->GetColourBrightness(*udst), 0, 0) : *udst;
+				Colour b = *anim != 0 ? Colour(GetColourBrightness(*udst), 0, 0) : *udst;
 				*udst = MakeTransparent(b, 154);
 				udst++;
 				anim++;

--- a/src/palette.cpp
+++ b/src/palette.cpp
@@ -131,6 +131,42 @@ uint8_t GetNearestColourIndex(uint8_t r, uint8_t g, uint8_t b)
 	return _palette_lookup[key];
 }
 
+/**
+ * Adjust brightness of colour.
+ * @param colour Colour to adjust.
+ * @param brightness Brightness to apply to colour.
+ * @returns Adjusted colour.
+ */
+Colour ReallyAdjustBrightness(Colour colour, int brightness)
+{
+	if (brightness == DEFAULT_BRIGHTNESS) return colour;
+
+	uint64_t combined = (static_cast<uint64_t>(colour.r) << 32) | (static_cast<uint64_t>(colour.g) << 16) | static_cast<uint64_t>(colour.b);
+	combined *= brightness;
+
+	uint16_t r = GB(combined, 39, 9);
+	uint16_t g = GB(combined, 23, 9);
+	uint16_t b = GB(combined, 7, 9);
+
+	if ((combined & 0x800080008000L) == 0L) {
+		return Colour(r, g, b, colour.a);
+	}
+
+	uint16_t ob = 0;
+	/* Sum overbright */
+	if (r > 255) ob += r - 255;
+	if (g > 255) ob += g - 255;
+	if (b > 255) ob += b - 255;
+
+	/* Reduce overbright strength */
+	ob /= 2;
+	return Colour(
+		r >= 255 ? 255 : std::min(r + ob * (255 - r) / 256, 255),
+		g >= 255 ? 255 : std::min(g + ob * (255 - g) / 256, 255),
+		b >= 255 ? 255 : std::min(b + ob * (255 - b) / 256, 255),
+		colour.a);
+}
+
 void DoPaletteAnimations();
 
 void GfxInitPalettes()

--- a/src/palette_func.h
+++ b/src/palette_func.h
@@ -21,6 +21,7 @@ bool CopyPalette(Palette &local_palette, bool force_copy = false);
 void GfxInitPalettes();
 
 uint8_t GetNearestColourIndex(uint8_t r, uint8_t g, uint8_t b);
+uint8_t GetNearestColourReshadeIndex(uint8_t b);
 
 inline uint8_t GetNearestColourIndex(const Colour colour)
 {

--- a/src/palette_func.h
+++ b/src/palette_func.h
@@ -27,6 +27,34 @@ inline uint8_t GetNearestColourIndex(const Colour colour)
 	return GetNearestColourIndex(colour.r, colour.g, colour.b);
 }
 
+static constexpr int DEFAULT_BRIGHTNESS = 128;
+
+Colour ReallyAdjustBrightness(Colour colour, int brightness);
+
+static inline Colour AdjustBrightness(Colour colour, uint8_t brightness)
+{
+	/* Shortcut for normal brightness */
+	if (brightness == DEFAULT_BRIGHTNESS) return colour;
+
+	return ReallyAdjustBrightness(colour, brightness);
+}
+
+/**
+ * Get the brightness of a colour.
+ * This uses the maximum value of R, G or B channel, instead of perceptual brightness.
+ * @param colour Colour to get the brightness of.
+ * @returns Brightness of colour.
+ */
+static inline uint8_t GetColourBrightness(Colour colour)
+{
+	uint8_t rgb_max = std::max(colour.r, std::max(colour.g, colour.b));
+
+	/* Black pixel (8bpp or old 32bpp image), so use default value */
+	if (rgb_max == 0) rgb_max = DEFAULT_BRIGHTNESS;
+
+	return rgb_max;
+}
+
 /**
  * Checks if a Colours value is valid.
  *

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -477,15 +477,17 @@ static void *ReadSprite(const SpriteCache *sc, SpriteID id, SpriteType sprite_ty
 
 	SpriteLoader::SpriteCollection sprite;
 	uint8_t sprite_avail = 0;
+	uint8_t avail_8bpp = 0;
+	uint8_t avail_32bpp = 0;
 	sprite[ZOOM_LVL_MIN].type = sprite_type;
 
 	SpriteLoaderGrf sprite_loader(file.GetContainerVersion());
 	if (sprite_type != SpriteType::MapGen && encoder->Is32BppSupported()) {
 		/* Try for 32bpp sprites first. */
-		sprite_avail = sprite_loader.LoadSprite(sprite, file, file_pos, sprite_type, true, sc->control_flags);
+		sprite_avail = sprite_loader.LoadSprite(sprite, file, file_pos, sprite_type, true, sc->control_flags, avail_8bpp, avail_32bpp);
 	}
 	if (sprite_avail == 0) {
-		sprite_avail = sprite_loader.LoadSprite(sprite, file, file_pos, sprite_type, false, sc->control_flags);
+		sprite_avail = sprite_loader.LoadSprite(sprite, file, file_pos, sprite_type, false, sc->control_flags, avail_8bpp, avail_32bpp);
 	}
 
 	if (sprite_avail == 0) {

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -10,6 +10,7 @@
 #include "stdafx.h"
 #include "random_access_file_type.h"
 #include "spriteloader/grf.hpp"
+#include "spriteloader/makeindexed.h"
 #include "gfx_func.h"
 #include "error.h"
 #include "error_func.h"
@@ -488,6 +489,11 @@ static void *ReadSprite(const SpriteCache *sc, SpriteID id, SpriteType sprite_ty
 	}
 	if (sprite_avail == 0) {
 		sprite_avail = sprite_loader.LoadSprite(sprite, file, file_pos, sprite_type, false, sc->control_flags, avail_8bpp, avail_32bpp);
+		if (sprite_type == SpriteType::Normal && avail_32bpp != 0 && !encoder->Is32BppSupported() && sprite_avail == 0) {
+			/* No 8bpp available, try converting from 32bpp. */
+			SpriteLoaderMakeIndexed make_indexed(sprite_loader);
+			sprite_avail = make_indexed.LoadSprite(sprite, file, file_pos, sprite_type, true, sc->control_flags, sprite_avail, avail_32bpp);
+		}
 	}
 
 	if (sprite_avail == 0) {

--- a/src/spriteloader/CMakeLists.txt
+++ b/src/spriteloader/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_files(
     grf.cpp
     grf.hpp
+    makeindexed.cpp
+    makeindexed.h
     sprite_file.cpp
     sprite_file_type.hpp
     spriteloader.hpp

--- a/src/spriteloader/grf.cpp
+++ b/src/spriteloader/grf.cpp
@@ -215,7 +215,7 @@ bool DecodeSingleSprite(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t f
 	return true;
 }
 
-uint8_t LoadSpriteV1(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp)
+uint8_t LoadSpriteV1(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, uint8_t &avail_8bpp)
 {
 	/* Check the requested colour depth. */
 	if (load_32bpp) return 0;
@@ -247,12 +247,15 @@ uint8_t LoadSpriteV1(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, s
 	 * In case it is uncompressed, the size is 'num' - 8 (header-size). */
 	num = (type & 0x02) ? sprite[zoom_lvl].width * sprite[zoom_lvl].height : num - 8;
 
-	if (DecodeSingleSprite(&sprite[zoom_lvl], file, file_pos, sprite_type, num, type, zoom_lvl, SCC_PAL, 1)) return 1 << zoom_lvl;
+	if (DecodeSingleSprite(&sprite[zoom_lvl], file, file_pos, sprite_type, num, type, zoom_lvl, SCC_PAL, 1)) {
+		SetBit(avail_8bpp, zoom_lvl);
+		return avail_8bpp;
+	}
 
 	return 0;
 }
 
-uint8_t LoadSpriteV2(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, uint8_t control_flags)
+uint8_t LoadSpriteV2(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, uint8_t control_flags, uint8_t &avail_8bpp, uint8_t &avail_32bpp)
 {
 	static const ZoomLevel zoom_lvl_map[6] = {ZOOM_LVL_NORMAL, ZOOM_LVL_IN_4X, ZOOM_LVL_IN_2X, ZOOM_LVL_OUT_2X, ZOOM_LVL_OUT_4X, ZOOM_LVL_OUT_8X};
 
@@ -281,6 +284,9 @@ uint8_t LoadSpriteV2(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, s
 
 		if (sprite_type != SpriteType::MapGen) {
 			if (zoom < lengthof(zoom_lvl_map)) {
+				if (colour == SCC_PAL) SetBit(avail_8bpp, zoom_lvl_map[zoom]);
+				if (colour != SCC_PAL) SetBit(avail_32bpp, zoom_lvl_map[zoom]);
+
 				is_wanted_zoom_lvl = true;
 				ZoomLevel zoom_min = sprite_type == SpriteType::Font ? ZOOM_LVL_MIN : _settings_client.gui.sprite_zoom_min;
 				if (zoom_min >= ZOOM_LVL_IN_2X &&
@@ -350,11 +356,11 @@ uint8_t LoadSpriteV2(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, s
 	return loaded_sprites;
 }
 
-uint8_t SpriteLoaderGrf::LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, uint8_t control_flags)
+uint8_t SpriteLoaderGrf::LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, uint8_t control_flags, uint8_t &avail_8bpp, uint8_t &avail_32bpp)
 {
 	if (this->container_ver >= 2) {
-		return LoadSpriteV2(sprite, file, file_pos, sprite_type, load_32bpp, control_flags);
+		return LoadSpriteV2(sprite, file, file_pos, sprite_type, load_32bpp, control_flags, avail_8bpp, avail_32bpp);
 	} else {
-		return LoadSpriteV1(sprite, file, file_pos, sprite_type, load_32bpp);
+		return LoadSpriteV1(sprite, file, file_pos, sprite_type, load_32bpp, avail_8bpp);
 	}
 }

--- a/src/spriteloader/grf.hpp
+++ b/src/spriteloader/grf.hpp
@@ -17,7 +17,7 @@ class SpriteLoaderGrf : public SpriteLoader {
 	uint8_t container_ver;
 public:
 	SpriteLoaderGrf(uint8_t container_ver) : container_ver(container_ver) {}
-	uint8_t LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, uint8_t control_flags) override;
+	uint8_t LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, uint8_t control_flags, uint8_t &avail_8bpp, uint8_t &avail_32bpp) override;
 };
 
 #endif /* SPRITELOADER_GRF_HPP */

--- a/src/spriteloader/makeindexed.cpp
+++ b/src/spriteloader/makeindexed.cpp
@@ -1,0 +1,60 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file makeindexed.cpp Implementation for converting sprites from another source from 32bpp RGBA to indexed 8bpp. */
+
+#include "../stdafx.h"
+#include "../core/bitmath_func.hpp"
+#include "../core/math_func.hpp"
+#include "../gfx_func.h"
+#include "../palette_func.h"
+#include "makeindexed.h"
+
+#include "../safeguards.h"
+
+/**
+ * Convert in place a 32bpp sprite to 8bpp.
+ * @param sprite Sprite to convert.
+ */
+static void Convert32bppTo8bpp(SpriteLoader::Sprite &sprite)
+{
+	const auto *pixel_end = sprite.data + sprite.width * sprite.height;
+	for (auto *pixel = sprite.data; pixel != pixel_end; ++pixel) {
+		if (pixel->m != 0) {
+			/* Pixel has 8bpp mask, test if should be reshaded. */
+			uint8_t brightness = std::max({pixel->r, pixel->g, pixel->b});
+			if (brightness == 0 || brightness == 128) continue;
+
+			/* Update RGB component with reshaded palette colour, and enabled reshade. */
+			Colour c = AdjustBrightness(_cur_palette.palette[pixel->m], brightness);
+
+			if (IsInsideMM(pixel->m, 0xC6, 0xCE)) {
+				/* Dumb but simple brightness conversion. */
+				pixel->m = GetNearestColourReshadeIndex((c.r + c.g + c.b) / 3);
+			} else {
+				pixel->m = GetNearestColourIndex(c.r, c.g, c.b);
+			}
+		} else if (pixel->a < 128) {
+			/* Transparent pixel. */
+			pixel->m = 0;
+		} else {
+			/* Find nearest match from palette. */
+			pixel->m = GetNearestColourIndex(pixel->r, pixel->g, pixel->b);
+		}
+	}
+}
+
+uint8_t SpriteLoaderMakeIndexed::LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool, uint8_t control_flags, uint8_t &avail_8bpp, uint8_t &avail_32bpp)
+{
+	uint8_t avail = this->baseloader.LoadSprite(sprite, file, file_pos, sprite_type, true, control_flags, avail_8bpp, avail_32bpp);
+
+	for (ZoomLevel zoom = ZOOM_LVL_NORMAL; zoom != ZOOM_LVL_END; zoom++) {
+		if (HasBit(avail, zoom)) Convert32bppTo8bpp(sprite[zoom]);
+	}
+
+	return avail;
+}

--- a/src/spriteloader/makeindexed.h
+++ b/src/spriteloader/makeindexed.h
@@ -1,0 +1,23 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file makeindexed.h Base for converting sprites from another source from 32bpp RGBA to indexed 8bpp. */
+
+#ifndef SPRITELOADER_MAKEINDEXED_H
+#define SPRITELOADER_MAKEINDEXED_H
+
+#include "spriteloader.hpp"
+
+/** Sprite loader for converting graphics coming from another source. */
+class SpriteLoaderMakeIndexed : public SpriteLoader {
+	SpriteLoader &baseloader;
+public:
+	SpriteLoaderMakeIndexed(SpriteLoader &baseloader) : baseloader(baseloader) {}
+	uint8_t LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, uint8_t control_flags, uint8_t &avail_8bpp, uint8_t &avail_32bpp) override;
+};
+
+#endif /* SPRITELOADER_MAKEINDEXED_H */

--- a/src/spriteloader/spriteloader.hpp
+++ b/src/spriteloader/spriteloader.hpp
@@ -79,7 +79,7 @@ public:
 	 * @param control_flags Control flags, see SpriteCacheCtrlFlags.
 	 * @return Bit mask of the zoom levels successfully loaded or 0 if no sprite could be loaded.
 	 */
-	virtual uint8_t LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, uint8_t control_flags) = 0;
+	virtual uint8_t LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, uint8_t control_flags, uint8_t &avail_8bpp, uint8_t &avail_32bpp) = 0;
 
 	virtual ~SpriteLoader() = default;
 };


### PR DESCRIPTION
## Motivation / Problem

OpenTTD supports creating 32bpp or 8bpp graphics, and some graphics sets are 32bpp-only. Loading these when the game is running with 8bpp provides a suboptimal experience:

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/41f2d13b-78bc-40d6-b8f4-31784bf72079)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This PR implements simple nearest-neighbour conversion of sprites from 32bpp to indexed 8bpp, along with a little bit of hackery to detect dummy sprites used to satisfy nml's requirement for 8bpp normal zoom sprites. (But preferably, graphics sets should just not have 8bpp if they want to not support 8bpp.)

Builds on top of #11580.

The implementation here uses a SpriteLoader shim that fits between the spritecache and SpriteLoaderGrf. This is done so that the conversion is almost self-contained.

While the automatic conversion to 8bpp is not super high quality, the results are fairly acceptable:

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/bddbb2bc-fdf8-49c3-9d19-9a6897e26fbc)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

~~The dummy sprite detection part is a proof of concept that happened to actually work quite well in most cases. Ideally it wouldn't need to exist.~~

Dummy sprite detection is now removed for this draft.

There's also the argument of "Why bother?" and just drop 8bpp blitter support instead.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
