### PR TITLE
Codechange: refactor DecodeHexText to a generic purpose ConvertHexToBytes

### DIFF
--- a/src/string.cpp
+++ b/src/string.cpp
@@ -702,6 +702,55 @@ static int ICUStringContains(const std::string_view str, const std::string_view 
 	return ci_str.find(ci_value) != CaseInsensitiveStringView::npos;
 }
 
+/**
+ * Convert a single hex-nibble to a byte.
+ *
+ * @param c The hex-nibble to convert.
+ * @return The byte the hex-nibble represents, or -1 if it is not a valid hex-nibble.
+ */
+static int ConvertHexNibbleToByte(char c)
+{
+	if (c >= '0' && c <= '9') return c - '0';
+	if (c >= 'A' && c <= 'F') return c + 10 - 'A';
+	if (c >= 'a' && c <= 'f') return c + 10 - 'a';
+	return -1;
+}
+
+/**
+ * Convert a hex-string to a byte-array, while validating it was actually hex.
+ *
+ * @param hex The hex-string to convert.
+ * @param bytes The byte-array to write the result to.
+ *
+ * @note The length of the hex-string has to be exactly twice that of the length
+ * of the byte-array, otherwise conversion will fail.
+ *
+ * @return True iff the hex-string was valid and the conversion succeeded.
+ */
+bool ConvertHexToBytes(std::string_view hex, std::span<uint8_t> bytes)
+{
+	if (bytes.size() != hex.size() / 2) {
+		return false;
+	}
+
+	/* Hex-string lengths are always divisible by 2. */
+	if (hex.size() % 2 != 0) {
+		return false;
+	}
+
+	for (size_t i = 0; i < hex.size() / 2; i++) {
+		auto hi = ConvertHexNibbleToByte(hex[i * 2]);
+		auto lo = ConvertHexNibbleToByte(hex[i * 2 + 1]);
+
+		if (hi < 0 || lo < 0) {
+			return false;
+		}
+
+		bytes[i] = (hi << 4) | lo;
+	}
+
+	return true;
+}
 
 #ifdef WITH_UNISCRIBE
 

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -39,6 +39,8 @@ void StrTrimInPlace(std::string &str);
 [[nodiscard]] bool StrNaturalContains(const std::string_view str, const std::string_view value);
 [[nodiscard]] bool StrNaturalContainsIgnoreCase(const std::string_view str, const std::string_view value);
 
+bool ConvertHexToBytes(std::string_view hex, std::span<uint8_t> bytes);
+
 /** Case insensitive comparator for strings, for example for use in std::map. */
 struct CaseInsensitiveComparator {
 	bool operator()(const std::string_view s1, const std::string_view s2) const { return StrCompareIgnoreCase(s1, s2) < 0; }

--- a/src/tests/string_func.cpp
+++ b/src/tests/string_func.cpp
@@ -342,3 +342,45 @@ TEST_CASE("FormatArrayAsHex")
 	CHECK(FormatArrayAsHex(std::array<byte, 1>{0x12}) == "12");
 	CHECK(FormatArrayAsHex(std::array<byte, 4>{0x13, 0x38, 0x42, 0xAF}) == "133842AF");
 }
+
+TEST_CASE("ConvertHexToBytes")
+{
+	CHECK(ConvertHexToBytes("", {}) == true);
+	CHECK(ConvertHexToBytes("1", {}) == false);
+	CHECK(ConvertHexToBytes("12", {}) == false);
+
+	std::array<uint8_t, 1> bytes1;
+	CHECK(ConvertHexToBytes("1", bytes1) == false);
+	CHECK(ConvertHexToBytes("12", bytes1) == true);
+	CHECK(bytes1[0] == 0x12);
+	CHECK(ConvertHexToBytes("123", bytes1) == false);
+	CHECK(ConvertHexToBytes("1g", bytes1) == false);
+	CHECK(ConvertHexToBytes("g1", bytes1) == false);
+
+	std::array<uint8_t, 2> bytes2;
+	CHECK(ConvertHexToBytes("12", bytes2) == false);
+	CHECK(ConvertHexToBytes("1234", bytes2) == true);
+	CHECK(bytes2[0] == 0x12);
+	CHECK(bytes2[1] == 0x34);
+
+	std::array<uint8_t, 8> bytes3;
+	CHECK(ConvertHexToBytes("123456789abcdef0", bytes3) == true);
+	CHECK(bytes3[0] == 0x12);
+	CHECK(bytes3[1] == 0x34);
+	CHECK(bytes3[2] == 0x56);
+	CHECK(bytes3[3] == 0x78);
+	CHECK(bytes3[4] == 0x9a);
+	CHECK(bytes3[5] == 0xbc);
+	CHECK(bytes3[6] == 0xde);
+	CHECK(bytes3[7] == 0xf0);
+
+	CHECK(ConvertHexToBytes("123456789ABCDEF0", bytes3) == true);
+	CHECK(bytes3[0] == 0x12);
+	CHECK(bytes3[1] == 0x34);
+	CHECK(bytes3[2] == 0x56);
+	CHECK(bytes3[3] == 0x78);
+	CHECK(bytes3[4] == 0x9a);
+	CHECK(bytes3[5] == 0xbc);
+	CHECK(bytes3[6] == 0xde);
+	CHECK(bytes3[7] == 0xf0);
+}


### PR DESCRIPTION
## Motivation / Problem

For another PR I needed a function that converts a hex-string to a byte sequence. We kinda had something, called DecodeHexText.

But, DecodeHexText() does more than just decoding hex. Making it impossible to reuse that.

## Description

Introducing ConvertHexToBytes(), which now only does pure hex decoding.

This required a bit of refactoring for the code using DecodeHexText(). But I think it also made the code a bit more readable, and a bit more C++. So it is an improvement.

## Limitations

This function does a lot of things in a short few lines of code. I did all kinds of testing to validate it still acts the way it should, but .. please check that it actually does :)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
