### PR TITLE
Fix #11802: Don't set edge traversability bit on aqueducts crossing that same edge side

### DIFF
--- a/src/pathfinder/water_regions.cpp
+++ b/src/pathfinder/water_regions.cpp
@@ -173,10 +173,25 @@ public:
 		const int top_x = TileX(tile_area.tile);
 		const int top_y = TileY(tile_area.tile);
 		for (int i = 0; i < WATER_REGION_EDGE_LENGTH; ++i) {
-			if (GetWaterTracks(TileXY(top_x + i, top_y)) & TRACK_BIT_3WAY_NW) SetBit(this->edge_traversability_bits[DIAGDIR_NW], i); // NW edge
-			if (GetWaterTracks(TileXY(top_x + i, top_y + WATER_REGION_EDGE_LENGTH - 1)) & TRACK_BIT_3WAY_SE) SetBit(this->edge_traversability_bits[DIAGDIR_SE], i); // SE edge
-			if (GetWaterTracks(TileXY(top_x, top_y + i)) & TRACK_BIT_3WAY_NE) SetBit(this->edge_traversability_bits[DIAGDIR_NE], i); // NE edge
-			if (GetWaterTracks(TileXY(top_x + WATER_REGION_EDGE_LENGTH - 1, top_y + i)) & TRACK_BIT_3WAY_SW) SetBit(this->edge_traversability_bits[DIAGDIR_SW], i); // SW edge
+			TileIndex edge_tile = TileXY(top_x + i, top_y); // NW edge
+			if ((GetWaterTracks(edge_tile) & TRACK_BIT_3WAY_NW) != 0 && (!IsAqueductTile(edge_tile) || GetTunnelBridgeDirection(edge_tile) != DIAGDIR_NW)) {
+				SetBit(this->edge_traversability_bits[DIAGDIR_NW], i);
+			}
+
+			edge_tile = TileXY(top_x + i, top_y + WATER_REGION_EDGE_LENGTH - 1); // SE edge
+			if ((GetWaterTracks(edge_tile) & TRACK_BIT_3WAY_SE) != 0 && (!IsAqueductTile(edge_tile) || GetTunnelBridgeDirection(edge_tile) != DIAGDIR_SE)) {
+				SetBit(this->edge_traversability_bits[DIAGDIR_SE], i);
+			}
+
+			edge_tile = TileXY(top_x, top_y + i); // NE edge
+			if ((GetWaterTracks(edge_tile) & TRACK_BIT_3WAY_NE) != 0 && (!IsAqueductTile(edge_tile) || GetTunnelBridgeDirection(edge_tile) != DIAGDIR_NE)) {
+				SetBit(this->edge_traversability_bits[DIAGDIR_NE], i);
+			}
+
+			edge_tile = TileXY(top_x + WATER_REGION_EDGE_LENGTH - 1, top_y + i); // SW edge
+			if ((GetWaterTracks(edge_tile) & TRACK_BIT_3WAY_SW) != 0 && (!IsAqueductTile(edge_tile) || GetTunnelBridgeDirection(edge_tile) != DIAGDIR_SW)) {
+				SetBit(this->edge_traversability_bits[DIAGDIR_SW], i);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Motivation / Problem
#11802 - Neighbouring regions on the same x_or_y may indeed have the traversability bits sets, but that doesn't necessarily mean ships can traverse their edges.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Actually check if water regions are reachable.

Don't set edge traversability bit on aqueducts crossing that same edge side.


Closes #11802.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Almost same performance. What used to be 3000 us on a 4096x4096 map is now 3100 us, even without aqueducts.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
