### PR TITLE
Change: Add per-company group numbers.

### DIFF
--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -6093,7 +6093,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
   GetNumEngines():          1
   GetNumEngines():          1
   GetNumEngines():          0
-  GetName():                Group 0
+  GetName():                Group 1
   GetName():                (null : 0x00000000)
   AIVehicle.SellVehicle():  true
   AITile.DemolishTile():    true

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -146,6 +146,7 @@ struct Company : CompanyProperties, CompanyPool::PoolItem<&_company_pool> {
 	CompanyInfrastructure infrastructure; ///< NOSAVE: Counts of company owned infrastructure.
 
 	FreeUnitIDGenerator freeunits[VEH_COMPANY_END];
+	FreeUnitIDGenerator freegroups;
 
 	Money GetMaxLoan() const;
 

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -424,8 +424,12 @@ void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner)
 	if (new_owner == INVALID_OWNER) {
 		RemoveAllGroupsForCompany(old_owner);
 	} else {
+		Company *c = Company::Get(old_owner);
 		for (Group *g : Group::Iterate()) {
-			if (g->owner == old_owner) g->owner = new_owner;
+			if (g->owner == old_owner) {
+				g->owner = new_owner;
+				g->number = c->freegroups.UseID(c->freegroups.NextID());
+			}
 		}
 	}
 

--- a/src/group.h
+++ b/src/group.h
@@ -81,6 +81,7 @@ struct Group : GroupPool::PoolItem<&_group_pool> {
 	bool folded;                ///< NOSAVE: Is this group folded in the group view?
 
 	GroupID parent;             ///< Parent group
+	uint16_t number; ///< Per-company group number.
 
 	Group(CompanyID owner = INVALID_COMPANY);
 };

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -350,8 +350,9 @@ std::tuple<CommandCost, GroupID> CmdCreateGroup(DoCommandFlag flags, VehicleType
 		g->vehicle_type = vt;
 		g->parent = INVALID_GROUP;
 
+		Company *c = Company::Get(g->owner);
+		g->number = c->freegroups.UseID(c->freegroups.NextID());
 		if (pg == nullptr) {
-			const Company *c = Company::Get(_current_company);
 			g->livery.colour1 = c->livery[LS_DEFAULT].colour1;
 			g->livery.colour2 = c->livery[LS_DEFAULT].colour2;
 			if (c->settings.renew_keep_length) SetBit(g->flags, GroupFlags::GF_REPLACE_WAGON_REMOVAL);
@@ -397,14 +398,15 @@ CommandCost CmdDeleteGroup(DoCommandFlag flags, GroupID group_id)
 		/* Update backupped orders if needed */
 		OrderBackup::ClearGroup(g->index);
 
-		/* If we set an autoreplace for the group we delete, remove it. */
-		if (_current_company < MAX_COMPANIES) {
-			Company *c;
+		if (g->owner < MAX_COMPANIES) {
+			Company *c = Company::Get(g->owner);
 
-			c = Company::Get(_current_company);
+			/* If we set an autoreplace for the group we delete, remove it. */
 			for (EngineRenew *er : EngineRenew::Iterate()) {
 				if (er->group_id == g->index) RemoveEngineReplacementForCompany(c, er->from, g->index, flags);
 			}
+
+			c->freegroups.ReleaseID(g->number);
 		}
 
 		VehicleType vt = g->vehicle_type;

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -180,7 +180,7 @@ void BuildGuiGroupList(GUIGroupList &dst, bool fold, Owner owner, VehicleType ve
 		}
 
 		int r = StrNaturalCompare(last_group[0].second, last_group[1].second); // Sort by name (natural sorting).
-		if (r == 0) return a.group->index < b.group->index;
+		if (r == 0) return a.group->number < b.group->number;
 		return r < 0;
 	});
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3286,6 +3286,17 @@ bool AfterLoadGame()
 		UpdateCompanyLiveries(c);
 	}
 
+	/* Update free group numbers data for each company, required regardless of savegame version. */
+	for (Group *g : Group::Iterate()) {
+		Company *c = Company::Get(g->owner);
+		if (IsSavegameVersionBefore(SLV_GROUP_NUMBERS)) {
+			/* Use the index as group number when converting old savegames. */
+			g->number = c->freegroups.UseID(g->index);
+		} else {
+			c->freegroups.UseID(g->number);
+		}
+	}
+
 	AfterLoadLabelMaps();
 	AfterLoadCompanyStats();
 	AfterLoadStoryBook();

--- a/src/saveload/group_sl.cpp
+++ b/src/saveload/group_sl.cpp
@@ -26,6 +26,7 @@ static const SaveLoad _group_desc[] = {
 	 SLE_CONDVAR(Group, livery.colour1,     SLE_UINT8,                     SLV_GROUP_LIVERIES, SL_MAX_VERSION),
 	 SLE_CONDVAR(Group, livery.colour2,     SLE_UINT8,                     SLV_GROUP_LIVERIES, SL_MAX_VERSION),
 	 SLE_CONDVAR(Group, parent,             SLE_UINT16,                    SLV_189, SL_MAX_VERSION),
+	 SLE_CONDVAR(Group, number, SLE_UINT16, SLV_GROUP_NUMBERS, SL_MAX_VERSION),
 };
 
 struct GRPSChunkHandler : ChunkHandler {

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -380,6 +380,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_VEHICLE_ECONOMY_AGE,                ///< 334  PR#12141 v14.0 Add vehicle age in economy year, for profit stats minimum age
 
 	SLV_COMPANY_ALLOW_LIST,                 ///< 335  PR#12337 Saving of list of client keys that are allowed to join this company.
+	SLV_GROUP_NUMBERS,                      ///< 336  PR#12297 Add per-company group numbers.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1539,7 +1539,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 						auto tmp_params = MakeParameters(g->name);
 						GetStringWithArgs(builder, STR_JUST_RAW_STRING, tmp_params);
 					} else {
-						auto tmp_params = MakeParameters(g->index);
+						auto tmp_params = MakeParameters(g->number);
 						GetStringWithArgs(builder, STR_FORMAT_GROUP_NAME, tmp_params);
 					}
 					break;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When creating groups, the default group name is `Group <index>`, where index is a global number starting at zero, and shared by all companies.

This results in arbitrary looking numbers when creating groups and is affected by other companies, and the first group created by a company is "Group 0",

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/a2099dea-5c62-4a4f-9f24-6f60c54a6b5a)


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, assign a per-company unique number to each group. The first group for each company will be named "Group 1". Other companies creating/deleting groups no longer affects another company's groups.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/04480d34-48ff-49d8-8ade-33de9354cd24)

This uses the existing FreeUnitIDGenerator system (which is now slightly misnamed) to get the next available free number. Similar to unit numbers, when a company is bought out, new group numbers are allocated.

Requires a savegame bump to store the group number.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Regression test results change as it expected to see "Group 0", but the first group is now "Group 1".

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
