### PR TITLE
Codechange: Replace C-style TICC/TOCC macros with C++ RAII implementation.

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -63,44 +63,38 @@ std::string GetDebugString();
 /* Shorter form for passing filename and linenumber */
 #define FILE_LINE __FILE__, __LINE__
 
-/**
- * Used for profiling.
- *
+/** TicToc profiling.
  * Usage:
- * TIC();
- *   --Do your code--
- * TOC("A name", 1);
- *
- * When you run the TIC() / TOC() multiple times, you can increase the '1'
- *  to only display average stats every N values. Some things to know:
- *
- * for (int i = 0; i < 5; i++) {
- *   TIC();
- *     --Do your code--
- *   TOC("A name", 5);
- * }
- *
- * Is the correct usage for multiple TIC() / TOC() calls.
- *
- * TIC() / TOC() creates its own block, so make sure not the mangle
- *  it with another block.
- *
- * The output is counted in microseconds. Mainly useful for local optimisations.
- **/
-#define TIC() {\
-	auto _start_ = std::chrono::high_resolution_clock::now();\
-	static uint64_t _sum_ = 0;\
-	static uint32_t _i_ = 0;
+ * static TicToc::State state("A name", 1);
+ * TicToc tt(state);
+ * --Do your code--
+ */
+struct TicToc {
+	/** Persistent state for TicToc profiling. */
+	struct State {
+		const std::string_view name;
+		const uint32_t max_count;
+		uint32_t count = 0;
+		uint64_t chrono_sum = 0;
 
-#define TOC(str, _count_)\
-	_sum_ += (std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - _start_)).count();\
-	if (++_i_ == _count_) {\
-		Debug(misc, 0, "[{}] {} us [avg: {:.1f} us]", str, _sum_, _sum_/(double)_i_);\
-		_i_ = 0;\
-		_sum_ = 0;\
-	}\
-}
+		constexpr State(std::string_view name, uint32_t max_count) : name(name), max_count(max_count) { }
+	};
 
+	State &state;
+	std::chrono::high_resolution_clock::time_point chrono_start; ///< real time count.
+
+	inline TicToc(State &state) : state(state), chrono_start(std::chrono::high_resolution_clock::now()) { }
+
+	inline ~TicToc()
+	{
+		this->state.chrono_sum += (std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - this->chrono_start)).count();
+		if (++this->state.count == this->state.max_count) {
+			Debug(misc, 0, "[{}] {} us [avg: {:.1f} us]", this->state.name, this->state.chrono_sum, this->state.chrono_sum / static_cast<double>(this->state.count));
+			this->state.count = 0;
+			this->state.chrono_sum = 0;
+		}
+	}
+};
 
 void ShowInfoI(const std::string &str);
 #define ShowInfo(format_string, ...) ShowInfoI(fmt::format(FMT_STRING(format_string), ## __VA_ARGS__))


### PR DESCRIPTION
## Motivation / Problem

The TICC/TOCC debug macros have some issues. They are:

1) Macros.
2) They hide a block.
3) If you return from inside the block the timing is skipped.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Replace with a class that performs the timing when its destructor is called. An extra class is used for storing static state.

Usage is more robust, and will always include timing when the TicToc object goes out of scope.


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
