### PR TITLE
Cleanup: Use standard comment format

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -97,7 +97,7 @@ inline constexpr auto MakeCommandsFromTraits(std::integer_sequence<T, i...>) noe
 static constexpr auto _command_proc_table = MakeCommandsFromTraits(std::make_integer_sequence<std::underlying_type_t<Commands>, CMD_END>{});
 
 
-/*!
+/**
  * This function range-checks a cmd.
  *
  * @param cmd The integer value of a command
@@ -108,7 +108,7 @@ bool IsValidCommand(Commands cmd)
 	return cmd < _command_proc_table.size();
 }
 
-/*!
+/**
  * This function mask the parameter with CMD_ID_MASK and returns
  * the flags which belongs to the given command.
  *
@@ -122,7 +122,7 @@ CommandFlags GetCommandFlags(Commands cmd)
 	return _command_proc_table[cmd].flags;
 }
 
-/*!
+/**
  * This function mask the parameter with CMD_ID_MASK and returns
  * the name which belongs to the given command.
  *


### PR DESCRIPTION
## Motivation / Problem
A few comments in command.cpp used a non-standard comment format starting with `/*!`.

## Description
Change them to the standard format starting with `/**`.

## Limitations
None.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
