### PR TITLE
Fix fd9e72a7: actually use the parameter value instead of the current date

### DIFF
--- a/src/timer/timer_game_economy.cpp
+++ b/src/timer/timer_game_economy.cpp
@@ -50,9 +50,9 @@ TimerGameEconomy::DateFract TimerGameEconomy::date_fract = {};
 
 	/* If we're using wallclock units, economy months have 30 days and an economy year has 360 days. */
 	TimerGameEconomy::YearMonthDay ymd;
-	ymd.year = TimerGameEconomy::date.base() / EconomyTime::DAYS_IN_ECONOMY_YEAR;
-	ymd.month = (TimerGameEconomy::date.base() % EconomyTime::DAYS_IN_ECONOMY_YEAR) / EconomyTime::DAYS_IN_ECONOMY_MONTH;
-	ymd.day = TimerGameEconomy::date.base() % EconomyTime::DAYS_IN_ECONOMY_MONTH;
+	ymd.year = date.base() / EconomyTime::DAYS_IN_ECONOMY_YEAR;
+	ymd.month = (date.base() % EconomyTime::DAYS_IN_ECONOMY_YEAR) / EconomyTime::DAYS_IN_ECONOMY_MONTH;
+	ymd.day = date.base() % EconomyTime::DAYS_IN_ECONOMY_MONTH;
 	return ymd;
 }
 


### PR DESCRIPTION
## Motivation / Problem

Fixes #11890.

## Description

@2TallTyler was being a bit silly, and I didn't see it during review :)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
