### PR TITLE
Fix #11801, 51f1e93: CalcClosestTownFromTile needs the kd-tree to be valid

### DIFF
--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -499,7 +499,12 @@ static Town *RemapTown(TileIndex fallback)
 {
 	/* In some cases depots, industries and stations could refer to a missing town. */
 	Town *t = Town::GetIfValid(RemapTownIndex(_old_town_index));
-	if (t == nullptr) t = CalcClosestTownFromTile(fallback);
+	if (t == nullptr) {
+		/* In case the town that was refered to does not exist, find the closest.
+		 * However, this needs the kd-tree to be present. */
+		RebuildTownKdtree();
+		t = CalcClosestTownFromTile(fallback);
+	}
 	return t;
 }
 


### PR DESCRIPTION
## Motivation / Problem

Fixes #11801.


## Description

Initialize the kd-tree before `CalcClosestTownFromTile`, otherwise it asserts because its empty.
Before 51f1e93 it used `Town::GetRandom`, but since the tile is known the closest is arguably the better solution.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
