### PR TITLE
Fix cb588d8d: Ordering of command per tick limit and pause mode filtering

### DIFF
--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -327,14 +327,14 @@ static void DistributeQueue(CommandQueue &queue, const NetworkClientSocket *owne
 
 	/* Not technically the most performant way, but consider clients rarely click more than once per tick. */
 	for (auto cp = queue.begin(); cp != queue.end(); /* removing some items */) {
-		/* Limit the number of commands per client per tick. */
-		if (--to_go < 0) break;
-
 		/* Do not distribute commands when paused and the command is not allowed while paused. */
 		if (_pause_mode != PM_UNPAUSED && !IsCommandAllowedWhilePaused(cp->cmd)) {
 			++cp;
 			continue;
 		}
+
+		/* Limit the number of commands per client per tick. */
+		if (--to_go < 0) break;
 
 		DistributeCommandPacket(*cp, owner);
 		NetworkAdminCmdLogging(owner, *cp);


### PR DESCRIPTION
## Motivation / Problem

The command per tick limit should be applied after the pause mode filter, instead of before.
Otherwise commands which may not distributed due to the pause mode can block the whole queue indefinitely.

## Description

The ordering was changed in cb588d8d, change it back

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
