### PR TITLE
Codechange: Remove pointer parameters in foundation/slope code.

### DIFF
--- a/src/bridge_map.cpp
+++ b/src/bridge_map.cpp
@@ -69,8 +69,7 @@ TileIndex GetOtherBridgeEnd(TileIndex tile)
  */
 int GetBridgeHeight(TileIndex t)
 {
-	int h;
-	Slope tileh = GetTileSlope(t, &h);
+	auto [tileh, h] = GetTileSlopeZ(t);
 	Foundation f = GetBridgeFoundation(tileh, DiagDirToAxis(GetTunnelBridgeDirection(t)));
 
 	/* one height level extra for the ramp */

--- a/src/bridge_map.cpp
+++ b/src/bridge_map.cpp
@@ -73,5 +73,5 @@ int GetBridgeHeight(TileIndex t)
 	Foundation f = GetBridgeFoundation(tileh, DiagDirToAxis(GetTunnelBridgeDirection(t)));
 
 	/* one height level extra for the ramp */
-	return h + 1 + ApplyFoundationToSlope(f, &tileh);
+	return h + 1 + ApplyFoundationToSlope(f, tileh);
 }

--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -129,8 +129,7 @@ static void DrawTile_Clear(TileInfo *ti)
 
 static int GetSlopePixelZ_Clear(TileIndex tile, uint x, uint y, bool)
 {
-	int z;
-	Slope tileh = GetTilePixelSlope(tile, &z);
+	auto [tileh, z] = GetTilePixelSlope(tile);
 
 	return z + GetPartialPixelZ(x & 0xF, y & 0xF, tileh);
 }

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -67,8 +67,8 @@ void CcPlaySound_CONSTRUCTION_WATER(Commands, const CommandCost &result, TileInd
  */
 static TileIndex GetOtherAqueductEnd(TileIndex tile_from, TileIndex *tile_to = nullptr)
 {
-	int z;
-	DiagDirection dir = GetInclinedSlopeDirection(GetTileSlope(tile_from, &z));
+	auto [slope, z] = GetTileSlopeZ(tile_from);
+	DiagDirection dir = GetInclinedSlopeDirection(slope);
 
 	/* If the direction isn't right, just return the next tile so the command
 	 * complains about the wrong slope instead of the ends not matching up.

--- a/src/elrail.cpp
+++ b/src/elrail.cpp
@@ -389,7 +389,7 @@ static void DrawRailCatenaryRailway(const TileInfo *ti)
 			foundation = GetBridgeFoundation(tileh[TS_NEIGHBOUR], DiagDirToAxis(GetTunnelBridgeDirection(neighbour)));
 		}
 
-		ApplyFoundationToSlope(foundation, &tileh[TS_NEIGHBOUR]);
+		ApplyFoundationToSlope(foundation, tileh[TS_NEIGHBOUR]);
 
 		/* Half tile slopes coincide only with horizontal/vertical track.
 		 * Faking a flat slope results in the correct sprites on positions. */

--- a/src/landscape.h
+++ b/src/landscape.h
@@ -34,7 +34,7 @@ byte LowestSnowLine();
 void ClearSnowLine();
 
 int GetSlopeZInCorner(Slope tileh, Corner corner);
-Slope GetFoundationSlope(TileIndex tile, int *z = nullptr);
+std::tuple<Slope, int> GetFoundationSlope(TileIndex tile);
 
 uint GetPartialPixelZ(int x, int y, Slope corners);
 int GetSlopePixelZ(int x, int y, bool ground_vehicle = false);
@@ -60,15 +60,12 @@ inline int GetSlopePixelZInCorner(Slope tileh, Corner corner)
  * If a tile does not have a foundation, the function returns the same as GetTilePixelSlope.
  *
  * @param tile The tile of interest.
- * @param z returns the z of the foundation slope. (Can be nullptr, if not needed)
- * @return The slope on top of the foundation.
+ * @return The slope on top of the foundation and the z of the foundation.
  */
-inline Slope GetFoundationPixelSlope(TileIndex tile, int *z)
+inline std::tuple<Slope, int> GetFoundationPixelSlope(TileIndex tile)
 {
-	assert(z != nullptr);
-	Slope s = GetFoundationSlope(tile, z);
-	*z *= TILE_HEIGHT;
-	return s;
+	auto [s, z] = GetFoundationSlope(tile);
+	return {s, z * TILE_HEIGHT};
 }
 
 /**

--- a/src/landscape.h
+++ b/src/landscape.h
@@ -39,7 +39,7 @@ std::tuple<Slope, int> GetFoundationSlope(TileIndex tile);
 uint GetPartialPixelZ(int x, int y, Slope corners);
 int GetSlopePixelZ(int x, int y, bool ground_vehicle = false);
 int GetSlopePixelZOutsideMap(int x, int y);
-void GetSlopePixelZOnEdge(Slope tileh, DiagDirection edge, int *z1, int *z2);
+void GetSlopePixelZOnEdge(Slope tileh, DiagDirection edge, int &z1, int &z2);
 
 /**
  * Determine the Z height of a corner relative to TileZ.
@@ -114,7 +114,7 @@ inline Point InverseRemapCoords(int x, int y)
 
 Point InverseRemapCoords2(int x, int y, bool clamp_to_map = false, bool *clamped = nullptr);
 
-uint ApplyFoundationToSlope(Foundation f, Slope *s);
+uint ApplyFoundationToSlope(Foundation f, Slope &s);
 /**
  * Applies a foundation to a slope.
  *
@@ -123,7 +123,7 @@ uint ApplyFoundationToSlope(Foundation f, Slope *s);
  * @param s  The #Slope to modify.
  * @return   Increment to the tile Z coordinate.
  */
-inline uint ApplyPixelFoundationToSlope(Foundation f, Slope *s)
+inline uint ApplyPixelFoundationToSlope(Foundation f, Slope &s)
 {
 	return ApplyFoundationToSlope(f, s) * TILE_HEIGHT;
 }

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -433,8 +433,7 @@ uint32_t GetNearbyTileInformation(TileIndex tile, bool grf_version8)
 	/* Fake tile type for trees on shore */
 	if (IsTileType(tile, MP_TREES) && GetTreeGround(tile) == TREE_GROUND_SHORE) tile_type = MP_WATER;
 
-	int z;
-	Slope tileh = GetTilePixelSlope(tile, &z);
+	auto [tileh, z] = GetTilePixelSlope(tile);
 	/* Return 0 if the tile is a land tile */
 	byte terrain_type = (HasTileWaterClass(tile) ? (GetWaterClass(tile) + 1) & 3 : 0) << 5 | GetTerrainType(tile) << 2 | (tile_type == MP_WATER ? 1 : 0) << 1;
 	if (grf_version8) z /= TILE_HEIGHT;

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -267,8 +267,8 @@ CommandCost CmdBuildObject(DoCommandFlag flags, TileIndex tile, ObjectType type,
 		}
 
 		/* So, now the surface is checked... check the slope of said surface. */
-		int allowed_z;
-		if (GetTileSlope(tile, &allowed_z) != SLOPE_FLAT) allowed_z++;
+		auto [slope, allowed_z] = GetTileSlopeZ(tile);
+		if (slope != SLOPE_FLAT) allowed_z++;
 
 		for (TileIndex t : ta) {
 			uint16_t callback = CALLBACK_FAILED;
@@ -492,8 +492,7 @@ static void DrawTile_Object(TileInfo *ti)
 static int GetSlopePixelZ_Object(TileIndex tile, uint x, uint y, bool)
 {
 	if (IsObjectType(tile, OBJECT_OWNED_LAND)) {
-		int z;
-		Slope tileh = GetTilePixelSlope(tile, &z);
+		auto [tileh, z] = GetTilePixelSlope(tile);
 
 		return z + GetPartialPixelZ(x & 0xF, y & 0xF, tileh);
 	} else {

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -2580,8 +2580,7 @@ void DrawTrainDepotSprite(int x, int y, int dir, RailType railtype)
 static int GetSlopePixelZ_Track(TileIndex tile, uint x, uint y, bool)
 {
 	if (IsPlainRail(tile)) {
-		int z;
-		Slope tileh = GetTilePixelSlope(tile, &z);
+		auto [tileh, z] = GetTilePixelSlope(tile);
 		if (tileh == SLOPE_FLAT) return z;
 
 		z += ApplyPixelFoundationToSlope(GetRailFoundation(tileh, GetTrackBits(tile)), &tileh);
@@ -2608,8 +2607,7 @@ static void TileLoop_Track(TileIndex tile)
 
 	switch (_settings_game.game_creation.landscape) {
 		case LT_ARCTIC: {
-			int z;
-			Slope slope = GetTileSlope(tile, &z);
+			auto [slope, z] = GetTileSlopeZ(tile);
 			bool half = false;
 
 			/* for non-flat track, use lower part of track
@@ -3052,8 +3050,7 @@ static Vehicle *EnsureNoShipProc(Vehicle *v, void *)
 
 static CommandCost TerraformTile_Track(TileIndex tile, DoCommandFlag flags, int z_new, Slope tileh_new)
 {
-	int z_old;
-	Slope tileh_old = GetTileSlope(tile, &z_old);
+	auto [tileh_old, z_old] = GetTileSlopeZ(tile);
 	if (IsPlainRail(tile)) {
 		TrackBits rail_bits = GetTrackBits(tile);
 		/* Is there flat water on the lower halftile that must be cleared expensively? */

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -793,7 +793,7 @@ bool FloodHalftile(TileIndex t)
 		}
 	} else {
 		/* Make shore on steep slopes and 'three-corners-raised'-slopes. */
-		if (ApplyFoundationToSlope(GetRailFoundation(tileh, rail_bits), &tileh) == 0) {
+		if (ApplyFoundationToSlope(GetRailFoundation(tileh, rail_bits), tileh) == 0) {
 			if (IsSteepSlope(tileh) || IsSlopeWithThreeCornersRaised(tileh)) {
 				flooded = true;
 				SetRailGroundType(t, RAIL_GROUND_WATER);
@@ -2583,7 +2583,7 @@ static int GetSlopePixelZ_Track(TileIndex tile, uint x, uint y, bool)
 		auto [tileh, z] = GetTilePixelSlope(tile);
 		if (tileh == SLOPE_FLAT) return z;
 
-		z += ApplyPixelFoundationToSlope(GetRailFoundation(tileh, GetTrackBits(tile)), &tileh);
+		z += ApplyPixelFoundationToSlope(GetRailFoundation(tileh, GetTrackBits(tile)), tileh);
 		return z + GetPartialPixelZ(x & 0xF, y & 0xF, tileh);
 	} else {
 		return GetTileMaxPixelZ(tile);
@@ -3009,8 +3009,8 @@ static CommandCost TestAutoslopeOnRailTile(TileIndex tile, uint flags, int z_old
 	if (CheckRailSlope(tileh_new, rail_bits, TRACK_BIT_NONE, tile).Failed()) return_cmd_error(STR_ERROR_MUST_REMOVE_RAILROAD_TRACK);
 
 	/* Get the slopes on top of the foundations */
-	z_old += ApplyFoundationToSlope(GetRailFoundation(tileh_old, rail_bits), &tileh_old);
-	z_new += ApplyFoundationToSlope(GetRailFoundation(tileh_new, rail_bits), &tileh_new);
+	z_old += ApplyFoundationToSlope(GetRailFoundation(tileh_old, rail_bits), tileh_old);
+	z_new += ApplyFoundationToSlope(GetRailFoundation(tileh_new, rail_bits), tileh_new);
 
 	Corner track_corner;
 	switch (rail_bits) {

--- a/src/road.cpp
+++ b/src/road.cpp
@@ -35,7 +35,7 @@ static bool IsPossibleCrossing(const TileIndex tile, Axis ax)
 	return (IsTileType(tile, MP_RAILWAY) &&
 		GetRailTileType(tile) == RAIL_TILE_NORMAL &&
 		GetTrackBits(tile) == (ax == AXIS_X ? TRACK_BIT_Y : TRACK_BIT_X) &&
-		GetFoundationSlope(tile) == SLOPE_FLAT);
+		std::get<0>(GetFoundationSlope(tile)) == SLOPE_FLAT);
 }
 
 /**

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1926,8 +1926,7 @@ static int GetSlopePixelZ_Road(TileIndex tile, uint x, uint y, bool)
 {
 
 	if (IsNormalRoad(tile)) {
-		int z;
-		Slope tileh = GetTilePixelSlope(tile, &z);
+		auto [tileh, z] = GetTilePixelSlope(tile);
 		if (tileh == SLOPE_FLAT) return z;
 
 		Foundation f = GetRoadFoundation(tileh, GetAllRoadBits(tile));
@@ -1999,7 +1998,7 @@ static void TileLoop_Road(TileIndex tile)
 			if (t->road_build_months != 0 &&
 					(DistanceManhattan(t->xy, tile) < 8 || grp != HZB_TOWN_EDGE) &&
 					IsNormalRoad(tile) && !HasAtMostOneBit(GetAllRoadBits(tile))) {
-				if (GetFoundationSlope(tile) == SLOPE_FLAT && EnsureNoVehicleOnGround(tile).Succeeded() && Chance16(1, 40)) {
+				if (std::get<0>(GetFoundationSlope(tile)) == SLOPE_FLAT && EnsureNoVehicleOnGround(tile).Succeeded() && Chance16(1, 40)) {
 					StartRoadWorks(tile);
 
 					if (_settings_client.sound.ambient) SndPlayTileFx(SND_21_ROAD_WORKS, tile);
@@ -2343,8 +2342,7 @@ static CommandCost TerraformTile_Road(TileIndex tile, DoCommandFlag flags, int z
 				if (CheckRoadSlope(tileh_new, &bits_copy, ROAD_NONE, ROAD_NONE).Succeeded()) {
 					/* CheckRoadSlope() sometimes changes the road_bits, if it does not agree with them. */
 					if (bits == bits_copy) {
-						int z_old;
-						Slope tileh_old = GetTileSlope(tile, &z_old);
+						auto [tileh_old, z_old] = GetTileSlopeZ(tile);
 
 						/* Get the slope on top of the foundation */
 						z_old += ApplyFoundationToSlope(GetRoadFoundation(tileh_old, bits), &tileh_old);

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1930,7 +1930,7 @@ static int GetSlopePixelZ_Road(TileIndex tile, uint x, uint y, bool)
 		if (tileh == SLOPE_FLAT) return z;
 
 		Foundation f = GetRoadFoundation(tileh, GetAllRoadBits(tile));
-		z += ApplyPixelFoundationToSlope(f, &tileh);
+		z += ApplyPixelFoundationToSlope(f, tileh);
 		return z + GetPartialPixelZ(x & 0xF, y & 0xF, tileh);
 	} else {
 		return GetTileMaxPixelZ(tile);
@@ -2345,8 +2345,8 @@ static CommandCost TerraformTile_Road(TileIndex tile, DoCommandFlag flags, int z
 						auto [tileh_old, z_old] = GetTileSlopeZ(tile);
 
 						/* Get the slope on top of the foundation */
-						z_old += ApplyFoundationToSlope(GetRoadFoundation(tileh_old, bits), &tileh_old);
-						z_new += ApplyFoundationToSlope(GetRoadFoundation(tileh_new, bits), &tileh_new);
+						z_old += ApplyFoundationToSlope(GetRoadFoundation(tileh_old, bits), tileh_old);
+						z_new += ApplyFoundationToSlope(GetRoadFoundation(tileh_new, bits), tileh_new);
 
 						/* The surface slope must not be changed */
 						if ((z_old == z_new) && (tileh_old == tileh_new)) return CommandCost(EXPENSES_CONSTRUCTION, _price[PR_BUILD_FOUNDATION]);

--- a/src/script/api/script_tile.cpp
+++ b/src/script/api/script_tile.cpp
@@ -199,8 +199,7 @@
 {
 	if (!::IsValidTile(tile) || !::IsValidCorner((::Corner)corner)) return -1;
 
-	int z;
-	::Slope slope = ::GetTileSlope(tile, &z);
+	auto [slope, z] = ::GetTileSlopeZ(tile);
 	return (z + ::GetSlopeZInCorner(slope, (::Corner)corner));
 }
 

--- a/src/script/api/script_tunnel.cpp
+++ b/src/script/api/script_tunnel.cpp
@@ -31,8 +31,7 @@
 	/* If it's a tunnel already, take the easy way out! */
 	if (IsTunnelTile(tile)) return ::GetOtherTunnelEnd(tile);
 
-	int start_z;
-	Slope start_tileh = ::GetTileSlope(tile, &start_z);
+	auto [start_tileh, start_z] = ::GetTileSlopeZ(tile);
 	DiagDirection direction = ::GetInclinedSlopeDirection(start_tileh);
 	if (direction == INVALID_DIAGDIR) return INVALID_TILE;
 
@@ -42,7 +41,7 @@
 		tile += delta;
 		if (!::IsValidTile(tile)) return INVALID_TILE;
 
-		::GetTileSlope(tile, &end_z);
+		std::tie(std::ignore, end_z) = ::GetTileSlopeZ(tile);
 	} while (start_z != end_z);
 
 	return tile;

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3087,7 +3087,7 @@ static void DrawTile_Station(TileInfo *ti)
 			}
 
 			OffsetGroundSprite(0, -8);
-			ti->z += ApplyPixelFoundationToSlope(FOUNDATION_LEVELED, &ti->tileh);
+			ti->z += ApplyPixelFoundationToSlope(FOUNDATION_LEVELED, ti->tileh);
 		} else {
 draw_default_foundation:
 			DrawFoundation(ti, FOUNDATION_LEVELED);

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -805,8 +805,7 @@ CommandCost CheckBuildableTile(TileIndex tile, uint invalid_dirs, int &allowed_z
 	CommandCost ret = EnsureNoVehicleOnGround(tile);
 	if (ret.Failed()) return ret;
 
-	int z;
-	Slope tileh = GetTileSlope(tile, &z);
+	auto [tileh, z] = GetTileSlopeZ(tile);
 
 	/* Prohibit building if
 	 *   1) The tile is "steep" (i.e. stretches two height levels).
@@ -3031,8 +3030,7 @@ static void DrawTile_Station(TileInfo *ti)
 			/* Station has custom foundations.
 			 * Check whether the foundation continues beyond the tile's upper sides. */
 			uint edge_info = 0;
-			int z;
-			Slope slope = GetFoundationPixelSlope(ti->tile, &z);
+			auto [slope, z] = GetFoundationPixelSlope(ti->tile);
 			if (!HasFoundationNW(ti->tile, slope, z)) SetBit(edge_info, 0);
 			if (!HasFoundationNE(ti->tile, slope, z)) SetBit(edge_info, 1);
 			SpriteID image = GetCustomStationFoundationRelocation(statspec, st, ti->tile, tile_layout, edge_info);

--- a/src/tile_map.cpp
+++ b/src/tile_map.cpp
@@ -18,10 +18,9 @@
  * @param hwest  The height at the western corner in the same unit as TileHeight.
  * @param heast  The height at the eastern corner in the same unit as TileHeight.
  * @param hsouth The height at the southern corner in the same unit as TileHeight.
- * @param[out] h The lowest height of the four corners.
- * @return The slope.
+ * @return The slope and the lowest height of the four corners.
  */
-static Slope GetTileSlopeGivenHeight(int hnorth, int hwest, int heast, int hsouth, int *h)
+static std::tuple<Slope, int> GetTileSlopeGivenHeight(int hnorth, int hwest, int heast, int hsouth)
 {
 	/* Due to the fact that tiles must connect with each other without leaving gaps, the
 	 * biggest difference in height between any corner and 'min' is between 0, 1, or 2.
@@ -31,8 +30,6 @@ static Slope GetTileSlopeGivenHeight(int hnorth, int hwest, int heast, int hsout
 	int hminnw = std::min(hnorth, hwest);
 	int hmines = std::min(heast, hsouth);
 	int hmin = std::min(hminnw, hmines);
-
-	if (h != nullptr) *h = hmin;
 
 	int hmaxnw = std::max(hnorth, hwest);
 	int hmaxes = std::max(heast, hsouth);
@@ -47,16 +44,15 @@ static Slope GetTileSlopeGivenHeight(int hnorth, int hwest, int heast, int hsout
 
 	if (hmax - hmin == 2) r |= SLOPE_STEEP;
 
-	return r;
+	return {r, hmin};
 }
 
 /**
  * Return the slope of a given tile inside the map.
  * @param tile Tile to compute slope of
- * @param h    If not \c nullptr, pointer to storage of z height
- * @return Slope of the tile, except for the HALFTILE part
+ * @return Slope of the tile, except for the HALFTILE part, and the z height
  */
-Slope GetTileSlope(TileIndex tile, int *h)
+std::tuple<Slope, int> GetTileSlopeZ(TileIndex tile)
 {
 	uint x1 = TileX(tile);
 	uint y1 = TileY(tile);
@@ -68,7 +64,7 @@ Slope GetTileSlope(TileIndex tile, int *h)
 	int heast  = TileHeight(TileXY(x1, y2)); // Height of the East corner.
 	int hsouth = TileHeight(TileXY(x2, y2)); // Height of the South corner.
 
-	return GetTileSlopeGivenHeight(hnorth, hwest, heast, hsouth, h);
+	return GetTileSlopeGivenHeight(hnorth, hwest, heast, hsouth);
 }
 
 /**
@@ -77,18 +73,17 @@ Slope GetTileSlope(TileIndex tile, int *h)
  * @param x X coordinate of the tile to compute slope of, may be outside the map.
  * @param y Y coordinate of the tile to compute slope of, may be outside the map.
  * @param h If not \c nullptr, pointer to storage of z height.
- * @return Slope of the tile, except for the HALFTILE part.
+ * @return Slope of the tile, except for the HALFTILE part, and the z height of the tile.
  */
-Slope GetTilePixelSlopeOutsideMap(int x, int y, int *h)
+std::tuple<Slope, int> GetTilePixelSlopeOutsideMap(int x, int y)
 {
 	int hnorth = TileHeightOutsideMap(x,     y);     // N corner.
 	int hwest  = TileHeightOutsideMap(x + 1, y);     // W corner.
 	int heast  = TileHeightOutsideMap(x,     y + 1); // E corner.
 	int hsouth = TileHeightOutsideMap(x + 1, y + 1); // S corner.
 
-	Slope s = GetTileSlopeGivenHeight(hnorth, hwest, heast, hsouth, h);
-	if (h != nullptr) *h *= TILE_HEIGHT;
-	return s;
+	auto [slope, h] = GetTileSlopeGivenHeight(hnorth, hwest, heast, hsouth);
+	return {slope, h * TILE_HEIGHT};
 }
 
 /**

--- a/src/tile_map.h
+++ b/src/tile_map.h
@@ -265,26 +265,34 @@ inline void SetAnimationFrame(Tile t, byte frame)
 	t.m7() = frame;
 }
 
-Slope GetTileSlope(TileIndex tile, int *h = nullptr);
+std::tuple<Slope, int> GetTileSlopeZ(TileIndex tile);
 int GetTileZ(TileIndex tile);
 int GetTileMaxZ(TileIndex tile);
 
 bool IsTileFlat(TileIndex tile, int *h = nullptr);
 
 /**
- * Return the slope of a given tile
+ * Return the slope of a given tile inside the map.
  * @param tile Tile to compute slope of
- * @param h    If not \c nullptr, pointer to storage of z height
  * @return Slope of the tile, except for the HALFTILE part
  */
-inline Slope GetTilePixelSlope(TileIndex tile, int *h)
+inline Slope GetTileSlope(TileIndex tile)
 {
-	Slope s = GetTileSlope(tile, h);
-	if (h != nullptr) *h *= TILE_HEIGHT;
-	return s;
+	return std::get<0>(GetTileSlopeZ(tile));
 }
 
-Slope GetTilePixelSlopeOutsideMap(int x, int y, int *h);
+/**
+ * Return the slope of a given tile
+ * @param tile Tile to compute slope of
+ * @return Slope of the tile, except for the HALFTILE part, and the z height.
+ */
+inline std::tuple<Slope, int> GetTilePixelSlope(TileIndex tile)
+{
+	auto [s, h] = GetTileSlopeZ(tile);
+	return {s, h * TILE_HEIGHT};
+}
+
+std::tuple<Slope, int> GetTilePixelSlopeOutsideMap(int x, int y);
 
 /**
  * Get bottom height of the tile

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1003,7 +1003,7 @@ static bool IsRoadAllowedHere(Town *t, TileIndex tile, DiagDirection dir)
 		}
 	}
 
-	Slope cur_slope = _settings_game.construction.build_on_slopes ? GetFoundationSlope(tile) : GetTileSlope(tile);
+	Slope cur_slope = _settings_game.construction.build_on_slopes ? std::get<0>(GetFoundationSlope(tile)) : GetTileSlope(tile);
 	bool ret = !IsNeighborRoadTile(tile, dir, t->layout == TL_ORIGINAL ? 1 : 2);
 	if (cur_slope == SLOPE_FLAT) return ret;
 

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -588,8 +588,7 @@ static void DrawTile_Trees(TileInfo *ti)
 
 static int GetSlopePixelZ_Trees(TileIndex tile, uint x, uint y, bool)
 {
-	int z;
-	Slope tileh = GetTilePixelSlope(tile, &z);
+	auto [tileh, z] = GetTilePixelSlope(tile);
 
 	return z + GetPartialPixelZ(x & 0xF, y & 0xF, tileh);
 }

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -324,10 +324,8 @@ CommandCost CmdBuildBridge(DoCommandFlag flags, TileIndex tile_end, TileIndex ti
 	}
 	bridge_len += 2; // begin and end tiles/ramps
 
-	int z_start;
-	int z_end;
-	Slope tileh_start = GetTileSlope(tile_start, &z_start);
-	Slope tileh_end = GetTileSlope(tile_end, &z_end);
+	auto [tileh_start, z_start] = GetTileSlopeZ(tile_start);
+	auto [tileh_end, z_end] = GetTileSlopeZ(tile_end);
 	bool pbs_reservation = false;
 
 	CommandCost terraform_cost_north = CheckBridgeSlope(BRIDGE_PIECE_NORTH, direction, &tileh_start, &z_start);
@@ -655,9 +653,7 @@ CommandCost CmdBuildTunnel(DoCommandFlag flags, TileIndex start_tile, TransportT
 		}
 	}
 
-	int start_z;
-	int end_z;
-	Slope start_tileh = GetTileSlope(start_tile, &start_z);
+	auto [start_tileh, start_z] = GetTileSlopeZ(start_tile);
 	DiagDirection direction = GetInclinedSlopeDirection(start_tileh);
 	if (direction == INVALID_DIAGDIR) return_cmd_error(STR_ERROR_SITE_UNSUITABLE_FOR_TUNNEL);
 
@@ -690,10 +686,11 @@ CommandCost CmdBuildTunnel(DoCommandFlag flags, TileIndex start_tile, TransportT
 
 	CommandCost cost(EXPENSES_CONSTRUCTION);
 	Slope end_tileh;
+	int end_z;
 	for (;;) {
 		end_tile += delta;
 		if (!IsValidTile(end_tile)) return_cmd_error(STR_ERROR_TUNNEL_THROUGH_MAP_BORDER);
-		end_tileh = GetTileSlope(end_tile, &end_z);
+		std::tie(end_tileh, end_z) = GetTileSlopeZ(end_tile);
 
 		if (start_z == end_z) break;
 
@@ -1666,8 +1663,7 @@ void DrawBridgeMiddle(const TileInfo *ti)
 
 static int GetSlopePixelZ_TunnelBridge(TileIndex tile, uint x, uint y, bool ground_vehicle)
 {
-	int z;
-	Slope tileh = GetTilePixelSlope(tile, &z);
+	auto [tileh, z] = GetTilePixelSlope(tile);
 
 	x &= 0xF;
 	y &= 0xF;
@@ -2042,8 +2038,7 @@ static CommandCost TerraformTile_TunnelBridge(TileIndex tile, DoCommandFlag flag
 		DiagDirection direction = GetTunnelBridgeDirection(tile);
 		Axis axis = DiagDirToAxis(direction);
 		CommandCost res;
-		int z_old;
-		Slope tileh_old = GetTileSlope(tile, &z_old);
+		auto [tileh_old, z_old] = GetTileSlopeZ(tile);
 
 		/* Check if new slope is valid for bridges in general (so we can safely call GetBridgeFoundation()) */
 		if ((direction == DIAGDIR_NW) || (direction == DIAGDIR_NE)) {

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1242,10 +1242,10 @@ static void ViewportAddLandscape()
 
 			if (tile_type != MP_VOID) {
 				/* We are inside the map => paint landscape. */
-				_cur_ti.tileh = GetTilePixelSlope(_cur_ti.tile, &_cur_ti.z);
+				std::tie(_cur_ti.tileh, _cur_ti.z) = GetTilePixelSlope(_cur_ti.tile);
 			} else {
 				/* We are outside the map => paint black. */
-				_cur_ti.tileh = GetTilePixelSlopeOutsideMap(tilecoord.x, tilecoord.y, &_cur_ti.z);
+				std::tie(_cur_ti.tileh, _cur_ti.z) = GetTilePixelSlopeOutsideMap(tilecoord.x, tilecoord.y);
 			}
 
 			int viewport_y = GetViewportY(tilecoord);

--- a/src/void_cmd.cpp
+++ b/src/void_cmd.cpp
@@ -29,8 +29,7 @@ static int GetSlopePixelZ_Void(TileIndex, uint x, uint y, bool)
 {
 	/* This function may be called on tiles outside the map, don't assume
 	 * that 'tile' is a valid tile index. See GetSlopePixelZOutsideMap. */
-	int z;
-	Slope tileh = GetTilePixelSlopeOutsideMap(x >> 4, y >> 4, &z);
+	auto [tileh, z] = GetTilePixelSlopeOutsideMap(x >> 4, y >> 4);
 
 	return z + GetPartialPixelZ(x & 0xF, y & 0xF, tileh);
 }

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -210,8 +210,7 @@ void MakeWaterKeepingClass(TileIndex tile, Owner o)
 	WaterClass wc = GetWaterClass(tile);
 
 	/* Autoslope might turn an originally canal or river tile into land */
-	int z;
-	Slope slope = GetTileSlope(tile, &z);
+	auto [slope, z] = GetTileSlopeZ(tile);
 
 	if (slope != SLOPE_FLAT) {
 		if (wc == WATER_CLASS_CANAL) {
@@ -951,8 +950,7 @@ void DrawShipDepotSprite(int x, int y, Axis axis, DepotPart part)
 
 static int GetSlopePixelZ_Water(TileIndex tile, uint x, uint y, bool)
 {
-	int z;
-	Slope tileh = GetTilePixelSlope(tile, &z);
+	auto [tileh, z] = GetTilePixelSlope(tile);
 
 	return z + GetPartialPixelZ(x & 0xF, y & 0xF, tileh);
 }
@@ -1245,18 +1243,17 @@ void TileLoop_Water(TileIndex tile)
 				/* TREE_GROUND_SHORE is the sign of a previous flood. */
 				if (IsTileType(dest, MP_TREES) && GetTreeGround(dest) == TREE_GROUND_SHORE) continue;
 
-				int z_dest;
-				Slope slope_dest = GetFoundationSlope(dest, &z_dest) & ~SLOPE_HALFTILE_MASK & ~SLOPE_STEEP;
+				auto [slope_dest, z_dest] = GetFoundationSlope(dest);
 				if (z_dest > 0) continue;
 
-				if (!HasBit(_flood_from_dirs[slope_dest], ReverseDir(dir))) continue;
+				if (!HasBit(_flood_from_dirs[slope_dest & ~SLOPE_HALFTILE_MASK & ~SLOPE_STEEP], ReverseDir(dir))) continue;
 
 				DoFloodTile(dest);
 			}
 			break;
 
 		case FLOOD_DRYUP: {
-			Slope slope_here = GetFoundationSlope(tile) & ~SLOPE_HALFTILE_MASK & ~SLOPE_STEEP;
+			Slope slope_here = std::get<0>(GetFoundationSlope(tile)) & ~SLOPE_HALFTILE_MASK & ~SLOPE_STEEP;
 			for (uint dir : SetBitIterator(_flood_from_dirs[slope_here])) {
 				TileIndex dest = tile + TileOffsByDir((Direction)dir);
 				if (dest >= Map::Size()) continue;
@@ -1274,10 +1271,8 @@ void TileLoop_Water(TileIndex tile)
 
 void ConvertGroundTilesIntoWaterTiles()
 {
-	int z;
-
 	for (TileIndex tile = 0; tile < Map::Size(); ++tile) {
-		Slope slope = GetTileSlope(tile, &z);
+		auto [slope, z] = GetTileSlopeZ(tile);
 		if (IsTileType(tile, MP_CLEAR) && z == 0) {
 			/* Make both water for tiles at level 0
 			 * and make shore, as that looks much better


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Multiple foundation/slope functions use pointer parameters for either non-optional values that are modified or to return a second value. Some functions are even confused in their docs if the argument is optional or not (e.g. `GetFoundationPixelSlope`).

## Description

Change secondary return values to use `std::tuple`. While the intention might have been to only calculate this secondary value if the caller wants it, all functions changed here calculate the value unconditionally anyway.

Functions with non-optional modified parameters are changed to use references to clearly indicate that the parameter is required.

## Limitations

References are not directly visible at the call site and thus it is not always obvious that the argument might be modified. Whether this is considered better or worse than passing invalid pointers is debatable.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
