### PR TITLE
Fix: Second colour vehicle-type default liveries not being updated when changing company default second colour

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -1046,7 +1046,7 @@ CommandCost CmdSetCompanyColour(DoCommandFlag flags, LiveryScheme scheme, bool p
 			c->livery[scheme].colour2 = colour;
 
 			if (scheme == LS_DEFAULT) {
-				UpdateCompanyGroupLiveries(c);
+				UpdateCompanyLiveries(c);
 			}
 		}
 


### PR DESCRIPTION
## Motivation / Problem

![Screenshot_2024-02-03_23-19-00](https://github.com/OpenTTD/OpenTTD/assets/3910080/2d659081-90c3-4d35-b219-c2cd676f809c)

Changing the company default secondary colour did not update vehicle type secondary colours which were set to the default, until the vehicle type secondary colour was next updated.

## Description

Update vehicle type secondary colours when changing the company default secondary colour.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
