### PR TITLE
Codechange: use std containers for CommandQueue

### DIFF
--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -131,24 +131,12 @@ enum PacketGameType : uint8_t {
 /** Packet that wraps a command */
 struct CommandPacket;
 
-/** A queue of CommandPackets. */
-class CommandQueue {
-	CommandPacket *first; ///< The first packet in the queue.
-	CommandPacket *last;  ///< The last packet in the queue; only valid when first != nullptr.
-	uint count;           ///< The number of items in the queue.
-
-public:
-	/** Initialise the command queue. */
-	CommandQueue() : first(nullptr), last(nullptr), count(0) {}
-	/** Clear the command queue. */
-	~CommandQueue() { this->Free(); }
-	void Append(CommandPacket *p);
-	CommandPacket *Pop(bool ignore_paused = false);
-	CommandPacket *Peek(bool ignore_paused = false);
-	void Free();
-	/** Get the number of items in the queue. */
-	uint Count() const { return this->count; }
-};
+/**
+ * A "queue" of CommandPackets.
+ * Not a std::queue because, when paused, some commands remain on the queue.
+ * In other words, you do not always pop the first element from this queue.
+ */
+using CommandQueue = std::vector<CommandPacket>;
 
 /** Base socket handler for all TCP sockets */
 class NetworkGameSocketHandler : public NetworkTCPSocketHandler {

--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -530,8 +530,8 @@ public:
 
 	NetworkRecvStatus ReceivePackets();
 
-	const char *ReceiveCommand(Packet &p, CommandPacket *cp);
-	void SendCommand(Packet &p, const CommandPacket *cp);
+	const char *ReceiveCommand(Packet &p, CommandPacket &cp);
+	void SendCommand(Packet &p, const CommandPacket &cp);
 
 	bool IsPendingDeletion() const { return this->is_pending_deletion; }
 

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -608,15 +608,15 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCmdNames()
  * @param client_id The client executing the command.
  * @param cp The command that would be executed.
  */
-NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCmdLogging(ClientID client_id, const CommandPacket *cp)
+NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCmdLogging(ClientID client_id, const CommandPacket &cp)
 {
 	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_CMD_LOGGING);
 
 	p->Send_uint32(client_id);
-	p->Send_uint8 (cp->company);
-	p->Send_uint16(cp->cmd);
-	p->Send_buffer(cp->data);
-	p->Send_uint32(cp->frame);
+	p->Send_uint8 (cp.company);
+	p->Send_uint16(cp.cmd);
+	p->Send_buffer(cp.data);
+	p->Send_uint32(cp.frame);
 
 	this->SendPacket(std::move(p));
 
@@ -959,7 +959,7 @@ void NetworkAdminGameScript(const std::string_view json)
  * @param owner The owner of the CommandPacket (who sent us the CommandPacket).
  * @param cp    The CommandPacket to be distributed.
  */
-void NetworkAdminCmdLogging(const NetworkClientSocket *owner, const CommandPacket *cp)
+void NetworkAdminCmdLogging(const NetworkClientSocket *owner, const CommandPacket &cp)
 {
 	ClientID client_id = owner == nullptr ? _network_own_client_id : owner->client_id;
 

--- a/src/network/network_admin.h
+++ b/src/network/network_admin.h
@@ -67,7 +67,7 @@ public:
 	NetworkRecvStatus SendConsole(const std::string_view origin, const std::string_view command);
 	NetworkRecvStatus SendGameScript(const std::string_view json);
 	NetworkRecvStatus SendCmdNames();
-	NetworkRecvStatus SendCmdLogging(ClientID client_id, const CommandPacket *cp);
+	NetworkRecvStatus SendCmdLogging(ClientID client_id, const CommandPacket &cp);
 	NetworkRecvStatus SendRconEnd(const std::string_view command);
 
 	static void Send();
@@ -112,6 +112,6 @@ void NetworkAdminUpdate(AdminUpdateFrequency freq);
 void NetworkServerSendAdminRcon(AdminIndex admin_index, TextColour colour_code, const std::string_view string);
 void NetworkAdminConsole(const std::string_view origin, const std::string_view string);
 void NetworkAdminGameScript(const std::string_view json);
-void NetworkAdminCmdLogging(const NetworkClientSocket *owner, const CommandPacket *cp);
+void NetworkAdminCmdLogging(const NetworkClientSocket *owner, const CommandPacket &cp);
 
 #endif /* NETWORK_ADMIN_H */

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -435,9 +435,9 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendAck()
  * Send a command to the server.
  * @param cp The command to send.
  */
-NetworkRecvStatus ClientNetworkGameSocketHandler::SendCommand(const CommandPacket *cp)
+NetworkRecvStatus ClientNetworkGameSocketHandler::SendCommand(const CommandPacket &cp)
 {
-	Debug(net, 9, "Client::SendCommand(): cmd={}", cp->cmd);
+	Debug(net, 9, "Client::SendCommand(): cmd={}", cp.cmd);
 
 	auto p = std::make_unique<Packet>(PACKET_CLIENT_COMMAND);
 	my_client->NetworkGameSocketHandler::SendCommand(*p, cp);
@@ -961,7 +961,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_COMMAND(Packet 
 	if (this->status != STATUS_ACTIVE) return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 
 	CommandPacket cp;
-	const char *err = this->ReceiveCommand(p, &cp);
+	const char *err = this->ReceiveCommand(p, cp);
 	cp.frame    = p.Recv_uint32();
 	cp.my_cmd   = p.Recv_bool();
 

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -972,7 +972,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_COMMAND(Packet 
 		return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 	}
 
-	this->incoming_queue.Append(&cp);
+	this->incoming_queue.push_back(cp);
 
 	return NETWORK_RECV_STATUS_OKAY;
 }

--- a/src/network/network_client.h
+++ b/src/network/network_client.h
@@ -80,7 +80,7 @@ public:
 	void ClientError(NetworkRecvStatus res);
 
 	static NetworkRecvStatus SendJoin();
-	static NetworkRecvStatus SendCommand(const CommandPacket *cp);
+	static NetworkRecvStatus SendCommand(const CommandPacket &cp);
 	static NetworkRecvStatus SendError(NetworkErrorCode errorno);
 	static NetworkRecvStatus SendQuit();
 	static NetworkRecvStatus SendAck();

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -304,9 +304,8 @@ void NetworkSendCommand(Commands cmd, StringID err_message, CommandCallback *cal
 void NetworkSyncCommandQueue(NetworkClientSocket *cs)
 {
 	for (CommandPacket *p = _local_execution_queue.Peek(); p != nullptr; p = p->next) {
-		CommandPacket c = *p;
+		CommandPacket &c = cs->outgoing_queue.emplace_back(*p);
 		c.callback = nullptr;
-		cs->outgoing_queue.Append(&c);
 	}
 }
 
@@ -371,7 +370,7 @@ static void DistributeCommandPacket(CommandPacket &cp, const NetworkClientSocket
 			 *  first place. This filters that out. */
 			cp.callback = (cs != owner) ? nullptr : callback;
 			cp.my_cmd = (cs == owner);
-			cs->outgoing_queue.Append(&cp);
+			cs->outgoing_queue.push_back(cp);
 		}
 	}
 

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -107,9 +107,7 @@ void UpdateNetworkGameWindow();
  * Everything we need to know about a command to be able to execute it.
  */
 struct CommandPacket {
-	/** Make sure the pointer is nullptr. */
-	CommandPacket() : next(nullptr), company(INVALID_COMPANY), frame(0), my_cmd(false) {}
-	CommandPacket *next; ///< the next command packet (if in queue)
+	CommandPacket() : company(INVALID_COMPANY), frame(0), my_cmd(false) {}
 	CompanyID company;   ///< company that is executing the command
 	uint32_t frame;        ///< the frame in which this packet is executed
 	bool my_cmd;         ///< did the command originate from "me"

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1060,7 +1060,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_COMMAND(Packet 
 		return this->SendError(NETWORK_ERROR_NOT_EXPECTED);
 	}
 
-	if (this->incoming_queue.Count() >= _settings_client.network.max_commands_in_queue) {
+	if (this->incoming_queue.size() >= _settings_client.network.max_commands_in_queue) {
 		return this->SendError(NETWORK_ERROR_TOO_MANY_COMMANDS);
 	}
 
@@ -1115,7 +1115,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_COMMAND(Packet 
 
 	if (GetCommandFlags(cp.cmd) & CMD_CLIENT_ID) NetworkReplaceCommandClientId(cp, this->client_id);
 
-	this->incoming_queue.Append(&cp);
+	this->incoming_queue.push_back(cp);
 	return NETWORK_RECV_STATUS_OKAY;
 }
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1701,11 +1701,8 @@ void NetworkServerSetCompanyPassword(CompanyID company_id, const std::string &pa
  */
 static void NetworkHandleCommandQueue(NetworkClientSocket *cs)
 {
-	CommandPacket *cp;
-	while ((cp = cs->outgoing_queue.Pop()) != nullptr) {
-		cs->SendCommand(cp);
-		delete cp;
-	}
+	for (auto &cp : cs->outgoing_queue) cs->SendCommand(&cp);
+	cs->outgoing_queue.clear();
 }
 
 /**

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -656,15 +656,15 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendSync()
  * Send a command to the client to execute.
  * @param cp The command to send.
  */
-NetworkRecvStatus ServerNetworkGameSocketHandler::SendCommand(const CommandPacket *cp)
+NetworkRecvStatus ServerNetworkGameSocketHandler::SendCommand(const CommandPacket &cp)
 {
-	Debug(net, 9, "client[{}] SendCommand(): cmd={}", this->client_id, cp->cmd);
+	Debug(net, 9, "client[{}] SendCommand(): cmd={}", this->client_id, cp.cmd);
 
 	auto p = std::make_unique<Packet>(PACKET_SERVER_COMMAND);
 
 	this->NetworkGameSocketHandler::SendCommand(*p, cp);
-	p->Send_uint32(cp->frame);
-	p->Send_bool  (cp->my_cmd);
+	p->Send_uint32(cp.frame);
+	p->Send_bool  (cp.my_cmd);
 
 	this->SendPacket(std::move(p));
 	return NETWORK_RECV_STATUS_OKAY;
@@ -1067,7 +1067,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_COMMAND(Packet 
 	Debug(net, 9, "client[{}] Receive_CLIENT_COMMAND()", this->client_id);
 
 	CommandPacket cp;
-	const char *err = this->ReceiveCommand(p, &cp);
+	const char *err = this->ReceiveCommand(p, cp);
 
 	if (this->HasClientQuit()) return NETWORK_RECV_STATUS_CLIENT_QUIT;
 
@@ -1701,7 +1701,7 @@ void NetworkServerSetCompanyPassword(CompanyID company_id, const std::string &pa
  */
 static void NetworkHandleCommandQueue(NetworkClientSocket *cs)
 {
-	for (auto &cp : cs->outgoing_queue) cs->SendCommand(&cp);
+	for (auto &cp : cs->outgoing_queue) cs->SendCommand(cp);
 	cs->outgoing_queue.clear();
 }
 

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -97,7 +97,7 @@ public:
 	NetworkRecvStatus SendJoin(ClientID client_id);
 	NetworkRecvStatus SendFrame();
 	NetworkRecvStatus SendSync();
-	NetworkRecvStatus SendCommand(const CommandPacket *cp);
+	NetworkRecvStatus SendCommand(const CommandPacket &cp);
 	NetworkRecvStatus SendCompanyUpdate();
 	NetworkRecvStatus SendConfigUpdate();
 

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -66,7 +66,7 @@ public:
 	byte last_token;             ///< The last random token we did send to verify the client is listening
 	uint32_t last_token_frame;     ///< The last frame we received the right token
 	ClientStatus status;         ///< Status of this client
-	std::vector<CommandPacket> outgoing_queue; ///< The command-queue awaiting delivery; conceptually more a bucket to gather commands in, after which the whole bucket is sent to the client.
+	CommandQueue outgoing_queue; ///< The command-queue awaiting delivery; conceptually more a bucket to gather commands in, after which the whole bucket is sent to the client.
 	size_t receive_limit;        ///< Amount of bytes that we can receive at this moment
 
 	std::shared_ptr<struct PacketWriter> savegame; ///< Writer used to write the savegame.

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -66,7 +66,7 @@ public:
 	byte last_token;             ///< The last random token we did send to verify the client is listening
 	uint32_t last_token_frame;     ///< The last frame we received the right token
 	ClientStatus status;         ///< Status of this client
-	CommandQueue outgoing_queue; ///< The command-queue awaiting delivery
+	std::vector<CommandPacket> outgoing_queue; ///< The command-queue awaiting delivery; conceptually more a bucket to gather commands in, after which the whole bucket is sent to the client.
 	size_t receive_limit;        ///< Amount of bytes that we can receive at this moment
 
 	std::shared_ptr<struct PacketWriter> savegame; ///< Writer used to write the savegame.


### PR DESCRIPTION
## Motivation / Problem

Self rolled container formats.
Complex logic that could be implemented much simpler.
Lots of manual memory management.


## Description

Replace the class `CommandQueue` with `std::vector<CommandPacket>`.
Pass `CommandPacket`s around as references.

Replace `Peek()`/`Pop()` with iterations over the vector.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
