### PR TITLE
Fix fdfcb09: for content service, fallback to TCP downloads when HTTP stalls

### DIFF
--- a/src/network/core/http_curl.cpp
+++ b/src/network/core/http_curl.cpp
@@ -190,7 +190,7 @@ void HttpThread()
 
 		/* Setup our (C-style) callback function which we pipe back into the callback. */
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, +[](char *ptr, size_t size, size_t nmemb, void *userdata) -> size_t {
-			Debug(net, 4, "HTTP callback: {} bytes", size * nmemb);
+			Debug(net, 6, "HTTP callback: {} bytes", size * nmemb);
 			HTTPThreadSafeCallback *callback = static_cast<HTTPThreadSafeCallback *>(userdata);
 
 			/* Copy the buffer out of CURL. OnReceiveData() will free it when done. */

--- a/src/network/core/http_winhttp.cpp
+++ b/src/network/core/http_winhttp.cpp
@@ -165,7 +165,7 @@ void NetworkHTTPRequest::WinHttpCallback(DWORD code, void *info, DWORD length)
 		} break;
 
 		case WINHTTP_CALLBACK_STATUS_READ_COMPLETE:
-			Debug(net, 4, "HTTP callback: {} bytes", length);
+			Debug(net, 6, "HTTP callback: {} bytes", length);
 
 			this->callback.OnReceiveData(std::unique_ptr<char[]>(static_cast<char *>(info)), length);
 

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -113,6 +113,7 @@ public:
 	void Connect();
 	void SendReceive();
 	NetworkRecvStatus CloseConnection(bool error = true) override;
+	void Cancel();
 
 	void RequestContentList(ContentType type);
 	void RequestContentList(uint count, const ContentID *content_ids);

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -291,7 +291,7 @@ public:
 	{
 		if (widget == WID_NCDS_CANCELOK) {
 			if (this->downloaded_bytes != this->total_bytes) {
-				_network_content_client.CloseConnection();
+				_network_content_client.Cancel();
 				this->Close();
 			} else {
 				/* If downloading succeeded, close the online content window. This will close


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

In 502a52e the `lastActivity` is reset every time an HTTP packet is processed, to avoid an idle-timeout to kick off that was suppose to only close the TCP connection; nothing else.
In fdfcb09 the code was changed that this idle-timeout also cancelled all pending HTTP downloads.

And although 502a52e absolutely fixed the issue, there are two problems that arise from it:
- The connection to the content-server is kept open for much longer than actually needed. This gives unneeded pressure on the backend.
- When the timeout does happen during an HTTP (for example, because of a stalling HTTP), it also doesn't fall back to the TCP (as the download is now cancelled).

## Description

Simplify the situation a bit, by reinstating the original intention of the idle-timeout, and have a new function that does the actual cancelling.

This means that even during an HTTP download, the connection to the content server can be disconnected (which is perfectly fine). If the HTTP download fails, it will fall back to TCP, and recreate the connection.

In result, this reverts 502a52e.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
