### PR TITLE
Fix: Scale graph gridlines and axes with GUI scale

### DIFF
--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -378,7 +378,9 @@ protected:
 		/* Draw the background of the graph itself. */
 		GfxFillRect(r.left, r.top, r.right, r.bottom, GRAPH_BASE_COLOUR);
 
-		/* Draw the vertical grid lines. */
+		/* Draw the grid lines. */
+		int gridline_width = WidgetDimensions::scaled.bevel.top;
+		int grid_colour = GRAPH_GRID_COLOUR;
 
 		/* Don't draw the first line, as that's where the axis will be. */
 		if (rtl) {
@@ -388,13 +390,12 @@ protected:
 			x = r.left + x_sep;
 		}
 
-		int grid_colour = GRAPH_GRID_COLOUR;
 		for (int i = 1; i < this->num_vert_lines + 1; i++) {
 			/* If using wallclock units, we separate periods with a lighter line. */
 			if (TimerGameEconomy::UsingWallclockUnits()) {
 				grid_colour = (i % 4 == 0) ? GRAPH_YEAR_LINE_COLOUR : GRAPH_GRID_COLOUR;
 			}
-			GfxFillRect(x, r.top, x, r.bottom, grid_colour);
+			GfxFillRect(x, r.top, x + gridline_width - 1, r.bottom, grid_colour);
 			x += x_sep;
 		}
 
@@ -403,20 +404,20 @@ protected:
 
 		for (int i = 0; i < (num_hori_lines + 1); i++) {
 			if (rtl) {
-				GfxFillRect(r.right + 1, y, r.right + ScaleGUITrad(3), y, GRAPH_AXIS_LINE_COLOUR);
+				GfxFillRect(r.right + 1, y, r.right + ScaleGUITrad(3), y + gridline_width - 1, GRAPH_AXIS_LINE_COLOUR);
 			} else {
-				GfxFillRect(r.left - ScaleGUITrad(3), y, r.left - 1, y, GRAPH_AXIS_LINE_COLOUR);
+				GfxFillRect(r.left - ScaleGUITrad(3), y, r.left - 1, y + gridline_width - 1, GRAPH_AXIS_LINE_COLOUR);
 			}
-			GfxFillRect(r.left, y, r.right, y, GRAPH_GRID_COLOUR);
+			GfxFillRect(r.left, y, r.right + gridline_width - 1, y + gridline_width - 1, GRAPH_GRID_COLOUR);
 			y -= y_sep;
 		}
 
 		/* Draw the y axis. */
-		GfxFillRect(r.left, r.top, r.left, r.bottom, GRAPH_AXIS_LINE_COLOUR);
+		GfxFillRect(r.left, r.top, r.left + gridline_width - 1, r.bottom + gridline_width - 1, GRAPH_AXIS_LINE_COLOUR);
 
 		/* Draw the x axis. */
 		y = x_axis_offset + r.top;
-		GfxFillRect(r.left, y, r.right, y, GRAPH_ZERO_LINE_COLOUR);
+		GfxFillRect(r.left, y, r.right + gridline_width - 1, y + gridline_width - 1, GRAPH_ZERO_LINE_COLOUR);
 
 		/* Find the largest value that will be drawn. */
 		if (this->num_on_x_axis == 0) return;
@@ -471,7 +472,7 @@ protected:
 					year++;
 
 					/* Draw a lighter grid line between years. Top and bottom adjustments ensure we don't draw over top and bottom horizontal grid lines. */
-					GfxFillRect(x + x_sep, r.top + 1, x + x_sep, r.bottom - 1, GRAPH_YEAR_LINE_COLOUR);
+					GfxFillRect(x + x_sep, r.top + gridline_width, x + x_sep + gridline_width - 1, r.bottom - 1, GRAPH_YEAR_LINE_COLOUR);
 				}
 				x += x_sep;
 			}
@@ -499,10 +500,11 @@ protected:
 			}
 		}
 
-		/* draw lines and dots */
-		uint linewidth = _settings_client.gui.graph_line_thickness;
-		uint pointoffs1 = (linewidth + 1) / 2;
-		uint pointoffs2 = linewidth + 1 - pointoffs1;
+		/* Draw lines and dots. */
+		uint linewidth = ScaleGUITrad(_settings_client.gui.graph_line_thickness);
+		uint pointwidth = ScaleGUITrad(_settings_client.gui.graph_line_thickness + 1);
+		uint pointoffs1 = pointwidth / 2;
+		uint pointoffs2 = pointwidth - pointoffs1;
 
 		auto draw_dataset = [&](const DataSet &dataset, uint8_t colour) {
 			if (HasBit(this->excluded_data, dataset.exclude_bit)) return;


### PR DESCRIPTION
## Motivation / Problem

Gridlines and axes on the graphs do not scale with GUI scaling, making them vanishingly thin when you get to larger GUI scales.

## Description

This is a simple update to scale the gridlines and axes width with GUI scale. Should work pixel-perfectly, tested at 1x, 2x and 3x (including checking for the annoying missing pixel at corners).

![graphlinescale](https://github.com/OpenTTD/OpenTTD/assets/2762690/a291445d-e8b1-4a2b-8199-b6fa77ea5f25)

It scales the gridline widths with the size of the bevels rather than GUI scale - IMO this is a little more visually consistent.

Also adds scaling of graph line and point wth GUI scale. These are scaled with the GUI scale, taking into account the graph line width user setting.

## Limitations

Scales the lines down-rightwards, rather than trying to centre them.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
