### PR TITLE
Codechange: Avoid repeatedly calling virtual methods in text drawing loop.

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -579,6 +579,8 @@ static int DrawLayoutLine(const ParagraphLayouter::Line &line, int y, int left, 
 	bool draw_shadow = false;
 	for (int run_index = 0; run_index < line.CountRuns(); run_index++) {
 		const ParagraphLayouter::VisualRun &run = line.GetVisualRun(run_index);
+		const auto &glyphs = run.GetGlyphs();
+		const auto &positions = run.GetPositions();
 		const Font *f = run.GetFont();
 
 		FontCache *fc = f->fc;
@@ -592,14 +594,14 @@ static int DrawLayoutLine(const ParagraphLayouter::Line &line, int y, int left, 
 		draw_shadow = fc->GetDrawGlyphShadow() && (colour & TC_NO_SHADE) == 0 && colour != TC_BLACK;
 
 		for (int i = 0; i < run.GetGlyphCount(); i++) {
-			GlyphID glyph = run.GetGlyphs()[i];
+			GlyphID glyph = glyphs[i];
 
 			/* Not a valid glyph (empty) */
 			if (glyph == 0xFFFF) continue;
 
-			int begin_x = (int)run.GetPositions()[i * 2]     + left - offset_x;
-			int end_x   = (int)run.GetPositions()[i * 2 + 2] + left - offset_x  - 1;
-			int top     = (int)run.GetPositions()[i * 2 + 1] + y;
+			int begin_x = (int)positions[i * 2]     + left - offset_x;
+			int end_x   = (int)positions[i * 2 + 2] + left - offset_x  - 1;
+			int top     = (int)positions[i * 2 + 1] + y;
 
 			/* Truncated away. */
 			if (truncation && (begin_x < min_x || end_x > max_x)) continue;


### PR DESCRIPTION
## Motivation / Problem

Repeated calls to `GetPositions()`, `GetGlyphs()` and `GetGlyphToCharMap()` inside the text drawing/layouter loops.

Possibly because these are virtual function calls these do not get compiled away even with optimizations.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Store the result of `GetPositions()`, `GetGlyphs()` and `GetGlyphToCharMap()` in locals outside of the loops to avoid the repeated calls.

Besides, it looks funny to use the array operator directly after a function call :)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

These loops probably do enough work actually drawing pixels for this to not make a difference, but maybe "every little helps".

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
