### PR TITLE
Fix #11752: [Win32] Wrong multi-line text layout due to incorrect partial run handling

### DIFF
--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -415,7 +415,7 @@ static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutF
 		UniscribeRun run = *i_run;
 
 		/* Partial run after line break (either start or end)? Reshape run to get the first/last glyphs right. */
-		if (i_run == last_run - 1 && remaining_offset < (last_run - 1)->len) {
+		if (i_run == last_run - 1 && remaining_offset <= (last_run - 1)->len) {
 			run.len = remaining_offset - 1;
 
 			if (!UniscribeShapeRun(this->text_buffer, run)) return nullptr;


### PR DESCRIPTION
Fixes #11752

## Motivation / Problem
Some characters are repeated when inserting line breaks.
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/ab7e7ceb-3e11-47df-aa44-a4ace8465be9)
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/7617e5f6-62b1-4dcf-9905-e49d4205c88b)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Detection of partial run end was off by one.
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/b87de259-565c-4b18-aa69-4ba9103d742e)
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/129f3ebe-2e4c-4924-80fc-bf773dc01558)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
