### PR TITLE
Add: {CURRENCY_SHORT} only did k / m suffix. Add bn / tn and make translatable.

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -5799,6 +5799,11 @@ STR_TOWN_NAME                                                   :{TOWN}
 STR_VEHICLE_NAME                                                :{VEHICLE}
 STR_WAYPOINT_NAME                                               :{WAYPOINT}
 
+STR_CURRENCY_SHORT_KILO                                         :{NBSP}k
+STR_CURRENCY_SHORT_MEGA                                         :{NBSP}m
+STR_CURRENCY_SHORT_GIGA                                         :{NBSP}bn
+STR_CURRENCY_SHORT_TERA                                         :{NBSP}tn
+
 STR_JUST_CARGO                                                  :{CARGO_LONG}
 STR_JUST_RIGHT_ARROW                                            :{RIGHT_ARROW}
 STR_JUST_CHECKMARK                                              :{CHECKMARK}


### PR DESCRIPTION
## Motivation / Problem

While creating #11915, I noticed this:

![300295128-07e07641-f157-429c-b4ee-675a5d17743a](https://github.com/OpenTTD/OpenTTD/assets/1663690/54edfa52-e495-4a0f-ac12-989209942a75)

And it really really annoyed me that it does read `M`, but ... still a HUGE number. Clearly that must be broken.

## Description

Turn out, the "compact" functionality was written for 32bit, and never extended to 64bit. So, here we go! Now it looks like this.

![image](https://github.com/OpenTTD/OpenTTD/assets/1663690/ca0b1084-13de-44d2-821d-72734970d27a)

Further more, turns out that the old code uses `k` and `M`, which is neither UK nor US method of presenting money. And as some comments below show, some people really would like that. As such, they are now part of the string system, and anyone can translate them how ever they like for their language to fit :)

PS: our `Money` class doesn't want to add/divide by `int64_t`, and only with `Money`. This seems a deliberate action in the `Money` class, to avoid people doing math with containers that are larger than `Money` (and `int64_t` is larger than `Money`, by 1 value on each side).

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
