### PR TITLE
Allow STRING/STRINGN parameter subspans to read all remaining available parameters in GS mode

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1140,6 +1140,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 				} else {
 					StringParameters sub_args(args, size);
 					GetStringWithArgs(builder, string_id, sub_args, next_substr_case_index, game_script);
+					args.AdvanceOffset(size);
 				}
 				next_substr_case_index = 0;
 				break;

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1118,7 +1118,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 				StringID string_id = args.GetNextParameter<StringID>();
 				if (game_script && GetStringTab(string_id) != TEXT_TAB_GAMESCRIPT_START) break;
 				/* It's prohibited for the included string to consume any arguments. */
-				StringParameters tmp_params(args, 0);
+				StringParameters tmp_params(args, game_script ? args.GetDataLeft() : 0);
 				GetStringWithArgs(builder, string_id, tmp_params, next_substr_case_index, game_script);
 				next_substr_case_index = 0;
 				break;
@@ -1138,7 +1138,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 				if (game_script && size > args.GetDataLeft()) {
 					builder += "(too many parameters)";
 				} else {
-					StringParameters sub_args(args, size);
+					StringParameters sub_args(args, game_script ? args.GetDataLeft() : size);
 					GetStringWithArgs(builder, string_id, sub_args, next_substr_case_index, game_script);
 					args.AdvanceOffset(size);
 				}

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -39,19 +39,12 @@ protected:
 public:
 	/**
 	 * Create a new StringParameters instance that can reference part of the data of
-	 * the given partent instance.
+	 * the given parent instance.
 	 */
 	StringParameters(StringParameters &parent, size_t size) :
 		parent(&parent),
 		parameters(parent.parameters.subspan(parent.offset, size))
 	{}
-
-	~StringParameters()
-	{
-		if (this->parent != nullptr) {
-			this->parent->offset += this->parameters.size();
-		}
-	}
 
 	void PrepareForNextRun();
 	void SetTypeOfNextParameter(char32_t type) { this->next_type = type; }
@@ -79,6 +72,17 @@ public:
 		 */
 		assert(offset < this->parameters.size() || this->offset == offset);
 		this->offset = offset;
+	}
+
+	/**
+	 * Advance the offset within the string from where to return the next result of
+	 * \c GetInt64 or \c GetInt32.
+	 * @param advance The amount to advance the offset by.
+	 */
+	void AdvanceOffset(size_t advance)
+	{
+		this->offset += advance;
+		assert(this->offset <= this->parameters.size());
 	}
 
 	/**


### PR DESCRIPTION
## Motivation / Problem

Allow GS/AI STRING/STRINGN parameter subspans to read all remaining available parameters, to be compatible with all existing (pre-14.0) GS/AI scripts.

See also: #11673.

## Description

No longer advance parent offset in StringParameters parent mode.
Add method to advance offset.
Allow STRING/STRINGN to use all remaining parameters in game script mode.

## Limitations

This will conflict with #11673, so can be rebased on top once that is done.
Other changes to be done separately.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
