### PR TITLE
Change: position error window closer to cursor on large screens

### DIFF
--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -223,26 +223,20 @@ public:
 			return pt;
 		}
 
-		/* Find the free screen space between the main toolbar at the top, and the statusbar at the bottom.
-		 * Add a fixed distance 20 to make it less cluttered.
-		 */
-		int scr_top = GetMainViewTop() + 20;
-		int scr_bot = GetMainViewBottom() - 20;
+		constexpr int distance_to_cursor = 200;
 
-		Point pt = RemapCoords(this->position.x, this->position.y, GetSlopePixelZOutsideMap(this->position.x, this->position.y));
-		const Viewport *vp = GetMainWindow()->viewport;
-		if (this->face == INVALID_COMPANY) {
-			/* move x pos to opposite corner */
-			pt.x = UnScaleByZoom(pt.x - vp->virtual_left, vp->zoom) + vp->left;
-			pt.x = (pt.x < (_screen.width >> 1)) ? _screen.width - sm_width - 20 : 20; // Stay 20 pixels away from the edge of the screen.
+		/* Position the error window just above the cursor. This makes the
+		 * error window clearly visible, without being in the way of what
+		 * the user is doing. */
+		Point pt;
+		pt.x = _cursor.pos.x - sm_width / 2;
+		pt.y = _cursor.pos.y - (distance_to_cursor + sm_height);
 
-			/* move y pos to opposite corner */
-			pt.y = UnScaleByZoom(pt.y - vp->virtual_top, vp->zoom) + vp->top;
-			pt.y = (pt.y < (_screen.height >> 1)) ? scr_bot - sm_height : scr_top;
-		} else {
-			pt.x = std::min(std::max(UnScaleByZoom(pt.x - vp->virtual_left, vp->zoom) + vp->left - (sm_width / 2), 0), _screen.width - sm_width);
-			pt.y = std::min(std::max(UnScaleByZoom(pt.y - vp->virtual_top,  vp->zoom) + vp->top  - (sm_height / 2), scr_top), scr_bot - sm_height);
+		if (pt.y < GetMainViewTop()) {
+			/* Window didn't fit above cursor, so place it below. */
+			pt.y = _cursor.pos.y + distance_to_cursor;
 		}
+
 		return pt;
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Fixes #9029.

One of my personal annoyances with the game, is that error windows appear in one of the four corners of the screen.

I don't know about you, but my screens are HUGE. So .. it feels like playing a tennis-match trying to find the error message. Even worse, often it takes for-ever for me to realise that my action isn't actually happening as there is a window popping up outside my field of vision / focus. So that frustrates me, I press some more, and only then: AH! There is an error ..

The reason the error window is opened at a corner is to make the chance it overlaps something you are working on as slim as possible. And on a 640x480 screen that made sense. On a 2k or 4k screen, it does not.

I wanted to fix that. This PR is an attempt in doing so.

## Description

Open the error window always relatively nearby the mouse: 200px above the cursor when possible. When too close to the top, put it 200px below the cursor. This is almost always within the field of vision / focus, and rarely obstructing anything I am working on. Even big stations are still fully visible.

## Limitations

This is a very opinionated way of resolving this. This works for me, but it might not work for you. Comments are open.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
