### PR TITLE
Cleanup: Remove unused constant YAPF_SHIP_PATH_CACHE_LENGTH

### DIFF
--- a/src/pathfinder/pathfinder_type.h
+++ b/src/pathfinder/pathfinder_type.h
@@ -39,9 +39,6 @@ static const int YAPF_TILE_CORNER_LENGTH = 71;
  */
 static const int YAPF_INFINITE_PENALTY = 1000 * YAPF_TILE_LENGTH;
 
-/** Maximum length of ship path cache */
-static const int YAPF_SHIP_PATH_CACHE_LENGTH = 32;
-
 /** Maximum segments of road vehicle path cache */
 static const int YAPF_ROADVEH_PATH_CACHE_SEGMENTS = 8;
 


### PR DESCRIPTION
## Motivation / Problem

The constant `YAPF_SHIP_PATH_CACHE_LENGTH` is now unused.

## Description

Remove it.

#11742 - attempt 2

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
