### PR TITLE
Add: Portuguese Escudo currency

### DIFF
--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -70,6 +70,7 @@ static const CurrencySpec origin_currency_specs[CURRENCY_END] = {
 	{   19, "", CF_NOEURO, "Rp",       "",             "IDR", 0, STR_GAME_OPTIONS_CURRENCY_IDR    }, ///< Indonesian Rupiah
 	{    5, "", CF_NOEURO, "RM",       "",             "MYR", 0, STR_GAME_OPTIONS_CURRENCY_MYR    }, ///< Malaysian Ringgit
 	{    1, "", 2014,      "",         NBSP "Ls",      "LVL", 1, STR_GAME_OPTIONS_CURRENCY_LVL    }, ///< latvian lats
+	{  400, "", 2002,      "",         "$00",          "PTE", 1, STR_GAME_OPTIONS_CURRENCY_PTE    }, ///< portuguese escudo
 };
 
 /** Array of currencies used by the system */

--- a/src/currency.h
+++ b/src/currency.h
@@ -67,6 +67,7 @@ enum Currencies {
 	CURRENCY_IDR,       ///< Indonesian Rupiah
 	CURRENCY_MYR,       ///< Malaysian Ringgit
 	CURRENCY_LVL,       ///< Latvian Lats
+	CURRENCY_PTE,       ///< Portuguese Escudo
 	CURRENCY_END,       ///< always the last item
 };
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -967,7 +967,7 @@ STR_GAME_OPTIONS_CURRENCY_UNITS_DROPDOWN_TOOLTIP                :{BLACK}Currency
 
 STR_GAME_OPTIONS_CURRENCY_CODE                                  :{STRING} ({RAW_STRING})
 
-###length 43
+###length 44
 STR_GAME_OPTIONS_CURRENCY_GBP                                   :British Pound
 STR_GAME_OPTIONS_CURRENCY_USD                                   :American Dollar
 STR_GAME_OPTIONS_CURRENCY_EUR                                   :Euro
@@ -1011,6 +1011,7 @@ STR_GAME_OPTIONS_CURRENCY_INR                                   :Indian Rupee
 STR_GAME_OPTIONS_CURRENCY_IDR                                   :Indonesian Rupiah
 STR_GAME_OPTIONS_CURRENCY_MYR                                   :Malaysian Ringgit
 STR_GAME_OPTIONS_CURRENCY_LVL                                   :Latvian Lats
+STR_GAME_OPTIONS_CURRENCY_PTE                                   :Portuguese Escudo
 
 STR_GAME_OPTIONS_AUTOSAVE_FRAME                                 :{BLACK}Autosave
 STR_GAME_OPTIONS_AUTOSAVE_DROPDOWN_TOOLTIP                      :{BLACK}Select interval between automatic game saves

--- a/src/table/settings/locale_settings.ini
+++ b/src/table/settings/locale_settings.ini
@@ -12,7 +12,7 @@ static void SettingsValueVelocityUnit(const IntSettingDesc &sd, uint first_param
 
 uint8_t _old_units;                                      ///< Old units from old savegames
 
-static constexpr std::initializer_list<const char*> _locale_currencies{"GBP", "USD", "EUR", "JPY", "ATS", "BEF", "CHF", "CZK", "DEM", "DKK", "ESP", "FIM", "FRF", "GRD", "HUF", "ISK", "ITL", "NLG", "NOK", "PLN", "RON", "RUR", "SIT", "SEK", "TRY", "SKK", "BRL", "EEK", "LTL", "KRW", "ZAR", "custom", "GEL", "IRR", "RUB", "MXN", "NTD", "CNY", "HKD", "INR", "IDR", "MYR", "LVL"};
+static constexpr std::initializer_list<const char*> _locale_currencies{"GBP", "USD", "EUR", "JPY", "ATS", "BEF", "CHF", "CZK", "DEM", "DKK", "ESP", "FIM", "FRF", "GRD", "HUF", "ISK", "ITL", "NLG", "NOK", "PLN", "RON", "RUR", "SIT", "SEK", "TRY", "SKK", "BRL", "EEK", "LTL", "KRW", "ZAR", "custom", "GEL", "IRR", "RUB", "MXN", "NTD", "CNY", "HKD", "INR", "IDR", "MYR", "LVL", "PTE"};
 static constexpr std::initializer_list<const char*> _locale_units{"imperial", "metric", "si", "gameunits", "knots"};
 
 static_assert(_locale_currencies.size() == CURRENCY_END);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation

- A good chunk of historical pre-Euro currencies are available
- Some European currencies were added during OpenTTD development that weren't originally available in TTD
- Portuguese (European / Portugal) is available as a selectable language
- Portuguese Escudo is not available

Adding to this points, there are also some Portugal scenarios / heightmaps available for download in-game, where this addition is welcome.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->



## Description

- Add Portuguese Escudo (PTE) as one of the game's currencies
- The exchange rate is 400$00 = £1, this value is based on the implemented rate for the Euro in-game (€2 = £1) and rate for the Euro in 2002 when the Escudo was discontinued (200$00 = €1) 
- $ is both in place of the currency symbol and as the decimal separator. Two decimal places are displayed even if the value is an integer ($00).
- If the value is written by hand the currency symbol use two strokes instead of one. This practice is not standardized. Unicode considers the one stroked $ and the two stroked version a typeface design choice. So in computer software $ was used in it's place.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

A new string was added to the English translation, new translations are needed in other available languages.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
