### PR TITLE
Fix #9655: [Emscripten] install the correct files on install

### DIFF
--- a/cmake/InstallAndPackage.cmake
+++ b/cmake/InstallAndPackage.cmake
@@ -23,16 +23,28 @@ install(TARGETS openttd
             COMPONENT Runtime
         )
 
-install(DIRECTORY
-                ${CMAKE_BINARY_DIR}/lang
-                ${CMAKE_BINARY_DIR}/baseset
-                ${CMAKE_BINARY_DIR}/ai
-                ${CMAKE_BINARY_DIR}/game
-                ${CMAKE_SOURCE_DIR}/bin/scripts
-        DESTINATION ${DATA_DESTINATION_DIR}
-        COMPONENT language_files
-        REGEX "ai/[^\.]+$" EXCLUDE # Ignore subdirs in ai dir
-)
+if (NOT EMSCRIPTEN)
+    # Emscripten embeds these files in openttd.data.
+    # See CMakeLists.txt in the root.
+    install(DIRECTORY
+                    ${CMAKE_BINARY_DIR}/lang
+                    ${CMAKE_BINARY_DIR}/baseset
+                    ${CMAKE_BINARY_DIR}/ai
+                    ${CMAKE_BINARY_DIR}/game
+                    ${CMAKE_SOURCE_DIR}/bin/scripts
+            DESTINATION ${DATA_DESTINATION_DIR}
+            COMPONENT language_files
+            REGEX "ai/[^\.]+$" EXCLUDE # Ignore subdirs in ai dir
+    )
+else()
+    install(FILES
+                ${CMAKE_BINARY_DIR}/openttd.js
+                ${CMAKE_BINARY_DIR}/openttd.wasm
+                ${CMAKE_BINARY_DIR}/openttd.data
+            DESTINATION ${BINARY_DESTINATION_DIR}
+            COMPONENT Runtime
+    )
+endif()
 
 install(FILES
                 ${CMAKE_SOURCE_DIR}/COPYING.md
@@ -79,7 +91,7 @@ if(OPTION_INSTALL_FHS)
             COMPONENT manual)
 endif()
 
-if(UNIX AND NOT APPLE)
+if(UNIX AND NOT APPLE AND NOT EMSCRIPTEN)
     install(DIRECTORY
                     ${CMAKE_BINARY_DIR}/media/icons
                     ${CMAKE_BINARY_DIR}/media/pixmaps


### PR DESCRIPTION
## Motivation / Problem

Fixes #9655.

The reported already made a commit. It was mostly right.

## Description

Emscripten doesn't need datafiles, and can't load scripts. But it does need `wasm` and other files to work. So copy the right files for that target to the same folder as the binaries, so it is all in one tiny lovely place :)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
