### PR TITLE
Remove: [Script] CONFIG_RANDOM from AddSetting flags

### DIFF
--- a/src/ai/ai_info.cpp
+++ b/src/ai/ai_info.cpp
@@ -42,14 +42,14 @@ template <> const char *GetClassName<AIInfo, ScriptType::AI>() { return "AIInfo"
 	SQAIInfo.DefSQAdvancedMethod(engine, &AIInfo::AddSetting, "AddSetting");
 	SQAIInfo.DefSQAdvancedMethod(engine, &AIInfo::AddLabels, "AddLabels");
 	SQAIInfo.DefSQConst(engine, SCRIPTCONFIG_NONE, "CONFIG_NONE");
-	SQAIInfo.DefSQConst(engine, SCRIPTCONFIG_RANDOM, "CONFIG_RANDOM");
+	SQAIInfo.DefSQConst(engine, SCRIPTCONFIG_NONE, "CONFIG_RANDOM"); // Deprecated, mapped to NONE.
 	SQAIInfo.DefSQConst(engine, SCRIPTCONFIG_BOOLEAN, "CONFIG_BOOLEAN");
 	SQAIInfo.DefSQConst(engine, SCRIPTCONFIG_INGAME, "CONFIG_INGAME");
 	SQAIInfo.DefSQConst(engine, SCRIPTCONFIG_DEVELOPER, "CONFIG_DEVELOPER");
 
 	/* Pre 1.2 had an AI prefix */
 	SQAIInfo.DefSQConst(engine, SCRIPTCONFIG_NONE, "AICONFIG_NONE");
-	SQAIInfo.DefSQConst(engine, SCRIPTCONFIG_RANDOM, "AICONFIG_RANDOM");
+	SQAIInfo.DefSQConst(engine, SCRIPTCONFIG_NONE, "AICONFIG_RANDOM"); // Deprecated, mapped to NONE.
 	SQAIInfo.DefSQConst(engine, SCRIPTCONFIG_BOOLEAN, "AICONFIG_BOOLEAN");
 	SQAIInfo.DefSQConst(engine, SCRIPTCONFIG_INGAME, "AICONFIG_INGAME");
 

--- a/src/game/game_info.cpp
+++ b/src/game/game_info.cpp
@@ -40,7 +40,7 @@ template <> const char *GetClassName<GameInfo, ScriptType::GS>() { return "GSInf
 	SQGSInfo.DefSQAdvancedMethod(engine, &GameInfo::AddSetting, "AddSetting");
 	SQGSInfo.DefSQAdvancedMethod(engine, &GameInfo::AddLabels, "AddLabels");
 	SQGSInfo.DefSQConst(engine, SCRIPTCONFIG_NONE, "CONFIG_NONE");
-	SQGSInfo.DefSQConst(engine, SCRIPTCONFIG_RANDOM, "CONFIG_RANDOM");
+	SQGSInfo.DefSQConst(engine, SCRIPTCONFIG_NONE, "CONFIG_RANDOM"); // Deprecated, mapped to NONE.
 	SQGSInfo.DefSQConst(engine, SCRIPTCONFIG_BOOLEAN, "CONFIG_BOOLEAN");
 	SQGSInfo.DefSQConst(engine, SCRIPTCONFIG_INGAME, "CONFIG_INGAME");
 	SQGSInfo.DefSQConst(engine, SCRIPTCONFIG_DEVELOPER, "CONFIG_DEVELOPER");

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -24,6 +24,7 @@
  *
  * API removals:
  * \li AIError::ERR_PRECONDITION_TOO_MANY_PARAMETERS, that error is never returned anymore.
+ * \li AIInfo::CONFIG_RANDOM, no longer used.
  *
  * Other changes:
  * \li AIGroupList accepts an optional filter function

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -90,6 +90,7 @@
  *
  * API removals:
  * \li GSError::ERR_PRECONDITION_TOO_MANY_PARAMETERS, that error is never returned anymore.
+ * \li AIInfo::CONFIG_RANDOM, no longer used.
  *
  * Other changes:
  * \li GSGroupList accepts an optional filter function

--- a/src/script/api/script_info_docs.hpp
+++ b/src/script/api/script_info_docs.hpp
@@ -203,7 +203,6 @@ public:
 	/** Miscellaneous flags for Script settings. */
 	enum ScriptConfigFlags {
 		CONFIG_NONE,      ///< Normal setting.
-		CONFIG_RANDOM,    ///< When randomizing the Script, pick any value between min_value and max_value (inclusive).
 		CONFIG_BOOLEAN,   ///< This value is a boolean (either 0 (false) or 1 (true) ).
 		CONFIG_INGAME,    ///< This setting can be changed while the Script is running.
 		CONFIG_DEVELOPER, ///< This setting will only be visible when the Script development tools are active.

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -34,14 +34,6 @@ void ScriptConfig::Change(std::optional<const std::string> name, int version, bo
 	this->ClearConfigList();
 
 	if (_game_mode == GM_NORMAL && this->info != nullptr) {
-		/* If we're in an existing game and the Script is changed, set all settings
-		 *  for the Script that have the random flag to a random value. */
-		for (const auto &item : *this->info->GetConfigList()) {
-			if (item.flags & SCRIPTCONFIG_RANDOM) {
-				this->SetSetting(item.name, ScriptObject::GetRandomizer(OWNER_NONE).Next(item.max_value + 1 - item.min_value) + item.min_value);
-			}
-		}
-
 		this->AddRandomDeviation();
 	}
 }

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -20,7 +20,7 @@ static const int INT32_DIGITS_WITH_SIGN_AND_TERMINATION = 10 + 1 + 1;
 /** Bitmask of flags for Script settings. */
 enum ScriptConfigFlags {
 	SCRIPTCONFIG_NONE      = 0x0, ///< No flags set.
-	SCRIPTCONFIG_RANDOM    = 0x1, ///< When randomizing the Script, pick any value between min_value and max_value when on custom difficulty setting.
+	// Unused flag 0x1.
 	SCRIPTCONFIG_BOOLEAN   = 0x2, ///< This value is a boolean (either 0 (false) or 1 (true) ).
 	SCRIPTCONFIG_INGAME    = 0x4, ///< This setting can be changed while the Script is running.
 	SCRIPTCONFIG_DEVELOPER = 0x8, ///< This setting will only be visible when the Script development tools are active.

--- a/src/script/script_info.cpp
+++ b/src/script/script_info.cpp
@@ -162,12 +162,6 @@ SQInteger ScriptInfo::AddSetting(HSQUIRRELVM vm)
 	}
 	sq_pop(vm, 1);
 
-	/* Don't allow both random_deviation and SCRIPTCONFIG_RANDOM to
-	 * be set for the same config item. */
-	if ((items & 0x200) != 0 && (config.flags & SCRIPTCONFIG_RANDOM) != 0) {
-		this->engine->ThrowError("Setting both random_deviation and SCRIPTCONFIG_RANDOM is not allowed");
-		return SQ_ERROR;
-	}
 	/* Reset the bit for random_deviation as it's optional. */
 	items &= ~0x200;
 


### PR DESCRIPTION
## Motivation / Problem

Closes #11914
Fixes #9540

`CONFIG_RANDOM`, which can be used as flag in `AIInfo.AddSetting` and `GSInfo.AddSetting` is a weird flag. It is commented to only be used when difficulty is "custom", but this wasn't actually what the code was doing. It was only checked and used when an AI was "changed", which happens in several moments:

- When the current saved version of an AI can't be loaded, but an older version is
- When a random AI is starting

And some other weird cases. Anyway, when that happened, the setting was randomized, no matter what the difficulty setting was. But this flag was never read when an AI started via normal configuration. This is all a very weird interaction, with unpredictable results.

Upon further investigation, turns out no AI / GS actually uses it, all but one. That gives me the impression the flag was also actually never understood. Time to remove it.

With access to all BaNaNaS content:
```
$ grep -R CONFIG_RANDOM | cut -d/ -f2,3 | cut -d- -f1 | uniq
4c444146/LuDiAI_AfterFix
46454747/Feca_Goal_Games
49444c49/Limitations
```
The 2nd and 3rd hit are commented out references to `CONFIG_RANDOM`. Only the first actually uses it.

## Description

Remove `CONFIG_RANDOM`. Well, I say remove, but as it is `AIInfo`, we actually can't remove it, as there is no compatibility layer for this class (as it needs info from that class to load the right layer). So it just maps to `CONFIG_NONE`. But it is removed from the documentation :)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
