### PR TITLE
Fix #12098: Don't allow unbunching at "nearest depot"

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -5113,6 +5113,7 @@ STR_ERROR_UNBUNCHING_NO_FULL_LOAD                               :{WHITE}... cann
 STR_ERROR_UNBUNCHING_NO_UNBUNCHING_FULL_LOAD                    :{WHITE}... cannot unbunch a vehicle with a full load order
 STR_ERROR_UNBUNCHING_NO_CONDITIONAL                             :{WHITE}... cannot use conditional orders when vehicle has an unbunching order
 STR_ERROR_UNBUNCHING_NO_UNBUNCHING_CONDITIONAL                  :{WHITE}... cannot unbunch a vehicle with a conditional order
+STR_ERROR_UNBUNCHING_NO_UNBUNCHING_NEAREST_DEPOT                :{WHITE}... must choose a depot to unbunch at
 
 # Autoreplace related errors
 STR_ERROR_TRAIN_TOO_LONG_AFTER_REPLACEMENT                      :{WHITE}{VEHICLE} is too long after replacement

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -820,6 +820,9 @@ CommandCost CmdInsertOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID se
 			if (new_order.GetDepotOrderType() & ~(ODTFB_PART_OF_ORDERS | ((new_order.GetDepotOrderType() & ODTFB_PART_OF_ORDERS) != 0 ? ODTFB_SERVICE : 0))) return CMD_ERROR;
 			if (new_order.GetDepotActionType() & ~(ODATFB_HALT | ODATFB_NEAREST_DEPOT | ODATFB_UNBUNCH)) return CMD_ERROR;
 			if ((new_order.GetDepotOrderType() & ODTFB_SERVICE) && (new_order.GetDepotActionType() & ODATFB_HALT)) return CMD_ERROR;
+
+			/* We don't allow unbunching at the nearest depot. The player must choose a specific depot. */
+			if ((new_order.GetDepotActionType() & ODATFB_NEAREST_DEPOT) && new_order.GetDepotActionType() & ODATFB_UNBUNCH) return CMD_ERROR;
 			break;
 		}
 
@@ -1310,6 +1313,8 @@ CommandCost CmdModifyOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID se
 					/* We don't allow unbunching if the vehicle has a full load order. */
 					if (o->IsType(OT_GOTO_STATION) && o->GetLoadType() & (OLFB_FULL_LOAD | OLF_FULL_LOAD_ANY)) return_cmd_error(STR_ERROR_UNBUNCHING_NO_UNBUNCHING_FULL_LOAD);
 				}
+				/* We don't allow unbunching at the nearest depot. The player must choose a specific depot. */
+				if (order->GetDepotActionType() & ODATFB_NEAREST_DEPOT) return_cmd_error(STR_ERROR_UNBUNCHING_NO_UNBUNCHING_NEAREST_DEPOT);
 			}
 			break;
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Vehicles can be told to go to the nearest depot. We should not allow setting this as an unbunching depot, because odd things could happen. Players should choose a specific depot to set for unbunching.

## Description

Block this action and give a descriptive error.

Closes #12098.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
