### PR TITLE
Codechange: Split bit numbers from values in RailTypeFlags, RoadTypeFlags enums

### DIFF
--- a/src/rail.h
+++ b/src/rail.h
@@ -21,15 +21,18 @@
 #include "signal_type.h"
 #include "settings_type.h"
 
-/** Railtype flags. */
-enum RailTypeFlags {
+/** Railtype flag bit numbers. */
+enum RailTypeFlag {
 	RTF_CATENARY          = 0,                           ///< Bit number for drawing a catenary.
 	RTF_NO_LEVEL_CROSSING = 1,                           ///< Bit number for disallowing level crossings.
 	RTF_HIDDEN            = 2,                           ///< Bit number for hiding from selection.
 	RTF_NO_SPRITE_COMBINE = 3,                           ///< Bit number for using non-combined junctions.
 	RTF_ALLOW_90DEG       = 4,                           ///< Bit number for always allowed 90 degree turns, regardless of setting.
 	RTF_DISALLOW_90DEG    = 5,                           ///< Bit number for never allowed 90 degree turns, regardless of setting.
+};
 
+/** Railtype flags. */
+enum RailTypeFlags : uint8_t {
 	RTFB_NONE              = 0,                          ///< All flags cleared.
 	RTFB_CATENARY          = 1 << RTF_CATENARY,          ///< Value for drawing a catenary.
 	RTFB_NO_LEVEL_CROSSING = 1 << RTF_NO_LEVEL_CROSSING, ///< Value for disallowing level crossings.

--- a/src/road.h
+++ b/src/road.h
@@ -33,14 +33,17 @@ DECLARE_ENUM_AS_BIT_SET(RoadTramTypes)
 
 static const RoadTramType _roadtramtypes[] = { RTT_ROAD, RTT_TRAM };
 
-/** Roadtype flags. Starts with RO instead of R because R is used for rails */
-enum RoadTypeFlags {
+/** Roadtype flag bit numbers. Starts with RO instead of R because R is used for rails */
+enum RoadTypeFlag {
 	ROTF_CATENARY = 0,                                     ///< Bit number for adding catenary
 	ROTF_NO_LEVEL_CROSSING,                                ///< Bit number for disabling level crossing
 	ROTF_NO_HOUSES,                                        ///< Bit number for setting this roadtype as not house friendly
 	ROTF_HIDDEN,                                           ///< Bit number for hidden from construction.
 	ROTF_TOWN_BUILD,                                       ///< Bit number for allowing towns to build this roadtype.
+};
 
+/** Roadtype flags. Starts with RO instead of R because R is used for rails */
+enum RoadTypeFlags : uint8_t {
 	ROTFB_NONE = 0,                                        ///< All flags cleared.
 	ROTFB_CATENARY          = 1 << ROTF_CATENARY,          ///< Value for drawing a catenary.
 	ROTFB_NO_LEVEL_CROSSING = 1 << ROTF_NO_LEVEL_CROSSING, ///< Value for disabling a level crossing.


### PR DESCRIPTION
## Motivation / Problem

The bit numbers and bit values for road and rail type flags are not of the same logical type.
Bitwise operations need not be enabled for bit numbers.
The bit flag types should have a suitable storage specifier.

## Description

Place bit number constants into separate enum types.
Add storage specifiers for the bit value enum types.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
