### PR TITLE
Fix 2d3af14: Don't draw script log over panel borders

### DIFF
--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -898,8 +898,19 @@ struct ScriptDebugWindow : public Window {
 		ScriptLogTypes::LogData &log = this->GetLogData();
 		if (log.empty()) return;
 
-		Rect br = r.Shrink(WidgetDimensions::scaled.bevel);
-		Rect tr = r.Shrink(WidgetDimensions::scaled.framerect);
+		Rect fr = r.Shrink(WidgetDimensions::scaled.framerect);
+
+		/* Setup a clipping rectangle... */
+		DrawPixelInfo tmp_dpi;
+		if (!FillDrawPixelInfo(&tmp_dpi, fr)) return;
+		/* ...but keep coordinates relative to the window. */
+		tmp_dpi.left += fr.left;
+		tmp_dpi.top += fr.top;
+
+		AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
+
+		fr.left -= this->hscroll->GetPosition();
+
 		for (int i = this->vscroll->GetPosition(); this->vscroll->IsVisible(i) && (size_t)i < log.size(); i++) {
 			const ScriptLogTypes::LogLine &line = log[i];
 
@@ -915,12 +926,13 @@ struct ScriptDebugWindow : public Window {
 
 			/* Check if the current line should be highlighted */
 			if (i == this->highlight_row) {
-				GfxFillRect(br.left, tr.top, br.right, tr.top + this->resize.step_height - 1, PC_BLACK);
+				fr.bottom = fr.top + this->resize.step_height - 1;
+				GfxFillRect(fr, PC_BLACK);
 				if (colour == TC_BLACK) colour = TC_WHITE; // Make black text readable by inverting it to white.
 			}
 
-			DrawString(-this->hscroll->GetPosition(), tr.right, tr.top, line.text, colour, SA_LEFT | SA_FORCE);
-			tr.top += this->resize.step_height;
+			DrawString(fr, line.text, colour, SA_LEFT | SA_FORCE);
+			fr.top += this->resize.step_height;
 		}
 	}
 


### PR DESCRIPTION
## Motivation / Problem
Since the addition of horizontal scrollbar to script debug window, log lines are drawn on the panel border.
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/b726d506-85d4-4524-8bf0-3cf32cb2d478)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Restore the original offset. This is done using a temporary clipping region and forced me to slightly adjust left and right border for highlighting. 
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/43302f4b-a9f7-4113-8d8a-768cc67ae743)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
