### PR TITLE
Fix: [HarfBuzz] make HarfBuzz use the same glyphs as we render

### DIFF
--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -157,6 +157,8 @@ ICUParagraphLayout::ICUVisualRun::ICUVisualRun(const ICURun &run, int x) :
 void ICURun::Shape(UChar *buff, size_t buff_length)
 {
 	auto hbfont = hb_ft_font_create_referenced(*(static_cast<const FT_Face *>(font->fc->GetOSHandle())));
+	/* Match the flags with how we render the glyphs. */
+	hb_ft_font_set_load_flags(hbfont, GetFontAAState(this->font->fc->GetSize()) ? FT_LOAD_TARGET_NORMAL : FT_LOAD_TARGET_MONO);
 
 	/* ICU buffer is in UTF-16. */
 	auto hbbuf = hb_buffer_create();

--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -26,7 +26,7 @@
 
 #include "safeguards.h"
 
-/** harfbuzz doesn't use floats, so we need a value to scale position with to get sub-pixel precision. */
+/** HarfBuzz FreeType integration sets the font scaling, which is always in 1/64th of a pixel. */
 constexpr float FONT_SCALE = 64.0;
 
 /**
@@ -157,7 +157,6 @@ ICUParagraphLayout::ICUVisualRun::ICUVisualRun(const ICURun &run, int x) :
 void ICURun::Shape(UChar *buff, size_t buff_length)
 {
 	auto hbfont = hb_ft_font_create_referenced(*(static_cast<const FT_Face *>(font->fc->GetOSHandle())));
-	hb_font_set_scale(hbfont, this->font->fc->GetFontSize() * FONT_SCALE, this->font->fc->GetFontSize() * FONT_SCALE);
 
 	/* ICU buffer is in UTF-16. */
 	auto hbbuf = hb_buffer_create();


### PR DESCRIPTION
## Motivation / Problem

HarfBuzz loads FreeType font glyphs on its own. This is done with loadflags that are initialized by HarfBuzz. Normally this would be fine, but we also have our own loadflags. And they do not match.

For example, with AA, we tell FreeType we want a monochrome experience. But we never told HarfBuzz. In result, HarfBuzz uses other "advance" values as the font really is, making a total mess of where we render glyphs.

Fixes #11765.

## Description

The above is fixed in the last commit. Also found out that us setting the scale isn't all that useful, and HarfBuzz already takes care of that.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
