### PR TITLE
Fix 62d7d92a: [CI] tibdex/github-app-token's syntax changed with v2

### DIFF
--- a/.github/workflows/upload-cdn.yml
+++ b/.github/workflows/upload-cdn.yml
@@ -126,8 +126,8 @@ jobs:
       with:
         app_id: ${{ secrets.DEPLOYMENT_APP_ID }}
         private_key: ${{ secrets.DEPLOYMENT_APP_PRIVATE_KEY }}
-        repositories: >-
-          ["OpenTTD/workflows"]
+        installation_retrieval_mode: "repository"
+        installation_retrieval_payload: "OpenTTD/workflows"
 
     - name: Trigger 'Publish Docs'
       uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
## Motivation / Problem

What to change when upgrade tibdex/github-app-token from v1 to v2 weren't all that clear.

We only read: `repository` is gone, `repositories` exist: done!

But no.

## Description

Properly read the documentation and properly upgrade the action. Tested this time.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
