### PR TITLE
Codechange: Get count of road vehicles by summing company group statistics data in small UFO handler.

### DIFF
--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -334,8 +334,8 @@ static bool DisasterTick_Ufo(DisasterVehicle *v)
 		v->state = 1;
 
 		uint n = 0; // Total number of targetable road vehicles.
-		for (const RoadVehicle *u : RoadVehicle::Iterate()) {
-			if (u->IsFrontEngine()) n++;
+		for (const Company *c : Company::Iterate()) {
+			n += c->group_all[VEH_ROAD].num_vehicle;
 		}
 
 		if (n == 0) {


### PR DESCRIPTION
## Motivation / Problem

In the small UFO tick handler, a loop is used to count every (front) road vehicle. This data is already available as a per-vehicle type count in company group statistics.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, get count of road vehicles by summing company group statistics data.

This avoids needing to iterate the complete vehicle pool. Company group statistics are maintained elsewhere already.

The vehicle pool is still iterated later to find the nth random road vehicle.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This code path is hardly ever followed so this is not going to have any real effect, but at least the change is simple enough...

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
