### PR TITLE
Change: rebrand Cheats as Sandbox Options

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -434,12 +434,13 @@ STR_SCENEDIT_FILE_MENU_SEPARATOR                                :
 STR_SCENEDIT_FILE_MENU_QUIT                                     :Exit
 
 # Settings menu
-###length 15
+###length 16
 STR_SETTINGS_MENU_GAME_OPTIONS                                  :Game options
 STR_SETTINGS_MENU_CONFIG_SETTINGS_TREE                          :Settings
 STR_SETTINGS_MENU_AI_SETTINGS                                   :AI settings
 STR_SETTINGS_MENU_GAMESCRIPT_SETTINGS                           :Game script settings
 STR_SETTINGS_MENU_NEWGRF_SETTINGS                               :NewGRF settings
+STR_SETTINGS_MENU_SANDBOX_OPTIONS                               :Sandbox options
 STR_SETTINGS_MENU_TRANSPARENCY_OPTIONS                          :Transparency options
 STR_SETTINGS_MENU_TOWN_NAMES_DISPLAYED                          :Town names displayed
 STR_SETTINGS_MENU_STATION_NAMES_DISPLAYED                       :Station names displayed
@@ -2224,9 +2225,7 @@ STR_HELP_WINDOW_BUGTRACKER                                      :{BLACK}Report a
 STR_HELP_WINDOW_COMMUNITY                                       :{BLACK}Community
 
 # Cheat window
-STR_CHEATS                                                      :{WHITE}Cheats
-STR_CHEATS_TOOLTIP                                              :{BLACK}Checkboxes indicate if you have used this cheat before
-STR_CHEATS_NOTE                                                 :{BLACK}Note: any usage of these settings will be recorded by the savegame
+STR_CHEATS                                                      :{WHITE}Sandbox Options
 STR_CHEAT_MONEY                                                 :{LTBLUE}Increase money by {CURRENCY_LONG}
 STR_CHEAT_CHANGE_COMPANY                                        :{LTBLUE}Playing as company: {ORANGE}{COMMA}
 STR_CHEAT_EXTRA_DYNAMITE                                        :{LTBLUE}Magic bulldozer (remove industries, unmovable objects): {ORANGE}{STRING1}

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -228,6 +228,7 @@ enum OptionMenuEntries {
 	OME_AI_SETTINGS,
 	OME_GAMESCRIPT_SETTINGS,
 	OME_NEWGRFSETTINGS,
+	ONE_SANDBOX,
 	OME_TRANSPARENCIES,
 	OME_SHOW_TOWNNAMES,
 	OME_SHOW_STATIONNAMES,
@@ -259,6 +260,9 @@ static CallBackFunction ToolbarOptionsClick(Window *w)
 		list.push_back(std::make_unique<DropDownListStringItem>(STR_SETTINGS_MENU_GAMESCRIPT_SETTINGS,  OME_GAMESCRIPT_SETTINGS, false));
 	}
 	list.push_back(std::make_unique<DropDownListStringItem>(STR_SETTINGS_MENU_NEWGRF_SETTINGS,          OME_NEWGRFSETTINGS, false));
+	if (_game_mode != GM_EDITOR) {
+		list.push_back(std::make_unique<DropDownListStringItem>(STR_SETTINGS_MENU_SANDBOX_OPTIONS,      ONE_SANDBOX, false));
+	}
 	list.push_back(std::make_unique<DropDownListStringItem>(STR_SETTINGS_MENU_TRANSPARENCY_OPTIONS,     OME_TRANSPARENCIES, false));
 	list.push_back(std::make_unique<DropDownListDividerItem>(-1, false));
 	list.push_back(std::make_unique<DropDownListCheckedItem>(HasBit(_display_opt, DO_SHOW_TOWN_NAMES), STR_SETTINGS_MENU_TOWN_NAMES_DISPLAYED, OME_SHOW_TOWNNAMES, false));
@@ -290,6 +294,7 @@ static CallBackFunction MenuClickSettings(int index)
 		case OME_AI_SETTINGS:          ShowAIConfigWindow();                            return CBF_NONE;
 		case OME_GAMESCRIPT_SETTINGS:  ShowGSConfigWindow();                            return CBF_NONE;
 		case OME_NEWGRFSETTINGS:       ShowNewGRFSettings(!_networking && _settings_client.gui.UserIsAllowedToChangeNewGRFs(), true, true, &_grfconfig); return CBF_NONE;
+		case ONE_SANDBOX:              ShowCheatWindow();                               break;
 		case OME_TRANSPARENCIES:       ShowTransparencyToolbar();                       break;
 
 		case OME_SHOW_TOWNNAMES:       ToggleBit(_display_opt, DO_SHOW_TOWN_NAMES);     break;


### PR DESCRIPTION
## Motivation / Problem

People have an emotion when they read "cheats", and are like: NOOOO, I DO NOT WANT TO USE CHEATS, but they do want to functionality it offers. Like "infinite money". Or "magic bulldozer".

I read this one too many times now to know it actually holds people back from using them, as "it is a cheat". But if you want to get more money to play the way you want to play, go nuts. Don't feel constrained because we call it "cheats".

This includes the warning at the bottom, and the "this has been used" marker on the left. Like we are punishing people for playing the way they want.

## Description

Remove the sentiment of "cheats" by rebranding it as "sandbox options".

Also remove the checkbox of "it is used" and the text that comes with it.

We do still store it in the savegame, but that has more to do for analysing bug reports; a savegame where the year has been changed has to be handled a bit differently.

![image](https://github.com/OpenTTD/OpenTTD/assets/1663690/56b4c324-e6f0-4a13-b7a4-6dc380c9aff4)

As bonus, and on popular demand, also added it to the menu (only in-game; not in SE)

![image](https://github.com/OpenTTD/OpenTTD/assets/1663690/7cdd9d7f-3db1-4ad7-b2a7-6f00ba7879fb)


## Limitations

- When you use one of these options in multiplayer, which you can't without modifying the client, you are still kicked for being a cheater. I am fine with that.
- I did not rename the internal references to "cheat", as .. we don't actually care how it is called :)
- You can have huge debates if certain options shouldn't be under settings. And some most likely do. Where others clearly don't. So the window will stay in all those scenarios, and I leave the debate about what should go where for another day. Not this PR at least.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
