### PR TITLE
Change: [Script] Match FormatString behaviour more closely

### DIFF
--- a/src/script/api/script_text.hpp
+++ b/src/script/api/script_text.hpp
@@ -165,8 +165,9 @@ private:
 	 * @param output The output to write the encoded text to.
 	 * @param param_count The number of parameters that are consumed by the string.
 	 * @param args The parameters to be consumed.
+	 * @param first Whether it's the first call in the recursion.
 	 */
-	void _GetEncodedText(std::back_insert_iterator<std::string> &output, int &param_count, ParamSpan args);
+	void _GetEncodedText(std::back_insert_iterator<std::string> &output, int &param_count, ParamSpan args, bool first);
 
 	/**
 	 * Set a parameter, where the value is the first item on the stack.

--- a/src/script/api/script_text.hpp
+++ b/src/script/api/script_text.hpp
@@ -137,10 +137,11 @@ private:
 		int idx;
 		Param *param;
 		bool used;
+		const char *cmd;
 
-		ParamCheck(StringID owner, int idx, Param *param) : owner(owner), idx(idx), param(param), used(false) {}
+		ParamCheck(StringID owner, int idx, Param *param) : owner(owner), idx(idx), param(param), used(false), cmd(nullptr) {}
 
-		void Encode(std::back_insert_iterator<std::string> &output);
+		void Encode(std::back_insert_iterator<std::string> &output, const char *cmd);
 	};
 
 	using ParamList = std::vector<ParamCheck>;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
GS string validation is still too strict compared to `FormatString()`.
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/2834b455-59c0-46f9-ac8c-4d670de82846)
Using the save from 13.4 (so town extra string is stored)
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/dba3bbbe-6d91-49b4-867d-28dddddfc8f7)
Master after #12187 (better but GS still crash)
![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/fc4ba2b5-60ed-4f93-8f61-66a001032553)



<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
`FormatString()` uses an array of 20 (SCRIPT_TEXT_MAX_PARAMETERS) parameters initialised with `0` to format a string from GS.
So do the same for the validation by filling extra `0` in parameter list.
`FormatString()` checks a parameter is used only for one command type (for instance, a parameter used in {STRING} can't be used later in {STRING2}), and don't consume the expected number of args in this case (they will be available to the next command).

So we do the same for the validation by filling extra `0` in parameter list, and by implementing a type check mechanism to match `FormatString()` behaviour.

I also noticed GSText parameters could be added more than once in the encoded string, so I also fixed that.

And I reduced the string consumption check from error to warning.

![image](https://github.com/OpenTTD/OpenTTD/assets/2952192/fd851350-c389-4773-905b-0c1f1ac1bab7)

In the end the encoded string is the same as in 13.4, but with some extra `:0` at the end depending on validation process (`FormatString()` would have these extra `0` anyway).

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
