### PR TITLE
Fix: [SDL2] only resolutions of the first display were shown

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1779,6 +1779,10 @@ bool ToggleFullScreen(bool fs)
 void SortResolutions()
 {
 	std::sort(_resolutions.begin(), _resolutions.end());
+
+	/* Remove any duplicates from the list. */
+	auto last = std::unique(_resolutions.begin(), _resolutions.end());
+	_resolutions.erase(last, _resolutions.end());
 }
 
 /**

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -59,13 +59,15 @@ static void FindResolutions()
 {
 	_resolutions.clear();
 
-	for (int i = 0; i < SDL_GetNumDisplayModes(0); i++) {
-		SDL_DisplayMode mode;
-		SDL_GetDisplayMode(0, i, &mode);
+	for (int display = 0; display < SDL_GetNumVideoDisplays(); display++) {
+		for (int i = 0; i < SDL_GetNumDisplayModes(display); i++) {
+			SDL_DisplayMode mode;
+			SDL_GetDisplayMode(display, i, &mode);
 
-		if (mode.w < 640 || mode.h < 480) continue;
-		if (std::find(_resolutions.begin(), _resolutions.end(), Dimension(mode.w, mode.h)) != _resolutions.end()) continue;
-		_resolutions.emplace_back(mode.w, mode.h);
+			if (mode.w < 640 || mode.h < 480) continue;
+			if (std::find(_resolutions.begin(), _resolutions.end(), Dimension(mode.w, mode.h)) != _resolutions.end()) continue;
+			_resolutions.emplace_back(mode.w, mode.h);
+		}
 	}
 
 	/* We have found no resolutions, show the default list */


### PR DESCRIPTION
## Motivation / Problem

We mostly assumes that in a multi-display setup all resolutions of all displays are identical. And as such, only the first display was asked for all resolutions.

As this assumption is not always true, some users didn't see their secondary display resolution in the list. This causes issues with fullscreen, which finds the closest matching screen resolution.

This was described in #11353, as what I classified as bug `#1.1`.

## Description

Stop assuming, starting checking. Iterate all resolutions of all displays.

Of course we now also need to deduplicate; we postpone that till we have sorted, as that is the best way to remove duplicates.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
