### PR TITLE
Codefix df691eb3: Reloading GRFs destructed small UFO targeting road vehicle

### DIFF
--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -503,7 +503,7 @@ void AfterLoadVehicles(bool part_of_load)
 					RoadVehicle *u = RoadVehicle::GetIfValid(v->dest_tile.base());
 					if (u != nullptr && u->IsFrontEngine()) {
 						/* Delete UFO targetting a vehicle which is already a target. */
-						if (u->disaster_vehicle != INVALID_VEHICLE) {
+						if (u->disaster_vehicle != INVALID_VEHICLE && u->disaster_vehicle != dv->index) {
 							delete v;
 							continue;
 						} else {


### PR DESCRIPTION
## Motivation / Problem

AfterLoadVehicles is called in the reload NewGRFs path.
The small UFO disaster handling in #12064 / df691eb3 is not idempotent, so reloading GRFs destructed all small UFOs currently targeting a road vehicle.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
