### PR TITLE
Fix #11966: Remove deferred monospace font-cache initialisation.

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2130,7 +2130,7 @@ DEF_CONSOLE_CMD(ConFont)
 		FontCacheSubSetting *setting = GetFontCacheSubSetting(fs);
 		/* Make sure all non sprite fonts are loaded. */
 		if (!setting->font.empty() && !fc->HasParent()) {
-			InitFontCache(fs == FS_MONO);
+			InitFontCache(fs);
 			fc = FontCache::Get(fs);
 		}
 		IConsolePrint(CC_DEFAULT, "{}: \"{}\" {} {} [\"{}\" {} {}]", FontSizeToName(fs), fc->GetFontName(), fc->GetFontSize(), GetFontAAState(fs) ? "aa" : "noaa", setting->font, setting->size, setting->aa ? "aa" : "noaa");

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -177,10 +177,15 @@ inline void InitializeUnicodeGlyphMap()
 	}
 }
 
-inline void ClearFontCache()
+inline void ClearFontCache(FontSize fs)
+{
+	FontCache::Get(fs)->ClearFontCache();
+}
+
+inline void ClearFontCaches()
 {
 	for (FontSize fs = FS_BEGIN; fs < FS_END; fs++) {
-		FontCache::Get(fs)->ClearFontCache();
+		ClearFontCache(fs);
 	}
 }
 
@@ -240,8 +245,9 @@ inline FontCacheSubSetting *GetFontCacheSubSetting(FontSize fs)
 	}
 }
 
-void InitFontCache(bool monospace);
-void UninitFontCache();
+void InitFontCaches();
+void InitFontCache(FontSize fs);
+void UninitFontCaches();
 bool HasAntialiasedFonts();
 
 bool GetFontAAState(FontSize size, bool check_blitter = true);

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1227,18 +1227,23 @@ static void GfxMainBlitter(const Sprite *sprite, int x, int y, BlitterMode mode,
 }
 
 /**
- * Initialize _stringwidth_table cache
- * @param monospace Whether to load the monospace cache or the normal fonts.
+ * Initialize _stringwidth_table cache for a specific font size.
+ * @param fs Font size to initialize stringwidth table for.
  */
-void LoadStringWidthTable(bool monospace)
+void LoadStringWidthTable(FontSize fs)
 {
-	ClearFontCache();
-
-	for (FontSize fs = monospace ? FS_MONO : FS_BEGIN; fs < (monospace ? FS_END : FS_MONO); fs++) {
-		for (uint i = 0; i != 224; i++) {
-			_stringwidth_table[fs][i] = GetGlyphWidth(fs, i + 32);
-		}
+	ClearFontCache(fs);
+	for (uint i = 0; i != 224; i++) {
+		_stringwidth_table[fs][i] = GetGlyphWidth(fs, i + 32);
 	}
+}
+
+/**
+ * Initialize _stringwidth_table cache for all font sizes.
+ */
+void LoadStringWidthTable()
+{
+	for (FontSize fs = FS_BEGIN; fs < FS_END; fs++) LoadStringWidthTable(fs);
 }
 
 /**
@@ -1827,7 +1832,7 @@ bool AdjustGUIZoom(bool automatic)
 	if (old_font_zoom != _font_zoom) {
 		GfxClearFontSpriteCache();
 	}
-	ClearFontCache();
+	ClearFontCaches();
 	LoadStringWidthTable();
 
 	SetupWidgetDimensions();

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -139,7 +139,8 @@ int GetStringHeight(StringID str, int maxw);
 int GetStringLineCount(StringID str, int maxw);
 Dimension GetStringMultiLineBoundingBox(StringID str, const Dimension &suggestion);
 Dimension GetStringMultiLineBoundingBox(std::string_view str, const Dimension &suggestion);
-void LoadStringWidthTable(bool monospace = false);
+void LoadStringWidthTable();
+void LoadStringWidthTable(FontSize fs);
 Point GetCharPosInString(std::string_view str, const char *ch, FontSize start_fontsize = FS_NORMAL);
 ptrdiff_t GetCharAtPosition(std::string_view str, int x, FontSize start_fontsize = FS_NORMAL);
 

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -236,7 +236,7 @@ static void RealChangeBlitter(const char *repl_blitter)
 
 	/* Clear caches that might have sprites for another blitter. */
 	VideoDriver::GetInstance()->ClearSystemSprites();
-	ClearFontCache();
+	ClearFontCaches();
 	GfxClearSpriteCache();
 	ReInitAllWindows(false);
 }
@@ -318,7 +318,7 @@ void CheckBlitter()
 {
 	if (!SwitchNewGRFBlitter()) return;
 
-	ClearFontCache();
+	ClearFontCaches();
 	GfxClearSpriteCache();
 	ReInitAllWindows(false);
 }
@@ -330,7 +330,7 @@ void GfxLoadSprites()
 
 	SwitchNewGRFBlitter();
 	VideoDriver::GetInstance()->ClearSystemSprites();
-	ClearFontCache();
+	ClearFontCaches();
 	GfxInitSpriteMem();
 	LoadSpriteTables();
 	GfxInitPalettes();

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -308,7 +308,7 @@ static void ShutdownGame()
 	/* No NewGRFs were loaded when it was still bootstrapping. */
 	if (_game_mode != GM_BOOTSTRAP) ResetNewGRFData();
 
-	UninitFontCache();
+	UninitFontCaches();
 }
 
 /**
@@ -705,7 +705,7 @@ int openttd_main(int argc, char *argv[])
 	InitializeLanguagePacks();
 
 	/* Initialize the font cache */
-	InitFontCache(false);
+	InitFontCaches();
 
 	/* This must be done early, since functions use the SetWindowDirty* calls */
 	InitWindowSystem();

--- a/src/os/unix/font_unix.cpp
+++ b/src/os/unix/font_unix.cpp
@@ -169,7 +169,7 @@ bool SetFallbackFont(FontCacheSettings *settings, const std::string &language_is
 		if (best_font != nullptr) {
 			ret = true;
 			callback->SetFontNames(settings, best_font, &best_index);
-			InitFontCache(callback->Monospace());
+			InitFontCache(callback->DefaultSize());
 		}
 
 		/* Clean up the list of filenames. */

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -764,9 +764,8 @@ struct GameOptionsWindow : Window {
 				this->SetWidgetDisabledState(WID_GO_GUI_FONT_AA, _fcsettings.prefer_sprite);
 				this->SetDirty();
 
-				InitFontCache(false);
-				InitFontCache(true);
-				ClearFontCache();
+				InitFontCaches();
+				ClearFontCaches();
 				CheckForMissingGlyphs();
 				SetupWidgetDimensions();
 				UpdateAllVirtCoords();
@@ -779,7 +778,7 @@ struct GameOptionsWindow : Window {
 				this->SetWidgetLoweredState(WID_GO_GUI_FONT_AA, _fcsettings.global_aa);
 				MarkWholeScreenDirty();
 
-				ClearFontCache();
+				ClearFontCaches();
 				break;
 #endif /* HAS_TRUETYPE_FONT */
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2165,7 +2165,7 @@ const char *GetCurrentLanguageIsoCode()
  */
 bool MissingGlyphSearcher::FindMissingGlyphs()
 {
-	InitFontCache(this->Monospace());
+	InitFontCache(this->DefaultSize());
 	const Sprite *question_mark[FS_END];
 
 	for (FontSize size = this->Monospace() ? FS_MONO : FS_BEGIN; size < (this->Monospace() ? FS_END : FS_MONO); size++) {
@@ -2301,7 +2301,7 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 			/* Our fallback font does miss characters too, so keep the
 			 * user chosen font as that is more likely to be any good than
 			 * the wild guess we made */
-			InitFontCache(searcher->Monospace());
+			InitFontCache(searcher->DefaultSize());
 		}
 	}
 #endif
@@ -2318,12 +2318,12 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 		ShowErrorMessage(STR_JUST_RAW_STRING, INVALID_STRING_ID, WL_WARNING);
 
 		/* Reset the font width */
-		LoadStringWidthTable(searcher->Monospace());
+		LoadStringWidthTable(searcher->DefaultSize());
 		return;
 	}
 
 	/* Update the font with cache */
-	LoadStringWidthTable(searcher->Monospace());
+	LoadStringWidthTable(searcher->DefaultSize());
 
 #if !(defined(WITH_ICU_I18N) && defined(WITH_HARFBUZZ)) && !defined(WITH_UNISCRIBE) && !defined(WITH_COCOA)
 	/*


### PR DESCRIPTION
## Motivation / Problem

It was possible to ask for monospace font dimensions without initialising the monospace font cache, resulting in incorrect dimensions.

This caused the issue reported in #11966, where an incorrect dimension is used.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Remove deferred monospace font-cache initialisation. Instead of initialising when loading a text file, it is now always initialised, ready for use.

The `font` console command is also now able to reinitialise only the changed font instead of all.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
