### PR TITLE
Codechange: use std::source_location over __FILE__/__LINE__ all over the code

### DIFF
--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -40,7 +40,7 @@
 	/* Clients shouldn't start AIs */
 	if (_networking && !_network_server) return;
 
-	Backup<CompanyID> cur_company(_current_company, company, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, company);
 	Company *c = Company::Get(company);
 
 	AIConfig *config = c->ai_config.get();
@@ -81,7 +81,7 @@
 	assert(_settings_game.difficulty.competitor_speed <= 4);
 	if ((AI::frame_counter & ((1 << (4 - _settings_game.difficulty.competitor_speed)) - 1)) != 0) return;
 
-	Backup<CompanyID> cur_company(_current_company, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company);
 	for (const Company *c : Company::Iterate()) {
 		if (c->is_ai) {
 			PerformanceMeasurer framerate((PerformanceElement)(PFE_AI0 + c->index));
@@ -109,7 +109,7 @@
 	if (_networking && !_network_server) return;
 	PerformanceMeasurer::SetInactive((PerformanceElement)(PFE_AI0 + company));
 
-	Backup<CompanyID> cur_company(_current_company, company, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, company);
 	Company *c = Company::Get(company);
 
 	delete c->ai_instance;
@@ -129,7 +129,7 @@
 	 * for the server owner to unpause the script again. */
 	if (_network_dedicated) return;
 
-	Backup<CompanyID> cur_company(_current_company, company, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, company);
 	Company::Get(company)->ai_instance->Pause();
 
 	cur_company.Restore();
@@ -137,7 +137,7 @@
 
 /* static */ void AI::Unpause(CompanyID company)
 {
-	Backup<CompanyID> cur_company(_current_company, company, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, company);
 	Company::Get(company)->ai_instance->Unpause();
 
 	cur_company.Restore();
@@ -145,7 +145,7 @@
 
 /* static */ bool AI::IsPaused(CompanyID company)
 {
-	Backup<CompanyID> cur_company(_current_company, company, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, company);
 	bool paused = Company::Get(company)->ai_instance->IsPaused();
 
 	cur_company.Restore();
@@ -259,7 +259,7 @@
 	}
 
 	/* Queue the event */
-	Backup<CompanyID> cur_company(_current_company, company, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, company);
 	Company::Get(_current_company)->ai_instance->InsertEvent(event);
 	cur_company.Restore();
 
@@ -293,7 +293,7 @@
 
 		/* When doing emergency saving, an AI can be not fully initialised. */
 		if (c->ai_instance != nullptr) {
-			Backup<CompanyID> cur_company(_current_company, company, FILE_LINE);
+			Backup<CompanyID> cur_company(_current_company, company);
 			c->ai_instance->Save();
 			cur_company.Restore();
 			return;

--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -82,7 +82,7 @@ static constexpr NWidgetPart _nested_ai_config_widgets[] = {
 };
 
 /** Window definition for the configure AI window. */
-static WindowDesc _ai_config_desc(__FILE__, __LINE__,
+static WindowDesc _ai_config_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_GAME_OPTIONS, WC_NONE,
 	0,

--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -1285,7 +1285,7 @@ void HandleMissingAircraftOrders(Aircraft *v)
 	 */
 	const Station *st = GetTargetAirportIfValid(v);
 	if (st == nullptr) {
-		Backup<CompanyID> cur_company(_current_company, v->owner, FILE_LINE);
+		Backup<CompanyID> cur_company(_current_company, v->owner);
 		CommandCost ret = Command<CMD_SEND_VEHICLE_TO_DEPOT>::Do(DC_EXEC, v->index, DepotCommand::None, {});
 		cur_company.Restore();
 
@@ -1651,7 +1651,7 @@ static void AircraftEventHandler_HeliTakeOff(Aircraft *v, const AirportFTAClass 
 
 	/* Send the helicopter to a hangar if needed for replacement */
 	if (v->NeedsAutomaticServicing()) {
-		Backup<CompanyID> cur_company(_current_company, v->owner, FILE_LINE);
+		Backup<CompanyID> cur_company(_current_company, v->owner);
 		Command<CMD_SEND_VEHICLE_TO_DEPOT>::Do(DC_EXEC, v->index, DepotCommand::Service | DepotCommand::LocateHangar, {});
 		cur_company.Restore();
 	}
@@ -1702,7 +1702,7 @@ static void AircraftEventHandler_Landing(Aircraft *v, const AirportFTAClass *)
 
 	/* check if the aircraft needs to be replaced or renewed and send it to a hangar if needed */
 	if (v->NeedsAutomaticServicing()) {
-		Backup<CompanyID> cur_company(_current_company, v->owner, FILE_LINE);
+		Backup<CompanyID> cur_company(_current_company, v->owner);
 		Command<CMD_SEND_VEHICLE_TO_DEPOT>::Do(DC_EXEC, v->index, DepotCommand::Service, {});
 		cur_company.Restore();
 	}

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -207,7 +207,7 @@ static constexpr NWidgetPart _nested_air_toolbar_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _air_toolbar_desc(__FILE__, __LINE__,
+static WindowDesc _air_toolbar_desc(
 	WDP_ALIGN_TOOLBAR, "toolbar_air", 0, 0,
 	WC_BUILD_TOOLBAR, WC_NONE,
 	WDF_CONSTRUCTION,
@@ -618,7 +618,7 @@ static constexpr NWidgetPart _nested_build_airport_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _build_airport_desc(__FILE__, __LINE__,
+static WindowDesc _build_airport_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_BUILD_STATION, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -787,7 +787,7 @@ static constexpr NWidgetPart _nested_replace_rail_vehicle_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _replace_rail_vehicle_desc(__FILE__, __LINE__,
+static WindowDesc _replace_rail_vehicle_desc(
 	WDP_AUTO, "replace_vehicle_train", 500, 140,
 	WC_REPLACE_VEHICLE, WC_NONE,
 	WDF_CONSTRUCTION,
@@ -845,7 +845,7 @@ static constexpr NWidgetPart _nested_replace_road_vehicle_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _replace_road_vehicle_desc(__FILE__, __LINE__,
+static WindowDesc _replace_road_vehicle_desc(
 	WDP_AUTO, "replace_vehicle_road", 500, 140,
 	WC_REPLACE_VEHICLE, WC_NONE,
 	WDF_CONSTRUCTION,
@@ -899,7 +899,7 @@ static constexpr NWidgetPart _nested_replace_vehicle_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _replace_vehicle_desc(__FILE__, __LINE__,
+static WindowDesc _replace_vehicle_desc(
 	WDP_AUTO, "replace_vehicle", 456, 118,
 	WC_REPLACE_VEHICLE, WC_NONE,
 	WDF_CONSTRUCTION,

--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -40,7 +40,7 @@ static constexpr NWidgetPart _background_widgets[] = {
 /**
  * Window description for the background window to prevent smearing.
  */
-static WindowDesc _background_desc(__FILE__, __LINE__,
+static WindowDesc _background_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_BOOTSTRAP, WC_NONE,
 	WDF_NO_CLOSE,
@@ -76,7 +76,7 @@ static constexpr NWidgetPart _nested_bootstrap_errmsg_widgets[] = {
 };
 
 /** Window description for the error window. */
-static WindowDesc _bootstrap_errmsg_desc(__FILE__, __LINE__,
+static WindowDesc _bootstrap_errmsg_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_BOOTSTRAP, WC_NONE,
 	WDF_MODAL | WDF_NO_CLOSE,
@@ -133,7 +133,7 @@ static constexpr NWidgetPart _nested_bootstrap_download_status_window_widgets[] 
 };
 
 /** Window description for the download window */
-static WindowDesc _bootstrap_download_status_window_desc(__FILE__, __LINE__,
+static WindowDesc _bootstrap_download_status_window_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_NETWORK_STATUS_WINDOW, WC_NONE,
 	WDF_MODAL | WDF_NO_CLOSE,
@@ -185,7 +185,7 @@ static constexpr NWidgetPart _bootstrap_query_widgets[] = {
 };
 
 /** The window description for the query. */
-static WindowDesc _bootstrap_query_desc(__FILE__, __LINE__,
+static WindowDesc _bootstrap_query_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_CONFIRM_POPUP_QUERY, WC_NONE,
 	WDF_NO_CLOSE,

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -341,7 +341,7 @@ static constexpr NWidgetPart _nested_build_bridge_widgets[] = {
 };
 
 /** Window definition for the rail bridge selection window. */
-static WindowDesc _build_bridge_desc(__FILE__, __LINE__,
+static WindowDesc _build_bridge_desc(
 	WDP_AUTO, "build_bridge", 200, 114,
 	WC_BUILD_BRIDGE, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1896,7 +1896,7 @@ struct BuildVehicleWindow : Window {
 	}};
 };
 
-static WindowDesc _build_vehicle_desc(__FILE__, __LINE__,
+static WindowDesc _build_vehicle_desc(
 	WDP_AUTO, "build_vehicle", 240, 268,
 	WC_BUILD_VEHICLE, WC_NONE,
 	WDF_CONSTRUCTION,

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -426,7 +426,7 @@ struct CheatWindow : Window {
 };
 
 /** Window description of the cheats GUI. */
-static WindowDesc _cheats_desc(__FILE__, __LINE__,
+static WindowDesc _cheats_desc(
 	WDP_AUTO, "cheats", 0, 0,
 	WC_CHEATS, WC_NONE,
 	0,

--- a/src/command_func.h
+++ b/src/command_func.h
@@ -372,7 +372,7 @@ protected:
 			assert(AllClientIdsSet(args, std::index_sequence_for<Targs...>{}));
 		}
 
-		Backup<CompanyID> cur_company(_current_company, FILE_LINE);
+		Backup<CompanyID> cur_company(_current_company);
 		if (!InternalExecutePrepTest(cmd_flags, tile, cur_company)) {
 			cur_company.Trash();
 			return MakeResult(CMD_ERROR);

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -1255,7 +1255,7 @@ CommandCost CmdGiveMoney(DoCommandFlag flags, Money money, CompanyID dest_compan
 
 	if (flags & DC_EXEC) {
 		/* Add money to company */
-		Backup<CompanyID> cur_company(_current_company, dest_company, FILE_LINE);
+		Backup<CompanyID> cur_company(_current_company, dest_company);
 		SubtractMoneyFromCompany(CommandCost(EXPENSES_OTHER, -amount.GetCost()));
 		cur_company.Restore();
 

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -529,7 +529,7 @@ struct CompanyFinancesWindow : Window {
 /** First conservative estimate of the maximum amount of money */
 Money CompanyFinancesWindow::max_money = INT32_MAX;
 
-static WindowDesc _company_finances_desc(__FILE__, __LINE__,
+static WindowDesc _company_finances_desc(
 	WDP_AUTO, "company_finances", 0, 0,
 	WC_FINANCES, WC_NONE,
 	0,
@@ -1139,7 +1139,7 @@ static constexpr NWidgetPart _nested_select_company_livery_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _select_company_livery_desc(__FILE__, __LINE__,
+static WindowDesc _select_company_livery_desc(
 	WDP_AUTO, "company_color_scheme", 0, 0,
 	WC_COMPANY_COLOUR, WC_NONE,
 	0,
@@ -1764,7 +1764,7 @@ public:
 };
 
 /** Company manager face selection window description */
-static WindowDesc _select_company_manager_face_desc(__FILE__, __LINE__,
+static WindowDesc _select_company_manager_face_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_COMPANY_MANAGER_FACE, WC_NONE,
 	WDF_CONSTRUCTION,
@@ -2141,7 +2141,7 @@ struct CompanyInfrastructureWindow : Window
 	}
 };
 
-static WindowDesc _company_infrastructure_desc(__FILE__, __LINE__,
+static WindowDesc _company_infrastructure_desc(
 	WDP_AUTO, "company_infrastructure", 0, 0,
 	WC_COMPANY_INFRASTRUCTURE, WC_NONE,
 	0,
@@ -2629,7 +2629,7 @@ struct CompanyWindow : Window
 	}
 };
 
-static WindowDesc _company_desc(__FILE__, __LINE__,
+static WindowDesc _company_desc(
 	WDP_AUTO, "company", 0, 0,
 	WC_COMPANY, WC_NONE,
 	0,
@@ -2763,7 +2763,7 @@ static constexpr NWidgetPart _nested_buy_company_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _buy_company_desc(__FILE__, __LINE__,
+static WindowDesc _buy_company_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_BUY_COMPANY, WC_NONE,
 	WDF_CONSTRUCTION,

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -102,7 +102,7 @@ static constexpr NWidgetPart _nested_console_window_widgets[] = {
 	NWidget(WWT_EMPTY, INVALID_COLOUR, WID_C_BACKGROUND), SetResize(1, 1),
 };
 
-static WindowDesc _console_window_desc(__FILE__, __LINE__,
+static WindowDesc _console_window_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_CONSOLE, WC_NONE,
 	0,

--- a/src/core/backup_type.hpp
+++ b/src/core/backup_type.hpp
@@ -22,20 +22,18 @@ struct Backup {
 	/**
 	 * Backup variable.
 	 * @param original Variable to backup.
-	 * @param file Filename for debug output. Use FILE_LINE macro.
-	 * @param line Linenumber for debug output. Use FILE_LINE macro.
+	 * @param location Source location for debug output.
 	 */
-	Backup(T &original, const char * const file, const int line) : original(original), valid(true), original_value(original), file(file), line(line) {}
+	Backup(T &original, const std::source_location location = std::source_location::current()) : original(original), valid(true), original_value(original), location(location) {}
 
 	/**
 	 * Backup variable and switch to new value.
 	 * @param original Variable to backup.
 	 * @param new_value New value for variable.
-	 * @param file Filename for debug output. Use FILE_LINE macro.
-	 * @param line Linenumber for debug output. Use FILE_LINE macro.
+	 * @param location Source location for debug output.
 	 */
 	template <typename U>
-	Backup(T &original, const U &new_value, const char * const file, const int line) : original(original), valid(true), original_value(original), file(file), line(line)
+	Backup(T &original, const U &new_value, const std::source_location location = std::source_location::current()) : original(original), valid(true), original_value(original), location(location)
 	{
 		/* Note: We use a separate typename U, so type conversions are handled by assignment operator. */
 		original = new_value;
@@ -51,7 +49,7 @@ struct Backup {
 		{
 			/* We cannot assert here, as missing restoration is 'normal' when exceptions are thrown.
 			 * Exceptions are especially used to abort world generation. */
-			Debug(misc, 0, "{}:{}: Backed-up value was not restored!", this->file, this->line);
+			Debug(misc, 0, "{}:{}: Backed-up value was not restored!", this->location.file_name(), this->location.line());
 			this->Restore();
 		}
 	}
@@ -140,8 +138,7 @@ private:
 	bool valid;
 	T original_value;
 
-	const char * const file;
-	const int line;
+	const std::source_location location;
 };
 
 /**

--- a/src/date_gui.cpp
+++ b/src/date_gui.cpp
@@ -195,7 +195,7 @@ static constexpr NWidgetPart _nested_set_date_widgets[] = {
 };
 
 /** Description of the date setting window. */
-static WindowDesc _set_date_desc(__FILE__, __LINE__,
+static WindowDesc _set_date_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_SET_DATE, WC_NONE,
 	0,

--- a/src/debug.h
+++ b/src/debug.h
@@ -60,9 +60,6 @@ void DumpDebugFacilityNames(std::back_insert_iterator<std::string> &output_itera
 void SetDebugString(const char *s, void (*error_func)(const std::string &));
 std::string GetDebugString();
 
-/* Shorter form for passing filename and linenumber */
-#define FILE_LINE __FILE__, __LINE__
-
 /** TicToc profiling.
  * Usage:
  * static TicToc::State state("A name", 1);

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -85,28 +85,28 @@ static constexpr NWidgetPart _nested_train_depot_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _train_depot_desc(__FILE__, __LINE__,
+static WindowDesc _train_depot_desc(
 	WDP_AUTO, "depot_train", 362, 123,
 	WC_VEHICLE_DEPOT, WC_NONE,
 	0,
 	std::begin(_nested_train_depot_widgets), std::end(_nested_train_depot_widgets)
 );
 
-static WindowDesc _road_depot_desc(__FILE__, __LINE__,
+static WindowDesc _road_depot_desc(
 	WDP_AUTO, "depot_roadveh", 316, 97,
 	WC_VEHICLE_DEPOT, WC_NONE,
 	0,
 	std::begin(_nested_train_depot_widgets), std::end(_nested_train_depot_widgets)
 );
 
-static WindowDesc _ship_depot_desc(__FILE__, __LINE__,
+static WindowDesc _ship_depot_desc(
 	WDP_AUTO, "depot_ship", 306, 99,
 	WC_VEHICLE_DEPOT, WC_NONE,
 	0,
 	std::begin(_nested_train_depot_widgets), std::end(_nested_train_depot_widgets)
 );
 
-static WindowDesc _aircraft_depot_desc(__FILE__, __LINE__,
+static WindowDesc _aircraft_depot_desc(
 	WDP_AUTO, "depot_aircraft", 332, 99,
 	WC_VEHICLE_DEPOT, WC_NONE,
 	0,

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -63,7 +63,7 @@ static void DisasterClearSquare(TileIndex tile)
 	switch (GetTileType(tile)) {
 		case MP_RAILWAY:
 			if (Company::IsHumanID(GetTileOwner(tile)) && !IsRailDepot(tile)) {
-				Backup<CompanyID> cur_company(_current_company, OWNER_WATER, FILE_LINE);
+				Backup<CompanyID> cur_company(_current_company, OWNER_WATER);
 				Command<CMD_LANDSCAPE_CLEAR>::Do(DC_EXEC, tile);
 				cur_company.Restore();
 
@@ -73,7 +73,7 @@ static void DisasterClearSquare(TileIndex tile)
 			break;
 
 		case MP_HOUSE: {
-			Backup<CompanyID> cur_company(_current_company, OWNER_NONE, FILE_LINE);
+			Backup<CompanyID> cur_company(_current_company, OWNER_NONE);
 			Command<CMD_LANDSCAPE_CLEAR>::Do(DC_EXEC, tile);
 			cur_company.Restore();
 			break;

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -344,7 +344,7 @@ static constexpr NWidgetPart _nested_build_docks_toolbar_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _build_docks_toolbar_desc(__FILE__, __LINE__,
+static WindowDesc _build_docks_toolbar_desc(
 	WDP_ALIGN_TOOLBAR, "toolbar_water", 0, 0,
 	WC_BUILD_TOOLBAR, WC_NONE,
 	WDF_CONSTRUCTION,
@@ -388,7 +388,7 @@ static constexpr NWidgetPart _nested_build_docks_scen_toolbar_widgets[] = {
 };
 
 /** Window definition for the build docks in scenario editor window. */
-static WindowDesc _build_docks_scen_toolbar_desc(__FILE__, __LINE__,
+static WindowDesc _build_docks_scen_toolbar_desc(
 	WDP_AUTO, "toolbar_water_scen", 0, 0,
 	WC_SCEN_BUILD_TOOLBAR, WC_NONE,
 	WDF_CONSTRUCTION,
@@ -498,7 +498,7 @@ static constexpr NWidgetPart _nested_build_dock_station_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _build_dock_station_desc(__FILE__, __LINE__,
+static WindowDesc _build_dock_station_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_BUILD_STATION, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
@@ -593,7 +593,7 @@ static constexpr NWidgetPart _nested_build_docks_depot_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _build_docks_depot_desc(__FILE__, __LINE__,
+static WindowDesc _build_docks_depot_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_BUILD_DEPOT, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -336,14 +336,14 @@ void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner)
 	/* We need to set _current_company to old_owner before we try to move
 	 * the client. This is needed as it needs to know whether "you" really
 	 * are the current local company. */
-	Backup<CompanyID> cur_company(_current_company, old_owner, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, old_owner);
 	/* In all cases, make spectators of clients connected to that company */
 	if (_networking) NetworkClientsToSpectators(old_owner);
 	if (old_owner == _local_company) {
 		/* Single player cheated to AI company.
 		 * There are no spectators in singleplayer mode, so we must pick some other company. */
 		assert(!_networking);
-		Backup<CompanyID> cur_company2(_current_company, FILE_LINE);
+		Backup<CompanyID> cur_company2(_current_company);
 		for (const Company *c : Company::Iterate()) {
 			if (c->index != old_owner) {
 				SetLocalCompany(c->index);
@@ -661,7 +661,7 @@ static void CompaniesGenStatistics()
 		CompanyCheckBankrupt(c);
 	}
 
-	Backup<CompanyID> cur_company(_current_company, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company);
 
 	/* Pay Infrastructure Maintenance, if enabled */
 	if (_settings_game.economy.infrastructure_maintenance) {
@@ -824,7 +824,7 @@ void RecomputePrices()
 /** Let all companies pay the monthly interest on their loan. */
 static void CompaniesPayInterest()
 {
-	Backup<CompanyID> cur_company(_current_company, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company);
 	for (const Company *c : Company::Iterate()) {
 		cur_company.Change(c->index);
 
@@ -1205,7 +1205,7 @@ CargoPayment::~CargoPayment()
 
 	if (this->visual_profit == 0 && this->visual_transfer == 0) return;
 
-	Backup<CompanyID> cur_company(_current_company, this->front->owner, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, this->front->owner);
 
 	SubtractMoneyFromCompany(CommandCost(this->front->GetExpenseType(true), -this->route_profit));
 	this->front->profit_this_year += (this->visual_profit + this->visual_transfer) << 8;
@@ -1496,7 +1496,7 @@ static void HandleStationRefit(Vehicle *v, CargoArray &consist_capleft, Station 
 	Vehicle *v_start = v->GetFirstEnginePart();
 	if (!IterateVehicleParts(v_start, IsEmptyAction())) return;
 
-	Backup<CompanyID> cur_company(_current_company, v->owner, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, v->owner);
 
 	CargoTypes refit_mask = v->GetEngine()->info.refit_mask;
 

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -144,7 +144,7 @@ struct EnginePreviewWindow : Window {
 	}
 };
 
-static WindowDesc _engine_preview_desc(__FILE__, __LINE__,
+static WindowDesc _engine_preview_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_ENGINE_PREVIEW, WC_NONE,
 	WDF_CONSTRUCTION,

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -10,12 +10,12 @@
 #include "stdafx.h"
 #include "error_func.h"
 
-[[noreturn]] void NotReachedError(int line, const char *file)
+[[noreturn]] void NOT_REACHED(const std::source_location location)
 {
-	FatalError("NOT_REACHED triggered at line {} of {}", line, file);
+	FatalError("NOT_REACHED triggered at line {} of {}", location.line(), location.file_name());
 }
 
-[[noreturn]] void AssertFailedError(int line, const char *file, const char *expression)
+[[noreturn]] void AssertFailedError(const char *expression, const std::source_location location)
 {
-	FatalError("Assertion failed at line {} of {}: {}", line, file, expression);
+	FatalError("Assertion failed at line {} of {}: {}", location.line(), location.file_name(), expression);
 }

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -43,7 +43,7 @@ static constexpr NWidgetPart _nested_errmsg_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _errmsg_desc(__FILE__, __LINE__,
+static WindowDesc _errmsg_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_ERRMSG, WC_NONE,
 	0,
@@ -63,7 +63,7 @@ static constexpr NWidgetPart _nested_errmsg_face_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _errmsg_face_desc(__FILE__, __LINE__,
+static WindowDesc _errmsg_face_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_ERRMSG, WC_NONE,
 	0,

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -883,7 +883,7 @@ public:
 };
 
 /** Load game/scenario */
-static WindowDesc _load_dialog_desc(__FILE__, __LINE__,
+static WindowDesc _load_dialog_desc(
 	WDP_CENTER, "load_game", 500, 294,
 	WC_SAVELOAD, WC_NONE,
 	0,
@@ -891,7 +891,7 @@ static WindowDesc _load_dialog_desc(__FILE__, __LINE__,
 );
 
 /** Load heightmap */
-static WindowDesc _load_heightmap_dialog_desc(__FILE__, __LINE__,
+static WindowDesc _load_heightmap_dialog_desc(
 	WDP_CENTER, "load_heightmap", 257, 320,
 	WC_SAVELOAD, WC_NONE,
 	0,
@@ -899,7 +899,7 @@ static WindowDesc _load_heightmap_dialog_desc(__FILE__, __LINE__,
 );
 
 /** Save game/scenario */
-static WindowDesc _save_dialog_desc(__FILE__, __LINE__,
+static WindowDesc _save_dialog_desc(
 	WDP_CENTER, "save_game", 500, 294,
 	WC_SAVELOAD, WC_NONE,
 	0,

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -726,7 +726,7 @@ struct FramerateWindow : Window {
 	}
 };
 
-static WindowDesc _framerate_display_desc(__FILE__, __LINE__,
+static WindowDesc _framerate_display_desc(
 	WDP_AUTO, "framerate_display", 0, 0,
 	WC_FRAMERATE_DISPLAY, WC_NONE,
 	0,
@@ -1017,7 +1017,7 @@ struct FrametimeGraphWindow : Window {
 	}
 };
 
-static WindowDesc _frametime_graph_window_desc(__FILE__, __LINE__,
+static WindowDesc _frametime_graph_window_desc(
 	WDP_AUTO, "frametime_graph", 140, 90,
 	WC_FRAMETIME_GRAPH, WC_NONE,
 	0,

--- a/src/game/game_core.cpp
+++ b/src/game/game_core.cpp
@@ -43,7 +43,7 @@
 
 	Game::frame_counter++;
 
-	Backup<CompanyID> cur_company(_current_company, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company);
 	cur_company.Change(OWNER_DEITY);
 	Game::instance->GameLoop();
 	cur_company.Restore();
@@ -85,7 +85,7 @@
 
 	config->AnchorUnchangeableSettings();
 
-	Backup<CompanyID> cur_company(_current_company, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company);
 	cur_company.Change(OWNER_DEITY);
 
 	Game::info = info;
@@ -101,7 +101,7 @@
 
 /* static */ void Game::Uninitialize(bool keepConfig)
 {
-	Backup<CompanyID> cur_company(_current_company, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company);
 
 	delete Game::instance;
 	Game::instance = nullptr;
@@ -161,7 +161,7 @@
 	}
 
 	/* Queue the event */
-	Backup<CompanyID> cur_company(_current_company, OWNER_DEITY, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, OWNER_DEITY);
 	Game::instance->InsertEvent(event);
 	cur_company.Restore();
 
@@ -211,7 +211,7 @@
 /* static */ void Game::Save()
 {
 	if (Game::instance != nullptr && (!_networking || _network_server)) {
-		Backup<CompanyID> cur_company(_current_company, OWNER_DEITY, FILE_LINE);
+		Backup<CompanyID> cur_company(_current_company, OWNER_DEITY);
 		Game::instance->Save();
 		cur_company.Restore();
 	} else {

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -73,7 +73,7 @@ static constexpr NWidgetPart _nested_gs_config_widgets[] = {
 };
 
 /** Window definition for the configure GS window. */
-static WindowDesc _gs_config_desc(__FILE__, __LINE__,
+static WindowDesc _gs_config_desc(
 	WDP_CENTER, "settings_gs_config", 500, 350,
 	WC_GAME_OPTIONS, WC_NONE,
 	0,

--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -86,7 +86,7 @@ static void CleanupGeneration()
 static void _GenerateWorld()
 {
 	/* Make sure everything is done via OWNER_NONE. */
-	Backup<CompanyID> _cur_company(_current_company, OWNER_NONE, FILE_LINE);
+	Backup<CompanyID> _cur_company(_current_company, OWNER_NONE);
 
 	try {
 		_generating_world = true;

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -1003,14 +1003,14 @@ struct GenerateLandscapeWindow : public Window {
 	}
 };
 
-static WindowDesc _generate_landscape_desc(__FILE__, __LINE__,
+static WindowDesc _generate_landscape_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_GENERATE_LANDSCAPE, WC_NONE,
 	0,
 	std::begin(_nested_generate_landscape_widgets), std::end(_nested_generate_landscape_widgets)
 );
 
-static WindowDesc _heightmap_load_desc(__FILE__, __LINE__,
+static WindowDesc _heightmap_load_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_GENERATE_LANDSCAPE, WC_NONE,
 	0,
@@ -1313,7 +1313,7 @@ static constexpr NWidgetPart _nested_create_scenario_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _create_scenario_desc(__FILE__, __LINE__,
+static WindowDesc _create_scenario_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_GENERATE_LANDSCAPE, WC_NONE,
 	0,
@@ -1339,7 +1339,7 @@ static constexpr NWidgetPart _nested_generate_progress_widgets[] = {
 };
 
 
-static WindowDesc _generate_progress_desc(__FILE__, __LINE__,
+static WindowDesc _generate_progress_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_MODAL_PROGRESS, WC_NONE,
 	0,

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1196,7 +1196,7 @@ std::unique_ptr<uint32_t[]> DrawSpriteToRgbaBuffer(SpriteID spriteId, ZoomLevel 
 	}
 
 	/* Temporarily disable screen animations while blitting - This prevents 40bpp_anim from writing to the animation buffer. */
-	Backup<bool> disable_anim(_screen_disable_anim, true, FILE_LINE);
+	Backup<bool> disable_anim(_screen_disable_anim, true);
 	GfxBlitter<1, true>(sprite, 0, 0, BM_NORMAL, nullptr, real_sprite, zoom, &dpi);
 	disable_anim.Restore();
 

--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -302,7 +302,7 @@ static constexpr NWidgetPart _nested_goals_list_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _goals_list_desc(__FILE__, __LINE__,
+static WindowDesc _goals_list_desc(
 	WDP_AUTO, "list_goals", 500, 127,
 	WC_GOALS_LIST, WC_NONE,
 	0,
@@ -447,28 +447,24 @@ static constexpr auto _nested_goal_question_widgets_error    = NestedGoalWidgets
 
 static WindowDesc _goal_question_list_desc[] = {
 	{
-		__FILE__, __LINE__,
 		WDP_CENTER, nullptr, 0, 0,
 		WC_GOAL_QUESTION, WC_NONE,
 		WDF_CONSTRUCTION,
 		std::begin(_nested_goal_question_widgets_question), std::end(_nested_goal_question_widgets_question),
 	},
 	{
-		__FILE__, __LINE__,
 		WDP_CENTER, nullptr, 0, 0,
 		WC_GOAL_QUESTION, WC_NONE,
 		WDF_CONSTRUCTION,
 		std::begin(_nested_goal_question_widgets_info), std::end(_nested_goal_question_widgets_info),
 	},
 	{
-		__FILE__, __LINE__,
 		WDP_CENTER, nullptr, 0, 0,
 		WC_GOAL_QUESTION, WC_NONE,
 		WDF_CONSTRUCTION,
 		std::begin(_nested_goal_question_widgets_warning), std::end(_nested_goal_question_widgets_warning),
 	},
 	{
-		__FILE__, __LINE__,
 		WDP_CENTER, nullptr, 0, 0,
 		WC_GOAL_QUESTION, WC_NONE,
 		WDF_CONSTRUCTION,

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -142,7 +142,7 @@ static constexpr NWidgetPart _nested_graph_legend_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _graph_legend_desc(__FILE__, __LINE__,
+static WindowDesc _graph_legend_desc(
 	WDP_AUTO, "graph_legend", 0, 0,
 	WC_GRAPH_LEGEND, WC_NONE,
 	0,
@@ -692,7 +692,7 @@ static constexpr NWidgetPart _nested_operating_profit_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _operating_profit_desc(__FILE__, __LINE__,
+static WindowDesc _operating_profit_desc(
 	WDP_AUTO, "graph_operating_profit", 0, 0,
 	WC_OPERATING_PROFIT, WC_NONE,
 	0,
@@ -751,7 +751,7 @@ static constexpr NWidgetPart _nested_income_graph_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _income_graph_desc(__FILE__, __LINE__,
+static WindowDesc _income_graph_desc(
 	WDP_AUTO, "graph_income", 0, 0,
 	WC_INCOME_GRAPH, WC_NONE,
 	0,
@@ -808,7 +808,7 @@ static constexpr NWidgetPart _nested_delivered_cargo_graph_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _delivered_cargo_graph_desc(__FILE__, __LINE__,
+static WindowDesc _delivered_cargo_graph_desc(
 	WDP_AUTO, "graph_delivered_cargo", 0, 0,
 	WC_DELIVERED_CARGO, WC_NONE,
 	0,
@@ -872,7 +872,7 @@ static constexpr NWidgetPart _nested_performance_history_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _performance_history_desc(__FILE__, __LINE__,
+static WindowDesc _performance_history_desc(
 	WDP_AUTO, "graph_performance", 0, 0,
 	WC_PERFORMANCE_HISTORY, WC_NONE,
 	0,
@@ -929,7 +929,7 @@ static constexpr NWidgetPart _nested_company_value_graph_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _company_value_graph_desc(__FILE__, __LINE__,
+static WindowDesc _company_value_graph_desc(
 	WDP_AUTO, "graph_company_value", 0, 0,
 	WC_COMPANY_VALUE, WC_NONE,
 	0,
@@ -1167,7 +1167,7 @@ static constexpr NWidgetPart _nested_cargo_payment_rates_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _cargo_payment_rates_desc(__FILE__, __LINE__,
+static WindowDesc _cargo_payment_rates_desc(
 	WDP_AUTO, "graph_cargo_payment_rates", 0, 0,
 	WC_PAYMENT_RATES, WC_NONE,
 	0,
@@ -1460,7 +1460,7 @@ static constexpr NWidgetPart _nested_performance_rating_detail_widgets[] = {
 	NWidgetFunction(MakePerformanceDetailPanels),
 };
 
-static WindowDesc _performance_rating_detail_desc(__FILE__, __LINE__,
+static WindowDesc _performance_rating_detail_desc(
 	WDP_AUTO, "league_details", 0, 0,
 	WC_PERFORMANCE_DETAIL, WC_NONE,
 	0,

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -1100,14 +1100,14 @@ public:
 };
 
 
-static WindowDesc _other_group_desc(__FILE__, __LINE__,
+static WindowDesc _other_group_desc(
 	WDP_AUTO, "list_groups", 460, 246,
 	WC_INVALID, WC_NONE,
 	0,
 	std::begin(_nested_group_widgets), std::end(_nested_group_widgets)
 );
 
-static WindowDesc _train_group_desc(__FILE__, __LINE__,
+static WindowDesc _train_group_desc(
 	WDP_AUTO, "list_groups_train", 525, 246,
 	WC_TRAINS_LIST, WC_NONE,
 	0,

--- a/src/help_gui.cpp
+++ b/src/help_gui.cpp
@@ -193,7 +193,7 @@ static constexpr NWidgetPart _nested_helpwin_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _helpwin_desc(__FILE__, __LINE__,
+static WindowDesc _helpwin_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_HELPWIN, WC_NONE,
 	0,

--- a/src/highscore_gui.cpp
+++ b/src/highscore_gui.cpp
@@ -214,14 +214,14 @@ static constexpr NWidgetPart _nested_highscore_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_BROWN, WID_H_BACKGROUND), SetResize(1, 1), EndContainer(),
 };
 
-static WindowDesc _highscore_desc(__FILE__, __LINE__,
+static WindowDesc _highscore_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_HIGHSCORE, WC_NONE,
 	0,
 	std::begin(_nested_highscore_widgets), std::end(_nested_highscore_widgets)
 );
 
-static WindowDesc _endgame_desc(__FILE__, __LINE__,
+static WindowDesc _endgame_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_ENDSCREEN, WC_NONE,
 	0,

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1105,7 +1105,7 @@ static bool SearchLumberMillTrees(TileIndex tile, void *)
 	if (IsTileType(tile, MP_TREES) && GetTreeGrowth(tile) > 2) { ///< 3 and up means all fully grown trees
 		/* found a tree */
 
-		Backup<CompanyID> cur_company(_current_company, OWNER_NONE, FILE_LINE);
+		Backup<CompanyID> cur_company(_current_company, OWNER_NONE);
 
 		_industry_sound_ctr = 1;
 		_industry_sound_tile = tile;
@@ -1500,7 +1500,7 @@ static CommandCost CheckIfIndustryTilesAreFree(TileIndex tile, const IndustryTil
 				}
 
 				/* Clear the tiles as OWNER_TOWN to not affect town rating, and to not clear protected buildings */
-				Backup<CompanyID> cur_company(_current_company, OWNER_TOWN, FILE_LINE);
+				Backup<CompanyID> cur_company(_current_company, OWNER_TOWN);
 				ret = Command<CMD_LANDSCAPE_CLEAR>::Do(DC_NONE, cur_tile);
 				cur_company.Restore();
 
@@ -1642,7 +1642,7 @@ static bool CheckIfCanLevelIndustryPlatform(TileIndex tile, DoCommandFlag flags,
 
 	/* _current_company is OWNER_NONE for randomly generated industries and in editor, or the company who funded or prospected the industry.
 	 * Perform terraforming as OWNER_TOWN to disable autoslope and town ratings. */
-	Backup<CompanyID> cur_company(_current_company, OWNER_TOWN, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, OWNER_TOWN);
 
 	for (TileIndex tile_walk : ta) {
 		uint curh = TileHeight(tile_walk);
@@ -2081,7 +2081,7 @@ CommandCost CmdBuildIndustry(DoCommandFlag flags, TileIndex tile, IndustryType i
 			if (prospect_success) {
 				/* Prospected industries are build as OWNER_TOWN to not e.g. be build on owned land of the founder */
 				IndustryAvailabilityCallType calltype = _current_company == OWNER_DEITY ? IACT_RANDOMCREATION : IACT_PROSPECTCREATION;
-				Backup<CompanyID> cur_company(_current_company, OWNER_TOWN, FILE_LINE);
+				Backup<CompanyID> cur_company(_current_company, OWNER_TOWN);
 				for (int i = 0; i < 5000; i++) {
 					/* We should not have more than one Random() in a function call
 					 * because parameter evaluation order is not guaranteed in the c++ standard
@@ -2383,7 +2383,7 @@ static Industry *PlaceIndustry(IndustryType type, IndustryAvailabilityCallType c
  */
 static void PlaceInitialIndustry(IndustryType type, bool try_hard)
 {
-	Backup<CompanyID> cur_company(_current_company, OWNER_NONE, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, OWNER_NONE);
 
 	IncreaseGeneratingWorldProgress(GWP_INDUSTRY);
 	PlaceIndustry(type, IACT_MAPGENERATION, try_hard);
@@ -3023,7 +3023,7 @@ static IntervalTimer<TimerGameEconomy> _economy_industries_daily({TimerGameEcono
 		return;  // Nothing to do? get out
 	}
 
-	Backup<CompanyID> cur_company(_current_company, OWNER_NONE, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, OWNER_NONE);
 
 	/* perform the required industry changes for the day */
 
@@ -3051,7 +3051,7 @@ static IntervalTimer<TimerGameEconomy> _economy_industries_daily({TimerGameEcono
 
 static IntervalTimer<TimerGameEconomy> _economy_industries_monthly({TimerGameEconomy::MONTH, TimerGameEconomy::Priority::INDUSTRY}, [](auto)
 {
-	Backup<CompanyID> cur_company(_current_company, OWNER_NONE, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, OWNER_NONE);
 
 	_industry_builder.EconomyMonthlyLoop();
 

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -292,7 +292,7 @@ static constexpr NWidgetPart _nested_build_industry_widgets[] = {
 };
 
 /** Window definition of the dynamic place industries gui */
-static WindowDesc _build_industry_desc(__FILE__, __LINE__,
+static WindowDesc _build_industry_desc(
 	WDP_AUTO, "build_industry", 170, 212,
 	WC_BUILD_INDUSTRY, WC_NONE,
 	WDF_CONSTRUCTION,
@@ -1216,7 +1216,7 @@ static constexpr NWidgetPart _nested_industry_view_widgets[] = {
 };
 
 /** Window definition of the view industry gui */
-static WindowDesc _industry_view_desc(__FILE__, __LINE__,
+static WindowDesc _industry_view_desc(
 	WDP_AUTO, "view_industry", 260, 120,
 	WC_INDUSTRY_VIEW, WC_NONE,
 	0,
@@ -1920,7 +1920,7 @@ CargoID IndustryDirectoryWindow::produced_cargo_filter = CargoFilterCriteria::CF
 
 
 /** Window definition of the industry directory gui */
-static WindowDesc _industry_directory_desc(__FILE__, __LINE__,
+static WindowDesc _industry_directory_desc(
 	WDP_AUTO, "list_industries", 428, 190,
 	WC_INDUSTRY_DIRECTORY, WC_NONE,
 	0,
@@ -1959,7 +1959,7 @@ static constexpr NWidgetPart _nested_industry_cargoes_widgets[] = {
 };
 
 /** Window description for the industry cargoes window. */
-static WindowDesc _industry_cargoes_desc(__FILE__, __LINE__,
+static WindowDesc _industry_cargoes_desc(
 	WDP_AUTO, "industry_cargoes", 300, 210,
 	WC_INDUSTRY_CARGOES, WC_NONE,
 	0,

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -603,7 +603,7 @@ public:
 		if (Town::GetNumItems() == 0) {
 			ShowErrorMessage(STR_ERROR_CAN_T_GENERATE_INDUSTRIES, STR_ERROR_MUST_FOUND_TOWN_FIRST, WL_INFO);
 		} else {
-			Backup<bool> old_generating_world(_generating_world, true, FILE_LINE);
+			Backup<bool> old_generating_world(_generating_world, true);
 			BasePersistentStorageArray::SwitchMode(PSM_ENTER_GAMELOOP);
 			GenerateIndustries();
 			BasePersistentStorageArray::SwitchMode(PSM_LEAVE_GAMELOOP);
@@ -707,8 +707,8 @@ public:
 				return;
 			}
 
-			Backup<CompanyID> cur_company(_current_company, OWNER_NONE, FILE_LINE);
-			Backup<bool> old_generating_world(_generating_world, true, FILE_LINE);
+			Backup<CompanyID> cur_company(_current_company, OWNER_NONE);
+			Backup<bool> old_generating_world(_generating_world, true);
 			_ignore_restrictions = true;
 
 			Command<CMD_BUILD_INDUSTRY>::Post(STR_ERROR_CAN_T_CONSTRUCT_THIS_INDUSTRY, &CcBuildIndustry, tile, this->selected_type, layout_index, false, seed);

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -456,7 +456,7 @@ static constexpr NWidgetPart _nested_select_game_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _select_game_desc(__FILE__, __LINE__,
+static WindowDesc _select_game_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_SELECT_GAME, WC_NONE,
 	WDF_NO_CLOSE,

--- a/src/league_gui.cpp
+++ b/src/league_gui.cpp
@@ -199,7 +199,7 @@ static constexpr NWidgetPart _nested_performance_league_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _performance_league_desc(__FILE__, __LINE__,
+static WindowDesc _performance_league_desc(
 	WDP_AUTO, "performance_league", 0, 0,
 	WC_COMPANY_LEAGUE, WC_NONE,
 	0,
@@ -434,7 +434,7 @@ static constexpr NWidgetPart _nested_script_league_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _script_league_desc(__FILE__, __LINE__,
+static WindowDesc _script_league_desc(
 	WDP_AUTO, "script_league", 0, 0,
 	WC_COMPANY_LEAGUE, WC_NONE,
 	0,

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -536,7 +536,7 @@ static constexpr NWidgetPart _nested_linkgraph_legend_widgets[] = {
 static_assert(WID_LGL_SATURATION_LAST - WID_LGL_SATURATION_FIRST ==
 		lengthof(LinkGraphOverlay::LINK_COLOURS[0]) - 1);
 
-static WindowDesc _linkgraph_legend_desc(__FILE__, __LINE__,
+static WindowDesc _linkgraph_legend_desc(
 	WDP_AUTO, "toolbar_linkgraph", 0, 0,
 	WC_LINKGRAPH_LEGEND, WC_NONE,
 	0,

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -513,7 +513,7 @@ struct MainWindow : Window
 	}};
 };
 
-static WindowDesc _main_window_desc(__FILE__, __LINE__,
+static WindowDesc _main_window_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_MAIN_WINDOW, WC_NONE,
 	WDF_NO_CLOSE,

--- a/src/misc_cmd.cpp
+++ b/src/misc_cmd.cpp
@@ -241,7 +241,7 @@ CommandCost CmdChangeBankBalance(DoCommandFlag flags, TileIndex tile, Money delt
 
 	if (flags & DC_EXEC) {
 		/* Change company bank balance of company. */
-		Backup<CompanyID> cur_company(_current_company, company, FILE_LINE);
+		Backup<CompanyID> cur_company(_current_company, company);
 		SubtractMoneyFromCompany(CommandCost(expenses_type, -delta));
 		cur_company.Restore();
 

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -59,7 +59,7 @@ static constexpr NWidgetPart _nested_land_info_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_GREY, WID_LI_BACKGROUND), EndContainer(),
 };
 
-static WindowDesc _land_info_desc(__FILE__, __LINE__,
+static WindowDesc _land_info_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_LAND_INFO, WC_NONE,
 	0,
@@ -397,7 +397,7 @@ static constexpr NWidgetPart _nested_about_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _about_desc(__FILE__, __LINE__,
+static WindowDesc _about_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_GAME_OPTIONS, WC_NONE,
 	0,
@@ -656,7 +656,7 @@ static constexpr NWidgetPart _nested_tooltips_widgets[] = {
 	NWidget(WWT_EMPTY, INVALID_COLOUR, WID_TT_BACKGROUND),
 };
 
-static WindowDesc _tool_tips_desc(__FILE__, __LINE__,
+static WindowDesc _tool_tips_desc(
 	WDP_MANUAL, nullptr, 0, 0, // Coordinates and sizes are not used,
 	WC_TOOLTIPS, WC_NONE,
 	WDF_NO_FOCUS | WDF_NO_CLOSE,
@@ -1069,7 +1069,7 @@ static constexpr NWidgetPart _nested_query_string_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _query_string_desc(__FILE__, __LINE__,
+static WindowDesc _query_string_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_QUERY_STRING, WC_NONE,
 	0,
@@ -1212,7 +1212,7 @@ static constexpr NWidgetPart _nested_query_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _query_desc(__FILE__, __LINE__,
+static WindowDesc _query_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_CONFIRM_POPUP_QUERY, WC_NONE,
 	WDF_MODAL,

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -667,7 +667,7 @@ static constexpr NWidgetPart _nested_music_track_selection_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _music_track_selection_desc(__FILE__, __LINE__,
+static WindowDesc _music_track_selection_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_MUSIC_TRACK_SELECTION, WC_NONE,
 	0,
@@ -926,7 +926,7 @@ static constexpr NWidgetPart _nested_music_window_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _music_window_desc(__FILE__, __LINE__,
+static WindowDesc _music_window_desc(
 	WDP_AUTO, "music", 0, 0,
 	WC_MUSIC_WINDOW, WC_NONE,
 	0,

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -506,7 +506,7 @@ static constexpr NWidgetPart _nested_chat_window_widgets[] = {
 };
 
 /** The description of the chat window. */
-static WindowDesc _chat_window_desc(__FILE__, __LINE__,
+static WindowDesc _chat_window_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_SEND_NETWORK_MSG, WC_NONE,
 	0,

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -1284,7 +1284,7 @@ void NetworkClientRequestMove(CompanyID company_id, const std::string &pass)
  */
 void NetworkClientsToSpectators(CompanyID cid)
 {
-	Backup<CompanyID> cur_company(_current_company, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company);
 	/* If our company is changing owner, go to spectators */
 	if (cid == _local_company) SetLocalCompany(COMPANY_SPECTATOR);
 

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -94,7 +94,7 @@ static constexpr NWidgetPart _nested_network_content_download_status_window_widg
 };
 
 /** Window description for the download window */
-static WindowDesc _network_content_download_status_window_desc(__FILE__, __LINE__,
+static WindowDesc _network_content_download_status_window_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_NETWORK_STATUS_WINDOW, WC_NONE,
 	WDF_MODAL,
@@ -1113,7 +1113,7 @@ static constexpr NWidgetPart _nested_network_content_list_widgets[] = {
 };
 
 /** Window description of the content list */
-static WindowDesc _network_content_list_desc(__FILE__, __LINE__,
+static WindowDesc _network_content_list_desc(
 	WDP_CENTER, "list_content", 630, 460,
 	WC_NETWORK_WINDOW, WC_NONE,
 	0,

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -955,7 +955,7 @@ static constexpr NWidgetPart _nested_network_game_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _network_game_window_desc(__FILE__, __LINE__,
+static WindowDesc _network_game_window_desc(
 	WDP_CENTER, "list_servers", 1000, 730,
 	WC_NETWORK_WINDOW, WC_NONE,
 	0,
@@ -1222,7 +1222,7 @@ static constexpr NWidgetPart _nested_network_start_server_window_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _network_start_server_window_desc(__FILE__, __LINE__,
+static WindowDesc _network_start_server_window_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_NETWORK_WINDOW, WC_NONE,
 	0,
@@ -1301,7 +1301,7 @@ static constexpr NWidgetPart _nested_client_list_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _client_list_desc(__FILE__, __LINE__,
+static WindowDesc _client_list_desc(
 	WDP_AUTO, "list_clients", 220, 300,
 	WC_CLIENT_LIST, WC_NONE,
 	0,
@@ -2223,7 +2223,7 @@ static constexpr NWidgetPart _nested_network_join_status_window_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _network_join_status_window_desc(__FILE__, __LINE__,
+static WindowDesc _network_join_status_window_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_NETWORK_STATUS_WINDOW, WC_NONE,
 	WDF_MODAL,
@@ -2345,7 +2345,7 @@ static constexpr NWidgetPart _nested_network_company_password_window_widgets[] =
 	EndContainer(),
 };
 
-static WindowDesc _network_company_password_window_desc(__FILE__, __LINE__,
+static WindowDesc _network_company_password_window_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_COMPANY_PASSWORD_WINDOW, WC_NONE,
 	0,
@@ -2454,7 +2454,7 @@ static constexpr NWidgetPart _nested_network_ask_relay_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _network_ask_relay_desc(__FILE__, __LINE__,
+static WindowDesc _network_ask_relay_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_NETWORK_ASK_RELAY, WC_NONE,
 	WDF_MODAL,
@@ -2552,7 +2552,7 @@ static constexpr NWidgetPart _nested_network_ask_survey_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _network_ask_survey_desc(__FILE__, __LINE__,
+static WindowDesc _network_ask_survey_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_NETWORK_ASK_SURVEY, WC_NONE,
 	WDF_MODAL,

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -679,14 +679,14 @@ static constexpr NWidgetPart _nested_newgrf_inspect_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _newgrf_inspect_chain_desc(__FILE__, __LINE__,
+static WindowDesc _newgrf_inspect_chain_desc(
 	WDP_AUTO, "newgrf_inspect_chain", 400, 300,
 	WC_NEWGRF_INSPECT, WC_NONE,
 	0,
 	std::begin(_nested_newgrf_inspect_chain_widgets), std::end(_nested_newgrf_inspect_chain_widgets)
 );
 
-static WindowDesc _newgrf_inspect_desc(__FILE__, __LINE__,
+static WindowDesc _newgrf_inspect_desc(
 	WDP_AUTO, "newgrf_inspect", 400, 300,
 	WC_NEWGRF_INSPECT, WC_NONE,
 	0,
@@ -1163,7 +1163,7 @@ static constexpr NWidgetPart _nested_sprite_aligner_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _sprite_aligner_desc(__FILE__, __LINE__,
+static WindowDesc _sprite_aligner_desc(
 	WDP_AUTO, "sprite_aligner", 400, 300,
 	WC_SPRITE_ALIGNER, WC_NONE,
 	0,

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -541,7 +541,7 @@ static constexpr NWidgetPart _nested_newgrf_parameter_widgets[] = {
 };
 
 /** Window definition for the change grf parameters window */
-static WindowDesc _newgrf_parameters_desc(__FILE__, __LINE__,
+static WindowDesc _newgrf_parameters_desc(
 	WDP_CENTER, "settings_newgrf_config", 500, 208,
 	WC_GRF_PARAMETERS, WC_NONE,
 	0,
@@ -1967,7 +1967,7 @@ static constexpr NWidgetPart _nested_newgrf_widgets[] = {
 };
 
 /* Window definition of the manage newgrfs window */
-static WindowDesc _newgrf_desc(__FILE__, __LINE__,
+static WindowDesc _newgrf_desc(
 	WDP_CENTER, "settings_newgrf", 300, 263,
 	WC_GAME_OPTIONS, WC_NONE,
 	0,
@@ -2051,7 +2051,7 @@ static constexpr NWidgetPart _nested_save_preset_widgets[] = {
 };
 
 /** Window description of the preset save window. */
-static WindowDesc _save_preset_desc(__FILE__, __LINE__,
+static WindowDesc _save_preset_desc(
 	WDP_CENTER, "save_preset", 140, 110,
 	WC_SAVE_PRESET, WC_GAME_OPTIONS,
 	WDF_MODAL,
@@ -2196,7 +2196,7 @@ static constexpr NWidgetPart _nested_scan_progress_widgets[] = {
 };
 
 /** Description of the widgets and other settings of the window. */
-static WindowDesc _scan_progress_desc(__FILE__, __LINE__,
+static WindowDesc _scan_progress_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_MODAL_PROGRESS, WC_NONE,
 	0,

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -96,7 +96,7 @@ static constexpr NWidgetPart _nested_normal_news_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _normal_news_desc(__FILE__, __LINE__,
+static WindowDesc _normal_news_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	0,
@@ -123,7 +123,7 @@ static constexpr NWidgetPart _nested_vehicle_news_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _vehicle_news_desc(__FILE__, __LINE__,
+static WindowDesc _vehicle_news_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	0,
@@ -151,7 +151,7 @@ static constexpr NWidgetPart _nested_company_news_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _company_news_desc(__FILE__, __LINE__,
+static WindowDesc _company_news_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	0,
@@ -174,7 +174,7 @@ static constexpr NWidgetPart _nested_thin_news_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _thin_news_desc(__FILE__, __LINE__,
+static WindowDesc _thin_news_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	0,
@@ -200,7 +200,7 @@ static constexpr NWidgetPart _nested_small_news_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _small_news_desc(__FILE__, __LINE__,
+static WindowDesc _small_news_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	0,
@@ -1228,7 +1228,7 @@ static constexpr NWidgetPart _nested_message_history[] = {
 	EndContainer(),
 };
 
-static WindowDesc _message_history_desc(__FILE__, __LINE__,
+static WindowDesc _message_history_desc(
 	WDP_AUTO, "list_news", 400, 140,
 	WC_MESSAGE_HISTORY, WC_NONE,
 	0,

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -711,7 +711,7 @@ static constexpr NWidgetPart _nested_build_object_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _build_object_desc(__FILE__, __LINE__,
+static WindowDesc _build_object_desc(
 	WDP_AUTO, "build_object", 0, 0,
 	WC_BUILD_OBJECT, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1475,7 +1475,7 @@ void StateGameLoop()
 
 		/* All these actions has to be done from OWNER_NONE
 		 *  for multiplayer compatibility */
-		Backup<CompanyID> cur_company(_current_company, OWNER_NONE, FILE_LINE);
+		Backup<CompanyID> cur_company(_current_company, OWNER_NONE);
 
 		BasePersistentStorageArray::SwitchMode(PSM_ENTER_GAMELOOP);
 		AnimateAnimatedTiles();

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -1686,7 +1686,7 @@ static constexpr NWidgetPart _nested_orders_train_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _orders_train_desc(__FILE__, __LINE__,
+static WindowDesc _orders_train_desc(
 	WDP_AUTO, "view_vehicle_orders_train", 384, 100,
 	WC_VEHICLE_ORDERS, WC_VEHICLE_VIEW,
 	WDF_CONSTRUCTION,
@@ -1759,7 +1759,7 @@ static constexpr NWidgetPart _nested_orders_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _orders_desc(__FILE__, __LINE__,
+static WindowDesc _orders_desc(
 	WDP_AUTO, "view_vehicle_orders", 384, 100,
 	WC_VEHICLE_ORDERS, WC_VEHICLE_VIEW,
 	WDF_CONSTRUCTION,
@@ -1786,7 +1786,7 @@ static constexpr NWidgetPart _nested_other_orders_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _other_orders_desc(__FILE__, __LINE__,
+static WindowDesc _other_orders_desc(
 	WDP_AUTO, "view_vehicle_orders_competitor", 384, 86,
 	WC_VEHICLE_ORDERS, WC_VEHICLE_VIEW,
 	WDF_CONSTRUCTION,

--- a/src/osk_gui.cpp
+++ b/src/osk_gui.cpp
@@ -333,7 +333,7 @@ static constexpr NWidgetPart _nested_osk_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _osk_desc(__FILE__, __LINE__,
+static WindowDesc _osk_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_OSK, WC_NONE,
 	0,

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -774,7 +774,7 @@ bool FloodHalftile(TileIndex t)
 
 		TrackBits to_remove = lower_track & rail_bits;
 		if (to_remove != 0) {
-			Backup<CompanyID> cur_company(_current_company, OWNER_WATER, FILE_LINE);
+			Backup<CompanyID> cur_company(_current_company, OWNER_WATER);
 			flooded = Command<CMD_REMOVE_SINGLE_RAIL>::Do(DC_EXEC, t, FindFirstTrack(to_remove)).Succeeded();
 			cur_company.Restore();
 			if (!flooded) return flooded; // not yet floodable

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -891,7 +891,7 @@ static constexpr NWidgetPart _nested_build_rail_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _build_rail_desc(__FILE__, __LINE__,
+static WindowDesc _build_rail_desc(
 	WDP_ALIGN_TOOLBAR, "toolbar_rail", 0, 0,
 	WC_BUILD_TOOLBAR, WC_NONE,
 	WDF_CONSTRUCTION,
@@ -1671,7 +1671,7 @@ static constexpr NWidgetPart _nested_station_builder_widgets[] = {
 };
 
 /** High level window description of the station-build window (default & newGRF) */
-static WindowDesc _station_builder_desc(__FILE__, __LINE__,
+static WindowDesc _station_builder_desc(
 	WDP_AUTO, "build_station_rail", 350, 0,
 	WC_BUILD_STATION, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
@@ -1931,7 +1931,7 @@ static constexpr NWidgetPart _nested_signal_builder_widgets[] = {
 };
 
 /** Signal selection window description */
-static WindowDesc _signal_builder_desc(__FILE__, __LINE__,
+static WindowDesc _signal_builder_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_BUILD_SIGNAL, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
@@ -2012,7 +2012,7 @@ static constexpr NWidgetPart _nested_build_depot_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _build_depot_desc(__FILE__, __LINE__,
+static WindowDesc _build_depot_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_BUILD_DEPOT, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
@@ -2241,7 +2241,7 @@ static constexpr NWidgetPart _nested_build_waypoint_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _build_waypoint_desc(__FILE__, __LINE__,
+static WindowDesc _build_waypoint_desc(
 	WDP_AUTO, "build_waypoint", 0, 0,
 	WC_BUILD_WAYPOINT, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -851,7 +851,7 @@ static constexpr NWidgetPart _nested_build_road_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _build_road_desc(__FILE__, __LINE__,
+static WindowDesc _build_road_desc(
 	WDP_ALIGN_TOOLBAR, "toolbar_road", 0, 0,
 	WC_BUILD_TOOLBAR, WC_NONE,
 	WDF_CONSTRUCTION,
@@ -892,7 +892,7 @@ static constexpr NWidgetPart _nested_build_tramway_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _build_tramway_desc(__FILE__, __LINE__,
+static WindowDesc _build_tramway_desc(
 	WDP_ALIGN_TOOLBAR, "toolbar_tramway", 0, 0,
 	WC_BUILD_TOOLBAR, WC_NONE,
 	WDF_CONSTRUCTION,
@@ -947,7 +947,7 @@ static constexpr NWidgetPart _nested_build_road_scen_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _build_road_scen_desc(__FILE__, __LINE__,
+static WindowDesc _build_road_scen_desc(
 	WDP_AUTO, "toolbar_road_scen", 0, 0,
 	WC_SCEN_BUILD_TOOLBAR, WC_NONE,
 	WDF_CONSTRUCTION,
@@ -982,7 +982,7 @@ static constexpr NWidgetPart _nested_build_tramway_scen_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _build_tramway_scen_desc(__FILE__, __LINE__,
+static WindowDesc _build_tramway_scen_desc(
 	WDP_AUTO, "toolbar_tram_scen", 0, 0,
 	WC_SCEN_BUILD_TOOLBAR, WC_NONE,
 	WDF_CONSTRUCTION,
@@ -1079,7 +1079,7 @@ static constexpr NWidgetPart _nested_build_road_depot_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _build_road_depot_desc(__FILE__, __LINE__,
+static WindowDesc _build_road_depot_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_BUILD_DEPOT, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
@@ -1701,7 +1701,7 @@ static constexpr NWidgetPart _nested_road_station_picker_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _road_station_picker_desc(__FILE__, __LINE__,
+static WindowDesc _road_station_picker_desc(
 	WDP_AUTO, "build_station_road", 0, 0,
 	WC_BUS_STATION, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
@@ -1779,7 +1779,7 @@ static constexpr NWidgetPart _nested_tram_station_picker_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _tram_station_picker_desc(__FILE__, __LINE__,
+static WindowDesc _tram_station_picker_desc(
 	WDP_AUTO, "build_station_tram", 0, 0,
 	WC_BUS_STATION, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -1135,7 +1135,7 @@ static Trackdir FollowPreviousRoadVehicle(const RoadVehicle *v, const RoadVehicl
 static bool CanBuildTramTrackOnTile(CompanyID c, TileIndex t, RoadType rt, RoadBits r)
 {
 	/* The 'current' company is not necessarily the owner of the vehicle. */
-	Backup<CompanyID> cur_company(_current_company, c, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, c);
 
 	CommandCost ret = Command<CMD_BUILD_ROAD>::Do(DC_NO_WATER, t, r, rt, DRD_NONE, 0);
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1857,7 +1857,7 @@ bool AfterLoadGame()
 			if (IsBuoyTile(t) || IsDriveThroughStopTile(t) || IsTileType(t, MP_WATER)) {
 				Owner o = GetTileOwner(t);
 				if (o < MAX_COMPANIES && !Company::IsValidID(o)) {
-					Backup<CompanyID> cur_company(_current_company, o, FILE_LINE);
+					Backup<CompanyID> cur_company(_current_company, o);
 					ChangeTileOwner(t, o, INVALID_OWNER);
 					cur_company.Restore();
 				}

--- a/src/screenshot_gui.cpp
+++ b/src/screenshot_gui.cpp
@@ -60,7 +60,7 @@ static constexpr NWidgetPart _nested_screenshot[] = {
 	EndContainer(),
 };
 
-static WindowDesc _screenshot_window_desc(__FILE__, __LINE__,
+static WindowDesc _screenshot_window_desc(
 	WDP_AUTO, "take_a_screenshot", 200, 100,
 	WC_SCREENSHOT, WC_NONE,
 	0,

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -261,7 +261,7 @@ static constexpr NWidgetPart _nested_script_list_widgets[] = {
 };
 
 /** Window definition for the ai list window. */
-static WindowDesc _script_list_desc(__FILE__, __LINE__,
+static WindowDesc _script_list_desc(
 	WDP_CENTER, "settings_script_list", 200, 234,
 	WC_SCRIPT_LIST, WC_NONE,
 	0,
@@ -606,7 +606,7 @@ static constexpr NWidgetPart _nested_script_settings_widgets[] = {
 };
 
 /** Window definition for the Script settings window. */
-static WindowDesc _script_settings_desc(__FILE__, __LINE__,
+static WindowDesc _script_settings_desc(
 	WDP_CENTER, "settings_script", 500, 208,
 	WC_SCRIPT_SETTINGS, WC_NONE,
 	0,
@@ -1288,7 +1288,7 @@ EndContainer(),
 };
 
 /** Window definition for the Script debug window. */
-static WindowDesc _script_debug_desc(__FILE__, __LINE__,
+static WindowDesc _script_debug_desc(
 	WDP_AUTO, "script_debug", 600, 450,
 	WC_SCRIPT_DEBUG, WC_NONE,
 	0,

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1173,7 +1173,7 @@ static constexpr NWidgetPart _nested_game_options_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _game_options_desc(__FILE__, __LINE__,
+static WindowDesc _game_options_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_GAME_OPTIONS, WC_NONE,
 	0,
@@ -2883,7 +2883,7 @@ static constexpr NWidgetPart _nested_settings_selection_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _settings_selection_desc(__FILE__, __LINE__,
+static WindowDesc _settings_selection_desc(
 	WDP_CENTER, "settings", 510, 450,
 	WC_GAME_OPTIONS, WC_NONE,
 	0,
@@ -3191,7 +3191,7 @@ static constexpr NWidgetPart _nested_cust_currency_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _cust_currency_desc(__FILE__, __LINE__,
+static WindowDesc _cust_currency_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_CUSTOM_CURRENCY, WC_NONE,
 	0,

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -383,7 +383,7 @@ static constexpr NWidgetPart _nested_sign_list_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _sign_list_desc(__FILE__, __LINE__,
+static WindowDesc _sign_list_desc(
 	WDP_AUTO, "list_signs", 358, 138,
 	WC_SIGN_LIST, WC_NONE,
 	0,
@@ -549,7 +549,7 @@ static constexpr NWidgetPart _nested_query_sign_edit_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _query_sign_edit_desc(__FILE__, __LINE__,
+static WindowDesc _query_sign_edit_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_QUERY_STRING, WC_NONE,
 	WDF_CONSTRUCTION,

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -1981,7 +1981,7 @@ static constexpr NWidgetPart _nested_smallmap_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _smallmap_desc(__FILE__, __LINE__,
+static WindowDesc _smallmap_desc(
 	WDP_AUTO, "smallmap", 484, 314,
 	WC_SMALLMAP, WC_NONE,
 	0,

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -762,7 +762,7 @@ static constexpr NWidgetPart _nested_company_stations_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _company_stations_desc(__FILE__, __LINE__,
+static WindowDesc _company_stations_desc(
 	WDP_AUTO, "list_stations", 358, 162,
 	WC_STATION_LIST, WC_NONE,
 	0,
@@ -2130,7 +2130,7 @@ const StringID StationViewWindow::_group_names[] = {
 	INVALID_STRING_ID
 };
 
-static WindowDesc _station_view_desc(__FILE__, __LINE__,
+static WindowDesc _station_view_desc(
 	WDP_AUTO, "view_station", 249, 117,
 	WC_STATION_VIEW, WC_NONE,
 	0,
@@ -2388,7 +2388,7 @@ struct SelectStationWindow : Window {
 	}
 };
 
-static WindowDesc _select_station_desc(__FILE__, __LINE__,
+static WindowDesc _select_station_desc(
 	WDP_AUTO, "build_station_join", 200, 180,
 	WC_SELECT_STATION, WC_NONE,
 	WDF_CONSTRUCTION,

--- a/src/statusbar_gui.cpp
+++ b/src/statusbar_gui.cpp
@@ -228,7 +228,7 @@ static constexpr NWidgetPart _nested_main_status_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _main_status_desc(__FILE__, __LINE__,
+static WindowDesc _main_status_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_STATUS_BAR, WC_NONE,
 	WDF_NO_FOCUS | WDF_NO_CLOSE,

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -71,6 +71,7 @@
 #include <numeric>
 #include <optional>
 #include <set>
+#include <source_location>
 #include <span>
 #include <stdexcept>
 #include <string>

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -349,14 +349,13 @@ static_assert(SIZE_MAX >= UINT32_MAX);
 /* For the FMT library we only want to use the headers, not link to some library. */
 #define FMT_HEADER_ONLY
 
-[[noreturn]] void NotReachedError(int line, const char *file);
-[[noreturn]] void AssertFailedError(int line, const char *file, const char *expression);
-#define NOT_REACHED() NotReachedError(__LINE__, __FILE__)
+[[noreturn]] void NOT_REACHED(const std::source_location location = std::source_location::current());
+[[noreturn]] void AssertFailedError(const char *expression, const std::source_location location = std::source_location::current());
 
 /* For non-debug builds with assertions enabled use the special assertion handler. */
 #if defined(NDEBUG) && defined(WITH_ASSERT)
 #	undef assert
-#	define assert(expression) do { if (!(expression)) [[unlikely]] AssertFailedError(__LINE__, __FILE__, #expression); } while (false)
+#	define assert(expression) do { if (!(expression)) [[unlikely]] AssertFailedError(#expression); } while (false)
 #endif
 
 /* Define JSON_ASSERT, which is used by nlohmann-json. Otherwise the header-file

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -968,14 +968,14 @@ static constexpr NWidgetPart _nested_story_book_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _story_book_desc(__FILE__, __LINE__,
+static WindowDesc _story_book_desc(
 	WDP_AUTO, "view_story", 400, 300,
 	WC_STORY_BOOK, WC_NONE,
 	0,
 	std::begin(_nested_story_book_widgets), std::end(_nested_story_book_widgets)
 );
 
-static WindowDesc _story_book_gs_desc(__FILE__, __LINE__,
+static WindowDesc _story_book_gs_desc(
 	WDP_CENTER, "view_story_gs", 400, 300,
 	WC_STORY_BOOK, WC_NONE,
 	0,

--- a/src/subsidy_gui.cpp
+++ b/src/subsidy_gui.cpp
@@ -267,7 +267,7 @@ static constexpr NWidgetPart _nested_subsidies_list_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _subsidies_list_desc(__FILE__, __LINE__,
+static WindowDesc _subsidies_list_desc(
 	WDP_AUTO, "list_subsidies", 500, 127,
 	WC_SUBSIDIES_LIST, WC_NONE,
 	0,

--- a/src/terraform_cmd.cpp
+++ b/src/terraform_cmd.cpp
@@ -268,7 +268,7 @@ std::tuple<CommandCost, Money, TileIndex> CmdTerraformLand(DoCommandFlag flags, 
 			bool indirectly_cleared = coa != nullptr && coa->first_tile != t;
 
 			/* Check tiletype-specific things, and add extra-cost */
-			Backup<bool> old_generating_world(_generating_world, FILE_LINE);
+			Backup<bool> old_generating_world(_generating_world);
 			if (_game_mode == GM_EDITOR) old_generating_world.Change(true); // used to create green terraformed land
 			DoCommandFlag tile_flags = flags | DC_AUTO | DC_FORCE_CLEAR_TILE;
 			if (pass == 0) {

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -351,7 +351,7 @@ static constexpr NWidgetPart _nested_terraform_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _terraform_desc(__FILE__, __LINE__,
+static WindowDesc _terraform_desc(
 	WDP_MANUAL, "toolbar_landscape", 0, 0,
 	WC_SCEN_LAND_GEN, WC_NONE,
 	WDF_CONSTRUCTION,
@@ -735,7 +735,7 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 	}, TerraformToolbarEditorGlobalHotkeys};
 };
 
-static WindowDesc _scen_edit_land_gen_desc(__FILE__, __LINE__,
+static WindowDesc _scen_edit_land_gen_desc(
 	WDP_AUTO, "toolbar_landscape_scen", 0, 0,
 	WC_SCEN_LAND_GEN, WC_NONE,
 	WDF_CONSTRUCTION,

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -59,7 +59,7 @@ static void GenerateDesertArea(TileIndex end, TileIndex start)
 {
 	if (_game_mode != GM_EDITOR) return;
 
-	Backup<bool> old_generating_world(_generating_world, true, FILE_LINE);
+	Backup<bool> old_generating_world(_generating_world, true);
 
 	TileArea ta(start, end);
 	for (TileIndex tile : ta) {
@@ -507,7 +507,7 @@ static void ResetLandscapeConfirmationCallback(Window *, bool confirmed)
 	if (confirmed) {
 		/* Set generating_world to true to get instant-green grass after removing
 		 * company property. */
-		Backup<bool> old_generating_world(_generating_world, true, FILE_LINE);
+		Backup<bool> old_generating_world(_generating_world, true);
 
 		/* Delete all companies */
 		for (Company *c : Company::Iterate()) {

--- a/src/tests/test_window_desc.cpp
+++ b/src/tests/test_window_desc.cpp
@@ -50,7 +50,7 @@ TEST_CASE("WindowDesc - ini_key validity")
 	bool has_inikey = window_desc->ini_key != nullptr;
 	bool has_widget = std::any_of(window_desc->nwid_begin, window_desc->nwid_end, [](const NWidgetPart &part) { return part.type == WWT_DEFSIZEBOX || part.type == WWT_STICKYBOX; });
 
-	INFO(fmt::format("{}:{}", window_desc->file, window_desc->line));
+	INFO(fmt::format("{}:{}", window_desc->source_location.file_name(), window_desc->source_location.line()));
 	CAPTURE(has_inikey);
 	CAPTURE(has_widget);
 
@@ -78,7 +78,7 @@ TEST_CASE("WindowDesc - NWidgetParts properly closed")
 {
 	const WindowDesc *window_desc = GENERATE(from_range(std::begin(*_window_descs), std::end(*_window_descs)));
 
-	INFO(fmt::format("{}:{}", window_desc->file, window_desc->line));
+	INFO(fmt::format("{}:{}", window_desc->source_location.file_name(), window_desc->source_location.line()));
 
 	CHECK(IsNWidgetTreeClosed(window_desc->nwid_begin, window_desc->nwid_end));
 }
@@ -87,7 +87,7 @@ TEST_CASE_METHOD(WindowDescTestsFixture, "WindowDesc - NWidgetPart validity")
 {
 	const WindowDesc *window_desc = GENERATE(from_range(std::begin(*_window_descs), std::end(*_window_descs)));
 
-	INFO(fmt::format("{}:{}", window_desc->file, window_desc->line));
+	INFO(fmt::format("{}:{}", window_desc->source_location.file_name(), window_desc->source_location.line()));
 
 	NWidgetStacked *shade_select = nullptr;
 	std::unique_ptr<NWidgetBase> root = nullptr;

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -74,7 +74,7 @@ static constexpr NWidgetPart _nested_textfile_widgets[] = {
 };
 
 /** Window definition for the textfile window */
-static WindowDesc _textfile_desc(__FILE__, __LINE__,
+static WindowDesc _textfile_desc(
 	WDP_CENTER, "textfile", 630, 460,
 	WC_TEXTFILE, WC_NONE,
 	0,

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -852,7 +852,7 @@ static constexpr NWidgetPart _nested_timetable_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _timetable_desc(__FILE__, __LINE__,
+static WindowDesc _timetable_desc(
 	WDP_AUTO, "view_vehicle_timetable", 400, 130,
 	WC_VEHICLE_TIMETABLE, WC_VEHICLE_VIEW,
 	WDF_CONSTRUCTION,

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2196,7 +2196,7 @@ static constexpr NWidgetPart _nested_toolbar_normal_widgets[] = {
 	NWidgetFunction(MakeMainToolbar),
 };
 
-static WindowDesc _toolb_normal_desc(__FILE__, __LINE__,
+static WindowDesc _toolb_normal_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_MAIN_TOOLBAR, WC_NONE,
 	WDF_NO_FOCUS | WDF_NO_CLOSE,
@@ -2536,7 +2536,7 @@ static constexpr NWidgetPart _nested_toolb_scen_widgets[] = {
 	NWidgetFunction(MakeScenarioToolbar),
 };
 
-static WindowDesc _toolb_scen_desc(__FILE__, __LINE__,
+static WindowDesc _toolb_scen_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_MAIN_TOOLBAR, WC_NONE,
 	WDF_NO_FOCUS | WDF_NO_CLOSE,

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -662,7 +662,7 @@ static void TileLoop_Town(TileIndex tile)
 		}
 	}
 
-	Backup<CompanyID> cur_company(_current_company, OWNER_TOWN, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, OWNER_TOWN);
 
 	if ((hs->building_flags & BUILDING_HAS_1_TILE) &&
 			HasBit(t->flags, TOWN_IS_GROWING) &&
@@ -1821,7 +1821,7 @@ static bool GrowTown(Town *t)
 	};
 
 	/* Current "company" is a town */
-	Backup<CompanyID> cur_company(_current_company, OWNER_TOWN, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, OWNER_TOWN);
 
 	TileIndex tile = t->xy; // The tile we are working with ATM
 
@@ -2108,7 +2108,7 @@ std::tuple<CommandCost, Money, TownID> CmdFoundTown(DoCommandFlag flags, TileInd
 			return { CommandCost(EXPENSES_OTHER), cost.GetCost(), INVALID_TOWN };
 		}
 
-		Backup<bool> old_generating_world(_generating_world, true, FILE_LINE);
+		Backup<bool> old_generating_world(_generating_world, true);
 		UpdateNearestTownForRoadTiles(true);
 		Town *t;
 		if (random_location) {
@@ -2303,7 +2303,7 @@ static Town *CreateRandomTown(uint attempts, uint32_t townnameparts, TownSize si
 		 * placement is so bad it couldn't grow at all */
 		if (t->cache.population > 0) return t;
 
-		Backup<CompanyID> cur_company(_current_company, OWNER_TOWN, FILE_LINE);
+		Backup<CompanyID> cur_company(_current_company, OWNER_TOWN);
 		[[maybe_unused]] CommandCost rc = Command<CMD_DELETE_TOWN>::Do(DC_EXEC, t->index);
 		cur_company.Restore();
 		assert(rc.Succeeded());
@@ -3250,7 +3250,7 @@ static CommandCost TownActionRoadRebuild(Town *t, DoCommandFlag flags)
  */
 static bool CheckClearTile(TileIndex tile)
 {
-	Backup<CompanyID> cur_company(_current_company, OWNER_NONE, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, OWNER_NONE);
 	CommandCost r = Command<CMD_LANDSCAPE_CLEAR>::Do(DC_NONE, tile);
 	cur_company.Restore();
 	return r.Succeeded();
@@ -3322,7 +3322,7 @@ static CommandCost TownActionBuildStatue(Town *t, DoCommandFlag flags)
 	if (!CircularTileSearch(&tile, 9, SearchTileForStatue, &statue_data)) return_cmd_error(STR_ERROR_STATUE_NO_SUITABLE_PLACE);
 
 	if (flags & DC_EXEC) {
-		Backup<CompanyID> cur_company(_current_company, OWNER_NONE, FILE_LINE);
+		Backup<CompanyID> cur_company(_current_company, OWNER_NONE);
 		Command<CMD_LANDSCAPE_CLEAR>::Do(DC_EXEC, statue_data.best_position);
 		cur_company.Restore();
 		BuildObject(OBJECT_STATUE, statue_data.best_position, _current_company, t);

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1236,7 +1236,7 @@ public:
 				break;
 
 			case WID_TF_MANY_RANDOM_TOWNS: {
-				Backup<bool> old_generating_world(_generating_world, true, FILE_LINE);
+				Backup<bool> old_generating_world(_generating_world, true);
 				UpdateNearestTownForRoadTiles(true);
 				if (!GenerateTowns(this->town_layout)) {
 					ShowErrorMessage(STR_ERROR_CAN_T_GENERATE_TOWN, STR_ERROR_NO_SPACE_FOR_TOWN, WL_INFO);

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -339,7 +339,7 @@ public:
 	}
 };
 
-static WindowDesc _town_authority_desc(__FILE__, __LINE__,
+static WindowDesc _town_authority_desc(
 	WDP_AUTO, "view_town_authority", 317, 222,
 	WC_TOWN_AUTHORITY, WC_NONE,
 	0,
@@ -633,7 +633,7 @@ static constexpr NWidgetPart _nested_town_game_view_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _town_game_view_desc(__FILE__, __LINE__,
+static WindowDesc _town_game_view_desc(
 	WDP_AUTO, "view_town", 260, TownViewWindow::WID_TV_HEIGHT_NORMAL,
 	WC_TOWN_VIEW, WC_NONE,
 	0,
@@ -664,7 +664,7 @@ static constexpr NWidgetPart _nested_town_editor_view_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _town_editor_view_desc(__FILE__, __LINE__,
+static WindowDesc _town_editor_view_desc(
 	WDP_AUTO, "view_town_scen", 260, TownViewWindow::WID_TV_HEIGHT_NORMAL,
 	WC_TOWN_VIEW, WC_NONE,
 	0,
@@ -1060,7 +1060,7 @@ GUITownList::SortFunction * const TownDirectoryWindow::sorter_funcs[] = {
 	&TownRatingSorter,
 };
 
-static WindowDesc _town_directory_desc(__FILE__, __LINE__,
+static WindowDesc _town_directory_desc(
 	WDP_AUTO, "list_towns", 208, 202,
 	WC_TOWN_DIRECTORY, WC_NONE,
 	0,
@@ -1294,7 +1294,7 @@ public:
 	}
 };
 
-static WindowDesc _found_town_desc(__FILE__, __LINE__,
+static WindowDesc _found_town_desc(
 	WDP_AUTO, "build_town", 160, 162,
 	WC_FOUND_TOWN, WC_NONE,
 	WDF_CONSTRUCTION,

--- a/src/transparency_gui.cpp
+++ b/src/transparency_gui.cpp
@@ -148,7 +148,7 @@ static constexpr NWidgetPart _nested_transparency_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _transparency_desc(__FILE__, __LINE__,
+static WindowDesc _transparency_desc(
 	WDP_MANUAL, "toolbar_transparency", 0, 0,
 	WC_TRANSPARENCY_TOOLBAR, WC_NONE,
 	0,

--- a/src/tree_gui.cpp
+++ b/src/tree_gui.cpp
@@ -313,7 +313,7 @@ static constexpr NWidgetPart _nested_build_trees_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _build_trees_desc(__FILE__, __LINE__,
+static WindowDesc _build_trees_desc(
 	WDP_AUTO, "build_tree", 0, 0,
 	WC_BUILD_TREES, WC_NONE,
 	WDF_CONSTRUCTION,

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1065,7 +1065,7 @@ void CallVehicleTicks()
 		}
 	}
 
-	Backup<CompanyID> cur_company(_current_company, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company);
 	for (auto &it : _vehicles_to_autoreplace) {
 		Vehicle *v = it.first;
 		/* Autoreplace needs the current company set as the vehicle owner */
@@ -1618,7 +1618,7 @@ void VehicleEnterDepot(Vehicle *v)
 		}
 
 		if (v->current_order.IsRefit()) {
-			Backup<CompanyID> cur_company(_current_company, v->owner, FILE_LINE);
+			Backup<CompanyID> cur_company(_current_company, v->owner);
 			CommandCost cost = std::get<0>(Command<CMD_REFIT_VEHICLE>::Do(DC_EXEC, v->index, v->current_order.GetRefitCargo(), 0xFF, false, false, 0));
 			cur_company.Restore();
 

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1271,7 +1271,7 @@ static constexpr NWidgetPart _nested_vehicle_refit_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _vehicle_refit_desc(__FILE__, __LINE__,
+static WindowDesc _vehicle_refit_desc(
 	WDP_AUTO, "view_vehicle_refit", 240, 174,
 	WC_VEHICLE_REFIT, WC_VEHICLE_VIEW,
 	WDF_CONSTRUCTION,
@@ -2200,14 +2200,14 @@ public:
 	}
 };
 
-static WindowDesc _vehicle_list_other_desc(__FILE__, __LINE__,
+static WindowDesc _vehicle_list_other_desc(
 	WDP_AUTO, "list_vehicles", 260, 246,
 	WC_INVALID, WC_NONE,
 	0,
 	std::begin(_nested_vehicle_list), std::end(_nested_vehicle_list)
 );
 
-static WindowDesc _vehicle_list_train_desc(__FILE__, __LINE__,
+static WindowDesc _vehicle_list_train_desc(
 	WDP_AUTO, "list_vehicles_train", 325, 246,
 	WC_TRAINS_LIST, WC_NONE,
 	0,
@@ -2766,7 +2766,7 @@ struct VehicleDetailsWindow : Window {
 };
 
 /** Vehicle details window descriptor. */
-static WindowDesc _train_vehicle_details_desc(__FILE__, __LINE__,
+static WindowDesc _train_vehicle_details_desc(
 	WDP_AUTO, "view_vehicle_details_train", 405, 178,
 	WC_VEHICLE_DETAILS, WC_VEHICLE_VIEW,
 	0,
@@ -2774,7 +2774,7 @@ static WindowDesc _train_vehicle_details_desc(__FILE__, __LINE__,
 );
 
 /** Vehicle details window descriptor for other vehicles than a train. */
-static WindowDesc _nontrain_vehicle_details_desc(__FILE__, __LINE__,
+static WindowDesc _nontrain_vehicle_details_desc(
 	WDP_AUTO, "view_vehicle_details", 405, 113,
 	WC_VEHICLE_DETAILS, WC_VEHICLE_VIEW,
 	0,
@@ -3373,7 +3373,7 @@ public:
 };
 
 /** Vehicle view window descriptor for all vehicles but trains. */
-static WindowDesc _vehicle_view_desc(__FILE__, __LINE__,
+static WindowDesc _vehicle_view_desc(
 	WDP_AUTO, "view_vehicle", 250, 116,
 	WC_VEHICLE_VIEW, WC_NONE,
 	0,
@@ -3385,7 +3385,7 @@ static WindowDesc _vehicle_view_desc(__FILE__, __LINE__,
  * Vehicle view window descriptor for trains. Only minimum_height and
  *  default_height are different for train view.
  */
-static WindowDesc _train_view_desc(__FILE__, __LINE__,
+static WindowDesc _train_view_desc(
 	WDP_AUTO, "view_vehicle_train", 250, 134,
 	WC_VEHICLE_VIEW, WC_NONE,
 	0,

--- a/src/viewport_gui.cpp
+++ b/src/viewport_gui.cpp
@@ -142,7 +142,7 @@ public:
 	}
 };
 
-static WindowDesc _extra_viewport_desc(__FILE__, __LINE__,
+static WindowDesc _extra_viewport_desc(
 	WDP_AUTO, "extra_viewport", 300, 268,
 	WC_EXTRA_VIEWPORT, WC_NONE,
 	0,

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -1120,7 +1120,7 @@ void DoFloodTile(TileIndex target)
 
 	bool flooded = false; // Will be set to true if something is changed.
 
-	Backup<CompanyID> cur_company(_current_company, OWNER_WATER, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, OWNER_WATER);
 
 	Slope tileh = GetTileSlope(target);
 	if (tileh != SLOPE_FLAT) {
@@ -1183,7 +1183,7 @@ void DoFloodTile(TileIndex target)
  */
 static void DoDryUp(TileIndex tile)
 {
-	Backup<CompanyID> cur_company(_current_company, OWNER_WATER, FILE_LINE);
+	Backup<CompanyID> cur_company(_current_company, OWNER_WATER);
 
 	switch (GetTileType(tile)) {
 		case MP_RAILWAY:

--- a/src/waypoint_gui.cpp
+++ b/src/waypoint_gui.cpp
@@ -183,7 +183,7 @@ static constexpr NWidgetPart _nested_waypoint_view_widgets[] = {
 };
 
 /** The description of the waypoint view. */
-static WindowDesc _waypoint_view_desc(__FILE__, __LINE__,
+static WindowDesc _waypoint_view_desc(
 	WDP_AUTO, "view_waypoint", 260, 118,
 	WC_WAYPOINT_VIEW, WC_NONE,
 	0,

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -31,7 +31,7 @@ static constexpr NWidgetPart _nested_dropdown_menu_widgets[] = {
 	EndContainer(),
 };
 
-static WindowDesc _dropdown_desc(__FILE__, __LINE__,
+static WindowDesc _dropdown_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_DROPDOWN_MENU, WC_NONE,
 	WDF_NO_FOCUS,

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -102,11 +102,11 @@ std::vector<WindowDesc*> *_window_descs = nullptr;
 std::string _windows_file;
 
 /** Window description constructor. */
-WindowDesc::WindowDesc(const char * const file, const int line, WindowPosition def_pos, const char *ini_key, int16_t def_width_trad, int16_t def_height_trad,
+WindowDesc::WindowDesc(WindowPosition def_pos, const char *ini_key, int16_t def_width_trad, int16_t def_height_trad,
 			WindowClass window_class, WindowClass parent_class, uint32_t flags,
-			const NWidgetPart *nwid_begin, const NWidgetPart *nwid_end, HotkeyList *hotkeys) :
-	file(file),
-	line(line),
+			const NWidgetPart *nwid_begin, const NWidgetPart *nwid_end, HotkeyList *hotkeys,
+			const std::source_location location) :
+	source_location(location),
 	default_pos(def_pos),
 	cls(window_class),
 	parent_cls(parent_class),

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -152,14 +152,14 @@ struct HotkeyList;
  */
 struct WindowDesc : ZeroedMemoryAllocator {
 
-	WindowDesc(const char * const file, const int line, WindowPosition default_pos, const char *ini_key, int16_t def_width_trad, int16_t def_height_trad,
+	WindowDesc(WindowPosition default_pos, const char *ini_key, int16_t def_width_trad, int16_t def_height_trad,
 			WindowClass window_class, WindowClass parent_class, uint32_t flags,
-			const NWidgetPart *nwid_begin, const NWidgetPart *nwid_end, HotkeyList *hotkeys = nullptr);
+			const NWidgetPart *nwid_begin, const NWidgetPart *nwid_end, HotkeyList *hotkeys = nullptr,
+			const std::source_location location = std::source_location::current());
 
 	~WindowDesc();
 
-	const char * const file; ///< Source file of this definition
-	const int line; ///< Source line of this definition
+	const std::source_location source_location; ///< Source location of this definition
 	WindowPosition default_pos;    ///< Preferred position of the window. @see WindowPosition()
 	WindowClass cls;               ///< Class of the window, @see WindowClass.
 	WindowClass parent_cls;        ///< Class of the parent window. @see WindowClass
@@ -184,10 +184,11 @@ private:
 	int16_t default_height_trad;     ///< Preferred initial height of the window (pixels at 1x zoom).
 
 	/**
-	 * Dummy private copy constructor to prevent compilers from
+	 * Delete copy constructor to prevent compilers from
 	 * copying the structure, which fails due to _window_descs.
 	 */
-	WindowDesc(const WindowDesc &other);
+	WindowDesc(const WindowDesc &) = delete;
+	WindowDesc& operator=(const WindowDesc &) = delete;
 };
 
 /**


### PR DESCRIPTION
## Motivation / Problem

There is quite a bit of `__FILE__, __LINE__` (or `FILE_LINE`) spread throughout the code, for which C++20 has a nice solution using `std::source_location` and a default argument.


## Description

Replace C-style method with C++-style method for `Backup`, `WindowDesc`, `NOT_REACHED` and `AssertionFailedError`.


## Limitations

There's also `TILE_ADD` and all of `Random`, but those are more involved. So they are left out, so this can remain a relatively simple change.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
