### PR TITLE
Fix: don't use non-owning string pointer in StringParameter

### DIFF
--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -16,7 +16,6 @@
 /** The data required to format and validate a single parameter of a string. */
 struct StringParameter {
 	uint64_t data; ///< The data of the parameter.
-	const char *string_view; ///< The string value, if it has any.
 	std::unique_ptr<std::string> string; ///< Copied string value, if it has any.
 	char32_t type; ///< The #StringControlCode to interpret this data with when it's the first parameter, otherwise '\0'.
 };
@@ -106,7 +105,7 @@ public:
 	const char *GetNextParameterString()
 	{
 		auto ptr = GetNextParameterPointer();
-		return ptr->string != nullptr ? ptr->string->c_str() : ptr->string_view;
+		return ptr->string != nullptr ? ptr->string->c_str() : nullptr;
 	}
 
 	/**
@@ -152,7 +151,6 @@ public:
 		assert(n < this->parameters.size());
 		this->parameters[n].data = v;
 		this->parameters[n].string.reset();
-		this->parameters[n].string_view = nullptr;
 	}
 
 	template <typename T, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value, int> = 0>
@@ -165,8 +163,7 @@ public:
 	{
 		assert(n < this->parameters.size());
 		this->parameters[n].data = 0;
-		this->parameters[n].string.reset();
-		this->parameters[n].string_view = str;
+		this->parameters[n].string = std::make_unique<std::string>(str);
 	}
 
 	void SetParam(size_t n, const std::string &str) { this->SetParam(n, str.c_str()); }
@@ -176,13 +173,12 @@ public:
 		assert(n < this->parameters.size());
 		this->parameters[n].data = 0;
 		this->parameters[n].string = std::make_unique<std::string>(std::move(str));
-		this->parameters[n].string_view = nullptr;
 	}
 
 	uint64_t GetParam(size_t n) const
 	{
 		assert(n < this->parameters.size());
-		assert(this->parameters[n].string_view == nullptr && this->parameters[n].string == nullptr);
+		assert(this->parameters[n].string == nullptr);
 		return this->parameters[n].data;
 	}
 
@@ -195,7 +191,7 @@ public:
 	{
 		assert(n < this->parameters.size());
 		auto &param = this->parameters[n];
-		return param.string != nullptr ? param.string->c_str() : param.string_view;
+		return param.string != nullptr ? param.string->c_str() : nullptr;
 	}
 };
 


### PR DESCRIPTION
## Motivation / Problem

Fixes #11922

The string pointer can become invalid before the reference is dropped, causing out-of-bound access in windows like ErrorWindow, or when closing the game.

## Description

Instead of referencing a string, copy it. That way we know it is always safe.

Backported from JGRPP.

This is more a stop-gap solution, to remove the issue for upcoming release. Better solutions might be presented at a later stage.

## Limitations

More memory usage when a pointer was used.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
