### PR TITLE
Fix f1144de: "knots" missing from settings units list.

### DIFF
--- a/src/table/settings/locale_settings.ini
+++ b/src/table/settings/locale_settings.ini
@@ -13,7 +13,7 @@ static void SettingsValueVelocityUnit(const IntSettingDesc &sd, uint first_param
 uint8_t _old_units;                                      ///< Old units from old savegames
 
 static constexpr std::initializer_list<const char*> _locale_currencies{"GBP", "USD", "EUR", "JPY", "ATS", "BEF", "CHF", "CZK", "DEM", "DKK", "ESP", "FIM", "FRF", "GRD", "HUF", "ISK", "ITL", "NLG", "NOK", "PLN", "RON", "RUR", "SIT", "SEK", "TRY", "SKK", "BRL", "EEK", "LTL", "KRW", "ZAR", "custom", "GEL", "IRR", "RUB", "MXN", "NTD", "CNY", "HKD", "INR", "IDR", "MYR", "LVL"};
-static constexpr std::initializer_list<const char*> _locale_units{"imperial", "metric", "si", "gameunits"};
+static constexpr std::initializer_list<const char*> _locale_units{"imperial", "metric", "si", "gameunits", "knots"};
 
 static_assert(_locale_currencies.size() == CURRENCY_END);
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Knots were added as a setting but not included in the settings list so were saved as a number instead of string. This affects survey results.

```
[locale]
units_velocity_nautical = 4
```

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add "knots" string to list.

```
[locale]
units_velocity_nautical = knots
```

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
