### PR TITLE
Fix #9697: don't extend the Online Players window too wide on opening

### DIFF
--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1677,6 +1677,18 @@ public:
 	void UpdateWidgetSize(WidgetID widget, Dimension *size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension *fill, [[maybe_unused]] Dimension *resize) override
 	{
 		switch (widget) {
+			case WID_CL_SERVER_NAME:
+			case WID_CL_CLIENT_NAME:
+				if (widget == WID_CL_SERVER_NAME) {
+					SetDParamStr(0, _network_server ? _settings_client.network.server_name : _network_server_name);
+				} else {
+					const NetworkClientInfo *own_ci = NetworkClientInfo::GetByClientID(_network_own_client_id);
+					SetDParamStr(0, own_ci != nullptr ? own_ci->client_name : _settings_client.network.client_name);
+				}
+				*size = GetStringBoundingBox(STR_JUST_RAW_STRING);
+				size->width = std::min(size->width, static_cast<uint>(ScaleGUITrad(200))); // By default, don't open the window too wide.
+				break;
+
 			case WID_CL_SERVER_VISIBILITY:
 				*size = maxdim(maxdim(GetStringBoundingBox(STR_NETWORK_SERVER_VISIBILITY_LOCAL), GetStringBoundingBox(STR_NETWORK_SERVER_VISIBILITY_PUBLIC)), GetStringBoundingBox(STR_NETWORK_SERVER_VISIBILITY_INVITE_ONLY));
 				size->width += padding.width;


### PR DESCRIPTION
## Motivation / Problem

Fixes #9697.

## Description

Cap the server-name / client-name to 200px when opening. This prevents a very wide Online Players for no real good reason.

Users can still scale it to bigger formats if they want.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
