### PR TITLE
Fix #12148, fca8166: Do not draw decimals when number of digits is 0

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1201,6 +1201,10 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 				case SCC_DECIMAL: { // {DECIMAL}
 					int64_t number = args.GetNextParameter<int64_t>();
 					int digits = args.GetNextParameter<int>();
+					if (digits == 0) {
+						FormatNumber(builder, number, _number_format_separators);
+						break;
+					}
 
 					int64_t divisor = PowerOfTen(digits);
 					int64_t fractional = number % divisor;


### PR DESCRIPTION
## Motivation / Problem

Fixes #12148.


## Description

Skip most of the decimal drawing routine when the requested number of digits is 0.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
