### PR TITLE
Fix #5713: FindClosestShipDepot only considers depots that are actually reachable

### DIFF
--- a/src/pathfinder/water_regions.cpp
+++ b/src/pathfinder/water_regions.cpp
@@ -24,6 +24,7 @@ constexpr TWaterRegionPatchLabel FIRST_REGION_LABEL = 1;
 constexpr TWaterRegionPatchLabel INVALID_WATER_REGION_PATCH = 0;
 
 static_assert(sizeof(TWaterRegionTraversabilityBits) * 8 == WATER_REGION_EDGE_LENGTH);
+static_assert(sizeof(TWaterRegionPatchLabel) == sizeof(byte)); // Important for the hash calculation.
 
 static inline TrackBits GetWaterTracks(TileIndex tile) { return TrackStatusToTrackBits(GetTileTrackStatus(tile, TRANSPORT_WATER, 0)); }
 static inline bool IsAqueductTile(TileIndex tile) { return IsBridgeTile(tile) && GetTunnelBridgeTransportType(tile) == TRANSPORT_WATER; }
@@ -223,12 +224,21 @@ WaterRegion &GetUpdatedWaterRegion(TileIndex tile)
 }
 
 /**
- * Returns the index of the water region
- * @param water_region The Water region to return the index for
+ * Returns the index of the water region.
+ * @param water_region The water region to return the index for.
  */
 TWaterRegionIndex GetWaterRegionIndex(const WaterRegionDesc &water_region)
 {
 	return GetWaterRegionIndex(water_region.x, water_region.y);
+}
+
+/**
+ * Calculates a number that uniquely identifies the provided water region patch.
+ * @param water_region_patch The Water region to calculate the hash for.
+ */
+int CalculateWaterRegionPatchHash(const WaterRegionPatchDesc &water_region_patch)
+{
+	return water_region_patch.label | GetWaterRegionIndex(water_region_patch) << 8;
 }
 
 /**

--- a/src/pathfinder/water_regions.h
+++ b/src/pathfinder/water_regions.h
@@ -50,6 +50,8 @@ struct WaterRegionDesc
 
 TWaterRegionIndex GetWaterRegionIndex(const WaterRegionDesc &water_region);
 
+int CalculateWaterRegionPatchHash(const WaterRegionPatchDesc &water_region_patch);
+
 TileIndex GetWaterRegionCenterTile(const WaterRegionDesc &water_region);
 
 WaterRegionDesc GetWaterRegionInfo(TileIndex tile);

--- a/src/pathfinder/yapf/yapf_ship_regions.cpp
+++ b/src/pathfinder/yapf/yapf_ship_regions.cpp
@@ -24,14 +24,12 @@ constexpr int MAX_NUMBER_OF_NODES = 65536;
 struct CYapfRegionPatchNodeKey {
 	WaterRegionPatchDesc m_water_region_patch;
 
-	static_assert(sizeof(TWaterRegionPatchLabel) == sizeof(byte)); // Important for the hash calculation.
-
 	inline void Set(const WaterRegionPatchDesc &water_region_patch)
 	{
 		m_water_region_patch = water_region_patch;
 	}
 
-	inline int CalcHash() const { return m_water_region_patch.label | GetWaterRegionIndex(m_water_region_patch) << 8; }
+	inline int CalcHash() const { return CalculateWaterRegionPatchHash(m_water_region_patch); }
 	inline bool operator==(const CYapfRegionPatchNodeKey &other) const { return CalcHash() == other.CalcHash(); }
 };
 

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -18,6 +18,7 @@
 #include "station_base.h"
 #include "newgrf_engine.h"
 #include "pathfinder/yapf/yapf.h"
+#include "pathfinder/yapf/yapf_ship_regions.h"
 #include "newgrf_sound.h"
 #include "spritecache.h"
 #include "strings_func.h"
@@ -38,7 +39,12 @@
 
 #include "table/strings.h"
 
+#include <unordered_set>
+
 #include "safeguards.h"
+
+/** Max distance in tiles (as the crow flies) to search for depots when user clicks "go to depot". */
+constexpr int MAX_SHIP_DEPOT_SEARCH_DISTANCE = 80;
 
 /**
  * Determine the effective #WaterClass for a ship travelling on a tile.
@@ -144,21 +150,49 @@ void Ship::GetImage(Direction direction, EngineImageType image_type, VehicleSpri
 
 static const Depot *FindClosestShipDepot(const Vehicle *v, uint max_distance)
 {
-	/* Find the closest depot */
-	const Depot *best_depot = nullptr;
-	/* If we don't have a maximum distance, i.e. distance = 0,
-	 * we want to find any depot so the best distance of no
-	 * depot must be more than any correct distance. On the
-	 * other hand if we have set a maximum distance, any depot
-	 * further away than max_distance can safely be ignored. */
-	uint best_dist = max_distance == 0 ? UINT_MAX : max_distance + 1;
+	const int max_region_distance = (max_distance / WATER_REGION_EDGE_LENGTH) + 1;
 
+	static std::unordered_set<int> visited_patch_hashes;
+	static std::deque<WaterRegionPatchDesc> patches_to_search;
+	visited_patch_hashes.clear();
+	patches_to_search.clear();
+
+	/* Step 1: find a set of reachable Water Region Patches using BFS. */
+	const WaterRegionPatchDesc start_patch = GetWaterRegionPatchInfo(v->tile);
+	patches_to_search.push_back(start_patch);
+	visited_patch_hashes.insert(CalculateWaterRegionPatchHash(start_patch));
+
+	while (!patches_to_search.empty()) {
+		/* Remove first patch from the queue and make it the current patch. */
+		const WaterRegionPatchDesc current_node = patches_to_search.front();
+		patches_to_search.pop_front();
+
+		/* Add neighbors of the current patch to the search queue. */
+		TVisitWaterRegionPatchCallBack visitFunc = [&](const WaterRegionPatchDesc &water_region_patch) {
+			/* Note that we check the max distance per axis, not the total distance. */
+			if (std::abs(water_region_patch.x - start_patch.x) > max_region_distance ||
+					std::abs(water_region_patch.y - start_patch.y) > max_region_distance) return;
+
+			const int hash = CalculateWaterRegionPatchHash(water_region_patch);
+			if (visited_patch_hashes.count(hash) == 0) {
+				visited_patch_hashes.insert(hash);
+				patches_to_search.push_back(water_region_patch);
+			}
+		};
+
+		VisitWaterRegionPatchNeighbors(current_node, visitFunc);
+	}
+
+	/* Step 2: Find the closest depot within the reachable Water Region Patches. */
+	const Depot *best_depot = nullptr;
+	uint best_dist_sq = std::numeric_limits<uint>::max();
 	for (const Depot *depot : Depot::Iterate()) {
-		TileIndex tile = depot->xy;
+		const TileIndex tile = depot->xy;
 		if (IsShipDepotTile(tile) && IsTileOwner(tile, v->owner)) {
-			uint dist = DistanceManhattan(tile, v->tile);
-			if (dist < best_dist) {
-				best_dist = dist;
+			const uint dist_sq = DistanceSquare(tile, v->tile);
+			if (dist_sq < best_dist_sq && dist_sq <= max_distance * max_distance &&
+					visited_patch_hashes.count(CalculateWaterRegionPatchHash(GetWaterRegionPatchInfo(tile))) > 0) {
+				best_dist_sq = dist_sq;
 				best_depot = depot;
 			}
 		}
@@ -927,7 +961,7 @@ CommandCost CmdBuildShip(DoCommandFlag flags, TileIndex tile, const Engine *e, V
 
 ClosestDepot Ship::FindClosestDepot()
 {
-	const Depot *depot = FindClosestShipDepot(this, 0);
+	const Depot *depot = FindClosestShipDepot(this, MAX_SHIP_DEPOT_SEARCH_DISTANCE);
 	if (depot == nullptr) return ClosestDepot();
 
 	return ClosestDepot(depot->xy, depot->index);


### PR DESCRIPTION
## Motivation / Problem

When a ship needs to go to a depot, it simply finds the closest depot based on as-the-crow-flies distance. It does not check whether that depot is actually reachable or not. Checking this was simply not feasible as the YAPF pathfinder would reach it's tile limit very quickly and just give up.

## Description

Now that https://github.com/OpenTTD/OpenTTD/pull/10543 we can do the reachability check using water regions, which is orders of magnitude faster. First a "blob" of reachable water region patches up to a certain distance is determined. Only depots within this blob are considered.

You might ask "why aren't you using the BFS to find the closest depot that way". That was my initial solution too, but the 16x16 water regions make for a too coarse resolution to pick the closest depot. Here's an example with some debug drawing added to show the region boundaries. The BFS search would prefer the depot in the same region as the ship, simply because it's "fever regions away":
![image](https://github.com/OpenTTD/OpenTTD/assets/68320206/47c7a36e-beda-4030-82a1-a06e60d3c01d) 

... in the end I went for a K.I.S.S. solution.


## Limitations

Note that an attempt has already been made at this: https://github.com/OpenTTD/OpenTTD/pull/10544 . I wanted to offer a simpler solution.

I took some artistic license on this:
- I've limited the max depot search to 80 tiles when the user clicks the "go to depot" button on a ship. I feel that it doesn't make sense for a ship to sail all across the map if there happens to be a depot there, possibly taking years. It also prevents the water region search to expand the entire map, although that would still be fast. *Note that ships looking for depot to service in use a search distance of 20 by default, this depends on pathfinder penalty settings. *
- I've changed the distance check from manhattan to circular. This makes more sense IMO.

One can still create situations where the "wrong" depot will be selected. In the screenshot below the depot with the yellow circle will be selected, even though the other depot is closer. This is existing behavior, and not something that this PR is trying to address.
![image](https://github.com/OpenTTD/OpenTTD/assets/68320206/a81b2602-193a-4f0e-95a2-b545c1c58a9d)



## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
