### PR TITLE
Fix: initialize _switch_mode_time so crash-logs before first game have a realistic time

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -517,6 +517,8 @@ static const OptionData _options[] = {
  */
 int openttd_main(int argc, char *argv[])
 {
+	_switch_mode_time = std::chrono::steady_clock::now();
+
 	std::string musicdriver;
 	std::string sounddriver;
 	std::string videodriver;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

I was looking in crashlogs of 14.0-RC1, and noticed that the "seconds" was the "time since computer start". This is because we never initialize it before you go into your first game.

## Description

The initialize value of `_switch_mode_time` shouldn't be zero, but `now()` on startup. That should sufficiently correct the issue.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
