### PR TITLE
Fix: Memory leak in ICUParagraphLayout::NextLine()

### DIFF
--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -335,6 +335,16 @@ Font *Layouter::GetFont(FontSize size, TextColour colour)
 }
 
 /**
+ * Perform initialization of layout engine.
+ */
+void Layouter::Initialize()
+{
+#if defined(WITH_ICU_I18N) && defined(WITH_HARFBUZZ)
+	ICUParagraphLayoutFactory::InitializeLayouter();
+#endif /* WITH_ICU_I18N && WITH_HARFBUZZ */
+}
+
+/**
  * Reset cached font information.
  * @param size Font size to reset.
  */

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -179,6 +179,7 @@ public:
 	Point GetCharPosition(std::string_view::const_iterator ch) const;
 	ptrdiff_t GetCharAtPosition(int x, size_t line_index) const;
 
+	static void Initialize();
 	static void ResetFontCache(FontSize size);
 	static void ResetLineCache();
 	static void ReduceLineCache();

--- a/src/gfx_layout_icu.h
+++ b/src/gfx_layout_icu.h
@@ -12,6 +12,7 @@
 
 #include "gfx_layout.h"
 
+#include <unicode/brkiter.h>
 #include <unicode/ustring.h>
 
 /**
@@ -26,6 +27,11 @@ public:
 
 	static ParagraphLayouter *GetParagraphLayout(UChar *buff, UChar *buff_end, FontMap &fontMapping);
 	static size_t AppendToBuffer(UChar *buff, const UChar *buffer_last, char32_t c);
+
+	static void InitializeLayouter();
+	static std::unique_ptr<icu::BreakIterator> GetBreakIterator();
+private:
+	static std::unique_ptr<icu::BreakIterator> break_iterator;
 };
 
 #endif /* GFX_LAYOUT_ICU_H */

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -37,6 +37,7 @@
 #include "network/network_content_gui.h"
 #include "newgrf_engine.h"
 #include "core/backup_type.hpp"
+#include "gfx_layout.h"
 #include <stack>
 #include <charconv>
 
@@ -1975,6 +1976,8 @@ bool ReadLanguagePack(const LanguageMetadata *lang)
 		_current_collator.reset();
 	}
 #endif /* WITH_ICU_I18N */
+
+	Layouter::Initialize();
 
 	/* Some lists need to be sorted again after a language change. */
 	ReconsiderGameScriptLanguage();


### PR DESCRIPTION
## Motivation / Problem

The function `ICUParagraphLayout::NextLine()` calls `icu::BreakIterator::createLineInstance()` but does not clean up after it, resulting in a memory leak whenever lines have to be wrapped.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

While the BreakIterator instance could be deleted every time after use, and doing so would mostly match current behaviour and be simpler, that has potential performance considerations as the line break rules need to be loaded each time.

Instead implement a static instance that is `clone()`d (for thread-safety) and then auto-deleted as necessary.

This uses `std::unique_ptr`s so that we don't need to manage clearing up afterwards.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
