### PR TITLE
Fix: ko-KR follows the western number formats for now

### DIFF
--- a/src/lang/korean.txt
+++ b/src/lang/korean.txt
@@ -3,8 +3,8 @@
 ##isocode ko_KR
 ##plural 11
 ##textdir ltr
-##numberformat 0000경0000조0000억0000만0000
-##numberabbreviations 4=0000경0000조0000억0000만|8=0000경0000조0000억|12=0000경0000조|16=0000경
+##numberformat 00,000,000,000,000,000,000
+##numberabbreviations 4=0000경{NBSP}0000조{NBSP}0000억{NBSP}0000만|8=0000경{NBSP}0000조{NBSP}0000억|12=0000경{NBSP}0000조|16=0000경
 ##decimalsep .
 ##winlangid 0x0412
 ##grflangid 0x3a


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As I described at #12123, the new number format for non-western language can not handle properly for Korean


## Description

For my language, Korean, follows the western number format just for now.

## Limitations

This PR just can be closed when a new enhancement will rise up.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
