### PR TITLE
Fix #11123: Land info build date is also renovation date

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3017,7 +3017,7 @@ STR_LAND_AREA_INFORMATION_RAIL_OWNER                            :{BLACK}Railway 
 STR_LAND_AREA_INFORMATION_LOCAL_AUTHORITY                       :{BLACK}Local authority: {LTBLUE}{STRING1}
 STR_LAND_AREA_INFORMATION_LOCAL_AUTHORITY_NONE                  :None
 STR_LAND_AREA_INFORMATION_LANDINFO_COORDS                       :{BLACK}Coordinates: {LTBLUE}{NUM} x {NUM} x {NUM} ({RAW_STRING})
-STR_LAND_AREA_INFORMATION_BUILD_DATE                            :{BLACK}Built: {LTBLUE}{DATE_LONG}
+STR_LAND_AREA_INFORMATION_BUILD_DATE                            :{BLACK}Built/renovated: {LTBLUE}{DATE_LONG}
 STR_LAND_AREA_INFORMATION_STATION_CLASS                         :{BLACK}Station class: {LTBLUE}{STRING}
 STR_LAND_AREA_INFORMATION_STATION_TYPE                          :{BLACK}Station type: {LTBLUE}{STRING}
 STR_LAND_AREA_INFORMATION_AIRPORT_CLASS                         :{BLACK}Airport class: {LTBLUE}{STRING}


### PR DESCRIPTION
## Motivation / Problem
_Originally posted by @DorpsGek in https://github.com/OpenTTD/OpenTTD/issues/4415#issuecomment-379443968_

> We could ofcourse opt to be obnoxiously specific about what the date means: "Date at which the last construction or rebuilt at this station took place". But that bloats the interface for no good reason.
> 
> We actually need to update the build date as it's used by NewGRFs and TTDPatch/OpenTTD have behaved for a decade like this, thus changing it would break quite a few NewGRFs. Even then it would be wrong given the former example.
> 

_Originally posted by me in https://github.com/OpenTTD/OpenTTD/issues/11123_
> Suggestion for "unfixable" station date "issue"

>How about "Last build/renovation date" or even "Build/renovation date"? Shorter, just as accurate and not that hard to implement, unless I'm mistaken?
> I get this is an old and unjustified "issue", feel free to close this immediately if the suggestion isn't useful.

_**When a station layout is modified in any way, the "Built: YYYY" section of the station's land info is also the renovation date. While fixing it properly would not be trivial, I propose a simpler short-term solution.**_

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Just change the basic string from "Built" to "Built/last renovated" or possibly "Most recent construction". 2TallTyler suggested "Built/renovated" to be as short as possible.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

I added a minor change to the language file. Apparently I forgot to submit it.

## Limitations
A more long-term solution is to record the original construction date and then also record the most recent renovation, but nothing in-between (it doesn't seem like anyone needs a history of the whole station).
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)