### PR TITLE
Fix: Original graphics' tycoon-of-the-century sprite assumes a black background.

### DIFF
--- a/src/highscore_gui.cpp
+++ b/src/highscore_gui.cpp
@@ -52,7 +52,12 @@ struct EndGameHighScoreBaseWindow : Window {
 		/* Standard background slices are 50 pixels high, but it's designed
 		 * for 480 pixels total. 96% of 500 is 480. */
 		Dimension dim = GetSpriteSize(this->background_img);
-		Point pt = this->GetTopLeft(dim.width, dim.height * 96 / 10);
+		auto total_height = dim.height * 96 / 10;
+		Point pt = this->GetTopLeft(dim.width, total_height);
+
+		/* Original graphics contain some transparency, which assumes a black background. */
+		GfxFillRect(pt.x, pt.y, pt.x + dim.width - 1, pt.y + total_height - 1, PC_BLACK);
+
 		/* Center Highscore/Endscreen background */
 		for (uint i = 0; i < 10; i++) { // the image is split into 10 50px high parts
 			DrawSprite(this->background_img + i, PAL_NONE, pt.x, pt.y + (i * dim.height));


### PR DESCRIPTION
## Motivation / Problem

![image](https://github.com/OpenTTD/OpenTTD/assets/23150643/2cf729e2-ebe8-42c5-abe1-d97729905321)


## Description

The tycoon-of-the-century sprite is shown in year 2051, if the player reached the maximum score.
* Originally this sprite was drawn in full-screen on 640x480 pixels.
* OpenTTD draws the sprite centered and with a brown background.
* In the original graphics the sprite contains a lot of transparency (colour 0).
* This PR draws a black background behind the sprite for the transparent parts, but keeps the screen-filling brown.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
