### PR TITLE
Fix: [CI] don't share Rust cache between legacy and generic linux

### DIFF
--- a/.github/workflows/release-linux-legacy.yml
+++ b/.github/workflows/release-linux-legacy.yml
@@ -52,6 +52,8 @@ jobs:
 
     - name: Enable Rust cache
       uses: Swatinem/rust-cache@v2.7.0
+      with:
+        key: legacy
 
     - name: Setup vcpkg caching
       uses: actions/github-script@v6


### PR DESCRIPTION
## Motivation / Problem

The resulting binaries of generic can't run on legacy. This can cause broken builds, seemingly, at random, or work okay for weeks at end.

## Description

Don't share cache between legacy and generic. Avoiding this issue.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
