### PR TITLE
Fix #11696: Graphics set parameters missing from survey data

### DIFF
--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -248,6 +248,12 @@ void SurveyConfiguration(nlohmann::json &survey)
 	}
 	if (BaseGraphics::GetUsedSet() != nullptr) {
 		survey["graphics_set"] = fmt::format("{}.{}", BaseGraphics::GetUsedSet()->name, BaseGraphics::GetUsedSet()->version);
+		const GRFConfig *extra_cfg = BaseGraphics::GetUsedSet()->GetExtraConfig();
+		if (extra_cfg != nullptr && extra_cfg->num_params > 0) {
+			survey["graphics_set_parameters"] = span<const uint32_t>(extra_cfg->param.data(), extra_cfg->num_params);
+		} else {
+			survey["graphics_set_parameters"] = span<const uint32_t>();
+		}
 	}
 	if (BaseMusic::GetUsedSet() != nullptr) {
 		survey["music_set"] = fmt::format("{}.{}", BaseMusic::GetUsedSet()->name, BaseMusic::GetUsedSet()->version);


### PR DESCRIPTION
## Motivation / Problem

#11696

## Description

Add graphics set parameters which were previous missing from survey data.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
