### PR TITLE
Fix #10118: Cycle through current signal group, not just path signals

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1946,7 +1946,7 @@ STR_CONFIG_SETTING_SEMAPHORE_BUILD_BEFORE_DATE_HELPTEXT         :Set the year wh
 STR_CONFIG_SETTING_CYCLE_SIGNAL_TYPES                           :Cycle through signal types: {STRING2}
 STR_CONFIG_SETTING_CYCLE_SIGNAL_TYPES_HELPTEXT                  :Select which signal types to cycle through when Ctrl+Clicking on a built signal with the signal tool
 ###length 2
-STR_CONFIG_SETTING_CYCLE_SIGNAL_PBS                             :Path signals only
+STR_CONFIG_SETTING_CYCLE_SIGNAL_GROUP                           :Current group only
 STR_CONFIG_SETTING_CYCLE_SIGNAL_ALL                             :All visible
 
 STR_CONFIG_SETTING_SIGNAL_GUI_MODE                              :Show signal types: {STRING2}

--- a/src/rail_gui.h
+++ b/src/rail_gui.h
@@ -27,8 +27,8 @@ enum SignalGUISettings : uint8_t {
 
 /** Settings for which signals are cycled through by control-clicking on the signal with the signal tool. */
 enum SignalCycleSettings : uint8_t {
-	SIGNAL_CYCLE_PATH = 0, ///< Cycle through path signals only.
-	SIGNAL_CYCLE_ALL = 1,  ///< Cycle through all signals visible.
+	SIGNAL_CYCLE_GROUP = 0, ///< Cycle through current signal group (block or path) only.
+	SIGNAL_CYCLE_ALL = 1,   ///< Cycle through all signals visible to the player.
 };
 
 #endif /* RAIL_GUI_H */

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -519,13 +519,13 @@ cat      = SC_EXPERT
 var      = gui.cycle_signal_types
 type     = SLE_UINT8
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
-def      = 0
-min      = 0
-max      = 1
+def      = SIGNAL_CYCLE_GROUP
+min      = SIGNAL_CYCLE_GROUP
+max      = SIGNAL_CYCLE_ALL
 interval = 1
 str      = STR_CONFIG_SETTING_CYCLE_SIGNAL_TYPES
 strhelp  = STR_CONFIG_SETTING_CYCLE_SIGNAL_TYPES_HELPTEXT
-strval   = STR_CONFIG_SETTING_CYCLE_SIGNAL_PBS
+strval   = STR_CONFIG_SETTING_CYCLE_SIGNAL_GROUP
 cat      = SC_ADVANCED
 
 [SDTC_VAR]


### PR DESCRIPTION
## Motivation / Problem

First, a bit of backstory: Once upon a time, players could chose which signal group to cycle through when Ctrl+Clicking signals: block, path, or all. #8688 changed that to `All visible` or `Path signals only`. My reasoning was that if this was set to block signals but block signals were hidden in the GUI, it would be confusing and hard to fix. Players would be able to build path signals and then convert them into a signal they can't see in the GUI -- a terrible user experience design. Thus the change.

Okay, now to the present. Players occasionally ask for this old setting back, citing the desire to cycle through block signals only (#10118) or swap between one-way and two-way path signals while still showing all types (https://github.com/OpenTTD/OpenTTD/pull/11769#issuecomment-1892751460).

## Description

This PR fulfils both feature requests by implementing @frosch123's idea in https://github.com/OpenTTD/OpenTTD/pull/10119#issuecomment-1299223877. The `Path signals only` option is changed to `Current group only`, consisting of two groups: block/entry/exit/combo and path/one-way path. 

Because of the interplay with the signal GUI mode, there are a couple edge cases which I think are handled in an intuitive way:

* If a block signal exists and the setting is `Current group only`, the signal is converted within its group even if the player cannot see this type of signal in the GUI. To me, this is different from the original problem because the player has already built a block signal -- and it's easily resolved by removing and rebuilding the signal with the correct type, rather than being stuck with the behavior due to a dropdown in the Settings menu.
* If a block signal exists and the setting is `All visible`, it is converted to a path signal because that's what the player can see.

Closes #10118.
Supersedes #11769.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
