### PR TITLE
Fix #8253: don't use INVALID_DATAPOINT for a valid value

### DIFF
--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -615,7 +615,13 @@ public:
 			if (c != nullptr) {
 				this->colours[numd] = _colour_gradient[c->colour][6];
 				for (int j = this->num_on_x_axis, i = 0; --j >= 0;) {
-					this->cost[numd][i] = (j >= c->num_valid_stat_ent) ? INVALID_DATAPOINT : GetGraphData(c, j);
+					if (j >= c->num_valid_stat_ent) {
+						this->cost[numd][i] = INVALID_DATAPOINT;
+					} else {
+						/* Ensure we never assign INVALID_DATAPOINT, as that has another meaning.
+						 * Instead, use the value just under it. Hopefully nobody will notice. */
+						this->cost[numd][i] = std::min(GetGraphData(c, j), INVALID_DATAPOINT - 1);
+					}
 					i++;
 				}
 			}


### PR DESCRIPTION
## Motivation / Problem

Fixes bug 1 out of 2 from #8253.

`INVALID_DATAPOINT` is used to notify the graph drawing there wasn't an actual point. But .. that is just `INT64_MAX - 1`. So whenever a company became REALLY REALLY REALLY rich, it started to introduce `INVALID_DATAPOINT` to the graph, while it was an actual value.

## Description

Cheat a bit, and whenever we want to assign `INVALID_DATAPOINT` when it is an actual datapoint, assign `INVALID_DATAPOINT - 1`. It is not exactly correct, but if you worry that the graph doesn't show `9223372036854775807` but `9223372036854775806`, you might want to see a doctor :D

Alternatively, we could make `this->cost` an `std::optional<Money>`, which would be more correct as in: the full range of money can be assigned. But that would add a whopping 10KB of RAM for something that is very very rare to happen in actual games :) So this "hack" felt more appropriate :)


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
