### PR TITLE
Codechange: split initiating of joining and identification of the client

### DIFF
--- a/src/network/core/tcp_game.cpp
+++ b/src/network/core/tcp_game.cpp
@@ -81,6 +81,7 @@ NetworkRecvStatus NetworkGameSocketHandler::HandlePacket(Packet &p)
 		case PACKET_CLIENT_GAME_INFO:             return this->Receive_CLIENT_GAME_INFO(p);
 		case PACKET_SERVER_GAME_INFO:             return this->Receive_SERVER_GAME_INFO(p);
 		case PACKET_SERVER_CLIENT_INFO:           return this->Receive_SERVER_CLIENT_INFO(p);
+		case PACKET_CLIENT_IDENTIFY:              return this->Receive_CLIENT_IDENTIFY(p);
 		case PACKET_SERVER_NEED_GAME_PASSWORD:    return this->Receive_SERVER_NEED_GAME_PASSWORD(p);
 		case PACKET_SERVER_NEED_COMPANY_PASSWORD: return this->Receive_SERVER_NEED_COMPANY_PASSWORD(p);
 		case PACKET_CLIENT_GAME_PASSWORD:         return this->Receive_CLIENT_GAME_PASSWORD(p);
@@ -162,6 +163,7 @@ NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_ERROR(Packet &) { ret
 NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_GAME_INFO(Packet &) { return this->ReceiveInvalidPacket(PACKET_CLIENT_GAME_INFO); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_GAME_INFO(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_GAME_INFO); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_CLIENT_INFO(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_CLIENT_INFO); }
+NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_IDENTIFY(Packet &) { return this->ReceiveInvalidPacket(PACKET_CLIENT_IDENTIFY); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_NEED_GAME_PASSWORD(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_NEED_GAME_PASSWORD); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_NEED_COMPANY_PASSWORD(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_NEED_COMPANY_PASSWORD); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_GAME_PASSWORD(Packet &) { return this->ReceiveInvalidPacket(PACKET_CLIENT_GAME_PASSWORD); }

--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -56,7 +56,10 @@ enum PacketGameType : uint8_t {
 	 * the map and other important data.
 	 */
 
-	/* After the join step, the first is checking NewGRFs. */
+	/* After the initial join, the next step is identification. */
+	PACKET_CLIENT_IDENTIFY,              ///< Client telling the server the client's name and requested company.
+
+	/* After the identify step, the next is checking NewGRFs. */
 	PACKET_SERVER_CHECK_NEWGRFS,         ///< Server sends NewGRF IDs and MD5 checksums for the client to check.
 	PACKET_CLIENT_NEWGRFS_CHECKED,       ///< Client acknowledges that it has all required NewGRFs.
 
@@ -162,10 +165,13 @@ protected:
 
 	/**
 	 * Try to join the server:
-	 * string  OpenTTD revision (norev000 if no revision).
-	 * string  Name of the client (max NETWORK_NAME_LENGTH).
-	 * uint8_t   ID of the company to play as (1..MAX_COMPANIES).
-	 * uint8_t   ID of the clients Language.
+	 * string   OpenTTD revision (norev000 if no revision).
+	 * uint32_t NewGRF version (added in 1.2).
+	 * string   Name of the client (max NETWORK_NAME_LENGTH) (removed in 15).
+	 * uint8_t  ID of the company to play as (1..MAX_COMPANIES) (removed in 15).
+	 * uint8_t  ID of the clients Language (removed in 15).
+	 * string   Client's unique identifier (removed in 1.0).
+	 *
 	 * @param p The packet that was just received.
 	 */
 	virtual NetworkRecvStatus Receive_CLIENT_JOIN(Packet &p);
@@ -198,6 +204,14 @@ protected:
 	 * @param p The packet that was just received.
 	 */
 	virtual NetworkRecvStatus Receive_SERVER_CLIENT_INFO(Packet &p);
+
+	/**
+	 * The client tells the server about the identity of the client:
+	 * string  Name of the client (max NETWORK_NAME_LENGTH).
+	 * uint8_t ID of the company to play as (1..MAX_COMPANIES).
+	 * @param p The packet that was just received.
+	 */
+	virtual NetworkRecvStatus Receive_CLIENT_IDENTIFY(Packet &p);
 
 	/**
 	 * Indication to the client that the server needs a game password.

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -347,9 +347,18 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendJoin()
 	auto p = std::make_unique<Packet>(my_client, PACKET_CLIENT_JOIN);
 	p->Send_string(GetNetworkRevisionString());
 	p->Send_uint32(_openttd_newgrf_version);
+	my_client->SendPacket(std::move(p));
+
+	return ClientNetworkGameSocketHandler::SendIdentify();
+}
+
+NetworkRecvStatus ClientNetworkGameSocketHandler::SendIdentify()
+{
+	Debug(net, 9, "Client::SendIdentify()");
+
+	auto p = std::make_unique<Packet>(my_client, PACKET_CLIENT_IDENTIFY);
 	p->Send_string(_settings_client.network.client_name); // Client name
-	p->Send_uint8 (_network_join.company);     // PlayAs
-	p->Send_uint8 (0); // Used to be language
+	p->Send_uint8(_network_join.company); // PlayAs
 	my_client->SendPacket(std::move(p));
 	return NETWORK_RECV_STATUS_OKAY;
 }

--- a/src/network/network_client.h
+++ b/src/network/network_client.h
@@ -71,6 +71,7 @@ protected:
 	static NetworkRecvStatus SendNewGRFsOk();
 	static NetworkRecvStatus SendGetMap();
 	static NetworkRecvStatus SendMapOk();
+	static NetworkRecvStatus SendIdentify();
 	void CheckConnection();
 public:
 	ClientNetworkGameSocketHandler(SOCKET s, const std::string &connection_string);

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -24,6 +24,7 @@ extern NetworkClientSocketPool _networkclientsocket_pool;
 class ServerNetworkGameSocketHandler : public NetworkClientSocketPool::PoolItem<&_networkclientsocket_pool>, public NetworkGameSocketHandler, public TCPListenHandler<ServerNetworkGameSocketHandler, PACKET_SERVER_FULL, PACKET_SERVER_BANNED> {
 protected:
 	NetworkRecvStatus Receive_CLIENT_JOIN(Packet &p) override;
+	NetworkRecvStatus Receive_CLIENT_IDENTIFY(Packet &p) override;
 	NetworkRecvStatus Receive_CLIENT_GAME_INFO(Packet &p) override;
 	NetworkRecvStatus Receive_CLIENT_GAME_PASSWORD(Packet &p) override;
 	NetworkRecvStatus Receive_CLIENT_COMPANY_PASSWORD(Packet &p) override;
@@ -50,6 +51,7 @@ public:
 	/** Status of a client */
 	enum ClientStatus {
 		STATUS_INACTIVE,      ///< The client is not connected nor active.
+		STATUS_IDENTIFY,      ///< The client is identifying itself.
 		STATUS_NEWGRFS_CHECK, ///< The client is checking NewGRFs.
 		STATUS_AUTH_GAME,     ///< The client is authorizing with game (server) password.
 		STATUS_AUTH_COMPANY,  ///< The client is authorizing with company password.


### PR DESCRIPTION
## Motivation / Problem

When encrypting the communication between the server and the client, it would be bad to send the identity of the client over the wire before encryption got initiated.


## Description

At the moment you start the joining process by sending a "CLIENT_JOIN" packet with your (NewGRF) version, client name and which company you want to join. 
At the moment the server first checks the (NewGRF) version. If they do not match, you are kicked out. When they do match, it will create a `NetworkClientInfo` with your name attached to the socket.

This PR just adds an intermediate state `IDENTIFY` and splits the "CLIENT_JOIN" into "CLIENT_JOIN" with just the (NewGRF) version, and "CLIENT_IDENTIFY" with the client name and company to play as.

This will make it possible to do the key exchange between `CLIENT_JOIN` and the identification.


## Limitations

Built upon #12294, so that needs to be merged first or the combined PRs gets merged.

Technically the "CLIENT_JOIN" packet is not fully backward compatible. When trying to join a server with a version before 15, we won't be sending the client's name and company to join any more; however, since the version check happens and the NewGRF version is incremented with each major release, this should not be a big issue as the client would get disconnected before that. Except when server/client are built without version string between branching of 14 and merging this.
When trying to join a server with a version before 1.2, there is no NewGRF version. So technically we should not be sending that to those versions, but the ship for fixing that has long sailed. Even then, there are only problems when server/client is built without version string and then the version check might not fail but things will fail at a later point. Since 14 already had that problem, it's not something to be solved by this PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
