### PR TITLE
Codechange: [Win32] Disable assert message box when no GUI

### DIFF
--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -126,6 +126,8 @@ const char *VideoDriver_Dedicated::Start(const StringList &)
 #ifdef _MSC_VER
 	/* Disable the MSVC assertion message box. */
 	_set_error_mode(_OUT_TO_STDERR);
+	_CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+	_CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
 #endif
 
 	Debug(driver, 1, "Loading dedicated server");

--- a/src/video/null_v.cpp
+++ b/src/video/null_v.cpp
@@ -24,6 +24,8 @@ const char *VideoDriver_Null::Start(const StringList &parm)
 #ifdef _MSC_VER
 	/* Disable the MSVC assertion message box. */
 	_set_error_mode(_OUT_TO_STDERR);
+	_CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+	_CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
 #endif
 
 	this->UpdateAutoResolution();


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Assertion failures from CRT during regression tests open an Abort/Retry/Ignore window.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Don't open this window for dedicated/null video driver.

Example output for https://github.com/OpenTTD/OpenTTD/actions/runs/8262899126/job/22603211234?pr=12287 with this PR included
```
...
      Start 61: regression_regression
61/62 Test #61: regression_regression ...........................................................................................................***Failed    5.78 sec
1: - 
1: + C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.39.33519/include/vector(1894) : Assertion failed: vector subscript out of range
2: - --TestInit--
2: + 
(9768 lines were expected but 2 were found)
CMake Error at D:/developpement/GitHub/glx22/OpenTTD/cmake/scripts/Regression.cmake:116 (message):
  Regression failed - Output in
  D:/developpement/GitHub/glx22/OpenTTD/out/build/x64-debug/regression_regression_output.txt
      Start 62: regression_stationlist
62/62 Test #62: regression_stationlist ..........................................................................................................***Failed    4.37 sec
1: - 
1: + C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.39.33519/include/vector(1894) : Assertion failed: vector subscript out of range
2: - --StationList--
2: + 
(128 lines were expected but 2 were found)
CMake Error at D:/developpement/GitHub/glx22/OpenTTD/cmake/scripts/Regression.cmake:116 (message):
  Regression failed - Output in
  D:/developpement/GitHub/glx22/OpenTTD/out/build/x64-debug/regression_stationlist_output.txt
97% tests passed, 2 tests failed out of 62
Total Test time (real) =  14.81 sec
The following tests FAILED:
	 61 - regression_regression (Failed)
	 62 - regression_stationlist (Failed)
Errors while running CTest
```

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
