### PR TITLE
Change: Calculate occupancy of drive through road stops from most recent entered vehicle

### DIFF
--- a/src/roadstop_base.h
+++ b/src/roadstop_base.h
@@ -33,12 +33,13 @@ struct RoadStop : RoadStopPool::PoolItem<&_roadstop_pool> {
 	private:
 		int length;      ///< The length of the stop in tile 'units'
 		int occupied;    ///< The amount of occupied stop in tile 'units'
+		int vehicles;    ///< The number of vehicles in the stop
 
 	public:
 		friend struct RoadStop; ///< Oh yeah, the road stop may play with me.
 
 		/** Create an entry */
-		Entry() : length(0), occupied(0) {}
+		Entry() : length(0), occupied(0), vehicles(0) {}
 
 		/**
 		 * Get the length of this drive through stop.
@@ -58,7 +59,7 @@ struct RoadStop : RoadStopPool::PoolItem<&_roadstop_pool> {
 			return this->occupied;
 		}
 
-		void Leave(const RoadVehicle *rv);
+		void Leave();
 		void Enter(const RoadVehicle *rv);
 		void CheckIntegrity(const RoadStop *rs) const;
 		void Rebuild(const RoadStop *rs, int side = -1);


### PR DESCRIPTION
## Motivation / Problem
Road vehicles sometimes queue behind each other outside of drive through stops instead of entering the stop from a different direction that is unoccupied. Unloading is delayed and profits down.

When there are two vehicles loading in a road stop and the first one in the queue leaves, the `occupied` level is reduced. However, although there is now free tile space in front of the second vehicle, it is inaccessible by vehicles arriving at the stop. The YAPF penalty is still calculated from the occupied level, even though the road stop tiles are inaccessible.

## Description
This change causes the occupied level of a drive through road stop to be calculated from the vehicle that most recently entered it.

This causes the YAPF to calculate a higher cost of using the stop, down-rating these routes. The result is that road vehicles will now sometimes favor a slightly longer route to enter the drive through stop from another direction when the occupancy is lower, however they will be able to unload sooner.

The occupancy level of the stop is reduced to 0 only when there are 0 vehicles in the stop.

## Limitations

In terms of gameplay limitations, this does not entirely solve vehicle queueing. Two or more vehicles can still queue if they have chosen the same route and arrive at the same time. However that scenario is a pre-existing behaviour. The idea solution would be for vehicles to be able to reserve bays/slots in road stops like trains can do, although that would be a much bigger change (beyond the scope of my ability). 

The player should still see less queueing with this patch.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
