### PR TITLE
Codechange: Use company group statistics to test for vehicles for drop down list state.

### DIFF
--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -145,9 +145,9 @@ static const int CTMN_SPECTATOR   = -3; ///< Show a company window as spectator
  * Pop up a generic company list menu.
  * @param w The toolbar window.
  * @param widget The button widget id.
- * @param grey A bitbask of which items to mark as disabled.
+ * @param grey A bitmask of which companies to mark as disabled.
  */
-static void PopupMainCompanyToolbMenu(Window *w, WidgetID widget, int grey = 0)
+static void PopupMainCompanyToolbMenu(Window *w, WidgetID widget, CompanyMask grey = 0)
 {
 	DropDownList list;
 
@@ -728,7 +728,7 @@ static CallBackFunction MenuClickIndustry(int index)
 
 static void ToolbarVehicleClick(Window *w, VehicleType veh)
 {
-	int dis = 0;
+	CompanyMask dis = 0;
 
 	for (const Company *c : Company::Iterate()) {
 		if (c->group_all[veh].num_vehicle == 0) SetBit(dis, c->index);

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -728,10 +728,10 @@ static CallBackFunction MenuClickIndustry(int index)
 
 static void ToolbarVehicleClick(Window *w, VehicleType veh)
 {
-	int dis = ~0;
+	int dis = 0;
 
-	for (const Vehicle *v : Vehicle::Iterate()) {
-		if (v->type == veh && v->IsPrimaryVehicle()) ClrBit(dis, v->owner);
+	for (const Company *c : Company::Iterate()) {
+		if (c->group_all[veh].num_vehicle == 0) SetBit(dis, c->index);
 	}
 	PopupMainCompanyToolbMenu(w, WID_TN_VEHICLE_START + veh, dis);
 }


### PR DESCRIPTION
## Motivation / Problem

When clicking on Train, Road Vehicle, Ship or Aircraft toolbar buttons, the game checks if each company has vehicles of the type to  display as black (has vehicles) or grey (has no vehicles).

This involves... iterating the whole vehicle pool.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Company group statistics already has this information per vehicle, so use this instead.

This avoids iterating full the vehicle pool to find out if a company has any vehicles of a particular type.


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This is unlikely to be noticeable in practice, and it is clutching at straws to be honest, but it is at least a fairly simple change?

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
