### PR TITLE
Change: Make street lights transparent with houses

### DIFF
--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1665,8 +1665,18 @@ static void DrawRoadBits(TileInfo *ti)
 	/* If there are no road bits, return, as there is nothing left to do */
 	if (HasAtMostOneBit(road)) return;
 
+	/* Do not draw details when invisible. */
 	if (roadside == ROADSIDE_TREES && IsInvisibilitySet(TO_TREES)) return;
-	bool is_transparent = roadside == ROADSIDE_TREES && IsTransparencySet(TO_TREES);
+	if (roadside == ROADSIDE_STREET_LIGHTS && IsInvisibilitySet(TO_HOUSES)) return;
+
+	/* Check whether details should be transparent. */
+	bool is_transparent = false;
+	if (roadside == ROADSIDE_TREES && IsTransparencySet(TO_TREES)) {
+		is_transparent = true;
+	}
+	if (roadside == ROADSIDE_STREET_LIGHTS && IsTransparencySet(TO_HOUSES)) {
+		is_transparent = true;
+	}
 
 	/* Draw extra details. */
 	for (const DrawRoadTileStruct *drts = _road_display_table[roadside][road | tram]; drts->image != 0; drts++) {


### PR DESCRIPTION
Make street lights transparent/invisible with the town buildings transparency/invisibility setting.

## Motivation / Problem

In towns, the only object that cannot be made transparent/invisible are the street lights. This isn't really an issue at 1x zoom, but becomes more prominent with 4x, with NewGRFs that replace the street lights with larger sprites, the big street lights in Toyland, etc.

![openttd_transparent_1](https://github.com/OpenTTD/OpenTTD/assets/2762690/a460f744-2560-45b1-a736-52c2b6f15dfd)
![openttd_transparent_2](https://github.com/OpenTTD/OpenTTD/assets/2762690/13f37b14-9ffc-401d-9254-8e5aa3ebb61e)

## Description

Fixed by making street lights transparent or invisible along with town houses.

## Limitations

It wasn't obvious with which transparency group to include street lights. There are two existing road decorations; town trees go with trees, and tram track catenary goes with catenaries. Neither really make sense for street lights, so I put them with houses.

## Checklist for review

~~Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)~~