### PR TITLE
Fix #10079: don't render at 1000fps if HW acceleration + vsync is requested but not active

### DIFF
--- a/src/video/cocoa/cocoa_ogl.h
+++ b/src/video/cocoa/cocoa_ogl.h
@@ -23,7 +23,7 @@ class VideoDriver_CocoaOpenGL : public VideoDriver_Cocoa {
 	const char *AllocateContext(bool allow_software);
 
 public:
-	VideoDriver_CocoaOpenGL() : gl_context(nullptr), anim_buffer(nullptr), driver_info(this->GetName()) {}
+	VideoDriver_CocoaOpenGL() : VideoDriver_Cocoa(true), gl_context(nullptr), anim_buffer(nullptr), driver_info(this->GetName()) {}
 
 	const char *Start(const StringList &param) override;
 	void Stop() override;

--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -35,7 +35,7 @@ public:
 	OTTD_CocoaWindowDelegate *delegate; //!< Window delegate object
 
 public:
-	VideoDriver_Cocoa();
+	VideoDriver_Cocoa(bool uses_hardware_acceleration = false);
 
 	void Stop() override;
 	void MainLoop() override;

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -87,7 +87,8 @@ static const Dimension _default_resolutions[] = {
 };
 
 
-VideoDriver_Cocoa::VideoDriver_Cocoa()
+VideoDriver_Cocoa::VideoDriver_Cocoa(bool uses_hardware_acceleration)
+	: VideoDriver(uses_hardware_acceleration)
 {
 	this->setup         = false;
 	this->buffer_locked = false;

--- a/src/video/sdl2_opengl_v.h
+++ b/src/video/sdl2_opengl_v.h
@@ -12,7 +12,7 @@
 /** The OpenGL video driver for windows. */
 class VideoDriver_SDL_OpenGL : public VideoDriver_SDL_Base {
 public:
-	VideoDriver_SDL_OpenGL() : gl_context(nullptr), anim_buffer(nullptr) {}
+	VideoDriver_SDL_OpenGL() : VideoDriver_SDL_Base(true), gl_context(nullptr), anim_buffer(nullptr) {}
 
 	const char *Start(const StringList &param) override;
 

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -17,7 +17,7 @@
 /** The SDL video driver. */
 class VideoDriver_SDL_Base : public VideoDriver {
 public:
-	VideoDriver_SDL_Base() : sdl_window(nullptr), buffer_locked(false) {}
+	VideoDriver_SDL_Base(bool uses_hardware_acceleration = false) : VideoDriver(uses_hardware_acceleration), sdl_window(nullptr), buffer_locked(false) {}
 
 	const char *Start(const StringList &param) override;
 

--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -22,8 +22,8 @@
 #include "../window_func.h"
 #include "video_driver.hpp"
 
-bool _video_hw_accel; ///< Whether to consider hardware accelerated video drivers.
-bool _video_vsync; ///< Whether we should use vsync (only if _video_hw_accel is enabled).
+bool _video_hw_accel; ///< Whether to consider hardware accelerated video drivers on startup.
+bool _video_vsync; ///< Whether we should use vsync (only if active video driver supports HW acceleration).
 
 void VideoDriver::GameLoop()
 {

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -35,7 +35,7 @@ class VideoDriver : public Driver {
 	const uint DEFAULT_WINDOW_HEIGHT = 480u; ///< Default window height.
 
 public:
-	VideoDriver() : fast_forward_key_pressed(false), fast_forward_via_key(false), is_game_threaded(true) {}
+	VideoDriver(bool uses_hardware_acceleration = false) : fast_forward_key_pressed(false), fast_forward_via_key(false), is_game_threaded(true), uses_hardware_acceleration(uses_hardware_acceleration) {}
 
 	/**
 	 * Mark a particular area dirty.
@@ -322,7 +322,7 @@ protected:
 	std::chrono::steady_clock::duration GetDrawInterval()
 	{
 		/* If vsync, draw interval is decided by the display driver */
-		if (_video_vsync && _video_hw_accel) return std::chrono::microseconds(0);
+		if (_video_vsync && this->uses_hardware_acceleration) return std::chrono::microseconds(0);
 		return std::chrono::microseconds(1000000 / _settings_client.gui.refresh_rate);
 	}
 
@@ -354,6 +354,8 @@ protected:
 	std::thread game_thread;
 	std::mutex game_state_mutex;
 	std::mutex game_thread_wait_mutex;
+
+	bool uses_hardware_acceleration;
 
 	static void GameThreadThunk(VideoDriver *drv);
 

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -18,7 +18,7 @@
 /** Base class for Windows video drivers. */
 class VideoDriver_Win32Base : public VideoDriver {
 public:
-	VideoDriver_Win32Base() : main_wnd(nullptr), fullscreen(false), buffer_locked(false) {}
+	VideoDriver_Win32Base(bool uses_hardware_acceleration = false) : VideoDriver(uses_hardware_acceleration), main_wnd(nullptr), fullscreen(false), buffer_locked(false) {}
 
 	void Stop() override;
 
@@ -118,7 +118,7 @@ public:
 /** The OpenGL video driver for windows. */
 class VideoDriver_Win32OpenGL : public VideoDriver_Win32Base {
 public:
-	VideoDriver_Win32OpenGL() : dc(nullptr), gl_rc(nullptr), anim_buffer(nullptr), driver_info(this->GetName()) {}
+	VideoDriver_Win32OpenGL() : VideoDriver_Win32Base(true), dc(nullptr), gl_rc(nullptr), anim_buffer(nullptr), driver_info(this->GetName()) {}
 
 	const char *Start(const StringList &param) override;
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Fixes #10079.

When you enable HW acceleration in-game, you get told to restart. But if you don't ....... you can also enable vsync, and the game actually tries to align with vsync. But there is no vsync in non-HW accelerated backends. So it just goes to 1000fps.

## Description

Query the driver to know whether it is hw-accelerated.

Sadly, this information was currently only available in the `DriverFactoryBase`, so it had to be duplicated into the `VideoDriver` to be available (in quick way) for `GetDrawInterval`.

## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
