### PR TITLE
Fix #12037: Blurry OpenTTD font on Mac OS.

### DIFF
--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -263,8 +263,7 @@ const Sprite *CoreTextFontCache::InternalGetGlyph(GlyphID key, bool use_aa)
 		CGContextSetAllowsFontSubpixelQuantization(context.get(), !use_aa);
 		CGContextSetShouldSmoothFonts(context.get(), false);
 
-		float offset = 0.5f; // CoreText uses 0.5 as pixel centers. We want pixel alignment.
-		CGPoint pos{offset - bounds.origin.x, offset - bounds.origin.y};
+		CGPoint pos{-bounds.origin.x, -bounds.origin.y};
 		CTFontDrawGlyphs(this->font.get(), &glyph, &pos, 1, context.get());
 
 		/* Draw shadow for medium size. */


### PR DESCRIPTION
## Motivation / Problem

As per #12037, our custom OpenTTD font rendered on Mac OS is blurry whatever size is used. This seems to be caused by the 0.5 pixel offset preventing pixel-perfect edges.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Remove 0.5 pixel offset, intended to produce better font rendering results but causing our own OpenTTD to be rendered with blurry edges.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This might affect clarity of system fonts, but might not. We'll find out?
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
