### PR TITLE
Codechange: use std::source_location over __FILE__ and __LINE__ for Random

### DIFF
--- a/src/core/random_func.cpp
+++ b/src/core/random_func.cpp
@@ -50,17 +50,6 @@ uint32_t Randomizer::Next()
 }
 
 /**
- * Generate the next pseudo random number scaled to \a limit, excluding \a limit
- * itself.
- * @param limit Limit of the range to be generated from.
- * @return Random number in [0,\a limit)
- */
-uint32_t Randomizer::Next(uint32_t limit)
-{
-	return ((uint64_t)this->Next() * (uint64_t)limit) >> 32;
-}
-
-/**
  * (Re)set the state of the random number generator.
  * @param seed the new state
  */
@@ -81,18 +70,13 @@ void SetRandomSeed(uint32_t seed)
 }
 
 #ifdef RANDOM_DEBUG
-uint32_t DoRandom(int line, const char *file)
+uint32_t Random(const std::source_location location)
 {
 	if (_networking && (!_network_server || (NetworkClientSocket::IsValidID(0) && NetworkClientSocket::Get(0)->status != NetworkClientSocket::STATUS_INACTIVE))) {
-		Debug(random, 0, "{:08x}; {:02x}; {:04x}; {:02x}; {}:{}", TimerGameEconomy::date, TimerGameEconomy::date_fract, _frame_counter, (byte)_current_company, file, line);
+		Debug(random, 0, "{:08x}; {:02x}; {:04x}; {:02x}; {}:{}", TimerGameEconomy::date, TimerGameEconomy::date_fract, _frame_counter, (byte)_current_company, location.file_name(), location.line());
 	}
 
 	return _random.Next();
-}
-
-uint32_t DoRandomRange(uint32_t limit, int line, const char *file)
-{
-	return ((uint64_t)DoRandom(line, file) * (uint64_t)limit) >> 32;
 }
 #endif /* RANDOM_DEBUG */
 


### PR DESCRIPTION
## Motivation / Problem

The `#define` trickery, especially for MacOS with `OTTD_Random`, that is done to differentiate between normal code and random debugging.


## Description

Add `std::source_location` to `Random`, even when it's not used for non-random debug. Due to the inlining the compiler ought to optimise it out, even with minimal optimisation (-O1 or -Og).
Get rid of the macro's and `#ifdef`s, except for `Random` differentiating between a non-inlines complex version when using random debug and a  near trivial inlines version when not using random debug.
Move scaling to limit `Next(uint32_t limit)` to the header, so `RandomRange` can reuse that logic, so it doesn't need its own special function for with and without random debugging.


## Limitations

Deliberately adding `[[maybe_unused]]` to a variable that will never be used in that context, just to have the same signature and simplifying all other accessors of the functionality.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
