### PR TITLE
Fix: Viewport virt coords not updated when sprite font toggled

### DIFF
--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -575,6 +575,7 @@ struct GameOptionsWindow : Window {
 				InitFontCache(true);
 				ClearFontCache();
 				SetupWidgetDimensions();
+				UpdateAllVirtCoords();
 				ReInitAllWindows(true);
 				break;
 


### PR DESCRIPTION
## Motivation / Problem

Fix viewport text labels being truncated when switching from TTF to sprite font.
This is because the TTF is narrower than the sprite font (on Linux at least), and UpdateAllVirtCoords was not called.

## Description

Call UpdateAllVirtCoords when toggling the sprite/TTF font state.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
