### PR TITLE
Codechange: Simplify SetBitIterator

### DIFF
--- a/src/core/bitmath_func.hpp
+++ b/src/core/bitmath_func.hpp
@@ -294,7 +294,7 @@ struct SetBitIterator {
 
 		bool operator==(const Iterator &other) const
 		{
-			return this->bitset == other.bitset && (this->bitset == 0 || this->bitpos == other.bitpos);
+			return this->bitset == other.bitset;
 		}
 		bool operator!=(const Iterator &other) const { return !(*this == other); }
 		Tbitpos operator*() const { return this->bitpos; }
@@ -305,12 +305,14 @@ struct SetBitIterator {
 		Tbitpos bitpos;
 		void Validate()
 		{
-			while (this->bitset != 0 && (this->bitset & 1) == 0) this->Next();
+			if (this->bitset != 0) {
+				typename std::make_unsigned<Tbitset>::type unsigned_value = this->bitset;
+				this->bitpos = static_cast<Tbitpos>(FindFirstBit(unsigned_value));
+			}
 		}
 		void Next()
 		{
-			this->bitset = static_cast<Tbitset>(this->bitset >> 1);
-			this->bitpos++;
+			this->bitset = KillFirstBit(this->bitset);
 		}
 	};
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_test_files(
+    bitmath_func.cpp
     landscape_partial_pixel_z.cpp
     math_func.cpp
     mock_environment.h

--- a/src/tests/bitmath_func.cpp
+++ b/src/tests/bitmath_func.cpp
@@ -1,0 +1,33 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file bitmath_func.cpp Test functionality from core/bitmath_func. */
+
+#include "../stdafx.h"
+
+#include "../3rdparty/catch2/catch.hpp"
+
+#include "../core/bitmath_func.hpp"
+
+TEST_CASE("SetBitIterator tests")
+{
+	auto test_case = [&](auto input, std::initializer_list<uint> expected) {
+		auto iter = expected.begin();
+		for (auto bit : SetBitIterator(input)) {
+			if (iter == expected.end()) return false;
+			if (bit != *iter) return false;
+			++iter;
+		}
+		return iter == expected.end();
+	};
+	CHECK(test_case(0, {}));
+	CHECK(test_case(1, { 0 }));
+	CHECK(test_case(42, { 1, 3, 5 }));
+	CHECK(test_case(0x8080FFFFU, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 23, 31 }));
+	CHECK(test_case(INT32_MIN, { 31 }));
+	CHECK(test_case(INT64_MIN, { 63 }));
+}


### PR DESCRIPTION
## Motivation / Problem

SetBitIterator can be simplified/improved now that C++20 bit operations are available.

## Description

Use FindFirstBit/KillFirstBit for bit iteration, such that the number of iterations is the number of set bits, not total bits.
This also allows the iterator operator== to be a simple comparison without branches/special cases.
Add some simple tests to inspire confidence.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
