### PR TITLE
Fix #11714: [SDL] remove hint to avoid hardware acceleration

### DIFF
--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -507,11 +507,6 @@ bool VideoDriver_SDL_Base::PollEvent()
 
 static const char *InitializeSDL()
 {
-	/* Explicitly disable hardware acceleration. Enabling this causes
-	 * UpdateWindowSurface() to update the window's texture instead of
-	 * its surface. */
-	SDL_SetHint(SDL_HINT_FRAMEBUFFER_ACCELERATION, "0");
-
 	/* Check if the video-driver is already initialized. */
 	if (SDL_WasInit(SDL_INIT_VIDEO) != 0) return nullptr;
 


### PR DESCRIPTION
## Motivation / Problem

The last remaining hint, `SDL_HINT_FRAMEBUFFER_ACCELERATION`, causes latest SDL on Wayland to fail to create a surface.

Fixes #11714.

## Description

This hint was once needed because of the way we handled surfaces. But as OpenGL already uses a hardware surface, we already had to fix all the issues that comes with it. As that is generic code, this hint is no longer actually needed. Further more, recent SDL versions break because of it on Wayland.

It is likely this also improves performance for people who do not pick hardware acceleration, but do have hardware acceleration available. As SDL will cheat, and still use a bunch of hardware acceleration. OpenTTD will not. But that is a choice you make :)

PS: the choice to use as much of the same code between the software and hardware accelerated SDL driver really pays off here :)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
