### PR TITLE
Feature: Show revision of newer savegames that have this information

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4902,7 +4902,7 @@ STR_ERROR_UNABLE_TO_DELETE_FILE                                 :{WHITE}Unable t
 STR_ERROR_GAME_LOAD_FAILED                                      :{WHITE}Game Load Failed{}{STRING1}
 STR_GAME_SAVELOAD_ERROR_BROKEN_INTERNAL_ERROR                   :Internal error: {RAW_STRING}
 STR_GAME_SAVELOAD_ERROR_BROKEN_SAVEGAME                         :Broken savegame - {RAW_STRING}
-STR_GAME_SAVELOAD_ERROR_TOO_NEW_SAVEGAME                        :Savegame is made with newer version
+STR_GAME_SAVELOAD_ERROR_TOO_NEW_SAVEGAME_WITH_REVISION          :Savegame is made with newer/unsupported version {RAW_STRING}
 STR_GAME_SAVELOAD_ERROR_FILE_NOT_READABLE                       :File not readable
 STR_GAME_SAVELOAD_ERROR_FILE_NOT_WRITEABLE                      :File not writeable
 STR_GAME_SAVELOAD_ERROR_DATA_INTEGRITY_CHECK_FAILED             :Data integrity check failed

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -138,7 +138,7 @@ struct PacketWriter : SaveFilter {
 		return false;
 	}
 
-	void Write(byte *buf, size_t size) override
+	void Write(const byte *buf, size_t size) override
 	{
 		/* We want to abort the saving when the socket is closed. */
 		if (this->cs == nullptr) SlError(STR_NETWORK_ERROR_LOSTCONNECTION);
@@ -147,7 +147,7 @@ struct PacketWriter : SaveFilter {
 
 		std::lock_guard<std::mutex> lock(this->mutex);
 
-		byte *bufe = buf + size;
+		const byte *bufe = buf + size;
 		while (buf != bufe) {
 			size_t written = this->current->Send_bytes(buf, bufe);
 			buf += written;

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2212,7 +2212,7 @@ struct FileWriter : SaveFilter {
 		this->Finish();
 	}
 
-	void Write(byte *buf, size_t size) override
+	void Write(const byte *buf, size_t size) override
 	{
 		/* We're in the process of shutting down, i.e. in "failure" mode. */
 		if (this->file == nullptr) return;
@@ -2295,7 +2295,7 @@ struct LZOSaveFilter : SaveFilter {
 		if (lzo_init() != LZO_E_OK) SlError(STR_GAME_SAVELOAD_ERROR_BROKEN_INTERNAL_ERROR, "cannot initialize compressor");
 	}
 
-	void Write(byte *buf, size_t size) override
+	void Write(const byte *buf, size_t size) override
 	{
 		const lzo_bytep in = buf;
 		/* Buffer size is from the LZO docs plus the chunk header size. */
@@ -2350,7 +2350,7 @@ struct NoCompSaveFilter : SaveFilter {
 	{
 	}
 
-	void Write(byte *buf, size_t size) override
+	void Write(const byte *buf, size_t size) override
 	{
 		this->chain->Write(buf, size);
 	}
@@ -2435,10 +2435,10 @@ struct ZlibSaveFilter : SaveFilter {
 	 * @param len  Amount of bytes to write.
 	 * @param mode Mode for deflate.
 	 */
-	void WriteLoop(byte *p, size_t len, int mode)
+	void WriteLoop(const byte *p, size_t len, int mode)
 	{
 		uint n;
-		this->z.next_in = p;
+		this->z.next_in = const_cast<byte *>(p);
 		this->z.avail_in = (uInt)len;
 		do {
 			this->z.next_out = this->fwrite_buf;
@@ -2463,7 +2463,7 @@ struct ZlibSaveFilter : SaveFilter {
 		} while (this->z.avail_in || !this->z.avail_out);
 	}
 
-	void Write(byte *buf, size_t size) override
+	void Write(const byte *buf, size_t size) override
 	{
 		this->WriteLoop(buf, size, 0);
 	}
@@ -2562,7 +2562,7 @@ struct LZMASaveFilter : SaveFilter {
 	 * @param len    Amount of bytes to write.
 	 * @param action Action for lzma_code.
 	 */
-	void WriteLoop(byte *p, size_t len, lzma_action action)
+	void WriteLoop(const byte *p, size_t len, lzma_action action)
 	{
 		size_t n;
 		this->lzma.next_in = p;
@@ -2582,7 +2582,7 @@ struct LZMASaveFilter : SaveFilter {
 		} while (this->lzma.avail_in || !this->lzma.avail_out);
 	}
 
-	void Write(byte *buf, size_t size) override
+	void Write(const byte *buf, size_t size) override
 	{
 		this->WriteLoop(buf, size, LZMA_RUN);
 	}

--- a/src/saveload/saveload_filter.h
+++ b/src/saveload/saveload_filter.h
@@ -78,7 +78,7 @@ struct SaveFilter {
 	 * @param buf The bytes to write.
 	 * @param len The number of bytes to write.
 	 */
-	virtual void Write(byte *buf, size_t len) = 0;
+	virtual void Write(const byte *buf, size_t len) = 0;
 
 	/**
 	 * Prepare everything to finish writing the savegame.


### PR DESCRIPTION
## Motivation / Problem

When looking at #8987 I thought... wouldn't is be even better to just show the revision of the version that is deemed too new? That will be way more useful for the user, as they know what version they need to load said save.
And for developers it's useful to see whether the save that can't be loaded is from one of our own development branches, and as such it's expected that it might not load.


## Description

Add the revision-string right after the eight byte header, and misuse an unused byte to store the length. This also means that the string will be saved uncompressed, so even when unknown compressions are used the revision can still be determined.

I have chosen for this solution because a save-load version is definitely not going to work, as there will be plenty of JGRPP saves that won't have this information with a higher save-load version. The byte has been saved as zero since at least the 0.4 era.
Also trying to read the game log chunks will eventually fail when there are more types are added, or when types change. So, this seems like the least intrusive way to add the revision.


## Limitations

This will break any save reading libraries/tools.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
