### PR TITLE
Fix #11894: Defer window OnResize event to avoid processing multiple times per input tick.

### DIFF
--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -274,6 +274,7 @@ protected:
 	virtual void FindWindowPlacementAndResize(int def_width, int def_height);
 
 	std::vector<int> scheduled_invalidation_data;  ///< Data of scheduled OnInvalidateData() calls.
+	bool scheduled_resize; ///< Set if window has been resized.
 
 	/* Protected to prevent deletion anywhere outside Window::DeleteClosedWindows(). */
 	virtual ~Window();
@@ -559,6 +560,8 @@ public:
 
 	void SetShaded(bool make_shaded);
 
+	void ScheduleResize();
+	void ProcessScheduledResize();
 	void InvalidateData(int data = 0, bool gui_scope = true);
 	void ProcessScheduledInvalidations();
 	void ProcessHighlightedInvalidations();


### PR DESCRIPTION
## Motivation / Problem

As per #11894, multiple input events can be processed in a single input tick. This can lead on to multiple resize events triggering, causing window reflows, invalidations, etc which, part from the last one, are redundant. Sometimes these events can be quite expensive, e.g. reflowing wrapped text with ICU.

Additionally, because these events are processed in the VideoDriver loop, they don't even appear in the framerate/performance monitor.

A screencast attached to #11894 shows the issue.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, defer all OnResize() events from the input tick and instead handle them in UpdateWindows(), similar to deferred window invalidations. This means that an OnResize() event is only performed once put window tick, and only with the current state of the window, no intermediate unnecessary states.

If OnResize() triggers another OnResize() event, this is handled immediately.

Because this is handled in the window tick, this will now show up in the framerate/performance monitor (although it falls under "Graphics rendering").

[Screencast from 2024-01-27 18-04-56.webm](https://github.com/OpenTTD/OpenTTD/assets/639850/549c0ff4-6940-467a-bd19-550c01e0c2cf)


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
