### PR TITLE
Codechange: Use bitmap for free unit ID generation.

### DIFF
--- a/src/company_base.h
+++ b/src/company_base.h
@@ -49,6 +49,19 @@ struct CompanyInfrastructure {
 	uint32_t GetTramTotal() const;
 };
 
+class FreeUnitIDGenerator {
+public:
+	UnitID NextID() const;
+	UnitID UseID(UnitID index);
+	void ReleaseID(UnitID index);
+
+private:
+	using BitmapStorage = size_t;
+	static constexpr size_t BITMAP_SIZE = std::numeric_limits<BitmapStorage>::digits;
+
+	std::vector<BitmapStorage> used_bitmap;
+};
+
 typedef Pool<Company, CompanyID, 1, MAX_COMPANIES> CompanyPool;
 extern CompanyPool _company_pool;
 
@@ -128,6 +141,8 @@ struct Company : CompanyProperties, CompanyPool::PoolItem<&_company_pool> {
 	GroupStatistics group_default[VEH_COMPANY_END];  ///< NOSAVE: Statistics for the DEFAULT_GROUP group.
 
 	CompanyInfrastructure infrastructure; ///< NOSAVE: Counts of company owned infrastructure.
+
+	FreeUnitIDGenerator freeunits[VEH_COMPANY_END];
 
 	Money GetMaxLoan() const;
 

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -430,17 +430,13 @@ void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner)
 	}
 
 	{
-		FreeUnitIDGenerator unitidgen[] = {
-			FreeUnitIDGenerator(VEH_TRAIN, new_owner), FreeUnitIDGenerator(VEH_ROAD,     new_owner),
-			FreeUnitIDGenerator(VEH_SHIP,  new_owner), FreeUnitIDGenerator(VEH_AIRCRAFT, new_owner)
-		};
+		Company *new_company = new_owner == INVALID_OWNER ? nullptr : Company::Get(new_owner);
 
 		/* Override company settings to new company defaults in case we need to convert them.
 		 * This is required as the CmdChangeServiceInt doesn't copy the supplied value when it is non-custom
 		 */
 		if (new_owner != INVALID_OWNER) {
 			Company *old_company = Company::Get(old_owner);
-			Company *new_company = Company::Get(new_owner);
 
 			old_company->settings.vehicle.servint_aircraft = new_company->settings.vehicle.servint_aircraft;
 			old_company->settings.vehicle.servint_trains = new_company->settings.vehicle.servint_trains;
@@ -457,8 +453,6 @@ void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner)
 				 * This prevents invalid values on mismatching company defaults being accepted.
 				 */
 				if (!v->ServiceIntervalIsCustom()) {
-					Company *new_company = Company::Get(new_owner);
-
 					/* Technically, passing the interval is not needed as the command will query the default value itself.
 					 * However, do not rely on that behaviour.
 					 */
@@ -477,7 +471,8 @@ void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner)
 				}
 				if (v->IsPrimaryVehicle()) {
 					GroupStatistics::CountVehicle(v, 1);
-					v->unitnumber = unitidgen[v->type].NextID();
+					auto &unitidgen = new_company->freeunits[v->type];
+					v->unitnumber = unitidgen.UseID(unitidgen.NextID());
 				}
 
 				/* Invalidate the vehicle's cargo payment "owner cache". */

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -517,6 +517,10 @@ void AfterLoadVehicles(bool part_of_load)
 			default: break;
 		}
 
+		if (part_of_load && v->unitnumber != 0) {
+			Company::Get(v->owner)->freeunits[v->type].UseID(v->unitnumber);
+		}
+
 		v->UpdateDeltaXY();
 		v->coord.left = INVALID_COORD;
 		v->sprite_cache.old_coord.left = INVALID_COORD;

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -1178,7 +1178,7 @@ static void NormaliseTrainHead(Train *head)
 
 	/* If we don't have a unit number yet, set one. */
 	if (head->unitnumber != 0) return;
-	head->unitnumber = GetFreeUnitNumber(VEH_TRAIN);
+	head->unitnumber = Company::Get(head->owner)->freeunits[head->type].UseID(GetFreeUnitNumber(VEH_TRAIN));
 }
 
 /**
@@ -1336,6 +1336,7 @@ CommandCost CmdMoveRailVehicle(DoCommandFlag flags, VehicleID src_veh, VehicleID
 			}
 			/* Remove stuff not valid anymore for non-front engines. */
 			DeleteVehicleOrders(src);
+			Company::Get(src->owner)->freeunits[src->type].ReleaseID(src->unitnumber);
 			src->unitnumber = 0;
 			src->name.clear();
 		}

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -755,7 +755,7 @@ public:
 	 * and that shall not be resetted for the new vehicle.
 	 * @param src The old vehicle
 	 */
-	inline void CopyVehicleConfigAndStatistics(const Vehicle *src)
+	inline void CopyVehicleConfigAndStatistics(Vehicle *src)
 	{
 		this->CopyConsistPropertiesFrom(src);
 
@@ -766,6 +766,8 @@ public:
 
 		this->profit_this_year = src->profit_this_year;
 		this->profit_last_year = src->profit_last_year;
+
+		src->unitnumber = 0;
 	}
 
 
@@ -1268,19 +1270,6 @@ struct SpecializedVehicle : public Vehicle {
 	 * @return an iterable ensemble of all valid vehicles of type T
 	 */
 	static Pool::IterateWrapper<T> Iterate(size_t from = 0) { return Pool::IterateWrapper<T>(from); }
-};
-
-/** Generates sequence of free UnitID numbers */
-struct FreeUnitIDGenerator {
-	bool *cache;  ///< array of occupied unit id numbers
-	UnitID maxid; ///< maximum ID at the moment of constructor call
-	UnitID curid; ///< last ID returned; 0 if none
-
-	FreeUnitIDGenerator(VehicleType type, CompanyID owner);
-	UnitID NextID();
-
-	/** Releases allocated memory */
-	~FreeUnitIDGenerator() { free(this->cache); }
 };
 
 /** Sentinel for an invalid coordinate. */

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -194,6 +194,8 @@ std::tuple<CommandCost, VehicleID, uint, uint16_t, CargoArray> CmdBuildVehicle(D
 				GroupStatistics::CountVehicle(v, 1);
 				if (!(subflags & DC_AUTOREPLACE)) OrderBackup::Restore(v, client_id);
 			}
+
+			Company::Get(v->owner)->freeunits[v->type].UseID(v->unitnumber);
 		}
 
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Searching for a free vehicle unit number can in some cases be quite slow, as the vehicle pool is iterated twice, and a vector is allocate for each possible unit number. This happens each time a unit number is needed, and the cached data is thrown away and recalculated between testmode and DC_EXEC.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use a bitmap for unit ID generation. This is stored for each of the 4 vehicle types for each company. It does use some memory, but it is fairly minor -- a bitmap for 5,000 units use 625 bytes.

Based loosely on pool's used slot bitmap, but simplified as it's used a bit less frequently, and contains fewer entries.

This improves performance of finding the next free unit number for a vehicle.

| Action                 | Master   | Bitmap |
| ---------------------- | -------- | ------ |
| Wentbourne Build Train | 5,354µs  | 0µs    |
| Wentbourne Build Plane | 1,781µs  | 0µs    |
| Wentbourne Build Ship  | 1,587µs  | 0µs    |
| Xarick4k4k Build Train | 16,356µs | 0µs    |
| Xarick4k4k Build RV    | 11,666µs | 0µs    |

(Yes, it's basically free now...)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Could be conditions I've not thought of where a unit number is not correctly released or marked used.

I've tested these and they seem to work:

* Buy vehicle
* Sell vehicle
* Rearrange train
* Clone vehicle (basically buy vehicle)
* Autoreplace
* Hostile takeover

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
