### PR TITLE
Codechange: Make window widget lists build-time.

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -27,7 +27,7 @@
 
 
 /** Widgets for the configure AI window. */
-static const NWidgetPart _nested_ai_config_widgets[] = {
+static constexpr NWidgetPart _nested_ai_config_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_MAUVE),
 		NWidget(WWT_CAPTION, COLOUR_MAUVE), SetDataTip(STR_AI_CONFIG_CAPTION_AI, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -194,7 +194,7 @@ struct BuildAirToolbarWindow : Window {
 	}, AirportToolbarGlobalHotkeys};
 };
 
-static const NWidgetPart _nested_air_toolbar_widgets[] = {
+static constexpr NWidgetPart _nested_air_toolbar_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_TOOLBAR_AIRCRAFT_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -581,7 +581,7 @@ public:
 	}};
 };
 
-static const NWidgetPart _nested_build_airport_widgets[] = {
+static constexpr NWidgetPart _nested_build_airport_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_STATION_BUILD_AIRPORT_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -732,7 +732,7 @@ public:
 	}
 };
 
-static const NWidgetPart _nested_replace_rail_vehicle_widgets[] = {
+static constexpr NWidgetPart _nested_replace_rail_vehicle_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_RV_CAPTION), SetDataTip(STR_REPLACE_VEHICLES_WHITE, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -796,7 +796,7 @@ static WindowDesc _replace_rail_vehicle_desc(__FILE__, __LINE__,
 	std::begin(_nested_replace_rail_vehicle_widgets), std::end(_nested_replace_rail_vehicle_widgets)
 );
 
-static const NWidgetPart _nested_replace_road_vehicle_widgets[] = {
+static constexpr NWidgetPart _nested_replace_road_vehicle_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_RV_CAPTION), SetDataTip(STR_REPLACE_VEHICLES_WHITE, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -854,7 +854,7 @@ static WindowDesc _replace_road_vehicle_desc(__FILE__, __LINE__,
 	std::begin(_nested_replace_road_vehicle_widgets), std::end(_nested_replace_road_vehicle_widgets)
 );
 
-static const NWidgetPart _nested_replace_vehicle_widgets[] = {
+static constexpr NWidgetPart _nested_replace_vehicle_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_RV_CAPTION), SetMinimalSize(433, 14), SetDataTip(STR_REPLACE_VEHICLES_WHITE, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -32,7 +32,7 @@
 #include "safeguards.h"
 
 /** Widgets for the background window to prevent smearing. */
-static const struct NWidgetPart _background_widgets[] = {
+static const NWidgetPart _background_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_DARK_BLUE, WID_BB_BACKGROUND), SetResize(1, 1),
 	EndContainer(),
 };

--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -32,7 +32,7 @@
 #include "safeguards.h"
 
 /** Widgets for the background window to prevent smearing. */
-static const NWidgetPart _background_widgets[] = {
+static constexpr NWidgetPart _background_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_DARK_BLUE, WID_BB_BACKGROUND), SetResize(1, 1),
 	EndContainer(),
 };
@@ -65,7 +65,7 @@ public:
 };
 
 /** Nested widgets for the error window. */
-static const NWidgetPart _nested_bootstrap_errmsg_widgets[] = {
+static constexpr NWidgetPart _nested_bootstrap_errmsg_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_BEM_CAPTION), SetDataTip(STR_MISSING_GRAPHICS_ERROR_TITLE, STR_NULL),
 	EndContainer(),
@@ -122,7 +122,7 @@ public:
 };
 
 /** Nested widgets for the download window. */
-static const NWidgetPart _nested_bootstrap_download_status_window_widgets[] = {
+static constexpr NWidgetPart _nested_bootstrap_download_status_window_widgets[] = {
 	NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_CONTENT_DOWNLOAD_TITLE, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
 	NWidget(WWT_PANEL, COLOUR_GREY),
 		NWidget(NWID_VERTICAL), SetPIP(0, WidgetDimensions::unscaled.vsep_wide, 0), SetPadding(WidgetDimensions::unscaled.modalpopup),
@@ -173,7 +173,7 @@ public:
 };
 
 /** The widgets for the query. It has no close box as that sprite does not exist yet. */
-static const NWidgetPart _bootstrap_query_widgets[] = {
+static constexpr NWidgetPart _bootstrap_query_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_MISSING_GRAPHICS_SET_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
 	EndContainer(),

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -313,7 +313,7 @@ const StringID BuildBridgeWindow::sorter_names[] = {
 };
 
 /** Widgets of the bridge gui. */
-static const NWidgetPart _nested_build_bridge_widgets[] = {
+static constexpr NWidgetPart _nested_build_bridge_widgets[] = {
 	/* Header */
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -54,7 +54,7 @@ uint GetEngineListHeight(VehicleType type)
 	return std::max<uint>(GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.matrix.Vertical(), GetVehicleImageCellSize(type, EIT_PURCHASE).height);
 }
 
-static const NWidgetPart _nested_build_vehicle_widgets[] = {
+static constexpr NWidgetPart _nested_build_vehicle_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_BV_CAPTION), SetDataTip(STR_JUST_STRING, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS), SetTextStyle(TC_WHITE),

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -204,7 +204,7 @@ static const CheatEntry _cheats_ui[] = {
 static_assert(CHT_NUM_CHEATS == lengthof(_cheats_ui));
 
 /** Widget definitions of the cheat GUI. */
-static const NWidgetPart _nested_cheat_widgets[] = {
+static constexpr NWidgetPart _nested_cheat_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_CHEATS, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -279,7 +279,7 @@ static void DrawYearColumn(const Rect &r, TimerGameCalendar::Year year, const Ex
 	DrawPrice(sum, r.left, r.right, y, TC_WHITE);
 }
 
-static const NWidgetPart _nested_company_finances_widgets[] = {
+static constexpr NWidgetPart _nested_company_finances_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_CF_CAPTION), SetDataTip(STR_FINANCES_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -1097,7 +1097,7 @@ public:
 	}
 };
 
-static const NWidgetPart _nested_select_company_livery_widgets[] = {
+static constexpr NWidgetPart _nested_select_company_livery_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_SCL_CAPTION), SetDataTip(STR_LIVERY_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -1192,7 +1192,7 @@ void DrawCompanyManagerFace(CompanyManagerFace cmf, int colour, const Rect &r)
 }
 
 /** Nested widget description for the company manager face selection dialog */
-static const NWidgetPart _nested_select_company_manager_face_widgets[] = {
+static constexpr NWidgetPart _nested_select_company_manager_face_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_SCMF_CAPTION), SetDataTip(STR_FACE_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -1771,7 +1771,7 @@ static void DoSelectCompanyManagerFace(Window *parent)
 	new SelectCompanyManagerFaceWindow(&_select_company_manager_face_desc, parent);
 }
 
-static const NWidgetPart _nested_company_infrastructure_widgets[] = {
+static constexpr NWidgetPart _nested_company_infrastructure_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_CI_CAPTION), SetDataTip(STR_COMPANY_INFRASTRUCTURE_VIEW_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -2140,7 +2140,7 @@ static void ShowCompanyInfrastructure(CompanyID company)
 	AllocateWindowDescFront<CompanyInfrastructureWindow>(&_company_infrastructure_desc, company);
 }
 
-static const NWidgetPart _nested_company_widgets[] = {
+static constexpr NWidgetPart _nested_company_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_C_CAPTION), SetDataTip(STR_COMPANY_VIEW_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -2726,7 +2726,7 @@ private:
 	Money company_value; ///< The value of the company for which the user can buy it.
 };
 
-static const NWidgetPart _nested_buy_company_widgets[] = {
+static constexpr NWidgetPart _nested_buy_company_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_LIGHT_BLUE),
 		NWidget(WWT_CAPTION, COLOUR_LIGHT_BLUE, WID_BC_CAPTION), SetDataTip(STR_ERROR_MESSAGE_CAPTION_OTHER_COMPANY, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -98,7 +98,7 @@ static inline void IConsoleResetHistoryPos()
 static const char *IConsoleHistoryAdd(const char *cmd);
 static void IConsoleHistoryNavigate(int direction);
 
-static const struct NWidgetPart _nested_console_window_widgets[] = {
+static const NWidgetPart _nested_console_window_widgets[] = {
 	NWidget(WWT_EMPTY, INVALID_COLOUR, WID_C_BACKGROUND), SetResize(1, 1),
 };
 

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -98,7 +98,7 @@ static inline void IConsoleResetHistoryPos()
 static const char *IConsoleHistoryAdd(const char *cmd);
 static void IConsoleHistoryNavigate(int direction);
 
-static const NWidgetPart _nested_console_window_widgets[] = {
+static constexpr NWidgetPart _nested_console_window_widgets[] = {
 	NWidget(WWT_EMPTY, INVALID_COLOUR, WID_C_BACKGROUND), SetResize(1, 1),
 };
 

--- a/src/core/geometry_type.hpp
+++ b/src/core/geometry_type.hpp
@@ -57,13 +57,13 @@ struct RectPadding {
 	 * Get total horizontal padding of RectPadding.
 	 * @return total horizontal padding.
 	 */
-	inline uint Horizontal() const { return this->left + this->right; }
+	constexpr uint Horizontal() const { return this->left + this->right; }
 
 	/**
 	 * Get total vertical padding of RectPadding.
 	 * @return total vertical padding.
 	 */
-	inline uint Vertical() const { return this->top + this->bottom; }
+	constexpr uint Vertical() const { return this->top + this->bottom; }
 };
 
 inline const RectPadding RectPadding::zero{};

--- a/src/date_gui.cpp
+++ b/src/date_gui.cpp
@@ -173,7 +173,7 @@ struct SetDateWindow : Window {
 };
 
 /** Widgets for the date setting window. */
-static const NWidgetPart _nested_set_date_widgets[] = {
+static constexpr NWidgetPart _nested_set_date_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN), SetDataTip(STR_DATE_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -46,7 +46,7 @@
  */
 
 /** Nested widget definition for train depots. */
-static const NWidgetPart _nested_train_depot_widgets[] = {
+static constexpr NWidgetPart _nested_train_depot_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(NWID_SELECTION, INVALID_COLOUR, WID_D_SHOW_RENAME), // rename button

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -326,7 +326,7 @@ struct BuildDocksToolbarWindow : Window {
  * Nested widget parts of docks toolbar, game version.
  * Position of #WID_DT_RIVER widget has changed.
  */
-static const NWidgetPart _nested_build_docks_toolbar_widgets[] = {
+static constexpr NWidgetPart _nested_build_docks_toolbar_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_WATERWAYS_TOOLBAR_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -371,7 +371,7 @@ Window *ShowBuildDocksToolbar()
  * Nested widget parts of docks toolbar, scenario editor version.
  * Positions of #WID_DT_DEPOT, #WID_DT_STATION, and #WID_DT_BUOY widgets have changed.
  */
-static const NWidgetPart _nested_build_docks_scen_toolbar_widgets[] = {
+static constexpr NWidgetPart _nested_build_docks_scen_toolbar_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_WATERWAYS_TOOLBAR_CAPTION_SE, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -479,7 +479,7 @@ public:
 };
 
 /** Nested widget parts of a build dock station window. */
-static const NWidgetPart _nested_build_dock_station_widgets[] = {
+static constexpr NWidgetPart _nested_build_dock_station_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_STATION_BUILD_DOCK_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -580,7 +580,7 @@ public:
 	}
 };
 
-static const NWidgetPart _nested_build_docks_depot_widgets[] = {
+static constexpr NWidgetPart _nested_build_docks_depot_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_DEPOT_BUILD_SHIP_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -51,7 +51,7 @@ StringID GetEngineCategoryName(EngineID engine)
 	}
 }
 
-static const NWidgetPart _nested_engine_preview_widgets[] = {
+static constexpr NWidgetPart _nested_engine_preview_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_LIGHT_BLUE),
 		NWidget(WWT_CAPTION, COLOUR_LIGHT_BLUE), SetDataTip(STR_ENGINE_PREVIEW_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -33,7 +33,7 @@
 
 #include "safeguards.h"
 
-static const NWidgetPart _nested_errmsg_widgets[] = {
+static constexpr NWidgetPart _nested_errmsg_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_RED),
 		NWidget(WWT_CAPTION, COLOUR_RED, WID_EM_CAPTION), SetDataTip(STR_ERROR_MESSAGE_CAPTION, STR_NULL),
@@ -50,7 +50,7 @@ static WindowDesc _errmsg_desc(__FILE__, __LINE__,
 	std::begin(_nested_errmsg_widgets), std::end(_nested_errmsg_widgets)
 );
 
-static const NWidgetPart _nested_errmsg_face_widgets[] = {
+static constexpr NWidgetPart _nested_errmsg_face_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_RED),
 		NWidget(WWT_CAPTION, COLOUR_RED, WID_EM_CAPTION), SetDataTip(STR_ERROR_MESSAGE_CAPTION_OTHER_COMPANY, STR_NULL),

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -63,7 +63,7 @@ void LoadCheckData::Clear()
 }
 
 /** Load game/scenario with optional content download */
-static const NWidgetPart _nested_load_dialog_widgets[] = {
+static constexpr NWidgetPart _nested_load_dialog_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_SL_CAPTION),
@@ -124,7 +124,7 @@ static const NWidgetPart _nested_load_dialog_widgets[] = {
 };
 
 /** Load heightmap with content download */
-static const NWidgetPart _nested_load_heightmap_dialog_widgets[] = {
+static constexpr NWidgetPart _nested_load_heightmap_dialog_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_SL_CAPTION),
@@ -169,7 +169,7 @@ static const NWidgetPart _nested_load_heightmap_dialog_widgets[] = {
 };
 
 /** Save game/scenario */
-static const NWidgetPart _nested_save_dialog_widgets[] = {
+static constexpr NWidgetPart _nested_save_dialog_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_SL_CAPTION),

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -372,7 +372,7 @@ static const char * GetAIName(int ai_index)
 }
 
 /** @hideinitializer */
-static const NWidgetPart _framerate_window_widgets[] = {
+static constexpr NWidgetPart _framerate_window_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_FRW_CAPTION), SetDataTip(STR_FRAMERATE_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -735,7 +735,7 @@ static WindowDesc _framerate_display_desc(__FILE__, __LINE__,
 
 
 /** @hideinitializer */
-static const NWidgetPart _frametime_graph_window_widgets[] = {
+static constexpr NWidgetPart _frametime_graph_window_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_FGW_CAPTION), SetDataTip(STR_JUST_STRING2, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS), SetTextStyle(TC_WHITE),

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -30,7 +30,7 @@
 
 
 /** Widgets for the configure GS window. */
-static const NWidgetPart _nested_gs_config_widgets[] = {
+static constexpr NWidgetPart _nested_gs_config_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_MAUVE),
 		NWidget(WWT_CAPTION, COLOUR_MAUVE), SetDataTip(STR_AI_CONFIG_CAPTION_GAMESCRIPT, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -69,7 +69,7 @@ void SetNewLandscapeType(byte landscape)
 }
 
 /** Widgets of GenerateLandscapeWindow when generating world */
-static const NWidgetPart _nested_generate_landscape_widgets[] = {
+static constexpr NWidgetPart _nested_generate_landscape_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN), SetDataTip(STR_MAPGEN_WORLD_GENERATION_CAPTION, STR_NULL),
@@ -193,7 +193,7 @@ static const NWidgetPart _nested_generate_landscape_widgets[] = {
 };
 
 /** Widgets of GenerateLandscapeWindow when loading heightmap */
-static const NWidgetPart _nested_heightmap_load_widgets[] = {
+static constexpr NWidgetPart _nested_heightmap_load_widgets[] = {
 	/* Window header. */
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -1254,7 +1254,7 @@ struct CreateScenarioWindow : public Window
 	}
 };
 
-static const NWidgetPart _nested_create_scenario_widgets[] = {
+static constexpr NWidgetPart _nested_create_scenario_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN), SetDataTip(STR_SE_MAPGEN_CAPTION, STR_NULL),
@@ -1327,7 +1327,7 @@ void ShowCreateScenario()
 	new CreateScenarioWindow(&_create_scenario_desc, GLWM_SCENARIO);
 }
 
-static const NWidgetPart _nested_generate_progress_widgets[] = {
+static constexpr NWidgetPart _nested_generate_progress_widgets[] = {
 	NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_GENERATION_WORLD, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
 	NWidget(WWT_PANEL, COLOUR_GREY),
 		NWidget(NWID_VERTICAL), SetPIP(0, WidgetDimensions::unscaled.vsep_wide, 0), SetPadding(WidgetDimensions::unscaled.modalpopup),

--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -280,7 +280,7 @@ struct GoalListWindow : public Window {
 };
 
 /** Widgets of the #GoalListWindow. */
-static const NWidgetPart _nested_goals_list_widgets[] = {
+static constexpr NWidgetPart _nested_goals_list_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN, WID_GOAL_CAPTION), SetDataTip(STR_JUST_STRING1, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -406,7 +406,7 @@ struct GoalQuestionWindow : public Window {
 };
 
 /** Widgets of the goal question window. */
-static const NWidgetPart _nested_goal_question_widgets_question[] = {
+static constexpr NWidgetPart _nested_goal_question_widgets_question[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_LIGHT_BLUE),
 		NWidget(WWT_CAPTION, COLOUR_LIGHT_BLUE, WID_GQ_CAPTION), SetDataTip(STR_GOAL_QUESTION_CAPTION_QUESTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -432,7 +432,7 @@ static const NWidgetPart _nested_goal_question_widgets_question[] = {
 	EndContainer(),
 };
 
-static const NWidgetPart _nested_goal_question_widgets_info[] = {
+static constexpr NWidgetPart _nested_goal_question_widgets_info[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_LIGHT_BLUE),
 		NWidget(WWT_CAPTION, COLOUR_LIGHT_BLUE, WID_GQ_CAPTION), SetDataTip(STR_GOAL_QUESTION_CAPTION_INFORMATION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -458,7 +458,7 @@ static const NWidgetPart _nested_goal_question_widgets_info[] = {
 	EndContainer(),
 };
 
-static const NWidgetPart _nested_goal_question_widgets_warning[] = {
+static constexpr NWidgetPart _nested_goal_question_widgets_warning[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_YELLOW),
 		NWidget(WWT_CAPTION, COLOUR_YELLOW, WID_GQ_CAPTION), SetDataTip(STR_GOAL_QUESTION_CAPTION_WARNING, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -484,7 +484,7 @@ static const NWidgetPart _nested_goal_question_widgets_warning[] = {
 	EndContainer(),
 };
 
-static const NWidgetPart _nested_goal_question_widgets_error[] = {
+static constexpr NWidgetPart _nested_goal_question_widgets_error[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_RED),
 		NWidget(WWT_CAPTION, COLOUR_RED, WID_GQ_CAPTION), SetDataTip(STR_GOAL_QUESTION_CAPTION_ERROR, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -126,7 +126,7 @@ static std::unique_ptr<NWidgetBase> MakeNWidgetCompanyLines()
 	return vert;
 }
 
-static const NWidgetPart _nested_graph_legend_widgets[] = {
+static constexpr NWidgetPart _nested_graph_legend_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN), SetDataTip(STR_GRAPH_KEY_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -630,7 +630,7 @@ struct OperatingProfitGraphWindow : BaseGraphWindow {
 	}
 };
 
-static const NWidgetPart _nested_operating_profit_widgets[] = {
+static constexpr NWidgetPart _nested_operating_profit_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN), SetDataTip(STR_GRAPH_OPERATING_PROFIT_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -681,7 +681,7 @@ struct IncomeGraphWindow : BaseGraphWindow {
 	}
 };
 
-static const NWidgetPart _nested_income_graph_widgets[] = {
+static constexpr NWidgetPart _nested_income_graph_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN), SetDataTip(STR_GRAPH_INCOME_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -730,7 +730,7 @@ struct DeliveredCargoGraphWindow : BaseGraphWindow {
 	}
 };
 
-static const NWidgetPart _nested_delivered_cargo_graph_widgets[] = {
+static constexpr NWidgetPart _nested_delivered_cargo_graph_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN), SetDataTip(STR_GRAPH_CARGO_DELIVERED_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -785,7 +785,7 @@ struct PerformanceHistoryGraphWindow : BaseGraphWindow {
 	}
 };
 
-static const NWidgetPart _nested_performance_history_widgets[] = {
+static constexpr NWidgetPart _nested_performance_history_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN), SetDataTip(STR_GRAPH_COMPANY_PERFORMANCE_RATINGS_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -835,7 +835,7 @@ struct CompanyValueGraphWindow : BaseGraphWindow {
 	}
 };
 
-static const NWidgetPart _nested_company_value_graph_widgets[] = {
+static constexpr NWidgetPart _nested_company_value_graph_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN), SetDataTip(STR_GRAPH_COMPANY_VALUES_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -1053,7 +1053,7 @@ struct PaymentRatesGraphWindow : BaseGraphWindow {
 	}
 };
 
-static const NWidgetPart _nested_cargo_payment_rates_widgets[] = {
+static constexpr NWidgetPart _nested_cargo_payment_rates_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN), SetDataTip(STR_GRAPH_CARGO_PAYMENT_RATES_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -1370,7 +1370,7 @@ std::unique_ptr<NWidgetBase> MakeCompanyButtonRowsGraphGUI()
 	return MakeCompanyButtonRows(WID_PRD_COMPANY_FIRST, WID_PRD_COMPANY_LAST, COLOUR_BROWN, 8, STR_PERFORMANCE_DETAIL_SELECT_COMPANY_TOOLTIP);
 }
 
-static const NWidgetPart _nested_performance_rating_detail_widgets[] = {
+static constexpr NWidgetPart _nested_performance_rating_detail_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN), SetDataTip(STR_PERFORMANCE_DETAIL, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -38,7 +38,7 @@
 
 typedef GUIList<const Group*> GUIGroupList;
 
-static const NWidgetPart _nested_group_widgets[] = {
+static constexpr NWidgetPart _nested_group_widgets[] = {
 	NWidget(NWID_HORIZONTAL), // Window header
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_GL_CAPTION),

--- a/src/help_gui.cpp
+++ b/src/help_gui.cpp
@@ -166,7 +166,7 @@ private:
 	}
 };
 
-static const NWidgetPart _nested_helpwin_widgets[] = {
+static constexpr NWidgetPart _nested_helpwin_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_HELP_WINDOW_CAPTION, STR_NULL),

--- a/src/highscore_gui.cpp
+++ b/src/highscore_gui.cpp
@@ -210,7 +210,7 @@ struct HighScoreWindow : EndGameHighScoreBaseWindow {
 	}
 };
 
-static const NWidgetPart _nested_highscore_widgets[] = {
+static constexpr NWidgetPart _nested_highscore_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_BROWN, WID_H_BACKGROUND), SetResize(1, 1), EndContainer(),
 };
 

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -261,7 +261,7 @@ void CcBuildIndustry(Commands, const CommandCost &result, TileIndex tile, Indust
 	}
 }
 
-static const NWidgetPart _nested_build_industry_widgets[] = {
+static constexpr NWidgetPart _nested_build_industry_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_FUND_INDUSTRY_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -1175,7 +1175,7 @@ static void UpdateIndustryProduction(Industry *i)
 }
 
 /** Widget definition of the view industry gui */
-static const NWidgetPart _nested_industry_view_widgets[] = {
+static constexpr NWidgetPart _nested_industry_view_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_CREAM),
 		NWidget(WWT_CAPTION, COLOUR_CREAM, WID_IV_CAPTION), SetDataTip(STR_INDUSTRY_VIEW_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -1212,7 +1212,7 @@ void ShowIndustryViewWindow(int industry)
 }
 
 /** Widget definition of the industry directory gui */
-static const NWidgetPart _nested_industry_directory_widgets[] = {
+static constexpr NWidgetPart _nested_industry_directory_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN), SetDataTip(STR_INDUSTRY_DIRECTORY_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -1918,7 +1918,7 @@ void ShowIndustryDirectory()
 }
 
 /** Widgets of the industry cargoes window. */
-static const NWidgetPart _nested_industry_cargoes_widgets[] = {
+static constexpr NWidgetPart _nested_industry_cargoes_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN, WID_IC_CAPTION), SetDataTip(STR_INDUSTRY_CARGOES_INDUSTRY_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -377,7 +377,7 @@ struct SelectGameWindow : public Window {
 	}
 };
 
-static const NWidgetPart _nested_select_game_widgets[] = {
+static constexpr NWidgetPart _nested_select_game_widgets[] = {
 	NWidget(WWT_CAPTION, COLOUR_BROWN), SetDataTip(STR_INTRO_CAPTION, STR_NULL),
 	NWidget(WWT_PANEL, COLOUR_BROWN),
 		NWidget(NWID_VERTICAL), SetPIP(0, WidgetDimensions::unscaled.vsep_wide, 0), SetPadding(WidgetDimensions::unscaled.sparse),

--- a/src/league_gui.cpp
+++ b/src/league_gui.cpp
@@ -186,7 +186,7 @@ public:
 	}
 };
 
-static const NWidgetPart _nested_performance_league_widgets[] = {
+static constexpr NWidgetPart _nested_performance_league_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN), SetDataTip(STR_COMPANY_LEAGUE_TABLE_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -419,7 +419,7 @@ public:
 	}
 };
 
-static const NWidgetPart _nested_script_league_widgets[] = {
+static constexpr NWidgetPart _nested_script_league_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN, WID_SLT_CAPTION), SetDataTip(STR_JUST_RAW_STRING, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -506,7 +506,7 @@ std::unique_ptr<NWidgetBase> MakeCargoesLegendLinkGraphGUI()
 }
 
 
-static const NWidgetPart _nested_linkgraph_legend_widgets[] = {
+static constexpr NWidgetPart _nested_linkgraph_legend_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN, WID_LGL_CAPTION), SetDataTip(STR_LINKGRAPH_LEGEND_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -176,7 +176,7 @@ void FixTitleGameZoom(int zoom_adjust)
 	vp->virtual_height = ScaleByZoom(vp->height, vp->zoom);
 }
 
-static const NWidgetPart _nested_main_window_widgets[] = {
+static constexpr NWidgetPart _nested_main_window_widgets[] = {
 	NWidget(NWID_VIEWPORT, INVALID_COLOUR, WID_M_VIEWPORT), SetResize(1, 1),
 };
 

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -176,7 +176,7 @@ void FixTitleGameZoom(int zoom_adjust)
 	vp->virtual_height = ScaleByZoom(vp->height, vp->zoom);
 }
 
-static const struct NWidgetPart _nested_main_window_widgets[] = {
+static const NWidgetPart _nested_main_window_widgets[] = {
 	NWidget(NWID_VIEWPORT, INVALID_COLOUR, WID_M_VIEWPORT), SetResize(1, 1),
 };
 

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -48,7 +48,7 @@ enum OskActivation {
 };
 
 
-static const NWidgetPart _nested_land_info_widgets[] = {
+static constexpr NWidgetPart _nested_land_info_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_LAND_AREA_INFORMATION_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -377,7 +377,7 @@ void ShowLandInfo(TileIndex tile)
 	new LandInfoWindow(tile);
 }
 
-static const NWidgetPart _nested_about_widgets[] = {
+static constexpr NWidgetPart _nested_about_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_ABOUT_OPENTTD, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -647,7 +647,7 @@ void HideFillingPercent(TextEffectID *te_id)
 	*te_id = INVALID_TE_ID;
 }
 
-static const NWidgetPart _nested_tooltips_widgets[] = {
+static constexpr NWidgetPart _nested_tooltips_widgets[] = {
 	NWidget(WWT_EMPTY, INVALID_COLOUR, WID_TT_BACKGROUND),
 };
 
@@ -1048,7 +1048,7 @@ struct QueryStringWindow : public Window
 	}
 };
 
-static const NWidgetPart _nested_query_string_widgets[] = {
+static constexpr NWidgetPart _nested_query_string_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_QS_CAPTION), SetDataTip(STR_JUST_STRING, STR_NULL), SetTextStyle(TC_WHITE),
@@ -1195,7 +1195,7 @@ struct QueryWindow : public Window {
 	}
 };
 
-static const NWidgetPart _nested_query_widgets[] = {
+static constexpr NWidgetPart _nested_query_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_RED),
 		NWidget(WWT_CAPTION, COLOUR_RED, WID_Q_CAPTION), // The caption's string is set in the constructor

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -630,7 +630,7 @@ struct MusicTrackSelectionWindow : public Window {
 	}
 };
 
-static const NWidgetPart _nested_music_track_selection_widgets[] = {
+static constexpr NWidgetPart _nested_music_track_selection_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_MTS_CAPTION), SetDataTip(STR_PLAYLIST_MUSIC_SELECTION_SETNAME, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -862,7 +862,7 @@ struct MusicWindow : public Window {
 	}
 };
 
-static const NWidgetPart _nested_music_window_widgets[] = {
+static constexpr NWidgetPart _nested_music_window_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_MUSIC_JAZZ_JUKEBOX_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -491,7 +491,7 @@ struct NetworkChatWindow : public Window {
 };
 
 /** The widgets of the chat window. */
-static const NWidgetPart _nested_chat_window_widgets[] = {
+static constexpr NWidgetPart _nested_chat_window_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY, WID_NC_CLOSE),
 		NWidget(WWT_PANEL, COLOUR_GREY, WID_NC_BACKGROUND),

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -80,7 +80,7 @@ void ShowContentTextfileWindow(TextfileType file_type, const ContentInfo *ci)
 }
 
 /** Nested widgets for the download window. */
-static const NWidgetPart _nested_network_content_download_status_window_widgets[] = {
+static constexpr NWidgetPart _nested_network_content_download_status_window_widgets[] = {
 	NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_CONTENT_DOWNLOAD_TITLE, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
 	NWidget(WWT_PANEL, COLOUR_GREY),
 		NWidget(NWID_VERTICAL), SetPIP(0, WidgetDimensions::unscaled.vsep_wide, 0), SetPadding(WidgetDimensions::unscaled.modalpopup),
@@ -1032,7 +1032,7 @@ void BuildContentTypeStringList()
 }
 
 /** The widgets for the content list. */
-static const NWidgetPart _nested_network_content_list_widgets[] = {
+static constexpr NWidgetPart _nested_network_content_list_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_LIGHT_BLUE),
 		NWidget(WWT_CAPTION, COLOUR_LIGHT_BLUE), SetDataTip(STR_CONTENT_TITLE, STR_NULL),

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -871,7 +871,7 @@ static std::unique_ptr<NWidgetBase> MakeResizableHeader()
 	return std::make_unique<NWidgetServerListHeader>();
 }
 
-static const NWidgetPart _nested_network_game_widgets[] = {
+static constexpr NWidgetPart _nested_network_game_widgets[] = {
 	/* TOP */
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_LIGHT_BLUE),
@@ -1149,7 +1149,7 @@ struct NetworkStartServerWindow : public Window {
 	}
 };
 
-static const NWidgetPart _nested_network_start_server_window_widgets[] = {
+static constexpr NWidgetPart _nested_network_start_server_window_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_LIGHT_BLUE),
 		NWidget(WWT_CAPTION, COLOUR_LIGHT_BLUE), SetDataTip(STR_NETWORK_START_SERVER_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -1237,7 +1237,7 @@ static void ShowNetworkStartServerWindow()
 
 extern void DrawCompanyIcon(CompanyID cid, int x, int y);
 
-static const NWidgetPart _nested_client_list_widgets[] = {
+static constexpr NWidgetPart _nested_client_list_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_NETWORK_CLIENT_LIST_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -2194,7 +2194,7 @@ struct NetworkJoinStatusWindow : Window {
 	}
 };
 
-static const NWidgetPart _nested_network_join_status_window_widgets[] = {
+static constexpr NWidgetPart _nested_network_join_status_window_widgets[] = {
 	NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_NETWORK_CONNECTING_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
 	NWidget(WWT_PANEL, COLOUR_GREY),
 		NWidget(NWID_VERTICAL), SetPIP(0, WidgetDimensions::unscaled.vsep_wide, 0), SetPadding(WidgetDimensions::unscaled.modalpopup),
@@ -2302,7 +2302,7 @@ struct NetworkCompanyPasswordWindow : public Window {
 	}
 };
 
-static const NWidgetPart _nested_network_company_password_window_widgets[] = {
+static constexpr NWidgetPart _nested_network_company_password_window_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_COMPANY_PASSWORD_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -2419,7 +2419,7 @@ struct NetworkAskRelayWindow : public Window {
 	}
 };
 
-static const NWidgetPart _nested_network_ask_relay_widgets[] = {
+static constexpr NWidgetPart _nested_network_ask_relay_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_RED),
 		NWidget(WWT_CAPTION, COLOUR_RED, WID_NAR_CAPTION), SetDataTip(STR_NETWORK_ASK_RELAY_CAPTION, STR_NULL),
@@ -2514,7 +2514,7 @@ struct NetworkAskSurveyWindow : public Window {
 	}
 };
 
-static const NWidgetPart _nested_network_ask_survey_widgets[] = {
+static constexpr NWidgetPart _nested_network_ask_survey_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_NAS_CAPTION), SetDataTip(STR_NETWORK_ASK_SURVEY_CAPTION, STR_NULL),

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -637,7 +637,7 @@ struct NewGRFInspectWindow : Window {
 
 /* static */ uint32_t NewGRFInspectWindow::var60params[GSF_FAKE_END][0x20] = { {0} }; // Use spec to have 0s in whole array
 
-static const NWidgetPart _nested_newgrf_inspect_chain_widgets[] = {
+static constexpr NWidgetPart _nested_newgrf_inspect_chain_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_NGRFI_CAPTION), SetDataTip(STR_NEWGRF_INSPECT_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -661,7 +661,7 @@ static const NWidgetPart _nested_newgrf_inspect_chain_widgets[] = {
 	EndContainer(),
 };
 
-static const NWidgetPart _nested_newgrf_inspect_widgets[] = {
+static constexpr NWidgetPart _nested_newgrf_inspect_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_NGRFI_CAPTION), SetDataTip(STR_NEWGRF_INSPECT_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -1090,7 +1090,7 @@ struct SpriteAlignerWindow : Window {
 bool SpriteAlignerWindow::centre = true;
 bool SpriteAlignerWindow::crosshair = true;
 
-static const NWidgetPart _nested_sprite_aligner_widgets[] = {
+static constexpr NWidgetPart _nested_sprite_aligner_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_SA_CAPTION), SetDataTip(STR_SPRITE_ALIGNER_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -508,7 +508,7 @@ struct NewGRFParametersWindow : public Window {
 GRFParameterInfo NewGRFParametersWindow::dummy_parameter_info(0);
 
 
-static const NWidgetPart _nested_newgrf_parameter_widgets[] = {
+static constexpr NWidgetPart _nested_newgrf_parameter_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_MAUVE),
 		NWidget(WWT_CAPTION, COLOUR_MAUVE, WID_NP_CAPTION),
@@ -1808,7 +1808,7 @@ public:
 const uint NWidgetNewGRFDisplay::MAX_EXTRA_INFO_WIDTH    = 150;
 const uint NWidgetNewGRFDisplay::MIN_EXTRA_FOR_3_COLUMNS = 50;
 
-static const NWidgetPart _nested_newgrf_actives_widgets[] = {
+static constexpr NWidgetPart _nested_newgrf_actives_widgets[] = {
 	NWidget(NWID_VERTICAL), SetPIP(0, WidgetDimensions::unscaled.vsep_wide, 0),
 		/* Left side, presets. */
 		NWidget(NWID_VERTICAL),
@@ -1863,7 +1863,7 @@ static const NWidgetPart _nested_newgrf_actives_widgets[] = {
 	EndContainer(),
 };
 
-static const NWidgetPart _nested_newgrf_availables_widgets[] = {
+static constexpr NWidgetPart _nested_newgrf_availables_widgets[] = {
 	NWidget(WWT_FRAME, COLOUR_MAUVE), SetDataTip(STR_NEWGRF_SETTINGS_INACTIVE_LIST, STR_NULL), SetPIP(0, WidgetDimensions::unscaled.vsep_wide, 0),
 		/* Left side, available grfs, filter edit box. */
 		NWidget(NWID_HORIZONTAL), SetPIP(0, WidgetDimensions::unscaled.hsep_wide, 0),
@@ -1896,7 +1896,7 @@ static const NWidgetPart _nested_newgrf_availables_widgets[] = {
 	EndContainer(),
 };
 
-static const NWidgetPart _nested_newgrf_infopanel_widgets[] = {
+static constexpr NWidgetPart _nested_newgrf_infopanel_widgets[] = {
 	NWidget(NWID_VERTICAL), SetPIP(0, WidgetDimensions::unscaled.vsep_wide, 0),
 		/* Right side, info panel. */
 		NWidget(WWT_PANEL, COLOUR_MAUVE),
@@ -1949,7 +1949,7 @@ std::unique_ptr<NWidgetBase> NewGRFDisplay()
 }
 
 /* Widget definition of the manage newgrfs window */
-static const NWidgetPart _nested_newgrf_widgets[] = {
+static constexpr NWidgetPart _nested_newgrf_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_MAUVE),
 		NWidget(WWT_CAPTION, COLOUR_MAUVE), SetDataTip(STR_NEWGRF_SETTINGS_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -2025,7 +2025,7 @@ void ShowNewGRFSettings(bool editable, bool show_params, bool exec_changes, GRFC
 }
 
 /** Widget parts of the save preset window. */
-static const NWidgetPart _nested_save_preset_widgets[] = {
+static constexpr NWidgetPart _nested_save_preset_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_SAVE_PRESET_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -2183,7 +2183,7 @@ static void ShowSavePresetWindow(const char *initial_text)
 }
 
 /** Widgets for the progress window. */
-static const NWidgetPart _nested_scan_progress_widgets[] = {
+static constexpr NWidgetPart _nested_scan_progress_widgets[] = {
 	NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_NEWGRF_SCAN_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
 	NWidget(WWT_PANEL, COLOUR_GREY),
 		NWidget(NWID_VERTICAL), SetPIP(0, WidgetDimensions::unscaled.vsep_wide, 0), SetPadding(WidgetDimensions::unscaled.modalpopup),

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -82,7 +82,7 @@ static TileIndex GetReferenceTile(NewsReferenceType reftype, uint32_t ref)
 }
 
 /* Normal news items. */
-static const NWidgetPart _nested_normal_news_widgets[] = {
+static constexpr NWidgetPart _nested_normal_news_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_WHITE, WID_N_PANEL),
 		NWidget(NWID_HORIZONTAL), SetPadding(1, 1, 0, 1),
 			NWidget(WWT_CLOSEBOX, COLOUR_WHITE, WID_N_CLOSEBOX), SetPadding(0, 0, 0, 1),
@@ -104,7 +104,7 @@ static WindowDesc _normal_news_desc(__FILE__, __LINE__,
 );
 
 /* New vehicles news items. */
-static const NWidgetPart _nested_vehicle_news_widgets[] = {
+static constexpr NWidgetPart _nested_vehicle_news_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_WHITE, WID_N_PANEL),
 		NWidget(NWID_HORIZONTAL), SetPadding(1, 1, 0, 1),
 			NWidget(NWID_VERTICAL),
@@ -131,7 +131,7 @@ static WindowDesc _vehicle_news_desc(__FILE__, __LINE__,
 );
 
 /* Company news items. */
-static const NWidgetPart _nested_company_news_widgets[] = {
+static constexpr NWidgetPart _nested_company_news_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_WHITE, WID_N_PANEL),
 		NWidget(NWID_HORIZONTAL), SetPadding(1, 1, 0, 1),
 			NWidget(NWID_VERTICAL),
@@ -159,7 +159,7 @@ static WindowDesc _company_news_desc(__FILE__, __LINE__,
 );
 
 /* Thin news items. */
-static const NWidgetPart _nested_thin_news_widgets[] = {
+static constexpr NWidgetPart _nested_thin_news_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_WHITE, WID_N_PANEL),
 		NWidget(NWID_HORIZONTAL), SetPadding(1, 1, 0, 1),
 			NWidget(WWT_CLOSEBOX, COLOUR_WHITE, WID_N_CLOSEBOX), SetPadding(0, 0, 0, 1),
@@ -182,7 +182,7 @@ static WindowDesc _thin_news_desc(__FILE__, __LINE__,
 );
 
 /* Small news items. */
-static const NWidgetPart _nested_small_news_widgets[] = {
+static constexpr NWidgetPart _nested_small_news_widgets[] = {
 	/* Caption + close box. The caption is no WWT_CAPTION as the window shall not be moveable and so on. */
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_LIGHT_BLUE, WID_N_CLOSEBOX),
@@ -1209,7 +1209,7 @@ struct MessageHistoryWindow : Window {
 	}
 };
 
-static const NWidgetPart _nested_message_history[] = {
+static constexpr NWidgetPart _nested_message_history[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN), SetDataTip(STR_MESSAGE_HISTORY, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -662,7 +662,7 @@ BuildObjectWindow::GUIObjectClassList::FilterFunction * const BuildObjectWindow:
 	&TagNameFilter,
 };
 
-static const NWidgetPart _nested_build_object_widgets[] = {
+static constexpr NWidgetPart _nested_build_object_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_OBJECT_BUILD_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -1567,7 +1567,7 @@ public:
 };
 
 /** Nested widget definition for "your" train orders. */
-static const NWidgetPart _nested_orders_train_widgets[] = {
+static constexpr NWidgetPart _nested_orders_train_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_O_CAPTION), SetDataTip(STR_ORDERS_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -1645,7 +1645,7 @@ static WindowDesc _orders_train_desc(__FILE__, __LINE__,
 );
 
 /** Nested widget definition for "your" orders (non-train). */
-static const NWidgetPart _nested_orders_widgets[] = {
+static constexpr NWidgetPart _nested_orders_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_O_CAPTION), SetDataTip(STR_ORDERS_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -1718,7 +1718,7 @@ static WindowDesc _orders_desc(__FILE__, __LINE__,
 );
 
 /** Nested widget definition for competitor orders. */
-static const NWidgetPart _nested_other_orders_widgets[] = {
+static constexpr NWidgetPart _nested_other_orders_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_O_CAPTION), SetDataTip(STR_ORDERS_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/osk_gui.cpp
+++ b/src/osk_gui.cpp
@@ -318,7 +318,7 @@ static std::unique_ptr<NWidgetBase> MakeSpacebarKeys()
 }
 
 
-static const NWidgetPart _nested_osk_widgets[] = {
+static constexpr NWidgetPart _nested_osk_widgets[] = {
 	NWidget(WWT_CAPTION, COLOUR_GREY, WID_OSK_CAPTION), SetDataTip(STR_JUST_STRING, STR_NULL), SetTextStyle(TC_WHITE),
 	NWidget(WWT_PANEL, COLOUR_GREY),
 		NWidget(WWT_EDITBOX, COLOUR_GREY, WID_OSK_TEXT), SetMinimalSize(252, 12), SetPadding(2, 2, 2, 2),

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -796,7 +796,7 @@ struct BuildRailToolbarWindow : Window {
 	}, RailToolbarGlobalHotkeys};
 };
 
-static const NWidgetPart _nested_build_rail_widgets[] = {
+static constexpr NWidgetPart _nested_build_rail_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN, WID_RAT_CAPTION), SetDataTip(STR_JUST_STRING2, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS), SetTextStyle(TC_WHITE),
@@ -1528,7 +1528,7 @@ BuildRailStationWindow::GUIStationClassList::FilterFunction * const BuildRailSta
 	&TagNameFilter,
 };
 
-static const NWidgetPart _nested_station_builder_widgets[] = {
+static constexpr NWidgetPart _nested_station_builder_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_STATION_BUILD_RAIL_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -1821,7 +1821,7 @@ public:
 };
 
 /** Nested widget definition of the build signal window */
-static const NWidgetPart _nested_signal_builder_widgets[] = {
+static constexpr NWidgetPart _nested_signal_builder_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN, WID_BS_CAPTION), SetDataTip(STR_BUILD_SIGNAL_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -1937,7 +1937,7 @@ struct BuildRailDepotWindow : public PickerWindowBase {
 };
 
 /** Nested widget definition of the build rail depot window */
-static const NWidgetPart _nested_build_depot_widgets[] = {
+static constexpr NWidgetPart _nested_build_depot_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_BUILD_DEPOT_TRAIN_ORIENTATION_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -2160,7 +2160,7 @@ struct BuildRailWaypointWindow : PickerWindowBase {
 /* static */ QueryString BuildRailWaypointWindow::editbox(BuildRailWaypointWindow::FILTER_LENGTH * MAX_CHAR_LENGTH, BuildRailWaypointWindow::FILTER_LENGTH);
 
 /** Nested widget definition for the build NewGRF rail waypoint window */
-static const NWidgetPart _nested_build_waypoint_widgets[] = {
+static constexpr NWidgetPart _nested_build_waypoint_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_WAYPOINT_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -816,7 +816,7 @@ struct BuildRoadToolbarWindow : Window {
 	}, TramToolbarGlobalHotkeys};
 };
 
-static const NWidgetPart _nested_build_road_widgets[] = {
+static constexpr NWidgetPart _nested_build_road_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN, WID_ROT_CAPTION), SetDataTip(STR_JUST_STRING2, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS), SetTextStyle(TC_WHITE),
@@ -859,7 +859,7 @@ static WindowDesc _build_road_desc(__FILE__, __LINE__,
 	&BuildRoadToolbarWindow::road_hotkeys
 );
 
-static const NWidgetPart _nested_build_tramway_widgets[] = {
+static constexpr NWidgetPart _nested_build_tramway_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN, WID_ROT_CAPTION), SetDataTip(STR_JUST_STRING2, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS), SetTextStyle(TC_WHITE),
@@ -918,7 +918,7 @@ Window *ShowBuildRoadToolbar(RoadType roadtype)
 	return AllocateWindowDescFront<BuildRoadToolbarWindow>(RoadTypeIsRoad(_cur_roadtype) ? &_build_road_desc : &_build_tramway_desc, TRANSPORT_ROAD);
 }
 
-static const NWidgetPart _nested_build_road_scen_widgets[] = {
+static constexpr NWidgetPart _nested_build_road_scen_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN, WID_ROT_CAPTION), SetDataTip(STR_JUST_STRING2, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS), SetTextStyle(TC_WHITE),
@@ -955,7 +955,7 @@ static WindowDesc _build_road_scen_desc(__FILE__, __LINE__,
 	&BuildRoadToolbarWindow::road_hotkeys
 );
 
-static const NWidgetPart _nested_build_tramway_scen_widgets[] = {
+static constexpr NWidgetPart _nested_build_tramway_scen_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN, WID_ROT_CAPTION), SetDataTip(STR_JUST_STRING2, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS), SetTextStyle(TC_WHITE),
@@ -1060,7 +1060,7 @@ struct BuildRoadDepotWindow : public PickerWindowBase {
 	}
 };
 
-static const NWidgetPart _nested_build_road_depot_widgets[] = {
+static constexpr NWidgetPart _nested_build_road_depot_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN, WID_BROD_CAPTION), SetDataTip(STR_BUILD_DEPOT_ROAD_ORIENTATION_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -1599,7 +1599,7 @@ BuildRoadStationWindow::GUIRoadStopClassList::FilterFunction * const BuildRoadSt
 };
 
 /** Widget definition of the build road station window */
-static const NWidgetPart _nested_road_station_picker_widgets[] = {
+static constexpr NWidgetPart _nested_road_station_picker_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION,  COLOUR_DARK_GREEN, WID_BROS_CAPTION),
@@ -1688,7 +1688,7 @@ static WindowDesc _road_station_picker_desc(__FILE__, __LINE__,
 );
 
 /** Widget definition of the build tram station window */
-static const NWidgetPart _nested_tram_station_picker_widgets[] = {
+static constexpr NWidgetPart _nested_tram_station_picker_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION,  COLOUR_DARK_GREEN, WID_BROS_CAPTION),

--- a/src/screenshot_gui.cpp
+++ b/src/screenshot_gui.cpp
@@ -43,7 +43,7 @@ struct ScreenshotWindow : Window {
 	}
 };
 
-static const NWidgetPart _nested_screenshot[] = {
+static constexpr NWidgetPart _nested_screenshot[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_SCREENSHOT_CAPTION, 0),

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -239,7 +239,7 @@ struct ScriptListWindow : public Window {
 };
 
 /** Widgets for the AI list window. */
-static const NWidgetPart _nested_script_list_widgets[] = {
+static constexpr NWidgetPart _nested_script_list_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_MAUVE),
 		NWidget(WWT_CAPTION, COLOUR_MAUVE, WID_SCRL_CAPTION), SetDataTip(STR_AI_LIST_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -586,7 +586,7 @@ private:
 };
 
 /** Widgets for the Script settings window. */
-static const NWidgetPart _nested_script_settings_widgets[] = {
+static constexpr NWidgetPart _nested_script_settings_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_MAUVE),
 		NWidget(WWT_CAPTION, COLOUR_MAUVE, WID_SCRS_CAPTION), SetDataTip(STR_AI_SETTINGS_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -1237,7 +1237,7 @@ std::unique_ptr<NWidgetBase> MakeCompanyButtonRowsScriptDebug()
 }
 
 /** Widgets for the Script debug window. */
-static const NWidgetPart _nested_script_debug_widgets[] = {
+static constexpr NWidgetPart _nested_script_debug_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_AI_DEBUG, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -803,7 +803,7 @@ struct GameOptionsWindow : Window {
 	}
 };
 
-static const NWidgetPart _nested_game_options_widgets[] = {
+static constexpr NWidgetPart _nested_game_options_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_GAME_OPTIONS_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -2670,7 +2670,7 @@ struct GameSettingsWindow : Window {
 
 GameSettings *GameSettingsWindow::settings_ptr = nullptr;
 
-static const NWidgetPart _nested_settings_selection_widgets[] = {
+static constexpr NWidgetPart _nested_settings_selection_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_MAUVE),
 		NWidget(WWT_CAPTION, COLOUR_MAUVE), SetDataTip(STR_CONFIG_SETTING_TREE_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -2977,7 +2977,7 @@ struct CustomCurrencyWindow : Window {
 	}
 };
 
-static const NWidgetPart _nested_cust_currency_widgets[] = {
+static constexpr NWidgetPart _nested_cust_currency_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_CURRENCY_WINDOW, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -356,7 +356,7 @@ struct SignListWindow : Window, SignList {
 	}, SignListGlobalHotkeys};
 };
 
-static const NWidgetPart _nested_sign_list_widgets[] = {
+static constexpr NWidgetPart _nested_sign_list_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN, WID_SIL_CAPTION), SetDataTip(STR_SIGN_LIST_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -530,7 +530,7 @@ struct SignWindow : Window, SignList {
 	}
 };
 
-static const NWidgetPart _nested_query_sign_edit_widgets[] = {
+static constexpr NWidgetPart _nested_query_sign_edit_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_QES_CAPTION), SetDataTip(STR_JUST_STRING, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS), SetTextStyle(TC_WHITE),

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -1896,14 +1896,14 @@ public:
 };
 
 /** Widget parts of the smallmap display. */
-static const NWidgetPart _nested_smallmap_display[] = {
+static constexpr NWidgetPart _nested_smallmap_display[] = {
 	NWidget(WWT_PANEL, COLOUR_BROWN, WID_SM_MAP_BORDER),
 		NWidget(WWT_INSET, COLOUR_BROWN, WID_SM_MAP), SetMinimalSize(346, 140), SetResize(1, 1), SetPadding(2, 2, 2, 2), EndContainer(),
 	EndContainer(),
 };
 
 /** Widget parts of the smallmap legend bar + image buttons. */
-static const NWidgetPart _nested_smallmap_bar[] = {
+static constexpr NWidgetPart _nested_smallmap_bar[] = {
 	NWidget(WWT_PANEL, COLOUR_BROWN),
 		NWidget(NWID_HORIZONTAL),
 			NWidget(WWT_EMPTY, INVALID_COLOUR, WID_SM_LEGEND), SetResize(1, 1),
@@ -1954,7 +1954,7 @@ static std::unique_ptr<NWidgetBase> SmallMapDisplay()
 }
 
 
-static const NWidgetPart _nested_smallmap_widgets[] = {
+static constexpr NWidgetPart _nested_smallmap_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN, WID_SM_CAPTION), SetDataTip(STR_SMALLMAP_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -732,7 +732,7 @@ static std::unique_ptr<NWidgetBase> CargoWidgets()
 	return container;
 }
 
-static const NWidgetPart _nested_company_stations_widgets[] = {
+static constexpr NWidgetPart _nested_company_stations_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_STL_CAPTION), SetDataTip(STR_STATION_LIST_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -786,7 +786,7 @@ void ShowCompanyStations(CompanyID company)
 	AllocateWindowDescFront<CompanyStationsWindow>(&_company_stations_desc, company);
 }
 
-static const NWidgetPart _nested_station_view_widgets[] = {
+static constexpr NWidgetPart _nested_station_view_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_PUSHIMGBTN, COLOUR_GREY, WID_SV_RENAME), SetMinimalSize(12, 14), SetDataTip(SPR_RENAME, STR_STATION_VIEW_RENAME_TOOLTIP),
@@ -2252,7 +2252,7 @@ static const T *FindStationsNearby(TileArea ta, bool distant_join)
 	return nullptr;
 }
 
-static const NWidgetPart _nested_select_station_widgets[] = {
+static constexpr NWidgetPart _nested_select_station_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN, WID_JS_CAPTION), SetDataTip(STR_JOIN_STATION_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/statusbar_gui.cpp
+++ b/src/statusbar_gui.cpp
@@ -218,7 +218,7 @@ struct StatusBarWindow : Window {
 	}};
 };
 
-static const NWidgetPart _nested_main_status_widgets[] = {
+static constexpr NWidgetPart _nested_main_status_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_PANEL, COLOUR_GREY, WID_S_LEFT), SetMinimalSize(140, 12), EndContainer(),
 		NWidget(WWT_PUSHBTN, COLOUR_GREY, WID_S_MIDDLE), SetMinimalSize(40, 12), SetDataTip(0x0, STR_STATUSBAR_TOOLTIP_SHOW_LAST_NEWS), SetResize(1, 0),

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -947,7 +947,7 @@ GUIStoryPageElementList::SortFunction * const StoryBookWindow::page_element_sort
 	&PageElementOrderSorter,
 };
 
-static const NWidgetPart _nested_story_book_widgets[] = {
+static constexpr NWidgetPart _nested_story_book_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN, WID_SB_CAPTION), SetDataTip(STR_JUST_STRING1, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/subsidy_gui.cpp
+++ b/src/subsidy_gui.cpp
@@ -216,7 +216,7 @@ struct SubsidyListWindow : Window {
 	}
 };
 
-static const NWidgetPart _nested_subsidies_list_widgets[] = {
+static constexpr NWidgetPart _nested_subsidies_list_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN), SetDataTip(STR_SUBSIDIES_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -320,7 +320,7 @@ struct TerraformToolbarWindow : Window {
 	}, TerraformToolbarGlobalHotkeys};
 };
 
-static const NWidgetPart _nested_terraform_widgets[] = {
+static constexpr NWidgetPart _nested_terraform_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_LANDSCAPING_TOOLBAR, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -449,7 +449,7 @@ static const int8_t _multi_terraform_coords[][2] = {
 	{-28,  0}, {-24, -2}, {-20, -4}, {-16, -6}, {-12, -8}, { -8,-10}, { -4,-12}, {  0,-14}, {  4,-12}, {  8,-10}, { 12, -8}, { 16, -6}, { 20, -4}, { 24, -2}, { 28,  0},
 };
 
-static const NWidgetPart _nested_scen_edit_land_gen_widgets[] = {
+static constexpr NWidgetPart _nested_scen_edit_land_gen_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_TERRAFORM_TOOLBAR_LAND_GENERATION_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -38,7 +38,7 @@
 #include "safeguards.h"
 
 /** Widgets for the textfile window. */
-static const NWidgetPart _nested_textfile_widgets[] = {
+static constexpr NWidgetPart _nested_textfile_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_MAUVE),
 		NWidget(WWT_PUSHARROWBTN, COLOUR_MAUVE, WID_TF_NAVBACK), SetFill(0, 1), SetMinimalSize(15, 1), SetDataTip(AWV_DECREASE, STR_TEXTFILE_NAVBACK_TOOLTIP),

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -800,7 +800,7 @@ struct TimetableWindow : Window {
 	}};
 };
 
-static const NWidgetPart _nested_timetable_widgets[] = {
+static constexpr NWidgetPart _nested_timetable_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_VT_CAPTION), SetDataTip(STR_TIMETABLE_TITLE, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2179,7 +2179,7 @@ static std::unique_ptr<NWidgetBase> MakeMainToolbar()
 	return hor;
 }
 
-static const NWidgetPart _nested_toolbar_normal_widgets[] = {
+static constexpr NWidgetPart _nested_toolbar_normal_widgets[] = {
 	NWidgetFunction(MakeMainToolbar),
 };
 
@@ -2479,7 +2479,7 @@ struct ScenarioEditorToolbarWindow : Window {
 	}};
 };
 
-static const NWidgetPart _nested_toolb_scen_inner_widgets[] = {
+static constexpr NWidgetPart _nested_toolb_scen_inner_widgets[] = {
 	NWidget(WWT_IMGBTN, COLOUR_GREY, WID_TE_PAUSE), SetDataTip(SPR_IMG_PAUSE, STR_TOOLBAR_TOOLTIP_PAUSE_GAME),
 	NWidget(WWT_IMGBTN, COLOUR_GREY, WID_TE_FAST_FORWARD), SetDataTip(SPR_IMG_FASTFORWARD, STR_TOOLBAR_TOOLTIP_FORWARD),
 	NWidget(WWT_IMGBTN, COLOUR_GREY, WID_TE_SETTINGS), SetDataTip(SPR_IMG_SETTINGS, STR_TOOLBAR_TOOLTIP_OPTIONS),
@@ -2519,7 +2519,7 @@ static std::unique_ptr<NWidgetBase> MakeScenarioToolbar()
 	return MakeNWidgets(std::begin(_nested_toolb_scen_inner_widgets), std::end(_nested_toolb_scen_inner_widgets), std::make_unique<NWidgetScenarioToolbarContainer>());
 }
 
-static const NWidgetPart _nested_toolb_scen_widgets[] = {
+static constexpr NWidgetPart _nested_toolb_scen_widgets[] = {
 	NWidgetFunction(MakeScenarioToolbar),
 };
 

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -50,7 +50,7 @@ TownKdtree _town_local_authority_kdtree(&Kdtree_TownXYFunc);
 
 typedef GUIList<const Town*, const bool &> GUITownList;
 
-static const NWidgetPart _nested_town_authority_widgets[] = {
+static constexpr NWidgetPart _nested_town_authority_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN, WID_TA_CAPTION), SetDataTip(STR_LOCAL_AUTHORITY_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -597,7 +597,7 @@ public:
 	}};
 };
 
-static const NWidgetPart _nested_town_game_view_widgets[] = {
+static constexpr NWidgetPart _nested_town_game_view_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_PUSHIMGBTN, COLOUR_BROWN, WID_TV_CHANGE_NAME), SetMinimalSize(12, 14), SetDataTip(SPR_RENAME, STR_TOWN_VIEW_RENAME_TOOLTIP),
@@ -627,7 +627,7 @@ static WindowDesc _town_game_view_desc(__FILE__, __LINE__,
 	std::begin(_nested_town_game_view_widgets), std::end(_nested_town_game_view_widgets)
 );
 
-static const NWidgetPart _nested_town_editor_view_widgets[] = {
+static constexpr NWidgetPart _nested_town_editor_view_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_PUSHIMGBTN, COLOUR_BROWN, WID_TV_CHANGE_NAME), SetMinimalSize(12, 14), SetDataTip(SPR_RENAME, STR_TOWN_VIEW_RENAME_TOOLTIP),
@@ -667,7 +667,7 @@ void ShowTownViewWindow(TownID town)
 	}
 }
 
-static const NWidgetPart _nested_town_directory_widgets[] = {
+static constexpr NWidgetPart _nested_town_directory_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN), SetDataTip(STR_TOWN_DIRECTORY_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -1075,7 +1075,7 @@ void CcFoundRandomTown(Commands, const CommandCost &result, Money, TownID town_i
 	if (result.Succeeded()) ScrollMainWindowToTile(Town::Get(town_id)->xy);
 }
 
-static const NWidgetPart _nested_found_town_widgets[] = {
+static constexpr NWidgetPart _nested_found_town_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_FOUND_TOWN_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/transparency_gui.cpp
+++ b/src/transparency_gui.cpp
@@ -125,7 +125,7 @@ public:
 	}
 };
 
-static const NWidgetPart _nested_transparency_widgets[] = {
+static constexpr NWidgetPart _nested_transparency_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_TRANSPARENCY_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/tree_gui.cpp
+++ b/src/tree_gui.cpp
@@ -285,7 +285,7 @@ static std::unique_ptr<NWidgetBase> MakeTreeTypeButtons()
 	return vstack;
 }
 
-static const NWidgetPart _nested_build_trees_widgets[] = {
+static constexpr NWidgetPart _nested_build_trees_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_PLANT_TREE_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1207,7 +1207,7 @@ struct RefitWindow : public Window {
 	}
 };
 
-static const NWidgetPart _nested_vehicle_refit_widgets[] = {
+static constexpr NWidgetPart _nested_vehicle_refit_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_VR_CAPTION), SetDataTip(STR_REFIT_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -1495,7 +1495,7 @@ void ChangeVehicleViewWindow(VehicleID from_index, VehicleID to_index)
 	ChangeVehicleWindow(WC_VEHICLE_TIMETABLE, from_index, to_index);
 }
 
-static const NWidgetPart _nested_vehicle_list[] = {
+static constexpr NWidgetPart _nested_vehicle_list[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(NWID_SELECTION, INVALID_COLOUR, WID_VL_CAPTION_SELECTION),
@@ -2232,7 +2232,7 @@ static_assert(WID_VD_DETAILS_CAPACITY_OF_EACH == WID_VD_DETAILS_CARGO_CARRIED + 
 static_assert(WID_VD_DETAILS_TOTAL_CARGO      == WID_VD_DETAILS_CARGO_CARRIED + TDW_TAB_TOTALS  );
 
 /** Vehicle details widgets (other than train). */
-static const NWidgetPart _nested_nontrain_vehicle_details_widgets[] = {
+static constexpr NWidgetPart _nested_nontrain_vehicle_details_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_VD_CAPTION), SetDataTip(STR_VEHICLE_DETAILS_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -2255,7 +2255,7 @@ static const NWidgetPart _nested_nontrain_vehicle_details_widgets[] = {
 };
 
 /** Train details widgets. */
-static const NWidgetPart _nested_train_vehicle_details_widgets[] = {
+static constexpr NWidgetPart _nested_train_vehicle_details_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_VD_CAPTION), SetDataTip(STR_VEHICLE_DETAILS_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -2693,7 +2693,7 @@ static void ShowVehicleDetailsWindow(const Vehicle *v)
 /* Unified vehicle GUI - Vehicle View Window */
 
 /** Vehicle view widgets. */
-static const NWidgetPart _nested_vehicle_view_widgets[] = {
+static constexpr NWidgetPart _nested_vehicle_view_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_PUSHIMGBTN, COLOUR_GREY, WID_VV_RENAME), SetMinimalSize(12, 14), SetDataTip(SPR_RENAME, STR_NULL /* filled in later */),

--- a/src/viewport_gui.cpp
+++ b/src/viewport_gui.cpp
@@ -23,7 +23,7 @@
 #include "safeguards.h"
 
 /* Extra Viewport Window Stuff */
-static const NWidgetPart _nested_extra_viewport_widgets[] = {
+static constexpr NWidgetPart _nested_extra_viewport_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_EV_CAPTION), SetDataTip(STR_EXTRA_VIEWPORT_TITLE, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),

--- a/src/waypoint_gui.cpp
+++ b/src/waypoint_gui.cpp
@@ -160,7 +160,7 @@ public:
 };
 
 /** The widgets of the waypoint view. */
-static const NWidgetPart _nested_waypoint_view_widgets[] = {
+static constexpr NWidgetPart _nested_waypoint_view_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
 		NWidget(WWT_PUSHIMGBTN, COLOUR_GREY, WID_W_RENAME), SetMinimalSize(12, 14), SetDataTip(SPR_RENAME, STR_BUOY_VIEW_CHANGE_BUOY_NAME),

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -25,145 +25,6 @@
 
 #include "safeguards.h"
 
-/** Distances used in drawing widgets. */
-enum WidgetDrawDistances {
-	/* WWT_IMGBTN(_2) */
-	WD_IMGBTN_LEFT    = 1,      ///< Left offset of the image in the button.
-	WD_IMGBTN_RIGHT   = 1,      ///< Right offset of the image in the button.
-	WD_IMGBTN_TOP     = 1,      ///< Top offset of image in the button.
-	WD_IMGBTN_BOTTOM  = 1,      ///< Bottom offset of image in the button.
-
-	/* WWT_INSET */
-	WD_INSET_LEFT  = 2,         ///< Left offset of string.
-	WD_INSET_RIGHT = 2,         ///< Right offset of string.
-	WD_INSET_TOP   = 1,         ///< Top offset of string.
-
-	WD_VSCROLLBAR_LEFT   = 2,   ///< Left offset of vertical scrollbar.
-	WD_VSCROLLBAR_RIGHT  = 2,   ///< Right offset of vertical scrollbar.
-	WD_VSCROLLBAR_TOP    = 3,   ///< Top offset of vertical scrollbar.
-	WD_VSCROLLBAR_BOTTOM = 3,   ///< Bottom offset of vertical scrollbar.
-
-	WD_HSCROLLBAR_LEFT   = 3,   ///< Left offset of horizontal scrollbar.
-	WD_HSCROLLBAR_RIGHT  = 3,   ///< Right offset of horizontal scrollbar.
-	WD_HSCROLLBAR_TOP    = 2,   ///< Top offset of horizontal scrollbar.
-	WD_HSCROLLBAR_BOTTOM = 2,   ///< Bottom offset of horizontal scrollbar.
-
-	/* Size of the pure frame bevel without any padding. */
-	WD_BEVEL_LEFT       = 1,    ///< Width of left bevel border.
-	WD_BEVEL_RIGHT      = 1,    ///< Width of right bevel border.
-	WD_BEVEL_TOP        = 1,    ///< Height of top bevel border.
-	WD_BEVEL_BOTTOM     = 1,    ///< Height of bottom bevel border.
-
-	/* FrameRect widgets, all text buttons, panel, editbox */
-	WD_FRAMERECT_LEFT   = 2,    ///< Offset at left to draw the frame rectangular area
-	WD_FRAMERECT_RIGHT  = 2,    ///< Offset at right to draw the frame rectangular area
-	WD_FRAMERECT_TOP    = 1,    ///< Offset at top to draw the frame rectangular area
-	WD_FRAMERECT_BOTTOM = 1,    ///< Offset at bottom to draw the frame rectangular area
-
-	/* WWT_FRAME */
-	WD_FRAMETEXT_LEFT   = 6,    ///< Left offset of the text of the frame.
-	WD_FRAMETEXT_RIGHT  = 6,    ///< Right offset of the text of the frame.
-	WD_FRAMETEXT_TOP    = 6,    ///< Top offset of the text of the frame
-	WD_FRAMETEXT_BOTTOM = 6,    ///< Bottom offset of the text of the frame
-
-	/* WWT_MATRIX */
-	WD_MATRIX_LEFT   = 2,       ///< Offset at left of a matrix cell.
-	WD_MATRIX_RIGHT  = 2,       ///< Offset at right of a matrix cell.
-	WD_MATRIX_TOP    = 3,       ///< Offset at top of a matrix cell.
-	WD_MATRIX_BOTTOM = 1,       ///< Offset at bottom of a matrix cell.
-
-	/* WWT_SHADEBOX */
-	WD_SHADEBOX_WIDTH  = 12,    ///< Width of a standard shade box widget.
-	WD_SHADEBOX_LEFT   = 2,     ///< Left offset of shade sprite.
-	WD_SHADEBOX_RIGHT  = 2,     ///< Right offset of shade sprite.
-	WD_SHADEBOX_TOP    = 3,     ///< Top offset of shade sprite.
-	WD_SHADEBOX_BOTTOM = 3,     ///< Bottom offset of shade sprite.
-
-	/* WWT_STICKYBOX */
-	WD_STICKYBOX_WIDTH  = 12,   ///< Width of a standard sticky box widget.
-	WD_STICKYBOX_LEFT   = 2,    ///< Left offset of sticky sprite.
-	WD_STICKYBOX_RIGHT  = 2,    ///< Right offset of sticky sprite.
-	WD_STICKYBOX_TOP    = 3,    ///< Top offset of sticky sprite.
-	WD_STICKYBOX_BOTTOM = 3,    ///< Bottom offset of sticky sprite.
-
-	/* WWT_DEBUGBOX */
-	WD_DEBUGBOX_WIDTH  = 12,    ///< Width of a standard debug box widget.
-	WD_DEBUGBOX_LEFT   = 2,     ///< Left offset of debug sprite.
-	WD_DEBUGBOX_RIGHT  = 2,     ///< Right offset of debug sprite.
-	WD_DEBUGBOX_TOP    = 3,     ///< Top offset of debug sprite.
-	WD_DEBUGBOX_BOTTOM = 3,     ///< Bottom offset of debug sprite.
-
-	/* WWT_DEFSIZEBOX */
-	WD_DEFSIZEBOX_WIDTH  = 12,  ///< Width of a standard defsize box widget.
-	WD_DEFSIZEBOX_LEFT   = 2,   ///< Left offset of defsize sprite.
-	WD_DEFSIZEBOX_RIGHT  = 2,   ///< Right offset of defsize sprite.
-	WD_DEFSIZEBOX_TOP    = 3,   ///< Top offset of defsize sprite.
-	WD_DEFSIZEBOX_BOTTOM = 3,   ///< Bottom offset of defsize sprite.
-
-	/* WWT_RESIZEBOX */
-	WD_RESIZEBOX_WIDTH  = 12,   ///< Width of a resize box widget.
-	WD_RESIZEBOX_LEFT   = 2,    ///< Left offset of resize sprite.
-	WD_RESIZEBOX_RIGHT  = 2,    ///< Right offset of resize sprite.
-	WD_RESIZEBOX_TOP    = 2,    ///< Top offset of resize sprite.
-	WD_RESIZEBOX_BOTTOM = 2,    ///< Bottom offset of resize sprite.
-
-	/* WWT_CLOSEBOX */
-	WD_CLOSEBOX_WIDTH  = 11,    ///< Width of a close box widget.
-	WD_CLOSEBOX_LEFT   = 2,     ///< Left offset of closebox string.
-	WD_CLOSEBOX_RIGHT  = 1,     ///< Right offset of closebox string.
-	WD_CLOSEBOX_TOP    = 2,     ///< Top offset of closebox string.
-	WD_CLOSEBOX_BOTTOM = 2,     ///< Bottom offset of closebox string.
-
-	/* WWT_CAPTION */
-	WD_CAPTION_HEIGHT     = 14, ///< Height of a title bar.
-	WD_CAPTIONTEXT_LEFT   = 2,  ///< Offset of the caption text at the left.
-	WD_CAPTIONTEXT_RIGHT  = 2,  ///< Offset of the caption text at the right.
-	WD_CAPTIONTEXT_TOP    = 2,  ///< Offset of the caption text at the top.
-	WD_CAPTIONTEXT_BOTTOM = 2,  ///< Offset of the caption text at the bottom.
-
-	/* Dropdown widget. */
-	WD_DROPDOWN_HEIGHT     = 12, ///< Height of a drop down widget.
-	WD_DROPDOWNTEXT_LEFT   = 2,  ///< Left offset of the dropdown widget string.
-	WD_DROPDOWNTEXT_RIGHT  = 2,  ///< Right offset of the dropdown widget string.
-	WD_DROPDOWNTEXT_TOP    = 1,  ///< Top offset of the dropdown widget string.
-	WD_DROPDOWNTEXT_BOTTOM = 1,  ///< Bottom offset of the dropdown widget string.
-
-	WD_PAR_VSEP_NORMAL = 2,      ///< Normal amount of vertical space between two paragraphs of text.
-	WD_PAR_VSEP_WIDE   = 8,      ///< Large amount of vertical space between two paragraphs of text.
-};
-
-const WidgetDimensions WidgetDimensions::unscaled = {
-	{WD_IMGBTN_LEFT,       WD_IMGBTN_TOP,       WD_IMGBTN_RIGHT,       WD_IMGBTN_BOTTOM},       ///< imgbtn
-	{WD_INSET_LEFT,        WD_INSET_TOP,        WD_INSET_RIGHT,        WD_BEVEL_BOTTOM},        ///< inset
-	{WD_VSCROLLBAR_LEFT,   WD_VSCROLLBAR_TOP,   WD_VSCROLLBAR_RIGHT,   WD_VSCROLLBAR_BOTTOM},   ///< vscrollbar
-	{WD_HSCROLLBAR_LEFT,   WD_HSCROLLBAR_TOP,   WD_HSCROLLBAR_RIGHT,   WD_HSCROLLBAR_BOTTOM},   ///< hscrollbar
-	{WD_BEVEL_LEFT,        WD_BEVEL_TOP,        WD_BEVEL_RIGHT,        WD_BEVEL_BOTTOM},        ///< bevel
-	{WD_BEVEL_LEFT,        WD_BEVEL_TOP,        WD_BEVEL_RIGHT,        WD_BEVEL_BOTTOM},        ///< fullbevel
-	{WD_FRAMERECT_LEFT,    WD_FRAMERECT_TOP,    WD_FRAMERECT_RIGHT,    WD_FRAMERECT_BOTTOM},    ///< framerect
-	{WD_FRAMETEXT_LEFT,    WD_FRAMETEXT_TOP,    WD_FRAMETEXT_RIGHT,    WD_FRAMETEXT_BOTTOM},    ///< frametext
-	{WD_MATRIX_LEFT,       WD_MATRIX_TOP,       WD_MATRIX_RIGHT,       WD_MATRIX_BOTTOM},       ///< matrix
-	{WD_SHADEBOX_LEFT,     WD_SHADEBOX_TOP,     WD_SHADEBOX_RIGHT,     WD_SHADEBOX_BOTTOM},     ///< shadebox
-	{WD_STICKYBOX_LEFT,    WD_STICKYBOX_TOP,    WD_STICKYBOX_RIGHT,    WD_STICKYBOX_BOTTOM},    ///< stickybox
-	{WD_DEBUGBOX_LEFT,     WD_DEBUGBOX_TOP,     WD_DEBUGBOX_RIGHT,     WD_DEBUGBOX_BOTTOM},     ///< debugbox
-	{WD_DEFSIZEBOX_LEFT,   WD_DEFSIZEBOX_TOP,   WD_DEFSIZEBOX_RIGHT,   WD_DEFSIZEBOX_BOTTOM},   ///< defsizebox
-	{WD_RESIZEBOX_LEFT,    WD_RESIZEBOX_TOP,    WD_RESIZEBOX_RIGHT,    WD_RESIZEBOX_BOTTOM},    ///< resizebox
-	{WD_CLOSEBOX_LEFT,     WD_CLOSEBOX_TOP,     WD_CLOSEBOX_RIGHT,     WD_CLOSEBOX_BOTTOM},     ///< closebox
-	{WD_CAPTIONTEXT_LEFT,  WD_CAPTIONTEXT_TOP,  WD_CAPTIONTEXT_RIGHT,  WD_CAPTIONTEXT_BOTTOM},  ///< captiontext
-	{WD_DROPDOWNTEXT_LEFT, WD_DROPDOWNTEXT_TOP, WD_DROPDOWNTEXT_RIGHT, WD_DROPDOWNTEXT_BOTTOM}, ///< dropdowntext
-	{WD_BEVEL_LEFT,        WD_BEVEL_TOP * 2,    WD_BEVEL_RIGHT,        WD_BEVEL_BOTTOM * 2},    ///< dropdownmenu
-	{20, 10, 20, 10},    ///< modalpopup
-	{3, 3, 3, 3},        ///< picker
-	{10, 8, 10, 8},      ///< sparse window padding
-	{10, 8, 10, 0},      ///< resizable sparse window padding
-	1,                   ///< vsep_picker
-	WD_PAR_VSEP_NORMAL,  ///< vsep_normal
-	4,                   ///< vsep_sparse
-	WD_PAR_VSEP_WIDE,    ///< vsep_wide
-	2,                   ///< hsep_normal
-	6,                   ///< hsep_wide
-	10,                  ///< hsep_indent
-};
-
 WidgetDimensions WidgetDimensions::scaled = {};
 
 /**
@@ -2650,50 +2511,50 @@ NWidgetLeaf::NWidgetLeaf(WidgetType tp, Colours colour, WidgetID index, uint32_t
 		case WWT_CAPTION:
 			this->SetFill(1, 0);
 			this->SetResize(1, 0);
-			this->SetMinimalSize(0, WD_CAPTION_HEIGHT);
+			this->SetMinimalSize(0, WidgetDimensions::WD_CAPTION_HEIGHT);
 			this->SetMinimalTextLines(1, WidgetDimensions::unscaled.captiontext.Vertical(), FS_NORMAL);
 			this->SetDataTip(data, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS);
 			break;
 
 		case WWT_STICKYBOX:
 			this->SetFill(0, 0);
-			this->SetMinimalSize(WD_STICKYBOX_WIDTH, WD_CAPTION_HEIGHT);
+			this->SetMinimalSize(WidgetDimensions::WD_STICKYBOX_WIDTH, WidgetDimensions::WD_CAPTION_HEIGHT);
 			this->SetDataTip(STR_NULL, STR_TOOLTIP_STICKY);
 			break;
 
 		case WWT_SHADEBOX:
 			this->SetFill(0, 0);
-			this->SetMinimalSize(WD_SHADEBOX_WIDTH, WD_CAPTION_HEIGHT);
+			this->SetMinimalSize(WidgetDimensions::WD_SHADEBOX_WIDTH, WidgetDimensions::WD_CAPTION_HEIGHT);
 			this->SetDataTip(STR_NULL, STR_TOOLTIP_SHADE);
 			break;
 
 		case WWT_DEBUGBOX:
 			this->SetFill(0, 0);
-			this->SetMinimalSize(WD_DEBUGBOX_WIDTH, WD_CAPTION_HEIGHT);
+			this->SetMinimalSize(WidgetDimensions::WD_DEBUGBOX_WIDTH, WidgetDimensions::WD_CAPTION_HEIGHT);
 			this->SetDataTip(STR_NULL, STR_TOOLTIP_DEBUG);
 			break;
 
 		case WWT_DEFSIZEBOX:
 			this->SetFill(0, 0);
-			this->SetMinimalSize(WD_DEFSIZEBOX_WIDTH, WD_CAPTION_HEIGHT);
+			this->SetMinimalSize(WidgetDimensions::WD_DEFSIZEBOX_WIDTH, WidgetDimensions::WD_CAPTION_HEIGHT);
 			this->SetDataTip(STR_NULL, STR_TOOLTIP_DEFSIZE);
 			break;
 
 		case WWT_RESIZEBOX:
 			this->SetFill(0, 0);
-			this->SetMinimalSize(WD_RESIZEBOX_WIDTH, 12);
+			this->SetMinimalSize(WidgetDimensions::WD_RESIZEBOX_WIDTH, 12);
 			this->SetDataTip(RWV_SHOW_BEVEL, STR_TOOLTIP_RESIZE);
 			break;
 
 		case WWT_CLOSEBOX:
 			this->SetFill(0, 0);
-			this->SetMinimalSize(WD_CLOSEBOX_WIDTH, WD_CAPTION_HEIGHT);
+			this->SetMinimalSize(WidgetDimensions::WD_CLOSEBOX_WIDTH, WidgetDimensions::WD_CAPTION_HEIGHT);
 			this->SetDataTip(STR_NULL, STR_TOOLTIP_CLOSE_WINDOW);
 			break;
 
 		case WWT_DROPDOWN:
 			this->SetFill(0, 0);
-			this->SetMinimalSize(0, WD_DROPDOWN_HEIGHT);
+			this->SetMinimalSize(0, WidgetDimensions::WD_DROPDOWN_HEIGHT);
 			this->SetAlignment(SA_TOP | SA_LEFT);
 			break;
 

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -1037,7 +1037,7 @@ typedef std::unique_ptr<NWidgetBase> NWidgetFunctionType();
  */
 struct NWidgetPart {
 	WidgetType type;                         ///< Type of the part. @see NWidgetPartType.
-	union {
+	union NWidgetPartUnion {
 		Point xy;                        ///< Part with an x/y size.
 		NWidgetPartDataTip data_tip;     ///< Part with a data/tooltip.
 		NWidgetPartWidget widget;        ///< Part with a start of a widget.
@@ -1048,7 +1048,33 @@ struct NWidgetPart {
 		NWidgetPartAlignment align;      ///< Part with internal alignment.
 		NWidgetFunctionType *func_ptr;   ///< Part with a function call.
 		NWidContainerFlags cont_flags;   ///< Part with container flags.
+
+		/* Constructors for each NWidgetPartUnion data type. */
+		constexpr NWidgetPartUnion() : xy() {}
+		constexpr NWidgetPartUnion(Point xy) : xy(xy) {}
+		constexpr NWidgetPartUnion(NWidgetPartDataTip data_tip) : data_tip(data_tip) {}
+		constexpr NWidgetPartUnion(NWidgetPartWidget widget) : widget(widget) {}
+		constexpr NWidgetPartUnion(NWidgetPartPaddings padding) : padding(padding) {}
+		constexpr NWidgetPartUnion(NWidgetPartPIP pip) : pip(pip) {}
+		constexpr NWidgetPartUnion(NWidgetPartTextLines text_lines) : text_lines(text_lines) {}
+		constexpr NWidgetPartUnion(NWidgetPartTextStyle text_style) : text_style(text_style) {}
+		constexpr NWidgetPartUnion(NWidgetPartAlignment align) : align(align) {}
+		constexpr NWidgetPartUnion(NWidgetFunctionType *func_ptr) : func_ptr(func_ptr) {}
+		constexpr NWidgetPartUnion(NWidContainerFlags cont_flags) : cont_flags(cont_flags) {}
 	} u;
+
+	/* Constructors for each NWidgetPart data type. */
+	explicit constexpr NWidgetPart(WidgetType type) : type(type), u() {}
+	constexpr NWidgetPart(WidgetType type, Point xy) : type(type), u(xy) {}
+	constexpr NWidgetPart(WidgetType type, NWidgetPartDataTip data_tip) : type(type), u(data_tip) {}
+	constexpr NWidgetPart(WidgetType type, NWidgetPartWidget widget) : type(type), u(widget) {}
+	constexpr NWidgetPart(WidgetType type, NWidgetPartPaddings padding) : type(type), u(padding) {}
+	constexpr NWidgetPart(WidgetType type, NWidgetPartPIP pip) : type(type), u(pip) {}
+	constexpr NWidgetPart(WidgetType type, NWidgetPartTextLines text_lines) : type(type), u(text_lines) {}
+	constexpr NWidgetPart(WidgetType type, NWidgetPartTextStyle text_style) : type(type), u(text_style) {}
+	constexpr NWidgetPart(WidgetType type, NWidgetPartAlignment align) : type(type), u(align) {}
+	constexpr NWidgetPart(WidgetType type, NWidgetFunctionType *func_ptr) : type(type), u(func_ptr) {}
+	constexpr NWidgetPart(WidgetType type, NWidContainerFlags cont_flags) : type(type), u(cont_flags) {}
 };
 
 /**
@@ -1057,15 +1083,9 @@ struct NWidgetPart {
  * @param dy Vertical resize step. 0 means no vertical resizing.
  * @ingroup NestedWidgetParts
  */
-inline NWidgetPart SetResize(int16_t dx, int16_t dy)
+constexpr NWidgetPart SetResize(int16_t dx, int16_t dy)
 {
-	NWidgetPart part;
-
-	part.type = WPT_RESIZE;
-	part.u.xy.x = dx;
-	part.u.xy.y = dy;
-
-	return part;
+	return NWidgetPart{WPT_RESIZE, Point{dx, dy}};
 }
 
 /**
@@ -1074,15 +1094,9 @@ inline NWidgetPart SetResize(int16_t dx, int16_t dy)
  * @param y Vertical minimal size.
  * @ingroup NestedWidgetParts
  */
-inline NWidgetPart SetMinimalSize(int16_t x, int16_t y)
+constexpr NWidgetPart SetMinimalSize(int16_t x, int16_t y)
 {
-	NWidgetPart part;
-
-	part.type = WPT_MINSIZE;
-	part.u.xy.x = x;
-	part.u.xy.y = y;
-
-	return part;
+	return NWidgetPart{WPT_MINSIZE, Point{x, y}};
 }
 
 /**
@@ -1092,16 +1106,9 @@ inline NWidgetPart SetMinimalSize(int16_t x, int16_t y)
  * @param size    Font size of text.
  * @ingroup NestedWidgetParts
  */
-inline NWidgetPart SetMinimalTextLines(uint8_t lines, uint8_t spacing, FontSize size = FS_NORMAL)
+constexpr NWidgetPart SetMinimalTextLines(uint8_t lines, uint8_t spacing, FontSize size = FS_NORMAL)
 {
-	NWidgetPart part;
-
-	part.type = WPT_MINTEXTLINES;
-	part.u.text_lines.lines = lines;
-	part.u.text_lines.spacing = spacing;
-	part.u.text_lines.size = size;
-
-	return part;
+	return NWidgetPart{WPT_MINTEXTLINES, NWidgetPartTextLines{lines, spacing, size}};
 }
 
 /**
@@ -1110,15 +1117,9 @@ inline NWidgetPart SetMinimalTextLines(uint8_t lines, uint8_t spacing, FontSize 
  * @param size Font size to draw string within widget.
  * @ingroup NestedWidgetParts
  */
-inline NWidgetPart SetTextStyle(TextColour colour, FontSize size = FS_NORMAL)
+constexpr NWidgetPart SetTextStyle(TextColour colour, FontSize size = FS_NORMAL)
 {
-	NWidgetPart part;
-
-	part.type = WPT_TEXTSTYLE;
-	part.u.text_style.colour = colour;
-	part.u.text_style.size = size;
-
-	return part;
+	return NWidgetPart{WPT_TEXTSTYLE, NWidgetPartTextStyle{colour, size}};
 }
 
 /**
@@ -1126,14 +1127,9 @@ inline NWidgetPart SetTextStyle(TextColour colour, FontSize size = FS_NORMAL)
  * @param align  Alignment of text/image within widget.
  * @ingroup NestedWidgetParts
  */
-inline NWidgetPart SetAlignment(StringAlignment align)
+constexpr NWidgetPart SetAlignment(StringAlignment align)
 {
-	NWidgetPart part;
-
-	part.type = WPT_ALIGNMENT;
-	part.u.align.align = align;
-
-	return part;
+	return NWidgetPart{WPT_ALIGNMENT, NWidgetPartAlignment{align}};
 }
 
 /**
@@ -1142,15 +1138,9 @@ inline NWidgetPart SetAlignment(StringAlignment align)
  * @param fill_y Vertical filling step from minimal size.
  * @ingroup NestedWidgetParts
  */
-inline NWidgetPart SetFill(uint fill_x, uint fill_y)
+constexpr NWidgetPart SetFill(uint16_t fill_x, uint16_t fill_y)
 {
-	NWidgetPart part;
-
-	part.type = WPT_FILL;
-	part.u.xy.x = fill_x;
-	part.u.xy.y = fill_y;
-
-	return part;
+	return NWidgetPart{WPT_FILL, Point{fill_x, fill_y}};
 }
 
 /**
@@ -1158,13 +1148,9 @@ inline NWidgetPart SetFill(uint fill_x, uint fill_y)
  * (horizontal, vertical, WWT_FRAME, WWT_INSET, or WWT_PANEL).
  * @ingroup NestedWidgetParts
  */
-inline NWidgetPart EndContainer()
+constexpr NWidgetPart EndContainer()
 {
-	NWidgetPart part;
-
-	part.type = WPT_ENDCONTAINER;
-
-	return part;
+	return NWidgetPart{WPT_ENDCONTAINER};
 }
 
 /**
@@ -1173,15 +1159,9 @@ inline NWidgetPart EndContainer()
  * @param tip  Tooltip of the widget.
  * @ingroup NestedWidgetParts
  */
-inline NWidgetPart SetDataTip(uint32_t data, StringID tip)
+constexpr NWidgetPart SetDataTip(uint32_t data, StringID tip)
 {
-	NWidgetPart part;
-
-	part.type = WPT_DATATIP;
-	part.u.data_tip.data = data;
-	part.u.data_tip.tooltip = tip;
-
-	return part;
+	return NWidgetPart{WPT_DATATIP, NWidgetPartDataTip{data, tip}};
 }
 
 /**
@@ -1191,7 +1171,7 @@ inline NWidgetPart SetDataTip(uint32_t data, StringID tip)
  * @param tip  Tooltip of the widget.
  * @ingroup NestedWidgetParts
  */
-inline NWidgetPart SetMatrixDataTip(uint8_t cols, uint8_t rows, StringID tip)
+constexpr NWidgetPart SetMatrixDataTip(uint8_t cols, uint8_t rows, StringID tip)
 {
 	return SetDataTip((rows << MAT_ROW_START) | (cols << MAT_COL_START), tip);
 }
@@ -1205,17 +1185,9 @@ inline NWidgetPart SetMatrixDataTip(uint8_t cols, uint8_t rows, StringID tip)
  * @param left The padding left of the widget.
  * @ingroup NestedWidgetParts
  */
-inline NWidgetPart SetPadding(uint8_t top, uint8_t right, uint8_t bottom, uint8_t left)
+constexpr NWidgetPart SetPadding(uint8_t top, uint8_t right, uint8_t bottom, uint8_t left)
 {
-	NWidgetPart part;
-
-	part.type = WPT_PADDING;
-	part.u.padding.top = top;
-	part.u.padding.right = right;
-	part.u.padding.bottom = bottom;
-	part.u.padding.left = left;
-
-	return part;
+	return NWidgetPart{WPT_PADDING, NWidgetPartPaddings{left, top, right, bottom}};
 }
 
 /**
@@ -1223,17 +1195,9 @@ inline NWidgetPart SetPadding(uint8_t top, uint8_t right, uint8_t bottom, uint8_
  * @param r The padding around the widget.
  * @ingroup NestedWidgetParts
  */
-inline NWidgetPart SetPadding(const RectPadding &padding)
+constexpr NWidgetPart SetPadding(const RectPadding &padding)
 {
-	NWidgetPart part;
-
-	part.type = WPT_PADDING;
-	part.u.padding.left = padding.left;
-	part.u.padding.top = padding.top;
-	part.u.padding.right = padding.right;
-	part.u.padding.bottom = padding.bottom;
-
-	return part;
+	return NWidgetPart{WPT_PADDING, NWidgetPartPaddings{padding}};
 }
 
 /**
@@ -1241,7 +1205,7 @@ inline NWidgetPart SetPadding(const RectPadding &padding)
  * @param padding The padding to use for all directions.
  * @ingroup NestedWidgetParts
  */
-inline NWidgetPart SetPadding(uint8_t padding)
+constexpr NWidgetPart SetPadding(uint8_t padding)
 {
 	return SetPadding(padding, padding, padding, padding);
 }
@@ -1253,16 +1217,9 @@ inline NWidgetPart SetPadding(uint8_t padding)
  * @param post The amount of space after the last widget.
  * @ingroup NestedWidgetParts
  */
-inline NWidgetPart SetPIP(uint8_t pre, uint8_t inter, uint8_t post)
+constexpr NWidgetPart SetPIP(uint8_t pre, uint8_t inter, uint8_t post)
 {
-	NWidgetPart part;
-
-	part.type = WPT_PIPSPACE;
-	part.u.pip.pre = pre;
-	part.u.pip.inter = inter;
-	part.u.pip.post = post;
-
-	return part;
+	return NWidgetPart{WPT_PIPSPACE, NWidgetPartPIP{pre, inter, post}};
 }
 
 /**
@@ -1272,16 +1229,9 @@ inline NWidgetPart SetPIP(uint8_t pre, uint8_t inter, uint8_t post)
  * @param post The ratio of space after the last widget.
  * @ingroup NestedWidgetParts
  */
-inline NWidgetPart SetPIPRatio(uint8_t ratio_pre, uint8_t ratio_inter, uint8_t ratio_post)
+constexpr NWidgetPart SetPIPRatio(uint8_t ratio_pre, uint8_t ratio_inter, uint8_t ratio_post)
 {
-	NWidgetPart part;
-
-	part.type = WPT_PIPRATIO;
-	part.u.pip.pre = ratio_pre;
-	part.u.pip.inter = ratio_inter;
-	part.u.pip.post = ratio_post;
-
-	return part;
+	return NWidgetPart{WPT_PIPRATIO, NWidgetPartPIP{ratio_pre, ratio_inter, ratio_post}};
 }
 
 /**
@@ -1291,14 +1241,9 @@ inline NWidgetPart SetPIPRatio(uint8_t ratio_pre, uint8_t ratio_inter, uint8_t r
  * @param index Widget index of the scrollbar.
  * @ingroup NestedWidgetParts
  */
-inline NWidgetPart SetScrollbar(WidgetID index)
+constexpr NWidgetPart SetScrollbar(WidgetID index)
 {
-	NWidgetPart part;
-
-	part.type = WPT_SCROLLBAR;
-	part.u.widget.index = index;
-
-	return part;
+	return NWidgetPart{WPT_SCROLLBAR, NWidgetPartWidget{INVALID_COLOUR, index}};
 }
 
 /**
@@ -1310,15 +1255,9 @@ inline NWidgetPart SetScrollbar(WidgetID index)
  *       Child widgets must have a index bigger than the parent index.
  * @ingroup NestedWidgetParts
  */
-inline NWidgetPart NWidget(WidgetType tp, Colours col, int idx = -1)
+constexpr NWidgetPart NWidget(WidgetType tp, Colours col, WidgetID idx = -1)
 {
-	NWidgetPart part;
-
-	part.type = tp;
-	part.u.widget.colour = col;
-	part.u.widget.index = idx;
-
-	return part;
+	return NWidgetPart{tp, NWidgetPartWidget{col, idx}};
 }
 
 /**
@@ -1327,14 +1266,9 @@ inline NWidgetPart NWidget(WidgetType tp, Colours col, int idx = -1)
  * @param cont_flags Flags for the containers (#NWID_HORIZONTAL and #NWID_VERTICAL).
  * @ingroup NestedWidgetParts
  */
-inline NWidgetPart NWidget(WidgetType tp, NWidContainerFlags cont_flags = NC_NONE)
+constexpr NWidgetPart NWidget(WidgetType tp, NWidContainerFlags cont_flags = NC_NONE)
 {
-	NWidgetPart part;
-
-	part.type = tp;
-	part.u.cont_flags = cont_flags;
-
-	return part;
+	return NWidgetPart{tp, NWidContainerFlags{cont_flags}};
 }
 
 /**
@@ -1342,14 +1276,9 @@ inline NWidgetPart NWidget(WidgetType tp, NWidContainerFlags cont_flags = NC_NON
  * @param func_ptr Pointer to function that returns the tree.
  * @ingroup NestedWidgetParts
  */
-inline NWidgetPart NWidgetFunction(NWidgetFunctionType *func_ptr)
+constexpr NWidgetPart NWidgetFunction(NWidgetFunctionType *func_ptr)
 {
-	NWidgetPart part;
-
-	part.type = WPT_FUNCTION;
-	part.u.func_ptr = func_ptr;
-
-	return part;
+	return NWidgetPart{WPT_FUNCTION, func_ptr};
 }
 
 bool IsContainerWidgetType(WidgetType tp);

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -22,7 +22,7 @@
 #include "../safeguards.h"
 
 
-static const NWidgetPart _nested_dropdown_menu_widgets[] = {
+static constexpr NWidgetPart _nested_dropdown_menu_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_PANEL, COLOUR_END, WID_DM_ITEMS), SetScrollbar(WID_DM_SCROLL), EndContainer(),
 		NWidget(NWID_SELECTION, INVALID_COLOUR, WID_DM_SHOW_SCROLL),

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -31,7 +31,8 @@ enum FrameFlags {
 
 DECLARE_ENUM_AS_BIT_SET(FrameFlags)
 
-struct WidgetDimensions {
+class WidgetDimensions {
+public:
 	RectPadding imgbtn;
 	RectPadding inset;
 	RectPadding vscrollbar;
@@ -65,6 +66,151 @@ struct WidgetDimensions {
 
 	static const WidgetDimensions unscaled; ///< Unscaled widget dimensions.
 	static WidgetDimensions scaled;         ///< Widget dimensions scaled for current zoom level.
+
+private:
+	/**
+	 * Distances used in drawing widgets.
+	 * These constants should not be used elsewhere, use scaled/unscaled WidgetDimensions instead.
+	 */
+	enum WidgetDrawDistances {
+		/* WWT_IMGBTN(_2) */
+		WD_IMGBTN_LEFT    = 1,      ///< Left offset of the image in the button.
+		WD_IMGBTN_RIGHT   = 2,      ///< Right offset of the image in the button.
+		WD_IMGBTN_TOP     = 1,      ///< Top offset of image in the button.
+		WD_IMGBTN_BOTTOM  = 2,      ///< Bottom offset of image in the button.
+
+		/* WWT_INSET */
+		WD_INSET_LEFT  = 2,         ///< Left offset of string.
+		WD_INSET_RIGHT = 2,         ///< Right offset of string.
+		WD_INSET_TOP   = 1,         ///< Top offset of string.
+
+		WD_VSCROLLBAR_LEFT   = 2,   ///< Left offset of vertical scrollbar.
+		WD_VSCROLLBAR_RIGHT  = 2,   ///< Right offset of vertical scrollbar.
+		WD_VSCROLLBAR_TOP    = 3,   ///< Top offset of vertical scrollbar.
+		WD_VSCROLLBAR_BOTTOM = 3,   ///< Bottom offset of vertical scrollbar.
+
+		WD_HSCROLLBAR_LEFT   = 3,   ///< Left offset of horizontal scrollbar.
+		WD_HSCROLLBAR_RIGHT  = 3,   ///< Right offset of horizontal scrollbar.
+		WD_HSCROLLBAR_TOP    = 2,   ///< Top offset of horizontal scrollbar.
+		WD_HSCROLLBAR_BOTTOM = 2,   ///< Bottom offset of horizontal scrollbar.
+
+		/* Size of the pure frame bevel without any padding. */
+		WD_BEVEL_LEFT       = 1,    ///< Width of left bevel border.
+		WD_BEVEL_RIGHT      = 1,    ///< Width of right bevel border.
+		WD_BEVEL_TOP        = 1,    ///< Height of top bevel border.
+		WD_BEVEL_BOTTOM     = 1,    ///< Height of bottom bevel border.
+
+		/* FrameRect widgets, all text buttons, panel, editbox */
+		WD_FRAMERECT_LEFT   = 2,    ///< Offset at left to draw the frame rectangular area
+		WD_FRAMERECT_RIGHT  = 2,    ///< Offset at right to draw the frame rectangular area
+		WD_FRAMERECT_TOP    = 1,    ///< Offset at top to draw the frame rectangular area
+		WD_FRAMERECT_BOTTOM = 1,    ///< Offset at bottom to draw the frame rectangular area
+
+		/* WWT_FRAME */
+		WD_FRAMETEXT_LEFT   = 6,    ///< Left offset of the text of the frame.
+		WD_FRAMETEXT_RIGHT  = 6,    ///< Right offset of the text of the frame.
+		WD_FRAMETEXT_TOP    = 6,    ///< Top offset of the text of the frame
+		WD_FRAMETEXT_BOTTOM = 6,    ///< Bottom offset of the text of the frame
+
+		/* WWT_MATRIX */
+		WD_MATRIX_LEFT   = 2,       ///< Offset at left of a matrix cell.
+		WD_MATRIX_RIGHT  = 2,       ///< Offset at right of a matrix cell.
+		WD_MATRIX_TOP    = 3,       ///< Offset at top of a matrix cell.
+		WD_MATRIX_BOTTOM = 1,       ///< Offset at bottom of a matrix cell.
+
+		/* WWT_SHADEBOX */
+		WD_SHADEBOX_WIDTH  = 12,    ///< Width of a standard shade box widget.
+		WD_SHADEBOX_LEFT   = 2,     ///< Left offset of shade sprite.
+		WD_SHADEBOX_RIGHT  = 2,     ///< Right offset of shade sprite.
+		WD_SHADEBOX_TOP    = 3,     ///< Top offset of shade sprite.
+		WD_SHADEBOX_BOTTOM = 3,     ///< Bottom offset of shade sprite.
+
+		/* WWT_STICKYBOX */
+		WD_STICKYBOX_WIDTH  = 12,   ///< Width of a standard sticky box widget.
+		WD_STICKYBOX_LEFT   = 2,    ///< Left offset of sticky sprite.
+		WD_STICKYBOX_RIGHT  = 2,    ///< Right offset of sticky sprite.
+		WD_STICKYBOX_TOP    = 3,    ///< Top offset of sticky sprite.
+		WD_STICKYBOX_BOTTOM = 3,    ///< Bottom offset of sticky sprite.
+
+		/* WWT_DEBUGBOX */
+		WD_DEBUGBOX_WIDTH  = 12,    ///< Width of a standard debug box widget.
+		WD_DEBUGBOX_LEFT   = 2,     ///< Left offset of debug sprite.
+		WD_DEBUGBOX_RIGHT  = 2,     ///< Right offset of debug sprite.
+		WD_DEBUGBOX_TOP    = 3,     ///< Top offset of debug sprite.
+		WD_DEBUGBOX_BOTTOM = 3,     ///< Bottom offset of debug sprite.
+
+		/* WWT_DEFSIZEBOX */
+		WD_DEFSIZEBOX_WIDTH  = 12,  ///< Width of a standard defsize box widget.
+		WD_DEFSIZEBOX_LEFT   = 2,   ///< Left offset of defsize sprite.
+		WD_DEFSIZEBOX_RIGHT  = 2,   ///< Right offset of defsize sprite.
+		WD_DEFSIZEBOX_TOP    = 3,   ///< Top offset of defsize sprite.
+		WD_DEFSIZEBOX_BOTTOM = 3,   ///< Bottom offset of defsize sprite.
+
+		/* WWT_RESIZEBOX */
+		WD_RESIZEBOX_WIDTH  = 12,   ///< Width of a resize box widget.
+		WD_RESIZEBOX_LEFT   = 2,    ///< Left offset of resize sprite.
+		WD_RESIZEBOX_RIGHT  = 2,    ///< Right offset of resize sprite.
+		WD_RESIZEBOX_TOP    = 2,    ///< Top offset of resize sprite.
+		WD_RESIZEBOX_BOTTOM = 2,    ///< Bottom offset of resize sprite.
+
+		/* WWT_CLOSEBOX */
+		WD_CLOSEBOX_WIDTH  = 11,    ///< Width of a close box widget.
+		WD_CLOSEBOX_LEFT   = 2,     ///< Left offset of closebox string.
+		WD_CLOSEBOX_RIGHT  = 1,     ///< Right offset of closebox string.
+		WD_CLOSEBOX_TOP    = 2,     ///< Top offset of closebox string.
+		WD_CLOSEBOX_BOTTOM = 2,     ///< Bottom offset of closebox string.
+
+		/* WWT_CAPTION */
+		WD_CAPTION_HEIGHT     = 14, ///< Height of a title bar.
+		WD_CAPTIONTEXT_LEFT   = 2,  ///< Offset of the caption text at the left.
+		WD_CAPTIONTEXT_RIGHT  = 2,  ///< Offset of the caption text at the right.
+		WD_CAPTIONTEXT_TOP    = 2,  ///< Offset of the caption text at the top.
+		WD_CAPTIONTEXT_BOTTOM = 2,  ///< Offset of the caption text at the bottom.
+
+		/* Dropdown widget. */
+		WD_DROPDOWN_HEIGHT     = 12, ///< Height of a drop down widget.
+		WD_DROPDOWNTEXT_LEFT   = 2,  ///< Left offset of the dropdown widget string.
+		WD_DROPDOWNTEXT_RIGHT  = 2,  ///< Right offset of the dropdown widget string.
+		WD_DROPDOWNTEXT_TOP    = 1,  ///< Top offset of the dropdown widget string.
+		WD_DROPDOWNTEXT_BOTTOM = 1,  ///< Bottom offset of the dropdown widget string.
+
+		WD_PAR_VSEP_NORMAL = 2,      ///< Normal amount of vertical space between two paragraphs of text.
+		WD_PAR_VSEP_WIDE   = 8,      ///< Large amount of vertical space between two paragraphs of text.
+	};
+
+	friend NWidgetLeaf;
+};
+
+inline constexpr WidgetDimensions WidgetDimensions::unscaled = {
+	{WD_IMGBTN_LEFT,       WD_IMGBTN_TOP,       WD_IMGBTN_RIGHT,       WD_IMGBTN_BOTTOM},       ///< imgbtn
+	{WD_INSET_LEFT,        WD_INSET_TOP,        WD_INSET_RIGHT,        WD_BEVEL_BOTTOM},        ///< inset
+	{WD_VSCROLLBAR_LEFT,   WD_VSCROLLBAR_TOP,   WD_VSCROLLBAR_RIGHT,   WD_VSCROLLBAR_BOTTOM},   ///< vscrollbar
+	{WD_HSCROLLBAR_LEFT,   WD_HSCROLLBAR_TOP,   WD_HSCROLLBAR_RIGHT,   WD_HSCROLLBAR_BOTTOM},   ///< hscrollbar
+	{WD_BEVEL_LEFT,        WD_BEVEL_TOP,        WD_BEVEL_RIGHT,        WD_BEVEL_BOTTOM},        ///< bevel
+	{WD_BEVEL_LEFT,        WD_BEVEL_TOP,        WD_BEVEL_RIGHT,        WD_BEVEL_BOTTOM},        ///< fullbevel
+	{WD_FRAMERECT_LEFT,    WD_FRAMERECT_TOP,    WD_FRAMERECT_RIGHT,    WD_FRAMERECT_BOTTOM},    ///< framerect
+	{WD_FRAMETEXT_LEFT,    WD_FRAMETEXT_TOP,    WD_FRAMETEXT_RIGHT,    WD_FRAMETEXT_BOTTOM},    ///< frametext
+	{WD_MATRIX_LEFT,       WD_MATRIX_TOP,       WD_MATRIX_RIGHT,       WD_MATRIX_BOTTOM},       ///< matrix
+	{WD_SHADEBOX_LEFT,     WD_SHADEBOX_TOP,     WD_SHADEBOX_RIGHT,     WD_SHADEBOX_BOTTOM},     ///< shadebox
+	{WD_STICKYBOX_LEFT,    WD_STICKYBOX_TOP,    WD_STICKYBOX_RIGHT,    WD_STICKYBOX_BOTTOM},    ///< stickybox
+	{WD_DEBUGBOX_LEFT,     WD_DEBUGBOX_TOP,     WD_DEBUGBOX_RIGHT,     WD_DEBUGBOX_BOTTOM},     ///< debugbox
+	{WD_DEFSIZEBOX_LEFT,   WD_DEFSIZEBOX_TOP,   WD_DEFSIZEBOX_RIGHT,   WD_DEFSIZEBOX_BOTTOM},   ///< defsizebox
+	{WD_RESIZEBOX_LEFT,    WD_RESIZEBOX_TOP,    WD_RESIZEBOX_RIGHT,    WD_RESIZEBOX_BOTTOM},    ///< resizebox
+	{WD_CLOSEBOX_LEFT,     WD_CLOSEBOX_TOP,     WD_CLOSEBOX_RIGHT,     WD_CLOSEBOX_BOTTOM},     ///< closebox
+	{WD_CAPTIONTEXT_LEFT,  WD_CAPTIONTEXT_TOP,  WD_CAPTIONTEXT_RIGHT,  WD_CAPTIONTEXT_BOTTOM},  ///< captiontext
+	{WD_DROPDOWNTEXT_LEFT, WD_DROPDOWNTEXT_TOP, WD_DROPDOWNTEXT_RIGHT, WD_DROPDOWNTEXT_BOTTOM}, ///< dropdowntext
+	{WD_BEVEL_LEFT,        WD_BEVEL_TOP * 2,    WD_BEVEL_RIGHT,        WD_BEVEL_BOTTOM * 2},    ///< dropdownmenu
+	{20, 10, 20, 10},    ///< modalpopup
+	{3, 3, 3, 3},        ///< picker
+	{10, 8, 10, 8},      ///< sparse window padding
+	{10, 8, 10, 1},      ///< resizable sparse window padding
+	1,                   ///< vsep_picker
+	WD_PAR_VSEP_NORMAL,  ///< vsep_normal
+	4,                   ///< vsep_sparse
+	WD_PAR_VSEP_WIDE,    ///< vsep_wide
+	2,                   ///< hsep_normal
+	6,                   ///< hsep_wide
+	10,                  ///< hsep_indent
 };
 
 /* widget.cpp */


### PR DESCRIPTION
## Motivation / Problem

Window NWidgetPart lists are const, but are actually built on start up because NWidgetPart functions are not constexpr.

Making NWidgetParts constexpr means that runtime variables cannot be used inadvertently.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

WIdgetDimensions::unscaled needs to be moved to the header file to also be constexpr, C++17 should support this without making multiple copies per file that includes it.

Add constexpr NWidgetPart constructors, and make NWidgetPart factory functions constexpr, and make NWIdgetPart lists constexpr too.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Whew

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
