### PR TITLE
Remove: setting "no_http_content_downloads"

### DIFF
--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -325,7 +325,7 @@ void ClientNetworkContentSocketHandler::DownloadSelectedContent(uint &files, uin
 
 	this->isCancelled = false;
 
-	if (_settings_client.network.no_http_content_downloads || fallback) {
+	if (fallback) {
 		this->DownloadSelectedContentFallback(content);
 	} else {
 		this->DownloadSelectedContentHTTP(content);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -158,7 +158,7 @@ enum IniFileVersion : uint32_t {
 	IFV_PRIVATE_SECRETS,                                   ///< 1  PR#9298  Moving of settings from openttd.cfg to private.cfg / secrets.cfg.
 	IFV_GAME_TYPE,                                         ///< 2  PR#9515  Convert server_advertise to server_game_type.
 	IFV_LINKGRAPH_SECONDS,                                 ///< 3  PR#10610 Store linkgraph update intervals in seconds instead of days.
-	IFV_NETWORK_PRIVATE_SETTINGS,                          ///< 4  PR#10762 Move no_http_content_downloads / use_relay_service to private settings.
+	IFV_NETWORK_PRIVATE_SETTINGS,                          ///< 4  PR#10762 Move use_relay_service to private settings.
 
 	IFV_AUTOSAVE_RENAME,                                   ///< 5  PR#11143 Renamed values of autosave to be in minutes.
 	IFV_RIGHT_CLICK_CLOSE,                                 ///< 6  PR#10204 Add alternative right click to close windows setting.
@@ -1378,19 +1378,10 @@ void LoadFromConfig(bool startup)
 			_settings_newgame.linkgraph.recalc_time     *= CalendarTime::SECONDS_PER_DAY;
 		}
 
-		/* Move no_http_content_downloads and use_relay_service from generic_ini to private_ini. */
+		/* Move use_relay_service from generic_ini to private_ini. */
 		if (generic_version < IFV_NETWORK_PRIVATE_SETTINGS) {
 			const IniGroup *network = generic_ini.GetGroup("network");
 			if (network != nullptr) {
-				const IniItem *no_http_content_downloads = network->GetItem("no_http_content_downloads");
-				if (no_http_content_downloads != nullptr) {
-					if (no_http_content_downloads->value == "true") {
-						_settings_client.network.no_http_content_downloads = true;
-					} else if (no_http_content_downloads->value == "false") {
-						_settings_client.network.no_http_content_downloads = false;
-					}
-				}
-
 				const IniItem *use_relay_service = network->GetItem("use_relay_service");
 				if (use_relay_service != nullptr) {
 					if (use_relay_service->value == "never") {
@@ -1496,7 +1487,6 @@ void SaveToConfig()
 	if (generic_version < IFV_NETWORK_PRIVATE_SETTINGS) {
 		IniGroup *network = generic_ini.GetGroup("network");
 		if (network != nullptr) {
-			network->RemoveItem("no_http_content_downloads");
 			network->RemoveItem("use_relay_service");
 		}
 	}

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -330,7 +330,6 @@ struct NetworkSettings {
 	uint8_t       min_active_clients;                       ///< minimum amount of active clients to unpause the game
 	bool        reload_cfg;                               ///< reload the config file before restarting
 	std::string last_joined;                              ///< Last joined server
-	bool        no_http_content_downloads;                ///< do not do content downloads over HTTP
 	UseRelayService use_relay_service;                    ///< Use relay service?
 	ParticipateSurvey participate_survey;                 ///< Participate in the automated survey
 };

--- a/src/table/settings/network_private_settings.ini
+++ b/src/table/settings/network_private_settings.ini
@@ -76,12 +76,6 @@ flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = """"
 cat      = SC_EXPERT
 
-[SDTC_BOOL]
-var      = network.no_http_content_downloads
-flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
-def      = false
-cat      = SC_EXPERT
-
 [SDTC_OMANY]
 var      = network.use_relay_service
 type     = SLE_UINT8


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As we now use HTTPS, it is very likely this will work on most systems. For systems that do have HTTPS blocked, it will fail instantly, and it will fallback to TCP anyway. That makes this setting no longer very useful.

Additionally, TCP downloads are very expensive (0.90 dollarcent per GB), and is the main part of our monthly bill (10GB a day via TCP is not an exception). By forcing the client to first use HTTPS, it possibly helps with our monthly bills.

## Description

In that balance, the setting not being very useful anymore (only in edge-cases, see below), and the price we pay for having that setting, I suggest we remove the `no_http_content_downloads` setting.

Always first try HTTPS, fallback to TCP if that failed.

As an added bonus, HTTPS downloads are, on average, always faster than TCP. This is because of how our infrastructure works. HTTPS is served from a local Cloudflare Point-of-Presence, where TCP always travels back to a single AWS datacenter in Ireland. So really, nobody should want to download over TCP, and HTTPS should always be the preference.

PS: the setting was once added to more easily debug issues with content service, but in reality I at least never used it for debugging. This is because the fallback always worked excellent, where my main concern back in the day was that it might not.

## Limitations

In cases where HTTPS isn't properly blocked, it will take 10 seconds before the client notices no HTTPS connection can be made, and falls back to TCP then. In these scenarios, this setting would still be useful. But the chances of that being the case in this day and age a very slim to none (not being able to do HTTPS connections but being able to do TCP connection on a random port, that is just not likely). On the flip-side, people that might have enabled `no_http_content_downloads` because they think it improves something (because someone somewhere told them it would), do more harm (cost-wise).

And no, the survey does not report `no_http_content_downloads`, as it is a private setting (which aren't tracked).

PS: some searching on the Internet indeed shows several posts and configurations where people enable this setting.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
