### PR TITLE
Fix: race-condition when quitting the game with libcurl

### DIFF
--- a/src/network/core/http_curl.cpp
+++ b/src/network/core/http_curl.cpp
@@ -278,10 +278,9 @@ void NetworkHTTPUninitialize()
 {
 	_http_thread_exit = true;
 
-	/* Queues must be cleared (and the queue CV signalled) after _http_thread_exit is set to ensure that the HTTP thread can exit */
-	for (auto &callback : _http_callbacks) {
-		callback->ClearQueue();
-	}
+	/* Ensure the callbacks are handled. This is mostly needed as we send
+	 * a survey just before close, and that might be pending here. */
+	NetworkHTTPSocketHandler::HTTPReceive();
 
 	{
 		std::lock_guard<std::mutex> lock(_http_mutex);

--- a/src/network/core/http_shared.h
+++ b/src/network/core/http_shared.h
@@ -97,20 +97,6 @@ public:
 		return this->queue.empty();
 	}
 
-
-	/**
-	 * Clear everything in the queue.
-	 *
-	 * Should be called from the Game Thread.
-	 */
-	void ClearQueue()
-	{
-		std::lock_guard<std::mutex> lock(this->mutex);
-
-		this->queue.clear();
-		this->queue_cv.notify_all();
-	}
-
 	HTTPThreadSafeCallback(HTTPCallback *callback) : callback(callback) {}
 
 	~HTTPThreadSafeCallback()


### PR DESCRIPTION
## Motivation / Problem

There could be a callback in `_new_http_callbacks` that is not processed yet. All callbacks in `_http_callbacks` were cancelled, but not the ones in `_new_http_callbacks`

## Description

Instead, call `HTTPReceive` to clean up all current callbacks. `_http_thread_exit` ensures no new callback results can be blocking.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
