### PR TITLE
Codechange: Split CT_INVALID/INVALID_CARGO and relocate special cargo placeholders.

### DIFF
--- a/src/articulated_vehicles.cpp
+++ b/src/articulated_vehicles.cpp
@@ -107,7 +107,7 @@ uint CountArticulatedParts(EngineID engine_type, bool purchase_window)
 static inline uint16_t GetVehicleDefaultCapacity(EngineID engine, CargoID *cargo_type)
 {
 	const Engine *e = Engine::Get(engine);
-	CargoID cargo = (e->CanCarryCargo() ? e->GetDefaultCargoType() : (CargoID)CT_INVALID);
+	CargoID cargo = (e->CanCarryCargo() ? e->GetDefaultCargoType() : INVALID_CARGO);
 	if (cargo_type != nullptr) *cargo_type = cargo;
 	if (!IsValidCargoID(cargo)) return 0;
 	return e->GetDisplayDefaultCapacity();
@@ -259,13 +259,13 @@ CargoTypes GetUnionOfArticulatedRefitMasks(EngineID engine, bool include_initial
  * Get cargo mask of all cargoes carried by an articulated vehicle.
  * Note: Vehicles not carrying anything are ignored
  * @param v the first vehicle in the chain
- * @param cargo_type returns the common CargoID if needed. (CT_INVALID if no part is carrying something or they are carrying different things)
+ * @param cargo_type returns the common CargoID if needed. (INVALID_CARGO if no part is carrying something or they are carrying different things)
  * @return cargo mask, may be 0 if the no vehicle parts have cargo capacity
  */
 CargoTypes GetCargoTypesOfArticulatedVehicle(const Vehicle *v, CargoID *cargo_type)
 {
 	CargoTypes cargoes = 0;
-	CargoID first_cargo = CT_INVALID;
+	CargoID first_cargo = INVALID_CARGO;
 
 	do {
 		if (IsValidCargoID(v->cargo_type) && v->GetEngine()->CanCarryCargo()) {
@@ -273,7 +273,7 @@ CargoTypes GetCargoTypesOfArticulatedVehicle(const Vehicle *v, CargoID *cargo_ty
 			if (!IsValidCargoID(first_cargo)) first_cargo = v->cargo_type;
 			if (first_cargo != v->cargo_type) {
 				if (cargo_type != nullptr) {
-					*cargo_type = CT_INVALID;
+					*cargo_type = INVALID_CARGO;
 					cargo_type = nullptr;
 				}
 			}

--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -226,7 +226,7 @@ static int GetIncompatibleRefitOrderIdForAutoreplace(const Vehicle *v, EngineID 
  * @param engine_type The EngineID of the vehicle that is being replaced to
  * @param part_of_chain The vehicle is part of a train
  * @return The cargo type to replace to
- *    CT_NO_REFIT is returned if no refit is needed
+ *    CARGO_NO_REFIT is returned if no refit is needed
  *    INVALID_CARGO is returned when both old and new vehicle got cargo capacity and refitting the new one to the old one's cargo type isn't possible
  */
 static CargoID GetNewCargoTypeForReplace(Vehicle *v, EngineID engine_type, bool part_of_chain)
@@ -234,23 +234,23 @@ static CargoID GetNewCargoTypeForReplace(Vehicle *v, EngineID engine_type, bool 
 	CargoTypes available_cargo_types, union_mask;
 	GetArticulatedRefitMasks(engine_type, true, &union_mask, &available_cargo_types);
 
-	if (union_mask == 0) return CT_NO_REFIT; // Don't try to refit an engine with no cargo capacity
+	if (union_mask == 0) return CARGO_NO_REFIT; // Don't try to refit an engine with no cargo capacity
 
 	CargoID cargo_type;
 	CargoTypes cargo_mask = GetCargoTypesOfArticulatedVehicle(v, &cargo_type);
 	if (!HasAtMostOneBit(cargo_mask)) {
 		CargoTypes new_engine_default_cargoes = GetCargoTypesOfArticulatedParts(engine_type);
 		if ((cargo_mask & new_engine_default_cargoes) == cargo_mask) {
-			return CT_NO_REFIT; // engine_type is already a mixed cargo type which matches the incoming vehicle by default, no refit required
+			return CARGO_NO_REFIT; // engine_type is already a mixed cargo type which matches the incoming vehicle by default, no refit required
 		}
 
 		return INVALID_CARGO; // We cannot refit to mixed cargoes in an automated way
 	}
 
 	if (!IsValidCargoID(cargo_type)) {
-		if (v->type != VEH_TRAIN) return CT_NO_REFIT; // If the vehicle does not carry anything at all, every replacement is fine.
+		if (v->type != VEH_TRAIN) return CARGO_NO_REFIT; // If the vehicle does not carry anything at all, every replacement is fine.
 
-		if (!part_of_chain) return CT_NO_REFIT;
+		if (!part_of_chain) return CARGO_NO_REFIT;
 
 		/* the old engine didn't have cargo capacity, but the new one does
 		 * now we will figure out what cargo the train is carrying and refit to fit this */
@@ -261,7 +261,7 @@ static CargoID GetNewCargoTypeForReplace(Vehicle *v, EngineID engine_type, bool 
 			if (HasBit(available_cargo_types, v->cargo_type)) return v->cargo_type;
 		}
 
-		return CT_NO_REFIT; // We failed to find a cargo type on the old vehicle and we will not refit the new one
+		return CARGO_NO_REFIT; // We failed to find a cargo type on the old vehicle and we will not refit the new one
 	} else {
 		if (!HasBit(available_cargo_types, cargo_type)) return INVALID_CARGO; // We can't refit the vehicle to carry the cargo we want
 
@@ -359,7 +359,7 @@ static CommandCost BuildReplacementVehicle(Vehicle *old_veh, Vehicle **new_vehic
 	*new_vehicle = new_veh;
 
 	/* Refit the vehicle if needed */
-	if (refit_cargo != CT_NO_REFIT) {
+	if (refit_cargo != CARGO_NO_REFIT) {
 		byte subtype = GetBestFittingSubType(old_veh, new_veh, refit_cargo);
 
 		cost.AddCost(std::get<0>(Command<CMD_REFIT_VEHICLE>::Do(DC_EXEC, new_veh->index, refit_cargo, subtype, false, false, 0)));

--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -227,7 +227,7 @@ static int GetIncompatibleRefitOrderIdForAutoreplace(const Vehicle *v, EngineID 
  * @param part_of_chain The vehicle is part of a train
  * @return The cargo type to replace to
  *    CT_NO_REFIT is returned if no refit is needed
- *    CT_INVALID is returned when both old and new vehicle got cargo capacity and refitting the new one to the old one's cargo type isn't possible
+ *    INVALID_CARGO is returned when both old and new vehicle got cargo capacity and refitting the new one to the old one's cargo type isn't possible
  */
 static CargoID GetNewCargoTypeForReplace(Vehicle *v, EngineID engine_type, bool part_of_chain)
 {
@@ -244,7 +244,7 @@ static CargoID GetNewCargoTypeForReplace(Vehicle *v, EngineID engine_type, bool 
 			return CT_NO_REFIT; // engine_type is already a mixed cargo type which matches the incoming vehicle by default, no refit required
 		}
 
-		return CT_INVALID; // We cannot refit to mixed cargoes in an automated way
+		return INVALID_CARGO; // We cannot refit to mixed cargoes in an automated way
 	}
 
 	if (!IsValidCargoID(cargo_type)) {
@@ -263,9 +263,9 @@ static CargoID GetNewCargoTypeForReplace(Vehicle *v, EngineID engine_type, bool 
 
 		return CT_NO_REFIT; // We failed to find a cargo type on the old vehicle and we will not refit the new one
 	} else {
-		if (!HasBit(available_cargo_types, cargo_type)) return CT_INVALID; // We can't refit the vehicle to carry the cargo we want
+		if (!HasBit(available_cargo_types, cargo_type)) return INVALID_CARGO; // We can't refit the vehicle to carry the cargo we want
 
-		if (part_of_chain && !VerifyAutoreplaceRefitForOrders(v, engine_type)) return CT_INVALID; // Some refit orders lose their effect
+		if (part_of_chain && !VerifyAutoreplaceRefitForOrders(v, engine_type)) return INVALID_CARGO; // Some refit orders lose their effect
 
 		return cargo_type;
 	}
@@ -352,7 +352,7 @@ static CommandCost BuildReplacementVehicle(Vehicle *old_veh, Vehicle **new_vehic
 
 	/* Build the new vehicle */
 	VehicleID new_veh_id;
-	std::tie(cost, new_veh_id, std::ignore, std::ignore, std::ignore) = Command<CMD_BUILD_VEHICLE>::Do(DC_EXEC | DC_AUTOREPLACE, old_veh->tile, e, true, CT_INVALID, INVALID_CLIENT_ID);
+	std::tie(cost, new_veh_id, std::ignore, std::ignore, std::ignore) = Command<CMD_BUILD_VEHICLE>::Do(DC_EXEC | DC_AUTOREPLACE, old_veh->tile, e, true, INVALID_CARGO, INVALID_CLIENT_ID);
 	if (cost.Failed()) return cost;
 
 	Vehicle *new_veh = Vehicle::Get(new_veh_id);

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -95,7 +95,7 @@ static const NWidgetPart _nested_build_vehicle_widgets[] = {
 
 /** Special cargo filter criteria */
 static const CargoID CF_ANY     = CT_NO_REFIT;   ///< Show all vehicles independent of carried cargo (i.e. no filtering)
-static const CargoID CF_NONE    = CT_INVALID;    ///< Show only vehicles which do not carry cargo (e.g. train engines)
+static const CargoID CF_NONE    = INVALID_CARGO; ///< Show only vehicles which do not carry cargo (e.g. train engines)
 static const CargoID CF_ENGINES = CT_AUTO_REFIT; ///< Show only engines (for rail vehicles only)
 
 bool _engine_sort_direction; ///< \c false = descending, \c true = ascending.
@@ -908,7 +908,7 @@ void TestedEngineDetails::FillDefaultCapacities(const Engine *e)
 		this->all_capacities[this->cargo] = this->capacity;
 		this->all_capacities[CT_MAIL] = this->mail_capacity;
 	}
-	if (this->all_capacities.GetCount() == 0) this->cargo = CT_INVALID;
+	if (this->all_capacities.GetCount() == 0) this->cargo = INVALID_CARGO;
 }
 
 /**
@@ -954,7 +954,7 @@ int DrawVehiclePurchaseInfo(int left, int right, int y, EngineID engine_number, 
 		int new_y = DrawCargoCapacityInfo(left, right, y, te, refittable);
 
 		if (new_y == y) {
-			SetDParam(0, CT_INVALID);
+			SetDParam(0, INVALID_CARGO);
 			SetDParam(2, STR_EMPTY);
 			DrawString(left, right, y, STR_PURCHASE_INFO_CAPACITY);
 			y += GetCharacterHeight(FS_NORMAL);
@@ -1293,7 +1293,7 @@ struct BuildVehicleWindow : Window {
 	void SelectEngine(EngineID engine)
 	{
 		CargoID cargo = this->cargo_filter_criteria;
-		if (cargo == CF_ANY || cargo == CF_ENGINES || cargo == CF_NONE) cargo = CT_INVALID;
+		if (cargo == CF_ANY || cargo == CF_ENGINES || cargo == CF_NONE) cargo = INVALID_CARGO;
 
 		this->sel_engine = engine;
 		this->SetBuyVehicleText();
@@ -1652,7 +1652,7 @@ struct BuildVehicleWindow : Window {
 				EngineID sel_eng = this->sel_engine;
 				if (sel_eng != INVALID_ENGINE) {
 					CargoID cargo = this->cargo_filter_criteria;
-					if (cargo == CF_ANY || cargo == CF_ENGINES || cargo == CF_NONE) cargo = CT_INVALID;
+					if (cargo == CF_ANY || cargo == CF_ENGINES || cargo == CF_NONE) cargo = INVALID_CARGO;
 					if (this->vehicle_type == VEH_TRAIN && RailVehInfo(sel_eng)->railveh_type == RAILVEH_WAGON) {
 						Command<CMD_BUILD_VEHICLE>::Post(GetCmdBuildVehMsg(this->vehicle_type), CcBuildWagon, this->window_number, sel_eng, true, cargo, INVALID_CLIENT_ID);
 					} else {

--- a/src/cargo_type.h
+++ b/src/cargo_type.h
@@ -69,10 +69,12 @@ enum CargoType {
 	CT_INVALID      = 0xFF, ///< Invalid cargo type.
 };
 
+static const CargoID INVALID_CARGO = UINT8_MAX;
+
 /** Test whether cargo type is not CT_INVALID */
 inline bool IsValidCargoType(CargoType t) { return t != CT_INVALID; }
-/** Test whether cargo type is not CT_INVALID */
-inline bool IsValidCargoID(CargoID t) { return t != CT_INVALID; }
+/** Test whether cargo type is not INVALID_CARGO */
+inline bool IsValidCargoID(CargoID t) { return t != INVALID_CARGO; }
 
 typedef uint64_t CargoTypes;
 

--- a/src/cargo_type.h
+++ b/src/cargo_type.h
@@ -61,15 +61,28 @@ enum CargoType {
 	CT_PLASTIC      = 10,
 	CT_FIZZY_DRINKS = 11,
 
-	NUM_ORIGINAL_CARGO = 12,
-	NUM_CARGO       = 64,   ///< Maximal number of cargo types in a game.
-
-	CT_AUTO_REFIT   = 0xFD, ///< Automatically choose cargo type when doing auto refitting.
-	CT_NO_REFIT     = 0xFE, ///< Do not refit cargo of a vehicle (used in vehicle orders and auto-replace/auto-new).
 	CT_INVALID      = 0xFF, ///< Invalid cargo type.
 };
 
+static const CargoID NUM_ORIGINAL_CARGO = 12; ///< Original number of cargo types.
+static const CargoID NUM_CARGO = 64; ///< Maximum number of cargo types in a game.
+
+/* CARGO_AUTO_REFIT and CARGO_NO_REFIT are stored in save-games for refit-orders, so should not be changed. */
+static const CargoID CARGO_AUTO_REFIT = 0xFD; ///< Automatically choose cargo type when doing auto refitting.
+static const CargoID CARGO_NO_REFIT = 0xFE; ///< Do not refit cargo of a vehicle (used in vehicle orders and auto-replace/auto-renew).
+
 static const CargoID INVALID_CARGO = UINT8_MAX;
+
+/**
+ * Special cargo filter criteria.
+ * These are used by user interface code only and must not be assigned to any entity. Not all values are valid for every UI filter.
+ */
+namespace CargoFilterCriteria {
+	static constexpr CargoID CF_ANY     = NUM_CARGO;     ///< Show all items independent of carried cargo (i.e. no filtering)
+	static constexpr CargoID CF_NONE    = NUM_CARGO + 1; ///< Show only items which do not carry cargo (e.g. train engines)
+	static constexpr CargoID CF_ENGINES = NUM_CARGO + 2; ///< Show only engines (for rail vehicles only)
+	static constexpr CargoID CF_FREIGHT = NUM_CARGO + 3; ///< Show only vehicles which carry any freight (non-passenger) cargo
+};
 
 /** Test whether cargo type is not CT_INVALID */
 inline bool IsValidCargoType(CargoType t) { return t != CT_INVALID; }

--- a/src/cargotype.cpp
+++ b/src/cargotype.cpp
@@ -88,13 +88,13 @@ Dimension GetLargestCargoIconSize()
  * Get the cargo ID of a default cargo, if present.
  * @param l Landscape
  * @param ct Default cargo type.
- * @return ID number if the cargo exists, else #CT_INVALID
+ * @return ID number if the cargo exists, else #INVALID_CARGO
  */
 CargoID GetDefaultCargoID(LandscapeID l, CargoType ct)
 {
 	assert(l < lengthof(_default_climate_cargo));
 
-	if (!IsValidCargoType(ct)) return CT_INVALID;
+	if (!IsValidCargoType(ct)) return INVALID_CARGO;
 
 	assert(ct < lengthof(_default_climate_cargo[0]));
 	CargoLabel cl = _default_climate_cargo[l][ct];
@@ -109,7 +109,7 @@ CargoID GetDefaultCargoID(LandscapeID l, CargoType ct)
 /**
  * Get the cargo ID by cargo label.
  * @param cl Cargo type to get.
- * @return ID number if the cargo exists, else #CT_INVALID
+ * @return ID number if the cargo exists, else #INVALID_CARGO
  */
 CargoID GetCargoIDByLabel(CargoLabel cl)
 {
@@ -118,25 +118,25 @@ CargoID GetCargoIDByLabel(CargoLabel cl)
 	}
 
 	/* No matching label was found, so it is invalid */
-	return CT_INVALID;
+	return INVALID_CARGO;
 }
 
 
 /**
  * Find the CargoID of a 'bitnum' value.
  * @param bitnum 'bitnum' to find.
- * @return First CargoID with the given bitnum, or #CT_INVALID if not found or if the provided \a bitnum is invalid.
+ * @return First CargoID with the given bitnum, or #INVALID_CARGO if not found or if the provided \a bitnum is invalid.
  */
 CargoID GetCargoIDByBitnum(uint8_t bitnum)
 {
-	if (bitnum == INVALID_CARGO_BITNUM) return CT_INVALID;
+	if (bitnum == INVALID_CARGO_BITNUM) return INVALID_CARGO;
 
 	for (const CargoSpec *cs : CargoSpec::Iterate()) {
 		if (cs->bitnum == bitnum) return cs->Index();
 	}
 
 	/* No matching label was found, so it is invalid */
-	return CT_INVALID;
+	return INVALID_CARGO;
 }
 
 /**

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1500,7 +1500,7 @@ static void HandleStationRefit(Vehicle *v, CargoArray &consist_capleft, Station 
 	/* Remove old capacity from consist capacity and collect refit mask. */
 	IterateVehicleParts(v_start, PrepareRefitAction(consist_capleft, refit_mask));
 
-	bool is_auto_refit = new_cid == CT_AUTO_REFIT;
+	bool is_auto_refit = new_cid == CARGO_AUTO_REFIT;
 	if (is_auto_refit) {
 		/* Get a refittable cargo type with waiting cargo for next_station or INVALID_STATION. */
 		new_cid = v_start->cargo_type;
@@ -1636,7 +1636,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 	Station *st = Station::Get(last_visited);
 
 	StationIDStack next_station = front->GetNextStoppingStation();
-	bool use_autorefit = front->current_order.IsRefit() && front->current_order.GetRefitCargo() == CT_AUTO_REFIT;
+	bool use_autorefit = front->current_order.IsRefit() && front->current_order.GetRefitCargo() == CARGO_AUTO_REFIT;
 	CargoArray consist_capleft{};
 	if (_settings_game.order.improved_load && use_autorefit ?
 			front->cargo_payment == nullptr : (front->current_order.GetLoadType() & OLFB_FULL_LOAD) != 0) {

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -85,8 +85,8 @@ Engine::Engine(VehicleType type, EngineID base)
 		this->info.base_life = 0xFF;
 		/* Set road vehicle tractive effort to the default value */
 		if (type == VEH_ROAD) this->u.road.tractive_effort = 0x4C;
-		/* Aircraft must have CT_INVALID as default, as there is no property */
-		if (type == VEH_AIRCRAFT) this->info.cargo_type = CT_INVALID;
+		/* Aircraft must have INVALID_CARGO as default, as there is no property */
+		if (type == VEH_AIRCRAFT) this->info.cargo_type = INVALID_CARGO;
 		/* Set visual effect to the default value */
 		switch (type) {
 			case VEH_TRAIN: this->u.rail.visual_effect = VE_DEFAULT; break;

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -88,7 +88,7 @@ struct Engine : EnginePool::PoolItem<&_engine_pool> {
 	 * Usually a valid cargo is returned, even though the vehicle has zero capacity, and can therefore not carry anything. But the cargotype is still used
 	 * for livery selection etc..
 	 *
-	 * Vehicles with CT_INVALID as default cargo are usually not available, but it can appear as default cargo of articulated parts.
+	 * Vehicles with INVALID_CARGO as default cargo are usually not available, but it can appear as default cargo of articulated parts.
 	 *
 	 * @return The default cargo type.
 	 * @see CanCarryCargo

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -183,7 +183,7 @@ static StringID GetTrainEngineInfoString(const Engine *e)
 		SetDParam(5, e->GetDefaultCargoType());
 		SetDParam(6, capacity);
 	} else {
-		SetDParam(5, CT_INVALID);
+		SetDParam(5, INVALID_CARGO);
 	}
 	return (_settings_game.vehicle.train_acceleration_model != AM_ORIGINAL && GetRailTypeInfo(e->u.rail.railtype)->acceleration_type != 2) ? STR_ENGINE_PREVIEW_COST_WEIGHT_SPEED_POWER_MAX_TE : STR_ENGINE_PREVIEW_COST_WEIGHT_SPEED_POWER;
 }
@@ -224,7 +224,7 @@ static StringID GetRoadVehEngineInfoString(const Engine *e)
 			SetDParam(2, e->GetDefaultCargoType());
 			SetDParam(3, capacity);
 		} else {
-			SetDParam(2, CT_INVALID);
+			SetDParam(2, INVALID_CARGO);
 		}
 		SetDParam(4, e->GetRunningCost());
 		return STR_ENGINE_PREVIEW_COST_MAX_SPEED_CAP_RUNCOST;
@@ -242,7 +242,7 @@ static StringID GetRoadVehEngineInfoString(const Engine *e)
 			SetDParam(5, e->GetDefaultCargoType());
 			SetDParam(6, capacity);
 		} else {
-			SetDParam(5, CT_INVALID);
+			SetDParam(5, INVALID_CARGO);
 		}
 		return STR_ENGINE_PREVIEW_COST_WEIGHT_SPEED_POWER_MAX_TE;
 	}

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -424,7 +424,7 @@ static void AddAcceptedCargo_Industry(TileIndex tile, CargoArray &acceptance, Ca
 			auto pos = std::find(std::begin(accepts_cargo), std::end(accepts_cargo), a.cargo);
 			if (pos == std::end(accepts_cargo)) {
 				/* Not found, insert */
-				pos = std::find(std::begin(accepts_cargo), std::end(accepts_cargo), CT_INVALID);
+				pos = std::find(std::begin(accepts_cargo), std::end(accepts_cargo), INVALID_CARGO);
 				if (pos == std::end(accepts_cargo)) continue; // nowhere to place, give up on this one
 				*pos = a.cargo;
 			}
@@ -436,7 +436,7 @@ static void AddAcceptedCargo_Industry(TileIndex tile, CargoArray &acceptance, Ca
 		/* Try callback for accepts list, if success override all existing accepts */
 		uint16_t res = GetIndustryTileCallback(CBID_INDTILE_ACCEPT_CARGO, 0, 0, gfx, Industry::GetByTile(tile), tile);
 		if (res != CALLBACK_FAILED) {
-			accepts_cargo.fill(CT_INVALID);
+			accepts_cargo.fill(INVALID_CARGO);
 			for (uint i = 0; i < 3; i++) accepts_cargo[i] = GetCargoTranslation(GB(res, i * 5, 5), itspec->grf_prop.grffile);
 		}
 	}
@@ -1838,7 +1838,7 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 
 	if (HasBit(indspec->callback_mask, CBM_IND_INPUT_CARGO_TYPES)) {
 		/* Clear all input cargo types */
-		for (auto &a : i->accepted) a.cargo = CT_INVALID;
+		for (auto &a : i->accepted) a.cargo = INVALID_CARGO;
 		/* Query actual types */
 		uint maxcargoes = (indspec->behaviour & INDUSTRYBEH_CARGOTYPES_UNLIMITED) ? static_cast<uint>(i->accepted.size()) : 3;
 		for (uint j = 0; j < maxcargoes; j++) {
@@ -1870,7 +1870,7 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 
 	if (HasBit(indspec->callback_mask, CBM_IND_OUTPUT_CARGO_TYPES)) {
 		/* Clear all output cargo types */
-		for (auto &p : i->produced) p.cargo = CT_INVALID;
+		for (auto &p : i->produced) p.cargo = INVALID_CARGO;
 		/* Query actual types */
 		uint maxcargoes = (indspec->behaviour & INDUSTRYBEH_CARGOTYPES_UNLIMITED) ? static_cast<uint>(i->produced.size()) : 2;
 		for (uint j = 0; j < maxcargoes; j++) {

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -148,7 +148,7 @@ enum CargoSuffixInOut {
  * @param ind the industry (nullptr if in fund window)
  * @param ind_type the industry type
  * @param indspec the industry spec
- * @param cargoes array with cargotypes. for CT_INVALID no suffix will be determined
+ * @param cargoes array with cargotypes. for INVALID_CARGO no suffix will be determined
  * @param suffixes is filled with the suffixes
  */
 template <typename TC, typename TS>
@@ -197,7 +197,7 @@ static inline void GetAllCargoSuffixes(CargoSuffixInOut use_input, CargoSuffixTy
  * @param ind the industry (nullptr if in fund window)
  * @param ind_type the industry type
  * @param indspec the industry spec
- * @param cargo cargotype. for CT_INVALID no suffix will be determined
+ * @param cargo cargotype. for INVALID_CARGO no suffix will be determined
  * @param slot accepts/produced slot number, used for old-style 3-in/2-out industries.
  * @param suffix is filled with the suffix
  */
@@ -1248,7 +1248,7 @@ typedef GUIList<const Industry *, const CargoID &, const std::pair<CargoID, Carg
 /** Special cargo filter criteria */
 enum CargoFilterSpecialType {
 	CF_ANY  = CT_NO_REFIT, ///< Show all industries (i.e. no filtering)
-	CF_NONE = CT_INVALID,  ///< Show only industries which do not produce/accept cargo
+	CF_NONE = INVALID_CARGO, ///< Show only industries which do not produce/accept cargo
 };
 
 /** Cargo filter functions */
@@ -1995,15 +1995,15 @@ struct CargoesField {
 			CargoID other_accepted[MAX_CARGOES];   ///< Cargoes accepted but not used in this figure.
 		} industry; ///< Industry data (for #CFT_INDUSTRY).
 		struct {
-			CargoID vertical_cargoes[MAX_CARGOES]; ///< Cargoes running from top to bottom (cargo ID or #CT_INVALID).
+			CargoID vertical_cargoes[MAX_CARGOES]; ///< Cargoes running from top to bottom (cargo ID or #INVALID_CARGO).
 			uint8_t num_cargoes;                   ///< Number of cargoes.
-			CargoID supp_cargoes[MAX_CARGOES];     ///< Cargoes entering from the left (index in #vertical_cargoes, or #CT_INVALID).
+			CargoID supp_cargoes[MAX_CARGOES];     ///< Cargoes entering from the left (index in #vertical_cargoes, or #INVALID_CARGO).
 			uint8_t top_end;                       ///< Stop at the top of the vertical cargoes.
-			CargoID cust_cargoes[MAX_CARGOES];     ///< Cargoes leaving to the right (index in #vertical_cargoes, or #CT_INVALID).
+			CargoID cust_cargoes[MAX_CARGOES];     ///< Cargoes leaving to the right (index in #vertical_cargoes, or #INVALID_CARGO).
 			uint8_t bottom_end;                    ///< Stop at the bottom of the vertical cargoes.
 		} cargo; ///< Cargo data (for #CFT_CARGO).
 		struct {
-			CargoID cargoes[MAX_CARGOES];          ///< Cargoes to display (or #CT_INVALID).
+			CargoID cargoes[MAX_CARGOES];          ///< Cargoes to display (or #INVALID_CARGO).
 			bool left_align;                       ///< Align all cargo texts to the left (else align to the right).
 		} cargo_label;   ///< Label data (for #CFT_CARGO_LABEL).
 		StringID header; ///< Header text (for #CFT_HEADER).
@@ -2027,8 +2027,8 @@ struct CargoesField {
 	{
 		this->type = CFT_INDUSTRY;
 		this->u.industry.ind_type = ind_type;
-		std::fill(std::begin(this->u.industry.other_accepted), std::end(this->u.industry.other_accepted), CT_INVALID);
-		std::fill(std::begin(this->u.industry.other_produced), std::end(this->u.industry.other_produced), CT_INVALID);
+		std::fill(std::begin(this->u.industry.other_accepted), std::end(this->u.industry.other_accepted), INVALID_CARGO);
+		std::fill(std::begin(this->u.industry.other_produced), std::end(this->u.industry.other_produced), INVALID_CARGO);
 	}
 
 	/**
@@ -2079,7 +2079,7 @@ struct CargoesField {
 
 	/**
 	 * Make a piece of cargo column.
-	 * @param cargoes    Array of #CargoID (may contain #CT_INVALID).
+	 * @param cargoes    Array of #CargoID (may contain #INVALID_CARGO).
 	 * @param length     Number of cargoes in \a cargoes.
 	 * @param count      Number of cargoes to display (should be at least the number of valid cargoes, or \c -1 to let the method compute it).
 	 * @param top_end    This is the first cargo field of this column.
@@ -2099,16 +2099,16 @@ struct CargoesField {
 		this->u.cargo.num_cargoes = (count < 0) ? static_cast<uint8_t>(insert - std::begin(this->u.cargo.vertical_cargoes)) : count;
 		CargoIDComparator comparator;
 		std::sort(std::begin(this->u.cargo.vertical_cargoes), insert, comparator);
-		std::fill(insert, std::end(this->u.cargo.vertical_cargoes), CT_INVALID);
+		std::fill(insert, std::end(this->u.cargo.vertical_cargoes), INVALID_CARGO);
 		this->u.cargo.top_end = top_end;
 		this->u.cargo.bottom_end = bottom_end;
-		std::fill(std::begin(this->u.cargo.supp_cargoes), std::end(this->u.cargo.supp_cargoes), CT_INVALID);
-		std::fill(std::begin(this->u.cargo.cust_cargoes), std::end(this->u.cargo.cust_cargoes), CT_INVALID);
+		std::fill(std::begin(this->u.cargo.supp_cargoes), std::end(this->u.cargo.supp_cargoes), INVALID_CARGO);
+		std::fill(std::begin(this->u.cargo.cust_cargoes), std::end(this->u.cargo.cust_cargoes), INVALID_CARGO);
 	}
 
 	/**
 	 * Make a field displaying cargo type names.
-	 * @param cargoes    Array of #CargoID (may contain #CT_INVALID).
+	 * @param cargoes    Array of #CargoID (may contain #INVALID_CARGO).
 	 * @param length     Number of cargoes in \a cargoes.
 	 * @param left_align ALign texts to the left (else to the right).
 	 */
@@ -2117,7 +2117,7 @@ struct CargoesField {
 		this->type = CFT_CARGO_LABEL;
 		uint i;
 		for (i = 0; i < MAX_CARGOES && i < length; i++) this->u.cargo_label.cargoes[i] = cargoes[i];
-		for (; i < MAX_CARGOES; i++) this->u.cargo_label.cargoes[i] = CT_INVALID;
+		for (; i < MAX_CARGOES; i++) this->u.cargo_label.cargoes[i] = INVALID_CARGO;
 		this->u.cargo_label.left_align = left_align;
 	}
 
@@ -2290,7 +2290,7 @@ struct CargoesField {
 	 * @param left  Left industry neighbour if available (else \c nullptr should be supplied).
 	 * @param right Right industry neighbour if available (else \c nullptr should be supplied).
 	 * @param pt    Click position in the cargo field.
-	 * @return Cargo clicked at, or #CT_INVALID if none.
+	 * @return Cargo clicked at, or #INVALID_CARGO if none.
 	 */
 	CargoID CargoClickedAt(const CargoesField *left, const CargoesField *right, Point pt) const
 	{
@@ -2309,11 +2309,11 @@ struct CargoesField {
 		int vpos = vert_inter_industry_space / 2 + CargoesField::cargo_border.width;
 		uint row;
 		for (row = 0; row < MAX_CARGOES; row++) {
-			if (pt.y < vpos) return CT_INVALID;
+			if (pt.y < vpos) return INVALID_CARGO;
 			if (pt.y < vpos + GetCharacterHeight(FS_NORMAL)) break;
 			vpos += GetCharacterHeight(FS_NORMAL) + CargoesField::cargo_space.width;
 		}
-		if (row == MAX_CARGOES) return CT_INVALID;
+		if (row == MAX_CARGOES) return INVALID_CARGO;
 
 		/* row = 0 -> at first horizontal row, row = 1 -> second horizontal row, 2 = 3rd horizontal row. */
 		if (col == 0) {
@@ -2322,7 +2322,7 @@ struct CargoesField {
 				if (left->type == CFT_INDUSTRY) return left->u.industry.other_produced[row];
 				if (left->type == CFT_CARGO_LABEL && !left->u.cargo_label.left_align) return left->u.cargo_label.cargoes[row];
 			}
-			return CT_INVALID;
+			return INVALID_CARGO;
 		}
 		if (col == this->u.cargo.num_cargoes) {
 			if (IsValidCargoID(this->u.cargo.cust_cargoes[row])) return this->u.cargo.vertical_cargoes[this->u.cargo.cust_cargoes[row]];
@@ -2330,7 +2330,7 @@ struct CargoesField {
 				if (right->type == CFT_INDUSTRY) return right->u.industry.other_accepted[row];
 				if (right->type == CFT_CARGO_LABEL && right->u.cargo_label.left_align) return right->u.cargo_label.cargoes[row];
 			}
-			return CT_INVALID;
+			return INVALID_CARGO;
 		}
 		if (row >= col) {
 			/* Clicked somewhere in-between vertical cargo connection.
@@ -2338,17 +2338,17 @@ struct CargoesField {
 			 * ensures we are left-below the main diagonal, thus at the supplying side.
 			 */
 			if (IsValidCargoID(this->u.cargo.supp_cargoes[row])) return this->u.cargo.vertical_cargoes[this->u.cargo.supp_cargoes[row]];
-			return CT_INVALID;
+			return INVALID_CARGO;
 		}
 		/* Clicked at a customer connection. */
 		if (IsValidCargoID(this->u.cargo.cust_cargoes[row])) return this->u.cargo.vertical_cargoes[this->u.cargo.cust_cargoes[row]];
-		return CT_INVALID;
+		return INVALID_CARGO;
 	}
 
 	/**
 	 * Decide what cargo the user clicked in the cargo label field.
 	 * @param pt Click position in the cargo label field.
-	 * @return Cargo clicked at, or #CT_INVALID if none.
+	 * @return Cargo clicked at, or #INVALID_CARGO if none.
 	 */
 	CargoID CargoLabelClickedAt(Point pt) const
 	{
@@ -2357,11 +2357,11 @@ struct CargoesField {
 		int vpos = vert_inter_industry_space / 2 + CargoesField::cargo_border.height;
 		uint row;
 		for (row = 0; row < MAX_CARGOES; row++) {
-			if (pt.y < vpos) return CT_INVALID;
+			if (pt.y < vpos) return INVALID_CARGO;
 			if (pt.y < vpos + GetCharacterHeight(FS_NORMAL)) break;
 			vpos += GetCharacterHeight(FS_NORMAL) + CargoesField::cargo_space.height;
 		}
-		if (row == MAX_CARGOES) return CT_INVALID;
+		if (row == MAX_CARGOES) return INVALID_CARGO;
 		return this->u.cargo_label.cargoes[row];
 	}
 
@@ -2416,7 +2416,7 @@ struct CargoesRow {
 		CargoesField *cargo_fld = this->columns + column + 1;
 		assert(ind_fld->type == CFT_INDUSTRY && cargo_fld->type == CFT_CARGO);
 
-		std::fill(std::begin(ind_fld->u.industry.other_produced), std::end(ind_fld->u.industry.other_produced), CT_INVALID);
+		std::fill(std::begin(ind_fld->u.industry.other_produced), std::end(ind_fld->u.industry.other_produced), INVALID_CARGO);
 
 		if (ind_fld->u.industry.ind_type < NUM_INDUSTRYTYPES) {
 			CargoID others[MAX_CARGOES]; // Produced cargoes not carried in the cargo column.
@@ -2450,7 +2450,7 @@ struct CargoesRow {
 	void MakeCargoLabel(int column, bool accepting)
 	{
 		CargoID cargoes[MAX_CARGOES];
-		std::fill(std::begin(cargoes), std::end(cargoes), CT_INVALID);
+		std::fill(std::begin(cargoes), std::end(cargoes), INVALID_CARGO);
 
 		CargoesField *label_fld = this->columns + column;
 		CargoesField *cargo_fld = this->columns + (accepting ? column - 1 : column + 1);
@@ -2474,7 +2474,7 @@ struct CargoesRow {
 		CargoesField *cargo_fld = this->columns + column - 1;
 		assert(ind_fld->type == CFT_INDUSTRY && cargo_fld->type == CFT_CARGO);
 
-		std::fill(std::begin(ind_fld->u.industry.other_accepted), std::end(ind_fld->u.industry.other_accepted), CT_INVALID);
+		std::fill(std::begin(ind_fld->u.industry.other_accepted), std::end(ind_fld->u.industry.other_accepted), INVALID_CARGO);
 
 		if (ind_fld->u.industry.ind_type < NUM_INDUSTRYTYPES) {
 			CargoID others[MAX_CARGOES]; // Accepted cargoes not carried in the cargo column.
@@ -3157,7 +3157,7 @@ struct IndustryCargoesWindow : public Window {
 		if (!CalculatePositionInWidget(pt, &fieldxy, &xy)) return false;
 
 		const CargoesField *fld = this->fields[fieldxy.y].columns + fieldxy.x;
-		CargoID cid = CT_INVALID;
+		CargoID cid = INVALID_CARGO;
 		switch (fld->type) {
 			case CFT_CARGO: {
 				CargoesField *lft = (fieldxy.x > 0) ? this->fields[fieldxy.y].columns + fieldxy.x - 1 : nullptr;

--- a/src/linkgraph/linkgraph.h
+++ b/src/linkgraph/linkgraph.h
@@ -189,7 +189,7 @@ public:
 	}
 
 	/** Bare constructor, only for save/load. */
-	LinkGraph() : cargo(CT_INVALID), last_compression(0) {}
+	LinkGraph() : cargo(INVALID_CARGO), last_compression(0) {}
 	/**
 	 * Real constructor.
 	 * @param cargo Cargo the link graph is about.

--- a/src/linkgraph/linkgraph_gui.h
+++ b/src/linkgraph/linkgraph_gui.h
@@ -21,7 +21,7 @@
  * Only the cargo type of the most saturated linkgraph is taken into account.
  */
 struct LinkProperties {
-	LinkProperties() : cargo(CT_INVALID), capacity(0), usage(0), planned(0), shared(false) {}
+	LinkProperties() : cargo(INVALID_CARGO), capacity(0), usage(0), planned(0), shared(false) {}
 
 	/** Return the usage of the link to display. */
 	uint Usage() const { return std::max(this->usage, this->planned); }

--- a/src/linkgraph/refresh.cpp
+++ b/src/linkgraph/refresh.cpp
@@ -67,7 +67,7 @@ bool LinkRefresher::Hop::operator<(const Hop &other) const
  * @param is_full_loading If the vehicle is full loading.
  */
 LinkRefresher::LinkRefresher(Vehicle *vehicle, HopSet *seen_hops, bool allow_merge, bool is_full_loading) :
-	vehicle(vehicle), seen_hops(seen_hops), cargo(CT_INVALID), allow_merge(allow_merge),
+	vehicle(vehicle), seen_hops(seen_hops), cargo(INVALID_CARGO), allow_merge(allow_merge),
 	is_full_loading(is_full_loading)
 {
 	memset(this->capacities, 0, sizeof(this->capacities));

--- a/src/linkgraph/refresh.h
+++ b/src/linkgraph/refresh.h
@@ -56,7 +56,7 @@ protected:
 	struct Hop {
 		OrderID from;  ///< Last order where vehicle could interact with cargo or absolute first order.
 		OrderID to;    ///< Next order to be processed.
-		CargoID cargo; ///< Cargo the consist is probably carrying or CT_INVALID if unknown.
+		CargoID cargo; ///< Cargo the consist is probably carrying or INVALID_CARGO if unknown.
 
 		/**
 		 * Default constructor should not be called but has to be visible for

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1140,15 +1140,15 @@ static ChangeInfoResult RailVehicleChangeInfo(uint engine, int numinfo, int prop
 
 				if (ctype == 0xFF) {
 					/* 0xFF is specified as 'use first refittable' */
-					ei->cargo_type = CT_INVALID;
+					ei->cargo_type = INVALID_CARGO;
 				} else if (_cur.grffile->grf_version >= 8) {
-					/* Use translated cargo. Might result in CT_INVALID (first refittable), if cargo is not defined. */
+					/* Use translated cargo. Might result in INVALID_CARGO (first refittable), if cargo is not defined. */
 					ei->cargo_type = GetCargoTranslation(ctype, _cur.grffile);
 				} else if (ctype < NUM_CARGO) {
 					/* Use untranslated cargo. */
 					ei->cargo_type = ctype;
 				} else {
-					ei->cargo_type = CT_INVALID;
+					ei->cargo_type = INVALID_CARGO;
 					GrfMsg(2, "RailVehicleChangeInfo: Invalid cargo type {}, using first refittable", ctype);
 				}
 				break;
@@ -1401,15 +1401,15 @@ static ChangeInfoResult RoadVehicleChangeInfo(uint engine, int numinfo, int prop
 
 				if (ctype == 0xFF) {
 					/* 0xFF is specified as 'use first refittable' */
-					ei->cargo_type = CT_INVALID;
+					ei->cargo_type = INVALID_CARGO;
 				} else if (_cur.grffile->grf_version >= 8) {
-					/* Use translated cargo. Might result in CT_INVALID (first refittable), if cargo is not defined. */
+					/* Use translated cargo. Might result in INVALID_CARGO (first refittable), if cargo is not defined. */
 					ei->cargo_type = GetCargoTranslation(ctype, _cur.grffile);
 				} else if (ctype < NUM_CARGO) {
 					/* Use untranslated cargo. */
 					ei->cargo_type = ctype;
 				} else {
-					ei->cargo_type = CT_INVALID;
+					ei->cargo_type = INVALID_CARGO;
 					GrfMsg(2, "RailVehicleChangeInfo: Invalid cargo type {}, using first refittable", ctype);
 				}
 				break;
@@ -1596,15 +1596,15 @@ static ChangeInfoResult ShipVehicleChangeInfo(uint engine, int numinfo, int prop
 
 				if (ctype == 0xFF) {
 					/* 0xFF is specified as 'use first refittable' */
-					ei->cargo_type = CT_INVALID;
+					ei->cargo_type = INVALID_CARGO;
 				} else if (_cur.grffile->grf_version >= 8) {
-					/* Use translated cargo. Might result in CT_INVALID (first refittable), if cargo is not defined. */
+					/* Use translated cargo. Might result in INVALID_CARGO (first refittable), if cargo is not defined. */
 					ei->cargo_type = GetCargoTranslation(ctype, _cur.grffile);
 				} else if (ctype < NUM_CARGO) {
 					/* Use untranslated cargo. */
 					ei->cargo_type = ctype;
 				} else {
-					ei->cargo_type = CT_INVALID;
+					ei->cargo_type = INVALID_CARGO;
 					GrfMsg(2, "ShipVehicleChangeInfo: Invalid cargo type {}, using first refittable", ctype);
 				}
 				break;
@@ -2588,7 +2588,7 @@ static ChangeInfoResult TownHouseChangeInfo(uint hid, int numinfo, int prop, Byt
 						housespec->accepts_cargo[i] = GetCargoTranslation(buf->ReadByte(), _cur.grffile);
 						housespec->cargo_acceptance[i] = buf->ReadByte();
 					} else {
-						housespec->accepts_cargo[i] = CT_INVALID;
+						housespec->accepts_cargo[i] = INVALID_CARGO;
 						housespec->cargo_acceptance[i] = 0;
 					}
 				}
@@ -3306,7 +3306,7 @@ static ChangeInfoResult IndustrytilesChangeInfo(uint indtid, int numinfo, int pr
 						/* Tile acceptance can be negative to counteract the INDTILE_SPECIAL_ACCEPTS_ALL_CARGO flag */
 						tsp->acceptance[i] = (int8_t)buf->ReadByte();
 					} else {
-						tsp->accepts_cargo[i] = CT_INVALID;
+						tsp->accepts_cargo[i] = INVALID_CARGO;
 						tsp->acceptance[i] = 0;
 					}
 				}
@@ -3753,7 +3753,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 						CargoID cargo = GetCargoTranslation(buf->ReadByte(), _cur.grffile);
 						indsp->produced_cargo[i] = cargo;
 					} else {
-						indsp->produced_cargo[i] = CT_INVALID;
+						indsp->produced_cargo[i] = INVALID_CARGO;
 					}
 				}
 				break;
@@ -3771,7 +3771,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 						CargoID cargo = GetCargoTranslation(buf->ReadByte(), _cur.grffile);
 						indsp->accepts_cargo[i] = cargo;
 					} else {
-						indsp->accepts_cargo[i] = CT_INVALID;
+						indsp->accepts_cargo[i] = INVALID_CARGO;
 					}
 				}
 				break;
@@ -5515,7 +5515,7 @@ static CargoID TranslateCargo(uint8_t feature, uint8_t ctype)
 		/* No cargo table, so use bitnum values */
 		if (ctype >= 32) {
 			GrfMsg(1, "TranslateCargo: Cargo bitnum {} out of range (max 31), skipping.", ctype);
-			return CT_INVALID;
+			return INVALID_CARGO;
 		}
 
 		for (const CargoSpec *cs : CargoSpec::Iterate()) {
@@ -5526,30 +5526,30 @@ static CargoID TranslateCargo(uint8_t feature, uint8_t ctype)
 		}
 
 		GrfMsg(5, "TranslateCargo: Cargo bitnum {} not available in this climate, skipping.", ctype);
-		return CT_INVALID;
+		return INVALID_CARGO;
 	}
 
 	/* Check if the cargo type is out of bounds of the cargo translation table */
 	if (ctype >= _cur.grffile->cargo_list.size()) {
 		GrfMsg(1, "TranslateCargo: Cargo type {} out of range (max {}), skipping.", ctype, (unsigned int)_cur.grffile->cargo_list.size() - 1);
-		return CT_INVALID;
+		return INVALID_CARGO;
 	}
 
 	/* Look up the cargo label from the translation table */
 	CargoLabel cl = _cur.grffile->cargo_list[ctype];
 	if (cl == 0) {
 		GrfMsg(5, "TranslateCargo: Cargo type {} not available in this climate, skipping.", ctype);
-		return CT_INVALID;
+		return INVALID_CARGO;
 	}
 
-	ctype = GetCargoIDByLabel(cl);
-	if (!IsValidCargoID(ctype)) {
+	CargoID cid = GetCargoIDByLabel(cl);
+	if (!IsValidCargoID(cid)) {
 		GrfMsg(5, "TranslateCargo: Cargo '{:c}{:c}{:c}{:c}' unsupported, skipping.", GB(cl, 24, 8), GB(cl, 16, 8), GB(cl, 8, 8), GB(cl, 0, 8));
-		return CT_INVALID;
+		return INVALID_CARGO;
 	}
 
-	GrfMsg(6, "TranslateCargo: Cargo '{:c}{:c}{:c}{:c}' mapped to cargo type {}.", GB(cl, 24, 8), GB(cl, 16, 8), GB(cl, 8, 8), GB(cl, 0, 8), ctype);
-	return ctype;
+	GrfMsg(6, "TranslateCargo: Cargo '{:c}{:c}{:c}{:c}' mapped to cargo type {}.", GB(cl, 24, 8), GB(cl, 16, 8), GB(cl, 8, 8), GB(cl, 0, 8), cid);
+	return cid;
 }
 
 
@@ -5612,8 +5612,8 @@ static void VehicleMapSpriteGroup(ByteReader *buf, byte feature, uint8_t idcount
 
 		GrfMsg(8, "VehicleMapSpriteGroup: * [{}] Cargo type 0x{:X}, group id 0x{:02X}", c, ctype, groupid);
 
-		ctype = TranslateCargo(feature, ctype);
-		if (!IsValidCargoID(ctype)) continue;
+		CargoID cid = TranslateCargo(feature, ctype);
+		if (!IsValidCargoID(cid)) continue;
 
 		for (uint i = 0; i < idcount; i++) {
 			EngineID engine = engines[i];
@@ -5621,9 +5621,9 @@ static void VehicleMapSpriteGroup(ByteReader *buf, byte feature, uint8_t idcount
 			GrfMsg(7, "VehicleMapSpriteGroup: [{}] Engine {}...", i, engine);
 
 			if (wagover) {
-				SetWagonOverrideSprites(engine, ctype, _cur.spritegroups[groupid], last_engines, last_engines_count);
+				SetWagonOverrideSprites(engine, cid, _cur.spritegroups[groupid], last_engines, last_engines_count);
 			} else {
-				SetCustomEngineSprites(engine, ctype, _cur.spritegroups[groupid]);
+				SetCustomEngineSprites(engine, cid, _cur.spritegroups[groupid]);
 			}
 		}
 	}
@@ -9055,12 +9055,12 @@ static void CalculateRefitMasks()
 		}
 
 		/* Clear invalid cargoslots (from default vehicles or pre-NewCargo GRFs) */
-		if (IsValidCargoID(ei->cargo_type) && !HasBit(_cargo_mask, ei->cargo_type)) ei->cargo_type = CT_INVALID;
+		if (IsValidCargoID(ei->cargo_type) && !HasBit(_cargo_mask, ei->cargo_type)) ei->cargo_type = INVALID_CARGO;
 
 		/* Ensure that the vehicle is either not refittable, or that the default cargo is one of the refittable cargoes.
 		 * Note: Vehicles refittable to no cargo are handle differently to vehicle refittable to a single cargo. The latter might have subtypes. */
 		if (!only_defaultcargo && (e->type != VEH_SHIP || e->u.ship.old_refittable) && IsValidCargoID(ei->cargo_type) && !HasBit(ei->refit_mask, ei->cargo_type)) {
-			ei->cargo_type = CT_INVALID;
+			ei->cargo_type = INVALID_CARGO;
 		}
 
 		/* Check if this engine's cargo type is valid. If not, set to the first refittable

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -5508,8 +5508,8 @@ static void NewSpriteGroup(ByteReader *buf)
 static CargoID TranslateCargo(uint8_t feature, uint8_t ctype)
 {
 	/* Special cargo types for purchase list and stations */
-	if ((feature == GSF_STATIONS || feature == GSF_ROADSTOPS) && ctype == 0xFE) return CT_DEFAULT_NA;
-	if (ctype == 0xFF) return CT_PURCHASE;
+	if ((feature == GSF_STATIONS || feature == GSF_ROADSTOPS) && ctype == 0xFE) return SpriteGroupCargo::SG_DEFAULT_NA;
+	if (ctype == 0xFF) return SpriteGroupCargo::SG_PURCHASE;
 
 	if (_cur.grffile->cargo_list.empty()) {
 		/* No cargo table, so use bitnum values */
@@ -5637,9 +5637,9 @@ static void VehicleMapSpriteGroup(ByteReader *buf, byte feature, uint8_t idcount
 		EngineID engine = engines[i];
 
 		if (wagover) {
-			SetWagonOverrideSprites(engine, CT_DEFAULT, _cur.spritegroups[groupid], last_engines, last_engines_count);
+			SetWagonOverrideSprites(engine, SpriteGroupCargo::SG_DEFAULT, _cur.spritegroups[groupid], last_engines, last_engines_count);
 		} else {
-			SetCustomEngineSprites(engine, CT_DEFAULT, _cur.spritegroups[groupid]);
+			SetCustomEngineSprites(engine, SpriteGroupCargo::SG_DEFAULT, _cur.spritegroups[groupid]);
 			SetEngineGRF(engine, _cur.grffile);
 		}
 	}
@@ -5722,7 +5722,7 @@ static void StationMapSpriteGroup(ByteReader *buf, uint8_t idcount)
 			continue;
 		}
 
-		statspec->grf_prop.spritegroup[CT_DEFAULT] = _cur.spritegroups[groupid];
+		statspec->grf_prop.spritegroup[SpriteGroupCargo::SG_DEFAULT] = _cur.spritegroups[groupid];
 		statspec->grf_prop.grffile = _cur.grffile;
 		statspec->grf_prop.local_id = station;
 		StationClass::Assign(statspec);
@@ -6092,7 +6092,7 @@ static void RoadStopMapSpriteGroup(ByteReader *buf, uint8_t idcount)
 			continue;
 		}
 
-		roadstopspec->grf_prop.spritegroup[CT_DEFAULT] = _cur.spritegroups[groupid];
+		roadstopspec->grf_prop.spritegroup[SpriteGroupCargo::SG_DEFAULT] = _cur.spritegroups[groupid];
 		roadstopspec->grf_prop.grffile = _cur.grffile;
 		roadstopspec->grf_prop.local_id = roadstop;
 		RoadStopClass::Assign(roadstopspec);

--- a/src/newgrf_airporttiles.h
+++ b/src/newgrf_airporttiles.h
@@ -85,8 +85,8 @@ private:
 };
 
 void AnimateAirportTile(TileIndex tile);
-void AirportTileAnimationTrigger(Station *st, TileIndex tile, AirpAnimationTrigger trigger, CargoID cargo_type = CT_INVALID);
-void AirportAnimationTrigger(Station *st, AirpAnimationTrigger trigger, CargoID cargo_type = CT_INVALID);
+void AirportTileAnimationTrigger(Station *st, TileIndex tile, AirpAnimationTrigger trigger, CargoID cargo_type = INVALID_CARGO);
+void AirportAnimationTrigger(Station *st, AirpAnimationTrigger trigger, CargoID cargo_type = INVALID_CARGO);
 bool DrawNewAirportTile(TileInfo *ti, Station *st, const AirportTileSpec *airts);
 
 #endif /* NEWGRF_AIRPORTTILES_H */

--- a/src/newgrf_cargo.cpp
+++ b/src/newgrf_cargo.cpp
@@ -74,13 +74,13 @@ uint16_t GetCargoCallback(CallbackID callback, uint32_t param1, uint32_t param2,
  * @param usebit  Defines the meaning of \a cargo for GRF version < 7.
  *                If true, then \a cargo is a bitnum. If false, then \a cargo is a cargoslot.
  *                For GRF version >= 7 \a cargo is always a translated cargo bit.
- * @return CargoID or CT_INVALID if the cargo is not available.
+ * @return CargoID or INVALID_CARGO if the cargo is not available.
  */
 CargoID GetCargoTranslation(uint8_t cargo, const GRFFile *grffile, bool usebit)
 {
 	/* Pre-version 7 uses the 'climate dependent' ID in callbacks and properties, i.e. cargo is the cargo ID */
 	if (grffile->grf_version < 7 && !usebit) {
-		if (cargo >= CargoSpec::GetArraySize() || !CargoSpec::Get(cargo)->IsValid()) return CT_INVALID;
+		if (cargo >= CargoSpec::GetArraySize() || !CargoSpec::Get(cargo)->IsValid()) return INVALID_CARGO;
 		return cargo;
 	}
 
@@ -94,5 +94,5 @@ CargoID GetCargoTranslation(uint8_t cargo, const GRFFile *grffile, bool usebit)
 		/* Else the cargo value is a 'climate independent' 'bitnum' */
 		return GetCargoIDByBitnum(cargo);
 	}
-	return CT_INVALID;
+	return INVALID_CARGO;
 }

--- a/src/newgrf_cargo.h
+++ b/src/newgrf_cargo.h
@@ -14,9 +14,16 @@
 #include "cargo_type.h"
 #include "gfx_type.h"
 
-static const CargoID CT_DEFAULT      = NUM_CARGO + 0;
-static const CargoID CT_PURCHASE     = NUM_CARGO + 1;
-static const CargoID CT_DEFAULT_NA   = NUM_CARGO + 2;
+/**
+ * Sprite Group Cargo types.
+ * These special cargo types are used when resolving sprite groups when non-cargo-specific sprites or callbacks are needed,
+ * e.g. in purchase lists, or if no specific cargo type sprite group is supplied.
+ */
+namespace SpriteGroupCargo {
+	static constexpr CargoID SG_DEFAULT    = NUM_CARGO;     ///< Default type used when no more-specific cargo matches.
+	static constexpr CargoID SG_PURCHASE   = NUM_CARGO + 1; ///< Used in purchase lists before an item exists.
+	static constexpr CargoID SG_DEFAULT_NA = NUM_CARGO + 2; ///< Used only by stations and roads when no more-specific cargo matches.
+};
 
 /* Forward declarations of structs used */
 struct CargoSpec;

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -31,7 +31,7 @@ void SetWagonOverrideSprites(EngineID engine, CargoID cargo, const SpriteGroup *
 {
 	Engine *e = Engine::Get(engine);
 
-	assert(cargo < NUM_CARGO + 2); // Include CT_DEFAULT and CT_PURCHASE pseudo cargoes.
+	assert(cargo < NUM_CARGO + 2); // Include SpriteGroupCargo::SG_DEFAULT and SpriteGroupCargo::SG_PURCHASE pseudo cargoes.
 
 	WagonOverride *wo = &e->overrides.emplace_back();
 	wo->group = group;
@@ -44,7 +44,7 @@ const SpriteGroup *GetWagonOverrideSpriteSet(EngineID engine, CargoID cargo, Eng
 	const Engine *e = Engine::Get(engine);
 
 	for (const WagonOverride &wo : e->overrides) {
-		if (wo.cargo != cargo && wo.cargo != CT_DEFAULT) continue;
+		if (wo.cargo != cargo && wo.cargo != SpriteGroupCargo::SG_DEFAULT) continue;
 		if (std::find(wo.engines.begin(), wo.engines.end(), overriding_engine) != wo.engines.end()) return wo.group;
 	}
 	return nullptr;
@@ -1044,7 +1044,7 @@ VehicleResolverObject::VehicleResolverObject(EngineID engine_type, const Vehicle
 	cached_relative_count(0)
 {
 	if (wagon_override == WO_SELF) {
-		this->root_spritegroup = GetWagonOverrideSpriteSet(engine_type, CT_DEFAULT, engine_type);
+		this->root_spritegroup = GetWagonOverrideSpriteSet(engine_type, SpriteGroupCargo::SG_DEFAULT, engine_type);
 	} else {
 		if (wagon_override != WO_NONE && v != nullptr && v->IsGroundVehicle()) {
 			assert(v->engine_type == engine_type); // overrides make little sense with fake scopes
@@ -1061,9 +1061,9 @@ VehicleResolverObject::VehicleResolverObject(EngineID engine_type, const Vehicle
 
 		if (this->root_spritegroup == nullptr) {
 			const Engine *e = Engine::Get(engine_type);
-			CargoID cargo = v != nullptr ? v->cargo_type : CT_PURCHASE;
+			CargoID cargo = v != nullptr ? v->cargo_type : SpriteGroupCargo::SG_PURCHASE;
 			assert(cargo < lengthof(e->grf_prop.spritegroup));
-			this->root_spritegroup = e->grf_prop.spritegroup[cargo] != nullptr ? e->grf_prop.spritegroup[cargo] : e->grf_prop.spritegroup[CT_DEFAULT];
+			this->root_spritegroup = e->grf_prop.spritegroup[cargo] != nullptr ? e->grf_prop.spritegroup[cargo] : e->grf_prop.spritegroup[SpriteGroupCargo::SG_DEFAULT];
 		}
 	}
 }

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -451,8 +451,8 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 
 				/* Pick the most common cargo type */
 				auto cargo_it = std::max_element(std::begin(common_cargoes), std::end(common_cargoes));
-				/* Return CT_INVALID if nothing is carried */
-				CargoID common_cargo_type = (*cargo_it == 0) ? (CargoID)CT_INVALID : static_cast<CargoID>(std::distance(std::begin(common_cargoes), cargo_it));
+				/* Return INVALID_CARGO if nothing is carried */
+				CargoID common_cargo_type = (*cargo_it == 0) ? INVALID_CARGO : static_cast<CargoID>(std::distance(std::begin(common_cargoes), cargo_it));
 
 				/* Count subcargo types of common_cargo_type */
 				std::array<uint8_t, UINT8_MAX + 1> common_subtypes{};
@@ -486,7 +486,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 			 *    And this is only done by CheckCaches().
 			 */
 			const GRFFile *grffile = object->ro.grffile;
-			uint8_t common_bitnum = (common_cargo_type == CT_INVALID) ? 0xFF :
+			uint8_t common_bitnum = (common_cargo_type == INVALID_CARGO) ? 0xFF :
 				(grffile == nullptr || grffile->grf_version < 8) ? CargoSpec::Get(common_cargo_type)->bitnum : grffile->cargo_map[common_cargo_type];
 
 			return (v->grf_cache.consist_cargo_information & 0xFFFF00FF) | common_bitnum << 8;

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -347,7 +347,7 @@ void TriggerRoadStopAnimation(BaseStation *st, TileIndex trigger_tile, StationAn
 		if (ss != nullptr && HasBit(ss->animation.triggers, trigger)) {
 			CargoID cargo;
 			if (!IsValidCargoID(cargo_type)) {
-				cargo = CT_INVALID;
+				cargo = INVALID_CARGO;
 			} else {
 				cargo = ss->grf_prop.grffile->cargo_map[cargo_type];
 			}

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -196,11 +196,11 @@ RoadStopResolverObject::RoadStopResolverObject(const RoadStopSpec *roadstopspec,
 
 	this->town_scope = nullptr;
 
-	CargoID ctype = CT_DEFAULT_NA;
+	CargoID ctype = SpriteGroupCargo::SG_DEFAULT_NA;
 
 	if (st == nullptr) {
 		/* No station, so we are in a purchase list */
-		ctype = CT_PURCHASE;
+		ctype = SpriteGroupCargo::SG_PURCHASE;
 	} else if (Station::IsExpected(st)) {
 		const Station *station = Station::From(st);
 		/* Pick the first cargo that we have waiting */
@@ -214,7 +214,7 @@ RoadStopResolverObject::RoadStopResolverObject(const RoadStopSpec *roadstopspec,
 	}
 
 	if (roadstopspec->grf_prop.spritegroup[ctype] == nullptr) {
-		ctype = CT_DEFAULT;
+		ctype = SpriteGroupCargo::SG_DEFAULT;
 	}
 
 	/* Remember the cargo type we've picked */

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -169,8 +169,8 @@ uint16_t GetRoadStopCallback(CallbackID callback, uint32_t param1, uint32_t para
 
 void AnimateRoadStopTile(TileIndex tile);
 uint8_t GetRoadStopTileAnimationSpeed(TileIndex tile);
-void TriggerRoadStopAnimation(BaseStation *st, TileIndex tile, StationAnimationTrigger trigger, CargoID cargo_type = CT_INVALID);
-void TriggerRoadStopRandomisation(Station *st, TileIndex tile, RoadStopRandomTrigger trigger, CargoID cargo_type = CT_INVALID);
+void TriggerRoadStopAnimation(BaseStation *st, TileIndex tile, StationAnimationTrigger trigger, CargoID cargo_type = INVALID_CARGO);
+void TriggerRoadStopRandomisation(Station *st, TileIndex tile, RoadStopRandomTrigger trigger, CargoID cargo_type = INVALID_CARGO);
 
 bool GetIfNewStopsByType(RoadStopType rs, RoadType roadtype);
 bool GetIfClassHasNewStopsByType(RoadStopClass *roadstopclass, RoadStopType rs, RoadType roadtype);

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -496,12 +496,12 @@ uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, byte variable, [[ma
 
 	switch (this->station_scope.cargo_type) {
 		case INVALID_CARGO:
-		case CT_DEFAULT_NA:
-		case CT_PURCHASE:
+		case SpriteGroupCargo::SG_DEFAULT_NA:
+		case SpriteGroupCargo::SG_PURCHASE:
 			cargo = 0;
 			break;
 
-		case CT_DEFAULT:
+		case SpriteGroupCargo::SG_DEFAULT:
 			for (const GoodsEntry &ge : st->goods) {
 				cargo += ge.cargo.TotalCount();
 			}
@@ -557,11 +557,11 @@ StationResolverObject::StationResolverObject(const StationSpec *statspec, BaseSt
 	/* Invalidate all cached vars */
 	_svc.valid = 0;
 
-	CargoID ctype = CT_DEFAULT_NA;
+	CargoID ctype = SpriteGroupCargo::SG_DEFAULT_NA;
 
 	if (this->station_scope.st == nullptr) {
 		/* No station, so we are in a purchase list */
-		ctype = CT_PURCHASE;
+		ctype = SpriteGroupCargo::SG_PURCHASE;
 	} else if (Station::IsExpected(this->station_scope.st)) {
 		const Station *st = Station::From(this->station_scope.st);
 		/* Pick the first cargo that we have waiting */
@@ -575,7 +575,7 @@ StationResolverObject::StationResolverObject(const StationSpec *statspec, BaseSt
 	}
 
 	if (this->station_scope.statspec->grf_prop.spritegroup[ctype] == nullptr) {
-		ctype = CT_DEFAULT;
+		ctype = SpriteGroupCargo::SG_DEFAULT;
 	}
 
 	/* Remember the cargo type we've picked */

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -495,7 +495,7 @@ uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, byte variable, [[ma
 	const Station *st = Station::From(this->station_scope.st);
 
 	switch (this->station_scope.cargo_type) {
-		case CT_INVALID:
+		case INVALID_CARGO:
 		case CT_DEFAULT_NA:
 		case CT_PURCHASE:
 			cargo = 0;
@@ -887,7 +887,7 @@ void TriggerStationAnimation(BaseStation *st, TileIndex trigger_tile, StationAni
 			if (ss != nullptr && HasBit(ss->animation.triggers, trigger)) {
 				CargoID cargo;
 				if (!IsValidCargoID(cargo_type)) {
-					cargo = CT_INVALID;
+					cargo = INVALID_CARGO;
 				} else {
 					cargo = ss->grf_prop.grffile->cargo_map[cargo_type];
 				}

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -36,7 +36,7 @@ struct StationScopeResolver : public ScopeResolver {
 	 * @param tile %Tile of the station.
 	 */
 	StationScopeResolver(ResolverObject &ro, const StationSpec *statspec, BaseStation *st, TileIndex tile)
-		: ScopeResolver(ro), tile(tile), st(st), statspec(statspec), cargo_type(CT_INVALID), axis(INVALID_AXIS)
+		: ScopeResolver(ro), tile(tile), st(st), statspec(statspec), cargo_type(INVALID_CARGO), axis(INVALID_AXIS)
 	{
 	}
 
@@ -198,8 +198,8 @@ void DeallocateSpecFromStation(BaseStation *st, byte specindex);
 bool DrawStationTile(int x, int y, RailType railtype, Axis axis, StationClassID sclass, uint station);
 
 void AnimateStationTile(TileIndex tile);
-void TriggerStationAnimation(BaseStation *st, TileIndex tile, StationAnimationTrigger trigger, CargoID cargo_type = CT_INVALID);
-void TriggerStationRandomisation(Station *st, TileIndex tile, StationRandomTrigger trigger, CargoID cargo_type = CT_INVALID);
+void TriggerStationAnimation(BaseStation *st, TileIndex tile, StationAnimationTrigger trigger, CargoID cargo_type = INVALID_CARGO);
+void TriggerStationRandomisation(Station *st, TileIndex tile, StationRandomTrigger trigger, CargoID cargo_type = INVALID_CARGO);
 void StationUpdateCachedTriggers(BaseStation *st);
 
 #endif /* NEWGRF_STATION_H */

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -58,7 +58,7 @@ private:
 public:
 	Order *next;          ///< Pointer to next order. If nullptr, end of list
 
-	Order() : flags(0), refit_cargo(CT_NO_REFIT), wait_time(0), travel_time(0), max_speed(UINT16_MAX) {}
+	Order() : flags(0), refit_cargo(CARGO_NO_REFIT), wait_time(0), travel_time(0), max_speed(UINT16_MAX) {}
 	~Order();
 
 	Order(uint32_t packed);
@@ -79,7 +79,7 @@ public:
 	void Free();
 
 	void MakeGoToStation(StationID destination);
-	void MakeGoToDepot(DepotID destination, OrderDepotTypeFlags order, OrderNonStopFlags non_stop_type = ONSF_NO_STOP_AT_INTERMEDIATE_STATIONS, OrderDepotActionFlags action = ODATF_SERVICE_ONLY, CargoID cargo = CT_NO_REFIT);
+	void MakeGoToDepot(DepotID destination, OrderDepotTypeFlags order, OrderNonStopFlags non_stop_type = ONSF_NO_STOP_AT_INTERMEDIATE_STATIONS, OrderDepotActionFlags action = ODATF_SERVICE_ONLY, CargoID cargo = CARGO_NO_REFIT);
 	void MakeGoToWaypoint(StationID destination);
 	void MakeLoading(bool ordered);
 	void MakeLeaveStation();
@@ -115,14 +115,14 @@ public:
 	 * @pre IsType(OT_GOTO_DEPOT) || IsType(OT_GOTO_STATION)
 	 * @return true if a refit should happen.
 	 */
-	inline bool IsRefit() const { return this->refit_cargo < NUM_CARGO || this->refit_cargo == CT_AUTO_REFIT; }
+	inline bool IsRefit() const { return this->refit_cargo < NUM_CARGO || this->refit_cargo == CARGO_AUTO_REFIT; }
 
 	/**
 	 * Is this order a auto-refit order.
 	 * @pre IsType(OT_GOTO_DEPOT) || IsType(OT_GOTO_STATION)
 	 * @return true if a auto-refit should happen.
 	 */
-	inline bool IsAutoRefit() const { return this->refit_cargo == CT_AUTO_REFIT; }
+	inline bool IsAutoRefit() const { return this->refit_cargo == CARGO_AUTO_REFIT; }
 
 	/**
 	 * Get the cargo to to refit to.

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -237,7 +237,7 @@ Order::Order(uint32_t packed)
 	this->flags   = GB(packed,  8,  8);
 	this->dest    = GB(packed, 16, 16);
 	this->next    = nullptr;
-	this->refit_cargo   = CT_NO_REFIT;
+	this->refit_cargo   = CARGO_NO_REFIT;
 	this->wait_time     = 0;
 	this->travel_time   = 0;
 	this->max_speed     = UINT16_MAX;
@@ -719,7 +719,7 @@ CommandCost CmdInsertOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID se
 	if (ret.Failed()) return ret;
 
 	/* Validate properties we don't want to have different from default as they are set by other commands. */
-	if (new_order.GetRefitCargo() != CT_NO_REFIT || new_order.GetWaitTime() != 0 || new_order.GetTravelTime() != 0 || new_order.GetMaxSpeed() != UINT16_MAX) return CMD_ERROR;
+	if (new_order.GetRefitCargo() != CARGO_NO_REFIT || new_order.GetWaitTime() != 0 || new_order.GetTravelTime() != 0 || new_order.GetMaxSpeed() != UINT16_MAX) return CMD_ERROR;
 
 	/* Check if the inserted order is to the correct destination (owner, type),
 	 * and has the correct flags if any */
@@ -1326,7 +1326,7 @@ CommandCost CmdModifyOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID se
 			case MOF_NON_STOP:
 				order->SetNonStopType((OrderNonStopFlags)data);
 				if (data & ONSF_NO_STOP_AT_DESTINATION_STATION) {
-					order->SetRefit(CT_NO_REFIT);
+					order->SetRefit(CARGO_NO_REFIT);
 					order->SetLoadType(OLF_LOAD_IF_POSSIBLE);
 					order->SetUnloadType(OUF_UNLOAD_IF_POSSIBLE);
 				}
@@ -1342,7 +1342,7 @@ CommandCost CmdModifyOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID se
 
 			case MOF_LOAD:
 				order->SetLoadType((OrderLoadFlags)data);
-				if (data & OLFB_NO_LOAD) order->SetRefit(CT_NO_REFIT);
+				if (data & OLFB_NO_LOAD) order->SetRefit(CARGO_NO_REFIT);
 				break;
 
 			case MOF_DEPOT_ACTION: {
@@ -1355,13 +1355,13 @@ CommandCost CmdModifyOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID se
 					case DA_SERVICE:
 						order->SetDepotOrderType((OrderDepotTypeFlags)(order->GetDepotOrderType() | ODTFB_SERVICE));
 						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() & ~ODATFB_HALT));
-						order->SetRefit(CT_NO_REFIT);
+						order->SetRefit(CARGO_NO_REFIT);
 						break;
 
 					case DA_STOP:
 						order->SetDepotOrderType((OrderDepotTypeFlags)(order->GetDepotOrderType() & ~ODTFB_SERVICE));
 						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() | ODATFB_HALT));
-						order->SetRefit(CT_NO_REFIT);
+						order->SetRefit(CARGO_NO_REFIT);
 						break;
 
 					default:
@@ -1618,7 +1618,7 @@ CommandCost CmdCloneOrder(DoCommandFlag flags, CloneOptions action, VehicleID ve
  */
 CommandCost CmdOrderRefit(DoCommandFlag flags, VehicleID veh, VehicleOrderID order_number, CargoID cargo)
 {
-	if (cargo >= NUM_CARGO && cargo != CT_NO_REFIT && cargo != CT_AUTO_REFIT) return CMD_ERROR;
+	if (cargo >= NUM_CARGO && cargo != CARGO_NO_REFIT && cargo != CARGO_AUTO_REFIT) return CMD_ERROR;
 
 	const Vehicle *v = Vehicle::GetIfValid(veh);
 	if (v == nullptr || !v->IsPrimaryVehicle()) return CMD_ERROR;
@@ -1630,7 +1630,7 @@ CommandCost CmdOrderRefit(DoCommandFlag flags, VehicleID veh, VehicleOrderID ord
 	if (order == nullptr) return CMD_ERROR;
 
 	/* Automatic refit cargo is only supported for goto station orders. */
-	if (cargo == CT_AUTO_REFIT && !order->IsType(OT_GOTO_STATION)) return CMD_ERROR;
+	if (cargo == CARGO_AUTO_REFIT && !order->IsType(OT_GOTO_STATION)) return CMD_ERROR;
 
 	if (order->GetLoadType() & OLFB_NO_LOAD) return CMD_ERROR;
 
@@ -1638,7 +1638,7 @@ CommandCost CmdOrderRefit(DoCommandFlag flags, VehicleID veh, VehicleOrderID ord
 		order->SetRefit(cargo);
 
 		/* Make the depot order an 'always go' order. */
-		if (cargo != CT_NO_REFIT && order->IsType(OT_GOTO_DEPOT)) {
+		if (cargo != CARGO_NO_REFIT && order->IsType(OT_GOTO_DEPOT)) {
 			order->SetDepotOrderType((OrderDepotTypeFlags)(order->GetDepotOrderType() & ~ODTFB_SERVICE));
 			order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() & ~ODATFB_HALT));
 		}

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -749,10 +749,10 @@ private:
 	{
 		if (_ctrl_pressed) {
 			/* Cancel refitting */
-			Command<CMD_ORDER_REFIT>::Post(this->vehicle->tile, this->vehicle->index, this->OrderGetSel(), CT_NO_REFIT);
+			Command<CMD_ORDER_REFIT>::Post(this->vehicle->tile, this->vehicle->index, this->OrderGetSel(), CARGO_NO_REFIT);
 		} else {
 			if (i == 1) { // Auto-refit to available cargo type.
-				Command<CMD_ORDER_REFIT>::Post(this->vehicle->tile, this->vehicle->index, this->OrderGetSel(), CT_AUTO_REFIT);
+				Command<CMD_ORDER_REFIT>::Post(this->vehicle->tile, this->vehicle->index, this->OrderGetSel(), CARGO_AUTO_REFIT);
 			} else {
 				ShowVehicleRefitWindow(this->vehicle, this->OrderGetSel(), this, auto_refit);
 			}

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1462,11 +1462,11 @@ bool AfterLoadGame()
 	/* Setting no refit flags to all orders in savegames from before refit in orders were added */
 	if (IsSavegameVersionBefore(SLV_36)) {
 		for (Order *order : Order::Iterate()) {
-			order->SetRefit(CT_NO_REFIT);
+			order->SetRefit(CARGO_NO_REFIT);
 		}
 
 		for (Vehicle *v : Vehicle::Iterate()) {
-			v->current_order.SetRefit(CT_NO_REFIT);
+			v->current_order.SetRefit(CARGO_NO_REFIT);
 		}
 	}
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3029,13 +3029,13 @@ bool AfterLoadGame()
 		/* Make sure added industry cargo slots are cleared */
 		for (Industry *i : Industry::Iterate()) {
 			for (auto it = std::begin(i->produced) + 2; it != std::end(i->produced); ++it) {
-				it->cargo = CT_INVALID;
+				it->cargo = INVALID_CARGO;
 				it->waiting = 0;
 				it->rate = 0;
 				it->history = {};
 			}
 			for (auto it = std::begin(i->accepted) + 3; it != std::end(i->accepted); ++it) {
-				it->cargo = CT_INVALID;
+				it->cargo = INVALID_CARGO;
 				it->waiting = 0;
 			}
 			/* Make sure last_cargo_accepted_at is copied to elements for every valid input cargo.

--- a/src/script/api/script_cargo.hpp
+++ b/src/script/api/script_cargo.hpp
@@ -57,7 +57,7 @@ public:
 		/* Note: these values represent part of the in-game CargoTypes enum */
 		CT_AUTO_REFIT = ::CT_AUTO_REFIT, ///< Automatically choose cargo type when doing auto-refitting.
 		CT_NO_REFIT   = ::CT_NO_REFIT,   ///< Do not refit cargo of a vehicle.
-		CT_INVALID    = ::CT_INVALID,    ///< An invalid cargo type.
+		CT_INVALID    = ::INVALID_CARGO, ///< An invalid cargo type.
 	};
 
 	/**

--- a/src/script/api/script_cargo.hpp
+++ b/src/script/api/script_cargo.hpp
@@ -55,8 +55,8 @@ public:
 	 */
 	enum SpecialCargoID {
 		/* Note: these values represent part of the in-game CargoTypes enum */
-		CT_AUTO_REFIT = ::CT_AUTO_REFIT, ///< Automatically choose cargo type when doing auto-refitting.
-		CT_NO_REFIT   = ::CT_NO_REFIT,   ///< Do not refit cargo of a vehicle.
+		CT_AUTO_REFIT = ::CARGO_AUTO_REFIT, ///< Automatically choose cargo type when doing auto-refitting.
+		CT_NO_REFIT   = ::CARGO_NO_REFIT, ///< Do not refit cargo of a vehicle.
 		CT_INVALID    = ::INVALID_CARGO, ///< An invalid cargo type.
 	};
 

--- a/src/script/api/script_engine.cpp
+++ b/src/script/api/script_engine.cpp
@@ -52,12 +52,12 @@
 
 /* static */ CargoID ScriptEngine::GetCargoType(EngineID engine_id)
 {
-	if (!IsValidEngine(engine_id)) return CT_INVALID;
+	if (!IsValidEngine(engine_id)) return INVALID_CARGO;
 
 	CargoArray cap = ::GetCapacityOfArticulatedParts(engine_id);
 
 	auto it = std::max_element(std::cbegin(cap), std::cend(cap));
-	if (*it == 0) return CT_INVALID;
+	if (*it == 0) return INVALID_CARGO;
 
 	return CargoID(std::distance(std::cbegin(cap), it));
 }

--- a/src/script/api/script_event_types.cpp
+++ b/src/script/api/script_event_types.cpp
@@ -39,11 +39,11 @@ std::optional<std::string> ScriptEventEnginePreview::GetName()
 
 CargoID ScriptEventEnginePreview::GetCargoType()
 {
-	if (!this->IsEngineValid()) return CT_INVALID;
+	if (!this->IsEngineValid()) return INVALID_CARGO;
 	CargoArray cap = ::GetCapacityOfArticulatedParts(this->engine);
 
 	auto it = std::max_element(std::cbegin(cap), std::cend(cap));
-	if (*it == 0) return CT_INVALID;
+	if (*it == 0) return INVALID_CARGO;
 
 	return CargoID(std::distance(std::cbegin(cap), it));
 }

--- a/src/script/api/script_industry.hpp
+++ b/src/script/api/script_industry.hpp
@@ -257,9 +257,9 @@ public:
 	/**
 	 * Get the last date this industry accepted any cargo delivery.
 	 * @param industry_id The index of the industry.
-	 * @param cargo_type The cargo to query, or CT_INVALID to query latest of all accepted cargoes.
+	 * @param cargo_type The cargo to query, or INVALID_CARGO to query latest of all accepted cargoes.
 	 * @pre IsValidIndustry(industry_id).
-	 * @pre IsValidCargo(cargo_type) || cargo_type == CT_INVALID.
+	 * @pre IsValidCargo(cargo_type) || cargo_type == INVALID_CARGO.
 	 * @return Date the industry last received cargo from a delivery, or ScriptDate::DATE_INVALID on error.
 	 * @api -ai
 	 */

--- a/src/script/api/script_order.cpp
+++ b/src/script/api/script_order.cpp
@@ -372,11 +372,11 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 
 /* static */ CargoID ScriptOrder::GetOrderRefit(VehicleID vehicle_id, OrderPosition order_position)
 {
-	if (!IsValidVehicleOrder(vehicle_id, order_position)) return CT_NO_REFIT;
-	if (order_position != ORDER_CURRENT && !IsGotoStationOrder(vehicle_id, order_position) && !IsGotoDepotOrder(vehicle_id, order_position)) return CT_NO_REFIT;
+	if (!IsValidVehicleOrder(vehicle_id, order_position)) return CARGO_NO_REFIT;
+	if (order_position != ORDER_CURRENT && !IsGotoStationOrder(vehicle_id, order_position) && !IsGotoDepotOrder(vehicle_id, order_position)) return CARGO_NO_REFIT;
 
 	const Order *order = ::ResolveOrder(vehicle_id, order_position);
-	return order->IsRefit() ? order->GetRefitCargo() : (CargoID)CT_NO_REFIT;
+	return order->IsRefit() ? order->GetRefitCargo() : CARGO_NO_REFIT;
 }
 
 /* static */ bool ScriptOrder::SetOrderJumpTo(VehicleID vehicle_id, OrderPosition order_position, OrderPosition jump_to)
@@ -441,8 +441,8 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 {
 	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicleOrder(vehicle_id, order_position));
-	EnforcePrecondition(false, IsGotoStationOrder(vehicle_id, order_position) || (IsGotoDepotOrder(vehicle_id, order_position) && refit_cargo != CT_AUTO_REFIT));
-	EnforcePrecondition(false, ScriptCargo::IsValidCargo(refit_cargo) || refit_cargo == CT_AUTO_REFIT || refit_cargo == CT_NO_REFIT);
+	EnforcePrecondition(false, IsGotoStationOrder(vehicle_id, order_position) || (IsGotoDepotOrder(vehicle_id, order_position) && refit_cargo != CARGO_AUTO_REFIT));
+	EnforcePrecondition(false, ScriptCargo::IsValidCargo(refit_cargo) || refit_cargo == CARGO_AUTO_REFIT || refit_cargo == CARGO_NO_REFIT);
 
 	return ScriptObject::Command<CMD_ORDER_REFIT>::Do(0, vehicle_id, ScriptOrderPositionToRealOrderPosition(vehicle_id, ScriptOrder::ResolveOrderPosition(vehicle_id, order_position)), refit_cargo);
 }

--- a/src/script/api/script_subsidy.cpp
+++ b/src/script/api/script_subsidy.cpp
@@ -67,7 +67,7 @@
 
 /* static */ CargoID ScriptSubsidy::GetCargoType(SubsidyID subsidy_id)
 {
-	if (!IsValidSubsidy(subsidy_id)) return CT_INVALID;
+	if (!IsValidSubsidy(subsidy_id)) return INVALID_CARGO;
 
 	return ::Subsidy::Get(subsidy_id)->cargo_type;
 }

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -89,7 +89,7 @@
 
 /* static */ VehicleID ScriptVehicle::BuildVehicle(TileIndex depot, EngineID engine_id)
 {
-	return _BuildVehicleInternal(depot, engine_id, CT_INVALID);
+	return _BuildVehicleInternal(depot, engine_id, INVALID_CARGO);
 }
 
 /* static */ VehicleID ScriptVehicle::BuildVehicleWithRefit(TileIndex depot, EngineID engine_id, CargoID cargo)

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -1750,7 +1750,7 @@ struct StationViewWindow : public Window {
 	 * @param cargo Current cargo being drawn (if cargo column has been passed).
 	 * @return row (in "pos" counting) after the one we have last drawn to.
 	 */
-	int DrawEntries(CargoDataEntry *entry, const Rect &r, int pos, int maxrows, int column, CargoID cargo = CT_INVALID)
+	int DrawEntries(CargoDataEntry *entry, const Rect &r, int pos, int maxrows, int column, CargoID cargo = INVALID_CARGO)
 	{
 		if (this->sortings[column] == CargoSortType::AsGrouping) {
 			if (this->groupings[column] != GR_CARGO) {

--- a/src/subsidy_base.h
+++ b/src/subsidy_base.h
@@ -20,7 +20,7 @@ extern SubsidyPool _subsidy_pool;
 
 /** Struct about subsidies, offered and awarded */
 struct Subsidy : SubsidyPool::PoolItem<&_subsidy_pool> {
-	CargoID cargo_type;  ///< Cargo type involved in this subsidy, CT_INVALID for invalid subsidy
+	CargoID cargo_type;  ///< Cargo type involved in this subsidy, INVALID_CARGO for invalid subsidy
 	uint16_t remaining;    ///< Remaining months when this subsidy is valid
 	CompanyID awarded;   ///< Subsidy is awarded to this company; INVALID_COMPANY if it's not awarded to anyone
 	SourceType src_type; ///< Source of subsidised path (SourceType::Industry or SourceType::Town)

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -273,7 +273,7 @@ static void GetCargoSummaryOfArticulatedVehicle(const Train *v, CargoSummary &su
 		if (!v->GetEngine()->CanCarryCargo()) continue;
 
 		CargoSummaryItem new_item;
-		new_item.cargo = v->cargo_cap > 0 ? v->cargo_type : (CargoID)CT_INVALID;
+		new_item.cargo = v->cargo_cap > 0 ? v->cargo_type : INVALID_CARGO;
 		new_item.subtype = GetCargoSubtypeText(v);
 		if (!IsValidCargoID(new_item.cargo) && new_item.subtype == STR_EMPTY) continue;
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1902,7 +1902,7 @@ bool CanBuildVehicleInfrastructure(VehicleType type, byte subtype)
  */
 LiveryScheme GetEngineLiveryScheme(EngineID engine_type, EngineID parent_engine_type, const Vehicle *v)
 {
-	CargoID cargo_type = v == nullptr ? (CargoID)CT_INVALID : v->cargo_type;
+	CargoID cargo_type = v == nullptr ? INVALID_CARGO : v->cargo_type;
 	const Engine *e = Engine::Get(engine_type);
 	switch (e->type) {
 		default: NOT_REACHED();

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -874,7 +874,7 @@ std::tuple<CommandCost, VehicleID> CmdCloneVehicle(DoCommandFlag flags, TileInde
 		if ((flags & DC_EXEC) && !v->IsPrimaryVehicle()) build_flags |= DC_AUTOREPLACE;
 
 		CommandCost cost;
-		std::tie(cost, new_veh_id, std::ignore, std::ignore, std::ignore) = Command<CMD_BUILD_VEHICLE>::Do(build_flags, tile, v->engine_type, false, CT_INVALID, INVALID_CLIENT_ID);
+		std::tie(cost, new_veh_id, std::ignore, std::ignore, std::ignore) = Command<CMD_BUILD_VEHICLE>::Do(build_flags, tile, v->engine_type, false, INVALID_CARGO, INVALID_CLIENT_ID);
 
 		if (cost.Failed()) {
 			/* Can't build a part, then sell the stuff we already made; clear up the mess */
@@ -953,7 +953,7 @@ std::tuple<CommandCost, VehicleID> CmdCloneVehicle(DoCommandFlag flags, TileInde
 				}
 			} else {
 				const Engine *e = v->GetEngine();
-				CargoID initial_cargo = (e->CanCarryCargo() ? e->GetDefaultCargoType() : (CargoID)CT_INVALID);
+				CargoID initial_cargo = (e->CanCarryCargo() ? e->GetDefaultCargoType() : INVALID_CARGO);
 
 				if (v->cargo_type != initial_cargo && IsValidCargoID(initial_cargo)) {
 					bool dummy;

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -245,16 +245,16 @@ void BaseVehicleListWindow::BuildVehicleList()
  */
 static bool CargoFilterSingle(const Vehicle *v, const CargoID cid)
 {
-	if (cid == BaseVehicleListWindow::CF_ANY) {
+	if (cid == CargoFilterCriteria::CF_ANY) {
 		return true;
-	} else if (cid == BaseVehicleListWindow::CF_NONE) {
+	} else if (cid == CargoFilterCriteria::CF_NONE) {
 		for (const Vehicle *w = v; w != nullptr; w = w->Next()) {
 			if (w->cargo_cap > 0) {
 				return false;
 			}
 		}
 		return true;
-	} else if (cid == BaseVehicleListWindow::CF_FREIGHT) {
+	} else if (cid == CargoFilterCriteria::CF_FREIGHT) {
 		bool have_capacity = false;
 		for (const Vehicle *w = v; w != nullptr; w = w->Next()) {
 			if (w->cargo_cap > 0) {
@@ -308,7 +308,7 @@ void BaseVehicleListWindow::SetCargoFilter(CargoID cid)
 	if (this->cargo_filter_criteria != cid) {
 		this->cargo_filter_criteria = cid;
 		/* Deactivate filter if criteria is 'Show All', activate it otherwise. */
-		this->vehgroups.SetFilterState(this->cargo_filter_criteria != CF_ANY);
+		this->vehgroups.SetFilterState(this->cargo_filter_criteria != CargoFilterCriteria::CF_ANY);
 		this->vehgroups.SetFilterType(0);
 		this->vehgroups.ForceRebuild();
 	}
@@ -319,9 +319,9 @@ void BaseVehicleListWindow::SetCargoFilter(CargoID cid)
  */
 void BaseVehicleListWindow::SetCargoFilterArray()
 {
-	this->cargo_filter_criteria = CF_ANY;
+	this->cargo_filter_criteria = CargoFilterCriteria::CF_ANY;
 	this->vehgroups.SetFilterFuncs(_filter_funcs);
-	this->vehgroups.SetFilterState(this->cargo_filter_criteria != CF_ANY);
+	this->vehgroups.SetFilterState(this->cargo_filter_criteria != CargoFilterCriteria::CF_ANY);
 }
 
 /**
@@ -372,9 +372,9 @@ void BaseVehicleListWindow::OnInit()
 StringID BaseVehicleListWindow::GetCargoFilterLabel(CargoID cid) const
 {
 	switch (cid) {
-		case CF_ANY: return STR_CARGO_TYPE_FILTER_ALL;
-		case CF_FREIGHT: return STR_CARGO_TYPE_FILTER_FREIGHT;
-		case CF_NONE: return STR_CARGO_TYPE_FILTER_NONE;
+		case CargoFilterCriteria::CF_ANY: return STR_CARGO_TYPE_FILTER_ALL;
+		case CargoFilterCriteria::CF_FREIGHT: return STR_CARGO_TYPE_FILTER_FREIGHT;
+		case CargoFilterCriteria::CF_NONE: return STR_CARGO_TYPE_FILTER_NONE;
 		default: return CargoSpec::Get(cid)->name;
 	}
 }
@@ -389,11 +389,11 @@ DropDownList BaseVehicleListWindow::BuildCargoDropDownList(bool full) const
 	DropDownList list;
 
 	/* Add item for disabling filtering. */
-	list.push_back(std::make_unique<DropDownListStringItem>(this->GetCargoFilterLabel(CF_ANY), CF_ANY, false));
+	list.push_back(std::make_unique<DropDownListStringItem>(this->GetCargoFilterLabel(CargoFilterCriteria::CF_ANY), CargoFilterCriteria::CF_ANY, false));
 	/* Add item for freight (i.e. vehicles with cargo capacity and with no passenger capacity). */
-	list.push_back(std::make_unique<DropDownListStringItem>(this->GetCargoFilterLabel(CF_FREIGHT), CF_FREIGHT, false));
+	list.push_back(std::make_unique<DropDownListStringItem>(this->GetCargoFilterLabel(CargoFilterCriteria::CF_FREIGHT), CargoFilterCriteria::CF_FREIGHT, false));
 	/* Add item for vehicles not carrying anything, e.g. train engines. */
-	list.push_back(std::make_unique<DropDownListStringItem>(this->GetCargoFilterLabel(CF_NONE), CF_NONE, false));
+	list.push_back(std::make_unique<DropDownListStringItem>(this->GetCargoFilterLabel(CargoFilterCriteria::CF_NONE), CargoFilterCriteria::CF_NONE, false));
 
 	/* Add cargos */
 	Dimension d = GetLargestCargoIconSize();

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -779,7 +779,7 @@ struct RefitWindow : public Window {
 	{
 		size_t scroll_row = 0;
 		size_t rows = 0;
-		CargoID cargo = this->selected_refit == nullptr ? (CargoID)CT_INVALID : this->selected_refit->cargo;
+		CargoID cargo = this->selected_refit == nullptr ? INVALID_CARGO : this->selected_refit->cargo;
 
 		for (const auto &pair : this->refit_list) {
 			if (pair.first == cargo) {

--- a/src/vehicle_gui_base.h
+++ b/src/vehicle_gui_base.h
@@ -73,13 +73,6 @@ struct BaseVehicleListWindow : public Window {
 		GB_END,
 	};
 
-	/** Special cargo filter criteria */
-	enum CargoFilterSpecialType {
-		CF_NONE = INVALID_CARGO,    ///< Show only vehicles which do not carry cargo (e.g. train engines)
-		CF_ANY = CT_NO_REFIT,       ///< Show all vehicles independent of carried cargo (i.e. no filtering)
-		CF_FREIGHT = CT_AUTO_REFIT, ///< Show only vehicles which carry any freight (non-passenger) cargo
-	};
-
 	GroupBy grouping;                           ///< How we want to group the list.
 	VehicleList vehicles;                       ///< List of vehicles.  This is the buffer for `vehgroups` to point into; if this is structurally modified, `vehgroups` must be rebuilt.
 	GUIVehicleGroupList vehgroups;              ///< List of (groups of) vehicles.  This stores iterators of `vehicles`, and should be rebuilt if `vehicles` is structurally changed.

--- a/src/vehicle_gui_base.h
+++ b/src/vehicle_gui_base.h
@@ -75,7 +75,7 @@ struct BaseVehicleListWindow : public Window {
 
 	/** Special cargo filter criteria */
 	enum CargoFilterSpecialType {
-		CF_NONE = CT_INVALID,       ///< Show only vehicles which do not carry cargo (e.g. train engines)
+		CF_NONE = INVALID_CARGO,    ///< Show only vehicles which do not carry cargo (e.g. train engines)
 		CF_ANY = CT_NO_REFIT,       ///< Show all vehicles independent of carried cargo (i.e. no filtering)
 		CF_FREIGHT = CT_AUTO_REFIT, ///< Show only vehicles which carry any freight (non-passenger) cargo
 	};


### PR DESCRIPTION
## Motivation / Problem

CT_INVALID is a CargoType but used like a CargoID. I previously unified these two as there were two names for the same thing, and this helped, however upon further inspection, I'm taking a different course.

There are also additional values used in places where CargoIDs are accepted, used for filtering UI lists, or used in spritegroup resolving tasks. These are (re-)defined in different source files and it's generally not clear how they relate.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Re-add INVALID_CARGO as a CargoID, and use it throughout the code where a CargoID is expected. Where a CargoType is expected (e.g. in defaults tables), continue using CT_INVALID. (This is not too well defined right now but will be addressed.)

Additionally, define all cargo IDs used by UI cargo filters in a single location, in a namespace to make their special use more distinct.

And do the same with CT_INVALID/CT_PURCHASE/CT_INVALID_NA.

I used namespaces instead of `enum class` as these do need to be compatible with CargoID.

(Some of this is part of #11719, but I think there is enough here to warrant a separate PR.)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
