### PR TITLE
Add: Setting for scaling time in cargo payment calculations

### DIFF
--- a/src/core/math_func.hpp
+++ b/src/core/math_func.hpp
@@ -352,4 +352,29 @@ constexpr int RoundDivSU(int a, uint b)
 
 uint32_t IntSqrt(uint32_t num);
 
+/**
+ * Scale a number by the required percentage.
+ *
+ * Calculation is performed in the type U of the num parameter.
+ * The result is clamped to the limits of type T if needed.
+ *
+ * @param num The number to scale.
+ * @param percentage The percentage value. 100% = don't scale.
+ * @return The number scaled by the percentage value.
+ */
+template <typename T, typename U>
+constexpr T ScaleByPercentage(U num, uint16_t percentage)
+{
+	U scaled;
+	/* We might not need to do anything. */
+	if (percentage == 100) {
+		scaled = num;
+	} else {
+		scaled = (num * static_cast<U>(percentage)) / 100;
+	}
+
+	/* Make sure the value fits resulting type T. */
+	return ClampTo<T>(scaled);
+}
+
 #endif /* MATH_FUNC_HPP */

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -984,6 +984,9 @@ Money GetTransportedGoodsIncome(uint num_pieces, uint dist, uint16_t transit_per
 		return 0;
 	}
 
+	/* Scale transit periods according to the game setting. NewGRFs callbacks operate on scaled value for compatibility. */
+	transit_periods = ScaleByPercentage<uint16_t, uint32_t>(transit_periods, _settings_game.economy.payment_time_scale);
+
 	/* Use callback to calculate cargo profit, if available */
 	if (HasBit(cs->callback_mask, CBM_CARGO_PROFIT_CALC)) {
 		uint32_t var18 = ClampTo<uint16_t>(dist) | (ClampTo<uint8_t>(num_pieces) << 16) | (ClampTo<uint8_t>(transit_periods) << 24);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1520,6 +1520,9 @@ STR_CONFIG_SETTING_MINUTES_PER_YEAR_VALUE                       :{NUM}
 ###setting-zero-is-special
 STR_CONFIG_SETTING_MINUTES_PER_YEAR_FROZEN                      :0 (calendar time frozen)
 
+STR_CONFIG_SETTING_PAYMENT_TIME_SCALE                           :Time scale for cargo payments: {STRING2}
+STR_CONFIG_SETTING_PAYMENT_TIME_SCALE_HELPTEXT                  :Adjusts the time scale factor (in percentage) in the cargo payment calculations. A lower value means faster deliveries, resulting in higher payments.
+
 STR_CONFIG_SETTING_AUTORENEW_VEHICLE                            :Autorenew vehicle when it gets old: {STRING2}
 STR_CONFIG_SETTING_AUTORENEW_VEHICLE_HELPTEXT                   :When enabled, a vehicle nearing its end of life gets automatically replaced when the renew conditions are fulfilled
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2093,6 +2093,7 @@ static SettingsContainer &GetSettingsTree()
 			accounting->Add(new SettingEntry("economy.infrastructure_maintenance"));
 			accounting->Add(new SettingEntry("difficulty.vehicle_costs"));
 			accounting->Add(new SettingEntry("difficulty.construction_cost"));
+			accounting->Add(new SettingEntry("economy.payment_time_scale"));
 		}
 
 		SettingsPage *vehicles = main->Add(new SettingsPage(STR_CONFIG_SETTING_VEHICLES));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -560,6 +560,7 @@ struct EconomySettings {
 	bool   infrastructure_maintenance;       ///< enable monthly maintenance fee for owner infrastructure
 	TimekeepingUnits timekeeping_units;      ///< time units to use for the game economy, either calendar or wallclock
 	uint16_t minutes_per_calendar_year;      ///< minutes per calendar year. Special value 0 means that calendar time is frozen.
+	uint16_t payment_time_scale;             ///< percentage of delivery time to use for payment calculations
 };
 
 struct LinkGraphSettings {

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -315,3 +315,16 @@ strval   = STR_CONFIG_SETTING_MINUTES_PER_YEAR_VALUE
 pre_cb   = [](auto) { return _game_mode == GM_MENU || _settings_game.economy.timekeeping_units == 1; }
 post_cb  = ChangeMinutesPerYear
 cat      = SC_BASIC
+
+[SDT_VAR]
+var      = economy.payment_time_scale
+type     = SLE_UINT16
+def      = 100
+min      = 0
+max      = 50000
+interval = 10
+str      = STR_CONFIG_SETTING_PAYMENT_TIME_SCALE
+strhelp  = STR_CONFIG_SETTING_PAYMENT_TIME_SCALE_HELPTEXT
+strval   = STR_CONFIG_SETTING_PERCENTAGE
+cat      = SC_EXPERT
+post_cb  = [](auto) { InvalidateWindowData(WC_PAYMENT_RATES, 0); }


### PR DESCRIPTION
## Motivation / Problem

In the aftermath of #10596, it has become apparent that certain players favor very lengthy routes. As a result, cargo profits, originally optimized for specific distances, do not align with every playstyle. Compounding the issue is that, in some cases (such as maglev), peak distances extend beyond the boundaries, even on a 4k*4k map. Before #10596, this situation was somewhat mitigated by the payment formula not being tailored for large distances, yielding some illogical income figures. However, a more comprehensive solution is now imperative.

While a similar effect can be achieved through cargo aging in a newgrf, this property is associated with the vehicle, not the cargo. Expecting every vehicle newgrf to introduce a scaling parameter is unreasonable, and it doesn't address pure vanilla gameplay.

## Description

Given that the desired optimal profit distance is a characteristic of playstyle and not directly correlated with map size, it cannot be automatically inferred. Therefore, this PR introduces a separate setting that scales time for payment calculations. Players who prefer longer distances can set the scaling below 100%, while those aiming to optimize for shorter distances can set it above 100%. There is also the option to set it to 0 for achieving "flat" payment rates, although the practicality of this is uncertain.

[Screencast from 30-01-24 17:37:10.webm](https://github.com/OpenTTD/OpenTTD/assets/413570/eb2620f9-4c23-4382-8bd1-576ea2d2e019)

## Limitations

More settings for the God of Settings.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
