### PR TITLE
Fix: "restart current" reproduces how the script config of the current game was when it started

### DIFF
--- a/src/ai/ai.hpp
+++ b/src/ai/ai.hpp
@@ -28,8 +28,9 @@ public:
 	 * Start a new AI company.
 	 * @param company At which slot the AI company should start.
 	 * @param rerandomise_ai Whether to rerandomise the configured AI.
+	 * @param deviate Whether to add random deviation to settings that allow it.
 	 */
-	static void StartNew(CompanyID company, bool rerandomise_ai = true);
+	static void StartNew(CompanyID company, bool rerandomise_ai = true, bool deviate = true);
 
 	/**
 	 * Called every game-tick to let AIs do something.

--- a/src/ai/ai_config.hpp
+++ b/src/ai/ai_config.hpp
@@ -24,8 +24,8 @@ public:
 		ScriptConfig()
 	{}
 
-	AIConfig(const AIConfig *config) :
-		ScriptConfig(config)
+	AIConfig(const AIConfig *config, bool add_random_deviation) :
+		ScriptConfig(config, add_random_deviation)
 	{}
 
 	class AIInfo *GetInfo() const;

--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -33,7 +33,7 @@
 	return !_networking || (_network_server && _settings_game.ai.ai_in_multiplayer);
 }
 
-/* static */ void AI::StartNew(CompanyID company, bool rerandomise_ai)
+/* static */ void AI::StartNew(CompanyID company, bool rerandomise_ai, bool deviate)
 {
 	assert(Company::IsValidID(company));
 
@@ -46,8 +46,9 @@
 		info = AI::scanner_info->SelectRandomAI();
 		assert(info != nullptr);
 		/* Load default data and store the name in the settings */
-		config->Change(info->GetName(), -1, false, true);
+		config->Change(info->GetName(), -1, false, true, false);
 	}
+	if (deviate) config->AddRandomDeviation();
 	config->AnchorUnchangeableSettings();
 
 	Backup<CompanyID> cur_company(_current_company, company, FILE_LINE);

--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -48,7 +48,6 @@
 		/* Load default data and store the name in the settings */
 		config->Change(info->GetName(), -1, false, true);
 	}
-	if (rerandomise_ai) config->AddRandomDeviation();
 	config->AnchorUnchangeableSettings();
 
 	Backup<CompanyID> cur_company(_current_company, company, FILE_LINE);
@@ -115,6 +114,10 @@
 	cur_company.Restore();
 
 	InvalidateWindowClassesData(WC_SCRIPT_DEBUG, -1);
+
+	if (AIConfig::GetConfig(company)->IsRandom()) {
+		AIConfig::GetConfig(company)->Change(std::nullopt);
+	}
 	CloseWindowById(WC_SCRIPT_SETTINGS, company);
 }
 

--- a/src/company_cmd.h
+++ b/src/company_cmd.h
@@ -17,7 +17,7 @@
 enum ClientID : uint32_t;
 enum Colours : byte;
 
-CommandCost CmdCompanyCtrl(DoCommandFlag flags, CompanyCtrlAction cca, CompanyID company_id, CompanyRemoveReason reason, ClientID client_id);
+CommandCost CmdCompanyCtrl(DoCommandFlag flags, CompanyCtrlAction cca, CompanyID company_id, CompanyRemoveReason reason, ClientID client_id, bool deviate);
 CommandCost CmdGiveMoney(DoCommandFlag flags, Money money, CompanyID dest_company);
 CommandCost CmdRenameCompany(DoCommandFlag flags, const std::string &text);
 CommandCost CmdRenamePresident(DoCommandFlag flags, const std::string &text);

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -645,7 +645,7 @@ static void CompanyCheckBankrupt(Company *c)
 			 * player we are sure (the above check) that we are not the local
 			 * company and thus we won't be moved. */
 			if (!_networking || _network_server) {
-				Command<CMD_COMPANY_CTRL>::Post(CCA_DELETE, c->index, CRR_BANKRUPT, INVALID_CLIENT_ID);
+				Command<CMD_COMPANY_CTRL>::Post(CCA_DELETE, c->index, CRR_BANKRUPT, INVALID_CLIENT_ID, false);
 				return;
 			}
 			break;

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -31,9 +31,8 @@ public:
 
 	/**
 	 * Start up a new GameScript.
-	 * @param randomise Whether to randomise the configured GameScript.
 	 */
-	static void StartNew(bool randomise = true);
+	static void StartNew();
 
 	/**
 	 * Uninitialize the Game system.

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -31,8 +31,9 @@ public:
 
 	/**
 	 * Start up a new GameScript.
+	 * @param deviation Whether to add random deviation to settings that allow it.
 	 */
-	static void StartNew();
+	static void StartNew(bool deviation = true);
 
 	/**
 	 * Uninitialize the Game system.

--- a/src/game/game_config.hpp
+++ b/src/game/game_config.hpp
@@ -23,8 +23,8 @@ public:
 		ScriptConfig()
 	{}
 
-	GameConfig(const GameConfig *config) :
-		ScriptConfig(config)
+	GameConfig(const GameConfig *config, bool add_random_deviation) :
+		ScriptConfig(config, add_random_deviation)
 	{}
 
 	class GameInfo *GetInfo() const;

--- a/src/game/game_core.cpp
+++ b/src/game/game_core.cpp
@@ -69,7 +69,7 @@
 	}
 }
 
-/* static */ void Game::StartNew(bool randomise)
+/* static */ void Game::StartNew()
 {
 	if (Game::instance != nullptr) return;
 
@@ -83,7 +83,6 @@
 	GameInfo *info = config->GetInfo();
 	if (info == nullptr) return;
 
-	if (randomise) config->AddRandomDeviation();
 	config->AnchorUnchangeableSettings();
 
 	Backup<CompanyID> cur_company(_current_company, FILE_LINE);

--- a/src/game/game_core.cpp
+++ b/src/game/game_core.cpp
@@ -69,7 +69,7 @@
 	}
 }
 
-/* static */ void Game::StartNew()
+/* static */ void Game::StartNew(bool deviation)
 {
 	if (Game::instance != nullptr) return;
 
@@ -83,6 +83,7 @@
 	GameInfo *info = config->GetInfo();
 	if (info == nullptr) return;
 
+	if (deviation) config->AddRandomDeviation();
 	config->AnchorUnchangeableSettings();
 
 	Backup<CompanyID> cur_company(_current_company, FILE_LINE);

--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -91,11 +91,8 @@ static void _GenerateWorld()
 	try {
 		_generating_world = true;
 		if (_network_dedicated) Debug(net, 3, "Generating map, please wait...");
-		/* Set the Random() seed to generation_seed so we produce the same map with the same seed */
-		_random.SetSeed(_settings_game.game_creation.generation_seed);
 		SetGeneratingWorldProgress(GWP_MAP_INIT, 2);
 		SetObjectToPlace(SPR_CURSOR_ZZZ, PAL_NONE, HT_NONE, WC_MAIN_WINDOW, 0);
-		ScriptObject::InitializeRandomizers();
 
 		BasePersistentStorageArray::SwitchMode(PSM_ENTER_GAMELOOP);
 
@@ -306,8 +303,6 @@ void GenerateWorld(GenWorldMode mode, uint size_x, uint size_y, bool reset_setti
 
 		_settings_game.construction.map_height_limit = std::max(MAP_HEIGHT_LIMIT_AUTO_MINIMUM, std::min(MAX_MAP_HEIGHT_LIMIT, estimated_height + MAP_HEIGHT_LIMIT_AUTO_CEILING_ROOM));
 	}
-
-	if (_settings_game.game_creation.generation_seed == GENERATE_NEW_SEED) _settings_game.game_creation.generation_seed = InteractiveRandom();
 
 	/* Load the right landscape stuff, and the NewGRFs! */
 	GfxLoadSprites();

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -187,18 +187,20 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
 			_settings_game.ai_config[c] = nullptr;
 			if (_settings_newgame.ai_config[c] != nullptr) {
-				_settings_game.ai_config[c] = new AIConfig(_settings_newgame.ai_config[c]);
+				_settings_game.ai_config[c] = new AIConfig(_settings_newgame.ai_config[c], true);
 			}
 		}
 		_settings_game.game_config = nullptr;
 		if (_settings_newgame.game_config != nullptr) {
-			_settings_game.game_config = new GameConfig(_settings_newgame.game_config);
+			_settings_game.game_config = new GameConfig(_settings_newgame.game_config, true);
 		}
 	}
 
-	/* Set random deviation for scripts. */
-	for (auto &ai_config : _settings_game.ai_config) {
-		if (ai_config != nullptr) ai_config->AddRandomDeviation();
+	if (_switch_mode == SM_RESTARTGAME) {
+		/* Simulate random deviation for scripts to keep the randomizer counters in sync, but don't set the deviated values. */
+		for (auto &ai_config : _settings_game.ai_config) {
+			if (ai_config != nullptr) ai_config->AddRandomDeviation();
+		}
+		if (_settings_game.game_config != nullptr) _settings_game.game_config->AddRandomDeviation();
 	}
-	if (_settings_game.game_config != nullptr) _settings_game.game_config->AddRandomDeviation();
 }

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -894,7 +894,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_MAP_DONE(Packet
 			Debug(net, 9, "Client::join_status = REGISTERING");
 			_network_join_status = NETWORK_JOIN_STATUS_REGISTERING;
 			ShowJoinStatusWindow();
-			Command<CMD_COMPANY_CTRL>::SendNet(STR_NULL, _local_company, CCA_NEW, INVALID_COMPANY, CRR_NONE, INVALID_CLIENT_ID);
+			Command<CMD_COMPANY_CTRL>::SendNet(STR_NULL, _local_company, CCA_NEW, INVALID_COMPANY, CRR_NONE, INVALID_CLIENT_ID, false);
 		}
 	} else {
 		/* take control over an existing company */

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1346,7 +1346,7 @@ static void AdminCompanyResetCallback(Window *, bool confirmed)
 {
 	if (confirmed) {
 		if (NetworkCompanyHasClients(_admin_company_id)) return;
-		Command<CMD_COMPANY_CTRL>::Post(CCA_DELETE, _admin_company_id, CRR_MANUAL, INVALID_CLIENT_ID);
+		Command<CMD_COMPANY_CTRL>::Post(CCA_DELETE, _admin_company_id, CRR_MANUAL, INVALID_CLIENT_ID, false);
 	}
 }
 
@@ -1482,9 +1482,9 @@ private:
 	static void OnClickCompanyNew([[maybe_unused]] NetworkClientListWindow *w, [[maybe_unused]] Point pt, CompanyID)
 	{
 		if (_network_server) {
-			Command<CMD_COMPANY_CTRL>::Post(CCA_NEW, INVALID_COMPANY, CRR_NONE, _network_own_client_id);
+			Command<CMD_COMPANY_CTRL>::Post(CCA_NEW, INVALID_COMPANY, CRR_NONE, _network_own_client_id, false);
 		} else {
-			Command<CMD_COMPANY_CTRL>::SendNet(STR_NULL, _local_company, CCA_NEW, INVALID_COMPANY, CRR_NONE, INVALID_CLIENT_ID);
+			Command<CMD_COMPANY_CTRL>::SendNet(STR_NULL, _local_company, CCA_NEW, INVALID_COMPANY, CRR_NONE, INVALID_CLIENT_ID, false);
 		}
 	}
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1590,7 +1590,7 @@ static void NetworkAutoCleanCompanies()
 			/* Is the company empty for autoclean_unprotected-months, and is there no protection? */
 			if (_settings_client.network.autoclean_unprotected != 0 && _network_company_states[c->index].months_empty > _settings_client.network.autoclean_unprotected && _network_company_states[c->index].password.empty()) {
 				/* Shut the company down */
-				Command<CMD_COMPANY_CTRL>::Post(CCA_DELETE, c->index, CRR_AUTOCLEAN, INVALID_CLIENT_ID);
+				Command<CMD_COMPANY_CTRL>::Post(CCA_DELETE, c->index, CRR_AUTOCLEAN, INVALID_CLIENT_ID, false);
 				IConsolePrint(CC_INFO, "Auto-cleaned company #{} with no password.", c->index + 1);
 			}
 			/* Is the company empty for autoclean_protected-months, and there is a protection? */
@@ -1604,7 +1604,7 @@ static void NetworkAutoCleanCompanies()
 			/* Is the company empty for autoclean_novehicles-months, and has no vehicles? */
 			if (_settings_client.network.autoclean_novehicles != 0 && _network_company_states[c->index].months_empty > _settings_client.network.autoclean_novehicles && !HasBit(has_vehicles, c->index)) {
 				/* Shut the company down */
-				Command<CMD_COMPANY_CTRL>::Post(CCA_DELETE, c->index, CRR_AUTOCLEAN, INVALID_CLIENT_ID);
+				Command<CMD_COMPANY_CTRL>::Post(CCA_DELETE, c->index, CRR_AUTOCLEAN, INVALID_CLIENT_ID, false);
 				IConsolePrint(CC_INFO, "Auto-cleaned company #{} with no vehicles.", c->index + 1);
 			}
 		} else {

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -96,7 +96,7 @@ void CallWindowGameTickEvent();
 bool HandleBootstrap();
 
 extern void AfterLoadCompanyStats();
-extern Company *DoStartupNewCompany(bool is_ai, CompanyID company = INVALID_COMPANY);
+extern Company *DoStartupNewCompany(bool is_ai, CompanyID company = INVALID_COMPANY, bool deviate = true);
 extern void OSOpenBrowser(const std::string &url);
 extern void RebuildTownCaches();
 extern void ShowOSErrorBox(const char *buf, bool system);
@@ -361,12 +361,12 @@ void MakeNewgameSettingsLive()
 	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
 		_settings_game.ai_config[c] = nullptr;
 		if (_settings_newgame.ai_config[c] != nullptr) {
-			_settings_game.ai_config[c] = new AIConfig(_settings_newgame.ai_config[c]);
+			_settings_game.ai_config[c] = new AIConfig(_settings_newgame.ai_config[c], false);
 		}
 	}
 	_settings_game.game_config = nullptr;
 	if (_settings_newgame.game_config != nullptr) {
-		_settings_game.game_config = new GameConfig(_settings_newgame.game_config);
+		_settings_game.game_config = new GameConfig(_settings_newgame.game_config, false);
 	}
 }
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -553,7 +553,7 @@ static void StartScripts()
 	}
 
 	/* Start the GameScript. */
-	Game::StartNew(false);
+	Game::StartNew();
 
 	ShowScriptDebugWindowIfScriptError();
 }

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -69,7 +69,7 @@
 
 #include "../safeguards.h"
 
-extern Company *DoStartupNewCompany(bool is_ai, CompanyID company = INVALID_COMPANY);
+extern Company *DoStartupNewCompany(bool is_ai, CompanyID company = INVALID_COMPANY, bool deviate = true);
 
 /**
  * Makes a tile canal or water depending on the surroundings.
@@ -549,11 +549,11 @@ static void StartScripts()
 
 	/* Start the AIs. */
 	for (const Company *c : Company::Iterate()) {
-		if (Company::IsValidAiID(c->index)) AI::StartNew(c->index, false);
+		if (Company::IsValidAiID(c->index)) AI::StartNew(c->index, false, false);
 	}
 
 	/* Start the GameScript. */
-	Game::StartNew();
+	Game::StartNew(false);
 
 	ShowScriptDebugWindowIfScriptError();
 }

--- a/src/saveload/ai_sl.cpp
+++ b/src/saveload/ai_sl.cpp
@@ -87,11 +87,11 @@ struct AIPLChunkHandler : ChunkHandler {
 				/* A random AI. */
 				config->Change(std::nullopt, -1, false, true);
 			} else {
-				config->Change(_ai_saveload_name, _ai_saveload_version, false, _ai_saveload_is_random);
+				config->Change(_ai_saveload_name, _ai_saveload_version, false, _ai_saveload_is_random, false);
 				if (!config->HasScript()) {
 					/* No version of the AI available that can load the data. Try to load the
 					 * latest version of the AI instead. */
-					config->Change(_ai_saveload_name, -1, false, _ai_saveload_is_random);
+					config->Change(_ai_saveload_name, -1, false, _ai_saveload_is_random, false);
 					if (!config->HasScript()) {
 						if (_ai_saveload_name.compare("%_dummy") != 0) {
 							Debug(script, 0, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -77,11 +77,11 @@ struct GSDTChunkHandler : ChunkHandler {
 
 		GameConfig *config = GameConfig::GetConfig(GameConfig::SSS_FORCE_GAME);
 		if (!_game_saveload_name.empty()) {
-			config->Change(_game_saveload_name, _game_saveload_version, false, _game_saveload_is_random);
+			config->Change(_game_saveload_name, _game_saveload_version, false, _game_saveload_is_random, false);
 			if (!config->HasScript()) {
 				/* No version of the GameScript available that can load the data. Try to load the
 				 * latest version of the GameScript instead. */
-				config->Change(_game_saveload_name, -1, false, _game_saveload_is_random);
+				config->Change(_game_saveload_name, -1, false, _game_saveload_is_random, false);
 				if (!config->HasScript()) {
 					if (_game_saveload_name.compare("%_dummy") != 0) {
 						Debug(script, 0, "The savegame has an GameScript by the name '{}', version {} which is no longer available.", _game_saveload_name, _game_saveload_version);

--- a/src/script/api/script_info_docs.hpp
+++ b/src/script/api/script_info_docs.hpp
@@ -228,7 +228,9 @@ public:
 	 *    actual value of the setting in game will be randomised in the range
 	 *    [user_configured_value - random_deviation, user_configured_value + random_deviation] (inclusive).
 	 *    random_deviation sign is ignored and the value is clamped in the range [0, MAX(int32_t)] (inclusive).
-	 *    The randomisation will happen just before the Script start.
+	 *    The randomisation will happen in the following cases:
+	 *    - right before game start, so after the user decided the settings for the script.
+	 *    - when a random AI starts.
 	 *    Not allowed if the CONFIG_BOOLEAN flag is set, otherwise optional.
 	 *  - step_size The increase/decrease of the value every time the user
 	 *    clicks one of the up/down arrow buttons. Optional, default is 1.

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -18,7 +18,7 @@
 
 #include "../safeguards.h"
 
-void ScriptConfig::Change(std::optional<const std::string> name, int version, bool force_exact_match, bool is_random)
+void ScriptConfig::Change(std::optional<const std::string> name, int version, bool force_exact_match, bool is_random, bool add_random_deviation)
 {
 	if (name.has_value()) {
 		this->name = std::move(name.value());
@@ -33,12 +33,12 @@ void ScriptConfig::Change(std::optional<const std::string> name, int version, bo
 
 	this->ClearConfigList();
 
-	if (_game_mode == GM_NORMAL && _switch_mode != SM_LOAD_GAME && this->info != nullptr) {
+	if (this->info != nullptr && add_random_deviation) {
 		this->AddRandomDeviation();
 	}
 }
 
-ScriptConfig::ScriptConfig(const ScriptConfig *config)
+ScriptConfig::ScriptConfig(const ScriptConfig *config, bool add_random_deviation)
 {
 	this->name = config->name;
 	this->info = config->info;
@@ -49,6 +49,8 @@ ScriptConfig::ScriptConfig(const ScriptConfig *config)
 	for (const auto &item : config->settings) {
 		this->settings[item.first] = item.second;
 	}
+
+	if (add_random_deviation) this->AddRandomDeviation();
 }
 
 ScriptConfig::~ScriptConfig()

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -32,6 +32,10 @@ void ScriptConfig::Change(std::optional<const std::string> name, int version, bo
 	this->to_load_data.reset();
 
 	this->ClearConfigList();
+
+	if (_game_mode == GM_NORMAL && _switch_mode != SM_LOAD_GAME && this->info != nullptr) {
+		this->AddRandomDeviation();
+	}
 }
 
 ScriptConfig::ScriptConfig(const ScriptConfig *config)
@@ -129,7 +133,8 @@ void ScriptConfig::AddRandomDeviation()
 {
 	for (const auto &item : *this->GetConfigList()) {
 		if (item.random_deviation != 0) {
-			this->SetSetting(item.name, ScriptObject::GetRandomizer(OWNER_NONE).Next(item.random_deviation * 2 + 1) - item.random_deviation + this->GetSetting(item.name));
+			uint32_t randomize = ScriptObject::GetRandomizer(OWNER_NONE).Next(item.random_deviation * 2 + 1);
+			if (_switch_mode != SM_RESTARTGAME) this->SetSetting(item.name, randomize - item.random_deviation + this->GetSetting(item.name));
 		}
 	}
 }

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -63,8 +63,9 @@ public:
 	/**
 	 * Create a new Script config that is a copy of an existing config.
 	 * @param config The object to copy.
+	 * @param add_random_deviation Whether to add random deviation to script settings that allow it.
 	 */
-	ScriptConfig(const ScriptConfig *config);
+	ScriptConfig(const ScriptConfig *config, bool add_random_deviation);
 
 	/** Delete an Script configuration. */
 	virtual ~ScriptConfig();
@@ -76,8 +77,9 @@ public:
 	 * @param force_exact_match If true try to find the exact same version
 	 *   as specified. If false any compatible version is ok.
 	 * @param is_random Is the Script chosen randomly?
+	 * @param add_random_deviation Apply random deviation to settings that allow it?
 	 */
-	void Change(std::optional<const std::string> name, int version = -1, bool force_exact_match = false, bool is_random = false);
+	void Change(std::optional<const std::string> name, int version = -1, bool force_exact_match = false, bool is_random = false, bool add_random_deviation = true);
 
 	/**
 	 * Get the ScriptInfo linked to this ScriptConfig.

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -176,7 +176,7 @@ struct ScriptListWindow : public Window {
 		} else {
 			ScriptInfoList::const_iterator it = this->info_list->cbegin();
 			std::advance(it, this->selected);
-			GetConfig(slot)->Change(it->second->GetName(), it->second->GetVersion());
+			GetConfig(slot)->Change(it->second->GetName(), it->second->GetVersion(), false, false, false);
 		}
 		InvalidateWindowData(WC_GAME_OPTIONS, slot == OWNER_DEITY ? WN_GAME_OPTIONS_GS : WN_GAME_OPTIONS_AI);
 		InvalidateWindowClassesData(WC_SCRIPT_SETTINGS);
@@ -1080,12 +1080,14 @@ struct ScriptDebugWindow : public Window {
 				ChangeToScript(OWNER_DEITY, _ctrl_pressed);
 				break;
 
-			case WID_SCRD_RELOAD_TOGGLE:
+			case WID_SCRD_RELOAD_TOGGLE: {
 				if (this->filter.script_debug_company == OWNER_DEITY) break;
+				bool deviate = AIConfig::GetConfig(this->filter.script_debug_company)->IsRandom();
 				/* First kill the company of the AI, then start a new one. This should start the current AI again */
-				Command<CMD_COMPANY_CTRL>::Post(CCA_DELETE, this->filter.script_debug_company, CRR_MANUAL, INVALID_CLIENT_ID);
-				Command<CMD_COMPANY_CTRL>::Post(CCA_NEW_AI, this->filter.script_debug_company, CRR_NONE, INVALID_CLIENT_ID);
+				Command<CMD_COMPANY_CTRL>::Post(CCA_DELETE, this->filter.script_debug_company, CRR_MANUAL, INVALID_CLIENT_ID, false);
+				Command<CMD_COMPANY_CTRL>::Post(CCA_NEW_AI, this->filter.script_debug_company, CRR_NONE, INVALID_CLIENT_ID, deviate);
 				break;
+			}
 
 			case WID_SCRD_SETTINGS:
 				ShowScriptSettingsWindow(this->filter.script_debug_company);

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -379,14 +379,14 @@ struct ScriptSettingsWindow : public Window {
 			TextColour colour;
 			uint idx = 0;
 			if (config_item.description.empty()) {
-				if (this->slot != OWNER_DEITY && !Company::IsValidID(this->slot) && config_item.random_deviation != 0) {
+				if (this->slot != OWNER_DEITY && _game_mode != GM_NORMAL && config_item.random_deviation != 0) {
 					str = STR_AI_SETTINGS_JUST_DEVIATION;
 				} else {
 					str = STR_JUST_STRING1;
 				}
 				colour = TC_ORANGE;
 			} else {
-				if (this->slot != OWNER_DEITY && !Company::IsValidID(this->slot) && config_item.random_deviation != 0) {
+				if (this->slot != OWNER_DEITY && _game_mode != GM_NORMAL && config_item.random_deviation != 0) {
 					str = STR_AI_SETTINGS_SETTING_DEVIATION;
 				} else {
 					str = STR_AI_SETTINGS_SETTING;
@@ -405,7 +405,7 @@ struct ScriptSettingsWindow : public Window {
 					DrawArrowButtons(br.left, y + button_y_offset, COLOUR_YELLOW, (this->clicked_button == i) ? 1 + (this->clicked_increase != rtl) : 0, editable && current_value > config_item.min_value, editable && current_value < config_item.max_value);
 				}
 
-				if (this->slot == OWNER_DEITY || Company::IsValidID(this->slot) || config_item.random_deviation == 0) {
+				if (this->slot == OWNER_DEITY || _game_mode == GM_NORMAL || config_item.random_deviation == 0) {
 					auto config_iterator = config_item.labels.find(current_value);
 					if (config_iterator != config_item.labels.end()) {
 						SetDParam(idx++, STR_JUST_RAW_STRING);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -953,7 +953,7 @@ static void AILoadConfig(const IniFile &ini, const char *grpname)
 	for (const IniItem &item : group->items) {
 		AIConfig *config = AIConfig::GetConfig(c, AIConfig::SSS_FORCE_NEWGAME);
 
-		config->Change(item.name);
+		config->Change(item.name, -1, false, false, false);
 		if (!config->HasScript()) {
 			if (item.name != "none") {
 				Debug(script, 0, "The AI by the name '{}' was no longer found, and removed from the list.", item.name);
@@ -980,7 +980,7 @@ static void GameLoadConfig(const IniFile &ini, const char *grpname)
 
 	GameConfig *config = GameConfig::GetConfig(AIConfig::SSS_FORCE_NEWGAME);
 
-	config->Change(item.name);
+	config->Change(item.name, -1, false, false, false);
 	if (!config->HasScript()) {
 		if (item.name != "none") {
 			Debug(script, 0, "The GameScript by the name '{}' was no longer found, and removed from the list.", item.name);


### PR DESCRIPTION
## Motivation / Problem
Alternative approach to #12003, without requiring a _saveload_ version bump.

In #11944, it was determined `random_deviation` was _inconsistent_, and an attempt to fix it was made so it would only deviate during script start. But this caused a few issues regarding reproducibility when using the recently introduced "restart current" command in #11963.
- `Reload AI` on a non-random AI makes the deviated values based on the current value, meaning they would walk outside the min-max range it had when the AI initially started.
- `restart current` does not roll back AIs that started as `Random AI`, does not roll back to the original values for parameters with random_deviation, similar to `Reload AI`, they could walk outside the min-max range.
- AIs that have not yet started at the time of saving game deviate to a different value once the company starts after loading from the savegame.
- `startai` when provided with the name of a script and parameters, applies random deviation on top of the user provided values.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
- Restore Random AI slot upon stopping a randomly started AI.
- On "restart current" console command, use the seed of the current game to set the seed of scripts.

- Apply random deviation to non-random script settings upon starting a new game, except when using "restart current" via console, where the randomization counter is simulated but the values remain not deviated.

- Show random deviation range for scripts only outside normal game mode.

- Explicitly control whether to add random deviation
- Reloading AIs will only add random deviation if they were a Random AI.

- Random deviation is no longer applied after selecting a script during a running game.

- "startai" console command applies random deviation depending on the number of arguments:
  - 0 arguments - Only if the slot config is Random AI.
  - 1 argument - Always, no parameters were provided.
  - 2 arguments - Never, user provided parameters.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
There's a partial revert of #11958 regarding GUI and #11944 regarding when random deviation is applied. This is done this way to make "restart current" reproducibility without necessitating a backup.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
