### PR TITLE
Fix: Don't issue autoreplace failed news message for command test mode.

### DIFF
--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -315,9 +315,10 @@ static CommandCost GetNewEngineType(const Vehicle *v, const Company *c, bool alw
  * @param old_veh A single (articulated/multiheaded) vehicle that shall be replaced.
  * @param new_vehicle Returns the newly build and refitted vehicle
  * @param part_of_chain The vehicle is part of a train
+ * @param flags The calling command flags.
  * @return cost or error
  */
-static CommandCost BuildReplacementVehicle(Vehicle *old_veh, Vehicle **new_vehicle, bool part_of_chain)
+static CommandCost BuildReplacementVehicle(Vehicle *old_veh, Vehicle **new_vehicle, bool part_of_chain, DoCommandFlag flags)
 {
 	*new_vehicle = nullptr;
 
@@ -331,7 +332,7 @@ static CommandCost BuildReplacementVehicle(Vehicle *old_veh, Vehicle **new_vehic
 	/* Does it need to be refitted */
 	CargoID refit_cargo = GetNewCargoTypeForReplace(old_veh, e, part_of_chain);
 	if (!IsValidCargoID(refit_cargo)) {
-		if (!IsLocalCompany()) return CommandCost();
+		if (!IsLocalCompany() || (flags & DC_EXEC) == 0) return CommandCost();
 
 		SetDParam(0, old_veh->index);
 
@@ -455,7 +456,7 @@ static CommandCost ReplaceFreeUnit(Vehicle **single_unit, DoCommandFlag flags, b
 
 	/* Build and refit replacement vehicle */
 	Vehicle *new_v = nullptr;
-	cost.AddCost(BuildReplacementVehicle(old_v, &new_v, false));
+	cost.AddCost(BuildReplacementVehicle(old_v, &new_v, false, flags));
 
 	/* Was a new vehicle constructed? */
 	if (cost.Succeeded() && new_v != nullptr) {
@@ -531,7 +532,7 @@ static CommandCost ReplaceChain(Vehicle **chain, DoCommandFlag flags, bool wagon
 		for (Train *w = Train::From(old_head); w != nullptr; w = w->GetNextUnit()) {
 			ReplaceChainItem &replacement = replacements.emplace_back(w, nullptr, 0);
 
-			CommandCost ret = BuildReplacementVehicle(replacement.old_veh, &replacement.new_veh, true);
+			CommandCost ret = BuildReplacementVehicle(replacement.old_veh, &replacement.new_veh, true, flags);
 			cost.AddCost(ret);
 			if (cost.Failed()) break;
 
@@ -688,7 +689,7 @@ static CommandCost ReplaceChain(Vehicle **chain, DoCommandFlag flags, bool wagon
 	} else {
 		/* Build and refit replacement vehicle */
 		Vehicle *new_head = nullptr;
-		cost.AddCost(BuildReplacementVehicle(old_head, &new_head, true));
+		cost.AddCost(BuildReplacementVehicle(old_head, &new_head, true, flags));
 
 		/* Was a new vehicle constructed? */
 		if (cost.Succeeded() && new_head != nullptr) {


### PR DESCRIPTION
## Motivation / Problem

`BuildReplacementVehicle()` issues a news message on failure, even if the action is a command test. This means that clicking on the "Autoreplace all vehicles in the depot" button will produce multiple news messages for the same issue.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/06e6c255-a2a1-4ad0-85c7-19fd943fe082)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Pass the caller's `DoCommandFlags` to `BuildReplacementVehicle()` and only issue a news message when DC_EXEC is set.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/9384b101-d80f-4b8e-ace8-18f2c44c9faf)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
