### PR TITLE
Codechange: replace LeastCommonMultiple with std::lcm

### DIFF
--- a/src/core/math_func.cpp
+++ b/src/core/math_func.cpp
@@ -13,41 +13,6 @@
 #include "../safeguards.h"
 
 /**
- * Compute least common multiple (lcm) of arguments \a a and \a b, the smallest
- * integer value that is a multiple of both \a a and \a b.
- * @param a First number.
- * @param b second number.
- * @return Least common multiple of values \a a and \a b.
- *
- * @note This function only works for non-negative values of \a a and \a b.
- */
-int LeastCommonMultiple(int a, int b)
-{
-	if (a == 0 || b == 0) return 0; // By definition.
-	if (a == 1 || a == b) return b;
-	if (b == 1) return a;
-
-	return a * b / GreatestCommonDivisor(a, b);
-}
-
-/**
- * Compute greatest common divisor (gcd) of \a a and \a b.
- * @param a First number.
- * @param b second number.
- * @return Greatest common divisor of \a a and \a b.
- */
-int GreatestCommonDivisor(int a, int b)
-{
-	while (b != 0) {
-		int t = b;
-		b = a % b;
-		a = t;
-	}
-	return a;
-
-}
-
-/**
  * Deterministic approximate division.
  * Cancels out division errors stemming from the integer nature of the division over multiple runs.
  * @param a Dividend.

--- a/src/core/math_func.hpp
+++ b/src/core/math_func.hpp
@@ -309,8 +309,6 @@ inline uint ToPercent16(uint i)
 	return i * 101 >> 16;
 }
 
-int LeastCommonMultiple(int a, int b);
-int GreatestCommonDivisor(int a, int b);
 int DivideApprox(int a, int b);
 
 /**

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1642,20 +1642,20 @@ public:
 		this->smallest_y = std::max(min_inf_height, min_acs_height + WidgetDimensions::scaled.vsep_wide + min_avs_height);
 
 		/* Filling. */
-		this->fill_x = LeastCommonMultiple(this->avs->fill_x, this->acs->fill_x);
+		this->fill_x = std::lcm(this->avs->fill_x, this->acs->fill_x);
 		if (this->inf->fill_x > 0 && (this->fill_x == 0 || this->fill_x > this->inf->fill_x)) this->fill_x = this->inf->fill_x;
 
 		this->fill_y = this->avs->fill_y;
 		if (this->acs->fill_y > 0 && (this->fill_y == 0 || this->fill_y > this->acs->fill_y)) this->fill_y = this->acs->fill_y;
-		this->fill_y = LeastCommonMultiple(this->fill_y, this->inf->fill_y);
+		this->fill_y = std::lcm(this->fill_y, this->inf->fill_y);
 
 		/* Resizing. */
-		this->resize_x = LeastCommonMultiple(this->avs->resize_x, this->acs->resize_x);
+		this->resize_x = std::lcm(this->avs->resize_x, this->acs->resize_x);
 		if (this->inf->resize_x > 0 && (this->resize_x == 0 || this->resize_x > this->inf->resize_x)) this->resize_x = this->inf->resize_x;
 
 		this->resize_y = this->avs->resize_y;
 		if (this->acs->resize_y > 0 && (this->resize_y == 0 || this->resize_y > this->acs->resize_y)) this->resize_y = this->acs->resize_y;
-		this->resize_y = LeastCommonMultiple(this->resize_y, this->inf->resize_y);
+		this->resize_y = std::lcm(this->resize_y, this->inf->resize_y);
 
 		/* Make sure the height suits the 3 column (resp. not-editable) format; the 2 column format can easily fill space between the lists */
 		this->smallest_y = ComputeMaxSize(min_acs_height, this->smallest_y + this->resize_y - 1, this->resize_y);

--- a/src/tests/math_func.cpp
+++ b/src/tests/math_func.cpp
@@ -13,41 +13,6 @@
 
 #include "../core/math_func.hpp"
 
-TEST_CASE("LeastCommonMultipleTest - Zero")
-{
-	CHECK(0 == LeastCommonMultiple(0, 0));
-	CHECK(0 == LeastCommonMultiple(0, 600));
-	CHECK(0 == LeastCommonMultiple(600, 0));
-}
-
-TEST_CASE("LeastCommonMultipleTest - FindLCM")
-{
-	CHECK(25 == LeastCommonMultiple(5, 25));
-	CHECK(25 == LeastCommonMultiple(25, 5));
-	CHECK(130 == LeastCommonMultiple(5, 26));
-	CHECK(130 == LeastCommonMultiple(26, 5));
-}
-
-TEST_CASE("GreatestCommonDivisorTest - Negative")
-{
-	CHECK(4 == GreatestCommonDivisor(4, -52));
-	// CHECK(3 == GreatestCommonDivisor(-27, 6)); // error - returns -3
-}
-
-TEST_CASE("GreatestCommonDivisorTest - Zero")
-{
-	CHECK(27 == GreatestCommonDivisor(0, 27));
-	CHECK(27 == GreatestCommonDivisor(27, 0));
-}
-
-TEST_CASE("GreatestCommonDivisorTest - FindGCD")
-{
-	CHECK(5 == GreatestCommonDivisor(5, 25));
-	CHECK(5 == GreatestCommonDivisor(25, 5));
-	CHECK(1 == GreatestCommonDivisor(7, 27));
-	CHECK(1 == GreatestCommonDivisor(27, 7));
-}
-
 TEST_CASE("DivideApproxTest - Negative")
 {
 	CHECK(-2 == DivideApprox(-5, 2));

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1239,10 +1239,10 @@ void NWidgetStacked::SetupSmallestSize(Window *w)
 
 		this->smallest_x = std::max(this->smallest_x, child_wid->smallest_x + child_wid->padding.Horizontal());
 		this->smallest_y = std::max(this->smallest_y, child_wid->smallest_y + child_wid->padding.Vertical());
-		this->fill_x = LeastCommonMultiple(this->fill_x, child_wid->fill_x);
-		this->fill_y = LeastCommonMultiple(this->fill_y, child_wid->fill_y);
-		this->resize_x = LeastCommonMultiple(this->resize_x, child_wid->resize_x);
-		this->resize_y = LeastCommonMultiple(this->resize_y, child_wid->resize_y);
+		this->fill_x = std::lcm(this->fill_x, child_wid->fill_x);
+		this->fill_y = std::lcm(this->fill_y, child_wid->fill_y);
+		this->resize_x = std::lcm(this->resize_x, child_wid->resize_x);
+		this->resize_y = std::lcm(this->resize_y, child_wid->resize_y);
 	}
 }
 
@@ -1409,12 +1409,12 @@ void NWidgetHorizontal::SetupSmallestSize(Window *w)
 		if (child_wid->fill_x > 0) {
 			if (this->fill_x == 0 || this->fill_x > child_wid->fill_x) this->fill_x = child_wid->fill_x;
 		}
-		this->fill_y = LeastCommonMultiple(this->fill_y, child_wid->fill_y);
+		this->fill_y = std::lcm(this->fill_y, child_wid->fill_y);
 
 		if (child_wid->resize_x > 0) {
 			if (this->resize_x == 0 || this->resize_x > child_wid->resize_x) this->resize_x = child_wid->resize_x;
 		}
-		this->resize_y = LeastCommonMultiple(this->resize_y, child_wid->resize_y);
+		this->resize_y = std::lcm(this->resize_y, child_wid->resize_y);
 	}
 	if (this->fill_x == 0 && this->pip_ratio_pre + this->pip_ratio_inter + this->pip_ratio_post > 0) this->fill_x = 1;
 	/* 4. Increase by required PIP space. */
@@ -1598,12 +1598,12 @@ void NWidgetVertical::SetupSmallestSize(Window *w)
 		if (child_wid->fill_y > 0) {
 			if (this->fill_y == 0 || this->fill_y > child_wid->fill_y) this->fill_y = child_wid->fill_y;
 		}
-		this->fill_x = LeastCommonMultiple(this->fill_x, child_wid->fill_x);
+		this->fill_x = std::lcm(this->fill_x, child_wid->fill_x);
 
 		if (child_wid->resize_y > 0) {
 			if (this->resize_y == 0 || this->resize_y > child_wid->resize_y) this->resize_y = child_wid->resize_y;
 		}
-		this->resize_x = LeastCommonMultiple(this->resize_x, child_wid->resize_x);
+		this->resize_x = std::lcm(this->resize_x, child_wid->resize_x);
 	}
 	if (this->fill_y == 0 && this->pip_ratio_pre + this->pip_ratio_inter + this->pip_ratio_post > 0) this->fill_y = 1;
 	/* 4. Increase by required PIP space. */


### PR DESCRIPTION
## Motivation / Problem

C++17 has the same functionality, so why roll our own?


## Description

Replace `LeastCommonMultiple` with `std::lcm`.
Remove `LeastCommonMultiple` and `GreatestCommonDivisor`.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
