### PR TITLE
Codechange: Skip non-water water region patches in neigbor search

### DIFF
--- a/src/pathfinder/water_regions.cpp
+++ b/src/pathfinder/water_regions.cpp
@@ -22,7 +22,6 @@
 
 using TWaterRegionTraversabilityBits = uint16_t;
 constexpr TWaterRegionPatchLabel FIRST_REGION_LABEL = 1;
-constexpr TWaterRegionPatchLabel INVALID_WATER_REGION_PATCH = 0;
 
 static_assert(sizeof(TWaterRegionTraversabilityBits) * 8 == WATER_REGION_EDGE_LENGTH);
 static_assert(sizeof(TWaterRegionPatchLabel) == sizeof(byte)); // Important for the hash calculation.
@@ -321,6 +320,8 @@ void InvalidateWaterRegion(TileIndex tile)
  */
 static inline void VisitAdjacentWaterRegionPatchNeighbors(const WaterRegionPatchDesc &water_region_patch, DiagDirection side, TVisitWaterRegionPatchCallBack &func)
 {
+	if (water_region_patch.label == INVALID_WATER_REGION_PATCH) return;
+
 	const WaterRegion &current_region = GetUpdatedWaterRegion(water_region_patch.x, water_region_patch.y);
 
 	const TileIndexDiffC offset = TileIndexDiffCByDiagDir(side);
@@ -354,6 +355,7 @@ static inline void VisitAdjacentWaterRegionPatchNeighbors(const WaterRegionPatch
 
 		const TileIndex neighbor_edge_tile = GetEdgeTileCoordinate(nx, ny, opposite_side, x_or_y);
 		const TWaterRegionPatchLabel neighbor_label = neighboring_region.GetLabel(neighbor_edge_tile);
+		assert(neighbor_label != INVALID_WATER_REGION_PATCH);
 		if (std::find(unique_labels.begin(), unique_labels.end(), neighbor_label) == unique_labels.end()) unique_labels.push_back(neighbor_label);
 	}
 	for (TWaterRegionPatchLabel unique_label : unique_labels) func(WaterRegionPatchDesc{ nx, ny, unique_label });
@@ -367,6 +369,8 @@ static inline void VisitAdjacentWaterRegionPatchNeighbors(const WaterRegionPatch
  */
 void VisitWaterRegionPatchNeighbors(const WaterRegionPatchDesc &water_region_patch, TVisitWaterRegionPatchCallBack &callback)
 {
+	if (water_region_patch.label == INVALID_WATER_REGION_PATCH) return;
+
 	const WaterRegion &current_region = GetUpdatedWaterRegion(water_region_patch.x, water_region_patch.y);
 
 	/* Visit adjacent water region patches in each cardinal direction */

--- a/src/pathfinder/water_regions.h
+++ b/src/pathfinder/water_regions.h
@@ -18,6 +18,7 @@ using TWaterRegionIndex = uint;
 
 constexpr int WATER_REGION_EDGE_LENGTH = 16;
 constexpr int WATER_REGION_NUMBER_OF_TILES = WATER_REGION_EDGE_LENGTH * WATER_REGION_EDGE_LENGTH;
+constexpr TWaterRegionPatchLabel INVALID_WATER_REGION_PATCH = 0;
 
 /**
  * Describes a single interconnected patch of water within a particular water region.

--- a/src/pathfinder/yapf/yapf_ship_regions.cpp
+++ b/src/pathfinder/yapf/yapf_ship_regions.cpp
@@ -102,6 +102,7 @@ private:
 public:
 	void AddOrigin(const WaterRegionPatchDesc &water_region_patch)
 	{
+		if (water_region_patch.label == INVALID_WATER_REGION_PATCH) return;
 		if (!HasOrigin(water_region_patch)) m_origin_keys.push_back(CYapfRegionPatchNodeKey{ water_region_patch });
 	}
 


### PR DESCRIPTION
## Motivation / Problem / Description

This address some of the points mentioned in #11862 but doesn't fully solve it. But it generally makes the water region neighbor search more robust. If an invalid water region patch is provided (in English: a patch of not-water is provided) then the functions simply return and do nothing. This makes them more resilient against edge cases such as what happens in #11862.

## Limitations

None

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
