### PR TITLE
Fix #11485: new run on same line must not use last_space of previous run

### DIFF
--- a/src/gfx_layout_fallback.cpp
+++ b/src/gfx_layout_fallback.cpp
@@ -256,6 +256,11 @@ std::unique_ptr<const ParagraphLayouter::Line> FallbackParagraphLayout::NextLine
 
 			next_run = this->buffer_begin + iter->first;
 			begin = this->buffer;
+			/* Since a next run is started, there is already some text that
+			 * will be shown for this line. However, we do not want to break
+			 * this line at the previous space, so pretend we passed a space
+			 * just before this next run. */
+			last_space = begin - 1;
 		}
 
 		if (IsWhitespace(c)) last_space = this->buffer;


### PR DESCRIPTION
## Motivation / Problem

Fixes #11485.

The fallback layout "next line" function maintains a `last_space` variable with the location of the last space. When that variable is not `nullptr`, the start point for the next line will be reset to the location of the last space.
When the font colour changes, there is a new so-called `run`. At that point the line up to the `run` is added to the flowed strings. Then it will continue in the new run at the first character. If that character causes the line to become too long, the start point for the next line is set to the location of the last space, which is before the run.

The result is that the last bit of the previous run is going to be output on the following line as well. Even worse, in theory when the window is just narrow enough (or the word without spaces long enough), this could go on infinitely.


## Description

Set `last_space` to fake that there is a space just before the new run started.


## Limitations

This will cause that punctuation after a new run starts might not be placed on the same line as the end of the previous run. In other words, the full stop might end up on the next line. Fixing that is a whole can of worms that I do not want to touch.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
