### PR TITLE
Replace old non-standard attributes with C++17/20 standard attributes.

### DIFF
--- a/src/3rdparty/squirrel/squirrel/sqcompiler.h
+++ b/src/3rdparty/squirrel/squirrel/sqcompiler.h
@@ -71,12 +71,7 @@ struct SQVM;
 #define TK_ENUM 323
 #define TK_CONST 324
 
-/* MSVC doesn't like NORETURN for function prototypes, but we kinda need it for GCC. */
-#if defined(_MSC_VER) && !defined(__clang__)
-typedef void(*CompilerErrorFunc)(void *ud, const SQChar *s);
-#else
-typedef NORETURN void(*CompilerErrorFunc)(void *ud, const SQChar *s);
-#endif
+using CompileException = std::runtime_error;
 
 bool Compile(SQVM *vm, SQLEXREADFUNC rg, SQUserPointer up, const SQChar *sourcename, SQObjectPtr &out, bool raiseerror, bool lineinfo);
 #endif //_SQCOMPILER_H_

--- a/src/3rdparty/squirrel/squirrel/sqfuncstate.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqfuncstate.cpp
@@ -93,7 +93,7 @@ void DumpLiteral(SQObjectPtr &o)
 }
 #endif
 
-SQFuncState::SQFuncState(SQSharedState *ss,SQFuncState *parent,CompilerErrorFunc efunc,void *ed)
+SQFuncState::SQFuncState(SQSharedState *ss,SQFuncState *parent)
 {
 		_nliterals = 0;
 		_literals = SQTable::Create(ss,0);
@@ -106,15 +106,13 @@ SQFuncState::SQFuncState(SQSharedState *ss,SQFuncState *parent,CompilerErrorFunc
 		_traps = 0;
 		_returnexp = 0;
 		_varparams = false;
-		_errfunc = efunc;
-		_errtarget = ed;
 		_bgenerator = false;
 
 }
 
 void SQFuncState::Error(const SQChar *err)
 {
-	_errfunc(_errtarget,err);
+	throw CompileException(err);
 }
 
 #ifdef _DEBUG_DUMP
@@ -550,7 +548,7 @@ SQFunctionProto *SQFuncState::BuildProto()
 SQFuncState *SQFuncState::PushChildState(SQSharedState *ss)
 {
 	SQFuncState *child = (SQFuncState *)sq_malloc(sizeof(SQFuncState));
-	new (child) SQFuncState(ss,this,_errfunc,_errtarget);
+	new (child) SQFuncState(ss,this);
 	_childstates.push_back(child);
 	return child;
 }

--- a/src/3rdparty/squirrel/squirrel/sqfuncstate.h
+++ b/src/3rdparty/squirrel/squirrel/sqfuncstate.h
@@ -6,12 +6,12 @@
 
 struct SQFuncState
 {
-	SQFuncState(SQSharedState *ss,SQFuncState *parent,CompilerErrorFunc efunc,void *ed);
+	SQFuncState(SQSharedState *ss,SQFuncState *parent);
 	~SQFuncState();
 #ifdef _DEBUG_DUMP
 	void Dump(SQFunctionProto *func);
 #endif
-	void Error(const SQChar *err);
+	[[noreturn]] void Error(const SQChar *err);
 	SQFuncState *PushChildState(SQSharedState *ss);
 	void PopChildState();
 	void AddInstruction(SQOpcode _op,SQInteger arg0=0,SQInteger arg1=0,SQInteger arg2=0,SQInteger arg3=0){SQInstruction i(_op,arg0,arg1,arg2,arg3);AddInstruction(i);}
@@ -75,9 +75,6 @@ struct SQFuncState
 	SQSharedState *_sharedstate;
 	sqvector<SQFuncState*> _childstates;
 	SQInteger GetConstant(const SQObject &cons);
-private:
-	CompilerErrorFunc _errfunc;
-	void *_errtarget;
 };
 
 

--- a/src/3rdparty/squirrel/squirrel/sqlexer.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqlexer.cpp
@@ -35,10 +35,8 @@ void SQLexer::APPEND_CHAR(char32_t c)
 	}
 }
 
-SQLexer::SQLexer(SQSharedState *ss, SQLEXREADFUNC rg, SQUserPointer up,CompilerErrorFunc efunc,void *ed)
+SQLexer::SQLexer(SQSharedState *ss, SQLEXREADFUNC rg, SQUserPointer up)
 {
-	_errfunc = efunc;
-	_errtarget = ed;
 	_sharedstate = ss;
 	_keywords = SQTable::Create(ss, 26);
 	ADD_KEYWORD(while, TK_WHILE);
@@ -96,7 +94,7 @@ SQLexer::SQLexer(SQSharedState *ss, SQLEXREADFUNC rg, SQUserPointer up,CompilerE
 
 NORETURN void SQLexer::Error(const SQChar *err)
 {
-	_errfunc(_errtarget,err);
+	throw CompileException(err);
 }
 
 void SQLexer::Next()

--- a/src/3rdparty/squirrel/squirrel/sqlexer.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqlexer.cpp
@@ -92,7 +92,7 @@ SQLexer::SQLexer(SQSharedState *ss, SQLEXREADFUNC rg, SQUserPointer up)
 	Next();
 }
 
-NORETURN void SQLexer::Error(const SQChar *err)
+[[noreturn]] void SQLexer::Error(const SQChar *err)
 {
 	throw CompileException(err);
 }

--- a/src/3rdparty/squirrel/squirrel/sqlexer.h
+++ b/src/3rdparty/squirrel/squirrel/sqlexer.h
@@ -5,8 +5,8 @@
 struct SQLexer
 {
 	~SQLexer();
-	SQLexer(SQSharedState *ss,SQLEXREADFUNC rg,SQUserPointer up,CompilerErrorFunc efunc,void *ed);
-	NORETURN void Error(const SQChar *err);
+	SQLexer(SQSharedState *ss,SQLEXREADFUNC rg,SQUserPointer up);
+	[[noreturn]] void Error(const SQChar *err);
 	SQInteger Lex();
 	const SQChar *Tok2Str(SQInteger tok);
 private:
@@ -35,8 +35,6 @@ public:
 	char32_t _currdata;
 	SQSharedState *_sharedstate;
 	sqvector<SQChar> _longstr;
-	CompilerErrorFunc _errfunc;
-	void *_errtarget;
 };
 
 #endif

--- a/src/3rdparty/squirrel/squirrel/sqvm.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqvm.cpp
@@ -217,7 +217,7 @@ bool SQVM::ObjCmp(const SQObjectPtr &o1,const SQObjectPtr &o2,SQInteger &result)
 					_RET_SUCCEED(_integer(res))
 				}
 			}
-			FALLTHROUGH;
+			[[fallthrough]];
 		default:
 			_RET_SUCCEED( _userpointer(o1) < _userpointer(o2)?-1:1 );
 		}
@@ -289,7 +289,7 @@ void SQVM::ToString(const SQObjectPtr &o,SQObjectPtr &res)
 				//else keeps going to the default
 			}
 		}
-		FALLTHROUGH;
+		[[fallthrough]];
 	default:
 		str = fmt::format("({} : 0x{:08X})",GetTypeName(o),(size_t)(void*)_rawval(o));
 	}
@@ -541,7 +541,7 @@ bool SQVM::FOREACH_OP(SQObjectPtr &o1,SQObjectPtr &o2,SQObjectPtr
 			_generator(o1)->Resume(this, arg_2+1);
 			_FINISH(0);
 		}
-		FALLTHROUGH;
+		[[fallthrough]];
 	default:
 		Raise_Error(fmt::format("cannot iterate {}", GetTypeName(o1)));
 	}
@@ -776,7 +776,7 @@ exception_restore:
 					ct_stackbase = _stackbase;
 					goto common_call;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 			case _OP_CALL: {
 					ct_tailcall = false;
 					ct_target = arg0;
@@ -1338,7 +1338,7 @@ bool SQVM::Set(const SQObjectPtr &self,const SQObjectPtr &key,const SQObjectPtr 
 				return true;
 			}
 		}
-		FALLTHROUGH;
+		[[fallthrough]];
 	case OT_USERDATA:
 		if(_delegable(self)->_delegate) {
 			SQObjectPtr t;

--- a/src/aircraft.h
+++ b/src/aircraft.h
@@ -71,7 +71,7 @@ struct AircraftCache {
 /**
  * Aircraft, helicopters, rotors and their shadows belong to this class.
  */
-struct Aircraft FINAL : public SpecializedVehicle<Aircraft, VEH_AIRCRAFT> {
+struct Aircraft final : public SpecializedVehicle<Aircraft, VEH_AIRCRAFT> {
 	uint16_t crashed_counter;        ///< Timer for handling crash animations.
 	byte pos;                      ///< Next desired position of the aircraft.
 	byte previous_pos;             ///< Previous desired position of the aircraft.

--- a/src/blitter/32bpp_anim_sse4.hpp
+++ b/src/blitter/32bpp_anim_sse4.hpp
@@ -32,7 +32,7 @@
 #define MARGIN_NORMAL_THRESHOLD 4
 
 /** The SSE4 32 bpp blitter with palette animation. */
-class Blitter_32bppSSE4_Anim FINAL : public Blitter_32bppSSE2_Anim, public Blitter_32bppSSE4 {
+class Blitter_32bppSSE4_Anim final : public Blitter_32bppSSE2_Anim, public Blitter_32bppSSE4 {
 private:
 
 public:

--- a/src/blitter/8bpp_optimized.hpp
+++ b/src/blitter/8bpp_optimized.hpp
@@ -14,7 +14,7 @@
 #include "factory.hpp"
 
 /** 8bpp blitter optimised for speed. */
-class Blitter_8bppOptimized FINAL : public Blitter_8bppBase {
+class Blitter_8bppOptimized final : public Blitter_8bppBase {
 public:
 	/** Data stored about a (single) sprite. */
 	struct SpriteData {

--- a/src/blitter/8bpp_simple.hpp
+++ b/src/blitter/8bpp_simple.hpp
@@ -14,7 +14,7 @@
 #include "factory.hpp"
 
 /** Most trivial 8bpp blitter. */
-class Blitter_8bppSimple FINAL : public Blitter_8bppBase {
+class Blitter_8bppSimple final : public Blitter_8bppBase {
 public:
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
 	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator) override;

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -399,7 +399,7 @@ struct CompanyFinancesWindow : Window {
 			case WID_CF_EXPS_PRICE2:
 			case WID_CF_EXPS_PRICE3:
 				size->height = GetTotalCategoriesHeight();
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case WID_CF_BALANCE_VALUE:
 			case WID_CF_LOAN_VALUE:
@@ -819,7 +819,7 @@ public:
 					size->width = 0;
 					break;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case WID_SCL_PRI_COL_DROPDOWN: {
 				this->square = GetSpriteSize(SPR_SQUARE);
@@ -1649,7 +1649,7 @@ public:
 			/* OK button */
 			case WID_SCMF_ACCEPT:
 				Command<CMD_SET_COMPANY_MANAGER_FACE>::Post(this->face);
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			/* Cancel button */
 			case WID_SCMF_CANCEL:

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -351,7 +351,7 @@ void IConsoleCmdExec(const std::string &command_string, const uint recurse_count
 				tokenstream[tstream_i++] = *++cmdptr;
 				break;
 			}
-			FALLTHROUGH;
+			[[fallthrough]];
 		default: // Normal character
 			tokenstream[tstream_i++] = *cmdptr;
 

--- a/src/core/alloc_func.cpp
+++ b/src/core/alloc_func.cpp
@@ -17,7 +17,7 @@
  * Function to exit with an error message after malloc() or calloc() have failed
  * @param size number of bytes we tried to allocate
  */
-void NORETURN MallocError(size_t size)
+[[noreturn]] void MallocError(size_t size)
 {
 	FatalError("Out of memory. Cannot allocate {} bytes", size);
 }
@@ -26,7 +26,7 @@ void NORETURN MallocError(size_t size)
  * Function to exit with an error message after realloc() have failed
  * @param size number of bytes we tried to allocate
  */
-void NORETURN ReallocError(size_t size)
+[[noreturn]] void ReallocError(size_t size)
 {
 	FatalError("Out of memory. Cannot reallocate {} bytes", size);
 }

--- a/src/core/alloc_func.hpp
+++ b/src/core/alloc_func.hpp
@@ -17,8 +17,8 @@
  * binary needlessly large.
  */
 
-void NORETURN MallocError(size_t size);
-void NORETURN ReallocError(size_t size);
+[[noreturn]] void MallocError(size_t size);
+[[noreturn]] void ReallocError(size_t size);
 
 /**
  * Checks whether allocating memory would overflow size_t.

--- a/src/core/overflowsafe_type.hpp
+++ b/src/core/overflowsafe_type.hpp
@@ -53,7 +53,7 @@ public:
 	inline constexpr OverflowSafeInt& operator += (const OverflowSafeInt& other)
 	{
 #ifdef HAS_OVERFLOW_BUILTINS
-		if (unlikely(__builtin_add_overflow(this->m_value, other.m_value, &this->m_value))) {
+		if (__builtin_add_overflow(this->m_value, other.m_value, &this->m_value)) [[unlikely]] {
 			this->m_value = (other.m_value < 0) ? T_MIN : T_MAX;
 		}
 #else
@@ -76,7 +76,7 @@ public:
 	inline constexpr OverflowSafeInt& operator -= (const OverflowSafeInt& other)
 	{
 #ifdef HAS_OVERFLOW_BUILTINS
-		if (unlikely(__builtin_sub_overflow(this->m_value, other.m_value, &this->m_value))) {
+		if (__builtin_sub_overflow(this->m_value, other.m_value, &this->m_value)) [[unlikely]] {
 			this->m_value = (other.m_value < 0) ? T_MAX : T_MIN;
 		}
 #else
@@ -114,7 +114,7 @@ public:
 	{
 #ifdef HAS_OVERFLOW_BUILTINS
 		const bool is_result_positive = (this->m_value < 0) == (factor < 0); // -ve * -ve == +ve
-		if (unlikely(__builtin_mul_overflow(this->m_value, factor, &this->m_value))) {
+		if (__builtin_mul_overflow(this->m_value, factor, &this->m_value)) [[unlikely]] {
 			this->m_value = is_result_positive ? T_MAX : T_MIN;
 		}
 #else

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -497,7 +497,7 @@ struct DepotWindow : Window {
 			switch (this->type) {
 				case VEH_TRAIN:
 					if (wagon) return MODE_ERROR;
-					FALLTHROUGH;
+					[[fallthrough]];
 
 				case VEH_ROAD:
 					if (xm <= this->flag_size.width) return MODE_START_STOP;

--- a/src/disaster_vehicle.h
+++ b/src/disaster_vehicle.h
@@ -34,7 +34,7 @@ enum DisasterSubType {
 /**
  * Disasters, like submarines, skyrangers and their shadows, belong to this class.
  */
-struct DisasterVehicle FINAL : public SpecializedVehicle<DisasterVehicle, VEH_DISASTER> {
+struct DisasterVehicle final : public SpecializedVehicle<DisasterVehicle, VEH_DISASTER> {
 	SpriteID image_override;            ///< Override for the default disaster vehicle sprite.
 	VehicleID big_ufo_destroyer_target; ///< The big UFO that this destroyer is supposed to bomb.
 	byte flags;                         ///< Flags about the state of the vehicle, @see AirVehicleFlags

--- a/src/effectvehicle_base.h
+++ b/src/effectvehicle_base.h
@@ -21,7 +21,7 @@
  *  - bulldozer (road works)
  *  - bubbles (industry)
  */
-struct EffectVehicle FINAL : public SpecializedVehicle<EffectVehicle, VEH_EFFECT> {
+struct EffectVehicle final : public SpecializedVehicle<EffectVehicle, VEH_EFFECT> {
 	uint16_t animation_state;  ///< State primarily used to change the graphics/behaviour.
 	byte animation_substate; ///< Sub state to time the change of the graphics/behaviour.
 

--- a/src/elrail.cpp
+++ b/src/elrail.cpp
@@ -125,7 +125,7 @@ static TrackBits GetRailTrackBitsUniversal(TileIndex t, byte *override)
 static TrackBits MaskWireBits(TileIndex t, TrackBits tracks)
 {
 	/* Single track bits are never masked out. */
-	if (likely(HasAtMostOneBit(tracks))) return tracks;
+	if (HasAtMostOneBit(tracks)) [[likely]] return tracks;
 
 	if (!IsPlainRailTile(t)) return tracks;
 

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -128,7 +128,7 @@ struct EnginePreviewWindow : Window {
 		switch (widget) {
 			case WID_EP_YES:
 				Command<CMD_WANT_ENGINE_PREVIEW>::Post(this->window_number);
-				FALLTHROUGH;
+				[[fallthrough]];
 			case WID_EP_NO:
 				if (!_shift_pressed) this->Close();
 				break;

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -10,12 +10,12 @@
 #include "stdafx.h"
 #include "error_func.h"
 
-void NORETURN NotReachedError(int line, const char *file)
+[[noreturn]] void NotReachedError(int line, const char *file)
 {
 	FatalError("NOT_REACHED triggered at line {} of {}", line, file);
 }
 
-void NORETURN AssertFailedError(int line, const char *file, const char *expression)
+[[noreturn]] void AssertFailedError(int line, const char *file, const char *expression)
 {
 	FatalError("Assertion failed at line {} of {}: {}", line, file, expression);
 }

--- a/src/error_func.h
+++ b/src/error_func.h
@@ -12,8 +12,8 @@
 
 #include "3rdparty/fmt/format.h"
 
-void NORETURN UserErrorI(const std::string &str);
-void NORETURN FatalErrorI(const std::string &str);
+[[noreturn]] void UserErrorI(const std::string &str);
+[[noreturn]] void FatalErrorI(const std::string &str);
 #define UserError(format_string, ...) UserErrorI(fmt::format(FMT_STRING(format_string), ## __VA_ARGS__))
 #define FatalError(format_string, ...) FatalErrorI(fmt::format(FMT_STRING(format_string), ## __VA_ARGS__))
 

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -327,7 +327,7 @@ FILE *FioFOpenFile(const std::string &filename, const char *mode, Subdirectory s
 			case BASESET_DIR:
 				f = FioFOpenFile(filename, mode, OLD_GM_DIR, filesize);
 				if (f != nullptr) break;
-				FALLTHROUGH;
+				[[fallthrough]];
 			case NEWGRF_DIR:
 				f = FioFOpenFile(filename, mode, OLD_DATA_DIR, filesize);
 				break;
@@ -1230,7 +1230,7 @@ uint FileScanner::Scan(const char *extension, Subdirectory sd, bool tars, bool r
 	switch (sd) {
 		case BASESET_DIR:
 			num += this->Scan(extension, OLD_GM_DIR, tars, recursive);
-			FALLTHROUGH;
+			[[fallthrough]];
 		case NEWGRF_DIR:
 			num += this->Scan(extension, OLD_DATA_DIR, tars, recursive);
 			break;

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -836,7 +836,7 @@ public:
 				/* We reset the files filtered */
 				this->OnInvalidateData(SLIWD_FILTER_CHANGES);
 
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case SLIWD_SELECTION_CHANGES:
 				/* Selection changes */

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -886,14 +886,14 @@ public:
 			switch (suffix.display) {
 				case CSD_CARGO_AMOUNT_TEXT:
 					SetDParamStr(3, suffix.text);
-					FALLTHROUGH;
+					[[fallthrough]];
 				case CSD_CARGO_AMOUNT:
 					str = stockpiling ? STR_INDUSTRY_VIEW_ACCEPT_CARGO_AMOUNT : STR_INDUSTRY_VIEW_ACCEPT_CARGO;
 					break;
 
 				case CSD_CARGO_TEXT:
 					SetDParamStr(3, suffix.text);
-					FALLTHROUGH;
+					[[fallthrough]];
 				case CSD_CARGO:
 					str = STR_INDUSTRY_VIEW_ACCEPT_CARGO;
 					break;

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -1025,11 +1025,11 @@ struct QueryStringWindow : public Window
 		switch (widget) {
 			case WID_QS_DEFAULT:
 				this->editbox.text.DeleteAll();
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case WID_QS_OK:
 				this->OnOk();
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case WID_QS_CANCEL:
 				this->Close();
@@ -1181,7 +1181,7 @@ struct QueryWindow : public Window {
 					this->proc(this->parent, true);
 					this->proc = nullptr;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case WKC_ESC:
 				this->Close();

--- a/src/music/extmidi.cpp
+++ b/src/music/extmidi.cpp
@@ -122,7 +122,7 @@ void MusicDriver_ExtMidi::DoPlay()
 
 		case -1:
 			Debug(driver, 0, "extmidi: couldn't fork: {}", strerror(errno));
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		default:
 			this->song.clear();

--- a/src/network/core/network_game_info.cpp
+++ b/src/network/core/network_game_info.cpp
@@ -274,17 +274,17 @@ void DeserializeNetworkGameInfo(Packet *p, NetworkGameInfo *info, const GameInfo
 	switch (game_info_version) {
 		case 7:
 			info->ticks_playing = p->Recv_uint64();
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case 6:
 			newgrf_serialisation = (NewGRFSerializationType)p->Recv_uint8();
 			if (newgrf_serialisation >= NST_END) return;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case 5: {
 			info->gamescript_version = (int)p->Recv_uint32();
 			info->gamescript_name = p->Recv_string(NETWORK_NAME_LENGTH);
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 
 		case 4: {
@@ -326,19 +326,19 @@ void DeserializeNetworkGameInfo(Packet *p, NetworkGameInfo *info, const GameInfo
 				*dst = c;
 				dst = &c->next;
 			}
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 
 		case 3:
 			info->calendar_date = Clamp(p->Recv_uint32(), 0, CalendarTime::MAX_DATE.base());
 			info->calendar_start = Clamp(p->Recv_uint32(), 0, CalendarTime::MAX_DATE.base());
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case 2:
 			info->companies_max  = p->Recv_uint8 ();
 			info->companies_on   = p->Recv_uint8 ();
 			p->Recv_uint8(); // Used to contain max-spectators.
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case 1:
 			info->server_name = p->Recv_string(NETWORK_NAME_LENGTH);

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -454,7 +454,7 @@ struct NetworkChatWindow : public Window {
 		switch (widget) {
 			case WID_NC_SENDBUTTON: /* Send */
 				SendChat(this->message_editbox.text.buf, this->dtype, this->dest);
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case WID_NC_CLOSE: /* Cancel */
 				this->Close();

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -894,7 +894,7 @@ public:
 						return ES_HANDLED;
 					}
 					/* space is pressed and filter is focused. */
-					FALLTHROUGH;
+					[[fallthrough]];
 
 				default:
 					return ES_NOT_HANDLED;

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -2134,7 +2134,7 @@ struct NetworkJoinStatusWindow : Window {
 							progress = 15; // We don't have the final size yet; the server is still compressing!
 							break;
 						}
-						FALLTHROUGH;
+						[[fallthrough]];
 
 					default: // Waiting is 15%, so the resting receivement of map is maximum 70%
 						progress = 15 + _network_join_bytes * (100 - 15) / _network_join_bytes_total;
@@ -2307,7 +2307,7 @@ struct NetworkCompanyPasswordWindow : public Window {
 		switch (widget) {
 			case WID_NCP_OK:
 				this->OnOk();
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case WID_NCP_CANCEL:
 				this->Close();

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1362,7 +1362,7 @@ void NetworkServerSendChat(NetworkAction action, DestType desttype, int dest, co
 		}
 		default:
 			Debug(net, 1, "Received unknown chat destination type {}; doing broadcast instead", desttype);
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case DESTTYPE_BROADCAST:
 			for (NetworkClientSocket *cs : NetworkClientSocket::Iterate()) {

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -3073,7 +3073,7 @@ static ChangeInfoResult CargoChangeInfo(uint cid, int numinfo, int prop, ByteRea
 					case 0x0B: cs->town_acceptance_effect = TAE_FOOD; break;
 					default:
 						GrfMsg(1, "CargoChangeInfo: Unknown town growth substitute value {}, setting to none.", substitute_type);
-						FALLTHROUGH;
+						[[fallthrough]];
 					case 0xFF: cs->town_acceptance_effect = TAE_NONE; break;
 				}
 				break;
@@ -4279,7 +4279,7 @@ static ChangeInfoResult RailTypeChangeInfo(uint id, int numinfo, int prop, ByteR
 					RailType resolved_rt = GetRailTypeByLabel(BSWAP32(label), false);
 					if (resolved_rt != INVALID_RAILTYPE) {
 						switch (prop) {
-							case 0x0F: SetBit(rti->powered_railtypes, resolved_rt);               FALLTHROUGH; // Powered implies compatible.
+							case 0x0F: SetBit(rti->powered_railtypes, resolved_rt);               [[fallthrough]]; // Powered implies compatible.
 							case 0x0E: SetBit(rti->compatible_railtypes, resolved_rt);            break;
 							case 0x18: SetBit(rti->introduction_required_railtypes, resolved_rt); break;
 							case 0x19: SetBit(rti->introduces_railtypes, resolved_rt);            break;
@@ -4396,7 +4396,7 @@ static ChangeInfoResult RailTypeReserveInfo(uint id, int numinfo, int prop, Byte
 					break;
 				}
 				GrfMsg(1, "RailTypeReserveInfo: Ignoring property 1D for rail type {} because no label was set", id + i);
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case 0x0E: // Compatible railtype list
 			case 0x0F: // Powered railtype list
@@ -4885,7 +4885,7 @@ static bool HandleChangeInfoResult(const char *caller, ChangeInfoResult cir, uin
 
 		case CIR_UNKNOWN:
 			GrfMsg(0, "{}: Unknown property 0x{:02X} of feature 0x{:02X}, disabling", caller, property, feature);
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case CIR_INVALID_ID: {
 			/* No debug message for an invalid ID, as it has already been output */

--- a/src/newgrf_airport.h
+++ b/src/newgrf_airport.h
@@ -189,7 +189,7 @@ struct AirportResolverObject : public ResolverObject {
 			{
 				TownScopeResolver *tsr = this->GetTown();
 				if (tsr != nullptr) return tsr;
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 			default: return ResolverObject::GetScope(scope, relative);
 		}

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1048,7 +1048,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 					break;
 				}
 				/* With double click, continue */
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 
 			case WID_NS_REMOVE: { // Remove GRF
@@ -1106,7 +1106,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 					break;
 				}
 				/* With double click, continue */
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 
 			case WID_NS_ADD:
@@ -1261,7 +1261,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 				}
 
 				this->avails.ForceRebuild();
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case GOID_NEWGRF_CURRENT_LOADED:
 				this->modified = false;
@@ -1270,7 +1270,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 
 			case GOID_NEWGRF_LIST_EDITED:
 				this->preset = -1;
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case GOID_NEWGRF_CHANGES_MADE:
 				UpdateScrollBars();

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -126,7 +126,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(byte param_setID, byte layo
 
 		case 0xFFFFFFFF: // current grf
 			GrfID = GetIndustrySpec(current->type)->grf_prop.grffile->grfid;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		default: // use the grfid specified in register 100h
 			SetBit(param_setID, 7); // bit 7 means it is not an old type

--- a/src/newgrf_industries.h
+++ b/src/newgrf_industries.h
@@ -57,7 +57,7 @@ struct IndustriesResolverObject : public ResolverObject {
 				TownScopeResolver *tsr = this->GetTown();
 				if (tsr != nullptr) return tsr;
 			}
-			FALLTHROUGH;
+			[[fallthrough]];
 
 			default:
 				return ResolverObject::GetScope(scope, relative);

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -239,7 +239,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(byte local_id, uint32_t grf
 
 		case 0xFFFFFFFF: // current grf
 			grf_id = grfid;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		default: // use the grfid specified in register 100h
 			idx = _object_mngr.GetID(local_id, grf_id);

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -148,7 +148,7 @@ struct ObjectResolverObject : public ResolverObject {
 			case VSG_SCOPE_PARENT: {
 				TownScopeResolver *tsr = this->GetTown();
 				if (tsr != nullptr) return tsr;
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 
 			default:

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -107,7 +107,7 @@ struct RoadStopResolverObject : public ResolverObject {
 			case VSG_SCOPE_PARENT: {
 				TownScopeResolver *tsr = this->GetTown();
 				if (tsr != nullptr) return tsr;
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 			default: return ResolverObject::GetScope(scope, relative);
 		}

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -66,7 +66,7 @@ struct StationResolverObject : public ResolverObject {
 			case VSG_SCOPE_PARENT: {
 				TownScopeResolver *tsr = this->GetTown();
 				if (tsr != nullptr) return tsr;
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 
 			default:

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -756,7 +756,7 @@ CommandCost CmdInsertOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID se
 				case OSL_PLATFORM_NEAR_END:
 				case OSL_PLATFORM_MIDDLE:
 					if (v->type != VEH_TRAIN) return CMD_ERROR;
-					FALLTHROUGH;
+					[[fallthrough]];
 
 				case OSL_PLATFORM_FAR_END:
 					break;
@@ -865,7 +865,7 @@ CommandCost CmdInsertOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID se
 				case OCV_LOAD_PERCENTAGE:
 				case OCV_RELIABILITY:
 					if (new_order.GetConditionValue() > 100) return CMD_ERROR;
-					FALLTHROUGH;
+					[[fallthrough]];
 
 				default:
 					if (occ == OCC_IS_TRUE || occ == OCC_IS_FALSE) return CMD_ERROR;
@@ -1388,7 +1388,7 @@ CommandCost CmdModifyOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID se
 					case OCV_LOAD_PERCENTAGE:
 					case OCV_RELIABILITY:
 						if (order->GetConditionValue() > 100) order->SetConditionValue(100);
-						FALLTHROUGH;
+						[[fallthrough]];
 
 					default:
 						if (occ == OCC_IS_TRUE || occ == OCC_IS_FALSE) order->SetConditionComparator(OCC_EQUALS);

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -844,7 +844,7 @@ public:
 			case VIWD_AUTOREPLACE:
 				/* Autoreplace replaced the vehicle */
 				this->vehicle = Vehicle::Get(this->window_number);
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case VIWD_CONSIST_CHANGED:
 				/* Vehicle composition was changed. */

--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -71,7 +71,7 @@ static const std::map<DWORD, std::string> exception_code_to_name{
  *
  * @param exit_code The exit code to return.
  */
-static void NORETURN ImmediateExitProcess(uint exit_code)
+[[noreturn]] static void ImmediateExitProcess(uint exit_code)
 {
 	/* TerminateProcess may fail in some special edge cases; fall back to ExitProcess in this case. */
 	TerminateProcess(GetCurrentProcess(), exit_code);

--- a/src/pathfinder/yapf/yapf_destrail.hpp
+++ b/src/pathfinder/yapf/yapf_destrail.hpp
@@ -140,7 +140,7 @@ public:
 					 * waypoint. */
 					Yapf().DisableCache(true);
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case OT_GOTO_STATION:
 				m_destTile = CalcClosestStationTile(v->current_order.GetDestination(), v->tile, v->current_order.IsType(OT_GOTO_STATION) ? STATION_RAIL : STATION_WAYPOINT);
@@ -152,7 +152,7 @@ public:
 				if (v->current_order.GetDepotActionType() & ODATFB_NEAREST_DEPOT) {
 					m_any_depot = true;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			default:
 				m_destTile = v->dest_tile;

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -562,7 +562,7 @@ CommandCost CmdBuildSingleRail(DoCommandFlag flags, TileIndex tile, RailType rai
 			if (IsLevelCrossing(tile) && GetCrossingRailBits(tile) == trackbit) {
 				return_cmd_error(STR_ERROR_ALREADY_BUILT);
 			}
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 
 		default: {
@@ -2475,13 +2475,13 @@ static void DrawTile_Track(TileInfo *ti)
 			switch (GetRailDepotDirection(ti->tile)) {
 				case DIAGDIR_NE:
 					if (!IsInvisibilitySet(TO_BUILDINGS)) break;
-					FALLTHROUGH;
+					[[fallthrough]];
 				case DIAGDIR_SW:
 					DrawGroundSprite(ground + RTO_X, PAL_NONE);
 					break;
 				case DIAGDIR_NW:
 					if (!IsInvisibilitySet(TO_BUILDINGS)) break;
-					FALLTHROUGH;
+					[[fallthrough]];
 				case DIAGDIR_SE:
 					DrawGroundSprite(ground + RTO_Y, PAL_NONE);
 					break;
@@ -2495,13 +2495,13 @@ static void DrawTile_Track(TileInfo *ti)
 				switch (GetRailDepotDirection(ti->tile)) {
 					case DIAGDIR_NE:
 						if (!IsInvisibilitySet(TO_BUILDINGS)) break;
-						FALLTHROUGH;
+						[[fallthrough]];
 					case DIAGDIR_SW:
 						DrawGroundSprite(overlay + RTO_X, PALETTE_CRASH);
 						break;
 					case DIAGDIR_NW:
 						if (!IsInvisibilitySet(TO_BUILDINGS)) break;
-						FALLTHROUGH;
+						[[fallthrough]];
 					case DIAGDIR_SE:
 						DrawGroundSprite(overlay + RTO_Y, PALETTE_CRASH);
 						break;
@@ -2515,13 +2515,13 @@ static void DrawTile_Track(TileInfo *ti)
 				switch (GetRailDepotDirection(ti->tile)) {
 					case DIAGDIR_NE:
 						if (!IsInvisibilitySet(TO_BUILDINGS)) break;
-						FALLTHROUGH;
+						[[fallthrough]];
 					case DIAGDIR_SW:
 						DrawGroundSprite(rti->base_sprites.single_x, PALETTE_CRASH);
 						break;
 					case DIAGDIR_NW:
 						if (!IsInvisibilitySet(TO_BUILDINGS)) break;
-						FALLTHROUGH;
+						[[fallthrough]];
 					case DIAGDIR_SE:
 						DrawGroundSprite(rti->base_sprites.single_y, PALETTE_CRASH);
 						break;

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2278,7 +2278,7 @@ static void SetDefaultRailGui()
 			if (count[rt] > 0) break;
 
 			/* No rail, just get the first available one */
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 		case 0: {
 			/* Use first available type */

--- a/src/roadveh.h
+++ b/src/roadveh.h
@@ -103,7 +103,7 @@ struct RoadVehPathCache {
 /**
  * Buses, trucks and trams belong to this class.
  */
-struct RoadVehicle FINAL : public GroundVehicle<RoadVehicle, VEH_ROAD> {
+struct RoadVehicle final : public GroundVehicle<RoadVehicle, VEH_ROAD> {
 	RoadVehPathCache path;  ///< Cached path.
 	byte state;             ///< @see RoadVehicleStates
 	byte frame;

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -160,7 +160,7 @@ static void ConvertTownOwner()
 				if (GB(tile.m5(), 4, 2) == ROAD_TILE_CROSSING && HasBit(tile.m3(), 7)) {
 					tile.m3() = OWNER_TOWN;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case MP_TUNNELBRIDGE:
 				if (tile.m1() & 0x80) SetTileOwner(tile, OWNER_TOWN);

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -186,7 +186,7 @@ void AfterLoadCompanyStats()
 						}
 					}
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case MP_OBJECT:
 				if (GetWaterClass(tile) == WATER_CLASS_CANAL) {

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -329,7 +329,7 @@ static void SlNullPointers()
  * @note This function does never return as it throws an exception to
  *       break out of all the saveload code.
  */
-void NORETURN SlError(StringID string, const std::string &extra_msg)
+[[noreturn]] void SlError(StringID string, const std::string &extra_msg)
 {
 	/* Distinguish between loading into _load_check_data vs. normal save/load. */
 	if (_sl.action == SLA_LOAD_CHECK) {
@@ -359,7 +359,7 @@ void NORETURN SlError(StringID string, const std::string &extra_msg)
  * @note This function does never return as it throws an exception to
  *       break out of all the saveload code.
  */
-void NORETURN SlErrorCorrupt(const std::string &msg)
+[[noreturn]] void SlErrorCorrupt(const std::string &msg)
 {
 	SlError(STR_GAME_SAVELOAD_ERROR_BROKEN_SAVEGAME, msg);
 }
@@ -1934,7 +1934,7 @@ void ChunkHandler::LoadCheck(size_t len) const
 		case CH_TABLE:
 		case CH_SPARSE_TABLE:
 			SlTableHeader({});
-			FALLTHROUGH;
+			[[fallthrough]];
 		case CH_ARRAY:
 		case CH_SPARSE_ARRAY:
 			SlSkipArray();

--- a/src/saveload/saveload_error.hpp
+++ b/src/saveload/saveload_error.hpp
@@ -13,8 +13,8 @@
 #include "../3rdparty/fmt/format.h"
 #include "../strings_type.h"
 
-void NORETURN SlError(StringID string, const std::string &extra_msg = {});
-void NORETURN SlErrorCorrupt(const std::string &msg);
+[[noreturn]] void SlError(StringID string, const std::string &extra_msg = {});
+[[noreturn]] void SlErrorCorrupt(const std::string &msg);
 
 /**
  * Issue an SlErrorCorrupt with a format string.
@@ -25,7 +25,7 @@ void NORETURN SlErrorCorrupt(const std::string &msg);
  *       break out of all the saveload code.
  */
 template <typename ... Args>
-inline void NORETURN SlErrorCorruptFmt(const fmt::format_string<Args...> format, Args&&... fmt_args)
+[[noreturn]] inline void SlErrorCorruptFmt(const fmt::format_string<Args...> format, Args&&... fmt_args)
 {
 	SlErrorCorrupt(fmt::format(format, std::forward<Args>(fmt_args)...));
 }

--- a/src/script/api/script_error.cpp
+++ b/src/script/api/script_error.cpp
@@ -38,7 +38,7 @@ ScriptError::ScriptErrorMapString ScriptError::error_map_string = ScriptError::S
 
 		case TEXT_TAB_SPECIAL:
 			if (index < 0xE4) break; // Player name
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case TEXT_TAB_TOWN:
 			if (index < 0xC0) break; // Town name

--- a/src/script/api/script_stationlist.cpp
+++ b/src/script/api/script_stationlist.cpp
@@ -153,13 +153,13 @@ void CargoCollector::Update(StationID from, StationID via, uint amount)
 	switch (Tselector) {
 		case ScriptStationList_Cargo::CS_VIA_BY_FROM:
 			if (via != this->other_station) return;
-			FALLTHROUGH;
+			[[fallthrough]];
 		case ScriptStationList_Cargo::CS_BY_FROM:
 			key = from;
 			break;
 		case ScriptStationList_Cargo::CS_FROM_BY_VIA:
 			if (from != this->other_station) return;
-			FALLTHROUGH;
+			[[fallthrough]];
 		case ScriptStationList_Cargo::CS_BY_VIA:
 			key = via;
 			break;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -255,7 +255,7 @@ static int ParseIntList(const char *p, T *items, size_t maxitems)
 				/* Do not accept multiple commas between numbers */
 				if (!comma) return -1;
 				comma = false;
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case ' ':
 				p++;

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -27,7 +27,7 @@
  * @param s Format string.
  * @note Function does not return.
  */
-void NORETURN FatalErrorI(const std::string &msg)
+[[noreturn]] void FatalErrorI(const std::string &msg)
 {
 	fmt::print(stderr, "settingsgen: FATAL: {}\n", msg);
 	exit(1);

--- a/src/ship.h
+++ b/src/ship.h
@@ -21,7 +21,7 @@ typedef std::deque<Trackdir> ShipPathCache;
 /**
  * All ships have this type.
  */
-struct Ship FINAL : public SpecializedVehicle<Ship, VEH_SHIP> {
+struct Ship final : public SpecializedVehicle<Ship, VEH_SHIP> {
 	TrackBits state;      ///< The "track" the ship is following.
 	ShipPathCache path;   ///< Cached path.
 	Direction rotation;   ///< Visible direction.

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -500,7 +500,7 @@ static SigSegState UpdateSignalsInBuffer(Owner owner)
 					_tbdset.Add(tile, INVALID_DIAGDIR); // start from depot inside
 					break;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case MP_STATION:
 			case MP_ROAD:
@@ -510,7 +510,7 @@ static SigSegState UpdateSignalsInBuffer(Owner owner)
 					_tbdset.Add(tile + TileOffsByDiagDir(dir), ReverseDiagDir(dir));
 					break;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			default:
 				/* jump to next tile */

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -521,7 +521,7 @@ struct SignWindow : Window, SignList {
 
 			case WID_QES_OK:
 				if (RenameSign(this->cur_sign, this->name_editbox.text.buf)) break;
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case WID_QES_CANCEL:
 				this->Close();

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -506,7 +506,7 @@ static inline uint32_t GetSmallMapRoutesPixels(TileIndex tile, TileType t)
 				const SmallMapColourScheme *cs = &_heightmap_schemes[_settings_client.gui.smallmap_land_colour];
 				return ApplyMask(cs->default_colour, &andor);
 			}
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 
 		default:
@@ -1598,11 +1598,11 @@ public:
 							if (tbl->show_on_map && tbl->type == _smallmap_industry_highlight) {
 								legend_colour = _smallmap_industry_highlight_state ? PC_WHITE : PC_BLACK;
 							}
-							FALLTHROUGH;
+							[[fallthrough]];
 
 						case SMT_LINKSTATS:
 							SetDParam(0, tbl->legend);
-							FALLTHROUGH;
+							[[fallthrough]];
 
 						case SMT_OWNER:
 							if (this->map_type != SMT_OWNER || tbl->company != INVALID_COMPANY) {
@@ -1617,7 +1617,7 @@ public:
 								}
 								break;
 							}
-							FALLTHROUGH;
+							[[fallthrough]];
 
 						default:
 							if (this->map_type == SMT_CONTOUR) SetDParam(0, tbl->height * TILE_HEIGHT_STEP);

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -913,7 +913,7 @@ static void *HandleInvalidSpriteRequest(SpriteID sprite, SpriteType requested, S
 	switch (requested) {
 		case SpriteType::Normal:
 			if (sprite == SPR_IMG_QUERY) UserError("Uhm, would you be so kind not to load a NewGRF that makes the 'query' sprite a non-normal sprite?");
-			FALLTHROUGH;
+			[[fallthrough]];
 		case SpriteType::Font:
 			return GetRawSprite(SPR_IMG_QUERY, SpriteType::Normal, allocator);
 		case SpriteType::Recolour:

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -439,7 +439,7 @@ struct IndustryCompare {
 typedef std::set<IndustryListEntry, IndustryCompare> IndustryList;
 
 /** Station data structure */
-struct Station FINAL : SpecializedStation<Station, false> {
+struct Station final : SpecializedStation<Station, false> {
 public:
 	RoadStop *GetPrimaryRoadStop(RoadStopType type) const
 	{

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3450,7 +3450,7 @@ static void TileLoop_Station(TileIndex tile)
 
 		case STATION_DOCK:
 			if (!IsTileFlat(tile)) break; // only handle water part
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case STATION_OILRIG: //(station part)
 		case STATION_BUOY:

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -49,7 +49,7 @@ void StrgenErrorI(const std::string &msg)
 	_errors++;
 }
 
-void NORETURN StrgenFatalI(const std::string &msg)
+[[noreturn]] void StrgenFatalI(const std::string &msg)
 {
 	fmt::print(stderr, LINE_NUM_FMT("FATAL"), _file, _cur_line, msg);
 #ifdef _MSC_VER
@@ -58,7 +58,7 @@ void NORETURN StrgenFatalI(const std::string &msg)
 	throw std::exception();
 }
 
-void NORETURN FatalErrorI(const std::string &msg)
+[[noreturn]] void FatalErrorI(const std::string &msg)
 {
 	fmt::print(stderr, LINE_NUM_FMT("FATAL"), _file, _cur_line, msg);
 #ifdef _MSC_VER

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -149,7 +149,7 @@ ParsedCommandStruct ExtractCommandString(const char *s, bool warnings);
 
 void StrgenWarningI(const std::string &msg);
 void StrgenErrorI(const std::string &msg);
-void NORETURN StrgenFatalI(const std::string &msg);
+[[noreturn]] void StrgenFatalI(const std::string &msg);
 #define StrgenWarning(format_string, ...) StrgenWarningI(fmt::format(FMT_STRING(format_string), ## __VA_ARGS__))
 #define StrgenError(format_string, ...) StrgenErrorI(fmt::format(FMT_STRING(format_string), ## __VA_ARGS__))
 #define StrgenFatal(format_string, ...) StrgenFatalI(fmt::format(FMT_STRING(format_string), ## __VA_ARGS__))

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -83,7 +83,7 @@ static void GenerateRockyArea(TileIndex end, TileIndex start)
 		switch (GetTileType(tile)) {
 			case MP_TREES:
 				if (GetTreeGround(tile) == TREE_GROUND_SHORE) continue;
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case MP_CLEAR:
 				MakeClear(tile, CLEAR_ROCKS, 3);

--- a/src/timer/timer.h
+++ b/src/timer/timer.h
@@ -30,7 +30,7 @@ public:
 	 *
 	 * @param period The period of the timer.
 	 */
-	NODISCARD BaseTimer(const TPeriod period) :
+	[[nodiscard]] BaseTimer(const TPeriod period) :
 		period(period)
 	{
 		TimerManager<TTimerType>::RegisterTimer(*this);
@@ -84,7 +84,7 @@ public:
 	 * @param interval The interval between each callback.
 	 * @param callback The callback to call when the interval has passed.
 	 */
-	NODISCARD IntervalTimer(const TPeriod interval, std::function<void(uint)> callback) :
+	[[nodiscard]] IntervalTimer(const TPeriod interval, std::function<void(uint)> callback) :
 		BaseTimer<TTimerType>(interval),
 		callback(callback)
 	{
@@ -127,7 +127,7 @@ public:
 	 * @param callback The callback to call when the timeout has passed.
 	 * @param start Whether to start the timer immediately. If false, you can call Reset() to start it.
 	 */
-	NODISCARD TimeoutTimer(const TPeriod timeout, std::function<void()> callback, bool start = false) :
+	[[nodiscard]] TimeoutTimer(const TPeriod timeout, std::function<void()> callback, bool start = false) :
 		BaseTimer<TTimerType>(timeout),
 		fired(!start),
 		callback(callback)

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -261,7 +261,7 @@ struct TimetableWindow : Window {
 					SetDParamMaxValue(1, TimerGameEconomy::DateAtStartOfYear(EconomyTime::MAX_YEAR), 0, FS_SMALL);
 					size->width = std::max(GetStringBoundingBox(STR_TIMETABLE_ARRIVAL_DATE).width, GetStringBoundingBox(STR_TIMETABLE_DEPARTURE_DATE).width) + WidgetDimensions::scaled.hsep_wide + padding.width;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case WID_VT_ARRIVAL_DEPARTURE_SELECTION:
 			case WID_VT_TIMETABLE_PANEL:

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1599,7 +1599,7 @@ static void GrowTownInTile(TileIndex *tile_ptr, RoadBits cur_rb, DiagDirection t
 
 				case TL_3X3_GRID: // Use 2x2 grid afterwards!
 					GrowTownWithExtraHouse(t1, TileAddByDiagDir(house_tile, target_dir));
-					FALLTHROUGH;
+					[[fallthrough]];
 
 				case TL_2X2_GRID:
 					rcmd = GetTownRoadGridElement(t1, tile, target_dir);
@@ -1608,7 +1608,7 @@ static void GrowTownInTile(TileIndex *tile_ptr, RoadBits cur_rb, DiagDirection t
 
 				case TL_BETTER_ROADS: // Use original afterwards!
 					GrowTownWithExtraHouse(t1, TileAddByDiagDir(house_tile, target_dir));
-					FALLTHROUGH;
+					[[fallthrough]];
 
 				case TL_ORIGINAL:
 					/* Allow a house at the edge. 60% chance or
@@ -3764,7 +3764,7 @@ Town *ClosestTownFromTile(TileIndex tile, uint threshold)
 
 				return town;
 			}
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case MP_HOUSE:
 			return Town::GetByTile(tile);

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -314,7 +314,7 @@ public:
 
 				/* When double-clicking, continue */
 				if (click_count == 1 || y < 0 || !HasBit(this->available_actions, y)) break;
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 
 			case WID_TA_EXECUTE:

--- a/src/train.h
+++ b/src/train.h
@@ -86,7 +86,7 @@ struct TrainCache {
 /**
  * 'Train' is either a loco or a wagon.
  */
-struct Train FINAL : public GroundVehicle<Train, VEH_TRAIN> {
+struct Train final : public GroundVehicle<Train, VEH_TRAIN> {
 	TrainCache tcache;
 
 	/* Link between the two ends of a multiheaded engine */

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -2644,7 +2644,7 @@ public:
 				case OT_GOTO_DEPOT:
 					/* Skip service in depot orders when the train doesn't need service. */
 					if ((order->GetDepotOrderType() & ODTFB_SERVICE) && !this->v->NeedsServicing()) break;
-					FALLTHROUGH;
+					[[fallthrough]];
 				case OT_GOTO_STATION:
 				case OT_GOTO_WAYPOINT:
 					this->v->current_order = *order;
@@ -3781,7 +3781,7 @@ static bool TrainApproachingLineEnd(Train *v, bool signal, bool reverse)
 	 * for other directions, it will be 1, 3, 5, ..., 15 */
 	switch (v->direction) {
 		case DIR_N : x = ~x + ~y + 25; break;
-		case DIR_NW: x = y;            FALLTHROUGH;
+		case DIR_NW: x = y;            [[fallthrough]];
 		case DIR_NE: x = ~x + 16;      break;
 		case DIR_E : x = ~x + y + 9;   break;
 		case DIR_SE: x = y;            break;

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -428,7 +428,7 @@ CommandCost CmdPlantTree(DoCommandFlag flags, TileIndex tile, TileIndex start_ti
 					msg = STR_ERROR_CAN_T_BUILD_ON_WATER;
 					continue;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case MP_CLEAR: {
 				if (IsBridgeAbove(current_tile)) {
@@ -744,7 +744,7 @@ static void TileLoop_Trees(TileIndex tile)
 							SetTreeGrowth(tile, 0);
 							break;
 						}
-						FALLTHROUGH;
+						[[fallthrough]];
 
 					case 2: { // add a neighbouring tree
 						if (!CanPlantExtraTrees(tile)) break;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1391,7 +1391,7 @@ bool Vehicle::HandleBreakdown()
 			SetWindowDirty(WC_VEHICLE_VIEW, this->index);
 			SetWindowDirty(WC_VEHICLE_DETAILS, this->index);
 
-			FALLTHROUGH;
+			[[fallthrough]];
 		case 1:
 			/* Aircraft breakdowns end only when arriving at the airport */
 			if (this->type == VEH_AIRCRAFT) return false;

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1071,7 +1071,7 @@ struct RefitWindow : public Window {
 				Vehicle *v = Vehicle::Get(this->window_number);
 				this->selected_vehicle = v->index;
 				this->num_vehicles = UINT8_MAX;
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 
 			case 2: { // The vehicle selection has changed; rebuild the entire list.
@@ -1097,7 +1097,7 @@ struct RefitWindow : public Window {
 					this->information_width = max_width;
 					this->ReInit();
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 
 			case 1: // A new cargo has been selected.
@@ -1158,7 +1158,7 @@ struct RefitWindow : public Window {
 					if (_ctrl_pressed) this->num_vehicles = UINT8_MAX;
 					break;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 
 			default:
@@ -1193,7 +1193,7 @@ struct RefitWindow : public Window {
 				this->InvalidateData(1);
 
 				if (click_count == 1) break;
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 
 			case WID_VR_REFIT: // refit button
@@ -3166,7 +3166,7 @@ public:
 						str = STR_VEHICLE_STATUS_LEAVING;
 						break;
 					}
-					FALLTHROUGH;
+					[[fallthrough]];
 				default:
 					if (v->GetNumManualOrders() == 0) {
 						str = STR_VEHICLE_STATUS_NO_ORDERS_VEL;

--- a/src/vehiclelist.cpp
+++ b/src/vehiclelist.cpp
@@ -145,7 +145,7 @@ bool GenerateVehicleSortList(VehicleList *list, const VehicleListIdentifier &vli
 				}
 				break;
 			}
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case VL_STANDARD:
 			for (const Vehicle *v : Vehicle::Iterate()) {

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -424,7 +424,7 @@ LRESULT CALLBACK WndProcGdi(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
 		case WM_PALETTECHANGED:
 			if ((HWND)wParam == hwnd) return 0;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case WM_QUERYNEWPALETTE:
 			video_driver->PaletteChanged(hwnd);

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -2895,7 +2895,7 @@ static int CalcHeightdiff(HighLightStyle style, uint distance, TileIndex start_t
 			byte style_t = (byte)(TileX(end_tile) > TileX(start_tile));
 			start_tile = TILE_ADD(start_tile, ToTileIndexDiff(heightdiff_area_by_dir[style_t]));
 			end_tile   = TILE_ADD(end_tile, ToTileIndexDiff(heightdiff_area_by_dir[2 + style_t]));
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 
 		case HT_POINT:
@@ -3240,7 +3240,7 @@ void VpSelectTilesWithMethod(int x, int y, ViewportPlaceMethod method)
 
 		case VPM_X_LIMITED: // Drag in X direction (limited size).
 			limit = (_thd.sizelimit - 1) * TILE_SIZE;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case VPM_FIX_X: // drag in Y direction
 			x = sx;
@@ -3249,7 +3249,7 @@ void VpSelectTilesWithMethod(int x, int y, ViewportPlaceMethod method)
 
 		case VPM_Y_LIMITED: // Drag in Y direction (limited size).
 			limit = (_thd.sizelimit - 1) * TILE_SIZE;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case VPM_FIX_Y: // drag in X direction
 			y = sy;
@@ -3286,7 +3286,7 @@ calc_heightdiff_single_direction:;
 			limit = (_thd.sizelimit - 1) * TILE_SIZE;
 			x = sx + Clamp(x - sx, -limit, limit);
 			y = sy + Clamp(y - sy, -limit, limit);
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case VPM_X_AND_Y: // drag an X by Y area
 			if (_settings_client.gui.measure_tooltip) {

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -165,7 +165,7 @@ bool IsPossibleDockingTile(Tile t)
 	switch (GetTileType(t)) {
 		case MP_WATER:
 			if (IsLock(t) && GetLockPart(t) == LOCK_PART_MIDDLE) return false;
-			FALLTHROUGH;
+			[[fallthrough]];
 		case MP_RAILWAY:
 		case MP_STATION:
 		case MP_TUNNELBRIDGE:
@@ -507,7 +507,7 @@ CommandCost CmdBuildCanal(DoCommandFlag flags, TileIndex tile, TileIndex start_t
 						MakeSea(current_tile);
 						break;
 					}
-					FALLTHROUGH;
+					[[fallthrough]];
 
 				default:
 					MakeCanal(current_tile, _current_company, Random());
@@ -1087,7 +1087,7 @@ FloodingBehaviour GetFloodingBehaviour(TileIndex tile)
 				Slope tileh = GetTileSlope(tile);
 				return (IsSlopeWithOneCornerRaised(tileh) ? FLOOD_ACTIVE : FLOOD_DRYUP);
 			}
-			FALLTHROUGH;
+			[[fallthrough]];
 		case MP_STATION:
 		case MP_INDUSTRY:
 		case MP_OBJECT:
@@ -1139,7 +1139,7 @@ void DoFloodTile(TileIndex target)
 					flooded = true;
 					break;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 
 			case MP_CLEAR:
 				if (Command<CMD_LANDSCAPE_CLEAR>::Do(DC_EXEC, target).Succeeded()) {

--- a/src/waypoint_base.h
+++ b/src/waypoint_base.h
@@ -13,7 +13,7 @@
 #include "base_station_base.h"
 
 /** Representation of a waypoint. */
-struct Waypoint FINAL : SpecializedStation<Waypoint, true> {
+struct Waypoint final : SpecializedStation<Waypoint, true> {
 	uint16_t town_cn;    ///< The N-1th waypoint for this town (consecutive number)
 
 	/**

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -2641,7 +2641,7 @@ void NWidgetLeaf::SetupSmallestSize(Window *w)
 			size.width = std::max(size.width, ScaleGUITrad(30) + sprite_size.width);
 			size.height = std::max(sprite_size.height, GetStringBoundingBox("_").height + WidgetDimensions::scaled.framerect.Vertical());
 		}
-		FALLTHROUGH;
+		[[fallthrough]];
 		case WWT_PUSHBTN: {
 			padding = {WidgetDimensions::scaled.frametext.Horizontal(), WidgetDimensions::scaled.framerect.Vertical()};
 			break;
@@ -2953,7 +2953,7 @@ static const NWidgetPart *MakeNWidget(const NWidgetPart *nwid_begin, const NWidg
 
 			case WPT_RESIZE: {
 				NWidgetResizeBase *nwrb = dynamic_cast<NWidgetResizeBase *>(dest.get());
-				if (unlikely(nwrb == nullptr)) throw std::runtime_error("WPT_RESIZE requires NWidgetResizeBase");
+				if (nwrb == nullptr) [[unlikely]] throw std::runtime_error("WPT_RESIZE requires NWidgetResizeBase");
 				assert(nwid_begin->u.xy.x >= 0 && nwid_begin->u.xy.y >= 0);
 				nwrb->SetResize(nwid_begin->u.xy.x, nwid_begin->u.xy.y);
 				break;
@@ -2961,7 +2961,7 @@ static const NWidgetPart *MakeNWidget(const NWidgetPart *nwid_begin, const NWidg
 
 			case WPT_MINSIZE: {
 				NWidgetResizeBase *nwrb = dynamic_cast<NWidgetResizeBase *>(dest.get());
-				if (unlikely(nwrb == nullptr)) throw std::runtime_error("WPT_MINSIZE requires NWidgetResizeBase");
+				if (nwrb == nullptr) [[unlikely]] throw std::runtime_error("WPT_MINSIZE requires NWidgetResizeBase");
 				assert(nwid_begin->u.xy.x >= 0 && nwid_begin->u.xy.y >= 0);
 				nwrb->SetMinimalSize(nwid_begin->u.xy.x, nwid_begin->u.xy.y);
 				break;
@@ -2969,7 +2969,7 @@ static const NWidgetPart *MakeNWidget(const NWidgetPart *nwid_begin, const NWidg
 
 			case WPT_MINTEXTLINES: {
 				NWidgetResizeBase *nwrb = dynamic_cast<NWidgetResizeBase *>(dest.get());
-				if (unlikely(nwrb == nullptr)) throw std::runtime_error("WPT_MINTEXTLINES requires NWidgetResizeBase");
+				if (nwrb == nullptr) [[unlikely]] throw std::runtime_error("WPT_MINTEXTLINES requires NWidgetResizeBase");
 				assert(nwid_begin->u.text_lines.size >= FS_BEGIN && nwid_begin->u.text_lines.size < FS_END);
 				nwrb->SetMinimalTextLines(nwid_begin->u.text_lines.lines, nwid_begin->u.text_lines.spacing, nwid_begin->u.text_lines.size);
 				break;
@@ -2977,35 +2977,35 @@ static const NWidgetPart *MakeNWidget(const NWidgetPart *nwid_begin, const NWidg
 
 			case WPT_TEXTSTYLE: {
 				NWidgetCore *nwc = dynamic_cast<NWidgetCore *>(dest.get());
-				if (unlikely(nwc == nullptr)) throw std::runtime_error("WPT_TEXTSTYLE requires NWidgetCore");
+				if (nwc == nullptr) [[unlikely]] throw std::runtime_error("WPT_TEXTSTYLE requires NWidgetCore");
 				nwc->SetTextStyle(nwid_begin->u.text_style.colour, nwid_begin->u.text_style.size);
 				break;
 			}
 
 			case WPT_ALIGNMENT: {
 				NWidgetCore *nwc = dynamic_cast<NWidgetCore *>(dest.get());
-				if (unlikely(nwc == nullptr)) throw std::runtime_error("WPT_ALIGNMENT requires NWidgetCore");
+				if (nwc == nullptr) [[unlikely]] throw std::runtime_error("WPT_ALIGNMENT requires NWidgetCore");
 				nwc->SetAlignment(nwid_begin->u.align.align);
 				break;
 			}
 
 			case WPT_FILL: {
 				NWidgetResizeBase *nwrb = dynamic_cast<NWidgetResizeBase *>(dest.get());
-				if (unlikely(nwrb == nullptr)) throw std::runtime_error("WPT_FILL requires NWidgetResizeBase");
+				if (nwrb == nullptr) [[unlikely]] throw std::runtime_error("WPT_FILL requires NWidgetResizeBase");
 				nwrb->SetFill(nwid_begin->u.xy.x, nwid_begin->u.xy.y);
 				break;
 			}
 
 			case WPT_DATATIP: {
 				NWidgetCore *nwc = dynamic_cast<NWidgetCore *>(dest.get());
-				if (unlikely(nwc == nullptr)) throw std::runtime_error("WPT_DATATIP requires NWidgetCore");
+				if (nwc == nullptr) [[unlikely]] throw std::runtime_error("WPT_DATATIP requires NWidgetCore");
 				nwc->widget_data = nwid_begin->u.data_tip.data;
 				nwc->tool_tip = nwid_begin->u.data_tip.tooltip;
 				break;
 			}
 
 			case WPT_PADDING:
-				if (unlikely(dest == nullptr)) throw std::runtime_error("WPT_PADDING requires NWidgetBase");
+				if (dest == nullptr) [[unlikely]] throw std::runtime_error("WPT_PADDING requires NWidgetBase");
 				dest->SetPadding(nwid_begin->u.padding);
 				break;
 
@@ -3016,7 +3016,7 @@ static const NWidgetPart *MakeNWidget(const NWidgetPart *nwid_begin, const NWidg
 				NWidgetBackground *nwb = dynamic_cast<NWidgetBackground *>(dest.get());
 				if (nwb != nullptr) nwb->SetPIP(nwid_begin->u.pip.pre, nwid_begin->u.pip.inter, nwid_begin->u.pip.post);
 
-				if (unlikely(nwc == nullptr && nwb == nullptr)) throw std::runtime_error("WPT_PIPSPACE requires NWidgetPIPContainer or NWidgetBackground");
+				if (nwc == nullptr && nwb == nullptr) [[unlikely]] throw std::runtime_error("WPT_PIPSPACE requires NWidgetPIPContainer or NWidgetBackground");
 				break;
 			}
 
@@ -3027,13 +3027,13 @@ static const NWidgetPart *MakeNWidget(const NWidgetPart *nwid_begin, const NWidg
 				NWidgetBackground *nwb = dynamic_cast<NWidgetBackground *>(dest.get());
 				if (nwb != nullptr) nwb->SetPIPRatio(nwid_begin->u.pip.pre, nwid_begin->u.pip.inter, nwid_begin->u.pip.post);
 
-				if (unlikely(nwc == nullptr && nwb == nullptr)) throw std::runtime_error("WPT_PIPRATIO requires NWidgetPIPContainer or NWidgetBackground");
+				if (nwc == nullptr && nwb == nullptr) [[unlikely]] throw std::runtime_error("WPT_PIPRATIO requires NWidgetPIPContainer or NWidgetBackground");
 				break;
 			}
 
 			case WPT_SCROLLBAR: {
 				NWidgetCore *nwc = dynamic_cast<NWidgetCore *>(dest.get());
-				if (unlikely(nwc == nullptr)) throw std::runtime_error("WPT_SCROLLBAR requires NWidgetCore");
+				if (nwc == nullptr) [[unlikely]] throw std::runtime_error("WPT_SCROLLBAR requires NWidgetCore");
 				nwc->scrollbar_index = nwid_begin->u.widget.index;
 				break;
 			}
@@ -3139,7 +3139,7 @@ std::unique_ptr<NWidgetBase> MakeNWidgets(const NWidgetPart *nwid_begin, const N
 	if (container == nullptr) container = std::make_unique<NWidgetVertical>();
 	[[maybe_unused]] const NWidgetPart *nwid_part = MakeWidgetTree(nwid_begin, nwid_end, container);
 #ifdef WITH_ASSERT
-	if (unlikely(nwid_part != nwid_end)) throw std::runtime_error("Did not consume all NWidgetParts");
+	if (nwid_part != nwid_end) [[unlikely]] throw std::runtime_error("Did not consume all NWidgetParts");
 #endif
 	return std::move(container);
 }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1267,45 +1267,45 @@ static uint GetWindowZPriority(WindowClass wc)
 	switch (wc) {
 		case WC_TOOLTIPS:
 			++z_priority;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case WC_ERRMSG:
 		case WC_CONFIRM_POPUP_QUERY:
 			++z_priority;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case WC_ENDSCREEN:
 			++z_priority;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case WC_HIGHSCORE:
 			++z_priority;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case WC_DROPDOWN_MENU:
 			++z_priority;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case WC_MAIN_TOOLBAR:
 		case WC_STATUS_BAR:
 			++z_priority;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case WC_OSK:
 			++z_priority;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case WC_QUERY_STRING:
 		case WC_SEND_NETWORK_MSG:
 			++z_priority;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case WC_NETWORK_ASK_RELAY:
 		case WC_MODAL_PROGRESS:
 		case WC_NETWORK_STATUS_WINDOW:
 		case WC_SAVE_PRESET:
 			++z_priority;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case WC_GENERATE_LANDSCAPE:
 		case WC_SAVELOAD:
@@ -1317,19 +1317,19 @@ static uint GetWindowZPriority(WindowClass wc)
 		case WC_SCRIPT_SETTINGS:
 		case WC_TEXTFILE:
 			++z_priority;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case WC_CONSOLE:
 			++z_priority;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case WC_NEWS_WINDOW:
 			++z_priority;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		default:
 			++z_priority;
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case WC_MAIN_WINDOW:
 			return z_priority;
@@ -2844,7 +2844,7 @@ static void MouseLoop(MouseClick click, int mousewheel)
 			if (!scrollwheel_scrolling || w == nullptr || w->window_class != WC_SMALLMAP) break;
 			/* We try to use the scrollwheel to scroll since we didn't touch any of the buttons.
 			 * Simulate a right button click so we can get started. */
-			FALLTHROUGH;
+			[[fallthrough]];
 
 		case MC_RIGHT:
 			DispatchRightClickEvent(w, x - w->left, y - w->top);


### PR DESCRIPTION
## Motivation / Problem

`stdafx.h` contained a number of macros, which provided non-standard attributes and their compiler-specific implementations.

Many of these attributes were standardized in C++17 or C++20.

## Description

| Old Macro | Standard | Equivalent |
| --- | --- | --- |
| `NORETURN` | C++11 | `[[noreturn]]` |
| `NODISCARD` | C++17 | `[[nodiscard]]` |
| `FINAL` | C++11 | `final` |
| `FALLTHROUGH` | C++17 | `[[fallthrough]]` |
| `likely` | C++20 | `[[likely]]` |
| `unlikely` | C++20 | `[[unlikely]]` |

This PR is mostly search+replace. It does not question the usage of the attributes; though some usages of `unlikely` are probably questionable :)

There was one non-standard usage of `[[noreturn]]` in squirrel: `[[noreturn]]` only applies to functions, not to function pointer typedefs. Easiest solution was to remove the function pointer entirely.

* Previously a tuple (static error handler, `void*` user data) was passed around.
* The only existing handler did cast the `void*` back to a class, and then called a member function.
* The member function than constructed a `std::string` and threw it.
* The `std::string`  was caught in exactly one place.

All this stuff was removed; now a `std::runtime_error` is thrown/caught directly.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
