### PR TITLE
Codechange: Remove outdated YAPF example code

### DIFF
--- a/src/pathfinder/yapf/yapf_base.hpp
+++ b/src/pathfinder/yapf/yapf_base.hpp
@@ -290,61 +290,6 @@ public:
 		dmp.WriteStructT("m_nodes", &m_nodes);
 		dmp.WriteValue("m_num_steps", m_num_steps);
 	}
-
-	/* methods that should be implemented at derived class Types::Tpf (derived from CYapfBaseT) */
-
-#if 0
-	/** Example: PfSetStartupNodes() - set source (origin) nodes */
-	inline void PfSetStartupNodes()
-	{
-		/* example: */
-		Node &n1 = *base::m_nodes.CreateNewNode();
-		.
-		. // setup node members here
-		.
-		base::m_nodes.InsertOpenNode(n1);
-	}
-
-	/** Example: PfFollowNode() - set following (child) nodes of the given node */
-	inline void PfFollowNode(Node &org)
-	{
-		for (each follower of node org) {
-			Node &n = *base::m_nodes.CreateNewNode();
-			.
-			. // setup node members here
-			.
-			n.m_parent   = &org; // set node's parent to allow back tracking
-			AddNewNode(n);
-		}
-	}
-
-	/** Example: PfCalcCost() - set path cost from origin to the given node */
-	inline bool PfCalcCost(Node &n)
-	{
-		/* evaluate last step cost */
-		int cost = ...;
-		/* set the node cost as sum of parent's cost and last step cost */
-		n.m_cost = n.m_parent->m_cost + cost;
-		return true; // true if node is valid follower (i.e. no obstacle was found)
-	}
-
-	/** Example: PfCalcEstimate() - set path cost estimate from origin to the target through given node */
-	inline bool PfCalcEstimate(Node &n)
-	{
-		/* evaluate the distance to our destination */
-		int distance = ...;
-		/* set estimate as sum of cost from origin + distance to the target */
-		n.m_estimate = n.m_cost + distance;
-		return true; // true if node is valid (i.e. not too far away :)
-	}
-
-	/** Example: PfDetectDestination() - return true if the given node is our destination */
-	inline bool PfDetectDestination(Node &n)
-	{
-		bool bDest = (n.m_key.m_x == m_x2) && (n.m_key.m_y == m_y2);
-		return bDest;
-	}
-#endif
 };
 
 #endif /* YAPF_BASE_HPP */


### PR DESCRIPTION
## Motivation / Problem

There's old example code in yapf_base.hpp. This code is not compiled and is not up to date with the actual implementation of YAPF. Furthermore, we have some real life examples (the actual YAPF ship/regions/rail/road implementations) that will stay relevant because they are compiled / maintained :). These are much more useful as examples IMO.

## Description

Removed it

## Limitations

None

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
