### PR TITLE
Fix: Spurious cancellations of HTTP content downloads

### DIFF
--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -609,6 +609,8 @@ void ClientNetworkContentSocketHandler::OnReceiveData(const char *data, size_t l
 	/* Ignore any latent data coming from a connection we closed. */
 	if (this->http_response_index == -2) return;
 
+	this->lastActivity = std::chrono::steady_clock::now();
+
 	if (this->http_response_index == -1) {
 		if (data != nullptr) {
 			/* Append the rest of the response. */


### PR DESCRIPTION
## Motivation / Problem

Fix spurious cancellations of HTTP content downloads (part 2 of #11636).

## Description

Fix HTTP content downloads being cancelled part way through by NetworkBackgroundLoop, resulting in the download and UI halting until user action is taken.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
