### PR TITLE
 Fix #12196: always show selected content, even when filtering and disable "select upgrade" button when filtering

### DIFF
--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -997,7 +997,7 @@ public:
 		this->SetWidgetDisabledState(WID_NCL_DOWNLOAD, this->filesize_sum == 0 || (FindWindowById(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_CONTENT_DOWNLOAD) != nullptr && data != 2));
 		this->SetWidgetDisabledState(WID_NCL_UNSELECT, this->filesize_sum == 0);
 		this->SetWidgetDisabledState(WID_NCL_SELECT_ALL, !show_select_all);
-		this->SetWidgetDisabledState(WID_NCL_SELECT_UPDATE, !show_select_upgrade);
+		this->SetWidgetDisabledState(WID_NCL_SELECT_UPDATE, !show_select_upgrade || !this->filter_data.string_filter.IsEmpty());
 		this->SetWidgetDisabledState(WID_NCL_OPEN_URL, this->selected == nullptr || this->selected->url.empty());
 		for (TextfileType tft = TFT_CONTENT_BEGIN; tft < TFT_CONTENT_END; tft++) {
 			this->SetWidgetDisabledState(WID_NCL_TEXTFILE + tft, this->selected == nullptr || this->selected->state != ContentInfo::ALREADY_HERE || !this->selected->GetTextfile(tft).has_value());

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -466,6 +466,8 @@ class NetworkContentListWindow : public Window, ContentCallback {
 	/** Filter content by tags/name */
 	static bool CDECL TagNameFilter(const ContentInfo * const *a, ContentListFilterData &filter)
 	{
+		if ((*a)->state == ContentInfo::SELECTED || (*a)->state == ContentInfo::AUTOSELECTED) return true;
+
 		filter.string_filter.ResetState();
 		for (auto &tag : (*a)->tags) filter.string_filter.AddLine(tag);
 
@@ -808,6 +810,7 @@ public:
 				if (click_count > 1 || IsInsideBS(pt.x, checkbox->pos_x, checkbox->current_x)) {
 					_network_content_client.ToggleSelectedState(this->selected);
 					this->content.ForceResort();
+					this->content.ForceRebuild();
 				}
 
 				if (this->filter_data.types.any()) {


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Fixes #12196.

See https://github.com/OpenTTD/OpenTTD/issues/12196#issuecomment-1973842264 for more details on the weirdness that is in the current window. tldr: when implementing the filter system, the buttons started to show different visual behaviour than the actual functionality they carried.

## Description

Two changes:
- Always show the selected entries, even when filtering. This makes everything more sensible: the total downloads is correct, the "unselect all" does what you expect, "download" button is clear what it will download. And cherry-on-top, you can see what you actually selected.
- Disable "select upgrade" button when filtering. It is really meant as a quick button to select everything that is out-dated. When filtering, it becomes really unclear what the button actually does or is suppose to do, as individual entries are not marked as "this is an upgrade".

## Limitations

The upgradability of items remains weird and quirky. At least with this change it is predictable.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
