### PR TITLE
Cleanup: Remove unnecessary Trackdir casts

### DIFF
--- a/src/pathfinder/npf/npf.cpp
+++ b/src/pathfinder/npf/npf.cpp
@@ -323,7 +323,7 @@ static int32_t NPFWaterPathCost(AyStar *, AyStarNode *current, OpenListNode *par
 		cost += _settings_game.pf.npf.npf_buoy_penalty; // A small penalty for going over buoys
 	}
 
-	if (current->direction != NextTrackdir((Trackdir)parent->path.node.direction)) {
+	if (current->direction != NextTrackdir(parent->path.node.direction)) {
 		cost += _settings_game.pf.npf.npf_water_curve_penalty;
 	}
 
@@ -527,7 +527,7 @@ static int32_t NPFRailPathCost(AyStar *as, AyStarNode *current, OpenListNode *pa
 	cost += NPFSlopeCost(current);
 
 	/* Check for turns */
-	if (current->direction != NextTrackdir((Trackdir)parent->path.node.direction)) {
+	if (current->direction != NextTrackdir(parent->path.node.direction)) {
 		cost += _settings_game.pf.npf.npf_rail_curve_penalty;
 	}
 	/* TODO, with realistic acceleration, also the amount of straight track between
@@ -1321,7 +1321,7 @@ Track NPFTrainChooseTrack(const Train *v, bool &path_found, bool reserve_track, 
 
 	if (target != nullptr) {
 		target->tile = ftd.node.tile;
-		target->trackdir = (Trackdir)ftd.node.direction;
+		target->trackdir = ftd.node.direction;
 		target->okay = ftd.res_okay;
 	}
 


### PR DESCRIPTION
## Motivation / Problem

While poking around in pathfinder code (don't ask 😛) I found some unnecessary casts. `AyStarNode->direction` is already a `Trackdir`.

## Description

Remove the cast.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
