### PR TITLE
Fix #10500: as client, try to reconnect more than once on server restart

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2640,6 +2640,7 @@ STR_NETWORK_MESSAGE_GIVE_MONEY                                  :*** {0:RAW_STRI
 STR_NETWORK_MESSAGE_SERVER_SHUTDOWN                             :{WHITE}The server closed the session
 STR_NETWORK_MESSAGE_SERVER_REBOOT                               :{WHITE}The server is restarting...{}Please wait...
 STR_NETWORK_MESSAGE_KICKED                                      :*** {RAW_STRING} was kicked. Reason: ({RAW_STRING})
+STR_NETWORK_MESSAGE_SERVER_REBOOT_REJOIN_FAILED                 :{WHITE}Failed to reconnect to server
 
 STR_NETWORK_ERROR_COORDINATOR_REGISTRATION_FAILED               :{WHITE}Server registration failed
 STR_NETWORK_ERROR_COORDINATOR_REUSE_OF_INVITE_CODE              :{WHITE}Another server with the same invite-code registered itself. Switching to "local" game-type.

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -74,6 +74,8 @@ static const uint NETWORK_TOKEN_LENGTH              =   64;           ///< The m
 
 static const uint NETWORK_GRF_NAME_LENGTH           =   80;           ///< Maximum length of the name of a GRF
 
+static const uint32_t NETWORK_RECONNECT_ATTEMPTS    =    8;           ///< How many attempts before we give up reconnecting.
+
 /**
  * Maximum number of GRFs that can be sent.
  *

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -344,6 +344,8 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendJoin()
 	_network_join_status = NETWORK_JOIN_STATUS_AUTHORIZING;
 	SetWindowDirty(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN);
 
+	_network_reconnect_attempts = 0;
+
 	auto p = std::make_unique<Packet>(PACKET_CLIENT_JOIN);
 	p->Send_string(GetNetworkRevisionString());
 	p->Send_uint32(_openttd_newgrf_version);
@@ -1124,14 +1126,10 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_NEWGAME(Packet 
 {
 	Debug(net, 9, "Client::Receive_SERVER_NEWGAME()");
 
-	/* Only when we're trying to join we really
-	 * care about the server shutting down. */
 	if (this->status >= STATUS_JOIN) {
-		/* To throttle the reconnects a bit, every clients waits its
-		 * Client ID modulo 16 + 1 (value 0 means no reconnect).
-		 * This way reconnects should be spread out a bit. */
-		_network_reconnect = _network_own_client_id % 16 + 1;
-		ShowErrorMessage(STR_NETWORK_MESSAGE_SERVER_REBOOT, INVALID_STRING_ID, WL_CRITICAL);
+		_network_reconnect_attempts = NETWORK_RECONNECT_ATTEMPTS;
+		_network_reconnect_backoff = std::chrono::seconds(1);
+		_network_reconnect = std::chrono::steady_clock::now() + _network_reconnect_backoff;
 	}
 
 	if (this->status == STATUS_ACTIVE) ClientNetworkEmergencySave();

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -28,7 +28,9 @@ extern NetworkCompanyState *_network_company_states;
 
 extern ClientID _network_own_client_id;
 extern ClientID _redirect_console_to_client;
-extern uint8_t _network_reconnect;
+extern uint32_t _network_reconnect_attempts;
+extern std::chrono::seconds _network_reconnect_backoff;
+extern std::chrono::steady_clock::time_point _network_reconnect;
 extern StringList _network_bind_list;
 extern StringList _network_host_list;
 extern StringList _network_ban_list;

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -91,8 +91,6 @@ extern std::string _network_server_invite_code;
 /* Variable available for clients. */
 extern std::string _network_server_name;
 
-extern uint8_t _network_reconnect;
-
 extern CompanyMask _network_company_passworded;
 
 void NetworkQueryServer(const std::string &connection_string);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1598,11 +1598,30 @@ void GameLoop()
 		/* Multiplayer */
 		NetworkGameLoop();
 	} else {
-		if (_network_reconnect > 0 && --_network_reconnect == 0) {
-			/* This means that we want to reconnect to the last host
-			 * We do this here, because it means that the network is really closed */
-			NetworkClientConnectGame(_settings_client.network.last_joined, COMPANY_SPECTATOR);
+		if (_network_reconnect_attempts > 0 && std::chrono::steady_clock::now() > _network_reconnect) {
+			Debug(net, 3, "Reconnect attempt #{}", _network_reconnect_attempts);
+
+			_network_reconnect_attempts--;
+			_network_reconnect_backoff = std::min(_network_reconnect_backoff * 2, std::chrono::seconds(30));
+			_network_reconnect = std::chrono::steady_clock::now() + _network_reconnect_backoff;
+
+			if (_network_reconnect_attempts == 0) {
+				ShowErrorMessage(STR_NETWORK_MESSAGE_SERVER_REBOOT_REJOIN_FAILED, INVALID_STRING_ID, WL_ERROR);
+			} else {
+				/* Show that we are reconnecting the first time we do an attempt.
+				 * We have to do it this late, as switching to the main menu closes
+				 * all errors (except critical, but this isn't critical). */
+				if (_network_reconnect_attempts == NETWORK_RECONNECT_ATTEMPTS - 1) {
+					ShowErrorMessage(STR_NETWORK_MESSAGE_SERVER_REBOOT, INVALID_STRING_ID, WL_ERROR);
+				}
+
+				/* If the AskRelay window is open, don't start a new connect. */
+				if (FindWindowByClass(WC_NETWORK_ASK_RELAY) == nullptr) {
+					NetworkClientConnectGame(_settings_client.network.last_joined, COMPANY_SPECTATOR);
+				}
+			}
 		}
+
 		/* Singleplayer */
 		StateGameLoop();
 	}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Fixes #10500 

In the old days, reconnecting was as simple as creating a connection to the IP:port you just came from. As the server was quick enough to have it ready to accept connections again, you just got queued till the server was ready to process your connection.

But ever since 12.0, we also have invite-codes. When a server restarts, its invite-code is invalid till the server is back up and running (including map generation). This means that clients that connected by invite-code (read: almost all of them) couldn't actually reconnect to a server that is restarting.

## Description

Make the reconnect try more than once, and make it depends on time, not ticks.

It uses a simple backoff algorithm to not retry constantly. First attempt is after 1 second, second after 2, third after 4, with a max of 30s delay.

If after ~2.5 minutes the connection is not established, show a nice error that reconnecting failed. Here I have the assumption that servers will be back in 2.5 minutes, but ofc on big maps with a lot of NewGRFs this might not be true. So we could increase that value. Not sure that is actually practical .. pretty sure most players already gave up by then.

Also moved the errors to an `WL_ERROR` instead of a `WL_CRITICAL`, as a critical stays on top, there can only be one critical (they are queued), and it is just annoying to deal with. With `WL_ERROR` it just replaces what ever `WL_ERROR` was active.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
