### PR TITLE
Change: [Script] Return different time values based on TimeMode

### DIFF
--- a/src/script/api/script_engine.cpp
+++ b/src/script/api/script_engine.cpp
@@ -10,6 +10,7 @@
 #include "../../stdafx.h"
 #include "script_engine.hpp"
 #include "script_cargo.hpp"
+#include "script_timemode.hpp"
 #include "../../company_base.h"
 #include "../../strings_func.h"
 #include "../../rail.h"
@@ -128,12 +129,14 @@
 	return ::Engine::Get(engine_id)->GetCost();
 }
 
-/* static */ SQInteger ScriptEngine::GetMaxAge(EngineID engine_id)
+/* static */ ScriptDate::Date ScriptEngine::GetMaxAge(EngineID engine_id)
 {
-	if (!IsValidEngine(engine_id)) return -1;
-	if (GetVehicleType(engine_id) == ScriptVehicle::VT_RAIL && IsWagon(engine_id)) return -1;
+	if (!IsValidEngine(engine_id)) return ScriptDate::DATE_INVALID;
+	if (GetVehicleType(engine_id) == ScriptVehicle::VT_RAIL && IsWagon(engine_id)) return ScriptDate::DATE_INVALID;
 
-	return ::Engine::Get(engine_id)->GetLifeLengthInDays().base();
+	if (ScriptTimeMode::IsCalendarMode()) return (ScriptDate::Date)::Engine::Get(engine_id)->GetLifeLengthInDays().base();
+
+	return (ScriptDate::Date)(::Engine::Get(engine_id)->GetLifeLengthInDays().base() * std::max<uint>(_settings_game.economy.minutes_per_calendar_year, CalendarTime::DEF_MINUTES_PER_YEAR) / CalendarTime::DEF_MINUTES_PER_YEAR);
 }
 
 /* static */ Money ScriptEngine::GetRunningCost(EngineID engine_id)

--- a/src/script/api/script_engine.hpp
+++ b/src/script/api/script_engine.hpp
@@ -128,7 +128,7 @@ public:
 	 * @returns The maximum age of a new engine in days.
 	 * @note Age is in days; divide by 366 to get per year.
 	 */
-	static SQInteger GetMaxAge(EngineID engine_id);
+	static ScriptDate::Date GetMaxAge(EngineID engine_id);
 
 	/**
 	 * Get the running cost of an engine.

--- a/src/script/api/script_vehicle.hpp
+++ b/src/script/api/script_vehicle.hpp
@@ -11,6 +11,7 @@
 #define SCRIPT_VEHICLE_HPP
 
 #include "script_road.hpp"
+#include "script_date.hpp"
 
 /**
  * Class that handles all vehicle related functions.
@@ -189,7 +190,7 @@ public:
 	 * @return The current age the vehicle has.
 	 * @note The age is in days.
 	 */
-	static SQInteger GetAge(VehicleID vehicle_id);
+	static ScriptDate::Date GetAge(VehicleID vehicle_id);
 
 	/**
 	 * Get the current age of a second (or third, etc.) engine in a train vehicle.
@@ -200,7 +201,7 @@ public:
 	 * @return The current age the vehicle has.
 	 * @note The age is in days.
 	 */
-	static SQInteger GetWagonAge(VehicleID vehicle_id, SQInteger wagon);
+	static ScriptDate::Date GetWagonAge(VehicleID vehicle_id, SQInteger wagon);
 
 	/**
 	 * Get the maximum age of a vehicle.
@@ -209,7 +210,7 @@ public:
 	 * @return The maximum age the vehicle has.
 	 * @note The age is in days.
 	 */
-	static SQInteger GetMaxAge(VehicleID vehicle_id);
+	static ScriptDate::Date GetMaxAge(VehicleID vehicle_id);
 
 	/**
 	 * Get the age a vehicle has left (maximum - current).
@@ -218,7 +219,7 @@ public:
 	 * @return The age the vehicle has left.
 	 * @note The age is in days.
 	 */
-	static SQInteger GetAgeLeft(VehicleID vehicle_id);
+	static ScriptDate::Date GetAgeLeft(VehicleID vehicle_id);
 
 	/**
 	 * Get the current speed of a vehicle.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
I'm not sure this is the right approach, but the problem I'm trying to address here is due to the Wallclock feature.
Some AIs use functions which use the Economy timer, mixed with functions that use Calendar timer. This results in broken behaviour. As an example, my AI tries to get vehicle current age to determine whether a running route is deemed profitable, but it bases that on values given by AIDate.GetCurrentDate and AIVehicle.GetAge. The values can't be used together like this. It breaks the logic in decision making. I also use some other logic to decide when to replace vehicles with old age. This one is tricky now, because AIVehicle.GetAgeLeft, albeit a small number, is now being used in the context of a dilated amount of time. It's going to depend on the use case.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Changes `ScriptEngine::GetMaxAge`, `ScriptVehicle::GetAge`, `ScriptVehicle::GetWagonAge`, `ScriptVehicle::GetMaxAge` and `ScriptVehicle::GetAgeLeft` return values depending on `TimeMode`.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
This PR is trying to do something so that AIs can chose which value they expect to get based on the timer mode in use, though I don't really have much faith for old unmaintained AIs. There was only one timer before, and it's not possible to assume they always meant the returned values were of Economy timer or Calendar timer.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
