### PR TITLE
Fix: Focus hotkey in road/tram stop building window

### DIFF
--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1582,7 +1582,11 @@ public:
 		this->InvalidateData();
 	}};
 
-	static inline HotkeyList hotkeys{"buildroadstop", {
+	static inline HotkeyList road_hotkeys{"buildroadstop", {
+		Hotkey('F', "focus_filter_box", BROSHK_FOCUS_FILTER_BOX),
+	}};
+
+	static inline HotkeyList tram_hotkeys{"buildtramstop", {
 		Hotkey('F', "focus_filter_box", BROSHK_FOCUS_FILTER_BOX),
 	}};
 };
@@ -1684,7 +1688,8 @@ static WindowDesc _road_station_picker_desc(__FILE__, __LINE__,
 	WDP_AUTO, "build_station_road", 0, 0,
 	WC_BUS_STATION, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_road_station_picker_widgets), std::end(_nested_road_station_picker_widgets)
+	std::begin(_nested_road_station_picker_widgets), std::end(_nested_road_station_picker_widgets),
+	&BuildRoadStationWindow::road_hotkeys
 );
 
 /** Widget definition of the build tram station window */
@@ -1761,7 +1766,8 @@ static WindowDesc _tram_station_picker_desc(__FILE__, __LINE__,
 	WDP_AUTO, "build_station_tram", 0, 0,
 	WC_BUS_STATION, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_tram_station_picker_widgets), std::end(_nested_tram_station_picker_widgets)
+	std::begin(_nested_tram_station_picker_widgets), std::end(_nested_tram_station_picker_widgets),
+	&BuildRoadStationWindow::tram_hotkeys
 );
 
 static void ShowRVStationPicker(Window *parent, RoadStopType rs)


### PR DESCRIPTION
## Motivation / Problem

Focus hotkey (F) in road/tram stop building window doesn't work.

## Description

Hotkey definition was there but not passed to WindowDesc, fixed that. And split into hotkeys for tram and road as in other windows.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
