### PR TITLE
Fix: [CI] unbreak Linux releases by using a slightly older rust-cache action

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -50,7 +50,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
 
     - name: Enable Rust cache
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@v2.7.0
 
     - name: Setup vcpkg caching
       uses: actions/github-script@v6


### PR DESCRIPTION
## Motivation / Problem

Fixes #11756

Linux release broke.

## Description

The maintainer bumped node16 -> node20 in a patch version, which is a bit awkward for us, as we can't run node20 in this workflow (yet). Most other actions used a major version for that, and for similar reasons we cannot upgrade "download-artifact" to v4.

This is a temporary solution, while we start looking into how to support node20 in this workflow.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
