### PR TITLE
Change: forcefully enable prefixing logs with date

### DIFF
--- a/cmake/scripts/Regression.cmake
+++ b/cmake/scripts/Regression.cmake
@@ -34,7 +34,6 @@ execute_process(COMMAND ${OPENTTD_EXECUTABLE}
                         -mnull
                         -vnull:ticks=30000
                         -d script=2
-                        -d misc=9
                         -Q
                 OUTPUT_VARIABLE REGRESSION_OUTPUT
                 ERROR_VARIABLE REGRESSION_RESULT
@@ -58,10 +57,13 @@ string(REPLACE "0x0x0" "0x00000000" REGRESSION_RESULT "${REGRESSION_RESULT}")
 string(REPLACE "\\" "/" REGRESSION_RESULT "${REGRESSION_RESULT}")
 
 # Remove timestamps if any
-string(REGEX REPLACE "\[[0-9-]+ [0-9:]+\] " "" REGRESSION_RESULT "${REGRESSION_RESULT}")
+string(REGEX REPLACE "\\\[[0-9-]+ [0-9:]+\\\] " "" REGRESSION_RESULT "${REGRESSION_RESULT}")
+
+# Remove log level
+string(REGEX REPLACE "\\\[script:[0-9]\\\]" "" REGRESSION_RESULT "${REGRESSION_RESULT}")
 
 # Convert the output to a format that is expected (and more readable) by result.txt
-string(REPLACE "\ndbg: [script]" "\n" REGRESSION_RESULT "${REGRESSION_RESULT}")
+string(REPLACE "\ndbg: " "\n" REGRESSION_RESULT "${REGRESSION_RESULT}")
 string(REPLACE "\n " "\nERROR: " REGRESSION_RESULT "${REGRESSION_RESULT}")
 string(REPLACE "\nERROR: [1] " "\n" REGRESSION_RESULT "${REGRESSION_RESULT}")
 string(REPLACE "\n[P] " "\n" REGRESSION_RESULT "${REGRESSION_RESULT}")

--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -1,4 +1,3 @@
-
 --TestInit--
  Ops:      9988
  TickTest: 1

--- a/regression/stationlist/result.txt
+++ b/regression/stationlist/result.txt
@@ -1,4 +1,3 @@
-
 --StationList--
   Count():             5
   Location ListDump:

--- a/src/debug.h
+++ b/src/debug.h
@@ -30,12 +30,12 @@
 
 /**
  * Ouptut a line of debugging information.
- * @param name The category of debug information.
+ * @param category The category of debug information.
  * @param level The maximum debug level this message should be shown at. When the debug level for this category is set lower, then the message will not be shown.
  * @param format_string The formatting string of the message.
  */
-#define Debug(name, level, format_string, ...) if ((level) == 0 || _debug_ ## name ## _level >= (level)) DebugPrint(#name, fmt::format(FMT_STRING(format_string), ## __VA_ARGS__))
-void DebugPrint(const char *level, const std::string &message);
+#define Debug(category, level, format_string, ...) if ((level) == 0 || _debug_ ## category ## _level >= (level)) DebugPrint(#category, level, fmt::format(FMT_STRING(format_string), ## __VA_ARGS__))
+void DebugPrint(const char *category, int level, const std::string &message);
 
 extern int _debug_driver_level;
 extern int _debug_grf_level;
@@ -99,7 +99,7 @@ struct TicToc {
 void ShowInfoI(const std::string &str);
 #define ShowInfo(format_string, ...) ShowInfoI(fmt::format(FMT_STRING(format_string), ## __VA_ARGS__))
 
-std::string GetLogPrefix();
+std::string GetLogPrefix(bool force = false);
 
 void DebugSendRemoteMessages();
 void DebugReconsiderSendRemoteMessages();


### PR DESCRIPTION
## Motivation / Problem

Currently it is a setting whether any logs have a date prefixed to a line. This makes total sense for the in-game console, but it makes no sense for logs meant to share with developers.

In fact, one of the things that makes many of the logs, especially network-related, very hard to use, is that there is no timeline.

## Description

As such, forcefully enable prefixing the logs with a date. The console however still listens to the option, which you can enable/disable as you like.

Additionally, add the log-level to the log message.

PS: turns out our regression script was a bit weird .. it had `misc=9`, but we filtered those out, and the timestamp regex didn't actually escape anything. `"\["` is just `"["` for the regex. We need to double-escape for it to work.

## Limitations

This means all dedicated servers now have the date enabled. This was kinda already the intention, but it was only done when building a dedicated build, instead of using `-D`.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
