### PR TITLE
Fix #12154: Incorrect calendar day lengths with minutes per year setting

### DIFF
--- a/src/timer/timer_game_calendar.cpp
+++ b/src/timer/timer_game_calendar.cpp
@@ -105,10 +105,13 @@ bool TimerManager<TimerGameCalendar>::Elapsed([[maybe_unused]] TimerGameCalendar
 
 	/* If we are using a non-default calendar progression speed, we need to check the sub_date_fract before updating date_fract. */
 	if (_settings_game.economy.minutes_per_calendar_year != CalendarTime::DEF_MINUTES_PER_YEAR) {
-		TimerGameCalendar::sub_date_fract++;
+		TimerGameCalendar::sub_date_fract += Ticks::DAY_TICKS;
 
 		/* Check if we are ready to increment date_fract */
-		if (TimerGameCalendar::sub_date_fract < (Ticks::DAY_TICKS * _settings_game.economy.minutes_per_calendar_year) / CalendarTime::DEF_MINUTES_PER_YEAR) return false;
+		const uint16_t threshold = (_settings_game.economy.minutes_per_calendar_year * Ticks::DAY_TICKS) / CalendarTime::DEF_MINUTES_PER_YEAR;
+		if (TimerGameCalendar::sub_date_fract < threshold) return false;
+
+		TimerGameCalendar::sub_date_fract = std::min<uint16_t>(TimerGameCalendar::sub_date_fract - threshold, Ticks::DAY_TICKS - 1);
 	}
 
 	TimerGameCalendar::date_fract++;


### PR DESCRIPTION
## Motivation / Problem

#12154: Calendar days were the wrong length for all non-trivial values of the minutes per year setting

## Description

Fix #12154.
Fix handling of TimerGameCalendar::sub_date_fract such that calendar days are the correct length.
e.g. 80 ticks at 13 minutes/year, 148 ticks at 24 minutes/year, 62160 ticks at 10080 minutes/year.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
