### PR TITLE
Cleanup: alignment related endian code

### DIFF
--- a/src/core/endian_func.hpp
+++ b/src/core/endian_func.hpp
@@ -38,18 +38,4 @@
 #	define TO_LE32X(x)  (x)
 #endif /* TTD_ENDIAN == TTD_BIG_ENDIAN */
 
-inline uint16_t ReadLE16Aligned(const void *x)
-{
-	return FROM_LE16(*(const uint16_t*)x);
-}
-
-inline uint16_t ReadLE16Unaligned(const void *x)
-{
-#if OTTD_ALIGNMENT == 1
-	return ((const byte*)x)[0] | ((const byte*)x)[1] << 8;
-#else
-	return FROM_LE16(*(const uint16_t*)x);
-#endif /* OTTD_ALIGNMENT == 1 */
-}
-
 #endif /* ENDIAN_FUNC_HPP */

--- a/src/core/endian_type.hpp
+++ b/src/core/endian_type.hpp
@@ -10,14 +10,6 @@
 #ifndef ENDIAN_TYPE_HPP
 #define ENDIAN_TYPE_HPP
 
-#if defined(ARM) || defined(__arm__) || defined(__alpha__)
-	/** The architecture requires aligned access. */
-#	define OTTD_ALIGNMENT 1
-#else
-	/** The architecture does not require aligned access. */
-#	define OTTD_ALIGNMENT 0
-#endif
-
 /** Little endian builds use this for TTD_ENDIAN. */
 #define TTD_LITTLE_ENDIAN 0
 /** Big endian builds use this for TTD_ENDIAN. */

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1840,17 +1840,11 @@ bool ReadLanguagePack(const LanguageMetadata *lang)
 		return false;
 	}
 
-#if TTD_ENDIAN == TTD_BIG_ENDIAN
-	for (uint i = 0; i < TEXT_TAB_END; i++) {
-		lang_pack->offsets[i] = ReadLE16Aligned(&lang_pack->offsets[i]);
-	}
-#endif /* TTD_ENDIAN == TTD_BIG_ENDIAN */
-
 	std::array<uint, TEXT_TAB_END> tab_start, tab_num;
 
 	uint count = 0;
 	for (uint i = 0; i < TEXT_TAB_END; i++) {
-		uint16_t num = lang_pack->offsets[i];
+		uint16_t num = FROM_LE16(lang_pack->offsets[i]);
 		if (num > TAB_SIZE) return false;
 
 		tab_start[i] = count;


### PR DESCRIPTION
## Motivation / Problem

There is code worrying specially about the alignment of data. That feels worrisome.
Good news, it's only two functions and a define, and only one functions is actually used (just once).


## Description

Replace the single used of `ReadLE16Aligned` with just `FROM_LE16`. With the current user the function makes no sense at all, as it's essentially getting the pointer of a value, casting it to void, then casting it back to its original type, to dereference it and pass that through `FROM_LE16`. In other words, just replace it with `FROM_LE16` and do not get the pointer.

Furthermore this code updated the offsets table in a loop (guarded by `#ifdef`s), after which it would loop over the same table to get the offset and do some work. Since this is the only place where the offset is accessed, we can just `FROM_LE16` the data there. Simple and effective.

Finally remove `ReadLE16Aligned`, `ReadLE16Unaligned` and `OTTD_ALIGNMENT`.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
