### PR TITLE
Fix #12057: Prevent NewGRF industries and houses producing/accepting a cargo type multiple times.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -9399,11 +9399,16 @@ static void FinaliseHouseArray()
 			hs->building_flags = TILE_NO_FLAG;
 		}
 
+		if (!hs->enabled) continue;
+
 		/* Apply default cargo translation map for unset cargo slots */
-		for (uint i = 0; i < lengthof(hs->accepts_cargo); ++i) {
-			if (!IsValidCargoID(hs->accepts_cargo[i])) hs->accepts_cargo[i] = GetCargoIDByLabel(hs->accepts_cargo_label[i]);
+		for (auto it = std::begin(hs->accepts_cargo); it != std::end(hs->accepts_cargo); ++it) {
+			auto slot = std::distance(std::begin(hs->accepts_cargo), it);
+			if (!IsValidCargoID(*it)) *it = GetCargoIDByLabel(hs->accepts_cargo_label[slot]);
+			/* If cargo is accepted already, disable this slot. */
+			if (IsValidCargoID(*it) && std::find(std::begin(hs->accepts_cargo), it, *it) != it) *it = INVALID_CARGO;
 			/* Disable acceptance if cargo type is invalid. */
-			if (!IsValidCargoID(hs->accepts_cargo[i])) hs->cargo_acceptance[i] = 0;
+			if (!IsValidCargoID(*it)) hs->cargo_acceptance[slot] = 0;
 		}
 	}
 
@@ -9478,21 +9483,30 @@ static void FinaliseIndustriesArray()
 		}
 		if (!indsp.enabled) {
 			indsp.name = STR_NEWGRF_INVALID_INDUSTRYTYPE;
+			continue;
 		}
 
 		/* Apply default cargo translation map for unset cargo slots */
-		for (uint i = 0; i < lengthof(indsp.produced_cargo); ++i) {
-			if (!IsValidCargoID(indsp.produced_cargo[i])) indsp.produced_cargo[i] = GetCargoIDByLabel(GetActiveCargoLabel(indsp.produced_cargo_label[i]));
+		for (auto it = std::begin(indsp.produced_cargo); it != std::end(indsp.produced_cargo); ++it) {
+			if (!IsValidCargoID(*it)) *it = GetCargoIDByLabel(GetActiveCargoLabel(indsp.produced_cargo_label[std::distance(std::begin(indsp.produced_cargo), it)]));
+			/* If cargo is produced already, disable this slot. */
+			if (IsValidCargoID(*it) && std::find(std::begin(indsp.produced_cargo), it, *it) != it) *it = INVALID_CARGO;
 		}
-		for (uint i = 0; i < lengthof(indsp.accepts_cargo); ++i) {
-			if (!IsValidCargoID(indsp.accepts_cargo[i])) indsp.accepts_cargo[i] = GetCargoIDByLabel(GetActiveCargoLabel(indsp.accepts_cargo_label[i]));
+		for (auto it = std::begin(indsp.accepts_cargo); it != std::end(indsp.accepts_cargo); ++it) {
+			if (!IsValidCargoID(*it)) *it = GetCargoIDByLabel(GetActiveCargoLabel(indsp.accepts_cargo_label[std::distance(std::begin(indsp.accepts_cargo), it)]));
+			/* If cargo is accepted already, disable this slot. */
+			if (IsValidCargoID(*it) && std::find(std::begin(indsp.accepts_cargo), it, *it) != it) *it = INVALID_CARGO;
 		}
 	}
 
 	for (auto &indtsp : _industry_tile_specs) {
+		if (!indtsp.enabled) continue;
+
 		/* Apply default cargo translation map for unset cargo slots */
-		for (uint i = 0; i < lengthof(indtsp.accepts_cargo); ++i) {
-			if (!IsValidCargoID(indtsp.accepts_cargo[i])) indtsp.accepts_cargo[i] = GetCargoIDByLabel(GetActiveCargoLabel(indtsp.accepts_cargo_label[i]));
+		for (auto it = std::begin(indtsp.accepts_cargo); it != std::end(indtsp.accepts_cargo); ++it) {
+			if (!IsValidCargoID(*it)) *it = GetCargoIDByLabel(GetActiveCargoLabel(indtsp.accepts_cargo_label[std::distance(std::begin(indtsp.accepts_cargo), it)]));
+			/* If cargo is accepted already, disable this slot. */
+			if (IsValidCargoID(*it) && std::find(std::begin(indtsp.accepts_cargo), it, *it) != it) *it = INVALID_CARGO;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

It's possible via NewGRF for an industry or house to specify in its produce or accept slots the same cargo multiple times. This breaks some game assumptions, at least the Industry Chain window.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Detect when multiple slots contain the same cargo type. Any extra occurrences will be set to INVALID_CARGO.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Not sure if the NewGRF spec mentions this case at all, but it doesn't seem to make sense to allow it.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
