### PR TITLE
Fix: Initialize random seed earlier in new game process.

### DIFF
--- a/src/core/random_func.hpp
+++ b/src/core/random_func.hpp
@@ -46,6 +46,19 @@ inline void SaveRandomSeeds(SavedRandomSeeds *storage)
 }
 
 /**
+ * Check if random seeds have been changed.
+ * @param saved_seeds Saved random seeds.
+ * @returns true if the saved seeds match the current random seeds.
+ */
+inline bool CheckRandomSeeds(const SavedRandomSeeds &saved_seeds)
+{
+	return (saved_seeds.random.state[0] == _random.state[0])
+		&& (saved_seeds.random.state[1] == _random.state[1])
+		&& (saved_seeds.interactive_random.state[0] == _interactive_random.state[0])
+		&& (saved_seeds.interactive_random.state[1] == _interactive_random.state[1]);
+}
+
+/**
  * Restores previously saved seeds
  * @param storage Storage where SaveRandomSeeds() stored th seeds
  */

--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -91,11 +91,9 @@ static void _GenerateWorld()
 	try {
 		_generating_world = true;
 		if (_network_dedicated) Debug(net, 3, "Generating map, please wait...");
-		/* Set the Random() seed to generation_seed so we produce the same map with the same seed */
-		_random.SetSeed(_settings_game.game_creation.generation_seed);
+
 		SetGeneratingWorldProgress(GWP_MAP_INIT, 2);
 		SetObjectToPlace(SPR_CURSOR_ZZZ, PAL_NONE, HT_NONE, WC_MAIN_WINDOW, 0);
-		ScriptObject::InitializeRandomizers();
 
 		BasePersistentStorageArray::SwitchMode(PSM_ENTER_GAMELOOP);
 
@@ -289,6 +287,10 @@ void GenerateWorld(GenWorldMode mode, uint size_x, uint size_y, bool reset_setti
 	SetLocalCompany(COMPANY_SPECTATOR);
 
 	InitializeGame(_gw.size_x, _gw.size_y, true, reset_settings);
+
+	SavedRandomSeeds saved_seeds;
+	SaveRandomSeeds(&saved_seeds);
+
 	PrepareGenerateWorldProgress();
 
 	if (_settings_game.construction.map_height_limit == 0) {
@@ -306,8 +308,6 @@ void GenerateWorld(GenWorldMode mode, uint size_x, uint size_y, bool reset_setti
 
 		_settings_game.construction.map_height_limit = std::max(MAP_HEIGHT_LIMIT_AUTO_MINIMUM, std::min(MAX_MAP_HEIGHT_LIMIT, estimated_height + MAP_HEIGHT_LIMIT_AUTO_CEILING_ROOM));
 	}
-
-	if (_settings_game.game_creation.generation_seed == GENERATE_NEW_SEED) _settings_game.game_creation.generation_seed = InteractiveRandom();
 
 	/* Load the right landscape stuff, and the NewGRFs! */
 	GfxLoadSprites();
@@ -328,6 +328,10 @@ void GenerateWorld(GenWorldMode mode, uint size_x, uint size_y, bool reset_setti
 
 	/* Centre the view on the map */
 	ScrollMainWindowToTile(TileXY(Map::SizeX() / 2, Map::SizeY() / 2), true);
+
+	/* Initialization should use Random() as that could affect the ability to recreate the same map with the
+	 * same settings. (This is not guaranteed between different versions though.) */
+	assert(CheckRandomSeeds(saved_seeds));
 
 	_GenerateWorld();
 }

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -8,6 +8,10 @@
 /** @file misc.cpp Misc functions that shouldn't be here. */
 
 #include "stdafx.h"
+#include "core/random_func.hpp"
+#include "ai/ai_config.hpp"
+#include "game/game_config.hpp"
+#include "genworld.h"
 #include "landscape.h"
 #include "news_func.h"
 #include "ai/ai.hpp"
@@ -173,4 +177,16 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 	_gamelog.Mode();
 	_gamelog.GRFAddList(_grfconfig);
 	_gamelog.StopAction();
+
+	/* Set the Random() seed to generation_seed so we produce the same map with the same seed. */
+	if (_settings_game.game_creation.generation_seed == GENERATE_NEW_SEED) _settings_game.game_creation.generation_seed = InteractiveRandom();
+
+	_random.SetSeed(_settings_game.game_creation.generation_seed);
+	ScriptObject::InitializeRandomizers();
+
+	/* Set random deviation for scripts. */
+	for (auto &ai_config : _settings_game.ai_config) {
+		if (ai_config != nullptr) ai_config->AddRandomDeviation();
+	}
+	if (_settings_game.game_config != nullptr) _settings_game.game_config->AddRandomDeviation();
 }

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -57,9 +57,6 @@ ScriptConfig::ScriptConfig(const ScriptConfig *config)
 	for (const auto &item : config->settings) {
 		this->settings[item.first] = item.second;
 	}
-
-	/* Virtual functions get called statically in constructors, so make it explicit to remove any confusion. */
-	this->ScriptConfig::AddRandomDeviation();
 }
 
 ScriptConfig::~ScriptConfig()


### PR DESCRIPTION
## Motivation / Problem

AI/GS script initialization depends on randomization but happens before a new game's seed is set.

```
ScriptConfig::ScriptConfig none
AddRandomDeviation
ScriptConfig::ScriptConfig LuDiAI AfterFix
AddRandomDeviation
ScriptConfig::ScriptConfig LuDiAI AfterFix
AddRandomDeviation
ScriptConfig::ScriptConfig none
AddRandomDeviation
...
InitializeRandomizers
```

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Move random seed earlier in new game process, from landscape generation (wtf?) to game initialization. This prevents setting up script settings with the seed not initialized.

```
InitializeRandomizers
ScriptConfig::ScriptConfig none
AddRandomDeviation
ScriptConfig::ScriptConfig LuDiAI AfterFix
AddRandomDeviation
ScriptConfig::ScriptConfig LuDiAI AfterFix
AddRandomDeviation
ScriptConfig::ScriptConfig none
AddRandomDeviation
...
AddRandomDeviation
```

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
