### PR TITLE
Change: "restart" now uses your newgame settings, where "reload" uses the current settings

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1217,17 +1217,13 @@ DEF_CONSOLE_CMD(ConRestart)
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Restart game. Usage: 'restart'.");
-		IConsolePrint(CC_HELP, "Restarts a game. It tries to reproduce the exact same map as the game started with.");
-		IConsolePrint(CC_HELP, "However:");
-		IConsolePrint(CC_HELP, " * restarting games started in another version might create another map due to difference in map generation.");
-		IConsolePrint(CC_HELP, " * restarting games based on scenarios, loaded games or heightmaps will start a new game based on the settings stored in the scenario/savegame.");
+		IConsolePrint(CC_HELP, "Restarts a game, using the newgame settings.");
+		IConsolePrint(CC_HELP, " * if you started from a new game, and your newgame settings haven't changed, the game will be identical to when you started it.");
+		IConsolePrint(CC_HELP, " * if you started from a savegame / scenario / heightmap, the game might be different, because your settings might differ.");
 		return true;
 	}
 
-	/* Don't copy the _newgame pointers to the real pointers, so call SwitchToMode directly */
-	_settings_game.game_creation.map_x = Map::LogX();
-	_settings_game.game_creation.map_y = Map::LogY();
-	_switch_mode = SM_RESTARTGAME;
+	StartNewGameWithoutGUI(_settings_game.game_creation.generation_seed);
 	return true;
 }
 
@@ -1236,12 +1232,12 @@ DEF_CONSOLE_CMD(ConReload)
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Reload game. Usage: 'reload'.");
 		IConsolePrint(CC_HELP, "Reloads a game.");
-		IConsolePrint(CC_HELP, " * if you started from a savegame / scenario / heightmap, that exact same savegame / scenario / heightmap will be loaded.");
-		IConsolePrint(CC_HELP, " * if you started from a new game, this acts the same as 'restart'.");
+		IConsolePrint(CC_HELP, " * if you started from a new game, reload the game with the current active settings.");
+		IConsolePrint(CC_HELP, " * if you started from a savegame / scenario / heightmap, that same savegame / scenario / heightmap will be loaded again.");
 		return true;
 	}
 
-	/* Don't copy the _newgame pointers to the real pointers, so call SwitchToMode directly */
+	/* Use a switch-mode to prevent copying over newgame settings to active settings. */
 	_settings_game.game_creation.map_x = Map::LogX();
 	_settings_game.game_creation.map_y = Map::LogY();
 	_switch_mode = SM_RELOADGAME;

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1049,7 +1049,7 @@ void SwitchToMode(SwitchMode new_mode)
 	if (new_mode != SM_SAVE_GAME) {
 		/* If the network is active, make it not-active */
 		if (_networking) {
-			if (_network_server && (new_mode == SM_LOAD_GAME || new_mode == SM_NEWGAME || new_mode == SM_RESTARTGAME)) {
+			if (_network_server && (new_mode == SM_LOAD_GAME || new_mode == SM_NEWGAME)) {
 				NetworkReboot();
 			} else {
 				NetworkDisconnect();
@@ -1113,7 +1113,6 @@ void SwitchToMode(SwitchMode new_mode)
 			UpdateSocialIntegration(GM_NORMAL);
 			break;
 
-		case SM_RESTARTGAME: // Restart --> 'Random game' with current settings
 		case SM_NEWGAME: // New Game --> 'Random game'
 			MakeNewGame(false, new_mode == SM_NEWGAME);
 			GenerateSavegameId();

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -26,7 +26,6 @@ enum GameMode {
 enum SwitchMode {
 	SM_NONE,
 	SM_NEWGAME,           ///< New Game --> 'Random game'.
-	SM_RESTARTGAME,       ///< Restart --> 'Random game' with current settings.
 	SM_RELOADGAME,        ///< Reload the savegame / scenario / heightmap you started the game with.
 	SM_EDITOR,            ///< Switch to scenario editor.
 	SM_LOAD_GAME,         ///< Load game, Play Scenario.


### PR DESCRIPTION
## Motivation / Problem

After reading #11950, and looking over our options, I realised there is just something weird about our "reload" and "restart" commands. They behave differently depending on what is loaded (newgame, savegame, ..), and in a way that is hard to explain to users.

So I thought, maybe we should be a bit more extreme than what I suggested in #11950, and just draw a clear line what settings become active with "reload", and what settings with "restart". Also why I made a new PR, I didn't want to do it to the author of #11950 to get blamed for being a bit more drastic, as I am with this PR.

The issue that brought this to life is that when an Random AI is assigned what to run exactly, "restart" was not reverting this, but kept that AI assigned. Although #11950 set out to fix that, the problem is much bigger: any setting changed since the start was not reverted, which means that a "restart" could result in completely different games. And this was both against how "restart" was documentated and also not the functionality most of us envision with "restart".
An other example that came to light: if you change NewGRFs during a game (you shouldn't!), a "restart" used the new NewGRFs, giving you a totally different experience. And there are many more examples where this just acts weird / unexpected / unpredictable.

Closes #11950

## Description

"restart" now uses the seed of the current map and your newgame settings to rebuild the map.
- For newgames this now means that you start the exact (identical, in every way) same game, as people expect. If it doesn't, I would consider that a bug to be solved.
- For savegames it means it will create the same map IF you have the exact same settings. Which, for AI and NewGRF testing is not unlikely (and these commands aim those kind of players). But for any game you receive from someone else, you might not be so lucky.

"reload" stays the same but becomes easier to explain:
- For newgames this restarts the map with the current settings. So if you made any changes, if a Random AI was being assigned, etc, those all stay exactly the same. In result, this might produce a different map all together (if you changed world generation settings, for example).
- For savegames it simply reloads the game.

Hopefully this makes it a bit easier to understand for users what command does what.

## Limitations

There might be spacebar heaters.

There now isn't a way to restart a savegame with the current settings of the game. But this also gives very surprising results, and what caused a bit of the back & forth about what is actually going on. As we don't store the newgame settings as they were at the start of the map, it doesn't reproduce the state of the start of the savegame, but some interpretation of that. So I think we are better off just not supporting that.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
