### PR TITLE
Fix: don't unneededly block on transmitting survey on exit

### DIFF
--- a/src/network/network_survey.h
+++ b/src/network/network_survey.h
@@ -41,7 +41,8 @@ public:
 
 private:
 	std::mutex mutex; ///< Mutex for the condition variable.
-	std::condition_variable loaded; ///< Condition variable to wait for the survey to be sent.
+	std::atomic<bool> transmitted; ///< Whether the survey has been transmitted.
+	std::condition_variable transmitted_cv; ///< Condition variable to inform changes to transmitted.
 };
 
 extern NetworkSurveyHandler _survey;


### PR DESCRIPTION
## Motivation / Problem

The game always has a 2 second delay when exiting, because the survey is sending (and the result is not being polled).

## Description

On sending a blocking survey, keep running the network background thread. As since #11639 this isn't done in the curl-thread anymore, so we need to pump the async callbacks for new data.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
