### PR TITLE
Fix #12001: Check cargo exists for old-style NewGRF town house 3rd cargo set up.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -2431,7 +2431,7 @@ static ChangeInfoResult TownHouseChangeInfo(uint hid, int numinfo, int prop, Byt
 					 * in the temperate climate. */
 					CargoID cid = housespec->accepts_cargo[2];
 					if (!IsValidCargoID(cid)) cid = GetCargoIDByLabel(housespec->accepts_cargo_label[2]);
-					if (!IsValidCargoID(cid) || !CargoSpec::Get(cid)->IsValid()) {
+					if (!IsValidCargoID(cid)) {
 						housespec->cargo_acceptance[2] = 0;
 					}
 				}
@@ -2471,7 +2471,7 @@ static ChangeInfoResult TownHouseChangeInfo(uint hid, int numinfo, int prop, Byt
 						((_settings_game.game_creation.landscape == LT_TOYLAND) ? GetCargoIDByLabel(CT_FIZZY_DRINKS) : GetCargoIDByLabel(CT_FOOD));
 
 				/* Make sure the cargo type is valid in this climate. */
-				if (!CargoSpec::Get(cid)->IsValid()) goods = 0;
+				if (!IsValidCargoID(cid)) goods = 0;
 
 				housespec->accepts_cargo[2] = cid;
 				housespec->accepts_cargo_label[2] = CT_INVALID;


### PR DESCRIPTION
## Motivation / Problem

As per #12001, the game will crash when loading a NewGRF that uses an old method to set food or goods acceptance on town houses when food or goods is not available.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Test if food or goods is valid with `IsValidCargoID()` instead of trying to get a possibly invalid cargo and checking it's `IsValid\(\)`. `GetCargoIDByLabel()` will not return cargo ID that is invalid, other than `INVALID_CARGO`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
