### PR TITLE
Fix: HTTP thread exit when using libcurl

### DIFF
--- a/src/network/core/http_curl.cpp
+++ b/src/network/core/http_curl.cpp
@@ -276,8 +276,6 @@ void NetworkHTTPInitialize()
 
 void NetworkHTTPUninitialize()
 {
-	curl_global_cleanup();
-
 	_http_thread_exit = true;
 
 	/* Queues must be cleared (and the queue CV signalled) after _http_thread_exit is set to ensure that the HTTP thread can exit */
@@ -293,4 +291,6 @@ void NetworkHTTPUninitialize()
 	if (_http_thread.joinable()) {
 		_http_thread.join();
 	}
+
+	curl_global_cleanup();
 }


### PR DESCRIPTION
## Motivation / Problem

If the libcurl HTTP thread queued anything between the last dequeue in the game thread, and NetworkHTTPUninitialize, it would deadlock.

## Description

In NetworkHTTPUninitialize clear the queues from the HTTP thread (signalling the CVs) after setting the exit flag. In the thread check the exit flag together with the queue state (whilst holding the lock).

Also fix curl_global_cleanup being called before use of libcurl was completed.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
