### PR TITLE
Fix: smooth-scrolling large distances didn't got smoothly in one direction

### DIFF
--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1894,9 +1894,20 @@ void UpdateViewportPosition(Window *w)
 		if (delta_x != 0 || delta_y != 0) {
 			if (_settings_client.gui.smooth_scroll) {
 				int max_scroll = Map::ScaleBySize1D(512 * ZOOM_LVL_BASE);
-				/* Not at our desired position yet... */
-				w->viewport->scrollpos_x += Clamp(DivAwayFromZero(delta_x, 4), -max_scroll, max_scroll);
-				w->viewport->scrollpos_y += Clamp(DivAwayFromZero(delta_y, 4), -max_scroll, max_scroll);
+
+				int delta_x_clamped;
+				int delta_y_clamped;
+
+				if (abs(delta_x) > abs(delta_y)) {
+					delta_x_clamped = Clamp(DivAwayFromZero(delta_x, 4), -max_scroll, max_scroll);
+					delta_y_clamped = delta_y * delta_x_clamped / delta_x;
+				} else {
+					delta_y_clamped = Clamp(DivAwayFromZero(delta_y, 4), -max_scroll, max_scroll);
+					delta_x_clamped = delta_x * delta_y_clamped / delta_y;
+				}
+
+				w->viewport->scrollpos_x += delta_x_clamped;
+				w->viewport->scrollpos_y += delta_y_clamped;
 			} else {
 				w->viewport->scrollpos_x = w->viewport->dest_scrollpos_x;
 				w->viewport->scrollpos_y = w->viewport->dest_scrollpos_y;


### PR DESCRIPTION
## Motivation / Problem

Smooth-scrolling only does N tiles per tick, but this is done individually of X and Y.

In result, if you create a 64x4096 map, and scroll from one end of the other, you get something funky:

One of the axis is clamped to N, but the other doesn't, as it can reach it easily. But that means that it starts off by going in one direction, changes to another a bit later, and just before landing at the destination, it changes again. Just try it out, it is really funny to observe.

## Description

Keep the ratio between x/y the same during scrolling, so we always go in one direction.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
