### PR TITLE
Remove: Debug redirect over network

### DIFF
--- a/docs/openttd.6
+++ b/docs/openttd.6
@@ -16,7 +16,6 @@
 .Op Fl g Op Ar savegame
 .Op Fl G Ar seed
 .Op Fl I Ar graphicsset
-.Op Fl l Ar host Ns Op : Ns Ar port
 .Op Fl m Ar driver
 .Op Fl M Ar musicset
 .Op Fl n Ar host Ns Oo : Ns Ar port Oc Ns Op # Ns Ar company
@@ -82,9 +81,6 @@ Select the graphics set
 see
 .Fl h
 for a full list.
-.It Fl l Ar host Ns Op : Ns Ar port
-Redirect debug output; see
-.Fl d .
 .It Fl m Ar driver
 Select the music driver
 .Ar driver ;

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -22,7 +22,6 @@
 #include "3rdparty/fmt/chrono.h"
 
 #include "network/network_admin.h"
-SOCKET _debug_socket = INVALID_SOCKET;
 
 #include "safeguards.h"
 
@@ -111,18 +110,6 @@ void DumpDebugFacilityNames(std::back_insert_iterator<std::string> &output_itera
  */
 void DebugPrint(const char *level, const std::string &message)
 {
-	if (_debug_socket != INVALID_SOCKET) {
-		std::string msg = fmt::format("{}dbg: [{}] {}\n", GetLogPrefix(), level, message);
-
-		/* Prevent sending a message concurrently, as that might cause interleaved messages. */
-		static std::mutex _debug_socket_mutex;
-		std::lock_guard<std::mutex> lock(_debug_socket_mutex);
-
-		/* Sending out an error when this fails would be nice, however... the error
-		 * would have to be send over this failing socket which won't work. */
-		send(_debug_socket, msg.c_str(), (int)msg.size(), 0);
-		return;
-	}
 	if (strcmp(level, "desync") == 0) {
 		static FILE *f = FioFOpenFile("commands-out.log", "wb", AUTOSAVE_DIR);
 		if (f == nullptr) return;

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -24,7 +24,6 @@ static const uint16_t NETWORK_TURN_SERVER_PORT        = 3974;           ///< The
 static const uint16_t NETWORK_CONTENT_SERVER_PORT     = 3978;           ///< The default port of the content server (TCP)
 static const uint16_t NETWORK_DEFAULT_PORT            = 3979;           ///< The default port of the game server (TCP & UDP)
 static const uint16_t NETWORK_ADMIN_PORT              = 3977;           ///< The default port for admin network
-static const uint16_t NETWORK_DEFAULT_DEBUGLOG_PORT   = 3982;           ///< The default port debug-log is sent to (TCP)
 
 static const uint16_t UDP_MTU                         = 1460;           ///< Number of bytes we can pack in a single UDP packet
 

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1218,32 +1218,6 @@ static void NetworkGenerateServerId()
 	_settings_client.network.network_id = GenerateUid("OpenTTD Server ID");
 }
 
-class TCPNetworkDebugConnecter : TCPConnecter {
-private:
-	std::string connection_string;
-
-public:
-	TCPNetworkDebugConnecter(const std::string &connection_string) : TCPConnecter(connection_string, NETWORK_DEFAULT_DEBUGLOG_PORT), connection_string(connection_string) {}
-
-	void OnFailure() override
-	{
-		Debug(net, 0, "Failed to open connection to {} for redirecting Debug()", this->connection_string);
-	}
-
-	void OnConnect(SOCKET s) override
-	{
-		Debug(net, 3, "Redirecting Debug() to {}", this->connection_string);
-
-		extern SOCKET _debug_socket;
-		_debug_socket = s;
-	}
-};
-
-void NetworkStartDebugLog(const std::string &connection_string)
-{
-	new TCPNetworkDebugConnecter(connection_string);
-}
-
 /** This tries to launch the network for a given OS */
 void NetworkStartUp()
 {

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -47,7 +47,6 @@ void NetworkDisconnect(bool close_admins = true);
 void NetworkGameLoop();
 void NetworkBackgroundLoop();
 std::string_view ParseFullConnectionString(const std::string &connection_string, uint16_t &port, CompanyID *company_id = nullptr);
-void NetworkStartDebugLog(const std::string &connection_string);
 void NetworkPopulateCompanyStats(NetworkCompanyStats *stats);
 
 void NetworkUpdateClientInfo(ClientID client_id);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -169,7 +169,6 @@ static void ShowHelp()
 		"  -p password         = Password to join server\n"
 		"  -P password         = Password to join company\n"
 		"  -D [host][:port]    = Start dedicated server\n"
-		"  -l host[:port]      = Redirect Debug()\n"
 #if !defined(_WIN32)
 		"  -f                  = Fork into the background (dedicated only)\n"
 #endif
@@ -489,7 +488,6 @@ static const OptionData _options[] = {
 	 GETOPT_SHORT_VALUE('b'),
 	GETOPT_SHORT_OPTVAL('D'),
 	 GETOPT_SHORT_VALUE('n'),
-	 GETOPT_SHORT_VALUE('l'),
 	 GETOPT_SHORT_VALUE('p'),
 	 GETOPT_SHORT_VALUE('P'),
 #if !defined(_WIN32)
@@ -528,7 +526,6 @@ int openttd_main(int argc, char *argv[])
 	Dimension resolution = {0, 0};
 	std::unique_ptr<AfterNewGRFScan> scanner(new AfterNewGRFScan());
 	bool dedicated = false;
-	char *debuglog_conn = nullptr;
 	bool only_local_path = false;
 
 	extern bool _dedicated_forks;
@@ -564,9 +561,6 @@ int openttd_main(int argc, char *argv[])
 		case 'f': _dedicated_forks = true; break;
 		case 'n':
 			scanner->connection_string = mgo.opt; // host:port#company parameter
-			break;
-		case 'l':
-			debuglog_conn = mgo.opt;
 			break;
 		case 'p':
 			scanner->join_server_password = mgo.opt;
@@ -761,10 +755,6 @@ int openttd_main(int argc, char *argv[])
 	AdjustGUIZoom(false);
 
 	NetworkStartUp(); // initialize network-core
-
-	if (debuglog_conn != nullptr && _network_available) {
-		NetworkStartDebugLog(debuglog_conn);
-	}
 
 	if (!HandleBootstrap()) {
 		ShutdownGame();


### PR DESCRIPTION
## Motivation / Problem

It does not work for dedicated servers because upon starting the process to resolve the address to redirect to gets killed. Also with all the async going on in the network code, the debug redirection will start very late in the process.

Since the problem has been introduced in January of 2009 there is only one issue (Closes #11590) mentioning this problem, so it is a very rarely used feature.
The problem can be solved by special casing the redirecting, so everything happens in a blocking manner. However, that feels like a maintenance nightmare. So removing it seems to be the better solution.


## Description

Just remove it.


## Limitations

No more simple debug redirection available at all in the application.
Though, maybe just redirect OpenTTD's output to `nc` and let that connect to another server?


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
