### PR TITLE
Fix #11862: Ships leaving docks could be momentarily lost

### DIFF
--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -44,8 +44,9 @@ protected:
 public:
 	void SetDestination(const Ship *v)
 	{
-		if (v->current_order.IsType(OT_GOTO_STATION)) {
+		if (v->current_order.IsType(OT_GOTO_STATION) || v->current_order.IsType(OT_LEAVESTATION)) {
 			this->dest_station = v->current_order.GetDestination();
+			assert(Station::IsValidID(this->dest_station));
 			this->dest_tile = CalcClosestStationTile(this->dest_station, v->tile, StationType::Dock);
 			this->dest_trackdirs = INVALID_TRACKDIR_BIT;
 		} else {

--- a/src/pathfinder/yapf/yapf_ship_regions.cpp
+++ b/src/pathfinder/yapf/yapf_ship_regions.cpp
@@ -184,8 +184,9 @@ public:
 		Tpf pf(std::min(static_cast<int>(Map::Size() * NODES_PER_REGION) / WATER_REGION_NUMBER_OF_TILES, MAX_NUMBER_OF_NODES));
 		pf.SetDestination(start_water_region_patch);
 
-		if (v->current_order.IsType(OT_GOTO_STATION)) {
+		if (v->current_order.IsType(OT_GOTO_STATION) || v->current_order.IsType(OT_LEAVESTATION)) {
 			DestinationID station_id = v->current_order.GetDestination();
+			assert(Station::IsValidID(station_id));
 			const BaseStation *station = BaseStation::Get(station_id);
 			TileArea tile_area;
 			station->GetTileArea(&tile_area, StationType::Dock);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
When a ship is departing from a dock, and wants to go back to it again, the destination tile is set as the origin, making the ship have a `OT_LEAVESTATION` `OrderType`. With this order type, the docking tiles aren't added as origins even though the tile is still that of a dock.

On YAPF, the ship becomes momentarily flagged as lost when this happens.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
`OT_LEAVESTATION` `OrderType` still has the same destination as that of `OT_GOTO_STATION`, so assume they still belong to the same dock.
Fixes #11862 
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
