### PR TITLE
Fix: Memory leak in WindowDescTestsFixture

### DIFF
--- a/src/tests/test_window_desc.cpp
+++ b/src/tests/test_window_desc.cpp
@@ -95,4 +95,5 @@ TEST_CASE_METHOD(WindowDescTestsFixture, "WindowDesc - NWidgetPart validity")
 
 	REQUIRE_NOTHROW(root = MakeWindowNWidgetTree(window_desc->nwid_begin, window_desc->nwid_end, &biggest_index, &shade_select));
 	CHECK((root != nullptr));
+	delete root;
 }


### PR DESCRIPTION
## Motivation / Problem

Fix memory leak in WindowDescTestsFixture so that the various tests can be run with memory checkers enabled, without unnecessarily failing the tests.

## Description

Delete widget tree returned from MakeWindowNWidgetTree.

## Limitations

Doesn't fix errors/warnings for other sanitiser types (e.g. undefined behaviour).

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
