### PR TITLE
Fix bde05ce7: also update the version in the OpenTTD docs to v0.4

### DIFF
--- a/media/baseset/OpenTTD-font.md
+++ b/media/baseset/OpenTTD-font.md
@@ -3,4 +3,4 @@
 The OpenTTD TrueType font was created by Zephyris and is maintained on [Github](https://github.com/zephyris/openttd-ttf).
 It is licensed under GPL-2.0.
 
-The currently included files correspond to release v0.3.
+The currently included files correspond to release v0.4.


### PR DESCRIPTION
## Motivation / Problem

Step 1) Ask for the original author that added OpenTTD TTF to add a document to track the version
Step 2) Be the first to update the TTFs to a newer version
???
Step 5) Profit

## Description

Yes, turns out, Step 3) is "Forget to update the version in the document".
So now you get a Step 4), with an extra commit to fix that oversight.

*sigh*

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
