### PR TITLE
Add: AI/GS Time Mode to choose between economy (default) and calendar time

### DIFF
--- a/src/script/api/CMakeLists.txt
+++ b/src/script/api/CMakeLists.txt
@@ -151,6 +151,7 @@ add_files(
     script_basestation.hpp
     script_bridge.hpp
     script_bridgelist.hpp
+    script_timemode.hpp
     script_cargo.hpp
     script_cargolist.hpp
     script_cargomonitor.hpp
@@ -225,6 +226,7 @@ add_files(
     script_basestation.cpp
     script_bridge.cpp
     script_bridgelist.cpp
+    script_timemode.cpp
     script_cargo.cpp
     script_cargolist.cpp
     script_cargomonitor.cpp

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -18,6 +18,7 @@
  * This version is not yet released. The following changes are not set in stone yet.
  *
  * API additions:
+ * \li AITimeMode
  * \li AITown::ROAD_LAYOUT_RANDOM
  * \li AIVehicle::IsPrimaryVehicle
  *

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -22,6 +22,7 @@
  * \li GSAsyncMode
  * \li GSCompanyMode::IsValid
  * \li GSCompanyMode::IsDeity
+ * \li GSTimeMode
  * \li GSTown::ROAD_LAYOUT_RANDOM
  * \li GSVehicle::IsPrimaryVehicle
  * \li GSOrder::SetOrderJumpTo

--- a/src/script/api/script_date.cpp
+++ b/src/script/api/script_date.cpp
@@ -9,7 +9,9 @@
 
 #include "../../stdafx.h"
 #include "script_date.hpp"
+#include "script_timemode.hpp"
 #include "../../timer/timer_game_calendar.h"
+#include "../../timer/timer_game_economy.h"
 
 #include <time.h>
 
@@ -22,14 +24,21 @@
 
 /* static */ ScriptDate::Date ScriptDate::GetCurrentDate()
 {
-	return (ScriptDate::Date)TimerGameCalendar::date.base();
+	if (ScriptTimeMode::IsCalendarMode()) return (ScriptDate::Date)TimerGameCalendar::date.base();
+
+	return (ScriptDate::Date)TimerGameEconomy::date.base();
 }
 
 /* static */ SQInteger ScriptDate::GetYear(ScriptDate::Date date)
 {
 	if (date < 0) return DATE_INVALID;
 
-	::TimerGameCalendar::YearMonthDay ymd = ::TimerGameCalendar::ConvertDateToYMD(date);
+	if (ScriptTimeMode::IsCalendarMode()) {
+		::TimerGameCalendar::YearMonthDay ymd = ::TimerGameCalendar::ConvertDateToYMD(date);
+		return ymd.year.base();
+	}
+
+	::TimerGameEconomy::YearMonthDay ymd = ::TimerGameEconomy::ConvertDateToYMD(date);
 	return ymd.year.base();
 }
 
@@ -37,7 +46,12 @@
 {
 	if (date < 0) return DATE_INVALID;
 
-	::TimerGameCalendar::YearMonthDay ymd = ::TimerGameCalendar::ConvertDateToYMD(date);
+	if (ScriptTimeMode::IsCalendarMode()) {
+		::TimerGameCalendar::YearMonthDay ymd = ::TimerGameCalendar::ConvertDateToYMD(date);
+		return ymd.month + 1;
+	}
+
+	::TimerGameEconomy::YearMonthDay ymd = ::TimerGameEconomy::ConvertDateToYMD(date);
 	return ymd.month + 1;
 }
 
@@ -45,7 +59,12 @@
 {
 	if (date < 0) return DATE_INVALID;
 
-	::TimerGameCalendar::YearMonthDay ymd = ::TimerGameCalendar::ConvertDateToYMD(date);
+	if (ScriptTimeMode::IsCalendarMode()) {
+		::TimerGameCalendar::YearMonthDay ymd = ::TimerGameCalendar::ConvertDateToYMD(date);
+		return ymd.day;
+	}
+
+	::TimerGameEconomy::YearMonthDay ymd = ::TimerGameEconomy::ConvertDateToYMD(date);
 	return ymd.day;
 }
 
@@ -55,7 +74,9 @@
 	if (day_of_month < 1 || day_of_month > 31) return DATE_INVALID;
 	if (year < 0 || year > CalendarTime::MAX_YEAR) return DATE_INVALID;
 
-	return (ScriptDate::Date)::TimerGameCalendar::ConvertYMDToDate(year, month - 1, day_of_month).base();
+	if (ScriptTimeMode::IsCalendarMode()) return (ScriptDate::Date)::TimerGameCalendar::ConvertYMDToDate(year, month - 1, day_of_month).base();
+
+	return (ScriptDate::Date)::TimerGameEconomy::ConvertYMDToDate(year, month - 1, day_of_month).base();
 }
 
 /* static */ SQInteger ScriptDate::GetSystemTime()

--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -200,6 +200,16 @@ ScriptObject::ActiveInstance::~ActiveInstance()
 	return GetStorage()->allow_do_command;
 }
 
+/* static */ void ScriptObject::SetTimeMode(bool calendar)
+{
+	GetStorage()->time_mode = calendar;
+}
+
+/* static */ bool ScriptObject::IsCalendarTimeMode()
+{
+	return GetStorage()->time_mode;
+}
+
 /* static */ void ScriptObject::SetCompany(CompanyID company)
 {
 	if (GetStorage()->root_company == INVALID_OWNER) GetStorage()->root_company = company;

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -245,6 +245,20 @@ protected:
 	static bool GetAllowDoCommand();
 
 	/**
+	 * Set if the script is running in calendar time or economy time mode.
+	 * Calendar time is used by OpenTTD for technology like vehicle introductions and expiration, and variable snowline. It can be sped up or slowed down by the player.
+	 * Economy time always runs at the same pace and handles things like cargo production, everything related to money, etc.
+	 * @param Calendar Should we use calendar time mode? (Set to false for economy time mode.)
+	 */
+	static void SetTimeMode(bool calendar);
+
+	/**
+	 * Check if the script is operating in calendar time mode, or in economy time mode. See SetTimeMode() for more information.
+	 * @return True if we are in calendar time mode, false if we are in economy time mode.
+	 */
+	static bool IsCalendarTimeMode();
+
+	/**
 	 * Set the current company to execute commands for or request
 	 *  information about.
 	 * @param company The new company.

--- a/src/script/api/script_timemode.cpp
+++ b/src/script/api/script_timemode.cpp
@@ -1,0 +1,29 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file script_timemode.cpp Implementation of ScriptTimeMode. */
+
+#include "../../stdafx.h"
+#include "script_timemode.hpp"
+
+#include "../../safeguards.h"
+
+ScriptTimeMode::ScriptTimeMode(bool calendar)
+{
+	this->last_time_mode = ScriptObject::IsCalendarTimeMode();
+	ScriptObject::SetTimeMode(calendar);
+}
+
+ScriptTimeMode::~ScriptTimeMode()
+{
+	ScriptObject::SetTimeMode(this->last_time_mode);
+}
+
+/* static */ bool ScriptTimeMode::IsCalendarMode()
+{
+	return ScriptObject::IsCalendarTimeMode();
+}

--- a/src/script/api/script_timemode.hpp
+++ b/src/script/api/script_timemode.hpp
@@ -1,0 +1,45 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file script_timemode.hpp Switch the time mode. */
+
+#ifndef SCRIPT_TIMEMODE_HPP
+#define SCRIPT_TIMEMODE_HPP
+
+#include "script_object.hpp"
+
+/**
+ * Class to switch the current time.
+ * If you create an instance of this class, the mode will be switched to either calendar time or economy time mode.
+ * @note Destroying this object will restore the previous time mode.
+ * @api ai game
+ */
+class ScriptTimeMode : public ScriptObject {
+private:
+	bool last_time_mode; ///< The last time mode we were using.
+public:
+	/**
+	 * Creating an instance of this class switches the time mode used for queries and commands.
+	 * Calendar time is used by OpenTTD for technology like vehicle introductions and expiration, and variable snowline. It can be sped up or slowed down by the player.
+	 * Economy time always runs at the same pace and handles things like cargo production, everything related to money, etc.
+	 * @param Calendar Should we use calendar time mode? (Set to false for economy time mode.)
+	 */
+	ScriptTimeMode(bool calendar);
+
+	/**
+	 * Destroying this instance resets the time mode to the mode it was in when the instance was created.
+	 */
+	~ScriptTimeMode();
+
+	/**
+	 * Check if the script is operating in calendar time mode, or in economy time mode. See ScriptTimeMode() for more information.
+	 * @return True if we are in calendar time mode, false if we are in economy time mode.
+	 */
+	static bool IsCalendarMode();
+};
+
+#endif /* SCRIPT_TIMEMODE_HPP */

--- a/src/script/script_storage.hpp
+++ b/src/script/script_storage.hpp
@@ -41,6 +41,7 @@ private:
 	class ScriptObject *mode_instance; ///< The instance belonging to the current build mode.
 	ScriptAsyncModeProc *async_mode;         ///< The current command async mode we are in.
 	class ScriptObject *async_mode_instance; ///< The instance belonging to the current command async mode.
+	bool time_mode;                          ///< True if we in calendar time mode, or false (default) if we are in economy time mode.
 	CompanyID root_company;          ///< The root company, the company that the script really belongs to.
 	CompanyID company;               ///< The current company.
 
@@ -70,6 +71,7 @@ public:
 		mode_instance     (nullptr),
 		async_mode        (nullptr),
 		async_mode_instance (nullptr),
+		time_mode         (false),
 		root_company      (INVALID_OWNER),
 		company           (INVALID_OWNER),
 		delay             (1),


### PR DESCRIPTION
## Motivation / Problem

#10700 splits off economy and calendar time. #11341 makes these time units not follow each other, and #11428 allows them to tick at different rates.

It's time we break the news to Game Scripts and AI.

## Description

The PR adds a Time Mode for scripts (both AI and GS) to operate in, which modifies what ScriptDate returns. This includes calls from other script methods (like ScriptSubsidy) to ScriptDate.

The default time mode is economy time. Existing scripts need a default, and the most crucial information for GS and AI is knowing how time in the game is progressing to grow towns, build new train lines, give the player new goals, etc. Since calendar time can be frozen in #11428, that's unsuitable as a way of scripts to keep track of time. More about this in Limitations.

(I previously opened #11588 and ran into issues with compat files, so @rubidium42 and @glx22 suggested this route instead.)

## Limitations

- If a script looks for a specific calendar date rather than using dates only to measure the passing of time (I can't think of any examples, but a hypothetical example would be building industries based on real-world economic history) will behave strangely. They won't crash, but when OpenTTD is using real-time units, economy starts in year 1 and the script will react accordingly. I am not aware of any ways to split time without the potential of breaking scripts in this way. 😢 
- I don't have a GS to test calendar mode, so it is not tested. I welcome help with this.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
