### PR TITLE
Fix: String scan for gender mode with SCC_INDUSTRY_NAME

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1469,14 +1469,14 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 					if (i == nullptr) break;
 
 					static bool use_cache = true;
-					if (use_cache) { // Use cached version if first call
-						AutoRestoreBackup cache_backup(use_cache, false);
-						builder += i->GetCachedName();
-					} else if (_scan_for_gender_data) {
+					if (_scan_for_gender_data) {
 						/* Gender is defined by the industry type.
 						 * STR_FORMAT_INDUSTRY_NAME may have the town first, so it would result in the gender of the town name */
 						auto tmp_params = ArrayStringParameters<0>();
 						FormatString(builder, GetStringPtr(GetIndustrySpec(i->type)->name), tmp_params, next_substr_case_index);
+					} else if (use_cache) { // Use cached version if first call
+						AutoRestoreBackup cache_backup(use_cache, false);
+						builder += i->GetCachedName();
 					} else {
 						/* First print the town name and the industry type name. */
 						auto tmp_params = MakeParameters(i->town->index, GetIndustrySpec(i->type)->name);


### PR DESCRIPTION
## Motivation / Problem

`_scan_for_gender_data` mode did not work correctly with `SCC_INDUSTRY_NAME`.
The wrong gender could be returned if `STR_FORMAT_INDUSTRY_NAME` had the town name first (see existing comment).

## Description

`_scan_for_gender_data` case should take priority over `use_cache` case.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
