### PR TITLE
Change: Allow to configure AI slots above max_no_competitors

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -149,20 +149,14 @@ struct AIConfigWindow : public Window {
 	/**
 	 * Can the AI config in the given company slot be edited?
 	 * @param slot The slot to query.
-	 * @return True if and only if the given AI Config slot can e edited.
+	 * @return True if and only if the given AI Config slot can be edited.
 	 */
 	static bool IsEditable(CompanyID slot)
 	{
 		if (_game_mode != GM_NORMAL) {
-			return slot > 0 && slot <= GetGameSettings().difficulty.max_no_competitors;
+			return slot > 0 && slot < MAX_COMPANIES;
 		}
-		if (Company::IsValidID(slot)) return false;
-
-		int max_slot = GetGameSettings().difficulty.max_no_competitors;
-		for (CompanyID cid = COMPANY_FIRST; cid < (CompanyID)max_slot && cid < MAX_COMPANIES; cid++) {
-			if (Company::IsValidHumanID(cid)) max_slot++;
-		}
-		return slot < max_slot;
+		return slot < MAX_COMPANIES && !Company::IsValidID(slot);
 	}
 
 	void DrawWidget(const Rect &r, WidgetID widget) const override
@@ -186,7 +180,14 @@ struct AIConfigWindow : public Window {
 					if (this->selected_slot == i) {
 						tc = TC_WHITE;
 					} else if (IsEditable((CompanyID)i)) {
-						tc = TC_ORANGE;
+						int max_slot = GetGameSettings().difficulty.max_no_competitors;
+						for (const Company *c : Company::Iterate()) {
+							if (c->is_ai) max_slot--;
+						}
+						for (CompanyID cid = COMPANY_FIRST; cid < (CompanyID)max_slot && cid < MAX_COMPANIES; cid++) {
+							if (Company::IsValidHumanID(cid)) max_slot++;
+						}
+						if (i < max_slot) tc = TC_ORANGE;
 					} else if (Company::IsValidAiID(i)) {
 						tc = TC_GREEN;
 					}


### PR DESCRIPTION
## Motivation / Problem
Only max_no_competitors AIs can be configured, but `start_ai` can be used to start more than max_no_competitors AIs.
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/cd548ef7-75d3-48fe-b620-1da63379b994)
Running AIs are not counted to decide if a slot if selectable.
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/86423f25-0ba0-4ef4-b093-7671abe5f2ea)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Ignore max_no_competitors to determine if a slot can be selected (but still don't allow clicking on "Human player") and show which slots are the next to start.
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/8ba10567-8731-434e-bd22-7149749c5878)
Account for running AIs when indicating next to start slot.
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/1971af0b-c094-4940-8731-01751a7f4d9c)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
