### PR TITLE
Codechange: [CI] build some targets every night, instead of every PR

### DIFF
--- a/.dorpsgek.yml
+++ b/.dorpsgek.yml
@@ -17,3 +17,4 @@ notifications:
   workflow-run:
     only:
     - .github/workflows/release.yml
+    - .github/workflows/ci-nightly.yml

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI - Build
 
 on:
   pull_request:
@@ -38,10 +38,6 @@ jobs:
           compiler: gcc
           cxxcompiler: g++
           libraries: libsdl2-dev
-        - name: GCC - SDL1.2
-          compiler: gcc
-          cxxcompiler: g++
-          libraries: libsdl1.2-dev
         - name: GCC - Dedicated
           compiler: gcc
           cxxcompiler: g++
@@ -83,38 +79,17 @@ jobs:
       matrix:
         include:
         - os: windows-latest
-          name: Windows
           arch: x86
         - os: windows-latest
-          name: Windows
           arch: x64
 
-    name: ${{ matrix.name }} (${{ matrix.arch }})
+    name: Windows (${{ matrix.arch }})
 
     uses: ./.github/workflows/ci-windows.yml
     secrets: inherit
 
     with:
       os: ${{ matrix.os }}
-      arch: ${{ matrix.arch }}
-
-  mingw:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - msystem: MINGW64
-            arch: x86_64
-          - msystem: MINGW32
-            arch: i686
-
-    name: MinGW (${{ matrix.arch }})
-
-    uses: ./.github/workflows/ci-mingw.yml
-    secrets: inherit
-
-    with:
-      msystem: ${{ matrix.msystem }}
       arch: ${{ matrix.arch }}
 
   check_annotations:
@@ -124,7 +99,6 @@ jobs:
     - linux
     - macos
     - windows
-    - mingw
 
     if: always() && github.event_name == 'pull_request'
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,56 +17,8 @@ jobs:
   emscripten:
     name: Emscripten
 
-    runs-on: ubuntu-20.04
-    container:
-      # If you change this version, change the number in the cache step too.
-      image: emscripten/emsdk:3.1.42
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Setup cache
-      uses: actions/cache@v4
-      with:
-        path: /emsdk/upstream/emscripten/cache
-        key: 3.1.42-${{ runner.os }}
-
-    - name: Patch Emscripten to support LZMA
-      run: |
-        cd /emsdk/upstream/emscripten
-        patch -p1 < ${GITHUB_WORKSPACE}/os/emscripten/emsdk-liblzma.patch
-
-    - name: Build (host tools)
-      run: |
-        mkdir build-host
-        cd build-host
-
-        echo "::group::CMake"
-        cmake .. -DOPTION_TOOLS_ONLY=ON
-        echo "::endgroup::"
-
-        echo "::group::Build"
-        echo "Running on $(nproc) cores"
-        cmake --build . -j $(nproc) --target tools
-        echo "::endgroup::"
-
-    - name: Install GCC problem matcher
-      uses: ammaraskar/gcc-problem-matcher@master
-
-    - name: Build
-      run: |
-        mkdir build
-        cd build
-
-        echo "::group::CMake"
-        emcmake cmake .. -DHOST_BINARY_DIR=../build-host
-        echo "::endgroup::"
-
-        echo "::group::Build"
-        echo "Running on $(nproc) cores"
-        cmake --build . -j $(nproc) --target openttd
-        echo "::endgroup::"
+    uses: ./.github/workflows/ci-emscripten.yml
+    secrets: inherit
 
   linux:
     strategy:
@@ -99,104 +51,14 @@ jobs:
 
     name: Linux (${{ matrix.name }})
 
-    runs-on: ubuntu-latest
-    env:
-      CC: ${{ matrix.compiler }}
-      CXX: ${{ matrix.cxxcompiler }}
+    uses: ./.github/workflows/ci-linux.yml
+    secrets: inherit
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Setup vcpkg caching
-      uses: actions/github-script@v7
-      with:
-        script: |
-          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-          core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite')
-
-    - name: Install vcpkg
-      run: |
-        git clone https://github.com/microsoft/vcpkg
-        ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
-
-    - name: Install dependencies
-      run: |
-        echo "::group::Update apt"
-        sudo apt-get update
-        echo "::endgroup::"
-
-        echo "::group::Install dependencies"
-        sudo apt-get install -y --no-install-recommends \
-          liballegro4-dev \
-          libcurl4-openssl-dev \
-          libfontconfig-dev \
-          libharfbuzz-dev \
-          libicu-dev \
-          liblzma-dev \
-          liblzo2-dev \
-          ${{ matrix.libraries }} \
-          zlib1g-dev \
-          # EOF
-
-        echo "::group::Install vcpkg dependencies"
-
-        # Disable vcpkg integration, as we mostly use system libraries.
-        mv vcpkg.json vcpkg-disabled.json
-
-        # We only use breakpad from vcpkg, as its CMake files
-        # are a bit special. So the Ubuntu's variant doesn't work.
-        ./vcpkg/vcpkg install breakpad
-
-        echo "::endgroup::"
-      env:
-        DEBIAN_FRONTEND: noninteractive
-
-    - name: Get OpenGFX
-      run: |
-        mkdir -p ~/.local/share/openttd/baseset
-        cd ~/.local/share/openttd/baseset
-
-        echo "::group::Download OpenGFX"
-        curl -L https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip -o opengfx-all.zip
-        echo "::endgroup::"
-
-        echo "::group::Unpack OpenGFX"
-        unzip opengfx-all.zip
-        echo "::endgroup::"
-
-        rm -f opengfx-all.zip
-
-    - name: Install GCC problem matcher
-      uses: ammaraskar/gcc-problem-matcher@master
-
-    - name: Build
-      run: |
-        mkdir build
-        cd build
-
-        echo "::group::CMake"
-        cmake .. -DCMAKE_TOOLCHAIN_FILE=${GITHUB_WORKSPACE}/vcpkg/scripts/buildsystems/vcpkg.cmake ${{ matrix.extra-cmake-parameters }}
-        echo "::endgroup::"
-
-        echo "::group::Build"
-        echo "Running on $(nproc) cores"
-        cmake --build . -j $(nproc)
-        echo "::endgroup::"
-
-    - name: Test
-      run: |
-        (
-          cd build
-          ctest -j $(nproc) --timeout 120
-        )
-
-        # Re-enable vcpkg.
-        mv vcpkg-disabled.json vcpkg.json
-
-        # Check no tracked files have been modified.
-        git diff --exit-code
+    with:
+      compiler: ${{ matrix.compiler }}
+      cxxcompiler: ${{ matrix.cxxcompiler }}
+      libraries: ${{ matrix.libraries }}
+      extra-cmake-parameters: ${{ matrix.extra-cmake-parameters }}
 
   macos:
     strategy:
@@ -208,148 +70,35 @@ jobs:
 
     name: Mac OS (${{ matrix.arch }})
 
-    runs-on: macos-14
-    env:
-      MACOSX_DEPLOYMENT_TARGET: 10.13
+    uses: ./.github/workflows/ci-macos.yml
+    secrets: inherit
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Setup vcpkg caching
-      uses: actions/github-script@v7
-      with:
-        script: |
-          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-          core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite')
-
-    - name: Install vcpkg
-      run: |
-        git clone https://github.com/microsoft/vcpkg
-        ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
-
-    - name: Install OpenGFX
-      run: |
-        mkdir -p ~/Documents/OpenTTD/baseset
-        cd ~/Documents/OpenTTD/baseset
-
-        echo "::group::Download OpenGFX"
-        curl -L https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip -o opengfx-all.zip
-        echo "::endgroup::"
-
-        echo "::group::Unpack OpenGFX"
-        unzip opengfx-all.zip
-        echo "::endgroup::"
-
-        rm -f opengfx-all.zip
-
-    - name: Install GCC problem matcher
-      uses: ammaraskar/gcc-problem-matcher@master
-
-    - name: Build
-      run: |
-        mkdir build
-        cd build
-
-        echo "::group::CMake"
-        cmake .. \
-          -DCMAKE_OSX_ARCHITECTURES=${{ matrix.full_arch }} \
-          -DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-osx \
-          -DCMAKE_TOOLCHAIN_FILE=${GITHUB_WORKSPACE}/vcpkg/scripts/buildsystems/vcpkg.cmake \
-          # EOF
-        echo "::endgroup::"
-
-        echo "::group::Build"
-        echo "Running on $(sysctl -n hw.logicalcpu) cores"
-        cmake --build . -j $(sysctl -n hw.logicalcpu)
-        echo "::endgroup::"
-
-    - name: Test
-      run: |
-        cd build
-        ctest -j $(sysctl -n hw.logicalcpu) --timeout 120
+    with:
+      arch: ${{ matrix.arch }}
+      full_arch: ${{ matrix.full_arch }}
 
   windows:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest]
-        arch: [x86, x64]
+        include:
+        - os: windows-latest
+          name: Windows
+          arch: x86
+        - os: windows-latest
+          name: Windows
+          arch: x64
 
-    name: Windows (${{ matrix.os }} / ${{ matrix.arch }})
+    name: ${{ matrix.name }} (${{ matrix.arch }})
 
-    runs-on: ${{ matrix.os }}
+    uses: ./.github/workflows/ci-windows.yml
+    secrets: inherit
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+    with:
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
 
-    - name: Setup vcpkg caching
-      uses: actions/github-script@v7
-      with:
-        script: |
-          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-          core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite')
-
-    - name: Install vcpkg
-      run: |
-        git clone https://github.com/microsoft/vcpkg
-        .\vcpkg\bootstrap-vcpkg.bat -disableMetrics
-
-    - name: Install OpenGFX
-      shell: bash
-      run: |
-        mkdir -p "C:/Users/Public/Documents/OpenTTD/baseset"
-        cd "C:/Users/Public/Documents/OpenTTD/baseset"
-
-        echo "::group::Download OpenGFX"
-        curl -L https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip -o opengfx-all.zip
-        echo "::endgroup::"
-
-        echo "::group::Unpack OpenGFX"
-        unzip opengfx-all.zip
-        echo "::endgroup::"
-
-        rm -f opengfx-all.zip
-
-    - name: Install MSVC problem matcher
-      uses: ammaraskar/msvc-problem-matcher@master
-
-    - name: Configure developer command prompt for ${{ matrix.arch }}
-      uses: ilammy/msvc-dev-cmd@v1
-      with:
-        arch: ${{ matrix.arch }}
-
-    - name: Build
-      shell: bash
-      env:
-        NINJA_STATUS: "[%f/%t -- %e] " # [finished_edges/total_edges -- elapsed_time], default value is "[%f/%t] "
-      run: |
-        mkdir build
-        cd build
-
-        echo "::group::CMake"
-        cmake .. \
-          -GNinja \
-          -DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-windows-static \
-          -DCMAKE_TOOLCHAIN_FILE="${GITHUB_WORKSPACE}\vcpkg\scripts\buildsystems\vcpkg.cmake" \
-          # EOF
-        echo "::endgroup::"
-
-        echo "::group::Build"
-        cmake --build .
-        echo "::endgroup::"
-
-    - name: Test
-      shell: bash
-      run: |
-        cd build
-        ctest --timeout 120
-
-
-  msys2:
+  mingw:
     strategy:
       fail-fast: false
       matrix:
@@ -361,70 +110,12 @@ jobs:
 
     name: MinGW (${{ matrix.arch }})
 
-    runs-on: windows-latest
+    uses: ./.github/workflows/ci-mingw.yml
+    secrets: inherit
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Setup MSYS2
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: ${{ matrix.msystem }}
-        release: false
-        install: >-
-          git
-          make
-          mingw-w64-${{ matrix.arch }}-cmake
-          mingw-w64-${{ matrix.arch }}-gcc
-          mingw-w64-${{ matrix.arch }}-lzo2
-          mingw-w64-${{ matrix.arch }}-libpng
-          mingw-w64-${{ matrix.arch }}-lld
-          mingw-w64-${{ matrix.arch }}-ninja
-
-    - name: Install OpenGFX
-      shell: bash
-      run: |
-        mkdir -p "C:/Users/Public/Documents/OpenTTD/baseset"
-        cd "C:/Users/Public/Documents/OpenTTD/baseset"
-
-        echo "::group::Download OpenGFX"
-        curl -L https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip -o opengfx-all.zip
-        echo "::endgroup::"
-
-        echo "::group::Unpack OpenGFX"
-        unzip opengfx-all.zip
-        echo "::endgroup::"
-
-        rm -f opengfx-all.zip
-
-    - name: Install GCC problem matcher
-      uses: ammaraskar/gcc-problem-matcher@master
-
-    - name: Build
-      shell: msys2 {0}
-      env:
-        NINJA_STATUS: "[%f/%t -- %e] " # [finished_edges/total_edges -- elapsed_time], default value is "[%f/%t] "
-      run: |
-        mkdir build
-        cd build
-
-        echo "::group::CMake"
-        cmake .. \
-          -GNinja \
-          -DCMAKE_CXX_FLAGS="-fuse-ld=lld" \
-          # EOF
-        echo "::endgroup::"
-
-        echo "::group::Build"
-        cmake --build .
-        echo "::endgroup::"
-
-    - name: Test
-      shell: msys2 {0}
-      run: |
-        cd build
-        ctest --timeout 120
+    with:
+      msystem: ${{ matrix.msystem }}
+      arch: ${{ matrix.arch }}
 
   check_annotations:
     name: Check Annotations
@@ -433,7 +124,7 @@ jobs:
     - linux
     - macos
     - windows
-    - msys2
+    - mingw
 
     if: always() && github.event_name == 'pull_request'
 

--- a/.github/workflows/ci-emscripten.yml
+++ b/.github/workflows/ci-emscripten.yml
@@ -1,0 +1,62 @@
+name: CI (Emscripten)
+
+on:
+  workflow_call:
+
+env:
+  CTEST_OUTPUT_ON_FAILURE: 1
+
+jobs:
+  emscripten:
+    name: CI
+
+    runs-on: ubuntu-20.04
+    container:
+      # If you change this version, change the number in the cache step too.
+      image: emscripten/emsdk:3.1.42
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup cache
+      uses: actions/cache@v4
+      with:
+        path: /emsdk/upstream/emscripten/cache
+        key: 3.1.42-${{ runner.os }}
+
+    - name: Patch Emscripten to support LZMA
+      run: |
+        cd /emsdk/upstream/emscripten
+        patch -p1 < ${GITHUB_WORKSPACE}/os/emscripten/emsdk-liblzma.patch
+
+    - name: Build (host tools)
+      run: |
+        mkdir build-host
+        cd build-host
+
+        echo "::group::CMake"
+        cmake .. -DOPTION_TOOLS_ONLY=ON
+        echo "::endgroup::"
+
+        echo "::group::Build"
+        echo "Running on $(nproc) cores"
+        cmake --build . -j $(nproc) --target tools
+        echo "::endgroup::"
+
+    - name: Install GCC problem matcher
+      uses: ammaraskar/gcc-problem-matcher@master
+
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+
+        echo "::group::CMake"
+        emcmake cmake .. -DHOST_BINARY_DIR=../build-host
+        echo "::endgroup::"
+
+        echo "::group::Build"
+        echo "Running on $(nproc) cores"
+        cmake --build . -j $(nproc) --target openttd
+        echo "::endgroup::"

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -1,0 +1,123 @@
+name: CI (Linux)
+
+on:
+  workflow_call:
+    inputs:
+      compiler:
+        required: true
+        type: string
+      cxxcompiler:
+        required: true
+        type: string
+      libraries:
+        required: true
+        type: string
+      extra-cmake-parameters:
+        required: true
+        type: string
+
+env:
+  CTEST_OUTPUT_ON_FAILURE: 1
+
+jobs:
+  linux:
+    name: CI
+
+    runs-on: ubuntu-latest
+    env:
+      CC: ${{ inputs.compiler }}
+      CXX: ${{ inputs.cxxcompiler }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup vcpkg caching
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+          core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite')
+
+    - name: Install vcpkg
+      run: |
+        git clone https://github.com/microsoft/vcpkg
+        ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+    - name: Install dependencies
+      run: |
+        echo "::group::Update apt"
+        sudo apt-get update
+        echo "::endgroup::"
+
+        echo "::group::Install dependencies"
+        sudo apt-get install -y --no-install-recommends \
+          liballegro4-dev \
+          libcurl4-openssl-dev \
+          libfontconfig-dev \
+          libharfbuzz-dev \
+          libicu-dev \
+          liblzma-dev \
+          liblzo2-dev \
+          ${{ inputs.libraries }} \
+          zlib1g-dev \
+          # EOF
+
+        echo "::group::Install vcpkg dependencies"
+
+        # Disable vcpkg integration, as we mostly use system libraries.
+        mv vcpkg.json vcpkg-disabled.json
+
+        # We only use breakpad from vcpkg, as its CMake files
+        # are a bit special. So the Ubuntu's variant doesn't work.
+        ./vcpkg/vcpkg install breakpad
+
+        echo "::endgroup::"
+      env:
+        DEBIAN_FRONTEND: noninteractive
+
+    - name: Get OpenGFX
+      run: |
+        mkdir -p ~/.local/share/openttd/baseset
+        cd ~/.local/share/openttd/baseset
+
+        echo "::group::Download OpenGFX"
+        curl -L https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip -o opengfx-all.zip
+        echo "::endgroup::"
+
+        echo "::group::Unpack OpenGFX"
+        unzip opengfx-all.zip
+        echo "::endgroup::"
+
+        rm -f opengfx-all.zip
+
+    - name: Install GCC problem matcher
+      uses: ammaraskar/gcc-problem-matcher@master
+
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+
+        echo "::group::CMake"
+        cmake .. -DCMAKE_TOOLCHAIN_FILE=${GITHUB_WORKSPACE}/vcpkg/scripts/buildsystems/vcpkg.cmake ${{ inputs.extra-cmake-parameters }}
+        echo "::endgroup::"
+
+        echo "::group::Build"
+        echo "Running on $(nproc) cores"
+        cmake --build . -j $(nproc)
+        echo "::endgroup::"
+
+    - name: Test
+      run: |
+        (
+          cd build
+          ctest -j $(nproc) --timeout 120
+        )
+
+        # Re-enable vcpkg.
+        mv vcpkg-disabled.json vcpkg.json
+
+        # Check no tracked files have been modified.
+        git diff --exit-code

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -1,0 +1,80 @@
+name: CI (MacOS)
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      full_arch:
+        required: true
+        type: string
+
+env:
+  CTEST_OUTPUT_ON_FAILURE: 1
+
+jobs:
+  macos:
+    name: CI
+
+    runs-on: macos-14
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 10.13
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup vcpkg caching
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+          core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite')
+
+    - name: Install vcpkg
+      run: |
+        git clone https://github.com/microsoft/vcpkg
+        ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+    - name: Install OpenGFX
+      run: |
+        mkdir -p ~/Documents/OpenTTD/baseset
+        cd ~/Documents/OpenTTD/baseset
+
+        echo "::group::Download OpenGFX"
+        curl -L https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip -o opengfx-all.zip
+        echo "::endgroup::"
+
+        echo "::group::Unpack OpenGFX"
+        unzip opengfx-all.zip
+        echo "::endgroup::"
+
+        rm -f opengfx-all.zip
+
+    - name: Install GCC problem matcher
+      uses: ammaraskar/gcc-problem-matcher@master
+
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+
+        echo "::group::CMake"
+        cmake .. \
+          -DCMAKE_OSX_ARCHITECTURES=${{ inputs.full_arch }} \
+          -DVCPKG_TARGET_TRIPLET=${{ inputs.arch }}-osx \
+          -DCMAKE_TOOLCHAIN_FILE=${GITHUB_WORKSPACE}/vcpkg/scripts/buildsystems/vcpkg.cmake \
+          # EOF
+        echo "::endgroup::"
+
+        echo "::group::Build"
+        echo "Running on $(sysctl -n hw.logicalcpu) cores"
+        cmake --build . -j $(sysctl -n hw.logicalcpu)
+        echo "::endgroup::"
+
+    - name: Test
+      run: |
+        cd build
+        ctest -j $(sysctl -n hw.logicalcpu) --timeout 120

--- a/.github/workflows/ci-mingw.yml
+++ b/.github/workflows/ci-mingw.yml
@@ -1,0 +1,83 @@
+name: CI (MinGW)
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      msystem:
+        required: true
+        type: string
+
+env:
+  CTEST_OUTPUT_ON_FAILURE: 1
+
+jobs:
+  mingw:
+    name: CI
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup MSYS2
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ inputs.msystem }}
+        release: false
+        install: >-
+          git
+          make
+          mingw-w64-${{ inputs.arch }}-cmake
+          mingw-w64-${{ inputs.arch }}-gcc
+          mingw-w64-${{ inputs.arch }}-lzo2
+          mingw-w64-${{ inputs.arch }}-libpng
+          mingw-w64-${{ inputs.arch }}-lld
+          mingw-w64-${{ inputs.arch }}-ninja
+
+    - name: Install OpenGFX
+      shell: bash
+      run: |
+        mkdir -p "C:/Users/Public/Documents/OpenTTD/baseset"
+        cd "C:/Users/Public/Documents/OpenTTD/baseset"
+
+        echo "::group::Download OpenGFX"
+        curl -L https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip -o opengfx-all.zip
+        echo "::endgroup::"
+
+        echo "::group::Unpack OpenGFX"
+        unzip opengfx-all.zip
+        echo "::endgroup::"
+
+        rm -f opengfx-all.zip
+
+    - name: Install GCC problem matcher
+      uses: ammaraskar/gcc-problem-matcher@master
+
+    - name: Build
+      shell: msys2 {0}
+      env:
+        NINJA_STATUS: "[%f/%t -- %e] " # [finished_edges/total_edges -- elapsed_time], default value is "[%f/%t] "
+      run: |
+        mkdir build
+        cd build
+
+        echo "::group::CMake"
+        cmake .. \
+          -GNinja \
+          -DCMAKE_CXX_FLAGS="-fuse-ld=lld" \
+          # EOF
+        echo "::endgroup::"
+
+        echo "::group::Build"
+        cmake --build .
+        echo "::endgroup::"
+
+    - name: Test
+      shell: msys2 {0}
+      run: |
+        cd build
+        ctest --timeout 120

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -1,0 +1,82 @@
+name: CI - Nightly
+
+on:
+  schedule:
+  - cron: '0 3 * * *'
+  workflow_dispatch:
+
+env:
+  CTEST_OUTPUT_ON_FAILURE: 1
+
+jobs:
+  linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name: GCC - SDL1.2
+          compiler: gcc
+          cxxcompiler: g++
+          libraries: libsdl1.2-dev
+
+    name: Linux (${{ matrix.name }})
+
+    uses: ./.github/workflows/ci-linux.yml
+    secrets: inherit
+
+    with:
+      compiler: ${{ matrix.compiler }}
+      cxxcompiler: ${{ matrix.cxxcompiler }}
+      libraries: ${{ matrix.libraries }}
+      extra-cmake-parameters:
+
+  macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - arch: x64
+          full_arch: x86_64
+
+    name: Mac OS (${{ matrix.arch }})
+
+    uses: ./.github/workflows/ci-macos.yml
+    secrets: inherit
+
+    with:
+      arch: ${{ matrix.arch }}
+      full_arch: ${{ matrix.full_arch }}
+
+  mingw:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - msystem: MINGW64
+          arch: x86_64
+        - msystem: MINGW32
+          arch: i686
+
+    name: MinGW (${{ matrix.arch }})
+
+    uses: ./.github/workflows/ci-mingw.yml
+    secrets: inherit
+
+    with:
+      msystem: ${{ matrix.msystem }}
+      arch: ${{ matrix.arch }}
+
+  check_annotations:
+    name: Check Annotations
+    needs:
+    - linux
+    - macos
+    - mingw
+
+    if: always()
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check annotations
+      uses: OpenTTD/actions/annotation-check@v5

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,0 +1,87 @@
+name: CI (Windows)
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      os:
+        required: true
+        type: string
+
+env:
+  CTEST_OUTPUT_ON_FAILURE: 1
+
+jobs:
+  windows:
+    name: CI
+
+    runs-on: ${{ inputs.os }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup vcpkg caching
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+          core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite')
+
+    - name: Install vcpkg
+      run: |
+        git clone https://github.com/microsoft/vcpkg
+        .\vcpkg\bootstrap-vcpkg.bat -disableMetrics
+
+    - name: Install OpenGFX
+      shell: bash
+      run: |
+        mkdir -p "C:/Users/Public/Documents/OpenTTD/baseset"
+        cd "C:/Users/Public/Documents/OpenTTD/baseset"
+
+        echo "::group::Download OpenGFX"
+        curl -L https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip -o opengfx-all.zip
+        echo "::endgroup::"
+
+        echo "::group::Unpack OpenGFX"
+        unzip opengfx-all.zip
+        echo "::endgroup::"
+
+        rm -f opengfx-all.zip
+
+    - name: Install MSVC problem matcher
+      uses: ammaraskar/msvc-problem-matcher@master
+
+    - name: Configure developer command prompt for ${{ inputs.arch }}
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: ${{ inputs.arch }}
+
+    - name: Build
+      shell: bash
+      env:
+        NINJA_STATUS: "[%f/%t -- %e] " # [finished_edges/total_edges -- elapsed_time], default value is "[%f/%t] "
+      run: |
+        mkdir build
+        cd build
+
+        echo "::group::CMake"
+        cmake .. \
+          -GNinja \
+          -DVCPKG_TARGET_TRIPLET=${{ inputs.arch }}-windows-static \
+          -DCMAKE_TOOLCHAIN_FILE="${GITHUB_WORKSPACE}\vcpkg\scripts\buildsystems\vcpkg.cmake" \
+          # EOF
+        echo "::endgroup::"
+
+        echo "::group::Build"
+        cmake --build .
+        echo "::endgroup::"
+
+    - name: Test
+      shell: bash
+      run: |
+        cd build
+        ctest --timeout 120


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Currently we run a lot of CI jobs on every PR. This didn't used to be a problem, but with more people now active on OpenTTD, there often is a (long) queue of CI jobs. We recently had an "incident" where an author rebased 15 open PRs, causing a long queue on the CI. Although those rebases were mostly unneeded, it is not behaviour we can control.

This PR tries to address these queue lengths; not the individual CI time.

It is basic math: GitHub offers us 20 runners for free (and we are very grateful for that). This means that every hour we have 1200 CPU-hours available to us.

Before this PR, every PR consumes: 5x 10m (Linux) + 4m (MacOS) + 2x 25m (MinGW) + 4x 10m (Windows) + 5m (Emscripten) + 40m (codeQL), a total of ~200 CPU minutes per PR. Means it can process ~6 PRs per hour.

Most of these jobs that run actually don't give us much new information, or very very very very very rarely point out a problem. MinGW is the best example here. We have it running as a single developer of us still uses it, and as such we want to make sure he can continue developing for OpenTTD. But it consumes a wopping 50 CPU-minutes, 1/3rd of the total. And how often does it fail while other jobs fail? Well ... I can't remember any of my PRs ever failing on it, not in the last months at least. So the actual added value here is very low.

~~Similar, we still compile for MSVC on Windows 2019. This has an older MSVC installed, and as we can still compile OpenTTD with it, we don't want to let go. But it hogs up another 20 CPU minutes every PR. While I have haven't seen 2019 fail where the Windows 2022 variant didn't fail, in the many PRs I saw/made in the last few months. So here too, very little added value, while consuming a lot of CPU-minutes.~~ Edit: we removed Windows 2019 completely.

Lastly, we see the same with SDL2 vs SDL1.2. I think SDL1.2 never failed, when SDL2 didn't. But still we spend 10 CPU-minutes on it, "just to be sure". As that is how we roll ;)

All other targets have a more well-defined role:
- Linux: Debug vs Release, Clang vs GCC, no PCH
- MacOS: as .. it is MacOS
- Windows: x64 vs x86 .. one can debate if x86 is still relevant, but for now, this is fine.
- CodeQL: it shows from time to time actual issues with PRs

## Description

Split the "build on PR" into two groups: "build on PR" and "build every night". And push the above mentioned jobs to the latter. That way we fee up 80 CPU-minutes per PR, 2/5th of the time a PR needs in terms of CPU-minutes. Means we can now process 10 PRs per hour: almost double the amount.

And that for a very low loss in value, as these targets, as mentioned above, already didn't actually add value.

PS: this also adds back x86_64 to MacOS, in the nightly, to ensure we don't run into any weird issues during release.

Example of a nightly run: https://github.com/TrueBrain/OpenTTD/actions/runs/8221285336

## Limitations

- Failures to this nightly job will be invisible; but I will add later today some code to DorpsGek to notify us when these kind of jobs fail, so we can react to it.
- This change will make us reactive for some platforms. So it is possible that someone merges a PR that makes one of these targets go BOOM, and we notice it only the next night. Pretty much like the old subversion days. But just much less likely to happen :)
- Every PR after merging this needs to be rebased, before the CI will approve it. Because of a deduplication action, the path to the CI result has changed.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
