### PR TITLE
Codechange: Make HouseSpec list and cached building counts dynamic.

### DIFF
--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -26,6 +26,7 @@
 #include "void_map.h"
 #include "town.h"
 #include "newgrf.h"
+#include "newgrf_house.h"
 #include "core/random_func.hpp"
 #include "core/backup_type.hpp"
 #include "progress.h"
@@ -311,6 +312,7 @@ void GenerateWorld(GenWorldMode mode, uint size_x, uint size_y, bool reset_setti
 
 	/* Load the right landscape stuff, and the NewGRFs! */
 	GfxLoadSprites();
+	InitializeBuildingCounts();
 	LoadStringWidthTable();
 
 	/* Re-init the windowing system */

--- a/src/house.h
+++ b/src/house.h
@@ -31,12 +31,6 @@ static const HouseID INVALID_HOUSE_ID = 0xFFFF;
 
 static const uint HOUSE_NUM_ACCEPTS = 16; ///< Max number of cargoes accepted by a tile
 
-/**
- * There can only be as many classes as there are new houses, plus one for
- * NO_CLASS, as the original houses don't have classes.
- */
-static const uint HOUSE_CLASS_MAX  = NUM_HOUSES - NEW_HOUSE_OFFSET + 1;
-
 enum BuildingFlags {
 	TILE_NO_FLAG         =       0,
 	TILE_SIZE_1x1        = 1U << 0,
@@ -123,14 +117,11 @@ struct HouseSpec {
 	byte minimum_life;                        ///< The minimum number of years this house will survive before the town rebuilds it
 	CargoTypes watched_cargoes;               ///< Cargo types watched for acceptance.
 
+	HouseID Index() const;
 	Money GetRemovalCost() const;
 
-	static inline HouseSpec *Get(size_t house_id)
-	{
-		assert(house_id < NUM_HOUSES);
-		extern HouseSpec _house_specs[];
-		return &_house_specs[house_id];
-	}
+	static std::vector<HouseSpec> &Specs();
+	static HouseSpec *Get(size_t house_id);
 };
 
 /**

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -2504,12 +2504,11 @@ struct CargoesRow {
 		} else {
 			/* Houses only display what is demanded. */
 			for (uint i = 0; i < cargo_fld->u.cargo.num_cargoes; i++) {
-				for (uint h = 0; h < NUM_HOUSES; h++) {
-					HouseSpec *hs = HouseSpec::Get(h);
-					if (!hs->enabled) continue;
+				for (const auto &hs : HouseSpec::Specs()) {
+					if (!hs.enabled) continue;
 
-					for (uint j = 0; j < lengthof(hs->accepts_cargo); j++) {
-						if (hs->cargo_acceptance[j] > 0 && cargo_fld->u.cargo.vertical_cargoes[i] == hs->accepts_cargo[j]) {
+					for (uint j = 0; j < lengthof(hs.accepts_cargo); j++) {
+						if (hs.cargo_acceptance[j] > 0 && cargo_fld->u.cargo.vertical_cargoes[i] == hs.accepts_cargo[j]) {
 							cargo_fld->ConnectCargo(cargo_fld->u.cargo.vertical_cargoes[i], false);
 							goto next_cargo;
 						}
@@ -2726,12 +2725,11 @@ struct IndustryCargoesWindow : public Window {
 		for (uint i = 0; i < length; i++) {
 			if (!IsValidCargoID(cargoes[i])) continue;
 
-			for (uint h = 0; h < NUM_HOUSES; h++) {
-				HouseSpec *hs = HouseSpec::Get(h);
-				if (!hs->enabled || !(hs->building_availability & climate_mask)) continue;
+			for (const auto &hs : HouseSpec::Specs()) {
+				if (!hs.enabled || !(hs.building_availability & climate_mask)) continue;
 
-				for (uint j = 0; j < lengthof(hs->accepts_cargo); j++) {
-					if (hs->cargo_acceptance[j] > 0 && cargoes[i] == hs->accepts_cargo[j]) return true;
+				for (uint j = 0; j < lengthof(hs.accepts_cargo); j++) {
+					if (hs.cargo_acceptance[j] > 0 && cargoes[i] == hs.accepts_cargo[j]) return true;
 				}
 			}
 		}

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -150,7 +150,6 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 	InitializeTrees();
 	InitializeIndustries();
 	InitializeObjects();
-	InitializeBuildingCounts();
 
 	InitializeNPF();
 

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -9329,20 +9329,18 @@ static void EnsureEarlyHouse(HouseZones bitmask)
 {
 	TimerGameCalendar::Year min_year = CalendarTime::MAX_YEAR;
 
-	for (int i = 0; i < NUM_HOUSES; i++) {
-		HouseSpec *hs = HouseSpec::Get(i);
-		if (hs == nullptr || !hs->enabled) continue;
-		if ((hs->building_availability & bitmask) != bitmask) continue;
-		if (hs->min_year < min_year) min_year = hs->min_year;
+	for (const auto &hs : HouseSpec::Specs()) {
+		if (!hs.enabled) continue;
+		if ((hs.building_availability & bitmask) != bitmask) continue;
+		if (hs.min_year < min_year) min_year = hs.min_year;
 	}
 
 	if (min_year == 0) return;
 
-	for (int i = 0; i < NUM_HOUSES; i++) {
-		HouseSpec *hs = HouseSpec::Get(i);
-		if (hs == nullptr || !hs->enabled) continue;
-		if ((hs->building_availability & bitmask) != bitmask) continue;
-		if (hs->min_year == min_year) hs->min_year = 0;
+	for (auto &hs : HouseSpec::Specs()) {
+		if (!hs.enabled) continue;
+		if ((hs.building_availability & bitmask) != bitmask) continue;
+		if (hs.min_year == min_year) hs.min_year = 0;
 	}
 }
 
@@ -9382,7 +9380,7 @@ static void FinaliseHouseArray()
 		}
 	}
 
-	for (size_t i = 0; i < NUM_HOUSES; i++) {
+	for (size_t i = 0; i < HouseSpec::Specs().size(); i++) {
 		HouseSpec *hs = HouseSpec::Get(i);
 		const HouseSpec *next1 = (i + 1 < NUM_HOUSES ? HouseSpec::Get(i + 1) : nullptr);
 		const HouseSpec *next2 = (i + 2 < NUM_HOUSES ? HouseSpec::Get(i + 2) : nullptr);

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -165,7 +165,11 @@ void HouseOverrideManager::SetEntitySpec(const HouseSpec *hs)
 		return;
 	}
 
-	*HouseSpec::Get(house_id) = *hs;
+	auto &house_specs = HouseSpec::Specs();
+
+	/* Now that we know we can use the given id, copy the spec to its final destination. */
+	if (house_id >= house_specs.size()) house_specs.resize(house_id + 1);
+	house_specs[house_id] = *hs;
 
 	/* Now add the overrides. */
 	for (int i = 0; i < this->max_offset; i++) {

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -24,8 +24,8 @@
 
 #include "safeguards.h"
 
-static BuildingCounts<uint32_t> _building_counts;
-static std::array<HouseClassMapping, HOUSE_CLASS_MAX> _class_mapping;
+static BuildingCounts<uint32_t> _building_counts{};
+static std::vector<HouseClassMapping> _class_mapping{};
 
 HouseOverrideManager _house_mngr(NEW_HOUSE_OFFSET, NUM_HOUSES, INVALID_HOUSE_ID);
 
@@ -38,6 +38,48 @@ static const GRFFile *GetHouseSpecGrf(HouseID house_id)
 {
 	const HouseSpec *hs  = HouseSpec::Get(house_id);
 	return (hs != nullptr) ? hs->grf_prop.grffile : nullptr;
+}
+
+extern const HouseSpec _original_house_specs[NEW_HOUSE_OFFSET];
+std::vector<HouseSpec> _house_specs;
+
+/**
+ * Get a reference to all HouseSpecs.
+ * @return Reference to vector of all HouseSpecs.
+ */
+std::vector<HouseSpec> &HouseSpec::Specs()
+{
+	return _house_specs;
+}
+
+/**
+ * Get the spec for a house ID.
+ * @param house_id The ID of the house.
+ * @return The HouseSpec associated with the ID.
+ */
+HouseSpec *HouseSpec::Get(size_t house_id)
+{
+	/* Empty house if index is out of range -- this might happen if NewGRFs are changed. */
+	static HouseSpec empty = {};
+
+	assert(house_id < NUM_HOUSES);
+	if (house_id >= _house_specs.size()) return &empty;
+	return &_house_specs[house_id];
+}
+
+/* Reset and initialise house specs. */
+void ResetHouses()
+{
+	_house_specs.clear();
+	_house_specs.reserve(std::size(_original_house_specs));
+
+	ResetHouseClassIDs();
+
+	/* Copy default houses. */
+	_house_specs.insert(std::end(_house_specs), std::begin(_original_house_specs), std::end(_original_house_specs));
+
+	/* Reset any overrides that have been set. */
+	_house_mngr.ResetOverride();
 }
 
 /**
@@ -74,32 +116,47 @@ uint32_t HouseResolverObject::GetDebugID() const
 
 void ResetHouseClassIDs()
 {
-	_class_mapping = {};
+	_class_mapping.clear();
+
+	/* Add initial entry for HOUSE_NO_CLASS. */
+	_class_mapping.emplace_back();
 }
 
 HouseClassID AllocateHouseClassID(byte grf_class_id, uint32_t grfid)
 {
 	/* Start from 1 because 0 means that no class has been assigned. */
-	for (int i = 1; i != lengthof(_class_mapping); i++) {
-		HouseClassMapping *map = &_class_mapping[i];
+	auto it = std::find_if(std::next(std::begin(_class_mapping)), std::end(_class_mapping), [grf_class_id, grfid](const HouseClassMapping &map) { return map.class_id == grf_class_id && map.grfid == grfid; });
 
-		if (map->class_id == grf_class_id && map->grfid == grfid) return (HouseClassID)i;
+	/* HouseClass not found, allocate a new one. */
+	if (it == std::end(_class_mapping)) it = _class_mapping.insert(it, {.grfid = grfid, .class_id = grf_class_id});
 
-		if (map->class_id == 0 && map->grfid == 0) {
-			map->class_id = grf_class_id;
-			map->grfid    = grfid;
-			return (HouseClassID)i;
-		}
-	}
-	return HOUSE_NO_CLASS;
+	return static_cast<HouseClassID>(std::distance(std::begin(_class_mapping), it));
 }
 
+/**
+ * Initialise building counts for a town.
+ * @param t Town cache to initialise.
+ */
+void InitializeBuildingCounts(Town *t)
+{
+	t->cache.building_counts.id_count.clear();
+	t->cache.building_counts.class_count.clear();
+	t->cache.building_counts.id_count.resize(HouseSpec::Specs().size());
+	t->cache.building_counts.class_count.resize(_class_mapping.size());
+}
+
+/**
+ * Initialise global building counts and all town building counts.
+ */
 void InitializeBuildingCounts()
 {
-	memset(&_building_counts, 0, sizeof(_building_counts));
+	_building_counts.id_count.clear();
+	_building_counts.class_count.clear();
+	_building_counts.id_count.resize(HouseSpec::Specs().size());
+	_building_counts.class_count.resize(_class_mapping.size());
 
 	for (Town *t : Town::Iterate()) {
-		memset(&t->cache.building_counts, 0, sizeof(t->cache.building_counts));
+		InitializeBuildingCounts(t);
 	}
 }
 

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -53,6 +53,15 @@ std::vector<HouseSpec> &HouseSpec::Specs()
 }
 
 /**
+ * Gets the index of this spec.
+ * @return The index.
+ */
+HouseID HouseSpec::Index() const
+{
+	return static_cast<HouseID>(this - _house_specs.data());
+}
+
+/**
  * Get the spec for a house ID.
  * @param house_id The ID of the house.
  * @return The HouseSpec associated with the ID.

--- a/src/newgrf_house.h
+++ b/src/newgrf_house.h
@@ -91,6 +91,7 @@ void ResetHouseClassIDs();
 HouseClassID AllocateHouseClassID(byte grf_class_id, uint32_t grfid);
 
 void InitializeBuildingCounts();
+void InitializeBuildingCounts(Town *t);
 void IncreaseBuildingCount(Town *t, HouseID house_id);
 void DecreaseBuildingCount(Town *t, HouseID house_id);
 

--- a/src/table/town_land.h
+++ b/src/table/town_land.h
@@ -1817,7 +1817,7 @@ static_assert(lengthof(_town_draw_tile_data) == (NEW_HOUSE_OFFSET) * 4 * 4);
 	bf, ba, true, GRFFileProps(INVALID_HOUSE_ID), 0, {COLOUR_BEGIN, COLOUR_BEGIN, COLOUR_BEGIN, COLOUR_BEGIN}, \
 	16, NO_EXTRA_FLAG, HOUSE_NO_CLASS, {0, 2, 0, 0}, 0, 0, 0}
 /** House specifications from original data */
-static const HouseSpec _original_house_specs[] = {
+extern const HouseSpec _original_house_specs[] = {
 	/**
 	 *                                                                              remove_rating_decrease
 	 *                                                                              |    mail_generation

--- a/src/town.h
+++ b/src/town.h
@@ -19,8 +19,8 @@
 
 template <typename T>
 struct BuildingCounts {
-	T id_count[NUM_HOUSES];
-	T class_count[HOUSE_CLASS_MAX];
+	std::vector<T> id_count;
+	std::vector<T> class_count;
 };
 
 static const uint CUSTOM_TOWN_NUMBER_DIFFICULTY  = 4; ///< value for custom town number in difficulty settings

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1941,6 +1941,7 @@ static void DoCreateTown(Town *t, TileIndex tile, uint32_t townnameparts, TownSi
 	UpdateTownRadius(t);
 	t->flags = 0;
 	t->cache.population = 0;
+	InitializeBuildingCounts(t);
 	/* Spread growth across ticks so even if there are many
 	 * similar towns they're unlikely to grow all in one tick */
 	t->grow_counter = t->index % Ticks::TOWN_GROWTH_TICKS;
@@ -3969,17 +3970,3 @@ extern const TileTypeProcs _tile_type_town_procs = {
 	GetFoundation_Town,      // get_foundation_proc
 	TerraformTile_Town,      // terraform_tile_proc
 };
-
-
-HouseSpec _house_specs[NUM_HOUSES];
-
-void ResetHouses()
-{
-	ResetHouseClassIDs();
-
-	auto insert = std::copy(std::begin(_original_house_specs), std::end(_original_house_specs), std::begin(_house_specs));
-	std::fill(insert, std::end(_house_specs), HouseSpec{});
-
-	/* Reset any overrides that have been set. */
-	_house_mngr.ResetOverride();
-}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

HouseSpecs and cached building counts use fixed size arrays. These arrays are
1) larger than necessary with default houses and
2) would be even larger if the house type limits were to be increased.

There are also some loops that go through all 512 possible House IDs, even though by default only 110 are used.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Replace HouseSpecs array with a vector, allocated as needed.

Change BuildingCounts to use vectors too -- these now require a bit of extra management to make sure they are initialized to the correct size when created.

This is based on how ObjectSpecs are dynamically allocated.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

`TownCache` is now 96 bytes + vector allocation, instead of a fixed 1880 bytes, however it now needs to allocate extra memory for each town, 2 bytes for each house type and 2 bytes for each class. By default this is  220 bytes and 2 bytes (there are no classes by default).

`BuildingCounts` could perhaps be resized on-demand in `IncreaseBuildingCount` which might reduce the (default) 220 bytes a little but means there'd be random allocations occurring.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
