### PR TITLE
Change: Improve ScriptSettings windows

### DIFF
--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -199,10 +199,18 @@ struct GSConfigWindow : public Window {
 					TextColour colour;
 					uint idx = 0;
 					if (config_item.description.empty()) {
-						str = STR_JUST_STRING1;
+						if (Game::GetInstance() == nullptr && config_item.random_deviation != 0) {
+							str = STR_AI_SETTINGS_JUST_DEVIATION;
+						} else {
+							str = STR_JUST_STRING1;
+						}
 						colour = TC_ORANGE;
 					} else {
-						str = STR_AI_SETTINGS_SETTING;
+						if (Game::GetInstance() == nullptr && config_item.random_deviation != 0) {
+							str = STR_AI_SETTINGS_SETTING_DEVIATION;
+						} else {
+							str = STR_AI_SETTINGS_SETTING;
+						}
 						colour = TC_LIGHT_BLUE;
 						SetDParamStr(idx++, config_item.description);
 					}
@@ -216,13 +224,36 @@ struct GSConfigWindow : public Window {
 						} else {
 							DrawArrowButtons(br.left, y + button_y_offset, COLOUR_YELLOW, (this->clicked_button == i) ? 1 + (this->clicked_increase != rtl) : 0, editable && current_value > config_item.min_value, editable && current_value < config_item.max_value);
 						}
-						auto config_iterator = config_item.labels.find(current_value);
-						if (config_iterator != config_item.labels.end()) {
-							SetDParam(idx++, STR_JUST_RAW_STRING);
-							SetDParamStr(idx++, config_iterator->second);
+
+						if (Game::GetInstance() != nullptr || config_item.random_deviation == 0) {
+							auto config_iterator = config_item.labels.find(current_value);
+							if (config_iterator != config_item.labels.end()) {
+								SetDParam(idx++, STR_JUST_RAW_STRING);
+								SetDParamStr(idx++, config_iterator->second);
+							} else {
+								SetDParam(idx++, STR_JUST_INT);
+								SetDParam(idx++, current_value);
+							}
 						} else {
-							SetDParam(idx++, STR_JUST_INT);
-							SetDParam(idx++, current_value);
+							int min_deviated = std::max(config_item.min_value, current_value - config_item.random_deviation);
+							auto config_iterator = config_item.labels.find(min_deviated);
+							if (config_iterator != config_item.labels.end()) {
+								SetDParam(idx++, STR_JUST_RAW_STRING);
+								SetDParamStr(idx++, config_iterator->second);
+							} else {
+								SetDParam(idx++, STR_JUST_INT);
+								SetDParam(idx++, min_deviated);
+							}
+
+							int max_deviated = std::min(config_item.max_value, current_value + config_item.random_deviation);
+							config_iterator = config_item.labels.find(max_deviated);
+							if (config_iterator != config_item.labels.end()) {
+								SetDParam(idx++, STR_JUST_RAW_STRING);
+								SetDParamStr(idx++, config_iterator->second);
+							} else {
+								SetDParam(idx++, STR_JUST_INT);
+								SetDParam(idx++, max_deviated);
+							}
 						}
 					}
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4835,6 +4835,8 @@ STR_AI_SETTINGS_CAPTION_GAMESCRIPT                              :Game Script
 STR_AI_SETTINGS_CLOSE                                           :{BLACK}Close
 STR_AI_SETTINGS_RESET                                           :{BLACK}Reset
 STR_AI_SETTINGS_SETTING                                         :{RAW_STRING}: {ORANGE}{STRING1}
+STR_AI_SETTINGS_SETTING_DEVIATION                               :{RAW_STRING}: {ORANGE}[{STRING1}, {STRING1}]
+STR_AI_SETTINGS_JUST_DEVIATION                                  :[{STRING1}, {STRING1}]
 
 
 # Textfile window

--- a/src/script/api/script_info_docs.hpp
+++ b/src/script/api/script_info_docs.hpp
@@ -239,6 +239,7 @@ public:
 	 *    [user_configured_value - random_deviation, user_configured_value + random_deviation] (inclusive).
 	 *    random_deviation sign is ignored and the value is clamped in the range [0, MAX(int32_t)] (inclusive).
 	 *    The randomisation will happen just before the Script start.
+	 *    Not allowed if the CONFIG_BOOLEAN flag is set, otherwise optional.
 	 *  - step_size The increase/decrease of the value every time the user
 	 *    clicks one of the up/down arrow buttons. Optional, default is 1.
 	 *  - flags Bitmask of some flags, see ScriptConfigFlags. Required.

--- a/src/script/script_info.cpp
+++ b/src/script/script_info.cpp
@@ -162,6 +162,13 @@ SQInteger ScriptInfo::AddSetting(HSQUIRRELVM vm)
 	}
 	sq_pop(vm, 1);
 
+	/* Don't allow both random_deviation and SCRIPTCONFIG_BOOLEAN to
+	 * be set for the same config item. */
+	if ((items & 0x200) != 0 && (config.flags & SCRIPTCONFIG_BOOLEAN) != 0) {
+		this->engine->ThrowError("setting both random_deviation and CONFIG_BOOLEAN is not allowed");
+		return SQ_ERROR;
+	}
+
 	/* Reset the bit for random_deviation as it's optional. */
 	items &= ~0x200;
 


### PR DESCRIPTION
## Motivation / Problem
User doesn't know if a setting will be deviated during script start.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Add a visual indication when configuring a script before its start.
With labels for all values:
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/65f8b773-0071-4ef2-a63f-e8fe65d050ff)
With labels for some values:
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/ee895467-5afa-45f2-bcdc-6a63c09cb0ec)

Once the script is running, display the actual value.
With labels for all values:
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/902436d8-3fa9-455f-a502-0c707044512a)
With labels for some values:
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/da672b6c-ccd6-4f12-9426-542860600021)

Random deviation for boolean settings is no longer allowed.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
