### PR TITLE
Codechange: Rename SIGTYPE_NORMAL to SIGTYPE_BLOCK

### DIFF
--- a/src/pathfinder/yapf/yapf_costrail.hpp
+++ b/src/pathfinder/yapf/yapf_costrail.hpp
@@ -217,7 +217,7 @@ public:
 							switch (sig_type) {
 								case SIGTYPE_COMBO:
 								case SIGTYPE_EXIT:   cost += Yapf().PfGetSettings().rail_firstred_exit_penalty; break; // first signal is red pre-signal-exit
-								case SIGTYPE_NORMAL:
+								case SIGTYPE_BLOCK:
 								case SIGTYPE_ENTRY:  cost += Yapf().PfGetSettings().rail_firstred_penalty; break;
 								default: break;
 							}

--- a/src/pathfinder/yapf/yapf_node_rail.hpp
+++ b/src/pathfinder/yapf/yapf_node_rail.hpp
@@ -142,7 +142,7 @@ struct CYapfRailNodeT
 		if (parent == nullptr) {
 			m_num_signals_passed      = 0;
 			flags_u.m_inherited_flags = 0;
-			m_last_red_signal_type    = SIGTYPE_NORMAL;
+			m_last_red_signal_type    = SIGTYPE_BLOCK;
 			/* We use PBS as initial signal type because if we are in
 			 * a PBS section and need to route, i.e. we're at a safe
 			 * waiting point of a station, we need to account for the

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -241,7 +241,7 @@ static void GenericPlaceSignals(TileIndex tile)
 		Command<CMD_REMOVE_SIGNALS>::Post(STR_ERROR_CAN_T_REMOVE_SIGNALS_FROM, CcPlaySound_CONSTRUCTION_RAIL, tile, track);
 	} else {
 		/* Which signals should we cycle through? */
-		SignalType cycle_start = _settings_client.gui.cycle_signal_types == SIGNAL_CYCLE_ALL && _settings_client.gui.signal_gui_mode == SIGNAL_GUI_ALL ? SIGTYPE_NORMAL : SIGTYPE_PBS;
+		SignalType cycle_start = _settings_client.gui.cycle_signal_types == SIGNAL_CYCLE_ALL && _settings_client.gui.signal_gui_mode == SIGNAL_GUI_ALL ? SIGTYPE_BLOCK : SIGTYPE_PBS;
 
 		if (FindWindowById(WC_BUILD_SIGNAL, 0) != nullptr) {
 			/* signal GUI is used */
@@ -1695,7 +1695,7 @@ public:
 		this->sig_sprite_size.height = 0;
 		this->sig_sprite_bottom_offset = 0;
 		const RailTypeInfo *rti = GetRailTypeInfo(_cur_railtype);
-		for (uint type = SIGTYPE_NORMAL; type < SIGTYPE_END; type++) {
+		for (uint type = SIGTYPE_BLOCK; type < SIGTYPE_END; type++) {
 			for (uint variant = SIG_ELECTRIC; variant <= SIG_SEMAPHORE; variant++) {
 				for (uint lowered = 0; lowered < 2; lowered++) {
 					Point offset;

--- a/src/script/api/script_rail.cpp
+++ b/src/script/api/script_rail.cpp
@@ -469,7 +469,7 @@ static bool IsValidSignalType(int signal_type)
 	}
 	::SignalType sig_type = (::SignalType)(signal >= SIGNALTYPE_TWOWAY ? signal ^ SIGNALTYPE_TWOWAY : signal);
 
-	return ScriptObject::Command<CMD_BUILD_SIGNALS>::Do(tile, track, sig_type, ::SIG_ELECTRIC, false, false, false, ::SIGTYPE_NORMAL, ::SIGTYPE_NORMAL, signal_cycles, 0);
+	return ScriptObject::Command<CMD_BUILD_SIGNALS>::Do(tile, track, sig_type, ::SIG_ELECTRIC, false, false, false, ::SIGTYPE_BLOCK, ::SIGTYPE_BLOCK, signal_cycles, 0);
 }
 
 /* static */ bool ScriptRail::RemoveSignal(TileIndex tile, TileIndex front)

--- a/src/script/api/script_rail.hpp
+++ b/src/script/api/script_rail.hpp
@@ -64,7 +64,7 @@ public:
 	 */
 	enum SignalType {
 		/* Note: these values represent part of the in-game SignalType enum */
-		SIGNALTYPE_NORMAL        = ::SIGTYPE_NORMAL,     ///< Normal signal.
+		SIGNALTYPE_NORMAL        = ::SIGTYPE_BLOCK,      ///< Block signal.
 		SIGNALTYPE_ENTRY         = ::SIGTYPE_ENTRY,      ///< Entry presignal.
 		SIGNALTYPE_EXIT          = ::SIGTYPE_EXIT,       ///< Exit signal.
 		SIGNALTYPE_COMBO         = ::SIGTYPE_COMBO,      ///< Combo signal.

--- a/src/signal_type.h
+++ b/src/signal_type.h
@@ -21,7 +21,7 @@ enum SignalVariant : byte {
 
 /** Type of signal, i.e. how does the signal behave? */
 enum SignalType : byte {
-	SIGTYPE_NORMAL     = 0, ///< normal signal
+	SIGTYPE_BLOCK      = 0, ///< block signal
 	SIGTYPE_ENTRY      = 1, ///< presignal block entry
 	SIGTYPE_EXIT       = 2, ///< presignal block exit
 	SIGTYPE_COMBO      = 3, ///< presignal inter-block


### PR DESCRIPTION
## Motivation / Problem

While working on #11769, I discovered a block-signal-normative bias in our code.

## Description

Rename `SIGTYPE_NORMAL` to `SIGTYPE_BLOCK` and rewrite some comments which are no longer accurate or are otherwise related and need some love.

## Limitations

The script API still uses `SIGTYPE_NORMAL` although I did update its comment to better describe which signal that refers to.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
