### PR TITLE
Fix: Don't replace striped characters with '?' in console

### DIFF
--- a/src/console.cpp
+++ b/src/console.cpp
@@ -106,7 +106,7 @@ void IConsolePrint(TextColour colour_code, const std::string &string)
 
 	/* Create a copy of the string, strip it of colours and invalid
 	 * characters and (when applicable) assign it to the console buffer */
-	std::string str = StrMakeValid(string);
+	std::string str = StrMakeValid(string, SVS_NONE);
 
 	if (_network_dedicated) {
 		NetworkAdminConsole("console", str);


### PR DESCRIPTION
## Motivation / Problem
Most likely since https://github.com/OpenTTD/OpenTTD/commit/e7628552018ab57101eefea12549639974e1cb5d, chat messages written in the console start with a question mark.
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/56f94974-6f62-4279-a5f2-9050e8929b7e)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
As the comment above the call to `StrMakeValid()` says "strip it of colours and invalid characters", just strip instead of replacing with question marks.
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/3d84ed48-0e81-4a9b-8adc-5e508f8e03e8)
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
