### PR TITLE
Fix: YAPF doesn't check destination for start nodes

### DIFF
--- a/src/pathfinder/yapf/yapf_base.hpp
+++ b/src/pathfinder/yapf/yapf_base.hpp
@@ -113,45 +113,39 @@ public:
 		m_veh = v;
 
 		Yapf().PfSetStartupNodes();
-		bool bDestFound = true;
 
 		for (;;) {
 			m_num_steps++;
-			Node *n = m_nodes.GetBestOpenNode();
-			if (n == nullptr) {
+			Node *best_open_node = m_nodes.GetBestOpenNode();
+			if (best_open_node == nullptr) break;
+
+			if (Yapf().PfDetectDestination(*best_open_node)) {
+				m_pBestDestNode = best_open_node;
 				break;
 			}
 
-			/* if the best open node was worse than the best path found, we can finish */
-			if (m_pBestDestNode != nullptr && m_pBestDestNode->GetCost() < n->GetCostEstimate()) {
-				break;
-			}
+			Yapf().PfFollowNode(*best_open_node);
+			if (m_max_search_nodes != 0 && m_nodes.ClosedCount() >= m_max_search_nodes) break;
 
-			Yapf().PfFollowNode(*n);
-			if (m_max_search_nodes == 0 || m_nodes.ClosedCount() < m_max_search_nodes) {
-				m_nodes.PopOpenNode(n->GetKey());
-				m_nodes.InsertClosedNode(*n);
-			} else {
-				bDestFound = false;
-				break;
-			}
+			m_nodes.PopOpenNode(best_open_node->GetKey());
+			m_nodes.InsertClosedNode(*best_open_node);
 		}
 
-		bDestFound &= (m_pBestDestNode != nullptr);
+		const bool destination_found = (m_pBestDestNode != nullptr);
 
 		if (_debug_yapf_level >= 3) {
-			UnitID veh_idx = (m_veh != nullptr) ? m_veh->unitnumber : 0;
-			char ttc = Yapf().TransportTypeChar();
-			float cache_hit_ratio = (m_stats_cache_hits == 0) ? 0.0f : ((float)m_stats_cache_hits / (float)(m_stats_cache_hits + m_stats_cost_calcs) * 100.0f);
-			int cost = bDestFound ? m_pBestDestNode->m_cost : -1;
-			int dist = bDestFound ? m_pBestDestNode->m_estimate - m_pBestDestNode->m_cost : -1;
+			const UnitID veh_idx = (m_veh != nullptr) ? m_veh->unitnumber : 0;
+			const char ttc = Yapf().TransportTypeChar();
+			const float cache_hit_ratio = (m_stats_cache_hits == 0) ? 0.0f : ((float)m_stats_cache_hits / (float)(m_stats_cache_hits + m_stats_cost_calcs) * 100.0f);
+			const int cost = destination_found ? m_pBestDestNode->m_cost : -1;
+			const int dist = destination_found ? m_pBestDestNode->m_estimate - m_pBestDestNode->m_cost : -1;
 
 			Debug(yapf, 3, "[YAPF{}]{}{:4d} - {} rounds - {} open - {} closed - CHR {:4.1f}% - C {} D {}",
-				ttc, bDestFound ? '-' : '!', veh_idx, m_num_steps, m_nodes.OpenCount(), m_nodes.ClosedCount(), cache_hit_ratio, cost, dist
+				ttc, destination_found ? '-' : '!', veh_idx, m_num_steps, m_nodes.OpenCount(), m_nodes.ClosedCount(), cache_hit_ratio, cost, dist
 			);
 		}
 
-		return bDestFound;
+		return destination_found;
 	}
 
 	/**
@@ -241,16 +235,6 @@ public:
 
 		/* have the cost or estimate callbacks marked this node as invalid? */
 		if (!bValid) return;
-
-		/* detect the destination */
-		bool bDestination = Yapf().PfDetectDestination(n);
-		if (bDestination) {
-			if (m_pBestDestNode == nullptr || n < *m_pBestDestNode) {
-				m_pBestDestNode = &n;
-			}
-			m_nodes.FoundBestNode(n);
-			return;
-		}
 
 		/* The new node can be set as the best intermediate node only once we're
 		 * certain it will be finalized by being inserted into the open list. */


### PR DESCRIPTION
## Motivation / Problem

YAPF doesn't properly check if start tiles are destination tiles. This can cause YAPF to return a longer path than necessary if the vehicle just happens to be at the destination already.

I managed to hit such a situation while working on some changes for the water region pathfinder.

I also wonder if the code removed in #12192 could have been a workaround for this problem, but I'm not sure about that. 

## Description

Adding starting node is done via AddStartupNode. Subsequent iterations are then done using AddNewNode. AddNewNode, in addition to a lot of other stuff, does the PfDetectDestination check. But this check is never done for any of the starting nodes.

The solution I chose is how it's typically done for most A* implementations: just do the PfDetectDestination for the best node as it's popped of the open queue.

## Limitations

Pathfinders being pathfinders, there could be some weird edge case that I didn't think about. 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
