### PR TITLE
Change: simplified water region evaluation, removed savegame data

### DIFF
--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -35,7 +35,6 @@
 #include "string_func.h"
 #include "thread.h"
 #include "tgp.h"
-#include "pathfinder/water_regions.h"
 
 #include "safeguards.h"
 
@@ -172,8 +171,6 @@ static void _GenerateWorld()
 				}
 			}
 		}
-
-		InitializeWaterRegions();
 
 		BasePersistentStorageArray::SwitchMode(PSM_LEAVE_GAMELOOP);
 

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -36,6 +36,7 @@
 #include "landscape_cmd.h"
 #include "terraform_cmd.h"
 #include "station_func.h"
+#include "pathfinder/water_regions.h"
 
 #include "table/strings.h"
 #include "table/sprites.h"
@@ -538,6 +539,8 @@ void DoClearSquare(TileIndex tile)
 	MakeClear(tile, CLEAR_GRASS, _generating_world ? 3 : 0);
 	MarkTileDirtyByTile(tile);
 	if (remove) RemoveDockingTile(tile);
+
+	InvalidateWaterRegion(tile);
 }
 
 /**

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -13,6 +13,7 @@
 #include "water_map.h"
 #include "error_func.h"
 #include "string_func.h"
+#include "pathfinder/water_regions.h"
 
 #include "safeguards.h"
 
@@ -62,6 +63,8 @@ extern "C" _CRTIMP void __cdecl _assert(void *, void *, unsigned);
 
 	Tile::base_tiles = CallocT<Tile::TileBase>(Map::size);
 	Tile::extended_tiles = CallocT<Tile::TileExtended>(Map::size);
+
+	AllocateWaterRegions();
 }
 
 

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -35,6 +35,7 @@
 #include "station_func.h"
 #include "object_cmd.h"
 #include "landscape_cmd.h"
+#include "pathfinder/water_regions.h"
 
 #include "table/strings.h"
 #include "table/object_land.h"
@@ -362,6 +363,7 @@ CommandCost CmdBuildObject(DoCommandFlag flags, TileIndex tile, ObjectType type,
 
 	if (flags & DC_EXEC) {
 		BuildObject(type, tile, _current_company == OWNER_DEITY ? OWNER_NONE : _current_company, nullptr, view);
+		for (TileIndex t : ta) InvalidateWaterRegion(t);
 
 		/* Make sure the HQ starts at the right size. */
 		if (type == OBJECT_HQ) UpdateCompanyHQ(tile, hq_score);

--- a/src/pathfinder/water_regions.h
+++ b/src/pathfinder/water_regions.h
@@ -60,14 +60,6 @@ void InvalidateWaterRegion(TileIndex tile);
 using TVisitWaterRegionPatchCallBack = std::function<void(const WaterRegionPatchDesc &)>;
 void VisitWaterRegionPatchNeighbors(const WaterRegionPatchDesc &water_region_patch, TVisitWaterRegionPatchCallBack &callback);
 
-void InitializeWaterRegions();
-
-struct WaterRegionSaveLoadInfo
-{
-	bool initialized;
-};
-
-std::vector<WaterRegionSaveLoadInfo> GetWaterRegionSaveLoadInfo();
-void LoadWaterRegions(const std::vector<WaterRegionSaveLoadInfo> &save_load_info);
+void AllocateWaterRegions();
 
 #endif /* WATER_REGIONS_H */

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -61,7 +61,6 @@
 #include "../timer/timer.h"
 #include "../timer/timer_game_calendar.h"
 #include "../timer/timer_game_tick.h"
-#include "../pathfinder/water_regions.h"
 
 #include "saveload_internal.h"
 
@@ -3296,8 +3295,6 @@ bool AfterLoadGame()
 			c->settings = _settings_client.company;
 		}
 	}
-
-	if (IsSavegameVersionBefore(SLV_WATER_REGIONS)) InitializeWaterRegions();
 
 	return true;
 }

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -367,6 +367,8 @@ enum SaveLoadVersion : uint16_t {
 	SLV_TIMETABLE_TICKS_TYPE,               ///< 323  PR#11435 Convert timetable current order time to ticks.
 	SLV_WATER_REGIONS,                      ///< 324  PR#10543 Water Regions for ship pathfinder.
 
+	SLV_WATER_REGION_EVAL_SIMPLIFIED,       ///< 325  PR#11750 Simplified Water Region evaluation.
+
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
 

--- a/src/saveload/water_regions_sl.cpp
+++ b/src/saveload/water_regions_sl.cpp
@@ -10,45 +10,23 @@
 #include "../stdafx.h"
 
 #include "saveload.h"
-#include "pathfinder/water_regions.h"
 
 #include "../safeguards.h"
 
-static const SaveLoad _water_region_desc[] = {
-	SLE_VAR(WaterRegionSaveLoadInfo, initialized, SLE_BOOL),
-};
+extern void SlSkipArray();
 
-struct WRGNChunkHandler : ChunkHandler {
-	WRGNChunkHandler() : ChunkHandler('WRGN', CH_TABLE) {}
-
-	void Save() const override
-	{
-		SlTableHeader(_water_region_desc);
-
-		int index = 0;
-		for (WaterRegionSaveLoadInfo &region : GetWaterRegionSaveLoadInfo()) {
-			SlSetArrayIndex(index++);
-			SlObject(&region, _water_region_desc);
-		}
-	}
+/* Water Region savegame data is no longer used, but still needed for old savegames to load without errors. */
+struct WaterRegionChunkHandler : ChunkHandler {
+	WaterRegionChunkHandler() : ChunkHandler('WRGN', CH_READONLY)
+	{}
 
 	void Load() const override
 	{
-		const std::vector<SaveLoad> slt = SlTableHeader(_water_region_desc);
-
-		int index;
-
-		std::vector<WaterRegionSaveLoadInfo> loaded_info;
-		while ((index = SlIterateArray()) != -1) {
-			WaterRegionSaveLoadInfo region_info;
-			SlObject(&region_info, slt);
-			loaded_info.push_back(std::move(region_info));
-		}
-
-		LoadWaterRegions(loaded_info);
-	}
+		SlTableHeader({});
+		SlSkipArray();
+	};
 };
 
-static const WRGNChunkHandler WRGN;
+static const WaterRegionChunkHandler WRGN;
 static const ChunkHandlerRef water_region_chunk_handlers[] = { WRGN };
 extern const ChunkHandlerTable _water_region_chunk_handlers(water_region_chunk_handlers);

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -562,8 +562,6 @@ CommandCost CmdBuildBridge(DoCommandFlag flags, TileIndex tile_end, TileIndex ti
 				MakeAqueductBridgeRamp(tile_end,   owner, ReverseDiagDir(dir));
 				CheckForDockingTile(tile_start);
 				CheckForDockingTile(tile_end);
-				InvalidateWaterRegion(tile_start);
-				InvalidateWaterRegion(tile_end);
 				break;
 
 			default:

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -134,9 +134,6 @@ CommandCost CmdBuildShipDepot(DoCommandFlag flags, TileIndex tile, Axis axis)
 	}
 
 	if (flags & DC_EXEC) {
-		InvalidateWaterRegion(tile);
-		InvalidateWaterRegion(tile2);
-
 		Depot *depot = new Depot(tile);
 		depot->build_date = TimerGameCalendar::date;
 
@@ -247,7 +244,6 @@ void MakeWaterKeepingClass(TileIndex tile, Owner o)
 
 	/* Zero map array and terminate animation */
 	DoClearSquare(tile);
-	InvalidateWaterRegion(tile);
 
 	/* Maybe change to water */
 	switch (wc) {
@@ -345,10 +341,6 @@ static CommandCost DoBuildLock(TileIndex tile, DiagDirection dir, DoCommandFlag 
 	}
 
 	if (flags & DC_EXEC) {
-		InvalidateWaterRegion(tile);
-		InvalidateWaterRegion(tile + delta);
-		InvalidateWaterRegion(tile - delta);
-
 		/* Update company infrastructure counts. */
 		Company *c = Company::GetIfValid(_current_company);
 		if (c != nullptr) {
@@ -491,8 +483,6 @@ CommandCost CmdBuildCanal(DoCommandFlag flags, TileIndex tile, TileIndex start_t
 		if (!water) cost.AddCost(ret);
 
 		if (flags & DC_EXEC) {
-			InvalidateWaterRegion(current_tile);
-
 			if (IsTileType(current_tile, MP_WATER) && IsCanal(current_tile)) {
 				Owner owner = GetTileOwner(current_tile);
 				if (Company::IsValidID(owner)) {
@@ -543,8 +533,6 @@ CommandCost CmdBuildCanal(DoCommandFlag flags, TileIndex tile, TileIndex start_t
 
 static CommandCost ClearTile_Water(TileIndex tile, DoCommandFlag flags)
 {
-	if (flags & DC_EXEC) InvalidateWaterRegion(tile);
-
 	switch (GetWaterTileType(tile)) {
 		case WATER_TILE_CLEAR: {
 			if (flags & DC_NO_WATER) return_cmd_error(STR_ERROR_CAN_T_BUILD_ON_WATER);
@@ -1175,8 +1163,6 @@ void DoFloodTile(TileIndex target)
 	}
 
 	if (flooded) {
-		InvalidateWaterRegion(target);
-
 		/* Mark surrounding canal tiles dirty too to avoid glitches */
 		MarkCanalsAndRiversAroundDirty(target);
 

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -347,7 +347,6 @@ CommandCost CmdBuildBuoy(DoCommandFlag flags, TileIndex tile)
 		if (wp->town == nullptr) MakeDefaultName(wp);
 
 		MakeBuoy(tile, wp->index, GetWaterClass(tile));
-		InvalidateWaterRegion(tile);
 		CheckForDockingTile(tile);
 		MarkTileDirtyByTile(tile);
 


### PR DESCRIPTION
## Motivation / Problem

This is closely related to the recently merged region-based ship pathfinder https://github.com/OpenTTD/OpenTTD/pull/10543

There was some discussion with @JGRennison and @SamuXarick on discord, there were worries about desyncs. In 10543 I've tried to prevent desyncs by saving the "is the region initialized "state of all regions in the savegame. The idea was to synchronize the "initialized-ness" in a bug-compatible way, meaning that if it wasn't initialized on the server then it wouldn't be initialized on the joining client either. But this is what can happen:

- server starts a game
- some action, say terraforming, doesn't properly invalidate water region X. Region X is now incorrectly marked as up-to-date.
- a client joins the game. The client needs to scan / label (i.e. update) all water regions that are labeled as up-to-date. This should put the client's water region cache in sync with the one on the server...
- ... but the cache on the server is corrupted, because the "up-to-dateness" of region X is incorrectly set to true. Region X on the server has a different state than region X on the client. This could leads to desyncs.

The current solution of syncing the up-to-date-state of the regions simply doesn't solve this.

Link to discord: https://discord.com/channels/142724111502802944/1008473233844097104/1194656849237127308

## Description

So I'm taking a slightly more simple and brute force approach: *invalidate a water region on any change*. This includes changes to tiles that might not be entirely relevant to the water regions. This by itself shouldn't really have big impact on performance, region invalidation is just a matter of setting a boolean.

## Limitations

- This approach will invalidate more regions than necessary, which in turn will cause more water regions having to update (re-do their connected component labeling). This will have some impact on performance, but I don't think it will be significant.
- I lowered the savegame version and removed the region data from the savegame. This will render some savegames incompatible, but only ones that were created with recent builds or the nightlies. I can change this if that's not acceptable.
- There's some debug code that's nice for testing, but ultimately has to be removed.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
