### PR TITLE
Fix 5a88027: [Script] Avoid overflow in scripts when infinite money is enabled

### DIFF
--- a/src/script/api/script_company.cpp
+++ b/src/script/api/script_company.cpp
@@ -178,6 +178,8 @@
 {
 	company = ResolveCompanyID(company);
 	if (company == COMPANY_INVALID) return -1;
+	/* If we return INT64_MAX as usual, overflows may occur in the script. So return a smaller value. */
+	if (_settings_game.difficulty.infinite_money) return INT32_MAX;
 
 	return GetAvailableMoney((::CompanyID)company);
 }

--- a/src/script/api/script_company.hpp
+++ b/src/script/api/script_company.hpp
@@ -258,9 +258,10 @@ public:
 
 	/**
 	 * Gets the bank balance. In other words, the amount of money the given company can spent.
+	 * If infinite money is enabled, it returns INT32_MAX.
 	 * @param company The company to get the bank balance of.
 	 * @pre ResolveCompanyID(company) != COMPANY_INVALID.
-	 * @return The actual bank balance.
+	 * @return The actual bank balance or INT32_MAX.
 	 */
 	static Money GetBankBalance(CompanyID company);
 


### PR DESCRIPTION
## Motivation / Problem
Infinite money mode as implemented in #11902 causes the script API's bank balance function to return `INT64_MAX`. When scripts do calculations with this value, overflows are likely to occur, since they do not use an overflow-proof data type to handle money.


## Description
Return `INT32_MAX` instead.


## Limitations
Scripts may think they don't have sufficient money to spend more than 2147483647 units of currency at a time.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
