### PR TITLE
Fix #11948: [Win32] Convert error messages to utf8

### DIFF
--- a/src/network/core/http_winhttp.cpp
+++ b/src/network/core/http_winhttp.cpp
@@ -73,15 +73,16 @@ NetworkHTTPRequest::NetworkHTTPRequest(const std::wstring &uri, HTTPCallback *ca
 
 static std::string GetLastErrorAsString()
 {
-	char buffer[512];
+	wchar_t buffer[512];
+
 	DWORD error_code = GetLastError();
 
-	if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_FROM_HMODULE | FORMAT_MESSAGE_IGNORE_INSERTS, GetModuleHandleA("winhttp.dll"), error_code,
-		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), buffer, sizeof(buffer), nullptr) == 0) {
+	if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_FROM_HMODULE | FORMAT_MESSAGE_IGNORE_INSERTS, GetModuleHandle(L"winhttp.dll"), error_code,
+		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), buffer, lengthof(buffer), nullptr) == 0) {
 		return fmt::format("unknown error {}", error_code);
 	}
 
-	return buffer;
+	return FS2OTTD(buffer);
 }
 
 /**

--- a/src/network/core/os_abstraction.cpp
+++ b/src/network/core/os_abstraction.cpp
@@ -81,12 +81,12 @@ const std::string &NetworkError::AsString() const
 {
 	if (this->message.empty()) {
 #if defined(_WIN32)
-		char buffer[512];
-		if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr, this->error,
-			MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), buffer, sizeof(buffer), nullptr) == 0) {
+		wchar_t buffer[512];
+		if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr, this->error,
+			MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), buffer, lengthof(buffer), nullptr) == 0) {
 			this->message.assign(fmt::format("Unknown error {}", this->error));
 		} else {
-			this->message.assign(buffer);
+			this->message.assign(FS2OTTD(buffer));
 		}
 #else
 		/* Make strerror thread safe by locking access to it. There is a thread safe strerror_r, however

--- a/src/os/windows/library_loader_win.cpp
+++ b/src/os/windows/library_loader_win.cpp
@@ -20,13 +20,13 @@ static std::string GetLoadError()
 {
 	auto error_code = GetLastError();
 
-	char buffer[512];
-	if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr, error_code,
-		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), buffer, sizeof(buffer), nullptr) == 0) {
+	wchar_t buffer[512];
+	if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr, error_code,
+		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), buffer, lengthof(buffer), nullptr) == 0) {
 		return fmt::format("Unknown error {}", error_code);
 	}
 
-	return buffer;
+	return FS2OTTD(buffer);
 }
 
 void *LibraryLoader::OpenLibrary(const std::string &filename)


### PR DESCRIPTION
## Motivation / Problem
FormatMessage() returns the string in local code page.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Convert the string to utf8.
I didn't use `FS2OTTD` for the network ones, because network often implies threads.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
