### PR TITLE
Codechange: Make the road vehicle path cache behave more like a std::deque

### DIFF
--- a/src/pathfinder/yapf/yapf_road.cpp
+++ b/src/pathfinder/yapf/yapf_road.cpp
@@ -393,8 +393,7 @@ public:
 			while (pNode->m_parent != nullptr) {
 				steps--;
 				if (pNode->GetIsChoice() && steps < YAPF_ROADVEH_PATH_CACHE_SEGMENTS) {
-					path_cache.td.push_front(pNode->GetTrackdir());
-					path_cache.tile.push_front(pNode->GetTile());
+					path_cache.push_front({ pNode->GetTile(), pNode->GetTrackdir() });
 				}
 				pNode = pNode->m_parent;
 			}
@@ -403,10 +402,7 @@ public:
 			assert(best_next_node.GetTile() == tile);
 			next_trackdir = best_next_node.GetTrackdir();
 			/* remove last element for the special case when tile == dest_tile */
-			if (path_found && !path_cache.empty() && tile == v->dest_tile) {
-				path_cache.td.pop_back();
-				path_cache.tile.pop_back();
-			}
+			if (path_found && !path_cache.empty() && tile == v->dest_tile) path_cache.pop_back();
 
 			/* Check if target is a station, and cached path ends within 8 tiles of the dest tile */
 			const Station *st = Yapf().GetDestinationStation();
@@ -417,10 +413,7 @@ public:
 					 * trim end of path cache within a number of tiles of road stop tile area */
 					TileArea non_cached_area = v->IsBus() ? st->bus_station : st->truck_station;
 					non_cached_area.Expand(YAPF_ROADVEH_PATH_CACHE_DESTINATION_LIMIT);
-					while (!path_cache.empty() && non_cached_area.Contains(path_cache.tile.back())) {
-						path_cache.td.pop_back();
-						path_cache.tile.pop_back();
-					}
+					while (!path_cache.empty() && non_cached_area.Contains(path_cache.back().tile)) path_cache.pop_back();
 				}
 			}
 		}

--- a/src/roadveh.h
+++ b/src/roadveh.h
@@ -82,8 +82,37 @@ void RoadVehUpdateCache(RoadVehicle *v, bool same_length = false);
 void GetRoadVehSpriteSize(EngineID engine, uint &width, uint &height, int &xoffs, int &yoffs, EngineImageType image_type);
 
 struct RoadVehPathCache {
+	friend class SlVehicleRoadVeh;
+private:
 	std::deque<Trackdir> td;
 	std::deque<TileIndex> tile;
+
+public:
+	struct Item {
+		TileIndex tile;
+		Trackdir trackdir;
+	};
+
+	Item front() { return {this->tile.front(), this->td.front()}; }
+	Item back() { return {this->tile.back(), this->td.back()}; }
+
+	inline void push_front(Item item)
+	{
+		this->tile.push_front(item.tile);
+		this->td.push_front(item.trackdir);
+	}
+
+	inline void pop_front()
+	{
+		this->td.pop_front();
+		this->tile.pop_front();
+	}
+
+	inline void pop_back()
+	{
+		this->td.pop_back();
+		this->tile.pop_back();
+	}
 
 	inline bool empty() const { return this->td.empty(); }
 

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -963,7 +963,7 @@ static Trackdir RoadFindPathToDest(RoadVehicle *v, TileIndex tile, DiagDirection
 
 	/* Only one track to choose between? */
 	if (KillFirstBit(trackdirs) == TRACKDIR_BIT_NONE) {
-		if (!v->path.empty() && v->path.tile.front() == tile) {
+		if (!v->path.empty() && v->path.front().tile == tile) {
 			/* Vehicle expected a choice here, invalidate its path. */
 			v->path.clear();
 		}
@@ -972,15 +972,14 @@ static Trackdir RoadFindPathToDest(RoadVehicle *v, TileIndex tile, DiagDirection
 
 	/* Attempt to follow cached path. */
 	if (!v->path.empty()) {
-		if (v->path.tile.front() != tile) {
+		if (v->path.front().tile != tile) {
 			/* Vehicle didn't expect a choice here, invalidate its path. */
 			v->path.clear();
 		} else {
-			Trackdir trackdir = v->path.td.front();
+			Trackdir trackdir = v->path.front().trackdir;
 
 			if (HasBit(trackdirs, trackdir)) {
-				v->path.td.pop_front();
-				v->path.tile.pop_front();
+				v->path.pop_front();
 				return_track(trackdir);
 			}
 
@@ -1291,8 +1290,7 @@ again:
 			if (u != nullptr) {
 				v->cur_speed = u->First()->cur_speed;
 				/* We might be blocked, prevent pathfinding rerun as we already know where we are heading to. */
-				v->path.tile.push_front(tile);
-				v->path.td.push_front(dir);
+				v->path.push_front({ tile, dir });
 				return false;
 			}
 		}
@@ -1407,8 +1405,7 @@ again:
 			if (u != nullptr) {
 				v->cur_speed = u->First()->cur_speed;
 				/* We might be blocked, prevent pathfinding rerun as we already know where we are heading to. */
-				v->path.tile.push_front(v->tile);
-				v->path.td.push_front(dir);
+				v->path.push_front({ v->tile, dir });
 				return false;
 			}
 		}


### PR DESCRIPTION
## Motivation / Problem

The Road Vehicle Path Cache is actually two std::deque's in one. That's a bit silly, but it is done to make saveload work. But the silliness has propaged into other parts of the code, where you basically have to push and pop items to both queues,

## Description

I tried to keep the two-queues-in-one an implementation detail. From the caller's perspective it works just like a single std::deque. Sort of, because I only implemented the functions that were needed ;)

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
