### PR TITLE
Change: Improve performance of finding free pool slots.

### DIFF
--- a/src/core/pool_type.hpp
+++ b/src/core/pool_type.hpp
@@ -83,6 +83,9 @@ struct Pool : PoolBase {
 
 	static constexpr size_t MAX_SIZE = Tmax_size; ///< Make template parameter accessible from outside
 
+	using BitmapStorage = size_t;
+	static constexpr size_t BITMAP_SIZE = std::numeric_limits<BitmapStorage>::digits;
+
 	const char * const name; ///< Name of this pool
 
 	size_t size;         ///< Current allocated size
@@ -95,6 +98,7 @@ struct Pool : PoolBase {
 	bool cleaning;       ///< True if cleaning pool (deleting all items)
 
 	Titem **data;        ///< Pointer to array of pointers to Titem
+	std::vector<BitmapStorage> used_bitmap; ///< Bitmap of used indices.
 
 	Pool(const char *name);
 	void CleanPool() override;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Finding a free pool slot often needs to iterate the pool. The first free index is stored, but after that is used, it needs to individually check if each item is empty.

Some vehicles produce lots of effect vehicles, so in a game with lots of vehicles finding a free slot can be called very often.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add a bitmap of used pool slots which allows finding a free pool slot without having to check if each index is already used or not. The size of the bitmap grows along with the size of the pool, although it is aligned to 64 items (one uint64_t) at a time.

This allows checking a block of 64 items in one go, and we also know which items are free in that block without individually checking.

The bitmap stores a bit per pool item, which means 8 bytes can store the state of 64 items. Conversely, each pool item pointer itself uses 8 bytes. This means that the bitmap uses only an additional 1/64th the memory  that is already used by the pool item pointers.

Loosely based on a JGRPP patch.

Performance runs with a heavy (4kx4k, 51MB) test save:

| Pool | master 10000 calls | master avg | this pr 10000 calls | this pr avg |
| ------- | ------------------ | ------------ | ------------------- | ----------- |
| Vehicle | 115050 us | avg: 11.5 us | 1837 us | avg: 0.2 us |
| Vehicle | 124895 us | avg: 12.5 us | 1550 us | avg: 0.2 us |
| Vehicle | 109787 us | avg: 11.0 us | 1402 us | avg: 0.1 us |
| Vehicle | 104227 us | avg: 10.4 us | 1429 us | avg: 0.1 us |
| Vehicle | 124463 us | avg: 12.4 us | 1659 us | avg: 0.2 us |
| Vehicle | 123507 us | avg: 12.4 us | 1477 us | avg: 0.1 us |
| Vehicle | 128174 us | avg: 12.8 us | 1525 us | avg: 0.2 us |
| Vehicle | 119987 us | avg: 12.0 us | 1667 us | avg: 0.2 us |
| Vehicle | 115823 us | avg: 11.6 us | 1639 us | avg: 0.2 us |
| Vehicle | 98529 us | avg: 9.9 us | 1492 us | avg: 0.1 us |
| Vehicle | 96376 us | avg: 9.6 us | 1452 us | avg: 0.1 us |
| Vehicle | 126777 us | avg: 12.7 us | 1455 us | avg: 0.1 us |
| Vehicle | 107639 us | avg: 10.8 us | 1387 us | avg: 0.1 us |
| Vehicle | 116721 us | avg: 11.7 us | 1481 us | avg: 0.1 us |
| Vehicle | 114456 us | avg: 11.4 us | 1738 us | avg: 0.2 us |

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
