### PR TITLE
Fix #11938: Check infinite money setting in cases where it was missed

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -836,17 +836,21 @@ static void CompaniesPayInterest()
 		/* Over a year the paid interest should be "loan * interest percentage",
 		 * but... as that number is likely not dividable by 12 (pay each month),
 		 * one needs to account for that in the monthly fee calculations.
+		 *
 		 * To easily calculate what one should pay "this" month, you calculate
 		 * what (total) should have been paid up to this month and you subtract
 		 * whatever has been paid in the previous months. This will mean one month
 		 * it'll be a bit more and the other it'll be a bit less than the average
 		 * monthly fee, but on average it will be exact.
+		 *
 		 * In order to prevent cheating or abuse (just not paying interest by not
-		 * taking a loan we make companies pay interest on negative cash as well
+		 * taking a loan) we make companies pay interest on negative cash as well,
+		 * except if infinite money is enabled.
 		 */
 		Money yearly_fee = c->current_loan * _economy.interest_rate / 100;
-		if (c->money < 0) {
-			yearly_fee += -c->money *_economy.interest_rate / 100;
+		Money available_money = GetAvailableMoney(c->index);
+		if (available_money < 0) {
+			yearly_fee += -available_money * _economy.interest_rate / 100;
 		}
 		Money up_to_previous_month = yearly_fee * TimerGameEconomy::month / 12;
 		Money up_to_this_month = yearly_fee * (TimerGameEconomy::month + 1) / 12;

--- a/src/misc_cmd.cpp
+++ b/src/misc_cmd.cpp
@@ -96,7 +96,7 @@ CommandCost CmdDecreaseLoan(DoCommandFlag flags, LoanCommand cmd, Money amount)
 			loan = std::min(c->current_loan, (Money)LOAN_INTERVAL);
 			break;
 		case LoanCommand::Max: // Pay back as much as possible
-			loan = std::max(std::min(c->current_loan, c->money), (Money)LOAN_INTERVAL);
+			loan = std::max(std::min(c->current_loan, GetAvailableMoneyForCommand()), (Money)LOAN_INTERVAL);
 			loan -= loan % LOAN_INTERVAL;
 			break;
 		case LoanCommand::Amount: // Repay the given amount of loan
@@ -105,7 +105,7 @@ CommandCost CmdDecreaseLoan(DoCommandFlag flags, LoanCommand cmd, Money amount)
 			break;
 	}
 
-	if (c->money < loan) {
+	if (GetAvailableMoneyForCommand() < loan) {
 		SetDParam(0, loan);
 		return_cmd_error(STR_ERROR_CURRENCY_REQUIRED);
 	}

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -3435,7 +3435,7 @@ TownActions GetMaskOfTownActions(CompanyID cid, const Town *t)
 	if (cid != COMPANY_SPECTATOR && !(_settings_game.economy.bribe && t->unwanted[cid])) {
 
 		/* Actions worth more than this are not able to be performed */
-		Money avail = Company::Get(cid)->money;
+		Money avail = GetAvailableMoney(cid);
 
 		/* Check the action bits for validity and
 		 * if they are valid add them */

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -245,7 +245,7 @@ public:
 			case WID_TA_ACTION_INFO:
 				if (this->sel_index != -1) {
 					Money action_cost = _price[PR_TOWN_ACTION] * _town_action_costs[this->sel_index] >> 8;
-					bool affordable = Company::IsValidID(_local_company) && action_cost < Company::Get(_local_company)->money;
+					bool affordable = Company::IsValidID(_local_company) && action_cost < GetAvailableMoney(_local_company);
 
 					SetDParam(0, action_cost);
 					DrawStringMultiLine(r.Shrink(WidgetDimensions::scaled.framerect),


### PR DESCRIPTION
## Motivation / Problem

Fixes #11938.
When repaying loans and performing town actions (such as bribery), the money of the company is checked directly, which resulted in "not enough money" when the balance was negative, even if the infinite money setting was enabled.

Also, interest is charged on negative money balances (as this is considered a type of loan), which does not make sense in infinite money mode.

## Description

Use `GetAvailableMoney()`, which returns `INT64_MAX` if infinite money is enabled, when checking for money in town actions and repaying loans. Also use it in checking for negative balance during interest payment.


## Limitations

Loans still exist even in infinite money mode and still charge interest. Loans are not really meaningful in infinite money mode, but since the setting is changeable during the game, ignoring the loan only while that setting is enabled would be weird IMO.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
