### PR TITLE
Fix: replace the cedilla characters with comma ones for Romanian

### DIFF
--- a/src/lang/romanian.txt
+++ b/src/lang/romanian.txt
@@ -308,7 +308,7 @@ STR_OSK_KEYBOARD_LAYOUT_CAPS                                    :~!@#$%^&*()_+|Q
 STR_MEASURE_LENGTH                                              :{BLACK}Lungime: {NUM}
 STR_MEASURE_AREA                                                :{BLACK}Suprafața: {NUM} x {NUM}
 STR_MEASURE_LENGTH_HEIGHTDIFF                                   :{BLACK}Lungime: {NUM}{}Diferența de înălțime: {HEIGHT}
-STR_MEASURE_AREA_HEIGHTDIFF                                     :{BLACK}Suprafaţa: {NUM} x {NUM}{}Diferenţa de înălţime: {HEIGHT}
+STR_MEASURE_AREA_HEIGHTDIFF                                     :{BLACK}Suprafața: {NUM} x {NUM}{}Diferența de înălțime: {HEIGHT}
 
 
 # These are used in buttons
@@ -316,24 +316,24 @@ STR_SORT_BY_CAPTION_NAME                                        :{BLACK}Nume
 STR_SORT_BY_CAPTION_DATE                                        :{BLACK}Dată
 # These are used in dropdowns
 STR_SORT_BY_NAME                                                :Nume
-STR_SORT_BY_PRODUCTION                                          :Producţie
+STR_SORT_BY_PRODUCTION                                          :Producție
 STR_SORT_BY_TYPE                                                :Tip
 STR_SORT_BY_TRANSPORTED                                         :Transportat
 STR_SORT_BY_NUMBER                                              :Număr
 STR_SORT_BY_PROFIT_LAST_YEAR                                    :Profit anul trecut
 STR_SORT_BY_PROFIT_THIS_YEAR                                    :Profit anul acesta
 STR_SORT_BY_AGE                                                 :Vechime
-STR_SORT_BY_RELIABILITY                                         :Eficienţă
-STR_SORT_BY_TOTAL_CAPACITY_PER_CARGOTYPE                        :Capacitatea totală în funcţie de încărcătură
+STR_SORT_BY_RELIABILITY                                         :Eficiență
+STR_SORT_BY_TOTAL_CAPACITY_PER_CARGOTYPE                        :Capacitatea totală în funcție de încărcătură
 STR_SORT_BY_MAX_SPEED                                           :Viteza maximă
 STR_SORT_BY_MODEL                                               :Model
 STR_SORT_BY_VALUE                                               :Valoare
 STR_SORT_BY_LENGTH                                              :Lungime
-STR_SORT_BY_LIFE_TIME                                           :Durată de viaţă rămasă
+STR_SORT_BY_LIFE_TIME                                           :Durată de viață rămasă
 STR_SORT_BY_TIMETABLE_DELAY                                     :Întârzieri
-STR_SORT_BY_FACILITY                                            :Tipul staţiei
-STR_SORT_BY_WAITING_TOTAL                                       :Încărcătură totală în aşteptare
-STR_SORT_BY_WAITING_AVAILABLE                                   :Încărcătură disponibilă în aşteptare
+STR_SORT_BY_FACILITY                                            :Tipul stației
+STR_SORT_BY_WAITING_TOTAL                                       :Încărcătură totală în așteptare
+STR_SORT_BY_WAITING_AVAILABLE                                   :Încărcătură disponibilă în așteptare
 STR_SORT_BY_RATING_MAX                                          :Cel mai mare rating
 STR_SORT_BY_RATING_MIN                                          :Cel mai mic rating
 STR_SORT_BY_ENGINE_ID                                           :IDMotor (model clasic)
@@ -345,8 +345,8 @@ STR_SORT_BY_RUNNING_COST                                        :Cost exploatare
 STR_SORT_BY_POWER_VS_RUNNING_COST                               :Putere/Cost exploatare
 STR_SORT_BY_CARGO_CAPACITY                                      :Capacitate încărcătură
 STR_SORT_BY_RANGE                                               :Raza de acțiune
-STR_SORT_BY_POPULATION                                          :Populaţia
-STR_SORT_BY_RATING                                              :Cotaţie
+STR_SORT_BY_POPULATION                                          :Populația
+STR_SORT_BY_RATING                                              :Cotație
 STR_SORT_BY_NUM_VEHICLES                                        :Număr de vehicule
 STR_SORT_BY_TOTAL_PROFIT_LAST_YEAR                              :Profit total în anul trecut
 STR_SORT_BY_TOTAL_PROFIT_THIS_YEAR                              :Profit total în acest an
@@ -364,51 +364,51 @@ STR_GOTO_ORDER_VIEW_TOOLTIP                                     :{BLACK}Deschide
 # Tooltips for the main toolbar
 ###length 31
 STR_TOOLBAR_TOOLTIP_PAUSE_GAME                                  :{BLACK}Pauză joc
-STR_TOOLBAR_TOOLTIP_FORWARD                                     :{BLACK}Măreşte viteza de trecere a timpului
+STR_TOOLBAR_TOOLTIP_FORWARD                                     :{BLACK}Mărește viteza de trecere a timpului
 STR_TOOLBAR_TOOLTIP_OPTIONS                                     :{BLACK}Opțiuni și setări
 STR_TOOLBAR_TOOLTIP_SAVE_GAME_ABANDON_GAME                      :{BLACK}Salvare, încărcare sau abandon joc, ieșire program
 STR_TOOLBAR_TOOLTIP_DISPLAY_MAP                                 :{BLACK}Afișează harta, vizor adițional, flux de marfă sau lista de semne
-STR_TOOLBAR_TOOLTIP_DISPLAY_TOWN_DIRECTORY                      :{BLACK}Afişează lista cu oraşele de pe hartă
-STR_TOOLBAR_TOOLTIP_DISPLAY_SUBSIDIES                           :{BLACK}Afişează subvenţiile
-STR_TOOLBAR_TOOLTIP_DISPLAY_LIST_OF_COMPANY_STATIONS            :{BLACK}Afişează lista cu staţiile companiei
-STR_TOOLBAR_TOOLTIP_DISPLAY_COMPANY_FINANCES                    :{BLACK}Afişează informaţiile financiare ale companiei
-STR_TOOLBAR_TOOLTIP_DISPLAY_COMPANY_GENERAL                     :{BLACK}Afişează date generale despre companie
-STR_TOOLBAR_TOOLTIP_DISPLAY_STORY_BOOK                          :{BLACK}Afişează cartea de poveste
-STR_TOOLBAR_TOOLTIP_DISPLAY_GOALS_LIST                          :{BLACK}Afişează lista de scopuri
+STR_TOOLBAR_TOOLTIP_DISPLAY_TOWN_DIRECTORY                      :{BLACK}Afișează lista cu orașele de pe hartă
+STR_TOOLBAR_TOOLTIP_DISPLAY_SUBSIDIES                           :{BLACK}Afișează subvențiile
+STR_TOOLBAR_TOOLTIP_DISPLAY_LIST_OF_COMPANY_STATIONS            :{BLACK}Afișează lista cu stațiile companiei
+STR_TOOLBAR_TOOLTIP_DISPLAY_COMPANY_FINANCES                    :{BLACK}Afișează informațiile financiare ale companiei
+STR_TOOLBAR_TOOLTIP_DISPLAY_COMPANY_GENERAL                     :{BLACK}Afișează date generale despre companie
+STR_TOOLBAR_TOOLTIP_DISPLAY_STORY_BOOK                          :{BLACK}Afișează cartea de poveste
+STR_TOOLBAR_TOOLTIP_DISPLAY_GOALS_LIST                          :{BLACK}Afișează lista de scopuri
 STR_TOOLBAR_TOOLTIP_DISPLAY_GRAPHS                              :{BLACK}Afișează graficele și ratele plăților pentru marfă ale companiei
-STR_TOOLBAR_TOOLTIP_DISPLAY_COMPANY_LEAGUE                      :{BLACK}Afişează clasamentul companiilor
+STR_TOOLBAR_TOOLTIP_DISPLAY_COMPANY_LEAGUE                      :{BLACK}Afișează clasamentul companiilor
 STR_TOOLBAR_TOOLTIP_FUND_CONSTRUCTION_OF_NEW                    :{BLACK}Examinează industriile sau fondează construcția unei noi industrii
 STR_TOOLBAR_TOOLTIP_DISPLAY_LIST_OF_COMPANY_TRAINS              :{BLACK}Afișează lista cu trenurile companiei. Ctrl+clic comută afișarea listei cu grupuri/vehicule
 STR_TOOLBAR_TOOLTIP_DISPLAY_LIST_OF_COMPANY_ROAD_VEHICLES       :{BLACK}Afișează lista cu autovehiculele companiei. Ctrl+clic comută afișarea listei cu grupuri/vehicule
 STR_TOOLBAR_TOOLTIP_DISPLAY_LIST_OF_COMPANY_SHIPS               :{BLACK}Afișează lista cu navele companiei. Ctrl+clic comută afișarea listei cu grupuri/vehicule
 STR_TOOLBAR_TOOLTIP_DISPLAY_LIST_OF_COMPANY_AIRCRAFT            :{BLACK}Afișează lista cu aeronavele companiei. Ctrl+clic comută afișarea listei cu grupuri/vehicule
-STR_TOOLBAR_TOOLTIP_ZOOM_THE_VIEW_IN                            :{BLACK}Măreşte imaginea
-STR_TOOLBAR_TOOLTIP_ZOOM_THE_VIEW_OUT                           :{BLACK}Micşorează imaginea
-STR_TOOLBAR_TOOLTIP_BUILD_RAILROAD_TRACK                        :{BLACK}Construieşte căi ferate
-STR_TOOLBAR_TOOLTIP_BUILD_ROADS                                 :{BLACK}Construieşte drumuri
+STR_TOOLBAR_TOOLTIP_ZOOM_THE_VIEW_IN                            :{BLACK}Mărește imaginea
+STR_TOOLBAR_TOOLTIP_ZOOM_THE_VIEW_OUT                           :{BLACK}Micșorează imaginea
+STR_TOOLBAR_TOOLTIP_BUILD_RAILROAD_TRACK                        :{BLACK}Construiește căi ferate
+STR_TOOLBAR_TOOLTIP_BUILD_ROADS                                 :{BLACK}Construiește drumuri
 STR_TOOLBAR_TOOLTIP_BUILD_TRAMWAYS                              :{BLACK}Construiește linii de tramvai
-STR_TOOLBAR_TOOLTIP_BUILD_SHIP_DOCKS                            :{BLACK}Construieşte porturi
-STR_TOOLBAR_TOOLTIP_BUILD_AIRPORTS                              :{BLACK}Construieşte aeroporturi
-STR_TOOLBAR_TOOLTIP_LANDSCAPING                                 :{BLACK}Afişează instrumentele pentru modelarea terenului, plantarea copacilor, etc.
-STR_TOOLBAR_TOOLTIP_SHOW_SOUND_MUSIC_WINDOW                     :{BLACK}Afişează fereastra pentru configurarea sunetului/muzicii
+STR_TOOLBAR_TOOLTIP_BUILD_SHIP_DOCKS                            :{BLACK}Construiește porturi
+STR_TOOLBAR_TOOLTIP_BUILD_AIRPORTS                              :{BLACK}Construiește aeroporturi
+STR_TOOLBAR_TOOLTIP_LANDSCAPING                                 :{BLACK}Afișează instrumentele pentru modelarea terenului, plantarea copacilor, etc.
+STR_TOOLBAR_TOOLTIP_SHOW_SOUND_MUSIC_WINDOW                     :{BLACK}Afișează fereastra pentru configurarea sunetului/muzicii
 STR_TOOLBAR_TOOLTIP_SHOW_LAST_MESSAGE_NEWS                      :{BLACK}Afișează ultimul mesaj (ultima știre), istoricul de mesaje sau șterge toate mesajele
 STR_TOOLBAR_TOOLTIP_LAND_BLOCK_INFORMATION                      :{BLACK}Informații despre teren, captură de ecran, despre OpenTTD și unelte de dezvoltare
 STR_TOOLBAR_TOOLTIP_SWITCH_TOOLBAR                              :{BLACK}Comută bara de unelte
 
 # Extra tooltips for the scenario editor toolbar
-STR_SCENEDIT_TOOLBAR_TOOLTIP_SAVE_SCENARIO_LOAD_SCENARIO        :{BLACK}Salvează/încarcă scenariu, abandonează editorul, ieşire
+STR_SCENEDIT_TOOLBAR_TOOLTIP_SAVE_SCENARIO_LOAD_SCENARIO        :{BLACK}Salvează/încarcă scenariu, abandonează editorul, ieșire
 STR_SCENEDIT_TOOLBAR_OPENTTD                                    :{YELLOW}OpenTTD
 STR_SCENEDIT_TOOLBAR_SCENARIO_EDITOR                            :{YELLOW}Editor de scenarii
 STR_SCENEDIT_TOOLBAR_TOOLTIP_MOVE_THE_STARTING_DATE_BACKWARD    :{BLACK}Schimbă data de start cu un an înapoi
 STR_SCENEDIT_TOOLBAR_TOOLTIP_MOVE_THE_STARTING_DATE_FORWARD     :{BLACK}Schimbă data de start cu un an înainte
 STR_SCENEDIT_TOOLBAR_TOOLTIP_SET_DATE                           :{BLACK}Click pentru a introduce anul de pornire
-STR_SCENEDIT_TOOLBAR_TOOLTIP_DISPLAY_MAP_TOWN_DIRECTORY         :{BLACK}Afişează harta, lista cu oraşe
+STR_SCENEDIT_TOOLBAR_TOOLTIP_DISPLAY_MAP_TOWN_DIRECTORY         :{BLACK}Afișează harta, lista cu orașe
 STR_SCENEDIT_TOOLBAR_LANDSCAPE_GENERATION                       :{BLACK}Generare peisaj
-STR_SCENEDIT_TOOLBAR_TOWN_GENERATION                            :{BLACK}Generare oraş
+STR_SCENEDIT_TOOLBAR_TOWN_GENERATION                            :{BLACK}Generare oraș
 STR_SCENEDIT_TOOLBAR_INDUSTRY_GENERATION                        :{BLACK}Generare industrii
-STR_SCENEDIT_TOOLBAR_ROAD_CONSTRUCTION                          :{BLACK}Construcţii rutiere
+STR_SCENEDIT_TOOLBAR_ROAD_CONSTRUCTION                          :{BLACK}Construcții rutiere
 STR_SCENEDIT_TOOLBAR_TRAM_CONSTRUCTION                          :{BLACK}Construcție tramvai
-STR_SCENEDIT_TOOLBAR_PLANT_TREES                                :{BLACK}Plantează arbori. Ctrl selectează zona în diagonală. Shift comută între plantare/afişare cost estimat
+STR_SCENEDIT_TOOLBAR_PLANT_TREES                                :{BLACK}Plantează arbori. Ctrl selectează zona în diagonală. Shift comută între plantare/afișare cost estimat
 STR_SCENEDIT_TOOLBAR_PLACE_SIGN                                 :{BLACK}Plasează semn
 STR_SCENEDIT_TOOLBAR_PLACE_OBJECT                               :{BLACK}Plasați obiectul. Ctrl selectează zona în diagonală. Shift comută construirea/afișarea estimării costurilor
 
@@ -416,35 +416,35 @@ STR_SCENEDIT_TOOLBAR_PLACE_OBJECT                               :{BLACK}Plasați
 ###length 7
 STR_SCENEDIT_FILE_MENU_SAVE_SCENARIO                            :Salvează scenariul
 STR_SCENEDIT_FILE_MENU_LOAD_SCENARIO                            :Încarcă scenariu
-STR_SCENEDIT_FILE_MENU_SAVE_HEIGHTMAP                           :Salvează harta înălţimilor
-STR_SCENEDIT_FILE_MENU_LOAD_HEIGHTMAP                           :Încarcă harta de înălţimi
+STR_SCENEDIT_FILE_MENU_SAVE_HEIGHTMAP                           :Salvează harta înălțimilor
+STR_SCENEDIT_FILE_MENU_LOAD_HEIGHTMAP                           :Încarcă harta de înălțimi
 STR_SCENEDIT_FILE_MENU_QUIT_EDITOR                              :Ieșire din editorul de scenarii
 STR_SCENEDIT_FILE_MENU_SEPARATOR                                :
-STR_SCENEDIT_FILE_MENU_QUIT                                     :Ieşire din joc
+STR_SCENEDIT_FILE_MENU_QUIT                                     :Ieșire din joc
 
 # Settings menu
 ###length 15
-STR_SETTINGS_MENU_GAME_OPTIONS                                  :Opţiunile jocului
+STR_SETTINGS_MENU_GAME_OPTIONS                                  :Opțiunile jocului
 STR_SETTINGS_MENU_CONFIG_SETTINGS_TREE                          :Setări
 STR_SETTINGS_MENU_AI_SETTINGS                                   :Setările AI
 STR_SETTINGS_MENU_GAMESCRIPT_SETTINGS                           :Setări pentru scriptul jocului
 STR_SETTINGS_MENU_NEWGRF_SETTINGS                               :Setări NewGRF
-STR_SETTINGS_MENU_TRANSPARENCY_OPTIONS                          :Opţiuni transparenţă
-STR_SETTINGS_MENU_TOWN_NAMES_DISPLAYED                          :Afişează numele oraşelor
-STR_SETTINGS_MENU_STATION_NAMES_DISPLAYED                       :Afişează numele staţiilor
-STR_SETTINGS_MENU_WAYPOINTS_DISPLAYED                           :Afişează numele punctelor de tranzit
-STR_SETTINGS_MENU_SIGNS_DISPLAYED                               :Afişează semnele de pe hartă
-STR_SETTINGS_MENU_SHOW_COMPETITOR_SIGNS                         :Afişează numele și semnele competitorilor
-STR_SETTINGS_MENU_FULL_ANIMATION                                :Animaţie completă
+STR_SETTINGS_MENU_TRANSPARENCY_OPTIONS                          :Opțiuni transparență
+STR_SETTINGS_MENU_TOWN_NAMES_DISPLAYED                          :Afișează numele orașelor
+STR_SETTINGS_MENU_STATION_NAMES_DISPLAYED                       :Afișează numele stațiilor
+STR_SETTINGS_MENU_WAYPOINTS_DISPLAYED                           :Afișează numele punctelor de tranzit
+STR_SETTINGS_MENU_SIGNS_DISPLAYED                               :Afișează semnele de pe hartă
+STR_SETTINGS_MENU_SHOW_COMPETITOR_SIGNS                         :Afișează numele și semnele competitorilor
+STR_SETTINGS_MENU_FULL_ANIMATION                                :Animație completă
 STR_SETTINGS_MENU_FULL_DETAIL                                   :Detalii grafice complete
 STR_SETTINGS_MENU_TRANSPARENT_BUILDINGS                         :Peisaj transparent
-STR_SETTINGS_MENU_TRANSPARENT_SIGNS                             :Nume staţii/semne transparente
+STR_SETTINGS_MENU_TRANSPARENT_SIGNS                             :Nume stații/semne transparente
 
 # File menu
 STR_FILE_MENU_SAVE_GAME                                         :Salvează jocul
 STR_FILE_MENU_LOAD_GAME                                         :Încarcă joc
 STR_FILE_MENU_QUIT_GAME                                         :Ieșire în meniul principal
-STR_FILE_MENU_EXIT                                              :Ieşire din joc
+STR_FILE_MENU_EXIT                                              :Ieșire din joc
 
 # Map menu
 STR_MAP_MENU_MAP_OF_WORLD                                       :Harta lumii
@@ -453,23 +453,23 @@ STR_MAP_MENU_LINGRAPH_LEGEND                                    :Legenda flux î
 STR_MAP_MENU_SIGN_LIST                                          :Lista de semne
 
 # Town menu
-STR_TOWN_MENU_TOWN_DIRECTORY                                    :Lista oraşelor
-STR_TOWN_MENU_FOUND_TOWN                                        :Fondează oraş
+STR_TOWN_MENU_TOWN_DIRECTORY                                    :Lista orașelor
+STR_TOWN_MENU_FOUND_TOWN                                        :Fondează oraș
 
 # Subsidies menu
-STR_SUBSIDIES_MENU_SUBSIDIES                                    :Subvenţii
+STR_SUBSIDIES_MENU_SUBSIDIES                                    :Subvenții
 
 # Graph menu
-STR_GRAPH_MENU_OPERATING_PROFIT_GRAPH                           :Profitul operaţional
+STR_GRAPH_MENU_OPERATING_PROFIT_GRAPH                           :Profitul operațional
 STR_GRAPH_MENU_INCOME_GRAPH                                     :Venituri
 STR_GRAPH_MENU_DELIVERED_CARGO_GRAPH                            :Număr încărcături livrate
-STR_GRAPH_MENU_PERFORMANCE_HISTORY_GRAPH                        :Evoluţia performanţei
+STR_GRAPH_MENU_PERFORMANCE_HISTORY_GRAPH                        :Evoluția performanței
 STR_GRAPH_MENU_COMPANY_VALUE_GRAPH                              :Valoarea companiei
 STR_GRAPH_MENU_CARGO_PAYMENT_RATES                              :Valorile plăților pe mărfuri
 
 # Company league menu
 STR_GRAPH_MENU_COMPANY_LEAGUE_TABLE                             :Clasamentul companiilor
-STR_GRAPH_MENU_DETAILED_PERFORMANCE_RATING                      :Rating de performanţă detaliat
+STR_GRAPH_MENU_DETAILED_PERFORMANCE_RATING                      :Rating de performanță detaliat
 STR_GRAPH_MENU_HIGHSCORE                                        :Tabela cu scoruri maxime
 
 # Industry menu
@@ -478,17 +478,17 @@ STR_INDUSTRY_MENU_INDUSTRY_CHAIN                                :Lanțuri indust
 STR_INDUSTRY_MENU_FUND_NEW_INDUSTRY                             :Obiectiv industrial nou
 
 # URailway construction menu
-STR_RAIL_MENU_RAILROAD_CONSTRUCTION                             :Construcţie cale ferată
-STR_RAIL_MENU_ELRAIL_CONSTRUCTION                               :Construcţie cale ferată electrificată
-STR_RAIL_MENU_MONORAIL_CONSTRUCTION                             :Construcţie monoşină
-STR_RAIL_MENU_MAGLEV_CONSTRUCTION                               :Construcţie pernă magnetică
+STR_RAIL_MENU_RAILROAD_CONSTRUCTION                             :Construcție cale ferată
+STR_RAIL_MENU_ELRAIL_CONSTRUCTION                               :Construcție cale ferată electrificată
+STR_RAIL_MENU_MONORAIL_CONSTRUCTION                             :Construcție monoșină
+STR_RAIL_MENU_MAGLEV_CONSTRUCTION                               :Construcție pernă magnetică
 
 # Road construction menu
-STR_ROAD_MENU_ROAD_CONSTRUCTION                                 :Construcţii rutiere
+STR_ROAD_MENU_ROAD_CONSTRUCTION                                 :Construcții rutiere
 STR_ROAD_MENU_TRAM_CONSTRUCTION                                 :Construcție tramvai
 
 # Waterways construction menu
-STR_WATERWAYS_MENU_WATERWAYS_CONSTRUCTION                       :Construcţie rute acvatice
+STR_WATERWAYS_MENU_WATERWAYS_CONSTRUCTION                       :Construcție rute acvatice
 
 # Aairport construction menu
 STR_AIRCRAFT_MENU_AIRPORT_CONSTRUCTION                          :Construire aeroport
@@ -507,15 +507,15 @@ STR_NEWS_MENU_MESSAGE_HISTORY_MENU                              :Lista ultimelor
 STR_NEWS_MENU_DELETE_ALL_MESSAGES                               :Șterge toate mesajele
 
 # About menu
-STR_ABOUT_MENU_LAND_BLOCK_INFO                                  :Informaţii despre teren
+STR_ABOUT_MENU_LAND_BLOCK_INFO                                  :Informații despre teren
 STR_ABOUT_MENU_HELP                                             :Ajutor și manuale
 STR_ABOUT_MENU_TOGGLE_CONSOLE                                   :Consolă pornit/oprit
-STR_ABOUT_MENU_AI_DEBUG                                         :Depanare Inteligenţă Artificială / Script Joc
+STR_ABOUT_MENU_AI_DEBUG                                         :Depanare Inteligență Artificială / Script Joc
 STR_ABOUT_MENU_SCREENSHOT                                       :Capturează ecranul
 STR_ABOUT_MENU_SHOW_FRAMERATE                                   :Arată FPS
 STR_ABOUT_MENU_ABOUT_OPENTTD                                    :Despre 'OpenTTD'
 STR_ABOUT_MENU_SPRITE_ALIGNER                                   :Aliniere imagini
-STR_ABOUT_MENU_TOGGLE_BOUNDING_BOXES                            :Afişează/ascunde casetele de încadrare
+STR_ABOUT_MENU_TOGGLE_BOUNDING_BOXES                            :Afișează/ascunde casetele de încadrare
 STR_ABOUT_MENU_TOGGLE_DIRTY_BLOCKS                              :Comutator pentru colorarea secțiunilor murdare
 STR_ABOUT_MENU_TOGGLE_WIDGET_OUTLINES                           :Comutați contururile widgetului
 
@@ -600,7 +600,7 @@ STR_MONTH_DEC                                                   :decembrie
 
 # Graph window
 STR_GRAPH_KEY_BUTTON                                            :{BLACK}Legendă
-STR_GRAPH_KEY_TOOLTIP                                           :{BLACK}Afişează legenda graficelor
+STR_GRAPH_KEY_TOOLTIP                                           :{BLACK}Afișează legenda graficelor
 STR_GRAPH_X_LABEL_MONTH                                         :{TINY_FONT}{STRING}
 STR_GRAPH_X_LABEL_MONTH_YEAR                                    :{TINY_FONT}{STRING}{}{NUM}
 STR_GRAPH_Y_LABEL                                               :{TINY_FONT}{STRING}
@@ -608,8 +608,8 @@ STR_GRAPH_Y_LABEL_NUMBER                                        :{TINY_FONT}{COM
 
 STR_GRAPH_OPERATING_PROFIT_CAPTION                              :{WHITE}Graficul profitului din operare
 STR_GRAPH_INCOME_CAPTION                                        :{WHITE}Graficul veniturilor
-STR_GRAPH_CARGO_DELIVERED_CAPTION                               :{WHITE}Unităţi de marfă livrate
-STR_GRAPH_COMPANY_PERFORMANCE_RATINGS_CAPTION                   :{WHITE}Evaluarea performanţelor companiilor (maxim=1000)
+STR_GRAPH_CARGO_DELIVERED_CAPTION                               :{WHITE}Unități de marfă livrate
+STR_GRAPH_COMPANY_PERFORMANCE_RATINGS_CAPTION                   :{WHITE}Evaluarea performanțelor companiilor (maxim=1000)
 STR_GRAPH_COMPANY_VALUES_CAPTION                                :{WHITE}Graficul valorii companiilor
 
 STR_GRAPH_CARGO_PAYMENT_RATES_CAPTION                           :{WHITE}Prețurile transportului de mărfuri
@@ -622,11 +622,11 @@ STR_GRAPH_CARGO_TOOLTIP_DISABLE_ALL                             :{BLACK}Nu afiș
 STR_GRAPH_CARGO_PAYMENT_TOGGLE_CARGO                            :{BLACK}Comută ascunderea/afișarea graficului de marfă
 STR_GRAPH_CARGO_PAYMENT_CARGO                                   :{TINY_FONT}{BLACK}{STRING}
 
-STR_GRAPH_PERFORMANCE_DETAIL_TOOLTIP                            :{BLACK}Afişează detaliile ratingului performanţei
+STR_GRAPH_PERFORMANCE_DETAIL_TOOLTIP                            :{BLACK}Afișează detaliile ratingului performanței
 
 # Graph key window
 STR_GRAPH_KEY_CAPTION                                           :{WHITE}Legenda graficelor
-STR_GRAPH_KEY_COMPANY_SELECTION_TOOLTIP                         :{BLACK}Click aici pentru a comuta afişarea informaţiilor despre companie
+STR_GRAPH_KEY_COMPANY_SELECTION_TOOLTIP                         :{BLACK}Click aici pentru a comuta afișarea informațiilor despre companie
 
 # Company league window
 STR_COMPANY_LEAGUE_TABLE_CAPTION                                :{WHITE}Clasamentul companiilor
@@ -638,11 +638,11 @@ STR_COMPANY_LEAGUE_PERFORMANCE_TITLE_ROUTE_SUPERVISOR           :Supervizor
 STR_COMPANY_LEAGUE_PERFORMANCE_TITLE_DIRECTOR                   :Director
 STR_COMPANY_LEAGUE_PERFORMANCE_TITLE_CHIEF_EXECUTIVE            :Director executiv
 STR_COMPANY_LEAGUE_PERFORMANCE_TITLE_CHAIRMAN                   :Director general
-STR_COMPANY_LEAGUE_PERFORMANCE_TITLE_PRESIDENT                  :Preşedinte
+STR_COMPANY_LEAGUE_PERFORMANCE_TITLE_PRESIDENT                  :Președinte
 STR_COMPANY_LEAGUE_PERFORMANCE_TITLE_TYCOON                     :Magnat
 
 # Performance detail window
-STR_PERFORMANCE_DETAIL                                          :{WHITE}Rating de performanţă detaliat
+STR_PERFORMANCE_DETAIL                                          :{WHITE}Rating de performanță detaliat
 STR_PERFORMANCE_DETAIL_KEY                                      :{BLACK}Detalii
 STR_PERFORMANCE_DETAIL_AMOUNT_CURRENCY                          :{BLACK}({CURRENCY_SHORT}/{CURRENCY_SHORT})
 STR_PERFORMANCE_DETAIL_AMOUNT_INT                               :{BLACK}({COMMA}/{COMMA})
@@ -651,7 +651,7 @@ STR_PERFORMANCE_DETAIL_SELECT_COMPANY_TOOLTIP                   :{BLACK}Vizualiz
 
 ###length 10
 STR_PERFORMANCE_DETAIL_VEHICLES                                 :{BLACK}Vehicule:
-STR_PERFORMANCE_DETAIL_STATIONS                                 :{BLACK}Staţii:
+STR_PERFORMANCE_DETAIL_STATIONS                                 :{BLACK}Stații:
 STR_PERFORMANCE_DETAIL_MIN_PROFIT                               :{BLACK}Profit minim:
 STR_PERFORMANCE_DETAIL_MIN_INCOME                               :{BLACK}Venit minim:
 STR_PERFORMANCE_DETAIL_MAX_INCOME                               :{BLACK}Venit maxim:
@@ -662,14 +662,14 @@ STR_PERFORMANCE_DETAIL_LOAN                                     :{BLACK}Credite:
 STR_PERFORMANCE_DETAIL_TOTAL                                    :{BLACK}Total:
 
 ###length 10
-STR_PERFORMANCE_DETAIL_VEHICLES_TOOLTIP                         :{BLACK}Numărul de vehicule profitabile pe anul precedent. Include autovehicule, trenuri, nave şi aeronave
-STR_PERFORMANCE_DETAIL_STATIONS_TOOLTIP                         :{BLACK}Numărul staţiilor. Se numără fiecare componentă în cazul unor staţii compuse simultan din gări, aeroporturi, porturi, staţii de autobuz, etc.
+STR_PERFORMANCE_DETAIL_VEHICLES_TOOLTIP                         :{BLACK}Numărul de vehicule profitabile pe anul precedent. Include autovehicule, trenuri, nave și aeronave
+STR_PERFORMANCE_DETAIL_STATIONS_TOOLTIP                         :{BLACK}Numărul stațiilor. Se numără fiecare componentă în cazul unor stații compuse simultan din gări, aeroporturi, porturi, stații de autobuz, etc.
 STR_PERFORMANCE_DETAIL_MIN_PROFIT_TOOLTIP                       :{BLACK}Profitul vehiculului cu cele mai mici încasări (doar vehiculele mai vechi de 2 ani sunt listate)
-STR_PERFORMANCE_DETAIL_MIN_INCOME_TOOLTIP                       :{BLACK}Suma de bani obţinută în trimestrul cu cel mai mic profit din ultimele 12 trimestre.
-STR_PERFORMANCE_DETAIL_MAX_INCOME_TOOLTIP                       :{BLACK}Suma de bani obţinută în trimestrul cu cel mai mare profit din ultimele 12 trimestre.
+STR_PERFORMANCE_DETAIL_MIN_INCOME_TOOLTIP                       :{BLACK}Suma de bani obținută în trimestrul cu cel mai mic profit din ultimele 12 trimestre.
+STR_PERFORMANCE_DETAIL_MAX_INCOME_TOOLTIP                       :{BLACK}Suma de bani obținută în trimestrul cu cel mai mare profit din ultimele 12 trimestre.
 STR_PERFORMANCE_DETAIL_DELIVERED_TOOLTIP                        :{BLACK}Numărul de încărcături transportate în ultimele 12 luni.
 STR_PERFORMANCE_DETAIL_CARGO_TOOLTIP                            :{BLACK}Tipuri de mărfuri transportate în ultimele 3 luni.
-STR_PERFORMANCE_DETAIL_MONEY_TOOLTIP                            :{BLACK}Balanţa curentă
+STR_PERFORMANCE_DETAIL_MONEY_TOOLTIP                            :{BLACK}Balanța curentă
 STR_PERFORMANCE_DETAIL_LOAN_TOOLTIP                             :{BLACK}Ponderea creditelor
 STR_PERFORMANCE_DETAIL_TOTAL_TOOLTIP                            :{BLACK}Punctajul total din numărul maxim posibil
 
@@ -694,9 +694,9 @@ STR_MUSIC_SHUFFLE                                               :{TINY_FONT}{BLA
 STR_MUSIC_PROGRAM                                               :{TINY_FONT}{BLACK}Program
 STR_MUSIC_TOOLTIP_SKIP_TO_PREVIOUS_TRACK                        :{BLACK}Sari la piesa precedentă din selecție
 STR_MUSIC_TOOLTIP_SKIP_TO_NEXT_TRACK_IN_SELECTION               :{BLACK}Sari la următoarea piesă din selecție
-STR_MUSIC_TOOLTIP_STOP_PLAYING_MUSIC                            :{BLACK}Opreşte muzica
-STR_MUSIC_TOOLTIP_START_PLAYING_MUSIC                           :{BLACK}Porneşte muzica
-STR_MUSIC_TOOLTIP_DRAG_SLIDERS_TO_SET_MUSIC                     :{BLACK}Foloseşte aceste indicatoare pentru a regla volumul muzicii şi al efectelor sonore
+STR_MUSIC_TOOLTIP_STOP_PLAYING_MUSIC                            :{BLACK}Oprește muzica
+STR_MUSIC_TOOLTIP_START_PLAYING_MUSIC                           :{BLACK}Pornește muzica
+STR_MUSIC_TOOLTIP_DRAG_SLIDERS_TO_SET_MUSIC                     :{BLACK}Folosește aceste indicatoare pentru a regla volumul muzicii și al efectelor sonore
 STR_MUSIC_TOOLTIP_SELECT_ALL_TRACKS_PROGRAM                     :{BLACK}Selectează programul 'toate melodiile'
 STR_MUSIC_TOOLTIP_SELECT_OLD_STYLE_MUSIC                        :{BLACK}Selectează programul 'oldies'
 STR_MUSIC_TOOLTIP_SELECT_NEW_STYLE_MUSIC                        :{BLACK}Selectează programul 'modern'
@@ -711,9 +711,9 @@ STR_PLAYLIST_MUSIC_SELECTION_SETNAME                            :{WHITE}Program 
 STR_PLAYLIST_TRACK_NAME                                         :{TINY_FONT}{LTBLUE}{ZEROFILL_NUM} "{STRING}"
 STR_PLAYLIST_TRACK_INDEX                                        :{TINY_FONT}{BLACK}Lista melodiilor
 STR_PLAYLIST_PROGRAM                                            :{TINY_FONT}{BLACK}Program - '{STRING}'
-STR_PLAYLIST_CLEAR                                              :{TINY_FONT}{BLACK}Şterge
+STR_PLAYLIST_CLEAR                                              :{TINY_FONT}{BLACK}șterge
 STR_PLAYLIST_CHANGE_SET                                         :{BLACK}Schimbă setul
-STR_PLAYLIST_TOOLTIP_CLEAR_CURRENT_PROGRAM_CUSTOM1              :{BLACK}Şterge programul curent (doar pentru cele personale)
+STR_PLAYLIST_TOOLTIP_CLEAR_CURRENT_PROGRAM_CUSTOM1              :{BLACK}șterge programul curent (doar pentru cele personale)
 STR_PLAYLIST_TOOLTIP_CHANGE_SET                                 :{BLACK}Schimbă selecția muzicală pe un alt set instalat
 STR_PLAYLIST_TOOLTIP_CLICK_TO_ADD_TRACK                         :{BLACK}Click pe o melodie pentru a o adăuga în programul personal curent
 STR_PLAYLIST_TOOLTIP_CLICK_TO_REMOVE_TRACK                      :{BLACK}Apasă pe melodie pentru a o elimina din programul actual (doar Custom1 sau Custom2)
@@ -723,7 +723,7 @@ STR_HIGHSCORE_TOP_COMPANIES                                     :{BIG_FONT}{BLAC
 STR_HIGHSCORE_POSITION                                          :{BIG_FONT}{BLACK}{COMMA}.
 STR_HIGHSCORE_PERFORMANCE_TITLE_BUSINESSMAN                     :Om de afaceri
 STR_HIGHSCORE_PERFORMANCE_TITLE_ENTREPRENEUR                    :Întreprinzător
-STR_HIGHSCORE_PERFORMANCE_TITLE_INDUSTRIALIST                   :Industriaş
+STR_HIGHSCORE_PERFORMANCE_TITLE_INDUSTRIALIST                   :Industriaș
 STR_HIGHSCORE_PERFORMANCE_TITLE_CAPITALIST                      :Capitalist
 STR_HIGHSCORE_PERFORMANCE_TITLE_MAGNATE                         :Magnat
 STR_HIGHSCORE_PERFORMANCE_TITLE_MOGUL                           :Mogul
@@ -731,7 +731,7 @@ STR_HIGHSCORE_PERFORMANCE_TITLE_TYCOON_OF_THE_CENTURY           :Magnatul Secolu
 STR_HIGHSCORE_NAME                                              :{PRESIDENT_NAME}, {COMPANY}
 STR_HIGHSCORE_STATS                                             :{BIG_FONT}'{STRING}'   ({COMMA})
 STR_HIGHSCORE_COMPANY_ACHIEVES_STATUS                           :{BIG_FONT}{BLACK}{COMPANY} a dobândit titlul de '{STRING}'!
-STR_HIGHSCORE_PRESIDENT_OF_COMPANY_ACHIEVES_STATUS              :{BIG_FONT}{WHITE}{PRESIDENT_NAME} al {COMPANY} dobândeşte titlul de '{STRING}'!
+STR_HIGHSCORE_PRESIDENT_OF_COMPANY_ACHIEVES_STATUS              :{BIG_FONT}{WHITE}{PRESIDENT_NAME} al {COMPANY} dobândește titlul de '{STRING}'!
 
 # Smallmap window
 STR_SMALLMAP_CAPTION                                            :{WHITE}Harta - {STRING}
@@ -742,7 +742,7 @@ STR_SMALLMAP_TYPE_VEHICLES                                      :Vehicule
 STR_SMALLMAP_TYPE_INDUSTRIES                                    :Industrii
 STR_SMALLMAP_TYPE_ROUTEMAP                                      :Fluxul încărcăturilor
 STR_SMALLMAP_TYPE_ROUTES                                        :Rute
-STR_SMALLMAP_TYPE_VEGETATION                                    :Vegetaţie
+STR_SMALLMAP_TYPE_VEGETATION                                    :Vegetație
 STR_SMALLMAP_TYPE_OWNERS                                        :Proprietari
 
 STR_SMALLMAP_TOOLTIP_SHOW_LAND_CONTOURS_ON_MAP                  :{BLACK}Arată relieful pe hartă
@@ -750,7 +750,7 @@ STR_SMALLMAP_TOOLTIP_SHOW_VEHICLES_ON_MAP                       :{BLACK}Arată v
 STR_SMALLMAP_TOOLTIP_SHOW_INDUSTRIES_ON_MAP                     :{BLACK}Arată industriile pe hartă
 STR_SMALLMAP_TOOLTIP_SHOW_LINK_STATS_ON_MAP                     :{BLACK}Arată fluxul încărcăturilor pe hartă
 STR_SMALLMAP_TOOLTIP_SHOW_TRANSPORT_ROUTES_ON                   :{BLACK}Arată rutele de transport pe hartă
-STR_SMALLMAP_TOOLTIP_SHOW_VEGETATION_ON_MAP                     :{BLACK}Arată vegetaţia pe hartă
+STR_SMALLMAP_TOOLTIP_SHOW_VEGETATION_ON_MAP                     :{BLACK}Arată vegetația pe hartă
 STR_SMALLMAP_TOOLTIP_SHOW_LAND_OWNERS_ON_MAP                    :{BLACK}Arată proprietarii de teren pe hartă
 STR_SMALLMAP_TOOLTIP_INDUSTRY_SELECTION                         :{BLACK}Click pe tipul de industrie pentru a comuta afișarea acestuia. Ctrl+clic dezactivează toate tipurile cu excepția celui selectat. Ctrl+clic din nou pentru a reactiva toate tipurile de industrii
 STR_SMALLMAP_TOOLTIP_COMPANY_SELECTION                          :{BLACK}Click pe o companie pentru a comuta afișarea proprietăților acesteia. Ctrl-Click dezactivează toate companiile cu excepția celei selectate. Ctrl-Click din nou pentru a activa toate companiile
@@ -758,7 +758,7 @@ STR_SMALLMAP_TOOLTIP_CARGO_SELECTION                            :{BLACK}Dă clic
 
 STR_SMALLMAP_LEGENDA_ROADS                                      :{TINY_FONT}{BLACK}Drumuri
 STR_SMALLMAP_LEGENDA_RAILROADS                                  :{TINY_FONT}{BLACK}Căi ferate
-STR_SMALLMAP_LEGENDA_STATIONS_AIRPORTS_DOCKS                    :{TINY_FONT}{BLACK}Staţii/Aeroporturi/Porturi
+STR_SMALLMAP_LEGENDA_STATIONS_AIRPORTS_DOCKS                    :{TINY_FONT}{BLACK}Stații/Aeroporturi/Porturi
 STR_SMALLMAP_LEGENDA_BUILDINGS_INDUSTRIES                       :{TINY_FONT}{BLACK}Clădiri/Industrii
 STR_SMALLMAP_LEGENDA_VEHICLES                                   :{TINY_FONT}{BLACK}Vehicule
 STR_SMALLMAP_LEGENDA_TRAINS                                     :{TINY_FONT}{BLACK}Trenuri
@@ -769,11 +769,11 @@ STR_SMALLMAP_LEGENDA_TRANSPORT_ROUTES                           :{TINY_FONT}{BLA
 STR_SMALLMAP_LEGENDA_FOREST                                     :{TINY_FONT}{BLACK}Pădure
 STR_SMALLMAP_LEGENDA_RAILROAD_STATION                           :{TINY_FONT}{BLACK}Gară
 STR_SMALLMAP_LEGENDA_TRUCK_LOADING_BAY                          :{TINY_FONT}{BLACK}Loc încărcare camioane
-STR_SMALLMAP_LEGENDA_BUS_STATION                                :{TINY_FONT}{BLACK}Staţie de autobuz
+STR_SMALLMAP_LEGENDA_BUS_STATION                                :{TINY_FONT}{BLACK}Stație de autobuz
 STR_SMALLMAP_LEGENDA_AIRPORT_HELIPORT                           :{TINY_FONT}{BLACK}Aeroport/Heliport
 STR_SMALLMAP_LEGENDA_DOCK                                       :{TINY_FONT}{BLACK}Port
 STR_SMALLMAP_LEGENDA_ROUGH_LAND                                 :{TINY_FONT}{BLACK}Teren pietros
-STR_SMALLMAP_LEGENDA_GRASS_LAND                                 :{TINY_FONT}{BLACK}Pajişte
+STR_SMALLMAP_LEGENDA_GRASS_LAND                                 :{TINY_FONT}{BLACK}Pajiște
 STR_SMALLMAP_LEGENDA_BARE_LAND                                  :{TINY_FONT}{BLACK}Teren viran
 STR_SMALLMAP_LEGENDA_RAINFOREST                                 :{TINY_FONT}{BLACK}Pădure tropicală
 STR_SMALLMAP_LEGENDA_FIELDS                                     :{TINY_FONT}{BLACK}Teren agricol
@@ -781,23 +781,23 @@ STR_SMALLMAP_LEGENDA_TREES                                      :{TINY_FONT}{BLA
 STR_SMALLMAP_LEGENDA_ROCKS                                      :{TINY_FONT}{BLACK}Pietre
 STR_SMALLMAP_LEGENDA_WATER                                      :{TINY_FONT}{BLACK}Apă
 STR_SMALLMAP_LEGENDA_NO_OWNER                                   :{TINY_FONT}{BLACK}Fără proprietar
-STR_SMALLMAP_LEGENDA_TOWNS                                      :{TINY_FONT}{BLACK}Oraşe
+STR_SMALLMAP_LEGENDA_TOWNS                                      :{TINY_FONT}{BLACK}Orașe
 STR_SMALLMAP_LEGENDA_INDUSTRIES                                 :{TINY_FONT}{BLACK}Industrii
-STR_SMALLMAP_LEGENDA_DESERT                                     :{TINY_FONT}{BLACK}Deşert
+STR_SMALLMAP_LEGENDA_DESERT                                     :{TINY_FONT}{BLACK}Deșert
 STR_SMALLMAP_LEGENDA_SNOW                                       :{TINY_FONT}{BLACK}Zăpadă
 
-STR_SMALLMAP_TOOLTIP_TOGGLE_TOWN_NAMES_ON_OFF                   :{BLACK}Comutator pentru afișarea numele oraşelor pe hartă
-STR_SMALLMAP_CENTER                                             :{BLACK}Centrează harta mică la poziţia actuală
+STR_SMALLMAP_TOOLTIP_TOGGLE_TOWN_NAMES_ON_OFF                   :{BLACK}Comutator pentru afișarea numele orașelor pe hartă
+STR_SMALLMAP_CENTER                                             :{BLACK}Centrează harta mică la poziția actuală
 STR_SMALLMAP_INDUSTRY                                           :{TINY_FONT}{STRING} ({NUM})
 STR_SMALLMAP_LINKSTATS                                          :{TINY_FONT}{STRING}
 STR_SMALLMAP_COMPANY                                            :{TINY_FONT}{COMPANY}
 STR_SMALLMAP_TOWN                                               :{TINY_FONT}{WHITE}{TOWN}
 STR_SMALLMAP_DISABLE_ALL                                        :{BLACK}Dezactivează toate
 STR_SMALLMAP_ENABLE_ALL                                         :{BLACK}Activează toate
-STR_SMALLMAP_SHOW_HEIGHT                                        :{BLACK}Afişează înălţimea
-STR_SMALLMAP_TOOLTIP_DISABLE_ALL_INDUSTRIES                     :{BLACK}Nu afişa nicio industrie pe hartă
-STR_SMALLMAP_TOOLTIP_ENABLE_ALL_INDUSTRIES                      :{BLACK}Afişează toate industriile pe hartă
-STR_SMALLMAP_TOOLTIP_SHOW_HEIGHT                                :{BLACK}Comută afişarea hărţii de înălţimi
+STR_SMALLMAP_SHOW_HEIGHT                                        :{BLACK}Afișează înălțimea
+STR_SMALLMAP_TOOLTIP_DISABLE_ALL_INDUSTRIES                     :{BLACK}Nu afișa nicio industrie pe hartă
+STR_SMALLMAP_TOOLTIP_ENABLE_ALL_INDUSTRIES                      :{BLACK}Afișează toate industriile pe hartă
+STR_SMALLMAP_TOOLTIP_SHOW_HEIGHT                                :{BLACK}Comută afișarea hărții de înălțimi
 STR_SMALLMAP_TOOLTIP_DISABLE_ALL_COMPANIES                      :{BLACK}Nu se afisează proprietățile companiilor pe hartă
 STR_SMALLMAP_TOOLTIP_ENABLE_ALL_COMPANIES                       :{BLACK}Afișează toate proprietățile companiei pe hartă
 STR_SMALLMAP_TOOLTIP_DISABLE_ALL_CARGOS                         :{BLACK}Nu afișa tipuri de încărcături pe hartă
@@ -821,67 +821,67 @@ STR_MESSAGE_NEWS_FORMAT                                         :{STRING}  -  {S
 STR_NEWS_MESSAGE_CAPTION                                        :{WHITE}Mesaj
 STR_NEWS_CUSTOM_ITEM                                            :{BIG_FONT}{BLACK}{STRING}
 
-STR_NEWS_FIRST_TRAIN_ARRIVAL                                    :{BIG_FONT}{BLACK}Cetăţenii sărbătoresc . . .{}Soseşte primul tren la {STATION}!
-STR_NEWS_FIRST_BUS_ARRIVAL                                      :{BIG_FONT}{BLACK}Cetăţenii sărbătoresc . . .{}Soseşte primul autobuz la {STATION}!
-STR_NEWS_FIRST_TRUCK_ARRIVAL                                    :{BIG_FONT}{BLACK}Cetăţenii sărbătoresc . . .{}Soseşte primul camion la {STATION}!
-STR_NEWS_FIRST_PASSENGER_TRAM_ARRIVAL                           :{BIG_FONT}{BLACK}Cetăţenii sărbătoresc . . .{}Soseşte primul tramvai pentru călători la {STATION}!
-STR_NEWS_FIRST_CARGO_TRAM_ARRIVAL                               :{BIG_FONT}{BLACK}Cetăţenii sărbătoresc . . .{}Soseşte primul tramvai pentru marfă la {STATION}!
-STR_NEWS_FIRST_SHIP_ARRIVAL                                     :{BIG_FONT}{BLACK}Cetăţenii sărbătoresc . . .{}Soseşte prima navă la {STATION}!
-STR_NEWS_FIRST_AIRCRAFT_ARRIVAL                                 :{BIG_FONT}{BLACK}Cetăţenii sărbătoresc . . .{}Soseşte prima aeronavă la {STATION}!
+STR_NEWS_FIRST_TRAIN_ARRIVAL                                    :{BIG_FONT}{BLACK}Cetățenii sărbătoresc . . .{}Sosește primul tren la {STATION}!
+STR_NEWS_FIRST_BUS_ARRIVAL                                      :{BIG_FONT}{BLACK}Cetățenii sărbătoresc . . .{}Sosește primul autobuz la {STATION}!
+STR_NEWS_FIRST_TRUCK_ARRIVAL                                    :{BIG_FONT}{BLACK}Cetățenii sărbătoresc . . .{}Sosește primul camion la {STATION}!
+STR_NEWS_FIRST_PASSENGER_TRAM_ARRIVAL                           :{BIG_FONT}{BLACK}Cetățenii sărbătoresc . . .{}Sosește primul tramvai pentru călători la {STATION}!
+STR_NEWS_FIRST_CARGO_TRAM_ARRIVAL                               :{BIG_FONT}{BLACK}Cetățenii sărbătoresc . . .{}Sosește primul tramvai pentru marfă la {STATION}!
+STR_NEWS_FIRST_SHIP_ARRIVAL                                     :{BIG_FONT}{BLACK}Cetățenii sărbătoresc . . .{}Sosește prima navă la {STATION}!
+STR_NEWS_FIRST_AIRCRAFT_ARRIVAL                                 :{BIG_FONT}{BLACK}Cetățenii sărbătoresc . . .{}Sosește prima aeronavă la {STATION}!
 
 STR_NEWS_TRAIN_CRASH                                            :{BIG_FONT}{BLACK}Accident feroviar!{}{COMMA} victime în urma coliziunii
 STR_NEWS_ROAD_VEHICLE_CRASH_DRIVER                              :{BIG_FONT}{BLACK}Accident rutier!{}Șoferul a decedat în urma coliziunii cu un tren
 STR_NEWS_ROAD_VEHICLE_CRASH                                     :{BIG_FONT}{BLACK}Accident rutier!{}{COMMA} victime în urma coliziunii cu un tren
-STR_NEWS_AIRCRAFT_CRASH                                         :{BIG_FONT}{BLACK}Accident aviatic!{}{COMMA} victime în urma prăbuşirii de la {STATION}
+STR_NEWS_AIRCRAFT_CRASH                                         :{BIG_FONT}{BLACK}Accident aviatic!{}{COMMA} victime în urma prăbușirii de la {STATION}
 STR_NEWS_PLANE_CRASH_OUT_OF_FUEL                                :{BIG_FONT}{BLACK}Accident aviatic!{}Aeronava a rămas fără combustibil, {COMMA} victime în urma dezastrului
 
 STR_NEWS_DISASTER_ZEPPELIN                                      :{BIG_FONT}{BLACK}Accident de zepelin la {STATION}!
 STR_NEWS_DISASTER_SMALL_UFO                                     :{BIG_FONT}{BLACK}Autovehicul distrus în urma coliziunii cu un OZN!
 STR_NEWS_DISASTER_AIRPLANE_OIL_REFINERY                         :{BIG_FONT}{BLACK}Explozie la o rafinărie de lângă {TOWN}!
-STR_NEWS_DISASTER_HELICOPTER_FACTORY                            :{BIG_FONT}{BLACK}Fabrică distrusă în condiţii misterioase lângă {TOWN}!
+STR_NEWS_DISASTER_HELICOPTER_FACTORY                            :{BIG_FONT}{BLACK}Fabrică distrusă în condiții misterioase lângă {TOWN}!
 STR_NEWS_DISASTER_BIG_UFO                                       :{BIG_FONT}{BLACK}Un OZN a aterizat lângă {TOWN}!
-STR_NEWS_DISASTER_COAL_MINE_SUBSIDENCE                          :{BIG_FONT}{BLACK}Prăbuşirea unei mine de cărbune lângă {TOWN} provoacă daune majore!
-STR_NEWS_DISASTER_FLOOD_VEHICLE                                 :{BIG_FONT}{BLACK}Inundaţii!{}Se estimează cel puţin {COMMA} victime!
+STR_NEWS_DISASTER_COAL_MINE_SUBSIDENCE                          :{BIG_FONT}{BLACK}Prăbușirea unei mine de cărbune lângă {TOWN} provoacă daune majore!
+STR_NEWS_DISASTER_FLOOD_VEHICLE                                 :{BIG_FONT}{BLACK}Inundații!{}Se estimează cel puțin {COMMA} victime!
 
 STR_NEWS_COMPANY_IN_TROUBLE_TITLE                               :{BIG_FONT}{BLACK}Companie de transport cu probleme!
-STR_NEWS_COMPANY_IN_TROUBLE_DESCRIPTION                         :{BIG_FONT}{BLACK}{STRING} va fi vândută sau declarată în faliment dacă situaţia financiară nu se va îmbunătăţi curând!
+STR_NEWS_COMPANY_IN_TROUBLE_DESCRIPTION                         :{BIG_FONT}{BLACK}{STRING} va fi vândută sau declarată în faliment dacă situația financiară nu se va îmbunătăți curând!
 STR_NEWS_COMPANY_MERGER_TITLE                                   :{BIG_FONT}{BLACK}Fuziune între companii de transport!
-STR_NEWS_COMPANY_MERGER_DESCRIPTION                             :{BIG_FONT}{BLACK}{STRING} a fost vândută companiei {STRING} la preţul de {CURRENCY_LONG}!
+STR_NEWS_COMPANY_MERGER_DESCRIPTION                             :{BIG_FONT}{BLACK}{STRING} a fost vândută companiei {STRING} la prețul de {CURRENCY_LONG}!
 STR_NEWS_COMPANY_BANKRUPT_TITLE                                 :{BIG_FONT}{BLACK}Faliment!
-STR_NEWS_COMPANY_BANKRUPT_DESCRIPTION                           :{BIG_FONT}{BLACK}Compania {STRING} a fost închisă şi toate activele au fost valorificate de creditori!
+STR_NEWS_COMPANY_BANKRUPT_DESCRIPTION                           :{BIG_FONT}{BLACK}Compania {STRING} a fost închisă și toate activele au fost valorificate de creditori!
 STR_NEWS_COMPANY_LAUNCH_TITLE                                   :{BIG_FONT}{BLACK}A apărut o nouă companie de transport!
-STR_NEWS_COMPANY_LAUNCH_DESCRIPTION                             :{BIG_FONT}{BLACK}{STRING} şi-a stabilit sediul lângă {TOWN}!
+STR_NEWS_COMPANY_LAUNCH_DESCRIPTION                             :{BIG_FONT}{BLACK}{STRING} și-a stabilit sediul lângă {TOWN}!
 STR_NEWS_MERGER_TAKEOVER_TITLE                                  :{BIG_FONT}{BLACK}{STRING} a fost preluată de {STRING} pentru o sumă nedezvăluită!
-STR_PRESIDENT_NAME_MANAGER                                      :{BLACK}{PRESIDENT_NAME}{}(Preşedinte)
+STR_PRESIDENT_NAME_MANAGER                                      :{BLACK}{PRESIDENT_NAME}{}(Președinte)
 
-STR_NEWS_NEW_TOWN                                               :{BLACK}{BIG_FONT}{STRING} a sponsorizat construcţia unui nou oras {TOWN}!
+STR_NEWS_NEW_TOWN                                               :{BLACK}{BIG_FONT}{STRING} a sponsorizat construcția unui nou oras {TOWN}!
 STR_NEWS_NEW_TOWN_UNSPONSORED                                   :{BLACK}{BIG_FONT}Un nou oraș, numit {TOWN}, a fost construit!
 
-STR_NEWS_INDUSTRY_CONSTRUCTION                                  :{BIG_FONT}{BLACK}Un nou obiectiv industrial ({STRING}) se construieşte lângă {TOWN}!
+STR_NEWS_INDUSTRY_CONSTRUCTION                                  :{BIG_FONT}{BLACK}Un nou obiectiv industrial ({STRING}) se construiește lângă {TOWN}!
 STR_NEWS_INDUSTRY_PLANTED                                       :{BIG_FONT}{BLACK}O nouă {STRING} se plantează lângă {TOWN}!
 
-STR_NEWS_INDUSTRY_CLOSURE_GENERAL                               :{BIG_FONT}{BLACK}{STRING} anunţă închiderea iminentă!
+STR_NEWS_INDUSTRY_CLOSURE_GENERAL                               :{BIG_FONT}{BLACK}{STRING} anunță închiderea iminentă!
 STR_NEWS_INDUSTRY_CLOSURE_SUPPLY_PROBLEMS                       :{BIG_FONT}{BLACK}Problemele de aprovizionare provoacă închiderea iminentă a {STRING}!
 STR_NEWS_INDUSTRY_CLOSURE_LACK_OF_TREES                         :{BIG_FONT}{BLACK}Lipsa de teren împădurit provoacă închiderea {STRING}!
 
-STR_NEWS_EURO_INTRODUCTION                                      :{BIG_FONT}{BLACK}Uniunea Monetară Europeană!{}{}Euro este introdus în ţară ca monedă unică de folosinţă în tranzacţiile zilnice!
-STR_NEWS_BEGIN_OF_RECESSION                                     :{BIG_FONT}{BLACK}Recesiune mondială!{}{}Experţii financiari se tem de ceea ce e mai rău odată cu prăbuşirea economică!
-STR_NEWS_END_OF_RECESSION                                       :{BIG_FONT}{BLACK}Recesiunea s-a încheiat!{}{}Creşterea comerţului dă încredere industriei, iar economia se redresează!
+STR_NEWS_EURO_INTRODUCTION                                      :{BIG_FONT}{BLACK}Uniunea Monetară Europeană!{}{}Euro este introdus în țară ca monedă unică de folosință în tranzacțiile zilnice!
+STR_NEWS_BEGIN_OF_RECESSION                                     :{BIG_FONT}{BLACK}Recesiune mondială!{}{}Experții financiari se tem de ceea ce e mai rău odată cu prăbușirea economică!
+STR_NEWS_END_OF_RECESSION                                       :{BIG_FONT}{BLACK}Recesiunea s-a încheiat!{}{}Creșterea comerțului dă încredere industriei, iar economia se redresează!
 
-STR_NEWS_INDUSTRY_PRODUCTION_INCREASE_GENERAL                   :{BIG_FONT}{BLACK}{INDUSTRY} măreşte producţia!
-STR_NEWS_INDUSTRY_PRODUCTION_INCREASE_COAL                      :{BIG_FONT}{BLACK}Rezerve noi de cărbune la {INDUSTRY}!{}Se preconizează dublarea producţiei!
-STR_NEWS_INDUSTRY_PRODUCTION_INCREASE_OIL                       :{BIG_FONT}{BLACK}Rezerve noi de petrol la {INDUSTRY}!{}Se preconizează dublarea producţiei!
-STR_NEWS_INDUSTRY_PRODUCTION_INCREASE_FARM                      :{BIG_FONT}{BLACK}Noile tehnologii folosite la {INDUSTRY} vor aduce dublarea producţiei!
-STR_NEWS_INDUSTRY_PRODUCTION_INCREASE_SMOOTH                    :{BIG_FONT}{BLACK}Producţia de {STRING} de la {INDUSTRY} crește cu {COMMA}%!
-STR_NEWS_INDUSTRY_PRODUCTION_DECREASE_GENERAL                   :{BIG_FONT}{BLACK}{INDUSTRY} scade producţia cu 50%
-STR_NEWS_INDUSTRY_PRODUCTION_DECREASE_FARM                      :{BIG_FONT}{BLACK}Insectele cauzează distrugeri masive la {INDUSTRY}!{}Producţia scade cu 50%
-STR_NEWS_INDUSTRY_PRODUCTION_DECREASE_SMOOTH                    :{BIG_FONT}{BLACK}Producţia de {STRING} de la {INDUSTRY} scade cu {COMMA}%!
+STR_NEWS_INDUSTRY_PRODUCTION_INCREASE_GENERAL                   :{BIG_FONT}{BLACK}{INDUSTRY} mărește producția!
+STR_NEWS_INDUSTRY_PRODUCTION_INCREASE_COAL                      :{BIG_FONT}{BLACK}Rezerve noi de cărbune la {INDUSTRY}!{}Se preconizează dublarea producției!
+STR_NEWS_INDUSTRY_PRODUCTION_INCREASE_OIL                       :{BIG_FONT}{BLACK}Rezerve noi de petrol la {INDUSTRY}!{}Se preconizează dublarea producției!
+STR_NEWS_INDUSTRY_PRODUCTION_INCREASE_FARM                      :{BIG_FONT}{BLACK}Noile tehnologii folosite la {INDUSTRY} vor aduce dublarea producției!
+STR_NEWS_INDUSTRY_PRODUCTION_INCREASE_SMOOTH                    :{BIG_FONT}{BLACK}Producția de {STRING} de la {INDUSTRY} crește cu {COMMA}%!
+STR_NEWS_INDUSTRY_PRODUCTION_DECREASE_GENERAL                   :{BIG_FONT}{BLACK}{INDUSTRY} scade producția cu 50%
+STR_NEWS_INDUSTRY_PRODUCTION_DECREASE_FARM                      :{BIG_FONT}{BLACK}Insectele cauzează distrugeri masive la {INDUSTRY}!{}Producția scade cu 50%
+STR_NEWS_INDUSTRY_PRODUCTION_DECREASE_SMOOTH                    :{BIG_FONT}{BLACK}Producția de {STRING} de la {INDUSTRY} scade cu {COMMA}%!
 
 ###length VEHICLE_TYPES
-STR_NEWS_TRAIN_IS_WAITING                                       :{WHITE}{VEHICLE} aşteaptă în depou
-STR_NEWS_ROAD_VEHICLE_IS_WAITING                                :{WHITE}{VEHICLE} aşteaptă în depou
-STR_NEWS_SHIP_IS_WAITING                                        :{WHITE}{VEHICLE} aşteaptă în depou
-STR_NEWS_AIRCRAFT_IS_WAITING                                    :{WHITE}{VEHICLE} aşteaptă în hangar
+STR_NEWS_TRAIN_IS_WAITING                                       :{WHITE}{VEHICLE} așteaptă în depou
+STR_NEWS_ROAD_VEHICLE_IS_WAITING                                :{WHITE}{VEHICLE} așteaptă în depou
+STR_NEWS_SHIP_IS_WAITING                                        :{WHITE}{VEHICLE} așteaptă în depou
+STR_NEWS_AIRCRAFT_IS_WAITING                                    :{WHITE}{VEHICLE} așteaptă în hangar
 ###next-name-looks-similar
 
 # Order review system / warnings
@@ -893,14 +893,14 @@ STR_NEWS_PLANE_USES_TOO_SHORT_RUNWAY                            :{WHITE}{VEHICLE
 
 STR_NEWS_VEHICLE_IS_GETTING_OLD                                 :{WHITE}{VEHICLE} este vechi
 STR_NEWS_VEHICLE_IS_GETTING_VERY_OLD                            :{WHITE}{VEHICLE} este foarte vechi
-STR_NEWS_VEHICLE_IS_GETTING_VERY_OLD_AND                        :{WHITE}{VEHICLE} este foarte vechi şi trebuie înlocuit
-STR_NEWS_TRAIN_IS_STUCK                                         :{WHITE}{VEHICLE} nu găseşte calea către destinaţie
+STR_NEWS_VEHICLE_IS_GETTING_VERY_OLD_AND                        :{WHITE}{VEHICLE} este foarte vechi și trebuie înlocuit
+STR_NEWS_TRAIN_IS_STUCK                                         :{WHITE}{VEHICLE} nu găsește calea către destinație
 STR_NEWS_VEHICLE_IS_LOST                                        :{WHITE}{VEHICLE} s-a rătăcit
 STR_NEWS_VEHICLE_IS_UNPROFITABLE                                :{WHITE}Profitul {VEHICLE} pe anul precedent a fost de {CURRENCY_LONG}
 STR_NEWS_AIRCRAFT_DEST_TOO_FAR                                  :{WHITE}{VEHICLE} nu poate ajunge la următoarea destinație deoarece se află în afara razei de acțiune
 
-STR_NEWS_ORDER_REFIT_FAILED                                     :{WHITE}{VEHICLE} s-a oprit deoarece recondiţionarea programată a eşuat
-STR_NEWS_VEHICLE_AUTORENEW_FAILED                               :{WHITE}Autoreînnoire eşuată pentru {VEHICLE}{}{STRING}
+STR_NEWS_ORDER_REFIT_FAILED                                     :{WHITE}{VEHICLE} s-a oprit deoarece recondiționarea programată a eșuat
+STR_NEWS_VEHICLE_AUTORENEW_FAILED                               :{WHITE}Autoînnoire eșuată pentru {VEHICLE}{}{STRING}
 
 STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE                              :{BIG_FONT}{BLACK}Un nou tip de {STRING} este acum disponibil!
 STR_NEWS_NEW_VEHICLE_TYPE                                       :{BIG_FONT}{BLACK}{ENGINE}
@@ -911,28 +911,28 @@ STR_NEWS_SHOW_VEHICLE_GROUP_TOOLTIP                             :{BLACK}Deschide
 STR_NEWS_STATION_NO_LONGER_ACCEPTS_CARGO_LIST                   :{WHITE}{STATION} nu mai acceptă: {CARGO_LIST}
 STR_NEWS_STATION_NOW_ACCEPTS_CARGO_LIST                         :{WHITE}{STATION} acceptă acum: {CARGO_LIST}
 
-STR_NEWS_OFFER_OF_SUBSIDY_EXPIRED                               :{BIG_FONT}{BLACK}Ofertă expirată:{}{}Transportul de {STRING} de la {STRING} la {STRING} nu va mai fi subvenţionat
-STR_NEWS_SUBSIDY_WITHDRAWN_SERVICE                              :{BIG_FONT}{BLACK}Ofertă retrasă:{}{}Transportul de {STRING} de la {STRING} la {STRING} nu va mai fi subvenţionat
-STR_NEWS_SERVICE_SUBSIDY_OFFERED                                :{BIG_FONT}{BLACK}Subvenţie oferită:{}{}Primul transport de {STRING} de la {STRING} la {STRING} va primi o subvenţie pe {NUM} {P an ani "de ani"} din partea autorităţilor locale!
+STR_NEWS_OFFER_OF_SUBSIDY_EXPIRED                               :{BIG_FONT}{BLACK}Ofertă expirată:{}{}Transportul de {STRING} de la {STRING} la {STRING} nu va mai fi subvenționat
+STR_NEWS_SUBSIDY_WITHDRAWN_SERVICE                              :{BIG_FONT}{BLACK}Ofertă retrasă:{}{}Transportul de {STRING} de la {STRING} la {STRING} nu va mai fi subvenționat
+STR_NEWS_SERVICE_SUBSIDY_OFFERED                                :{BIG_FONT}{BLACK}Subvenție oferită:{}{}Primul transport de {STRING} de la {STRING} la {STRING} va primi o subvenție pe {NUM} {P an ani "de ani"} din partea autorităților locale!
 ###length 4
-STR_NEWS_SERVICE_SUBSIDY_AWARDED_HALF                           :{BIG_FONT}{BLACK}Subvenţie acordată companiei {STRING}!{}{}Transportul de {STRING} de la {STRING} la {STRING} va aduce încasări cu 50% mai mari în următor{P 4 ul ii ii} {NUM} {P an ani "de ani"}!
-STR_NEWS_SERVICE_SUBSIDY_AWARDED_DOUBLE                         :{BIG_FONT}{BLACK}Subvenţie acordată companiei {STRING}!{}{}Transportul de {STRING} de la {STRING} la {STRING} va aduce încasări duble în următor{P 4 ul ii ii} {NUM} {P an ani "de ani"}!
-STR_NEWS_SERVICE_SUBSIDY_AWARDED_TRIPLE                         :{BIG_FONT}{BLACK}Subvenţie acordată companiei {STRING}!{}{}Transportul de {STRING} de la {STRING} la {STRING} va aduce încasări triple în următor{P 4 ul ii ii} {NUM} {P an ani "de ani"}!
-STR_NEWS_SERVICE_SUBSIDY_AWARDED_QUADRUPLE                      :{BIG_FONT}{BLACK}Subvenţie acordată companiei {STRING}!{}{}Transportul de {STRING} de la {STRING} la {STRING} va aduce încasări de patru ori mai mari în următor{P 4 ul ii ii} {NUM} {P an ani "de ani"}!
+STR_NEWS_SERVICE_SUBSIDY_AWARDED_HALF                           :{BIG_FONT}{BLACK}Subvenție acordată companiei {STRING}!{}{}Transportul de {STRING} de la {STRING} la {STRING} va aduce încasări cu 50% mai mari în următor{P 4 ul ii ii} {NUM} {P an ani "de ani"}!
+STR_NEWS_SERVICE_SUBSIDY_AWARDED_DOUBLE                         :{BIG_FONT}{BLACK}Subvenție acordată companiei {STRING}!{}{}Transportul de {STRING} de la {STRING} la {STRING} va aduce încasări duble în următor{P 4 ul ii ii} {NUM} {P an ani "de ani"}!
+STR_NEWS_SERVICE_SUBSIDY_AWARDED_TRIPLE                         :{BIG_FONT}{BLACK}Subvenție acordată companiei {STRING}!{}{}Transportul de {STRING} de la {STRING} la {STRING} va aduce încasări triple în următor{P 4 ul ii ii} {NUM} {P an ani "de ani"}!
+STR_NEWS_SERVICE_SUBSIDY_AWARDED_QUADRUPLE                      :{BIG_FONT}{BLACK}Subvenție acordată companiei {STRING}!{}{}Transportul de {STRING} de la {STRING} la {STRING} va aduce încasări de patru ori mai mari în următor{P 4 ul ii ii} {NUM} {P an ani "de ani"}!
 
 STR_NEWS_ROAD_REBUILDING                                        :{BIG_FONT}{BLACK}Haos pe străzile din {TOWN}!{}{}Programul finanțat de {STRING} pentru reconstrucția străzilor aduce 6 luni de haos participanților la trafic!
 STR_NEWS_EXCLUSIVE_RIGHTS_TITLE                                 :{BIG_FONT}{BLACK}Monopol de transport!
-STR_NEWS_EXCLUSIVE_RIGHTS_DESCRIPTION                           :{BIG_FONT}{BLACK}Autoritatea locală a oraşului {TOWN} semnează un contract cu {STRING} pentru un an de drepturi exclusive de transport!
+STR_NEWS_EXCLUSIVE_RIGHTS_DESCRIPTION                           :{BIG_FONT}{BLACK}Autoritatea locală a orașului {TOWN} semnează un contract cu {STRING} pentru un an de drepturi exclusive de transport!
 
 # Extra view window
 STR_EXTRA_VIEWPORT_TITLE                                        :{WHITE}Ecran {COMMA}
 STR_EXTRA_VIEW_MOVE_VIEW_TO_MAIN                                :{BLACK}Copiază în ecran
-STR_EXTRA_VIEW_MOVE_VIEW_TO_MAIN_TT                             :{BLACK}Copiază locaţia ecranului principal în acest ecran
+STR_EXTRA_VIEW_MOVE_VIEW_TO_MAIN_TT                             :{BLACK}Copiază locația ecranului principal în acest ecran
 STR_EXTRA_VIEW_MOVE_MAIN_TO_VIEW                                :{BLACK}Importă din ecran
-STR_EXTRA_VIEW_MOVE_MAIN_TO_VIEW_TT                             :{BLACK}Copiază locaţia acestui ecran în ecranul principal
+STR_EXTRA_VIEW_MOVE_MAIN_TO_VIEW_TT                             :{BLACK}Copiază locația acestui ecran în ecranul principal
 
 # Game options window
-STR_GAME_OPTIONS_CAPTION                                        :{WHITE}Opţiuni
+STR_GAME_OPTIONS_CAPTION                                        :{WHITE}Opțiuni
 
 STR_GAME_OPTIONS_TAB_GENERAL                                    :General
 STR_GAME_OPTIONS_TAB_GENERAL_TT                                 :{BLACK}Alege setările generale
@@ -961,9 +961,9 @@ STR_GAME_OPTIONS_CURRENCY_GBP                                   :Liră sterlină
 STR_GAME_OPTIONS_CURRENCY_USD                                   :Dolar american
 STR_GAME_OPTIONS_CURRENCY_EUR                                   :Euro
 STR_GAME_OPTIONS_CURRENCY_JPY                                   :Yen japonez
-STR_GAME_OPTIONS_CURRENCY_ATS                                   :Şiling austriac
+STR_GAME_OPTIONS_CURRENCY_ATS                                   :șiling austriac
 STR_GAME_OPTIONS_CURRENCY_BEF                                   :Franc belgian
-STR_GAME_OPTIONS_CURRENCY_CHF                                   :Franc elveţian
+STR_GAME_OPTIONS_CURRENCY_CHF                                   :Franc elvețian
 STR_GAME_OPTIONS_CURRENCY_CZK                                   :Coroană cehă
 STR_GAME_OPTIONS_CURRENCY_DEM                                   :Marcă germană
 STR_GAME_OPTIONS_CURRENCY_DKK                                   :Coroană daneză
@@ -1012,14 +1012,14 @@ STR_GAME_OPTIONS_AUTOSAVE_DROPDOWN_EVERY_60_MINUTES             :La fiecare 60 d
 STR_GAME_OPTIONS_AUTOSAVE_DROPDOWN_EVERY_120_MINUTES            :La fiecare 120 de minute
 
 STR_GAME_OPTIONS_LANGUAGE                                       :{BLACK}Limba
-STR_GAME_OPTIONS_LANGUAGE_TOOLTIP                               :{BLACK}Alege limba în care doreşti afişată interfaţa
+STR_GAME_OPTIONS_LANGUAGE_TOOLTIP                               :{BLACK}Alege limba în care dorești afișată interfața
 STR_GAME_OPTIONS_LANGUAGE_PERCENTAGE                            :{STRING} ({NUM}% finalizat)
 
 STR_GAME_OPTIONS_FULLSCREEN                                     :{BLACK}Ecran întreg
-STR_GAME_OPTIONS_FULLSCREEN_TOOLTIP                             :{BLACK}Bifează această căsuţă pentru a juca pe tot ecranul
+STR_GAME_OPTIONS_FULLSCREEN_TOOLTIP                             :{BLACK}Bifează această căsuță pentru a juca pe tot ecranul
 
-STR_GAME_OPTIONS_RESOLUTION                                     :{BLACK}Rezoluţia ecranului
-STR_GAME_OPTIONS_RESOLUTION_TOOLTIP                             :{BLACK}Alege rezoluţia dorită pentru joc
+STR_GAME_OPTIONS_RESOLUTION                                     :{BLACK}Rezoluția ecranului
+STR_GAME_OPTIONS_RESOLUTION_TOOLTIP                             :{BLACK}Alege rezoluția dorită pentru joc
 STR_GAME_OPTIONS_RESOLUTION_OTHER                               :(alta/nespecificată)
 STR_GAME_OPTIONS_RESOLUTION_ITEM                                :{NUM}x{NUM}
 
@@ -1032,10 +1032,10 @@ STR_GAME_OPTIONS_VIDEO_VSYNC_TOOLTIP                            :{BLACK}Bifați 
 
 STR_GAME_OPTIONS_VIDEO_DRIVER_INFO                              :{BLACK}Driver curent: {STRING}
 
-STR_GAME_OPTIONS_GUI_SCALE_FRAME                                :{BLACK}Dimensiune interfaţă
+STR_GAME_OPTIONS_GUI_SCALE_FRAME                                :{BLACK}Dimensiune interfață
 STR_GAME_OPTIONS_GUI_SCALE_TOOLTIP                              :{BLACK}Trageți glisorul pentru a seta dimensiunea interfeței. Țineți apăsat Ctrl pentru ajustare continuă
 STR_GAME_OPTIONS_GUI_SCALE_AUTO                                 :{BLACK}Detectează automat dimensiunea
-STR_GAME_OPTIONS_GUI_SCALE_AUTO_TOOLTIP                         :{BLACK}Bifați această căsuţă pentru a detecta automat dimensiunea interfeței
+STR_GAME_OPTIONS_GUI_SCALE_AUTO_TOOLTIP                         :{BLACK}Bifați această căsuță pentru a detecta automat dimensiunea interfeței
 
 STR_GAME_OPTIONS_GUI_SCALE_BEVELS                               :{BLACK}Scalează marginile
 STR_GAME_OPTIONS_GUI_SCALE_BEVELS_TOOLTIP                       :{BLACK}Bifați această casetă pentru a scala marginile în funcție de dimensiunea interfeței
@@ -1063,26 +1063,26 @@ STR_GAME_OPTIONS_REFRESH_RATE_WARNING                           :{WHITE}Ratele d
 
 STR_GAME_OPTIONS_BASE_GRF                                       :{BLACK}Set grafic de bază
 STR_GAME_OPTIONS_BASE_GRF_TOOLTIP                               :{BLACK}Selectați setul de grafică de bază pe care să îl utilizați (nu poate fi schimbat în joc, doar din meniul principal)
-STR_GAME_OPTIONS_BASE_GRF_DESCRIPTION_TOOLTIP                   :{BLACK}Informaţii adiţionale despre setul grafic de bază
+STR_GAME_OPTIONS_BASE_GRF_DESCRIPTION_TOOLTIP                   :{BLACK}Informații adiționale despre setul grafic de bază
 
 STR_GAME_OPTIONS_BASE_SFX                                       :{BLACK}Set sunete de bază
 STR_GAME_OPTIONS_BASE_SFX_TOOLTIP                               :{BLACK}Selectați sunetele de bază setate pentru a fi utilizate (nu pot fi modificate în joc, doar din meniul principal)
-STR_GAME_OPTIONS_BASE_SFX_DESCRIPTION_TOOLTIP                   :{BLACK}Informaţii adiţionale despre setul de sunete de bază
+STR_GAME_OPTIONS_BASE_SFX_DESCRIPTION_TOOLTIP                   :{BLACK}Informații adiționale despre setul de sunete de bază
 
 STR_GAME_OPTIONS_BASE_MUSIC                                     :{BLACK}Setul de muzică de bază
-STR_GAME_OPTIONS_BASE_MUSIC_TOOLTIP                             :{BLACK}Selectaţi setul de muzică de bază
-STR_GAME_OPTIONS_BASE_MUSIC_DESCRIPTION_TOOLTIP                 :{BLACK}Informaţii adiţionale despre setul de muzică de bază
+STR_GAME_OPTIONS_BASE_MUSIC_TOOLTIP                             :{BLACK}Selectați setul de muzică de bază
+STR_GAME_OPTIONS_BASE_MUSIC_DESCRIPTION_TOOLTIP                 :{BLACK}Informații adiționale despre setul de muzică de bază
 
 
 STR_ERROR_RESOLUTION_LIST_FAILED                                :{WHITE}Nu s-a putut obține lista de rezoluții suportate
-STR_ERROR_FULLSCREEN_FAILED                                     :{WHITE}Comutarea pe întreg ecranul a eşuat
+STR_ERROR_FULLSCREEN_FAILED                                     :{WHITE}Comutarea pe întreg ecranul a eșuat
 
 # Custom currency window
 
 STR_CURRENCY_WINDOW                                             :{WHITE}Monedă proprie
 STR_CURRENCY_EXCHANGE_RATE                                      :{LTBLUE}Curs de schimb: {ORANGE}{CURRENCY_LONG} = £ {COMMA}
 STR_CURRENCY_DECREASE_EXCHANGE_RATE_TOOLTIP                     :{BLACK}Scade valoarea monedei tale pentru o liră sterlină (£)
-STR_CURRENCY_INCREASE_EXCHANGE_RATE_TOOLTIP                     :{BLACK}Măreşte valoarea monedei tale pentru o liră sterlină (£)
+STR_CURRENCY_INCREASE_EXCHANGE_RATE_TOOLTIP                     :{BLACK}Mărește valoarea monedei tale pentru o liră sterlină (£)
 STR_CURRENCY_SET_EXCHANGE_RATE_TOOLTIP                          :{BLACK}Setează rata de schimb pentru o liră sterlină (£)
 
 STR_CURRENCY_SEPARATOR                                          :{LTBLUE}Separator: {ORANGE}{STRING}
@@ -1137,14 +1137,14 @@ STR_SEA_LEVEL_CUSTOM_PERCENTAGE                                 :Personalizat ({
 
 ###length 4
 STR_RIVERS_NONE                                                 :Deloc
-STR_RIVERS_FEW                                                  :Puţine
+STR_RIVERS_FEW                                                  :Puține
 STR_RIVERS_MODERATE                                             :Mediu
 STR_RIVERS_LOT                                                  :Multe
 
 ###length 3
 STR_DISASTER_NONE                                               :Deloc
 STR_DISASTER_REDUCED                                            :Redus
-STR_DISASTER_NORMAL                                             :Frecvenţă normală
+STR_DISASTER_NORMAL                                             :Frecvență normală
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1,5
@@ -1156,7 +1156,7 @@ STR_SUBSIDY_X4                                                  :x4
 STR_CLIMATE_TEMPERATE_LANDSCAPE                                 :peisajul temperat
 STR_CLIMATE_SUB_ARCTIC_LANDSCAPE                                :peisajul sub-arctic
 STR_CLIMATE_SUB_TROPICAL_LANDSCAPE                              :peisajul sub-tropical
-STR_CLIMATE_TOYLAND_LANDSCAPE                                   :peisajul 'ţara jucăriilor'
+STR_CLIMATE_TOYLAND_LANDSCAPE                                   :peisajul 'țara jucăriilor'
 
 ###length 7
 STR_TERRAIN_TYPE_VERY_FLAT                                      :Foarte plat
@@ -1173,7 +1173,7 @@ STR_CITY_APPROVAL_TOLERANT                                      :Tolerantă
 STR_CITY_APPROVAL_HOSTILE                                       :Ostilă
 STR_CITY_APPROVAL_PERMISSIVE                                    :Permisivă (fara efect asupra actiunilor companiei)
 
-STR_WARNING_NO_SUITABLE_AI                                      :{WHITE}Nu este disponibil nici un modul de Inteligenţă Artificială...{}Puteţi descărca diferite module de Inteligenţă Artificială prin sistemul de 'Resurse Online'
+STR_WARNING_NO_SUITABLE_AI                                      :{WHITE}Nu este disponibil nici un modul de Inteligență Artificială...{}Puteți descărca diferite module de Inteligență Artificială prin sistemul de 'Resurse Online'
 
 # Settings tree window
 STR_CONFIG_SETTING_TREE_CAPTION                                 :{WHITE}Setări
@@ -1186,19 +1186,19 @@ STR_CONFIG_SETTING_VALUE                                        :{PUSH_COLOUR}{O
 STR_CONFIG_SETTING_DEFAULT_VALUE                                :{LTBLUE}Valoare implicită: {ORANGE}{STRING}
 STR_CONFIG_SETTING_TYPE                                         :{LTBLUE}Tip setare: {ORANGE}{STRING}
 STR_CONFIG_SETTING_TYPE_CLIENT                                  :Setare client (nu se stochează în salvări; se aplică pentru toate jocurile)
-STR_CONFIG_SETTING_TYPE_GAME_MENU                               :Setări joc (stocate în fişierele de salvare; afectează doar jocurile noi)
+STR_CONFIG_SETTING_TYPE_GAME_MENU                               :Setări joc (stocate în fișierele de salvare; afectează doar jocurile noi)
 STR_CONFIG_SETTING_TYPE_GAME_INGAME                             :Setări joc (stocate în fișierul de salvare; afectează doar jocul curent)
-STR_CONFIG_SETTING_TYPE_COMPANY_MENU                            :Setări companie (stocate în fişierele de salvare; afectează doar jocurile noi)
-STR_CONFIG_SETTING_TYPE_COMPANY_INGAME                          :Setări companie (stocate în fişierul de salvare; afectează doar compania curentă)
+STR_CONFIG_SETTING_TYPE_COMPANY_MENU                            :Setări companie (stocate în fișierele de salvare; afectează doar jocurile noi)
+STR_CONFIG_SETTING_TYPE_COMPANY_INGAME                          :Setări companie (stocate în fișierul de salvare; afectează doar compania curentă)
 STR_CONFIG_SETTING_RESET_ALL_CONFIRMATION_DIALOG_CAPTION        :{WHITE}Atenție!
 STR_CONFIG_SETTING_RESET_ALL_CONFIRMATION_DIALOG_TEXT           :{WHITE}Această acțiune va reface toate setările jocului la valorile implicite.{}Sigur vrei să continui?
 
 STR_CONFIG_SETTING_RESTRICT_CATEGORY                            :{BLACK}Categorie:
 STR_CONFIG_SETTING_RESTRICT_TYPE                                :{BLACK}Tip:
 STR_CONFIG_SETTING_RESTRICT_DROPDOWN_HELPTEXT                   :{BLACK}Limitează lista de mai jos doar la setările modificate
-STR_CONFIG_SETTING_RESTRICT_BASIC                               :Setări de bază (afişează numai setări importante)
-STR_CONFIG_SETTING_RESTRICT_ADVANCED                            :Setări avansate (afişează majoritatea setărilor)
-STR_CONFIG_SETTING_RESTRICT_ALL                                 :Setări expert (afişează toate setările)
+STR_CONFIG_SETTING_RESTRICT_BASIC                               :Setări de bază (afișează numai setări importante)
+STR_CONFIG_SETTING_RESTRICT_ADVANCED                            :Setări avansate (afișează majoritatea setărilor)
+STR_CONFIG_SETTING_RESTRICT_ALL                                 :Setări expert (afișează toate setările)
 STR_CONFIG_SETTING_RESTRICT_CHANGED_AGAINST_DEFAULT             :Setări cu altă valoare decît cea prestabilită
 STR_CONFIG_SETTING_RESTRICT_CHANGED_AGAINST_NEW                 :Setări cu valori diferite față de cele setate de tine pentru joc nou
 
@@ -1287,17 +1287,17 @@ STR_CONFIG_SETTING_MAP_HEIGHT_LIMIT_VALUE                       :{NUM}
 STR_CONFIG_SETTING_MAP_HEIGHT_LIMIT_AUTO                        :(auto)
 STR_CONFIG_SETTING_TOO_HIGH_MOUNTAIN                            :{WHITE}Nu poți seta înălțimea maximă a hărții la această valoare. Cel puțin un munte de pe hartă este mai înalt de-atât.
 
-STR_CONFIG_SETTING_AUTOSLOPE                                    :Permite terra-formarea sub clădiri, şine, etc. (auto-pante): {STRING}
-STR_CONFIG_SETTING_AUTOSLOPE_HELPTEXT                           :Permite terraformarea sub clădiri şi şine fără eliminarea acestora
+STR_CONFIG_SETTING_AUTOSLOPE                                    :Permite terra-formarea sub clădiri, șine, etc. (auto-pante): {STRING}
+STR_CONFIG_SETTING_AUTOSLOPE_HELPTEXT                           :Permite terraformarea sub clădiri și șine fără eliminarea acestora
 
 STR_CONFIG_SETTING_CATCHMENT                                    :Permite arii de cuprindere mai realiste: {STRING}
-STR_CONFIG_SETTING_CATCHMENT_HELPTEXT                           :Permite zone diferite de captare pentru tipuri diferite de staţii şi aeroporturi
+STR_CONFIG_SETTING_CATCHMENT_HELPTEXT                           :Permite zone diferite de captare pentru tipuri diferite de stații și aeroporturi
 
 STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES                     :Stațiile companiei pot deservi industrii cu stații neutre atașate: {STRING}
 STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES_HELPTEXT            :Când este activată, industriile cu stații atașate (cum ar fi platformele petroliere) pot fi deservite și de stații deținute de companie construite în apropiere. Când sunt dezactivate, aceste industrii pot fi deservite numai de stațiile atașate. Orice stație a companiei din apropiere nu le va putea deservi și nici stația atașată nu va deservi altceva decât industria
 
 STR_CONFIG_SETTING_EXTRADYNAMITE                                :Permite demolarea unui nr. mai mare de drumuri, poduri și tunele deținute de oraș: {STRING}
-STR_CONFIG_SETTING_EXTRADYNAMITE_HELPTEXT                       :Facilitează eliminarea de clădiri şi infrastructură deţinute de oraş
+STR_CONFIG_SETTING_EXTRADYNAMITE_HELPTEXT                       :Facilitează eliminarea de clădiri și infrastructură deținute de oraș
 
 STR_CONFIG_SETTING_TRAIN_LENGTH                                 :Lungimea maximă a trenurilor: {STRING}
 STR_CONFIG_SETTING_TRAIN_LENGTH_HELPTEXT                        :Configurează lungimea maximă a trenurilor
@@ -1306,59 +1306,59 @@ STR_CONFIG_SETTING_TILE_LENGTH                                  :{COMMA} {P 0 p�
 STR_CONFIG_SETTING_SMOKE_AMOUNT                                 :Cantitatea de fum/ scântei ale vehiculului: {STRING}
 STR_CONFIG_SETTING_SMOKE_AMOUNT_HELPTEXT                        :Configurează cât de mult fum sau cât de multe scântei sunt emise de vehicule
 
-STR_CONFIG_SETTING_TRAIN_ACCELERATION_MODEL                     :Modelul de acceleraţie al trenurilor: {STRING}
-STR_CONFIG_SETTING_TRAIN_ACCELERATION_MODEL_HELPTEXT            :Selectează modelul fizic pentru accelerarea trenurilor. Modelul "original" penalizează pantele în mod egal pentru toate vehiculele. Modelul "realistic" penalizează pantele şi curbele în funcţie de mai mulţi parametrii, cum ar fi lungimea şi efortul tractor
+STR_CONFIG_SETTING_TRAIN_ACCELERATION_MODEL                     :Modelul de accelerație al trenurilor: {STRING}
+STR_CONFIG_SETTING_TRAIN_ACCELERATION_MODEL_HELPTEXT            :Selectează modelul fizic pentru accelerarea trenurilor. Modelul "original" penalizează pantele în mod egal pentru toate vehiculele. Modelul "realistic" penalizează pantele și curbele în funcție de mai mulți parametrii, cum ar fi lungimea și efortul tractor
 
 STR_CONFIG_SETTING_ROAD_VEHICLE_ACCELERATION_MODEL              :Modelul de accelerație al vehiculelor rutiere: {STRING}
-STR_CONFIG_SETTING_ROAD_VEHICLE_ACCELERATION_MODEL_HELPTEXT     :Selectează modelul fizic pentru accelerarea autovehiculelor. Modelul "original" penalizează pantele în mod egal pentru toate autovehiculele. Modelul "realistic" penalizează pantele şi curbele în funcţie de mai mulţi parametrii ai motorului, cum ar fi efortul tractor
+STR_CONFIG_SETTING_ROAD_VEHICLE_ACCELERATION_MODEL_HELPTEXT     :Selectează modelul fizic pentru accelerarea autovehiculelor. Modelul "original" penalizează pantele în mod egal pentru toate autovehiculele. Modelul "realistic" penalizează pantele și curbele în funcție de mai mulți parametrii ai motorului, cum ar fi efortul tractor
 
 STR_CONFIG_SETTING_TRAIN_SLOPE_STEEPNESS                        :Înclinarea pantelor pentru trenuri: {STRING}
-STR_CONFIG_SETTING_TRAIN_SLOPE_STEEPNESS_HELPTEXT               :Înclinarea unui pătrăţel de pantă pentru trenuri. O valoare mai mare face urcarea mai dificilă
+STR_CONFIG_SETTING_TRAIN_SLOPE_STEEPNESS_HELPTEXT               :Înclinarea unui pătrățel de pantă pentru trenuri. O valoare mai mare face urcarea mai dificilă
 STR_CONFIG_SETTING_PERCENTAGE                                   :{COMMA}%
 
 STR_CONFIG_SETTING_ROAD_VEHICLE_SLOPE_STEEPNESS                 :Înclinarea pantelor pentru autovehicule: {STRING}
-STR_CONFIG_SETTING_ROAD_VEHICLE_SLOPE_STEEPNESS_HELPTEXT        :Înclinarea unui pătrăţel de pantă pentru autovehicule. O valoare mai mare face urcarea mai dificilă
+STR_CONFIG_SETTING_ROAD_VEHICLE_SLOPE_STEEPNESS_HELPTEXT        :Înclinarea unui pătrățel de pantă pentru autovehicule. O valoare mai mare face urcarea mai dificilă
 
-STR_CONFIG_SETTING_FORBID_90_DEG                                :Interzice trenurilor şi navelor să facă întoarceri la 90°: {STRING}
-STR_CONFIG_SETTING_FORBID_90_DEG_HELPTEXT                       :Întoarcerile la 90 de grade au loc atunci când o bucată orizontală de şină este urmată imediat de o bucată verticală, astfel făcând trenul să întoarcă la 90 de grade când traversează muchia unui pătrăţel faţă de întoarcerile obişnuite de la 45 de grade pentru alte combinaţii de şină. Aceasta se aplică şi unghiului de întoarcere al navelor
+STR_CONFIG_SETTING_FORBID_90_DEG                                :Interzice trenurilor și navelor să facă întoarceri la 90°: {STRING}
+STR_CONFIG_SETTING_FORBID_90_DEG_HELPTEXT                       :Întoarcerile la 90 de grade au loc atunci când o bucată orizontală de șină este urmată imediat de o bucată verticală, astfel făcând trenul să întoarcă la 90 de grade când traversează muchia unui pătrățel față de întoarcerile obișnuite de la 45 de grade pentru alte combinații de șină. Aceasta se aplică și unghiului de întoarcere al navelor
 
-STR_CONFIG_SETTING_DISTANT_JOIN_STATIONS                        :Permite unirea staţiilor neînvecinate: {STRING}
-STR_CONFIG_SETTING_DISTANT_JOIN_STATIONS_HELPTEXT               :Permite adăugarea de elemente unei staţii fără a atinge direct elemente existente. Necesită Ctrl+Click pentru adăugărea elementelor noi
+STR_CONFIG_SETTING_DISTANT_JOIN_STATIONS                        :Permite unirea stațiilor neînvecinate: {STRING}
+STR_CONFIG_SETTING_DISTANT_JOIN_STATIONS_HELPTEXT               :Permite adăugarea de elemente unei stații fără a atinge direct elemente existente. Necesită Ctrl+Click pentru adăugărea elementelor noi
 
-STR_CONFIG_SETTING_INFLATION                                    :Inflaţia: {STRING}
-STR_CONFIG_SETTING_INFLATION_HELPTEXT                           :Activează inflaţia în economie, unde costurile cresc ceva mai rapid decât plăţile
+STR_CONFIG_SETTING_INFLATION                                    :Inflația: {STRING}
+STR_CONFIG_SETTING_INFLATION_HELPTEXT                           :Activează inflația în economie, unde costurile cresc ceva mai rapid decât plățile
 
 STR_CONFIG_SETTING_MAX_BRIDGE_LENGTH                            :Lungimea maximă a podurilor: {STRING}
-STR_CONFIG_SETTING_MAX_BRIDGE_LENGTH_HELPTEXT                   :Lungimea maximă pentru construcţia de poduri
+STR_CONFIG_SETTING_MAX_BRIDGE_LENGTH_HELPTEXT                   :Lungimea maximă pentru construcția de poduri
 
 STR_CONFIG_SETTING_MAX_BRIDGE_HEIGHT                            :Înălțimea maximă a podurilor: {STRING}
 STR_CONFIG_SETTING_MAX_BRIDGE_HEIGHT_HELPTEXT                   :Înălțimea maximă pentru construcția de poduri
 
 STR_CONFIG_SETTING_MAX_TUNNEL_LENGTH                            :Lungimea maximă a tunelurilor: {STRING}
-STR_CONFIG_SETTING_MAX_TUNNEL_LENGTH_HELPTEXT                   :Lungimea maximă pentru construcţia de tuneluri
+STR_CONFIG_SETTING_MAX_TUNNEL_LENGTH_HELPTEXT                   :Lungimea maximă pentru construcția de tuneluri
 
-STR_CONFIG_SETTING_RAW_INDUSTRY_CONSTRUCTION_METHOD             :Metoda manuală de construcţie a industriilor primare: {STRING}
+STR_CONFIG_SETTING_RAW_INDUSTRY_CONSTRUCTION_METHOD             :Metoda manuală de construcție a industriilor primare: {STRING}
 STR_CONFIG_SETTING_RAW_INDUSTRY_CONSTRUCTION_METHOD_HELPTEXT    :Metoda de finanțare a industriilor primare. „niciuna” înseamnă că nu este posibil să se finanțeze niciuna, „prospectare” înseamnă că finanțarea este posibilă, dar construcția se realizează într-un loc aleator și poate eșua, „la fel ca celelalte industrii” înseamnă că industriile de materie primă pot fi construite de către companii la fel ca industriile procesatoare, în orice locație doresc
 ###length 3
 STR_CONFIG_SETTING_RAW_INDUSTRY_CONSTRUCTION_METHOD_NONE        :niciuna
 STR_CONFIG_SETTING_RAW_INDUSTRY_CONSTRUCTION_METHOD_NORMAL      :ca alte industrii
-STR_CONFIG_SETTING_RAW_INDUSTRY_CONSTRUCTION_METHOD_PROSPECTING :de prospecţie
+STR_CONFIG_SETTING_RAW_INDUSTRY_CONSTRUCTION_METHOD_PROSPECTING :de prospecție
 
 STR_CONFIG_SETTING_INDUSTRY_PLATFORM                            :Zonă plată în jurul industriilor: {STRING}
-STR_CONFIG_SETTING_INDUSTRY_PLATFORM_HELPTEXT                   :Suprafaţa zonei plate din jurul industriilor. Aceasta asigură că există spaţiu liber în jurul industriilor pentru construcţia de şine, etc
+STR_CONFIG_SETTING_INDUSTRY_PLATFORM_HELPTEXT                   :Suprafața zonei plate din jurul industriilor. Aceasta asigură că există spațiu liber în jurul industriilor pentru construcția de șine, etc
 
-STR_CONFIG_SETTING_MULTIPINDTOWN                                :Permite mai multe industrii similare în acelaşi oras: {STRING}
+STR_CONFIG_SETTING_MULTIPINDTOWN                                :Permite mai multe industrii similare în același oras: {STRING}
 STR_CONFIG_SETTING_MULTIPINDTOWN_HELPTEXT                       :De obicei, un oraș nu dorește mai multe industrii de același tip. Cu această setare, se permit mai multe industrii de același tip în același oraș
 
 STR_CONFIG_SETTING_SIGNALSIDE                                   :Arată semnalele: {STRING}
-STR_CONFIG_SETTING_SIGNALSIDE_HELPTEXT                          :Selectează pe care parte a şinei să fie plasate semnalele
+STR_CONFIG_SETTING_SIGNALSIDE_HELPTEXT                          :Selectează pe care parte a șinei să fie plasate semnalele
 ###length 3
 STR_CONFIG_SETTING_SIGNALSIDE_LEFT                              :Pe partea stângă
-STR_CONFIG_SETTING_SIGNALSIDE_DRIVING_SIDE                      :În direcţia de mers
+STR_CONFIG_SETTING_SIGNALSIDE_DRIVING_SIDE                      :În direcția de mers
 STR_CONFIG_SETTING_SIGNALSIDE_RIGHT                             :Pe partea dreaptă
 
-STR_CONFIG_SETTING_SHOWFINANCES                                 :Afişează finanţele la sfârşitul fiecărui an: {STRING}
-STR_CONFIG_SETTING_SHOWFINANCES_HELPTEXT                        :Dacă este activat, fereastra de finanţe apare automat la sfârşitul fiecărui an pentru a permite inspectarea facilă a stării financiale a companiei
+STR_CONFIG_SETTING_SHOWFINANCES                                 :Afișează finanțele la sfârșitul fiecărui an: {STRING}
+STR_CONFIG_SETTING_SHOWFINANCES_HELPTEXT                        :Dacă este activat, fereastra de finanțe apare automat la sfârșitul fiecărui an pentru a permite inspectarea facilă a stării financiale a companiei
 
 STR_CONFIG_SETTING_NONSTOP_BY_DEFAULT                           :Comenzile noi sunt implicit „fără oprire”: {STRING}
 STR_CONFIG_SETTING_NONSTOP_BY_DEFAULT_HELPTEXT                  :În mod normal, un vehicul va opri în fiecare stație prin care trece. Prin activarea acestei setări, va trece fără oprire prin toate stațiile în drumul către destinația finală. Notă: această setare are efect doar asupra valorii implicite pentru comenzile noi. Comenzile individuale pot fi configurate explicit cu oricare din variante
@@ -1378,13 +1378,13 @@ STR_CONFIG_SETTING_AUTOSCROLL_MAIN_VIEWPORT_FULLSCREEN          :ecranul princip
 STR_CONFIG_SETTING_AUTOSCROLL_MAIN_VIEWPORT                     :ecranul principal
 STR_CONFIG_SETTING_AUTOSCROLL_EVERY_VIEWPORT                    :fiecare ecran
 
-STR_CONFIG_SETTING_BRIBE                                        :Permite mituirea autorităţilor locale: {STRING}
+STR_CONFIG_SETTING_BRIBE                                        :Permite mituirea autorităților locale: {STRING}
 STR_CONFIG_SETTING_BRIBE_HELPTEXT                               :Permite companiilor să încerce să mituiască autoritatea locală. Daca încercarea este descoperită de către un inspector, compania nu va mai putea executa nici o acțiune în oraș timp de șase luni
 
 STR_CONFIG_SETTING_ALLOW_EXCLUSIVE                              :Permite cumpărarea de drepturi exclusive de transport: {STRING}
 STR_CONFIG_SETTING_ALLOW_EXCLUSIVE_HELPTEXT                     :Dacă o companie cumpără drepturi exclusive de transport într-un oraș, stațiile concurenței (de pasageri și mărfuri) nu vor primi niciun fel de marfă timp de un an
 
-STR_CONFIG_SETTING_ALLOW_FUND_BUILDINGS                         :Permite finaţarea clădirilor noi: {STRING}
+STR_CONFIG_SETTING_ALLOW_FUND_BUILDINGS                         :Permite finațarea clădirilor noi: {STRING}
 STR_CONFIG_SETTING_ALLOW_FUND_BUILDINGS_HELPTEXT                :Permite companiilor să doneze bani orașelor pentru construcția de noi locuințe
 
 STR_CONFIG_SETTING_ALLOW_FUND_ROAD                              :Permite finanțarea reconstrucției străzilor locale: {STRING}
@@ -1412,7 +1412,7 @@ STR_CONFIG_SETTING_CROSSING_WITH_COMPETITOR_HELPTEXT            :Permite constru
 
 STR_CONFIG_SETTING_STOP_ON_TOWN_ROAD                            :Permite construirea stațiilor pe drumurile deținute de orașe: {STRING}
 STR_CONFIG_SETTING_STOP_ON_TOWN_ROAD_HELPTEXT                   :Permite construirea de stații pe drumurile aflate în proprietatea orașelor
-STR_CONFIG_SETTING_STOP_ON_COMPETITOR_ROAD                      :Permite construirea staţiilor pe drumurile competitorilor: {STRING}
+STR_CONFIG_SETTING_STOP_ON_COMPETITOR_ROAD                      :Permite construirea stațiilor pe drumurile competitorilor: {STRING}
 STR_CONFIG_SETTING_STOP_ON_COMPETITOR_ROAD_HELPTEXT             :Permite construcția stațiilor pe drumurile construite de altă companie
 STR_CONFIG_SETTING_DYNAMIC_ENGINES_EXISTING_VEHICLES            :{WHITE}Schimbarea acestei setări nu este permisă când există vehicule în joc
 
@@ -1445,16 +1445,16 @@ STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES                        :Vehiculele nu e
 STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES_HELPTEXT               :După activare, toate modelele de vehicule rămân disponibile permanent după introducerea lor
 
 STR_CONFIG_SETTING_AUTORENEW_VEHICLE                            :Înnoire automată pentru vehiculele învechite: {STRING}
-STR_CONFIG_SETTING_AUTORENEW_VEHICLE_HELPTEXT                   :După activare, orice vehicul care este învechit va fi reînnoit automat când condițiile de înlocuire automată sunt îndeplinite
+STR_CONFIG_SETTING_AUTORENEW_VEHICLE_HELPTEXT                   :După activare, orice vehicul care este învechit va fi înnoit automat când condițiile de înlocuire automată sunt îndeplinite
 
-STR_CONFIG_SETTING_AUTORENEW_MONTHS                             :Autoreînnoire când vehiculul {STRING} vârsta maximă
-STR_CONFIG_SETTING_AUTORENEW_MONTHS_HELPTEXT                    :Vârsta aproximativă când un vehicul ar trebui autoreînnoit
+STR_CONFIG_SETTING_AUTORENEW_MONTHS                             :Autoînnoire când vehiculul {STRING} vârsta maximă
+STR_CONFIG_SETTING_AUTORENEW_MONTHS_HELPTEXT                    :Vârsta aproximativă când un vehicul ar trebui autoînnoit
 ###length 2
 STR_CONFIG_SETTING_AUTORENEW_MONTHS_VALUE_BEFORE                :{COMMA} {P 0 lună luni "de luni"} până la
 STR_CONFIG_SETTING_AUTORENEW_MONTHS_VALUE_AFTER                 :{COMMA} {P 0 lună luni "de luni"}
 
 STR_CONFIG_SETTING_AUTORENEW_MONEY                              :Fonduri minime pentru înnoire automată: {STRING}
-STR_CONFIG_SETTING_AUTORENEW_MONEY_HELPTEXT                     :Suma minimă care trebuie să rămână disponibilă atunci când se face autoreînnoirea
+STR_CONFIG_SETTING_AUTORENEW_MONEY_HELPTEXT                     :Suma minimă care trebuie să rămână disponibilă atunci când se face autoînnoirea
 
 STR_CONFIG_SETTING_ERRMSG_DURATION                              :Durata de afișare a mesajelor de eroare: {STRING}
 STR_CONFIG_SETTING_ERRMSG_DURATION_HELPTEXT                     :Durata afișării mesajelor de eroare în fereastra roșie. Unele mesaje de eroare (cele critice) nu sunt închise automat după trecerea acestei perioade, și trebuie închise manual.
@@ -1465,7 +1465,7 @@ STR_CONFIG_SETTING_HOVER_DELAY_VALUE                            :Plutește {COMM
 ###setting-zero-is-special
 STR_CONFIG_SETTING_HOVER_DELAY_DISABLED                         :Click dreapta
 
-STR_CONFIG_SETTING_POPULATION_IN_LABEL                          :Afişează populaţia unui oras lângă nume: {STRING}
+STR_CONFIG_SETTING_POPULATION_IN_LABEL                          :Afișează populația unui oras lângă nume: {STRING}
 STR_CONFIG_SETTING_POPULATION_IN_LABEL_HELPTEXT                 :Afișează populația orașelor în numele afișate pe hartă
 
 STR_CONFIG_SETTING_GRAPH_LINE_THICKNESS                         :Grosimea liniilor din grafice: {STRING}
@@ -1492,7 +1492,7 @@ STR_CONFIG_SETTING_INDUSTRY_DENSITY                             :Densitatea indu
 STR_CONFIG_SETTING_INDUSTRY_DENSITY_HELPTEXT                    :Stabilește câte industrii ar trebui generate și ce nivel ar trebui întreținut pe durata jocului
 
 STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE                        :Distanța maximă de la marginea hărții pentru rafinării: {STRING}
-STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE_HELPTEXT               :Rafinăriile de petrol vor fi construite doar la marginea hărţii, sau pe coastă, în cazul harţilor insulare
+STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE_HELPTEXT               :Rafinăriile de petrol vor fi construite doar la marginea hărții, sau pe coastă, în cazul harților insulare
 
 STR_CONFIG_SETTING_SNOWLINE_HEIGHT                              :Grosimea stratului de zăpadă: {STRING}
 STR_CONFIG_SETTING_SNOWLINE_HEIGHT_HELPTEXT                     :Controlează înălțimea de la care zăpada apare în peisajul sub-arctic. Zăpada afectează și generarea industriilor și cerințele de creștere a orașelor. Se poate modifica doar prin Editorul de scenarii sau este calculat prin „acoperirea cu zăpadă”
@@ -1524,7 +1524,7 @@ STR_CONFIG_SETTING_TREE_PLACER_HELPTEXT                         :Alegeți distri
 ###length 3
 STR_CONFIG_SETTING_TREE_PLACER_NONE                             :Niciunul
 STR_CONFIG_SETTING_TREE_PLACER_ORIGINAL                         :Original
-STR_CONFIG_SETTING_TREE_PLACER_IMPROVED                         :Îmbunătăţit
+STR_CONFIG_SETTING_TREE_PLACER_IMPROVED                         :Îmbunătățit
 
 STR_CONFIG_SETTING_ROAD_SIDE                                    :Autovehicule: {STRING}
 STR_CONFIG_SETTING_ROAD_SIDE_HELPTEXT                           :Alege banda pentru condus
@@ -1533,16 +1533,16 @@ STR_CONFIG_SETTING_ROAD_SIDE_HELPTEXT                           :Alege banda pen
 STR_CONFIG_SETTING_ROAD_SIDE_LEFT                               :Pe partea stângă
 STR_CONFIG_SETTING_ROAD_SIDE_RIGHT                              :Pe partea dreaptă
 
-STR_CONFIG_SETTING_HEIGHTMAP_ROTATION                           :Rotaţie hartă înălţimi: {STRING}
+STR_CONFIG_SETTING_HEIGHTMAP_ROTATION                           :Rotație hartă înălțimi: {STRING}
 STR_CONFIG_SETTING_HEIGHTMAP_ROTATION_TOOLTIP                   :Alegeți modul în care imaginea hărții de înălțime este rotită pentru a se potrivi în lumea jocului
 ###length 2
 STR_CONFIG_SETTING_HEIGHTMAP_ROTATION_COUNTER_CLOCKWISE         :Spre stânga
 STR_CONFIG_SETTING_HEIGHTMAP_ROTATION_CLOCKWISE                 :Spre dreapta
 
-STR_CONFIG_SETTING_SE_FLAT_WORLD_HEIGHT                         :Nivelul înălţimii pentru hărţile plane: {STRING}
+STR_CONFIG_SETTING_SE_FLAT_WORLD_HEIGHT                         :Nivelul înălțimii pentru hărțile plane: {STRING}
 ###length 2
-STR_CONFIG_SETTING_EDGES_NOT_EMPTY                              :{WHITE}Una sau mai multe suprafeţe din marginea nordică nu sunt goale
-STR_CONFIG_SETTING_EDGES_NOT_WATER                              :{WHITE}Una sau mai multe suprafeţe din marginea hărţii nu contin apă
+STR_CONFIG_SETTING_EDGES_NOT_EMPTY                              :{WHITE}Una sau mai multe suprafețe din marginea nordică nu sunt goale
+STR_CONFIG_SETTING_EDGES_NOT_WATER                              :{WHITE}Una sau mai multe suprafețe din marginea hărții nu contin apă
 
 STR_CONFIG_SETTING_STATION_SPREAD                               :Întinderea maximă a stațiilor: {STRING}
 STR_CONFIG_SETTING_STATION_SPREAD_HELPTEXT                      :Zona maximă în care o stație se poate întinde. Valorile mari vor încetini jocul
@@ -1550,7 +1550,7 @@ STR_CONFIG_SETTING_STATION_SPREAD_HELPTEXT                      :Zona maximă î
 STR_CONFIG_SETTING_SERVICEATHELIPAD                             :Service automat pentru elicoptere la helipaduri: {STRING}
 STR_CONFIG_SETTING_SERVICEATHELIPAD_HELPTEXT                    :Efectueaza service pentru elicoptere la fiecare aterizare, chiar dacă nu există hangar acolo
 
-STR_CONFIG_SETTING_LINK_TERRAFORM_TOOLBAR                       :Conectează bara de instrumente pentru peisaj cu cea de construcţii feroviare/auto/navale/aeriene: {STRING}
+STR_CONFIG_SETTING_LINK_TERRAFORM_TOOLBAR                       :Conectează bara de instrumente pentru peisaj cu cea de construcții feroviare/auto/navale/aeriene: {STRING}
 STR_CONFIG_SETTING_LINK_TERRAFORM_TOOLBAR_HELPTEXT              :La deschiderea unei bare de instrumente pentru construcția unor căi de transport, deschide și bara de instrumente pentru modificarea terenului
 
 STR_CONFIG_SETTING_SMALLMAP_LAND_COLOUR                         :Culoarea terenului folosită pentru harta mică: {STRING}
@@ -1579,7 +1579,7 @@ STR_CONFIG_SETTING_SCROLLMODE_LMB                               :Mută harta cu 
 STR_CONFIG_SETTING_SMOOTH_SCROLLING                             :Derulare ușoară vizor: {STRING}
 STR_CONFIG_SETTING_SMOOTH_SCROLLING_HELPTEXT                    :Controlează modul de deplasare a imaginii din ecranul principal când se face click pe harta mică sau când se execută o comandă de deplasare către un obiect anume de pe hartă. Dacă este activată, imaginea se deplasează în mod fluid, altfel imaginea sare direct la zona dorită
 
-STR_CONFIG_SETTING_MEASURE_TOOLTIP                              :Arată o indicaţie de distanţă la folosirea uneltelor de construcţie: {STRING}
+STR_CONFIG_SETTING_MEASURE_TOOLTIP                              :Arată o indicație de distanță la folosirea uneltelor de construcție: {STRING}
 STR_CONFIG_SETTING_MEASURE_TOOLTIP_HELPTEXT                     :Afișează distanțele în pătrățele și diferențele de înălțime la mișcarea mouse-ului în timpul operațiilor de construcție
 
 STR_CONFIG_SETTING_LIVERIES                                     :Arată culorile companiilor: {STRING}
@@ -1592,10 +1592,10 @@ STR_CONFIG_SETTING_LIVERIES_ALL                                 :Toate companiil
 STR_CONFIG_SETTING_PREFER_TEAMCHAT                              :Chat între membrii echipei folosind tasta <ENTER>: {STRING}
 STR_CONFIG_SETTING_PREFER_TEAMCHAT_HELPTEXT                     :Schimbă modul de afisare a conversatiei publice și a conversației interne a companiei, folosind tasta <ENTER> sau <Ctrl+ENTER>
 
-STR_CONFIG_SETTING_SCROLLWHEEL_MULTIPLIER                       :Viteza de derulare a hărtii pt rotiţa mouse-ului: {STRING}
+STR_CONFIG_SETTING_SCROLLWHEEL_MULTIPLIER                       :Viteza de derulare a hărtii pt rotița mouse-ului: {STRING}
 STR_CONFIG_SETTING_SCROLLWHEEL_MULTIPLIER_HELPTEXT              :Controlează senzitivitatea roatei de scroll a mouse-ului
 
-STR_CONFIG_SETTING_SCROLLWHEEL_SCROLLING                        :Funcţia roţii mouse-ului: {STRING}
+STR_CONFIG_SETTING_SCROLLWHEEL_SCROLLING                        :Funcția roții mouse-ului: {STRING}
 STR_CONFIG_SETTING_SCROLLWHEEL_SCROLLING_HELPTEXT               :Activează deplasarea imaginii folosind mouse cu roată de scroll bi-dimensională
 ###length 3
 STR_CONFIG_SETTING_SCROLLWHEEL_ZOOM                             :Zoom hartă
@@ -1631,7 +1631,7 @@ STR_CONFIG_SETTING_RIGHT_MOUSE_WND_CLOSE_NO                     :Nu
 STR_CONFIG_SETTING_RIGHT_MOUSE_WND_CLOSE_YES                    :Da
 STR_CONFIG_SETTING_RIGHT_MOUSE_WND_CLOSE_YES_EXCEPT_STICKY      :Da, mai puțin cele lipite
 
-STR_CONFIG_SETTING_DATE_FORMAT_IN_SAVE_NAMES                    :Foloseşte formatul datei {STRING} pentru numele salvărilor
+STR_CONFIG_SETTING_DATE_FORMAT_IN_SAVE_NAMES                    :Folosește formatul datei {STRING} pentru numele salvărilor
 STR_CONFIG_SETTING_DATE_FORMAT_IN_SAVE_NAMES_HELPTEXT           :Formatul datei in numele salvărilor
 ###length 3
 STR_CONFIG_SETTING_DATE_FORMAT_IN_SAVE_NAMES_LONG               :lung (31 Dec 2008)
@@ -1644,15 +1644,15 @@ STR_CONFIG_SETTING_PAUSE_ON_NEW_GAME_HELPTEXT                   :Când este acti
 STR_CONFIG_SETTING_COMMAND_PAUSE_LEVEL                          :Când jocul este în pauză permite: {STRING}
 STR_CONFIG_SETTING_COMMAND_PAUSE_LEVEL_HELPTEXT                 :Alege ce acțiuni se pot efectua cât timp jocul este în pauză
 ###length 4
-STR_CONFIG_SETTING_COMMAND_PAUSE_LEVEL_NO_ACTIONS               :nicio acţiune
-STR_CONFIG_SETTING_COMMAND_PAUSE_LEVEL_ALL_NON_CONSTRUCTION     :toate acţiunile non-construcție
+STR_CONFIG_SETTING_COMMAND_PAUSE_LEVEL_NO_ACTIONS               :nicio acțiune
+STR_CONFIG_SETTING_COMMAND_PAUSE_LEVEL_ALL_NON_CONSTRUCTION     :toate acțiunile non-construcție
 STR_CONFIG_SETTING_COMMAND_PAUSE_LEVEL_ALL_NON_LANDSCAPING      :toate exceptând modificarea peisajului
 STR_CONFIG_SETTING_COMMAND_PAUSE_LEVEL_ALL_ACTIONS              :toate acțiunile
 
-STR_CONFIG_SETTING_ADVANCED_VEHICLE_LISTS                       :Foloseşte lista avansată de vehicule: {STRING}
+STR_CONFIG_SETTING_ADVANCED_VEHICLE_LISTS                       :Folosește lista avansată de vehicule: {STRING}
 STR_CONFIG_SETTING_ADVANCED_VEHICLE_LISTS_HELPTEXT              :Activează folosirea listelor avansate de vehicule pentru a gruparea acestor vehicule
 
-STR_CONFIG_SETTING_LOADING_INDICATORS                           :Foloseşte indicatorii de încărcare: {STRING}
+STR_CONFIG_SETTING_LOADING_INDICATORS                           :Folosește indicatorii de încărcare: {STRING}
 STR_CONFIG_SETTING_LOADING_INDICATORS_HELPTEXT                  :Alege dacă indicatori de încărcare sunt afișați deasupra unor vehicule care sunt în proces de încărcare sau descărcare
 
 STR_CONFIG_SETTING_TIMETABLE_MODE                               :Unități de timp pentru orare: {STRING}
@@ -1667,7 +1667,7 @@ STR_CONFIG_SETTING_TIMETABLE_SHOW_ARRIVAL_DEPARTURE_HELPTEXT    :Arată timpii e
 STR_CONFIG_SETTING_QUICKGOTO                                    :Creare rapidă a comenzilor pentru vehicule: {STRING}
 STR_CONFIG_SETTING_QUICKGOTO_HELPTEXT                           :Preselectează cursorul "mergi la" când se deschide fereastra de comenzi
 
-STR_CONFIG_SETTING_DEFAULT_RAIL_TYPE                            :Tipul implicit de şină (după joc nou/încarcare joc): {STRING}
+STR_CONFIG_SETTING_DEFAULT_RAIL_TYPE                            :Tipul implicit de șină (după joc nou/încarcare joc): {STRING}
 STR_CONFIG_SETTING_DEFAULT_RAIL_TYPE_HELPTEXT                   :Tipul de cale feroviară care va fi ales la pornirea sau îmcărcarea jocului. 'Prima disponibilă' alege cel mai nou tip de cale feroviară și 'Cea mai folosită' alege tipul cel mai des folosit în acel moment.
 ###length 3
 STR_CONFIG_SETTING_DEFAULT_RAIL_TYPE_FIRST                      :Prima disponibilă
@@ -1677,7 +1677,7 @@ STR_CONFIG_SETTING_DEFAULT_RAIL_TYPE_MOST_USED                  :Cea mai folosit
 STR_CONFIG_SETTING_SHOW_TRACK_RESERVATION                       :Arată liniile rezervate: {STRING}
 STR_CONFIG_SETTING_SHOW_TRACK_RESERVATION_HELPTEXT              :Acordă căilor feroviare rezervate o culoare diferită pentru a depista mai ușor probleme cum ar fi trenuri refuzând intrarea în secțiuni bazate pe căi stabilite anterior
 
-STR_CONFIG_SETTING_PERSISTENT_BUILDINGTOOLS                     :Pastrează active instrumentele de construcţie după utilizare: {STRING}
+STR_CONFIG_SETTING_PERSISTENT_BUILDINGTOOLS                     :Pastrează active instrumentele de construcție după utilizare: {STRING}
 STR_CONFIG_SETTING_PERSISTENT_BUILDINGTOOLS_HELPTEXT            :Menține barele de construcție pentru tunele, poduri șamd deschise după folosire
 
 STR_CONFIG_SETTING_AUTO_REMOVE_SIGNALS                          :Elimină automat semnalele pe durata construcției șinelor: {STRING}
@@ -1725,16 +1725,16 @@ STR_CONFIG_SETTING_MAX_AIRCRAFT_HELPTEXT                        :Numărul maxim 
 STR_CONFIG_SETTING_MAX_SHIPS                                    :Nr. max. de nave per companie: {STRING}
 STR_CONFIG_SETTING_MAX_SHIPS_HELPTEXT                           :Numărul maxim de nave pe care o companie le poate deține
 
-STR_CONFIG_SETTING_AI_BUILDS_TRAINS                             :Dezactivează trenurile pentru jucătorii controlaţi de calculator: {STRING}
+STR_CONFIG_SETTING_AI_BUILDS_TRAINS                             :Dezactivează trenurile pentru jucătorii controlați de calculator: {STRING}
 STR_CONFIG_SETTING_AI_BUILDS_TRAINS_HELPTEXT                    :Prin activarea acestei opțiuni, jucătorul controlat de calculator nu poate construi trenuri
 
-STR_CONFIG_SETTING_AI_BUILDS_ROAD_VEHICLES                      :Dezactivează autovehiculele pentru jucătorii controlaţi de calculator: {STRING}
+STR_CONFIG_SETTING_AI_BUILDS_ROAD_VEHICLES                      :Dezactivează autovehiculele pentru jucătorii controlați de calculator: {STRING}
 STR_CONFIG_SETTING_AI_BUILDS_ROAD_VEHICLES_HELPTEXT             :Prin activarea acestei opțiuni, jucătorul controlat de calculator nu poate construi vehicule rutiere
 
-STR_CONFIG_SETTING_AI_BUILDS_AIRCRAFT                           :Dezactivează aeronavele pentru jucătorii controlaţi de calculator: {STRING}
+STR_CONFIG_SETTING_AI_BUILDS_AIRCRAFT                           :Dezactivează aeronavele pentru jucătorii controlați de calculator: {STRING}
 STR_CONFIG_SETTING_AI_BUILDS_AIRCRAFT_HELPTEXT                  :Prin activarea acestei opțiuni, jucătorul controlat de calculator nu poate construi aeronave
 
-STR_CONFIG_SETTING_AI_BUILDS_SHIPS                              :Dezactivează navele pentru jucătorii controlaţi de calculator: {STRING}
+STR_CONFIG_SETTING_AI_BUILDS_SHIPS                              :Dezactivează navele pentru jucătorii controlați de calculator: {STRING}
 STR_CONFIG_SETTING_AI_BUILDS_SHIPS_HELPTEXT                     :Prin activarea acestei opțiuni, jucătorul controlat de calculator nu poate construi nave
 
 STR_CONFIG_SETTING_AI_PROFILE                                   :Configurația implicită: {STRING}
@@ -1744,7 +1744,7 @@ STR_CONFIG_SETTING_AI_PROFILE_EASY                              :Ușor
 STR_CONFIG_SETTING_AI_PROFILE_MEDIUM                            :Mediu
 STR_CONFIG_SETTING_AI_PROFILE_HARD                              :Dificil
 
-STR_CONFIG_SETTING_AI_IN_MULTIPLAYER                            :Permite Inteligenţă Artificială în multiplayer: {STRING}
+STR_CONFIG_SETTING_AI_IN_MULTIPLAYER                            :Permite Inteligență Artificială în multiplayer: {STRING}
 STR_CONFIG_SETTING_AI_IN_MULTIPLAYER_HELPTEXT                   :Permite ca jucătorii controlați de AI să participe în jocuri multiplayer
 
 STR_CONFIG_SETTING_SCRIPT_MAX_OPCODES                           :Număr opcodes înainte de suspendarea scripturilor: {STRING}
@@ -1768,19 +1768,19 @@ STR_CONFIG_SETTING_SERVINT_VALUE                                :{COMMA} {P 0 zi
 ###setting-zero-is-special
 STR_CONFIG_SETTING_SERVINT_DISABLED                             :Dezactivat
 
-STR_CONFIG_SETTING_NOSERVICE                                    :Deactivare service când defecţiunile nu sunt active: {STRING}
+STR_CONFIG_SETTING_NOSERVICE                                    :Deactivare service când defecțiunile nu sunt active: {STRING}
 STR_CONFIG_SETTING_NOSERVICE_HELPTEXT                           :Dacă este activată, vehiculele nu vor întreținute dacă nu se pot defecta
 
 STR_CONFIG_SETTING_WAGONSPEEDLIMITS                             :Activează limite de viteză pentru vagoane: {STRING}
 STR_CONFIG_SETTING_WAGONSPEEDLIMITS_HELPTEXT                    :Dacă este activată, folosește și limita de viteză a vagoanelor pentru a stabili viteza maximă a trenului
 
-STR_CONFIG_SETTING_DISABLE_ELRAILS                              :Dezactivează şinele electrice: {STRING}
+STR_CONFIG_SETTING_DISABLE_ELRAILS                              :Dezactivează șinele electrice: {STRING}
 STR_CONFIG_SETTING_DISABLE_ELRAILS_HELPTEXT                     :Prin activarea acestei opțiuni, se dezactivează cerința de a avea cale feroviară electrificată pentru a putea folosi locomotive electrice pe această cale feroviară
 
-STR_CONFIG_SETTING_NEWS_ARRIVAL_FIRST_VEHICLE_OWN               :Sosirea primului vehicul la una din staţiile tale: {STRING}
+STR_CONFIG_SETTING_NEWS_ARRIVAL_FIRST_VEHICLE_OWN               :Sosirea primului vehicul la una din stațiile tale: {STRING}
 STR_CONFIG_SETTING_NEWS_ARRIVAL_FIRST_VEHICLE_OWN_HELPTEXT      :Afișează un ziar când o stație nouă a companiei primește primul vehicul
 
-STR_CONFIG_SETTING_NEWS_ARRIVAL_FIRST_VEHICLE_OTHER             :Sosirea primului vehicul la una din staţiile competitorilor: {STRING}
+STR_CONFIG_SETTING_NEWS_ARRIVAL_FIRST_VEHICLE_OTHER             :Sosirea primului vehicul la una din stațiile competitorilor: {STRING}
 STR_CONFIG_SETTING_NEWS_ARRIVAL_FIRST_VEHICLE_OTHER_HELPTEXT    :Afișează un ziar când o stație nouă a unui competitor primește primul vehicul
 
 STR_CONFIG_SETTING_NEWS_ACCIDENTS_DISASTERS                     :Accidente / dezastre: {STRING}
@@ -1789,7 +1789,7 @@ STR_CONFIG_SETTING_NEWS_ACCIDENTS_DISASTERS_HELPTEXT            :Afișează un z
 STR_CONFIG_SETTING_NEWS_ACCIDENT_OTHER                          :Accidente cu vehiculele concurenților: {STRING}
 STR_CONFIG_SETTING_NEWS_ACCIDENT_OTHER_HELPTEXT                 :Afișați un ziar despre vehiculele accidentate pentru concurenți
 
-STR_CONFIG_SETTING_NEWS_COMPANY_INFORMATION                     :Informaţii despre companie: {STRING}
+STR_CONFIG_SETTING_NEWS_COMPANY_INFORMATION                     :Informații despre companie: {STRING}
 STR_CONFIG_SETTING_NEWS_COMPANY_INFORMATION_HELPTEXT            :Afișează un ziar când o nouă companie este înființată, sau când o companie este pe cale de a intra în faliment
 
 STR_CONFIG_SETTING_NEWS_INDUSTRY_OPEN                           :Inaugurare industrii: {STRING}
@@ -1801,16 +1801,16 @@ STR_CONFIG_SETTING_NEWS_INDUSTRY_CLOSE_HELPTEXT                 :Afișează un z
 STR_CONFIG_SETTING_NEWS_ECONOMY_CHANGES                         :Schimbări economice: {STRING}
 STR_CONFIG_SETTING_NEWS_ECONOMY_CHANGES_HELPTEXT                :Afișează un ziar când apar schimbări globale ale economiei
 
-STR_CONFIG_SETTING_NEWS_INDUSTRY_CHANGES_COMPANY                :Schimbări de producţie ale industriilor partenere cu compania: {STRING}
+STR_CONFIG_SETTING_NEWS_INDUSTRY_CHANGES_COMPANY                :Schimbări de producție ale industriilor partenere cu compania: {STRING}
 STR_CONFIG_SETTING_NEWS_INDUSTRY_CHANGES_COMPANY_HELPTEXT       :Afișează un ziar când nivelul de producție al unei industrii, deservită de companie, se schimbă
 
-STR_CONFIG_SETTING_NEWS_INDUSTRY_CHANGES_OTHER                  :Schimbări de producţie ale industriilor partenere cu concurenţa: {STRING}
+STR_CONFIG_SETTING_NEWS_INDUSTRY_CHANGES_OTHER                  :Schimbări de producție ale industriilor partenere cu concurența: {STRING}
 STR_CONFIG_SETTING_NEWS_INDUSTRY_CHANGES_OTHER_HELPTEXT         :Afișează un ziar când nivelul de producție al unei industrii, deservită de competitori, se schimbă
 
-STR_CONFIG_SETTING_NEWS_INDUSTRY_CHANGES_UNSERVED               :Alte schimbări în producţia industrială: {STRING}
+STR_CONFIG_SETTING_NEWS_INDUSTRY_CHANGES_UNSERVED               :Alte schimbări în producția industrială: {STRING}
 STR_CONFIG_SETTING_NEWS_INDUSTRY_CHANGES_UNSERVED_HELPTEXT      :Afișează un ziar când nivelul de producție al unei industrii, neservită de companie sau competitori, se schimbă
 
-STR_CONFIG_SETTING_NEWS_ADVICE                                  :Sugestii / informaţii despre vehiculele companiei: {STRING}
+STR_CONFIG_SETTING_NEWS_ADVICE                                  :Sugestii / informații despre vehiculele companiei: {STRING}
 STR_CONFIG_SETTING_NEWS_ADVICE_HELPTEXT                         :Afișează mesaje referitoare la vehicule care trebuie inspectate
 
 STR_CONFIG_SETTING_NEWS_NEW_VEHICLES                            :Vehicule noi: {STRING}
@@ -1819,17 +1819,17 @@ STR_CONFIG_SETTING_NEWS_NEW_VEHICLES_HELPTEXT                   :Afișează un z
 STR_CONFIG_SETTING_NEWS_CHANGES_ACCEPTANCE                      :Schimbări ale acceptării mărfurilor: {STRING}
 STR_CONFIG_SETTING_NEWS_CHANGES_ACCEPTANCE_HELPTEXT             :Afișează mesaje referitoare la modificarea tipurilor de cargo acceptate de către stații
 
-STR_CONFIG_SETTING_NEWS_SUBSIDIES                               :Subvenţii: {STRING}
+STR_CONFIG_SETTING_NEWS_SUBSIDIES                               :Subvenții: {STRING}
 STR_CONFIG_SETTING_NEWS_SUBSIDIES_HELPTEXT                      :Afișează ziarul evenimentelor legate de subvenții
 
-STR_CONFIG_SETTING_NEWS_GENERAL_INFORMATION                     :Informaţii generale: {STRING}
+STR_CONFIG_SETTING_NEWS_GENERAL_INFORMATION                     :Informații generale: {STRING}
 STR_CONFIG_SETTING_NEWS_GENERAL_INFORMATION_HELPTEXT            :Afișează ziarul despre evenimentele generale, precum achizițiile de drepturi exclusive sau finanțările reconstrucțiilor de drumuri
 ###length 3
 STR_CONFIG_SETTING_NEWS_MESSAGES_OFF                            :Oprit
 STR_CONFIG_SETTING_NEWS_MESSAGES_SUMMARY                        :Pe scurt
 STR_CONFIG_SETTING_NEWS_MESSAGES_FULL                           :Pe larg
 
-STR_CONFIG_SETTING_COLOURED_NEWS_YEAR                           :Ştirile color apar în: {STRING}
+STR_CONFIG_SETTING_COLOURED_NEWS_YEAR                           :știrile color apar în: {STRING}
 STR_CONFIG_SETTING_COLOURED_NEWS_YEAR_HELPTEXT                  :Anul începând cu care anunțurile din ziar sunt tipărite color. Înainte de acest an, anunturile sunt monocrome (alb/negru)
 STR_CONFIG_SETTING_STARTING_YEAR                                :Anul de început al jocului: {STRING}
 
@@ -1846,20 +1846,20 @@ STR_CONFIG_SETTING_ECONOMY_TYPE_ORIGINAL                        :Original
 STR_CONFIG_SETTING_ECONOMY_TYPE_SMOOTH                          :Lin
 STR_CONFIG_SETTING_ECONOMY_TYPE_FROZEN                          :Înghețată
 
-STR_CONFIG_SETTING_FEEDER_PAYMENT_SHARE                         :Procentul din profitul pe secţiune care să fie plătit pentru alimentare: {STRING}
-STR_CONFIG_SETTING_FEEDER_PAYMENT_SHARE_HELPTEXT                :Procentul din câştig care este oferit legăturilor intermediare pentru alimentare, oferind mai mult control asupra încasărilor
+STR_CONFIG_SETTING_FEEDER_PAYMENT_SHARE                         :Procentul din profitul pe secțiune care să fie plătit pentru alimentare: {STRING}
+STR_CONFIG_SETTING_FEEDER_PAYMENT_SHARE_HELPTEXT                :Procentul din câștig care este oferit legăturilor intermediare pentru alimentare, oferind mai mult control asupra încasărilor
 
 STR_CONFIG_SETTING_DRAG_SIGNALS_DENSITY                         :Când se trage cu mouse-ul, plasează semnale la fiecare: {STRING}
 STR_CONFIG_SETTING_DRAG_SIGNALS_DENSITY_HELPTEXT                :Configurează distanța la care se vor construi semnale pe șină până la următorul obstacol (semnal, intersecție), dacă se trage cu mausul
 STR_CONFIG_SETTING_DRAG_SIGNALS_DENSITY_VALUE                   :{COMMA} {P 0 pătrățel pătrățele "de pătrățele"}
-STR_CONFIG_SETTING_DRAG_SIGNALS_FIXED_DISTANCE                  :La plasarea mai multor semale, păstrează distanţa fixă între acestea: {STRING}
+STR_CONFIG_SETTING_DRAG_SIGNALS_FIXED_DISTANCE                  :La plasarea mai multor semale, păstrează distanța fixă între acestea: {STRING}
 STR_CONFIG_SETTING_DRAG_SIGNALS_FIXED_DISTANCE_HELPTEXT         :Alege modul plasării de semnale la Ctrl+tragerea semnalelor. Dacă este dezactivat, semnalele sunt plasate în jurul tunelelor sau podurilor, pentru evitarea segmentelor lungi fără semnale. Dacă este activat, semnalele sunt plasate la fiecare n dale, ușurând alinierea semnalelor pe linii paralele
 
-STR_CONFIG_SETTING_SEMAPHORE_BUILD_BEFORE_DATE                  :Construieşte automat semafoare înainte de: {STRING}
+STR_CONFIG_SETTING_SEMAPHORE_BUILD_BEFORE_DATE                  :Construiește automat semafoare înainte de: {STRING}
 STR_CONFIG_SETTING_SEMAPHORE_BUILD_BEFORE_DATE_HELPTEXT         :Alege anul din care se vor folosi semnale electrice pe calea feroviară. Înainte de acest an, se vor folosi semnale non-electrice care au aceeasi funcționalitate dar arată diferit
 
 STR_CONFIG_SETTING_CYCLE_SIGNAL_TYPES                           :Ciclu prin tipurile de semnal: {STRING}
-STR_CONFIG_SETTING_CYCLE_SIGNAL_TYPES_HELPTEXT                  :Selectează între care tipuri de semnale să se cicleze când se apasă Ctrl+Click pe un semnal folosind unealta de construcţie
+STR_CONFIG_SETTING_CYCLE_SIGNAL_TYPES_HELPTEXT                  :Selectează între care tipuri de semnale să se cicleze când se apasă Ctrl+Click pe un semnal folosind unealta de construcție
 ###length 2
 STR_CONFIG_SETTING_CYCLE_SIGNAL_PBS                             :Doar avansat
 STR_CONFIG_SETTING_CYCLE_SIGNAL_ALL                             :Toate vizibile
@@ -1870,8 +1870,8 @@ STR_CONFIG_SETTING_SIGNAL_GUI_MODE_HELPTEXT                     :Alege ce tipuri
 STR_CONFIG_SETTING_SIGNAL_GUI_MODE_PATH                         :Doar semnale de cale
 STR_CONFIG_SETTING_SIGNAL_GUI_MODE_ALL_CYCLE_PATH               :Toate semnalele
 
-STR_CONFIG_SETTING_TOWN_LAYOUT                                  :Modelul drumurilor pentru oraşele noi: {STRING}
-STR_CONFIG_SETTING_TOWN_LAYOUT_HELPTEXT                         :Poziţionarea sistemului rutier în oraşe
+STR_CONFIG_SETTING_TOWN_LAYOUT                                  :Modelul drumurilor pentru orașele noi: {STRING}
+STR_CONFIG_SETTING_TOWN_LAYOUT_HELPTEXT                         :Poziționarea sistemului rutier în orașe
 ###length 5
 STR_CONFIG_SETTING_TOWN_LAYOUT_DEFAULT                          :original
 STR_CONFIG_SETTING_TOWN_LAYOUT_BETTER_ROADS                     :drumuri mai bune
@@ -1879,7 +1879,7 @@ STR_CONFIG_SETTING_TOWN_LAYOUT_2X2_GRID                         :grilă 2x2
 STR_CONFIG_SETTING_TOWN_LAYOUT_3X3_GRID                         :grilă 3x3
 STR_CONFIG_SETTING_TOWN_LAYOUT_RANDOM                           :aleator
 
-STR_CONFIG_SETTING_ALLOW_TOWN_ROADS                             :Oraşele pot construi drumuri: {STRING}
+STR_CONFIG_SETTING_ALLOW_TOWN_ROADS                             :Orașele pot construi drumuri: {STRING}
 STR_CONFIG_SETTING_ALLOW_TOWN_ROADS_HELPTEXT                    :Permite ca orașele să construiască șosele pentru a se dezvolta. Dezactivează pentru a nu permite orașelor să construiască independent șosele
 STR_CONFIG_SETTING_ALLOW_TOWN_LEVEL_CROSSINGS                   :Orașele au voie să construiască treceri la nivel cu calea ferată: {STRING}
 STR_CONFIG_SETTING_ALLOW_TOWN_LEVEL_CROSSINGS_HELPTEXT          :Dacă este activată, orașele vor putea să construiască treceri la nivel cu calea ferată
@@ -1887,12 +1887,12 @@ STR_CONFIG_SETTING_ALLOW_TOWN_LEVEL_CROSSINGS_HELPTEXT          :Dacă este acti
 STR_CONFIG_SETTING_NOISE_LEVEL                                  :Limitează amplasarea aeroportului în funcție de nivelul de zgomot: {STRING}
 STR_CONFIG_SETTING_NOISE_LEVEL_HELPTEXT                         :Permiteți orașelor să blocheze construcția aeroportului pe baza nivelului de acceptare a zgomotului, care se bazează pe populația orașului și pe dimensiunea și distanța aeroportului. Dacă această setare este dezactivată, orașele permit doar două aeroporturi, cu excepția cazului în care atitudinea autorităților locale este setată la „Permisiv”.
 
-STR_CONFIG_SETTING_TOWN_FOUNDING                                :Crearea oraşelor în joc: {STRING}
+STR_CONFIG_SETTING_TOWN_FOUNDING                                :Crearea orașelor în joc: {STRING}
 STR_CONFIG_SETTING_TOWN_FOUNDING_HELPTEXT                       :Dacă este activată, jucătorii pot fonda noi orașe în joc
 ###length 3
 STR_CONFIG_SETTING_TOWN_FOUNDING_FORBIDDEN                      :nepermis
 STR_CONFIG_SETTING_TOWN_FOUNDING_ALLOWED                        :permis
-STR_CONFIG_SETTING_TOWN_FOUNDING_ALLOWED_CUSTOM_LAYOUT          :permis, aspect particularizat al oraşului
+STR_CONFIG_SETTING_TOWN_FOUNDING_ALLOWED_CUSTOM_LAYOUT          :permis, aspect particularizat al orașului
 
 STR_CONFIG_SETTING_TOWN_CARGOGENMODE                            :Modalitatea de generare a cargoului dintr-un oraș: {STRING}
 STR_CONFIG_SETTING_TOWN_CARGOGENMODE_HELPTEXT                   :Câtă marfa este produsă de casele dintr-un oraș, relativ la populația totală a orașului.{}Creștere pătratică: Un oraș de 2 ori mai mare generează de 4 ori mai mulți pasageri.{}Creștere liniară: Un oraș de 2 ori mai mare generează de 4 ori mai mulți pasageri.
@@ -1900,7 +1900,7 @@ STR_CONFIG_SETTING_TOWN_CARGOGENMODE_HELPTEXT                   :Câtă marfa es
 STR_CONFIG_SETTING_TOWN_CARGOGENMODE_ORIGINAL                   :Pătratică (originală)
 STR_CONFIG_SETTING_TOWN_CARGOGENMODE_BITCOUNT                   :Liniar
 
-STR_CONFIG_SETTING_EXTRA_TREE_PLACEMENT                         :Poziţionarea copacilor în joc: {STRING}
+STR_CONFIG_SETTING_EXTRA_TREE_PLACEMENT                         :Poziționarea copacilor în joc: {STRING}
 STR_CONFIG_SETTING_EXTRA_TREE_PLACEMENT_HELPTEXT                :Controlează apariția aleatoare a copacilor în joc. Este posibil ca această opțiune să afecteze industrii care depind de creșterea copacilor, cum ar fi fabricile de cherestea
 ###length 4
 STR_CONFIG_SETTING_EXTRA_TREE_PLACEMENT_NO_SPREAD               :Cresc dar nu se extind {RED}(strică fabrica de cherestea)
@@ -1908,10 +1908,10 @@ STR_CONFIG_SETTING_EXTRA_TREE_PLACEMENT_SPREAD_RAINFOREST       :Cresc dar se ex
 STR_CONFIG_SETTING_EXTRA_TREE_PLACEMENT_SPREAD_ALL              :Cresc și se extind peste tot
 STR_CONFIG_SETTING_EXTRA_TREE_PLACEMENT_NO_GROWTH_NO_SPREAD     :Nu cresc, nu se extind {RED}(strică fabrica de cherestea)
 
-STR_CONFIG_SETTING_TOOLBAR_POS                                  :Poziţia barei principale de instrumente: {STRING}
-STR_CONFIG_SETTING_TOOLBAR_POS_HELPTEXT                         :Poziţia orizontală a barei principale în partea de sus a ecranului
-STR_CONFIG_SETTING_STATUSBAR_POS                                :Poziţia barei de stare: {STRING}
-STR_CONFIG_SETTING_STATUSBAR_POS_HELPTEXT                       :Poziţia orizontală a barei principale în partea de jos a ecranului
+STR_CONFIG_SETTING_TOOLBAR_POS                                  :Poziția barei principale de instrumente: {STRING}
+STR_CONFIG_SETTING_TOOLBAR_POS_HELPTEXT                         :Poziția orizontală a barei principale în partea de sus a ecranului
+STR_CONFIG_SETTING_STATUSBAR_POS                                :Poziția barei de stare: {STRING}
+STR_CONFIG_SETTING_STATUSBAR_POS_HELPTEXT                       :Poziția orizontală a barei principale în partea de jos a ecranului
 STR_CONFIG_SETTING_SNAP_RADIUS                                  :Raza "magnetică" a ferestrelor: {STRING}
 STR_CONFIG_SETTING_SNAP_RADIUS_HELPTEXT                         :Distanța dintre ferestre înainte ca fereastra mutată să fie alipită automat de ferestrele învecinate
 STR_CONFIG_SETTING_SNAP_RADIUS_VALUE                            :{COMMA} {P 0 pixel pixeli "de pixeli"}
@@ -1942,8 +1942,8 @@ STR_CONFIG_SETTING_SPRITE_ZOOM_LVL_MIN                          :4x
 STR_CONFIG_SETTING_SPRITE_ZOOM_LVL_IN_2X                        :2x
 STR_CONFIG_SETTING_SPRITE_ZOOM_LVL_NORMAL                       :1x
 
-STR_CONFIG_SETTING_TOWN_GROWTH                                  :Viteza de dezvoltare a oraşului: {STRING}
-STR_CONFIG_SETTING_TOWN_GROWTH_HELPTEXT                         :Viteza creşterii oraşelor
+STR_CONFIG_SETTING_TOWN_GROWTH                                  :Viteza de dezvoltare a orașului: {STRING}
+STR_CONFIG_SETTING_TOWN_GROWTH_HELPTEXT                         :Viteza creșterii orașelor
 ###length 5
 STR_CONFIG_SETTING_TOWN_GROWTH_NONE                             :Deloc
 STR_CONFIG_SETTING_TOWN_GROWTH_SLOW                             :Lentă
@@ -1951,12 +1951,12 @@ STR_CONFIG_SETTING_TOWN_GROWTH_NORMAL                           :Normală
 STR_CONFIG_SETTING_TOWN_GROWTH_FAST                             :Rapidă
 STR_CONFIG_SETTING_TOWN_GROWTH_VERY_FAST                        :Foarte rapidă
 
-STR_CONFIG_SETTING_LARGER_TOWNS                                 :Proporţia oraşelor care vor deveni mari: {STRING}
+STR_CONFIG_SETTING_LARGER_TOWNS                                 :Proporția orașelor care vor deveni mari: {STRING}
 STR_CONFIG_SETTING_LARGER_TOWNS_HELPTEXT                        :Numărul de orașe care devin mari, deci un oraș care pornește mai mare crește mai rapid
 STR_CONFIG_SETTING_LARGER_TOWNS_VALUE                           :1 din {COMMA}
 ###setting-zero-is-special
 STR_CONFIG_SETTING_LARGER_TOWNS_DISABLED                        :deloc
-STR_CONFIG_SETTING_CITY_SIZE_MULTIPLIER                         :Multiplicator iniţial dimensiune oraş: {STRING}
+STR_CONFIG_SETTING_CITY_SIZE_MULTIPLIER                         :Multiplicator inițial dimensiune oraș: {STRING}
 STR_CONFIG_SETTING_CITY_SIZE_MULTIPLIER_HELPTEXT                :Dimensiunea medie a orașelor mari față de orașele normale, la începutul jocului
 
 STR_CONFIG_SETTING_LINKGRAPH_RECALC_INTERVAL                    :Actualizează graficul de distribuție la fiecare {STRING}
@@ -1966,7 +1966,7 @@ STR_CONFIG_SETTING_LINKGRAPH_RECALC_TIME_HELPTEXT               :Durată de timp
 
 STR_CONFIG_SETTING_DISTRIBUTION_PAX                             :Modalitatea de distribuire a pasagerilor: {STRING}
 STR_CONFIG_SETTING_DISTRIBUTION_PAX_HELPTEXT                    :"Simetric" înseamnă că aproximativ același număr de pasageri va fi transportat din stația A spre stația B, precum de la B la A. "Asimetric" presupune transportul unui număr arbitrar de pasageri în fiecare direcție. "Manual" înseamnă că repartizarea pasagerilor nu va fi automatizată.
-STR_CONFIG_SETTING_DISTRIBUTION_MAIL                            :Modalitatea de distribuire a poştei: {STRING}
+STR_CONFIG_SETTING_DISTRIBUTION_MAIL                            :Modalitatea de distribuire a poștei: {STRING}
 STR_CONFIG_SETTING_DISTRIBUTION_MAIL_HELPTEXT                   :"Simetric" înseamnă că aproximativ aceeași cantitate de poștă va fi expediată din stația A spre stația B, precum de la B la A. "Asimetric" presupune expedierea de cantități arbitrare de poștă în fiecare direcție. "Manual" înseamnă că repartizarea poștei nu va fi automatizată.
 STR_CONFIG_SETTING_DISTRIBUTION_ARMOURED                        :Modalitatea de distribuire pentru clasa de cargo BLINDAT: {STRING}
 STR_CONFIG_SETTING_DISTRIBUTION_ARMOURED_HELPTEXT               :Clasa de marfă ARMORED conține obiecte de valoare în climat temperat, diamante în climat subtropical sau aur în climat subarctic. NewGRF-urile pot schimba asta. „Simetric” înseamnă că aproximativ aceeași cantitate din acea marfă va fi trimisă de la o stație A la o stație B ca de la B la A. „Asimetric” înseamnă că cantități arbitrare ale acelei mărfuri pot fi trimise în ambele direcții. „Manual” înseamnă că nu va avea loc nicio distribuție automată pentru acea marfă. Este recomandat să setați acest lucru la asimetric sau manual atunci când jucați subarctic sau subtropical, deoarece băncile doar primesc bunuri in aceste climate. Pentru climatul temperat, puteți alege și simetric, deoarece băncile vor trimite obiectele de valoare înapoi la banca de origine a unei încărcături.
@@ -1977,20 +1977,20 @@ STR_CONFIG_SETTING_DISTRIBUTION_MANUAL                          :manual
 STR_CONFIG_SETTING_DISTRIBUTION_ASYMMETRIC                      :asimetric
 STR_CONFIG_SETTING_DISTRIBUTION_SYMMETRIC                       :simetric
 
-STR_CONFIG_SETTING_LINKGRAPH_ACCURACY                           :Acurateţea distribuţiei: {STRING}
+STR_CONFIG_SETTING_LINKGRAPH_ACCURACY                           :Acuratețea distribuției: {STRING}
 STR_CONFIG_SETTING_LINKGRAPH_ACCURACY_HELPTEXT                  :Cu cât setezi o valoare mai mare, cu atât mai mult timp va lua calcularea graficului de conexiuni. Dacă durează prea mult, vei sesiza întârzieri. Iar dacă setezi o valoare mică, distribuția va fi imprecisă și ai putea sesiza că anumite mărfuri nu sunt trimise unde te aștepți să ajungă.
 
-STR_CONFIG_SETTING_DEMAND_DISTANCE                              :Efectul distanţei asupra cererii: {STRING}
+STR_CONFIG_SETTING_DEMAND_DISTANCE                              :Efectul distanței asupra cererii: {STRING}
 STR_CONFIG_SETTING_DEMAND_DISTANCE_HELPTEXT                     :Dacă setezi această valoare peste 0, distanța dintre stația origine A al mărfii și o posibilă stație B va afecta cantitatea de marfă trimisă din punctul A în B. Cu cât e mai departe B de A cu atât va fi mai mică cantitatea de marfă transportată. Cu cât mărești această valoare, cu atât mai puțină marfă se livrează spre destinațiile îndepărtate si cu atât mai multă la cele mai apropiate.
 STR_CONFIG_SETTING_DEMAND_SIZE                                  :Cantitatea de cargo la întoarcere pentru modul simetric: {STRING}
 STR_CONFIG_SETTING_DEMAND_SIZE_HELPTEXT                         :O valoare sub 100% face distribuția simetrică să se comporte mai mult ca una asimetrică. Mai puțină marfă va fi trimisă forțat înapoi dacă o anumită cantitate este trimisă spre o stație. Dacă o setezi la 0%, distribuția simetrică se va comporta la fel ca cea asimetrică.
 
-STR_CONFIG_SETTING_SHORT_PATH_SATURATION                        :Saturaţia căilor de capacitate mică înainte de a utiliza căi de capacitate mare: {STRING}
+STR_CONFIG_SETTING_SHORT_PATH_SATURATION                        :Saturația căilor de capacitate mică înainte de a utiliza căi de capacitate mare: {STRING}
 STR_CONFIG_SETTING_SHORT_PATH_SATURATION_HELPTEXT               :Adesea, există mai multe căi între două stații date. Cargodist va satura mai întâi calea cea mai scurtă, apoi va folosi a doua cea mai scurtă cale până când aceasta este saturată și așa mai departe. Saturația este determinată de o estimare a capacității și a utilizării planificate. Odată ce a saturat toate căile, dacă mai rămâne cerere, va supraîncărca toate căile, preferându-le pe cele cu capacitate mare. Totuși, de cele mai multe ori algoritmul nu va estima capacitatea cu acuratețe. Această setare vă permite să specificați până la ce procent o cale mai scurtă trebuie să fie saturată în prima trecere înainte de a alege următoarea mai lungă. Setați-l la mai puțin de 100% pentru a evita stațiile supraaglomerate în caz de capacitate supraestimată.
 
 STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY                  :Unitate viteză (terestru): {STRING}
 STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_NAUTICAL         :Unități de viteză (nautice): {STRING}
-STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_HELPTEXT         :Afişează viteza în interfaţă folosind unităţile selectate
+STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_HELPTEXT         :Afișează viteza în interfață folosind unitățile selectate
 ###length 5
 STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_IMPERIAL         :Imperial (mph)
 STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_METRIC           :Metric (km/h)
@@ -1999,35 +1999,35 @@ STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_GAMEUNITS        :Unități de jo
 STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_KNOTS            :Noduri
 
 STR_CONFIG_SETTING_LOCALISATION_UNITS_POWER                     :Unitate putere vehicule: {STRING}
-STR_CONFIG_SETTING_LOCALISATION_UNITS_POWER_HELPTEXT            :Afişează puterea vehiculelor în interfaţă folosind unităţile selectate
+STR_CONFIG_SETTING_LOCALISATION_UNITS_POWER_HELPTEXT            :Afișează puterea vehiculelor în interfață folosind unitățile selectate
 ###length 3
 STR_CONFIG_SETTING_LOCALISATION_UNITS_POWER_IMPERIAL            :Imperial (cp)
 STR_CONFIG_SETTING_LOCALISATION_UNITS_POWER_METRIC              :Metric (cp)
 STR_CONFIG_SETTING_LOCALISATION_UNITS_POWER_SI                  :SI (kW)
 
 STR_CONFIG_SETTING_LOCALISATION_UNITS_WEIGHT                    :Unitate pentru greutate: {STRING}
-STR_CONFIG_SETTING_LOCALISATION_UNITS_WEIGHT_HELPTEXT           :Afişează greutatea în interfaţă folosind unităţile selectate
+STR_CONFIG_SETTING_LOCALISATION_UNITS_WEIGHT_HELPTEXT           :Afișează greutatea în interfață folosind unitățile selectate
 ###length 3
 STR_CONFIG_SETTING_LOCALISATION_UNITS_WEIGHT_IMPERIAL           :Imperial (t/tonă scurtă)
 STR_CONFIG_SETTING_LOCALISATION_UNITS_WEIGHT_METRIC             :Metric (t/tonă)
 STR_CONFIG_SETTING_LOCALISATION_UNITS_WEIGHT_SI                 :SI (kg)
 
 STR_CONFIG_SETTING_LOCALISATION_UNITS_VOLUME                    :Unitate volum: {STRING}
-STR_CONFIG_SETTING_LOCALISATION_UNITS_VOLUME_HELPTEXT           :Afişează volumele în interfaţă folosind unităţile selectate
+STR_CONFIG_SETTING_LOCALISATION_UNITS_VOLUME_HELPTEXT           :Afișează volumele în interfață folosind unitățile selectate
 ###length 3
 STR_CONFIG_SETTING_LOCALISATION_UNITS_VOLUME_IMPERIAL           :Imperial (gal)
 STR_CONFIG_SETTING_LOCALISATION_UNITS_VOLUME_METRIC             :Metric (l)
 STR_CONFIG_SETTING_LOCALISATION_UNITS_VOLUME_SI                 :SI (m³)
 
-STR_CONFIG_SETTING_LOCALISATION_UNITS_FORCE                     :Unitate efort de tracţiune: {STRING}
-STR_CONFIG_SETTING_LOCALISATION_UNITS_FORCE_HELPTEXT            :Afişează efortul de tracţiune, denumit şi forţa de tracţiune, în interfaţă folosind unităţile selectate
+STR_CONFIG_SETTING_LOCALISATION_UNITS_FORCE                     :Unitate efort de tracțiune: {STRING}
+STR_CONFIG_SETTING_LOCALISATION_UNITS_FORCE_HELPTEXT            :Afișează efortul de tracțiune, denumit și forța de tracțiune, în interfață folosind unitățile selectate
 ###length 3
 STR_CONFIG_SETTING_LOCALISATION_UNITS_FORCE_IMPERIAL            :Imperial (lbf)
 STR_CONFIG_SETTING_LOCALISATION_UNITS_FORCE_METRIC              :Metric (kgf)
 STR_CONFIG_SETTING_LOCALISATION_UNITS_FORCE_SI                  :SI (kN)
 
-STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT                    :Unitate înălţime: {STRING}
-STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT_HELPTEXT           :Afişează înălţimile în interfaţă folosind unităţile selectate
+STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT                    :Unitate înălțime: {STRING}
+STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT_HELPTEXT           :Afișează înălțimile în interfață folosind unitățile selectate
 ###length 3
 STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT_IMPERIAL           :Imperial (ft)
 STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT_METRIC             :Metric (m)
@@ -2036,25 +2036,25 @@ STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT_SI                 :SI (m)
 STR_CONFIG_SETTING_LOCALISATION                                 :Localizare
 STR_CONFIG_SETTING_GRAPHICS                                     :Grafică
 STR_CONFIG_SETTING_SOUND                                        :Efecte sonore
-STR_CONFIG_SETTING_INTERFACE                                    :Interfaţă
+STR_CONFIG_SETTING_INTERFACE                                    :Interfață
 STR_CONFIG_SETTING_INTERFACE_GENERAL                            :General
 STR_CONFIG_SETTING_INTERFACE_VIEWPORTS                          :Câmpuri vizuale
-STR_CONFIG_SETTING_INTERFACE_CONSTRUCTION                       :Construcţie
+STR_CONFIG_SETTING_INTERFACE_CONSTRUCTION                       :Construcție
 STR_CONFIG_SETTING_ADVISORS                                     :Știri / Consilieri
 STR_CONFIG_SETTING_COMPANY                                      :Companie
 STR_CONFIG_SETTING_ACCOUNTING                                   :Contabilitate
 STR_CONFIG_SETTING_VEHICLES                                     :Vehicule
 STR_CONFIG_SETTING_VEHICLES_PHYSICS                             :Fizică
-STR_CONFIG_SETTING_VEHICLES_ROUTING                             :Direcţionare
+STR_CONFIG_SETTING_VEHICLES_ROUTING                             :Direcționare
 STR_CONFIG_SETTING_LIMITATIONS                                  :Limitări
 STR_CONFIG_SETTING_ACCIDENTS                                    :Dezastre / Accidente
 STR_CONFIG_SETTING_GENWORLD                                     :Generare lume
 STR_CONFIG_SETTING_ENVIRONMENT                                  :Mediu
 STR_CONFIG_SETTING_ENVIRONMENT_AUTHORITIES                      :Autorități
-STR_CONFIG_SETTING_ENVIRONMENT_TOWNS                            :Oraşe
+STR_CONFIG_SETTING_ENVIRONMENT_TOWNS                            :Orașe
 STR_CONFIG_SETTING_ENVIRONMENT_INDUSTRIES                       :Industrii
-STR_CONFIG_SETTING_ENVIRONMENT_CARGODIST                        :Distribuţie cargo
-STR_CONFIG_SETTING_AI                                           :Concurenţi
+STR_CONFIG_SETTING_ENVIRONMENT_CARGODIST                        :Distribuție cargo
+STR_CONFIG_SETTING_AI                                           :Concurenți
 STR_CONFIG_SETTING_AI_NPC                                       :Jucători virtuali
 STR_CONFIG_SETTING_NETWORK                                      :Rețea
 
@@ -2065,7 +2065,7 @@ STR_CONFIG_SETTING_PATHFINDER_FOR_ROAD_VEHICLES_HELPTEXT        :Algoritmul de r
 STR_CONFIG_SETTING_PATHFINDER_FOR_SHIPS                         :Algoritm de rutare pentru nave: {STRING}
 STR_CONFIG_SETTING_PATHFINDER_FOR_SHIPS_HELPTEXT                :Algoritmul de rutare folosit pentru nave
 STR_CONFIG_SETTING_REVERSE_AT_SIGNALS                           :Întoarcere automată la semafoare: {STRING}
-STR_CONFIG_SETTING_REVERSE_AT_SIGNALS_HELPTEXT                  :Permite trenurilor să întoarcă la semafor, dacă aşteaptă de mult timp
+STR_CONFIG_SETTING_REVERSE_AT_SIGNALS_HELPTEXT                  :Permite trenurilor să întoarcă la semafor, dacă așteaptă de mult timp
 ###length 2
 STR_CONFIG_SETTING_PATHFINDER_NPF                               :NPF
 STR_CONFIG_SETTING_PATHFINDER_YAPF                              :YAPF {BLUE}(Recomandat)
@@ -2115,9 +2115,9 @@ STR_INTRO_NEWGRF_SETTINGS                                       :{BLACK}Setări 
 STR_INTRO_ONLINE_CONTENT                                        :{BLACK}Resurse online
 STR_INTRO_AI_SETTINGS                                           :{BLACK}Setări AI
 STR_INTRO_GAMESCRIPT_SETTINGS                                   :{BLACK}Setări pentru scriptul jocului
-STR_INTRO_QUIT                                                  :{BLACK}Ieşire
+STR_INTRO_QUIT                                                  :{BLACK}Ieșire
 
-STR_INTRO_TOOLTIP_NEW_GAME                                      :{BLACK}Începere joc nou. Ctrl+Click pentru a sări peste fereastra de configuraţie a harţii
+STR_INTRO_TOOLTIP_NEW_GAME                                      :{BLACK}Începere joc nou. Ctrl+Click pentru a sări peste fereastra de configurație a harții
 STR_INTRO_TOOLTIP_LOAD_GAME                                     :{BLACK}Încarcă un joc salvat
 STR_INTRO_TOOLTIP_PLAY_HEIGHTMAP                                :{BLACK}Începe un joc nou folosind o hartă topografică pentru generarea terenului
 STR_INTRO_TOOLTIP_PLAY_SCENARIO                                 :{BLACK}Începe un joc nou folosind un scenariu deja existent
@@ -2127,23 +2127,23 @@ STR_INTRO_TOOLTIP_MULTIPLAYER                                   :{BLACK}Începe 
 STR_INTRO_TOOLTIP_TEMPERATE                                     :{BLACK}Alege peisajul 'climă temperată'
 STR_INTRO_TOOLTIP_SUB_ARCTIC_LANDSCAPE                          :{BLACK}Alege peisajul 'climă sub-arctică'
 STR_INTRO_TOOLTIP_SUB_TROPICAL_LANDSCAPE                        :{BLACK}Alege peisajul 'climă sub-tropicală'
-STR_INTRO_TOOLTIP_TOYLAND_LANDSCAPE                             :{BLACK}Alege peisajul 'ţara jucăriilor'
+STR_INTRO_TOOLTIP_TOYLAND_LANDSCAPE                             :{BLACK}Alege peisajul 'țara jucăriilor'
 
-STR_INTRO_TOOLTIP_GAME_OPTIONS                                  :{BLACK}Afişează opţiunile jocului
+STR_INTRO_TOOLTIP_GAME_OPTIONS                                  :{BLACK}Afișează opțiunile jocului
 STR_INTRO_TOOLTIP_HIGHSCORE                                     :{BLACK}Afișează tabela cu scoruri maxime
 STR_INTRO_TOOLTIP_HELP                                          :{BLACK}Obțineți acces la documentație și resurse online
-STR_INTRO_TOOLTIP_CONFIG_SETTINGS_TREE                          :{BLACK}Setări afişare
-STR_INTRO_TOOLTIP_NEWGRF_SETTINGS                               :{BLACK}Afişează setările NewGRF
+STR_INTRO_TOOLTIP_CONFIG_SETTINGS_TREE                          :{BLACK}Setări afișare
+STR_INTRO_TOOLTIP_NEWGRF_SETTINGS                               :{BLACK}Afișează setările NewGRF
 STR_INTRO_TOOLTIP_ONLINE_CONTENT                                :{BLACK}Verifică dacă există resurse noi sau actualizate pentru descărcare
 STR_INTRO_TOOLTIP_AI_SETTINGS                                   :{BLACK}Afișează setările AI
 STR_INTRO_TOOLTIP_GAMESCRIPT_SETTINGS                           :{BLACK}Afișează setările scriptului de joc
 STR_INTRO_TOOLTIP_QUIT                                          :{BLACK}Ieși din 'OpenTTD'
 
 STR_INTRO_BASESET                                               :{BLACK}Setul grafic actual are lipsă {NUM} {P sprite spriteuri "de spriteuri"}. Verificați actualizările pentru setul de bază.
-STR_INTRO_TRANSLATION                                           :{BLACK}Acestei traduceri îi lipse{P 0 "şte" "sc" "sc"} {NUM} {P text texte "de texte"}. Te rugăm să ajuti la îmbunătățirea OpenTTD înrolându-te ca traducător. Citește fișierul readme.txt pentru detalii.
+STR_INTRO_TRANSLATION                                           :{BLACK}Acestei traduceri îi lipse{P 0 "ște" "sc" "sc"} {NUM} {P text texte "de texte"}. Te rugăm să ajuti la îmbunătățirea OpenTTD înrolându-te ca traducător. Citește fișierul readme.txt pentru detalii.
 
 # Quit window
-STR_QUIT_CAPTION                                                :{WHITE}Ieşire din joc
+STR_QUIT_CAPTION                                                :{WHITE}Ieșire din joc
 STR_QUIT_ARE_YOU_SURE_YOU_WANT_TO_EXIT_OPENTTD                  :{YELLOW}Sigur vrei să abandonezi jocul curent?
 STR_QUIT_YES                                                    :{BLACK}Da
 STR_QUIT_NO                                                     :{BLACK}Nu
@@ -2168,31 +2168,31 @@ STR_HELP_WINDOW_COMMUNITY                                       :{BLACK}Comunita
 
 # Cheat window
 STR_CHEATS                                                      :{WHITE}Cheat-uri
-STR_CHEATS_TOOLTIP                                              :{BLACK}Bifa vă indică dacă aţi folosit anterior acest cheat
+STR_CHEATS_TOOLTIP                                              :{BLACK}Bifa vă indică dacă ați folosit anterior acest cheat
 STR_CHEATS_NOTE                                                 :{BLACK}Notă: utilizarea acestor setări va fi memorată în salvarea jocului
-STR_CHEAT_MONEY                                                 :{LTBLUE}Măreşte fondurile cu {CURRENCY_LONG}
+STR_CHEAT_MONEY                                                 :{LTBLUE}Mărește fondurile cu {CURRENCY_LONG}
 STR_CHEAT_CHANGE_COMPANY                                        :{LTBLUE}Joacă drept compania: {ORANGE}{COMMA}
 STR_CHEAT_EXTRA_DYNAMITE                                        :{LTBLUE}Buldozer magic (demolează industrii și lucruri amovibile): {ORANGE}{STRING}
 STR_CHEAT_CROSSINGTUNNELS                                       :{LTBLUE}Tunelele se pot intersecta: {ORANGE}{STRING}
-STR_CHEAT_NO_JETCRASH                                           :{LTBLUE}Avioanele cu reacţie nu se vor prăbuşi (frecvent) pe aeroporturile mici: {ORANGE}{STRING}
+STR_CHEAT_NO_JETCRASH                                           :{LTBLUE}Avioanele cu reacție nu se vor prăbuși (frecvent) pe aeroporturile mici: {ORANGE}{STRING}
 STR_CHEAT_EDIT_MAX_HL                                           :{LTBLUE}Schimbă înălțimea maximă a hărții: {ORANGE}{NUM}
 STR_CHEAT_EDIT_MAX_HL_QUERY_CAPT                                :{WHITE}Schimbă înălțimea maximă a munților pe hartă
 STR_CHEAT_CHANGE_DATE                                           :{LTBLUE}Schimbă data: {ORANGE}{DATE_SHORT}
 STR_CHEAT_CHANGE_DATE_QUERY_CAPT                                :{WHITE}Schimbă anul curent
-STR_CHEAT_SETUP_PROD                                            :{LTBLUE}Activează accesul la valorile de producţie: {ORANGE}{STRING}
-STR_CHEAT_STATION_RATING                                        :{LTBLUE}Remediați evaluările staţiei la 100%: {ORANGE}{STRING}
+STR_CHEAT_SETUP_PROD                                            :{LTBLUE}Activează accesul la valorile de producție: {ORANGE}{STRING}
+STR_CHEAT_STATION_RATING                                        :{LTBLUE}Remediați evaluările stației la 100%: {ORANGE}{STRING}
 
 # Livery window
 STR_LIVERY_CAPTION                                              :{WHITE}{COMPANY} - Schemă de culori
 
-STR_LIVERY_GENERAL_TOOLTIP                                      :{BLACK}Afişează schemele generale de culori
+STR_LIVERY_GENERAL_TOOLTIP                                      :{BLACK}Afișează schemele generale de culori
 STR_LIVERY_TRAIN_TOOLTIP                                        :{BLACK}Arată schemele de culori pentru trenuri
 STR_LIVERY_ROAD_VEHICLE_TOOLTIP                                 :{BLACK}Arată schemele de culori pentru autovehicule
 STR_LIVERY_SHIP_TOOLTIP                                         :{BLACK}Arată schemele de culori pentru nave
 STR_LIVERY_AIRCRAFT_TOOLTIP                                     :{BLACK}Arată schemele de culori pentru aeronave
 STR_LIVERY_PRIMARY_TOOLTIP                                      :{BLACK}Alege culoarea principală pentru schema selectată. Ctrl+Click va seta această culoare pentru toate schemele
 STR_LIVERY_SECONDARY_TOOLTIP                                    :{BLACK}Alege culoarea secundară pentru schema selectată. Ctrl+Click va seta această culoare pentru toate schemele
-STR_LIVERY_PANEL_TOOLTIP                                        :{BLACK}Alege o schemă de culori pentru modificare sau mai multe scheme, folosind Ctrl+Click. Apasă pe căsuţă pentru a comuta schema
+STR_LIVERY_PANEL_TOOLTIP                                        :{BLACK}Alege o schemă de culori pentru modificare sau mai multe scheme, folosind Ctrl+Click. Apasă pe căsuță pentru a comuta schema
 
 ###length 23
 STR_LIVERY_DEFAULT                                              :Uniforma standard
@@ -2206,7 +2206,7 @@ STR_LIVERY_EMU                                                  :EMU
 STR_LIVERY_PASSENGER_WAGON_STEAM                                :Vagon călători (Aburi)
 STR_LIVERY_PASSENGER_WAGON_DIESEL                               :Vagon călători (Diesel)
 STR_LIVERY_PASSENGER_WAGON_ELECTRIC                             :Vagon călători (Electric)
-STR_LIVERY_PASSENGER_WAGON_MONORAIL                             :Vagon călători (Monoşină)
+STR_LIVERY_PASSENGER_WAGON_MONORAIL                             :Vagon călători (Monoșină)
 STR_LIVERY_PASSENGER_WAGON_MAGLEV                               :Vagon călători (Pernă Mag.)
 STR_LIVERY_FREIGHT_WAGON                                        :Vagon de marfă
 STR_LIVERY_BUS                                                  :Autobuz
@@ -2232,27 +2232,27 @@ STR_FACE_FEMALE_TOOLTIP                                         :{BLACK}Alege fi
 STR_FACE_NEW_FACE_BUTTON                                        :{BLACK}Poză nouă
 STR_FACE_NEW_FACE_TOOLTIP                                       :{BLACK}Generează poză aleatoare
 STR_FACE_ADVANCED                                               :{BLACK}Avansat
-STR_FACE_ADVANCED_TOOLTIP                                       :{BLACK}Selecţie avansată a feţei
+STR_FACE_ADVANCED_TOOLTIP                                       :{BLACK}Selecție avansată a feței
 STR_FACE_SIMPLE                                                 :{BLACK}Simplu
-STR_FACE_SIMPLE_TOOLTIP                                         :{BLACK}Selecţie simplă a feţei
+STR_FACE_SIMPLE_TOOLTIP                                         :{BLACK}Selecție simplă a feței
 STR_FACE_LOAD                                                   :{BLACK}Încărcare
-STR_FACE_LOAD_TOOLTIP                                           :{BLACK}Încarcă o faţă preferată
-STR_FACE_LOAD_DONE                                              :{WHITE}Faţa dvs. preferată a fost încărcată din fişierul de configurare al OpenTTD.
-STR_FACE_FACECODE                                               :{BLACK}Nr. faţă jucător
-STR_FACE_FACECODE_TOOLTIP                                       :{BLACK}Vizualizează şi/sau setează numărul feţei pentru președintele companiei
-STR_FACE_FACECODE_CAPTION                                       :{WHITE}Vizualizează şi/sau setează numărul feţei pentru președinte
-STR_FACE_FACECODE_SET                                           :{WHITE}Noul cod numeric pentru faţă a fost stabilit
-STR_FACE_FACECODE_ERR                                           :{WHITE}Nu am putut seta numărul de faţă al președintelui - trebuie să fie un număr între 0 şi 4.294.967.295!
+STR_FACE_LOAD_TOOLTIP                                           :{BLACK}Încarcă o față preferată
+STR_FACE_LOAD_DONE                                              :{WHITE}Fața dvs. preferată a fost încărcată din fișierul de configurare al OpenTTD.
+STR_FACE_FACECODE                                               :{BLACK}Nr. față jucător
+STR_FACE_FACECODE_TOOLTIP                                       :{BLACK}Vizualizează și/sau setează numărul feței pentru președintele companiei
+STR_FACE_FACECODE_CAPTION                                       :{WHITE}Vizualizează și/sau setează numărul feței pentru președinte
+STR_FACE_FACECODE_SET                                           :{WHITE}Noul cod numeric pentru față a fost stabilit
+STR_FACE_FACECODE_ERR                                           :{WHITE}Nu am putut seta numărul de față al președintelui - trebuie să fie un număr între 0 și 4.294.967.295!
 STR_FACE_SAVE                                                   :{BLACK}Salvează
-STR_FACE_SAVE_TOOLTIP                                           :{BLACK}Salvează faţa preferată
-STR_FACE_SAVE_DONE                                              :{WHITE}Această faţă va fi salvată ca faţa preferată în fişierul de configurare al OpenTTD.
+STR_FACE_SAVE_TOOLTIP                                           :{BLACK}Salvează fața preferată
+STR_FACE_SAVE_DONE                                              :{WHITE}Această față va fi salvată ca fața preferată în fișierul de configurare al OpenTTD.
 STR_FACE_EUROPEAN                                               :{BLACK}European
-STR_FACE_SELECT_EUROPEAN                                        :{BLACK}Alege feţe europene
+STR_FACE_SELECT_EUROPEAN                                        :{BLACK}Alege fețe europene
 STR_FACE_AFRICAN                                                :{BLACK}African
-STR_FACE_SELECT_AFRICAN                                         :{BLACK}Alege feţe africane
+STR_FACE_SELECT_AFRICAN                                         :{BLACK}Alege fețe africane
 STR_FACE_YES                                                    :Da
 STR_FACE_NO                                                     :Nu
-STR_FACE_MOUSTACHE_EARRING_TOOLTIP                              :{BLACK}Permite mustaţă sau cercei
+STR_FACE_MOUSTACHE_EARRING_TOOLTIP                              :{BLACK}Permite mustață sau cercei
 STR_FACE_HAIR                                                   :Păr:
 STR_FACE_HAIR_TOOLTIP                                           :{BLACK}Schimbă părul
 STR_FACE_EYEBROWS                                               :Sprâncene:
@@ -2265,8 +2265,8 @@ STR_FACE_GLASSES_TOOLTIP_2                                      :{BLACK}Schimbă
 STR_FACE_NOSE                                                   :Nas:
 STR_FACE_NOSE_TOOLTIP                                           :{BLACK}Schimbă nasul
 STR_FACE_LIPS                                                   :Buze:
-STR_FACE_MOUSTACHE                                              :Mustaţă:
-STR_FACE_LIPS_MOUSTACHE_TOOLTIP                                 :{BLACK}Schimbă buzele sau mustaţa
+STR_FACE_MOUSTACHE                                              :Mustață:
+STR_FACE_LIPS_MOUSTACHE_TOOLTIP                                 :{BLACK}Schimbă buzele sau mustața
 STR_FACE_CHIN                                                   :Bărbie:
 STR_FACE_CHIN_TOOLTIP                                           :{BLACK}Schimbă bărbia
 STR_FACE_JACKET                                                 :Haină:
@@ -2286,16 +2286,16 @@ STR_NETWORK_SERVER_VISIBILITY_INVITE_ONLY                       :Doar cu invita�
 # Network server list
 STR_NETWORK_SERVER_LIST_CAPTION                                 :{WHITE}Multiplayer
 STR_NETWORK_SERVER_LIST_PLAYER_NAME                             :{BLACK}Numele jucătorului:
-STR_NETWORK_SERVER_LIST_ENTER_NAME_TOOLTIP                      :{BLACK}Acesta este numele prin care te vor identifica ceilalţi
+STR_NETWORK_SERVER_LIST_ENTER_NAME_TOOLTIP                      :{BLACK}Acesta este numele prin care te vor identifica ceilalți
 
 STR_NETWORK_SERVER_LIST_GAME_NAME                               :{BLACK}Nume
 STR_NETWORK_SERVER_LIST_GAME_NAME_TOOLTIP                       :{BLACK}Numele jocului
 STR_NETWORK_SERVER_LIST_GENERAL_ONLINE                          :{BLACK}{COMMA}/{COMMA} - {COMMA}/{COMMA}
-STR_NETWORK_SERVER_LIST_CLIENTS_CAPTION                         :{BLACK}Clienţi
-STR_NETWORK_SERVER_LIST_CLIENTS_CAPTION_TOOLTIP                 :{BLACK}Clienţi online / Nr. max. clienţi{}Companii online / Nr. max. companii
+STR_NETWORK_SERVER_LIST_CLIENTS_CAPTION                         :{BLACK}Clienți
+STR_NETWORK_SERVER_LIST_CLIENTS_CAPTION_TOOLTIP                 :{BLACK}Clienți online / Nr. max. clienți{}Companii online / Nr. max. companii
 STR_NETWORK_SERVER_LIST_MAP_SIZE_SHORT                          :{BLACK}{COMMA}x{COMMA}
 STR_NETWORK_SERVER_LIST_MAP_SIZE_CAPTION                        :{BLACK}Dimensiune hartă
-STR_NETWORK_SERVER_LIST_MAP_SIZE_CAPTION_TOOLTIP                :{BLACK}Dimensiunea hărţii jocului{}Click pentru sortarea după suprafaţă
+STR_NETWORK_SERVER_LIST_MAP_SIZE_CAPTION_TOOLTIP                :{BLACK}Dimensiunea hărții jocului{}Click pentru sortarea după suprafață
 STR_NETWORK_SERVER_LIST_DATE_CAPTION                            :{BLACK}Data
 STR_NETWORK_SERVER_LIST_DATE_CAPTION_TOOLTIP                    :{BLACK}Data curentă
 STR_NETWORK_SERVER_LIST_YEARS_CAPTION                           :{BLACK}Ani
@@ -2303,13 +2303,13 @@ STR_NETWORK_SERVER_LIST_YEARS_CAPTION_TOOLTIP                   :{BLACK}Numărul
 STR_NETWORK_SERVER_LIST_INFO_ICONS_TOOLTIP                      :{BLACK}Limba, versiunea serverului, etc.
 
 STR_NETWORK_SERVER_LIST_CLICK_GAME_TO_SELECT                    :{BLACK}Click pe un joc din listă pentru a-l selecta
-STR_NETWORK_SERVER_LIST_LAST_JOINED_SERVER                      :{BLACK}Server-ul la care v-aţi conectat data trecută:
+STR_NETWORK_SERVER_LIST_LAST_JOINED_SERVER                      :{BLACK}Server-ul la care v-ați conectat data trecută:
 STR_NETWORK_SERVER_LIST_CLICK_TO_SELECT_LAST                    :{BLACK}Click pentru a alege serverul de data trecută
 
 STR_NETWORK_SERVER_LIST_GAME_INFO                               :{SILVER}INFO JOC
-STR_NETWORK_SERVER_LIST_CLIENTS                                 :{SILVER}Clienţi: {WHITE}{COMMA} / {COMMA} - {COMMA} / {COMMA}
+STR_NETWORK_SERVER_LIST_CLIENTS                                 :{SILVER}Clienți: {WHITE}{COMMA} / {COMMA} - {COMMA} / {COMMA}
 STR_NETWORK_SERVER_LIST_LANDSCAPE                               :{SILVER}Peisaj: {WHITE}{STRING}
-STR_NETWORK_SERVER_LIST_MAP_SIZE                                :{SILVER}Mărimea hărţii: {WHITE}{COMMA}x{COMMA}
+STR_NETWORK_SERVER_LIST_MAP_SIZE                                :{SILVER}Mărimea hărții: {WHITE}{COMMA}x{COMMA}
 STR_NETWORK_SERVER_LIST_SERVER_VERSION                          :{SILVER}Versiune server: {WHITE}{STRING}
 STR_NETWORK_SERVER_LIST_SERVER_ADDRESS                          :{SILVER}Adresa serverului: {WHITE}{STRING}
 STR_NETWORK_SERVER_LIST_INVITE_CODE                             :{SILVER}Cod de invitație: {WHITE}{STRING}
@@ -2326,7 +2326,7 @@ STR_NETWORK_SERVER_LIST_GRF_MISMATCH                            :{SILVER}NEPOTRI
 
 STR_NETWORK_SERVER_LIST_JOIN_GAME                               :{BLACK}Intră în joc
 STR_NETWORK_SERVER_LIST_REFRESH                                 :{BLACK}Actualizează serverul
-STR_NETWORK_SERVER_LIST_REFRESH_TOOLTIP                         :{BLACK}Actualizează informaţiile despre server
+STR_NETWORK_SERVER_LIST_REFRESH_TOOLTIP                         :{BLACK}Actualizează informațiile despre server
 
 STR_NETWORK_SERVER_LIST_SEARCH_SERVER_INTERNET                  :{BLACK}Caută pe internet
 STR_NETWORK_SERVER_LIST_SEARCH_SERVER_INTERNET_TOOLTIP          :{BLACK}Caută servere publice în internet
@@ -2334,47 +2334,47 @@ STR_NETWORK_SERVER_LIST_SEARCH_SERVER_LAN                       :{BLACK}Caută �
 STR_NETWORK_SERVER_LIST_SEARCH_SERVER_LAN_TOOLTIP               :{BLACK}Caută servere în rețeaua locală
 STR_NETWORK_SERVER_LIST_ADD_SERVER                              :{BLACK}Adaugă un server
 STR_NETWORK_SERVER_LIST_ADD_SERVER_TOOLTIP                      :{BLACK}Adaugă un server la listă. Poate să fie ori o adresă de server, ori un cod de invitație
-STR_NETWORK_SERVER_LIST_START_SERVER                            :{BLACK}Porneşte serverul
-STR_NETWORK_SERVER_LIST_START_SERVER_TOOLTIP                    :{BLACK}Porneşte un server propriu
+STR_NETWORK_SERVER_LIST_START_SERVER                            :{BLACK}Pornește serverul
+STR_NETWORK_SERVER_LIST_START_SERVER_TOOLTIP                    :{BLACK}Pornește un server propriu
 
-STR_NETWORK_SERVER_LIST_PLAYER_NAME_OSKTITLE                    :{BLACK}Introduceţi numele dvs.
+STR_NETWORK_SERVER_LIST_PLAYER_NAME_OSKTITLE                    :{BLACK}Introduceți numele dvs.
 STR_NETWORK_SERVER_LIST_ENTER_SERVER_ADDRESS                    :{BLACK}Introdu adresa serverului sau codul invitației
 
 # Start new multiplayer server
 STR_NETWORK_START_SERVER_CAPTION                                :{WHITE}Începe un joc nou
 
 STR_NETWORK_START_SERVER_NEW_GAME_NAME                          :{BLACK}Nume joc:
-STR_NETWORK_START_SERVER_NEW_GAME_NAME_TOOLTIP                  :{BLACK}Numele jocului va fi afişat celorlalţi jucători în meniul de selectare al jocurilor multiplayer
+STR_NETWORK_START_SERVER_NEW_GAME_NAME_TOOLTIP                  :{BLACK}Numele jocului va fi afișat celorlalți jucători în meniul de selectare al jocurilor multiplayer
 STR_NETWORK_START_SERVER_SET_PASSWORD                           :{BLACK}Pune parolă
-STR_NETWORK_START_SERVER_PASSWORD_TOOLTIP                       :{BLACK}Protejează-ţi jocul cu o parolă dacă nu vrei să intre jucători neautorizaţi
+STR_NETWORK_START_SERVER_PASSWORD_TOOLTIP                       :{BLACK}Protejează-ți jocul cu o parolă dacă nu vrei să intre jucători neautorizați
 
 STR_NETWORK_START_SERVER_VISIBILITY_LABEL                       :{BLACK}Vizibilitate
 STR_NETWORK_START_SERVER_VISIBILITY_TOOLTIP                     :{BLACK}Dacă alți oameni îți pot vedea serverul în lista publică
-STR_NETWORK_START_SERVER_CLIENTS_SELECT                         :{BLACK}{NUM} {P client clienţi "de clienți"}
-STR_NETWORK_START_SERVER_NUMBER_OF_CLIENTS                      :{BLACK}Număr maxim de clienţi:
-STR_NETWORK_START_SERVER_NUMBER_OF_CLIENTS_TOOLTIP              :{BLACK}Alege un număr maxim de clienţi. Nu trebuie ocupate toate locurile.
+STR_NETWORK_START_SERVER_CLIENTS_SELECT                         :{BLACK}{NUM} {P client clienți "de clienți"}
+STR_NETWORK_START_SERVER_NUMBER_OF_CLIENTS                      :{BLACK}Număr maxim de clienți:
+STR_NETWORK_START_SERVER_NUMBER_OF_CLIENTS_TOOLTIP              :{BLACK}Alege un număr maxim de clienți. Nu trebuie ocupate toate locurile.
 STR_NETWORK_START_SERVER_COMPANIES_SELECT                       :{BLACK}{NUM} {P companie companii "de companii"}
 STR_NETWORK_START_SERVER_NUMBER_OF_COMPANIES                    :{BLACK}Companii maxim:
 STR_NETWORK_START_SERVER_NUMBER_OF_COMPANIES_TOOLTIP            :{BLACK}Limitează serverul la un anumit număr de companii
 
-STR_NETWORK_START_SERVER_NEW_GAME_NAME_OSKTITLE                 :{BLACK}Introduceţi un nume pentru joc
+STR_NETWORK_START_SERVER_NEW_GAME_NAME_OSKTITLE                 :{BLACK}Introduceți un nume pentru joc
 
 # Network connecting window
 STR_NETWORK_CONNECTING_CAPTION                                  :{WHITE}Conectare...
 
 STR_NETWORK_CONNECTING_WAITING                                  :{BLACK}{NUM} {P client clienți "de clienți"} înaintea ta
 STR_NETWORK_CONNECTING_DOWNLOADING_1                            :{BLACK}{BYTES} descărcat până acum
-STR_NETWORK_CONNECTING_DOWNLOADING_2                            :{BLACK}{BYTES} / {BYTES} descărcaţi până acum
+STR_NETWORK_CONNECTING_DOWNLOADING_2                            :{BLACK}{BYTES} / {BYTES} descărcați până acum
 
 ###length 8
 STR_NETWORK_CONNECTING_1                                        :{BLACK}(1/6) Conectare...
 STR_NETWORK_CONNECTING_2                                        :{BLACK}(2/6) Autorizare...
-STR_NETWORK_CONNECTING_3                                        :{BLACK}(3/6) Aşteptaţi...
+STR_NETWORK_CONNECTING_3                                        :{BLACK}(3/6) Așteptați...
 STR_NETWORK_CONNECTING_4                                        :{BLACK}(4/6) Descărcare hartă...
 STR_NETWORK_CONNECTING_5                                        :{BLACK}(5/6) Prelucrare date...
 STR_NETWORK_CONNECTING_6                                        :{BLACK}(6/6) Înregistrare...
-STR_NETWORK_CONNECTING_SPECIAL_1                                :{BLACK}Preluare informaţii joc...
-STR_NETWORK_CONNECTING_SPECIAL_2                                :{BLACK}Preluare informaţii companie...
+STR_NETWORK_CONNECTING_SPECIAL_1                                :{BLACK}Preluare informații joc...
+STR_NETWORK_CONNECTING_SPECIAL_2                                :{BLACK}Preluare informații companie...
 
 STR_NETWORK_CONNECTION_DISCONNECT                               :{BLACK}Deconectare
 
@@ -2462,36 +2462,36 @@ STR_COMPANY_PASSWORD_MAKE_DEFAULT_TOOLTIP                       :{BLACK}Foloseș
 STR_COMPANY_VIEW_JOIN                                           :{BLACK}Intră
 STR_COMPANY_VIEW_JOIN_TOOLTIP                                   :{BLACK}Intră în joc ca membru al acestei companii
 STR_COMPANY_VIEW_PASSWORD                                       :{BLACK}Parola
-STR_COMPANY_VIEW_PASSWORD_TOOLTIP                               :{BLACK}Protejează-ţi compania cu o parolă pentru a preveni accesul neautorizat
+STR_COMPANY_VIEW_PASSWORD_TOOLTIP                               :{BLACK}Protejează-ți compania cu o parolă pentru a preveni accesul neautorizat
 STR_COMPANY_VIEW_SET_PASSWORD                                   :{BLACK}Alege parola companiei
 
 # Network chat
 STR_NETWORK_CHAT_SEND                                           :{BLACK}Trimite
 STR_NETWORK_CHAT_COMPANY_CAPTION                                :[Echipă] :
 STR_NETWORK_CHAT_CLIENT_CAPTION                                 :[Mesaj privat] {STRING}:
-STR_NETWORK_CHAT_ALL_CAPTION                                    :[Toţi] :
+STR_NETWORK_CHAT_ALL_CAPTION                                    :[Toți] :
 
 STR_NETWORK_CHAT_COMPANY                                        :[Echipă] {STRING}: {WHITE}{STRING}
 STR_NETWORK_CHAT_TO_COMPANY                                     :[Echipă] Către {STRING}: {WHITE}{STRING}
 STR_NETWORK_CHAT_CLIENT                                         :[Mesaj privat] {STRING}: {WHITE}{STRING}
 STR_NETWORK_CHAT_TO_CLIENT                                      :[Mesaj privat] Către {STRING}: {WHITE}{STRING}
-STR_NETWORK_CHAT_ALL                                            :[Toţi] {STRING}: {WHITE}{STRING}
+STR_NETWORK_CHAT_ALL                                            :[Toți] {STRING}: {WHITE}{STRING}
 STR_NETWORK_CHAT_EXTERNAL                                       :[{3:STRING}] {0:STRING}: {WHITE}{1:STRING}
 STR_NETWORK_CHAT_OSKTITLE                                       :{BLACK}Introdu textul pentru chat în retea
 
 # Network messages
-STR_NETWORK_ERROR_NOTAVAILABLE                                  :{WHITE}Nu am detectat o placă de reţea sau jocul a fost compilat fără ENABLE_NETWORK
+STR_NETWORK_ERROR_NOTAVAILABLE                                  :{WHITE}Nu am detectat o placă de rețea sau jocul a fost compilat fără ENABLE_NETWORK
 STR_NETWORK_ERROR_NOCONNECTION                                  :{WHITE}Conexiunea la server nu s-a efectuat în timp util sau a fost refuzată
 STR_NETWORK_ERROR_NEWGRF_MISMATCH                               :{WHITE}Nu m-am putut conecta din cauza unei nepotriviri NewGRF
-STR_NETWORK_ERROR_DESYNC                                        :{WHITE}Sincronizarea jocului în reţea a eşuat
-STR_NETWORK_ERROR_LOSTCONNECTION                                :{WHITE}Conexiunea jocului în reţea a fost întreruptă
-STR_NETWORK_ERROR_SAVEGAMEERROR                                 :{WHITE}Nu am reuşit să încarc jocul salvat
+STR_NETWORK_ERROR_DESYNC                                        :{WHITE}Sincronizarea jocului în rețea a eșuat
+STR_NETWORK_ERROR_LOSTCONNECTION                                :{WHITE}Conexiunea jocului în rețea a fost întreruptă
+STR_NETWORK_ERROR_SAVEGAMEERROR                                 :{WHITE}Nu am reușit să încarc jocul salvat
 STR_NETWORK_ERROR_SERVER_START                                  :{WHITE}Serverul nu a putut fi pornit
 STR_NETWORK_ERROR_SERVER_ERROR                                  :{WHITE}Eroare de protocol. Conexiunea a fost închisă
 STR_NETWORK_ERROR_BAD_PLAYER_NAME                               :{WHITE}Nu ți-ai setat numele în joc. Numele se setează din partea de sus a ferestrei Multiplayer
 STR_NETWORK_ERROR_BAD_SERVER_NAME                               :{WHITE}Nu ai setat numele serverului. Numele se setează din partea de sus a ferestrei Multiplayer
 STR_NETWORK_ERROR_WRONG_REVISION                                :{WHITE}Versiunea acestui client este diferită de cea a serverului
-STR_NETWORK_ERROR_WRONG_PASSWORD                                :{WHITE}Parolă greşită
+STR_NETWORK_ERROR_WRONG_PASSWORD                                :{WHITE}Parolă greșită
 STR_NETWORK_ERROR_SERVER_FULL                                   :{WHITE}Serverul este plin
 STR_NETWORK_ERROR_SERVER_BANNED                                 :{WHITE}Accesul tău este interzis pe acest server
 STR_NETWORK_ERROR_KICKED                                        :{WHITE}Ai fost dat afară din joc
@@ -2500,7 +2500,7 @@ STR_NETWORK_ERROR_CHEATER                                       :{WHITE}Cheat-ur
 STR_NETWORK_ERROR_TOO_MANY_COMMANDS                             :{WHITE}Trimiteai prea multe comenzi către server
 STR_NETWORK_ERROR_TIMEOUT_PASSWORD                              :{WHITE}A expirat timpul pentru introducerea unei parole
 STR_NETWORK_ERROR_TIMEOUT_COMPUTER                              :{WHITE}Calculatorul dvs. este prea lent pentru a se sincroniza cu serverul
-STR_NETWORK_ERROR_TIMEOUT_MAP                                   :{WHITE}A expirat timpul pentru descărcarea hărţii
+STR_NETWORK_ERROR_TIMEOUT_MAP                                   :{WHITE}A expirat timpul pentru descărcarea hărții
 STR_NETWORK_ERROR_TIMEOUT_JOIN                                  :{WHITE}A expirat timpul pentru conectarea la server
 STR_NETWORK_ERROR_INVALID_CLIENT_NAME                           :{WHITE}Numele tău de jucător nu este valid
 
@@ -2515,7 +2515,7 @@ STR_NETWORK_ERROR_CLIENT_CONNECTION_LOST                        :conexiune pierd
 STR_NETWORK_ERROR_CLIENT_PROTOCOL_ERROR                         :eroare de protocol
 STR_NETWORK_ERROR_CLIENT_NEWGRF_MISMATCH                        :Nepotrivire NewGRF
 STR_NETWORK_ERROR_CLIENT_NOT_AUTHORIZED                         :neautorizat
-STR_NETWORK_ERROR_CLIENT_NOT_EXPECTED                           :recepţionat pachet invalid sau neaşteptat
+STR_NETWORK_ERROR_CLIENT_NOT_EXPECTED                           :recepționat pachet invalid sau neașteptat
 STR_NETWORK_ERROR_CLIENT_WRONG_REVISION                         :versiune incorectă
 STR_NETWORK_ERROR_CLIENT_NAME_IN_USE                            :nume folosit deja
 STR_NETWORK_ERROR_CLIENT_WRONG_PASSWORD                         :parolă incorectă
@@ -2526,8 +2526,8 @@ STR_NETWORK_ERROR_CLIENT_SERVER_FULL                            :server plin
 STR_NETWORK_ERROR_CLIENT_TOO_MANY_COMMANDS                      :trimitea prea multe comenzi
 STR_NETWORK_ERROR_CLIENT_TIMEOUT_PASSWORD                       :a expirat timpul alocat pentru transmiterea parolei
 STR_NETWORK_ERROR_CLIENT_TIMEOUT_COMPUTER                       :a expirat timpul alocat
-STR_NETWORK_ERROR_CLIENT_TIMEOUT_MAP                            :a expirat timpul alocat descărcării hărţii
-STR_NETWORK_ERROR_CLIENT_TIMEOUT_JOIN                           :a expirat timpul alocat procesării hărţii
+STR_NETWORK_ERROR_CLIENT_TIMEOUT_MAP                            :a expirat timpul alocat descărcării hărții
+STR_NETWORK_ERROR_CLIENT_TIMEOUT_JOIN                           :a expirat timpul alocat procesării hărții
 STR_NETWORK_ERROR_CLIENT_INVALID_CLIENT_NAME                    :numele clientului nu este valid
 
 # Network related errors
@@ -2542,7 +2542,7 @@ STR_NETWORK_SERVER_MESSAGE_GAME_STILL_PAUSED_4                  :Jocul încă es
 STR_NETWORK_SERVER_MESSAGE_GAME_STILL_PAUSED_5                  :Jocul încă este în pauză ({STRING}, {STRING}, {STRING}, {STRING}, {STRING})
 STR_NETWORK_SERVER_MESSAGE_GAME_UNPAUSED                        :Jocul continuă ({STRING})
 STR_NETWORK_SERVER_MESSAGE_GAME_REASON_NOT_ENOUGH_PLAYERS       :număr de jucători
-STR_NETWORK_SERVER_MESSAGE_GAME_REASON_CONNECTING_CLIENTS       :conectare clienţi
+STR_NETWORK_SERVER_MESSAGE_GAME_REASON_CONNECTING_CLIENTS       :conectare clienți
 STR_NETWORK_SERVER_MESSAGE_GAME_REASON_MANUAL                   :manual
 STR_NETWORK_SERVER_MESSAGE_GAME_REASON_GAME_SCRIPT              :script-ul jocului
 STR_NETWORK_SERVER_MESSAGE_GAME_REASON_LINK_GRAPH               :se așteaptă pentru actualizarea graficului conexiunilor
@@ -2553,11 +2553,11 @@ STR_NETWORK_MESSAGE_CLIENT_JOINED_ID                            :*** {0:STRING} 
 STR_NETWORK_MESSAGE_CLIENT_COMPANY_JOIN                         :*** {0:STRING} a intrat în compania #{2:NUM}
 STR_NETWORK_MESSAGE_CLIENT_COMPANY_SPECTATE                     :*** {STRING} a intrat ca spectator
 STR_NETWORK_MESSAGE_CLIENT_COMPANY_NEW                          :*** {STRING} a început o companie nouă (#{2:NUM})
-STR_NETWORK_MESSAGE_CLIENT_LEFT                                 :*** {0:STRING} a ieşit din joc ({2:STRING})
+STR_NETWORK_MESSAGE_CLIENT_LEFT                                 :*** {0:STRING} a ieșit din joc ({2:STRING})
 STR_NETWORK_MESSAGE_NAME_CHANGE                                 :*** {STRING} și-a schimbat numele în {STRING}
 STR_NETWORK_MESSAGE_GIVE_MONEY                                  :*** {0:STRING} a dat {2:CURRENCY_LONG} către {1:STRING}
 STR_NETWORK_MESSAGE_SERVER_SHUTDOWN                             :{WHITE}Serverul a închis conexiunea
-STR_NETWORK_MESSAGE_SERVER_REBOOT                               :{WHITE}Serverul este repornit...{}Vă rugăm aşteptaţi...
+STR_NETWORK_MESSAGE_SERVER_REBOOT                               :{WHITE}Serverul este repornit...{}Vă rugăm așteptați...
 STR_NETWORK_MESSAGE_KICKED                                      :*** {STRING} a fost dat afară. Motiv: ({STRING})
 
 STR_NETWORK_ERROR_COORDINATOR_REGISTRATION_FAILED               :{WHITE}Înregistrarea serverului a eșuat
@@ -2593,9 +2593,9 @@ STR_CONTENT_DETAIL_TITLE                                        :{SILVER}INFO RE
 ###length 5
 STR_CONTENT_DETAIL_SUBTITLE_UNSELECTED                          :{SILVER}Această resursă nu a fost selectată pentru descărcare
 STR_CONTENT_DETAIL_SUBTITLE_SELECTED                            :{SILVER}Această resursă a fost selectată pentru descărcare
-STR_CONTENT_DETAIL_SUBTITLE_AUTOSELECTED                        :{SILVER}Aceasă dependinţă a fost selectată pentru descărcare
+STR_CONTENT_DETAIL_SUBTITLE_AUTOSELECTED                        :{SILVER}Aceasă dependință a fost selectată pentru descărcare
 STR_CONTENT_DETAIL_SUBTITLE_ALREADY_HERE                        :{SILVER}Deja ai această resursă
-STR_CONTENT_DETAIL_SUBTITLE_DOES_NOT_EXIST                      :{SILVER}Acestă resursă este necunoscută şi nu poate fi descărcată în OpenTTD
+STR_CONTENT_DETAIL_SUBTITLE_DOES_NOT_EXIST                      :{SILVER}Acestă resursă este necunoscută și nu poate fi descărcată în OpenTTD
 
 STR_CONTENT_DETAIL_UPDATE                                       :{SILVER}Acestă resursă este un înlocuitor pentru un/o {STRING} existent/ă
 STR_CONTENT_DETAIL_NAME                                         :{SILVER}Nume: {WHITE}{STRING}
@@ -2605,7 +2605,7 @@ STR_CONTENT_DETAIL_URL                                          :{SILVER}URL: {W
 STR_CONTENT_DETAIL_TYPE                                         :{SILVER}Tip: {WHITE}{STRING}
 STR_CONTENT_DETAIL_FILESIZE                                     :{SILVER}Dimensiune: {WHITE}{BYTES}
 STR_CONTENT_DETAIL_SELECTED_BECAUSE_OF                          :{SILVER}Selectat datorită: {WHITE}{STRING}
-STR_CONTENT_DETAIL_DEPENDENCIES                                 :{SILVER}Dependinţe: {WHITE}{STRING}
+STR_CONTENT_DETAIL_DEPENDENCIES                                 :{SILVER}Dependințe: {WHITE}{STRING}
 STR_CONTENT_DETAIL_TAGS                                         :{SILVER}Etichete: {WHITE}{STRING}
 STR_CONTENT_NO_ZLIB                                             :{WHITE}OpenTTD a fost compilat fără suport "zlib"...
 STR_CONTENT_NO_ZLIB_SUB                                         :{WHITE}... descărcarea resurselor nu este posibilă!
@@ -2624,19 +2624,19 @@ STR_CONTENT_TYPE_GS_LIBRARY                                     :Librărie scrip
 
 # Content downloading progress window
 STR_CONTENT_DOWNLOAD_TITLE                                      :{WHITE}Descarc resursele...
-STR_CONTENT_DOWNLOAD_INITIALISE                                 :{WHITE}Solicit fişierele...
+STR_CONTENT_DOWNLOAD_INITIALISE                                 :{WHITE}Solicit fișierele...
 STR_CONTENT_DOWNLOAD_FILE                                       :{WHITE}Se descarcă {STRING} ({NUM} din {NUM})
 STR_CONTENT_DOWNLOAD_COMPLETE                                   :{WHITE}Descărcare completă
-STR_CONTENT_DOWNLOAD_PROGRESS_SIZE                              :{WHITE}{BYTES} din {BYTES} descărcaţi ({NUM}%)
+STR_CONTENT_DOWNLOAD_PROGRESS_SIZE                              :{WHITE}{BYTES} din {BYTES} descărcați ({NUM}%)
 
 # Content downloading error messages
 STR_CONTENT_ERROR_COULD_NOT_CONNECT                             :{WHITE}Conectarea la serverul de conținut a eșuat...
 STR_CONTENT_ERROR_COULD_NOT_DOWNLOAD                            :{WHITE}Descărcare eșuată
-STR_CONTENT_ERROR_COULD_NOT_DOWNLOAD_FILE_NOT_WRITABLE          :{WHITE}... fişierul nu poate fi scris
-STR_CONTENT_ERROR_COULD_NOT_EXTRACT                             :{WHITE}Fişierul descărcat nu a putut fi decompresat
+STR_CONTENT_ERROR_COULD_NOT_DOWNLOAD_FILE_NOT_WRITABLE          :{WHITE}... fișierul nu poate fi scris
+STR_CONTENT_ERROR_COULD_NOT_EXTRACT                             :{WHITE}Fișierul descărcat nu a putut fi decompresat
 
 STR_MISSING_GRAPHICS_SET_CAPTION                                :{WHITE}Elemente grafice lipsă
-STR_MISSING_GRAPHICS_SET_MESSAGE                                :{BLACK}OpenTTD necesită elemente grafice pentru a funcționa, dar niciun pachet grafic nu a fost găsit. Permiteţi ca OpenTTD să descarce și să instaleze pachetele grafice necesare?
+STR_MISSING_GRAPHICS_SET_MESSAGE                                :{BLACK}OpenTTD necesită elemente grafice pentru a funcționa, dar niciun pachet grafic nu a fost găsit. Permiteți ca OpenTTD să descarce și să instaleze pachetele grafice necesare?
 STR_MISSING_GRAPHICS_YES_DOWNLOAD                               :{BLACK}Da, descarcă pachetele grafice
 STR_MISSING_GRAPHICS_NO_QUIT                                    :{BLACK}Nu, ieși din OpenTTD
 
@@ -2645,15 +2645,15 @@ STR_MISSING_GRAPHICS_ERROR                                      :{BLACK}Descărc
 STR_MISSING_GRAPHICS_ERROR_QUIT                                 :{BLACK}Ieșire din OpenTTD
 
 # Transparency settings window
-STR_TRANSPARENCY_CAPTION                                        :{WHITE}Optiuni transparenţă
-STR_TRANSPARENT_SIGNS_TOOLTIP                                   :{BLACK}Comută transparenţa pentru nume/semne. Ctrl+Click pentru blocare
-STR_TRANSPARENT_TREES_TOOLTIP                                   :{BLACK}Comută transparenţa pentru arbori. Ctrl+Click pentru blocare
-STR_TRANSPARENT_HOUSES_TOOLTIP                                  :{BLACK}Comută transparenţa pentru case. Ctrl+Click pentru blocare
-STR_TRANSPARENT_INDUSTRIES_TOOLTIP                              :{BLACK}Comută transparenţa pentru industrii. Ctrl+Click pentru blocare
-STR_TRANSPARENT_BUILDINGS_TOOLTIP                               :{BLACK}Comută transparenţa pentru construcţii, precum staţii, depouri, indicatoare şi linii electrificate. Ctrl+Click pentru blocare
-STR_TRANSPARENT_BRIDGES_TOOLTIP                                 :{BLACK}Comută transparenţa pentru poduri. Ctrl+Click pentru blocare
-STR_TRANSPARENT_STRUCTURES_TOOLTIP                              :{BLACK}Comută transparenţa pentru structuri de tip faruri şi antene. Ctrl+Click pentru blocare
-STR_TRANSPARENT_CATENARY_TOOLTIP                                :{BLACK}Comută transparenţa pentru catenar. Ctrl+Click pentru blocare
+STR_TRANSPARENCY_CAPTION                                        :{WHITE}Optiuni transparență
+STR_TRANSPARENT_SIGNS_TOOLTIP                                   :{BLACK}Comută transparența pentru nume/semne. Ctrl+Click pentru blocare
+STR_TRANSPARENT_TREES_TOOLTIP                                   :{BLACK}Comută transparența pentru arbori. Ctrl+Click pentru blocare
+STR_TRANSPARENT_HOUSES_TOOLTIP                                  :{BLACK}Comută transparența pentru case. Ctrl+Click pentru blocare
+STR_TRANSPARENT_INDUSTRIES_TOOLTIP                              :{BLACK}Comută transparența pentru industrii. Ctrl+Click pentru blocare
+STR_TRANSPARENT_BUILDINGS_TOOLTIP                               :{BLACK}Comută transparența pentru construcții, precum stații, depouri, indicatoare și linii electrificate. Ctrl+Click pentru blocare
+STR_TRANSPARENT_BRIDGES_TOOLTIP                                 :{BLACK}Comută transparența pentru poduri. Ctrl+Click pentru blocare
+STR_TRANSPARENT_STRUCTURES_TOOLTIP                              :{BLACK}Comută transparența pentru structuri de tip faruri și antene. Ctrl+Click pentru blocare
+STR_TRANSPARENT_CATENARY_TOOLTIP                                :{BLACK}Comută transparența pentru catenar. Ctrl+Click pentru blocare
 STR_TRANSPARENT_TEXT_TOOLTIP                                    :{BLACK}Comută transparența textului pentru încărcare și cost/venit. Ctrl+Clic pentru a bloca
 STR_TRANSPARENT_INVISIBLE_TOOLTIP                               :{BLACK}Setează obiectele ca invizibile în loc de transparente
 
@@ -2678,38 +2678,38 @@ STR_LINKGRAPH_STATS_TOOLTIP_TIME_EXTENSION                      :{}Durată medie
 STR_STATION_BUILD_COVERAGE_AREA_TITLE                           :{BLACK}Aria de acoperire
 STR_STATION_BUILD_COVERAGE_OFF                                  :{BLACK}Inactiv
 STR_STATION_BUILD_COVERAGE_ON                                   :{BLACK}Activ
-STR_STATION_BUILD_COVERAGE_AREA_OFF_TOOLTIP                     :{BLACK}Nu arăta aria de acoperire a locaţiei propuse
-STR_STATION_BUILD_COVERAGE_AREA_ON_TOOLTIP                      :{BLACK}Arată aria de acoperire a locaţiei propuse
+STR_STATION_BUILD_COVERAGE_AREA_OFF_TOOLTIP                     :{BLACK}Nu arăta aria de acoperire a locației propuse
+STR_STATION_BUILD_COVERAGE_AREA_ON_TOOLTIP                      :{BLACK}Arată aria de acoperire a locației propuse
 STR_STATION_BUILD_ACCEPTS_CARGO                                 :{BLACK}Acceptă: {GOLD}{CARGO_LIST}
 STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Furnizează: {GOLD}{CARGO_LIST}
 STR_STATION_BUILD_INFRASTRUCTURE_COST                           :{BLACK}Cost întreținere: {GOLD}{CURRENCY_SHORT}/an
 
 # Join station window
-STR_JOIN_STATION_CAPTION                                        :{WHITE}Uneşte staţia
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Construieşte o staţie separată
+STR_JOIN_STATION_CAPTION                                        :{WHITE}Unește stația
+STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Construiește o stație separată
 
-STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Uneşte punctul de tranzit
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Construieşte un punct de tranzit separat
+STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Unește punctul de tranzit
+STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Construiește un punct de tranzit separat
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Dezactivat, deoarece momentan nu sunt vehicule disponibile pentru acest tip de infrastructură
 
 # Rail construction toolbar
-STR_RAIL_TOOLBAR_RAILROAD_CONSTRUCTION_CAPTION                  :Construcţie cale ferată
-STR_RAIL_TOOLBAR_ELRAIL_CONSTRUCTION_CAPTION                    :Construcţie cale ferată electrificată
-STR_RAIL_TOOLBAR_MONORAIL_CONSTRUCTION_CAPTION                  :Construcţie monoşină
-STR_RAIL_TOOLBAR_MAGLEV_CONSTRUCTION_CAPTION                    :Construcţie pernă magnetică
+STR_RAIL_TOOLBAR_RAILROAD_CONSTRUCTION_CAPTION                  :Construcție cale ferată
+STR_RAIL_TOOLBAR_ELRAIL_CONSTRUCTION_CAPTION                    :Construcție cale ferată electrificată
+STR_RAIL_TOOLBAR_MONORAIL_CONSTRUCTION_CAPTION                  :Construcție monoșină
+STR_RAIL_TOOLBAR_MAGLEV_CONSTRUCTION_CAPTION                    :Construcție pernă magnetică
 
 STR_RAIL_TOOLBAR_TOOLTIP_BUILD_RAILROAD_TRACK                   :{BLACK}Construiește o cale ferată. Ctrl comută construirea/eliminarea căii ferate. Shift comută între construire/afișare cost estimat
 STR_RAIL_TOOLBAR_TOOLTIP_BUILD_AUTORAIL                         :{BLACK}Construiește cale ferată în modul automat. Ctrl comută construirea/eliminarea căii ferate. Shift comută între construire/afișare cost estimat
 STR_RAIL_TOOLBAR_TOOLTIP_BUILD_TRAIN_DEPOT_FOR_BUILDING         :{BLACK}Construiește un depou feroviar (pentru achiziție și service de trenuri). Shift comută între construire/afișare cost estimat
-STR_RAIL_TOOLBAR_TOOLTIP_CONVERT_RAIL_TO_WAYPOINT               :{BLACK}Converteşte linia în punct de tranzit. Ctrl permite alipirea punctelor de tranzit distante. Shift comută între convertire/afişare cost estimat
+STR_RAIL_TOOLBAR_TOOLTIP_CONVERT_RAIL_TO_WAYPOINT               :{BLACK}Convertește linia în punct de tranzit. Ctrl permite alipirea punctelor de tranzit distante. Shift comută între convertire/afișare cost estimat
 STR_RAIL_TOOLBAR_TOOLTIP_BUILD_RAILROAD_STATION                 :{BLACK}Construiește gară. Ctrl permite alipirea stațiilor. Shift comută între construire/afișare cost estimat
 STR_RAIL_TOOLBAR_TOOLTIP_BUILD_RAILROAD_SIGNALS                 :{BLACK}Plasează semnale feroviare. Ctrl comută între semafoare/semnale electrice{}Trage cu mausul pentru a construi automat semnale pe o porțiune de șină dreaptă. Apasă Ctrl pentru a construi semnale până la următoarea joncțiune{}Ctrl+Clic comută deschiderea ferestrei de selecție a tipului de semnal. Shift comută între construire/afișare cost estimat
 STR_RAIL_TOOLBAR_TOOLTIP_BUILD_RAILROAD_BRIDGE                  :{BLACK}Construiește un pod de cale ferată. Shift comută între construire/afișare cost estimat
 STR_RAIL_TOOLBAR_TOOLTIP_BUILD_RAILROAD_TUNNEL                  :{BLACK}Construiește un tunel feroviar. Shift comută între construire/afișare cost estimat
-STR_RAIL_TOOLBAR_TOOLTIP_TOGGLE_BUILD_REMOVE_FOR                :{BLACK}Comută construcţia/înlăturarea căilor ferate, semnalelor, punctelor de tranzit şi a staţiilor. Ctrl+Click înlătură şinele din punctele de tranzit şi din staţii
-STR_RAIL_TOOLBAR_TOOLTIP_CONVERT_RAIL                           :{BLACK}Converteşte tipul de cale ferată. Shift comută între convertire/afişare cost estimat
+STR_RAIL_TOOLBAR_TOOLTIP_TOGGLE_BUILD_REMOVE_FOR                :{BLACK}Comută construcția/înlăturarea căilor ferate, semnalelor, punctelor de tranzit și a stațiilor. Ctrl+Click înlătură șinele din punctele de tranzit și din stații
+STR_RAIL_TOOLBAR_TOOLTIP_CONVERT_RAIL                           :{BLACK}Convertește tipul de cale ferată. Shift comută între convertire/afișare cost estimat
 
 STR_RAIL_NAME_RAILROAD                                          :Cale ferată
 STR_RAIL_NAME_ELRAIL                                            :Șină electrificată
@@ -2733,10 +2733,10 @@ STR_STATION_BUILD_NUMBER_OF_TRACKS_TOOLTIP                      :{BLACK}Alege nu
 STR_STATION_BUILD_PLATFORM_LENGTH                               :{BLACK}Lungimea platformei
 STR_STATION_BUILD_PLATFORM_LENGTH_TOOLTIP                       :{BLACK}Alege lungimea platformei gării
 STR_STATION_BUILD_DRAG_DROP                                     :{BLACK}Drag & Drop
-STR_STATION_BUILD_DRAG_DROP_TOOLTIP                             :{BLACK}Construieşte o staţie prin drag & drop
+STR_STATION_BUILD_DRAG_DROP_TOOLTIP                             :{BLACK}Construiește o stație prin drag & drop
 
-STR_STATION_BUILD_STATION_CLASS_TOOLTIP                         :{BLACK}Alege o clasă de staţii pentru afişare
-STR_STATION_BUILD_STATION_TYPE_TOOLTIP                          :{BLACK}Alege tipul de staţie pentru construcţie
+STR_STATION_BUILD_STATION_CLASS_TOOLTIP                         :{BLACK}Alege o clasă de stații pentru afișare
+STR_STATION_BUILD_STATION_TYPE_TOOLTIP                          :{BLACK}Alege tipul de stație pentru construcție
 
 STR_STATION_CLASS_DFLT                                          :Implicită
 STR_STATION_CLASS_DFLT_STATION                                  :Stație implicită
@@ -2747,22 +2747,22 @@ STR_STATION_CLASS_WAYP_WAYPOINT                                 :Punct intermedi
 # Signal window
 STR_BUILD_SIGNAL_CAPTION                                        :{WHITE}Alegere semnal
 STR_BUILD_SIGNAL_TOGGLE_ADVANCED_SIGNAL_TOOLTIP                 :{BLACK}Comută afișarea tipurilor de semnal avansate
-STR_BUILD_SIGNAL_SEMAPHORE_NORM_TOOLTIP                         :{BLACK}Semnal standard (semafor){}Acesta este cel mai simplu tip de semnal, permiţând numai unui tren să fie în acelaşi bloc, la un moment dat
-STR_BUILD_SIGNAL_SEMAPHORE_ENTRY_TOOLTIP                        :{BLACK}Semnal de intrare (semafor){}Verde, atat timp cât există unul sau mai multe semnale verzi de ieşire din secţiunea următoare a căii ferate. Altfel indică roşu
+STR_BUILD_SIGNAL_SEMAPHORE_NORM_TOOLTIP                         :{BLACK}Semnal standard (semafor){}Acesta este cel mai simplu tip de semnal, permițând numai unui tren să fie în același bloc, la un moment dat
+STR_BUILD_SIGNAL_SEMAPHORE_ENTRY_TOOLTIP                        :{BLACK}Semnal de intrare (semafor){}Verde, atat timp cât există unul sau mai multe semnale verzi de ieșire din secțiunea următoare a căii ferate. Altfel indică roșu
 STR_BUILD_SIGNAL_SEMAPHORE_EXIT_TOOLTIP                         :{BLACK}Semnal de ieșire (semafor){}Se comportă în același fel ca semnalul normal, dar este necesar pentru declanșarea culorii corecte la presemnalizatoarele de intrare și cele combinate
 STR_BUILD_SIGNAL_SEMAPHORE_COMBO_TOOLTIP                        :{BLACK}Semnal combinat (semafor){}Semnalul combinat se comportă atât ca semnal de intrare, cât și de ieșire. Acest lucru permite construcția „arborilor” mari de presemnalizare
-STR_BUILD_SIGNAL_SEMAPHORE_PBS_TOOLTIP                          :{BLACK}Semnal de cale (semafor){}Un semnal de cale va permite trecerea în acelaşi timp în blocurile de semnale a mai multor trenuri, dacă trenurile pot găsi o cale până la un punct sigur pentru oprire. Semnalele standard de cale permit trecerea din ambele sensuri
+STR_BUILD_SIGNAL_SEMAPHORE_PBS_TOOLTIP                          :{BLACK}Semnal de cale (semafor){}Un semnal de cale va permite trecerea în același timp în blocurile de semnale a mai multor trenuri, dacă trenurile pot găsi o cale până la un punct sigur pentru oprire. Semnalele standard de cale permit trecerea din ambele sensuri
 STR_BUILD_SIGNAL_SEMAPHORE_PBS_OWAY_TOOLTIP                     :{BLACK}Semnal de cale cu sens unic (semafor){}Un semnal de cale permite trecerea simultană a mai multor trenuri prin blocurile de semnale, dacă trenul poate rezerva o cale până la un punct sigur de oprire. Semnalele de cale cu sens unic permit trecerea intr-un singur sens
 STR_BUILD_SIGNAL_ELECTRIC_NORM_TOOLTIP                          :{BLACK}Semnal standard (electric){}Acesta este cel mai simplu tip de semnal, permițând numai unui tren să fie în același bloc, la un moment dat
 STR_BUILD_SIGNAL_ELECTRIC_ENTRY_TOOLTIP                         :{BLACK}Semnal de intrare (electric){}Verde, atât timp cât există unul sau mai multe semnale verzi de ieșire în secțiunea următoare a căii ferate. Altfel indică roșu
 STR_BUILD_SIGNAL_ELECTRIC_EXIT_TOOLTIP                          :{BLACK}Semnal de ieșire (electric){}Se comportă în același fel ca semnalul normal, dar este necesar pentru declanșarea culorii corecte la presemnalizatoarele de intrare și cele combinate
 STR_BUILD_SIGNAL_ELECTRIC_COMBO_TOOLTIP                         :{BLACK}Semnal combinat (electric){}Semnalul combinat se comportă atât ca semnal de intrare, cât și de ieșire. Acest lucru permite construcția „arborilor” mari de presemnalizare
-STR_BUILD_SIGNAL_ELECTRIC_PBS_TOOLTIP                           :{BLACK}Semnal de cale (electric){}Un semnal de cale va permite trecerea în acelaşi timp în blocurile de semnale a mai multor trenuri, dacă trenurile pot găsi o cale până la un punct sigur pentru oprire. Semnalele standard de cale permit trecerea din ambele sensuri
+STR_BUILD_SIGNAL_ELECTRIC_PBS_TOOLTIP                           :{BLACK}Semnal de cale (electric){}Un semnal de cale va permite trecerea în același timp în blocurile de semnale a mai multor trenuri, dacă trenurile pot găsi o cale până la un punct sigur pentru oprire. Semnalele standard de cale permit trecerea din ambele sensuri
 STR_BUILD_SIGNAL_ELECTRIC_PBS_OWAY_TOOLTIP                      :{BLACK}Semnal de cale cu sens unic (electric){}Un semnal de cale permite trecerea simultană a mai multor trenuri prin blocurile de semnale, dacă trenul poate rezerva o cale până la un punct sigur de oprire. Semnalele de cale cu sens unic permit trecerea intr-un singur sens
 STR_BUILD_SIGNAL_CONVERT_TOOLTIP                                :{BLACK}Conversie semnal{}Când este selectat, clicul pe un semafor existent îl va converti în tipul și varianta selectată de semnalizare. Ctrl+clic va comuta varianta existentă. Shift+clic afișează costul estimat al conversiei
 STR_BUILD_SIGNAL_DRAG_SIGNALS_DENSITY_TOOLTIP                   :{BLACK}Densitatea semnalelor plasate prin tragerea cu mouse-ul
 STR_BUILD_SIGNAL_DRAG_SIGNALS_DENSITY_DECREASE_TOOLTIP          :{BLACK}Redu distanța semnalelor plasate prin tragerea cu mouse-ul
-STR_BUILD_SIGNAL_DRAG_SIGNALS_DENSITY_INCREASE_TOOLTIP          :{BLACK}Creşte densitatea semnalelor plasate prin tragerea cu mouse-ul
+STR_BUILD_SIGNAL_DRAG_SIGNALS_DENSITY_INCREASE_TOOLTIP          :{BLACK}Crește densitatea semnalelor plasate prin tragerea cu mouse-ul
 
 # Bridge selection window
 STR_SELECT_RAIL_BRIDGE_CAPTION                                  :{WHITE}Alege pod de cale ferată
@@ -2772,36 +2772,36 @@ STR_SELECT_BRIDGE_INFO_NAME                                     :{GOLD}{STRING}
 STR_SELECT_BRIDGE_INFO_NAME_MAX_SPEED                           :{GOLD}{STRING},{} {VELOCITY}
 STR_SELECT_BRIDGE_INFO_NAME_COST                                :{GOLD}{0:STRING},{} {WHITE}{2:CURRENCY_LONG}
 STR_SELECT_BRIDGE_INFO_NAME_MAX_SPEED_COST                      :{GOLD}{STRING},{} {VELOCITY} {WHITE}{CURRENCY_LONG}
-STR_BRIDGE_NAME_SUSPENSION_STEEL                                :Suspensie, Oţel
-STR_BRIDGE_NAME_GIRDER_STEEL                                    :Grindă, Oţel
-STR_BRIDGE_NAME_CANTILEVER_STEEL                                :Arc, Oţel
+STR_BRIDGE_NAME_SUSPENSION_STEEL                                :Suspensie, Oțel
+STR_BRIDGE_NAME_GIRDER_STEEL                                    :Grindă, Oțel
+STR_BRIDGE_NAME_CANTILEVER_STEEL                                :Arc, Oțel
 STR_BRIDGE_NAME_SUSPENSION_CONCRETE                             :Suspensie, Beton
 STR_BRIDGE_NAME_WOODEN                                          :Lemn
 STR_BRIDGE_NAME_CONCRETE                                        :Beton
-STR_BRIDGE_NAME_TUBULAR_STEEL                                   :Tubular, Oţel
+STR_BRIDGE_NAME_TUBULAR_STEEL                                   :Tubular, Oțel
 STR_BRIDGE_TUBULAR_SILICON                                      :Tubular, Silicon
 
 
 # Road construction toolbar
-STR_ROAD_TOOLBAR_ROAD_CONSTRUCTION_CAPTION                      :{WHITE}Construcţii rutiere
-STR_ROAD_TOOLBAR_TRAM_CONSTRUCTION_CAPTION                      :{WHITE}Construcţie tramvai
+STR_ROAD_TOOLBAR_ROAD_CONSTRUCTION_CAPTION                      :{WHITE}Construcții rutiere
+STR_ROAD_TOOLBAR_TRAM_CONSTRUCTION_CAPTION                      :{WHITE}Construcție tramvai
 STR_ROAD_TOOLBAR_TOOLTIP_BUILD_ROAD_SECTION                     :{BLACK}Construiește o secțiune de șosea. Ctrl comută construirea/eliminarea șoselei. Shift comută între construire/afișare cost estimat
 STR_ROAD_TOOLBAR_TOOLTIP_BUILD_TRAMWAY_SECTION                  :{BLACK}Construiește șină de tramvai. Ctrl comută construirea/eliminarea șinei. Shift comută între construire/afișare cost estimat
 STR_ROAD_TOOLBAR_TOOLTIP_BUILD_AUTOROAD                         :{BLACK}Construiește secțiune de șosea folosind modul Auto-șosea. Ctrl comută construirea/eliminarea șoselei. Shift comută între construire/afișare cost estimat
 STR_ROAD_TOOLBAR_TOOLTIP_BUILD_AUTOTRAM                         :{BLACK}Construiește secțiune de șină de tramvai folosind modul Auto-tramvai. Ctrl comută construirea/eliminarea șinei. Shift comută între construire/afișare cost estimat
 STR_ROAD_TOOLBAR_TOOLTIP_BUILD_ROAD_VEHICLE_DEPOT               :{BLACK}Construiește o autobază (pentru achiziție și service vehicule). Shift comută între construire/afișare cost estimat
 STR_ROAD_TOOLBAR_TOOLTIP_BUILD_TRAM_VEHICLE_DEPOT               :{BLACK}Construiește un depou de tramvaie (pentru achiziție și service vehicule). Shift comută între construire/afișare cost estimat
-STR_ROAD_TOOLBAR_TOOLTIP_BUILD_BUS_STATION                      :{BLACK}Construiește staţie de autobuz. Ctrl permite alipirea stațiilor. Shift comută între construire/afișare cost estimat
+STR_ROAD_TOOLBAR_TOOLTIP_BUILD_BUS_STATION                      :{BLACK}Construiește stație de autobuz. Ctrl permite alipirea stațiilor. Shift comută între construire/afișare cost estimat
 STR_ROAD_TOOLBAR_TOOLTIP_BUILD_PASSENGER_TRAM_STATION           :{BLACK}Construiește stație de tramvai pentru călători. Ctrl permite alipirea stațiilor. Shift comută între construire/afișare cost estimat
 STR_ROAD_TOOLBAR_TOOLTIP_BUILD_TRUCK_LOADING_BAY                :{BLACK}Construiește platformă pentru camioane. Ctrl permite alipirea stațiilor. Shift comută între construire/afișare cost estimat
 STR_ROAD_TOOLBAR_TOOLTIP_BUILD_CARGO_TRAM_STATION               :{BLACK}Construiește stație pentru tramvai de marfă. Ctrl permite alipirea stațiilor. Shift comută între construire/afișare cost estimat
 STR_ROAD_TOOLBAR_TOOLTIP_TOGGLE_ONE_WAY_ROAD                    :{BLACK}Activare/Dezactivare sensuri unice
 STR_ROAD_TOOLBAR_TOOLTIP_BUILD_ROAD_BRIDGE                      :{BLACK}Construiește un pod rutier. Shift comută între construire/afișare cost estimat
-STR_ROAD_TOOLBAR_TOOLTIP_BUILD_TRAMWAY_BRIDGE                   :{BLACK}Construieşte pod pentru tramvaie. Shift comută între construire/afişare cost estimat
-STR_ROAD_TOOLBAR_TOOLTIP_BUILD_ROAD_TUNNEL                      :{BLACK}Construieşte tunel rutier. Shift comută între construire/afişare cost estimat
-STR_ROAD_TOOLBAR_TOOLTIP_BUILD_TRAMWAY_TUNNEL                   :{BLACK}Construieşte tunel pentru tramvaie. Shift comută între construire/afişare cost estimat
-STR_ROAD_TOOLBAR_TOOLTIP_TOGGLE_BUILD_REMOVE_FOR_ROAD           :{BLACK}Comutator pentru construcţie/înlăturare şosele
-STR_ROAD_TOOLBAR_TOOLTIP_TOGGLE_BUILD_REMOVE_FOR_TRAMWAYS       :{BLACK}Comută construcţie/înlăturare pentru şine de tramvai
+STR_ROAD_TOOLBAR_TOOLTIP_BUILD_TRAMWAY_BRIDGE                   :{BLACK}Construiește pod pentru tramvaie. Shift comută între construire/afișare cost estimat
+STR_ROAD_TOOLBAR_TOOLTIP_BUILD_ROAD_TUNNEL                      :{BLACK}Construiește tunel rutier. Shift comută între construire/afișare cost estimat
+STR_ROAD_TOOLBAR_TOOLTIP_BUILD_TRAMWAY_TUNNEL                   :{BLACK}Construiește tunel pentru tramvaie. Shift comută între construire/afișare cost estimat
+STR_ROAD_TOOLBAR_TOOLTIP_TOGGLE_BUILD_REMOVE_FOR_ROAD           :{BLACK}Comutator pentru construcție/înlăturare șosele
+STR_ROAD_TOOLBAR_TOOLTIP_TOGGLE_BUILD_REMOVE_FOR_TRAMWAYS       :{BLACK}Comută construcție/înlăturare pentru șine de tramvai
 STR_ROAD_TOOLBAR_TOOLTIP_CONVERT_ROAD                           :{BLACK}Convertește/Modernizează tipul drumului. Shift comută construcția/afișarea costului estimat
 STR_ROAD_TOOLBAR_TOOLTIP_CONVERT_TRAM                           :{BLACK}Convertește/Modernizează tipul tramvaiului. Shift comută construcția/afișarea costului estimat
 
@@ -2815,30 +2815,30 @@ STR_BUILD_DEPOT_TRAM_ORIENTATION_CAPTION                        :{WHITE}Orientar
 STR_BUILD_DEPOT_TRAM_ORIENTATION_SELECT_TOOLTIP                 :{BLACK}Alege orientarea depoului de tramvaie
 
 # Road vehicle station construction window
-STR_STATION_BUILD_BUS_ORIENTATION                               :{WHITE}Orientarea staţiei de autobuz
-STR_STATION_BUILD_BUS_ORIENTATION_TOOLTIP                       :{BLACK}Alege orientarea staţiei de autobuz
+STR_STATION_BUILD_BUS_ORIENTATION                               :{WHITE}Orientarea stației de autobuz
+STR_STATION_BUILD_BUS_ORIENTATION_TOOLTIP                       :{BLACK}Alege orientarea stației de autobuz
 STR_STATION_BUILD_TRUCK_ORIENTATION                             :{WHITE}Orientarea platformei pentru camioane
 STR_STATION_BUILD_TRUCK_ORIENTATION_TOOLTIP                     :{BLACK}Alege orientarea platformei pentru camioane
-STR_STATION_BUILD_PASSENGER_TRAM_ORIENTATION                    :{WHITE}Orientarea staţiei de tramvai pentru călători
-STR_STATION_BUILD_PASSENGER_TRAM_ORIENTATION_TOOLTIP            :{BLACK}Alege orientarea staţiei de tramvai pentru călători
-STR_STATION_BUILD_CARGO_TRAM_ORIENTATION                        :{WHITE}Orientarea staţiei de tramvai pentru marfă
-STR_STATION_BUILD_CARGO_TRAM_ORIENTATION_TOOLTIP                :{BLACK}Alege orientarea staţiei de tramvai pentru marfă
+STR_STATION_BUILD_PASSENGER_TRAM_ORIENTATION                    :{WHITE}Orientarea stației de tramvai pentru călători
+STR_STATION_BUILD_PASSENGER_TRAM_ORIENTATION_TOOLTIP            :{BLACK}Alege orientarea stației de tramvai pentru călători
+STR_STATION_BUILD_CARGO_TRAM_ORIENTATION                        :{WHITE}Orientarea stației de tramvai pentru marfă
+STR_STATION_BUILD_CARGO_TRAM_ORIENTATION_TOOLTIP                :{BLACK}Alege orientarea stației de tramvai pentru marfă
 
 # Waterways toolbar (last two for SE only)
-STR_WATERWAYS_TOOLBAR_CAPTION                                   :{WHITE}Construcţie rute acvatice
+STR_WATERWAYS_TOOLBAR_CAPTION                                   :{WHITE}Construcție rute acvatice
 STR_WATERWAYS_TOOLBAR_CAPTION_SE                                :{WHITE}Rute acvatice
-STR_WATERWAYS_TOOLBAR_BUILD_CANALS_TOOLTIP                      :{BLACK}Construieşte canale. Shift comută între construire/afişare cost estimat
-STR_WATERWAYS_TOOLBAR_BUILD_LOCKS_TOOLTIP                       :{BLACK}Construieşte ecluză. Shift comută între construire/afişare cost estimat
+STR_WATERWAYS_TOOLBAR_BUILD_CANALS_TOOLTIP                      :{BLACK}Construiește canale. Shift comută între construire/afișare cost estimat
+STR_WATERWAYS_TOOLBAR_BUILD_LOCKS_TOOLTIP                       :{BLACK}Construiește ecluză. Shift comută între construire/afișare cost estimat
 STR_WATERWAYS_TOOLBAR_BUILD_DEPOT_TOOLTIP                       :{BLACK}Construiește un șantier naval (pentru achiziționare și service nave). Shift comută între construire/afișare cost estimat
-STR_WATERWAYS_TOOLBAR_BUILD_DOCK_TOOLTIP                        :{BLACK}Construieşte port. Ctrl permite alipirea staţiilor distante. Shift comută între construire/afişare cost estimat
-STR_WATERWAYS_TOOLBAR_BUOY_TOOLTIP                              :{BLACK}Amplasează o baliză ce poate fi utilizată pentru direcţionare. Shift comută între amplasare/afişare cost estimat
-STR_WATERWAYS_TOOLBAR_BUILD_AQUEDUCT_TOOLTIP                    :{BLACK}Construieşte apeduct. Shift comută între construire/afişare cost estimat
-STR_WATERWAYS_TOOLBAR_CREATE_LAKE_TOOLTIP                       :{BLACK}Defineşte zona apei.{}Creează un canal, excepţie când Ctrl este apăsat la nivelul mării, ce va determina inundarea împrejurimilor
+STR_WATERWAYS_TOOLBAR_BUILD_DOCK_TOOLTIP                        :{BLACK}Construiește port. Ctrl permite alipirea stațiilor distante. Shift comută între construire/afișare cost estimat
+STR_WATERWAYS_TOOLBAR_BUOY_TOOLTIP                              :{BLACK}Amplasează o baliză ce poate fi utilizată pentru direcționare. Shift comută între amplasare/afișare cost estimat
+STR_WATERWAYS_TOOLBAR_BUILD_AQUEDUCT_TOOLTIP                    :{BLACK}Construiește apeduct. Shift comută între construire/afișare cost estimat
+STR_WATERWAYS_TOOLBAR_CREATE_LAKE_TOOLTIP                       :{BLACK}Definește zona apei.{}Creează un canal, excepție când Ctrl este apăsat la nivelul mării, ce va determina inundarea împrejurimilor
 STR_WATERWAYS_TOOLBAR_CREATE_RIVER_TOOLTIP                      :{BLACK}Amplasează râuri. Ctrl selectează aria pe diagonală
 
 # Ship depot construction window
-STR_DEPOT_BUILD_SHIP_CAPTION                                    :{WHITE}Orientarea şantierului naval
-STR_DEPOT_BUILD_SHIP_ORIENTATION_TOOLTIP                        :{BLACK}Alege orientarea şantierului naval
+STR_DEPOT_BUILD_SHIP_CAPTION                                    :{WHITE}Orientarea șantierului naval
+STR_DEPOT_BUILD_SHIP_ORIENTATION_TOOLTIP                        :{BLACK}Alege orientarea șantierului naval
 
 # Dock construction window
 STR_STATION_BUILD_DOCK_CAPTION                                  :{WHITE}Port
@@ -2849,14 +2849,14 @@ STR_TOOLBAR_AIRCRAFT_BUILD_AIRPORT_TOOLTIP                      :{BLACK}Construi
 
 # Airport construction window
 STR_STATION_BUILD_AIRPORT_CAPTION                               :{WHITE}Alege tipul de aeroport
-STR_STATION_BUILD_AIRPORT_TOOLTIP                               :{BLACK}Alege tipul şi mărimea aeroportului
+STR_STATION_BUILD_AIRPORT_TOOLTIP                               :{BLACK}Alege tipul și mărimea aeroportului
 STR_STATION_BUILD_AIRPORT_CLASS_LABEL                           :{BLACK}Clasa aeroportului
 STR_STATION_BUILD_AIRPORT_LAYOUT_NAME                           :{BLACK}Amplasare {NUM}
 
 STR_AIRPORT_SMALL                                               :Mic
-STR_AIRPORT_CITY                                                :Orăşenesc
+STR_AIRPORT_CITY                                                :Orășenesc
 STR_AIRPORT_METRO                                               :Metropolitan
-STR_AIRPORT_INTERNATIONAL                                       :Internaţional
+STR_AIRPORT_INTERNATIONAL                                       :Internațional
 STR_AIRPORT_COMMUTER                                            :Navetist
 STR_AIRPORT_INTERCONTINENTAL                                    :Intercontinental
 STR_AIRPORT_HELIPORT                                            :Helidrom
@@ -2872,26 +2872,26 @@ STR_STATION_BUILD_NOISE                                         :{BLACK}Zgomot g
 
 # Landscaping toolbar
 STR_LANDSCAPING_TOOLBAR                                         :{WHITE}Modificare peisaj
-STR_LANDSCAPING_TOOLTIP_LOWER_A_CORNER_OF_LAND                  :{BLACK}Scade altitudinea unui punct de teren. Trage cu mouse-ul pentru a coborî primul punct de teren și a nivela restul zonei la noua înălțime a acestuia. Ctrl pentru selecţie pe diagonală.
-STR_LANDSCAPING_TOOLTIP_RAISE_A_CORNER_OF_LAND                  :{BLACK}Creşte altitudinea unui punct de teren. Trage cu mouse-ul pentru a ridica primul punct de teren și a nivela restul zonei la noua înălțime a acestuia. Ctrl pentru selecţie pe diagonală.
+STR_LANDSCAPING_TOOLTIP_LOWER_A_CORNER_OF_LAND                  :{BLACK}Scade altitudinea unui punct de teren. Trage cu mouse-ul pentru a coborî primul punct de teren și a nivela restul zonei la noua înălțime a acestuia. Ctrl pentru selecție pe diagonală.
+STR_LANDSCAPING_TOOLTIP_RAISE_A_CORNER_OF_LAND                  :{BLACK}Crește altitudinea unui punct de teren. Trage cu mouse-ul pentru a ridica primul punct de teren și a nivela restul zonei la noua înălțime a acestuia. Ctrl pentru selecție pe diagonală.
 STR_LANDSCAPING_LEVEL_LAND_TOOLTIP                              :{BLACK}Nivelează terenul la înălțimea primului colț selectat. Ctrl pentru selecție pe diagonală
 STR_LANDSCAPING_TOOLTIP_PURCHASE_LAND                           :{BLACK}Cumpărați teren pentru utilizare ulterioară. Ctrl selectează zona în diagonală. Shift comută construirea/afișarea estimării costurilor
 
 # Object construction window
-STR_OBJECT_BUILD_CAPTION                                        :{WHITE}Selecţia obiectelor
+STR_OBJECT_BUILD_CAPTION                                        :{WHITE}Selecția obiectelor
 STR_OBJECT_BUILD_TOOLTIP                                        :{BLACK}Selectați obiectul de construit. Ctrl selectează zona în diagonală. Shift comută construirea/afișarea estimării costurilor
 STR_OBJECT_BUILD_CLASS_TOOLTIP                                  :{BLACK}Selectează clasa obiectului de construit
 STR_OBJECT_BUILD_PREVIEW_TOOLTIP                                :{BLACK}Previzualizarea obiectului
-STR_OBJECT_BUILD_SIZE                                           :{BLACK}Dimensiune: {GOLD}{NUM} x {NUM} pătrăţele
+STR_OBJECT_BUILD_SIZE                                           :{BLACK}Dimensiune: {GOLD}{NUM} x {NUM} pătrățele
 
 STR_OBJECT_CLASS_LTHS                                           :Faruri
-STR_OBJECT_CLASS_TRNS                                           :Transmiţătoare
+STR_OBJECT_CLASS_TRNS                                           :Transmițătoare
 
 # Tree planting window (last eight for SE only)
 STR_PLANT_TREE_CAPTION                                          :{WHITE}Arbori
 STR_PLANT_TREE_TOOLTIP                                          :{BLACK}Alege specia de arbori de plantat. Dacă există deja un arbore în locația dorită, se vor adăuga arbori de tip mixt, indiferent de specia selectată
 STR_TREES_RANDOM_TYPE                                           :{BLACK}Arbori din specii aleatoare
-STR_TREES_RANDOM_TYPE_TOOLTIP                                   :{BLACK}Plantează arbori din diverse specii la întâmplare. Ctrl selectează zona în diagonală. Shift comută între plantare/afişare cost estimat
+STR_TREES_RANDOM_TYPE_TOOLTIP                                   :{BLACK}Plantează arbori din diverse specii la întâmplare. Ctrl selectează zona în diagonală. Shift comută între plantare/afișare cost estimat
 STR_TREES_RANDOM_TREES_BUTTON                                   :{BLACK}Arbori aleatori
 STR_TREES_RANDOM_TREES_TOOLTIP                                  :{BLACK}Plantează aleator arbori pe uscat
 STR_TREES_MODE_NORMAL_BUTTON                                    :{BLACK}Normal
@@ -2902,49 +2902,49 @@ STR_TREES_MODE_FOREST_LG_BUTTON                                 :{BLACK}Pădure
 STR_TREES_MODE_FOREST_LG_TOOLTIP                                :{BLACK}Plantează păduri întinse prin tragerea peste peisaj.
 
 # Land generation window (SE)
-STR_TERRAFORM_TOOLBAR_LAND_GENERATION_CAPTION                   :{WHITE}Generator suprafaţă uscat
-STR_TERRAFORM_TOOLTIP_PLACE_ROCKY_AREAS_ON_LANDSCAPE            :{BLACK}Plasează formaţiuni pietroase
-STR_TERRAFORM_TOOLTIP_DEFINE_DESERT_AREA                        :{BLACK}Defineşte suprafaţa de deşert.{}Ţine apăsat Ctrl pentru a şterge
-STR_TERRAFORM_TOOLTIP_INCREASE_SIZE_OF_LAND_AREA                :{BLACK}Măreşte aria de editare a terenului
-STR_TERRAFORM_TOOLTIP_DECREASE_SIZE_OF_LAND_AREA                :{BLACK}Micşorează aria de editare a terenului
+STR_TERRAFORM_TOOLBAR_LAND_GENERATION_CAPTION                   :{WHITE}Generator suprafață uscat
+STR_TERRAFORM_TOOLTIP_PLACE_ROCKY_AREAS_ON_LANDSCAPE            :{BLACK}Plasează formațiuni pietroase
+STR_TERRAFORM_TOOLTIP_DEFINE_DESERT_AREA                        :{BLACK}Definește suprafața de deșert.{}ține apăsat Ctrl pentru a șterge
+STR_TERRAFORM_TOOLTIP_INCREASE_SIZE_OF_LAND_AREA                :{BLACK}Mărește aria de editare a terenului
+STR_TERRAFORM_TOOLTIP_DECREASE_SIZE_OF_LAND_AREA                :{BLACK}Micșorează aria de editare a terenului
 STR_TERRAFORM_TOOLTIP_GENERATE_RANDOM_LAND                      :{BLACK}Generează teren aleator
 STR_TERRAFORM_SE_NEW_WORLD                                      :{BLACK}Creează o hartă nouă
 STR_TERRAFORM_RESET_LANDSCAPE                                   :{BLACK}Resetează peisajul
-STR_TERRAFORM_RESET_LANDSCAPE_TOOLTIP                           :{BLACK}Elimină de pe hartă toate proprietăţile deţinute de companii
+STR_TERRAFORM_RESET_LANDSCAPE_TOOLTIP                           :{BLACK}Elimină de pe hartă toate proprietățile deținute de companii
 
 STR_QUERY_RESET_LANDSCAPE_CAPTION                               :{WHITE}Resetare peisaj
-STR_RESET_LANDSCAPE_CONFIRMATION_TEXT                           :{WHITE}Eşti sigur că vrei să elimini toate proprietăţile deţinute de companii?
+STR_RESET_LANDSCAPE_CONFIRMATION_TEXT                           :{WHITE}Ești sigur că vrei să elimini toate proprietățile deținute de companii?
 
 # Town generation window (SE)
-STR_FOUND_TOWN_CAPTION                                          :{WHITE}Generare oraş
-STR_FOUND_TOWN_NEW_TOWN_BUTTON                                  :{BLACK}Oraş nou
-STR_FOUND_TOWN_NEW_TOWN_TOOLTIP                                 :{BLACK}Construieşte un oraş nou. Shift+Click arată costul estimat
-STR_FOUND_TOWN_RANDOM_TOWN_BUTTON                               :{BLACK}Oraş aleator
-STR_FOUND_TOWN_RANDOM_TOWN_TOOLTIP                              :{BLACK}Construieşte un oraş într-o locaţie aleatoare
-STR_FOUND_TOWN_MANY_RANDOM_TOWNS                                :{BLACK}Mai multe oraşe aleatoare
-STR_FOUND_TOWN_RANDOM_TOWNS_TOOLTIP                             :{BLACK}Umple harta cu oraşe generate aleator
+STR_FOUND_TOWN_CAPTION                                          :{WHITE}Generare oraș
+STR_FOUND_TOWN_NEW_TOWN_BUTTON                                  :{BLACK}Oraș nou
+STR_FOUND_TOWN_NEW_TOWN_TOOLTIP                                 :{BLACK}Construiește un oraș nou. Shift+Click arată costul estimat
+STR_FOUND_TOWN_RANDOM_TOWN_BUTTON                               :{BLACK}Oraș aleator
+STR_FOUND_TOWN_RANDOM_TOWN_TOOLTIP                              :{BLACK}Construiește un oraș într-o locație aleatoare
+STR_FOUND_TOWN_MANY_RANDOM_TOWNS                                :{BLACK}Mai multe orașe aleatoare
+STR_FOUND_TOWN_RANDOM_TOWNS_TOOLTIP                             :{BLACK}Umple harta cu orașe generate aleator
 STR_FOUND_TOWN_EXPAND_ALL_TOWNS                                 :{BLACK}Extinde orasele
 STR_FOUND_TOWN_EXPAND_ALL_TOWNS_TOOLTIP                         :{BLACK}Fă toate orașele să crească ușor
 
-STR_FOUND_TOWN_NAME_TITLE                                       :{YELLOW}Nume oraş:
-STR_FOUND_TOWN_NAME_EDITOR_TITLE                                :{BLACK}Introdu numele oraşului
-STR_FOUND_TOWN_NAME_EDITOR_HELP                                 :{BLACK}Click pentru a introduce numele oraşului
+STR_FOUND_TOWN_NAME_TITLE                                       :{YELLOW}Nume oraș:
+STR_FOUND_TOWN_NAME_EDITOR_TITLE                                :{BLACK}Introdu numele orașului
+STR_FOUND_TOWN_NAME_EDITOR_HELP                                 :{BLACK}Click pentru a introduce numele orașului
 STR_FOUND_TOWN_NAME_RANDOM_BUTTON                               :{BLACK}Nume aleator
 STR_FOUND_TOWN_NAME_RANDOM_TOOLTIP                              :{BLACK}Generează un nume aleator
 
-STR_FOUND_TOWN_INITIAL_SIZE_TITLE                               :{YELLOW}Mărime oraş:
+STR_FOUND_TOWN_INITIAL_SIZE_TITLE                               :{YELLOW}Mărime oraș:
 STR_FOUND_TOWN_INITIAL_SIZE_SMALL_BUTTON                        :{BLACK}Mic
 STR_FOUND_TOWN_INITIAL_SIZE_MEDIUM_BUTTON                       :{BLACK}Mediu
 STR_FOUND_TOWN_INITIAL_SIZE_LARGE_BUTTON                        :{BLACK}Mare
 STR_FOUND_TOWN_SIZE_RANDOM                                      :{BLACK}Aleator
-STR_FOUND_TOWN_INITIAL_SIZE_TOOLTIP                             :{BLACK}Alege mărimea oraşului
+STR_FOUND_TOWN_INITIAL_SIZE_TOOLTIP                             :{BLACK}Alege mărimea orașului
 STR_FOUND_TOWN_CITY                                             :{BLACK}Metropolă
 STR_FOUND_TOWN_CITY_TOOLTIP                                     :{BLACK}Metropolele cresc mai repede decât orașele{}În funcție de setări, sunt mai mari când sunt fondate
 
-STR_FOUND_TOWN_ROAD_LAYOUT                                      :{YELLOW}Modelul drumului în oraş:
-STR_FOUND_TOWN_SELECT_TOWN_ROAD_LAYOUT                          :{BLACK}Alege modelul de drum folosit pentru acest oraş
+STR_FOUND_TOWN_ROAD_LAYOUT                                      :{YELLOW}Modelul drumului în oraș:
+STR_FOUND_TOWN_SELECT_TOWN_ROAD_LAYOUT                          :{BLACK}Alege modelul de drum folosit pentru acest oraș
 STR_FOUND_TOWN_SELECT_LAYOUT_ORIGINAL                           :{BLACK}Original
-STR_FOUND_TOWN_SELECT_LAYOUT_BETTER_ROADS                       :{BLACK}Îmbunătăţit
+STR_FOUND_TOWN_SELECT_LAYOUT_BETTER_ROADS                       :{BLACK}Îmbunătățit
 STR_FOUND_TOWN_SELECT_LAYOUT_2X2_GRID                           :{BLACK}Grilă 2x2
 STR_FOUND_TOWN_SELECT_LAYOUT_3X3_GRID                           :{BLACK}Grilă 3x3
 STR_FOUND_TOWN_SELECT_LAYOUT_RANDOM                             :{BLACK}Aleator
@@ -2958,8 +2958,8 @@ STR_FUND_INDUSTRY_MANY_RANDOM_INDUSTRIES_CAPTION                :{WHITE}Creează
 STR_FUND_INDUSTRY_MANY_RANDOM_INDUSTRIES_QUERY                  :{YELLOW}Sigure vrei să creezi multe industrii aleatoare?
 STR_FUND_INDUSTRY_INDUSTRY_BUILD_COST                           :{BLACK}Cost: {YELLOW}{CURRENCY_LONG}
 STR_FUND_INDUSTRY_PROSPECT_NEW_INDUSTRY                         :{BLACK}Prospectează
-STR_FUND_INDUSTRY_BUILD_NEW_INDUSTRY                            :{BLACK}Construieşte
-STR_FUND_INDUSTRY_FUND_NEW_INDUSTRY                             :{BLACK}Finanţează
+STR_FUND_INDUSTRY_BUILD_NEW_INDUSTRY                            :{BLACK}Construiește
+STR_FUND_INDUSTRY_FUND_NEW_INDUSTRY                             :{BLACK}Finanțează
 STR_FUND_INDUSTRY_REMOVE_ALL_INDUSTRIES                         :{BLACK}Elimină toate industriile
 STR_FUND_INDUSTRY_REMOVE_ALL_INDUSTRIES_TOOLTIP                 :{BLACK}Elimină toate industriile prezente acum pe hartă
 STR_FUND_INDUSTRY_REMOVE_ALL_INDUSTRIES_CAPTION                 :{WHITE}Elimină toate industriile
@@ -2971,12 +2971,12 @@ STR_INDUSTRY_CARGOES_CARGO_CAPTION                              :{WHITE}Lant de 
 STR_INDUSTRY_CARGOES_PRODUCERS                                  :{WHITE}Industrii producătoare
 STR_INDUSTRY_CARGOES_CUSTOMERS                                  :{WHITE}Industrii acceptante
 STR_INDUSTRY_CARGOES_HOUSES                                     :{WHITE}Case
-STR_INDUSTRY_CARGOES_INDUSTRY_TOOLTIP                           :{BLACK}Click pe industrie pentru a vedea furnizorii şi clienţii săi
-STR_INDUSTRY_CARGOES_CARGO_TOOLTIP                              :{BLACK}{STRING}{}Click pe cargo pentru a vedea furnizorii şi clienţii săi
-STR_INDUSTRY_DISPLAY_CHAIN                                      :{BLACK}Lanţ industrial
+STR_INDUSTRY_CARGOES_INDUSTRY_TOOLTIP                           :{BLACK}Click pe industrie pentru a vedea furnizorii și clienții săi
+STR_INDUSTRY_CARGOES_CARGO_TOOLTIP                              :{BLACK}{STRING}{}Click pe cargo pentru a vedea furnizorii și clienții săi
+STR_INDUSTRY_DISPLAY_CHAIN                                      :{BLACK}Lanț industrial
 STR_INDUSTRY_DISPLAY_CHAIN_TOOLTIP                              :{BLACK}Afișează industriile care furnizează și acceptă marfă
 STR_INDUSTRY_CARGOES_NOTIFY_SMALLMAP                            :{BLACK}Link către harta mică
-STR_INDUSTRY_CARGOES_NOTIFY_SMALLMAP_TOOLTIP                    :{BLACK}Selectează industriile afişate şi pe harta mică
+STR_INDUSTRY_CARGOES_NOTIFY_SMALLMAP_TOOLTIP                    :{BLACK}Selectează industriile afișate și pe harta mică
 STR_INDUSTRY_CARGOES_SELECT_CARGO                               :{BLACK}Alege tipul de marfă
 STR_INDUSTRY_CARGOES_SELECT_CARGO_TOOLTIP                       :{BLACK}Alege tipul de marfă pe care dorești să îl afișezi
 STR_INDUSTRY_CARGOES_SELECT_INDUSTRY                            :{BLACK}Alege industria
@@ -2987,18 +2987,18 @@ STR_LAND_AREA_INFORMATION_CAPTION                               :{WHITE}Informa�
 STR_LAND_AREA_INFORMATION_LOCATION_TOOLTIP                      :{BLACK}Centrează vizorul principal pe locația dalei. Ctrl+clic deschide un vizor nou pe locația dalei
 STR_LAND_AREA_INFORMATION_COST_TO_CLEAR_N_A                     :{BLACK}Costul demolării: {LTBLUE}nu este cazul
 STR_LAND_AREA_INFORMATION_COST_TO_CLEAR                         :{BLACK}Costul demolării: {RED}{CURRENCY_LONG}
-STR_LAND_AREA_INFORMATION_REVENUE_WHEN_CLEARED                  :{BLACK}Încasări după curăţare: {LTBLUE}{CURRENCY_LONG}
+STR_LAND_AREA_INFORMATION_REVENUE_WHEN_CLEARED                  :{BLACK}Încasări după curățare: {LTBLUE}{CURRENCY_LONG}
 STR_LAND_AREA_INFORMATION_OWNER_N_A                             :nu este cazul
 STR_LAND_AREA_INFORMATION_OWNER                                 :{BLACK}Proprietar: {LTBLUE}{STRING}
 STR_LAND_AREA_INFORMATION_ROAD_OWNER                            :{BLACK}Proprietar al drumului: {LTBLUE}{STRING}
-STR_LAND_AREA_INFORMATION_TRAM_OWNER                            :{BLACK}Proprietar al şinei de tramvai: {LTBLUE}{STRING}
+STR_LAND_AREA_INFORMATION_TRAM_OWNER                            :{BLACK}Proprietar al șinei de tramvai: {LTBLUE}{STRING}
 STR_LAND_AREA_INFORMATION_RAIL_OWNER                            :{BLACK}Proprietar al căii ferate: {LTBLUE}{STRING}
 STR_LAND_AREA_INFORMATION_LOCAL_AUTHORITY                       :{BLACK}Autoritatea locală: {LTBLUE}{STRING}
 STR_LAND_AREA_INFORMATION_LOCAL_AUTHORITY_NONE                  :Niciuna
 STR_LAND_AREA_INFORMATION_LANDINFO_COORDS                       :{BLACK}Coordonate: {LTBLUE}{NUM} x {NUM} x {NUM} ({STRING})
-STR_LAND_AREA_INFORMATION_BUILD_DATE                            :{BLACK}Data construcţiei: {LTBLUE}{DATE_LONG}
-STR_LAND_AREA_INFORMATION_STATION_CLASS                         :{BLACK}Clasa staţiei: {LTBLUE}{STRING}
-STR_LAND_AREA_INFORMATION_STATION_TYPE                          :{BLACK}Tip staţie: {LTBLUE}{STRING}
+STR_LAND_AREA_INFORMATION_BUILD_DATE                            :{BLACK}Data construcției: {LTBLUE}{DATE_LONG}
+STR_LAND_AREA_INFORMATION_STATION_CLASS                         :{BLACK}Clasa stației: {LTBLUE}{STRING}
+STR_LAND_AREA_INFORMATION_STATION_TYPE                          :{BLACK}Tip stație: {LTBLUE}{STRING}
 STR_LAND_AREA_INFORMATION_AIRPORT_CLASS                         :{BLACK}Clasă aeroport: {LTBLUE}{STRING}
 STR_LAND_AREA_INFORMATION_AIRPORT_NAME                          :{BLACK}Nume aeroport: {LTBLUE}{STRING}
 STR_LAND_AREA_INFORMATION_AIRPORTTILE_NAME                      :{BLACK}Numele dalei aeroportului: {LTBLUE}{STRING}
@@ -3016,10 +3016,10 @@ STR_LANG_AREA_INFORMATION_TRAM_SPEED_LIMIT                      :{BLACK}Limită 
 STR_LAI_CLEAR_DESCRIPTION_ROCKS                                 :Stânci
 STR_LAI_CLEAR_DESCRIPTION_ROUGH_LAND                            :Teren pietros
 STR_LAI_CLEAR_DESCRIPTION_BARE_LAND                             :Teren viran
-STR_LAI_CLEAR_DESCRIPTION_GRASS                                 :Verdeaţă
+STR_LAI_CLEAR_DESCRIPTION_GRASS                                 :Verdeață
 STR_LAI_CLEAR_DESCRIPTION_FIELDS                                :Teren agricol
 STR_LAI_CLEAR_DESCRIPTION_SNOW_COVERED_LAND                     :Teren înzăpezit
-STR_LAI_CLEAR_DESCRIPTION_DESERT                                :Deşert
+STR_LAI_CLEAR_DESCRIPTION_DESERT                                :Deșert
 
 STR_LAI_RAIL_DESCRIPTION_TRACK                                  :Cale ferată cale ferată
 STR_LAI_RAIL_DESCRIPTION_TRACK_WITH_NORMAL_SIGNALS              :Cale ferată cale ferată cu semafoare
@@ -3042,28 +3042,28 @@ STR_LAI_RAIL_DESCRIPTION_TRACK_WITH_EXIT_PBSSIGNALS             :Cale ferată ca
 STR_LAI_RAIL_DESCRIPTION_TRACK_WITH_EXIT_NOENTRYSIGNALS         :Cale ferată cale ferată cu semafoare de ieșire și semafoare direcționale unidirecționale
 STR_LAI_RAIL_DESCRIPTION_TRACK_WITH_COMBO_PBSSIGNALS            :Cale ferată cale ferată cu semafoare combo și semafoare direcționale
 STR_LAI_RAIL_DESCRIPTION_TRACK_WITH_COMBO_NOENTRYSIGNALS        :Cale ferată cale ferată cu semafoare combo și semafoare direcționale unidirecționale
-STR_LAI_RAIL_DESCRIPTION_TRACK_WITH_PBS_NOENTRYSIGNALS          :Cale ferată cale ferată cu semafoare direcționale şi semafoare directionale unidirecționale
+STR_LAI_RAIL_DESCRIPTION_TRACK_WITH_PBS_NOENTRYSIGNALS          :Cale ferată cale ferată cu semafoare direcționale și semafoare directionale unidirecționale
 STR_LAI_RAIL_DESCRIPTION_TRAIN_DEPOT                            :Cale ferată depou trenuri
 
-STR_LAI_ROAD_DESCRIPTION_ROAD                                   :Şosea
+STR_LAI_ROAD_DESCRIPTION_ROAD                                   :șosea
 STR_LAI_ROAD_DESCRIPTION_ROAD_WITH_STREETLIGHTS                 :Stradă iluminată
 STR_LAI_ROAD_DESCRIPTION_TREE_LINED_ROAD                        :Stradă cu copaci pe margine
 STR_LAI_ROAD_DESCRIPTION_ROAD_VEHICLE_DEPOT                     :Autobază
 STR_LAI_ROAD_DESCRIPTION_ROAD_RAIL_LEVEL_CROSSING               :Trecere la nivel cu calea ferată
-STR_LAI_ROAD_DESCRIPTION_TRAMWAY                                :Şină de tramvai
+STR_LAI_ROAD_DESCRIPTION_TRAMWAY                                :șină de tramvai
 
 # Houses come directly from their building names
-STR_LAI_TOWN_INDUSTRY_DESCRIPTION_UNDER_CONSTRUCTION            :{STRING} (în construcţie)
+STR_LAI_TOWN_INDUSTRY_DESCRIPTION_UNDER_CONSTRUCTION            :{STRING} (în construcție)
 
 STR_LAI_TREE_NAME_TREES                                         :Arbori
 STR_LAI_TREE_NAME_RAINFOREST                                    :Pădure tropicală
-STR_LAI_TREE_NAME_CACTUS_PLANTS                                 :Cactuşi
+STR_LAI_TREE_NAME_CACTUS_PLANTS                                 :Cactuși
 
 STR_LAI_STATION_DESCRIPTION_RAILROAD_STATION                    :Gară
 STR_LAI_STATION_DESCRIPTION_AIRCRAFT_HANGAR                     :Hangar
 STR_LAI_STATION_DESCRIPTION_AIRPORT                             :Aeroport
 STR_LAI_STATION_DESCRIPTION_TRUCK_LOADING_AREA                  :Platformă pentru camioane
-STR_LAI_STATION_DESCRIPTION_BUS_STATION                         :Staţie de autobuz
+STR_LAI_STATION_DESCRIPTION_BUS_STATION                         :Stație de autobuz
 STR_LAI_STATION_DESCRIPTION_SHIP_DOCK                           :Port
 STR_LAI_STATION_DESCRIPTION_BUOY                                :Baliză
 STR_LAI_STATION_DESCRIPTION_WAYPOINT                            :Punct de tranzit
@@ -3073,24 +3073,24 @@ STR_LAI_WATER_DESCRIPTION_CANAL                                 :Canal
 STR_LAI_WATER_DESCRIPTION_LOCK                                  :Ecluză
 STR_LAI_WATER_DESCRIPTION_RIVER                                 :Râu
 STR_LAI_WATER_DESCRIPTION_COAST_OR_RIVERBANK                    :Coastă sau mal
-STR_LAI_WATER_DESCRIPTION_SHIP_DEPOT                            :Şantier naval
+STR_LAI_WATER_DESCRIPTION_SHIP_DEPOT                            :șantier naval
 
 # Industries come directly from their industry names
 
 STR_LAI_TUNNEL_DESCRIPTION_RAILROAD                             :Tunel feroviar
 STR_LAI_TUNNEL_DESCRIPTION_ROAD                                 :Tunel rutier
 
-STR_LAI_BRIDGE_DESCRIPTION_RAIL_SUSPENSION_STEEL                :Pod feroviar suspendat din oţel
-STR_LAI_BRIDGE_DESCRIPTION_RAIL_GIRDER_STEEL                    :Pod feroviar tip grindă din oţel
-STR_LAI_BRIDGE_DESCRIPTION_RAIL_CANTILEVER_STEEL                :Pod feroviar tip arc din oţel
+STR_LAI_BRIDGE_DESCRIPTION_RAIL_SUSPENSION_STEEL                :Pod feroviar suspendat din oțel
+STR_LAI_BRIDGE_DESCRIPTION_RAIL_GIRDER_STEEL                    :Pod feroviar tip grindă din oțel
+STR_LAI_BRIDGE_DESCRIPTION_RAIL_CANTILEVER_STEEL                :Pod feroviar tip arc din oțel
 STR_LAI_BRIDGE_DESCRIPTION_RAIL_SUSPENSION_CONCRETE             :Pod feroviar suspendat din beton
 STR_LAI_BRIDGE_DESCRIPTION_RAIL_WOODEN                          :Pod feroviar din lemn
 STR_LAI_BRIDGE_DESCRIPTION_RAIL_CONCRETE                        :Pod feroviar din beton
 STR_LAI_BRIDGE_DESCRIPTION_RAIL_TUBULAR_STEEL                   :Pod feroviar tubular
 
-STR_LAI_BRIDGE_DESCRIPTION_ROAD_SUSPENSION_STEEL                :Pod rutier suspendat din oţel
-STR_LAI_BRIDGE_DESCRIPTION_ROAD_GIRDER_STEEL                    :Pod rutier tip grindă din oţel
-STR_LAI_BRIDGE_DESCRIPTION_ROAD_CANTILEVER_STEEL                :Pod rutier tip arc din oţel
+STR_LAI_BRIDGE_DESCRIPTION_ROAD_SUSPENSION_STEEL                :Pod rutier suspendat din oțel
+STR_LAI_BRIDGE_DESCRIPTION_ROAD_GIRDER_STEEL                    :Pod rutier tip grindă din oțel
+STR_LAI_BRIDGE_DESCRIPTION_ROAD_CANTILEVER_STEEL                :Pod rutier tip arc din oțel
 STR_LAI_BRIDGE_DESCRIPTION_ROAD_SUSPENSION_CONCRETE             :Pod rutier suspendat din beton armat
 STR_LAI_BRIDGE_DESCRIPTION_ROAD_WOODEN                          :Pod rutier din lemn
 STR_LAI_BRIDGE_DESCRIPTION_ROAD_CONCRETE                        :Pod rutier din beton
@@ -3098,7 +3098,7 @@ STR_LAI_BRIDGE_DESCRIPTION_ROAD_TUBULAR_STEEL                   :Pod rutier tubu
 
 STR_LAI_BRIDGE_DESCRIPTION_AQUEDUCT                             :Apeduct
 
-STR_LAI_OBJECT_DESCRIPTION_TRANSMITTER                          :Transmiţător
+STR_LAI_OBJECT_DESCRIPTION_TRANSMITTER                          :Transmițător
 STR_LAI_OBJECT_DESCRIPTION_LIGHTHOUSE                           :Far
 STR_LAI_OBJECT_DESCRIPTION_COMPANY_HEADQUARTERS                 :Sediu companie
 STR_LAI_OBJECT_DESCRIPTION_COMPANY_OWNED_LAND                   :Teren în proprietatea unei companii
@@ -3172,21 +3172,21 @@ STR_SAVELOAD_SAVE_CAPTION                                       :{WHITE}Salveaz�
 STR_SAVELOAD_LOAD_CAPTION                                       :{WHITE}Încarcă joc
 STR_SAVELOAD_SAVE_SCENARIO                                      :{WHITE}Salvează scenariu
 STR_SAVELOAD_LOAD_SCENARIO                                      :{WHITE}Încarcă scenariu
-STR_SAVELOAD_LOAD_HEIGHTMAP                                     :{WHITE}Încarcă harta înălţimilor
-STR_SAVELOAD_SAVE_HEIGHTMAP                                     :{WHITE}Salvează harta înălţimilor
+STR_SAVELOAD_LOAD_HEIGHTMAP                                     :{WHITE}Încarcă harta înălțimilor
+STR_SAVELOAD_SAVE_HEIGHTMAP                                     :{WHITE}Salvează harta înălțimilor
 STR_SAVELOAD_HOME_BUTTON                                        :{BLACK}Click aici pentru a ajunge la directorul predefinit pentru salvări
 STR_SAVELOAD_BYTES_FREE                                         :{BLACK}{BYTES} liberi
-STR_SAVELOAD_LIST_TOOLTIP                                       :{BLACK}Lista de discuri, directoare şi fişiere cu jocuri salvate
+STR_SAVELOAD_LIST_TOOLTIP                                       :{BLACK}Lista de discuri, directoare și fișiere cu jocuri salvate
 STR_SAVELOAD_EDITBOX_TOOLTIP                                    :{BLACK}Numele selectat pentru un joc salvat
-STR_SAVELOAD_DELETE_BUTTON                                      :{BLACK}Şterge
-STR_SAVELOAD_DELETE_TOOLTIP                                     :{BLACK}Şterge jocul salvat selectat
+STR_SAVELOAD_DELETE_BUTTON                                      :{BLACK}șterge
+STR_SAVELOAD_DELETE_TOOLTIP                                     :{BLACK}șterge jocul salvat selectat
 STR_SAVELOAD_SAVE_BUTTON                                        :{BLACK}Salvează
 STR_SAVELOAD_SAVE_TOOLTIP                                       :{BLACK}Salvează cu numele selectat jocul curent
 STR_SAVELOAD_LOAD_BUTTON                                        :{BLACK}Încarcă
 STR_SAVELOAD_LOAD_TOOLTIP                                       :{BLACK}Încarcă salvarea selectată
 STR_SAVELOAD_LOAD_HEIGHTMAP_TOOLTIP                             :{BLACK}Încarcă harta selectată
 STR_SAVELOAD_DETAIL_CAPTION                                     :{BLACK}Detalii joc
-STR_SAVELOAD_DETAIL_NOT_AVAILABLE                               :{BLACK}Nicio informaţie disponibilă
+STR_SAVELOAD_DETAIL_NOT_AVAILABLE                               :{BLACK}Nicio informație disponibilă
 STR_SAVELOAD_DETAIL_COMPANY_INDEX                               :{SILVER}{COMMA}: {WHITE}{STRING}
 STR_SAVELOAD_DETAIL_GRFSTATUS                                   :{SILVER}NewGRF: {WHITE}{STRING}
 STR_SAVELOAD_FILTER_TITLE                                       :{BLACK}Filtru:
@@ -3195,17 +3195,17 @@ STR_SAVELOAD_OVERWRITE_WARNING                                  :{YELLOW}Sigur v
 STR_SAVELOAD_DIRECTORY                                          :{STRING} (listă)
 STR_SAVELOAD_PARENT_DIRECTORY                                   :{STRING} (Director părinte)
 
-STR_SAVELOAD_OSKTITLE                                           :{BLACK}Introduceţi un nume pentru salvare
+STR_SAVELOAD_OSKTITLE                                           :{BLACK}Introduceți un nume pentru salvare
 
 # World generation
 STR_MAPGEN_WORLD_GENERATION_CAPTION                             :{WHITE}Generare lume
 STR_MAPGEN_MAPSIZE                                              :{BLACK}Mărime hartă:
 STR_MAPGEN_MAPSIZE_TOOLTIP                                      :{BLACK}Alege mărimea hărții folosind ca unitate de măsură suprafețele. Numărul de suprafețe disponibile va fi puțin mai mic decât această valoare
 STR_MAPGEN_BY                                                   :{BLACK}*
-STR_MAPGEN_NUMBER_OF_TOWNS                                      :{BLACK}Nr. de oraşe:
+STR_MAPGEN_NUMBER_OF_TOWNS                                      :{BLACK}Nr. de orașe:
 STR_MAPGEN_NUMBER_OF_TOWNS_TOOLTIP                              :{BLACK}Selectați densitatea orașelor sau un număr personalizat
 STR_MAPGEN_TOWN_NAME_LABEL                                      :{BLACK}Numele orașelor:
-STR_MAPGEN_TOWN_NAME_DROPDOWN_TOOLTIP                           :{BLACK}Alege naţionalitatea numelor oraşelor
+STR_MAPGEN_TOWN_NAME_DROPDOWN_TOOLTIP                           :{BLACK}Alege naționalitatea numelor orașelor
 STR_MAPGEN_DATE                                                 :{BLACK}Data:
 STR_MAPGEN_DATE_TOOLTIP                                         :{BLACK}Selectați data de începere
 STR_MAPGEN_NUMBER_OF_INDUSTRIES                                 :{BLACK}Nr. de industrii:
@@ -3227,21 +3227,21 @@ STR_MAPGEN_SEA_LEVEL                                            :{BLACK}Nivelul 
 STR_MAPGEN_SEA_LEVEL_TOOLTIP                                    :{BLACK}Selectați nivelul mării
 STR_MAPGEN_QUANTITY_OF_RIVERS                                   :{BLACK}Râuri:
 STR_MAPGEN_SMOOTHNESS                                           :{BLACK}Netezime:
-STR_MAPGEN_VARIETY                                              :{BLACK}Distribuţia varietăţii:
+STR_MAPGEN_VARIETY                                              :{BLACK}Distribuția varietății:
 STR_MAPGEN_GENERATE                                             :{WHITE}Generează
 STR_MAPGEN_GENERATE_TOOLTIP                                     :{BLACK}Creează lumea și joacă OpenTTD!
 STR_MAPGEN_NEWGRF_SETTINGS                                      :{BLACK}Setări NewGRF
-STR_MAPGEN_NEWGRF_SETTINGS_TOOLTIP                              :{BLACK}Afişează setările NewGRF
+STR_MAPGEN_NEWGRF_SETTINGS_TOOLTIP                              :{BLACK}Afișează setările NewGRF
 STR_MAPGEN_AI_SETTINGS                                          :{BLACK}Configurație AI
 STR_MAPGEN_AI_SETTINGS_TOOLTIP                                  :{BLACK}Afișează setările AI
 STR_MAPGEN_GS_SETTINGS                                          :{BLACK}Setări pentru scriptul de joc
 STR_MAPGEN_GS_SETTINGS_TOOLTIP                                  :{BLACK}Afișează setările scriptului de joc
 
 ###length 21
-STR_MAPGEN_TOWN_NAME_ORIGINAL_ENGLISH                           :Englezeşti (Original)
-STR_MAPGEN_TOWN_NAME_FRENCH                                     :Franţuzeşti
-STR_MAPGEN_TOWN_NAME_GERMAN                                     :Nemţeşti
-STR_MAPGEN_TOWN_NAME_ADDITIONAL_ENGLISH                         :Englezeşti (Adiţional)
+STR_MAPGEN_TOWN_NAME_ORIGINAL_ENGLISH                           :Englezești (Original)
+STR_MAPGEN_TOWN_NAME_FRENCH                                     :Franțuzești
+STR_MAPGEN_TOWN_NAME_GERMAN                                     :Nemțești
+STR_MAPGEN_TOWN_NAME_ADDITIONAL_ENGLISH                         :Englezești (Adițional)
 STR_MAPGEN_TOWN_NAME_LATIN_AMERICAN                             :Latino-Americane
 STR_MAPGEN_TOWN_NAME_SILLY                                      :Amuzante
 STR_MAPGEN_TOWN_NAME_SWEDISH                                    :Suedeze
@@ -3250,14 +3250,14 @@ STR_MAPGEN_TOWN_NAME_FINNISH                                    :Finlandeze
 STR_MAPGEN_TOWN_NAME_POLISH                                     :Poloneze
 STR_MAPGEN_TOWN_NAME_SLOVAK                                     :Slovace
 STR_MAPGEN_TOWN_NAME_NORWEGIAN                                  :Norvegiene
-STR_MAPGEN_TOWN_NAME_HUNGARIAN                                  :Ungureşti
+STR_MAPGEN_TOWN_NAME_HUNGARIAN                                  :Ungurești
 STR_MAPGEN_TOWN_NAME_AUSTRIAN                                   :Austriece
-STR_MAPGEN_TOWN_NAME_ROMANIAN                                   :Româneşti
-STR_MAPGEN_TOWN_NAME_CZECH                                      :Ceheşti
-STR_MAPGEN_TOWN_NAME_SWISS                                      :Elveţiene
+STR_MAPGEN_TOWN_NAME_ROMANIAN                                   :Românești
+STR_MAPGEN_TOWN_NAME_CZECH                                      :Cehești
+STR_MAPGEN_TOWN_NAME_SWISS                                      :Elvețiene
 STR_MAPGEN_TOWN_NAME_DANISH                                     :Daneze
-STR_MAPGEN_TOWN_NAME_TURKISH                                    :Turceşti
-STR_MAPGEN_TOWN_NAME_ITALIAN                                    :Italieneşti
+STR_MAPGEN_TOWN_NAME_TURKISH                                    :Turcești
+STR_MAPGEN_TOWN_NAME_ITALIAN                                    :Italienești
 STR_MAPGEN_TOWN_NAME_CATALAN                                    :Catalană
 
 # Strings for map borders at game generation
@@ -3273,8 +3273,8 @@ STR_MAPGEN_BORDER_RANDOM                                        :{BLACK}Aleator
 STR_MAPGEN_BORDER_RANDOMIZE                                     :{BLACK}Aleator
 STR_MAPGEN_BORDER_MANUAL                                        :{BLACK}Manual
 
-STR_MAPGEN_HEIGHTMAP_ROTATION                                   :{BLACK}Rotaţie hartă înălţimi:
-STR_MAPGEN_HEIGHTMAP_NAME                                       :{BLACK}Nume hartă înălţimi:
+STR_MAPGEN_HEIGHTMAP_ROTATION                                   :{BLACK}Rotație hartă înălțimi:
+STR_MAPGEN_HEIGHTMAP_NAME                                       :{BLACK}Nume hartă înălțimi:
 STR_MAPGEN_HEIGHTMAP_NAME_TOOLTIP                               :{BLACK}Numele fișierului al hărții de înălțime
 STR_MAPGEN_HEIGHTMAP_SIZE_LABEL                                 :{BLACK}Dimensiune:
 STR_MAPGEN_HEIGHTMAP_SIZE_LABEL_TOOLTIP                         :{BLACK}Dimensiunea imaginii hărții de înălțime. Pentru cele mai bune rezultate, fiecare margine ar trebui să se potrivească cu o lungime disponibilă a marginii hărții în OpenTTD, cum ar fi 256, 512, 1024 etc.
@@ -3291,25 +3291,25 @@ STR_SE_MAPGEN_CAPTION                                           :{WHITE}Tipul sc
 STR_SE_MAPGEN_FLAT_WORLD                                        :{WHITE}Teren plat
 STR_SE_MAPGEN_FLAT_WORLD_TOOLTIP                                :{BLACK}Generează un teren plat
 STR_SE_MAPGEN_RANDOM_LAND                                       :{WHITE}Teren aleator
-STR_SE_MAPGEN_FLAT_WORLD_HEIGHT                                 :{BLACK}Înălţimea terenului plat:
+STR_SE_MAPGEN_FLAT_WORLD_HEIGHT                                 :{BLACK}Înălțimea terenului plat:
 STR_SE_MAPGEN_FLAT_WORLD_HEIGHT_TOOLTIP                         :{BLACK}Alegeți înălțimea terenului deasupra nivelului mării
-STR_SE_MAPGEN_FLAT_WORLD_HEIGHT_DOWN                            :{BLACK}Mută înălţimea terenului plat cu o unitate în jos
-STR_SE_MAPGEN_FLAT_WORLD_HEIGHT_UP                              :{BLACK}Mută înălţimea terenului plat cu o unitate în sus
+STR_SE_MAPGEN_FLAT_WORLD_HEIGHT_DOWN                            :{BLACK}Mută înălțimea terenului plat cu o unitate în jos
+STR_SE_MAPGEN_FLAT_WORLD_HEIGHT_UP                              :{BLACK}Mută înălțimea terenului plat cu o unitate în sus
 
-STR_SE_MAPGEN_FLAT_WORLD_HEIGHT_QUERY_CAPT                      :{WHITE}Modifică înălţimea terenului plat
+STR_SE_MAPGEN_FLAT_WORLD_HEIGHT_QUERY_CAPT                      :{WHITE}Modifică înălțimea terenului plat
 
 # Map generation progress
 STR_GENERATION_WORLD                                            :{WHITE}Generez lumea...
 STR_GENERATION_ABORT                                            :{BLACK}Anulează
 STR_GENERATION_ABORT_CAPTION                                    :{WHITE}Anulează Generarea Lumii
-STR_GENERATION_ABORT_MESSAGE                                    :{YELLOW}Sigur doreşti să anulezi generarea?
+STR_GENERATION_ABORT_MESSAGE                                    :{YELLOW}Sigur dorești să anulezi generarea?
 STR_GENERATION_PROGRESS                                         :{WHITE}{NUM}% efectuat
 STR_GENERATION_PROGRESS_NUM                                     :{BLACK}{NUM} / {NUM}
 STR_GENERATION_WORLD_GENERATION                                 :{BLACK}Generare lume
 STR_GENERATION_RIVER_GENERATION                                 :{BLACK}Generarea râurilor
 STR_GENERATION_TREE_GENERATION                                  :{BLACK}Generare arbori
 STR_GENERATION_OBJECT_GENERATION                                :{BLACK}Generare fixă
-STR_GENERATION_CLEARING_TILES                                   :{BLACK}Generare zonă dură şi pietroasă
+STR_GENERATION_CLEARING_TILES                                   :{BLACK}Generare zonă dură și pietroasă
 STR_GENERATION_SETTINGUP_GAME                                   :{BLACK}Se configurează jocul
 STR_GENERATION_PREPARING_TILELOOP                               :{BLACK}Initializez ciclul dalelor
 STR_GENERATION_PREPARING_SCRIPT                                 :{BLACK}Se rulează script-ul
@@ -3317,29 +3317,29 @@ STR_GENERATION_PREPARING_GAME                                   :{BLACK}Pregăte
 
 # NewGRF settings
 STR_NEWGRF_SETTINGS_CAPTION                                     :{WHITE}Setări NewGRF
-STR_NEWGRF_SETTINGS_INFO_TITLE                                  :{WHITE}Informaţie detaliată NewGRF
-STR_NEWGRF_SETTINGS_ACTIVE_LIST                                 :{WHITE}Fişiere NewGRF active
-STR_NEWGRF_SETTINGS_INACTIVE_LIST                               :{WHITE}Fişiere NewGRF inactive
+STR_NEWGRF_SETTINGS_INFO_TITLE                                  :{WHITE}Informație detaliată NewGRF
+STR_NEWGRF_SETTINGS_ACTIVE_LIST                                 :{WHITE}Fișiere NewGRF active
+STR_NEWGRF_SETTINGS_INACTIVE_LIST                               :{WHITE}Fișiere NewGRF inactive
 STR_NEWGRF_SETTINGS_SELECT_PRESET                               :{ORANGE}Selectează preset:
 STR_NEWGRF_FILTER_TITLE                                         :{ORANGE}Filtru:
 STR_NEWGRF_SETTINGS_PRESET_LIST_TOOLTIP                         :{BLACK}Încarcă presetarea selectată
 STR_NEWGRF_SETTINGS_PRESET_SAVE                                 :{BLACK}Salvează presetare
 STR_NEWGRF_SETTINGS_PRESET_SAVE_TOOLTIP                         :{BLACK}Salvează lista curentă ca presetare
-STR_NEWGRF_SETTINGS_PRESET_DELETE                               :{BLACK}Şterge presetarea
+STR_NEWGRF_SETTINGS_PRESET_DELETE                               :{BLACK}șterge presetarea
 STR_NEWGRF_SETTINGS_PRESET_DELETE_TOOLTIP                       :{BLACK}Șterge presetarea selectată
 STR_NEWGRF_SETTINGS_ADD                                         :{BLACK}Adaugă
-STR_NEWGRF_SETTINGS_ADD_FILE_TOOLTIP                            :{BLACK}Adaugă fişierul NewGRF ales în configuraţie
-STR_NEWGRF_SETTINGS_RESCAN_FILES                                :{BLACK}Redetectează fişierele
-STR_NEWGRF_SETTINGS_RESCAN_FILES_TOOLTIP                        :{BLACK}Actualizează lista de fişiere NewGRF disponibile
+STR_NEWGRF_SETTINGS_ADD_FILE_TOOLTIP                            :{BLACK}Adaugă fișierul NewGRF ales în configurație
+STR_NEWGRF_SETTINGS_RESCAN_FILES                                :{BLACK}Redetectează fișierele
+STR_NEWGRF_SETTINGS_RESCAN_FILES_TOOLTIP                        :{BLACK}Actualizează lista de fișiere NewGRF disponibile
 STR_NEWGRF_SETTINGS_REMOVE                                      :{BLACK}Elimină
-STR_NEWGRF_SETTINGS_REMOVE_TOOLTIP                              :{BLACK}Elimină fişierul NewGRF selectat din listă
+STR_NEWGRF_SETTINGS_REMOVE_TOOLTIP                              :{BLACK}Elimină fișierul NewGRF selectat din listă
 STR_NEWGRF_SETTINGS_MOVEUP                                      :{BLACK}Mută în sus
-STR_NEWGRF_SETTINGS_MOVEUP_TOOLTIP                              :{BLACK}Mută fişierul NewGRF selectat mai sus în listă
+STR_NEWGRF_SETTINGS_MOVEUP_TOOLTIP                              :{BLACK}Mută fișierul NewGRF selectat mai sus în listă
 STR_NEWGRF_SETTINGS_MOVEDOWN                                    :{BLACK}Mută în jos
-STR_NEWGRF_SETTINGS_MOVEDOWN_TOOLTIP                            :{BLACK}Mută fişierul NewGRF selectat mai jos în listă
+STR_NEWGRF_SETTINGS_MOVEDOWN_TOOLTIP                            :{BLACK}Mută fișierul NewGRF selectat mai jos în listă
 STR_NEWGRF_SETTINGS_UPGRADE                                     :{BLACK}Upgrade
 STR_NEWGRF_SETTINGS_UPGRADE_TOOLTIP                             :{BLACK}Actualizați fișierele NewGRF pentru care aveți o versiune mai nouă instalată
-STR_NEWGRF_SETTINGS_FILE_TOOLTIP                                :{BLACK}O listă a fişierelor NewGRF instalate
+STR_NEWGRF_SETTINGS_FILE_TOOLTIP                                :{BLACK}O listă a fișierelor NewGRF instalate
 
 STR_NEWGRF_SETTINGS_SET_PARAMETERS                              :{BLACK}Setează parametri
 STR_NEWGRF_SETTINGS_SHOW_PARAMETERS                             :{BLACK}Afișează parametrii
@@ -3350,7 +3350,7 @@ STR_NEWGRF_SETTINGS_APPLY_CHANGES                               :{BLACK}Aplică 
 STR_NEWGRF_SETTINGS_FIND_MISSING_CONTENT_BUTTON                 :{BLACK}Caută online resursele lipsă
 STR_NEWGRF_SETTINGS_FIND_MISSING_CONTENT_TOOLTIP                :{BLACK}Verifică dacă resursele care lipsesc pot fi găsite online
 
-STR_NEWGRF_SETTINGS_FILENAME                                    :{BLACK}Nume fişier: {SILVER}{STRING}
+STR_NEWGRF_SETTINGS_FILENAME                                    :{BLACK}Nume fișier: {SILVER}{STRING}
 STR_NEWGRF_SETTINGS_GRF_ID                                      :{BLACK}ID GRF: {SILVER}{STRING}
 STR_NEWGRF_SETTINGS_VERSION                                     :{BLACK}Versiune: {SILVER}{NUM}
 STR_NEWGRF_SETTINGS_MIN_VERSION                                 :{BLACK}Vers. minimă compatibilă: {SILVER}{NUM}
@@ -3363,7 +3363,7 @@ STR_NEWGRF_SETTINGS_PALETTE_LEGACY_32BPP                        :Legacy (W) / 32
 STR_NEWGRF_SETTINGS_PARAMETER                                   :{BLACK}Parametri: {SILVER}{STRING}
 STR_NEWGRF_SETTINGS_PARAMETER_NONE                              :Nimic
 
-STR_NEWGRF_SETTINGS_NO_INFO                                     :{BLACK}Nicio informaţie disponibilă
+STR_NEWGRF_SETTINGS_NO_INFO                                     :{BLACK}Nicio informație disponibilă
 STR_NEWGRF_SETTINGS_NOT_FOUND                                   :{RED}Niciun fisier potrivit
 STR_NEWGRF_SETTINGS_DISABLED                                    :{RED}Dezactivat
 STR_NEWGRF_SETTINGS_INCOMPATIBLE                                :{RED}Incompatibil cu această versiune de OpenTTD
@@ -3383,7 +3383,7 @@ STR_BASEGRF_PARAMETERS_CAPTION                                  :{WHITE}Schimba�
 STR_NEWGRF_PARAMETERS_CAPTION                                   :{WHITE}Schimbă parametrii NewGRF
 STR_NEWGRF_PARAMETERS_CLOSE                                     :{BLACK}Închide
 STR_NEWGRF_PARAMETERS_RESET                                     :{BLACK}Resetează
-STR_NEWGRF_PARAMETERS_RESET_TOOLTIP                             :{BLACK}Setează toţii parametrii la valorile implicite
+STR_NEWGRF_PARAMETERS_RESET_TOOLTIP                             :{BLACK}Setează toții parametrii la valorile implicite
 STR_NEWGRF_PARAMETERS_DEFAULT_NAME                              :Parametru {NUM}
 STR_NEWGRF_PARAMETERS_SETTING                                   :{STRING}: {ORANGE}{STRING}
 STR_NEWGRF_PARAMETERS_NUM_PARAM                                 :{LTBLUE}Număr de parametrii: {ORANGE}{NUM}
@@ -3395,7 +3395,7 @@ STR_NEWGRF_INSPECT_PARENT_TOOLTIP                               :{BLACK}Analizea
 
 STR_NEWGRF_INSPECT_CAPTION_OBJECT_AT                            :{STRING} la {HEX}
 STR_NEWGRF_INSPECT_CAPTION_OBJECT_AT_OBJECT                     :Obiect
-STR_NEWGRF_INSPECT_CAPTION_OBJECT_AT_RAIL_TYPE                  :Tip şină
+STR_NEWGRF_INSPECT_CAPTION_OBJECT_AT_RAIL_TYPE                  :Tip șină
 STR_NEWGRF_INSPECT_CAPTION_OBJECT_AT_ROAD_TYPE                  :Tip de drum
 
 STR_NEWGRF_INSPECT_QUERY_CAPTION                                :{WHITE}Parametru variabilă 60+x NewGRF (hexadecimal)
@@ -3403,13 +3403,13 @@ STR_NEWGRF_INSPECT_QUERY_CAPTION                                :{WHITE}Parametr
 # Sprite aligner window
 STR_SPRITE_ALIGNER_CAPTION                                      :{WHITE}Aliniere imagine {COMMA} ({STRING})
 STR_SPRITE_ALIGNER_NEXT_BUTTON                                  :{BLACK}Imaginea următoare
-STR_SPRITE_ALIGNER_NEXT_TOOLTIP                                 :{BLACK}Mergi la următoarea imagine normală, sărind peste pseudo-imagini, recolorări sau fonturi şi reporneşte când s-a ajuns la sfârşit
+STR_SPRITE_ALIGNER_NEXT_TOOLTIP                                 :{BLACK}Mergi la următoarea imagine normală, sărind peste pseudo-imagini, recolorări sau fonturi și repornește când s-a ajuns la sfârșit
 STR_SPRITE_ALIGNER_GOTO_BUTTON                                  :{BLACK}Mergi la imagine
 STR_SPRITE_ALIGNER_GOTO_TOOLTIP                                 :{BLACK}Mergi la imaginea indicată. Dacă nu este o imagine normală, mergi la următoarea imagine normală
 STR_SPRITE_ALIGNER_PREVIOUS_BUTTON                              :{BLACK}Imaginea precedentă
-STR_SPRITE_ALIGNER_PREVIOUS_TOOLTIP                             :{BLACK}Mergi la precedenta imagine normală, sărind peste pseudo-imagini, recolorări sau fonturi şi reporneşte când s-a ajuns la sfârşit
+STR_SPRITE_ALIGNER_PREVIOUS_TOOLTIP                             :{BLACK}Mergi la precedenta imagine normală, sărind peste pseudo-imagini, recolorări sau fonturi și repornește când s-a ajuns la sfârșit
 STR_SPRITE_ALIGNER_SPRITE_TOOLTIP                               :{BLACK}Reprezentarea imaginii curente. Aliniamentul este ignorat
-STR_SPRITE_ALIGNER_MOVE_TOOLTIP                                 :{BLACK}Mișcă imaginea schimbând distanțele pe axele X şi Y. Ctrl+Clic pentru mutarea imaginii câte opt unități la un pas
+STR_SPRITE_ALIGNER_MOVE_TOOLTIP                                 :{BLACK}Mișcă imaginea schimbând distanțele pe axele X și Y. Ctrl+Clic pentru mutarea imaginii câte opt unități la un pas
 
 ###length 2
 STR_SPRITE_ALIGNER_CENTRE_OFFSET                                :{BLACK}Offset centrat
@@ -3428,27 +3428,27 @@ STR_SPRITE_ALIGNER_GOTO_CAPTION                                 :{WHITE}Mergi la
 
 # NewGRF (self) generated warnings/errors
 STR_NEWGRF_ERROR_MSG_INFO                                       :{SILVER}{STRING}
-STR_NEWGRF_ERROR_MSG_WARNING                                    :{RED}Atenţie: {SILVER}{STRING}
+STR_NEWGRF_ERROR_MSG_WARNING                                    :{RED}Atenție: {SILVER}{STRING}
 STR_NEWGRF_ERROR_MSG_ERROR                                      :{RED}Eroare: {SILVER}{STRING}
 STR_NEWGRF_ERROR_MSG_FATAL                                      :{RED}Fatal: {SILVER}{STRING}
 STR_NEWGRF_ERROR_FATAL_POPUP                                    :{WHITE}NewGRF-ul "{STRING}" a avut o eroare fatală:{}{STRING}
 STR_NEWGRF_ERROR_POPUP                                          :{WHITE}NewGRF-ul "{STRING}" a avut o eroare:{}{STRING}
-STR_NEWGRF_ERROR_VERSION_NUMBER                                 :{1:STRING} nu va funcţiona cu versiunea TTDPatch raportată de OpenTTD
+STR_NEWGRF_ERROR_VERSION_NUMBER                                 :{1:STRING} nu va funcționa cu versiunea TTDPatch raportată de OpenTTD
 STR_NEWGRF_ERROR_DOS_OR_WINDOWS                                 :{1:STRING} este pentru versiunea {2:STRING} a TTD
 STR_NEWGRF_ERROR_UNSET_SWITCH                                   :{1:STRING} este conceput pentru a fi folosit cu {2:STRING}
 STR_NEWGRF_ERROR_INVALID_PARAMETER                              :Parametru invalid pentru {1:STRING}: parametrul {2:STRING} ({3:NUM})
 STR_NEWGRF_ERROR_LOAD_BEFORE                                    :{1:STRING} trebuie să fie încărcat înaintea {2:STRING}
 STR_NEWGRF_ERROR_LOAD_AFTER                                     :{1:STRING} trebuie să fie încărcat după {2:STRING}
 STR_NEWGRF_ERROR_OTTD_VERSION_NUMBER                            :{1:STRING} necesită OpenTTD versiunea {2:STRING} sau mai nouă
-STR_NEWGRF_ERROR_AFTER_TRANSLATED_FILE                          :fişierul GRF conceput pentru traducere
+STR_NEWGRF_ERROR_AFTER_TRANSLATED_FILE                          :fișierul GRF conceput pentru traducere
 STR_NEWGRF_ERROR_TOO_MANY_NEWGRFS_LOADED                        :Sunt încărcate prea multe NewGRF-uri
 STR_NEWGRF_ERROR_STATIC_GRF_CAUSES_DESYNC                       :Încărcarea {1:STRING} ca un NewGRF static cu {2:STRING} ar putea cauza desincronizări
 STR_NEWGRF_ERROR_UNEXPECTED_SPRITE                              :Element grafic neașteptat (sprite {3:NUM})
 STR_NEWGRF_ERROR_UNKNOWN_PROPERTY                               :Proprietate necunoscută pentru Acțiunea 0 {4:HEX} (sprite {3:NUM})
 STR_NEWGRF_ERROR_INVALID_ID                                     :Încercare de a folosi un ID invalid (sprite {3:NUM})
-STR_NEWGRF_ERROR_CORRUPT_SPRITE                                 :{YELLOW}{STRING} conţine o imagine coruptă. Toate imaginile corupte vor fi afişate ca semne de întrebare (?) roşii
+STR_NEWGRF_ERROR_CORRUPT_SPRITE                                 :{YELLOW}{STRING} conține o imagine coruptă. Toate imaginile corupte vor fi afișate ca semne de întrebare (?) roșii
 STR_NEWGRF_ERROR_MULTIPLE_ACTION_8                              :Conține mai multe intrări pentru Acțiunea 8 (sprite {3:NUM})
-STR_NEWGRF_ERROR_READ_BOUNDS                                    :Citire după sfârşitul preudo-elementului grafic (sprite {3:NUM})
+STR_NEWGRF_ERROR_READ_BOUNDS                                    :Citire după sfârșitul preudo-elementului grafic (sprite {3:NUM})
 STR_NEWGRF_ERROR_GRM_FAILED                                     :Resursele GRF solicitate nu sunt disponibile (sprite {3:NUM})
 STR_NEWGRF_ERROR_FORCEFULLY_DISABLED                            :{1:STRING} a fost dezactivat de {STRING}
 STR_NEWGRF_ERROR_INVALID_SPRITE_LAYOUT                          :Structură necunoscută/invalidă pentru elementul grafic (sprite {3:NUM})
@@ -3456,35 +3456,35 @@ STR_NEWGRF_ERROR_LIST_PROPERTY_TOO_LONG                         :Prea multe elem
 STR_NEWGRF_ERROR_INDPROD_CALLBACK                               :Reapelare de producție nevalidă (sprite {3:NUM}, „{2:STRING}”)
 
 # NewGRF related 'general' warnings
-STR_NEWGRF_POPUP_CAUTION_CAPTION                                :{WHITE}Atenţie!
-STR_NEWGRF_CONFIRMATION_TEXT                                    :{YELLOW}Eşti pe cale să faci modificări într-un joc activ. Aceasta poate destabiliza OpenTTD. Nu raporta probleme de acest gen.{}Eşti absolut sigur că vrei să faci asta?
+STR_NEWGRF_POPUP_CAUTION_CAPTION                                :{WHITE}Atenție!
+STR_NEWGRF_CONFIRMATION_TEXT                                    :{YELLOW}Ești pe cale să faci modificări într-un joc activ. Aceasta poate destabiliza OpenTTD. Nu raporta probleme de acest gen.{}Ești absolut sigur că vrei să faci asta?
 
-STR_NEWGRF_DUPLICATE_GRFID                                      :{WHITE}Nu pot adăuga fişierul: ID GRF duplicat
-STR_NEWGRF_COMPATIBLE_LOADED                                    :{ORANGE}Nu am găsit niciun fişier corespunzător (am încărcat un GRF compatibil)
+STR_NEWGRF_DUPLICATE_GRFID                                      :{WHITE}Nu pot adăuga fișierul: ID GRF duplicat
+STR_NEWGRF_COMPATIBLE_LOADED                                    :{ORANGE}Nu am găsit niciun fișier corespunzător (am încărcat un GRF compatibil)
 STR_NEWGRF_TOO_MANY_NEWGRFS                                     :{WHITE}Nu pot adăuga fișierul: Limita de fișiere NewGRF este atinsă
 
-STR_NEWGRF_COMPATIBLE_LOAD_WARNING                              :{WHITE}GRF-uri compatibile au fost încărcate pentru fişierele lipsă
-STR_NEWGRF_DISABLED_WARNING                                     :{WHITE}Fişierele GRF lipsă au fost dezactivate
-STR_NEWGRF_UNPAUSE_WARNING_TITLE                                :{YELLOW}Fişier(e) GRF lipsă
-STR_NEWGRF_UNPAUSE_WARNING                                      :{WHITE}Reluarea jocului poate bloca OpenTTD. Nu raportaţi bug-uri pentru blocările ulterioare.{}Sigur doreşti să reiei jocul?
+STR_NEWGRF_COMPATIBLE_LOAD_WARNING                              :{WHITE}GRF-uri compatibile au fost încărcate pentru fișierele lipsă
+STR_NEWGRF_DISABLED_WARNING                                     :{WHITE}Fișierele GRF lipsă au fost dezactivate
+STR_NEWGRF_UNPAUSE_WARNING_TITLE                                :{YELLOW}Fișier(e) GRF lipsă
+STR_NEWGRF_UNPAUSE_WARNING                                      :{WHITE}Reluarea jocului poate bloca OpenTTD. Nu raportați bug-uri pentru blocările ulterioare.{}Sigur dorești să reiei jocul?
 
 # NewGRF status
 STR_NEWGRF_LIST_NONE                                            :Nimic
 ###length 3
-STR_NEWGRF_LIST_ALL_FOUND                                       :Toate fişierele necesare sunt prezente
-STR_NEWGRF_LIST_COMPATIBLE                                      :{YELLOW}Fişiere compatibile găsite
-STR_NEWGRF_LIST_MISSING                                         :{RED}Fişiere lipsă
+STR_NEWGRF_LIST_ALL_FOUND                                       :Toate fișierele necesare sunt prezente
+STR_NEWGRF_LIST_COMPATIBLE                                      :{YELLOW}Fișiere compatibile găsite
+STR_NEWGRF_LIST_MISSING                                         :{RED}Fișiere lipsă
 
 # NewGRF 'it's broken' warnings
-STR_NEWGRF_BROKEN                                               :{WHITE}Comportamentul NewGRF '{0:STRING}' poate cauza desincronizări şi/sau blocări
+STR_NEWGRF_BROKEN                                               :{WHITE}Comportamentul NewGRF '{0:STRING}' poate cauza desincronizări și/sau blocări
 STR_NEWGRF_BROKEN_POWERED_WAGON                                 :{WHITE}A modificat starea trenului pentru '{1:ENGINE}' când nu se afla în depou
 STR_NEWGRF_BROKEN_VEHICLE_LENGTH                                :{WHITE}A modificat lungimea vehiculului pentru '{1:ENGINE}' când nu se afla în depou
 STR_NEWGRF_BROKEN_CAPACITY                                      :{WHITE}A modificat capacitatea vehiculului pentru '{1:ENGINE}' când nu a fost într-un depou sau în timpul conversiei
 STR_BROKEN_VEHICLE_LENGTH                                       :{WHITE}Trenul '{VEHICLE}', aparținând '{COMPANY}', nu are o lungime validă. Probabil este o problemă cu fișierele NewGRF. Jocul s-ar putea desincroniza sau bloca
 
-STR_NEWGRF_BUGGY                                                :{WHITE}NewGRF '{0:STRING}' produce informaţii incorecte
-STR_NEWGRF_BUGGY_ARTICULATED_CARGO                              :{WHITE}Datele despre marfa/regarnisire pentru '{1:ENGINE}' diferă de valorile iniţiale după construcţie. Acest lucru ar putea cauza eşuarea autorenovarii/schimbarii.
-STR_NEWGRF_BUGGY_ENDLESS_PRODUCTION_CALLBACK                    :{WHITE}'{1:STRING}' a cauzat o buclă infinită în funcţia de producţie
+STR_NEWGRF_BUGGY                                                :{WHITE}NewGRF '{0:STRING}' produce informații incorecte
+STR_NEWGRF_BUGGY_ARTICULATED_CARGO                              :{WHITE}Datele despre marfa/regarnisire pentru '{1:ENGINE}' diferă de valorile inițiale după construcție. Acest lucru ar putea cauza eșuarea autorenovarii/schimbarii.
+STR_NEWGRF_BUGGY_ENDLESS_PRODUCTION_CALLBACK                    :{WHITE}'{1:STRING}' a cauzat o buclă infinită în funcția de producție
 STR_NEWGRF_BUGGY_UNKNOWN_CALLBACK_RESULT                        :{WHITE}Execuția {1:HEX} a returnat un răspuns nevalid/necunoscut {2:HEX}
 STR_NEWGRF_BUGGY_INVALID_CARGO_PRODUCTION_CALLBACK              :{WHITE}'{1:STRING}' a returnat un tip nevalid de marfă în retro-apelul produsului la {2:HEX}
 
@@ -3518,19 +3518,19 @@ STR_EDIT_SIGN_PREVIOUS_SIGN_TOOLTIP                             :{BLACK}Mergi la
 STR_EDIT_SIGN_SIGN_OSKTITLE                                     :{BLACK}Introdu un nume pentru semn
 
 # Town directory window
-STR_TOWN_DIRECTORY_CAPTION                                      :{WHITE}Oraşe
+STR_TOWN_DIRECTORY_CAPTION                                      :{WHITE}Orașe
 STR_TOWN_DIRECTORY_NONE                                         :{ORANGE}- Nimic -
 STR_TOWN_DIRECTORY_TOWN                                         :{ORANGE}{TOWN}{BLACK} ({COMMA})
 STR_TOWN_DIRECTORY_CITY                                         :{ORANGE}{TOWN}{YELLOW} (oraș){BLACK} ({COMMA})
-STR_TOWN_DIRECTORY_LIST_TOOLTIP                                 :{BLACK}Numele oraşelor - clic pe un nume pentru a centra imaginea pe oraşul respectiv. Ctrl+Click deshide o fereastra cu locaţia oraşului
-STR_TOWN_POPULATION                                             :{BLACK}Populaţia totală: {COMMA}
+STR_TOWN_DIRECTORY_LIST_TOOLTIP                                 :{BLACK}Numele orașelor - clic pe un nume pentru a centra imaginea pe orașul respectiv. Ctrl+Click deshide o fereastra cu locația orașului
+STR_TOWN_POPULATION                                             :{BLACK}Populația totală: {COMMA}
 
 # Town view window
 STR_TOWN_VIEW_TOWN_CAPTION                                      :{WHITE}{TOWN}
 STR_TOWN_VIEW_CITY_CAPTION                                      :{WHITE}{TOWN} (Metropolă)
-STR_TOWN_VIEW_POPULATION_HOUSES                                 :{BLACK}Populaţia: {ORANGE}{COMMA}{BLACK}  Locuinţe: {ORANGE}{COMMA}
+STR_TOWN_VIEW_POPULATION_HOUSES                                 :{BLACK}Populația: {ORANGE}{COMMA}{BLACK}  Locuințe: {ORANGE}{COMMA}
 STR_TOWN_VIEW_CARGO_LAST_MONTH_MAX                              :{BLACK}{CARGO_LIST} luna trecută: {ORANGE}{COMMA}{BLACK}  max: {ORANGE}{COMMA}
-STR_TOWN_VIEW_CARGO_FOR_TOWNGROWTH                              :{BLACK}Transporturi necesare dezvoltării oraşului:
+STR_TOWN_VIEW_CARGO_FOR_TOWNGROWTH                              :{BLACK}Transporturi necesare dezvoltării orașului:
 STR_TOWN_VIEW_CARGO_FOR_TOWNGROWTH_REQUIRED_GENERAL             :{ORANGE}{STRING}{RED} necesare
 STR_TOWN_VIEW_CARGO_FOR_TOWNGROWTH_REQUIRED_WINTER              :{ORANGE}{STRING}{BLACK} necesare iarna
 STR_TOWN_VIEW_CARGO_FOR_TOWNGROWTH_DELIVERED_GENERAL            :{ORANGE}{STRING}{GREEN} livrate
@@ -3539,18 +3539,18 @@ STR_TOWN_VIEW_CARGO_FOR_TOWNGROWTH_DELIVERED                    :{ORANGE}{CARGO_
 STR_TOWN_VIEW_TOWN_GROWS_EVERY                                  :{BLACK}Orașul crește la fiecare {ORANGE}{COMMA}{BLACK}{NBSP}{P zi zile "de zile"}
 STR_TOWN_VIEW_TOWN_GROWS_EVERY_FUNDED                           :{BLACK}Orașul crește la fiecare {ORANGE}{COMMA}{BLACK}{NBSP}{P zi zile "de zile"} (cu fonduri)
 STR_TOWN_VIEW_TOWN_GROW_STOPPED                                 :{BLACK}Orașul {RED}nu{BLACK} crește
-STR_TOWN_VIEW_NOISE_IN_TOWN                                     :{BLACK}Limita zgomotului în oraş: {ORANGE}{COMMA}{BLACK}  maxim: {ORANGE}{COMMA}
-STR_TOWN_VIEW_CENTER_TOOLTIP                                    :{BLACK}Centrează imaginea pe locaţia oraşului. Ctrl+Click deshide o fereastra cu locaţia oraşului
+STR_TOWN_VIEW_NOISE_IN_TOWN                                     :{BLACK}Limita zgomotului în oraș: {ORANGE}{COMMA}{BLACK}  maxim: {ORANGE}{COMMA}
+STR_TOWN_VIEW_CENTER_TOOLTIP                                    :{BLACK}Centrează imaginea pe locația orașului. Ctrl+Click deshide o fereastra cu locația orașului
 STR_TOWN_VIEW_LOCAL_AUTHORITY_BUTTON                            :{BLACK}Autoritate locală
-STR_TOWN_VIEW_LOCAL_AUTHORITY_TOOLTIP                           :{BLACK}Afişează informaţii referitoare la autoritatea locală
-STR_TOWN_VIEW_RENAME_TOOLTIP                                    :{BLACK}Schimbă numele oraşului
+STR_TOWN_VIEW_LOCAL_AUTHORITY_TOOLTIP                           :{BLACK}Afișează informații referitoare la autoritatea locală
+STR_TOWN_VIEW_RENAME_TOOLTIP                                    :{BLACK}Schimbă numele orașului
 
 STR_TOWN_VIEW_EXPAND_BUTTON                                     :{BLACK}Extinde
-STR_TOWN_VIEW_EXPAND_TOOLTIP                                    :{BLACK}Măreşte dimensiunile oraşului
-STR_TOWN_VIEW_DELETE_BUTTON                                     :{BLACK}Şterge
+STR_TOWN_VIEW_EXPAND_TOOLTIP                                    :{BLACK}Mărește dimensiunile orașului
+STR_TOWN_VIEW_DELETE_BUTTON                                     :{BLACK}șterge
 STR_TOWN_VIEW_DELETE_TOOLTIP                                    :{BLACK}Șterge acest oraș
 
-STR_TOWN_VIEW_RENAME_TOWN_BUTTON                                :Redenumire oraş
+STR_TOWN_VIEW_RENAME_TOWN_BUTTON                                :Redenumire oraș
 
 # Town local authority window
 STR_LOCAL_AUTHORITY_CAPTION                                     :{WHITE}Autoritatea locală din {TOWN}
@@ -3558,20 +3558,20 @@ STR_LOCAL_AUTHORITY_ZONE                                        :{BLACK}Zonă
 STR_LOCAL_AUTHORITY_ZONE_TOOLTIP                                :{BLACK}Arată zona de acoperire a autorităților locale
 STR_LOCAL_AUTHORITY_COMPANY_RATINGS                             :{BLACK}Evaluarea companiilor de transport:
 STR_LOCAL_AUTHORITY_COMPANY_RATING                              :{YELLOW}{COMPANY} {COMPANY_NUM}: {ORANGE}{STRING}
-STR_LOCAL_AUTHORITY_ACTIONS_TITLE                               :{BLACK}Acţiuni disponibile:
-STR_LOCAL_AUTHORITY_ACTIONS_TOOLTIP                             :{BLACK}Lista de acţiuni disponibile pentru acest oraş - clic pe fiecare pentru mai multe detalii
+STR_LOCAL_AUTHORITY_ACTIONS_TITLE                               :{BLACK}Acțiuni disponibile:
+STR_LOCAL_AUTHORITY_ACTIONS_TOOLTIP                             :{BLACK}Lista de acțiuni disponibile pentru acest oraș - clic pe fiecare pentru mai multe detalii
 STR_LOCAL_AUTHORITY_DO_IT_BUTTON                                :{BLACK}Alege
-STR_LOCAL_AUTHORITY_DO_IT_TOOLTIP                               :{BLACK}Activează acţiunea selectată din listă
+STR_LOCAL_AUTHORITY_DO_IT_TOOLTIP                               :{BLACK}Activează acțiunea selectată din listă
 
 ###length 8
 STR_LOCAL_AUTHORITY_ACTION_SMALL_ADVERTISING_CAMPAIGN           :Campanie publicitară mică
 STR_LOCAL_AUTHORITY_ACTION_MEDIUM_ADVERTISING_CAMPAIGN          :Campanie publicitară medie
 STR_LOCAL_AUTHORITY_ACTION_LARGE_ADVERTISING_CAMPAIGN           :Campanie publicitară mare
 STR_LOCAL_AUTHORITY_ACTION_ROAD_RECONSTRUCTION                  :Finanțează reconstrucția străzilor
-STR_LOCAL_AUTHORITY_ACTION_STATUE_OF_COMPANY                    :Ridică un monument dedicat preşedintelui companiei
-STR_LOCAL_AUTHORITY_ACTION_NEW_BUILDINGS                        :Finanţează construcţia de noi clădiri
+STR_LOCAL_AUTHORITY_ACTION_STATUE_OF_COMPANY                    :Ridică un monument dedicat președintelui companiei
+STR_LOCAL_AUTHORITY_ACTION_NEW_BUILDINGS                        :Finanțează construcția de noi clădiri
 STR_LOCAL_AUTHORITY_ACTION_EXCLUSIVE_TRANSPORT                  :Cumpără drepturi exclusive de transport
-STR_LOCAL_AUTHORITY_ACTION_BRIBE                                :Mituieşte autoritatea locală
+STR_LOCAL_AUTHORITY_ACTION_BRIBE                                :Mituiește autoritatea locală
 
 ###length 8
 STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_SMALL_ADVERTISING            :{PUSH_COLOUR}{YELLOW}Inițiază o campanie publicitară mică pentru a atrage mai mulți călători și mai multe mărfuri spre compania ta.{}Oferă temporar un spor la cotația staților tale pe o rază mică în jurul centrului orașului.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
@@ -3595,7 +3595,7 @@ STR_GOALS_TEXT                                                  :{ORANGE}{STRING
 STR_GOALS_NONE                                                  :{ORANGE}- Nici unul -
 STR_GOALS_PROGRESS                                              :{ORANGE}{STRING}
 STR_GOALS_PROGRESS_COMPLETE                                     :{GREEN}{STRING}
-STR_GOALS_TOOLTIP_CLICK_ON_SERVICE_TO_CENTER                    :{BLACK}Click pe ţintă pentru a centra ecranul principal pe industrie/oraş/zonă. Ctrl+Click deschide o fereastră nouă de vizualizare a industriei/oraşului/zonei
+STR_GOALS_TOOLTIP_CLICK_ON_SERVICE_TO_CENTER                    :{BLACK}Click pe țintă pentru a centra ecranul principal pe industrie/oraș/zonă. Ctrl+Click deschide o fereastră nouă de vizualizare a industriei/orașului/zonei
 
 # Goal question window
 STR_GOAL_QUESTION_CAPTION_QUESTION                              :{BLACK}Întrebare
@@ -3625,13 +3625,13 @@ STR_GOAL_QUESTION_BUTTON_SURRENDER                              :Renunță
 STR_GOAL_QUESTION_BUTTON_CLOSE                                  :Închide
 
 # Subsidies window
-STR_SUBSIDIES_CAPTION                                           :{WHITE}Subvenţii (F6)
-STR_SUBSIDIES_OFFERED_TITLE                                     :{BLACK}Subvenţii disponibile:
+STR_SUBSIDIES_CAPTION                                           :{WHITE}Subvenții (F6)
+STR_SUBSIDIES_OFFERED_TITLE                                     :{BLACK}Subvenții disponibile:
 STR_SUBSIDIES_OFFERED_FROM_TO                                   :{ORANGE}{STRING} de la {STRING} la {STRING}{YELLOW} (după {DATE_SHORT})
 STR_SUBSIDIES_NONE                                              :{ORANGE} - nici una -
-STR_SUBSIDIES_SUBSIDISED_TITLE                                  :{BLACK}Subvenţii acordate la ora actuală:
+STR_SUBSIDIES_SUBSIDISED_TITLE                                  :{BLACK}Subvenții acordate la ora actuală:
 STR_SUBSIDIES_SUBSIDISED_FROM_TO                                :{ORANGE}- {STRING} de la {STRING} la {STRING}{YELLOW} ({COMPANY}{YELLOW}, până în {DATE_SHORT})
-STR_SUBSIDIES_TOOLTIP_CLICK_ON_SERVICE_TO_CENTER                :{BLACK}Click pe serviciu pentru a centra imaginea pe industrie/oraş. Ctrl+Click deshide o fereastră cu locaţia industriei/oraşului
+STR_SUBSIDIES_TOOLTIP_CLICK_ON_SERVICE_TO_CENTER                :{BLACK}Click pe serviciu pentru a centra imaginea pe industrie/oraș. Ctrl+Click deshide o fereastră cu locația industriei/orașului
 
 # Story book window
 STR_STORY_BOOK_CAPTION                                          :{WHITE}{COMPANY} Carte de poveste
@@ -3644,18 +3644,18 @@ STR_STORY_BOOK_PREV_PAGE                                        :{BLACK}Anterior
 STR_STORY_BOOK_PREV_PAGE_TOOLTIP                                :{BLACK}Mergi la pagina anterioară
 STR_STORY_BOOK_NEXT_PAGE                                        :{BLACK}Următor
 STR_STORY_BOOK_NEXT_PAGE_TOOLTIP                                :{BLACK}Mergi la pagina următoare
-STR_STORY_BOOK_INVALID_GOAL_REF                                 :{RED}Referinţă invalidă pentru scop
+STR_STORY_BOOK_INVALID_GOAL_REF                                 :{RED}Referință invalidă pentru scop
 
 # Station list window
-STR_STATION_LIST_TOOLTIP                                        :{BLACK}Numele staţiilor - clic pe un nume pentru a centra imaginea pe staţia respectivă. Ctrl+Click deshide o fereastra cu locaţia staţiei
-STR_STATION_LIST_USE_CTRL_TO_SELECT_MORE                        :{BLACK}Ţine apăsat Ctrl pentru a alege mai multe obiecte
+STR_STATION_LIST_TOOLTIP                                        :{BLACK}Numele stațiilor - clic pe un nume pentru a centra imaginea pe stația respectivă. Ctrl+Click deshide o fereastra cu locația stației
+STR_STATION_LIST_USE_CTRL_TO_SELECT_MORE                        :{BLACK}ține apăsat Ctrl pentru a alege mai multe obiecte
 STR_STATION_LIST_CAPTION                                        :{WHITE}{COMPANY} - {COMMA} {P stație stații "de stații"}
 STR_STATION_LIST_STATION                                        :{YELLOW}{STATION} {STATION_FEATURES}
 STR_STATION_LIST_WAYPOINT                                       :{YELLOW}{WAYPOINT}
 STR_STATION_LIST_NONE                                           :{YELLOW}- Nici una -
-STR_STATION_LIST_SELECT_ALL_FACILITIES                          :{BLACK}Alege toate facilităţile
+STR_STATION_LIST_SELECT_ALL_FACILITIES                          :{BLACK}Alege toate facilitățile
 STR_STATION_LIST_SELECT_ALL_TYPES                               :{BLACK}Alege toate tipurile de încãrcãturi (inclusiv încãrcãturile care nu sunt în asteptare)
-STR_STATION_LIST_NO_WAITING_CARGO                               :{BLACK}Nu este nici un fel de încărcătură în aşteptare
+STR_STATION_LIST_NO_WAITING_CARGO                               :{BLACK}Nu este nici un fel de încărcătură în așteptare
 
 # Station view window
 STR_STATION_VIEW_CAPTION                                        :{WHITE}{STATION} {STATION_FEATURES}
@@ -3663,39 +3663,39 @@ STR_STATION_VIEW_WAITING_CARGO                                  :{WHITE}{CARGO_L
 STR_STATION_VIEW_RESERVED                                       :{YELLOW}({CARGO_SHORT} rezervat pentru încărcare)
 
 STR_STATION_VIEW_ACCEPTS_BUTTON                                 :{BLACK}Ce acceptă
-STR_STATION_VIEW_ACCEPTS_TOOLTIP                                :{BLACK}Afişează lista de încărcături acceptate
+STR_STATION_VIEW_ACCEPTS_TOOLTIP                                :{BLACK}Afișează lista de încărcături acceptate
 STR_STATION_VIEW_ACCEPTS_CARGO                                  :{BLACK}Acceptă: {WHITE}{CARGO_LIST}
 
-STR_STATION_VIEW_EXCLUSIVE_RIGHTS_SELF                          :{BLACK}Această staţie are drepturi exclusive de transport în acest oraş.
-STR_STATION_VIEW_EXCLUSIVE_RIGHTS_COMPANY                       :{YELLOW}{COMPANY}{BLACK} a cumpărat drepturi exclusive de transport în acest oraş.
+STR_STATION_VIEW_EXCLUSIVE_RIGHTS_SELF                          :{BLACK}Această stație are drepturi exclusive de transport în acest oraș.
+STR_STATION_VIEW_EXCLUSIVE_RIGHTS_COMPANY                       :{YELLOW}{COMPANY}{BLACK} a cumpărat drepturi exclusive de transport în acest oraș.
 
 STR_STATION_VIEW_RATINGS_BUTTON                                 :{BLACK}Evaluări
-STR_STATION_VIEW_RATINGS_TOOLTIP                                :{BLACK}Afişează evaluările staţiei
+STR_STATION_VIEW_RATINGS_TOOLTIP                                :{BLACK}Afișează evaluările stației
 STR_STATION_VIEW_SUPPLY_RATINGS_TITLE                           :{BLACK}Aprovizionare lunară și evaluare locală:
 STR_STATION_VIEW_CARGO_SUPPLY_RATING                            :{WHITE}{STRING}: {YELLOW}{COMMA} / {STRING} ({COMMA}%)
 
 STR_STATION_VIEW_GROUP                                          :{BLACK}Grupează după
-STR_STATION_VIEW_WAITING_STATION                                :Staţie: Aşteptare
-STR_STATION_VIEW_WAITING_AMOUNT                                 :Sumă: Aşteptare
-STR_STATION_VIEW_PLANNED_STATION                                :Staţie: Planificat
+STR_STATION_VIEW_WAITING_STATION                                :Stație: Așteptare
+STR_STATION_VIEW_WAITING_AMOUNT                                 :Sumă: Așteptare
+STR_STATION_VIEW_PLANNED_STATION                                :Stație: Planificat
 STR_STATION_VIEW_PLANNED_AMOUNT                                 :Sumă: Planificat
 STR_STATION_VIEW_FROM                                           :{YELLOW}{CARGO_SHORT} de la {STATION}
 STR_STATION_VIEW_VIA                                            :{YELLOW}{CARGO_SHORT} via {STATION}
 STR_STATION_VIEW_TO                                             :{YELLOW}{CARGO_SHORT} către {STATION}
-STR_STATION_VIEW_FROM_ANY                                       :{RED}{CARGO_SHORT} de la staţie necunoscută
-STR_STATION_VIEW_TO_ANY                                         :{RED}{CARGO_SHORT} către orice staţie
-STR_STATION_VIEW_VIA_ANY                                        :{RED}{CARGO_SHORT} prin orice staţie
-STR_STATION_VIEW_FROM_HERE                                      :{GREEN}{CARGO_SHORT} de la această staţie
-STR_STATION_VIEW_VIA_HERE                                       :{GREEN}{CARGO_SHORT} opreşte la această staţie
-STR_STATION_VIEW_TO_HERE                                        :{GREEN}{CARGO_SHORT} către această staţie
+STR_STATION_VIEW_FROM_ANY                                       :{RED}{CARGO_SHORT} de la stație necunoscută
+STR_STATION_VIEW_TO_ANY                                         :{RED}{CARGO_SHORT} către orice stație
+STR_STATION_VIEW_VIA_ANY                                        :{RED}{CARGO_SHORT} prin orice stație
+STR_STATION_VIEW_FROM_HERE                                      :{GREEN}{CARGO_SHORT} de la această stație
+STR_STATION_VIEW_VIA_HERE                                       :{GREEN}{CARGO_SHORT} oprește la această stație
+STR_STATION_VIEW_TO_HERE                                        :{GREEN}{CARGO_SHORT} către această stație
 STR_STATION_VIEW_NONSTOP                                        :{YELLOW}{CARGO_SHORT} non-stop
 
-STR_STATION_VIEW_GROUP_S_V_D                                    :Sursă-Via-Destinaţie
-STR_STATION_VIEW_GROUP_S_D_V                                    :Sursă-Destinaţie-Via
-STR_STATION_VIEW_GROUP_V_S_D                                    :Via-Sursă-Destinaţie
-STR_STATION_VIEW_GROUP_V_D_S                                    :Via-Destinaţie-Sursă
-STR_STATION_VIEW_GROUP_D_S_V                                    :Destinaţie-Sursă-Via
-STR_STATION_VIEW_GROUP_D_V_S                                    :Destinaţie-Via-Sursă
+STR_STATION_VIEW_GROUP_S_V_D                                    :Sursă-Via-Destinație
+STR_STATION_VIEW_GROUP_S_D_V                                    :Sursă-Destinație-Via
+STR_STATION_VIEW_GROUP_V_S_D                                    :Via-Sursă-Destinație
+STR_STATION_VIEW_GROUP_V_D_S                                    :Via-Destinație-Sursă
+STR_STATION_VIEW_GROUP_D_S_V                                    :Destinație-Sursă-Via
+STR_STATION_VIEW_GROUP_D_V_S                                    :Destinație-Via-Sursă
 
 ###length 8
 STR_CARGO_RATING_APPALLING                                      :Deplorabil
@@ -3707,22 +3707,22 @@ STR_CARGO_RATING_VERY_GOOD                                      :Foarte bun
 STR_CARGO_RATING_EXCELLENT                                      :Excelent
 STR_CARGO_RATING_OUTSTANDING                                    :Fantastic
 
-STR_STATION_VIEW_CENTER_TOOLTIP                                 :{BLACK}Centrează imaginea pe locaţia staţiei. Ctrl+Click deshide o fereastra cu locaţia staţiei
-STR_STATION_VIEW_RENAME_TOOLTIP                                 :{BLACK}Schimbă numele staţiei
+STR_STATION_VIEW_CENTER_TOOLTIP                                 :{BLACK}Centrează imaginea pe locația stației. Ctrl+Click deshide o fereastra cu locația stației
+STR_STATION_VIEW_RENAME_TOOLTIP                                 :{BLACK}Schimbă numele stației
 
 STR_STATION_VIEW_SCHEDULED_TRAINS_TOOLTIP                       :{BLACK}Afiseaza toate trenurile care opresc in aceasta statie
 STR_STATION_VIEW_SCHEDULED_ROAD_VEHICLES_TOOLTIP                :{BLACK}Afiseaza toate autovehiculele care opresc in aceasta statie
 STR_STATION_VIEW_SCHEDULED_AIRCRAFT_TOOLTIP                     :{BLACK}Afiseaza toate aeronavele care opresc in aceasta statie
 STR_STATION_VIEW_SCHEDULED_SHIPS_TOOLTIP                        :{BLACK}Afiseaza toate navele care opresc in aceasta statie
 
-STR_STATION_VIEW_RENAME_STATION_CAPTION                         :Redenumeşte staţia
+STR_STATION_VIEW_RENAME_STATION_CAPTION                         :Redenumește stația
 
 STR_STATION_VIEW_CLOSE_AIRPORT                                  :{BLACK}Închide aeroport
 STR_STATION_VIEW_CLOSE_AIRPORT_TOOLTIP                          :{BLACK}Nu permite avioanelor să aterizeze pe acest aeroport
 
 # Waypoint/buoy view window
 STR_WAYPOINT_VIEW_CAPTION                                       :{WHITE}{WAYPOINT}
-STR_WAYPOINT_VIEW_CENTER_TOOLTIP                                :{BLACK}Centrază fereasta principală pe punctul de tranzit. Ctrl+Click deshide o fereastra cu locaţia punctului de tranzit
+STR_WAYPOINT_VIEW_CENTER_TOOLTIP                                :{BLACK}Centrază fereasta principală pe punctul de tranzit. Ctrl+Click deshide o fereastra cu locația punctului de tranzit
 STR_WAYPOINT_VIEW_CHANGE_WAYPOINT_NAME                          :{BLACK}Schimbă numele haltei
 STR_BUOY_VIEW_CENTER_TOOLTIP                                    :{BLACK}Centrează vizorul principal pe locația balizei. Ctrl+clic deschide un vizor cu locația balizei
 STR_BUOY_VIEW_CHANGE_BUOY_NAME                                  :{BLACK}Schimbă numele balizei
@@ -3730,7 +3730,7 @@ STR_BUOY_VIEW_CHANGE_BUOY_NAME                                  :{BLACK}Schimbă
 STR_EDIT_WAYPOINT_NAME                                          :{WHITE}Editează numele haltei
 
 # Finances window
-STR_FINANCES_CAPTION                                            :{WHITE}Situaţia financiară a companiei {COMPANY} {BLACK}{COMPANY_NUM}
+STR_FINANCES_CAPTION                                            :{WHITE}Situația financiară a companiei {COMPANY} {BLACK}{COMPANY_NUM}
 STR_FINANCES_YEAR                                               :{WHITE}{NUM}
 
 ###length 3
@@ -3740,7 +3740,7 @@ STR_FINANCES_CAPITAL_EXPENSES_TITLE                             :{WHITE}Cheltuie
 
 
 ###length 13
-STR_FINANCES_SECTION_CONSTRUCTION                               :{GOLD}Construcţii
+STR_FINANCES_SECTION_CONSTRUCTION                               :{GOLD}Construcții
 STR_FINANCES_SECTION_NEW_VEHICLES                               :{GOLD}Vehicule noi
 STR_FINANCES_SECTION_TRAIN_RUNNING_COSTS                        :{GOLD}Trenuri
 STR_FINANCES_SECTION_ROAD_VEHICLE_RUNNING_COSTS                 :{GOLD}Autovehicule
@@ -3759,7 +3759,7 @@ STR_FINANCES_NEGATIVE_INCOME                                    :-{CURRENCY_LONG
 STR_FINANCES_ZERO_INCOME                                        :{CURRENCY_LONG}
 STR_FINANCES_POSITIVE_INCOME                                    :+{CURRENCY_LONG}
 STR_FINANCES_PROFIT                                             :{WHITE}Profit
-STR_FINANCES_BANK_BALANCE_TITLE                                 :{WHITE}Balanţă curentă
+STR_FINANCES_BANK_BALANCE_TITLE                                 :{WHITE}Balanță curentă
 STR_FINANCES_OWN_FUNDS_TITLE                                    :{WHITE}Fonduri proprii
 STR_FINANCES_LOAN_TITLE                                         :{WHITE}Credite
 STR_FINANCES_INTEREST_RATE                                      :{WHITE}Dobândā la credit: {BLACK}{NUM}%
@@ -3768,15 +3768,15 @@ STR_FINANCES_TOTAL_CURRENCY                                     :{BLACK}{CURRENC
 STR_FINANCES_BANK_BALANCE                                       :{WHITE}{CURRENCY_LONG}
 STR_FINANCES_BORROW_BUTTON                                      :{BLACK}Împrumută {CURRENCY_LONG}
 STR_FINANCES_BORROW_TOOLTIP                                     :{BLACK}Împrumută o nouă sumă de bani. Ctrl-click pentru a împrumuta suma maximă posibilă
-STR_FINANCES_REPAY_BUTTON                                       :{BLACK}Plăteşte înapoi {CURRENCY_LONG}
-STR_FINANCES_REPAY_TOOLTIP                                      :{BLACK}Plăteşte înapoi o parte din credite. Ctrl-click pentru a plăti cât de mult permit finanţele
+STR_FINANCES_REPAY_BUTTON                                       :{BLACK}Plătește înapoi {CURRENCY_LONG}
+STR_FINANCES_REPAY_TOOLTIP                                      :{BLACK}Plătește înapoi o parte din credite. Ctrl-click pentru a plăti cât de mult permit finanțele
 STR_FINANCES_INFRASTRUCTURE_BUTTON                              :{BLACK}Infrastructură
 
 # Company view
 STR_COMPANY_VIEW_CAPTION                                        :{WHITE}{COMPANY} {BLACK}{COMPANY_NUM}
-STR_COMPANY_VIEW_PRESIDENT_MANAGER_TITLE                        :{WHITE}{PRESIDENT_NAME}{}{GOLD}(Preşedinte)
+STR_COMPANY_VIEW_PRESIDENT_MANAGER_TITLE                        :{WHITE}{PRESIDENT_NAME}{}{GOLD}(Președinte)
 
-STR_COMPANY_VIEW_INAUGURATED_TITLE                              :{GOLD}Anul înfiinţării: {WHITE}{NUM}
+STR_COMPANY_VIEW_INAUGURATED_TITLE                              :{GOLD}Anul înființării: {WHITE}{NUM}
 STR_COMPANY_VIEW_COLOUR_SCHEME_TITLE                            :{GOLD}Schemă culori:
 STR_COMPANY_VIEW_VEHICLES_TITLE                                 :{GOLD}Vehicule:
 STR_COMPANY_VIEW_TRAINS                                         :{WHITE}{COMMA} {P tren trenuri "de trenuri"}
@@ -3794,7 +3794,7 @@ STR_COMPANY_VIEW_INFRASTRUCTURE_AIRPORT                         :{WHITE}{COMMA} 
 STR_COMPANY_VIEW_INFRASTRUCTURE_NONE                            :{WHITE}Niciuna
 
 STR_COMPANY_VIEW_BUILD_HQ_BUTTON                                :{BLACK}Constr. sediu
-STR_COMPANY_VIEW_BUILD_HQ_TOOLTIP                               :{BLACK}Construieşte sediul companiei
+STR_COMPANY_VIEW_BUILD_HQ_TOOLTIP                               :{BLACK}Construiește sediul companiei
 STR_COMPANY_VIEW_VIEW_HQ_BUTTON                                 :{BLACK}Vezi sediul
 STR_COMPANY_VIEW_VIEW_HQ_TOOLTIP                                :{BLACK}Vezi sediul companiei
 STR_COMPANY_VIEW_RELOCATE_HQ                                    :{BLACK}Mută sediu
@@ -3807,19 +3807,19 @@ STR_COMPANY_VIEW_HOSTILE_TAKEOVER_BUTTON                        :{BLACK}Preluare
 STR_COMPANY_VIEW_HOSTILE_TAKEOVER_TOOLTIP                       :{BLACK}Preia ostil această companie
 
 STR_COMPANY_VIEW_NEW_FACE_BUTTON                                :{BLACK}Schimbă poza
-STR_COMPANY_VIEW_NEW_FACE_TOOLTIP                               :{BLACK}Alege o nouă poză a preşedintelui
+STR_COMPANY_VIEW_NEW_FACE_TOOLTIP                               :{BLACK}Alege o nouă poză a președintelui
 STR_COMPANY_VIEW_COLOUR_SCHEME_BUTTON                           :{BLACK}Schemă culori
-STR_COMPANY_VIEW_COLOUR_SCHEME_TOOLTIP                          :{BLACK}Schimbă culoarea care îţi reprezintă compania
+STR_COMPANY_VIEW_COLOUR_SCHEME_TOOLTIP                          :{BLACK}Schimbă culoarea care îți reprezintă compania
 STR_COMPANY_VIEW_COMPANY_NAME_BUTTON                            :{BLACK}Nume companie
 STR_COMPANY_VIEW_COMPANY_NAME_TOOLTIP                           :{BLACK}Schimbă numele companiei
-STR_COMPANY_VIEW_PRESIDENT_NAME_BUTTON                          :{BLACK}Nume preşedinte
+STR_COMPANY_VIEW_PRESIDENT_NAME_BUTTON                          :{BLACK}Nume președinte
 STR_COMPANY_VIEW_PRESIDENT_NAME_TOOLTIP                         :{BLACK}Schimbă numele președintelui
 
 STR_COMPANY_VIEW_COMPANY_NAME_QUERY_CAPTION                     :Noul nume al companiei
-STR_COMPANY_VIEW_PRESIDENT_S_NAME_QUERY_CAPTION                 :Noul nume al preşedintelui
+STR_COMPANY_VIEW_PRESIDENT_S_NAME_QUERY_CAPTION                 :Noul nume al președintelui
 STR_COMPANY_VIEW_GIVE_MONEY_QUERY_CAPTION                       :Introdu suma de bani pe care vrei să o dai
 
-STR_BUY_COMPANY_MESSAGE                                         :{WHITE}Căutăm o companie de transport care să preia societatea noastră{}{}Doriţi să cumpăraţi {COMPANY} la preţul de {CURRENCY_LONG}?
+STR_BUY_COMPANY_MESSAGE                                         :{WHITE}Căutăm o companie de transport care să preia societatea noastră{}{}Doriți să cumpărați {COMPANY} la prețul de {CURRENCY_LONG}?
 STR_BUY_COMPANY_HOSTILE_TAKEOVER                                :{WHITE}Prin preluarea ostilă a {COMPANY}, vei cumpăra toate bunurile acesteia, vei plăti toate împrumuturile și vei plăti profitul pe doi ani.{}{}Totalul estimat este {CURRENCY_LONG}.{}{}Vrei să dai curs preluării ostile?
 
 # Company infrastructure window
@@ -3844,7 +3844,7 @@ STR_INDUSTRY_DIRECTORY_ITEM_PROD1                               :{ORANGE}{INDUST
 STR_INDUSTRY_DIRECTORY_ITEM_PROD2                               :{ORANGE}{INDUSTRY} {STRING}, {STRING}
 STR_INDUSTRY_DIRECTORY_ITEM_PROD3                               :{ORANGE}{INDUSTRY} {STRING}, {STRING}, {STRING}
 STR_INDUSTRY_DIRECTORY_ITEM_PRODMORE                            :{ORANGE}{INDUSTRY} {STRING}, {STRING}, {STRING} și încă {NUM}...
-STR_INDUSTRY_DIRECTORY_LIST_CAPTION                             :{BLACK}Numele industriilor - clic pe nume pentru focalizarea pe industrie. Ctrl+Click deschide o fereastră cu locaţia industriei
+STR_INDUSTRY_DIRECTORY_LIST_CAPTION                             :{BLACK}Numele industriilor - clic pe nume pentru focalizarea pe industrie. Ctrl+Click deschide o fereastră cu locația industriei
 STR_INDUSTRY_DIRECTORY_ACCEPTED_CARGO_FILTER                    :{BLACK}Marfă acceptată: {SILVER}{STRING}
 STR_INDUSTRY_DIRECTORY_PRODUCED_CARGO_FILTER                    :{BLACK}Marfă produsă: {SILVER}{STRING}
 STR_INDUSTRY_DIRECTORY_FILTER_ALL_TYPES                         :Toate tipurile de mărfuri
@@ -3852,11 +3852,11 @@ STR_INDUSTRY_DIRECTORY_FILTER_NONE                              :Niciunul
 
 # Industry view
 STR_INDUSTRY_VIEW_CAPTION                                       :{WHITE}{INDUSTRY}
-STR_INDUSTRY_VIEW_PRODUCTION_LAST_MONTH_TITLE                   :{BLACK}Producţia lunii trecute:
+STR_INDUSTRY_VIEW_PRODUCTION_LAST_MONTH_TITLE                   :{BLACK}Producția lunii trecute:
 STR_INDUSTRY_VIEW_TRANSPORTED                                   :{YELLOW}{CARGO_LONG}{STRING}{BLACK} ({COMMA}% transportat)
-STR_INDUSTRY_VIEW_LOCATION_TOOLTIP                              :{BLACK}Centrează imaginea pe locaţia industriei. Ctrl+Click deshide o fereastra cu locaţia industriei
-STR_INDUSTRY_VIEW_PRODUCTION_LEVEL                              :{BLACK}Nivelul producţiei: {YELLOW}{COMMA}%
-STR_INDUSTRY_VIEW_INDUSTRY_ANNOUNCED_CLOSURE                    :{YELLOW}Industria a anunţat închiderea iminentă!
+STR_INDUSTRY_VIEW_LOCATION_TOOLTIP                              :{BLACK}Centrează imaginea pe locația industriei. Ctrl+Click deshide o fereastra cu locația industriei
+STR_INDUSTRY_VIEW_PRODUCTION_LEVEL                              :{BLACK}Nivelul producției: {YELLOW}{COMMA}%
+STR_INDUSTRY_VIEW_INDUSTRY_ANNOUNCED_CLOSURE                    :{YELLOW}Industria a anunțat închiderea iminentă!
 
 STR_INDUSTRY_VIEW_REQUIRES_N_CARGO                              :{BLACK}Necesită: {YELLOW}{STRING}{STRING}
 STR_INDUSTRY_VIEW_PRODUCES_N_CARGO                              :{BLACK}Produce: {YELLOW}{STRING}{STRING}
@@ -3867,7 +3867,7 @@ STR_INDUSTRY_VIEW_ACCEPT_CARGO                                  :{YELLOW}{0:STRI
 STR_INDUSTRY_VIEW_ACCEPT_CARGO_AMOUNT                           :{YELLOW}{STRING}{BLACK}: {CARGO_SHORT} așteaptă{STRING}
 
 STR_CONFIG_GAME_PRODUCTION                                      :{WHITE}Schimba productia (multiplu de 8, până la 2040)
-STR_CONFIG_GAME_PRODUCTION_LEVEL                                :{WHITE}Modifică nivelul producţiei (procent, până la 800%)
+STR_CONFIG_GAME_PRODUCTION_LEVEL                                :{WHITE}Modifică nivelul producției (procent, până la 800%)
 
 # Vehicle lists
 ###length VEHICLE_TYPES
@@ -3879,8 +3879,8 @@ STR_VEHICLE_LIST_AIRCRAFT_CAPTION                               :{WHITE}{STRING}
 ###length VEHICLE_TYPES
 STR_VEHICLE_LIST_TRAIN_LIST_TOOLTIP                             :{BLACK}Trenuri - click pe tren pentru informații
 STR_VEHICLE_LIST_ROAD_VEHICLE_TOOLTIP                           :{BLACK}Autovehicule - clic pe vehicul pentru informatii
-STR_VEHICLE_LIST_SHIP_TOOLTIP                                   :{BLACK}Nave - click pe navă pentru informaţii
-STR_VEHICLE_LIST_AIRCRAFT_TOOLTIP                               :{BLACK}Aeronavă - clic pe aeronavă pentru informaţii
+STR_VEHICLE_LIST_SHIP_TOOLTIP                                   :{BLACK}Nave - click pe navă pentru informații
+STR_VEHICLE_LIST_AIRCRAFT_TOOLTIP                               :{BLACK}Aeronavă - clic pe aeronavă pentru informații
 
 ###length VEHICLE_TYPES
 STR_VEHICLE_LIST_AVAILABLE_TRAINS                               :Trenuri disponibile
@@ -3926,7 +3926,7 @@ STR_GROUP_COUNT_WITH_SUBGROUP                                   :{TINY_FONT}{COM
 STR_GROUPS_CLICK_ON_GROUP_FOR_TOOLTIP                           :{BLACK}Grupuri - apasă pe un grup pentru lista completă a vehiculelor acestuia
 STR_GROUP_CREATE_TOOLTIP                                        :{BLACK}Apasă pentru a crea un grup
 STR_GROUP_DELETE_TOOLTIP                                        :{BLACK}Șterge grupul selectat
-STR_GROUP_RENAME_TOOLTIP                                        :{BLACK}Redenumeşte grupul selectat
+STR_GROUP_RENAME_TOOLTIP                                        :{BLACK}Redenumește grupul selectat
 STR_GROUP_LIVERY_TOOLTIP                                        :{BLACK}Schimbă uniforma grupului selectat
 STR_GROUP_REPLACE_PROTECTION_TOOLTIP                            :{BLACK}Apasă aici pentru a proteja acest grup de înlocuirile automate globale. Ctrl+Click pentru a proteja de asemenea subgrupurile
 
@@ -3936,7 +3936,7 @@ STR_GROUP_DELETE_QUERY_TEXT                                     :{WHITE}Sigur do
 STR_GROUP_ADD_SHARED_VEHICLE                                    :Adaugă vehicule partajate
 STR_GROUP_REMOVE_ALL_VEHICLES                                   :Elimină toate vehiculele
 
-STR_GROUP_RENAME_CAPTION                                        :{BLACK}Redenumeşte un grup
+STR_GROUP_RENAME_CAPTION                                        :{BLACK}Redenumește un grup
 
 STR_GROUP_PROFIT_THIS_YEAR                                      :Profitul pe anul acesta:
 STR_GROUP_PROFIT_LAST_YEAR                                      :Profitul anului trecut:
@@ -3947,7 +3947,7 @@ STR_GROUP_OCCUPANCY_VALUE                                       :{NUM}%
 ###length 4
 STR_BUY_VEHICLE_TRAIN_RAIL_CAPTION                              :Noi vehicule feroviare
 STR_BUY_VEHICLE_TRAIN_ELRAIL_CAPTION                            :Noi vehicule electrice pe șine
-STR_BUY_VEHICLE_TRAIN_MONORAIL_CAPTION                          :Noi vehicule monoşină
+STR_BUY_VEHICLE_TRAIN_MONORAIL_CAPTION                          :Noi vehicule monoșină
 STR_BUY_VEHICLE_TRAIN_MAGLEV_CAPTION                            :Noi vehicule pe Pernă Magnetică
 
 STR_BUY_VEHICLE_ROAD_VEHICLE_CAPTION                            :Autovehicule noi
@@ -3969,8 +3969,8 @@ STR_PURCHASE_INFO_SPEED_CANAL                                   :{BLACK}Viteza p
 STR_PURCHASE_INFO_RUNNINGCOST                                   :{BLACK}Cost de rulare: {GOLD}{CURRENCY_LONG}/an
 STR_PURCHASE_INFO_CAPACITY                                      :{BLACK}Capacitate: {GOLD}{CARGO_LONG} {STRING}
 STR_PURCHASE_INFO_REFITTABLE                                    :(suportă alte mărfuri)
-STR_PURCHASE_INFO_DESIGNED_LIFE                                 :{BLACK}An apariţie: {GOLD}{NUM}{BLACK} Durata de viaţă: {GOLD}{COMMA} ani
-STR_PURCHASE_INFO_RELIABILITY                                   :{BLACK}Eficienţă max.: {GOLD}{COMMA}%
+STR_PURCHASE_INFO_DESIGNED_LIFE                                 :{BLACK}An apariție: {GOLD}{NUM}{BLACK} Durata de viață: {GOLD}{COMMA} ani
+STR_PURCHASE_INFO_RELIABILITY                                   :{BLACK}Eficiență max.: {GOLD}{COMMA}%
 STR_PURCHASE_INFO_COST                                          :{BLACK}Cost: {GOLD}{CURRENCY_LONG}
 STR_PURCHASE_INFO_COST_REFIT                                    :{BLACK}Cost: {GOLD}{CURRENCY_LONG}{BLACK} (Cost reparații: {GOLD}{CURRENCY_LONG}{BLACK})
 STR_PURCHASE_INFO_WEIGHT_CWEIGHT                                :{BLACK}Greutate: {GOLD}{WEIGHT_SHORT} ({WEIGHT_SHORT})
@@ -3982,7 +3982,7 @@ STR_PURCHASE_INFO_REFITTABLE_TO                                 :{BLACK}Modifica
 STR_PURCHASE_INFO_ALL_TYPES                                     :Toate tipurile de mărfuri
 STR_PURCHASE_INFO_NONE                                          :Niciunul
 STR_PURCHASE_INFO_ENGINES_ONLY                                  :Doar locomotive
-STR_PURCHASE_INFO_ALL_BUT                                       :Toate, cu excepţia {CARGO_LIST}
+STR_PURCHASE_INFO_ALL_BUT                                       :Toate, cu excepția {CARGO_LIST}
 STR_PURCHASE_INFO_MAX_TE                                        :{BLACK}Efort tractor max.: {GOLD}{FORCE}
 STR_PURCHASE_INFO_AIRCRAFT_RANGE                                :{BLACK}Rază acțiune: {GOLD}{COMMA} pătrățele
 STR_PURCHASE_INFO_AIRCRAFT_TYPE                                 :{BLACK}Tip de aeronavă: {GOLD}{STRING}
@@ -3994,9 +3994,9 @@ STR_CARGO_TYPE_FILTER_NONE                                      :Niciunul
 
 ###length VEHICLE_TYPES
 STR_BUY_VEHICLE_TRAIN_LIST_TOOLTIP                              :{BLACK}Lista de selectie a componentelor trenului - clic pe vehicule pt. informatii
-STR_BUY_VEHICLE_ROAD_VEHICLE_LIST_TOOLTIP                       :{BLACK}Listă selecţie vehicule rutiere - apasă pe vehicul pentru informaţii
-STR_BUY_VEHICLE_SHIP_LIST_TOOLTIP                               :{BLACK}Listă de selecţie a navelor - click pe o navă pentru informaţii
-STR_BUY_VEHICLE_AIRCRAFT_LIST_TOOLTIP                           :{BLACK}Lista de selecţie a aeronavelor - clic pe o aeronavă pentru informaţii
+STR_BUY_VEHICLE_ROAD_VEHICLE_LIST_TOOLTIP                       :{BLACK}Listă selecție vehicule rutiere - apasă pe vehicul pentru informații
+STR_BUY_VEHICLE_SHIP_LIST_TOOLTIP                               :{BLACK}Listă de selecție a navelor - click pe o navă pentru informații
+STR_BUY_VEHICLE_AIRCRAFT_LIST_TOOLTIP                           :{BLACK}Lista de selecție a aeronavelor - clic pe o aeronavă pentru informații
 
 ###length VEHICLE_TYPES
 STR_BUY_VEHICLE_TRAIN_BUY_VEHICLE_BUTTON                        :{BLACK}Cumpără vehicul
@@ -4013,8 +4013,8 @@ STR_BUY_VEHICLE_AIRCRAFT_BUY_REFIT_VEHICLE_BUTTON               :{BLACK}Cumpăr�
 ###length VEHICLE_TYPES
 STR_BUY_VEHICLE_TRAIN_BUY_VEHICLE_TOOLTIP                       :{BLACK}Cumpără vehiculul feroviar selectat. Shift+Click arată costul estimat fără să cumpere vehiculul
 STR_BUY_VEHICLE_ROAD_VEHICLE_BUY_VEHICLE_TOOLTIP                :{BLACK}Cumpără autovehiculul selectat. Shift+clic arată costul estimat fără achiziția autovehiculului
-STR_BUY_VEHICLE_SHIP_BUY_VEHICLE_TOOLTIP                        :{BLACK}Cumpără nava selectată. Shift+Click arată costul estimativ fără a efectua achiziţia
-STR_BUY_VEHICLE_AIRCRAFT_BUY_VEHICLE_TOOLTIP                    :{BLACK}Cumpără aeronava selectată. Shift+Click arată costul estimativ fără a efectua achiziţia
+STR_BUY_VEHICLE_SHIP_BUY_VEHICLE_TOOLTIP                        :{BLACK}Cumpără nava selectată. Shift+Click arată costul estimativ fără a efectua achiziția
+STR_BUY_VEHICLE_AIRCRAFT_BUY_VEHICLE_TOOLTIP                    :{BLACK}Cumpără aeronava selectată. Shift+Click arată costul estimativ fără a efectua achiziția
 
 ###length VEHICLE_TYPES
 STR_BUY_VEHICLE_TRAIN_BUY_REFIT_VEHICLE_TOOLTIP                 :{BLACK}Cumpără și convertește trenul selectat. Shift+clic arată costul estimat fără achiziție
@@ -4031,8 +4031,8 @@ STR_BUY_VEHICLE_AIRCRAFT_RENAME_BUTTON                          :{BLACK}Redenumi
 ###length VEHICLE_TYPES
 STR_BUY_VEHICLE_TRAIN_RENAME_TOOLTIP                            :{BLACK}Redenumește modelul vehiculului feroviar
 STR_BUY_VEHICLE_ROAD_VEHICLE_RENAME_TOOLTIP                     :{BLACK}Redenumește modelul de autovehicul
-STR_BUY_VEHICLE_SHIP_RENAME_TOOLTIP                             :{BLACK}Redenumeşte modelul de navă
-STR_BUY_VEHICLE_AIRCRAFT_RENAME_TOOLTIP                         :{BLACK}Redenumeşte modelul de aeronavă
+STR_BUY_VEHICLE_SHIP_RENAME_TOOLTIP                             :{BLACK}Redenumește modelul de navă
+STR_BUY_VEHICLE_AIRCRAFT_RENAME_TOOLTIP                         :{BLACK}Redenumește modelul de aeronavă
 
 ###length VEHICLE_TYPES
 STR_BUY_VEHICLE_TRAIN_HIDE_TOGGLE_BUTTON                        :{BLACK}Ascunde
@@ -4055,8 +4055,8 @@ STR_BUY_VEHICLE_AIRCRAFT_HIDE_SHOW_TOGGLE_TOOLTIP               :{BLACK}Comută 
 ###length VEHICLE_TYPES
 STR_QUERY_RENAME_TRAIN_TYPE_CAPTION                             :{WHITE}Redenumește modelul vehiculului feroviar
 STR_QUERY_RENAME_ROAD_VEHICLE_TYPE_CAPTION                      :{WHITE}Redenumește modelul de autovehicul
-STR_QUERY_RENAME_SHIP_TYPE_CAPTION                              :{WHITE}Redenumeşte modelul de navă
-STR_QUERY_RENAME_AIRCRAFT_TYPE_CAPTION                          :{WHITE}Redenumeşte modelul de aeronavă
+STR_QUERY_RENAME_SHIP_TYPE_CAPTION                              :{WHITE}Redenumește modelul de navă
+STR_QUERY_RENAME_AIRCRAFT_TYPE_CAPTION                          :{WHITE}Redenumește modelul de aeronavă
 
 # Depot window
 STR_DEPOT_CAPTION                                               :{WHITE}{DEPOT}
@@ -4070,10 +4070,10 @@ STR_DEPOT_VEHICLE_TOOLTIP_CHAIN                                 :{BLACK}{NUM} {P
 STR_DEPOT_VEHICLE_TOOLTIP_CARGO                                 :{}{CARGO_LONG} ({CARGO_SHORT})
 
 ###length VEHICLE_TYPES
-STR_DEPOT_TRAIN_LIST_TOOLTIP                                    :{BLACK}Trenuri - trage vehiculele cu click stânga pentru a adauga/elimina din tren, click dreapta pe vehicul pentru informaţii. Tasta Ctrl aplică funcţiile pentru întreaga garnitură
-STR_DEPOT_ROAD_VEHICLE_LIST_TOOLTIP                             :{BLACK}Autovehicule - clic dreapta pe vehicul pentru informaţii
-STR_DEPOT_SHIP_LIST_TOOLTIP                                     :{BLACK}Nave - clic dreapta pe o navă pentru informaţii
-STR_DEPOT_AIRCRAFT_LIST_TOOLTIP                                 :{BLACK}Aeronavă - clic dreapta pe aeronavă pentru informaţii
+STR_DEPOT_TRAIN_LIST_TOOLTIP                                    :{BLACK}Trenuri - trage vehiculele cu click stânga pentru a adauga/elimina din tren, click dreapta pe vehicul pentru informații. Tasta Ctrl aplică funcțiile pentru întreaga garnitură
+STR_DEPOT_ROAD_VEHICLE_LIST_TOOLTIP                             :{BLACK}Autovehicule - clic dreapta pe vehicul pentru informații
+STR_DEPOT_SHIP_LIST_TOOLTIP                                     :{BLACK}Nave - clic dreapta pe o navă pentru informații
+STR_DEPOT_AIRCRAFT_LIST_TOOLTIP                                 :{BLACK}Aeronavă - clic dreapta pe aeronavă pentru informații
 
 ###length VEHICLE_TYPES
 STR_DEPOT_TRAIN_SELL_TOOLTIP                                    :{BLACK}Mută un vehicul aici pentru a-l vinde
@@ -4088,10 +4088,10 @@ STR_DEPOT_SELL_ALL_BUTTON_SHIP_TOOLTIP                          :{BLACK}Vinde to
 STR_DEPOT_SELL_ALL_BUTTON_AIRCRAFT_TOOLTIP                      :{BLACK}Vinde toate aeronavele din hangar
 
 ###length VEHICLE_TYPES
-STR_DEPOT_AUTOREPLACE_TRAIN_TOOLTIP                             :{BLACK}înlocuieşte automat toate din depou
-STR_DEPOT_AUTOREPLACE_ROAD_VEHICLE_TOOLTIP                      :{BLACK}înlocuieşte automat toate autovehiculele din depou
-STR_DEPOT_AUTOREPLACE_SHIP_TOOLTIP                              :{BLACK}înlocuieşte automat toate vasele din depou
-STR_DEPOT_AUTOREPLACE_AIRCRAFT_TOOLTIP                          :{BLACK}înlocuieşte automat toate aeronavele din hangar
+STR_DEPOT_AUTOREPLACE_TRAIN_TOOLTIP                             :{BLACK}înlocuiește automat toate din depou
+STR_DEPOT_AUTOREPLACE_ROAD_VEHICLE_TOOLTIP                      :{BLACK}înlocuiește automat toate autovehiculele din depou
+STR_DEPOT_AUTOREPLACE_SHIP_TOOLTIP                              :{BLACK}înlocuiește automat toate vasele din depou
+STR_DEPOT_AUTOREPLACE_AIRCRAFT_TOOLTIP                          :{BLACK}înlocuiește automat toate aeronavele din hangar
 
 ###length VEHICLE_TYPES
 STR_DEPOT_TRAIN_NEW_VEHICLES_BUTTON                             :{BLACK}Vehicule noi
@@ -4100,7 +4100,7 @@ STR_DEPOT_SHIP_NEW_VEHICLES_BUTTON                              :{BLACK}Nave noi
 STR_DEPOT_AIRCRAFT_NEW_VEHICLES_BUTTON                          :{BLACK}Aeronavă nouă
 
 ###length VEHICLE_TYPES
-STR_DEPOT_TRAIN_NEW_VEHICLES_TOOLTIP                            :{BLACK}Construieşte un nou vehicul feroviar
+STR_DEPOT_TRAIN_NEW_VEHICLES_TOOLTIP                            :{BLACK}Construiește un nou vehicul feroviar
 STR_DEPOT_ROAD_VEHICLE_NEW_VEHICLES_TOOLTIP                     :{BLACK}Cumpără un autovehicul nou
 STR_DEPOT_SHIP_NEW_VEHICLES_TOOLTIP                             :{BLACK}Cumpără o navă nouă
 STR_DEPOT_AIRCRAFT_NEW_VEHICLES_TOOLTIP                         :{BLACK}Cumpără o nouă aeronavă
@@ -4142,15 +4142,15 @@ STR_DEPOT_MASS_START_DEPOT_SHIP_TOOLTIP                         :{BLACK}Clic pen
 STR_DEPOT_MASS_START_HANGAR_TOOLTIP                             :{BLACK}Click pt pornirea tuturor aeronavelor din hangar
 
 STR_DEPOT_DRAG_WHOLE_TRAIN_TO_SELL_TOOLTIP                      :{BLACK}Trage locomotiva aici pentru a vinde întregul tren
-STR_DEPOT_SELL_CONFIRMATION_TEXT                                :{YELLOW}Eşti pe cale să vinzi toate vehiculele din depou. Eşti sigur?
+STR_DEPOT_SELL_CONFIRMATION_TEXT                                :{YELLOW}Ești pe cale să vinzi toate vehiculele din depou. Ești sigur?
 
 # Engine preview window
 STR_ENGINE_PREVIEW_CAPTION                                      :{WHITE}Mesaj de la producătorul de vehicule
-STR_ENGINE_PREVIEW_MESSAGE                                      :{GOLD}Am creat un nou tip de {STRING}. Aţi fi interesaţi de folosirea exclusivă pentru un an a acestui vehicul, astfel ca noi să-i putem observa performanţele înaintea lansării oficiale?
+STR_ENGINE_PREVIEW_MESSAGE                                      :{GOLD}Am creat un nou tip de {STRING}. Ați fi interesați de folosirea exclusivă pentru un an a acestui vehicul, astfel ca noi să-i putem observa performanțele înaintea lansării oficiale?
 
 STR_ENGINE_PREVIEW_RAILROAD_LOCOMOTIVE                          :locomotivă
 STR_ENGINE_PREVIEW_ELRAIL_LOCOMOTIVE                            :locomotivă electrificată
-STR_ENGINE_PREVIEW_MONORAIL_LOCOMOTIVE                          :locomotivă monoşină
+STR_ENGINE_PREVIEW_MONORAIL_LOCOMOTIVE                          :locomotivă monoșină
 STR_ENGINE_PREVIEW_MAGLEV_LOCOMOTIVE                            :locomotivă pernă magnetică
 
 STR_ENGINE_PREVIEW_ROAD_VEHICLE                                 :autovehicul
@@ -4168,7 +4168,7 @@ STR_ENGINE_PREVIEW_COST_MAX_SPEED_TYPE_RANGE_CAP_CAP_RUNCOST    :{BLACK}Cost: {C
 STR_ENGINE_PREVIEW_COST_MAX_SPEED_TYPE_RANGE_CAP_RUNCOST        :{BLACK}Cost: {CURRENCY_LONG} Viteză max.: {VELOCITY}{}Tip aeronavă: {STRING} Autonomie: {COMMA} dale{}Capacitate: {CARGO_LONG}{}Mentenanță: {CURRENCY_LONG}/an
 
 # Autoreplace window
-STR_REPLACE_VEHICLES_WHITE                                      :{WHITE}Înlocuieşte {STRING} - {STRING}
+STR_REPLACE_VEHICLES_WHITE                                      :{WHITE}Înlocuiește {STRING} - {STRING}
 
 STR_REPLACE_VEHICLE_VEHICLES_IN_USE                             :{YELLOW}Vehicule în uz
 STR_REPLACE_VEHICLE_VEHICLES_IN_USE_TOOLTIP                     :{BLACK}Coloana vehiculelor pe care le deții
@@ -4182,11 +4182,11 @@ STR_REPLACE_VEHICLE_SHIP                                        :Nava
 STR_REPLACE_VEHICLE_AIRCRAFT                                    :Aeronava
 
 STR_REPLACE_HELP_LEFT_ARRAY                                     :{BLACK}Alege tipul de motor pentru înlocuire
-STR_REPLACE_HELP_RIGHT_ARRAY                                    :{BLACK}Alege noul tip de motor pe care doreşti să-l foloseşti în locul motorului selectat în stânga
+STR_REPLACE_HELP_RIGHT_ARRAY                                    :{BLACK}Alege noul tip de motor pe care dorești să-l folosești în locul motorului selectat în stânga
 
 STR_REPLACE_VEHICLES_START                                      :{BLACK}Incepere inlocuire vehicule
-STR_REPLACE_VEHICLES_NOW                                        :Înlocuieşte toate vehiculele acum
-STR_REPLACE_VEHICLES_WHEN_OLD                                   :Înlocuieşte doar vehiculele vechi
+STR_REPLACE_VEHICLES_NOW                                        :Înlocuiește toate vehiculele acum
+STR_REPLACE_VEHICLES_WHEN_OLD                                   :Înlocuiește doar vehiculele vechi
 STR_REPLACE_HELP_START_BUTTON                                   :{BLACK}Apasă aici pentru a începe înlocuirea motorului selectat în stânga cu cel selectat în dreapta
 STR_REPLACE_NOT_REPLACING                                       :{BLACK}Neinlocuire
 STR_REPLACE_NOT_REPLACING_VEHICLE_SELECTED                      :{BLACK}Nici un vehicul selectat
@@ -4215,7 +4215,7 @@ STR_REPLACE_ROAD_VEHICLES                                       :Autovehicule
 STR_REPLACE_TRAM_VEHICLES                                       :Tramvaie
 
 STR_REPLACE_REMOVE_WAGON                                        :{BLACK}Retragere vagoane ({STRING}): {ORANGE}{STRING}
-STR_REPLACE_REMOVE_WAGON_HELP                                   :{BLACK}Fă optiunea de autoînlocuire să păstreze identică lungimea unui tren prin eliminarea vagoanelor (începând din faţă) dacă înlocuirea locomotivei ar face trenul mai lung
+STR_REPLACE_REMOVE_WAGON_HELP                                   :{BLACK}Fă optiunea de autoînlocuire să păstreze identică lungimea unui tren prin eliminarea vagoanelor (începând din față) dacă înlocuirea locomotivei ar face trenul mai lung
 STR_REPLACE_REMOVE_WAGON_GROUP_HELP                             :{STRING}. Ctrl+clic pentru aplicare și la sub-grupuri
 
 # Vehicle view
@@ -4230,8 +4230,8 @@ STR_VEHICLE_VIEW_AIRCRAFT_CENTER_TOOLTIP                        :{BLACK}Centreaz
 ###length VEHICLE_TYPES
 STR_VEHICLE_VIEW_TRAIN_SEND_TO_DEPOT_TOOLTIP                    :{BLACK}Trimite trenul într-un depou
 STR_VEHICLE_VIEW_ROAD_VEHICLE_SEND_TO_DEPOT_TOOLTIP             :{BLACK}Trimite autovehiculul la autobază. Ctrl+clic pentru service
-STR_VEHICLE_VIEW_SHIP_SEND_TO_DEPOT_TOOLTIP                     :{BLACK}Trimite nava în şantier. Ctrl+clic pentru întreţinere
-STR_VEHICLE_VIEW_AIRCRAFT_SEND_TO_DEPOT_TOOLTIP                 :{BLACK}Trimite aeronava la hangar. Ctrl+clic pentru întreţinere
+STR_VEHICLE_VIEW_SHIP_SEND_TO_DEPOT_TOOLTIP                     :{BLACK}Trimite nava în șantier. Ctrl+clic pentru întreținere
+STR_VEHICLE_VIEW_AIRCRAFT_SEND_TO_DEPOT_TOOLTIP                 :{BLACK}Trimite aeronava la hangar. Ctrl+clic pentru întreținere
 
 ###length VEHICLE_TYPES
 STR_VEHICLE_VIEW_CLONE_TRAIN_INFO                               :{BLACK}Acest buton va crea o copie a întregului tren. Ctrl+Click va sincroniza comenzile. Shift+Click va afișa costul estimat fără a achiziționa trenul
@@ -4239,9 +4239,9 @@ STR_VEHICLE_VIEW_CLONE_ROAD_VEHICLE_INFO                        :{BLACK}Acest bu
 STR_VEHICLE_VIEW_CLONE_SHIP_INFO                                :{BLACK}Acest buton va crea o copie a navei. Ctrl+clic va sincroniza comenzile. Shift+clic va afișa costul estimat fără a achiziționa nava
 STR_VEHICLE_VIEW_CLONE_AIRCRAFT_INFO                            :{BLACK}Acest buton va crea o copie a aeronavei. Ctrl+clic va sincroniza comenzile. Shift+clic va afișa costul estimat fără a cumpăra aeronava
 
-STR_VEHICLE_VIEW_TRAIN_IGNORE_SIGNAL_TOOLTIP                    :{BLACK}Forţează trenul să ignore semnalizarea de oprire
-STR_VEHICLE_VIEW_TRAIN_REVERSE_TOOLTIP                          :{BLACK}Schimbă sensul de circulaţie al trenului
-STR_VEHICLE_VIEW_ROAD_VEHICLE_REVERSE_TOOLTIP                   :{BLACK}Forţează vehiculul să întoarcă
+STR_VEHICLE_VIEW_TRAIN_IGNORE_SIGNAL_TOOLTIP                    :{BLACK}Forțează trenul să ignore semnalizarea de oprire
+STR_VEHICLE_VIEW_TRAIN_REVERSE_TOOLTIP                          :{BLACK}Schimbă sensul de circulație al trenului
+STR_VEHICLE_VIEW_ROAD_VEHICLE_REVERSE_TOOLTIP                   :{BLACK}Forțează vehiculul să întoarcă
 STR_VEHICLE_VIEW_ORDER_LOCATION_TOOLTIP                         :{BLACK}Centrează vizorul principal pe destinația comenzii. Ctrl+clic deschide un nou vizor pe locația de destinație a comenzii
 
 ###length VEHICLE_TYPES
@@ -4257,10 +4257,10 @@ STR_VEHICLE_VIEW_SHIP_ORDERS_TOOLTIP                            :{BLACK}Afișeaz
 STR_VEHICLE_VIEW_AIRCRAFT_ORDERS_TOOLTIP                        :{BLACK}Afișează comenzile aeronavei. Ctrl-clic afișează orarul
 
 ###length VEHICLE_TYPES
-STR_VEHICLE_VIEW_TRAIN_SHOW_DETAILS_TOOLTIP                     :{BLACK}Afişează detaliile trenului
-STR_VEHICLE_VIEW_ROAD_VEHICLE_SHOW_DETAILS_TOOLTIP              :{BLACK}Afişează detaliile autovehiculului
-STR_VEHICLE_VIEW_SHIP_SHOW_DETAILS_TOOLTIP                      :{BLACK}Afişează detaliile navei
-STR_VEHICLE_VIEW_AIRCRAFT_SHOW_DETAILS_TOOLTIP                  :{BLACK}Afişează detaliile aeronavei
+STR_VEHICLE_VIEW_TRAIN_SHOW_DETAILS_TOOLTIP                     :{BLACK}Afișează detaliile trenului
+STR_VEHICLE_VIEW_ROAD_VEHICLE_SHOW_DETAILS_TOOLTIP              :{BLACK}Afișează detaliile autovehiculului
+STR_VEHICLE_VIEW_SHIP_SHOW_DETAILS_TOOLTIP                      :{BLACK}Afișează detaliile navei
+STR_VEHICLE_VIEW_AIRCRAFT_SHOW_DETAILS_TOOLTIP                  :{BLACK}Afișează detaliile aeronavei
 
 ###length VEHICLE_TYPES
 STR_VEHICLE_VIEW_TRAIN_STATUS_START_STOP_TOOLTIP                :{BLACK}Acțiunea trenului curent - clic pentru oprirea/pornirea trenului
@@ -4305,10 +4305,10 @@ STR_VEHICLE_DETAILS_CAPTION                                     :{WHITE}{VEHICLE
 ###length VEHICLE_TYPES
 STR_VEHICLE_DETAILS_TRAIN_RENAME                                :{BLACK}Numele trenului
 STR_VEHICLE_DETAILS_ROAD_VEHICLE_RENAME                         :{BLACK}Numele autovehiculului
-STR_VEHICLE_DETAILS_SHIP_RENAME                                 :{BLACK}Denumeşte această navă
-STR_VEHICLE_DETAILS_AIRCRAFT_RENAME                             :{BLACK}Denumeşte aeronava
+STR_VEHICLE_DETAILS_SHIP_RENAME                                 :{BLACK}Denumește această navă
+STR_VEHICLE_DETAILS_AIRCRAFT_RENAME                             :{BLACK}Denumește aeronava
 
-STR_VEHICLE_INFO_AGE_RUNNING_COST_YR                            :{BLACK}Vechime: {LTBLUE}{STRING}{BLACK}   Mentenanţă: {LTBLUE}{CURRENCY_LONG}/an
+STR_VEHICLE_INFO_AGE_RUNNING_COST_YR                            :{BLACK}Vechime: {LTBLUE}{STRING}{BLACK}   Mentenanță: {LTBLUE}{CURRENCY_LONG}/an
 STR_VEHICLE_INFO_AGE                                            :{COMMA} {P an ani "de ani"} ({COMMA})
 STR_VEHICLE_INFO_AGE_RED                                        :{RED}{COMMA} {P an ani "de ani"} ({COMMA})
 
@@ -4320,7 +4320,7 @@ STR_VEHICLE_INFO_WEIGHT_POWER_MAX_SPEED_MAX_TE                  :{BLACK}Greutate
 
 STR_VEHICLE_INFO_PROFIT_THIS_YEAR_LAST_YEAR                     :{BLACK}Profit pe anul curent: {LTBLUE}{CURRENCY_LONG} (anul precedent: {CURRENCY_LONG})
 STR_VEHICLE_INFO_PROFIT_THIS_YEAR_LAST_YEAR_MIN_PERFORMANCE     :{BLACK}Profit anul curent: {LTBLUE}{CURRENCY_LONG} (anul trecut: {CURRENCY_LONG}) {BLACK}performanta minima: {LTBLUE}{POWER_TO_WEIGHT}
-STR_VEHICLE_INFO_RELIABILITY_BREAKDOWNS                         :{BLACK}Eficienţă: {LTBLUE}{COMMA}%  {BLACK}Defecţiuni de la ultimul service: {LTBLUE}{COMMA}
+STR_VEHICLE_INFO_RELIABILITY_BREAKDOWNS                         :{BLACK}Eficiență: {LTBLUE}{COMMA}%  {BLACK}Defecțiuni de la ultimul service: {LTBLUE}{COMMA}
 
 STR_VEHICLE_INFO_BUILT_VALUE                                    :{LTBLUE}{ENGINE} {BLACK}Construit: {LTBLUE}{NUM}{BLACK} Valoare: {LTBLUE}{CURRENCY_LONG}
 STR_VEHICLE_INFO_NO_CAPACITY                                    :{BLACK}Capacitate: {LTBLUE}Nimic{STRING}
@@ -4330,10 +4330,10 @@ STR_VEHICLE_INFO_CAPACITY_CAPACITY                              :{BLACK}Capacita
 
 STR_VEHICLE_INFO_FEEDER_CARGO_VALUE                             :{BLACK}Transferă Credit: {LTBLUE}{CURRENCY_LONG}
 
-STR_VEHICLE_DETAILS_SERVICING_INTERVAL_DAYS                     :{BLACK}Intervalul pentru întreţinere: {LTBLUE}{COMMA}zile{BLACK}   Ultima întreţinere: {LTBLUE}{DATE_LONG}
+STR_VEHICLE_DETAILS_SERVICING_INTERVAL_DAYS                     :{BLACK}Intervalul pentru întreținere: {LTBLUE}{COMMA}zile{BLACK}   Ultima întreținere: {LTBLUE}{DATE_LONG}
 STR_VEHICLE_DETAILS_SERVICING_INTERVAL_PERCENT                  :{BLACK}Intervalul de service: {LTBLUE}{COMMA}%{BLACK}   Ultimul service: {LTBLUE}{DATE_LONG}
-STR_VEHICLE_DETAILS_INCREASE_SERVICING_INTERVAL_TOOLTIP         :{BLACK}Măreşte intervalul de service cu 10. Ctrl+click măreşte intervalul de service cu 5
-STR_VEHICLE_DETAILS_DECREASE_SERVICING_INTERVAL_TOOLTIP         :{BLACK}Micşorează intervalul de service cu 10. Ctrl+Click micşorează intervalul de service cu 5
+STR_VEHICLE_DETAILS_INCREASE_SERVICING_INTERVAL_TOOLTIP         :{BLACK}Mărește intervalul de service cu 10. Ctrl+click mărește intervalul de service cu 5
+STR_VEHICLE_DETAILS_DECREASE_SERVICING_INTERVAL_TOOLTIP         :{BLACK}Micșorează intervalul de service cu 10. Ctrl+Click micșorează intervalul de service cu 5
 
 STR_SERVICE_INTERVAL_DROPDOWN_TOOLTIP                           :{BLACK}Schimbă tipul intervalului de întreținere
 STR_VEHICLE_DETAILS_DEFAULT                                     :Standard
@@ -4343,8 +4343,8 @@ STR_VEHICLE_DETAILS_PERCENT                                     :Procent
 ###length VEHICLE_TYPES
 STR_QUERY_RENAME_TRAIN_CAPTION                                  :{WHITE}Numele trenului
 STR_QUERY_RENAME_ROAD_VEHICLE_CAPTION                           :{WHITE}Numele autovehiculului
-STR_QUERY_RENAME_SHIP_CAPTION                                   :{WHITE}Denumeşte această navă
-STR_QUERY_RENAME_AIRCRAFT_CAPTION                               :{WHITE}Denumeşte aeronava
+STR_QUERY_RENAME_SHIP_CAPTION                                   :{WHITE}Denumește această navă
+STR_QUERY_RENAME_AIRCRAFT_CAPTION                               :{WHITE}Denumește aeronava
 
 # Extra buttons for train details windows
 STR_VEHICLE_DETAILS_TRAIN_ENGINE_BUILT_AND_VALUE                :{LTBLUE}{ENGINE}{BLACK}   Cumpărat: {LTBLUE}{NUM}{BLACK} Valoare: {LTBLUE}{CURRENCY_LONG}
@@ -4359,11 +4359,11 @@ STR_VEHICLE_DETAILS_CARGO_FROM                                  :{LTBLUE}{CARGO_
 STR_VEHICLE_DETAILS_CARGO_FROM_MULT                             :{LTBLUE}{CARGO_LONG} de la {STATION} (x{NUM})
 
 STR_VEHICLE_DETAIL_TAB_CARGO                                    :{BLACK}Încărcătură
-STR_VEHICLE_DETAILS_TRAIN_CARGO_TOOLTIP                         :{BLACK}Afişează detalii despre încărcătura transportată
+STR_VEHICLE_DETAILS_TRAIN_CARGO_TOOLTIP                         :{BLACK}Afișează detalii despre încărcătura transportată
 STR_VEHICLE_DETAIL_TAB_INFORMATION                              :{BLACK}Informatii
-STR_VEHICLE_DETAILS_TRAIN_INFORMATION_TOOLTIP                   :{BLACK}Afişează detalii despre componentele trenului
-STR_VEHICLE_DETAIL_TAB_CAPACITIES                               :{BLACK}Capacităţi
-STR_VEHICLE_DETAILS_TRAIN_CAPACITIES_TOOLTIP                    :{BLACK}Afişează capacităţile fiecărei componente
+STR_VEHICLE_DETAILS_TRAIN_INFORMATION_TOOLTIP                   :{BLACK}Afișează detalii despre componentele trenului
+STR_VEHICLE_DETAIL_TAB_CAPACITIES                               :{BLACK}Capacități
+STR_VEHICLE_DETAILS_TRAIN_CAPACITIES_TOOLTIP                    :{BLACK}Afișează capacitățile fiecărei componente
 STR_VEHICLE_DETAIL_TAB_TOTAL_CARGO                              :{BLACK}Încãrcãturi
 STR_VEHICLE_DETAILS_TRAIN_TOTAL_CARGO_TOOLTIP                   :{BLACK}Afiseazã capacitãtile totale ale trenului, diferentiate pe tip de încãrcãturã
 
@@ -4401,12 +4401,12 @@ STR_ORDERS_CAPTION                                              :{WHITE}{VEHICLE
 STR_ORDERS_TIMETABLE_VIEW                                       :{BLACK}Orar
 STR_ORDERS_TIMETABLE_VIEW_TOOLTIP                               :{BLACK}Comută în modul de vizualizare orar
 
-STR_ORDERS_LIST_TOOLTIP                                         :{BLACK}Lista de comenzi - clic pe o comandă pentru a o selecta. Ctrl+Click poziţionează ecranul pe staţia destinație
+STR_ORDERS_LIST_TOOLTIP                                         :{BLACK}Lista de comenzi - clic pe o comandă pentru a o selecta. Ctrl+Click poziționează ecranul pe stația destinație
 STR_ORDER_INDEX                                                 :{COMMA}:{NBSP}
 STR_ORDER_TEXT                                                  :{STRING} {STRING} {STRING}
 
-STR_ORDERS_END_OF_ORDERS                                        :- - Sfârşitul comenzilor - -
-STR_ORDERS_END_OF_SHARED_ORDERS                                 :- - Sfârşitul comenzilor sincronizate - -
+STR_ORDERS_END_OF_ORDERS                                        :- - Sfârșitul comenzilor - -
+STR_ORDERS_END_OF_SHARED_ORDERS                                 :- - Sfârșitul comenzilor sincronizate - -
 
 # Order bottom buttons
 STR_ORDER_NON_STOP                                              :{BLACK}Non-stop
@@ -4448,12 +4448,12 @@ STR_ORDER_CONDITIONAL_VARIABLE_TOOLTIP                          :{BLACK}Datele v
 # Conditional order variables, must follow order of OrderConditionVariable enum
 ###length 8
 STR_ORDER_CONDITIONAL_LOAD_PERCENTAGE                           :Procentaj încărcare
-STR_ORDER_CONDITIONAL_RELIABILITY                               :Eficienţă
+STR_ORDER_CONDITIONAL_RELIABILITY                               :Eficiență
 STR_ORDER_CONDITIONAL_MAX_SPEED                                 :Viteză maximă
 STR_ORDER_CONDITIONAL_AGE                                       :Vechime (ani)
 STR_ORDER_CONDITIONAL_REQUIRES_SERVICE                          :Necesită service
 STR_ORDER_CONDITIONAL_UNCONDITIONALLY                           :Întotdeauna
-STR_ORDER_CONDITIONAL_REMAINING_LIFETIME                        :Durată de viaţă rămasă
+STR_ORDER_CONDITIONAL_REMAINING_LIFETIME                        :Durată de viață rămasă
 STR_ORDER_CONDITIONAL_MAX_RELIABILITY                           :Fiabilitate maximă
 ###next-name-looks-similar
 
@@ -4468,15 +4468,15 @@ STR_ORDER_CONDITIONAL_COMPARATOR_IS_TRUE                        :este adevărat
 STR_ORDER_CONDITIONAL_COMPARATOR_IS_FALSE                       :este fals
 
 STR_ORDER_CONDITIONAL_VALUE_TOOLTIP                             :{BLACK}Valoarea cu care se compară
-STR_ORDER_CONDITIONAL_VALUE_CAPT                                :{WHITE}Introduceţi valoarea de comparat
+STR_ORDER_CONDITIONAL_VALUE_CAPT                                :{WHITE}Introduceți valoarea de comparat
 
 STR_ORDERS_SKIP_BUTTON                                          :{BLACK}Treci la următoarea
 STR_ORDERS_SKIP_TOOLTIP                                         :{BLACK}Sari peste comanda actuală și preia-o pe următoarea. Ctrl+clic sare la comanda selectată
 
-STR_ORDERS_DELETE_BUTTON                                        :{BLACK}Şterge
+STR_ORDERS_DELETE_BUTTON                                        :{BLACK}șterge
 STR_ORDERS_DELETE_TOOLTIP                                       :{BLACK}Șterge comanda selectată
 STR_ORDERS_DELETE_ALL_TOOLTIP                                   :{BLACK}Șterge toate comenzile
-STR_ORDERS_STOP_SHARING_BUTTON                                  :{BLACK}Opreşte sincronizarea
+STR_ORDERS_STOP_SHARING_BUTTON                                  :{BLACK}Oprește sincronizarea
 STR_ORDERS_STOP_SHARING_TOOLTIP                                 :{BLACK}Oprește sincronizarea comenzilor. Ctrl-clic șterge toate comenzile acestui vehicul
 
 STR_ORDERS_GO_TO_BUTTON                                         :{BLACK}Mergi la
@@ -4500,14 +4500,14 @@ STR_ORDER_NEAREST_HANGAR                                        :cel mai apropia
 ###length 3
 STR_ORDER_TRAIN_DEPOT                                           :Depou de Trenuri
 STR_ORDER_ROAD_VEHICLE_DEPOT                                    :Autobază
-STR_ORDER_SHIP_DEPOT                                            :Şantier Naval
+STR_ORDER_SHIP_DEPOT                                            :șantier Naval
 ###next-name-looks-similar
 
 STR_ORDER_GO_TO_NEAREST_DEPOT_FORMAT                            :{STRING} {STRING} {STRING}
 STR_ORDER_GO_TO_DEPOT_FORMAT                                    :{STRING} {DEPOT}
 
 STR_ORDER_REFIT_ORDER                                           :(Rearanjeaza in {STRING})
-STR_ORDER_REFIT_STOP_ORDER                                      :(Modifică pentru {STRING} şi opreşte)
+STR_ORDER_REFIT_STOP_ORDER                                      :(Modifică pentru {STRING} și oprește)
 STR_ORDER_STOP_ORDER                                            :(Stop)
 
 STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
@@ -4518,17 +4518,17 @@ STR_ORDER_IMPLICIT                                              :(Implicit)
 STR_ORDER_FULL_LOAD                                             :(Încărcare maximă)
 STR_ORDER_FULL_LOAD_ANY                                         :(Încărcare orice produs)
 STR_ORDER_NO_LOAD                                               :(Fără încărcare)
-STR_ORDER_UNLOAD                                                :(Descarcă şi preia încărcătura)
-STR_ORDER_UNLOAD_FULL_LOAD                                      :(Descarcă şi aşteaptă încărcare maximă)
-STR_ORDER_UNLOAD_FULL_LOAD_ANY                                  :(Descarcă şi aşteaptă orice încărcătură)
-STR_ORDER_UNLOAD_NO_LOAD                                        :(Descarcă şi pleacă)
+STR_ORDER_UNLOAD                                                :(Descarcă și preia încărcătura)
+STR_ORDER_UNLOAD_FULL_LOAD                                      :(Descarcă și așteaptă încărcare maximă)
+STR_ORDER_UNLOAD_FULL_LOAD_ANY                                  :(Descarcă și așteaptă orice încărcătură)
+STR_ORDER_UNLOAD_NO_LOAD                                        :(Descarcă și pleacă)
 STR_ORDER_TRANSFER                                              :(Transferă - preia încărcătura)
-STR_ORDER_TRANSFER_FULL_LOAD                                    :(Transferă şi aşteaptă încărcare maximă)
-STR_ORDER_TRANSFER_FULL_LOAD_ANY                                :(Transferă şi aşteaptă orice încărcătură)
+STR_ORDER_TRANSFER_FULL_LOAD                                    :(Transferă și așteaptă încărcare maximă)
+STR_ORDER_TRANSFER_FULL_LOAD_ANY                                :(Transferă și așteaptă orice încărcătură)
 STR_ORDER_TRANSFER_NO_LOAD                                      :(Transferă - pleacă descărcat)
-STR_ORDER_NO_UNLOAD                                             :(Nu descărca şi preia încărcătura)
-STR_ORDER_NO_UNLOAD_FULL_LOAD                                   :(Nu descărca şi aşteaptă încărcare maximă)
-STR_ORDER_NO_UNLOAD_FULL_LOAD_ANY                               :(Nu descărca şi aşteaptă orice încărcătură)
+STR_ORDER_NO_UNLOAD                                             :(Nu descărca și preia încărcătura)
+STR_ORDER_NO_UNLOAD_FULL_LOAD                                   :(Nu descărca și așteaptă încărcare maximă)
+STR_ORDER_NO_UNLOAD_FULL_LOAD_ANY                               :(Nu descărca și așteaptă orice încărcătură)
 STR_ORDER_NO_UNLOAD_NO_LOAD                                     :(Fără încărcare sau descărcare)
 
 STR_ORDER_AUTO_REFIT                                            :(Înlocuire automată cu {STRING})
@@ -4603,18 +4603,18 @@ STR_TIMETABLE_CLEAR_TIME_TOOLTIP                                :{BLACK}Elimină
 STR_TIMETABLE_CHANGE_SPEED                                      :{BLACK}Schimbă limita de viteză
 STR_TIMETABLE_CHANGE_SPEED_TOOLTIP                              :{BLACK}Schimbă limita maximă de viteză a comenzii selectate. Ctrl+Click setează viteza pentru toate comenzile
 
-STR_TIMETABLE_CLEAR_SPEED                                       :{BLACK}Şterge limita de viteză
+STR_TIMETABLE_CLEAR_SPEED                                       :{BLACK}șterge limita de viteză
 STR_TIMETABLE_CLEAR_SPEED_TOOLTIP                               :{BLACK}Ștergeți viteza maximă de deplasare a comenzii evidențiate. Ctrl+Click șterge viteza pentru toate comenzile
 
 STR_TIMETABLE_RESET_LATENESS                                    :{BLACK}Reinitializeaza contorul de intarziere
-STR_TIMETABLE_RESET_LATENESS_TOOLTIP                            :{BLACK}Reiniţializează contorul de întârziere, astfel ca vehiculul să ajungă la timp. Ctrl+clic va reseta tot grupul astfel încât cel mai întârziat vehicul va ajunge la timp și toate celelalte vor ajunge mai devreme
+STR_TIMETABLE_RESET_LATENESS_TOOLTIP                            :{BLACK}Reinițializează contorul de întârziere, astfel ca vehiculul să ajungă la timp. Ctrl+clic va reseta tot grupul astfel încât cel mai întârziat vehicul va ajunge la timp și toate celelalte vor ajunge mai devreme
 
 STR_TIMETABLE_AUTOFILL                                          :{BLACK}Auto-completare
 STR_TIMETABLE_AUTOFILL_TOOLTIP                                  :{BLACK}Completați automat orarul cu valorile din următoarea călătorie. Ctrl+Click pentru a încerca să păstrați timpii de așteptare
 
 STR_TIMETABLE_EXPECTED                                          :{BLACK}Estimat
 STR_TIMETABLE_SCHEDULED                                         :{BLACK}Planificat
-STR_TIMETABLE_EXPECTED_TOOLTIP                                  :{BLACK}Comută între estimare şi orar
+STR_TIMETABLE_EXPECTED_TOOLTIP                                  :{BLACK}Comută între estimare și orar
 
 STR_TIMETABLE_ARRIVAL_DATE                                      :S: {COLOUR}{DATE_TINY}
 STR_TIMETABLE_DEPARTURE_DATE                                    :P: {COLOUR}{DATE_TINY}
@@ -4625,7 +4625,7 @@ STR_TIMETABLE_DEPARTURE_SECONDS_IN_FUTURE                       :P: {COLOUR}{COM
 # Date window (for timetable)
 STR_DATE_CAPTION                                                :{WHITE}Setează data
 STR_DATE_SET_DATE                                               :{BLACK}Setează data
-STR_DATE_SET_DATE_TOOLTIP                                       :{BLACK}Foloseşte data selectată ca dată de pornire pentru acest orar
+STR_DATE_SET_DATE_TOOLTIP                                       :{BLACK}Folosește data selectată ca dată de pornire pentru acest orar
 STR_DATE_DAY_TOOLTIP                                            :{BLACK}Alege ziua
 STR_DATE_MONTH_TOOLTIP                                          :{BLACK}Alege luna
 STR_DATE_YEAR_TOOLTIP                                           :{BLACK}Alege anul
@@ -4638,20 +4638,20 @@ STR_AI_DEBUG_NAME_TOOLTIP                                       :{BLACK}Numele s
 STR_AI_DEBUG_SETTINGS                                           :{BLACK}Setări
 STR_AI_DEBUG_SETTINGS_TOOLTIP                                   :{BLACK}Schimbă setările scriptului
 STR_AI_DEBUG_RELOAD                                             :{BLACK}Reîncarcă IA
-STR_AI_DEBUG_RELOAD_TOOLTIP                                     :{BLACK}Opreşte IA, raîncarcă scriptul, apoi reporneşte IA
-STR_AI_DEBUG_BREAK_STR_ON_OFF_TOOLTIP                           :{BLACK}Activează/dezactivează suspendarea când un mesaj de la IA se potriveşte cu string-ul de oprire
-STR_AI_DEBUG_BREAK_ON_LABEL                                     :{BLACK}Opreşte la:
-STR_AI_DEBUG_BREAK_STR_OSKTITLE                                 :{BLACK}Opreşte la
-STR_AI_DEBUG_BREAK_STR_TOOLTIP                                  :{BLACK}Când un mesaj al modului de IA se potriveşte cu acest string, se suspendă jocul
+STR_AI_DEBUG_RELOAD_TOOLTIP                                     :{BLACK}Oprește IA, raîncarcă scriptul, apoi repornește IA
+STR_AI_DEBUG_BREAK_STR_ON_OFF_TOOLTIP                           :{BLACK}Activează/dezactivează suspendarea când un mesaj de la IA se potrivește cu string-ul de oprire
+STR_AI_DEBUG_BREAK_ON_LABEL                                     :{BLACK}Oprește la:
+STR_AI_DEBUG_BREAK_STR_OSKTITLE                                 :{BLACK}Oprește la
+STR_AI_DEBUG_BREAK_STR_TOOLTIP                                  :{BLACK}Când un mesaj al modului de IA se potrivește cu acest string, se suspendă jocul
 STR_AI_DEBUG_MATCH_CASE                                         :{BLACK}Potrivire majuscule/minuscule
-STR_AI_DEBUG_MATCH_CASE_TOOLTIP                                 :{BLACK}Comută potrivirea pe majuscule/minuscule când se compară fişierele log ale AI cu string-ul de oprire
+STR_AI_DEBUG_MATCH_CASE_TOOLTIP                                 :{BLACK}Comută potrivirea pe majuscule/minuscule când se compară fișierele log ale AI cu string-ul de oprire
 STR_AI_DEBUG_CONTINUE                                           :{BLACK}Continuă
-STR_AI_DEBUG_CONTINUE_TOOLTIP                                   :{BLACK}Continuă execuţia modulului de Inteligenţă Artificială
+STR_AI_DEBUG_CONTINUE_TOOLTIP                                   :{BLACK}Continuă execuția modulului de Inteligență Artificială
 STR_AI_DEBUG_SELECT_AI_TOOLTIP                                  :{BLACK}Vizualizează datele de debug ale acestui modul de IA
 STR_AI_GAME_SCRIPT                                              :{BLACK}Game Script
 STR_AI_GAME_SCRIPT_TOOLTIP                                      :{BLACK}Verifică log-ul Game Script
 
-STR_ERROR_AI_NO_AI_FOUND                                        :Nici o IA potrivită a fost găsită{}Această IA este nefuncţională.{}Poţi descărca IA-uri folsind opţiunea "Resurse online" din meniul principal.
+STR_ERROR_AI_NO_AI_FOUND                                        :Nici o IA potrivită a fost găsită{}Această IA este nefuncțională.{}Poți descărca IA-uri folsind opțiunea "Resurse online" din meniul principal.
 STR_ERROR_AI_PLEASE_REPORT_CRASH                                :{WHITE}O Inteligentă Artificială/Script Joc s-a oprit în mod eronat. Raportează această problemă autorului împreună cu o captură de ecran a ferestrei Depanare IA/Script Joc
 STR_ERROR_AI_DEBUG_SERVER_ONLY                                  :{YELLOW}Fereastra pentru depanare IA / Script Joc este disponibilă doar serverului
 
@@ -4726,7 +4726,7 @@ STR_TEXTFILE_VIEW_README                                        :{BLACK}Vezi fi�
 STR_TEXTFILE_VIEW_README_TOOLTIP                                :Vizualizați "citiți-mă / readme" pentru acest conținut
 STR_TEXTFILE_VIEW_CHANGELOG                                     :{BLACK}Listă modificări
 STR_TEXTFILE_VIEW_CHANGELOG_TOOLTIP                             :Vizualizați jurnalul de modificări pentru acest conținut
-STR_TEXTFILE_VIEW_LICENCE                                       :{BLACK}Licenţă
+STR_TEXTFILE_VIEW_LICENCE                                       :{BLACK}Licență
 STR_TEXTFILE_VIEW_LICENCE_TOOLTIP                               :Vedeți licența pentru acest conținut
 ###length 5
 STR_TEXTFILE_README_CAPTION                                     :{WHITE}{STRING}, fișier readme al {STRING}
@@ -4764,27 +4764,27 @@ STR_MESSAGE_ESTIMATED_INCOME                                    :{WHITE}Venit es
 STR_ERROR_SAVE_STILL_IN_PROGRESS                                :{WHITE}Salvarea se efectueaza încã,{}vã rugãm asteptati pânã se încheie!
 STR_ERROR_AUTOSAVE_FAILED                                       :{WHITE}Auto-salvarea a esuat
 STR_ERROR_UNABLE_TO_READ_DRIVE                                  :{BLACK}Discul nu a putut fi citit
-STR_ERROR_GAME_SAVE_FAILED                                      :{WHITE}Salvarea jocului eşuată{}{STRING}
+STR_ERROR_GAME_SAVE_FAILED                                      :{WHITE}Salvarea jocului eșuată{}{STRING}
 STR_ERROR_UNABLE_TO_DELETE_FILE                                 :{WHITE}Ștergerea fișierului a eșuat
-STR_ERROR_GAME_LOAD_FAILED                                      :{WHITE}Încărcarea jocului eşuată{}{STRING}
+STR_ERROR_GAME_LOAD_FAILED                                      :{WHITE}Încărcarea jocului eșuată{}{STRING}
 STR_GAME_SAVELOAD_ERROR_BROKEN_INTERNAL_ERROR                   :Eroare internă: {STRING}
 STR_GAME_SAVELOAD_ERROR_BROKEN_SAVEGAME                         :Salvare eronată - {STRING}
 STR_GAME_SAVELOAD_ERROR_TOO_NEW_SAVEGAME                        :Salvarea a fost făcută cu o versiune mai nouă
-STR_GAME_SAVELOAD_ERROR_FILE_NOT_READABLE                       :Fişierul nu poate fi citit
-STR_GAME_SAVELOAD_ERROR_FILE_NOT_WRITEABLE                      :Fişierul nu poate fi scris
+STR_GAME_SAVELOAD_ERROR_FILE_NOT_READABLE                       :Fișierul nu poate fi citit
+STR_GAME_SAVELOAD_ERROR_FILE_NOT_WRITEABLE                      :Fișierul nu poate fi scris
 STR_GAME_SAVELOAD_ERROR_DATA_INTEGRITY_CHECK_FAILED             :Integritatea datelor compromisă
 STR_GAME_SAVELOAD_ERROR_PATCHPACK                               :Salvarea este realizată cu o versiune modificată
 STR_GAME_SAVELOAD_NOT_AVAILABLE                                 :<indisponibil>
 STR_WARNING_LOADGAME_REMOVED_TRAMS                              :{WHITE}Jocul a fost salvat într-o versiune fără suport pentru tramvaie. Toate tramvaiele au fost eliminate
 
 # Map generation messages
-STR_ERROR_COULD_NOT_CREATE_TOWN                                 :{WHITE}Generarea hărţii a eşuat...{}... nici o locaţie potrivită pentru oraş
-STR_ERROR_NO_TOWN_IN_SCENARIO                                   :{WHITE}... în acest scenariu nu există nici un oraş
+STR_ERROR_COULD_NOT_CREATE_TOWN                                 :{WHITE}Generarea hărții a eșuat...{}... nici o locație potrivită pentru oraș
+STR_ERROR_NO_TOWN_IN_SCENARIO                                   :{WHITE}... în acest scenariu nu există nici un oraș
 
 STR_ERROR_PNGMAP                                                :{WHITE}Nu pot încărca peisajul din PNG...
-STR_ERROR_PNGMAP_FILE_NOT_FOUND                                 :{WHITE}... fişierul lipseşte
-STR_ERROR_PNGMAP_IMAGE_TYPE                                     :{WHITE}... nu am reuşit conversia tipului de imagine. Este necesară o imagine PNG pe 8 sau 24 de biţi
-STR_ERROR_PNGMAP_MISC                                           :{WHITE}... ceva nu a funcţionat cum trebuie (probabil fişierul este defect)
+STR_ERROR_PNGMAP_FILE_NOT_FOUND                                 :{WHITE}... fișierul lipsește
+STR_ERROR_PNGMAP_IMAGE_TYPE                                     :{WHITE}... nu am reușit conversia tipului de imagine. Este necesară o imagine PNG pe 8 sau 24 de biți
+STR_ERROR_PNGMAP_MISC                                           :{WHITE}... ceva nu a funcționat cum trebuie (probabil fișierul este defect)
 
 STR_ERROR_BMPMAP                                                :{WHITE}Nu pot încărca peisajul din BMP...
 STR_ERROR_BMPMAP_IMAGE_TYPE                                     :{WHITE}... nu am putut converti tipul de imagine
@@ -4795,14 +4795,14 @@ STR_WARNING_HEIGHTMAP_SCALE_CAPTION                             :{WHITE}Avertism
 STR_WARNING_HEIGHTMAP_SCALE_MESSAGE                             :{YELLOW}Redimensionarea excesiva a hartii nu este recomandata. Continui cu generarea?
 
 # Soundset messages
-STR_WARNING_FALLBACK_SOUNDSET                                   :{WHITE}Doar un set nul de efecte sonore a fost găsit. Dacă doreşti sunete, instalează un set de sunete folosind sistemul de Resurse Online
+STR_WARNING_FALLBACK_SOUNDSET                                   :{WHITE}Doar un set nul de efecte sonore a fost găsit. Dacă dorești sunete, instalează un set de sunete folosind sistemul de Resurse Online
 
 # Screenshot related messages
 STR_WARNING_SCREENSHOT_SIZE_CAPTION                             :{WHITE}Imagine de dimensiune foarte mare
 STR_WARNING_SCREENSHOT_SIZE_MESSAGE                             :{YELLOW}Imaginea capturată va avea o dimensiune de {COMMA} x {COMMA} pixeli. Realizarea unei capturi va dura ceva timp. Dorești să continui?
 
 STR_MESSAGE_HEIGHTMAP_SUCCESSFULLY                              :{WHITE}Harta înălțimilor s-a salvat cu succes ca '{STRING}'. Cel mai înalt vârf este {NUM}
-STR_MESSAGE_SCREENSHOT_SUCCESSFULLY                             :{WHITE}Imagine salvată cu succes pe disc în fişierul '{STRING}'
+STR_MESSAGE_SCREENSHOT_SUCCESSFULLY                             :{WHITE}Imagine salvată cu succes pe disc în fișierul '{STRING}'
 STR_ERROR_SCREENSHOT_FAILED                                     :{WHITE}Imaginea nu a putut fi capturată!
 
 # Error message titles
@@ -4810,15 +4810,15 @@ STR_ERROR_MESSAGE_CAPTION                                       :{YELLOW}Mesaj
 STR_ERROR_MESSAGE_CAPTION_OTHER_COMPANY                         :{YELLOW}Mesaj de la {STRING}
 
 # Generic construction errors
-STR_ERROR_OFF_EDGE_OF_MAP                                       :{WHITE}Depăşeşte limita hărţii
-STR_ERROR_TOO_CLOSE_TO_EDGE_OF_MAP                              :{WHITE}Prea aproape de marginea hărţii
-STR_ERROR_NOT_ENOUGH_CASH_REQUIRES_CURRENCY                     :{WHITE}Nu ai destui bani - îţi trebuie {CURRENCY_LONG}
+STR_ERROR_OFF_EDGE_OF_MAP                                       :{WHITE}Depășește limita hărții
+STR_ERROR_TOO_CLOSE_TO_EDGE_OF_MAP                              :{WHITE}Prea aproape de marginea hărții
+STR_ERROR_NOT_ENOUGH_CASH_REQUIRES_CURRENCY                     :{WHITE}Nu ai destui bani - îți trebuie {CURRENCY_LONG}
 STR_ERROR_FLAT_LAND_REQUIRED                                    :{WHITE}Necesită teren plat
-STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION                        :{WHITE}Terenul are o înclinaţie nepotrivită
+STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION                        :{WHITE}Terenul are o înclinație nepotrivită
 STR_ERROR_CAN_T_DO_THIS                                         :{WHITE}Nu se poate face asta...
 STR_ERROR_BUILDING_MUST_BE_DEMOLISHED                           :{WHITE}Mai întâi trebuie demolată clădirea
-STR_ERROR_CAN_T_CLEAR_THIS_AREA                                 :{WHITE}Nu se poate curăţa terenul...
-STR_ERROR_SITE_UNSUITABLE                                       :{WHITE}... locaţie nepotrivită
+STR_ERROR_CAN_T_CLEAR_THIS_AREA                                 :{WHITE}Nu se poate curăța terenul...
+STR_ERROR_SITE_UNSUITABLE                                       :{WHITE}... locație nepotrivită
 STR_ERROR_ALREADY_BUILT                                         :{WHITE}... deja construit
 STR_ERROR_OWNED_BY                                              :{WHITE}... apartine companiei {STRING}
 STR_ERROR_AREA_IS_OWNED_BY_ANOTHER                              :{WHITE}... terenul se află în proprietatea altei companii
@@ -4836,7 +4836,7 @@ STR_ERROR_LOCAL_AUTHORITY_REFUSES_NOISE                         :{WHITE}Autorita
 STR_ERROR_BRIBE_FAILED                                          :{WHITE}Tentativa de mituire a fost descoperită de un investigator regional
 
 # Levelling errors
-STR_ERROR_CAN_T_RAISE_LAND_HERE                                 :{WHITE}Nu se poate înălţa terenul...
+STR_ERROR_CAN_T_RAISE_LAND_HERE                                 :{WHITE}Nu se poate înălța terenul...
 STR_ERROR_CAN_T_LOWER_LAND_HERE                                 :{WHITE}Nu se poate coborî terenul...
 STR_ERROR_CAN_T_LEVEL_LAND_HERE                                 :{WHITE}Terenul nu poate fi uniformizat aici...
 STR_ERROR_EXCAVATION_WOULD_DAMAGE                               :{WHITE}Săpăturile ar afecta tunelul
@@ -4847,26 +4847,26 @@ STR_ERROR_BRIDGE_TOO_HIGH_AFTER_LOWER_LAND                      :{WHITE}După ac
 
 # Company related errors
 STR_ERROR_CAN_T_CHANGE_COMPANY_NAME                             :{WHITE}Nu se poate schimba numele companiei...
-STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Nu se poate schimba numele preşedintelui...
+STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Nu se poate schimba numele președintelui...
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... creditul maxim permis este de {CURRENCY_LONG}
-STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Nu mai poţi împrumuta bani...
+STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Nu mai poți împrumuta bani...
 STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... nu ai nici un credit de plătit
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... ai nevoie de {CURRENCY_LONG}
-STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Nu poţi plăti creditul...
-STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Nu poţi dona din banii împrumutaţi de la bancă...
+STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Nu poți plăti creditul...
+STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Nu poți dona din banii împrumutați de la bancă...
 STR_ERROR_CAN_T_GIVE_MONEY                                      :{WHITE}Nu se pot da bani acestei companii...
 STR_ERROR_CAN_T_BUY_COMPANY                                     :{WHITE}Nu se poate cumpăra compania...
 STR_ERROR_CAN_T_BUILD_COMPANY_HEADQUARTERS                      :{WHITE}Nu se poate construi sediul companiei...
 
 # Town related errors
 STR_ERROR_CAN_T_GENERATE_TOWN                                   :{WHITE}Nu pot construi nici un oras
-STR_ERROR_CAN_T_RENAME_TOWN                                     :{WHITE}Nu se poate redenumi oraşul...
-STR_ERROR_CAN_T_FOUND_TOWN_HERE                                 :{WHITE}Nu se poate construi un oraş aici...
-STR_ERROR_CAN_T_EXPAND_TOWN                                     :{WHITE}Oraşul nu poate fi extins...
-STR_ERROR_TOO_CLOSE_TO_EDGE_OF_MAP_SUB                          :{WHITE}... prea aproape de marginea hărţii
-STR_ERROR_TOO_CLOSE_TO_ANOTHER_TOWN                             :{WHITE}... prea aproape de alt oraş
-STR_ERROR_TOO_MANY_TOWNS                                        :{WHITE}... prea multe oraşe
+STR_ERROR_CAN_T_RENAME_TOWN                                     :{WHITE}Nu se poate redenumi orașul...
+STR_ERROR_CAN_T_FOUND_TOWN_HERE                                 :{WHITE}Nu se poate construi un oraș aici...
+STR_ERROR_CAN_T_EXPAND_TOWN                                     :{WHITE}Orașul nu poate fi extins...
+STR_ERROR_TOO_CLOSE_TO_EDGE_OF_MAP_SUB                          :{WHITE}... prea aproape de marginea hărții
+STR_ERROR_TOO_CLOSE_TO_ANOTHER_TOWN                             :{WHITE}... prea aproape de alt oraș
+STR_ERROR_TOO_MANY_TOWNS                                        :{WHITE}... prea multe orașe
 STR_ERROR_NO_SPACE_FOR_TOWN                                     :{WHITE}... nu mai este loc pe hartă
 STR_ERROR_ROAD_WORKS_IN_PROGRESS                                :{WHITE}Lucrari la drum in curs de desfasurare
 STR_ERROR_TOWN_CAN_T_DELETE                                     :{WHITE}Acest oraș nu poate fi șters...{}O stație sau un depou face referire la acest oraș, sau o parcelă deținută de oraș nu poate fi eliminată
@@ -4879,15 +4879,15 @@ STR_ERROR_CAN_T_BUILD_HERE                                      :{WHITE}Nu se po
 STR_ERROR_CAN_T_CONSTRUCT_THIS_INDUSTRY                         :{WHITE}Acest tip de industrie nu se poate construi aici...
 STR_ERROR_CAN_T_PROSPECT_INDUSTRY                               :{WHITE}Nu pot prospecta industria...
 STR_ERROR_INDUSTRY_TOO_CLOSE                                    :{WHITE}... prea aproape de altă industrie
-STR_ERROR_MUST_FOUND_TOWN_FIRST                                 :{WHITE}... mai întâi trebuie creat un oraş
-STR_ERROR_ONLY_ONE_ALLOWED_PER_TOWN                             :{WHITE}... un singur obiectiv de acest tip este permis per oraş
-STR_ERROR_CAN_ONLY_BE_BUILT_IN_TOWNS_WITH_POPULATION_OF_1200    :{WHITE}... se poate construi doar în oraşe cu populaţia de cel puţin 1200
+STR_ERROR_MUST_FOUND_TOWN_FIRST                                 :{WHITE}... mai întâi trebuie creat un oraș
+STR_ERROR_ONLY_ONE_ALLOWED_PER_TOWN                             :{WHITE}... un singur obiectiv de acest tip este permis per oraș
+STR_ERROR_CAN_ONLY_BE_BUILT_IN_TOWNS_WITH_POPULATION_OF_1200    :{WHITE}... se poate construi doar în orașe cu populația de cel puțin 1200
 STR_ERROR_CAN_ONLY_BE_BUILT_IN_RAINFOREST                       :{WHITE}... se poate construi doar in padurile tropicale
-STR_ERROR_CAN_ONLY_BE_BUILT_IN_DESERT                           :{WHITE}... se poate construi doar în zonele de deşert
-STR_ERROR_CAN_ONLY_BE_BUILT_IN_TOWNS                            :{WHITE}... se poate construi doar în oraşe (înlocuind casele)
+STR_ERROR_CAN_ONLY_BE_BUILT_IN_DESERT                           :{WHITE}... se poate construi doar în zonele de deșert
+STR_ERROR_CAN_ONLY_BE_BUILT_IN_TOWNS                            :{WHITE}... se poate construi doar în orașe (înlocuind casele)
 STR_ERROR_CAN_ONLY_BE_BUILT_NEAR_TOWN_CENTER                    :{WHITE}... se poate construi doar lângă centrul orașului
 STR_ERROR_CAN_ONLY_BE_BUILT_IN_LOW_AREAS                        :{WHITE}... poate fi construit(ă) doar în zone joase
-STR_ERROR_CAN_ONLY_BE_POSITIONED                                :{WHITE}... se poate construi doar la marginea hărţii
+STR_ERROR_CAN_ONLY_BE_POSITIONED                                :{WHITE}... se poate construi doar la marginea hărții
 STR_ERROR_FOREST_CAN_ONLY_BE_PLANTED                            :{WHITE}... pădurile pot fi plantate doar în zonele înzăpezite
 STR_ERROR_CAN_ONLY_BE_BUILT_ABOVE_SNOW_LINE                     :{WHITE}... poate fi construit doar deasupra liniei zăpezii
 STR_ERROR_CAN_ONLY_BE_BUILT_BELOW_SNOW_LINE                     :{WHITE}... poate fi construit doar sub linia zăpezii
@@ -4899,54 +4899,54 @@ STR_ERROR_NO_SUITABLE_PLACES_FOR_INDUSTRIES_EXPLANATION         :{WHITE}Modific�
 
 # Station construction related errors
 STR_ERROR_CAN_T_BUILD_RAILROAD_STATION                          :{WHITE}Nu se poate construi o gară aici...
-STR_ERROR_CAN_T_BUILD_BUS_STATION                               :{WHITE}Nu se poate construi staţie de autobuz...
+STR_ERROR_CAN_T_BUILD_BUS_STATION                               :{WHITE}Nu se poate construi stație de autobuz...
 STR_ERROR_CAN_T_BUILD_TRUCK_STATION                             :{WHITE}Nu se poate construi platformă pentru camioane...
-STR_ERROR_CAN_T_BUILD_PASSENGER_TRAM_STATION                    :{WHITE}Nu pot construi staţie de tramvai aici...
-STR_ERROR_CAN_T_BUILD_CARGO_TRAM_STATION                        :{WHITE}Nu pot construi staţie de tramvai aici...
+STR_ERROR_CAN_T_BUILD_PASSENGER_TRAM_STATION                    :{WHITE}Nu pot construi stație de tramvai aici...
+STR_ERROR_CAN_T_BUILD_CARGO_TRAM_STATION                        :{WHITE}Nu pot construi stație de tramvai aici...
 STR_ERROR_CAN_T_BUILD_DOCK_HERE                                 :{WHITE}Nu pot construi port aici...
 STR_ERROR_CAN_T_BUILD_AIRPORT_HERE                              :{WHITE}Nu se poate construi un aeroport aici...
 
-STR_ERROR_ADJOINS_MORE_THAN_ONE_EXISTING                        :{WHITE}Este adiacentă mai multor staţii
-STR_ERROR_STATION_TOO_SPREAD_OUT                                :{WHITE}... staţie prea întinsă
-STR_ERROR_TOO_MANY_STATIONS_LOADING                             :{WHITE}Prea multe staţii
-STR_ERROR_TOO_MANY_STATION_SPECS                                :{WHITE}Staţia are prea multe componente
-STR_ERROR_TOO_MANY_BUS_STOPS                                    :{WHITE}Prea multe staţii de autobuz
-STR_ERROR_TOO_MANY_TRUCK_STOPS                                  :{WHITE}Prea multe staţii de camion
+STR_ERROR_ADJOINS_MORE_THAN_ONE_EXISTING                        :{WHITE}Este adiacentă mai multor stații
+STR_ERROR_STATION_TOO_SPREAD_OUT                                :{WHITE}... stație prea întinsă
+STR_ERROR_TOO_MANY_STATIONS_LOADING                             :{WHITE}Prea multe stații
+STR_ERROR_TOO_MANY_STATION_SPECS                                :{WHITE}Stația are prea multe componente
+STR_ERROR_TOO_MANY_BUS_STOPS                                    :{WHITE}Prea multe stații de autobuz
+STR_ERROR_TOO_MANY_TRUCK_STOPS                                  :{WHITE}Prea multe stații de camion
 STR_ERROR_TOO_CLOSE_TO_ANOTHER_DOCK                             :{WHITE}Prea aproape de alt port
 STR_ERROR_TOO_CLOSE_TO_ANOTHER_AIRPORT                          :{WHITE}Prea aproape de un alt aeroport
-STR_ERROR_CAN_T_RENAME_STATION                                  :{WHITE}Nu se poate redenumi staţia...
+STR_ERROR_CAN_T_RENAME_STATION                                  :{WHITE}Nu se poate redenumi stația...
 STR_ERROR_DRIVE_THROUGH_ON_TOWN_ROAD                            :{WHITE}... drum deținut de un oraș
-STR_ERROR_DRIVE_THROUGH_DIRECTION                               :{WHITE}... drum orientat în direcţia greşită
-STR_ERROR_DRIVE_THROUGH_CORNER                                  :{WHITE}... haltele nu pot avea colţuri
-STR_ERROR_DRIVE_THROUGH_JUNCTION                                :{WHITE}... haltele nu pot avea intersecţii
+STR_ERROR_DRIVE_THROUGH_DIRECTION                               :{WHITE}... drum orientat în direcția greșită
+STR_ERROR_DRIVE_THROUGH_CORNER                                  :{WHITE}... haltele nu pot avea colțuri
+STR_ERROR_DRIVE_THROUGH_JUNCTION                                :{WHITE}... haltele nu pot avea intersecții
 
 # Station destruction related errors
-STR_ERROR_CAN_T_REMOVE_PART_OF_STATION                          :{WHITE}Nu se poate demola doar o parte din staţie...
-STR_ERROR_MUST_REMOVE_RAILWAY_STATION_FIRST                     :{WHITE}Trebuie mai întâi să demolaţi gara
-STR_ERROR_CAN_T_REMOVE_BUS_STATION                              :{WHITE}Staţia de autobuz nu poate fi demolată...
-STR_ERROR_CAN_T_REMOVE_TRUCK_STATION                            :{WHITE}Staţia de camioane nu poate fi ştearsă...
-STR_ERROR_CAN_T_REMOVE_PASSENGER_TRAM_STATION                   :{WHITE}Nu pot înlătura staţia de tramvai...
-STR_ERROR_CAN_T_REMOVE_CARGO_TRAM_STATION                       :{WHITE}Nu pot înlătura staţia de tramvai...
-STR_ERROR_MUST_REMOVE_ROAD_STOP_FIRST                           :{WHITE}Trebuie îndepărtată staţia mai întâi
-STR_ERROR_THERE_IS_NO_STATION                                   :{WHITE}...nu există staţie aici
+STR_ERROR_CAN_T_REMOVE_PART_OF_STATION                          :{WHITE}Nu se poate demola doar o parte din stație...
+STR_ERROR_MUST_REMOVE_RAILWAY_STATION_FIRST                     :{WHITE}Trebuie mai întâi să demolați gara
+STR_ERROR_CAN_T_REMOVE_BUS_STATION                              :{WHITE}Stația de autobuz nu poate fi demolată...
+STR_ERROR_CAN_T_REMOVE_TRUCK_STATION                            :{WHITE}Stația de camioane nu poate fi ștearsă...
+STR_ERROR_CAN_T_REMOVE_PASSENGER_TRAM_STATION                   :{WHITE}Nu pot înlătura stația de tramvai...
+STR_ERROR_CAN_T_REMOVE_CARGO_TRAM_STATION                       :{WHITE}Nu pot înlătura stația de tramvai...
+STR_ERROR_MUST_REMOVE_ROAD_STOP_FIRST                           :{WHITE}Trebuie îndepărtată stația mai întâi
+STR_ERROR_THERE_IS_NO_STATION                                   :{WHITE}...nu există stație aici
 
 STR_ERROR_MUST_DEMOLISH_RAILROAD                                :{WHITE}Mai întâi trebuie demolată gara
-STR_ERROR_MUST_DEMOLISH_BUS_STATION_FIRST                       :{WHITE}Mai întâi trebuie demolată staţia de autobuz
+STR_ERROR_MUST_DEMOLISH_BUS_STATION_FIRST                       :{WHITE}Mai întâi trebuie demolată stația de autobuz
 STR_ERROR_MUST_DEMOLISH_TRUCK_STATION_FIRST                     :{WHITE}Mai întâi trebuie demolată platforma pentru camioane
-STR_ERROR_MUST_DEMOLISH_PASSENGER_TRAM_STATION_FIRST            :{WHITE}Mai întâi trebuie demolată staţia de tramvai
-STR_ERROR_MUST_DEMOLISH_CARGO_TRAM_STATION_FIRST                :{WHITE}Mai întâi trebuie demolată staţia de tramvai
+STR_ERROR_MUST_DEMOLISH_PASSENGER_TRAM_STATION_FIRST            :{WHITE}Mai întâi trebuie demolată stația de tramvai
+STR_ERROR_MUST_DEMOLISH_CARGO_TRAM_STATION_FIRST                :{WHITE}Mai întâi trebuie demolată stația de tramvai
 STR_ERROR_MUST_DEMOLISH_DOCK_FIRST                              :{WHITE}Mai întâi trebuie demolat portul
 STR_ERROR_MUST_DEMOLISH_AIRPORT_FIRST                           :{WHITE}Mai întâi trebuie demolat aeroportul
 
 # Waypoint related errors
-STR_ERROR_WAYPOINT_ADJOINS_MORE_THAN_ONE_EXISTING               :{WHITE}Uneşte mai multe puncte de tranzit
+STR_ERROR_WAYPOINT_ADJOINS_MORE_THAN_ONE_EXISTING               :{WHITE}Unește mai multe puncte de tranzit
 STR_ERROR_TOO_CLOSE_TO_ANOTHER_WAYPOINT                         :{WHITE}Prea aproape de alt punct de tranzit
 
 STR_ERROR_CAN_T_BUILD_TRAIN_WAYPOINT                            :{WHITE}Nu se poate plasa o haltă aici...
 STR_ERROR_CAN_T_POSITION_BUOY_HERE                              :{WHITE}Nu se poate amplasa baliză aici...
 STR_ERROR_CAN_T_CHANGE_WAYPOINT_NAME                            :{WHITE}Nu pot schimba numele haltei...
 
-STR_ERROR_CAN_T_REMOVE_TRAIN_WAYPOINT                           :{WHITE}Nu se poate desfiinţa halta de aici...
+STR_ERROR_CAN_T_REMOVE_TRAIN_WAYPOINT                           :{WHITE}Nu se poate desființa halta de aici...
 STR_ERROR_MUST_REMOVE_RAILWAYPOINT_FIRST                        :{WHITE}Trebuie îndepărtat punctul de tranzit feroviar mai intai
 STR_ERROR_BUOY_IN_THE_WAY                                       :{WHITE}... baliză în cale
 STR_ERROR_BUOY_IS_IN_USE                                        :{WHITE}... baliza este folosită de o altă companie!
@@ -4955,18 +4955,18 @@ STR_ERROR_BUOY_IS_IN_USE                                        :{WHITE}... bali
 STR_ERROR_CAN_T_BUILD_TRAIN_DEPOT                               :{WHITE}Nu se poate construi depou feroviar aici...
 STR_ERROR_CAN_T_BUILD_ROAD_DEPOT                                :{WHITE}Nu se poate construi autobază aici...
 STR_ERROR_CAN_T_BUILD_TRAM_DEPOT                                :{WHITE}Nu pot construi depou de tramvaie aici...
-STR_ERROR_CAN_T_BUILD_SHIP_DEPOT                                :{WHITE}Nu se poate construi şantier naval aici...
+STR_ERROR_CAN_T_BUILD_SHIP_DEPOT                                :{WHITE}Nu se poate construi șantier naval aici...
 
 STR_ERROR_CAN_T_RENAME_DEPOT                                    :{WHITE}Nu se poate redenumi depoul...
 
 STR_ERROR_TRAIN_MUST_BE_STOPPED_INSIDE_DEPOT                    :{WHITE}... trebuie oprit într-un depou
 STR_ERROR_ROAD_VEHICLE_MUST_BE_STOPPED_INSIDE_DEPOT             :{WHITE}... trebuie oprit într-o autobază
-STR_ERROR_SHIP_MUST_BE_STOPPED_INSIDE_DEPOT                     :{WHITE}... trebuie oprită într-un şantier naval
+STR_ERROR_SHIP_MUST_BE_STOPPED_INSIDE_DEPOT                     :{WHITE}... trebuie oprită într-un șantier naval
 STR_ERROR_AIRCRAFT_MUST_BE_STOPPED_INSIDE_HANGAR                :{WHITE}... trebuie oprită intr-un hangar
 
-STR_ERROR_TRAINS_CAN_ONLY_BE_ALTERED_INSIDE_A_DEPOT             :{WHITE}Trenurile pot fi modificate doar când staţionează într-un depou
+STR_ERROR_TRAINS_CAN_ONLY_BE_ALTERED_INSIDE_A_DEPOT             :{WHITE}Trenurile pot fi modificate doar când staționează într-un depou
 STR_ERROR_TRAIN_TOO_LONG                                        :{WHITE}Tren prea lung
-STR_ERROR_CAN_T_REVERSE_DIRECTION_RAIL_VEHICLE                  :{WHITE}Nu se poate inversa direcţia vehiculului...
+STR_ERROR_CAN_T_REVERSE_DIRECTION_RAIL_VEHICLE                  :{WHITE}Nu se poate inversa direcția vehiculului...
 STR_ERROR_CAN_T_REVERSE_DIRECTION_RAIL_VEHICLE_MULTIPLE_UNITS   :{WHITE}... este alcătuit din mai multe unități
 STR_ERROR_INCOMPATIBLE_RAIL_TYPES                               :Tipurile de șine sunt incompatibile
 
@@ -4979,13 +4979,13 @@ STR_ERROR_DEPOT_WRONG_DEPOT_TYPE                                :Tip incorect de
 
 # Autoreplace related errors
 STR_ERROR_TRAIN_TOO_LONG_AFTER_REPLACEMENT                      :{WHITE}{VEHICLE} este prea lung după înlocuire
-STR_ERROR_AUTOREPLACE_NOTHING_TO_DO                             :{WHITE}Nicio regulă autoînlocuire/reînnoire aplicată
+STR_ERROR_AUTOREPLACE_NOTHING_TO_DO                             :{WHITE}Nicio regulă autoînlocuire/înnoire aplicată
 STR_ERROR_AUTOREPLACE_MONEY_LIMIT                               :(fonduri limitate)
 STR_ERROR_AUTOREPLACE_INCOMPATIBLE_CARGO                        :{WHITE}Noul vehicul nu poate transporta {STRING}
 STR_ERROR_AUTOREPLACE_INCOMPATIBLE_REFIT                        :{WHITE}Noul vehicul nu poate fi reparat în comanda {NUM}
 
 # Rail construction errors
-STR_ERROR_IMPOSSIBLE_TRACK_COMBINATION                          :{WHITE}Combinaţie de linii imposibilă
+STR_ERROR_IMPOSSIBLE_TRACK_COMBINATION                          :{WHITE}Combinație de linii imposibilă
 STR_ERROR_MUST_REMOVE_SIGNALS_FIRST                             :{WHITE}Trebuie îndepărtate semafoarele mai întâi
 STR_ERROR_NO_SUITABLE_RAILROAD_TRACK                            :{WHITE}Cale ferată nepotrivită
 STR_ERROR_MUST_REMOVE_RAILROAD_TRACK                            :{WHITE}Mai întâi trebuie înlăturată calea ferată
@@ -5000,17 +5000,17 @@ STR_ERROR_SIGNAL_CAN_T_CONVERT_SIGNALS_HERE                     :{WHITE}Nu se po
 STR_ERROR_THERE_IS_NO_RAILROAD_TRACK                            :{WHITE}...nu există cale ferată aici
 STR_ERROR_THERE_ARE_NO_SIGNALS                                  :{WHITE}...nu există semafoare
 
-STR_ERROR_CAN_T_CONVERT_RAIL                                    :{WHITE}Tipul de şină nu poate fi convertit aici...
+STR_ERROR_CAN_T_CONVERT_RAIL                                    :{WHITE}Tipul de șină nu poate fi convertit aici...
 
 # Road construction errors
-STR_ERROR_MUST_REMOVE_ROAD_FIRST                                :{WHITE}Mai întâi trebuie înlăturată şoseaua
+STR_ERROR_MUST_REMOVE_ROAD_FIRST                                :{WHITE}Mai întâi trebuie înlăturată șoseaua
 STR_ERROR_ONEWAY_ROADS_CAN_T_HAVE_JUNCTION                      :{WHITE}... drumurile cu sens unic nu pot avea bifurcatii
-STR_ERROR_CAN_T_BUILD_ROAD_HERE                                 :{WHITE}Nu se poate construi şosea aici...
-STR_ERROR_CAN_T_BUILD_TRAMWAY_HERE                              :{WHITE}Nu pot construi şină de tramvai aici...
-STR_ERROR_CAN_T_REMOVE_ROAD_FROM                                :{WHITE}Nu se poate înlătura şoseaua...
-STR_ERROR_CAN_T_REMOVE_TRAMWAY_FROM                             :{WHITE}Nu pot înlătura şina de tramvai de aici...
+STR_ERROR_CAN_T_BUILD_ROAD_HERE                                 :{WHITE}Nu se poate construi șosea aici...
+STR_ERROR_CAN_T_BUILD_TRAMWAY_HERE                              :{WHITE}Nu pot construi șină de tramvai aici...
+STR_ERROR_CAN_T_REMOVE_ROAD_FROM                                :{WHITE}Nu se poate înlătura șoseaua...
+STR_ERROR_CAN_T_REMOVE_TRAMWAY_FROM                             :{WHITE}Nu pot înlătura șina de tramvai de aici...
 STR_ERROR_THERE_IS_NO_ROAD                                      :{WHITE}...nu există drum aici
-STR_ERROR_THERE_IS_NO_TRAMWAY                                   :{WHITE}...nu există şină de tramvai aici
+STR_ERROR_THERE_IS_NO_TRAMWAY                                   :{WHITE}...nu există șină de tramvai aici
 STR_ERROR_CAN_T_CONVERT_ROAD                                    :{WHITE}Tipul de drum nu poate fi convertit aici...
 STR_ERROR_CAN_T_CONVERT_TRAMWAY                                 :{WHITE}Nu pot converti tipul de tramvai aici...
 STR_ERROR_NO_SUITABLE_ROAD                                      :{WHITE}Niciun drum adecvat
@@ -5029,14 +5029,14 @@ STR_ERROR_MUST_DEMOLISH_CANAL_FIRST                             :{WHITE}Trebuie 
 STR_ERROR_CAN_T_BUILD_AQUEDUCT_HERE                             :{WHITE}Nu pot construi apeductul aici...
 
 # Tree related errors
-STR_ERROR_TREE_ALREADY_HERE                                     :{WHITE}... sunt deja plantaţi arbori
+STR_ERROR_TREE_ALREADY_HERE                                     :{WHITE}... sunt deja plantați arbori
 STR_ERROR_TREE_WRONG_TERRAIN_FOR_TREE_TYPE                      :{WHITE}... terenul nu este propice acestui tip de copac
 STR_ERROR_CAN_T_PLANT_TREE_HERE                                 :{WHITE}Nu se pot planta arbori aici...
 
 # Bridge related errors
 STR_ERROR_CAN_T_BUILD_BRIDGE_HERE                               :{WHITE}Nu se poate construi pod aici...
 STR_ERROR_MUST_DEMOLISH_BRIDGE_FIRST                            :{WHITE}Mai întâi trebuie demolat podul
-STR_ERROR_CAN_T_START_AND_END_ON                                :{WHITE}Cele două capete nu se pot situa în acelaşi loc
+STR_ERROR_CAN_T_START_AND_END_ON                                :{WHITE}Cele două capete nu se pot situa în același loc
 STR_ERROR_BRIDGEHEADS_NOT_SAME_HEIGHT                           :{WHITE}Capetele podului nu sunt la acelasi nivel
 STR_ERROR_BRIDGE_TOO_LOW_FOR_TERRAIN                            :{WHITE}Podul este prea jos pentru terenul corespunzator
 STR_ERROR_BRIDGE_TOO_HIGH_FOR_TERRAIN                           :{WHITE}Podul este prea înalt pentru acest teren.
@@ -5050,7 +5050,7 @@ STR_ERROR_CAN_T_BUILD_TUNNEL_HERE                               :{WHITE}Nu se po
 STR_ERROR_SITE_UNSUITABLE_FOR_TUNNEL                            :{WHITE}Loc nepotrivit pentru intrarea într-un tunel
 STR_ERROR_MUST_DEMOLISH_TUNNEL_FIRST                            :{WHITE}Mai întâi trebuie demolat tunelul
 STR_ERROR_ANOTHER_TUNNEL_IN_THE_WAY                             :{WHITE}Intersectare cu alt tunel
-STR_ERROR_TUNNEL_THROUGH_MAP_BORDER                             :{WHITE}Tunelul ar ieşi din hartă
+STR_ERROR_TUNNEL_THROUGH_MAP_BORDER                             :{WHITE}Tunelul ar ieși din hartă
 STR_ERROR_UNABLE_TO_EXCAVATE_LAND                               :{WHITE}Terenul de la celălalt capăt al tunelului este imposibil de excavat
 STR_ERROR_TUNNEL_TOO_LONG                                       :{WHITE}... tunel prea lung
 
@@ -5059,7 +5059,7 @@ STR_ERROR_TOO_MANY_OBJECTS                                      :{WHITE}... prea
 STR_ERROR_CAN_T_BUILD_OBJECT                                    :{WHITE}Obiectul nu poate fi construit...
 STR_ERROR_OBJECT_IN_THE_WAY                                     :{WHITE}Obiect în cale
 STR_ERROR_COMPANY_HEADQUARTERS_IN                               :{WHITE}... sediu de companie în cale
-STR_ERROR_CAN_T_PURCHASE_THIS_LAND                              :{WHITE}Nu poţi cumpăra teren aici...
+STR_ERROR_CAN_T_PURCHASE_THIS_LAND                              :{WHITE}Nu poți cumpăra teren aici...
 STR_ERROR_YOU_ALREADY_OWN_IT                                    :{WHITE}... este deja în proprietatea ta!
 STR_ERROR_BUILD_OBJECT_LIMIT_REACHED                            :{WHITE}... limita de obiecte construibile a fost atinsă
 
@@ -5108,7 +5108,7 @@ STR_ERROR_CAN_T_STOP_START_AIRCRAFT                             :{WHITE}Nu se po
 ###length VEHICLE_TYPES
 STR_ERROR_CAN_T_SEND_TRAIN_TO_DEPOT                             :{WHITE}Nu se poate trimite trenul la depou...
 STR_ERROR_CAN_T_SEND_ROAD_VEHICLE_TO_DEPOT                      :{WHITE}Nu pot trimite autovehiculul la autobază...
-STR_ERROR_CAN_T_SEND_SHIP_TO_DEPOT                              :{WHITE}Nu pot trimite nava în şantier...
+STR_ERROR_CAN_T_SEND_SHIP_TO_DEPOT                              :{WHITE}Nu pot trimite nava în șantier...
 STR_ERROR_CAN_T_SEND_AIRCRAFT_TO_HANGAR                         :{WHITE}Nu se poate trimite aeronava la hangar...
 
 ###length VEHICLE_TYPES
@@ -5130,14 +5130,14 @@ STR_ERROR_CAN_T_SELL_SHIP                                       :{WHITE}Nu pot v
 STR_ERROR_CAN_T_SELL_AIRCRAFT                                   :{WHITE}Nu se poate vinde aeronava...
 
 STR_ERROR_TOO_MANY_VEHICLES_IN_GAME                             :{WHITE}Prea multe vehicule în joc
-STR_ERROR_CAN_T_CHANGE_SERVICING                                :{WHITE}Nu se poate schimba intervalul de întreţinere...
+STR_ERROR_CAN_T_CHANGE_SERVICING                                :{WHITE}Nu se poate schimba intervalul de întreținere...
 
 STR_ERROR_VEHICLE_IS_DESTROYED                                  :{WHITE}... vehiculul este distrus
 
 STR_ERROR_CAN_T_CLONE_VEHICLE_LIST                              :{WHITE}... nu toate vehiculele sunt identice
 
 STR_ERROR_NO_VEHICLES_AVAILABLE_AT_ALL                          :{WHITE}Niciun vehicul nu va fi disponibil
-STR_ERROR_NO_VEHICLES_AVAILABLE_AT_ALL_EXPLANATION              :{WHITE}Schimbă configuraţia NewGRF
+STR_ERROR_NO_VEHICLES_AVAILABLE_AT_ALL_EXPLANATION              :{WHITE}Schimbă configurația NewGRF
 STR_ERROR_NO_VEHICLES_AVAILABLE_YET                             :{WHITE}Niciun vehicul nu este disponibil încă
 STR_ERROR_NO_VEHICLES_AVAILABLE_YET_EXPLANATION                 :{WHITE}Începe un joc nou după {DATE_SHORT} sau utilizează un NewGRF care oferă vehicule în avans
 
@@ -5159,16 +5159,16 @@ STR_ERROR_CAN_T_MODIFY_THIS_ORDER                               :{WHITE}Nu se po
 STR_ERROR_CAN_T_MOVE_THIS_ORDER                                 :{WHITE}Nu pot muta acest ordin...
 STR_ERROR_CAN_T_SKIP_ORDER                                      :{WHITE}Nu se poate sări peste comanda actuală...
 STR_ERROR_CAN_T_SKIP_TO_ORDER                                   :{WHITE}Nu pot sări la comanda selectată...
-STR_ERROR_CAN_T_COPY_SHARE_ORDER                                :{WHITE}... vehiculul nu poate ajunge la toate staţiile
-STR_ERROR_CAN_T_ADD_ORDER                                       :{WHITE}... vehiculul nu poate ajunge la acea staţie
-STR_ERROR_CAN_T_ADD_ORDER_SHARED                                :{WHITE}... un vehicul care are acest ordin nu poate ajunge la acea staţie
+STR_ERROR_CAN_T_COPY_SHARE_ORDER                                :{WHITE}... vehiculul nu poate ajunge la toate stațiile
+STR_ERROR_CAN_T_ADD_ORDER                                       :{WHITE}... vehiculul nu poate ajunge la acea stație
+STR_ERROR_CAN_T_ADD_ORDER_SHARED                                :{WHITE}... un vehicul care are acest ordin nu poate ajunge la acea stație
 STR_ERROR_CAN_T_COPY_ORDER_VEHICLE_LIST                         :{WHITE}... nu toate vehiculele au aceleași comenzi
 STR_ERROR_CAN_T_SHARE_ORDER_VEHICLE_LIST                        :{WHITE}... nu toate vehiculele împart comenzi
 
 STR_ERROR_CAN_T_SHARE_ORDER_LIST                                :{WHITE}Nu se poate trece la comenzi sincronizate...
 STR_ERROR_CAN_T_STOP_SHARING_ORDER_LIST                         :{WHITE}Nu pot opri sincronizarea listei de comenzi...
 STR_ERROR_CAN_T_COPY_ORDER_LIST                                 :{WHITE}Nu pot copia lista de comenzi...
-STR_ERROR_TOO_FAR_FROM_PREVIOUS_DESTINATION                     :{WHITE}... prea departe de destinaţia precedentă
+STR_ERROR_TOO_FAR_FROM_PREVIOUS_DESTINATION                     :{WHITE}... prea departe de destinația precedentă
 STR_ERROR_AIRCRAFT_NOT_ENOUGH_RANGE                             :{WHITE}... avionul nu are o rază de acțiune suficientă
 
 # Extra messages which go on the third line of errors, explaining why orders failed
@@ -5187,8 +5187,8 @@ STR_ERROR_NO_BUOY                                               :{WHITE}Nu exist
 
 # Timetable related errors
 STR_ERROR_CAN_T_TIMETABLE_VEHICLE                               :{WHITE}Nu pot programa vehiculul...
-STR_ERROR_TIMETABLE_ONLY_WAIT_AT_STATIONS                       :{WHITE}Vehiculele pot aştepta numai în staţii
-STR_ERROR_TIMETABLE_NOT_STOPPING_HERE                           :{WHITE}Acest vehicul nu are oprire în această staţie
+STR_ERROR_TIMETABLE_ONLY_WAIT_AT_STATIONS                       :{WHITE}Vehiculele pot aștepta numai în stații
+STR_ERROR_TIMETABLE_NOT_STOPPING_HERE                           :{WHITE}Acest vehicul nu are oprire în această stație
 STR_ERROR_TIMETABLE_INCOMPLETE                                  :{WHITE}... orarul este incomplet
 STR_ERROR_TIMETABLE_NOT_STARTED                                 :{WHITE}... orarul nu a început încă
 
@@ -5228,18 +5228,18 @@ STR_TOWN_BUILDING_NAME_STATUE_1                                 :Statuie
 STR_TOWN_BUILDING_NAME_FOUNTAIN_1                               :Fântână
 STR_TOWN_BUILDING_NAME_PARK_1                                   :Parc
 STR_TOWN_BUILDING_NAME_OFFICE_BLOCK_2                           :Clădire de birouri
-STR_TOWN_BUILDING_NAME_SHOPS_AND_OFFICES_1                      :Magazine şi birouri
+STR_TOWN_BUILDING_NAME_SHOPS_AND_OFFICES_1                      :Magazine și birouri
 STR_TOWN_BUILDING_NAME_MODERN_OFFICE_BUILDING_1                 :Clădire modernă de birouri
 STR_TOWN_BUILDING_NAME_WAREHOUSE_1                              :Depozit
 STR_TOWN_BUILDING_NAME_OFFICE_BLOCK_3                           :Bloc de birouri
 STR_TOWN_BUILDING_NAME_STADIUM_1                                :Stadion
 STR_TOWN_BUILDING_NAME_OLD_HOUSES_1                             :Case vechi
-STR_TOWN_BUILDING_NAME_COTTAGES_1                               :Căsuţe
+STR_TOWN_BUILDING_NAME_COTTAGES_1                               :Căsuțe
 STR_TOWN_BUILDING_NAME_HOUSES_1                                 :Case
 STR_TOWN_BUILDING_NAME_FLATS_1                                  :Blocuri
 STR_TOWN_BUILDING_NAME_TALL_OFFICE_BLOCK_2                      :Clădire înaltă de birouri
-STR_TOWN_BUILDING_NAME_SHOPS_AND_OFFICES_2                      :Magazine şi birouri
-STR_TOWN_BUILDING_NAME_SHOPS_AND_OFFICES_3                      :Magazine şi birouri
+STR_TOWN_BUILDING_NAME_SHOPS_AND_OFFICES_2                      :Magazine și birouri
+STR_TOWN_BUILDING_NAME_SHOPS_AND_OFFICES_3                      :Magazine și birouri
 STR_TOWN_BUILDING_NAME_THEATER_1                                :Teatru
 STR_TOWN_BUILDING_NAME_STADIUM_2                                :Stadion
 STR_TOWN_BUILDING_NAME_OFFICES_1                                :Birouri
@@ -5249,7 +5249,7 @@ STR_TOWN_BUILDING_NAME_SHOPPING_MALL_1                          :Centru comercia
 STR_TOWN_BUILDING_NAME_IGLOO_1                                  :Iglu
 STR_TOWN_BUILDING_NAME_TEPEES_1                                 :Corturi
 STR_TOWN_BUILDING_NAME_TEAPOT_HOUSE_1                           :Casă-ceainic
-STR_TOWN_BUILDING_NAME_PIGGY_BANK_1                             :Puşculiţă
+STR_TOWN_BUILDING_NAME_PIGGY_BANK_1                             :Pușculiță
 
 ##id 0x4800
 # industry names
@@ -5261,7 +5261,7 @@ STR_INDUSTRY_NAME_OIL_REFINERY                                  :Rafinărie
 STR_INDUSTRY_NAME_OIL_RIG                                       :Platformă petrolieră
 STR_INDUSTRY_NAME_FACTORY                                       :Fabrică de conserve
 STR_INDUSTRY_NAME_PRINTING_WORKS                                :Tipografie
-STR_INDUSTRY_NAME_STEEL_MILL                                    :Oţelărie
+STR_INDUSTRY_NAME_STEEL_MILL                                    :Oțelărie
 STR_INDUSTRY_NAME_FARM                                          :Fermă
 STR_INDUSTRY_NAME_COPPER_ORE_MINE                               :Mină de cupru
 STR_INDUSTRY_NAME_OIL_WELLS                                     :Sonde de petrol
@@ -5273,7 +5273,7 @@ STR_INDUSTRY_NAME_BANK_TROPIC_ARCTIC                            :Bancă
 STR_INDUSTRY_NAME_DIAMOND_MINE                                  :Mină de diamante
 STR_INDUSTRY_NAME_IRON_ORE_MINE                                 :Mină de fier
 STR_INDUSTRY_NAME_FRUIT_PLANTATION                              :Livadă
-STR_INDUSTRY_NAME_RUBBER_PLANTATION                             :Plantaţie de cauciuc
+STR_INDUSTRY_NAME_RUBBER_PLANTATION                             :Plantație de cauciuc
 STR_INDUSTRY_NAME_WATER_SUPPLY                                  :Rezervor
 STR_INDUSTRY_NAME_WATER_TOWER                                   :Turn de apă
 STR_INDUSTRY_NAME_FACTORY_2                                     :Fabrică de conserve
@@ -5287,7 +5287,7 @@ STR_INDUSTRY_NAME_TOY_SHOP                                      :Magazin de juc�
 STR_INDUSTRY_NAME_TOY_FACTORY                                   :Fabrică de jucării
 STR_INDUSTRY_NAME_PLASTIC_FOUNTAINS                             :Fântâni de plastic
 STR_INDUSTRY_NAME_FIZZY_DRINK_FACTORY                           :Fabrică de sucuri
-STR_INDUSTRY_NAME_BUBBLE_GENERATOR                              :Generator de balonaşe
+STR_INDUSTRY_NAME_BUBBLE_GENERATOR                              :Generator de balonașe
 STR_INDUSTRY_NAME_TOFFEE_QUARRY                                 :Carieră de caramel
 STR_INDUSTRY_NAME_SUGAR_MINE                                    :Mină de zahăr
 
@@ -5315,7 +5315,7 @@ STR_SV_STNAME_VALLEY                                            :Valea {STRING}
 STR_SV_STNAME_HEIGHTS                                           :Dealurile {STRING}
 STR_SV_STNAME_WOODS                                             :Pădurea {STRING}
 STR_SV_STNAME_LAKESIDE                                          :Lacul {STRING}
-STR_SV_STNAME_EXCHANGE                                          :Piaţa {STRING}
+STR_SV_STNAME_EXCHANGE                                          :Piața {STRING}
 STR_SV_STNAME_AIRPORT                                           :Aeroportul {STRING}
 STR_SV_STNAME_OILFIELD                                          :Platforma {STRING}
 STR_SV_STNAME_MINES                                             :Minele {STRING}
@@ -5330,7 +5330,7 @@ STR_SV_STNAME_UPPER                                             :{STRING} de Sus
 STR_SV_STNAME_LOWER                                             :{STRING} de Jos
 STR_SV_STNAME_HELIPORT                                          :Heliportul {STRING}
 STR_SV_STNAME_FOREST                                            :Pădurea {STRING}
-STR_SV_STNAME_FALLBACK                                          :{STRING} Staţia #{NUM}
+STR_SV_STNAME_FALLBACK                                          :{STRING} Stația #{NUM}
 
 ############ end of savegame specific region!
 
@@ -5365,7 +5365,7 @@ STR_VEHICLE_NAME_TRAIN_ENGINE_RAIL_SH_40_ELECTRIC               :SH '40' (Electr
 STR_VEHICLE_NAME_TRAIN_ENGINE_RAIL_T_I_M_ELECTRIC               :'T.I.M.' (Electric)
 STR_VEHICLE_NAME_TRAIN_ENGINE_RAIL_ASIASTAR_ELECTRIC            :'AsiaStar' (Electric)
 STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_PASSENGER_CAR                 :Vagon pentru călători
-STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_MAIL_VAN                      :Vagon pentru poştă
+STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_MAIL_VAN                      :Vagon pentru poștă
 STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_COAL_CAR                      :Vagon pentru cărbuni
 STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_OIL_TANKER                    :Cisternă pentru petrol
 STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_LIVESTOCK_VAN                 :Vagon pentru animale
@@ -5373,7 +5373,7 @@ STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_GOODS_VAN                     :Vagon pentru bu
 STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_GRAIN_HOPPER                  :Vagon pentru cereale
 STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_WOOD_TRUCK                    :Vagon pentru lemne
 STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_IRON_ORE_HOPPER               :Vagon pentru minereu de fier
-STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_STEEL_TRUCK                   :Vagon pentru oţel
+STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_STEEL_TRUCK                   :Vagon pentru oțel
 STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_ARMORED_VAN                   :Vagon blindat
 STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_FOOD_VAN                      :Vagon pentru alimente
 STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_PAPER_TRUCK                   :Vagon pentru hârtie
@@ -5384,7 +5384,7 @@ STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_RUBBER_TRUCK                  :Vagon pentru ca
 STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_SUGAR_TRUCK                   :Vagon pentru zahăr
 STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_COTTON_CANDY_HOPPER           :Vagon pentru vată de zahăr
 STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_TOFFEE_HOPPER                 :Vagon pentru caramel
-STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_BUBBLE_VAN                    :Vagon pentru balonaşe
+STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_BUBBLE_VAN                    :Vagon pentru balonașe
 STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_COLA_TANKER                   :Cisternă pentru cola
 STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_CANDY_VAN                     :Vagon pentru bomboane
 STR_VEHICLE_NAME_TRAIN_WAGON_RAIL_TOY_VAN                       :Vagon pentru jucării
@@ -5395,7 +5395,7 @@ STR_VEHICLE_NAME_TRAIN_ENGINE_MONORAIL_X2001_ELECTRIC           :'X2001' (Electr
 STR_VEHICLE_NAME_TRAIN_ENGINE_MONORAIL_MILLENNIUM_Z1_ELECTRIC   :'Millennium Z1' (Electric)
 STR_VEHICLE_NAME_TRAIN_ENGINE_MONORAIL_WIZZOWOW_Z99             :Wizzowow Z99
 STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_PASSENGER_CAR             :Vagon pentru călători
-STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_MAIL_VAN                  :Vagon pentru poştă
+STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_MAIL_VAN                  :Vagon pentru poștă
 STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_COAL_CAR                  :Vagon pentru cărbuni
 STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_OIL_TANKER                :Cisternă pentru petrol
 STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_LIVESTOCK_VAN             :Vagon pentru animale
@@ -5403,7 +5403,7 @@ STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_GOODS_VAN                 :Vagon pentru bu
 STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_GRAIN_HOPPER              :Vagon pentru cereale
 STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_WOOD_TRUCK                :Vagon pentru lemne
 STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_IRON_ORE_HOPPER           :Vagon pentru minereu de fier
-STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_STEEL_TRUCK               :Vagon pentru oţel
+STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_STEEL_TRUCK               :Vagon pentru oțel
 STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_ARMORED_VAN               :Vagon blindat
 STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_FOOD_VAN                  :Vagon pentru alimente
 STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_PAPER_TRUCK               :Vagon pentru hârtie
@@ -5414,7 +5414,7 @@ STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_RUBBER_TRUCK              :Vagon pentru ca
 STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_SUGAR_TRUCK               :Vagon pentru zahăr
 STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_COTTON_CANDY_HOPPER       :Vagon pentru vată de zahăr
 STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_TOFFEE_HOPPER             :Vagon pentru caramel
-STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_BUBBLE_VAN                :Vagon pentru balonaşe
+STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_BUBBLE_VAN                :Vagon pentru balonașe
 STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_COLA_TANKER               :Cisternă pentru cola
 STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_CANDY_VAN                 :Vagon pentru bomboane
 STR_VEHICLE_NAME_TRAIN_WAGON_MONORAIL_TOY_VAN                   :Vagon pentru jucării
@@ -5427,7 +5427,7 @@ STR_VEHICLE_NAME_TRAIN_ENGINE_MAGLEV_LEV3_PEGASUS_ELECTRIC      :Lev3 'Pegasus' 
 STR_VEHICLE_NAME_TRAIN_ENGINE_MAGLEV_LEV4_CHIMAERA_ELECTRIC     :Lev4 'Chimaera' (Electric)
 STR_VEHICLE_NAME_TRAIN_ENGINE_MAGLEV_WIZZOWOW_ROCKETEER         :Wizzowow Rocketeer
 STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_PASSENGER_CAR               :Vagon pentru călători
-STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_MAIL_VAN                    :Vagon pentru poştă
+STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_MAIL_VAN                    :Vagon pentru poștă
 STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_COAL_CAR                    :Vagon pentru cărbuni
 STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_OIL_TANKER                  :Cisternă pentru petrol
 STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_LIVESTOCK_VAN               :Vagon pentru animale
@@ -5435,7 +5435,7 @@ STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_GOODS_VAN                   :Vagon pentru bu
 STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_GRAIN_HOPPER                :Vagon pentru cereale
 STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_WOOD_TRUCK                  :Vagon pentru lemne
 STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_IRON_ORE_HOPPER             :Vagon pentru minereu de fier
-STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_STEEL_TRUCK                 :Vagon pentru oţel
+STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_STEEL_TRUCK                 :Vagon pentru oțel
 STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_ARMORED_VAN                 :Vagon blindat
 STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_FOOD_VAN                    :Vagon pentru alimente
 STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_PAPER_TRUCK                 :Vagon pentru hârtie
@@ -5446,7 +5446,7 @@ STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_RUBBER_TRUCK                :Vagon pentru ca
 STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_SUGAR_TRUCK                 :Vagon pentru zahăr
 STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_COTTON_CANDY_HOPPER         :Vagon pentru vată de zahăr
 STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_TOFFEE_HOPPER               :Vagon pentru caramel
-STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_BUBBLE_VAN                  :Vagon pentru balonaşe
+STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_BUBBLE_VAN                  :Vagon pentru balonașe
 STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_COLA_TANKER                 :Cisternă pentru cola
 STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_CANDY_VAN                   :Vagon pentru bomboane
 STR_VEHICLE_NAME_TRAIN_WAGON_MAGLEV_TOY_VAN                     :Vagon pentru jucării
@@ -5465,12 +5465,12 @@ STR_VEHICLE_NAME_ROAD_VEHICLE_PLODDYPHUT_MKIII_BUS              :Autobuz Ploddyp
 STR_VEHICLE_NAME_ROAD_VEHICLE_BALOGH_COAL_TRUCK                 :Camion pentru cărbuni Balogh
 STR_VEHICLE_NAME_ROAD_VEHICLE_UHL_COAL_TRUCK                    :Camion pentru cărbuni Uhl
 STR_VEHICLE_NAME_ROAD_VEHICLE_DW_COAL_TRUCK                     :Camion pentru cărbuni DW
-STR_VEHICLE_NAME_ROAD_VEHICLE_MPS_MAIL_TRUCK                    :Camion poştal MPS
-STR_VEHICLE_NAME_ROAD_VEHICLE_REYNARD_MAIL_TRUCK                :Camion poştal Reynard
-STR_VEHICLE_NAME_ROAD_VEHICLE_PERRY_MAIL_TRUCK                  :Camion poştal Perry
-STR_VEHICLE_NAME_ROAD_VEHICLE_MIGHTYMOVER_MAIL_TRUCK            :Camion poştal MightyMover
-STR_VEHICLE_NAME_ROAD_VEHICLE_POWERNAUGHT_MAIL_TRUCK            :Camion poştal Powernaught
-STR_VEHICLE_NAME_ROAD_VEHICLE_WIZZOWOW_MAIL_TRUCK               :Camion poştal Wizzowow
+STR_VEHICLE_NAME_ROAD_VEHICLE_MPS_MAIL_TRUCK                    :Camion poștal MPS
+STR_VEHICLE_NAME_ROAD_VEHICLE_REYNARD_MAIL_TRUCK                :Camion poștal Reynard
+STR_VEHICLE_NAME_ROAD_VEHICLE_PERRY_MAIL_TRUCK                  :Camion poștal Perry
+STR_VEHICLE_NAME_ROAD_VEHICLE_MIGHTYMOVER_MAIL_TRUCK            :Camion poștal MightyMover
+STR_VEHICLE_NAME_ROAD_VEHICLE_POWERNAUGHT_MAIL_TRUCK            :Camion poștal Powernaught
+STR_VEHICLE_NAME_ROAD_VEHICLE_WIZZOWOW_MAIL_TRUCK               :Camion poștal Wizzowow
 STR_VEHICLE_NAME_ROAD_VEHICLE_WITCOMBE_OIL_TANKER               :Cisternă pentru petrol Witcombe
 STR_VEHICLE_NAME_ROAD_VEHICLE_FOSTER_OIL_TANKER                 :Cisternă pentru petrol Foster
 STR_VEHICLE_NAME_ROAD_VEHICLE_PERRY_OIL_TANKER                  :Cisternă pentru petrol Perry
@@ -5489,9 +5489,9 @@ STR_VEHICLE_NAME_ROAD_VEHICLE_MORELAND_WOOD_TRUCK               :Camion pentru l
 STR_VEHICLE_NAME_ROAD_VEHICLE_MPS_IRON_ORE_TRUCK                :Camion pentru fier MPS
 STR_VEHICLE_NAME_ROAD_VEHICLE_UHL_IRON_ORE_TRUCK                :Camion pentru fier Uhl
 STR_VEHICLE_NAME_ROAD_VEHICLE_CHIPPY_IRON_ORE_TRUCK             :Camion pentru fier Chippy
-STR_VEHICLE_NAME_ROAD_VEHICLE_BALOGH_STEEL_TRUCK                :Camion pentru oţel Balogh
-STR_VEHICLE_NAME_ROAD_VEHICLE_UHL_STEEL_TRUCK                   :Camion pentru oţel Uhl
-STR_VEHICLE_NAME_ROAD_VEHICLE_KELLING_STEEL_TRUCK               :Camion pentru oţel Kelling
+STR_VEHICLE_NAME_ROAD_VEHICLE_BALOGH_STEEL_TRUCK                :Camion pentru oțel Balogh
+STR_VEHICLE_NAME_ROAD_VEHICLE_UHL_STEEL_TRUCK                   :Camion pentru oțel Uhl
+STR_VEHICLE_NAME_ROAD_VEHICLE_KELLING_STEEL_TRUCK               :Camion pentru oțel Kelling
 STR_VEHICLE_NAME_ROAD_VEHICLE_BALOGH_ARMORED_TRUCK              :Camion blindat Balogh
 STR_VEHICLE_NAME_ROAD_VEHICLE_UHL_ARMORED_TRUCK                 :Camion blindat Uhl
 STR_VEHICLE_NAME_ROAD_VEHICLE_FOSTER_ARMORED_TRUCK              :Camion blindat Foster
@@ -5540,9 +5540,9 @@ STR_VEHICLE_NAME_ROAD_VEHICLE_WIZZOWOW_FIZZY_DRINK_TRUCK        :Camion pentru s
 STR_VEHICLE_NAME_ROAD_VEHICLE_MIGHTYMOVER_PLASTIC_TRUCK         :Camion pentru plastic MightyMover
 STR_VEHICLE_NAME_ROAD_VEHICLE_POWERNAUGHT_PLASTIC_TRUCK         :Camion pentru plastic Powernaught
 STR_VEHICLE_NAME_ROAD_VEHICLE_WIZZOWOW_PLASTIC_TRUCK            :Camion pentru plastic Wizzowow
-STR_VEHICLE_NAME_ROAD_VEHICLE_MIGHTYMOVER_BUBBLE_TRUCK          :Camion pentru balonaşe MightyMover
-STR_VEHICLE_NAME_ROAD_VEHICLE_POWERNAUGHT_BUBBLE_TRUCK          :Camion pentru balonaşe Powernaught
-STR_VEHICLE_NAME_ROAD_VEHICLE_WIZZOWOW_BUBBLE_TRUCK             :Camion pentru balonaşe Wizzowow
+STR_VEHICLE_NAME_ROAD_VEHICLE_MIGHTYMOVER_BUBBLE_TRUCK          :Camion pentru balonașe MightyMover
+STR_VEHICLE_NAME_ROAD_VEHICLE_POWERNAUGHT_BUBBLE_TRUCK          :Camion pentru balonașe Powernaught
+STR_VEHICLE_NAME_ROAD_VEHICLE_WIZZOWOW_BUBBLE_TRUCK             :Camion pentru balonașe Wizzowow
 
 ###length 11
 STR_VEHICLE_NAME_SHIP_MPS_OIL_TANKER                            :Tanc petrolier MPS
@@ -5632,7 +5632,7 @@ STR_FORMAT_DEPOT_NAME_SHIP_SERIAL                               :{TOWN} Depou na
 STR_FORMAT_DEPOT_NAME_AIRCRAFT                                  :{STATION} Hangar
 # _SERIAL version of AIRACRAFT doesn't exist
 
-STR_UNKNOWN_STATION                                             :staţie necunoscută
+STR_UNKNOWN_STATION                                             :stație necunoscută
 STR_DEFAULT_SIGN_NAME                                           :Semn
 STR_COMPANY_SOMEONE                                             :cineva
 


### PR DESCRIPTION
This is specifically for s-cedilla and t-cedilla to their comma variants.
These variants, especially in smaller font sizes, look almost identical but
they are different. Currently the translation uses a mix of the cedilla and
comma variants, where the cedilla ones are often in the older strings.

Replace reinnoi with innoi, as it is the correct form.