### PR TITLE
Codefix: Fully initialise `MidiFile::DataBlock` to avoid gcc warning.

### DIFF
--- a/src/music/midifile.hpp
+++ b/src/music/midifile.hpp
@@ -17,8 +17,8 @@ struct MusicSongInfo;
 
 struct MidiFile {
 	struct DataBlock {
-		uint32_t ticktime;        ///< tick number since start of file this block should be triggered at
-		uint32_t realtime;        ///< real-time (microseconds) since start of file this block should be triggered at
+		uint32_t ticktime; ///< tick number since start of file this block should be triggered at
+		uint32_t realtime = 0; ///< real-time (microseconds) since start of file this block should be triggered at
 		std::vector<byte> data; ///< raw midi data contained in block
 		DataBlock(uint32_t _ticktime = 0) : ticktime(_ticktime) { }
 	};


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

For me, compiling with GCC 12.0 gives a warning in `midifile.hpp` due to possible uninitialised access of `DataBlock::realtime`. From a quick look at how `realtime` is used this isn't actually correct, but it does not hurt to explicitly initialise the member.

```
In file included from /home/petern/src/openttd/src/music/midifile.cpp:10:
In constructor ‘constexpr MidiFile::DataBlock::DataBlock(MidiFile::DataBlock&&)’,
    inlined from ‘constexpr decltype (::new(void*(0)) _Tp) std::construct_at(_Tp*, _Args&& ...) [with _Tp = MidiFile::DataBlock; _Args = {MidiFile::DataBlock}]’ at /usr/include/c++/12/bits/stl_construct.h:97:14,
    inlined from ‘static constexpr void std::allocator_traits<std::allocator<_Up> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = MidiFile::DataBlock; _Args = {MidiFile::DataBlock}; _Tp = MidiFile::DataBlock]’ at /usr/include/c++/12/bits/alloc_traits.h:518:21,
    inlined from ‘constexpr std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::emplace_back(_Args&& ...) [with _Args = {MidiFile::DataBlock}; _Tp = MidiFile::DataBlock; _Alloc = std::allocator<MidiFile::DataBlock>]’ at /usr/include/c++/12/bits/vector.tcc:117:30,
    inlined from ‘constexpr void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = MidiFile::DataBlock; _Alloc = std::allocator<MidiFile::DataBlock>]’ at /usr/include/c++/12/bits/stl_vector.h:1294:21,
    inlined from ‘bool MpsMachine::PlayInto()’ at /home/petern/src/openttd/src/music/midifile.cpp:794:32:
/home/petern/src/openttd/src/music/midifile.hpp:19:16: warning: ‘<unnamed>.MidiFile::DataBlock::realtime’ may be used uninitialized [-Wmaybe-uninitialized]
   19 |         struct DataBlock {
      |                ^~~~~~~~~
/home/petern/src/openttd/src/music/midifile.cpp: In member function ‘bool MpsMachine::PlayInto()’:
/home/petern/src/openttd/src/music/midifile.cpp:794:67: note: ‘<anonymous>’ declared here
  794 |                 this->target.blocks.push_back(MidiFile::DataBlock());
      |                                                                   ^
```

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Explicitly initialise `realtime` to `0` in `DataBlock`'s constructor to silence this warning.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
