### PR TITLE
Codechange: Replace mishmash of types for widget index with WidgetID.

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -115,7 +115,7 @@ struct AIConfigWindow : public Window {
 		this->Window::Close();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_AIC_NUMBER:
@@ -128,7 +128,7 @@ struct AIConfigWindow : public Window {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_AIC_DECREASE_NUMBER:
@@ -165,7 +165,7 @@ struct AIConfigWindow : public Window {
 		return slot < max_slot;
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_AIC_LIST: {
@@ -190,7 +190,7 @@ struct AIConfigWindow : public Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget >= WID_AIC_TEXTFILE && widget < WID_AIC_TEXTFILE + TFT_CONTENT_END) {
 			if (this->selected_slot == INVALID_COMPANY || AIConfig::GetConfig(this->selected_slot) == nullptr) return;

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -118,7 +118,7 @@ struct BuildAirToolbarWindow : Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_AT_AIRPORT:
@@ -291,7 +291,7 @@ public:
 		this->PickerWindowBase::Close();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_AP_CLASS_DROPDOWN:
@@ -316,7 +316,7 @@ public:
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_AP_CLASS_DROPDOWN: {
@@ -377,7 +377,7 @@ public:
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_AP_AIRPORT_LIST: {
@@ -487,7 +487,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_AP_CLASS_DROPDOWN:
@@ -562,7 +562,7 @@ public:
 		this->SelectOtherAirport(-1);
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		if (widget == WID_AP_CLASS_DROPDOWN) {
 			_selected_airport_class = (AirportClassID)index;

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -315,7 +315,7 @@ public:
 		this->sel_group = id_g;
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_RV_SORT_ASCENDING_DESCENDING: {
@@ -402,7 +402,7 @@ public:
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_RV_CAPTION:
@@ -457,7 +457,7 @@ public:
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_RV_SORT_ASCENDING_DESCENDING:
@@ -541,7 +541,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_RV_SORT_ASCENDING_DESCENDING:
@@ -655,7 +655,7 @@ public:
 		}
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		switch (widget) {
 			case WID_RV_SORT_DROPDOWN:
@@ -697,7 +697,7 @@ public:
 		}
 	}
 
-	bool OnTooltip([[maybe_unused]] Point pt, int widget, TooltipCloseCondition close_cond) override
+	bool OnTooltip([[maybe_unused]] Point pt, WidgetID widget, TooltipCloseCondition close_cond) override
 	{
 		if (widget != WID_RV_TRAIN_WAGONREMOVE_TOGGLE) return false;
 

--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -57,7 +57,7 @@ public:
 		ResizeWindow(this, _screen.width, _screen.height);
 	}
 
-	void DrawWidget(const Rect &r, int) const override
+	void DrawWidget(const Rect &r, WidgetID) const override
 	{
 		GfxFillRect(r.left, r.top, r.right, r.bottom, 4, FILLRECT_OPAQUE);
 		GfxFillRect(r.left, r.top, r.right, r.bottom, 0, FILLRECT_CHECKER);
@@ -97,7 +97,7 @@ public:
 		this->Window::Close();
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget == WID_BEM_MESSAGE) {
 			*size = GetStringBoundingBox(STR_MISSING_GRAPHICS_ERROR);
@@ -106,14 +106,14 @@ public:
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget == WID_BEM_MESSAGE) {
 			DrawStringMultiLine(r.Shrink(WidgetDimensions::scaled.frametext), STR_MISSING_GRAPHICS_ERROR, TC_FROMSTRING, SA_CENTER);
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget == WID_BEM_QUIT) {
 			_exit_game = true;
@@ -211,7 +211,7 @@ public:
 		this->Window::Close();
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		/* We cache the button size. This is safe as no reinit can happen here. */
 		if (this->button_size.width == 0) {
@@ -234,14 +234,14 @@ public:
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_BAFD_QUESTION) return;
 
 		DrawStringMultiLine(r.Shrink(WidgetDimensions::scaled.frametext), STR_MISSING_GRAPHICS_SET_MESSAGE, TC_FROMSTRING, SA_CENTER);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_BAFD_YES:

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -174,7 +174,7 @@ public:
 		this->last_sorting = this->bridges.GetListing();
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_BBS_DROPDOWN_ORDER: {
@@ -221,7 +221,7 @@ public:
 		return corner;
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_BBS_DROPDOWN_ORDER:
@@ -255,7 +255,7 @@ public:
 		return ES_NOT_HANDLED;
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			default: break;
@@ -279,7 +279,7 @@ public:
 		}
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		if (widget == WID_BBS_DROPDOWN_CRITERIA && this->bridges.SortType() != index) {
 			this->bridges.SetSortType(index);

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1586,7 +1586,7 @@ struct BuildVehicleWindow : Window {
 		return list;
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_BV_SORT_ASCENDING_DESCENDING:
@@ -1707,7 +1707,7 @@ struct BuildVehicleWindow : Window {
 		this->eng_list.ForceRebuild();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_BV_CAPTION:
@@ -1742,7 +1742,7 @@ struct BuildVehicleWindow : Window {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_BV_LIST:
@@ -1783,7 +1783,7 @@ struct BuildVehicleWindow : Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_BV_LIST:
@@ -1841,7 +1841,7 @@ struct BuildVehicleWindow : Window {
 		Command<CMD_RENAME_ENGINE>::Post(STR_ERROR_CAN_T_RENAME_TRAIN_TYPE + this->vehicle_type, this->rename_engine, str);
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		switch (widget) {
 			case WID_BV_SORT_DROPDOWN:
@@ -1871,7 +1871,7 @@ struct BuildVehicleWindow : Window {
 		this->vscroll->SetCapacityFromWidget(this, WID_BV_LIST);
 	}
 
-	void OnEditboxChanged(int wid) override
+	void OnEditboxChanged(WidgetID wid) override
 	{
 		if (wid == WID_BV_FILTER) {
 			this->string_filter.SetFilterTerm(this->vehicle_editbox.text.buf);

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -236,7 +236,7 @@ struct CheatWindow : Window {
 		this->icon = GetSpriteSize(SPR_COMPANY_ICON);
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_C_PANEL) return;
 
@@ -298,7 +298,7 @@ struct CheatWindow : Window {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget != WID_C_PANEL) return;
 
@@ -344,7 +344,7 @@ struct CheatWindow : Window {
 		size->height = WidgetDimensions::scaled.framerect.Vertical() + this->line_height * lengthof(_cheats_ui);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget != WID_C_PANEL) return;
 

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -342,7 +342,7 @@ struct CompanyFinancesWindow : Window {
 		this->owner = (Owner)this->window_number;
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_CF_CAPTION:
@@ -383,7 +383,7 @@ struct CompanyFinancesWindow : Window {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_CF_EXPS_CATEGORY:
@@ -410,7 +410,7 @@ struct CompanyFinancesWindow : Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_CF_EXPS_CATEGORY:
@@ -479,7 +479,7 @@ struct CompanyFinancesWindow : Window {
 		this->DrawWidgets();
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_CF_TOGGLE_SIZE: // toggle size
@@ -772,7 +772,7 @@ public:
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_SCL_SPACER_DROPDOWN: {
@@ -838,7 +838,7 @@ public:
 		this->DrawWidgets();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_SCL_CAPTION:
@@ -878,7 +878,7 @@ public:
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_SCL_MATRIX) return;
 
@@ -950,7 +950,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			/* Livery Class buttons */
@@ -1029,7 +1029,7 @@ public:
 		this->vscroll->SetCapacityFromWidget(this, WID_SCL_MATRIX);
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		bool local = (CompanyID)this->window_number == _local_company;
 		if (!local) return;
@@ -1368,7 +1368,7 @@ class SelectCompanyManagerFaceWindow : public Window
 	 * @param val            the value which will be displayed
 	 * @param is_bool_widget is it a bool button
 	 */
-	void SetFaceStringParameters(byte widget_index, uint8_t val, bool is_bool_widget) const
+	void SetFaceStringParameters(WidgetID widget_index, uint8_t val, bool is_bool_widget) const
 	{
 		const NWidgetCore *nwi_widget = this->GetWidget<NWidgetCore>(widget_index);
 		if (nwi_widget->IsDisabled()) {
@@ -1452,7 +1452,7 @@ public:
 		this->number_dim = number_dim;
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_SCMF_HAS_MOUSTACHE_EARRING_TEXT:
@@ -1555,7 +1555,7 @@ public:
 		this->DrawWidgets();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_SCMF_HAS_MOUSTACHE_EARRING:
@@ -1616,7 +1616,7 @@ public:
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_SCMF_FACE:
@@ -1625,7 +1625,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			/* Toggle size, advanced/simple face selection */
@@ -1878,7 +1878,7 @@ struct CompanyInfrastructureWindow : Window
 		return total;
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_CI_CAPTION:
@@ -1887,7 +1887,7 @@ struct CompanyInfrastructureWindow : Window
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		const Company *c = Company::Get((CompanyID)this->window_number);
 
@@ -2012,7 +2012,7 @@ struct CompanyInfrastructureWindow : Window
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		const Company *c = Company::Get((CompanyID)this->window_number);
 
@@ -2291,7 +2291,7 @@ struct CompanyWindow : Window
 		this->DrawWidgets();
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_C_FACE:
@@ -2419,7 +2419,7 @@ struct CompanyWindow : Window
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		const Company *c = Company::Get((CompanyID)this->window_number);
 		switch (widget) {
@@ -2456,7 +2456,7 @@ struct CompanyWindow : Window
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_C_CAPTION:
@@ -2474,7 +2474,7 @@ struct CompanyWindow : Window
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_C_NEW_FACE: DoSelectCompanyManagerFace(this); break;
@@ -2648,7 +2648,7 @@ struct BuyCompanyWindow : Window {
 		this->company_value = hostile_takeover ? CalculateHostileTakeoverValue(c) : c->bankrupt_value;
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_BC_FACE:
@@ -2664,7 +2664,7 @@ struct BuyCompanyWindow : Window {
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_BC_CAPTION:
@@ -2674,7 +2674,7 @@ struct BuyCompanyWindow : Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_BC_FACE: {
@@ -2693,7 +2693,7 @@ struct BuyCompanyWindow : Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_BC_NO:

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -271,7 +271,7 @@ struct IConsoleWindow : Window
 		return ES_HANDLED;
 	}
 
-	void InsertTextString(int, const char *str, bool marked, const char *caret, const char *insert_location, const char *replacement_end) override
+	void InsertTextString(WidgetID, const char *str, bool marked, const char *caret, const char *insert_location, const char *replacement_end) override
 	{
 		if (_iconsole_cmdline.InsertString(str, marked, caret, insert_location, replacement_end)) {
 			IConsoleWindow::scroll = 0;

--- a/src/date_gui.cpp
+++ b/src/date_gui.cpp
@@ -65,7 +65,7 @@ struct SetDateWindow : Window {
 	 * Helper function to construct the dropdown.
 	 * @param widget the dropdown widget to create the dropdown for
 	 */
-	void ShowDateDropDown(int widget)
+	void ShowDateDropDown(WidgetID widget)
 	{
 		int selected;
 		DropDownList list;
@@ -99,7 +99,7 @@ struct SetDateWindow : Window {
 		ShowDropDownList(this, std::move(list), selected, widget);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		Dimension d = {0, 0};
 		switch (widget) {
@@ -128,7 +128,7 @@ struct SetDateWindow : Window {
 		*size = d;
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_SD_DAY:   SetDParam(0, this->date.day - 1 + STR_DAY_NUMBER_1ST); break;
@@ -137,7 +137,7 @@ struct SetDateWindow : Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_SD_DAY:
@@ -153,7 +153,7 @@ struct SetDateWindow : Window {
 		}
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		switch (widget) {
 			case WID_SD_DAY:

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -258,7 +258,7 @@ struct DepotWindow : Window {
 	VehicleID vehicle_over; ///< Rail vehicle over which another one is dragged, \c INVALID_VEHICLE if none.
 	VehicleType type;
 	bool generate_list;
-	int hovered_widget; ///< Index of the widget being hovered during drag/drop. -1 if no drag is in progress.
+	WidgetID hovered_widget; ///< Index of the widget being hovered during drag/drop. -1 if no drag is in progress.
 	VehicleList vehicle_list;
 	VehicleList wagon_list;
 	uint unitnumber_digits;
@@ -363,7 +363,7 @@ struct DepotWindow : Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_D_MATRIX) return;
 
@@ -421,7 +421,7 @@ struct DepotWindow : Window {
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget != WID_D_CAPTION) return;
 
@@ -653,7 +653,7 @@ struct DepotWindow : Window {
 		this->flag_size = maxdim(GetScaledSpriteSize(SPR_FLAG_VEH_STOPPED), GetScaledSpriteSize(SPR_FLAG_VEH_RUNNING));
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_D_MATRIX: {
@@ -757,7 +757,7 @@ struct DepotWindow : Window {
 		this->DrawWidgets();
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_D_MATRIX: // List
@@ -839,7 +839,7 @@ struct DepotWindow : Window {
 		Command<CMD_RENAME_DEPOT>::Post(STR_ERROR_CAN_T_RENAME_DEPOT, this->GetDepotIndex(), str);
 	}
 
-	bool OnRightClick([[maybe_unused]] Point pt, int widget) override
+	bool OnRightClick([[maybe_unused]] Point pt, WidgetID widget) override
 	{
 		if (widget != WID_D_MATRIX) return false;
 
@@ -974,7 +974,7 @@ struct DepotWindow : Window {
 		}
 	}
 
-	void OnMouseDrag(Point pt, int widget) override
+	void OnMouseDrag(Point pt, WidgetID widget) override
 	{
 		if (this->sel == INVALID_VEHICLE) return;
 		if (widget != this->hovered_widget) {
@@ -1025,7 +1025,7 @@ struct DepotWindow : Window {
 		this->SetWidgetDirty(widget);
 	}
 
-	void OnDragDrop(Point pt, int widget) override
+	void OnDragDrop(Point pt, WidgetID widget) override
 	{
 		switch (widget) {
 			case WID_D_MATRIX: {

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -148,7 +148,7 @@ struct BuildDocksToolbarWindow : Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_DT_CANAL: // Build canal button
@@ -453,7 +453,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case BDSW_LT_OFF:
@@ -529,7 +529,7 @@ public:
 		UpdateDocksDirection();
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_BDD_X:
@@ -540,7 +540,7 @@ public:
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		DrawPixelInfo tmp_dpi;
 
@@ -564,7 +564,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_BDD_X:

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -78,7 +78,7 @@ struct EnginePreviewWindow : Window {
 		this->flags |= WF_STICKY;
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget != WID_EP_QUESTION) return;
 
@@ -105,7 +105,7 @@ struct EnginePreviewWindow : Window {
 		size->height += GetStringHeight(GetEngineInfoString(engine), size->width);
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_EP_QUESTION) return;
 
@@ -123,7 +123,7 @@ struct EnginePreviewWindow : Window {
 		DrawStringMultiLine(r.left, r.right, y, r.bottom, GetEngineInfoString(engine), TC_FROMSTRING, SA_CENTER);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_EP_YES:

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -189,7 +189,7 @@ public:
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_EM_MESSAGE: {
@@ -257,12 +257,12 @@ public:
 		if (this->face != INVALID_COMPANY && !Company::IsValidID(this->face)) this->Close();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_EM_CAPTION) CopyInDParam(this->params);
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_EM_FACE: {

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -408,7 +408,7 @@ public:
 		this->Window::Close();
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_SL_SORT_BYNAME:
@@ -561,7 +561,7 @@ public:
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_SL_BACKGROUND:
@@ -594,7 +594,7 @@ public:
 		this->DrawWidgets();
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_SL_SORT_BYNAME: // Sort save names by name
@@ -716,7 +716,7 @@ public:
 		}
 	}
 
-	void OnMouseOver([[maybe_unused]] Point pt, int widget) override
+	void OnMouseOver([[maybe_unused]] Point pt, WidgetID widget) override
 	{
 		if (widget == WID_SL_DRIVES_DIRECTORIES_LIST) {
 			auto it = this->vscroll->GetScrolledItemFromWidget(this->display_list, pt.y, this, WID_SL_DRIVES_DIRECTORIES_LIST, WidgetDimensions::scaled.inset.top);
@@ -873,7 +873,7 @@ public:
 		}
 	}
 
-	void OnEditboxChanged(int wid) override
+	void OnEditboxChanged(WidgetID wid) override
 	{
 		if (wid == WID_SL_FILTER) {
 			this->string_filter.SetFilterTerm(this->filter_editbox.text.buf);

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -512,7 +512,7 @@ struct FramerateWindow : Window {
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_FRW_CAPTION:
@@ -540,7 +540,7 @@ struct FramerateWindow : Window {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_FRW_RATE_GAMELOOP:
@@ -651,7 +651,7 @@ struct FramerateWindow : Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_FRW_TIMES_NAMES: {
@@ -693,7 +693,7 @@ struct FramerateWindow : Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_FRW_TIMES_NAMES:
@@ -765,7 +765,7 @@ struct FrametimeGraphWindow : Window {
 		this->UpdateScale();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_FGW_CAPTION:
@@ -780,7 +780,7 @@ struct FrametimeGraphWindow : Window {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget == WID_FGW_GRAPH) {
 			SetDParam(0, 100);
@@ -897,7 +897,7 @@ struct FrametimeGraphWindow : Window {
 		return (value - src_min) * dst_diff / src_diff + dst_min;
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget == WID_FGW_GRAPH) {
 			const TimingMeasurement *durations  = _pf_data[this->element].durations;

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -135,7 +135,7 @@ struct GSConfigWindow : public Window {
 		this->vscroll->SetCount(this->visible_settings.size());
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_GSC_SETTINGS:
@@ -161,7 +161,7 @@ struct GSConfigWindow : public Window {
 		return _game_mode != GM_NORMAL || Game::GetInstance() != nullptr;
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_GSC_GSLIST: {
@@ -243,7 +243,7 @@ struct GSConfigWindow : public Window {
 		this->DrawWidgets();
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget >= WID_GSC_TEXTFILE && widget < WID_GSC_TEXTFILE + TFT_CONTENT_END) {
 			if (GameConfig::GetConfig() == nullptr) return;
@@ -373,14 +373,14 @@ struct GSConfigWindow : public Window {
 		SetValue(value);
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		if (widget != WID_GSC_SETTING_DROPDOWN) return;
 		assert(this->clicked_dropdown);
 		SetValue(index);
 	}
 
-	void OnDropdownClose(Point, int widget, int, bool) override
+	void OnDropdownClose(Point, WidgetID widget, int, bool) override
 	{
 		if (widget != WID_GSC_SETTING_DROPDOWN) return;
 		/* We cannot raise the dropdown button just yet. OnClick needs some hint, whether

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -384,7 +384,7 @@ static const StringID _variety[]     = {STR_VARIETY_NONE, STR_VARIETY_VERY_LOW, 
 static_assert(lengthof(_num_inds) == ID_END + 1);
 
 struct GenerateLandscapeWindow : public Window {
-	uint widget_id;
+	WidgetID widget_id;
 	uint x;
 	uint y;
 	std::string name;
@@ -415,7 +415,7 @@ struct GenerateLandscapeWindow : public Window {
 	}
 
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_GL_START_DATE_TEXT:      SetDParam(0, TimerGameCalendar::ConvertYMDToDate(_settings_newgame.game_creation.starting_year, 0, 1)); break;
@@ -570,7 +570,7 @@ struct GenerateLandscapeWindow : public Window {
 
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		Dimension d{0, (uint)GetCharacterHeight(FS_NORMAL)};
 		const StringID *strs = nullptr;
@@ -669,7 +669,7 @@ struct GenerateLandscapeWindow : public Window {
 		*size = maxdim(*size, d);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_GL_TEMPERATE:
@@ -879,7 +879,7 @@ struct GenerateLandscapeWindow : public Window {
 		}
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		switch (widget) {
 			case WID_GL_MAPSIZE_X_PULLDOWN:     _settings_newgame.game_creation.map_x = index; break;
@@ -1076,7 +1076,7 @@ void StartNewGameWithoutGUI(uint32_t seed)
 
 struct CreateScenarioWindow : public Window
 {
-	uint widget_id;
+	WidgetID widget_id;
 
 	CreateScenarioWindow(WindowDesc *desc, WindowNumber window_number) : Window(desc)
 	{
@@ -1084,7 +1084,7 @@ struct CreateScenarioWindow : public Window
 		this->LowerWidget(_settings_newgame.game_creation.landscape + WID_CS_TEMPERATE);
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_CS_START_DATE_TEXT:
@@ -1120,7 +1120,7 @@ struct CreateScenarioWindow : public Window
 		this->DrawWidgets();
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		StringID str = STR_JUST_INT;
 		switch (widget) {
@@ -1153,7 +1153,7 @@ struct CreateScenarioWindow : public Window
 		*size = maxdim(*size, d);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_CS_TEMPERATE:
@@ -1223,7 +1223,7 @@ struct CreateScenarioWindow : public Window
 		this->RaiseWidgetsWhenLowered(WID_CS_START_DATE_DOWN, WID_CS_START_DATE_UP, WID_CS_FLAT_LAND_HEIGHT_DOWN, WID_CS_FLAT_LAND_HEIGHT_UP);
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		switch (widget) {
 			case WID_CS_MAPSIZE_X_PULLDOWN: _settings_newgame.game_creation.map_x = index; break;
@@ -1389,7 +1389,7 @@ struct GenerateProgressWindow : public Window {
 		this->InitNested();
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_GP_ABORT:
@@ -1404,7 +1404,7 @@ struct GenerateProgressWindow : public Window {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_GP_PROGRESS_BAR: {
@@ -1425,7 +1425,7 @@ struct GenerateProgressWindow : public Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_GP_PROGRESS_BAR: {

--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -51,7 +51,7 @@ struct GoalListWindow : public Window {
 		this->OnInvalidateData(0);
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget != WID_GOAL_CAPTION) return;
 
@@ -63,7 +63,7 @@ struct GoalListWindow : public Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_GOAL_GLOBAL_BUTTON:
@@ -168,7 +168,7 @@ struct GoalListWindow : public Window {
 		return num;
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget != WID_GOAL_LIST) return;
 		Dimension d = GetStringBoundingBox(STR_GOALS_NONE);
@@ -351,7 +351,7 @@ struct GoalQuestionWindow : public Window {
 	}
 
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_GQ_BUTTON_1:
@@ -368,7 +368,7 @@ struct GoalQuestionWindow : public Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_GQ_BUTTON_1:
@@ -388,7 +388,7 @@ struct GoalQuestionWindow : public Window {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget != WID_GQ_QUESTION) return;
 
@@ -396,7 +396,7 @@ struct GoalQuestionWindow : public Window {
 		size->height = GetStringHeight(STR_JUST_RAW_STRING, size->width);
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_GQ_QUESTION) return;
 

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -56,7 +56,7 @@ struct GraphLegendWindow : Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (!IsInsideMM(widget, WID_GL_FIRST_COMPANY, MAX_COMPANIES + WID_GL_FIRST_COMPANY)) return;
 
@@ -76,7 +76,7 @@ struct GraphLegendWindow : Window {
 		DrawString(tr.left, tr.right, CenterBounds(tr.top, tr.bottom, GetCharacterHeight(FS_NORMAL)), STR_COMPANY_NAME_COMPANY_NUM, HasBit(_legend_excluded_companies, cid) ? TC_BLACK : TC_WHITE);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (!IsInsideMM(widget, WID_GL_FIRST_COMPANY, MAX_COMPANIES + WID_GL_FIRST_COMPANY)) return;
 
@@ -115,7 +115,7 @@ static NWidgetBase *MakeNWidgetCompanyLines()
 	vert->SetPadding(2, 2, 2, 2);
 	uint sprite_height = GetSpriteSize(SPR_COMPANY_ICON, nullptr, ZOOM_LVL_OUT_4X).height;
 
-	for (int widnum = WID_GL_FIRST_COMPANY; widnum <= WID_GL_LAST_COMPANY; widnum++) {
+	for (WidgetID widnum = WID_GL_FIRST_COMPANY; widnum <= WID_GL_LAST_COMPANY; widnum++) {
 		NWidgetBackground *panel = new NWidgetBackground(WWT_PANEL, COLOUR_BROWN, widnum);
 		panel->SetMinimalSize(246, sprite_height + WidgetDimensions::unscaled.framerect.Vertical());
 		panel->SetMinimalTextLines(1, WidgetDimensions::unscaled.framerect.Vertical(), FS_NORMAL);
@@ -191,7 +191,7 @@ protected:
 	uint16_t x_values_start;
 	uint16_t x_values_increment;
 
-	int graph_widget;
+	WidgetID graph_widget;
 	StringID format_str_y_axis;
 	byte colours[GRAPH_MAX_DATASETS];
 	OverflowSafeInt64 cost[GRAPH_MAX_DATASETS][GRAPH_NUM_MONTHS]; ///< Stored costs for the last #GRAPH_NUM_MONTHS months
@@ -471,7 +471,7 @@ protected:
 	}
 
 
-	BaseGraphWindow(WindowDesc *desc, int widget, StringID format_str_y_axis) :
+	BaseGraphWindow(WindowDesc *desc, WidgetID widget, StringID format_str_y_axis) :
 			Window(desc),
 			format_str_y_axis(format_str_y_axis)
 	{
@@ -489,7 +489,7 @@ protected:
 	}
 
 public:
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget != this->graph_widget) return;
 
@@ -525,7 +525,7 @@ public:
 		size->height = std::max<uint>(size->height, size->width / 3);
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != this->graph_widget) return;
 
@@ -537,7 +537,7 @@ public:
 		return INVALID_DATAPOINT;
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		/* Clicked on legend? */
 		if (widget == WID_CV_KEY_BUTTON) ShowGraphLegend();
@@ -778,7 +778,7 @@ struct PerformanceHistoryGraphWindow : BaseGraphWindow {
 		return c->old_economy[j].performance_history;
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget == WID_PHG_DETAILED_PERFORMANCE) ShowPerformanceRatingDetail();
 		this->BaseGraphWindow::OnClick(pt, widget, click_count);
@@ -912,7 +912,7 @@ struct PaymentRatesGraphWindow : BaseGraphWindow {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget != WID_CPR_MATRIX) {
 			BaseGraphWindow::UpdateWidgetSize(widget, size, padding, fill, resize);
@@ -936,7 +936,7 @@ struct PaymentRatesGraphWindow : BaseGraphWindow {
 		resize->height = this->line_height;
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_CPR_MATRIX) {
 			BaseGraphWindow::DrawWidget(r, widget);
@@ -973,7 +973,7 @@ struct PaymentRatesGraphWindow : BaseGraphWindow {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_CPR_ENABLE_CARGOES:
@@ -1140,7 +1140,7 @@ struct PerformanceRatingDetailWindow : Window {
 	uint score_detail_left;
 	uint score_detail_right;
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_PRD_SCORE_FIRST:
@@ -1198,7 +1198,7 @@ struct PerformanceRatingDetailWindow : Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		/* No need to draw when there's nothing to draw */
 		if (this->company == INVALID_COMPANY) return;
@@ -1276,7 +1276,7 @@ struct PerformanceRatingDetailWindow : Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		/* Check which button is clicked */
 		if (IsInsideMM(widget, WID_PRD_COMPANY_FIRST, WID_PRD_COMPANY_LAST + 1)) {
@@ -1355,7 +1355,7 @@ static NWidgetBase *MakePerformanceDetailPanels()
 	static_assert(lengthof(performance_tips) == SCORE_END - SCORE_BEGIN);
 
 	NWidgetVertical *vert = new NWidgetVertical(NC_EQUALSIZE);
-	for (int widnum = WID_PRD_SCORE_FIRST; widnum <= WID_PRD_SCORE_LAST; widnum++) {
+	for (WidgetID widnum = WID_PRD_SCORE_FIRST; widnum <= WID_PRD_SCORE_LAST; widnum++) {
 		NWidgetBackground *panel = new NWidgetBackground(WWT_PANEL, COLOUR_BROWN, widnum);
 		panel->SetFill(1, 1);
 		panel->SetDataTip(0x0, performance_tips[widnum - WID_PRD_SCORE_FIRST]);

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -384,7 +384,7 @@ public:
 		*this->sorting = this->vehgroups.GetListing();
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_GL_LIST_GROUP:
@@ -466,7 +466,7 @@ public:
 		this->SetDirty();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_GL_FILTER_BY_CARGO:
@@ -552,7 +552,7 @@ public:
 		this->DrawWidgets();
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_GL_ALL_VEHICLES:
@@ -648,7 +648,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_GL_SORT_BY_ORDER: // Flip sorting method ascending/descending
@@ -823,7 +823,7 @@ public:
 		}
 	}
 
-	void OnDragDrop_Group(Point pt, int widget)
+	void OnDragDrop_Group(Point pt, WidgetID widget)
 	{
 		const Group *g = Group::Get(this->group_sel);
 
@@ -855,7 +855,7 @@ public:
 		}
 	}
 
-	void OnDragDrop_Vehicle(Point pt, int widget)
+	void OnDragDrop_Vehicle(Point pt, WidgetID widget)
 	{
 		switch (widget) {
 			case WID_GL_DEFAULT_VEHICLES: // Ungrouped vehicles
@@ -921,7 +921,7 @@ public:
 		}
 	}
 
-	void OnDragDrop(Point pt, int widget) override
+	void OnDragDrop(Point pt, WidgetID widget) override
 	{
 		if (this->vehicle_sel != INVALID_VEHICLE) OnDragDrop_Vehicle(pt, widget);
 		if (this->group_sel != INVALID_GROUP) OnDragDrop_Group(pt, widget);
@@ -941,7 +941,7 @@ public:
 		this->vscroll->SetCapacityFromWidget(this, WID_GL_LIST_VEHICLE);
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		switch (widget) {
 			case WID_GL_GROUP_BY_DROPDOWN:
@@ -1010,7 +1010,7 @@ public:
 		this->SetWidgetDirty(WID_GL_LIST_VEHICLE);
 	}
 
-	void OnMouseDrag(Point pt, int widget) override
+	void OnMouseDrag(Point pt, WidgetID widget) override
 	{
 		if (this->vehicle_sel == INVALID_VEHICLE && this->group_sel == INVALID_GROUP) return;
 

--- a/src/help_gui.cpp
+++ b/src/help_gui.cpp
@@ -73,7 +73,7 @@ struct GameManualTextfileWindow : public TextfileWindow {
 		this->OnClick({ 0, 0 }, WID_TF_WRAPTEXT, 1);
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_TF_CAPTION) {
 			SetDParamStr(0, this->filename);
@@ -129,7 +129,7 @@ struct HelpWindow : public Window {
 		this->EnableTextfileButton(LICENSE_FILENAME, WID_HW_LICENSE);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_HW_README:

--- a/src/highscore_gui.cpp
+++ b/src/highscore_gui.cpp
@@ -65,7 +65,7 @@ struct EndGameHighScoreBaseWindow : Window {
 		return pt;
 	}
 
-	void OnClick([[maybe_unused]] Point pt, [[maybe_unused]] int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, [[maybe_unused]] WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		this->Close();
 	}

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -422,7 +422,7 @@ public:
 		this->SetupArrays();
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_DPI_MATRIX_WIDGET: {
@@ -494,7 +494,7 @@ public:
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_DPI_FUND_WIDGET:
@@ -515,7 +515,7 @@ public:
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_DPI_MATRIX_WIDGET: {
@@ -626,7 +626,7 @@ public:
 		MarkWholeScreenDirty();
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_DPI_CREATE_RANDOM_INDUSTRIES_WIDGET: {
@@ -981,17 +981,17 @@ public:
 		return ir.top - 1 + WidgetDimensions::scaled.framerect.bottom;
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_IV_CAPTION) SetDParam(0, this->window_number);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget == WID_IV_INFO) size->height = this->info_height;
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_IV_INFO: {
@@ -1646,7 +1646,7 @@ public:
 		this->SetCargoFilterArray();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_ID_DROPDOWN_CRITERIA:
@@ -1663,7 +1663,7 @@ public:
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_ID_DROPDOWN_ORDER:
@@ -1709,7 +1709,7 @@ public:
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_ID_DROPDOWN_ORDER: {
@@ -1761,7 +1761,7 @@ public:
 		return list;
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_ID_DROPDOWN_ORDER:
@@ -1795,7 +1795,7 @@ public:
 		}
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		switch (widget) {
 			case WID_ID_DROPDOWN_CRITERIA: {
@@ -1826,7 +1826,7 @@ public:
 		this->hscroll->SetCapacityFromWidget(this, WID_ID_INDUSTRY_LIST);
 	}
 
-	void OnEditboxChanged(int wid) override
+	void OnEditboxChanged(WidgetID wid) override
 	{
 		if (wid == WID_ID_FILTER) {
 			this->string_filter.SetFilterTerm(this->industry_editbox.text.buf);
@@ -2626,7 +2626,7 @@ struct IndustryCargoesWindow : public Window {
 		CargoesField::cargo_field_width = CargoesField::cargo_border.width * 2 + CargoesField::cargo_line.width * CargoesField::max_cargoes + CargoesField::cargo_space.width * (CargoesField::max_cargoes - 1);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_IC_PANEL:
@@ -2647,7 +2647,7 @@ struct IndustryCargoesWindow : public Window {
 
 
 	CargoesFieldType type; ///< Type of field.
-	void SetStringParameters  (int widget) const override
+	void SetStringParameters  (WidgetID widget) const override
 	{
 		if (widget != WID_IC_CAPTION) return;
 
@@ -2976,7 +2976,7 @@ struct IndustryCargoesWindow : public Window {
 		this->ComputeIndustryDisplay(data);
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_IC_PANEL) return;
 
@@ -3061,7 +3061,7 @@ struct IndustryCargoesWindow : public Window {
 		return true;
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_IC_PANEL: {
@@ -3134,7 +3134,7 @@ struct IndustryCargoesWindow : public Window {
 		}
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		if (index < 0) return;
 
@@ -3149,7 +3149,7 @@ struct IndustryCargoesWindow : public Window {
 		}
 	}
 
-	bool OnTooltip([[maybe_unused]] Point pt, int widget, TooltipCloseCondition close_cond) override
+	bool OnTooltip([[maybe_unused]] Point pt, WidgetID widget, TooltipCloseCondition close_cond) override
 	{
 		if (widget != WID_IC_PANEL) return false;
 

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -282,7 +282,7 @@ struct SelectGameWindow : public Window {
 		this->GetWidget<NWidgetStacked>(WID_SGI_TRANSLATION_SELECTION)->SetDisplayedPlane(missing_lang ? 0 : SZSP_NONE);
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_SGI_BASESET:
@@ -297,7 +297,7 @@ struct SelectGameWindow : public Window {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_SGI_TEMPERATE_LANDSCAPE: case WID_SGI_ARCTIC_LANDSCAPE:
@@ -325,7 +325,7 @@ struct SelectGameWindow : public Window {
 		if (changed) this->ReInit(0, 0, this->flags & WF_CENTERED);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		/* Do not create a network server when you (just) have closed one of the game
 		 * creation/load windows for the network server. */

--- a/src/league_gui.cpp
+++ b/src/league_gui.cpp
@@ -100,7 +100,7 @@ public:
 		this->DrawWidgets();
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_PLT_BACKGROUND) return;
 
@@ -127,7 +127,7 @@ public:
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget != WID_PLT_BACKGROUND) return;
 
@@ -302,7 +302,7 @@ public:
 		this->InitNested(table);
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget != WID_SLT_CAPTION) return;
 		SetDParamStr(0, this->title);
@@ -313,7 +313,7 @@ public:
 		this->DrawWidgets();
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_SLT_BACKGROUND) return;
 
@@ -355,7 +355,7 @@ public:
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget != WID_SLT_BACKGROUND) return;
 
@@ -395,7 +395,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget != WID_SLT_BACKGROUND) return;
 

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -582,7 +582,7 @@ void LinkGraphLegendWindow::SetOverlay(std::shared_ptr<LinkGraphOverlay> overlay
 	}
 }
 
-void LinkGraphLegendWindow::UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize)
+void LinkGraphLegendWindow::UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize)
 {
 	if (IsInsideMM(widget, WID_LGL_SATURATION_FIRST, WID_LGL_SATURATION_LAST + 1)) {
 		StringID str = STR_NULL;
@@ -609,7 +609,7 @@ void LinkGraphLegendWindow::UpdateWidgetSize(int widget, Dimension *size, [[mayb
 	}
 }
 
-void LinkGraphLegendWindow::DrawWidget(const Rect &r, int widget) const
+void LinkGraphLegendWindow::DrawWidget(const Rect &r, WidgetID widget) const
 {
 	Rect br = r.Shrink(WidgetDimensions::scaled.bevel);
 	if (IsInsideMM(widget, WID_LGL_COMPANY_FIRST, WID_LGL_COMPANY_LAST + 1)) {
@@ -640,7 +640,7 @@ void LinkGraphLegendWindow::DrawWidget(const Rect &r, int widget) const
 	}
 }
 
-bool LinkGraphLegendWindow::OnTooltip([[maybe_unused]] Point, int widget, TooltipCloseCondition close_cond)
+bool LinkGraphLegendWindow::OnTooltip([[maybe_unused]] Point, WidgetID widget, TooltipCloseCondition close_cond)
 {
 	if (IsInsideMM(widget, WID_LGL_COMPANY_FIRST, WID_LGL_COMPANY_LAST + 1)) {
 		if (this->IsWidgetDisabled(widget)) {
@@ -687,7 +687,7 @@ void LinkGraphLegendWindow::UpdateOverlayCargoes()
 	this->overlay->SetCargoMask(mask);
 }
 
-void LinkGraphLegendWindow::OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count)
+void LinkGraphLegendWindow::OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count)
 {
 	/* Check which button is clicked */
 	if (IsInsideMM(widget, WID_LGL_COMPANY_FIRST, WID_LGL_COMPANY_LAST + 1)) {

--- a/src/linkgraph/linkgraph_gui.h
+++ b/src/linkgraph/linkgraph_gui.h
@@ -54,7 +54,7 @@ public:
 	 * @param company_mask Bitmask of companies to be shown.
 	 * @param scale Desired thickness of lines and size of station dots.
 	 */
-	LinkGraphOverlay(Window *w, uint wid, CargoTypes cargo_mask, CompanyMask company_mask, uint scale) :
+	LinkGraphOverlay(Window *w, WidgetID wid, CargoTypes cargo_mask, CompanyMask company_mask, uint scale) :
 			window(w), widget_id(wid), cargo_mask(cargo_mask), company_mask(company_mask), scale(scale)
 	{}
 
@@ -75,7 +75,7 @@ public:
 
 protected:
 	Window *window;                    ///< Window to be drawn into.
-	const uint widget_id;              ///< ID of Widget in Window to be drawn to.
+	const WidgetID widget_id;          ///< ID of Widget in Window to be drawn to.
 	CargoTypes cargo_mask;             ///< Bitmask of cargos to be displayed.
 	CompanyMask company_mask;          ///< Bitmask of companies to be displayed.
 	LinkMap cached_links;              ///< Cache for links to reduce recalculation.
@@ -108,10 +108,10 @@ public:
 	LinkGraphLegendWindow(WindowDesc *desc, int window_number);
 	void SetOverlay(std::shared_ptr<LinkGraphOverlay> overlay);
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override;
-	void DrawWidget(const Rect &r, int widget) const override;
-	bool OnTooltip([[maybe_unused]] Point pt, int widget, TooltipCloseCondition close_cond) override;
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override;
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override;
+	void DrawWidget(const Rect &r, WidgetID widget) const override;
+	bool OnTooltip([[maybe_unused]] Point pt, WidgetID widget, TooltipCloseCondition close_cond) override;
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override;
 	void OnInvalidateData(int data = 0, bool gui_scope = true) override;
 
 private:

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -60,7 +60,7 @@
  * @param mode Tile highlighting mode, e.g. drawing a rectangle or a dot on the ground
  * @return true if the button is clicked, false if it's unclicked
  */
-bool HandlePlacePushButton(Window *w, int widget, CursorID cursor, HighLightStyle mode)
+bool HandlePlacePushButton(Window *w, WidgetID widget, CursorID cursor, HighLightStyle mode)
 {
 	if (w->IsWidgetDisabled(widget)) return false;
 
@@ -448,7 +448,7 @@ struct MainWindow : Window
 		}
 	}
 
-	bool OnTooltip([[maybe_unused]] Point pt, int widget, TooltipCloseCondition close_cond) override
+	bool OnTooltip([[maybe_unused]] Point pt, WidgetID widget, TooltipCloseCondition close_cond) override
 	{
 		if (widget != WID_M_VIEWPORT) return false;
 		return this->viewport->overlay->ShowTooltip(pt, close_cond);

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -72,7 +72,7 @@ class LandInfoWindow : public Window {
 public:
 	TileIndex tile;
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_LI_BACKGROUND) return;
 
@@ -88,7 +88,7 @@ public:
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget != WID_LI_BACKGROUND) return;
 
@@ -340,7 +340,7 @@ public:
 		::ShowNewGRFInspectWindow(GetGrfSpecFeature(this->tile), this->tile.base());
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_LI_LOCATION:
@@ -478,13 +478,13 @@ struct AboutWindow : public Window {
 		this->text_position = this->GetWidget<NWidgetBase>(WID_A_SCROLLING_TEXT)->pos_y + this->GetWidget<NWidgetBase>(WID_A_SCROLLING_TEXT)->current_y;
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_A_WEBSITE) SetDParamStr(0, "Website: https://www.openttd.org");
 		if (widget == WID_A_COPYRIGHT) SetDParamStr(0, _openttd_revision_year);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget != WID_A_SCROLLING_TEXT) return;
 
@@ -500,7 +500,7 @@ struct AboutWindow : public Window {
 		*size = maxdim(*size, d);
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_A_SCROLLING_TEXT) return;
 
@@ -697,7 +697,7 @@ struct TooltipsWindow : public Window
 		return pt;
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget != WID_TT_BACKGROUND) return;
 		CopyInDParam(this->params);
@@ -710,7 +710,7 @@ struct TooltipsWindow : public Window
 		size->height += WidgetDimensions::scaled.framerect.Vertical()    + WidgetDimensions::scaled.fullbevel.Vertical();
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_TT_BACKGROUND) return;
 		GfxFillRect(r, PC_BLACK);
@@ -760,7 +760,7 @@ void GuiShowTooltips(Window *parent, StringID str, TooltipCloseCondition close_t
 	new TooltipsWindow(parent, str, paramcount, close_tooltip);
 }
 
-void QueryString::HandleEditBox(Window *w, int wid)
+void QueryString::HandleEditBox(Window *w, WidgetID wid)
 {
 	if (w->IsWidgetGloballyFocused(wid) && this->text.HandleCaret()) {
 		w->SetWidgetDirty(wid);
@@ -775,7 +775,7 @@ static int GetCaretWidth()
 	return GetCharacterWidth(FS_NORMAL, '_');
 }
 
-void QueryString::DrawEditBox(const Window *w, int wid) const
+void QueryString::DrawEditBox(const Window *w, WidgetID wid) const
 {
 	const NWidgetLeaf *wi = w->GetWidget<NWidgetLeaf>(wid);
 
@@ -827,7 +827,7 @@ void QueryString::DrawEditBox(const Window *w, int wid) const
  * @param wid Widget index.
  * @return Top-left location of the caret, relative to the window.
  */
-Point QueryString::GetCaretPosition(const Window *w, int wid) const
+Point QueryString::GetCaretPosition(const Window *w, WidgetID wid) const
 {
 	const NWidgetLeaf *wi = w->GetWidget<NWidgetLeaf>(wid);
 
@@ -856,7 +856,7 @@ Point QueryString::GetCaretPosition(const Window *w, int wid) const
  * @param to End of the string range.
  * @return Rectangle encompassing the string range, relative to the window.
  */
-Rect QueryString::GetBoundingRect(const Window *w, int wid, const char *from, const char *to) const
+Rect QueryString::GetBoundingRect(const Window *w, WidgetID wid, const char *from, const char *to) const
 {
 	const NWidgetLeaf *wi = w->GetWidget<NWidgetLeaf>(wid);
 
@@ -887,7 +887,7 @@ Rect QueryString::GetBoundingRect(const Window *w, int wid, const char *from, co
  * @param pt Position to test.
  * @return Index of the character position or -1 if no character is at the position.
  */
-ptrdiff_t QueryString::GetCharAtPosition(const Window *w, int wid, const Point &pt) const
+ptrdiff_t QueryString::GetCharAtPosition(const Window *w, WidgetID wid, const Point &pt) const
 {
 	const NWidgetLeaf *wi = w->GetWidget<NWidgetLeaf>(wid);
 
@@ -909,7 +909,7 @@ ptrdiff_t QueryString::GetCharAtPosition(const Window *w, int wid, const Point &
 	return ::GetCharAtPosition(tb->buf, pt.x - delta - r.left);
 }
 
-void QueryString::ClickEditBox(Window *w, Point pt, int wid, int click_count, bool focus_changed)
+void QueryString::ClickEditBox(Window *w, Point pt, WidgetID wid, int click_count, bool focus_changed)
 {
 	const NWidgetLeaf *wi = w->GetWidget<NWidgetLeaf>(wid);
 
@@ -981,7 +981,7 @@ struct QueryStringWindow : public Window
 		this->ReInit();
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget == WID_QS_DEFAULT && (this->flags & QSF_ENABLE_DEFAULT) == 0) {
 			/* We don't want this widget to show! */
@@ -995,7 +995,7 @@ struct QueryStringWindow : public Window
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_QS_WARNING) return;
 
@@ -1005,7 +1005,7 @@ struct QueryStringWindow : public Window
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_QS_CAPTION) SetDParam(0, this->editbox.caption);
 	}
@@ -1020,7 +1020,7 @@ struct QueryStringWindow : public Window
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_QS_DEFAULT:
@@ -1124,7 +1124,7 @@ struct QueryWindow : public Window {
 		this->SetDirty();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_Q_CAPTION:
@@ -1134,7 +1134,7 @@ struct QueryWindow : public Window {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget != WID_Q_TEXT) return;
 
@@ -1144,7 +1144,7 @@ struct QueryWindow : public Window {
 		*size = d;
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_Q_TEXT) return;
 
@@ -1152,7 +1152,7 @@ struct QueryWindow : public Window {
 				this->message, TC_FROMSTRING, SA_CENTER);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_Q_YES: {

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -486,7 +486,7 @@ struct MusicTrackSelectionWindow : public Window {
 		this->LowerWidget(WID_MTS_ALL + _settings_client.music.playlist);
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_MTS_PLAYLIST:
@@ -518,7 +518,7 @@ struct MusicTrackSelectionWindow : public Window {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_MTS_PLAYLIST: {
@@ -553,7 +553,7 @@ struct MusicTrackSelectionWindow : public Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_MTS_LIST_LEFT: {
@@ -586,7 +586,7 @@ struct MusicTrackSelectionWindow : public Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_MTS_LIST_LEFT: { // add to playlist
@@ -618,7 +618,7 @@ struct MusicTrackSelectionWindow : public Window {
 		}
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		switch (widget) {
 			case WID_MTS_MUSICSET:
@@ -700,7 +700,7 @@ struct MusicWindow : public Window {
 			);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			/* Make sure that WID_M_SHUFFLE and WID_M_PROGRAMME have the same size.
@@ -742,7 +742,7 @@ struct MusicWindow : public Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_M_TRACK_NR: {
@@ -805,7 +805,7 @@ struct MusicWindow : public Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_M_PREV: // skip to prev

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -440,7 +440,7 @@ struct NetworkChatWindow : public Window {
 		return pt;
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget != WID_NC_DESTINATION) return;
 
@@ -449,7 +449,7 @@ struct NetworkChatWindow : public Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_NC_SENDBUTTON: /* Send */
@@ -472,7 +472,7 @@ struct NetworkChatWindow : public Window {
 		return state;
 	}
 
-	void OnEditboxChanged(int widget) override
+	void OnEditboxChanged(WidgetID widget) override
 	{
 		if (widget == WID_NC_TEXTBOX) {
 			_chat_tab_completion_active = false;

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -64,7 +64,7 @@ struct ContentTextfileWindow : public TextfileWindow {
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_TF_CAPTION) {
 			SetDParam(0, this->GetTypeString());
@@ -114,7 +114,7 @@ void BaseNetworkContentDownloadStatusWindow::Close([[maybe_unused]] int data)
 	this->Window::Close();
 }
 
-void BaseNetworkContentDownloadStatusWindow::UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize)
+void BaseNetworkContentDownloadStatusWindow::UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize)
 {
 	switch (widget) {
 		case WID_NCDS_PROGRESS_BAR:
@@ -133,7 +133,7 @@ void BaseNetworkContentDownloadStatusWindow::UpdateWidgetSize(int widget, Dimens
 	}
 }
 
-void BaseNetworkContentDownloadStatusWindow::DrawWidget(const Rect &r, int widget) const
+void BaseNetworkContentDownloadStatusWindow::DrawWidget(const Rect &r, WidgetID widget) const
 {
 	switch (widget) {
 		case WID_NCDS_PROGRESS_BAR: {
@@ -285,7 +285,7 @@ public:
 		this->BaseNetworkContentDownloadStatusWindow::Close();
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget == WID_NCDS_CANCELOK) {
 			if (this->downloaded_bytes != this->total_bytes) {
@@ -581,7 +581,7 @@ public:
 		this->checkbox_size = maxdim(maxdim(GetSpriteSize(SPR_BOX_EMPTY), GetSpriteSize(SPR_BOX_CHECKED)), GetSpriteSize(SPR_BLOT));
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_NCL_CHECKBOX:
@@ -605,7 +605,7 @@ public:
 	}
 
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_NCL_DETAILS:
@@ -788,7 +788,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget >= WID_NCL_TEXTFILE && widget < WID_NCL_TEXTFILE + TFT_CONTENT_END) {
 			if (this->selected == nullptr || this->selected->state != ContentInfo::ALREADY_HERE) return;
@@ -921,7 +921,7 @@ public:
 		return ES_HANDLED;
 	}
 
-	void OnEditboxChanged(int wid) override
+	void OnEditboxChanged(WidgetID wid) override
 	{
 		if (wid == WID_NCL_FILTER) {
 			this->filter_data.string_filter.SetFilterTerm(this->filter_editbox.text.buf);

--- a/src/network/network_content_gui.h
+++ b/src/network/network_content_gui.h
@@ -33,8 +33,8 @@ public:
 	BaseNetworkContentDownloadStatusWindow(WindowDesc *desc);
 
 	void Close([[maybe_unused]] int data = 0) override;
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override;
-	void DrawWidget(const Rect &r, int widget) const override;
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override;
+	void DrawWidget(const Rect &r, WidgetID widget) const override;
 	void OnDownloadProgress(const ContentInfo *ci, int bytes) override;
 };
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -462,7 +462,7 @@ public:
 		this->flag_offset = this->blot_offset + ScaleGUITrad(2) + GetSpriteSize(SPR_BLOT).width;
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_NG_MATRIX:
@@ -508,7 +508,7 @@ public:
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_NG_MATRIX: {
@@ -666,7 +666,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_NG_CANCEL: // Cancel button
@@ -800,7 +800,7 @@ public:
 		return state;
 	}
 
-	void OnEditboxChanged(int wid) override
+	void OnEditboxChanged(WidgetID wid) override
 	{
 		switch (wid) {
 			case WID_NG_FILTER: {
@@ -963,7 +963,7 @@ void ShowNetworkGameWindow()
 }
 
 struct NetworkStartServerWindow : public Window {
-	byte widget_id;              ///< The widget that has the pop-up input menu
+	WidgetID widget_id;          ///< The widget that has the pop-up input menu
 	QueryString name_editbox;    ///< Server name editbox.
 
 	NetworkStartServerWindow(WindowDesc *desc) : Window(desc), name_editbox(NETWORK_NAME_LENGTH)
@@ -976,7 +976,7 @@ struct NetworkStartServerWindow : public Window {
 		this->SetFocusedWidget(WID_NSS_GAMENAME);
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_NSS_CONNTYPE_BTN:
@@ -993,7 +993,7 @@ struct NetworkStartServerWindow : public Window {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_NSS_CONNTYPE_BTN:
@@ -1004,7 +1004,7 @@ struct NetworkStartServerWindow : public Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_NSS_SETPWD:
@@ -1013,7 +1013,7 @@ struct NetworkStartServerWindow : public Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_NSS_CANCEL: // Cancel button
@@ -1091,7 +1091,7 @@ struct NetworkStartServerWindow : public Window {
 		}
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		switch (widget) {
 			case WID_NSS_CONNTYPE_BTN:
@@ -1656,7 +1656,7 @@ public:
 		this->SetWidgetDisabledState(WID_CL_SERVER_NAME_EDIT, !_network_server);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_CL_SERVER_VISIBILITY:
@@ -1684,7 +1684,7 @@ public:
 		this->vscroll->SetCapacityFromWidget(this, WID_CL_MATRIX);
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_CL_SERVER_NAME:
@@ -1719,7 +1719,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_CL_SERVER_NAME_EDIT:
@@ -1753,7 +1753,7 @@ public:
 		}
 	}
 
-	bool OnTooltip([[maybe_unused]] Point pt, int widget, TooltipCloseCondition close_cond) override
+	bool OnTooltip([[maybe_unused]] Point pt, WidgetID widget, TooltipCloseCondition close_cond) override
 	{
 		switch (widget) {
 			case WID_CL_MATRIX: {
@@ -1792,7 +1792,7 @@ public:
 		return false;
 	}
 
-	void OnDropdownClose(Point pt, int widget, int index, bool instant_close) override
+	void OnDropdownClose(Point pt, WidgetID widget, int index, bool instant_close) override
 	{
 		/* If you close the dropdown outside the list, don't take any action. */
 		if (widget == WID_CL_MATRIX) return;
@@ -1800,7 +1800,7 @@ public:
 		Window::OnDropdownClose(pt, widget, index, instant_close);
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		switch (widget) {
 			case WID_CL_SERVER_VISIBILITY:
@@ -2010,7 +2010,7 @@ public:
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_CL_MATRIX: {
@@ -2046,7 +2046,7 @@ public:
 		}
 	}
 
-	void OnMouseOver([[maybe_unused]] Point pt, int widget) override
+	void OnMouseOver([[maybe_unused]] Point pt, WidgetID widget) override
 	{
 		if (widget != WID_CL_MATRIX) {
 			if (this->hover_index != -1) {
@@ -2082,7 +2082,7 @@ struct NetworkJoinStatusWindow : Window {
 		this->InitNested(WN_NETWORK_STATUS_WINDOW_JOIN);
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_NJS_PROGRESS_BAR: {
@@ -2133,7 +2133,7 @@ struct NetworkJoinStatusWindow : Window {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_NJS_PROGRESS_BAR:
@@ -2159,7 +2159,7 @@ struct NetworkJoinStatusWindow : Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget == WID_NJS_CANCELOK) { // Disconnect button
 			NetworkDisconnect();
@@ -2248,14 +2248,14 @@ struct NetworkCompanyPasswordWindow : public Window {
 		this->ReInit();
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget == WID_NCP_WARNING) {
 			*size = this->warning_size;
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_NCP_WARNING) return;
 
@@ -2272,7 +2272,7 @@ struct NetworkCompanyPasswordWindow : public Window {
 		NetworkChangeCompanyPassword(_local_company, this->password_editbox.text.buf);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_NCP_OK:
@@ -2354,14 +2354,14 @@ struct NetworkAskRelayWindow : public Window {
 		this->Window::Close();
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget == WID_NAR_TEXT) {
 			*size = GetStringBoundingBox(STR_NETWORK_ASK_RELAY_TEXT);
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget == WID_NAR_TEXT) {
 			DrawStringMultiLine(r, STR_NETWORK_ASK_RELAY_TEXT, TC_FROMSTRING, SA_CENTER);
@@ -2376,7 +2376,7 @@ struct NetworkAskRelayWindow : public Window {
 		this->SetDirty();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_NAR_TEXT:
@@ -2386,7 +2386,7 @@ struct NetworkAskRelayWindow : public Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_NAR_NO:
@@ -2457,14 +2457,14 @@ struct NetworkAskSurveyWindow : public Window {
 		this->InitNested(0);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget == WID_NAS_TEXT) {
 			*size = GetStringBoundingBox(STR_NETWORK_ASK_SURVEY_TEXT);
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget == WID_NAS_TEXT) {
 			DrawStringMultiLine(r, STR_NETWORK_ASK_SURVEY_TEXT, TC_BLACK, SA_CENTER);
@@ -2479,7 +2479,7 @@ struct NetworkAskSurveyWindow : public Window {
 		this->SetDirty();
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_NAS_PREVIEW:

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -359,14 +359,14 @@ struct NewGRFInspectWindow : Window {
 		this->OnInvalidateData(0, true);
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget != WID_NGRFI_CAPTION) return;
 
 		GetFeatureHelper(this->window_number)->SetStringParameters(this->GetFeatureIndex());
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_NGRFI_VEH_CHAIN: {
@@ -542,7 +542,7 @@ struct NewGRFInspectWindow : Window {
 		const_cast<NewGRFInspectWindow*>(this)->vscroll->SetCount(i);
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_NGRFI_VEH_CHAIN:
@@ -555,7 +555,7 @@ struct NewGRFInspectWindow : Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_NGRFI_PARENT: {
@@ -843,7 +843,7 @@ struct SpriteAlignerWindow : Window {
 		this->InvalidateData(0, true);
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		const Sprite *spr = GetSprite(this->current_sprite, SpriteType::Normal);
 		switch (widget) {
@@ -877,7 +877,7 @@ struct SpriteAlignerWindow : Window {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_SA_SPRITE:
@@ -895,7 +895,7 @@ struct SpriteAlignerWindow : Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_SA_SPRITE: {
@@ -947,7 +947,7 @@ struct SpriteAlignerWindow : Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_SA_PREVIOUS:

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -210,7 +210,7 @@ struct NewGRFParametersWindow : public Window {
 		return this->HasParameterInfo(nr) ? this->grf_config->param_info[nr].value() : GetDummyParameterInfo(nr);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_NP_NUMPAR_DEC:
@@ -253,7 +253,7 @@ struct NewGRFParametersWindow : public Window {
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_NP_NUMPAR:
@@ -262,7 +262,7 @@ struct NewGRFParametersWindow : public Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget == WID_NP_DESCRIPTION) {
 			if (!this->HasParameterInfo(this->clicked_row)) return;
@@ -331,7 +331,7 @@ struct NewGRFParametersWindow : public Window {
 		this->DrawWidgets();
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_NP_NUMPAR_DEC:
@@ -453,7 +453,7 @@ struct NewGRFParametersWindow : public Window {
 		this->SetDirty();
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		if (widget != WID_NP_SETTING_DROPDOWN) return;
 		assert(this->clicked_dropdown);
@@ -462,7 +462,7 @@ struct NewGRFParametersWindow : public Window {
 		this->SetDirty();
 	}
 
-	void OnDropdownClose(Point, int widget, int, bool) override
+	void OnDropdownClose(Point, WidgetID widget, int, bool) override
 	{
 		if (widget != WID_NP_SETTING_DROPDOWN) return;
 		/* We cannot raise the dropdown button just yet. OnClick needs some hint, whether
@@ -564,7 +564,7 @@ struct NewGRFTextfileWindow : public TextfileWindow {
 		this->LoadTextfile(textfile.value(), NEWGRF_DIR);
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_TF_CAPTION) {
 			SetDParam(0, STR_CONTENT_TYPE_NEWGRF);
@@ -741,7 +741,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_NS_FILE_LIST:
@@ -799,7 +799,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		this->vscroll2->SetCapacityFromWidget(this, WID_NS_AVAIL_LIST);
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_NS_PRESET_LIST:
@@ -848,7 +848,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		return pal;
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_NS_FILE_LIST: {
@@ -940,7 +940,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget >= WID_NS_NEWGRF_TEXTFILE && widget < WID_NS_NEWGRF_TEXTFILE + TFT_CONTENT_END) {
 			if (this->active_sel == nullptr && this->avail_sel == nullptr) return;
@@ -1175,7 +1175,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		this->CloseChildWindows(WC_QUERY_STRING); // Remove the parameter query window
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		if (widget != WID_NS_PRESET_LIST) return;
 		if (!this->editable) return;
@@ -1361,7 +1361,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		return ES_HANDLED;
 	}
 
-	void OnEditboxChanged(int widget) override
+	void OnEditboxChanged(WidgetID widget) override
 	{
 		if (!this->editable) return;
 
@@ -1373,7 +1373,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		}
 	}
 
-	void OnDragDrop(Point pt, int widget) override
+	void OnDragDrop(Point pt, WidgetID widget) override
 	{
 		if (!this->editable) return;
 
@@ -1421,7 +1421,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		}
 	}
 
-	void OnMouseDrag(Point pt, int widget) override
+	void OnMouseDrag(Point pt, WidgetID widget) override
 	{
 		if (!this->editable) return;
 
@@ -2096,7 +2096,7 @@ struct SavePresetWindow : public Window {
 	{
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_SVP_PRESET_LIST: {
@@ -2113,7 +2113,7 @@ struct SavePresetWindow : public Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_SVP_PRESET_LIST: {
@@ -2137,7 +2137,7 @@ struct SavePresetWindow : public Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_SVP_PRESET_LIST: {
@@ -2211,7 +2211,7 @@ struct ScanProgressWindow : public Window {
 		this->InitNested(1);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_SP_PROGRESS_BAR: {
@@ -2234,7 +2234,7 @@ struct ScanProgressWindow : public Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_SP_PROGRESS_BAR: {

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -342,7 +342,7 @@ struct NewsWindow : Window {
 		return pt;
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		StringID str = STR_NULL;
 		switch (widget) {
@@ -416,12 +416,12 @@ struct NewsWindow : Window {
 		*size = maxdim(*size, d);
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_N_DATE) SetDParam(0, this->ni->date);
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_N_CAPTION:
@@ -478,7 +478,7 @@ struct NewsWindow : Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_N_CLOSEBOX:
@@ -590,7 +590,7 @@ private:
 		return this->ni->params[1].data;
 	}
 
-	StringID GetNewVehicleMessageString(int widget) const
+	StringID GetNewVehicleMessageString(WidgetID widget) const
 	{
 		assert(this->ni->reftype1 == NR_ENGINE);
 		EngineID engine = this->ni->ref1;
@@ -1127,7 +1127,7 @@ struct MessageHistoryWindow : Window {
 		this->OnInvalidateData(0);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget == WID_MH_BACKGROUND) {
 			this->line_height = GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.vsep_normal;
@@ -1149,7 +1149,7 @@ struct MessageHistoryWindow : Window {
 		this->DrawWidgets();
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_MH_BACKGROUND || _total_news == 0) return;
 
@@ -1188,7 +1188,7 @@ struct MessageHistoryWindow : Window {
 		this->vscroll->SetCount(_total_news);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget == WID_MH_BACKGROUND) {
 			NewsItem *ni = _latest_news;

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -184,7 +184,7 @@ public:
 		assert(ObjectClass::Get(_selected_object_class)->GetUISpecCount() > 0); // object GUI should be disabled elsewise
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_BO_OBJECT_NAME: {
@@ -212,7 +212,7 @@ public:
 		this->object_margin = ScaleGUITrad(4);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_BO_CLASS_LIST: {
@@ -304,7 +304,7 @@ public:
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (GB(widget, 0, 16)) {
 			case WID_BO_CLASS_LIST: {
@@ -494,7 +494,7 @@ public:
 		this->vscroll->SetCapacityFromWidget(this, WID_BO_CLASS_LIST);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (GB(widget, 0, 16)) {
 			case WID_BO_CLASS_LIST: {
@@ -575,7 +575,7 @@ public:
 		return ES_HANDLED;
 	}
 
-	void OnEditboxChanged(int widget) override
+	void OnEditboxChanged(WidgetID widget) override
 	{
 		if (widget == WID_BO_FILTER) {
 			string_filter.SetFilterTerm(this->filter_editbox.text.buf);

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -801,7 +801,7 @@ public:
 		this->OnInvalidateData(VIWD_MODIFY_ORDERS);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_O_ORDER_LIST:
@@ -1081,7 +1081,7 @@ public:
 		this->DrawWidgets();
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_O_ORDER_LIST) return;
 
@@ -1140,7 +1140,7 @@ public:
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_O_COND_VALUE: {
@@ -1161,7 +1161,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_O_ORDER_LIST: {
@@ -1351,7 +1351,7 @@ public:
 		}
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		switch (widget) {
 			case WID_O_NON_STOP:
@@ -1394,7 +1394,7 @@ public:
 		}
 	}
 
-	void OnDragDrop(Point pt, int widget) override
+	void OnDragDrop(Point pt, WidgetID widget) override
 	{
 		switch (widget) {
 			case WID_O_ORDER_LIST: {
@@ -1525,7 +1525,7 @@ public:
 		}
 	}
 
-	void OnMouseDrag(Point pt, int widget) override
+	void OnMouseDrag(Point pt, WidgetID widget) override
 	{
 		if (this->selected_order != -1 && widget == WID_O_ORDER_LIST) {
 			/* An order is dragged.. */

--- a/src/osk_gui.cpp
+++ b/src/osk_gui.cpp
@@ -37,7 +37,7 @@ static byte _keystate = KEYS_NONE;
 struct OskWindow : public Window {
 	StringID caption;      ///< the caption for this window.
 	QueryString *qs;       ///< text-input
-	int text_btn;          ///< widget number of parent's text field
+	WidgetID text_btn;     ///< widget number of parent's text field
 	Textbuf *text;         ///< pointer to parent's textbuffer (to update caret position)
 	std::string orig_str;  ///< Original string.
 	bool shift;            ///< Is the shift effectively pressed?
@@ -88,12 +88,12 @@ struct OskWindow : public Window {
 		this->SetWidgetLoweredState(WID_OSK_CAPS, HasBit(_keystate, KEYS_CAPS));
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_OSK_CAPTION) SetDParam(0, this->caption);
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget < WID_OSK_LETTERS) return;
 
@@ -101,7 +101,7 @@ struct OskWindow : public Window {
 		DrawCharCentered(_keyboard[this->shift][widget], r, TC_BLACK);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		/* clicked a letter */
 		if (widget >= WID_OSK_LETTERS) {
@@ -183,7 +183,7 @@ struct OskWindow : public Window {
 		}
 	}
 
-	void OnEditboxChanged(int widget) override
+	void OnEditboxChanged(WidgetID widget) override
 	{
 		if (widget == WID_OSK_TEXT) {
 			this->SetWidgetDirty(WID_OSK_TEXT);
@@ -222,7 +222,7 @@ static const int KEY_PADDING = 6;     // Vertical padding for remaining key rows
  * @param widdata Data value of the key widget.
  * @note Key width is measured in 1/2 keys to allow for 1/2 key shifting between rows.
  */
-static void AddKey(NWidgetHorizontal *hor, int pad_y, int num_half, WidgetType widtype, int widnum, uint16_t widdata)
+static void AddKey(NWidgetHorizontal *hor, int pad_y, int num_half, WidgetType widtype, WidgetID widnum, uint16_t widdata)
 {
 	int key_width = HALF_KEY_WIDTH + (INTER_KEY_SPACE + HALF_KEY_WIDTH) * (num_half - 1);
 
@@ -260,7 +260,7 @@ static NWidgetBase *MakeNumberKeys()
 {
 	NWidgetHorizontal *hor = new NWidgetHorizontalLTR();
 
-	for (int widnum = WID_OSK_NUMBERS_FIRST; widnum <= WID_OSK_NUMBERS_LAST; widnum++) {
+	for (WidgetID widnum = WID_OSK_NUMBERS_FIRST; widnum <= WID_OSK_NUMBERS_LAST; widnum++) {
 		AddKey(hor, KEY_PADDING, 2, WWT_PUSHBTN, widnum, 0x0);
 	}
 	return hor;
@@ -272,7 +272,7 @@ static NWidgetBase *MakeQwertyKeys()
 	NWidgetHorizontal *hor = new NWidgetHorizontalLTR();
 
 	AddKey(hor, KEY_PADDING, 3, WWT_PUSHIMGBTN, WID_OSK_SPECIAL, SPR_OSK_SPECIAL);
-	for (int widnum = WID_OSK_QWERTY_FIRST; widnum <= WID_OSK_QWERTY_LAST; widnum++) {
+	for (WidgetID widnum = WID_OSK_QWERTY_FIRST; widnum <= WID_OSK_QWERTY_LAST; widnum++) {
 		AddKey(hor, KEY_PADDING, 2, WWT_PUSHBTN, widnum, 0x0);
 	}
 	AddKey(hor, KEY_PADDING, 1, NWID_SPACER, 0, 0);
@@ -285,7 +285,7 @@ static NWidgetBase *MakeAsdfgKeys()
 	NWidgetHorizontal *hor = new NWidgetHorizontalLTR();
 
 	AddKey(hor, KEY_PADDING, 4, WWT_IMGBTN, WID_OSK_CAPS, SPR_OSK_CAPS);
-	for (int widnum = WID_OSK_ASDFG_FIRST; widnum <= WID_OSK_ASDFG_LAST; widnum++) {
+	for (WidgetID widnum = WID_OSK_ASDFG_FIRST; widnum <= WID_OSK_ASDFG_LAST; widnum++) {
 		AddKey(hor, KEY_PADDING, 2, WWT_PUSHBTN, widnum, 0x0);
 	}
 	return hor;
@@ -297,7 +297,7 @@ static NWidgetBase *MakeZxcvbKeys()
 	NWidgetHorizontal *hor = new NWidgetHorizontalLTR();
 
 	AddKey(hor, KEY_PADDING, 3, WWT_IMGBTN, WID_OSK_SHIFT, SPR_OSK_SHIFT);
-	for (int widnum = WID_OSK_ZXCVB_FIRST; widnum <= WID_OSK_ZXCVB_LAST; widnum++) {
+	for (WidgetID widnum = WID_OSK_ZXCVB_FIRST; widnum <= WID_OSK_ZXCVB_LAST; widnum++) {
 		AddKey(hor, KEY_PADDING, 2, WWT_PUSHBTN, widnum, 0x0);
 	}
 	AddKey(hor, KEY_PADDING, 1, NWID_SPACER, 0, 0);
@@ -390,7 +390,7 @@ void GetKeyboardLayout()
  * @param parent pointer to the Window where this keyboard originated from
  * @param button widget number of parent's textbox
  */
-void ShowOnScreenKeyboard(Window *parent, int button)
+void ShowOnScreenKeyboard(Window *parent, WidgetID button)
 {
 	CloseWindowById(WC_OSK, 0);
 
@@ -405,7 +405,7 @@ void ShowOnScreenKeyboard(Window *parent, int button)
  * @param parent window that just updated its original text
  * @param button widget number of parent's textbox to update
  */
-void UpdateOSKOriginalText(const Window *parent, int button)
+void UpdateOSKOriginalText(const Window *parent, WidgetID button)
 {
 	OskWindow *osk = dynamic_cast<OskWindow *>(FindWindowById(WC_OSK, 0));
 	if (osk == nullptr || osk->parent != parent || osk->text_btn != button) return;
@@ -421,7 +421,7 @@ void UpdateOSKOriginalText(const Window *parent, int button)
  * @param button Editbox of \a w to check for
  * @return true if the OSK is opened for \a button.
  */
-bool IsOSKOpenedFor(const Window *w, int button)
+bool IsOSKOpenedFor(const Window *w, WidgetID button)
 {
 	OskWindow *osk = dynamic_cast<OskWindow *>(FindWindowById(WC_OSK, 0));
 	return osk != nullptr && osk->parent == w && osk->text_btn == button;

--- a/src/querystring_gui.h
+++ b/src/querystring_gui.h
@@ -40,17 +40,17 @@ struct QueryString {
 	}
 
 public:
-	void DrawEditBox(const Window *w, int wid) const;
-	void ClickEditBox(Window *w, Point pt, int wid, int click_count, bool focus_changed);
-	void HandleEditBox(Window *w, int wid);
+	void DrawEditBox(const Window *w, WidgetID wid) const;
+	void ClickEditBox(Window *w, Point pt, WidgetID wid, int click_count, bool focus_changed);
+	void HandleEditBox(Window *w, WidgetID wid);
 
-	Point GetCaretPosition(const Window *w, int wid) const;
-	Rect GetBoundingRect(const Window *w, int wid, const char *from, const char *to) const;
-	ptrdiff_t GetCharAtPosition(const Window *w, int wid, const Point &pt) const;
+	Point GetCaretPosition(const Window *w, WidgetID wid) const;
+	Rect GetBoundingRect(const Window *w, WidgetID wid, const char *from, const char *to) const;
+	ptrdiff_t GetCharAtPosition(const Window *w, WidgetID wid, const Point &pt) const;
 };
 
-void ShowOnScreenKeyboard(Window *parent, int button);
-void UpdateOSKOriginalText(const Window *parent, int button);
-bool IsOSKOpenedFor(const Window *w, int button);
+void ShowOnScreenKeyboard(Window *parent, WidgetID button);
+void UpdateOSKOriginalText(const Window *parent, WidgetID button);
+bool IsOSKOpenedFor(const Window *w, WidgetID button);
 
 #endif /* QUERYSTRING_GUI_H */

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -306,7 +306,7 @@ static bool RailToolbar_CtrlChanged(Window *w)
 	if (w->IsWidgetDisabled(WID_RAT_REMOVE)) return false;
 
 	/* allow ctrl to switch remove mode only for these widgets */
-	for (uint i = WID_RAT_BUILD_NS; i <= WID_RAT_BUILD_STATION; i++) {
+	for (WidgetID i = WID_RAT_BUILD_NS; i <= WID_RAT_BUILD_STATION; i++) {
 		if ((i <= WID_RAT_AUTORAIL || i >= WID_RAT_BUILD_WAYPOINT) && w->IsWidgetLowered(i)) {
 			ToggleRailButton_Remove(w);
 			return true;
@@ -458,7 +458,7 @@ struct BuildRailToolbarWindow : Window {
 		this->ReInit();
 	}
 
-	void UpdateRemoveWidgetStatus(int clicked_widget)
+	void UpdateRemoveWidgetStatus(WidgetID clicked_widget)
 	{
 		switch (clicked_widget) {
 			case WID_RAT_REMOVE:
@@ -488,7 +488,7 @@ struct BuildRailToolbarWindow : Window {
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_RAT_CAPTION) {
 			const RailTypeInfo *rti = GetRailTypeInfo(this->railtype);
@@ -502,7 +502,7 @@ struct BuildRailToolbarWindow : Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget < WID_RAT_BUILD_NS) return;
 
@@ -1123,7 +1123,7 @@ public:
 		return ES_HANDLED;
 	}
 
-	void OnEditboxChanged(int widget) override
+	void OnEditboxChanged(WidgetID widget) override
 	{
 		if (widget == WID_BRAS_FILTER_EDITBOX) {
 			string_filter.SetFilterTerm(this->filter_editbox.text.buf);
@@ -1181,7 +1181,7 @@ public:
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_BRAS_NEWST_LIST: {
@@ -1236,7 +1236,7 @@ public:
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		DrawPixelInfo tmp_dpi;
 
@@ -1315,7 +1315,7 @@ public:
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_BRAS_SHOW_NEWST_TYPE) {
 			const StationSpec *statspec = StationClass::Get(_railstation.station_class)->GetSpec(_railstation.station_type);
@@ -1323,7 +1323,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (GB(widget, 0, 16)) {
 			case WID_BRAS_PLATFORM_DIR_X:
@@ -1644,7 +1644,7 @@ private:
 	 * @param widget_index index of this widget in the window
 	 * @param image        the sprite to draw
 	 */
-	void DrawSignalSprite(const Rect &r, int widget_index, SpriteID image) const
+	void DrawSignalSprite(const Rect &r, WidgetID widget_index, SpriteID image) const
 	{
 		Point offset;
 		Dimension sprite_size = GetSpriteSize(image, &offset);
@@ -1708,7 +1708,7 @@ public:
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget == WID_BS_DRAG_SIGNALS_DENSITY_LABEL) {
 			/* Two digits for signals density. */
@@ -1721,7 +1721,7 @@ public:
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_BS_DRAG_SIGNALS_DENSITY_LABEL:
@@ -1730,7 +1730,7 @@ public:
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (IsInsideMM(widget, WID_BS_SEMAPHORE_NORM, WID_BS_ELECTRIC_PBS_OWAY + 1)) {
 			/* Extract signal from widget number. */
@@ -1742,7 +1742,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_BS_SEMAPHORE_NORM:
@@ -1897,7 +1897,7 @@ struct BuildRailDepotWindow : public PickerWindowBase {
 		this->LowerWidget(_build_depot_direction + WID_BRAD_DEPOT_NE);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (!IsInsideMM(widget, WID_BRAD_DEPOT_NE, WID_BRAD_DEPOT_NW + 1)) return;
 
@@ -1905,7 +1905,7 @@ struct BuildRailDepotWindow : public PickerWindowBase {
 		size->height = ScaleGUITrad(48) + WidgetDimensions::scaled.fullbevel.Vertical();
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (!IsInsideMM(widget, WID_BRAD_DEPOT_NE, WID_BRAD_DEPOT_NW + 1)) return;
 
@@ -1919,7 +1919,7 @@ struct BuildRailDepotWindow : public PickerWindowBase {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_BRAD_DEPOT_NE:
@@ -2052,7 +2052,7 @@ struct BuildRailWaypointWindow : PickerWindowBase {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_BRW_WAYPOINT_MATRIX:
@@ -2071,7 +2071,7 @@ struct BuildRailWaypointWindow : PickerWindowBase {
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_BRW_NAME) {
 			if (!this->list.empty() && IsInsideBS(_cur_waypoint_type, 0, this->waypoints->GetSpecCount())) {
@@ -2093,7 +2093,7 @@ struct BuildRailWaypointWindow : PickerWindowBase {
 		this->DrawWidgets();
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (GB(widget, 0, 16)) {
 			case WID_BRW_WAYPOINT: {
@@ -2116,7 +2116,7 @@ struct BuildRailWaypointWindow : PickerWindowBase {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (GB(widget, 0, 16)) {
 			case WID_BRW_WAYPOINT: {
@@ -2143,7 +2143,7 @@ struct BuildRailWaypointWindow : PickerWindowBase {
 		this->list.ForceRebuild();
 	}
 
-	void OnEditboxChanged(int wid) override
+	void OnEditboxChanged(WidgetID wid) override
 	{
 		if (wid == WID_BRW_FILTER) {
 			this->string_filter.SetFilterTerm(this->editbox.text.buf);

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -294,7 +294,7 @@ static bool RoadToolbar_CtrlChanged(Window *w)
 	if (w->IsWidgetDisabled(WID_ROT_REMOVE)) return false;
 
 	/* allow ctrl to switch remove mode only for these widgets */
-	for (uint i = WID_ROT_ROAD_X; i <= WID_ROT_AUTOROAD; i++) {
+	for (WidgetID i = WID_ROT_ROAD_X; i <= WID_ROT_AUTOROAD; i++) {
 		if (w->IsWidgetLowered(i)) {
 			ToggleRoadButton_Remove(w);
 			return true;
@@ -403,7 +403,7 @@ struct BuildRoadToolbarWindow : Window {
 		this->ReInit();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_ROT_CAPTION) {
 			if (this->rti->max_speed > 0) {
@@ -470,7 +470,7 @@ struct BuildRoadToolbarWindow : Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		_remove_button_clicked = false;
 		_one_way_button_clicked = false;
@@ -1010,13 +1010,15 @@ struct BuildRoadDepotWindow : public PickerWindowBase {
 		this->LowerWidget(_road_depot_orientation + WID_BROD_DEPOT_NE);
 		if (RoadTypeIsTram(_cur_roadtype)) {
 			this->GetWidget<NWidgetCore>(WID_BROD_CAPTION)->widget_data = STR_BUILD_DEPOT_TRAM_ORIENTATION_CAPTION;
-			for (int i = WID_BROD_DEPOT_NE; i <= WID_BROD_DEPOT_NW; i++) this->GetWidget<NWidgetCore>(i)->tool_tip = STR_BUILD_DEPOT_TRAM_ORIENTATION_SELECT_TOOLTIP;
+			for (WidgetID i = WID_BROD_DEPOT_NE; i <= WID_BROD_DEPOT_NW; i++) {
+				this->GetWidget<NWidgetCore>(i)->tool_tip = STR_BUILD_DEPOT_TRAM_ORIENTATION_SELECT_TOOLTIP;
+			}
 		}
 
 		this->FinishInitNested(TRANSPORT_ROAD);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (!IsInsideMM(widget, WID_BROD_DEPOT_NE, WID_BROD_DEPOT_NW + 1)) return;
 
@@ -1024,7 +1026,7 @@ struct BuildRoadDepotWindow : public PickerWindowBase {
 		size->height = ScaleGUITrad(48) + WidgetDimensions::scaled.fullbevel.Vertical();
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (!IsInsideMM(widget, WID_BROD_DEPOT_NE, WID_BROD_DEPOT_NW + 1)) return;
 
@@ -1038,7 +1040,7 @@ struct BuildRoadDepotWindow : public PickerWindowBase {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_BROD_DEPOT_NW:
@@ -1178,7 +1180,7 @@ public:
 		const RoadTypeInfo *rti = GetRoadTypeInfo(_cur_roadtype);
 		this->GetWidget<NWidgetCore>(WID_BROS_CAPTION)->widget_data = rti->strings.picker_title[rs];
 
-		for (uint i = RoadTypeIsTram(_cur_roadtype) ? WID_BROS_STATION_X : WID_BROS_STATION_NE; i < WID_BROS_LT_OFF; i++) {
+		for (WidgetID i = RoadTypeIsTram(_cur_roadtype) ? WID_BROS_STATION_X : WID_BROS_STATION_NE; i < WID_BROS_LT_OFF; i++) {
 			this->GetWidget<NWidgetCore>(i)->tool_tip = rti->strings.picker_tooltip[rs];
 		}
 
@@ -1303,7 +1305,7 @@ public:
 		return ES_NOT_HANDLED;
 	}
 
-	void OnEditboxChanged(int widget) override
+	void OnEditboxChanged(WidgetID widget) override
 	{
 		if (widget == WID_BROS_FILTER_EDITBOX) {
 			string_filter.SetFilterTerm(this->filter_editbox.text.buf);
@@ -1341,7 +1343,7 @@ public:
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_BROS_NEWST_LIST: {
@@ -1405,7 +1407,7 @@ public:
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (GB(widget, 0, 16)) {
 			case WID_BROS_STATION_NE:
@@ -1485,7 +1487,7 @@ public:
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_BROS_SHOW_NEWST_TYPE) {
 			const RoadStopSpec *roadstopspec = RoadStopClass::Get(_roadstop_gui_settings.roadstop_class)->GetSpec(_roadstop_gui_settings.roadstop_type);
@@ -1493,7 +1495,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (GB(widget, 0, 16)) {
 			case WID_BROS_STATION_NE:

--- a/src/screenshot_gui.cpp
+++ b/src/screenshot_gui.cpp
@@ -27,7 +27,7 @@ struct ScreenshotWindow : Window {
 		this->DrawWidgets();
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		ScreenshotType st;
 		switch (widget) {

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -924,7 +924,7 @@ public:
 	 * @param number The windownumber that was clicked.
 	 * @param widget The widget in the window that was clicked.
 	 */
-	ScriptEventWindowWidgetClick(ScriptWindow::WindowClass window, uint32_t number, uint8_t widget) :
+	ScriptEventWindowWidgetClick(ScriptWindow::WindowClass window, uint32_t number, WidgetID widget) :
 		ScriptEvent(ET_WINDOW_WIDGET_CLICK),
 		window(window),
 		number(number),
@@ -955,12 +955,12 @@ public:
 	 * Get the number of the widget that was clicked.
 	 * @return The number of the clicked widget.
 	 */
-	uint8_t GetWidgetNumber() { return this->widget; }
+	int GetWidgetNumber() { return this->widget; }
 
 private:
 	ScriptWindow::WindowClass window; ///< Window of the click.
-	uint32_t number;                    ///< Number of the click.
-	uint8_t widget;                     ///< Widget of the click.
+	uint32_t number;                  ///< Number of the click.
+	WidgetID widget;                       ///< Widget of the click.
 };
 
 /**

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -95,14 +95,14 @@ struct ScriptListWindow : public Window {
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget != WID_SCRL_CAPTION) return;
 
 		SetDParam(0, (this->slot == OWNER_DEITY) ? STR_AI_LIST_CAPTION_GAMESCRIPT : STR_AI_LIST_CAPTION_AI);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget != WID_SCRL_LIST) return;
 
@@ -113,7 +113,7 @@ struct ScriptListWindow : public Window {
 		size->height = 5 * this->line_height;
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_SCRL_LIST: {
@@ -184,7 +184,7 @@ struct ScriptListWindow : public Window {
 		InvalidateWindowClassesData(WC_TEXTFILE);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_SCRL_LIST: { // Select one of the Scripts
@@ -335,14 +335,14 @@ struct ScriptSettingsWindow : public Window {
 		this->vscroll->SetCount(this->visible_settings.size());
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget != WID_SCRS_CAPTION) return;
 
 		SetDParam(0, (this->slot == OWNER_DEITY) ? STR_AI_SETTINGS_CAPTION_GAMESCRIPT : STR_AI_SETTINGS_CAPTION_AI);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget != WID_SCRS_BACKGROUND) return;
 
@@ -353,7 +353,7 @@ struct ScriptSettingsWindow : public Window {
 		size->height = 5 * this->line_height;
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_SCRS_BACKGROUND) return;
 
@@ -421,7 +421,7 @@ struct ScriptSettingsWindow : public Window {
 		this->DrawWidgets();
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_SCRS_BACKGROUND: {
@@ -524,14 +524,14 @@ struct ScriptSettingsWindow : public Window {
 		SetValue(value);
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		if (widget != WID_SCRS_SETTING_DROPDOWN) return;
 		assert(this->clicked_dropdown);
 		SetValue(index);
 	}
 
-	void OnDropdownClose(Point, int widget, int, bool) override
+	void OnDropdownClose(Point, WidgetID widget, int, bool) override
 	{
 		if (widget != WID_SCRS_SETTING_DROPDOWN) return;
 		/* We cannot raise the dropdown button just yet. OnClick needs some hint, whether
@@ -634,7 +634,7 @@ struct ScriptTextfileWindow : public TextfileWindow {
 		this->OnInvalidateData();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_TF_CAPTION) {
 			SetDParam(0, (slot == OWNER_DEITY) ? STR_CONTENT_TYPE_GAME_SCRIPT : STR_CONTENT_TYPE_AI);
@@ -821,7 +821,7 @@ struct ScriptDebugWindow : public Window {
 		ScriptDebugWindow::initial_state = this->filter;
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget == WID_SCRD_LOG_PANEL) {
 			resize->height = GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.vsep_normal;
@@ -838,7 +838,7 @@ struct ScriptDebugWindow : public Window {
 		this->DrawWidgets();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget != WID_SCRD_NAME_TEXT) return;
 
@@ -859,7 +859,7 @@ struct ScriptDebugWindow : public Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_SCRD_LOG_PANEL:
@@ -880,7 +880,7 @@ struct ScriptDebugWindow : public Window {
 	 * @param widget Widget index to start.
 	 * @param start Widget index of first company button.
 	 */
-	void DrawWidgetCompanyButton(const Rect &r, int widget, int start) const
+	void DrawWidgetCompanyButton(const Rect &r, WidgetID widget, int start) const
 	{
 		if (this->IsWidgetDisabled(widget)) return;
 		CompanyID cid = (CompanyID)(widget - start);
@@ -1034,7 +1034,7 @@ struct ScriptDebugWindow : public Window {
 		this->last_vscroll_pos = this->vscroll->GetPosition();
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		/* Also called for hotkeys, so check for disabledness */
 		if (this->IsWidgetDisabled(widget)) return;
@@ -1103,7 +1103,7 @@ struct ScriptDebugWindow : public Window {
 		}
 	}
 
-	void OnEditboxChanged(int wid) override
+	void OnEditboxChanged(WidgetID wid) override
 	{
 		if (wid != WID_SCRD_BREAK_STR_EDIT_BOX) return;
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -96,7 +96,7 @@ struct BaseSetTextfileWindow : public TextfileWindow {
 		this->LoadTextfile(textfile.value(), BASESET_DIR);
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_TF_CAPTION) {
 			SetDParam(0, content_type);
@@ -170,7 +170,7 @@ struct GameOptionsWindow : Window {
 	GameSettings *opt;
 	bool reload;
 	int gui_scale;
-	static inline int active_tab = WID_GO_TAB_GENERAL;
+	static inline WidgetID active_tab = WID_GO_TAB_GENERAL;
 
 	GameOptionsWindow(WindowDesc *desc) : Window(desc)
 	{
@@ -202,7 +202,7 @@ struct GameOptionsWindow : Window {
 	 * @param selected_index Currently selected item
 	 * @return the built dropdown list, or nullptr if the widget has no dropdown menu.
 	 */
-	DropDownList BuildDropDownList(int widget, int *selected_index) const
+	DropDownList BuildDropDownList(WidgetID widget, int *selected_index) const
 	{
 		DropDownList list;
 		switch (widget) {
@@ -304,7 +304,7 @@ struct GameOptionsWindow : Window {
 		return list;
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_GO_CURRENCY_DROPDOWN: {
@@ -347,7 +347,7 @@ struct GameOptionsWindow : Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_GO_BASE_GRF_DESCRIPTION:
@@ -384,7 +384,7 @@ struct GameOptionsWindow : Window {
 		}
 	}
 
-	void SetTab(int widget)
+	void SetTab(WidgetID widget)
 	{
 		this->SetWidgetsLoweredState(false, WID_GO_TAB_GENERAL, WID_GO_TAB_GRAPHICS, WID_GO_TAB_SOUND);
 		this->LowerWidget(widget);
@@ -433,7 +433,7 @@ struct GameOptionsWindow : Window {
 		if (changed) this->ReInit(0, 0, this->flags & WF_CENTERED);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_GO_TEXT_SFX_VOLUME:
@@ -453,7 +453,7 @@ struct GameOptionsWindow : Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget >= WID_GO_BASE_GRF_TEXTFILE && widget < WID_GO_BASE_GRF_TEXTFILE + TFT_CONTENT_END) {
 			if (BaseGraphics::GetUsedSet() == nullptr) return;
@@ -644,7 +644,7 @@ struct GameOptionsWindow : Window {
 		}
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		switch (widget) {
 			case WID_GO_CURRENCY_DROPDOWN: // Currency
@@ -2110,7 +2110,7 @@ struct GameSettingsWindow : Window {
 		_circle_size = maxdim(GetSpriteSize(SPR_CIRCLE_FOLDED), GetSpriteSize(SPR_CIRCLE_UNFOLDED));
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_GS_OPTIONSPANEL:
@@ -2178,7 +2178,7 @@ struct GameSettingsWindow : Window {
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_GS_RESTRICT_DROPDOWN:
@@ -2196,7 +2196,7 @@ struct GameSettingsWindow : Window {
 		}
 	}
 
-	DropDownList BuildDropDownList(int widget) const
+	DropDownList BuildDropDownList(WidgetID widget) const
 	{
 		DropDownList list;
 		switch (widget) {
@@ -2220,7 +2220,7 @@ struct GameSettingsWindow : Window {
 		return list;
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_GS_OPTIONSPANEL: {
@@ -2270,7 +2270,7 @@ struct GameSettingsWindow : Window {
 		this->last_clicked = pe;
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_GS_EXPAND_ALL:
@@ -2488,7 +2488,7 @@ struct GameSettingsWindow : Window {
 		this->SetDirty();
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		switch (widget) {
 			case WID_GS_RESTRICT_DROPDOWN:
@@ -2525,7 +2525,7 @@ struct GameSettingsWindow : Window {
 		}
 	}
 
-	void OnDropdownClose(Point pt, int widget, int index, bool instant_close) override
+	void OnDropdownClose(Point pt, WidgetID widget, int index, bool instant_close) override
 	{
 		if (widget != WID_GS_SETTING_DROPDOWN) {
 			/* Normally the default implementation of OnDropdownClose() takes care of
@@ -2574,7 +2574,7 @@ struct GameSettingsWindow : Window {
 		this->SetWidgetDisabledState(WID_GS_COLLAPSE_ALL, all_folded);
 	}
 
-	void OnEditboxChanged(int wid) override
+	void OnEditboxChanged(WidgetID wid) override
 	{
 		if (wid == WID_GS_FILTER) {
 			this->filter.string.SetFilterTerm(this->filter_editbox.text.buf);
@@ -2737,7 +2737,7 @@ struct CustomCurrencyWindow : Window {
 		this->SetWidgetDisabledState(WID_CC_YEAR_UP, _custom_currency.to_euro == CalendarTime::MAX_YEAR);
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_CC_RATE:      SetDParam(0, 1); SetDParam(1, 1);            break;
@@ -2755,7 +2755,7 @@ struct CustomCurrencyWindow : Window {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			/* Set the appropriate width for the up/down buttons. */
@@ -2782,7 +2782,7 @@ struct CustomCurrencyWindow : Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		int line = 0;
 		int len = 0;

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -192,7 +192,7 @@ struct SignListWindow : Window, SignList {
 		this->DrawWidgets();
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_SIL_LIST: {
@@ -226,12 +226,12 @@ struct SignListWindow : Window, SignList {
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_SIL_CAPTION) SetDParam(0, this->vscroll->GetCount());
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_SIL_LIST: {
@@ -263,7 +263,7 @@ struct SignListWindow : Window, SignList {
 		this->vscroll->SetCapacityFromWidget(this, WID_SIL_LIST, WidgetDimensions::scaled.framerect.Vertical());
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_SIL_LIST: {
@@ -299,7 +299,7 @@ struct SignListWindow : Window, SignList {
 		return ES_HANDLED;
 	}
 
-	void OnEditboxChanged(int widget) override
+	void OnEditboxChanged(WidgetID widget) override
 	{
 		if (widget == WID_SIL_FILTER_TEXT) this->SetFilterString(this->filter_editbox.text.buf);
 	}
@@ -474,7 +474,7 @@ struct SignWindow : Window, SignList {
 		return next ? this->signs.front() : this->signs.back();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_QES_CAPTION:
@@ -483,7 +483,7 @@ struct SignWindow : Window, SignList {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_QES_LOCATION: {

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -1459,7 +1459,7 @@ public:
 		this->Window::Close();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_SM_CAPTION:
@@ -1537,7 +1537,7 @@ public:
 		this->DrawWidgets();
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_SM_MAP: {
@@ -1634,7 +1634,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_SM_MAP: { // Map window
@@ -1779,7 +1779,7 @@ public:
 		this->SetDirty();
 	}
 
-	bool OnRightClick(Point, int widget) override
+	bool OnRightClick(Point, WidgetID widget) override
 	{
 		if (widget != WID_SM_MAP || _scrolling_viewport) return false;
 
@@ -1812,7 +1812,7 @@ public:
 		this->SetDirty();
 	}
 
-	void OnMouseOver([[maybe_unused]] Point pt, int widget) override
+	void OnMouseOver([[maybe_unused]] Point pt, WidgetID widget) override
 	{
 		IndustryType new_highlight = INVALID_INDUSTRYTYPE;
 		if (widget == WID_SM_LEGEND && this->map_type == SMT_INDUSTRY) {

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -399,7 +399,7 @@ public:
 		CompanyStationsWindow::initial_state = this->filter;
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_STL_SORTBY: {
@@ -453,7 +453,7 @@ public:
 		this->DrawWidgets();
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_STL_SORTBY:
@@ -525,7 +525,7 @@ public:
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_STL_CAPTION) {
 			SetDParam(0, this->window_number);
@@ -533,7 +533,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_STL_LIST: {
@@ -572,7 +572,7 @@ public:
 				break;
 
 			case WID_STL_FACILALL:
-				for (uint i = WID_STL_TRAIN; i <= WID_STL_SHIP; i++) {
+				for (WidgetID i = WID_STL_TRAIN; i <= WID_STL_SHIP; i++) {
 					this->LowerWidget(i);
 				}
 
@@ -648,7 +648,7 @@ public:
 		}
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		if (widget == WID_STL_SORTDROPBTN) {
 			if (this->stations.SortType() != index) {
@@ -1386,7 +1386,7 @@ struct StationViewWindow : public Window {
 		data->Update(count);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_SV_WAITING:
@@ -1470,7 +1470,7 @@ struct StationViewWindow : public Window {
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_SV_CAPTION) {
 			const Station *st = Station::Get(this->window_number);
@@ -1914,7 +1914,7 @@ struct StationViewWindow : public Window {
 		this->SetWidgetDirty(WID_SV_WAITING);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_SV_WAITING:
@@ -2079,7 +2079,7 @@ struct StationViewWindow : public Window {
 		this->SetDirty();
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		if (widget == WID_SV_SORT_BY) {
 			this->SelectSortBy(index);
@@ -2299,7 +2299,7 @@ struct SelectStationWindow : Window {
 		this->Window::Close();
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget != WID_JS_PANEL) return;
 
@@ -2320,7 +2320,7 @@ struct SelectStationWindow : Window {
 		*size = d;
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_JS_PANEL) return;
 
@@ -2338,7 +2338,7 @@ struct SelectStationWindow : Window {
 
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget != WID_JS_PANEL) return;
 
@@ -2378,7 +2378,7 @@ struct SelectStationWindow : Window {
 		this->SetDirty();
 	}
 
-	void OnMouseOver([[maybe_unused]] Point pt, int widget) override
+	void OnMouseOver([[maybe_unused]] Point pt, WidgetID widget) override
 	{
 		if (widget != WID_JS_PANEL) {
 			SetViewportCatchmentSpecializedStation<T>(nullptr, true);

--- a/src/statusbar_gui.cpp
+++ b/src/statusbar_gui.cpp
@@ -83,7 +83,7 @@ struct StatusBarWindow : Window {
 		Window::FindWindowPlacementAndResize(_toolbar_width, def_height);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		Dimension d;
 		switch (widget) {
@@ -109,7 +109,7 @@ struct StatusBarWindow : Window {
 		*size = maxdim(d, *size);
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		Rect tr = r.Shrink(WidgetDimensions::scaled.framerect, RectPadding::zero);
 		tr.top = CenterBounds(r.top, r.bottom, GetCharacterHeight(FS_NORMAL));
@@ -190,7 +190,7 @@ struct StatusBarWindow : Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_S_MIDDLE: ShowLastNewsMessage(); break;

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -643,7 +643,7 @@ public:
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_SB_SEL_PAGE: {
@@ -677,7 +677,7 @@ public:
 		this->DrawWidgets();
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_SB_PAGE_PANEL) return;
 
@@ -751,7 +751,7 @@ public:
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget != WID_SB_SEL_PAGE && widget != WID_SB_PAGE_PANEL) return;
 
@@ -801,7 +801,7 @@ public:
 		this->vscroll->SetCount(this->GetContentHeight());
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_SB_SEL_PAGE: {
@@ -842,7 +842,7 @@ public:
 		}
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		if (widget != WID_SB_SEL_PAGE) return;
 

--- a/src/subsidy_gui.cpp
+++ b/src/subsidy_gui.cpp
@@ -36,7 +36,7 @@ struct SubsidyListWindow : Window {
 		this->OnInvalidateData(0);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget != WID_SUL_PANEL) return;
 
@@ -125,7 +125,7 @@ struct SubsidyListWindow : Window {
 		return 3 + num_awarded + num_not_awarded;
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget != WID_SUL_PANEL) return;
 		Dimension d = maxdim(GetStringBoundingBox(STR_SUBSIDIES_OFFERED_TITLE), GetStringBoundingBox(STR_SUBSIDIES_SUBSIDISED_TITLE));
@@ -138,7 +138,7 @@ struct SubsidyListWindow : Window {
 		*size = maxdim(*size, d);
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_SUL_PANEL) return;
 

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -175,7 +175,7 @@ struct TerraformToolbarWindow : Window {
 		show_object->SetDisplayedPlane(ObjectClass::GetUIClassCount() != 0 ? 0 : SZSP_NONE);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget < WID_TT_BUTTONS_START) return;
 
@@ -553,7 +553,7 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget != WID_ETT_DOTS) return;
 
@@ -561,7 +561,7 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 		size->height = std::max<uint>(size->height, ScaleGUITrad(31));
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_ETT_DOTS) return;
 
@@ -578,7 +578,7 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 		} while (--n);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget < WID_ETT_BUTTONS_START) return;
 

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -126,7 +126,7 @@ uint TextfileWindow::GetContentHeight()
 	return this->lines.back().bottom;
 }
 
-/* virtual */ void TextfileWindow::UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize)
+/* virtual */ void TextfileWindow::UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize)
 {
 	switch (widget) {
 		case WID_TF_BACKGROUND:
@@ -516,7 +516,7 @@ void TextfileWindow::AfterLoadMarkdown()
 	}
 }
 
-/* virtual */ void TextfileWindow::OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count)
+/* virtual */ void TextfileWindow::OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count)
 {
 	switch (widget) {
 		case WID_TF_WRAPTEXT:
@@ -548,7 +548,7 @@ void TextfileWindow::AfterLoadMarkdown()
 	}
 }
 
-/* virtual */ void TextfileWindow::DrawWidget(const Rect &r, int widget) const
+/* virtual */ void TextfileWindow::DrawWidget(const Rect &r, WidgetID widget) const
 {
 	if (widget != WID_TF_BACKGROUND) return;
 
@@ -592,7 +592,7 @@ void TextfileWindow::AfterLoadMarkdown()
 	this->SetupScrollbars(true);
 }
 
-void TextfileWindow::OnDropdownSelect(int widget, int index)
+void TextfileWindow::OnDropdownSelect(WidgetID widget, int index)
 {
 	if (widget != WID_TF_JUMPLIST) return;
 

--- a/src/textfile_gui.h
+++ b/src/textfile_gui.h
@@ -25,12 +25,12 @@ struct TextfileWindow : public Window, MissingGlyphSearcher {
 
 	TextfileWindow(TextfileType file_type);
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override;
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override;
-	void DrawWidget(const Rect &r, int widget) const override;
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override;
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override;
+	void DrawWidget(const Rect &r, WidgetID widget) const override;
 	void OnResize() override;
 	void OnInvalidateData(int data = 0, bool gui_scope = true) override;
-	void OnDropdownSelect(int widget, int index) override;
+	void OnDropdownSelect(WidgetID widget, int index) override;
 
 	void Reset() override;
 	FontSize DefaultSize() override;

--- a/src/tilehighlight_func.h
+++ b/src/tilehighlight_func.h
@@ -16,7 +16,7 @@
 void PlaceProc_DemolishArea(TileIndex tile);
 bool GUIPlaceProcDragXY(ViewportDragDropSelectionProcess proc, TileIndex start_tile, TileIndex end_tile);
 
-bool HandlePlacePushButton(Window *w, int widget, CursorID cursor, HighLightStyle mode);
+bool HandlePlacePushButton(Window *w, WidgetID widget, CursorID cursor, HighLightStyle mode);
 void SetObjectToPlaceWnd(CursorID icon, PaletteID pal, HighLightStyle mode, Window *w);
 void SetObjectToPlace(CursorID icon, PaletteID pal, HighLightStyle mode, WindowClass window_class, WindowNumber window_num);
 void ResetObjectToPlace();

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -242,7 +242,7 @@ struct TimetableWindow : Window {
 		return (travelling && v->lateness_counter < 0);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_VT_ARRIVAL_DEPARTURE_PANEL:
@@ -396,7 +396,7 @@ struct TimetableWindow : Window {
 		this->DrawWidgets();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_VT_CAPTION: SetDParam(0, this->vehicle->index); break;
@@ -590,7 +590,7 @@ struct TimetableWindow : Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_VT_TIMETABLE_PANEL: {
@@ -620,7 +620,7 @@ struct TimetableWindow : Window {
 		return { order_number, mtf };
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		const Vehicle *v = this->vehicle;
 

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -109,7 +109,7 @@ public:
  * @param list List of items
  * @param def Default item
  */
-static void PopupMainToolbarMenu(Window *w, int widget, DropDownList &&list, int def)
+static void PopupMainToolbarMenu(Window *w, WidgetID widget, DropDownList &&list, int def)
 {
 	ShowDropDownList(w, std::move(list), def, widget, 0, true);
 	if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
@@ -121,7 +121,7 @@ static void PopupMainToolbarMenu(Window *w, int widget, DropDownList &&list, int
  * @param widget Toolbar button
  * @param strings List of strings for each item in the menu
  */
-static void PopupMainToolbarMenu(Window *w, int widget, const std::initializer_list<StringID> &strings)
+static void PopupMainToolbarMenu(Window *w, WidgetID widget, const std::initializer_list<StringID> &strings)
 {
 	DropDownList list;
 	int i = 0;
@@ -147,7 +147,7 @@ static const int CTMN_SPECTATOR   = -3; ///< Show a company window as spectator
  * @param widget The button widget id.
  * @param grey A bitbask of which items to mark as disabled.
  */
-static void PopupMainCompanyToolbMenu(Window *w, int widget, int grey = 0)
+static void PopupMainCompanyToolbMenu(Window *w, WidgetID widget, int grey = 0)
 {
 	DropDownList list;
 
@@ -820,7 +820,7 @@ static CallBackFunction MenuClickShowAir(int index)
 static CallBackFunction ToolbarZoomInClick(Window *w)
 {
 	if (DoZoomInOutWindow(ZOOM_IN, GetMainWindow())) {
-		w->HandleButtonClick((_game_mode == GM_EDITOR) ? (byte)WID_TE_ZOOM_IN : (byte)WID_TN_ZOOM_IN);
+		w->HandleButtonClick((_game_mode == GM_EDITOR) ? (WidgetID)WID_TE_ZOOM_IN : (WidgetID)WID_TN_ZOOM_IN);
 		if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
 	}
 	return CBF_NONE;
@@ -831,7 +831,7 @@ static CallBackFunction ToolbarZoomInClick(Window *w)
 static CallBackFunction ToolbarZoomOutClick(Window *w)
 {
 	if (DoZoomInOutWindow(ZOOM_OUT, GetMainWindow())) {
-		w->HandleButtonClick((_game_mode == GM_EDITOR) ? (byte)WID_TE_ZOOM_OUT : (byte)WID_TN_ZOOM_OUT);
+		w->HandleButtonClick((_game_mode == GM_EDITOR) ? (WidgetID)WID_TE_ZOOM_OUT : (WidgetID)WID_TN_ZOOM_OUT);
 		if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
 	}
 	return CBF_NONE;
@@ -980,7 +980,7 @@ static CallBackFunction MenuClickForest(int index)
 
 static CallBackFunction ToolbarMusicClick(Window *w)
 {
-	PopupMainToolbarMenu(w, _game_mode == GM_EDITOR ? (int)WID_TE_MUSIC_SOUND : (int)WID_TN_MUSIC_SOUND, {STR_TOOLBAR_SOUND_MUSIC});
+	PopupMainToolbarMenu(w, _game_mode == GM_EDITOR ? (WidgetID)WID_TE_MUSIC_SOUND : (WidgetID)WID_TN_MUSIC_SOUND, {STR_TOOLBAR_SOUND_MUSIC});
 	return CBF_NONE;
 }
 
@@ -1035,13 +1035,13 @@ static CallBackFunction PlaceLandBlockInfo()
 static CallBackFunction ToolbarHelpClick(Window *w)
 {
 	if (_settings_client.gui.newgrf_developer_tools) {
-		PopupMainToolbarMenu(w, _game_mode == GM_EDITOR ? (int)WID_TE_HELP : (int)WID_TN_HELP, {STR_ABOUT_MENU_LAND_BLOCK_INFO,
+		PopupMainToolbarMenu(w, _game_mode == GM_EDITOR ? (WidgetID)WID_TE_HELP : (WidgetID)WID_TN_HELP, {STR_ABOUT_MENU_LAND_BLOCK_INFO,
 				STR_ABOUT_MENU_HELP, STR_NULL, STR_ABOUT_MENU_TOGGLE_CONSOLE, STR_ABOUT_MENU_AI_DEBUG,
 				STR_ABOUT_MENU_SCREENSHOT, STR_ABOUT_MENU_SHOW_FRAMERATE, STR_ABOUT_MENU_ABOUT_OPENTTD,
 				STR_ABOUT_MENU_SPRITE_ALIGNER, STR_ABOUT_MENU_TOGGLE_BOUNDING_BOXES, STR_ABOUT_MENU_TOGGLE_DIRTY_BLOCKS,
 				STR_ABOUT_MENU_TOGGLE_WIDGET_OUTLINES});
 	} else {
-		PopupMainToolbarMenu(w, _game_mode == GM_EDITOR ? (int)WID_TE_HELP : (int)WID_TN_HELP, {STR_ABOUT_MENU_LAND_BLOCK_INFO,
+		PopupMainToolbarMenu(w, _game_mode == GM_EDITOR ? (WidgetID)WID_TE_HELP : (WidgetID)WID_TN_HELP, {STR_ABOUT_MENU_LAND_BLOCK_INFO,
 				STR_ABOUT_MENU_HELP, STR_NULL, STR_ABOUT_MENU_TOGGLE_CONSOLE, STR_ABOUT_MENU_AI_DEBUG,
 				STR_ABOUT_MENU_SCREENSHOT, STR_ABOUT_MENU_SHOW_FRAMERATE, STR_ABOUT_MENU_ABOUT_OPENTTD});
 	}
@@ -1143,7 +1143,7 @@ static CallBackFunction ToolbarSwitchClick(Window *w)
 	}
 
 	w->ReInit();
-	w->SetWidgetLoweredState(_game_mode == GM_EDITOR ? (uint)WID_TE_SWITCH_BAR : (uint)WID_TN_SWITCH_BAR, _toolbar_mode == TB_LOWER);
+	w->SetWidgetLoweredState(_game_mode == GM_EDITOR ? (WidgetID)WID_TE_SWITCH_BAR : (WidgetID)WID_TN_SWITCH_BAR, _toolbar_mode == TB_LOWER);
 	if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
 	return CBF_NONE;
 }
@@ -1379,7 +1379,7 @@ public:
 
 		/* Figure out what are the visible buttons */
 		uint arrangable_count, button_count, spacer_count;
-		const byte *arrangement = GetButtonArrangement(given_width, arrangable_count, button_count, spacer_count);
+		const WidgetID *arrangement = GetButtonArrangement(given_width, arrangable_count, button_count, spacer_count);
 
 		/* Create us ourselves a quick lookup table */
 		NWidgetBase *widgets[WID_TN_END];
@@ -1397,7 +1397,7 @@ public:
 		uint button_i = 0;
 
 		/* Index into the arrangement indices. The macro lastof cannot be used here! */
-		const byte *cur_wid = rtl ? &arrangement[arrangable_count - 1] : arrangement;
+		const WidgetID *cur_wid = rtl ? &arrangement[arrangable_count - 1] : arrangement;
 		for (uint i = 0; i < arrangable_count; i++) {
 			NWidgetBase *child_wid = widgets[*cur_wid];
 			/* If we have to give space to the spacers, do that */
@@ -1448,12 +1448,12 @@ public:
 	 * @param spacer_count output of the number of spacers.
 	 * @return the button configuration.
 	 */
-	virtual const byte *GetButtonArrangement(uint &width, uint &arrangable_count, uint &button_count, uint &spacer_count) const = 0;
+	virtual const WidgetID *GetButtonArrangement(uint &width, uint &arrangable_count, uint &button_count, uint &spacer_count) const = 0;
 };
 
 /** Container for the 'normal' main toolbar */
 class NWidgetMainToolbarContainer : public NWidgetToolbarContainer {
-	const byte *GetButtonArrangement(uint &width, uint &arrangable_count, uint &button_count, uint &spacer_count) const override
+	const WidgetID *GetButtonArrangement(uint &width, uint &arrangable_count, uint &button_count, uint &spacer_count) const override
 	{
 		static const uint SMALLEST_ARRANGEMENT = 14;
 		static const uint BIGGEST_ARRANGEMENT  = 20;
@@ -1464,7 +1464,7 @@ class NWidgetMainToolbarContainer : public NWidgetToolbarContainer {
 		 * pause button appearing on the right of the lower toolbar and weird resizing of the widgets even if there is
 		 * enough space.
 		 */
-		static const byte arrange14[] = {
+		static const WidgetID arrange14[] = {
 			WID_TN_PAUSE,
 			WID_TN_FAST_FORWARD,
 			WID_TN_TRAINS,
@@ -1495,7 +1495,7 @@ class NWidgetMainToolbarContainer : public NWidgetToolbarContainer {
 			WID_TN_HELP,
 			WID_TN_SWITCH_BAR,
 		};
-		static const byte arrange15[] = {
+		static const WidgetID arrange15[] = {
 			WID_TN_PAUSE,
 			WID_TN_FAST_FORWARD,
 			WID_TN_SMALL_MAP,
@@ -1528,7 +1528,7 @@ class NWidgetMainToolbarContainer : public NWidgetToolbarContainer {
 			WID_TN_HELP,
 			WID_TN_SWITCH_BAR,
 		};
-		static const byte arrange16[] = {
+		static const WidgetID arrange16[] = {
 			WID_TN_PAUSE,
 			WID_TN_FAST_FORWARD,
 			WID_TN_SETTINGS,
@@ -1563,7 +1563,7 @@ class NWidgetMainToolbarContainer : public NWidgetToolbarContainer {
 			WID_TN_ZOOM_OUT,
 			WID_TN_SWITCH_BAR,
 		};
-		static const byte arrange17[] = {
+		static const WidgetID arrange17[] = {
 			WID_TN_PAUSE,
 			WID_TN_FAST_FORWARD,
 			WID_TN_SETTINGS,
@@ -1600,7 +1600,7 @@ class NWidgetMainToolbarContainer : public NWidgetToolbarContainer {
 			WID_TN_ZOOM_OUT,
 			WID_TN_SWITCH_BAR,
 		};
-		static const byte arrange18[] = {
+		static const WidgetID arrange18[] = {
 			WID_TN_PAUSE,
 			WID_TN_FAST_FORWARD,
 			WID_TN_SETTINGS,
@@ -1639,7 +1639,7 @@ class NWidgetMainToolbarContainer : public NWidgetToolbarContainer {
 			WID_TN_ZOOM_OUT,
 			WID_TN_SWITCH_BAR,
 		};
-		static const byte arrange19[] = {
+		static const WidgetID arrange19[] = {
 			WID_TN_PAUSE,
 			WID_TN_FAST_FORWARD,
 			WID_TN_SETTINGS,
@@ -1680,7 +1680,7 @@ class NWidgetMainToolbarContainer : public NWidgetToolbarContainer {
 			WID_TN_ZOOM_OUT,
 			WID_TN_SWITCH_BAR,
 		};
-		static const byte arrange20[] = {
+		static const WidgetID arrange20[] = {
 			WID_TN_PAUSE,
 			WID_TN_FAST_FORWARD,
 			WID_TN_SETTINGS,
@@ -1723,7 +1723,7 @@ class NWidgetMainToolbarContainer : public NWidgetToolbarContainer {
 			WID_TN_ZOOM_OUT,
 			WID_TN_SWITCH_BAR,
 		};
-		static const byte arrange_all[] = {
+		static const WidgetID arrange_all[] = {
 			WID_TN_PAUSE,
 			WID_TN_FAST_FORWARD,
 			WID_TN_SETTINGS,
@@ -1765,7 +1765,7 @@ class NWidgetMainToolbarContainer : public NWidgetToolbarContainer {
 		}
 
 		/* Introduce the split toolbar */
-		static const byte * const arrangements[] = { arrange14, arrange15, arrange16, arrange17, arrange18, arrange19, arrange20 };
+		static const WidgetID * const arrangements[] = { arrange14, arrange15, arrange16, arrange17, arrange18, arrange19, arrange20 };
 
 		button_count = arrangable_count = full_buttons;
 		spacer_count = this->spacers;
@@ -1792,9 +1792,9 @@ class NWidgetScenarioToolbarContainer : public NWidgetToolbarContainer {
 		}
 	}
 
-	const byte *GetButtonArrangement(uint &width, uint &arrangable_count, uint &button_count, uint &spacer_count) const override
+	const WidgetID *GetButtonArrangement(uint &width, uint &arrangable_count, uint &button_count, uint &spacer_count) const override
 	{
-		static const byte arrange_all[] = {
+		static const WidgetID arrange_all[] = {
 			WID_TE_PAUSE,
 			WID_TE_FAST_FORWARD,
 			WID_TE_SETTINGS,
@@ -1815,7 +1815,7 @@ class NWidgetScenarioToolbarContainer : public NWidgetToolbarContainer {
 			WID_TE_MUSIC_SOUND,
 			WID_TE_HELP,
 		};
-		static const byte arrange_nopanel[] = {
+		static const WidgetID arrange_nopanel[] = {
 			WID_TE_PAUSE,
 			WID_TE_FAST_FORWARD,
 			WID_TE_SETTINGS,
@@ -1835,7 +1835,7 @@ class NWidgetScenarioToolbarContainer : public NWidgetToolbarContainer {
 			WID_TE_MUSIC_SOUND,
 			WID_TE_HELP,
 		};
-		static const byte arrange_switch[] = {
+		static const WidgetID arrange_switch[] = {
 			WID_TE_DATE_PANEL,
 			WID_TE_SMALL_MAP,
 			WID_TE_LAND_GENERATE,
@@ -1962,12 +1962,12 @@ struct MainToolbarWindow : Window {
 		this->DrawWidgets();
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (_game_mode != GM_MENU && !this->IsWidgetDisabled(widget)) _toolbar_button_procs[widget](this);
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		CallBackFunction cbf = _menu_clicked_procs[widget](index);
 		if (cbf != CBF_NONE) _last_started_action = cbf;
@@ -2060,7 +2060,7 @@ struct MainToolbarWindow : Window {
 	{
 		/* We do not want to automatically raise the pause, fast forward and
 		 * switchbar buttons; they have to stay down when pressed etc. */
-		for (uint i = WID_TN_SETTINGS; i < WID_TN_SWITCH_BAR; i++) {
+		for (WidgetID i = WID_TN_SETTINGS; i < WID_TN_SWITCH_BAR; i++) {
 			this->RaiseWidgetWhenLowered(i);
 		}
 	}
@@ -2158,7 +2158,7 @@ static NWidgetBase *MakeMainToolbar()
 	};
 
 	NWidgetMainToolbarContainer *hor = new NWidgetMainToolbarContainer();
-	for (uint i = 0; i < WID_TN_END; i++) {
+	for (WidgetID i = 0; i < WID_TN_END; i++) {
 		switch (i) {
 			case WID_TN_SMALL_MAP:
 			case WID_TN_FINANCES:
@@ -2296,7 +2296,7 @@ struct ScenarioEditorToolbarWindow : Window {
 		this->DrawWidgets();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_TE_DATE:
@@ -2305,7 +2305,7 @@ struct ScenarioEditorToolbarWindow : Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_TE_SPACER: {
@@ -2321,7 +2321,7 @@ struct ScenarioEditorToolbarWindow : Window {
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_TE_SPACER:
@@ -2335,14 +2335,14 @@ struct ScenarioEditorToolbarWindow : Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (_game_mode == GM_MENU) return;
 		CallBackFunction cbf = _scen_toolbar_button_procs[widget](this);
 		if (cbf != CBF_NONE) _last_started_action = cbf;
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		CallBackFunction cbf = _scen_toolbar_dropdown_procs[widget](index);
 		if (cbf != CBF_NONE) _last_started_action = cbf;

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -222,12 +222,12 @@ public:
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_TA_CAPTION) SetDParam(0, this->window_number);
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_TA_ACTION_INFO:
@@ -244,7 +244,7 @@ public:
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_TA_ACTION_INFO: {
@@ -276,7 +276,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_TA_ZONE_BUTTON: {
@@ -371,7 +371,7 @@ public:
 		this->Window::Close();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_TV_CAPTION) SetDParam(0, this->town->index);
 	}
@@ -384,7 +384,7 @@ public:
 		this->DrawWidgets();
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_TV_INFO) return;
 
@@ -476,7 +476,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_TV_CENTER_VIEW: // scroll to location
@@ -511,7 +511,7 @@ public:
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_TV_INFO:
@@ -796,7 +796,7 @@ public:
 		this->townname_editbox.cancel_button = QueryString::ACTION_CLEAR;
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_TD_WORLD_POPULATION:
@@ -819,7 +819,7 @@ public:
 		return t->larger_town ? STR_TOWN_DIRECTORY_CITY : STR_TOWN_DIRECTORY_TOWN;
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_TD_SORT_ORDER:
@@ -866,7 +866,7 @@ public:
 		}
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_TD_SORT_ORDER: {
@@ -918,7 +918,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_TD_SORT_ORDER: // Click on sort order button
@@ -955,7 +955,7 @@ public:
 		}
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		if (widget != WID_TD_SORT_CRITERIA) return;
 
@@ -983,7 +983,7 @@ public:
 		this->vscroll->SetCapacityFromWidget(this, WID_TD_LIST);
 	}
 
-	void OnEditboxChanged(int wid) override
+	void OnEditboxChanged(WidgetID wid) override
 	{
 		if (wid == WID_TD_FILTER) {
 			this->string_filter.SetFilterTerm(this->townname_editbox.text.buf);
@@ -1174,13 +1174,13 @@ public:
 			if (_settings_game.economy.found_town != TF_CUSTOM_LAYOUT) town_layout = _settings_game.economy.town_layout;
 		}
 
-		for (int i = WID_TF_SIZE_SMALL; i <= WID_TF_SIZE_RANDOM; i++) {
+		for (WidgetID i = WID_TF_SIZE_SMALL; i <= WID_TF_SIZE_RANDOM; i++) {
 			this->SetWidgetLoweredState(i, i == WID_TF_SIZE_SMALL + this->town_size);
 		}
 
 		this->SetWidgetLoweredState(WID_TF_CITY, this->city);
 
-		for (int i = WID_TF_LAYOUT_ORIGINAL; i <= WID_TF_LAYOUT_RANDOM; i++) {
+		for (WidgetID i = WID_TF_LAYOUT_ORIGINAL; i <= WID_TF_LAYOUT_RANDOM; i++) {
 			this->SetWidgetLoweredState(i, i == WID_TF_LAYOUT_ORIGINAL + this->town_layout);
 		}
 
@@ -1207,7 +1207,7 @@ public:
 		if (success && !_shift_pressed) this->RandomTownName();
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_TF_NEW_TOWN:

--- a/src/transparency_gui.cpp
+++ b/src/transparency_gui.cpp
@@ -39,7 +39,7 @@ public:
 		this->DrawWidgets();
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_TT_SIGNS:
@@ -51,13 +51,13 @@ public:
 			case WID_TT_STRUCTURES:
 			case WID_TT_CATENARY:
 			case WID_TT_TEXT: {
-				uint i = widget - WID_TT_BEGIN;
+				int i = widget - WID_TT_BEGIN;
 				if (HasBit(_transparency_lock, i)) DrawSprite(SPR_LOCK, PAL_NONE, r.left + WidgetDimensions::scaled.fullbevel.left, r.top + WidgetDimensions::scaled.fullbevel.top);
 				break;
 			}
 			case WID_TT_BUTTONS: {
 				const Rect fr = r.Shrink(WidgetDimensions::scaled.framerect);
-				for (uint i = WID_TT_BEGIN; i < WID_TT_END; i++) {
+				for (WidgetID i = WID_TT_BEGIN; i < WID_TT_END; i++) {
 					if (i == WID_TT_TEXT) continue; // Loading and cost/income text has no invisibility button.
 
 					const Rect wr = this->GetWidget<NWidgetBase>(i)->GetCurrentRect().Shrink(WidgetDimensions::scaled.fullbevel);
@@ -69,7 +69,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget >= WID_TT_BEGIN && widget < WID_TT_END) {
 			if (_ctrl_pressed) {
@@ -119,7 +119,7 @@ public:
 	void OnInvalidateData([[maybe_unused]] int data = 0, [[maybe_unused]] bool gui_scope = true) override
 	{
 		if (!gui_scope) return;
-		for (uint i = WID_TT_BEGIN; i < WID_TT_END; i++) {
+		for (WidgetID i = WID_TT_BEGIN; i < WID_TT_END; i++) {
 			this->SetWidgetLoweredState(i, IsTransparencySet((TransparencyOption)(i - WID_TT_BEGIN)));
 		}
 	}

--- a/src/tree_gui.cpp
+++ b/src/tree_gui.cpp
@@ -152,7 +152,7 @@ public:
 		this->FinishInitNested(window_number);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget >= WID_BT_TYPE_BUTTON_FIRST) {
 			/* Ensure tree type buttons are sized after the largest tree type */
@@ -162,7 +162,7 @@ public:
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget >= WID_BT_TYPE_BUTTON_FIRST) {
 			const int index = widget - WID_BT_TYPE_BUTTON_FIRST;
@@ -171,7 +171,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_BT_TYPE_RANDOM: // tree of random type.

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -868,7 +868,7 @@ struct RefitWindow : public Window {
 		this->DrawWidgets();
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_VR_MATRIX:
@@ -886,7 +886,7 @@ struct RefitWindow : public Window {
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_VR_CAPTION) SetDParam(0, Vehicle::Get(this->window_number)->index);
 	}
@@ -936,7 +936,7 @@ struct RefitWindow : public Window {
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_VR_VEHICLE_PANEL_DISPLAY: {
@@ -1131,7 +1131,7 @@ struct RefitWindow : public Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_VR_VEHICLE_PANEL_DISPLAY: { // Vehicle image.
@@ -1173,7 +1173,7 @@ struct RefitWindow : public Window {
 		}
 	}
 
-	void OnMouseDrag(Point pt, int widget) override
+	void OnMouseDrag(Point pt, WidgetID widget) override
 	{
 		switch (widget) {
 			case WID_VR_VEHICLE_PANEL_DISPLAY: { // Vehicle image.
@@ -1186,7 +1186,7 @@ struct RefitWindow : public Window {
 		}
 	}
 
-	void OnDragDrop(Point pt, int widget) override
+	void OnDragDrop(Point pt, WidgetID widget) override
 	{
 		switch (widget) {
 			case WID_VR_VEHICLE_PANEL_DISPLAY: { // Vehicle image.
@@ -1853,7 +1853,7 @@ public:
 		*this->sorting = this->vehgroups.GetListing();
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_VL_LIST:
@@ -1904,7 +1904,7 @@ public:
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_VL_AVAILABLE_VEHICLES:
@@ -1947,7 +1947,7 @@ public:
 		}
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_VL_SORT_ORDER:
@@ -1997,7 +1997,7 @@ public:
 		this->DrawWidgets();
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 		    case WID_VL_ORDER_VIEW: // Open the shared orders window
@@ -2081,7 +2081,7 @@ public:
 		}
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		switch (widget) {
 			case WID_VL_GROUP_BY_PULLDOWN:
@@ -2367,7 +2367,7 @@ struct VehicleDetailsWindow : Window {
 		return desired_height;
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
 			case WID_VD_TOP_DETAILS: {
@@ -2474,12 +2474,12 @@ struct VehicleDetailsWindow : Window {
 		}
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_VD_CAPTION) SetDParam(0, Vehicle::Get(this->window_number)->index);
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		const Vehicle *v = Vehicle::Get(this->window_number);
 
@@ -2604,7 +2604,7 @@ struct VehicleDetailsWindow : Window {
 		this->DrawWidgets();
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_VD_INCREASE_SERVICING_INTERVAL:   // increase int
@@ -2642,7 +2642,7 @@ struct VehicleDetailsWindow : Window {
 		}
 	}
 
-	void OnDropdownSelect(int widget, int index) override
+	void OnDropdownSelect(WidgetID widget, int index) override
 	{
 		switch (widget) {
 			case WID_VD_SERVICE_INTERVAL_DROPDOWN: {
@@ -2927,7 +2927,7 @@ public:
 		this->Window::Close();
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		const Vehicle *v = Vehicle::Get(this->window_number);
 		switch (widget) {
@@ -2974,7 +2974,7 @@ public:
 		this->DrawWidgets();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget != WID_VV_CAPTION) return;
 
@@ -2982,7 +2982,7 @@ public:
 		SetDParam(0, v->index);
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_VV_START_STOP) return;
 
@@ -3087,7 +3087,7 @@ public:
 		DrawString(tr.left, tr.right, CenterBounds(tr.top, tr.bottom, GetCharacterHeight(FS_NORMAL)), str, text_colour, SA_HOR_CENTER);
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		const Vehicle *v = Vehicle::Get(this->window_number);
 
@@ -3195,7 +3195,7 @@ public:
 		Command<CMD_RENAME_VEHICLE>::Post(STR_ERROR_CAN_T_RENAME_TRAIN + Vehicle::Get(this->window_number)->type, this->window_number, str);
 	}
 
-	void OnMouseOver([[maybe_unused]] Point pt, int widget) override
+	void OnMouseOver([[maybe_unused]] Point pt, WidgetID widget) override
 	{
 		bool start_stop = widget == WID_VV_START_STOP;
 		if (start_stop != mouse_over_start_stop) {

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -488,7 +488,7 @@ Point GetTileZoomCenterWindow(bool in, Window * w)
  * @param widget_zoom_in widget index for window with zoom-in button
  * @param widget_zoom_out widget index for window with zoom-out button
  */
-void HandleZoomMessage(Window *w, const Viewport *vp, byte widget_zoom_in, byte widget_zoom_out)
+void HandleZoomMessage(Window *w, const Viewport *vp, WidgetID widget_zoom_in, WidgetID widget_zoom_out)
 {
 	w->SetWidgetDisabledState(widget_zoom_in, vp->zoom <= _settings_client.gui.zoom_min);
 	w->SetWidgetDirty(widget_zoom_in);

--- a/src/viewport_func.h
+++ b/src/viewport_func.h
@@ -35,7 +35,7 @@ void ZoomInOrOutToCursorWindow(bool in, Window * w);
 void ConstrainAllViewportsZoom();
 Point GetTileZoomCenterWindow(bool in, Window * w);
 void FixTitleGameZoom(int zoom_adjust = 0);
-void HandleZoomMessage(Window *w, const Viewport *vp, byte widget_zoom_in, byte widget_zoom_out);
+void HandleZoomMessage(Window *w, const Viewport *vp, WidgetID widget_zoom_in, WidgetID widget_zoom_out);
 
 /**
  * Zoom a viewport as far as possible in the given direction.

--- a/src/viewport_gui.cpp
+++ b/src/viewport_gui.cpp
@@ -61,7 +61,7 @@ public:
 		if (_settings_client.gui.zoom_min == viewport->zoom) this->DisableWidget(WID_EV_ZOOM_IN);
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
 			case WID_EV_CAPTION:
@@ -71,7 +71,7 @@ public:
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_EV_ZOOM_IN: DoZoomInOutWindow(ZOOM_IN,  this); break;
@@ -117,7 +117,7 @@ public:
 		this->viewport->dest_scrollpos_y = this->viewport->scrollpos_y;
 	}
 
-	bool OnRightClick([[maybe_unused]] Point pt, int widget) override
+	bool OnRightClick([[maybe_unused]] Point pt, WidgetID widget) override
 	{
 		return widget == WID_EV_VIEWPORT;
 	}

--- a/src/waypoint_gui.cpp
+++ b/src/waypoint_gui.cpp
@@ -83,7 +83,7 @@ public:
 		this->Window::Close();
 	}
 
-	void SetStringParameters(int widget) const override
+	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_W_CAPTION) SetDParam(0, this->wp->index);
 	}
@@ -97,7 +97,7 @@ public:
 		this->DrawWidgets();
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
 			case WID_W_CENTER_VIEW: // scroll to location

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -402,7 +402,7 @@ void ScrollbarClickHandler(Window *w, NWidgetCore *nw, int x, int y)
  * @param  y The Window client y coordinate
  * @return A widget index, or -1 if no widget was found.
  */
-int GetWidgetFromPos(const Window *w, int x, int y)
+WidgetID GetWidgetFromPos(const Window *w, int x, int y)
 {
 	NWidgetCore *nw = w->nested_root->GetWidgetFromPos(x, y);
 	return (nw != nullptr) ? nw->index : -1;
@@ -899,7 +899,7 @@ void Window::DrawWidgets() const
  * @param widget Sort button widget
  * @param state State of sort button
  */
-void Window::DrawSortButtonState(int widget, SortButtonState state) const
+void Window::DrawSortButtonState(WidgetID widget, SortButtonState state) const
 {
 	if (state == SBS_OFF) return;
 
@@ -1229,7 +1229,7 @@ NWidgetCore::NWidgetCore(WidgetType tp, Colours colour, uint fill_x, uint fill_y
  * Set index of the nested widget in the widget array.
  * @param index Index to use.
  */
-void NWidgetCore::SetIndex(int index)
+void NWidgetCore::SetIndex(WidgetID index)
 {
 	assert(index >= 0);
 	this->index = index;
@@ -1379,7 +1379,7 @@ NWidgetStacked::NWidgetStacked() : NWidgetContainer(NWID_SELECTION)
 	this->index = -1;
 }
 
-void NWidgetStacked::SetIndex(int index)
+void NWidgetStacked::SetIndex(WidgetID index)
 {
 	this->index = index;
 }
@@ -1954,7 +1954,7 @@ NWidgetMatrix::NWidgetMatrix() : NWidgetPIPContainer(NWID_MATRIX, NC_EQUALSIZE),
 {
 }
 
-void NWidgetMatrix::SetIndex(int index)
+void NWidgetMatrix::SetIndex(WidgetID index)
 {
 	this->index = index;
 }
@@ -2189,7 +2189,7 @@ void NWidgetMatrix::GetScrollOffsets(int &start_x, int &start_y, int &base_offs_
  *               vertical container will be inserted while adding the first
  *               child widget.
  */
-NWidgetBackground::NWidgetBackground(WidgetType tp, Colours colour, int index, NWidgetPIPContainer *child) : NWidgetCore(tp, colour, 1, 1, 0x0, STR_NULL)
+NWidgetBackground::NWidgetBackground(WidgetType tp, Colours colour, WidgetID index, NWidgetPIPContainer *child) : NWidgetCore(tp, colour, 1, 1, 0x0, STR_NULL)
 {
 	assert(tp == WWT_PANEL || tp == WWT_INSET || tp == WWT_FRAME);
 	if (index >= 0) this->SetIndex(index);
@@ -2397,7 +2397,7 @@ NWidgetBase *NWidgetBackground::GetWidgetOfType(WidgetType tp)
 	return nwid;
 }
 
-NWidgetViewport::NWidgetViewport(int index) : NWidgetCore(NWID_VIEWPORT, INVALID_COLOUR, 1, 1, 0x0, STR_NULL)
+NWidgetViewport::NWidgetViewport(WidgetID index) : NWidgetCore(NWID_VIEWPORT, INVALID_COLOUR, 1, 1, 0x0, STR_NULL)
 {
 	this->SetIndex(index);
 }
@@ -2467,7 +2467,7 @@ void NWidgetViewport::UpdateViewportCoordinates(Window *w)
  * @param line_height Height of a single row. A negative value means using the vertical resize step of the widget.
  * @return Row number clicked at. If clicked at a wrong position, #INT_MAX is returned.
  */
-int Scrollbar::GetScrolledRowFromWidget(int clickpos, const Window * const w, int widget, int padding, int line_height) const
+int Scrollbar::GetScrolledRowFromWidget(int clickpos, const Window * const w, WidgetID widget, int padding, int line_height) const
 {
 	uint pos = w->GetRowFromWidget(clickpos, widget, padding, line_height);
 	if (pos != INT_MAX) pos += this->GetPosition();
@@ -2541,7 +2541,7 @@ EventState Scrollbar::UpdateListPositionOnKeyPress(int &list_position, uint16_t 
  * @param padding Padding to subtract from the size.
  * @note Updates the position if needed.
  */
-void Scrollbar::SetCapacityFromWidget(Window *w, int widget, int padding)
+void Scrollbar::SetCapacityFromWidget(Window *w, WidgetID widget, int padding)
 {
 	NWidgetBase *nwid = w->GetWidget<NWidgetBase>(widget);
 	if (this->IsVertical()) {
@@ -2557,7 +2557,7 @@ void Scrollbar::SetCapacityFromWidget(Window *w, int widget, int padding)
  * @param colour Colour of the scrollbar.
  * @param index  Index of the widget.
  */
-NWidgetScrollbar::NWidgetScrollbar(WidgetType tp, Colours colour, int index) : NWidgetCore(tp, colour, 1, 1, 0x0, STR_NULL), Scrollbar(tp != NWID_HSCROLLBAR)
+NWidgetScrollbar::NWidgetScrollbar(WidgetType tp, Colours colour, WidgetID index) : NWidgetCore(tp, colour, 1, 1, 0x0, STR_NULL), Scrollbar(tp != NWID_HSCROLLBAR)
 {
 	assert(tp == NWID_HSCROLLBAR || tp == NWID_VSCROLLBAR);
 	this->SetIndex(index);
@@ -2683,7 +2683,7 @@ Dimension NWidgetLeaf::dropdown_dimension   = {0, 0};
  * @param data   Data of the widget.
  * @param tip    Tooltip of the widget.
  */
-NWidgetLeaf::NWidgetLeaf(WidgetType tp, Colours colour, int index, uint32_t data, StringID tip) : NWidgetCore(tp, colour, 1, 1, data, tip)
+NWidgetLeaf::NWidgetLeaf(WidgetType tp, Colours colour, WidgetID index, uint32_t data, StringID tip) : NWidgetCore(tp, colour, 1, 1, data, tip)
 {
 	assert(index >= 0 || tp == WWT_LABEL || tp == WWT_TEXT || tp == WWT_CAPTION || tp == WWT_RESIZEBOX || tp == WWT_SHADEBOX || tp == WWT_DEFSIZEBOX || tp == WWT_DEBUGBOX || tp == WWT_STICKYBOX || tp == WWT_CLOSEBOX);
 	if (index >= 0) this->SetIndex(index);
@@ -3416,7 +3416,7 @@ NWidgetContainer *MakeWindowNWidgetTree(const NWidgetPart *nwid_begin, const NWi
  * @param button_tooltip The tooltip-string of every button.
  * @return Panel with rows of company buttons.
  */
-NWidgetBase *MakeCompanyButtonRows(int widget_first, int widget_last, Colours button_colour, int max_length, StringID button_tooltip)
+NWidgetBase *MakeCompanyButtonRows(WidgetID widget_first, WidgetID widget_last, Colours button_colour, int max_length, StringID button_tooltip)
 {
 	assert(max_length >= 1);
 	NWidgetVertical *vert = nullptr; // Storage for all rows.
@@ -3427,7 +3427,7 @@ NWidgetBase *MakeCompanyButtonRows(int widget_first, int widget_last, Colours bu
 	sprite_size.width  += WidgetDimensions::unscaled.matrix.Horizontal();
 	sprite_size.height += WidgetDimensions::unscaled.matrix.Vertical() + 1; // 1 for the 'offset' of being pressed
 
-	for (int widnum = widget_first; widnum <= widget_last; widnum++) {
+	for (WidgetID widnum = widget_first; widnum <= widget_last; widnum++) {
 		/* Ensure there is room in 'hor' for another button. */
 		if (hor_length == max_length) {
 			if (vert == nullptr) vert = new NWidgetVertical();

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -123,7 +123,7 @@ class NWidgetCore;
 class Scrollbar;
 
 /** Lookup between widget IDs and NWidget objects. */
-using WidgetLookup = std::map<int, class NWidgetBase *>;
+using WidgetLookup = std::map<WidgetID, class NWidgetBase *>;
 
 /**
  * Baseclass for nested widgets.
@@ -329,7 +329,7 @@ class NWidgetCore : public NWidgetResizeBase {
 public:
 	NWidgetCore(WidgetType tp, Colours colour, uint fill_x, uint fill_y, uint32_t widget_data, StringID tool_tip);
 
-	void SetIndex(int index);
+	void SetIndex(WidgetID index);
 	void SetDataTip(uint32_t widget_data, StringID tool_tip);
 	void SetToolTip(StringID tool_tip);
 	void SetTextStyle(TextColour colour, FontSize size);
@@ -348,10 +348,10 @@ public:
 
 	NWidgetDisplay disp_flags; ///< Flags that affect display and interaction with the widget.
 	Colours colour;            ///< Colour of this widget.
-	int index;                 ///< Index of the nested widget (\c -1 means 'not used').
+	WidgetID index;            ///< Index of the nested widget (\c -1 means 'not used').
 	uint32_t widget_data;        ///< Data of the widget. @see Widget::data
 	StringID tool_tip;         ///< Tooltip of the widget. @see Widget::tootips
-	int scrollbar_index;       ///< Index of an attached scrollbar.
+	WidgetID scrollbar_index;  ///< Index of an attached scrollbar.
 	TextColour highlight_colour; ///< Colour of highlight.
 	TextColour text_colour;    ///< Colour of text within widget.
 	FontSize text_size;        ///< Size of text within widget.
@@ -460,7 +460,7 @@ class NWidgetStacked : public NWidgetContainer {
 public:
 	NWidgetStacked();
 
-	void SetIndex(int index);
+	void SetIndex(WidgetID index);
 
 	void AdjustPaddingForZoom() override;
 	void SetupSmallestSize(Window *w) override;
@@ -473,7 +473,7 @@ public:
 	bool SetDisplayedPlane(int plane);
 
 	int shown_plane; ///< Plane being displayed (for #NWID_SELECTION only).
-	int index;       ///< If non-negative, index in the #Window::widget_lookup.
+	WidgetID index;  ///< If non-negative, index in the #Window::widget_lookup.
 };
 
 /** Nested widget container flags, */
@@ -559,7 +559,7 @@ class NWidgetMatrix : public NWidgetPIPContainer {
 public:
 	NWidgetMatrix();
 
-	void SetIndex(int index);
+	void SetIndex(WidgetID index);
 	void SetColour(Colours colour);
 	void SetClicked(int clicked);
 	void SetCount(int count);
@@ -572,7 +572,7 @@ public:
 	NWidgetCore *GetWidgetFromPos(int x, int y) override;
 	void Draw(const Window *w) override;
 protected:
-	int index;      ///< If non-negative, index in the #Window::widget_lookup.
+	WidgetID index; ///< If non-negative, index in the #Window::widget_lookup.
 	Colours colour; ///< Colour of this widget.
 	int clicked;    ///< The currently clicked widget.
 	int count;      ///< Amount of valid widgets.
@@ -609,7 +609,7 @@ public:
  */
 class NWidgetBackground : public NWidgetCore {
 public:
-	NWidgetBackground(WidgetType tp, Colours colour, int index, NWidgetPIPContainer *child = nullptr);
+	NWidgetBackground(WidgetType tp, Colours colour, WidgetID index, NWidgetPIPContainer *child = nullptr);
 	~NWidgetBackground();
 
 	void Add(NWidgetBase *nwid);
@@ -641,7 +641,7 @@ private:
  */
 class NWidgetViewport : public NWidgetCore {
 public:
-	NWidgetViewport(int index);
+	NWidgetViewport(WidgetID index);
 
 	void SetupSmallestSize(Window *w) override;
 	void Draw(const Window *w) override;
@@ -758,7 +758,7 @@ public:
 		this->SetPosition(this->pos);
 	}
 
-	void SetCapacityFromWidget(Window *w, int widget, int padding = 0);
+	void SetCapacityFromWidget(Window *w, WidgetID widget, int padding = 0);
 
 	/**
 	 * Sets the position of the first visible element
@@ -807,7 +807,7 @@ public:
 		}
 	}
 
-	int GetScrolledRowFromWidget(int clickpos, const Window * const w, int widget, int padding = 0, int line_height = -1) const;
+	int GetScrolledRowFromWidget(int clickpos, const Window * const w, WidgetID widget, int padding = 0, int line_height = -1) const;
 
 	/**
 	 * Return an iterator pointing to the element of a scrolled widget that a user clicked in.
@@ -820,7 +820,7 @@ public:
 	 * @return Iterator to the element clicked at. If clicked at a wrong position, returns as interator to the end of the container.
 	 */
 	template <typename Tcontainer>
-	typename Tcontainer::iterator GetScrolledItemFromWidget(Tcontainer &container, int clickpos, const Window * const w, int widget, int padding = 0, int line_height = -1) const
+	typename Tcontainer::iterator GetScrolledItemFromWidget(Tcontainer &container, int clickpos, const Window * const w, WidgetID widget, int padding = 0, int line_height = -1) const
 	{
 		assert(this->GetCount() == container.size()); // Scrollbar and container size must match.
 		int row = this->GetScrolledRowFromWidget(clickpos, w, widget, padding, line_height);
@@ -841,7 +841,7 @@ public:
  */
 class NWidgetScrollbar : public NWidgetCore, public Scrollbar {
 public:
-	NWidgetScrollbar(WidgetType tp, Colours colour, int index);
+	NWidgetScrollbar(WidgetType tp, Colours colour, WidgetID index);
 
 	void SetupSmallestSize(Window *w) override;
 	void Draw(const Window *w) override;
@@ -861,7 +861,7 @@ private:
  */
 class NWidgetLeaf : public NWidgetCore {
 public:
-	NWidgetLeaf(WidgetType tp, Colours colour, int index, uint32_t data, StringID tip);
+	NWidgetLeaf(WidgetType tp, Colours colour, WidgetID index, uint32_t data, StringID tip);
 
 	void SetupSmallestSize(Window *w) override;
 	void Draw(const Window *w) override;
@@ -958,7 +958,7 @@ struct NWidgetPartDataTip {
  */
 struct NWidgetPartWidget {
 	Colours colour; ///< Widget colour.
-	int16_t index; ///< Index of the widget.
+	WidgetID index; ///< Index of the widget.
 };
 
 /**
@@ -1269,7 +1269,7 @@ static inline NWidgetPart SetPIPRatio(uint8_t ratio_pre, uint8_t ratio_inter, ui
  * @param index Widget index of the scrollbar.
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart SetScrollbar(int index)
+static inline NWidgetPart SetScrollbar(WidgetID index)
 {
 	NWidgetPart part;
 
@@ -1288,7 +1288,7 @@ static inline NWidgetPart SetScrollbar(int index)
  *       Child widgets must have a index bigger than the parent index.
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart NWidget(WidgetType tp, Colours col, int16_t idx = -1)
+static inline NWidgetPart NWidget(WidgetType tp, Colours col, int idx = -1)
 {
 	NWidgetPart part;
 
@@ -1334,7 +1334,7 @@ bool IsContainerWidgetType(WidgetType tp);
 NWidgetContainer *MakeNWidgets(const NWidgetPart *nwid_begin, const NWidgetPart *nwid_end, NWidgetContainer *container);
 NWidgetContainer *MakeWindowNWidgetTree(const NWidgetPart *nwid_begin, const NWidgetPart *nwid_end, NWidgetStacked **shade_select);
 
-NWidgetBase *MakeCompanyButtonRows(int widget_first, int widget_last, Colours button_colour, int max_length, StringID button_tooltip);
+NWidgetBase *MakeCompanyButtonRows(WidgetID widget_first, WidgetID widget_last, Colours button_colour, int max_length, StringID button_tooltip);
 
 void SetupWidgetDimensions();
 

--- a/src/widgets/ai_widget.h
+++ b/src/widgets/ai_widget.h
@@ -13,7 +13,7 @@
 #include "../textfile_type.h"
 
 /** Widgets of the #AIConfigWindow class. */
-enum AIConfigWidgets {
+enum AIConfigWidgets : WidgetID {
 	WID_AIC_BACKGROUND,       ///< Window background.
 	WID_AIC_DECREASE_NUMBER,  ///< Decrease the number of AIs.
 	WID_AIC_INCREASE_NUMBER,  ///< Increase the number of AIs.

--- a/src/widgets/airport_widget.h
+++ b/src/widgets/airport_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_AIRPORT_WIDGET_H
 
 /** Widgets of the #BuildAirToolbarWindow class. */
-enum AirportToolbarWidgets {
+enum AirportToolbarWidgets : WidgetID {
 	WID_AT_AIRPORT,  ///< Build airport button.
 	WID_AT_DEMOLISH, ///< Demolish button.
 
@@ -19,7 +19,7 @@ enum AirportToolbarWidgets {
 };
 
 /** Widgets of the #BuildAirportWindow class. */
-enum AirportPickerWidgets {
+enum AirportPickerWidgets : WidgetID {
 	WID_AP_CLASS_DROPDOWN,  ///< Dropdown of airport classes.
 	WID_AP_AIRPORT_LIST,    ///< List of airports.
 	WID_AP_SCROLLBAR,       ///< Scrollbar of the list.

--- a/src/widgets/autoreplace_widget.h
+++ b/src/widgets/autoreplace_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_AUTOREPLACE_WIDGET_H
 
 /** Widgets of the #ReplaceVehicleWindow class. */
-enum ReplaceVehicleWidgets {
+enum ReplaceVehicleWidgets : WidgetID {
 	WID_RV_CAPTION,                  ///< Caption of the window.
 
 	/* Sort dropdown at the right. */

--- a/src/widgets/bootstrap_widget.h
+++ b/src/widgets/bootstrap_widget.h
@@ -11,19 +11,19 @@
 #define WIDGETS_BOOTSTRAP_WIDGET_H
 
 /** Widgets of the #BootstrapBackground class. */
-enum BootstrapBackgroundWidgets {
+enum BootstrapBackgroundWidgets : WidgetID {
 	WID_BB_BACKGROUND, ///< Background of the window.
 };
 
 /** Widgets of the #BootstrapErrmsgWindow class. */
-enum BootstrapErrorMessageWidgets {
+enum BootstrapErrorMessageWidgets : WidgetID {
 	WID_BEM_CAPTION, ///< Caption of the window.
 	WID_BEM_MESSAGE, ///< Error message.
 	WID_BEM_QUIT,    ///< Quit button.
 };
 
 /** Widgets of the #BootstrapContentDownloadStatusWindow class. */
-enum BootstrapAskForDownloadWidgets {
+enum BootstrapAskForDownloadWidgets : WidgetID {
 	WID_BAFD_QUESTION, ///< The question whether to download.
 	WID_BAFD_YES,      ///< An affirmative answer to the question.
 	WID_BAFD_NO,       ///< An negative answer to the question.

--- a/src/widgets/bridge_widget.h
+++ b/src/widgets/bridge_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_BRIDGE_WIDGET_H
 
 /** Widgets of the #BuildBridgeWindow class. */
-enum BuildBridgeSelectionWidgets {
+enum BuildBridgeSelectionWidgets : WidgetID {
 	WID_BBS_CAPTION,           ///< Caption of the window.
 	WID_BBS_DROPDOWN_ORDER,    ///< Direction of sort dropdown.
 	WID_BBS_DROPDOWN_CRITERIA, ///< Criteria of sort dropdown.

--- a/src/widgets/build_vehicle_widget.h
+++ b/src/widgets/build_vehicle_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_BUILD_VEHICLE_WIDGET_H
 
 /** Widgets of the #BuildVehicleWindow class. */
-enum BuildVehicleWidgets {
+enum BuildVehicleWidgets : WidgetID {
 	WID_BV_CAPTION,                   ///< Caption of window.
 	WID_BV_SORT_ASCENDING_DESCENDING, ///< Sort direction.
 	WID_BV_SORT_DROPDOWN,             ///< Criteria of sorting dropdown.

--- a/src/widgets/cheat_widget.h
+++ b/src/widgets/cheat_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_CHEAT_WIDGET_H
 
 /** Widgets of the #CheatWindow class. */
-enum CheatWidgets {
+enum CheatWidgets : WidgetID {
 	WID_C_NOTE,  ///< Note on top of panel for use of cheat.
 	WID_C_PANEL, ///< Panel where all cheats are shown in.
 };

--- a/src/widgets/company_widget.h
+++ b/src/widgets/company_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_COMPANY_WIDGET_H
 
 /** Widgets of the #CompanyWindow class. */
-enum CompanyWidgets {
+enum CompanyWidgets : WidgetID {
 	WID_C_CAPTION,                    ///< Caption of the window.
 
 	WID_C_FACE,                       ///< View of the face.
@@ -54,7 +54,7 @@ enum CompanyWidgets {
 };
 
 /** Widgets of the #CompanyFinancesWindow class. */
-enum CompanyFinancesWidgets {
+enum CompanyFinancesWidgets : WidgetID {
 	WID_CF_CAPTION,        ///< Caption of the window.
 	WID_CF_TOGGLE_SIZE,    ///< Toggle windows size.
 	WID_CF_SEL_PANEL,      ///< Select panel or nothing.
@@ -78,7 +78,7 @@ enum CompanyFinancesWidgets {
 
 
 /** Widgets of the #SelectCompanyLiveryWindow class. */
-enum SelectCompanyLiveryWidgets {
+enum SelectCompanyLiveryWidgets : WidgetID {
 	WID_SCL_CAPTION,          ///< Caption of window.
 	WID_SCL_CLASS_GENERAL,    ///< Class general.
 	WID_SCL_CLASS_RAIL,       ///< Class rail.
@@ -102,7 +102,7 @@ enum SelectCompanyLiveryWidgets {
  * Do not change the order of the widgets from WID_SCMF_HAS_MOUSTACHE_EARRING to WID_SCMF_GLASSES_R,
  * this order is needed for the WE_CLICK event of DrawFaceStringLabel().
  */
-enum SelectCompanyManagerFaceWidgets {
+enum SelectCompanyManagerFaceWidgets : WidgetID {
 	WID_SCMF_CAPTION,                    ///< Caption of window.
 	WID_SCMF_TOGGLE_LARGE_SMALL,         ///< Toggle for large or small.
 	WID_SCMF_SELECT_FACE,                ///< Select face.
@@ -170,7 +170,7 @@ enum SelectCompanyManagerFaceWidgets {
 };
 
 /** Widgets of the #CompanyInfrastructureWindow class. */
-enum CompanyInfrastructureWidgets {
+enum CompanyInfrastructureWidgets : WidgetID {
 	WID_CI_CAPTION,       ///< Caption of window.
 	WID_CI_RAIL_DESC,     ///< Description of rail.
 	WID_CI_RAIL_COUNT,    ///< Count of rail.
@@ -187,7 +187,7 @@ enum CompanyInfrastructureWidgets {
 };
 
 /** Widgets of the #BuyCompanyWindow class. */
-enum BuyCompanyWidgets {
+enum BuyCompanyWidgets : WidgetID {
 	WID_BC_CAPTION,  ///< Caption of window.
 	WID_BC_FACE,     ///< Face button.
 	WID_BC_QUESTION, ///< Question text.

--- a/src/widgets/console_widget.h
+++ b/src/widgets/console_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_CONSOLE_WIDGET_H
 
 /** Widgets of the #IConsoleWindow class. */
-enum ConsoleWidgets {
+enum ConsoleWidgets : WidgetID {
 	WID_C_BACKGROUND, ///< Background of the console.
 };
 

--- a/src/widgets/date_widget.h
+++ b/src/widgets/date_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_DATE_WIDGET_H
 
 /** Widgets of the #SetDateWindow class. */
-enum SetDateWidgets {
+enum SetDateWidgets : WidgetID {
 	WID_SD_DAY,      ///< Dropdown for the day.
 	WID_SD_MONTH,    ///< Dropdown for the month.
 	WID_SD_YEAR,     ///< Dropdown for the year.

--- a/src/widgets/depot_widget.h
+++ b/src/widgets/depot_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_DEPOT_WIDGET_H
 
 /** Widgets of the #DepotWindow class. */
-enum DepotWidgets {
+enum DepotWidgets : WidgetID {
 	WID_D_CAPTION,         ///< Caption of window.
 	WID_D_SELL,            ///< Sell button.
 	WID_D_SHOW_SELL_CHAIN, ///< Show sell chain panel.

--- a/src/widgets/dock_widget.h
+++ b/src/widgets/dock_widget.h
@@ -11,14 +11,14 @@
 #define WIDGETS_DOCK_WIDGET_H
 
 /** Widgets of the #BuildDocksDepotWindow class. */
-enum BuildDockDepotWidgets {
+enum BuildDockDepotWidgets : WidgetID {
 	WID_BDD_BACKGROUND, ///< Background of the window.
 	WID_BDD_X,          ///< X-direction button.
 	WID_BDD_Y,          ///< Y-direction button.
 };
 
 /** Widgets of the #BuildDocksToolbarWindow class. */
-enum DockToolbarWidgets {
+enum DockToolbarWidgets : WidgetID {
 	WID_DT_CANAL,          ///< Build canal button.
 	WID_DT_LOCK,           ///< Build lock button.
 	WID_DT_DEMOLISH,       ///< Demolish aka dynamite button.

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -40,7 +40,7 @@ static WindowDesc _dropdown_desc(__FILE__, __LINE__,
 
 /** Drop-down menu window */
 struct DropdownWindow : Window {
-	int parent_button;            ///< Parent widget number where the window is dropped from.
+	WidgetID parent_button;       ///< Parent widget number where the window is dropped from.
 	Rect wi_rect;                 ///< Rect of the button that opened the dropdown.
 	const DropDownList list;      ///< List with dropdown menu items.
 	int selected_result;          ///< Result value of the selected item in the list.
@@ -63,7 +63,7 @@ struct DropdownWindow : Window {
 	 * @param instant_close Close the window when the mouse button is raised.
 	 * @param wi_colour     Colour of the parent widget.
 	 */
-	DropdownWindow(Window *parent, DropDownList &&list, int selected, int button, const Rect wi_rect, bool instant_close, Colours wi_colour)
+	DropdownWindow(Window *parent, DropDownList &&list, int selected, WidgetID button, const Rect wi_rect, bool instant_close, Colours wi_colour)
 			: Window(&_dropdown_desc)
 			, parent_button(button)
 			, wi_rect(wi_rect)
@@ -172,7 +172,7 @@ struct DropdownWindow : Window {
 		if (this->position.y < button_rect.top && list_dim.height > widget_dim.height) this->vscroll->UpdatePosition(INT_MAX);
 	}
 
-	void UpdateWidgetSize(int widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
+	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		if (widget == WID_DM_ITEMS) *size = this->items_dim;
 	}
@@ -213,7 +213,7 @@ struct DropdownWindow : Window {
 		return false;
 	}
 
-	void DrawWidget(const Rect &r, int widget) const override
+	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_DM_ITEMS) return;
 
@@ -240,7 +240,7 @@ struct DropdownWindow : Window {
 		}
 	}
 
-	void OnClick([[maybe_unused]] Point pt, int widget, [[maybe_unused]] int click_count) override
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget != WID_DM_ITEMS) return;
 		int item;
@@ -329,7 +329,7 @@ Dimension GetDropDownListDimension(const DropDownList &list)
  * @param instant_close Set to true if releasing mouse button should close the
  *                      list regardless of where the cursor is.
  */
-void ShowDropDownListAt(Window *w, DropDownList &&list, int selected, int button, Rect wi_rect, Colours wi_colour, bool instant_close)
+void ShowDropDownListAt(Window *w, DropDownList &&list, int selected, WidgetID button, Rect wi_rect, Colours wi_colour, bool instant_close)
 {
 	CloseWindowByClass(WC_DROPDOWN_MENU);
 	new DropdownWindow(w, std::move(list), selected, button, wi_rect, instant_close, wi_colour);
@@ -346,7 +346,7 @@ void ShowDropDownListAt(Window *w, DropDownList &&list, int selected, int button
  * @param instant_close Set to true if releasing mouse button should close the
  *                      list regardless of where the cursor is.
  */
-void ShowDropDownList(Window *w, DropDownList &&list, int selected, int button, uint width, bool instant_close)
+void ShowDropDownList(Window *w, DropDownList &&list, int selected, WidgetID button, uint width, bool instant_close)
 {
 	/* Our parent's button widget is used to determine where to place the drop
 	 * down list window. */
@@ -383,7 +383,7 @@ void ShowDropDownList(Window *w, DropDownList &&list, int selected, int button, 
  * @param hidden_mask   Bitmask for hidden items (items with their bit set are not copied to the dropdown list).
  * @param width         Minimum width of the dropdown menu.
  */
-void ShowDropDownMenu(Window *w, const StringID *strings, int selected, int button, uint32_t disabled_mask, uint32_t hidden_mask, uint width)
+void ShowDropDownMenu(Window *w, const StringID *strings, int selected, WidgetID button, uint32_t disabled_mask, uint32_t hidden_mask, uint width)
 {
 	DropDownList list;
 

--- a/src/widgets/dropdown_func.h
+++ b/src/widgets/dropdown_func.h
@@ -13,6 +13,6 @@
 #include "../window_gui.h"
 
 /* Show drop down menu containing a fixed list of strings */
-void ShowDropDownMenu(Window *w, const StringID *strings, int selected, int button, uint32_t disabled_mask, uint32_t hidden_mask, uint width = 0);
+void ShowDropDownMenu(Window *w, const StringID *strings, int selected, WidgetID button, uint32_t disabled_mask, uint32_t hidden_mask, uint width = 0);
 
 #endif /* WIDGETS_DROPDOWN_FUNC_H */

--- a/src/widgets/dropdown_type.h
+++ b/src/widgets/dropdown_type.h
@@ -209,9 +209,9 @@ using DropDownListCheckedItem = DropDownCheck<DropDownString<DropDownListItem>>;
  */
 typedef std::vector<std::unique_ptr<const DropDownListItem>> DropDownList;
 
-void ShowDropDownListAt(Window *w, DropDownList &&list, int selected, int button, Rect wi_rect, Colours wi_colour, bool instant_close = false);
+void ShowDropDownListAt(Window *w, DropDownList &&list, int selected, WidgetID button, Rect wi_rect, Colours wi_colour, bool instant_close = false);
 
-void ShowDropDownList(Window *w, DropDownList &&list, int selected, int button, uint width = 0, bool instant_close = false);
+void ShowDropDownList(Window *w, DropDownList &&list, int selected, WidgetID button, uint width = 0, bool instant_close = false);
 
 Dimension GetDropDownListDimension(const DropDownList &list);
 

--- a/src/widgets/dropdown_widget.h
+++ b/src/widgets/dropdown_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_DROPDOWN_WIDGET_H
 
 /** Widgets of the #DropdownWindow class. */
-enum DropdownMenuWidgets {
+enum DropdownMenuWidgets : WidgetID {
 	WID_DM_ITEMS,        ///< Panel showing the dropdown items.
 	WID_DM_SHOW_SCROLL,  ///< Hide scrollbar if too few items.
 	WID_DM_SCROLL,       ///< Scrollbar.

--- a/src/widgets/engine_widget.h
+++ b/src/widgets/engine_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_ENGINE_WIDGET_H
 
 /** Widgets of the #EnginePreviewWindow class. */
-enum EnginePreviewWidgets {
+enum EnginePreviewWidgets : WidgetID {
 	WID_EP_QUESTION, ///< The container for the question.
 	WID_EP_NO,       ///< No button.
 	WID_EP_YES,      ///< Yes button.

--- a/src/widgets/error_widget.h
+++ b/src/widgets/error_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_ERROR_WIDGET_H
 
 /** Widgets of the #ErrmsgWindow class. */
-enum ErrorMessageWidgets {
+enum ErrorMessageWidgets : WidgetID {
 	WID_EM_CAPTION, ///< Caption of the window.
 	WID_EM_FACE,    ///< Error title.
 	WID_EM_MESSAGE, ///< Error message.

--- a/src/widgets/fios_widget.h
+++ b/src/widgets/fios_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_FIOS_WIDGET_H
 
 /** Widgets of the #SaveLoadWindow class. */
-enum SaveLoadWidgets {
+enum SaveLoadWidgets : WidgetID {
 	WID_SL_CAPTION,                 ///< Caption of the window.
 	WID_SL_SORT_BYNAME,             ///< Sort by name button.
 	WID_SL_SORT_BYDATE,             ///< Sort by date button.

--- a/src/widgets/framerate_widget.h
+++ b/src/widgets/framerate_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_FRAMERATE_WIDGET_H
 
 /** Widgets of the #FramerateWindow class. */
-enum FramerateWindowWidgets {
+enum FramerateWindowWidgets : WidgetID {
 	WID_FRW_CAPTION,
 	WID_FRW_RATE_GAMELOOP,
 	WID_FRW_RATE_DRAWING,
@@ -26,7 +26,7 @@ enum FramerateWindowWidgets {
 };
 
 /** Widgets of the #FrametimeGraphWindow class. */
-enum FrametimeGraphWindowWidgets {
+enum FrametimeGraphWindowWidgets : WidgetID {
 	WID_FGW_CAPTION,
 	WID_FGW_GRAPH,
 };

--- a/src/widgets/game_widget.h
+++ b/src/widgets/game_widget.h
@@ -13,7 +13,7 @@
 #include "../textfile_type.h"
 
 /** Widgets of the #GSConfigWindow class. */
-enum GSConfigWidgets {
+enum GSConfigWidgets : WidgetID {
 	WID_GSC_BACKGROUND,       ///< Window background.
 	WID_GSC_GSLIST,           ///< List with current selected Game Script.
 	WID_GSC_SETTINGS,         ///< Panel to draw the Game Script settings on

--- a/src/widgets/genworld_widget.h
+++ b/src/widgets/genworld_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_GENWORLD_WIDGET_H
 
 /** Widgets of the #GenerateLandscapeWindow class. */
-enum GenerateLandscapeWidgets {
+enum GenerateLandscapeWidgets : WidgetID {
 	WID_GL_TEMPERATE,                   ///< Button with icon "Temperate".
 	WID_GL_ARCTIC,                      ///< Button with icon "Arctic".
 	WID_GL_TROPICAL,                    ///< Button with icon "Tropical".
@@ -69,7 +69,7 @@ enum GenerateLandscapeWidgets {
 };
 
 /** Widgets of the #CreateScenarioWindow class. */
-enum CreateScenarioWidgets {
+enum CreateScenarioWidgets : WidgetID {
 	WID_CS_TEMPERATE,              ///< Select temperate landscape style.
 	WID_CS_ARCTIC,                 ///< Select arctic landscape style.
 	WID_CS_TROPICAL,               ///< Select tropical landscape style.
@@ -87,7 +87,7 @@ enum CreateScenarioWidgets {
 };
 
 /** Widgets of the #GenerateProgressWindow class. */
-enum GenerationProgressWidgets {
+enum GenerationProgressWidgets : WidgetID {
 	WID_GP_PROGRESS_BAR,  ///< Progress bar.
 	WID_GP_PROGRESS_TEXT, ///< Text with the progress bar.
 	WID_GP_ABORT,         ///< Abort button.

--- a/src/widgets/goal_widget.h
+++ b/src/widgets/goal_widget.h
@@ -12,7 +12,7 @@
 #define WIDGETS_GOAL_WIDGET_H
 
 /** Widgets of the #GoalListWindow class. */
-enum GoalListWidgets {
+enum GoalListWidgets : WidgetID {
 	WID_GOAL_CAPTION,         ///< Caption of the window.
 	WID_GOAL_SELECT_BUTTONS,  ///< Selection widget for the title bar button.
 	WID_GOAL_GLOBAL_BUTTON,   ///< Button to show global goals.
@@ -22,7 +22,7 @@ enum GoalListWidgets {
 };
 
 /** Widgets of the #GoalQuestionWindow class. */
-enum GoalQuestionWidgets {
+enum GoalQuestionWidgets : WidgetID {
 	WID_GQ_CAPTION,        ///< Caption of the window.
 	WID_GQ_QUESTION,       ///< Question text.
 	WID_GQ_BUTTONS,        ///< Buttons selection (between 1, 2 or 3).

--- a/src/widgets/graph_widget.h
+++ b/src/widgets/graph_widget.h
@@ -14,7 +14,7 @@
 #include "../company_type.h"
 
 /** Widgets of the #GraphLegendWindow class. */
-enum GraphLegendWidgets {
+enum GraphLegendWidgets : WidgetID {
 	WID_GL_BACKGROUND,    ///< Background of the window.
 
 	WID_GL_FIRST_COMPANY, ///< First company in the legend.
@@ -22,7 +22,7 @@ enum GraphLegendWidgets {
 };
 
 /** Widgets of the #OperatingProfitGraphWindow class, #IncomeGraphWindow class, #DeliveredCargoGraphWindow class, and #CompanyValueGraphWindow class. */
-enum CompanyValueWidgets {
+enum CompanyValueWidgets : WidgetID {
 	WID_CV_KEY_BUTTON, ///< Key button.
 	WID_CV_BACKGROUND, ///< Background of the window.
 	WID_CV_GRAPH,      ///< Graph itself.
@@ -30,7 +30,7 @@ enum CompanyValueWidgets {
 };
 
 /** Widget of the #PerformanceHistoryGraphWindow class. */
-enum PerformanceHistoryGraphWidgets {
+enum PerformanceHistoryGraphWidgets : WidgetID {
 	WID_PHG_KEY,                  ///< Key button.
 	WID_PHG_DETAILED_PERFORMANCE, ///< Detailed performance.
 	WID_PHG_BACKGROUND,           ///< Background of the window.
@@ -39,7 +39,7 @@ enum PerformanceHistoryGraphWidgets {
 };
 
 /** Widget of the #PaymentRatesGraphWindow class. */
-enum CargoPaymentRatesWidgets {
+enum CargoPaymentRatesWidgets : WidgetID {
 	WID_CPR_BACKGROUND,      ///< Background of the window.
 	WID_CPR_HEADER,          ///< Header.
 	WID_CPR_GRAPH,           ///< Graph itself.
@@ -52,7 +52,7 @@ enum CargoPaymentRatesWidgets {
 };
 
 /** Widget of the #PerformanceRatingDetailWindow class. */
-enum PerformanceRatingDetailsWidgets {
+enum PerformanceRatingDetailsWidgets : WidgetID {
 	WID_PRD_SCORE_FIRST, ///< First entry in the score list.
 	WID_PRD_SCORE_LAST = WID_PRD_SCORE_FIRST + (SCORE_END - SCORE_BEGIN) - 1, ///< Last entry in the score list.
 

--- a/src/widgets/group_widget.h
+++ b/src/widgets/group_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_GROUP_WIDGET_H
 
 /** Widgets of the #VehicleGroupWindow class. */
-enum GroupListWidgets {
+enum GroupListWidgets : WidgetID {
 	WID_GL_CAPTION,                  ///< Caption of the window.
 	WID_GL_GROUP_BY_ORDER,           ///< Group order.
 	WID_GL_GROUP_BY_DROPDOWN,        ///< Group by dropdown list.

--- a/src/widgets/help_widget.h
+++ b/src/widgets/help_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_HELP_WIDGET_H
 
 /** Widgets of the #HelpWindow class. */
-enum HelpWindowWidgets {
+enum HelpWindowWidgets : WidgetID {
 	WID_HW_README,
 	WID_HW_CHANGELOG,
 	WID_HW_KNOWN_BUGS,

--- a/src/widgets/highscore_widget.h
+++ b/src/widgets/highscore_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_HIGHSCORE_WIDGET_H
 
 /** Widgets of the #EndGameHighScoreBaseWindow class and #HighScoreWindow class. */
-enum HighscoreWidgets {
+enum HighscoreWidgets : WidgetID {
 	WID_H_BACKGROUND, ///< Background of the window.
 };
 

--- a/src/widgets/industry_widget.h
+++ b/src/widgets/industry_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_INDUSTRY_WIDGET_H
 
 /** Widgets of the #BuildIndustryWindow class. */
-enum DynamicPlaceIndustriesWidgets {
+enum DynamicPlaceIndustriesWidgets : WidgetID {
 	WID_DPI_SCENARIO_EDITOR_PANE,            ///< Pane containing SE-only widgets.
 	WID_DPI_REMOVE_ALL_INDUSTRIES_WIDGET,    ///< Remove all industries button.
 	WID_DPI_CREATE_RANDOM_INDUSTRIES_WIDGET, ///< Create random industries button.
@@ -23,7 +23,7 @@ enum DynamicPlaceIndustriesWidgets {
 };
 
 /** Widgets of the #IndustryViewWindow class. */
-enum IndustryViewWidgets {
+enum IndustryViewWidgets : WidgetID {
 	WID_IV_CAPTION,  ///< Caption of the window.
 	WID_IV_VIEWPORT, ///< Viewport of the industry.
 	WID_IV_INFO,     ///< Info of the industry.
@@ -32,7 +32,7 @@ enum IndustryViewWidgets {
 };
 
 /** Widgets of the #IndustryDirectoryWindow class. */
-enum IndustryDirectoryWidgets {
+enum IndustryDirectoryWidgets : WidgetID {
 	WID_ID_DROPDOWN_ORDER,       ///< Dropdown for the order of the sort.
 	WID_ID_DROPDOWN_CRITERIA,    ///< Dropdown for the criteria of the sort.
 	WID_ID_FILTER_BY_ACC_CARGO,  ///< Accepted cargo filter dropdown list.
@@ -44,7 +44,7 @@ enum IndustryDirectoryWidgets {
 };
 
 /** Widgets of the #IndustryCargoesWindow class */
-enum IndustryCargoesWidgets {
+enum IndustryCargoesWidgets : WidgetID {
 	WID_IC_CAPTION,        ///< Caption of the window.
 	WID_IC_NOTIFY,         ///< Row of buttons at the bottom.
 	WID_IC_PANEL,          ///< Panel that shows the chain.

--- a/src/widgets/intro_widget.h
+++ b/src/widgets/intro_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_INTRO_WIDGET_H
 
 /** Widgets of the #SelectGameWindow class. */
-enum SelectGameIntroWidgets {
+enum SelectGameIntroWidgets : WidgetID {
 	WID_SGI_GENERATE_GAME,         ///< Generate game button.
 	WID_SGI_LOAD_GAME,             ///< Load game button.
 	WID_SGI_PLAY_SCENARIO,         ///< Play scenario button.

--- a/src/widgets/league_widget.h
+++ b/src/widgets/league_widget.h
@@ -11,12 +11,12 @@
 #define WIDGETS_LEAGUE_WIDGET_H
 
 /** Widget of the #PerformanceLeagueWindow class. */
-enum PerformanceLeagueWidgets {
+enum PerformanceLeagueWidgets : WidgetID {
 	WID_PLT_BACKGROUND, ///< Background of the window.
 };
 
 /** Widget of the #ScriptLeagueWindow class. */
-enum ScriptLeagueWidgets {
+enum ScriptLeagueWidgets : WidgetID {
 	WID_SLT_CAPTION,    ///< Caption of the window.
 	WID_SLT_BACKGROUND, ///< Background of the window.
 };

--- a/src/widgets/link_graph_legend_widget.h
+++ b/src/widgets/link_graph_legend_widget.h
@@ -14,7 +14,7 @@
 
 /** Widgets of the WC_LINKGRAPH_LEGEND. */
 
-enum LinkGraphLegendWidgets {
+enum LinkGraphLegendWidgets : WidgetID {
 	WID_LGL_CAPTION,           ///< Caption widget.
 	WID_LGL_SATURATION,        ///< Saturation legend.
 	WID_LGL_SATURATION_FIRST,

--- a/src/widgets/main_widget.h
+++ b/src/widgets/main_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_MAIN_WIDGET_H
 
 /** Widgets of the #MainWindow class. */
-enum MainWidgets {
+enum MainWidgets : WidgetID {
 	WID_M_VIEWPORT, ///< Main window viewport.
 };
 

--- a/src/widgets/misc_widget.h
+++ b/src/widgets/misc_widget.h
@@ -11,25 +11,25 @@
 #define WIDGETS_MISC_WIDGET_H
 
 /** Widgets of the #LandInfoWindow class. */
-enum LandInfoWidgets {
+enum LandInfoWidgets : WidgetID {
 	WID_LI_LOCATION, ///< Scroll to location.
 	WID_LI_BACKGROUND, ///< Background of the window.
 };
 
 /** Widgets of the #TooltipsWindow class. */
-enum ToolTipsWidgets {
+enum ToolTipsWidgets : WidgetID {
 	WID_TT_BACKGROUND, ///< Background of the window.
 };
 
 /** Widgets of the #AboutWindow class. */
-enum AboutWidgets {
+enum AboutWidgets : WidgetID {
 	WID_A_SCROLLING_TEXT, ///< The actually scrolling text.
 	WID_A_WEBSITE,        ///< URL of OpenTTD website.
 	WID_A_COPYRIGHT,      ///< Copyright string
 };
 
 /** Widgets of the #QueryStringWindow class. */
-enum QueryStringWidgets {
+enum QueryStringWidgets : WidgetID {
 	WID_QS_CAPTION, ///< Caption of the window.
 	WID_QS_TEXT,    ///< Text of the query.
 	WID_QS_WARNING, ///< Warning label about password security
@@ -39,7 +39,7 @@ enum QueryStringWidgets {
 };
 
 /** Widgets of the #QueryWindow class. */
-enum QueryWidgets {
+enum QueryWidgets : WidgetID {
 	WID_Q_CAPTION, ///< Caption of the window.
 	WID_Q_TEXT,    ///< Text of the query.
 	WID_Q_NO,      ///< Yes button.
@@ -47,7 +47,7 @@ enum QueryWidgets {
 };
 
 /** Widgets of the #TextfileWindow class. */
-enum TextfileWidgets {
+enum TextfileWidgets : WidgetID {
 	WID_TF_CAPTION,      ///< The caption of the window.
 	WID_TF_NAVBACK,      ///< Navigate back button.
 	WID_TF_NAVFORWARD,   ///< Navigate forward button.

--- a/src/widgets/music_widget.h
+++ b/src/widgets/music_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_MUSIC_WIDGET_H
 
 /** Widgets of the #MusicTrackSelectionWindow class. */
-enum MusicTrackSelectionWidgets {
+enum MusicTrackSelectionWidgets : WidgetID {
 	WID_MTS_CAPTION,    ///< Window caption.
 	WID_MTS_LIST_LEFT,  ///< Left button.
 	WID_MTS_PLAYLIST,   ///< Playlist.
@@ -27,7 +27,7 @@ enum MusicTrackSelectionWidgets {
 };
 
 /** Widgets of the #MusicWindow class. */
-enum MusicWidgets {
+enum MusicWidgets : WidgetID {
 	WID_M_PREV,        ///< Previous button.
 	WID_M_NEXT,        ///< Next button.
 	WID_M_STOP,        ///< Stop button.

--- a/src/widgets/network_chat_widget.h
+++ b/src/widgets/network_chat_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_NETWORK_CHAT_WIDGET_H
 
 /** Widgets of the #NetworkChatWindow class. */
-enum NetWorkChatWidgets {
+enum NetWorkChatWidgets : WidgetID {
 	WID_NC_CLOSE,       ///< Close button.
 	WID_NC_BACKGROUND,  ///< Background of the window.
 	WID_NC_DESTINATION, ///< Destination.

--- a/src/widgets/network_content_widget.h
+++ b/src/widgets/network_content_widget.h
@@ -13,14 +13,14 @@
 #include "../textfile_type.h"
 
 /** Widgets of the #NetworkContentDownloadStatusWindow class. */
-enum NetworkContentDownloadStatusWidgets {
+enum NetworkContentDownloadStatusWidgets : WidgetID {
 	WID_NCDS_PROGRESS_BAR,  ///< Simple progress bar.
 	WID_NCDS_PROGRESS_TEXT, ///< Text explaining what is happening.
 	WID_NCDS_CANCELOK,      ///< (Optional) Cancel/OK button.
 };
 
 /** Widgets of the #NetworkContentListWindow class. */
-enum NetworkContentListWidgets {
+enum NetworkContentListWidgets : WidgetID {
 	WID_NCL_BACKGROUND,     ///< Resize button.
 
 	WID_NCL_FILTER_CAPT,    ///< Caption for the filter editbox.

--- a/src/widgets/network_widget.h
+++ b/src/widgets/network_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_NETWORK_WIDGET_H
 
 /** Widgets of the #NetworkGameWindow class. */
-enum NetworkGameWidgets {
+enum NetworkGameWidgets : WidgetID {
 	WID_NG_MAIN,               ///< Main panel.
 
 	WID_NG_CLIENT_LABEL,       ///< Label in front of client name edit box.
@@ -49,7 +49,7 @@ enum NetworkGameWidgets {
 };
 
 /** Widgets of the #NetworkStartServerWindow class. */
-enum NetworkStartServerWidgets {
+enum NetworkStartServerWidgets : WidgetID {
 	WID_NSS_BACKGROUND,        ///< Background of the window.
 	WID_NSS_GAMENAME_LABEL,    ///< Label for the game name.
 	WID_NSS_GAMENAME,          ///< Background for editbox to set game name.
@@ -74,7 +74,7 @@ enum NetworkStartServerWidgets {
 };
 
 /** Widgets of the #NetworkClientListWindow class. */
-enum ClientListWidgets {
+enum ClientListWidgets : WidgetID {
 	WID_CL_PANEL,                      ///< Panel of the window.
 	WID_CL_SERVER_SELECTOR,            ///< Selector to hide the server frame.
 	WID_CL_SERVER_NAME,                ///< Server name.
@@ -91,14 +91,14 @@ enum ClientListWidgets {
 };
 
 /** Widgets of the #NetworkJoinStatusWindow class. */
-enum NetworkJoinStatusWidgets {
+enum NetworkJoinStatusWidgets : WidgetID {
 	WID_NJS_PROGRESS_BAR,  ///< Simple progress bar.
 	WID_NJS_PROGRESS_TEXT, ///< Text explaining what is happening.
 	WID_NJS_CANCELOK,      ///< Cancel / OK button.
 };
 
 /** Widgets of the #NetworkCompanyPasswordWindow class. */
-enum NetworkCompanyPasswordWidgets {
+enum NetworkCompanyPasswordWidgets : WidgetID {
 	WID_NCP_BACKGROUND,               ///< Background of the window.
 	WID_NCP_LABEL,                    ///< Label in front of the password field.
 	WID_NCP_PASSWORD,                 ///< Input field for the password.
@@ -109,7 +109,7 @@ enum NetworkCompanyPasswordWidgets {
 };
 
 /** Widgets of the #NetworkAskRelayWindow class. */
-enum NetworkAskRelayWidgets {
+enum NetworkAskRelayWidgets : WidgetID {
 	WID_NAR_CAPTION,    ///< Caption of the window.
 	WID_NAR_TEXT,       ///< Text in the window.
 	WID_NAR_NO,         ///< "No" button.
@@ -118,7 +118,7 @@ enum NetworkAskRelayWidgets {
 };
 
 /** Widgets of the #NetworkAskSurveyWindow class. */
-enum NetworkAskSurveyWidgets {
+enum NetworkAskSurveyWidgets : WidgetID {
 	WID_NAS_CAPTION,    ///< Caption of the window.
 	WID_NAS_TEXT,       ///< Text in the window.
 	WID_NAS_PREVIEW,    ///< "Preview" button.

--- a/src/widgets/newgrf_debug_widget.h
+++ b/src/widgets/newgrf_debug_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_NEWGRF_DEBUG_WIDGET_H
 
 /** Widgets of the #NewGRFInspectWindow class. */
-enum NewGRFInspectWidgets {
+enum NewGRFInspectWidgets : WidgetID {
 	WID_NGRFI_CAPTION,   ///< The caption bar of course.
 	WID_NGRFI_PARENT,    ///< Inspect the parent.
 	WID_NGRFI_VEH_PREV,  ///< Go to previous vehicle in chain.
@@ -22,7 +22,7 @@ enum NewGRFInspectWidgets {
 };
 
 /** Widgets of the #SpriteAlignerWindow class. */
-enum SpriteAlignerWidgets {
+enum SpriteAlignerWidgets : WidgetID {
 	WID_SA_CAPTION,     ///< Caption of the window.
 	WID_SA_PREVIOUS,    ///< Skip to the previous sprite.
 	WID_SA_GOTO,        ///< Go to a given sprite.

--- a/src/widgets/newgrf_widget.h
+++ b/src/widgets/newgrf_widget.h
@@ -14,7 +14,7 @@
 #include "../textfile_type.h"
 
 /** Widgets of the #NewGRFParametersWindow class. */
-enum NewGRFParametersWidgets {
+enum NewGRFParametersWidgets : WidgetID {
 	WID_NP_CAPTION,          ///< Caption of the window.
 	WID_NP_SHOW_NUMPAR,      ///< #NWID_SELECTION to optionally display #WID_NP_NUMPAR.
 	WID_NP_NUMPAR_DEC,       ///< Button to decrease number of parameters.
@@ -32,7 +32,7 @@ enum NewGRFParametersWidgets {
 };
 
 /** Widgets of the #NewGRFWindow class. */
-enum NewGRFStateWidgets {
+enum NewGRFStateWidgets : WidgetID {
 	WID_NS_PRESET_LIST,       ///< Active NewGRF preset.
 	WID_NS_PRESET_SAVE,       ///< Save list of active NewGRFs as presets.
 	WID_NS_PRESET_DELETE,     ///< Delete active preset.
@@ -63,7 +63,7 @@ enum NewGRFStateWidgets {
 };
 
 /** Widgets of the #SavePresetWindow class. */
-enum SavePresetWidgets {
+enum SavePresetWidgets : WidgetID {
 	WID_SVP_PRESET_LIST, ///< List with available preset names.
 	WID_SVP_SCROLLBAR,   ///< Scrollbar for the list available preset names.
 	WID_SVP_EDITBOX,     ///< Edit box for changing the preset name.
@@ -72,7 +72,7 @@ enum SavePresetWidgets {
 };
 
 /** Widgets of the #ScanProgressWindow class. */
-enum ScanProgressWidgets {
+enum ScanProgressWidgets : WidgetID {
 	WID_SP_PROGRESS_BAR,  ///< Simple progress bar.
 	WID_SP_PROGRESS_TEXT, ///< Text explaining what is happening.
 };

--- a/src/widgets/news_widget.h
+++ b/src/widgets/news_widget.h
@@ -13,7 +13,7 @@
 #include "../news_type.h"
 
 /** Widgets of the #NewsWindow class. */
-enum NewsWidgets {
+enum NewsWidgets : WidgetID {
 	WID_N_PANEL,       ///< Panel of the window.
 	WID_N_TITLE,       ///< Title of the company news.
 	WID_N_HEADLINE,    ///< The news headline.
@@ -35,7 +35,7 @@ enum NewsWidgets {
 };
 
 /** Widgets of the #MessageHistoryWindow class. */
-enum MessageHistoryWidgets {
+enum MessageHistoryWidgets : WidgetID {
 	WID_MH_STICKYBOX,  ///< Stickybox.
 	WID_MH_BACKGROUND, ///< Background of the window.
 	WID_MH_SCROLLBAR,  ///< Scrollbar for the list.

--- a/src/widgets/object_widget.h
+++ b/src/widgets/object_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_OBJECT_WIDGET_H
 
 /** Widgets of the #BuildObjectWindow class. */
-enum BuildObjectWidgets {
+enum BuildObjectWidgets : WidgetID {
 	WID_BO_FILTER,         ///< The filter text box for the object list.
 	WID_BO_CLASS_LIST,     ///< The list with classes.
 	WID_BO_SCROLLBAR,      ///< The scrollbar associated with the list.

--- a/src/widgets/order_widget.h
+++ b/src/widgets/order_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_ORDER_WIDGET_H
 
 /** Widgets of the #OrdersWindow class. */
-enum OrderWidgets {
+enum OrderWidgets : WidgetID {
 	WID_O_CAPTION,                   ///< Caption of the window.
 	WID_O_TIMETABLE_VIEW,            ///< Toggle timetable view.
 	WID_O_ORDER_LIST,                ///< Order list panel.

--- a/src/widgets/osk_widget.h
+++ b/src/widgets/osk_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_OSK_WIDGET_H
 
 /** Widgets of the #OskWindow class. */
-enum OnScreenKeyboardWidgets {
+enum OnScreenKeyboardWidgets : WidgetID {
 	WID_OSK_CAPTION,   ///< Caption of window.
 	WID_OSK_TEXT,      ///< Edit box.
 	WID_OSK_CANCEL,    ///< Cancel key.

--- a/src/widgets/rail_widget.h
+++ b/src/widgets/rail_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_RAIL_WIDGET_H
 
 /** Widgets of the #BuildRailToolbarWindow class. */
-enum RailToolbarWidgets {
+enum RailToolbarWidgets : WidgetID {
 	/* Name starts with RA instead of R, because of collision with RoadToolbarWidgets */
 	WID_RAT_CAPTION,        ///< Caption of the window.
 	WID_RAT_BUILD_NS,       ///< Build rail along the game view Y axis.
@@ -33,7 +33,7 @@ enum RailToolbarWidgets {
 };
 
 /** Widgets of the #BuildRailStationWindow class. */
-enum BuildRailStationWidgets {
+enum BuildRailStationWidgets : WidgetID {
 	/* Name starts with BRA instead of BR, because of collision with BuildRoadStationWidgets */
 	WID_BRAS_PLATFORM_DIR_X,       ///< Button to select '/' view.
 	WID_BRAS_PLATFORM_DIR_Y,       ///< Button to select '\' view.
@@ -79,7 +79,7 @@ enum BuildRailStationWidgets {
 };
 
 /** Widgets of the #BuildSignalWindow class. */
-enum BuildSignalWidgets {
+enum BuildSignalWidgets : WidgetID {
 	WID_BS_CAPTION,            ///< Caption for the Signal Selection window.
 	WID_BS_TOGGLE_SIZE,        ///< Toggle showing advanced signal types.
 	WID_BS_SEMAPHORE_NORM,     ///< Build a semaphore normal block signal.
@@ -109,7 +109,7 @@ enum BuildSignalWidgets {
 };
 
 /** Widgets of the #BuildRailDepotWindow class. */
-enum BuildRailDepotWidgets {
+enum BuildRailDepotWidgets : WidgetID {
 	/* Name starts with BRA instead of BR, because of collision with BuildRoadDepotWidgets */
 	WID_BRAD_DEPOT_NE, ///< Build a depot with the entrance in the north east.
 	WID_BRAD_DEPOT_SE, ///< Build a depot with the entrance in the south east.
@@ -118,7 +118,7 @@ enum BuildRailDepotWidgets {
 };
 
 /** Widgets of the #BuildRailWaypointWindow class. */
-enum BuildRailWaypointWidgets {
+enum BuildRailWaypointWidgets : WidgetID {
 	WID_BRW_FILTER,          ///< Text filter.
 	WID_BRW_WAYPOINT_MATRIX, ///< Matrix with waypoints.
 	WID_BRW_WAYPOINT,        ///< A single waypoint.

--- a/src/widgets/road_widget.h
+++ b/src/widgets/road_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_ROAD_WIDGET_H
 
 /** Widgets of the #BuildRoadToolbarWindow class. */
-enum RoadToolbarWidgets {
+enum RoadToolbarWidgets : WidgetID {
 	/* Name starts with RO instead of R, because of collision with RailToolbarWidgets */
 	WID_ROT_CAPTION,        ///< Caption of the window
 	WID_ROT_ROAD_X,         ///< Build road in x-direction.
@@ -31,7 +31,7 @@ enum RoadToolbarWidgets {
 };
 
 /** Widgets of the #BuildRoadDepotWindow class. */
-enum BuildRoadDepotWidgets {
+enum BuildRoadDepotWidgets : WidgetID {
 	/* Name starts with BRO instead of BR, because of collision with BuildRailDepotWidgets */
 	WID_BROD_CAPTION,   ///< Caption of the window.
 	WID_BROD_DEPOT_NE,  ///< Depot with NE entry.
@@ -41,7 +41,7 @@ enum BuildRoadDepotWidgets {
 };
 
 /** Widgets of the #BuildRoadStationWindow class. */
-enum BuildRoadStationWidgets {
+enum BuildRoadStationWidgets : WidgetID {
 	/* Name starts with BRO instead of BR, because of collision with BuildRailStationWidgets */
 	WID_BROS_CAPTION,                ///< Caption of the window.
 	WID_BROS_STATION_NE,             ///< Terminal station with NE entry.

--- a/src/widgets/screenshot_widget.h
+++ b/src/widgets/screenshot_widget.h
@@ -12,7 +12,7 @@
 
 /** Widgets of the #ScreenshotWindow class. */
 
-enum ScreenshotWindowWidgets {
+enum ScreenshotWindowWidgets : WidgetID {
 	WID_SC_TAKE,             ///< Button for taking a normal screenshot
 	WID_SC_TAKE_ZOOMIN,      ///< Button for taking a zoomed in screenshot
 	WID_SC_TAKE_DEFAULTZOOM, ///< Button for taking a screenshot at normal zoom

--- a/src/widgets/script_widget.h
+++ b/src/widgets/script_widget.h
@@ -13,7 +13,7 @@
 #include "../company_type.h"
 
 /** Widgets of the #ScriptListWindow class. */
-enum ScriptListWidgets {
+enum ScriptListWidgets : WidgetID {
 	WID_SCRL_CAPTION,   ///< Caption of the window.
 	WID_SCRL_LIST,      ///< The matrix with all available Scripts.
 	WID_SCRL_SCROLLBAR, ///< Scrollbar next to the Script list.
@@ -23,7 +23,7 @@ enum ScriptListWidgets {
 };
 
 /** Widgets of the #ScriptSettingsWindow class. */
-enum ScriptSettingsWidgets {
+enum ScriptSettingsWidgets : WidgetID {
 	WID_SCRS_CAPTION,    ///< Caption of the window.
 	WID_SCRS_BACKGROUND, ///< Panel to draw the settings on.
 	WID_SCRS_SCROLLBAR,  ///< Scrollbar to scroll through all settings.
@@ -34,7 +34,7 @@ enum ScriptSettingsWidgets {
 };
 
 /** Widgets of the #ScriptDebugWindow class. */
-enum ScriptDebugWidgets {
+enum ScriptDebugWidgets : WidgetID {
 	WID_SCRD_VIEW,                 ///< The row of company buttons.
 	WID_SCRD_NAME_TEXT,            ///< Name of the current selected.
 	WID_SCRD_SETTINGS,             ///< Settings button.

--- a/src/widgets/settings_widget.h
+++ b/src/widgets/settings_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_SETTINGS_WIDGET_H
 
 /** Widgets of the #GameOptionsWindow class. */
-enum GameOptionsWidgets {
+enum GameOptionsWidgets : WidgetID {
 	WID_GO_TAB_GENERAL,            ///< General tab.
 	WID_GO_TAB_GRAPHICS,           ///< Graphics tab.
 	WID_GO_TAB_SOUND,              ///< Sound tab.
@@ -54,7 +54,7 @@ enum GameOptionsWidgets {
 };
 
 /** Widgets of the #GameSettingsWindow class. */
-enum GameSettingsWidgets {
+enum GameSettingsWidgets : WidgetID {
 	WID_GS_FILTER,             ///< Text filter.
 	WID_GS_OPTIONSPANEL,       ///< Panel widget containing the option lists.
 	WID_GS_SCROLLBAR,          ///< Scrollbar.
@@ -71,7 +71,7 @@ enum GameSettingsWidgets {
 };
 
 /** Widgets of the #CustomCurrencyWindow class. */
-enum CustomCurrencyWidgets {
+enum CustomCurrencyWidgets : WidgetID {
 	WID_CC_RATE_DOWN,      ///< Down button.
 	WID_CC_RATE_UP,        ///< Up button.
 	WID_CC_RATE,           ///< Rate of currency.

--- a/src/widgets/sign_widget.h
+++ b/src/widgets/sign_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_SIGN_WIDGET_H
 
 /** Widgets of the #SignListWindow class. */
-enum SignListWidgets {
+enum SignListWidgets : WidgetID {
 	/* Name starts with SI instead of S, because of collision with SaveLoadWidgets */
 	WID_SIL_CAPTION,               ///< Caption of the window.
 	WID_SIL_LIST,                  ///< List of signs.
@@ -22,7 +22,7 @@ enum SignListWidgets {
 };
 
 /** Widgets of the #SignWindow class. */
-enum QueryEditSignWidgets {
+enum QueryEditSignWidgets : WidgetID {
 	WID_QES_CAPTION,  ///< Caption of the window.
 	WID_QES_LOCATION, ///< Scroll to sign location.
 	WID_QES_TEXT,     ///< Text of the query.

--- a/src/widgets/smallmap_widget.h
+++ b/src/widgets/smallmap_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_SMALLMAP_WIDGET_H
 
 /** Widgets of the #SmallMapWindow class. */
-enum SmallMapWidgets {
+enum SmallMapWidgets : WidgetID {
 	WID_SM_CAPTION,        ///< Caption of the window.
 	WID_SM_MAP_BORDER,     ///< Border around the smallmap.
 	WID_SM_MAP,            ///< Panel containing the smallmap.

--- a/src/widgets/station_widget.h
+++ b/src/widgets/station_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_STATION_WIDGET_H
 
 /** Widgets of the #StationViewWindow class. */
-enum StationViewWidgets {
+enum StationViewWidgets : WidgetID {
 	WID_SV_CAPTION,            ///< Caption of the window.
 	WID_SV_GROUP,              ///< label for "group by"
 	WID_SV_GROUP_BY,           ///< 'Group by' button
@@ -32,7 +32,7 @@ enum StationViewWidgets {
 };
 
 /** Widgets of the #CompanyStationsWindow class. */
-enum StationListWidgets {
+enum StationListWidgets : WidgetID {
 	/* Name starts with ST instead of S, because of collision with SaveLoadWidgets */
 	WID_STL_CAPTION,        ///< Caption of the window.
 	WID_STL_LIST,           ///< The main panel, list of stations.
@@ -56,7 +56,7 @@ enum StationListWidgets {
 };
 
 /** Widgets of the #SelectStationWindow class. */
-enum JoinStationWidgets {
+enum JoinStationWidgets : WidgetID {
 	WID_JS_CAPTION,   // Caption of the window.
 	WID_JS_PANEL,     // Main panel.
 	WID_JS_SCROLLBAR, // Scrollbar of the panel.

--- a/src/widgets/statusbar_widget.h
+++ b/src/widgets/statusbar_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_STATUSBAR_WIDGET_H
 
 /** Widgets of the #StatusBarWindow class. */
-enum StatusbarWidgets {
+enum StatusbarWidgets : WidgetID {
 	WID_S_LEFT,   ///< Left part of the statusbar; date is shown there.
 	WID_S_MIDDLE, ///< Middle part; current news or company name or *** SAVING *** or *** PAUSED ***.
 	WID_S_RIGHT,  ///< Right part; bank balance.

--- a/src/widgets/story_widget.h
+++ b/src/widgets/story_widget.h
@@ -12,7 +12,7 @@
 #define WIDGETS_STORY_WIDGET_H
 
 /** Widgets of the #GoalListWindow class. */
-enum StoryBookWidgets {
+enum StoryBookWidgets : WidgetID {
 	WID_SB_CAPTION,   ///< Caption of the window.
 	WID_SB_SEL_PAGE,  ///< Page selector.
 	WID_SB_PAGE_PANEL,///< Page body.

--- a/src/widgets/subsidy_widget.h
+++ b/src/widgets/subsidy_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_SUBSIDY_WIDGET_H
 
 /** Widgets of the #SubsidyListWindow class. */
-enum SubsidyListWidgets {
+enum SubsidyListWidgets : WidgetID {
 	/* Name starts with SU instead of S, because of collision with SaveLoadWidgets. */
 	WID_SUL_PANEL,     ///< Main panel of window.
 	WID_SUL_SCROLLBAR, ///< Scrollbar of panel.

--- a/src/widgets/terraform_widget.h
+++ b/src/widgets/terraform_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_TERRAFORM_WIDGET_H
 
 /** Widgets of the #TerraformToolbarWindow class. */
-enum TerraformToolbarWidgets {
+enum TerraformToolbarWidgets : WidgetID {
 	WID_TT_SHOW_PLACE_OBJECT,                 ///< Should the place object button be shown?
 	WID_TT_BUTTONS_START,                     ///< Start of pushable buttons.
 	WID_TT_LOWER_LAND = WID_TT_BUTTONS_START, ///< Lower land button.
@@ -27,7 +27,7 @@ enum TerraformToolbarWidgets {
 };
 
 /** Widgets of the #ScenarioEditorLandscapeGenerationWindow class. */
-enum EditorTerraformToolbarWidgets {
+enum EditorTerraformToolbarWidgets : WidgetID {
 	WID_ETT_SHOW_PLACE_DESERT,                   ///< Should the place desert button be shown?
 	WID_ETT_START,                               ///< Used for iterations.
 	WID_ETT_DOTS = WID_ETT_START,                ///< Invisible widget for rendering the terraform size on.

--- a/src/widgets/timetable_widget.h
+++ b/src/widgets/timetable_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_TIMETABLE_WIDGET_H
 
 /** Widgets of the #TimetableWindow class. */
-enum VehicleTimetableWidgets {
+enum VehicleTimetableWidgets : WidgetID {
 	WID_VT_CAPTION,                     ///< Caption of the window.
 	WID_VT_ORDER_VIEW,                  ///< Order view.
 	WID_VT_TIMETABLE_PANEL,             ///< Timetable panel.

--- a/src/widgets/toolbar_widget.h
+++ b/src/widgets/toolbar_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_TOOLBAR_WIDGET_H
 
 /** Widgets of the #MainToolbarWindow class. */
-enum ToolbarNormalWidgets {
+enum ToolbarNormalWidgets : WidgetID {
 	WID_TN_PAUSE,         ///< Pause the game.
 	WID_TN_FAST_FORWARD,  ///< Fast forward the game.
 	WID_TN_SETTINGS,      ///< Settings menu.
@@ -49,7 +49,7 @@ enum ToolbarNormalWidgets {
 };
 
 /** Widgets of the #ScenarioEditorToolbarWindow class. */
-enum ToolbarEditorWidgets {
+enum ToolbarEditorWidgets : WidgetID {
 	WID_TE_PAUSE,         ///< Pause the game.
 	WID_TE_FAST_FORWARD,  ///< Fast forward the game.
 	WID_TE_SETTINGS,      ///< Settings menu.

--- a/src/widgets/town_widget.h
+++ b/src/widgets/town_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_TOWN_WIDGET_H
 
 /** Widgets of the #TownDirectoryWindow class. */
-enum TownDirectoryWidgets {
+enum TownDirectoryWidgets : WidgetID {
 	WID_TD_SORT_ORDER,       ///< Direction of sort dropdown.
 	WID_TD_SORT_CRITERIA,    ///< Criteria of sort dropdown.
 	WID_TD_FILTER,           ///< Filter of name.
@@ -21,7 +21,7 @@ enum TownDirectoryWidgets {
 };
 
 /** Widgets of the #TownAuthorityWindow class. */
-enum TownAuthorityWidgets {
+enum TownAuthorityWidgets : WidgetID {
 	WID_TA_CAPTION,      ///< Caption of window.
 	WID_TA_ZONE_BUTTON,  ///< Turn on/off showing local authority zone.
 	WID_TA_RATING_INFO,  ///< Overview with ratings for each company.
@@ -32,7 +32,7 @@ enum TownAuthorityWidgets {
 };
 
 /** Widgets of the #TownViewWindow class. */
-enum TownViewWidgets {
+enum TownViewWidgets : WidgetID {
 	WID_TV_CAPTION,        ///< Caption of window.
 	WID_TV_VIEWPORT,       ///< View of the center of the town.
 	WID_TV_INFO,           ///< General information about the town.
@@ -45,7 +45,7 @@ enum TownViewWidgets {
 };
 
 /** Widgets of the #FoundTownWindow class. */
-enum TownFoundingWidgets {
+enum TownFoundingWidgets : WidgetID {
 	WID_TF_NEW_TOWN,          ///< Create a new town.
 	WID_TF_RANDOM_TOWN,       ///< Randomly place a town.
 	WID_TF_MANY_RANDOM_TOWNS, ///< Randomly place many towns.

--- a/src/widgets/transparency_widget.h
+++ b/src/widgets/transparency_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_TRANSPARENCY_WIDGET_H
 
 /** Widgets of the #TransparenciesWindow class. */
-enum TransparencyToolbarWidgets {
+enum TransparencyToolbarWidgets : WidgetID {
 	/* Button row. */
 	WID_TT_BEGIN,                    ///< First toggle button.
 	WID_TT_SIGNS = WID_TT_BEGIN,     ///< Signs background transparency toggle button.

--- a/src/widgets/tree_widget.h
+++ b/src/widgets/tree_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_TREE_WIDGET_H
 
 /** Widgets of the #BuildTreesWindow class. */
-enum BuildTreesWidgets {
+enum BuildTreesWidgets : WidgetID {
 	WID_BT_TYPE_RANDOM,     ///< Button to build random type of tree.
 	WID_BT_SE_PANE,         ///< Selection pane to show/hide scenario editor tools.
 	WID_BT_MODE_NORMAL,     ///< Select normal/rectangle planting mode.

--- a/src/widgets/vehicle_widget.h
+++ b/src/widgets/vehicle_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_VEHICLE_WIDGET_H
 
 /** Widgets of the #VehicleViewWindow class. */
-enum VehicleViewWidgets {
+enum VehicleViewWidgets : WidgetID {
 	WID_VV_CAPTION,            ///< Caption of window.
 	WID_VV_VIEWPORT,           ///< Viewport widget.
 	WID_VV_START_STOP,         ///< Start or stop this vehicle, and show information about the current state.
@@ -31,7 +31,7 @@ enum VehicleViewWidgets {
 };
 
 /** Widgets of the #RefitWindow class. */
-enum VehicleRefitWidgets {
+enum VehicleRefitWidgets : WidgetID {
 	WID_VR_CAPTION,               ///< Caption of window.
 	WID_VR_VEHICLE_PANEL_DISPLAY, ///< Display with a representation of the vehicle to refit.
 	WID_VR_SHOW_HSCROLLBAR,       ///< Selection widget for the horizontal scrollbar.
@@ -44,7 +44,7 @@ enum VehicleRefitWidgets {
 };
 
 /** Widgets of the #VehicleDetailsWindow class. */
-enum VehicleDetailsWidgets {
+enum VehicleDetailsWidgets : WidgetID {
 	WID_VD_CAPTION,                     ///< Caption of window.
 	WID_VD_TOP_DETAILS,                 ///< Panel with generic details.
 	WID_VD_INCREASE_SERVICING_INTERVAL, ///< Increase the servicing interval.
@@ -61,7 +61,7 @@ enum VehicleDetailsWidgets {
 };
 
 /** Widgets of the #VehicleListWindow class. */
-enum VehicleListWidgets {
+enum VehicleListWidgets : WidgetID {
 	WID_VL_CAPTION,                  ///< Caption of window (for non shared orders windows).
 	WID_VL_CAPTION_SHARED_ORDERS,    ///< Caption of window (for shared orders windows).
 	WID_VL_CAPTION_SELECTION,        ///< Selection for caption.

--- a/src/widgets/viewport_widget.h
+++ b/src/widgets/viewport_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_VIEWPORT_WIDGET_H
 
 /** Widgets of the #ExtraViewportWindow class. */
-enum ExtraViewportWidgets {
+enum ExtraViewportWidgets : WidgetID {
 	WID_EV_CAPTION,      ///< Caption of window.
 	WID_EV_VIEWPORT,     ///< The viewport.
 	WID_EV_ZOOM_IN,      ///< Zoom in.

--- a/src/widgets/waypoint_widget.h
+++ b/src/widgets/waypoint_widget.h
@@ -11,7 +11,7 @@
 #define WIDGETS_WAYPOINT_WIDGET_H
 
 /** Widgets of the #WaypointWindow class. */
-enum WaypointWidgets {
+enum WaypointWidgets : WidgetID {
 	WID_W_CAPTION,       ///< Caption of window.
 	WID_W_VIEWPORT,      ///< The viewport on this waypoint.
 	WID_W_CENTER_VIEW,   ///< Center the main view on this waypoint.

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -211,7 +211,7 @@ void Window::ApplyDefaults()
  * @return Row number clicked at. If clicked at a wrong position, #INT_MAX is returned.
  * @note The widget does not know where a list printed at the widget ends, so below a list is not a wrong position.
  */
-int Window::GetRowFromWidget(int clickpos, int widget, int padding, int line_height) const
+int Window::GetRowFromWidget(int clickpos, WidgetID widget, int padding, int line_height) const
 {
 	const NWidgetBase *wid = this->GetWidget<NWidgetBase>(widget);
 	if (line_height < 0) line_height = wid->resize_y;
@@ -240,7 +240,7 @@ void Window::DisableAllWidgetHighlight()
  * @param widget_index index of this widget in the window
  * @param highlighted_colour Colour of highlight, or TC_INVALID to disable.
  */
-void Window::SetWidgetHighlight(byte widget_index, TextColour highlighted_colour)
+void Window::SetWidgetHighlight(WidgetID widget_index, TextColour highlighted_colour)
 {
 	NWidgetBase *nwid = this->GetWidget<NWidgetBase>(widget_index);
 	if (nwid == nullptr) return;
@@ -270,7 +270,7 @@ void Window::SetWidgetHighlight(byte widget_index, TextColour highlighted_colour
  * @param widget_index index of this widget in the window
  * @return status of the widget ie: highlighted = true, not highlighted = false
  */
-bool Window::IsWidgetHighlighted(byte widget_index) const
+bool Window::IsWidgetHighlighted(WidgetID widget_index) const
 {
 	const NWidgetBase *nwid = this->GetWidget<NWidgetBase>(widget_index);
 	if (nwid == nullptr) return false;
@@ -285,7 +285,7 @@ bool Window::IsWidgetHighlighted(byte widget_index) const
  * @param index the element in the dropdown that is selected.
  * @param instant_close whether the dropdown was configured to close on mouse up.
  */
-void Window::OnDropdownClose(Point pt, int widget, int index, bool instant_close)
+void Window::OnDropdownClose(Point pt, WidgetID widget, int index, bool instant_close)
 {
 	if (widget < 0) return;
 
@@ -312,7 +312,7 @@ void Window::OnDropdownClose(Point pt, int widget, int index, bool instant_close
  * @param widnum Scrollbar widget index
  * @return Scrollbar to the widget
  */
-const Scrollbar *Window::GetScrollbar(uint widnum) const
+const Scrollbar *Window::GetScrollbar(WidgetID widnum) const
 {
 	return this->GetWidget<NWidgetScrollbar>(widnum);
 }
@@ -322,7 +322,7 @@ const Scrollbar *Window::GetScrollbar(uint widnum) const
  * @param widnum Scrollbar widget index
  * @return Scrollbar to the widget
  */
-Scrollbar *Window::GetScrollbar(uint widnum)
+Scrollbar *Window::GetScrollbar(WidgetID widnum)
 {
 	return this->GetWidget<NWidgetScrollbar>(widnum);
 }
@@ -332,7 +332,7 @@ Scrollbar *Window::GetScrollbar(uint widnum)
  * @param widnum Editbox widget index
  * @return QueryString or nullptr.
  */
-const QueryString *Window::GetQueryString(uint widnum) const
+const QueryString *Window::GetQueryString(WidgetID widnum) const
 {
 	auto query = this->querystrings.find(widnum);
 	return query != this->querystrings.end() ? query->second : nullptr;
@@ -343,7 +343,7 @@ const QueryString *Window::GetQueryString(uint widnum) const
  * @param widnum Editbox widget index
  * @return QueryString or nullptr.
  */
-QueryString *Window::GetQueryString(uint widnum)
+QueryString *Window::GetQueryString(WidgetID widnum)
 {
 	auto query = this->querystrings.find(widnum);
 	return query != this->querystrings.end() ? query->second : nullptr;
@@ -484,7 +484,7 @@ void Window::UnfocusFocusedWidget()
  * @param widget_index Index of the widget in the window to set the focus to.
  * @return Focus has changed.
  */
-bool Window::SetFocusedWidget(int widget_index)
+bool Window::SetFocusedWidget(WidgetID widget_index)
 {
 	NWidgetCore *widget = this->GetWidget<NWidgetCore>(widget_index);
 	assert(widget != nullptr); /* Setting focus to a non-existing widget is a bad idea. */
@@ -549,7 +549,7 @@ void Window::RaiseButtons(bool autoraise)
  * Invalidate a widget, i.e. mark it as being changed and in need of redraw.
  * @param widget_index the widget to redraw.
  */
-void Window::SetWidgetDirty(byte widget_index) const
+void Window::SetWidgetDirty(WidgetID widget_index) const
 {
 	/* Sometimes this function is called before the window is even fully initialized */
 	auto it = this->widget_lookup.find(widget_index);
@@ -588,7 +588,7 @@ EventState Window::OnHotkey(int hotkey)
  * unclicked in a few ticks.
  * @param widget the widget to "click"
  */
-void Window::HandleButtonClick(byte widget)
+void Window::HandleButtonClick(WidgetID widget)
 {
 	this->LowerWidget(widget);
 	this->SetTimeout();
@@ -627,7 +627,7 @@ static void DispatchLeftClickEvent(Window *w, int x, int y, int click_count)
 	/* don't allow any interaction if the button has been disabled */
 	if (nw->IsDisabled()) return;
 
-	int widget_index = nw->index; ///< Index of the widget
+	WidgetID widget_index = nw->index; ///< Index of the widget
 
 	/* Clicked on a widget that is not disabled.
 	 * So unless the clicked widget is the caption bar, change focus to this widget.
@@ -2472,7 +2472,7 @@ static bool MaybeBringWindowToFront(Window *w)
  * @return #ES_HANDLED if the key press has been handled and no other
  *         window should receive the event.
  */
-EventState Window::HandleEditBoxKey(int wid, char32_t key, uint16_t keycode)
+EventState Window::HandleEditBoxKey(WidgetID wid, char32_t key, uint16_t keycode)
 {
 	QueryString *query = this->GetQueryString(wid);
 	if (query == nullptr) return ES_NOT_HANDLED;
@@ -2630,7 +2630,7 @@ void HandleCtrlChanged()
  * @param wid Edit box widget.
  * @param str Text string to insert.
  */
-/* virtual */ void Window::InsertTextString(int wid, const char *str, bool marked, const char *caret, const char *insert_location, const char *replacement_end)
+/* virtual */ void Window::InsertTextString(WidgetID wid, const char *str, bool marked, const char *caret, const char *insert_location, const char *replacement_end)
 {
 	QueryString *query = this->GetQueryString(wid);
 	if (query == nullptr) return;
@@ -3092,7 +3092,7 @@ void SetWindowDirty(WindowClass cls, WindowNumber number)
  * @param number Window number in that class
  * @param widget_index Index number of the widget that needs repainting
  */
-void SetWindowWidgetDirty(WindowClass cls, WindowNumber number, byte widget_index)
+void SetWindowWidgetDirty(WindowClass cls, WindowNumber number, WidgetID widget_index)
 {
 	for (const Window *w : Window::Iterate()) {
 		if (w->window_class == cls && w->window_number == number) {

--- a/src/window_func.h
+++ b/src/window_func.h
@@ -63,7 +63,7 @@ void ShowVitalWindows();
  */
 void ReInitAllWindows(bool zoom_changed);
 
-void SetWindowWidgetDirty(WindowClass cls, WindowNumber number, byte widget_index);
+void SetWindowWidgetDirty(WindowClass cls, WindowNumber number, WidgetID widget_index);
 void SetWindowDirty(WindowClass cls, WindowNumber number);
 void SetWindowClassesDirty(WindowClass cls);
 

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -264,21 +264,21 @@ public:
 	NWidgetStacked *shade_select;    ///< Selection widget (#NWID_SELECTION) to use for shading the window. If \c nullptr, window cannot shade.
 	Dimension unshaded_size;         ///< Last known unshaded size (only valid while shaded).
 
-	int mouse_capture_widget;        ///< Widgetindex of current mouse capture widget (e.g. dragged scrollbar). -1 if no widget has mouse capture.
+	WidgetID mouse_capture_widget;   ///< ID of current mouse capture widget (e.g. dragged scrollbar). -1 if no widget has mouse capture.
 
 	Window *parent;                  ///< Parent window.
 	WindowList::iterator z_position;
 
 	template <class NWID>
-	inline const NWID *GetWidget(uint widnum) const;
+	inline const NWID *GetWidget(WidgetID widnum) const;
 	template <class NWID>
-	inline NWID *GetWidget(uint widnum);
+	inline NWID *GetWidget(WidgetID widnum);
 
-	const Scrollbar *GetScrollbar(uint widnum) const;
-	Scrollbar *GetScrollbar(uint widnum);
+	const Scrollbar *GetScrollbar(WidgetID widnum) const;
+	Scrollbar *GetScrollbar(WidgetID widnum);
 
-	const QueryString *GetQueryString(uint widnum) const;
-	QueryString *GetQueryString(uint widnum);
+	const QueryString *GetQueryString(WidgetID widnum) const;
+	QueryString *GetQueryString(WidgetID widnum);
 	void UpdateQueryStringSize();
 
 	virtual const struct Textbuf *GetFocusedTextbuf() const;
@@ -315,8 +315,8 @@ public:
 	}
 
 	void DisableAllWidgetHighlight();
-	void SetWidgetHighlight(byte widget_index, TextColour highlighted_colour);
-	bool IsWidgetHighlighted(byte widget_index) const;
+	void SetWidgetHighlight(WidgetID widget_index, TextColour highlighted_colour);
+	bool IsWidgetHighlighted(WidgetID widget_index) const;
 
 	/**
 	 * Sets the enabled/disabled status of a widget.
@@ -325,7 +325,7 @@ public:
 	 * @param widget_index index of this widget in the window
 	 * @param disab_stat status to use ie: disabled = true, enabled = false
 	 */
-	inline void SetWidgetDisabledState(byte widget_index, bool disab_stat)
+	inline void SetWidgetDisabledState(WidgetID widget_index, bool disab_stat)
 	{
 		this->GetWidget<NWidgetCore>(widget_index)->SetDisabled(disab_stat);
 	}
@@ -334,7 +334,7 @@ public:
 	 * Sets a widget to disabled.
 	 * @param widget_index index of this widget in the window
 	 */
-	inline void DisableWidget(byte widget_index)
+	inline void DisableWidget(WidgetID widget_index)
 	{
 		SetWidgetDisabledState(widget_index, true);
 	}
@@ -343,7 +343,7 @@ public:
 	 * Sets a widget to Enabled.
 	 * @param widget_index index of this widget in the window
 	 */
-	inline void EnableWidget(byte widget_index)
+	inline void EnableWidget(WidgetID widget_index)
 	{
 		SetWidgetDisabledState(widget_index, false);
 	}
@@ -353,7 +353,7 @@ public:
 	 * @param widget_index index of this widget in the window
 	 * @return status of the widget ie: disabled = true, enabled = false
 	 */
-	inline bool IsWidgetDisabled(byte widget_index) const
+	inline bool IsWidgetDisabled(WidgetID widget_index) const
 	{
 		return this->GetWidget<NWidgetCore>(widget_index)->IsDisabled();
 	}
@@ -363,7 +363,7 @@ public:
 	 * @param widget_index : index of the widget in the window to check
 	 * @return true if given widget is the focused window in this window
 	 */
-	inline bool IsWidgetFocused(byte widget_index) const
+	inline bool IsWidgetFocused(WidgetID widget_index) const
 	{
 		return this->nested_focus != nullptr && this->nested_focus->index == widget_index;
 	}
@@ -374,7 +374,7 @@ public:
 	 * @param widget_index : index of the widget in the window to check
 	 * @return true if given widget is the focused window in this window and this window has focus
 	 */
-	inline bool IsWidgetGloballyFocused(byte widget_index) const
+	inline bool IsWidgetGloballyFocused(WidgetID widget_index) const
 	{
 		return _focused_window == this && IsWidgetFocused(widget_index);
 	}
@@ -384,7 +384,7 @@ public:
 	 * @param widget_index index of this widget in the window
 	 * @param lowered_stat status to use ie: lowered = true, raised = false
 	 */
-	inline void SetWidgetLoweredState(byte widget_index, bool lowered_stat)
+	inline void SetWidgetLoweredState(WidgetID widget_index, bool lowered_stat)
 	{
 		this->GetWidget<NWidgetCore>(widget_index)->SetLowered(lowered_stat);
 	}
@@ -393,7 +393,7 @@ public:
 	 * Invert the lowered/raised  status of a widget.
 	 * @param widget_index index of this widget in the window
 	 */
-	inline void ToggleWidgetLoweredState(byte widget_index)
+	inline void ToggleWidgetLoweredState(WidgetID widget_index)
 	{
 		bool lowered_state = this->GetWidget<NWidgetCore>(widget_index)->IsLowered();
 		this->GetWidget<NWidgetCore>(widget_index)->SetLowered(!lowered_state);
@@ -403,7 +403,7 @@ public:
 	 * Marks a widget as lowered.
 	 * @param widget_index index of this widget in the window
 	 */
-	inline void LowerWidget(byte widget_index)
+	inline void LowerWidget(WidgetID widget_index)
 	{
 		SetWidgetLoweredState(widget_index, true);
 	}
@@ -412,7 +412,7 @@ public:
 	 * Marks a widget as raised.
 	 * @param widget_index index of this widget in the window
 	 */
-	inline void RaiseWidget(byte widget_index)
+	inline void RaiseWidget(WidgetID widget_index)
 	{
 		SetWidgetLoweredState(widget_index, false);
 	}
@@ -434,19 +434,19 @@ public:
 	 * @param widget_index index of this widget in the window
 	 * @return status of the widget ie: lowered = true, raised= false
 	 */
-	inline bool IsWidgetLowered(byte widget_index) const
+	inline bool IsWidgetLowered(WidgetID widget_index) const
 	{
 		return this->GetWidget<NWidgetCore>(widget_index)->IsLowered();
 	}
 
 	void UnfocusFocusedWidget();
-	bool SetFocusedWidget(int widget_index);
+	bool SetFocusedWidget(WidgetID widget_index);
 
-	EventState HandleEditBoxKey(int wid, char32_t key, uint16_t keycode);
-	virtual void InsertTextString(int wid, const char *str, bool marked, const char *caret, const char *insert_location, const char *replacement_end);
+	EventState HandleEditBoxKey(WidgetID wid, char32_t key, uint16_t keycode);
+	virtual void InsertTextString(WidgetID wid, const char *str, bool marked, const char *caret, const char *insert_location, const char *replacement_end);
 
-	void HandleButtonClick(byte widget);
-	int GetRowFromWidget(int clickpos, int widget, int padding, int line_height = -1) const;
+	void HandleButtonClick(WidgetID widget);
+	int GetRowFromWidget(int clickpos, WidgetID widget, int padding, int line_height = -1) const;
 
 	void RaiseButtons(bool autoraise = false);
 
@@ -484,11 +484,11 @@ public:
 		(this->RaiseWidgetWhenLowered(widgets), ...);
 	}
 
-	void SetWidgetDirty(byte widget_index) const;
+	void SetWidgetDirty(WidgetID widget_index) const;
 
 	void DrawWidgets() const;
 	void DrawViewport() const;
-	void DrawSortButtonState(int widget, SortButtonState state) const;
+	void DrawSortButtonState(WidgetID widget, SortButtonState state) const;
 	static int SortButtonWidth();
 
 	void CloseChildWindows(WindowClass wc = WC_INVALID) const;
@@ -544,7 +544,7 @@ public:
 	 * @param widget Number of the widget to draw.
 	 * @note This method may not change any state, it may only use drawing functions.
 	 */
-	virtual void DrawWidget([[maybe_unused]] const Rect &r, [[maybe_unused]] int widget) const {}
+	virtual void DrawWidget([[maybe_unused]] const Rect &r, [[maybe_unused]] WidgetID widget) const {}
 
 	/**
 	 * Update size and resize step of a widget in the window.
@@ -558,7 +558,7 @@ public:
 	 * @param fill    Fill step of the widget.
 	 * @param resize  Resize step of the widget.
 	 */
-	virtual void UpdateWidgetSize([[maybe_unused]] int widget, [[maybe_unused]] Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) {}
+	virtual void UpdateWidgetSize([[maybe_unused]] WidgetID widget, [[maybe_unused]] Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) {}
 
 	/**
 	 * Initialize string parameters for a widget.
@@ -566,7 +566,7 @@ public:
 	 * and while re-initializing the window. Only for widgets that render text initializing is requested.
 	 * @param widget  Widget number.
 	 */
-	virtual void SetStringParameters([[maybe_unused]] int widget) const {}
+	virtual void SetStringParameters([[maybe_unused]] WidgetID widget) const {}
 
 	/**
 	 * The window has gained focus.
@@ -604,7 +604,7 @@ public:
 	 * @param widget the clicked widget.
 	 * @param click_count Number of fast consecutive clicks at same position
 	 */
-	virtual void OnClick([[maybe_unused]] Point pt, [[maybe_unused]] int widget, [[maybe_unused]] int click_count) {}
+	virtual void OnClick([[maybe_unused]] Point pt, [[maybe_unused]] WidgetID widget, [[maybe_unused]] int click_count) {}
 
 	/**
 	 * A click with the right mouse button has been made on the window.
@@ -613,14 +613,14 @@ public:
 	 * @return true if the click was actually handled, i.e. do not show a
 	 *         tooltip if tooltip-on-right-click is enabled.
 	 */
-	virtual bool OnRightClick([[maybe_unused]] Point pt, [[maybe_unused]] int widget) { return false; }
+	virtual bool OnRightClick([[maybe_unused]] Point pt, [[maybe_unused]] WidgetID widget) { return false; }
 
 	/**
 	 * The mouse is hovering over a widget in the window, perform an action for it.
 	 * @param pt     The point where the mouse is hovering.
 	 * @param widget The widget where the mouse is hovering.
 	 */
-	virtual void OnHover([[maybe_unused]] Point pt, [[maybe_unused]] int widget) {}
+	virtual void OnHover([[maybe_unused]] Point pt, [[maybe_unused]] WidgetID widget) {}
 
 	/**
 	 * Event to display a custom tooltip.
@@ -628,21 +628,21 @@ public:
 	 * @param widget The widget where the mouse is located.
 	 * @return True if the event is handled, false if it is ignored.
 	 */
-	virtual bool OnTooltip([[maybe_unused]] Point pt, [[maybe_unused]] int widget, [[maybe_unused]] TooltipCloseCondition close_cond) { return false; }
+	virtual bool OnTooltip([[maybe_unused]] Point pt, [[maybe_unused]] WidgetID widget, [[maybe_unused]] TooltipCloseCondition close_cond) { return false; }
 
 	/**
 	 * An 'object' is being dragged at the provided position, highlight the target if possible.
 	 * @param pt     The point inside the window that the mouse hovers over.
 	 * @param widget The widget the mouse hovers over.
 	 */
-	virtual void OnMouseDrag([[maybe_unused]] Point pt, [[maybe_unused]] int widget) {}
+	virtual void OnMouseDrag([[maybe_unused]] Point pt, [[maybe_unused]] WidgetID widget) {}
 
 	/**
 	 * A dragged 'object' has been released.
 	 * @param pt     the point inside the window where the release took place.
 	 * @param widget the widget where the release took place.
 	 */
-	virtual void OnDragDrop([[maybe_unused]] Point pt, [[maybe_unused]] int widget) {}
+	virtual void OnDragDrop([[maybe_unused]] Point pt, [[maybe_unused]] WidgetID widget) {}
 
 	/**
 	 * Handle the request for (viewport) scrolling.
@@ -656,7 +656,7 @@ public:
 	 * @param pt     the point inside the window that the mouse hovers over.
 	 * @param widget the widget the mouse hovers over.
 	 */
-	virtual void OnMouseOver([[maybe_unused]] Point pt, [[maybe_unused]] int widget) {}
+	virtual void OnMouseOver([[maybe_unused]] Point pt, [[maybe_unused]] WidgetID widget) {}
 
 	/**
 	 * The mouse wheel has been turned.
@@ -697,15 +697,15 @@ public:
 	 * @param widget the widget (button) that the dropdown is associated with.
 	 * @param index  the element in the dropdown that is selected.
 	 */
-	virtual void OnDropdownSelect([[maybe_unused]] int widget, [[maybe_unused]] int index) {}
+	virtual void OnDropdownSelect([[maybe_unused]] WidgetID widget, [[maybe_unused]] int index) {}
 
-	virtual void OnDropdownClose(Point pt, int widget, int index, bool instant_close);
+	virtual void OnDropdownClose(Point pt, WidgetID widget, int index, bool instant_close);
 
 	/**
 	 * The text in an editbox has been edited.
 	 * @param widget The widget of the editbox.
 	 */
-	virtual void OnEditboxChanged([[maybe_unused]] int widget) {}
+	virtual void OnEditboxChanged([[maybe_unused]] WidgetID widget) {}
 
 	/**
 	 * The query window opened from this window has closed.
@@ -886,7 +886,7 @@ inline bool AllEqual(It begin, It end, Pred pred)
  * @return The requested widget if it is instantiated, \c nullptr otherwise.
  */
 template <class NWID>
-inline NWID *Window::GetWidget(uint widnum)
+inline NWID *Window::GetWidget(WidgetID widnum)
 {
 	auto it = this->widget_lookup.find(widnum);
 	if (it == std::end(this->widget_lookup)) return nullptr;
@@ -897,7 +897,7 @@ inline NWID *Window::GetWidget(uint widnum)
 
 /** Specialized case of #Window::GetWidget for the nested widget base class. */
 template <>
-inline const NWidgetBase *Window::GetWidget<NWidgetBase>(uint widnum) const
+inline const NWidgetBase *Window::GetWidget<NWidgetBase>(WidgetID widnum) const
 {
 	auto it = this->widget_lookup.find(widnum);
 	if (it == std::end(this->widget_lookup)) return nullptr;
@@ -911,7 +911,7 @@ inline const NWidgetBase *Window::GetWidget<NWidgetBase>(uint widnum) const
  * @return The requested widget if it is instantiated, \c nullptr otherwise.
  */
 template <class NWID>
-inline const NWID *Window::GetWidget(uint widnum) const
+inline const NWID *Window::GetWidget(WidgetID widnum) const
 {
 	return const_cast<Window *>(this)->GetWidget<NWID>(widnum);
 }
@@ -961,7 +961,7 @@ void RelocateAllWindows(int neww, int newh);
 void GuiShowTooltips(Window *parent, StringID str, TooltipCloseCondition close_tooltip, uint paramcount = 0);
 
 /* widget.cpp */
-int GetWidgetFromPos(const Window *w, int x, int y);
+WidgetID GetWidgetFromPos(const Window *w, int x, int y);
 
 extern Point _cursorpos_drag_start;
 

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -10,6 +10,13 @@
 #ifndef WINDOW_TYPE_H
 #define WINDOW_TYPE_H
 
+/**
+ * Widget ID.
+ * Even though the ID is signed, actual IDs must be non-negative.
+ * Negative IDs are used for special cases, like denoting 'no widget'.
+ */
+using WidgetID = int;
+
 /** %Window numbers. */
 enum WindowNumberEnum {
 	WN_GAME_OPTIONS_AI = 0,          ///< AI settings.


### PR DESCRIPTION
## Motivation / Problem

Widget indexes were stored as int, but often passed around as uint/uint8_t and casts.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

## Description

Alias WidgetID to int, and use WidgetID consistently instead. This does not address the mishmash of variable names...

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
