### PR TITLE
Fix: [Script] Apply random deviation only at script start

### DIFF
--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -48,6 +48,7 @@
 		/* Load default data and store the name in the settings */
 		config->Change(info->GetName(), -1, false, true);
 	}
+	if (rerandomise_ai) config->AddRandomDeviation();
 	config->AnchorUnchangeableSettings();
 
 	Backup<CompanyID> cur_company(_current_company, company, FILE_LINE);

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -31,8 +31,9 @@ public:
 
 	/**
 	 * Start up a new GameScript.
+	 * @param randomise Whether to randomise the configured GameScript.
 	 */
-	static void StartNew();
+	static void StartNew(bool randomise = true);
 
 	/**
 	 * Uninitialize the Game system.

--- a/src/game/game_core.cpp
+++ b/src/game/game_core.cpp
@@ -69,7 +69,7 @@
 	}
 }
 
-/* static */ void Game::StartNew()
+/* static */ void Game::StartNew(bool randomise)
 {
 	if (Game::instance != nullptr) return;
 
@@ -83,6 +83,7 @@
 	GameInfo *info = config->GetInfo();
 	if (info == nullptr) return;
 
+	if (randomise) config->AddRandomDeviation();
 	config->AnchorUnchangeableSettings();
 
 	Backup<CompanyID> cur_company(_current_company, FILE_LINE);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -553,7 +553,7 @@ static void StartScripts()
 	}
 
 	/* Start the GameScript. */
-	Game::StartNew();
+	Game::StartNew(false);
 
 	ShowScriptDebugWindowIfScriptError();
 }

--- a/src/script/api/script_info_docs.hpp
+++ b/src/script/api/script_info_docs.hpp
@@ -235,9 +235,10 @@ public:
 	 *    is selected. Required. The value will be clamped in the range
 	 *    [MIN(int32_t), MAX(int32_t)] (inclusive).
 	 *  - random_deviation If this property has a nonzero value, then the
-	 *    actual value of the setting in game will be randomized in the range
+	 *    actual value of the setting in game will be randomised in the range
 	 *    [user_configured_value - random_deviation, user_configured_value + random_deviation] (inclusive).
 	 *    random_deviation sign is ignored and the value is clamped in the range [0, MAX(int32_t)] (inclusive).
+	 *    The randomisation will happen just before the Script start.
 	 *    Not allowed if the CONFIG_RANDOM flag is set, otherwise optional.
 	 *  - step_size The increase/decrease of the value every time the user
 	 *    clicks one of the up/down arrow buttons. Optional, default is 1.

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -32,10 +32,6 @@ void ScriptConfig::Change(std::optional<const std::string> name, int version, bo
 	this->to_load_data.reset();
 
 	this->ClearConfigList();
-
-	if (_game_mode == GM_NORMAL && this->info != nullptr) {
-		this->AddRandomDeviation();
-	}
 }
 
 ScriptConfig::ScriptConfig(const ScriptConfig *config)
@@ -49,9 +45,6 @@ ScriptConfig::ScriptConfig(const ScriptConfig *config)
 	for (const auto &item : config->settings) {
 		this->settings[item.first] = item.second;
 	}
-
-	/* Virtual functions get called statically in constructors, so make it explicit to remove any confusion. */
-	this->ScriptConfig::AddRandomDeviation();
 }
 
 ScriptConfig::~ScriptConfig()


### PR DESCRIPTION
## Motivation / Problem
Random deviation is applied inconsistently:
* It's applied right before game start (in `MakeNewgameSettingsLive()`) so after the user decided the settings for the script.
* It's applied when changing script (`ScriptConfig::Change()`) for a slot during game, but before the user has access to the settings.
* It's applied when loading a savegame (`ScriptConfig::Change()`).
* It's applied when a random AI starts (`ScriptConfig::Change()`).
* It's applied during `start_ai` command (`ScriptConfig::Change()`) but only if a script name is specified and before applying the provided settings, else it uses the current config for the slot without deviation.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
The random deviation is now applied only when a script starts (random or not), so always after user decided the settings for the script. And it's never applied when loading a savegame.

Documentation was not very clear about when the random deviation would be applied, so I fixed it.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
