### PR TITLE
Fix #12145: Incorrect date handling in date cheat in wallclock time-keeping mode

### DIFF
--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -107,18 +107,21 @@ static int32_t ClickChangeDateCheat(int32_t new_value, int32_t)
 
 	TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(TimerGameCalendar::date);
 	TimerGameCalendar::Date new_calendar_date = TimerGameCalendar::ConvertYMDToDate(new_year, ymd.month, ymd.day);
-	/* Keep economy and calendar dates synced. */
-	TimerGameEconomy::Date new_economy_date = new_calendar_date.base();
 
-	/* Shift cached dates before we change the date. */
-	for (auto v : Vehicle::Iterate()) v->ShiftDates(new_economy_date - TimerGameEconomy::date);
-	LinkGraphSchedule::instance.ShiftDates(new_economy_date - TimerGameEconomy::date);
-
-	/* Now it's safe to actually change the date. */
 	TimerGameCalendar::SetDate(new_calendar_date, TimerGameCalendar::date_fract);
 
 	/* If not using wallclock units, we keep economy date in sync with calendar date and must change it also. */
-	if (!TimerGameEconomy::UsingWallclockUnits()) TimerGameEconomy::SetDate(new_economy_date, TimerGameEconomy::date_fract);
+	if (!TimerGameEconomy::UsingWallclockUnits()) {
+		/* Keep economy and calendar dates synced. */
+		TimerGameEconomy::Date new_economy_date = new_calendar_date.base();
+
+		/* Shift cached dates before we change the date. */
+		for (auto v : Vehicle::Iterate()) v->ShiftDates(new_economy_date - TimerGameEconomy::date);
+		LinkGraphSchedule::instance.ShiftDates(new_economy_date - TimerGameEconomy::date);
+
+		/* Now it's safe to actually change the date. */
+		TimerGameEconomy::SetDate(new_economy_date, TimerGameEconomy::date_fract);
+	}
 
 	CalendarEnginesMonthlyLoop();
 	SetWindowDirty(WC_STATUS_BAR, 0);


### PR DESCRIPTION
## Motivation / Problem

#12145
The date cheat change shifted stored economy dates even when no change was or should be made to the current economy date.

## Description

No longer shift stored economy dates when using the date cheat in wallclock time-keeping mode.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
