### PR TITLE
Fix: [Script] Improve ScriptText validation

### DIFF
--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -268,9 +268,15 @@ static void ExtractStringParams(const StringData &data, StringParamsList &params
 			StringParams &param = params.emplace_back();
 			ParsedCommandStruct pcs = ExtractCommandString(ls->english.c_str(), false);
 
-			for (const CmdStruct *cs : pcs.consuming_commands) {
-				if (cs == nullptr) break;
-				param.emplace_back(GetParamType(cs), cs->consumes);
+			for (auto it = pcs.consuming_commands.begin(); it != pcs.consuming_commands.end(); it++) {
+				if (*it == nullptr) {
+					/* Skip empty param unless a non empty param exist after it. */
+					if (std::all_of(it, pcs.consuming_commands.end(), [](auto cs) { return cs == nullptr; })) break;
+					param.emplace_back(StringParam::UNUSED, 1, nullptr);
+					continue;
+				}
+				const CmdStruct *cs = *it;
+				param.emplace_back(GetParamType(cs), cs->consumes, cs->cmd);
 			}
 		}
 	}

--- a/src/game/game_text.hpp
+++ b/src/game/game_text.hpp
@@ -12,6 +12,7 @@
 
 struct StringParam {
 	enum ParamType {
+		UNUSED,
 		RAW_STRING,
 		STRING,
 		OTHER
@@ -19,8 +20,9 @@ struct StringParam {
 
 	ParamType type;
 	uint8_t consumes;
+	const char *cmd;
 
-	StringParam(ParamType type, uint8_t consumes) : type(type), consumes(consumes) {}
+	StringParam(ParamType type, uint8_t consumes, const char *cmd) : type(type), consumes(consumes), cmd(cmd) {}
 };
 using StringParams = std::vector<StringParam>;
 using StringParamsList = std::vector<StringParams>;

--- a/src/script/api/script_text.hpp
+++ b/src/script/api/script_text.hpp
@@ -130,10 +130,30 @@ public:
 private:
 	using ScriptTextRef = ScriptObjectRef<ScriptText>;
 	using StringIDList = std::vector<StringID>;
+	using Param = std::variant<SQInteger, std::string, ScriptTextRef>;
+
+	struct ParamCheck {
+		StringID owner;
+		int idx;
+		Param *param;
+
+		ParamCheck(StringID owner, int idx, Param *param) : owner(owner), idx(idx), param(param) {}
+	};
+
+	using ParamList = std::vector<ParamCheck>;
+	using ParamSpan = std::span<ParamCheck>;
 
 	StringID string;
-	std::variant<SQInteger, std::string, ScriptTextRef> param[SCRIPT_TEXT_MAX_PARAMETERS];
+	Param param[SCRIPT_TEXT_MAX_PARAMETERS];
 	int paramc;
+
+	/**
+	 * Internal function to recursively fill a list of parameters.
+	 * The parameters are added as _GetEncodedText used to encode them
+	 *  before the addition of parameter validation.
+	 * @param params The list of parameters to fill.
+	 */
+	void _FillParamList(ParamList &params);
 
 	/**
 	 * Internal function for recursive calling this function over multiple
@@ -142,7 +162,7 @@ private:
 	 * @param param_count The number of parameters that are in the string.
 	 * @param seen_ids The list of seen StringID.
 	 */
-	void _GetEncodedText(std::back_insert_iterator<std::string> &output, int &param_count, StringIDList &seen_ids);
+	void _GetEncodedText(std::back_insert_iterator<std::string> &output, int &param_count, StringIDList &seen_ids, ParamSpan args);
 
 	/**
 	 * Set a parameter, where the value is the first item on the stack.


### PR DESCRIPTION
## Motivation / Problem
While running some GS to see how they are affected by ScriptText validation [awards v8](https://bananas.openttd.org/package/game-script/41574453) crashed with `Your script made an error: STR_RANK: Not enough parameters`.
It's because it uses constructs that used to work, producing a valid encoded string (`\SCC_ENCODED4:\SCC_ENCODED13:1:0:0`)
```
	res = GSText(GSText.STR_GREEN);
	res.AddParam(GSText(GSText.STR_RANK));
	res.AddParam(counter);
	res.AddParam(comp);
	res.AddParam(points);
```
with
```
STR_GREEN		: {GREEN}{STRING}
STR_RANK		: {NUM} - {COMPANY} with {NUM} points
```

But that doesn't pass the "strict" validation.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Current validation checks types only for the parameters of the current string, and disables the checks for extra parameters coming from substrings. So it needs to be reworked to actually validate all parameters, and also accept things that used to work (even if the usage is incorrect).

So I reworked the validation process to use two steps:
- First we get list of the parameters in the same order they used to be in encoded string. That way GSTexts that used to work before introduction of validation should still work.
- The second step encodes the string like it used to be, but each parameter is validated as FormatString would use them.

Holes in parameters are now allowed, IIRC some GS use paramindex to work around their improper STRING/STRINGN usage.

I rewrote the messages to be more helpful:
- param numbers are 1-indexed to match SetParam() syntax.
- the string command is shown in the message.
- the expected/consumed mismatch message is more explicit.
- when a GSText consumes parameters other than its own, this is explicit too.

And now `awards` GS works as it used to (with extra messages in script log because it doesn't conform to the expected usage).

Also my previous test
```
		local text = GSText(GSText.STR_TEST);
		text.SetParam(1, GSText(GSText.STR_FOO, "foo"));
		text.SetParam(2, GSWindow.TC_RED);
		text.SetParam(3, 42);
		GSTown.SetText(0, text);
```
and
```
STR_TEST :{STRING} - {COLOUR}{NUM} is supposed to be 42
STR_FOO  :'{RAW_STRING}'
```
Now fails with
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/3a3df841-d688-495e-b37a-9a1c2bbff80f)
instead of showing a "broken" string
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/827dfc9a-c39d-4e8e-bc0e-7dfc520629bd)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
