### PR TITLE
Fix #12193: Don't use the entire docking area when computing closest station tile

### DIFF
--- a/src/pathfinder/pathfinder_func.h
+++ b/src/pathfinder/pathfinder_func.h
@@ -12,6 +12,40 @@
 
 #include "../tile_cmd.h"
 #include "../waypoint_base.h"
+#include "../ship.h"
+
+/**
+ * Creates a list containing possible destination tiles for a ship.
+ * @param v The ship
+ * return Vector of tiles filled with all possible destinations.
+ */
+inline std::vector<TileIndex> GetShipDestinationTiles(const Ship *v)
+{
+	std::vector<TileIndex> dest_tiles;
+
+	if (v->current_order.IsType(OT_GOTO_STATION)) {
+		const StationID station = v->current_order.GetDestination().ToStationID();
+
+		const BaseStation *st = BaseStation::Get(station);
+		TileArea ta = st->GetTileArea(StationType::Dock);
+
+		/* If the dock station is (temporarily) not present, use the station sign to drive near the station. */
+		if (ta.tile == INVALID_TILE) {
+			dest_tiles.push_back(st->xy);
+		} else {
+			for (const TileIndex &docking_tile : ta) {
+				if (!IsDockingTile(docking_tile) || !IsShipDestinationTile(docking_tile, station)) continue;
+				dest_tiles.push_back(docking_tile);
+			}
+		}
+	} else {
+		dest_tiles.push_back(v->dest_tile == INVALID_TILE ? TileIndex{} : v->dest_tile);
+	}
+
+	assert(!dest_tiles.empty());
+
+	return dest_tiles;
+}
 
 /**
  * Calculates the tile of given station that is closest to a given tile

--- a/src/pathfinder/yapf/yapf_ship_regions.cpp
+++ b/src/pathfinder/yapf/yapf_ship_regions.cpp
@@ -174,7 +174,7 @@ public:
 
 	inline char TransportTypeChar() const { return '^'; }
 
-	static std::vector<WaterRegionPatchDesc> FindWaterRegionPath(const Ship *v, TileIndex start_tile, int max_returned_path_length)
+	static std::vector<WaterRegionPatchDesc> FindWaterRegionPath(const Ship *v, TileIndex start_tile, int max_returned_path_length, const std::span<TileIndex> dest_tiles)
 	{
 		const WaterRegionPatchDesc start_water_region_patch = GetWaterRegionPatchInfo(start_tile);
 
@@ -184,16 +184,7 @@ public:
 		YapfShipRegions pf(node_limit);
 		pf.SetDestination(start_water_region_patch);
 
-		if (v->current_order.IsType(OT_GOTO_STATION)) {
-			StationID station_id = v->current_order.GetDestination().ToStationID();
-			const BaseStation *station = BaseStation::Get(station_id);
-			for (const auto &tile : station->GetTileArea(StationType::Dock)) {
-				if (IsDockingTile(tile) && IsShipDestinationTile(tile, station_id)) {
-					pf.AddOrigin(GetWaterRegionPatchInfo(tile));
-				}
-			}
-		} else {
-			TileIndex tile = v->dest_tile == INVALID_TILE ? TileIndex{} : v->dest_tile;
+		for (const TileIndex &tile : dest_tiles) {
 			pf.AddOrigin(GetWaterRegionPatchInfo(tile));
 		}
 
@@ -223,9 +214,10 @@ public:
  * @param v The ship to find a path for.
  * @param start_tile The tile to start searching from.
  * @param max_returned_path_length The maximum length of the path that will be returned.
+ * @param dest_tiles List of destination tiles.
  * @returns A path of water region patches, or an empty vector if no path was found.
  */
-std::vector<WaterRegionPatchDesc> YapfShipFindWaterRegionPath(const Ship *v, TileIndex start_tile, int max_returned_path_length)
+std::vector<WaterRegionPatchDesc> YapfShipFindWaterRegionPath(const Ship *v, TileIndex start_tile, int max_returned_path_length, const std::span<TileIndex> dest_tiles)
 {
-	return YapfShipRegions::FindWaterRegionPath(v, start_tile, max_returned_path_length);
+	return YapfShipRegions::FindWaterRegionPath(v, start_tile, max_returned_path_length, dest_tiles);
 }

--- a/src/pathfinder/yapf/yapf_ship_regions.h
+++ b/src/pathfinder/yapf/yapf_ship_regions.h
@@ -15,6 +15,6 @@
 
 struct Ship;
 
-std::vector<WaterRegionPatchDesc> YapfShipFindWaterRegionPath(const Ship *v, TileIndex start_tile, int max_returned_path_length);
+std::vector<WaterRegionPatchDesc> YapfShipFindWaterRegionPath(const Ship *v, TileIndex start_tile, int max_returned_path_length, const std::span<TileIndex> dest_tiles);
 
 #endif /* YAPF_SHIP_REGIONS_H */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Docks have a `TileArea` of tiles designated for ships to dock at, and pathfinders require one of those tiles as the target to compute a path. `CalcClosestStationTile` is used for that effect, however it is flawed. The area contains more tiles than necessary. In #12193, 3 docks are placed far apart from each other, and all 3 belong to the same station. This generates a very large area covering nearly the entire map. If the ship is inside this area, `CalcClosestStationTile` returns the ship's current position as the target for pathfinders, essentially saying the ship is already there. This is not handled properly and the result is sub-optimal paths at best.

For YAPF, the search is compounded by a high level pf and a low level pf with two attempts. The high level pf finds a path without issues to the region which requires the least number of regions to traverse, but in this example, that path ends up being sub-optimal. The low level pf is affected, as it's here that `CalcClosestStationTile` is used, and that uses the ship's current position for the first attempt. Though it correctly paths to itself, it fails `IsShipDestinationTile` test.  On the second attempt, the search is restricted to a corridor of regions and a path is found, but it makes the ship take a big detour to the back side due to the restrictions. This path is doubly sub-optimal.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Fix #12193
Don't use `CalcClosestStationTile` for ships. Instead, use a specialized `GetShipDestinationTiles` which creates a list of possible destination tiles. For docks, it only takes into consideration the tiles that pass both `IsDockingTile` and `IsShipDestinationTile` tests. For the other cases it just takes the ship's current `dest_tile`.

Modified `CYapfDestinationTileWaterT` class to accept multiple destinations. In this manner, the estimate cost is calculated for each of the destination tiles and the shortest estimate is returned. Some adaptation was necessary to make this possible to work for both the high- and low-level pathfinders and the existing functions. `ChooseShipTrack` and its `FindWaterRegionPath` brother both will take the same destination tiles which are calculated at either `YapfShipChooseTrack` or `YapfShipCheckReverse`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
None, now that NPF was removed.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
