### PR TITLE
Fix: Update widget dimensions before updating viewport signs.

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1993,6 +1993,7 @@ bool AdjustGUIZoom(bool automatic)
 	ClearFontCache();
 	LoadStringWidthTable();
 
+	SetupWidgetDimensions();
 	UpdateAllVirtCoords();
 
 	/* Adjust all window sizes to match the new zoom level, so that they don't appear


### PR DESCRIPTION
## Motivation / Problem

When changing interface scale, viewport signs were refreshed and used bevel WidgetDimensions before it was updated for the new interface scale.

This can result in truncated viewport signs, e.g. town names, station signs, etc.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/dd452926-4b4c-410e-92fe-7887042972ac)


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This is resolved by explicitly calling `SetupWidgetDimensions()` in `AdjustGUIZoom()` before `UpdateAllVirtCoords()`. Whilst this does mean that widget dimensions are updated multiple times, due to the different code paths it's difficult to eradicate that, and it's not exactly expensive.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/f5cf2278-45f1-43ec-be1a-7c0b4261ccb9)


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
