### PR TITLE
Fix #11783: make TTO savegames load again

### DIFF
--- a/src/saveload/oldloader.h
+++ b/src/saveload/oldloader.h
@@ -14,7 +14,7 @@
 #include "../tile_type.h"
 
 static const uint BUFFER_SIZE = 4096;
-static const uint OLD_MAP_SIZE = 256 * 256;
+static const uint OLD_MAP_SIZE = 256;
 
 struct LoadgameState {
 	FILE *file;

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -957,9 +957,9 @@ static const OldChunks _company_chunk[] = {
 	OCL_CNULL( OC_TTD, 1 ), // avail_railtypes
 	OCL_SVAR(   OC_TILE, Company, location_of_HQ ),
 
-	OCL_NULL( 4 ),           // Shares
+	OCL_CNULL( OC_TTD, 4 ), // Shares
 
-	OCL_CNULL( OC_TTD, 8 ), ///< junk at end of chunk
+	OCL_CNULL( OC_TTD, 8 ), // junk at end of chunk
 
 	OCL_END()
 };

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -52,8 +52,7 @@ void FixOldMapArray()
 
 static void FixTTDMapArray()
 {
-	for (TileIndex t = 0; t < OLD_MAP_SIZE; t++) {
-		Tile tile(t);
+	for (auto tile : Map::Iterate()) {
 		switch (GetTileType(tile)) {
 			case MP_STATION:
 				tile.m4() = 0; // We do not understand this TTDP station mapping (yet)
@@ -213,8 +212,7 @@ void FixOldVehicles()
 
 static bool FixTTOMapArray()
 {
-	for (TileIndex t = 0; t < OLD_MAP_SIZE; t++) {
-		Tile tile(t);
+	for (auto tile : Map::Iterate()) {
 		TileType tt = GetTileType(tile);
 		if (tt == 11) {
 			/* TTO has a different way of storing monorail.
@@ -1484,25 +1482,23 @@ static bool LoadOldMapPart1(LoadgameState *ls, int)
 		Map::Allocate(OLD_MAP_SIZE, OLD_MAP_SIZE);
 	}
 
-	for (uint i = 0; i < OLD_MAP_SIZE; i++) {
-		Tile(i).m1() = ReadByte(ls);
+	for (auto t : Map::Iterate()) {
+		t.m1() = ReadByte(ls);
 	}
-	for (uint i = 0; i < OLD_MAP_SIZE; i++) {
-		Tile(i).m2() = ReadByte(ls);
+	for (auto t : Map::Iterate()) {
+		t.m2() = ReadByte(ls);
 	}
 
 	if (_savegame_type != SGT_TTO) {
 		/* old map3 is split into to m3 and m4 */
-		for (uint i = 0; i < OLD_MAP_SIZE; i++) {
-			Tile(i).m3() = ReadByte(ls);
-			Tile(i).m4() = ReadByte(ls);
+		for (auto t : Map::Iterate()) {
+			t.m3() = ReadByte(ls);
+			t.m4() = ReadByte(ls);
 		}
-		for (uint i = 0; i < OLD_MAP_SIZE / 4; i++) {
+		auto range = Map::Iterate();
+		for (auto it = range.begin(); it != range.end(); /* nothing. */) {
 			byte b = ReadByte(ls);
-			Tile(i * 4 + 0).m6() = GB(b, 0, 2);
-			Tile(i * 4 + 1).m6() = GB(b, 2, 2);
-			Tile(i * 4 + 2).m6() = GB(b, 4, 2);
-			Tile(i * 4 + 3).m6() = GB(b, 6, 2);
+			for (int i = 0; i < 8; i += 2, ++it) (*it).m6() = GB(b, i, 2);
 		}
 	}
 
@@ -1511,13 +1507,11 @@ static bool LoadOldMapPart1(LoadgameState *ls, int)
 
 static bool LoadOldMapPart2(LoadgameState *ls, int)
 {
-	uint i;
-
-	for (i = 0; i < OLD_MAP_SIZE; i++) {
-		Tile(i).type() = ReadByte(ls);
+	for (auto t : Map::Iterate()) {
+		t.type() = ReadByte(ls);
 	}
-	for (i = 0; i < OLD_MAP_SIZE; i++) {
-		Tile(i).m5() = ReadByte(ls);
+	for (auto t : Map::Iterate()) {
+		t.m5() = ReadByte(ls);
 	}
 
 	return true;

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -198,6 +198,18 @@ void UpdateOldAircraft()
 			SetAircraftPosition(a, gp.x, gp.y, GetAircraftFlightLevel(a));
 		}
 	}
+
+	/* Clear aircraft from loading vehicles, if we bumped them into the air. */
+	for (Station *st : Station::Iterate()) {
+		for (auto iter = st->loading_vehicles.begin(); iter != st->loading_vehicles.end(); /* nothing */) {
+			Vehicle *v = *iter;
+			if (v->type == VEH_AIRCRAFT && !v->current_order.IsType(OT_LOADING)) {
+				iter = st->loading_vehicles.erase(iter);
+			} else {
+				++iter;
+			}
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Fixes #11783.
Fixes #11785.


## Description

To solve #11783, I ran into the issue that `OLD_MAP_SIZE` isn't clear in whether it's the number of tiles, or the number of tiles along an edge. Since it is mostly used to loop over the map array, I wondered whether the constant was actually needed that often. Well, it isn't... iterating using `Map::Iterate` works fine in most cases, although there's a bit of a mess with `old_map3` which we split into two values. However, why first copy the data to one array, to copy it into the already allocated map array?

Then there were crashes with resolving towns. It wasn't the issue in the end, but making since depots already had some resiliency baked in, I also used that for industries and stations.
The reason the loading crashed, was because it was reading 4 bytes that are only for TTD when getting the TTO save, and because validating the type did not set the position of the file to the expected location. Solving this made the saves loadable.

All but one would not run, and most were running into the same issue as #11785. The problem here is that for very old saves the aircraft, in some states, are bumped into the air as migrating apparently was not possible. With #9680 a crash was solved by moving this process to later in `AfterLoadGame`, specifically when the map would be valid. However, in between all the map fixing, vehicles with a loading state (before version 57, so including TTO and TTD) were added to the list of loading vehicles at a station. When aircraft are then bumped into the air, they are in the list of loading vehicles but not actually in the loading state. So, simply remove aircraft not in a loading state from those lists again.

That leaves one, `5965 - Trt03.sv1`, that crashes the game when unpausing. However, that also happens in 1.11 and 1.6, which is old enough for me to draw the proverbial line stating that this one likely never loaded correctly in OpenTTD.


## Limitations

Don't have a large corpus of old test games to test with.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
