### PR TITLE
Change: [Script] replace easy/medium/hard values with default value

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1812,13 +1812,6 @@ STR_CONFIG_SETTING_AI_BUILDS_AIRCRAFT_HELPTEXT                  :Enabling this s
 STR_CONFIG_SETTING_AI_BUILDS_SHIPS                              :Disable ships for computer: {STRING2}
 STR_CONFIG_SETTING_AI_BUILDS_SHIPS_HELPTEXT                     :Enabling this setting makes building ships impossible for a computer player
 
-STR_CONFIG_SETTING_AI_PROFILE                                   :Default settings profile: {STRING2}
-STR_CONFIG_SETTING_AI_PROFILE_HELPTEXT                          :Choose which settings profile to use for random AIs or for initial values when adding a new AI or Game Script
-###length 3
-STR_CONFIG_SETTING_AI_PROFILE_EASY                              :Easy
-STR_CONFIG_SETTING_AI_PROFILE_MEDIUM                            :Medium
-STR_CONFIG_SETTING_AI_PROFILE_HARD                              :Hard
-
 STR_CONFIG_SETTING_AI_IN_MULTIPLAYER                            :Allow AIs in multiplayer: {STRING2}
 STR_CONFIG_SETTING_AI_IN_MULTIPLAYER_HELPTEXT                   :Allow AI computer players to participate in multiplayer games
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2862,12 +2862,6 @@ bool AfterLoadGame()
 		}
 	}
 
-	if (IsSavegameVersionBefore(SLV_178)) {
-		extern uint8_t _old_diff_level;
-		/* Initialise script settings profile */
-		_settings_game.script.settings_profile = IsInsideMM(_old_diff_level, SP_BEGIN, SP_END) ? _old_diff_level : (uint)SP_MEDIUM;
-	}
-
 	{
 		/* Station blocked, wires and pylon flags need to be stored in the map. This is effectively cached data, so no
 		 * version check is necessary. This is done here as the SLV_182 check below needs the blocked status. */

--- a/src/saveload/compat/settings_sl_compat.h
+++ b/src/saveload/compat/settings_sl_compat.h
@@ -162,7 +162,7 @@ const SaveLoadCompat _settings_sl_compat[] = {
 	SLC_VAR("economy.initial_city_size"),
 	SLC_VAR("economy.mod_road_rebuild"),
 	SLC_NULL(1, SL_MIN_VERSION, SLV_107),
-	SLC_VAR("script.settings_profile"),
+	SLC_NULL(1, SLV_178, SLV_TABLE_CHUNKS),
 	SLC_VAR("ai.ai_in_multiplayer"),
 	SLC_VAR("ai.ai_disable_veh_train"),
 	SLC_VAR("ai.ai_disable_veh_roadveh"),

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -33,6 +33,7 @@
  * \li AISubsidyList accepts an optional filter function
  * \li AITownList accepts an optional filter function
  * \li AIVehicleList accepts an optional filter function
+ * \li AIInfo::AddSettings easy_value / medium_value / hard_value are replaced with default_value
  *
  * \b 13.0
  *

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -99,6 +99,7 @@
  * \li GSSubsidyList accepts an optional filter function
  * \li GSTownList accepts an optional filter function
  * \li GSVehicleList accepts an optional filter function
+ * \li GSInfo::AddSettings easy_value / medium_value / hard_value are replaced with default_value
  *
  * \b 13.0
  *

--- a/src/script/api/script_info_docs.hpp
+++ b/src/script/api/script_info_docs.hpp
@@ -222,18 +222,8 @@ public:
 	 *  - max_value The maximum value of this setting. Required for integer
 	 *    settings and not allowed for boolean settings. The value will be
 	 *    clamped in the range [MIN(int32_t), MAX(int32_t)] (inclusive).
-	 *  - easy_value The default value if the easy difficulty level
-	 *    is selected. Required. The value will be clamped in the range
-	 *    [MIN(int32_t), MAX(int32_t)] (inclusive).
-	 *  - medium_value The default value if the medium difficulty level
-	 *    is selected. Required. The value will be clamped in the range
-	 *    [MIN(int32_t), MAX(int32_t)] (inclusive).
-	 *  - hard_value The default value if the hard difficulty level
-	 *    is selected. Required. The value will be clamped in the range
-	 *    [MIN(int32_t), MAX(int32_t)] (inclusive).
-	 *  - custom_value The default value if the custom difficulty level
-	 *    is selected. Required. The value will be clamped in the range
-	 *    [MIN(int32_t), MAX(int32_t)] (inclusive).
+	 *  - default_value The default value. Required. The value will be
+	 *    clamped in the range [MIN(int32_t), MAX(int32_t)] (inclusive).
 	 *  - random_deviation If this property has a nonzero value, then the
 	 *    actual value of the setting in game will be randomised in the range
 	 *    [user_configured_value - random_deviation, user_configured_value + random_deviation] (inclusive).

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -34,10 +34,7 @@ struct ScriptConfigItem {
 	std::string description;      ///< The description of the configuration setting.
 	int min_value = 0;            ///< The minimal value this configuration setting can have.
 	int max_value = 1;            ///< The maximal value this configuration setting can have.
-	int custom_value = 0;         ///< The default value on custom difficulty setting.
-	int easy_value = 0;           ///< The default value on easy difficulty setting.
-	int medium_value = 0;         ///< The default value on medium difficulty setting.
-	int hard_value = 0;           ///< The default value on hard difficulty setting.
+	int default_value = 0;        ///< The default value of this configuration setting.
 	int random_deviation = 0;     ///< The maximum random deviation from the default value.
 	int step_size = 1;            ///< The step size in the gui.
 	ScriptConfigFlags flags = SCRIPTCONFIG_NONE; ///< Flags for the configuration setting.

--- a/src/script/script_info.cpp
+++ b/src/script/script_info.cpp
@@ -87,6 +87,10 @@ SQInteger ScriptInfo::AddSetting(HSQUIRRELVM vm)
 	ScriptConfigItem config;
 	uint items = 0;
 
+	int easy_value = INT32_MIN;
+	int medium_value = INT32_MIN;
+	int hard_value = INT32_MIN;
+
 	/* Read the table, and find all properties we care about */
 	sq_pushnull(vm);
 	while (SQ_SUCCEEDED(sq_next(vm, -2))) {
@@ -122,28 +126,30 @@ SQInteger ScriptInfo::AddSetting(HSQUIRRELVM vm)
 		} else if (key == "easy_value") {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
-			config.easy_value = ClampTo<int32_t>(res);
+			easy_value = ClampTo<int32_t>(res);
 			items |= 0x010;
 		} else if (key == "medium_value") {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
-			config.medium_value = ClampTo<int32_t>(res);
+			medium_value = ClampTo<int32_t>(res);
 			items |= 0x020;
 		} else if (key == "hard_value") {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
-			config.hard_value = ClampTo<int32_t>(res);
+			hard_value = ClampTo<int32_t>(res);
 			items |= 0x040;
+		} else if (key == "custom_value") {
+			// No longer parsed.
+		} else if (key == "default_value") {
+			SQInteger res;
+			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
+			config.default_value = ClampTo<int32_t>(res);
+			items |= 0x080;
 		} else if (key == "random_deviation") {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
 			config.random_deviation = ClampTo<int32_t>(abs(res));
 			items |= 0x200;
-		} else if (key == "custom_value") {
-			SQInteger res;
-			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
-			config.custom_value = ClampTo<int32_t>(res);
-			items |= 0x080;
 		} else if (key == "step_size") {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
@@ -161,6 +167,28 @@ SQInteger ScriptInfo::AddSetting(HSQUIRRELVM vm)
 		sq_pop(vm, 2);
 	}
 	sq_pop(vm, 1);
+
+	/* Check if default_value is set. Although required, this was changed with
+	 * 14.0, and as such, older AIs don't use it yet. So we convert the older
+	 * values into a default_value. */
+	if ((items & 0x080) == 0) {
+		/* Easy/medium/hard should all three be defined. */
+		if ((items & 0x010) == 0 || (items & 0x020) == 0 || (items & 0x040) == 0) {
+			this->engine->ThrowError("please define all properties of a setting (min/max not allowed for booleans)");
+			return SQ_ERROR;
+		}
+
+		config.default_value = medium_value;
+		/* If not boolean and no random deviation set, calculate it based on easy/hard difference. */
+		if ((config.flags & SCRIPTCONFIG_BOOLEAN) == 0 && (items & 0x200) == 0) {
+			config.random_deviation = abs(hard_value - easy_value) / 2;
+			items |= 0x200;
+		}
+		items |= 0x080;
+	} else {
+		/* For compatibility, also act like the default sets the easy/medium/hard. */
+		items |= 0x010 | 0x020 | 0x040;
+	}
 
 	/* Don't allow both random_deviation and SCRIPTCONFIG_BOOLEAN to
 	 * be set for the same config item. */
@@ -252,14 +280,7 @@ int ScriptInfo::GetSettingDefaultValue(const std::string &name) const
 {
 	for (const auto &item : this->config_list) {
 		if (item.name != name) continue;
-		/* The default value depends on the difficulty level */
-		switch (GetGameSettings().script.settings_profile) {
-			case SP_EASY:   return item.easy_value;
-			case SP_MEDIUM: return item.medium_value;
-			case SP_HARD:   return item.hard_value;
-			case SP_CUSTOM: return item.custom_value;
-			default: NOT_REACHED();
-		}
+		return item.default_value;
 	}
 
 	/* There is no such setting */

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2249,7 +2249,6 @@ static SettingsContainer &GetSettingsTree()
 		{
 			SettingsPage *npc = ai->Add(new SettingsPage(STR_CONFIG_SETTING_AI_NPC));
 			{
-				npc->Add(new SettingEntry("script.settings_profile"));
 				npc->Add(new SettingEntry("script.script_max_opcode_till_suspend"));
 				npc->Add(new SettingEntry("script.script_max_memory_megabytes"));
 				npc->Add(new SettingEntry("difficulty.competitor_speed"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -405,7 +405,6 @@ struct AISettings {
 
 /** Settings related to scripts. */
 struct ScriptSettings {
-	uint8_t  settings_profile;                 ///< difficulty profile to set initial settings of scripts, esp. random AIs
 	uint32_t script_max_opcode_till_suspend;   ///< max opcode calls till scripts will suspend
 	uint32_t script_max_memory_megabytes;      ///< limit on memory a single script instance may have allocated
 };

--- a/src/table/settings/script_settings.ini
+++ b/src/table/settings/script_settings.ini
@@ -8,7 +8,6 @@
 ; and in the savegame PATS chunk.
 
 [pre-amble]
-static constexpr std::initializer_list<const char*> _settings_profiles{"easy", "medium", "hard"};
 
 static const SettingVariant _script_settings_table[] = {
 [post-amble]
@@ -40,20 +39,6 @@ cat      = SC_ADVANCED
 extra    = 0
 startup  = false
 
-
-[SDT_OMANY]
-var      = script.settings_profile
-type     = SLE_UINT8
-from     = SLV_178
-flags    = SF_GUI_DROPDOWN
-def      = SP_EASY
-min      = SP_EASY
-max      = SP_HARD
-full     = _settings_profiles
-str      = STR_CONFIG_SETTING_AI_PROFILE
-strhelp  = STR_CONFIG_SETTING_AI_PROFILE_HELPTEXT
-strval   = STR_CONFIG_SETTING_AI_PROFILE_EASY
-cat      = SC_BASIC
 
 [SDT_VAR]
 var      = script.script_max_opcode_till_suspend


### PR DESCRIPTION
## Motivation / Problem

As mentioned in #11943, the `settings_profile` is a rather hidden setting. And its interaction with AI Configuration is vague at best (see ticket for more details).

Difficulty was removed from OpenTTD years ago, but it was left behind for AIs. Just a bit hidden.

Time to make the next step, and remove the difficulty completely from the game.

## Description

Remove `settings_profile` from game settings and `easy_value` / `medium_value` / `hard_value` / `custom_value` from `AddSetting`. Add `default_value` in `AddSetting`. Together with `random_deviation` it should still allow for variation. Just not based on difficulty.

As most AI authors do actually use easy/medium/hard, I didn't want to just waste the information and pick one of the three. So instead, medium is picked as median, and easy/hard are converted into `random_deviation`. That way, games are always somewhere between easy and hard. Best we can do, I would say.

`custom_value` was never actually used. It was impossible to set `settings_profile` to custom, so it was just being there. And not being useful.

An alternative to this PR could be to move the `settings_profile` into the AI configuration window. But given we removed it from OpenTTD, I think this approach is better.

## Limitations

Did basic testing, but nothing in-depth.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
