### PR TITLE
Fix d3b2a576: LOAD_HEIGHTMAP / LOAD_SCENARIO report wrong status to social plugins

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1135,7 +1135,7 @@ void SwitchToMode(SwitchMode new_mode)
 			GenerateSavegameId();
 			MarkWholeScreenDirty();
 
-			UpdateSocialIntegration(GM_NORMAL);
+			UpdateSocialIntegration(GM_EDITOR);
 			break;
 
 		case SM_LOAD_SCENARIO: { // Load scenario from scenario editor
@@ -1150,7 +1150,7 @@ void SwitchToMode(SwitchMode new_mode)
 				ShowErrorMessage(STR_JUST_RAW_STRING, INVALID_STRING_ID, WL_CRITICAL);
 			}
 
-			UpdateSocialIntegration(GM_NORMAL);
+			UpdateSocialIntegration(GM_EDITOR);
 			break;
 		}
 


### PR DESCRIPTION
## Motivation / Problem

While working on another patch, I noticed I misunderstood these two modes. They are scenario editors. Not normal games.

## Description

Fix the status for the social plugins.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
