### PR TITLE
Change: Limit scheduled window invalidation events to just one.

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3121,7 +3121,9 @@ void Window::InvalidateData(int data, bool gui_scope)
 	this->SetDirty();
 	if (!gui_scope) {
 		/* Schedule GUI-scope invalidation for next redraw. */
-		this->scheduled_invalidation_data.push_back(data);
+		if (std::find(std::begin(this->scheduled_invalidation_data), std::end(this->scheduled_invalidation_data), data) == std::end(this->scheduled_invalidation_data)) {
+			this->scheduled_invalidation_data.push_back(data);
+		}
 	}
 	this->OnInvalidateData(data, gui_scope);
 }


### PR DESCRIPTION
## Motivation / Problem

Stacking up window invalidation events does not serve much use as in all cases the data passed is the same.

When processing the events, it would then invalidate windows multiple times for no reason.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, store the intended invalidation data in a `std::optional`. Windows are now only invalidated once even if multiple scheduled invalidations occur. The last data value passed is the value used for invalidating.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

The `std::vector` queue probably had an intended purpose at some point but given all invalidations using it use the same data it seemed pointless to keep it around.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
