### PR TITLE
Fix: [Script] Only show debug script window at the end of savegame loading

### DIFF
--- a/src/ai/ai_instance.cpp
+++ b/src/ai/ai_instance.cpp
@@ -64,6 +64,9 @@ void AIInstance::Died()
 	/* Intro is not supposed to use AI, but it may have 'dummy' AI which instant dies. */
 	if (_game_mode == GM_MENU) return;
 
+	/* Don't show errors while loading savegame. They will be shown at end of loading anyway. */
+	if (_switch_mode != SM_NONE) return;
+
 	ShowScriptDebugWindow(_current_company);
 
 	const AIInfo *info = AIConfig::GetConfig(_current_company)->GetInfo();

--- a/src/game/game_instance.cpp
+++ b/src/game/game_instance.cpp
@@ -67,6 +67,9 @@ void GameInstance::Died()
 {
 	ScriptInstance::Died();
 
+	/* Don't show errors while loading savegame. They will be shown at end of loading anyway. */
+	if (_switch_mode != SM_NONE) return;
+
 	ShowScriptDebugWindow(OWNER_DEITY);
 
 	const GameInfo *info = Game::GetInfo();


### PR DESCRIPTION

<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Dumps in #12133 show crashes unrelated to the report itself, but caused by an AI failing to start, which then opens the script debug window while other AIs are still in a not fully initialised state.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
As the script debug window is open if there have been any errors at the end of loading, skip the opening on failure during loading.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
