### PR TITLE
Fix #11644: Off by one error/buffer over-read in StrMakeValid

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -486,7 +486,7 @@ static std::string ExtractString(char *buffer, size_t buffer_length)
 {
 	size_t length = 0;
 	for (; length < buffer_length && buffer[length] != '\0'; length++) {}
-	return StrMakeValid(std::string(buffer, length));
+	return StrMakeValid(std::string_view(buffer, length));
 }
 
 bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] const std::string &tar_filename)

--- a/src/ini_load.cpp
+++ b/src/ini_load.cpp
@@ -284,7 +284,7 @@ void IniLoadFile::LoadFromDisk(const std::string &filename, Subdirectory subdir)
 			if (!quoted && e == t) {
 				item.value.reset();
 			} else {
-				item.value = StrMakeValid(std::string(t));
+				item.value = StrMakeValid(std::string_view(t));
 			}
 		} else {
 			/* it's an orphan item */

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -211,8 +211,10 @@ void StrMakeValidInPlace(char *str, StringValidationSettings settings)
  */
 std::string StrMakeValid(std::string_view str, StringValidationSettings settings)
 {
+	if (str.empty()) return {};
+
 	auto buf = str.data();
-	auto last = buf + str.size();
+	auto last = buf + str.size() - 1;
 
 	std::ostringstream dst;
 	std::ostreambuf_iterator<char> dst_iter(dst);

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -141,7 +141,7 @@ static void StrMakeValid(T &dst, const char *str, const char *last, StringValida
 		 * would also reach the "last" byte of the string and a normal '\0'
 		 * termination will be placed after it.
 		 */
-		if (len == 0 || str + len > last || len != Utf8Decode(&c, str)) {
+		if (len == 0 || str + len > last + 1 || len != Utf8Decode(&c, str)) {
 			/* Maybe the next byte is still a valid character? */
 			str++;
 			continue;


### PR DESCRIPTION
## Motivation / Problem

#11644

## Description

Fix off by one error in StrMakeValid buffer last character
Fix off by one in StrMakeValid UTF-8 decode overrun detection
Fix unnecessary string duplication at StrMakeValid call sites

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
