### PR TITLE
Codechange: prevent out-of-bound read (even if the result is never used)

### DIFF
--- a/src/ai/ai_config.cpp
+++ b/src/ai/ai_config.cpp
@@ -18,6 +18,8 @@
 
 /* static */ AIConfig *AIConfig::GetConfig(CompanyID company, ScriptSettingSource source)
 {
+	assert(company < MAX_COMPANIES);
+
 	AIConfig **config;
 	if (source == SSS_FORCE_NEWGAME || (source == SSS_DEFAULT && _game_mode == GM_MENU)) {
 		config = &_settings_newgame.ai_config[company];

--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -289,7 +289,7 @@ struct AIConfigWindow : public Window {
 
 		if (!gui_scope) return;
 
-		AIConfig *config = AIConfig::GetConfig(this->selected_slot);
+		AIConfig *config = this->selected_slot == INVALID_COMPANY ? nullptr : AIConfig::GetConfig(this->selected_slot);
 
 		this->SetWidgetDisabledState(WID_AIC_DECREASE_NUMBER, GetGameSettings().difficulty.max_no_competitors == 0);
 		this->SetWidgetDisabledState(WID_AIC_INCREASE_NUMBER, GetGameSettings().difficulty.max_no_competitors == MAX_COMPANIES - 1);


### PR DESCRIPTION
## Motivation / Problem

When running with clang's address sanitizer, it is impossible to open the AI Configuration because of a `global-buffer-overflow`.

`OnInvalidateData` of `AIConfigWindow` uses `AIConfig::GetConfig` on a potential `INVALID_COMPANY`. This is not handled by `GetConfig`, and an out-of-bound read is done.

There is no actual danger, as every access to the result is guarded by a check if the company wasn't `INVALID_COMPANY`. As such, this is not a bug (and as such, not a fix). But still broken.

## Description

Ensure that `GetConfig` throws an assertions if it is access for a company that is out-of-bound. That way we can detect more easily if there are more users of this function that do this; although an initial scan of the code shows there shouldn't be.

Secondly, don't call `GetConfig` on `INVALID_COMPANY`.

I didn't make `GetConfig` return a `nullptr`, as the function currently behaves as if the return is `AIInfo &`. As this would make much more sense (but is not for this PR to address), I left that as it is, and just guarded against not calling the function like that.
Mostly, all code using `GetConfig` assumes it doesn't get a `nullptr` back.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
