### PR TITLE
Fix #11975, 27a920c: Running AIs also occupy a slot

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -164,6 +164,17 @@ struct AIConfigWindow : public Window {
 		switch (widget) {
 			case WID_AIC_LIST: {
 				Rect tr = r.Shrink(WidgetDimensions::scaled.matrix);
+				int max_slot = GetGameSettings().difficulty.max_no_competitors;
+				if (_game_mode == GM_NORMAL) {
+					for (const Company *c : Company::Iterate()) {
+						if (c->is_ai) max_slot--;
+					}
+					for (CompanyID cid = COMPANY_FIRST; cid < (CompanyID)max_slot && cid < MAX_COMPANIES; cid++) {
+						if (Company::IsValidID(cid)) max_slot++;
+					}
+				} else {
+					max_slot++; // Slot 0 is human
+				}
 				for (int i = this->vscroll->GetPosition(); this->vscroll->IsVisible(i) && i < MAX_COMPANIES; i++) {
 					StringID text;
 
@@ -180,13 +191,6 @@ struct AIConfigWindow : public Window {
 					if (this->selected_slot == i) {
 						tc = TC_WHITE;
 					} else if (IsEditable((CompanyID)i)) {
-						int max_slot = GetGameSettings().difficulty.max_no_competitors;
-						for (const Company *c : Company::Iterate()) {
-							if (c->is_ai) max_slot--;
-						}
-						for (CompanyID cid = COMPANY_FIRST; cid < (CompanyID)max_slot && cid < MAX_COMPANIES; cid++) {
-							if (Company::IsValidHumanID(cid)) max_slot++;
-						}
 						if (i < max_slot) tc = TC_ORANGE;
 					} else if (Company::IsValidAiID(i)) {
 						tc = TC_GREEN;


### PR DESCRIPTION
## Motivation / Problem
Only human company are accounted when determining next to start slots, but running AIs also occupy slots.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Properly account occupied slots.
Also handled `_game_mode` as iterating companies or checking their validity in main menu is just wrong.
And moved `max_slot` determination outside of the loop.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
