### PR TITLE
Codechange: Rework regression output filtering

### DIFF
--- a/cmake/scripts/Regression.cmake
+++ b/cmake/scripts/Regression.cmake
@@ -63,11 +63,10 @@ string(REGEX REPLACE "\\\[[0-9-]+ [0-9:]+\\\] " "" REGRESSION_RESULT "${REGRESSI
 string(REGEX REPLACE "\\\[script:[0-9]\\\]" "" REGRESSION_RESULT "${REGRESSION_RESULT}")
 
 # Convert the output to a format that is expected (and more readable) by result.txt
-string(REPLACE "\ndbg: " "\n" REGRESSION_RESULT "${REGRESSION_RESULT}")
-string(REPLACE "\n " "\nERROR: " REGRESSION_RESULT "${REGRESSION_RESULT}")
-string(REPLACE "\nERROR: [1] " "\n" REGRESSION_RESULT "${REGRESSION_RESULT}")
-string(REPLACE "\n[P] " "\n" REGRESSION_RESULT "${REGRESSION_RESULT}")
-string(REPLACE "\n[S] " "\n" REGRESSION_RESULT "${REGRESSION_RESULT}")
+string(REPLACE "dbg:  " "ERROR: " REGRESSION_RESULT "${REGRESSION_RESULT}")
+string(REPLACE "ERROR: [1] " "" REGRESSION_RESULT "${REGRESSION_RESULT}")
+string(REPLACE "[P] " "" REGRESSION_RESULT "${REGRESSION_RESULT}")
+string(REPLACE "[S] " "" REGRESSION_RESULT "${REGRESSION_RESULT}")
 string(REGEX REPLACE "dbg: ([^\n]*)\n?" "" REGRESSION_RESULT "${REGRESSION_RESULT}")
 
 # Remove duplicate script info

--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -1,3 +1,4 @@
+
 --TestInit--
  Ops:      9988
  TickTest: 1

--- a/regression/stationlist/result.txt
+++ b/regression/stationlist/result.txt
@@ -1,3 +1,4 @@
+
 --StationList--
   Count():             5
   Location ListDump:


### PR DESCRIPTION
## Motivation / Problem
Regression fails if there's any debug output before regression output (could be social plugin failure, or duplicate script messages).
The failure happens since https://github.com/OpenTTD/OpenTTD/commit/46b1114c67c4d882dc1498aad96251821b87d726 removed `-d misc=9` from regression command line, and this debug level used to output a lot of lines before regression output.
Since all formatting commands expect at least 1 line before regression output (they are all in the `\nsomething` form), this caused removal of the first line of regression output, which then reappears if anything is present before it.

Regression/main.nut first output is
```
	print("");
	print("--TestInit--");
```
so the empty line removal was a bug.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Rewrite the formatting without `\n`.
Now the first line of regression output is never removed, with or without debug messages before regression output.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
