### PR TITLE
Codechange: [CI] use "cargo install --locked" to use pinned dependency versions

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -124,7 +124,7 @@ jobs:
         )
 
         echo "::group::Install breakpad dependencies"
-        cargo install dump_syms
+        cargo install --locked dump_syms
         echo "::endgroup::"
 
     - name: Install GCC problem matcher

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -52,7 +52,7 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Install breakpad dependencies"
-        cargo install dump_syms
+        cargo install --locked dump_syms
         echo "::endgroup::"
 
     - name: Install GCC problem matcher

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -61,7 +61,7 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Install breakpad dependencies"
-        cargo install dump_syms
+        cargo install --locked dump_syms
         echo "::endgroup::"
 
     - name: Install MSVC problem matcher

--- a/docs/symbol_server.md
+++ b/docs/symbol_server.md
@@ -19,7 +19,7 @@ Now simply open up the `crash.dmp`, and start debugging.
 The best tool to use is `minidump-stackwalk` as published in the Rust's cargo index:
 
 ```bash
-cargo install minidump-stackwalk
+cargo install --locked minidump-stackwalk
 ```
 
 For how to install Rust, please see [here](https://doc.rust-lang.org/cargo/getting-started/installation.html).


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

"cargo install dump_syms" fails to compile, causing release build failures if dump_syms is no longer available in our local cache.

## Description

Normally "cargo install" will use the latest dependencies, but this causes an issue with "dump_syms". Use "--locked" makes sure we use the dependency versions as indicated by "dump_syms", instead of the latest version.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
