### PR TITLE
Change: Don't handle 'missing' string parameters as 0.

### DIFF
--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -95,7 +95,7 @@ public:
 	T GetNextParameter()
 	{
 		auto ptr = GetNextParameterPointer();
-		return static_cast<T>(ptr == nullptr ? 0 : ptr->data);
+		return static_cast<T>(ptr->data);
 	}
 
 	/**
@@ -107,7 +107,6 @@ public:
 	const char *GetNextParameterString()
 	{
 		auto ptr = GetNextParameterPointer();
-		if (ptr == nullptr) return nullptr;
 		return ptr->string != nullptr ? ptr->string->c_str() : ptr->string_view;
 	}
 


### PR DESCRIPTION
## Motivation / Problem

If not enough parameters are supplied for a string, then a value of 0 was used, which could result in incorrect information being displayed.

Players may not notice there is an issue.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/3300f520-c789-49d8-a30d-f39572dc6170)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, throw an exception and include an error in the string. This is non-translatable, like existing string error messages.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/fcb54824-f4eb-449c-8e5b-5803cc9c5e0d)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This is not intended as a fix for GSText compatibility, that is another issue :)

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
