### PR TITLE
Change: add vcpkg.json to instruct vcpkg what dependencies we require

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -108,6 +108,14 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Setup vcpkg caching
+      uses: actions/github-script@v6
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+          core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite')
+
     - name: Install dependencies
       run: |
         echo "::group::Update apt"
@@ -192,18 +200,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Prepare cache key
-      id: key
-      run: |
-        echo "image=$ImageOS-$ImageVersion" >> $GITHUB_OUTPUT
-
-    - name: Enable vcpkg cache
-      uses: actions/cache@v3
+    - name: Setup vcpkg caching
+      uses: actions/github-script@v6
       with:
-        path: /usr/local/share/vcpkg/installed
-        key: ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}-1 # Increase the number whenever dependencies are modified
-        restore-keys: |
-          ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+          core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite')
 
     - name: Prepare vcpkg
       run: |
@@ -272,22 +275,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Prepare cache key
-      id: key
-      shell: powershell
-      run: |
-        # Work around caching failure with GNU tar
-        New-Item -Type Junction -Path vcpkg -Target c:\vcpkg
-
-        Write-Output "image=$env:ImageOS-$env:ImageVersion" >> $env:GITHUB_OUTPUT
-
-    - name: Enable vcpkg cache
-      uses: actions/cache@v3
+    - name: Setup vcpkg caching
+      uses: actions/github-script@v6
       with:
-        path: vcpkg/installed
-        key: ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}-1 # Increase the number whenever dependencies are modified
-        restore-keys: |
-          ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+          core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite')
 
     - name: Prepare vcpkg
       shell: bash

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -192,15 +192,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Install dependencies
-      env:
-        HOMEBREW_NO_AUTO_UPDATE: 1
-        HOMEBREW_NO_INSTALL_CLEANUP: 1
-      run: |
-        brew install \
-          pkg-config \
-          # EOF
-
     - name: Prepare cache key
       id: key
       run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -99,7 +99,7 @@ jobs:
 
     name: Linux (${{ matrix.name }})
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: ${{ matrix.compiler }}
       CXX: ${{ matrix.cxxcompiler }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -135,9 +135,15 @@ jobs:
           zlib1g-dev \
           # EOF
 
-        sudo vcpkg install \
-          breakpad \
-          # EOF
+        echo "::group::Install vcpkg dependencies"
+
+        # Disable vcpkg integration, as we mostly use system libraries.
+        mv vcpkg.json vcpkg-disabled.json
+
+        # We only use breakpad from vcpkg, as its CMake files
+        # are a bit special. So the Ubuntu's variant doesn't work.
+        vcpkg install breakpad
+
         echo "::endgroup::"
       env:
         DEBIAN_FRONTEND: noninteractive
@@ -176,10 +182,15 @@ jobs:
 
     - name: Test
       run: |
-        cd build
-        ctest -j $(nproc) --timeout 120
+        (
+          cd build
+          ctest -j $(nproc) --timeout 120
+        )
 
-        # Check no tracked files have been modified
+        # Re-enable vcpkg.
+        mv vcpkg-disabled.json vcpkg.json
+
+        # Check no tracked files have been modified.
         git diff --exit-code
 
   macos:
@@ -207,17 +218,6 @@ jobs:
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
           core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite')
-
-    - name: Prepare vcpkg
-      run: |
-        vcpkg install --triplet=${{ matrix.arch }}-osx \
-          breakpad \
-          curl \
-          liblzma \
-          libpng \
-          lzo \
-          zlib \
-          # EOF
 
     - name: Install OpenGFX
       run: |
@@ -282,17 +282,6 @@ jobs:
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
           core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite')
-
-    - name: Prepare vcpkg
-      shell: bash
-      run: |
-        vcpkg install --triplet=${{ matrix.arch }}-windows-static \
-          breakpad \
-          liblzma \
-          libpng \
-          lzo \
-          zlib \
-          # EOF
 
     - name: Install OpenGFX
       shell: bash

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -33,12 +33,23 @@ jobs:
       run: |
         tar -xf source.tar.gz --strip-components=1
 
-    # dtolnay/rust-toolchain uses a curl argument (--retry-connrefused) that the curl shipped with our container doesn't support.
-    # So we need to do one part ourselves; the action takes over the rest and prepares the setup further.
-    - name: Prepare Rust toolchain
+    # curl is too old for most of the tools to work properly. For example,
+    # rust-toolchain doesn't work properly, neither vcpkg caching.
+    # The easier solution here is to upgrade curl.
+    - name: Update curl
       run: |
-        curl --proto '=https' --tlsv1.2 --retry 10 --location --silent --show-error --fail "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
-        echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+        yum install -y \
+          openssl-devel \
+          # EOF
+
+        mkdir /curl
+        cd /curl
+        curl -o curl-7.81.0.zip https://curl.se/download/curl-7.81.0.zip
+        unzip curl-7.81.0.zip
+        cd curl-7.81.0
+        ./configure --with-ssl --with-zlib --prefix=/usr --libdir=/usr/lib64
+        make -j $(nproc)
+        make install
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -17,11 +17,6 @@ jobs:
       # manylinux2014 is based on CentOS 7, but already has a lot of things
       # installed and preconfigured. It makes it easier to build OpenTTD.
       image: quay.io/pypa/manylinux2014_x86_64
-      volumes:
-      - /usr/local/share/vcpkg:/vcpkg
-      env:
-        ImageOS: ${{ env.ImageOS }}
-        ImageVersion: ${{ env.ImageVersion }}
 
     steps:
     - name: Download source
@@ -57,18 +52,13 @@ jobs:
     - name: Enable Rust cache
       uses: Swatinem/rust-cache@v2
 
-    - name: Prepare cache key
-      id: key
-      run: |
-        echo "image=$ImageOS-$ImageVersion" >> $GITHUB_OUTPUT
-
-    - name: Enable vcpkg cache
-      uses: actions/cache@v3
+    - name: Setup vcpkg caching
+      uses: actions/github-script@v6
       with:
-        path: /vcpkg/installed
-        key: ${{ steps.key.outputs.image }}-vcpkg-release-1 # Increase the number whenever dependencies are modified
-        restore-keys: |
-          ${{ steps.key.outputs.image }}-vcpkg-release
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+          core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite')
 
     - name: Install dependencies
       run: |
@@ -132,7 +122,16 @@ jobs:
         # We use vcpkg for our dependencies, to get more up-to-date version.
         echo "::group::Install vcpkg and dependencies"
 
-        # Make Python3 available for other packages.
+        git clone https://github.com/microsoft/vcpkg /vcpkg
+
+        (
+          cd /vcpkg
+          ./bootstrap-vcpkg.sh -disableMetrics
+        )
+
+        # Make Python3 available for other packages. This needs to be done
+        # first, as otherwise dependencies fail to build because Python3 is
+        # not available.
         /vcpkg/vcpkg install python3
         ln -sf /vcpkg/installed/x64-linux/tools/python3/python3.[0-9][0-9] /usr/bin/python3
 

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -132,28 +132,12 @@ jobs:
         # Make Python3 available for other packages. This needs to be done
         # first, as otherwise dependencies fail to build because Python3 is
         # not available.
-        /vcpkg/vcpkg install python3
-        ln -sf /vcpkg/installed/x64-linux/tools/python3/python3.[0-9][0-9] /usr/bin/python3
+        (
+          cd /
 
-        # SDL2 needs dbus, but dbus default install comes with libsystemd
-        # and some of libsystemd deps fail to build on our quite old linux.
-        # So just install basic dbus without any extra deps.
-        /vcpkg/vcpkg install dbus[core]
-
-        # Now we can install OpenTTD dependencies
-        /vcpkg/vcpkg install \
-          breakpad \
-          curl[http2] \
-          fontconfig \
-          freetype \
-          harfbuzz \
-          icu \
-          liblzma \
-          libpng \
-          lzo \
-          sdl2 \
-          zlib \
-          # EOF
+          /vcpkg/vcpkg install python3
+          ln -sf /vcpkg/installed/x64-linux/tools/python3/python3.[0-9][0-9] /usr/bin/python3
+        )
         echo "::endgroup::"
 
         echo "::group::Install breakpad dependencies"

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -12,7 +12,7 @@ jobs:
   linux:
     name: Linux (Generic)
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       # manylinux2014 is based on CentOS 7, but already has a lot of things
       # installed and preconfigured. It makes it easier to build OpenTTD.

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -12,7 +12,7 @@ jobs:
   macos:
     name: MacOS
 
-    runs-on: macos-12
+    runs-on: macos-latest
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.13
 

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -55,23 +55,6 @@ jobs:
         cargo install dump_syms
         echo "::endgroup::"
 
-    - name: Prepare vcpkg
-      run: |
-        vcpkg install \
-          breakpad:x64-osx \
-          breakpad:arm64-osx \
-          curl:x64-osx \
-          curl:arm64-osx \
-          liblzma:x64-osx \
-          liblzma:arm64-osx \
-          libpng:x64-osx \
-          libpng:arm64-osx \
-          lzo:x64-osx \
-          lzo:arm64-osx \
-          zlib:x64-osx \
-          zlib:arm64-osx \
-          # EOF
-
     - name: Install GCC problem matcher
       uses: ammaraskar/gcc-problem-matcher@master
 

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -40,7 +40,6 @@ jobs:
         echo "::group::Install brew dependencies"
         brew install \
           pandoc \
-          pkg-config \
           # EOF
         echo "::endgroup::"
 

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -32,6 +32,14 @@ jobs:
     - name: Enable Rust cache
       uses: Swatinem/rust-cache@v2
 
+    - name: Setup vcpkg caching
+      uses: actions/github-script@v6
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+          core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite')
+
     - name: Install dependencies
       env:
         HOMEBREW_NO_AUTO_UPDATE: 1
@@ -46,20 +54,6 @@ jobs:
         echo "::group::Install breakpad dependencies"
         cargo install dump_syms
         echo "::endgroup::"
-
-    - name: Prepare cache key
-      id: key
-      run: |
-        echo "image=$ImageOS-$ImageVersion" >> $GITHUB_OUTPUT
-
-    - name: Enable vcpkg cache
-      uses: actions/cache@v3
-      with:
-        path: /usr/local/share/vcpkg/installed
-        key: ${{ steps.key.outputs.image }}-vcpkg-release-1 # Increase the number whenever dependencies are modified
-        restore-keys: |
-          ${{ steps.key.outputs.image }}-vcpkg-release
-          ${{ steps.key.outputs.image }}-vcpkg-x64
 
     - name: Prepare vcpkg
       run: |

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -45,6 +45,14 @@ jobs:
     - name: Enable Rust cache
       uses: Swatinem/rust-cache@v2
 
+    - name: Setup vcpkg caching
+      uses: actions/github-script@v6
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+          core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite')
+
     - name: Install dependencies
       shell: bash
       run: |
@@ -55,23 +63,6 @@ jobs:
         echo "::group::Install breakpad dependencies"
         cargo install dump_syms
         echo "::endgroup::"
-
-    - name: Prepare cache key
-      id: key
-      shell: powershell
-      run: |
-        # Work around caching failure with GNU tar
-        New-Item -Type Junction -Path vcpkg -Target c:\vcpkg
-
-        Write-Output "image=$env:ImageOS-$env:ImageVersion" >> $env:GITHUB_OUTPUT
-
-    - name: Enable vcpkg cache
-      uses: actions/cache@v3
-      with:
-        path: vcpkg/installed
-        key: ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}-1 # Increase the number whenever dependencies are modified
-        restore-keys: |
-          ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}
 
     - name: Prepare vcpkg
       shell: bash

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -64,23 +64,6 @@ jobs:
         cargo install dump_syms
         echo "::endgroup::"
 
-    - name: Prepare vcpkg
-      shell: bash
-      run: |
-        vcpkg install --triplet=${{ matrix.arch }}-windows-static \
-          liblzma \
-          libpng \
-          lzo \
-          zlib \
-          # EOF
-
-        # arm64-windows-static is not (yet) supported for breakpad.
-        if [ "${{ matrix.arch }}" != "arm64" ]; then
-          vcpkg install --triplet=${{ matrix.arch }}-windows-static \
-            breakpad \
-            # EOF
-        fi
-
     - name: Install MSVC problem matcher
       uses: ammaraskar/msvc-problem-matcher@master
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/aidocs/*
 docs/gamedocs/*
 docs/source/*
 /out
+/vcpkg_installed

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -59,8 +59,8 @@ the `static` versions, and OpenTTD currently needs the following dependencies:
 To install both the x64 (64bit) and x86 (32bit) variants (though only one is necessary), you can use:
 
 ```ps
-.\vcpkg install breakpad:x64-windows-static liblzma:x64-windows-static libpng:x64-windows-static lzo:x64-windows-static zlib:x64-windows-static
-.\vcpkg install breakpad:x86-windows-static liblzma:x86-windows-static libpng:x86-windows-static lzo:x86-windows-static zlib:x86-windows-static
+.\vcpkg install --triplet=x64-windows-static
+.\vcpkg install --triplet=x86-windows-static
 ```
 
 You can open the folder (as a CMake project). CMake will be detected, and you can compile from there.

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "dependencies": [
+    {
+      "name": "breakpad",
+      "platform": "!(windows & arm)"
+    },
+    {
+      "name": "curl",
+      "platform": "linux",
+      "features": [
+        "http2"
+      ]
+    },
+    {
+      "name": "dbus",
+      "platform": "linux",
+      "default-features": false
+    },
+    {
+      "name": "fontconfig",
+      "platform": "linux"
+    },
+    {
+      "name": "freetype",
+      "platform": "linux"
+    },
+    {
+      "name": "harfbuzz",
+      "platform": "linux"
+    },
+    {
+      "name": "icu",
+      "platform": "linux"
+    },
+    {
+      "name": "liblzma"
+    },
+    {
+      "name": "libpng"
+    },
+    {
+      "name": "lzo"
+    },
+    {
+      "name": "sdl2",
+      "platform": "linux"
+    },
+    {
+      "name": "zlib"
+    }
+  ],
+  "builtin-baseline": "94cf042e6b7713913a3b3150f3ca3d0f4550f7c4"
+}


### PR DESCRIPTION
## Motivation / Problem

MSVC now integrated vcpkg, meaning the developer experience to get going is much smoother if we supply a `vcpkg.json` which states the dependencies.

Not unexpected, it turns out that this makes listing our dependencies also a lot easier for the other targets, like Linux and MacOS. It also gives a nice overview of what dependencies we use for what OS.

## Description

So, introducing, `vcpkg.json`, which lists our dependencies to get going.

There is one trick .. for our Linux CI we depend on system libraries rather than vcpkg libraries, with the exception of breakpad. But when vcpkg sees a `vcpkg.json`, it absolutely refuses to install a single package. So we just rename the file.
Similar for the Release CI, we need to install Python3 first. For this we simply change folder.

This PR grew a bit bigger than just this change, and now also changes how vcpkg is being cached. We now use the integrated GitHub Actions method, instead of doing it ourselves. This greatly speeds up compiles in most situations, while always installing the latest dependencies.

Also, while at it, 3 commits to clean up some minor stuff with our GitHub Workflows.

Example run of a release: https://github.com/TrueBrain/OpenTTD/actions/runs/7365346246

## Limitations

I had to revert an older commit which made the Linux Release use the vcpkg of the host system. The problem with this is that it became difficult to locally test if the workflow was using. As the problems we experiences were unrelated to what vcpkg to use anyway, switching back to cloning vcpkg locally, and using that. That makes it far easier to test out the Linux Release.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
