### PR TITLE
Change: only open story-book in center when a GS does it

### DIFF
--- a/src/gui.h
+++ b/src/gui.h
@@ -65,7 +65,7 @@ void ShowGoalsList(CompanyID company);
 void ShowGoalQuestion(uint16_t id, byte type, uint32_t button_mask, const std::string &question);
 
 /* story_gui.cpp */
-void ShowStoryBook(CompanyID company, uint16_t page_id = INVALID_STORY_PAGE);
+void ShowStoryBook(CompanyID company, uint16_t page_id = INVALID_STORY_PAGE, bool centered = false);
 
 /* viewport_gui.cpp */
 void ShowExtraViewportWindow(TileIndex tile = INVALID_TILE);

--- a/src/story.cpp
+++ b/src/story.cpp
@@ -368,7 +368,7 @@ CommandCost CmdShowStoryPage(DoCommandFlag flags, StoryPageID page_id)
 
 	if (flags & DC_EXEC) {
 		StoryPage *g = StoryPage::Get(page_id);
-		if ((g->company != INVALID_COMPANY && g->company == _local_company) || (g->company == INVALID_COMPANY && Company::IsValidID(_local_company))) ShowStoryBook(_local_company, page_id);
+		if ((g->company != INVALID_COMPANY && g->company == _local_company) || (g->company == INVALID_COMPANY && Company::IsValidID(_local_company))) ShowStoryBook(_local_company, page_id, true);
 	}
 
 	return CommandCost();

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -969,7 +969,14 @@ static constexpr NWidgetPart _nested_story_book_widgets[] = {
 };
 
 static WindowDesc _story_book_desc(__FILE__, __LINE__,
-	WDP_CENTER, "view_story", 400, 300,
+	WDP_AUTO, "view_story", 400, 300,
+	WC_STORY_BOOK, WC_NONE,
+	0,
+	std::begin(_nested_story_book_widgets), std::end(_nested_story_book_widgets)
+);
+
+static WindowDesc _story_book_gs_desc(__FILE__, __LINE__,
+	WDP_CENTER, "view_story_gs", 400, 300,
 	WC_STORY_BOOK, WC_NONE,
 	0,
 	std::begin(_nested_story_book_widgets), std::end(_nested_story_book_widgets)
@@ -1041,11 +1048,12 @@ static CursorID TranslateStoryPageButtonCursor(StoryPageButtonCursor cursor)
  * Raise or create the story book window for \a company, at page \a page_id.
  * @param company 'Owner' of the story book, may be #INVALID_COMPANY.
  * @param page_id Page to open, may be #INVALID_STORY_PAGE.
+ * @param centered Whether to open the window centered.
  */
-void ShowStoryBook(CompanyID company, uint16_t page_id)
+void ShowStoryBook(CompanyID company, uint16_t page_id, bool centered)
 {
 	if (!Company::IsValidID(company)) company = (CompanyID)INVALID_COMPANY;
 
-	StoryBookWindow *w = AllocateWindowDescFront<StoryBookWindow>(&_story_book_desc, company, true);
+	StoryBookWindow *w = AllocateWindowDescFront<StoryBookWindow>(centered ? &_story_book_gs_desc : &_story_book_desc, company, true);
 	if (page_id != INVALID_STORY_PAGE) w->SetSelectedPage(page_id);
 }


### PR DESCRIPTION
## Motivation / Problem

Fixes #9030.

As mentioned in that ticket, it really annoys me that the story book opens in the center of the screen. Like it is feeling really important, more so than other windows (the audacity!). But worst of all: if you open two of them, they are flat on top of each other, and no way to see that is the case. I consider this bad UX.

There are other windows that open in the center, but they are all windows that require attention. Editbox, engine preview, ... Opening the story book from the menu doesn't require more attention than opening the finance window. Or the Company window. I mean .. it is just a window! /me ends rant here.

The only reason I can understand that opening in the center would be useful, is when it is done from a GS, as it requires attention. 

## Description

By default, open the story book like any other window, somewhere where there is space.

The only exception: when it is opened via the `CmdShowStoryPage`, which GS uses to open a story page.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
