### PR TITLE
Add: Support zero-width space {ZWSP} to indicate where strings may additionally break

### DIFF
--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -93,6 +93,8 @@ static inline void GetLayouter(Layouter::LineCacheItem &line, std::string_view s
 			state.PopColour();
 		} else if (c >= SCC_FIRST_FONT && c <= SCC_LAST_FONT) {
 			state.SetFontSize((FontSize)(c - SCC_FIRST_FONT));
+		} else if (c == 0x200B) {
+			/* Zero-width space. */
 		} else {
 			/* Filter out non printable characters */
 			if (!IsPrintable(c)) continue;

--- a/src/table/strgen_tables.h
+++ b/src/table/strgen_tables.h
@@ -140,6 +140,7 @@ static const CmdStruct _cmd_structs[] = {
 	{"RIGHT_ARROW",       EmitSingleChar, SCC_RIGHT_ARROW,        0, -1, C_DONTCOUNT},
 	{"SMALL_LEFT_ARROW",  EmitSingleChar, SCC_LESS_THAN,          0, -1, C_DONTCOUNT},
 	{"SMALL_RIGHT_ARROW", EmitSingleChar, SCC_GREATER_THAN,       0, -1, C_DONTCOUNT},
+	{"ZWSP",              EmitSingleChar, 0x200B,                 0, -1, C_DONTCOUNT},
 
 	/* The following are directional formatting codes used to get the RTL strings right:
 	 * http://www.unicode.org/unicode/reports/tr9/#Directional_Formatting_Codes */


### PR DESCRIPTION
## Motivation / Problem

Non-Latin translations may use characters after which a break could be made, which are not treated as breaking characters, e.g. `：` instead of `:`. As an example the string:

`STR_NEWGRF_SETTINGS_FILENAME                                    :{BLACK}文件名：{SILVER}{STRING}`

may be wrapped as

```
文件
名：filename
```

instead of

```
文件名：
filename
```

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add support for zero-width space as `{ZWSP}`. This allows translators to continue using non-ascii symbols like `：` instead of `: `.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Probably requires modifications to eints, and some how translators need to know this is an option.

I've tested this as far as I can, but ICU already seems to wrap after `：`.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
