### PR TITLE
Fix #10118: Always cycle through all visible signal types

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1873,12 +1873,6 @@ STR_CONFIG_SETTING_DRAG_SIGNALS_FIXED_DISTANCE_HELPTEXT         :Select the beha
 STR_CONFIG_SETTING_SEMAPHORE_BUILD_BEFORE_DATE                  :Automatically build semaphores before: {STRING2}
 STR_CONFIG_SETTING_SEMAPHORE_BUILD_BEFORE_DATE_HELPTEXT         :Set the year when electric signals will be used for tracks. Before this year, non-electric signals will be used (which have the exact same function, but different looks)
 
-STR_CONFIG_SETTING_CYCLE_SIGNAL_TYPES                           :Cycle through signal types: {STRING2}
-STR_CONFIG_SETTING_CYCLE_SIGNAL_TYPES_HELPTEXT                  :Select which signal types to cycle through when Ctrl+clicking on a built signal with the signal tool
-###length 2
-STR_CONFIG_SETTING_CYCLE_SIGNAL_PBS                             :Path signals only
-STR_CONFIG_SETTING_CYCLE_SIGNAL_ALL                             :All visible
-
 STR_CONFIG_SETTING_SIGNAL_GUI_MODE                              :Show signal types: {STRING2}
 STR_CONFIG_SETTING_SIGNAL_GUI_MODE_HELPTEXT                     :Choose which signal types are shown in the signal toolbar
 ###length 2

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -240,8 +240,8 @@ static void GenericPlaceSignals(TileIndex tile)
 	if (_remove_button_clicked) {
 		Command<CMD_REMOVE_SIGNALS>::Post(STR_ERROR_CAN_T_REMOVE_SIGNALS_FROM, CcPlaySound_CONSTRUCTION_RAIL, tile, track);
 	} else {
-		/* Which signals should we cycle through? */
-		SignalType cycle_start = _settings_client.gui.cycle_signal_types == SIGNAL_CYCLE_ALL && _settings_client.gui.signal_gui_mode == SIGNAL_GUI_ALL ? SIGTYPE_BLOCK : SIGTYPE_PBS;
+		/* Only cycle through signals that are visible in the menu. */
+		SignalType cycle_start = _settings_client.gui.signal_gui_mode == SIGNAL_GUI_ALL ? SIGTYPE_BLOCK : SIGTYPE_PBS;
 
 		if (FindWindowById(WC_BUILD_SIGNAL, 0) != nullptr) {
 			/* signal GUI is used */

--- a/src/rail_gui.h
+++ b/src/rail_gui.h
@@ -25,10 +25,4 @@ enum SignalGUISettings : uint8_t {
 	SIGNAL_GUI_ALL = 1,  ///< Show all signals, including block and presignals.
 };
 
-/** Settings for which signals are cycled through by control-clicking on the signal with the signal tool. */
-enum SignalCycleSettings : uint8_t {
-	SIGNAL_CYCLE_PATH = 0, ///< Cycle through path signals only.
-	SIGNAL_CYCLE_ALL = 1,  ///< Cycle through all signals visible.
-};
-
 #endif /* RAIL_GUI_H */

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1861,7 +1861,6 @@ static SettingsContainer &GetSettingsTree()
 				construction->Add(new SettingEntry("gui.default_rail_type"));
 				construction->Add(new SettingEntry("gui.semaphore_build_before"));
 				construction->Add(new SettingEntry("gui.signal_gui_mode"));
-				construction->Add(new SettingEntry("gui.cycle_signal_types"));
 				construction->Add(new SettingEntry("gui.drag_signals_fixed_distance"));
 				construction->Add(new SettingEntry("gui.auto_remove_signals"));
 			}

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -165,7 +165,6 @@ struct GUISettings {
 	RightClickClose  right_click_wnd_close;  ///< close window with right click
 	bool   pause_on_newgame;                 ///< whether to start new games paused or not
 	SignalGUISettings signal_gui_mode;       ///< select which signal types are shown in the signal GUI
-	SignalCycleSettings cycle_signal_types;  ///< Which signal types to cycle with the build signal tool.
 	SignalType default_signal_type;          ///< The default signal type, which is set automatically by the last signal used. Not available in Settings.
 	TimerGameCalendar::Year coloured_news_year; ///< when does newspaper become coloured?
 	TimetableMode timetable_mode;            ///< Time units for timetables: days, seconds, or ticks

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -509,19 +509,6 @@ strval   = STR_JUST_INT
 cat      = SC_EXPERT
 
 [SDTC_VAR]
-var      = gui.cycle_signal_types
-type     = SLE_UINT8
-flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
-def      = 0
-min      = 0
-max      = 1
-interval = 1
-str      = STR_CONFIG_SETTING_CYCLE_SIGNAL_TYPES
-strhelp  = STR_CONFIG_SETTING_CYCLE_SIGNAL_TYPES_HELPTEXT
-strval   = STR_CONFIG_SETTING_CYCLE_SIGNAL_PBS
-cat      = SC_ADVANCED
-
-[SDTC_VAR]
 var      = gui.drag_signals_density
 type     = SLE_UINT8
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC


### PR DESCRIPTION
## Motivation / Problem

We have two separate settings which control which signals are cycled through when Ctrl+Clicking a signal. The first is the signal menu mode: if all signals are shown or just path signals. The second is `Cycle through signal types` which since #8688 has two choices: `All visible` and `Path signals only`.

This second setting doesn't really make sense, as reported in #10118. In the comments of #10119, @frosch123 suggested we remove it entirely to always cycle through visible signals only, and I agree.

## Description

Remove the setting, so we always cycle through whatever signals are visible to the player.

Closes #10118.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
