### PR TITLE
Fix: survey-time seconds for clients was calculated wrong

### DIFF
--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -881,6 +881,9 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_MAP_DONE(Packet
 	/* Say we received the map and loaded it correctly! */
 	SendMapOk();
 
+	/* As we skipped switch-mode, update the time we "switched". */
+	_switch_mode_time = std::chrono::steady_clock::now();
+
 	ShowClientList();
 
 	/* New company/spectator (invalid company) or company we want to join is not active


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When a client joins a game, switch-mode is skipped (the game is loaded directly from the main menu which force-changes the game-mode, without going via switch-mode). This appears to be the only way where you can bypass switch-mode.

In result, the survey-time recorded "seconds" in the game was based on the last switch-mode executed; in most cases, that was never. Which, depending on the compiler/OS, could mean that the "seconds" recorded became the amount of seconds since 1970, or since you started your computer.

Both ways, very wrong.


## Description

Set the "switch mode" time to now() when joining a network game.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
