### PR TITLE
Codechange: ignore duplicate script messages in regression output

### DIFF
--- a/cmake/scripts/Regression.cmake
+++ b/cmake/scripts/Regression.cmake
@@ -68,6 +68,11 @@ string(REPLACE "\n[P] " "\n" REGRESSION_RESULT "${REGRESSION_RESULT}")
 string(REPLACE "\n[S] " "\n" REGRESSION_RESULT "${REGRESSION_RESULT}")
 string(REGEX REPLACE "dbg: ([^\n]*)\n?" "" REGRESSION_RESULT "${REGRESSION_RESULT}")
 
+# Remove duplicate script info
+string(REGEX REPLACE "ERROR: Registering([^\n]*)\n?" "" REGRESSION_RESULT "${REGRESSION_RESULT}")
+string(REGEX REPLACE "ERROR:   [12]([^\n]*)\n?" "" REGRESSION_RESULT "${REGRESSION_RESULT}")
+string(REGEX REPLACE "ERROR: The first([^\n]*)\n?" "" REGRESSION_RESULT "${REGRESSION_RESULT}")
+
 # Read the expected result
 file(READ ai/${REGRESSION_TEST}/result.txt REGRESSION_EXPECTED)
 


### PR DESCRIPTION
## Motivation / Problem
Since [#11855](https://github.com/OpenTTD/OpenTTD/issues/11855) I can't run the regression locally because
```
ERROR: Registering two scripts with the same name and version
ERROR:   1: 41444d4c-admiralai-25.tar/admiralai-25/main.nut
ERROR:   2: admiralai-25.tar/admiralai-25/main.nut
ERROR: The first is taking precedence.
... 41 more duplicates ...
ERROR: Registering two scripts with the same name and version
ERROR:   1: 5350524c-superlib-6.tar/superlib-6/main.nut
ERROR:   2: superlib-6.tar/superlib-6/main.nut
ERROR: The first is taking precedence.
```
And no I don't want to dig into my files to remove the duplicates ;) (mostly because some may come back).
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Filter out these lines from the regression output.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
