### PR TITLE
Fix #12301: Update ship current order destination tile when relocating buoys

### DIFF
--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -2189,9 +2189,23 @@ bool ProcessOrders(Vehicle *v)
 	}
 
 	/* If it is unchanged, keep it. */
-	if (order->Equals(v->current_order) && (v->type == VEH_AIRCRAFT || v->dest_tile != 0) &&
-			(v->type != VEH_SHIP || !order->IsType(OT_GOTO_STATION) || Station::Get(order->GetDestination())->ship_station.tile != INVALID_TILE)) {
-		return false;
+	if (order->Equals(v->current_order) && (v->type == VEH_AIRCRAFT || v->dest_tile != 0)) {
+		if (v->type != VEH_SHIP) {
+			return false;
+		} else {
+			switch (order->GetType()) {
+				case OT_GOTO_STATION:
+					if (Station::Get(order->GetDestination())->ship_station.tile != INVALID_TILE) return false;
+					break;
+
+				case OT_GOTO_WAYPOINT:
+					if (Waypoint::Get(order->GetDestination())->xy == v->dest_tile) return false;
+					break;
+
+				default:
+					return false;
+			}
+		}
 	}
 
 	/* Otherwise set it, and determine the destination tile. */

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -22,6 +22,7 @@
 #include "window_func.h"
 #include "timer/timer_game_calendar.h"
 #include "vehicle_func.h"
+#include "ship.h"
 #include "string_func.h"
 #include "company_func.h"
 #include "newgrf_station.h"
@@ -487,8 +488,14 @@ CommandCost CmdBuildBuoy(DoCommandFlag flags, TileIndex tile)
 		if (wp == nullptr) {
 			wp = new Waypoint(tile);
 		} else {
-			/* Move existing (recently deleted) buoy to the new location */
-			wp->xy = tile;
+			if (wp->xy != tile) {
+				/* Move existing (recently deleted) buoy to the new location. */
+				wp->xy = tile;
+				for (Ship *v : Ship::Iterate()) {
+					if (!v->current_order.IsType(OT_GOTO_WAYPOINT) || v->current_order.GetDestination() != wp->index) continue;
+					v->SetDestTile(wp->xy);
+				}
+			}
 			InvalidateWindowData(WC_WAYPOINT_VIEW, wp->index);
 		}
 		wp->rect.BeforeAddTile(tile, StationRect::ADD_TRY);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
#12301 
Relocating a buoy to another tile isn't updating `v->dest_tile`, sending the wrong tile for the pathfinders.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Fix #12301 Update `v->dest_tile` when relocating buoys.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
