### PR TITLE
Fix: [CI] wait for all targets to succeeded before uploading to any

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,8 @@ jobs:
     with:
       version: ${{ needs.source.outputs.version }}
 
-  upload-cdn:
-    name: Upload (CDN)
+  upload:
+    name: Upload
     needs:
     - source
     - docs
@@ -101,6 +101,25 @@ jobs:
     # The always() makes sure the rest is always evaluated.
     if: always() && needs.source.result == 'success' && needs.docs.result == 'success' && needs.linux-legacy.result == 'success' && needs.linux.result == 'success' && needs.macos.result == 'success' && needs.windows.result == 'success' && (needs.windows-store.result == 'success' || needs.windows-store.result == 'skipped')
 
+    runs-on: ubuntu-latest
+
+    # This job is empty, but ensures no upload job starts before all targets finished and are successful.
+    steps:
+    - name: Build completed
+      run: |
+        true
+
+  upload-cdn:
+    name: Upload (CDN)
+    needs:
+    - source
+    - upload
+
+    # As windows-store is condition, we need to check ourselves if we need to run.
+    # The always() makes sure the rest is always evaluated.
+    # Yes, you even need to do this if you yourself don't depend on the condition.
+    if: always() && needs.source.result == 'success' && needs.upload.result == 'success'
+
     uses: ./.github/workflows/upload-cdn.yml
     secrets: inherit
 
@@ -113,11 +132,13 @@ jobs:
     name: Upload (Steam)
     needs:
     - source
-    - linux
-    - macos
-    - windows
+    - upload
 
-    if: needs.source.outputs.trigger_type == 'new-master' || needs.source.outputs.trigger_type == 'new-tag'
+    # As windows-store is condition, we need to check ourselves if we need to run.
+    # The always() makes sure the rest is always evaluated.
+    # Yes, you even need to do this if you yourself don't depend on the condition.
+    # Additionally, only nightlies and releases go to Steam; not PRs.
+    if: always() && needs.source.result == 'success' && needs.upload.result == 'success' && (needs.source.outputs.trigger_type == 'new-master' || needs.source.outputs.trigger_type == 'new-tag')
 
     uses: ./.github/workflows/upload-steam.yml
     secrets: inherit
@@ -130,11 +151,13 @@ jobs:
     name: Upload (GOG)
     needs:
     - source
-    - linux
-    - macos
-    - windows
+    - upload
 
-    if: needs.source.outputs.trigger_type == 'new-tag'
+    # As windows-store is condition, we need to check ourselves if we need to run.
+    # The always() makes sure the rest is always evaluated.
+    # Yes, you even need to do this if you yourself don't depend on the condition.
+    # Additionally, only releases go to GOG; not nightlies or PRs.
+    if: always() && needs.source.result == 'success' && needs.upload.result == 'success' && needs.source.outputs.trigger_type == 'new-tag'
 
     uses: ./.github/workflows/upload-gog.yml
     secrets: inherit


### PR DESCRIPTION
## Motivation / Problem

Otherwise it is possible Steam upload happens while CDN upload does not, which is a bit awkward.

## Description

Funnel all upload jobs through a single one that does nothing but ensures all others are ready.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
