### PR TITLE
Change: Draw north-edge fences at tile edge instead of 1/16th in.

### DIFF
--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -69,14 +69,14 @@ static void DrawClearLandFence(const TileInfo *ti)
 	if (fence_nw != 0) {
 		int z = GetSlopePixelZInCorner(ti->tileh, CORNER_W);
 		SpriteID sprite = _clear_land_fence_sprites[fence_nw - 1] + _fence_mod_by_tileh_nw[ti->tileh];
-		AddSortableSpriteToDraw(sprite, PAL_NONE, ti->x, ti->y - 15, 16, 31, maxz - z + 4, ti->z + z, false, 0, 15, -z);
+		AddSortableSpriteToDraw(sprite, PAL_NONE, ti->x, ti->y - 16, 16, 32, maxz - z + 4, ti->z + z, false, 0, 16, -z);
 	}
 
 	uint fence_ne = GetFence(ti->tile, DIAGDIR_NE);
 	if (fence_ne != 0) {
 		int z = GetSlopePixelZInCorner(ti->tileh, CORNER_E);
 		SpriteID sprite = _clear_land_fence_sprites[fence_ne - 1] + _fence_mod_by_tileh_ne[ti->tileh];
-		AddSortableSpriteToDraw(sprite, PAL_NONE, ti->x - 15, ti->y, 31, 16, maxz - z + 4, ti->z + z, false, 15, 0, -z);
+		AddSortableSpriteToDraw(sprite, PAL_NONE, ti->x - 16, ti->y, 32, 16, maxz - z + 4, ti->z + z, false, 16, 0, -z);
 	}
 
 	uint fence_sw = GetFence(ti->tile, DIAGDIR_SW);

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1013,16 +1013,21 @@ static bool IsSuitableForFarmField(TileIndex tile, bool allow_fields)
 static void SetupFarmFieldFence(TileIndex tile, int size, byte type, DiagDirection side)
 {
 	TileIndexDiff diff = (DiagDirToAxis(side) == AXIS_Y ? TileDiffXY(1, 0) : TileDiffXY(0, 1));
+	TileIndexDiff neighbour_diff = TileOffsByDiagDir(side);
 
 	do {
 		tile = Map::WrapToMap(tile);
 
 		if (IsTileType(tile, MP_CLEAR) && IsClearGround(tile, CLEAR_FIELDS)) {
-			byte or_ = type;
+			TileIndex neighbour = tile + neighbour_diff;
+			if (!IsTileType(neighbour, MP_CLEAR) || !IsClearGround(neighbour, CLEAR_FIELDS) || GetFence(neighbour, ReverseDiagDir(side)) == 0) {
+				/* Add fence as long as neighbouring tile does not already have a fence in the same position. */
+				byte or_ = type;
 
-			if (or_ == 1 && Chance16(1, 7)) or_ = 2;
+				if (or_ == 1 && Chance16(1, 7)) or_ = 2;
 
-			SetFence(tile, side, or_);
+				SetFence(tile, side, or_);
+			}
 		}
 
 		tile += diff;


### PR DESCRIPTION
## Motivation / Problem

(Fences here means fences, hedges and walls.)

Drawing fences at 1/16th in and at 16/16ths means that is it not possible to make fences align nicely. This is more problematic with high resolution 4x extra zoom graphics.

These sprites were also originally (in OpenTTD before r23168 and in TTD) only drawn on tiles edges, never 1/16th in.

r23168 also allowed adjacent fences to be created, which can look a bit odd.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/cb609c88-bd20-49fe-82ef-305bb16fc002)
![image](https://github.com/OpenTTD/OpenTTD/assets/639850/300ca414-acb0-45f5-bc79-3cbe9d5da522)


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Draw north-edge fences at the tile edge instead. This allows high resolution sprites to align better around fields, and matches the older behaviour. When farms place fields we also now avoid placing fields along an edge that already has fences.

This is listed as a change not a fix, as the old behaviour was not broken as such, but it can be awkward for artists to work with.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/cf3b38aa-2dc9-4dba-8697-9a2d0d29db17)
![image](https://github.com/OpenTTD/OpenTTD/assets/639850/e2ce1cfe-aadf-4063-a109-d2fbe8b19634)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Pitchforks somewhere.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
