### PR TITLE
Codefix #12162, 3105d0b: Textbuf::Assign read beyond std::string_view

### DIFF
--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -413,9 +413,11 @@ void Textbuf::Assign(StringID string)
  */
 void Textbuf::Assign(const std::string_view text)
 {
-	const char *last_of = &this->buf[this->max_bytes - 1];
-	strecpy(this->buf, text.data(), last_of);
-	StrMakeValidInPlace(this->buf, last_of, SVS_NONE);
+	size_t bytes = std::min<size_t>(this->max_bytes - 1, text.size());
+	memcpy(this->buf, text.data(), bytes);
+	this->buf[bytes] = '\0';
+
+	StrMakeValidInPlace(this->buf, &this->buf[bytes], SVS_NONE);
 
 	/* Make sure the name isn't too long for the text buffer in the number of
 	 * characters (not bytes). max_chars also counts the '\0' characters. */


### PR DESCRIPTION
## Motivation / Problem

Technically reading beyond the buffer, after all the view ends at the last character and not the '\0'.
Practically not really a problem yet as all our uses use `char *` or `std::string`, however a problem when actually passing a substring (fixes #12162).


## Description

Just copy the bytes of the view, up to `max_bytes - 1` and add the '\0' termination, instead of looking for the '\0' termination.


## Limitations

Is this a Codefix or not? Technically it's reading beyond the buffer of the `std::string_view`, but in all instances the underlying string is `\0`-terminated just beyond the view and as such nothing's visible.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
