### PR TITLE
Fix #9722: create vital windows as soon as local_company is set

### DIFF
--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -72,8 +72,6 @@ static void CleanupGeneration()
 	_generating_world = false;
 
 	SetMouseCursorBusy(false);
-	/* Show all vital windows again, because we have hidden them */
-	if (_game_mode != GM_MENU) ShowVitalWindows();
 	SetModalProgress(false);
 	_gw.proc     = nullptr;
 	_gw.abortp   = nullptr;
@@ -182,6 +180,8 @@ static void _GenerateWorld()
 		ResetObjectToPlace();
 		_cur_company.Trash();
 		_current_company = _local_company = _gw.lc;
+		/* Show all vital windows again, because we have hidden them. */
+		if (_game_mode != GM_MENU) ShowVitalWindows();
 
 		SetGeneratingWorldProgress(GWP_GAME_START, 1);
 		/* Call any callback */


### PR DESCRIPTION
## Motivation / Problem

Fixes #9722.

There is a very small window during world generation where `local_company` is valid but the vital windows don't exist yet. However, the rest of the code assumes that if `local_company` is valid, the vital windows exist.

## Description

Resolve this by assuring that if `local_company` is valid, the vital windows also exist.

That said, there are a gazillion other ways to resolve this. For example, by having a boolean to indicate whether terrain generation is done (and no `_generate_world` is not that boolean. It means something else). Or to make the code check if vital windows exists, before assuming they are. But all those had a much higher impact on the code base, and it is hard to validate if all possible paths are covered that way. This one was just easier.

PS: this is mostly a problem for hotkeys, as they bypass all kind of other validations.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
