### PR TITLE
Fix #11997: Adjust economy date by 1920 when loading TTD/TTO savegames

### DIFF
--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1436,6 +1436,8 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SLV_31)) {
 		TimerGameCalendar::date += CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR;
 		TimerGameCalendar::year += CalendarTime::ORIGINAL_BASE_YEAR;
+		TimerGameEconomy::date += EconomyTime::DAYS_TILL_ORIGINAL_BASE_YEAR;
+		TimerGameEconomy::year += EconomyTime::ORIGINAL_BASE_YEAR;
 
 		for (Station *st : Station::Iterate())   st->build_date      += CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR;
 		for (Waypoint *wp : Waypoint::Iterate()) wp->build_date      += CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR;


### PR DESCRIPTION
## Motivation / Problem

Dates in TTD/TTO are 0 when the year is 1920.

Dates in OpenTTD are 0 when the year is 0.

When loading old savegames, we adjust TimerGameCalendar accordingly. But I forgot to also adjust TimerGameEconomy.

## Description

Add the same offsets to TimerGameEconomy.

Closes #11997.

## Limitations

I do not have a TTD/TTO savegame with which to test this.

Dates are set before loading sprites, so I can't move the TimerGameEconomy = TimerGameCalendar synchronization (L741-L746) after this offset is made. And I don't want to move the offset before loading sprites. Let's not change the order of things in afterload. 😅 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
