### PR TITLE
Remove macros with unguarded "if"

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -34,7 +34,7 @@
  * @param level The maximum debug level this message should be shown at. When the debug level for this category is set lower, then the message will not be shown.
  * @param format_string The formatting string of the message.
  */
-#define Debug(category, level, format_string, ...) if ((level) == 0 || _debug_ ## category ## _level >= (level)) DebugPrint(#category, level, fmt::format(FMT_STRING(format_string), ## __VA_ARGS__))
+#define Debug(category, level, format_string, ...) do { if ((level) == 0 || _debug_ ## category ## _level >= (level)) DebugPrint(#category, level, fmt::format(FMT_STRING(format_string), ## __VA_ARGS__)); } while (false)
 void DebugPrint(const char *category, int level, const std::string &message);
 
 extern int _debug_driver_level;

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -2387,7 +2387,9 @@ static void DrawTrackBits(TileInfo *ti, TrackBits track)
 
 static void DrawSignals(TileIndex tile, TrackBits rails, const RailTypeInfo *rti)
 {
-#define MAYBE_DRAW_SIGNAL(x, y, z, t) if (IsSignalPresent(tile, x)) DrawSingleSignal(tile, rti, t, GetSingleSignalState(tile, x), y, z)
+	auto MAYBE_DRAW_SIGNAL = [&](byte signalbit, SignalOffsets image, uint pos, Track track) {
+		if (IsSignalPresent(tile, signalbit)) DrawSingleSignal(tile, rti, track, GetSingleSignalState(tile, signalbit), image, pos);
+	};
 
 	if (!(rails & TRACK_BIT_Y)) {
 		if (!(rails & TRACK_BIT_X)) {

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -392,7 +392,7 @@ void NORETURN AssertFailedError(int line, const char *file, const char *expressi
 /* For non-debug builds with assertions enabled use the special assertion handler. */
 #if defined(NDEBUG) && defined(WITH_ASSERT)
 #	undef assert
-#	define assert(expression) if (unlikely(!(expression))) AssertFailedError(__LINE__, __FILE__, #expression);
+#	define assert(expression) do { if (unlikely(!(expression))) AssertFailedError(__LINE__, __FILE__, #expression); } while (false)
 #endif
 
 /* Define JSON_ASSERT, which is used by nlohmann-json. Otherwise the header-file


### PR DESCRIPTION
## Motivation / Problem

Macros starting with `if` are dangerous, since they break if macro usage is followed with `else`.

## Description

* Wrap affected macros into `do {  } while (false)`. This is the standard solution for macros, which should be used with a following `;`
* Even better: replace macros with lambdas.

## Limitations

There is another weird macro left in `ClientNetworkContentSocketHandler::OnReceiveData`, but the whole method should probably get rewritten using `std::string` or CTRE (if we ever get it).

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
