### PR TITLE
Change: Allow rail and road depot overbuilding in current orientation in order to connect to rail or road

### DIFF
--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -7510,7 +7510,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     BuildRailDepot():              false
     BuildRailDepot():              true
     BuildRailDepot():              true
-    BuildRailDepot():              false
+    BuildRailDepot():              true
     GetRailDepotFrontTile():       33412
     IsBuildable():                 false
     DepotList
@@ -7604,12 +7604,12 @@ ERROR: IsEnd() is invalid as Begin() is never called
     BuildRoadDepot():              false
     BuildRoadDepot():              true
     BuildRoadDepot():              true
-    BuildRoadDepot():              false
+    BuildRoadDepot():              true
     HasRoadType(Road):             true
     HasRoadType(Tram):             false
-    GetLastError():                259
-    GetLastErrorString():          ERR_ALREADY_BUILT
-    GetErrorCategory():            1
+    GetLastError():                0
+    GetLastErrorString():          ERR_NONE
+    GetErrorCategory():            0
     IsRoadTile():                  false
     GetRoadDepotFrontTile():       33412
     IsRoadDepotTile():             true
@@ -9471,7 +9471,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
   IsStoppedInDepot():   false
   --Accounting--
     GetCosts():         -5947
-    Should be:          -5946
+    Should be:          -5947
   GetName():            Road Vehicle #1
   SetName():            true
   GetName():            MyVehicleName
@@ -9485,7 +9485,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAgeLeft():        5489
     GetCurrentSpeed():   7
     GetRunningCost():    421
-    GetProfitThisYear(): -1
+    GetProfitThisYear(): 0
     GetProfitLastYear(): 0
     GetCurrentValue():   5947
     GetVehicleType():    1
@@ -9604,7 +9604,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     16 => 0
     14 => 0
     13 => 0
-    12 => -1
+    12 => 0
   ProfitLastYear ListDump:
     17 => 0
     16 => 0

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -989,7 +989,7 @@ CommandCost CmdBuildTrainDepot(DoCommandFlag flags, TileIndex tile, RailType rai
 		CommandCost ret = CheckTileOwnership(tile);
 		if (ret.Failed()) return ret;
 
-		if (dir == GetRailDepotDirection(tile)) return_cmd_error(STR_ERROR_ALREADY_BUILT);
+		if (dir == GetRailDepotDirection(tile)) return CommandCost();
 
 		ret = EnsureNoVehicleOnGround(tile);
 		if (ret.Failed()) return ret;

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1167,7 +1167,7 @@ CommandCost CmdBuildRoadDepot(DoCommandFlag flags, TileIndex tile, RoadType rt, 
 		CommandCost ret = CheckTileOwnership(tile);
 		if (ret.Failed()) return ret;
 
-		if (dir == GetRoadDepotDirection(tile)) return_cmd_error(STR_ERROR_ALREADY_BUILT);
+		if (dir == GetRoadDepotDirection(tile)) return CommandCost();
 
 		ret = EnsureNoVehicleOnGround(tile);
 		if (ret.Failed()) return ret;


### PR DESCRIPTION
## Motivation / Problem
![openttd_iTAPbr1RRu](https://github.com/OpenTTD/OpenTTD/assets/68320206/cf82eeb3-0201-4c2e-b5ca-265eb397074a)

Sometimes you happen to build a depot right when a train is passing by. As a result no connecting rails are created. It would be nice if you could simply overbuild the depot in the same orientation as soon as the train is gone. But that currently results in an "Already built" error.

This also applies to road vehicles and trams.

## Description
![openttd_Vf7jkFWwzs](https://github.com/OpenTTD/OpenTTD/assets/68320206/15da477e-40db-40d7-950b-0056ecc99d06)

We no longer throw a error when the depot is already in the desired orientation. We don't charge any money for it either, we just silently ignore it. This behavior is similar to overbuilding station tiles.

Money is charged for any pieces of connecting rail / road that get constructed as a result of this user action.

## Limitations

Not sure if this is something that could mess with AI logic.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
