### PR TITLE
Codechange: Add and use method to get parent widget by type.

### DIFF
--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -333,7 +333,7 @@ public:
 				 * look nice in all layouts, we use the 4x4 layout (smallest previews) as starting point. For the bigger
 				 * previews in the layouts with less views we add space homogeneously on all sides, so the 4x4 preview-rectangle
 				 * is centered in the 2x1, 1x2 resp. 1x1 buttons. */
-				const NWidgetMatrix *matrix = this->GetWidget<NWidgetMatrix>(WID_BO_OBJECT_MATRIX);
+				const NWidgetMatrix *matrix = this->GetWidget<NWidgetBase>(widget)->GetParentWidget<NWidgetMatrix>();
 				uint matrix_height = matrix->current_y;
 
 				DrawPixelInfo tmp_dpi;
@@ -354,7 +354,7 @@ public:
 
 			case WID_BO_SELECT_IMAGE: {
 				ObjectClass *objclass = ObjectClass::Get(_selected_object_class);
-				int obj_index = objclass->GetIndexFromUI(this->GetWidget<NWidgetMatrix>(WID_BO_SELECT_MATRIX)->GetCurrentElement());
+				int obj_index = objclass->GetIndexFromUI(this->GetWidget<NWidgetBase>(widget)->GetParentWidget<NWidgetMatrix>()->GetCurrentElement());
 				if (obj_index < 0) break;
 				const ObjectSpec *spec = objclass->GetSpec(obj_index);
 				if (spec == nullptr) break;
@@ -509,14 +509,14 @@ public:
 
 			case WID_BO_SELECT_IMAGE: {
 				ObjectClass *objclass = ObjectClass::Get(_selected_object_class);
-				int num_clicked = objclass->GetIndexFromUI(this->GetWidget<NWidgetMatrix>(WID_BO_SELECT_MATRIX)->GetCurrentElement());
+				int num_clicked = objclass->GetIndexFromUI(this->GetWidget<NWidgetBase>(widget)->GetParentWidget<NWidgetMatrix>()->GetCurrentElement());
 				if (num_clicked >= 0 && objclass->GetSpec(num_clicked)->IsAvailable()) this->SelectOtherObject(num_clicked);
 				break;
 			}
 
 			case WID_BO_OBJECT_SPRITE:
 				if (_selected_object_index != -1) {
-					_selected_object_view = this->GetWidget<NWidgetMatrix>(WID_BO_OBJECT_MATRIX)->GetCurrentElement();
+					_selected_object_view = this->GetWidget<NWidgetBase>(widget)->GetParentWidget<NWidgetMatrix>()->GetCurrentElement();
 					this->SelectOtherObject(_selected_object_index); // Re-select the object for a different view.
 				}
 				break;

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1285,7 +1285,7 @@ public:
 			}
 
 			case WID_BRAS_IMAGE: {
-				uint16_t type = this->GetWidget<NWidgetMatrix>(WID_BRAS_MATRIX)->GetCurrentElement();
+				uint16_t type = this->GetWidget<NWidgetBase>(widget)->GetParentWidget<NWidgetMatrix>()->GetCurrentElement();
 				assert(type < _railstation.station_count);
 				/* Check station availability callback */
 				const StationSpec *statspec = StationClass::Get(_railstation.station_class)->GetSpec(type);
@@ -1470,7 +1470,7 @@ public:
 			}
 
 			case WID_BRAS_IMAGE: {
-				uint16_t y = this->GetWidget<NWidgetMatrix>(WID_BRAS_MATRIX)->GetCurrentElement();
+				uint16_t y = this->GetWidget<NWidgetBase>(widget)->GetParentWidget<NWidgetMatrix>()->GetCurrentElement();
 				if (y >= _railstation.station_count) return;
 
 				/* Check station availability callback */
@@ -1480,7 +1480,7 @@ public:
 				_railstation.station_type = y;
 
 				this->CheckSelectedSize(statspec);
-				this->GetWidget<NWidgetMatrix>(WID_BRAS_MATRIX)->SetClicked(_railstation.station_type);
+				this->GetWidget<NWidgetBase>(widget)->GetParentWidget<NWidgetMatrix>()->SetClicked(_railstation.station_type);
 
 				if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
 				this->SetDirty();
@@ -2097,7 +2097,7 @@ struct BuildRailWaypointWindow : PickerWindowBase {
 	{
 		switch (widget) {
 			case WID_BRW_WAYPOINT: {
-				uint16_t type = this->list.at(this->GetWidget<NWidgetMatrix>(WID_BRW_WAYPOINT_MATRIX)->GetCurrentElement());
+				uint16_t type = this->list.at(this->GetWidget<NWidgetBase>(widget)->GetParentWidget<NWidgetMatrix>()->GetCurrentElement());
 				const StationSpec *statspec = this->waypoints->GetSpec(type);
 
 				DrawPixelInfo tmp_dpi;
@@ -2120,7 +2120,7 @@ struct BuildRailWaypointWindow : PickerWindowBase {
 	{
 		switch (widget) {
 			case WID_BRW_WAYPOINT: {
-				uint16_t sel = this->GetWidget<NWidgetMatrix>(WID_BRW_WAYPOINT_MATRIX)->GetCurrentElement();
+				uint16_t sel = this->GetWidget<NWidgetBase>(widget)->GetParentWidget<NWidgetMatrix>()->GetCurrentElement();
 				assert(sel < this->list.size());
 				uint16_t type = this->list.at(sel);
 
@@ -2129,7 +2129,7 @@ struct BuildRailWaypointWindow : PickerWindowBase {
 				if (!IsStationAvailable(statspec)) return;
 
 				_cur_waypoint_type = type;
-				this->GetWidget<NWidgetMatrix>(WID_BRW_WAYPOINT_MATRIX)->SetClicked(sel);
+				this->GetWidget<NWidgetBase>(widget)->GetParentWidget<NWidgetMatrix>()->SetClicked(sel);
 				if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
 				this->SetDirty();
 				break;

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1451,7 +1451,7 @@ public:
 			}
 
 			case WID_BROS_IMAGE: {
-				uint16_t type = this->GetWidget<NWidgetMatrix>(WID_BROS_MATRIX)->GetCurrentElement();
+				uint16_t type = this->GetWidget<NWidgetBase>(widget)->GetParentWidget<NWidgetMatrix>()->GetCurrentElement();
 				assert(type < _roadstop_gui_settings.roadstop_count);
 
 				const RoadStopSpec *spec = RoadStopClass::Get(_roadstop_gui_settings.roadstop_class)->GetSpec(type);
@@ -1549,7 +1549,7 @@ public:
 			}
 
 			case WID_BROS_IMAGE: {
-				uint16_t y = this->GetWidget<NWidgetMatrix>(WID_BROS_MATRIX)->GetCurrentElement();
+				uint16_t y = this->GetWidget<NWidgetBase>(widget)->GetParentWidget<NWidgetMatrix>()->GetCurrentElement();
 				if (y >= _roadstop_gui_settings.roadstop_count) return;
 
 				const RoadStopSpec *spec = RoadStopClass::Get(_roadstop_gui_settings.roadstop_class)->GetSpec(y);
@@ -1559,7 +1559,7 @@ public:
 
 				_roadstop_gui_settings.roadstop_type = y;
 
-				this->GetWidget<NWidgetMatrix>(WID_BROS_MATRIX)->SetClicked(_roadstop_gui_settings.roadstop_type);
+				this->GetWidget<NWidgetBase>(widget)->GetParentWidget<NWidgetMatrix>()->SetClicked(_roadstop_gui_settings.roadstop_type);
 
 				if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
 				this->SetDirty();

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1319,6 +1319,8 @@ void NWidgetContainer::AdjustPaddingForZoom()
  */
 void NWidgetContainer::Add(NWidgetBase *wid)
 {
+	assert(wid != nullptr);
+	wid->parent = this;
 	assert(wid->next == nullptr && wid->prev == nullptr);
 
 	if (this->head == nullptr) {
@@ -2170,6 +2172,7 @@ NWidgetBackground::NWidgetBackground(WidgetType tp, Colours colour, WidgetID ind
 {
 	assert(tp == WWT_PANEL || tp == WWT_INSET || tp == WWT_FRAME);
 	this->child = child;
+	if (this->child != nullptr) this->child->parent = this;
 	this->SetAlignment(SA_TOP | SA_LEFT);
 }
 
@@ -2190,6 +2193,7 @@ void NWidgetBackground::Add(NWidgetBase *nwid)
 	if (this->child == nullptr) {
 		this->child = new NWidgetVertical();
 	}
+	nwid->parent = this->child;
 	this->child->Add(nwid);
 }
 
@@ -2208,6 +2212,7 @@ void NWidgetBackground::SetPIP(uint8_t pip_pre, uint8_t pip_inter, uint8_t pip_p
 	if (this->child == nullptr) {
 		this->child = new NWidgetVertical();
 	}
+	this->child->parent = this;
 	this->child->SetPIP(pip_pre, pip_inter, pip_post);
 }
 
@@ -2226,6 +2231,7 @@ void NWidgetBackground::SetPIPRatio(uint8_t pip_ratio_pre, uint8_t pip_ratio_int
 	if (this->child == nullptr) {
 		this->child = new NWidgetVertical();
 	}
+	this->child->parent = this;
 	this->child->SetPIPRatio(pip_ratio_pre, pip_ratio_inter, pip_ratio_post);
 }
 

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -144,6 +144,34 @@ public:
 	virtual NWidgetCore *GetWidgetFromPos(int x, int y) = 0;
 	virtual NWidgetBase *GetWidgetOfType(WidgetType tp);
 
+	/**
+	 * Get parent widget of type NWID.
+	 * @tparam NWID Type of the nested widget.
+	 * @returns Parent widget, or nullptr if no widget of the specified type is found.
+	 */
+	template <class NWID>
+	NWID *GetParentWidget()
+	{
+		for (NWidgetBase *nwid_parent = this->parent; nwid_parent != nullptr; nwid_parent = nwid_parent->parent) {
+			if (NWID *nwid = dynamic_cast<NWID *>(nwid_parent); nwid != nullptr) return nwid;
+		}
+		return nullptr;
+	}
+
+	/**
+	 * Get parent widget of type NWID.
+	 * @tparam NWID Type of the nested widget.
+	 * @returns Parent widget, or nullptr if no widget of the specified type is found.
+	 */
+	template <class NWID>
+	const NWID *GetParentWidget() const
+	{
+		for (const NWidgetBase *nwid_parent = this->parent; nwid_parent != nullptr; nwid_parent = nwid_parent->parent) {
+			if (const NWID *nwid = dynamic_cast<const NWID *>(nwid_parent); nwid != nullptr) return nwid;
+		}
+		return nullptr;
+	}
+
 	virtual bool IsHighlighted() const { return false; }
 	virtual TextColour GetHighlightColour() const { return TC_INVALID; }
 	virtual void SetHighlighted([[maybe_unused]] TextColour highlight_colour) {}
@@ -212,6 +240,8 @@ public:
 
 	RectPadding padding;    ///< Padding added to the widget. Managed by parent container widget. (parent container may swap left and right for RTL)
 	RectPadding uz_padding; ///< Unscaled padding, for resize calculation.
+
+	NWidgetBase *parent; ///< Parent widget of this widget, automatically filled in when added to container.
 
 protected:
 	inline void StoreSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height);


### PR DESCRIPTION
## Motivation / Problem

Although widgets are organised as a nested tree, there is no way to traverse back up the tree to find a widget's parent.

This means that code that wants to do so needs to know the WidgetID of its parent and look it that way. This is potentially error-prone as it requires knowledge to ensure the correct WidgetID is used.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, store the parent widget of each widget, and add GetParentWidget<>() to traverse the tree to get the specified parent.

This moves knowledge of parents to the nested tree so that it no longer relies on WidgetIDs.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
