### PR TITLE
Codechange: Replace C-style nested array with std::map for widget lookup.

### DIFF
--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -107,11 +107,9 @@ struct GraphLegendWindow : Window {
 
 /**
  * Construct a vertical list of buttons, one for each company.
- * @param biggest_index Storage for collecting the biggest index used in the returned tree.
  * @return Panel with company buttons.
- * @post \c *biggest_index contains the largest used index in the tree.
  */
-static NWidgetBase *MakeNWidgetCompanyLines(int *biggest_index)
+static NWidgetBase *MakeNWidgetCompanyLines()
 {
 	NWidgetVertical *vert = new NWidgetVertical(NC_EQUALSIZE);
 	vert->SetPadding(2, 2, 2, 2);
@@ -125,7 +123,6 @@ static NWidgetBase *MakeNWidgetCompanyLines(int *biggest_index)
 		panel->SetDataTip(0x0, STR_GRAPH_KEY_COMPANY_SELECTION_TOOLTIP);
 		vert->Add(panel);
 	}
-	*biggest_index = WID_GL_LAST_COMPANY;
 	return vert;
 }
 
@@ -1338,11 +1335,9 @@ CompanyID PerformanceRatingDetailWindow::company = INVALID_COMPANY;
 
 /**
  * Make a vertical list of panels for outputting score details.
- * @param biggest_index Storage for collecting the biggest index used in the returned tree.
  * @return Panel with performance details.
- * @post \c *biggest_index contains the largest used index in the tree.
  */
-static NWidgetBase *MakePerformanceDetailPanels(int *biggest_index)
+static NWidgetBase *MakePerformanceDetailPanels()
 {
 	const StringID performance_tips[] = {
 		STR_PERFORMANCE_DETAIL_VEHICLES_TOOLTIP,
@@ -1366,14 +1361,13 @@ static NWidgetBase *MakePerformanceDetailPanels(int *biggest_index)
 		panel->SetDataTip(0x0, performance_tips[widnum - WID_PRD_SCORE_FIRST]);
 		vert->Add(panel);
 	}
-	*biggest_index = WID_PRD_SCORE_LAST;
 	return vert;
 }
 
 /** Make a number of rows with buttons for each company for the performance rating detail window. */
-NWidgetBase *MakeCompanyButtonRowsGraphGUI(int *biggest_index)
+NWidgetBase *MakeCompanyButtonRowsGraphGUI()
 {
-	return MakeCompanyButtonRows(biggest_index, WID_PRD_COMPANY_FIRST, WID_PRD_COMPANY_LAST, COLOUR_BROWN, 8, STR_PERFORMANCE_DETAIL_SELECT_COMPANY_TOOLTIP);
+	return MakeCompanyButtonRows(WID_PRD_COMPANY_FIRST, WID_PRD_COMPANY_LAST, COLOUR_BROWN, 8, STR_PERFORMANCE_DETAIL_SELECT_COMPANY_TOOLTIP);
 }
 
 static const NWidgetPart _nested_performance_rating_detail_widgets[] = {

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -454,12 +454,12 @@ void LinkGraphOverlay::SetCompanyMask(CompanyMask company_mask)
 }
 
 /** Make a number of rows with buttons for each company for the linkgraph legend window. */
-NWidgetBase *MakeCompanyButtonRowsLinkGraphGUI(int *biggest_index)
+NWidgetBase *MakeCompanyButtonRowsLinkGraphGUI()
 {
-	return MakeCompanyButtonRows(biggest_index, WID_LGL_COMPANY_FIRST, WID_LGL_COMPANY_LAST, COLOUR_GREY, 3, STR_NULL);
+	return MakeCompanyButtonRows(WID_LGL_COMPANY_FIRST, WID_LGL_COMPANY_LAST, COLOUR_GREY, 3, STR_NULL);
 }
 
-NWidgetBase *MakeSaturationLegendLinkGraphGUI(int *biggest_index)
+NWidgetBase *MakeSaturationLegendLinkGraphGUI()
 {
 	NWidgetVertical *panel = new NWidgetVertical(NC_EQUALSIZE);
 	for (uint i = 0; i < lengthof(LinkGraphOverlay::LINK_COLOURS[0]); ++i) {
@@ -470,11 +470,10 @@ NWidgetBase *MakeSaturationLegendLinkGraphGUI(int *biggest_index)
 		wid->SetResize(0, 0);
 		panel->Add(wid);
 	}
-	*biggest_index = WID_LGL_SATURATION_LAST;
 	return panel;
 }
 
-NWidgetBase *MakeCargoesLegendLinkGraphGUI(int *biggest_index)
+NWidgetBase *MakeCargoesLegendLinkGraphGUI()
 {
 	uint num_cargo = static_cast<uint>(_sorted_cargo_specs.size());
 	static const uint ENTRIES_PER_COL = 5;
@@ -503,7 +502,6 @@ NWidgetBase *MakeCargoesLegendLinkGraphGUI(int *biggest_index)
 	}
 	/* If there are no cargo specs defined, then col won't have been created so don't add it. */
 	if (col != nullptr) panel->Add(col);
-	*biggest_index = WID_LGL_CARGO_LAST;
 	return panel;
 }
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -855,9 +855,8 @@ GUIGameServerList::FilterFunction * const NetworkGameWindow::filter_funcs[] = {
 	&NGameSearchFilter
 };
 
-static NWidgetBase *MakeResizableHeader(int *biggest_index)
+static NWidgetBase *MakeResizableHeader()
 {
-	*biggest_index = std::max<int>(*biggest_index, WID_NG_INFO);
 	return new NWidgetServerListHeader();
 }
 

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1937,16 +1937,11 @@ static const NWidgetPart _nested_newgrf_infopanel_widgets[] = {
 };
 
 /** Construct nested container widget for managing the lists and the info panel of the NewGRF GUI. */
-NWidgetBase* NewGRFDisplay(int *biggest_index)
+NWidgetBase* NewGRFDisplay()
 {
-	NWidgetBase *avs = MakeNWidgets(std::begin(_nested_newgrf_availables_widgets), std::end(_nested_newgrf_availables_widgets), biggest_index, nullptr);
-
-	int biggest2;
-	NWidgetBase *acs = MakeNWidgets(std::begin(_nested_newgrf_actives_widgets), std::end(_nested_newgrf_actives_widgets), &biggest2, nullptr);
-	*biggest_index = std::max(*biggest_index, biggest2);
-
-	NWidgetBase *inf = MakeNWidgets(std::begin(_nested_newgrf_infopanel_widgets), std::end(_nested_newgrf_infopanel_widgets), &biggest2, nullptr);
-	*biggest_index = std::max(*biggest_index, biggest2);
+	NWidgetBase *avs = MakeNWidgets(std::begin(_nested_newgrf_availables_widgets), std::end(_nested_newgrf_availables_widgets), nullptr);
+	NWidgetBase *acs = MakeNWidgets(std::begin(_nested_newgrf_actives_widgets), std::end(_nested_newgrf_actives_widgets), nullptr);
+	NWidgetBase *inf = MakeNWidgets(std::begin(_nested_newgrf_infopanel_widgets), std::end(_nested_newgrf_infopanel_widgets), nullptr);
 
 	return new NWidgetNewGRFDisplay(avs, acs, inf);
 }

--- a/src/osk_gui.cpp
+++ b/src/osk_gui.cpp
@@ -220,10 +220,9 @@ static const int KEY_PADDING = 6;     // Vertical padding for remaining key rows
  * @param widtype Widget type of the key. Must be either \c NWID_SPACER for an invisible key, or a \c WWT_* widget.
  * @param widnum  Widget number of the key.
  * @param widdata Data value of the key widget.
- * @param biggest_index Collected biggest widget index so far.
  * @note Key width is measured in 1/2 keys to allow for 1/2 key shifting between rows.
  */
-static void AddKey(NWidgetHorizontal *hor, int pad_y, int num_half, WidgetType widtype, int widnum, uint16_t widdata, int *biggest_index)
+static void AddKey(NWidgetHorizontal *hor, int pad_y, int num_half, WidgetType widtype, int widnum, uint16_t widdata)
 {
 	int key_width = HALF_KEY_WIDTH + (INTER_KEY_SPACE + HALF_KEY_WIDTH) * (num_half - 1);
 
@@ -243,80 +242,78 @@ static void AddKey(NWidgetHorizontal *hor, int pad_y, int num_half, WidgetType w
 		leaf->SetMinimalTextLines(1, pad_y, FS_NORMAL);
 		hor->Add(leaf);
 	}
-
-	*biggest_index = std::max(*biggest_index, widnum);
 }
 
 /** Construct the top row keys (cancel, ok, backspace). */
-static NWidgetBase *MakeTopKeys(int *biggest_index)
+static NWidgetBase *MakeTopKeys()
 {
 	NWidgetHorizontal *hor = new NWidgetHorizontal();
 
-	AddKey(hor, TOP_KEY_PADDING, 6 * 2, WWT_TEXTBTN,    WID_OSK_CANCEL,    STR_BUTTON_CANCEL, biggest_index);
-	AddKey(hor, TOP_KEY_PADDING, 6 * 2, WWT_TEXTBTN,    WID_OSK_OK,        STR_BUTTON_OK,     biggest_index);
-	AddKey(hor, TOP_KEY_PADDING, 2 * 2, WWT_PUSHIMGBTN, WID_OSK_BACKSPACE, SPR_OSK_BACKSPACE, biggest_index);
+	AddKey(hor, TOP_KEY_PADDING, 6 * 2, WWT_TEXTBTN,    WID_OSK_CANCEL,    STR_BUTTON_CANCEL);
+	AddKey(hor, TOP_KEY_PADDING, 6 * 2, WWT_TEXTBTN,    WID_OSK_OK,        STR_BUTTON_OK    );
+	AddKey(hor, TOP_KEY_PADDING, 2 * 2, WWT_PUSHIMGBTN, WID_OSK_BACKSPACE, SPR_OSK_BACKSPACE);
 	return hor;
 }
 
 /** Construct the row containing the digit keys. */
-static NWidgetBase *MakeNumberKeys(int *biggest_index)
+static NWidgetBase *MakeNumberKeys()
 {
 	NWidgetHorizontal *hor = new NWidgetHorizontalLTR();
 
 	for (int widnum = WID_OSK_NUMBERS_FIRST; widnum <= WID_OSK_NUMBERS_LAST; widnum++) {
-		AddKey(hor, KEY_PADDING, 2, WWT_PUSHBTN, widnum, 0x0, biggest_index);
+		AddKey(hor, KEY_PADDING, 2, WWT_PUSHBTN, widnum, 0x0);
 	}
 	return hor;
 }
 
 /** Construct the qwerty row keys. */
-static NWidgetBase *MakeQwertyKeys(int *biggest_index)
+static NWidgetBase *MakeQwertyKeys()
 {
 	NWidgetHorizontal *hor = new NWidgetHorizontalLTR();
 
-	AddKey(hor, KEY_PADDING, 3, WWT_PUSHIMGBTN, WID_OSK_SPECIAL, SPR_OSK_SPECIAL, biggest_index);
+	AddKey(hor, KEY_PADDING, 3, WWT_PUSHIMGBTN, WID_OSK_SPECIAL, SPR_OSK_SPECIAL);
 	for (int widnum = WID_OSK_QWERTY_FIRST; widnum <= WID_OSK_QWERTY_LAST; widnum++) {
-		AddKey(hor, KEY_PADDING, 2, WWT_PUSHBTN, widnum, 0x0, biggest_index);
+		AddKey(hor, KEY_PADDING, 2, WWT_PUSHBTN, widnum, 0x0);
 	}
-	AddKey(hor, KEY_PADDING, 1, NWID_SPACER, 0, 0, biggest_index);
+	AddKey(hor, KEY_PADDING, 1, NWID_SPACER, 0, 0);
 	return hor;
 }
 
 /** Construct the asdfg row keys. */
-static NWidgetBase *MakeAsdfgKeys(int *biggest_index)
+static NWidgetBase *MakeAsdfgKeys()
 {
 	NWidgetHorizontal *hor = new NWidgetHorizontalLTR();
 
-	AddKey(hor, KEY_PADDING, 4, WWT_IMGBTN, WID_OSK_CAPS, SPR_OSK_CAPS, biggest_index);
+	AddKey(hor, KEY_PADDING, 4, WWT_IMGBTN, WID_OSK_CAPS, SPR_OSK_CAPS);
 	for (int widnum = WID_OSK_ASDFG_FIRST; widnum <= WID_OSK_ASDFG_LAST; widnum++) {
-		AddKey(hor, KEY_PADDING, 2, WWT_PUSHBTN, widnum, 0x0, biggest_index);
+		AddKey(hor, KEY_PADDING, 2, WWT_PUSHBTN, widnum, 0x0);
 	}
 	return hor;
 }
 
 /** Construct the zxcvb row keys. */
-static NWidgetBase *MakeZxcvbKeys(int *biggest_index)
+static NWidgetBase *MakeZxcvbKeys()
 {
 	NWidgetHorizontal *hor = new NWidgetHorizontalLTR();
 
-	AddKey(hor, KEY_PADDING, 3, WWT_IMGBTN, WID_OSK_SHIFT, SPR_OSK_SHIFT, biggest_index);
+	AddKey(hor, KEY_PADDING, 3, WWT_IMGBTN, WID_OSK_SHIFT, SPR_OSK_SHIFT);
 	for (int widnum = WID_OSK_ZXCVB_FIRST; widnum <= WID_OSK_ZXCVB_LAST; widnum++) {
-		AddKey(hor, KEY_PADDING, 2, WWT_PUSHBTN, widnum, 0x0, biggest_index);
+		AddKey(hor, KEY_PADDING, 2, WWT_PUSHBTN, widnum, 0x0);
 	}
-	AddKey(hor, KEY_PADDING, 1, NWID_SPACER, 0, 0, biggest_index);
+	AddKey(hor, KEY_PADDING, 1, NWID_SPACER, 0, 0);
 	return hor;
 }
 
 /** Construct the spacebar row keys. */
-static NWidgetBase *MakeSpacebarKeys(int *biggest_index)
+static NWidgetBase *MakeSpacebarKeys()
 {
 	NWidgetHorizontal *hor = new NWidgetHorizontal();
 
-	AddKey(hor, KEY_PADDING,  8, NWID_SPACER, 0, 0, biggest_index);
-	AddKey(hor, KEY_PADDING, 13, WWT_PUSHTXTBTN, WID_OSK_SPACE, STR_EMPTY, biggest_index);
-	AddKey(hor, KEY_PADDING,  3, NWID_SPACER, 0, 0, biggest_index);
-	AddKey(hor, KEY_PADDING,  2, WWT_PUSHIMGBTN, WID_OSK_LEFT,  SPR_OSK_LEFT, biggest_index);
-	AddKey(hor, KEY_PADDING,  2, WWT_PUSHIMGBTN, WID_OSK_RIGHT, SPR_OSK_RIGHT, biggest_index);
+	AddKey(hor, KEY_PADDING,  8, NWID_SPACER, 0, 0);
+	AddKey(hor, KEY_PADDING, 13, WWT_PUSHTXTBTN, WID_OSK_SPACE, STR_EMPTY);
+	AddKey(hor, KEY_PADDING,  3, NWID_SPACER, 0, 0);
+	AddKey(hor, KEY_PADDING,  2, WWT_PUSHIMGBTN, WID_OSK_LEFT,  SPR_OSK_LEFT);
+	AddKey(hor, KEY_PADDING,  2, WWT_PUSHIMGBTN, WID_OSK_RIGHT, SPR_OSK_RIGHT);
 	return hor;
 }
 

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -1229,9 +1229,9 @@ struct ScriptDebugWindow : public Window {
 };
 
 /** Make a number of rows with buttons for each company for the Script debug window. */
-NWidgetBase *MakeCompanyButtonRowsScriptDebug(int *biggest_index)
+NWidgetBase *MakeCompanyButtonRowsScriptDebug()
 {
-	return MakeCompanyButtonRows(biggest_index, WID_SCRD_COMPANY_BUTTON_START, WID_SCRD_COMPANY_BUTTON_END, COLOUR_GREY, 8, STR_AI_DEBUG_SELECT_AI_TOOLTIP);
+	return MakeCompanyButtonRows(WID_SCRD_COMPANY_BUTTON_START, WID_SCRD_COMPANY_BUTTON_END, COLOUR_GREY, 8, STR_AI_DEBUG_SELECT_AI_TOOLTIP);
 }
 
 /** Widgets for the Script debug window. */

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -1942,12 +1942,12 @@ static const NWidgetPart _nested_smallmap_bar[] = {
 	EndContainer(),
 };
 
-static NWidgetBase *SmallMapDisplay(int *biggest_index)
+static NWidgetBase *SmallMapDisplay()
 {
 	NWidgetContainer *map_display = new NWidgetSmallmapDisplay;
 
-	MakeNWidgets(std::begin(_nested_smallmap_display), std::end(_nested_smallmap_display), biggest_index, map_display);
-	MakeNWidgets(std::begin(_nested_smallmap_bar), std::end(_nested_smallmap_bar), biggest_index, map_display);
+	MakeNWidgets(std::begin(_nested_smallmap_display), std::end(_nested_smallmap_display), map_display);
+	MakeNWidgets(std::begin(_nested_smallmap_bar), std::end(_nested_smallmap_bar), map_display);
 	return map_display;
 }
 

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -714,10 +714,9 @@ const StringID CompanyStationsWindow::sorter_names[] = {
 
 /**
  * Make a horizontal row of cargo buttons, starting at widget #WID_STL_CARGOSTART.
- * @param biggest_index Pointer to store biggest used widget number of the buttons.
  * @return Horizontal row.
  */
-static NWidgetBase *CargoWidgets(int *biggest_index)
+static NWidgetBase *CargoWidgets()
 {
 	NWidgetHorizontal *container = new NWidgetHorizontal();
 
@@ -730,7 +729,6 @@ static NWidgetBase *CargoWidgets(int *biggest_index)
 		panel->SetDataTip(0, STR_STATION_LIST_USE_CTRL_TO_SELECT_MORE);
 		container->Add(panel);
 	}
-	*biggest_index = WID_STL_CARGOSTART + static_cast<int>(_sorted_standard_cargo_specs.size());
 	return container;
 }
 

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -646,9 +646,9 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 
 	void OnTimeout() override
 	{
-		for (uint i = WID_ETT_START; i < this->nested_array_size; i++) {
-			if (i == WID_ETT_BUTTONS_START) i = WID_ETT_BUTTONS_END; // skip the buttons
-			this->RaiseWidgetWhenLowered(i);
+		for (const auto &pair : this->widget_lookup) {
+			if (pair.first < WID_ETT_START || (pair.first >= WID_ETT_BUTTONS_START && pair.first < WID_ETT_BUTTONS_END)) continue; // skip the buttons
+			this->RaiseWidgetWhenLowered(pair.first);
 		}
 	}
 

--- a/src/tests/test_window_desc.cpp
+++ b/src/tests/test_window_desc.cpp
@@ -89,11 +89,10 @@ TEST_CASE_METHOD(WindowDescTestsFixture, "WindowDesc - NWidgetPart validity")
 
 	INFO(fmt::format("{}:{}", window_desc->file, window_desc->line));
 
-	int biggest_index = -1;
 	NWidgetStacked *shade_select = nullptr;
 	NWidgetBase *root = nullptr;
 
-	REQUIRE_NOTHROW(root = MakeWindowNWidgetTree(window_desc->nwid_begin, window_desc->nwid_end, &biggest_index, &shade_select));
+	REQUIRE_NOTHROW(root = MakeWindowNWidgetTree(window_desc->nwid_begin, window_desc->nwid_end, &shade_select));
 	CHECK((root != nullptr));
 	delete root;
 }

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2120,7 +2120,7 @@ struct MainToolbarWindow : Window {
 	}};
 };
 
-static NWidgetBase *MakeMainToolbar(int *biggest_index)
+static NWidgetBase *MakeMainToolbar()
 {
 	/** Sprites to use for the different toolbar buttons */
 	static const SpriteID toolbar_button_sprites[] = {
@@ -2174,7 +2174,6 @@ static NWidgetBase *MakeMainToolbar(int *biggest_index)
 		hor->Add(leaf);
 	}
 
-	*biggest_index = std::max<int>(*biggest_index, WID_TN_SWITCH_BAR);
 	return hor;
 }
 
@@ -2513,9 +2512,9 @@ static const NWidgetPart _nested_toolb_scen_inner_widgets[] = {
 	NWidget(WWT_IMGBTN, COLOUR_GREY, WID_TE_SWITCH_BAR), SetDataTip(SPR_IMG_SWITCH_TOOLBAR, STR_TOOLBAR_TOOLTIP_SWITCH_TOOLBAR),
 };
 
-static NWidgetBase *MakeScenarioToolbar(int *biggest_index)
+static NWidgetBase *MakeScenarioToolbar()
 {
-	return MakeNWidgets(std::begin(_nested_toolb_scen_inner_widgets), std::end(_nested_toolb_scen_inner_widgets), biggest_index, new NWidgetScenarioToolbarContainer());
+	return MakeNWidgets(std::begin(_nested_toolb_scen_inner_widgets), std::end(_nested_toolb_scen_inner_widgets), new NWidgetScenarioToolbarContainer());
 }
 
 static const NWidgetPart _nested_toolb_scen_widgets[] = {

--- a/src/tree_gui.cpp
+++ b/src/tree_gui.cpp
@@ -256,7 +256,7 @@ public:
  * get producing the correct result than dynamically building the widgets is.
  * @see NWidgetFunctionType
  */
-static NWidgetBase *MakeTreeTypeButtons(int *biggest_index)
+static NWidgetBase *MakeTreeTypeButtons()
 {
 	const byte type_base = _tree_base_by_landscape[_settings_game.game_creation.landscape];
 	const byte type_count = _tree_count_by_landscape[_settings_game.game_creation.landscape];
@@ -278,7 +278,6 @@ static NWidgetBase *MakeTreeTypeButtons(int *biggest_index)
 			NWidgetBackground *button = new NWidgetBackground(WWT_PANEL, COLOUR_GREY, WID_BT_TYPE_BUTTON_FIRST + cur_type);
 			button->SetDataTip(0x0, STR_PLANT_TREE_TOOLTIP);
 			hstack->Add(button);
-			*biggest_index = WID_BT_TYPE_BUTTON_FIRST + cur_type;
 			cur_type++;
 		}
 	}

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -903,7 +903,7 @@ void Window::DrawSortButtonState(int widget, SortButtonState state) const
 {
 	if (state == SBS_OFF) return;
 
-	assert(this->nested_array != nullptr);
+	assert(this->widget_lookup != nullptr);
 	Rect r = this->GetWidget<NWidgetBase>(widget)->GetCurrentRect();
 
 	/* Sort button uses the same sprites as vertical scrollbar */
@@ -1023,8 +1023,8 @@ NWidgetBase::NWidgetBase(WidgetType tp) : ZeroedMemoryAllocator()
  */
 
 /**
- * @fn void NWidgetBase::FillNestedArray(NWidgetBase **array, uint length)
- * Fill the Window::nested_array array with pointers to nested widgets in the tree.
+ * @fn void NWidgetBase::FillWidgetLookup(NWidgetBase **widget_lookup, uint length)
+ * Fill the Window::widget_lookup array with pointers to nested widgets in the tree.
  * @param array Base pointer of the array.
  * @param length Length of the array.
  */
@@ -1276,9 +1276,9 @@ void NWidgetCore::SetAlignment(StringAlignment align)
 	this->align = align;
 }
 
-void NWidgetCore::FillNestedArray(NWidgetBase **array, uint length)
+void NWidgetCore::FillWidgetLookup(NWidgetBase **widget_lookup, uint length)
 {
-	if (this->index >= 0 && (uint)(this->index) < length) array[this->index] = this;
+	if (this->index >= 0 && (uint)(this->index) < length) widget_lookup[this->index] = this;
 }
 
 NWidgetCore *NWidgetCore::GetWidgetFromPos(int x, int y)
@@ -1345,10 +1345,10 @@ void NWidgetContainer::Add(NWidgetBase *wid)
 	}
 }
 
-void NWidgetContainer::FillNestedArray(NWidgetBase **array, uint length)
+void NWidgetContainer::FillWidgetLookup(NWidgetBase **widget_lookup, uint length)
 {
 	for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
-		child_wid->FillNestedArray(array, length);
+		child_wid->FillWidgetLookup(widget_lookup, length);
 	}
 }
 
@@ -1452,10 +1452,10 @@ void NWidgetStacked::AssignSizePosition(SizingType sizing, int x, int y, uint gi
 	}
 }
 
-void NWidgetStacked::FillNestedArray(NWidgetBase **array, uint length)
+void NWidgetStacked::FillWidgetLookup(NWidgetBase **widget_lookup, uint length)
 {
-	if (this->index >= 0 && (uint)(this->index) < length) array[this->index] = this;
-	NWidgetContainer::FillNestedArray(array, length);
+	if (this->index >= 0 && (uint)(this->index) < length) widget_lookup[this->index] = this;
+	NWidgetContainer::FillWidgetLookup(widget_lookup, length);
 }
 
 void NWidgetStacked::Draw(const Window *w)
@@ -1925,7 +1925,7 @@ void NWidgetSpacer::SetupSmallestSize(Window *)
 	this->smallest_y = this->min_y;
 }
 
-void NWidgetSpacer::FillNestedArray(NWidgetBase **, uint)
+void NWidgetSpacer::FillWidgetLookup(NWidgetBase **, uint)
 {
 }
 
@@ -2065,10 +2065,10 @@ void NWidgetMatrix::AssignSizePosition(SizingType, int x, int y, uint given_widt
 	this->SetCount(this->count);
 }
 
-void NWidgetMatrix::FillNestedArray(NWidgetBase **array, uint length)
+void NWidgetMatrix::FillWidgetLookup(NWidgetBase **widget_lookup, uint length)
 {
-	if (this->index >= 0 && (uint)(this->index) < length) array[this->index] = this;
-	NWidgetContainer::FillNestedArray(array, length);
+	if (this->index >= 0 && (uint)(this->index) < length) widget_lookup[this->index] = this;
+	NWidgetContainer::FillWidgetLookup(widget_lookup, length);
 }
 
 NWidgetCore *NWidgetMatrix::GetWidgetFromPos(int x, int y)
@@ -2335,10 +2335,10 @@ void NWidgetBackground::AssignSizePosition(SizingType sizing, int x, int y, uint
 	}
 }
 
-void NWidgetBackground::FillNestedArray(NWidgetBase **array, uint length)
+void NWidgetBackground::FillWidgetLookup(NWidgetBase **widget_lookup, uint length)
 {
-	if (this->index >= 0 && (uint)(this->index) < length) array[this->index] = this;
-	if (this->child != nullptr) this->child->FillNestedArray(array, length);
+	if (this->index >= 0 && (uint)(this->index) < length) widget_lookup[this->index] = this;
+	if (this->child != nullptr) this->child->FillWidgetLookup(widget_lookup, length);
 }
 
 void NWidgetBackground::Draw(const Window *w)

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -136,7 +136,7 @@ public:
 	virtual void SetupSmallestSize(Window *w) = 0;
 	virtual void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) = 0;
 
-	virtual void FillNestedArray(NWidgetBase **array, uint length) = 0;
+	virtual void FillWidgetLookup(NWidgetBase **widget_lookup, uint length) = 0;
 
 	virtual NWidgetCore *GetWidgetFromPos(int x, int y) = 0;
 	virtual NWidgetBase *GetWidgetOfType(WidgetType tp);
@@ -337,7 +337,7 @@ public:
 	inline void SetDisabled(bool disabled);
 	inline bool IsDisabled() const;
 
-	void FillNestedArray(NWidgetBase **array, uint length) override;
+	void FillWidgetLookup(NWidgetBase **widget_lookup, uint length) override;
 	NWidgetCore *GetWidgetFromPos(int x, int y) override;
 	bool IsHighlighted() const override;
 	TextColour GetHighlightColour() const override;
@@ -419,7 +419,7 @@ public:
 
 	void AdjustPaddingForZoom() override;
 	void Add(NWidgetBase *wid);
-	void FillNestedArray(NWidgetBase **array, uint length) override;
+	void FillWidgetLookup(NWidgetBase **widget_lookup, uint length) override;
 
 	void Draw(const Window *w) override;
 	NWidgetCore *GetWidgetFromPos(int x, int y) override;
@@ -462,7 +462,7 @@ public:
 	void AdjustPaddingForZoom() override;
 	void SetupSmallestSize(Window *w) override;
 	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;
-	void FillNestedArray(NWidgetBase **array, uint length) override;
+	void FillWidgetLookup(NWidgetBase **widget_lookup, uint length) override;
 
 	void Draw(const Window *w) override;
 	NWidgetCore *GetWidgetFromPos(int x, int y) override;
@@ -470,7 +470,7 @@ public:
 	bool SetDisplayedPlane(int plane);
 
 	int shown_plane; ///< Plane being displayed (for #NWID_SELECTION only).
-	int index;       ///< If non-negative, index in the #Window::nested_array.
+	int index;       ///< If non-negative, index in the #Window::widget_lookup.
 };
 
 /** Nested widget container flags, */
@@ -564,12 +564,12 @@ public:
 
 	void SetupSmallestSize(Window *w) override;
 	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;
-	void FillNestedArray(NWidgetBase **array, uint length) override;
+	void FillWidgetLookup(NWidgetBase **widget_lookup, uint length) override;
 
 	NWidgetCore *GetWidgetFromPos(int x, int y) override;
 	void Draw(const Window *w) override;
 protected:
-	int index;      ///< If non-negative, index in the #Window::nested_array.
+	int index;      ///< If non-negative, index in the #Window::widget_lookup.
 	Colours colour; ///< Colour of this widget.
 	int clicked;    ///< The currently clicked widget.
 	int count;      ///< Amount of valid widgets.
@@ -593,7 +593,7 @@ public:
 	NWidgetSpacer(int width, int height);
 
 	void SetupSmallestSize(Window *w) override;
-	void FillNestedArray(NWidgetBase **array, uint length) override;
+	void FillWidgetLookup(NWidgetBase **widget_lookup, uint length) override;
 
 	void Draw(const Window *w) override;
 	void SetDirty(const Window *w) const override;
@@ -617,7 +617,7 @@ public:
 	void SetupSmallestSize(Window *w) override;
 	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;
 
-	void FillNestedArray(NWidgetBase **array, uint length) override;
+	void FillWidgetLookup(NWidgetBase **widget_lookup, uint length) override;
 
 	void Draw(const Window *w) override;
 	NWidgetCore *GetWidgetFromPos(int x, int y) override;

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -260,7 +260,7 @@ public:
 	const NWidgetCore *nested_focus; ///< Currently focused nested widget, or \c nullptr if no nested widget has focus.
 	std::map<int, QueryString*> querystrings; ///< QueryString associated to WWT_EDITBOX widgets.
 	NWidgetBase *nested_root;        ///< Root of the nested tree.
-	NWidgetBase **nested_array;      ///< Array of pointers into the tree. Do not access directly, use #Window::GetWidget() instead.
+	NWidgetBase **widget_lookup;      ///< Array of pointers into the tree. Do not access directly, use #Window::GetWidget() instead.
 	uint nested_array_size;          ///< Size of the nested array.
 	NWidgetStacked *shade_select;    ///< Selection widget (#NWID_SELECTION) to use for shading the window. If \c nullptr, window cannot shade.
 	Dimension unshaded_size;         ///< Last known unshaded size (only valid while shaded).
@@ -329,7 +329,7 @@ public:
 	inline void SetWidgetDisabledState(byte widget_index, bool disab_stat)
 	{
 		assert(widget_index < this->nested_array_size);
-		if (this->nested_array[widget_index] != nullptr) this->GetWidget<NWidgetCore>(widget_index)->SetDisabled(disab_stat);
+		if (this->widget_lookup[widget_index] != nullptr) this->GetWidget<NWidgetCore>(widget_index)->SetDisabled(disab_stat);
 	}
 
 	/**
@@ -520,7 +520,7 @@ public:
 
 	/**
 	 * Notification that the nested widget tree gets initialized. The event can be used to perform general computations.
-	 * @note #nested_root and/or #nested_array (normally accessed via #GetWidget()) may not exist during this call.
+	 * @note #nested_root and/or #widget_lookup (normally accessed via #GetWidget()) may not exist during this call.
 	 */
 	virtual void OnInit() { }
 
@@ -894,8 +894,8 @@ inline bool AllEqual(It begin, It end, Pred pred)
 template <class NWID>
 inline NWID *Window::GetWidget(uint widnum)
 {
-	if (widnum >= this->nested_array_size || this->nested_array[widnum] == nullptr) return nullptr;
-	NWID *nwid = dynamic_cast<NWID *>(this->nested_array[widnum]);
+	if (widnum >= this->nested_array_size || this->widget_lookup[widnum] == nullptr) return nullptr;
+	NWID *nwid = dynamic_cast<NWID *>(this->widget_lookup[widnum]);
 	assert(nwid != nullptr);
 	return nwid;
 }
@@ -905,7 +905,7 @@ template <>
 inline const NWidgetBase *Window::GetWidget<NWidgetBase>(uint widnum) const
 {
 	if (widnum >= this->nested_array_size) return nullptr;
-	return this->nested_array[widnum];
+	return this->widget_lookup[widnum];
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

For indexed widget access, an array is allocated and two stages, first to find the maximum index, then to fill in the array.

This uses C-style memory allocation, and is generally clumsy.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Rename nested_array to widget_lookup, to name the member by functionality rather than type, and replace the C-style memory allocation with a std::map, which handles its own allocation and can be filled in as needed.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
