### PR TITLE
Fix #6377: two tarballs with the same folder in them were considered as one

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -529,6 +529,9 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 
 	_tar_list[this->subdir][filename] = std::string{};
 
+	std::string filename_base = std::filesystem::path(filename).filename().string();
+	SimplifyFileName(filename_base);
+
 	TarLinkList links; ///< Temporary list to collect links
 
 	TarHeader th;
@@ -583,7 +586,7 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 				SimplifyFileName(name);
 
 				Debug(misc, 6, "Found file in tar: {} ({} bytes, {} offset)", name, skip, pos);
-				if (_tar_filelist[this->subdir].insert(TarFileList::value_type(name, entry)).second) num++;
+				if (_tar_filelist[this->subdir].insert(TarFileList::value_type(filename_base + PATHSEPCHAR + name, entry)).second) num++;
 
 				break;
 			}
@@ -615,7 +618,7 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 
 				/* Store links in temporary list */
 				Debug(misc, 6, "Found link in tar: {} -> {}", name, dest);
-				links.insert(TarLinkList::value_type(name, dest));
+				links.insert(TarLinkList::value_type(filename_base + PATHSEPCHAR + name, filename_base + PATHSEPCHAR + dest));
 
 				break;
 			}


### PR DESCRIPTION
## Motivation / Problem

When you have two tarballs, both with the same foldername in them, they are considered to be part of the same folder. This means they merged together.

This is especially tricky if they also contain the same files, but with different content. Which file is actually being seen by OpenTTD heavily depends on in which order the game loads the tarballs.

This was identified in #6377, but never resolved. Yes, I am solving 9 year old bugs that were marked "good first issues". Also, given nobody replied to the ticket in 7 years, it seems to not be that big of a problem. But okay.

Fixes #6377.

## Description

Although #6377 makes it sound like it is trivial to fix, and that "It is now no longer needed, but noone removed it.", it doesn't actually say what to remove. Turns out, it is not removing anything, it is about adding stuff.

Prefix all files added to the tar-list with the tarname they came from. This means that even if two tarballs have the same folder in them, they are different from one another.

## Limitations

This is really hard to test. Although this "should be fine", and initial testing shows that base graphics, NewGRFs and AIs work fine, it is very hard to say if not something made an assumption somewhere in how deep an `info.nut` or whatever has to be.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
