### PR TITLE
Fix: Missing word in conditional order comparator

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4475,9 +4475,9 @@ STR_ORDER_CONDITIONAL_COMPARATOR_TOOLTIP                        :{BLACK}How to c
 STR_ORDER_CONDITIONAL_COMPARATOR_EQUALS                         :is equal to
 STR_ORDER_CONDITIONAL_COMPARATOR_NOT_EQUALS                     :is not equal to
 STR_ORDER_CONDITIONAL_COMPARATOR_LESS_THAN                      :is less than
-STR_ORDER_CONDITIONAL_COMPARATOR_LESS_EQUALS                    :is less or equal to
+STR_ORDER_CONDITIONAL_COMPARATOR_LESS_EQUALS                    :is less than or equal to
 STR_ORDER_CONDITIONAL_COMPARATOR_MORE_THAN                      :is more than
-STR_ORDER_CONDITIONAL_COMPARATOR_MORE_EQUALS                    :is more or equal to
+STR_ORDER_CONDITIONAL_COMPARATOR_MORE_EQUALS                    :is more than or equal to
 STR_ORDER_CONDITIONAL_COMPARATOR_IS_TRUE                        :is true
 STR_ORDER_CONDITIONAL_COMPARATOR_IS_FALSE                       :is false
 


### PR DESCRIPTION
Fix: Grammatical corrections.

## Motivation / Problem

When I was creating some conditional orders with OTTD 13.4 as packaged in Debian Sid, I noted that in the EN_AU translation two of the options were grammatically incorrect:
- is less or equal to
- is greater or equal to

## Description

This error was propagated from the EN_GB base text, so this PR corrects the EN_GB strings to:
- is less than or equal to
- is greater than or equal to

## Limitations

None known.