### PR TITLE
Codechange: use span to send bytes to Packet and add span recv function

### DIFF
--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -66,7 +66,7 @@ public:
 	void   Send_uint64(uint64_t data);
 	void   Send_string(const std::string_view data);
 	void   Send_buffer(const std::vector<byte> &data);
-	size_t Send_bytes (const byte *begin, const byte *end);
+	std::span<const byte> Send_bytes(const std::span<const byte> span);
 
 	/* Reading/receiving of packets */
 	bool HasPacketSizeData() const;
@@ -82,6 +82,7 @@ public:
 	uint32_t Recv_uint32();
 	uint64_t Recv_uint64();
 	std::vector<byte> Recv_buffer();
+	size_t Recv_bytes(std::span<byte> span);
 	std::string Recv_string(size_t length, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 
 	size_t RemainingBytesToTransfer() const;

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -145,14 +145,13 @@ struct PacketWriter : SaveFilter {
 
 		if (this->current == nullptr) this->current = std::make_unique<Packet>(this->cs, PACKET_SERVER_MAP_DATA, TCP_MTU);
 
-		byte *bufe = buf + size;
-		while (buf != bufe) {
-			size_t written = this->current->Send_bytes(buf, bufe);
-			buf += written;
+		std::span<const byte> to_write(buf, size);
+		while (!to_write.empty()) {
+			to_write = this->current->Send_bytes(to_write);
 
 			if (!this->current->CanWriteToPacket(1)) {
 				this->packets.push_back(std::move(this->current));
-				if (buf != bufe) this->current = std::make_unique<Packet>(this->cs, PACKET_SERVER_MAP_DATA, TCP_MTU);
+				if (!to_write.empty()) this->current = std::make_unique<Packet>(this->cs, PACKET_SERVER_MAP_DATA, TCP_MTU);
 			}
 		}
 


### PR DESCRIPTION
## Motivation / Problem

With #12300 (encrypted game sockets) a lot more arrays of just bytes have to be written to and read from packets. To prevent having to use `array.data()` and `array.data() + array.size()`, it would be better to transform that `Packet` API to just use `std::span` instead.


## Description

Use `std::span` for `Send_bytes`, returning the remaining to be sent span.
Introduce `Recv_bytes`, which allows writing bytes into a `std::span`.


## Limitations

`Recv_bytes` is technically dead code until #12300 gets merged.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
