### PR TITLE
Fix #12019, #12020: Depot unbunching dropdown issues

### DIFF
--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1389,13 +1389,14 @@ CommandCost CmdModifyOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID se
 					case DA_SERVICE:
 						order->SetDepotOrderType((OrderDepotTypeFlags)(order->GetDepotOrderType() | ODTFB_SERVICE));
 						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() & ~ODATFB_HALT));
+						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() & ~ODATFB_UNBUNCH));
 						order->SetRefit(CARGO_NO_REFIT);
 						break;
 
 					case DA_STOP:
 						order->SetDepotOrderType((OrderDepotTypeFlags)(order->GetDepotOrderType() & ~ODTFB_SERVICE));
-						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() & ~ODATFB_UNBUNCH));
 						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() | ODATFB_HALT));
+						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() & ~ODATFB_UNBUNCH));
 						order->SetRefit(CARGO_NO_REFIT);
 						break;
 

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -194,6 +194,8 @@ static int DepotActionStringIndex(const Order *order)
 		return DA_STOP;
 	} else if (order->GetDepotOrderType() & ODTFB_SERVICE) {
 		return DA_SERVICE;
+	} else if (order->GetDepotActionType() & ODATFB_UNBUNCH) {
+		return DA_UNBUNCH;
 	} else {
 		return DA_ALWAYS_GO;
 	}


### PR DESCRIPTION
## Motivation / Problem

1. #12019: The dropdown to select order type for a go to depot order should highlight the current order type, ie. if it's a "Stop" order then "Stop" should be highlighted, if it's a "Wait to unbunch" order then "Unbunch" should be highlighted.
2. #12020: An "Unbunch" depot order type should be mutually exclusive with all other depot order types ("Always go", "Service if needed" and "Stop").

## Description

1. Properly highlight the Unbunch option in dropdown menus, if selected for the current depot. 
2. When changing the depot action from Unbunch to Service if required, unset the Unbunch action flag. 

Closes #12019.
Closes #12020.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
