### PR TITLE
Fix #11791, e1f5be62: Run missing-glyph detection after toggling sprite font.

### DIFF
--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -574,6 +574,7 @@ struct GameOptionsWindow : Window {
 				InitFontCache(false);
 				InitFontCache(true);
 				ClearFontCache();
+				CheckForMissingGlyphs();
 				SetupWidgetDimensions();
 				UpdateAllVirtCoords();
 				ReInitAllWindows(true);


### PR DESCRIPTION
## Motivation / Problem / Description / Limitations

Toggling the "prefer sprite font" option when using a language that is not covered by the sprite font and/or the built-in TTF would leave the game displaying lots of ???????.

To fix this, re-run the messing glyph check after the options has been changed. This will make sure users can always read the text, but might override their selected preference.

Fixes #11791 


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
