### PR TITLE
Codechange: compile-time validate the string format of IConsolePrint

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -267,20 +267,18 @@ DEF_CONSOLE_CMD(ConZoomToLevel)
 		case 0:
 			IConsolePrint(CC_HELP, "Set the current zoom level of the main viewport.");
 			IConsolePrint(CC_HELP, "Usage: 'zoomto <level>'.");
-			IConsolePrint(
-				CC_HELP,
-				ZOOM_LVL_MIN < _settings_client.gui.zoom_min ?
-					"The lowest zoom-in level allowed by current client settings is {}." :
-					"The lowest supported zoom-in level is {}.",
-				std::max(ZOOM_LVL_MIN, _settings_client.gui.zoom_min)
-			);
-			IConsolePrint(
-				CC_HELP,
-				_settings_client.gui.zoom_max < ZOOM_LVL_MAX ?
-					"The highest zoom-out level allowed by current client settings is {}." :
-					"The highest supported zoom-out level is {}.",
-				std::min(_settings_client.gui.zoom_max, ZOOM_LVL_MAX)
-			);
+
+			if (ZOOM_LVL_MIN < _settings_client.gui.zoom_min) {
+				IConsolePrint(CC_HELP, "The lowest zoom-in level allowed by current client settings is {}.", std::max(ZOOM_LVL_MIN, _settings_client.gui.zoom_min));
+			} else {
+				IConsolePrint(CC_HELP, "The lowest supported zoom-in level is {}.", std::max(ZOOM_LVL_MIN, _settings_client.gui.zoom_min));
+			}
+
+			if (_settings_client.gui.zoom_max < ZOOM_LVL_MAX) {
+				IConsolePrint(CC_HELP, "The highest zoom-out level allowed by current client settings is {}.", std::min(_settings_client.gui.zoom_max, ZOOM_LVL_MAX));
+			} else {
+				IConsolePrint(CC_HELP, "The highest supported zoom-out level is {}.", std::min(_settings_client.gui.zoom_max, ZOOM_LVL_MAX));
+			}
 			return true;
 
 		case 2: {

--- a/src/console_func.h
+++ b/src/console_func.h
@@ -34,16 +34,15 @@ void IConsolePrint(TextColour colour_code, const std::string &string);
  * @param format_string The formatting string to tell what to do with the remaining arguments.
  * @param first_arg The first argument to the format.
  * @param other_args The other arguments to the format.
- * @tparam T The type of formatting parameter.
  * @tparam A The type of the first argument.
  * @tparam Args The types of the other arguments.
  */
-template <typename T, typename A, typename ... Args>
-inline void IConsolePrint(TextColour colour_code, const T &format, A first_arg, Args&&... other_args)
+template <typename A, typename ... Args>
+inline void IConsolePrint(TextColour colour_code, fmt::format_string<A, Args...> format, A first_arg, Args&&... other_args)
 {
 	/* The separate first_arg argument is added to aid overloading.
 	 * Otherwise the calls that do no need formatting will still use this function. */
-	IConsolePrint(colour_code, fmt::format(format, first_arg, other_args...));
+	IConsolePrint(colour_code, fmt::format(format, std::forward<A>(first_arg), std::forward<Args>(other_args)...));
 }
 
 /* Parser */

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1704,12 +1704,14 @@ void NetworkServer_Tick(bool send_frame)
 			case NetworkClientSocket::STATUS_ACTIVE:
 				if (lag > _settings_client.network.max_lag_time) {
 					/* Client did still not report in within the specified limit. */
-					IConsolePrint(CC_WARNING, cs->last_packet + std::chrono::milliseconds(lag * MILLISECONDS_PER_TICK) > std::chrono::steady_clock::now() ?
-							/* A packet was received in the last three game days, so the client is likely lagging behind. */
-								"Client #{} (IP: {}) is dropped because the client's game state is more than {} ticks behind." :
-							/* No packet was received in the last three game days; sounds like a lost connection. */
-								"Client #{} (IP: {}) is dropped because the client did not respond for more than {} ticks.",
-							cs->client_id, cs->GetClientIP(), lag);
+
+					if (cs->last_packet + std::chrono::milliseconds(lag * MILLISECONDS_PER_TICK) > std::chrono::steady_clock::now()) {
+						/* A packet was received in the last three game days, so the client is likely lagging behind. */
+						IConsolePrint(CC_WARNING, "Client #{} (IP: {}) is dropped because the client's game state is more than {} ticks behind.", cs->client_id, cs->GetClientIP(), lag);
+					} else {
+						/* No packet was received in the last three game days; sounds like a lost connection. */
+						IConsolePrint(CC_WARNING, "Client #{} (IP: {}) is dropped because the client did not respond for more than {} ticks.", cs->client_id, cs->GetClientIP(), lag);
+					}
 					cs->SendError(NETWORK_ERROR_TIMEOUT_COMPUTER);
 					continue;
 				}


### PR DESCRIPTION
## Motivation / Problem

While working on #11800, found out that `IConsolePrint` isn't all that nice. It doesn't check the format of the string.

## Description

Address that issue, and make it C++20 compatible.

This also means we can no longer use runtime picking what string to use.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
