### PR TITLE
Change: make smooth-scrolling based on actual time

### DIFF
--- a/src/core/math_func.hpp
+++ b/src/core/math_func.hpp
@@ -350,23 +350,6 @@ constexpr int RoundDivSU(int a, uint b)
 	}
 }
 
-/**
- * Computes (a / b) rounded away from zero.
- * @param a Numerator
- * @param b Denominator
- * @return Quotient, rounded away from zero
- */
-constexpr int DivAwayFromZero(int a, uint b)
-{
-	const int _b = static_cast<int>(b);
-	if (a > 0) {
-		return (a + _b - 1) / _b;
-	} else {
-		/* Note: Behaviour of negative numerator division is truncation toward zero. */
-		return (a - _b + 1) / _b;
-	}
-}
-
 uint32_t IntSqrt(uint32_t num);
 
 #endif /* MATH_FUNC_HPP */

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -190,7 +190,7 @@ struct SelectGameWindow : public Window {
 		this->mouse_idle_pos = _cursor.pos;
 	}
 
-	void OnRealtimeTick([[maybe_unused]] uint delta_ms) override
+	void OnRealtimeTick(uint delta_ms) override
 	{
 		/* Move the main game viewport according to intro viewport commands. */
 
@@ -252,7 +252,7 @@ struct SelectGameWindow : public Window {
 		/* Update the viewport position. */
 		mw->viewport->dest_scrollpos_x = mw->viewport->scrollpos_x = pos.x;
 		mw->viewport->dest_scrollpos_y = mw->viewport->scrollpos_y = pos.y;
-		UpdateViewportPosition(mw);
+		UpdateViewportPosition(mw, delta_ms);
 		mw->SetDirty(); // Required during panning, otherwise logo graphics disappears
 
 		/* If there is only one command, we just executed it and don't need to do any more */

--- a/src/viewport_func.h
+++ b/src/viewport_func.h
@@ -26,7 +26,7 @@ void InitializeWindowViewport(Window *w, int x, int y, int width, int height, st
 Viewport *IsPtInWindowViewport(const Window *w, int x, int y);
 Point TranslateXYToTileCoord(const Viewport *vp, int x, int y, bool clamp_to_map = true);
 Point GetTileBelowCursor();
-void UpdateViewportPosition(Window *w);
+void UpdateViewportPosition(Window *w, uint32_t delta_ms);
 
 bool MarkAllViewportsDirty(int left, int top, int right, int bottom);
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3066,7 +3066,7 @@ void UpdateWindows()
 
 	for (Window *w : Window::Iterate()) {
 		/* Update viewport only if window is not shaded. */
-		if (w->viewport != nullptr && !w->IsShaded()) UpdateViewportPosition(w);
+		if (w->viewport != nullptr && !w->IsShaded()) UpdateViewportPosition(w, delta_ms.count());
 	}
 	NetworkDrawChatMessage();
 	/* Redraw mouse cursor in case it was hidden */


### PR DESCRIPTION
## Motivation / Problem

I noticed that when smooth-scrolling is one, and rendering takes a bit of time, scrolling just took longer. This is not what I would expect, and kinda annoying to be honest. I like the smooth-scrolling, but I don't want it to get in the way of getting from A to B.

Additionally, it was balanced to take about a second to get to the destination if you scroll the full map. This feels rather excessive to me.

Fixes #11873 (could have been another PR, but I didn't feel like it)

## Description

Make max-speed of smooth-scrolling depend on actual time passed, so if a slowdown happens, scrolling just goes faster. This also demystifies the `512`: viewport isn't based on zoom-level, but has everything to do with tile-size.

Smooth movement is done by moving 1/4th every 30ms. As the time between calls can be variable, we need to find out how much distance we should travel. This is an iterative process:

```
delta_left = delta_x
N = delta_ms / 30ms
for every N: delta_left *= 0.75
```

This means that after 30ms, we are 75% away from the destination. After 60ms 75% of 75%, etc etc. So in the end, `delta_left` contains how far we are still from the destination. The distance traveled is now `delta_x - delta_left`. As the original code assumed N was always 1, this was simplified by taking 25% of `delta_x`. But 25% of `delta_x` is the same as `delta_x - 75% of delta_x`.

## Limitations

Due to rounding issues, it is very likely that when you travel long distances, one axis arrives earlier on its destination than the other. Especially when the distance traveled on one axis is a lot more than the other. So your travels will be like:

```
\
 \
  \
   \
    |
```

Which is not ideal, but also unavoidable without using floats or subpixels. It is what it is. (was already the case before this PR; just not something this PR addresses)

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
