### PR TITLE
Fix #11767: [Linux] install all X11 dependencies in linux-generic

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -119,6 +119,22 @@ jobs:
           # EOF
         echo "::endgroup::"
 
+        echo "::group::Install video drivers"
+        # These video libs are to make sure the SDL version of vcpkg adds
+        # video-support; these libraries are not added to the resulting
+        # binary, but the headers are used to enable them in SDL.
+        yum install -y \
+          libX11-devel \
+          libXcursor-devel \
+          libXext-devel \
+          libXfixes-devel \
+          libXi-devel \
+          libxkbcommon-devel \
+          libXrandr-devel \
+          libXScrnSaver-devel \
+          # EOF
+        echo "::endgroup::"
+
         # We use vcpkg for our dependencies, to get more up-to-date version.
         echo "::group::Install vcpkg and dependencies"
 


### PR DESCRIPTION
## Motivation / Problem

Without this, xrandr support is not compiled into SDL, which means that SDL will only see a single display spanning all your displays (a virtual desktop).

Fixes #11767.

## Description

Install xrandr (and other dependencies) to ensure SDL compiles with as much support as possible.

Wayland will not work, as 1.15 is available where SDL wants 1.18. That is for an other PR to address.

Before fix:
`dbg: [driver] SDL2: Mouse is at (3859, 1264), use display 0 (0, 0, 6560, 2560)`

After fix:
`dbg: [driver] SDL2: Mouse is at (2560, 510), use display 0 (2560, 510, 2560, 1440)`

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
