### PR TITLE
Codechange: Remove unnecessary vector for writing GRF parameter JSON

### DIFF
--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -338,12 +338,7 @@ void SurveyGrfs(nlohmann::json &survey)
 		if ((c->palette & GRFP_BLT_MASK) == GRFP_BLT_32BPP) grf["blitter"] = "32bpp";
 
 		grf["is_static"] = HasBit(c->flags, GCF_STATIC);
-
-		std::vector<uint32_t> parameters;
-		for (int i = 0; i < c->num_params; i++) {
-			parameters.push_back(c->param[i]);
-		}
-		grf["parameters"] = parameters;
+		grf["parameters"] = span<const uint32_t>(c->param.data(), c->num_params);
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem

Remove unnecessary temporary vector for writing GRF parameter JSON.

## Description

Use a const span instead.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
