### PR TITLE
Codechange: use std::shared_ptr for vector of TCPConnecters

### DIFF
--- a/src/network/core/tcp.h
+++ b/src/network/core/tcp.h
@@ -100,6 +100,8 @@ private:
 	NetworkAddress bind_address;                        ///< Address we're binding to, if any.
 	int family = AF_UNSPEC;                             ///< Family we are using to connect with.
 
+	static std::vector<std::shared_ptr<TCPConnecter>> connecters; ///< List of connections that are currently being created.
+
 	void Resolve();
 	void OnResolved(addrinfo *ai);
 	bool TryNextAddress();
@@ -132,6 +134,18 @@ public:
 
 	static void CheckCallbacks();
 	static void KillAll();
+
+	/**
+	 * Create the connecter, and initiate connecting by putting it in the collection of TCP connections to make.
+	 * @tparam T The type of connecter to create.
+	 * @param args The arguments to the constructor of T.
+	 * @return Shared pointer to the connecter.
+	 */
+	template <class T, typename... Args>
+	static std::shared_ptr<TCPConnecter> Create(Args&& ... args)
+	{
+		return TCPConnecter::connecters.emplace_back(std::make_shared<T>(std::forward<Args>(args)...));
+	}
 };
 
 class TCPServerConnecter : public TCPConnecter {

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -624,7 +624,7 @@ static void NetworkInitialize(bool close_admins = true)
 }
 
 /** Non blocking connection to query servers for their game info. */
-class TCPQueryConnecter : TCPServerConnecter {
+class TCPQueryConnecter : public TCPServerConnecter {
 private:
 	std::string connection_string;
 
@@ -658,7 +658,7 @@ void NetworkQueryServer(const std::string &connection_string)
 	NetworkGameList *item = NetworkGameListAddItem(connection_string);
 	item->refreshing = true;
 
-	new TCPQueryConnecter(connection_string);
+	TCPConnecter::Create<TCPQueryConnecter>(connection_string);
 }
 
 /**
@@ -721,7 +721,7 @@ void NetworkRebuildHostList()
 }
 
 /** Non blocking connection create to actually connect to servers */
-class TCPClientConnecter : TCPServerConnecter {
+class TCPClientConnecter : public TCPServerConnecter {
 private:
 	std::string connection_string;
 
@@ -800,7 +800,7 @@ void NetworkClientJoinGame()
 	_network_join_status = NETWORK_JOIN_STATUS_CONNECTING;
 	ShowJoinStatusWindow();
 
-	new TCPClientConnecter(_network_join.connection_string);
+	TCPConnecter::Create<TCPClientConnecter>(_network_join.connection_string);
 }
 
 static void NetworkInitGameInfo()

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -756,7 +756,7 @@ ClientNetworkContentSocketHandler::~ClientNetworkContentSocketHandler()
 }
 
 /** Connect to the content server. */
-class NetworkContentConnecter : TCPConnecter {
+class NetworkContentConnecter : public TCPConnecter {
 public:
 	/**
 	 * Initiate the connecting.
@@ -791,7 +791,7 @@ void ClientNetworkContentSocketHandler::Connect()
 	this->isCancelled = false;
 	this->isConnecting = true;
 
-	new NetworkContentConnecter(NetworkContentServerConnectionString());
+	TCPConnecter::Create<NetworkContentConnecter>(NetworkContentServerConnectionString());
 }
 
 /**

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -100,7 +100,7 @@ public:
 };
 
 /** Connect to the Game Coordinator server. */
-class NetworkCoordinatorConnecter : TCPConnecter {
+class NetworkCoordinatorConnecter : public TCPConnecter {
 public:
 	/**
 	 * Initiate the connecting.
@@ -306,7 +306,7 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_DIRECT_CONNECT(Packet *p)
 		this->game_connecter = nullptr;
 	}
 
-	this->game_connecter = new NetworkDirectConnecter(hostname, port, token, tracking_number);
+	this->game_connecter = TCPConnecter::Create<NetworkDirectConnecter>(hostname, port, token, tracking_number);
 	return true;
 }
 
@@ -349,7 +349,7 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_STUN_CONNECT(Packet *p)
 	 * STUN server. This means that if there is any NAT in the local network,
 	 * the public ip:port is still pointing to the local address, and as such
 	 * a connection can be established. */
-	this->game_connecter = new NetworkReuseStunConnecter(host, port, family_it->second->local_addr, token, tracking_number, family);
+	this->game_connecter = TCPConnecter::Create<NetworkReuseStunConnecter>(host, port, family_it->second->local_addr, token, tracking_number, family);
 	return true;
 }
 
@@ -426,7 +426,7 @@ void ClientNetworkCoordinatorSocketHandler::Connect()
 	this->connecting = true;
 	this->last_activity = std::chrono::steady_clock::now();
 
-	new NetworkCoordinatorConnecter(NetworkCoordinatorConnectionString());
+	TCPConnecter::Create<NetworkCoordinatorConnecter>(NetworkCoordinatorConnectionString());
 }
 
 NetworkRecvStatus ClientNetworkCoordinatorSocketHandler::CloseConnection(bool error)

--- a/src/network/network_coordinator.h
+++ b/src/network/network_coordinator.h
@@ -57,7 +57,7 @@ private:
 	std::map<std::string, TCPServerConnecter *> connecter_pre; ///< Based on invite codes, the current connecters that are pending.
 	std::map<std::string, std::map<int, std::unique_ptr<ClientNetworkStunSocketHandler>>> stun_handlers; ///< All pending STUN handlers, stored by token:family.
 	std::map<std::string, std::unique_ptr<ClientNetworkTurnSocketHandler>> turn_handlers; ///< Pending TURN handler (if any), stored by token.
-	TCPConnecter *game_connecter = nullptr; ///< Pending connecter to the game server.
+	std::shared_ptr<TCPConnecter> game_connecter{}; ///< Pending connecter to the game server.
 
 	uint32_t newgrf_lookup_table_cursor = 0; ///< Last received cursor for the #GameInfoNewGRFLookupTable updates.
 	GameInfoNewGRFLookupTable newgrf_lookup_table; ///< Table to look up NewGRFs in the GC_LISTING packets.

--- a/src/network/network_stun.cpp
+++ b/src/network/network_stun.cpp
@@ -71,7 +71,7 @@ void ClientNetworkStunSocketHandler::Connect(const std::string &token, uint8_t f
 	this->token = token;
 	this->family = family;
 
-	this->connecter = new NetworkStunConnecter(this, NetworkStunConnectionString(), token, family);
+	this->connecter = TCPConnecter::Create<NetworkStunConnecter>(this, NetworkStunConnectionString(), token, family);
 }
 
 /**

--- a/src/network/network_stun.h
+++ b/src/network/network_stun.h
@@ -20,7 +20,7 @@ private:
 	bool sent_result = false; ///< Did we sent the result of the STUN connection?
 
 public:
-	TCPConnecter *connecter = nullptr; ///< Connecter instance.
+	std::shared_ptr<TCPConnecter> connecter{}; ///< Connecter instance.
 	NetworkAddress local_addr;         ///< Local addresses of the socket.
 
 	NetworkRecvStatus CloseConnection(bool error = true) override;

--- a/src/network/network_turn.cpp
+++ b/src/network/network_turn.cpp
@@ -73,7 +73,7 @@ bool ClientNetworkTurnSocketHandler::Receive_TURN_CONNECTED(Packet *p)
 void ClientNetworkTurnSocketHandler::Connect()
 {
 	this->connect_started = true;
-	this->connecter = new NetworkTurnConnecter(this, this->connection_string);
+	this->connecter = TCPConnecter::Create<NetworkTurnConnecter>(this, this->connection_string);
 }
 
 /**

--- a/src/network/network_turn.h
+++ b/src/network/network_turn.h
@@ -24,7 +24,7 @@ protected:
 	bool Receive_TURN_CONNECTED(Packet *p) override;
 
 public:
-	TCPConnecter *connecter = nullptr; ///< Connecter instance.
+	std::shared_ptr<TCPConnecter> connecter{}; ///< Connecter instance.
 	bool connect_started = false;      ///< Whether we started the connection.
 
 	ClientNetworkTurnSocketHandler(const std::string &token, uint8_t tracking_number, const std::string &connection_string) : token(token), tracking_number(tracking_number), connection_string(connection_string) {}


### PR DESCRIPTION
## Motivation / Problem

Multiple CodeQL warnings "Resource not released in destructor". Especially in the network coordinator.

My main problem is that there `new` calls all over the place, but the `delete` is hidden somewhere far away in the internals. This makes it difficult to reason, and the straight forward way of putting them in `std::unique_ptr` at the point of construction is wrong.


## Description

Make the collection of `TCPConnecter`'s store `std::unique_ptr` instead of raw pointers, thus having a clear location with the ownership of the `TCPConnecter`'s memory.
Introduce a static templated method to create an instance of a sub class of `TCPConnecter`, which puts it into the collector of connecters (instead of the constructors) and then returns a non-owning pointer to those that are interested in it.

Use vector's `clear` to kill all connection attempts, since the `unique_ptr` handles all the further clean up.

Use `std::remove_if` to simplify the `CheckCallbacks` function, i.e. not needing the manual iterator updates depending on whether it got removed or not.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
