### PR TITLE
Fix 4a2038e301: fully restore script break filter on reopen

### DIFF
--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -800,8 +800,9 @@ struct ScriptDebugWindow : public Window {
 		SetWidgetsDisabledState(!this->show_break_box, WID_SCRD_BREAK_STR_ON_OFF_BTN, WID_SCRD_BREAK_STR_EDIT_BOX, WID_SCRD_MATCH_CASE_BTN);
 		this->hscroll->SetStepSize(10); // Speed up horizontal scrollbar
 
-		/* Restore the break string value from static variable */
+		/* Restore the break string value from static variable, and enable the filter. */
 		this->break_editbox.text.Assign(this->filter.break_string);
+		this->break_string_filter.SetFilterTerm(this->filter.break_string);
 
 		if (show_company == INVALID_COMPANY) {
 			this->SelectValidDebugCompany();


### PR DESCRIPTION
## Motivation / Problem
`break_string_filter` used to be static, so setting it in `OnEditboxChanged()` was enough for it to be correct on reopen.
But it is non static now and on reopen it is empty (even if the editbox is properly restored).
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
After restoring editbox content, also set `break_string_filter`.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
