### PR TITLE
Codechange: Use locals for company/deity mode during loops.

### DIFF
--- a/src/script/api/script_depotlist.cpp
+++ b/src/script/api/script_depotlist.cpp
@@ -27,8 +27,10 @@ ScriptDepotList::ScriptDepotList(ScriptTile::TransportType transport_type)
 
 		case ScriptTile::TRANSPORT_AIR: {
 			/* Hangars are not seen as real depots by the depot code. */
+			bool is_deity = ScriptCompanyMode::IsDeity();
+			CompanyID owner = ScriptObject::GetCompany();
 			for (const Station *st : Station::Iterate()) {
-				if (st->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity()) {
+				if (is_deity || st->owner == owner) {
 					for (uint i = 0; i < st->airport.GetNumHangars(); i++) {
 						this->AddItem(st->airport.GetHangarTile(i).base());
 					}
@@ -39,7 +41,9 @@ ScriptDepotList::ScriptDepotList(ScriptTile::TransportType transport_type)
 	}
 
 	/* Handle 'standard' depots. */
+	bool is_deity = ScriptCompanyMode::IsDeity();
+	CompanyID owner = ScriptObject::GetCompany();
 	for (const Depot *depot : Depot::Iterate()) {
-		if ((::GetTileOwner(depot->xy) == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity()) && ::IsTileType(depot->xy, tile_type)) this->AddItem(depot->xy.base());
+		if ((is_deity || ::GetTileOwner(depot->xy) == owner) && ::IsTileType(depot->xy, tile_type)) this->AddItem(depot->xy.base());
 	}
 }

--- a/src/script/api/script_enginelist.cpp
+++ b/src/script/api/script_enginelist.cpp
@@ -16,7 +16,9 @@
 ScriptEngineList::ScriptEngineList(ScriptVehicle::VehicleType vehicle_type)
 {
 	EnforceDeityOrCompanyModeValid_Void();
+	bool is_deity = ScriptCompanyMode::IsDeity();
+	CompanyID owner = ScriptObject::GetCompany();
 	for (const Engine *e : Engine::IterateType((::VehicleType)vehicle_type)) {
-		if (ScriptCompanyMode::IsDeity() || HasBit(e->company_avail, ScriptObject::GetCompany())) this->AddItem(e->index);
+		if (is_deity || HasBit(e->company_avail, owner)) this->AddItem(e->index);
 	}
 }

--- a/src/script/api/script_grouplist.cpp
+++ b/src/script/api/script_grouplist.cpp
@@ -17,7 +17,8 @@
 ScriptGroupList::ScriptGroupList()
 {
 	EnforceCompanyModeValid_Void();
+	CompanyID owner = ScriptObject::GetCompany();
 	for (const Group *g : Group::Iterate()) {
-		if (g->owner == ScriptObject::GetCompany()) this->AddItem(g->index);
+		if (g->owner == owner) this->AddItem(g->index);
 	}
 }

--- a/src/script/api/script_railtypelist.cpp
+++ b/src/script/api/script_railtypelist.cpp
@@ -17,7 +17,9 @@
 ScriptRailTypeList::ScriptRailTypeList()
 {
 	EnforceDeityOrCompanyModeValid_Void();
+	bool is_deity = ScriptCompanyMode::IsDeity();
+	CompanyID owner = ScriptObject::GetCompany();
 	for (RailType rt = RAILTYPE_BEGIN; rt != RAILTYPE_END; rt++) {
-		if (ScriptCompanyMode::IsDeity() || ::HasRailTypeAvail(ScriptObject::GetCompany(), rt)) this->AddItem(rt);
+		if (is_deity || ::HasRailTypeAvail(owner, rt)) this->AddItem(rt);
 	}
 }

--- a/src/script/api/script_roadtypelist.cpp
+++ b/src/script/api/script_roadtypelist.cpp
@@ -16,8 +16,9 @@
 ScriptRoadTypeList::ScriptRoadTypeList(ScriptRoad::RoadTramTypes rtts)
 {
 	EnforceDeityOrCompanyModeValid_Void();
+	CompanyID owner = ScriptObject::GetCompany();
 	for (RoadType rt = ROADTYPE_BEGIN; rt != ROADTYPE_END; rt++) {
 		if (!HasBit(rtts, GetRoadTramType(rt))) continue;
-		if (::HasRoadTypeAvail(ScriptObject::GetCompany(), rt)) this->AddItem(rt);
+		if (::HasRoadTypeAvail(owner, rt)) this->AddItem(rt);
 	}
 }

--- a/src/script/api/script_stationlist.cpp
+++ b/src/script/api/script_stationlist.cpp
@@ -19,8 +19,10 @@
 ScriptStationList::ScriptStationList(ScriptStation::StationType station_type)
 {
 	EnforceDeityOrCompanyModeValid_Void();
+	bool is_deity = ScriptCompanyMode::IsDeity();
+	CompanyID owner = ScriptObject::GetCompany();
 	for (Station *st : Station::Iterate()) {
-		if ((st->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity()) && (st->facilities & station_type) != 0) this->AddItem(st->index);
+		if ((is_deity || st->owner == owner) && (st->facilities & station_type) != 0) this->AddItem(st->index);
 	}
 }
 

--- a/src/script/api/script_vehiclelist.cpp
+++ b/src/script/api/script_vehiclelist.cpp
@@ -51,8 +51,10 @@ ScriptVehicleList::ScriptVehicleList(HSQUIRRELVM vm)
 	}
 	AutoRestoreBackup ops_error_threshold_backup(vm->_ops_till_suspend_error_threshold, new_ops_error_threshold);
 
+	bool is_deity = ScriptCompanyMode::IsDeity();
+	CompanyID owner = ScriptObject::GetCompany();
 	for (const Vehicle *v : Vehicle::Iterate()) {
-		if (v->owner != ScriptObject::GetCompany() && !ScriptCompanyMode::IsDeity()) continue;
+		if (v->owner != owner && !is_deity) continue;
 		if (!v->IsPrimaryVehicle() && !(v->type == VEH_TRAIN && ::Train::From(v)->IsFreeWagon())) continue;
 
 		if (nparam < 1) {
@@ -107,8 +109,10 @@ ScriptVehicleList_Station::ScriptVehicleList_Station(StationID station_id)
 	EnforceDeityOrCompanyModeValid_Void();
 	if (!ScriptBaseStation::IsValidBaseStation(station_id)) return;
 
+	bool is_deity = ScriptCompanyMode::IsDeity();
+	CompanyID owner = ScriptObject::GetCompany();
 	for (const Vehicle *v : Vehicle::Iterate()) {
-		if ((v->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity()) && v->IsPrimaryVehicle()) {
+		if ((v->owner == owner || is_deity) && v->IsPrimaryVehicle()) {
 			for (const Order *order : v->Orders()) {
 				if ((order->IsType(OT_GOTO_STATION) || order->IsType(OT_GOTO_WAYPOINT)) && order->GetDestination() == station_id) {
 					this->AddItem(v->index);
@@ -156,8 +160,10 @@ ScriptVehicleList_Depot::ScriptVehicleList_Depot(TileIndex tile)
 			return;
 	}
 
+	bool is_deity = ScriptCompanyMode::IsDeity();
+	CompanyID owner = ScriptObject::GetCompany();
 	for (const Vehicle *v : Vehicle::Iterate()) {
-		if ((v->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity()) && v->IsPrimaryVehicle() && v->type == type) {
+		if ((v->owner == owner || is_deity) && v->IsPrimaryVehicle() && v->type == type) {
 			for (const Order *order : v->Orders()) {
 				if (order->IsType(OT_GOTO_DEPOT) && order->GetDestination() == dest) {
 					this->AddItem(v->index);
@@ -182,8 +188,9 @@ ScriptVehicleList_Group::ScriptVehicleList_Group(GroupID group_id)
 	EnforceCompanyModeValid_Void();
 	if (!ScriptGroup::IsValidGroup((ScriptGroup::GroupID)group_id)) return;
 
+	CompanyID owner = ScriptObject::GetCompany();
 	for (const Vehicle *v : Vehicle::Iterate()) {
-		if (v->owner == ScriptObject::GetCompany() && v->IsPrimaryVehicle()) {
+		if (v->owner == owner && v->IsPrimaryVehicle()) {
 			if (v->group_id == group_id) this->AddItem(v->index);
 		}
 	}
@@ -194,8 +201,9 @@ ScriptVehicleList_DefaultGroup::ScriptVehicleList_DefaultGroup(ScriptVehicle::Ve
 	EnforceCompanyModeValid_Void();
 	if (vehicle_type < ScriptVehicle::VT_RAIL || vehicle_type > ScriptVehicle::VT_AIR) return;
 
+	CompanyID owner = ScriptObject::GetCompany();
 	for (const Vehicle *v : Vehicle::Iterate()) {
-		if (v->owner == ScriptObject::GetCompany() && v->IsPrimaryVehicle()) {
+		if (v->owner == owner && v->IsPrimaryVehicle()) {
 			if (v->type == (::VehicleType)vehicle_type && v->group_id == ScriptGroup::GROUP_DEFAULT) this->AddItem(v->index);
 		}
 	}


### PR DESCRIPTION
## Motivation / Problem

Script methods that build lists with ownership checks call `ScriptObject::GetCompany()` and/or `ScriptCopmanyMode::IsDeity()` for every iteration.

While individually these are not very expensive, the cost adds up.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, store the value of these calls in local variables before iterating the loops. This gives a reasonable benefit with large games and heavy scripts, though of course in practice results vary.

This is the result using Xarick's corona gs save from #10548:

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/4280f27b-918d-4dae-a8fb-524d23a0f9a2)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This is related to but conflicts with #11676. I'm made this a separate PR as it has wider scope and the changes are a bit more straightforward.


<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
