### PR TITLE
Fix #12176: Ships are circling in one place

### DIFF
--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -259,10 +259,19 @@ public:
 			 * caching the full path the ship can get stuck in a loop. */
 			const WaterRegionPatchDesc end_water_patch = GetWaterRegionPatchInfo(node->GetTile());
 			const WaterRegionPatchDesc start_water_patch = GetWaterRegionPatchInfo(tile);
+			assert(start_water_patch == high_level_path.front());
 			while (node->m_parent) {
 				const WaterRegionPatchDesc node_water_patch = GetWaterRegionPatchInfo(node->GetTile());
-				if (node_water_patch == start_water_patch || (!is_intermediate_destination && node_water_patch != end_water_patch)) {
+
+				const bool node_water_patch_on_high_level_path = std::find(high_level_path.begin(), high_level_path.end(), node_water_patch) != high_level_path.end();
+				const bool add_full_path = !is_intermediate_destination && node_water_patch != end_water_patch;
+
+				/* The cached path must always lead to a region patch that's on the high level path.
+				 * This is what can happen when that's not the case https://github.com/OpenTTD/OpenTTD/issues/12176. */
+				if (add_full_path || !node_water_patch_on_high_level_path || node_water_patch == start_water_patch) {
 					path_cache.push_front(node->GetTrackdir());
+				} else {
+					path_cache.clear();
 				}
 				node = node->m_parent;
 			}


### PR DESCRIPTION
## Motivation / Problem

Fixes #12176 

## Description

The high level pathfinder finds a path of water region patches to the (intermediate) destination. The low level pathfinder then has the freedom to deviate from this high level path, as this leads to better / less clunky paths in many situations. The pathfinder currently caches the part of the path that is within the current water region. The pathfinder will run again as soon as the ship enters a new region.

If the pathfinder decided to stray away from the high level path, the ship ends up on water region patch that was not on the original high level path. This can lead to a completely different high level path the next time the pathfinder is called. In most cases this is not a problem, but in rare cases this causes ships to move back and forth between two regions, like in #12176. 

The solution is to always cache the low level path so that it leads to a region that is on the high level path. This way the ship always ends up back on the high level path after it runs out of cached directions, and the high level path won't change the next time the pathfinder runs.

## Limitations

None

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
