### PR TITLE
Change: [Script] Store randomizers in savegame

### DIFF
--- a/src/saveload/CMakeLists.txt
+++ b/src/saveload/CMakeLists.txt
@@ -30,6 +30,7 @@ add_files(
     oldloader.h
     oldloader_sl.cpp
     order_sl.cpp
+    randomizer_sl.cpp
     saveload.cpp
     saveload.h
     saveload_filter.h

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -255,8 +255,6 @@ static void InitializeWindowsAndCaches()
 	UpdateAllVirtCoords();
 	ResetViewportAfterLoadGame();
 
-	ScriptObject::InitializeRandomizers();
-
 	for (Company *c : Company::Iterate()) {
 		/* For each company, verify (while loading a scenario) that the inauguration date is the current year and set it
 		 * accordingly if it is not the case.  No need to set it on companies that are not been used already,
@@ -3286,6 +3284,10 @@ bool AfterLoadGame()
 		for (Company *c : Company::Iterate()) {
 			c->max_loan = COMPANY_MAX_LOAN_DEFAULT;
 		}
+	}
+
+	if (IsSavegameVersionBefore(SLV_SCRIPT_RANDOMIZER)) {
+		ScriptObject::InitializeRandomizers();
 	}
 
 	for (Company *c : Company::Iterate()) {

--- a/src/saveload/randomizer_sl.cpp
+++ b/src/saveload/randomizer_sl.cpp
@@ -1,0 +1,51 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file randomizer_sl.cpp Code handling saving and loading of script randomizers */
+
+#include "../stdafx.h"
+#include "../script/api/script_object.hpp"
+#include "saveload.h"
+#include "saveload_internal.h"
+#include "../safeguards.h"
+
+static const SaveLoad _randomizer_desc[] = {
+	SLE_VAR(Randomizer, state[0], SLE_UINT32),
+	SLE_VAR(Randomizer, state[1], SLE_UINT32),
+};
+
+struct SRNDChunkHandler : ChunkHandler {
+	SRNDChunkHandler() : ChunkHandler('SRND', CH_TABLE)
+	{}
+
+	void Save() const override
+	{
+		SlTableHeader(_randomizer_desc);
+
+		for (Owner owner = OWNER_BEGIN; owner < OWNER_END; owner++) {
+			SlSetArrayIndex(owner);
+			SlObject(&ScriptObject::GetRandomizer(owner), _randomizer_desc);
+		}
+	}
+
+	void Load() const override
+	{
+		SlTableHeader(_randomizer_desc);
+
+		Owner index;
+		while ((index = (Owner)SlIterateArray()) != (Owner)-1) {
+			SlObject(&ScriptObject::GetRandomizer(index), _randomizer_desc);
+		}
+	}
+};
+
+static const SRNDChunkHandler SRND;
+static const ChunkHandlerRef randomizer_chunk_handlers[] = {
+	SRND,
+};
+
+extern const ChunkHandlerTable _randomizer_chunk_handlers(randomizer_chunk_handlers);

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -250,6 +250,7 @@ static const std::vector<ChunkHandlerRef> &ChunkHandlers()
 	extern const ChunkHandlerTable _object_chunk_handlers;
 	extern const ChunkHandlerTable _persistent_storage_chunk_handlers;
 	extern const ChunkHandlerTable _water_region_chunk_handlers;
+	extern const ChunkHandlerTable _randomizer_chunk_handlers;
 
 	/** List of all chunks in a savegame. */
 	static const ChunkHandlerTable _chunk_handler_tables[] = {
@@ -288,6 +289,7 @@ static const std::vector<ChunkHandlerRef> &ChunkHandlers()
 		_object_chunk_handlers,
 		_persistent_storage_chunk_handlers,
 		_water_region_chunk_handlers,
+		_randomizer_chunk_handlers,
 	};
 
 	static std::vector<ChunkHandlerRef> _chunk_handlers;

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -376,6 +376,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_MAX_LOAN_FOR_COMPANY,               ///< 330  PR#11224 Separate max loan for each company.
 	SLV_DEPOT_UNBUNCHING,                   ///< 331  PR#11945 Allow unbunching shared order vehicles at a depot.
 	SLV_AI_LOCAL_CONFIG,                    ///< 332  PR#12003 Config of running AI is stored inside Company.
+	SLV_SCRIPT_RANDOMIZER,                  ///< 333  PR#12063 Save script randomizers.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Script randomizers are initialized on load from main randomizer, which affects reproducibility of scripts events (values returned immediately after save are not the same as those returned immediately after load).
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Store the script randomizers in a new chunk so save/load doesn't affect reproducibility.
Older saves keep the initialisation from main randomizer.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
