### PR TITLE
Change: [Script] Use company randomizer when adding random deviation

### DIFF
--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -56,7 +56,7 @@
 		/* Load default data and store the name in the settings */
 		config->Change(info->GetName(), -1, false);
 	}
-	if (deviate) config->AddRandomDeviation();
+	if (deviate) config->AddRandomDeviation(company);
 	config->AnchorUnchangeableSettings();
 
 	c->ai_info = info;

--- a/src/game/game_core.cpp
+++ b/src/game/game_core.cpp
@@ -83,7 +83,7 @@
 	GameInfo *info = config->GetInfo();
 	if (info == nullptr) return;
 
-	if (deviate) config->AddRandomDeviation();
+	if (deviate) config->AddRandomDeviation(OWNER_DEITY);
 	config->AnchorUnchangeableSettings();
 
 	Backup<CompanyID> cur_company(_current_company, FILE_LINE);

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -123,11 +123,11 @@ void ScriptConfig::ResetEditableSettings(bool yet_to_start)
 	}
 }
 
-void ScriptConfig::AddRandomDeviation()
+void ScriptConfig::AddRandomDeviation(CompanyID owner)
 {
 	for (const auto &item : *this->GetConfigList()) {
 		if (item.random_deviation != 0) {
-			this->SetSetting(item.name, ScriptObject::GetRandomizer(OWNER_NONE).Next(item.random_deviation * 2 + 1) - item.random_deviation + this->GetSetting(item.name));
+			this->SetSetting(item.name, ScriptObject::GetRandomizer(owner).Next(item.random_deviation * 2 + 1) - item.random_deviation + this->GetSetting(item.name));
 		}
 	}
 }

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -135,7 +135,7 @@ public:
 	/**
 	 * Randomize all settings the Script requested to be randomized.
 	 */
-	void AddRandomDeviation();
+	void AddRandomDeviation(CompanyID owner);
 
 	/**
 	 * Is this config attached to an Script? In other words, is there a Script


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Before #11944, random deviation could happen in many places, so using OWNER_NONE randomizer was the easiest solution.
OWNER_NONE is also used for selecting a random AI, and to add some randomness to next AI start.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Now random deviation only happens in places where current company slot is known, so use the company randomizer instead of OWNER_NONE to determine random deviation.
This should reduce possible reproducibility problems due to OWNER_NONE usage before the start of script in a given slot.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
