### PR TITLE
Fix #4415: Land info build date is also renovation date

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3017,7 +3017,7 @@ STR_LAND_AREA_INFORMATION_RAIL_OWNER                            :{BLACK}Railway 
 STR_LAND_AREA_INFORMATION_LOCAL_AUTHORITY                       :{BLACK}Local authority: {LTBLUE}{STRING1}
 STR_LAND_AREA_INFORMATION_LOCAL_AUTHORITY_NONE                  :None
 STR_LAND_AREA_INFORMATION_LANDINFO_COORDS                       :{BLACK}Coordinates: {LTBLUE}{NUM} x {NUM} x {NUM} ({RAW_STRING})
-STR_LAND_AREA_INFORMATION_BUILD_DATE                            :{BLACK}Built: {LTBLUE}{DATE_LONG}
+STR_LAND_AREA_INFORMATION_BUILD_DATE                            :{BLACK}Built/renovated: {LTBLUE}{DATE_LONG}
 STR_LAND_AREA_INFORMATION_STATION_CLASS                         :{BLACK}Station class: {LTBLUE}{STRING}
 STR_LAND_AREA_INFORMATION_STATION_TYPE                          :{BLACK}Station type: {LTBLUE}{STRING}
 STR_LAND_AREA_INFORMATION_AIRPORT_CLASS                         :{BLACK}Airport class: {LTBLUE}{STRING}


### PR DESCRIPTION
## Motivation / Problem

Sometime in the distant past, #4415 reported that when you modify a station, it updates the build date of the entire station, and this is confusing in the land info tool.

That issue was closed as a "won't fix" with the reasoning that we can't change it without breaking NewGRFs.

@Gadg8eer proposed that we change the string of the land info tool to explain that it's also the renovation date, but had Git issues so I thought I'd help out. 😉 

## Description

Change the land info tool from `Built:` to `Built/renovated:` to accurately describe what date is shown. This is shown and accurate for:
* Stations
* Waypoints
* Objects

The only other things which show a build date (to my knowledge) are depots. These can be overbuilt since #9642, but this does not update the build date, so I guess this is not considered renovation. Nor are build dates updated for any infrastructure type when the railtype or roadtype is changed.

Closes #11757.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
