### PR TITLE
Codechange: minor bits and pieces related to fmt::format()

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -95,7 +95,7 @@ void DumpDebugFacilityNames(std::back_insert_iterator<std::string> &output_itera
 		} else {
 			fmt::format_to(output_iterator, ", ");
 		}
-		fmt::format_to(output_iterator, i->name);
+		fmt::format_to(output_iterator, "{}", i->name);
 		written = true;
 	}
 	if (written) {

--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -242,7 +242,11 @@ void Gamelog::Print(std::function<void(const std::string &)> proc)
 {
 	/* A NewGRF got removed from the game, either manually or by it missing when loading the game. */
 	auto gm = grf_names.find(this->grfid);
-	fmt::format_to(output_iterator, action_type == GLAT_LOAD ? "Missing NewGRF: " : "Removed NewGRF: ");
+	if (action_type == GLAT_LOAD) {
+		fmt::format_to(output_iterator, "Missing NewGRF: ");
+	} else {
+		fmt::format_to(output_iterator, "Removed NewGRF: ");
+	}
 	AddGrfInfo(output_iterator, this->grfid, nullptr, gm != grf_names.end() ? gm->second.gc : nullptr);
 	if (gm == grf_names.end()) {
 		fmt::format_to(output_iterator, ". Gamelog inconsistency: GrfID was never added!");

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -93,7 +93,7 @@ static const char *GetAddressFormatString(uint16_t family, bool with_family)
  */
 std::string NetworkAddress::GetAddressAsString(bool with_family)
 {
-	return fmt::format(GetAddressFormatString(this->GetAddress()->ss_family, with_family), this->GetHostname(), this->GetPort());
+	return fmt::format(fmt::runtime(GetAddressFormatString(this->GetAddress()->ss_family, with_family)), this->GetHostname(), this->GetPort());
 }
 
 /**

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -131,7 +131,7 @@ void NewGRFProfiler::Abort()
  */
 std::string NewGRFProfiler::GetOutputFilename() const
 {
-	return fmt::format("{}grfprofile-{%Y%m%d-%H%M}-{:08X}.csv", FiosGetScreenshotDir(), fmt::localtime(time(nullptr)), BSWAP32(this->grffile->grfid));
+	return fmt::format("{}grfprofile-{:%Y%m%d-%H%M}-{:08X}.csv", FiosGetScreenshotDir(), fmt::localtime(time(nullptr)), BSWAP32(this->grffile->grfid));
 }
 
 /* static */ uint32_t NewGRFProfiler::FinishAll()


### PR DESCRIPTION
## Motivation / Problem

Various of issues I found when looking at #11800, where we got the `fmt::format` stuff just wrong.

## Description

In C++17 there is actually no way I could find to error on these mistakes, but C++20 will. So preparing for the future!

- Don't make run-time formatting what can be done compile-time.
- Be explicit about run-time formatting.
- Fix datetime printing.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
