### PR TITLE
Fix 661bdae2: cargo_payment not cleared when aircraft loading cancelled

### DIFF
--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -23,6 +23,7 @@
 #include "../company_base.h"
 #include "../company_func.h"
 #include "../disaster_vehicle.h"
+#include "../economy_base.h"
 
 #include "../safeguards.h"
 
@@ -205,6 +206,7 @@ void UpdateOldAircraft()
 			Vehicle *v = *iter;
 			if (v->type == VEH_AIRCRAFT && !v->current_order.IsType(OT_LOADING)) {
 				iter = st->loading_vehicles.erase(iter);
+				delete v->cargo_payment;
 			} else {
 				++iter;
 			}


### PR DESCRIPTION
## Motivation / Problem

This fixes the assertion that occurs when an aircraft whose loading was cancelled by means of 661bdae2 next attempts to load.

See

## Description

Delete the cargo_payment.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
