### PR TITLE
Fix e1f5be62: Clear font cache when toggling sprite font.

### DIFF
--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -573,6 +573,7 @@ struct GameOptionsWindow : Window {
 
 				InitFontCache(false);
 				InitFontCache(true);
+				ClearFontCache();
 				SetupWidgetDimensions();
 				ReInitAllWindows(true);
 				break;


### PR DESCRIPTION
## Motivation / Problem

When toggling sprite fonts, the height and ascender of the sprite font are not updated for the current interface scale. This can result in incorrect rendering depending on previous settings.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/1f769352-1a26-4b79-aaaf-eb478364e7f7)


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This is resolved by clearing font cache when toggling sprite font, which will reinitialize the height and ascender for the current interface scale.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
