### PR TITLE
Fix: Extra refit button when train/RV is in a depot

### DIFF
--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -778,9 +778,6 @@ public:
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_O_SCROLLBAR);
 		this->FinishInitNested(v->index);
-		if (v->owner == _local_company) {
-			this->DisableWidget(WID_O_EMPTY);
-		}
 
 		this->selected_order = -1;
 		this->order_over = INVALID_VEH_ORDER_ID;
@@ -1600,8 +1597,7 @@ static constexpr NWidgetPart _nested_orders_train_widgets[] = {
 															SetDataTip(STR_ORDER_SERVICE, STR_ORDER_SERVICE_TOOLTIP), SetResize(1, 0),
 				EndContainer(),
 				NWidget(NWID_SELECTION, INVALID_COLOUR, WID_O_SEL_TOP_RIGHT),
-					NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_O_EMPTY), SetMinimalSize(93, 12), SetFill(1, 0),
-															SetDataTip(STR_ORDER_REFIT, STR_ORDER_REFIT_TOOLTIP), SetResize(1, 0),
+					NWidget(WWT_PANEL, COLOUR_GREY), SetMinimalSize(93, 12), SetFill(1, 0), SetResize(1, 0), EndContainer(),
 					NWidget(NWID_BUTTON_DROPDOWN, COLOUR_GREY, WID_O_REFIT_DROPDOWN), SetMinimalSize(93, 12), SetFill(1, 0),
 															SetDataTip(STR_ORDER_REFIT_AUTO, STR_ORDER_REFIT_AUTO_TOOLTIP), SetResize(1, 0),
 				EndContainer(),

--- a/src/widgets/order_widget.h
+++ b/src/widgets/order_widget.h
@@ -25,7 +25,6 @@ enum OrderWidgets : WidgetID {
 	WID_O_UNLOAD,                    ///< Select unload.
 	WID_O_REFIT,                     ///< Select refit.
 	WID_O_SERVICE,                   ///< Select service (at depot).
-	WID_O_EMPTY,                     ///< Placeholder for refit dropdown when not owner.
 	WID_O_REFIT_DROPDOWN,            ///< Open refit options.
 	WID_O_COND_VARIABLE,             ///< Choose condition variable.
 	WID_O_COND_COMPARATOR,           ///< Choose condition type.


### PR DESCRIPTION
## Motivation / Problem

![refit](https://github.com/OpenTTD/OpenTTD/assets/55058389/5117041f-d063-46e5-92a8-6ce38a61b1e3)

When a train or road vehicle is stopped in a depot, there are two refit buttons. Only one works. Why?

## Description

The disabled button is a placeholder for the dropdown that appears when a station is highlighted. It's called `WID_O_EMPTY` and is a wonderful exploration into vestigial code. It's documented as a placeholder to be used when looking at other companies' orders -- but if you try that, you'll see that none of the buttons are shown in this case.

The widget selection code indicates what is supposed to be here:

```
DP_RIGHT_EMPTY     = 0, ///< Display an empty panel in the right button of the top row of the train/rv order window.
```

Let's do that instead.

![empty_box](https://github.com/OpenTTD/OpenTTD/assets/55058389/94246d8a-b261-4289-a75b-9775e184f71b)

## Limitations

It would be cleaner to show a three-column layout instead. But the widget code for the orders window is a nightmare and refactoring it is a much bigger project.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
