### PR TITLE
Fix #12123: Allow not emitting zero digits in certain cases in number formats

### DIFF
--- a/src/lang/korean.txt
+++ b/src/lang/korean.txt
@@ -3,8 +3,8 @@
 ##isocode ko_KR
 ##plural 11
 ##textdir ltr
-##numberformat 0000경0000조0000억0000만0000
-##numberabbreviations 4=0000경0000조0000억0000만|8=0000경0000조0000억|12=0000경0000조|16=0000경
+##numberformat 0000경{NBSP}1000조{NBSP}1000억{NBSP}1000만1000
+##numberabbreviations 4=0000경{NBSP}1000조{NBSP}1000억{NBSP}1000만|8=0000경{NBSP}1000조{NBSP}1000억|12=0000경{NBSP}1000조|16=0000경
 ##decimalsep .
 ##winlangid 0x0412
 ##grflangid 0x3a

--- a/src/language.h
+++ b/src/language.h
@@ -109,13 +109,23 @@ extern std::unique_ptr<icu::Collator> _current_collator;
 
 /** The number digits available in a uint64_t. */
 constexpr int DIGITS_IN_UINT64_T = 20;
+/** Container for the formatting of a single digit. */
+struct DigitFormat {
+	enum EmitBehaviour {
+		DEFAULT, ///< Only emit the digit when it's not zero, or there is a higher digit not zero.
+		EMIT_WHEN_NOTHING_IS_EMITTED_YET, ///< Emit the digit when it's not zero, or there is a higher digit not zero, or no digit has been emitted yet.
+		RESET_HIGHER_DIGIT, ///< Only emit the digit when it is not zero, and reset the 'there is a higher digit not zero'-flag.
+	};
+	std::string separator; ///< The string to write after the digit, when the digit is emitted.
+	EmitBehaviour emit_behaviour; ///< The behaviour with respect to emitting the digit.
+};
 /**
  * Table with the text to place after each of the digits of a number. The text at index "20 - i" will be
  * inserted after the digit with value "10**i". So, for "normal" thousand separators, the strings at indices
  * 3, 6, 9, 12, 15 and 18 will be filled. For CJK the strings at indices 0, 4, 8, 12 and 16 will be filled.
  * @see ParseNumberFormatSeparators
  */
-using NumberFormatSeparators = std::array<std::string, DIGITS_IN_UINT64_T>;
+using NumberFormatSeparators = std::array<DigitFormat, DIGITS_IN_UINT64_T>;
 /** Container for the power to abbreviation mapping for formatting short numbers. */
 struct NumberAbbreviation {
 	NumberAbbreviation(int64_t threshold, NumberFormatSeparators &format) : threshold(threshold), format(format) {}

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -423,15 +423,20 @@ static void FormatNumber(StringBuilder &builder, int64_t number, const NumberFor
 	uint64_t divisor = 10000000000000000000ULL;
 	uint64_t num = number;
 	uint64_t tot = 0;
-	for (size_t i = 0; i < separators.size(); i++) {
+	bool emitted = false;
+	for (const DigitFormat &format : separators) {
 		uint64_t quot = 0;
 		if (num >= divisor) {
 			quot = num / divisor;
 			num = num % divisor;
 		}
-		if ((tot |= quot) != 0 || i == separators.size() - 1) {
+
+		if (format.emit_behaviour == DigitFormat::RESET_HIGHER_DIGIT) tot = 0;
+
+		if ((tot |= quot) != 0 || (format.emit_behaviour == DigitFormat::EMIT_WHEN_NOTHING_IS_EMITTED_YET && !emitted)) {
 			builder += '0' + quot; // quot is a single digit
-			builder += separators[i].data();
+			builder += format.separator.data();
+			emitted = true;
 		}
 
 		divisor /= 10;


### PR DESCRIPTION
## Motivation / Problem

See #12123.
It looks like you are allowed to just leave out whole ranges of zero digits in Korean (and possible also Chinese/Japanese).


## Description

Introduce a flag in the number format that essentially allows you to reset whether a higher digit has been seen. If you use this at the start of each of the digit groups in Korean, it's handling it as if it were a much smaller number and omit the zeros and separators that are not needed.

However, this brings a problem at the end of the number. If one of the higher digit grouping already had a number, then the last digit grouping should be omitted if everything is zero. So, introduce yet another flag that's automatically set for the last digit which will cause the digit only to be omitted if nothing was omitted yet (or any of the other reasons why the default case would omit a digit).

![이름 없음의 게임, 2035-01-01](https://github.com/OpenTTD/OpenTTD/assets/13785744/3c76f6c4-05e3-4555-a6b8-822b905ae593)


## Limitations

There's probably something else I'm missing in the CJK number formats.

Since Korean wants a space after the character (see #12124), but it also wants to omit whole groups the `{NBSP}` of a higher grouping could end up to be the last character. This could cause a visual jump in tables such as in the finance window. I do not know an elegant solution for it, but a nasty work-around would be to always emit a trailing `{NBSP}` so they are aligned. Or maybe yet another flag to influence `{NBSP}` placement or something. Who has a great idea?


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
