### PR TITLE
Fix: Restore Random AI slot upon stopping a randomly started AI

### DIFF
--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -115,6 +115,10 @@
 	cur_company.Restore();
 
 	InvalidateWindowClassesData(WC_SCRIPT_DEBUG, -1);
+
+	if (AIConfig::GetConfig(company)->IsRandom()) {
+		AIConfig::GetConfig(company)->Change(std::nullopt);
+	}
 	CloseWindowById(WC_SCRIPT_SETTINGS, company);
 }
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1227,7 +1227,12 @@ DEF_CONSOLE_CMD(ConRestart)
 	/* Don't copy the _newgame pointers to the real pointers, so call SwitchToMode directly */
 	_settings_game.game_creation.map_x = Map::LogX();
 	_settings_game.game_creation.map_y = Map::LogY();
-	_switch_mode = SM_RESTARTGAME;
+	if (_file_to_saveload.abstract_ftype == FT_SAVEGAME || _file_to_saveload.abstract_ftype == FT_SCENARIO || _file_to_saveload.abstract_ftype == FT_HEIGHTMAP) {
+		_switch_mode = SM_RESTARTGAME;
+	} else {
+		_settings_newgame.game_creation.generation_seed = _settings_game.game_creation.generation_seed;
+		_switch_mode = SM_NEWGAME;
+	}
 	return true;
 }
 


### PR DESCRIPTION
## Motivation / Problem
Slight improvement to "restart" console command to be better at replicating the AI/GS config.

The issue is that when a Random AI starts and becomes an AI, the config slot is modified to the config of the AI it randomized to. Doing a "restart" would then use the config of the AI it randomized to instead or rolling back to Random AI.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

With the help of a customized AI which uses random deviation settings, I checked the behaviours of "newgame", "restart" and savegame load, and I believe restoring the Random AI slot is a step in the right direction to reach reproduceability. It's still not totally there, the other issue is random deviation on non-random AIs, which is not addressed by this PR.

Notes summarised: https://gist.github.com/SamuXarick/5dec2054a0f15122268038f6ce120715 

Additionally, when restarting after a new game, use the seed of the current game and use the new game settings configuration.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Someone would prefer to have the config not revert back to Random AI upon stopping the AI of that slot. It's a compromise.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
