### PR TITLE
Revert: Build signals to the next junction when dragging regardless of the Ctrl state

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1923,7 +1923,7 @@ STR_CONFIG_SETTING_DRAG_SIGNALS_DENSITY                         :When dragging, 
 STR_CONFIG_SETTING_DRAG_SIGNALS_DENSITY_HELPTEXT                :Set the distance at which signals will be built on a track up to the next obstacle (signal, junction), if signals are dragged
 STR_CONFIG_SETTING_DRAG_SIGNALS_DENSITY_VALUE                   :{COMMA} tile{P 0 "" s}
 STR_CONFIG_SETTING_DRAG_SIGNALS_FIXED_DISTANCE                  :When dragging, keep fixed distance between signals: {STRING2}
-STR_CONFIG_SETTING_DRAG_SIGNALS_FIXED_DISTANCE_HELPTEXT         :Select the behaviour of signal placement when dragging signals. If disabled, signals are placed around tunnels or bridges to avoid long stretches without signals. If enabled, signals are placed every n tiles, making alignment of signals at parallel tracks easier
+STR_CONFIG_SETTING_DRAG_SIGNALS_FIXED_DISTANCE_HELPTEXT         :Select the behaviour of signal placement when Ctrl+dragging signals. If disabled, signals are placed around tunnels or bridges to avoid long stretches without signals. If enabled, signals are placed every n tiles, making alignment of signals at parallel tracks easier
 
 STR_CONFIG_SETTING_SEMAPHORE_BUILD_BEFORE_DATE                  :Automatically build semaphores before: {STRING2}
 STR_CONFIG_SETTING_SEMAPHORE_BUILD_BEFORE_DATE_HELPTEXT         :Set the year when electric signals will be used for tracks. Before this year, non-electric signals will be used (which have the exact same function, but different looks)
@@ -2788,7 +2788,7 @@ STR_RAIL_TOOLBAR_TOOLTIP_BUILD_AUTORAIL                         :{BLACK}Build ra
 STR_RAIL_TOOLBAR_TOOLTIP_BUILD_TRAIN_DEPOT_FOR_BUILDING         :{BLACK}Build train depot (for buying and servicing trains). Also press Shift to show cost estimate only
 STR_RAIL_TOOLBAR_TOOLTIP_CONVERT_RAIL_TO_WAYPOINT               :{BLACK}Build waypoint on railway. Ctrl+Click to select another waypoint to join. Also press Shift to show cost estimate only
 STR_RAIL_TOOLBAR_TOOLTIP_BUILD_RAILROAD_STATION                 :{BLACK}Build railway station. Ctrl+Click to select another station to join. Also press Shift to show cost estimate only
-STR_RAIL_TOOLBAR_TOOLTIP_BUILD_RAILROAD_SIGNALS                 :{BLACK}Build signal on railway. Ctrl+Click to build the alternate signal style{}Click+Drag to fill signals up to the next junction, station, or signal. Also press Shift to show cost estimate only
+STR_RAIL_TOOLBAR_TOOLTIP_BUILD_RAILROAD_SIGNALS                 :{BLACK}Build signal on railway. Ctrl+Click to build the alternate signal style{}Click+Drag to fill the selected section of rail with signals at the chosen spacing. Ctrl+Click+Drag to fill signals up to the next junction, station, or signal. Also press Shift to show cost estimate only
 STR_RAIL_TOOLBAR_TOOLTIP_BUILD_RAILROAD_BRIDGE                  :{BLACK}Build railway bridge. Also press Shift to show cost estimate only
 STR_RAIL_TOOLBAR_TOOLTIP_BUILD_RAILROAD_TUNNEL                  :{BLACK}Build railway tunnel. Also press Shift to show cost estimate only
 STR_RAIL_TOOLBAR_TOOLTIP_TOGGLE_BUILD_REMOVE_FOR                :{BLACK}Toggle build/remove for railway track, signals, waypoints and stations. Ctrl+Click to also remove the rail of waypoints and stations

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -1450,7 +1450,7 @@ static CommandCost CmdSignalTrackHelper(DoCommandFlag flags, TileIndex tile, Til
  * @param sigtype default signal type
  * @param sigvar signal variant to build
  * @param mode true = override signal/semaphore, or pre/exit/combo signal (CTRL-toggle)
- * @param autofill fill beyond selected stretch? (currently always true but keep the command parameter so network-compatible patch packs can restore this functionality).
+ * @param autofill fill beyond selected stretch?
  * @param minimise_gaps false = keep fixed distance, true = minimise gaps between signals
  * @param signal_density user defined signals_density
  * @return the cost of this operation or an error
@@ -1530,7 +1530,7 @@ CommandCost CmdRemoveSingleSignal(DoCommandFlag flags, TileIndex tile, Track tra
  * @param tile start tile of drag
  * @param end_tile end tile of drag
  * @param track track-orientation
- * @param autofill fill beyond selected stretch? (currently always true but keep the command parameter so network-compatible patch packs can restore this functionality).
+ * @param autofill fill beyond selected stretch?
  * @return the cost of this operation or an error
  * @see CmdSignalTrackHelper
  */

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -413,13 +413,13 @@ static void HandleAutoSignalPlacement()
 	 * in a network game can specify their own signal density */
 	if (_remove_button_clicked) {
 		Command<CMD_REMOVE_SIGNAL_TRACK>::Post(STR_ERROR_CAN_T_REMOVE_SIGNALS_FROM, CcPlaySound_CONSTRUCTION_RAIL,
-				TileVirtXY(_thd.selstart.x, _thd.selstart.y), TileVirtXY(_thd.selend.x, _thd.selend.y), track, true);
+				TileVirtXY(_thd.selstart.x, _thd.selstart.y), TileVirtXY(_thd.selend.x, _thd.selend.y), track, _ctrl_pressed);
 	} else {
 		bool sig_gui = FindWindowById(WC_BUILD_SIGNAL, 0) != nullptr;
 		SignalType sigtype = sig_gui ? _cur_signal_type : _settings_client.gui.default_signal_type;
 		SignalVariant sigvar = sig_gui ? _cur_signal_variant : (TimerGameCalendar::year < _settings_client.gui.semaphore_build_before ? SIG_SEMAPHORE : SIG_ELECTRIC);
 		Command<CMD_BUILD_SIGNAL_TRACK>::Post(STR_ERROR_CAN_T_BUILD_SIGNALS_HERE, CcPlaySound_CONSTRUCTION_RAIL,
-				TileVirtXY(_thd.selstart.x, _thd.selstart.y), TileVirtXY(_thd.selend.x, _thd.selend.y), track, sigtype, sigvar, false, true, !_settings_client.gui.drag_signals_fixed_distance, _settings_client.gui.drag_signals_density);
+				TileVirtXY(_thd.selstart.x, _thd.selstart.y), TileVirtXY(_thd.selend.x, _thd.selend.y), track, sigtype, sigvar, false, _ctrl_pressed, !_settings_client.gui.drag_signals_fixed_distance, _settings_client.gui.drag_signals_density);
 	}
 }
 


### PR DESCRIPTION
This reverts commit b370ae1212abdc97034a6b4b8a2dffcffa1911f0 and #9637.

## Motivation / Problem

Honestly, the idea of the PR is solid. Just the execution is confusing to any existing player, and basically alienates them. I think what has been missed in #9637 what this does to the current players. Let me explain a bit more.

When dragging signals it normally placed signals in the block that becomes white. Visually very clear what is going on. When holding CTRL it would continue to the next block. Nothing visually telling you that, but if you knew, you knew.

Now with #9637 we completely removed the non-CTRL and made the CTRL the default. Not an option, not a way to invert this behaviour, nothing. Which I am not against, except ....

There is no visual indicator that this is going on. So from a player perspective, I drag my signal for N tiles, and it does this all the way to the next junction. This is mostly confusing if you select OVER a junction: signals are not appearing now passed the junction.
Even worse, the "Length: " text still gives the suggestion it will do it for your selection. It is a lie :)

For new players, this most likely isn't the biggest problem, but for existing players this is just hostile. You don't understand what is going on, and no feedback is given what actually happens. This is because visually NOTHING changed. But the behaviour changed drastically.

Video to illustrate the frustration:

https://github.com/OpenTTD/OpenTTD/assets/1663690/43ad8290-80ab-40a3-8966-627ba281ae93

## Description

I think we need to take #9637 back to the drawing board. For example, a good solution might be to highlight all the track the signals will be placed on. Nothing more, nothing less. This makes it very clear what is going to happen. People might still disagree with the change, but at least visually there is a very clear indication that the behaviour changed, and how.

Another option might be to stop the highlighting after 3 tiles, to indicate it is going to auto-fill. Or show an icon to indicate auto-fill. Or basically ... ANYTHING, to show the behaviour is different.

Cheesing our way out, it could help to change the label "Length: NN" to "Till next junction", or something.

Yet another suggestion from Discord: add a button in the Signal GUI to enable/disable auto-fill.

But, as we are closing in on 14.0, I suggest we just revert the PR for now, so we can think about this in less of a rush, to find a better solution.

Again, I have nothing against the concept of #9637; I do about making a change we force upon everyone without having any visual indicators we did so :) Which makes this very different from changing a default setting, hiding signals by default, etc etc.

#12033 should be considered in the new solution too. For now, this closes #12033.

PS: what mostly tripped me up was trying to remove 2 signals on a rail; it removes all to the next junction, without telling me. I was confused. A lot :) Muscle memory is a tricky thing, especially when no visual conflict is created :)

https://github.com/OpenTTD/OpenTTD/assets/1663690/45cb1e10-ae4a-4807-b027-31c10a52f227

Again, visual indicator is the issue. Not the actual change :)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
