### PR TITLE
Change: set smooth-scrolling on by default

### DIFF
--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -123,7 +123,7 @@ cat      = SC_BASIC
 [SDTC_BOOL]
 var      = gui.smooth_scroll
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
-def      = false
+def      = true
 str      = STR_CONFIG_SETTING_SMOOTH_SCROLLING
 strhelp  = STR_CONFIG_SETTING_SMOOTH_SCROLLING_HELPTEXT
 


### PR DESCRIPTION
## Motivation / Problem

Without smooth-scrolling it is very hard to get a feel towards which direction you "teleported" to. Additionally, moving the viewport with the arrows is a terrible experience without smooth-scrolling. For example, #8968 would be resolved by making this the default.

On the other hand, with smooth-scrolling you get a much better sense if you move the viewport to an industry or train or whatever, where abouts on the map it is from where you came from.

I think it is one of those settings that is a bit hidden from view, and that most people don't know how much better your map awareness gets when you enable it.
On JGRPP survey results we can see that 40% already have it enabled. So I am not alone in thinking that smooth-scrolling is just better for .. well .. everything.

## Description

Flip the switch, and learn everyone to be more aware where on the map they are going to.

(As always, this changes the default; it will not change your game if you played before. This only changes the new user experience).

NOTE: the smooth-scrolling experience has been improved (by a lot, if you ask me) in recent master. Please check that out before you create an opinion :)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
