### PR TITLE
Change: remove sorting weights when generating a company colour

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -406,8 +406,6 @@ bad_town_name:;
 	}
 }
 
-/** Sorting weights for the company colours. */
-static const byte _colour_sort[COLOUR_END] = {2, 2, 3, 2, 3, 2, 3, 2, 3, 2, 2, 2, 3, 1, 1, 1};
 /** Similar colours, so we can try to prevent same coloured companies. */
 static const Colours _similar_colour[COLOUR_END][2] = {
 	{ COLOUR_BLUE,       COLOUR_LIGHT_BLUE }, // COLOUR_DARK_BLUE
@@ -443,15 +441,6 @@ static Colours GenerateCompanyColour()
 	for (uint i = 0; i < 100; i++) {
 		uint r = Random();
 		Swap(colours[GB(r, 0, 4)], colours[GB(r, 4, 4)]);
-	}
-
-	/* Bubble sort it according to the values in table 1 */
-	for (uint i = 0; i < COLOUR_END; i++) {
-		for (uint j = 1; j < COLOUR_END; j++) {
-			if (_colour_sort[colours[j - 1]] < _colour_sort[colours[j]]) {
-				Swap(colours[j - 1], colours[j]);
-			}
-		}
 	}
 
 	/* Move the colours that look similar to each company's colour to the side */


### PR DESCRIPTION
## Motivation / Problem

When starting a new company, a company colour is selected at random. However, it isn't really random because the game prioritises certain colours over others. The result is that the first five companies that are founded will always end up with the same five colours (assuming they're not changed manually). 

![image](https://github.com/OpenTTD/OpenTTD/assets/68182631/23d7fdff-7ba9-49c2-953d-af62f83e20d6)


This is because the game splits company colour options into 3 priorities and sorts them accordingly when generating a new company colour, and only selects lower priority colours once all the higher priority ones have been used up. The result is that when all the company slots are filled, the colours always end up in a similar order, with red, green, pink, orange, and blue at the top and brown, grey, and white near the middle or bottom.

This is an arbitrary choice which seems to be inherited from TTD. Company colour is a personal preference, and since https://github.com/OpenTTD/OpenTTD/pull/6998 players can select their preferred colours in the settings, giving certain colours priority becomes even less relevant.


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This PR removes a few lines of code which prioritises some colours over others when generating a company colour. It does not affect the code which prevents similar company colours from appearing next to each other, in fact that code ostensibly becomes more useful. 

This means that when starting a new game, a company colour is selected at random from all 16 colour options instead of just five. All subsequent companies will also receive a random colour, but the game will still prevent similar colours from appearing next to each other.

![image](https://github.com/OpenTTD/OpenTTD/assets/68182631/b0228d45-6007-4356-8780-dad100408bcb)


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Some players might prefer starting with a bright colour but don't care for a specific one, they might be annoyed that they could be given brown or grey instead.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
