### PR TITLE
Fix: compilation without precompiled headers

### DIFF
--- a/src/blitter/32bpp_anim_sse4.cpp
+++ b/src/blitter/32bpp_anim_sse4.cpp
@@ -7,10 +7,10 @@
 
 /** @file 32bpp_anim_sse4.cpp Implementation of the SSE4 32 bpp blitter with animation support. */
 
-#include "palette_func.h"
 #ifdef WITH_SSE
 
 #include "../stdafx.h"
+#include "../palette_func.h"
 #include "../video/video_driver.hpp"
 #include "../table/sprites.h"
 #include "32bpp_anim_sse4.hpp"

--- a/src/network/core/os_abstraction.cpp
+++ b/src/network/core/os_abstraction.cpp
@@ -19,6 +19,7 @@
 #include "stdafx.h"
 #include "os_abstraction.h"
 #include "../../string_func.h"
+#include "../../3rdparty/fmt/format.h"
 #include <mutex>
 
 #include "../../safeguards.h"

--- a/src/os/windows/library_loader_win.cpp
+++ b/src/os/windows/library_loader_win.cpp
@@ -12,6 +12,7 @@
 #include <windows.h>
 
 #include "../../library_loader.h"
+#include "../../3rdparty/fmt/format.h"
 
 #include "../../safeguards.h"
 


### PR DESCRIPTION
## Motivation / Problem
While trying to trace the WITH_ASSERT issue for MacOS releases, I had to disable precompiled headers.
And build fails without precompiled headers.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Some missing includes and a totally not in the right place one.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
