### PR TITLE
Allow GS to add animated/static text to the map

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -498,6 +498,8 @@ add_files(
     textbuf_type.h
     texteff.cpp
     texteff.hpp
+    texteff_cmd.cpp
+    texteff_cmd.h
     textfile_gui.cpp
     textfile_gui.h
     textfile_type.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -505,6 +505,8 @@ add_files(
     textbuf_type.h
     texteff.cpp
     texteff.hpp
+    texteff_cmd.cpp
+    texteff_cmd.h
     textfile_gui.cpp
     textfile_gui.h
     textfile_type.h

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -46,6 +46,7 @@
 #include "station_cmd.h"
 #include "story_cmd.h"
 #include "subsidy_cmd.h"
+#include "texteff_cmd.h"
 #include "terraform_cmd.h"
 #include "timetable_cmd.h"
 #include "town_cmd.h"

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -372,6 +372,10 @@ enum Commands : uint8_t {
 	CMD_UPDATE_LEAGUE_TABLE_ELEMENT_SCORE, ///< update the score of a league table element
 	CMD_REMOVE_LEAGUE_TABLE_ELEMENT,       ///< remove a league table element
 
+	CMD_CREATE_TEXT_EFFECT,           ///< create a new text effect
+	CMD_UPDATE_TEXT_EFFECT,           ///< update text effect
+	CMD_REMOVE_TEXT_EFFECT,           ///< remove text effect
+
 	CMD_END,                          ///< Must ALWAYS be on the end of this list!! (period)
 };
 

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -380,6 +380,10 @@ enum class Commands : uint8_t {
 	UpdateLeagueTableElementScore, ///< update the score of a league table element
 	RemoveLeagueTableElement, ///< remove a league table element
 
+	CreateTextEffect, ///< create a new text effect
+	UpdateTextEffect, ///< update a text effect
+	RemoveTextEffect, ///< remove a text effect
+
 	End, ///< @important Must ALWAYS be on the end of this list!! (period)
 };
 

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -40,6 +40,7 @@
 #include "../station_cmd.h"
 #include "../story_cmd.h"
 #include "../subsidy_cmd.h"
+#include "../texteff_cmd.h"
 #include "../terraform_cmd.h"
 #include "../timetable_cmd.h"
 #include "../town_cmd.h"

--- a/src/saveload/CMakeLists.txt
+++ b/src/saveload/CMakeLists.txt
@@ -44,6 +44,7 @@ add_files(
     strings_sl.cpp
     story_sl.cpp
     subsidy_sl.cpp
+    texteff_sl.cpp
     town_sl.cpp
     vehicle_sl.cpp
     waypoint_sl.cpp

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -242,6 +242,7 @@ static const std::vector<ChunkHandlerRef> &ChunkHandlers()
 	extern const ChunkHandlerTable _goal_chunk_handlers;
 	extern const ChunkHandlerTable _story_page_chunk_handlers;
 	extern const ChunkHandlerTable _league_chunk_handlers;
+	extern const ChunkHandlerTable _text_effect_chunk_handlers;
 	extern const ChunkHandlerTable _ai_chunk_handlers;
 	extern const ChunkHandlerTable _game_chunk_handlers;
 	extern const ChunkHandlerTable _animated_tile_chunk_handlers;
@@ -276,6 +277,7 @@ static const std::vector<ChunkHandlerRef> &ChunkHandlers()
 		_goal_chunk_handlers,
 		_story_page_chunk_handlers,
 		_league_chunk_handlers,
+		_text_effect_chunk_handlers,
 		_engine_chunk_handlers,
 		_town_chunk_handlers,
 		_sign_chunk_handlers,

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -420,6 +420,7 @@ enum class SaveLoadVersion : uint16_t {
 
 	DriveBackwards, ///< Saveload version: 365, GitHub pull request: 15379\n Trains can drive backwards.
 	DepotsUnderBridges, ///< Saveload version: 366, GitHub pull request: 15836\n Allow depots under bridges.
+	ScriptTextEffects, ///< Saveload version: 367, GitHub pull request: 11672\n Store GameScript-created text effects.
 
 	MaxVersion, ///< Highest possible saveload version.
 };

--- a/src/saveload/texteff_sl.cpp
+++ b/src/saveload/texteff_sl.cpp
@@ -1,0 +1,63 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file texteff_sl.cpp Code handling saving and loading of GameScript text effects. */
+
+#include "../stdafx.h"
+
+#include "saveload.h"
+
+#include "../texteff.hpp"
+
+#include "../safeguards.h"
+
+/** Description of the saved fields of a GameScript text effect. */
+static const SaveLoad _script_text_effect_desc[] = {
+	    SLE_VAR(ScriptTextEffectData, x,        VarTypes::I32),
+	    SLE_VAR(ScriptTextEffectData, y,        VarTypes::I32),
+	    SLE_VAR(ScriptTextEffectData, mode,     VarTypes::U8),
+	    SLE_VAR(ScriptTextEffectData, duration, VarTypes::U8),
+	    SLE_VAR(ScriptTextEffectData, colour,   VarTypes::U8),
+	   SLE_SSTR(ScriptTextEffectData, msg,      VarTypes::STR | StringValidationSetting::AllowControlCode),
+};
+
+/** Chunk handler for GameScript text effects. */
+struct TEFFChunkHandler : ChunkHandler {
+	/** Create the handler for the "TEFF" chunk. */
+	TEFFChunkHandler() : ChunkHandler("TEFF", ChunkType::Table) {}
+
+	void Save() const override
+	{
+		SlTableHeader(_script_text_effect_desc);
+
+		for (ScriptTextEffectData *effect : ScriptTextEffectData::Iterate()) {
+			SlSetArrayIndex(effect->index);
+			SlObject(effect, _script_text_effect_desc);
+		}
+	}
+
+	void Load() const override
+	{
+		const std::vector<SaveLoad> slt = SlTableHeader(_script_text_effect_desc);
+
+		int index;
+		while ((index = SlIterateArray()) != -1) {
+			ScriptTextEffectData *effect = ScriptTextEffectData::CreateAtIndex(ScriptTextEffectID(index));
+			SlObject(effect, slt);
+		}
+	}
+};
+
+static const TEFFChunkHandler TEFF; ///< Handler for the "TEFF" chunk.
+
+/** All chunk handlers related to text effects. */
+static const ChunkHandlerRef text_effect_chunk_handlers[] = {
+	TEFF,
+};
+
+/** Table of all chunk handlers related to text effects. */
+extern const ChunkHandlerTable _text_effect_chunk_handlers{text_effect_chunk_handlers};

--- a/src/script/api/CMakeLists.txt
+++ b/src/script/api/CMakeLists.txt
@@ -206,6 +206,7 @@ add_files(
     script_subsidylist.hpp
     script_testmode.hpp
     script_text.hpp
+    script_text_effect.hpp
     script_tile.hpp
     script_tilelist.hpp
     script_town.hpp
@@ -278,6 +279,7 @@ add_files(
     script_subsidylist.cpp
     script_testmode.cpp
     script_text.cpp
+    script_text_effect.cpp
     script_tile.cpp
     script_tilelist.cpp
     script_town.cpp

--- a/src/script/api/CMakeLists.txt
+++ b/src/script/api/CMakeLists.txt
@@ -207,6 +207,7 @@ add_files(
     script_subsidylist.hpp
     script_testmode.hpp
     script_text.hpp
+    script_text_effect.hpp
     script_tile.hpp
     script_tilelist.hpp
     script_town.hpp
@@ -279,6 +280,7 @@ add_files(
     script_subsidylist.cpp
     script_testmode.cpp
     script_text.cpp
+    script_text_effect.cpp
     script_tile.cpp
     script_tilelist.cpp
     script_town.cpp

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -18,6 +18,9 @@
  * \b 16.0
  *
  * This version is not yet released. The following changes are not set in stone yet.
+ * API additions:
+ * \li GSTextEffect
+ *
  * Other changes:
  * \li GSTown::ExpandTown Change to town expansion to match expected behaviour with the 'allow_town_roads' setting
  *

--- a/src/script/api/script_text_effect.cpp
+++ b/src/script/api/script_text_effect.cpp
@@ -1,0 +1,63 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file script_text_effect.cpp Implementation of ScriptTextEffect with multiplayer support. */
+
+#include "../../stdafx.h"
+#include "script_text_effect.hpp"
+#include "script_error.hpp"
+#include "script_map.hpp"
+#include "../script_instance.hpp"
+#include "../../texteff.hpp"
+#include "../../strings_func.h"
+#include "../../tile_map.h"
+#include "../../command_func.h"
+#include "../../texteff_cmd.h"
+
+#include "../../safeguards.h"
+
+/* static */ TextEffectID ScriptTextEffect::CreateAtPosition(SQInteger x, SQInteger y, Text *text, ScriptTextEffectMode mode)
+{
+    ScriptObjectRef counter(text);
+
+    EnforceDeityMode(false);
+    EnforcePrecondition(false, text != nullptr);
+    EnforcePrecondition(false, !text->GetEncodedText().empty());
+    EnforcePrecondition(false, mode == TE_RISING || mode == TE_STATIC);
+
+    return ScriptObject::Command<CMD_CREATE_TEXT_EFFECT>::Do(&ScriptInstance::DoCommandReturnTextEffectID, x, y, (TextEffectMode)mode, text->GetEncodedText());
+}
+
+/* static */ TextEffectID ScriptTextEffect::Create(TileIndex tile, Text *text, ScriptTextEffectMode mode)
+{
+    EnforcePrecondition(false, ScriptMap::IsValidTile(tile));
+    
+    int x = TileX(tile) * TILE_SIZE + TILE_SIZE / 2;
+    int y = TileY(tile) * TILE_SIZE + TILE_SIZE / 2;
+    
+    return CreateAtPosition(x, y, text, mode);
+}
+
+/* static */ bool ScriptTextEffect::Update(TextEffectID te_id, Text *text)
+{
+    ScriptObjectRef counter(text);
+
+    EnforceDeityMode(false);
+    EnforcePrecondition(false, te_id != INVALID_TE_ID);
+    EnforcePrecondition(false, text != nullptr);
+    EnforcePrecondition(false, !text->GetEncodedText().empty());
+
+    return ScriptObject::Command<CMD_UPDATE_TEXT_EFFECT>::Do(te_id, text->GetEncodedText());
+}
+
+/* static */ bool ScriptTextEffect::Remove(TextEffectID te_id)
+{
+    EnforceDeityMode(false);
+    EnforcePrecondition(false, te_id != INVALID_TE_ID);
+
+    return ScriptObject::Command<CMD_REMOVE_TEXT_EFFECT>::Do(te_id);    
+}

--- a/src/script/api/script_text_effect.cpp
+++ b/src/script/api/script_text_effect.cpp
@@ -1,0 +1,77 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file script_text_effect.cpp Implementation of ScriptTextEffect with multiplayer support. */
+
+#include "../../stdafx.h"
+#include "script_text_effect.hpp"
+#include "script_error.hpp"
+#include "script_map.hpp"
+#include "../script_instance.hpp"
+#include "../../landscape.h"
+#include "../../tile_map.h"
+#include "../../texteff_cmd.h"
+
+#include "../../safeguards.h"
+
+/* static */ bool ScriptTextEffect::IsValidTextEffect(ScriptTextEffectID effect_id)
+{
+	EnforceDeityMode(false);
+	return ::ScriptTextEffectData::IsValidID(effect_id);
+}
+
+/* static */ ScriptTextEffectID ScriptTextEffect::CreateAtPosition(SQInteger x, SQInteger y, Text *text, TextEffectMode mode, ScriptCompany::Colours colour)
+{
+	ScriptObjectRef counter(text);
+
+	EnforceDeityMode(TEXT_EFFECT_INVALID);
+	EnforcePrecondition(TEXT_EFFECT_INVALID, x >= 0 && x < static_cast<SQInteger>(Map::SizeX() * TILE_SIZE));
+	EnforcePrecondition(TEXT_EFFECT_INVALID, y >= 0 && y < static_cast<SQInteger>(Map::SizeY() * TILE_SIZE));
+	EnforcePrecondition(TEXT_EFFECT_INVALID, text != nullptr);
+	EncodedString encoded_text = text->GetEncodedText();
+	EnforcePreconditionEncodedText(TEXT_EFFECT_INVALID, encoded_text);
+	EnforcePrecondition(TEXT_EFFECT_INVALID, mode == TE_RISING || mode == TE_STATIC);
+	EnforcePrecondition(TEXT_EFFECT_INVALID, colour >= ScriptCompany::COLOUR_DARK_BLUE && colour <= ScriptCompany::COLOUR_WHITE);
+
+	if (!ScriptObject::Command<Commands::CreateTextEffect>::Do(&ScriptInstance::DoCommandReturnTextEffectID, static_cast<int32_t>(x), static_cast<int32_t>(y), static_cast<::TextEffectMode>(mode), static_cast<::Colours>(colour), encoded_text)) {
+		return TEXT_EFFECT_INVALID;
+	}
+
+	/* In test mode, return the first valid ID. */
+	return ScriptTextEffectID::Begin();
+}
+
+/* static */ ScriptTextEffectID ScriptTextEffect::Create(TileIndex tile, Text *text, TextEffectMode mode, ScriptCompany::Colours colour)
+{
+	EnforcePrecondition(TEXT_EFFECT_INVALID, ScriptMap::IsValidTile(tile));
+
+	SQInteger x = TileX(tile) * TILE_SIZE + TILE_SIZE / 2;
+	SQInteger y = TileY(tile) * TILE_SIZE + TILE_SIZE / 2;
+	return CreateAtPosition(x, y, text, mode, colour);
+}
+
+/* static */ bool ScriptTextEffect::Update(ScriptTextEffectID effect_id, Text *text, ScriptCompany::Colours colour)
+{
+	ScriptObjectRef counter(text);
+
+	EnforceDeityMode(false);
+	EnforcePrecondition(false, IsValidTextEffect(effect_id));
+	EnforcePrecondition(false, text != nullptr);
+	EncodedString encoded_text = text->GetEncodedText();
+	EnforcePreconditionEncodedText(false, encoded_text);
+	EnforcePrecondition(false, colour >= ScriptCompany::COLOUR_DARK_BLUE && colour <= ScriptCompany::COLOUR_WHITE);
+
+	return ScriptObject::Command<Commands::UpdateTextEffect>::Do(effect_id, static_cast<::Colours>(colour), encoded_text);
+}
+
+/* static */ bool ScriptTextEffect::Remove(ScriptTextEffectID effect_id)
+{
+	EnforceDeityMode(false);
+	EnforcePrecondition(false, IsValidTextEffect(effect_id));
+
+	return ScriptObject::Command<Commands::RemoveTextEffect>::Do(effect_id);
+}

--- a/src/script/api/script_text_effect.hpp
+++ b/src/script/api/script_text_effect.hpp
@@ -1,0 +1,66 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file script_text_effect.hpp Everything to display animated text in the game world. */
+
+#ifndef SCRIPT_TEXT_EFFECT_HPP
+#define SCRIPT_TEXT_EFFECT_HPP
+
+#include "script_object.hpp"
+#include "script_text.hpp"
+#include "../../texteff.hpp"
+
+/**
+ * Class that handles text effect display in the game world.
+ * @api game
+ */
+class ScriptTextEffect : public ScriptObject {
+public:
+    /**
+     * Text effect animation modes.
+     */
+    enum ScriptTextEffectMode {
+        TE_RISING = ::TE_RISING, ///< Text slowly rises upwards
+        TE_STATIC = ::TE_STATIC, ///< Text stays in place
+    };
+
+    /**
+     * Create animated text at a tile location.
+     * @param tile The tile where to show the text.
+     * @param text The text to display.
+     * @param mode The animation mode to use.
+     * @return True if the text effect was created successfully.
+     */
+    static TextEffectID Create(TileIndex tile, Text *text, ScriptTextEffectMode mode);
+
+    /**
+     * Create animated text at the specified location.
+     * @param x X coordinate in the game world.
+     * @param y Y coordinate in the game world.
+     * @param text The text to display.
+     * @param mode The animation mode to use.
+     * @return True if the text effect was created successfully.
+     */
+    static TextEffectID CreateAtPosition(SQInteger x, SQInteger y, Text *text, ScriptTextEffectMode mode);
+    
+    /**
+     * Update animated text
+     * @param te_id Text effect ID.
+     * @param text The text to update
+     * @return True if the text effect was updated successfully
+     */
+    static bool Update(TextEffectID te_id, Text *text);
+
+    /**
+     * Update animated text
+     * @param te_id Text effect ID.
+     * @return True if the text effect was removed successfully
+     */
+    static bool Remove(TextEffectID te_id);
+};
+
+#endif /* SCRIPT_TEXT_EFFECT_HPP */

--- a/src/script/api/script_text_effect.hpp
+++ b/src/script/api/script_text_effect.hpp
@@ -1,0 +1,98 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file script_text_effect.hpp Everything to display animated text in the game world. */
+
+#ifndef SCRIPT_TEXT_EFFECT_HPP
+#define SCRIPT_TEXT_EFFECT_HPP
+
+#include "script_object.hpp"
+#include "script_company.hpp"
+#include "script_text.hpp"
+#include "../../texteff.hpp"
+
+/**
+ * Class that handles text effect display in the game world.
+ *
+ * Text effects are saved and loaded. Static effects remain until explicitly
+ * removed; rising effects disappear after their animation finishes.
+ * @api game
+ */
+class ScriptTextEffect : public ScriptObject {
+public:
+	static constexpr ScriptTextEffectID TEXT_EFFECT_INVALID = ScriptTextEffectID::Invalid(); ///< An invalid text effect ID.
+
+	/**
+	 * Text effect animation modes.
+	 */
+	enum TextEffectMode : uint8_t {
+		TE_RISING = to_underlying(::TextEffectMode::Rising), ///< Text slowly rises upwards and then disappears.
+		TE_STATIC = to_underlying(::TextEffectMode::Static), ///< Text stays in place until removed.
+	};
+
+	/**
+	 * Check whether a text effect exists.
+	 * @param effect_id The text effect ID to check.
+	 * @return True if and only if this text effect currently exists.
+	 */
+	static bool IsValidTextEffect(ScriptTextEffectID effect_id);
+
+	/**
+	 * Create text at the centre of a tile.
+	 * @param tile The tile where the text is shown.
+	 * @param text The text to display (a raw string or ScriptText object).
+	 * @param mode The animation mode to use.
+	 * @param colour The text colour.
+	 * @return The new text effect ID, or #TEXT_EFFECT_INVALID if creation failed.
+	 * @pre ScriptCompanyMode::IsDeity().
+	 * @pre ScriptMap::IsValidTile(tile).
+	 * @pre text != null && len(text) != 0.
+	 * @pre mode is TE_RISING or TE_STATIC.
+	 * @pre colour is a valid ScriptCompany::Colours value.
+	 */
+	static ScriptTextEffectID Create(TileIndex tile, Text *text, TextEffectMode mode, ScriptCompany::Colours colour);
+
+	/**
+	 * Create text at a world position.
+	 * @param x X coordinate in the game world.
+	 * @param y Y coordinate in the game world.
+	 * @param text The text to display (a raw string or ScriptText object).
+	 * @param mode The animation mode to use.
+	 * @param colour The text colour.
+	 * @return The new text effect ID, or #TEXT_EFFECT_INVALID if creation failed.
+	 * @pre ScriptCompanyMode::IsDeity().
+	 * @pre x and y identify a position within the map.
+	 * @pre text != null && len(text) != 0.
+	 * @pre mode is TE_RISING or TE_STATIC.
+	 * @pre colour is a valid ScriptCompany::Colours value.
+	 */
+	static ScriptTextEffectID CreateAtPosition(SQInteger x, SQInteger y, Text *text, TextEffectMode mode, ScriptCompany::Colours colour);
+
+	/**
+	 * Update a text effect.
+	 * @param effect_id Text effect ID.
+	 * @param text The new text (a raw string or ScriptText object).
+	 * @param colour The new text colour.
+	 * @return True if the text effect was updated.
+	 * @pre ScriptCompanyMode::IsDeity().
+	 * @pre IsValidTextEffect(effect_id).
+	 * @pre text != null && len(text) != 0.
+	 * @pre colour is a valid ScriptCompany::Colours value.
+	 */
+	static bool Update(ScriptTextEffectID effect_id, Text *text, ScriptCompany::Colours colour);
+
+	/**
+	 * Remove a text effect.
+	 * @param effect_id Text effect ID.
+	 * @return True if the text effect was removed.
+	 * @pre ScriptCompanyMode::IsDeity().
+	 * @pre IsValidTextEffect(effect_id).
+	 */
+	static bool Remove(ScriptTextEffectID effect_id);
+};
+
+#endif /* SCRIPT_TEXT_EFFECT_HPP */

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -29,6 +29,7 @@
 #include "../fileio_func.h"
 #include "../league_type.h"
 #include "../misc/endian_buffer.hpp"
+#include "../texteff.hpp"
 
 #include "../safeguards.h"
 
@@ -315,6 +316,10 @@ void ScriptInstance::CollectGarbage()
 	instance->engine->InsertResult(EndianBufferReader::ToValue<LeagueTableID>(ScriptObject::GetLastCommandResData()));
 }
 
+/* static */ void ScriptInstance::DoCommandReturnTextEffectID(ScriptInstance *instance)
+{
+	instance->engine->InsertResult(EndianBufferReader::ToValue<TextEffectID>(ScriptObject::GetLastCommandResData()));
+}
 
 ScriptStorage *ScriptInstance::GetStorage()
 {

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -31,6 +31,7 @@
 #include "../signs_type.h"
 #include "../story_type.h"
 #include "../misc/endian_buffer.hpp"
+#include "../texteff.hpp"
 
 #include "../safeguards.h"
 
@@ -326,6 +327,10 @@ void ScriptInstance::CollectGarbage()
 	instance.engine->InsertResult(EndianBufferReader::ToValue<LeagueTableID>(ScriptObject::GetLastCommandResData()));
 }
 
+/* static */ void ScriptInstance::DoCommandReturnTextEffectID(ScriptInstance &instance)
+{
+	instance.engine->InsertResult(EndianBufferReader::ToValue<ScriptTextEffectID>(ScriptObject::GetLastCommandResData()));
+}
 
 ScriptStorage &ScriptInstance::GetStorage()
 {

--- a/src/script/script_instance.hpp
+++ b/src/script/script_instance.hpp
@@ -144,6 +144,11 @@ public:
 	static void DoCommandReturnLeagueTableElementID(ScriptInstance *instance);
 
 	/**
+	 * Return a TextEffectID reply for a DoCommand.
+	 */
+	static void DoCommandReturnTextEffectID(ScriptInstance *instance);
+	
+	/**
 	 * Get the controller attached to the instance.
 	 */
 	class ScriptController *GetController() { return controller; }

--- a/src/script/script_instance.hpp
+++ b/src/script/script_instance.hpp
@@ -156,6 +156,12 @@ public:
 	static void DoCommandReturnLeagueTableElementID(ScriptInstance &instance);
 
 	/**
+	 * Return a ScriptTextEffectID reply for a DoCommand.
+	 * @param instance The instance to return the reply to.
+	 */
+	static void DoCommandReturnTextEffectID(ScriptInstance &instance);
+
+	/**
 	 * Get the controller attached to the instance.
 	 * @return The instance's controller.
 	 */

--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -9,12 +9,15 @@
 
 #include "stdafx.h"
 #include "texteff.hpp"
+#include "landscape.h"
 #include "transparency.h"
 #include "strings_func.h"
 #include "viewport_func.h"
 #include "settings_type.h"
 #include "command_type.h"
+#include "core/pool_func.hpp"
 #include "timer/timer.h"
+#include "timer/timer_game_tick.h"
 #include "timer/timer_window.h"
 
 #include "safeguards.h"
@@ -38,8 +41,33 @@ struct TextEffect : public ViewportSign {
 
 static std::vector<TextEffect> _text_effects; ///< Text effects are stored there
 
-/* Text Effects */
-TextEffectID AddTextEffect(EncodedString &&msg, int center, int y, uint8_t duration, TextEffectMode mode)
+ScriptTextEffectDataPool _script_text_effect_pool("ScriptTextEffect"); ///< Pool holding all GameScript-created text effects.
+INSTANTIATE_POOL_METHODS(ScriptTextEffectData)
+
+/** Remove the text effect from the screen. */
+ScriptTextEffectData::~ScriptTextEffectData()
+{
+	if (!CleaningPool()) this->sign.MarkDirty();
+}
+
+/** Recompute the viewport position of this text effect. */
+void ScriptTextEffectData::UpdateVirtCoord()
+{
+	Point pt = RemapCoords(this->x, this->y, GetSlopePixelZ(this->x, this->y));
+	int offset = this->mode == TextEffectMode::Rising ? (Ticks::DAY_TICKS - this->duration) * ZOOM_BASE : 0;
+	this->sign.UpdatePosition(pt.x, pt.y - offset, this->msg.GetDecodedString());
+}
+
+/**
+ * Add a text effect to the list of text effects.
+ * @param msg Encoded message to show.
+ * @param center Horizontal center of the text effect, in viewport coordinates.
+ * @param y Top of the text effect, in viewport coordinates.
+ * @param duration Lifetime in game ticks for rising effects.
+ * @param mode Type of text effect.
+ * @return The ID of the new text effect, or INVALID_TE_ID when none could be allocated.
+ */
+static TextEffectID AddTextEffectInternal(EncodedString &&msg, int center, int y, uint8_t duration, TextEffectMode mode)
 {
 	if (_game_mode == GameMode::Menu) return INVALID_TE_ID;
 
@@ -64,8 +92,16 @@ TextEffectID AddTextEffect(EncodedString &&msg, int center, int y, uint8_t durat
 	return static_cast<TextEffectID>(it - std::begin(_text_effects));
 }
 
+/* Text Effects */
+TextEffectID AddTextEffect(EncodedString &&msg, int center, int y, uint8_t duration, TextEffectMode mode)
+{
+	return AddTextEffectInternal(std::move(msg), center, y, duration, mode);
+}
+
 void UpdateTextEffect(TextEffectID te_id, EncodedString &&msg)
 {
+	if (te_id >= _text_effects.size() || !_text_effects[te_id].IsValid()) return;
+
 	/* Update details */
 	TextEffect &te = _text_effects[te_id];
 	if (msg == te.msg) return;
@@ -81,10 +117,15 @@ void UpdateAllTextEffectVirtCoords()
 
 		te.UpdatePosition(te.center, te.top, te.msg.GetDecodedString());
 	}
+
+	for (ScriptTextEffectData *te : ScriptTextEffectData::Iterate()) {
+		te->UpdateVirtCoord();
+	}
 }
 
 void RemoveTextEffect(TextEffectID te_id)
 {
+	if (te_id >= _text_effects.size() || !_text_effects[te_id].IsValid()) return;
 	_text_effects[te_id].Reset();
 }
 
@@ -105,6 +146,23 @@ const IntervalTimer<TimerWindow> move_all_text_effects_interval = {std::chrono::
 		te.duration -= count;
 		te.top -= count * ZOOM_BASE;
 		te.MarkDirty(ZoomLevel::TextEffect);
+	}
+}};
+
+/** Move and expire GameScript-created rising effects deterministically. */
+const IntervalTimer<TimerGameTick> move_script_text_effects_interval = {{TimerGameTick::Priority::None, 1}, [](uint count) {
+	for (ScriptTextEffectData *te : ScriptTextEffectData::Iterate()) {
+		if (te->mode != TextEffectMode::Rising) continue;
+
+		if (te->duration < count) {
+			delete te;
+			continue;
+		}
+
+		te->sign.MarkDirty(ZoomLevel::TextEffect);
+		te->duration -= count;
+		te->sign.top -= count * ZOOM_BASE;
+		te->sign.MarkDirty(ZoomLevel::TextEffect);
 	}
 }};
 
@@ -132,5 +190,17 @@ void DrawTextEffects(DrawPixelInfo *dpi)
 
 			*str = te.msg.GetDecodedString();
 		}
+	}
+
+	for (const ScriptTextEffectData *te : ScriptTextEffectData::Iterate()) {
+		ViewportStringFlags effect_flags = flags;
+		Colours colour = te->colour;
+		effect_flags.Set(ViewportStringFlag::TextColour);
+		if (colour == Colours::White) colour = Colours::Invalid;
+
+		std::string *str = ViewportAddString(dpi, &te->sign, effect_flags, colour);
+		if (str == nullptr) continue;
+
+		*str = te->msg.GetDecodedString();
 	}
 }

--- a/src/texteff.hpp
+++ b/src/texteff.hpp
@@ -13,6 +13,8 @@
 #include "economy_type.h"
 #include "gfx_type.h"
 #include "strings_type.h"
+#include "viewport_type.h"
+#include "core/pool_type.hpp"
 
 /**
  * Text effect modes.
@@ -27,7 +29,53 @@ using TextEffectID = uint16_t;
 
 static const TextEffectID INVALID_TE_ID = UINT16_MAX;
 
+/** The type of IDs for GameScript-created text effects. */
+using ScriptTextEffectID = PoolID<uint32_t, struct ScriptTextEffectIDTag, 65535, UINT32_MAX>;
+
+/** Sentinel value for an invalid GameScript-created text effect. */
+static constexpr ScriptTextEffectID INVALID_SCRIPT_TEXT_EFFECT_ID = ScriptTextEffectID::Invalid();
+
 TextEffectID AddTextEffect(EncodedString &&msg, int x, int y, uint8_t duration, TextEffectMode mode);
+
+struct ScriptTextEffectData;
+/** Type of the pool holding all GameScript-created text effects. */
+using ScriptTextEffectDataPool = Pool<ScriptTextEffectData, ScriptTextEffectID, 16>;
+extern ScriptTextEffectDataPool _script_text_effect_pool; ///< Pool holding all GameScript-created text effects.
+
+/** Authoritative state for a GameScript-created text effect. */
+struct ScriptTextEffectData : ScriptTextEffectDataPool::PoolItem<&_script_text_effect_pool> {
+	int32_t x = 0; ///< X coordinate in the game world.
+	int32_t y = 0; ///< Y coordinate in the game world.
+	TextEffectMode mode = TextEffectMode::Invalid; ///< Type of text effect.
+	uint8_t duration = 0; ///< Remaining lifetime in game ticks for rising effects.
+	Colours colour = Colours::Invalid; ///< Text colour.
+	EncodedString msg{}; ///< Encoded message.
+	ViewportSign sign{}; ///< Client-side viewport position cache.
+
+	/**
+	 * Create an empty text effect, to be filled in later.
+	 * @param index Pool index to create the text effect at.
+	 */
+	ScriptTextEffectData(ScriptTextEffectID index) : ScriptTextEffectDataPool::PoolItem<&_script_text_effect_pool>(index) {}
+
+	/**
+	 * Create a fully defined text effect.
+	 * @param index Pool index to create the text effect at.
+	 * @param x X coordinate in the game world.
+	 * @param y Y coordinate in the game world.
+	 * @param mode Type of text effect.
+	 * @param duration Remaining lifetime in game ticks for rising effects.
+	 * @param colour Text colour.
+	 * @param msg Encoded message to show.
+	 */
+	ScriptTextEffectData(ScriptTextEffectID index, int32_t x, int32_t y, TextEffectMode mode, uint8_t duration, Colours colour, const EncodedString &msg) :
+		ScriptTextEffectDataPool::PoolItem<&_script_text_effect_pool>(index), x(x), y(y), mode(mode), duration(duration), colour(colour), msg(msg) {}
+
+	~ScriptTextEffectData();
+
+	void UpdateVirtCoord();
+};
+
 void InitTextEffects();
 void DrawTextEffects(DrawPixelInfo *dpi);
 void UpdateTextEffect(TextEffectID effect_id, EncodedString &&msg);

--- a/src/texteff_cmd.cpp
+++ b/src/texteff_cmd.cpp
@@ -1,0 +1,75 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file texteff_cmd.cpp Command handling for text effects */
+
+#include "stdafx.h"
+#include "command_func.h"
+#include "texteff.hpp"
+#include "strings_func.h"
+#include "tile_map.h"
+#include "texteff_cmd.h"
+
+#include "table/strings.h"
+
+#include "safeguards.h"
+#include "landscape.h"
+
+/**
+ * Show a text effect at the specified location.
+ * @param flags operation to perform
+ * @param x X coordinate in the game
+ * @param y Y coordinate in the game
+ * @param mode The animation mode to use
+ * @param text The text to display
+ * @return the cost of this operation or an error
+ */
+std::tuple<CommandCost, TextEffectID> CmdCreateTextEffect(DoCommandFlags flags, int32_t x, int32_t y, TextEffectMode mode, const EncodedString &text)
+{
+    if (text.empty()) return { CMD_ERROR, INVALID_TE_ID };
+    if (mode != TE_RISING && mode != TE_STATIC) return { CMD_ERROR, INVALID_TE_ID };
+
+    if (flags.Test(DoCommandFlag::Execute)) {        
+        Point pt = RemapCoords2(x, y);
+        EncodedString encoded_text = text;
+        TextEffectID te_id;
+
+        if (mode == TE_RISING) {
+            te_id = AddTextEffect(std::move(encoded_text), pt.x, pt.y, Ticks::DAY_TICKS, TE_RISING);
+        } else {
+            te_id = AddTextEffect(std::move(encoded_text), pt.x, pt.y, 0, TE_STATIC);
+        }
+        
+        return { CommandCost(), te_id };
+    }
+
+    return { CommandCost(), INVALID_TE_ID };
+}
+
+CommandCost CmdUpdateTextEffect(DoCommandFlags flags, TextEffectID te_id, const EncodedString &text)
+{
+    if (te_id == INVALID_TE_ID) return CMD_ERROR;
+    if (text.empty()) return CMD_ERROR;
+
+    if (flags.Test(DoCommandFlag::Execute)) {        
+        EncodedString encoded_text = text;
+        UpdateTextEffect(te_id, std::move(encoded_text));
+    }
+
+    return CommandCost();
+}
+
+CommandCost CmdRemoveTextEffect(DoCommandFlags flags, TextEffectID te_id)
+{
+    if (te_id == INVALID_TE_ID) return CMD_ERROR;
+
+    if (flags.Test(DoCommandFlag::Execute)) {        
+        RemoveTextEffect(te_id);
+    }
+
+    return CommandCost();
+}

--- a/src/texteff_cmd.cpp
+++ b/src/texteff_cmd.cpp
@@ -1,0 +1,84 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file texteff_cmd.cpp Command handling for text effects. */
+
+#include "stdafx.h"
+#include "command_func.h"
+#include "texteff.hpp"
+#include "landscape.h"
+#include "texteff_cmd.h"
+
+#include "safeguards.h"
+
+/**
+ * Create a GameScript text effect at the specified world location.
+ * @param flags Operation to perform.
+ * @param x World X coordinate.
+ * @param y World Y coordinate.
+ * @param mode Animation mode to use.
+ * @param colour Colour of the text.
+ * @param text Text to display.
+ * @return The cost of this operation and the stable text effect ID.
+ */
+std::tuple<CommandCost, ScriptTextEffectID> CmdCreateTextEffect(DoCommandFlags flags, int32_t x, int32_t y, TextEffectMode mode, Colours colour, const EncodedString &text)
+{
+	if (!ScriptTextEffectData::CanAllocateItem()) return { CMD_ERROR, INVALID_SCRIPT_TEXT_EFFECT_ID };
+	if (text.empty()) return { CMD_ERROR, INVALID_SCRIPT_TEXT_EFFECT_ID };
+	if (mode != TextEffectMode::Rising && mode != TextEffectMode::Static) return { CMD_ERROR, INVALID_SCRIPT_TEXT_EFFECT_ID };
+	if (colour >= Colours::End) return { CMD_ERROR, INVALID_SCRIPT_TEXT_EFFECT_ID };
+	if (x < 0 || y < 0 || static_cast<uint32_t>(x) >= Map::SizeX() * TILE_SIZE || static_cast<uint32_t>(y) >= Map::SizeY() * TILE_SIZE) {
+		return { CMD_ERROR, INVALID_SCRIPT_TEXT_EFFECT_ID };
+	}
+
+	if (flags.Test(DoCommandFlag::Execute)) {
+		uint8_t duration = mode == TextEffectMode::Rising ? Ticks::DAY_TICKS : 0;
+		ScriptTextEffectData *effect = ScriptTextEffectData::Create(x, y, mode, duration, colour, text);
+		effect->UpdateVirtCoord();
+		return { CommandCost(), effect->index };
+	}
+
+	return { CommandCost(), INVALID_SCRIPT_TEXT_EFFECT_ID };
+}
+
+/**
+ * Update a GameScript text effect.
+ * @param flags Operation to perform.
+ * @param effect_id Stable ID of the text effect.
+ * @param colour New colour of the text.
+ * @param text New text to display.
+ * @return The cost of this operation or an error.
+ */
+CommandCost CmdUpdateTextEffect(DoCommandFlags flags, ScriptTextEffectID effect_id, Colours colour, const EncodedString &text)
+{
+	if (effect_id == INVALID_SCRIPT_TEXT_EFFECT_ID || text.empty() || colour >= Colours::End) return CMD_ERROR;
+	if (!ScriptTextEffectData::IsValidID(effect_id)) return CMD_ERROR;
+
+	if (flags.Test(DoCommandFlag::Execute)) {
+		ScriptTextEffectData *effect = ScriptTextEffectData::Get(effect_id);
+		effect->sign.MarkDirty();
+		effect->msg = text;
+		effect->colour = colour;
+		effect->UpdateVirtCoord();
+	}
+	return CommandCost();
+}
+
+/**
+ * Remove a GameScript text effect.
+ * @param flags Operation to perform.
+ * @param effect_id Stable ID of the text effect.
+ * @return The cost of this operation or an error.
+ */
+CommandCost CmdRemoveTextEffect(DoCommandFlags flags, ScriptTextEffectID effect_id)
+{
+	if (effect_id == INVALID_SCRIPT_TEXT_EFFECT_ID) return CMD_ERROR;
+	if (!ScriptTextEffectData::IsValidID(effect_id)) return CMD_ERROR;
+
+	if (flags.Test(DoCommandFlag::Execute)) delete ScriptTextEffectData::Get(effect_id);
+	return CommandCost();
+}

--- a/src/texteff_cmd.h
+++ b/src/texteff_cmd.h
@@ -1,0 +1,24 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file texteff_cmd.h Command declarations for text effects */
+
+#ifndef TEXTEFF_CMD_H
+#define TEXTEFF_CMD_H
+
+#include "command_type.h"
+#include "texteff.hpp"
+
+std::tuple<CommandCost, TextEffectID> CmdCreateTextEffect(DoCommandFlags flags, int32_t x, int32_t y, TextEffectMode mode, const EncodedString &text);
+CommandCost CmdUpdateTextEffect(DoCommandFlags flags, TextEffectID te_id, const EncodedString &text);
+CommandCost CmdRemoveTextEffect(DoCommandFlags flags, TextEffectID te_id);
+
+DEF_CMD_TRAIT(CMD_CREATE_TEXT_EFFECT, CmdCreateTextEffect, CommandFlags({CommandFlag::Deity, CommandFlag::StrCtrl}), CMDT_OTHER_MANAGEMENT)
+DEF_CMD_TRAIT(CMD_UPDATE_TEXT_EFFECT, CmdUpdateTextEffect, CommandFlags({CommandFlag::Deity, CommandFlag::StrCtrl}), CMDT_OTHER_MANAGEMENT)
+DEF_CMD_TRAIT(CMD_REMOVE_TEXT_EFFECT, CmdRemoveTextEffect, CommandFlag::Deity, CMDT_OTHER_MANAGEMENT)
+
+#endif /* TEXTEFF_CMD_H */

--- a/src/texteff_cmd.h
+++ b/src/texteff_cmd.h
@@ -1,0 +1,24 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file texteff_cmd.h Command declarations for text effects. */
+
+#ifndef TEXTEFF_CMD_H
+#define TEXTEFF_CMD_H
+
+#include "command_type.h"
+#include "texteff.hpp"
+
+std::tuple<CommandCost, ScriptTextEffectID> CmdCreateTextEffect(DoCommandFlags flags, int32_t x, int32_t y, TextEffectMode mode, Colours colour, const EncodedString &text);
+CommandCost CmdUpdateTextEffect(DoCommandFlags flags, ScriptTextEffectID effect_id, Colours colour, const EncodedString &text);
+CommandCost CmdRemoveTextEffect(DoCommandFlags flags, ScriptTextEffectID effect_id);
+
+DEF_CMD_TRAIT(Commands::CreateTextEffect, CmdCreateTextEffect, CommandFlags({CommandFlag::Deity, CommandFlag::StrCtrl}), CommandType::OtherManagement)
+DEF_CMD_TRAIT(Commands::UpdateTextEffect, CmdUpdateTextEffect, CommandFlags({CommandFlag::Deity, CommandFlag::StrCtrl}), CommandType::OtherManagement)
+DEF_CMD_TRAIT(Commands::RemoveTextEffect, CmdRemoveTextEffect, CommandFlag::Deity, CommandType::OtherManagement)
+
+#endif /* TEXTEFF_CMD_H */


### PR DESCRIPTION
## Motivation / Problem

Motivation to develop this feature is adding more features which could be used in multiplayer by Game Scripts. This will be very similar to how income from eg. trains shows on the map.

![Screenshot_1586](https://github.com/OpenTTD/OpenTTD/assets/13676368/7957a93f-7f6d-4005-b481-95d3ff1bc543)

## Description

This PR adds `SpawnAnimatedText` method to `GSTile` class. This could be useful in games which use some kind of scenarios or game scripts to indicate of changes, eg. in city builder mode it could indicate increase in population.

## Limitations

**Last time I coded in C++ was 12 years ago**. 

So any help and advices would be appreciated. I would like this to take full advantage of `GSText` with colors, but I'm stuck. I'm not sure how to work with `string`/`StringID`. As I understand GS will execute command with string which will be converted from `GSText`. However I don't know how to actually display it since method responsible for showing income `ShowCostOrIncomeAnimation` (which functionality I base on) uses `StringID`.