### PR TITLE
Codechange: replace static inline with static for non-class functions

### DIFF
--- a/src/3rdparty/squirrel/include/squirrel.h
+++ b/src/3rdparty/squirrel/include/squirrel.h
@@ -238,7 +238,7 @@ void sq_newclosure(HSQUIRRELVM v,SQFUNCTION func,SQUnsignedInteger nfreevars);
 SQRESULT sq_setparamscheck(HSQUIRRELVM v,SQInteger nparamscheck,const SQChar *typemask);
 SQRESULT sq_bindenv(HSQUIRRELVM v,SQInteger idx);
 void sq_pushstring(HSQUIRRELVM v,const SQChar *s,SQInteger len);
-static inline void sq_pushstring(HSQUIRRELVM v, const std::string &str, SQInteger len = -1) { sq_pushstring(v, str.data(), len == -1 ? str.size() : len); }
+inline void sq_pushstring(HSQUIRRELVM v, const std::string &str, SQInteger len = -1) { sq_pushstring(v, str.data(), len == -1 ? str.size() : len); }
 void sq_pushfloat(HSQUIRRELVM v,SQFloat f);
 void sq_pushinteger(HSQUIRRELVM v,SQInteger n);
 void sq_pushbool(HSQUIRRELVM v,SQBool b);
@@ -308,7 +308,7 @@ SQRESULT sq_resume(HSQUIRRELVM v,SQBool retval,SQBool raiseerror);
 const SQChar *sq_getlocal(HSQUIRRELVM v,SQUnsignedInteger level,SQUnsignedInteger idx);
 const SQChar *sq_getfreevariable(HSQUIRRELVM v,SQInteger idx,SQUnsignedInteger nval);
 SQRESULT sq_throwerror(HSQUIRRELVM v,const SQChar *err, SQInteger len = -1);
-static inline SQRESULT sq_throwerror(HSQUIRRELVM v, const std::string_view err) { return sq_throwerror(v, err.data(), err.size()); }
+inline SQRESULT sq_throwerror(HSQUIRRELVM v, const std::string_view err) { return sq_throwerror(v, err.data(), err.size()); }
 void sq_reseterror(HSQUIRRELVM v);
 void sq_getlasterror(HSQUIRRELVM v);
 

--- a/src/autoreplace_func.h
+++ b/src/autoreplace_func.h
@@ -22,7 +22,7 @@ CommandCost RemoveEngineReplacement(EngineRenewList *erl, EngineID engine, Group
  * Remove all engine replacement settings for the given company.
  * @param c the company.
  */
-static inline void RemoveAllEngineReplacementForCompany(Company *c)
+inline void RemoveAllEngineReplacementForCompany(Company *c)
 {
 	RemoveAllEngineReplacement(&c->engine_renew_list);
 }
@@ -36,7 +36,7 @@ static inline void RemoveAllEngineReplacementForCompany(Company *c)
  * @return The engine type to replace with, or INVALID_ENGINE if no
  * replacement is in the list.
  */
-static inline EngineID EngineReplacementForCompany(const Company *c, EngineID engine, GroupID group, bool *replace_when_old = nullptr)
+inline EngineID EngineReplacementForCompany(const Company *c, EngineID engine, GroupID group, bool *replace_when_old = nullptr)
 {
 	return EngineReplacement(c->engine_renew_list, engine, group, replace_when_old);
 }
@@ -48,7 +48,7 @@ static inline EngineID EngineReplacementForCompany(const Company *c, EngineID en
  * @param group The group related to this replacement.
  * @return true if a replacement was set up, false otherwise.
  */
-static inline bool EngineHasReplacementForCompany(const Company *c, EngineID engine, GroupID group)
+inline bool EngineHasReplacementForCompany(const Company *c, EngineID engine, GroupID group)
 {
 	return EngineReplacementForCompany(c, engine, group) != INVALID_ENGINE;
 }
@@ -60,7 +60,7 @@ static inline bool EngineHasReplacementForCompany(const Company *c, EngineID eng
  * @param group The group related to this replacement.
  * @return True if a replacement when old was set up, false otherwise.
  */
-static inline bool EngineHasReplacementWhenOldForCompany(const Company *c, EngineID engine, GroupID group)
+inline bool EngineHasReplacementWhenOldForCompany(const Company *c, EngineID engine, GroupID group)
 {
 	bool replace_when_old;
 	EngineReplacement(c->engine_renew_list, engine, group, &replace_when_old);
@@ -77,7 +77,7 @@ static inline bool EngineHasReplacementWhenOldForCompany(const Company *c, Engin
  * @param flags The calling command flags.
  * @return 0 on success, CMD_ERROR on failure.
  */
-static inline CommandCost AddEngineReplacementForCompany(Company *c, EngineID old_engine, EngineID new_engine, GroupID group, bool replace_when_old, DoCommandFlag flags)
+inline CommandCost AddEngineReplacementForCompany(Company *c, EngineID old_engine, EngineID new_engine, GroupID group, bool replace_when_old, DoCommandFlag flags)
 {
 	return AddEngineReplacement(&c->engine_renew_list, old_engine, new_engine, group, replace_when_old, flags);
 }
@@ -90,7 +90,7 @@ static inline CommandCost AddEngineReplacementForCompany(Company *c, EngineID ol
  * @param flags The calling command flags.
  * @return 0 on success, CMD_ERROR on failure.
  */
-static inline CommandCost RemoveEngineReplacementForCompany(Company *c, EngineID engine, GroupID group, DoCommandFlag flags)
+inline CommandCost RemoveEngineReplacementForCompany(Company *c, EngineID engine, GroupID group, DoCommandFlag flags)
 {
 	return RemoveEngineReplacement(&c->engine_renew_list, engine, group, flags);
 }

--- a/src/autoslope.h
+++ b/src/autoslope.h
@@ -28,7 +28,7 @@
  * @param entrance Entrance edge.
  * @return true iff terraforming is allowed.
  */
-static inline bool AutoslopeCheckForEntranceEdge(TileIndex tile, int z_new, Slope tileh_new, DiagDirection entrance)
+inline bool AutoslopeCheckForEntranceEdge(TileIndex tile, int z_new, Slope tileh_new, DiagDirection entrance)
 {
 	if (GetTileMaxZ(tile) != z_new + GetSlopeMaxZ(tileh_new)) return false;
 	return ((tileh_new == SLOPE_FLAT) || CanBuildDepotByTileh(entrance, tileh_new));
@@ -41,7 +41,7 @@ static inline bool AutoslopeCheckForEntranceEdge(TileIndex tile, int z_new, Slop
  *
  * @return true iff autoslope is enabled.
  */
-static inline bool AutoslopeEnabled()
+inline bool AutoslopeEnabled()
 {
 	return (_settings_game.construction.autoslope &&
 	        (_current_company < MAX_COMPANIES ||

--- a/src/blitter/32bpp_sse_func.hpp
+++ b/src/blitter/32bpp_sse_func.hpp
@@ -13,7 +13,7 @@
 #ifdef WITH_SSE
 
 GNU_TARGET(SSE_TARGET)
-static inline void InsertFirstUint32(const uint32_t value, __m128i &into)
+inline void InsertFirstUint32(const uint32_t value, __m128i &into)
 {
 #if (SSE_VERSION >= 4)
 	into = _mm_insert_epi32(into, value, 0);
@@ -24,7 +24,7 @@ static inline void InsertFirstUint32(const uint32_t value, __m128i &into)
 }
 
 GNU_TARGET(SSE_TARGET)
-static inline void InsertSecondUint32(const uint32_t value, __m128i &into)
+inline void InsertSecondUint32(const uint32_t value, __m128i &into)
 {
 #if (SSE_VERSION >= 4)
 	into = _mm_insert_epi32(into, value, 1);
@@ -35,7 +35,7 @@ static inline void InsertSecondUint32(const uint32_t value, __m128i &into)
 }
 
 GNU_TARGET(SSE_TARGET)
-static inline void LoadUint64(const uint64_t value, __m128i &into)
+inline void LoadUint64(const uint64_t value, __m128i &into)
 {
 #ifdef POINTER_IS_64BIT
 	into = _mm_cvtsi64_si128(value);
@@ -50,7 +50,7 @@ static inline void LoadUint64(const uint64_t value, __m128i &into)
 }
 
 GNU_TARGET(SSE_TARGET)
-static inline __m128i PackUnsaturated(__m128i from, const __m128i &mask)
+inline __m128i PackUnsaturated(__m128i from, const __m128i &mask)
 {
 #if (SSE_VERSION == 2)
 	from = _mm_and_si128(from, mask);    // PAND, wipe high bytes to keep low bytes when packing
@@ -61,7 +61,7 @@ static inline __m128i PackUnsaturated(__m128i from, const __m128i &mask)
 }
 
 GNU_TARGET(SSE_TARGET)
-static inline __m128i DistributeAlpha(const __m128i from, const __m128i &mask)
+inline __m128i DistributeAlpha(const __m128i from, const __m128i &mask)
 {
 #if (SSE_VERSION == 2)
 	__m128i alphaAB = _mm_shufflelo_epi16(from, 0x3F); // PSHUFLW, put alpha1 in front of each rgb1
@@ -73,7 +73,7 @@ static inline __m128i DistributeAlpha(const __m128i from, const __m128i &mask)
 }
 
 GNU_TARGET(SSE_TARGET)
-static inline __m128i AlphaBlendTwoPixels(__m128i src, __m128i dst, const __m128i &distribution_mask, const __m128i &pack_mask, const __m128i &alpha_mask)
+inline __m128i AlphaBlendTwoPixels(__m128i src, __m128i dst, const __m128i &distribution_mask, const __m128i &pack_mask, const __m128i &alpha_mask)
 {
 	__m128i srcAB = _mm_unpacklo_epi8(src, _mm_setzero_si128());   // PUNPCKLBW, expand each uint8_t into uint16
 	__m128i dstAB = _mm_unpacklo_epi8(dst, _mm_setzero_si128());
@@ -97,7 +97,7 @@ static inline __m128i AlphaBlendTwoPixels(__m128i src, __m128i dst, const __m128
  * rgb = rgb * ((256/4) * 4 - (alpha/4)) / ((256/4) * 4)
  */
 GNU_TARGET(SSE_TARGET)
-static inline __m128i DarkenTwoPixels(__m128i src, __m128i dst, const __m128i &distribution_mask, const __m128i &tr_nom_base)
+inline __m128i DarkenTwoPixels(__m128i src, __m128i dst, const __m128i &distribution_mask, const __m128i &tr_nom_base)
 {
 	__m128i srcAB = _mm_unpacklo_epi8(src, _mm_setzero_si128());
 	__m128i dstAB = _mm_unpacklo_epi8(dst, _mm_setzero_si128());
@@ -145,7 +145,7 @@ IGNORE_UNINITIALIZED_WARNING_STOP
 /** ReallyAdjustBrightness() is not called that often.
  * Inlining this function implies a far jump, which has a huge latency.
  */
-static inline Colour AdjustBrightneSSE(Colour colour, uint8_t brightness)
+inline Colour AdjustBrightneSSE(Colour colour, uint8_t brightness)
 {
 	/* Shortcut for normal brightness. */
 	if (brightness == Blitter_32bppBase::DEFAULT_BRIGHTNESS) return colour;
@@ -154,7 +154,7 @@ static inline Colour AdjustBrightneSSE(Colour colour, uint8_t brightness)
 }
 
 GNU_TARGET(SSE_TARGET)
-static inline __m128i AdjustBrightnessOfTwoPixels([[maybe_unused]] __m128i from, [[maybe_unused]] uint32_t brightness)
+inline __m128i AdjustBrightnessOfTwoPixels([[maybe_unused]] __m128i from, [[maybe_unused]] uint32_t brightness)
 {
 #if (SSE_VERSION < 3)
 	NOT_REACHED();

--- a/src/bridge.h
+++ b/src/bridge.h
@@ -63,7 +63,7 @@ bool HasBridgeFlatRamp(Slope tileh, Axis axis);
  * @param i The type of bridge to get the specification for.
  * @return The specification.
  */
-static inline const BridgeSpec *GetBridgeSpec(BridgeType i)
+inline const BridgeSpec *GetBridgeSpec(BridgeType i)
 {
 	assert(i < lengthof(_bridge));
 	return &_bridge[i];

--- a/src/bridge_map.h
+++ b/src/bridge_map.h
@@ -21,7 +21,7 @@
  * @pre IsTileType(t, MP_TUNNELBRIDGE)
  * @return true if the structure is a bridge one
  */
-static inline bool IsBridge(Tile t)
+inline bool IsBridge(Tile t)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
 	return HasBit(t.m5(), 7);
@@ -32,7 +32,7 @@ static inline bool IsBridge(Tile t)
  * @param t The tile to analyze
  * @return true if a bridge is present
  */
-static inline bool IsBridgeTile(Tile t)
+inline bool IsBridgeTile(Tile t)
 {
 	return IsTileType(t, MP_TUNNELBRIDGE) && IsBridge(t);
 }
@@ -42,7 +42,7 @@ static inline bool IsBridgeTile(Tile t)
  * @param t The tile to analyze
  * @return true if a bridge is detected above
  */
-static inline bool IsBridgeAbove(Tile t)
+inline bool IsBridgeAbove(Tile t)
 {
 	return GB(t.type(), 2, 2) != 0;
 }
@@ -53,7 +53,7 @@ static inline bool IsBridgeAbove(Tile t)
  * @pre IsBridgeTile(t)
  * @return The bridge type
  */
-static inline BridgeType GetBridgeType(Tile t)
+inline BridgeType GetBridgeType(Tile t)
 {
 	assert(IsBridgeTile(t));
 	return GB(t.m6(), 2, 4);
@@ -65,7 +65,7 @@ static inline BridgeType GetBridgeType(Tile t)
  * @pre IsBridgeAbove(t)
  * @return the above mentioned axis
  */
-static inline Axis GetBridgeAxis(Tile t)
+inline Axis GetBridgeAxis(Tile t)
 {
 	assert(IsBridgeAbove(t));
 	return (Axis)(GB(t.type(), 2, 2) - 1);
@@ -81,7 +81,7 @@ int GetBridgeHeight(TileIndex tile);
  * @param tile the bridge ramp tile to get the bridge height from
  * @return the height of the bridge in pixels
  */
-static inline int GetBridgePixelHeight(TileIndex tile)
+inline int GetBridgePixelHeight(TileIndex tile)
 {
 	return GetBridgeHeight(tile) * TILE_HEIGHT;
 }
@@ -91,7 +91,7 @@ static inline int GetBridgePixelHeight(TileIndex tile)
  * @param t the tile to remove the bridge from
  * @param a the axis of the bridge to remove
  */
-static inline void ClearSingleBridgeMiddle(Tile t, Axis a)
+inline void ClearSingleBridgeMiddle(Tile t, Axis a)
 {
 	ClrBit(t.type(), 2 + a);
 }
@@ -100,7 +100,7 @@ static inline void ClearSingleBridgeMiddle(Tile t, Axis a)
  * Removes bridges from the given, that is bridges along the X and Y axis.
  * @param t the tile to remove the bridge from
  */
-static inline void ClearBridgeMiddle(Tile t)
+inline void ClearBridgeMiddle(Tile t)
 {
 	ClearSingleBridgeMiddle(t, AXIS_X);
 	ClearSingleBridgeMiddle(t, AXIS_Y);
@@ -111,7 +111,7 @@ static inline void ClearBridgeMiddle(Tile t)
  * @param t the tile to add the bridge to
  * @param a the axis of the bridge to add
  */
-static inline void SetBridgeMiddle(Tile t, Axis a)
+inline void SetBridgeMiddle(Tile t, Axis a)
 {
 	SetBit(t.type(), 2 + a);
 }
@@ -125,7 +125,7 @@ static inline void SetBridgeMiddle(Tile t, Axis a)
  * @param tt         the transport type of the bridge
  * @note this function should not be called directly.
  */
-static inline void MakeBridgeRamp(Tile t, Owner o, BridgeType bridgetype, DiagDirection d, TransportType tt)
+inline void MakeBridgeRamp(Tile t, Owner o, BridgeType bridgetype, DiagDirection d, TransportType tt)
 {
 	SetTileType(t, MP_TUNNELBRIDGE);
 	SetTileOwner(t, o);
@@ -150,7 +150,7 @@ static inline void MakeBridgeRamp(Tile t, Owner o, BridgeType bridgetype, DiagDi
  * @param road_rt    the road type of the bridge
  * @param tram_rt    the tram type of the bridge
  */
-static inline void MakeRoadBridgeRamp(Tile t, Owner o, Owner owner_road, Owner owner_tram, BridgeType bridgetype, DiagDirection d, RoadType road_rt, RoadType tram_rt)
+inline void MakeRoadBridgeRamp(Tile t, Owner o, Owner owner_road, Owner owner_tram, BridgeType bridgetype, DiagDirection d, RoadType road_rt, RoadType tram_rt)
 {
 	MakeBridgeRamp(t, o, bridgetype, d, TRANSPORT_ROAD);
 	SetRoadOwner(t, RTT_ROAD, owner_road);
@@ -166,7 +166,7 @@ static inline void MakeRoadBridgeRamp(Tile t, Owner o, Owner owner_road, Owner o
  * @param d          the direction this ramp must be facing
  * @param rt         the rail type of the bridge
  */
-static inline void MakeRailBridgeRamp(Tile t, Owner o, BridgeType bridgetype, DiagDirection d, RailType rt)
+inline void MakeRailBridgeRamp(Tile t, Owner o, BridgeType bridgetype, DiagDirection d, RailType rt)
 {
 	MakeBridgeRamp(t, o, bridgetype, d, TRANSPORT_RAIL);
 	SetRailType(t, rt);
@@ -178,7 +178,7 @@ static inline void MakeRailBridgeRamp(Tile t, Owner o, BridgeType bridgetype, Di
  * @param o          the new owner of the bridge ramp
  * @param d          the direction this ramp must be facing
  */
-static inline void MakeAqueductBridgeRamp(Tile t, Owner o, DiagDirection d)
+inline void MakeAqueductBridgeRamp(Tile t, Owner o, DiagDirection d)
 {
 	MakeBridgeRamp(t, o, 0, d, TRANSPORT_WATER);
 }

--- a/src/cargomonitor.h
+++ b/src/cargomonitor.h
@@ -58,7 +58,7 @@ static_assert(MAX_COMPANIES <= (1 << CCB_COMPANY_LENGTH));
  * @param ind %Industry providing or accepting the cargo.
  * @return The encoded cargo/company/industry number.
  */
-static inline CargoMonitorID EncodeCargoIndustryMonitor(CompanyID company, CargoID ctype, IndustryID ind)
+inline CargoMonitorID EncodeCargoIndustryMonitor(CompanyID company, CargoID ctype, IndustryID ind)
 {
 	assert(ctype < (1 << CCB_CARGO_TYPE_LENGTH));
 	assert(company < (1 << CCB_COMPANY_LENGTH));
@@ -78,7 +78,7 @@ static inline CargoMonitorID EncodeCargoIndustryMonitor(CompanyID company, Cargo
  * @param town %Town providing or accepting the cargo.
  * @return The encoded cargo/company/town number.
  */
-static inline CargoMonitorID EncodeCargoTownMonitor(CompanyID company, CargoID ctype, TownID town)
+inline CargoMonitorID EncodeCargoTownMonitor(CompanyID company, CargoID ctype, TownID town)
 {
 	assert(ctype < (1 << CCB_CARGO_TYPE_LENGTH));
 	assert(company < (1 << CCB_COMPANY_LENGTH));
@@ -95,7 +95,7 @@ static inline CargoMonitorID EncodeCargoTownMonitor(CompanyID company, CargoID c
  * @param num Cargo monitoring number to decode.
  * @return The extracted company id.
  */
-static inline CompanyID DecodeMonitorCompany(CargoMonitorID num)
+inline CompanyID DecodeMonitorCompany(CargoMonitorID num)
 {
 	return static_cast<CompanyID>(GB(num, CCB_COMPANY_START, CCB_COMPANY_LENGTH));
 }
@@ -105,7 +105,7 @@ static inline CompanyID DecodeMonitorCompany(CargoMonitorID num)
  * @param num Cargo monitoring number to decode.
  * @return The extracted cargo type.
  */
-static inline CargoID DecodeMonitorCargoType(CargoMonitorID num)
+inline CargoID DecodeMonitorCargoType(CargoMonitorID num)
 {
 	return GB(num, CCB_CARGO_TYPE_START, CCB_CARGO_TYPE_LENGTH);
 }
@@ -115,7 +115,7 @@ static inline CargoID DecodeMonitorCargoType(CargoMonitorID num)
  * @param num Cargo monitoring number to decode.
  * @return true if monitoring an industry, false if monitoring a town.
  */
-static inline bool MonitorMonitorsIndustry(CargoMonitorID num)
+inline bool MonitorMonitorsIndustry(CargoMonitorID num)
 {
 	return HasBit(num, CCB_IS_INDUSTRY_BIT);
 }
@@ -125,7 +125,7 @@ static inline bool MonitorMonitorsIndustry(CargoMonitorID num)
  * @param num Cargo monitoring number to decode.
  * @return The extracted industry id, or #INVALID_INDUSTRY if the number does not monitor an industry.
  */
-static inline IndustryID DecodeMonitorIndustry(CargoMonitorID num)
+inline IndustryID DecodeMonitorIndustry(CargoMonitorID num)
 {
 	if (!MonitorMonitorsIndustry(num)) return INVALID_INDUSTRY;
 	return GB(num, CCB_TOWN_IND_NUMBER_START, CCB_TOWN_IND_NUMBER_LENGTH);
@@ -136,7 +136,7 @@ static inline IndustryID DecodeMonitorIndustry(CargoMonitorID num)
  * @param num Cargo monitoring number to decode.
  * @return The extracted town id, or #INVALID_TOWN if the number does not monitor a town.
  */
-static inline TownID DecodeMonitorTown(CargoMonitorID num)
+inline TownID DecodeMonitorTown(CargoMonitorID num)
 {
 	if (MonitorMonitorsIndustry(num)) return INVALID_TOWN;
 	return GB(num, CCB_TOWN_IND_NUMBER_START, CCB_TOWN_IND_NUMBER_LENGTH);

--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -198,7 +198,7 @@ extern span<const CargoSpec *> _sorted_standard_cargo_specs;
  * @param cc Cargo class.
  * @return The type fits in the class.
  */
-static inline bool IsCargoInClass(CargoID c, CargoClass cc)
+inline bool IsCargoInClass(CargoID c, CargoClass cc)
 {
 	return (CargoSpec::Get(c)->classes & cc) != 0;
 }

--- a/src/clear_map.h
+++ b/src/clear_map.h
@@ -32,7 +32,7 @@ enum ClearGround {
  * @pre IsTileType(t, MP_CLEAR)
  * @return whether the tile is covered with snow.
  */
-static inline bool IsSnowTile(Tile t)
+inline bool IsSnowTile(Tile t)
 {
 	assert(IsTileType(t, MP_CLEAR));
 	return HasBit(t.m3(), 4);
@@ -44,7 +44,7 @@ static inline bool IsSnowTile(Tile t)
  * @pre IsTileType(t, MP_CLEAR)
  * @return the ground type
  */
-static inline ClearGround GetRawClearGround(Tile t)
+inline ClearGround GetRawClearGround(Tile t)
 {
 	assert(IsTileType(t, MP_CLEAR));
 	return (ClearGround)GB(t.m5(), 2, 3);
@@ -56,7 +56,7 @@ static inline ClearGround GetRawClearGround(Tile t)
  * @pre IsTileType(t, MP_CLEAR)
  * @return the ground type
  */
-static inline ClearGround GetClearGround(Tile t)
+inline ClearGround GetClearGround(Tile t)
 {
 	if (IsSnowTile(t)) return CLEAR_SNOW;
 	return GetRawClearGround(t);
@@ -68,7 +68,7 @@ static inline ClearGround GetClearGround(Tile t)
  * @param ct the ground type
  * @pre IsTileType(t, MP_CLEAR)
  */
-static inline bool IsClearGround(Tile t, ClearGround ct)
+inline bool IsClearGround(Tile t, ClearGround ct)
 {
 	return GetClearGround(t) == ct;
 }
@@ -80,7 +80,7 @@ static inline bool IsClearGround(Tile t, ClearGround ct)
  * @pre IsTileType(t, MP_CLEAR)
  * @return the density
  */
-static inline uint GetClearDensity(Tile t)
+inline uint GetClearDensity(Tile t)
 {
 	assert(IsTileType(t, MP_CLEAR));
 	return GB(t.m5(), 0, 2);
@@ -92,7 +92,7 @@ static inline uint GetClearDensity(Tile t)
  * @param d the amount to increment the density with
  * @pre IsTileType(t, MP_CLEAR)
  */
-static inline void AddClearDensity(Tile t, int d)
+inline void AddClearDensity(Tile t, int d)
 {
 	assert(IsTileType(t, MP_CLEAR)); // XXX incomplete
 	t.m5() += d;
@@ -104,7 +104,7 @@ static inline void AddClearDensity(Tile t, int d)
  * @param d the new density
  * @pre IsTileType(t, MP_CLEAR)
  */
-static inline void SetClearDensity(Tile t, uint d)
+inline void SetClearDensity(Tile t, uint d)
 {
 	assert(IsTileType(t, MP_CLEAR));
 	SB(t.m5(), 0, 2, d);
@@ -117,7 +117,7 @@ static inline void SetClearDensity(Tile t, uint d)
  * @pre IsTileType(t, MP_CLEAR)
  * @return the value of the counter
  */
-static inline uint GetClearCounter(Tile t)
+inline uint GetClearCounter(Tile t)
 {
 	assert(IsTileType(t, MP_CLEAR));
 	return GB(t.m5(), 5, 3);
@@ -129,7 +129,7 @@ static inline uint GetClearCounter(Tile t)
  * @param c the amount to increment the counter with
  * @pre IsTileType(t, MP_CLEAR)
  */
-static inline void AddClearCounter(Tile t, int c)
+inline void AddClearCounter(Tile t, int c)
 {
 	assert(IsTileType(t, MP_CLEAR)); // XXX incomplete
 	t.m5() += c << 5;
@@ -141,7 +141,7 @@ static inline void AddClearCounter(Tile t, int c)
  * @param c the amount to set the counter to
  * @pre IsTileType(t, MP_CLEAR)
  */
-static inline void SetClearCounter(Tile t, uint c)
+inline void SetClearCounter(Tile t, uint c)
 {
 	assert(IsTileType(t, MP_CLEAR)); // XXX incomplete
 	SB(t.m5(), 5, 3, c);
@@ -155,7 +155,7 @@ static inline void SetClearCounter(Tile t, uint c)
  * @param density the density of the ground tile
  * @pre IsTileType(t, MP_CLEAR)
  */
-static inline void SetClearGroundDensity(Tile t, ClearGround type, uint density)
+inline void SetClearGroundDensity(Tile t, ClearGround type, uint density)
 {
 	assert(IsTileType(t, MP_CLEAR)); // XXX incomplete
 	t.m5() = 0 << 5 | type << 2 | density;
@@ -168,7 +168,7 @@ static inline void SetClearGroundDensity(Tile t, ClearGround type, uint density)
  * @pre GetClearGround(t) == CLEAR_FIELDS
  * @return the field type
  */
-static inline uint GetFieldType(Tile t)
+inline uint GetFieldType(Tile t)
 {
 	assert(GetClearGround(t) == CLEAR_FIELDS);
 	return GB(t.m3(), 0, 4);
@@ -180,7 +180,7 @@ static inline uint GetFieldType(Tile t)
  * @param f the field type
  * @pre GetClearGround(t) == CLEAR_FIELDS
  */
-static inline void SetFieldType(Tile t, uint f)
+inline void SetFieldType(Tile t, uint f)
 {
 	assert(GetClearGround(t) == CLEAR_FIELDS); // XXX incomplete
 	SB(t.m3(), 0, 4, f);
@@ -192,7 +192,7 @@ static inline void SetFieldType(Tile t, uint f)
  * @pre GetClearGround(t) == CLEAR_FIELDS
  * @return the industry that made the field
  */
-static inline IndustryID GetIndustryIndexOfField(Tile t)
+inline IndustryID GetIndustryIndexOfField(Tile t)
 {
 	assert(GetClearGround(t) == CLEAR_FIELDS);
 	return(IndustryID) t.m2();
@@ -204,7 +204,7 @@ static inline IndustryID GetIndustryIndexOfField(Tile t)
  * @param i the industry that made the field
  * @pre GetClearGround(t) == CLEAR_FIELDS
  */
-static inline void SetIndustryIndexOfField(Tile t, IndustryID i)
+inline void SetIndustryIndexOfField(Tile t, IndustryID i)
 {
 	assert(GetClearGround(t) == CLEAR_FIELDS);
 	t.m2() = i;
@@ -218,7 +218,7 @@ static inline void SetIndustryIndexOfField(Tile t, IndustryID i)
  * @pre IsClearGround(t, CLEAR_FIELDS)
  * @return 0 if there is no fence, otherwise the fence type
  */
-static inline uint GetFence(Tile t, DiagDirection side)
+inline uint GetFence(Tile t, DiagDirection side)
 {
 	assert(IsClearGround(t, CLEAR_FIELDS));
 	switch (side) {
@@ -237,7 +237,7 @@ static inline uint GetFence(Tile t, DiagDirection side)
  * @param h 0 if there is no fence, otherwise the fence type
  * @pre IsClearGround(t, CLEAR_FIELDS)
  */
-static inline void SetFence(Tile t, DiagDirection side, uint h)
+inline void SetFence(Tile t, DiagDirection side, uint h)
 {
 	assert(IsClearGround(t, CLEAR_FIELDS));
 	switch (side) {
@@ -256,7 +256,7 @@ static inline void SetFence(Tile t, DiagDirection side, uint h)
  * @param g       the type of ground
  * @param density the density of the grass/snow/desert etc
  */
-static inline void MakeClear(Tile t, ClearGround g, uint density)
+inline void MakeClear(Tile t, ClearGround g, uint density)
 {
 	SetTileType(t, MP_CLEAR);
 	t.m1() = 0;
@@ -277,7 +277,7 @@ static inline void MakeClear(Tile t, ClearGround g, uint density)
  * @param field_type the 'growth' level of the field
  * @param industry   the industry this tile belongs to
  */
-static inline void MakeField(Tile t, uint field_type, IndustryID industry)
+inline void MakeField(Tile t, uint field_type, IndustryID industry)
 {
 	SetTileType(t, MP_CLEAR);
 	t.m1() = 0;
@@ -297,7 +297,7 @@ static inline void MakeField(Tile t, uint field_type, IndustryID industry)
  * @param density The density of snowiness.
  * @pre GetClearGround(t) != CLEAR_SNOW
  */
-static inline void MakeSnow(Tile t, uint density = 0)
+inline void MakeSnow(Tile t, uint density = 0)
 {
 	assert(GetClearGround(t) != CLEAR_SNOW);
 	SetBit(t.m3(), 4);
@@ -313,7 +313,7 @@ static inline void MakeSnow(Tile t, uint density = 0)
  * @param t the tile to clear of snow
  * @pre GetClearGround(t) == CLEAR_SNOW
  */
-static inline void ClearSnow(Tile t)
+inline void ClearSnow(Tile t)
 {
 	assert(GetClearGround(t) == CLEAR_SNOW);
 	ClrBit(t.m3(), 4);

--- a/src/company_func.h
+++ b/src/company_func.h
@@ -42,7 +42,7 @@ extern CompanyManagerFace _company_manager_face;
  * Is the current company the local company?
  * @return \c true of the current company is the local company, \c false otherwise.
  */
-static inline bool IsLocalCompany()
+inline bool IsLocalCompany()
 {
 	return _local_company == _current_company;
 }
@@ -52,7 +52,7 @@ static inline bool IsLocalCompany()
  * @param company Company where interaction is needed with.
  * @return Gives \c true if the user can answer questions interactively as representative of \a company, else \c false
  */
-static inline bool IsInteractiveCompany(CompanyID company)
+inline bool IsInteractiveCompany(CompanyID company)
 {
 	return company == _local_company;
 }

--- a/src/company_manager_face.h
+++ b/src/company_manager_face.h
@@ -93,7 +93,7 @@ static_assert(lengthof(_cmf_info) == CMFV_END);
  * @pre _cmf_info[cmfv].valid_values[ge] != 0
  * @return the requested bits
  */
-static inline uint GetCompanyManagerFaceBits(CompanyManagerFace cmf, CompanyManagerFaceVariable cmfv, [[maybe_unused]] GenderEthnicity ge)
+inline uint GetCompanyManagerFaceBits(CompanyManagerFace cmf, CompanyManagerFaceVariable cmfv, [[maybe_unused]] GenderEthnicity ge)
 {
 	assert(_cmf_info[cmfv].valid_values[ge] != 0);
 
@@ -108,7 +108,7 @@ static inline uint GetCompanyManagerFaceBits(CompanyManagerFace cmf, CompanyMana
  * @param val  the new value
  * @pre val < _cmf_info[cmfv].valid_values[ge]
  */
-static inline void SetCompanyManagerFaceBits(CompanyManagerFace &cmf, CompanyManagerFaceVariable cmfv, [[maybe_unused]] GenderEthnicity ge, uint val)
+inline void SetCompanyManagerFaceBits(CompanyManagerFace &cmf, CompanyManagerFaceVariable cmfv, [[maybe_unused]] GenderEthnicity ge, uint val)
 {
 	assert(val < _cmf_info[cmfv].valid_values[ge]);
 
@@ -127,7 +127,7 @@ static inline void SetCompanyManagerFaceBits(CompanyManagerFace &cmf, CompanyMan
  *
  * @pre 0 <= val < _cmf_info[cmfv].valid_values[ge]
  */
-static inline void IncreaseCompanyManagerFaceBits(CompanyManagerFace &cmf, CompanyManagerFaceVariable cmfv, GenderEthnicity ge, int8_t amount)
+inline void IncreaseCompanyManagerFaceBits(CompanyManagerFace &cmf, CompanyManagerFaceVariable cmfv, GenderEthnicity ge, int8_t amount)
 {
 	int8_t val = GetCompanyManagerFaceBits(cmf, cmfv, ge) + amount; // the new value for the cmfv
 
@@ -148,7 +148,7 @@ static inline void IncreaseCompanyManagerFaceBits(CompanyManagerFace &cmf, Compa
  * @param ge   the gender and ethnicity of the face
  * @return true if and only if the bits are valid
  */
-static inline bool AreCompanyManagerFaceBitsValid(CompanyManagerFace cmf, CompanyManagerFaceVariable cmfv, GenderEthnicity ge)
+inline bool AreCompanyManagerFaceBitsValid(CompanyManagerFace cmf, CompanyManagerFaceVariable cmfv, GenderEthnicity ge)
 {
 	return GB(cmf, _cmf_info[cmfv].offset, _cmf_info[cmfv].length) < _cmf_info[cmfv].valid_values[ge];
 }
@@ -161,7 +161,7 @@ static inline bool AreCompanyManagerFaceBitsValid(CompanyManagerFace cmf, Compan
  * @pre val < (1U << _cmf_info[cmfv].length), i.e. val has a value of 0..2^(bits used for this variable)-1
  * @return the scaled value
  */
-static inline uint ScaleCompanyManagerFaceValue(CompanyManagerFaceVariable cmfv, GenderEthnicity ge, uint val)
+inline uint ScaleCompanyManagerFaceValue(CompanyManagerFaceVariable cmfv, GenderEthnicity ge, uint val)
 {
 	assert(val < (1U << _cmf_info[cmfv].length));
 
@@ -173,7 +173,7 @@ static inline uint ScaleCompanyManagerFaceValue(CompanyManagerFaceVariable cmfv,
  *
  * @param cmf the company manager's face to write the bits to
  */
-static inline void ScaleAllCompanyManagerFaceBits(CompanyManagerFace &cmf)
+inline void ScaleAllCompanyManagerFaceBits(CompanyManagerFace &cmf)
 {
 	IncreaseCompanyManagerFaceBits(cmf, CMFV_ETHNICITY, GE_WM, 0); // scales the ethnicity
 
@@ -203,7 +203,7 @@ static inline void ScaleAllCompanyManagerFaceBits(CompanyManagerFace &cmf)
  *
  * @pre scale 'ge' to a valid gender/ethnicity combination
  */
-static inline void RandomCompanyManagerFaceBits(CompanyManagerFace &cmf, GenderEthnicity ge, bool adv, Randomizer &randomizer)
+inline void RandomCompanyManagerFaceBits(CompanyManagerFace &cmf, GenderEthnicity ge, bool adv, Randomizer &randomizer)
 {
 	cmf = randomizer.Next(); // random all company manager's face bits
 
@@ -229,7 +229,7 @@ static inline void RandomCompanyManagerFaceBits(CompanyManagerFace &cmf, GenderE
  * @pre _cmf_info[cmfv].valid_values[ge] != 0
  * @return sprite to draw
  */
-static inline SpriteID GetCompanyManagerFaceSprite(CompanyManagerFace cmf, CompanyManagerFaceVariable cmfv, GenderEthnicity ge)
+inline SpriteID GetCompanyManagerFaceSprite(CompanyManagerFace cmf, CompanyManagerFaceVariable cmfv, GenderEthnicity ge)
 {
 	assert(_cmf_info[cmfv].valid_values[ge] != 0);
 

--- a/src/console_func.h
+++ b/src/console_func.h
@@ -39,7 +39,7 @@ void IConsolePrint(TextColour colour_code, const std::string &string);
  * @tparam Args The types of the other arguments.
  */
 template <typename T, typename A, typename ... Args>
-static inline void IConsolePrint(TextColour colour_code, const T &format, A first_arg, Args&&... other_args)
+inline void IConsolePrint(TextColour colour_code, const T &format, A first_arg, Args&&... other_args)
 {
 	/* The separate first_arg argument is added to aid overloading.
 	 * Otherwise the calls that do no need formatting will still use this function. */

--- a/src/core/alloc_func.hpp
+++ b/src/core/alloc_func.hpp
@@ -26,7 +26,7 @@ void NORETURN ReallocError(size_t size);
  * @param element_size Size of the structure to allocate.
  * @param num_elements Number of elements to allocate.
  */
-static inline void CheckAllocationConstraints(size_t element_size, size_t num_elements)
+inline void CheckAllocationConstraints(size_t element_size, size_t num_elements)
 {
 	if (num_elements > SIZE_MAX / element_size) MallocError(SIZE_MAX);
 }
@@ -38,7 +38,7 @@ static inline void CheckAllocationConstraints(size_t element_size, size_t num_el
  * @param num_elements Number of elements to allocate.
  */
 template <typename T>
-static inline void CheckAllocationConstraints(size_t num_elements)
+inline void CheckAllocationConstraints(size_t num_elements)
 {
 	CheckAllocationConstraints(sizeof(T), num_elements);
 }
@@ -54,7 +54,7 @@ static inline void CheckAllocationConstraints(size_t num_elements)
  * @return nullptr when num_elements == 0, non-nullptr otherwise.
  */
 template <typename T>
-static inline T *MallocT(size_t num_elements)
+inline T *MallocT(size_t num_elements)
 {
 	/*
 	 * MorphOS cannot handle 0 elements allocations, or rather that always
@@ -82,7 +82,7 @@ static inline T *MallocT(size_t num_elements)
  * @return nullptr when num_elements == 0, non-nullptr otherwise.
  */
 template <typename T>
-static inline T *CallocT(size_t num_elements)
+inline T *CallocT(size_t num_elements)
 {
 	/*
 	 * MorphOS cannot handle 0 elements allocations, or rather that always
@@ -108,7 +108,7 @@ static inline T *CallocT(size_t num_elements)
  * @return nullptr when num_elements == 0, non-nullptr otherwise.
  */
 template <typename T>
-static inline T *ReallocT(T *t_ptr, size_t num_elements)
+inline T *ReallocT(T *t_ptr, size_t num_elements)
 {
 	/*
 	 * MorphOS cannot handle 0 elements allocations, or rather that always

--- a/src/core/bitmath_func.hpp
+++ b/src/core/bitmath_func.hpp
@@ -55,7 +55,7 @@ debug_inline constexpr static uint GB(const T x, const uint8_t s, const uint8_t 
  * @return The new value of \a x
  */
 template <typename T, typename U>
-static inline T SB(T &x, const uint8_t s, const uint8_t n, const U d)
+inline T SB(T &x, const uint8_t s, const uint8_t n, const U d)
 {
 	x &= (T)(~((((T)1U << n) - 1) << s));
 	x |= (T)(d << s);
@@ -80,7 +80,7 @@ static inline T SB(T &x, const uint8_t s, const uint8_t n, const U d)
  * @return The new value of \a x
  */
 template <typename T, typename U>
-static inline T AB(T &x, const uint8_t s, const uint8_t n, const U i)
+inline T AB(T &x, const uint8_t s, const uint8_t n, const U i)
 {
 	const T mask = ((((T)1U << n) - 1) << s);
 	x = (T)((x & ~mask) | ((x + (i << s)) & mask));
@@ -118,7 +118,7 @@ debug_inline static bool HasBit(const T x, const uint8_t y)
  * @return The new value of the old value with the bit set
  */
 template <typename T>
-static inline T SetBit(T &x, const uint8_t y)
+inline T SetBit(T &x, const uint8_t y)
 {
 	return x = (T)(x | ((T)1U << y));
 }
@@ -148,7 +148,7 @@ static inline T SetBit(T &x, const uint8_t y)
  * @return The new value of the old value with the bit cleared
  */
 template <typename T>
-static inline T ClrBit(T &x, const uint8_t y)
+inline T ClrBit(T &x, const uint8_t y)
 {
 	return x = (T)(x & ~((T)1U << y));
 }
@@ -178,7 +178,7 @@ static inline T ClrBit(T &x, const uint8_t y)
  * @return The new value of the old value with the bit toggled
  */
 template <typename T>
-static inline T ToggleBit(T &x, const uint8_t y)
+inline T ToggleBit(T &x, const uint8_t y)
 {
 	return x = (T)(x ^ ((T)1U << y));
 }
@@ -213,7 +213,7 @@ extern const uint8_t _ffb_64[64];
  * @return The position of the first bit which is set
  * @see FIND_FIRST_BIT
  */
-static inline uint8_t FindFirstBit2x64(const int value)
+inline uint8_t FindFirstBit2x64(const int value)
 {
 	if ((value & 0xFF) == 0) {
 		return FIND_FIRST_BIT((value >> 8) & 0x3F) + 8;
@@ -236,7 +236,7 @@ uint8_t FindLastBit(uint64_t x);
  * @return The new value with the first bit cleared
  */
 template <typename T>
-static inline T KillFirstBit(T value)
+inline T KillFirstBit(T value)
 {
 	return value &= (T)(value - 1);
 }
@@ -248,7 +248,7 @@ static inline T KillFirstBit(T value)
  * @return the number of bits.
  */
 template <typename T>
-static inline uint CountBits(T value)
+inline uint CountBits(T value)
 {
 	uint num;
 
@@ -271,7 +271,7 @@ static inline uint CountBits(T value)
  * @return does \a value have exactly 1 bit set?
  */
 template <typename T>
-static inline bool HasExactlyOneBit(T value)
+inline bool HasExactlyOneBit(T value)
 {
 	return value != 0 && (value & (value - 1)) == 0;
 }
@@ -283,7 +283,7 @@ static inline bool HasExactlyOneBit(T value)
  * @return does \a value have at most 1 bit set?
  */
 template <typename T>
-static inline bool HasAtMostOneBit(T value)
+inline bool HasAtMostOneBit(T value)
 {
 	return (value & (value - 1)) == 0;
 }
@@ -298,7 +298,7 @@ static inline bool HasAtMostOneBit(T value)
  * @return A bit rotated number
  */
 template <typename T>
-static inline T ROL(const T x, const uint8_t n)
+inline T ROL(const T x, const uint8_t n)
 {
 	if (n == 0) return x;
 	return (T)(x << n | x >> (sizeof(x) * 8 - n));
@@ -314,7 +314,7 @@ static inline T ROL(const T x, const uint8_t n)
  * @return A bit rotated number
  */
 template <typename T>
-static inline T ROR(const T x, const uint8_t n)
+inline T ROR(const T x, const uint8_t n)
 {
 	if (n == 0) return x;
 	return (T)(x >> n | x << (sizeof(x) * 8 - n));

--- a/src/core/endian_func.hpp
+++ b/src/core/endian_func.hpp
@@ -38,12 +38,12 @@
 #	define TO_LE32X(x)  (x)
 #endif /* TTD_ENDIAN == TTD_BIG_ENDIAN */
 
-static inline uint16_t ReadLE16Aligned(const void *x)
+inline uint16_t ReadLE16Aligned(const void *x)
 {
 	return FROM_LE16(*(const uint16_t*)x);
 }
 
-static inline uint16_t ReadLE16Unaligned(const void *x)
+inline uint16_t ReadLE16Unaligned(const void *x)
 {
 #if OTTD_ALIGNMENT == 1
 	return ((const byte*)x)[0] | ((const byte*)x)[1] << 8;

--- a/src/core/geometry_func.hpp
+++ b/src/core/geometry_func.hpp
@@ -19,7 +19,7 @@ Dimension maxdim(const Dimension &d1, const Dimension &d2);
  * @param r Rectangle to check.
  * @return True if and only if the rectangle doesn't define space.
  */
-static inline bool IsEmptyRect(const Rect &r)
+inline bool IsEmptyRect(const Rect &r)
 {
 	return (r.left | r.top | r.right | r.bottom) == 0;
 }

--- a/src/core/math_func.hpp
+++ b/src/core/math_func.hpp
@@ -20,7 +20,7 @@
  * @return The unsigned value
  */
 template <typename T>
-static inline T abs(const T a)
+inline T abs(const T a)
 {
 	return (a < (T)0) ? -a : a;
 }
@@ -34,7 +34,7 @@ static inline T abs(const T a)
  * @return The smallest multiple of n equal or greater than x
  */
 template <typename T>
-static inline T Align(const T x, uint n)
+inline T Align(const T x, uint n)
 {
 	assert((n & (n - 1)) == 0 && n != 0);
 	n--;
@@ -52,7 +52,7 @@ static inline T Align(const T x, uint n)
  * @see Align()
  */
 template <typename T>
-static inline T *AlignPtr(T *x, uint n)
+inline T *AlignPtr(T *x, uint n)
 {
 	static_assert(sizeof(size_t) == sizeof(void *));
 	return reinterpret_cast<T *>(Align((size_t)x, n));
@@ -76,7 +76,7 @@ static inline T *AlignPtr(T *x, uint n)
  * @see Clamp(int, int, int)
  */
 template <typename T>
-static inline T Clamp(const T a, const T min, const T max)
+inline T Clamp(const T a, const T min, const T max)
 {
 	assert(min <= max);
 	if (a <= min) return min;
@@ -99,7 +99,7 @@ static inline T Clamp(const T a, const T min, const T max)
  * @returns A value between min and max which is closest to a.
  */
 template <typename T>
-static inline T SoftClamp(const T a, const T min, const T max)
+inline T SoftClamp(const T a, const T min, const T max)
 {
 	if (min > max) {
 		using U = std::make_unsigned_t<T>;
@@ -126,7 +126,7 @@ static inline T SoftClamp(const T a, const T min, const T max)
  * @returns A value between min and max which is closest to a.
  * @see ClampU(uint, uint, uint)
  */
-static inline int Clamp(const int a, const int min, const int max)
+inline int Clamp(const int a, const int min, const int max)
 {
 	return Clamp<int>(a, min, max);
 }
@@ -147,7 +147,7 @@ static inline int Clamp(const int a, const int min, const int max)
  * @returns A value between min and max which is closest to a.
  * @see Clamp(int, int, int)
  */
-static inline uint ClampU(const uint a, const uint min, const uint max)
+inline uint ClampU(const uint a, const uint min, const uint max)
 {
 	return Clamp<uint>(a, min, max);
 }
@@ -231,7 +231,7 @@ constexpr To ClampTo(From value)
  * @return The absolute difference between the given scalars
  */
 template <typename T>
-static inline T Delta(const T a, const T b)
+inline T Delta(const T a, const T b)
 {
 	return (a < b) ? b - a : a - b;
 }
@@ -249,7 +249,7 @@ static inline T Delta(const T a, const T b)
  * @return True if the value is in the interval, false else.
  */
 template <typename T>
-static inline bool IsInsideBS(const T x, const size_t base, const size_t size)
+inline bool IsInsideBS(const T x, const size_t base, const size_t size)
 {
 	return (size_t)(x - base) < size;
 }
@@ -280,7 +280,7 @@ static constexpr inline bool IsInsideMM(const T x, const size_t min, const size_
  * @param b variable to swap with a
  */
 template <typename T>
-static inline void Swap(T &a, T &b)
+inline void Swap(T &a, T &b)
 {
 	T t = a;
 	a = b;
@@ -292,7 +292,7 @@ static inline void Swap(T &a, T &b)
  * @param i value to convert, range 0..255
  * @return value in range 0..100
  */
-static inline uint ToPercent8(uint i)
+inline uint ToPercent8(uint i)
 {
 	assert(i < 256);
 	return i * 101 >> 8;
@@ -303,7 +303,7 @@ static inline uint ToPercent8(uint i)
  * @param i value to convert, range 0..65535
  * @return value in range 0..100
  */
-static inline uint ToPercent16(uint i)
+inline uint ToPercent16(uint i)
 {
 	assert(i < 65536);
 	return i * 101 >> 16;
@@ -319,7 +319,7 @@ int DivideApprox(int a, int b);
  * @param b Denominator
  * @return Quotient, rounded up
  */
-static inline uint CeilDiv(uint a, uint b)
+inline uint CeilDiv(uint a, uint b)
 {
 	return (a + b - 1) / b;
 }
@@ -330,7 +330,7 @@ static inline uint CeilDiv(uint a, uint b)
  * @param b Denominator
  * @return a rounded up to the nearest multiple of b.
  */
-static inline uint Ceil(uint a, uint b)
+inline uint Ceil(uint a, uint b)
 {
 	return CeilDiv(a, b) * b;
 }
@@ -341,7 +341,7 @@ static inline uint Ceil(uint a, uint b)
  * @param b Denominator
  * @return Quotient, rounded to nearest
  */
-static inline int RoundDivSU(int a, uint b)
+inline int RoundDivSU(int a, uint b)
 {
 	if (a > 0) {
 		/* 0.5 is rounded to 1 */
@@ -358,7 +358,7 @@ static inline int RoundDivSU(int a, uint b)
  * @param b Denominator
  * @return Quotient, rounded away from zero
  */
-static inline int DivAwayFromZero(int a, uint b)
+inline int DivAwayFromZero(int a, uint b)
 {
 	const int _b = static_cast<int>(b);
 	if (a > 0) {

--- a/src/core/mem_func.hpp
+++ b/src/core/mem_func.hpp
@@ -20,7 +20,7 @@
  * @param num number of items to be copied. (!not number of bytes!)
  */
 template <typename T>
-static inline void MemCpyT(T *destination, const T *source, size_t num = 1)
+inline void MemCpyT(T *destination, const T *source, size_t num = 1)
 {
 	memcpy(destination, source, num * sizeof(T));
 }
@@ -33,7 +33,7 @@ static inline void MemCpyT(T *destination, const T *source, size_t num = 1)
  * @param num number of items to be copied. (!not number of bytes!)
  */
 template <typename T>
-static inline void MemMoveT(T *destination, const T *source, size_t num = 1)
+inline void MemMoveT(T *destination, const T *source, size_t num = 1)
 {
 	memmove(destination, source, num * sizeof(T));
 }
@@ -46,7 +46,7 @@ static inline void MemMoveT(T *destination, const T *source, size_t num = 1)
  * @param num number of items to be set (!not number of bytes!)
  */
 template <typename T>
-static inline void MemSetT(T *ptr, byte value, size_t num = 1)
+inline void MemSetT(T *ptr, byte value, size_t num = 1)
 {
 	memset(ptr, value, num * sizeof(T));
 }
@@ -60,7 +60,7 @@ static inline void MemSetT(T *ptr, byte value, size_t num = 1)
  * @return an int value indicating the relationship between the content of the two buffers
  */
 template <typename T>
-static inline int MemCmpT(const T *ptr1, const T *ptr2, size_t num = 1)
+inline int MemCmpT(const T *ptr1, const T *ptr2, size_t num = 1)
 {
 	return memcmp(ptr1, ptr2, num * sizeof(T));
 }

--- a/src/core/random_func.hpp
+++ b/src/core/random_func.hpp
@@ -39,7 +39,7 @@ struct SavedRandomSeeds {
  * Saves the current seeds
  * @param storage Storage for saving
  */
-static inline void SaveRandomSeeds(SavedRandomSeeds *storage)
+inline void SaveRandomSeeds(SavedRandomSeeds *storage)
 {
 	storage->random = _random;
 	storage->interactive_random = _interactive_random;
@@ -49,7 +49,7 @@ static inline void SaveRandomSeeds(SavedRandomSeeds *storage)
  * Restores previously saved seeds
  * @param storage Storage where SaveRandomSeeds() stored th seeds
  */
-static inline void RestoreRandomSeeds(const SavedRandomSeeds &storage)
+inline void RestoreRandomSeeds(const SavedRandomSeeds &storage)
 {
 	_random = storage.random;
 	_interactive_random = storage.interactive_random;
@@ -84,12 +84,12 @@ void SetRandomSeed(uint32_t seed);
 	}
 #endif
 
-static inline uint32_t InteractiveRandom()
+inline uint32_t InteractiveRandom()
 {
 	return _interactive_random.Next();
 }
 
-static inline uint32_t InteractiveRandomRange(uint32_t limit)
+inline uint32_t InteractiveRandomRange(uint32_t limit)
 {
 	return _interactive_random.Next(limit);
 }
@@ -109,7 +109,7 @@ static inline uint32_t InteractiveRandomRange(uint32_t limit)
  * @param r The given randomize-number
  * @return True if the probability given by r is less or equal to (a/b)
  */
-static inline bool Chance16I(const uint a, const uint b, const uint32_t r)
+inline bool Chance16I(const uint a, const uint b, const uint32_t r)
 {
 	assert(b != 0);
 	return (((uint16_t)r * b + b / 2) >> 16) < a;
@@ -128,7 +128,7 @@ static inline bool Chance16I(const uint a, const uint b, const uint32_t r)
 #ifdef RANDOM_DEBUG
 #	define Chance16(a, b) Chance16I(a, b, DoRandom(__LINE__, __FILE__))
 #else
-static inline bool Chance16(const uint a, const uint b)
+inline bool Chance16(const uint a, const uint b)
 {
 	return Chance16I(a, b, Random());
 }
@@ -152,7 +152,7 @@ static inline bool Chance16(const uint a, const uint b)
 #ifdef RANDOM_DEBUG
 #	define Chance16R(a, b, r) (r = DoRandom(__LINE__, __FILE__), Chance16I(a, b, r))
 #else
-static inline bool Chance16R(const uint a, const uint b, uint32_t &r)
+inline bool Chance16R(const uint a, const uint b, uint32_t &r)
 {
 	r = Random();
 	return Chance16I(a, b, r);

--- a/src/depot_func.h
+++ b/src/depot_func.h
@@ -24,7 +24,7 @@ void DeleteDepotHighlightOfVehicle(const Vehicle *v);
  * @param tileh The slope of the tile in question
  * @return true if the construction is possible
  */
-static inline bool CanBuildDepotByTileh(DiagDirection direction, Slope tileh)
+inline bool CanBuildDepotByTileh(DiagDirection direction, Slope tileh)
 {
 	assert(tileh != SLOPE_FLAT);
 	Slope entrance_corners = InclinedSlope(direction);

--- a/src/depot_map.h
+++ b/src/depot_map.h
@@ -15,7 +15,7 @@
 /**
  * Check if a tile is a depot and it is a depot of the given type.
  */
-static inline bool IsDepotTypeTile(Tile tile, TransportType type)
+inline bool IsDepotTypeTile(Tile tile, TransportType type)
 {
 	switch (type) {
 		default: NOT_REACHED();
@@ -38,7 +38,7 @@ static inline bool IsDepotTypeTile(Tile tile, TransportType type)
  * @param tile the tile to check
  * @return true if and only if there is a depot on the tile.
  */
-static inline bool IsDepotTile(Tile tile)
+inline bool IsDepotTile(Tile tile)
 {
 	return IsRailDepotTile(tile) || IsRoadDepotTile(tile) || IsShipDepotTile(tile) || IsHangarTile(tile);
 }
@@ -49,7 +49,7 @@ static inline bool IsDepotTile(Tile tile)
  * @pre IsRailDepotTile(t) || IsRoadDepotTile(t) || IsShipDepotTile(t)
  * @return DepotID
  */
-static inline DepotID GetDepotIndex(Tile t)
+inline DepotID GetDepotIndex(Tile t)
 {
 	/* Hangars don't have a Depot class, thus store no DepotID. */
 	assert(IsRailDepotTile(t) || IsRoadDepotTile(t) || IsShipDepotTile(t));
@@ -62,7 +62,7 @@ static inline DepotID GetDepotIndex(Tile t)
  * @pre IsDepotTile(t)
  * @return the type of vehicles that can use the depot
  */
-static inline VehicleType GetDepotVehicleType(Tile t)
+inline VehicleType GetDepotVehicleType(Tile t)
 {
 	switch (GetTileType(t)) {
 		default: NOT_REACHED();

--- a/src/direction_func.h
+++ b/src/direction_func.h
@@ -18,7 +18,7 @@
  * @param d The value to check
  * @return True if the value belongs to a DiagDirection, else false
  */
-static inline bool IsValidDiagDirection(DiagDirection d)
+inline bool IsValidDiagDirection(DiagDirection d)
 {
 	return d < DIAGDIR_END;
 }
@@ -29,7 +29,7 @@ static inline bool IsValidDiagDirection(DiagDirection d)
  * @param d The value to check
  * @return True if the value belongs to a Direction, else false
  */
-static inline bool IsValidDirection(Direction d)
+inline bool IsValidDirection(Direction d)
 {
 	return d < DIR_END;
 }
@@ -40,7 +40,7 @@ static inline bool IsValidDirection(Direction d)
  * @param d The value to check
  * @return True if the value belongs to an Axis, else false
  */
-static inline bool IsValidAxis(Axis d)
+inline bool IsValidAxis(Axis d)
 {
 	return d < AXIS_END;
 }
@@ -51,7 +51,7 @@ static inline bool IsValidAxis(Axis d)
  * @param d The direction to get the reverse from
  * @return The reverse Direction
  */
-static inline Direction ReverseDir(Direction d)
+inline Direction ReverseDir(Direction d)
 {
 	assert(IsValidDirection(d));
 	return (Direction)(4 ^ d);
@@ -65,7 +65,7 @@ static inline Direction ReverseDir(Direction d)
  * @param d1 The second direction as the offset from the base
  * @return The difference how the second direction drifts of the first one.
  */
-static inline DirDiff DirDifference(Direction d0, Direction d1)
+inline DirDiff DirDifference(Direction d0, Direction d1)
 {
 	assert(IsValidDirection(d0));
 	assert(IsValidDirection(d1));
@@ -85,7 +85,7 @@ static inline DirDiff DirDifference(Direction d0, Direction d1)
  * @param delta The second difference to add on
  * @return The resulting difference
  */
-static inline DirDiff ChangeDirDiff(DirDiff d, DirDiff delta)
+inline DirDiff ChangeDirDiff(DirDiff d, DirDiff delta)
 {
 	/* Cast to uint so compiler can use bitmask. Result can never be negative. */
 	return (DirDiff)((uint)(d + delta) % 8);
@@ -101,7 +101,7 @@ static inline DirDiff ChangeDirDiff(DirDiff d, DirDiff delta)
  * @param delta The offset/drift applied to the direction
  * @return The new direction
  */
-static inline Direction ChangeDir(Direction d, DirDiff delta)
+inline Direction ChangeDir(Direction d, DirDiff delta)
 {
 	assert(IsValidDirection(d));
 	/* Cast to uint so compiler can use bitmask. Result can never be negative. */
@@ -115,7 +115,7 @@ static inline Direction ChangeDir(Direction d, DirDiff delta)
  * @param d The DiagDirection to get the reverse from
  * @return The reverse direction
  */
-static inline DiagDirection ReverseDiagDir(DiagDirection d)
+inline DiagDirection ReverseDiagDir(DiagDirection d)
 {
 	assert(IsValidDiagDirection(d));
 	return (DiagDirection)(2 ^ d);
@@ -128,7 +128,7 @@ static inline DiagDirection ReverseDiagDir(DiagDirection d)
  * @param d1 The second direction as the offset from the base
  * @return The difference how the second direction drifts of the first one.
  */
-static inline DiagDirDiff DiagDirDifference(DiagDirection d0, DiagDirection d1)
+inline DiagDirDiff DiagDirDifference(DiagDirection d0, DiagDirection d1)
 {
 	assert(IsValidDiagDirection(d0));
 	assert(IsValidDiagDirection(d1));
@@ -146,7 +146,7 @@ static inline DiagDirDiff DiagDirDifference(DiagDirection d0, DiagDirection d1)
  * @param delta The difference to apply on
  * @return The new direction which was calculated
  */
-static inline DiagDirection ChangeDiagDir(DiagDirection d, DiagDirDiff delta)
+inline DiagDirection ChangeDiagDir(DiagDirection d, DiagDirDiff delta)
 {
 	assert(IsValidDiagDirection(d));
 	/* Cast to uint so compiler can use bitmask. Result can never be negative. */
@@ -163,7 +163,7 @@ static inline DiagDirection ChangeDiagDir(DiagDirection d, DiagDirDiff delta)
  * @param dir The direction to convert
  * @return The resulting DiagDirection, maybe "rounded clockwise".
  */
-static inline DiagDirection DirToDiagDir(Direction dir)
+inline DiagDirection DirToDiagDir(Direction dir)
 {
 	assert(IsValidDirection(dir));
 	return (DiagDirection)(dir >> 1);
@@ -179,7 +179,7 @@ static inline DiagDirection DirToDiagDir(Direction dir)
  * @param dir The direction to convert
  * @return The resulting Direction
  */
-static inline Direction DiagDirToDir(DiagDirection dir)
+inline Direction DiagDirToDir(DiagDirection dir)
 {
 	assert(IsValidDiagDirection(dir));
 	return (Direction)(dir * 2 + 1);
@@ -194,7 +194,7 @@ static inline Direction DiagDirToDir(DiagDirection dir)
  * @param a The given axis
  * @return The other axis
  */
-static inline Axis OtherAxis(Axis a)
+inline Axis OtherAxis(Axis a)
 {
 	assert(IsValidAxis(a));
 	return (Axis)(a ^ 1);
@@ -211,7 +211,7 @@ static inline Axis OtherAxis(Axis a)
  * @param d The DiagDirection
  * @return The axis which belongs to the direction
  */
-static inline Axis DiagDirToAxis(DiagDirection d)
+inline Axis DiagDirToAxis(DiagDirection d)
 {
 	assert(IsValidDiagDirection(d));
 	return (Axis)(d & 1);
@@ -229,7 +229,7 @@ static inline Axis DiagDirToAxis(DiagDirection d)
  * @param a The axis
  * @return The direction pointed to south
  */
-static inline DiagDirection AxisToDiagDir(Axis a)
+inline DiagDirection AxisToDiagDir(Axis a)
 {
 	assert(IsValidAxis(a));
 	return (DiagDirection)(2 - a);
@@ -246,7 +246,7 @@ static inline DiagDirection AxisToDiagDir(Axis a)
  * @param a The axis
  * @return The direction pointed to south
  */
-static inline Direction AxisToDirection(Axis a)
+inline Direction AxisToDirection(Axis a)
 {
 	assert(IsValidAxis(a));
 	return (Direction)(5 - 2 * a);
@@ -258,7 +258,7 @@ static inline Direction AxisToDirection(Axis a)
  * @param ns north -> 0, south -> 1
  * @return the desired DiagDirection
  */
-static inline DiagDirection XYNSToDiagDir(Axis xy, uint ns)
+inline DiagDirection XYNSToDiagDir(Axis xy, uint ns)
 {
 	assert(IsValidAxis(xy));
 	return (DiagDirection)(xy * 3 ^ ns * 2);
@@ -270,7 +270,7 @@ static inline DiagDirection XYNSToDiagDir(Axis xy, uint ns)
  * @param dir The given direction.
  * @return True if the direction is diagonal.
  */
-static inline bool IsDiagonalDirection(Direction dir)
+inline bool IsDiagonalDirection(Direction dir)
 {
 	assert(IsValidDirection(dir));
 	return (dir & 1) != 0;

--- a/src/economy_func.h
+++ b/src/economy_func.h
@@ -44,7 +44,7 @@ bool AddInflation(bool check_year = true);
  * Is the economy in recession?
  * @return \c True if economy is in recession, \c false otherwise.
  */
-static inline bool EconomyIsInRecession()
+inline bool EconomyIsInRecession()
 {
 	return _economy.fluct <= 0;
 }

--- a/src/elrail_func.h
+++ b/src/elrail_func.h
@@ -18,7 +18,7 @@
  * Test if a rail type has catenary
  * @param rt Rail type to test
  */
-static inline bool HasRailCatenary(RailType rt)
+inline bool HasRailCatenary(RailType rt)
 {
 	return HasBit(GetRailTypeInfo(rt)->flags, RTF_CATENARY);
 }
@@ -27,7 +27,7 @@ static inline bool HasRailCatenary(RailType rt)
  * Test if we should draw rail catenary
  * @param rt Rail type to test
  */
-static inline bool HasRailCatenaryDrawn(RailType rt)
+inline bool HasRailCatenaryDrawn(RailType rt)
 {
 	return HasRailCatenary(rt) && !IsInvisibilitySet(TO_CATENARY) && !_settings_game.vehicle.disable_elrails;
 }

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -211,27 +211,27 @@ struct EngineOverrideManager : std::vector<EngineIDMapping> {
 
 extern EngineOverrideManager _engine_mngr;
 
-static inline const EngineInfo *EngInfo(EngineID e)
+inline const EngineInfo *EngInfo(EngineID e)
 {
 	return &Engine::Get(e)->info;
 }
 
-static inline const RailVehicleInfo *RailVehInfo(EngineID e)
+inline const RailVehicleInfo *RailVehInfo(EngineID e)
 {
 	return &Engine::Get(e)->u.rail;
 }
 
-static inline const RoadVehicleInfo *RoadVehInfo(EngineID e)
+inline const RoadVehicleInfo *RoadVehInfo(EngineID e)
 {
 	return &Engine::Get(e)->u.road;
 }
 
-static inline const ShipVehicleInfo *ShipVehInfo(EngineID e)
+inline const ShipVehicleInfo *ShipVehInfo(EngineID e)
 {
 	return &Engine::Get(e)->u.ship;
 }
 
-static inline const AircraftVehicleInfo *AircraftVehInfo(EngineID e)
+inline const AircraftVehicleInfo *AircraftVehInfo(EngineID e)
 {
 	return &Engine::Get(e)->u.air;
 }

--- a/src/fileio_func.h
+++ b/src/fileio_func.h
@@ -108,7 +108,7 @@ int closedir(DIR *d);
  * @param path string to open directory of
  * @return DIR pointer
  */
-static inline DIR *ttd_opendir(const char *path)
+inline DIR *ttd_opendir(const char *path)
 {
 	return opendir(OTTD2FS(path).c_str());
 }

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -163,20 +163,20 @@ public:
 };
 
 /** Map a SpriteID to the font size and key */
-static inline void SetUnicodeGlyph(FontSize size, char32_t key, SpriteID sprite)
+inline void SetUnicodeGlyph(FontSize size, char32_t key, SpriteID sprite)
 {
 	FontCache::Get(size)->SetUnicodeGlyph(key, sprite);
 }
 
 /** Initialize the glyph map */
-static inline void InitializeUnicodeGlyphMap()
+inline void InitializeUnicodeGlyphMap()
 {
 	for (FontSize fs = FS_BEGIN; fs < FS_END; fs++) {
 		FontCache::Get(fs)->InitializeUnicodeGlyphMap();
 	}
 }
 
-static inline void ClearFontCache()
+inline void ClearFontCache()
 {
 	for (FontSize fs = FS_BEGIN; fs < FS_END; fs++) {
 		FontCache::Get(fs)->ClearFontCache();
@@ -184,20 +184,20 @@ static inline void ClearFontCache()
 }
 
 /** Get the Sprite for a glyph */
-static inline const Sprite *GetGlyph(FontSize size, char32_t key)
+inline const Sprite *GetGlyph(FontSize size, char32_t key)
 {
 	FontCache *fc = FontCache::Get(size);
 	return fc->GetGlyph(fc->MapCharToGlyph(key));
 }
 
 /** Get the width of a glyph */
-static inline uint GetGlyphWidth(FontSize size, char32_t key)
+inline uint GetGlyphWidth(FontSize size, char32_t key)
 {
 	FontCache *fc = FontCache::Get(size);
 	return fc->GetGlyphWidth(fc->MapCharToGlyph(key));
 }
 
-static inline bool GetDrawGlyphShadow(FontSize size)
+inline bool GetDrawGlyphShadow(FontSize size)
 {
 	return FontCache::Get(size)->GetDrawGlyphShadow();
 }
@@ -226,7 +226,7 @@ extern FontCacheSettings _fcsettings;
  * @param fs The font size to look up.
  * @return The settings.
  */
-static inline FontCacheSubSetting *GetFontCacheSubSetting(FontSize fs)
+inline FontCacheSubSetting *GetFontCacheSubSetting(FontSize fs)
 {
 	switch (fs) {
 		default: NOT_REACHED();

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -106,27 +106,27 @@ void DrawBox(int x, int y, int dx1, int dy1, int dx2, int dy2, int dx3, int dy3)
 void DrawRectOutline(const Rect &r, int colour, int width = 1, int dash = 0);
 
 /* Versions of DrawString/DrawStringMultiLine that accept a Rect instead of separate left, right, top and bottom parameters. */
-static inline int DrawString(const Rect &r, std::string_view str, TextColour colour = TC_FROMSTRING, StringAlignment align = SA_LEFT, bool underline = false, FontSize fontsize = FS_NORMAL)
+inline int DrawString(const Rect &r, std::string_view str, TextColour colour = TC_FROMSTRING, StringAlignment align = SA_LEFT, bool underline = false, FontSize fontsize = FS_NORMAL)
 {
 	return DrawString(r.left, r.right, r.top, str, colour, align, underline, fontsize);
 }
 
-static inline int DrawString(const Rect &r, StringID str, TextColour colour = TC_FROMSTRING, StringAlignment align = SA_LEFT, bool underline = false, FontSize fontsize = FS_NORMAL)
+inline int DrawString(const Rect &r, StringID str, TextColour colour = TC_FROMSTRING, StringAlignment align = SA_LEFT, bool underline = false, FontSize fontsize = FS_NORMAL)
 {
 	return DrawString(r.left, r.right, r.top, str, colour, align, underline, fontsize);
 }
 
-static inline int DrawStringMultiLine(const Rect &r, std::string_view str, TextColour colour = TC_FROMSTRING, StringAlignment align = (SA_TOP | SA_LEFT), bool underline = false, FontSize fontsize = FS_NORMAL)
+inline int DrawStringMultiLine(const Rect &r, std::string_view str, TextColour colour = TC_FROMSTRING, StringAlignment align = (SA_TOP | SA_LEFT), bool underline = false, FontSize fontsize = FS_NORMAL)
 {
 	return DrawStringMultiLine(r.left, r.right, r.top, r.bottom, str, colour, align, underline, fontsize);
 }
 
-static inline int DrawStringMultiLine(const Rect &r, StringID str, TextColour colour = TC_FROMSTRING, StringAlignment align = (SA_TOP | SA_LEFT), bool underline = false, FontSize fontsize = FS_NORMAL)
+inline int DrawStringMultiLine(const Rect &r, StringID str, TextColour colour = TC_FROMSTRING, StringAlignment align = (SA_TOP | SA_LEFT), bool underline = false, FontSize fontsize = FS_NORMAL)
 {
 	return DrawStringMultiLine(r.left, r.right, r.top, r.bottom, str, colour, align, underline, fontsize);
 }
 
-static inline void GfxFillRect(const Rect &r, int colour, FillRectMode mode = FILLRECT_OPAQUE)
+inline void GfxFillRect(const Rect &r, int colour, FillRectMode mode = FILLRECT_OPAQUE)
 {
 	GfxFillRect(r.left, r.top, r.right, r.bottom, colour, mode);
 }
@@ -151,7 +151,7 @@ void CheckBlitter();
 
 bool FillDrawPixelInfo(DrawPixelInfo *n, int left, int top, int width, int height);
 
-static inline bool FillDrawPixelInfo(DrawPixelInfo *n, const Rect &r)
+inline bool FillDrawPixelInfo(DrawPixelInfo *n, const Rect &r)
 {
 	return FillDrawPixelInfo(n, r.left, r.top, r.Width(), r.Height());
 }
@@ -163,7 +163,7 @@ static inline bool FillDrawPixelInfo(DrawPixelInfo *n, const Rect &r)
  * @param size The height or width of the object to draw.
  * @return Offset of where to start drawing the object.
  */
-static inline int CenterBounds(int min, int max, int size)
+inline int CenterBounds(int min, int max, int size)
 {
 	return (min + max - size + 1) / 2;
 }

--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -210,7 +210,7 @@ enum FontSize {
 };
 DECLARE_POSTFIX_INCREMENT(FontSize)
 
-static inline const char *FontSizeToName(FontSize fs)
+inline const char *FontSizeToName(FontSize fs)
 {
 	static const char *SIZE_TO_NAME[] = { "medium", "small", "large", "mono" };
 	assert(fs < FS_END);

--- a/src/group.h
+++ b/src/group.h
@@ -87,7 +87,7 @@ struct Group : GroupPool::PoolItem<&_group_pool> {
 };
 
 
-static inline bool IsDefaultGroupID(GroupID index)
+inline bool IsDefaultGroupID(GroupID index)
 {
 	return index == DEFAULT_GROUP;
 }
@@ -97,7 +97,7 @@ static inline bool IsDefaultGroupID(GroupID index)
  * @param id_g The GroupID to check
  * @return true is id_g is identical to ALL_GROUP
  */
-static inline bool IsAllGroupID(GroupID id_g)
+inline bool IsAllGroupID(GroupID id_g)
 {
 	return id_g == ALL_GROUP;
 }

--- a/src/house.h
+++ b/src/house.h
@@ -137,7 +137,7 @@ struct HouseSpec {
  * @param hid the HouseID to get the override for.
  * @return the HouseID to actually work with.
  */
-static inline HouseID GetTranslatedHouseID(HouseID hid)
+inline HouseID GetTranslatedHouseID(HouseID hid)
 {
 	const HouseSpec *hs = HouseSpec::Get(hid);
 	return hs->grf_prop.override == INVALID_HOUSE_ID ? hid : hs->grf_prop.override;

--- a/src/industry_map.h
+++ b/src/industry_map.h
@@ -60,7 +60,7 @@ enum IndustryGraphics {
  * @pre IsTileType(t, MP_INDUSTRY)
  * @return the industry ID
  */
-static inline IndustryID GetIndustryIndex(Tile t)
+inline IndustryID GetIndustryIndex(Tile t)
 {
 	assert(IsTileType(t, MP_INDUSTRY));
 	return t.m2();
@@ -72,7 +72,7 @@ static inline IndustryID GetIndustryIndex(Tile t)
  * @pre IsTileType(t, MP_INDUSTRY)
  * @return true if and only if the industry tile is fully built
  */
-static inline bool IsIndustryCompleted(Tile t)
+inline bool IsIndustryCompleted(Tile t)
 {
 	assert(IsTileType(t, MP_INDUSTRY));
 	return HasBit(t.m1(), 7);
@@ -85,7 +85,7 @@ IndustryType GetIndustryType(Tile tile);
  * @param tile the tile to query
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-static inline void SetIndustryCompleted(Tile tile)
+inline void SetIndustryCompleted(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	SB(tile.m1(), 7, 1, 1);
@@ -97,7 +97,7 @@ static inline void SetIndustryCompleted(Tile tile)
  * @pre IsTileType(tile, MP_INDUSTRY)
  * @return the construction stage
  */
-static inline byte GetIndustryConstructionStage(Tile tile)
+inline byte GetIndustryConstructionStage(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	return IsIndustryCompleted(tile) ? (byte)INDUSTRY_COMPLETED : GB(tile.m1(), 0, 2);
@@ -109,7 +109,7 @@ static inline byte GetIndustryConstructionStage(Tile tile)
  * @param value the new construction stage
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-static inline void SetIndustryConstructionStage(Tile tile, byte value)
+inline void SetIndustryConstructionStage(Tile tile, byte value)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	SB(tile.m1(), 0, 2, value);
@@ -122,7 +122,7 @@ static inline void SetIndustryConstructionStage(Tile tile, byte value)
  * @pre IsTileType(t, MP_INDUSTRY)
  * @return the gfx ID
  */
-static inline IndustryGfx GetCleanIndustryGfx(Tile t)
+inline IndustryGfx GetCleanIndustryGfx(Tile t)
 {
 	assert(IsTileType(t, MP_INDUSTRY));
 	return t.m5() | (GB(t.m6(), 2, 1) << 8);
@@ -134,7 +134,7 @@ static inline IndustryGfx GetCleanIndustryGfx(Tile t)
  * @pre IsTileType(t, MP_INDUSTRY)
  * @return the gfx ID
  */
-static inline IndustryGfx GetIndustryGfx(Tile t)
+inline IndustryGfx GetIndustryGfx(Tile t)
 {
 	assert(IsTileType(t, MP_INDUSTRY));
 	return GetTranslatedIndustryTileID(GetCleanIndustryGfx(t));
@@ -146,7 +146,7 @@ static inline IndustryGfx GetIndustryGfx(Tile t)
  * @pre IsTileType(t, MP_INDUSTRY)
  * @param gfx the graphics ID
  */
-static inline void SetIndustryGfx(Tile t, IndustryGfx gfx)
+inline void SetIndustryGfx(Tile t, IndustryGfx gfx)
 {
 	assert(IsTileType(t, MP_INDUSTRY));
 	t.m5() = GB(gfx, 0, 8);
@@ -159,7 +159,7 @@ static inline void SetIndustryGfx(Tile t, IndustryGfx gfx)
  * @pre IsTileType(tile, MP_INDUSTRY)
  * @return the construction counter
  */
-static inline byte GetIndustryConstructionCounter(Tile tile)
+inline byte GetIndustryConstructionCounter(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	return GB(tile.m1(), 2, 2);
@@ -171,7 +171,7 @@ static inline byte GetIndustryConstructionCounter(Tile tile)
  * @param value the new value for the construction counter
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-static inline void SetIndustryConstructionCounter(Tile tile, byte value)
+inline void SetIndustryConstructionCounter(Tile tile, byte value)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	SB(tile.m1(), 2, 2, value);
@@ -184,7 +184,7 @@ static inline void SetIndustryConstructionCounter(Tile tile, byte value)
  * @param tile the tile to query
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-static inline void ResetIndustryConstructionStage(Tile tile)
+inline void ResetIndustryConstructionStage(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	SB(tile.m1(), 0, 4, 0);
@@ -196,7 +196,7 @@ static inline void ResetIndustryConstructionStage(Tile tile)
  * @param tile the tile to get the animation loop number of
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-static inline byte GetIndustryAnimationLoop(Tile tile)
+inline byte GetIndustryAnimationLoop(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	return tile.m4();
@@ -208,7 +208,7 @@ static inline byte GetIndustryAnimationLoop(Tile tile)
  * @param count the new animation frame number
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-static inline void SetIndustryAnimationLoop(Tile tile, byte count)
+inline void SetIndustryAnimationLoop(Tile tile, byte count)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	tile.m4() = count;
@@ -221,7 +221,7 @@ static inline void SetIndustryAnimationLoop(Tile tile, byte count)
  * @pre IsTileType(tile, MP_INDUSTRY)
  * @return requested bits
  */
-static inline byte GetIndustryRandomBits(Tile tile)
+inline byte GetIndustryRandomBits(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	return tile.m3();
@@ -234,7 +234,7 @@ static inline byte GetIndustryRandomBits(Tile tile)
  * @param bits the random bits
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-static inline void SetIndustryRandomBits(Tile tile, byte bits)
+inline void SetIndustryRandomBits(Tile tile, byte bits)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	tile.m3() = bits;
@@ -247,7 +247,7 @@ static inline void SetIndustryRandomBits(Tile tile, byte bits)
  * @pre IsTileType(tile, MP_INDUSTRY)
  * @return requested triggers
  */
-static inline byte GetIndustryTriggers(Tile tile)
+inline byte GetIndustryTriggers(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	return GB(tile.m6(), 3, 3);
@@ -261,7 +261,7 @@ static inline byte GetIndustryTriggers(Tile tile)
  * @param triggers the triggers to set
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-static inline void SetIndustryTriggers(Tile tile, byte triggers)
+inline void SetIndustryTriggers(Tile tile, byte triggers)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	SB(tile.m6(), 3, 3, triggers);
@@ -275,7 +275,7 @@ static inline void SetIndustryTriggers(Tile tile, byte triggers)
  * @param random the random value
  * @param wc     the water class for this industry; only useful when build on water
  */
-static inline void MakeIndustry(Tile t, IndustryID index, IndustryGfx gfx, uint8_t random, WaterClass wc)
+inline void MakeIndustry(Tile t, IndustryID index, IndustryGfx gfx, uint8_t random, WaterClass wc)
 {
 	SetTileType(t, MP_INDUSTRY);
 	t.m1() = 0;

--- a/src/industrytype.h
+++ b/src/industrytype.h
@@ -189,7 +189,7 @@ extern std::array<IndustryType, NUM_INDUSTRYTYPES> _sorted_industry_types;
  * @param gfx the type to get the override for.
  * @return the gfx to actually work with.
  */
-static inline IndustryGfx GetTranslatedIndustryTileID(IndustryGfx gfx)
+inline IndustryGfx GetTranslatedIndustryTileID(IndustryGfx gfx)
 {
 	/* the 0xFF should be GFX_WATERTILE_SPECIALCHECK but for reasons of include mess,
 	 * we'll simplify the writing.

--- a/src/landscape.h
+++ b/src/landscape.h
@@ -50,7 +50,7 @@ void GetSlopePixelZOnEdge(Slope tileh, DiagDirection edge, int *z1, int *z2);
  * @param corner The corner.
  * @return Z position of corner relative to TileZ.
  */
-static inline int GetSlopePixelZInCorner(Slope tileh, Corner corner)
+inline int GetSlopePixelZInCorner(Slope tileh, Corner corner)
 {
 	return GetSlopeZInCorner(tileh, corner) * TILE_HEIGHT;
 }
@@ -63,7 +63,7 @@ static inline int GetSlopePixelZInCorner(Slope tileh, Corner corner)
  * @param z returns the z of the foundation slope. (Can be nullptr, if not needed)
  * @return The slope on top of the foundation.
  */
-static inline Slope GetFoundationPixelSlope(TileIndex tile, int *z)
+inline Slope GetFoundationPixelSlope(TileIndex tile, int *z)
 {
 	assert(z != nullptr);
 	Slope s = GetFoundationSlope(tile, z);
@@ -79,7 +79,7 @@ static inline Slope GetFoundationPixelSlope(TileIndex tile, int *z)
  * @return Equivalent coordinate in the 2D view.
  * @see RemapCoords2
  */
-static inline Point RemapCoords(int x, int y, int z)
+inline Point RemapCoords(int x, int y, int z)
 {
 	Point pt;
 	pt.x = (y - x) * 2 * ZOOM_LVL_BASE;
@@ -95,7 +95,7 @@ static inline Point RemapCoords(int x, int y, int z)
  * @return Equivalent coordinate in the 2D view.
  * @see RemapCoords
  */
-static inline Point RemapCoords2(int x, int y)
+inline Point RemapCoords2(int x, int y)
 {
 	return RemapCoords(x, y, GetSlopePixelZ(x, y, false));
 }
@@ -109,7 +109,7 @@ static inline Point RemapCoords2(int x, int y)
  * @note Inverse of #RemapCoords function. Smaller values may get rounded.
  * @see InverseRemapCoords2
  */
-static inline Point InverseRemapCoords(int x, int y)
+inline Point InverseRemapCoords(int x, int y)
 {
 	Point pt = {(y * 2 - x) >> (2 + ZOOM_LVL_SHIFT), (y * 2 + x) >> (2 + ZOOM_LVL_SHIFT)};
 	return pt;
@@ -126,7 +126,7 @@ uint ApplyFoundationToSlope(Foundation f, Slope *s);
  * @param s  The #Slope to modify.
  * @return   Increment to the tile Z coordinate.
  */
-static inline uint ApplyPixelFoundationToSlope(Foundation f, Slope *s)
+inline uint ApplyPixelFoundationToSlope(Foundation f, Slope *s)
 {
 	return ApplyFoundationToSlope(f, s) * TILE_HEIGHT;
 }

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -398,7 +398,7 @@ debug_inline static TileIndex TileXY(uint x, uint y)
  * @return The resulting offset value of the given coordinate
  * @see ToTileIndexDiff(TileIndexDiffC)
  */
-static inline TileIndexDiff TileDiffXY(int x, int y)
+inline TileIndexDiff TileDiffXY(int x, int y)
 {
 	/* Multiplication gives much better optimization on MSVC than shifting.
 	 * 0 << shift isn't optimized to 0 properly.
@@ -449,7 +449,7 @@ debug_inline static uint TileY(TileIndex tile)
  * @return The difference between two tiles.
  * @see TileDiffXY(int, int)
  */
-static inline TileIndexDiff ToTileIndexDiff(TileIndexDiffC tidc)
+inline TileIndexDiff ToTileIndexDiff(TileIndexDiffC tidc)
 {
 	return (tidc.y << Map::LogX()) + tidc.x;
 }
@@ -487,7 +487,7 @@ TileIndex TileAddWrap(TileIndex tile, int addx, int addy);
  * @param dir The given direction
  * @return The offset as TileIndexDiffC value
  */
-static inline TileIndexDiffC TileIndexDiffCByDiagDir(DiagDirection dir)
+inline TileIndexDiffC TileIndexDiffCByDiagDir(DiagDirection dir)
 {
 	extern const TileIndexDiffC _tileoffs_by_diagdir[DIAGDIR_END];
 
@@ -501,7 +501,7 @@ static inline TileIndexDiffC TileIndexDiffCByDiagDir(DiagDirection dir)
  * @param dir The given direction
  * @return The offset as TileIndexDiffC value
  */
-static inline TileIndexDiffC TileIndexDiffCByDir(Direction dir)
+inline TileIndexDiffC TileIndexDiffCByDir(Direction dir)
 {
 	extern const TileIndexDiffC _tileoffs_by_dir[DIR_END];
 
@@ -519,7 +519,7 @@ static inline TileIndexDiffC TileIndexDiffCByDir(Direction dir)
  * @param diff The offset to add on the tile
  * @return The resulting TileIndex
  */
-static inline TileIndex AddTileIndexDiffCWrap(TileIndex tile, TileIndexDiffC diff)
+inline TileIndex AddTileIndexDiffCWrap(TileIndex tile, TileIndexDiffC diff)
 {
 	int x = TileX(tile) + diff.x;
 	int y = TileY(tile) + diff.y;
@@ -535,7 +535,7 @@ static inline TileIndex AddTileIndexDiffCWrap(TileIndex tile, TileIndexDiffC dif
  * @param tile_b to tile
  * @return the difference between tila_a and tile_b
  */
-static inline TileIndexDiffC TileIndexToTileIndexDiffC(TileIndex tile_a, TileIndex tile_b)
+inline TileIndexDiffC TileIndexToTileIndexDiffC(TileIndex tile_a, TileIndex tile_b)
 {
 	TileIndexDiffC difference;
 
@@ -560,7 +560,7 @@ uint DistanceFromEdgeDir(TileIndex, DiagDirection); ///< distance from the map e
  * @return The resulting TileIndexDiff
  * @see TileIndexDiffCByDiagDir
  */
-static inline TileIndexDiff TileOffsByDiagDir(DiagDirection dir)
+inline TileIndexDiff TileOffsByDiagDir(DiagDirection dir)
 {
 	extern const TileIndexDiffC _tileoffs_by_diagdir[DIAGDIR_END];
 
@@ -574,7 +574,7 @@ static inline TileIndexDiff TileOffsByDiagDir(DiagDirection dir)
  * @param dir The direction to convert from
  * @return The resulting TileIndexDiff
  */
-static inline TileIndexDiff TileOffsByDir(Direction dir)
+inline TileIndexDiff TileOffsByDir(Direction dir)
 {
 	extern const TileIndexDiffC _tileoffs_by_dir[DIR_END];
 
@@ -589,7 +589,7 @@ static inline TileIndexDiff TileOffsByDir(Direction dir)
  * @param dir The direction in which we want to step
  * @return the moved tile
  */
-static inline TileIndex TileAddByDir(TileIndex tile, Direction dir)
+inline TileIndex TileAddByDir(TileIndex tile, Direction dir)
 {
 	return TILE_ADD(tile, TileOffsByDir(dir));
 }
@@ -601,7 +601,7 @@ static inline TileIndex TileAddByDir(TileIndex tile, Direction dir)
  * @param dir The direction in which we want to step
  * @return the moved tile
  */
-static inline TileIndex TileAddByDiagDir(TileIndex tile, DiagDirection dir)
+inline TileIndex TileAddByDiagDir(TileIndex tile, DiagDirection dir)
 {
 	return TILE_ADD(tile, TileOffsByDiagDir(dir));
 }
@@ -613,7 +613,7 @@ static inline TileIndex TileAddByDiagDir(TileIndex tile, DiagDirection dir)
  * @param tile_to Destination tile
  * @return DiagDirection from tile_from towards tile_to, or INVALID_DIAGDIR if the tiles are not on an axis
  */
-static inline DiagDirection DiagdirBetweenTiles(TileIndex tile_from, TileIndex tile_to)
+inline DiagDirection DiagdirBetweenTiles(TileIndex tile_from, TileIndex tile_to)
 {
 	int dx = (int)TileX(tile_to) - (int)TileX(tile_from);
 	int dy = (int)TileY(tile_to) - (int)TileY(tile_from);
@@ -643,7 +643,7 @@ bool CircularTileSearch(TileIndex *tile, uint radius, uint w, uint h, TestTileOn
  * @param r the random 'seed'
  * @return a valid tile
  */
-static inline TileIndex RandomTileSeed(uint32_t r)
+inline TileIndex RandomTileSeed(uint32_t r)
 {
 	return Map::WrapToMap(r);
 }

--- a/src/network/core/os_abstraction.h
+++ b/src/network/core/os_abstraction.h
@@ -121,7 +121,7 @@ typedef unsigned long in_addr_t;
  * @param address The address returned by those four functions.
  * @return The correct value for addrlen.
  */
-static inline socklen_t FixAddrLenForEmscripten(struct sockaddr_storage &address)
+inline socklen_t FixAddrLenForEmscripten(struct sockaddr_storage &address)
 {
 	switch (address.ss_family) {
 		case AF_INET6: return sizeof(struct sockaddr_in6);

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -186,7 +186,7 @@ struct GRFLoadedFeatures {
  * @param bit The bit to check.
  * @return Whether the bit is set.
  */
-static inline bool HasGrfMiscBit(GrfMiscBit bit)
+inline bool HasGrfMiscBit(GrfMiscBit bit)
 {
 	extern byte _misc_grf_features;
 	return HasBit(_misc_grf_features, bit);

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -71,7 +71,7 @@ DECLARE_ENUM_AS_BIT_SET(TileLayoutFlags)
  * @param num_sprites Number of available sprites to select stage from.
  * @return Sprite to use
  */
-static inline uint GetConstructionStageOffset(uint construction_stage, uint num_sprites)
+inline uint GetConstructionStageOffset(uint construction_stage, uint num_sprites)
 {
 	assert(num_sprites > 0);
 	if (num_sprites > 4) num_sprites = 4;

--- a/src/newgrf_generic.h
+++ b/src/newgrf_generic.h
@@ -51,7 +51,7 @@ uint16_t GetAiPurchaseCallbackResult(uint8_t feature, CargoID cargo_type, uint8_
 void AmbientSoundEffectCallback(TileIndex tile);
 
 /** Play an ambient sound effect for an empty tile. */
-static inline void AmbientSoundEffect(TileIndex tile)
+inline void AmbientSoundEffect(TileIndex tile)
 {
 	/* Only run callback if enabled. */
 	if (!HasGrfMiscBit(GMB_AMBIENT_SOUND_CALLBACK)) return;

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -26,7 +26,7 @@
  * @pre i < 0x110
  * @return the value of the register
  */
-static inline uint32_t GetRegister(uint i)
+inline uint32_t GetRegister(uint i)
 {
 	extern TemporaryStorageArray<int32_t, 0x110> _temp_store;
 	return _temp_store.GetValue(i);

--- a/src/news_func.h
+++ b/src/news_func.h
@@ -17,7 +17,7 @@
 
 void AddNewsItem(StringID string, NewsType type, NewsFlag flags, NewsReferenceType reftype1 = NR_NONE, uint32_t ref1 = UINT32_MAX, NewsReferenceType reftype2 = NR_NONE, uint32_t ref2 = UINT32_MAX, const NewsAllocatedData *data = nullptr);
 
-static inline void AddCompanyNewsItem(StringID string, CompanyNewsInformation *cni)
+inline void AddCompanyNewsItem(StringID string, CompanyNewsInformation *cni)
 {
 	AddNewsItem(string, NT_COMPANY_INFO, NF_COMPANY, NR_NONE, UINT32_MAX, NR_NONE, UINT32_MAX, cni);
 }
@@ -27,7 +27,7 @@ static inline void AddCompanyNewsItem(StringID string, CompanyNewsInformation *c
  *
  * @warning The DParams may not reference the vehicle due to autoreplace stuff. See AddVehicleAdviceNewsItem for how that can be done.
  */
-static inline void AddVehicleNewsItem(StringID string, NewsType type, VehicleID vehicle, StationID station = INVALID_STATION)
+inline void AddVehicleNewsItem(StringID string, NewsType type, VehicleID vehicle, StationID station = INVALID_STATION)
 {
 	AddNewsItem(string, type, NF_NO_TRANSPARENT | NF_SHADE | NF_THIN, NR_VEHICLE, vehicle, station == INVALID_STATION ? NR_NONE : NR_STATION, station);
 }
@@ -37,17 +37,17 @@ static inline void AddVehicleNewsItem(StringID string, NewsType type, VehicleID 
  *
  * @warning DParam 0 must reference the vehicle!
  */
-static inline void AddVehicleAdviceNewsItem(StringID string, VehicleID vehicle)
+inline void AddVehicleAdviceNewsItem(StringID string, VehicleID vehicle)
 {
 	AddNewsItem(string, NT_ADVICE, NF_INCOLOUR | NF_SMALL | NF_VEHICLE_PARAM0, NR_VEHICLE, vehicle);
 }
 
-static inline void AddTileNewsItem(StringID string, NewsType type, TileIndex tile, const NewsAllocatedData *data = nullptr, StationID station = INVALID_STATION)
+inline void AddTileNewsItem(StringID string, NewsType type, TileIndex tile, const NewsAllocatedData *data = nullptr, StationID station = INVALID_STATION)
 {
 	AddNewsItem(string, type, NF_NO_TRANSPARENT | NF_SHADE | NF_THIN, NR_TILE, tile.base(), station == INVALID_STATION ? NR_NONE : NR_STATION, station, data);
 }
 
-static inline void AddIndustryNewsItem(StringID string, NewsType type, IndustryID industry, const NewsAllocatedData *data = nullptr)
+inline void AddIndustryNewsItem(StringID string, NewsType type, IndustryID industry, const NewsAllocatedData *data = nullptr)
 {
 	AddNewsItem(string, type, NF_NO_TRANSPARENT | NF_SHADE | NF_THIN, NR_INDUSTRY, industry, NR_NONE, UINT32_MAX, data);
 }

--- a/src/object_map.h
+++ b/src/object_map.h
@@ -22,7 +22,7 @@ ObjectType GetObjectType(Tile t);
  * @pre IsTileType(t, MP_OBJECT)
  * @return True if type matches.
  */
-static inline bool IsObjectType(Tile t, ObjectType type)
+inline bool IsObjectType(Tile t, ObjectType type)
 {
 	return GetObjectType(t) == type;
 }
@@ -33,7 +33,7 @@ static inline bool IsObjectType(Tile t, ObjectType type)
  * @param type Type to test.
  * @return True if type matches.
  */
-static inline bool IsObjectTypeTile(Tile t, ObjectType type)
+inline bool IsObjectTypeTile(Tile t, ObjectType type)
 {
 	return IsTileType(t, MP_OBJECT) && GetObjectType(t) == type;
 }
@@ -44,7 +44,7 @@ static inline bool IsObjectTypeTile(Tile t, ObjectType type)
  * @pre IsTileType(t, MP_OBJECT)
  * @return The ObjectID of the object.
  */
-static inline ObjectID GetObjectIndex(Tile t)
+inline ObjectID GetObjectIndex(Tile t)
 {
 	assert(IsTileType(t, MP_OBJECT));
 	return t.m2() | t.m5() << 16;
@@ -56,7 +56,7 @@ static inline ObjectID GetObjectIndex(Tile t)
  * @pre IsTileType(t, MP_OBJECT)
  * @return The random bits.
  */
-static inline byte GetObjectRandomBits(Tile t)
+inline byte GetObjectRandomBits(Tile t)
 {
 	assert(IsTileType(t, MP_OBJECT));
 	return t.m3();
@@ -71,7 +71,7 @@ static inline byte GetObjectRandomBits(Tile t)
  * @param wc     Water class for this object.
  * @param random Random data to store on the tile
  */
-static inline void MakeObject(Tile t, Owner o, ObjectID index, WaterClass wc, byte random)
+inline void MakeObject(Tile t, Owner o, ObjectID index, WaterClass wc, byte random)
 {
 	SetTileType(t, MP_OBJECT);
 	SetTileOwner(t, o);

--- a/src/os/macosx/macos.h
+++ b/src/os/macosx/macos.h
@@ -22,7 +22,7 @@ void GetMacOSVersion(int *return_major, int *return_minor, int *return_bugfix);
  * @param bugfix bugfix version of the os. This would be 11 in the case of 10.4.11.
  * @return true if the running os is at least what we asked, false otherwise.
  */
-static inline bool MacOSVersionIsAtLeast(long major, long minor, long bugfix)
+inline bool MacOSVersionIsAtLeast(long major, long minor, long bugfix)
 {
 	int version_major, version_minor, version_bugfix;
 	GetMacOSVersion(&version_major, &version_minor, &version_bugfix);

--- a/src/palette_func.h
+++ b/src/palette_func.h
@@ -21,7 +21,7 @@ void GfxInitPalettes();
 
 uint8_t GetNearestColourIndex(uint8_t r, uint8_t g, uint8_t b);
 
-static inline uint8_t GetNearestColourIndex(const Colour colour)
+inline uint8_t GetNearestColourIndex(const Colour colour)
 {
 	return GetNearestColourIndex(colour.r, colour.g, colour.b);
 }
@@ -32,7 +32,7 @@ static inline uint8_t GetNearestColourIndex(const Colour colour)
  * @param colours The value to check
  * @return true if the given value is a valid Colours.
  */
-static inline bool IsValidColours(Colours colours)
+inline bool IsValidColours(Colours colours)
 {
 	return colours < COLOUR_END;
 }

--- a/src/pathfinder/pathfinder_func.h
+++ b/src/pathfinder/pathfinder_func.h
@@ -22,7 +22,7 @@
  * @param station_type the station type to get the closest tile of
  * @return The closest station tile to the given tile.
  */
-static inline TileIndex CalcClosestStationTile(StationID station, TileIndex tile, StationType station_type)
+inline TileIndex CalcClosestStationTile(StationID station, TileIndex tile, StationType station_type)
 {
 	const BaseStation *st = BaseStation::Get(station);
 	TileArea ta;
@@ -57,7 +57,7 @@ static inline TileIndex CalcClosestStationTile(StationID station, TileIndex tile
  * the pathfinders cannot exit on the wrong side and allows reversing on such
  * tiles.
  */
-static inline TrackdirBits GetTrackdirBitsForRoad(TileIndex tile, RoadTramType rtt)
+inline TrackdirBits GetTrackdirBitsForRoad(TileIndex tile, RoadTramType rtt)
 {
 	TrackdirBits bits = TrackStatusToTrackdirBits(GetTileTrackStatus(tile, TRANSPORT_ROAD, rtt));
 

--- a/src/pbs.h
+++ b/src/pbs.h
@@ -55,7 +55,7 @@ Train *GetTrainForReservation(TileIndex tile, Track track);
  * @param tracks the tracks to test
  * @return true if at least on of tracks is reserved
  */
-static inline bool HasReservedTracks(TileIndex tile, TrackBits tracks)
+inline bool HasReservedTracks(TileIndex tile, TrackBits tracks)
 {
 	return (GetReservedTrackbits(tile) & tracks) != TRACK_BIT_NONE;
 }

--- a/src/progress.h
+++ b/src/progress.h
@@ -14,7 +14,7 @@
  * Check if we are currently in a modal progress state.
  * @return Are we in the modal state?
  */
-static inline bool HasModalProgress()
+inline bool HasModalProgress()
 {
 	extern bool _in_modal_progress;
 	return _in_modal_progress;

--- a/src/rail.h
+++ b/src/rail.h
@@ -301,7 +301,7 @@ public:
  * @param railtype the rail type which the information is requested for
  * @return The pointer to the RailTypeInfo
  */
-static inline const RailTypeInfo *GetRailTypeInfo(RailType railtype)
+inline const RailTypeInfo *GetRailTypeInfo(RailType railtype)
 {
 	extern RailTypeInfo _railtypes[RAILTYPE_END];
 	assert(railtype < RAILTYPE_END);
@@ -316,7 +316,7 @@ static inline const RailTypeInfo *GetRailTypeInfo(RailType railtype)
  * @param  enginetype The RailType of the engine we are considering.
  * @param  tiletype   The RailType of the tile we are considering.
  */
-static inline bool IsCompatibleRail(RailType enginetype, RailType tiletype)
+inline bool IsCompatibleRail(RailType enginetype, RailType tiletype)
 {
 	return HasBit(GetRailTypeInfo(enginetype)->compatible_railtypes, tiletype);
 }
@@ -329,7 +329,7 @@ static inline bool IsCompatibleRail(RailType enginetype, RailType tiletype)
  * @param  enginetype The RailType of the engine we are considering.
  * @param  tiletype   The RailType of the tile we are considering.
  */
-static inline bool HasPowerOnRail(RailType enginetype, RailType tiletype)
+inline bool HasPowerOnRail(RailType enginetype, RailType tiletype)
 {
 	return HasBit(GetRailTypeInfo(enginetype)->powered_railtypes, tiletype);
 }
@@ -339,7 +339,7 @@ static inline bool HasPowerOnRail(RailType enginetype, RailType tiletype)
  * @param rt The RailType to check.
  * @return Whether level crossings are not allowed.
  */
-static inline bool RailNoLevelCrossings(RailType rt)
+inline bool RailNoLevelCrossings(RailType rt)
 {
 	return HasBit(GetRailTypeInfo(rt)->flags, RTF_NO_LEVEL_CROSSING);
 }
@@ -351,7 +351,7 @@ static inline bool RailNoLevelCrossings(RailType rt)
  * @param def Default value to use if the rail type doesn't specify anything.
  * @return True if 90 degree turns are disallowed between the two rail types.
  */
-static inline bool Rail90DegTurnDisallowed(RailType rt1, RailType rt2, bool def = _settings_game.pf.forbid_90_deg)
+inline bool Rail90DegTurnDisallowed(RailType rt1, RailType rt2, bool def = _settings_game.pf.forbid_90_deg)
 {
 	if (rt1 == INVALID_RAILTYPE || rt2 == INVALID_RAILTYPE) return def;
 
@@ -369,7 +369,7 @@ static inline bool Rail90DegTurnDisallowed(RailType rt1, RailType rt2, bool def 
  * @param railtype The railtype being built.
  * @return The cost multiplier.
  */
-static inline Money RailBuildCost(RailType railtype)
+inline Money RailBuildCost(RailType railtype)
 {
 	assert(railtype < RAILTYPE_END);
 	return (_price[PR_BUILD_RAIL] * GetRailTypeInfo(railtype)->cost_multiplier) >> 3;
@@ -380,7 +380,7 @@ static inline Money RailBuildCost(RailType railtype)
  * @param railtype The railtype being removed.
  * @return The cost.
  */
-static inline Money RailClearCost(RailType railtype)
+inline Money RailClearCost(RailType railtype)
 {
 	/* Clearing rail in fact earns money, but if the build cost is set
 	 * very low then a loophole exists where money can be made.
@@ -397,7 +397,7 @@ static inline Money RailClearCost(RailType railtype)
  * @param to   The railtype we are converting to
  * @return Cost per TrackBit
  */
-static inline Money RailConvertCost(RailType from, RailType to)
+inline Money RailConvertCost(RailType from, RailType to)
 {
 	/* Get the costs for removing and building anew
 	 * A conversion can never be more costly */
@@ -424,7 +424,7 @@ static inline Money RailConvertCost(RailType from, RailType to)
  * @param total_num Total number of track bits of all railtypes.
  * @return Total cost.
  */
-static inline Money RailMaintenanceCost(RailType railtype, uint32_t num, uint32_t total_num)
+inline Money RailMaintenanceCost(RailType railtype, uint32_t num, uint32_t total_num)
 {
 	assert(railtype < RAILTYPE_END);
 	return (_price[PR_INFRASTRUCTURE_RAIL] * GetRailTypeInfo(railtype)->maintenance_multiplier * num * (1 + IntSqrt(total_num))) >> 11; // 4 bits fraction for the multiplier and 7 bits scaling.
@@ -435,7 +435,7 @@ static inline Money RailMaintenanceCost(RailType railtype, uint32_t num, uint32_
  * @param num Number of signals.
  * @return Total cost.
  */
-static inline Money SignalMaintenanceCost(uint32_t num)
+inline Money SignalMaintenanceCost(uint32_t num)
 {
 	return (_price[PR_INFRASTRUCTURE_RAIL] * 15 * num * (1 + IntSqrt(num))) >> 8; // 1 bit fraction for the multiplier and 7 bits scaling.
 }

--- a/src/rail_map.h
+++ b/src/rail_map.h
@@ -69,7 +69,7 @@ debug_inline static bool IsPlainRailTile(Tile t)
  * @pre IsTileType(t, MP_RAILWAY)
  * @return true if and only if the tile has signals
  */
-static inline bool HasSignals(Tile t)
+inline bool HasSignals(Tile t)
 {
 	return GetRailTileType(t) == RAIL_TILE_SIGNALS;
 }
@@ -80,7 +80,7 @@ static inline bool HasSignals(Tile t)
  * @param signals whether the rail tile should have signals or not
  * @pre IsPlainRailTile(tile)
  */
-static inline void SetHasSignals(Tile tile, bool signals)
+inline void SetHasSignals(Tile tile, bool signals)
 {
 	assert(IsPlainRailTile(tile));
 	SB(tile.m5(), 6, 1, signals);
@@ -112,7 +112,7 @@ debug_inline static bool IsRailDepotTile(Tile t)
  * @param t the tile to get the rail type from
  * @return the rail type of the tile
  */
-static inline RailType GetRailType(Tile t)
+inline RailType GetRailType(Tile t)
 {
 	return (RailType)GB(t.m8(), 0, 6);
 }
@@ -122,7 +122,7 @@ static inline RailType GetRailType(Tile t)
  * @param t the tile to set the rail type of
  * @param r the new rail type for the tile
  */
-static inline void SetRailType(Tile t, RailType r)
+inline void SetRailType(Tile t, RailType r)
 {
 	SB(t.m8(), 0, 6, r);
 }
@@ -133,7 +133,7 @@ static inline void SetRailType(Tile t, RailType r)
  * @param tile the tile to get the track bits from
  * @return the track bits of the tile
  */
-static inline TrackBits GetTrackBits(Tile tile)
+inline TrackBits GetTrackBits(Tile tile)
 {
 	assert(IsPlainRailTile(tile));
 	return (TrackBits)GB(tile.m5(), 0, 6);
@@ -144,7 +144,7 @@ static inline TrackBits GetTrackBits(Tile tile)
  * @param t the tile to set the track bits of
  * @param b the new track bits for the tile
  */
-static inline void SetTrackBits(Tile t, TrackBits b)
+inline void SetTrackBits(Tile t, TrackBits b)
 {
 	assert(IsPlainRailTile(t));
 	SB(t.m5(), 0, 6, b);
@@ -157,7 +157,7 @@ static inline void SetTrackBits(Tile t, TrackBits b)
  * @pre IsPlainRailTile(tile)
  * @return true if and only if the given track exists on the tile
  */
-static inline bool HasTrack(Tile tile, Track track)
+inline bool HasTrack(Tile tile, Track track)
 {
 	return HasBit(GetTrackBits(tile), track);
 }
@@ -168,7 +168,7 @@ static inline bool HasTrack(Tile tile, Track track)
  * @pre IsRailDepotTile(t)
  * @return the direction the depot is facing
  */
-static inline DiagDirection GetRailDepotDirection(Tile t)
+inline DiagDirection GetRailDepotDirection(Tile t)
 {
 	return (DiagDirection)GB(t.m5(), 0, 2);
 }
@@ -179,7 +179,7 @@ static inline DiagDirection GetRailDepotDirection(Tile t)
  * @param t the tile to get the depot track from
  * @return the track of the depot
  */
-static inline Track GetRailDepotTrack(Tile t)
+inline Track GetRailDepotTrack(Tile t)
 {
 	return DiagDirToDiagTrack(GetRailDepotDirection(t));
 }
@@ -191,7 +191,7 @@ static inline Track GetRailDepotTrack(Tile t)
  * @param t the tile to query
  * @return the track bits
  */
-static inline TrackBits GetRailReservationTrackBits(Tile t)
+inline TrackBits GetRailReservationTrackBits(Tile t)
 {
 	assert(IsPlainRailTile(t));
 	byte track_b = GB(t.m2(), 8, 3);
@@ -206,7 +206,7 @@ static inline TrackBits GetRailReservationTrackBits(Tile t)
  * @param t the tile to change
  * @param b the track bits
  */
-static inline void SetTrackReservation(Tile t, TrackBits b)
+inline void SetTrackReservation(Tile t, TrackBits b)
 {
 	assert(IsPlainRailTile(t));
 	assert(b != INVALID_TRACK_BIT);
@@ -223,7 +223,7 @@ static inline void SetTrackReservation(Tile t, TrackBits b)
  * @param t the rack to reserve
  * @return true if successful
  */
-static inline bool TryReserveTrack(Tile tile, Track t)
+inline bool TryReserveTrack(Tile tile, Track t)
 {
 	assert(HasTrack(tile, t));
 	TrackBits bits = TrackToTrackBits(t);
@@ -241,7 +241,7 @@ static inline bool TryReserveTrack(Tile tile, Track t)
  * @param tile the tile
  * @param t the track to free
  */
-static inline void UnreserveTrack(Tile tile, Track t)
+inline void UnreserveTrack(Tile tile, Track t)
 {
 	assert(HasTrack(tile, t));
 	TrackBits res = GetRailReservationTrackBits(tile);
@@ -255,7 +255,7 @@ static inline void UnreserveTrack(Tile tile, Track t)
  * @param t the depot tile
  * @return reservation state
  */
-static inline bool HasDepotReservation(Tile t)
+inline bool HasDepotReservation(Tile t)
 {
 	assert(IsRailDepot(t));
 	return HasBit(t.m5(), 4);
@@ -267,7 +267,7 @@ static inline bool HasDepotReservation(Tile t)
  * @param t the depot tile
  * @param b the reservation state
  */
-static inline void SetDepotReservation(Tile t, bool b)
+inline void SetDepotReservation(Tile t, bool b)
 {
 	assert(IsRailDepot(t));
 	SB(t.m5(), 4, 1, (byte)b);
@@ -279,25 +279,25 @@ static inline void SetDepotReservation(Tile t, bool b)
  * @param t the tile
  * @return reserved track bits
  */
-static inline TrackBits GetDepotReservationTrackBits(Tile t)
+inline TrackBits GetDepotReservationTrackBits(Tile t)
 {
 	return HasDepotReservation(t) ? TrackToTrackBits(GetRailDepotTrack(t)) : TRACK_BIT_NONE;
 }
 
 
-static inline bool IsPbsSignal(SignalType s)
+inline bool IsPbsSignal(SignalType s)
 {
 	return s == SIGTYPE_PBS || s == SIGTYPE_PBS_ONEWAY;
 }
 
-static inline SignalType GetSignalType(Tile t, Track track)
+inline SignalType GetSignalType(Tile t, Track track)
 {
 	assert(GetRailTileType(t) == RAIL_TILE_SIGNALS);
 	byte pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 4 : 0;
 	return (SignalType)GB(t.m2(), pos, 3);
 }
 
-static inline void SetSignalType(Tile t, Track track, SignalType s)
+inline void SetSignalType(Tile t, Track track, SignalType s)
 {
 	assert(GetRailTileType(t) == RAIL_TILE_SIGNALS);
 	byte pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 4 : 0;
@@ -305,23 +305,23 @@ static inline void SetSignalType(Tile t, Track track, SignalType s)
 	if (track == INVALID_TRACK) SB(t.m2(), 4, 3, s);
 }
 
-static inline bool IsPresignalEntry(Tile t, Track track)
+inline bool IsPresignalEntry(Tile t, Track track)
 {
 	return GetSignalType(t, track) == SIGTYPE_ENTRY || GetSignalType(t, track) == SIGTYPE_COMBO;
 }
 
-static inline bool IsPresignalExit(Tile t, Track track)
+inline bool IsPresignalExit(Tile t, Track track)
 {
 	return GetSignalType(t, track) == SIGTYPE_EXIT || GetSignalType(t, track) == SIGTYPE_COMBO;
 }
 
 /** One-way signals can't be passed the 'wrong' way. */
-static inline bool IsOnewaySignal(Tile t, Track track)
+inline bool IsOnewaySignal(Tile t, Track track)
 {
 	return GetSignalType(t, track) != SIGTYPE_PBS;
 }
 
-static inline void CycleSignalSide(Tile t, Track track)
+inline void CycleSignalSide(Tile t, Track track)
 {
 	byte sig;
 	byte pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 4 : 6;
@@ -331,13 +331,13 @@ static inline void CycleSignalSide(Tile t, Track track)
 	SB(t.m3(), pos, 2, sig);
 }
 
-static inline SignalVariant GetSignalVariant(Tile t, Track track)
+inline SignalVariant GetSignalVariant(Tile t, Track track)
 {
 	byte pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 7 : 3;
 	return (SignalVariant)GB(t.m2(), pos, 1);
 }
 
-static inline void SetSignalVariant(Tile t, Track track, SignalVariant v)
+inline void SetSignalVariant(Tile t, Track track, SignalVariant v)
 {
 	byte pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 7 : 3;
 	SB(t.m2(), pos, 1, v);
@@ -349,7 +349,7 @@ static inline void SetSignalVariant(Tile t, Track track, SignalVariant v)
  * @param tile  the tile to set the states for
  * @param state the new state
  */
-static inline void SetSignalStates(Tile tile, uint state)
+inline void SetSignalStates(Tile tile, uint state)
 {
 	SB(tile.m4(), 4, 4, state);
 }
@@ -359,7 +359,7 @@ static inline void SetSignalStates(Tile tile, uint state)
  * @param tile  the tile to set the states for
  * @return the state of the signals
  */
-static inline uint GetSignalStates(Tile tile)
+inline uint GetSignalStates(Tile tile)
 {
 	return GB(tile.m4(), 4, 4);
 }
@@ -370,7 +370,7 @@ static inline uint GetSignalStates(Tile tile)
  * @param signalbit the signal
  * @return the state of the signal
  */
-static inline SignalState GetSingleSignalState(Tile t, byte signalbit)
+inline SignalState GetSingleSignalState(Tile t, byte signalbit)
 {
 	return (SignalState)HasBit(GetSignalStates(t), signalbit);
 }
@@ -380,7 +380,7 @@ static inline SignalState GetSingleSignalState(Tile t, byte signalbit)
  * @param tile    the tile to set the present signals for
  * @param signals the signals that have to be present
  */
-static inline void SetPresentSignals(Tile tile, uint signals)
+inline void SetPresentSignals(Tile tile, uint signals)
 {
 	SB(tile.m3(), 4, 4, signals);
 }
@@ -390,7 +390,7 @@ static inline void SetPresentSignals(Tile tile, uint signals)
  * @param tile the tile to get the present signals for
  * @return the signals that are present
  */
-static inline uint GetPresentSignals(Tile tile)
+inline uint GetPresentSignals(Tile tile)
 {
 	return GB(tile.m3(), 4, 4);
 }
@@ -401,7 +401,7 @@ static inline uint GetPresentSignals(Tile tile)
  * @param signalbit the signal
  * @return true if and only if the signal is present
  */
-static inline bool IsSignalPresent(Tile t, byte signalbit)
+inline bool IsSignalPresent(Tile t, byte signalbit)
 {
 	return HasBit(GetPresentSignals(t), signalbit);
 }
@@ -410,7 +410,7 @@ static inline bool IsSignalPresent(Tile t, byte signalbit)
  * Checks for the presence of signals (either way) on the given track on the
  * given rail tile.
  */
-static inline bool HasSignalOnTrack(Tile tile, Track track)
+inline bool HasSignalOnTrack(Tile tile, Track track)
 {
 	assert(IsValidTrack(track));
 	return GetRailTileType(tile) == RAIL_TILE_SIGNALS && (GetPresentSignals(tile) & SignalOnTrack(track)) != 0;
@@ -423,7 +423,7 @@ static inline bool HasSignalOnTrack(Tile tile, Track track)
  * Along meaning if you are currently driving on the given trackdir, this is
  * the signal that is facing us (for which we stop when it's red).
  */
-static inline bool HasSignalOnTrackdir(Tile tile, Trackdir trackdir)
+inline bool HasSignalOnTrackdir(Tile tile, Trackdir trackdir)
 {
 	assert (IsValidTrackdir(trackdir));
 	return GetRailTileType(tile) == RAIL_TILE_SIGNALS && GetPresentSignals(tile) & SignalAlongTrackdir(trackdir);
@@ -435,7 +435,7 @@ static inline bool HasSignalOnTrackdir(Tile tile, Trackdir trackdir)
  * Along meaning if you are currently driving on the given trackdir, this is
  * the signal that is facing us (for which we stop when it's red).
  */
-static inline SignalState GetSignalStateByTrackdir(Tile tile, Trackdir trackdir)
+inline SignalState GetSignalStateByTrackdir(Tile tile, Trackdir trackdir)
 {
 	assert(IsValidTrackdir(trackdir));
 	assert(HasSignalOnTrack(tile, TrackdirToTrack(trackdir)));
@@ -446,7 +446,7 @@ static inline SignalState GetSignalStateByTrackdir(Tile tile, Trackdir trackdir)
 /**
  * Sets the state of the signal along the given trackdir.
  */
-static inline void SetSignalStateByTrackdir(Tile tile, Trackdir trackdir, SignalState state)
+inline void SetSignalStateByTrackdir(Tile tile, Trackdir trackdir, SignalState state)
 {
 	if (state == SIGNAL_STATE_GREEN) { // set 1
 		SetSignalStates(tile, GetSignalStates(tile) | SignalAlongTrackdir(trackdir));
@@ -460,7 +460,7 @@ static inline void SetSignalStateByTrackdir(Tile tile, Trackdir trackdir, Signal
  * @param tile the tile to check
  * @param td the trackdir to check
  */
-static inline bool HasPbsSignalOnTrackdir(Tile tile, Trackdir td)
+inline bool HasPbsSignalOnTrackdir(Tile tile, Trackdir td)
 {
 	return IsTileType(tile, MP_RAILWAY) && HasSignalOnTrackdir(tile, td) &&
 			IsPbsSignal(GetSignalType(tile, TrackdirToTrack(td)));
@@ -472,7 +472,7 @@ static inline bool HasPbsSignalOnTrackdir(Tile tile, Trackdir td)
  * @param tile the tile to check
  * @param td the trackdir to check
  */
-static inline bool HasOnewaySignalBlockingTrackdir(Tile tile, Trackdir td)
+inline bool HasOnewaySignalBlockingTrackdir(Tile tile, Trackdir td)
 {
 	return IsTileType(tile, MP_RAILWAY) && HasSignalOnTrackdir(tile, ReverseTrackdir(td)) &&
 			!HasSignalOnTrackdir(tile, td) && IsOnewaySignal(tile, TrackdirToTrack(td));
@@ -500,23 +500,23 @@ enum RailGroundType {
 	RAIL_GROUND_HALF_SNOW    = 14, ///< Snow only on higher part of slope (steep or one corner raised)
 };
 
-static inline void SetRailGroundType(Tile t, RailGroundType rgt)
+inline void SetRailGroundType(Tile t, RailGroundType rgt)
 {
 	SB(t.m4(), 0, 4, rgt);
 }
 
-static inline RailGroundType GetRailGroundType(Tile t)
+inline RailGroundType GetRailGroundType(Tile t)
 {
 	return (RailGroundType)GB(t.m4(), 0, 4);
 }
 
-static inline bool IsSnowRailGround(Tile t)
+inline bool IsSnowRailGround(Tile t)
 {
 	return GetRailGroundType(t) == RAIL_GROUND_ICE_DESERT;
 }
 
 
-static inline void MakeRailNormal(Tile t, Owner o, TrackBits b, RailType r)
+inline void MakeRailNormal(Tile t, Owner o, TrackBits b, RailType r)
 {
 	SetTileType(t, MP_RAILWAY);
 	SetTileOwner(t, o);
@@ -535,7 +535,7 @@ static inline void MakeRailNormal(Tile t, Owner o, TrackBits b, RailType r)
  * @param tile Tile of the depot.
  * @param dir  Direction of the depot exit.
  */
-static inline void SetRailDepotExitDirection(Tile tile, DiagDirection dir)
+inline void SetRailDepotExitDirection(Tile tile, DiagDirection dir)
 {
 	assert(IsRailDepotTile(tile));
 	SB(tile.m5(), 0, 2, dir);
@@ -549,7 +549,7 @@ static inline void SetRailDepotExitDirection(Tile tile, DiagDirection dir)
  * @param dir       Direction of the depot exit.
  * @param rail_type Rail type of the depot.
  */
-static inline void MakeRailDepot(Tile tile, Owner owner, DepotID depot_id, DiagDirection dir, RailType rail_type)
+inline void MakeRailDepot(Tile tile, Owner owner, DepotID depot_id, DiagDirection dir, RailType rail_type)
 {
 	SetTileType(tile, MP_RAILWAY);
 	SetTileOwner(tile, owner);

--- a/src/road.h
+++ b/src/road.h
@@ -196,22 +196,22 @@ public:
 
 extern RoadTypes _roadtypes_type;
 
-static inline bool RoadTypeIsRoad(RoadType roadtype)
+inline bool RoadTypeIsRoad(RoadType roadtype)
 {
 	return !HasBit(_roadtypes_type, roadtype);
 }
 
-static inline bool RoadTypeIsTram(RoadType roadtype)
+inline bool RoadTypeIsTram(RoadType roadtype)
 {
 	return HasBit(_roadtypes_type, roadtype);
 }
 
-static inline RoadTramType GetRoadTramType(RoadType roadtype)
+inline RoadTramType GetRoadTramType(RoadType roadtype)
 {
 	return RoadTypeIsTram(roadtype) ? RTT_TRAM : RTT_ROAD;
 }
 
-static inline RoadTramType OtherRoadTramType(RoadTramType rtt)
+inline RoadTramType OtherRoadTramType(RoadTramType rtt)
 {
 	return rtt == RTT_ROAD ? RTT_TRAM : RTT_ROAD;
 }
@@ -221,7 +221,7 @@ static inline RoadTramType OtherRoadTramType(RoadTramType rtt)
  * @param roadtype the road type which the information is requested for
  * @return The pointer to the RoadTypeInfo
  */
-static inline const RoadTypeInfo *GetRoadTypeInfo(RoadType roadtype)
+inline const RoadTypeInfo *GetRoadTypeInfo(RoadType roadtype)
 {
 	extern RoadTypeInfo _roadtypes[ROADTYPE_END];
 	assert(roadtype < ROADTYPE_END);
@@ -236,7 +236,7 @@ static inline const RoadTypeInfo *GetRoadTypeInfo(RoadType roadtype)
  * @param  enginetype The RoadType of the engine we are considering.
  * @param  tiletype   The RoadType of the tile we are considering.
  */
-static inline bool HasPowerOnRoad(RoadType enginetype, RoadType tiletype)
+inline bool HasPowerOnRoad(RoadType enginetype, RoadType tiletype)
 {
 	return HasBit(GetRoadTypeInfo(enginetype)->powered_roadtypes, tiletype);
 }
@@ -246,7 +246,7 @@ static inline bool HasPowerOnRoad(RoadType enginetype, RoadType tiletype)
  * @param roadtype The roadtype being built.
  * @return The cost multiplier.
  */
-static inline Money RoadBuildCost(RoadType roadtype)
+inline Money RoadBuildCost(RoadType roadtype)
 {
 	assert(roadtype < ROADTYPE_END);
 	return (_price[PR_BUILD_ROAD] * GetRoadTypeInfo(roadtype)->cost_multiplier) >> 3;
@@ -257,7 +257,7 @@ static inline Money RoadBuildCost(RoadType roadtype)
  * @param roadtype The roadtype being removed.
  * @return The cost.
  */
-static inline Money RoadClearCost(RoadType roadtype)
+inline Money RoadClearCost(RoadType roadtype)
 {
 	assert(roadtype < ROADTYPE_END);
 
@@ -275,7 +275,7 @@ static inline Money RoadClearCost(RoadType roadtype)
  * @param to   The roadtype we are converting to
  * @return Cost per RoadBit
  */
-static inline Money RoadConvertCost(RoadType from, RoadType to)
+inline Money RoadConvertCost(RoadType from, RoadType to)
 {
 	/* Don't apply convert costs when converting to the same roadtype (ex. building a roadstop over existing road) */
 	if (from == to) return (Money)0;
@@ -289,7 +289,7 @@ static inline Money RoadConvertCost(RoadType from, RoadType to)
  * @param roadtype The roadtype we are testing
  * @return True iff the roadtype disallows level crossings
  */
-static inline bool RoadNoLevelCrossing(RoadType roadtype)
+inline bool RoadNoLevelCrossing(RoadType roadtype)
 {
 	assert(roadtype < ROADTYPE_END);
 	return HasBit(GetRoadTypeInfo(roadtype)->flags, ROTF_NO_LEVEL_CROSSING);

--- a/src/road_func.h
+++ b/src/road_func.h
@@ -20,7 +20,7 @@
  * @param r the roadtype to check for validness
  * @return true if and only if valid
  */
-static inline bool IsValidRoadBits(RoadBits r)
+inline bool IsValidRoadBits(RoadBits r)
 {
 	return r < ROAD_END;
 }
@@ -34,7 +34,7 @@ static inline bool IsValidRoadBits(RoadBits r)
  * @param r The given RoadBits value
  * @return the complement
  */
-static inline RoadBits ComplementRoadBits(RoadBits r)
+inline RoadBits ComplementRoadBits(RoadBits r)
 {
 	assert(IsValidRoadBits(r));
 	return (RoadBits)(ROAD_ALL ^ r);
@@ -48,7 +48,7 @@ static inline RoadBits ComplementRoadBits(RoadBits r)
  * @param r The given RoadBits value
  * @return the mirrored
  */
-static inline RoadBits MirrorRoadBits(RoadBits r)
+inline RoadBits MirrorRoadBits(RoadBits r)
 {
 	assert(IsValidRoadBits(r));
 	return (RoadBits)(GB(r, 0, 2) << 2 | GB(r, 2, 2));
@@ -63,7 +63,7 @@ static inline RoadBits MirrorRoadBits(RoadBits r)
  * @param rot The given Rotation angle
  * @return the rotated
  */
-static inline RoadBits RotateRoadBits(RoadBits r, DiagDirDiff rot)
+inline RoadBits RotateRoadBits(RoadBits r, DiagDirDiff rot)
 {
 	assert(IsValidRoadBits(r));
 	for (; rot > (DiagDirDiff)0; rot--) {
@@ -78,7 +78,7 @@ static inline RoadBits RotateRoadBits(RoadBits r, DiagDirDiff rot)
  * @param r The given RoadBits
  * @return true if we've got a straight road
  */
-static inline bool IsStraightRoad(RoadBits r)
+inline bool IsStraightRoad(RoadBits r)
 {
 	assert(IsValidRoadBits(r));
 	return (r == ROAD_X || r == ROAD_Y);
@@ -93,7 +93,7 @@ static inline bool IsStraightRoad(RoadBits r)
  * @param d The DiagDirection
  * @return The result RoadBits which the selected road-part set
  */
-static inline RoadBits DiagDirToRoadBits(DiagDirection d)
+inline RoadBits DiagDirToRoadBits(DiagDirection d)
 {
 	assert(IsValidDiagDirection(d));
 	return (RoadBits)(ROAD_NW << (3 ^ d));
@@ -108,7 +108,7 @@ static inline RoadBits DiagDirToRoadBits(DiagDirection d)
  * @param a The Axis
  * @return The result RoadBits which the selected road-part set
  */
-static inline RoadBits AxisToRoadBits(Axis a)
+inline RoadBits AxisToRoadBits(Axis a)
 {
 	assert(IsValidAxis(a));
 	return a == AXIS_X ? ROAD_X : ROAD_Y;
@@ -122,7 +122,7 @@ static inline RoadBits AxisToRoadBits(Axis a)
  * @param total_num Total number of road bits of all road/tram-types.
  * @return Total cost.
  */
-static inline Money RoadMaintenanceCost(RoadType roadtype, uint32_t num, uint32_t total_num)
+inline Money RoadMaintenanceCost(RoadType roadtype, uint32_t num, uint32_t total_num)
 {
 	assert(roadtype < ROADTYPE_END);
 	return (_price[PR_INFRASTRUCTURE_ROAD] * GetRoadTypeInfo(roadtype)->maintenance_multiplier * num * (1 + IntSqrt(total_num))) >> 12;
@@ -132,7 +132,7 @@ static inline Money RoadMaintenanceCost(RoadType roadtype, uint32_t num, uint32_
  * Test if a road type has catenary
  * @param roadtype Road type to test
  */
-static inline bool HasRoadCatenary(RoadType roadtype)
+inline bool HasRoadCatenary(RoadType roadtype)
 {
 	assert(roadtype < ROADTYPE_END);
 	return HasBit(GetRoadTypeInfo(roadtype)->flags, ROTF_CATENARY);
@@ -142,7 +142,7 @@ static inline bool HasRoadCatenary(RoadType roadtype)
  * Test if we should draw road catenary
  * @param roadtype Road type to test
  */
-static inline bool HasRoadCatenaryDrawn(RoadType roadtype)
+inline bool HasRoadCatenaryDrawn(RoadType roadtype)
 {
 	return HasRoadCatenary(roadtype) && !IsInvisibilitySet(TO_CATENARY);
 }

--- a/src/road_map.h
+++ b/src/road_map.h
@@ -30,7 +30,7 @@ enum RoadTileType {
  * @param t Tile to query.
  * @return true if tile can be queried about road/tram types.
  */
-static inline bool MayHaveRoad(Tile t)
+inline bool MayHaveRoad(Tile t)
 {
 	switch (GetTileType(t)) {
 		case MP_ROAD:
@@ -82,7 +82,7 @@ debug_inline static bool IsNormalRoadTile(Tile t)
  * @pre IsTileType(t, MP_ROAD)
  * @return True if level crossing.
  */
-static inline bool IsLevelCrossing(Tile t)
+inline bool IsLevelCrossing(Tile t)
 {
 	return GetRoadTileType(t) == ROAD_TILE_CROSSING;
 }
@@ -92,7 +92,7 @@ static inline bool IsLevelCrossing(Tile t)
  * @param t Tile to query.
  * @return True if level crossing tile.
  */
-static inline bool IsLevelCrossingTile(Tile t)
+inline bool IsLevelCrossingTile(Tile t)
 {
 	return IsTileType(t, MP_ROAD) && IsLevelCrossing(t);
 }
@@ -125,7 +125,7 @@ debug_inline static bool IsRoadDepotTile(Tile t)
  * @pre IsNormalRoad(t)
  * @return The present road bits for the road type.
  */
-static inline RoadBits GetRoadBits(Tile t, RoadTramType rtt)
+inline RoadBits GetRoadBits(Tile t, RoadTramType rtt)
 {
 	assert(IsNormalRoad(t));
 	if (rtt == RTT_TRAM) return (RoadBits)GB(t.m3(), 0, 4);
@@ -138,7 +138,7 @@ static inline RoadBits GetRoadBits(Tile t, RoadTramType rtt)
  * @param tile The tile from which we want to get the RoadBits
  * @return all set RoadBits of the tile
  */
-static inline RoadBits GetAllRoadBits(Tile tile)
+inline RoadBits GetAllRoadBits(Tile tile)
 {
 	return GetRoadBits(tile, RTT_ROAD) | GetRoadBits(tile, RTT_TRAM);
 }
@@ -150,7 +150,7 @@ static inline RoadBits GetAllRoadBits(Tile tile)
  * @param rt Road type.
  * @pre IsNormalRoad(t)
  */
-static inline void SetRoadBits(Tile t, RoadBits r, RoadTramType rtt)
+inline void SetRoadBits(Tile t, RoadBits r, RoadTramType rtt)
 {
 	assert(IsNormalRoad(t)); // XXX incomplete
 	if (rtt == RTT_TRAM) {
@@ -160,19 +160,19 @@ static inline void SetRoadBits(Tile t, RoadBits r, RoadTramType rtt)
 	}
 }
 
-static inline RoadType GetRoadTypeRoad(Tile t)
+inline RoadType GetRoadTypeRoad(Tile t)
 {
 	assert(MayHaveRoad(t));
 	return (RoadType)GB(t.m4(), 0, 6);
 }
 
-static inline RoadType GetRoadTypeTram(Tile t)
+inline RoadType GetRoadTypeTram(Tile t)
 {
 	assert(MayHaveRoad(t));
 	return (RoadType)GB(t.m8(), 6, 6);
 }
 
-static inline RoadType GetRoadType(Tile t, RoadTramType rtt)
+inline RoadType GetRoadType(Tile t, RoadTramType rtt)
 {
 	return (rtt == RTT_TRAM) ? GetRoadTypeTram(t) : GetRoadTypeRoad(t);
 }
@@ -182,7 +182,7 @@ static inline RoadType GetRoadType(Tile t, RoadTramType rtt)
  * @param t The tile to query.
  * @return Present road types.
  */
-static inline RoadTypes GetPresentRoadTypes(Tile t)
+inline RoadTypes GetPresentRoadTypes(Tile t)
 {
 	RoadTypes result = ROADTYPES_NONE;
 	if (MayHaveRoad(t)) {
@@ -192,12 +192,12 @@ static inline RoadTypes GetPresentRoadTypes(Tile t)
 	return result;
 }
 
-static inline bool HasRoadTypeRoad(Tile t)
+inline bool HasRoadTypeRoad(Tile t)
 {
 	return GetRoadTypeRoad(t) != INVALID_ROADTYPE;
 }
 
-static inline bool HasRoadTypeTram(Tile t)
+inline bool HasRoadTypeTram(Tile t)
 {
 	return GetRoadTypeTram(t) != INVALID_ROADTYPE;
 }
@@ -208,7 +208,7 @@ static inline bool HasRoadTypeTram(Tile t)
  * @param tram True to check tram, false to check road.
  * @return True if the tile has the specified road type.
  */
-static inline bool HasTileRoadType(Tile t, RoadTramType rtt)
+inline bool HasTileRoadType(Tile t, RoadTramType rtt)
 {
 	return GetRoadType(t, rtt) != INVALID_ROADTYPE;
 }
@@ -219,7 +219,7 @@ static inline bool HasTileRoadType(Tile t, RoadTramType rtt)
  * @param rts Allowed road types.
  * @return True if the tile has one of the specified road types.
  */
-static inline bool HasTileAnyRoadType(Tile t, RoadTypes rts)
+inline bool HasTileAnyRoadType(Tile t, RoadTypes rts)
 {
 	if (!MayHaveRoad(t)) return false;
 	return (GetPresentRoadTypes(t) & rts);
@@ -231,7 +231,7 @@ static inline bool HasTileAnyRoadType(Tile t, RoadTypes rts)
  * @param rtt RoadTramType.
  * @return Owner of the given road type.
  */
-static inline Owner GetRoadOwner(Tile t, RoadTramType rtt)
+inline Owner GetRoadOwner(Tile t, RoadTramType rtt)
 {
 	assert(MayHaveRoad(t));
 	if (rtt == RTT_ROAD) return (Owner)GB(IsNormalRoadTile(t) ? t.m1() : t.m7(), 0, 5);
@@ -248,7 +248,7 @@ static inline Owner GetRoadOwner(Tile t, RoadTramType rtt)
  * @param rtt RoadTramType.
  * @param o  New owner of the given road type.
  */
-static inline void SetRoadOwner(Tile t, RoadTramType rtt, Owner o)
+inline void SetRoadOwner(Tile t, RoadTramType rtt, Owner o)
 {
 	if (rtt == RTT_ROAD) {
 		SB(IsNormalRoadTile(t) ? t.m1() : t.m7(), 0, 5, o);
@@ -265,7 +265,7 @@ static inline void SetRoadOwner(Tile t, RoadTramType rtt, Owner o)
  * @pre HasTileRoadType(t, rt)
  * @return True if the road type is owned by the given owner.
  */
-static inline bool IsRoadOwner(Tile t, RoadTramType rtt, Owner o)
+inline bool IsRoadOwner(Tile t, RoadTramType rtt, Owner o)
 {
 	assert(HasTileRoadType(t, rtt));
 	return (GetRoadOwner(t, rtt) == o);
@@ -277,7 +277,7 @@ static inline bool IsRoadOwner(Tile t, RoadTramType rtt, Owner o)
  * @pre IsTileType(t, MP_ROAD)
  * @return true iff tile has road and the road is owned by a town
  */
-static inline bool HasTownOwnedRoad(Tile t)
+inline bool HasTownOwnedRoad(Tile t)
 {
 	return HasTileRoadType(t, RTT_ROAD) && IsRoadOwner(t, RTT_ROAD, OWNER_TOWN);
 }
@@ -288,7 +288,7 @@ static inline bool HasTownOwnedRoad(Tile t)
  * @param wc The value to check
  * @return true if the given value is a valid DisallowedRoadDirections.
  */
-static inline bool IsValidDisallowedRoadDirections(DisallowedRoadDirections drt)
+inline bool IsValidDisallowedRoadDirections(DisallowedRoadDirections drt)
 {
 	return drt < DRD_END;
 }
@@ -298,7 +298,7 @@ static inline bool IsValidDisallowedRoadDirections(DisallowedRoadDirections drt)
  * @param t the tile to get the directions from
  * @return the disallowed directions
  */
-static inline DisallowedRoadDirections GetDisallowedRoadDirections(Tile t)
+inline DisallowedRoadDirections GetDisallowedRoadDirections(Tile t)
 {
 	assert(IsNormalRoad(t));
 	return (DisallowedRoadDirections)GB(t.m5(), 4, 2);
@@ -309,7 +309,7 @@ static inline DisallowedRoadDirections GetDisallowedRoadDirections(Tile t)
  * @param t   the tile to set the directions for
  * @param drd the disallowed directions
  */
-static inline void SetDisallowedRoadDirections(Tile t, DisallowedRoadDirections drd)
+inline void SetDisallowedRoadDirections(Tile t, DisallowedRoadDirections drd)
 {
 	assert(IsNormalRoad(t));
 	assert(drd < DRD_END);
@@ -322,7 +322,7 @@ static inline void SetDisallowedRoadDirections(Tile t, DisallowedRoadDirections 
  * @pre IsLevelCrossing(t)
  * @return The axis of the road.
  */
-static inline Axis GetCrossingRoadAxis(Tile t)
+inline Axis GetCrossingRoadAxis(Tile t)
 {
 	assert(IsLevelCrossing(t));
 	return (Axis)GB(t.m5(), 0, 1);
@@ -334,7 +334,7 @@ static inline Axis GetCrossingRoadAxis(Tile t)
  * @pre IsLevelCrossing(t)
  * @return The axis of the rail.
  */
-static inline Axis GetCrossingRailAxis(Tile t)
+inline Axis GetCrossingRailAxis(Tile t)
 {
 	assert(IsLevelCrossing(t));
 	return OtherAxis((Axis)GetCrossingRoadAxis(t));
@@ -345,7 +345,7 @@ static inline Axis GetCrossingRailAxis(Tile t)
  * @param tile The tile to query.
  * @return The present road bits.
  */
-static inline RoadBits GetCrossingRoadBits(Tile tile)
+inline RoadBits GetCrossingRoadBits(Tile tile)
 {
 	return GetCrossingRoadAxis(tile) == AXIS_X ? ROAD_X : ROAD_Y;
 }
@@ -355,7 +355,7 @@ static inline RoadBits GetCrossingRoadBits(Tile tile)
  * @param tile The tile to query.
  * @return The rail track.
  */
-static inline Track GetCrossingRailTrack(Tile tile)
+inline Track GetCrossingRailTrack(Tile tile)
 {
 	return AxisToTrack(GetCrossingRailAxis(tile));
 }
@@ -365,7 +365,7 @@ static inline Track GetCrossingRailTrack(Tile tile)
  * @param tile The tile to query.
  * @return The rail track bits.
  */
-static inline TrackBits GetCrossingRailBits(Tile tile)
+inline TrackBits GetCrossingRailBits(Tile tile)
 {
 	return AxisToTrackBits(GetCrossingRailAxis(tile));
 }
@@ -377,7 +377,7 @@ static inline TrackBits GetCrossingRailBits(Tile tile)
  * @return reservation state
  * @pre IsLevelCrossingTile(t)
  */
-static inline bool HasCrossingReservation(Tile t)
+inline bool HasCrossingReservation(Tile t)
 {
 	assert(IsLevelCrossingTile(t));
 	return HasBit(t.m5(), 4);
@@ -390,7 +390,7 @@ static inline bool HasCrossingReservation(Tile t)
  * @param b the reservation state
  * @pre IsLevelCrossingTile(t)
  */
-static inline void SetCrossingReservation(Tile t, bool b)
+inline void SetCrossingReservation(Tile t, bool b)
 {
 	assert(IsLevelCrossingTile(t));
 	SB(t.m5(), 4, 1, b ? 1 : 0);
@@ -402,7 +402,7 @@ static inline void SetCrossingReservation(Tile t, bool b)
  * @pre IsLevelCrossingTile(t)
  * @return reserved track bits
  */
-static inline TrackBits GetCrossingReservationTrackBits(Tile t)
+inline TrackBits GetCrossingReservationTrackBits(Tile t)
 {
 	return HasCrossingReservation(t) ? GetCrossingRailBits(t) : TRACK_BIT_NONE;
 }
@@ -413,7 +413,7 @@ static inline TrackBits GetCrossingReservationTrackBits(Tile t)
  * @pre IsLevelCrossing(t)
  * @return True if the level crossing is barred.
  */
-static inline bool IsCrossingBarred(Tile t)
+inline bool IsCrossingBarred(Tile t)
 {
 	assert(IsLevelCrossing(t));
 	return HasBit(t.m5(), 5);
@@ -425,7 +425,7 @@ static inline bool IsCrossingBarred(Tile t)
  * @param barred True if the crossing should be barred, false otherwise.
  * @pre IsLevelCrossing(t)
  */
-static inline void SetCrossingBarred(Tile t, bool barred)
+inline void SetCrossingBarred(Tile t, bool barred)
 {
 	assert(IsLevelCrossing(t));
 	SB(t.m5(), 5, 1, barred ? 1 : 0);
@@ -435,7 +435,7 @@ static inline void SetCrossingBarred(Tile t, bool barred)
  * Unbar a level crossing.
  * @param t The tile to change.
  */
-static inline void UnbarCrossing(Tile t)
+inline void UnbarCrossing(Tile t)
 {
 	SetCrossingBarred(t, false);
 }
@@ -444,7 +444,7 @@ static inline void UnbarCrossing(Tile t)
  * Bar a level crossing.
  * @param t The tile to change.
  */
-static inline void BarCrossing(Tile t)
+inline void BarCrossing(Tile t)
 {
 	SetCrossingBarred(t, true);
 }
@@ -456,7 +456,7 @@ static inline void BarCrossing(Tile t)
  * @param t The tile to query.
  * @return True if the tile has snow/desert.
  */
-static inline bool IsOnSnow(Tile t)
+inline bool IsOnSnow(Tile t)
 {
 	return HasBit(t.m7(), 5);
 }
@@ -467,7 +467,7 @@ static inline bool IsOnSnow(Tile t)
  * Toggle the snow/desert state of a road tile.
  * @param t The tile to change.
  */
-static inline void ToggleSnow(Tile t)
+inline void ToggleSnow(Tile t)
 {
 	ToggleBit(t.m7(), 5);
 }
@@ -490,7 +490,7 @@ enum Roadside {
  * @param tile The tile to query.
  * @return The road decoration of the tile.
  */
-static inline Roadside GetRoadside(Tile tile)
+inline Roadside GetRoadside(Tile tile)
 {
 	return (Roadside)GB(tile.m6(), 3, 3);
 }
@@ -500,7 +500,7 @@ static inline Roadside GetRoadside(Tile tile)
  * @param tile The tile to change.
  * @param s    The new road decoration of the tile.
  */
-static inline void SetRoadside(Tile tile, Roadside s)
+inline void SetRoadside(Tile tile, Roadside s)
 {
 	SB(tile.m6(), 3, 3, s);
 }
@@ -510,7 +510,7 @@ static inline void SetRoadside(Tile tile, Roadside s)
  * @param t The tile to check.
  * @return True if the tile has road works in progress.
  */
-static inline bool HasRoadWorks(Tile t)
+inline bool HasRoadWorks(Tile t)
 {
 	return GetRoadside(t) >= ROADSIDE_GRASS_ROAD_WORKS;
 }
@@ -520,7 +520,7 @@ static inline bool HasRoadWorks(Tile t)
  * @param t The tile to modify.
  * @return True if the road works are in the last stage.
  */
-static inline bool IncreaseRoadWorksCounter(Tile t)
+inline bool IncreaseRoadWorksCounter(Tile t)
 {
 	AB(t.m7(), 0, 4, 1);
 
@@ -532,7 +532,7 @@ static inline bool IncreaseRoadWorksCounter(Tile t)
  * @param t The tile to start the work on.
  * @pre !HasRoadWorks(t)
  */
-static inline void StartRoadWorks(Tile t)
+inline void StartRoadWorks(Tile t)
 {
 	assert(!HasRoadWorks(t));
 	/* Remove any trees or lamps in case or roadwork */
@@ -548,7 +548,7 @@ static inline void StartRoadWorks(Tile t)
  * @param t Tile to stop the road works on.
  * @pre HasRoadWorks(t)
  */
-static inline void TerminateRoadWorks(Tile t)
+inline void TerminateRoadWorks(Tile t)
 {
 	assert(HasRoadWorks(t));
 	SetRoadside(t, (Roadside)(GetRoadside(t) - ROADSIDE_GRASS_ROAD_WORKS + ROADSIDE_GRASS));
@@ -562,7 +562,7 @@ static inline void TerminateRoadWorks(Tile t)
  * @param t The tile to query.
  * @return Diagonal direction of the depot exit.
  */
-static inline DiagDirection GetRoadDepotDirection(Tile t)
+inline DiagDirection GetRoadDepotDirection(Tile t)
 {
 	assert(IsRoadDepot(t));
 	return (DiagDirection)GB(t.m5(), 0, 2);
@@ -576,7 +576,7 @@ RoadBits GetAnyRoadBits(Tile tile, RoadTramType rtt, bool straight_tunnel_bridge
  * @param t The tile to change.
  * @param rt The road type to set.
  */
-static inline void SetRoadTypeRoad(Tile t, RoadType rt)
+inline void SetRoadTypeRoad(Tile t, RoadType rt)
 {
 	assert(MayHaveRoad(t));
 	assert(rt == INVALID_ROADTYPE || RoadTypeIsRoad(rt));
@@ -588,7 +588,7 @@ static inline void SetRoadTypeRoad(Tile t, RoadType rt)
  * @param t The tile to change.
  * @param rt The road type to set.
  */
-static inline void SetRoadTypeTram(Tile t, RoadType rt)
+inline void SetRoadTypeTram(Tile t, RoadType rt)
 {
 	assert(MayHaveRoad(t));
 	assert(rt == INVALID_ROADTYPE || RoadTypeIsTram(rt));
@@ -601,7 +601,7 @@ static inline void SetRoadTypeTram(Tile t, RoadType rt)
  * @param rtt Set road or tram type.
  * @param rt The road type to set.
  */
-static inline void SetRoadType(Tile t, RoadTramType rtt, RoadType rt)
+inline void SetRoadType(Tile t, RoadTramType rtt, RoadType rt)
 {
 	if (rtt == RTT_TRAM) {
 		SetRoadTypeTram(t, rt);
@@ -616,7 +616,7 @@ static inline void SetRoadType(Tile t, RoadTramType rtt, RoadType rt)
  * @param road_rt The road roadtype to set for the tile.
  * @param tram_rt The tram roadtype to set for the tile.
  */
-static inline void SetRoadTypes(Tile t, RoadType road_rt, RoadType tram_rt)
+inline void SetRoadTypes(Tile t, RoadType road_rt, RoadType tram_rt)
 {
 	SetRoadTypeRoad(t, road_rt);
 	SetRoadTypeTram(t, tram_rt);
@@ -632,7 +632,7 @@ static inline void SetRoadTypes(Tile t, RoadType road_rt, RoadType tram_rt)
  * @param road    New owner of road.
  * @param tram    New owner of tram tracks.
  */
-static inline void MakeRoadNormal(Tile t, RoadBits bits, RoadType road_rt, RoadType tram_rt, TownID town, Owner road, Owner tram)
+inline void MakeRoadNormal(Tile t, RoadBits bits, RoadType road_rt, RoadType tram_rt, TownID town, Owner road, Owner tram)
 {
 	SetTileType(t, MP_ROAD);
 	SetTileOwner(t, road);
@@ -657,7 +657,7 @@ static inline void MakeRoadNormal(Tile t, RoadBits bits, RoadType road_rt, RoadT
  * @param tram_rt The tram roadtype to set for the tile.
  * @param town    Town ID if the road is a town-owned road.
  */
-static inline void MakeRoadCrossing(Tile t, Owner road, Owner tram, Owner rail, Axis roaddir, RailType rat, RoadType road_rt, RoadType tram_rt, uint town)
+inline void MakeRoadCrossing(Tile t, Owner road, Owner tram, Owner rail, Axis roaddir, RailType rat, RoadType road_rt, RoadType tram_rt, uint town)
 {
 	SetTileType(t, MP_ROAD);
 	SetTileOwner(t, rail);
@@ -677,7 +677,7 @@ static inline void MakeRoadCrossing(Tile t, Owner road, Owner tram, Owner rail, 
  * @param tile Tile of the depot.
  * @param dir  Direction of the depot exit.
  */
-static inline void SetRoadDepotExitDirection(Tile tile, DiagDirection dir)
+inline void SetRoadDepotExitDirection(Tile tile, DiagDirection dir)
 {
 	assert(IsRoadDepotTile(tile));
 	SB(tile.m5(), 0, 2, dir);
@@ -691,7 +691,7 @@ static inline void SetRoadDepotExitDirection(Tile tile, DiagDirection dir)
  * @param dir       Direction of the depot exit.
  * @param rt        Road type of the depot.
  */
-static inline void MakeRoadDepot(Tile tile, Owner owner, DepotID depot_id, DiagDirection dir, RoadType rt)
+inline void MakeRoadDepot(Tile tile, Owner owner, DepotID depot_id, DiagDirection dir, RoadType rt)
 {
 	SetTileType(tile, MP_ROAD);
 	SetTileOwner(tile, owner);

--- a/src/saveload/oldloader.h
+++ b/src/saveload/oldloader.h
@@ -100,13 +100,13 @@ bool LoadChunk(LoadgameState *ls, void *base, const OldChunks *chunks);
 bool LoadTTDMain(LoadgameState *ls);
 bool LoadTTOMain(LoadgameState *ls);
 
-static inline uint16_t ReadUint16(LoadgameState *ls)
+inline uint16_t ReadUint16(LoadgameState *ls)
 {
 	byte x = ReadByte(ls);
 	return x | ReadByte(ls) << 8;
 }
 
-static inline uint32_t ReadUint32(LoadgameState *ls)
+inline uint32_t ReadUint32(LoadgameState *ls)
 {
 	uint16_t x = ReadUint16(ls);
 	return x | ReadUint16(ls) << 16;

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -716,7 +716,7 @@ struct SaveLoadCompat {
  * @param type VarType holding information about the variable-type
  * @return the SLE_VAR_* part of a variable-type description
  */
-static inline constexpr VarType GetVarMemType(VarType type)
+inline constexpr VarType GetVarMemType(VarType type)
 {
 	return GB(type, 4, 4) << 4;
 }
@@ -727,7 +727,7 @@ static inline constexpr VarType GetVarMemType(VarType type)
  * @param type VarType holding information about the file-type
  * @return the SLE_FILE_* part of a variable-type description
  */
-static inline constexpr VarType GetVarFileType(VarType type)
+inline constexpr VarType GetVarFileType(VarType type)
 {
 	return GB(type, 0, 4);
 }
@@ -737,7 +737,7 @@ static inline constexpr VarType GetVarFileType(VarType type)
  * @param conv the type to check
  * @return True if it's a numeric type.
  */
-static inline constexpr bool IsNumericType(VarType conv)
+inline constexpr bool IsNumericType(VarType conv)
 {
 	return GetVarMemType(conv) <= SLE_VAR_U64;
 }
@@ -747,7 +747,7 @@ static inline constexpr bool IsNumericType(VarType conv)
  * @param type VarType to get size of.
  * @return size of type in bytes.
  */
-static inline constexpr size_t SlVarSize(VarType type)
+inline constexpr size_t SlVarSize(VarType type)
 {
 	switch (GetVarMemType(type)) {
 		case SLE_VAR_BL: return sizeof(bool);
@@ -775,7 +775,7 @@ static inline constexpr size_t SlVarSize(VarType type)
  * @param size Actual size of variable.
  * @return true iff the sizes match.
  */
-static inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t length, size_t size)
+inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t length, size_t size)
 {
 	switch (cmd) {
 		case SL_VAR: return SlVarSize(type) == size;
@@ -1191,7 +1191,7 @@ static inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size
  * @param minor Minor number of the version to check against. If \a minor is 0 or not specified, only the major number is checked.
  * @return Savegame version is earlier than the specified version.
  */
-static inline bool IsSavegameVersionBefore(SaveLoadVersion major, byte minor = 0)
+inline bool IsSavegameVersionBefore(SaveLoadVersion major, byte minor = 0)
 {
 	extern SaveLoadVersion _sl_version;
 	extern byte            _sl_minor_version;
@@ -1205,7 +1205,7 @@ static inline bool IsSavegameVersionBefore(SaveLoadVersion major, byte minor = 0
  * @param major Major number of the version to check against.
  * @return Savegame version is at most the specified version.
  */
-static inline bool IsSavegameVersionBeforeOrAt(SaveLoadVersion major)
+inline bool IsSavegameVersionBeforeOrAt(SaveLoadVersion major)
 {
 	extern SaveLoadVersion _sl_version;
 	return _sl_version <= major;
@@ -1218,7 +1218,7 @@ static inline bool IsSavegameVersionBeforeOrAt(SaveLoadVersion major)
  * @param version_to   Exclusive savegame version upper bound. SL_MAX_VERSION if no upper bound.
  * @return Active savegame version falls within the given range.
  */
-static inline bool SlIsObjectCurrentlyValid(SaveLoadVersion version_from, SaveLoadVersion version_to)
+inline bool SlIsObjectCurrentlyValid(SaveLoadVersion version_from, SaveLoadVersion version_to)
 {
 	extern const SaveLoadVersion SAVEGAME_VERSION;
 	return version_from <= SAVEGAME_VERSION && SAVEGAME_VERSION < version_to;
@@ -1229,7 +1229,7 @@ static inline bool SlIsObjectCurrentlyValid(SaveLoadVersion version_from, SaveLo
  * everything else has a callback function that returns the address based
  * on the saveload data and the current object for non-globals.
  */
-static inline void *GetVariableAddress(const void *object, const SaveLoad &sld)
+inline void *GetVariableAddress(const void *object, const SaveLoad &sld)
 {
 	/* Entry is a null-variable, mostly used to read old savegames etc. */
 	if (GetVarMemType(sld.conv) == SLE_VAR_NULL) {
@@ -1273,7 +1273,7 @@ bool SaveloadCrashWithMissingNewGRFs();
  * anything with them, discarding them in effect
  * @param length The amount of bytes that is being treated this way
  */
-static inline void SlSkipBytes(size_t length)
+inline void SlSkipBytes(size_t length)
 {
 	for (; length != 0; length--) SlReadByte();
 }

--- a/src/saveload/saveload_error.hpp
+++ b/src/saveload/saveload_error.hpp
@@ -26,7 +26,7 @@ void NORETURN SlErrorCorrupt(const std::string &msg);
  *       break out of all the saveload code.
  */
 template <typename T, typename ... Args>
-static inline void NORETURN SlErrorCorruptFmt(const T &format, Args&&... fmt_args)
+inline void NORETURN SlErrorCorruptFmt(const T &format, Args&&... fmt_args)
 {
 	SlErrorCorrupt(fmt::format(format, fmt_args...));
 }

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -646,7 +646,7 @@ extern VehicleDefaultSettings _old_vds;
  * Get the settings-object applicable for the current situation: the newgame settings
  * when we're in the main menu and otherwise the settings of the current game.
  */
-static inline GameSettings &GetGameSettings()
+inline GameSettings &GetGameSettings()
 {
 	return (_game_mode == GM_MENU) ? _settings_newgame : _settings_game;
 }

--- a/src/signal_func.h
+++ b/src/signal_func.h
@@ -19,7 +19,7 @@
  * Maps a trackdir to the bit that stores its status in the map arrays, in the
  * direction along with the trackdir.
  */
-static inline byte SignalAlongTrackdir(Trackdir trackdir)
+inline byte SignalAlongTrackdir(Trackdir trackdir)
 {
 	extern const byte _signal_along_trackdir[TRACKDIR_END];
 	return _signal_along_trackdir[trackdir];
@@ -29,7 +29,7 @@ static inline byte SignalAlongTrackdir(Trackdir trackdir)
  * Maps a trackdir to the bit that stores its status in the map arrays, in the
  * direction against the trackdir.
  */
-static inline byte SignalAgainstTrackdir(Trackdir trackdir)
+inline byte SignalAgainstTrackdir(Trackdir trackdir)
 {
 	extern const byte _signal_against_trackdir[TRACKDIR_END];
 	return _signal_against_trackdir[trackdir];
@@ -39,7 +39,7 @@ static inline byte SignalAgainstTrackdir(Trackdir trackdir)
  * Maps a Track to the bits that store the status of the two signals that can
  * be present on the given track.
  */
-static inline byte SignalOnTrack(Track track)
+inline byte SignalOnTrack(Track track)
 {
 	extern const byte _signal_on_track[TRACK_END];
 	return _signal_on_track[track];

--- a/src/slope_func.h
+++ b/src/slope_func.h
@@ -73,7 +73,7 @@ static constexpr inline Slope RemoveHalftileSlope(Slope s)
  * @param s The #Slope to get the complement.
  * @return a complement Slope of the given slope.
  */
-static inline Slope ComplementSlope(Slope s)
+inline Slope ComplementSlope(Slope s)
 {
 	assert(!IsSteepSlope(s) && !IsHalftileSlope(s));
 	return s ^ SLOPE_ELEVATED;
@@ -85,7 +85,7 @@ static inline Slope ComplementSlope(Slope s)
  * @param s The #Slope
  * @return true iff exactly one corner is raised
  */
-static inline bool IsSlopeWithOneCornerRaised(Slope s)
+inline bool IsSlopeWithOneCornerRaised(Slope s)
 {
 	return (s == SLOPE_W) || (s == SLOPE_S) || (s == SLOPE_E) || (s == SLOPE_N);
 }
@@ -96,7 +96,7 @@ static inline bool IsSlopeWithOneCornerRaised(Slope s)
  * @param corner The #Corner.
  * @return The #Slope with corner "corner" raised.
  */
-static inline Slope SlopeWithOneCornerRaised(Corner corner)
+inline Slope SlopeWithOneCornerRaised(Corner corner)
 {
 	assert(IsValidCorner(corner));
 	return (Slope)(1 << corner);
@@ -110,7 +110,7 @@ static inline Slope SlopeWithOneCornerRaised(Corner corner)
  * @param s The #Slope.
  * @return  true iff the slope has a highest corner.
  */
-static inline bool HasSlopeHighestCorner(Slope s)
+inline bool HasSlopeHighestCorner(Slope s)
 {
 	s = RemoveHalftileSlope(s);
 	return IsSteepSlope(s) || IsSlopeWithOneCornerRaised(s);
@@ -123,7 +123,7 @@ static inline bool HasSlopeHighestCorner(Slope s)
  * @param s  The #Slope.
  * @return   Highest corner.
  */
-static inline Corner GetHighestSlopeCorner(Slope s)
+inline Corner GetHighestSlopeCorner(Slope s)
 {
 	switch (RemoveHalftileSlope(s)) {
 		case SLOPE_W:
@@ -181,7 +181,7 @@ static constexpr inline int GetSlopeMaxPixelZ(Slope s)
  * @param corner A #Corner.
  * @return The opposite corner to "corner".
  */
-static inline Corner OppositeCorner(Corner corner)
+inline Corner OppositeCorner(Corner corner)
 {
 	return (Corner)(corner ^ 2);
 }
@@ -192,7 +192,7 @@ static inline Corner OppositeCorner(Corner corner)
  * @param s The #Slope
  * @return true iff exactly three corners are raised
  */
-static inline bool IsSlopeWithThreeCornersRaised(Slope s)
+inline bool IsSlopeWithThreeCornersRaised(Slope s)
 {
 	return !IsHalftileSlope(s) && !IsSteepSlope(s) && IsSlopeWithOneCornerRaised(ComplementSlope(s));
 }
@@ -203,7 +203,7 @@ static inline bool IsSlopeWithThreeCornersRaised(Slope s)
  * @param corner The #Corner.
  * @return The #Slope with all corners but "corner" raised.
  */
-static inline Slope SlopeWithThreeCornersRaised(Corner corner)
+inline Slope SlopeWithThreeCornersRaised(Corner corner)
 {
 	return ComplementSlope(SlopeWithOneCornerRaised(corner));
 }
@@ -214,7 +214,7 @@ static inline Slope SlopeWithThreeCornersRaised(Corner corner)
  * @param corner A #Corner.
  * @return The steep #Slope with "corner" as highest corner.
  */
-static inline Slope SteepSlope(Corner corner)
+inline Slope SteepSlope(Corner corner)
 {
 	return SLOPE_STEEP | SlopeWithThreeCornersRaised(OppositeCorner(corner));
 }
@@ -225,7 +225,7 @@ static inline Slope SteepSlope(Corner corner)
  * @param s The #Slope
  * @return true iff the slope is inclined.
  */
-static inline bool IsInclinedSlope(Slope s)
+inline bool IsInclinedSlope(Slope s)
 {
 	return (s == SLOPE_NW) || (s == SLOPE_SW) || (s == SLOPE_SE) || (s == SLOPE_NE);
 }
@@ -236,7 +236,7 @@ static inline bool IsInclinedSlope(Slope s)
  * @param s A #Slope
  * @return The direction the slope goes up in. Or INVALID_DIAGDIR if the slope is not an inclined slope.
  */
-static inline DiagDirection GetInclinedSlopeDirection(Slope s)
+inline DiagDirection GetInclinedSlopeDirection(Slope s)
 {
 	switch (s) {
 		case SLOPE_NE: return DIAGDIR_NE;
@@ -253,7 +253,7 @@ static inline DiagDirection GetInclinedSlopeDirection(Slope s)
  * @param dir A #DiagDirection
  * @return The #Slope that goes up in direction dir.
  */
-static inline Slope InclinedSlope(DiagDirection dir)
+inline Slope InclinedSlope(DiagDirection dir)
 {
 	switch (dir) {
 		case DIAGDIR_NE: return SLOPE_NE;
@@ -284,7 +284,7 @@ static constexpr inline Slope HalftileSlope(Slope s, Corner corner)
  * @param f  Maybe a #Foundation.
  * @return   true iff f is a foundation.
  */
-static inline bool IsFoundation(Foundation f)
+inline bool IsFoundation(Foundation f)
 {
 	return f != FOUNDATION_NONE;
 }
@@ -295,7 +295,7 @@ static inline bool IsFoundation(Foundation f)
  * @param f  The #Foundation.
  * @return   true iff f is a leveled foundation.
  */
-static inline bool IsLeveledFoundation(Foundation f)
+inline bool IsLeveledFoundation(Foundation f)
 {
 	return f == FOUNDATION_LEVELED;
 }
@@ -306,7 +306,7 @@ static inline bool IsLeveledFoundation(Foundation f)
  * @param f  The #Foundation.
  * @return   true iff f is an inclined foundation.
  */
-static inline bool IsInclinedFoundation(Foundation f)
+inline bool IsInclinedFoundation(Foundation f)
 {
 	return (f == FOUNDATION_INCLINED_X) || (f == FOUNDATION_INCLINED_Y);
 }
@@ -317,7 +317,7 @@ static inline bool IsInclinedFoundation(Foundation f)
  * @param f  The #Foundation.
  * @return   true iff f is a non-continuous foundation
  */
-static inline bool IsNonContinuousFoundation(Foundation f)
+inline bool IsNonContinuousFoundation(Foundation f)
 {
 	return IsInsideMM(f, FOUNDATION_STEEP_BOTH, FOUNDATION_HALFTILE_N + 1);
 }
@@ -330,7 +330,7 @@ static inline bool IsNonContinuousFoundation(Foundation f)
  * @param f  The #Foundation.
  * @return   The #Corner with track.
  */
-static inline Corner GetHalftileFoundationCorner(Foundation f)
+inline Corner GetHalftileFoundationCorner(Foundation f)
 {
 	assert(IsInsideMM(f, FOUNDATION_HALFTILE_W, FOUNDATION_HALFTILE_N + 1));
 	return (Corner)(f - FOUNDATION_HALFTILE_W);
@@ -342,7 +342,7 @@ static inline Corner GetHalftileFoundationCorner(Foundation f)
  * @param f  The #Foundation.
  * @return   true iff f is a special rail foundation for single horizontal/vertical track.
  */
-static inline bool IsSpecialRailFoundation(Foundation f)
+inline bool IsSpecialRailFoundation(Foundation f)
 {
 	return IsInsideMM(f, FOUNDATION_RAIL_W, FOUNDATION_RAIL_N + 1);
 }
@@ -353,7 +353,7 @@ static inline bool IsSpecialRailFoundation(Foundation f)
  * @param f  The #Foundation.
  * @return   The #Corner with track.
  */
-static inline Corner GetRailFoundationCorner(Foundation f)
+inline Corner GetRailFoundationCorner(Foundation f)
 {
 	assert(IsSpecialRailFoundation(f));
 	return (Corner)(f - FOUNDATION_RAIL_W);
@@ -366,7 +366,7 @@ static inline Corner GetRailFoundationCorner(Foundation f)
  * @param s  The current #Slope.
  * @return   The needed #Foundation.
  */
-static inline Foundation FlatteningFoundation(Slope s)
+inline Foundation FlatteningFoundation(Slope s)
 {
 	return (s == SLOPE_FLAT ? FOUNDATION_NONE : FOUNDATION_LEVELED);
 }
@@ -377,7 +377,7 @@ static inline Foundation FlatteningFoundation(Slope s)
  * @param axis  The #Axis.
  * @return      The needed #Foundation.
  */
-static inline Foundation InclinedFoundation(Axis axis)
+inline Foundation InclinedFoundation(Axis axis)
 {
 	return (axis == AXIS_X ? FOUNDATION_INCLINED_X : FOUNDATION_INCLINED_Y);
 }
@@ -388,7 +388,7 @@ static inline Foundation InclinedFoundation(Axis axis)
  * @param corner The #Corner with the track.
  * @return       The wanted #Foundation.
  */
-static inline Foundation HalftileFoundation(Corner corner)
+inline Foundation HalftileFoundation(Corner corner)
 {
 	assert(IsValidCorner(corner));
 	return (Foundation)(FOUNDATION_HALFTILE_W + corner);
@@ -400,7 +400,7 @@ static inline Foundation HalftileFoundation(Corner corner)
  * @param corner The #Corner with the track.
  * @return       The wanted #Foundation.
  */
-static inline Foundation SpecialRailFoundation(Corner corner)
+inline Foundation SpecialRailFoundation(Corner corner)
 {
 	assert(IsValidCorner(corner));
 	return (Foundation)(FOUNDATION_RAIL_W + corner);
@@ -412,7 +412,7 @@ static inline Foundation SpecialRailFoundation(Corner corner)
  * @param s The #Slope to get the offset for.
  * @return The sprite offset for this #Slope.
  */
-static inline uint SlopeToSpriteOffset(Slope s)
+inline uint SlopeToSpriteOffset(Slope s)
 {
 	extern const byte _slope_to_sprite_offset[32];
 	return _slope_to_sprite_offset[s];

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -86,7 +86,7 @@ void DrawCommonTileSeqInGUI(int x, int y, const DrawTileSprites *dts, int32_t or
  * @param total_offset Spriteoffset from normal rail to current railtype.
  * @param newgrf_offset Startsprite of the Action1 to use.
  */
-static inline void DrawRailTileSeq(const struct TileInfo *ti, const DrawTileSprites *dts, TransparencyOption to, int32_t total_offset, uint32_t newgrf_offset, PaletteID default_palette)
+inline void DrawRailTileSeq(const struct TileInfo *ti, const DrawTileSprites *dts, TransparencyOption to, int32_t total_offset, uint32_t newgrf_offset, PaletteID default_palette)
 {
 	DrawCommonTileSeq(ti, dts, to, total_offset, newgrf_offset, default_palette, false);
 }
@@ -96,7 +96,7 @@ static inline void DrawRailTileSeq(const struct TileInfo *ti, const DrawTileSpri
  * @param total_offset Spriteoffset from normal rail to current railtype.
  * @param newgrf_offset Startsprite of the Action1 to use.
  */
-static inline void DrawRailTileSeqInGUI(int x, int y, const DrawTileSprites *dts, int32_t total_offset, uint32_t newgrf_offset, PaletteID default_palette)
+inline void DrawRailTileSeqInGUI(int x, int y, const DrawTileSprites *dts, int32_t total_offset, uint32_t newgrf_offset, PaletteID default_palette)
 {
 	DrawCommonTileSeqInGUI(x, y, dts, total_offset, newgrf_offset, default_palette, false);
 }
@@ -104,7 +104,7 @@ static inline void DrawRailTileSeqInGUI(int x, int y, const DrawTileSprites *dts
 /**
  * Draw TTD sprite sequence on tile.
  */
-static inline void DrawOrigTileSeq(const struct TileInfo *ti, const DrawTileSprites *dts, TransparencyOption to, PaletteID default_palette)
+inline void DrawOrigTileSeq(const struct TileInfo *ti, const DrawTileSprites *dts, TransparencyOption to, PaletteID default_palette)
 {
 	DrawCommonTileSeq(ti, dts, to, 0, 0, default_palette, false);
 }
@@ -112,7 +112,7 @@ static inline void DrawOrigTileSeq(const struct TileInfo *ti, const DrawTileSpri
 /**
  * Draw TTD sprite sequence in GUI.
  */
-static inline void DrawOrigTileSeqInGUI(int x, int y, const DrawTileSprites *dts, PaletteID default_palette)
+inline void DrawOrigTileSeqInGUI(int x, int y, const DrawTileSprites *dts, PaletteID default_palette)
 {
 	DrawCommonTileSeqInGUI(x, y, dts, 0, 0, default_palette, false);
 }
@@ -121,7 +121,7 @@ static inline void DrawOrigTileSeqInGUI(int x, int y, const DrawTileSprites *dts
  * Draw NewGRF industrytile or house sprite layout
  * @param stage Sprite inside the Action1 spritesets to use, i.e. construction stage.
  */
-static inline void DrawNewGRFTileSeq(const struct TileInfo *ti, const DrawTileSprites *dts, TransparencyOption to, uint32_t stage, PaletteID default_palette)
+inline void DrawNewGRFTileSeq(const struct TileInfo *ti, const DrawTileSprites *dts, TransparencyOption to, uint32_t stage, PaletteID default_palette)
 {
 	DrawCommonTileSeq(ti, dts, to, 0, stage, default_palette, true);
 }
@@ -130,7 +130,7 @@ static inline void DrawNewGRFTileSeq(const struct TileInfo *ti, const DrawTileSp
  * Draw NewGRF object in GUI
  * @param stage Sprite inside the Action1 spritesets to use, i.e. construction stage.
  */
-static inline void DrawNewGRFTileSeqInGUI(int x, int y, const DrawTileSprites *dts, uint32_t stage, PaletteID default_palette)
+inline void DrawNewGRFTileSeqInGUI(int x, int y, const DrawTileSprites *dts, uint32_t stage, PaletteID default_palette)
 {
 	DrawCommonTileSeqInGUI(x, y, dts, 0, stage, default_palette, true);
 }
@@ -146,7 +146,7 @@ static inline void DrawNewGRFTileSeqInGUI(int x, int y, const DrawTileSprites *d
  * @param default_pal The default recolour sprite to use (typically company colour resp. random industry/house colour)
  * @return The palette to use
  */
-static inline PaletteID SpriteLayoutPaletteTransform(SpriteID image, PaletteID pal, PaletteID default_pal)
+inline PaletteID SpriteLayoutPaletteTransform(SpriteID image, PaletteID pal, PaletteID default_pal)
 {
 	if (HasBit(image, PALETTE_MODIFIER_TRANSPARENT) || HasBit(image, PALETTE_MODIFIER_COLOUR)) {
 		return (pal != 0 ? pal : default_pal);
@@ -165,7 +165,7 @@ static inline PaletteID SpriteLayoutPaletteTransform(SpriteID image, PaletteID p
  * @param default_pal The default recolour sprite to use (typically company colour resp. random industry/house colour)
  * @return The palette to use
  */
-static inline PaletteID GroundSpritePaletteTransform(SpriteID image, PaletteID pal, PaletteID default_pal)
+inline PaletteID GroundSpritePaletteTransform(SpriteID image, PaletteID pal, PaletteID default_pal)
 {
 	if (HasBit(image, PALETTE_MODIFIER_COLOUR)) {
 		return (pal != 0 ? pal : default_pal);

--- a/src/spritecache.h
+++ b/src/spritecache.h
@@ -44,13 +44,13 @@ uint GetSpriteCountForFile(const std::string &filename, SpriteID begin, SpriteID
 uint GetMaxSpriteID();
 
 
-static inline const Sprite *GetSprite(SpriteID sprite, SpriteType type)
+inline const Sprite *GetSprite(SpriteID sprite, SpriteType type)
 {
 	assert(type != SpriteType::Recolour);
 	return (Sprite*)GetRawSprite(sprite, type);
 }
 
-static inline const byte *GetNonSprite(SpriteID sprite, SpriteType type)
+inline const byte *GetNonSprite(SpriteID sprite, SpriteType type)
 {
 	assert(type == SpriteType::Recolour);
 	return (byte*)GetRawSprite(sprite, type);

--- a/src/spritecache_internal.h
+++ b/src/spritecache_internal.h
@@ -31,7 +31,7 @@ struct SpriteCache {
 	byte control_flags;  ///< Control flags, see SpriteCacheCtrlFlags
 };
 
-static inline bool IsMapgenSpriteID(SpriteID sprite)
+inline bool IsMapgenSpriteID(SpriteID sprite)
 {
 	return IsInsideMM(sprite, SPR_MAPGEN_BEGIN, SPR_MAPGEN_END);
 }

--- a/src/station_func.h
+++ b/src/station_func.h
@@ -56,7 +56,7 @@ void RerouteCargo(Station *st, CargoID c, StationID avoid, StationID avoid2);
  * @param num Number of station tiles.
  * @return Total cost.
  */
-static inline Money StationMaintenanceCost(uint32_t num)
+inline Money StationMaintenanceCost(uint32_t num)
 {
 	return (_price[PR_INFRASTRUCTURE_STATION] * num * (1 + IntSqrt(num))) >> 7; // 7 bits scaling.
 }

--- a/src/station_map.h
+++ b/src/station_map.h
@@ -25,7 +25,7 @@ typedef byte StationGfx; ///< Index of station graphics. @see _station_display_d
  * @pre IsTileType(t, MP_STATION)
  * @return Station ID of the station at \a t
  */
-static inline StationID GetStationIndex(Tile t)
+inline StationID GetStationIndex(Tile t)
 {
 	assert(IsTileType(t, MP_STATION));
 	return (StationID)t.m2();
@@ -41,7 +41,7 @@ static const int GFX_TRUCK_BUS_DRIVETHROUGH_OFFSET =  4; ///< The offset for the
  * @pre IsTileType(t, MP_STATION)
  * @return the station type
  */
-static inline StationType GetStationType(Tile t)
+inline StationType GetStationType(Tile t)
 {
 	assert(IsTileType(t, MP_STATION));
 	return (StationType)GB(t.m6(), 3, 3);
@@ -53,7 +53,7 @@ static inline StationType GetStationType(Tile t)
  * @pre GetStationType(t) == STATION_TRUCK || GetStationType(t) == STATION_BUS
  * @return the road stop type
  */
-static inline RoadStopType GetRoadStopType(Tile t)
+inline RoadStopType GetRoadStopType(Tile t)
 {
 	assert(GetStationType(t) == STATION_TRUCK || GetStationType(t) == STATION_BUS);
 	return GetStationType(t) == STATION_TRUCK ? ROADSTOP_TRUCK : ROADSTOP_BUS;
@@ -65,7 +65,7 @@ static inline RoadStopType GetRoadStopType(Tile t)
  * @pre IsTileType(t, MP_STATION)
  * @return the station graphics
  */
-static inline StationGfx GetStationGfx(Tile t)
+inline StationGfx GetStationGfx(Tile t)
 {
 	assert(IsTileType(t, MP_STATION));
 	return t.m5();
@@ -77,7 +77,7 @@ static inline StationGfx GetStationGfx(Tile t)
  * @param gfx the new graphics
  * @pre IsTileType(t, MP_STATION)
  */
-static inline void SetStationGfx(Tile t, StationGfx gfx)
+inline void SetStationGfx(Tile t, StationGfx gfx)
 {
 	assert(IsTileType(t, MP_STATION));
 	t.m5() = gfx;
@@ -89,7 +89,7 @@ static inline void SetStationGfx(Tile t, StationGfx gfx)
  * @pre IsTileType(t, MP_STATION)
  * @return true if and only if the tile is a rail station
  */
-static inline bool IsRailStation(Tile t)
+inline bool IsRailStation(Tile t)
 {
 	return GetStationType(t) == STATION_RAIL;
 }
@@ -99,7 +99,7 @@ static inline bool IsRailStation(Tile t)
  * @param t the tile to get the information from
  * @return true if and only if the tile is a rail station
  */
-static inline bool IsRailStationTile(Tile t)
+inline bool IsRailStationTile(Tile t)
 {
 	return IsTileType(t, MP_STATION) && IsRailStation(t);
 }
@@ -110,7 +110,7 @@ static inline bool IsRailStationTile(Tile t)
  * @pre IsTileType(t, MP_STATION)
  * @return true if and only if the tile is a rail waypoint
  */
-static inline bool IsRailWaypoint(Tile t)
+inline bool IsRailWaypoint(Tile t)
 {
 	return GetStationType(t) == STATION_WAYPOINT;
 }
@@ -120,7 +120,7 @@ static inline bool IsRailWaypoint(Tile t)
  * @param t the tile to get the information from
  * @return true if and only if the tile is a rail waypoint
  */
-static inline bool IsRailWaypointTile(Tile t)
+inline bool IsRailWaypointTile(Tile t)
 {
 	return IsTileType(t, MP_STATION) && IsRailWaypoint(t);
 }
@@ -132,7 +132,7 @@ static inline bool IsRailWaypointTile(Tile t)
  * @pre IsTileType(t, MP_STATION)
  * @return true if and only if the tile has rail
  */
-static inline bool HasStationRail(Tile t)
+inline bool HasStationRail(Tile t)
 {
 	return IsRailStation(t) || IsRailWaypoint(t);
 }
@@ -143,7 +143,7 @@ static inline bool HasStationRail(Tile t)
  * @param t the tile to check
  * @return true if and only if the tile is a station tile and has rail
  */
-static inline bool HasStationTileRail(Tile t)
+inline bool HasStationTileRail(Tile t)
 {
 	return IsTileType(t, MP_STATION) && HasStationRail(t);
 }
@@ -154,7 +154,7 @@ static inline bool HasStationTileRail(Tile t)
  * @pre IsTileType(t, MP_STATION)
  * @return true if and only if the tile is an airport
  */
-static inline bool IsAirport(Tile t)
+inline bool IsAirport(Tile t)
 {
 	return GetStationType(t) == STATION_AIRPORT;
 }
@@ -164,7 +164,7 @@ static inline bool IsAirport(Tile t)
  * @param t the tile to get the information from
  * @return true if and only if the tile is an airport
  */
-static inline bool IsAirportTile(Tile t)
+inline bool IsAirportTile(Tile t)
 {
 	return IsTileType(t, MP_STATION) && IsAirport(t);
 }
@@ -177,7 +177,7 @@ bool IsHangar(Tile t);
  * @pre IsTileType(t, MP_STATION)
  * @return \c true if station is a truck stop, \c false otherwise
  */
-static inline bool IsTruckStop(Tile t)
+inline bool IsTruckStop(Tile t)
 {
 	return GetStationType(t) == STATION_TRUCK;
 }
@@ -188,7 +188,7 @@ static inline bool IsTruckStop(Tile t)
  * @pre IsTileType(t, MP_STATION)
  * @return \c true if station is a bus stop, \c false otherwise
  */
-static inline bool IsBusStop(Tile t)
+inline bool IsBusStop(Tile t)
 {
 	return GetStationType(t) == STATION_BUS;
 }
@@ -199,7 +199,7 @@ static inline bool IsBusStop(Tile t)
  * @pre IsTileType(t, MP_STATION)
  * @return \c true if station at the tile is a bus top or a truck stop, \c false otherwise
  */
-static inline bool IsRoadStop(Tile t)
+inline bool IsRoadStop(Tile t)
 {
 	assert(IsTileType(t, MP_STATION));
 	return IsTruckStop(t) || IsBusStop(t);
@@ -210,7 +210,7 @@ static inline bool IsRoadStop(Tile t)
  * @param t Tile to check
  * @return \c true if the tile is a station tile and a road stop
  */
-static inline bool IsRoadStopTile(Tile t)
+inline bool IsRoadStopTile(Tile t)
 {
 	return IsTileType(t, MP_STATION) && IsRoadStop(t);
 }
@@ -220,7 +220,7 @@ static inline bool IsRoadStopTile(Tile t)
  * @param t Tile to check
  * @return \c true if the tile is a station tile and a bay road stop
  */
-static inline bool IsBayRoadStopTile(Tile t)
+inline bool IsBayRoadStopTile(Tile t)
 {
 	return IsRoadStopTile(t) && GetStationGfx(t) < GFX_TRUCK_BUS_DRIVETHROUGH_OFFSET;
 }
@@ -230,7 +230,7 @@ static inline bool IsBayRoadStopTile(Tile t)
  * @param t Tile to check
  * @return \c true if the tile is a station tile and a drive through road stop
  */
-static inline bool IsDriveThroughStopTile(Tile t)
+inline bool IsDriveThroughStopTile(Tile t)
 {
 	return IsRoadStopTile(t) && GetStationGfx(t) >= GFX_TRUCK_BUS_DRIVETHROUGH_OFFSET;
 }
@@ -243,7 +243,7 @@ StationGfx GetTranslatedAirportTileID(StationGfx gfx);
  * @pre IsAirport(t)
  * @return the station graphics
  */
-static inline StationGfx GetAirportGfx(Tile t)
+inline StationGfx GetAirportGfx(Tile t)
 {
 	assert(IsAirport(t));
 	return GetTranslatedAirportTileID(GetStationGfx(t));
@@ -255,7 +255,7 @@ static inline StationGfx GetAirportGfx(Tile t)
  * @pre IsRoadStopTile(t)
  * @return the direction of the entrance
  */
-static inline DiagDirection GetRoadStopDir(Tile t)
+inline DiagDirection GetRoadStopDir(Tile t)
 {
 	StationGfx gfx = GetStationGfx(t);
 	assert(IsRoadStopTile(t));
@@ -272,7 +272,7 @@ static inline DiagDirection GetRoadStopDir(Tile t)
  * @pre IsTileType(t, MP_STATION)
  * @return \c true if the tile is an oilrig tile
  */
-static inline bool IsOilRig(Tile t)
+inline bool IsOilRig(Tile t)
 {
 	return GetStationType(t) == STATION_OILRIG;
 }
@@ -283,7 +283,7 @@ static inline bool IsOilRig(Tile t)
  * @pre IsTileType(t, MP_STATION)
  * @return \c true if the tile is a dock
  */
-static inline bool IsDock(Tile t)
+inline bool IsDock(Tile t)
 {
 	return GetStationType(t) == STATION_DOCK;
 }
@@ -293,7 +293,7 @@ static inline bool IsDock(Tile t)
  * @param t Tile to check
  * @return \c true if the tile is a dock
  */
-static inline bool IsDockTile(Tile t)
+inline bool IsDockTile(Tile t)
 {
 	return IsTileType(t, MP_STATION) && GetStationType(t) == STATION_DOCK;
 }
@@ -304,7 +304,7 @@ static inline bool IsDockTile(Tile t)
  * @pre IsTileType(t, MP_STATION)
  * @return \c true if the tile is a buoy
  */
-static inline bool IsBuoy(Tile t)
+inline bool IsBuoy(Tile t)
 {
 	return GetStationType(t) == STATION_BUOY;
 }
@@ -314,7 +314,7 @@ static inline bool IsBuoy(Tile t)
  * @param t Tile to check
  * @return \c true if the tile is a buoy
  */
-static inline bool IsBuoyTile(Tile t)
+inline bool IsBuoyTile(Tile t)
 {
 	return IsTileType(t, MP_STATION) && IsBuoy(t);
 }
@@ -324,7 +324,7 @@ static inline bool IsBuoyTile(Tile t)
  * @param t Tile to check
  * @return \c true if the tile is an hangar
  */
-static inline bool IsHangarTile(Tile t)
+inline bool IsHangarTile(Tile t)
 {
 	return IsTileType(t, MP_STATION) && IsHangar(t);
 }
@@ -335,7 +335,7 @@ static inline bool IsHangarTile(Tile t)
  * @param t Tile to check
  * @return \c true if the tile is blocked
  */
-static inline bool IsStationTileBlocked(Tile t)
+inline bool IsStationTileBlocked(Tile t)
 {
 	assert(HasStationRail(t));
 	return HasBit(t.m6(), 0);
@@ -347,7 +347,7 @@ static inline bool IsStationTileBlocked(Tile t)
  * @param t the station tile
  * @param b the blocked state
  */
-static inline void SetStationTileBlocked(Tile t, bool b)
+inline void SetStationTileBlocked(Tile t, bool b)
 {
 	assert(HasStationRail(t));
 	SB(t.m6(), 0, 1, b ? 1 : 0);
@@ -359,7 +359,7 @@ static inline void SetStationTileBlocked(Tile t, bool b)
  * @param t Tile to check
  * @return \c true if the tile can have catenary wires
  */
-static inline bool CanStationTileHaveWires(Tile t)
+inline bool CanStationTileHaveWires(Tile t)
 {
 	assert(HasStationRail(t));
 	return HasBit(t.m6(), 6);
@@ -371,7 +371,7 @@ static inline bool CanStationTileHaveWires(Tile t)
  * @param t the station tile
  * @param b the catenary wires state
  */
-static inline void SetStationTileHaveWires(Tile t, bool b)
+inline void SetStationTileHaveWires(Tile t, bool b)
 {
 	assert(HasStationRail(t));
 	SB(t.m6(), 6, 1, b ? 1 : 0);
@@ -383,7 +383,7 @@ static inline void SetStationTileHaveWires(Tile t, bool b)
  * @param t Tile to check
  * @return \c true if the tile can have catenary pylons
  */
-static inline bool CanStationTileHavePylons(Tile t)
+inline bool CanStationTileHavePylons(Tile t)
 {
 	assert(HasStationRail(t));
 	return HasBit(t.m6(), 7);
@@ -395,7 +395,7 @@ static inline bool CanStationTileHavePylons(Tile t)
  * @param t the station tile
  * @param b the catenary pylons state
  */
-static inline void SetStationTileHavePylons(Tile t, bool b)
+inline void SetStationTileHavePylons(Tile t, bool b)
 {
 	assert(HasStationRail(t));
 	SB(t.m6(), 7, 1, b ? 1 : 0);
@@ -407,7 +407,7 @@ static inline void SetStationTileHavePylons(Tile t, bool b)
  * @pre HasStationRail(t)
  * @return The direction of the rails on tile \a t.
  */
-static inline Axis GetRailStationAxis(Tile t)
+inline Axis GetRailStationAxis(Tile t)
 {
 	assert(HasStationRail(t));
 	return HasBit(GetStationGfx(t), 0) ? AXIS_Y : AXIS_X;
@@ -419,7 +419,7 @@ static inline Axis GetRailStationAxis(Tile t)
  * @pre HasStationRail(t)
  * @return The rail track of the rails on tile \a t.
  */
-static inline Track GetRailStationTrack(Tile t)
+inline Track GetRailStationTrack(Tile t)
 {
 	return AxisToTrack(GetRailStationAxis(t));
 }
@@ -430,7 +430,7 @@ static inline Track GetRailStationTrack(Tile t)
  * @pre HasStationRail(t)
  * @return The trackbits of the rails on tile \a t.
  */
-static inline TrackBits GetRailStationTrackBits(Tile t)
+inline TrackBits GetRailStationTrackBits(Tile t)
 {
 	return AxisToTrackBits(GetRailStationAxis(t));
 }
@@ -448,7 +448,7 @@ static inline TrackBits GetRailStationTrackBits(Tile t)
  * @pre IsRailStationTile(station_tile)
  * @return true if the two tiles are compatible
  */
-static inline bool IsCompatibleTrainStationTile(Tile test_tile, Tile station_tile)
+inline bool IsCompatibleTrainStationTile(Tile test_tile, Tile station_tile)
 {
 	assert(IsRailStationTile(station_tile));
 	return IsRailStationTile(test_tile) && !IsStationTileBlocked(test_tile) &&
@@ -463,7 +463,7 @@ static inline bool IsCompatibleTrainStationTile(Tile test_tile, Tile station_til
  * @param t the station tile
  * @return reservation state
  */
-static inline bool HasStationReservation(Tile t)
+inline bool HasStationReservation(Tile t)
 {
 	assert(HasStationRail(t));
 	return HasBit(t.m6(), 2);
@@ -475,7 +475,7 @@ static inline bool HasStationReservation(Tile t)
  * @param t the station tile
  * @param b the reservation state
  */
-static inline void SetRailStationReservation(Tile t, bool b)
+inline void SetRailStationReservation(Tile t, bool b)
 {
 	assert(HasStationRail(t));
 	SB(t.m6(), 2, 1, b ? 1 : 0);
@@ -487,7 +487,7 @@ static inline void SetRailStationReservation(Tile t, bool b)
  * @param t the tile
  * @return reserved track bits
  */
-static inline TrackBits GetStationReservationTrackBits(Tile t)
+inline TrackBits GetStationReservationTrackBits(Tile t)
 {
 	return HasStationReservation(t) ? GetRailStationTrackBits(t) : TRACK_BIT_NONE;
 }
@@ -499,7 +499,7 @@ static inline TrackBits GetStationReservationTrackBits(Tile t)
  * @pre \a t is the land part of the dock
  * @return The direction of the dock on tile \a t.
  */
-static inline DiagDirection GetDockDirection(Tile t)
+inline DiagDirection GetDockDirection(Tile t)
 {
 	StationGfx gfx = GetStationGfx(t);
 	assert(IsDock(t) && gfx < GFX_DOCK_BASE_WATER_PART);
@@ -509,7 +509,7 @@ static inline DiagDirection GetDockDirection(Tile t)
 /**
  * Check whether a dock tile is the tile on water.
  */
-static inline bool IsDockWaterPart(Tile t)
+inline bool IsDockWaterPart(Tile t)
 {
 	assert(IsDockTile(t));
 	StationGfx gfx = GetStationGfx(t);
@@ -522,7 +522,7 @@ static inline bool IsDockWaterPart(Tile t)
  * @pre HasStationTileRail(t)
  * @return True if this station is part of a newgrf station.
  */
-static inline bool IsCustomStationSpecIndex(Tile t)
+inline bool IsCustomStationSpecIndex(Tile t)
 {
 	assert(HasStationTileRail(t));
 	return t.m4() != 0;
@@ -534,7 +534,7 @@ static inline bool IsCustomStationSpecIndex(Tile t)
  * @param specindex The new spec.
  * @pre HasStationTileRail(t)
  */
-static inline void SetCustomStationSpecIndex(Tile t, byte specindex)
+inline void SetCustomStationSpecIndex(Tile t, byte specindex)
 {
 	assert(HasStationTileRail(t));
 	t.m4() = specindex;
@@ -546,7 +546,7 @@ static inline void SetCustomStationSpecIndex(Tile t, byte specindex)
  * @pre HasStationTileRail(t)
  * @return The custom station spec of this tile.
  */
-static inline uint GetCustomStationSpecIndex(Tile t)
+inline uint GetCustomStationSpecIndex(Tile t)
 {
 	assert(HasStationTileRail(t));
 	return t.m4();
@@ -558,7 +558,7 @@ static inline uint GetCustomStationSpecIndex(Tile t)
  * @pre IsRoadStopTile(t)
  * @return True if this station is part of a newgrf station.
  */
-static inline bool IsCustomRoadStopSpecIndex(Tile t)
+inline bool IsCustomRoadStopSpecIndex(Tile t)
 {
 	assert(IsRoadStopTile(t));
 	return GB(t.m8(), 0, 6) != 0;
@@ -570,7 +570,7 @@ static inline bool IsCustomRoadStopSpecIndex(Tile t)
  * @param specindex The new spec.
  * @pre IsRoadStopTile(t)
  */
-static inline void SetCustomRoadStopSpecIndex(Tile t, byte specindex)
+inline void SetCustomRoadStopSpecIndex(Tile t, byte specindex)
 {
 	assert(IsRoadStopTile(t));
 	SB(t.m8(), 0, 6, specindex);
@@ -582,7 +582,7 @@ static inline void SetCustomRoadStopSpecIndex(Tile t, byte specindex)
  * @pre IsRoadStopTile(t)
  * @return The custom station spec of this tile.
  */
-static inline uint GetCustomRoadStopSpecIndex(Tile t)
+inline uint GetCustomRoadStopSpecIndex(Tile t)
 {
 	assert(IsRoadStopTile(t));
 	return GB(t.m8(), 0, 6);
@@ -594,7 +594,7 @@ static inline uint GetCustomRoadStopSpecIndex(Tile t)
  * @param random_bits The random bits.
  * @pre IsTileType(t, MP_STATION)
  */
-static inline void SetStationTileRandomBits(Tile t, byte random_bits)
+inline void SetStationTileRandomBits(Tile t, byte random_bits)
 {
 	assert(IsTileType(t, MP_STATION));
 	SB(t.m3(), 4, 4, random_bits);
@@ -606,7 +606,7 @@ static inline void SetStationTileRandomBits(Tile t, byte random_bits)
  * @pre IsTileType(t, MP_STATION)
  * @return The random bits for this station tile.
  */
-static inline byte GetStationTileRandomBits(Tile t)
+inline byte GetStationTileRandomBits(Tile t)
 {
 	assert(IsTileType(t, MP_STATION));
 	return GB(t.m3(), 4, 4);
@@ -621,7 +621,7 @@ static inline byte GetStationTileRandomBits(Tile t)
  * @param section the StationGfx to be used for this tile
  * @param wc The water class of the station
  */
-static inline void MakeStation(Tile t, Owner o, StationID sid, StationType st, byte section, WaterClass wc = WATER_CLASS_INVALID)
+inline void MakeStation(Tile t, Owner o, StationID sid, StationType st, byte section, WaterClass wc = WATER_CLASS_INVALID)
 {
 	SetTileType(t, MP_STATION);
 	SetTileOwner(t, o);
@@ -646,7 +646,7 @@ static inline void MakeStation(Tile t, Owner o, StationID sid, StationType st, b
  * @param section the StationGfx to be used for this tile
  * @param rt the railtype of this tile
  */
-static inline void MakeRailStation(Tile t, Owner o, StationID sid, Axis a, byte section, RailType rt)
+inline void MakeRailStation(Tile t, Owner o, StationID sid, Axis a, byte section, RailType rt)
 {
 	MakeStation(t, o, sid, STATION_RAIL, section + a);
 	SetRailType(t, rt);
@@ -662,7 +662,7 @@ static inline void MakeRailStation(Tile t, Owner o, StationID sid, Axis a, byte 
  * @param section the StationGfx to be used for this tile
  * @param rt the railtype of this tile
  */
-static inline void MakeRailWaypoint(Tile t, Owner o, StationID sid, Axis a, byte section, RailType rt)
+inline void MakeRailWaypoint(Tile t, Owner o, StationID sid, Axis a, byte section, RailType rt)
 {
 	MakeStation(t, o, sid, STATION_WAYPOINT, section + a);
 	SetRailType(t, rt);
@@ -679,7 +679,7 @@ static inline void MakeRailWaypoint(Tile t, Owner o, StationID sid, Axis a, byte
  * @param tram_rt the tram roadtype on this tile
  * @param d the direction of the roadstop
  */
-static inline void MakeRoadStop(Tile t, Owner o, StationID sid, RoadStopType rst, RoadType road_rt, RoadType tram_rt, DiagDirection d)
+inline void MakeRoadStop(Tile t, Owner o, StationID sid, RoadStopType rst, RoadType road_rt, RoadType tram_rt, DiagDirection d)
 {
 	MakeStation(t, o, sid, (rst == ROADSTOP_BUS ? STATION_BUS : STATION_TRUCK), d);
 	SetRoadTypes(t, road_rt, tram_rt);
@@ -699,7 +699,7 @@ static inline void MakeRoadStop(Tile t, Owner o, StationID sid, RoadStopType rst
  * @param tram_rt the tram roadtype on this tile
  * @param a the direction of the roadstop
  */
-static inline void MakeDriveThroughRoadStop(Tile t, Owner station, Owner road, Owner tram, StationID sid, RoadStopType rst, RoadType road_rt, RoadType tram_rt, Axis a)
+inline void MakeDriveThroughRoadStop(Tile t, Owner station, Owner road, Owner tram, StationID sid, RoadStopType rst, RoadType road_rt, RoadType tram_rt, Axis a)
 {
 	MakeStation(t, station, sid, (rst == ROADSTOP_BUS ? STATION_BUS : STATION_TRUCK), GFX_TRUCK_BUS_DRIVETHROUGH_OFFSET + a);
 	SetRoadTypes(t, road_rt, tram_rt);
@@ -715,7 +715,7 @@ static inline void MakeDriveThroughRoadStop(Tile t, Owner station, Owner road, O
  * @param section the StationGfx to be used for this tile
  * @param wc the type of water on this tile
  */
-static inline void MakeAirport(Tile t, Owner o, StationID sid, byte section, WaterClass wc)
+inline void MakeAirport(Tile t, Owner o, StationID sid, byte section, WaterClass wc)
 {
 	MakeStation(t, o, sid, STATION_AIRPORT, section, wc);
 }
@@ -726,7 +726,7 @@ static inline void MakeAirport(Tile t, Owner o, StationID sid, byte section, Wat
  * @param sid the station to which this tile belongs
  * @param wc the type of water on this tile
  */
-static inline void MakeBuoy(Tile t, StationID sid, WaterClass wc)
+inline void MakeBuoy(Tile t, StationID sid, WaterClass wc)
 {
 	/* Make the owner of the buoy tile the same as the current owner of the
 	 * water tile. In this way, we can reset the owner of the water to its
@@ -742,7 +742,7 @@ static inline void MakeBuoy(Tile t, StationID sid, WaterClass wc)
  * @param d the direction of the dock
  * @param wc the type of water on this tile
  */
-static inline void MakeDock(Tile t, Owner o, StationID sid, DiagDirection d, WaterClass wc)
+inline void MakeDock(Tile t, Owner o, StationID sid, DiagDirection d, WaterClass wc)
 {
 	MakeStation(t, o, sid, STATION_DOCK, d);
 	MakeStation(TileIndex(t) + TileOffsByDiagDir(d), o, sid, STATION_DOCK, GFX_DOCK_BASE_WATER_PART + DiagDirToAxis(d), wc);
@@ -754,7 +754,7 @@ static inline void MakeDock(Tile t, Owner o, StationID sid, DiagDirection d, Wat
  * @param sid the station to which this tile belongs
  * @param wc the type of water on this tile
  */
-static inline void MakeOilrig(Tile t, StationID sid, WaterClass wc)
+inline void MakeOilrig(Tile t, StationID sid, WaterClass wc)
 {
 	MakeStation(t, OWNER_NONE, sid, STATION_OILRIG, 0, wc);
 }

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -411,7 +411,7 @@ void NORETURN AssertFailedError(int line, const char *file, const char *expressi
  * Version of the standard free that accepts const pointers.
  * @param ptr The data to free.
  */
-static inline void free(const void *ptr)
+inline void free(const void *ptr)
 {
 	free(const_cast<void *>(ptr));
 }

--- a/src/story_base.h
+++ b/src/story_base.h
@@ -113,7 +113,7 @@ enum StoryPageButtonCursor : byte {
  * @param wc The value to check
  * @return true if the given value is a valid StoryPageButtonCursor.
  */
-static inline bool IsValidStoryPageButtonCursor(StoryPageButtonCursor cursor)
+inline bool IsValidStoryPageButtonCursor(StoryPageButtonCursor cursor)
 {
 	return cursor < SPBC_END;
 }

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -54,7 +54,7 @@ struct CaseInsensitiveComparator {
  * @return true if the buffer starts with the terminating null-character or
  *         if the given pointer points to nullptr else return false
  */
-static inline bool StrEmpty(const char *s)
+inline bool StrEmpty(const char *s)
 {
 	return s == nullptr || s[0] == '\0';
 }
@@ -66,7 +66,7 @@ static inline bool StrEmpty(const char *s)
  * @param maxlen The maximum size of the buffer
  * @return The length of the string
  */
-static inline size_t ttd_strnlen(const char *str, size_t maxlen)
+inline size_t ttd_strnlen(const char *str, size_t maxlen)
 {
 	const char *t;
 	for (t = str; (size_t)(t - str) < maxlen && *t != '\0'; t++) {}
@@ -82,7 +82,7 @@ size_t Utf8Encode(std::back_insert_iterator<std::string> &buf, char32_t c);
 size_t Utf8TrimString(char *s, size_t maxlen);
 
 
-static inline char32_t Utf8Consume(const char **s)
+inline char32_t Utf8Consume(const char **s)
 {
 	char32_t c;
 	*s += Utf8Decode(&c, *s);
@@ -90,7 +90,7 @@ static inline char32_t Utf8Consume(const char **s)
 }
 
 template <class Titr>
-static inline char32_t Utf8Consume(Titr &s)
+inline char32_t Utf8Consume(Titr &s)
 {
 	char32_t c;
 	s += Utf8Decode(&c, &*s);
@@ -102,7 +102,7 @@ static inline char32_t Utf8Consume(Titr &s)
  * @param c Unicode character.
  * @return Length of UTF-8 encoding for character.
  */
-static inline int8_t Utf8CharLen(char32_t c)
+inline int8_t Utf8CharLen(char32_t c)
 {
 	if (c < 0x80)       return 1;
 	if (c < 0x800)      return 2;
@@ -121,7 +121,7 @@ static inline int8_t Utf8CharLen(char32_t c)
  * @param c char to query length of
  * @return requested size
  */
-static inline int8_t Utf8EncodedCharLen(char c)
+inline int8_t Utf8EncodedCharLen(char c)
 {
 	if (GB(c, 3, 5) == 0x1E) return 4;
 	if (GB(c, 4, 4) == 0x0E) return 3;
@@ -134,7 +134,7 @@ static inline int8_t Utf8EncodedCharLen(char c)
 
 
 /* Check if the given character is part of a UTF8 sequence */
-static inline bool IsUtf8Part(char c)
+inline bool IsUtf8Part(char c)
 {
 	return GB(c, 6, 2) == 2;
 }
@@ -146,14 +146,14 @@ static inline bool IsUtf8Part(char c)
  * @note The function should not be used to determine the length of the previous
  * encoded char because it might be an invalid/corrupt start-sequence
  */
-static inline char *Utf8PrevChar(char *s)
+inline char *Utf8PrevChar(char *s)
 {
 	char *ret = s;
 	while (IsUtf8Part(*--ret)) {}
 	return ret;
 }
 
-static inline const char *Utf8PrevChar(const char *s)
+inline const char *Utf8PrevChar(const char *s)
 {
 	const char *ret = s;
 	while (IsUtf8Part(*--ret)) {}
@@ -168,7 +168,7 @@ size_t Utf8StringLength(const std::string &str);
  * @param c The character to test.
  * @return True if the character is a lead surrogate code point.
  */
-static inline bool Utf16IsLeadSurrogate(uint c)
+inline bool Utf16IsLeadSurrogate(uint c)
 {
 	return c >= 0xD800 && c <= 0xDBFF;
 }
@@ -178,7 +178,7 @@ static inline bool Utf16IsLeadSurrogate(uint c)
  * @param c The character to test.
  * @return True if the character is a lead surrogate code point.
  */
-static inline bool Utf16IsTrailSurrogate(uint c)
+inline bool Utf16IsTrailSurrogate(uint c)
 {
 	return c >= 0xDC00 && c <= 0xDFFF;
 }
@@ -189,7 +189,7 @@ static inline bool Utf16IsTrailSurrogate(uint c)
  * @param trail Trail surrogate code point.
  * @return Decoded Unicode character.
  */
-static inline char32_t Utf16DecodeSurrogate(uint lead, uint trail)
+inline char32_t Utf16DecodeSurrogate(uint lead, uint trail)
 {
 	return 0x10000 + (((lead - 0xD800) << 10) | (trail - 0xDC00));
 }
@@ -199,7 +199,7 @@ static inline char32_t Utf16DecodeSurrogate(uint lead, uint trail)
  * @param c Pointer to one or two UTF-16 code points.
  * @return Decoded Unicode character.
  */
-static inline char32_t Utf16DecodeChar(const uint16_t *c)
+inline char32_t Utf16DecodeChar(const uint16_t *c)
 {
 	if (Utf16IsLeadSurrogate(c[0])) {
 		return Utf16DecodeSurrogate(c[0], c[1]);
@@ -214,7 +214,7 @@ static inline char32_t Utf16DecodeChar(const uint16_t *c)
  * @return true iff the character is used to influence
  *         the text direction.
  */
-static inline bool IsTextDirectionChar(char32_t c)
+inline bool IsTextDirectionChar(char32_t c)
 {
 	switch (c) {
 		case CHAR_TD_LRM:
@@ -231,7 +231,7 @@ static inline bool IsTextDirectionChar(char32_t c)
 	}
 }
 
-static inline bool IsPrintable(char32_t c)
+inline bool IsPrintable(char32_t c)
 {
 	if (c < 0x20)   return false;
 	if (c < 0xE000) return true;
@@ -246,7 +246,7 @@ static inline bool IsPrintable(char32_t c)
  * @return a boolean value whether 'c' is a whitespace character or not
  * @see http://www.fileformat.info/info/unicode/category/Zs/list.htm
  */
-static inline bool IsWhitespace(char32_t c)
+inline bool IsWhitespace(char32_t c)
 {
 	return c == 0x0020 /* SPACE */ || c == 0x3000; /* IDEOGRAPHIC SPACE */
 }

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -23,7 +23,7 @@
  * @param str String identifier
  * @return StringTab from \a str
  */
-static inline StringTab GetStringTab(StringID str)
+inline StringTab GetStringTab(StringID str)
 {
 	StringTab result = (StringTab)(str >> TAB_SIZE_BITS);
 	if (result >= TEXT_TAB_NEWGRF_START) return TEXT_TAB_NEWGRF_START;
@@ -36,7 +36,7 @@ static inline StringTab GetStringTab(StringID str)
  * @param str String identifier
  * @return StringIndex from \a str
  */
-static inline uint GetStringIndex(StringID str)
+inline uint GetStringIndex(StringID str)
 {
 	return str - (GetStringTab(str) << TAB_SIZE_BITS);
 }
@@ -47,7 +47,7 @@ static inline uint GetStringIndex(StringID str)
  * @param index StringIndex
  * @return StringID composed from \a tab and \a index
  */
-static inline StringID MakeStringID(StringTab tab, uint index)
+inline StringID MakeStringID(StringTab tab, uint index)
 {
 	if (tab == TEXT_TAB_NEWGRF_START) {
 		assert(index < TAB_SIZE_NEWGRF);
@@ -72,7 +72,7 @@ uint ConvertDisplaySpeedToKmhishSpeed(uint speed, VehicleType type);
  * @param type Type of vehicle for parameter.
  * @return Bit-packed velocity and vehicle type, for use with SetDParam().
  */
-static inline int64_t PackVelocity(uint speed, VehicleType type)
+inline int64_t PackVelocity(uint speed, VehicleType type)
 {
 	/* Vehicle type is a byte, so packed into the top 8 bits of the 64-bit
 	 * parameter, although only values from 0-3 are relevant. */

--- a/src/tile_cmd.h
+++ b/src/tile_cmd.h
@@ -179,7 +179,7 @@ VehicleEnterTileStatus VehicleEnterTile(Vehicle *v, TileIndex tile, int x, int y
 void ChangeTileOwner(TileIndex tile, Owner old_owner, Owner new_owner);
 void GetTileDesc(TileIndex tile, TileDesc *td);
 
-static inline void AddAcceptedCargo(TileIndex tile, CargoArray &acceptance, CargoTypes *always_accepted)
+inline void AddAcceptedCargo(TileIndex tile, CargoArray &acceptance, CargoTypes *always_accepted)
 {
 	AddAcceptedCargoProc *proc = _tile_type_procs[GetTileType(tile)]->add_accepted_cargo_proc;
 	if (proc == nullptr) return;
@@ -187,21 +187,21 @@ static inline void AddAcceptedCargo(TileIndex tile, CargoArray &acceptance, Carg
 	proc(tile, acceptance, always_accepted == nullptr ? &dummy : always_accepted);
 }
 
-static inline void AddProducedCargo(TileIndex tile, CargoArray &produced)
+inline void AddProducedCargo(TileIndex tile, CargoArray &produced)
 {
 	AddProducedCargoProc *proc = _tile_type_procs[GetTileType(tile)]->add_produced_cargo_proc;
 	if (proc == nullptr) return;
 	proc(tile, produced);
 }
 
-static inline void AnimateTile(TileIndex tile)
+inline void AnimateTile(TileIndex tile)
 {
 	AnimateTileProc *proc = _tile_type_procs[GetTileType(tile)]->animate_tile_proc;
 	assert(proc != nullptr);
 	proc(tile);
 }
 
-static inline bool ClickTile(TileIndex tile)
+inline bool ClickTile(TileIndex tile)
 {
 	ClickTileProc *proc = _tile_type_procs[GetTileType(tile)]->click_tile_proc;
 	if (proc == nullptr) return false;

--- a/src/tile_map.h
+++ b/src/tile_map.h
@@ -39,7 +39,7 @@ debug_inline static uint TileHeight(Tile tile)
  * @param y Y coordinate of the tile, may be outside the map.
  * @return The height in the same unit as TileHeight.
  */
-static inline uint TileHeightOutsideMap(int x, int y)
+inline uint TileHeightOutsideMap(int x, int y)
 {
 	return TileHeight(TileXY(Clamp(x, 0, Map::MaxX()), Clamp(y, 0, Map::MaxY())));
 }
@@ -54,7 +54,7 @@ static inline uint TileHeightOutsideMap(int x, int y)
  * @pre tile < Map::Size()
  * @pre height <= MAX_TILE_HEIGHT
  */
-static inline void SetTileHeight(Tile tile, uint height)
+inline void SetTileHeight(Tile tile, uint height)
 {
 	assert(tile < Map::Size());
 	assert(height <= MAX_TILE_HEIGHT);
@@ -69,7 +69,7 @@ static inline void SetTileHeight(Tile tile, uint height)
  * @param tile The tile to get the height
  * @return The height of the tile in pixel
  */
-static inline uint TilePixelHeight(Tile tile)
+inline uint TilePixelHeight(Tile tile)
 {
 	return TileHeight(tile) * TILE_HEIGHT;
 }
@@ -81,7 +81,7 @@ static inline uint TilePixelHeight(Tile tile)
  * @param y Y coordinate of the tile, may be outside the map.
  * @return The height in pixels in the same unit as TilePixelHeight.
  */
-static inline uint TilePixelHeightOutsideMap(int x, int y)
+inline uint TilePixelHeightOutsideMap(int x, int y)
 {
 	return TileHeightOutsideMap(x, y) * TILE_HEIGHT;
 }
@@ -106,7 +106,7 @@ debug_inline static TileType GetTileType(Tile tile)
  * @return Whether the tile is in the interior of the map
  * @pre tile < Map::Size()
  */
-static inline bool IsInnerTile(Tile tile)
+inline bool IsInnerTile(Tile tile)
 {
 	assert(tile < Map::Size());
 
@@ -128,7 +128,7 @@ static inline bool IsInnerTile(Tile tile)
  * @pre tile < Map::Size()
  * @pre type MP_VOID <=> tile is on the south-east or south-west edge.
  */
-static inline void SetTileType(Tile tile, TileType type)
+inline void SetTileType(Tile tile, TileType type)
 {
 	assert(tile < Map::Size());
 	/* VOID tiles (and no others) are exactly allowed at the lower left and right
@@ -158,7 +158,7 @@ debug_inline static bool IsTileType(Tile tile, TileType type)
  * @param tile The tile to check
  * @return True if the tile is on the map and not one of MP_VOID.
  */
-static inline bool IsValidTile(Tile tile)
+inline bool IsValidTile(Tile tile)
 {
 	return tile < Map::Size() && !IsTileType(tile, MP_VOID);
 }
@@ -175,7 +175,7 @@ static inline bool IsValidTile(Tile tile)
  * @pre IsValidTile(tile)
  * @pre The type of the tile must not be MP_HOUSE and MP_INDUSTRY
  */
-static inline Owner GetTileOwner(Tile tile)
+inline Owner GetTileOwner(Tile tile)
 {
 	assert(IsValidTile(tile));
 	assert(!IsTileType(tile, MP_HOUSE));
@@ -195,7 +195,7 @@ static inline Owner GetTileOwner(Tile tile)
  * @pre IsValidTile(tile)
  * @pre The type of the tile must not be MP_HOUSE and MP_INDUSTRY
  */
-static inline void SetTileOwner(Tile tile, Owner owner)
+inline void SetTileOwner(Tile tile, Owner owner)
 {
 	assert(IsValidTile(tile));
 	assert(!IsTileType(tile, MP_HOUSE));
@@ -211,7 +211,7 @@ static inline void SetTileOwner(Tile tile, Owner owner)
  * @param owner The owner to check against
  * @return True if a tile belongs the the given owner
  */
-static inline bool IsTileOwner(Tile tile, Owner owner)
+inline bool IsTileOwner(Tile tile, Owner owner)
 {
 	return GetTileOwner(tile) == owner;
 }
@@ -222,7 +222,7 @@ static inline bool IsTileOwner(Tile tile, Owner owner)
  * @param type the new type
  * @pre tile < Map::Size()
  */
-static inline void SetTropicZone(Tile tile, TropicZone type)
+inline void SetTropicZone(Tile tile, TropicZone type)
 {
 	assert(tile < Map::Size());
 	assert(!IsTileType(tile, MP_VOID) || type == TROPICZONE_NORMAL);
@@ -235,7 +235,7 @@ static inline void SetTropicZone(Tile tile, TropicZone type)
  * @pre tile < Map::Size()
  * @return the zone type
  */
-static inline TropicZone GetTropicZone(Tile tile)
+inline TropicZone GetTropicZone(Tile tile)
 {
 	assert(tile < Map::Size());
 	return (TropicZone)GB(tile.type(), 0, 2);
@@ -247,7 +247,7 @@ static inline TropicZone GetTropicZone(Tile tile)
  * @pre IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) ||IsTileType(t, MP_STATION)
  * @return frame number
  */
-static inline byte GetAnimationFrame(Tile t)
+inline byte GetAnimationFrame(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) ||IsTileType(t, MP_STATION));
 	return t.m7();
@@ -259,7 +259,7 @@ static inline byte GetAnimationFrame(Tile t)
  * @param frame the new frame number
  * @pre IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) ||IsTileType(t, MP_STATION)
  */
-static inline void SetAnimationFrame(Tile t, byte frame)
+inline void SetAnimationFrame(Tile t, byte frame)
 {
 	assert(IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) ||IsTileType(t, MP_STATION));
 	t.m7() = frame;
@@ -277,7 +277,7 @@ bool IsTileFlat(TileIndex tile, int *h = nullptr);
  * @param h    If not \c nullptr, pointer to storage of z height
  * @return Slope of the tile, except for the HALFTILE part
  */
-static inline Slope GetTilePixelSlope(TileIndex tile, int *h)
+inline Slope GetTilePixelSlope(TileIndex tile, int *h)
 {
 	Slope s = GetTileSlope(tile, h);
 	if (h != nullptr) *h *= TILE_HEIGHT;
@@ -291,7 +291,7 @@ Slope GetTilePixelSlopeOutsideMap(int x, int y, int *h);
  * @param tile Tile to compute height of
  * @return Minimum height of the tile
  */
-static inline int GetTilePixelZ(TileIndex tile)
+inline int GetTilePixelZ(TileIndex tile)
 {
 	return GetTileZ(tile) * TILE_HEIGHT;
 }
@@ -301,7 +301,7 @@ static inline int GetTilePixelZ(TileIndex tile)
  * @param tile Tile to compute height of
  * @return Maximum height of the tile
  */
-static inline int GetTileMaxPixelZ(TileIndex tile)
+inline int GetTileMaxPixelZ(TileIndex tile)
 {
 	return GetTileMaxZ(tile) * TILE_HEIGHT;
 }
@@ -313,7 +313,7 @@ static inline int GetTileMaxPixelZ(TileIndex tile)
  * @param y The Y coordinate
  * @return The hash of the tile
  */
-static inline uint TileHash(uint x, uint y)
+inline uint TileHash(uint x, uint y)
 {
 	uint hash = x >> 4;
 	hash ^= x >> 6;
@@ -331,7 +331,7 @@ static inline uint TileHash(uint x, uint y)
  * @param y The Y coordinate
  * @return The last two bits from hash of the tile
  */
-static inline uint TileHash2Bit(uint x, uint y)
+inline uint TileHash2Bit(uint x, uint y)
 {
 	return GB(TileHash(x, y), 0, 2);
 }

--- a/src/tile_type.h
+++ b/src/tile_type.h
@@ -92,6 +92,6 @@ static_assert(sizeof(TileIndex) == 4);
 /**
  * The very nice invalid tile marker
  */
-static inline constexpr TileIndex INVALID_TILE = TileIndex{ (uint32_t)-1 };
+inline constexpr TileIndex INVALID_TILE = TileIndex{ (uint32_t)-1 };
 
 #endif /* TILE_TYPE_H */

--- a/src/town.h
+++ b/src/town.h
@@ -304,7 +304,7 @@ void MakeDefaultName(T *obj)
  * Converts original town ticks counters to plain game ticks. Note that
  * tick 0 is a valid tick so actual amount is one more than the counter value.
  */
-static inline uint16_t TownTicksToGameTicks(uint16_t ticks)
+inline uint16_t TownTicksToGameTicks(uint16_t ticks)
 {
 	return (std::min(ticks, MAX_TOWN_GROWTH_TICKS) + 1) * Ticks::TOWN_GROWTH_TICKS - 1;
 }

--- a/src/town_map.h
+++ b/src/town_map.h
@@ -20,7 +20,7 @@
  * @pre IsTileType(t, MP_HOUSE) or IsTileType(t, MP_ROAD) but not a road depot
  * @return TownID
  */
-static inline TownID GetTownIndex(Tile t)
+inline TownID GetTownIndex(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE) || (IsTileType(t, MP_ROAD) && !IsRoadDepot(t)));
 	return t.m2();
@@ -32,7 +32,7 @@ static inline TownID GetTownIndex(Tile t)
  * @param index the index of the town
  * @pre IsTileType(t, MP_HOUSE) or IsTileType(t, MP_ROAD) but not a road depot
  */
-static inline void SetTownIndex(Tile t, TownID index)
+inline void SetTownIndex(Tile t, TownID index)
 {
 	assert(IsTileType(t, MP_HOUSE) || (IsTileType(t, MP_ROAD) && !IsRoadDepot(t)));
 	t.m2() = index;
@@ -45,7 +45,7 @@ static inline void SetTownIndex(Tile t, TownID index)
  * @pre IsTileType(t, MP_HOUSE)
  * @return house type
  */
-static inline HouseID GetCleanHouseType(Tile t)
+inline HouseID GetCleanHouseType(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	return t.m4() | (GB(t.m3(), 6, 1) << 8);
@@ -57,7 +57,7 @@ static inline HouseID GetCleanHouseType(Tile t)
  * @pre IsTileType(t, MP_HOUSE)
  * @return house type
  */
-static inline HouseID GetHouseType(Tile t)
+inline HouseID GetHouseType(Tile t)
 {
 	return GetTranslatedHouseID(GetCleanHouseType(t));
 }
@@ -68,7 +68,7 @@ static inline HouseID GetHouseType(Tile t)
  * @param house_id the new house type
  * @pre IsTileType(t, MP_HOUSE)
  */
-static inline void SetHouseType(Tile t, HouseID house_id)
+inline void SetHouseType(Tile t, HouseID house_id)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	t.m4() = GB(house_id, 0, 8);
@@ -80,7 +80,7 @@ static inline void SetHouseType(Tile t, HouseID house_id)
  * @param t the tile
  * @return has destination
  */
-static inline bool LiftHasDestination(Tile t)
+inline bool LiftHasDestination(Tile t)
 {
 	return HasBit(t.m7(), 0);
 }
@@ -91,7 +91,7 @@ static inline bool LiftHasDestination(Tile t)
  * @param t the tile
  * @param dest new destination
  */
-static inline void SetLiftDestination(Tile t, byte dest)
+inline void SetLiftDestination(Tile t, byte dest)
 {
 	SetBit(t.m7(), 0);
 	SB(t.m7(), 1, 3, dest);
@@ -102,7 +102,7 @@ static inline void SetLiftDestination(Tile t, byte dest)
  * @param t the tile
  * @return destination
  */
-static inline byte GetLiftDestination(Tile t)
+inline byte GetLiftDestination(Tile t)
 {
 	return GB(t.m7(), 1, 3);
 }
@@ -113,7 +113,7 @@ static inline byte GetLiftDestination(Tile t)
  * and the destination.
  * @param t the tile
  */
-static inline void HaltLift(Tile t)
+inline void HaltLift(Tile t)
 {
 	SB(t.m7(), 0, 4, 0);
 }
@@ -123,7 +123,7 @@ static inline void HaltLift(Tile t)
  * @param t the tile
  * @return position, from 0 to 36
  */
-static inline byte GetLiftPosition(Tile t)
+inline byte GetLiftPosition(Tile t)
 {
 	return GB(t.m6(), 2, 6);
 }
@@ -133,7 +133,7 @@ static inline byte GetLiftPosition(Tile t)
  * @param t the tile
  * @param pos position, from 0 to 36
  */
-static inline void SetLiftPosition(Tile t, byte pos)
+inline void SetLiftPosition(Tile t, byte pos)
 {
 	SB(t.m6(), 2, 6, pos);
 }
@@ -143,7 +143,7 @@ static inline void SetLiftPosition(Tile t, byte pos)
  * @param t the tile
  * @return true if it is, false if it is not
  */
-static inline bool IsHouseCompleted(Tile t)
+inline bool IsHouseCompleted(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	return HasBit(t.m3(), 7);
@@ -154,7 +154,7 @@ static inline bool IsHouseCompleted(Tile t)
  * @param t the tile
  * @param status
  */
-static inline void SetHouseCompleted(Tile t, bool status)
+inline void SetHouseCompleted(Tile t, bool status)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	SB(t.m3(), 7, 1, !!status);
@@ -181,7 +181,7 @@ static inline void SetHouseCompleted(Tile t, bool status)
  * @pre IsTileType(t, MP_HOUSE)
  * @return the building stage of the house
  */
-static inline byte GetHouseBuildingStage(Tile t)
+inline byte GetHouseBuildingStage(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	return IsHouseCompleted(t) ? (byte)TOWN_HOUSE_COMPLETED : GB(t.m5(), 3, 2);
@@ -193,7 +193,7 @@ static inline byte GetHouseBuildingStage(Tile t)
  * @pre IsTileType(t, MP_HOUSE)
  * @return the construction stage of the house
  */
-static inline byte GetHouseConstructionTick(Tile t)
+inline byte GetHouseConstructionTick(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	return IsHouseCompleted(t) ? 0 : GB(t.m5(), 0, 3);
@@ -206,7 +206,7 @@ static inline byte GetHouseConstructionTick(Tile t)
  * @param t the tile of the house to increment the construction stage of
  * @pre IsTileType(t, MP_HOUSE)
  */
-static inline void IncHouseConstructionTick(Tile t)
+inline void IncHouseConstructionTick(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	AB(t.m5(), 0, 5, 1);
@@ -224,7 +224,7 @@ static inline void IncHouseConstructionTick(Tile t)
  * @param t the tile of this house
  * @pre IsTileType(t, MP_HOUSE) && IsHouseCompleted(t)
  */
-static inline void ResetHouseAge(Tile t)
+inline void ResetHouseAge(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE) && IsHouseCompleted(t));
 	t.m5() = 0;
@@ -235,7 +235,7 @@ static inline void ResetHouseAge(Tile t)
  * @param t the tile of this house
  * @pre IsTileType(t, MP_HOUSE)
  */
-static inline void IncrementHouseAge(Tile t)
+inline void IncrementHouseAge(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	if (IsHouseCompleted(t) && t.m5() < 0xFF) t.m5()++;
@@ -247,7 +247,7 @@ static inline void IncrementHouseAge(Tile t)
  * @pre IsTileType(t, MP_HOUSE)
  * @return year
  */
-static inline TimerGameCalendar::Year GetHouseAge(Tile t)
+inline TimerGameCalendar::Year GetHouseAge(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	return IsHouseCompleted(t) ? t.m5() : 0;
@@ -260,7 +260,7 @@ static inline TimerGameCalendar::Year GetHouseAge(Tile t)
  * @param random the new random bits
  * @pre IsTileType(t, MP_HOUSE)
  */
-static inline void SetHouseRandomBits(Tile t, byte random)
+inline void SetHouseRandomBits(Tile t, byte random)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	t.m1() = random;
@@ -273,7 +273,7 @@ static inline void SetHouseRandomBits(Tile t, byte random)
  * @pre IsTileType(t, MP_HOUSE)
  * @return random bits
  */
-static inline byte GetHouseRandomBits(Tile t)
+inline byte GetHouseRandomBits(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	return t.m1();
@@ -286,7 +286,7 @@ static inline byte GetHouseRandomBits(Tile t)
  * @param triggers the activated triggers
  * @pre IsTileType(t, MP_HOUSE)
  */
-static inline void SetHouseTriggers(Tile t, byte triggers)
+inline void SetHouseTriggers(Tile t, byte triggers)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	SB(t.m3(), 0, 5, triggers);
@@ -299,7 +299,7 @@ static inline void SetHouseTriggers(Tile t, byte triggers)
  * @pre IsTileType(t, MP_HOUSE)
  * @return triggers
  */
-static inline byte GetHouseTriggers(Tile t)
+inline byte GetHouseTriggers(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	return GB(t.m3(), 0, 5);
@@ -311,7 +311,7 @@ static inline byte GetHouseTriggers(Tile t)
  * @pre IsTileType(t, MP_HOUSE)
  * @return time remaining
  */
-static inline byte GetHouseProcessingTime(Tile t)
+inline byte GetHouseProcessingTime(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	return GB(t.m6(), 2, 6);
@@ -323,7 +323,7 @@ static inline byte GetHouseProcessingTime(Tile t)
  * @param time the time to be set
  * @pre IsTileType(t, MP_HOUSE)
  */
-static inline void SetHouseProcessingTime(Tile t, byte time)
+inline void SetHouseProcessingTime(Tile t, byte time)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	SB(t.m6(), 2, 6, time);
@@ -334,7 +334,7 @@ static inline void SetHouseProcessingTime(Tile t, byte time)
  * @param t the house tile
  * @pre IsTileType(t, MP_HOUSE)
  */
-static inline void DecHouseProcessingTime(Tile t)
+inline void DecHouseProcessingTime(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	t.m6() -= 1 << 2;
@@ -350,7 +350,7 @@ static inline void DecHouseProcessingTime(Tile t)
  * @param random_bits required for newgrf houses
  * @pre IsTileType(t, MP_CLEAR)
  */
-static inline void MakeHouseTile(Tile t, TownID tid, byte counter, byte stage, HouseID type, byte random_bits)
+inline void MakeHouseTile(Tile t, TownID tid, byte counter, byte stage, HouseID type, byte random_bits)
 {
 	assert(IsTileType(t, MP_CLEAR));
 

--- a/src/track_func.h
+++ b/src/track_func.h
@@ -24,7 +24,7 @@ using SetTrackBitIterator = SetBitIterator<Track, TrackBits>;
  * @return true if the given value is a valid track.
  * @note Use this in an assert()
  */
-static inline bool IsValidTrack(Track track)
+inline bool IsValidTrack(Track track)
 {
 	return track < TRACK_END;
 }
@@ -36,7 +36,7 @@ static inline bool IsValidTrack(Track track)
  * @return true if the given value is a valid Trackdir
  * @note Use this in an assert()
  */
-static inline bool IsValidTrackdirForRoadVehicle(Trackdir trackdir)
+inline bool IsValidTrackdirForRoadVehicle(Trackdir trackdir)
 {
 	return trackdir < TRACKDIR_END;
 }
@@ -48,7 +48,7 @@ static inline bool IsValidTrackdirForRoadVehicle(Trackdir trackdir)
  * @return true if the given value is a valid Trackdir
  * @note Use this in an assert()
  */
-static inline bool IsValidTrackdir(Trackdir trackdir)
+inline bool IsValidTrackdir(Trackdir trackdir)
 {
 	return trackdir != INVALID_TRACKDIR && ((1 << trackdir & TRACKDIR_BIT_MASK) != TRACKDIR_BIT_NONE);
 }
@@ -62,7 +62,7 @@ static inline bool IsValidTrackdir(Trackdir trackdir)
  * @param a the axis to convert
  * @return the track corresponding to the axis
  */
-static inline Track AxisToTrack(Axis a)
+inline Track AxisToTrack(Axis a)
 {
 	assert(IsValidAxis(a));
 	return (Track)a;
@@ -73,7 +73,7 @@ static inline Track AxisToTrack(Axis a)
  * @param track the track to convert
  * @return the converted TrackBits value of the track
  */
-static inline TrackBits TrackToTrackBits(Track track)
+inline TrackBits TrackToTrackBits(Track track)
 {
 	assert(IsValidTrack(track));
 	return (TrackBits)(1 << track);
@@ -84,7 +84,7 @@ static inline TrackBits TrackToTrackBits(Track track)
  * @param a the axis to convert
  * @return the converted TrackBits value of the axis
  */
-static inline TrackBits AxisToTrackBits(Axis a)
+inline TrackBits AxisToTrackBits(Axis a)
 {
 	return TrackToTrackBits(AxisToTrack(a));
 }
@@ -95,7 +95,7 @@ static inline TrackBits AxisToTrackBits(Axis a)
  * @param corner The corner of a tile.
  * @return The TrackBits of the track in the corner.
  */
-static inline TrackBits CornerToTrackBits(Corner corner)
+inline TrackBits CornerToTrackBits(Corner corner)
 {
 	extern const TrackBits _corner_to_trackbits[];
 	assert(IsValidCorner(corner));
@@ -107,7 +107,7 @@ static inline TrackBits CornerToTrackBits(Corner corner)
  * @param trackdir the track direction to convert
  * @return the converted TrackdirBits value
  */
-static inline TrackdirBits TrackdirToTrackdirBits(Trackdir trackdir)
+inline TrackdirBits TrackdirToTrackdirBits(Trackdir trackdir)
 {
 	assert(IsValidTrackdir(trackdir));
 	return (TrackdirBits)(1 << trackdir);
@@ -127,7 +127,7 @@ static inline TrackdirBits TrackdirToTrackdirBits(Trackdir trackdir)
  * @return The first Track from the TrackBits value
  * @see FindFirstTrack
  */
-static inline Track RemoveFirstTrack(TrackBits *tracks)
+inline Track RemoveFirstTrack(TrackBits *tracks)
 {
 	if (*tracks != TRACK_BIT_NONE && *tracks != INVALID_TRACK_BIT) {
 		assert((*tracks & ~TRACK_BIT_MASK) == TRACK_BIT_NONE);
@@ -152,7 +152,7 @@ static inline Track RemoveFirstTrack(TrackBits *tracks)
  * @return The first Trackdir from the TrackdirBits value
  * @see FindFirstTrackdir
  */
-static inline Trackdir RemoveFirstTrackdir(TrackdirBits *trackdirs)
+inline Trackdir RemoveFirstTrackdir(TrackdirBits *trackdirs)
 {
 	if (*trackdirs != TRACKDIR_BIT_NONE && *trackdirs != INVALID_TRACKDIR_BIT) {
 		assert((*trackdirs & ~TRACKDIR_BIT_MASK) == TRACKDIR_BIT_NONE);
@@ -173,7 +173,7 @@ static inline Trackdir RemoveFirstTrackdir(TrackdirBits *trackdirs)
  * @return The first Track found or INVALID_TRACK
  * @see RemoveFirstTrack
  */
-static inline Track FindFirstTrack(TrackBits tracks)
+inline Track FindFirstTrack(TrackBits tracks)
 {
 	return (tracks != TRACK_BIT_NONE && tracks != INVALID_TRACK_BIT) ? (Track)FIND_FIRST_BIT(tracks) : INVALID_TRACK;
 }
@@ -189,7 +189,7 @@ static inline Track FindFirstTrack(TrackBits tracks)
  * @return The Track from the value or INVALID_TRACK
  * @pre tracks must contains only one Track or be INVALID_TRACK_BIT
  */
-static inline Track TrackBitsToTrack(TrackBits tracks)
+inline Track TrackBitsToTrack(TrackBits tracks)
 {
 	assert(tracks == INVALID_TRACK_BIT || (tracks != TRACK_BIT_NONE && KillFirstBit(tracks & TRACK_BIT_MASK) == TRACK_BIT_NONE));
 	return tracks != INVALID_TRACK_BIT ? (Track)FIND_FIRST_BIT(tracks & TRACK_BIT_MASK) : INVALID_TRACK;
@@ -207,7 +207,7 @@ static inline Track TrackBitsToTrack(TrackBits tracks)
  * @pre trackdirs must not be INVALID_TRACKDIR_BIT
  * @see RemoveFirstTrackdir
  */
-static inline Trackdir FindFirstTrackdir(TrackdirBits trackdirs)
+inline Trackdir FindFirstTrackdir(TrackdirBits trackdirs)
 {
 	assert((trackdirs & ~TRACKDIR_BIT_MASK) == TRACKDIR_BIT_NONE);
 	return (trackdirs != TRACKDIR_BIT_NONE) ? (Trackdir)FindFirstBit2x64(trackdirs) : INVALID_TRACKDIR;
@@ -227,7 +227,7 @@ static inline Trackdir FindFirstTrackdir(TrackdirBits trackdirs)
  * @param t the track to convert
  * @return the opposite track
  */
-static inline Track TrackToOppositeTrack(Track t)
+inline Track TrackToOppositeTrack(Track t)
 {
 	assert(IsValidTrack(t));
 	return (Track)(t ^ 1);
@@ -243,7 +243,7 @@ static inline Track TrackToOppositeTrack(Track t)
  * @return The reverse trackdir
  * @pre trackdir must not be INVALID_TRACKDIR
  */
-static inline Trackdir ReverseTrackdir(Trackdir trackdir)
+inline Trackdir ReverseTrackdir(Trackdir trackdir)
 {
 	assert(IsValidTrackdirForRoadVehicle(trackdir));
 	return (Trackdir)(trackdir ^ 8);
@@ -258,7 +258,7 @@ static inline Trackdir ReverseTrackdir(Trackdir trackdir)
  * @param trackdir The trackdir value
  * @return The Track which is used in the value
  */
-static inline Track TrackdirToTrack(Trackdir trackdir)
+inline Track TrackdirToTrack(Trackdir trackdir)
 {
 	assert(IsValidTrackdir(trackdir));
 	return (Track)(trackdir & 0x7);
@@ -275,7 +275,7 @@ static inline Track TrackdirToTrack(Trackdir trackdir)
  * @param track The given Track
  * @return The Trackdir from the given Track
  */
-static inline Trackdir TrackToTrackdir(Track track)
+inline Trackdir TrackToTrackdir(Track track)
 {
 	assert(IsValidTrack(track));
 	return (Trackdir)track;
@@ -290,7 +290,7 @@ static inline Trackdir TrackToTrackdir(Track track)
  * @param track The track to get the TrackdirBits from
  * @return The TrackdirBits which the selected tracks
  */
-static inline TrackdirBits TrackToTrackdirBits(Track track)
+inline TrackdirBits TrackToTrackdirBits(Track track)
 {
 	Trackdir td = TrackToTrackdir(track);
 	return (TrackdirBits)(TrackdirToTrackdirBits(td) | TrackdirToTrackdirBits(ReverseTrackdir(td)));
@@ -304,7 +304,7 @@ static inline TrackdirBits TrackToTrackdirBits(Track track)
  * @param bits The TrackdirBits to get the TrackBits from
  * @return The TrackBits
  */
-static inline TrackBits TrackdirBitsToTrackBits(TrackdirBits bits)
+inline TrackBits TrackdirBitsToTrackBits(TrackdirBits bits)
 {
 	return (TrackBits)((bits | (bits >> 8)) & TRACK_BIT_MASK);
 }
@@ -315,7 +315,7 @@ static inline TrackBits TrackdirBitsToTrackBits(TrackdirBits bits)
  * @param bits The TrackBits
  * @return The TrackdirBits containing of bits in both directions.
  */
-static inline TrackdirBits TrackBitsToTrackdirBits(TrackBits bits)
+inline TrackdirBits TrackBitsToTrackdirBits(TrackBits bits)
 {
 	return (TrackdirBits)(bits * 0x101);
 }
@@ -325,7 +325,7 @@ static inline TrackdirBits TrackBitsToTrackdirBits(TrackBits bits)
  * @param tracks The track bits.
  * @param track The track to check.
  */
-static inline bool HasTrack(TrackBits tracks, Track track)
+inline bool HasTrack(TrackBits tracks, Track track)
 {
 	assert(IsValidTrack(track));
 	return HasBit(tracks, track);
@@ -336,7 +336,7 @@ static inline bool HasTrack(TrackBits tracks, Track track)
  * @param trackdirs The trackdir bits.
  * @param trackdir The trackdir to check.
  */
-static inline bool HasTrackdir(TrackdirBits trackdirs, Trackdir trackdir)
+inline bool HasTrackdir(TrackdirBits trackdirs, Trackdir trackdir)
 {
 	assert(IsValidTrackdir(trackdir));
 	return HasBit(trackdirs, trackdir);
@@ -348,7 +348,7 @@ static inline bool HasTrackdir(TrackdirBits trackdirs, Trackdir trackdir)
  * @param ts The TrackStatus returned by GetTileTrackStatus()
  * @return the present trackdirs
  */
-static inline TrackdirBits TrackStatusToTrackdirBits(TrackStatus ts)
+inline TrackdirBits TrackStatusToTrackdirBits(TrackStatus ts)
 {
 	return (TrackdirBits)(ts & TRACKDIR_BIT_MASK);
 }
@@ -359,7 +359,7 @@ static inline TrackdirBits TrackStatusToTrackdirBits(TrackStatus ts)
  * @param ts The TrackStatus returned by GetTileTrackStatus()
  * @return the present tracks
  */
-static inline TrackBits TrackStatusToTrackBits(TrackStatus ts)
+inline TrackBits TrackStatusToTrackBits(TrackStatus ts)
 {
 	return TrackdirBitsToTrackBits(TrackStatusToTrackdirBits(ts));
 }
@@ -372,7 +372,7 @@ static inline TrackBits TrackStatusToTrackBits(TrackStatus ts)
  * @param ts The TrackStatus returned by GetTileTrackStatus()
  * @return the The trackdirs that are blocked by red-signals
  */
-static inline TrackdirBits TrackStatusToRedSignals(TrackStatus ts)
+inline TrackdirBits TrackStatusToRedSignals(TrackStatus ts)
 {
 	return (TrackdirBits)((ts >> 16) & TRACKDIR_BIT_MASK);
 }
@@ -384,7 +384,7 @@ static inline TrackdirBits TrackStatusToRedSignals(TrackStatus ts)
  * @param red_signals red signals
  * @return the TrackStatus representing the given information
  */
-static inline TrackStatus CombineTrackStatus(TrackdirBits trackdirbits, TrackdirBits red_signals)
+inline TrackStatus CombineTrackStatus(TrackdirBits trackdirbits, TrackdirBits red_signals)
 {
 	return (TrackStatus)(trackdirbits | (red_signals << 16));
 }
@@ -399,7 +399,7 @@ static inline TrackStatus CombineTrackStatus(TrackdirBits trackdirbits, Trackdir
  * @param trackdir The given trackdir
  * @return The next Trackdir value of the next tile.
  */
-static inline Trackdir NextTrackdir(Trackdir trackdir)
+inline Trackdir NextTrackdir(Trackdir trackdir)
 {
 	assert(IsValidTrackdir(trackdir));
 	extern const Trackdir _next_trackdir[TRACKDIR_END];
@@ -416,7 +416,7 @@ static inline Trackdir NextTrackdir(Trackdir trackdir)
  * @param track The given track
  * @return The TrackBits with the tracks marked which cross the given track by 90 deg.
  */
-static inline TrackBits TrackCrossesTracks(Track track)
+inline TrackBits TrackCrossesTracks(Track track)
 {
 	assert(IsValidTrack(track));
 	extern const TrackBits _track_crosses_tracks[TRACK_END];
@@ -435,7 +435,7 @@ static inline TrackBits TrackCrossesTracks(Track track)
  * @param trackdir The given track direction
  * @return The direction which points to the resulting tile if following the Trackdir
  */
-static inline DiagDirection TrackdirToExitdir(Trackdir trackdir)
+inline DiagDirection TrackdirToExitdir(Trackdir trackdir)
 {
 	assert(IsValidTrackdirForRoadVehicle(trackdir));
 	extern const DiagDirection _trackdir_to_exitdir[TRACKDIR_END];
@@ -457,7 +457,7 @@ static inline DiagDirection TrackdirToExitdir(Trackdir trackdir)
  * @param diagdir The DiagDirection to apply on
  * @return The resulting track direction or INVALID_TRACKDIR if not possible.
  */
-static inline Trackdir TrackExitdirToTrackdir(Track track, DiagDirection diagdir)
+inline Trackdir TrackExitdirToTrackdir(Track track, DiagDirection diagdir)
 {
 	assert(IsValidTrack(track));
 	assert(IsValidDiagDirection(diagdir));
@@ -482,7 +482,7 @@ static inline Trackdir TrackExitdirToTrackdir(Track track, DiagDirection diagdir
  * @param diagdir The direction to "come from"
  * @return the resulting Trackdir or INVALID_TRACKDIR if not possible.
  */
-static inline Trackdir TrackEnterdirToTrackdir(Track track, DiagDirection diagdir)
+inline Trackdir TrackEnterdirToTrackdir(Track track, DiagDirection diagdir)
 {
 	assert(IsValidTrack(track));
 	assert(IsValidDiagDirection(diagdir));
@@ -494,7 +494,7 @@ static inline Trackdir TrackEnterdirToTrackdir(Track track, DiagDirection diagdi
  * Maps a track and a full (8-way) direction to the trackdir that represents
  * the track running in the given direction.
  */
-static inline Trackdir TrackDirectionToTrackdir(Track track, Direction dir)
+inline Trackdir TrackDirectionToTrackdir(Track track, Direction dir)
 {
 	assert(IsValidTrack(track));
 	assert(IsValidDirection(dir));
@@ -508,7 +508,7 @@ static inline Trackdir TrackDirectionToTrackdir(Track track, Direction dir)
  * @param diagdir The direction
  * @return The resulting Track
  */
-static inline Track DiagDirToDiagTrack(DiagDirection diagdir)
+inline Track DiagDirToDiagTrack(DiagDirection diagdir)
 {
 	assert(IsValidDiagDirection(diagdir));
 	return (Track)(diagdir & 1);
@@ -520,7 +520,7 @@ static inline Track DiagDirToDiagTrack(DiagDirection diagdir)
  * @param diagdir The direction
  * @return The resulting TrackBits
  */
-static inline TrackBits DiagDirToDiagTrackBits(DiagDirection diagdir)
+inline TrackBits DiagDirToDiagTrackBits(DiagDirection diagdir)
 {
 	assert(IsValidDiagDirection(diagdir));
 	return TrackToTrackBits(DiagDirToDiagTrack(diagdir));
@@ -533,7 +533,7 @@ static inline TrackBits DiagDirToDiagTrackBits(DiagDirection diagdir)
  * @param diagdir The direction
  * @return The resulting Trackdir direction
  */
-static inline Trackdir DiagDirToDiagTrackdir(DiagDirection diagdir)
+inline Trackdir DiagDirToDiagTrackdir(DiagDirection diagdir)
 {
 	assert(IsValidDiagDirection(diagdir));
 	extern const Trackdir _dir_to_diag_trackdir[DIAGDIR_END];
@@ -551,7 +551,7 @@ static inline Trackdir DiagDirToDiagTrackdir(DiagDirection diagdir)
  * @return The TrackdirBits which can be used from the given direction
  * @see DiagdirReachesTracks
  */
-static inline TrackdirBits DiagdirReachesTrackdirs(DiagDirection diagdir)
+inline TrackdirBits DiagdirReachesTrackdirs(DiagDirection diagdir)
 {
 	assert(IsValidDiagDirection(diagdir));
 	extern const TrackdirBits _exitdir_reaches_trackdirs[DIAGDIR_END];
@@ -569,7 +569,7 @@ static inline TrackdirBits DiagdirReachesTrackdirs(DiagDirection diagdir)
  * @return The tracks which can be used
  * @see DiagdirReachesTrackdirs
  */
-static inline TrackBits DiagdirReachesTracks(DiagDirection diagdir) { return TrackdirBitsToTrackBits(DiagdirReachesTrackdirs(diagdir)); }
+inline TrackBits DiagdirReachesTracks(DiagDirection diagdir) { return TrackdirBitsToTrackBits(DiagdirReachesTrackdirs(diagdir)); }
 
 /**
  * Maps a trackdir to the trackdirs that can be reached from it (ie, when
@@ -580,7 +580,7 @@ static inline TrackBits DiagdirReachesTracks(DiagDirection diagdir) { return Tra
  * @param trackdir The track direction which will be leaved
  * @return The track directions which can be used from this direction (in the next tile)
  */
-static inline TrackdirBits TrackdirReachesTrackdirs(Trackdir trackdir)
+inline TrackdirBits TrackdirReachesTrackdirs(Trackdir trackdir)
 {
 	assert(IsValidTrackdir(trackdir));
 	extern const TrackdirBits _exitdir_reaches_trackdirs[DIAGDIR_END];
@@ -602,7 +602,7 @@ static inline TrackdirBits TrackdirReachesTrackdirs(Trackdir trackdir)
  * @param trackdir The track direction
  * @return The TrackdirBits which are (more or less) 90 deg turns.
  */
-static inline TrackdirBits TrackdirCrossesTrackdirs(Trackdir trackdir)
+inline TrackdirBits TrackdirCrossesTrackdirs(Trackdir trackdir)
 {
 	assert(IsValidTrackdirForRoadVehicle(trackdir));
 	extern const TrackdirBits _track_crosses_trackdirs[TRACK_END];
@@ -615,7 +615,7 @@ static inline TrackdirBits TrackdirCrossesTrackdirs(Trackdir trackdir)
  * @param track The given track to check
  * @return true if diagonal, else false
  */
-static inline bool IsDiagonalTrack(Track track)
+inline bool IsDiagonalTrack(Track track)
 {
 	assert(IsValidTrack(track));
 	return (track == TRACK_X) || (track == TRACK_Y);
@@ -627,7 +627,7 @@ static inline bool IsDiagonalTrack(Track track)
  * @param trackdir The given trackdir
  * @return true if the trackdir use a diagonal track
  */
-static inline bool IsDiagonalTrackdir(Trackdir trackdir)
+inline bool IsDiagonalTrackdir(Trackdir trackdir)
 {
 	assert(IsValidTrackdir(trackdir));
 	return IsDiagonalTrack(TrackdirToTrack(trackdir));
@@ -641,7 +641,7 @@ static inline bool IsDiagonalTrackdir(Trackdir trackdir)
  * @param  bits The tracks present.
  * @return Whether the tracks present overlap in any way.
  */
-static inline bool TracksOverlap(TrackBits bits)
+inline bool TracksOverlap(TrackBits bits)
 {
 	/* With no, or only one track, there is no overlap */
 	if (bits == TRACK_BIT_NONE || KillFirstBit(bits) == TRACK_BIT_NONE) return false;
@@ -658,7 +658,7 @@ static inline bool TracksOverlap(TrackBits bits)
  * @param track The track to test
  * @return true if the track is already in the tracks or overlaps the tracks.
  */
-static inline bool TrackOverlapsTracks(TrackBits tracks, Track track)
+inline bool TrackOverlapsTracks(TrackBits tracks, Track track)
 {
 	if (HasBit(tracks, track)) return true;
 	return TracksOverlap(tracks | TrackToTrackBits(track));
@@ -669,7 +669,7 @@ static inline bool TrackOverlapsTracks(TrackBits tracks, Track track)
  * @param dir the trackdir to check
  * @return true if it is a reversing road trackdir
  */
-static inline bool IsReversingRoadTrackdir(Trackdir dir)
+inline bool IsReversingRoadTrackdir(Trackdir dir)
 {
 	assert(IsValidTrackdirForRoadVehicle(dir));
 	return (dir & 0x07) >= 6;
@@ -680,7 +680,7 @@ static inline bool IsReversingRoadTrackdir(Trackdir dir)
  * @param dir the trackdir to check
  * @return true if it is a straight road trackdir
  */
-static inline bool IsStraightRoadTrackdir(Trackdir dir)
+inline bool IsStraightRoadTrackdir(Trackdir dir)
 {
 	assert(IsValidTrackdirForRoadVehicle(dir));
 	return (dir & 0x06) == 0;
@@ -696,7 +696,7 @@ static inline bool IsStraightRoadTrackdir(Trackdir dir)
  * @param dir The trackdir of interest.
  * @return true iff the track goes upwards.
  */
-static inline bool IsUphillTrackdir(Slope slope, Trackdir dir)
+inline bool IsUphillTrackdir(Slope slope, Trackdir dir)
 {
 	assert(IsValidTrackdirForRoadVehicle(dir));
 	extern const TrackdirBits _uphill_trackdirs[];
@@ -710,7 +710,7 @@ static inline bool IsUphillTrackdir(Slope slope, Trackdir dir)
  * @param track vehicle track bits
  * @return side of tile the vehicle will leave
  */
-static inline DiagDirection VehicleExitDir(Direction direction, TrackBits track)
+inline DiagDirection VehicleExitDir(Direction direction, TrackBits track)
 {
 	static const TrackBits state_dir_table[DIAGDIR_END] = { TRACK_BIT_RIGHT, TRACK_BIT_LOWER, TRACK_BIT_LEFT, TRACK_BIT_UPPER };
 

--- a/src/transparency.h
+++ b/src/transparency.h
@@ -45,7 +45,7 @@ extern byte _display_opt;
  *
  * @param to the structure which transparency option is ask for
  */
-static inline bool IsTransparencySet(TransparencyOption to)
+inline bool IsTransparencySet(TransparencyOption to)
 {
 	return (HasBit(_transparency_opt, to) && _game_mode != GM_MENU);
 }
@@ -56,7 +56,7 @@ static inline bool IsTransparencySet(TransparencyOption to)
  *
  * @param to the structure which invisibility option is ask for
  */
-static inline bool IsInvisibilitySet(TransparencyOption to)
+inline bool IsInvisibilitySet(TransparencyOption to)
 {
 	return (HasBit(_transparency_opt & _invisibility_opt, to) && _game_mode != GM_MENU);
 }
@@ -66,7 +66,7 @@ static inline bool IsInvisibilitySet(TransparencyOption to)
  *
  * @param to the transparency option to be toggled
  */
-static inline void ToggleTransparency(TransparencyOption to)
+inline void ToggleTransparency(TransparencyOption to)
 {
 	ToggleBit(_transparency_opt, to);
 }
@@ -76,7 +76,7 @@ static inline void ToggleTransparency(TransparencyOption to)
  *
  * @param to the structure which invisibility option is toggle
  */
-static inline void ToggleInvisibility(TransparencyOption to)
+inline void ToggleInvisibility(TransparencyOption to)
 {
 	ToggleBit(_invisibility_opt, to);
 }
@@ -88,7 +88,7 @@ static inline void ToggleInvisibility(TransparencyOption to)
  *
  * @param to the object type which invisibility option to toggle
  */
-static inline void ToggleInvisibilityWithTransparency(TransparencyOption to)
+inline void ToggleInvisibilityWithTransparency(TransparencyOption to)
 {
 	if (IsInvisibilitySet(to)) {
 		ClrBit(_invisibility_opt, to);
@@ -104,13 +104,13 @@ static inline void ToggleInvisibilityWithTransparency(TransparencyOption to)
  *
  * @param to the transparency option to be locked or unlocked
  */
-static inline void ToggleTransparencyLock(TransparencyOption to)
+inline void ToggleTransparencyLock(TransparencyOption to)
 {
 	ToggleBit(_transparency_lock, to);
 }
 
 /** Set or clear all non-locked transparency options */
-static inline void ResetRestoreAllTransparency()
+inline void ResetRestoreAllTransparency()
 {
 	/* if none of the non-locked options are set */
 	if ((_transparency_opt & ~_transparency_lock) == 0) {

--- a/src/tree_map.h
+++ b/src/tree_map.h
@@ -70,7 +70,7 @@ enum TreeGround {
  * @return The treetype of the given tile with trees
  * @pre Tile t must be of type MP_TREES
  */
-static inline TreeType GetTreeType(Tile t)
+inline TreeType GetTreeType(Tile t)
 {
 	assert(IsTileType(t, MP_TREES));
 	return (TreeType)t.m3();
@@ -85,7 +85,7 @@ static inline TreeType GetTreeType(Tile t)
  * @return The groundtype of the tile
  * @pre Tile must be of type MP_TREES
  */
-static inline TreeGround GetTreeGround(Tile t)
+inline TreeGround GetTreeGround(Tile t)
 {
 	assert(IsTileType(t, MP_TREES));
 	return (TreeGround)GB(t.m2(), 6, 3);
@@ -110,7 +110,7 @@ static inline TreeGround GetTreeGround(Tile t)
  * @pre Tile must be of type MP_TREES
  * @see GetTreeCount
  */
-static inline uint GetTreeDensity(Tile t)
+inline uint GetTreeDensity(Tile t)
 {
 	assert(IsTileType(t, MP_TREES));
 	return GB(t.m2(), 4, 2);
@@ -127,7 +127,7 @@ static inline uint GetTreeDensity(Tile t)
  * @param d The density to save with
  * @pre Tile must be of type MP_TREES
  */
-static inline void SetTreeGroundDensity(Tile t, TreeGround g, uint d)
+inline void SetTreeGroundDensity(Tile t, TreeGround g, uint d)
 {
 	assert(IsTileType(t, MP_TREES)); // XXX incomplete
 	SB(t.m2(), 4, 2, d);
@@ -146,7 +146,7 @@ static inline void SetTreeGroundDensity(Tile t, TreeGround g, uint d)
  * @return The number of trees (1-4)
  * @pre Tile must be of type MP_TREES
  */
-static inline uint GetTreeCount(Tile t)
+inline uint GetTreeCount(Tile t)
 {
 	assert(IsTileType(t, MP_TREES));
 	return GB(t.m5(), 6, 2) + 1;
@@ -163,7 +163,7 @@ static inline uint GetTreeCount(Tile t)
  * @param c The value to add (or reduce) on the tree-count value
  * @pre Tile must be of type MP_TREES
  */
-static inline void AddTreeCount(Tile t, int c)
+inline void AddTreeCount(Tile t, int c)
 {
 	assert(IsTileType(t, MP_TREES)); // XXX incomplete
 	t.m5() += c << 6;
@@ -178,7 +178,7 @@ static inline void AddTreeCount(Tile t, int c)
  * @return The tree growth status
  * @pre Tile must be of type MP_TREES
  */
-static inline uint GetTreeGrowth(Tile t)
+inline uint GetTreeGrowth(Tile t)
 {
 	assert(IsTileType(t, MP_TREES));
 	return GB(t.m5(), 0, 3);
@@ -193,7 +193,7 @@ static inline uint GetTreeGrowth(Tile t)
  * @param a The value to add on the tree growth status
  * @pre Tile must be of type MP_TREES
  */
-static inline void AddTreeGrowth(Tile t, int a)
+inline void AddTreeGrowth(Tile t, int a)
 {
 	assert(IsTileType(t, MP_TREES)); // XXX incomplete
 	t.m5() += a;
@@ -209,7 +209,7 @@ static inline void AddTreeGrowth(Tile t, int a)
  * @param g The new value
  * @pre Tile must be of type MP_TREES
  */
-static inline void SetTreeGrowth(Tile t, uint g)
+inline void SetTreeGrowth(Tile t, uint g)
 {
 	assert(IsTileType(t, MP_TREES)); // XXX incomplete
 	SB(t.m5(), 0, 3, g);
@@ -227,7 +227,7 @@ static inline void SetTreeGrowth(Tile t, uint g)
  * @param ground the ground type
  * @param density the density (not the number of trees)
  */
-static inline void MakeTree(Tile t, TreeType type, uint count, uint growth, TreeGround ground, uint density)
+inline void MakeTree(Tile t, TreeType type, uint count, uint growth, TreeGround ground, uint density)
 {
 	SetTileType(t, MP_TREES);
 	SetTileOwner(t, OWNER_NONE);

--- a/src/tunnel_map.h
+++ b/src/tunnel_map.h
@@ -20,7 +20,7 @@
  * @pre IsTileType(t, MP_TUNNELBRIDGE)
  * @return true if and only if this tile is a tunnel (entrance)
  */
-static inline bool IsTunnel(Tile t)
+inline bool IsTunnel(Tile t)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
 	return !HasBit(t.m5(), 7);
@@ -31,7 +31,7 @@ static inline bool IsTunnel(Tile t)
  * @param t the tile that might be a tunnel
  * @return true if and only if this tile is a tunnel (entrance)
  */
-static inline bool IsTunnelTile(Tile t)
+inline bool IsTunnelTile(Tile t)
 {
 	return IsTileType(t, MP_TUNNELBRIDGE) && IsTunnel(t);
 }
@@ -47,7 +47,7 @@ bool IsTunnelInWayDir(TileIndex tile, int z, DiagDirection dir);
  * @param d the direction facing out of the tunnel
  * @param r the road type used in the tunnel
  */
-static inline void MakeRoadTunnel(Tile t, Owner o, DiagDirection d, RoadType road_rt, RoadType tram_rt)
+inline void MakeRoadTunnel(Tile t, Owner o, DiagDirection d, RoadType road_rt, RoadType tram_rt)
 {
 	SetTileType(t, MP_TUNNELBRIDGE);
 	SetTileOwner(t, o);
@@ -70,7 +70,7 @@ static inline void MakeRoadTunnel(Tile t, Owner o, DiagDirection d, RoadType roa
  * @param d the direction facing out of the tunnel
  * @param r the rail type used in the tunnel
  */
-static inline void MakeRailTunnel(Tile t, Owner o, DiagDirection d, RailType r)
+inline void MakeRailTunnel(Tile t, Owner o, DiagDirection d, RailType r)
 {
 	SetTileType(t, MP_TUNNELBRIDGE);
 	SetTileOwner(t, o);

--- a/src/tunnelbridge.h
+++ b/src/tunnelbridge.h
@@ -22,7 +22,7 @@ void MarkBridgeDirty(TileIndex tile);
  * @param end   The end of the tunnel or bridge.
  * @return length of bridge/tunnel middle
  */
-static inline uint GetTunnelBridgeLength(TileIndex begin, TileIndex end)
+inline uint GetTunnelBridgeLength(TileIndex begin, TileIndex end)
 {
 	int x1 = TileX(begin);
 	int y1 = TileY(begin);
@@ -38,7 +38,7 @@ static inline uint GetTunnelBridgeLength(TileIndex begin, TileIndex end)
  * @param end   The end of the tunnel or bridge.
  * @param owner The new owner to set
  */
-static inline void SetTunnelBridgeOwner(TileIndex begin, TileIndex end, Owner owner)
+inline void SetTunnelBridgeOwner(TileIndex begin, TileIndex end, Owner owner)
 {
 	SetTileOwner(begin, owner);
 	SetTileOwner(end, owner);

--- a/src/tunnelbridge_map.h
+++ b/src/tunnelbridge_map.h
@@ -23,7 +23,7 @@
  * @pre IsTileType(t, MP_TUNNELBRIDGE)
  * @return the above mentioned direction
  */
-static inline DiagDirection GetTunnelBridgeDirection(Tile t)
+inline DiagDirection GetTunnelBridgeDirection(Tile t)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
 	return (DiagDirection)GB(t.m5(), 0, 2);
@@ -36,7 +36,7 @@ static inline DiagDirection GetTunnelBridgeDirection(Tile t)
  * @pre IsTileType(t, MP_TUNNELBRIDGE)
  * @return the transport type in the tunnel/bridge
  */
-static inline TransportType GetTunnelBridgeTransportType(Tile t)
+inline TransportType GetTunnelBridgeTransportType(Tile t)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
 	return (TransportType)GB(t.m5(), 2, 2);
@@ -49,7 +49,7 @@ static inline TransportType GetTunnelBridgeTransportType(Tile t)
  * @pre IsTileType(t, MP_TUNNELBRIDGE)
  * @return true if and only if the tile is in a snowy/desert area
  */
-static inline bool HasTunnelBridgeSnowOrDesert(Tile t)
+inline bool HasTunnelBridgeSnowOrDesert(Tile t)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
 	return HasBit(t.m7(), 5);
@@ -63,7 +63,7 @@ static inline bool HasTunnelBridgeSnowOrDesert(Tile t)
  *                       not in snow and not in desert false
  * @pre IsTileType(t, MP_TUNNELBRIDGE)
  */
-static inline void SetTunnelBridgeSnowOrDesert(Tile t, bool snow_or_desert)
+inline void SetTunnelBridgeSnowOrDesert(Tile t, bool snow_or_desert)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
 	SB(t.m7(), 5, 1, snow_or_desert);
@@ -75,7 +75,7 @@ static inline void SetTunnelBridgeSnowOrDesert(Tile t, bool snow_or_desert)
  * @pre IsTileType(t, MP_TUNNELBRIDGE)
  * @return other end
  */
-static inline TileIndex GetOtherTunnelBridgeEnd(Tile t)
+inline TileIndex GetOtherTunnelBridgeEnd(Tile t)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
 	return IsTunnel(t) ? GetOtherTunnelEnd(t) : GetOtherBridgeEnd(t);
@@ -88,7 +88,7 @@ static inline TileIndex GetOtherTunnelBridgeEnd(Tile t)
  * @param t the tile
  * @return reservation state
  */
-static inline bool HasTunnelBridgeReservation(Tile t)
+inline bool HasTunnelBridgeReservation(Tile t)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
 	assert(GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL);
@@ -101,7 +101,7 @@ static inline bool HasTunnelBridgeReservation(Tile t)
  * @param t the tile
  * @param b the reservation state
  */
-static inline void SetTunnelBridgeReservation(Tile t, bool b)
+inline void SetTunnelBridgeReservation(Tile t, bool b)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
 	assert(GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL);
@@ -114,7 +114,7 @@ static inline void SetTunnelBridgeReservation(Tile t, bool b)
  * @param t the tile
  * @return reserved track bits
  */
-static inline TrackBits GetTunnelBridgeReservationTrackBits(Tile t)
+inline TrackBits GetTunnelBridgeReservationTrackBits(Tile t)
 {
 	return HasTunnelBridgeReservation(t) ? DiagDirToDiagTrackBits(GetTunnelBridgeDirection(t)) : TRACK_BIT_NONE;
 }

--- a/src/vehicle_func.h
+++ b/src/vehicle_func.h
@@ -85,7 +85,7 @@ Direction GetDirectionTowards(const Vehicle *v, int x, int y);
  * @param type Vehicle type being queried.
  * @return Vehicle type is buildable by a company.
  */
-static inline bool IsCompanyBuildableVehicleType(VehicleType type)
+inline bool IsCompanyBuildableVehicleType(VehicleType type)
 {
 	switch (type) {
 		case VEH_TRAIN:
@@ -103,7 +103,7 @@ static inline bool IsCompanyBuildableVehicleType(VehicleType type)
  * @param v Vehicle being queried.
  * @return Vehicle is buildable by a company.
  */
-static inline bool IsCompanyBuildableVehicleType(const BaseVehicle *v)
+inline bool IsCompanyBuildableVehicleType(const BaseVehicle *v)
 {
 	return IsCompanyBuildableVehicleType(v->type);
 }
@@ -120,42 +120,42 @@ extern const StringID _veh_refit_msg_table[];
 extern const StringID _send_to_depot_msg_table[];
 
 /* Functions to find the right command for certain vehicle type */
-static inline StringID GetCmdBuildVehMsg(VehicleType type)
+inline StringID GetCmdBuildVehMsg(VehicleType type)
 {
 	return _veh_build_msg_table[type];
 }
 
-static inline StringID GetCmdBuildVehMsg(const BaseVehicle *v)
+inline StringID GetCmdBuildVehMsg(const BaseVehicle *v)
 {
 	return GetCmdBuildVehMsg(v->type);
 }
 
-static inline StringID GetCmdSellVehMsg(VehicleType type)
+inline StringID GetCmdSellVehMsg(VehicleType type)
 {
 	return _veh_sell_msg_table[type];
 }
 
-static inline StringID GetCmdSellVehMsg(const BaseVehicle *v)
+inline StringID GetCmdSellVehMsg(const BaseVehicle *v)
 {
 	return GetCmdSellVehMsg(v->type);
 }
 
-static inline StringID GetCmdRefitVehMsg(VehicleType type)
+inline StringID GetCmdRefitVehMsg(VehicleType type)
 {
 	return _veh_refit_msg_table[type];
 }
 
-static inline StringID GetCmdRefitVehMsg(const BaseVehicle *v)
+inline StringID GetCmdRefitVehMsg(const BaseVehicle *v)
 {
 	return GetCmdRefitVehMsg(v->type);
 }
 
-static inline StringID GetCmdSendToDepotMsg(VehicleType type)
+inline StringID GetCmdSendToDepotMsg(VehicleType type)
 {
 	return _send_to_depot_msg_table[type];
 }
 
-static inline StringID GetCmdSendToDepotMsg(const BaseVehicle *v)
+inline StringID GetCmdSendToDepotMsg(const BaseVehicle *v)
 {
 	return GetCmdSendToDepotMsg(v->type);
 }

--- a/src/vehicle_gui.h
+++ b/src/vehicle_gui.h
@@ -70,7 +70,7 @@ void ShowVehicleListWindow(CompanyID company, VehicleType vehicle_type, TileInde
  * @param type the vehicle type to look at
  * @return the height
  */
-static inline uint GetVehicleHeight(VehicleType type)
+inline uint GetVehicleHeight(VehicleType type)
 {
 	return (type == VEH_TRAIN || type == VEH_ROAD) ? 14 : 24;
 }
@@ -93,7 +93,7 @@ VehicleCellSize GetVehicleImageCellSize(VehicleType type, EngineImageType image_
  * @return corresponding window class
  * @note works only for company buildable vehicle types
  */
-static inline WindowClass GetWindowClassForVehicleType(VehicleType vt)
+inline WindowClass GetWindowClassForVehicleType(VehicleType vt)
 {
 	switch (vt) {
 		default: NOT_REACHED();

--- a/src/viewport_func.h
+++ b/src/viewport_func.h
@@ -43,7 +43,7 @@ void HandleZoomMessage(Window *w, const Viewport *vp, WidgetID widget_zoom_in, W
  * @param w   Window owning the viewport.
  * @pre \a how should not be #ZOOM_NONE.
  */
-static inline void MaxZoomInOut(ZoomStateChange how, Window *w)
+inline void MaxZoomInOut(ZoomStateChange how, Window *w)
 {
 	while (DoZoomInOutWindow(how, w)) {};
 }
@@ -88,7 +88,7 @@ void MarkTileDirtyByTile(TileIndex tile, int bridge_level_offset, int tile_heigh
  * @param bridge_level_offset Height of bridge on tile to also mark dirty. (Height level relative to north corner.)
  * @ingroup dirty
  */
-static inline void MarkTileDirtyByTile(TileIndex tile, int bridge_level_offset = 0)
+inline void MarkTileDirtyByTile(TileIndex tile, int bridge_level_offset = 0)
 {
 	MarkTileDirtyByTile(tile, bridge_level_offset, TileHeight(tile));
 }

--- a/src/void_map.h
+++ b/src/void_map.h
@@ -16,7 +16,7 @@
  * Make a nice void tile ;)
  * @param t the tile to make void
  */
-static inline void MakeVoid(Tile t)
+inline void MakeVoid(Tile t)
 {
 	SetTileType(t, MP_VOID);
 	SetTileHeight(t, 0);

--- a/src/water.h
+++ b/src/water.h
@@ -49,7 +49,7 @@ bool IsWateredTile(TileIndex tile, Direction from);
  * @param num Number of canal tiles.
  * @return Total cost.
  */
-static inline Money CanalMaintenanceCost(uint32_t num)
+inline Money CanalMaintenanceCost(uint32_t num)
 {
 	return (_price[PR_INFRASTRUCTURE_WATER] * num * (1 + IntSqrt(num))) >> 6; // 6 bits scaling.
 }

--- a/src/water_map.h
+++ b/src/water_map.h
@@ -57,7 +57,7 @@ enum WaterClass : byte {
  * @param wc The value to check
  * @return true if the given value is a valid water class.
  */
-static inline bool IsValidWaterClass(WaterClass wc)
+inline bool IsValidWaterClass(WaterClass wc)
 {
 	return wc < WATER_CLASS_INVALID;
 }
@@ -83,7 +83,7 @@ bool IsPossibleDockingTile(Tile t);
  * @param t Water tile to query.
  * @return Water tile type at the tile.
  */
-static inline WaterTileType GetWaterTileType(Tile t)
+inline WaterTileType GetWaterTileType(Tile t)
 {
 	assert(IsTileType(t, MP_WATER));
 
@@ -101,7 +101,7 @@ static inline WaterTileType GetWaterTileType(Tile t)
  * @param t Tile to query.
  * @return True if the tiletype has a waterclass.
  */
-static inline bool HasTileWaterClass(Tile t)
+inline bool HasTileWaterClass(Tile t)
 {
 	return IsTileType(t, MP_WATER) || IsTileType(t, MP_STATION) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_TREES);
 }
@@ -112,7 +112,7 @@ static inline bool HasTileWaterClass(Tile t)
  * @pre IsTileType(t, MP_WATER) || IsTileType(t, MP_STATION) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_OBJECT)
  * @return Water class at the tile.
  */
-static inline WaterClass GetWaterClass(Tile t)
+inline WaterClass GetWaterClass(Tile t)
 {
 	assert(HasTileWaterClass(t));
 	return (WaterClass)GB(t.m1(), 5, 2);
@@ -124,7 +124,7 @@ static inline WaterClass GetWaterClass(Tile t)
  * @param wc New water class.
  * @pre IsTileType(t, MP_WATER) || IsTileType(t, MP_STATION) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_OBJECT)
  */
-static inline void SetWaterClass(Tile t, WaterClass wc)
+inline void SetWaterClass(Tile t, WaterClass wc)
 {
 	assert(HasTileWaterClass(t));
 	SB(t.m1(), 5, 2, wc);
@@ -136,7 +136,7 @@ static inline void SetWaterClass(Tile t, WaterClass wc)
  * @pre IsTileType(t, MP_WATER) || IsTileType(t, MP_STATION) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_OBJECT)
  * @return true iff on water
  */
-static inline bool IsTileOnWater(Tile t)
+inline bool IsTileOnWater(Tile t)
 {
 	return (GetWaterClass(t) != WATER_CLASS_INVALID);
 }
@@ -147,7 +147,7 @@ static inline bool IsTileOnWater(Tile t)
  * @return \c true if any type of clear water like ocean, river, or canal.
  * @pre IsTileType(t, MP_WATER)
  */
-static inline bool IsWater(Tile t)
+inline bool IsWater(Tile t)
 {
 	return GetWaterTileType(t) == WATER_TILE_CLEAR;
 }
@@ -158,7 +158,7 @@ static inline bool IsWater(Tile t)
  * @return \c true if it is a sea water tile.
  * @pre IsTileType(t, MP_WATER)
  */
-static inline bool IsSea(Tile t)
+inline bool IsSea(Tile t)
 {
 	return IsWater(t) && GetWaterClass(t) == WATER_CLASS_SEA;
 }
@@ -169,7 +169,7 @@ static inline bool IsSea(Tile t)
  * @return \c true if it is a canal tile.
  * @pre IsTileType(t, MP_WATER)
  */
-static inline bool IsCanal(Tile t)
+inline bool IsCanal(Tile t)
 {
 	return IsWater(t) && GetWaterClass(t) == WATER_CLASS_CANAL;
 }
@@ -180,7 +180,7 @@ static inline bool IsCanal(Tile t)
  * @return \c true if it is a river water tile.
  * @pre IsTileType(t, MP_WATER)
  */
-static inline bool IsRiver(Tile t)
+inline bool IsRiver(Tile t)
 {
 	return IsWater(t) && GetWaterClass(t) == WATER_CLASS_RIVER;
 }
@@ -190,7 +190,7 @@ static inline bool IsRiver(Tile t)
  * @param t Tile to query.
  * @return \c true if it is a plain water tile.
  */
-static inline bool IsWaterTile(Tile t)
+inline bool IsWaterTile(Tile t)
 {
 	return IsTileType(t, MP_WATER) && IsWater(t);
 }
@@ -201,7 +201,7 @@ static inline bool IsWaterTile(Tile t)
  * @return \c true if it is a sea water tile.
  * @pre IsTileType(t, MP_WATER)
  */
-static inline bool IsCoast(Tile t)
+inline bool IsCoast(Tile t)
 {
 	return GetWaterTileType(t) == WATER_TILE_COAST;
 }
@@ -211,7 +211,7 @@ static inline bool IsCoast(Tile t)
  * @param t Tile to query.
  * @return \c true if it is a coast.
  */
-static inline bool IsCoastTile(Tile t)
+inline bool IsCoastTile(Tile t)
 {
 	return (IsTileType(t, MP_WATER) && IsCoast(t)) || (IsTileType(t, MP_TREES) && GetWaterClass(t) != WATER_CLASS_INVALID);
 }
@@ -222,7 +222,7 @@ static inline bool IsCoastTile(Tile t)
  * @return \c true if it is a ship depot tile.
  * @pre IsTileType(t, MP_WATER)
  */
-static inline bool IsShipDepot(Tile t)
+inline bool IsShipDepot(Tile t)
 {
 	return GetWaterTileType(t) == WATER_TILE_DEPOT;
 }
@@ -232,7 +232,7 @@ static inline bool IsShipDepot(Tile t)
  * @param t Tile to query.
  * @return \c true if it is a ship depot tile.
  */
-static inline bool IsShipDepotTile(Tile t)
+inline bool IsShipDepotTile(Tile t)
 {
 	return IsTileType(t, MP_WATER) && IsShipDepot(t);
 }
@@ -243,7 +243,7 @@ static inline bool IsShipDepotTile(Tile t)
  * @return Axis of the depot.
  * @pre IsShipDepotTile(t)
  */
-static inline Axis GetShipDepotAxis(Tile t)
+inline Axis GetShipDepotAxis(Tile t)
 {
 	assert(IsShipDepotTile(t));
 	return (Axis)GB(t.m5(), WBL_DEPOT_AXIS, 1);
@@ -255,7 +255,7 @@ static inline Axis GetShipDepotAxis(Tile t)
  * @return Part of the depot.
  * @pre IsShipDepotTile(t)
  */
-static inline DepotPart GetShipDepotPart(Tile t)
+inline DepotPart GetShipDepotPart(Tile t)
 {
 	assert(IsShipDepotTile(t));
 	return (DepotPart)GB(t.m5(), WBL_DEPOT_PART, 1);
@@ -267,7 +267,7 @@ static inline DepotPart GetShipDepotPart(Tile t)
  * @return Direction of the depot.
  * @pre IsShipDepotTile(t)
  */
-static inline DiagDirection GetShipDepotDirection(Tile t)
+inline DiagDirection GetShipDepotDirection(Tile t)
 {
 	return XYNSToDiagDir(GetShipDepotAxis(t), GetShipDepotPart(t));
 }
@@ -278,7 +278,7 @@ static inline DiagDirection GetShipDepotDirection(Tile t)
  * @return Tile containing the other section of the depot.
  * @pre IsShipDepotTile(t)
  */
-static inline TileIndex GetOtherShipDepotTile(Tile t)
+inline TileIndex GetOtherShipDepotTile(Tile t)
 {
 	return TileIndex(t) + (GetShipDepotPart(t) != DEPOT_PART_NORTH ? -1 : 1) * (GetShipDepotAxis(t) != AXIS_X ? TileDiffXY(0, 1) : TileDiffXY(1, 0));
 }
@@ -289,7 +289,7 @@ static inline TileIndex GetOtherShipDepotTile(Tile t)
  * @return The northern tile of the depot.
  * @pre IsShipDepotTile(t)
  */
-static inline TileIndex GetShipDepotNorthTile(Tile t)
+inline TileIndex GetShipDepotNorthTile(Tile t)
 {
 	assert(IsShipDepot(t));
 	TileIndex tile2 = GetOtherShipDepotTile(t);
@@ -303,7 +303,7 @@ static inline TileIndex GetShipDepotNorthTile(Tile t)
  * @return \c true if it is a water lock tile.
  * @pre IsTileType(t, MP_WATER)
  */
-static inline bool IsLock(Tile t)
+inline bool IsLock(Tile t)
 {
 	return GetWaterTileType(t) == WATER_TILE_LOCK;
 }
@@ -314,7 +314,7 @@ static inline bool IsLock(Tile t)
  * @return Direction of the lock.
  * @pre IsTileType(t, MP_WATER) && IsLock(t)
  */
-static inline DiagDirection GetLockDirection(Tile t)
+inline DiagDirection GetLockDirection(Tile t)
 {
 	assert(IsLock(t));
 	return (DiagDirection)GB(t.m5(), WBL_LOCK_ORIENT_BEGIN, WBL_LOCK_ORIENT_COUNT);
@@ -326,7 +326,7 @@ static inline DiagDirection GetLockDirection(Tile t)
  * @return The part.
  * @pre IsTileType(t, MP_WATER) && IsLock(t)
  */
-static inline byte GetLockPart(Tile t)
+inline byte GetLockPart(Tile t)
 {
 	assert(IsLock(t));
 	return GB(t.m5(), WBL_LOCK_PART_BEGIN, WBL_LOCK_PART_COUNT);
@@ -338,7 +338,7 @@ static inline byte GetLockPart(Tile t)
  * @return Random bits of the tile.
  * @pre IsTileType(t, MP_WATER)
  */
-static inline byte GetWaterTileRandomBits(Tile t)
+inline byte GetWaterTileRandomBits(Tile t)
 {
 	assert(IsTileType(t, MP_WATER));
 	return t.m4();
@@ -350,7 +350,7 @@ static inline byte GetWaterTileRandomBits(Tile t)
  * @return true iff the tile has water at the ground.
  * @note Coast tiles are not considered waterish, even if there is water on a halftile.
  */
-static inline bool HasTileWaterGround(Tile t)
+inline bool HasTileWaterGround(Tile t)
 {
 	return HasTileWaterClass(t) && IsTileOnWater(t) && !IsCoastTile(t);
 }
@@ -361,7 +361,7 @@ static inline bool HasTileWaterGround(Tile t)
  * @param t the tile
  * @param b the docking tile state
  */
-static inline void SetDockingTile(Tile t, bool b)
+inline void SetDockingTile(Tile t, bool b)
 {
 	assert(IsTileType(t, MP_WATER) || IsTileType(t, MP_RAILWAY) || IsTileType(t, MP_STATION) || IsTileType(t, MP_TUNNELBRIDGE));
 	SB(t.m1(), 7, 1, b ? 1 : 0);
@@ -371,7 +371,7 @@ static inline void SetDockingTile(Tile t, bool b)
  * Checks whether the tile is marked as a dockling tile.
  * @return true iff the tile is marked as a docking tile.
  */
-static inline bool IsDockingTile(Tile t)
+inline bool IsDockingTile(Tile t)
 {
 	return (IsTileType(t, MP_WATER) || IsTileType(t, MP_RAILWAY) || IsTileType(t, MP_STATION) || IsTileType(t, MP_TUNNELBRIDGE)) && HasBit(t.m1(), 7);
 }
@@ -381,7 +381,7 @@ static inline bool IsDockingTile(Tile t)
  * Helper function to make a coast tile.
  * @param t The tile to change into water
  */
-static inline void MakeShore(Tile t)
+inline void MakeShore(Tile t)
 {
 	SetTileType(t, MP_WATER);
 	SetTileOwner(t, OWNER_WATER);
@@ -402,7 +402,7 @@ static inline void MakeShore(Tile t)
  * @param wc The class of water the tile has to be
  * @param random_bits Eventual random bits to be set for this tile
  */
-static inline void MakeWater(Tile t, Owner o, WaterClass wc, uint8_t random_bits)
+inline void MakeWater(Tile t, Owner o, WaterClass wc, uint8_t random_bits)
 {
 	SetTileType(t, MP_WATER);
 	SetTileOwner(t, o);
@@ -420,7 +420,7 @@ static inline void MakeWater(Tile t, Owner o, WaterClass wc, uint8_t random_bits
  * Make a sea tile.
  * @param t The tile to change into sea
  */
-static inline void MakeSea(Tile t)
+inline void MakeSea(Tile t)
 {
 	MakeWater(t, OWNER_WATER, WATER_CLASS_SEA, 0);
 }
@@ -430,7 +430,7 @@ static inline void MakeSea(Tile t)
  * @param t The tile to change into river
  * @param random_bits Random bits to be set for this tile
  */
-static inline void MakeRiver(Tile t, uint8_t random_bits)
+inline void MakeRiver(Tile t, uint8_t random_bits)
 {
 	MakeWater(t, OWNER_WATER, WATER_CLASS_RIVER, random_bits);
 }
@@ -441,7 +441,7 @@ static inline void MakeRiver(Tile t, uint8_t random_bits)
  * @param o The owner of the canal
  * @param random_bits Random bits to be set for this tile
  */
-static inline void MakeCanal(Tile t, Owner o, uint8_t random_bits)
+inline void MakeCanal(Tile t, Owner o, uint8_t random_bits)
 {
 	assert(o != OWNER_WATER);
 	MakeWater(t, o, WATER_CLASS_CANAL, random_bits);
@@ -456,7 +456,7 @@ static inline void MakeCanal(Tile t, Owner o, uint8_t random_bits)
  * @param a    Axis of the depot.
  * @param original_water_class Original water class.
  */
-static inline void MakeShipDepot(Tile t, Owner o, DepotID did, DepotPart part, Axis a, WaterClass original_water_class)
+inline void MakeShipDepot(Tile t, Owner o, DepotID did, DepotPart part, Axis a, WaterClass original_water_class)
 {
 	SetTileType(t, MP_WATER);
 	SetTileOwner(t, o);
@@ -479,7 +479,7 @@ static inline void MakeShipDepot(Tile t, Owner o, DepotID did, DepotPart part, A
  * @param original_water_class Original water class.
  * @see MakeLock
  */
-static inline void MakeLockTile(Tile t, Owner o, LockPart part, DiagDirection dir, WaterClass original_water_class)
+inline void MakeLockTile(Tile t, Owner o, LockPart part, DiagDirection dir, WaterClass original_water_class)
 {
 	SetTileType(t, MP_WATER);
 	SetTileOwner(t, o);
@@ -502,7 +502,7 @@ static inline void MakeLockTile(Tile t, Owner o, LockPart part, DiagDirection di
  * @param wc_upper Original water class of the upper part.
  * @param wc_middle Original water class of the middle part.
  */
-static inline void MakeLock(Tile t, Owner o, DiagDirection d, WaterClass wc_lower, WaterClass wc_upper, WaterClass wc_middle)
+inline void MakeLock(Tile t, Owner o, DiagDirection d, WaterClass wc_lower, WaterClass wc_upper, WaterClass wc_middle)
 {
 	TileIndexDiff delta = TileOffsByDiagDir(d);
 	Tile lower_tile = TileIndex(t) - delta;

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -909,7 +909,7 @@ private:
  * @param step      Stepsize of the widget.
  * @return Biggest possible size of the widget, assuming that \a base may only be incremented by \a step size steps.
  */
-static inline uint ComputeMaxSize(uint base, uint max_space, uint step)
+inline uint ComputeMaxSize(uint base, uint max_space, uint step)
 {
 	if (base >= max_space || step == 0) return base;
 	if (step == 1) return max_space;
@@ -1057,7 +1057,7 @@ struct NWidgetPart {
  * @param dy Vertical resize step. 0 means no vertical resizing.
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart SetResize(int16_t dx, int16_t dy)
+inline NWidgetPart SetResize(int16_t dx, int16_t dy)
 {
 	NWidgetPart part;
 
@@ -1074,7 +1074,7 @@ static inline NWidgetPart SetResize(int16_t dx, int16_t dy)
  * @param y Vertical minimal size.
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart SetMinimalSize(int16_t x, int16_t y)
+inline NWidgetPart SetMinimalSize(int16_t x, int16_t y)
 {
 	NWidgetPart part;
 
@@ -1092,7 +1092,7 @@ static inline NWidgetPart SetMinimalSize(int16_t x, int16_t y)
  * @param size    Font size of text.
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart SetMinimalTextLines(uint8_t lines, uint8_t spacing, FontSize size = FS_NORMAL)
+inline NWidgetPart SetMinimalTextLines(uint8_t lines, uint8_t spacing, FontSize size = FS_NORMAL)
 {
 	NWidgetPart part;
 
@@ -1110,7 +1110,7 @@ static inline NWidgetPart SetMinimalTextLines(uint8_t lines, uint8_t spacing, Fo
  * @param size Font size to draw string within widget.
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart SetTextStyle(TextColour colour, FontSize size = FS_NORMAL)
+inline NWidgetPart SetTextStyle(TextColour colour, FontSize size = FS_NORMAL)
 {
 	NWidgetPart part;
 
@@ -1126,7 +1126,7 @@ static inline NWidgetPart SetTextStyle(TextColour colour, FontSize size = FS_NOR
  * @param align  Alignment of text/image within widget.
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart SetAlignment(StringAlignment align)
+inline NWidgetPart SetAlignment(StringAlignment align)
 {
 	NWidgetPart part;
 
@@ -1142,7 +1142,7 @@ static inline NWidgetPart SetAlignment(StringAlignment align)
  * @param fill_y Vertical filling step from minimal size.
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart SetFill(uint fill_x, uint fill_y)
+inline NWidgetPart SetFill(uint fill_x, uint fill_y)
 {
 	NWidgetPart part;
 
@@ -1158,7 +1158,7 @@ static inline NWidgetPart SetFill(uint fill_x, uint fill_y)
  * (horizontal, vertical, WWT_FRAME, WWT_INSET, or WWT_PANEL).
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart EndContainer()
+inline NWidgetPart EndContainer()
 {
 	NWidgetPart part;
 
@@ -1173,7 +1173,7 @@ static inline NWidgetPart EndContainer()
  * @param tip  Tooltip of the widget.
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart SetDataTip(uint32_t data, StringID tip)
+inline NWidgetPart SetDataTip(uint32_t data, StringID tip)
 {
 	NWidgetPart part;
 
@@ -1191,7 +1191,7 @@ static inline NWidgetPart SetDataTip(uint32_t data, StringID tip)
  * @param tip  Tooltip of the widget.
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart SetMatrixDataTip(uint8_t cols, uint8_t rows, StringID tip)
+inline NWidgetPart SetMatrixDataTip(uint8_t cols, uint8_t rows, StringID tip)
 {
 	return SetDataTip((rows << MAT_ROW_START) | (cols << MAT_COL_START), tip);
 }
@@ -1205,7 +1205,7 @@ static inline NWidgetPart SetMatrixDataTip(uint8_t cols, uint8_t rows, StringID 
  * @param left The padding left of the widget.
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart SetPadding(uint8_t top, uint8_t right, uint8_t bottom, uint8_t left)
+inline NWidgetPart SetPadding(uint8_t top, uint8_t right, uint8_t bottom, uint8_t left)
 {
 	NWidgetPart part;
 
@@ -1223,7 +1223,7 @@ static inline NWidgetPart SetPadding(uint8_t top, uint8_t right, uint8_t bottom,
  * @param r The padding around the widget.
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart SetPadding(const RectPadding &padding)
+inline NWidgetPart SetPadding(const RectPadding &padding)
 {
 	NWidgetPart part;
 
@@ -1241,7 +1241,7 @@ static inline NWidgetPart SetPadding(const RectPadding &padding)
  * @param padding The padding to use for all directions.
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart SetPadding(uint8_t padding)
+inline NWidgetPart SetPadding(uint8_t padding)
 {
 	return SetPadding(padding, padding, padding, padding);
 }
@@ -1253,7 +1253,7 @@ static inline NWidgetPart SetPadding(uint8_t padding)
  * @param post The amount of space after the last widget.
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart SetPIP(uint8_t pre, uint8_t inter, uint8_t post)
+inline NWidgetPart SetPIP(uint8_t pre, uint8_t inter, uint8_t post)
 {
 	NWidgetPart part;
 
@@ -1272,7 +1272,7 @@ static inline NWidgetPart SetPIP(uint8_t pre, uint8_t inter, uint8_t post)
  * @param post The ratio of space after the last widget.
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart SetPIPRatio(uint8_t ratio_pre, uint8_t ratio_inter, uint8_t ratio_post)
+inline NWidgetPart SetPIPRatio(uint8_t ratio_pre, uint8_t ratio_inter, uint8_t ratio_post)
 {
 	NWidgetPart part;
 
@@ -1291,7 +1291,7 @@ static inline NWidgetPart SetPIPRatio(uint8_t ratio_pre, uint8_t ratio_inter, ui
  * @param index Widget index of the scrollbar.
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart SetScrollbar(WidgetID index)
+inline NWidgetPart SetScrollbar(WidgetID index)
 {
 	NWidgetPart part;
 
@@ -1310,7 +1310,7 @@ static inline NWidgetPart SetScrollbar(WidgetID index)
  *       Child widgets must have a index bigger than the parent index.
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart NWidget(WidgetType tp, Colours col, int idx = -1)
+inline NWidgetPart NWidget(WidgetType tp, Colours col, int idx = -1)
 {
 	NWidgetPart part;
 
@@ -1327,7 +1327,7 @@ static inline NWidgetPart NWidget(WidgetType tp, Colours col, int idx = -1)
  * @param cont_flags Flags for the containers (#NWID_HORIZONTAL and #NWID_VERTICAL).
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart NWidget(WidgetType tp, NWidContainerFlags cont_flags = NC_NONE)
+inline NWidgetPart NWidget(WidgetType tp, NWidContainerFlags cont_flags = NC_NONE)
 {
 	NWidgetPart part;
 
@@ -1342,7 +1342,7 @@ static inline NWidgetPart NWidget(WidgetType tp, NWidContainerFlags cont_flags =
  * @param func_ptr Pointer to function that returns the tree.
  * @ingroup NestedWidgetParts
  */
-static inline NWidgetPart NWidgetFunction(NWidgetFunctionType *func_ptr)
+inline NWidgetPart NWidgetFunction(NWidgetFunctionType *func_ptr)
 {
 	NWidgetPart part;
 

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -70,7 +70,7 @@ struct WidgetDimensions {
 /* widget.cpp */
 void DrawFrameRect(int left, int top, int right, int bottom, Colours colour, FrameFlags flags);
 
-static inline void DrawFrameRect(const Rect &r, Colours colour, FrameFlags flags)
+inline void DrawFrameRect(const Rect &r, Colours colour, FrameFlags flags)
 {
 	DrawFrameRect(r.left, r.top, r.right, r.bottom, colour, flags);
 }

--- a/src/zoom_func.h
+++ b/src/zoom_func.h
@@ -19,7 +19,7 @@
  * @param zoom  zoom level to shift to
  * @return shifted value
  */
-static inline int ScaleByZoom(int value, ZoomLevel zoom)
+inline int ScaleByZoom(int value, ZoomLevel zoom)
 {
 	return value << zoom;
 }
@@ -31,7 +31,7 @@ static inline int ScaleByZoom(int value, ZoomLevel zoom)
  * @param zoom  zoom level to shift to
  * @return shifted value
  */
-static inline int UnScaleByZoom(int value, ZoomLevel zoom)
+inline int UnScaleByZoom(int value, ZoomLevel zoom)
 {
 	return (value + (1 << zoom) - 1) >> zoom;
 }
@@ -42,7 +42,7 @@ static inline int UnScaleByZoom(int value, ZoomLevel zoom)
  * @param zoom zoom level to shift to
  * @return shifted value
  */
-static inline int AdjustByZoom(int value, int zoom)
+inline int AdjustByZoom(int value, int zoom)
 {
 	return zoom < 0 ? UnScaleByZoom(value, ZoomLevel(-zoom)) : ScaleByZoom(value, ZoomLevel(zoom));
 }
@@ -53,7 +53,7 @@ static inline int AdjustByZoom(int value, int zoom)
  * @param zoom  zoom level to shift to
  * @return shifted value
  */
-static inline int ScaleByZoomLower(int value, ZoomLevel zoom)
+inline int ScaleByZoomLower(int value, ZoomLevel zoom)
 {
 	return value << zoom;
 }
@@ -64,7 +64,7 @@ static inline int ScaleByZoomLower(int value, ZoomLevel zoom)
  * @param zoom  zoom level to shift to
  * @return shifted value
  */
-static inline int UnScaleByZoomLower(int value, ZoomLevel zoom)
+inline int UnScaleByZoomLower(int value, ZoomLevel zoom)
 {
 	return value >> zoom;
 }
@@ -74,7 +74,7 @@ static inline int UnScaleByZoomLower(int value, ZoomLevel zoom)
  * @param value Pixel amount at #ZOOM_LVL_BEGIN (full zoom in).
  * @return Pixel amount at #ZOOM_LVL_GUI (current interface size).
  */
-static inline int UnScaleGUI(int value)
+inline int UnScaleGUI(int value)
 {
 	return UnScaleByZoom(value, ZOOM_LVL_GUI);
 }
@@ -84,7 +84,7 @@ static inline int UnScaleGUI(int value)
  * @param value zoom level to scale
  * @return scaled zoom level
  */
-static inline ZoomLevel ScaleZoomGUI(ZoomLevel value)
+inline ZoomLevel ScaleZoomGUI(ZoomLevel value)
 {
 	return std::clamp(ZoomLevel(value + (ZOOM_LVL_GUI - ZOOM_LVL_OUT_4X)), ZOOM_LVL_MIN, ZOOM_LVL_MAX);
 }
@@ -94,7 +94,7 @@ static inline ZoomLevel ScaleZoomGUI(ZoomLevel value)
  * @param value zoom level to scale
  * @return un-scaled zoom level
  */
-static inline ZoomLevel UnScaleZoomGUI(ZoomLevel value)
+inline ZoomLevel UnScaleZoomGUI(ZoomLevel value)
 {
 	return std::clamp(ZoomLevel(value - (ZOOM_LVL_GUI - ZOOM_LVL_OUT_4X)), ZOOM_LVL_MIN, ZOOM_LVL_MAX);
 }
@@ -104,7 +104,7 @@ static inline ZoomLevel UnScaleZoomGUI(ZoomLevel value)
  * @param value Pixel amount at #ZOOM_LVL_BASE (traditional "normal" interface size).
  * @return Pixel amount at #ZOOM_LVL_GUI (current interface size).
  */
-static inline int ScaleSpriteTrad(int value)
+inline int ScaleSpriteTrad(int value)
 {
 	return UnScaleGUI(value * ZOOM_LVL_BASE);
 }
@@ -114,7 +114,7 @@ static inline int ScaleSpriteTrad(int value)
  * @param value Pixel amount at #ZOOM_LVL_BASE (traditional "normal" interface size).
  * @return Pixel amount at #ZOOM_LVL_GUI (current interface size).
  */
-static inline int ScaleGUITrad(int value)
+inline int ScaleGUITrad(int value)
 {
 	return value * _gui_scale / 100;
 }


### PR DESCRIPTION
## Motivation / Problem

Looking at the region based pathfinder I wondered why it used `inline` for functions we would usually `static inline`.

It turns out that a lot of `static inline`, especially in headers, is to please the C linker not complaining about duplicate definitions. With C++ only `inline` in the headers is fine for non-struct/class functions; actually, it is kind of encouraged. Why? Because the `inline` is only a wish that the compiler may ignore. However, the linker at the end only have one non-inlined version of the code.
With `static inline` the static will make it local to the translation unit, and as such linking is not allowed to merge the same functions. The result is a larger binary.

On my Linux machine a debug build is roughly 500 kB smaller (on 300 MB) and a stripped release build 20 kB (on 15 MB). So fairly insignificant in the grand scheme of things, but it is a C-thing that transcended into our C++-code.


## Description

Remove `static` from `static inline` functions that are not part of a class and are in a header.


## Limitations

I left `static inline` in the non-header files, even though they could technically be removed. This is more as the static in there also denoted that it's local to the file and as such should not get external linkage.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
