### PR TITLE
Fix #11337: Station blocked/pylon/wire bits with CBID_STATION_TILE_LAYOUT

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1439,20 +1439,6 @@ CommandCost CmdBuildRailStation(DoCommandFlag flags, TileIndex tile_org, RailTyp
 				SetStationTileRandomBits(tile, GB(Random(), 0, 4));
 				SetAnimationFrame(tile, 0);
 
-				/* Should be the same as layout but axis component could be wrong... */
-				StationGfx gfx = GetStationGfx(tile);
-				bool blocked = statspec != nullptr && HasBit(statspec->blocked, gfx);
-				/* Default stations do not draw pylons under roofs (gfx >= 4) */
-				bool pylons = statspec != nullptr ? HasBit(statspec->pylons, gfx) : gfx < 4;
-				bool wires = statspec == nullptr || !HasBit(statspec->wires, gfx);
-
-				SetStationTileBlocked(tile, blocked);
-				SetStationTileHavePylons(tile, pylons);
-				SetStationTileHaveWires(tile, wires);
-
-				if (!blocked) c->infrastructure.rail[rt]++;
-				c->infrastructure.station++;
-
 				if (statspec != nullptr) {
 					/* Use a fixed axis for GetPlatformInfo as our platforms / numtracks are always the right way around */
 					uint32_t platinfo = GetPlatformInfo(AXIS_X, GetStationGfx(tile), plat_len, numtracks_orig, plat_len - w, numtracks_orig - numtracks, false);
@@ -1470,6 +1456,20 @@ CommandCost CmdBuildRailStation(DoCommandFlag flags, TileIndex tile_org, RailTyp
 					/* Trigger station animation -- after building? */
 					TriggerStationAnimation(st, tile, SAT_BUILT);
 				}
+
+				/* Should be the same as layout but axis component could be wrong... */
+				StationGfx gfx = GetStationGfx(tile);
+				bool blocked = statspec != nullptr && HasBit(statspec->blocked, gfx);
+				/* Default stations do not draw pylons under roofs (gfx >= 4) */
+				bool pylons = statspec != nullptr ? HasBit(statspec->pylons, gfx) : gfx < 4;
+				bool wires = statspec == nullptr || !HasBit(statspec->wires, gfx);
+
+				SetStationTileBlocked(tile, blocked);
+				SetStationTileHavePylons(tile, pylons);
+				SetStationTileHaveWires(tile, wires);
+
+				if (!blocked) c->infrastructure.rail[rt]++;
+				c->infrastructure.station++;
 
 				tile += tile_delta;
 			} while (--w);


### PR DESCRIPTION
## Motivation / Problem

#11337 can set the station tile blocked/pylon/wire bits incorrectly when CBID_STATION_TILE_LAYOUT is used,
because it uses the station GFX before CBID_STATION_TILE_LAYOUT instead of after.

The GRF author noting this issue has not supplied a GRF which exhibits the problem, however the issue was described sufficiently to identify this as the cause.

## Description

Set station tile blocked/pylon/wire bits after CBID_STATION_TILE_LAYOUT instead of before.

## Limitations

Requires #11655 to be fixed before proper testing can be undertaken.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
