### PR TITLE
Fix #10405, a3dd750: [Script] Test engine and vehicle type validity for ScriptGroup::GetNumEngines

### DIFF
--- a/src/script/api/script_group.cpp
+++ b/src/script/api/script_group.cpp
@@ -111,7 +111,10 @@
 /* static */ SQInteger ScriptGroup::GetNumEngines(GroupID group_id, EngineID engine_id)
 {
 	EnforceCompanyModeValid(-1);
-	if (!IsValidGroup(group_id) && group_id != GROUP_DEFAULT && group_id != GROUP_ALL) return -1;
+	if (!ScriptEngine::IsValidEngine(engine_id)) return -1;
+	bool valid_group = IsValidGroup(group_id);
+	if (!valid_group && group_id != GROUP_DEFAULT && group_id != GROUP_ALL) return -1;
+	if (valid_group && ScriptEngine::GetVehicleType(engine_id) != GetVehicleType(group_id)) return -1;
 
 	return GetGroupNumEngines(ScriptObject::GetCompany(), group_id, engine_id);
 }

--- a/src/script/api/script_group.hpp
+++ b/src/script/api/script_group.hpp
@@ -128,7 +128,9 @@ public:
 	 * Get the number of engines in a given group.
 	 * @param group_id The group to get the number of engines in.
 	 * @param engine_id The engine id to count.
-	 * @pre IsValidGroup(group_id) || group_id == GROUP_ALL || group_id == GROUP_DEFAULT.
+	 * @pre ScriptEngine::IsValidEngine(engine_id).
+	 * @pre (IsValidGroup(group_id) && ScriptEngine::GetVehicleType(engine_id) == GetVehicleType(group_id)) ||
+	     group_id == GROUP_ALL || group_id == GROUP_DEFAULT.
 	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return The number of engines with id engine_id in the group with id group_id.
 	 */


### PR DESCRIPTION
## Motivation / Problem
Fix #10405 
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
This fixes a crash that would occur if GetNumEngines was passed an invalid engine or an engine of a different vehicle type of that of the group.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
