### PR TITLE
Change: Restore original width of spacers in main toolbars.

### DIFF
--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -1414,7 +1414,13 @@ public:
 				child_wid->current_x = child_wid->smallest_x;
 			}
 		}
-		_toolbar_width = nbuttons * this->smallest_x;
+
+		/* Exclude the switcher button which is not displayed when the toolbar fits the screen. When the switch is
+		 * displayed there will be no spacers anyway. */
+		--nbuttons;
+
+		/* Allow space for all buttons, and include spacers at quarter the width of buttons. */
+		_toolbar_width = nbuttons * this->smallest_x + this->spacers * this->smallest_x / 4;
 	}
 
 	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override


### PR DESCRIPTION
## Motivation / Problem

Over time we've added more buttons to the toolbar, which has reduced the width of the spacers. However, the toolbar itself is not actually fixed width, so I looked into how the width of the spacers are determined.

And I found that they only have space due to a bug.

Width for all spacers is included only due to an off-by-one from counting buttons and not excluding the normally hidden switcher buttons—so all spacers fit into the size of a single button, and they're barely visible now.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/f923a312-49f4-4d08-9d56-8ae7b0566c79)


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, exclude the switcher button from the button count, and include spacer width of half the button width is now included explicitly. This width was chosen to match original TTD, although it's not exact as that varies between 11 or 12 pixels.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/db84edae-5f84-481c-9595-109b498a7893)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

We're all probably used to the narrow spacers by now...
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
