### PR TITLE
Fix: [Script] Don't kill GS misusing GSText

### DIFF
--- a/src/script/api/script_text.hpp
+++ b/src/script/api/script_text.hpp
@@ -136,8 +136,11 @@ private:
 		StringID owner;
 		int idx;
 		Param *param;
+		bool used;
 
-		ParamCheck(StringID owner, int idx, Param *param) : owner(owner), idx(idx), param(param) {}
+		ParamCheck(StringID owner, int idx, Param *param) : owner(owner), idx(idx), param(param), used(false) {}
+
+		void Encode(std::back_insert_iterator<std::string> &output);
 	};
 
 	using ParamList = std::vector<ParamCheck>;


### PR DESCRIPTION
## Motivation / Problem
Some script misuse string system, like `Bee Reward` with
 ```
STR_COMPANY_GOAL_REWARD                :Deliver {GOLD}{CARGO_LONG} {ORANGE}to {STRING}{ORANGE} for {WHITE}{STRING}{CURRENCY_LONG}
```
where the first `{STRING}` (which should be `{STRING1}`) is used with
```
STR_TOWN_NAME                          :{WHITE}{TOWN}
STR_INDUSTRY_NAME                      :{YELLOW}{INDUSTRY}
```
and the second `{STRING}` is there to skip/discard the `{TOWN}`/`{INDUSTRY}` of the substring.

In 13.4 it "works":
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/0b8c9a46-8b0b-495f-91fb-e6b103e621a1)

In 14.0/master it doesn't:
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/7619f980-cc64-4532-bc87-41a59fb02fd7)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Instead of killing the script, just display an error message in the log and continue to encode the string.
OpenTTD will validate the parameters anyway.
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/47b56954-7485-45e3-a3e6-d044bf469c13)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
