### PR TITLE
Fix: Display rank correctly with more than 15 companies in a league table

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -537,24 +537,6 @@ STR_ABOUT_MENU_TOGGLE_BOUNDING_BOXES                            :Toggle bounding
 STR_ABOUT_MENU_TOGGLE_DIRTY_BLOCKS                              :Toggle colouring of dirty blocks
 STR_ABOUT_MENU_TOGGLE_WIDGET_OUTLINES                           :Toggle widget outlines
 
-# Place in highscore window
-###length 15
-STR_ORDINAL_NUMBER_1ST                                          :1st
-STR_ORDINAL_NUMBER_2ND                                          :2nd
-STR_ORDINAL_NUMBER_3RD                                          :3rd
-STR_ORDINAL_NUMBER_4TH                                          :4th
-STR_ORDINAL_NUMBER_5TH                                          :5th
-STR_ORDINAL_NUMBER_6TH                                          :6th
-STR_ORDINAL_NUMBER_7TH                                          :7th
-STR_ORDINAL_NUMBER_8TH                                          :8th
-STR_ORDINAL_NUMBER_9TH                                          :9th
-STR_ORDINAL_NUMBER_10TH                                         :10th
-STR_ORDINAL_NUMBER_11TH                                         :11th
-STR_ORDINAL_NUMBER_12TH                                         :12th
-STR_ORDINAL_NUMBER_13TH                                         :13th
-STR_ORDINAL_NUMBER_14TH                                         :14th
-STR_ORDINAL_NUMBER_15TH                                         :15th
-
 ###length 31
 STR_DAY_NUMBER_1ST                                              :1st
 STR_DAY_NUMBER_2ND                                              :2nd
@@ -652,6 +634,7 @@ STR_GRAPH_KEY_COMPANY_SELECTION_TOOLTIP                         :{BLACK}Click he
 # Company league window
 STR_COMPANY_LEAGUE_TABLE_CAPTION                                :{WHITE}Company League Table
 STR_COMPANY_LEAGUE_COMPANY_NAME                                 :{ORANGE}{COMPANY} {BLACK}{COMPANY_NUM} '{STRING}'
+STR_COMPANY_LEAGUE_COMPANY_RANK                                 :{YELLOW}#{NUM}
 STR_COMPANY_LEAGUE_PERFORMANCE_TITLE_ENGINEER                   :Engineer
 STR_COMPANY_LEAGUE_PERFORMANCE_TITLE_TRAFFIC_MANAGER            :Traffic Manager
 STR_COMPANY_LEAGUE_PERFORMANCE_TITLE_TRANSPORT_COORDINATOR      :Transport Coordinator

--- a/src/league_gui.cpp
+++ b/src/league_gui.cpp
@@ -115,7 +115,8 @@ public:
 
 		for (uint i = 0; i != this->companies.size(); i++) {
 			const Company *c = this->companies[i];
-			DrawString(ordinal.left, ordinal.right, ir.top + text_y_offset, i + STR_ORDINAL_NUMBER_1ST, i == 0 ? TC_WHITE : TC_YELLOW);
+			SetDParam(0, i + 1);
+			DrawString(ordinal.left, ordinal.right, ir.top + text_y_offset, STR_COMPANY_LEAGUE_COMPANY_RANK);
 
 			DrawCompanyIcon(c->index, icon_left, ir.top + icon_y_offset);
 
@@ -133,7 +134,8 @@ public:
 
 		this->ordinal_width = 0;
 		for (uint i = 0; i < MAX_COMPANIES; i++) {
-			this->ordinal_width = std::max(this->ordinal_width, GetStringBoundingBox(STR_ORDINAL_NUMBER_1ST + i).width);
+			SetDParam(0, i + 1);
+			this->ordinal_width = std::max(this->ordinal_width, GetStringBoundingBox(STR_COMPANY_LEAGUE_COMPANY_RANK).width);
 		}
 		this->ordinal_width += WidgetDimensions::scaled.hsep_wide; // Keep some extra spacing
 
@@ -339,7 +341,8 @@ public:
 		Rect score_rect = ir.Indent(this->rank_width + 2 * spacer + this->icon_size.width + this->text_width, rtl).WithWidth(this->score_width, rtl);
 
 		for (auto [rank, lte] : this->rows) {
-			DrawString(rank_rect.left, rank_rect.right, ir.top + text_y_offset, rank + STR_ORDINAL_NUMBER_1ST, rank == 0 ? TC_WHITE : TC_YELLOW);
+			SetDParam(0, rank + 1);
+			DrawString(rank_rect.left, rank_rect.right, ir.top + text_y_offset, STR_COMPANY_LEAGUE_COMPANY_RANK);
 			if (this->icon_size.width > 0 && lte->company != INVALID_COMPANY) DrawCompanyIcon(lte->company, icon_rect.left, ir.top + icon_y_offset);
 			SetDParamStr(0, lte->text);
 			DrawString(text_rect.left, text_rect.right, ir.top + text_y_offset, STR_JUST_RAW_STRING, TC_BLACK);
@@ -369,7 +372,8 @@ public:
 		this->rank_width = this->text_width = this->score_width = 0;
 		bool show_icon_column = false;
 		for (auto [rank, lte] : this->rows) {
-			this->rank_width = std::max(this->rank_width, GetStringBoundingBox(STR_ORDINAL_NUMBER_1ST + rank).width);
+			SetDParam(0, rank + 1);
+			this->rank_width = std::max(this->rank_width, GetStringBoundingBox(STR_COMPANY_LEAGUE_COMPANY_RANK).width);
 			SetDParamStr(0, lte->text);
 			this->text_width = std::max(this->text_width, GetStringBoundingBox(STR_JUST_RAW_STRING).width);
 			SetDParamStr(0, lte->score);


### PR DESCRIPTION
## Motivation / Problem

There can be more than 15 ranks in GameScript league tables so numeration got broken.

## Description

Replace ordinal strings with "#N" allowing arbitrary number of ranks. While there also moved colour into the string like many other strings do. 

Before (13.4)/After:
![Screenshot from 2024-01-31 23-29-53](https://github.com/OpenTTD/OpenTTD/assets/413570/8e08664d-325a-40a3-bd8c-055c8394a14b)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
