### PR TITLE
Change: Add dividers in vehicle group action dropdown

### DIFF
--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -454,16 +454,25 @@ DropDownList BaseVehicleListWindow::BuildActionDropdownList(bool show_autoreplac
 {
 	DropDownList list;
 
-	if (show_autoreplace) list.push_back(std::make_unique<DropDownListStringItem>(STR_VEHICLE_LIST_REPLACE_VEHICLES, ADI_REPLACE, false));
-	list.push_back(std::make_unique<DropDownListStringItem>(STR_VEHICLE_LIST_SEND_FOR_SERVICING, ADI_SERVICE, false));
-	list.push_back(std::make_unique<DropDownListStringItem>(this->vehicle_depot_name[this->vli.vtype], ADI_DEPOT, false));
+	/* Autoreplace actions. */
+	if (show_autoreplace) {
+		list.push_back(std::make_unique<DropDownListStringItem>(STR_VEHICLE_LIST_REPLACE_VEHICLES, ADI_REPLACE, false));
+		list.push_back(std::make_unique<DropDownListDividerItem>(-1, false));
+	}
 
+	/* Group actions. */
 	if (show_group) {
 		list.push_back(std::make_unique<DropDownListStringItem>(STR_GROUP_ADD_SHARED_VEHICLE, ADI_ADD_SHARED, false));
 		list.push_back(std::make_unique<DropDownListStringItem>(STR_GROUP_REMOVE_ALL_VEHICLES, ADI_REMOVE_ALL, false));
+		list.push_back(std::make_unique<DropDownListDividerItem>(-1, false));
 	} else if (show_create) {
 		list.push_back(std::make_unique<DropDownListStringItem>(STR_VEHICLE_LIST_CREATE_GROUP, ADI_CREATE_GROUP, false));
+		list.push_back(std::make_unique<DropDownListDividerItem>(-1, false));
 	}
+
+	/* Depot actions. */
+	list.push_back(std::make_unique<DropDownListStringItem>(STR_VEHICLE_LIST_SEND_FOR_SERVICING, ADI_SERVICE, false));
+	list.push_back(std::make_unique<DropDownListStringItem>(this->vehicle_depot_name[this->vli.vtype], ADI_DEPOT, false));
 
 	return list;
 }


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

The vehicle group action dropdown makes it easy to accidentally send all vehicles to a depot, as described in #11132.

In https://github.com/OpenTTD/OpenTTD/discussions/11132#discussioncomment-8635641 @DefinitelyNotRau117 suggests adding a divider to separate the safe actions from the depot actions and make it a bit harder to misclick.

I like the divider idea to better organize the actions, and if it makes it protects against misclicks, even better!

## Description

There are three types of actions: Autoreplace, group, and depot. I moved the "unsafe" depot actions to the bottom where they're furthest from the dropdown itself (and misclicks), and added dividers between each type of action.

![replace](https://github.com/OpenTTD/OpenTTD/assets/55058389/0e6c213b-1ca8-4516-8e9d-328c726039b2)

Implicit groups, like vehicles that share orders or serve a station, don't have the `Replace vehicles` action.

![shared-order-implicit-group](https://github.com/OpenTTD/OpenTTD/assets/55058389/4e75387d-5f06-426c-ad50-fa66ab68f2e5)

## Limitations

Dropdown highlights are currently broken, reported in #12283. I tried to choose the correct default selection but it didn't work, so I think it's a separate bug which is out of scope here.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
