### PR TITLE
Fix: [CMake] Link test executable with log library in Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,10 @@ target_link_libraries(openttd
 )
 
 target_link_libraries(openttd_test PRIVATE openttd_lib)
+if(ANDROID)
+    target_link_libraries(openttd_test PRIVATE log)
+endif()
+
 include(Catch)
 catch_discover_tests(openttd_test)
 


### PR DESCRIPTION

    This fixes the following compiler error.
    
    ld.lld: error: undefined symbol: __android_log_write
    referenced by test_main.cpp
    CMakeFiles/openttd_test.dir/src/tests/test_main.cpp.o:
    (Catch::writeToDebugConsole(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&))
