### PR TITLE
Codechange: replace NULL with nullptr

### DIFF
--- a/src/3rdparty/squirrel/sqstdlib/sqstdmath.cpp
+++ b/src/3rdparty/squirrel/sqstdlib/sqstdmath.cpp
@@ -84,7 +84,7 @@ static SQRegFunction mathlib_funcs[] = {
 	_DECL_FUNC(exp,2,".n"),
 #ifdef EXPORT_DEFAULT_SQUIRREL_FUNCTIONS
 	_DECL_FUNC(srand,2,".n"),
-	_DECL_FUNC(rand,1,NULL),
+	_DECL_FUNC(rand,1,nullptr),
 #endif /* EXPORT_DEFAULT_SQUIRREL_FUNCTIONS */
 	_DECL_FUNC(fabs,2,".n"),
 	_DECL_FUNC(abs,2,".n"),

--- a/src/3rdparty/squirrel/sqstdlib/sqstdrex.cpp
+++ b/src/3rdparty/squirrel/sqstdlib/sqstdrex.cpp
@@ -378,8 +378,8 @@ static const SQChar *sqstd_rex_matchnode(SQRex* exp,SQRexNode *node,const SQChar
 	SQRexNodeType type = node->type;
 	switch(type) {
 	case OP_GREEDY: {
-		//SQRexNode *greedystop = (node->next != -1) ? &exp->_nodes[node->next] : NULL;
-		SQRexNode *greedystop = NULL;
+		//SQRexNode *greedystop = (node->next != -1) ? &exp->_nodes[node->next] : nullptr;
+		SQRexNode *greedystop = nullptr;
 		SQInteger p0 = (node->right >> 16)&0x0000FFFF, p1 = node->right&0x0000FFFF, nmaches = 0;
 		const SQChar *s=str, *good = str;
 
@@ -403,7 +403,7 @@ static const SQChar *sqstd_rex_matchnode(SQRex* exp,SQRexNode *node,const SQChar
 				if(greedystop->type != OP_GREEDY ||
 				(greedystop->type == OP_GREEDY && ((greedystop->right >> 16)&0x0000FFFF) != 0))
 				{
-					SQRexNode *gnext = NULL;
+					SQRexNode *gnext = nullptr;
 					if(greedystop->next != -1) {
 						gnext = &exp->_nodes[greedystop->next];
 					}else if(next && next->next != -1){
@@ -425,12 +425,12 @@ static const SQChar *sqstd_rex_matchnode(SQRex* exp,SQRexNode *node,const SQChar
 		if(p0 == p1 && p0 == nmaches) return good;
 		else if(nmaches >= p0 && p1 == 0xFFFF) return good;
 		else if(nmaches >= p0 && nmaches <= p1) return good;
-		return NULL;
+		return nullptr;
 	}
 	case OP_OR: {
 			const SQChar *asd = str;
 			SQRexNode *temp=&exp->_nodes[node->left];
-			while( (asd = sqstd_rex_matchnode(exp,temp,asd,NULL)) ) {
+			while( (asd = sqstd_rex_matchnode(exp,temp,asd,nullptr)) ) {
 				if(temp->next != -1)
 					temp = &exp->_nodes[temp->next];
 				else
@@ -438,13 +438,13 @@ static const SQChar *sqstd_rex_matchnode(SQRex* exp,SQRexNode *node,const SQChar
 			}
 			asd = str;
 			temp = &exp->_nodes[node->right];
-			while( (asd = sqstd_rex_matchnode(exp,temp,asd,NULL)) ) {
+			while( (asd = sqstd_rex_matchnode(exp,temp,asd,nullptr)) ) {
 				if(temp->next != -1)
 					temp = &exp->_nodes[temp->next];
 				else
 					return asd;
 			}
-			return NULL;
+			return nullptr;
 			break;
 	}
 	case OP_EXPR:
@@ -459,7 +459,7 @@ static const SQChar *sqstd_rex_matchnode(SQRex* exp,SQRexNode *node,const SQChar
 			}
 
 			do {
-				SQRexNode *subnext = NULL;
+				SQRexNode *subnext = nullptr;
 				if(n->next != -1) {
 					subnext = &exp->_nodes[n->next];
 				}else {
@@ -470,7 +470,7 @@ static const SQChar *sqstd_rex_matchnode(SQRex* exp,SQRexNode *node,const SQChar
 						exp->_matches[capture].begin = 0;
 						exp->_matches[capture].len = 0;
 					}
-					return NULL;
+					return nullptr;
 				}
 			} while((n->next != -1) && (n = &exp->_nodes[n->next]));
 
@@ -483,15 +483,15 @@ static const SQChar *sqstd_rex_matchnode(SQRex* exp,SQRexNode *node,const SQChar
 		 || (str == exp->_eol && !isspace(*(str-1)))
 		 || (!isspace(*str) && isspace(*(str+1)))
 		 || (isspace(*str) && !isspace(*(str+1))) ) {
-			return (node->left == 'b')?str:NULL;
+			return (node->left == 'b')?str:nullptr;
 		}
-		return (node->left == 'b')?NULL:str;
+		return (node->left == 'b')?nullptr:str;
 	case OP_BOL:
 		if(str == exp->_bol) return str;
-		return NULL;
+		return nullptr;
 	case OP_EOL:
 		if(str == exp->_eol) return str;
-		return NULL;
+		return nullptr;
 	case OP_DOT:{
 		*str++;
 				}
@@ -502,26 +502,26 @@ static const SQChar *sqstd_rex_matchnode(SQRex* exp,SQRexNode *node,const SQChar
 			*str++;
 			return str;
 		}
-		return NULL;
+		return nullptr;
 	case OP_CCLASS:
 		if(sqstd_rex_matchcclass(node->left,*str)) {
 			*str++;
 			return str;
 		}
-		return NULL;
+		return nullptr;
 	default: /* char */
-		if(*str != (SQChar)node->type) return NULL;
+		if(*str != (SQChar)node->type) return nullptr;
 		*str++;
 		return str;
 	}
-	return NULL;
+	return nullptr;
 }
 
 /* public api */
 SQRex *sqstd_rex_compile(const SQChar *pattern,const SQChar **error)
 {
 	SQRex *exp = (SQRex *)sq_malloc(sizeof(SQRex));
-	exp->_eol = exp->_bol = NULL;
+	exp->_eol = exp->_bol = nullptr;
 	exp->_p = pattern;
 	exp->_nallocated = (SQInteger)strlen(pattern) * sizeof(SQChar);
 	exp->_nodes = (SQRexNode *)sq_malloc(exp->_nallocated * sizeof(SQRexNode));
@@ -558,7 +558,7 @@ SQRex *sqstd_rex_compile(const SQChar *pattern,const SQChar **error)
 	}
 	catch (...) {
 		sqstd_rex_free(exp);
-		return NULL;
+		return nullptr;
 	}
 	return exp;
 }
@@ -574,19 +574,19 @@ void sqstd_rex_free(SQRex *exp)
 
 SQBool sqstd_rex_match(SQRex* exp,const SQChar* text)
 {
-	const SQChar* res = NULL;
+	const SQChar* res = nullptr;
 	exp->_bol = text;
 	exp->_eol = text + strlen(text);
 	exp->_currsubexp = 0;
-	res = sqstd_rex_matchnode(exp,exp->_nodes,text,NULL);
-	if(res == NULL || res != exp->_eol)
+	res = sqstd_rex_matchnode(exp,exp->_nodes,text,nullptr);
+	if(res == nullptr || res != exp->_eol)
 		return SQFalse;
 	return SQTrue;
 }
 
 SQBool sqstd_rex_searchrange(SQRex* exp,const SQChar* text_begin,const SQChar* text_end,const SQChar** out_begin, const SQChar** out_end)
 {
-	const SQChar *cur = NULL;
+	const SQChar *cur = nullptr;
 	SQInteger node = exp->_first;
 	if(text_begin >= text_end) return SQFalse;
 	exp->_bol = text_begin;
@@ -595,15 +595,15 @@ SQBool sqstd_rex_searchrange(SQRex* exp,const SQChar* text_begin,const SQChar* t
 		cur = text_begin;
 		while(node != -1) {
 			exp->_currsubexp = 0;
-			cur = sqstd_rex_matchnode(exp,&exp->_nodes[node],cur,NULL);
+			cur = sqstd_rex_matchnode(exp,&exp->_nodes[node],cur,nullptr);
 			if(!cur)
 				break;
 			node = exp->_nodes[node].next;
 		}
 		*text_begin++;
-	} while(cur == NULL && text_begin != text_end);
+	} while(cur == nullptr && text_begin != text_end);
 
-	if(cur == NULL)
+	if(cur == nullptr)
 		return SQFalse;
 
 	--text_begin;

--- a/src/3rdparty/squirrel/sqstdlib/sqstdstring.cpp
+++ b/src/3rdparty/squirrel/sqstdlib/sqstdstring.cpp
@@ -112,16 +112,16 @@ static SQInteger _string_split(HSQUIRRELVM v)
 	memcpy(stemp,str,memsize);
 	tok = scstrtok(stemp,seps);
 	sq_newarray(v,0);
-	while( tok != NULL ) {
+	while( tok != nullptr ) {
 		sq_pushstring(v,tok,-1);
 		sq_arrayappend(v,-2);
-		tok = scstrtok( NULL, seps );
+		tok = scstrtok( nullptr, seps );
 	}
 	return 1;
 }
 
 #define SETUP_REX(v) \
-	SQRex *self = NULL; \
+	SQRex *self = nullptr; \
 	sq_getinstanceup(v,1,(SQUserPointer *)&self,0);
 
 static SQInteger _rexobj_releasehook(SQUserPointer p, SQInteger size)

--- a/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
@@ -101,7 +101,7 @@ static SQInteger base_getstackinfos(HSQUIRRELVM v)
 	SQInteger level;
 	SQStackInfos si;
 	SQInteger seq = 0;
-	const SQChar *name = NULL;
+	const SQChar *name = nullptr;
 	sq_getinteger(v, -1, &level);
 	if (SQ_SUCCEEDED(sq_stackinfos(v, level, &si)))
 	{
@@ -180,7 +180,7 @@ static SQInteger base_print(HSQUIRRELVM v)
 static SQInteger base_compilestring(HSQUIRRELVM v)
 {
 	SQInteger nargs=sq_gettop(v);
-	const SQChar *src=NULL,*name="unnamedbuffer";
+	const SQChar *src=nullptr,*name="unnamedbuffer";
 	SQInteger size;
 	sq_getstring(v,2,&src);
 	size=sq_getsize(v,2);
@@ -239,26 +239,26 @@ static SQInteger base_type(HSQUIRRELVM v)
 static SQRegFunction base_funcs[]={
 	//generic
 #ifdef EXPORT_DEFAULT_SQUIRREL_FUNCTIONS
-	{"seterrorhandler",base_seterrorhandler,2, NULL},
-	{"setdebughook",base_setdebughook,2, NULL},
-	{"enabledebuginfo",base_enabledebuginfo,2, NULL},
+	{"seterrorhandler",base_seterrorhandler,2, nullptr},
+	{"setdebughook",base_setdebughook,2, nullptr},
+	{"enabledebuginfo",base_enabledebuginfo,2, nullptr},
 	{"getstackinfos",base_getstackinfos,2, ".n"},
-	{"getroottable",base_getroottable,1, NULL},
-	{"setroottable",base_setroottable,2, NULL},
-	{"getconsttable",base_getconsttable,1, NULL},
-	{"setconsttable",base_setconsttable,2, NULL},
+	{"getroottable",base_getroottable,1, nullptr},
+	{"setroottable",base_setroottable,2, nullptr},
+	{"getconsttable",base_getconsttable,1, nullptr},
+	{"setconsttable",base_setconsttable,2, nullptr},
 #endif
 	{"assert",base_assert,2, nullptr},
 	{"print",base_print,2, nullptr},
 #ifdef EXPORT_DEFAULT_SQUIRREL_FUNCTIONS
 	{"compilestring",base_compilestring,-2, ".ss"},
 	{"newthread",base_newthread,2, ".c"},
-	{"suspend",base_suspend,-1, NULL},
+	{"suspend",base_suspend,-1, nullptr},
 #endif
 	{"array",base_array,-2, ".n"},
 	{"type",base_type,2, nullptr},
 #ifdef EXPORT_DEFAULT_SQUIRREL_FUNCTIONS
-	{"dummy",base_dummy,0,NULL},
+	{"dummy",base_dummy,0,nullptr},
 #ifndef NO_GARBAGE_COLLECTOR
 	{"collectgarbage",base_collectgarbage,1, "t"},
 #endif

--- a/src/3rdparty/squirrel/squirrel/sqobject.h
+++ b/src/3rdparty/squirrel/squirrel/sqobject.h
@@ -107,7 +107,7 @@ struct SQObjectPtr;
 		(obj)->_uiRef--; \
 		if((obj)->_uiRef == 0) \
 			(obj)->Release(); \
-		(obj) = NULL;	\
+		(obj) = nullptr;	\
 	} \
 }
 
@@ -417,7 +417,7 @@ public:
 #define ADD_TO_CHAIN(chain,obj) AddToChain(chain,obj)
 #define REMOVE_FROM_CHAIN(chain,obj) {if(!(_uiRef&MARK_FLAG))RemoveFromChain(chain,obj);}
 #define CHAINABLE_OBJ SQCollectable
-#define INIT_CHAIN() {_next=NULL;_prev=NULL;_sharedstate=ss;}
+#define INIT_CHAIN() {_next=nullptr;_prev=nullptr;_sharedstate=ss;}
 #else
 
 #define ADD_TO_CHAIN(chain,obj) ((void)0)

--- a/src/3rdparty/squirrel/squirrel/sqstate.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqstate.cpp
@@ -201,7 +201,7 @@ SQSharedState::~SQSharedState()
 			t = nx;
 		}
 	}
-//	assert(_gc_chain==NULL); //just to proove a theory
+//	assert(_gc_chain==nullptr); //just to proove a theory
 	while(_gc_chain){
 		_gc_chain->_uiRef--;
 		_gc_chain->Release();

--- a/src/3rdparty/squirrel/squirrel/sqvm.h
+++ b/src/3rdparty/squirrel/squirrel/sqvm.h
@@ -194,7 +194,7 @@ inline SQObjectPtr &stack_get(HSQUIRRELVM v,SQInteger idx){return ((idx>=0)?(v->
 #ifndef NO_GARBAGE_COLLECTOR
 #define _opt_ss(_vm_) (_vm_)->_sharedstate
 #else
-#define _opt_ss(_vm_) NULL
+#define _opt_ss(_vm_) nullptr
 #endif
 
 #define PUSH_CALLINFO(v,nci){ \
@@ -218,6 +218,6 @@ inline SQObjectPtr &stack_get(HSQUIRRELVM v,SQInteger idx){return ((idx>=0)?(v->
 	if(v->_callsstacksize)	\
 		v->ci = &v->_callsstack[v->_callsstacksize-1] ; \
 	else	\
-		v->ci = NULL; \
+		v->ci = nullptr; \
 }
 #endif //_SQVM_H_

--- a/src/network/core/http_winhttp.cpp
+++ b/src/network/core/http_winhttp.cpp
@@ -67,7 +67,7 @@ static std::string GetLastErrorAsString()
 	DWORD error_code = GetLastError();
 
 	if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_FROM_HMODULE | FORMAT_MESSAGE_IGNORE_INSERTS, GetModuleHandleA("winhttp.dll"), error_code,
-		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), buffer, sizeof(buffer), NULL) == 0) {
+		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), buffer, sizeof(buffer), nullptr) == 0) {
 		return fmt::format("unknown error {}", error_code);
 	}
 

--- a/src/network/core/os_abstraction.cpp
+++ b/src/network/core/os_abstraction.cpp
@@ -81,8 +81,8 @@ const std::string &NetworkError::AsString() const
 	if (this->message.empty()) {
 #if defined(_WIN32)
 		char buffer[512];
-		if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, this->error,
-			MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), buffer, sizeof(buffer), NULL) == 0) {
+		if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr, this->error,
+			MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), buffer, sizeof(buffer), nullptr) == 0) {
 			this->message.assign(fmt::format("Unknown error {}", this->error));
 		} else {
 			this->message.assign(buffer);

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -664,7 +664,7 @@ void VideoDriver_CocoaQuartz::AllocateBackingStore(bool)
 		kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Host
 	);
 
-	assert(this->cgcontext != NULL);
+	assert(this->cgcontext != nullptr);
 	CGContextSetShouldAntialias(this->cgcontext, FALSE);
 	CGContextSetAllowsAntialiasing(this->cgcontext, FALSE);
 	CGContextSetInterpolationQuality(this->cgcontext, kCGInterpolationNone);

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -929,16 +929,16 @@ void CocoaDialog(const char *title, const char *message, const char *buttonLabel
 
 	NSString *s = [ aString isKindOfClass:[ NSAttributedString class ] ] ? [ aString string ] : (NSString *)aString;
 
-	const char *insert_point = NULL;
-	const char *replace_range = NULL;
+	const char *insert_point = nullptr;
+	const char *replace_range = nullptr;
 	if (replacementRange.location != NSNotFound) {
 		/* Calculate the part to be replaced. */
 		insert_point = Utf8AdvanceByUtf16Units(_focused_window->GetFocusedTextbuf()->GetText(), replacementRange.location);
 		replace_range = Utf8AdvanceByUtf16Units(insert_point, replacementRange.length);
 	}
 
-	HandleTextInput(NULL, true);
-	HandleTextInput([ s UTF8String ], false, NULL, insert_point, replace_range);
+	HandleTextInput(nullptr, true);
+	HandleTextInput([ s UTF8String ], false, nullptr, insert_point, replace_range);
 }
 
 /** Insert the given text at the caret. */
@@ -955,9 +955,9 @@ void CocoaDialog(const char *title, const char *message, const char *buttonLabel
 	NSString *s = [ aString isKindOfClass:[ NSAttributedString class ] ] ? [ aString string ] : (NSString *)aString;
 
 	const char *utf8 = [ s UTF8String ];
-	if (utf8 != NULL) {
-		const char *insert_point = NULL;
-		const char *replace_range = NULL;
+	if (utf8 != nullptr) {
+		const char *insert_point = nullptr;
+		const char *replace_range = nullptr;
 		if (replacementRange.location != NSNotFound) {
 			/* Calculate the part to be replaced. */
 			NSRange marked = [ self markedRange ];

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -275,7 +275,7 @@ static bool DrawIMECompositionString()
 static void SetCompositionPos(HWND hwnd)
 {
 	HIMC hIMC = ImmGetContext(hwnd);
-	if (hIMC != NULL) {
+	if (hIMC != nullptr) {
 		COMPOSITIONFORM cf;
 		cf.dwStyle = CFS_POINT;
 
@@ -297,7 +297,7 @@ static void SetCompositionPos(HWND hwnd)
 static void SetCandidatePos(HWND hwnd)
 {
 	HIMC hIMC = ImmGetContext(hwnd);
-	if (hIMC != NULL) {
+	if (hIMC != nullptr) {
 		CANDIDATEFORM cf;
 		cf.dwIndex = 0;
 		cf.dwStyle = CFS_EXCLUDE;
@@ -332,7 +332,7 @@ static LRESULT HandleIMEComposition(HWND hwnd, WPARAM wParam, LPARAM lParam)
 {
 	HIMC hIMC = ImmGetContext(hwnd);
 
-	if (hIMC != NULL) {
+	if (hIMC != nullptr) {
 		if (lParam & GCS_RESULTSTR) {
 			/* Read result string from the IME. */
 			LONG len = ImmGetCompositionString(hIMC, GCS_RESULTSTR, nullptr, 0); // Length is always in bytes, even in UNICODE build.
@@ -391,7 +391,7 @@ static LRESULT HandleIMEComposition(HWND hwnd, WPARAM wParam, LPARAM lParam)
 static void CancelIMEComposition(HWND hwnd)
 {
 	HIMC hIMC = ImmGetContext(hwnd);
-	if (hIMC != NULL) ImmNotifyIME(hIMC, NI_COMPOSITIONSTR, CPS_CANCEL, 0);
+	if (hIMC != nullptr) ImmNotifyIME(hIMC, NI_COMPOSITIONSTR, CPS_CANCEL, 0);
 	ImmReleaseContext(hwnd, hIMC);
 	/* Clear any marked string from the current edit box. */
 	HandleTextInput(nullptr, true);
@@ -688,7 +688,7 @@ LRESULT CALLBACK WndProcGdi(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 			/* Resize the window to match the new DPI setting. */
 			RECT *prcNewWindow = (RECT *)lParam;
 			SetWindowPos(hwnd,
-				NULL,
+				nullptr,
 				prcNewWindow->left,
 				prcNewWindow->top,
 				prcNewWindow->right - prcNewWindow->left,


### PR DESCRIPTION
## Motivation / Problem

Someone commenting on `NULL` in a diff, made me wonder if there's still any `NULL` left. There is.


## Description

Replace `NULL` with `nullptr`, in two commits; one for squirrel and one for the rest.


## Limitations

There are still some `NULL`s in the code, but that's in printf output, comments and json.hpp defines.
```
./saveload/compat/cheat_sl_compat.h:26: SLC(1, SL_MIN_VERSION, SLV_TABLE_CHUNKS), // Need to be two NULL fields. See Load_CHTS().
./saveload/compat/cheat_sl_compat.h:30: SLC(1, SL_MIN_VERSION, SLV_TABLE_CHUNKS), // Need to be two NULL fields. See Load_CHTS().
./saveload/compat/cheat_sl_compat.h:36: SLC(1, SL_MIN_VERSION, SLV_TABLE_CHUNKS), // Need to be two NULL fields. See Load_CHTS().
./saveload/saveload.h:708:      uint16_t length;                ///< Length of the NULL field.
./saveload/saveload.cpp:310:     * during NULLing; especially those that try to get
./stdafx.h:145:#        pragma warning(disable: 6011)   // code analyzer: Dereferencing NULL pointer 'pfGetAddrInfo': Lines: 995, 996, 998, 999, 1001
./fontcache.cpp:67:             return "[NULL]";
./3rdparty/squirrel/squirrel/sqvm.cpp:1583:             case OT:                        printf("NULL"); break;
./3rdparty/squirrel/sqstdlib/sqstdaux.cpp:56:                                   pf(v,fmt::format("[{}] NULL\n",name));
./3rdparty/nlohmann/json.hpp:2198:    #elif defined(NULL)
./3rdparty/nlohmann/json.hpp:2199:        #define JSON_HEDLEY NULL
./3rdparty/nlohmann/json.hpp:2203:#elif defined(NULL)
./3rdparty/nlohmann/json.hpp:2204:    #define JSON_HEDLEY NULL
./3rdparty/catch2/catch.hpp:2314:    // Specialised comparison functions to handle equality comparisons between ints and pointers (NULL deduces as an int)
```

The Microsoft API uses `NULL`, which [also allows nullptr](https://devblogs.microsoft.com/oldnewthing/20180307-00/?p=98175). We were already using `nullptr` in some places so I made it consistent.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
