### PR TITLE
Codechange: Use vector of points instead of interlaced x/y values for layouter positions.

### DIFF
--- a/src/core/geometry_type.hpp
+++ b/src/core/geometry_type.hpp
@@ -21,6 +21,9 @@
 struct Point {
 	int x;
 	int y;
+
+	constexpr Point() : x(0), y(0) {}
+	constexpr Point(int x, int y) : x(x), y(y) {}
 };
 
 /** Dimensions (a width and height) of a rectangle in 2D */

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -599,9 +599,9 @@ static int DrawLayoutLine(const ParagraphLayouter::Line &line, int y, int left, 
 			/* Not a valid glyph (empty) */
 			if (glyph == 0xFFFF) continue;
 
-			int begin_x = (int)positions[i * 2]     + left - offset_x;
-			int end_x   = (int)positions[i * 2 + 2] + left - offset_x  - 1;
-			int top     = (int)positions[i * 2 + 1] + y;
+			int begin_x = positions[i].x     + left - offset_x;
+			int end_x   = positions[i + 1].x + left - offset_x  - 1;
+			int top     = positions[i].y + y;
 
 			/* Truncated away. */
 			if (truncation && (begin_x < min_x || end_x > max_x)) continue;

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -260,8 +260,7 @@ Point Layouter::GetCharPosition(std::string_view::const_iterator ch) const
 		for (int i = 0; i < run.GetGlyphCount(); i++) {
 			/* Matching glyph? Return position. */
 			if ((size_t)charmap[i] == index) {
-				Point p = { (int)positions[i * 2], (int)positions[i * 2 + 1] };
-				return p;
+				return positions[i];
 			}
 		}
 	}
@@ -291,8 +290,8 @@ ptrdiff_t Layouter::GetCharAtPosition(int x, size_t line_index) const
 			/* Not a valid glyph (empty). */
 			if (glyphs[i] == 0xFFFF) continue;
 
-			int begin_x = (int)positions[i * 2];
-			int end_x   = (int)positions[i * 2 + 2];
+			int begin_x = positions[i].x;
+			int end_x   = positions[i + 1].x;
 
 			if (IsInsideMM(x, begin_x, end_x)) {
 				/* Found our glyph, now convert to UTF-8 string index. */

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -97,7 +97,7 @@ public:
 		virtual const Font *GetFont() const = 0;
 		virtual int GetGlyphCount() const = 0;
 		virtual const std::vector<GlyphID> &GetGlyphs() const = 0;
-		virtual const std::vector<float> &GetPositions() const = 0;
+		virtual const std::vector<Point> &GetPositions() const = 0;
 		virtual int GetLeading() const = 0;
 		virtual const std::vector<int> &GetGlyphToCharMap() const = 0;
 	};

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -96,10 +96,10 @@ public:
 		virtual ~VisualRun() = default;
 		virtual const Font *GetFont() const = 0;
 		virtual int GetGlyphCount() const = 0;
-		virtual const GlyphID *GetGlyphs() const = 0;
-		virtual const float *GetPositions() const = 0;
+		virtual const std::vector<GlyphID> &GetGlyphs() const = 0;
+		virtual const std::vector<float> &GetPositions() const = 0;
 		virtual int GetLeading() const = 0;
-		virtual const int *GetGlyphToCharMap() const = 0;
+		virtual const std::vector<int> &GetGlyphToCharMap() const = 0;
 	};
 
 	/** A single line worth of VisualRuns. */

--- a/src/gfx_layout_fallback.cpp
+++ b/src/gfx_layout_fallback.cpp
@@ -49,10 +49,10 @@ public:
 		FallbackVisualRun(Font *font, const char32_t *chars, int glyph_count, int char_offset, int x);
 		const Font *GetFont() const override { return this->font; }
 		int GetGlyphCount() const override { return static_cast<int>(this->glyphs.size()); }
-		const GlyphID *GetGlyphs() const override { return this->glyphs.data(); }
-		const float *GetPositions() const override { return this->positions.data(); }
+		const std::vector<GlyphID> &GetGlyphs() const override { return this->glyphs; }
+		const std::vector<float> &GetPositions() const override { return this->positions; }
 		int GetLeading() const override { return this->GetFont()->fc->GetHeight(); }
-		const int *GetGlyphToCharMap() const override { return this->glyph_to_char.data(); }
+		const std::vector<int> &GetGlyphToCharMap() const override { return this->glyph_to_char; }
 	};
 
 	/** A single line worth of VisualRuns. */

--- a/src/gfx_layout_fallback.cpp
+++ b/src/gfx_layout_fallback.cpp
@@ -40,7 +40,7 @@ public:
 	/** Visual run contains data about the bit of text with the same font. */
 	class FallbackVisualRun : public ParagraphLayouter::VisualRun {
 		std::vector<GlyphID> glyphs; ///< The glyphs we're drawing.
-		std::vector<float> positions; ///< The positions of the glyphs.
+		std::vector<Point> positions; ///< The positions of the glyphs.
 		std::vector<int> glyph_to_char; ///< The char index of the glyphs.
 
 		Font *font;       ///< The font used to layout these.
@@ -50,7 +50,7 @@ public:
 		const Font *GetFont() const override { return this->font; }
 		int GetGlyphCount() const override { return static_cast<int>(this->glyphs.size()); }
 		const std::vector<GlyphID> &GetGlyphs() const override { return this->glyphs; }
-		const std::vector<float> &GetPositions() const override { return this->positions; }
+		const std::vector<Point> &GetPositions() const override { return this->positions; }
 		int GetLeading() const override { return this->GetFont()->fc->GetHeight(); }
 		const std::vector<int> &GetGlyphToCharMap() const override { return this->glyph_to_char; }
 	};
@@ -118,21 +118,23 @@ FallbackParagraphLayout::FallbackVisualRun::FallbackVisualRun(Font *font, const 
 	this->glyph_to_char.reserve(char_count);
 
 	/* Positions contains the location of the begin of each of the glyphs, and the end of the last one. */
-	this->positions.resize(char_count * 2 + 2);
-	this->positions[0] = x;
+	this->positions.reserve(char_count + 1);
 
+	int advance = x;
 	for (int i = 0; i < char_count; i++) {
 		const GlyphID &glyph_id = this->glyphs.emplace_back(font->fc->MapCharToGlyph(chars[i]));
 		if (isbuiltin) {
-			this->positions[2 * i + 1] = font->fc->GetAscender(); // Apply sprite font's ascender.
+			this->positions.emplace_back(advance, font->fc->GetAscender()); // Apply sprite font's ascender.
 		} else if (chars[i] >= SCC_SPRITE_START && chars[i] <= SCC_SPRITE_END) {
-			this->positions[2 * i + 1] = (font->fc->GetHeight() - ScaleSpriteTrad(FontCache::GetDefaultFontHeight(font->fc->GetSize()))) / 2; // Align sprite font to centre
+			this->positions.emplace_back(advance, (font->fc->GetHeight() - ScaleSpriteTrad(FontCache::GetDefaultFontHeight(font->fc->GetSize()))) / 2); // Align sprite font to centre
 		} else {
-			this->positions[2 * i + 1] = 0;                       // No ascender adjustment.
+			this->positions.emplace_back(advance, 0); // No ascender adjustment.
 		}
-		this->positions[2 * i + 2] = this->positions[2 * i] + font->fc->GetGlyphWidth(glyph_id);
+		advance += font->fc->GetGlyphWidth(glyph_id);
 		this->glyph_to_char.push_back(char_offset + i);
 	}
+	/* End-of-run position. */
+	this->positions.emplace_back(advance, 0);
 }
 
 /**
@@ -163,7 +165,7 @@ int FallbackParagraphLayout::FallbackLine::GetWidth() const
 	 * the last run gives us the end of the line and thus the width.
 	 */
 	const auto &run = this->GetVisualRun(this->CountRuns() - 1);
-	return (int)run.GetPositions()[run.GetGlyphCount() * 2];
+	return run.GetPositions().back().x;
 }
 
 /**

--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -71,9 +71,9 @@ public:
 	public:
 		ICUVisualRun(const ICURun &run, int x);
 
-		const GlyphID *GetGlyphs() const override { return this->glyphs.data(); }
-		const float *GetPositions() const override { return this->positions.data(); }
-		const int *GetGlyphToCharMap() const override { return this->glyph_to_char.data(); }
+		const std::vector<GlyphID> &GetGlyphs() const override { return this->glyphs; }
+		const std::vector<float> &GetPositions() const override { return this->positions; }
+		const std::vector<int> &GetGlyphToCharMap() const override { return this->glyph_to_char; }
 
 		const Font *GetFont() const override { return this->font; }
 		int GetLeading() const override { return this->font->fc->GetHeight(); }

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -81,9 +81,9 @@ public:
 		CoreTextVisualRun(CTRunRef run, Font *font, const CoreTextParagraphLayoutFactory::CharType *buff);
 		CoreTextVisualRun(CoreTextVisualRun &&other) = default;
 
-		const GlyphID *GetGlyphs() const override { return &this->glyphs[0]; }
-		const float *GetPositions() const override { return &this->positions[0]; }
-		const int *GetGlyphToCharMap() const override { return &this->glyph_to_char[0]; }
+		const std::vector<GlyphID> &GetGlyphs() const override { return this->glyphs; }
+		const std::vector<float> &GetPositions() const override { return this->positions; }
+		const std::vector<int> &GetGlyphToCharMap() const override { return this->glyph_to_char; }
 
 		const Font *GetFont() const override { return this->font;  }
 		int GetLeading() const override { return this->font->fc->GetHeight(); }

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -74,7 +74,7 @@ public:
 	class UniscribeVisualRun : public ParagraphLayouter::VisualRun {
 	private:
 		std::vector<GlyphID> glyphs;
-		std::vector<float> positions;
+		std::vector<Point> positions;
 		std::vector<WORD> char_to_glyph;
 
 		int start_pos;
@@ -89,7 +89,7 @@ public:
 		UniscribeVisualRun(UniscribeVisualRun &&other) noexcept;
 
 		const std::vector<GlyphID> &GetGlyphs() const override { return this->glyphs; }
-		const std::vector<float> &GetPositions() const override { return this->positions; }
+		const std::vector<Point> &GetPositions() const override { return this->positions; }
 		const std::vector<int> &GetGlyphToCharMap() const override;
 
 		const Font *GetFont() const override { return this->font;  }
@@ -474,16 +474,16 @@ int UniscribeParagraphLayout::UniscribeLine::GetWidth() const
 UniscribeParagraphLayout::UniscribeVisualRun::UniscribeVisualRun(const UniscribeRun &range, int x) : glyphs(range.ft_glyphs), char_to_glyph(range.char_to_glyph), start_pos(range.pos), total_advance(range.total_advance), font(range.font)
 {
 	this->num_glyphs = (int)glyphs.size();
-	this->positions.resize(this->num_glyphs * 2 + 2);
+	this->positions.reserve(this->num_glyphs + 1);
 
-	int advance = 0;
+	int advance = x;
 	for (int i = 0; i < this->num_glyphs; i++) {
-		this->positions[i * 2 + 0] = range.offsets[i].du + advance + x;
-		this->positions[i * 2 + 1] = range.offsets[i].dv;
+		this->positions.emplace_back(range.offsets[i].du + advance, range.offsets[i].dv);
 
 		advance += range.advances[i];
 	}
-	this->positions[this->num_glyphs * 2] = advance + x;
+	/* End-of-run position. */
+	this->positions.emplace_back(advance, 0);
 }
 
 UniscribeParagraphLayout::UniscribeVisualRun::UniscribeVisualRun(UniscribeVisualRun&& other) noexcept


### PR DESCRIPTION
## Motivation / Problem

Dealing with layouter glyph positions is confusing because it's an interlaced vector of x/y coordinates, requiring multiplications and additions to get either x or y position.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Replace the vectors of floats with vectors of Points, which stores both x & y coordinate together in a way that accessing them is much clearer.

This also uses emplace_back() to add each point in one go, instead of using array indices and multipliers everywhere.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Tested with fallback and ICU/harfbuzz layouters on Linux, needs testing with Windows and MacOS.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
