### PR TITLE
Feature: encrypted game sockets

### DIFF
--- a/src/network/core/core.h
+++ b/src/network/core/core.h
@@ -13,6 +13,7 @@
 #define NETWORK_CORE_CORE_H
 
 #include "../../newgrf_config.h"
+#include "../network_crypto.h"
 #include "config.h"
 
 bool NetworkCoreInitialize();
@@ -42,6 +43,11 @@ struct Packet;
 class NetworkSocketHandler {
 private:
 	bool has_quit; ///< Whether the current client has quit/send a bad packet
+
+protected:
+	friend struct Packet;
+	std::unique_ptr<class NetworkEncryptionHandler> receive_encryption_handler; ///< The handler for decrypting received packets.
+	std::unique_ptr<class NetworkEncryptionHandler> send_encryption_handler; ///< The handler for encrypting sent packets.
 
 public:
 	/** Create a new unbound socket */

--- a/src/network/core/packet.cpp
+++ b/src/network/core/packet.cpp
@@ -223,7 +223,7 @@ bool Packet::CanReadFromPacket(size_t bytes_to_read, bool close_connection)
  */
 bool Packet::HasPacketSizeData() const
 {
-	return this->pos >= sizeof(PacketSize);
+	return this->pos >= EncodedLengthOfPacketSize();
 }
 
 /**
@@ -250,10 +250,10 @@ bool Packet::ParsePacketSize()
 	/* If the size of the packet is less than the bytes required for the size and type of
 	 * the packet, or more than the allowed limit, then something is wrong with the packet.
 	 * In those cases the packet can generally be regarded as containing garbage data. */
-	if (size < sizeof(PacketSize) + sizeof(PacketType) || size > this->limit) return false;
+	if (size < EncodedLengthOfPacketSize() + EncodedLengthOfPacketType() || size > this->limit) return false;
 
 	this->buffer.resize(size);
-	this->pos = sizeof(PacketSize);
+	this->pos = static_cast<PacketSize>(EncodedLengthOfPacketSize());
 	return true;
 }
 
@@ -263,7 +263,7 @@ bool Packet::ParsePacketSize()
 void Packet::PrepareToRead()
 {
 	/* Put the position on the right place */
-	this->pos = sizeof(PacketSize);
+	this->pos = static_cast<PacketSize>(EncodedLengthOfPacketSize());
 }
 
 /**
@@ -272,8 +272,8 @@ void Packet::PrepareToRead()
  */
 PacketType Packet::GetPacketType() const
 {
-	assert(this->Size() >= sizeof(PacketSize) + sizeof(PacketType));
-	return static_cast<PacketType>(buffer[sizeof(PacketSize)]);
+	assert(this->Size() >= EncodedLengthOfPacketSize() + EncodedLengthOfPacketType());
+	return static_cast<PacketType>(buffer[EncodedLengthOfPacketSize()]);
 }
 
 /**

--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -40,6 +40,8 @@ typedef uint8_t  PacketType; ///< Identifier for the packet
  *     (year % 4 == 0) and ((year % 100 != 0) or (year % 400 == 0))
  */
 struct Packet {
+	static constexpr size_t EncodedLengthOfPacketSize() { return sizeof(PacketSize); }
+	static constexpr size_t EncodedLengthOfPacketType() { return sizeof(PacketType); }
 private:
 	/** The current read/write position in the packet */
 	PacketSize pos;
@@ -52,7 +54,7 @@ private:
 	NetworkSocketHandler *cs;
 
 public:
-	Packet(NetworkSocketHandler *cs, size_t limit, size_t initial_read_size = sizeof(PacketSize));
+	Packet(NetworkSocketHandler *cs, size_t limit, size_t initial_read_size = EncodedLengthOfPacketSize());
 	Packet(NetworkSocketHandler *cs, PacketType type, size_t limit = COMPAT_MTU);
 
 	/* Sending/writing of packets */

--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -74,7 +74,7 @@ public:
 	bool HasPacketSizeData() const;
 	bool ParsePacketSize();
 	size_t Size() const;
-	void PrepareToRead();
+	[[nodiscard]] bool PrepareToRead();
 	PacketType GetPacketType() const;
 
 	bool   CanReadFromPacket(size_t bytes_to_read, bool close_connection = false);

--- a/src/network/core/tcp.cpp
+++ b/src/network/core/tcp.cpp
@@ -188,7 +188,11 @@ std::unique_ptr<Packet> NetworkTCPSocketHandler::ReceivePacket()
 		}
 	}
 
-	p.PrepareToRead();
+	if (!p.PrepareToRead()) {
+		Debug(net, 0, "Invalid packet received (too small / decryption error)");
+		this->CloseConnection();
+		return nullptr;
+	}
 	return std::move(this->packet_recv);
 }
 

--- a/src/network/core/tcp_game.cpp
+++ b/src/network/core/tcp_game.cpp
@@ -85,7 +85,7 @@ NetworkRecvStatus NetworkGameSocketHandler::HandlePacket(Packet &p)
 		case PACKET_SERVER_AUTH_REQUEST:          return this->Receive_SERVER_AUTH_REQUEST(p);
 		case PACKET_SERVER_NEED_COMPANY_PASSWORD: return this->Receive_SERVER_NEED_COMPANY_PASSWORD(p);
 		case PACKET_CLIENT_AUTH_RESPONSE:         return this->Receive_CLIENT_AUTH_RESPONSE(p);
-		case PACKET_SERVER_AUTH_COMPLETED:        return this->Receive_SERVER_AUTH_COMPLETED(p);
+		case PACKET_SERVER_ENABLE_ENCRYPTION:     return this->Receive_SERVER_ENABLE_ENCRYPTION(p);
 		case PACKET_CLIENT_COMPANY_PASSWORD:      return this->Receive_CLIENT_COMPANY_PASSWORD(p);
 		case PACKET_SERVER_WELCOME:               return this->Receive_SERVER_WELCOME(p);
 		case PACKET_CLIENT_GETMAP:                return this->Receive_CLIENT_GETMAP(p);
@@ -168,7 +168,7 @@ NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_IDENTIFY(Packet &) { 
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_AUTH_REQUEST(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_AUTH_REQUEST); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_NEED_COMPANY_PASSWORD(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_NEED_COMPANY_PASSWORD); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_AUTH_RESPONSE(Packet &) { return this->ReceiveInvalidPacket(PACKET_CLIENT_AUTH_RESPONSE); }
-NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_AUTH_COMPLETED(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_AUTH_COMPLETED); }
+NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_ENABLE_ENCRYPTION(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_ENABLE_ENCRYPTION); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_COMPANY_PASSWORD(Packet &) { return this->ReceiveInvalidPacket(PACKET_CLIENT_COMPANY_PASSWORD); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_WELCOME(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_WELCOME); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_GETMAP(Packet &) { return this->ReceiveInvalidPacket(PACKET_CLIENT_GETMAP); }

--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -15,7 +15,6 @@
 #include "os_abstraction.h"
 #include "tcp.h"
 #include "../network_type.h"
-#include "../network_crypto.h"
 #include "../../core/pool_type.hpp"
 #include <chrono>
 
@@ -60,7 +59,7 @@ enum PacketGameType : uint8_t {
 	/* After the join step, the first perform game authentication and enabling encryption. */
 	PACKET_SERVER_AUTH_REQUEST,          ///< The server requests the client to authenticate using a number of methods.
 	PACKET_CLIENT_AUTH_RESPONSE,         ///< The client responds to the authentication request.
-	PACKET_SERVER_AUTH_COMPLETED,        ///< The server indicates the authentication is completed.
+	PACKET_SERVER_ENABLE_ENCRYPTION,     ///< The server tells that authentication has completed and requests to enable encryption with the keys of the last \c PACKET_CLIENT_AUTH_RESPONSE.
 
 	/* After the authentication is done, the next step is identification. */
 	PACKET_CLIENT_IDENTIFY,              ///< Client telling the server the client's name and requested company.
@@ -244,10 +243,10 @@ protected:
 	virtual NetworkRecvStatus Receive_CLIENT_AUTH_RESPONSE(Packet &p);
 
 	/**
-	 * Indication to the client that authentication has completed.
+	 * Indication to the client that authentication is complete and encryption has to be used from here on forward.
 	 * @param p The packet that was just received.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_AUTH_COMPLETED(Packet &p);
+	virtual NetworkRecvStatus Receive_SERVER_ENABLE_ENCRYPTION(Packet &p);
 
 	/**
 	 * Send a password to the server to authorize

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -137,7 +137,10 @@ void NetworkUDPSocketHandler::ReceivePackets()
 				Debug(net, 1, "Received a packet with mismatching size from {}", address.GetAddressAsString());
 				continue;
 			}
-			p.PrepareToRead();
+			if (!p.PrepareToRead()) {
+				Debug(net, 1, "Invalid packet received (too small / decryption error)");
+				continue;
+			}
 
 			/* Handle the packet */
 			this->HandleUDPPacket(p, address);

--- a/src/network/network_client.h
+++ b/src/network/network_client.h
@@ -25,7 +25,7 @@ private:
 		STATUS_INACTIVE,      ///< The client is not connected nor active.
 		STATUS_JOIN,          ///< We are trying to join a server.
 		STATUS_AUTH_GAME,     ///< Last action was requesting game (server) password.
-		STATUS_AUTHENTICATED, ///< The game authentication has completed.
+		STATUS_ENCRYPTED,     ///< The game authentication has completed and from here on the connection to the server is encrypted.
 		STATUS_NEWGRFS_CHECK, ///< Last action was checking NewGRFs.
 		STATUS_AUTH_COMPANY,  ///< Last action was requesting company password.
 		STATUS_AUTHORIZED,    ///< The client is authorized at the server.
@@ -47,7 +47,7 @@ protected:
 	NetworkRecvStatus Receive_SERVER_ERROR(Packet &p) override;
 	NetworkRecvStatus Receive_SERVER_CLIENT_INFO(Packet &p) override;
 	NetworkRecvStatus Receive_SERVER_AUTH_REQUEST(Packet &p) override;
-	NetworkRecvStatus Receive_SERVER_AUTH_COMPLETED(Packet &p) override;
+	NetworkRecvStatus Receive_SERVER_ENABLE_ENCRYPTION(Packet &p) override;
 	NetworkRecvStatus Receive_SERVER_NEED_COMPANY_PASSWORD(Packet &p) override;
 	NetworkRecvStatus Receive_SERVER_WELCOME(Packet &p) override;
 	NetworkRecvStatus Receive_SERVER_WAIT(Packet &p) override;

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -47,7 +47,7 @@ protected:
 	NetworkRecvStatus SendNewGRFCheck();
 	NetworkRecvStatus SendWelcome();
 	NetworkRecvStatus SendAuthRequest();
-	NetworkRecvStatus SendAuthCompleted();
+	NetworkRecvStatus SendEnableEncryption();
 	NetworkRecvStatus SendNeedCompanyPassword();
 
 public:


### PR DESCRIPTION
## Motivation / Problem

The game socket is not encrypted, making passwords that are sent over it trivially extractable.


## Description

Use Monocypher to perform a key exchange, and use monocypher to encrypt the content of `Packet`s.

The key exchange is done directly after the join, where the server sends its public key, a nonce and whether or not the server's password is used in the key exchange. When the client receives the message, it has to check whether it needs to ask for the password, and once it has the password it can start the key exchange where it creates the keys for both directions of the connection locally using its own public and private key, the servers public key and nonce, and the password.

The client will then generate a message and sign that, and send that together with its public key to the server. The server then performs the same key exchange now it knows the public key of the client, and decrypts and checks the signature of the message from the client. When that is wrong, the client is kicked out for not knowing the password .

The key exchange will also yield a set of keys for client-to-server and server-to-client encryption. From the moment those are known, they will be used for encrypting and decrypting the packets. For this the first two bytes with the packet size remain untouched, but 16 bytes are injected for the message authentication code (MAC), and after that the packet is filled as normal. When sending, the content is encrypted and the MAC is filled. For receiving messages the same steps happen, but in reverse. 

Since we could be sending an error message back for kicking the user because the password was incorrect, a new packet has been introduced to instruct the client to enable encryption. After this all packets are considered encrypted, and when a packet is too small to be encrypted, the connection is closed due to receiving invalid data.

This PR also contains basic authorized keys for the game connection, but that can be split to a different PR.


## Limitations

To keep the scope small, this does not:
* handle company passwords
* handle other protocols, such as the admin connection like #11878 does

This is built upon #12017, #12294 and #12296.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
