### PR TITLE
Codechange: replace ROR/ROL with std::rotr/rotl

### DIFF
--- a/src/3rdparty/md5/md5.cpp
+++ b/src/3rdparty/md5/md5.cpp
@@ -130,14 +130,14 @@ static inline void Md5Set1(const uint32_t *X, uint32_t *a, const uint32_t *b, co
 {
 	uint32_t t = (*b & *c) | (~*b & *d);
 	t += *a + X[k] + Ti;
-	*a = ROL(t, s) + *b;
+	*a = std::rotl(t, s) + *b;
 }
 
 static inline void Md5Set2(const uint32_t *X, uint32_t *a, const uint32_t *b, const uint32_t *c, const uint32_t *d, const uint8_t k, const uint8_t s, const uint32_t Ti)
 {
 	uint32_t t = (*b & *d) | (*c & ~*d);
 	t += *a + X[k] + Ti;
-	*a = ROL(t, s) + *b;
+	*a = std::rotl(t, s) + *b;
 }
 
 
@@ -145,14 +145,14 @@ static inline void Md5Set3(const uint32_t *X, uint32_t *a, const uint32_t *b, co
 {
 	uint32_t t = *b ^ *c ^ *d;
 	t += *a + X[k] + Ti;
-	*a = ROL(t, s) + *b;
+	*a = std::rotl(t, s) + *b;
 }
 
 static inline void Md5Set4(const uint32_t *X, uint32_t *a, const uint32_t *b, const uint32_t *c, const uint32_t *d, const uint8_t k, const uint8_t s, const uint32_t Ti)
 {
 	uint32_t t = *c ^ (*b | ~*d);
 	t += *a + X[k] + Ti;
-	*a = ROL(t, s) + *b;
+	*a = std::rotl(t, s) + *b;
 }
 
 Md5::Md5()

--- a/src/core/bitmath_func.hpp
+++ b/src/core/bitmath_func.hpp
@@ -288,38 +288,6 @@ inline bool HasAtMostOneBit(T value)
 	return (value & (value - 1)) == 0;
 }
 
-/**
- * ROtate \a x Left by \a n
- *
- * @note Assumes a byte has 8 bits
- * @param x The value which we want to rotate
- * @param n The number how many we want to rotate
- * @pre n < sizeof(T) * 8
- * @return A bit rotated number
- */
-template <typename T>
-inline T ROL(const T x, const uint8_t n)
-{
-	if (n == 0) return x;
-	return (T)(x << n | x >> (sizeof(x) * 8 - n));
-}
-
-/**
- * ROtate \a x Right by \a n
- *
- * @note Assumes a byte has 8 bits
- * @param x The value which we want to rotate
- * @param n The number how many we want to rotate
- * @pre n < sizeof(T) * 8
- * @return A bit rotated number
- */
-template <typename T>
-inline T ROR(const T x, const uint8_t n)
-{
-	if (n == 0) return x;
-	return (T)(x >> n | x << (sizeof(x) * 8 - n));
-}
-
  /**
  * Iterable ensemble of each set bit in a value.
  * @tparam Tbitpos Type of the position variable.

--- a/src/core/random_func.cpp
+++ b/src/core/random_func.cpp
@@ -33,8 +33,8 @@ uint32_t Randomizer::Next()
 	const uint32_t s = this->state[0];
 	const uint32_t t = this->state[1];
 
-	this->state[0] = s + ROR(t ^ 0x1234567F, 7) + 1;
-	return this->state[1] = ROR(s, 3) - 1;
+	this->state[0] = s + std::rotr(t ^ 0x1234567F, 7) + 1;
+	return this->state[1] = std::rotr(s, 3) - 1;
 }
 
 /**

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -169,7 +169,7 @@ static U EvalAdjustT(const DeterministicSpriteGroupAdjust &adjust, ScopeResolver
 		case DSGA_OP_STO:  _temp_store.StoreValue((U)value, (S)last_value); return last_value;
 		case DSGA_OP_RST:  return value;
 		case DSGA_OP_STOP: scope->StorePSA((U)value, (S)last_value); return last_value;
-		case DSGA_OP_ROR:  return ROR<uint32_t>((U)last_value, (U)value & 0x1F); // mask 'value' to 5 bits, which should behave the same on all architectures.
+		case DSGA_OP_ROR:  return std::rotr<uint32_t>((U)last_value, (U)value & 0x1F); // mask 'value' to 5 bits, which should behave the same on all architectures.
 		case DSGA_OP_SCMP: return ((S)last_value == (S)value) ? 1 : ((S)last_value < (S)value ? 0 : 2);
 		case DSGA_OP_UCMP: return ((U)last_value == (U)value) ? 1 : ((U)last_value < (U)value ? 0 : 2);
 		case DSGA_OP_SHL:  return (uint32_t)(U)last_value << ((U)value & 0x1F); // Same behaviour as in ParamSet, mask 'value' to 5 bits, which should behave the same on all architectures.

--- a/src/saveload/oldloader.cpp
+++ b/src/saveload/oldloader.cpp
@@ -212,7 +212,7 @@ static bool VerifyOldNameChecksum(char *title, uint len)
 	uint16_t sum = 0;
 	for (uint i = 0; i < len - HEADER_CHECKSUM_SIZE; i++) {
 		sum += title[i];
-		sum = ROL(sum, 1);
+		sum = std::rotl(sum, 1);
 	}
 
 	sum ^= 0xAAAA; // computed checksum

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -48,6 +48,7 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cassert>
 #include <cctype>
 #include <cerrno>

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -115,7 +115,7 @@ LangString *StringData::Find(const std::string_view s)
 uint StringData::VersionHashStr(uint hash, const char *s) const
 {
 	for (; *s != '\0'; s++) {
-		hash = ROL(hash, 3) ^ *s;
+		hash = std::rotl(hash, 3) ^ *s;
 		hash = (hash & 1 ? hash >> 1 ^ 0xDEADBEEF : hash >> 1);
 	}
 	return hash;


### PR DESCRIPTION
## Motivation / Problem

Why implement something ourselves when C++20 provides it?


## Description

Replace `ROR` with `std::rotr` and `ROL` with `std::rotl`.


## Limitations

None?


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
