### PR TITLE
Change: Limit total script ops that can be consumed by a list valuate

### DIFF
--- a/src/3rdparty/squirrel/squirrel/sqvm.h
+++ b/src/3rdparty/squirrel/squirrel/sqvm.h
@@ -168,11 +168,18 @@ public:
 
 	SQBool _can_suspend;
 	SQInteger _ops_till_suspend;
+	SQInteger _ops_till_suspend_error_threshold;
+	const char *_ops_till_suspend_error_label;
 	SQBool _in_stackoverflow;
 
 	bool ShouldSuspend()
 	{
 		return _can_suspend && _ops_till_suspend <= 0;
+	}
+
+	bool IsOpsTillSuspendError()
+	{
+		return _ops_till_suspend < _ops_till_suspend_error_threshold;
 	}
 
 	void DecreaseOps(SQInteger amount)

--- a/src/script/api/script_list.hpp
+++ b/src/script/api/script_list.hpp
@@ -13,6 +13,9 @@
 
 #include "script_object.hpp"
 
+/** Maximum number of operations allowed for valuating a list. */
+static const int MAX_VALUATE_OPS = 500000;
+
 class ScriptListSorter;
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Script functions called by ScriptList::Valuate are never suspended.
A single script function called by ScriptList::Valuate could therefore consume an unlimited amount of CPU time, blocking the actual game.

## Description

Generate an error, killing the script, once a threshold number of ops is consumed by a (top level) valuate operation, even in the case where the function would never otherwise return.

## Limitations

Using the suspend parameter of sq_call complicates the accounting of the remaining ops and the handling of the stack in the case where the limit has been reached. An attempt was made using this, but was abandoned in favour of the approach in this PR.

The existing squirrel code is mostly very ugly. In order to maintain a consistent code style care has been taken to ensure that this PR is also aesthetically displeasing.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
