### PR TITLE
Doc: Fix broken links in COMPILING and CONTRIBUTING guides

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -38,7 +38,7 @@ OpenTTD needs the Platform SDK, if it isn't installed already. This can be
 done during installing Visual Studio, by selecting
 `Visual C++ MFC for x86 and x64` (and possibly
 `Visual C++ ATL for x86 and x64` depending on your version). If not, you
-can get download it as [MS Windows Platform SDK](https://developer.microsoft.com/en-US/windows/downloads/windows-10-sdk).
+can get download it as [MS Windows Platform SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk).
 
 Install the SDK by following the instructions as given.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ Every pull request should have a clear scope, with no unrelated commits.
 
 Adhering to the following process is the best way to get your work included in the project:
 
-1. [Fork](https://help.github.com/fork-a-repo/) the project, clone your fork, and configure the remotes:
+1. [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) the project, clone your fork, and configure the remotes:
 
 ```bash
 git clone https://github.com/<your-username>/OpenTTD.git openttd
@@ -266,7 +266,7 @@ This is inevitable, because it is a main feature of git.
 If you are concerned about your privacy, we strongly recommend to use "Anonymous &lt;anonymous@openttd.org&gt;" as the git commit author. We might refuse anonymous contributions if malicious intent is suspected.
 
 Please note that the contributor identity, once given, is used for copyright verification and to provide proof should a malicious commit be made.
-As such, the [EU GDPR](https://www.eugdpr.org/key-changes.html) "right to be forgotten" does not apply, as this is an overriding legitimate interest.
+As such, the [EU GDPR](https://gdpr.eu) "right to be forgotten" does not apply, as this is an overriding legitimate interest.
 
 Please also note that your commit is public and as such will potentially be processed by many third-parties.
 Git's distributed nature makes it impossible to track where exactly your commit, and thus your personal data, will be stored and be processed.


### PR DESCRIPTION
## Motivation / Problem

I found a broken link.

## Description

I checked the rest of the markdown docs in the root OpenTTD folder and fixed all the broken links I found.

## Limitations

I'm not sure what exactly the EU GDPR link used to point to, but I imagine the main page is a good enough replacement.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
