### PR TITLE
Fix: TextfileWindow called virtual methods before constructor completed.

### DIFF
--- a/src/help_gui.cpp
+++ b/src/help_gui.cpp
@@ -59,6 +59,8 @@ static std::optional<std::string> FindGameManualFilePath(std::string_view filena
 struct GameManualTextfileWindow : public TextfileWindow {
 	GameManualTextfileWindow(std::string_view filename) : TextfileWindow(TFT_GAME_MANUAL)
 	{
+		this->ConstructWindow();
+
 		/* Mark the content of these files as trusted. */
 		this->trusted = true;
 

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -43,6 +43,8 @@ struct ContentTextfileWindow : public TextfileWindow {
 
 	ContentTextfileWindow(TextfileType file_type, const ContentInfo *ci) : TextfileWindow(file_type), ci(ci)
 	{
+		this->ConstructWindow();
+
 		auto textfile = this->ci->GetTextfile(file_type);
 		this->LoadTextfile(textfile.value(), GetContentInfoSubDir(this->ci->type));
 	}

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -560,6 +560,8 @@ struct NewGRFTextfileWindow : public TextfileWindow {
 
 	NewGRFTextfileWindow(TextfileType file_type, const GRFConfig *c) : TextfileWindow(file_type), grf_config(c)
 	{
+		this->ConstructWindow();
+
 		auto textfile = this->grf_config->GetTextfile(file_type);
 		this->LoadTextfile(textfile.value(), NEWGRF_DIR);
 	}

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -631,6 +631,7 @@ struct ScriptTextfileWindow : public TextfileWindow {
 
 	ScriptTextfileWindow(TextfileType file_type, CompanyID slot) : TextfileWindow(file_type), slot(slot)
 	{
+		this->ConstructWindow();
 		this->OnInvalidateData();
 	}
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -97,6 +97,8 @@ struct BaseSetTextfileWindow : public TextfileWindow {
 
 	BaseSetTextfileWindow(TextfileType file_type, const TBaseSet *baseset, StringID content_type) : TextfileWindow(file_type), baseset(baseset), content_type(content_type)
 	{
+		this->ConstructWindow();
+
 		auto textfile = this->baseset->GetTextfile(file_type);
 		this->LoadTextfile(textfile.value(), BASESET_DIR);
 	}

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -83,12 +83,18 @@ static WindowDesc _textfile_desc(__FILE__, __LINE__,
 
 TextfileWindow::TextfileWindow(TextfileType file_type) : Window(&_textfile_desc), file_type(file_type)
 {
+	/* Init of nested tree is deferred.
+	 * TextfileWindow::ConstructWindow must be called by the inheriting window. */
+}
+
+void TextfileWindow::ConstructWindow()
+{
 	this->CreateNestedTree();
 	this->vscroll = this->GetScrollbar(WID_TF_VSCROLLBAR);
 	this->hscroll = this->GetScrollbar(WID_TF_HSCROLLBAR);
-	this->GetWidget<NWidgetCore>(WID_TF_CAPTION)->SetDataTip(STR_TEXTFILE_README_CAPTION + file_type, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS);
+	this->GetWidget<NWidgetCore>(WID_TF_CAPTION)->SetDataTip(STR_TEXTFILE_README_CAPTION + this->file_type, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS);
 	this->GetWidget<NWidgetStacked>(WID_TF_SEL_JUMPLIST)->SetDisplayedPlane(SZSP_HORIZONTAL);
-	this->FinishInitNested(file_type);
+	this->FinishInitNested(this->file_type);
 
 	this->DisableWidget(WID_TF_NAVBACK);
 	this->DisableWidget(WID_TF_NAVFORWARD);

--- a/src/textfile_gui.h
+++ b/src/textfile_gui.h
@@ -23,8 +23,6 @@ struct TextfileWindow : public Window, MissingGlyphSearcher {
 	Scrollbar *vscroll;              ///< Vertical scrollbar.
 	Scrollbar *hscroll;              ///< Horizontal scrollbar.
 
-	TextfileWindow(TextfileType file_type);
-
 	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override;
 	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override;
 	void DrawWidget(const Rect &r, WidgetID widget) const override;
@@ -42,6 +40,9 @@ struct TextfileWindow : public Window, MissingGlyphSearcher {
 	virtual void LoadTextfile(const std::string &textfile, Subdirectory dir);
 
 protected:
+	TextfileWindow(TextfileType file_type);
+	void ConstructWindow();
+
 	struct Line {
 		int top{0};                  ///< Top scroll position in visual lines.
 		int bottom{0};               ///< Bottom scroll position in visual lines.


### PR DESCRIPTION
## Motivation / Problem

SetStringParameters() was called during widget tree init in the constructor.

Calls within a constructor cannot call the derived classes methods. This would result in invalid data being passed to the string system, which could then crash.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This is fixed by requiring classes derived from `TextfileWindow` to initialise the widget tree in their own constructor by calling `TextfileWindow::ConstructWindow()`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
