### PR TITLE
Revert #11606: Don't auto-build past tunnelbridge ends

### DIFF
--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -886,32 +886,22 @@ static CommandCost CmdRailTrackHelper(DoCommandFlag flags, TileIndex tile, TileI
 	if (ret.Failed()) return ret;
 
 	bool had_success = false;
-	bool under_tunnelbridge = false;
 	CommandCost last_error = CMD_ERROR;
 	for (;;) {
-		/* Don't try to place rail between tunnelbridge ends */
-		if (IsTileType(tile, MP_TUNNELBRIDGE)) {
-			under_tunnelbridge = !under_tunnelbridge;
-		} else if (!under_tunnelbridge) {
-			if (remove) {
-				ret = Command<CMD_REMOVE_SINGLE_RAIL>::Do(flags, tile, TrackdirToTrack(trackdir));
-			} else {
-				ret = Command<CMD_BUILD_SINGLE_RAIL>::Do(flags, tile, railtype, TrackdirToTrack(trackdir), auto_remove_signals);
+		ret = remove ? Command<CMD_REMOVE_SINGLE_RAIL>::Do(flags, tile, TrackdirToTrack(trackdir)) : Command<CMD_BUILD_SINGLE_RAIL>::Do(flags, tile, railtype, TrackdirToTrack(trackdir), auto_remove_signals);
+
+		if (ret.Failed()) {
+			last_error = ret;
+			if (last_error.GetErrorMessage() != STR_ERROR_ALREADY_BUILT && !remove) {
+				if (fail_on_obstacle) return last_error;
+				if (had_success) break; // Keep going if we haven't constructed any rail yet, skipping the start of the drag
 			}
 
-			if (ret.Failed()) {
-				last_error = ret;
-				if (last_error.GetErrorMessage() != STR_ERROR_ALREADY_BUILT && !remove) {
-					if (fail_on_obstacle) return last_error;
-					if (had_success) break; // Keep going if we haven't constructed any rail yet, skipping the start of the drag
-				}
-
-				/* Ownership errors are more important. */
-				if (last_error.GetErrorMessage() == STR_ERROR_OWNED_BY && remove) break;
-			} else {
-				had_success = true;
-				total_cost.AddCost(ret);
-			}
+			/* Ownership errors are more important. */
+			if (last_error.GetErrorMessage() == STR_ERROR_OWNED_BY && remove) break;
+		} else {
+			had_success = true;
+			total_cost.AddCost(ret);
 		}
 
 		if (tile == end_tile) break;

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1007,55 +1007,49 @@ CommandCost CmdBuildLongRoad(DoCommandFlag flags, TileIndex end_tile, TileIndex 
 	bool had_bridge = false;
 	bool had_tunnel = false;
 	bool had_success = false;
-	bool under_tunnelbridge = false;
 
 	/* Start tile is the first tile clicked by the user. */
 	for (;;) {
-		/* Don't try to place road between tunnelbridge ends */
-		if (IsTileType(tile, MP_TUNNELBRIDGE)) {
-			under_tunnelbridge = !under_tunnelbridge;
-		} else if (!under_tunnelbridge) {
-			RoadBits bits = AxisToRoadBits(axis);
+		RoadBits bits = AxisToRoadBits(axis);
 
-			/* Determine which road parts should be built. */
-			if (!is_ai && start_tile != end_tile) {
-				/* Only build the first and last roadbit if they can connect to something. */
-				if (tile == end_tile && !CanConnectToRoad(tile, rt, dir)) {
-					bits = DiagDirToRoadBits(ReverseDiagDir(dir));
-				} else if (tile == start_tile && !CanConnectToRoad(tile, rt, ReverseDiagDir(dir))) {
-					bits = DiagDirToRoadBits(dir);
-				}
-			} else {
-				/* Road parts only have to be built at the start tile or at the end tile. */
-				if (tile == end_tile && !end_half) bits &= DiagDirToRoadBits(ReverseDiagDir(dir));
-				if (tile == start_tile && start_half) bits &= DiagDirToRoadBits(dir);
+		/* Determine which road parts should be built. */
+		if (!is_ai && start_tile != end_tile) {
+			/* Only build the first and last roadbit if they can connect to something. */
+			if (tile == end_tile && !CanConnectToRoad(tile, rt, dir)) {
+				bits = DiagDirToRoadBits(ReverseDiagDir(dir));
+			} else if (tile == start_tile && !CanConnectToRoad(tile, rt, ReverseDiagDir(dir))) {
+				bits = DiagDirToRoadBits(dir);
 			}
+		} else {
+			/* Road parts only have to be built at the start tile or at the end tile. */
+			if (tile == end_tile && !end_half) bits &= DiagDirToRoadBits(ReverseDiagDir(dir));
+			if (tile == start_tile && start_half) bits &= DiagDirToRoadBits(dir);
+		}
 
-			CommandCost ret = Command<CMD_BUILD_ROAD>::Do(flags, tile, bits, rt, drd, 0);
-			if (ret.Failed()) {
-				last_error = ret;
-				if (last_error.GetErrorMessage() != STR_ERROR_ALREADY_BUILT) {
-					if (is_ai) return last_error;
-					if (had_success) break; // Keep going if we haven't constructed any road yet, skipping the start of the drag
+		CommandCost ret = Command<CMD_BUILD_ROAD>::Do(flags, tile, bits, rt, drd, 0);
+		if (ret.Failed()) {
+			last_error = ret;
+			if (last_error.GetErrorMessage() != STR_ERROR_ALREADY_BUILT) {
+				if (is_ai) return last_error;
+				if (had_success) break; // Keep going if we haven't constructed any road yet, skipping the start of the drag
+			}
+		} else {
+			had_success = true;
+			/* Only pay for the upgrade on one side of the bridges and tunnels */
+			if (IsTileType(tile, MP_TUNNELBRIDGE)) {
+				if (IsBridge(tile)) {
+					if (!had_bridge || GetTunnelBridgeDirection(tile) == dir) {
+						cost.AddCost(ret);
+					}
+					had_bridge = true;
+				} else { // IsTunnel(tile)
+					if (!had_tunnel || GetTunnelBridgeDirection(tile) == dir) {
+						cost.AddCost(ret);
+					}
+					had_tunnel = true;
 				}
 			} else {
-				had_success = true;
-				/* Only pay for the upgrade on one side of the bridges and tunnels */
-				if (IsTileType(tile, MP_TUNNELBRIDGE)) {
-					if (IsBridge(tile)) {
-						if (!had_bridge || GetTunnelBridgeDirection(tile) == dir) {
-							cost.AddCost(ret);
-						}
-						had_bridge = true;
-					} else { // IsTunnel(tile)
-						if (!had_tunnel || GetTunnelBridgeDirection(tile) == dir) {
-							cost.AddCost(ret);
-						}
-						had_tunnel = true;
-					}
-				} else {
-					cost.AddCost(ret);
-				}
+				cost.AddCost(ret);
 			}
 		}
 


### PR DESCRIPTION
## Motivation / Problem

Fixes #12102.

Not being to add road/tram onto an existing bridge is definitely a regression. It misbehaving when there are tunnel-/bridgeheads under/above bridge/tunnel does not help.

The functionality improvement on the sticker of #11606 is definitely a nice one, but nobody has fixed the issue and the actual release is near, so just reverting it seems the easiest step to resolve this regression for now.


## Description

Reverts OpenTTD/OpenTTD#11606.


## Limitations

I made this using the revert functionality of Github, so I hope it's pass all the (commit) checker gates.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
