### PR TITLE
Codechange: Use per-vehicle-type list when ticking vehicles.

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -2099,8 +2099,6 @@ bool Aircraft::Tick()
 {
 	if (!this->IsNormalAircraft()) return true;
 
-	PerformanceAccumulator framerate(PFE_GL_AIRCRAFT);
-
 	this->tick_counter++;
 
 	if (!(this->vehstatus & VS_STOPPED)) this->running_ticks++;

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -1643,8 +1643,6 @@ Money RoadVehicle::GetRunningCost() const
 
 bool RoadVehicle::Tick()
 {
-	PerformanceAccumulator framerate(PFE_GL_ROADVEHS);
-
 	this->tick_counter++;
 
 	if (this->IsFrontEngine()) {

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -839,8 +839,6 @@ static void ShipController(Ship *v)
 
 bool Ship::Tick()
 {
-	PerformanceAccumulator framerate(PFE_GL_SHIPS);
-
 	if (!(this->vehstatus & VS_STOPPED)) this->running_ticks++;
 
 	ShipController(this);

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -4097,8 +4097,6 @@ bool Train::Tick()
 	this->tick_counter++;
 
 	if (this->IsFrontEngine()) {
-		PerformanceAccumulator framerate(PFE_GL_TRAINS);
-
 		if (!(this->vehstatus & VS_STOPPED) || this->cur_speed > 0) this->running_ticks++;
 
 		this->current_order_time++;

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -1062,6 +1062,9 @@ public:
 
 	uint32_t GetDisplayMaxWeight() const;
 	uint32_t GetDisplayMinPowerToWeight() const;
+
+	virtual void AddTickable() {}
+	virtual void RemoveTickable() {}
 };
 
 /**
@@ -1080,6 +1083,12 @@ struct SpecializedVehicle : public Vehicle {
 	inline SpecializedVehicle<T, Type>() : Vehicle(Type)
 	{
 		this->sprite_cache.sprite_seq.count = 1;
+		this->AddTickable();
+	}
+
+	inline ~SpecializedVehicle<T, Type>()
+	{
+		this->RemoveTickable();
 	}
 
 	/**
@@ -1259,6 +1268,21 @@ struct SpecializedVehicle : public Vehicle {
 	 * @return an iterable ensemble of all valid vehicles of type T
 	 */
 	static Pool::IterateWrapper<T> Iterate(size_t from = 0) { return Pool::IterateWrapper<T>(from); }
+
+	/**
+	 * List of tickable vehicles for this type.
+	 */
+	static inline std::map<VehicleID, SpecializedVehicle<T, Type> *> tickable_vehicles;
+
+	void AddTickable() override
+	{
+		tickable_vehicles.insert(std::make_pair(this->index, this));
+	}
+
+	void RemoveTickable() override
+	{
+		tickable_vehicles.erase(this->index);
+	}
 };
 
 /** Generates sequence of free UnitID numbers */


### PR DESCRIPTION
## Motivation / Problem

As per #7247, using PerformanceAccumulator when ticking vehicles can be a performance hit on some systems, as start/stop time needs to be determined fore each vehicle. PerformanceMeasurer is more effecient as only one start/stop time is needed, but then it is not possible to measure per vehicle type.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This PR implements a per-vehicle type std::map (ordered by vehicle index) of vehicles, each of which can be ticked in one go. This may improve performance.

it will also likely increase the reported value for trains, as due to #10055, not all parts of Train::Tick are counted.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Dodgy iterators :)

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
