### PR TITLE
Fix a253205: remove (now) unused currency separator

### DIFF
--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -21,55 +21,55 @@
 
 #include "safeguards.h"
 
-	/*   exchange rate    prefix                             code
-	 *   |  separator        |           postfix              |  symbol_pos
-	 *   |   |   Euro year   |              |                 |     | name
-	 *   |   |    |          |              |                 |     |  | */
+	/*   exchange rate             postfix         code
+	 *   |  Euro year              |               |     symbol_pos
+	 *   |  |          prefix      |               |     | name
+	 *   |  |          |           |               |     |  | */
 /** The original currency specifications. */
 static const CurrencySpec origin_currency_specs[CURRENCY_END] = {
-	{    1, "", CF_NOEURO, "\u00a3",   "",             "GBP", 0, STR_GAME_OPTIONS_CURRENCY_GBP    }, ///< british pound
-	{    2, "", CF_NOEURO, "$",        "",             "USD", 0, STR_GAME_OPTIONS_CURRENCY_USD    }, ///< american dollar
-	{    2, "", CF_ISEURO, "\u20ac",   "",             "EUR", 0, STR_GAME_OPTIONS_CURRENCY_EUR    }, ///< euro
-	{  220, "", CF_NOEURO, "\u00a5",   "",             "JPY", 0, STR_GAME_OPTIONS_CURRENCY_JPY    }, ///< japanese yen
-	{   27, "", 2002,      "",         NBSP "S.",      "ATS", 1, STR_GAME_OPTIONS_CURRENCY_ATS    }, ///< austrian schilling
-	{   81, "", 2002,      "BEF" NBSP, "",             "BEF", 0, STR_GAME_OPTIONS_CURRENCY_BEF    }, ///< belgian franc
-	{    2, "", CF_NOEURO, "CHF" NBSP, "",             "CHF", 0, STR_GAME_OPTIONS_CURRENCY_CHF    }, ///< swiss franc
-	{   41, "", CF_NOEURO, "",         NBSP "K\u010d", "CZK", 1, STR_GAME_OPTIONS_CURRENCY_CZK    }, ///< czech koruna
-	{    4, "", 2002,      "DM" NBSP,  "",             "DEM", 0, STR_GAME_OPTIONS_CURRENCY_DEM    }, ///< deutsche mark
-	{   11, "", CF_NOEURO, "",         NBSP "kr",      "DKK", 1, STR_GAME_OPTIONS_CURRENCY_DKK    }, ///< danish krone
-	{  333, "", 2002,      "Pts" NBSP, "",             "ESP", 0, STR_GAME_OPTIONS_CURRENCY_ESP    }, ///< spanish peseta
-	{   12, "", 2002,      "",         NBSP "mk",      "FIM", 1, STR_GAME_OPTIONS_CURRENCY_FIM    }, ///< finnish markka
-	{   13, "", 2002,      "FF" NBSP,  "",             "FRF", 0, STR_GAME_OPTIONS_CURRENCY_FRF    }, ///< french franc
-	{  681, "", 2002,      "",         "Dr.",          "GRD", 1, STR_GAME_OPTIONS_CURRENCY_GRD    }, ///< greek drachma
-	{  378, "", CF_NOEURO, "",         NBSP "Ft",      "HUF", 1, STR_GAME_OPTIONS_CURRENCY_HUF    }, ///< hungarian forint
-	{  130, "", CF_NOEURO, "",         NBSP "Kr",      "ISK", 1, STR_GAME_OPTIONS_CURRENCY_ISK    }, ///< icelandic krona
-	{ 3873, "", 2002,      "",         NBSP "L.",      "ITL", 1, STR_GAME_OPTIONS_CURRENCY_ITL    }, ///< italian lira
-	{    4, "", 2002,      "NLG" NBSP, "",             "NLG", 0, STR_GAME_OPTIONS_CURRENCY_NLG    }, ///< dutch gulden
-	{   12, "", CF_NOEURO, "",         NBSP "Kr",      "NOK", 1, STR_GAME_OPTIONS_CURRENCY_NOK    }, ///< norwegian krone
-	{    6, "", CF_NOEURO, "",         NBSP "z\u0142", "PLN", 1, STR_GAME_OPTIONS_CURRENCY_PLN    }, ///< polish zloty
-	{    5, "", CF_NOEURO, "",         NBSP "Lei",     "RON", 1, STR_GAME_OPTIONS_CURRENCY_RON    }, ///< romanian leu
-	{   50, "", CF_NOEURO, "",         NBSP "p",       "RUR", 1, STR_GAME_OPTIONS_CURRENCY_RUR    }, ///< russian rouble
-	{  479, "", 2007,      "",         NBSP "SIT",     "SIT", 1, STR_GAME_OPTIONS_CURRENCY_SIT    }, ///< slovenian tolar
-	{   13, "", CF_NOEURO, "",         NBSP "Kr",      "SEK", 1, STR_GAME_OPTIONS_CURRENCY_SEK    }, ///< swedish krona
-	{    3, "", CF_NOEURO, "",         NBSP "TL",      "TRY", 1, STR_GAME_OPTIONS_CURRENCY_TRY    }, ///< turkish lira
-	{   60, "", 2009,      "",         NBSP "Sk",      "SKK", 1, STR_GAME_OPTIONS_CURRENCY_SKK    }, ///< slovak koruna
-	{    4, "", CF_NOEURO, "R$" NBSP,  "",             "BRL", 0, STR_GAME_OPTIONS_CURRENCY_BRL    }, ///< brazil real
-	{   31, "", 2011,      "",         NBSP "EEK",     "EEK", 1, STR_GAME_OPTIONS_CURRENCY_EEK    }, ///< estonian krooni
-	{    4, "", 2015,      "",         NBSP "Lt",      "LTL", 1, STR_GAME_OPTIONS_CURRENCY_LTL    }, ///< lithuanian litas
-	{ 1850, "", CF_NOEURO, "\u20a9",   "",             "KRW", 0, STR_GAME_OPTIONS_CURRENCY_KRW    }, ///< south korean won
-	{   13, "", CF_NOEURO, "R" NBSP,   "",             "ZAR", 0, STR_GAME_OPTIONS_CURRENCY_ZAR    }, ///< south african rand
-	{    1, "", CF_NOEURO, "",         "",             "",    2, STR_GAME_OPTIONS_CURRENCY_CUSTOM }, ///< custom currency (add further languages below)
-	{    3, "", CF_NOEURO, "",         NBSP "GEL",     "GEL", 1, STR_GAME_OPTIONS_CURRENCY_GEL    }, ///< Georgian Lari
-	{ 4901, "", CF_NOEURO, "",         NBSP "Rls",     "IRR", 1, STR_GAME_OPTIONS_CURRENCY_IRR    }, ///< Iranian Rial
-	{   80, "", CF_NOEURO, "",         NBSP "rub",     "RUB", 1, STR_GAME_OPTIONS_CURRENCY_RUB    }, ///< New Russian Ruble
-	{   24, "", CF_NOEURO, "$",        "",             "MXN", 0, STR_GAME_OPTIONS_CURRENCY_MXN    }, ///< Mexican peso
-	{   40, "", CF_NOEURO, "NTD" NBSP, "",             "NTD", 0, STR_GAME_OPTIONS_CURRENCY_NTD    }, ///< new taiwan dollar
-	{    8, "", CF_NOEURO, "\u00a5",   "",             "CNY", 0, STR_GAME_OPTIONS_CURRENCY_CNY    }, ///< chinese renminbi
-	{   10, "", CF_NOEURO, "HKD" NBSP, "",             "HKD", 0, STR_GAME_OPTIONS_CURRENCY_HKD    }, ///< hong kong dollar
-	{   90, "", CF_NOEURO, "\u20b9",   "",             "INR", 0, STR_GAME_OPTIONS_CURRENCY_INR    }, ///< Indian Rupee
-	{   19, "", CF_NOEURO, "Rp",       "",             "IDR", 0, STR_GAME_OPTIONS_CURRENCY_IDR    }, ///< Indonesian Rupiah
-	{    5, "", CF_NOEURO, "RM",       "",             "MYR", 0, STR_GAME_OPTIONS_CURRENCY_MYR    }, ///< Malaysian Ringgit
-	{    1, "", 2014,      "",         NBSP "Ls",      "LVL", 1, STR_GAME_OPTIONS_CURRENCY_LVL    }, ///< latvian lats
+	{    1, CF_NOEURO, "\u00a3",   "",             "GBP", 0, STR_GAME_OPTIONS_CURRENCY_GBP    }, ///< british pound
+	{    2, CF_NOEURO, "$",        "",             "USD", 0, STR_GAME_OPTIONS_CURRENCY_USD    }, ///< american dollar
+	{    2, CF_ISEURO, "\u20ac",   "",             "EUR", 0, STR_GAME_OPTIONS_CURRENCY_EUR    }, ///< euro
+	{  220, CF_NOEURO, "\u00a5",   "",             "JPY", 0, STR_GAME_OPTIONS_CURRENCY_JPY    }, ///< japanese yen
+	{   27, 2002,      "",         NBSP "S.",      "ATS", 1, STR_GAME_OPTIONS_CURRENCY_ATS    }, ///< austrian schilling
+	{   81, 2002,      "BEF" NBSP, "",             "BEF", 0, STR_GAME_OPTIONS_CURRENCY_BEF    }, ///< belgian franc
+	{    2, CF_NOEURO, "CHF" NBSP, "",             "CHF", 0, STR_GAME_OPTIONS_CURRENCY_CHF    }, ///< swiss franc
+	{   41, CF_NOEURO, "",         NBSP "K\u010d", "CZK", 1, STR_GAME_OPTIONS_CURRENCY_CZK    }, ///< czech koruna
+	{    4, 2002,      "DM" NBSP,  "",             "DEM", 0, STR_GAME_OPTIONS_CURRENCY_DEM    }, ///< deutsche mark
+	{   11, CF_NOEURO, "",         NBSP "kr",      "DKK", 1, STR_GAME_OPTIONS_CURRENCY_DKK    }, ///< danish krone
+	{  333, 2002,      "Pts" NBSP, "",             "ESP", 0, STR_GAME_OPTIONS_CURRENCY_ESP    }, ///< spanish peseta
+	{   12, 2002,      "",         NBSP "mk",      "FIM", 1, STR_GAME_OPTIONS_CURRENCY_FIM    }, ///< finnish markka
+	{   13, 2002,      "FF" NBSP,  "",             "FRF", 0, STR_GAME_OPTIONS_CURRENCY_FRF    }, ///< french franc
+	{  681, 2002,      "",         "Dr.",          "GRD", 1, STR_GAME_OPTIONS_CURRENCY_GRD    }, ///< greek drachma
+	{  378, CF_NOEURO, "",         NBSP "Ft",      "HUF", 1, STR_GAME_OPTIONS_CURRENCY_HUF    }, ///< hungarian forint
+	{  130, CF_NOEURO, "",         NBSP "Kr",      "ISK", 1, STR_GAME_OPTIONS_CURRENCY_ISK    }, ///< icelandic krona
+	{ 3873, 2002,      "",         NBSP "L.",      "ITL", 1, STR_GAME_OPTIONS_CURRENCY_ITL    }, ///< italian lira
+	{    4, 2002,      "NLG" NBSP, "",             "NLG", 0, STR_GAME_OPTIONS_CURRENCY_NLG    }, ///< dutch gulden
+	{   12, CF_NOEURO, "",         NBSP "Kr",      "NOK", 1, STR_GAME_OPTIONS_CURRENCY_NOK    }, ///< norwegian krone
+	{    6, CF_NOEURO, "",         NBSP "z\u0142", "PLN", 1, STR_GAME_OPTIONS_CURRENCY_PLN    }, ///< polish zloty
+	{    5, CF_NOEURO, "",         NBSP "Lei",     "RON", 1, STR_GAME_OPTIONS_CURRENCY_RON    }, ///< romanian leu
+	{   50, CF_NOEURO, "",         NBSP "p",       "RUR", 1, STR_GAME_OPTIONS_CURRENCY_RUR    }, ///< russian rouble
+	{  479, 2007,      "",         NBSP "SIT",     "SIT", 1, STR_GAME_OPTIONS_CURRENCY_SIT    }, ///< slovenian tolar
+	{   13, CF_NOEURO, "",         NBSP "Kr",      "SEK", 1, STR_GAME_OPTIONS_CURRENCY_SEK    }, ///< swedish krona
+	{    3, CF_NOEURO, "",         NBSP "TL",      "TRY", 1, STR_GAME_OPTIONS_CURRENCY_TRY    }, ///< turkish lira
+	{   60, 2009,      "",         NBSP "Sk",      "SKK", 1, STR_GAME_OPTIONS_CURRENCY_SKK    }, ///< slovak koruna
+	{    4, CF_NOEURO, "R$" NBSP,  "",             "BRL", 0, STR_GAME_OPTIONS_CURRENCY_BRL    }, ///< brazil real
+	{   31, 2011,      "",         NBSP "EEK",     "EEK", 1, STR_GAME_OPTIONS_CURRENCY_EEK    }, ///< estonian krooni
+	{    4, 2015,      "",         NBSP "Lt",      "LTL", 1, STR_GAME_OPTIONS_CURRENCY_LTL    }, ///< lithuanian litas
+	{ 1850, CF_NOEURO, "\u20a9",   "",             "KRW", 0, STR_GAME_OPTIONS_CURRENCY_KRW    }, ///< south korean won
+	{   13, CF_NOEURO, "R" NBSP,   "",             "ZAR", 0, STR_GAME_OPTIONS_CURRENCY_ZAR    }, ///< south african rand
+	{    1, CF_NOEURO, "",         "",             "",    2, STR_GAME_OPTIONS_CURRENCY_CUSTOM }, ///< custom currency (add further languages below)
+	{    3, CF_NOEURO, "",         NBSP "GEL",     "GEL", 1, STR_GAME_OPTIONS_CURRENCY_GEL    }, ///< Georgian Lari
+	{ 4901, CF_NOEURO, "",         NBSP "Rls",     "IRR", 1, STR_GAME_OPTIONS_CURRENCY_IRR    }, ///< Iranian Rial
+	{   80, CF_NOEURO, "",         NBSP "rub",     "RUB", 1, STR_GAME_OPTIONS_CURRENCY_RUB    }, ///< New Russian Ruble
+	{   24, CF_NOEURO, "$",        "",             "MXN", 0, STR_GAME_OPTIONS_CURRENCY_MXN    }, ///< Mexican peso
+	{   40, CF_NOEURO, "NTD" NBSP, "",             "NTD", 0, STR_GAME_OPTIONS_CURRENCY_NTD    }, ///< new taiwan dollar
+	{    8, CF_NOEURO, "\u00a5",   "",             "CNY", 0, STR_GAME_OPTIONS_CURRENCY_CNY    }, ///< chinese renminbi
+	{   10, CF_NOEURO, "HKD" NBSP, "",             "HKD", 0, STR_GAME_OPTIONS_CURRENCY_HKD    }, ///< hong kong dollar
+	{   90, CF_NOEURO, "\u20b9",   "",             "INR", 0, STR_GAME_OPTIONS_CURRENCY_INR    }, ///< Indian Rupee
+	{   19, CF_NOEURO, "Rp",       "",             "IDR", 0, STR_GAME_OPTIONS_CURRENCY_IDR    }, ///< Indonesian Rupiah
+	{    5, CF_NOEURO, "RM",       "",             "MYR", 0, STR_GAME_OPTIONS_CURRENCY_MYR    }, ///< Malaysian Ringgit
+	{    1, 2014,      "",         NBSP "Ls",      "LVL", 1, STR_GAME_OPTIONS_CURRENCY_LVL    }, ///< latvian lats
 };
 
 /** Array of currencies used by the system */

--- a/src/currency.h
+++ b/src/currency.h
@@ -73,7 +73,6 @@ enum Currencies {
 /** Specification of a currency. */
 struct CurrencySpec {
 	uint16_t rate;           ///< The conversion rate compared to the base currency.
-	std::string separator; ///< The thousands separator for this currency.
 	TimerGameCalendar::Year to_euro; ///< Year of switching to the Euro. May also be #CF_NOEURO or #CF_ISEURO.
 	std::string prefix;    ///< Prefix to apply when formatting money in this currency.
 	std::string suffix;    ///< Suffix to apply when formatting money in this currency.
@@ -92,8 +91,8 @@ struct CurrencySpec {
 
 	CurrencySpec() = default;
 
-	CurrencySpec(uint16_t rate, const char *separator, TimerGameCalendar::Year to_euro, const char *prefix, const char *suffix, const char *code, byte symbol_pos, StringID name) :
-		rate(rate), separator(separator), to_euro(to_euro), prefix(prefix), suffix(suffix), code(code), symbol_pos(symbol_pos), name(name)
+	CurrencySpec(uint16_t rate, TimerGameCalendar::Year to_euro, const char *prefix, const char *suffix, const char *code, byte symbol_pos, StringID name) :
+		rate(rate), to_euro(to_euro), prefix(prefix), suffix(suffix), code(code), symbol_pos(symbol_pos), name(name)
 	{
 	}
 };

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1117,9 +1117,6 @@ STR_CURRENCY_DECREASE_EXCHANGE_RATE_TOOLTIP                     :{BLACK}Decrease
 STR_CURRENCY_INCREASE_EXCHANGE_RATE_TOOLTIP                     :{BLACK}Increase the amount of your currency for one Pound (£)
 STR_CURRENCY_SET_EXCHANGE_RATE_TOOLTIP                          :{BLACK}Set the exchange rate of your currency for one Pound (£)
 
-STR_CURRENCY_SEPARATOR                                          :{LTBLUE}Separator: {ORANGE}{RAW_STRING}
-STR_CURRENCY_SET_CUSTOM_CURRENCY_SEPARATOR_TOOLTIP              :{BLACK}Set the separator for your currency
-
 STR_CURRENCY_PREFIX                                             :{LTBLUE}Prefix: {ORANGE}{RAW_STRING}
 STR_CURRENCY_SET_CUSTOM_CURRENCY_PREFIX_TOOLTIP                 :{BLACK}Set the prefix string for your currency
 STR_CURRENCY_SUFFIX                                             :{LTBLUE}Suffix: {ORANGE}{RAW_STRING}

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -2746,8 +2746,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint gvid, int numinfo, int prop, By
 				uint16_t options = buf->ReadWord();
 
 				if (curidx < CURRENCY_END) {
-					_currency_specs[curidx].separator.clear();
-					_currency_specs[curidx].separator.push_back(GB(options, 0, 8));
+					/* Ignore the thousands separator, as this is a translated thing. */
 					/* By specifying only one bit, we prevent errors,
 					 * since newgrf specs said that only 0 and 1 can be set for symbol_pos */
 					_currency_specs[curidx].symbol_pos = GB(options, 8, 1);

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2989,7 +2989,6 @@ struct CustomCurrencyWindow : Window {
 	{
 		switch (widget) {
 			case WID_CC_RATE:      SetDParam(0, 1); SetDParam(1, 1);            break;
-			case WID_CC_SEPARATOR: SetDParamStr(0, _custom_currency.separator); break;
 			case WID_CC_PREFIX:    SetDParamStr(0, _custom_currency.prefix);    break;
 			case WID_CC_SUFFIX:    SetDParamStr(0, _custom_currency.suffix);    break;
 			case WID_CC_YEAR:
@@ -3015,7 +3014,6 @@ struct CustomCurrencyWindow : Window {
 				break;
 
 			/* Set the appropriate width for the edit buttons. */
-			case WID_CC_SEPARATOR_EDIT:
 			case WID_CC_PREFIX_EDIT:
 			case WID_CC_SUFFIX_EDIT:
 				*size = maxdim(*size, {(uint)SETTING_BUTTON_WIDTH, (uint)SETTING_BUTTON_HEIGHT});
@@ -3056,14 +3054,6 @@ struct CustomCurrencyWindow : Window {
 				len = 5;
 				line = WID_CC_RATE;
 				afilter = CS_NUMERAL;
-				break;
-
-			case WID_CC_SEPARATOR_EDIT:
-			case WID_CC_SEPARATOR:
-				SetDParamStr(0, _custom_currency.separator);
-				str = STR_JUST_RAW_STRING;
-				len = 7;
-				line = WID_CC_SEPARATOR;
 				break;
 
 			case WID_CC_PREFIX_EDIT:
@@ -3121,10 +3111,6 @@ struct CustomCurrencyWindow : Window {
 				_custom_currency.rate = Clamp(atoi(str), 1, UINT16_MAX);
 				break;
 
-			case WID_CC_SEPARATOR: // Thousands separator
-				_custom_currency.separator = str;
-				break;
-
 			case WID_CC_PREFIX:
 				_custom_currency.prefix = str;
 				break;
@@ -3164,10 +3150,6 @@ static constexpr NWidgetPart _nested_cust_currency_widgets[] = {
 						NWidget(WWT_PUSHARROWBTN, COLOUR_YELLOW, WID_CC_RATE_UP), SetDataTip(AWV_INCREASE, STR_CURRENCY_INCREASE_EXCHANGE_RATE_TOOLTIP),
 					EndContainer(),
 					NWidget(WWT_TEXT, COLOUR_BLUE, WID_CC_RATE), SetDataTip(STR_CURRENCY_EXCHANGE_RATE, STR_CURRENCY_SET_EXCHANGE_RATE_TOOLTIP), SetFill(1, 0),
-				EndContainer(),
-				NWidget(NWID_HORIZONTAL), SetPIP(0, WidgetDimensions::unscaled.hsep_wide, 0),
-					NWidget(WWT_PUSHBTN, COLOUR_DARK_BLUE, WID_CC_SEPARATOR_EDIT), SetDataTip(0x0, STR_CURRENCY_SET_CUSTOM_CURRENCY_SEPARATOR_TOOLTIP), SetFill(0, 1),
-					NWidget(WWT_TEXT, COLOUR_BLUE, WID_CC_SEPARATOR), SetDataTip(STR_CURRENCY_SEPARATOR, STR_CURRENCY_SET_CUSTOM_CURRENCY_SEPARATOR_TOOLTIP), SetFill(1, 0),
 				EndContainer(),
 				NWidget(NWID_HORIZONTAL), SetPIP(0, WidgetDimensions::unscaled.hsep_wide, 0),
 					NWidget(WWT_PUSHBTN, COLOUR_DARK_BLUE, WID_CC_PREFIX_EDIT), SetDataTip(0x0, STR_CURRENCY_SET_CUSTOM_CURRENCY_PREFIX_TOOLTIP), SetFill(0, 1),

--- a/src/table/settings/currency_settings.ini
+++ b/src/table/settings/currency_settings.ini
@@ -43,12 +43,6 @@ def      = 1
 min      = 0
 max      = UINT16_MAX
 
-[SDT_SSTR]
-var      = separator
-type     = SLE_STRQ
-def      = "".""
-cat      = SC_BASIC
-
 [SDT_VAR]
 var      = to_euro
 type     = SLE_INT32

--- a/src/widgets/settings_widget.h
+++ b/src/widgets/settings_widget.h
@@ -82,8 +82,6 @@ enum CustomCurrencyWidgets : WidgetID {
 	WID_CC_RATE_DOWN,      ///< Down button.
 	WID_CC_RATE_UP,        ///< Up button.
 	WID_CC_RATE,           ///< Rate of currency.
-	WID_CC_SEPARATOR_EDIT, ///< Separator edit button.
-	WID_CC_SEPARATOR,      ///< Current separator.
 	WID_CC_PREFIX_EDIT,    ///< Prefix edit button.
 	WID_CC_PREFIX,         ///< Current prefix.
 	WID_CC_SUFFIX_EDIT,    ///< Suffix edit button.


### PR DESCRIPTION
## Motivation / Problem

With the number format the custom currency separator was removed, as it's mutually exclusive with supporting CJK number formats.


## Description

Remove the remnants of the separator in the `CurrencySpec`.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
