### PR TITLE
Add: [Script] GetExtraLastError and GetExtraLastErrorString

### DIFF
--- a/regression/regression/main.nut
+++ b/regression/regression/main.nut
@@ -1828,6 +1828,17 @@ function Regression::Vehicle()
 	print("    GetLastErrorString():  " + AIError.GetLastErrorString());
 	print("    SendVehicleToDepot():  " + AIVehicle.SendVehicleToDepot(13));
 	print("    GetLastErrorString():  " + AIError.GetLastErrorString());
+	print("    BuildVehicle():        " + AIVehicle.BuildVehicle(33417, 116));
+	print("    AppendOrder():         " + AIOrder.AppendOrder(20, 33421, AIOrder.OF_NONE));
+	print("    GetLastError():        " + AIError.GetLastError());
+	print("    GetLastErrorString():  " + AIError.GetLastErrorString());
+	print("    GetExtraLastError():   " + AIError.GetExtraLastError());
+	print("    GetExtraLastErrorString(): " + AIError.GetExtraLastErrorString());
+	print("    SellVehicle():         " + AIVehicle.SellVehicle(20));
+	print("    GetLastError():        " + AIError.GetLastError());
+	print("    GetLastErrorString():  " + AIError.GetLastErrorString());
+	print("    GetExtraLastError():   " + AIError.GetExtraLastError());
+	print("    GetExtraLastErrorString(): " + AIError.GetExtraLastErrorString());
 
 	local list = AIVehicleList();
 	local in_depot = AIVehicleList(AIVehicle.IsInDepot);

--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -9546,6 +9546,17 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetLastErrorString():  ERR_VEHICLE_NOT_IN_DEPOT
     SendVehicleToDepot():  false
     GetLastErrorString():  ERR_UNKNOWN
+    BuildVehicle():        20
+    AppendOrder():         false
+    GetLastError():        1
+    GetLastErrorString():  ERR_UNKNOWN
+    GetExtraLastError():   1
+    GetExtraLastErrorString(): ERR_UNKNOWN
+    SellVehicle():         true
+    GetLastError():        0
+    GetLastErrorString():  ERR_NONE
+    GetExtraLastError():   0
+    GetExtraLastErrorString(): ERR_NONE
 
 --VehicleList--
   Count():             5
@@ -9588,7 +9599,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     13 => 5490
     12 => 5489
   CurrentSpeed ListDump:
-    12 => 27
+    12 => 31
     17 => 0
     16 => 0
     14 => 0
@@ -9763,9 +9774,9 @@ ERROR: IsEnd() is invalid as Begin() is never called
 --Valuate() with excessive CPU usage--
 Your script made an error: excessive CPU usage in valuator function
 
-*FUNCTION [unknown()] regression/main.nut line [2065]
+*FUNCTION [unknown()] regression/main.nut line [2076]
 *FUNCTION [Valuate()] NATIVE line [-1]
-*FUNCTION [Start()] regression/main.nut line [2066]
+*FUNCTION [Start()] regression/main.nut line [2077]
 
 [id] 0
 [this] TABLE
@@ -9774,7 +9785,7 @@ Your script made an error: excessive CPU usage in valuator function
 [this] INSTANCE
 Your script made an error: excessive CPU usage in valuator function
 
-*FUNCTION [Start()] regression/main.nut line [2066]
+*FUNCTION [Start()] regression/main.nut line [2077]
 
 [Infinite] CLOSURE
 [list] INSTANCE

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -21,6 +21,8 @@
  * \li AIEventVehicleCrashed::GetVictims
  * \li AIEventCompanyRenamed
  * \li AIEventPresidentRenamed
+ * \li AIError::GetExtraLastError
+ * \li AIError::GetExtraLastErrorString
  *
  * \b 14.0
  *

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -21,6 +21,8 @@
  * \li GSEventVehicleCrashed::GetVictims
  * \li GSEventCompanyRenamed
  * \li GSEventPresidentRenamed
+ * \li GSError::GetExtraLastError
+ * \li GSError::GetExtraLastErrorString
  *
  * \b 14.0
  *

--- a/src/script/api/script_basestation.cpp
+++ b/src/script/api/script_basestation.cpp
@@ -44,7 +44,7 @@
 	EnforcePrecondition(false, name != nullptr);
 	const std::string &text = name->GetDecodedText();
 	EnforcePreconditionEncodedText(false, text);
-	EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_STATION_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG);
+	EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_STATION_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG, ScriptError::ERR_UNKNOWN);
 
 	if (::Station::IsValidID(station_id)) {
 		return ScriptObject::Command<CMD_RENAME_STATION>::Do(station_id, text);

--- a/src/script/api/script_company.cpp
+++ b/src/script/api/script_company.cpp
@@ -52,7 +52,7 @@
 	EnforcePrecondition(false, name != nullptr);
 	const std::string &text = name->GetDecodedText();
 	EnforcePreconditionEncodedText(false, text);
-	EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_COMPANY_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG);
+	EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_COMPANY_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG, ScriptError::ERR_UNKNOWN);
 
 	return ScriptObject::Command<CMD_RENAME_COMPANY>::Do(text);
 }
@@ -74,7 +74,7 @@
 	EnforcePrecondition(false, name != nullptr);
 	const std::string &text = name->GetDecodedText();
 	EnforcePreconditionEncodedText(false, text);
-	EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_PRESIDENT_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG);
+	EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_PRESIDENT_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG, ScriptError::ERR_UNKNOWN);
 
 	return ScriptObject::Command<CMD_RENAME_PRESIDENT>::Do(text);
 }

--- a/src/script/api/script_error.cpp
+++ b/src/script/api/script_error.cpp
@@ -23,9 +23,19 @@ ScriptError::ScriptErrorMapString ScriptError::error_map_string = ScriptError::S
 	return ScriptObject::GetLastError();
 }
 
+/* static */ ScriptErrorType ScriptError::GetExtraLastError()
+{
+	return ScriptObject::GetExtraLastError();
+}
+
 /* static */ std::optional<std::string> ScriptError::GetLastErrorString()
 {
 	return (*error_map_string.find(ScriptError::GetLastError())).second;
+}
+
+/* static */ std::optional<std::string> ScriptError::GetExtraLastErrorString()
+{
+	return (*error_map_string.find(ScriptError::GetExtraLastError())).second;
 }
 
 /* static */ ScriptErrorType ScriptError::StringToError(StringID internal_string_id)

--- a/src/script/api/script_error.hpp
+++ b/src/script/api/script_error.hpp
@@ -30,11 +30,12 @@
  * @param returnval The value to return on failure.
  * @param condition The condition that must be obeyed.
  * @param error_code The error code passed to ScriptObject::SetLastError.
+ * @param extra_error_code The extra error code passed to ScriptObject::SetExtraLastError.
  */
-#define EnforcePreconditionCustomError(returnval, condition, error_code)   \
+#define EnforcePreconditionCustomError(returnval, condition, error_code, extra_error_code)   \
 	if (!(condition)) {                                                      \
 		ScriptObject::SetLastError(error_code);                                    \
-		ScriptObject::SetExtraLastError(ScriptError::ERR_UNKNOWN);             \
+		ScriptObject::SetExtraLastError(extra_error_code);             \
 		return returnval;                                                      \
 	}
 
@@ -55,7 +56,7 @@
  * @param returnval The value to return on failure.
  */
 #define EnforceCompanyModeValid(returnval) \
-	EnforcePreconditionCustomError(returnval, ScriptCompanyMode::IsValid(), ScriptError::ERR_PRECONDITION_INVALID_COMPANY)
+	EnforcePreconditionCustomError(returnval, ScriptCompanyMode::IsValid(), ScriptError::ERR_PRECONDITION_INVALID_COMPANY, ScriptError::ERR_UNKNOWN)
 
 /**
  * Helper to enforce the precondition that the company mode is valid.
@@ -72,14 +73,14 @@
  * @param returnval The value to return on failure.
  */
 #define EnforceDeityMode(returnval) \
-	EnforcePreconditionCustomError(returnval, ScriptCompanyMode::IsDeity(), ScriptError::ERR_PRECONDITION_INVALID_COMPANY)
+	EnforcePreconditionCustomError(returnval, ScriptCompanyMode::IsDeity(), ScriptError::ERR_PRECONDITION_INVALID_COMPANY, ScriptError::ERR_UNKNOWN)
 
 /**
  * Helper to enforce the precondition that the company mode is valid or that we are a deity.
  * @param returnval The value to return on failure.
  */
 #define EnforceDeityOrCompanyModeValid(returnval) \
-	EnforcePreconditionCustomError(returnval, ScriptCompanyMode::IsDeity() || ScriptCompanyMode::IsValid(), ScriptError::ERR_PRECONDITION_INVALID_COMPANY)
+	EnforcePreconditionCustomError(returnval, ScriptCompanyMode::IsDeity() || ScriptCompanyMode::IsValid(), ScriptError::ERR_PRECONDITION_INVALID_COMPANY, ScriptError::ERR_UNKNOWN)
 
 /**
  * Helper to enforce the precondition that the company mode is valid or that we are a deity.

--- a/src/script/api/script_error.hpp
+++ b/src/script/api/script_error.hpp
@@ -21,6 +21,7 @@
 #define EnforcePrecondition(returnval, condition)               \
 	if (!(condition)) {                                           \
 		ScriptObject::SetLastError(ScriptError::ERR_PRECONDITION_FAILED);   \
+		ScriptObject::SetExtraLastError(ScriptError::ERR_UNKNOWN);             \
 		return returnval;                                           \
 	}
 
@@ -33,6 +34,7 @@
 #define EnforcePreconditionCustomError(returnval, condition, error_code)   \
 	if (!(condition)) {                                                      \
 		ScriptObject::SetLastError(error_code);                                    \
+		ScriptObject::SetExtraLastError(ScriptError::ERR_UNKNOWN);             \
 		return returnval;                                                      \
 	}
 
@@ -44,6 +46,7 @@
 #define EnforcePreconditionEncodedText(returnval, string)   \
 	if (string.empty()) { \
 		ScriptObject::SetLastError(ScriptError::ERR_PRECONDITION_FAILED); \
+		ScriptObject::SetExtraLastError(ScriptError::ERR_UNKNOWN);             \
 		return returnval; \
 	}
 
@@ -60,6 +63,7 @@
 #define EnforceCompanyModeValid_Void() \
 	if (!ScriptCompanyMode::IsValid()) { \
 		ScriptObject::SetLastError(ScriptError::ERR_PRECONDITION_INVALID_COMPANY); \
+		ScriptObject::SetExtraLastError(ScriptError::ERR_UNKNOWN);             \
 		return; \
 	}
 
@@ -83,6 +87,7 @@
 #define EnforceDeityOrCompanyModeValid_Void() \
 	if (!(ScriptCompanyMode::IsDeity() || ScriptCompanyMode::IsValid())) { \
 		ScriptObject::SetLastError(ScriptError::ERR_PRECONDITION_INVALID_COMPANY); \
+		ScriptObject::SetExtraLastError(ScriptError::ERR_UNKNOWN);             \
 		return; \
 	}
 
@@ -191,10 +196,22 @@ public:
 	static ScriptErrorType GetLastError();
 
 	/**
+	 * Get the extra last error.
+	 * @return An ErrorMessages enum value.
+	 */
+	static ScriptErrorType GetExtraLastError();
+
+	/**
 	 * Get the last error in string format (for human readability).
 	 * @return An ErrorMessage enum item, as string.
 	 */
 	static std::optional<std::string> GetLastErrorString();
+
+	/**
+	 * Get the extra last error in string format (for human readability).
+	 * @return An ErrorMessage enum item, as string.
+	 */
+	static std::optional<std::string> GetExtraLastErrorString();
 
 	/**
 	 * Get the error based on the OpenTTD StringID.

--- a/src/script/api/script_group.cpp
+++ b/src/script/api/script_group.cpp
@@ -63,7 +63,7 @@
 	EnforcePrecondition(false, name != nullptr);
 	const std::string &text = name->GetDecodedText();
 	EnforcePreconditionEncodedText(false, text);
-	EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_GROUP_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG);
+	EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_GROUP_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG, ScriptError::ERR_UNKNOWN);
 
 	return ScriptObject::Command<CMD_ALTER_GROUP>::Do(AlterGroupMode::Rename, group_id, 0, text);
 }

--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -150,9 +150,19 @@ ScriptObject::ActiveInstance::~ActiveInstance()
 	GetStorage()->last_error = last_error;
 }
 
+/* static */ void ScriptObject::SetExtraLastError(ScriptErrorType extra_last_error)
+{
+	GetStorage()->extra_last_error = extra_last_error;
+}
+
 /* static */ ScriptErrorType ScriptObject::GetLastError()
 {
 	return GetStorage()->last_error;
+}
+
+/* static */ ScriptErrorType ScriptObject::GetExtraLastError()
+{
+	return GetStorage()->extra_last_error;
 }
 
 /* static */ void ScriptObject::SetLastCost(Money last_cost)
@@ -286,6 +296,7 @@ std::tuple<bool, bool, bool, bool> ScriptObject::DoCommandPrep()
 
 	if (!ScriptCompanyMode::IsDeity() && !ScriptCompanyMode::IsValid()) {
 		ScriptObject::SetLastError(ScriptError::ERR_PRECONDITION_INVALID_COMPANY);
+		ScriptObject::SetExtraLastError(ScriptError::ERR_UNKNOWN);
 		return { true, estimate_only, asynchronous, networking };
 	}
 
@@ -300,11 +311,13 @@ bool ScriptObject::DoCommandProcessResult(const CommandCost &res, Script_Suspend
 	/* We failed; set the error and bail out */
 	if (res.Failed()) {
 		SetLastError(ScriptError::StringToError(res.GetErrorMessage()));
+		SetExtraLastError(ScriptError::StringToError(res.GetExtraErrorMessage()));
 		return false;
 	}
 
 	/* No error, then clear it. */
 	SetLastError(ScriptError::ERR_NONE);
+	SetExtraLastError(ScriptError::ERR_NONE);
 
 	/* Estimates, update the cost for the estimate and be done */
 	if (estimate_only) {

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -175,9 +175,19 @@ protected:
 	static void SetLastError(ScriptErrorType last_error);
 
 	/**
+	 * Set the DoCommand extra last error.
+	 */
+	static void SetExtraLastError(ScriptErrorType extra_last_error);
+
+	/**
 	 * Get the DoCommand last error.
 	 */
 	static ScriptErrorType GetLastError();
+
+	/**
+	 * Get the DoCommand extra last error.
+	 */
+	static ScriptErrorType GetExtraLastError();
 
 	/**
 	 * Set the road type.

--- a/src/script/api/script_priorityqueue.cpp
+++ b/src/script/api/script_priorityqueue.cpp
@@ -52,6 +52,7 @@ SQInteger ScriptPriorityQueue::Pop(HSQUIRRELVM vm)
 {
 	if (this->IsEmpty()) {
 		ScriptObject::SetLastError(ScriptError::ERR_PRECONDITION_FAILED);
+		ScriptObject::SetExtraLastError(ScriptError::ERR_UNKNOWN);
 		sq_pushnull(vm);
 		return 1;
 	}
@@ -70,6 +71,7 @@ SQInteger ScriptPriorityQueue::Peek(HSQUIRRELVM vm)
 {
 	if (this->IsEmpty()) {
 		ScriptObject::SetLastError(ScriptError::ERR_PRECONDITION_FAILED);
+		ScriptObject::SetExtraLastError(ScriptError::ERR_UNKNOWN);
 		sq_pushnull(vm);
 		return 1;
 	}

--- a/src/script/api/script_sign.cpp
+++ b/src/script/api/script_sign.cpp
@@ -42,7 +42,7 @@
 	EnforcePrecondition(false, name != nullptr);
 	const std::string &text = name->GetDecodedText();
 	EnforcePreconditionEncodedText(false, text);
-	EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_SIGN_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG);
+	EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_SIGN_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG, ScriptError::ERR_UNKNOWN);
 
 	return ScriptObject::Command<CMD_RENAME_SIGN>::Do(sign_id, text);
 }
@@ -79,7 +79,7 @@
 	EnforcePrecondition(INVALID_SIGN, name != nullptr);
 	const std::string &text = name->GetDecodedText();
 	EnforcePreconditionEncodedText(INVALID_SIGN, text);
-	EnforcePreconditionCustomError(INVALID_SIGN, ::Utf8StringLength(text) < MAX_LENGTH_SIGN_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG);
+	EnforcePreconditionCustomError(INVALID_SIGN, ::Utf8StringLength(text) < MAX_LENGTH_SIGN_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG, ScriptError::ERR_UNKNOWN);
 
 	if (!ScriptObject::Command<CMD_PLACE_SIGN>::Do(&ScriptInstance::DoCommandReturnSignID, location, text)) return INVALID_SIGN;
 

--- a/src/script/api/script_town.cpp
+++ b/src/script/api/script_town.cpp
@@ -305,6 +305,7 @@
 	uint32_t townnameparts;
 	if (!GenerateTownName(ScriptObject::GetRandomizer(), &townnameparts)) {
 		ScriptObject::SetLastError(ScriptError::ERR_NAME_IS_NOT_UNIQUE);
+		ScriptObject::SetExtraLastError(ScriptError::ERR_UNKNOWN);
 		return false;
 	}
 

--- a/src/script/api/script_town.cpp
+++ b/src/script/api/script_town.cpp
@@ -49,7 +49,7 @@
 	std::string text;
 	if (name != nullptr) {
 		text = name->GetDecodedText();
-		EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_TOWN_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG);
+		EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_TOWN_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG, ScriptError::ERR_UNKNOWN);
 	}
 
 	return ScriptObject::Command<CMD_RENAME_TOWN>::Do(town_id, text);
@@ -300,7 +300,7 @@
 	std::string text;
 	if (name != nullptr) {
 		text = name->GetDecodedText();
-		EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_TOWN_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG);
+		EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_TOWN_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG, ScriptError::ERR_UNKNOWN);
 	}
 	uint32_t townnameparts;
 	if (!GenerateTownName(ScriptObject::GetRandomizer(), &townnameparts)) {

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -79,7 +79,7 @@
 
 	::VehicleType type = ::Engine::Get(engine_id)->type;
 
-	EnforcePreconditionCustomError(VEHICLE_INVALID, !ScriptGameSettings::IsDisabledVehicleType((ScriptVehicle::VehicleType)type), ScriptVehicle::ERR_VEHICLE_BUILD_DISABLED);
+	EnforcePreconditionCustomError(VEHICLE_INVALID, !ScriptGameSettings::IsDisabledVehicleType((ScriptVehicle::VehicleType)type), ScriptVehicle::ERR_VEHICLE_BUILD_DISABLED, ScriptError::ERR_UNKNOWN);
 
 	if (!ScriptObject::Command<CMD_BUILD_VEHICLE>::Do(&ScriptInstance::DoCommandReturnVehicleID, depot, engine_id, true, cargo, INVALID_CLIENT_ID)) return VEHICLE_INVALID;
 
@@ -254,7 +254,7 @@
 	EnforcePrecondition(false, name != nullptr);
 	const std::string &text = name->GetDecodedText();
 	EnforcePreconditionEncodedText(false, text);
-	EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_VEHICLE_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG);
+	EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_VEHICLE_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG, ScriptError::ERR_UNKNOWN);
 
 	return ScriptObject::Command<CMD_RENAME_VEHICLE>::Do(vehicle_id, text);
 }

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -759,6 +759,7 @@ bool ScriptInstance::DoCommandCallback(const CommandCost &result, const CommandD
 
 	if (result.Failed()) {
 		ScriptObject::SetLastError(ScriptError::StringToError(result.GetErrorMessage()));
+		ScriptObject::SetExtraLastError(ScriptError::StringToError(result.GetExtraErrorMessage()));
 	} else {
 		ScriptObject::IncreaseDoCommandCosts(result.GetCost());
 		ScriptObject::SetLastCost(result.GetCost());

--- a/src/script/script_storage.hpp
+++ b/src/script/script_storage.hpp
@@ -51,6 +51,7 @@ private:
 	CommandCost costs;               ///< The costs the script is tracking.
 	Money last_cost;                 ///< The last cost of the command.
 	ScriptErrorType last_error{}; ///< The last error of the command.
+	ScriptErrorType extra_last_error{}; ///< The extra last error of the command.
 	bool last_command_res;           ///< The last result of the command.
 
 	CommandDataBuffer last_data;     ///< The last data passed to a command.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Scripts have no way to get the extra last error message from failed commands (not that it matters anyway, because there's no error strings mapped to them yet).
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Allow scripts to get the extra error message of their last command.

Allow DoCommand and a few others to set extra error messages upon returning result.

Add regression tests.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
There are still no mapped extra errors.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
