### PR TITLE
Fix: Off by one in TimerGameEconomy::ConvertDateToYMD in wallclock mode

### DIFF
--- a/src/timer/timer_game_economy.cpp
+++ b/src/timer/timer_game_economy.cpp
@@ -52,7 +52,7 @@ TimerGameEconomy::DateFract TimerGameEconomy::date_fract = {};
 	TimerGameEconomy::YearMonthDay ymd;
 	ymd.year = date.base() / EconomyTime::DAYS_IN_ECONOMY_YEAR;
 	ymd.month = (date.base() % EconomyTime::DAYS_IN_ECONOMY_YEAR) / EconomyTime::DAYS_IN_ECONOMY_MONTH;
-	ymd.day = date.base() % EconomyTime::DAYS_IN_ECONOMY_MONTH;
+	ymd.day = (date.base() % EconomyTime::DAYS_IN_ECONOMY_MONTH) + 1;
 	return ymd;
 }
 


### PR DESCRIPTION
## Motivation / Problem

TimerGameEconomy::ConvertDateToYMD and TimerGameEconomy::ConvertYMDToDate did not round-trip in wallclock mode. Days are 1-indexed instead of 0-indexed.

## Description

Fix off by one in TimerGameEconomy::ConvertDateToYMD in wallclock mode

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
