### PR TITLE
Fix #11802: Made determining water region edge traversability more robust

### DIFF
--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -29,6 +29,7 @@
 #include "rev.h"
 #include "timer/timer.h"
 #include "timer/timer_window.h"
+#include "pathfinder/water_regions.h"
 
 #include "widgets/misc_widget.h"
 
@@ -128,6 +129,8 @@ public:
 		Debug(misc, LANDINFOD_LEVEL, "m6     = 0x{:x}", tile.m6());
 		Debug(misc, LANDINFOD_LEVEL, "m7     = 0x{:x}", tile.m7());
 		Debug(misc, LANDINFOD_LEVEL, "m8     = 0x{:x}", tile.m8());
+
+		PrintWaterRegionDebugInfo(tile);
 #undef LANDINFOD_LEVEL
 	}
 

--- a/src/pathfinder/water_regions.cpp
+++ b/src/pathfinder/water_regions.cpp
@@ -182,6 +182,33 @@ public:
 	{
 		if (!this->initialized) ForceUpdate();
 	}
+
+	void PrintDebugInfo()
+	{
+		Debug(map, 9, "Water region {},{} labels and edge traversability = ...", GetWaterRegionX(tile_area.tile), GetWaterRegionY(tile_area.tile));
+
+		const size_t max_element_width = std::to_string(this->number_of_patches).size();
+
+		std::array<int, 16> traversability_NW{0};
+		for (auto bitIndex : SetBitIterator(edge_traversability_bits[DIAGDIR_NW])) *(traversability_NW.rbegin() + bitIndex) = 1;
+		Debug(map, 9, "    {:{}}", fmt::join(traversability_NW, " "), max_element_width);
+		Debug(map, 9, "  +{:->{}}+", "", WATER_REGION_EDGE_LENGTH * (max_element_width + 1) + 1);
+
+		for (int y = 0; y < WATER_REGION_EDGE_LENGTH; ++y) {
+			std::string line{};
+			for (int x = 0; x < WATER_REGION_EDGE_LENGTH; ++x) {
+				const auto label = this->tile_patch_labels[x + y * WATER_REGION_EDGE_LENGTH];
+				const std::string label_str = label == INVALID_WATER_REGION_PATCH ? "." : std::to_string(label);
+				line = fmt::format("{:{}}", label_str, max_element_width) + " " + line;
+			}
+			Debug(map, 9, "{} | {}| {}", GB(this->edge_traversability_bits[DIAGDIR_SW], y, 1), line, GB(this->edge_traversability_bits[DIAGDIR_NE], y, 1));
+		}
+
+		Debug(map, 9, "  +{:->{}}+", "", WATER_REGION_EDGE_LENGTH * (max_element_width + 1) + 1);
+		std::array<int, 16> traversability_SE{0};
+		for (auto bitIndex : SetBitIterator(edge_traversability_bits[DIAGDIR_SE])) *(traversability_SE.rbegin() + bitIndex) = 1;
+		Debug(map, 9, "    {:{}}", fmt::join(traversability_SE, " "), max_element_width);
+	}
 };
 
 std::vector<WaterRegion> _water_regions;
@@ -371,4 +398,9 @@ void AllocateWaterRegions()
 			_water_regions.emplace_back(region_x, region_y);
 		}
 	}
+}
+
+void PrintWaterRegionDebugInfo(TileIndex tile)
+{
+	GetUpdatedWaterRegion(tile).PrintDebugInfo();
 }

--- a/src/pathfinder/water_regions.h
+++ b/src/pathfinder/water_regions.h
@@ -64,4 +64,6 @@ void VisitWaterRegionPatchNeighbors(const WaterRegionPatchDesc &water_region_pat
 
 void AllocateWaterRegions();
 
+void PrintWaterRegionDebugInfo(TileIndex tile);
+
 #endif /* WATER_REGIONS_H */


### PR DESCRIPTION
## Motivation / Problem

Determining water region edge traversability (i.e. whether you can move from one region into an adjacent one) wasn't done in the most robust way. At least one edge case was already found and a fix is in this PR https://github.com/OpenTTD/OpenTTD/pull/11817 . While the fix is good, there might be other edge cases that we don't know of. I wanted to come up with a more robust method.

## Description

I've found that the best way to fix these kinds of issues are to "play by the same rules as ships". This means using the Track Follower for ships. This trick was already used for the connected component labeling (CCL) inside the water regions, but not yet to determine the inter-region traversability.

After this change the CCL is allowed to "hop over the edges" of the water region. When it does it sets the traversability of that particular tile. This actually made cross-region-aqueduct-detection easier too.

## Limitations

- This introduces a dependency on the water tiles of the edge of any adjacent water region. If any of those external edge tiles get changed it could affect the water region traversability. The InvalidateWaterRegion function has been modified to take this into account and invalidates any adjacent water regions in such a case.
- This stuff is hard to inspect / debug, so I added some debug printing. The land info tool calls it. This is the printout for the region marked in white (it includes the void edge tiles):
![image](https://github.com/OpenTTD/OpenTTD/assets/68320206/e9ac5252-dfe7-4107-ab82-09d941316675)


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
