### PR TITLE
Fix a253205: division by zero when attempting to format some short currencies

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -404,7 +404,7 @@ void InitializeNumberFormats()
 		loaded_number_abbreviations = !res.has_value();
 	}
 	if (!loaded_number_abbreviations) ParseNumberAbbreviations(_number_abbreviations, _current_language->number_abbreviations);
-	_number_abbreviations.emplace_back(0, _number_format_separators);
+	_number_abbreviations.emplace_back(1, _number_format_separators);
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Division by zero / crash with some abbreviated currencies.
https://cdn.discordapp.com/attachments/1008473233844097104/1208515221522620476/image.png?ex=65e39081&is=65d11b81&hm=b3658bc6858bb5a5bae487e87ca5649228cb9cf387ffd10242d5b0397d48bc90&


## Description

Division by 0 that should have been a division by 1.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
