### PR TITLE
Change: Use same audio buffer size and config parameter for all sound drivers.

### DIFF
--- a/src/sound/win32_s.cpp
+++ b/src/sound/win32_s.cpp
@@ -70,7 +70,7 @@ const char *SoundDriver_Win32::Start(const StringList &parm)
 	wfex.nAvgBytesPerSec = wfex.nSamplesPerSec * wfex.nBlockAlign;
 
 	/* Limit buffer size to prevent overflows. */
-	_bufsize = GetDriverParamInt(parm, "bufsize", 8192);
+	_bufsize = GetDriverParamInt(parm, "samples", 1024);
 	_bufsize = std::min<int>(_bufsize, UINT16_MAX);
 
 	try {

--- a/src/sound/xaudio2_s.cpp
+++ b/src/sound/xaudio2_s.cpp
@@ -205,7 +205,7 @@ const char *SoundDriver_XAudio2::Start(const StringList &parm)
 	wfex.nAvgBytesPerSec = wfex.nSamplesPerSec * wfex.nBlockAlign;
 
 	// Limit buffer size to prevent overflows
-	int bufsize = GetDriverParamInt(parm, "bufsize", 8192);
+	int bufsize = GetDriverParamInt(parm, "samples", 1024);
 	bufsize = std::min<int>(bufsize, UINT16_MAX);
 
 	_voice_context = new StreamingVoiceContext(bufsize * 4);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

For Allegro, SDL and SDLv2 sound drivers, the parameter to change audio frame size is `samples`, however for the two Windows sound drivers (win32 and xaudio2) the parameter is named `bufsize`.

The default value for all drivers that use `samples` is `1024`, but the default for drivers that use `bufsize` is `8192`.

At 44100 Hz, these sizes provide a latency per buffer (usually there are at least 2 buffers) of 23 ms and 186 ms respectively.

Our audio mixer is limited to only playing 8 sound effects at once, and that limit applies to the whole buffer size. Therefore with a larger buffer size, it is more likely that mixer channels will be used up and new sounds get blocked from playing.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Bring the two Windows driver in line by changing the parameter name to `samples` for all drivers, and change the default buffer size to `1024`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This does not touch the Cocoa driver, with how the macOS API works we don't actually set the buffer size and just use what we're given.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
