### PR TITLE
Fix #11528: Don't auto-build past tunnelbridge ends

### DIFF
--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1005,49 +1005,55 @@ CommandCost CmdBuildLongRoad(DoCommandFlag flags, TileIndex end_tile, TileIndex 
 	bool had_bridge = false;
 	bool had_tunnel = false;
 	bool had_success = false;
+	bool under_tunnelbridge = false;
 
 	/* Start tile is the first tile clicked by the user. */
 	for (;;) {
-		RoadBits bits = AxisToRoadBits(axis);
+		/* Don't try to place road between tunnelbridge ends */
+		if (IsTileType(tile, MP_TUNNELBRIDGE)) {
+			under_tunnelbridge = !under_tunnelbridge;
+		} else if (!under_tunnelbridge) {
+			RoadBits bits = AxisToRoadBits(axis);
 
-		/* Determine which road parts should be built. */
-		if (!is_ai && start_tile != end_tile) {
-			/* Only build the first and last roadbit if they can connect to something. */
-			if (tile == end_tile && !CanConnectToRoad(tile, rt, dir)) {
-				bits = DiagDirToRoadBits(ReverseDiagDir(dir));
-			} else if (tile == start_tile && !CanConnectToRoad(tile, rt, ReverseDiagDir(dir))) {
-				bits = DiagDirToRoadBits(dir);
-			}
-		} else {
-			/* Road parts only have to be built at the start tile or at the end tile. */
-			if (tile == end_tile && !end_half) bits &= DiagDirToRoadBits(ReverseDiagDir(dir));
-			if (tile == start_tile && start_half) bits &= DiagDirToRoadBits(dir);
-		}
-
-		CommandCost ret = Command<CMD_BUILD_ROAD>::Do(flags, tile, bits, rt, drd, 0);
-		if (ret.Failed()) {
-			last_error = ret;
-			if (last_error.GetErrorMessage() != STR_ERROR_ALREADY_BUILT) {
-				if (is_ai) return last_error;
-				if (had_success) break; // Keep going if we haven't constructed any road yet, skipping the start of the drag
-			}
-		} else {
-			had_success = true;
-			/* Only pay for the upgrade on one side of the bridges and tunnels */
-			if (IsTileType(tile, MP_TUNNELBRIDGE)) {
-				if (IsBridge(tile)) {
-					if (!had_bridge || GetTunnelBridgeDirection(tile) == dir) {
-						cost.AddCost(ret);
-					}
-					had_bridge = true;
-				} else { // IsTunnel(tile)
-					if (!had_tunnel || GetTunnelBridgeDirection(tile) == dir) {
-						cost.AddCost(ret);
-					}
-					had_tunnel = true;
+			/* Determine which road parts should be built. */
+			if (!is_ai && start_tile != end_tile) {
+				/* Only build the first and last roadbit if they can connect to something. */
+				if (tile == end_tile && !CanConnectToRoad(tile, rt, dir)) {
+					bits = DiagDirToRoadBits(ReverseDiagDir(dir));
+				} else if (tile == start_tile && !CanConnectToRoad(tile, rt, ReverseDiagDir(dir))) {
+					bits = DiagDirToRoadBits(dir);
 				}
 			} else {
-				cost.AddCost(ret);
+				/* Road parts only have to be built at the start tile or at the end tile. */
+				if (tile == end_tile && !end_half) bits &= DiagDirToRoadBits(ReverseDiagDir(dir));
+				if (tile == start_tile && start_half) bits &= DiagDirToRoadBits(dir);
+			}
+
+			CommandCost ret = Command<CMD_BUILD_ROAD>::Do(flags, tile, bits, rt, drd, 0);
+			if (ret.Failed()) {
+				last_error = ret;
+				if (last_error.GetErrorMessage() != STR_ERROR_ALREADY_BUILT) {
+					if (is_ai) return last_error;
+					if (had_success) break; // Keep going if we haven't constructed any road yet, skipping the start of the drag
+				}
+			} else {
+				had_success = true;
+				/* Only pay for the upgrade on one side of the bridges and tunnels */
+				if (IsTileType(tile, MP_TUNNELBRIDGE)) {
+					if (IsBridge(tile)) {
+						if (!had_bridge || GetTunnelBridgeDirection(tile) == dir) {
+							cost.AddCost(ret);
+						}
+						had_bridge = true;
+					} else { // IsTunnel(tile)
+						if (!had_tunnel || GetTunnelBridgeDirection(tile) == dir) {
+							cost.AddCost(ret);
+						}
+						had_tunnel = true;
+					}
+				} else {
+					cost.AddCost(ret);
+				}
 			}
 		}
 


### PR DESCRIPTION
## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

#11528 - autodragging over existing rail/road would start under a bridge, which is not expected behaviour

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

Keep track of whether we're under a tunnel or bridge when dragging and toggle as appropriate.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

Feels very "just increase complexity" and there's probably additional edge cases that aren't covered, or are created, by this change.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
