### PR TITLE
Fix: use correct size parameter type in TileArea constructors

### DIFF
--- a/src/tilearea_type.h
+++ b/src/tilearea_type.h
@@ -26,7 +26,7 @@ struct OrthogonalTileArea {
 	 * @param w the width
 	 * @param h the height
 	 */
-	OrthogonalTileArea(TileIndex tile = INVALID_TILE, uint8_t w = 0, uint8_t h = 0) : tile(tile), w(w), h(h)
+	OrthogonalTileArea(TileIndex tile = INVALID_TILE, uint16_t w = 0, uint16_t h = 0) : tile(tile), w(w), h(h)
 	{
 	}
 
@@ -79,7 +79,7 @@ struct DiagonalTileArea {
 	 * @param a The "x" extent.
 	 * @param b The "y" estent.
 	 */
-	DiagonalTileArea(TileIndex tile = INVALID_TILE, int8_t a = 0, int8_t b = 0) : tile(tile), a(a), b(b)
+	DiagonalTileArea(TileIndex tile = INVALID_TILE, int16_t a = 0, int16_t b = 0) : tile(tile), a(a), b(b)
 	{
 	}
 


### PR DESCRIPTION
## Motivation / Problem / Description

Ran into this while looking into the different Tile Area classes. They seem to take the wrong type of size parameters in their constructors. This effectively limits their size to 255x255 upon construction and you can get strange results when the values overflow.

## Limitations

None

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
