### PR TITLE
Codefix: Correct coding style on fall through

### DIFF
--- a/CODINGSTYLE.md
+++ b/CODINGSTYLE.md
@@ -157,7 +157,7 @@ enum SomeEnumeration {
 * Use curly braces and put the contained statements on their own lines (e.g., don't put them directly after the **if**).
 * Opening curly bracket **{** stays on the first line, closing curly bracket **}** gets a line to itself (except for the **}** preceding an **else**, which should be on the same line as the **else**).
 * When only a single statement is contained, the brackets can be omitted. In this case, put the single statement on the same line as the preceding keyword (**if**, **while**, etc.). Note that this is only allowed for if statements without an **else** clause.
-* All fall throughs must be documented, using a **FALLTHROUGH** define/macro.
+* Non-trivial fall throughs must be documented, using a `[[fallthrough]]` attribute.
 * The NOT_REACHED() macro can be used in default constructs that should never be reached.
 * Unconditional loops are written with **`for (;;) {`**
 
@@ -180,7 +180,7 @@ switch (a) {
 
 	case 1:
 		DoSomething();
-		FALLTHROUGH;
+		[[fallthrough]];
 
 	case 2:
 		DoMore();
@@ -191,7 +191,7 @@ switch (a) {
 		int r = 2;
 
 		DoEvenMore(a);
-		FALLTHROUGH;
+		[[fallthrough]];
 	}
 
 	case 4: {


### PR DESCRIPTION
## Motivation / Problem
Coding style mentions `FALLTHROUGH` macro which is outdated since #11941.


## Description
Use the current standard attributes instead.

Also, clarify that obvious cases (eg. a single line) does not necessarily need a `[[fallthrough]]`, based on comment from @glx22.


## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
