### PR TITLE
Codechange: [CI] Use Azure Code Signing for Windows build

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -100,21 +100,6 @@ jobs:
       with:
         arch: ${{ matrix.host }}
 
-    - name: Import code signing certificate
-      shell: powershell
-      # If this is run on a fork, there may not be a certificate set up - continue in this case
-      continue-on-error: true
-      run: |
-        $tempFile = [System.IO.Path]::GetTempFileName()
-        $bytes = [System.Convert]::FromBase64String($env:WINDOWS_CERTIFICATE_P12)
-        [IO.File]::WriteAllBytes($tempFile, $bytes)
-        $pwd = ConvertTo-SecureString $env:WINDOWS_CERTIFICATE_PASSWORD -AsPlainText -Force
-        Import-PfxCertificate -FilePath $tempFile -CertStoreLocation Cert:\CurrentUser\My -Password $pwd
-        Remove-Item $tempFile
-      env:
-        WINDOWS_CERTIFICATE_P12: ${{ secrets.WINDOWS_CERTIFICATE_P12 }}
-        WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
-
     - name: Build (with installer)
       if: inputs.is_tag == 'true'
       shell: bash
@@ -131,7 +116,6 @@ jobs:
           -DHOST_BINARY_DIR=${GITHUB_WORKSPACE}/build-host \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DOPTION_SURVEY_KEY=${{ inputs.survey_key }} \
-          -DWINDOWS_CERTIFICATE_COMMON_NAME="${WINDOWS_CERTIFICATE_COMMON_NAME}" \
           # EOF
         echo "::endgroup::"
 
@@ -139,7 +123,12 @@ jobs:
         cmake --build . --target openttd
         echo "::endgroup::"
       env:
-        WINDOWS_CERTIFICATE_COMMON_NAME: ${{ secrets.WINDOWS_CERTIFICATE_COMMON_NAME }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        AZURE_CODESIGN_ACCOUNT_NAME: ${{ secrets.AZURE_CODESIGN_ACCOUNT_NAME }}
+        AZURE_CODESIGN_ENDPOINT: ${{ secrets.AZURE_CODESIGN_ENDPOINT }}
+        AZURE_CODESIGN_PROFILE_NAME: ${{ secrets.AZURE_CODESIGN_PROFILE_NAME }}
 
     - name: Build (without installer)
       if: inputs.is_tag != 'true'
@@ -156,7 +145,6 @@ jobs:
           -DHOST_BINARY_DIR=${GITHUB_WORKSPACE}/build-host \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DOPTION_SURVEY_KEY=${{ inputs.survey_key }} \
-          -DWINDOWS_CERTIFICATE_COMMON_NAME="${WINDOWS_CERTIFICATE_COMMON_NAME}" \
           # EOF
         echo "::endgroup::"
 
@@ -164,7 +152,12 @@ jobs:
         cmake --build . --target openttd
         echo "::endgroup::"
       env:
-        WINDOWS_CERTIFICATE_COMMON_NAME: ${{ secrets.WINDOWS_CERTIFICATE_COMMON_NAME }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        AZURE_CODESIGN_ACCOUNT_NAME: ${{ secrets.AZURE_CODESIGN_ACCOUNT_NAME }}
+        AZURE_CODESIGN_ENDPOINT: ${{ secrets.AZURE_CODESIGN_ENDPOINT }}
+        AZURE_CODESIGN_PROFILE_NAME: ${{ secrets.AZURE_CODESIGN_PROFILE_NAME }}
 
     - name: Create breakpad symbols
       shell: bash
@@ -198,13 +191,15 @@ jobs:
     - name: Sign installer
       if: inputs.is_tag == 'true'
       shell: bash
-      # If this is run on a fork, there may not be a certificate set up - continue in this case
-      continue-on-error: true
       run: |
-        cd ${GITHUB_WORKSPACE}/build/bundles
-        ../../os/windows/sign.bat *.exe "${WINDOWS_CERTIFICATE_COMMON_NAME}"
+        ${GITHUB_WORKSPACE}/os/windows/sign.bat "${GITHUB_WORKSPACE}/build/bundles"
       env:
-        WINDOWS_CERTIFICATE_COMMON_NAME: ${{ secrets.WINDOWS_CERTIFICATE_COMMON_NAME }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        AZURE_CODESIGN_ACCOUNT_NAME: ${{ secrets.AZURE_CODESIGN_ACCOUNT_NAME }}
+        AZURE_CODESIGN_ENDPOINT: ${{ secrets.AZURE_CODESIGN_ENDPOINT }}
+        AZURE_CODESIGN_PROFILE_NAME: ${{ secrets.AZURE_CODESIGN_PROFILE_NAME }}
 
     - name: Store bundles
       uses: actions/upload-artifact@v4

--- a/cmake/InstallAndPackage.cmake
+++ b/cmake/InstallAndPackage.cmake
@@ -172,10 +172,10 @@ elseif(WIN32)
 
     set(CPACK_PACKAGE_FILE_NAME "openttd-#CPACK_PACKAGE_VERSION#-windows-${CPACK_SYSTEM_NAME}")
 
-    if(WINDOWS_CERTIFICATE_COMMON_NAME)
+    if(DEFINED ENV{AZURE_CODESIGN_PROFILE_NAME})
       add_custom_command(TARGET openttd
         POST_BUILD
-        COMMAND "${CMAKE_SOURCE_DIR}/os/windows/sign.bat" "$<TARGET_FILE:openttd>" "${WINDOWS_CERTIFICATE_COMMON_NAME}"
+        COMMAND "${CMAKE_SOURCE_DIR}/os/windows/sign.bat" "${BINARY_DESTINATION_DIR}"
       )
     endif()
 elseif(UNIX)

--- a/os/windows/sign.bat
+++ b/os/windows/sign.bat
@@ -1,18 +1,2 @@
 @echo off
-REM Signing script
-REM Arguments: sign.bat exe_to_sign certificate_subject_name
-
-REM This is a loose wrapper around the Microsoft signtool application (included in the Windows SDK).
-REM See https://docs.microsoft.com/en-us/dotnet/framework/tools/signtool-exe for more details.
-
-REM Path to signtool.exe
-IF NOT DEFINED SIGNTOOL_PATH (SET SIGNTOOL_PATH=signtool)
-
-REM URL of the timestamp server
-IF NOT DEFINED SIGNTOOL_TIMESTAMP_URL (SET SIGNTOOL_TIMESTAMP_URL=http://timestamp.digicert.com)
-
-REM Sign with SHA-1 for Windows 7 and below
-"%SIGNTOOL_PATH%" sign -v -n %2 -t %SIGNTOOL_TIMESTAMP_URL% -fd sha1 %1
-
-REM Sign with SHA-256 for Windows 8 and above
-"%SIGNTOOL_PATH%" sign -v -n %2 -tr %SIGNTOOL_TIMESTAMP_URL% -fd sha256 -td sha256 -as %1
+pwsh -File "%~dp0sign_azure.ps1" %1

--- a/os/windows/sign_azure.ps1
+++ b/os/windows/sign_azure.ps1
@@ -1,0 +1,40 @@
+# Signing script for Azure Code Signing
+# Arguments: sign_azure.ps1 path_to_sign
+#
+# Environment variables must be set up before use:
+#
+# AZURE_TENANT_ID
+# AZURE_CLIENT_ID
+# AZURE_CLIENT_SECRET
+# AZURE_CODESIGN_ACCOUNT_NAME
+# AZURE_CODESIGN_ENDPOINT
+# AZURE_CODESIGN_PROFILE_NAME
+
+Param
+(
+    # Files folder
+    [Parameter(Mandatory=$true, Position=0)]
+    $FilesFolder
+)
+
+if (!$Env:AZURE_CODESIGN_ENDPOINT -or !$Env:AZURE_CODESIGN_ACCOUNT_NAME -or !$Env:AZURE_CODESIGN_PROFILE_NAME -or
+	!$Env:AZURE_TENANT_ID -or !$Env:AZURE_CLIENT_ID -or !$Env:AZURE_CLIENT_SECRET)
+{
+	"Code signing variables not found; most likely running in a fork. Skipping signing."
+	exit
+}
+
+Install-Module -Name AzureCodeSigning -Scope CurrentUser -RequiredVersion 0.3.0 -Force -Repository PSGallery
+
+$params = @{}
+
+$params["Endpoint"] = $Env:AZURE_CODESIGN_ENDPOINT
+$params["CodeSigningAccountName"] = $Env:AZURE_CODESIGN_ACCOUNT_NAME
+$params["CertificateProfileName"] = $Env:AZURE_CODESIGN_PROFILE_NAME
+$params["FilesFolder"] = $FilesFolder
+$params["FilesFolderFilter"] = "exe"
+$params["FileDigest"] = "SHA256"
+$params["TimestampRfc3161"] = "http://timestamp.acs.microsoft.com"
+$params["TimestampDigest"] = "SHA256"
+
+Invoke-AzureCodeSigning @params


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Our current code signing certificate is due for renewal in a few months, and due to recent policy changes by the Certificate Authority cabal, you now need to store a certificate on a pricey hardware dongle or a certified HSM vault. For something compatible with GitHub Actions, we'd probably need to use an Azure HSM vault, but would still need to pay several hundred GBP per year for a certificate, a considerable increase compared with what we've got just now.

However, the good folks at [ImageMagick](https://github.com/dlemstra/github-stories/blob/main/2023/ImageMagick%20now%20uses%20Azure%20Code%20Signing/Readme.md) alerted me to a preview programme Microsoft is running, called Azure Code Signing. This offers a more Mac-like solution, with Microsoft providing a code signing certificate. I applied for us to join their preview programme, and was accepted. Currently, the preview is free; it's not yet clear when this will become generally available or what pricing may be involved, but one would hope it'll be considerably cheaper than the alternatives.

## Description

This PR adds support for Azure Code Signing to the build process. To keep things fairly simple, I've created a `sign_azure.bat` script that acts as an alternative for `sign.bat` (which is called within the CMake process). Microsoft does offer a GitHub Action for Azure Code Signing, but that would involve a bit more surgery. (If we'd rather do things that way, however, it's certainly possible.) CMake will choose which code signing method to use based upon which environment variables are defined, as somebody might want to fork OpenTTD and sign it with a traditional certificate perhaps.

The actual code signing is performed via a PowerShell script. Microsoft takes a checksum of the binary, uploads it to Azure, where a signature is generated and returned (so the binaries themselves are not transferred). We don't get access to the actual certificate (which is valid for only 3 days before being regenerated automatically).

## Limitations

If a user happens to be using an older version of Windows that hasn't been kept up-to-date, they may receive a certificate warning as the certification authority root certificate dates back to 2020 and has only been included in Windows for a couple of years. It's quite possible this would happen with other recent code signing certificates anyway, though.

The Azure client secret is valid for a maximum of 2 years, so will need to be regenerated and updated in the GitHub secrets store periodically.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
