### PR TITLE
Fix #11748: Incorrect clamping of negative service interval values

### DIFF
--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1849,7 +1849,7 @@ void DeleteVehicleOrders(Vehicle *v, bool keep_orderlist, bool reset_order_indic
  * @param interval proposed service interval
  * @return Clamped service interval
  */
-uint16_t GetServiceIntervalClamped(uint interval, bool ispercent)
+uint16_t GetServiceIntervalClamped(int interval, bool ispercent)
 {
 	return ispercent ? Clamp(interval, MIN_SERVINT_PERCENT, MAX_SERVINT_PERCENT) : Clamp(interval, MIN_SERVINT_DAYS, MAX_SERVINT_DAYS);
 }

--- a/src/order_func.h
+++ b/src/order_func.h
@@ -37,6 +37,6 @@ static const uint DEF_SERVINT_PERCENT = 50;
 static const uint MIN_SERVINT_PERCENT = 5;
 static const uint MAX_SERVINT_PERCENT = 90;
 
-uint16_t GetServiceIntervalClamped(uint interval, bool ispercent);
+uint16_t GetServiceIntervalClamped(int interval, bool ispercent);
 
 #endif /* ORDER_FUNC_H */


### PR DESCRIPTION
Fixes #11748

## Motivation / Problem
When clicking on "decrease" while current service interval is 5% it jumps to 90%.
https://github.com/OpenTTD/OpenTTD/blob/86b046cd26a67c1a216e5487ff72c91f80d8e4d0/src/vehicle_gui.cpp#L2616
`mod` is -10, `v->GetServiceInterval()` is 5 so -5 is passed to `GetServiceIntervalClamped()`
https://github.com/OpenTTD/OpenTTD/blob/86b046cd26a67c1a216e5487ff72c91f80d8e4d0/src/order_cmd.cpp#L1852-L1855
`GetServiceIntervalClamped()` takes an uint so the -5 is actually a huge positive number and it's clamped to 90.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Use `int` for the clamping in `GetServiceIntervalClamped()`.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
