### PR TITLE
Remove: "generation_seed" from config, as it was a write-only value

### DIFF
--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -307,7 +307,7 @@ void GenerateWorld(GenWorldMode mode, uint size_x, uint size_y, bool reset_setti
 		_settings_game.construction.map_height_limit = std::max(MAP_HEIGHT_LIMIT_AUTO_MINIMUM, std::min(MAX_MAP_HEIGHT_LIMIT, estimated_height + MAP_HEIGHT_LIMIT_AUTO_CEILING_ROOM));
 	}
 
-	if (_settings_game.game_creation.generation_seed == GENERATE_NEW_SEED) _settings_game.game_creation.generation_seed = _settings_newgame.game_creation.generation_seed = InteractiveRandom();
+	if (_settings_game.game_creation.generation_seed == GENERATE_NEW_SEED) _settings_game.game_creation.generation_seed = InteractiveRandom();
 
 	/* Load the right landscape stuff, and the NewGRFs! */
 	GfxLoadSprites();

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -430,7 +430,7 @@ struct AfterNewGRFScan : NewGRFScanCallback {
 		SetEffectVolume(_settings_client.music.effect_vol);
 
 		if (startyear != CalendarTime::INVALID_YEAR) IConsoleSetSetting("game_creation.starting_year", startyear.base());
-		if (generation_seed != GENERATE_NEW_SEED) _settings_newgame.game_creation.generation_seed = generation_seed;
+		_settings_newgame.game_creation.generation_seed = generation_seed;
 
 		if (!dedicated_host.empty()) {
 			_network_bind_list.clear();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -159,8 +159,10 @@ enum IniFileVersion : uint32_t {
 	IFV_GAME_TYPE,                                         ///< 2  PR#9515  Convert server_advertise to server_game_type.
 	IFV_LINKGRAPH_SECONDS,                                 ///< 3  PR#10610 Store linkgraph update intervals in seconds instead of days.
 	IFV_NETWORK_PRIVATE_SETTINGS,                          ///< 4  PR#10762 Move no_http_content_downloads / use_relay_service to private settings.
+
 	IFV_AUTOSAVE_RENAME,                                   ///< 5  PR#11143 Renamed values of autosave to be in minutes.
 	IFV_RIGHT_CLICK_CLOSE,                                 ///< 6  PR#10204 Add alternative right click to close windows setting.
+	IFV_REMOVE_GENERATION_SEED,                            ///< 7  PR#11927 Remove "generation_seed" from configuration.
 
 	IFV_MAX_VERSION,       ///< Highest possible ini-file version.
 };
@@ -1480,6 +1482,13 @@ void SaveToConfig()
 		/* Remove all settings from the generic ini that are now in the secrets ini. */
 		for (auto &table : SecretSettingTables()) {
 			RemoveEntriesFromIni(generic_ini, table);
+		}
+	}
+
+	if (generic_version < IFV_REMOVE_GENERATION_SEED) {
+		IniGroup *game_creation = generic_ini.GetGroup("game_creation");
+		if (game_creation != nullptr) {
+			game_creation->RemoveItem("generation_seed");
 		}
 	}
 

--- a/src/table/settings/world_settings.ini
+++ b/src/table/settings/world_settings.ini
@@ -199,6 +199,7 @@ strval   = STR_VARIETY_NONE
 var      = game_creation.generation_seed
 type     = SLE_UINT32
 from     = SLV_30
+flags    = SF_NOT_IN_CONFIG
 def      = GENERATE_NEW_SEED
 min      = 0
 max      = UINT32_MAX


### PR DESCRIPTION
## Motivation / Problem

Fixes #9433.

A long long time ago, 10 years ago to be more precise, we removed the ability to change the generation-seed from the GUI. However, the value remained in the ini-file.

The kicker? That value was, for all intents and purpose, a write-only value. And this causes confusion with players, thinking they can alter the value to get a map with a specific seed. They cannot.

In more detail, there are four flows to set the generation seed in our code:

- When you open the World Generation GUI, a new seed is picked. Every time you open it.
- When a server restarts a new game. This is always a new random seed.
- When you start a new game via the console (which can either pick a random seed, or one you define).
- With the usage of `-G` from the CLI.

The first two always pick a random seed. The last two leaves it up to the user.

In no of these flows the value from the ini-file was used, and you need to go via at least one of these flows to get into a game. So effectively, the value in the ini-file had no purpose, and due to another weird statement in our code, it was always assigned the last seed used to create the world.

## Description

A few fixes packed in one:

- Don't assigned the `newgame` seed on starting a new game. It doesn't seem to define any actual purpose.
- Don't conditionally set the seed on startup; it is a pointless if-statement, from a past long ago.
- Make the setting a "not in config".
- Remove the setting pro-actively from the config.

This last point isn't actually needed; we can just leave the value in there for older configuration. But I remove it explicitly, to avoid people with old configuration being confused, and still trying to influence the seed that way. Call it "going to extra mile".

To be perfectly clear: this PR does not introduce any functional change (or at least, it really shouldn't). The game still behaves exactly as before this PR. The only difference is that we no longer give the suggestion that `generation_seed` in the ini-file has any effect at all.

Also, maybe in summary:

- Starting OpenTTD with `-g -G<seed>` sets the seed.
- Starting a new game via the console with `newgame <seed>` sets the seed.
- All other flows will always generate a new random seed on new game.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
