### PR TITLE
Add: "restart current" console command to regenerate the map based on current settings

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1215,15 +1215,22 @@ DEF_CONSOLE_CMD(ConNewGame)
 
 DEF_CONSOLE_CMD(ConRestart)
 {
-	if (argc == 0) {
-		IConsolePrint(CC_HELP, "Restart game. Usage: 'restart'.");
-		IConsolePrint(CC_HELP, "Restarts a game, using the newgame settings.");
-		IConsolePrint(CC_HELP, " * if you started from a new game, and your newgame settings haven't changed, the game will be identical to when you started it.");
-		IConsolePrint(CC_HELP, " * if you started from a savegame / scenario / heightmap, the game might be different, because your settings might differ.");
+	if (argc == 0 || argc > 2) {
+		IConsolePrint(CC_HELP, "Restart game. Usage: 'restart [current|newgame]'.");
+		IConsolePrint(CC_HELP, "Restarts a game, using either the current or newgame (default) settings.");
+		IConsolePrint(CC_HELP, " * if you started from a new game, and your current/newgame settings haven't changed, the game will be identical to when you started it.");
+		IConsolePrint(CC_HELP, " * if you started from a savegame / scenario / heightmap, the game might be different, because the current/newgame settings might differ.");
 		return true;
 	}
 
-	StartNewGameWithoutGUI(_settings_game.game_creation.generation_seed);
+	if (argc == 1 || std::string_view(argv[1]) == "newgame") {
+		StartNewGameWithoutGUI(_settings_game.game_creation.generation_seed);
+	} else {
+		_settings_game.game_creation.map_x = Map::LogX();
+		_settings_game.game_creation.map_y = Map::LogY();
+		_switch_mode = SM_RESTARTGAME;
+	}
+
 	return true;
 }
 
@@ -1231,9 +1238,12 @@ DEF_CONSOLE_CMD(ConReload)
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Reload game. Usage: 'reload'.");
-		IConsolePrint(CC_HELP, "Reloads a game.");
-		IConsolePrint(CC_HELP, " * if you started from a new game, reload the game with the current active settings.");
-		IConsolePrint(CC_HELP, " * if you started from a savegame / scenario / heightmap, that same savegame / scenario / heightmap will be loaded again.");
+		IConsolePrint(CC_HELP, "Reloads a game if loaded via savegame / scenario / heightmap.");
+		return true;
+	}
+
+	if (_file_to_saveload.abstract_ftype == FT_NONE || _file_to_saveload.abstract_ftype == FT_INVALID) {
+		IConsolePrint(CC_ERROR, "No game loaded to reload.");
 		return true;
 	}
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1049,7 +1049,7 @@ void SwitchToMode(SwitchMode new_mode)
 	if (new_mode != SM_SAVE_GAME) {
 		/* If the network is active, make it not-active */
 		if (_networking) {
-			if (_network_server && (new_mode == SM_LOAD_GAME || new_mode == SM_NEWGAME)) {
+			if (_network_server && (new_mode == SM_LOAD_GAME || new_mode == SM_NEWGAME || new_mode == SM_RESTARTGAME)) {
 				NetworkReboot();
 			} else {
 				NetworkDisconnect();
@@ -1113,6 +1113,7 @@ void SwitchToMode(SwitchMode new_mode)
 			UpdateSocialIntegration(GM_NORMAL);
 			break;
 
+		case SM_RESTARTGAME: // Restart --> 'Random game' with current settings
 		case SM_NEWGAME: // New Game --> 'Random game'
 			MakeNewGame(false, new_mode == SM_NEWGAME);
 			GenerateSavegameId();

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -26,6 +26,7 @@ enum GameMode {
 enum SwitchMode {
 	SM_NONE,
 	SM_NEWGAME,           ///< New Game --> 'Random game'.
+	SM_RESTARTGAME,       ///< Restart --> 'Random game' with current settings.
 	SM_RELOADGAME,        ///< Reload the savegame / scenario / heightmap you started the game with.
 	SM_EDITOR,            ///< Switch to scenario editor.
 	SM_LOAD_GAME,         ///< Load game, Play Scenario.


### PR DESCRIPTION
## Motivation / Problem

With the changes to "restart" / "reload" (#11962), you couldn't recreate a savegame based on the current settings, which apparently is something that @frosch123 does :)

Small effort to introduce that.

## Description

Next to "restart", you can now also do "restart current" or "restart newgame" (where the latter is the same as "restart"). The first uses the current settings, the last uses the newgame settings. This allows the user to pick what they prefer.

While at it, make "reload" not work on new games, to avoid the confusion of what it does exactly. Use "restart current" instead.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
