### PR TITLE
Fix bd85f61a: [Linux] don't include sys/random.h on older glibc systems

### DIFF
--- a/src/core/random_func.cpp
+++ b/src/core/random_func.cpp
@@ -24,10 +24,12 @@
 #if defined(_WIN32)
 #	include <windows.h>
 #	include <bcrypt.h>
+#elif defined(__APPLE__) || defined(__NetBSD__) || defined(__FreeBSD__)
+// No includes required.
+#elif defined(__GLIBC__) && ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 25)))
+#	include <sys/random.h>
 #elif defined(__EMSCRIPTEN__)
 #	include <emscripten.h>
-#elif !defined(__APPLE__) && !defined(__NetBSD__) && !defined(__FreeBSD__)
-#	include <sys/random.h>
 #endif
 
 #include "../safeguards.h"


### PR DESCRIPTION
## Motivation / Problem

Linux Legacy doesn't build, as it uses a very old glibc.

## Description

I was trying to be clever with the includes, which backfired. Let's be less clever.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
