### PR TITLE
Codechange: a wild quote appeared; it is gone now

### DIFF
--- a/cmake/scripts/Regression.cmake
+++ b/cmake/scripts/Regression.cmake
@@ -96,7 +96,7 @@ foreach(RESULT IN LISTS REGRESSION_RESULT)
 
     if(NOT RESULT STREQUAL EXPECTED)
         message("${ARGC}: - ${EXPECTED}")
-        message("${ARGC}: + ${RESULT}'")
+        message("${ARGC}: + ${RESULT}")
         set(ERROR YES)
     endif()
 endforeach()


### PR DESCRIPTION
## Motivation / Problem

If the regression notices a difference, it start yapping about a quote being wrong. But that is a lie.

## Description

In fact, someone just liked to add a random quote in a random place. Let's not do that, shall we? :D

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
