### PR TITLE
Fix 9ce1626b: Some blitters have `bp->remap` aliased to `remap` for performance.

### DIFF
--- a/src/blitter/32bpp_anim.cpp
+++ b/src/blitter/32bpp_anim.cpp
@@ -218,7 +218,7 @@ inline void Blitter_32bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 					if (src_px->a != 0) {
 						src_px += n;
 						do {
-							*dst = this->LookupColourInPalette(bp->remap[GetNearestColourIndex(*dst)]);
+							*dst = this->LookupColourInPalette(remap[GetNearestColourIndex(*dst)]);
 							*anim = 0;
 							anim++;
 							dst++;

--- a/src/blitter/32bpp_anim_sse4.cpp
+++ b/src/blitter/32bpp_anim_sse4.cpp
@@ -322,7 +322,7 @@ bmcr_alpha_blend_single:
 				/* Apply custom transparency remap. */
 				for (uint x = (uint) bp->width; x > 0; x--) {
 					if (src->a != 0) {
-						*dst = this->LookupColourInPalette(bp->remap[GetNearestColourIndex(*dst)]);
+						*dst = this->LookupColourInPalette(remap[GetNearestColourIndex(*dst)]);
 						*anim = 0;
 					}
 					src_mv++;

--- a/src/blitter/32bpp_optimized.cpp
+++ b/src/blitter/32bpp_optimized.cpp
@@ -209,7 +209,7 @@ inline void Blitter_32bppOptimized::Draw(const Blitter::BlitterParams *bp, ZoomL
 					if (src_px->a != 0) {
 						src_px += n;
 						do {
-							*dst = this->LookupColourInPalette(bp->remap[GetNearestColourIndex(*dst)]);
+							*dst = this->LookupColourInPalette(remap[GetNearestColourIndex(*dst)]);
 							dst++;
 						} while (--n != 0);
 					} else {

--- a/src/blitter/32bpp_sse_func.hpp
+++ b/src/blitter/32bpp_sse_func.hpp
@@ -396,7 +396,7 @@ bmcr_alpha_blend_single:
 				/* Apply custom transparency remap. */
 				for (uint x = (uint) bp->width; x > 0; x--) {
 					if (src->a != 0) {
-						*dst = this->LookupColourInPalette(bp->remap[GetNearestColourIndex(*dst)]);
+						*dst = this->LookupColourInPalette(remap[GetNearestColourIndex(*dst)]);
 					}
 					src_mv++;
 					dst++;

--- a/src/blitter/40bpp_anim.cpp
+++ b/src/blitter/40bpp_anim.cpp
@@ -267,9 +267,9 @@ inline void Blitter_40bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 						src_px += n;
 						do {
 							if (*anim != 0) {
-								*anim = bp->remap[*anim];
+								*anim = remap[*anim];
 							} else {
-								*dst = this->LookupColourInPalette(bp->remap[GetNearestColourIndex(*dst)]);
+								*dst = this->LookupColourInPalette(remap[GetNearestColourIndex(*dst)]);
 								*anim = 0;
 							}
 							anim++;


### PR DESCRIPTION
## Motivation / Problem

Some blitters have `bp->remap` aliased to `remap` for performance. In my copy & pasting from one blitter to another, I didn't notice this, and always used `bp->remap`

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use `remap` instead of `bp->remap` where available. While this probably doesn't make a huge difference for the custom transparent remap code path, the alias is there so use it.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
