### PR TITLE
Codechange: Scan station catchment tiles when removing station from nearby towns/industries.

### DIFF
--- a/src/station.cpp
+++ b/src/station.cpp
@@ -424,12 +424,24 @@ void Station::RemoveIndustryToDeliver(Industry *ind)
 
 
 /**
- * Remove this station from the nearby stations lists of all towns and industries.
+ * Remove this station from the nearby stations lists of nearby towns and industries.
  */
 void Station::RemoveFromAllNearbyLists()
 {
-	for (Town *t : Town::Iterate()) { t->stations_near.erase(this); }
-	for (Industry *i : Industry::Iterate()) { i->stations_near.erase(this); }
+	std::set<TownID> towns;
+	std::set<IndustryID> industries;
+
+	for (const auto &tile : this->catchment_tiles) {
+		TileType type = GetTileType(tile);
+		if (type == MP_HOUSE) {
+			towns.insert(GetTownIndex(tile));
+		} else if (type == MP_INDUSTRY) {
+			industries.insert(GetIndustryIndex(tile));
+		}
+	}
+
+	for (const TownID &townid : towns) { Town::Get(townid)->stations_near.erase(this); }
+	for (const IndustryID &industryid : industries) { Industry::Get(industryid)->stations_near.erase(this); }
 }
 
 /**


### PR DESCRIPTION

<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

On a map with lots of towns and industries, along with lots of stations, iterating the complete town and industry pool to (possibly) remove the station from town and industry nearby stations lists can take some time.

This is most noticeable when a company goes bankrupt as lots of updates are done together, but also has a small impact on removing stations parts.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Stations also have a list of catchment tiles covered, which is updated after the town and industry nearby station lists are cleared.

So we can avoid iterating all towns and industries when updating station catchment, and scan a limited portion of the map instead.

This provides a modest performance benefit when many towns/industries exist:

| game         | stations | towns  | industries | action                          | before      | after     |
| ------------ | -------- | ------ | ---------- | ------------------------------- | ----------- | --------- |
| reddit 1     | 591      | 512    | 1,560      | RemoveFromAllNearbyLists() x100 | 2,420µs     | 61µs      |
| Wentbourne   | 2,648    | 368    | 1,309      | RemoveFromAllNearbyLists() x100 | 3,417µs     | 111µs     |
| Xarick_4kx4k | 20,856   | 12,538 | 20,873     | RemoveFromAllNearbyLists() x100 | 823,153µs   | 645µs     |
| Wentbourne   |          |        |            | `reset_company 1`               | 499,610µs   | 458,537µs |
| Xarick_4kx4k |          |        |            | `stop_ai 2`                     | 2,284,738µs | 604,671µs |


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Relies on `catchment_tiles` not missing any tile. It shouldn't do as that would cause other issues too.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
