### PR TITLE
Feature: Support more number formats than just the 'Western' one

### DIFF
--- a/src/core/math_func.hpp
+++ b/src/core/math_func.hpp
@@ -350,6 +350,19 @@ constexpr int RoundDivSU(int a, uint b)
 	}
 }
 
+/**
+ * Computes ten to the given power.
+ * @param power The power of ten to get.
+ * @return The power of ten.
+ */
+constexpr uint64_t PowerOfTen(int power)
+{
+	assert(power >= 0 && power <= 20 /* digits in uint64_t */);
+	uint64_t result = 1;
+	for (int i = 0; i < power; i++) result *= 10;
+	return result;
+}
+
 uint32_t IntSqrt(uint32_t num);
 
 #endif /* MATH_FUNC_HPP */

--- a/src/lang/afrikaans.txt
+++ b/src/lang/afrikaans.txt
@@ -3,8 +3,6 @@
 ##isocode af_ZA
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0436
 ##grflangid 0x1b

--- a/src/lang/afrikaans.txt
+++ b/src/lang/afrikaans.txt
@@ -3,6 +3,8 @@
 ##isocode af_ZA
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0436
 ##grflangid 0x1b

--- a/src/lang/arabic_egypt.txt
+++ b/src/lang/arabic_egypt.txt
@@ -3,8 +3,6 @@
 ##isocode ar_EG
 ##plural 1
 ##textdir rtl
-##digitsep ٬
-##digitsepcur ٬
 ##decimalsep ٫
 ##winlangid 0x0c01
 ##grflangid 0x14

--- a/src/lang/arabic_egypt.txt
+++ b/src/lang/arabic_egypt.txt
@@ -3,6 +3,8 @@
 ##isocode ar_EG
 ##plural 1
 ##textdir rtl
+##numberformat 00٬000٬000٬000٬000٬000٬000
+##numberabbreviations 3=00٬000٬000٬000٬000٬000{NBSP}k|6=00٬000٬000٬000٬000{NBSP}m|9=00٬000٬000٬000{NBSP}bn|12=00٬000٬000{NBSP}tn|15=00٬000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ٫
 ##winlangid 0x0c01
 ##grflangid 0x14

--- a/src/lang/basque.txt
+++ b/src/lang/basque.txt
@@ -3,6 +3,8 @@
 ##isocode eu_ES
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x042d
 ##grflangid 0x21

--- a/src/lang/basque.txt
+++ b/src/lang/basque.txt
@@ -3,8 +3,6 @@
 ##isocode eu_ES
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x042d
 ##grflangid 0x21

--- a/src/lang/belarusian.txt
+++ b/src/lang/belarusian.txt
@@ -3,6 +3,8 @@
 ##isocode be_BY
 ##plural 6
 ##textdir ltr
+##numberformat 00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000
+##numberabbreviations 3=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}k|6=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}m|9=00{NBSP}000{NBSP}000{NBSP}000{NBSP}bn|12=00{NBSP}000{NBSP}000{NBSP}tn|15=00{NBSP}000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0423
 ##grflangid 0x10

--- a/src/lang/belarusian.txt
+++ b/src/lang/belarusian.txt
@@ -3,8 +3,6 @@
 ##isocode be_BY
 ##plural 6
 ##textdir ltr
-##digitsep {NBSP}
-##digitsepcur {NBSP}
 ##decimalsep ,
 ##winlangid 0x0423
 ##grflangid 0x10

--- a/src/lang/brazilian_portuguese.txt
+++ b/src/lang/brazilian_portuguese.txt
@@ -3,8 +3,6 @@
 ##isocode pt_BR
 ##plural 2
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0416
 ##grflangid 0x37

--- a/src/lang/brazilian_portuguese.txt
+++ b/src/lang/brazilian_portuguese.txt
@@ -3,6 +3,8 @@
 ##isocode pt_BR
 ##plural 2
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0416
 ##grflangid 0x37

--- a/src/lang/bulgarian.txt
+++ b/src/lang/bulgarian.txt
@@ -3,6 +3,8 @@
 ##isocode bg_BG
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0402
 ##grflangid 0x18

--- a/src/lang/bulgarian.txt
+++ b/src/lang/bulgarian.txt
@@ -3,8 +3,6 @@
 ##isocode bg_BG
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0402
 ##grflangid 0x18

--- a/src/lang/catalan.txt
+++ b/src/lang/catalan.txt
@@ -3,6 +3,8 @@
 ##isocode ca_ES
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}M|9=00.000.000.000{NBSP}G|12=00.000.000{NBSP}T|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0403
 ##grflangid 0x22

--- a/src/lang/catalan.txt
+++ b/src/lang/catalan.txt
@@ -3,8 +3,6 @@
 ##isocode ca_ES
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0403
 ##grflangid 0x22

--- a/src/lang/chuvash.txt
+++ b/src/lang/chuvash.txt
@@ -3,8 +3,6 @@
 ##isocode cv_RU
 ##plural 0
 ##textdir ltr
-##digitsep {NBSP}
-##digitsepcur {NBSP}
 ##decimalsep ,
 ##winlangid 0x0419
 ##grflangid 0x0b

--- a/src/lang/chuvash.txt
+++ b/src/lang/chuvash.txt
@@ -3,6 +3,8 @@
 ##isocode cv_RU
 ##plural 0
 ##textdir ltr
+##numberformat 00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000
+##numberabbreviations 3=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}k|6=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}m|9=00{NBSP}000{NBSP}000{NBSP}000{NBSP}bn|12=00{NBSP}000{NBSP}000{NBSP}tn|15=00{NBSP}000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0419
 ##grflangid 0x0b

--- a/src/lang/croatian.txt
+++ b/src/lang/croatian.txt
@@ -3,6 +3,8 @@
 ##isocode hr_HR
 ##plural 6
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x041a
 ##grflangid 0x38

--- a/src/lang/croatian.txt
+++ b/src/lang/croatian.txt
@@ -3,8 +3,6 @@
 ##isocode hr_HR
 ##plural 6
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x041a
 ##grflangid 0x38

--- a/src/lang/czech.txt
+++ b/src/lang/czech.txt
@@ -3,8 +3,6 @@
 ##isocode cs_CZ
 ##plural 10
 ##textdir ltr
-##digitsep {NBSP}
-##digitsepcur {NBSP}
 ##decimalsep ,
 ##winlangid 0x0405
 ##grflangid 0x15

--- a/src/lang/czech.txt
+++ b/src/lang/czech.txt
@@ -3,6 +3,8 @@
 ##isocode cs_CZ
 ##plural 10
 ##textdir ltr
+##numberformat 00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000
+##numberabbreviations 3=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}tis.|6=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}mil.|9=00{NBSP}000{NBSP}000{NBSP}000{NBSP}mld.|12=00{NBSP}000{NBSP}000{NBSP}bil.|15=00{NBSP}000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0405
 ##grflangid 0x15

--- a/src/lang/danish.txt
+++ b/src/lang/danish.txt
@@ -3,8 +3,6 @@
 ##isocode da_DK
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0406
 ##grflangid 0x2d

--- a/src/lang/danish.txt
+++ b/src/lang/danish.txt
@@ -3,6 +3,8 @@
 ##isocode da_DK
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0406
 ##grflangid 0x2d

--- a/src/lang/dutch.txt
+++ b/src/lang/dutch.txt
@@ -3,8 +3,6 @@
 ##isocode nl_NL
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0413
 ##grflangid 0x1f

--- a/src/lang/dutch.txt
+++ b/src/lang/dutch.txt
@@ -3,6 +3,8 @@
 ##isocode nl_NL
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}mj|9=00.000.000.000{NBSP}md|12=00.000.000{NBSP}bn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0413
 ##grflangid 0x1f

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -5,8 +5,6 @@
 ##textdir ltr
 ##numberformat 00,000,000,000,000,000,000
 ##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
-##digitsep ,
-##digitsepcur ,
 ##decimalsep .
 ##winlangid 0x0809
 ##grflangid 0x01
@@ -5811,11 +5809,6 @@ STR_STATION_NAME                                                :{STATION}
 STR_TOWN_NAME                                                   :{TOWN}
 STR_VEHICLE_NAME                                                :{VEHICLE}
 STR_WAYPOINT_NAME                                               :{WAYPOINT}
-
-STR_CURRENCY_SHORT_KILO                                         :{NBSP}k
-STR_CURRENCY_SHORT_MEGA                                         :{NBSP}m
-STR_CURRENCY_SHORT_GIGA                                         :{NBSP}bn
-STR_CURRENCY_SHORT_TERA                                         :{NBSP}tn
 
 STR_JUST_CARGO                                                  :{CARGO_LONG}
 STR_JUST_RIGHT_ARROW                                            :{RIGHT_ARROW}

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3,6 +3,8 @@
 ##isocode en_GB
 ##plural 0
 ##textdir ltr
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
 ##digitsep ,
 ##digitsepcur ,
 ##decimalsep .

--- a/src/lang/english_AU.txt
+++ b/src/lang/english_AU.txt
@@ -3,6 +3,8 @@
 ##isocode en_AU
 ##plural 0
 ##textdir ltr
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep .
 ##winlangid 0x0c09
 ##grflangid 0x3d

--- a/src/lang/english_AU.txt
+++ b/src/lang/english_AU.txt
@@ -3,8 +3,6 @@
 ##isocode en_AU
 ##plural 0
 ##textdir ltr
-##digitsep ,
-##digitsepcur ,
 ##decimalsep .
 ##winlangid 0x0c09
 ##grflangid 0x3d

--- a/src/lang/english_US.txt
+++ b/src/lang/english_US.txt
@@ -3,6 +3,8 @@
 ##isocode en_US
 ##plural 0
 ##textdir ltr
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 3=00,000,000,000,000,000{NBSP}K|6=00,000,000,000,000{NBSP}M|9=00,000,000,000{NBSP}B|12=00,000,000{NBSP}T|15=00,000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep .
 ##winlangid 0x0409
 ##grflangid 0x00

--- a/src/lang/english_US.txt
+++ b/src/lang/english_US.txt
@@ -3,8 +3,6 @@
 ##isocode en_US
 ##plural 0
 ##textdir ltr
-##digitsep ,
-##digitsepcur ,
 ##decimalsep .
 ##winlangid 0x0409
 ##grflangid 0x00

--- a/src/lang/esperanto.txt
+++ b/src/lang/esperanto.txt
@@ -3,6 +3,8 @@
 ##isocode eo_EO
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0000
 ##grflangid 0x05

--- a/src/lang/esperanto.txt
+++ b/src/lang/esperanto.txt
@@ -3,8 +3,6 @@
 ##isocode eo_EO
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0000
 ##grflangid 0x05

--- a/src/lang/estonian.txt
+++ b/src/lang/estonian.txt
@@ -3,8 +3,6 @@
 ##isocode et_EE
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0425
 ##grflangid 0x34

--- a/src/lang/estonian.txt
+++ b/src/lang/estonian.txt
@@ -3,6 +3,8 @@
 ##isocode et_EE
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0425
 ##grflangid 0x34

--- a/src/lang/faroese.txt
+++ b/src/lang/faroese.txt
@@ -3,8 +3,6 @@
 ##isocode fo_FO
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0438
 ##grflangid 0x12

--- a/src/lang/faroese.txt
+++ b/src/lang/faroese.txt
@@ -3,6 +3,8 @@
 ##isocode fo_FO
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0438
 ##grflangid 0x12

--- a/src/lang/finnish.txt
+++ b/src/lang/finnish.txt
@@ -3,8 +3,6 @@
 ##isocode fi_FI
 ##plural 0
 ##textdir ltr
-##digitsep {NBSP}
-##digitsepcur {NBSP}
 ##decimalsep ,
 ##winlangid 0x040b
 ##grflangid 0x35

--- a/src/lang/finnish.txt
+++ b/src/lang/finnish.txt
@@ -3,6 +3,8 @@
 ##isocode fi_FI
 ##plural 0
 ##textdir ltr
+##numberformat 00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000
+##numberabbreviations 6=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}milj.|9=00{NBSP}000{NBSP}000{NBSP}000{NBSP}mrd.|12=00{NBSP}000{NBSP}000{NBSP} t|15=00{NBSP}000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x040b
 ##grflangid 0x35

--- a/src/lang/french.txt
+++ b/src/lang/french.txt
@@ -3,8 +3,6 @@
 ##isocode fr_FR
 ##plural 2
 ##textdir ltr
-##digitsep {NBSP}
-##digitsepcur {NBSP}
 ##decimalsep ,
 ##winlangid 0x040c
 ##grflangid 0x03

--- a/src/lang/french.txt
+++ b/src/lang/french.txt
@@ -3,6 +3,8 @@
 ##isocode fr_FR
 ##plural 2
 ##textdir ltr
+##numberformat 00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000
+##numberabbreviations 3=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}k|6=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}Mio|9=00{NBSP}000{NBSP}000{NBSP}000{NBSP}Mrd|12=00{NBSP}000{NBSP}000{NBSP}kMrd|15=00{NBSP}000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x040c
 ##grflangid 0x03

--- a/src/lang/frisian.txt
+++ b/src/lang/frisian.txt
@@ -3,8 +3,6 @@
 ##isocode fy_NL
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0462
 ##grflangid 0x32

--- a/src/lang/frisian.txt
+++ b/src/lang/frisian.txt
@@ -3,6 +3,8 @@
 ##isocode fy_NL
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0462
 ##grflangid 0x32

--- a/src/lang/gaelic.txt
+++ b/src/lang/gaelic.txt
@@ -3,8 +3,6 @@
 ##isocode gd_GB
 ##plural 13
 ##textdir ltr
-##digitsep ,
-##digitsepcur ,
 ##decimalsep .
 ##winlangid 0x083c
 ##grflangid 0x13

--- a/src/lang/gaelic.txt
+++ b/src/lang/gaelic.txt
@@ -3,6 +3,8 @@
 ##isocode gd_GB
 ##plural 13
 ##textdir ltr
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep .
 ##winlangid 0x083c
 ##grflangid 0x13

--- a/src/lang/galician.txt
+++ b/src/lang/galician.txt
@@ -3,8 +3,6 @@
 ##isocode gl_ES
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0456
 ##grflangid 0x31

--- a/src/lang/galician.txt
+++ b/src/lang/galician.txt
@@ -3,6 +3,8 @@
 ##isocode gl_ES
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}M|9=00.000.000.000{NBSP}MM|12=00.000.000{NBSP}bn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0456
 ##grflangid 0x31

--- a/src/lang/german.txt
+++ b/src/lang/german.txt
@@ -3,8 +3,6 @@
 ##isocode de_DE
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0407
 ##grflangid 0x02

--- a/src/lang/german.txt
+++ b/src/lang/german.txt
@@ -3,6 +3,8 @@
 ##isocode de_DE
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}t|6=00.000.000.000.000{NBSP}Mio|9=00.000.000.000{NBSP}Mrd|12=00.000.000{NBSP}Bio|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0407
 ##grflangid 0x02

--- a/src/lang/german.txt
+++ b/src/lang/german.txt
@@ -4,7 +4,7 @@
 ##plural 0
 ##textdir ltr
 ##numberformat 00.000.000.000.000.000.000
-##numberabbreviations 3=00.000.000.000.000.000{NBSP}t|6=00.000.000.000.000{NBSP}Mio|9=00.000.000.000{NBSP}Mrd|12=00.000.000{NBSP}Bio|15=00.000{NBSP}Qa|18=00{NBSP}Qi
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}Tsd.|6=00.000.000.000.000{NBSP}Mio.|9=00.000.000.000{NBSP}Mrd.|12=00.000.000{NBSP}Bio.|15=00.000{NBSP}Brd.|18=00{NBSP}Trill.
 ##decimalsep ,
 ##winlangid 0x0407
 ##grflangid 0x02

--- a/src/lang/greek.txt
+++ b/src/lang/greek.txt
@@ -3,6 +3,8 @@
 ##isocode el_GR
 ##plural 2
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0408
 ##grflangid 0x1e

--- a/src/lang/greek.txt
+++ b/src/lang/greek.txt
@@ -3,8 +3,6 @@
 ##isocode el_GR
 ##plural 2
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0408
 ##grflangid 0x1e

--- a/src/lang/hebrew.txt
+++ b/src/lang/hebrew.txt
@@ -3,8 +3,6 @@
 ##isocode he_IL
 ##plural 0
 ##textdir rtl
-##digitsep ,
-##digitsepcur ,
 ##decimalsep .
 ##winlangid 0x040d
 ##grflangid 0x61

--- a/src/lang/hebrew.txt
+++ b/src/lang/hebrew.txt
@@ -3,6 +3,8 @@
 ##isocode he_IL
 ##plural 0
 ##textdir rtl
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep .
 ##winlangid 0x040d
 ##grflangid 0x61

--- a/src/lang/hindi.txt
+++ b/src/lang/hindi.txt
@@ -3,8 +3,6 @@
 ##isocode hi_IN
 ##plural 0
 ##textdir ltr
-##digitsep ,
-##digitsepcur ,
 ##decimalsep .
 ##winlangid 0x0439
 ##grflangid 0x17

--- a/src/lang/hindi.txt
+++ b/src/lang/hindi.txt
@@ -3,6 +3,8 @@
 ##isocode hi_IN
 ##plural 0
 ##textdir ltr
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep .
 ##winlangid 0x0439
 ##grflangid 0x17

--- a/src/lang/hungarian.txt
+++ b/src/lang/hungarian.txt
@@ -3,6 +3,8 @@
 ##isocode hu_HU
 ##plural 2
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}e|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}mrd|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x040e
 ##grflangid 0x24

--- a/src/lang/hungarian.txt
+++ b/src/lang/hungarian.txt
@@ -3,8 +3,6 @@
 ##isocode hu_HU
 ##plural 2
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x040e
 ##grflangid 0x24

--- a/src/lang/icelandic.txt
+++ b/src/lang/icelandic.txt
@@ -3,8 +3,6 @@
 ##isocode is_IS
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x040f
 ##grflangid 0x29

--- a/src/lang/icelandic.txt
+++ b/src/lang/icelandic.txt
@@ -3,6 +3,8 @@
 ##isocode is_IS
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x040f
 ##grflangid 0x29

--- a/src/lang/ido.txt
+++ b/src/lang/ido.txt
@@ -3,8 +3,6 @@
 ##isocode io_IO
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0000
 ##grflangid 0x06

--- a/src/lang/ido.txt
+++ b/src/lang/ido.txt
@@ -3,6 +3,8 @@
 ##isocode io_IO
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0000
 ##grflangid 0x06

--- a/src/lang/indonesian.txt
+++ b/src/lang/indonesian.txt
@@ -3,6 +3,8 @@
 ##isocode id_ID
 ##plural 1
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0421
 ##grflangid 0x5a

--- a/src/lang/indonesian.txt
+++ b/src/lang/indonesian.txt
@@ -3,8 +3,6 @@
 ##isocode id_ID
 ##plural 1
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0421
 ##grflangid 0x5a

--- a/src/lang/irish.txt
+++ b/src/lang/irish.txt
@@ -3,8 +3,6 @@
 ##isocode ga_IE
 ##plural 4
 ##textdir ltr
-##digitsep ,
-##digitsepcur ,
 ##decimalsep .
 ##winlangid 0x083c
 ##grflangid 0x08

--- a/src/lang/irish.txt
+++ b/src/lang/irish.txt
@@ -3,6 +3,8 @@
 ##isocode ga_IE
 ##plural 4
 ##textdir ltr
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep .
 ##winlangid 0x083c
 ##grflangid 0x08

--- a/src/lang/italian.txt
+++ b/src/lang/italian.txt
@@ -3,8 +3,6 @@
 ##isocode it_IT
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0410
 ##grflangid 0x27

--- a/src/lang/italian.txt
+++ b/src/lang/italian.txt
@@ -3,6 +3,8 @@
 ##isocode it_IT
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0410
 ##grflangid 0x27

--- a/src/lang/japanese.txt
+++ b/src/lang/japanese.txt
@@ -3,6 +3,8 @@
 ##isocode ja_JP
 ##plural 1
 ##textdir ltr
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep .
 ##winlangid 0x0411
 ##grflangid 0x39

--- a/src/lang/japanese.txt
+++ b/src/lang/japanese.txt
@@ -3,8 +3,8 @@
 ##isocode ja_JP
 ##plural 1
 ##textdir ltr
-##numberformat 00,000,000,000,000,000,000
-##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
+##numberformat 0000京0000兆0000億0000万0000
+##numberabbreviations 4=0000京0000兆0000億0000万|8=0000京0000兆0000億|12=0000京0000兆|16=0000京
 ##decimalsep .
 ##winlangid 0x0411
 ##grflangid 0x39

--- a/src/lang/japanese.txt
+++ b/src/lang/japanese.txt
@@ -3,8 +3,6 @@
 ##isocode ja_JP
 ##plural 1
 ##textdir ltr
-##digitsep ,
-##digitsepcur ,
 ##decimalsep .
 ##winlangid 0x0411
 ##grflangid 0x39

--- a/src/lang/korean.txt
+++ b/src/lang/korean.txt
@@ -3,8 +3,6 @@
 ##isocode ko_KR
 ##plural 11
 ##textdir ltr
-##digitsep ,
-##digitsepcur ,
 ##decimalsep .
 ##winlangid 0x0412
 ##grflangid 0x3a

--- a/src/lang/korean.txt
+++ b/src/lang/korean.txt
@@ -3,8 +3,8 @@
 ##isocode ko_KR
 ##plural 11
 ##textdir ltr
-##numberformat 00,000,000,000,000,000,000
-##numberabbreviations 3=00,000,000,000,000,000k|6=00,000,000,000,000m|9=00,000,000,000bn|12=00,000,000tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
+##numberformat 0000경0000조0000억0000만0000
+##numberabbreviations 4=0000경0000조0000억0000만|8=0000경0000조0000억|12=0000경0000조|16=0000경
 ##decimalsep .
 ##winlangid 0x0412
 ##grflangid 0x3a

--- a/src/lang/korean.txt
+++ b/src/lang/korean.txt
@@ -3,6 +3,8 @@
 ##isocode ko_KR
 ##plural 11
 ##textdir ltr
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 3=00,000,000,000,000,000k|6=00,000,000,000,000m|9=00,000,000,000bn|12=00,000,000tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep .
 ##winlangid 0x0412
 ##grflangid 0x3a

--- a/src/lang/latin.txt
+++ b/src/lang/latin.txt
@@ -3,6 +3,8 @@
 ##isocode la_VA
 ##plural 0
 ##textdir ltr
+##numberformat 00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000
+##numberabbreviations 3=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}k|6=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}m|9=00{NBSP}000{NBSP}000{NBSP}000{NBSP}bn|12=00{NBSP}000{NBSP}000{NBSP}tn|15=00{NBSP}000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep .
 ##winlangid 0x0476
 ##grflangid 0x66

--- a/src/lang/latin.txt
+++ b/src/lang/latin.txt
@@ -3,8 +3,6 @@
 ##isocode la_VA
 ##plural 0
 ##textdir ltr
-##digitsep {NBSP}
-##digitsepcur {NBSP}
 ##decimalsep .
 ##winlangid 0x0476
 ##grflangid 0x66

--- a/src/lang/latvian.txt
+++ b/src/lang/latvian.txt
@@ -3,6 +3,8 @@
 ##isocode lv_LV
 ##plural 3
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}tk.|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}mljrd.|12=00.000.000{NBSP}tonna|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0426
 ##grflangid 0x2a

--- a/src/lang/latvian.txt
+++ b/src/lang/latvian.txt
@@ -3,8 +3,6 @@
 ##isocode lv_LV
 ##plural 3
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0426
 ##grflangid 0x2a

--- a/src/lang/lithuanian.txt
+++ b/src/lang/lithuanian.txt
@@ -3,8 +3,6 @@
 ##isocode lt_LT
 ##plural 5
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0427
 ##grflangid 0x2b

--- a/src/lang/lithuanian.txt
+++ b/src/lang/lithuanian.txt
@@ -3,6 +3,8 @@
 ##isocode lt_LT
 ##plural 5
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0427
 ##grflangid 0x2b

--- a/src/lang/luxembourgish.txt
+++ b/src/lang/luxembourgish.txt
@@ -3,6 +3,8 @@
 ##isocode lb_LU
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}d|6=00.000.000.000.000{NBSP}Mio|9=00.000.000.000{NBSP}Mrd|12=00.000.000{NBSP}Bio|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x046e
 ##grflangid 0x23

--- a/src/lang/luxembourgish.txt
+++ b/src/lang/luxembourgish.txt
@@ -3,8 +3,6 @@
 ##isocode lb_LU
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x046e
 ##grflangid 0x23

--- a/src/lang/macedonian.txt
+++ b/src/lang/macedonian.txt
@@ -3,8 +3,6 @@
 ##isocode mk_MK
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x042f
 ##grflangid 0x26

--- a/src/lang/macedonian.txt
+++ b/src/lang/macedonian.txt
@@ -3,6 +3,8 @@
 ##isocode mk_MK
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x042f
 ##grflangid 0x26

--- a/src/lang/malay.txt
+++ b/src/lang/malay.txt
@@ -3,6 +3,8 @@
 ##isocode ms_MY
 ##plural 0
 ##textdir ltr
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep .
 ##winlangid 0x043a
 ##grflangid 0x3c

--- a/src/lang/malay.txt
+++ b/src/lang/malay.txt
@@ -3,8 +3,6 @@
 ##isocode ms_MY
 ##plural 0
 ##textdir ltr
-##digitsep ,
-##digitsepcur ,
 ##decimalsep .
 ##winlangid 0x043a
 ##grflangid 0x3c

--- a/src/lang/maltese.txt
+++ b/src/lang/maltese.txt
@@ -3,6 +3,8 @@
 ##isocode mt_MT
 ##plural 12
 ##textdir ltr
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep .
 ##winlangid 0x043a
 ##grflangid 0x09

--- a/src/lang/maltese.txt
+++ b/src/lang/maltese.txt
@@ -3,8 +3,6 @@
 ##isocode mt_MT
 ##plural 12
 ##textdir ltr
-##digitsep ,
-##digitsepcur ,
 ##decimalsep .
 ##winlangid 0x043a
 ##grflangid 0x09

--- a/src/lang/marathi.txt
+++ b/src/lang/marathi.txt
@@ -3,8 +3,6 @@
 ##isocode mr_IN
 ##plural 0
 ##textdir ltr
-##digitsep ,
-##digitsepcur ,
 ##decimalsep .
 ##winlangid 0x044e
 ##grflangid 0x11

--- a/src/lang/marathi.txt
+++ b/src/lang/marathi.txt
@@ -3,6 +3,8 @@
 ##isocode mr_IN
 ##plural 0
 ##textdir ltr
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep .
 ##winlangid 0x044e
 ##grflangid 0x11

--- a/src/lang/norwegian_bokmal.txt
+++ b/src/lang/norwegian_bokmal.txt
@@ -3,8 +3,6 @@
 ##isocode nb_NO
 ##plural 0
 ##textdir ltr
-##digitsep {NBSP}
-##digitsepcur {NBSP}
 ##decimalsep ,
 ##winlangid 0x0414
 ##grflangid 0x2f

--- a/src/lang/norwegian_bokmal.txt
+++ b/src/lang/norwegian_bokmal.txt
@@ -3,6 +3,8 @@
 ##isocode nb_NO
 ##plural 0
 ##textdir ltr
+##numberformat 00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000
+##numberabbreviations 3=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}k|6=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}m|9=00{NBSP}000{NBSP}000{NBSP}000{NBSP}bn|12=00{NBSP}000{NBSP}000{NBSP}tn|15=00{NBSP}000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0414
 ##grflangid 0x2f

--- a/src/lang/norwegian_nynorsk.txt
+++ b/src/lang/norwegian_nynorsk.txt
@@ -3,6 +3,8 @@
 ##isocode nn_NO
 ##plural 0
 ##textdir ltr
+##numberformat 00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000
+##numberabbreviations 3=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}k|6=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}m|9=00{NBSP}000{NBSP}000{NBSP}000{NBSP}bn|12=00{NBSP}000{NBSP}000{NBSP}tn|15=00{NBSP}000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0814
 ##grflangid 0x0e

--- a/src/lang/norwegian_nynorsk.txt
+++ b/src/lang/norwegian_nynorsk.txt
@@ -3,8 +3,6 @@
 ##isocode nn_NO
 ##plural 0
 ##textdir ltr
-##digitsep {NBSP}
-##digitsepcur {NBSP}
 ##decimalsep ,
 ##winlangid 0x0814
 ##grflangid 0x0e

--- a/src/lang/persian.txt
+++ b/src/lang/persian.txt
@@ -3,8 +3,6 @@
 ##isocode fa_IR
 ##plural 0
 ##textdir rtl
-##digitsep ٬
-##digitsepcur ٬
 ##decimalsep ٫
 ##winlangid 0x0429
 ##grflangid 0x62

--- a/src/lang/persian.txt
+++ b/src/lang/persian.txt
@@ -3,6 +3,8 @@
 ##isocode fa_IR
 ##plural 0
 ##textdir rtl
+##numberformat 00٬000٬000٬000٬000٬000٬000
+##numberabbreviations 3=00٬000٬000٬000٬000٬000{NBSP}k|6=00٬000٬000٬000٬000{NBSP}m|9=00٬000٬000٬000{NBSP}bn|12=00٬000٬000{NBSP}tn|15=00٬000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ٫
 ##winlangid 0x0429
 ##grflangid 0x62

--- a/src/lang/polish.txt
+++ b/src/lang/polish.txt
@@ -3,8 +3,6 @@
 ##isocode pl_PL
 ##plural 7
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0415
 ##grflangid 0x30

--- a/src/lang/polish.txt
+++ b/src/lang/polish.txt
@@ -3,6 +3,8 @@
 ##isocode pl_PL
 ##plural 7
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}M|9=00.000.000.000{NBSP}G|12=00.000.000{NBSP}T|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0415
 ##grflangid 0x30

--- a/src/lang/portuguese.txt
+++ b/src/lang/portuguese.txt
@@ -3,8 +3,6 @@
 ##isocode pt_PT
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0816
 ##grflangid 0x36

--- a/src/lang/portuguese.txt
+++ b/src/lang/portuguese.txt
@@ -3,6 +3,8 @@
 ##isocode pt_PT
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0816
 ##grflangid 0x36

--- a/src/lang/romanian.txt
+++ b/src/lang/romanian.txt
@@ -3,8 +3,6 @@
 ##isocode ro_RO
 ##plural 14
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0418
 ##grflangid 0x28

--- a/src/lang/romanian.txt
+++ b/src/lang/romanian.txt
@@ -3,6 +3,8 @@
 ##isocode ro_RO
 ##plural 14
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}mii|6=00.000.000.000.000{NBSP}mil.|9=00.000.000.000{NBSP}mld.|12=00.000.000{NBSP}bil.|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0418
 ##grflangid 0x28

--- a/src/lang/russian.txt
+++ b/src/lang/russian.txt
@@ -3,8 +3,6 @@
 ##isocode ru_RU
 ##plural 6
 ##textdir ltr
-##digitsep {NBSP}
-##digitsepcur {NBSP}
 ##decimalsep ,
 ##winlangid 0x0419
 ##grflangid 0x07

--- a/src/lang/russian.txt
+++ b/src/lang/russian.txt
@@ -3,6 +3,8 @@
 ##isocode ru_RU
 ##plural 6
 ##textdir ltr
+##numberformat 00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000
+##numberabbreviations 3=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}тыс.|6=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}млн|9=00{NBSP}000{NBSP}000{NBSP}000{NBSP}млрд.|12=00{NBSP}000{NBSP}000{NBSP}трлн.|15=00{NBSP}000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0419
 ##grflangid 0x07

--- a/src/lang/serbian.txt
+++ b/src/lang/serbian.txt
@@ -3,6 +3,8 @@
 ##isocode sr_RS
 ##plural 6
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x7c1a
 ##grflangid 0x0d

--- a/src/lang/serbian.txt
+++ b/src/lang/serbian.txt
@@ -3,8 +3,6 @@
 ##isocode sr_RS
 ##plural 6
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x7c1a
 ##grflangid 0x0d

--- a/src/lang/simplified_chinese.txt
+++ b/src/lang/simplified_chinese.txt
@@ -3,8 +3,6 @@
 ##isocode zh_CN
 ##plural 1
 ##textdir ltr
-##digitsep ,
-##digitsepcur ,
 ##decimalsep .
 ##winlangid 0x0804
 ##grflangid 0x56

--- a/src/lang/simplified_chinese.txt
+++ b/src/lang/simplified_chinese.txt
@@ -3,8 +3,8 @@
 ##isocode zh_CN
 ##plural 1
 ##textdir ltr
-##numberformat 00,000,000,000,000,000,000
-##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000b|12=00,000,000t|15=00,000{NBSP}Qa|18=00{NBSP}Qi
+##numberformat 0000京0000兆0000亿0000万0000
+##numberabbreviations 4=0000京0000兆0000亿0000万|8=0000京0000兆0000亿|12=0000京0000兆|16=0000京
 ##decimalsep .
 ##winlangid 0x0804
 ##grflangid 0x56

--- a/src/lang/simplified_chinese.txt
+++ b/src/lang/simplified_chinese.txt
@@ -3,6 +3,8 @@
 ##isocode zh_CN
 ##plural 1
 ##textdir ltr
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000b|12=00,000,000t|15=00,000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep .
 ##winlangid 0x0804
 ##grflangid 0x56

--- a/src/lang/slovak.txt
+++ b/src/lang/slovak.txt
@@ -3,8 +3,6 @@
 ##isocode sk_SK
 ##plural 10
 ##textdir ltr
-##digitsep {NBSP}
-##digitsepcur {NBSP}
 ##decimalsep ,
 ##winlangid 0x041b
 ##grflangid 0x16

--- a/src/lang/slovak.txt
+++ b/src/lang/slovak.txt
@@ -3,6 +3,8 @@
 ##isocode sk_SK
 ##plural 10
 ##textdir ltr
+##numberformat 00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000
+##numberabbreviations 3=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}k|6=00{NBSP}000{NBSP}000{NBSP}000{NBSP}000{NBSP}m|9=00{NBSP}000{NBSP}000{NBSP}000{NBSP}bn|12=00{NBSP}000{NBSP}000{NBSP}tn|15=00{NBSP}000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x041b
 ##grflangid 0x16

--- a/src/lang/slovenian.txt
+++ b/src/lang/slovenian.txt
@@ -3,8 +3,6 @@
 ##isocode sl_SI
 ##plural 8
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0424
 ##grflangid 0x2c

--- a/src/lang/slovenian.txt
+++ b/src/lang/slovenian.txt
@@ -3,6 +3,8 @@
 ##isocode sl_SI
 ##plural 8
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0424
 ##grflangid 0x2c

--- a/src/lang/spanish.txt
+++ b/src/lang/spanish.txt
@@ -3,6 +3,8 @@
 ##isocode es_ES
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}M|9=00.000.000.000{NBSP}kM|12=00.000.000{NBSP}MM|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0c0a
 ##grflangid 0x04

--- a/src/lang/spanish.txt
+++ b/src/lang/spanish.txt
@@ -3,8 +3,6 @@
 ##isocode es_ES
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0c0a
 ##grflangid 0x04

--- a/src/lang/spanish_MX.txt
+++ b/src/lang/spanish_MX.txt
@@ -3,6 +3,8 @@
 ##isocode es_MX
 ##plural 0
 ##textdir ltr
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep .
 ##winlangid 0x080a
 ##grflangid 0x55

--- a/src/lang/spanish_MX.txt
+++ b/src/lang/spanish_MX.txt
@@ -3,8 +3,6 @@
 ##isocode es_MX
 ##plural 0
 ##textdir ltr
-##digitsep ,
-##digitsepcur ,
 ##decimalsep .
 ##winlangid 0x080a
 ##grflangid 0x55

--- a/src/lang/swedish.txt
+++ b/src/lang/swedish.txt
@@ -3,8 +3,6 @@
 ##isocode sv_SE
 ##plural 0
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x081d
 ##grflangid 0x2e

--- a/src/lang/swedish.txt
+++ b/src/lang/swedish.txt
@@ -3,6 +3,8 @@
 ##isocode sv_SE
 ##plural 0
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}t|6=00.000.000.000.000{NBSP}mn|9=00.000.000.000{NBSP}md|12=00.000.000{NBSP}bn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x081d
 ##grflangid 0x2e

--- a/src/lang/tamil.txt
+++ b/src/lang/tamil.txt
@@ -3,6 +3,8 @@
 ##isocode ta_IN
 ##plural 0
 ##textdir ltr
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep .
 ##winlangid 0x0449
 ##grflangid 0x0a

--- a/src/lang/tamil.txt
+++ b/src/lang/tamil.txt
@@ -3,8 +3,6 @@
 ##isocode ta_IN
 ##plural 0
 ##textdir ltr
-##digitsep ,
-##digitsepcur ,
 ##decimalsep .
 ##winlangid 0x0449
 ##grflangid 0x0a

--- a/src/lang/thai.txt
+++ b/src/lang/thai.txt
@@ -3,6 +3,8 @@
 ##isocode th_TH
 ##plural 1
 ##textdir ltr
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep .
 ##winlangid 0x041e
 ##grflangid 0x42

--- a/src/lang/thai.txt
+++ b/src/lang/thai.txt
@@ -3,8 +3,6 @@
 ##isocode th_TH
 ##plural 1
 ##textdir ltr
-##digitsep ,
-##digitsepcur ,
 ##decimalsep .
 ##winlangid 0x041e
 ##grflangid 0x42

--- a/src/lang/traditional_chinese.txt
+++ b/src/lang/traditional_chinese.txt
@@ -3,6 +3,8 @@
 ##isocode zh_TW
 ##plural 1
 ##textdir ltr
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep .
 ##winlangid 0x0404
 ##grflangid 0x0c

--- a/src/lang/traditional_chinese.txt
+++ b/src/lang/traditional_chinese.txt
@@ -3,8 +3,6 @@
 ##isocode zh_TW
 ##plural 1
 ##textdir ltr
-##digitsep ,
-##digitsepcur ,
 ##decimalsep .
 ##winlangid 0x0404
 ##grflangid 0x0c

--- a/src/lang/traditional_chinese.txt
+++ b/src/lang/traditional_chinese.txt
@@ -3,8 +3,8 @@
 ##isocode zh_TW
 ##plural 1
 ##textdir ltr
-##numberformat 00,000,000,000,000,000,000
-##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
+##numberformat 0000京0000兆0000億0000万0000
+##numberabbreviations 4=0000京0000兆0000億0000万|8=0000京0000兆0000億|12=0000京0000兆|16=0000京
 ##decimalsep .
 ##winlangid 0x0404
 ##grflangid 0x0c

--- a/src/lang/turkish.txt
+++ b/src/lang/turkish.txt
@@ -3,6 +3,8 @@
 ##isocode tr_TR
 ##plural 1
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}mlyn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x041f
 ##grflangid 0x3e

--- a/src/lang/turkish.txt
+++ b/src/lang/turkish.txt
@@ -3,8 +3,6 @@
 ##isocode tr_TR
 ##plural 1
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x041f
 ##grflangid 0x3e

--- a/src/lang/ukrainian.txt
+++ b/src/lang/ukrainian.txt
@@ -3,6 +3,8 @@
 ##isocode uk_UA
 ##plural 6
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}тис.|6=00.000.000.000.000{NBSP}млн|9=00.000.000.000{NBSP}млрд|12=00.000.000{NBSP}трлн|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x0422
 ##grflangid 0x33

--- a/src/lang/ukrainian.txt
+++ b/src/lang/ukrainian.txt
@@ -3,8 +3,6 @@
 ##isocode uk_UA
 ##plural 6
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x0422
 ##grflangid 0x33

--- a/src/lang/urdu.txt
+++ b/src/lang/urdu.txt
@@ -3,8 +3,6 @@
 ##isocode ur_PK
 ##plural 0
 ##textdir rtl
-##digitsep ٬
-##digitsepcur ٬
 ##decimalsep ٫
 ##winlangid 0x0420
 ##grflangid 0x5c

--- a/src/lang/urdu.txt
+++ b/src/lang/urdu.txt
@@ -3,6 +3,8 @@
 ##isocode ur_PK
 ##plural 0
 ##textdir rtl
+##numberformat 00٬000٬000٬000٬000٬000٬000
+##numberabbreviations 3=00٬000٬000٬000٬000٬000{NBSP}k|6=00٬000٬000٬000٬000{NBSP}m|9=00٬000٬000٬000{NBSP}bn|12=00٬000٬000{NBSP}tn|15=00٬000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ٫
 ##winlangid 0x0420
 ##grflangid 0x5c

--- a/src/lang/vietnamese.txt
+++ b/src/lang/vietnamese.txt
@@ -3,8 +3,6 @@
 ##isocode vi_VN
 ##plural 1
 ##textdir ltr
-##digitsep .
-##digitsepcur .
 ##decimalsep ,
 ##winlangid 0x042a
 ##grflangid 0x54

--- a/src/lang/vietnamese.txt
+++ b/src/lang/vietnamese.txt
@@ -3,6 +3,8 @@
 ##isocode vi_VN
 ##plural 1
 ##textdir ltr
+##numberformat 00.000.000.000.000.000.000
+##numberabbreviations 3=00.000.000.000.000.000{NBSP}k|6=00.000.000.000.000{NBSP}m|9=00.000.000.000{NBSP}bn|12=00.000.000{NBSP}tn|15=00.000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep ,
 ##winlangid 0x042a
 ##grflangid 0x54

--- a/src/lang/welsh.txt
+++ b/src/lang/welsh.txt
@@ -3,6 +3,8 @@
 ##isocode cy_GB
 ##plural 0
 ##textdir ltr
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi
 ##decimalsep .
 ##winlangid 0x0452
 ##grflangid 0x0f

--- a/src/lang/welsh.txt
+++ b/src/lang/welsh.txt
@@ -3,8 +3,6 @@
 ##isocode cy_GB
 ##plural 0
 ##textdir ltr
-##digitsep ,
-##digitsepcur ,
 ##decimalsep .
 ##winlangid 0x0452
 ##grflangid 0x0f

--- a/src/language.h
+++ b/src/language.h
@@ -35,10 +35,6 @@ struct LanguagePackHeader {
 	char number_format[64];
 	/** The raw formatting string for number abbreviations. */
 	char number_abbreviations[256];
-	/** Thousand separator used for anything not currencies */
-	char digit_group_separator[8];
-	/** Thousand separator used for currencies */
-	char digit_group_separator_currency[8];
 	/** Decimal separator */
 	char digit_decimal_separator[8];
 	uint16_t missing;     ///< number of missing strings.

--- a/src/saveload/compat/settings_sl_compat.h
+++ b/src/saveload/compat/settings_sl_compat.h
@@ -258,9 +258,9 @@ const SaveLoadCompat _settings_sl_compat[] = {
 	SLC_VAR("locale.units_volume"),
 	SLC_VAR("locale.units_force"),
 	SLC_VAR("locale.units_height"),
-	SLC_VAR("locale.digit_group_separator"),
-	SLC_VAR("locale.digit_group_separator_currency"),
-	SLC_VAR("locale.digit_decimal_separator"),
+	SLC_NULL_STR(1, SLV_118, SLV_TABLE_CHUNKS),
+	SLC_NULL_STR(1, SLV_118, SLV_TABLE_CHUNKS),
+	SLC_NULL_STR(1, SLV_126, SLV_TABLE_CHUNKS),
 };
 
 #endif /* SAVELOAD_COMPAT_SETTINGS_H */

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -623,9 +623,16 @@ static inline byte SlCalcConvFileLen(VarType conv)
 {
 	static const byte conv_file_size[] = {0, 1, 1, 2, 2, 4, 4, 8, 8, 2};
 
-	uint8_t type = GetVarFileType(conv);
-	assert(type < lengthof(conv_file_size));
-	return conv_file_size[type];
+	switch (GetVarFileType(conv)) {
+		case SLE_FILE_STRING:
+			return SlReadArrayLength();
+
+		default:
+			uint8_t type = GetVarFileType(conv);
+			if (type >= lengthof(conv_file_size)) fmt::println("{}", type);
+			assert(type < lengthof(conv_file_size));
+			return conv_file_size[type];
+	}
 }
 
 /** Return the size in bytes of a reference (pointer) */
@@ -1864,7 +1871,7 @@ std::vector<SaveLoad> SlCompatTableHeader(const SaveLoadTable &slt, const SaveLo
 			/* In old savegames there can be data we no longer care for. We
 			 * skip this by simply reading the amount of bytes indicated and
 			 * send those to /dev/null. */
-			saveloads.push_back({"", SL_NULL, SLE_FILE_U8 | SLE_VAR_NULL, slc.length, slc.version_from, slc.version_to, 0, nullptr, 0, nullptr});
+			saveloads.push_back({"", SL_NULL, GetVarFileType(slc.null_type) | SLE_VAR_NULL, slc.null_length, slc.version_from, slc.version_to, 0, nullptr, 0, nullptr});
 		} else {
 			auto sld_it = key_lookup.find(slc.name);
 			/* If this branch triggers, it means that an entry in the

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -715,10 +715,11 @@ struct SaveLoad {
  * to make that happen.
  */
 struct SaveLoadCompat {
-	std::string name;             ///< Name of the field.
-	uint16_t length;                ///< Length of the NULL field.
+	std::string name; ///< Name of the field.
+	VarTypes null_type; ///< The type associated with the NULL field; defaults to SLE_FILE_U8 to just count bytes.
+	uint16_t null_length; ///< Length of the NULL field.
 	SaveLoadVersion version_from; ///< Save/load the variable starting from this savegame version.
-	SaveLoadVersion version_to;   ///< Save/load the variable before this savegame version.
+	SaveLoadVersion version_to; ///< Save/load the variable before this savegame version.
 };
 
 /**
@@ -1183,18 +1184,26 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * Field name where the real SaveLoad can be located.
  * @param name The name of the field.
  */
-#define SLC_VAR(name) {name, 0, SL_MIN_VERSION, SL_MAX_VERSION}
+#define SLC_VAR(name) {name, SLE_FILE_U8, 0, SL_MIN_VERSION, SL_MAX_VERSION}
 
 /**
  * Empty space in every savegame version.
- * @param length Length of the empty space.
+ * @param length Length of the empty space in bytes.
  * @param from   First savegame version that has the empty space.
  * @param to     Last savegame version that has the empty space.
  */
-#define SLC_NULL(length, from, to) {{}, length, from, to}
+#define SLC_NULL(length, from, to) {{}, SLE_FILE_U8, length, from, to}
+
+/**
+ * Empty space in every savegame version that was filled with a string.
+ * @param length Number of strings in the empty space.
+ * @param from   First savegame version that has the empty space.
+ * @param to     Last savegame version that has the empty space.
+ */
+#define SLC_NULL_STR(length, from, to) {{}, SLE_FILE_STRING, length, from, to}
 
 /** End marker of compat variables save or load. */
-#define SLC_END() {{}, 0, SL_MIN_VERSION, SL_MIN_VERSION}
+#define SLC_END() {{}, 0, 0, SL_MIN_VERSION, SL_MIN_VERSION}
 
 /**
  * Checks whether the savegame is below \a major.\a minor.

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -50,6 +50,7 @@
 #include "void_map.h"
 #include "station_func.h"
 #include "station_base.h"
+#include "language.h"
 
 #include "table/strings.h"
 #include "table/settings.h"

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -222,6 +222,8 @@ struct GUISettings {
 
 	bool   scale_bevels;                     ///< bevels are scaled with GUI scale.
 
+	std::string digit_decimal_separator; ///< decimal separator
+
 	/**
 	 * Returns true when the user has sufficient privileges to edit newgrfs on a running game
 	 * @return whether the user has sufficient privileges to edit newgrfs in an existing game
@@ -265,9 +267,6 @@ struct LocaleSettings {
 	byte        units_volume;                     ///< unit system for volume
 	byte        units_force;                      ///< unit system for force
 	byte        units_height;                     ///< unit system for height
-	std::string digit_group_separator;            ///< thousand separator for non-currencies
-	std::string digit_group_separator_currency;   ///< thousand separator for currencies
-	std::string digit_decimal_separator;          ///< decimal separator
 };
 
 /** Settings related to news */

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -222,6 +222,8 @@ struct GUISettings {
 
 	bool   scale_bevels;                     ///< bevels are scaled with GUI scale.
 
+	std::string number_format; ///< formatting string for numbers (like "thousands" grouping)
+	std::string number_abbreviations; ///< mapping to number formats for different powers of ten/thresholds
 	std::string digit_decimal_separator; ///< decimal separator
 
 	/**

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -121,6 +121,22 @@ void FileStringReader::HandlePragma(char *str)
 		} else {
 			FatalError("Invalid textdir {}", str + 8);
 		}
+	} else if (!memcmp(str, "numberformat ", 13)) {
+		str += 13;
+
+		NumberFormatSeparators separators;
+		auto result = ParseNumberFormatSeparators(separators, str);
+		if (result.has_value()) FatalError("Invalid number format: {}", *result);
+
+		strecpy(_lang.number_format, str, lastof(_lang.number_format));
+	} else if (!memcmp(str, "numberabbreviations ", 20)) {
+		str += 20;
+
+		NumberAbbreviations abbreviations;
+		auto result = ParseNumberAbbreviations(abbreviations, str);
+		if (result.has_value()) FatalError("Invalid number abbreviations: {}", *result);
+
+		strecpy(_lang.number_abbreviations, str, lastof(_lang.number_abbreviations));
 	} else if (!memcmp(str, "digitsep ", 9)) {
 		str += 9;
 		strecpy(_lang.digit_group_separator, strcmp(str, "{NBSP}") == 0 ? NBSP : str, lastof(_lang.digit_group_separator));

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -137,12 +137,6 @@ void FileStringReader::HandlePragma(char *str)
 		if (result.has_value()) FatalError("Invalid number abbreviations: {}", *result);
 
 		strecpy(_lang.number_abbreviations, str, lastof(_lang.number_abbreviations));
-	} else if (!memcmp(str, "digitsep ", 9)) {
-		str += 9;
-		strecpy(_lang.digit_group_separator, strcmp(str, "{NBSP}") == 0 ? NBSP : str, lastof(_lang.digit_group_separator));
-	} else if (!memcmp(str, "digitsepcur ", 12)) {
-		str += 12;
-		strecpy(_lang.digit_group_separator_currency, strcmp(str, "{NBSP}") == 0 ? NBSP : str, lastof(_lang.digit_group_separator_currency));
 	} else if (!memcmp(str, "decimalsep ", 11)) {
 		str += 11;
 		strecpy(_lang.digit_decimal_separator, strcmp(str, "{NBSP}") == 0 ? NBSP : str, lastof(_lang.digit_decimal_separator));

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -758,8 +758,6 @@ void StringReader::ParseFile()
 	MemSetT(&_lang, 0);
 	strecpy(_lang.number_format, "00,000,000,000,000,000,000", lastof(_lang.number_format));
 	strecpy(_lang.number_abbreviations, "3=00,000,000,000,000,000{NBSP}k|6=00,000,000,000,000{NBSP}m|9=00,000,000,000{NBSP}bn|12=00,000,000{NBSP}tn|15=00,000{NBSP}Qa|18=00{NBSP}Qi", lastof(_lang.number_abbreviations));
-	strecpy(_lang.digit_group_separator, ",", lastof(_lang.digit_group_separator));
-	strecpy(_lang.digit_group_separator_currency, ",", lastof(_lang.digit_group_separator_currency));
 	strecpy(_lang.digit_decimal_separator, ".", lastof(_lang.digit_decimal_separator));
 
 	_cur_line = 1;

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1892,8 +1892,6 @@ bool LanguagePackHeader::IsValid() const
 	       StrValid(this->isocode,                        lastof(this->isocode)) &&
 	       StrValid(this->number_format,                  lastof(this->number_format)) &&
 	       StrValid(this->number_abbreviations,           lastof(this->number_abbreviations)) &&
-	       StrValid(this->digit_group_separator,          lastof(this->digit_group_separator)) &&
-	       StrValid(this->digit_group_separator_currency, lastof(this->digit_group_separator_currency)) &&
 	       StrValid(this->digit_decimal_separator,        lastof(this->digit_decimal_separator));
 }
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1884,6 +1884,8 @@ bool LanguagePackHeader::IsValid() const
 	       StrValid(this->name,                           lastof(this->name)) &&
 	       StrValid(this->own_name,                       lastof(this->own_name)) &&
 	       StrValid(this->isocode,                        lastof(this->isocode)) &&
+	       StrValid(this->number_format,                  lastof(this->number_format)) &&
+	       StrValid(this->number_abbreviations,           lastof(this->number_abbreviations)) &&
 	       StrValid(this->digit_group_separator,          lastof(this->digit_group_separator)) &&
 	       StrValid(this->digit_group_separator_currency, lastof(this->digit_group_separator_currency)) &&
 	       StrValid(this->digit_decimal_separator,        lastof(this->digit_decimal_separator));

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -377,6 +377,13 @@ void SetDParamStr(size_t n, std::string &&str)
 	_global_string_params.SetParam(n, std::move(str));
 }
 
+static const char *GetDecimalSeparator()
+{
+	const char *decimal_separator = _settings_game.locale.digit_decimal_separator.c_str();
+	if (StrEmpty(decimal_separator)) decimal_separator = _langpack.langpack->digit_decimal_separator;
+	return decimal_separator;
+}
+
 /**
  * Format a number into a string.
  * @param builder   the string builder to write to
@@ -403,9 +410,7 @@ static void FormatNumber(StringBuilder &builder, int64_t number, const char *sep
 	uint64_t tot = 0;
 	for (int i = 0; i < max_digits; i++) {
 		if (i == max_digits - fractional_digits) {
-			const char *decimal_separator = _settings_game.locale.digit_decimal_separator.c_str();
-			if (StrEmpty(decimal_separator)) decimal_separator = _langpack.langpack->digit_decimal_separator;
-			builder += decimal_separator;
+			builder += GetDecimalSeparator();
 		}
 
 		uint64_t quot = 0;
@@ -461,16 +466,13 @@ static void FormatBytes(StringBuilder &builder, int64_t number)
 		id++;
 	}
 
-	const char *decimal_separator = _settings_game.locale.digit_decimal_separator.c_str();
-	if (StrEmpty(decimal_separator)) decimal_separator = _langpack.langpack->digit_decimal_separator;
-
 	if (number < 1024) {
 		id = 0;
 		fmt::format_to(builder, "{}", number);
 	} else if (number < 1024 * 10) {
-		fmt::format_to(builder, "{}{}{:02}", number / 1024, decimal_separator, (number % 1024) * 100 / 1024);
+		fmt::format_to(builder, "{}{}{:02}", number / 1024, GetDecimalSeparator(), (number % 1024) * 100 / 1024);
 	} else if (number < 1024 * 100) {
-		fmt::format_to(builder, "{}{}{:01}", number / 1024, decimal_separator, (number % 1024) * 10 / 1024);
+		fmt::format_to(builder, "{}{}{:01}", number / 1024, GetDecimalSeparator(), (number % 1024) * 10 / 1024);
 	} else {
 		assert(number < 1024 * 1024);
 		fmt::format_to(builder, "{}", number / 1024);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -382,7 +382,7 @@ void SetDParamStr(size_t n, std::string &&str)
 
 static const char *GetDecimalSeparator()
 {
-	const char *decimal_separator = _settings_game.locale.digit_decimal_separator.c_str();
+	const char *decimal_separator = _settings_client.gui.digit_decimal_separator.c_str();
 	if (StrEmpty(decimal_separator)) decimal_separator = _langpack.langpack->digit_decimal_separator;
 	return decimal_separator;
 }

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -389,8 +389,21 @@ static const char *GetDecimalSeparator()
 
 void InitializeNumberFormats()
 {
-	ParseNumberFormatSeparators(_number_format_separators, _current_language->number_format);
-	ParseNumberAbbreviations(_number_abbreviations, _current_language->number_abbreviations);
+	bool loaded_number_format = false;
+	if (!_settings_client.gui.number_format.empty()) {
+		auto res = ParseNumberFormatSeparators(_number_format_separators, _settings_client.gui.number_format);
+		if (res.has_value()) UserError("The setting 'number_format' under 'gui' is invalid: {}", *res);
+		loaded_number_format = !res.has_value();
+	}
+	if (!loaded_number_format) ParseNumberFormatSeparators(_number_format_separators, _current_language->number_format);
+
+	bool loaded_number_abbreviations = false;
+	if (!_settings_client.gui.number_abbreviations.empty()) {
+		auto res = ParseNumberAbbreviations(_number_abbreviations, _settings_client.gui.number_abbreviations);
+		if (res.has_value()) UserError("The setting 'number_abbreviations' under 'gui' is invalid: {}", *res);
+		loaded_number_abbreviations = !res.has_value();
+	}
+	if (!loaded_number_abbreviations) ParseNumberAbbreviations(_number_abbreviations, _current_language->number_abbreviations);
 	_number_abbreviations.emplace_back(0, _number_format_separators);
 }
 

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -28,6 +28,7 @@ static const SettingVariant _gui_settings_table[] = {
 SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
 SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
 SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_SSTR  =  SDTC_SSTR(              $var, $type, $flags, $def,             0,                                        $pre_cb, $post_cb,                             $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTC_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -903,3 +904,9 @@ post_cb  = [](auto) { SetupWidgetDimensions(); ReInitAllWindows(true); }
 cat      = SC_BASIC
 startup  = true
 
+[SDTC_SSTR]
+var      = gui.digit_decimal_separator
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
+type     = SLE_STRQ
+def      = nullptr
+post_cb  = [](auto) { MarkWholeScreenDirty(); }

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -16,6 +16,7 @@ static void InvalidateCompanyLiveryWindow(int32_t new_value);
 static void InvalidateNewGRFChangeWindows(int32_t new_value);
 static void ZoomMinMaxChanged(int32_t new_value);
 static void SpriteZoomMinChanged(int32_t new_value);
+void InitializeNumberFormats();
 
 static constexpr std::initializer_list<const char*> _osk_activation{"disabled", "double", "single", "immediately"};
 static constexpr std::initializer_list<const char*> _savegame_date{"long", "short", "iso"};
@@ -902,6 +903,24 @@ flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 post_cb  = [](auto) { SetupWidgetDimensions(); ReInitAllWindows(true); }
 cat      = SC_BASIC
+startup  = true
+
+[SDTC_SSTR]
+var      = gui.number_format
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
+type     = SLE_STRQ
+def      = nullptr
+pre_cb   = [](auto format) { NumberFormatSeparators separators; return !ParseNumberFormatSeparators(separators, format).has_value(); }
+post_cb  = [](auto) { InitializeNumberFormats(); MarkWholeScreenDirty(); }
+startup  = true
+
+[SDTC_SSTR]
+var      = gui.number_abbreviations
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
+type     = SLE_STRQ
+def      = nullptr
+pre_cb   = [](auto format) { NumberAbbreviations abbreviations; return !ParseNumberAbbreviations(abbreviations, format).has_value(); }
+post_cb  = [](auto) { InitializeNumberFormats(); MarkWholeScreenDirty(); }
 startup  = true
 
 [SDTC_SSTR]

--- a/src/table/settings/locale_settings.ini
+++ b/src/table/settings/locale_settings.ini
@@ -23,7 +23,6 @@ static const SettingVariant _locale_settings_table[] = {
 [templates]
 SDTG_OMANY = SDTG_OMANY($name,              $type, $flags, $var, $def,       $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
 SDT_OMANY  =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $load, $cat, $extra, $startup),
-SDT_SSTR   =   SDT_SSTR(GameSettings, $var, $type, $flags, $def,                                                       $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTG_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -169,30 +168,3 @@ cat      = SC_BASIC
 str      = STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT
 strhelp  = STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT_HELPTEXT
 strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT_IMPERIAL
-
-[SDT_SSTR]
-var      = locale.digit_group_separator
-type     = SLE_STRQ
-from     = SLV_118
-flags    = SF_NO_NETWORK_SYNC
-def      = nullptr
-post_cb  = [](auto) { MarkWholeScreenDirty(); }
-cat      = SC_BASIC
-
-[SDT_SSTR]
-var      = locale.digit_group_separator_currency
-type     = SLE_STRQ
-from     = SLV_118
-flags    = SF_NO_NETWORK_SYNC
-def      = nullptr
-post_cb  = [](auto) { MarkWholeScreenDirty(); }
-cat      = SC_BASIC
-
-[SDT_SSTR]
-var      = locale.digit_decimal_separator
-type     = SLE_STRQ
-from     = SLV_126
-flags    = SF_NO_NETWORK_SYNC
-def      = nullptr
-post_cb  = [](auto) { MarkWholeScreenDirty(); }
-cat      = SC_BASIC

--- a/src/table/settings/old_gameopt_settings.ini
+++ b/src/table/settings/old_gameopt_settings.ini
@@ -32,7 +32,6 @@ static const SettingVariant _old_gameopt_settings_table[] = {
 [templates]
 SDTG_LIST    =  SDTG_LIST($name,              $type, $flags, $var, $def, $length, $from, $to, $cat, $extra, $startup),
 SDTG_VAR     =   SDTG_VAR($name,              $type, $flags, $var, $def, $min, $max, $interval,  $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $cat, $extra, $startup),
-SDT_NULL     =   SDT_NULL(                                                          $length,                                                            $from, $to),
 SDTC_OMANY   = SDTC_OMANY(              $var, $type, $flags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
 SDTG_OMANY   = SDTG_OMANY($name,              $type, $flags, $var, $def, $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
 SDT_OMANY    =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $load, $cat, $extra, $startup),


### PR DESCRIPTION
## Motivation / Problem

Fixes #11953. It has been known that the number formats in OpenTTD are not catered for many non-Western languages due to different grouping of the digits.

In the Western countries we group our numbers every three digits. In CJK that's every four digits, and the separators differ for each of the locations. In Hindi it's first three digits and then every two digits. And I probably forgot some other language (group) that does it in an even different manner.


## Description

First a "number format" gets introduced, which is a simple string with twenty zeros (number of digits in uint64_t) where the translators can put characters between at the appropriate place. This allows separators at any location.

Next a "number abbreviation" gets introduced, which defines a mapping between a power and a "number format" for the remaining digits. With these mappings an appropriate version can be chosen for `{CURRENCY_SHORT}`.

The format and abbreviation are added as pragmas/attributes to the language files, so any updates need to be done via a PR and not via eints (at the moment). The format and abbreviation are also configurable in the configuration file, when the user does not like the default choice for the language.

With this change we lose the digit separator and digit separator currency. These two have been the same since their introduction, except if/when someone changed their configuration. It also removes the decimal separator from the saves, so it only remains in the configuration file (moved to the gui section).

English:
![Unnamed, 2035-10-13](https://github.com/OpenTTD/OpenTTD/assets/13785744/646237ef-6a46-4b77-9fe0-d7b5d3453d02)
Hindi:
![Unnamed, 2035-10-13#1](https://github.com/OpenTTD/OpenTTD/assets/13785744/baa79bf1-2f26-433f-9444-7d40687d2cdd)
CJK:
![未命名, 2035-10-13#3](https://github.com/OpenTTD/OpenTTD/assets/13785744/e10a3fe8-91ad-451b-bfcc-4955206a61aa)

Configuring:
![未命名, 2035-10-13#4](https://github.com/OpenTTD/OpenTTD/assets/13785744/6ac15584-02b9-4c7d-a224-e9809ca0f579)


## Limitations

The number formats have been set for each of the languages based on their digit group separator. These might not be right for all languages, e.g. Hindi.

The number abbreviations have been set for each of the languages based on the defaults for English, where the `STR_CURRENCY_SHORT_*` values have been replaced. The higher powers are still untranslated.

The highest power will never actually be shown in the UI, since the `{CURRENCY_SHORT}` code is written to show a least two digit groups. That means it needs to know the size of the next group, which is why those are added but never actually used. However, if we ever decide we need a `{CURRENCY_TINY}`, then it would be trivial to use it.

There is a validation of the settings for the format and abbreviations, but it's quite rude as it kills the application with a `UserError`. I have done this as I need to load these settings before the language gets loaded, and using the normal mechanism will cause the error messages to be lost when the UI is finally fully initialised. Given "Survey says" that the current digit grouping and decimal are always empty, i.e. unused, it's not likely to be a huge base of users that are going to change it.

So technically, for most languages the mapping table is not complete. Since there is no support in eints yet, this might cause quite a few bug reports/PRs in the rear future.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
