### PR TITLE
Change: Support custom transparent palette remaps.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -325,6 +325,8 @@ add_files(
     order_gui.cpp
     order_type.h
     osk_gui.cpp
+    palette.cpp
+    palette_func.h
     pbs.cpp
     pbs.h
     progress.cpp

--- a/src/blitter/32bpp_anim_sse4.cpp
+++ b/src/blitter/32bpp_anim_sse4.cpp
@@ -7,6 +7,7 @@
 
 /** @file 32bpp_anim_sse4.cpp Implementation of the SSE4 32 bpp blitter with animation support. */
 
+#include "palette_func.h"
 #ifdef WITH_SSE
 
 #include "../stdafx.h"
@@ -317,6 +318,21 @@ bmcr_alpha_blend_single:
 				}
 				break;
 
+			case BM_TRANSPARENT_REMAP:
+				/* Apply custom transparency remap. */
+				for (uint x = (uint) bp->width; x > 0; x--) {
+					if (src->a != 0) {
+						*dst = this->LookupColourInPalette(bp->remap[GetNearestColourIndex(*dst)]);
+						*anim = 0;
+					}
+					src_mv++;
+					dst++;
+					src++;
+					anim++;
+				}
+				break;
+
+
 			case BM_CRASH_REMAP:
 				for (uint x = (uint) bp->width; x > 0; x--) {
 					if (src_mv->m == 0) {
@@ -351,7 +367,7 @@ bmcr_alpha_blend_single:
 		}
 
 next_line:
-		if (mode != BM_TRANSPARENT) src_mv_line += si->sprite_width;
+		if (mode != BM_TRANSPARENT && mode != BM_TRANSPARENT_REMAP) src_mv_line += si->sprite_width;
 		src_rgba_line = (const Colour*) ((const byte*) src_rgba_line + si->sprite_line_size);
 		dst_line += bp->pitch;
 		anim_line += this->anim_buf_pitch;
@@ -414,6 +430,7 @@ bm_normal:
 			}
 			break;
 		case BM_TRANSPARENT:  Draw<BM_TRANSPARENT, RM_NONE, BT_NONE, true, true>(bp, zoom); return;
+		case BM_TRANSPARENT_REMAP: Draw<BM_TRANSPARENT_REMAP, RM_NONE, BT_NONE, true, true>(bp, zoom); return;
 		case BM_CRASH_REMAP:  Draw<BM_CRASH_REMAP, RM_NONE, BT_NONE, true, true>(bp, zoom); return;
 		case BM_BLACK_REMAP:  Draw<BM_BLACK_REMAP, RM_NONE, BT_NONE, true, true>(bp, zoom); return;
 	}

--- a/src/blitter/32bpp_optimized.cpp
+++ b/src/blitter/32bpp_optimized.cpp
@@ -10,6 +10,7 @@
 #include "../stdafx.h"
 #include "../zoom_func.h"
 #include "../settings_type.h"
+#include "../palette_func.h"
 #include "32bpp_optimized.hpp"
 
 #include "../safeguards.h"
@@ -185,10 +186,6 @@ inline void Blitter_32bppOptimized::Draw(const Blitter::BlitterParams *bp, ZoomL
 					break;
 
 				case BM_TRANSPARENT:
-					/* TODO -- We make an assumption here that the remap in fact is transparency, not some colour.
-					 *  This is never a problem with the code we produce, but newgrfs can make it fail... or at least:
-					 *  we produce a result the newgrf maker didn't expect ;) */
-
 					/* Make the current colour a bit more black, so it looks like this image is transparent */
 					src_n += n;
 					if (src_px->a == 255) {
@@ -203,6 +200,21 @@ inline void Blitter_32bppOptimized::Draw(const Blitter::BlitterParams *bp, ZoomL
 							dst++;
 							src_px++;
 						} while (--n != 0);
+					}
+					break;
+
+				case BM_TRANSPARENT_REMAP:
+					/* Apply custom transparency remap. */
+					src_n += n;
+					if (src_px->a != 0) {
+						src_px += n;
+						do {
+							*dst = this->LookupColourInPalette(bp->remap[GetNearestColourIndex(*dst)]);
+							dst++;
+						} while (--n != 0);
+					} else {
+						dst += n;
+						src_px += n;
 					}
 					break;
 
@@ -252,6 +264,7 @@ void Blitter_32bppOptimized::Draw(Blitter::BlitterParams *bp, BlitterMode mode, 
 		case BM_NORMAL:       Draw<BM_NORMAL, Tpal_to_rgb>(bp, zoom); return;
 		case BM_COLOUR_REMAP: Draw<BM_COLOUR_REMAP, Tpal_to_rgb>(bp, zoom); return;
 		case BM_TRANSPARENT:  Draw<BM_TRANSPARENT, Tpal_to_rgb>(bp, zoom); return;
+		case BM_TRANSPARENT_REMAP: Draw<BM_TRANSPARENT_REMAP, Tpal_to_rgb>(bp, zoom); return;
 		case BM_CRASH_REMAP:  Draw<BM_CRASH_REMAP, Tpal_to_rgb>(bp, zoom); return;
 		case BM_BLACK_REMAP:  Draw<BM_BLACK_REMAP, Tpal_to_rgb>(bp, zoom); return;
 	}

--- a/src/blitter/32bpp_simple.cpp
+++ b/src/blitter/32bpp_simple.cpp
@@ -9,6 +9,7 @@
 
 #include "../stdafx.h"
 #include "../zoom_func.h"
+#include "../palette_func.h"
 #include "32bpp_simple.hpp"
 
 #include "../table/sprites.h"
@@ -63,12 +64,17 @@ void Blitter_32bppSimple::Draw(Blitter::BlitterParams *bp, BlitterMode mode, Zoo
 					break;
 
 				case BM_TRANSPARENT:
-					/* TODO -- We make an assumption here that the remap in fact is transparency, not some colour.
-					 *  This is never a problem with the code we produce, but newgrfs can make it fail... or at least:
-					 *  we produce a result the newgrf maker didn't expect ;) */
-
 					/* Make the current colour a bit more black, so it looks like this image is transparent */
-					if (src->a != 0) *dst = MakeTransparent(*dst, 192);
+					if (src->a != 0) {
+						*dst = MakeTransparent(*dst, 192);
+					}
+					break;
+
+				case BM_TRANSPARENT_REMAP:
+					/* Apply custom transparency remap. */
+					if (src->a != 0) {
+						*dst = this->LookupColourInPalette(bp->remap[GetNearestColourIndex(*dst)]);
+					}
 					break;
 
 				default:

--- a/src/blitter/32bpp_sse_func.hpp
+++ b/src/blitter/32bpp_sse_func.hpp
@@ -392,6 +392,18 @@ bmcr_alpha_blend_single:
 				}
 				break;
 
+			case BM_TRANSPARENT_REMAP:
+				/* Apply custom transparency remap. */
+				for (uint x = (uint) bp->width; x > 0; x--) {
+					if (src->a != 0) {
+						*dst = this->LookupColourInPalette(bp->remap[GetNearestColourIndex(*dst)]);
+					}
+					src_mv++;
+					dst++;
+					src++;
+				}
+				break;
+
 			case BM_CRASH_REMAP:
 				for (uint x = (uint) bp->width; x > 0; x--) {
 					if (src_mv->m == 0) {
@@ -471,6 +483,7 @@ bm_normal:
 				Draw<BM_COLOUR_REMAP, RM_WITH_MARGIN, BT_NONE, true>(bp, zoom); return;
 			}
 		case BM_TRANSPARENT:  Draw<BM_TRANSPARENT, RM_NONE, BT_NONE, true>(bp, zoom); return;
+		case BM_TRANSPARENT_REMAP: Draw<BM_TRANSPARENT_REMAP, RM_NONE, BT_NONE, true>(bp, zoom); return;
 		case BM_CRASH_REMAP:  Draw<BM_CRASH_REMAP, RM_NONE, BT_NONE, true>(bp, zoom); return;
 		case BM_BLACK_REMAP:  Draw<BM_BLACK_REMAP, RM_NONE, BT_NONE, true>(bp, zoom); return;
 	}

--- a/src/blitter/40bpp_anim.cpp
+++ b/src/blitter/40bpp_anim.cpp
@@ -11,6 +11,7 @@
 #include "../zoom_func.h"
 #include "../settings_type.h"
 #include "../video/video_driver.hpp"
+#include "../palette_func.h"
 #include "40bpp_anim.hpp"
 #include "common.hpp"
 
@@ -234,10 +235,6 @@ inline void Blitter_40bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 					break;
 
 				case BM_TRANSPARENT:
-					/* TODO -- We make an assumption here that the remap in fact is transparency, not some colour.
-					 *  This is never a problem with the code we produce, but newgrfs can make it fail... or at least:
-					 *  we produce a result the newgrf maker didn't expect ;) */
-
 					/* Make the current colour a bit more black, so it looks like this image is transparent */
 					src_n += n;
 					if (src_px->a == 255) {
@@ -260,6 +257,28 @@ inline void Blitter_40bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 							dst++;
 							src_px++;
 						} while (--n != 0);
+					}
+					break;
+
+				case BM_TRANSPARENT_REMAP:
+					/* Apply custom transparency remap. */
+					src_n += n;
+					if (src_px->a != 0) {
+						src_px += n;
+						do {
+							if (*anim != 0) {
+								*anim = bp->remap[*anim];
+							} else {
+								*dst = this->LookupColourInPalette(bp->remap[GetNearestColourIndex(*dst)]);
+								*anim = 0;
+							}
+							anim++;
+							dst++;
+						} while (--n != 0);
+					} else {
+						dst += n;
+						anim += n;
+						src_px += n;
 					}
 					break;
 
@@ -323,6 +342,7 @@ void Blitter_40bppAnim::Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomL
 		case BM_NORMAL:       Draw<BM_NORMAL>      (bp, zoom); return;
 		case BM_COLOUR_REMAP: Draw<BM_COLOUR_REMAP>(bp, zoom); return;
 		case BM_TRANSPARENT:  Draw<BM_TRANSPARENT> (bp, zoom); return;
+		case BM_TRANSPARENT_REMAP: Draw<BM_TRANSPARENT_REMAP>(bp, zoom); return;
 		case BM_CRASH_REMAP:  Draw<BM_CRASH_REMAP> (bp, zoom); return;
 		case BM_BLACK_REMAP:  Draw<BM_BLACK_REMAP> (bp, zoom); return;
 	}

--- a/src/blitter/8bpp_optimized.cpp
+++ b/src/blitter/8bpp_optimized.cpp
@@ -100,7 +100,8 @@ void Blitter_8bppOptimized::Draw(Blitter::BlitterParams *bp, BlitterMode mode, Z
 					dst += pixels;
 					break;
 
-				case BM_TRANSPARENT: {
+				case BM_TRANSPARENT:
+				case BM_TRANSPARENT_REMAP: {
 					const uint8_t *remap = bp->remap;
 					src += pixels;
 					do {

--- a/src/blitter/8bpp_simple.cpp
+++ b/src/blitter/8bpp_simple.cpp
@@ -42,6 +42,7 @@ void Blitter_8bppSimple::Draw(Blitter::BlitterParams *bp, BlitterMode mode, Zoom
 					break;
 
 				case BM_TRANSPARENT:
+				case BM_TRANSPARENT_REMAP:
 					if (*src != 0) colour = bp->remap[*dst];
 					break;
 

--- a/src/blitter/base.hpp
+++ b/src/blitter/base.hpp
@@ -17,7 +17,8 @@
 enum BlitterMode {
 	BM_NORMAL,       ///< Perform the simple blitting.
 	BM_COLOUR_REMAP, ///< Perform a colour remapping.
-	BM_TRANSPARENT,  ///< Perform transparency colour remapping.
+	BM_TRANSPARENT,  ///< Perform transparency darkening remapping.
+	BM_TRANSPARENT_REMAP, ///< Perform transparency colour remapping.
 	BM_CRASH_REMAP,  ///< Perform a crash remapping.
 	BM_BLACK_REMAP,  ///< Perform remapping to a completely blackened sprite
 };

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1368,12 +1368,10 @@ void DoPaletteAnimations()
 
 	if (blitter != nullptr && blitter->UsePaletteAnimation() == Blitter::PALETTE_ANIMATION_NONE) {
 		palette_animation_counter = old_tc;
-	} else {
-		if (memcmp(old_val, &_cur_palette.palette[PALETTE_ANIM_START], sizeof(old_val)) != 0 && _cur_palette.count_dirty == 0) {
-			/* Did we changed anything on the palette? Seems so.  Mark it as dirty */
-			_cur_palette.first_dirty = PALETTE_ANIM_START;
-			_cur_palette.count_dirty = PALETTE_ANIM_SIZE;
-		}
+	} else if (_cur_palette.count_dirty == 0 && memcmp(old_val, &_cur_palette.palette[PALETTE_ANIM_START], sizeof(old_val)) != 0) {
+		/* Did we changed anything on the palette? Seems so.  Mark it as dirty */
+		_cur_palette.first_dirty = PALETTE_ANIM_START;
+		_cur_palette.count_dirty = PALETTE_ANIM_SIZE;
 	}
 }
 

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -978,8 +978,9 @@ void DrawSpriteViewport(SpriteID img, PaletteID pal, int x, int y, const SubSpri
 {
 	SpriteID real_sprite = GB(img, 0, SPRITE_WIDTH);
 	if (HasBit(img, PALETTE_MODIFIER_TRANSPARENT)) {
-		_colour_remap_ptr = GetNonSprite(GB(pal, 0, PALETTE_WIDTH), SpriteType::Recolour) + 1;
-		GfxMainBlitterViewport(GetSprite(real_sprite, SpriteType::Normal), x, y, BM_TRANSPARENT, sub, real_sprite);
+		pal = GB(pal, 0, PALETTE_WIDTH);
+		_colour_remap_ptr = GetNonSprite(pal, SpriteType::Recolour) + 1;
+		GfxMainBlitterViewport(GetSprite(real_sprite, SpriteType::Normal), x, y, pal == PALETTE_TO_TRANSPARENT ? BM_TRANSPARENT : BM_TRANSPARENT_REMAP, sub, real_sprite);
 	} else if (pal != PAL_NONE) {
 		if (HasBit(pal, PALETTE_TEXT_RECOLOUR)) {
 			SetColourRemap((TextColour)GB(pal, 0, PALETTE_WIDTH));
@@ -1005,8 +1006,9 @@ void DrawSprite(SpriteID img, PaletteID pal, int x, int y, const SubSprite *sub,
 {
 	SpriteID real_sprite = GB(img, 0, SPRITE_WIDTH);
 	if (HasBit(img, PALETTE_MODIFIER_TRANSPARENT)) {
-		_colour_remap_ptr = GetNonSprite(GB(pal, 0, PALETTE_WIDTH), SpriteType::Recolour) + 1;
-		GfxMainBlitter(GetSprite(real_sprite, SpriteType::Normal), x, y, BM_TRANSPARENT, sub, real_sprite, zoom);
+		pal = GB(pal, 0, PALETTE_WIDTH);
+		_colour_remap_ptr = GetNonSprite(pal, SpriteType::Recolour) + 1;
+		GfxMainBlitter(GetSprite(real_sprite, SpriteType::Normal), x, y, pal == PALETTE_TO_TRANSPARENT ? BM_TRANSPARENT : BM_TRANSPARENT_REMAP, sub, real_sprite, zoom);
 	} else if (pal != PAL_NONE) {
 		if (HasBit(pal, PALETTE_TEXT_RECOLOUR)) {
 			SetColourRemap((TextColour)GB(pal, 0, PALETTE_WIDTH));

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -20,12 +20,10 @@
 #include "window_gui.h"
 #include "window_func.h"
 #include "newgrf_debug.h"
-#include "thread.h"
 #include "core/backup_type.hpp"
 #include "core/container_func.hpp"
 #include "viewport_func.h"
 
-#include "table/palettes.h"
 #include "table/string_colours.h"
 #include "table/sprites.h"
 #include "table/control_codes.h"
@@ -50,13 +48,9 @@ GameMode _game_mode;
 SwitchMode _switch_mode;  ///< The next mainloop command.
 std::chrono::steady_clock::time_point _switch_mode_time; ///< The time when the switch mode was requested.
 PauseMode _pause_mode;
-Palette _cur_palette;
 
 static byte _stringwidth_table[FS_END][224]; ///< Cache containing width of often used characters. @see GetCharacterWidth()
 DrawPixelInfo *_cur_dpi;
-byte _colour_gradient[COLOUR_END][8];
-
-static std::recursive_mutex _palette_mutex; ///< To coordinate access to _cur_palette.
 
 static void GfxMainBlitterViewport(const Sprite *sprite, int x, int y, BlitterMode mode, const SubSprite *sub = nullptr, SpriteID sprite_id = SPR_CURSOR_MOUSE);
 static void GfxMainBlitter(const Sprite *sprite, int x, int y, BlitterMode mode, const SubSprite *sub = nullptr, SpriteID sprite_id = SPR_CURSOR_MOUSE, ZoomLevel zoom = ZOOM_LVL_NORMAL);
@@ -1226,169 +1220,6 @@ static void GfxMainBlitterViewport(const Sprite *sprite, int x, int y, BlitterMo
 static void GfxMainBlitter(const Sprite *sprite, int x, int y, BlitterMode mode, const SubSprite *sub, SpriteID sprite_id, ZoomLevel zoom)
 {
 	GfxBlitter<1, true>(sprite, x, y, mode, sub, sprite_id, zoom);
-}
-
-void DoPaletteAnimations();
-
-void GfxInitPalettes()
-{
-	std::lock_guard<std::recursive_mutex> lock(_palette_mutex);
-	memcpy(&_cur_palette, &_palette, sizeof(_cur_palette));
-	DoPaletteAnimations();
-}
-
-/**
- * Copy the current palette if the palette was updated.
- * Used by video-driver to get a current up-to-date version of the palette,
- * to avoid two threads accessing the same piece of memory (with a good chance
- * one is already updating the palette while the other is drawing based on it).
- * @param local_palette The location to copy the palette to.
- * @param force_copy Whether to ignore if there is an update for the palette.
- * @return True iff a copy was done.
- */
-bool CopyPalette(Palette &local_palette, bool force_copy)
-{
-	std::lock_guard<std::recursive_mutex> lock(_palette_mutex);
-
-	if (!force_copy && _cur_palette.count_dirty == 0) return false;
-
-	local_palette = _cur_palette;
-	_cur_palette.count_dirty = 0;
-
-	if (force_copy) {
-		local_palette.first_dirty = 0;
-		local_palette.count_dirty = 256;
-	}
-
-	return true;
-}
-
-#define EXTR(p, q) (((uint16_t)(palette_animation_counter * (p)) * (q)) >> 16)
-#define EXTR2(p, q) (((uint16_t)(~palette_animation_counter * (p)) * (q)) >> 16)
-
-void DoPaletteAnimations()
-{
-	std::lock_guard<std::recursive_mutex> lock(_palette_mutex);
-
-	/* Animation counter for the palette animation. */
-	static int palette_animation_counter = 0;
-	palette_animation_counter += 8;
-
-	Blitter *blitter = BlitterFactory::GetCurrentBlitter();
-	const Colour *s;
-	const ExtraPaletteValues *ev = &_extra_palette_values;
-	Colour old_val[PALETTE_ANIM_SIZE];
-	const uint old_tc = palette_animation_counter;
-	uint j;
-
-	if (blitter != nullptr && blitter->UsePaletteAnimation() == Blitter::PALETTE_ANIMATION_NONE) {
-		palette_animation_counter = 0;
-	}
-
-	Colour *palette_pos = &_cur_palette.palette[PALETTE_ANIM_START];  // Points to where animations are taking place on the palette
-	/* Makes a copy of the current animation palette in old_val,
-	 * so the work on the current palette could be compared, see if there has been any changes */
-	memcpy(old_val, palette_pos, sizeof(old_val));
-
-	/* Fizzy Drink bubbles animation */
-	s = ev->fizzy_drink;
-	j = EXTR2(512, EPV_CYCLES_FIZZY_DRINK);
-	for (uint i = 0; i != EPV_CYCLES_FIZZY_DRINK; i++) {
-		*palette_pos++ = s[j];
-		j++;
-		if (j == EPV_CYCLES_FIZZY_DRINK) j = 0;
-	}
-
-	/* Oil refinery fire animation */
-	s = ev->oil_refinery;
-	j = EXTR2(512, EPV_CYCLES_OIL_REFINERY);
-	for (uint i = 0; i != EPV_CYCLES_OIL_REFINERY; i++) {
-		*palette_pos++ = s[j];
-		j++;
-		if (j == EPV_CYCLES_OIL_REFINERY) j = 0;
-	}
-
-	/* Radio tower blinking */
-	{
-		byte i = (palette_animation_counter >> 1) & 0x7F;
-		byte v;
-
-		if (i < 0x3f) {
-			v = 255;
-		} else if (i < 0x4A || i >= 0x75) {
-			v = 128;
-		} else {
-			v = 20;
-		}
-		palette_pos->r = v;
-		palette_pos->g = 0;
-		palette_pos->b = 0;
-		palette_pos++;
-
-		i ^= 0x40;
-		if (i < 0x3f) {
-			v = 255;
-		} else if (i < 0x4A || i >= 0x75) {
-			v = 128;
-		} else {
-			v = 20;
-		}
-		palette_pos->r = v;
-		palette_pos->g = 0;
-		palette_pos->b = 0;
-		palette_pos++;
-	}
-
-	/* Handle lighthouse and stadium animation */
-	s = ev->lighthouse;
-	j = EXTR(256, EPV_CYCLES_LIGHTHOUSE);
-	for (uint i = 0; i != EPV_CYCLES_LIGHTHOUSE; i++) {
-		*palette_pos++ = s[j];
-		j++;
-		if (j == EPV_CYCLES_LIGHTHOUSE) j = 0;
-	}
-
-	/* Dark blue water */
-	s = (_settings_game.game_creation.landscape == LT_TOYLAND) ? ev->dark_water_toyland : ev->dark_water;
-	j = EXTR(320, EPV_CYCLES_DARK_WATER);
-	for (uint i = 0; i != EPV_CYCLES_DARK_WATER; i++) {
-		*palette_pos++ = s[j];
-		j++;
-		if (j == EPV_CYCLES_DARK_WATER) j = 0;
-	}
-
-	/* Glittery water */
-	s = (_settings_game.game_creation.landscape == LT_TOYLAND) ? ev->glitter_water_toyland : ev->glitter_water;
-	j = EXTR(128, EPV_CYCLES_GLITTER_WATER);
-	for (uint i = 0; i != EPV_CYCLES_GLITTER_WATER / 3; i++) {
-		*palette_pos++ = s[j];
-		j += 3;
-		if (j >= EPV_CYCLES_GLITTER_WATER) j -= EPV_CYCLES_GLITTER_WATER;
-	}
-
-	if (blitter != nullptr && blitter->UsePaletteAnimation() == Blitter::PALETTE_ANIMATION_NONE) {
-		palette_animation_counter = old_tc;
-	} else if (_cur_palette.count_dirty == 0 && memcmp(old_val, &_cur_palette.palette[PALETTE_ANIM_START], sizeof(old_val)) != 0) {
-		/* Did we changed anything on the palette? Seems so.  Mark it as dirty */
-		_cur_palette.first_dirty = PALETTE_ANIM_START;
-		_cur_palette.count_dirty = PALETTE_ANIM_SIZE;
-	}
-}
-
-/**
- * Determine a contrasty text colour for a coloured background.
- * @param background Background colour.
- * @param threshold Background colour brightness threshold below which the background is considered dark and TC_WHITE is returned, range: 0 - 255, default 128.
- * @return TC_BLACK or TC_WHITE depending on what gives a better contrast.
- */
-TextColour GetContrastColour(uint8_t background, uint8_t threshold)
-{
-	Colour c = _cur_palette.palette[background];
-	/* Compute brightness according to http://www.w3.org/TR/AERT#color-contrast.
-	 * The following formula computes 1000 * brightness^2, with brightness being in range 0 to 255. */
-	uint sq1000_brightness = c.r * c.r * 299 + c.g * c.g * 587 + c.b * c.b * 114;
-	/* Compare with threshold brightness which defaults to 128 (50%) */
-	return sq1000_brightness < ((uint) threshold) * ((uint) threshold) * 1000 ? TC_WHITE : TC_BLACK;
 }
 
 /**

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -147,8 +147,6 @@ void DrawDirtyBlocks();
 void AddDirtyBlock(int left, int top, int right, int bottom);
 void MarkWholeScreenDirty();
 
-bool CopyPalette(Palette &local_palette, bool force_copy = false);
-void GfxInitPalettes();
 void CheckBlitter();
 
 bool FillDrawPixelInfo(DrawPixelInfo *n, int left, int top, int width, int height);
@@ -191,60 +189,4 @@ int GetCharacterHeight(FontSize size);
 
 extern DrawPixelInfo *_cur_dpi;
 
-/**
- * Checks if a Colours value is valid.
- *
- * @param colours The value to check
- * @return true if the given value is a valid Colours.
- */
-static inline bool IsValidColours(Colours colours)
-{
-	return colours < COLOUR_END;
-}
-
-TextColour GetContrastColour(uint8_t background, uint8_t threshold = 128);
-
-/**
- * All 16 colour gradients
- * 8 colours per gradient from darkest (0) to lightest (7)
- */
-extern byte _colour_gradient[COLOUR_END][8];
-
-/**
- * Return the colour for a particular greyscale level.
- * @param level Intensity, 0 = black, 15 = white
- * @return colour
- */
-#define GREY_SCALE(level) (level)
-
-static const uint8_t PC_BLACK              = GREY_SCALE(1);  ///< Black palette colour.
-static const uint8_t PC_DARK_GREY          = GREY_SCALE(6);  ///< Dark grey palette colour.
-static const uint8_t PC_GREY               = GREY_SCALE(10); ///< Grey palette colour.
-static const uint8_t PC_WHITE              = GREY_SCALE(15); ///< White palette colour.
-
-static const uint8_t PC_VERY_DARK_RED      = 0xB2;           ///< Almost-black red palette colour.
-static const uint8_t PC_DARK_RED           = 0xB4;           ///< Dark red palette colour.
-static const uint8_t PC_RED                = 0xB8;           ///< Red palette colour.
-
-static const uint8_t PC_VERY_DARK_BROWN    = 0x56;           ///< Almost-black brown palette colour.
-
-static const uint8_t PC_ORANGE             = 0xC2;           ///< Orange palette colour.
-
-static const uint8_t PC_YELLOW             = 0xBF;           ///< Yellow palette colour.
-static const uint8_t PC_LIGHT_YELLOW       = 0x44;           ///< Light yellow palette colour.
-static const uint8_t PC_VERY_LIGHT_YELLOW  = 0x45;           ///< Almost-white yellow palette colour.
-
-static const uint8_t PC_GREEN              = 0xD0;           ///< Green palette colour.
-
-static const uint8_t PC_VERY_DARK_BLUE     = 0x9A;           ///< Almost-black blue palette colour.
-static const uint8_t PC_DARK_BLUE          = 0x9D;           ///< Dark blue palette colour.
-static const uint8_t PC_LIGHT_BLUE         = 0x98;           ///< Light blue palette colour.
-
-static const uint8_t PC_ROUGH_LAND         = 0x52;           ///< Dark green palette colour for rough land.
-static const uint8_t PC_GRASS_LAND         = 0x54;           ///< Dark green palette colour for grass land.
-static const uint8_t PC_BARE_LAND          = 0x37;           ///< Brown palette colour for bare land.
-static const uint8_t PC_RAINFOREST         = 0x5C;           ///< Pale green palette colour for rainforest.
-static const uint8_t PC_FIELDS             = 0x25;           ///< Light brown palette colour for fields.
-static const uint8_t PC_TREES              = 0x57;           ///< Green palette colour for trees.
-static const uint8_t PC_WATER              = 0xC9;           ///< Dark blue palette colour for water.
 #endif /* GFX_FUNC_H */

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -17,6 +17,7 @@
 #include "blitter/factory.hpp"
 #include "video/video_driver.hpp"
 #include "window_func.h"
+#include "palette_func.h"
 
 /* The type of set we're replacing */
 #define SET_TYPE "graphics"

--- a/src/palette.cpp
+++ b/src/palette.cpp
@@ -1,0 +1,190 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file palette.cpp Handling of palettes. */
+
+#include "stdafx.h"
+#include "blitter/base.hpp"
+#include "blitter/factory.hpp"
+#include "gfx_type.h"
+#include "landscape_type.h"
+#include "palette_func.h"
+#include "settings_type.h"
+#include "thread.h"
+
+#include "table/palettes.h"
+
+#include "safeguards.h"
+
+Palette _cur_palette;
+
+byte _colour_gradient[COLOUR_END][8];
+
+static std::recursive_mutex _palette_mutex; ///< To coordinate access to _cur_palette.
+
+void DoPaletteAnimations();
+
+void GfxInitPalettes()
+{
+	std::lock_guard<std::recursive_mutex> lock(_palette_mutex);
+	memcpy(&_cur_palette, &_palette, sizeof(_cur_palette));
+	DoPaletteAnimations();
+}
+
+/**
+ * Copy the current palette if the palette was updated.
+ * Used by video-driver to get a current up-to-date version of the palette,
+ * to avoid two threads accessing the same piece of memory (with a good chance
+ * one is already updating the palette while the other is drawing based on it).
+ * @param local_palette The location to copy the palette to.
+ * @param force_copy Whether to ignore if there is an update for the palette.
+ * @return True iff a copy was done.
+ */
+bool CopyPalette(Palette &local_palette, bool force_copy)
+{
+	std::lock_guard<std::recursive_mutex> lock(_palette_mutex);
+
+	if (!force_copy && _cur_palette.count_dirty == 0) return false;
+
+	local_palette = _cur_palette;
+	_cur_palette.count_dirty = 0;
+
+	if (force_copy) {
+		local_palette.first_dirty = 0;
+		local_palette.count_dirty = 256;
+	}
+
+	return true;
+}
+
+#define EXTR(p, q) (((uint16_t)(palette_animation_counter * (p)) * (q)) >> 16)
+#define EXTR2(p, q) (((uint16_t)(~palette_animation_counter * (p)) * (q)) >> 16)
+
+void DoPaletteAnimations()
+{
+	std::lock_guard<std::recursive_mutex> lock(_palette_mutex);
+
+	/* Animation counter for the palette animation. */
+	static int palette_animation_counter = 0;
+	palette_animation_counter += 8;
+
+	Blitter *blitter = BlitterFactory::GetCurrentBlitter();
+	const Colour *s;
+	const ExtraPaletteValues *ev = &_extra_palette_values;
+	Colour old_val[PALETTE_ANIM_SIZE];
+	const uint old_tc = palette_animation_counter;
+	uint j;
+
+	if (blitter != nullptr && blitter->UsePaletteAnimation() == Blitter::PALETTE_ANIMATION_NONE) {
+		palette_animation_counter = 0;
+	}
+
+	Colour *palette_pos = &_cur_palette.palette[PALETTE_ANIM_START];  // Points to where animations are taking place on the palette
+	/* Makes a copy of the current animation palette in old_val,
+	 * so the work on the current palette could be compared, see if there has been any changes */
+	memcpy(old_val, palette_pos, sizeof(old_val));
+
+	/* Fizzy Drink bubbles animation */
+	s = ev->fizzy_drink;
+	j = EXTR2(512, EPV_CYCLES_FIZZY_DRINK);
+	for (uint i = 0; i != EPV_CYCLES_FIZZY_DRINK; i++) {
+		*palette_pos++ = s[j];
+		j++;
+		if (j == EPV_CYCLES_FIZZY_DRINK) j = 0;
+	}
+
+	/* Oil refinery fire animation */
+	s = ev->oil_refinery;
+	j = EXTR2(512, EPV_CYCLES_OIL_REFINERY);
+	for (uint i = 0; i != EPV_CYCLES_OIL_REFINERY; i++) {
+		*palette_pos++ = s[j];
+		j++;
+		if (j == EPV_CYCLES_OIL_REFINERY) j = 0;
+	}
+
+	/* Radio tower blinking */
+	{
+		byte i = (palette_animation_counter >> 1) & 0x7F;
+		byte v;
+
+		if (i < 0x3f) {
+			v = 255;
+		} else if (i < 0x4A || i >= 0x75) {
+			v = 128;
+		} else {
+			v = 20;
+		}
+		palette_pos->r = v;
+		palette_pos->g = 0;
+		palette_pos->b = 0;
+		palette_pos++;
+
+		i ^= 0x40;
+		if (i < 0x3f) {
+			v = 255;
+		} else if (i < 0x4A || i >= 0x75) {
+			v = 128;
+		} else {
+			v = 20;
+		}
+		palette_pos->r = v;
+		palette_pos->g = 0;
+		palette_pos->b = 0;
+		palette_pos++;
+	}
+
+	/* Handle lighthouse and stadium animation */
+	s = ev->lighthouse;
+	j = EXTR(256, EPV_CYCLES_LIGHTHOUSE);
+	for (uint i = 0; i != EPV_CYCLES_LIGHTHOUSE; i++) {
+		*palette_pos++ = s[j];
+		j++;
+		if (j == EPV_CYCLES_LIGHTHOUSE) j = 0;
+	}
+
+	/* Dark blue water */
+	s = (_settings_game.game_creation.landscape == LT_TOYLAND) ? ev->dark_water_toyland : ev->dark_water;
+	j = EXTR(320, EPV_CYCLES_DARK_WATER);
+	for (uint i = 0; i != EPV_CYCLES_DARK_WATER; i++) {
+		*palette_pos++ = s[j];
+		j++;
+		if (j == EPV_CYCLES_DARK_WATER) j = 0;
+	}
+
+	/* Glittery water */
+	s = (_settings_game.game_creation.landscape == LT_TOYLAND) ? ev->glitter_water_toyland : ev->glitter_water;
+	j = EXTR(128, EPV_CYCLES_GLITTER_WATER);
+	for (uint i = 0; i != EPV_CYCLES_GLITTER_WATER / 3; i++) {
+		*palette_pos++ = s[j];
+		j += 3;
+		if (j >= EPV_CYCLES_GLITTER_WATER) j -= EPV_CYCLES_GLITTER_WATER;
+	}
+
+	if (blitter != nullptr && blitter->UsePaletteAnimation() == Blitter::PALETTE_ANIMATION_NONE) {
+		palette_animation_counter = old_tc;
+	} else if (_cur_palette.count_dirty == 0 && memcmp(old_val, &_cur_palette.palette[PALETTE_ANIM_START], sizeof(old_val)) != 0) {
+		/* Did we changed anything on the palette? Seems so.  Mark it as dirty */
+		_cur_palette.first_dirty = PALETTE_ANIM_START;
+		_cur_palette.count_dirty = PALETTE_ANIM_SIZE;
+	}
+}
+
+/**
+ * Determine a contrasty text colour for a coloured background.
+ * @param background Background colour.
+ * @param threshold Background colour brightness threshold below which the background is considered dark and TC_WHITE is returned, range: 0 - 255, default 128.
+ * @return TC_BLACK or TC_WHITE depending on what gives a better contrast.
+ */
+TextColour GetContrastColour(uint8_t background, uint8_t threshold)
+{
+	Colour c = _cur_palette.palette[background];
+	/* Compute brightness according to http://www.w3.org/TR/AERT#color-contrast.
+	 * The following formula computes 1000 * brightness^2, with brightness being in range 0 to 255. */
+	uint sq1000_brightness = c.r * c.r * 299 + c.g * c.g * 587 + c.b * c.b * 114;
+	/* Compare with threshold brightness which defaults to 128 (50%) */
+	return sq1000_brightness < ((uint) threshold) * ((uint) threshold) * 1000 ? TC_WHITE : TC_BLACK;
+}

--- a/src/palette_func.h
+++ b/src/palette_func.h
@@ -19,6 +19,13 @@ extern Palette _cur_palette; ///< Current palette
 bool CopyPalette(Palette &local_palette, bool force_copy = false);
 void GfxInitPalettes();
 
+uint8_t GetNearestColourIndex(uint8_t r, uint8_t g, uint8_t b);
+
+static inline uint8_t GetNearestColourIndex(const Colour colour)
+{
+	return GetNearestColourIndex(colour.r, colour.g, colour.b);
+}
+
 /**
  * Checks if a Colours value is valid.
  *

--- a/src/palette_func.h
+++ b/src/palette_func.h
@@ -1,0 +1,79 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file palette_func.h Functions related to palettes. */
+
+#ifndef PALETTE_FUNC_H
+#define PALETTE_FUNC_H
+
+#include "gfx_type.h"
+#include "strings_type.h"
+#include "string_type.h"
+
+extern Palette _cur_palette; ///< Current palette
+
+bool CopyPalette(Palette &local_palette, bool force_copy = false);
+void GfxInitPalettes();
+
+/**
+ * Checks if a Colours value is valid.
+ *
+ * @param colours The value to check
+ * @return true if the given value is a valid Colours.
+ */
+static inline bool IsValidColours(Colours colours)
+{
+	return colours < COLOUR_END;
+}
+
+TextColour GetContrastColour(uint8_t background, uint8_t threshold = 128);
+
+/**
+ * All 16 colour gradients
+ * 8 colours per gradient from darkest (0) to lightest (7)
+ */
+extern byte _colour_gradient[COLOUR_END][8];
+
+/**
+ * Return the colour for a particular greyscale level.
+ * @param level Intensity, 0 = black, 15 = white
+ * @return colour
+ */
+#define GREY_SCALE(level) (level)
+
+static const uint8_t PC_BLACK              = GREY_SCALE(1);  ///< Black palette colour.
+static const uint8_t PC_DARK_GREY          = GREY_SCALE(6);  ///< Dark grey palette colour.
+static const uint8_t PC_GREY               = GREY_SCALE(10); ///< Grey palette colour.
+static const uint8_t PC_WHITE              = GREY_SCALE(15); ///< White palette colour.
+
+static const uint8_t PC_VERY_DARK_RED      = 0xB2;           ///< Almost-black red palette colour.
+static const uint8_t PC_DARK_RED           = 0xB4;           ///< Dark red palette colour.
+static const uint8_t PC_RED                = 0xB8;           ///< Red palette colour.
+
+static const uint8_t PC_VERY_DARK_BROWN    = 0x56;           ///< Almost-black brown palette colour.
+
+static const uint8_t PC_ORANGE             = 0xC2;           ///< Orange palette colour.
+
+static const uint8_t PC_YELLOW             = 0xBF;           ///< Yellow palette colour.
+static const uint8_t PC_LIGHT_YELLOW       = 0x44;           ///< Light yellow palette colour.
+static const uint8_t PC_VERY_LIGHT_YELLOW  = 0x45;           ///< Almost-white yellow palette colour.
+
+static const uint8_t PC_GREEN              = 0xD0;           ///< Green palette colour.
+
+static const uint8_t PC_VERY_DARK_BLUE     = 0x9A;           ///< Almost-black blue palette colour.
+static const uint8_t PC_DARK_BLUE          = 0x9D;           ///< Dark blue palette colour.
+static const uint8_t PC_LIGHT_BLUE         = 0x98;           ///< Light blue palette colour.
+
+static const uint8_t PC_ROUGH_LAND         = 0x52;           ///< Dark green palette colour for rough land.
+static const uint8_t PC_GRASS_LAND         = 0x54;           ///< Dark green palette colour for grass land.
+static const uint8_t PC_BARE_LAND          = 0x37;           ///< Brown palette colour for bare land.
+static const uint8_t PC_RAINFOREST         = 0x5C;           ///< Pale green palette colour for rainforest.
+static const uint8_t PC_FIELDS             = 0x25;           ///< Light brown palette colour for fields.
+static const uint8_t PC_TREES              = 0x57;           ///< Green palette colour for trees.
+static const uint8_t PC_WATER              = 0xC9;           ///< Dark blue palette colour for water.
+
+#endif /* PALETTE_FUNC_H */

--- a/src/widgets/dropdown_type.h
+++ b/src/widgets/dropdown_type.h
@@ -13,6 +13,7 @@
 #include "../window_type.h"
 #include "../gfx_func.h"
 #include "../gfx_type.h"
+#include "../palette_func.h"
 #include "../string_func.h"
 #include "../strings_func.h"
 #include "../table/strings.h"

--- a/src/widgets/slider.cpp
+++ b/src/widgets/slider.cpp
@@ -8,6 +8,7 @@
 /** @file slider.cpp Implementation of the horizontal slider widget. */
 
 #include "../stdafx.h"
+#include "../palette_func.h"
 #include "../window_gui.h"
 #include "../window_func.h"
 #include "../strings_func.h"


### PR DESCRIPTION
## Motivation / Problem

When 32bpp was introduced, we left a note that custom transparency remaps are no longer supported, and left it with a TODO comment.

This is feature that relies on 8bpp palette remaps to change the colour of existing pixels. In the picture below, the station roofs should have a green tint, and when in 8bpp they do.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/33684897-26d3-42b5-9ce1-2da3fee765e8)

It was never done...

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

... until now.

This change implements a lookup table to convert 32bpp to 8bpp palette indexes. This can then have the palette remap applied, and be redrawn in the viewport. To reduce the size of the lookup table, some bits of the 32bpp value are dropped, but due to the nature of converting to an 8bpp palette, this is not really noticeable, especially given it's remapped anyway.

So finally this (limited use) feature can be supported with 32bpp blitters:

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/125a80aa-37b8-4122-bf59-7ceb154bb3b5)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
