### PR TITLE
Codechange: Build station and depot vehicle lists from shared order lists.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -510,6 +510,7 @@ add_files(
     vehiclelist.cpp
     vehiclelist.h
     vehiclelist_cmd.h
+    vehiclelist_func.h
     viewport.cpp
     viewport_cmd.h
     viewport_func.h

--- a/src/vehiclelist.cpp
+++ b/src/vehiclelist.cpp
@@ -10,6 +10,7 @@
 #include "stdafx.h"
 #include "train.h"
 #include "vehiclelist.h"
+#include "vehiclelist_func.h"
 #include "group.h"
 
 #include "safeguards.h"
@@ -116,17 +117,11 @@ bool GenerateVehicleSortList(VehicleList *list, const VehicleListIdentifier &vli
 
 	switch (vli.type) {
 		case VL_STATION_LIST:
-			for (const Vehicle *v : Vehicle::Iterate()) {
-				if (v->type == vli.vtype && v->IsPrimaryVehicle()) {
-					for (const Order *order : v->Orders()) {
-						if ((order->IsType(OT_GOTO_STATION) || order->IsType(OT_GOTO_WAYPOINT) || order->IsType(OT_IMPLICIT))
-								&& order->GetDestination() == vli.index) {
-							list->push_back(v);
-							break;
-						}
-					}
-				}
-			}
+			FindVehiclesWithOrder(
+				[&vli](const Vehicle *v) { return v->type == vli.vtype; },
+				[&vli](const Order *order) { return (order->IsType(OT_GOTO_STATION) || order->IsType(OT_GOTO_WAYPOINT) || order->IsType(OT_IMPLICIT)) && order->GetDestination() == vli.index; },
+				[&list](const Vehicle *v) { list->push_back(v); }
+			);
 			break;
 
 		case VL_SHARED_ORDERS: {
@@ -161,16 +156,11 @@ bool GenerateVehicleSortList(VehicleList *list, const VehicleListIdentifier &vli
 			break;
 
 		case VL_DEPOT_LIST:
-			for (const Vehicle *v : Vehicle::Iterate()) {
-				if (v->type == vli.vtype && v->IsPrimaryVehicle()) {
-					for (const Order *order : v->Orders()) {
-						if (order->IsType(OT_GOTO_DEPOT) && !(order->GetDepotActionType() & ODATFB_NEAREST_DEPOT) && order->GetDestination() == vli.index) {
-							list->push_back(v);
-							break;
-						}
-					}
-				}
-			}
+			FindVehiclesWithOrder(
+				[&vli](const Vehicle *v) { return v->type == vli.vtype; },
+				[&vli](const Order *order) { return order->IsType(OT_GOTO_DEPOT) && !(order->GetDepotActionType() & ODATFB_NEAREST_DEPOT) && order->GetDestination() == vli.index; },
+				[&list](const Vehicle *v) { list->push_back(v); }
+			);
 			break;
 
 		default: return false;

--- a/src/vehiclelist_func.h
+++ b/src/vehiclelist_func.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file vehiclelist_func.h Functions and type for generating vehicle lists. */
+
+#ifndef VEHICLELIST_FUNC_H
+#define VEHICLELIST_FUNC_H
+
+#include "order_base.h"
+#include "vehicle_base.h"
+
+/**
+ * Find vehicles matching an order.
+ * This can be used, e.g. to find all vehicles that stop at a particular station.
+ * @param veh_pred Vehicle selection predicate. This is called only for the first vehicle using the order list.
+ * @param ord_pred Order selection predicate.
+ * @param veh_func Called for each vehicle that matches both vehicle and order predicates.
+ **/
+template <class VehiclePredicate, class OrderPredicate, class VehicleFunc>
+void FindVehiclesWithOrder(VehiclePredicate veh_pred, OrderPredicate ord_pred, VehicleFunc veh_func)
+{
+	for (const OrderList *orderlist : OrderList::Iterate()) {
+
+		/* We assume all vehicles sharing an order list match the condition. */
+		const Vehicle *v = orderlist->GetFirstSharedVehicle();
+		if (!veh_pred(v)) continue;
+
+		/* Vehicle is a candidate, search for a matching order. */
+		for (const Order *order = orderlist->GetFirstOrder(); order != nullptr; order = order->next) {
+
+			if (!ord_pred(order)) continue;
+
+			/* An order matches, we can add all shared vehicles to the list. */
+			for (; v != nullptr; v = v->NextShared()) {
+				veh_func(v);
+			}
+			break;
+		}
+	}
+}
+
+#endif /* VEHICLELIST_FUNC_H */


### PR DESCRIPTION
## Motivation / Problem

When building lists of vehicles from stations and depots, we iterate all vehicles, filter to find suitable vehicles, and then check each other to see if it matches the station/depot we're listing.

This is a bit bruteforce, and means for shared orders, we are checking order lists multiple times.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, build station and depot vehicle lists from shared order lists.

This brings some performance advantages:

* No need to iterate all vehicles and check for primary vehicle as only vehicles that can have orders are listed.
* Orders shared by vehicles only need to be tested once instead of for each vehicle sharing them.
* Vehicle tests only need to be performed on the first shared vehicle instead of all.

Stats from Xarick's corona test game:

| version | AI station |
| ------ | ------- |
| master | avg 3600µs | 
| this PR | avg 1200µs | 

Stats from Wentbourne:

| version | VLI station list | VLI depot list |
| -------- | -------- | ------- |
| master | avg 2100µs | avg 2000µs |
| this PR | avg 350µs | avg 350µs |
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This is reasonable improvement, and only uses data that we already have.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
