### PR TITLE
Doc: indicate a bit better that mass-change PRs for translations are possible

### DIFF
--- a/docs/eints.md
+++ b/docs/eints.md
@@ -25,6 +25,10 @@ The translators will decide whether, where and how to apply your suggestion.
 
 Sorry, we don't offer this option.
 
+Only when there is a consistency problem that needs addressing, this can be done via a PR.
+We are very strict about this, and in general all PRs making translation changes will be closed.
+But if it is really needed, and the change is not a revert of any older change, a PR can be created to do mass changes to a translation.
+
 ### I want to change the language definition (plural form, genders, cases) of a translation.
 
 Please [create an issue](https://github.com/OpenTTD/OpenTTD/issues/new/choose) for this.


### PR DESCRIPTION
## Motivation / Problem

The eints documentation is very strong and unambiguous that PRs for translations are not allowed. But in reality, see #11665, they kinda are.

## Description

Be more verbose under what situations it is allowed. More meant to make sure we developers know we can. As nobody knew. Except @frosch123 ofc :)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
