### PR TITLE
Add: show in multiplayer the amount of hours a game has been unpaused

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2362,8 +2362,9 @@ STR_NETWORK_SERVER_LIST_MAP_SIZE_CAPTION                        :{BLACK}Map size
 STR_NETWORK_SERVER_LIST_MAP_SIZE_CAPTION_TOOLTIP                :{BLACK}Map size of the game{}Click to sort by area
 STR_NETWORK_SERVER_LIST_DATE_CAPTION                            :{BLACK}Date
 STR_NETWORK_SERVER_LIST_DATE_CAPTION_TOOLTIP                    :{BLACK}Current date
-STR_NETWORK_SERVER_LIST_YEARS_CAPTION                           :{BLACK}Years
-STR_NETWORK_SERVER_LIST_YEARS_CAPTION_TOOLTIP                   :{BLACK}Number of years{}the game is running
+STR_NETWORK_SERVER_LIST_PLAY_TIME_SHORT                         :{BLACK}{NUM}h {NUM}m
+STR_NETWORK_SERVER_LIST_PLAY_TIME_CAPTION                       :{BLACK}Play time
+STR_NETWORK_SERVER_LIST_PLAY_TIME_CAPTION_TOOLTIP               :{BLACK}Time played while{}game was not paused
 STR_NETWORK_SERVER_LIST_INFO_ICONS_TOOLTIP                      :{BLACK}Language, server version, etc.
 
 STR_NETWORK_SERVER_LIST_CLICK_GAME_TO_SELECT                    :{BLACK}Click a game from the list to select it
@@ -2379,6 +2380,7 @@ STR_NETWORK_SERVER_LIST_SERVER_ADDRESS                          :{SILVER}Server 
 STR_NETWORK_SERVER_LIST_INVITE_CODE                             :{SILVER}Invite code: {WHITE}{RAW_STRING}
 STR_NETWORK_SERVER_LIST_START_DATE                              :{SILVER}Start date: {WHITE}{DATE_SHORT}
 STR_NETWORK_SERVER_LIST_CURRENT_DATE                            :{SILVER}Current date: {WHITE}{DATE_SHORT}
+STR_NETWORK_SERVER_LIST_PLAY_TIME                               :{SILVER}Play time: {WHITE}{NUM}h {NUM}m
 STR_NETWORK_SERVER_LIST_GAMESCRIPT                              :{SILVER}Game Script: {WHITE}{RAW_STRING} (v{NUM})
 STR_NETWORK_SERVER_LIST_PASSWORD                                :{SILVER}Password protected!
 STR_NETWORK_SERVER_LIST_SERVER_OFFLINE                          :{SILVER}SERVER OFFLINE

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -46,7 +46,7 @@ static const uint16_t TCP_MTU                         = 32767;          ///< Num
 static const uint16_t COMPAT_MTU                      = 1460;           ///< Number of bytes we can pack in a single packet for backward compatibility
 
 static const byte NETWORK_GAME_ADMIN_VERSION        =    3;           ///< What version of the admin network do we use?
-static const byte NETWORK_GAME_INFO_VERSION         =    6;           ///< What version of game-info do we use?
+static const byte NETWORK_GAME_INFO_VERSION         =    7;           ///< What version of game-info do we use?
 static const byte NETWORK_COORDINATOR_VERSION       =    6;           ///< What version of game-coordinator-protocol do we use?
 static const byte NETWORK_SURVEY_VERSION            =    1;           ///< What version of the survey do we use?
 

--- a/src/network/core/network_game_info.h
+++ b/src/network/core/network_game_info.h
@@ -16,6 +16,7 @@
 #include "core.h"
 #include "../../newgrf_config.h"
 #include "../../timer/timer_game_calendar.h"
+#include "../../timer/timer_game_tick.h"
 
 #include <unordered_map>
 
@@ -26,6 +27,8 @@
  *
  * Version: Bytes:  Description:
  *   all      1       the version of this packet's structure
+ *
+ *   7+       8       amount of ticks this game has been running unpaused.
  *
  *   6+       1       type of storage for the NewGRFs below:
  *                      0 = NewGRF ID and MD5 checksum.
@@ -54,8 +57,8 @@
  *                     - 4 byte lookup table index.
  *                       For v6+ in case of type 2.
  *
- *   3+       4       current game date in days since 1-1-0 (DMY)
- *   3+       4       game introduction date in days since 1-1-0 (DMY)
+ *   3+       4       current calendar date in days since 1-1-0 (DMY)
+ *   3+       4       calendar start date in days since 1-1-0 (DMY)
  *
  *   2+       1       maximum number of companies allowed on the server
  *   2+       1       number of companies on the server
@@ -92,8 +95,9 @@ enum NewGRFSerializationType {
  */
 struct NetworkServerGameInfo {
 	GRFConfig *grfconfig;        ///< List of NewGRF files used
-	TimerGameCalendar::Date start_date; ///< When the game started
-	TimerGameCalendar::Date game_date;  ///< Current date
+	TimerGameCalendar::Date calendar_start; ///< When the game started.
+	TimerGameCalendar::Date calendar_date; ///< Current calendar date.
+	TimerGameTick::TickCounter ticks_playing; ///< Amount of ticks the game has been running unpaused.
 	uint16_t map_width;            ///< Map width
 	uint16_t map_height;           ///< Map height
 	std::string server_name;     ///< Server name


### PR DESCRIPTION
## Motivation / Problem

@2TallTyler made it so the calendar can freeze in time. Problematic. As we show that date on our website and in-game when you look at a server.

So time to solve that!

## Description

Send to all clients the amount of ticks a game has been played. From this, real-time can be deduced. And this is shown, in hours, in the in-game multiplayer list (and soon on the website; but that is not for this PR to fix :P ).

Also, renamed `game_date` to `calendar_date`, to avoid confusion later on.

![image](https://github.com/OpenTTD/OpenTTD/assets/1663690/825ba9cf-4c42-451a-a587-b66b0044a44e)
![image](https://github.com/OpenTTD/OpenTTD/assets/1663690/ba82d599-0cba-4461-80c1-182497490945)

## Limitations

- "recently" we changed how long a tick takes, so calculated the real-time can be off for older servers.
- This only counts the time a server was not paused. Which can be a good or bad thing, depending whether "build-when-paused" is enabled or not ;)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
