### PR TITLE
Codechange: Don't scan vehicle pool to find targeting disaster vehicle when deleting any vehicle.

### DIFF
--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -348,6 +348,11 @@ static bool DisasterTick_Ufo(DisasterVehicle *v)
 		for (RoadVehicle *u : RoadVehicle::Iterate()) {
 			/* Find (n+1)-th road vehicle. */
 			if (u->IsFrontEngine() && (n-- == 0)) {
+				if (u->crashed_ctr != 0 || u->disaster_vehicle != INVALID_VEHICLE) {
+					/* Targetted vehicle is crashed or already a target, destroy the UFO. */
+					delete v;
+					return false;
+				}
 				/* Target it. */
 				v->dest_tile = u->index;
 				v->age = 0;

--- a/src/roadveh.h
+++ b/src/roadveh.h
@@ -116,6 +116,8 @@ struct RoadVehicle final : public GroundVehicle<RoadVehicle, VEH_ROAD> {
 	RoadType roadtype;              //!< Roadtype of this vehicle.
 	RoadTypes compatible_roadtypes; //!< Roadtypes this consist is powered on.
 
+	VehicleID disaster_vehicle = INVALID_VEHICLE; ///< NOSAVE: Disaster vehicle targetting this vehicle.
+
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
 	RoadVehicle() : GroundVehicleBase() {}
 	/** We want to 'destruct' the right class. */

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -496,6 +496,16 @@ void AfterLoadVehicles(bool part_of_load)
 					UpdateAircraftCache(Aircraft::From(v), true);
 				}
 				break;
+
+			case VEH_DISASTER: {
+				auto *dv = DisasterVehicle::From(v);
+				if (dv->subtype == ST_SMALL_UFO && dv->state != 0) {
+					RoadVehicle *u = RoadVehicle::GetIfValid(v->dest_tile.base());
+					if (u != nullptr && u->IsFrontEngine()) u->disaster_vehicle = dv->index;
+				}
+				break;
+			}
+
 			default: break;
 		}
 

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -501,7 +501,15 @@ void AfterLoadVehicles(bool part_of_load)
 				auto *dv = DisasterVehicle::From(v);
 				if (dv->subtype == ST_SMALL_UFO && dv->state != 0) {
 					RoadVehicle *u = RoadVehicle::GetIfValid(v->dest_tile.base());
-					if (u != nullptr && u->IsFrontEngine()) u->disaster_vehicle = dv->index;
+					if (u != nullptr && u->IsFrontEngine()) {
+						/* Delete UFO targetting a vehicle which is already a target. */
+						if (u->disaster_vehicle != INVALID_VEHICLE) {
+							delete v;
+							continue;
+						} else {
+							u->disaster_vehicle = dv->index;
+						}
+					}
 				}
 				break;
 			}

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -862,6 +862,8 @@ void Vehicle::PreDestructor()
 			/* Leave the drive through roadstop, when you have not already left it. */
 			RoadStop::GetByTile(v->tile, GetRoadStopType(v->tile))->Leave(v);
 		}
+
+		if (v->disaster_vehicle != INVALID_VEHICLE) ReleaseDisasterVehicle(v->disaster_vehicle);
 	}
 
 	if (this->Previous() == nullptr) {
@@ -884,8 +886,6 @@ void Vehicle::PreDestructor()
 	DeleteDepotHighlightOfVehicle(this);
 
 	StopGlobalFollowVehicle(this);
-
-	ReleaseDisastersTargetingVehicle(this->index);
 }
 
 Vehicle::~Vehicle()

--- a/src/vehicle_func.h
+++ b/src/vehicle_func.h
@@ -168,7 +168,7 @@ bool CanVehicleUseStation(EngineID engine_type, const struct Station *st);
 bool CanVehicleUseStation(const Vehicle *v, const struct Station *st);
 StringID GetVehicleCannotUseStationReason(const Vehicle *v, const Station *st);
 
-void ReleaseDisastersTargetingVehicle(VehicleID vehicle);
+void ReleaseDisasterVehicle(VehicleID vehicle);
 
 typedef std::vector<VehicleID> VehicleSet;
 void GetVehicleSet(VehicleSet &set, Vehicle *v, uint8_t num_vehicles);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When deleting a vehicle, the vehicle pool is scanned to find a targetting disaster vehicle. With lots of vehicles this can take some time, especially when deleting multiple consecutive vehicles.

Disasters vehicles can actually only target road vehicles, so doing so for any vehicle type is a waste.




<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Store the index of the DisasterVehicle targetting a road vehicle inside in the road vehicle, so that no pool scan is necessary.

This has a huge performance benefit when removing vehicles in a very large game (Xarick's 51MB 4kx4k test), especially when a company goes bankrupt:

| Action | Master | This PR |
| - | - | - |
| stop_ai 3 | 79,605,653us | 68,431us |
| Vehicle::PreDestructor (autoreplace) in Wentbourne | 646us | 1us |
| Vehicle::PreDestructor in Xarick's save | 5832us | 3us |

...and of course, there aren't any disaster vehicles in this save...

For the PreDestructor actions, that is the whole of that function, so this check takes an inordinate amount of time relative to the rest of it.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
