### PR TITLE
Fix #11889: ConstructWindow not called from SurveyResultTextfileWindow constructor

### DIFF
--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -2568,6 +2568,8 @@ struct SurveyResultTextfileWindow : public TextfileWindow {
 
 	SurveyResultTextfileWindow(TextfileType file_type) : TextfileWindow(file_type)
 	{
+		this->ConstructWindow();
+
 		auto result = _survey.CreatePayload(NetworkSurveyHandler::Reason::PREVIEW, true);
 		this->LoadText(result);
 		this->InvalidateData();


### PR DESCRIPTION
## Motivation / Problem

Fix the crash when opening the survey preview window since #11889.

## Description

Add missing call to ConstructWindow.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
