### PR TITLE
Codechange: use std managed pointers in saveload

### DIFF
--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -155,7 +155,6 @@ ClientNetworkGameSocketHandler::~ClientNetworkGameSocketHandler()
 	assert(ClientNetworkGameSocketHandler::my_client == this);
 	ClientNetworkGameSocketHandler::my_client = nullptr;
 
-	delete this->savegame;
 	delete this->GetInfo();
 }
 
@@ -567,7 +566,7 @@ bool ClientNetworkGameSocketHandler::IsConnected()
  *   DEF_CLIENT_RECEIVE_COMMAND has parameter: Packet *p
  ************/
 
-extern bool SafeLoad(const std::string &filename, SaveLoadOperation fop, DetailedFileType dft, GameMode newgm, Subdirectory subdir, struct LoadFilter *lf = nullptr);
+extern bool SafeLoad(const std::string &filename, SaveLoadOperation fop, DetailedFileType dft, GameMode newgm, Subdirectory subdir, std::shared_ptr<struct LoadFilter> lf);
 
 NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_FULL(Packet *)
 {
@@ -810,7 +809,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_MAP_BEGIN(Packe
 
 	if (this->savegame != nullptr) return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 
-	this->savegame = new PacketReader();
+	this->savegame = std::make_shared<PacketReader>();
 
 	_frame_counter = _frame_counter_server = _frame_counter_max = p->Recv_uint32();
 
@@ -864,20 +863,12 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_MAP_DONE(Packet
 	_network_join_status = NETWORK_JOIN_STATUS_PROCESSING;
 	SetWindowDirty(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN);
 
-	/*
-	 * Make sure everything is set for reading.
-	 *
-	 * We need the local copy and reset this->savegame because when
-	 * loading fails the network gets reset upon loading the intro
-	 * game, which would cause us to free this->savegame twice.
-	 */
-	LoadFilter *lf = this->savegame;
-	this->savegame = nullptr;
-	lf->Reset();
+	this->savegame->Reset();
 
 	/* The map is done downloading, load it */
 	ClearErrorMessages();
-	bool load_success = SafeLoad({}, SLO_LOAD, DFT_GAME_FILE, GM_NORMAL, NO_DIRECTORY, lf);
+	bool load_success = SafeLoad({}, SLO_LOAD, DFT_GAME_FILE, GM_NORMAL, NO_DIRECTORY, this->savegame);
+	this->savegame = nullptr;
 
 	/* Long savegame loads shouldn't affect the lag calculation! */
 	this->last_packet = std::chrono::steady_clock::now();

--- a/src/network/network_client.h
+++ b/src/network/network_client.h
@@ -16,7 +16,7 @@
 class ClientNetworkGameSocketHandler : public ZeroedMemoryAllocator, public NetworkGameSocketHandler {
 private:
 	std::string connection_string; ///< Address we are connected to.
-	struct PacketReader *savegame; ///< Packet reader for reading the savegame.
+	std::shared_ptr<struct PacketReader> savegame; ///< Packet reader for reading the savegame.
 	byte token;                    ///< The token we need to send back to the server to prove we're the right client.
 
 	/** Status of the connection with the server. */

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -576,7 +576,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendMap()
 		Debug(net, 9, "client[{}] SendMap(): first_packet", this->client_id);
 
 		WaitTillSaved();
-		this->savegame = new PacketWriter(this);
+		this->savegame = std::make_shared<PacketWriter>(this);
 
 		/* Now send the _frame_counter and how many packets are coming */
 		Packet *p = new Packet(PACKET_SERVER_MAP_BEGIN);

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -69,7 +69,7 @@ public:
 	CommandQueue outgoing_queue; ///< The command-queue awaiting delivery
 	size_t receive_limit;        ///< Amount of bytes that we can receive at this moment
 
-	struct PacketWriter *savegame; ///< Writer used to write the savegame.
+	std::shared_ptr<struct PacketWriter> savegame; ///< Writer used to write the savegame.
 	NetworkAddress client_address; ///< IP-address of the client (so they can be banned)
 
 	ServerNetworkGameSocketHandler(SOCKET s);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -966,7 +966,7 @@ static void MakeNewEditorWorld()
  * @param subdir default directory to look for filename, set to 0 if not needed
  * @param lf Load filter to use, if nullptr: use filename + subdir.
  */
-bool SafeLoad(const std::string &filename, SaveLoadOperation fop, DetailedFileType dft, GameMode newgm, Subdirectory subdir, struct LoadFilter *lf = nullptr)
+bool SafeLoad(const std::string &filename, SaveLoadOperation fop, DetailedFileType dft, GameMode newgm, Subdirectory subdir, std::shared_ptr<LoadFilter> lf = nullptr)
 {
 	assert(fop == SLO_LOAD);
 	assert(dft == DFT_GAME_FILE || (lf == nullptr && dft == DFT_OLD_GAME_FILE));

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -420,8 +420,8 @@ void DoExitSave();
 
 void DoAutoOrNetsave(FiosNumberedSaveName &counter);
 
-SaveOrLoadResult SaveWithFilter(struct SaveFilter *writer, bool threaded);
-SaveOrLoadResult LoadWithFilter(struct LoadFilter *reader);
+SaveOrLoadResult SaveWithFilter(std::shared_ptr<struct SaveFilter> writer, bool threaded);
+SaveOrLoadResult LoadWithFilter(std::shared_ptr<struct LoadFilter> reader);
 
 typedef void AutolengthProc(void *arg);
 

--- a/src/saveload/saveload_filter.h
+++ b/src/saveload/saveload_filter.h
@@ -13,20 +13,19 @@
 /** Interface for filtering a savegame till it is loaded. */
 struct LoadFilter {
 	/** Chained to the (savegame) filters. */
-	LoadFilter *chain;
+	std::shared_ptr<LoadFilter> chain;
 
 	/**
 	 * Initialise this filter.
 	 * @param chain The next filter in this chain.
 	 */
-	LoadFilter(LoadFilter *chain) : chain(chain)
+	LoadFilter(std::shared_ptr<LoadFilter> chain) : chain(chain)
 	{
 	}
 
 	/** Make sure the writers are properly closed. */
 	virtual ~LoadFilter()
 	{
-		delete this->chain;
 	}
 
 	/**
@@ -51,28 +50,27 @@ struct LoadFilter {
  * @param chain The next filter in this chain.
  * @tparam T    The type of load filter to create.
  */
-template <typename T> LoadFilter *CreateLoadFilter(LoadFilter *chain)
+template <typename T> std::shared_ptr<LoadFilter> CreateLoadFilter(std::shared_ptr<LoadFilter> chain)
 {
-	return new T(chain);
+	return std::make_shared<T>(chain);
 }
 
 /** Interface for filtering a savegame till it is written. */
 struct SaveFilter {
 	/** Chained to the (savegame) filters. */
-	SaveFilter *chain;
+	std::shared_ptr<SaveFilter> chain;
 
 	/**
 	 * Initialise this filter.
 	 * @param chain The next filter in this chain.
 	 */
-	SaveFilter(SaveFilter *chain) : chain(chain)
+	SaveFilter(std::shared_ptr<SaveFilter> chain) : chain(chain)
 	{
 	}
 
 	/** Make sure the writers are properly closed. */
 	virtual ~SaveFilter()
 	{
-		delete this->chain;
 	}
 
 	/**
@@ -97,9 +95,9 @@ struct SaveFilter {
  * @param compression_level The requested level of compression.
  * @tparam T                The type of save filter to create.
  */
-template <typename T> SaveFilter *CreateSaveFilter(SaveFilter *chain, byte compression_level)
+template <typename T> std::shared_ptr<SaveFilter> CreateSaveFilter(std::shared_ptr<SaveFilter> chain, byte compression_level)
 {
-	return new T(chain, compression_level);
+	return std::make_shared<T>(chain, compression_level);
 }
 
 #endif /* SAVELOAD_FILTER_H */


### PR DESCRIPTION
## Motivation / Problem

First of all replacing manual memory management with automatic management.
Secondly there are at least three places where special actions are taken to prevent double frees.


## Description

Replace the saveload filter pointers with `std::shared_ptr`. This due to some interactions with the networking code, for example the server wanting to retain the savegame after it's done saving. So, since network and saveload can run async from each other having shared custody over the memory seems best.

Replace two other pointers in `SaveloadParams` with `std::unique_ptr`.


## Limitations

There are still `CallocT`-ed bits of memory in the saveload code, but I'll consider that out of scope for now. 


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
