### PR TITLE
Add: allow loading heightmaps from command-line

### DIFF
--- a/docs/openttd.6
+++ b/docs/openttd.6
@@ -13,7 +13,7 @@
 .Op Fl c Ar config_file
 .Op Fl d Op Ar level | Ar cat Ns = Ns Ar lvl Ns Op , Ns Ar ...
 .Op Fl D Oo Ar host Oc Ns Op : Ns Ar port
-.Op Fl g Op Ar savegame
+.Op Fl g Op Ar file
 .Op Fl G Ar seed
 .Op Fl I Ar graphicsset
 .Op Fl m Ar driver
@@ -62,11 +62,11 @@ Start in world editor mode.
 .It Fl f
 Fork into background (dedicated server only, see
 .Fl D ) .
-.It Fl g Op Ar savegame
+.It Fl g Op Ar file
 Load
-.Ar savegame
-at start or start a new game if omitted.
-.Ar savegame
+.Ar file
+(can be either a savegame, scenario, or heightmap) at start or start a new game if omitted.
+.Ar file
 must be either an absolute path or one relative to the current path or one of
 the search paths.
 .It Fl G Ar seed

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -447,9 +447,6 @@ std::tuple<FiosType, std::string> FiosGetSavegameListCallback(SaveLoadOperation 
 	 * .SV1 Transport Tycoon Deluxe (Patch) saved game
 	 * .SV2 Transport Tycoon Deluxe (Patch) saved 2-player game */
 
-	/* Don't crash if we supply no extension */
-	if (ext.empty()) return { FIOS_TYPE_INVALID, {} };
-
 	if (StrEqualsIgnoreCase(ext, ".sav")) {
 		return { FIOS_TYPE_FILE, GetFileTitle(file, SAVE_DIR) };
 	}
@@ -490,7 +487,7 @@ void FiosGetSavegameList(SaveLoadOperation fop, FileList &file_list)
  * @see FiosGetFileList
  * @see FiosGetScenarioList
  */
-static std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext)
+std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext)
 {
 	/* Show scenario files
 	 * .SCN OpenTTD style scenario file
@@ -530,7 +527,7 @@ void FiosGetScenarioList(SaveLoadOperation fop, FileList &file_list)
 	FiosGetFileList(fop, &FiosGetScenarioListCallback, subdir, file_list);
 }
 
-static std::tuple<FiosType, std::string> FiosGetHeightmapListCallback(SaveLoadOperation, const std::string &file, const std::string_view ext)
+std::tuple<FiosType, std::string> FiosGetHeightmapListCallback(SaveLoadOperation, const std::string &file, const std::string_view ext)
 {
 	/* Show heightmap files
 	 * .PNG PNG Based heightmap files

--- a/src/fios.h
+++ b/src/fios.h
@@ -117,6 +117,8 @@ std::string FiosMakeHeightmapName(const char *name);
 std::string FiosMakeSavegameName(const char *name);
 
 std::tuple<FiosType, std::string> FiosGetSavegameListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext);
+std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext);
+std::tuple<FiosType, std::string> FiosGetHeightmapListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext);
 
 void ScanScenarios();
 const char *FindScenario(const ContentInfo *ci, bool md5sum);

--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -103,8 +103,14 @@ static void _GenerateWorld()
 		/* Must start economy early because of the costs. */
 		StartupEconomy();
 
+		bool landscape_generated = false;
+
 		/* Don't generate landscape items when in the scenario editor. */
-		if (_gw.mode == GWM_EMPTY) {
+		if (_gw.mode != GWM_EMPTY) {
+			landscape_generated = GenerateLandscape(_gw.mode);
+		}
+
+		if (!landscape_generated) {
 			SetGeneratingWorldProgress(GWP_OBJECT, 1);
 
 			/* Make sure the tiles at the north border are void tiles if needed. */
@@ -121,7 +127,6 @@ static void _GenerateWorld()
 
 			_settings_game.game_creation.snow_line_height = DEF_SNOWLINE_HEIGHT;
 		} else {
-			GenerateLandscape(_gw.mode);
 			GenerateClearTile();
 
 			/* Only generate towns, tree and industries in newgame mode. */

--- a/src/heightmap.cpp
+++ b/src/heightmap.cpp
@@ -520,14 +520,14 @@ bool GetHeightmapDimensions(DetailedFileType dft, const char *filename, uint *x,
  * @param dft Type of image file.
  * @param filename of the heightmap file to be imported
  */
-void LoadHeightmap(DetailedFileType dft, const char *filename)
+bool LoadHeightmap(DetailedFileType dft, const char *filename)
 {
 	uint x, y;
 	byte *map = nullptr;
 
 	if (!ReadHeightMap(dft, filename, &x, &y, &map)) {
 		free(map);
-		return;
+		return false;
 	}
 
 	GrayscaleToMapHeights(x, y, map);
@@ -535,6 +535,8 @@ void LoadHeightmap(DetailedFileType dft, const char *filename)
 
 	FixSlopes();
 	MarkWholeScreenDirty();
+
+	return true;
 }
 
 /**

--- a/src/heightmap.h
+++ b/src/heightmap.h
@@ -22,7 +22,7 @@ enum HeightmapRotation {
 };
 
 bool GetHeightmapDimensions(DetailedFileType dft, const char *filename, uint *x, uint *y);
-void LoadHeightmap(DetailedFileType dft, const char *filename);
+bool LoadHeightmap(DetailedFileType dft, const char *filename);
 void FlatEmptyWorld(byte tile_height);
 void FixSlopes();
 

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1557,7 +1557,7 @@ static uint8_t CalculateDesertLine()
 	return CalculateCoverageLine(100 - _settings_game.game_creation.desert_coverage, 4);
 }
 
-void GenerateLandscape(byte mode)
+bool GenerateLandscape(byte mode)
 {
 	/** Number of steps of landscape generation */
 	enum GenLandscapeSteps {
@@ -1571,7 +1571,9 @@ void GenerateLandscape(byte mode)
 
 	if (mode == GWM_HEIGHTMAP) {
 		SetGeneratingWorldProgress(GWP_LANDSCAPE, steps + GLS_HEIGHTMAP);
-		LoadHeightmap(_file_to_saveload.detail_ftype, _file_to_saveload.name.c_str());
+		if (!LoadHeightmap(_file_to_saveload.detail_ftype, _file_to_saveload.name.c_str())) {
+			return false;
+		}
 		IncreaseGeneratingWorldProgress(GWP_LANDSCAPE);
 	} else if (_settings_game.game_creation.land_generator == LG_TERRAGENESIS) {
 		SetGeneratingWorldProgress(GWP_LANDSCAPE, steps + GLS_TERRAGENESIS);
@@ -1657,6 +1659,7 @@ void GenerateLandscape(byte mode)
 	}
 
 	CreateRivers();
+	return true;
 }
 
 void OnTick_Town();

--- a/src/landscape.h
+++ b/src/landscape.h
@@ -139,6 +139,6 @@ void DoClearSquare(TileIndex tile);
 void RunTileLoop();
 
 void InitializeLandscape();
-void GenerateLandscape(byte mode);
+bool GenerateLandscape(byte mode);
 
 #endif /* LANDSCAPE_H */

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -204,8 +204,8 @@ void VideoDriver_Dedicated::MainLoop()
 	_network_dedicated = true;
 	_current_company = _local_company = COMPANY_SPECTATOR;
 
-	/* If SwitchMode is SM_LOAD_GAME, it means that the user used the '-g' options */
-	if (_switch_mode != SM_LOAD_GAME) {
+	/* If SwitchMode is SM_LOAD_GAME / SM_START_HEIGHTMAP, it means that the user used the '-g' options */
+	if (_switch_mode != SM_LOAD_GAME && _switch_mode != SM_START_HEIGHTMAP) {
 		StartNewGameWithoutGUI(GENERATE_NEW_SEED);
 	}
 


### PR DESCRIPTION
## Motivation / Problem

The `-g` option is a bit weird. It allows loading savegames, and by a bit of luck, scenarios, but not heightmaps. And the interaction with `-e` works, but readable it is not.

Closes #11386, which does something similar.

## Description

Refactor how `-g` (and `-e`) work, and allow loading of heightmaps. This showed a few places in the code things weren't handled correctly; normally invisible, but for example loading an invalid heightmap caused all kind of trouble.

If you want to load a file from tar, you have to give the file inside the tar in order for it to work:

`<tar-file>/<dir-in-tar>/<file>.png`

With `-e` you can start the SE with savegames, scenarios, and heightmaps alike.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
