### PR TITLE
Codechange: Missing some conversions to WidgetID.

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1095,7 +1095,7 @@ void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_li
  * @param selected Currently selected sort criterium.
  * @param button Widget button.
  */
-void DisplayVehicleSortDropDown(Window *w, VehicleType vehicle_type, int selected, int button)
+void DisplayVehicleSortDropDown(Window *w, VehicleType vehicle_type, int selected, WidgetID button)
 {
 	uint32_t hidden_mask = 0;
 	/* Disable sorting by power or tractive effort when the original acceleration model for road vehicles is being used. */

--- a/src/engine_gui.h
+++ b/src/engine_gui.h
@@ -51,6 +51,6 @@ extern const StringID _engine_sort_listing[][12];
 extern EngList_SortTypeFunction * const _engine_sort_functions[][11];
 
 uint GetEngineListHeight(VehicleType type);
-void DisplayVehicleSortDropDown(Window *w, VehicleType vehicle_type, int selected, int button);
+void DisplayVehicleSortDropDown(Window *w, VehicleType vehicle_type, int selected, WidgetID button);
 
 #endif /* ENGINE_GUI_H */

--- a/src/help_gui.cpp
+++ b/src/help_gui.cpp
@@ -160,7 +160,7 @@ struct HelpWindow : public Window {
 	}
 
 private:
-	void EnableTextfileButton(std::string_view filename, int button_widget)
+	void EnableTextfileButton(std::string_view filename, WidgetID button_widget)
 	{
 		this->GetWidget<NWidgetLeaf>(button_widget)->SetDisabled(!FindGameManualFilePath(filename).has_value());
 	}

--- a/src/osk_gui.cpp
+++ b/src/osk_gui.cpp
@@ -42,7 +42,7 @@ struct OskWindow : public Window {
 	std::string orig_str;  ///< Original string.
 	bool shift;            ///< Is the shift effectively pressed?
 
-	OskWindow(WindowDesc *desc, Window *parent, int button) : Window(desc)
+	OskWindow(WindowDesc *desc, Window *parent, WidgetID button) : Window(desc)
 	{
 		this->parent = parent;
 		assert(parent != nullptr);

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -258,7 +258,7 @@ public:
 
 	ViewportData *viewport;          ///< Pointer to viewport data, if present.
 	const NWidgetCore *nested_focus; ///< Currently focused nested widget, or \c nullptr if no nested widget has focus.
-	std::map<int, QueryString*> querystrings; ///< QueryString associated to WWT_EDITBOX widgets.
+	std::map<WidgetID, QueryString*> querystrings; ///< QueryString associated to WWT_EDITBOX widgets.
 	std::unique_ptr<NWidgetBase> nested_root; ///< Root of the nested tree.
 	WidgetLookup widget_lookup; ///< Indexed access to the nested widget tree. Do not access directly, use #Window::GetWidget() instead.
 	NWidgetStacked *shade_select;    ///< Selection widget (#NWID_SELECTION) to use for shading the window. If \c nullptr, window cannot shade.


### PR DESCRIPTION
## Motivation / Problem

#11642 introduced WidgetID and used it for many places where widget numbers are passed, but some places are missing and still using int...

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use WidgetID in a few more places.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
