### PR TITLE
Fix #11442: "default" colour in group colour window is not updated when changing master colour

### DIFF
--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -924,9 +924,10 @@ public:
 			y += this->line_height;
 		};
 
+		const Company *c = Company::Get((CompanyID)this->window_number);
+
 		if (livery_class < LC_GROUP_RAIL) {
 			int pos = this->vscroll->GetPosition();
-			const Company *c = Company::Get((CompanyID)this->window_number);
 			for (LiveryScheme scheme = LS_DEFAULT; scheme < LS_END; scheme++) {
 				if (_livery_class[scheme] == this->livery_class && HasBit(_loaded_newgrf_features.used_liveries, scheme)) {
 					if (pos-- > 0) continue;
@@ -937,8 +938,9 @@ public:
 			uint max = static_cast<uint>(std::min<size_t>(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), this->groups.size()));
 			for (uint i = this->vscroll->GetPosition(); i < max; ++i) {
 				const Group *g = this->groups[i];
+				const bool livery_set = HasBit(g->livery.in_use, 0);
 				SetDParam(0, g->index);
-				draw_livery(STR_GROUP_NAME, g->livery, this->sel == g->index, false, this->indents[i] * WidgetDimensions::scaled.hsep_indent);
+				draw_livery(STR_GROUP_NAME, livery_set ? g->livery : c->livery[LS_DEFAULT], this->sel == g->index, livery_set, this->indents[i] * WidgetDimensions::scaled.hsep_indent);
 			}
 		}
 	}


### PR DESCRIPTION
## Motivation / Problem

As described in issue #11442. When setting the default company livery colour, previously created groups that use the default company livery will still display the default colour as being the one automatically set at the start of the game.

This is purely an interface issue which can prove distracting and/or confusing to the user due to the visible inconsistency it creates.

## Description

Under company_gui.cpp the DrawWidget method of SelectCompanyLiveryWIndow is responsible for rendering the default colour square preview in the groups window. 

The company default livery can be conditionally passed, to draw_livery, instead of the group livery. This is done with a constant boolean, livery_set, from HasBit on the group’s livery.in_use 0 bit. livery_set is also passed to the def parameter.

Furthermore, both branches of the if else statement of DrawWidget use the company constant, it was moved to be before the if statement so that both conditionals had it within their scope.

## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
