### PR TITLE
Codechange: use consistent types for Packets

### DIFF
--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -25,7 +25,7 @@ static const uint16_t NETWORK_CONTENT_SERVER_PORT     = 3978;           ///< The
 static const uint16_t NETWORK_DEFAULT_PORT            = 3979;           ///< The default port of the game server (TCP & UDP)
 static const uint16_t NETWORK_ADMIN_PORT              = 3977;           ///< The default port for admin network
 
-static const size_t UDP_MTU                         = 1460;           ///< Number of bytes we can pack in a single UDP packet
+static const size_t UDP_MTU = 1460; ///< Number of bytes we can pack in a single UDP packet
 
 static const std::string NETWORK_SURVEY_DETAILS_LINK = "https://survey.openttd.org/participate"; ///< Link with more details & privacy statement of the survey.
 /*
@@ -42,8 +42,8 @@ static const std::string NETWORK_SURVEY_DETAILS_LINK = "https://survey.openttd.o
  * Send_uint16(GB(size, 16, 14) | 0b10 << 14)
  * Send_uint16(GB(size,  0, 16))
  */
-static const size_t TCP_MTU                         = 32767;          ///< Number of bytes we can pack in a single TCP packet
-static const size_t COMPAT_MTU                      = 1460;           ///< Number of bytes we can pack in a single packet for backward compatibility
+static const size_t TCP_MTU = 32767; ///< Number of bytes we can pack in a single TCP packet
+static const size_t COMPAT_MTU = 1460; ///< Number of bytes we can pack in a single packet for backward compatibility
 
 static const byte NETWORK_GAME_ADMIN_VERSION        =    3;           ///< What version of the admin network do we use?
 static const byte NETWORK_GAME_INFO_VERSION         =    7;           ///< What version of game-info do we use?

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -25,7 +25,7 @@ static const uint16_t NETWORK_CONTENT_SERVER_PORT     = 3978;           ///< The
 static const uint16_t NETWORK_DEFAULT_PORT            = 3979;           ///< The default port of the game server (TCP & UDP)
 static const uint16_t NETWORK_ADMIN_PORT              = 3977;           ///< The default port for admin network
 
-static const uint16_t UDP_MTU                         = 1460;           ///< Number of bytes we can pack in a single UDP packet
+static const size_t UDP_MTU                         = 1460;           ///< Number of bytes we can pack in a single UDP packet
 
 static const std::string NETWORK_SURVEY_DETAILS_LINK = "https://survey.openttd.org/participate"; ///< Link with more details & privacy statement of the survey.
 /*
@@ -42,8 +42,8 @@ static const std::string NETWORK_SURVEY_DETAILS_LINK = "https://survey.openttd.o
  * Send_uint16(GB(size, 16, 14) | 0b10 << 14)
  * Send_uint16(GB(size,  0, 16))
  */
-static const uint16_t TCP_MTU                         = 32767;          ///< Number of bytes we can pack in a single TCP packet
-static const uint16_t COMPAT_MTU                      = 1460;           ///< Number of bytes we can pack in a single packet for backward compatibility
+static const size_t TCP_MTU                         = 32767;          ///< Number of bytes we can pack in a single TCP packet
+static const size_t COMPAT_MTU                      = 1460;           ///< Number of bytes we can pack in a single packet for backward compatibility
 
 static const byte NETWORK_GAME_ADMIN_VERSION        =    3;           ///< What version of the admin network do we use?
 static const byte NETWORK_GAME_INFO_VERSION         =    7;           ///< What version of game-info do we use?

--- a/src/network/core/tcp_admin.h
+++ b/src/network/core/tcp_admin.h
@@ -21,7 +21,7 @@
  * Enum with types of TCP packets specific to the admin network.
  * This protocol may only be extended to ensure stability.
  */
-enum PacketAdminType {
+enum PacketAdminType : uint8_t {
 	ADMIN_PACKET_ADMIN_JOIN,             ///< The admin announces and authenticates itself to the server.
 	ADMIN_PACKET_ADMIN_QUIT,             ///< The admin tells the server that it is quitting.
 	ADMIN_PACKET_ADMIN_UPDATE_FREQUENCY, ///< The admin tells the server the update frequency of a particular piece of information.

--- a/src/network/core/tcp_content_type.h
+++ b/src/network/core/tcp_content_type.h
@@ -32,7 +32,7 @@ enum ContentType {
 };
 
 /** Enum with all types of TCP content packets. The order MUST not be changed **/
-enum PacketContentType {
+enum PacketContentType : uint8_t {
 	PACKET_CONTENT_CLIENT_INFO_LIST,      ///< Queries the content server for a list of info of a given content type
 	PACKET_CONTENT_CLIENT_INFO_ID,        ///< Queries the content server for information about a list of internal IDs
 	PACKET_CONTENT_CLIENT_INFO_EXTID,     ///< Queries the content server for information about a list of external IDs

--- a/src/network/core/tcp_coordinator.h
+++ b/src/network/core/tcp_coordinator.h
@@ -25,7 +25,7 @@
  * CLIENT -> packets from Client to Game Coordinator.
  * SERCLI -> packets from either the Server or Client to Game Coordinator.
  **/
-enum PacketCoordinatorType {
+enum PacketCoordinatorType : uint8_t {
 	PACKET_COORDINATOR_GC_ERROR,              ///< Game Coordinator indicates there was an error.
 	PACKET_COORDINATOR_SERVER_REGISTER,       ///< Server registration.
 	PACKET_COORDINATOR_GC_REGISTER_ACK,       ///< Game Coordinator accepts the registration.

--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -22,7 +22,7 @@
  * Enum with all types of TCP packets.
  * For the exact meaning, look at #NetworkGameSocketHandler.
  */
-enum PacketGameType {
+enum PacketGameType : uint8_t {
 	/*
 	 * These first four pair of packets (thus eight in
 	 * total) must remain in this order for backward

--- a/src/network/core/tcp_stun.h
+++ b/src/network/core/tcp_stun.h
@@ -17,7 +17,7 @@
 #include "packet.h"
 
 /** Enum with all types of TCP STUN packets. The order MUST not be changed. **/
-enum PacketStunType {
+enum PacketStunType : uint8_t {
 	PACKET_STUN_SERCLI_STUN,  ///< Send a STUN request to the STUN server.
 	PACKET_STUN_END,          ///< Must ALWAYS be on the end of this list!! (period)
 };

--- a/src/network/core/tcp_turn.h
+++ b/src/network/core/tcp_turn.h
@@ -18,7 +18,7 @@
 #include "network_game_info.h"
 
 /** Enum with all types of TCP TURN packets. The order MUST not be changed. **/
-enum PacketTurnType {
+enum PacketTurnType : uint8_t {
 	PACKET_TURN_TURN_ERROR,     ///< TURN server is unable to relay.
 	PACKET_TURN_SERCLI_CONNECT, ///< Client or server is connecting to the TURN server.
 	PACKET_TURN_TURN_CONNECTED, ///< TURN server indicates the socket is now being relayed.

--- a/src/network/core/udp.h
+++ b/src/network/core/udp.h
@@ -16,7 +16,7 @@
 #include "packet.h"
 
 /** Enum with all types of UDP packets. The order MUST not be changed **/
-enum PacketUDPType {
+enum PacketUDPType : uint8_t {
 	PACKET_UDP_CLIENT_FIND_SERVER,   ///< Queries a game server for game information
 	PACKET_UDP_SERVER_RESPONSE,      ///< Reply of the game server with game information
 	PACKET_UDP_END,                  ///< Must ALWAYS be on the end of this list!! (period)


### PR DESCRIPTION
## Motivation / Problem

The MTU values are configured as `uint16_t`, but everywhere they are passed to they become `size_t`.
The `PacketType` "sub" enumerations do not have a `uint8_t`/`PacketType` storage.

The result is a number of unneeded type conversions, but also when adding `NetworkSocketHandler` to the packets that are to be sent there is a lot of type confusion and the compiler starts throwing fits. "Changing" the types solves that issue completely.


## Description

Make the MTU constants `size_t`. Make the `PacketType` enumerations all use `uint8_t` as base type.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
