### PR TITLE
Fix #12236: Ship pathfinder causes crash when ship is already at destination

### DIFF
--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -263,7 +263,10 @@ public:
 				}
 				node = node->m_parent;
 			}
-			assert(!path_cache.empty());
+
+			/* A empty path means we are already at the destination. The pathfinder shouldn't have been called at all.
+			 * Return a random reachable trackdir to hopefully nudge the ship out of this strange situation. */
+			if (path_cache.empty()) return GetRandomFollowUpTrackdir(v, src_tile, trackdir, true);
 
 			/* Take out the last trackdir as the result. */
 			const Trackdir result = path_cache.front();


### PR DESCRIPTION
## Motivation / Problem

Fixes #12236

## Description

A call to chooseShipTrack is pointless when already at the destination, but it can happen in certain edge cases. Whether these situations should occur in the first place is debatable, and #11862 is an example of such a situation. However, the PF should be able to deal with such strange requests. It certainly shouldn't crash.

I opted for just returning a single random trackdir that can be reached, or INVALID_DIR otherwise, which in turn causes the ship to turn around. This should hopefully get nudge the ship out of the current situation and find a correct path ont he next PF call.

I also decided to not report the ship as lost (by not setting path_found = false), since the destination is technically found and the ship is not really lost. It's a strange situation so the solution is maybe a little strange as well.

## Limitations

While this will make the PF more robust, the issue causing these situations is not fixed.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
