### PR TITLE
Remove: setting_newgame console command

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2163,25 +2163,6 @@ DEF_CONSOLE_CMD(ConSetting)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConSettingNewgame)
-{
-	if (argc == 0) {
-		IConsolePrint(CC_HELP, "Change setting for the next game. Usage: 'setting_newgame <name> [<value>]'.");
-		IConsolePrint(CC_HELP, "Omitting <value> will print out the current value of the setting.");
-		return true;
-	}
-
-	if (argc == 1 || argc > 3) return false;
-
-	if (argc == 2) {
-		IConsoleGetSetting(argv[1], true);
-	} else {
-		IConsoleSetSetting(argv[1], argv[2], true);
-	}
-
-	return true;
-}
-
 DEF_CONSOLE_CMD(ConListSettings)
 {
 	if (argc == 0) {
@@ -2643,7 +2624,6 @@ void IConsoleStdLibRegister()
 	IConsole::CmdRegister("clear",                   ConClearBuffer);
 	IConsole::CmdRegister("font",                    ConFont);
 	IConsole::CmdRegister("setting",                 ConSetting);
-	IConsole::CmdRegister("setting_newgame",         ConSettingNewgame);
 	IConsole::CmdRegister("list_settings",           ConListSettings);
 	IConsole::CmdRegister("gamelog",                 ConGamelogPrint);
 	IConsole::CmdRegister("rescan_newgrf",           ConRescanNewGRF);
@@ -2654,7 +2634,6 @@ void IConsoleStdLibRegister()
 	IConsole::AliasRegister("newmap",                "newgame");
 	IConsole::AliasRegister("patch",                 "setting %+");
 	IConsole::AliasRegister("set",                   "setting %+");
-	IConsole::AliasRegister("set_newgame",           "setting_newgame %+");
 	IConsole::AliasRegister("list_patches",          "list_settings %+");
 	IConsole::AliasRegister("developer",             "setting developer %+");
 

--- a/src/settings_func.h
+++ b/src/settings_func.h
@@ -15,9 +15,9 @@
 
 struct IniFile;
 
-void IConsoleSetSetting(const char *name, const char *value, bool force_newgame = false);
+void IConsoleSetSetting(const char *name, const char *value);
 void IConsoleSetSetting(const char *name, int32_t value);
-void IConsoleGetSetting(const char *name, bool force_newgame = false);
+void IConsoleGetSetting(const char *name);
 void IConsoleListSettings(const char *prefilter);
 
 void LoadFromConfig(bool minimal = false);

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -379,7 +379,7 @@ typedef std::span<const SettingVariant> SettingTable;
 
 const SettingDesc *GetSettingFromName(const std::string_view name);
 void GetSaveLoadFromSettingTable(SettingTable settings, std::vector<SaveLoad> &saveloads);
-bool SetSettingValue(const IntSettingDesc *sd, int32_t value, bool force_newgame = false);
-bool SetSettingValue(const StringSettingDesc *sd, const std::string value, bool force_newgame = false);
+bool SetSettingValue(const IntSettingDesc *sd, int32_t value);
+bool SetSettingValue(const StringSettingDesc *sd, const std::string value);
 
 #endif /* SETTINGS_INTERNAL_H */


### PR DESCRIPTION
## Motivation / Problem

#12059

None of the pre and post callbacks which do different things for the active game and game menu cases correctly handle changing settings in this way (the interface offers no means to do so).

## Description

Remove setting_newgame console command
Remove now unused force_newgame parameters

Fixes: #12059

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
