### PR TITLE
Codechange: Simplify ConvertDateToYMD by returning YearMonthDay instead of outputting to a pointer.

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -920,8 +920,7 @@ void TestedEngineDetails::FillDefaultCapacities(const Engine *e)
 int DrawVehiclePurchaseInfo(int left, int right, int y, EngineID engine_number, TestedEngineDetails &te)
 {
 	const Engine *e = Engine::Get(engine_number);
-	TimerGameCalendar::YearMonthDay ymd;
-	TimerGameCalendar::ConvertDateToYMD(e->intro_date, &ymd);
+	TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(e->intro_date);
 	bool refittable = IsArticulatedVehicleRefittable(engine_number);
 	bool articulated_cargo = false;
 

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -104,8 +104,7 @@ static int32_t ClickChangeDateCheat(int32_t new_value, int32_t)
 	auto new_year = Clamp(TimerGameCalendar::Year(new_value), CalendarTime::MIN_YEAR, CalendarTime::MAX_YEAR);
 	if (new_year == TimerGameCalendar::year) return TimerGameCalendar::year.base();
 
-	TimerGameCalendar::YearMonthDay ymd;
-	TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date, &ymd);
+	TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date);
 	TimerGameCalendar::Date new_date = TimerGameCalendar::ConvertYMDToDate(new_year, ymd.month, ymd.day);
 
 	/* Shift cached dates before we change the date. */

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1442,8 +1442,7 @@ DEF_CONSOLE_CMD(ConGetDate)
 		return true;
 	}
 
-	TimerGameCalendar::YearMonthDay ymd;
-	TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date, &ymd);
+	TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date);
 	IConsolePrint(CC_DEFAULT, "Date: {:04d}-{:02d}-{:02d}", ymd.year, ymd.month + 1, ymd.day);
 	return true;
 }

--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -57,8 +57,7 @@ static void SurveyRecentNews(nlohmann::json &json)
 
 	int i = 0;
 	for (NewsItem *news = _latest_news; i < 32 && news != nullptr; news = news->prev, i++) {
-		TimerGameCalendar::YearMonthDay ymd;
-		TimerGameCalendar::ConvertDateToYMD(news->date, &ymd);
+		TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(news->date);
 		json.push_back(fmt::format("({}-{:02}-{:02}) StringID: {}, Type: {}, Ref1: {}, {}, Ref2: {}, {}",
 		               ymd.year, ymd.month + 1, ymd.day, news->string_id, news->type,
 		               news->reftype1, news->ref1, news->reftype2, news->ref2));

--- a/src/date_gui.cpp
+++ b/src/date_gui.cpp
@@ -51,7 +51,7 @@ struct SetDateWindow : Window {
 		this->InitNested(window_number);
 
 		if (initial_date == 0) initial_date = TimerGameCalendar::date;
-		TimerGameCalendar::ConvertDateToYMD(initial_date, &this->date);
+		this->date = TimerGameCalendar::ConvertDateToYMD(initial_date);
 		this->date.year = Clamp(this->date.year, min_year, max_year);
 	}
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -663,8 +663,7 @@ void SetYearEngineAgingStops()
 		if (e->type == VEH_TRAIN && e->u.rail.railveh_type == RAILVEH_WAGON) continue;
 
 		/* Base year ending date on half the model life */
-		TimerGameCalendar::YearMonthDay ymd;
-		TimerGameCalendar::ConvertDateToYMD(ei->base_intro + (ei->lifelength.base() * CalendarTime::DAYS_IN_LEAP_YEAR) / 2, &ymd);
+		TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(ei->base_intro + (ei->lifelength.base() * CalendarTime::DAYS_IN_LEAP_YEAR) / 2);
 
 		_year_engine_aging_stops = std::max(_year_engine_aging_stops, ymd.year);
 	}

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -609,8 +609,7 @@ byte GetSnowLine()
 {
 	if (_snow_line == nullptr) return _settings_game.game_creation.snow_line_height;
 
-	TimerGameCalendar::YearMonthDay ymd;
-	TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date, &ymd);
+	TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date);
 	return _snow_line->table[ymd.month][ymd.day];
 }
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -381,8 +381,7 @@ protected:
 			if (const NWidgetBase *nwid = this->GetWidget<NWidgetBase>(WID_NG_DATE); nwid->current_x != 0) {
 				/* current date */
 				Rect date = nwid->GetCurrentRect();
-				TimerGameCalendar::YearMonthDay ymd;
-				TimerGameCalendar::ConvertDateToYMD(cur_item->info.game_date, &ymd);
+				TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(cur_item->info.game_date);
 				SetDParam(0, ymd.year);
 				DrawString(date.left, date.right, y + text_y_offset, STR_JUST_INT, TC_BLACK, SA_HOR_CENTER);
 			}
@@ -390,9 +389,8 @@ protected:
 			if (const NWidgetBase *nwid = this->GetWidget<NWidgetBase>(WID_NG_YEARS); nwid->current_x != 0) {
 				/* number of years the game is running */
 				Rect years = nwid->GetCurrentRect();
-				TimerGameCalendar::YearMonthDay ymd_cur, ymd_start;
-				TimerGameCalendar::ConvertDateToYMD(cur_item->info.game_date, &ymd_cur);
-				TimerGameCalendar::ConvertDateToYMD(cur_item->info.start_date, &ymd_start);
+				TimerGameCalendar::YearMonthDay ymd_cur = TimerGameCalendar::ConvertDateToYMD(cur_item->info.game_date);
+				TimerGameCalendar::YearMonthDay ymd_start = TimerGameCalendar::ConvertDateToYMD(cur_item->info.start_date);
 				SetDParam(0, ymd_cur.year - ymd_start.year);
 				DrawString(years.left, years.right, y + text_y_offset, STR_JUST_INT, TC_BLACK, SA_HOR_CENTER);
 			}

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -6520,8 +6520,7 @@ bool GetGlobalVariable(byte param, uint32_t *value, const GRFFile *grffile)
 			return true;
 
 		case 0x02: { // detailed date information: month of year (bit 0-7), day of month (bit 8-12), leap year (bit 15), day of year (bit 16-24)
-			TimerGameCalendar::YearMonthDay ymd;
-			TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date, &ymd);
+			TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date);
 			TimerGameCalendar::Date start_of_year = TimerGameCalendar::ConvertYMDToDate(ymd.year, 0, 1);
 			*value = ymd.month | (ymd.day - 1) << 8 | (TimerGameCalendar::IsLeapYear(ymd.year) ? 1 << 15 : 0) | (TimerGameCalendar::date - start_of_year).base() << 16;
 			return true;

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -844,8 +844,7 @@ static bool LoadOldIndustry(LoadgameState *ls, int num)
 			if (i->type > 0x06) i->type++; // Printing Works were added
 			if (i->type == 0x0A) i->type = 0x12; // Iron Ore Mine has different ID
 
-			TimerGameCalendar::YearMonthDay ymd;
-			TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date, &ymd);
+			TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date);
 			i->last_prod_year = ymd.year;
 
 			i->random_colour = RemapTTOColour(i->random_colour);

--- a/src/script/api/script_date.cpp
+++ b/src/script/api/script_date.cpp
@@ -29,8 +29,7 @@
 {
 	if (date < 0) return DATE_INVALID;
 
-	::TimerGameCalendar::YearMonthDay ymd;
-	::TimerGameCalendar::ConvertDateToYMD(date, &ymd);
+	::TimerGameCalendar::YearMonthDay ymd = ::TimerGameCalendar::ConvertDateToYMD(date);
 	return ymd.year.base();
 }
 
@@ -38,8 +37,7 @@
 {
 	if (date < 0) return DATE_INVALID;
 
-	::TimerGameCalendar::YearMonthDay ymd;
-	::TimerGameCalendar::ConvertDateToYMD(date, &ymd);
+	::TimerGameCalendar::YearMonthDay ymd = ::TimerGameCalendar::ConvertDateToYMD(date);
 	return ymd.month + 1;
 }
 
@@ -47,8 +45,7 @@
 {
 	if (date < 0) return DATE_INVALID;
 
-	::TimerGameCalendar::YearMonthDay ymd;
-	::TimerGameCalendar::ConvertDateToYMD(date, &ymd);
+	::TimerGameCalendar::YearMonthDay ymd = ::TimerGameCalendar::ConvertDateToYMD(date);
 	return ymd.day;
 }
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -483,8 +483,7 @@ static void FormatBytes(StringBuilder &builder, int64_t number)
 
 static void FormatYmdString(StringBuilder &builder, TimerGameCalendar::Date date, uint case_index)
 {
-	TimerGameCalendar::YearMonthDay ymd;
-	TimerGameCalendar::ConvertDateToYMD(date, &ymd);
+	TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(date);
 
 	auto tmp_params = MakeParameters(ymd.day + STR_DAY_NUMBER_1ST - 1, STR_MONTH_ABBREV_JAN + ymd.month, ymd.year);
 	FormatString(builder, GetStringPtr(STR_FORMAT_DATE_LONG), tmp_params, case_index);
@@ -492,8 +491,7 @@ static void FormatYmdString(StringBuilder &builder, TimerGameCalendar::Date date
 
 static void FormatMonthAndYear(StringBuilder &builder, TimerGameCalendar::Date date, uint case_index)
 {
-	TimerGameCalendar::YearMonthDay ymd;
-	TimerGameCalendar::ConvertDateToYMD(date, &ymd);
+	TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(date);
 
 	auto tmp_params = MakeParameters(STR_MONTH_JAN + ymd.month, ymd.year);
 	FormatString(builder, GetStringPtr(STR_FORMAT_DATE_SHORT), tmp_params, case_index);
@@ -501,8 +499,7 @@ static void FormatMonthAndYear(StringBuilder &builder, TimerGameCalendar::Date d
 
 static void FormatTinyOrISODate(StringBuilder &builder, TimerGameCalendar::Date date, StringID str)
 {
-	TimerGameCalendar::YearMonthDay ymd;
-	TimerGameCalendar::ConvertDateToYMD(date, &ymd);
+	TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(date);
 
 	/* Day and month are zero-padded with ZEROFILL_NUM, hence the two 2s. */
 	auto tmp_params = MakeParameters(ymd.day, 2, ymd.month + 1, 2, ymd.year);

--- a/src/subsidy_gui.cpp
+++ b/src/subsidy_gui.cpp
@@ -142,8 +142,7 @@ struct SubsidyListWindow : Window {
 	{
 		if (widget != WID_SUL_PANEL) return;
 
-		TimerGameCalendar::YearMonthDay ymd;
-		TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date, &ymd);
+		TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date);
 
 		Rect tr = r.Shrink(WidgetDimensions::scaled.framerect);
 

--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -311,8 +311,7 @@ void SurveyTimers(nlohmann::json &survey)
 	survey["ticks"] = TimerGameTick::counter;
 	survey["seconds"] = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - _switch_mode_time).count();
 
-	TimerGameCalendar::YearMonthDay ymd;
-	TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date, &ymd);
+	TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date);
 	survey["calendar"] = fmt::format("{:04}-{:02}-{:02} ({})", ymd.year, ymd.month + 1, ymd.day, TimerGameCalendar::date_fract);
 }
 

--- a/src/timer/timer_game_calendar.cpp
+++ b/src/timer/timer_game_calendar.cpp
@@ -66,9 +66,9 @@ static const uint16_t _accum_days_for_month[] = {
 /**
  * Converts a Date to a Year, Month & Day.
  * @param date the date to convert from
- * @param ymd  the year, month and day to write to
+ * @returns YearMonthDay representation of the Date.
  */
-/* static */ void TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::Date date, TimerGameCalendar::YearMonthDay *ymd)
+/* static */ TimerGameCalendar::YearMonthDay TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::Date date)
 {
 	/* Year determination in multiple steps to account for leap
 	 * years. First do the large steps, then the smaller ones.
@@ -77,7 +77,6 @@ static const uint16_t _accum_days_for_month[] = {
 	/* There are 97 leap years in 400 years */
 	TimerGameCalendar::Year yr = 400 * (date.base() / (CalendarTime::DAYS_IN_YEAR * 400 + 97));
 	int rem = date.base() % (CalendarTime::DAYS_IN_YEAR * 400 + 97);
-	uint16_t x;
 
 	if (rem >= CalendarTime::DAYS_IN_YEAR * 100 + 25) {
 		/* There are 25 leap years in the first 100 years after
@@ -110,11 +109,13 @@ static const uint16_t _accum_days_for_month[] = {
 	/* Skip the 29th of February in non-leap years */
 	if (!TimerGameCalendar::IsLeapYear(yr) && rem >= ACCUM_MAR - 1) rem++;
 
-	ymd->year = yr;
+	uint16_t x = _month_date_from_year_day[rem];
 
-	x = _month_date_from_year_day[rem];
-	ymd->month = x >> 5;
-	ymd->day = x & 0x1F;
+	YearMonthDay ymd;
+	ymd.year = yr;
+	ymd.month = x >> 5;
+	ymd.day = x & 0x1F;
+	return ymd;
 }
 
 /**
@@ -153,11 +154,9 @@ static const uint16_t _accum_days_for_month[] = {
 {
 	assert(fract < Ticks::DAY_TICKS);
 
-	TimerGameCalendar::YearMonthDay ymd;
-
 	TimerGameCalendar::date = date;
 	TimerGameCalendar::date_fract = fract;
-	TimerGameCalendar::ConvertDateToYMD(date, &ymd);
+	TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(date);
 	TimerGameCalendar::year = ymd.year;
 	TimerGameCalendar::month = ymd.month;
 }
@@ -195,8 +194,7 @@ void TimerManager<TimerGameCalendar>::Elapsed([[maybe_unused]] TimerGameCalendar
 	/* increase day counter */
 	TimerGameCalendar::date++;
 
-	TimerGameCalendar::YearMonthDay ymd;
-	TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date, &ymd);
+	TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date);
 
 	/* check if we entered a new month? */
 	bool new_month = ymd.month != TimerGameCalendar::month;

--- a/src/timer/timer_game_calendar.h
+++ b/src/timer/timer_game_calendar.h
@@ -101,7 +101,7 @@ public:
 	};
 
 	static bool IsLeapYear(Year yr);
-	static void ConvertDateToYMD(Date date, YearMonthDay * ymd);
+	static YearMonthDay ConvertDateToYMD(Date date);
 	static Date ConvertYMDToDate(Year year, Month month, Day day);
 	static void SetDate(Date date, DateFract fract);
 


### PR DESCRIPTION
## Motivation / Problem

`TimerGameCalendar::ConvertDateToYMD()` is awkward to use as we need to create a `YearMonthDay` variable and pass it as a pointer to be an output variable. This feels like a left-over from when the code was C.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, make `ConvertDateToYMD()` just return a `YearMonthDay` itself.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
