### PR TITLE
Fix #12076: Do not allow 'join' command on dedicated servers

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -156,6 +156,21 @@ DEF_CONSOLE_HOOK(ConHookNeedNetwork)
 }
 
 /**
+ * Check whether we are in a multiplayer game and are playing, i.e. we are not the dedicated server.
+ * @return Are we a client or non-dedicated server in a network game? True when yes, false otherwise.
+ */
+DEF_CONSOLE_HOOK(ConHookNeedNonDedicatedNetwork)
+{
+	if (!NetworkAvailable(echo)) return CHR_DISALLOW;
+
+	if (_network_dedicated) {
+		if (echo) IConsolePrint(CC_ERROR, "This command is not available to a dedicated network server.");
+		return CHR_DISALLOW;
+	}
+	return CHR_ALLOW;
+}
+
+/**
  * Check whether we are in singleplayer mode.
  * @return True when no network is active.
  */
@@ -2693,7 +2708,7 @@ void IConsoleStdLibRegister()
 	IConsole::CmdRegister("reconnect",               ConNetworkReconnect, ConHookClientOnly);
 	IConsole::CmdRegister("rcon",                    ConRcon,             ConHookNeedNetwork);
 
-	IConsole::CmdRegister("join",                    ConJoinCompany,      ConHookNeedNetwork);
+	IConsole::CmdRegister("join",                    ConJoinCompany,      ConHookNeedNonDedicatedNetwork);
 	IConsole::AliasRegister("spectate",              "join 255");
 	IConsole::CmdRegister("move",                    ConMoveClient,       ConHookServerOnly);
 	IConsole::CmdRegister("reset_company",           ConResetCompany,     ConHookServerOnly);


### PR DESCRIPTION
## Motivation / Problem

Deep down `NetworkServerDoMove` silently ignores calls for the dedicated server, but the user typing the `join` command does not get notified of the failure.


## Description

Add a new hook that prevents commands from being executed on the dedicated server, and use it for the `join` command.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
