### PR TITLE
Fix: Maximum permitted sound volume is 128.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -3153,7 +3153,7 @@ static ChangeInfoResult SoundEffectChangeInfo(uint sid, int numinfo, int prop, B
 
 		switch (prop) {
 			case 0x08: // Relative volume
-				sound->volume = buf->ReadByte();
+				sound->volume = Clamp(buf->ReadByte(), 0, SOUND_EFFECT_MAX_VOLUME);
 				break;
 
 			case 0x09: // Priority
@@ -7857,7 +7857,7 @@ static void ImportGRFSound(SoundEntry *sound)
 	*sound = *GetSound(file->sound_offset + sound_id);
 
 	/* Reset volume and priority, which TTDPatch doesn't copy */
-	sound->volume   = 128;
+	sound->volume = SOUND_EFFECT_MAX_VOLUME;
 	sound->priority = 0;
 }
 
@@ -7869,7 +7869,7 @@ static void ImportGRFSound(SoundEntry *sound)
 static void LoadGRFSound(size_t offs, SoundEntry *sound)
 {
 	/* Set default volume and priority */
-	sound->volume = 0x80;
+	sound->volume = SOUND_EFFECT_MAX_VOLUME;
 	sound->priority = 0;
 
 	if (offs != SIZE_MAX) {

--- a/src/sound_type.h
+++ b/src/sound_type.h
@@ -119,4 +119,6 @@ typedef uint16_t SoundID;
 
 static const SoundID INVALID_SOUND = 0xFFFF;
 
+static const uint8_t SOUND_EFFECT_MAX_VOLUME = 128;
+
 #endif /* SOUND_TYPE_H */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

The NewGRF property for sound effect volume is meant to be in the range 0-128 (inclusive), however OpenTTD does not check this and allows values from 0-255 instead.

Values greater than 128 could potentially cause audio clipping, although that depends on the sound effect as well.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add a constant for maximum sound effect volume, and clamp the NewGRF property to this constant.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
