### PR TITLE
Change: Don't allow station/roadstop/object picker text to extend width.

### DIFF
--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -510,6 +510,19 @@ public:
 		if (wid->UpdateVerticalSize(this->name.height)) this->ReInit(0, 0);
 	}
 
+	bool OnTooltip([[maybe_unused]] Point pt, WidgetID widget, TooltipCloseCondition close_cond) override
+	{
+		if (widget != WID_BO_CLASS_LIST) return false;
+
+		auto it = this->vscroll->GetScrolledItemFromWidget(this->object_classes, pt.y, this, WID_BO_CLASS_LIST);
+		if (it == this->object_classes.end()) return false;
+
+		StringID str = ObjectClass::Get(*it)->name;
+		GuiShowTooltips(this, str, close_cond, 0);
+
+		return true;
+	}
+
 	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1336,6 +1336,19 @@ public:
 		}
 	}
 
+	bool OnTooltip([[maybe_unused]] Point pt, WidgetID widget, TooltipCloseCondition close_cond) override
+	{
+		if (widget != WID_BRAS_NEWST_LIST) return false;
+
+		auto it = this->vscroll->GetScrolledItemFromWidget(this->station_classes, pt.y, this, WID_BRAS_NEWST_LIST);
+		if (it == this->station_classes.end()) return false;
+
+		StringID str = StationClass::Get(*it)->name;
+		GuiShowTooltips(this, str, close_cond, 0);
+
+		return true;
+	}
+
 	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1512,6 +1512,19 @@ public:
 		}
 	}
 
+	bool OnTooltip([[maybe_unused]] Point pt, WidgetID widget, TooltipCloseCondition close_cond) override
+	{
+		if (widget != WID_BROS_NEWST_LIST) return false;
+
+		auto it = this->vscrollList->GetScrolledItemFromWidget(this->roadstop_classes, pt.y, this, WID_BROS_NEWST_LIST);
+		if (it == this->roadstop_classes.end()) return false;
+
+		StringID str = RoadStopClass::Get(*it)->name;
+		GuiShowTooltips(this, str, close_cond, 0);
+
+		return true;
+	}
+
 	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {


### PR DESCRIPTION
## Motivation / Problem

Some NewGRF stations/roadstops/objects use very long strings for class or type names, which results in a very wide window.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/8b166af5-c403-4ebb-b89c-b7f7b6152286)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, truncate or wrap the text as appropriate.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/f285b035-35a3-4802-aa6c-25f23f2dcde8)


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Long class names are truncated, but I'm not sure if that's much of an issue. WWT_MATRIX can't have variable height entries.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
