### PR TITLE
Codechange: add constexpr to core/(bit)math

### DIFF
--- a/src/core/bitmath_func.hpp
+++ b/src/core/bitmath_func.hpp
@@ -55,7 +55,7 @@ debug_inline constexpr static uint GB(const T x, const uint8_t s, const uint8_t 
  * @return The new value of \a x
  */
 template <typename T, typename U>
-inline T SB(T &x, const uint8_t s, const uint8_t n, const U d)
+constexpr T SB(T &x, const uint8_t s, const uint8_t n, const U d)
 {
 	x &= (T)(~((((T)1U << n) - 1) << s));
 	x |= (T)(d << s);
@@ -80,7 +80,7 @@ inline T SB(T &x, const uint8_t s, const uint8_t n, const U d)
  * @return The new value of \a x
  */
 template <typename T, typename U>
-inline T AB(T &x, const uint8_t s, const uint8_t n, const U i)
+constexpr T AB(T &x, const uint8_t s, const uint8_t n, const U i)
 {
 	const T mask = ((((T)1U << n) - 1) << s);
 	x = (T)((x & ~mask) | ((x + (i << s)) & mask));
@@ -100,7 +100,7 @@ inline T AB(T &x, const uint8_t s, const uint8_t n, const U i)
  * @return True if the bit is set, false else.
  */
 template <typename T>
-debug_inline static bool HasBit(const T x, const uint8_t y)
+debug_inline constexpr bool HasBit(const T x, const uint8_t y)
 {
 	return (x & ((T)1U << y)) != 0;
 }
@@ -118,7 +118,7 @@ debug_inline static bool HasBit(const T x, const uint8_t y)
  * @return The new value of the old value with the bit set
  */
 template <typename T>
-inline T SetBit(T &x, const uint8_t y)
+constexpr T SetBit(T &x, const uint8_t y)
 {
 	return x = (T)(x | ((T)1U << y));
 }
@@ -148,7 +148,7 @@ inline T SetBit(T &x, const uint8_t y)
  * @return The new value of the old value with the bit cleared
  */
 template <typename T>
-inline T ClrBit(T &x, const uint8_t y)
+constexpr T ClrBit(T &x, const uint8_t y)
 {
 	return x = (T)(x & ~((T)1U << y));
 }
@@ -178,7 +178,7 @@ inline T ClrBit(T &x, const uint8_t y)
  * @return The new value of the old value with the bit toggled
  */
 template <typename T>
-inline T ToggleBit(T &x, const uint8_t y)
+constexpr T ToggleBit(T &x, const uint8_t y)
 {
 	return x = (T)(x ^ ((T)1U << y));
 }
@@ -228,7 +228,7 @@ constexpr uint8_t FindLastBit(T x)
  * @return The new value with the first bit cleared
  */
 template <typename T>
-inline T KillFirstBit(T value)
+constexpr T KillFirstBit(T value)
 {
 	return value &= (T)(value - 1);
 }
@@ -256,7 +256,7 @@ constexpr uint CountBits(T value)
  * @return does \a value have exactly 1 bit set?
  */
 template <typename T>
-inline bool HasExactlyOneBit(T value)
+constexpr bool HasExactlyOneBit(T value)
 {
 	return value != 0 && (value & (value - 1)) == 0;
 }
@@ -268,7 +268,7 @@ inline bool HasExactlyOneBit(T value)
  * @return does \a value have at most 1 bit set?
  */
 template <typename T>
-inline bool HasAtMostOneBit(T value)
+constexpr bool HasAtMostOneBit(T value)
 {
 	return (value & (value - 1)) == 0;
 }

--- a/src/core/math_func.hpp
+++ b/src/core/math_func.hpp
@@ -20,7 +20,7 @@
  * @return The unsigned value
  */
 template <typename T>
-inline T abs(const T a)
+constexpr T abs(const T a)
 {
 	return (a < (T)0) ? -a : a;
 }
@@ -34,7 +34,7 @@ inline T abs(const T a)
  * @return The smallest multiple of n equal or greater than x
  */
 template <typename T>
-inline T Align(const T x, uint n)
+constexpr T Align(const T x, uint n)
 {
 	assert((n & (n - 1)) == 0 && n != 0);
 	n--;
@@ -52,7 +52,7 @@ inline T Align(const T x, uint n)
  * @see Align()
  */
 template <typename T>
-inline T *AlignPtr(T *x, uint n)
+constexpr T *AlignPtr(T *x, uint n)
 {
 	static_assert(sizeof(size_t) == sizeof(void *));
 	return reinterpret_cast<T *>(Align((size_t)x, n));
@@ -76,7 +76,7 @@ inline T *AlignPtr(T *x, uint n)
  * @see Clamp(int, int, int)
  */
 template <typename T>
-inline T Clamp(const T a, const T min, const T max)
+constexpr T Clamp(const T a, const T min, const T max)
 {
 	assert(min <= max);
 	if (a <= min) return min;
@@ -99,7 +99,7 @@ inline T Clamp(const T a, const T min, const T max)
  * @returns A value between min and max which is closest to a.
  */
 template <typename T>
-inline T SoftClamp(const T a, const T min, const T max)
+constexpr T SoftClamp(const T a, const T min, const T max)
 {
 	if (min > max) {
 		using U = std::make_unsigned_t<T>;
@@ -126,7 +126,7 @@ inline T SoftClamp(const T a, const T min, const T max)
  * @returns A value between min and max which is closest to a.
  * @see ClampU(uint, uint, uint)
  */
-inline int Clamp(const int a, const int min, const int max)
+constexpr int Clamp(const int a, const int min, const int max)
 {
 	return Clamp<int>(a, min, max);
 }
@@ -147,7 +147,7 @@ inline int Clamp(const int a, const int min, const int max)
  * @returns A value between min and max which is closest to a.
  * @see Clamp(int, int, int)
  */
-inline uint ClampU(const uint a, const uint min, const uint max)
+constexpr uint ClampU(const uint a, const uint min, const uint max)
 {
 	return Clamp<uint>(a, min, max);
 }
@@ -231,7 +231,7 @@ constexpr To ClampTo(From value)
  * @return The absolute difference between the given scalars
  */
 template <typename T>
-inline T Delta(const T a, const T b)
+constexpr T Delta(const T a, const T b)
 {
 	return (a < b) ? b - a : a - b;
 }
@@ -249,7 +249,7 @@ inline T Delta(const T a, const T b)
  * @return True if the value is in the interval, false else.
  */
 template <typename T>
-inline bool IsInsideBS(const T x, const size_t base, const size_t size)
+constexpr bool IsInsideBS(const T x, const size_t base, const size_t size)
 {
 	return (size_t)(x - base) < size;
 }
@@ -265,7 +265,7 @@ inline bool IsInsideBS(const T x, const size_t base, const size_t size)
  * @see IsInsideBS()
  */
 template <typename T, std::enable_if_t<std::disjunction_v<std::is_convertible<T, size_t>, std::is_base_of<StrongTypedefBase, T>>, int> = 0>
-static constexpr inline bool IsInsideMM(const T x, const size_t min, const size_t max) noexcept
+constexpr bool IsInsideMM(const T x, const size_t min, const size_t max) noexcept
 {
 	if constexpr (std::is_base_of_v<StrongTypedefBase, T>) {
 		return (size_t)(x.base() - min) < (max - min);
@@ -280,7 +280,7 @@ static constexpr inline bool IsInsideMM(const T x, const size_t min, const size_
  * @param b variable to swap with a
  */
 template <typename T>
-inline void Swap(T &a, T &b)
+constexpr void Swap(T &a, T &b)
 {
 	T t = a;
 	a = b;
@@ -292,7 +292,7 @@ inline void Swap(T &a, T &b)
  * @param i value to convert, range 0..255
  * @return value in range 0..100
  */
-inline uint ToPercent8(uint i)
+constexpr uint ToPercent8(uint i)
 {
 	assert(i < 256);
 	return i * 101 >> 8;
@@ -303,7 +303,7 @@ inline uint ToPercent8(uint i)
  * @param i value to convert, range 0..65535
  * @return value in range 0..100
  */
-inline uint ToPercent16(uint i)
+constexpr uint ToPercent16(uint i)
 {
 	assert(i < 65536);
 	return i * 101 >> 16;
@@ -317,7 +317,7 @@ int DivideApprox(int a, int b);
  * @param b Denominator
  * @return Quotient, rounded up
  */
-inline uint CeilDiv(uint a, uint b)
+constexpr uint CeilDiv(uint a, uint b)
 {
 	return (a + b - 1) / b;
 }
@@ -328,7 +328,7 @@ inline uint CeilDiv(uint a, uint b)
  * @param b Denominator
  * @return a rounded up to the nearest multiple of b.
  */
-inline uint Ceil(uint a, uint b)
+constexpr uint Ceil(uint a, uint b)
 {
 	return CeilDiv(a, b) * b;
 }
@@ -339,7 +339,7 @@ inline uint Ceil(uint a, uint b)
  * @param b Denominator
  * @return Quotient, rounded to nearest
  */
-inline int RoundDivSU(int a, uint b)
+constexpr int RoundDivSU(int a, uint b)
 {
 	if (a > 0) {
 		/* 0.5 is rounded to 1 */
@@ -356,7 +356,7 @@ inline int RoundDivSU(int a, uint b)
  * @param b Denominator
  * @return Quotient, rounded away from zero
  */
-inline int DivAwayFromZero(int a, uint b)
+constexpr int DivAwayFromZero(int a, uint b)
 {
 	const int _b = static_cast<int>(b);
 	if (a > 0) {


### PR DESCRIPTION
## Motivation / Problem

Make the (bit)math functions useable for compile time validation and construction of objects.


## Description

Just replace `inline` with `constexpr` (`constexpr` implies `inline`).


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
