### PR TITLE
Codechange: simplify TileAdd and replace macro's with functions

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -64,7 +64,7 @@
 
 
 #ifdef _DEBUG
-TileIndex TILE_ADD(TileIndex tile, TileIndexDiff offset, std::source_location location)
+TileIndex TILE_ADD(TileIndex tile, TileIndexDiff offset)
 {
 	int dx = offset & Map::MaxX();
 	if (dx >= (int)Map::SizeX() / 2) dx -= Map::SizeX();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -69,32 +69,26 @@ extern "C" _CRTIMP void __cdecl _assert(void *, void *, unsigned);
 
 
 #ifdef _DEBUG
-TileIndex TileAdd(TileIndex tile, TileIndexDiff add,
-	const char *exp, const char *file, int line)
+TileIndex TILE_ADD(TileIndex tile, TileIndexDiff offset, std::source_location location)
 {
-	int dx;
-	int dy;
-	uint x;
-	uint y;
-
-	dx = add & Map::MaxX();
+	int dx = offset & Map::MaxX();
 	if (dx >= (int)Map::SizeX() / 2) dx -= Map::SizeX();
-	dy = (add - dx) / (int)Map::SizeX();
+	int dy = (offset - dx) / (int)Map::SizeX();
 
-	x = TileX(tile) + dx;
-	y = TileY(tile) + dy;
+	uint x = TileX(tile) + dx;
+	uint y = TileY(tile) + dy;
 
 	if (x >= Map::SizeX() || y >= Map::SizeY()) {
-		std::string message = fmt::format("TILE_ADD({}) when adding 0x{:04X} and 0x{:04X} failed",
-			exp, tile, add);
+		std::string message = fmt::format("TILE_ADD when adding 0x{:04X} and 0x{:04X} failed",
+			tile, offset);
 #if !defined(_MSC_VER)
-		fmt::print(stderr, "{}:{} {}\n", file, line, message);
+		fmt::print(stderr, "{}:{}:{} {}\n", location.file_name(), location.line(), location.column(), message);
 #else
-		_assert(message.data(), (char*)file, line);
+		_assert(message.data(), (char*)location.file_name(), location.line());
 #endif
 	}
 
-	assert(TileXY(x, y) == Map::WrapToMap(tile + add));
+	assert(TileXY(x, y) == Map::WrapToMap(tile + offset));
 
 	return TileXY(x, y);
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -17,11 +17,6 @@
 
 #include "safeguards.h"
 
-#if defined(_MSC_VER)
-/* Why the hell is that not in all MSVC headers?? */
-extern "C" _CRTIMP void __cdecl _assert(void *, void *, unsigned);
-#endif
-
 /* static */ uint Map::log_x;     ///< 2^_map_log_x == _map_size_x
 /* static */ uint Map::log_y;     ///< 2^_map_log_y == _map_size_y
 /* static */ uint Map::size_x;    ///< Size of the map along the X
@@ -75,19 +70,11 @@ TileIndex TILE_ADD(TileIndex tile, TileIndexDiff offset, std::source_location lo
 	if (dx >= (int)Map::SizeX() / 2) dx -= Map::SizeX();
 	int dy = (offset - dx) / (int)Map::SizeX();
 
-	uint x = TileX(tile) + dx;
-	uint y = TileY(tile) + dy;
+	uint32_t x = TileX(tile) + dx;
+	uint32_t y = TileY(tile) + dy;
 
-	if (x >= Map::SizeX() || y >= Map::SizeY()) {
-		std::string message = fmt::format("TILE_ADD when adding 0x{:04X} and 0x{:04X} failed",
-			tile, offset);
-#if !defined(_MSC_VER)
-		fmt::print(stderr, "{}:{}:{} {}\n", location.file_name(), location.line(), location.column(), message);
-#else
-		_assert(message.data(), (char*)location.file_name(), location.line());
-#endif
-	}
-
+	assert(x < Map::SizeX());
+	assert(y < Map::SizeY());
 	assert(TileXY(x, y) == Map::WrapToMap(tile + offset));
 
 	return TileXY(x, y);

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -455,29 +455,31 @@ inline TileIndexDiff ToTileIndexDiff(TileIndexDiffC tidc)
 }
 
 
+/**
+ * Adds a given offset to a tile.
+ *
+ * @param tile The tile to add an offset to.
+ * @param offset The offset to add.
+ * @return The resulting tile.
+ */
 #ifndef _DEBUG
-	/**
-	 * Adds two tiles together.
-	 *
-	 * @param x One tile
-	 * @param y Another tile to add
-	 * @return The resulting tile(index)
-	 */
-#	define TILE_ADD(x, y) ((x) + (y))
+	constexpr TileIndex TILE_ADD(TileIndex tile, TileIndexDiff offset, [[maybe_unused]] const std::source_location location = std::source_location::current()) { return tile + offset; }
 #else
-	extern TileIndex TileAdd(TileIndex tile, TileIndexDiff add,
-		const char *exp, const char *file, int line);
-#	define TILE_ADD(x, y) (TileAdd((x), (y), #x " + " #y, __FILE__, __LINE__))
+	TileIndex TILE_ADD(TileIndex tile, TileIndexDiff offset, const std::source_location location = std::source_location::current());
 #endif
 
 /**
  * Adds a given offset to a tile.
  *
- * @param tile The tile to add an offset on it
- * @param x The x offset to add to the tile
- * @param y The y offset to add to the tile
+ * @param tile The tile to add an offset to.
+ * @param x The x offset to add to the tile.
+ * @param y The y offset to add to the tile.
+ * @return The resulting tile.
  */
-#define TILE_ADDXY(tile, x, y) TILE_ADD(tile, TileDiffXY(x, y))
+inline TileIndex TILE_ADDXY(TileIndex tile, int x, int y, const std::source_location location = std::source_location::current())
+{
+	return TILE_ADD(tile, TileDiffXY(x, y), location);
+}
 
 TileIndex TileAddWrap(TileIndex tile, int addx, int addy);
 

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -463,9 +463,9 @@ inline TileIndexDiff ToTileIndexDiff(TileIndexDiffC tidc)
  * @return The resulting tile.
  */
 #ifndef _DEBUG
-	constexpr TileIndex TILE_ADD(TileIndex tile, TileIndexDiff offset, [[maybe_unused]] const std::source_location location = std::source_location::current()) { return tile + offset; }
+	constexpr TileIndex TILE_ADD(TileIndex tile, TileIndexDiff offset) { return tile + offset; }
 #else
-	TileIndex TILE_ADD(TileIndex tile, TileIndexDiff offset, const std::source_location location = std::source_location::current());
+	TileIndex TILE_ADD(TileIndex tile, TileIndexDiff offset);
 #endif
 
 /**
@@ -476,9 +476,9 @@ inline TileIndexDiff ToTileIndexDiff(TileIndexDiffC tidc)
  * @param y The y offset to add to the tile.
  * @return The resulting tile.
  */
-inline TileIndex TILE_ADDXY(TileIndex tile, int x, int y, const std::source_location location = std::source_location::current())
+inline TileIndex TILE_ADDXY(TileIndex tile, int x, int y)
 {
-	return TILE_ADD(tile, TileDiffXY(x, y), location);
+	return TILE_ADD(tile, TileDiffXY(x, y));
 }
 
 TileIndex TileAddWrap(TileIndex tile, int addx, int addy);


### PR DESCRIPTION
## Motivation / Problem

`#define` magic over `C++` functionality.

The expression string describing expression passed into `TILE_ADD` is the same for all cases where `TILE_ADD` is called twice on the same line of code, and as such it doesn't distinguish between the two. Not a real problem, as if it fails it should also fail on the first call, but still inconsistent.
In all other cases the expression does not add a lot to the assertion message.


## Description

Remove the expression string in lieu of the column number from `std::source_location`.
Use `std::source_location` in the function with default value, to pass the file and line to `TILE_ADD` instead of going via a preprocessor macro.
Always passing the `std::source_location` from `TILE_ADDXY` to `TILE_ADD`; the compiler ought to optimise this away with even minimal optimisations, which are likely when debugging is disabled.


## Limitations

Deliberately adding [[maybe_unused]] to a variable that will never be used in that context, just to have the same signature and simplifying the other accessor of the functionality.

The `TileAdd` function got renamed to the name of the old macro `TILE_ADD`, just to prevent massive changes all over the code. This can be trivially changed in a separate PR. Something similar holds for `TILE_ADDXY`, which was a macro and has become a function.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
