### PR TITLE
Fix: Use alternate timekeeping units in savegame title

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -5710,8 +5710,9 @@ STR_UNKNOWN_STATION                                             :unknown station
 STR_DEFAULT_SIGN_NAME                                           :Sign
 STR_COMPANY_SOMEONE                                             :someone
 
-STR_SAVEGAME_NAME_DEFAULT                                       :{COMPANY}, {STRING1}
-STR_SAVEGAME_NAME_SPECTATOR                                     :Spectator, {1:STRING1}
+STR_SAVEGAME_DURATION_REALTIME                                  :{NUM}h {NUM}m
+STR_SAVEGAME_NAME_DEFAULT                                       :{COMPANY}, {STRING2}
+STR_SAVEGAME_NAME_SPECTATOR                                     :Spectator, {1:STRING2}
 
 # Viewport strings
 STR_VIEWPORT_TOWN_POP                                           :{WHITE}{TOWN} ({COMMA})


### PR DESCRIPTION
## Motivation / Problem

When creating file names for savegames, OpenTTD includes the current date. This allows players to easily keep multiple saves of the same game ~~for save-scumming of local authority bribes~~.

Now that we can slow or freeze the passage of calendar time, the date is no longer suitable for keeping save file names unique.

## Description

There are a few parts to this.

* When creating regular saves in Calendar timekeeping mode, the economy date follows the calendar date perfectly. We can use the economy date for consistency, but players will not see a difference from how this has always worked.
* In Wallclock timekeeping mode, the economy "year" is displayed as a period, but the months and days that make that up are nonsensical. Instead, we use hours and minutes, as in #11886.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
