### PR TITLE
Codechange: compile-time validate the string format of SlErrorCorruptFmt

### DIFF
--- a/src/saveload/saveload_error.hpp
+++ b/src/saveload/saveload_error.hpp
@@ -20,15 +20,14 @@ void NORETURN SlErrorCorrupt(const std::string &msg);
  * Issue an SlErrorCorrupt with a format string.
  * @param format_string The formatting string to tell what to do with the remaining arguments.
  * @param fmt_args The arguments to be passed to fmt.
- * @tparam T The type of formatting parameter.
  * @tparam Args The types of the fmt arguments.
  * @note This function does never return as it throws an exception to
  *       break out of all the saveload code.
  */
-template <typename T, typename ... Args>
-inline void NORETURN SlErrorCorruptFmt(const T &format, Args&&... fmt_args)
+template <typename ... Args>
+inline void NORETURN SlErrorCorruptFmt(const fmt::format_string<Args...> format, Args&&... fmt_args)
 {
-	SlErrorCorrupt(fmt::format(format, fmt_args...));
+	SlErrorCorrupt(fmt::format(format, std::forward<Args>(fmt_args)...));
 }
 
 #endif /* SAVELOAD_ERROR_HPP */


### PR DESCRIPTION
## Motivation / Problem

While working on https://github.com/OpenTTD/OpenTTD/pull/11800, found out that `SlErrorCorruptFmt` isn't all that nice. It doesn't check the format of the string.


## Description

Address that issue, and make it C++20 compatible.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
