### PR TITLE
Codechange: use std::popcount instead of hand written loop

### DIFF
--- a/src/core/bitmath_func.hpp
+++ b/src/core/bitmath_func.hpp
@@ -248,20 +248,13 @@ inline T KillFirstBit(T value)
  * @return the number of bits.
  */
 template <typename T>
-inline uint CountBits(T value)
+constexpr uint CountBits(T value)
 {
-	uint num;
-
-	/* This loop is only called once for every bit set by clearing the lowest
-	 * bit in each loop. The number of bits is therefore equal to the number of
-	 * times the loop was called. It was found at the following website:
-	 * http://graphics.stanford.edu/~seander/bithacks.html */
-
-	for (num = 0; value != 0; num++) {
-		value &= (T)(value - 1);
+	if constexpr (std::is_enum_v<T>) {
+		return std::popcount<std::underlying_type_t<T>>(value);
+	} else {
+		return std::popcount(value);
 	}
-
-	return num;
 }
 
 /**

--- a/src/script/api/script_goal.cpp
+++ b/src/script/api/script_goal.cpp
@@ -126,7 +126,7 @@
 	std::string text = question->GetEncodedText();
 	EnforcePreconditionEncodedText(false, text);
 	uint min_buttons = (type == QT_QUESTION ? 1 : 0);
-	EnforcePrecondition(false, CountBits(buttons) >= min_buttons && CountBits(buttons) <= 3);
+	EnforcePrecondition(false, CountBits<uint64_t>(buttons) >= min_buttons && CountBits<uint64_t>(buttons) <= 3);
 	EnforcePrecondition(false, buttons >= 0 && buttons < (1 << ::GOAL_QUESTION_BUTTON_COUNT));
 	EnforcePrecondition(false, (int)type < ::GQT_END);
 	EnforcePrecondition(false, uniqueid >= 0 && uniqueid <= UINT16_MAX);


### PR DESCRIPTION
## Motivation / Problem

C++20 has `std::popcount` that does basically what `CountBits`'s loop does.
It seems to be a lot faster than our loop.


## Description

Replace the content of `CountBits` with `std::popcount`.
`std::popcount` is a bit more picky about the types it allows; it only allows unsigned integrals, so for some cases it's needed to pass the template type.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
