### PR TITLE
Fix #11646: Non-thread safe shared buffer returned from GetLogPrefix().

### DIFF
--- a/src/console.cpp
+++ b/src/console.cpp
@@ -51,10 +51,9 @@ static void IConsoleWriteToLogFile(const std::string &string)
 {
 	if (_iconsole_output_file != nullptr) {
 		/* if there is an console output file ... also print it there */
-		const char *header = GetLogPrefix();
-		if ((strlen(header) != 0 && fwrite(header, strlen(header), 1, _iconsole_output_file) != 1) ||
-				fwrite(string.c_str(), string.size(), 1, _iconsole_output_file) != 1 ||
-				fwrite("\n", 1, 1, _iconsole_output_file) != 1) {
+		try {
+			fmt::print(_iconsole_output_file, "{}{}\n", GetLogPrefix(), string);
+		} catch (const std::system_error &) {
 			fclose(_iconsole_output_file);
 			_iconsole_output_file = nullptr;
 			IConsolePrint(CC_ERROR, "Cannot write to console log file; closing the log file.");

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -232,18 +232,16 @@ std::string GetDebugString()
 
 /**
  * Get the prefix for logs; if show_date_in_logs is enabled it returns
- * the date, otherwise it returns nothing.
- * @return the prefix for logs (do not free), never nullptr
+ * the date, otherwise it returns an empty string.
+ * @return the prefix for logs.
  */
-const char *GetLogPrefix()
+std::string GetLogPrefix()
 {
-	static std::string _log_prefix;
+	std::string log_prefix;
 	if (_settings_client.gui.show_date_in_logs) {
-		_log_prefix = fmt::format("[{:%Y-%m-%d %H:%M:%S}] ", fmt::localtime(time(nullptr)));
-	} else {
-		_log_prefix.clear();
+		log_prefix = fmt::format("[{:%Y-%m-%d %H:%M:%S}] ", fmt::localtime(time(nullptr)));
 	}
-	return _log_prefix.c_str();
+	return log_prefix;
 }
 
 /**

--- a/src/debug.h
+++ b/src/debug.h
@@ -120,7 +120,7 @@ std::string GetDebugString();
 void ShowInfoI(const std::string &str);
 #define ShowInfo(format_string, ...) ShowInfoI(fmt::format(FMT_STRING(format_string), ## __VA_ARGS__))
 
-const char *GetLogPrefix();
+std::string GetLogPrefix();
 
 void DebugSendRemoteMessages();
 void DebugReconsiderSendRemoteMessages();


### PR DESCRIPTION
## Motivation / Problem

GetLogPrefix reuses a static std::string, and returns its buffer after updating it. This is not thread safe.

This is probably a left-over from using C-style strings.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Return string from GetLogPrefix instead of shared string's buffer.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
