### PR TITLE
Remove: official support for MSVC 2019

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -274,7 +274,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, windows-2019]
+        os: [windows-latest]
         arch: [x86, x64]
 
     name: Windows (${{ matrix.os }} / ${{ matrix.arch }})


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

#12252 ran into a bug with MSVC 2019, which made us wonder: why do we still build for MSVC 2019?

MSVC 2022 is out for a while now, and upgrading is free for the community edition. And how long do we actually want to support these older MSVC?

Mostly as we are pretty cutting edge in our C++ support (C++20), supporting these older compilers is just a pita, with relatively low benefit.

## Description

Remove building for MSVC 2019 in CI, meaning we also no longer support MSVC 2019 officially. And with #12252 we most likely break being able to build on it.

Sorry for all those that still use MSVC 2019; but please upgrade to MSVC 2022 :)

## Limitations

Our compiling-instructions still mention MSVC 2017 as option; but pretty sure that hasn't worked in months. So that needs a cleanup, but by someone that actually uses MSVC. As I don't actually know what is true or not. Not sure that should be part of this PR, as it is already broken / wrong.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
