### PR TITLE
Fix: Redraw orders when a station feature is added/removed.

### DIFF
--- a/src/station.cpp
+++ b/src/station.cpp
@@ -233,6 +233,7 @@ void Station::AddFacility(StationFacility new_facility_bit, TileIndex facil_xy)
 	this->facilities |= new_facility_bit;
 	this->owner = _current_company;
 	this->build_date = TimerGameCalendar::date;
+	SetWindowClassesDirty(WC_VEHICLE_ORDERS);
 }
 
 /**

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1695,6 +1695,7 @@ CommandCost RemoveFromRailBaseStation(TileArea ta, std::vector<T *> &affected_st
 		/* if we deleted the whole station, delete the train facility. */
 		if (st->train_station.tile == INVALID_TILE) {
 			st->facilities &= ~FACIL_TRAIN;
+			SetWindowClassesDirty(WC_VEHICLE_ORDERS);
 			SetWindowWidgetDirty(WC_STATION_VIEW, st->index, WID_SV_TRAINS);
 			MarkCatchmentTilesDirty();
 			st->UpdateVirtCoord();
@@ -2142,6 +2143,7 @@ static CommandCost RemoveRoadStop(TileIndex tile, DoCommandFlag flags, int repla
 			/* removed the only stop? */
 			if (*primary_stop == nullptr) {
 				st->facilities &= (is_truck ? ~FACIL_TRUCK_STOP : ~FACIL_BUS_STOP);
+				SetWindowClassesDirty(WC_VEHICLE_ORDERS);
 			}
 		} else {
 			/* tell the predecessor in the list to skip this stop */
@@ -2574,6 +2576,7 @@ static CommandCost RemoveAirport(TileIndex tile, DoCommandFlag flags)
 
 		st->airport.Clear();
 		st->facilities &= ~FACIL_AIRPORT;
+		SetWindowClassesDirty(WC_VEHICLE_ORDERS);
 
 		InvalidateWindowData(WC_STATION_VIEW, st->index, -1);
 
@@ -2827,6 +2830,7 @@ static CommandCost RemoveDock(TileIndex tile, DoCommandFlag flags)
 			st->ship_station.Clear();
 			st->docking_station.Clear();
 			st->facilities &= ~FACIL_DOCK;
+			SetWindowClassesDirty(WC_VEHICLE_ORDERS);
 		}
 
 		Company::Get(st->owner)->infrastructure.station -= 2;


### PR DESCRIPTION
## Motivation / Problem
When a station feature is added or removed, if there is a vehicle order list opened that has an order to that station, the order can change from valid to "can't use station".
As the order list is not redrawn immediately, there are some glitches:

![Screenshot_20240211_171130](https://github.com/OpenTTD/OpenTTD/assets/3152990/51de74a2-972b-478d-ac2f-01587ac53634)


## Description
A solution can be to redraw all lists when that occurs.


## Limitations
Even when adding new stations (even a 1x1 bus station), all order lists will be redrawn.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
