### PR TITLE
Fix #12147: reset all saved settings to their default before loading a game

### DIFF
--- a/src/saveload/settings_sl.cpp
+++ b/src/saveload/settings_sl.cpp
@@ -187,10 +187,20 @@ struct PATSChunkHandler : ChunkHandler {
 
 	void Load() const override
 	{
-		/* Copy over default setting since some might not get loaded in
-		 * a networking environment. This ensures for example that the local
-		 * currency setting stays when joining a network-server */
-		LoadSettings(this->GetSettingTable(), &_settings_game, _settings_sl_compat);
+		const auto settings_table = this->GetSettingTable();
+
+		/* Reset all settings to their default, so any settings missing in the savegame
+		 * are their default, and not "value of last game". AfterLoad might still fix
+		 * up values to become non-default, depending on the saveload version. */
+		for (auto &desc : settings_table) {
+			const SettingDesc *sd = GetSettingDesc(desc);
+			if (sd->flags & SF_NOT_IN_SAVE) continue;
+			if ((sd->flags & SF_NO_NETWORK_SYNC) && _networking && !_network_server) continue;
+
+			sd->ResetToDefault(&_settings_game);
+		}
+
+		LoadSettings(settings_table, &_settings_game, _settings_sl_compat);
 	}
 
 	void LoadCheck(size_t) const override

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -768,6 +768,11 @@ bool IntSettingDesc::IsDefaultValue(void *object) const
 	return this->def == object_value;
 }
 
+void IntSettingDesc::ResetToDefault(void *object) const
+{
+	this->Write(object, this->def);
+}
+
 std::string StringSettingDesc::FormatValue(const void *object) const
 {
 	const std::string &str = this->Read(object);
@@ -800,6 +805,11 @@ bool StringSettingDesc::IsDefaultValue(void *object) const
 	return this->def == str;
 }
 
+void StringSettingDesc::ResetToDefault(void *object) const
+{
+	this->Write(object, this->def);
+}
+
 bool ListSettingDesc::IsSameValue(const IniItem *, void *) const
 {
 	/* Checking for equality is way more expensive than just writing the value. */
@@ -810,6 +820,12 @@ bool ListSettingDesc::IsDefaultValue(void *) const
 {
 	/* Defaults of lists are often complicated, and hard to compare. */
 	return false;
+}
+
+void ListSettingDesc::ResetToDefault(void *) const
+{
+	/* Resetting a list to default is not supported. */
+	NOT_REACHED();
 }
 
 /**

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -137,6 +137,11 @@ struct SettingDesc {
 	 * @return true iff the value is the default value.
 	 */
 	virtual bool IsDefaultValue(void *object) const = 0;
+
+	/**
+	 * Reset the setting to its default value.
+	 */
+	virtual void ResetToDefault(void *object) const = 0;
 };
 
 /** Base integer type, including boolean, settings. Only these are shown in the settings UI. */
@@ -236,6 +241,7 @@ struct IntSettingDesc : SettingDesc {
 	void ParseValue(const IniItem *item, void *object) const override;
 	bool IsSameValue(const IniItem *item, void *object) const override;
 	bool IsDefaultValue(void *object) const override;
+	void ResetToDefault(void *object) const override;
 	int32_t Read(const void *object) const;
 
 private:
@@ -332,6 +338,7 @@ struct StringSettingDesc : SettingDesc {
 	void ParseValue(const IniItem *item, void *object) const override;
 	bool IsSameValue(const IniItem *item, void *object) const override;
 	bool IsDefaultValue(void *object) const override;
+	void ResetToDefault(void *object) const override;
 	const std::string &Read(const void *object) const;
 
 private:
@@ -350,6 +357,7 @@ struct ListSettingDesc : SettingDesc {
 	void ParseValue(const IniItem *item, void *object) const override;
 	bool IsSameValue(const IniItem *item, void *object) const override;
 	bool IsDefaultValue(void *object) const override;
+	void ResetToDefault(void *object) const override;
 };
 
 /** Placeholder for settings that have been removed, but might still linger in the savegame. */
@@ -361,6 +369,7 @@ struct NullSettingDesc : SettingDesc {
 	void ParseValue(const IniItem *, void *) const override { NOT_REACHED(); }
 	bool IsSameValue(const IniItem *, void *) const override { NOT_REACHED(); }
 	bool IsDefaultValue(void *) const override { NOT_REACHED(); }
+	void ResetToDefault(void *) const override { NOT_REACHED(); }
 };
 
 typedef std::variant<IntSettingDesc, BoolSettingDesc, OneOfManySettingDesc, ManyOfManySettingDesc, StringSettingDesc, ListSettingDesc, NullSettingDesc> SettingVariant;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Fixes #12147.

When adding new settings, we no longer have to bump the savegame and write afterload code to ensure a good value for the new setting. At least, that was the idea. Sadly, we never actually implemented that part, so the value of new settings was what-ever the value was of the last game played.

## Description

Always first reset the settings to their default (for settings that are suppose to be in the savegame). After that, load the savegame. This gives a predictable set of settings before going into the loading routine, instead of using what-ever was used in the last game.

## Limitations

ListSettingDesc isn't used for any setting that is saved in the savegame. Although the implementation should be trivial (it can be taken from `ParseValue`), there is no way to validate it is. As such, I left it as a `NOT_REACHED()`, to prevent it having an implementation that is broken.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
