### PR TITLE
Fix: [CI] patch in SHF_COMPRESSED symbol for our Linux Generic binaries

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -97,6 +97,14 @@ jobs:
           cmake --build . -j $(nproc)
           cmake --install .
         )
+
+        # The container we use is old enough, that it doesn't know SHF_COMPRESSED.
+        # But, breakpad needs this symbol to exist. So we patch it in our system
+        # libraries.
+        (
+          cd /
+          patch -p1 < ${GITHUB_WORKSPACE}/os/linux/shf-compressed.patch
+        )
         echo "::endgroup::"
 
         echo "::group::Install audio drivers"

--- a/os/linux/shf-compressed.patch
+++ b/os/linux/shf-compressed.patch
@@ -1,0 +1,10 @@
+--- a/usr/include/elf.h	2023-12-30 13:46:27.038645199 +0100
++++ b/usr/include/elf.h	2023-12-30 13:46:42.278641893 +0100
+@@ -365,6 +365,7 @@
+ 					   required */
+ #define SHF_GROUP	     (1 << 9)	/* Section is member of a group.  */
+ #define SHF_TLS		     (1 << 10)	/* Section hold thread-local data.  */
++#define SHF_COMPRESSED	     (1 << 11)	/* Section with compressed data. */
+ #define SHF_MASKOS	     0x0ff00000	/* OS-specific.  */
+ #define SHF_MASKPROC	     0xf0000000	/* Processor-specific */
+ #define SHF_ORDERED	     (1 << 30)	/* Special ordering requirement


### PR DESCRIPTION
## Motivation / Problem

Fixes #11650.

vcpkg upgraded to a breakpad that is somewhat recent (over a year old, but still). Sadly, in this new version breakpad started to use `SHF_COMPRESSED`, without actually checking of the OS knows that symbol. They just assume your OS is new enough ..

And guess what: our linux-generic builds on an OS a tiny bit older :P (to make sure we are as compatible as we can be).

In short: build fails because of it.

## Description

Solution is simply: patch in that symbol on system-level.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
