### PR TITLE
Codefix: DrawEngineList does not accept EngineID.

### DIFF
--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -33,7 +33,7 @@
 
 #include "safeguards.h"
 
-void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_list, uint16_t min, uint16_t max, EngineID selected_id, bool show_count, GroupID selected_group);
+void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_list, const Scrollbar &sb, EngineID selected_id, bool show_count, GroupID selected_group);
 
 static bool EngineNumberSorter(const GUIEngineListItem &a, const GUIEngineListItem &b)
 {
@@ -487,11 +487,9 @@ public:
 			case WID_RV_LEFT_MATRIX:
 			case WID_RV_RIGHT_MATRIX: {
 				int side = (widget == WID_RV_LEFT_MATRIX) ? 0 : 1;
-				EngineID start  = static_cast<EngineID>(this->vscroll[side]->GetPosition()); // what is the offset for the start (scrolling)
-				EngineID end    = static_cast<EngineID>(std::min<size_t>(this->vscroll[side]->GetCapacity() + start, this->engines[side].size()));
 
 				/* Do the actual drawing */
-				DrawEngineList((VehicleType)this->window_number, r, this->engines[side], start, end, this->sel_engine[side], side == 0, this->sel_group);
+				DrawEngineList((VehicleType)this->window_number, r, this->engines[side], *this->vscroll[side], this->sel_engine[side], side == 0, this->sel_group);
 				break;
 			}
 		}

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -998,18 +998,16 @@ int DrawVehiclePurchaseInfo(int left, int right, int y, EngineID engine_number, 
  * @param type Type of vehicle (VEH_*)
  * @param r The Rect of the list
  * @param eng_list What engines to draw
- * @param min where to start in the list
- * @param max where in the list to end
+ * @param sb Scrollbar of list.
  * @param selected_id what engine to highlight as selected, if any
  * @param show_count Whether to show the amount of engines or not
  * @param selected_group the group to list the engines of
  */
-void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_list, uint16_t min, uint16_t max, EngineID selected_id, bool show_count, GroupID selected_group)
+void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_list, const Scrollbar &sb, EngineID selected_id, bool show_count, GroupID selected_group)
 {
 	static const int sprite_y_offsets[] = { -1, -1, -2, -2 };
 
-	/* Obligatory sanity checks! */
-	assert(max <= eng_list.size());
+	auto [first, last] = sb.GetVisibleRangeIterators(eng_list);
 
 	bool rtl = _current_text_dir == TD_RTL;
 	int step_size = GetEngineListHeight(type);
@@ -1028,9 +1026,8 @@ void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_li
 		replace_icon = GetSpriteSize(SPR_GROUP_REPLACE_ACTIVE);
 
 		uint biggest_num_engines = 0;
-		for (auto i = min; i < max; i++) {
-			const auto &item = eng_list[i];
-			const uint num_engines = GetGroupNumEngines(_local_company, selected_group, item.engine_id);
+		for (auto it = first; it != last; ++it) {
+			const uint num_engines = GetGroupNumEngines(_local_company, selected_group, it->engine_id);
 			biggest_num_engines = std::max(biggest_num_engines, num_engines);
 		}
 
@@ -1048,8 +1045,8 @@ void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_li
 	int replace_icon_y_offset = (ir.Height() - replace_icon.height) / 2;
 
 	int y = ir.top;
-	for (; min < max; min++, y += step_size) {
-		const auto &item = eng_list[min];
+	for (auto it = first; it != last; ++it) {
+		const auto &item = *it;
 		uint indent       = item.indent * WidgetDimensions::scaled.hsep_indent;
 		bool has_variants = (item.flags & EngineDisplayFlags::HasVariants) != EngineDisplayFlags::None;
 		bool is_folded    = (item.flags & EngineDisplayFlags::IsFolded)    != EngineDisplayFlags::None;
@@ -1085,10 +1082,11 @@ void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_li
 			/* Draw tree lines */
 			Rect fr = ir.Indent(indent - WidgetDimensions::scaled.hsep_indent, rtl).WithWidth(circle_width, rtl);
 			int ycenter = y + normal_text_y_offset + GetCharacterHeight(FS_NORMAL) / 2;
-			bool continues = (min + 1U) < eng_list.size() && eng_list[min + 1].indent == item.indent;
+			bool continues = std::next(it) != std::end(eng_list) && std::next(it)->indent == item.indent;
 			GfxDrawLine(fr.left + circle_width / 2, y - WidgetDimensions::scaled.matrix.top, fr.left + circle_width / 2, continues ? y - WidgetDimensions::scaled.matrix.top + step_size - 1 : ycenter, linecolour, WidgetDimensions::scaled.fullbevel.top);
 			GfxDrawLine(fr.left + circle_width / 2, ycenter, fr.right, ycenter, linecolour, WidgetDimensions::scaled.fullbevel.top);
 		}
+		y += step_size;
 	}
 }
 
@@ -1791,8 +1789,7 @@ struct BuildVehicleWindow : Window {
 					this->vehicle_type,
 					r,
 					this->eng_list,
-					this->vscroll->GetPosition(),
-					static_cast<uint16_t>(std::min<size_t>(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), this->eng_list.size())),
+					*this->vscroll,
 					this->sel_engine,
 					false,
 					DEFAULT_GROUP

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -834,6 +834,20 @@ public:
 	int GetScrolledRowFromWidget(int clickpos, const Window * const w, WidgetID widget, int padding = 0, int line_height = -1) const;
 
 	/**
+	 * Get a pair of iterators for the range of visible elements in a container.
+	 * @param container Container of elements represented by the scrollbar.
+	 * @returns Pair of iterators of visible elements.
+	 */
+	template <typename Tcontainer>
+	auto GetVisibleRangeIterators(Tcontainer &container) const
+	{
+		assert(this->GetCount() == container.size()); // Scrollbar and container size must match.
+		auto first = std::next(std::begin(container), this->GetPosition());
+		auto last = std::next(first, std::min<size_t>(this->GetCapacity(), this->GetCount() - this->GetPosition()));
+		return std::make_pair(first, last);
+	}
+
+	/**
 	 * Return an iterator pointing to the element of a scrolled widget that a user clicked in.
 	 * @param container   Container of elements represented by the scrollbar.
 	 * @param clickpos    Vertical position of the mouse click (without taking scrolling into account).


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`DrawEngineList()` accepts two `uint16_t` parameters, `min` and `max`, but the caller in autoreplace_gui thinks they are `EngineID`s and casts to that instead first.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead of just correcting the type from `EngineID` to `uint16_t`:

* Add `GetVisibleRangeIterators()` to `Scrollbar` which returns iterators to be first and last (+ 1) visible items. This has plenty of uses beyond this change.
* Replace the min/max parameters of `DrawEngineList()` with scrollbar reference, and use `GetVisibleRangeIterators()` instead of indices.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Ideally `GetVisibleRangeIterators()` would return a strong `std::pair<Tcontainer::const_iterator, Tcontainer::const_iterator>`  but it returns `auto` due to `std::span` (not used here, but intended to be used elsewhere later) not supporting `const_iterator` in C++20.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
