### PR TITLE
Remove: [Script] random_deviation from setting description table

### DIFF
--- a/src/ai/ai.hpp
+++ b/src/ai/ai.hpp
@@ -27,9 +27,8 @@ public:
 	/**
 	 * Start a new AI company.
 	 * @param company At which slot the AI company should start.
-	 * @param deviate Whether to apply random deviation to the configured AI.
 	 */
-	static void StartNew(CompanyID company, bool deviate = true);
+	static void StartNew(CompanyID company);
 
 	/**
 	 * Called every game-tick to let AIs do something.

--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -33,7 +33,7 @@
 	return !_networking || (_network_server && _settings_game.ai.ai_in_multiplayer);
 }
 
-/* static */ void AI::StartNew(CompanyID company, bool deviate)
+/* static */ void AI::StartNew(CompanyID company)
 {
 	assert(Company::IsValidID(company));
 
@@ -56,7 +56,6 @@
 		/* Load default data and store the name in the settings */
 		config->Change(info->GetName(), -1, false);
 	}
-	if (deviate) config->AddRandomDeviation(company);
 	config->AnchorUnchangeableSettings();
 
 	c->ai_info = info;
@@ -221,7 +220,7 @@
 					 * killing the offending AI we start a random other one in it's place, just
 					 * like what would happen if the AI was missing during loading. */
 					AI::Stop(c);
-					AI::StartNew(c, false);
+					AI::StartNew(c);
 				}
 			} else if (Company::IsValidAiID(c)) {
 				/* Update the reference in the Company struct. */

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -31,9 +31,8 @@ public:
 
 	/**
 	 * Start up a new GameScript.
-	 * @param deviate Whether to apply random deviation to the configured GameScript.
 	 */
-	static void StartNew(bool deviate = true);
+	static void StartNew();
 
 	/**
 	 * Uninitialize the Game system.

--- a/src/game/game_core.cpp
+++ b/src/game/game_core.cpp
@@ -69,7 +69,7 @@
 	}
 }
 
-/* static */ void Game::StartNew(bool deviate)
+/* static */ void Game::StartNew()
 {
 	if (Game::instance != nullptr) return;
 
@@ -83,7 +83,6 @@
 	GameInfo *info = config->GetInfo();
 	if (info == nullptr) return;
 
-	if (deviate) config->AddRandomDeviation(OWNER_DEITY);
 	config->AnchorUnchangeableSettings();
 
 	Backup<CompanyID> cur_company(_current_company, FILE_LINE);

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -199,18 +199,10 @@ struct GSConfigWindow : public Window {
 					TextColour colour;
 					uint idx = 0;
 					if (config_item.description.empty()) {
-						if (Game::GetInstance() == nullptr && config_item.random_deviation != 0) {
-							str = STR_AI_SETTINGS_JUST_DEVIATION;
-						} else {
-							str = STR_JUST_STRING1;
-						}
+						str = STR_JUST_STRING1;
 						colour = TC_ORANGE;
 					} else {
-						if (Game::GetInstance() == nullptr && config_item.random_deviation != 0) {
-							str = STR_AI_SETTINGS_SETTING_DEVIATION;
-						} else {
-							str = STR_AI_SETTINGS_SETTING;
-						}
+						str = STR_AI_SETTINGS_SETTING;
 						colour = TC_LIGHT_BLUE;
 						SetDParamStr(idx++, config_item.description);
 					}
@@ -225,35 +217,13 @@ struct GSConfigWindow : public Window {
 							DrawArrowButtons(br.left, y + button_y_offset, COLOUR_YELLOW, (this->clicked_button == i) ? 1 + (this->clicked_increase != rtl) : 0, editable && current_value > config_item.min_value, editable && current_value < config_item.max_value);
 						}
 
-						if (Game::GetInstance() != nullptr || config_item.random_deviation == 0) {
-							auto config_iterator = config_item.labels.find(current_value);
-							if (config_iterator != config_item.labels.end()) {
-								SetDParam(idx++, STR_JUST_RAW_STRING);
-								SetDParamStr(idx++, config_iterator->second);
-							} else {
-								SetDParam(idx++, STR_JUST_INT);
-								SetDParam(idx++, current_value);
-							}
+						auto config_iterator = config_item.labels.find(current_value);
+						if (config_iterator != config_item.labels.end()) {
+							SetDParam(idx++, STR_JUST_RAW_STRING);
+							SetDParamStr(idx++, config_iterator->second);
 						} else {
-							int min_deviated = std::max(config_item.min_value, current_value - config_item.random_deviation);
-							auto config_iterator = config_item.labels.find(min_deviated);
-							if (config_iterator != config_item.labels.end()) {
-								SetDParam(idx++, STR_JUST_RAW_STRING);
-								SetDParamStr(idx++, config_iterator->second);
-							} else {
-								SetDParam(idx++, STR_JUST_INT);
-								SetDParam(idx++, min_deviated);
-							}
-
-							int max_deviated = std::min(config_item.max_value, current_value + config_item.random_deviation);
-							config_iterator = config_item.labels.find(max_deviated);
-							if (config_iterator != config_item.labels.end()) {
-								SetDParam(idx++, STR_JUST_RAW_STRING);
-								SetDParamStr(idx++, config_iterator->second);
-							} else {
-								SetDParam(idx++, STR_JUST_INT);
-								SetDParam(idx++, max_deviated);
-							}
+							SetDParam(idx++, STR_JUST_INT);
+							SetDParam(idx++, current_value);
 						}
 					}
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4843,8 +4843,6 @@ STR_AI_SETTINGS_CAPTION_GAMESCRIPT                              :Game Script
 STR_AI_SETTINGS_CLOSE                                           :{BLACK}Close
 STR_AI_SETTINGS_RESET                                           :{BLACK}Reset
 STR_AI_SETTINGS_SETTING                                         :{RAW_STRING}: {ORANGE}{STRING1}
-STR_AI_SETTINGS_SETTING_DEVIATION                               :{RAW_STRING}: {ORANGE}[{STRING1}, {STRING1}]
-STR_AI_SETTINGS_JUST_DEVIATION                                  :[{STRING1}, {STRING1}]
 
 
 # Textfile window

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -547,11 +547,11 @@ static void StartScripts()
 
 	/* Start the AIs. */
 	for (const Company *c : Company::Iterate()) {
-		if (Company::IsValidAiID(c->index)) AI::StartNew(c->index, false);
+		if (Company::IsValidAiID(c->index)) AI::StartNew(c->index);
 	}
 
 	/* Start the GameScript. */
-	Game::StartNew(false);
+	Game::StartNew();
 
 	ShowScriptDebugWindowIfScriptError();
 }

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -29,6 +29,7 @@
  * API removals:
  * \li AIError::ERR_PRECONDITION_TOO_MANY_PARAMETERS, that error is never returned anymore.
  * \li AIInfo::CONFIG_RANDOM, no longer used.
+ * \li AIInfo::AddSettings random_deviation is no longer used.
  *
  * Other changes:
  * \li AIGroupList accepts an optional filter function

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -95,6 +95,7 @@
  * API removals:
  * \li GSError::ERR_PRECONDITION_TOO_MANY_PARAMETERS, that error is never returned anymore.
  * \li GSInfo::CONFIG_RANDOM, no longer used.
+ * \li GSInfo::AddSettings random_deviation is no longer used.
  *
  * Other changes:
  * \li GSGroupList accepts an optional filter function

--- a/src/script/api/script_info_docs.hpp
+++ b/src/script/api/script_info_docs.hpp
@@ -224,12 +224,6 @@ public:
 	 *    clamped in the range [MIN(int32_t), MAX(int32_t)] (inclusive).
 	 *  - default_value The default value. Required. The value will be
 	 *    clamped in the range [MIN(int32_t), MAX(int32_t)] (inclusive).
-	 *  - random_deviation If this property has a nonzero value, then the
-	 *    actual value of the setting in game will be randomised in the range
-	 *    [user_configured_value - random_deviation, user_configured_value + random_deviation] (inclusive).
-	 *    random_deviation sign is ignored and the value is clamped in the range [0, MAX(int32_t)] (inclusive).
-	 *    The randomisation will happen just before the Script start.
-	 *    Not allowed if the CONFIG_BOOLEAN flag is set, otherwise optional.
 	 *  - step_size The increase/decrease of the value every time the user
 	 *    clicks one of the up/down arrow buttons. Optional, default is 1.
 	 *  - flags Bitmask of some flags, see ScriptConfigFlags. Required.

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -123,15 +123,6 @@ void ScriptConfig::ResetEditableSettings(bool yet_to_start)
 	}
 }
 
-void ScriptConfig::AddRandomDeviation(CompanyID owner)
-{
-	for (const auto &item : *this->GetConfigList()) {
-		if (item.random_deviation != 0) {
-			this->SetSetting(item.name, ScriptObject::GetRandomizer(owner).Next(item.random_deviation * 2 + 1) - item.random_deviation + this->GetSetting(item.name));
-		}
-	}
-}
-
 bool ScriptConfig::HasScript() const
 {
 	return this->info != nullptr;

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -35,7 +35,6 @@ struct ScriptConfigItem {
 	int min_value = 0;            ///< The minimal value this configuration setting can have.
 	int max_value = 1;            ///< The maximal value this configuration setting can have.
 	int default_value = 0;        ///< The default value of this configuration setting.
-	int random_deviation = 0;     ///< The maximum random deviation from the default value.
 	int step_size = 1;            ///< The step size in the gui.
 	ScriptConfigFlags flags = SCRIPTCONFIG_NONE; ///< Flags for the configuration setting.
 	LabelMapping labels;          ///< Text labels for the integer values.
@@ -131,11 +130,6 @@ public:
 	 * Reset only editable and visible settings to their default value.
 	 */
 	void ResetEditableSettings(bool yet_to_start);
-
-	/**
-	 * Randomize all settings the Script requested to be randomized.
-	 */
-	void AddRandomDeviation(CompanyID owner);
 
 	/**
 	 * Is this config attached to an Script? In other words, is there a Script

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -377,18 +377,10 @@ struct ScriptSettingsWindow : public Window {
 			TextColour colour;
 			uint idx = 0;
 			if (config_item.description.empty()) {
-				if (this->slot != OWNER_DEITY && !Company::IsValidID(this->slot) && config_item.random_deviation != 0) {
-					str = STR_AI_SETTINGS_JUST_DEVIATION;
-				} else {
-					str = STR_JUST_STRING1;
-				}
+				str = STR_JUST_STRING1;
 				colour = TC_ORANGE;
 			} else {
-				if (this->slot != OWNER_DEITY && !Company::IsValidID(this->slot) && config_item.random_deviation != 0) {
-					str = STR_AI_SETTINGS_SETTING_DEVIATION;
-				} else {
-					str = STR_AI_SETTINGS_SETTING;
-				}
+				str = STR_AI_SETTINGS_SETTING;
 				colour = TC_LIGHT_BLUE;
 				SetDParamStr(idx++, config_item.description);
 			}
@@ -403,35 +395,13 @@ struct ScriptSettingsWindow : public Window {
 					DrawArrowButtons(br.left, y + button_y_offset, COLOUR_YELLOW, (this->clicked_button == i) ? 1 + (this->clicked_increase != rtl) : 0, editable && current_value > config_item.min_value, editable && current_value < config_item.max_value);
 				}
 
-				if (this->slot == OWNER_DEITY || Company::IsValidID(this->slot) || config_item.random_deviation == 0) {
-					auto config_iterator = config_item.labels.find(current_value);
-					if (config_iterator != config_item.labels.end()) {
-						SetDParam(idx++, STR_JUST_RAW_STRING);
-						SetDParamStr(idx++, config_iterator->second);
-					} else {
-						SetDParam(idx++, STR_JUST_INT);
-						SetDParam(idx++, current_value);
-					}
+				auto config_iterator = config_item.labels.find(current_value);
+				if (config_iterator != config_item.labels.end()) {
+					SetDParam(idx++, STR_JUST_RAW_STRING);
+					SetDParamStr(idx++, config_iterator->second);
 				} else {
-					int min_deviated = std::max(config_item.min_value, current_value - config_item.random_deviation);
-					auto config_iterator = config_item.labels.find(min_deviated);
-					if (config_iterator != config_item.labels.end()) {
-						SetDParam(idx++, STR_JUST_RAW_STRING);
-						SetDParamStr(idx++, config_iterator->second);
-					} else {
-						SetDParam(idx++, STR_JUST_INT);
-						SetDParam(idx++, min_deviated);
-					}
-
-					int max_deviated = std::min(config_item.max_value, current_value + config_item.random_deviation);
-					config_iterator = config_item.labels.find(max_deviated);
-					if (config_iterator != config_item.labels.end()) {
-						SetDParam(idx++, STR_JUST_RAW_STRING);
-						SetDParamStr(idx++, config_iterator->second);
-					} else {
-						SetDParam(idx++, STR_JUST_INT);
-						SetDParam(idx++, max_deviated);
-					}
+					SetDParam(idx++, STR_JUST_INT);
+					SetDParam(idx++, current_value);
 				}
 			}
 

--- a/src/script/script_info.cpp
+++ b/src/script/script_info.cpp
@@ -87,9 +87,7 @@ SQInteger ScriptInfo::AddSetting(HSQUIRRELVM vm)
 	ScriptConfigItem config;
 	uint items = 0;
 
-	int easy_value = INT32_MIN;
 	int medium_value = INT32_MIN;
-	int hard_value = INT32_MIN;
 
 	/* Read the table, and find all properties we care about */
 	sq_pushnull(vm);
@@ -124,9 +122,7 @@ SQInteger ScriptInfo::AddSetting(HSQUIRRELVM vm)
 			config.max_value = ClampTo<int32_t>(res);
 			items |= 0x008;
 		} else if (key == "easy_value") {
-			SQInteger res;
-			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
-			easy_value = ClampTo<int32_t>(res);
+			// No longer parsed.
 			items |= 0x010;
 		} else if (key == "medium_value") {
 			SQInteger res;
@@ -134,9 +130,7 @@ SQInteger ScriptInfo::AddSetting(HSQUIRRELVM vm)
 			medium_value = ClampTo<int32_t>(res);
 			items |= 0x020;
 		} else if (key == "hard_value") {
-			SQInteger res;
-			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
-			hard_value = ClampTo<int32_t>(res);
+			// No longer parsed.
 			items |= 0x040;
 		} else if (key == "custom_value") {
 			// No longer parsed.
@@ -146,10 +140,7 @@ SQInteger ScriptInfo::AddSetting(HSQUIRRELVM vm)
 			config.default_value = ClampTo<int32_t>(res);
 			items |= 0x080;
 		} else if (key == "random_deviation") {
-			SQInteger res;
-			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
-			config.random_deviation = ClampTo<int32_t>(abs(res));
-			items |= 0x200;
+			// No longer parsed.
 		} else if (key == "step_size") {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
@@ -179,26 +170,11 @@ SQInteger ScriptInfo::AddSetting(HSQUIRRELVM vm)
 		}
 
 		config.default_value = medium_value;
-		/* If not boolean and no random deviation set, calculate it based on easy/hard difference. */
-		if ((config.flags & SCRIPTCONFIG_BOOLEAN) == 0 && (items & 0x200) == 0) {
-			config.random_deviation = abs(hard_value - easy_value) / 2;
-			items |= 0x200;
-		}
 		items |= 0x080;
 	} else {
 		/* For compatibility, also act like the default sets the easy/medium/hard. */
 		items |= 0x010 | 0x020 | 0x040;
 	}
-
-	/* Don't allow both random_deviation and SCRIPTCONFIG_BOOLEAN to
-	 * be set for the same config item. */
-	if ((items & 0x200) != 0 && (config.flags & SCRIPTCONFIG_BOOLEAN) != 0) {
-		this->engine->ThrowError("setting both random_deviation and CONFIG_BOOLEAN is not allowed");
-		return SQ_ERROR;
-	}
-
-	/* Reset the bit for random_deviation as it's optional. */
-	items &= ~0x200;
 
 	/* Make sure all properties are defined */
 	uint mask = (config.flags & SCRIPTCONFIG_BOOLEAN) ? 0x1F3 : 0x1FF;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
* Only 1 existing AI (from all AI/GS in bananas) is using `random_deviation`.
* It was applied inconsistently before #11944
* It was invisible before #11958
* Our conversion from easy/medium/hard to default=medium + random_deviation((hard - easy) / 2) causes confusion (#12182).
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Just remove `random_deviation`.
`medium_value` is used for default when converting from easy/medium/hard.
Fixes #12182.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
