### PR TITLE
Codechange: also store the sending socket in Packets

### DIFF
--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -53,7 +53,7 @@ private:
 
 public:
 	Packet(NetworkSocketHandler *cs, size_t limit, size_t initial_read_size = sizeof(PacketSize));
-	Packet(PacketType type, size_t limit = COMPAT_MTU);
+	Packet(NetworkSocketHandler *cs, PacketType type, size_t limit = COMPAT_MTU);
 
 	/* Sending/writing of packets */
 	void PrepareToSend();

--- a/src/network/core/tcp_listen.h
+++ b/src/network/core/tcp_listen.h
@@ -35,7 +35,7 @@ public:
 		/* Check if the client is banned. */
 		for (const auto &entry : _network_ban_list) {
 			if (address.IsInNetmask(entry)) {
-				Packet p(Tban_packet);
+				Packet p(nullptr, Tban_packet);
 				p.PrepareToSend();
 
 				Debug(net, 2, "[{}] Banned ip tried to join ({}), refused", Tsocket::GetName(), entry);
@@ -52,7 +52,7 @@ public:
 		if (!Tsocket::AllowConnection()) {
 			/* No more clients allowed?
 			 * Send to the client that we are full! */
-			Packet p(Tfull_packet);
+			Packet p(nullptr, Tfull_packet);
 			p.PrepareToSend();
 
 			if (p.TransferOut<int>(send, s, 0) < 0) {

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -134,7 +134,7 @@ ServerNetworkAdminSocketHandler::~ServerNetworkAdminSocketHandler()
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendError(NetworkErrorCode error)
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_ERROR);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_ERROR);
 
 	p->Send_uint8(error);
 	this->SendPacket(std::move(p));
@@ -149,7 +149,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendError(NetworkErrorCode er
 /** Send the protocol version to the admin. */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendProtocol()
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_PROTOCOL);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_PROTOCOL);
 
 	/* announce the protocol version */
 	p->Send_uint8(NETWORK_GAME_ADMIN_VERSION);
@@ -169,7 +169,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendProtocol()
 /** Send a welcome message to the admin. */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendWelcome()
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_WELCOME);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_WELCOME);
 
 	p->Send_string(_settings_client.network.server_name);
 	p->Send_string(GetNetworkRevisionString());
@@ -190,7 +190,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendWelcome()
 /** Tell the admin we started a new game. */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendNewGame()
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_NEWGAME);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_NEWGAME);
 	this->SendPacket(std::move(p));
 	return NETWORK_RECV_STATUS_OKAY;
 }
@@ -198,7 +198,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendNewGame()
 /** Tell the admin we're shutting down. */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendShutdown()
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_SHUTDOWN);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_SHUTDOWN);
 	this->SendPacket(std::move(p));
 	return NETWORK_RECV_STATUS_OKAY;
 }
@@ -206,7 +206,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendShutdown()
 /** Tell the admin the date. */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendDate()
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_DATE);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_DATE);
 
 	p->Send_uint32(TimerGameCalendar::date.base());
 	this->SendPacket(std::move(p));
@@ -220,7 +220,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendDate()
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientJoin(ClientID client_id)
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_CLIENT_JOIN);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CLIENT_JOIN);
 
 	p->Send_uint32(client_id);
 	this->SendPacket(std::move(p));
@@ -238,7 +238,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientInfo(const NetworkC
 	/* Only send data when we're a proper client, not just someone trying to query the server. */
 	if (ci == nullptr) return NETWORK_RECV_STATUS_OKAY;
 
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_CLIENT_INFO);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CLIENT_INFO);
 
 	p->Send_uint32(ci->client_id);
 	p->Send_string(cs == nullptr ? "" : const_cast<NetworkAddress &>(cs->client_address).GetHostname());
@@ -259,7 +259,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientInfo(const NetworkC
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientUpdate(const NetworkClientInfo *ci)
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_CLIENT_UPDATE);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CLIENT_UPDATE);
 
 	p->Send_uint32(ci->client_id);
 	p->Send_string(ci->client_name);
@@ -276,7 +276,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientUpdate(const Networ
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientQuit(ClientID client_id)
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_CLIENT_QUIT);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CLIENT_QUIT);
 
 	p->Send_uint32(client_id);
 	this->SendPacket(std::move(p));
@@ -291,7 +291,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientQuit(ClientID clien
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientError(ClientID client_id, NetworkErrorCode error)
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_CLIENT_ERROR);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CLIENT_ERROR);
 
 	p->Send_uint32(client_id);
 	p->Send_uint8 (error);
@@ -306,7 +306,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientError(ClientID clie
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyNew(CompanyID company_id)
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_COMPANY_NEW);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_COMPANY_NEW);
 	p->Send_uint8(company_id);
 
 	this->SendPacket(std::move(p));
@@ -320,7 +320,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyNew(CompanyID comp
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyInfo(const Company *c)
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_COMPANY_INFO);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_COMPANY_INFO);
 
 	p->Send_uint8 (c->index);
 	SetDParam(0, c->index);
@@ -345,7 +345,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyInfo(const Company
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyUpdate(const Company *c)
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_COMPANY_UPDATE);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_COMPANY_UPDATE);
 
 	p->Send_uint8 (c->index);
 	SetDParam(0, c->index);
@@ -368,7 +368,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyUpdate(const Compa
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyRemove(CompanyID company_id, AdminCompanyRemoveReason acrr)
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_COMPANY_REMOVE);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_COMPANY_REMOVE);
 
 	p->Send_uint8(company_id);
 	p->Send_uint8(acrr);
@@ -385,7 +385,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyEconomy()
 		/* Get the income. */
 		Money income = -std::reduce(std::begin(company->yearly_expenses[0]), std::end(company->yearly_expenses[0]));
 
-		auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_COMPANY_ECONOMY);
+		auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_COMPANY_ECONOMY);
 
 		p->Send_uint8(company->index);
 
@@ -418,7 +418,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyStats()
 
 	/* Go through all the companies. */
 	for (const Company *company : Company::Iterate()) {
-		auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_COMPANY_STATS);
+		auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_COMPANY_STATS);
 
 		/* Send the information. */
 		p->Send_uint8(company->index);
@@ -447,7 +447,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyStats()
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendChat(NetworkAction action, DestType desttype, ClientID client_id, const std::string &msg, int64_t data)
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_CHAT);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CHAT);
 
 	p->Send_uint8 (action);
 	p->Send_uint8 (desttype);
@@ -465,7 +465,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendChat(NetworkAction action
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendRconEnd(const std::string_view command)
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_RCON_END);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_RCON_END);
 
 	p->Send_string(command);
 	this->SendPacket(std::move(p));
@@ -480,7 +480,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendRconEnd(const std::string
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendRcon(uint16_t colour, const std::string_view result)
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_RCON);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_RCON);
 
 	p->Send_uint16(colour);
 	p->Send_string(result);
@@ -539,7 +539,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendConsole(const std::string
 	 * smaller than COMPAT_MTU. */
 	if (origin.size() + string.size() + 2 + 3 >= COMPAT_MTU) return NETWORK_RECV_STATUS_OKAY;
 
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_CONSOLE);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CONSOLE);
 
 	p->Send_string(origin);
 	p->Send_string(string);
@@ -554,7 +554,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendConsole(const std::string
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendGameScript(const std::string_view json)
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_GAMESCRIPT);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_GAMESCRIPT);
 
 	p->Send_string(json);
 	this->SendPacket(std::move(p));
@@ -565,7 +565,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendGameScript(const std::str
 /** Send ping-reply (pong) to admin **/
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendPong(uint32_t d1)
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_PONG);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_PONG);
 
 	p->Send_uint32(d1);
 	this->SendPacket(std::move(p));
@@ -576,7 +576,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendPong(uint32_t d1)
 /** Send the names of the commands. */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCmdNames()
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_CMD_NAMES);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CMD_NAMES);
 
 	for (uint16_t i = 0; i < CMD_END; i++) {
 		const char *cmdname = GetCommandName(static_cast<Commands>(i));
@@ -588,7 +588,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCmdNames()
 			p->Send_bool(false);
 			this->SendPacket(std::move(p));
 
-			p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_CMD_NAMES);
+			p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CMD_NAMES);
 		}
 
 		p->Send_bool(true);
@@ -610,7 +610,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCmdNames()
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCmdLogging(ClientID client_id, const CommandPacket &cp)
 {
-	auto p = std::make_unique<Packet>(ADMIN_PACKET_SERVER_CMD_LOGGING);
+	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CMD_LOGGING);
 
 	p->Send_uint32(client_id);
 	p->Send_uint8 (cp.company);

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -344,7 +344,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendJoin()
 	_network_join_status = NETWORK_JOIN_STATUS_AUTHORIZING;
 	SetWindowDirty(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN);
 
-	auto p = std::make_unique<Packet>(PACKET_CLIENT_JOIN);
+	auto p = std::make_unique<Packet>(my_client, PACKET_CLIENT_JOIN);
 	p->Send_string(GetNetworkRevisionString());
 	p->Send_uint32(_openttd_newgrf_version);
 	p->Send_string(_settings_client.network.client_name); // Client name
@@ -359,7 +359,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendNewGRFsOk()
 {
 	Debug(net, 9, "Client::SendNewGRFsOk()");
 
-	auto p = std::make_unique<Packet>(PACKET_CLIENT_NEWGRFS_CHECKED);
+	auto p = std::make_unique<Packet>(my_client, PACKET_CLIENT_NEWGRFS_CHECKED);
 	my_client->SendPacket(std::move(p));
 	return NETWORK_RECV_STATUS_OKAY;
 }
@@ -372,7 +372,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendGamePassword(const std::st
 {
 	Debug(net, 9, "Client::SendGamePassword()");
 
-	auto p = std::make_unique<Packet>(PACKET_CLIENT_GAME_PASSWORD);
+	auto p = std::make_unique<Packet>(my_client, PACKET_CLIENT_GAME_PASSWORD);
 	p->Send_string(password);
 	my_client->SendPacket(std::move(p));
 	return NETWORK_RECV_STATUS_OKAY;
@@ -386,7 +386,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendCompanyPassword(const std:
 {
 	Debug(net, 9, "Client::SendCompanyPassword()");
 
-	auto p = std::make_unique<Packet>(PACKET_CLIENT_COMPANY_PASSWORD);
+	auto p = std::make_unique<Packet>(my_client, PACKET_CLIENT_COMPANY_PASSWORD);
 	p->Send_string(GenerateCompanyPasswordHash(password, _password_server_id, _password_game_seed));
 	my_client->SendPacket(std::move(p));
 	return NETWORK_RECV_STATUS_OKAY;
@@ -400,7 +400,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendGetMap()
 	Debug(net, 9, "Client::status = MAP_WAIT");
 	my_client->status = STATUS_MAP_WAIT;
 
-	auto p = std::make_unique<Packet>(PACKET_CLIENT_GETMAP);
+	auto p = std::make_unique<Packet>(my_client, PACKET_CLIENT_GETMAP);
 	my_client->SendPacket(std::move(p));
 	return NETWORK_RECV_STATUS_OKAY;
 }
@@ -413,7 +413,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendMapOk()
 	Debug(net, 9, "Client::status = ACTIVE");
 	my_client->status = STATUS_ACTIVE;
 
-	auto p = std::make_unique<Packet>(PACKET_CLIENT_MAP_OK);
+	auto p = std::make_unique<Packet>(my_client, PACKET_CLIENT_MAP_OK);
 	my_client->SendPacket(std::move(p));
 	return NETWORK_RECV_STATUS_OKAY;
 }
@@ -423,7 +423,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendAck()
 {
 	Debug(net, 9, "Client::SendAck()");
 
-	auto p = std::make_unique<Packet>(PACKET_CLIENT_ACK);
+	auto p = std::make_unique<Packet>(my_client, PACKET_CLIENT_ACK);
 
 	p->Send_uint32(_frame_counter);
 	p->Send_uint8 (my_client->token);
@@ -439,7 +439,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendCommand(const CommandPacke
 {
 	Debug(net, 9, "Client::SendCommand(): cmd={}", cp.cmd);
 
-	auto p = std::make_unique<Packet>(PACKET_CLIENT_COMMAND);
+	auto p = std::make_unique<Packet>(my_client, PACKET_CLIENT_COMMAND);
 	my_client->NetworkGameSocketHandler::SendCommand(*p, cp);
 
 	my_client->SendPacket(std::move(p));
@@ -451,7 +451,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendChat(NetworkAction action,
 {
 	Debug(net, 9, "Client::SendChat(): action={}, type={}, dest={}", action, type, dest);
 
-	auto p = std::make_unique<Packet>(PACKET_CLIENT_CHAT);
+	auto p = std::make_unique<Packet>(my_client, PACKET_CLIENT_CHAT);
 
 	p->Send_uint8 (action);
 	p->Send_uint8 (type);
@@ -468,7 +468,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendError(NetworkErrorCode err
 {
 	Debug(net, 9, "Client::SendError(): errorno={}", errorno);
 
-	auto p = std::make_unique<Packet>(PACKET_CLIENT_ERROR);
+	auto p = std::make_unique<Packet>(my_client, PACKET_CLIENT_ERROR);
 
 	p->Send_uint8(errorno);
 	my_client->SendPacket(std::move(p));
@@ -483,7 +483,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendSetPassword(const std::str
 {
 	Debug(net, 9, "Client::SendSetPassword()");
 
-	auto p = std::make_unique<Packet>(PACKET_CLIENT_SET_PASSWORD);
+	auto p = std::make_unique<Packet>(my_client, PACKET_CLIENT_SET_PASSWORD);
 
 	p->Send_string(GenerateCompanyPasswordHash(password, _password_server_id, _password_game_seed));
 	my_client->SendPacket(std::move(p));
@@ -498,7 +498,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendSetName(const std::string 
 {
 	Debug(net, 9, "Client::SendSetName()");
 
-	auto p = std::make_unique<Packet>(PACKET_CLIENT_SET_NAME);
+	auto p = std::make_unique<Packet>(my_client, PACKET_CLIENT_SET_NAME);
 
 	p->Send_string(name);
 	my_client->SendPacket(std::move(p));
@@ -512,7 +512,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendQuit()
 {
 	Debug(net, 9, "Client::SendSetName()");
 
-	auto p = std::make_unique<Packet>(PACKET_CLIENT_QUIT);
+	auto p = std::make_unique<Packet>(my_client, PACKET_CLIENT_QUIT);
 
 	my_client->SendPacket(std::move(p));
 	return NETWORK_RECV_STATUS_OKAY;
@@ -527,7 +527,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendRCon(const std::string &pa
 {
 	Debug(net, 9, "Client::SendRCon()");
 
-	auto p = std::make_unique<Packet>(PACKET_CLIENT_RCON);
+	auto p = std::make_unique<Packet>(my_client, PACKET_CLIENT_RCON);
 	p->Send_string(pass);
 	p->Send_string(command);
 	my_client->SendPacket(std::move(p));
@@ -543,7 +543,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendMove(CompanyID company, co
 {
 	Debug(net, 9, "Client::SendMove(): company={}", company);
 
-	auto p = std::make_unique<Packet>(PACKET_CLIENT_MOVE);
+	auto p = std::make_unique<Packet>(my_client, PACKET_CLIENT_MOVE);
 	p->Send_uint8(company);
 	p->Send_string(GenerateCompanyPasswordHash(password, _password_server_id, _password_game_seed));
 	my_client->SendPacket(std::move(p));

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -204,7 +204,7 @@ void ClientNetworkContentSocketHandler::RequestContentList(ContentType type)
 
 	this->Connect();
 
-	auto p = std::make_unique<Packet>(PACKET_CONTENT_CLIENT_INFO_LIST);
+	auto p = std::make_unique<Packet>(this, PACKET_CONTENT_CLIENT_INFO_LIST);
 	p->Send_uint8 ((byte)type);
 	p->Send_uint32(0xffffffff);
 	p->Send_uint8 (1);
@@ -240,7 +240,7 @@ void ClientNetworkContentSocketHandler::RequestContentList(uint count, const Con
 		 * The rest of the packet can be used for the IDs. */
 		uint p_count = std::min<uint>(count, (TCP_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint16_t)) / sizeof(uint32_t));
 
-		auto p = std::make_unique<Packet>(PACKET_CONTENT_CLIENT_INFO_ID, TCP_MTU);
+		auto p = std::make_unique<Packet>(this, PACKET_CONTENT_CLIENT_INFO_ID, TCP_MTU);
 		p->Send_uint16(p_count);
 
 		for (uint i = 0; i < p_count; i++) {
@@ -268,7 +268,7 @@ void ClientNetworkContentSocketHandler::RequestContentList(ContentVector *cv, bo
 	assert(cv->size() < (TCP_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint8_t)) /
 			(sizeof(uint8_t) + sizeof(uint32_t) + (send_md5sum ? MD5_HASH_BYTES : 0)));
 
-	auto p = std::make_unique<Packet>(send_md5sum ? PACKET_CONTENT_CLIENT_INFO_EXTID_MD5 : PACKET_CONTENT_CLIENT_INFO_EXTID, TCP_MTU);
+	auto p = std::make_unique<Packet>(this, send_md5sum ? PACKET_CONTENT_CLIENT_INFO_EXTID_MD5 : PACKET_CONTENT_CLIENT_INFO_EXTID, TCP_MTU);
 	p->Send_uint8((uint8_t)cv->size());
 
 	for (const ContentInfo *ci : *cv) {
@@ -365,7 +365,7 @@ void ClientNetworkContentSocketHandler::DownloadSelectedContentFallback(const Co
 		 * The rest of the packet can be used for the IDs. */
 		uint p_count = std::min<uint>(count, (TCP_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint16_t)) / sizeof(uint32_t));
 
-		auto p = std::make_unique<Packet>(PACKET_CONTENT_CLIENT_CONTENT, TCP_MTU);
+		auto p = std::make_unique<Packet>(this, PACKET_CONTENT_CLIENT_CONTENT, TCP_MTU);
 		p->Send_uint16(p_count);
 
 		for (uint i = 0; i < p_count; i++) {

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -458,7 +458,7 @@ void ClientNetworkCoordinatorSocketHandler::Register()
 
 	this->Connect();
 
-	auto p = std::make_unique<Packet>(PACKET_COORDINATOR_SERVER_REGISTER);
+	auto p = std::make_unique<Packet>(this, PACKET_COORDINATOR_SERVER_REGISTER);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_uint8(_settings_client.network.server_game_type);
 	p->Send_uint16(_settings_client.network.server_port);
@@ -480,7 +480,7 @@ void ClientNetworkCoordinatorSocketHandler::SendServerUpdate()
 {
 	Debug(net, 6, "Sending server update to Game Coordinator");
 
-	auto p = std::make_unique<Packet>(PACKET_COORDINATOR_SERVER_UPDATE, TCP_MTU);
+	auto p = std::make_unique<Packet>(this, PACKET_COORDINATOR_SERVER_UPDATE, TCP_MTU);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	SerializeNetworkGameInfo(*p, GetCurrentNetworkServerGameInfo(), this->next_update.time_since_epoch() != std::chrono::nanoseconds::zero());
 
@@ -498,7 +498,7 @@ void ClientNetworkCoordinatorSocketHandler::GetListing()
 
 	_network_game_list_version++;
 
-	auto p = std::make_unique<Packet>(PACKET_COORDINATOR_CLIENT_LISTING);
+	auto p = std::make_unique<Packet>(this, PACKET_COORDINATOR_CLIENT_LISTING);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_uint8(NETWORK_GAME_INFO_VERSION);
 	p->Send_string(_openttd_revision);
@@ -530,7 +530,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectToServer(const std::string &i
 
 	this->Connect();
 
-	auto p = std::make_unique<Packet>(PACKET_COORDINATOR_CLIENT_CONNECT);
+	auto p = std::make_unique<Packet>(this, PACKET_COORDINATOR_CLIENT_CONNECT);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_string(invite_code);
 
@@ -547,7 +547,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectFailure(const std::string &to
 	/* Connecter will destroy itself. */
 	this->game_connecter = nullptr;
 
-	auto p = std::make_unique<Packet>(PACKET_COORDINATOR_SERCLI_CONNECT_FAILED);
+	auto p = std::make_unique<Packet>(this, PACKET_COORDINATOR_SERCLI_CONNECT_FAILED);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_string(token);
 	p->Send_uint8(tracking_number);
@@ -578,7 +578,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectSuccess(const std::string &to
 	} else {
 		/* The client informs the Game Coordinator about the success. The server
 		 * doesn't have to, as it is implied by the client telling. */
-		auto p = std::make_unique<Packet>(PACKET_COORDINATOR_CLIENT_CONNECTED);
+		auto p = std::make_unique<Packet>(this, PACKET_COORDINATOR_CLIENT_CONNECTED);
 		p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 		p->Send_string(token);
 		this->SendPacket(std::move(p));
@@ -606,7 +606,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectSuccess(const std::string &to
  */
 void ClientNetworkCoordinatorSocketHandler::StunResult(const std::string &token, uint8_t family, bool result)
 {
-	auto p = std::make_unique<Packet>(PACKET_COORDINATOR_SERCLI_STUN_RESULT);
+	auto p = std::make_unique<Packet>(this, PACKET_COORDINATOR_SERCLI_STUN_RESULT);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_string(token);
 	p->Send_uint8(family);

--- a/src/network/network_query.cpp
+++ b/src/network/network_query.cpp
@@ -83,7 +83,7 @@ NetworkRecvStatus QueryNetworkGameSocketHandler::SendGameInfo()
 {
 	Debug(net, 9, "Query::SendGameInfo()");
 
-	this->SendPacket(std::make_unique<Packet>(PACKET_CLIENT_GAME_INFO));
+	this->SendPacket(std::make_unique<Packet>(this, PACKET_CLIENT_GAME_INFO));
 	return NETWORK_RECV_STATUS_OKAY;
 }
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -116,10 +116,9 @@ struct PacketWriter : SaveFilter {
 	/**
 	 * Transfer all packets from here to the network's queue while holding
 	 * the lock on our mutex.
-	 * @param socket The network socket to write to.
 	 * @return True iff the last packet of the map has been sent.
 	 */
-	bool TransferToNetworkQueue(ServerNetworkGameSocketHandler *socket)
+	bool TransferToNetworkQueue()
 	{
 		/* Unsafe check for the queue being empty or not. */
 		if (this->packets.empty()) return false;
@@ -128,7 +127,7 @@ struct PacketWriter : SaveFilter {
 
 		while (!this->packets.empty()) {
 			bool last_packet = this->packets.front()->GetPacketType() == PACKET_SERVER_MAP_DONE;
-			socket->SendPacket(std::move(this->packets.front()));
+			this->cs->SendPacket(std::move(this->packets.front()));
 			this->packets.pop_front();
 
 			if (last_packet) return true;
@@ -577,7 +576,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendMap()
 	}
 
 	if (this->status == STATUS_MAP) {
-		bool last_packet = this->savegame->TransferToNetworkQueue(this);
+		bool last_packet = this->savegame->TransferToNetworkQueue();
 		if (last_packet) {
 			Debug(net, 9, "client[{}] SendMap(): last_packet", this->client_id);
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -138,12 +138,12 @@ struct PacketWriter : SaveFilter {
 
 	void Write(byte *buf, size_t size) override
 	{
+		std::lock_guard<std::mutex> lock(this->mutex);
+
 		/* We want to abort the saving when the socket is closed. */
 		if (this->cs == nullptr) SlError(STR_NETWORK_ERROR_LOSTCONNECTION);
 
 		if (this->current == nullptr) this->current = std::make_unique<Packet>(PACKET_SERVER_MAP_DATA, TCP_MTU);
-
-		std::lock_guard<std::mutex> lock(this->mutex);
 
 		byte *bufe = buf + size;
 		while (buf != bufe) {
@@ -161,10 +161,10 @@ struct PacketWriter : SaveFilter {
 
 	void Finish() override
 	{
+		std::lock_guard<std::mutex> lock(this->mutex);
+
 		/* We want to abort the saving when the socket is closed. */
 		if (this->cs == nullptr) SlError(STR_NETWORK_ERROR_LOSTCONNECTION);
-
-		std::lock_guard<std::mutex> lock(this->mutex);
 
 		/* Make sure the last packet is flushed. */
 		if (this->current != nullptr) this->packets.push_back(std::move(this->current));

--- a/src/network/network_stun.cpp
+++ b/src/network/network_stun.cpp
@@ -92,7 +92,7 @@ std::unique_ptr<ClientNetworkStunSocketHandler> ClientNetworkStunSocketHandler::
 
 	stun_handler->Connect(token, family);
 
-	auto p = std::make_unique<Packet>(PACKET_STUN_SERCLI_STUN);
+	auto p = std::make_unique<Packet>(stun_handler.get(), PACKET_STUN_SERCLI_STUN);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_string(token);
 	p->Send_uint8(family);

--- a/src/network/network_turn.cpp
+++ b/src/network/network_turn.cpp
@@ -100,7 +100,7 @@ void ClientNetworkTurnSocketHandler::Connect()
 {
 	auto turn_handler = std::make_unique<ClientNetworkTurnSocketHandler>(token, tracking_number, connection_string);
 
-	auto p = std::make_unique<Packet>(PACKET_TURN_SERCLI_CONNECT);
+	auto p = std::make_unique<Packet>(turn_handler.get(), PACKET_TURN_SERCLI_CONNECT);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_string(ticket);
 

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -75,7 +75,7 @@ public:
 
 void ServerNetworkUDPSocketHandler::Receive_CLIENT_FIND_SERVER(Packet &, NetworkAddress &client_addr)
 {
-	Packet packet(PACKET_UDP_SERVER_RESPONSE);
+	Packet packet(this, PACKET_UDP_SERVER_RESPONSE);
 	this->SendPacket(packet, client_addr);
 
 	Debug(net, 7, "Queried from {}", client_addr.GetHostname());
@@ -104,7 +104,7 @@ static void NetworkUDPBroadCast(NetworkUDPSocketHandler *socket)
 	for (NetworkAddress &addr : _broadcast_list) {
 		Debug(net, 5, "Broadcasting to {}", addr.GetHostname());
 
-		Packet p(PACKET_UDP_CLIENT_FIND_SERVER);
+		Packet p(socket, PACKET_UDP_CLIENT_FIND_SERVER);
 		socket->SendPacket(p, addr, true, true);
 	}
 }


### PR DESCRIPTION
## Motivation / Problem

When adding encryption to our network packets, we need to add a "message authentication code" (MAC) data to the packet. This will take up some space if/when the packet gets encrypted.
Since some packets are filled up to the maximum size, before continuing to the next packet, the allocation for the MAC needs to be made when the packet is created. For this it needs to know whether the encryption is enabled on the socket.

There are multiple ways of achieving this:
* adding a `boolean` to the constructor, and then add checks to the socket handler at each of the call sites.
* adding the socket handler to the constructor.

When adding the `boolean` to the constructor you still need to pass the socket handler in `PrepareToSend` and you need to add some state whether the encryption has been added to the packet as well.
When passing the socket handler, it can be put in the already existing field for the socket handler and it can be set to `nullptr` in case encryption is not needed any more, saving a bit of space.

Note that adding encryption will be a post-14-branch endeavour. However, having this infrastructure available in the 14 branch makes it easier to backport any network changes that are not related with the encryption/key exchange.


## Description

`TransferToNetworkQueue` has a socket as parameter, but that is always equals to `this->cs` except when the server already closed the connection. Though then you would not be copying packets to the network queue.

The `PacketWriter`, that writes the network "map" packets during saving the game, reads and writes some instance variables that are accessed in other places within a lock. Either it is for allocating memory based on the variable being `nullptr`, or it is for checking the connection got closed. In case of the former that could technically be a problem when doing multiple simultaneous calls. In the latter case you could check for `nullptr`, then wait on the lock that `Destroy` has done and still do the expensive work. Moving it here just avoids that problem, for a tiny penalty when the socket got closed during download, though arguably that should be happening that often.

The last commit finally adds the socket to the packet's constructor. Except for some error messages that are sent before we even create the socket handler.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
