### PR TITLE
Feature: Order flag to unbunch vehicles at depot

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -1477,6 +1477,7 @@ void AircraftLeaveHangar(Aircraft *v, Direction exit_dir)
 	}
 
 	VehicleServiceInDepot(v);
+	v->LeaveUnbunchingDepot();
 	SetAircraftPosition(v, v->x_pos, v->y_pos, v->z_pos);
 	InvalidateWindowData(WC_VEHICLE_DEPOT, v->tile);
 	SetWindowClassesDirty(WC_AIRCRAFT_LIST);
@@ -1520,6 +1521,9 @@ static void AircraftEventHandler_InHangar(Aircraft *v, const AirportFTAClass *ap
 		v->current_order.Free();
 		return;
 	}
+
+	/* Check if we should wait here for unbunching. */
+	if (v->IsWaitingForUnbunching()) return;
 
 	if (!v->current_order.IsType(OT_GOTO_STATION) &&
 			!v->current_order.IsType(OT_GOTO_DEPOT))

--- a/src/base_consist.cpp
+++ b/src/base_consist.cpp
@@ -42,3 +42,13 @@ void BaseConsist::CopyConsistPropertiesFrom(const BaseConsist *src)
 	}
 	if (HasBit(src->vehicle_flags, VF_SERVINT_IS_CUSTOM)) SetBit(this->vehicle_flags, VF_SERVINT_IS_CUSTOM);
 }
+
+/**
+ * Resets all the data used for depot unbunching.
+ */
+void BaseConsist::ResetDepotUnbunching()
+{
+	this->depot_unbunching_last_departure = 0;
+	this->depot_unbunching_next_departure = 0;
+	this->round_trip_time = 0;
+}

--- a/src/base_consist.h
+++ b/src/base_consist.h
@@ -22,6 +22,10 @@ struct BaseConsist {
 	TimerGameTick::Ticks lateness_counter;      ///< How many ticks late (or early if negative) this vehicle is.
 	TimerGameTick::TickCounter timetable_start; ///< At what tick of TimerGameTick::counter the vehicle should start its timetable.
 
+	TimerGameTick::TickCounter depot_unbunching_last_departure; ///< When the vehicle last left its unbunching depot.
+	TimerGameTick::TickCounter depot_unbunching_next_departure; ///< When the vehicle will next try to leave its unbunching depot.
+	TimerGameTick::Ticks round_trip_time;  ///< How many ticks for a single circumnavigation of the orders.
+
 	uint16_t service_interval;            ///< The interval for (automatic) servicing; either in days or %.
 
 	VehicleOrderID cur_real_order_index;///< The index to the current real (non-implicit) order
@@ -32,6 +36,7 @@ struct BaseConsist {
 	virtual ~BaseConsist() = default;
 
 	void CopyConsistPropertiesFrom(const BaseConsist *src);
+	void ResetDepotUnbunching();
 };
 
 #endif /* BASE_CONSIST_H */

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -5121,6 +5121,14 @@ STR_ERROR_UNABLE_TO_FIND_LOCAL_DEPOT                            :{WHITE}Unable t
 
 STR_ERROR_DEPOT_WRONG_DEPOT_TYPE                                :Wrong depot type
 
+# Depot unbunching related errors
+STR_ERROR_UNBUNCHING_ONLY_ONE_ALLOWED                           :{WHITE}... can only have one unbunching order
+STR_ERROR_UNBUNCHING_NO_FULL_LOAD                               :{WHITE}... cannot use full load orders when vehicle has an unbunching order
+STR_ERROR_UNBUNCHING_NO_UNBUNCHING_FULL_LOAD                    :{WHITE}... cannot unbunch a vehicle with a full load order
+STR_ERROR_UNBUNCHING_NO_CONDITIONAL                             :{WHITE}... cannot use conditional orders when vehicle has an unbunching order
+STR_ERROR_UNBUNCHING_NO_UNBUNCHING_CONDITIONAL                  :{WHITE}... cannot unbunch a vehicle with a conditional order
+STR_ERROR_UNBUNCHING_NO_SERVICE_IF_NEEDED                       :{WHITE}... vehicle must always visit the depot to unbunch there
+
 # Autoreplace related errors
 STR_ERROR_TRAIN_TOO_LONG_AFTER_REPLACEMENT                      :{WHITE}{VEHICLE} is too long after replacement
 STR_ERROR_AUTOREPLACE_NOTHING_TO_DO                             :{WHITE}No autoreplace/renew rules applied

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4400,6 +4400,7 @@ STR_VEHICLE_VIEW_AIRCRAFT_STATUS_START_STOP_TOOLTIP             :{BLACK}Current 
 # Messages in the start stop button in the vehicle view
 STR_VEHICLE_STATUS_LOADING_UNLOADING                            :{LTBLUE}Loading / Unloading
 STR_VEHICLE_STATUS_LEAVING                                      :{LTBLUE}Leaving
+STR_VEHICLE_STATUS_WAITING_UNBUNCHING                           :{LTBLUE}Waiting to unbunch
 STR_VEHICLE_STATUS_CRASHED                                      :{RED}Crashed!
 STR_VEHICLE_STATUS_BROKEN_DOWN                                  :{RED}Broken down
 STR_VEHICLE_STATUS_STOPPED                                      :{RED}Stopped
@@ -4413,6 +4414,7 @@ STR_VEHICLE_STATUS_NO_ORDERS_VEL                                :{LTBLUE}No orde
 STR_VEHICLE_STATUS_HEADING_FOR_WAYPOINT_VEL                     :{LTBLUE}Heading for {WAYPOINT}, {VELOCITY}
 STR_VEHICLE_STATUS_HEADING_FOR_DEPOT_VEL                        :{ORANGE}Heading for {DEPOT}, {VELOCITY}
 STR_VEHICLE_STATUS_HEADING_FOR_DEPOT_SERVICE_VEL                :{LTBLUE}Service at {DEPOT}, {VELOCITY}
+STR_VEHICLE_STATUS_HEADING_FOR_DEPOT_UNBUNCH_VEL                :{LTBLUE}Unbunch and service at {DEPOT}, {VELOCITY}
 
 STR_VEHICLE_STATUS_CANNOT_REACH_STATION_VEL                     :{LTBLUE}Cannot reach {STATION}, {VELOCITY}
 STR_VEHICLE_STATUS_CANNOT_REACH_WAYPOINT_VEL                    :{LTBLUE}Cannot reach {WAYPOINT}, {VELOCITY}
@@ -4543,7 +4545,7 @@ STR_ORDERS_TIMETABLE_VIEW_TOOLTIP                               :{BLACK}Switch t
 
 STR_ORDERS_LIST_TOOLTIP                                         :{BLACK}Order list - click on an order to highlight it. Ctrl+Click to scroll to the order's destination
 STR_ORDER_INDEX                                                 :{COMMA}:{NBSP}
-STR_ORDER_TEXT                                                  :{STRING4} {STRING2} {STRING}
+STR_ORDER_TEXT                                                  :{STRING4} {STRING2} {STRING} {STRING}
 
 STR_ORDERS_END_OF_ORDERS                                        :- - End of Orders - -
 STR_ORDERS_END_OF_SHARED_ORDERS                                 :- - End of Shared Orders - -
@@ -4577,11 +4579,11 @@ STR_ORDER_REFIT_AUTO_TOOLTIP                                    :{BLACK}Select w
 STR_ORDER_DROP_REFIT_AUTO                                       :Fixed cargo
 STR_ORDER_DROP_REFIT_AUTO_ANY                                   :Available cargo
 
-STR_ORDER_SERVICE                                               :{BLACK}Service
 STR_ORDER_DROP_GO_ALWAYS_DEPOT                                  :Always go
 STR_ORDER_DROP_SERVICE_DEPOT                                    :Service if needed
 STR_ORDER_DROP_HALT_DEPOT                                       :Stop
-STR_ORDER_SERVICE_TOOLTIP                                       :{BLACK}Skip this order unless a service is needed
+STR_ORDER_DROP_UNBUNCH                                          :Unbunch
+STR_ORDER_DEPOT_ACTION_TOOLTIP                                  :{BLACK}Select the action to take at this depot
 
 STR_ORDER_CONDITIONAL_VARIABLE_TOOLTIP                          :{BLACK}Vehicle data to base jumping on
 
@@ -4649,6 +4651,8 @@ STR_ORDER_GO_TO_DEPOT_FORMAT                                    :{STRING} {DEPOT
 STR_ORDER_REFIT_ORDER                                           :(Refit to {STRING})
 STR_ORDER_REFIT_STOP_ORDER                                      :(Refit to {STRING} and stop)
 STR_ORDER_STOP_ORDER                                            :(Stop)
+
+STR_ORDER_WAIT_TO_UNBUNCH                                       :(wait to unbunch)
 
 STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING1}
 STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Can't use station){POP_COLOUR} {STRING} {STATION} {STRING1}

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -144,7 +144,7 @@ public:
 	/** What caused us going to the depot? */
 	inline OrderDepotTypeFlags GetDepotOrderType() const { return (OrderDepotTypeFlags)GB(this->flags, 0, 3); }
 	/** What are we going to do when in the depot. */
-	inline OrderDepotActionFlags GetDepotActionType() const { return (OrderDepotActionFlags)GB(this->flags, 4, 3); }
+	inline OrderDepotActionFlags GetDepotActionType() const { return (OrderDepotActionFlags)GB(this->flags, 3, 4); }
 	/** What variable do we have to compare? */
 	inline OrderConditionVariable GetConditionVariable() const { return (OrderConditionVariable)GB(this->dest, 11, 5); }
 	/** What is the comparator to use? */
@@ -165,7 +165,7 @@ public:
 	/** Set the cause to go to the depot. */
 	inline void SetDepotOrderType(OrderDepotTypeFlags depot_order_type) { SB(this->flags, 0, 3, depot_order_type); }
 	/** Set what we are going to do in the depot. */
-	inline void SetDepotActionType(OrderDepotActionFlags depot_service_type) { SB(this->flags, 4, 3, depot_service_type); }
+	inline void SetDepotActionType(OrderDepotActionFlags depot_service_type) { SB(this->flags, 3, 4, depot_service_type); }
 	/** Set variable we have to compare. */
 	inline void SetConditionVariable(OrderConditionVariable condition_variable) { SB(this->dest, 11, 5, condition_variable); }
 	/** Set the comparator to use. */

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -937,6 +937,9 @@ void InsertOrder(Vehicle *v, Order *new_o, VehicleOrderID sel_ord)
 				u->cur_implicit_order_index = cur;
 			}
 		}
+		/* Unbunching data is no longer valid. */
+		u->ResetDepotUnbunching();
+
 		/* Update any possible open window of the vehicle */
 		InvalidateVehicleOrder(u, INVALID_VEH_ORDER_ID | (sel_ord << 8));
 	}
@@ -1051,6 +1054,8 @@ void DeleteOrder(Vehicle *v, VehicleOrderID sel_ord)
 				if (u->cur_implicit_order_index >= u->GetNumOrders()) u->cur_implicit_order_index = 0;
 			}
 		}
+		/* Unbunching data is no longer valid. */
+		u->ResetDepotUnbunching();
 
 		/* Update any possible open window of the vehicle */
 		InvalidateVehicleOrder(u, sel_ord | (INVALID_VEH_ORDER_ID << 8));
@@ -1096,6 +1101,9 @@ CommandCost CmdSkipToOrder(DoCommandFlag flags, VehicleID veh_id, VehicleOrderID
 
 		v->cur_implicit_order_index = v->cur_real_order_index = sel_ord;
 		v->UpdateRealOrderIndex();
+
+		/* Unbunching data is no longer valid. */
+		v->ResetDepotUnbunching();
 
 		InvalidateVehicleOrder(v, VIWD_MODIFY_ORDERS);
 
@@ -1173,6 +1181,9 @@ CommandCost CmdMoveOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID movi
 			} else if (u->cur_implicit_order_index < moving_order && u->cur_implicit_order_index >= target_order) {
 				u->cur_implicit_order_index++;
 			}
+			/* Unbunching data is no longer valid. */
+			u->ResetDepotUnbunching();
+
 
 			assert(v->orders == u->orders);
 			/* Update any possible open window of the vehicle */
@@ -1430,6 +1441,10 @@ CommandCost CmdModifyOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID se
 					u->current_order.GetLoadType() != order->GetLoadType()) {
 				u->current_order.SetLoadType(order->GetLoadType());
 			}
+
+			/* Unbunching data is no longer valid. */
+			u->ResetDepotUnbunching();
+
 			InvalidateVehicleOrder(u, VIWD_MODIFY_ORDERS);
 		}
 	}
@@ -1834,6 +1849,9 @@ void DeleteVehicleOrders(Vehicle *v, bool keep_orderlist, bool reset_order_indic
 		v->orders->FreeChain(keep_orderlist);
 		if (!keep_orderlist) v->orders = nullptr;
 	}
+
+	/* Unbunching data is no longer valid. */
+	v->ResetDepotUnbunching();
 
 	if (reset_order_indices) {
 		v->cur_implicit_order_index = v->cur_real_order_index = 0;

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1361,6 +1361,7 @@ CommandCost CmdModifyOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID se
 					case DA_ALWAYS_GO:
 						order->SetDepotOrderType((OrderDepotTypeFlags)(order->GetDepotOrderType() & ~ODTFB_SERVICE));
 						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() & ~ODATFB_HALT));
+						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() & ~ODATFB_UNBUNCH));
 						break;
 
 					case DA_SERVICE:
@@ -1371,8 +1372,15 @@ CommandCost CmdModifyOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID se
 
 					case DA_STOP:
 						order->SetDepotOrderType((OrderDepotTypeFlags)(order->GetDepotOrderType() & ~ODTFB_SERVICE));
+						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() & ~ODATFB_UNBUNCH));
 						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() | ODATFB_HALT));
 						order->SetRefit(CARGO_NO_REFIT);
+						break;
+
+					case DA_UNBUNCH:
+						order->SetDepotOrderType((OrderDepotTypeFlags)(order->GetDepotOrderType() & ~ODTFB_SERVICE));
+						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() & ~ODATFB_HALT));
+						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() | ODATFB_UNBUNCH));
 						break;
 
 					default:

--- a/src/order_type.h
+++ b/src/order_type.h
@@ -161,6 +161,7 @@ enum OrderDepotAction {
 	DA_ALWAYS_GO, ///< Always go to the depot
 	DA_SERVICE,   ///< Service only if needed
 	DA_STOP,      ///< Go to the depot and stop there
+	DA_UNBUNCH,   ///< Go to the depot and unbunch
 	DA_END
 };
 

--- a/src/order_type.h
+++ b/src/order_type.h
@@ -103,6 +103,7 @@ enum OrderDepotActionFlags {
 	ODATF_SERVICE_ONLY   = 0,      ///< Only service the vehicle.
 	ODATFB_HALT          = 1 << 0, ///< Service the vehicle and then halt it.
 	ODATFB_NEAREST_DEPOT = 1 << 1, ///< Send the vehicle to the nearest depot.
+	ODATFB_UNBUNCH       = 1 << 2, ///< Service the vehicle and then unbunch it.
 };
 DECLARE_ENUM_AS_BIT_SET(OrderDepotActionFlags)
 

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -1030,6 +1030,7 @@ bool RoadVehLeaveDepot(RoadVehicle *v, bool first)
 		if (RoadVehFindCloseTo(v, x, y, v->direction, false) != nullptr) return true;
 
 		VehicleServiceInDepot(v);
+		v->LeaveUnbunchingDepot();
 
 		StartRoadVehSound(v);
 
@@ -1587,7 +1588,11 @@ static bool RoadVehController(RoadVehicle *v)
 
 	if (v->current_order.IsType(OT_LOADING)) return true;
 
-	if (v->IsInDepot() && RoadVehLeaveDepot(v, true)) return true;
+	if (v->IsInDepot()) {
+		/* Check if we should wait here for unbunching. */
+		if (v->IsWaitingForUnbunching()) return true;
+		if (RoadVehLeaveDepot(v, true)) return true;
+	}
 
 	v->ShowVisualEffect();
 

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -387,7 +387,12 @@ CommandCost CmdTurnRoadVeh(DoCommandFlag flags, VehicleID veh_id)
 
 	if (IsTileType(v->tile, MP_TUNNELBRIDGE) && DirToDiagDir(v->direction) == GetTunnelBridgeDirection(v->tile)) return CMD_ERROR;
 
-	if (flags & DC_EXEC) v->reverse_ctr = 180;
+	if (flags & DC_EXEC) {
+		v->reverse_ctr = 180;
+
+		/* Unbunching data is no longer valid. */
+		v->ResetDepotUnbunching();
+	}
 
 	return CommandCost();
 }

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1765,6 +1765,12 @@ bool AfterLoadGame()
 				v->current_order.SetLoadType(OLFB_NO_LOAD);
 			}
 		}
+	} else if (IsSavegameVersionBefore(SLV_DEPOT_UNBUNCHING)) {
+		/* OrderDepotActionFlags were moved, instead of starting at bit 4 they now start at bit 3. */
+		for (Order *order : Order::Iterate()) {
+			if (!order->IsType(OT_GOTO_DEPOT)) continue;
+			order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() >> 1));
+		}
 	}
 
 	/* The water class was moved/unified. */

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -374,6 +374,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_SHIP_ACCELERATION,                  ///< 329  PR#10734 Start using Vehicle's acceleration field for ships too.
 
 	SLV_MAX_LOAN_FOR_COMPANY,               ///< 330  PR#11224 Separate max loan for each company.
+	SLV_DEPOT_UNBUNCHING,                   ///< 330  PR#11945 Allow unbunching shared order vehicles at a depot.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -738,6 +738,10 @@ public:
 		SLE_CONDVAR(Vehicle, current_order_time,    SLE_INT32,                   SLV_TIMETABLE_TICKS_TYPE, SL_MAX_VERSION),
 		SLE_CONDVAR(Vehicle, last_loading_tick,     SLE_UINT64,                   SLV_LAST_LOADING_TICK, SL_MAX_VERSION),
 		SLE_CONDVAR(Vehicle, lateness_counter,      SLE_INT32,                   SLV_67, SL_MAX_VERSION),
+
+		SLE_CONDVAR(Vehicle, depot_unbunching_last_departure, SLE_UINT64,        SLV_DEPOT_UNBUNCHING, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, depot_unbunching_next_departure, SLE_UINT64,        SLV_DEPOT_UNBUNCHING, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, round_trip_time,       SLE_INT32,                   SLV_DEPOT_UNBUNCHING, SL_MAX_VERSION),
 	};
 #if defined(_MSC_VER) && (_MSC_VER == 1915 || _MSC_VER == 1916)
 		return description;

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -387,6 +387,9 @@ static bool CheckShipLeaveDepot(Ship *v)
 {
 	if (!v->IsChainInDepot()) return false;
 
+	/* Check if we should wait here for unbunching. */
+	if (v->IsWaitingForUnbunching()) return true;
+
 	/* We are leaving a depot, but have to go to the exact same one; re-enter */
 	if (v->current_order.IsType(OT_GOTO_DEPOT) &&
 			IsShipDepotTile(v->tile) && GetDepotIndex(v->tile) == v->current_order.GetDestination()) {
@@ -433,8 +436,9 @@ static bool CheckShipLeaveDepot(Ship *v)
 	v->UpdateViewport(true, true);
 	SetWindowDirty(WC_VEHICLE_DEPOT, v->tile);
 
-	v->PlayLeaveStationSound();
 	VehicleServiceInDepot(v);
+	v->LeaveUnbunchingDepot();
+	v->PlayLeaveStationSound();
 	InvalidateWindowData(WC_VEHICLE_DEPOT, v->tile);
 	SetWindowClassesDirty(WC_SHIPS_LIST);
 

--- a/src/timetable_cmd.cpp
+++ b/src/timetable_cmd.cpp
@@ -205,6 +205,12 @@ CommandCost CmdChangeTimetable(DoCommandFlag flags, VehicleID veh, VehicleOrderI
 			default:
 				break;
 		}
+
+		/* Unbunching data is no longer valid for any vehicle in this shared order group. */
+		Vehicle *u = v->FirstShared();
+		for (; u != nullptr; u = u->NextShared()) {
+			u->ResetDepotUnbunching();
+		}
 	}
 
 	return CommandCost();
@@ -272,6 +278,9 @@ CommandCost CmdSetVehicleOnTime(DoCommandFlag flags, VehicleID veh, bool apply_t
 				if (u->lateness_counter > most_late) {
 					most_late = u->lateness_counter;
 				}
+
+				/* Unbunching data is no longer valid. */
+				u->ResetDepotUnbunching();
 			}
 			if (most_late > 0) {
 				for (Vehicle *u = v->FirstShared(); u != nullptr; u = u->NextShared()) {
@@ -284,6 +293,8 @@ CommandCost CmdSetVehicleOnTime(DoCommandFlag flags, VehicleID veh, bool apply_t
 			}
 		} else {
 			v->lateness_counter = 0;
+			/* Unbunching data is no longer valid. */
+			v->ResetDepotUnbunching();
 			SetWindowDirty(WC_VEHICLE_TIMETABLE, v->index);
 		}
 	}
@@ -383,11 +394,14 @@ CommandCost CmdSetTimetableStart(DoCommandFlag flags, VehicleID veh_id, bool tim
 		int idx = 0;
 
 		for (Vehicle *w : vehs) {
-
 			w->lateness_counter = 0;
 			ClrBit(w->vehicle_flags, VF_TIMETABLE_STARTED);
 			/* Do multiplication, then division to reduce rounding errors. */
 			w->timetable_start = start_tick + (idx * total_duration / num_vehs);
+
+			/* Unbunching data is no longer valid. */
+			v->ResetDepotUnbunching();
+
 			SetWindowDirty(WC_VEHICLE_TIMETABLE, w->index);
 			++idx;
 		}

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -2112,6 +2112,9 @@ CommandCost CmdReverseTrainDirection(DoCommandFlag flags, VehicleID veh_id, bool
 				HideFillingPercent(&v->fill_percent_te_id);
 				ReverseTrainDirection(v);
 			}
+
+			/* Unbunching data is no longer valid. */
+			v->ResetDepotUnbunching();
 		}
 	}
 	return CommandCost();
@@ -2142,6 +2145,9 @@ CommandCost CmdForceTrainProceed(DoCommandFlag flags, VehicleID veh_id)
 		 * next signal we encounter. */
 		t->force_proceed = t->force_proceed == TFP_SIGNAL ? TFP_NONE : HasBit(t->flags, VRF_TRAIN_STUCK) || t->IsChainInDepot() ? TFP_STUCK : TFP_SIGNAL;
 		SetWindowDirty(WC_VEHICLE_VIEW, t->index);
+
+		/* Unbunching data is no longer valid. */
+		t->ResetDepotUnbunching();
 	}
 
 	return CommandCost();

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -2275,6 +2275,9 @@ static bool CheckTrainStayInDepot(Train *v)
 		return true;
 	}
 
+	/* Check if we should wait here for unbunching. */
+	if (v->IsWaitingForUnbunching()) return true;
+
 	SigSegState seg_state;
 
 	if (v->force_proceed == TFP_NONE) {
@@ -2315,8 +2318,9 @@ static bool CheckTrainStayInDepot(Train *v)
 	if (_settings_client.gui.show_track_reservation) MarkTileDirtyByTile(v->tile);
 
 	VehicleServiceInDepot(v);
-	SetWindowClassesDirty(WC_TRAINS_LIST);
+	v->LeaveUnbunchingDepot();
 	v->PlayLeaveStationSound();
+	SetWindowClassesDirty(WC_TRAINS_LIST);
 
 	v->track = TRACK_BIT_X;
 	if (v->direction & 2) v->track = TRACK_BIT_Y;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -810,6 +810,10 @@ void Vehicle::HandlePathfindingResult(bool path_found)
 	SetBit(this->vehicle_flags, VF_PATHFINDER_LOST);
 	SetWindowWidgetDirty(WC_VEHICLE_VIEW, this->index, WID_VV_START_STOP);
 	InvalidateWindowClassesData(GetWindowClassForVehicleType(this->type));
+
+	/* Unbunching data is no longer valid. */
+	this->ResetDepotUnbunching();
+
 	/* Notify user about the event. */
 	AI::NewEvent(this->owner, new ScriptEventVehicleLost(this->index));
 	if (_settings_client.gui.lost_vehicle_warn && this->owner == _local_company) {
@@ -2505,6 +2509,9 @@ CommandCost Vehicle::SendToDepot(DoCommandFlag flags, DepotCommand command)
 
 	if (this->vehstatus & VS_CRASHED) return CMD_ERROR;
 	if (this->IsStoppedInDepot()) return CMD_ERROR;
+
+	/* No matter why we're headed to the depot, unbunching data is no longer valid. */
+	if (flags & DC_EXEC) this->ResetDepotUnbunching();
 
 	if (this->current_order.IsType(OT_GOTO_DEPOT)) {
 		bool halt_in_depot = (this->current_order.GetDepotActionType() & ODATFB_HALT) != 0;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1635,12 +1635,23 @@ void VehicleEnterDepot(Vehicle *v)
 			 * before the stop to the station after the stop can't be predicted
 			 * we shouldn't construct it when the vehicle visits the next stop. */
 			v->last_loading_station = INVALID_STATION;
+
+			/* Clear unbunching data. */
+			v->ResetDepotUnbunching();
+
+			/* Announce that the vehicle is waiting to players and AIs. */
 			if (v->owner == _local_company) {
 				SetDParam(0, v->index);
 				AddVehicleAdviceNewsItem(STR_NEWS_TRAIN_IS_WAITING + v->type, v->index);
 			}
 			AI::NewEvent(v->owner, new ScriptEventVehicleWaitingInDepot(v->index));
 		}
+
+		/* If we've entered our unbunching depot, record the round trip duration. */
+		if (v->current_order.GetDepotActionType() & ODATFB_UNBUNCH && v->depot_unbunching_last_departure > 0) {
+			v->round_trip_time = (TimerGameTick::counter - v->depot_unbunching_last_departure);
+		}
+
 		v->current_order.MakeDummy();
 	}
 }
@@ -2401,6 +2412,85 @@ void Vehicle::HandleLoading(bool mode)
 
 	this->IncrementImplicitOrderIndex();
 }
+
+/**
+ * Check if the current vehicle has an unbunching order.
+ * @return true Iff this vehicle has an unbunching order.
+ */
+bool Vehicle::HasUnbunchingOrder() const
+{
+	for (Order *o : this->Orders()) {
+		if (o->IsType(OT_GOTO_DEPOT) && o->GetDepotActionType() & ODATFB_UNBUNCH) return true;
+	}
+	return false;
+}
+
+/**
+ * Leave an unbunching depot and calculate the next departure time for shared order vehicles.
+ */
+void Vehicle::LeaveUnbunchingDepot()
+{
+	/* Set the start point for this round trip time. */
+	this->depot_unbunching_last_departure = TimerGameTick::counter;
+
+	/* Tell the timetable we are now "on time." */
+	this->lateness_counter = 0;
+	SetWindowDirty(WC_VEHICLE_TIMETABLE, this->index);
+
+	/* Find the average travel time of vehicles that we share orders with. */
+	uint num_vehicles = 0;
+	TimerGameTick::Ticks total_travel_time = 0;
+
+	Vehicle *u = this->FirstShared();
+	for (; u != nullptr; u = u->NextShared()) {
+		/* Ignore vehicles that are manually stopped or crashed. */
+		if (u->vehstatus & (VS_STOPPED | VS_CRASHED)) continue;
+
+		num_vehicles++;
+		total_travel_time += u->round_trip_time;
+	}
+
+	/* Make sure we cannot divide by 0. */
+	num_vehicles = std::max(num_vehicles, 1u);
+
+	/* Calculate the separation by finding the average travel time, then calculating equal separation (minimum 1 tick) between vehicles. */
+	TimerGameTick::Ticks separation = std::max((total_travel_time / num_vehicles / num_vehicles), 1u);
+	TimerGameTick::TickCounter next_departure = TimerGameTick::counter + separation;
+
+	/* Set the departure time of all vehicles that we share orders with. */
+	u = this->FirstShared();
+	for (; u != nullptr; u = u->NextShared()) {
+		/* Ignore vehicles that are manually stopped or crashed. */
+		if (u->vehstatus & (VS_STOPPED | VS_CRASHED)) continue;
+
+		u->depot_unbunching_next_departure = next_departure;
+	}
+}
+
+/**
+ * Check whether a vehicle inside a depot is waiting for unbunching.
+ * @return True if the vehicle must continue waiting, or false if it may try to leave the depot.
+ */
+bool Vehicle::IsWaitingForUnbunching() const
+{
+	assert(this->IsInDepot());
+
+	/* Don't bother if there are no vehicles sharing orders. */
+	if (!this->IsOrderListShared()) return false;
+
+	/* Don't do anything if there aren't enough orders. */
+	if (this->GetNumOrders() <= 1) return false;
+
+	/*
+	 * Make sure this is the correct depot for unbunching.
+	 * If we are headed for the first order, we must wrap around back to the last order.
+	 */
+	bool is_first_order = (this->GetOrder(this->cur_real_order_index) == this->GetFirstOrder());
+	Order *previous_order = (is_first_order) ? this->GetLastOrder() : this->GetOrder(this->cur_real_order_index - 1);
+	if (previous_order == nullptr || !previous_order->IsType(OT_GOTO_DEPOT) || !(previous_order->GetDepotActionType() & ODATFB_UNBUNCH)) return false;
+
+	return (this->depot_unbunching_next_departure > TimerGameTick::counter);
+};
 
 /**
  * Send this vehicle to the depot using the given command(s).

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -817,6 +817,10 @@ public:
 
 	inline void SetServiceIntervalIsPercent(bool on) { SB(this->vehicle_flags, VF_SERVINT_IS_PERCENT, 1, on); }
 
+	bool HasUnbunchingOrder() const;
+	void LeaveUnbunchingDepot();
+	bool IsWaitingForUnbunching() const;
+
 private:
 	/**
 	 * Advance cur_real_order_index to the next real order.

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -629,6 +629,10 @@ CommandCost CmdStartStopVehicle(DoCommandFlag flags, VehicleID veh_id, bool eval
 
 		v->vehstatus ^= VS_STOPPED;
 		if (v->type != VEH_TRAIN) v->cur_speed = 0; // trains can stop 'slowly'
+
+		/* Unbunching data is no longer valid. */
+		v->ResetDepotUnbunching();
+
 		v->MarkDirty();
 		SetWindowWidgetDirty(WC_VEHICLE_VIEW, v->index, WID_VV_START_STOP);
 		SetWindowDirty(WC_VEHICLE_DEPOT, v->tile);

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -3087,7 +3087,7 @@ public:
 	{
 		if (widget != WID_VV_START_STOP) return;
 
-		const Vehicle *v = Vehicle::Get(this->window_number);
+		Vehicle *v = Vehicle::Get(this->window_number);
 		StringID str;
 		TextColour text_colour = TC_FROMSTRING;
 		if (v->vehstatus & VS_CRASHED) {
@@ -3113,6 +3113,8 @@ public:
 			str = STR_VEHICLE_STATUS_TRAIN_STUCK;
 		} else if (v->type == VEH_AIRCRAFT && HasBit(Aircraft::From(v)->flags, VAF_DEST_TOO_FAR) && !v->current_order.IsType(OT_LOADING)) {
 			str = STR_VEHICLE_STATUS_AIRCRAFT_TOO_FAR;
+		} else if (v->IsInDepot() && v->IsWaitingForUnbunching()) {
+			str = STR_VEHICLE_STATUS_WAITING_UNBUNCHING;
 		} else { // vehicle is in a "normal" state, show current order
 			if (mouse_over_start_stop) {
 				if (v->vehstatus & VS_STOPPED) {
@@ -3143,6 +3145,8 @@ public:
 						str = STR_EMPTY;
 					} else if (v->current_order.GetDepotActionType() & ODATFB_HALT) {
 						str = HasBit(v->vehicle_flags, VF_PATHFINDER_LOST) ? STR_VEHICLE_STATUS_CANNOT_REACH_DEPOT_VEL : STR_VEHICLE_STATUS_HEADING_FOR_DEPOT_VEL;
+					} else if (v->current_order.GetDepotActionType() & ODATFB_UNBUNCH) {
+						str = HasBit(v->vehicle_flags, VF_PATHFINDER_LOST) ? STR_VEHICLE_STATUS_CANNOT_REACH_DEPOT_SERVICE_VEL : STR_VEHICLE_STATUS_HEADING_FOR_DEPOT_UNBUNCH_VEL;
 					} else {
 						str = HasBit(v->vehicle_flags, VF_PATHFINDER_LOST) ? STR_VEHICLE_STATUS_CANNOT_REACH_DEPOT_SERVICE_VEL : STR_VEHICLE_STATUS_HEADING_FOR_DEPOT_SERVICE_VEL;
 					}

--- a/src/widgets/order_widget.h
+++ b/src/widgets/order_widget.h
@@ -20,11 +20,12 @@ enum OrderWidgets : WidgetID {
 	WID_O_DELETE,                    ///< Delete selected order.
 	WID_O_STOP_SHARING,              ///< Stop sharing orders.
 	WID_O_NON_STOP,                  ///< Goto non-stop to destination.
+	WID_O_DEPOT_UNBUNCHING,          ///< Toggle unbunching.
 	WID_O_GOTO,                      ///< Goto destination.
 	WID_O_FULL_LOAD,                 ///< Select full load.
 	WID_O_UNLOAD,                    ///< Select unload.
 	WID_O_REFIT,                     ///< Select refit.
-	WID_O_SERVICE,                   ///< Select service (at depot).
+	WID_O_DEPOT_ACTION,              ///< Dropdown to select the depot action (stop, service if needed, unbunch).
 	WID_O_REFIT_DROPDOWN,            ///< Open refit options.
 	WID_O_COND_VARIABLE,             ///< Choose condition variable.
 	WID_O_COND_COMPARATOR,           ///< Choose condition type.


### PR DESCRIPTION
## Motivation / Problem

### Background

"Bus bunching" is [a real-world phenomena](https://en.wikipedia.org/wiki/Bus_bunching) that we experience in OpenTTD, across all vehicle types. (It also exists in [Cities: Skylines](https://steamcommunity.com/sharedfiles/filedetails/?id=531401164)! 😄 )

A feature to unbunch these vehicles (typically called "automatic separation") is a feature that has been requested [for](https://www.tt-forums.net/viewtopic.php?f=33&t=33524) [years](https://www.tt-forums.net/viewtopic.php?t=46391). It exists in [a simple form](https://wiki.openttd.org/en/Manual/Timetable#automatic-spacing) in our current timetable system, but has a finicky setup, requires manual updating when new vehicles are purchased, and like timetables in general, cannot be easily updated when the vehicles on the route are upgraded to faster models. JGR's Patchpack implements automatic adaptation of timetable-based separation. I've used it and have never had problems, but its controls in the timetable window aren't the most intuitive to players.

### Deadlock danger
Fundamentally, unbunching requires delaying vehicles in order to keep a consistent interval between trips. You can't make a late-running vehicle faster, but you can delay the next vehicle. This introduces the fundamental danger of this feature: deadlocks. Vehicles get out of order, they block each other waiting to be on time, and the player has no idea why.

We've had [an automatic separation PR](https://github.com/OpenTTD/OpenTTD/pull/8342) open since 2020, but Andy managed to find a deadlock situation. This PR has some complex code to try to detect deadlocks, but it's hard to evaluate and test. And you know what they say: 
>Make it idiot-proof, and someone will make a better idiot.

### A new approach

There is one place where vehicles cannot deadlock: **Depots**.

With a goal of building the simplest possible implementation, I started with #8342 and eventually replaced most of it moving the unbunching point to the depot.

## Description

### How do players use it?

Depots gain a new action type marking them as the unbunching point for a vehicle, chosen from the depot action dropdown (which now shows the selection action instead of the `Service` toggle button).

![unbunch](https://github.com/OpenTTD/OpenTTD/assets/55058389/524b5ebe-5a84-4345-9865-3c94b458119f)

A vehicle can only have one order marked for unbunching, so if you try and add a second you get an error. In addition, unbunching cannot be used with full load or conditional orders. Trying to add one of these orders, or trying to mark a depot for unbunching when the order list already includes one of these orders, blocks the new change and gives a descriptive error.

### How does it work?

When a vehicle enters a depot, it records the duration of its last trip, in ticks. When it tries to exit a depot, it checks if its next departure time has arrived yet. If we are past the departure time, it leaves and immediately calculates the departure time of the _next_ vehicle.

This calculation is simple: Take the average last trip duration of all vehicles, then divide by the number of vehicles to get the interval between trips, then look that many ticks ahead. The averaging evens out inconsistencies in trip times due to traffic, (train) routing, etc., and also handles new or changed vehicles that don't have a recorded trip time. Inconsistencies take a few cycles to stabilize, but the system should be quite resilient.

The next departure time calculated by the exiting vehicle is given to every vehicle in the shared order group. We don't know which one is supposed to leave next, but we don't care: whichever is processed first attempting to leave the depot is the lucky bus, and it will set a new departure time for all the others to wait for.

### What about timetables?

When a vehicle leaves a depot after being unbunched, we reset its late counter, making it "on time." The only oddity of overriding the timetable is that the expected arrival/departure times of orders after the depot may not be correct if the vehicle is held in the depot for unbunching.

### Review notes

I know we're right up against 14.0 feature freeze, but I'd quite like this to make it in. From my own experience and conversations with other players, the lack of this feature in vanilla OpenTTD is one of the main motivators for people to switch to JGRPP. Let's win those sales back and earn ourselves a nice bonus on all the additional revenue. 😛 

I split this into several commits for ease of review. I will squash when merging.

Please check out the preview and see if you can break this.

I wonder if @JGRennison and @twpol, the two people most familiar with automatic separation, would be willing to take a look for anything I missed or got wrong. ❤️ 

Closes #8342.

## Limitations

* If a vehicle is extremely delayed, the next trips of its shared order groups will be delayed to match this average trip duration. It eventually settles down, but if two vehicles are delayed for an hour, the next two departures will have an interval of 30 minutes. This is a bit of an extreme edge case, but worth noting for anyone who tries testing this. 😉 

* A vehicle loaded with cargo which spends time waiting in a depot for unbunching will lose some cargo value. Players who are bothered by this should unload the vehicle first.

* NewGRF aircraft which use the range limit feature (Av8 shown below) display this error after the `(wait for unbunching)` instruction. There's an extra space between the airport name and the error because of how `STR_ORDER_TEXT` works. I could fix it with a duplicate string, but I'm really not sure it's worth the effort based on the rarity of this error.

![range](https://github.com/OpenTTD/OpenTTD/assets/55058389/b6cb96d5-dc3d-464c-a067-db76e0eaf4fd)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
