### PR TITLE
Codechange: rename byte to uint8_t

### DIFF
--- a/CODINGSTYLE.md
+++ b/CODINGSTYLE.md
@@ -248,7 +248,7 @@ Templates are a very powerful C++ tool, but they can easily confuse beginners. T
 * Templates are to be documented in a very clear and verbose manner. Never assume anything in the documentation.
 * the template keyword and the template layout get a separate line. typenames are either "T" or preceded by a "T", integers get a single capital letter or a descriptive name preceded by "T".
 ```c++
-template <typename T, typename Tsomething, int N, byte Tnumber_of_something>
+template <typename T, typename Tsomething, int N, uint8_t Tnumber_of_something>
 int Func();
 ```
 

--- a/src/3rdparty/md5/md5.h
+++ b/src/3rdparty/md5/md5.h
@@ -57,8 +57,8 @@
 static const size_t MD5_HASH_BYTES = 16;
 
 /** Container for storing a MD5 hash/checksum/digest. */
-struct MD5Hash : std::array<byte, MD5_HASH_BYTES> {
-	MD5Hash() : std::array<byte, MD5_HASH_BYTES>{} {}
+struct MD5Hash : std::array<uint8_t, MD5_HASH_BYTES> {
+	MD5Hash() : std::array<uint8_t, MD5_HASH_BYTES>{} {}
 
 	/**
 	 * Exclusively-or the given hash into this hash.

--- a/src/aircraft.h
+++ b/src/aircraft.h
@@ -73,14 +73,14 @@ struct AircraftCache {
  */
 struct Aircraft final : public SpecializedVehicle<Aircraft, VEH_AIRCRAFT> {
 	uint16_t crashed_counter;        ///< Timer for handling crash animations.
-	byte pos;                      ///< Next desired position of the aircraft.
-	byte previous_pos;             ///< Previous desired position of the aircraft.
+	uint8_t pos;                      ///< Next desired position of the aircraft.
+	uint8_t previous_pos;             ///< Previous desired position of the aircraft.
 	StationID targetairport;       ///< Airport to go to next.
-	byte state;                    ///< State of the airport. @see AirportMovementStates
+	uint8_t state;                    ///< State of the airport. @see AirportMovementStates
 	Direction last_direction;
-	byte number_consecutive_turns; ///< Protection to prevent the aircraft of making a lot of turns in order to reach a specific point.
-	byte turn_counter;             ///< Ticks between each turn to prevent > 45 degree turns.
-	byte flags;                    ///< Aircraft flags. @see AirVehicleFlags
+	uint8_t number_consecutive_turns; ///< Protection to prevent the aircraft of making a lot of turns in order to reach a specific point.
+	uint8_t turn_counter;             ///< Ticks between each turn to prevent > 45 degree turns.
+	uint8_t flags;                    ///< Aircraft flags. @see AirVehicleFlags
 
 	AircraftCache acache;
 

--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -655,7 +655,7 @@ static int UpdateAircraftSpeed(Aircraft *v, uint speed_limit = SPEED_LIMIT_NONE,
 	 *                               ~ acceleration * 77 (km-ish/h / 256)
 	 */
 	uint spd = v->acceleration * 77;
-	byte t;
+	uint8_t t;
 
 	/* Adjust speed limits by plane speed factor to prevent taxiing
 	 * and take-off speeds being too low. */
@@ -672,7 +672,7 @@ static int UpdateAircraftSpeed(Aircraft *v, uint speed_limit = SPEED_LIMIT_NONE,
 		speed_limit = v->vcache.cached_max_speed;
 	}
 
-	v->subspeed = (t = v->subspeed) + (byte)spd;
+	v->subspeed = (t = v->subspeed) + (uint8_t)spd;
 
 	/* Aircraft's current speed is used twice so that very fast planes are
 	 * forced to slow down rapidly in the short distance needed. The magic
@@ -699,7 +699,7 @@ static int UpdateAircraftSpeed(Aircraft *v, uint speed_limit = SPEED_LIMIT_NONE,
 	spd = v->GetOldAdvanceSpeed(spd);
 
 	spd += v->progress;
-	v->progress = (byte)spd;
+	v->progress = (uint8_t)spd;
 	return spd >> 8;
 }
 
@@ -825,7 +825,7 @@ template int GetAircraftFlightLevel(Aircraft *v, bool takeoff);
  * @param rotation The rotation of the airport.
  * @return   The index of the entry point
  */
-static byte AircraftGetEntryPoint(const Aircraft *v, const AirportFTAClass *apc, Direction rotation)
+static uint8_t AircraftGetEntryPoint(const Aircraft *v, const AirportFTAClass *apc, Direction rotation)
 {
 	assert(v != nullptr);
 	assert(apc != nullptr);
@@ -1666,7 +1666,7 @@ static void AircraftEventHandler_Flying(Aircraft *v, const AirportFTAClass *apc)
 		/* {32,FLYING,NOTHING_block,37}, {32,LANDING,N,33}, {32,HELILANDING,N,41},
 		 * if it is an airplane, look for LANDING, for helicopter HELILANDING
 		 * it is possible to choose from multiple landing runways, so loop until a free one is found */
-		byte landingtype = (v->subtype == AIR_HELICOPTER) ? HELILANDING : LANDING;
+		uint8_t landingtype = (v->subtype == AIR_HELICOPTER) ? HELILANDING : LANDING;
 		const AirportFTA *current = apc->layout[v->pos].next;
 		while (current != nullptr) {
 			if (current->heading == landingtype) {
@@ -1813,8 +1813,8 @@ static bool AirportMove(Aircraft *v, const AirportFTAClass *apc)
 	const AirportFTA *current = &apc->layout[v->pos];
 	/* we have arrived in an important state (eg terminal, hangar, etc.) */
 	if (current->heading == v->state) {
-		byte prev_pos = v->pos; // location could be changed in state, so save it before-hand
-		byte prev_state = v->state;
+		uint8_t prev_pos = v->pos; // location could be changed in state, so save it before-hand
+		uint8_t prev_state = v->state;
 		_aircraft_state_handlers[v->state](v, apc);
 		if (v->state != FLYING) v->previous_pos = prev_pos;
 		if (v->state != prev_state || v->pos != prev_pos) UpdateAircraftCache(v);
@@ -1950,7 +1950,7 @@ static const MovementTerminalMapping _airport_terminal_mapping[] = {
  * @param last_terminal Terminal number to stop examining.
  * @return A terminal or helipad has been found, and has been assigned to the aircraft.
  */
-static bool FreeTerminal(Aircraft *v, byte i, byte last_terminal)
+static bool FreeTerminal(Aircraft *v, uint8_t i, uint8_t last_terminal)
 {
 	assert(last_terminal <= lengthof(_airport_terminal_mapping));
 	Station *st = Station::Get(v->targetairport);

--- a/src/airport.cpp
+++ b/src/airport.cpp
@@ -110,12 +110,12 @@ AirportMovingData RotateAirportMovingData(const AirportMovingData *orig, Directi
 
 AirportFTAClass::AirportFTAClass(
 	const AirportMovingData *moving_data_,
-	const byte *terminals_,
-	const byte num_helipads_,
-	const byte *entry_points_,
+	const uint8_t *terminals_,
+	const uint8_t num_helipads_,
+	const uint8_t *entry_points_,
 	Flags flags_,
 	const AirportFTAbuildup *apFA,
-	byte delta_z_
+	uint8_t delta_z_
 ) :
 	moving_data(moving_data_),
 	terminals(terminals_),
@@ -204,7 +204,7 @@ static AirportFTA *AirportBuildAutomata(uint nofelements, const AirportFTAbuildu
  * @param airport_type %Airport type to query FTA from. @see AirportTypes
  * @return Finite state machine of the airport.
  */
-const AirportFTAClass *GetAirport(const byte airport_type)
+const AirportFTAClass *GetAirport(const uint8_t airport_type)
 {
 	if (airport_type == AT_DUMMY) return &_airportfta_dummy;
 	return AirportSpec::Get(airport_type)->fsm;
@@ -215,7 +215,7 @@ const AirportFTAClass *GetAirport(const byte airport_type)
  * @param hangar_tile The tile on which the vehicle is build
  * @return The position (index in airport node array) where the aircraft ends up
  */
-byte GetVehiclePosOnBuild(TileIndex hangar_tile)
+uint8_t GetVehiclePosOnBuild(TileIndex hangar_tile)
 {
 	const Station *st = Station::GetByTile(hangar_tile);
 	const AirportFTAClass *apc = st->airport.GetFTA();

--- a/src/airport.h
+++ b/src/airport.h
@@ -152,12 +152,12 @@ public:
 
 	AirportFTAClass(
 		const AirportMovingData *moving_data,
-		const byte *terminals,
-		const byte num_helipads,
-		const byte *entry_points,
+		const uint8_t *terminals,
+		const uint8_t num_helipads,
+		const uint8_t *entry_points,
 		Flags flags,
 		const AirportFTAbuildup *apFA,
-		byte delta_z
+		uint8_t delta_z
 	);
 
 	~AirportFTAClass();
@@ -167,7 +167,7 @@ public:
 	 * @param position Element number to get movement data about.
 	 * @return Pointer to the movement data.
 	 */
-	const AirportMovingData *MovingData(byte position) const
+	const AirportMovingData *MovingData(uint8_t position) const
 	{
 		assert(position < nofelements);
 		return &moving_data[position];
@@ -175,12 +175,12 @@ public:
 
 	const AirportMovingData *moving_data; ///< Movement data.
 	struct AirportFTA *layout;            ///< state machine for airport
-	const byte *terminals;                ///< %Array with the number of terminal groups, followed by the number of terminals in each group.
-	const byte num_helipads;              ///< Number of helipads on this airport. When 0 helicopters will go to normal terminals.
+	const uint8_t *terminals;                ///< %Array with the number of terminal groups, followed by the number of terminals in each group.
+	const uint8_t num_helipads;              ///< Number of helipads on this airport. When 0 helicopters will go to normal terminals.
 	Flags flags;                          ///< Flags for this airport type.
-	byte nofelements;                     ///< number of positions the airport consists of
-	const byte *entry_points;             ///< when an airplane arrives at this airport, enter it at position entry_point, index depends on direction
-	byte delta_z;                         ///< Z adjustment for helicopter pads
+	uint8_t nofelements;                     ///< number of positions the airport consists of
+	const uint8_t *entry_points;             ///< when an airplane arrives at this airport, enter it at position entry_point, index depends on direction
+	uint8_t delta_z;                         ///< Z adjustment for helicopter pads
 };
 
 DECLARE_ENUM_AS_BIT_SET(AirportFTAClass::Flags)
@@ -190,12 +190,12 @@ DECLARE_ENUM_AS_BIT_SET(AirportFTAClass::Flags)
 struct AirportFTA {
 	AirportFTA *next;        ///< possible extra movement choices from this position
 	uint64_t block;            ///< 64 bit blocks (st->airport.flags), should be enough for the most complex airports
-	byte position;           ///< the position that an airplane is at
-	byte next_position;      ///< next position from this position
-	byte heading;            ///< heading (current orders), guiding an airplane to its target on an airport
+	uint8_t position;           ///< the position that an airplane is at
+	uint8_t next_position;      ///< next position from this position
+	uint8_t heading;            ///< heading (current orders), guiding an airplane to its target on an airport
 };
 
-const AirportFTAClass *GetAirport(const byte airport_type);
-byte GetVehiclePosOnBuild(TileIndex hangar_tile);
+const AirportFTAClass *GetAirport(const uint8_t airport_type);
+uint8_t GetVehiclePosOnBuild(TileIndex hangar_tile);
 
 #endif /* AIRPORT_H */

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -41,11 +41,11 @@
 
 static AirportClassID _selected_airport_class; ///< the currently visible airport class
 static int _selected_airport_index;            ///< the index of the selected airport in the current class or -1
-static byte _selected_airport_layout;          ///< selected airport layout number.
+static uint8_t _selected_airport_layout;          ///< selected airport layout number.
 
 static void ShowBuildAirportPicker(Window *parent);
 
-SpriteID GetCustomAirportSprite(const AirportSpec *as, byte layout);
+SpriteID GetCustomAirportSprite(const AirportSpec *as, uint8_t layout);
 
 void CcBuildAirport(Commands, const CommandCost &result, TileIndex tile)
 {
@@ -63,8 +63,8 @@ static void PlaceAirport(TileIndex tile)
 {
 	if (_selected_airport_index == -1) return;
 
-	byte airport_type = AirportClass::Get(_selected_airport_class)->GetSpec(_selected_airport_index)->GetIndex();
-	byte layout = _selected_airport_layout;
+	uint8_t airport_type = AirportClass::Get(_selected_airport_class)->GetSpec(_selected_airport_index)->GetIndex();
+	uint8_t layout = _selected_airport_layout;
 	bool adjacent = _ctrl_pressed;
 
 	auto proc = [=](bool test, StationID to_join) -> bool {
@@ -347,7 +347,7 @@ public:
 				for (int i = 0; i < NUM_AIRPORTS; i++) {
 					const AirportSpec *as = AirportSpec::Get(i);
 					if (!as->enabled) continue;
-					for (byte layout = 0; layout < as->num_table; layout++) {
+					for (uint8_t layout = 0; layout < as->num_table; layout++) {
 						SpriteID sprite = GetCustomAirportSprite(as, layout);
 						if (sprite != 0) {
 							Dimension d = GetSpriteSize(sprite);
@@ -363,7 +363,7 @@ public:
 				for (int i = NEW_AIRPORT_OFFSET; i < NUM_AIRPORTS; i++) {
 					const AirportSpec *as = AirportSpec::Get(i);
 					if (!as->enabled) continue;
-					for (byte layout = 0; layout < as->num_table; layout++) {
+					for (uint8_t layout = 0; layout < as->num_table; layout++) {
 						StringID string = GetAirportTextCallback(as, layout, CBID_AIRPORT_ADDITIONAL_TEXT);
 						if (string == STR_UNDEFINED) continue;
 

--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -362,7 +362,7 @@ static CommandCost BuildReplacementVehicle(Vehicle *old_veh, Vehicle **new_vehic
 
 	/* Refit the vehicle if needed */
 	if (refit_cargo != CARGO_NO_REFIT) {
-		byte subtype = GetBestFittingSubType(old_veh, new_veh, refit_cargo);
+		uint8_t subtype = GetBestFittingSubType(old_veh, new_veh, refit_cargo);
 
 		cost.AddCost(std::get<0>(Command<CMD_REFIT_VEHICLE>::Do(DC_EXEC, new_veh->index, refit_cargo, subtype, false, false, 0)));
 		assert(cost.Succeeded()); // This should be ensured by GetNewCargoTypeForReplace()

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -85,7 +85,7 @@ class ReplaceVehicleWindow : public Window {
 	bool reset_sel_engine;        ///< Also reset #sel_engine while updating left and/or right and no valid engine selected.
 	GroupID sel_group;            ///< Group selected to replace.
 	int details_height;           ///< Minimal needed height of the details panels, in text lines (found so far).
-	byte sort_criteria;           ///< Criteria of sorting vehicles.
+	uint8_t sort_criteria;           ///< Criteria of sorting vehicles.
 	bool descending_sort_order;   ///< Order of sorting vehicles.
 	bool show_hidden_engines;     ///< Whether to show the hidden engines.
 	RailType sel_railtype;        ///< Type of rail tracks selected. #INVALID_RAILTYPE to show all.
@@ -143,7 +143,7 @@ class ReplaceVehicleWindow : public Window {
 		std::vector<EngineID> variants;
 		EngineID selected_engine = INVALID_ENGINE;
 		VehicleType type = (VehicleType)this->window_number;
-		byte side = draw_left ? 0 : 1;
+		uint8_t side = draw_left ? 0 : 1;
 
 		GUIEngineList list;
 
@@ -607,7 +607,7 @@ public:
 
 			case WID_RV_LEFT_MATRIX:
 			case WID_RV_RIGHT_MATRIX: {
-				byte click_side;
+				uint8_t click_side;
 				if (widget == WID_RV_LEFT_MATRIX) {
 					click_side = 0;
 				} else {

--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -314,7 +314,7 @@ static const uint NUM_SONGS_PLAYLIST  = 32;
 
 /* Functions to read DOS music CAT files, similar to but not quite the same as sound effect CAT files */
 char *GetMusicCatEntryName(const std::string &filename, size_t entrynum);
-byte *GetMusicCatEntryData(const std::string &filename, size_t entrynum, size_t &entrylen);
+uint8_t *GetMusicCatEntryData(const std::string &filename, size_t entrynum, size_t &entrylen);
 
 enum MusicTrackType {
 	MTT_STANDARDMIDI, ///< Standard MIDI file
@@ -324,7 +324,7 @@ enum MusicTrackType {
 /** Metadata about a music track. */
 struct MusicSongInfo {
 	std::string songname;    ///< name of song displayed in UI
-	byte tracknr;            ///< track number of song displayed in UI
+	uint8_t tracknr;            ///< track number of song displayed in UI
 	std::string filename;    ///< file on disk containing song (when used in MusicSet class)
 	MusicTrackType filetype; ///< decoder required for song file
 	int cat_index;           ///< entry index in CAT file, for filetype==MTT_MPSMIDI
@@ -338,7 +338,7 @@ struct MusicSet : BaseSet<MusicSet, NUM_SONGS_AVAILABLE, false> {
 	/** Data about individual songs in set. */
 	MusicSongInfo songinfo[NUM_SONGS_AVAILABLE];
 	/** Number of valid songs in set. */
-	byte num_available;
+	uint8_t num_available;
 
 	bool FillSetDetails(const IniFile &ini, const std::string &path, const std::string &full_filename);
 };

--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -59,7 +59,7 @@ struct StationRect : public Rect {
 struct BaseStation : StationPool::PoolItem<&_station_pool> {
 	TileIndex xy;                   ///< Base tile of the station
 	TrackedViewportSign sign;       ///< NOSAVE: Dimensions of sign
-	byte delete_ctr;                ///< Delete counter. If greater than 0 then it is decremented until it reaches 0; the waypoint is then is deleted.
+	uint8_t delete_ctr;                ///< Delete counter. If greater than 0 then it is decremented until it reaches 0; the waypoint is then is deleted.
 
 	std::string name;               ///< Custom name
 	StringID string_id;             ///< Default name (town area) of station
@@ -75,7 +75,7 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 	TimerGameCalendar::Date build_date; ///< Date of construction
 
 	uint16_t random_bits;             ///< Random bits assigned to this station
-	byte waiting_triggers;          ///< Waiting triggers (NewGRF) for this station
+	uint8_t waiting_triggers;          ///< Waiting triggers (NewGRF) for this station
 	uint8_t cached_anim_triggers;                ///< NOSAVE: Combined animation trigger bitmask, used to determine if trigger processing should happen.
 	uint8_t cached_roadstop_anim_triggers;       ///< NOSAVE: Combined animation trigger bitmask for road stops, used to determine if trigger processing should happen.
 	CargoTypes cached_cargo_triggers;          ///< NOSAVE: Combined cargo trigger bitmask
@@ -113,7 +113,7 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 	 * @param available will return false if ever the variable asked for does not exist
 	 * @return the value stored in the corresponding variable
 	 */
-	virtual uint32_t GetNewGRFVariable(const struct ResolverObject &object, byte variable, byte parameter, bool *available) const = 0;
+	virtual uint32_t GetNewGRFVariable(const struct ResolverObject &object, uint8_t variable, uint8_t parameter, bool *available) const = 0;
 
 	/**
 	 * Update the coordinated of the sign (as shown in the viewport).
@@ -179,7 +179,7 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 		return (this->facilities & ~FACIL_WAYPOINT) != 0;
 	}
 
-	inline byte GetRoadStopRandomBits(TileIndex tile) const
+	inline uint8_t GetRoadStopRandomBits(TileIndex tile) const
 	{
 		for (const RoadStopTileData &tile_data : this->custom_roadstop_tile_data) {
 			if (tile_data.tile == tile) return tile_data.random_bits;
@@ -187,7 +187,7 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 		return 0;
 	}
 
-	inline byte GetRoadStopAnimationFrame(TileIndex tile) const
+	inline uint8_t GetRoadStopAnimationFrame(TileIndex tile) const
 	{
 		for (const RoadStopTileData &tile_data : this->custom_roadstop_tile_data) {
 			if (tile_data.tile == tile) return tile_data.animation_frame;
@@ -196,11 +196,11 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 	}
 
 private:
-	void SetRoadStopTileData(TileIndex tile, byte data, bool animation);
+	void SetRoadStopTileData(TileIndex tile, uint8_t data, bool animation);
 
 public:
-	inline void SetRoadStopRandomBits(TileIndex tile, byte random_bits) { this->SetRoadStopTileData(tile, random_bits, false); }
-	inline void SetRoadStopAnimationFrame(TileIndex tile, byte frame) { this->SetRoadStopTileData(tile, frame, true); }
+	inline void SetRoadStopRandomBits(TileIndex tile, uint8_t random_bits) { this->SetRoadStopTileData(tile, random_bits, false); }
+	inline void SetRoadStopAnimationFrame(TileIndex tile, uint8_t frame) { this->SetRoadStopTileData(tile, frame, true); }
 	void RemoveRoadStopTileData(TileIndex tile);
 
 	static void PostDestructor(size_t index);

--- a/src/blitter/32bpp_anim.cpp
+++ b/src/blitter/32bpp_anim.cpp
@@ -34,23 +34,23 @@ inline void Blitter_32bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 	const uint16_t *src_n  = (const uint16_t *)(src->data + src->offset[zoom][1]);
 
 	for (uint i = bp->skip_top; i != 0; i--) {
-		src_px = (const Colour *)((const byte *)src_px + *(const uint32_t *)src_px);
-		src_n  = (const uint16_t *)((const byte *)src_n  + *(const uint32_t *)src_n);
+		src_px = (const Colour *)((const uint8_t *)src_px + *(const uint32_t *)src_px);
+		src_n  = (const uint16_t *)((const uint8_t *)src_n  + *(const uint32_t *)src_n);
 	}
 
 	Colour *dst = (Colour *)bp->dst + bp->top * bp->pitch + bp->left;
 	uint16_t *anim = this->anim_buf + this->ScreenToAnimOffset((uint32_t *)bp->dst) + bp->top * this->anim_buf_pitch + bp->left;
 
-	const byte *remap = bp->remap; // store so we don't have to access it via bp every time
+	const uint8_t *remap = bp->remap; // store so we don't have to access it via bp every time
 
 	for (int y = 0; y < bp->height; y++) {
 		Colour *dst_ln = dst + bp->pitch;
 		uint16_t *anim_ln = anim + this->anim_buf_pitch;
 
-		const Colour *src_px_ln = (const Colour *)((const byte *)src_px + *(const uint32_t *)src_px);
+		const Colour *src_px_ln = (const Colour *)((const uint8_t *)src_px + *(const uint32_t *)src_px);
 		src_px++;
 
-		const uint16_t *src_n_ln = (const uint16_t *)((const byte *)src_n + *(const uint32_t *)src_n);
+		const uint16_t *src_n_ln = (const uint16_t *)((const uint8_t *)src_n + *(const uint32_t *)src_n);
 		src_n += 2;
 
 		Colour *dst_end = dst + bp->skip_left;

--- a/src/blitter/32bpp_anim_sse4.cpp
+++ b/src/blitter/32bpp_anim_sse4.cpp
@@ -33,7 +33,7 @@ template <BlitterMode mode, Blitter_32bppSSE2::ReadMode read_mode, Blitter_32bpp
 GNU_TARGET("sse4.1")
 inline void Blitter_32bppSSE4_Anim::Draw(const BlitterParams *bp, ZoomLevel zoom)
 {
-	const byte * const remap = bp->remap;
+	const uint8_t * const remap = bp->remap;
 	Colour *dst_line = (Colour *) bp->dst + bp->top * bp->pitch + bp->left;
 	uint16_t *anim_line = this->anim_buf + this->ScreenToAnimOffset((uint32_t *)bp->dst) + bp->top * this->anim_buf_pitch + bp->left;
 	int effective_width = bp->width;
@@ -42,7 +42,7 @@ inline void Blitter_32bppSSE4_Anim::Draw(const BlitterParams *bp, ZoomLevel zoom
 	const Blitter_32bppSSE_Base::SpriteData * const sd = (const Blitter_32bppSSE_Base::SpriteData *) bp->sprite;
 	const SpriteInfo * const si = &sd->infos[zoom];
 	const MapValue *src_mv_line = (const MapValue *) &sd->data[si->mv_offset] + bp->skip_top * si->sprite_width;
-	const Colour *src_rgba_line = (const Colour *) ((const byte *) &sd->data[si->sprite_offset] + bp->skip_top * si->sprite_line_size);
+	const Colour *src_rgba_line = (const Colour *) ((const uint8_t *) &sd->data[si->sprite_offset] + bp->skip_top * si->sprite_line_size);
 
 	if (read_mode != RM_WITH_MARGIN) {
 		src_rgba_line += bp->skip_left;
@@ -104,20 +104,20 @@ inline void Blitter_32bppSSE4_Anim::Draw(const BlitterParams *bp, ZoomLevel zoom
 
 					if (animated) {
 						/* Remap colours. */
-						const byte m0 = mvX2;
+						const uint8_t m0 = mvX2;
 						if (m0 >= PALETTE_ANIM_START) {
 							const Colour c0 = (this->LookupColourInPalette(m0).data & 0x00FFFFFF) | (src[0].data & 0xFF000000);
-							InsertFirstUint32(AdjustBrightneSSE(c0, (byte) (mvX2 >> 8)).data, srcABCD);
+							InsertFirstUint32(AdjustBrightneSSE(c0, (uint8_t) (mvX2 >> 8)).data, srcABCD);
 						}
-						const byte m1 = mvX2 >> 16;
+						const uint8_t m1 = mvX2 >> 16;
 						if (m1 >= PALETTE_ANIM_START) {
 							const Colour c1 = (this->LookupColourInPalette(m1).data & 0x00FFFFFF) | (src[1].data & 0xFF000000);
-							InsertSecondUint32(AdjustBrightneSSE(c1, (byte) (mvX2 >> 24)).data, srcABCD);
+							InsertSecondUint32(AdjustBrightneSSE(c1, (uint8_t) (mvX2 >> 24)).data, srcABCD);
 						}
 
 						/* Update anim buffer. */
-						const byte a0 = src[0].a;
-						const byte a1 = src[1].a;
+						const uint8_t a0 = src[0].a;
+						const uint8_t a1 = src[1].a;
 						uint32_t anim01 = 0;
 						if (a0 == 255) {
 							if (a1 == 255) {
@@ -185,9 +185,9 @@ bmno_full_transparency:
 					__m128i dstABCD = _mm_loadl_epi64((__m128i*) dst);
 
 					/* Remap colours. */
-					const uint m0 = (byte) mvX2;
+					const uint m0 = (uint8_t) mvX2;
 					const uint r0 = remap[m0];
-					const uint m1 = (byte) (mvX2 >> 16);
+					const uint m1 = (uint8_t) (mvX2 >> 16);
 					const uint r1 = remap[m1];
 					if (mvX2 & 0x00FF00FF) {
 						#define CMOV_REMAP(m_colour, m_colour_init, m_src, m_m) \
@@ -195,7 +195,7 @@ bmno_full_transparency:
 							Colour m_colour = m_colour_init; \
 							{ \
 							const Colour srcm = (Colour) (m_src); \
-							const uint m = (byte) (m_m); \
+							const uint m = (uint8_t) (m_m); \
 							const uint r = remap[m]; \
 							const Colour cmap = (this->LookupColourInPalette(r).data & 0x00FFFFFF) | (srcm.data & 0xFF000000); \
 							m_colour = r == 0 ? m_colour : cmap; \
@@ -225,8 +225,8 @@ bmno_full_transparency:
 
 					/* Update anim buffer. */
 					if (animated) {
-						const byte a0 = src[0].a;
-						const byte a1 = src[1].a;
+						const uint8_t a0 = src[0].a;
+						const uint8_t a1 = src[1].a;
 						uint32_t anim01 = mvX2 & 0xFF00FF00;
 						if (a0 == 255) {
 							anim01 |= r0;
@@ -368,7 +368,7 @@ bmcr_alpha_blend_single:
 
 next_line:
 		if (mode != BM_TRANSPARENT && mode != BM_TRANSPARENT_REMAP) src_mv_line += si->sprite_width;
-		src_rgba_line = (const Colour*) ((const byte*) src_rgba_line + si->sprite_line_size);
+		src_rgba_line = (const Colour*) ((const uint8_t*) src_rgba_line + si->sprite_line_size);
 		dst_line += bp->pitch;
 		anim_line += this->anim_buf_pitch;
 	}

--- a/src/blitter/32bpp_optimized.cpp
+++ b/src/blitter/32bpp_optimized.cpp
@@ -40,26 +40,26 @@ inline void Blitter_32bppOptimized::Draw(const Blitter::BlitterParams *bp, ZoomL
 
 	/* skip upper lines in src_px and src_n */
 	for (uint i = bp->skip_top; i != 0; i--) {
-		src_px = (const Colour *)((const byte *)src_px + *(const uint32_t *)src_px);
-		src_n = (const uint16_t *)((const byte *)src_n + *(const uint32_t *)src_n);
+		src_px = (const Colour *)((const uint8_t *)src_px + *(const uint32_t *)src_px);
+		src_n = (const uint16_t *)((const uint8_t *)src_n + *(const uint32_t *)src_n);
 	}
 
 	/* skip lines in dst */
 	Colour *dst = (Colour *)bp->dst + bp->top * bp->pitch + bp->left;
 
 	/* store so we don't have to access it via bp every time (compiler assumes pointer aliasing) */
-	const byte *remap = bp->remap;
+	const uint8_t *remap = bp->remap;
 
 	for (int y = 0; y < bp->height; y++) {
 		/* next dst line begins here */
 		Colour *dst_ln = dst + bp->pitch;
 
 		/* next src line begins here */
-		const Colour *src_px_ln = (const Colour *)((const byte *)src_px + *(const uint32_t *)src_px);
+		const Colour *src_px_ln = (const Colour *)((const uint8_t *)src_px + *(const uint32_t *)src_px);
 		src_px++;
 
 		/* next src_n line begins here */
-		const uint16_t *src_n_ln = (const uint16_t *)((const byte *)src_n + *(const uint32_t *)src_n);
+		const uint16_t *src_n_ln = (const uint16_t *)((const uint8_t *)src_n + *(const uint32_t *)src_n);
 		src_n += 2;
 
 		/* we will end this line when we reach this point */
@@ -405,8 +405,8 @@ template <bool Tpal_to_rgb> Sprite *Blitter_32bppOptimized::EncodeInternal(const
 			dst_n_ln =  (uint32_t *)dst_n;
 		}
 
-		lengths[z][0] = (byte *)dst_px_ln - (byte *)dst_px_orig[z]; // all are aligned to 4B boundary
-		lengths[z][1] = (byte *)dst_n_ln  - (byte *)dst_n_orig[z];
+		lengths[z][0] = (uint8_t *)dst_px_ln - (uint8_t *)dst_px_orig[z]; // all are aligned to 4B boundary
+		lengths[z][1] = (uint8_t *)dst_n_ln  - (uint8_t *)dst_n_orig[z];
 	}
 
 	uint len = 0; // total length of data

--- a/src/blitter/32bpp_optimized.hpp
+++ b/src/blitter/32bpp_optimized.hpp
@@ -18,7 +18,7 @@ public:
 	/** Data stored about a (single) sprite. */
 	struct SpriteData {
 		uint32_t offset[ZOOM_LVL_END][2]; ///< Offsets (from .data) to streams for different zoom levels, and the normal and remap image information.
-		byte data[];                      ///< Data, all zoomlevels.
+		uint8_t data[];                      ///< Data, all zoomlevels.
 	};
 
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;

--- a/src/blitter/32bpp_sse2.cpp
+++ b/src/blitter/32bpp_sse2.cpp
@@ -114,7 +114,7 @@ Sprite *Blitter_32bppSSE_Base::Encode(const SpriteLoader::SpriteCollection &spri
 			(*dst_rgba_line).data = nb_pix_transp;
 
 			Colour *nb_right = dst_rgba_line + 1;
-			dst_rgba_line = (Colour*) ((byte*) dst_rgba_line + sd.infos[z].sprite_line_size);
+			dst_rgba_line = (Colour*) ((uint8_t*) dst_rgba_line + sd.infos[z].sprite_line_size);
 
 			/* Count the number of transparent pixels from the right. */
 			dst_rgba = dst_rgba_line - 1;

--- a/src/blitter/32bpp_sse2.hpp
+++ b/src/blitter/32bpp_sse2.hpp
@@ -73,7 +73,7 @@ public:
 	struct SpriteData {
 		SpriteFlags flags;
 		SpriteInfo infos[ZOOM_LVL_END];
-		byte data[]; ///< Data, all zoomlevels.
+		uint8_t data[]; ///< Data, all zoomlevels.
 	};
 
 	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator);

--- a/src/blitter/32bpp_sse_func.hpp
+++ b/src/blitter/32bpp_sse_func.hpp
@@ -214,7 +214,7 @@ inline void Blitter_32bppSSSE3::Draw(const Blitter::BlitterParams *bp, ZoomLevel
 inline void Blitter_32bppSSE4::Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom)
 #endif
 {
-	const byte * const remap = bp->remap;
+	const uint8_t * const remap = bp->remap;
 	Colour *dst_line = (Colour *) bp->dst + bp->top * bp->pitch + bp->left;
 	int effective_width = bp->width;
 
@@ -222,7 +222,7 @@ inline void Blitter_32bppSSE4::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 	const SpriteData * const sd = (const SpriteData *) bp->sprite;
 	const SpriteInfo * const si = &sd->infos[zoom];
 	const MapValue *src_mv_line = (const MapValue *) &sd->data[si->mv_offset] + bp->skip_top * si->sprite_width;
-	const Colour *src_rgba_line = (const Colour *) ((const byte *) &sd->data[si->sprite_offset] + bp->skip_top * si->sprite_line_size);
+	const Colour *src_rgba_line = (const Colour *) ((const uint8_t *) &sd->data[si->sprite_offset] + bp->skip_top * si->sprite_line_size);
 
 	if (read_mode != RM_WITH_MARGIN) {
 		src_rgba_line += bp->skip_left;
@@ -307,7 +307,7 @@ inline void Blitter_32bppSSE4::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 							Colour m_colour = m_colour_init; \
 							{ \
 							const Colour srcm = (Colour) (m_src); \
-							const uint m = (byte) (m_m); \
+							const uint m = (uint8_t) (m_m); \
 							const uint r = remap[m]; \
 							const Colour cmap = (this->LookupColourInPalette(r).data & 0x00FFFFFF) | (srcm.data & 0xFF000000); \
 							m_colour = r == 0 ? m_colour : cmap; \
@@ -435,7 +435,7 @@ bmcr_alpha_blend_single:
 
 next_line:
 		if (mode == BM_COLOUR_REMAP || mode == BM_CRASH_REMAP) src_mv_line += si->sprite_width;
-		src_rgba_line = (const Colour*) ((const byte*) src_rgba_line + si->sprite_line_size);
+		src_rgba_line = (const Colour*) ((const uint8_t*) src_rgba_line + si->sprite_line_size);
 		dst_line += bp->pitch;
 	}
 }

--- a/src/blitter/40bpp_anim.cpp
+++ b/src/blitter/40bpp_anim.cpp
@@ -104,8 +104,8 @@ inline void Blitter_40bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 
 	/* skip upper lines in src_px and src_n */
 	for (uint i = bp->skip_top; i != 0; i--) {
-		src_px = (const Colour *)((const byte *)src_px + *(const uint32_t *)src_px);
-		src_n = (const uint16_t *)((const byte *)src_n + *(const uint32_t *)src_n);
+		src_px = (const Colour *)((const uint8_t *)src_px + *(const uint32_t *)src_px);
+		src_n = (const uint16_t *)((const uint8_t *)src_n + *(const uint32_t *)src_n);
 	}
 
 	/* skip lines in dst */
@@ -114,7 +114,7 @@ inline void Blitter_40bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 	uint8_t *anim = VideoDriver::GetInstance()->GetAnimBuffer() + ((uint32_t *)bp->dst - (uint32_t *)_screen.dst_ptr) + bp->top * bp->pitch + bp->left;
 
 	/* store so we don't have to access it via bp everytime (compiler assumes pointer aliasing) */
-	const byte *remap = bp->remap;
+	const uint8_t *remap = bp->remap;
 
 	for (int y = 0; y < bp->height; y++) {
 		/* next dst line begins here */
@@ -122,11 +122,11 @@ inline void Blitter_40bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 		uint8_t *anim_ln = anim + bp->pitch;
 
 		/* next src line begins here */
-		const Colour *src_px_ln = (const Colour *)((const byte *)src_px + *(const uint32_t *)src_px);
+		const Colour *src_px_ln = (const Colour *)((const uint8_t *)src_px + *(const uint32_t *)src_px);
 		src_px++;
 
 		/* next src_n line begins here */
-		const uint16_t *src_n_ln = (const uint16_t *)((const byte *)src_n + *(const uint32_t *)src_n);
+		const uint16_t *src_n_ln = (const uint16_t *)((const uint8_t *)src_n + *(const uint32_t *)src_n);
 		src_n += 2;
 
 		/* we will end this line when we reach this point */

--- a/src/blitter/8bpp_optimized.cpp
+++ b/src/blitter/8bpp_optimized.cpp
@@ -147,10 +147,10 @@ Sprite *Blitter_8bppOptimized::Encode(const SpriteLoader::SpriteCollection &spri
 	/* Don't allocate memory each time, but just keep some
 	 * memory around as this function is called quite often
 	 * and the memory usage is quite low. */
-	static ReusableBuffer<byte> temp_buffer;
+	static ReusableBuffer<uint8_t> temp_buffer;
 	SpriteData *temp_dst = (SpriteData *)temp_buffer.Allocate(memory);
 	memset(temp_dst, 0, sizeof(*temp_dst));
-	byte *dst = temp_dst->data;
+	uint8_t *dst = temp_dst->data;
 
 	/* Make the sprites per zoom-level */
 	for (ZoomLevel i = zoom_min; i <= zoom_max; i++) {
@@ -166,7 +166,7 @@ Sprite *Blitter_8bppOptimized::Encode(const SpriteLoader::SpriteCollection &spri
 			uint trans = 0;
 			uint pixels = 0;
 			uint last_colour = 0;
-			byte *count_dst = nullptr;
+			uint8_t *count_dst = nullptr;
 
 			/* Store the scaled image */
 			const SpriteLoader::CommonPixel *src = &sprite[i].data[y * sprite[i].width];
@@ -213,7 +213,7 @@ Sprite *Blitter_8bppOptimized::Encode(const SpriteLoader::SpriteCollection &spri
 		}
 	}
 
-	uint size = dst - (byte *)temp_dst;
+	uint size = dst - (uint8_t *)temp_dst;
 
 	/* Safety check, to make sure we guessed the size correctly */
 	assert(size < memory);

--- a/src/blitter/8bpp_optimized.hpp
+++ b/src/blitter/8bpp_optimized.hpp
@@ -19,7 +19,7 @@ public:
 	/** Data stored about a (single) sprite. */
 	struct SpriteData {
 		uint32_t offset[ZOOM_LVL_END]; ///< Offsets (from .data) to streams for different zoom levels.
-		byte data[];                   ///< Data, all zoomlevels.
+		uint8_t data[];                   ///< Data, all zoomlevels.
 	};
 
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;

--- a/src/blitter/base.hpp
+++ b/src/blitter/base.hpp
@@ -31,7 +31,7 @@ public:
 	/** Parameters related to blitting. */
 	struct BlitterParams {
 		const void *sprite; ///< Pointer to the sprite how ever the encoder stored it
-		const byte *remap;  ///< XXX -- Temporary storage for remap array
+		const uint8_t *remap;  ///< XXX -- Temporary storage for remap array
 
 		int skip_left;      ///< How much pixels of the source to skip on the left (based on zoom of dst)
 		int skip_top;       ///< How much pixels of the source to skip on the top (based on zoom of dst)

--- a/src/bmp.cpp
+++ b/src/bmp.cpp
@@ -39,7 +39,7 @@ static inline bool EndOfBuffer(BmpBuffer *buffer)
 	return buffer->pos == buffer->read;
 }
 
-static inline byte ReadByte(BmpBuffer *buffer)
+static inline uint8_t ReadByte(BmpBuffer *buffer)
 {
 	if (buffer->read < 0) return 0;
 
@@ -83,9 +83,9 @@ static inline void SetStreamOffset(BmpBuffer *buffer, int offset)
 static inline bool BmpRead1(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
 {
 	uint x, y, i;
-	byte pad = GB(4 - info->width / 8, 0, 2);
-	byte *pixel_row;
-	byte b;
+	uint8_t pad = GB(4 - info->width / 8, 0, 2);
+	uint8_t *pixel_row;
+	uint8_t b;
 	for (y = info->height; y > 0; y--) {
 		x = 0;
 		pixel_row = &data->bitmap[(y - 1) * info->width];
@@ -110,9 +110,9 @@ static inline bool BmpRead1(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
 static inline bool BmpRead4(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
 {
 	uint x, y;
-	byte pad = GB(4 - info->width / 2, 0, 2);
-	byte *pixel_row;
-	byte b;
+	uint8_t pad = GB(4 - info->width / 2, 0, 2);
+	uint8_t *pixel_row;
+	uint8_t b;
 	for (y = info->height; y > 0; y--) {
 		x = 0;
 		pixel_row = &data->bitmap[(y - 1) * info->width];
@@ -140,12 +140,12 @@ static inline bool BmpRead4Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
 {
 	uint x = 0;
 	uint y = info->height - 1;
-	byte *pixel = &data->bitmap[y * info->width];
+	uint8_t *pixel = &data->bitmap[y * info->width];
 	while (y != 0 || x < info->width) {
 		if (EndOfBuffer(buffer)) return false; // the file is shorter than expected
 
-		byte n = ReadByte(buffer);
-		byte c = ReadByte(buffer);
+		uint8_t n = ReadByte(buffer);
+		uint8_t c = ReadByte(buffer);
 		if (n == 0) {
 			switch (c) {
 				case 0: // end of line
@@ -159,8 +159,8 @@ static inline bool BmpRead4Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
 
 				case 2: { // delta
 					if (EndOfBuffer(buffer)) return false;
-					byte dx = ReadByte(buffer);
-					byte dy = ReadByte(buffer);
+					uint8_t dx = ReadByte(buffer);
+					uint8_t dy = ReadByte(buffer);
 
 					/* Check for over- and underflow. */
 					if (x + dx >= info->width || x + dx < x || dy > y) return false;
@@ -175,7 +175,7 @@ static inline bool BmpRead4Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
 					uint i = 0;
 					while (i++ < c) {
 						if (EndOfBuffer(buffer) || x >= info->width) return false;
-						byte b = ReadByte(buffer);
+						uint8_t b = ReadByte(buffer);
 						*pixel++ = GB(b, 4, 4);
 						x++;
 						if (i++ < c) {
@@ -214,8 +214,8 @@ static inline bool BmpRead8(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
 {
 	uint i;
 	uint y;
-	byte pad = GB(4 - info->width, 0, 2);
-	byte *pixel;
+	uint8_t pad = GB(4 - info->width, 0, 2);
+	uint8_t *pixel;
 	for (y = info->height; y > 0; y--) {
 		if (EndOfBuffer(buffer)) return false; // the file is shorter than expected
 		pixel = &data->bitmap[(y - 1) * info->width];
@@ -233,12 +233,12 @@ static inline bool BmpRead8Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
 {
 	uint x = 0;
 	uint y = info->height - 1;
-	byte *pixel = &data->bitmap[y * info->width];
+	uint8_t *pixel = &data->bitmap[y * info->width];
 	while (y != 0 || x < info->width) {
 		if (EndOfBuffer(buffer)) return false; // the file is shorter than expected
 
-		byte n = ReadByte(buffer);
-		byte c = ReadByte(buffer);
+		uint8_t n = ReadByte(buffer);
+		uint8_t c = ReadByte(buffer);
 		if (n == 0) {
 			switch (c) {
 				case 0: // end of line
@@ -252,8 +252,8 @@ static inline bool BmpRead8Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
 
 				case 2: { // delta
 					if (EndOfBuffer(buffer)) return false;
-					byte dx = ReadByte(buffer);
-					byte dy = ReadByte(buffer);
+					uint8_t dx = ReadByte(buffer);
+					uint8_t dy = ReadByte(buffer);
 
 					/* Check for over- and underflow. */
 					if (x + dx >= info->width || x + dx < x || dy > y) return false;
@@ -294,8 +294,8 @@ static inline bool BmpRead8Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
 static inline bool BmpRead24(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
 {
 	uint x, y;
-	byte pad = GB(4 - info->width * 3, 0, 2);
-	byte *pixel_row;
+	uint8_t pad = GB(4 - info->width * 3, 0, 2);
+	uint8_t *pixel_row;
 	for (y = info->height; y > 0; y--) {
 		pixel_row = &data->bitmap[(y - 1) * info->width * 3];
 		for (x = 0; x < info->width; x++) {
@@ -395,7 +395,7 @@ bool BmpReadBitmap(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
 {
 	assert(info != nullptr && data != nullptr);
 
-	data->bitmap = CallocT<byte>(static_cast<size_t>(info->width) * info->height * ((info->bpp == 24) ? 3 : 1));
+	data->bitmap = CallocT<uint8_t>(static_cast<size_t>(info->width) * info->height * ((info->bpp == 24) ? 3 : 1));
 
 	/* Load image */
 	SetStreamOffset(buffer, info->offset);

--- a/src/bmp.h
+++ b/src/bmp.h
@@ -24,13 +24,13 @@ struct BmpInfo {
 
 struct BmpData {
 	Colour *palette;
-	byte   *bitmap;
+	uint8_t   *bitmap;
 };
 
 #define BMP_BUFFER_SIZE 1024
 
 struct BmpBuffer {
-	byte data[BMP_BUFFER_SIZE];
+	uint8_t data[BMP_BUFFER_SIZE];
 	int pos;
 	int read;
 	FILE *file;

--- a/src/bridge.h
+++ b/src/bridge.h
@@ -41,7 +41,7 @@ typedef uint BridgeType; ///< Bridge spec number.
  */
 struct BridgeSpec {
 	TimerGameCalendar::Year avail_year; ///< the year where it becomes available
-	byte min_length;                    ///< the minimum length (not counting start and end tile)
+	uint8_t min_length;                    ///< the minimum length (not counting start and end tile)
 	uint16_t max_length;                  ///< the maximum length (not counting start and end tile)
 	uint16_t price;                       ///< the price multiplier
 	uint16_t speed;                       ///< maximum travel speed (1 unit = 1/1.6 mph = 1 km-ish/h)
@@ -50,7 +50,7 @@ struct BridgeSpec {
 	StringID material;                  ///< the string that contains the bridge description
 	StringID transport_name[2];         ///< description of the bridge, when built for road or rail
 	PalSpriteID **sprite_table;         ///< table of sprites for drawing the bridge
-	byte flags;                         ///< bit 0 set: disable drawing of far pillars.
+	uint8_t flags;                         ///< bit 0 set: disable drawing of far pillars.
 };
 
 extern BridgeSpec _bridge[MAX_BRIDGES];

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -54,7 +54,7 @@ typedef GUIList<BuildBridgeData> GUIBridgeList; ///< List of bridges, used in #B
  * @param tile_start start tile
  * @param transport_type transport type.
  */
-void CcBuildBridge(Commands, const CommandCost &result, TileIndex end_tile, TileIndex tile_start, TransportType transport_type, BridgeType, byte)
+void CcBuildBridge(Commands, const CommandCost &result, TileIndex end_tile, TileIndex tile_start, TransportType transport_type, BridgeType, uint8_t)
 {
 	if (result.Failed()) return;
 	if (_settings_client.sound.confirm) SndPlayTileFx(SND_27_CONSTRUCTION_BRIDGE, end_tile);
@@ -82,7 +82,7 @@ private:
 	TileIndex start_tile;
 	TileIndex end_tile;
 	TransportType transport_type;
-	byte road_rail_type;
+	uint8_t road_rail_type;
 	GUIBridgeList bridges;
 	int icon_width; ///< Scaled width of the the bridge icon sprite.
 	Scrollbar *vscroll;
@@ -147,7 +147,7 @@ private:
 	}
 
 public:
-	BuildBridgeWindow(WindowDesc *desc, TileIndex start, TileIndex end, TransportType transport_type, byte road_rail_type, GUIBridgeList &&bl) : Window(desc),
+	BuildBridgeWindow(WindowDesc *desc, TileIndex start, TileIndex end, TransportType transport_type, uint8_t road_rail_type, GUIBridgeList &&bl) : Window(desc),
 		start_tile(start),
 		end_tile(end),
 		transport_type(transport_type),
@@ -358,7 +358,7 @@ static WindowDesc _build_bridge_desc(
  * @param transport_type The transport type
  * @param road_rail_type The road/rail type
  */
-void ShowBuildBridgeWindow(TileIndex start, TileIndex end, TransportType transport_type, byte road_rail_type)
+void ShowBuildBridgeWindow(TileIndex start, TileIndex end, TransportType transport_type, uint8_t road_rail_type)
 {
 	CloseWindowByClass(WC_BUILD_BRIDGE);
 

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -95,7 +95,7 @@ static constexpr NWidgetPart _nested_build_vehicle_widgets[] = {
 
 
 bool _engine_sort_direction; ///< \c false = descending, \c true = ascending.
-byte _engine_sort_last_criteria[]       = {0, 0, 0, 0};                 ///< Last set sort criteria, for each vehicle type.
+uint8_t _engine_sort_last_criteria[]       = {0, 0, 0, 0};                 ///< Last set sort criteria, for each vehicle type.
 bool _engine_sort_last_order[]          = {false, false, false, false}; ///< Last set direction of the sort order, for each vehicle type.
 bool _engine_sort_show_hidden_engines[] = {false, false, false, false}; ///< Last set 'show hidden engines' setting for each vehicle type.
 static CargoID _engine_sort_last_cargo_criteria[] = {CargoFilterCriteria::CF_ANY, CargoFilterCriteria::CF_ANY, CargoFilterCriteria::CF_ANY, CargoFilterCriteria::CF_ANY}; ///< Last set filter criteria, for each vehicle type.
@@ -1126,7 +1126,7 @@ struct BuildVehicleWindow : Window {
 		RoadType roadtype;   ///< Road type to show, or #INVALID_ROADTYPE.
 	} filter;                                   ///< Filter to apply.
 	bool descending_sort_order;                 ///< Sort direction, @see _engine_sort_direction
-	byte sort_criteria;                         ///< Current sort criterium.
+	uint8_t sort_criteria;                         ///< Current sort criterium.
 	bool show_hidden_engines;                   ///< State of the 'show hidden engines' button.
 	bool listview_mode;                         ///< If set, only display the available vehicles and do not show a 'build' button.
 	EngineID sel_engine;                        ///< Currently selected engine, or #INVALID_ENGINE

--- a/src/cargo_type.h
+++ b/src/cargo_type.h
@@ -19,7 +19,7 @@ using CargoLabel = StrongType::Typedef<uint32_t, struct CargoLabelTag, StrongTyp
 /**
  * Cargo slots to indicate a cargo type within a game.
  */
-using CargoID = byte;
+using CargoID = uint8_t;
 
 /**
  * Available types of cargo
@@ -134,7 +134,7 @@ struct CargoArray : std::array<uint, NUM_CARGO> {
 
 
 /** Types of cargo source and destination */
-enum class SourceType : byte {
+enum class SourceType : uint8_t {
 	Industry,     ///< Source/destination is an industry
 	Town,         ///< Source/destination is a town
 	Headquarters, ///< Source/destination are company headquarters

--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -18,7 +18,7 @@
 #include "core/bitmath_func.hpp"
 
 /** Town growth effect when delivering cargo. */
-enum TownAcceptanceEffect : byte {
+enum TownAcceptanceEffect : uint8_t {
 	TAE_BEGIN = 0,
 	TAE_NONE = TAE_BEGIN, ///< Cargo has no effect.
 	TAE_PASSENGERS, ///< Cargo behaves passenger-like.
@@ -31,7 +31,7 @@ enum TownAcceptanceEffect : byte {
 };
 
 /** Town effect when producing cargo. */
-enum TownProductionEffect : byte {
+enum TownProductionEffect : uint8_t {
 	TPE_NONE, ///< Town will not produce this cargo type.
 	TPE_PASSENGERS, ///< Cargo behaves passenger-like for production.
 	TPE_MAIL, ///< Cargo behaves mail-like for production.
@@ -60,7 +60,7 @@ enum CargoClass {
 	CC_SPECIAL      = 1 << 15, ///< Special bit used for livery refit tricks instead of normal cargoes.
 };
 
-static const byte INVALID_CARGO_BITNUM = 0xFF; ///< Constant representing invalid cargo
+static const uint8_t INVALID_CARGO_BITNUM = 0xFF; ///< Constant representing invalid cargo
 
 static const uint TOWN_PRODUCTION_DIVISOR = 256;
 

--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -44,7 +44,7 @@ static CommandCost ClearTile_Clear(TileIndex tile, DoCommandFlag flags)
 	return price;
 }
 
-void DrawClearLandTile(const TileInfo *ti, byte set)
+void DrawClearLandTile(const TileInfo *ti, uint8_t set)
 {
 	DrawGroundSprite(SPR_FLAT_BARE_LAND + SlopeToSpriteOffset(ti->tileh) + set * 19, PAL_NONE);
 }

--- a/src/clear_func.h
+++ b/src/clear_func.h
@@ -13,6 +13,6 @@
 #include "tile_cmd.h"
 
 void DrawHillyLandTile(const TileInfo *ti);
-void DrawClearLandTile(const TileInfo *ti, byte set);
+void DrawClearLandTile(const TileInfo *ti, uint8_t set);
 
 #endif /* CLEAR_FUNC_H */

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -462,7 +462,7 @@ template <Commands Tcmd> struct CommandTraits;
 	};
 
 /** Storage buffer for serialized command data. */
-typedef std::vector<byte> CommandDataBuffer;
+typedef std::vector<uint8_t> CommandDataBuffer;
 
 /**
  * Define a callback function for the client, after the command is finished.

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -78,20 +78,20 @@ struct CompanyProperties {
 	CompanyManagerFace face;         ///< Face description of the president.
 
 	Money money;                     ///< Money owned by the company.
-	byte money_fraction;             ///< Fraction of money of the company, too small to represent in #money.
+	uint8_t money_fraction;             ///< Fraction of money of the company, too small to represent in #money.
 	Money current_loan;              ///< Amount of money borrowed from the bank.
 	Money max_loan;                  ///< Max allowed amount of the loan or COMPANY_MAX_LOAN_DEFAULT.
 
 	Colours colour;                  ///< Company colour.
 
-	byte block_preview;              ///< Number of quarters that the company is not allowed to get new exclusive engine previews (see CompaniesGenStatistics).
+	uint8_t block_preview;              ///< Number of quarters that the company is not allowed to get new exclusive engine previews (see CompaniesGenStatistics).
 
 	TileIndex location_of_HQ;        ///< Northern tile of HQ; #INVALID_TILE when there is none.
 	TileIndex last_build_coordinate; ///< Coordinate of the last build thing by this company.
 
 	TimerGameEconomy::Year inaugurated_year; ///< Economy year of starting the company.
 
-	byte months_of_bankruptcy;       ///< Number of months that the company is unable to pay its debts
+	uint8_t months_of_bankruptcy;       ///< Number of months that the company is unable to pay its debts
 	CompanyMask bankrupt_asked;      ///< which companies were asked about buying it?
 	int16_t bankrupt_timeout;          ///< If bigger than \c 0, amount of time to wait for an answer on an offer to buy this company.
 	Money bankrupt_value;
@@ -110,7 +110,7 @@ struct CompanyProperties {
 	std::array<Expenses, 3> yearly_expenses{}; ///< Expenses of the company for the last three years.
 	CompanyEconomyEntry cur_economy;                       ///< Economic data of the company of this quarter.
 	CompanyEconomyEntry old_economy[MAX_HISTORY_QUARTERS]; ///< Economic data of the company of the last #MAX_HISTORY_QUARTERS quarters.
-	byte num_valid_stat_ent;                               ///< Number of valid statistical entries in #old_economy.
+	uint8_t num_valid_stat_ent;                               ///< Number of valid statistical entries in #old_economy.
 
 	Livery livery[LS_END];
 

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -298,10 +298,10 @@ void SubtractMoneyFromCompany(const CommandCost &cost)
 void SubtractMoneyFromCompanyFract(CompanyID company, const CommandCost &cst)
 {
 	Company *c = Company::Get(company);
-	byte m = c->money_fraction;
+	uint8_t m = c->money_fraction;
 	Money cost = cst.GetCost();
 
-	c->money_fraction = m - (byte)cost;
+	c->money_fraction = m - (uint8_t)cost;
 	cost >>= 8;
 	if (c->money_fraction > m) cost++;
 	if (cost != 0) SubtractMoneyFromAnyCompany(c, CommandCost(cst.GetExpensesType(), cost));
@@ -447,7 +447,7 @@ bad_town_name:;
 }
 
 /** Sorting weights for the company colours. */
-static const byte _colour_sort[COLOUR_END] = {2, 2, 3, 2, 3, 2, 3, 2, 3, 2, 2, 2, 3, 1, 1, 1};
+static const uint8_t _colour_sort[COLOUR_END] = {2, 2, 3, 2, 3, 2, 3, 2, 3, 2, 2, 2, 3, 1, 1, 1};
 /** Similar colours, so we can try to prevent same coloured companies. */
 static const Colours _similar_colour[COLOUR_END][2] = {
 	{ COLOUR_BLUE,       COLOUR_LIGHT_BLUE }, // COLOUR_DARK_BLUE

--- a/src/company_cmd.h
+++ b/src/company_cmd.h
@@ -15,7 +15,7 @@
 #include "livery.h"
 
 enum ClientID : uint32_t;
-enum Colours : byte;
+enum Colours : uint8_t;
 
 CommandCost CmdCompanyCtrl(DoCommandFlag flags, CompanyCtrlAction cca, CompanyID company_id, CompanyRemoveReason reason, ClientID client_id);
 CommandCost CmdGiveMoney(DoCommandFlag flags, Money money, CompanyID dest_company);

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -610,7 +610,7 @@ private:
 		uint32_t used_colours = 0;
 		const Livery *livery, *default_livery = nullptr;
 		bool primary = widget == WID_SCL_PRI_COL_DROPDOWN;
-		byte default_col = 0;
+		uint8_t default_col = 0;
 
 		/* Disallow other company colours for the primary colour */
 		if (this->livery_class < LC_GROUP_RAIL && HasBit(this->sel, LS_DEFAULT) && primary) {
@@ -651,7 +651,7 @@ private:
 			list.push_back(std::make_unique<DropDownListColourItem<>>(i, HasBit(used_colours, i)));
 		}
 
-		byte sel;
+		uint8_t sel;
 		if (default_livery == nullptr || HasBit(livery->in_use, primary ? 0 : 1)) {
 			sel = primary ? livery->colour1 : livery->colour2;
 		} else {
@@ -2524,7 +2524,7 @@ struct CompanyWindow : Window
 			}
 
 			case WID_C_BUILD_HQ:
-				if ((byte)this->window_number != _local_company) return;
+				if ((uint8_t)this->window_number != _local_company) return;
 				if (this->IsWidgetLowered(WID_C_BUILD_HQ)) {
 					ResetObjectToPlace();
 					this->RaiseButtons();

--- a/src/company_manager_face.h
+++ b/src/company_manager_face.h
@@ -54,9 +54,9 @@ DECLARE_POSTFIX_INCREMENT(CompanyManagerFaceVariable)
 
 /** Information about the valid values of CompanyManagerFace bitgroups as well as the sprites to draw */
 struct CompanyManagerFaceBitsInfo {
-	byte     offset;               ///< Offset in bits into the CompanyManagerFace
-	byte     length;               ///< Number of bits used in the CompanyManagerFace
-	byte     valid_values[GE_END]; ///< The number of valid values per gender/ethnicity
+	uint8_t     offset;               ///< Offset in bits into the CompanyManagerFace
+	uint8_t     length;               ///< Number of bits used in the CompanyManagerFace
+	uint8_t     valid_values[GE_END]; ///< The number of valid values per gender/ethnicity
 	SpriteID first_sprite[GE_END]; ///< The first sprite per gender/ethnicity
 };
 

--- a/src/company_type.h
+++ b/src/company_type.h
@@ -15,7 +15,7 @@
 /**
  * Enum for all companies/owners.
  */
-enum Owner : byte {
+enum Owner : uint8_t {
 	/* All companies below MAX_COMPANIES are playable
 	 * companies, above, they are special, computer controlled 'companies' */
 	OWNER_BEGIN     = 0x00, ///< First owner

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -206,7 +206,7 @@ static std::string RemoveUnderscores(std::string name)
  * @param tokencount the number of parameters passed
  * @param *tokens are the parameters given to the original command (0 is the first param)
  */
-static void IConsoleAliasExec(const IConsoleAlias *alias, byte tokencount, char *tokens[ICON_TOKEN_COUNT], const uint recurse_count)
+static void IConsoleAliasExec(const IConsoleAlias *alias, uint8_t tokencount, char *tokens[ICON_TOKEN_COUNT], const uint recurse_count)
 {
 	std::string alias_buffer;
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -89,7 +89,7 @@ static ConsoleFileList _console_file_list_scenario{FT_SCENARIO, false}; ///< Fil
 static ConsoleFileList _console_file_list_heightmap{FT_HEIGHTMAP, false}; ///< File storage cache for heightmaps.
 
 /* console command defines */
-#define DEF_CONSOLE_CMD(function) static bool function([[maybe_unused]] byte argc, [[maybe_unused]] char *argv[])
+#define DEF_CONSOLE_CMD(function) static bool function([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 #define DEF_CONSOLE_HOOK(function) static ConsoleHookResult function(bool echo)
 
 
@@ -2113,7 +2113,7 @@ DEF_CONSOLE_CMD(ConFont)
 		uint size = setting->size;
 		bool aa = setting->aa;
 
-		byte arg_index = 2;
+		uint8_t arg_index = 2;
 		/* We may encounter "aa" or "noaa" but it must be the last argument. */
 		if (StrEqualsIgnoreCase(argv[arg_index], "aa") || StrEqualsIgnoreCase(argv[arg_index], "noaa")) {
 			aa = !StrStartsWithIgnoreCase(argv[arg_index++], "no");

--- a/src/console_internal.h
+++ b/src/console_internal.h
@@ -30,7 +30,7 @@ enum ConsoleHookResult {
  * If you want to handle multiple words as one, enclose them in double-quotes
  * eg. 'say "hello everybody"'
  */
-typedef bool IConsoleCmdProc(byte argc, char *argv[]);
+typedef bool IConsoleCmdProc(uint8_t argc, char *argv[]);
 typedef ConsoleHookResult IConsoleHook(bool echo);
 struct IConsoleCmd {
 	IConsoleCmd(const std::string &name, IConsoleCmdProc *proc, IConsoleHook *hook) : name(name), proc(proc), hook(hook) {}

--- a/src/core/alloc_type.hpp
+++ b/src/core/alloc_type.hpp
@@ -93,14 +93,14 @@ public:
 	 * @param size the amount of bytes to allocate.
 	 * @return the given amounts of bytes zeroed.
 	 */
-	inline void *operator new(size_t size) { return CallocT<byte>(size); }
+	inline void *operator new(size_t size) { return CallocT<uint8_t>(size); }
 
 	/**
 	 * Memory allocator for an array of class instances.
 	 * @param size the amount of bytes to allocate.
 	 * @return the given amounts of bytes zeroed.
 	 */
-	inline void *operator new[](size_t size) { return CallocT<byte>(size); }
+	inline void *operator new[](size_t size) { return CallocT<uint8_t>(size); }
 
 	/**
 	 * Memory release for a single class instance.

--- a/src/core/mem_func.hpp
+++ b/src/core/mem_func.hpp
@@ -46,7 +46,7 @@ inline void MemMoveT(T *destination, const T *source, size_t num = 1)
  * @param num number of items to be set (!not number of bytes!)
  */
 template <typename T>
-inline void MemSetT(T *ptr, byte value, size_t num = 1)
+inline void MemSetT(T *ptr, uint8_t value, size_t num = 1)
 {
 	memset(ptr, value, num * sizeof(T));
 }

--- a/src/core/overflowsafe_type.hpp
+++ b/src/core/overflowsafe_type.hpp
@@ -140,7 +140,7 @@ public:
 	inline constexpr OverflowSafeInt operator * (const int    factor) const { OverflowSafeInt result = *this; result *= (int64_t)factor; return result; }
 	inline constexpr OverflowSafeInt operator * (const uint   factor) const { OverflowSafeInt result = *this; result *= (int64_t)factor; return result; }
 	inline constexpr OverflowSafeInt operator * (const uint16_t factor) const { OverflowSafeInt result = *this; result *= (int64_t)factor; return result; }
-	inline constexpr OverflowSafeInt operator * (const byte   factor) const { OverflowSafeInt result = *this; result *= (int64_t)factor; return result; }
+	inline constexpr OverflowSafeInt operator * (const uint8_t   factor) const { OverflowSafeInt result = *this; result *= (int64_t)factor; return result; }
 
 	/* Operators for division. */
 	inline constexpr OverflowSafeInt& operator /= (const int64_t            divisor)       { this->m_value /= divisor; return *this; }
@@ -200,10 +200,10 @@ template <class T> inline constexpr OverflowSafeInt<T> operator * (const uint  a
 template <class T> inline constexpr OverflowSafeInt<T> operator / (const uint  a, const OverflowSafeInt<T> b) { return (OverflowSafeInt<T>)a / (int)b; }
 
 /* Sometimes we got byte operator OverflowSafeInt instead of vice versa. Handle that properly. */
-template <class T> inline constexpr OverflowSafeInt<T> operator + (const byte  a, const OverflowSafeInt<T> b) { return b + (uint)a; }
-template <class T> inline constexpr OverflowSafeInt<T> operator - (const byte  a, const OverflowSafeInt<T> b) { return -b + (uint)a; }
-template <class T> inline constexpr OverflowSafeInt<T> operator * (const byte  a, const OverflowSafeInt<T> b) { return b * (uint)a; }
-template <class T> inline constexpr OverflowSafeInt<T> operator / (const byte  a, const OverflowSafeInt<T> b) { return (OverflowSafeInt<T>)a / (int)b; }
+template <class T> inline constexpr OverflowSafeInt<T> operator + (const uint8_t  a, const OverflowSafeInt<T> b) { return b + (uint)a; }
+template <class T> inline constexpr OverflowSafeInt<T> operator - (const uint8_t  a, const OverflowSafeInt<T> b) { return -b + (uint)a; }
+template <class T> inline constexpr OverflowSafeInt<T> operator * (const uint8_t  a, const OverflowSafeInt<T> b) { return b * (uint)a; }
+template <class T> inline constexpr OverflowSafeInt<T> operator / (const uint8_t  a, const OverflowSafeInt<T> b) { return (OverflowSafeInt<T>)a / (int)b; }
 
 typedef OverflowSafeInt<int64_t> OverflowSafeInt64;
 typedef OverflowSafeInt<int32_t> OverflowSafeInt32;

--- a/src/core/pool_func.hpp
+++ b/src/core/pool_func.hpp
@@ -123,9 +123,9 @@ DEFINE_POOL_METHOD(inline void *)::AllocateItem(size_t size, size_t index)
 			memset((void *)item, 0, sizeof(Titem));
 		}
 	} else if (Tzero) {
-		item = (Titem *)CallocT<byte>(size);
+		item = (Titem *)CallocT<uint8_t>(size);
 	} else {
-		item = (Titem *)MallocT<byte>(size);
+		item = (Titem *)MallocT<uint8_t>(size);
 	}
 	this->data[index] = item;
 	SetBit(this->used_bitmap[index / BITMAP_SIZE], index % BITMAP_SIZE);

--- a/src/core/random_func.cpp
+++ b/src/core/random_func.cpp
@@ -73,7 +73,7 @@ void SetRandomSeed(uint32_t seed)
 uint32_t Random(const std::source_location location)
 {
 	if (_networking && (!_network_server || (NetworkClientSocket::IsValidID(0) && NetworkClientSocket::Get(0)->status != NetworkClientSocket::STATUS_INACTIVE))) {
-		Debug(random, 0, "{:08x}; {:02x}; {:04x}; {:02x}; {}:{}", TimerGameEconomy::date, TimerGameEconomy::date_fract, _frame_counter, (byte)_current_company, location.file_name(), location.line());
+		Debug(random, 0, "{:08x}; {:02x}; {:04x}; {:02x}; {}:{}", TimerGameEconomy::date, TimerGameEconomy::date_fract, _frame_counter, (uint8_t)_current_company, location.file_name(), location.line());
 	}
 
 	return _random.Next();

--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -82,7 +82,7 @@ CurrencySpec _currency_specs[CURRENCY_END];
  * When a grf sends currencies, they are based on the order defined by TTDPatch.
  * So, we must reindex them to our own order.
  */
-const byte TTDPatch_To_OTTDIndex[] =
+const uint8_t TTDPatch_To_OTTDIndex[] =
 {
 	CURRENCY_GBP,
 	CURRENCY_USD,
@@ -113,7 +113,7 @@ const byte TTDPatch_To_OTTDIndex[] =
  * @param grfcurr_id currency id coming from newgrf
  * @return the corrected index
  */
-byte GetNewgrfCurrencyIdConverted(byte grfcurr_id)
+uint8_t GetNewgrfCurrencyIdConverted(uint8_t grfcurr_id)
 {
 	return (grfcurr_id >= lengthof(TTDPatch_To_OTTDIndex)) ? grfcurr_id : TTDPatch_To_OTTDIndex[grfcurr_id];
 }

--- a/src/currency.h
+++ b/src/currency.h
@@ -88,12 +88,12 @@ struct CurrencySpec {
 	 *            It is not a spec from Newgrf,
 	 *            rather a way to let users do what they want with custom currency
 	 */
-	byte symbol_pos;
+	uint8_t symbol_pos;
 	StringID name;
 
 	CurrencySpec() = default;
 
-	CurrencySpec(uint16_t rate, const char *separator, TimerGameCalendar::Year to_euro, const char *prefix, const char *suffix, const char *code, byte symbol_pos, StringID name) :
+	CurrencySpec(uint16_t rate, const char *separator, TimerGameCalendar::Year to_euro, const char *prefix, const char *suffix, const char *code, uint8_t symbol_pos, StringID name) :
 		rate(rate), separator(separator), to_euro(to_euro), prefix(prefix), suffix(suffix), code(code), symbol_pos(symbol_pos), name(name)
 	{
 	}
@@ -107,6 +107,6 @@ extern CurrencySpec _currency_specs[CURRENCY_END];
 
 uint64_t GetMaskOfAllowedCurrencies();
 void ResetCurrencies(bool preserve_custom = true);
-byte GetNewgrfCurrencyIdConverted(byte grfcurr_id);
+uint8_t GetNewgrfCurrencyIdConverted(uint8_t grfcurr_id);
 
 #endif /* CURRENCY_H */

--- a/src/direction_type.h
+++ b/src/direction_type.h
@@ -21,7 +21,7 @@
  * your viewport and not rotated by 45 degrees left or right to get
  * a "north" used in you games.
  */
-enum Direction : byte {
+enum Direction : uint8_t {
 	DIR_BEGIN = 0,          ///< Used to iterate
 	DIR_N   = 0,            ///< North
 	DIR_NE  = 1,            ///< Northeast
@@ -70,7 +70,7 @@ enum DirDiff {
  *
  * This enumeration is used for the 4 direction of the tile-edges.
  */
-enum DiagDirection : byte {
+enum DiagDirection : uint8_t {
 	DIAGDIR_BEGIN = 0,      ///< Used for iterations
 	DIAGDIR_NE  = 0,        ///< Northeast, upper right on your monitor
 	DIAGDIR_SE  = 1,        ///< Southeast
@@ -113,7 +113,7 @@ DECLARE_POSTFIX_INCREMENT(DiagDirDiff)
  * (and south-east edge). The Y axis must be so the one which goes
  * align the north-east edge (and south-west) edge.
  */
-enum Axis : byte {
+enum Axis : uint8_t {
 	AXIS_X = 0,          ///< The X axis
 	AXIS_Y = 1,          ///< The y axis
 	AXIS_END,            ///< Used for iterations

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -925,11 +925,11 @@ static const Disaster _disasters[] = {
 
 static void DoDisaster()
 {
-	byte buf[lengthof(_disasters)];
+	uint8_t buf[lengthof(_disasters)];
 
-	byte j = 0;
+	uint8_t j = 0;
 	for (size_t i = 0; i != lengthof(_disasters); i++) {
-		if (TimerGameCalendar::year >= _disasters[i].min_year && TimerGameCalendar::year < _disasters[i].max_year) buf[j++] = (byte)i;
+		if (TimerGameCalendar::year >= _disasters[i].min_year && TimerGameCalendar::year < _disasters[i].max_year) buf[j++] = (uint8_t)i;
 	}
 
 	if (j == 0) return;

--- a/src/disaster_vehicle.h
+++ b/src/disaster_vehicle.h
@@ -37,7 +37,7 @@ enum DisasterSubType {
 struct DisasterVehicle final : public SpecializedVehicle<DisasterVehicle, VEH_DISASTER> {
 	SpriteID image_override;            ///< Override for the default disaster vehicle sprite.
 	VehicleID big_ufo_destroyer_target; ///< The big UFO that this destroyer is supposed to bomb.
-	byte flags;                         ///< Flags about the state of the vehicle, @see AirVehicleFlags
+	uint8_t flags;                         ///< Flags about the state of the vehicle, @see AirVehicleFlags
 	uint16_t state;                     ///< Action stage of the disaster vehicle.
 
 	/** For use by saveload. */

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -118,7 +118,7 @@ static Money CalculateCompanyAssetValue(const Company *c)
 	uint num = 0;
 
 	for (const Station *st : Station::Iterate()) {
-		if (st->owner == owner) num += CountBits((byte)st->facilities);
+		if (st->owner == owner) num += CountBits((uint8_t)st->facilities);
 	}
 
 	Money value = num * _price[PR_STATION_VALUE] * 25;
@@ -239,7 +239,7 @@ int UpdateCompanyRatingAndValue(Company *c, bool update)
 		uint num = 0;
 		for (const Station *st : Station::Iterate()) {
 			/* Only count stations that are actually serviced */
-			if (st->owner == owner && (st->time_since_load <= 20 || st->time_since_unload <= 20)) num += CountBits((byte)st->facilities);
+			if (st->owner == owner && (st->time_since_load <= 20 || st->time_since_unload <= 20)) num += CountBits((uint8_t)st->facilities);
 		}
 		_score_part[owner][SCORE_STATIONS] = num;
 	}

--- a/src/economy_type.h
+++ b/src/economy_type.h
@@ -43,9 +43,9 @@ static const int DEF_CARGO_SCALE = 100;
 struct Economy {
 	Money max_loan;                       ///< NOSAVE: Maximum possible loan
 	int16_t fluct;                          ///< Economy fluctuation status
-	byte interest_rate;                   ///< Interest
-	byte infl_amount;                     ///< inflation amount
-	byte infl_amount_pr;                  ///< inflation rate for payment rates
+	uint8_t interest_rate;                   ///< Interest
+	uint8_t infl_amount;                     ///< inflation amount
+	uint8_t infl_amount_pr;                  ///< inflation rate for payment rates
 	uint32_t industry_daily_change_counter; ///< Bits 31-16 are number of industry to be performed, 15-0 are fractional collected daily
 	uint32_t industry_daily_increment;      ///< The value which will increment industry_daily_change_counter. Computed value. NOSAVE
 	uint64_t inflation_prices;              ///< Cumulated inflation of prices since game start; 16 bit fractional part
@@ -169,7 +169,7 @@ typedef Money Prices[PR_END]; ///< Prices of everything. @see Price
 typedef int8_t PriceMultipliers[PR_END];
 
 /** Types of expenses. */
-enum ExpensesType : byte {
+enum ExpensesType : uint8_t {
 	EXPENSES_CONSTRUCTION =  0,   ///< Construction costs.
 	EXPENSES_NEW_VEHICLES,        ///< New vehicles.
 	EXPENSES_TRAIN_RUN,           ///< Running costs trains.

--- a/src/effectvehicle.cpp
+++ b/src/effectvehicle.cpp
@@ -245,9 +245,9 @@ static void BulldozerInit(EffectVehicle *v)
 }
 
 struct BulldozerMovement {
-	byte direction:2;
-	byte image:2;
-	byte duration:3;
+	uint8_t direction:2;
+	uint8_t image:2;
+	uint8_t duration:3;
 };
 
 static const BulldozerMovement _bulldozer_movement[] = {
@@ -320,7 +320,7 @@ struct BubbleMovement {
 	int8_t x:4;
 	int8_t y:4;
 	int8_t z:4;
-	byte image:4;
+	uint8_t image:4;
 };
 
 #define MK(x, y, z, i) { x, y, z, i }

--- a/src/effectvehicle_base.h
+++ b/src/effectvehicle_base.h
@@ -23,7 +23,7 @@
  */
 struct EffectVehicle final : public SpecializedVehicle<EffectVehicle, VEH_EFFECT> {
 	uint16_t animation_state;  ///< State primarily used to change the graphics/behaviour.
-	byte animation_substate; ///< Sub state to time the change of the graphics/behaviour.
+	uint8_t animation_substate; ///< Sub state to time the change of the graphics/behaviour.
 
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
 	EffectVehicle() : SpecializedVehicleBase() {}

--- a/src/elrail.cpp
+++ b/src/elrail.cpp
@@ -83,7 +83,7 @@ static inline TLG GetTLG(TileIndex t)
  * @param override pointer to PCP override, can be nullptr
  * @return trackbits of tile if it is electrified
  */
-static TrackBits GetRailTrackBitsUniversal(TileIndex t, byte *override)
+static TrackBits GetRailTrackBitsUniversal(TileIndex t, uint8_t *override)
 {
 	switch (GetTileType(t)) {
 		case MP_RAILWAY:
@@ -295,10 +295,10 @@ static void DrawRailCatenaryRailway(const TileInfo *ti)
 	}
 
 	TLG tlg = GetTLG(ti->tile);
-	byte PCPstatus = 0;
-	byte OverridePCP = 0;
-	byte PPPpreferred[DIAGDIR_END];
-	byte PPPallowed[DIAGDIR_END];
+	uint8_t PCPstatus = 0;
+	uint8_t OverridePCP = 0;
+	uint8_t PPPpreferred[DIAGDIR_END];
+	uint8_t PPPallowed[DIAGDIR_END];
 
 	/* Find which rail bits are present, and select the override points.
 	 * We don't draw a pylon:
@@ -425,7 +425,7 @@ static void DrawRailCatenaryRailway(const TileInfo *ti)
 		if (PPPallowed[i] != 0 && HasBit(PCPstatus, i) && !HasBit(OverridePCP, i) &&
 				(!IsRailStationTile(ti->tile) || CanStationTileHavePylons(ti->tile))) {
 			for (Direction k = DIR_BEGIN; k < DIR_END; k++) {
-				byte temp = PPPorder[i][GetTLG(ti->tile)][k];
+				uint8_t temp = PPPorder[i][GetTLG(ti->tile)][k];
 
 				if (HasBit(PPPallowed[i], temp)) {
 					uint x  = ti->x + x_pcp_offsets[i] + x_ppp_offsets[temp];
@@ -474,7 +474,7 @@ static void DrawRailCatenaryRailway(const TileInfo *ti)
 	/* Drawing of pylons is finished, now draw the wires */
 	for (Track t : SetTrackBitIterator(wireconfig[TS_HOME])) {
 		SpriteID wire_base = (t == halftile_track) ? wire_halftile : wire_normal;
-		byte PCPconfig = HasBit(PCPstatus, PCPpositions[t][0]) +
+		uint8_t PCPconfig = HasBit(PCPstatus, PCPpositions[t][0]) +
 			(HasBit(PCPstatus, PCPpositions[t][1]) << 1);
 
 		const SortableSpriteStruct *sss;

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -23,7 +23,7 @@ struct WagonOverride {
 };
 
 /** Flags used client-side in the purchase/autorenew engine list. */
-enum class EngineDisplayFlags : byte {
+enum class EngineDisplayFlags : uint8_t {
 	None        = 0,         ///< No flag set.
 	HasVariants = (1U << 0), ///< Set if engine has variants.
 	IsFolded    = (1U << 1), ///< Set if display of variants should be folded (hidden).
@@ -46,10 +46,10 @@ struct Engine : EnginePool::PoolItem<&_engine_pool> {
 	uint16_t duration_phase_1;    ///< First reliability phase in months, increasing reliability from #reliability_start to #reliability_max.
 	uint16_t duration_phase_2;    ///< Second reliability phase in months, keeping #reliability_max.
 	uint16_t duration_phase_3;    ///< Third reliability phase in months, decaying to #reliability_final.
-	byte flags;                 ///< Flags of the engine. @see EngineFlags
+	uint8_t flags;                 ///< Flags of the engine. @see EngineFlags
 	CompanyMask preview_asked;  ///< Bit for each company which has already been offered a preview.
 	CompanyID preview_company;  ///< Company which is currently being offered a preview \c INVALID_COMPANY means no company.
-	byte preview_wait;          ///< Daily countdown timer for timeout of offering the engine to the #preview_company company.
+	uint8_t preview_wait;          ///< Daily countdown timer for timeout of offering the engine to the #preview_company company.
 	CompanyMask company_avail;  ///< Bit for each company whether the engine is available for that company.
 	CompanyMask company_hidden; ///< Bit for each company whether the engine is normally hidden in the build gui for that company.
 	uint8_t original_image_index; ///< Original vehicle image index, thus the image index of the overridden vehicle

--- a/src/engine_gui.h
+++ b/src/engine_gui.h
@@ -44,7 +44,7 @@ void DrawShipEngine(int left, int right, int preferred_x, int y, EngineID engine
 void DrawAircraftEngine(int left, int right, int preferred_x, int y, EngineID engine, PaletteID pal, EngineImageType image_type);
 
 extern bool _engine_sort_direction;
-extern byte _engine_sort_last_criteria[];
+extern uint8_t _engine_sort_last_criteria[];
 extern bool _engine_sort_last_order[];
 extern bool _engine_sort_show_hidden_engines[];
 extern const StringID _engine_sort_listing[][12];

--- a/src/engine_type.h
+++ b/src/engine_type.h
@@ -40,42 +40,42 @@ enum EngineClass {
 
 /** Information about a rail vehicle. */
 struct RailVehicleInfo {
-	byte image_index;
+	uint8_t image_index;
 	RailVehicleTypes railveh_type;
-	byte cost_factor;               ///< Purchase cost factor;      For multiheaded engines the sum of both engine prices.
+	uint8_t cost_factor;               ///< Purchase cost factor;      For multiheaded engines the sum of both engine prices.
 	RailType railtype;              ///< Railtype, mangled if elrail is disabled.
 	RailType intended_railtype;     ///< Intended railtype, regardless of elrail being enabled or disabled.
 	uint16_t max_speed;               ///< Maximum speed (1 unit = 1/1.6 mph = 1 km-ish/h)
 	uint16_t power;                   ///< Power of engine (hp);      For multiheaded engines the sum of both engine powers.
 	uint16_t weight;                  ///< Weight of vehicle (tons);  For multiheaded engines the weight of each single engine.
-	byte running_cost;              ///< Running cost of engine;    For multiheaded engines the sum of both running costs.
+	uint8_t running_cost;              ///< Running cost of engine;    For multiheaded engines the sum of both running costs.
 	Price running_cost_class;
 	EngineClass engclass;           ///< Class of engine for this vehicle
-	byte capacity;                  ///< Cargo capacity of vehicle; For multiheaded engines the capacity of each single engine.
-	byte ai_passenger_only;         ///< Bit value to tell AI that this engine is for passenger use only
+	uint8_t capacity;                  ///< Cargo capacity of vehicle; For multiheaded engines the capacity of each single engine.
+	uint8_t ai_passenger_only;         ///< Bit value to tell AI that this engine is for passenger use only
 	uint16_t pow_wag_power;           ///< Extra power applied to consist if wagon should be powered
-	byte pow_wag_weight;            ///< Extra weight applied to consist if wagon should be powered
-	byte visual_effect;             ///< Bitstuffed NewGRF visual effect data
-	byte shorten_factor;            ///< length on main map for this type is 8 - shorten_factor
-	byte tractive_effort;           ///< Tractive effort coefficient
-	byte air_drag;                  ///< Coefficient of air drag
-	byte user_def_data;             ///< Property 0x25: "User-defined bit mask" Used only for (very few) NewGRF vehicles
+	uint8_t pow_wag_weight;            ///< Extra weight applied to consist if wagon should be powered
+	uint8_t visual_effect;             ///< Bitstuffed NewGRF visual effect data
+	uint8_t shorten_factor;            ///< length on main map for this type is 8 - shorten_factor
+	uint8_t tractive_effort;           ///< Tractive effort coefficient
+	uint8_t air_drag;                  ///< Coefficient of air drag
+	uint8_t user_def_data;             ///< Property 0x25: "User-defined bit mask" Used only for (very few) NewGRF vehicles
 	int16_t curve_speed_mod;          ///< Modifier to maximum speed in curves (fixed-point binary with 8 fractional bits)
 };
 
 /** Information about a ship vehicle. */
 struct ShipVehicleInfo {
-	byte image_index;
-	byte cost_factor;
+	uint8_t image_index;
+	uint8_t cost_factor;
 	uint8_t acceleration;    ///< Acceleration (1 unit = 1/3.2 mph per tick = 0.5 km-ish/h per tick)
 	uint16_t max_speed;      ///< Maximum speed (1 unit = 1/3.2 mph = 0.5 km-ish/h)
 	uint16_t capacity;
-	byte running_cost;
+	uint8_t running_cost;
 	SoundID sfx;
 	bool old_refittable;   ///< Is ship refittable; only used during initialisation. Later use EngineInfo::refit_mask.
-	byte visual_effect;    ///< Bitstuffed NewGRF visual effect data
-	byte ocean_speed_frac; ///< Fraction of maximum speed for ocean tiles.
-	byte canal_speed_frac; ///< Fraction of maximum speed for canal/river tiles.
+	uint8_t visual_effect;    ///< Bitstuffed NewGRF visual effect data
+	uint8_t ocean_speed_frac; ///< Fraction of maximum speed for ocean tiles.
+	uint8_t canal_speed_frac; ///< Fraction of maximum speed for canal/river tiles.
 
 	/** Apply ocean/canal speed fraction to a velocity */
 	uint ApplyWaterClassSpeedFrac(uint raw_speed, bool is_ocean) const
@@ -98,33 +98,33 @@ enum AircraftSubTypeBits {
 
 /** Information about a aircraft vehicle. */
 struct AircraftVehicleInfo {
-	byte image_index;
-	byte cost_factor;
-	byte running_cost;
-	byte subtype;               ///< Type of aircraft. @see AircraftSubTypeBits
+	uint8_t image_index;
+	uint8_t cost_factor;
+	uint8_t running_cost;
+	uint8_t subtype;               ///< Type of aircraft. @see AircraftSubTypeBits
 	SoundID sfx;
-	byte acceleration;
+	uint8_t acceleration;
 	uint16_t max_speed;           ///< Maximum speed (1 unit = 8 mph = 12.8 km-ish/h)
-	byte mail_capacity;         ///< Mail capacity (bags).
+	uint8_t mail_capacity;         ///< Mail capacity (bags).
 	uint16_t passenger_capacity;  ///< Passenger capacity (persons).
 	uint16_t max_range;           ///< Maximum range of this aircraft.
 };
 
 /** Information about a road vehicle. */
 struct RoadVehicleInfo {
-	byte image_index;
-	byte cost_factor;
-	byte running_cost;
+	uint8_t image_index;
+	uint8_t cost_factor;
+	uint8_t running_cost;
 	Price running_cost_class;
 	SoundID sfx;
 	uint16_t max_speed;        ///< Maximum speed (1 unit = 1/3.2 mph = 0.5 km-ish/h)
-	byte capacity;
+	uint8_t capacity;
 	uint8_t weight;            ///< Weight in 1/4t units
 	uint8_t power;             ///< Power in 10hp units
 	uint8_t tractive_effort;   ///< Coefficient of tractive effort
 	uint8_t air_drag;          ///< Coefficient of air drag
-	byte visual_effect;      ///< Bitstuffed NewGRF visual effect data
-	byte shorten_factor;     ///< length on main map for this type is 8 - shorten_factor
+	uint8_t visual_effect;      ///< Bitstuffed NewGRF visual effect data
+	uint8_t shorten_factor;     ///< length on main map for this type is 8 - shorten_factor
 	RoadType roadtype;       ///< Road type
 };
 
@@ -145,14 +145,14 @@ struct EngineInfo {
 	TimerGameCalendar::Date base_intro;    ///< Basic date of engine introduction (without random parts).
 	TimerGameCalendar::Year lifelength;    ///< Lifetime of a single vehicle
 	TimerGameCalendar::Year base_life;     ///< Basic duration of engine availability (without random parts). \c 0xFF means infinite life.
-	byte decay_speed;
-	byte load_amount;
-	byte climates;      ///< Climates supported by the engine.
+	uint8_t decay_speed;
+	uint8_t load_amount;
+	uint8_t climates;      ///< Climates supported by the engine.
 	CargoID cargo_type;
 	std::variant<CargoLabel, MixedCargoType> cargo_label;
 	CargoTypes refit_mask;
-	byte refit_cost;
-	byte misc_flags;         ///< Miscellaneous flags. @see EngineMiscFlags
+	uint8_t refit_cost;
+	uint8_t misc_flags;         ///< Miscellaneous flags. @see EngineMiscFlags
 	uint16_t callback_mask;    ///< Bitmask of vehicle callbacks that have to be called
 	int8_t retire_early;       ///< Number of years early to retire vehicle
 	StringID string_id;      ///< Default name of engine

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -498,7 +498,7 @@ public:
 			if (tr.top > tr.bottom) return;
 
 			/* Climate */
-			byte landscape = _load_check_data.settings.game_creation.landscape;
+			uint8_t landscape = _load_check_data.settings.game_creation.landscape;
 			if (landscape < NUM_LANDSCAPE) {
 				SetDParam(0, STR_CLIMATE_TEMPERATE_LANDSCAPE + landscape);
 				DrawString(tr, STR_NETWORK_SERVER_LIST_LANDSCAPE);

--- a/src/fontcache/spritefontcache.cpp
+++ b/src/fontcache/spritefontcache.cpp
@@ -85,7 +85,7 @@ void SpriteFontCache::InitializeUnicodeGlyphMap()
 	}
 
 	for (uint i = 0; i < lengthof(_default_unicode_map); i++) {
-		byte key = _default_unicode_map[i].key;
+		uint8_t key = _default_unicode_map[i].key;
 		if (key == CLRA) {
 			/* Clear the glyph. This happens if the glyph at this code point
 			 * is non-standard and should be accessed by an SCC_xxx enum

--- a/src/fontcache/truetypefontcache.h
+++ b/src/fontcache/truetypefontcache.h
@@ -15,8 +15,8 @@
 
 static const int MAX_FONT_SIZE = 72; ///< Maximum font size.
 
-static const byte FACE_COLOUR = 1;
-static const byte SHADOW_COLOUR = 2;
+static const uint8_t FACE_COLOUR = 1;
+static const uint8_t SHADOW_COLOUR = 2;
 
 /** Font cache for fonts that are based on a TrueType font. */
 class TrueTypeFontCache : public FontCache {
@@ -33,7 +33,7 @@ protected:
 	/** Container for information about a glyph. */
 	struct GlyphEntry {
 		Sprite *sprite; ///< The loaded sprite.
-		byte width;     ///< The width of the glyph.
+		uint8_t width;     ///< The width of the glyph.
 		bool duplicate; ///< Whether this glyph entry is a duplicate, i.e. may this be freed?
 	};
 

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -136,7 +136,7 @@ struct TranslationWriter : LanguageWriter {
 		/* We don't write the length. */
 	}
 
-	void Write(const byte *buffer, size_t length) override
+	void Write(const uint8_t *buffer, size_t length) override
 	{
 		this->strings.emplace_back((const char *)buffer, length);
 	}

--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -26,7 +26,7 @@ extern SavegameType _savegame_type; ///< type of savegame we are loading
 
 extern uint32_t _ttdp_version;        ///< version of TTDP savegame (if applicable)
 extern SaveLoadVersion _sl_version; ///< the major savegame version identifier
-extern byte   _sl_minor_version;    ///< the minor savegame version, DO NOT USE!
+extern uint8_t   _sl_minor_version;    ///< the minor savegame version, DO NOT USE!
 
 Gamelog _gamelog; ///< Gamelog instance
 
@@ -463,7 +463,7 @@ void Gamelog::TestMode()
  * @param bug type of bug, @see enum GRFBugs
  * @param data additional data
  */
-void Gamelog::GRFBug(uint32_t grfid, byte bug, uint64_t data)
+void Gamelog::GRFBug(uint32_t grfid, uint8_t bug, uint64_t data)
 {
 	assert(this->action_type == GLAT_GRFBUG);
 
@@ -682,7 +682,7 @@ void Gamelog::GRFUpdate(const GRFConfig *oldc, const GRFConfig *newc)
  * @param[out] ever_modified Max value of 'modified' from all binaries that ever saved this savegame.
  * @param[out] removed_newgrfs Set to true if any NewGRFs have been removed.
  */
-void Gamelog::Info(uint32_t *last_ottd_rev, byte *ever_modified, bool *removed_newgrfs)
+void Gamelog::Info(uint32_t *last_ottd_rev, uint8_t *ever_modified, bool *removed_newgrfs)
 {
 	for (const LoggedAction &la : this->data->action) {
 		for (const auto &lc : la.change) {

--- a/src/gamelog.h
+++ b/src/gamelog.h
@@ -80,7 +80,7 @@ public:
 	void GRFAddList(const GRFConfig *newg);
 	void GRFRemove(uint32_t grfid);
 	void GRFAdd(const GRFConfig *newg);
-	void GRFBug(uint32_t grfid, byte bug, uint64_t data);
+	void GRFBug(uint32_t grfid, uint8_t bug, uint64_t data);
 	bool GRFBugReverse(uint32_t grfid, uint16_t internal_id);
 	void GRFCompatible(const GRFIdentifier *newg);
 	void GRFMove(uint32_t grfid, int32_t offset);
@@ -89,7 +89,7 @@ public:
 	void TestRevision();
 	void TestMode();
 
-	void Info(uint32_t *last_ottd_rev, byte *ever_modified, bool *removed_newgrfs);
+	void Info(uint32_t *last_ottd_rev, uint8_t *ever_modified, bool *removed_newgrfs);
 	const GRFIdentifier *GetOverriddenIdentifier(const GRFConfig *c);
 
 	/* Saveload handler for gamelog needs access to internal data. */

--- a/src/gamelog_internal.h
+++ b/src/gamelog_internal.h
@@ -38,24 +38,24 @@ struct LoggedChange {
 
 struct LoggedChangeMode : LoggedChange {
 	LoggedChangeMode() : LoggedChange(GLCT_MODE) {}
-	LoggedChangeMode(byte mode, byte landscape) :
+	LoggedChangeMode(uint8_t mode, uint8_t landscape) :
 		LoggedChange(GLCT_MODE), mode(mode), landscape(landscape) {}
 	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
 
-	byte mode;      ///< new game mode - Editor x Game
-	byte landscape; ///< landscape (temperate, arctic, ...)
+	uint8_t mode;      ///< new game mode - Editor x Game
+	uint8_t landscape; ///< landscape (temperate, arctic, ...)
 };
 
 struct LoggedChangeRevision : LoggedChange {
 	LoggedChangeRevision() : LoggedChange(GLCT_REVISION) {}
-	LoggedChangeRevision(const std::string &text, uint32_t newgrf, uint16_t slver, byte modified) :
+	LoggedChangeRevision(const std::string &text, uint32_t newgrf, uint16_t slver, uint8_t modified) :
 		LoggedChange(GLCT_REVISION), text(text), newgrf(newgrf), slver(slver), modified(modified) {}
 	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
 
 	std::string text; ///< revision string, _openttd_revision
 	uint32_t newgrf;  ///< _openttd_newgrf_version
 	uint16_t slver;   ///< _sl_version
-	byte modified;    //< _openttd_revision_modified
+	uint8_t modified;    //< _openttd_revision_modified
 };
 
 struct LoggedChangeOldVersion : LoggedChange {
@@ -123,13 +123,13 @@ struct LoggedChangeSettingChanged : LoggedChange {
 
 struct LoggedChangeGRFBug : LoggedChange {
 	LoggedChangeGRFBug() : LoggedChange(GLCT_GRFBUG) {}
-	LoggedChangeGRFBug(uint64_t data, uint32_t grfid, byte bug) :
+	LoggedChangeGRFBug(uint64_t data, uint32_t grfid, uint8_t bug) :
 		LoggedChange(GLCT_GRFBUG), data(data), grfid(grfid), bug(bug) {}
 	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
 
 	uint64_t data;  ///< additional data
 	uint32_t grfid; ///< ID of problematic GRF
-	byte bug;       ///< type of bug, @see enum GRFBugs
+	uint8_t bug;       ///< type of bug, @see enum GRFBugs
 };
 
 struct LoggedChangeEmergencySave : LoggedChange {

--- a/src/genworld.h
+++ b/src/genworld.h
@@ -91,7 +91,7 @@ bool IsGeneratingWorldAborted();
 void HandleGeneratingWorldAbortion();
 
 /* genworld_gui.cpp */
-void SetNewLandscapeType(byte landscape);
+void SetNewLandscapeType(uint8_t landscape);
 void SetGeneratingWorldProgress(GenWorldProgress cls, uint total);
 void IncreaseGeneratingWorldProgress(GenWorldProgress cls);
 void PrepareGenerateWorldProgress();

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -61,7 +61,7 @@ static uint GetMapHeightLimit()
  * Changes landscape type and sets genworld window dirty
  * @param landscape new landscape type
  */
-void SetNewLandscapeType(byte landscape)
+void SetNewLandscapeType(uint8_t landscape)
 {
 	_settings_newgame.game_creation.landscape = landscape;
 	InvalidateWindowClassesData(WC_SELECT_GAME);

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -30,9 +30,9 @@
 
 #include "safeguards.h"
 
-byte _dirkeys;        ///< 1 = left, 2 = up, 4 = right, 8 = down
+uint8_t _dirkeys;        ///< 1 = left, 2 = up, 4 = right, 8 = down
 bool _fullscreen;
-byte _support8bpp;
+uint8_t _support8bpp;
 CursorVars _cursor;
 bool _ctrl_pressed;   ///< Is Ctrl pressed?
 bool _shift_pressed;  ///< Is Shift pressed?
@@ -49,7 +49,7 @@ SwitchMode _switch_mode;  ///< The next mainloop command.
 PauseMode _pause_mode;
 GameSessionStats _game_session_stats; ///< Statistics about the current session.
 
-static byte _stringwidth_table[FS_END][224]; ///< Cache containing width of often used characters. @see GetCharacterWidth()
+static uint8_t _stringwidth_table[FS_END][224]; ///< Cache containing width of often used characters. @see GetCharacterWidth()
 DrawPixelInfo *_cur_dpi;
 
 static void GfxMainBlitterViewport(const Sprite *sprite, int x, int y, BlitterMode mode, const SubSprite *sub = nullptr, SpriteID sprite_id = SPR_CURSOR_MOUSE);
@@ -70,14 +70,14 @@ int _gui_scale_cfg;                         ///< GUI scale in config.
  * @ingroup dirty
  */
 static Rect _invalid_rect;
-static const byte *_colour_remap_ptr;
-static byte _string_colourremap[3]; ///< Recoloursprite for stringdrawing. The grf loader ensures that #SpriteType::Font sprites only use colours 0 to 2.
+static const uint8_t *_colour_remap_ptr;
+static uint8_t _string_colourremap[3]; ///< Recoloursprite for stringdrawing. The grf loader ensures that #SpriteType::Font sprites only use colours 0 to 2.
 
 static const uint DIRTY_BLOCK_HEIGHT   = 8;
 static const uint DIRTY_BLOCK_WIDTH    = 64;
 
 static uint _dirty_bytes_per_line = 0;
-static byte *_dirty_blocks = nullptr;
+static uint8_t *_dirty_blocks = nullptr;
 extern uint _dirty_block_colour;
 
 void GfxScroll(int left, int top, int width, int height, int xo, int yo)
@@ -147,7 +147,7 @@ void GfxFillRect(int left, int top, int right, int bottom, int colour, FillRectM
 			break;
 
 		case FILLRECT_CHECKER: {
-			byte bo = (oleft - left + dpi->left + otop - top + dpi->top) & 1;
+			uint8_t bo = (oleft - left + dpi->left + otop - top + dpi->top) & 1;
 			do {
 				for (int i = (bo ^= 1); i < right; i += 2) blitter->SetPixel(dst, i, 0, (uint8_t)colour);
 				dst = blitter->MoveTo(dst, 0, 1);
@@ -431,7 +431,7 @@ void DrawBox(int x, int y, int dx1, int dy1, int dx2, int dy2, int dx3, int dy3)
 	 *            ....V.
 	 */
 
-	static const byte colour = PC_WHITE;
+	static const uint8_t colour = PC_WHITE;
 
 	GfxDrawLineUnscaled(x, y, x + dx1, y + dy1, colour);
 	GfxDrawLineUnscaled(x, y, x + dx2, y + dy2, colour);
@@ -474,7 +474,7 @@ static void SetColourRemap(TextColour colour)
 	bool raw_colour = (colour & TC_IS_PALETTE_COLOUR) != 0;
 	colour &= ~(TC_NO_SHADE | TC_IS_PALETTE_COLOUR | TC_FORCED);
 
-	_string_colourremap[1] = raw_colour ? (byte)colour : _string_colourmap[colour];
+	_string_colourremap[1] = raw_colour ? (uint8_t)colour : _string_colourmap[colour];
 	_string_colourremap[2] = no_shade ? 0 : 1;
 	_colour_remap_ptr = _string_colourremap;
 }
@@ -1185,9 +1185,9 @@ std::unique_ptr<uint32_t[]> DrawSpriteToRgbaBuffer(SpriteID spriteId, ZoomLevel 
 	dim_size = static_cast<size_t>(dim.width) * dim.height;
 
 	/* If the current blitter is a paletted blitter, we have to render to an extra buffer and resolve the palette later. */
-	std::unique_ptr<byte[]> pal_buffer{};
+	std::unique_ptr<uint8_t[]> pal_buffer{};
 	if (blitter->GetScreenDepth() == 8) {
-		pal_buffer = std::make_unique<byte[]>(dim_size);
+		pal_buffer = std::make_unique<uint8_t[]>(dim_size);
 		dpi.dst_ptr = pal_buffer.get();
 	}
 
@@ -1199,7 +1199,7 @@ std::unique_ptr<uint32_t[]> DrawSpriteToRgbaBuffer(SpriteID spriteId, ZoomLevel 
 	if (blitter->GetScreenDepth() == 8) {
 		/* Resolve palette. */
 		uint32_t *dst = result.get();
-		const byte *src = pal_buffer.get();
+		const uint8_t *src = pal_buffer.get();
 		for (size_t i = 0; i < dim_size; ++i) {
 			*dst++ = _cur_palette.palette[*src++].data;
 		}
@@ -1239,7 +1239,7 @@ void LoadStringWidthTable(bool monospace)
  * @param key   Character code glyph
  * @return Width of the character glyph
  */
-byte GetCharacterWidth(FontSize size, char32_t key)
+uint8_t GetCharacterWidth(FontSize size, char32_t key)
 {
 	/* Use _stringwidth_table cache if possible */
 	if (key >= 32 && key < 256) return _stringwidth_table[size][key - 32];
@@ -1252,9 +1252,9 @@ byte GetCharacterWidth(FontSize size, char32_t key)
  * @param size  Font of the digit
  * @return Width of the digit.
  */
-byte GetDigitWidth(FontSize size)
+uint8_t GetDigitWidth(FontSize size)
 {
-	byte width = 0;
+	uint8_t width = 0;
 	for (char c = '0'; c <= '9'; c++) {
 		width = std::max(GetCharacterWidth(size, c), width);
 	}
@@ -1283,7 +1283,7 @@ void GetBroadestDigit(uint *front, uint *next, FontSize size)
 void ScreenSizeChanged()
 {
 	_dirty_bytes_per_line = CeilDiv(_screen.width, DIRTY_BLOCK_WIDTH);
-	_dirty_blocks = ReallocT<byte>(_dirty_blocks, static_cast<size_t>(_dirty_bytes_per_line) * CeilDiv(_screen.height, DIRTY_BLOCK_HEIGHT));
+	_dirty_blocks = ReallocT<uint8_t>(_dirty_blocks, static_cast<size_t>(_dirty_bytes_per_line) * CeilDiv(_screen.height, DIRTY_BLOCK_HEIGHT));
 
 	/* check the dirty rect */
 	if (_invalid_rect.right >= _screen.width) _invalid_rect.right = _screen.width;
@@ -1411,7 +1411,7 @@ void RedrawScreenRect(int left, int top, int right, int bottom)
  */
 void DrawDirtyBlocks()
 {
-	byte *b = _dirty_blocks;
+	uint8_t *b = _dirty_blocks;
 	const int w = Align(_screen.width,  DIRTY_BLOCK_WIDTH);
 	const int h = Align(_screen.height, DIRTY_BLOCK_HEIGHT);
 	int x;
@@ -1426,7 +1426,7 @@ void DrawDirtyBlocks()
 				int top;
 				int right = x + DIRTY_BLOCK_WIDTH;
 				int bottom = y;
-				byte *p = b;
+				uint8_t *p = b;
 				int h2;
 
 				/* First try coalescing downwards */
@@ -1442,7 +1442,7 @@ void DrawDirtyBlocks()
 				p = b;
 
 				while (right != w) {
-					byte *p2 = ++p;
+					uint8_t *p2 = ++p;
 					int i = h2;
 					/* Check if a full line of dirty flags is set. */
 					do {
@@ -1500,7 +1500,7 @@ void DrawDirtyBlocks()
  */
 void AddDirtyBlock(int left, int top, int right, int bottom)
 {
-	byte *b;
+	uint8_t *b;
 	int width;
 	int height;
 

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -48,9 +48,9 @@ void GameLoop();
 
 void CreateConsole();
 
-extern byte _dirkeys;        ///< 1 = left, 2 = up, 4 = right, 8 = down
+extern uint8_t _dirkeys;        ///< 1 = left, 2 = up, 4 = right, 8 = down
 extern bool _fullscreen;
-extern byte _support8bpp;
+extern uint8_t _support8bpp;
 extern CursorVars _cursor;
 extern bool _ctrl_pressed;   ///< Is Ctrl pressed?
 extern bool _shift_pressed;  ///< Is Shift pressed?
@@ -181,8 +181,8 @@ void SortResolutions();
 bool ToggleFullScreen(bool fs);
 
 /* gfx.cpp */
-byte GetCharacterWidth(FontSize size, char32_t key);
-byte GetDigitWidth(FontSize size = FS_NORMAL);
+uint8_t GetCharacterWidth(FontSize size, char32_t key);
+uint8_t GetDigitWidth(FontSize size = FS_NORMAL);
 void GetBroadestDigit(uint *front, uint *next, FontSize size = FS_NORMAL);
 
 int GetCharacterHeight(FontSize size);

--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -109,7 +109,7 @@ enum WindowKeyCodes {
 struct AnimCursor {
 	static const CursorID LAST = MAX_UVALUE(CursorID);
 	CursorID sprite;   ///< Must be set to LAST_ANIM when it is the last sprite of the loop
-	byte display_time; ///< Amount of ticks this sprite will be shown
+	uint8_t display_time; ///< Amount of ticks this sprite will be shown
 };
 
 /** Collection of variables for cursor-display and -animation */
@@ -227,7 +227,7 @@ struct SubSprite {
 	int left, top, right, bottom;
 };
 
-enum Colours : byte {
+enum Colours : uint8_t {
 	COLOUR_BEGIN,
 	COLOUR_DARK_BLUE = COLOUR_BEGIN,
 	COLOUR_PALE_GREEN,
@@ -306,7 +306,7 @@ enum PaletteType {
 };
 
 /** Types of sprites that might be loaded */
-enum class SpriteType : byte {
+enum class SpriteType : uint8_t {
 	Normal   = 0,      ///< The most basic (normal) sprite
 	MapGen   = 1,      ///< Special sprite for the map generator
 	Font     = 2,      ///< A sprite used for fonts

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -52,12 +52,12 @@ static uint LoadGrfFile(const std::string &filename, uint load_index, bool needs
 
 	Debug(sprite, 2, "Reading grf-file '{}'", filename);
 
-	byte container_ver = file.GetContainerVersion();
+	uint8_t container_ver = file.GetContainerVersion();
 	if (container_ver == 0) UserError("Base grf '{}' is corrupt", filename);
 	ReadGRFSpriteOffsets(file);
 	if (container_ver >= 2) {
 		/* Read compression. */
-		byte compression = file.ReadByte();
+		uint8_t compression = file.ReadByte();
 		if (compression != 0) UserError("Unsupported compression format");
 	}
 
@@ -89,12 +89,12 @@ static void LoadGrfFileIndexed(const std::string &filename, const SpriteID *inde
 
 	Debug(sprite, 2, "Reading indexed grf-file '{}'", filename);
 
-	byte container_ver = file.GetContainerVersion();
+	uint8_t container_ver = file.GetContainerVersion();
 	if (container_ver == 0) UserError("Base grf '{}' is corrupt", filename);
 	ReadGRFSpriteOffsets(file);
 	if (container_ver >= 2) {
 		/* Read compression. */
-		byte compression = file.ReadByte();
+		uint8_t compression = file.ReadByte();
 		if (compression != 0) UserError("Unsupported compression format");
 	}
 

--- a/src/goal.cpp
+++ b/src/goal.cpp
@@ -306,7 +306,7 @@ CommandCost CmdGoalQuestionAnswer(DoCommandFlag flags, uint16_t uniqueid, uint8_
 	}
 
 	if (flags & DC_EXEC) {
-		Game::NewEvent(new ScriptEventGoalQuestionAnswer(uniqueid, (ScriptCompany::CompanyID)(byte)_current_company, (ScriptGoal::QuestionButton)(1 << button)));
+		Game::NewEvent(new ScriptEventGoalQuestionAnswer(uniqueid, (ScriptCompany::CompanyID)(uint8_t)_current_company, (ScriptGoal::QuestionButton)(1 << button)));
 	}
 
 	return CommandCost();

--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -479,7 +479,7 @@ static WindowDesc _goal_question_list_desc[] = {
  * @param button_mask Buttons to display.
  * @param question Question to ask.
  */
-void ShowGoalQuestion(uint16_t id, byte type, uint32_t button_mask, const std::string &question)
+void ShowGoalQuestion(uint16_t id, uint8_t type, uint32_t button_mask, const std::string &question)
 {
 	assert(type < GQT_END);
 	new GoalQuestionWindow(&_goal_question_list_desc[type], id, type == 3 ? TC_WHITE : TC_BLACK, button_mask, question);

--- a/src/goal_type.h
+++ b/src/goal_type.h
@@ -14,7 +14,7 @@
 
 static const uint32_t GOAL_QUESTION_BUTTON_COUNT = 18; ///< Amount of buttons available.
 
-enum GoalQuestionType : byte {
+enum GoalQuestionType : uint8_t {
 	GQT_QUESTION = 0,
 	GQT_INFORMATION = 1,
 	GQT_WARNING = 2,
@@ -23,7 +23,7 @@ enum GoalQuestionType : byte {
 };
 
 /** Types of goal destinations */
-enum GoalType : byte {
+enum GoalType : uint8_t {
 	GT_NONE,         ///< Destination is not linked
 	GT_TILE,         ///< Destination is a tile
 	GT_INDUSTRY,     ///< Destination is an industry

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -183,9 +183,9 @@ protected:
 	static const int MIN_GRID_PIXEL_SIZE    =  20; ///< Minimum distance between graph lines.
 
 	uint64_t excluded_data; ///< bitmask of the datasets that shouldn't be displayed.
-	byte num_dataset;
-	byte num_on_x_axis;
-	byte num_vert_lines;
+	uint8_t num_dataset;
+	uint8_t num_on_x_axis;
+	uint8_t num_vert_lines;
 
 	/* The starting month and year that values are plotted against. */
 	TimerGameEconomy::Month month;
@@ -199,7 +199,7 @@ protected:
 	uint16_t x_values_increment;
 
 	StringID format_str_y_axis;
-	byte colours[GRAPH_MAX_DATASETS];
+	uint8_t colours[GRAPH_MAX_DATASETS];
 	OverflowSafeInt64 cost[GRAPH_MAX_DATASETS][GRAPH_NUM_MONTHS]; ///< Stored costs for the last #GRAPH_NUM_MONTHS months
 
 	/**
@@ -443,7 +443,7 @@ protected:
 				/* Centre the dot between the grid lines. */
 				x = r.left + (x_sep / 2);
 
-				byte colour  = this->colours[i];
+				uint8_t colour  = this->colours[i];
 				uint prev_x = INVALID_DATAPOINT_POS;
 				uint prev_y = INVALID_DATAPOINT_POS;
 
@@ -600,7 +600,7 @@ public:
 			if (!Company::IsValidID(c)) SetBit(excluded_companies, c);
 		}
 
-		byte nums = 0;
+		uint8_t nums = 0;
 		for (const Company *c : Company::Iterate()) {
 			nums = std::min(this->num_vert_lines, std::max(nums, c->num_valid_stat_ent));
 		}

--- a/src/ground_vehicle.cpp
+++ b/src/ground_vehicle.cpp
@@ -41,8 +41,8 @@ void GroundVehicle<T, Type>::PowerChanged()
 		if (track_speed > 0) max_track_speed = std::min(max_track_speed, track_speed);
 	}
 
-	byte air_drag;
-	byte air_drag_value = v->GetAirDrag();
+	uint8_t air_drag;
+	uint8_t air_drag_value = v->GetAirDrag();
 
 	/* If air drag is set to zero (default), the resulting air drag coefficient is dependent on max speed. */
 	if (air_drag_value == 0) {

--- a/src/ground_vehicle.hpp
+++ b/src/ground_vehicle.hpp
@@ -63,9 +63,9 @@ enum GroundVehicleFlags {
  * virtual uint16_t      GetPower() const = 0;
  * virtual uint16_t      GetPoweredPartPower(const T *head) const = 0;
  * virtual uint16_t      GetWeight() const = 0;
- * virtual byte        GetTractiveEffort() const = 0;
- * virtual byte        GetAirDrag() const = 0;
- * virtual byte        GetAirDragArea() const = 0;
+ * virtual uint8_t        GetTractiveEffort() const = 0;
+ * virtual uint8_t        GetAirDrag() const = 0;
+ * virtual uint8_t        GetAirDragArea() const = 0;
  * virtual AccelStatus GetAccelerationStatus() const = 0;
  * virtual uint16_t      GetCurrentSpeed() const = 0;
  * virtual uint32_t      GetRollingFriction() const = 0;
@@ -362,7 +362,7 @@ protected:
 	inline uint DoUpdateSpeed(uint accel, int min_speed, int max_speed)
 	{
 		uint spd = this->subspeed + accel;
-		this->subspeed = (byte)spd;
+		this->subspeed = (uint8_t)spd;
 
 		/* When we are going faster than the maximum speed, reduce the speed
 		 * somewhat gradually. But never lower than the maximum speed. */

--- a/src/group_cmd.h
+++ b/src/group_cmd.h
@@ -16,11 +16,11 @@
 #include "vehiclelist.h"
 #include "vehiclelist_cmd.h"
 
-enum Colours : byte;
+enum Colours : uint8_t;
 enum GroupFlags : uint8_t;
 
 /** Action for \c CmdAlterGroup. */
-enum class AlterGroupMode : byte {
+enum class AlterGroupMode : uint8_t {
 	Rename,    ///< Change group name.
 	SetParent, ///< Change group parent.
 };

--- a/src/gui.h
+++ b/src/gui.h
@@ -62,7 +62,7 @@ void ShowSubsidiesList();
 
 /* goal_gui.cpp */
 void ShowGoalsList(CompanyID company);
-void ShowGoalQuestion(uint16_t id, byte type, uint32_t button_mask, const std::string &question);
+void ShowGoalQuestion(uint16_t id, uint8_t type, uint32_t button_mask, const std::string &question);
 
 /* story_gui.cpp */
 void ShowStoryBook(CompanyID company, uint16_t page_id = INVALID_STORY_PAGE, bool centered = false);
@@ -72,7 +72,7 @@ void ShowExtraViewportWindow(TileIndex tile = INVALID_TILE);
 void ShowExtraViewportWindowForTileUnderCursor();
 
 /* bridge_gui.cpp */
-void ShowBuildBridgeWindow(TileIndex start, TileIndex end, TransportType transport_type, byte bridge_type);
+void ShowBuildBridgeWindow(TileIndex start, TileIndex end, TransportType transport_type, uint8_t bridge_type);
 
 /* music_gui.cpp */
 void ShowMusicWindow();

--- a/src/heightmap.h
+++ b/src/heightmap.h
@@ -23,7 +23,7 @@ enum HeightmapRotation {
 
 bool GetHeightmapDimensions(DetailedFileType dft, const char *filename, uint *x, uint *y);
 bool LoadHeightmap(DetailedFileType dft, const char *filename);
-void FlatEmptyWorld(byte tile_height);
+void FlatEmptyWorld(uint8_t tile_height);
 void FixSlopes();
 
 #endif /* HEIGHTMAP_H */

--- a/src/highscore.cpp
+++ b/src/highscore.cpp
@@ -129,7 +129,7 @@ void SaveToHighScore()
 	for (int i = 0; i < SP_SAVED_HIGHSCORE_END; i++) {
 		for (HighScore &hs : _highscore_table[i]) {
 			/* This code is weird and old fashioned to keep compatibility with the old high score files. */
-			byte name_length = ClampTo<byte>(hs.name.size());
+			uint8_t name_length = ClampTo<uint8_t>(hs.name.size());
 			if (fwrite(&name_length, sizeof(name_length), 1, fp.get()) != 1 || // Write the string length of the name
 					fwrite(hs.name.data(), name_length, 1, fp.get()) > 1 || // Yes... could be 0 bytes too
 					fwrite(&hs.score, sizeof(hs.score), 1, fp.get()) != 1 ||
@@ -153,7 +153,7 @@ void LoadFromHighScore()
 	for (int i = 0; i < SP_SAVED_HIGHSCORE_END; i++) {
 		for (HighScore &hs : _highscore_table[i]) {
 			/* This code is weird and old fashioned to keep compatibility with the old high score files. */
-			byte name_length;
+			uint8_t name_length;
 			char buffer[std::numeric_limits<decltype(name_length)>::max() + 1];
 
 			if (fread(&name_length, sizeof(name_length), 1, fp.get()) !=  1 ||

--- a/src/house.h
+++ b/src/house.h
@@ -20,7 +20,7 @@
  * Simple value that indicates the house has reached the final stage of
  * construction.
  */
-static const byte TOWN_HOUSE_COMPLETED = 3;
+static const uint8_t TOWN_HOUSE_COMPLETED = 3;
 
 static const HouseID NUM_HOUSES_PER_GRF = 255;    ///< Number of supported houses per NewGRF; limited to 255 to allow extending Action3 with an extended byte later on.
 
@@ -99,12 +99,12 @@ struct HouseSpec {
 	/* Standard properties */
 	TimerGameCalendar::Year min_year;         ///< introduction year of the house
 	TimerGameCalendar::Year max_year;         ///< last year it can be built
-	byte population;                          ///< population (Zero on other tiles in multi tile house.)
-	byte removal_cost;                        ///< cost multiplier for removing it
+	uint8_t population;                          ///< population (Zero on other tiles in multi tile house.)
+	uint8_t removal_cost;                        ///< cost multiplier for removing it
 	StringID building_name;                   ///< building name
 	uint16_t remove_rating_decrease;            ///< rating decrease if removed
-	byte mail_generation;                     ///< mail generation multiplier (tile based, as the acceptances below)
-	byte cargo_acceptance[HOUSE_NUM_ACCEPTS]; ///< acceptance level for the cargo slots
+	uint8_t mail_generation;                     ///< mail generation multiplier (tile based, as the acceptances below)
+	uint8_t cargo_acceptance[HOUSE_NUM_ACCEPTS]; ///< acceptance level for the cargo slots
 	CargoID accepts_cargo[HOUSE_NUM_ACCEPTS]; ///< input cargo slots
 	CargoLabel accepts_cargo_label[HOUSE_NUM_ACCEPTS]; ///< input landscape cargo slots
 	BuildingFlags building_flags;             ///< some flags that describe the house (size, stadium etc...)
@@ -115,12 +115,12 @@ struct HouseSpec {
 	GRFFileProps grf_prop;                    ///< Properties related the the grf file
 	uint16_t callback_mask;                     ///< Bitmask of house callbacks that have to be called
 	Colours random_colour[4];                 ///< 4 "random" colours
-	byte probability;                         ///< Relative probability of appearing (16 is the standard value)
+	uint8_t probability;                         ///< Relative probability of appearing (16 is the standard value)
 	HouseExtraFlags extra_flags;              ///< some more flags
 	HouseClassID class_id;                    ///< defines the class this house has (not grf file based)
 	AnimationInfo animation;                  ///< information about the animation.
-	byte processing_time;                     ///< Periodic refresh multiplier
-	byte minimum_life;                        ///< The minimum number of years this house will survive before the town rebuilds it
+	uint8_t processing_time;                     ///< Periodic refresh multiplier
+	uint8_t minimum_life;                        ///< The minimum number of years this house will survive before the town rebuilds it
 	CargoTypes watched_cargoes;               ///< Cargo types watched for acceptance.
 
 	Money GetRemovalCost() const;

--- a/src/industry.h
+++ b/src/industry.h
@@ -41,7 +41,7 @@ enum ProductionLevels {
  * Flags to control/override the behaviour of an industry.
  * These flags are controlled by game scripts.
  */
-enum IndustryControlFlags : byte {
+enum IndustryControlFlags : uint8_t {
 	/** No flags in effect */
 	INDCTL_NONE                   = 0,
 	/** When industry production change is evaluated, rolls to decrease are ignored. */
@@ -98,14 +98,14 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 	Station *neutral_station;                              ///< Associated neutral station
 	ProducedCargoArray produced; ///< INDUSTRY_NUM_OUTPUTS production cargo slots
 	AcceptedCargoArray accepted; ///< INDUSTRY_NUM_INPUTS input cargo slots
-	byte prod_level;                                       ///< general production level
+	uint8_t prod_level;                                       ///< general production level
 	uint16_t counter;                                        ///< used for animation and/or production (if available cargo)
 
 	IndustryType type;             ///< type of industry.
 	Owner owner;                   ///< owner of the industry.  Which SHOULD always be (imho) OWNER_NONE
 	Colours random_colour;         ///< randomized colour of the industry, for display purpose
 	TimerGameEconomy::Year last_prod_year; ///< last economy year of production
-	byte was_cargo_delivered;      ///< flag that indicate this has been the closest industry chosen for cargo delivery by a station. see DeliverGoodsToIndustry
+	uint8_t was_cargo_delivered;      ///< flag that indicate this has been the closest industry chosen for cargo delivery by a station. see DeliverGoodsToIndustry
 	IndustryControlFlags ctlflags; ///< flags overriding standard behaviours
 
 	PartOfSubsidy part_of_subsidy; ///< NOSAVE: is this industry a source/destination of a subsidy?
@@ -115,7 +115,7 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 	Owner founder;                 ///< Founder of the industry
 	TimerGameCalendar::Date construction_date; ///< Date of the construction of the industry
 	uint8_t construction_type;       ///< Way the industry was constructed (@see IndustryConstructionType)
-	byte selected_layout;          ///< Which tile layout was used when creating the industry
+	uint8_t selected_layout;          ///< Which tile layout was used when creating the industry
 	Owner exclusive_supplier;      ///< Which company has exclusive rights to deliver cargo (INVALID_OWNER = anyone)
 	Owner exclusive_consumer;      ///< Which company has exclusive rights to take cargo (INVALID_OWNER = anyone)
 	std::string text;              ///< General text with additional information.
@@ -275,7 +275,7 @@ bool IsTileForestIndustry(TileIndex tile);
 /** Data for managing the number of industries of a single industry type. */
 struct IndustryTypeBuildData {
 	uint32_t probability;  ///< Relative probability of building this industry.
-	byte   min_number;   ///< Smallest number of industries that should exist (either \c 0 or \c 1).
+	uint8_t   min_number;   ///< Smallest number of industries that should exist (either \c 0 or \c 1).
 	uint16_t target_count; ///< Desired number of industries of this type.
 	uint16_t max_wait;     ///< Starting number of turns to wait (copied to #wait_count).
 	uint16_t wait_count;   ///< Number of turns to wait before trying to build again.

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -60,7 +60,7 @@ INSTANTIATE_POOL_METHODS(Industry)
 void ShowIndustryViewWindow(int industry);
 void BuildOilRig(TileIndex tile);
 
-static byte _industry_sound_ctr;
+static uint8_t _industry_sound_ctr;
 static TileIndex _industry_sound_tile;
 
 uint16_t Industry::counts[NUM_INDUSTRYTYPES];
@@ -451,7 +451,7 @@ static void AddAcceptedCargo_Industry(TileIndex tile, CargoArray &acceptance, Ca
 		}
 	}
 
-	for (byte i = 0; i < std::size(itspec->accepts_cargo); i++) {
+	for (uint8_t i = 0; i < std::size(itspec->accepts_cargo); i++) {
 		CargoID a = accepts_cargo[i];
 		if (!IsValidCargoID(a) || cargo_acceptance[i] <= 0) continue; // work only with valid cargoes
 
@@ -547,7 +547,7 @@ static bool TransportIndustryGoods(TileIndex tile)
 
 static void AnimateSugarSieve(TileIndex tile)
 {
-	byte m = GetAnimationFrame(tile) + 1;
+	uint8_t m = GetAnimationFrame(tile) + 1;
 
 	if (_settings_client.sound.ambient) {
 		switch (m & 7) {
@@ -567,7 +567,7 @@ static void AnimateSugarSieve(TileIndex tile)
 
 static void AnimateToffeeQuarry(TileIndex tile)
 {
-	byte m = GetAnimationFrame(tile);
+	uint8_t m = GetAnimationFrame(tile);
 
 	if (_industry_anim_offs_toffee[m] == 0xFF && _settings_client.sound.ambient) {
 		SndPlayTileFx(SND_30_TOFFEE_QUARRY, tile);
@@ -584,7 +584,7 @@ static void AnimateToffeeQuarry(TileIndex tile)
 
 static void AnimateBubbleCatcher(TileIndex tile)
 {
-	byte m = GetAnimationFrame(tile);
+	uint8_t m = GetAnimationFrame(tile);
 
 	if (++m >= 40) {
 		m = 0;
@@ -597,7 +597,7 @@ static void AnimateBubbleCatcher(TileIndex tile)
 
 static void AnimatePowerPlantSparks(TileIndex tile)
 {
-	byte m = GetAnimationFrame(tile);
+	uint8_t m = GetAnimationFrame(tile);
 	if (m == 6) {
 		SetAnimationFrame(tile, 0);
 		DeleteAnimatedTile(tile);
@@ -609,7 +609,7 @@ static void AnimatePowerPlantSparks(TileIndex tile)
 
 static void AnimateToyFactory(TileIndex tile)
 {
-	byte m = GetAnimationFrame(tile) + 1;
+	uint8_t m = GetAnimationFrame(tile) + 1;
 
 	switch (m) {
 		case  1: if (_settings_client.sound.ambient) SndPlayTileFx(SND_2C_TOY_FACTORY_1, tile); break;
@@ -641,7 +641,7 @@ static void AnimatePlasticFountain(TileIndex tile, IndustryGfx gfx)
 static void AnimateOilWell(TileIndex tile, IndustryGfx gfx)
 {
 	bool b = Chance16(1, 7);
-	byte m = GetAnimationFrame(tile) + 1;
+	uint8_t m = GetAnimationFrame(tile) + 1;
 	if (m == 4 && (m = 0, ++gfx) == GFX_OILWELL_ANIMATED_3 + 1 && (gfx = GFX_OILWELL_ANIMATED_1, b)) {
 		SetIndustryGfx(tile, GFX_OILWELL_NOT_ANIMATED);
 		SetIndustryConstructionStage(tile, 3);
@@ -661,7 +661,7 @@ static void AnimateMineTower(TileIndex tile)
 
 	if (state < 0x1A0) {
 		if (state < 0x20 || state >= 0x180) {
-			byte m = GetAnimationFrame(tile);
+			uint8_t m = GetAnimationFrame(tile);
 			if (!(m & 0x40)) {
 				SetAnimationFrame(tile, m | 0x40);
 				if (_settings_client.sound.ambient) SndPlayTileFx(SND_0B_MINE, tile);
@@ -670,7 +670,7 @@ static void AnimateMineTower(TileIndex tile)
 		} else {
 			if (state & 3) return;
 		}
-		byte m = (GetAnimationFrame(tile) + 1) | 0x40;
+		uint8_t m = (GetAnimationFrame(tile) + 1) | 0x40;
 		if (m > 0xC2) m = 0xC0;
 		SetAnimationFrame(tile, m);
 		MarkTileDirtyByTile(tile);
@@ -678,7 +678,7 @@ static void AnimateMineTower(TileIndex tile)
 		int i = (state < 0x220 || state >= 0x380) ? 7 : 3;
 		if (state & i) return;
 
-		byte m = (GetAnimationFrame(tile) & 0xBF) - 1;
+		uint8_t m = (GetAnimationFrame(tile) & 0xBF) - 1;
 		if (m < 0x80) m = 0x82;
 		SetAnimationFrame(tile, m);
 		MarkTileDirtyByTile(tile);
@@ -747,13 +747,13 @@ static void CreateChimneySmoke(TileIndex tile)
 
 static void MakeIndustryTileBigger(TileIndex tile)
 {
-	byte cnt = GetIndustryConstructionCounter(tile) + 1;
+	uint8_t cnt = GetIndustryConstructionCounter(tile) + 1;
 	if (cnt != 4) {
 		SetIndustryConstructionCounter(tile, cnt);
 		return;
 	}
 
-	byte stage = GetIndustryConstructionStage(tile) + 1;
+	uint8_t stage = GetIndustryConstructionStage(tile) + 1;
 	SetIndustryConstructionCounter(tile, 0);
 	SetIndustryConstructionStage(tile, stage);
 	StartStopIndustryTileAnimation(tile, IAT_CONSTRUCTION_STATE_CHANGE);
@@ -985,7 +985,7 @@ bool IsTileForestIndustry(TileIndex tile)
 	return std::any_of(std::begin(ind->produced), std::end(ind->produced), [](const auto &p) { return IsValidCargoID(p.cargo) && CargoSpec::Get(p.cargo)->label == CT_WOOD; });
 }
 
-static const byte _plantfarmfield_type[] = {1, 1, 1, 1, 1, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6};
+static const uint8_t _plantfarmfield_type[] = {1, 1, 1, 1, 1, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6};
 
 /**
  * Check whether the tile can be replaced by a farm field.
@@ -1010,7 +1010,7 @@ static bool IsSuitableForFarmField(TileIndex tile, bool allow_fields)
  * @param type type of fence to set
  * @param side the side of the tile to attempt placement
  */
-static void SetupFarmFieldFence(TileIndex tile, int size, byte type, DiagDirection side)
+static void SetupFarmFieldFence(TileIndex tile, int size, uint8_t type, DiagDirection side)
 {
 	TileIndexDiff diff = (DiagDirToAxis(side) == AXIS_Y ? TileDiffXY(1, 0) : TileDiffXY(0, 1));
 	TileIndexDiff neighbour_diff = TileOffsByDiagDir(side);
@@ -1022,7 +1022,7 @@ static void SetupFarmFieldFence(TileIndex tile, int size, byte type, DiagDirecti
 			TileIndex neighbour = tile + neighbour_diff;
 			if (!IsTileType(neighbour, MP_CLEAR) || !IsClearGround(neighbour, CLEAR_FIELDS) || GetFence(neighbour, ReverseDiagDir(side)) == 0) {
 				/* Add fence as long as neighbouring tile does not already have a fence in the same position. */
-				byte or_ = type;
+				uint8_t or_ = type;
 
 				if (or_ == 1 && Chance16(1, 7)) or_ = 2;
 
@@ -1433,7 +1433,7 @@ static CommandCost FindTownForIndustry(TileIndex tile, int type, Town **t)
 	if (_settings_game.economy.multiple_industry_per_town) return CommandCost();
 
 	for (const Industry *i : Industry::Iterate()) {
-		if (i->type == (byte)type && i->town == *t) {
+		if (i->type == (uint8_t)type && i->town == *t) {
 			*t = nullptr;
 			return_cmd_error(STR_ERROR_ONLY_ONE_ALLOWED_PER_TOWN);
 		}
@@ -1801,7 +1801,7 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 	/* Randomize inital production if non-original economy is used and there are no production related callbacks. */
 	if (!indspec->UsesOriginalEconomy()) {
 		for (auto &p : i->produced) {
-			p.rate = ClampTo<byte>((RandomRange(256) + 128) * p.rate >> 8);
+			p.rate = ClampTo<uint8_t>((RandomRange(256) + 128) * p.rate >> 8);
 		}
 	}
 
@@ -1824,7 +1824,7 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 	/* Adding 1 here makes it conform to specs of var44 of varaction2 for industries
 	 * 0 = created prior of newindustries
 	 * else, chosen layout + 1 */
-	i->selected_layout = (byte)(layout_index + 1);
+	i->selected_layout = (uint8_t)(layout_index + 1);
 
 	i->exclusive_supplier = INVALID_OWNER;
 	i->exclusive_consumer = INVALID_OWNER;
@@ -2157,7 +2157,7 @@ CommandCost CmdIndustrySetFlags(DoCommandFlag flags, IndustryID ind_id, Industry
  * @param custom_news Custom news message text.
  * @return Empty cost or an error.
  */
-CommandCost CmdIndustrySetProduction(DoCommandFlag flags, IndustryID ind_id, byte prod_level, bool show_news, const std::string &custom_news)
+CommandCost CmdIndustrySetProduction(DoCommandFlag flags, IndustryID ind_id, uint8_t prod_level, bool show_news, const std::string &custom_news)
 {
 	if (_current_company != OWNER_DEITY) return CMD_ERROR;
 	if (prod_level < PRODLEVEL_MINIMUM || prod_level > PRODLEVEL_MAXIMUM) return CMD_ERROR;
@@ -2313,7 +2313,7 @@ static uint32_t GetScaledIndustryGenerationProbability(IndustryType it, bool *fo
  * @param[out] min_number Minimal number of industries that should exist at the map.
  * @return Relative probability for the industry to appear.
  */
-static uint16_t GetIndustryGamePlayProbability(IndustryType it, byte *min_number)
+static uint16_t GetIndustryGamePlayProbability(IndustryType it, uint8_t *min_number)
 {
 	if (_settings_game.difficulty.industry_density == ID_FUND_ONLY) {
 		*min_number = 0;
@@ -2321,7 +2321,7 @@ static uint16_t GetIndustryGamePlayProbability(IndustryType it, byte *min_number
 	}
 
 	const IndustrySpec *ind_spc = GetIndustrySpec(it);
-	byte chance = ind_spc->appear_ingame[_settings_game.game_creation.landscape];
+	uint8_t chance = ind_spc->appear_ingame[_settings_game.game_creation.landscape];
 	if (!ind_spc->enabled || ind_spc->layouts.empty() ||
 			((ind_spc->behaviour & INDUSTRYBEH_BEFORE_1950) && TimerGameCalendar::year > 1950) ||
 			((ind_spc->behaviour & INDUSTRYBEH_AFTER_1960) && TimerGameCalendar::year < 1960) ||
@@ -2541,7 +2541,7 @@ void ClearAllIndustryCachedNames()
  */
 bool IndustryTypeBuildData::GetIndustryTypeData(IndustryType it)
 {
-	byte min_number;
+	uint8_t min_number;
 	uint32_t probability = GetIndustryGamePlayProbability(it, &min_number);
 	bool changed = min_number != this->min_number || probability != this->probability;
 	this->min_number = min_number;
@@ -2801,8 +2801,8 @@ static void ChangeIndustryProduction(Industry *i, bool monthly)
 	bool recalculate_multipliers = false; ///< reinitialize production_rate to match prod_level
 	/* use original economy for industries using production related callbacks */
 	bool original_economy = indspec->UsesOriginalEconomy();
-	byte div = 0;
-	byte mul = 0;
+	uint8_t div = 0;
+	uint8_t mul = 0;
 	int8_t increment = 0;
 
 	bool callback_enabled = HasBit(indspec->callback_mask, monthly ? CBM_IND_MONTHLYPROD_CHANGE : CBM_IND_PRODUCTION_CHANGE);

--- a/src/industry_cmd.h
+++ b/src/industry_cmd.h
@@ -14,13 +14,13 @@
 #include "company_type.h"
 #include "industry_type.h"
 
-enum IndustryControlFlags : byte;
+enum IndustryControlFlags : uint8_t;
 
 CommandCost CmdBuildIndustry(DoCommandFlag flags, TileIndex tile, IndustryType it, uint32_t first_layout, bool fund, uint32_t seed);
 CommandCost CmdIndustrySetFlags(DoCommandFlag flags, IndustryID ind_id, IndustryControlFlags ctlflags);
 CommandCost CmdIndustrySetExclusivity(DoCommandFlag flags, IndustryID ind_id, Owner company_id, bool consumer);
 CommandCost CmdIndustrySetText(DoCommandFlag flags, IndustryID ind_id, const std::string &text);
-CommandCost CmdIndustrySetProduction(DoCommandFlag flags, IndustryID ind_id, byte prod_level, bool show_news, const std::string &text);
+CommandCost CmdIndustrySetProduction(DoCommandFlag flags, IndustryID ind_id, uint8_t prod_level, bool show_news, const std::string &text);
 
 DEF_CMD_TRAIT(CMD_BUILD_INDUSTRY, CmdBuildIndustry, CMD_DEITY, CMDT_LANDSCAPE_CONSTRUCTION)
 DEF_CMD_TRAIT(CMD_INDUSTRY_SET_FLAGS, CmdIndustrySetFlags, CMD_DEITY, CMDT_OTHER_MANAGEMENT)

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -160,7 +160,7 @@ static inline void GetAllCargoSuffixes(CargoSuffixInOut use_input, CargoSuffixTy
 		/* Reworked behaviour with new many-in-many-out scheme */
 		for (uint j = 0; j < lengthof(suffixes); j++) {
 			if (IsValidCargoID(cargoes[j])) {
-				byte local_id = indspec->grf_prop.grffile->cargo_map[cargoes[j]]; // should we check the value for valid?
+				uint8_t local_id = indspec->grf_prop.grffile->cargo_map[cargoes[j]]; // should we check the value for valid?
 				uint cargotype = local_id << 16 | use_input;
 				GetCargoSuffix(cargotype, cst, ind, ind_type, indspec, suffixes[j]);
 			} else {
@@ -207,7 +207,7 @@ void GetCargoSuffix(CargoSuffixInOut use_input, CargoSuffixType cst, const Indus
 	suffix.display = CSD_CARGO;
 	if (!IsValidCargoID(cargo)) return;
 	if (indspec->behaviour & INDUSTRYBEH_CARGOTYPES_UNLIMITED) {
-		byte local_id = indspec->grf_prop.grffile->cargo_map[cargo]; // should we check the value for valid?
+		uint8_t local_id = indspec->grf_prop.grffile->cargo_map[cargo]; // should we check the value for valid?
 		uint cargotype = local_id << 16 | use_input;
 		GetCargoSuffix(cargotype, cst, ind, ind_type, indspec, suffix);
 	} else if (use_input == CARGOSUFFIX_IN) {
@@ -805,7 +805,7 @@ class IndustryViewWindow : public Window
 	Editability editable;     ///< Mode for changing production
 	InfoLine editbox_line;    ///< The line clicked to open the edit box
 	InfoLine clicked_line;    ///< The line of the button that has been clicked
-	byte clicked_button;      ///< The button that has been clicked (to raise)
+	uint8_t clicked_button;      ///< The button that has been clicked (to raise)
 	int production_offset_y;  ///< The offset of the production texts/buttons
 	int info_height;          ///< Height needed for the #WID_IV_INFO panel
 	int cheat_line_height;    ///< Height of each line for the #WID_IV_INFO panel
@@ -1048,10 +1048,10 @@ public:
 						case EA_MULTIPLIER:
 							if (decrease) {
 								if (i->prod_level <= PRODLEVEL_MINIMUM) return;
-								i->prod_level = static_cast<byte>(std::max<uint>(i->prod_level / 2, PRODLEVEL_MINIMUM));
+								i->prod_level = static_cast<uint8_t>(std::max<uint>(i->prod_level / 2, PRODLEVEL_MINIMUM));
 							} else {
 								if (i->prod_level >= PRODLEVEL_MAXIMUM) return;
-								i->prod_level = static_cast<byte>(std::min<uint>(i->prod_level * 2, PRODLEVEL_MAXIMUM));
+								i->prod_level = static_cast<uint8_t>(std::min<uint>(i->prod_level * 2, PRODLEVEL_MAXIMUM));
 							}
 							break;
 
@@ -1063,7 +1063,7 @@ public:
 								if (i->produced[line - IL_RATE1].rate >= 255) return;
 								/* a zero production industry is unlikely to give anything but zero, so push it a little bit */
 								int new_prod = i->produced[line - IL_RATE1].rate == 0 ? 1 : i->produced[line - IL_RATE1].rate * 2;
-								i->produced[line - IL_RATE1].rate = ClampTo<byte>(new_prod);
+								i->produced[line - IL_RATE1].rate = ClampTo<uint8_t>(new_prod);
 							}
 							break;
 
@@ -1551,7 +1551,7 @@ protected:
 	StringID GetIndustryString(const Industry *i) const
 	{
 		const IndustrySpec *indsp = GetIndustrySpec(i->type);
-		byte p = 0;
+		uint8_t p = 0;
 
 		/* Industry name */
 		SetDParam(p++, i->index);

--- a/src/industry_map.h
+++ b/src/industry_map.h
@@ -97,10 +97,10 @@ inline void SetIndustryCompleted(Tile tile)
  * @pre IsTileType(tile, MP_INDUSTRY)
  * @return the construction stage
  */
-inline byte GetIndustryConstructionStage(Tile tile)
+inline uint8_t GetIndustryConstructionStage(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
-	return IsIndustryCompleted(tile) ? (byte)INDUSTRY_COMPLETED : GB(tile.m1(), 0, 2);
+	return IsIndustryCompleted(tile) ? (uint8_t)INDUSTRY_COMPLETED : GB(tile.m1(), 0, 2);
 }
 
 /**
@@ -109,7 +109,7 @@ inline byte GetIndustryConstructionStage(Tile tile)
  * @param value the new construction stage
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-inline void SetIndustryConstructionStage(Tile tile, byte value)
+inline void SetIndustryConstructionStage(Tile tile, uint8_t value)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	SB(tile.m1(), 0, 2, value);
@@ -159,7 +159,7 @@ inline void SetIndustryGfx(Tile t, IndustryGfx gfx)
  * @pre IsTileType(tile, MP_INDUSTRY)
  * @return the construction counter
  */
-inline byte GetIndustryConstructionCounter(Tile tile)
+inline uint8_t GetIndustryConstructionCounter(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	return GB(tile.m1(), 2, 2);
@@ -171,7 +171,7 @@ inline byte GetIndustryConstructionCounter(Tile tile)
  * @param value the new value for the construction counter
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-inline void SetIndustryConstructionCounter(Tile tile, byte value)
+inline void SetIndustryConstructionCounter(Tile tile, uint8_t value)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	SB(tile.m1(), 2, 2, value);
@@ -196,7 +196,7 @@ inline void ResetIndustryConstructionStage(Tile tile)
  * @param tile the tile to get the animation loop number of
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-inline byte GetIndustryAnimationLoop(Tile tile)
+inline uint8_t GetIndustryAnimationLoop(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	return tile.m4();
@@ -208,7 +208,7 @@ inline byte GetIndustryAnimationLoop(Tile tile)
  * @param count the new animation frame number
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-inline void SetIndustryAnimationLoop(Tile tile, byte count)
+inline void SetIndustryAnimationLoop(Tile tile, uint8_t count)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	tile.m4() = count;
@@ -221,7 +221,7 @@ inline void SetIndustryAnimationLoop(Tile tile, byte count)
  * @pre IsTileType(tile, MP_INDUSTRY)
  * @return requested bits
  */
-inline byte GetIndustryRandomBits(Tile tile)
+inline uint8_t GetIndustryRandomBits(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	return tile.m3();
@@ -234,7 +234,7 @@ inline byte GetIndustryRandomBits(Tile tile)
  * @param bits the random bits
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-inline void SetIndustryRandomBits(Tile tile, byte bits)
+inline void SetIndustryRandomBits(Tile tile, uint8_t bits)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	tile.m3() = bits;
@@ -247,7 +247,7 @@ inline void SetIndustryRandomBits(Tile tile, byte bits)
  * @pre IsTileType(tile, MP_INDUSTRY)
  * @return requested triggers
  */
-inline byte GetIndustryTriggers(Tile tile)
+inline uint8_t GetIndustryTriggers(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	return GB(tile.m6(), 3, 3);
@@ -261,7 +261,7 @@ inline byte GetIndustryTriggers(Tile tile)
  * @param triggers the triggers to set
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-inline void SetIndustryTriggers(Tile tile, byte triggers)
+inline void SetIndustryTriggers(Tile tile, uint8_t triggers)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	SB(tile.m6(), 3, 3, triggers);

--- a/src/industrytype.h
+++ b/src/industrytype.h
@@ -108,30 +108,30 @@ struct IndustrySpec {
 	uint32_t removal_cost_multiplier;             ///< Base removal cost multiplier.
 	uint32_t prospecting_chance;                  ///< Chance prospecting succeeds
 	IndustryType conflicting[3];                ///< Industries this industry cannot be close to
-	byte check_proc;                            ///< Index to a procedure to check for conflicting circumstances
+	uint8_t check_proc;                            ///< Index to a procedure to check for conflicting circumstances
 	CargoID produced_cargo[INDUSTRY_NUM_OUTPUTS];
 	std::variant<CargoLabel, MixedCargoType> produced_cargo_label[INDUSTRY_NUM_OUTPUTS];
-	byte production_rate[INDUSTRY_NUM_OUTPUTS];
+	uint8_t production_rate[INDUSTRY_NUM_OUTPUTS];
 	/**
 	 * minimum amount of cargo transported to the stations.
 	 * If the waiting cargo is less than this number, no cargo is moved to it.
 	 */
-	byte minimal_cargo;
+	uint8_t minimal_cargo;
 	CargoID accepts_cargo[INDUSTRY_NUM_INPUTS]; ///< 16 accepted cargoes.
 	std::variant<CargoLabel, MixedCargoType> accepts_cargo_label[INDUSTRY_NUM_INPUTS];
 	uint16_t input_cargo_multiplier[INDUSTRY_NUM_INPUTS][INDUSTRY_NUM_OUTPUTS]; ///< Input cargo multipliers (multiply amount of incoming cargo for the produced cargoes)
 	IndustryLifeType life_type;                 ///< This is also known as Industry production flag, in newgrf specs
-	byte climate_availability;                  ///< Bitmask, giving landscape enums as bit position
+	uint8_t climate_availability;                  ///< Bitmask, giving landscape enums as bit position
 	IndustryBehaviour behaviour;                ///< How this industry will behave, and how others entities can use it
-	byte map_colour;                            ///< colour used for the small map
+	uint8_t map_colour;                            ///< colour used for the small map
 	StringID name;                              ///< Displayed name of the industry
 	StringID new_industry_text;                 ///< Message appearing when the industry is built
 	StringID closure_text;                      ///< Message appearing when the industry closes
 	StringID production_up_text;                ///< Message appearing when the industry's production is increasing
 	StringID production_down_text;              ///< Message appearing when the industry's production is decreasing
 	StringID station_name;                      ///< Default name for nearby station
-	byte appear_ingame[NUM_LANDSCAPE];          ///< Probability of appearance in game
-	byte appear_creation[NUM_LANDSCAPE];        ///< Probability of appearance during map creation
+	uint8_t appear_ingame[NUM_LANDSCAPE];          ///< Probability of appearance in game
+	uint8_t appear_creation[NUM_LANDSCAPE];        ///< Probability of appearance during map creation
 	uint8_t number_of_sounds;                     ///< Number of sounds available in the sounds array
 	const uint8_t *random_sounds;                 ///< array of random sounds.
 	/* Newgrf data */
@@ -158,8 +158,8 @@ struct IndustryTileSpec {
 	std::array<std::variant<CargoLabel, MixedCargoType>, INDUSTRY_NUM_INPUTS> accepts_cargo_label;
 	std::array<int8_t, INDUSTRY_NUM_INPUTS> acceptance; ///< Level of acceptance per cargo type (signed, may be negative!)
 	Slope slopes_refused;                 ///< slope pattern on which this tile cannot be built
-	byte anim_production;                 ///< Animation frame to start when goods are produced
-	byte anim_next;                       ///< Next frame in an animation
+	uint8_t anim_production;                 ///< Animation frame to start when goods are produced
+	uint8_t anim_next;                       ///< Next frame in an animation
 	/**
 	 * When true, the tile has to be drawn using the animation
 	 * state instead of the construction state

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -48,13 +48,13 @@
  */
 struct IntroGameViewportCommand {
 	/** Horizontal alignment value. */
-	enum AlignmentH : byte {
+	enum AlignmentH : uint8_t {
 		LEFT,
 		CENTRE,
 		RIGHT,
 	};
 	/** Vertical alignment value. */
-	enum AlignmentV : byte {
+	enum AlignmentV : uint8_t {
 		TOP,
 		MIDDLE,
 		BOTTOM,

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -76,7 +76,7 @@ const TileTypeProcs * const _tile_type_procs[16] = {
 };
 
 /** landscape slope => sprite */
-extern const byte _slope_to_sprite_offset[32] = {
+extern const uint8_t _slope_to_sprite_offset[32] = {
 	0, 1, 2, 3, 4, 5, 6,  7, 8, 9, 10, 11, 12, 13, 14, 0,
 	0, 0, 0, 0, 0, 0, 0, 16, 0, 0,  0, 17,  0, 15, 18, 0,
 };
@@ -455,7 +455,7 @@ void DrawFoundation(TileInfo *ti, Foundation f)
 
 		if (IsInclinedFoundation(f)) {
 			/* inclined foundation */
-			byte inclined = highest_corner * 2 + (f == FOUNDATION_INCLINED_Y ? 1 : 0);
+			uint8_t inclined = highest_corner * 2 + (f == FOUNDATION_INCLINED_Y ? 1 : 0);
 
 			AddSortableSpriteToDraw(inclined_base + inclined, PAL_NONE, ti->x, ti->y,
 				f == FOUNDATION_INCLINED_X ? TILE_SIZE : 1,
@@ -510,7 +510,7 @@ void DrawFoundation(TileInfo *ti, Foundation f)
 			OffsetGroundSprite(0, 0);
 		} else {
 			/* inclined foundation */
-			byte inclined = GetHighestSlopeCorner(ti->tileh) * 2 + (f == FOUNDATION_INCLINED_Y ? 1 : 0);
+			uint8_t inclined = GetHighestSlopeCorner(ti->tileh) * 2 + (f == FOUNDATION_INCLINED_Y ? 1 : 0);
 
 			AddSortableSpriteToDraw(inclined_base + inclined, PAL_NONE, ti->x, ti->y,
 				f == FOUNDATION_INCLINED_X ? TILE_SIZE : 1,
@@ -582,7 +582,7 @@ bool IsSnowLineSet()
  * @param table the 12 * 32 byte table containing the snowline for each day
  * @ingroup SnowLineGroup
  */
-void SetSnowLine(byte table[SNOW_LINE_MONTHS][SNOW_LINE_DAYS])
+void SetSnowLine(uint8_t table[SNOW_LINE_MONTHS][SNOW_LINE_DAYS])
 {
 	_snow_line = CallocT<SnowLine>(1);
 	_snow_line->lowest_value = 0xFF;
@@ -601,7 +601,7 @@ void SetSnowLine(byte table[SNOW_LINE_MONTHS][SNOW_LINE_DAYS])
  * @return the snow line height.
  * @ingroup SnowLineGroup
  */
-byte GetSnowLine()
+uint8_t GetSnowLine()
 {
 	if (_snow_line == nullptr) return _settings_game.game_creation.snow_line_height;
 
@@ -614,7 +614,7 @@ byte GetSnowLine()
  * @return the highest snow line height.
  * @ingroup SnowLineGroup
  */
-byte HighestSnowLine()
+uint8_t HighestSnowLine()
 {
 	return _snow_line == nullptr ? _settings_game.game_creation.snow_line_height : _snow_line->highest_value;
 }
@@ -624,7 +624,7 @@ byte HighestSnowLine()
  * @return the lowest snow line height.
  * @ingroup SnowLineGroup
  */
-byte LowestSnowLine()
+uint8_t LowestSnowLine()
 {
 	return _snow_line == nullptr ? _settings_game.game_creation.snow_line_height : _snow_line->lowest_value;
 }
@@ -805,8 +805,8 @@ void InitializeLandscape()
 	for (uint y = 0; y < Map::SizeY(); y++) MakeVoid(TileXY(Map::MaxX(), y));
 }
 
-static const byte _genterrain_tbl_1[5] = { 10, 22, 33, 37, 4  };
-static const byte _genterrain_tbl_2[5] = {  0,  0,  0,  0, 33 };
+static const uint8_t _genterrain_tbl_1[5] = { 10, 22, 33, 37, 4  };
+static const uint8_t _genterrain_tbl_2[5] = {  0,  0,  0,  0, 33 };
 
 static void GenerateTerrain(int type, uint flag)
 {
@@ -830,7 +830,7 @@ static void GenerateTerrain(int type, uint flag)
 
 	if (DiagDirToAxis(direction) == AXIS_Y) Swap(w, h);
 
-	const byte *p = templ->data;
+	const uint8_t *p = templ->data;
 
 	if ((flag & 4) != 0) {
 		/* This is only executed in secondary/tertiary loops to generate the terrain for arctic and tropic.
@@ -1550,7 +1550,7 @@ static uint8_t CalculateDesertLine()
 	return CalculateCoverageLine(100 - _settings_game.game_creation.desert_coverage, 4);
 }
 
-bool GenerateLandscape(byte mode)
+bool GenerateLandscape(uint8_t mode)
 {
 	/** Number of steps of landscape generation */
 	enum GenLandscapeSteps {

--- a/src/landscape.h
+++ b/src/landscape.h
@@ -21,16 +21,16 @@ static const uint SNOW_LINE_DAYS   = 32; ///< Number of days in each month in th
  * @ingroup SnowLineGroup
  */
 struct SnowLine {
-	byte table[SNOW_LINE_MONTHS][SNOW_LINE_DAYS]; ///< Height of the snow line each day of the year
-	byte highest_value; ///< Highest snow line of the year
-	byte lowest_value;  ///< Lowest snow line of the year
+	uint8_t table[SNOW_LINE_MONTHS][SNOW_LINE_DAYS]; ///< Height of the snow line each day of the year
+	uint8_t highest_value; ///< Highest snow line of the year
+	uint8_t lowest_value;  ///< Lowest snow line of the year
 };
 
 bool IsSnowLineSet();
-void SetSnowLine(byte table[SNOW_LINE_MONTHS][SNOW_LINE_DAYS]);
-byte GetSnowLine();
-byte HighestSnowLine();
-byte LowestSnowLine();
+void SetSnowLine(uint8_t table[SNOW_LINE_MONTHS][SNOW_LINE_DAYS]);
+uint8_t GetSnowLine();
+uint8_t HighestSnowLine();
+uint8_t LowestSnowLine();
 void ClearSnowLine();
 
 int GetSlopeZInCorner(Slope tileh, Corner corner);
@@ -136,6 +136,6 @@ void DoClearSquare(TileIndex tile);
 void RunTileLoop();
 
 void InitializeLandscape();
-bool GenerateLandscape(byte mode);
+bool GenerateLandscape(uint8_t mode);
 
 #endif /* LANDSCAPE_H */

--- a/src/landscape_type.h
+++ b/src/landscape_type.h
@@ -10,7 +10,7 @@
 #ifndef LANDSCAPE_TYPE_H
 #define LANDSCAPE_TYPE_H
 
-typedef byte LandscapeID; ///< Landscape type. @see LandscapeType
+typedef uint8_t LandscapeID; ///< Landscape type. @see LandscapeType
 
 /** Landscape types */
 enum LandscapeType {

--- a/src/language.h
+++ b/src/language.h
@@ -38,8 +38,8 @@ struct LanguagePackHeader {
 	/** Decimal separator */
 	char digit_decimal_separator[8];
 	uint16_t missing;     ///< number of missing strings.
-	byte plural_form;   ///< plural form index
-	byte text_dir;      ///< default direction of the text
+	uint8_t plural_form;   ///< plural form index
+	uint8_t text_dir;      ///< default direction of the text
 	/**
 	 * Windows language ID:
 	 * Windows cannot and will not convert isocodes to something it can use to
@@ -52,7 +52,7 @@ struct LanguagePackHeader {
 	uint8_t newgrflangid; ///< newgrf language id
 	uint8_t num_genders;  ///< the number of genders of this language
 	uint8_t num_cases;    ///< the number of cases of this language
-	byte pad[3];        ///< pad header to be a multiple of 4
+	uint8_t pad[3];        ///< pad header to be a multiple of 4
 
 	char genders[MAX_NUM_GENDERS][CASE_GENDER_LEN]; ///< the genders used by this translation
 	char cases[MAX_NUM_CASES][CASE_GENDER_LEN];     ///< the cases used by this translation
@@ -108,6 +108,6 @@ extern std::unique_ptr<icu::Collator> _current_collator;
 #endif /* WITH_ICU_I18N */
 
 bool ReadLanguagePack(const LanguageMetadata *lang);
-const LanguageMetadata *GetLanguage(byte newgrflangid);
+const LanguageMetadata *GetLanguage(uint8_t newgrflangid);
 
 #endif /* LANGUAGE_H */

--- a/src/league_type.h
+++ b/src/league_type.h
@@ -11,7 +11,7 @@
 #define LEAGUE_TYPE_H
 
 /** Types of the possible link targets. */
-enum LinkType : byte {
+enum LinkType : uint8_t {
 	LT_NONE = 0,         ///< No link
 	LT_TILE = 1,         ///< Link a tile
 	LT_INDUSTRY = 2,     ///< Link an industry

--- a/src/linkgraph/linkgraph_type.h
+++ b/src/linkgraph/linkgraph_type.h
@@ -19,7 +19,7 @@ static const LinkGraphJobID INVALID_LINK_GRAPH_JOB = UINT16_MAX;
 typedef uint16_t NodeID;
 static const NodeID INVALID_NODE = UINT16_MAX;
 
-enum DistributionType : byte {
+enum DistributionType : uint8_t {
 	DT_BEGIN = 0,
 	DT_MIN = 0,
 	DT_MANUAL = 0,           ///< Manual distribution. No link graph calculations are run.

--- a/src/linkgraph/refresh.cpp
+++ b/src/linkgraph/refresh.cpp
@@ -102,7 +102,7 @@ bool LinkRefresher::HandleRefit(CargoID refit_cargo)
 
 		/* Back up the vehicle's cargo type */
 		CargoID temp_cid = v->cargo_type;
-		byte temp_subtype = v->cargo_subtype;
+		uint8_t temp_subtype = v->cargo_subtype;
 		v->cargo_type = this->cargo;
 		v->cargo_subtype = GetBestFittingSubType(v, v, this->cargo);
 

--- a/src/livery.h
+++ b/src/livery.h
@@ -13,12 +13,12 @@
 #include "company_type.h"
 #include "gfx_type.h"
 
-static const byte LIT_NONE    = 0; ///< Don't show the liveries at all
-static const byte LIT_COMPANY = 1; ///< Show the liveries of your own company
-static const byte LIT_ALL     = 2; ///< Show the liveries of all companies
+static const uint8_t LIT_NONE    = 0; ///< Don't show the liveries at all
+static const uint8_t LIT_COMPANY = 1; ///< Show the liveries of your own company
+static const uint8_t LIT_ALL     = 2; ///< Show the liveries of all companies
 
 /** List of different livery schemes. */
-enum LiveryScheme : byte {
+enum LiveryScheme : uint8_t {
 	LS_BEGIN = 0,
 	LS_DEFAULT = 0,
 
@@ -60,7 +60,7 @@ enum LiveryScheme : byte {
 DECLARE_POSTFIX_INCREMENT(LiveryScheme)
 
 /** List of different livery classes, used only by the livery GUI. */
-enum LiveryClass : byte {
+enum LiveryClass : uint8_t {
 	LC_OTHER,
 	LC_RAIL,
 	LC_ROAD,
@@ -76,7 +76,7 @@ DECLARE_ENUM_AS_ADDABLE(LiveryClass)
 
 /** Information about a particular livery. */
 struct Livery {
-	byte in_use;  ///< Bit 0 set if this livery should override the default livery first colour, Bit 1 for the second colour.
+	uint8_t in_use;  ///< Bit 0 set if this livery should override the default livery first colour, Bit 1 for the second colour.
 	Colours colour1; ///< First colour, for all vehicles.
 	Colours colour2; ///< Second colour, for vehicles with 2CC support.
 };

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -335,7 +335,7 @@ struct MainWindow : Window
 			case GHK_REFRESH_SCREEN: MarkWholeScreenDirty(); break;
 
 			case GHK_CRASH: // Crash the game
-				*(volatile byte *)nullptr = 0;
+				*(volatile uint8_t *)nullptr = 0;
 				break;
 
 			case GHK_MONEY: // Gimme money
@@ -541,7 +541,7 @@ void ShowSelectGameWindow();
 void SetupColoursAndInitialWindow()
 {
 	for (Colours i = COLOUR_BEGIN; i != COLOUR_END; i++) {
-		const byte *b = GetNonSprite(GENERAL_SPRITE_COLOUR(i), SpriteType::Recolour) + 1;
+		const uint8_t *b = GetNonSprite(GENERAL_SPRITE_COLOUR(i), SpriteType::Recolour) + 1;
 		assert(b != nullptr);
 		for (ColourShade j = SHADE_BEGIN; j < SHADE_END; j++) {
 			SetColourGradient(i, j, b[0xC6 + j]);

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -30,13 +30,13 @@ private:
 	 * Look at docs/landscape.html for the exact meaning of the members.
 	 */
 	struct TileBase {
-		byte   type;   ///< The type (bits 4..7), bridges (2..3), rainforest/desert (0..1)
-		byte   height; ///< The height of the northern corner.
+		uint8_t   type;   ///< The type (bits 4..7), bridges (2..3), rainforest/desert (0..1)
+		uint8_t   height; ///< The height of the northern corner.
 		uint16_t m2;     ///< Primarily used for indices to towns, industries and stations
-		byte   m1;     ///< Primarily used for ownership information
-		byte   m3;     ///< General purpose
-		byte   m4;     ///< General purpose
-		byte   m5;     ///< General purpose
+		uint8_t   m1;     ///< Primarily used for ownership information
+		uint8_t   m3;     ///< General purpose
+		uint8_t   m4;     ///< General purpose
+		uint8_t   m5;     ///< General purpose
 	};
 
 	static_assert(sizeof(TileBase) == 8);
@@ -46,8 +46,8 @@ private:
 	 * Look at docs/landscape.html for the exact meaning of the members.
 	 */
 	struct TileExtended {
-		byte m6;   ///< General purpose
-		byte m7;   ///< Primarily used for newgrf support
+		uint8_t m6;   ///< General purpose
+		uint8_t m7;   ///< Primarily used for newgrf support
 		uint16_t m8; ///< General purpose
 	};
 
@@ -86,7 +86,7 @@ public:
 	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
-	debug_inline byte &type()
+	debug_inline uint8_t &type()
 	{
 		return base_tiles[tile.base()].type;
 	}
@@ -98,7 +98,7 @@ public:
 	 * @param tile The tile to get the height for.
 	 * @return reference to the byte holding the height.
 	 */
-	debug_inline byte &height()
+	debug_inline uint8_t &height()
 	{
 		return base_tiles[tile.base()].height;
 	}
@@ -110,7 +110,7 @@ public:
 	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
-	debug_inline byte &m1()
+	debug_inline uint8_t &m1()
 	{
 		return base_tiles[tile.base()].m1;
 	}
@@ -134,7 +134,7 @@ public:
 	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
-	debug_inline byte &m3()
+	debug_inline uint8_t &m3()
 	{
 		return base_tiles[tile.base()].m3;
 	}
@@ -146,7 +146,7 @@ public:
 	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
-	debug_inline byte &m4()
+	debug_inline uint8_t &m4()
 	{
 		return base_tiles[tile.base()].m4;
 	}
@@ -158,7 +158,7 @@ public:
 	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
-	debug_inline byte &m5()
+	debug_inline uint8_t &m5()
 	{
 		return base_tiles[tile.base()].m5;
 	}
@@ -170,7 +170,7 @@ public:
 	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
-	debug_inline byte &m6()
+	debug_inline uint8_t &m6()
 	{
 		return extended_tiles[tile.base()].m6;
 	}
@@ -182,7 +182,7 @@ public:
 	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
-	debug_inline byte &m7()
+	debug_inline uint8_t &m7()
 	{
 		return extended_tiles[tile.base()].m7;
 	}

--- a/src/map_type.h
+++ b/src/map_type.h
@@ -52,7 +52,7 @@ static const uint MAX_MAP_SIZE      = 1U << MAX_MAP_SIZE_BITS; ///< Maximal map 
 #define STRAIGHT_TRACK_LENGTH 7071/10000
 
 /** Argument for CmdLevelLand describing what to do. */
-enum LevelMode : byte {
+enum LevelMode : uint8_t {
 	LM_LEVEL, ///< Level the land.
 	LM_LOWER, ///< Lower the land.
 	LM_RAISE, ///< Raise the land.

--- a/src/misc/endian_buffer.hpp
+++ b/src/misc/endian_buffer.hpp
@@ -22,7 +22,7 @@ struct StrongTypedefBase;
  * as this allows providing custom operator overloads for more complex types
  * like e.g. structs without needing to modify this class.
  */
-template <typename Tcont = typename std::vector<byte>, typename Titer = typename std::back_insert_iterator<Tcont>>
+template <typename Tcont = typename std::vector<uint8_t>, typename Titer = typename std::back_insert_iterator<Tcont>>
 class EndianBufferWriter {
 	/** Output iterator for the destination buffer. */
 	Titer buffer;
@@ -34,7 +34,7 @@ public:
 	EndianBufferWriter &operator <<(const std::string &data) { return *this << std::string_view{ data }; }
 	EndianBufferWriter &operator <<(const char *data) { return *this << std::string_view{ data }; }
 	EndianBufferWriter &operator <<(std::string_view data) { this->Write(data); return *this; }
-	EndianBufferWriter &operator <<(bool data) { return *this << static_cast<byte>(data ? 1 : 0); }
+	EndianBufferWriter &operator <<(bool data) { return *this << static_cast<uint8_t>(data ? 1 : 0); }
 
 	template <typename T>
 	EndianBufferWriter &operator <<(const OverflowSafeInt<T> &data) { return *this << static_cast<T>(data); };
@@ -59,7 +59,7 @@ public:
 		return *this;
 	}
 
-	template <typename Tvalue, typename Tbuf = std::vector<byte>>
+	template <typename Tvalue, typename Tbuf = std::vector<uint8_t>>
 	static Tbuf FromValue(const Tvalue &data)
 	{
 		Tbuf buffer;
@@ -118,17 +118,17 @@ private:
  */
 class EndianBufferReader {
 	/** Reference to storage buffer. */
-	std::span<const byte> buffer;
+	std::span<const uint8_t> buffer;
 	/** Current read position. */
 	size_t read_pos = 0;
 
 public:
-	EndianBufferReader(std::span<const byte> buffer) : buffer(buffer) {}
+	EndianBufferReader(std::span<const uint8_t> buffer) : buffer(buffer) {}
 
 	void rewind() { this->read_pos = 0; }
 
 	EndianBufferReader &operator >>(std::string &data) { data = this->ReadStr(); return *this; }
-	EndianBufferReader &operator >>(bool &data) { data = this->Read<byte>() != 0; return *this; }
+	EndianBufferReader &operator >>(bool &data) { data = this->Read<uint8_t>() != 0; return *this; }
 
 	template <typename T>
 	EndianBufferReader &operator >>(OverflowSafeInt<T> &data) { data = this->Read<T>(); return *this; };
@@ -154,7 +154,7 @@ public:
 	}
 
 	template <typename Tvalue>
-	static Tvalue ToValue(std::span<const byte> buffer)
+	static Tvalue ToValue(std::span<const uint8_t> buffer)
 	{
 		Tvalue result{};
 		EndianBufferReader reader{ buffer };

--- a/src/misc/fixedsizearray.hpp
+++ b/src/misc/fixedsizearray.hpp
@@ -41,13 +41,13 @@ protected:
 	/** return reference to the array header (non-const) */
 	inline ArrayHeader &Hdr()
 	{
-		return *(ArrayHeader*)(((byte*)data) - HeaderSize);
+		return *(ArrayHeader*)(((uint8_t*)data) - HeaderSize);
 	}
 
 	/** return reference to the array header (const) */
 	inline const ArrayHeader &Hdr() const
 	{
-		return *(ArrayHeader*)(((byte*)data) - HeaderSize);
+		return *(ArrayHeader*)(((uint8_t*)data) - HeaderSize);
 	}
 
 	/** return reference to the block reference counter */
@@ -70,7 +70,7 @@ public:
 		static_assert(C < (SIZE_MAX - HeaderSize) / Tsize);
 
 		/* allocate block for header + items (don't construct items) */
-		data = (T*)((MallocT<byte>(HeaderSize + C * Tsize)) + HeaderSize);
+		data = (T*)((MallocT<uint8_t>(HeaderSize + C * Tsize)) + HeaderSize);
 		SizeRef() = 0; // initial number of items
 		RefCnt() = 1; // initial reference counter
 	}
@@ -91,7 +91,7 @@ public:
 
 		Clear();
 		/* free the memory block occupied by items */
-		free(((byte*)data) - HeaderSize);
+		free(((uint8_t*)data) - HeaderSize);
 		data = nullptr;
 	}
 

--- a/src/misc/getoptdata.h
+++ b/src/misc/getoptdata.h
@@ -20,7 +20,7 @@ enum OptionDataFlags {
 
 /** Data of an option. */
 struct OptionData {
-	byte id;              ///< Unique identification of this option data, often the same as #shortname.
+	uint8_t id;              ///< Unique identification of this option data, often the same as #shortname.
 	char shortname;       ///< Short option letter if available, else use \c '\0'.
 	uint16_t flags;         ///< Option data flags. @see OptionDataFlags
 	const char *longname; ///< Long option name including '-'/'--' prefix, use \c nullptr if not available.

--- a/src/misc_cmd.h
+++ b/src/misc_cmd.h
@@ -13,9 +13,9 @@
 #include "command_type.h"
 #include "economy_type.h"
 
-enum PauseMode : byte;
+enum PauseMode : uint8_t;
 
-enum class LoanCommand : byte {
+enum class LoanCommand : uint8_t {
 	Interval,
 	Max,
 	Amount,

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -35,7 +35,7 @@ char *GetMusicCatEntryName(const std::string &filename, size_t entrynum)
 	if (entrynum < entry_count) {
 		file.SeekTo(entrynum * 8, SEEK_SET);
 		file.SeekTo(file.ReadDword(), SEEK_SET);
-		byte namelen = file.ReadByte();
+		uint8_t namelen = file.ReadByte();
 		char *name = MallocT<char>(namelen + 1);
 		file.ReadBlock(name, namelen);
 		name[namelen] = '\0';
@@ -52,7 +52,7 @@ char *GetMusicCatEntryName(const std::string &filename, size_t entrynum)
  * @return Pointer to buffer with data read, caller is responsible for freeind memory,
  *         nullptr if entrynum does not exist.
  */
-byte *GetMusicCatEntryData(const std::string &filename, size_t entrynum, size_t &entrylen)
+uint8_t *GetMusicCatEntryData(const std::string &filename, size_t entrynum, size_t &entrylen)
 {
 	entrylen = 0;
 	if (!FioCheckFileExists(filename, BASESET_DIR)) return nullptr;
@@ -66,7 +66,7 @@ byte *GetMusicCatEntryData(const std::string &filename, size_t entrynum, size_t 
 		entrylen = file.ReadDword();
 		file.SeekTo(entrypos, SEEK_SET);
 		file.SkipBytes(file.ReadByte());
-		byte *data = MallocT<byte>(entrylen);
+		uint8_t *data = MallocT<uint8_t>(entrylen);
 		file.ReadBlock(data, entrylen);
 		return data;
 	}

--- a/src/music/allegro_m.cpp
+++ b/src/music/allegro_m.cpp
@@ -80,7 +80,7 @@ bool MusicDriver_Allegro::IsSongPlaying()
 	return midi_pos >= 0;
 }
 
-void MusicDriver_Allegro::SetVolume(byte vol)
+void MusicDriver_Allegro::SetVolume(uint8_t vol)
 {
 	set_volume(-1, vol);
 }

--- a/src/music/allegro_m.h
+++ b/src/music/allegro_m.h
@@ -25,7 +25,7 @@ public:
 
 	bool IsSongPlaying() override;
 
-	void SetVolume(byte vol) override;
+	void SetVolume(uint8_t vol) override;
 	const char *GetName() const override { return "allegro"; }
 };
 

--- a/src/music/bemidi.cpp
+++ b/src/music/bemidi.cpp
@@ -69,7 +69,7 @@ bool MusicDriver_BeMidi::IsSongPlaying()
 	return !this->midi_synth_file->IsFinished();
 }
 
-void MusicDriver_BeMidi::SetVolume(byte vol)
+void MusicDriver_BeMidi::SetVolume(uint8_t vol)
 {
 	this->current_volume = vol / 128.0;
 	if (this->midi_synth_file != nullptr) this->midi_synth_file->SetVolume(this->current_volume);

--- a/src/music/bemidi.h
+++ b/src/music/bemidi.h
@@ -28,7 +28,7 @@ public:
 
 	bool IsSongPlaying() override;
 
-	void SetVolume(byte vol) override;
+	void SetVolume(uint8_t vol) override;
 	const char *GetName() const override { return "bemidi"; }
 
 private:

--- a/src/music/cocoa_m.cpp
+++ b/src/music/cocoa_m.cpp
@@ -37,7 +37,7 @@ static MusicPlayer    _player = nullptr;
 static MusicSequence  _sequence = nullptr;
 static MusicTimeStamp _seq_length = 0;
 static bool           _playing = false;
-static byte           _volume = 127;
+static uint8_t           _volume = 127;
 
 
 /** Set the volume of the current sequence. */
@@ -193,7 +193,7 @@ void MusicDriver_Cocoa::StopSong()
  *
  * @param vol The desired volume, range of the value is @c 0-127
  */
-void MusicDriver_Cocoa::SetVolume(byte vol)
+void MusicDriver_Cocoa::SetVolume(uint8_t vol)
 {
 	_volume = vol;
 	DoSetVolume();

--- a/src/music/cocoa_m.h
+++ b/src/music/cocoa_m.h
@@ -24,7 +24,7 @@ public:
 
 	bool IsSongPlaying() override;
 
-	void SetVolume(byte vol) override;
+	void SetVolume(uint8_t vol) override;
 	const char *GetName() const override { return "cocoa"; }
 };
 

--- a/src/music/dmusic.h
+++ b/src/music/dmusic.h
@@ -27,7 +27,7 @@ public:
 
 	bool IsSongPlaying() override;
 
-	void SetVolume(byte vol) override;
+	void SetVolume(uint8_t vol) override;
 	const char *GetName() const override { return "dmusic"; }
 };
 

--- a/src/music/extmidi.cpp
+++ b/src/music/extmidi.cpp
@@ -95,7 +95,7 @@ bool MusicDriver_ExtMidi::IsSongPlaying()
 	return this->pid != -1;
 }
 
-void MusicDriver_ExtMidi::SetVolume(byte)
+void MusicDriver_ExtMidi::SetVolume(uint8_t)
 {
 	Debug(driver, 1, "extmidi: set volume not implemented");
 }

--- a/src/music/extmidi.h
+++ b/src/music/extmidi.h
@@ -32,7 +32,7 @@ public:
 
 	bool IsSongPlaying() override;
 
-	void SetVolume(byte vol) override;
+	void SetVolume(uint8_t vol) override;
 	const char *GetName() const override { return "extmidi"; }
 };
 

--- a/src/music/fluidsynth.cpp
+++ b/src/music/fluidsynth.cpp
@@ -183,7 +183,7 @@ bool MusicDriver_FluidSynth::IsSongPlaying()
 	return fluid_player_get_status(_midi.player) == FLUID_PLAYER_PLAYING;
 }
 
-void MusicDriver_FluidSynth::SetVolume(byte vol)
+void MusicDriver_FluidSynth::SetVolume(uint8_t vol)
 {
 	std::lock_guard<std::mutex> lock{ _midi.synth_mutex };
 	if (_midi.settings == nullptr) return;

--- a/src/music/fluidsynth.h
+++ b/src/music/fluidsynth.h
@@ -25,7 +25,7 @@ public:
 
 	bool IsSongPlaying() override;
 
-	void SetVolume(byte vol) override;
+	void SetVolume(uint8_t vol) override;
 	const char *GetName() const override { return "fluidsynth"; }
 };
 

--- a/src/music/midi.h
+++ b/src/music/midi.h
@@ -152,6 +152,6 @@ enum class MidiSysexMessage {
 	RolandSetReverb,
 };
 
-const byte *MidiGetStandardSysexMessage(MidiSysexMessage msg, size_t &length);
+const uint8_t *MidiGetStandardSysexMessage(MidiSysexMessage msg, size_t &length);
 
 #endif /* MUSIC_MIDI_H */

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -30,12 +30,12 @@ static MidiFile *_midifile_instance = nullptr;
  * @param[out] length Receives the length of the returned buffer
  * @return Pointer to byte buffer with sysex message
  */
-const byte *MidiGetStandardSysexMessage(MidiSysexMessage msg, size_t &length)
+const uint8_t *MidiGetStandardSysexMessage(MidiSysexMessage msg, size_t &length)
 {
-	static byte reset_gm_sysex[] = { 0xF0, 0x7E, 0x7F, 0x09, 0x01, 0xF7 };
-	static byte reset_gs_sysex[] = { 0xF0, 0x41, 0x10, 0x42, 0x12, 0x40, 0x00, 0x7F, 0x00, 0x41, 0xF7 };
-	static byte reset_xg_sysex[] = { 0xF0, 0x43, 0x10, 0x4C, 0x00, 0x00, 0x7E, 0x00, 0xF7 };
-	static byte roland_reverb_sysex[] = { 0xF0, 0x41, 0x10, 0x42, 0x12, 0x40, 0x01, 0x30, 0x02, 0x04, 0x00, 0x40, 0x40, 0x00, 0x00, 0x09, 0xF7 };
+	static uint8_t reset_gm_sysex[] = { 0xF0, 0x7E, 0x7F, 0x09, 0x01, 0xF7 };
+	static uint8_t reset_gs_sysex[] = { 0xF0, 0x41, 0x10, 0x42, 0x12, 0x40, 0x00, 0x7F, 0x00, 0x41, 0xF7 };
+	static uint8_t reset_xg_sysex[] = { 0xF0, 0x43, 0x10, 0x4C, 0x00, 0x00, 0x7E, 0x00, 0xF7 };
+	static uint8_t roland_reverb_sysex[] = { 0xF0, 0x41, 0x10, 0x42, 0x12, 0x40, 0x01, 0x30, 0x02, 0x04, 0x00, 0x40, 0x40, 0x00, 0x00, 0x09, 0xF7 };
 
 	switch (msg) {
 		case MidiSysexMessage::ResetGM:
@@ -60,7 +60,7 @@ const byte *MidiGetStandardSysexMessage(MidiSysexMessage msg, size_t &length)
  * RAII-compliant to make teardown in error situations easier.
  */
 class ByteBuffer {
-	std::vector<byte> buf;
+	std::vector<uint8_t> buf;
 	size_t pos;
 public:
 	/**
@@ -104,7 +104,7 @@ public:
 	 * @param[out] b returns the read value
 	 * @return true if a byte was available for reading
 	 */
-	bool ReadByte(byte &b)
+	bool ReadByte(uint8_t &b)
 	{
 		if (this->IsEnd()) return false;
 		b = this->buf[this->pos++];
@@ -121,7 +121,7 @@ public:
 	bool ReadVariableLength(uint32_t &res)
 	{
 		res = 0;
-		byte b = 0;
+		uint8_t b = 0;
 		do {
 			if (this->IsEnd()) return false;
 			b = this->buf[this->pos++];
@@ -136,7 +136,7 @@ public:
 	 * @param length number of bytes to read
 	 * @return true if the requested number of bytes were available
 	 */
-	bool ReadBuffer(byte *dest, size_t length)
+	bool ReadBuffer(uint8_t *dest, size_t length)
 	{
 		if (this->IsEnd()) return false;
 		if (this->buf.size() - this->pos < length) return false;
@@ -188,9 +188,9 @@ public:
 
 static bool ReadTrackChunk(FILE *file, MidiFile &target)
 {
-	byte buf[4];
+	uint8_t buf[4];
 
-	const byte magic[] = { 'M', 'T', 'r', 'k' };
+	const uint8_t magic[] = { 'M', 'T', 'r', 'k' };
 	if (fread(buf, sizeof(magic), 1, file) != 1) {
 		return false;
 	}
@@ -213,7 +213,7 @@ static bool ReadTrackChunk(FILE *file, MidiFile &target)
 	target.blocks.push_back(MidiFile::DataBlock());
 	MidiFile::DataBlock *block = &target.blocks.back();
 
-	byte last_status = 0;
+	uint8_t last_status = 0;
 	bool running_sysex = false;
 	while (!chunk.IsEnd()) {
 		/* Read deltatime for event, start new block */
@@ -227,7 +227,7 @@ static bool ReadTrackChunk(FILE *file, MidiFile &target)
 		}
 
 		/* Read status byte */
-		byte status;
+		uint8_t status;
 		if (!chunk.ReadByte(status)) {
 			return false;
 		}
@@ -422,13 +422,13 @@ bool MidiFile::ReadSMFHeader(const std::string &filename, SMFHeader &header)
 bool MidiFile::ReadSMFHeader(FILE *file, SMFHeader &header)
 {
 	/* Try to read header, fixed size */
-	byte buffer[14];
+	uint8_t buffer[14];
 	if (fread(buffer, sizeof(buffer), 1, file) != 1) {
 		return false;
 	}
 
 	/* Check magic, 'MThd' followed by 4 byte length indicator (always = 6 in SMF) */
-	const byte magic[] = { 'M', 'T', 'h', 'd', 0x00, 0x00, 0x00, 0x06 };
+	const uint8_t magic[] = { 'M', 'T', 'h', 'd', 0x00, 0x00, 0x00, 0x06 };
 	if (MemCmpT(buffer, magic, sizeof(magic)) != 0) {
 		return false;
 	}
@@ -505,8 +505,8 @@ cleanup:
 struct MpsMachine {
 	/** Starting parameter and playback status for one channel/track */
 	struct Channel {
-		byte cur_program;    ///< program selected, used for velocity scaling (lookup into programvelocities array)
-		byte running_status; ///< last midi status code seen
+		uint8_t cur_program;    ///< program selected, used for velocity scaling (lookup into programvelocities array)
+		uint8_t running_status; ///< last midi status code seen
 		uint16_t delay;        ///< frames until next command
 		uint32_t playpos;      ///< next byte to play this channel from
 		uint32_t startpos;     ///< start position of master track
@@ -521,9 +521,9 @@ struct MpsMachine {
 	bool shouldplayflag;          ///< not-end-of-song flag
 
 	static const int TEMPO_RATE;
-	static const byte programvelocities[128];
+	static const uint8_t programvelocities[128];
 
-	const byte *songdata; ///< raw data array
+	const uint8_t *songdata; ///< raw data array
 	size_t songdatalen;   ///< length of song data
 	MidiFile &target;     ///< recipient of data
 
@@ -534,12 +534,12 @@ struct MpsMachine {
 		MPSMIDIST_ENDSONG        = 0xFF, ///< immediately end the song
 	};
 
-	static void AddMidiData(MidiFile::DataBlock &block, byte b1, byte b2)
+	static void AddMidiData(MidiFile::DataBlock &block, uint8_t b1, uint8_t b2)
 	{
 		block.data.push_back(b1);
 		block.data.push_back(b2);
 	}
-	static void AddMidiData(MidiFile::DataBlock &block, byte b1, byte b2, byte b3)
+	static void AddMidiData(MidiFile::DataBlock &block, uint8_t b1, uint8_t b2, uint8_t b3)
 	{
 		block.data.push_back(b1);
 		block.data.push_back(b2);
@@ -552,7 +552,7 @@ struct MpsMachine {
 	 * @param length Length of the data buffer in bytes
 	 * @param target MidiFile object to add decoded data to
 	 */
-	MpsMachine(const byte *data, size_t length, MidiFile &target)
+	MpsMachine(const uint8_t *data, size_t length, MidiFile &target)
 		: songdata(data), songdatalen(length), target(target)
 	{
 		uint32_t pos = 0;
@@ -580,7 +580,7 @@ struct MpsMachine {
 			/* Similar structure to segments list, but also has
 			 * the MIDI channel number as a byte before the offset
 			 * to next track. */
-			byte ch = this->songdata[pos++];
+			uint8_t ch = this->songdata[pos++];
 			this->channels[ch].startpos = pos + 4;
 			pos += FROM_LE16(*(const int16_t *)(this->songdata + pos));
 		}
@@ -593,7 +593,7 @@ struct MpsMachine {
 	 */
 	uint16_t ReadVariableLength(uint32_t &pos)
 	{
-		byte b = 0;
+		uint8_t b = 0;
 		uint16_t res = 0;
 		do {
 			b = this->songdata[pos++];
@@ -627,7 +627,7 @@ struct MpsMachine {
 	uint16_t PlayChannelFrame(MidiFile::DataBlock &outblock, int channel)
 	{
 		uint16_t newdelay = 0;
-		byte b1, b2;
+		uint8_t b1, b2;
 		Channel &chandata = this->channels[channel];
 
 		do {
@@ -811,7 +811,7 @@ struct MpsMachine {
 /** Frames/ticks per second for music playback */
 const int MpsMachine::TEMPO_RATE = 148;
 /** Base note velocities for various GM programs */
-const byte MpsMachine::programvelocities[128] = {
+const uint8_t MpsMachine::programvelocities[128] = {
 	100, 100, 100, 100, 100,  90, 100, 100, 100, 100, 100,  90, 100, 100, 100, 100,
 	100, 100,  85, 100, 100, 100, 100, 100, 100, 100, 100, 100,  90,  90, 110,  80,
 	100, 100, 100,  90,  70, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100,
@@ -828,7 +828,7 @@ const byte MpsMachine::programvelocities[128] = {
  * @param length size of data in bytes
  * @return true if the data could be loaded
  */
-bool MidiFile::LoadMpsData(const byte *data, size_t length)
+bool MidiFile::LoadMpsData(const uint8_t *data, size_t length)
 {
 	_midifile_instance = this;
 
@@ -844,7 +844,7 @@ bool MidiFile::LoadSong(const MusicSongInfo &song)
 		case MTT_MPSMIDI:
 		{
 			size_t songdatalen = 0;
-			byte *songdata = GetMusicCatEntryData(song.filename, song.cat_index, songdatalen);
+			uint8_t *songdata = GetMusicCatEntryData(song.filename, song.cat_index, songdatalen);
 			if (songdata != nullptr) {
 				bool result = this->LoadMpsData(songdata, songdatalen);
 				free(songdata);
@@ -878,21 +878,21 @@ void MidiFile::MoveFrom(MidiFile &other)
 static void WriteVariableLen(FILE *f, uint32_t value)
 {
 	if (value <= 0x7F) {
-		byte tb = value;
+		uint8_t tb = value;
 		fwrite(&tb, 1, 1, f);
 	} else if (value <= 0x3FFF) {
-		byte tb[2];
+		uint8_t tb[2];
 		tb[1] =  value & 0x7F;         value >>= 7;
 		tb[0] = (value & 0x7F) | 0x80; value >>= 7;
 		fwrite(tb, 1, sizeof(tb), f);
 	} else if (value <= 0x1FFFFF) {
-		byte tb[3];
+		uint8_t tb[3];
 		tb[2] =  value & 0x7F;         value >>= 7;
 		tb[1] = (value & 0x7F) | 0x80; value >>= 7;
 		tb[0] = (value & 0x7F) | 0x80; value >>= 7;
 		fwrite(tb, 1, sizeof(tb), f);
 	} else if (value <= 0x0FFFFFFF) {
-		byte tb[4];
+		uint8_t tb[4];
 		tb[3] =  value & 0x7F;         value >>= 7;
 		tb[2] = (value & 0x7F) | 0x80; value >>= 7;
 		tb[1] = (value & 0x7F) | 0x80; value >>= 7;
@@ -914,17 +914,17 @@ bool MidiFile::WriteSMF(const std::string &filename)
 	}
 
 	/* SMF header */
-	const byte fileheader[] = {
+	const uint8_t fileheader[] = {
 		'M', 'T', 'h', 'd',     // block name
 		0x00, 0x00, 0x00, 0x06, // BE32 block length, always 6 bytes
 		0x00, 0x00,             // writing format 0 (all in one track)
 		0x00, 0x01,             // containing 1 track (BE16)
-		(byte)(this->tickdiv >> 8), (byte)this->tickdiv, // tickdiv in BE16
+		(uint8_t)(this->tickdiv >> 8), (uint8_t)this->tickdiv, // tickdiv in BE16
 	};
 	fwrite(fileheader, sizeof(fileheader), 1, f);
 
 	/* Track header */
-	const byte trackheader[] = {
+	const uint8_t trackheader[] = {
 		'M', 'T', 'r', 'k', // block name
 		0, 0, 0, 0,         // BE32 block length, unknown at this time
 	};
@@ -953,7 +953,7 @@ bool MidiFile::WriteSMF(const std::string &filename)
 
 		/* Write tempo change if there is one */
 		if (nexttempo.ticktime <= block.ticktime) {
-			byte tempobuf[6] = { MIDIST_SMF_META, 0x51, 0x03, 0, 0, 0 };
+			uint8_t tempobuf[6] = { MIDIST_SMF_META, 0x51, 0x03, 0, 0, 0 };
 			tempobuf[3] = (nexttempo.tempo & 0x00FF0000) >> 16;
 			tempobuf[4] = (nexttempo.tempo & 0x0000FF00) >>  8;
 			tempobuf[5] = (nexttempo.tempo & 0x000000FF);
@@ -970,7 +970,7 @@ bool MidiFile::WriteSMF(const std::string &filename)
 		}
 
 		/* Write each block data command */
-		byte *dp = block.data.data();
+		uint8_t *dp = block.data.data();
 		while (dp < block.data.data() + block.data.size()) {
 			/* Always zero delta time inside blocks */
 			if (needtime) {
@@ -999,7 +999,7 @@ bool MidiFile::WriteSMF(const std::string &filename)
 			if (*dp == MIDIST_SYSEX) {
 				fwrite(dp, 1, 1, f);
 				dp++;
-				byte *sysexend = dp;
+				uint8_t *sysexend = dp;
 				while (*sysexend != MIDIST_ENDSYSEX) sysexend++;
 				ptrdiff_t sysexlen = sysexend - dp;
 				WriteVariableLen(f, sysexlen);
@@ -1015,7 +1015,7 @@ bool MidiFile::WriteSMF(const std::string &filename)
 	}
 
 	/* End of track marker */
-	static const byte track_end_marker[] = { 0x00, MIDIST_SMF_META, 0x2F, 0x00 };
+	static const uint8_t track_end_marker[] = { 0x00, MIDIST_SMF_META, 0x2F, 0x00 };
 	fwrite(&track_end_marker, sizeof(track_end_marker), 1, f);
 
 	/* Fill out the RIFF block length */
@@ -1078,7 +1078,7 @@ std::string MidiFile::GetSMFFile(const MusicSongInfo &song)
 		return output_filename;
 	}
 
-	byte *data;
+	uint8_t *data;
 	size_t datalen;
 	data = GetMusicCatEntryData(song.filename, song.cat_index, datalen);
 	if (data == nullptr) return std::string();
@@ -1098,7 +1098,7 @@ std::string MidiFile::GetSMFFile(const MusicSongInfo &song)
 }
 
 
-static bool CmdDumpSMF(byte argc, char *argv[])
+static bool CmdDumpSMF(uint8_t argc, char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Write the current song to a Standard MIDI File. Usage: 'dumpsmf <filename>'.");

--- a/src/music/midifile.hpp
+++ b/src/music/midifile.hpp
@@ -19,7 +19,7 @@ struct MidiFile {
 	struct DataBlock {
 		uint32_t ticktime; ///< tick number since start of file this block should be triggered at
 		uint32_t realtime = 0; ///< real-time (microseconds) since start of file this block should be triggered at
-		std::vector<byte> data; ///< raw midi data contained in block
+		std::vector<uint8_t> data; ///< raw midi data contained in block
 		DataBlock(uint32_t _ticktime = 0) : ticktime(_ticktime) { }
 	};
 	struct TempoChange {
@@ -36,7 +36,7 @@ struct MidiFile {
 	~MidiFile();
 
 	bool LoadFile(const std::string &filename);
-	bool LoadMpsData(const byte *data, size_t length);
+	bool LoadMpsData(const uint8_t *data, size_t length);
 	bool LoadSong(const MusicSongInfo &song);
 	void MoveFrom(MidiFile &other);
 

--- a/src/music/music_driver.hpp
+++ b/src/music/music_driver.hpp
@@ -38,7 +38,7 @@ public:
 	 * Set the volume, if possible.
 	 * @param vol The new volume.
 	 */
-	virtual void SetVolume(byte vol) = 0;
+	virtual void SetVolume(uint8_t vol) = 0;
 
 	/**
 	 * Get the currently active instance of the music driver.

--- a/src/music/null_m.h
+++ b/src/music/null_m.h
@@ -25,7 +25,7 @@ public:
 
 	bool IsSongPlaying() override { return true; }
 
-	void SetVolume(byte) override { }
+	void SetVolume(uint8_t) override { }
 	const char *GetName() const override { return "null"; }
 };
 

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -37,8 +37,8 @@ static struct {
 	bool playing;        ///< flag indicating that playback is active
 	int do_start;        ///< flag for starting playback of next_file at next opportunity
 	bool do_stop;        ///< flag for stopping playback at next opportunity
-	byte current_volume; ///< current effective volume setting
-	byte new_volume;     ///< volume setting to change to
+	uint8_t current_volume; ///< current effective volume setting
+	uint8_t new_volume;     ///< volume setting to change to
 
 	MidiFile current_file;           ///< file currently being played from
 	PlaybackSegment current_segment; ///< segment info for current playback
@@ -47,13 +47,13 @@ static struct {
 	MidiFile next_file;              ///< upcoming file to play
 	PlaybackSegment next_segment;    ///< segment info for upcoming file
 
-	byte channel_volumes[16]; ///< last seen volume controller values in raw data
+	uint8_t channel_volumes[16]; ///< last seen volume controller values in raw data
 } _midi;
 
 static FMusicDriver_Win32 iFMusicDriver_Win32;
 
 
-static byte ScaleVolume(byte original, byte scale)
+static uint8_t ScaleVolume(uint8_t original, uint8_t scale)
 {
 	return original * scale / 127;
 }
@@ -68,21 +68,21 @@ void CALLBACK MidiOutProc(HMIDIOUT hmo, UINT wMsg, DWORD_PTR, DWORD_PTR dwParam1
 	}
 }
 
-static void TransmitChannelMsg(byte status, byte p1, byte p2 = 0)
+static void TransmitChannelMsg(uint8_t status, uint8_t p1, uint8_t p2 = 0)
 {
 	midiOutShortMsg(_midi.midi_out, status | (p1 << 8) | (p2 << 16));
 }
 
-static void TransmitSysex(const byte *&msg_start, size_t &remaining)
+static void TransmitSysex(const uint8_t *&msg_start, size_t &remaining)
 {
 	/* find end of message */
-	const byte *msg_end = msg_start;
+	const uint8_t *msg_end = msg_start;
 	while (*msg_end != MIDIST_ENDSYSEX) msg_end++;
 	msg_end++; /* also include sysex end byte */
 
 	/* prepare header */
 	MIDIHDR *hdr = CallocT<MIDIHDR>(1);
-	hdr->lpData = reinterpret_cast<LPSTR>(const_cast<byte *>(msg_start));
+	hdr->lpData = reinterpret_cast<LPSTR>(const_cast<uint8_t *>(msg_start));
 	hdr->dwBufferLength = msg_end - msg_start;
 	if (midiOutPrepareHeader(_midi.midi_out, hdr, sizeof(*hdr)) == MMSYSERR_NOERROR) {
 		/* transmit - just point directly into the data buffer */
@@ -100,7 +100,7 @@ static void TransmitSysex(const byte *&msg_start, size_t &remaining)
 static void TransmitStandardSysex(MidiSysexMessage msg)
 {
 	size_t length = 0;
-	const byte *data = MidiGetStandardSysexMessage(msg, length);
+	const uint8_t *data = MidiGetStandardSysexMessage(msg, length);
 	TransmitSysex(data, length);
 }
 
@@ -164,7 +164,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR
 			_midi.do_start = 0;
 			_midi.current_block = 0;
 
-			MemSetT<byte>(_midi.channel_volumes, 127, lengthof(_midi.channel_volumes));
+			MemSetT<uint8_t>(_midi.channel_volumes, 127, lengthof(_midi.channel_volumes));
 			/* Invalidate current volume. */
 			_midi.current_volume = UINT8_MAX;
 			volume_throttle = 0;
@@ -184,7 +184,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR
 			_midi.current_volume = _midi.new_volume;
 			volume_throttle = 20 / _midi.time_period;
 			for (int ch = 0; ch < 16; ch++) {
-				byte vol = ScaleVolume(_midi.channel_volumes[ch], _midi.current_volume);
+				uint8_t vol = ScaleVolume(_midi.channel_volumes[ch], _midi.current_volume);
 				TransmitChannelMsg(MIDIST_CONTROLLER | ch, MIDICT_CHANVOLUME, vol);
 			}
 		} else {
@@ -242,13 +242,13 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR
 			break;
 		}
 
-		const byte *data = block.data.data();
+		const uint8_t *data = block.data.data();
 		size_t remaining = block.data.size();
-		byte last_status = 0;
+		uint8_t last_status = 0;
 		while (remaining > 0) {
 			/* MidiFile ought to have converted everything out of running status,
 			 * but handle it anyway just to be safe */
-			byte status = data[0];
+			uint8_t status = data[0];
 			if (status & 0x80) {
 				last_status = status;
 				data++;
@@ -361,7 +361,7 @@ bool MusicDriver_Win32::IsSongPlaying()
 	return _midi.playing || (_midi.do_start != 0);
 }
 
-void MusicDriver_Win32::SetVolume(byte vol)
+void MusicDriver_Win32::SetVolume(uint8_t vol)
 {
 	std::lock_guard<std::mutex> mutex_lock(_midi.lock);
 	_midi.new_volume = vol;

--- a/src/music/win32_m.h
+++ b/src/music/win32_m.h
@@ -25,7 +25,7 @@ public:
 
 	bool IsSongPlaying() override;
 
-	void SetVolume(byte vol) override;
+	void SetVolume(uint8_t vol) override;
 	const char *GetName() const override { return "win32"; }
 };
 

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -428,7 +428,7 @@ void MusicSystem::ChangePlaylistPosition(int ofs)
  */
 void MusicSystem::SaveCustomPlaylist(PlaylistChoices pl)
 {
-	byte *settings_pl;
+	uint8_t *settings_pl;
 	if (pl == PLCH_CUSTOM1) {
 		settings_pl = _settings_client.music.custom_1;
 	} else if (pl == PLCH_CUSTOM2) {
@@ -442,7 +442,7 @@ void MusicSystem::SaveCustomPlaylist(PlaylistChoices pl)
 
 	for (const auto &song : this->standard_playlists[pl]) {
 		/* Music set indices in the settings playlist are 1-based, 0 means unused slot */
-		settings_pl[num++] = (byte)song.set_index + 1;
+		settings_pl[num++] = (uint8_t)song.set_index + 1;
 	}
 }
 
@@ -825,7 +825,7 @@ struct MusicWindow : public Window {
 				break;
 
 			case WID_M_MUSIC_VOL: case WID_M_EFFECT_VOL: { // volume sliders
-				byte &vol = (widget == WID_M_MUSIC_VOL) ? _settings_client.music.music_vol : _settings_client.music.effect_vol;
+				uint8_t &vol = (widget == WID_M_MUSIC_VOL) ? _settings_client.music.music_vol : _settings_client.music.effect_vol;
 				if (ClickSliderWidget(this->GetWidget<NWidgetBase>(widget)->GetCurrentRect(), pt, 0, INT8_MAX, vol)) {
 					if (widget == WID_M_MUSIC_VOL) {
 						MusicDriver::GetInstance()->SetVolume(vol);

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -45,10 +45,10 @@ static const std::string NETWORK_SURVEY_DETAILS_LINK = "https://survey.openttd.o
 static const size_t TCP_MTU = 32767; ///< Number of bytes we can pack in a single TCP packet
 static const size_t COMPAT_MTU = 1460; ///< Number of bytes we can pack in a single packet for backward compatibility
 
-static const byte NETWORK_GAME_ADMIN_VERSION        =    3;           ///< What version of the admin network do we use?
-static const byte NETWORK_GAME_INFO_VERSION         =    7;           ///< What version of game-info do we use?
-static const byte NETWORK_COORDINATOR_VERSION       =    6;           ///< What version of game-coordinator-protocol do we use?
-static const byte NETWORK_SURVEY_VERSION            =    2;           ///< What version of the survey do we use?
+static const uint8_t NETWORK_GAME_ADMIN_VERSION        =    3;           ///< What version of the admin network do we use?
+static const uint8_t NETWORK_GAME_INFO_VERSION         =    7;           ///< What version of game-info do we use?
+static const uint8_t NETWORK_COORDINATOR_VERSION       =    6;           ///< What version of game-coordinator-protocol do we use?
+static const uint8_t NETWORK_SURVEY_VERSION            =    2;           ///< What version of the survey do we use?
 
 static const uint NETWORK_NAME_LENGTH               =   80;           ///< The maximum length of the server name and map name, in bytes including '\0'
 static const uint NETWORK_COMPANY_NAME_LENGTH       =  128;           ///< The maximum length of the company name, in bytes including '\0'

--- a/src/network/core/network_game_info.cpp
+++ b/src/network/core/network_game_info.cpp
@@ -148,7 +148,7 @@ const NetworkServerGameInfo &GetCurrentNetworkServerGameInfo()
 	 *  - invite_code
 	 * These don't need to be updated manually here.
 	 */
-	_network_game_info.companies_on  = (byte)Company::GetNumItems();
+	_network_game_info.companies_on  = (uint8_t)Company::GetNumItems();
 	_network_game_info.spectators_on = NetworkSpectatorCount();
 	_network_game_info.calendar_date = TimerGameCalendar::date;
 	_network_game_info.ticks_playing = TimerGameTick::counter;
@@ -260,7 +260,7 @@ void SerializeNetworkGameInfo(Packet &p, const NetworkServerGameInfo &info, bool
  */
 void DeserializeNetworkGameInfo(Packet &p, NetworkGameInfo &info, const GameInfoNewGRFLookupTable *newgrf_lookup_table)
 {
-	byte game_info_version = p.Recv_uint8();
+	uint8_t game_info_version = p.Recv_uint8();
 	NewGRFSerializationType newgrf_serialisation = NST_GRFID_MD5;
 
 	/*

--- a/src/network/core/network_game_info.h
+++ b/src/network/core/network_game_info.h
@@ -104,12 +104,12 @@ struct NetworkServerGameInfo {
 	std::string server_revision; ///< The version number the server is using (e.g.: 'r304' or 0.5.0)
 	bool dedicated;              ///< Is this a dedicated server?
 	bool use_password;           ///< Is this server passworded?
-	byte clients_on;             ///< Current count of clients on server
-	byte clients_max;            ///< Max clients allowed on server
-	byte companies_on;           ///< How many started companies do we have
-	byte companies_max;          ///< Max companies allowed on server
-	byte spectators_on;          ///< How many spectators do we have?
-	byte landscape;              ///< The used landscape
+	uint8_t clients_on;             ///< Current count of clients on server
+	uint8_t clients_max;            ///< Max clients allowed on server
+	uint8_t companies_on;           ///< How many started companies do we have
+	uint8_t companies_max;          ///< Max companies allowed on server
+	uint8_t spectators_on;          ///< How many spectators do we have?
+	uint8_t landscape;              ///< The used landscape
 	int gamescript_version;      ///< Version of the gamescript.
 	std::string gamescript_name; ///< Name of the gamescript.
 };

--- a/src/network/core/packet.cpp
+++ b/src/network/core/packet.cpp
@@ -166,7 +166,7 @@ void Packet::Send_string(const std::string_view data)
  * Copy a sized byte buffer into the packet.
  * @param data The data to send.
  */
-void Packet::Send_buffer(const std::vector<byte> &data)
+void Packet::Send_buffer(const std::vector<uint8_t> &data)
 {
 	assert(this->CanWriteToPacket(sizeof(uint16_t) + data.size()));
 	this->Send_uint16((uint16_t)data.size());
@@ -180,7 +180,7 @@ void Packet::Send_buffer(const std::vector<byte> &data)
  * @param span The span describing the range of bytes to send.
  * @return The span of bytes that were not written.
  */
-std::span<const byte> Packet::Send_bytes(const std::span<const byte> span)
+std::span<const uint8_t> Packet::Send_bytes(const std::span<const uint8_t> span)
 {
 	size_t amount = std::min<size_t>(span.size(), this->limit - this->Size());
 	this->buffer.insert(this->buffer.end(), span.data(), span.data() + amount);
@@ -356,12 +356,12 @@ uint64_t Packet::Recv_uint64()
  * Extract a sized byte buffer from the packet.
  * @return The extracted buffer.
  */
-std::vector<byte> Packet::Recv_buffer()
+std::vector<uint8_t> Packet::Recv_buffer()
 {
 	uint16_t size = this->Recv_uint16();
 	if (size == 0 || !this->CanReadFromPacket(size, true)) return {};
 
-	std::vector<byte> data;
+	std::vector<uint8_t> data;
 	while (size-- > 0) {
 		data.push_back(this->buffer[this->pos++]);
 	}
@@ -374,9 +374,9 @@ std::vector<byte> Packet::Recv_buffer()
  * @param span The span to write the bytes to.
  * @return The number of bytes that were actually read.
  */
-size_t Packet::Recv_bytes(std::span<byte> span)
+size_t Packet::Recv_bytes(std::span<uint8_t> span)
 {
-	auto tranfer_to_span = [](std::span<byte> destination, const char *source, size_t amount) {
+	auto tranfer_to_span = [](std::span<uint8_t> destination, const char *source, size_t amount) {
 		size_t to_copy = std::min(amount, destination.size());
 		std::copy(source, source + to_copy, destination.data());
 		return to_copy;

--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -44,7 +44,7 @@ private:
 	/** The current read/write position in the packet */
 	PacketSize pos;
 	/** The buffer of this packet. */
-	std::vector<byte> buffer;
+	std::vector<uint8_t> buffer;
 	/** The limit for the packet size. */
 	size_t limit;
 
@@ -65,8 +65,8 @@ public:
 	void   Send_uint32(uint32_t data);
 	void   Send_uint64(uint64_t data);
 	void   Send_string(const std::string_view data);
-	void   Send_buffer(const std::vector<byte> &data);
-	std::span<const byte> Send_bytes(const std::span<const byte> span);
+	void   Send_buffer(const std::vector<uint8_t> &data);
+	std::span<const uint8_t> Send_bytes(const std::span<const uint8_t> span);
 
 	/* Reading/receiving of packets */
 	bool HasPacketSizeData() const;
@@ -81,8 +81,8 @@ public:
 	uint16_t Recv_uint16();
 	uint32_t Recv_uint32();
 	uint64_t Recv_uint64();
-	std::vector<byte> Recv_buffer();
-	size_t Recv_bytes(std::span<byte> span);
+	std::vector<uint8_t> Recv_buffer();
+	size_t Recv_bytes(std::span<uint8_t> span);
 	std::string Recv_string(size_t length, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 
 	size_t RemainingBytesToTransfer() const;

--- a/src/network/core/tcp_content.h
+++ b/src/network/core/tcp_content.h
@@ -25,7 +25,7 @@ protected:
 
 	/**
 	 * Client requesting a list of content info:
-	 *  byte    type
+	 *  uint8_t    type
 	 *  uint32_t  openttd version (or 0xFFFFFFFF if using a list)
 	 * Only if the above value is 0xFFFFFFFF:
 	 *  uint8_t   count
@@ -76,7 +76,7 @@ protected:
 
 	/**
 	 * Server sending list of content info:
-	 *  byte    type (invalid ID == does not exist)
+	 *  uint8_t    type (invalid ID == does not exist)
 	 *  uint32_t  id
 	 *  uint32_t  file_size
 	 *  string  name (max 32 characters)

--- a/src/network/core/tcp_coordinator.h
+++ b/src/network/core/tcp_coordinator.h
@@ -277,7 +277,7 @@ protected:
 	 *  uint16_t   Number of NewGRFs in the packet, with for each of the NewGRFs:
 	 *      uint32_t   Lookup table index for the NewGRF.
 	 *      uint32_t   Unique NewGRF ID.
-	 *      byte[16] MD5 checksum of the NewGRF
+	 *      uint8_t[16] MD5 checksum of the NewGRF
 	 *      string   Name of the NewGRF.
 	 *
 	 * The lookup table built using these packets are used by the deserialisation

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -84,7 +84,7 @@ CompanyMask _network_company_passworded; ///< Bitmask of the password status of 
 static_assert((int)NETWORK_COMPANY_NAME_LENGTH == MAX_LENGTH_COMPANY_NAME_CHARS * MAX_CHAR_LENGTH);
 
 /** The amount of clients connected */
-byte _network_clients_connected = 0;
+uint8_t _network_clients_connected = 0;
 
 extern std::string GenerateUid(std::string_view subject);
 
@@ -134,9 +134,9 @@ NetworkClientInfo::~NetworkClientInfo()
 	return nullptr;
 }
 
-byte NetworkSpectatorCount()
+uint8_t NetworkSpectatorCount()
 {
-	byte count = 0;
+	uint8_t count = 0;
 
 	for (const NetworkClientInfo *ci : NetworkClientInfo::Iterate()) {
 		if (ci->client_playas == COMPANY_SPECTATOR) count++;
@@ -1130,10 +1130,10 @@ void NetworkGameLoop()
 				cp->cmd = (Commands)cmd;
 
 				/* Parse command data. */
-				std::vector<byte> args;
+				std::vector<uint8_t> args;
 				size_t arg_len = strlen(buffer);
 				for (size_t i = 0; i + 1 < arg_len; i += 2) {
-					byte e = 0;
+					uint8_t e = 0;
 					std::from_chars(buffer + i, buffer + i + 2, e, 16);
 					args.emplace_back(e);
 				}

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -32,7 +32,7 @@
 AdminIndex _redirect_console_to_admin = INVALID_ADMIN_ID;
 
 /** The amount of admins connected. */
-byte _network_admins_connected = 0;
+uint8_t _network_admins_connected = 0;
 
 /** The pool with sockets/clients. */
 NetworkAdminSocketPool _networkadminsocket_pool("NetworkAdminSocket");

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -43,10 +43,10 @@
 struct PacketReader : LoadFilter {
 	static const size_t CHUNK = 32 * 1024;  ///< 32 KiB chunks of memory.
 
-	std::vector<byte *> blocks;             ///< Buffer with blocks of allocated memory.
-	byte *buf;                              ///< Buffer we're going to write to/read from.
-	byte *bufe;                             ///< End of the buffer we write to/read from.
-	byte **block;                           ///< The block we're reading from/writing to.
+	std::vector<uint8_t *> blocks;             ///< Buffer with blocks of allocated memory.
+	uint8_t *buf;                              ///< Buffer we're going to write to/read from.
+	uint8_t *bufe;                             ///< End of the buffer we write to/read from.
+	uint8_t **block;                           ///< The block we're reading from/writing to.
 	size_t written_bytes;                   ///< The total number of bytes we've written.
 	size_t read_bytes;                      ///< The total number of read bytes.
 
@@ -90,18 +90,18 @@ struct PacketReader : LoadFilter {
 		if (p.RemainingBytesToTransfer() == 0) return;
 
 		/* Allocate a new chunk and add the remaining data. */
-		this->blocks.push_back(this->buf = CallocT<byte>(CHUNK));
+		this->blocks.push_back(this->buf = CallocT<uint8_t>(CHUNK));
 		this->bufe = this->buf + CHUNK;
 
 		p.TransferOutWithLimit(TransferOutMemCopy, this->bufe - this->buf, this);
 	}
 
-	size_t Read(byte *rbuf, size_t size) override
+	size_t Read(uint8_t *rbuf, size_t size) override
 	{
 		/* Limit the amount to read to whatever we still have. */
 		size_t ret_size = size = std::min(this->written_bytes - this->read_bytes, size);
 		this->read_bytes += ret_size;
-		const byte *rbufe = rbuf + ret_size;
+		const uint8_t *rbufe = rbuf + ret_size;
 
 		while (rbuf != rbufe) {
 			if (this->buf == this->bufe) {

--- a/src/network/network_client.h
+++ b/src/network/network_client.h
@@ -17,7 +17,7 @@ class ClientNetworkGameSocketHandler : public ZeroedMemoryAllocator, public Netw
 private:
 	std::string connection_string; ///< Address we are connected to.
 	std::shared_ptr<struct PacketReader> savegame; ///< Packet reader for reading the savegame.
-	byte token;                    ///< The token we need to send back to the server to prove we're the right client.
+	uint8_t token;                    ///< The token we need to send back to the server to prove we're the right client.
 
 	/** Status of the connection with the server. */
 	enum ServerStatus {

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -369,7 +369,7 @@ const char *NetworkGameSocketHandler::ReceiveCommand(Packet &p, CommandPacket &c
 	cp.err_msg = p.Recv_uint16();
 	cp.data    = _cmd_dispatch[cp.cmd].Sanitize(p.Recv_buffer());
 
-	byte callback = p.Recv_uint8();
+	uint8_t callback = p.Recv_uint8();
 	if (callback >= _callback_table.size() || _cmd_dispatch[cp.cmd].Unpack[callback] == nullptr)  return "invalid callback";
 
 	cp.callback = _callback_table[callback];

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -205,7 +205,7 @@ void ClientNetworkContentSocketHandler::RequestContentList(ContentType type)
 	this->Connect();
 
 	auto p = std::make_unique<Packet>(this, PACKET_CONTENT_CLIENT_INFO_LIST);
-	p->Send_uint8 ((byte)type);
+	p->Send_uint8 ((uint8_t)type);
 	p->Send_uint32(0xffffffff);
 	p->Send_uint8 (1);
 	p->Send_string("vanilla");
@@ -238,7 +238,7 @@ void ClientNetworkContentSocketHandler::RequestContentList(uint count, const Con
 		 * A packet begins with the packet size and a byte for the type.
 		 * Then this packet adds a uint16_t for the count in this packet.
 		 * The rest of the packet can be used for the IDs. */
-		uint p_count = std::min<uint>(count, (TCP_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint16_t)) / sizeof(uint32_t));
+		uint p_count = std::min<uint>(count, (TCP_MTU - sizeof(PacketSize) - sizeof(uint8_t) - sizeof(uint16_t)) / sizeof(uint32_t));
 
 		auto p = std::make_unique<Packet>(this, PACKET_CONTENT_CLIENT_INFO_ID, TCP_MTU);
 		p->Send_uint16(p_count);
@@ -265,14 +265,14 @@ void ClientNetworkContentSocketHandler::RequestContentList(ContentVector *cv, bo
 	this->Connect();
 
 	assert(cv->size() < 255);
-	assert(cv->size() < (TCP_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint8_t)) /
+	assert(cv->size() < (TCP_MTU - sizeof(PacketSize) - sizeof(uint8_t) - sizeof(uint8_t)) /
 			(sizeof(uint8_t) + sizeof(uint32_t) + (send_md5sum ? MD5_HASH_BYTES : 0)));
 
 	auto p = std::make_unique<Packet>(this, send_md5sum ? PACKET_CONTENT_CLIENT_INFO_EXTID_MD5 : PACKET_CONTENT_CLIENT_INFO_EXTID, TCP_MTU);
 	p->Send_uint8((uint8_t)cv->size());
 
 	for (const ContentInfo *ci : *cv) {
-		p->Send_uint8((byte)ci->type);
+		p->Send_uint8((uint8_t)ci->type);
 		p->Send_uint32(ci->unique_id);
 		if (!send_md5sum) continue;
 
@@ -363,7 +363,7 @@ void ClientNetworkContentSocketHandler::DownloadSelectedContentFallback(const Co
 		 * A packet begins with the packet size and a byte for the type.
 		 * Then this packet adds a uint16_t for the count in this packet.
 		 * The rest of the packet can be used for the IDs. */
-		uint p_count = std::min<uint>(count, (TCP_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint16_t)) / sizeof(uint32_t));
+		uint p_count = std::min<uint>(count, (TCP_MTU - sizeof(PacketSize) - sizeof(uint8_t) - sizeof(uint16_t)) / sizeof(uint32_t));
 
 		auto p = std::make_unique<Packet>(this, PACKET_CONTENT_CLIENT_CONTENT, TCP_MTU);
 		p->Send_uint16(p_count);
@@ -420,7 +420,7 @@ static bool GunzipFile(const ContentInfo *ci)
 	if (fin == nullptr || fout == nullptr) {
 		ret = false;
 	} else {
-		byte buff[8192];
+		uint8_t buff[8192];
 		for (;;) {
 			int read = gzread(fin, buff, sizeof(buff));
 			if (read == 0) {

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -33,7 +33,7 @@ extern StringList _network_bind_list;
 extern StringList _network_host_list;
 extern StringList _network_ban_list;
 
-byte NetworkSpectatorCount();
+uint8_t NetworkSpectatorCount();
 bool NetworkIsValidClientName(const std::string_view client_name);
 bool NetworkValidateOurClientName();
 bool NetworkValidateClientName(std::string &client_name);

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -136,7 +136,7 @@ struct PacketWriter : SaveFilter {
 		return false;
 	}
 
-	void Write(byte *buf, size_t size) override
+	void Write(uint8_t *buf, size_t size) override
 	{
 		std::lock_guard<std::mutex> lock(this->mutex);
 
@@ -145,7 +145,7 @@ struct PacketWriter : SaveFilter {
 
 		if (this->current == nullptr) this->current = std::make_unique<Packet>(this->cs, PACKET_SERVER_MAP_DATA, TCP_MTU);
 
-		std::span<const byte> to_write(buf, size);
+		std::span<const uint8_t> to_write(buf, size);
 		while (!to_write.empty()) {
 			to_write = this->current->Send_bytes(to_write);
 
@@ -267,7 +267,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::CloseConnection(NetworkRecvSta
 
 	/* We just lost one client :( */
 	if (this->status >= STATUS_AUTHORIZED) _network_game_info.clients_on--;
-	extern byte _network_clients_connected;
+	extern uint8_t _network_clients_connected;
 	_network_clients_connected--;
 
 	this->SendPackets(true);
@@ -285,7 +285,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::CloseConnection(NetworkRecvSta
  */
 /* static */ bool ServerNetworkGameSocketHandler::AllowConnection()
 {
-	extern byte _network_clients_connected;
+	extern uint8_t _network_clients_connected;
 	bool accept = _network_clients_connected < MAX_CLIENTS;
 
 	/* We can't go over the MAX_CLIENTS limit here. However, the
@@ -1505,7 +1505,7 @@ void NetworkPopulateCompanyStats(NetworkCompanyStats *stats)
 	/* Go through all vehicles and count the type of vehicles */
 	for (const Vehicle *v : Vehicle::Iterate()) {
 		if (!Company::IsValidID(v->owner) || !v->IsPrimaryVehicle()) continue;
-		byte type = 0;
+		uint8_t type = 0;
 		switch (v->type) {
 			case VEH_TRAIN: type = NETWORK_VEH_TRAIN; break;
 			case VEH_ROAD: type = RoadVehicle::From(v)->IsBus() ? NETWORK_VEH_BUS : NETWORK_VEH_LORRY; break;

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -62,8 +62,8 @@ public:
 		STATUS_END,           ///< Must ALWAYS be on the end of this list!! (period).
 	};
 
-	byte lag_test;               ///< Byte used for lag-testing the client
-	byte last_token;             ///< The last random token we did send to verify the client is listening
+	uint8_t lag_test;               ///< Byte used for lag-testing the client
+	uint8_t last_token;             ///< The last random token we did send to verify the client is listening
 	uint32_t last_token_frame;     ///< The last frame we received the right token
 	ClientStatus status;         ///< Status of this client
 	CommandQueue outgoing_queue; ///< The command-queue awaiting delivery; conceptually more a bucket to gather commands in, after which the whole bucket is sent to the client.

--- a/src/network/network_type.h
+++ b/src/network/network_type.h
@@ -88,7 +88,7 @@ enum NetworkPasswordType {
  * Destination of our chat messages.
  * @warning The values of the enum items are part of the admin network API. Only append at the end.
  */
-enum DestType : byte {
+enum DestType : uint8_t {
 	DESTTYPE_BROADCAST, ///< Send message/notice to all clients (All)
 	DESTTYPE_TEAM,      ///< Send message/notice to everyone playing the same company (Team)
 	DESTTYPE_CLIENT,    ///< Send message/notice to only a certain client (Private)

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -73,7 +73,7 @@ const std::vector<GRFFile *> &GetAllGRFFiles()
 }
 
 /** Miscellaneous GRF features, set by Action 0x0D, parameter 0x9E */
-byte _misc_grf_features = 0;
+uint8_t _misc_grf_features = 0;
 
 /** 32 * 8 = 256 flags. Apparently TTDPatch uses this many.. */
 static uint32_t _ttdpatch_flags[8];
@@ -133,7 +133,7 @@ public:
 	 * @param numsets Number of sets to define.
 	 * @param numents Number of sprites per set to define.
 	 */
-	void AddSpriteSets(byte feature, SpriteID first_sprite, uint first_set, uint numsets, uint numents)
+	void AddSpriteSets(uint8_t feature, SpriteID first_sprite, uint first_set, uint numsets, uint numents)
 	{
 		assert(feature < GSF_END);
 		for (uint i = 0; i < numsets; i++) {
@@ -149,7 +149,7 @@ public:
 	 * @return true if there are any valid sets.
 	 * @note Spritesets with zero sprites are valid to allow callback-failures.
 	 */
-	bool HasValidSpriteSets(byte feature) const
+	bool HasValidSpriteSets(uint8_t feature) const
 	{
 		assert(feature < GSF_END);
 		return !this->spritesets[feature].empty();
@@ -162,7 +162,7 @@ public:
 	 * @return true if the set is valid.
 	 * @note Spritesets with zero sprites are valid to allow callback-failures.
 	 */
-	bool IsValidSpriteSet(byte feature, uint set) const
+	bool IsValidSpriteSet(uint8_t feature, uint set) const
 	{
 		assert(feature < GSF_END);
 		return this->spritesets[feature].find(set) != this->spritesets[feature].end();
@@ -174,7 +174,7 @@ public:
 	 * @param set Set to query.
 	 * @return First sprite of the set.
 	 */
-	SpriteID GetSprite(byte feature, uint set) const
+	SpriteID GetSprite(uint8_t feature, uint set) const
 	{
 		assert(IsValidSpriteSet(feature, set));
 		return this->spritesets[feature].find(set)->second.sprite;
@@ -186,7 +186,7 @@ public:
 	 * @param set Set to query.
 	 * @return Number of sprites in the set.
 	 */
-	uint GetNumEnts(byte feature, uint set) const
+	uint GetNumEnts(uint8_t feature, uint set) const
 	{
 		assert(IsValidSpriteSet(feature, set));
 		return this->spritesets[feature].find(set)->second.num_sprites;
@@ -213,13 +213,13 @@ class OTTDByteReaderSignal { };
 /** Class to read from a NewGRF file */
 class ByteReader {
 protected:
-	byte *data;
-	byte *end;
+	uint8_t *data;
+	uint8_t *end;
 
 public:
-	ByteReader(byte *data, byte *end) : data(data), end(end) { }
+	ByteReader(uint8_t *data, uint8_t *end) : data(data), end(end) { }
 
-	inline byte *ReadBytes(size_t size)
+	inline uint8_t *ReadBytes(size_t size)
 	{
 		if (data + size >= end) {
 			/* Put data at the end, as would happen if every byte had been individually read. */
@@ -227,12 +227,12 @@ public:
 			throw OTTDByteReaderSignal();
 		}
 
-		byte *ret = data;
+		uint8_t *ret = data;
 		data += size;
 		return ret;
 	}
 
-	inline byte ReadByte()
+	inline uint8_t ReadByte()
 	{
 		if (data < end) return *(data)++;
 		throw OTTDByteReaderSignal();
@@ -256,7 +256,7 @@ public:
 		return val | (ReadWord() << 16);
 	}
 
-	uint32_t ReadVarSize(byte size)
+	uint32_t ReadVarSize(uint8_t size)
 	{
 		switch (size) {
 			case 1: return ReadByte();
@@ -296,7 +296,7 @@ public:
 		return data + count <= end;
 	}
 
-	inline byte *Data()
+	inline uint8_t *Data()
 	{
 		return data;
 	}
@@ -377,7 +377,7 @@ struct GRFLocation {
 };
 
 static std::map<GRFLocation, SpriteID> _grm_sprites;
-typedef std::map<GRFLocation, std::vector<byte>> GRFLineToSpriteOverride;
+typedef std::map<GRFLocation, std::vector<uint8_t>> GRFLineToSpriteOverride;
 static GRFLineToSpriteOverride _grf_line_to_action6_sprite_override;
 
 /**
@@ -845,7 +845,7 @@ static void ReadSpriteLayoutRegisters(ByteReader *buf, TileLayoutFlags flags, bo
  * @param dts                  Layout container to output into
  * @return True on error (GRF was disabled).
  */
-static bool ReadSpriteLayout(ByteReader *buf, uint num_building_sprites, bool use_cur_spritesets, byte feature, bool allow_var10, bool no_z_position, NewGRFSpriteLayout *dts)
+static bool ReadSpriteLayout(ByteReader *buf, uint num_building_sprites, bool use_cur_spritesets, uint8_t feature, bool allow_var10, bool no_z_position, NewGRFSpriteLayout *dts)
 {
 	bool has_flags = HasBit(num_building_sprites, 6);
 	ClrBit(num_building_sprites, 6);
@@ -1255,7 +1255,7 @@ static ChangeInfoResult RailVehicleChangeInfo(uint engine, int numinfo, int prop
 				break;
 
 			case 0x24: { // High byte of vehicle weight
-				byte weight = buf->ReadByte();
+				uint8_t weight = buf->ReadByte();
 
 				if (weight > 4) {
 					GrfMsg(2, "RailVehicleChangeInfo: Nonsensical weight of {} tons, ignoring", weight << 8);
@@ -2025,15 +2025,15 @@ static ChangeInfoResult StationChangeInfo(uint stid, int numinfo, int prop, Byte
 
 			case 0x0E: // Define custom layout
 				while (buf->HasData()) {
-					byte length = buf->ReadByte();
-					byte number = buf->ReadByte();
+					uint8_t length = buf->ReadByte();
+					uint8_t number = buf->ReadByte();
 
 					if (length == 0 || number == 0) break;
 
 					if (statspec->layouts.size() < length) statspec->layouts.resize(length);
 					if (statspec->layouts[length - 1].size() < number) statspec->layouts[length - 1].resize(number);
 
-					const byte *layout = buf->ReadBytes(length * number);
+					const uint8_t *layout = buf->ReadBytes(length * number);
 					statspec->layouts[length - 1][number - 1].assign(layout, layout + length * number);
 
 					/* Validate tile values are only the permitted 00, 02, 04 and 06. */
@@ -2207,7 +2207,7 @@ static ChangeInfoResult BridgeChangeInfo(uint brid, int numinfo, int prop, ByteR
 		switch (prop) {
 			case 0x08: { // Year of availability
 				/* We treat '0' as always available */
-				byte year = buf->ReadByte();
+				uint8_t year = buf->ReadByte();
 				bridge->avail_year = (year > 0 ? CalendarTime::ORIGINAL_BASE_YEAR + year : 0);
 				break;
 			}
@@ -2231,8 +2231,8 @@ static ChangeInfoResult BridgeChangeInfo(uint brid, int numinfo, int prop, ByteR
 				break;
 
 			case 0x0D: { // Bridge sprite tables
-				byte tableid = buf->ReadByte();
-				byte numtables = buf->ReadByte();
+				uint8_t tableid = buf->ReadByte();
+				uint8_t numtables = buf->ReadByte();
 
 				if (bridge->sprite_table == nullptr) {
 					/* Allocate memory for sprite table pointers and zero out */
@@ -2242,7 +2242,7 @@ static ChangeInfoResult BridgeChangeInfo(uint brid, int numinfo, int prop, ByteR
 				for (; numtables-- != 0; tableid++) {
 					if (tableid >= 7) { // skip invalid data
 						GrfMsg(1, "BridgeChangeInfo: Table {} >= 7, skipping", tableid);
-						for (byte sprite = 0; sprite < 32; sprite++) buf->ReadDWord();
+						for (uint8_t sprite = 0; sprite < 32; sprite++) buf->ReadDWord();
 						continue;
 					}
 
@@ -2250,7 +2250,7 @@ static ChangeInfoResult BridgeChangeInfo(uint brid, int numinfo, int prop, ByteR
 						bridge->sprite_table[tableid] = MallocT<PalSpriteID>(32);
 					}
 
-					for (byte sprite = 0; sprite < 32; sprite++) {
+					for (uint8_t sprite = 0; sprite < 32; sprite++) {
 						SpriteID image = buf->ReadWord();
 						PaletteID pal  = buf->ReadWord();
 
@@ -2346,8 +2346,8 @@ static ChangeInfoResult IgnoreTownHouseProperty(int prop, ByteReader *buf)
 			break;
 
 		case 0x20: {
-			byte count = buf->ReadByte();
-			for (byte j = 0; j < count; j++) buf->ReadByte();
+			uint8_t count = buf->ReadByte();
+			for (uint8_t j = 0; j < count; j++) buf->ReadByte();
 			break;
 		}
 
@@ -2394,7 +2394,7 @@ static ChangeInfoResult TownHouseChangeInfo(uint hid, int numinfo, int prop, Byt
 
 		switch (prop) {
 			case 0x08: { // Substitute building type, and definition of a new house
-				byte subs_id = buf->ReadByte();
+				uint8_t subs_id = buf->ReadByte();
 				if (subs_id == 0xFF) {
 					/* Instead of defining a new house, a substitute house id
 					 * of 0xFF disables the old house with the current id. */
@@ -2500,7 +2500,7 @@ static ChangeInfoResult TownHouseChangeInfo(uint hid, int numinfo, int prop, Byt
 				break;
 
 			case 0x15: { // House override byte
-				byte override = buf->ReadByte();
+				uint8_t override = buf->ReadByte();
 
 				/* The house being overridden must be an original house. */
 				if (override >= NEW_HOUSE_OFFSET) {
@@ -2513,7 +2513,7 @@ static ChangeInfoResult TownHouseChangeInfo(uint hid, int numinfo, int prop, Byt
 			}
 
 			case 0x16: // Periodic refresh multiplier
-				housespec->processing_time = std::min<byte>(buf->ReadByte(), 63u);
+				housespec->processing_time = std::min<uint8_t>(buf->ReadByte(), 63u);
 				break;
 
 			case 0x17: // Four random colours to use
@@ -2572,8 +2572,8 @@ static ChangeInfoResult TownHouseChangeInfo(uint hid, int numinfo, int prop, Byt
 				break;
 
 			case 0x20: { // Cargo acceptance watch list
-				byte count = buf->ReadByte();
-				for (byte j = 0; j < count; j++) {
+				uint8_t count = buf->ReadByte();
+				for (uint8_t j = 0; j < count; j++) {
 					CargoID cargo = GetCargoTranslation(buf->ReadByte(), _cur.grffile);
 					if (IsValidCargoID(cargo)) SetBit(housespec->watched_cargoes, cargo);
 				}
@@ -2799,7 +2799,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint gvid, int numinfo, int prop, By
 				} else if (buf->Remaining() < SNOW_LINE_MONTHS * SNOW_LINE_DAYS) {
 					GrfMsg(1, "GlobalVarChangeInfo: Not enough entries set in the snowline table ({})", buf->Remaining());
 				} else {
-					byte table[SNOW_LINE_MONTHS][SNOW_LINE_DAYS];
+					uint8_t table[SNOW_LINE_MONTHS][SNOW_LINE_DAYS];
 
 					for (uint i = 0; i < SNOW_LINE_MONTHS; i++) {
 						for (uint j = 0; j < SNOW_LINE_DAYS; j++) {
@@ -2856,7 +2856,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint gvid, int numinfo, int prop, By
 					break;
 				}
 
-				byte newgrf_id = buf->ReadByte(); // The NewGRF (custom) identifier.
+				uint8_t newgrf_id = buf->ReadByte(); // The NewGRF (custom) identifier.
 				while (newgrf_id != 0) {
 					const char *name = buf->ReadString(); // The name for the OpenTTD identifier.
 
@@ -3252,7 +3252,7 @@ static ChangeInfoResult IndustrytilesChangeInfo(uint indtid, int numinfo, int pr
 
 		switch (prop) {
 			case 0x08: { // Substitute industry tile type
-				byte subs_id = buf->ReadByte();
+				uint8_t subs_id = buf->ReadByte();
 				if (subs_id >= NEW_INDUSTRYTILEOFFSET) {
 					/* The substitute id must be one of the original industry tile. */
 					GrfMsg(2, "IndustryTilesChangeInfo: Attempt to use new industry tile {} as substitute industry tile for {}. Ignoring.", subs_id, indtid + i);
@@ -3281,7 +3281,7 @@ static ChangeInfoResult IndustrytilesChangeInfo(uint indtid, int numinfo, int pr
 			}
 
 			case 0x09: { // Industry tile override
-				byte ovrid = buf->ReadByte();
+				uint8_t ovrid = buf->ReadByte();
 
 				/* The industry being overridden must be an original industry. */
 				if (ovrid >= NEW_INDUSTRYTILEOFFSET) {
@@ -3328,7 +3328,7 @@ static ChangeInfoResult IndustrytilesChangeInfo(uint indtid, int numinfo, int pr
 				break;
 
 			case 0x13: { // variable length cargo acceptance
-				byte num_cargoes = buf->ReadByte();
+				uint8_t num_cargoes = buf->ReadByte();
 				if (num_cargoes > std::size(tsp->acceptance)) {
 					GRFError *error = DisableGrf(STR_NEWGRF_ERROR_LIST_PROPERTY_TOO_LONG);
 					error->param_value[1] = prop;
@@ -3403,20 +3403,20 @@ static ChangeInfoResult IgnoreIndustryProperty(int prop, ByteReader *buf)
 			break;
 
 		case 0x0A: {
-			byte num_table = buf->ReadByte();
-			for (byte j = 0; j < num_table; j++) {
+			uint8_t num_table = buf->ReadByte();
+			for (uint8_t j = 0; j < num_table; j++) {
 				for (uint k = 0;; k++) {
-					byte x = buf->ReadByte();
+					uint8_t x = buf->ReadByte();
 					if (x == 0xFE && k == 0) {
 						buf->ReadByte();
 						buf->ReadByte();
 						break;
 					}
 
-					byte y = buf->ReadByte();
+					uint8_t y = buf->ReadByte();
 					if (x == 0 && y == 0x80) break;
 
-					byte gfx = buf->ReadByte();
+					uint8_t gfx = buf->ReadByte();
 					if (gfx == 0xFE) buf->ReadWord();
 				}
 			}
@@ -3424,7 +3424,7 @@ static ChangeInfoResult IgnoreIndustryProperty(int prop, ByteReader *buf)
 		}
 
 		case 0x16:
-			for (byte j = 0; j < 3; j++) buf->ReadByte();
+			for (uint8_t j = 0; j < 3; j++) buf->ReadByte();
 			break;
 
 		case 0x15:
@@ -3509,7 +3509,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 
 		switch (prop) {
 			case 0x08: { // Substitute industry type
-				byte subs_id = buf->ReadByte();
+				uint8_t subs_id = buf->ReadByte();
 				if (subs_id == 0xFF) {
 					/* Instead of defining a new industry, a substitute industry id
 					 * of 0xFF disables the old industry with the current id. */
@@ -3540,7 +3540,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 			}
 
 			case 0x09: { // Industry type override
-				byte ovrid = buf->ReadByte();
+				uint8_t ovrid = buf->ReadByte();
 
 				/* The industry being overridden must be an original industry. */
 				if (ovrid >= NEW_INDUSTRYOFFSET) {
@@ -3553,13 +3553,13 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 			}
 
 			case 0x0A: { // Set industry layout(s)
-				byte new_num_layouts = buf->ReadByte();
+				uint8_t new_num_layouts = buf->ReadByte();
 				uint32_t definition_size = buf->ReadDWord();
 				uint32_t bytes_read = 0;
 				std::vector<IndustryTileLayout> new_layouts;
 				IndustryTileLayout layout;
 
-				for (byte j = 0; j < new_num_layouts; j++) {
+				for (uint8_t j = 0; j < new_num_layouts; j++) {
 					layout.clear();
 
 					for (uint k = 0;; k++) {
@@ -3578,7 +3578,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 						if (it.ti.x == 0xFE && k == 0) {
 							/* This means we have to borrow the layout from an old industry */
 							IndustryType type = buf->ReadByte();
-							byte laynbr = buf->ReadByte();
+							uint8_t laynbr = buf->ReadByte();
 							bytes_read += 2;
 
 							if (type >= lengthof(_origin_industry_specs)) {
@@ -3672,14 +3672,14 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 				break;
 
 			case 0x10: // Production cargo types
-				for (byte j = 0; j < 2; j++) {
+				for (uint8_t j = 0; j < 2; j++) {
 					indsp->produced_cargo[j] = GetCargoTranslation(buf->ReadByte(), _cur.grffile);
 					indsp->produced_cargo_label[j] = CT_INVALID;
 				}
 				break;
 
 			case 0x11: // Acceptance cargo types
-				for (byte j = 0; j < 3; j++) {
+				for (uint8_t j = 0; j < 3; j++) {
 					indsp->accepts_cargo[j] = GetCargoTranslation(buf->ReadByte(), _cur.grffile);
 					indsp->accepts_cargo_label[j] = CT_INVALID;
 				}
@@ -3717,7 +3717,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 			}
 
 			case 0x16: // Conflicting industry types
-				for (byte j = 0; j < 3; j++) indsp->conflicting[j] = buf->ReadByte();
+				for (uint8_t j = 0; j < 3; j++) indsp->conflicting[j] = buf->ReadByte();
 				break;
 
 			case 0x17: // Probability in random game
@@ -3759,7 +3759,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 
 			case 0x21:   // Callback mask
 			case 0x22: { // Callback additional mask
-				byte aflag = buf->ReadByte();
+				uint8_t aflag = buf->ReadByte();
 				SB(indsp->callback_mask, (prop - 0x21) * 8, 8, aflag);
 				break;
 			}
@@ -3779,7 +3779,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 			}
 
 			case 0x25: { // variable length produced cargoes
-				byte num_cargoes = buf->ReadByte();
+				uint8_t num_cargoes = buf->ReadByte();
 				if (num_cargoes > lengthof(indsp->produced_cargo)) {
 					GRFError *error = DisableGrf(STR_NEWGRF_ERROR_LIST_PROPERTY_TOO_LONG);
 					error->param_value[1] = prop;
@@ -3798,7 +3798,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 			}
 
 			case 0x26: { // variable length accepted cargoes
-				byte num_cargoes = buf->ReadByte();
+				uint8_t num_cargoes = buf->ReadByte();
 				if (num_cargoes > lengthof(indsp->accepts_cargo)) {
 					GRFError *error = DisableGrf(STR_NEWGRF_ERROR_LIST_PROPERTY_TOO_LONG);
 					error->param_value[1] = prop;
@@ -3817,7 +3817,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 			}
 
 			case 0x27: { // variable length production rates
-				byte num_cargoes = buf->ReadByte();
+				uint8_t num_cargoes = buf->ReadByte();
 				if (num_cargoes > lengthof(indsp->production_rate)) {
 					GRFError *error = DisableGrf(STR_NEWGRF_ERROR_LIST_PROPERTY_TOO_LONG);
 					error->param_value[1] = prop;
@@ -3834,8 +3834,8 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 			}
 
 			case 0x28: { // variable size input/output production multiplier table
-				byte num_inputs = buf->ReadByte();
-				byte num_outputs = buf->ReadByte();
+				uint8_t num_inputs = buf->ReadByte();
+				uint8_t num_outputs = buf->ReadByte();
 				if (num_inputs > lengthof(indsp->accepts_cargo) || num_outputs > lengthof(indsp->produced_cargo)) {
 					GRFError *error = DisableGrf(STR_NEWGRF_ERROR_LIST_PROPERTY_TOO_LONG);
 					error->param_value[1] = prop;
@@ -3916,7 +3916,7 @@ static ChangeInfoResult AirportChangeInfo(uint airport, int numinfo, int prop, B
 
 		switch (prop) {
 			case 0x08: { // Modify original airport
-				byte subs_id = buf->ReadByte();
+				uint8_t subs_id = buf->ReadByte();
 				if (subs_id == 0xFF) {
 					/* Instead of defining a new airport, an airport id
 					 * of 0xFF disables the old airport with the current id. */
@@ -3948,7 +3948,7 @@ static ChangeInfoResult AirportChangeInfo(uint airport, int numinfo, int prop, B
 			}
 
 			case 0x0A: { // Set airport layout
-				byte old_num_table = as->num_table;
+				uint8_t old_num_table = as->num_table;
 				free(as->rotation);
 				as->num_table = buf->ReadByte(); // Number of layaouts
 				as->rotation = MallocT<Direction>(as->num_table);
@@ -3958,7 +3958,7 @@ static ChangeInfoResult AirportChangeInfo(uint airport, int numinfo, int prop, B
 				int size;
 				const AirportTileTable *copy_from;
 				try {
-					for (byte j = 0; j < as->num_table; j++) {
+					for (uint8_t j = 0; j < as->num_table; j++) {
 						const_cast<Direction&>(as->rotation[j]) = (Direction)buf->ReadByte();
 						for (int k = 0;; k++) {
 							att[k].ti.x = buf->ReadByte(); // Offsets from northermost tile
@@ -3997,11 +3997,11 @@ static ChangeInfoResult AirportChangeInfo(uint airport, int numinfo, int prop, B
 							}
 
 							if (as->rotation[j] == DIR_E || as->rotation[j] == DIR_W) {
-								as->size_x = std::max<byte>(as->size_x, att[k].ti.y + 1);
-								as->size_y = std::max<byte>(as->size_y, att[k].ti.x + 1);
+								as->size_x = std::max<uint8_t>(as->size_x, att[k].ti.y + 1);
+								as->size_y = std::max<uint8_t>(as->size_y, att[k].ti.x + 1);
 							} else {
-								as->size_x = std::max<byte>(as->size_x, att[k].ti.x + 1);
-								as->size_y = std::max<byte>(as->size_y, att[k].ti.y + 1);
+								as->size_x = std::max<uint8_t>(as->size_x, att[k].ti.x + 1);
+								as->size_y = std::max<uint8_t>(as->size_y, att[k].ti.y + 1);
 							}
 						}
 						tile_table[j] = CallocT<AirportTileTable>(size);
@@ -4705,7 +4705,7 @@ static ChangeInfoResult AirportTilesChangeInfo(uint airtid, int numinfo, int pro
 
 		switch (prop) {
 			case 0x08: { // Substitute airport tile type
-				byte subs_id = buf->ReadByte();
+				uint8_t subs_id = buf->ReadByte();
 				if (subs_id >= NEW_AIRPORTTILE_OFFSET) {
 					/* The substitute id must be one of the original airport tiles. */
 					GrfMsg(2, "AirportTileChangeInfo: Attempt to use new airport tile {} as substitute airport tile for {}. Ignoring.", subs_id, airtid + i);
@@ -4730,7 +4730,7 @@ static ChangeInfoResult AirportTilesChangeInfo(uint airtid, int numinfo, int pro
 			}
 
 			case 0x09: { // Airport tile override
-				byte override = buf->ReadByte();
+				uint8_t override = buf->ReadByte();
 
 				/* The airport tile being overridden must be an original airport tile. */
 				if (override >= NEW_AIRPORTTILE_OFFSET) {
@@ -5141,7 +5141,7 @@ static void SkipAct1(ByteReader *buf)
 
 /* Helper function to either create a callback or link to a previously
  * defined spritegroup. */
-static const SpriteGroup *GetGroupFromGroupID(byte setid, byte type, uint16_t groupid)
+static const SpriteGroup *GetGroupFromGroupID(uint8_t setid, uint8_t type, uint16_t groupid)
 {
 	if (HasBit(groupid, 15)) {
 		assert(CallbackResultSpriteGroup::CanAllocateItem());
@@ -5164,7 +5164,7 @@ static const SpriteGroup *GetGroupFromGroupID(byte setid, byte type, uint16_t gr
  * @param spriteid Raw value from the GRF for the new spritegroup; describes either the return value or the referenced spritegroup.
  * @return Created spritegroup.
  */
-static const SpriteGroup *CreateGroupFromGroupID(byte feature, byte setid, byte type, uint16_t spriteid)
+static const SpriteGroup *CreateGroupFromGroupID(uint8_t feature, uint8_t setid, uint8_t type, uint16_t spriteid)
 {
 	if (HasBit(spriteid, 15)) {
 		assert(CallbackResultSpriteGroup::CanAllocateItem());
@@ -5223,8 +5223,8 @@ static void NewSpriteGroup(ByteReader *buf)
 		case 0x89: // Self scope, dword
 		case 0x8A: // Parent scope, dword
 		{
-			byte varadjust;
-			byte varsize;
+			uint8_t varadjust;
+			uint8_t varsize;
 
 			assert(DeterministicSpriteGroup::CanAllocateItem());
 			DeterministicSpriteGroup *group = new DeterministicSpriteGroup();
@@ -5344,7 +5344,7 @@ static void NewSpriteGroup(ByteReader *buf)
 			group->cmp_mode       = HasBit(triggers, 7) ? RSG_CMP_ALL : RSG_CMP_ANY;
 			group->lowest_randbit = buf->ReadByte();
 
-			byte num_groups = buf->ReadByte();
+			uint8_t num_groups = buf->ReadByte();
 			if (!HasExactlyOneBit(num_groups)) {
 				GrfMsg(1, "NewSpriteGroup: Random Action 2 nrand should be power of 2");
 			}
@@ -5372,8 +5372,8 @@ static void NewSpriteGroup(ByteReader *buf)
 				case GSF_ROADTYPES:
 				case GSF_TRAMTYPES:
 				{
-					byte num_loaded  = type;
-					byte num_loading = buf->ReadByte();
+					uint8_t num_loaded  = type;
+					uint8_t num_loading = buf->ReadByte();
 
 					if (!_cur.HasValidSpriteSets(feature)) {
 						GrfMsg(0, "NewSpriteGroup: No sprite set to work on! Skipping");
@@ -5442,7 +5442,7 @@ static void NewSpriteGroup(ByteReader *buf)
 				case GSF_OBJECTS:
 				case GSF_INDUSTRYTILES:
 				case GSF_ROADSTOPS: {
-					byte num_building_sprites = std::max((uint8_t)1, type);
+					uint8_t num_building_sprites = std::max((uint8_t)1, type);
 
 					assert(TileLayoutSpriteGroup::CanAllocateItem());
 					TileLayoutSpriteGroup *group = new TileLayoutSpriteGroup();
@@ -5493,7 +5493,7 @@ static void NewSpriteGroup(ByteReader *buf)
 							return;
 						}
 						for (uint i = 0; i < group->num_input; i++) {
-							byte rawcargo = buf->ReadByte();
+							uint8_t rawcargo = buf->ReadByte();
 							CargoID cargo = GetCargoTranslation(rawcargo, _cur.grffile);
 							if (!IsValidCargoID(cargo)) {
 								/* The mapped cargo is invalid. This is permitted at this point,
@@ -5515,7 +5515,7 @@ static void NewSpriteGroup(ByteReader *buf)
 							return;
 						}
 						for (uint i = 0; i < group->num_output; i++) {
-							byte rawcargo = buf->ReadByte();
+							uint8_t rawcargo = buf->ReadByte();
 							CargoID cargo = GetCargoTranslation(rawcargo, _cur.grffile);
 							if (!IsValidCargoID(cargo)) {
 								/* Mark this result as invalid to use */
@@ -5602,7 +5602,7 @@ static bool IsValidGroupID(uint16_t groupid, const char *function)
 	return true;
 }
 
-static void VehicleMapSpriteGroup(ByteReader *buf, byte feature, uint8_t idcount)
+static void VehicleMapSpriteGroup(ByteReader *buf, uint8_t feature, uint8_t idcount)
 {
 	static EngineID *last_engines;
 	static uint last_engines_count;
@@ -6547,7 +6547,7 @@ static void SkipAct5(ByteReader *buf)
  * @param grffile NewGRF querying the variable
  * @return true iff the variable is known and the value is returned in 'value'.
  */
-bool GetGlobalVariable(byte param, uint32_t *value, const GRFFile *grffile)
+bool GetGlobalVariable(uint8_t param, uint32_t *value, const GRFFile *grffile)
 {
 	switch (param) {
 		case 0x00: // current date
@@ -6648,7 +6648,7 @@ bool GetGlobalVariable(byte param, uint32_t *value, const GRFFile *grffile)
 		/* case 0x1F: // locale dependent settings not implemented to avoid desync */
 
 		case 0x20: { // snow line height
-			byte snowline = GetSnowLine();
+			uint8_t snowline = GetSnowLine();
 			if (_settings_game.game_creation.landscape == LT_ARCTIC && snowline <= _settings_game.construction.map_height_limit) {
 				*value = Clamp(snowline * (grffile->grf_version >= 8 ? 1 : TILE_HEIGHT), 0, 0xFE);
 			} else {
@@ -6678,7 +6678,7 @@ bool GetGlobalVariable(byte param, uint32_t *value, const GRFFile *grffile)
 	}
 }
 
-static uint32_t GetParamVal(byte param, uint32_t *cond_val)
+static uint32_t GetParamVal(uint8_t param, uint32_t *cond_val)
 {
 	/* First handle variable common with VarAction2 */
 	uint32_t value;
@@ -6753,7 +6753,7 @@ static void CfgApply(ByteReader *buf)
 
 	/* Get (or create) the override for the next sprite. */
 	GRFLocation location(_cur.grfconfig->ident.grfid, _cur.nfo_line + 1);
-	std::vector<byte> &preload_sprite = _grf_line_to_action6_sprite_override[location];
+	std::vector<uint8_t> &preload_sprite = _grf_line_to_action6_sprite_override[location];
 
 	/* Load new sprite data if it hasn't already been loaded. */
 	if (preload_sprite.empty()) {
@@ -7157,9 +7157,9 @@ static void GRFLoadError(ByteReader *buf)
 		STR_NEWGRF_ERROR_MSG_FATAL
 	};
 
-	byte severity   = buf->ReadByte();
-	byte lang       = buf->ReadByte();
-	byte message_id = buf->ReadByte();
+	uint8_t severity   = buf->ReadByte();
+	uint8_t lang       = buf->ReadByte();
+	uint8_t message_id = buf->ReadByte();
 
 	/* Skip the error if it isn't valid for the current language. */
 	if (!CheckGrfLangID(lang, _cur.grffile->grf_version)) return;
@@ -7303,10 +7303,10 @@ static uint32_t GetPatchVariable(uint8_t param)
 		 * SS : combination of both X and Y, thus giving the size(log2) of the map
 		 */
 		case 0x13: {
-			byte map_bits = 0;
-			byte log_X = Map::LogX() - 6; // subtraction is required to make the minimal size (64) zero based
-			byte log_Y = Map::LogY() - 6;
-			byte max_edge = std::max(log_X, log_Y);
+			uint8_t map_bits = 0;
+			uint8_t log_X = Map::LogX() - 6; // subtraction is required to make the minimal size (64) zero based
+			uint8_t log_Y = Map::LogY() - 6;
+			uint8_t max_edge = std::max(log_X, log_Y);
 
 			if (log_X == log_Y) { // we have a squared map, since both edges are identical
 				SetBit(map_bits, 0);
@@ -7752,7 +7752,7 @@ static void FeatureTownName(ByteReader *buf)
 
 	GRFTownName *townname = AddGRFTownName(grfid);
 
-	byte id = buf->ReadByte();
+	uint8_t id = buf->ReadByte();
 	GrfMsg(6, "FeatureTownName: definition 0x{:02X}", id & 0x7F);
 
 	if (HasBit(id, 7)) {
@@ -7760,7 +7760,7 @@ static void FeatureTownName(ByteReader *buf)
 		ClrBit(id, 7);
 		bool new_scheme = _cur.grffile->grf_version >= 7;
 
-		byte lang = buf->ReadByte();
+		uint8_t lang = buf->ReadByte();
 		StringID style = STR_UNDEFINED;
 
 		do {
@@ -7796,7 +7796,7 @@ static void FeatureTownName(ByteReader *buf)
 			part.prob = buf->ReadByte();
 
 			if (HasBit(part.prob, 7)) {
-				byte ref_id = buf->ReadByte();
+				uint8_t ref_id = buf->ReadByte();
 				if (ref_id >= GRFTownName::MAX_LISTS || townname->partlists[ref_id].empty()) {
 					GrfMsg(0, "FeatureTownName: definition 0x{:02X} doesn't exist, deactivating", ref_id);
 					DelGRFTownName(grfid);
@@ -7824,7 +7824,7 @@ static void DefineGotoLabel(ByteReader *buf)
 	 * B label      The label to define
 	 * V comment    Optional comment - ignored */
 
-	byte nfo_label = buf->ReadByte();
+	uint8_t nfo_label = buf->ReadByte();
 
 	_cur.grffile->labels.emplace_back(nfo_label, _cur.nfo_line, _cur.file->GetPos());
 
@@ -7900,7 +7900,7 @@ static void GRFSound(ByteReader *buf)
 	}
 
 	SpriteFile &file = *_cur.file;
-	byte grf_container_version = file.GetContainerVersion();
+	uint8_t grf_container_version = file.GetContainerVersion();
 	for (int i = 0; i < num; i++) {
 		_cur.nfo_line++;
 
@@ -7911,7 +7911,7 @@ static void GRFSound(ByteReader *buf)
 		size_t offs = file.GetPos();
 
 		uint32_t len = grf_container_version >= 2 ? file.ReadDword() : file.ReadWord();
-		byte type = file.ReadByte();
+		uint8_t type = file.ReadByte();
 
 		if (grf_container_version >= 2 && type == 0xFD) {
 			/* Reference to sprite section. */
@@ -7940,7 +7940,7 @@ static void GRFSound(ByteReader *buf)
 			file.SkipBytes(len);
 		}
 
-		byte action = file.ReadByte();
+		uint8_t action = file.ReadByte();
 		switch (action) {
 			case 0xFF:
 				/* Allocate sound only in init stage. */
@@ -8074,8 +8074,8 @@ static void TranslateGRFStrings(ByteReader *buf)
 	 * new_scheme has to be true as well, which will also be implicitly the case for version 8
 	 * and higher. A language id of 0x7F will be overridden by a non-generic id, so this will
 	 * not change anything if a string has been provided specifically for this language. */
-	byte language = _cur.grffile->grf_version >= 8 ? buf->ReadByte() : 0x7F;
-	byte num_strings = buf->ReadByte();
+	uint8_t language = _cur.grffile->grf_version >= 8 ? buf->ReadByte() : 0x7F;
+	uint8_t num_strings = buf->ReadByte();
 	uint16_t first_id  = buf->ReadWord();
 
 	if (!((first_id >= 0xD000 && first_id + num_strings <= 0xD400) || (first_id >= 0xD800 && first_id + num_strings <= 0xE000))) {
@@ -8096,21 +8096,21 @@ static void TranslateGRFStrings(ByteReader *buf)
 }
 
 /** Callback function for 'INFO'->'NAME' to add a translation to the newgrf name. */
-static bool ChangeGRFName(byte langid, const char *str)
+static bool ChangeGRFName(uint8_t langid, const char *str)
 {
 	AddGRFTextToList(_cur.grfconfig->name, langid, _cur.grfconfig->ident.grfid, false, str);
 	return true;
 }
 
 /** Callback function for 'INFO'->'DESC' to add a translation to the newgrf description. */
-static bool ChangeGRFDescription(byte langid, const char *str)
+static bool ChangeGRFDescription(uint8_t langid, const char *str)
 {
 	AddGRFTextToList(_cur.grfconfig->info, langid, _cur.grfconfig->ident.grfid, true, str);
 	return true;
 }
 
 /** Callback function for 'INFO'->'URL_' to set the newgrf url. */
-static bool ChangeGRFURL(byte langid, const char *str)
+static bool ChangeGRFURL(uint8_t langid, const char *str)
 {
 	AddGRFTextToList(_cur.grfconfig->url, langid, _cur.grfconfig->ident.grfid, false, str);
 	return true;
@@ -8212,14 +8212,14 @@ static bool ChangeGRFMinVersion(size_t len, ByteReader *buf)
 static GRFParameterInfo *_cur_parameter; ///< The parameter which info is currently changed by the newgrf.
 
 /** Callback function for 'INFO'->'PARAM'->param_num->'NAME' to set the name of a parameter. */
-static bool ChangeGRFParamName(byte langid, const char *str)
+static bool ChangeGRFParamName(uint8_t langid, const char *str)
 {
 	AddGRFTextToList(_cur_parameter->name, langid, _cur.grfconfig->ident.grfid, false, str);
 	return true;
 }
 
 /** Callback function for 'INFO'->'PARAM'->param_num->'DESC' to set the description of a parameter. */
-static bool ChangeGRFParamDescription(byte langid, const char *str)
+static bool ChangeGRFParamDescription(uint8_t langid, const char *str)
 {
 	AddGRFTextToList(_cur_parameter->desc, langid, _cur.grfconfig->ident.grfid, true, str);
 	return true;
@@ -8271,14 +8271,14 @@ static bool ChangeGRFParamMask(size_t len, ByteReader *buf)
 		GrfMsg(2, "StaticGRFInfo: expected 1 to 3 bytes for 'INFO'->'PARA'->'MASK' but got {}, ignoring this field", len);
 		buf->Skip(len);
 	} else {
-		byte param_nr = buf->ReadByte();
+		uint8_t param_nr = buf->ReadByte();
 		if (param_nr >= _cur.grfconfig->param.size()) {
 			GrfMsg(2, "StaticGRFInfo: invalid parameter number in 'INFO'->'PARA'->'MASK', param {}, ignoring this field", param_nr);
 			buf->Skip(len - 1);
 		} else {
 			_cur_parameter->param_nr = param_nr;
-			if (len >= 2) _cur_parameter->first_bit = std::min<byte>(buf->ReadByte(), 31);
-			if (len >= 3) _cur_parameter->num_bit = std::min<byte>(buf->ReadByte(), 32 - _cur_parameter->first_bit);
+			if (len >= 2) _cur_parameter->first_bit = std::min<uint8_t>(buf->ReadByte(), 31);
+			if (len >= 3) _cur_parameter->num_bit = std::min<uint8_t>(buf->ReadByte(), 32 - _cur_parameter->first_bit);
 		}
 	}
 
@@ -8299,7 +8299,7 @@ static bool ChangeGRFParamDefault(size_t len, ByteReader *buf)
 }
 
 typedef bool (*DataHandler)(size_t, ByteReader *);  ///< Type of callback function for binary nodes
-typedef bool (*TextHandler)(byte, const char *str); ///< Type of callback function for text nodes
+typedef bool (*TextHandler)(uint8_t, const char *str); ///< Type of callback function for text nodes
 typedef bool (*BranchHandler)(ByteReader *);        ///< Type of callback function for branch nodes
 
 /**
@@ -8367,7 +8367,7 @@ struct AllowedSubtags {
 	}
 
 	uint32_t id; ///< The identifier for this node
-	byte type; ///< The type of the node, must be one of 'C', 'B' or 'T'.
+	uint8_t type; ///< The type of the node, must be one of 'C', 'B' or 'T'.
 	union {
 		DataHandler data; ///< Callback function for a binary node, only valid if type == 'B'.
 		TextHandler text; ///< Callback function for a text node, only valid if type == 'T'.
@@ -8381,7 +8381,7 @@ struct AllowedSubtags {
 	} handler;
 };
 
-static bool SkipUnknownInfo(ByteReader *buf, byte type);
+static bool SkipUnknownInfo(ByteReader *buf, uint8_t type);
 static bool HandleNodes(ByteReader *buf, AllowedSubtags *tags);
 
 /**
@@ -8392,7 +8392,7 @@ static bool HandleNodes(ByteReader *buf, AllowedSubtags *tags);
  */
 static bool ChangeGRFParamValueNames(ByteReader *buf)
 {
-	byte type = buf->ReadByte();
+	uint8_t type = buf->ReadByte();
 	while (type != 0) {
 		uint32_t id = buf->ReadDWord();
 		if (type != 'T' || id > _cur_parameter->max_value) {
@@ -8402,7 +8402,7 @@ static bool ChangeGRFParamValueNames(ByteReader *buf)
 			continue;
 		}
 
-		byte langid = buf->ReadByte();
+		uint8_t langid = buf->ReadByte();
 		const char *name_string = buf->ReadString();
 
 		auto val_name = _cur_parameter->value_names.find(id);
@@ -8439,7 +8439,7 @@ AllowedSubtags _tags_parameters[] = {
  */
 static bool HandleParameterInfo(ByteReader *buf)
 {
-	byte type = buf->ReadByte();
+	uint8_t type = buf->ReadByte();
 	while (type != 0) {
 		uint32_t id = buf->ReadDWord();
 		if (type != 'C' || id >= _cur.grfconfig->num_valid_params) {
@@ -8490,12 +8490,12 @@ AllowedSubtags _tags_root[] = {
  * @param type The node type to skip.
  * @return True if we could skip the node, false if an error occurred.
  */
-static bool SkipUnknownInfo(ByteReader *buf, byte type)
+static bool SkipUnknownInfo(ByteReader *buf, uint8_t type)
 {
 	/* type and id are already read */
 	switch (type) {
 		case 'C': {
-			byte new_type = buf->ReadByte();
+			uint8_t new_type = buf->ReadByte();
 			while (new_type != 0) {
 				buf->ReadDWord(); // skip the id
 				if (!SkipUnknownInfo(buf, new_type)) return false;
@@ -8530,7 +8530,7 @@ static bool SkipUnknownInfo(ByteReader *buf, byte type)
  * @param subtags Allowed subtags.
  * @return Whether all tags could be handled.
  */
-static bool HandleNode(byte type, uint32_t id, ByteReader *buf, AllowedSubtags subtags[])
+static bool HandleNode(uint8_t type, uint32_t id, ByteReader *buf, AllowedSubtags subtags[])
 {
 	uint i = 0;
 	AllowedSubtags *tag;
@@ -8540,7 +8540,7 @@ static bool HandleNode(byte type, uint32_t id, ByteReader *buf, AllowedSubtags s
 			default: NOT_REACHED();
 
 			case 'T': {
-				byte langid = buf->ReadByte();
+				uint8_t langid = buf->ReadByte();
 				return tag->handler.text(langid, buf->ReadString());
 			}
 
@@ -8570,7 +8570,7 @@ static bool HandleNode(byte type, uint32_t id, ByteReader *buf, AllowedSubtags s
  */
 static bool HandleNodes(ByteReader *buf, AllowedSubtags subtags[])
 {
-	byte type = buf->ReadByte();
+	uint8_t type = buf->ReadByte();
 	while (type != 0) {
 		uint32_t id = buf->ReadDWord();
 		if (!HandleNode(type, id, buf, subtags)) return false;
@@ -9023,12 +9023,12 @@ static void CalculateRefitMasks()
 		if (_gted[engine].defaultcargo_grf == nullptr) {
 			/* If the vehicle has any capacity, apply the default refit masks */
 			if (e->type != VEH_TRAIN || e->u.rail.capacity != 0) {
-				static constexpr byte T = 1 << LT_TEMPERATE;
-				static constexpr byte A = 1 << LT_ARCTIC;
-				static constexpr byte S = 1 << LT_TROPIC;
-				static constexpr byte Y = 1 << LT_TOYLAND;
+				static constexpr uint8_t T = 1 << LT_TEMPERATE;
+				static constexpr uint8_t A = 1 << LT_ARCTIC;
+				static constexpr uint8_t S = 1 << LT_TROPIC;
+				static constexpr uint8_t Y = 1 << LT_TOYLAND;
 				static const struct DefaultRefitMasks {
-					byte climate;
+					uint8_t climate;
 					CargoLabel cargo_label;
 					CargoTypes cargo_allowed;
 					CargoTypes cargo_disallowed;
@@ -9146,9 +9146,9 @@ static void CalculateRefitMasks()
 			if (file == nullptr) file = e->GetGRF();
 			if (file != nullptr && file->grf_version >= 8 && !file->cargo_list.empty()) {
 				/* Use first refittable cargo from cargo translation table */
-				byte best_local_slot = UINT8_MAX;
+				uint8_t best_local_slot = UINT8_MAX;
 				for (CargoID cargo_type : SetCargoBitIterator(ei->refit_mask)) {
-					byte local_slot = file->cargo_map[cargo_type];
+					uint8_t local_slot = file->cargo_map[cargo_type];
 					if (local_slot < best_local_slot) {
 						best_local_slot = local_slot;
 						ei->cargo_type = cargo_type;
@@ -9545,7 +9545,7 @@ static void FinaliseAirportsArray()
  * XXX: We consider GRF files trusted. It would be trivial to exploit OTTD by
  * a crafted invalid GRF file. We should tell that to the user somehow, or
  * better make this more robust in the future. */
-static void DecodeSpecialSprite(byte *buf, uint num, GrfLoadingStage stage)
+static void DecodeSpecialSprite(uint8_t *buf, uint num, GrfLoadingStage stage)
 {
 	/* XXX: There is a difference between staged loading in TTDPatch and
 	 * here.  In TTDPatch, for some reason actions 1 and 2 are carried out
@@ -9603,7 +9603,7 @@ static void DecodeSpecialSprite(byte *buf, uint num, GrfLoadingStage stage)
 	ByteReader *bufp = &br;
 
 	try {
-		byte action = bufp->ReadByte();
+		uint8_t action = bufp->ReadByte();
 
 		if (action == 0xFF) {
 			GrfMsg(2, "DecodeSpecialSprite: Unexpected data block, skipping");
@@ -9636,7 +9636,7 @@ static void LoadNewGRFFileFromFile(GRFConfig *config, GrfLoadingStage stage, Spr
 
 	Debug(grf, 2, "LoadNewGRFFile: Reading NewGRF-file '{}'", config->filename);
 
-	byte grf_container_version = file.GetContainerVersion();
+	uint8_t grf_container_version = file.GetContainerVersion();
 	if (grf_container_version == 0) {
 		Debug(grf, 7, "LoadNewGRFFile: Custom .grf has invalid format");
 		return;
@@ -9653,7 +9653,7 @@ static void LoadNewGRFFileFromFile(GRFConfig *config, GrfLoadingStage stage, Spr
 
 	if (grf_container_version >= 2) {
 		/* Read compression value. */
-		byte compression = file.ReadByte();
+		uint8_t compression = file.ReadByte();
 		if (compression != 0) {
 			Debug(grf, 7, "LoadNewGRFFile: Unsupported compression format");
 			return;
@@ -9673,10 +9673,10 @@ static void LoadNewGRFFileFromFile(GRFConfig *config, GrfLoadingStage stage, Spr
 
 	_cur.ClearDataForNextFile();
 
-	ReusableBuffer<byte> buf;
+	ReusableBuffer<uint8_t> buf;
 
 	while ((num = (grf_container_version >= 2 ? file.ReadDword() : file.ReadWord())) != 0) {
-		byte type = file.ReadByte();
+		uint8_t type = file.ReadByte();
 		_cur.nfo_line++;
 
 		if (type == 0xFF) {
@@ -10055,7 +10055,7 @@ void LoadNewGRF(uint load_index, uint num_baseset)
 	TimerGameEconomy::DateFract economy_date_fract = TimerGameEconomy::date_fract;
 
 	uint64_t tick_counter  = TimerGameTick::counter;
-	byte display_opt     = _display_opt;
+	uint8_t display_opt     = _display_opt;
 
 	if (_networking) {
 		TimerGameCalendar::year = _settings_game.game_creation.starting_year;

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -96,18 +96,18 @@ enum GrfSpecFeature {
 static const uint32_t INVALID_GRFID = 0xFFFFFFFF;
 
 struct GRFLabel {
-	byte label;
+	uint8_t label;
 	uint32_t nfo_line;
 	size_t pos;
 
-	GRFLabel(byte label, uint32_t nfo_line, size_t pos) : label(label), nfo_line(nfo_line), pos(pos) {}
+	GRFLabel(uint8_t label, uint32_t nfo_line, size_t pos) : label(label), nfo_line(nfo_line), pos(pos) {}
 };
 
 /** Dynamic data of a loaded NewGRF */
 struct GRFFile : ZeroedMemoryAllocator {
 	std::string filename;
 	uint32_t grfid;
-	byte grf_version;
+	uint8_t grf_version;
 
 	uint sound_offset;
 	uint16_t num_sounds;
@@ -188,7 +188,7 @@ struct GRFLoadedFeatures {
  */
 inline bool HasGrfMiscBit(GrfMiscBit bit)
 {
-	extern byte _misc_grf_features;
+	extern uint8_t _misc_grf_features;
 	return HasBit(_misc_grf_features, bit);
 }
 
@@ -204,7 +204,7 @@ void ResetPersistentNewGRFData();
 void GrfMsgI(int severity, const std::string &msg);
 #define GrfMsg(severity, format_string, ...) GrfMsgI(severity, fmt::format(FMT_STRING(format_string), ## __VA_ARGS__))
 
-bool GetGlobalVariable(byte param, uint32_t *value, const GRFFile *grffile);
+bool GetGlobalVariable(uint8_t param, uint32_t *value, const GRFFile *grffile);
 
 StringID MapGRFStringID(uint32_t grfid, StringID str);
 void ShowNewGRFError();

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -51,13 +51,13 @@ AirportSpec AirportSpec::specs[NUM_AIRPORTS]; ///< Airport specifications.
  * @param type index of airport
  * @return A pointer to the corresponding AirportSpec
  */
-/* static */ const AirportSpec *AirportSpec::Get(byte type)
+/* static */ const AirportSpec *AirportSpec::Get(uint8_t type)
 {
 	assert(type < lengthof(AirportSpec::specs));
 	const AirportSpec *as = &AirportSpec::specs[type];
 	if (type >= NEW_AIRPORT_OFFSET && !as->enabled) {
 		if (_airport_mngr.GetGRFID(type) == 0) return as;
-		byte subst_id = _airport_mngr.GetSubstituteID(type);
+		uint8_t subst_id = _airport_mngr.GetSubstituteID(type);
 		if (subst_id == AT_INVALID) return as;
 		as = &AirportSpec::specs[subst_id];
 	}
@@ -71,7 +71,7 @@ AirportSpec AirportSpec::specs[NUM_AIRPORTS]; ///< Airport specifications.
  * @param type index of airport
  * @return A pointer to the corresponding AirportSpec
  */
-/* static */ AirportSpec *AirportSpec::GetWithoutOverride(byte type)
+/* static */ AirportSpec *AirportSpec::GetWithoutOverride(uint8_t type)
 {
 	assert(type < lengthof(AirportSpec::specs));
 	return &AirportSpec::specs[type];
@@ -92,12 +92,12 @@ bool AirportSpec::IsAvailable() const
  * @param tile Top corner of the airport.
  * @return true iff the airport would be within the map bounds at the given tile.
  */
-bool AirportSpec::IsWithinMapBounds(byte table, TileIndex tile) const
+bool AirportSpec::IsWithinMapBounds(uint8_t table, TileIndex tile) const
 {
 	if (table >= this->num_table) return false;
 
-	byte w = this->size_x;
-	byte h = this->size_y;
+	uint8_t w = this->size_x;
+	uint8_t h = this->size_y;
 	if (this->rotation[table] == DIR_E || this->rotation[table] == DIR_W) Swap(w, h);
 
 	return TileX(tile) + w < Map::SizeX() &&
@@ -131,7 +131,7 @@ void BindAirportSpecs()
 
 void AirportOverrideManager::SetEntitySpec(AirportSpec *as)
 {
-	byte airport_id = this->AddEntityID(as->grf_prop.local_id, as->grf_prop.grffile->grfid, as->grf_prop.subst_id);
+	uint8_t airport_id = this->AddEntityID(as->grf_prop.local_id, as->grf_prop.grffile->grfid, as->grf_prop.subst_id);
 
 	if (airport_id == this->invalid_id) {
 		GrfMsg(1, "Airport.SetEntitySpec: Too many airports allocated. Ignoring.");
@@ -153,7 +153,7 @@ void AirportOverrideManager::SetEntitySpec(AirportSpec *as)
 	}
 }
 
-/* virtual */ uint32_t AirportScopeResolver::GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const
+/* virtual */ uint32_t AirportScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const
 {
 	switch (variable) {
 		case 0x40: return this->layout;
@@ -241,14 +241,14 @@ TownScopeResolver *AirportResolverObject::GetTown()
  * @param param1 First parameter (var 10) of the callback.
  * @param param2 Second parameter (var 18) of the callback.
  */
-AirportResolverObject::AirportResolverObject(TileIndex tile, Station *st, byte airport_id, byte layout,
+AirportResolverObject::AirportResolverObject(TileIndex tile, Station *st, uint8_t airport_id, uint8_t layout,
 		CallbackID callback, uint32_t param1, uint32_t param2)
 	: ResolverObject(AirportSpec::Get(airport_id)->grf_prop.grffile, callback, param1, param2), airport_scope(*this, tile, st, airport_id, layout)
 {
 	this->root_spritegroup = AirportSpec::Get(airport_id)->grf_prop.spritegroup[0];
 }
 
-SpriteID GetCustomAirportSprite(const AirportSpec *as, byte layout)
+SpriteID GetCustomAirportSprite(const AirportSpec *as, uint8_t layout)
 {
 	AirportResolverObject object(INVALID_TILE, nullptr, as->GetIndex(), layout);
 	const SpriteGroup *group = object.Resolve();
@@ -270,7 +270,7 @@ uint16_t GetAirportCallback(CallbackID callback, uint32_t param1, uint32_t param
  * @param callback The callback to call.
  * @return The custom text.
  */
-StringID GetAirportTextCallback(const AirportSpec *as, byte layout, uint16_t callback)
+StringID GetAirportTextCallback(const AirportSpec *as, uint8_t layout, uint16_t callback)
 {
 	AirportResolverObject object(INVALID_TILE, nullptr, as->GetIndex(), layout, (CallbackID)callback);
 	uint16_t cb_res = object.ResolveCallback();

--- a/src/newgrf_airport.h
+++ b/src/newgrf_airport.h
@@ -19,7 +19,7 @@
 #include "tilearea_type.h"
 
 /** Copy from station_map.h */
-typedef byte StationGfx;
+typedef uint8_t StationGfx;
 
 /** Tile-offset / AirportTileID pair. */
 struct AirportTileTable {
@@ -91,7 +91,7 @@ enum TTDPAirportType {
 struct HangarTileTable {
 	TileIndexDiffC ti; ///< Tile offset from the top-most airport tile.
 	Direction dir;     ///< Direction of the exit.
-	byte hangar_num;   ///< The hangar to which this tile belongs.
+	uint8_t hangar_num;   ///< The hangar to which this tile belongs.
 };
 
 /**
@@ -101,13 +101,13 @@ struct AirportSpec {
 	const struct AirportFTAClass *fsm;     ///< the finite statemachine for the default airports
 	const AirportTileTable * const *table; ///< list of the tiles composing the airport
 	const Direction *rotation;             ///< the rotation of each tiletable
-	byte num_table;                        ///< number of elements in the table
+	uint8_t num_table;                        ///< number of elements in the table
 	const HangarTileTable *depot_table;    ///< gives the position of the depots on the airports
-	byte nof_depots;                       ///< the number of hangar tiles in this airport
-	byte size_x;                           ///< size of airport in x direction
-	byte size_y;                           ///< size of airport in y direction
-	byte noise_level;                      ///< noise that this airport generates
-	byte catchment;                        ///< catchment area of this airport
+	uint8_t nof_depots;                       ///< the number of hangar tiles in this airport
+	uint8_t size_x;                           ///< size of airport in x direction
+	uint8_t size_y;                           ///< size of airport in y direction
+	uint8_t noise_level;                      ///< noise that this airport generates
+	uint8_t catchment;                        ///< catchment area of this airport
 	TimerGameCalendar::Year min_year;      ///< first year the airport is available
 	TimerGameCalendar::Year max_year;      ///< last year the airport is available
 	StringID name;                         ///< name of this airport
@@ -119,19 +119,19 @@ struct AirportSpec {
 	bool enabled;                          ///< Entity still available (by default true). Newgrf can disable it, though.
 	struct GRFFileProps grf_prop;          ///< Properties related to the grf file.
 
-	static const AirportSpec *Get(byte type);
-	static AirportSpec *GetWithoutOverride(byte type);
+	static const AirportSpec *Get(uint8_t type);
+	static AirportSpec *GetWithoutOverride(uint8_t type);
 
 	bool IsAvailable() const;
-	bool IsWithinMapBounds(byte table, TileIndex index) const;
+	bool IsWithinMapBounds(uint8_t table, TileIndex index) const;
 
 	static void ResetAirports();
 
 	/** Get the index of this spec. */
-	byte GetIndex() const
+	uint8_t GetIndex() const
 	{
 		assert(this >= specs && this < endof(specs));
-		return (byte)(this - specs);
+		return (uint8_t)(this - specs);
 	}
 
 	static const AirportSpec dummy; ///< The dummy airport.
@@ -148,8 +148,8 @@ void BindAirportSpecs();
 /** Resolver for the airport scope. */
 struct AirportScopeResolver : public ScopeResolver {
 	struct Station *st; ///< Station of the airport for which the callback is run, or \c nullptr for build gui.
-	byte airport_id;    ///< Type of airport for which the callback is run.
-	byte layout;        ///< Layout of the airport to build.
+	uint8_t airport_id;    ///< Type of airport for which the callback is run.
+	uint8_t layout;        ///< Layout of the airport to build.
 	TileIndex tile;     ///< Tile for the callback, only valid for airporttile callbacks.
 
 	/**
@@ -160,13 +160,13 @@ struct AirportScopeResolver : public ScopeResolver {
 	 * @param airport_id Type of airport for which the callback is run.
 	 * @param layout Layout of the airport to build.
 	 */
-	AirportScopeResolver(ResolverObject &ro, TileIndex tile, Station *st, byte airport_id, byte layout)
+	AirportScopeResolver(ResolverObject &ro, TileIndex tile, Station *st, uint8_t airport_id, uint8_t layout)
 		: ScopeResolver(ro), st(st), airport_id(airport_id), layout(layout), tile(tile)
 	{
 	}
 
 	uint32_t GetRandomBits() const override;
-	uint32_t GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
+	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
 	void StorePSA(uint pos, int32_t value) override;
 };
 
@@ -176,12 +176,12 @@ struct AirportResolverObject : public ResolverObject {
 	AirportScopeResolver airport_scope;
 	std::unique_ptr<TownScopeResolver> town_scope; ///< The town scope resolver (created on the first call).
 
-	AirportResolverObject(TileIndex tile, Station *st, byte airport_id, byte layout,
+	AirportResolverObject(TileIndex tile, Station *st, uint8_t airport_id, uint8_t layout,
 			CallbackID callback = CBID_NO_CALLBACK, uint32_t callback_param1 = 0, uint32_t callback_param2 = 0);
 
 	TownScopeResolver *GetTown();
 
-	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0) override
+	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override
 	{
 		switch (scope) {
 			case VSG_SCOPE_SELF: return &this->airport_scope;
@@ -199,6 +199,6 @@ struct AirportResolverObject : public ResolverObject {
 	uint32_t GetDebugID() const override;
 };
 
-StringID GetAirportTextCallback(const AirportSpec *as, byte layout, uint16_t callback);
+StringID GetAirportTextCallback(const AirportSpec *as, uint8_t layout, uint16_t callback);
 
 #endif /* NEWGRF_AIRPORT_H */

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -107,7 +107,7 @@ StationGfx GetTranslatedAirportTileID(StationGfx gfx)
  * @param grf_version8 True, if we are dealing with a new NewGRF which uses GRF version >= 8.
  * @return a construction of bits obeying the newgrf format
  */
-static uint32_t GetNearbyAirportTileInformation(byte parameter, TileIndex tile, StationID index, bool grf_version8)
+static uint32_t GetNearbyAirportTileInformation(uint8_t parameter, TileIndex tile, StationID index, bool grf_version8)
 {
 	if (parameter != 0) tile = GetNearbyTile(parameter, tile); // only perform if it is required
 	bool is_same_airport = (IsTileType(tile, MP_STATION) && IsAirport(tile) && GetStationIndex(tile) == index);
@@ -159,7 +159,7 @@ static uint32_t GetAirportTileIDAtOffset(TileIndex tile, const Station *st, uint
 	return 0xFF << 8 | ats->grf_prop.subst_id; // so just give it the substitute
 }
 
-/* virtual */ uint32_t AirportTileScopeResolver::GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const
+/* virtual */ uint32_t AirportTileScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const
 {
 	assert(this->st != nullptr);
 
@@ -216,7 +216,7 @@ AirportTileResolverObject::AirportTileResolverObject(const AirportTileSpec *ats,
 		CallbackID callback, uint32_t callback_param1, uint32_t callback_param2)
 	: ResolverObject(ats->grf_prop.grffile, callback, callback_param1, callback_param2),
 		tiles_scope(*this, ats, tile, st),
-		airport_scope(*this, tile, st, st != nullptr ? st->airport.type : (byte)AT_DUMMY, st != nullptr ? st->airport.layout : 0)
+		airport_scope(*this, tile, st, st != nullptr ? st->airport.type : (uint8_t)AT_DUMMY, st != nullptr ? st->airport.layout : 0)
 {
 	this->root_spritegroup = ats->grf_prop.spritegroup[0];
 }
@@ -237,7 +237,7 @@ uint16_t GetAirportTileCallback(CallbackID callback, uint32_t param1, uint32_t p
 	return object.ResolveCallback();
 }
 
-static void AirportDrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, byte colour)
+static void AirportDrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, uint8_t colour)
 {
 	const DrawTileSprites *dts = group->ProcessRegisters(nullptr);
 

--- a/src/newgrf_airporttiles.h
+++ b/src/newgrf_airporttiles.h
@@ -20,7 +20,7 @@
 /** Scope resolver for handling the tiles of an airport. */
 struct AirportTileScopeResolver : public ScopeResolver {
 	struct Station *st;  ///< %Station of the airport for which the callback is run, or \c nullptr for build gui.
-	byte airport_id;     ///< Type of airport for which the callback is run.
+	uint8_t airport_id;     ///< Type of airport for which the callback is run.
 	TileIndex tile;      ///< Tile for the callback, only valid for airporttile callbacks.
 	const AirportTileSpec *ats;
 
@@ -38,7 +38,7 @@ struct AirportTileScopeResolver : public ScopeResolver {
 	}
 
 	uint32_t GetRandomBits() const override;
-	uint32_t GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
+	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
 };
 
 /** Resolver for tiles of an airport. */
@@ -49,7 +49,7 @@ struct AirportTileResolverObject : public ResolverObject {
 	AirportTileResolverObject(const AirportTileSpec *ats, TileIndex tile, Station *st,
 			CallbackID callback = CBID_NO_CALLBACK, uint32_t callback_param1 = 0, uint32_t callback_param2 = 0);
 
-	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0) override
+	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override
 	{
 		switch (scope) {
 			case VSG_SCOPE_SELF: return &tiles_scope;

--- a/src/newgrf_animation_base.h
+++ b/src/newgrf_animation_base.h
@@ -19,8 +19,8 @@
 
 template <typename Tobj>
 struct TileAnimationFrameAnimationHelper {
-	static byte Get(Tobj *, TileIndex tile) { return GetAnimationFrame(tile); }
-	static void Set(Tobj *, TileIndex tile, byte frame) { SetAnimationFrame(tile, frame); }
+	static uint8_t Get(Tobj *, TileIndex tile) { return GetAnimationFrame(tile); }
+	static void Set(Tobj *, TileIndex tile, uint8_t frame) { SetAnimationFrame(tile, frame); }
 };
 
 /**

--- a/src/newgrf_canal.cpp
+++ b/src/newgrf_canal.cpp
@@ -30,7 +30,7 @@ struct CanalScopeResolver : public ScopeResolver {
 	}
 
 	uint32_t GetRandomBits() const override;
-	uint32_t GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
+	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
 };
 
 /** Resolver object for canals. */
@@ -41,7 +41,7 @@ struct CanalResolverObject : public ResolverObject {
 	CanalResolverObject(CanalFeature feature, TileIndex tile,
 			CallbackID callback = CBID_NO_CALLBACK, uint32_t callback_param1 = 0, uint32_t callback_param2 = 0);
 
-	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0) override
+	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override
 	{
 		switch (scope) {
 			case VSG_SCOPE_SELF: return &this->canal_scope;
@@ -59,7 +59,7 @@ struct CanalResolverObject : public ResolverObject {
 	return IsTileType(this->tile, MP_WATER) ? GetWaterTileRandomBits(this->tile) : 0;
 }
 
-/* virtual */ uint32_t CanalScopeResolver::GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const
+/* virtual */ uint32_t CanalScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const
 {
 	switch (variable) {
 		/* Height of tile */

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -403,7 +403,7 @@ uint32_t GetTerrainType(TileIndex tile, TileContext context)
  * @param axis Axis of a railways station.
  * @return The tile at the offset.
  */
-TileIndex GetNearbyTile(byte parameter, TileIndex tile, bool signed_offsets, Axis axis)
+TileIndex GetNearbyTile(uint8_t parameter, TileIndex tile, bool signed_offsets, Axis axis)
 {
 	int8_t x = GB(parameter, 0, 4);
 	int8_t y = GB(parameter, 4, 4);
@@ -435,7 +435,7 @@ uint32_t GetNearbyTileInformation(TileIndex tile, bool grf_version8)
 
 	auto [tileh, z] = GetTilePixelSlope(tile);
 	/* Return 0 if the tile is a land tile */
-	byte terrain_type = (HasTileWaterClass(tile) ? (GetWaterClass(tile) + 1) & 3 : 0) << 5 | GetTerrainType(tile) << 2 | (tile_type == MP_WATER ? 1 : 0) << 1;
+	uint8_t terrain_type = (HasTileWaterClass(tile) ? (GetWaterClass(tile) + 1) & 3 : 0) << 5 | GetTerrainType(tile) << 2 | (tile_type == MP_WATER ? 1 : 0) << 1;
 	if (grf_version8) z /= TILE_HEIGHT;
 	return tile_type << 24 | ClampTo<uint8_t>(z) << 16 | terrain_type << 8 | tileh;
 }

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -293,7 +293,7 @@ extern AirportTileOverrideManager _airporttile_mngr;
 extern ObjectOverrideManager _object_mngr;
 
 uint32_t GetTerrainType(TileIndex tile, TileContext context = TCX_NORMAL);
-TileIndex GetNearbyTile(byte parameter, TileIndex tile, bool signed_offsets = true, Axis axis = INVALID_AXIS);
+TileIndex GetNearbyTile(uint8_t parameter, TileIndex tile, bool signed_offsets = true, Axis axis = INVALID_AXIS);
 uint32_t GetNearbyTileInformation(TileIndex tile, bool grf_version8);
 uint32_t GetCompanyInfo(CompanyID owner, const struct Livery *l = nullptr);
 CommandCost GetErrorMessageFromLocationCallbackResult(uint16_t cb_res, const GRFFile *grffile, StringID default_error);

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -254,10 +254,10 @@ void UpdateNewGRFConfigPalette(int32_t)
  */
 size_t GRFGetSizeOfDataSection(FILE *f)
 {
-	extern const byte _grf_cont_v2_sig[];
+	extern const uint8_t _grf_cont_v2_sig[];
 	static const uint header_len = 14;
 
-	byte data[header_len];
+	uint8_t data[header_len];
 	if (fread(data, 1, header_len, f) == header_len) {
 		if (data[0] == 0 && data[1] == 0 && MemCmpT(data + 2, _grf_cont_v2_sig, 8) == 0) {
 			/* Valid container version 2, get data section size. */

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -132,9 +132,9 @@ struct GRFParameterInfo {
 	uint32_t min_value;      ///< The minimal value this parameter can have
 	uint32_t max_value;      ///< The maximal value of this parameter
 	uint32_t def_value;      ///< Default value of this parameter
-	byte param_nr;         ///< GRF parameter to store content in
-	byte first_bit;        ///< First bit to use in the GRF parameter
-	byte num_bit;          ///< Number of bits to use for this parameter
+	uint8_t param_nr;         ///< GRF parameter to store content in
+	uint8_t first_bit;        ///< First bit to use in the GRF parameter
+	uint8_t num_bit;          ///< Number of bits to use for this parameter
 	std::map<uint32_t, GRFTextList> value_names; ///< Names for each value.
 	bool complete_labels;  ///< True if all values have a label.
 

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -86,9 +86,9 @@ typedef const void *NIOffsetProc(const void *b);
 struct NIProperty {
 	const char *name;          ///< A (human readable) name for the property
 	NIOffsetProc *offset_proc; ///< Callback proc to get the actual variable address in memory
-	byte read_size;            ///< Number of bytes (i.e. byte, word, dword etc)
-	byte prop;                 ///< The number of the property
-	byte type;
+	uint8_t read_size;            ///< Number of bytes (i.e. byte, word, dword etc)
+	uint8_t prop;                 ///< The number of the property
+	uint8_t type;
 };
 
 
@@ -99,8 +99,8 @@ struct NIProperty {
 struct NICallback {
 	const char *name;          ///< The human readable name of the callback
 	NIOffsetProc *offset_proc; ///< Callback proc to get the actual variable address in memory
-	byte read_size;            ///< The number of bytes (i.e. byte, word, dword etc) to read
-	byte cb_bit;               ///< The bit that needs to be set for this callback to be enabled
+	uint8_t read_size;            ///< The number of bytes (i.e. byte, word, dword etc) to read
+	uint8_t cb_bit;               ///< The bit that needs to be set for this callback to be enabled
 	uint16_t cb_id;              ///< The number of the callback
 };
 /** Mask to show no bit needs to be enabled for the callback. */
@@ -109,7 +109,7 @@ static const int CBM_NO_BIT = UINT8_MAX;
 /** Representation on the NewGRF variables. */
 struct NIVariable {
 	const char *name;
-	byte var;
+	uint8_t var;
 };
 
 /** Helper class to wrap some functionality/queries in. */
@@ -284,7 +284,7 @@ struct NewGRFInspectWindow : Window {
 	uint chain_index;
 
 	/** The currently edited parameter, to update the right one. */
-	byte current_edit_param;
+	uint8_t current_edit_param;
 
 	Scrollbar *vscroll;
 

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -50,7 +50,7 @@ const SpriteGroup *GetWagonOverrideSpriteSet(EngineID engine, CargoID cargo, Eng
 	return nullptr;
 }
 
-void SetCustomEngineSprites(EngineID engine, byte cargo, const SpriteGroup *group)
+void SetCustomEngineSprites(EngineID engine, uint8_t cargo, const SpriteGroup *group)
 {
 	Engine *e = Engine::Get(engine);
 	assert(cargo < lengthof(e->grf_prop.spritegroup));
@@ -130,7 +130,7 @@ enum TTDPAircraftMovementStates {
  * Map OTTD aircraft movement states to TTDPatch style movement states
  * (VarAction 2 Variable 0xE2)
  */
-static byte MapAircraftMovementState(const Aircraft *v)
+static uint8_t MapAircraftMovementState(const Aircraft *v)
 {
 	const Station *st = GetTargetAirportIfValid(v);
 	if (st == nullptr) return AMS_TTDP_FLIGHT_TO_TOWER;
@@ -257,7 +257,7 @@ enum TTDPAircraftMovementActions {
  * (VarAction 2 Variable 0xE6)
  * This is not fully supported yet but it's enough for Planeset.
  */
-static byte MapAircraftMovementAction(const Aircraft *v)
+static uint8_t MapAircraftMovementAction(const Aircraft *v)
 {
 	switch (v->state) {
 		case HANGAR:
@@ -315,7 +315,7 @@ static byte MapAircraftMovementAction(const Aircraft *v)
 }
 
 
-/* virtual */ ScopeResolver *VehicleResolverObject::GetScope(VarSpriteGroupScope scope, byte relative)
+/* virtual */ ScopeResolver *VehicleResolverObject::GetScope(VarSpriteGroupScope scope, uint8_t relative)
 {
 	switch (scope) {
 		case VSG_SCOPE_SELF:   return &this->self_scope;
@@ -396,8 +396,8 @@ static const Livery *LiveryHelper(EngineID engine, const Vehicle *v)
 static uint32_t PositionHelper(const Vehicle *v, bool consecutive)
 {
 	const Vehicle *u;
-	byte chain_before = 0;
-	byte chain_after  = 0;
+	uint8_t chain_before = 0;
+	uint8_t chain_after  = 0;
 
 	for (u = v->First(); u != v; u = u->Next()) {
 		chain_before++;
@@ -412,7 +412,7 @@ static uint32_t PositionHelper(const Vehicle *v, bool consecutive)
 	return chain_before | chain_after << 8 | (chain_before + chain_after + consecutive) << 16;
 }
 
-static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *object, byte variable, uint32_t parameter, bool *available)
+static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *object, uint8_t variable, uint32_t parameter, bool *available)
 {
 	/* Calculated vehicle parameters */
 	switch (variable) {
@@ -436,8 +436,8 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 		case 0x42: { // Consist cargo information
 			if (!HasBit(v->grf_cache.cache_valid, NCVV_CONSIST_CARGO_INFORMATION)) {
 				std::array<uint8_t, NUM_CARGO> common_cargoes{};
-				byte cargo_classes = 0;
-				byte user_def_data = 0;
+				uint8_t cargo_classes = 0;
+				uint8_t user_def_data = 0;
 
 				for (const Vehicle *u = v; u != nullptr; u = u->Next()) {
 					if (v->type == VEH_TRAIN) user_def_data |= Train::From(u)->tcache.user_def_data;
@@ -506,7 +506,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 				const Vehicle *w = v->Next();
 				assert(w != nullptr);
 				uint16_t altitude = ClampTo<uint16_t>(v->z_pos - w->z_pos); // Aircraft height - shadow height
-				byte airporttype = ATP_TTDP_LARGE;
+				uint8_t airporttype = ATP_TTDP_LARGE;
 
 				const Station *st = GetTargetAirportIfValid(Aircraft::From(v));
 
@@ -590,9 +590,9 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 
 		case 0x4D: // Position within articulated vehicle
 			if (!HasBit(v->grf_cache.cache_valid, NCVV_POSITION_IN_VEHICLE)) {
-				byte artic_before = 0;
+				uint8_t artic_before = 0;
 				for (const Vehicle *u = v; u->IsArticulatedPart(); u = u->Previous()) artic_before++;
-				byte artic_after = 0;
+				uint8_t artic_after = 0;
 				for (const Vehicle *u = v; u->HasArticulatedPart(); u = u->Next()) artic_after++;
 				v->grf_cache.position_in_vehicle = artic_before | artic_after << 8;
 				SetBit(v->grf_cache.cache_valid, NCVV_POSITION_IN_VEHICLE);
@@ -939,7 +939,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 	return UINT_MAX;
 }
 
-/* virtual */ uint32_t VehicleScopeResolver::GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const
+/* virtual */ uint32_t VehicleScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const
 {
 	if (this->v == nullptr) {
 		/* Vehicle does not exist, so we're in a purchase list */

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -39,7 +39,7 @@ struct VehicleScopeResolver : public ScopeResolver {
 	void SetVehicle(const Vehicle *v) { this->v = v; }
 
 	uint32_t GetRandomBits() const override;
-	uint32_t GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
+	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
 	uint32_t GetTriggers() const override;
 };
 
@@ -57,12 +57,12 @@ struct VehicleResolverObject : public ResolverObject {
 	VehicleScopeResolver parent_scope;   ///< Scope resolver for its parent vehicle.
 
 	VehicleScopeResolver relative_scope; ///< Scope resolver for an other vehicle in the chain.
-	byte cached_relative_count;          ///< Relative position of the other vehicle.
+	uint8_t cached_relative_count;          ///< Relative position of the other vehicle.
 
 	VehicleResolverObject(EngineID engine_type, const Vehicle *v, WagonOverride wagon_override, bool rotor_in_gui = false,
 			CallbackID callback = CBID_NO_CALLBACK, uint32_t callback_param1 = 0, uint32_t callback_param2 = 0);
 
-	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0) override;
+	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override;
 
 	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
 
@@ -78,7 +78,7 @@ struct VehicleSpriteSeq;
 
 void SetWagonOverrideSprites(EngineID engine, CargoID cargo, const struct SpriteGroup *group, EngineID *train_id, uint trains);
 const SpriteGroup *GetWagonOverrideSpriteSet(EngineID engine, CargoID cargo, EngineID overriding_engine);
-void SetCustomEngineSprites(EngineID engine, byte cargo, const struct SpriteGroup *group);
+void SetCustomEngineSprites(EngineID engine, uint8_t cargo, const struct SpriteGroup *group);
 
 void GetCustomEngineSprite(EngineID engine, const Vehicle *v, Direction direction, EngineImageType image_type, VehicleSpriteSeq *result);
 #define GetCustomVehicleSprite(v, direction, image_type, result) GetCustomEngineSprite(v->engine_type, v, direction, image_type, result)

--- a/src/newgrf_generic.cpp
+++ b/src/newgrf_generic.cpp
@@ -41,7 +41,7 @@ struct GenericScopeResolver : public ScopeResolver {
 	{
 	}
 
-	uint32_t GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
+	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
 
 private:
 	bool ai_callback; ///< Callback comes from the AI.
@@ -54,7 +54,7 @@ struct GenericResolverObject : public ResolverObject {
 
 	GenericResolverObject(bool ai_callback, CallbackID callback = CBID_NO_CALLBACK);
 
-	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0) override
+	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override
 	{
 		switch (scope) {
 			case VSG_SCOPE_SELF: return &this->generic_scope;
@@ -118,7 +118,7 @@ void AddGenericCallback(uint8_t feature, const GRFFile *file, const SpriteGroup 
 	_gcl[feature].push_front(GenericCallback(file, group));
 }
 
-/* virtual */ uint32_t GenericScopeResolver::GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const
+/* virtual */ uint32_t GenericScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const
 {
 	if (this->ai_callback) {
 		switch (variable) {

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -77,7 +77,7 @@ void ResetHouseClassIDs()
 	_class_mapping = {};
 }
 
-HouseClassID AllocateHouseClassID(byte grf_class_id, uint32_t grfid)
+HouseClassID AllocateHouseClassID(uint8_t grf_class_id, uint32_t grfid)
 {
 	/* Start from 1 because 0 means that no class has been assigned. */
 	for (int i = 1; i != lengthof(_class_mapping); i++) {
@@ -174,7 +174,7 @@ static uint32_t GetNumHouses(HouseID house_id, const Town *town)
  * @param grf_version8 True, if we are dealing with a new NewGRF which uses GRF version >= 8.
  * @return a construction of bits obeying the newgrf format
  */
-static uint32_t GetNearbyTileInformation(byte parameter, TileIndex tile, bool grf_version8)
+static uint32_t GetNearbyTileInformation(uint8_t parameter, TileIndex tile, bool grf_version8)
 {
 	tile = GetNearbyTile(parameter, tile);
 	return GetNearbyTileInformation(tile, grf_version8);
@@ -294,7 +294,7 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex tile, Ho
 /**
  * @note Used by the resolver to get values for feature 07 deterministic spritegroups.
  */
-/* virtual */ uint32_t HouseScopeResolver::GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const
+/* virtual */ uint32_t HouseScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const
 {
 	switch (variable) {
 		/* Construction stage. */
@@ -424,7 +424,7 @@ uint16_t GetHouseCallback(CallbackID callback, uint32_t param1, uint32_t param2,
 	return object.ResolveCallback();
 }
 
-static void DrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, byte stage, HouseID house_id)
+static void DrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, uint8_t stage, HouseID house_id)
 {
 	const DrawTileSprites *dts = group->ProcessRegisters(&stage);
 
@@ -472,7 +472,7 @@ void DrawNewHouseTile(TileInfo *ti, HouseID house_id)
 	if (group != nullptr && group->type == SGT_TILELAYOUT) {
 		/* Limit the building stage to the number of stages supplied. */
 		const TileLayoutSpriteGroup *tlgroup = (const TileLayoutSpriteGroup *)group;
-		byte stage = GetHouseBuildingStage(ti->tile);
+		uint8_t stage = GetHouseBuildingStage(ti->tile);
 		DrawTileLayout(ti, tlgroup, stage, house_id);
 	}
 }
@@ -580,7 +580,7 @@ bool NewHouseTileLoop(TileIndex tile)
 	return true;
 }
 
-static void DoTriggerHouse(TileIndex tile, HouseTrigger trigger, byte base_random, bool first)
+static void DoTriggerHouse(TileIndex tile, HouseTrigger trigger, uint8_t base_random, bool first)
 {
 	/* We can't trigger a non-existent building... */
 	assert(IsTileType(tile, MP_HOUSE));
@@ -601,8 +601,8 @@ static void DoTriggerHouse(TileIndex tile, HouseTrigger trigger, byte base_rando
 	SetHouseTriggers(tile, object.GetRemainingTriggers());
 
 	/* Rerandomise bits. Scopes other than SELF are invalid for houses. For bug-to-bug-compatibility with TTDP we ignore the scope. */
-	byte new_random_bits = Random();
-	byte random_bits = GetHouseRandomBits(tile);
+	uint8_t new_random_bits = Random();
+	uint8_t random_bits = GetHouseRandomBits(tile);
 	uint32_t reseed = object.GetReseedSum();
 	random_bits &= ~reseed;
 	random_bits |= (first ? new_random_bits : base_random) & reseed;

--- a/src/newgrf_house.h
+++ b/src/newgrf_house.h
@@ -43,7 +43,7 @@ struct HouseScopeResolver : public ScopeResolver {
 	}
 
 	uint32_t GetRandomBits() const override;
-	uint32_t GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
+	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
 	uint32_t GetTriggers() const override;
 };
 
@@ -56,7 +56,7 @@ struct HouseResolverObject : public ResolverObject {
 			CallbackID callback = CBID_NO_CALLBACK, uint32_t param1 = 0, uint32_t param2 = 0,
 			bool not_yet_constructed = false, uint8_t initial_random_bits = 0, CargoTypes watched_cargo_triggers = 0);
 
-	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0) override
+	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override
 	{
 		switch (scope) {
 			case VSG_SCOPE_SELF:   return &this->house_scope;
@@ -88,7 +88,7 @@ struct HouseClassMapping {
 };
 
 void ResetHouseClassIDs();
-HouseClassID AllocateHouseClassID(byte grf_class_id, uint32_t grfid);
+HouseClassID AllocateHouseClassID(uint8_t grf_class_id, uint32_t grfid);
 
 void InitializeBuildingCounts();
 void IncreaseBuildingCount(Town *t, HouseID house_id);

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -111,12 +111,12 @@ static uint32_t GetClosestIndustry(TileIndex tile, IndustryType type, const Indu
  * @param current Industry for which the inquiry is made
  * @return the formatted answer to the callback : rr(reserved) cc(count) dddd(manhattan distance of closest sister)
  */
-static uint32_t GetCountAndDistanceOfClosestInstance(byte param_setID, byte layout_filter, bool town_filter, const Industry *current)
+static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t param_setID, uint8_t layout_filter, bool town_filter, const Industry *current)
 {
 	uint32_t GrfID = GetRegister(0x100);  ///< Get the GRFID of the definition to look for in register 100h
 	IndustryType ind_index;
 	uint32_t closest_dist = UINT32_MAX;
-	byte count = 0;
+	uint8_t count = 0;
 
 	/* Determine what will be the industry type to look for */
 	switch (GrfID) {
@@ -141,7 +141,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(byte param_setID, byte layo
 		/* If the filter is 0, it could be because none was specified as well as being really a 0.
 		 * In either case, just do the regular var67 */
 		closest_dist = GetClosestIndustry(current->location.tile, ind_index, current);
-		count = ClampTo<byte>(Industry::GetIndustryTypeCount(ind_index));
+		count = ClampTo<uint8_t>(Industry::GetIndustryTypeCount(ind_index));
 	} else {
 		/* Count only those who match the same industry type and layout filter
 		 * Unfortunately, we have to do it manually */
@@ -156,7 +156,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(byte param_setID, byte layo
 	return count << 16 | GB(closest_dist, 0, 16);
 }
 
-/* virtual */ uint32_t IndustriesScopeResolver::GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const
+/* virtual */ uint32_t IndustriesScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const
 {
 	if (this->ro.callback == CBID_INDUSTRY_LOCATION) {
 		/* Variables available during construction check. */
@@ -233,7 +233,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(byte param_setID, byte layo
 
 		/* Company info */
 		case 0x45: {
-			byte colours = 0;
+			uint8_t colours = 0;
 			bool is_ai = false;
 
 			const Company *c = Company::GetIfValid(this->industry->founder);
@@ -298,7 +298,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(byte param_setID, byte layo
 		 * 68 is the same as 67, but with a filtering on selected layout */
 		case 0x67:
 		case 0x68: {
-			byte layout_filter = 0;
+			uint8_t layout_filter = 0;
 			bool town_filter = false;
 			if (variable == 0x68) {
 				uint32_t reg = GetRegister(0x101);
@@ -545,7 +545,7 @@ CommandCost CheckIfCallBackAllowsCreation(TileIndex tile, IndustryType type, siz
 	ind.location.tile = tile;
 	ind.location.w = 0; // important to mark the industry invalid
 	ind.type = type;
-	ind.selected_layout = (byte)layout;
+	ind.selected_layout = (uint8_t)layout;
 	ind.town = ClosestTownFromTile(tile, UINT_MAX);
 	ind.random = initial_random_bits;
 	ind.founder = founder;

--- a/src/newgrf_industries.h
+++ b/src/newgrf_industries.h
@@ -33,7 +33,7 @@ struct IndustriesScopeResolver : public ScopeResolver {
 	}
 
 	uint32_t GetRandomBits() const override;
-	uint32_t GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
+	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
 	uint32_t GetTriggers() const override;
 	void StorePSA(uint pos, int32_t value) override;
 };
@@ -49,7 +49,7 @@ struct IndustriesResolverObject : public ResolverObject {
 
 	TownScopeResolver *GetTown();
 
-	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0) override
+	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override
 	{
 		switch (scope) {
 			case VSG_SCOPE_SELF: return &industries_scope;
@@ -97,6 +97,6 @@ bool IndustryTemporarilyRefusesCargo(Industry *ind, CargoID cargo_type);
 IndustryType MapNewGRFIndustryType(IndustryType grf_type, uint32_t grf_id);
 
 /* in newgrf_industrytiles.cpp*/
-uint32_t GetNearbyIndustryTileInformation(byte parameter, TileIndex tile, IndustryID index, bool signed_offsets, bool grf_version8);
+uint32_t GetNearbyIndustryTileInformation(uint8_t parameter, TileIndex tile, IndustryID index, bool signed_offsets, bool grf_version8);
 
 #endif /* NEWGRF_INDUSTRIES_H */

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -31,7 +31,7 @@
  * @param grf_version8 True, if we are dealing with a new NewGRF which uses GRF version >= 8.
  * @return a construction of bits obeying the newgrf format
  */
-uint32_t GetNearbyIndustryTileInformation(byte parameter, TileIndex tile, IndustryID index, bool signed_offsets, bool grf_version8)
+uint32_t GetNearbyIndustryTileInformation(uint8_t parameter, TileIndex tile, IndustryID index, bool signed_offsets, bool grf_version8)
 {
 	if (parameter != 0) tile = GetNearbyTile(parameter, tile, signed_offsets); // only perform if it is required
 	bool is_same_industry = (IsTileType(tile, MP_INDUSTRY) && GetIndustryIndex(tile) == index);
@@ -52,13 +52,13 @@ uint32_t GetNearbyIndustryTileInformation(byte parameter, TileIndex tile, Indust
  */
 uint32_t GetRelativePosition(TileIndex tile, TileIndex ind_tile)
 {
-	byte x = TileX(tile) - TileX(ind_tile);
-	byte y = TileY(tile) - TileY(ind_tile);
+	uint8_t x = TileX(tile) - TileX(ind_tile);
+	uint8_t y = TileY(tile) - TileY(ind_tile);
 
 	return ((y & 0xF) << 20) | ((x & 0xF) << 16) | (y << 8) | x;
 }
 
-/* virtual */ uint32_t IndustryTileScopeResolver::GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const
+/* virtual */ uint32_t IndustryTileScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const
 {
 	switch (variable) {
 		/* Construction state of the tile: a value between 0 and 3 */
@@ -155,7 +155,7 @@ uint32_t IndustryTileResolverObject::GetDebugID() const
 	return GetIndustryTileSpec(gfx)->grf_prop.local_id;
 }
 
-static void IndustryDrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, byte rnd_colour, byte stage)
+static void IndustryDrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, uint8_t rnd_colour, uint8_t stage)
 {
 	const DrawTileSprites *dts = group->ProcessRegisters(&stage);
 
@@ -207,7 +207,7 @@ bool DrawNewIndustryTile(TileInfo *ti, Industry *i, IndustryGfx gfx, const Indus
 
 	/* Limit the building stage to the number of stages supplied. */
 	const TileLayoutSpriteGroup *tlgroup = (const TileLayoutSpriteGroup *)group;
-	byte stage = GetIndustryConstructionStage(ti->tile);
+	uint8_t stage = GetIndustryConstructionStage(ti->tile);
 	IndustryDrawTileLayout(ti, tlgroup, i->random_colour, stage);
 	return true;
 }
@@ -327,8 +327,8 @@ static void DoTriggerIndustryTile(TileIndex tile, IndustryTileTrigger trigger, I
 	SetIndustryTriggers(tile, object.GetRemainingTriggers());
 
 	/* Rerandomise tile bits */
-	byte new_random_bits = Random();
-	byte random_bits = GetIndustryRandomBits(tile);
+	uint8_t new_random_bits = Random();
+	uint8_t random_bits = GetIndustryRandomBits(tile);
 	random_bits &= ~object.reseed[VSG_SCOPE_SELF];
 	random_bits |= new_random_bits & object.reseed[VSG_SCOPE_SELF];
 	SetIndustryRandomBits(tile, random_bits);

--- a/src/newgrf_industrytiles.h
+++ b/src/newgrf_industrytiles.h
@@ -31,7 +31,7 @@ struct IndustryTileScopeResolver : public ScopeResolver {
 	}
 
 	uint32_t GetRandomBits() const override;
-	uint32_t GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
+	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
 	uint32_t GetTriggers() const override;
 };
 
@@ -44,7 +44,7 @@ struct IndustryTileResolverObject : public ResolverObject {
 	IndustryTileResolverObject(IndustryGfx gfx, TileIndex tile, Industry *indus,
 			CallbackID callback = CBID_NO_CALLBACK, uint32_t callback_param1 = 0, uint32_t callback_param2 = 0);
 
-	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0) override
+	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override
 	{
 		switch (scope) {
 			case VSG_SCOPE_SELF: return &indtile_scope;

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -191,7 +191,7 @@ static uint32_t GetObjectIDAtOffset(TileIndex tile, uint32_t cur_grfid)
  * @param grf_version8 True, if we are dealing with a new NewGRF which uses GRF version >= 8.
  * @return a construction of bits obeying the newgrf format
  */
-static uint32_t GetNearbyObjectTileInformation(byte parameter, TileIndex tile, ObjectID index, bool grf_version8)
+static uint32_t GetNearbyObjectTileInformation(uint8_t parameter, TileIndex tile, ObjectID index, bool grf_version8)
 {
 	if (parameter != 0) tile = GetNearbyTile(parameter, tile); // only perform if it is required
 	bool is_same_object = (IsTileType(tile, MP_OBJECT) && GetObjectIndex(tile) == index);
@@ -226,7 +226,7 @@ static uint32_t GetClosestObject(TileIndex tile, ObjectType type, const Object *
  * @param current  Object for which the inquiry is made
  * @return The formatted answer to the callback : rr(reserved) cc(count) dddd(manhattan distance of closest sister)
  */
-static uint32_t GetCountAndDistanceOfClosestInstance(byte local_id, uint32_t grfid, TileIndex tile, const Object *current)
+static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t local_id, uint32_t grfid, TileIndex tile, const Object *current)
 {
 	uint32_t grf_id = GetRegister(0x100);  // Get the GRFID of the definition to look for in register 100h
 	uint32_t idx;
@@ -253,7 +253,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(byte local_id, uint32_t grf
 }
 
 /** Used by the resolver to get values for feature 0F deterministic spritegroups. */
-/* virtual */ uint32_t ObjectScopeResolver::GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const
+/* virtual */ uint32_t ObjectScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const
 {
 	/* We get the town from the object, or we calculate the closest
 	 * town if we need to when there's no object. */

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -127,7 +127,7 @@ struct ObjectScopeResolver : public ScopeResolver {
 	}
 
 	uint32_t GetRandomBits() const override;
-	uint32_t GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
+	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
 };
 
 /** A resolver object to be used with feature 0F spritegroups. */
@@ -139,7 +139,7 @@ struct ObjectResolverObject : public ResolverObject {
 			CallbackID callback = CBID_NO_CALLBACK, uint32_t param1 = 0, uint32_t param2 = 0);
 	~ObjectResolverObject();
 
-	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0) override
+	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override
 	{
 		switch (scope) {
 			case VSG_SCOPE_SELF:

--- a/src/newgrf_railtype.cpp
+++ b/src/newgrf_railtype.cpp
@@ -23,7 +23,7 @@
 	return GB(tmp, 0, 2);
 }
 
-/* virtual */ uint32_t RailTypeScopeResolver::GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const
+/* virtual */ uint32_t RailTypeScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const
 {
 	if (this->tile == INVALID_TILE) {
 		switch (variable) {

--- a/src/newgrf_railtype.h
+++ b/src/newgrf_railtype.h
@@ -32,7 +32,7 @@ struct RailTypeScopeResolver : public ScopeResolver {
 	}
 
 	uint32_t GetRandomBits() const override;
-	uint32_t GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
+	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
 };
 
 /** Resolver object for rail types. */
@@ -41,7 +41,7 @@ struct RailTypeResolverObject : public ResolverObject {
 
 	RailTypeResolverObject(const RailTypeInfo *rti, TileIndex tile, TileContext context, RailTypeSpriteGroup rtsg, uint32_t param1 = 0, uint32_t param2 = 0);
 
-	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0) override
+	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override
 	{
 		switch (scope) {
 			case VSG_SCOPE_SELF: return &this->railtype_scope;

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -63,7 +63,7 @@ uint32_t RoadStopScopeResolver::GetTriggers() const
 	return this->st == nullptr ? 0 : this->st->waiting_triggers;
 }
 
-uint32_t RoadStopScopeResolver::GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const
+uint32_t RoadStopScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const
 {
 	auto get_road_type_variable = [&](RoadTramType rtt) -> uint32_t {
 		RoadType rt;
@@ -328,8 +328,8 @@ uint16_t GetAnimRoadStopCallback(CallbackID callback, uint32_t param1, uint32_t 
 }
 
 struct RoadStopAnimationFrameAnimationHelper {
-	static byte Get(BaseStation *st, TileIndex tile) { return st->GetRoadStopAnimationFrame(tile); }
-	static void Set(BaseStation *st, TileIndex tile, byte frame) { st->SetRoadStopAnimationFrame(tile, frame); }
+	static uint8_t Get(BaseStation *st, TileIndex tile) { return st->GetRoadStopAnimationFrame(tile); }
+	static void Set(BaseStation *st, TileIndex tile, uint8_t frame) { st->SetRoadStopAnimationFrame(tile, frame); }
 };
 
 /** Helper class for animation control. */
@@ -564,7 +564,7 @@ int AllocateSpecToRoadStop(const RoadStopSpec *statspec, BaseStation *st, bool e
 	return i;
 }
 
-void DeallocateSpecFromRoadStop(BaseStation *st, byte specindex)
+void DeallocateSpecFromRoadStop(BaseStation *st, uint8_t specindex)
 {
 	/* specindex of 0 (default) is never freeable */
 	if (specindex == 0) return;

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -22,7 +22,7 @@
 /** The maximum amount of roadstops a single GRF is allowed to add */
 static const int NUM_ROADSTOPS_PER_GRF = UINT16_MAX - 1;
 
-enum RoadStopClassID : byte {
+enum RoadStopClassID : uint8_t {
 	ROADSTOP_CLASS_BEGIN = 0,    ///< The lowest valid value
 	ROADSTOP_CLASS_DFLT = 0,     ///< Default road stop class.
 	ROADSTOP_CLASS_WAYP,         ///< Waypoint class (unimplemented: this is reserved for future use with road waypoints).
@@ -43,7 +43,7 @@ enum RoadStopRandomTrigger {
  * Various different options for availability, restricting
  * the roadstop to be only for busses or for trucks.
  */
-enum RoadStopAvailabilityType : byte {
+enum RoadStopAvailabilityType : uint8_t {
 	ROADSTOPTYPE_PASSENGER,    ///< This RoadStop is for passenger (bus) stops.
 	ROADSTOPTYPE_FREIGHT,      ///< This RoadStop is for freight (truck) stops.
 	ROADSTOPTYPE_ALL,          ///< This RoadStop is for both types of station road stops.
@@ -55,7 +55,7 @@ enum RoadStopAvailabilityType : byte {
  * Different draw modes to disallow rendering of some parts of the stop
  * or road.
  */
-enum RoadStopDrawMode : byte {
+enum RoadStopDrawMode : uint8_t {
 	ROADSTOP_DRAW_MODE_NONE        = 0,
 	ROADSTOP_DRAW_MODE_ROAD        = 1 << 0, ///< Bay stops: Draw the road itself
 	ROADSTOP_DRAW_MODE_OVERLAY     = 1 << 1, ///< Drive-through stops: Draw the road overlay, e.g. pavement
@@ -89,7 +89,7 @@ struct RoadStopScopeResolver : public ScopeResolver {
 	uint32_t GetRandomBits() const override;
 	uint32_t GetTriggers() const override;
 
-	uint32_t GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
+	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
 };
 
 /** Road stop resolver. */
@@ -100,7 +100,7 @@ struct RoadStopResolverObject : public ResolverObject {
 	RoadStopResolverObject(const RoadStopSpec *roadstopspec, BaseStation *st, TileIndex tile, RoadType roadtype, StationType type, uint8_t view, CallbackID callback = CBID_NO_CALLBACK, uint32_t param1 = 0, uint32_t param2 = 0);
 	~RoadStopResolverObject();
 
-	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0) override
+	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override
 	{
 		switch (scope) {
 			case VSG_SCOPE_SELF: return &this->roadstop_scope;
@@ -140,8 +140,8 @@ struct RoadStopSpec {
 
 	AnimationInfo animation;
 
-	byte bridge_height[6];             ///< Minimum height for a bridge above, 0 for none
-	byte bridge_disallowed_pillars[6]; ///< Disallowed pillar flags for a bridge above
+	uint8_t bridge_height[6];             ///< Minimum height for a bridge above, 0 for none
+	uint8_t bridge_disallowed_pillars[6]; ///< Disallowed pillar flags for a bridge above
 
 	uint8_t build_cost_multiplier = 16;  ///< Build cost multiplier per tile.
 	uint8_t clear_cost_multiplier = 16;  ///< Clear cost multiplier per tile.
@@ -178,7 +178,7 @@ bool GetIfStopIsForType(const RoadStopSpec *roadstopspec, RoadStopType rs, RoadT
 
 const RoadStopSpec *GetRoadStopSpec(TileIndex t);
 int AllocateSpecToRoadStop(const RoadStopSpec *statspec, BaseStation *st, bool exec);
-void DeallocateSpecFromRoadStop(BaseStation *st, byte specindex);
+void DeallocateSpecFromRoadStop(BaseStation *st, uint8_t specindex);
 void RoadStopUpdateCachedTriggers(BaseStation *st);
 
 #endif /* NEWGRF_ROADSTATION_H */

--- a/src/newgrf_roadtype.cpp
+++ b/src/newgrf_roadtype.cpp
@@ -23,7 +23,7 @@
 	return GB(tmp, 0, 2);
 }
 
-/* virtual */ uint32_t RoadTypeScopeResolver::GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const
+/* virtual */ uint32_t RoadTypeScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const
 {
 	if (this->tile == INVALID_TILE) {
 		switch (variable) {

--- a/src/newgrf_roadtype.h
+++ b/src/newgrf_roadtype.h
@@ -33,7 +33,7 @@ struct RoadTypeScopeResolver : public ScopeResolver {
 	}
 
 	uint32_t GetRandomBits() const override;
-	uint32_t GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
+	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
 };
 
 /** Resolver object for road types. */
@@ -42,7 +42,7 @@ struct RoadTypeResolverObject : public ResolverObject {
 
 	RoadTypeResolverObject(const RoadTypeInfo *rti, TileIndex tile, TileContext context, RoadTypeSpriteGroup rtsg, uint32_t param1 = 0, uint32_t param2 = 0);
 
-	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0) override
+	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override
 	{
 		switch (scope) {
 			case VSG_SCOPE_SELF: return &this->roadtype_scope;

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -53,7 +53,7 @@ TemporaryStorageArray<int32_t, 0x110> _temp_store;
 	}
 }
 
-static inline uint32_t GetVariable(const ResolverObject &object, ScopeResolver *scope, byte variable, uint32_t parameter, bool *available)
+static inline uint32_t GetVariable(const ResolverObject &object, ScopeResolver *scope, uint8_t variable, uint32_t parameter, bool *available)
 {
 	uint32_t value;
 	switch (variable) {
@@ -103,7 +103,7 @@ static inline uint32_t GetVariable(const ResolverObject &object, ScopeResolver *
  * @param[out] available Set to false, in case the variable does not exist.
  * @return Value
  */
-/* virtual */ uint32_t ScopeResolver::GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const
+/* virtual */ uint32_t ScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const
 {
 	Debug(grf, 1, "Unhandled scope variable 0x{:X}", variable);
 	*available = false;
@@ -132,7 +132,7 @@ static inline uint32_t GetVariable(const ResolverObject &object, ScopeResolver *
  * Get a resolver for the \a scope.
  * @return The resolver for the requested scope.
  */
-/* virtual */ ScopeResolver *ResolverObject::GetScope(VarSpriteGroupScope, byte)
+/* virtual */ ScopeResolver *ResolverObject::GetScope(VarSpriteGroupScope, uint8_t)
 {
 	return &this->default_scope;
 }
@@ -258,7 +258,7 @@ const SpriteGroup *RandomizedSpriteGroup::Resolve(ResolverObject &object) const
 	ScopeResolver *scope = object.GetScope(this->var_scope, this->count);
 	if (object.callback == CBID_RANDOM_TRIGGER) {
 		/* Handle triggers */
-		byte match = this->triggers & object.waiting_triggers;
+		uint8_t match = this->triggers & object.waiting_triggers;
 		bool res = (this->cmp_mode == RSG_CMP_ANY) ? (match != 0) : (match == this->triggers);
 
 		if (res) {
@@ -268,7 +268,7 @@ const SpriteGroup *RandomizedSpriteGroup::Resolve(ResolverObject &object) const
 	}
 
 	uint32_t mask = ((uint)this->groups.size() - 1) << this->lowest_randbit;
-	byte index = (scope->GetRandomBits() & mask) >> this->lowest_randbit;
+	uint8_t index = (scope->GetRandomBits() & mask) >> this->lowest_randbit;
 
 	return SpriteGroup::Resolve(this->groups[index], object, false);
 }

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -67,7 +67,7 @@ public:
 	SpriteGroupType type;
 
 	virtual SpriteID GetResult() const { return 0; }
-	virtual byte GetNumResults() const { return 0; }
+	virtual uint8_t GetNumResults() const { return 0; }
 	virtual uint16_t GetCallbackResult() const { return CALLBACK_FAILED; }
 
 	static const SpriteGroup *Resolve(const SpriteGroup *group, ResolverObject &object, bool top_level = true);
@@ -147,9 +147,9 @@ enum DeterministicSpriteGroupAdjustOperation {
 struct DeterministicSpriteGroupAdjust {
 	DeterministicSpriteGroupAdjustOperation operation;
 	DeterministicSpriteGroupAdjustType type;
-	byte variable;
-	byte parameter; ///< Used for variables between 0x60 and 0x7F inclusive.
-	byte shift_num;
+	uint8_t variable;
+	uint8_t parameter; ///< Used for variables between 0x60 and 0x7F inclusive.
+	uint8_t shift_num;
 	uint32_t and_mask;
 	uint32_t add_val;
 	uint32_t divmod_val;
@@ -193,10 +193,10 @@ struct RandomizedSpriteGroup : SpriteGroup {
 	VarSpriteGroupScope var_scope;  ///< Take this object:
 
 	RandomizedSpriteGroupCompareMode cmp_mode; ///< Check for these triggers:
-	byte triggers;
-	byte count;
+	uint8_t triggers;
+	uint8_t count;
 
-	byte lowest_randbit; ///< Look for this in the per-object randomized bitmask:
+	uint8_t lowest_randbit; ///< Look for this in the per-object randomized bitmask:
 
 	std::vector<const SpriteGroup *> groups; ///< Take the group with appropriate index:
 
@@ -240,7 +240,7 @@ struct ResultSpriteGroup : SpriteGroup {
 	 * @param num_sprites The number of sprites per set.
 	 * @return A spritegroup representing the sprite number result.
 	 */
-	ResultSpriteGroup(SpriteID sprite, byte num_sprites) :
+	ResultSpriteGroup(SpriteID sprite, uint8_t num_sprites) :
 		SpriteGroup(SGT_RESULT),
 		sprite(sprite),
 		num_sprites(num_sprites)
@@ -248,9 +248,9 @@ struct ResultSpriteGroup : SpriteGroup {
 	}
 
 	SpriteID sprite;
-	byte num_sprites;
+	uint8_t num_sprites;
 	SpriteID GetResult() const override { return this->sprite; }
-	byte GetNumResults() const override { return this->num_sprites; }
+	uint8_t GetNumResults() const override { return this->num_sprites; }
 };
 
 /**
@@ -294,7 +294,7 @@ struct ScopeResolver {
 	virtual uint32_t GetRandomBits() const;
 	virtual uint32_t GetTriggers() const;
 
-	virtual uint32_t GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const;
+	virtual uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const;
 	virtual void StorePSA(uint reg, int32_t value);
 };
 
@@ -356,7 +356,7 @@ struct ResolverObject {
 
 	virtual const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const;
 
-	virtual ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0);
+	virtual ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0);
 
 	/**
 	 * Returns the waiting triggers that did not trigger any rerandomisation.

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -100,7 +100,7 @@ struct ETileArea : TileArea {
  * if centered, C/P start from the centre and c/p are not available.
  * @return Platform information in bit-stuffed format.
  */
-uint32_t GetPlatformInfo(Axis axis, byte tile, int platforms, int length, int x, int y, bool centred)
+uint32_t GetPlatformInfo(Axis axis, uint8_t tile, int platforms, int length, int x, int y, bool centred)
 {
 	uint32_t retval = 0;
 
@@ -140,7 +140,7 @@ uint32_t GetPlatformInfo(Axis axis, byte tile, int platforms, int length, int x,
  */
 static TileIndex FindRailStationEnd(TileIndex tile, TileIndexDiff delta, bool check_type, bool check_axis)
 {
-	byte orig_type = 0;
+	uint8_t orig_type = 0;
 	Axis orig_axis = AXIS_X;
 	StationID sid = GetStationIndex(tile);
 
@@ -266,7 +266,7 @@ TownScopeResolver *StationResolverObject::GetTown()
 	return this->town_scope;
 }
 
-/* virtual */ uint32_t StationScopeResolver::GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const
+/* virtual */ uint32_t StationScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const
 {
 	if (this->st == nullptr) {
 		/* Station does not exist, so we're in a purchase list or the land slope check callback. */
@@ -403,7 +403,7 @@ TownScopeResolver *StationResolverObject::GetTown()
 	return this->st->GetNewGRFVariable(this->ro, variable, parameter, available);
 }
 
-uint32_t Station::GetNewGRFVariable(const ResolverObject &object, byte variable, byte parameter, bool *available) const
+uint32_t Station::GetNewGRFVariable(const ResolverObject &object, uint8_t variable, uint8_t parameter, bool *available) const
 {
 	switch (variable) {
 		case 0x48: { // Accepted cargo types
@@ -469,7 +469,7 @@ uint32_t Station::GetNewGRFVariable(const ResolverObject &object, byte variable,
 	return UINT_MAX;
 }
 
-uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, byte variable, [[maybe_unused]] byte parameter, bool *available) const
+uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, uint8_t variable, [[maybe_unused]] uint8_t parameter, bool *available) const
 {
 	switch (variable) {
 		case 0x48: return 0; // Accepted cargo types
@@ -658,7 +658,7 @@ uint16_t GetStationCallback(CallbackID callback, uint32_t param1, uint32_t param
  * @param numtracks Number of platforms.
  * @return Succeeded or failed command.
  */
-CommandCost PerformStationTileSlopeCheck(TileIndex north_tile, TileIndex cur_tile, const StationSpec *statspec, Axis axis, byte plat_len, byte numtracks)
+CommandCost PerformStationTileSlopeCheck(TileIndex north_tile, TileIndex cur_tile, const StationSpec *statspec, Axis axis, uint8_t plat_len, uint8_t numtracks)
 {
 	TileIndex diff = cur_tile - north_tile;
 	Slope slope = GetTileSlope(cur_tile);
@@ -728,7 +728,7 @@ int AllocateSpecToStation(const StationSpec *statspec, BaseStation *st, bool exe
  * @param specindex Index of the custom station within the Station's spec list.
  * @return Indicates whether the StationSpec was deallocated.
  */
-void DeallocateSpecFromStation(BaseStation *st, byte specindex)
+void DeallocateSpecFromStation(BaseStation *st, uint8_t specindex)
 {
 	/* specindex of 0 (default) is never freeable */
 	if (specindex == 0) return;

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -43,7 +43,7 @@ struct StationScopeResolver : public ScopeResolver {
 	uint32_t GetRandomBits() const override;
 	uint32_t GetTriggers() const override;
 
-	uint32_t GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
+	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
 };
 
 /** Station resolver. */
@@ -57,7 +57,7 @@ struct StationResolverObject : public ResolverObject {
 
 	TownScopeResolver *GetTown();
 
-	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0) override
+	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override
 	{
 		switch (scope) {
 			case VSG_SCOPE_SELF:
@@ -80,7 +80,7 @@ struct StationResolverObject : public ResolverObject {
 	uint32_t GetDebugID() const override;
 };
 
-enum StationClassID : byte {
+enum StationClassID : uint8_t {
 	STAT_CLASS_BEGIN = 0,    ///< the lowest valid value
 	STAT_CLASS_DFLT = 0,     ///< Default station class.
 	STAT_CLASS_WAYP,         ///< Waypoint class.
@@ -129,12 +129,12 @@ struct StationSpec {
 	 * Bitmask of number of platforms available for the station.
 	 * 0..6 correspond to 1..7, while bit 7 corresponds to >7 platforms.
 	 */
-	byte disallowed_platforms;
+	uint8_t disallowed_platforms;
 	/**
 	 * Bitmask of platform lengths available for the station.
 	 * 0..6 correspond to 1..7, while bit 7 corresponds to >7 tiles long.
 	 */
-	byte disallowed_lengths;
+	uint8_t disallowed_lengths;
 
 	/**
 	 * Number of tile layouts.
@@ -154,13 +154,13 @@ struct StationSpec {
 
 	CargoTypes cargo_triggers; ///< Bitmask of cargo types which cause trigger re-randomizing
 
-	byte callback_mask; ///< Bitmask of station callbacks that have to be called
+	uint8_t callback_mask; ///< Bitmask of station callbacks that have to be called
 
-	byte flags; ///< Bitmask of flags, bit 0: use different sprite set; bit 1: divide cargo about by station size
+	uint8_t flags; ///< Bitmask of flags, bit 0: use different sprite set; bit 1: divide cargo about by station size
 
-	byte pylons;  ///< Bitmask of base tiles (0 - 7) which should contain elrail pylons
-	byte wires;   ///< Bitmask of base tiles (0 - 7) which should contain elrail wires
-	byte blocked; ///< Bitmask of base tiles (0 - 7) which are blocked to trains
+	uint8_t pylons;  ///< Bitmask of base tiles (0 - 7) which should contain elrail pylons
+	uint8_t wires;   ///< Bitmask of base tiles (0 - 7) which should contain elrail wires
+	uint8_t blocked; ///< Bitmask of base tiles (0 - 7) which are blocked to trains
 
 	AnimationInfo animation;
 
@@ -172,7 +172,7 @@ struct StationSpec {
 	 * These can be sparsely populated, and the upper limit is not defined but
 	 * limited to 255.
 	 */
-	std::vector<std::vector<std::vector<byte>>> layouts;
+	std::vector<std::vector<std::vector<uint8_t>>> layouts;
 };
 
 /** Struct containing information relating to station classes. */
@@ -181,18 +181,18 @@ typedef NewGRFClass<StationSpec, StationClassID, STAT_CLASS_MAX> StationClass;
 const StationSpec *GetStationSpec(TileIndex t);
 
 /* Evaluate a tile's position within a station, and return the result a bitstuffed format. */
-uint32_t GetPlatformInfo(Axis axis, byte tile, int platforms, int length, int x, int y, bool centred);
+uint32_t GetPlatformInfo(Axis axis, uint8_t tile, int platforms, int length, int x, int y, bool centred);
 
 SpriteID GetCustomStationRelocation(const StationSpec *statspec, BaseStation *st, TileIndex tile, uint32_t var10 = 0);
 SpriteID GetCustomStationFoundationRelocation(const StationSpec *statspec, BaseStation *st, TileIndex tile, uint layout, uint edge_info);
 uint16_t GetStationCallback(CallbackID callback, uint32_t param1, uint32_t param2, const StationSpec *statspec, BaseStation *st, TileIndex tile);
-CommandCost PerformStationTileSlopeCheck(TileIndex north_tile, TileIndex cur_tile, const StationSpec *statspec, Axis axis, byte plat_len, byte numtracks);
+CommandCost PerformStationTileSlopeCheck(TileIndex north_tile, TileIndex cur_tile, const StationSpec *statspec, Axis axis, uint8_t plat_len, uint8_t numtracks);
 
 /* Allocate a StationSpec to a Station. This is called once per build operation. */
 int AllocateSpecToStation(const StationSpec *statspec, BaseStation *st, bool exec);
 
 /* Deallocate a StationSpec from a Station. Called when removing a single station tile. */
-void DeallocateSpecFromStation(BaseStation *st, byte specindex);
+void DeallocateSpecFromStation(BaseStation *st, uint8_t specindex);
 
 /* Draw representation of a station tile for GUI purposes. */
 bool DrawStationTile(int x, int y, RailType railtype, Axis axis, StationClassID sclass, uint station);

--- a/src/newgrf_storage.h
+++ b/src/newgrf_storage.h
@@ -32,7 +32,7 @@ enum PersistentStorageMode {
  */
 struct BasePersistentStorageArray {
 	uint32_t grfid;    ///< GRFID associated to this persistent storage. A value of zero means "default".
-	byte feature;    ///< NOSAVE: Used to identify in the owner of the array in debug output.
+	uint8_t feature;    ///< NOSAVE: Used to identify in the owner of the array in debug output.
 	TileIndex tile;  ///< NOSAVE: Used to identify in the owner of the array in debug output.
 
 	virtual ~BasePersistentStorageArray();
@@ -198,7 +198,7 @@ extern PersistentStoragePool _persistent_storage_pool;
  */
 struct PersistentStorage : PersistentStorageArray<int32_t, 256>, PersistentStoragePool::PoolItem<&_persistent_storage_pool> {
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
-	PersistentStorage(const uint32_t new_grfid, byte feature, TileIndex tile)
+	PersistentStorage(const uint32_t new_grfid, uint8_t feature, TileIndex tile)
 	{
 		this->grfid = new_grfid;
 		this->feature = feature;

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -72,7 +72,7 @@ struct GRFTextEntry {
 
 
 static std::vector<GRFTextEntry> _grf_text;
-static byte _currentLangID = GRFLX_ENGLISH;  ///< by default, english is used.
+static uint8_t _currentLangID = GRFLX_ENGLISH;  ///< by default, english is used.
 
 /**
  * Get the mapping from the NewGRF supplied ID to OpenTTD's internal ID.
@@ -120,7 +120,7 @@ struct UnmappedChoiceList {
 	int offset;             ///< The offset for the plural/gender form.
 
 	/** Mapping of NewGRF supplied ID to the different strings in the choice list. */
-	std::map<byte, std::stringstream> strings;
+	std::map<uint8_t, std::stringstream> strings;
 
 	/**
 	 * Flush this choice list into the destination string.
@@ -269,7 +269,7 @@ std::string TranslateTTDPatchCodes(uint32_t grfid, uint8_t language_id, bool all
 				continue;
 			}
 		} else {
-			c = (byte)*src++;
+			c = (uint8_t)*src++;
 		}
 
 		if (c == '\0') break;
@@ -482,7 +482,7 @@ string_end:
  * @param langid The The language of the new text.
  * @param text_to_add The text to add to the list.
  */
-static void AddGRFTextToList(GRFTextList &list, byte langid, const std::string &text_to_add)
+static void AddGRFTextToList(GRFTextList &list, uint8_t langid, const std::string &text_to_add)
 {
 	/* Loop through all languages and see if we can replace a string */
 	for (auto &text : list) {
@@ -505,7 +505,7 @@ static void AddGRFTextToList(GRFTextList &list, byte langid, const std::string &
  * @param text_to_add The text to add to the list.
  * @note All text-codes will be translated.
  */
-void AddGRFTextToList(GRFTextList &list, byte langid, uint32_t grfid, bool allow_newlines, const char *text_to_add)
+void AddGRFTextToList(GRFTextList &list, uint8_t langid, uint32_t grfid, bool allow_newlines, const char *text_to_add)
 {
 	AddGRFTextToList(list, langid, TranslateTTDPatchCodes(grfid, langid, allow_newlines, text_to_add));
 }
@@ -519,7 +519,7 @@ void AddGRFTextToList(GRFTextList &list, byte langid, uint32_t grfid, bool allow
  * @param text_to_add The text to add to the list.
  * @note All text-codes will be translated.
  */
-void AddGRFTextToList(GRFTextWrapper &list, byte langid, uint32_t grfid, bool allow_newlines, const char *text_to_add)
+void AddGRFTextToList(GRFTextWrapper &list, uint8_t langid, uint32_t grfid, bool allow_newlines, const char *text_to_add)
 {
 	if (!list) list.reset(new GRFTextList());
 	AddGRFTextToList(*list, langid, grfid, allow_newlines, text_to_add);
@@ -540,7 +540,7 @@ void AddGRFTextToList(GRFTextWrapper &list, const std::string &text_to_add)
 /**
  * Add the new read string into our structure.
  */
-StringID AddGRFString(uint32_t grfid, uint16_t stringid, byte langid_to_add, bool new_scheme, bool allow_newlines, const char *text_to_add, StringID def_string)
+StringID AddGRFString(uint32_t grfid, uint16_t stringid, uint8_t langid_to_add, bool new_scheme, bool allow_newlines, const char *text_to_add, StringID def_string)
 {
 	/* When working with the old language scheme (grf_version is less than 7) and
 	 * English or American is among the set bits, simply add it as English in
@@ -656,12 +656,12 @@ const char *GetGRFStringPtr(uint32_t stringid)
  * from strings.cpp:ReadLanguagePack
  * @param language_id iso code of current selection
  */
-void SetCurrentGrfLangID(byte language_id)
+void SetCurrentGrfLangID(uint8_t language_id)
 {
 	_currentLangID = language_id;
 }
 
-bool CheckGrfLangID(byte lang_id, byte grf_version)
+bool CheckGrfLangID(uint8_t lang_id, uint8_t grf_version)
 {
 	if (grf_version < 7) {
 		switch (_currentLangID) {
@@ -685,8 +685,8 @@ void CleanUpStrings()
 }
 
 struct TextRefStack {
-	std::array<byte, 0x30> stack;
-	byte position;
+	std::array<uint8_t, 0x30> stack;
+	uint8_t position;
 	const GRFFile *grffile;
 	bool used;
 
@@ -719,7 +719,7 @@ struct TextRefStack {
 	/** Rotate the top four words down: W1, W2, W3, W4 -> W4, W1, W2, W3 */
 	void RotateTop4Words()
 	{
-		byte tmp[2];
+		uint8_t tmp[2];
 		for (int i = 0; i  < 2; i++) tmp[i] = this->stack[this->position + i + 6];
 		for (int i = 5; i >= 0; i--) this->stack[this->position + i + 2] = this->stack[this->position + i];
 		for (int i = 0; i  < 2; i++) this->stack[this->position + i] = tmp[i];
@@ -795,7 +795,7 @@ void RestoreTextRefStackBackup(struct TextRefStack *backup)
  * @param numEntries number of entries to copy from the registers
  * @param values values to copy onto the stack; if nullptr the temporary NewGRF registers will be used instead
  */
-void StartTextRefStackUsage(const GRFFile *grffile, byte numEntries, const uint32_t *values)
+void StartTextRefStackUsage(const GRFFile *grffile, uint8_t numEntries, const uint32_t *values)
 {
 	extern TemporaryStorageArray<int32_t, 0x110> _temp_store;
 

--- a/src/newgrf_text.h
+++ b/src/newgrf_text.h
@@ -20,7 +20,7 @@ static const char32_t NFO_UTF8_IDENTIFIER = 0x00DE;
 
 /** A GRF text with associated language ID. */
 struct GRFText {
-	byte langid;      ///< The language associated with this GRFText.
+	uint8_t langid;      ///< The language associated with this GRFText.
 	std::string text; ///< The actual (translated) text.
 };
 
@@ -29,21 +29,21 @@ typedef std::vector<GRFText> GRFTextList;
 /** Reference counted wrapper around a GRFText pointer. */
 typedef std::shared_ptr<GRFTextList> GRFTextWrapper;
 
-StringID AddGRFString(uint32_t grfid, uint16_t stringid, byte langid, bool new_scheme, bool allow_newlines, const char *text_to_add, StringID def_string);
+StringID AddGRFString(uint32_t grfid, uint16_t stringid, uint8_t langid, bool new_scheme, bool allow_newlines, const char *text_to_add, StringID def_string);
 StringID GetGRFStringID(uint32_t grfid, StringID stringid);
 const char *GetGRFStringFromGRFText(const GRFTextList &text_list);
 const char *GetGRFStringFromGRFText(const GRFTextWrapper &text);
 const char *GetGRFStringPtr(uint32_t stringid);
 void CleanUpStrings();
-void SetCurrentGrfLangID(byte language_id);
+void SetCurrentGrfLangID(uint8_t language_id);
 std::string TranslateTTDPatchCodes(uint32_t grfid, uint8_t language_id, bool allow_newlines, const std::string &str, StringControlCode byte80 = SCC_NEWGRF_PRINT_WORD_STRING_ID);
-void AddGRFTextToList(GRFTextList &list, byte langid, uint32_t grfid, bool allow_newlines, const char *text_to_add);
-void AddGRFTextToList(GRFTextWrapper &list, byte langid, uint32_t grfid, bool allow_newlines, const char *text_to_add);
+void AddGRFTextToList(GRFTextList &list, uint8_t langid, uint32_t grfid, bool allow_newlines, const char *text_to_add);
+void AddGRFTextToList(GRFTextWrapper &list, uint8_t langid, uint32_t grfid, bool allow_newlines, const char *text_to_add);
 void AddGRFTextToList(GRFTextWrapper &list, const std::string &text_to_add);
 
-bool CheckGrfLangID(byte lang_id, byte grf_version);
+bool CheckGrfLangID(uint8_t lang_id, uint8_t grf_version);
 
-void StartTextRefStackUsage(const struct GRFFile *grffile, byte numEntries, const uint32_t *values = nullptr);
+void StartTextRefStackUsage(const struct GRFFile *grffile, uint8_t numEntries, const uint32_t *values = nullptr);
 void StopTextRefStackUsage();
 bool UsingNewGRFTextStack();
 struct TextRefStack *CreateTextRefStackBackup();
@@ -53,8 +53,8 @@ void RestoreTextRefStackBackup(struct TextRefStack *backup);
 struct LanguageMap {
 	/** Mapping between NewGRF and OpenTTD IDs. */
 	struct Mapping {
-		byte newgrf_id;  ///< NewGRF's internal ID for a case/gender.
-		byte openttd_id; ///< OpenTTD's internal ID for a case/gender.
+		uint8_t newgrf_id;  ///< NewGRF's internal ID for a case/gender.
+		uint8_t openttd_id; ///< OpenTTD's internal ID for a case/gender.
 	};
 
 	/* We need a vector and can't use SmallMap due to the fact that for "setting" a

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -15,7 +15,7 @@
 
 #include "safeguards.h"
 
-/* virtual */ uint32_t TownScopeResolver::GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const
+/* virtual */ uint32_t TownScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const
 {
 	CargoID cid;
 	switch (variable) {

--- a/src/newgrf_town.h
+++ b/src/newgrf_town.h
@@ -34,7 +34,7 @@ struct TownScopeResolver : public ScopeResolver {
 	{
 	}
 
-	uint32_t GetVariable(byte variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
+	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool *available) const override;
 	void StorePSA(uint reg, int32_t value) override;
 };
 
@@ -44,7 +44,7 @@ struct TownResolverObject : public ResolverObject {
 
 	TownResolverObject(const struct GRFFile *grffile, Town *t, bool readonly);
 
-	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0) override
+	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override
 	{
 		switch (scope) {
 			case VSG_SCOPE_SELF: return &town_scope;

--- a/src/newgrf_townname.cpp
+++ b/src/newgrf_townname.cpp
@@ -47,11 +47,11 @@ void DelGRFTownName(uint32_t grfid)
 	_grf_townnames.erase(std::find_if(std::begin(_grf_townnames), std::end(_grf_townnames), [&grfid](const GRFTownName &t){ return t.grfid == grfid; }));
 }
 
-static void RandomPart(StringBuilder &builder, const GRFTownName *t, uint32_t seed, byte id)
+static void RandomPart(StringBuilder &builder, const GRFTownName *t, uint32_t seed, uint8_t id)
 {
 	assert(t != nullptr);
 	for (const auto &partlist : t->partlists[id]) {
-		byte count = partlist.bitcount;
+		uint8_t count = partlist.bitcount;
 		uint16_t maxprob = partlist.maxprob;
 		uint32_t r = (GB(seed, partlist.bitstart, count) * maxprob) >> count;
 		for (const auto &part : partlist.parts) {

--- a/src/newgrf_townname.h
+++ b/src/newgrf_townname.h
@@ -17,22 +17,22 @@
 
 struct NamePart {
 	std::string text; ///< If probability bit 7 is clear
-	byte id;          ///< If probability bit 7 is set
-	byte prob;        ///< The relative probability of the following name to appear in the bottom 7 bits.
+	uint8_t id;          ///< If probability bit 7 is set
+	uint8_t prob;        ///< The relative probability of the following name to appear in the bottom 7 bits.
 };
 
 struct NamePartList {
-	byte bitstart;  ///< Start of random seed bits to use.
-	byte bitcount;  ///< Number of bits of random seed to use.
+	uint8_t bitstart;  ///< Start of random seed bits to use.
+	uint8_t bitcount;  ///< Number of bits of random seed to use.
 	uint16_t maxprob; ///< Total probability of all parts.
 	std::vector<NamePart> parts; ///< List of parts to choose from.
 };
 
 struct TownNameStyle {
 	StringID name; ///< String ID of this town name style.
-	byte id;       ///< Index within partlist for this town name style.
+	uint8_t id;       ///< Index within partlist for this town name style.
 
-	TownNameStyle(StringID name, byte id) : name(name), id(id) { }
+	TownNameStyle(StringID name, uint8_t id) : name(name), id(id) { }
 };
 
 struct GRFTownName {

--- a/src/news_type.h
+++ b/src/news_type.h
@@ -20,7 +20,7 @@
 /**
  * Type of news.
  */
-enum NewsType : byte {
+enum NewsType : uint8_t {
 	NT_ARRIVAL_COMPANY, ///< First vehicle arrived for company
 	NT_ARRIVAL_OTHER,   ///< First vehicle arrived for competitor
 	NT_ACCIDENT,        ///< An accident or disaster has occurred
@@ -49,7 +49,7 @@ enum NewsType : byte {
  * You have to make sure, #ChangeVehicleNews catches the DParams of your message.
  * This is NOT ensured by the references.
  */
-enum NewsReferenceType : byte {
+enum NewsReferenceType : uint8_t {
 	NR_NONE,      ///< Empty reference
 	NR_TILE,      ///< Reference tile.     Scroll to tile when clicking on the news.
 	NR_VEHICLE,   ///< Reference vehicle.  Scroll to vehicle when clicking on the news. Delete news when vehicle is deleted.
@@ -99,7 +99,7 @@ enum NewsDisplay {
  */
 struct NewsTypeData {
 	const char * const name;    ///< Name
-	const byte age;             ///< Maximum age of news items (in days)
+	const uint8_t age;             ///< Maximum age of news items (in days)
 	const SoundFx sound;        ///< Sound
 
 	/**
@@ -108,7 +108,7 @@ struct NewsTypeData {
 	 * @param age The maximum age for these messages.
 	 * @param sound The sound to play.
 	 */
-	NewsTypeData(const char *name, byte age, SoundFx sound) :
+	NewsTypeData(const char *name, uint8_t age, SoundFx sound) :
 		name(name),
 		age(age),
 		sound(sound)

--- a/src/object_base.h
+++ b/src/object_base.h
@@ -25,8 +25,8 @@ struct Object : ObjectPool::PoolItem<&_object_pool> {
 	Town *town;         ///< Town the object is built in
 	TileArea location;  ///< Location of the object
 	TimerGameCalendar::Date build_date; ///< Date of construction
-	byte colour;        ///< Colour of the object, for display purpose
-	byte view;          ///< The view setting for this object
+	uint8_t colour;        ///< Colour of the object, for display purpose
+	uint8_t view;          ///< The view setting for this object
 
 	/** Make sure the object isn't zeroed. */
 	Object() {}

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -163,7 +163,7 @@ void UpdateCompanyHQ(TileIndex tile, uint score)
 {
 	if (tile == INVALID_TILE) return;
 
-	byte val = 0;
+	uint8_t val = 0;
 	if (score >= 170) val++;
 	if (score >= 350) val++;
 	if (score >= 520) val++;

--- a/src/object_map.h
+++ b/src/object_map.h
@@ -56,7 +56,7 @@ inline ObjectID GetObjectIndex(Tile t)
  * @pre IsTileType(t, MP_OBJECT)
  * @return The random bits.
  */
-inline byte GetObjectRandomBits(Tile t)
+inline uint8_t GetObjectRandomBits(Tile t)
 {
 	assert(IsTileType(t, MP_OBJECT));
 	return t.m3();
@@ -71,7 +71,7 @@ inline byte GetObjectRandomBits(Tile t)
  * @param wc     Water class for this object.
  * @param random Random data to store on the tile
  */
-inline void MakeObject(Tile t, Owner o, ObjectID index, WaterClass wc, byte random)
+inline void MakeObject(Tile t, Owner o, ObjectID index, WaterClass wc, uint8_t random)
 {
 	SetTileType(t, MP_OBJECT);
 	SetTileOwner(t, o);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -227,7 +227,7 @@ static void WriteSavegameInfo(const std::string &name)
 {
 	extern SaveLoadVersion _sl_version;
 	uint32_t last_ottd_rev = 0;
-	byte ever_modified = 0;
+	uint8_t ever_modified = 0;
 	bool removed_newgrfs = false;
 
 	_gamelog.Info(&last_ottd_rev, &ever_modified, &removed_newgrfs);
@@ -1362,7 +1362,7 @@ static void CheckCaches()
 
 	/* Check whether the caches are still valid */
 	for (Vehicle *v : Vehicle::Iterate()) {
-		byte buff[sizeof(VehicleCargoList)];
+		uint8_t buff[sizeof(VehicleCargoList)];
 		memcpy(buff, &v->cargo, sizeof(VehicleCargoList));
 		v->cargo.InvalidateCache();
 		assert(memcmp(&v->cargo, buff, sizeof(VehicleCargoList)) == 0);
@@ -1377,7 +1377,7 @@ static void CheckCaches()
 
 	for (Station *st : Station::Iterate()) {
 		for (GoodsEntry &ge : st->goods) {
-			byte buff[sizeof(StationCargoList)];
+			uint8_t buff[sizeof(StationCargoList)];
 			memcpy(buff, &ge.cargo, sizeof(StationCargoList));
 			ge.cargo.InvalidateCache();
 			assert(memcmp(&ge.cargo, buff, sizeof(StationCargoList)) == 0);

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -65,7 +65,7 @@ extern std::atomic<bool> _exit_game;
 extern bool _save_config;
 
 /** Modes of pausing we've got */
-enum PauseMode : byte {
+enum PauseMode : uint8_t {
 	PM_UNPAUSED              = 0,      ///< A normal unpaused game
 	PM_PAUSED_NORMAL         = 1 << 0, ///< A game normally paused
 	PM_PAUSED_SAVELOAD       = 1 << 1, ///< A game paused for saving/loading

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -454,7 +454,7 @@ static Order GetOrderCmdFromTile(const Vehicle *v, TileIndex tile)
 			st = in->neutral_station;
 		}
 		if (st != nullptr && (st->owner == _local_company || st->owner == OWNER_NONE)) {
-			byte facil;
+			uint8_t facil;
 			switch (v->type) {
 				case VEH_SHIP:     facil = FACIL_DOCK;    break;
 				case VEH_TRAIN:    facil = FACIL_TRAIN;   break;

--- a/src/order_type.h
+++ b/src/order_type.h
@@ -12,7 +12,7 @@
 
 #include "core/enum_type.hpp"
 
-typedef byte VehicleOrderID;  ///< The index of an order within its current vehicle (not pool related)
+typedef uint8_t VehicleOrderID;  ///< The index of an order within its current vehicle (not pool related)
 typedef uint32_t OrderID;
 typedef uint16_t OrderListID;
 typedef uint16_t DestinationID;
@@ -32,7 +32,7 @@ static const OrderID INVALID_ORDER = 0xFFFFFF;
 static const uint IMPLICIT_ORDER_ONLY_CAP = 32;
 
 /** Order types. It needs to be 8bits, because we save and load it as such */
-enum OrderType : byte {
+enum OrderType : uint8_t {
 	OT_BEGIN         = 0,
 	OT_NOTHING       = 0,
 	OT_GOTO_STATION  = 1,
@@ -141,7 +141,7 @@ enum OrderConditionComparator {
 /**
  * Enumeration for the data to set in #CmdModifyOrder.
  */
-enum ModifyOrderFlags : byte {
+enum ModifyOrderFlags : uint8_t {
 	MOF_NON_STOP,        ///< Passes an OrderNonStopFlags.
 	MOF_STOP_LOCATION,   ///< Passes an OrderStopLocation.
 	MOF_UNLOAD,          ///< Passes an OrderUnloadType.
@@ -168,7 +168,7 @@ enum OrderDepotAction {
 /**
  * Enumeration for the data to set in #CmdChangeTimetable.
  */
-enum ModifyTimetableFlags : byte {
+enum ModifyTimetableFlags : uint8_t {
 	MTF_WAIT_TIME,    ///< Set wait time.
 	MTF_TRAVEL_TIME,  ///< Set travel time.
 	MTF_TRAVEL_SPEED, ///< Set max travel speed.
@@ -176,7 +176,7 @@ enum ModifyTimetableFlags : byte {
 };
 
 /** Clone actions. */
-enum CloneOptions : byte {
+enum CloneOptions : uint8_t {
 	CO_SHARE   = 0,
 	CO_COPY    = 1,
 	CO_UNSHARE = 2

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -255,7 +255,7 @@ const Sprite *CoreTextFontCache::InternalGetGlyph(GlyphID key, bool use_aa)
 
 		/* We only need the alpha channel, as we apply our own colour constants to the sprite. */
 		int pitch = Align(bb_width, 16);
-		byte *bmp = CallocT<byte>(bb_height * pitch);
+		uint8_t *bmp = CallocT<uint8_t>(bb_height * pitch);
 		CFAutoRelease<CGContextRef> context(CGBitmapContextCreate(bmp, bb_width, bb_height, 8, pitch, nullptr, kCGImageAlphaOnly));
 		/* Set antialias according to requirements. */
 		CGContextSetAllowsAntialiasing(context.get(), use_aa);
@@ -291,7 +291,7 @@ const Sprite *CoreTextFontCache::InternalGetGlyph(GlyphID key, bool use_aa)
 
 	GlyphEntry new_glyph;
 	new_glyph.sprite = BlitterFactory::GetCurrentBlitter()->Encode(spritecollection, SimpleSpriteAlloc);
-	new_glyph.width = (byte)std::round(CTFontGetAdvancesForGlyphs(this->font.get(), kCTFontOrientationDefault, &glyph, nullptr, 1));
+	new_glyph.width = (uint8_t)std::round(CTFontGetAdvancesForGlyphs(this->font.get(), kCTFontOrientationDefault, &glyph, nullptr, 1));
 	this->SetGlyphPtr(key, &new_glyph);
 
 	return new_glyph.sprite;

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -227,7 +227,7 @@ void Win32FontCache::ClearFontCache()
 	if (width > MAX_GLYPH_DIM || height > MAX_GLYPH_DIM) UserError("Font glyph is too large");
 
 	/* Call GetGlyphOutline again with size to actually render the glyph. */
-	byte *bmp = new byte[size];
+	uint8_t *bmp = new uint8_t[size];
 	GetGlyphOutline(this->dc, key, GGO_GLYPH_INDEX | (aa ? GGO_GRAY8_BITMAP : GGO_BITMAP), &gm, size, bmp, &mat);
 
 	/* GDI has rendered the glyph, now we allocate a sprite and copy the image into it. */
@@ -344,11 +344,11 @@ static bool TryLoadFontFromFile(const std::string &font_name, LOGFONT &logfont)
 				/* Try to query an array of LOGFONTs that describe the file. */
 				DWORD len = 0;
 				if (GetFontResourceInfo(fontPath, &len, nullptr, 2) && len >= sizeof(LOGFONT)) {
-					LOGFONT *buf = (LOGFONT *)new byte[len];
+					LOGFONT *buf = (LOGFONT *)new uint8_t[len];
 					if (GetFontResourceInfo(fontPath, &len, buf, 2)) {
 						logfont = *buf; // Just use first entry.
 					}
-					delete[](byte *)buf;
+					delete[](uint8_t *)buf;
 				}
 			}
 

--- a/src/osk_gui.cpp
+++ b/src/osk_gui.cpp
@@ -32,7 +32,7 @@ enum KeyStateBits {
 	KEYS_SHIFT,
 	KEYS_CAPS
 };
-static byte _keystate = KEYS_NONE;
+static uint8_t _keystate = KEYS_NONE;
 
 struct OskWindow : public Window {
 	StringID caption;      ///< the caption for this window.

--- a/src/palette.cpp
+++ b/src/palette.cpp
@@ -213,8 +213,8 @@ void DoPaletteAnimations()
 
 	/* Radio tower blinking */
 	{
-		byte i = (palette_animation_counter >> 1) & 0x7F;
-		byte v;
+		uint8_t i = (palette_animation_counter >> 1) & 0x7F;
+		uint8_t v;
 
 		if (i < 0x3f) {
 			v = 255;
@@ -300,7 +300,7 @@ TextColour GetContrastColour(uint8_t background, uint8_t threshold)
  */
 struct ColourGradients
 {
-	using ColourGradient = std::array<byte, SHADE_END>;
+	using ColourGradient = std::array<uint8_t, SHADE_END>;
 
 	static inline std::array<ColourGradient, COLOUR_END> gradient{};
 };
@@ -311,7 +311,7 @@ struct ColourGradients
  * @param shade Shade level from 1 to 7.
  * @returns palette index of colour.
  */
-byte GetColourGradient(Colours colour, ColourShade shade)
+uint8_t GetColourGradient(Colours colour, ColourShade shade)
 {
 	return ColourGradients::gradient[colour % COLOUR_END][shade % SHADE_END];
 }
@@ -322,7 +322,7 @@ byte GetColourGradient(Colours colour, ColourShade shade)
  * @param shade Shade level from 1 to 7.
  * @param palette_index Palette index to set.
  */
-void SetColourGradient(Colours colour, ColourShade shade, byte palette_index)
+void SetColourGradient(Colours colour, ColourShade shade, uint8_t palette_index)
 {
 	assert(colour < COLOUR_END);
 	assert(shade < SHADE_END);

--- a/src/palette_func.h
+++ b/src/palette_func.h
@@ -54,8 +54,8 @@ enum ColourShade : uint8_t {
 };
 DECLARE_POSTFIX_INCREMENT(ColourShade)
 
-byte GetColourGradient(Colours colour, ColourShade shade);
-void SetColourGradient(Colours colour, ColourShade shade, byte palette_colour);
+uint8_t GetColourGradient(Colours colour, ColourShade shade);
+void SetColourGradient(Colours colour, ColourShade shade, uint8_t palette_colour);
 
 /**
  * Return the colour for a particular greyscale level.

--- a/src/pathfinder/npf/aystar.h
+++ b/src/pathfinder/npf/aystar.h
@@ -135,14 +135,14 @@ struct AyStar {
 	void *user_target;
 	void *user_data;
 
-	byte loops_per_tick;   ///< How many loops are there called before Main() gives control back to the caller. 0 = until done.
+	uint8_t loops_per_tick;   ///< How many loops are there called before Main() gives control back to the caller. 0 = until done.
 	uint max_path_cost;    ///< If the g-value goes over this number, it stops searching, 0 = infinite.
 	uint max_search_nodes; ///< The maximum number of nodes that will be expanded, 0 = infinite.
 
 	/* These should be filled with the neighbours of a tile by
 	 * GetNeighbours */
 	AyStarNode neighbours[12];
-	byte num_neighbours;
+	uint8_t num_neighbours;
 
 	void Init(Hash_HashProc hash, uint num_buckets);
 

--- a/src/pathfinder/npf/queue.cpp
+++ b/src/pathfinder/npf/queue.cpp
@@ -240,7 +240,7 @@ void Hash::Init(Hash_HashProc *hash, uint num_buckets)
 	this->hash = hash;
 	this->size = 0;
 	this->num_buckets = num_buckets;
-	this->buckets = (HashNode*)MallocT<byte>(num_buckets * (sizeof(*this->buckets) + sizeof(*this->buckets_in_use)));
+	this->buckets = (HashNode*)MallocT<uint8_t>(num_buckets * (sizeof(*this->buckets) + sizeof(*this->buckets_in_use)));
 	this->buckets_in_use = (bool*)(this->buckets + num_buckets);
 	for (i = 0; i < num_buckets; i++) this->buckets_in_use[i] = false;
 }

--- a/src/pathfinder/water_regions.cpp
+++ b/src/pathfinder/water_regions.cpp
@@ -24,7 +24,7 @@ using TWaterRegionTraversabilityBits = uint16_t;
 constexpr TWaterRegionPatchLabel FIRST_REGION_LABEL = 1;
 
 static_assert(sizeof(TWaterRegionTraversabilityBits) * 8 == WATER_REGION_EDGE_LENGTH);
-static_assert(sizeof(TWaterRegionPatchLabel) == sizeof(byte)); // Important for the hash calculation.
+static_assert(sizeof(TWaterRegionPatchLabel) == sizeof(uint8_t)); // Important for the hash calculation.
 
 static inline TrackBits GetWaterTracks(TileIndex tile) { return TrackStatusToTrackBits(GetTileTrackStatus(tile, TRANSPORT_WATER, 0)); }
 static inline bool IsAqueductTile(TileIndex tile) { return IsBridgeTile(tile) && GetTunnelBridgeTransportType(tile) == TRANSPORT_WATER; }

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -400,7 +400,7 @@ public:
 
 		/* Ocean/canal speed penalty. */
 		const ShipVehicleInfo *svi = ShipVehInfo(Yapf().GetVehicle()->engine_type);
-		byte speed_frac = (GetEffectiveWaterClass(n.GetTile()) == WATER_CLASS_SEA) ? svi->ocean_speed_frac : svi->canal_speed_frac;
+		uint8_t speed_frac = (GetEffectiveWaterClass(n.GetTile()) == WATER_CLASS_SEA) ? svi->ocean_speed_frac : svi->canal_speed_frac;
 		if (speed_frac > 0) c += YAPF_TILE_LENGTH * (1 + tf->m_tiles_skipped) * speed_frac / (256 - speed_frac);
 
 		/* Apply it. */

--- a/src/rail.cpp
+++ b/src/rail.cpp
@@ -20,21 +20,21 @@
 /* XXX: Below 3 tables store duplicate data. Maybe remove some? */
 /* Maps a trackdir to the bit that stores its status in the map arrays, in the
  * direction along with the trackdir */
-extern const byte _signal_along_trackdir[TRACKDIR_END] = {
+extern const uint8_t _signal_along_trackdir[TRACKDIR_END] = {
 	0x8, 0x8, 0x8, 0x2, 0x4, 0x1, 0, 0,
 	0x4, 0x4, 0x4, 0x1, 0x8, 0x2
 };
 
 /* Maps a trackdir to the bit that stores its status in the map arrays, in the
  * direction against the trackdir */
-extern const byte _signal_against_trackdir[TRACKDIR_END] = {
+extern const uint8_t _signal_against_trackdir[TRACKDIR_END] = {
 	0x4, 0x4, 0x4, 0x1, 0x8, 0x2, 0, 0,
 	0x8, 0x8, 0x8, 0x2, 0x4, 0x1
 };
 
 /* Maps a Track to the bits that store the status of the two signals that can
  * be present on the given track */
-extern const byte _signal_on_track[] = {
+extern const uint8_t _signal_on_track[] = {
 	0xC, 0xC, 0xC, 0x3, 0xC, 0x3
 };
 

--- a/src/rail.h
+++ b/src/rail.h
@@ -198,12 +198,12 @@ public:
 	/**
 	 * Original railtype number to use when drawing non-newgrf railtypes, or when drawing stations.
 	 */
-	byte fallback_railtype;
+	uint8_t fallback_railtype;
 
 	/**
 	 * Multiplier for curve maximum speed advantage
 	 */
-	byte curve_speed;
+	uint8_t curve_speed;
 
 	/**
 	 * Bit mask of rail type flags
@@ -243,7 +243,7 @@ public:
 	/**
 	 * Colour on mini-map
 	 */
-	byte map_colour;
+	uint8_t map_colour;
 
 	/**
 	 * Introduction date.
@@ -268,7 +268,7 @@ public:
 	/**
 	 * The sorting order of this railtype for the toolbar dropdown.
 	 */
-	byte sorting_order;
+	uint8_t sorting_order;
 
 	/**
 	 * NewGRF providing the Action3 for the railtype. nullptr if not available.

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -179,7 +179,7 @@ RailType AllocateRailType(RailTypeLabel label)
 	return INVALID_RAILTYPE;
 }
 
-static const byte _track_sloped_sprites[14] = {
+static const uint8_t _track_sloped_sprites[14] = {
 	14, 15, 22, 13,
 	 0, 21, 17, 12,
 	23,  0, 18, 20,
@@ -1049,7 +1049,7 @@ CommandCost CmdBuildTrainDepot(DoCommandFlag flags, TileIndex tile, RailType rai
  * @return the cost of this operation or an error
  * @todo p2 should be replaced by two bits for "along" and "against" the track.
  */
-CommandCost CmdBuildSingleSignal(DoCommandFlag flags, TileIndex tile, Track track, SignalType sigtype, SignalVariant sigvar, bool convert_signal, bool skip_existing_signals, bool ctrl_pressed, SignalType cycle_start, SignalType cycle_stop, uint8_t num_dir_cycle, byte signals_copy)
+CommandCost CmdBuildSingleSignal(DoCommandFlag flags, TileIndex tile, Track track, SignalType sigtype, SignalVariant sigvar, bool convert_signal, bool skip_existing_signals, bool ctrl_pressed, SignalType cycle_start, SignalType cycle_stop, uint8_t num_dir_cycle, uint8_t signals_copy)
 {
 	if (sigtype > SIGTYPE_LAST || sigvar > SIG_SEMAPHORE) return CMD_ERROR;
 	if (cycle_start > cycle_stop || cycle_stop > SIGTYPE_LAST) return CMD_ERROR;
@@ -1279,7 +1279,7 @@ static CommandCost CmdSignalTrackHelper(DoCommandFlag flags, TileIndex tile, Til
 	/* Must start on a valid track to be able to avoid loops */
 	if (!HasTrack(tile, track)) return CMD_ERROR;
 
-	byte signals;
+	uint8_t signals;
 	/* copy the signal-style of the first rail-piece if existing */
 	if (HasSignalOnTrack(tile, track)) {
 		signals = GetPresentSignals(tile) & SignalOnTrack(track);
@@ -1295,7 +1295,7 @@ static CommandCost CmdSignalTrackHelper(DoCommandFlag flags, TileIndex tile, Til
 		signals = IsPbsSignal(sigtype) ? SignalAlongTrackdir(trackdir) : SignalOnTrack(track);
 	}
 
-	byte signal_dir = 0;
+	uint8_t signal_dir = 0;
 	if (signals & SignalAlongTrackdir(trackdir))   SetBit(signal_dir, 0);
 	if (signals & SignalAgainstTrackdir(trackdir)) SetBit(signal_dir, 1);
 
@@ -1320,7 +1320,7 @@ static CommandCost CmdSignalTrackHelper(DoCommandFlag flags, TileIndex tile, Til
 	bool had_success = false;
 	auto build_signal = [&](TileIndex tile, Trackdir trackdir, bool test_only) {
 		/* Pick the correct orientation for the track direction */
-		byte signals = 0;
+		uint8_t signals = 0;
 		if (HasBit(signal_dir, 0)) signals |= SignalAlongTrackdir(trackdir);
 		if (HasBit(signal_dir, 1)) signals |= SignalAgainstTrackdir(trackdir);
 
@@ -1446,7 +1446,7 @@ static CommandCost CmdSignalTrackHelper(DoCommandFlag flags, TileIndex tile, Til
  * @return the cost of this operation or an error
  * @see CmdSignalTrackHelper
  */
-CommandCost CmdBuildSignalTrack(DoCommandFlag flags, TileIndex tile, TileIndex end_tile, Track track, SignalType sigtype, SignalVariant sigvar, bool mode, bool autofill, bool minimise_gaps, byte signal_density)
+CommandCost CmdBuildSignalTrack(DoCommandFlag flags, TileIndex tile, TileIndex end_tile, Track track, SignalType sigtype, SignalVariant sigvar, bool mode, bool autofill, bool minimise_gaps, uint8_t signal_density)
 {
 	return CmdSignalTrackHelper(flags, tile, end_tile, track, sigtype, sigvar, mode, false, autofill, minimise_gaps, signal_density);
 }
@@ -2379,7 +2379,7 @@ static void DrawTrackBits(TileInfo *ti, TrackBits track)
 		DrawGroundSprite(image, pal, &(_halftile_sub_sprite[halftile_corner]));
 
 		if (_game_mode != GM_MENU && _settings_client.gui.show_track_reservation && HasReservedTracks(ti->tile, CornerToTrackBits(halftile_corner))) {
-			static const byte _corner_to_track_sprite[] = {3, 1, 2, 0};
+			static const uint8_t _corner_to_track_sprite[] = {3, 1, 2, 0};
 			DrawGroundSprite(_corner_to_track_sprite[halftile_corner] + rti->base_sprites.single_n, PALETTE_CRASH, nullptr, 0, -(int)TILE_HEIGHT);
 		}
 	}
@@ -2387,7 +2387,7 @@ static void DrawTrackBits(TileInfo *ti, TrackBits track)
 
 static void DrawSignals(TileIndex tile, TrackBits rails, const RailTypeInfo *rti)
 {
-	auto MAYBE_DRAW_SIGNAL = [&](byte signalbit, SignalOffsets image, uint pos, Track track) {
+	auto MAYBE_DRAW_SIGNAL = [&](uint8_t signalbit, SignalOffsets image, uint pos, Track track) {
 		if (IsSignalPresent(tile, signalbit)) DrawSingleSignal(tile, rti, track, GetSingleSignalState(tile, signalbit), image, pos);
 	};
 
@@ -2667,7 +2667,7 @@ static void TileLoop_Track(TileIndex tile)
 		TrackBits rail = GetTrackBits(tile);
 
 		Owner owner = GetTileOwner(tile);
-		byte fences = 0;
+		uint8_t fences = 0;
 
 		for (DiagDirection d = DIAGDIR_BEGIN; d < DIAGDIR_END; d++) {
 			static const TrackBits dir_to_trackbits[DIAGDIR_END] = {TRACK_BIT_3WAY_NE, TRACK_BIT_3WAY_SE, TRACK_BIT_3WAY_SW, TRACK_BIT_3WAY_NW};
@@ -2736,7 +2736,7 @@ static TrackStatus GetTileTrackStatus_Track(TileIndex tile, TransportType mode, 
 
 		case RAIL_TILE_SIGNALS: {
 			trackbits = GetTrackBits(tile);
-			byte a = GetPresentSignals(tile);
+			uint8_t a = GetPresentSignals(tile);
 			uint b = GetSignalStates(tile);
 
 			b &= a;
@@ -2899,8 +2899,8 @@ static void ChangeTileOwner_Track(TileIndex tile, Owner old_owner, Owner new_own
 	}
 }
 
-static const byte _fractcoords_behind[4] = { 0x8F, 0x8, 0x80, 0xF8 };
-static const byte _fractcoords_enter[4] = { 0x8A, 0x48, 0x84, 0xA8 };
+static const uint8_t _fractcoords_behind[4] = { 0x8F, 0x8, 0x80, 0xF8 };
+static const uint8_t _fractcoords_enter[4] = { 0x8A, 0x48, 0x84, 0xA8 };
 static const int8_t _deltacoord_leaveoffset[8] = {
 	-1,  0,  1,  0, /* x */
 	 0,  1,  0, -1  /* y */
@@ -2939,7 +2939,7 @@ static VehicleEnterTileStatus VehicleEnter_Track(Vehicle *u, TileIndex tile, int
 	/* Depot direction. */
 	DiagDirection dir = GetRailDepotDirection(tile);
 
-	byte fract_coord = (x & 0xF) + ((y & 0xF) << 4);
+	uint8_t fract_coord = (x & 0xF) + ((y & 0xF) << 4);
 
 	/* Make sure a train is not entering the tile from behind. */
 	if (_fractcoords_behind[dir] == fract_coord) return VETSB_CANNOT_ENTER;
@@ -2951,7 +2951,7 @@ static VehicleEnterTileStatus VehicleEnter_Track(Vehicle *u, TileIndex tile, int
 		/* Calculate the point where the following wagon should be activated. */
 		int length = v->CalcNextVehicleOffset();
 
-		byte fract_coord_leave =
+		uint8_t fract_coord_leave =
 			((_fractcoords_enter[dir] & 0x0F) + // x
 				(length + 1) * _deltacoord_leaveoffset[dir]) +
 			(((_fractcoords_enter[dir] >> 4) +  // y

--- a/src/rail_cmd.h
+++ b/src/rail_cmd.h
@@ -20,10 +20,10 @@ CommandCost CmdRemoveRailroadTrack(DoCommandFlag flags, TileIndex end_tile, Tile
 CommandCost CmdBuildSingleRail(DoCommandFlag flags, TileIndex tile, RailType railtype, Track track, bool auto_remove_signals);
 CommandCost CmdRemoveSingleRail(DoCommandFlag flags, TileIndex tile, Track track);
 CommandCost CmdBuildTrainDepot(DoCommandFlag flags, TileIndex tile, RailType railtype, DiagDirection dir);
-CommandCost CmdBuildSingleSignal(DoCommandFlag flags, TileIndex tile, Track track, SignalType sigtype, SignalVariant sigvar, bool convert_signal, bool skip_existing_signals, bool ctrl_pressed, SignalType cycle_start, SignalType cycle_stop, uint8_t num_dir_cycle, byte signals_copy);
+CommandCost CmdBuildSingleSignal(DoCommandFlag flags, TileIndex tile, Track track, SignalType sigtype, SignalVariant sigvar, bool convert_signal, bool skip_existing_signals, bool ctrl_pressed, SignalType cycle_start, SignalType cycle_stop, uint8_t num_dir_cycle, uint8_t signals_copy);
 CommandCost CmdRemoveSingleSignal(DoCommandFlag flags, TileIndex tile, Track track);
 CommandCost CmdConvertRail(DoCommandFlag flags, TileIndex tile, TileIndex area_start, RailType totype, bool diagonal);
-CommandCost CmdBuildSignalTrack(DoCommandFlag flags, TileIndex tile, TileIndex end_tile, Track track, SignalType sigtype, SignalVariant sigvar, bool mode, bool autofill, bool minimise_gaps, byte signal_density);
+CommandCost CmdBuildSignalTrack(DoCommandFlag flags, TileIndex tile, TileIndex end_tile, Track track, SignalType sigtype, SignalVariant sigvar, bool mode, bool autofill, bool minimise_gaps, uint8_t signal_density);
 CommandCost CmdRemoveSignalTrack(DoCommandFlag flags, TileIndex tile, TileIndex end_tile, Track track, bool autofill);
 
 DEF_CMD_TRAIT(CMD_BUILD_RAILROAD_TRACK,  CmdBuildRailroadTrack,  CMD_AUTO | CMD_NO_WATER, CMDT_LANDSCAPE_CONSTRUCTION)

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -202,8 +202,8 @@ static void PlaceRail_Station(TileIndex tile)
 
 		RailStationGUISettings params = _railstation;
 		RailType rt = _cur_railtype;
-		byte numtracks = _settings_client.gui.station_numtracks;
-		byte platlength = _settings_client.gui.station_platlength;
+		uint8_t numtracks = _settings_client.gui.station_numtracks;
+		uint8_t platlength = _settings_client.gui.station_platlength;
 		bool adjacent = _ctrl_pressed;
 
 		auto proc = [=](bool test, StationID to_join) -> bool {

--- a/src/rail_map.h
+++ b/src/rail_map.h
@@ -194,7 +194,7 @@ inline Track GetRailDepotTrack(Tile t)
 inline TrackBits GetRailReservationTrackBits(Tile t)
 {
 	assert(IsPlainRailTile(t));
-	byte track_b = GB(t.m2(), 8, 3);
+	uint8_t track_b = GB(t.m2(), 8, 3);
 	Track track = (Track)(track_b - 1);    // map array saves Track+1
 	if (track_b == 0) return TRACK_BIT_NONE;
 	return (TrackBits)(TrackToTrackBits(track) | (HasBit(t.m2(), 11) ? TrackToTrackBits(TrackToOppositeTrack(track)) : 0));
@@ -213,7 +213,7 @@ inline void SetTrackReservation(Tile t, TrackBits b)
 	assert(!TracksOverlap(b));
 	Track track = RemoveFirstTrack(&b);
 	SB(t.m2(), 8, 3, track == INVALID_TRACK ? 0 : track + 1);
-	SB(t.m2(), 11, 1, (byte)(b != TRACK_BIT_NONE));
+	SB(t.m2(), 11, 1, (uint8_t)(b != TRACK_BIT_NONE));
 }
 
 /**
@@ -270,7 +270,7 @@ inline bool HasDepotReservation(Tile t)
 inline void SetDepotReservation(Tile t, bool b)
 {
 	assert(IsRailDepot(t));
-	SB(t.m5(), 4, 1, (byte)b);
+	SB(t.m5(), 4, 1, (uint8_t)b);
 }
 
 /**
@@ -293,14 +293,14 @@ inline bool IsPbsSignal(SignalType s)
 inline SignalType GetSignalType(Tile t, Track track)
 {
 	assert(GetRailTileType(t) == RAIL_TILE_SIGNALS);
-	byte pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 4 : 0;
+	uint8_t pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 4 : 0;
 	return (SignalType)GB(t.m2(), pos, 3);
 }
 
 inline void SetSignalType(Tile t, Track track, SignalType s)
 {
 	assert(GetRailTileType(t) == RAIL_TILE_SIGNALS);
-	byte pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 4 : 0;
+	uint8_t pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 4 : 0;
 	SB(t.m2(), pos, 3, s);
 	if (track == INVALID_TRACK) SB(t.m2(), 4, 3, s);
 }
@@ -323,8 +323,8 @@ inline bool IsOnewaySignal(Tile t, Track track)
 
 inline void CycleSignalSide(Tile t, Track track)
 {
-	byte sig;
-	byte pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 4 : 6;
+	uint8_t sig;
+	uint8_t pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 4 : 6;
 
 	sig = GB(t.m3(), pos, 2);
 	if (--sig == 0) sig = IsPbsSignal(GetSignalType(t, track)) ? 2 : 3;
@@ -333,13 +333,13 @@ inline void CycleSignalSide(Tile t, Track track)
 
 inline SignalVariant GetSignalVariant(Tile t, Track track)
 {
-	byte pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 7 : 3;
+	uint8_t pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 7 : 3;
 	return (SignalVariant)GB(t.m2(), pos, 1);
 }
 
 inline void SetSignalVariant(Tile t, Track track, SignalVariant v)
 {
-	byte pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 7 : 3;
+	uint8_t pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 7 : 3;
 	SB(t.m2(), pos, 1, v);
 	if (track == INVALID_TRACK) SB(t.m2(), 7, 1, v);
 }
@@ -370,7 +370,7 @@ inline uint GetSignalStates(Tile tile)
  * @param signalbit the signal
  * @return the state of the signal
  */
-inline SignalState GetSingleSignalState(Tile t, byte signalbit)
+inline SignalState GetSingleSignalState(Tile t, uint8_t signalbit)
 {
 	return (SignalState)HasBit(GetSignalStates(t), signalbit);
 }
@@ -401,7 +401,7 @@ inline uint GetPresentSignals(Tile tile)
  * @param signalbit the signal
  * @return true if and only if the signal is present
  */
-inline bool IsSignalPresent(Tile t, byte signalbit)
+inline bool IsSignalPresent(Tile t, uint8_t signalbit)
 {
 	return HasBit(GetPresentSignals(t), signalbit);
 }

--- a/src/rail_type.h
+++ b/src/rail_type.h
@@ -24,7 +24,7 @@ static const RailTypeLabel RAILTYPE_LABEL_MAGLEV   = 'MGLV';
  *
  * This enumeration defines all 4 possible railtypes.
  */
-enum RailType : byte {
+enum RailType : uint8_t {
 	RAILTYPE_BEGIN    = 0,          ///< Used for iterations
 	RAILTYPE_RAIL     = 0,          ///< Standard non-electric rails
 	RAILTYPE_ELECTRIC = 1,          ///< Electric rails

--- a/src/random_access_file.cpp
+++ b/src/random_access_file.cpp
@@ -98,7 +98,7 @@ void RandomAccessFile::SeekTo(size_t pos, int mode)
  * Read a byte from the file.
  * @return Read byte.
  */
-byte RandomAccessFile::ReadByte()
+uint8_t RandomAccessFile::ReadByte()
 {
 	if (this->buffer == this->buffer_end) {
 		this->buffer = this->buffer_start;
@@ -117,7 +117,7 @@ byte RandomAccessFile::ReadByte()
  */
 uint16_t RandomAccessFile::ReadWord()
 {
-	byte b = this->ReadByte();
+	uint8_t b = this->ReadByte();
 	return (this->ReadByte() << 8) | b;
 }
 

--- a/src/random_access_file_type.h
+++ b/src/random_access_file_type.h
@@ -29,9 +29,9 @@ class RandomAccessFile {
 	FILE *file_handle;               ///< File handle of the open file.
 	size_t pos;                      ///< Position in the file of the end of the read buffer.
 
-	byte *buffer;                    ///< Current position within the local buffer.
-	byte *buffer_end;                ///< Last valid byte of buffer.
-	byte buffer_start[BUFFER_SIZE];  ///< Local buffer when read from file.
+	uint8_t *buffer;                    ///< Current position within the local buffer.
+	uint8_t *buffer_end;                ///< Last valid byte of buffer.
+	uint8_t buffer_start[BUFFER_SIZE];  ///< Local buffer when read from file.
 
 public:
 	RandomAccessFile(const std::string &filename, Subdirectory subdir);
@@ -46,7 +46,7 @@ public:
 	size_t GetPos() const;
 	void SeekTo(size_t pos, int mode);
 
-	byte ReadByte();
+	uint8_t ReadByte();
 	uint16_t ReadWord();
 	uint32_t ReadDword();
 

--- a/src/rev.cpp.in
+++ b/src/rev.cpp.in
@@ -63,14 +63,14 @@ const char _openttd_revision_year[] = "${REV_YEAR}";
  * (compiling from sources without any version control software)
  * and 2 is for modified revision.
  */
-const byte _openttd_revision_modified = ${REV_MODIFIED};
+const uint8_t _openttd_revision_modified = ${REV_MODIFIED};
 
 /**
  * Indicate whether this is a tagged version.
  * If this is non-0, then _openttd_revision is the name of the tag,
  * and the version is likely a beta, release candidate, or real release.
  */
-const byte _openttd_revision_tagged = ${REV_ISTAG};
+const uint8_t _openttd_revision_tagged = ${REV_ISTAG};
 
 /**
  * To check compatibility of BaNaNaS content, this version string is used.

--- a/src/rev.h
+++ b/src/rev.h
@@ -14,8 +14,8 @@ extern const char _openttd_revision[];
 extern const char _openttd_build_date[];
 extern const char _openttd_revision_hash[];
 extern const char _openttd_revision_year[];
-extern const byte _openttd_revision_modified;
-extern const byte _openttd_revision_tagged;
+extern const uint8_t _openttd_revision_modified;
+extern const uint8_t _openttd_revision_tagged;
 extern const char _openttd_content_version[];
 extern const uint32_t _openttd_newgrf_version;
 

--- a/src/road.h
+++ b/src/road.h
@@ -154,7 +154,7 @@ public:
 	/**
 	 * Colour on mini-map
 	 */
-	byte map_colour;
+	uint8_t map_colour;
 
 	/**
 	 * Introduction date.
@@ -179,7 +179,7 @@ public:
 	/**
 	 * The sorting order of this roadtype for the toolbar dropdown.
 	 */
-	byte sorting_order;
+	uint8_t sorting_order;
 
 	/**
 	 * NewGRF providing the Action3 for the roadtype. nullptr if not available.

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1285,8 +1285,8 @@ static CommandCost ClearTile_Road(TileIndex tile, DoCommandFlag flags)
 
 struct DrawRoadTileStruct {
 	uint16_t image;
-	byte subcoord_x;
-	byte subcoord_y;
+	uint8_t subcoord_x;
+	uint8_t subcoord_y;
 };
 
 #include "table/road_land.h"
@@ -1320,7 +1320,7 @@ static Foundation GetRoadFoundation(Slope tileh, RoadBits bits)
 	return (bits == ROAD_X ? FOUNDATION_INCLINED_X : FOUNDATION_INCLINED_Y);
 }
 
-const byte _road_sloped_sprites[14] = {
+const uint8_t _road_sloped_sprites[14] = {
 	0,  0,  2,  0,
 	0,  1,  0,  0,
 	3,  0,  0,  0,
@@ -2232,7 +2232,7 @@ static void GetTileDesc_Road(TileIndex tile, TileDesc *td)
  * Given the direction the road depot is pointing, this is the direction the
  * vehicle should be travelling in in order to enter the depot.
  */
-static const byte _roadveh_enter_depot_dir[4] = {
+static const uint8_t _roadveh_enter_depot_dir[4] = {
 	TRACKDIR_X_SW, TRACKDIR_Y_NW, TRACKDIR_X_NE, TRACKDIR_Y_SE
 };
 

--- a/src/road_cmd.h
+++ b/src/road_cmd.h
@@ -14,7 +14,7 @@
 #include "road_type.h"
 #include "command_type.h"
 
-enum RoadStopClassID : byte;
+enum RoadStopClassID : uint8_t;
 
 void DrawRoadDepotSprite(int x, int y, DiagDirection dir, RoadType rt);
 void UpdateNearestTownForRoadTiles(bool invalidate);

--- a/src/road_type.h
+++ b/src/road_type.h
@@ -22,7 +22,7 @@ static const RoadTypeLabel ROADTYPE_LABEL_TRAM = 'ELRL';
  *
  * @note currently only ROADTYPE_ROAD and ROADTYPE_TRAM are supported.
  */
-enum RoadType : byte {
+enum RoadType : uint8_t {
 	ROADTYPE_BEGIN   = 0,    ///< Used for iterations
 	ROADTYPE_ROAD    = 0,    ///< Basic road type
 	ROADTYPE_TRAM    = 1,    ///< Trams
@@ -49,7 +49,7 @@ DECLARE_ENUM_AS_BIT_SET(RoadTypes)
  * This enumeration defines the possible road parts which
  * can be build on a tile.
  */
-enum RoadBits : byte {
+enum RoadBits : uint8_t {
 	ROAD_NONE = 0U,                  ///< No road-part is build
 	ROAD_NW   = 1U,                  ///< North-west part
 	ROAD_SW   = 2U,                  ///< South-west part
@@ -70,7 +70,7 @@ enum RoadBits : byte {
 DECLARE_ENUM_AS_BIT_SET(RoadBits)
 
 /** Which directions are disallowed ? */
-enum DisallowedRoadDirections : byte {
+enum DisallowedRoadDirections : uint8_t {
 	DRD_NONE,       ///< None of the directions are disallowed
 	DRD_SOUTHBOUND, ///< All southbound traffic is disallowed
 	DRD_NORTHBOUND, ///< All northbound traffic is disallowed

--- a/src/roadstop_base.h
+++ b/src/roadstop_base.h
@@ -65,7 +65,7 @@ struct RoadStop : RoadStopPool::PoolItem<&_roadstop_pool> {
 	};
 
 	TileIndex       xy;     ///< Position on the map
-	byte            status; ///< Current status of the Stop, @see RoadStopSatusFlag. Access using *Bay and *Busy functions.
+	uint8_t            status; ///< Current status of the Stop, @see RoadStopSatusFlag. Access using *Bay and *Busy functions.
 	struct RoadStop *next;  ///< Next stop of the given type at this station
 
 	/** Initializes a RoadStop */

--- a/src/roadveh.h
+++ b/src/roadveh.h
@@ -76,7 +76,7 @@ static const uint RVC_DRIVE_THROUGH_STOP_FRAME           = 11;
 static const uint RVC_DEPOT_STOP_FRAME                   = 11;
 
 /** The number of ticks a vehicle has for overtaking. */
-static const byte RV_OVERTAKE_TIMEOUT = 35;
+static const uint8_t RV_OVERTAKE_TIMEOUT = 35;
 
 void RoadVehUpdateCache(RoadVehicle *v, bool same_length = false);
 void GetRoadVehSpriteSize(EngineID engine, uint &width, uint &height, int &xoffs, int &yoffs, EngineImageType image_type);
@@ -105,13 +105,13 @@ struct RoadVehPathCache {
  */
 struct RoadVehicle final : public GroundVehicle<RoadVehicle, VEH_ROAD> {
 	RoadVehPathCache path;  ///< Cached path.
-	byte state;             ///< @see RoadVehicleStates
-	byte frame;
+	uint8_t state;             ///< @see RoadVehicleStates
+	uint8_t frame;
 	uint16_t blocked_ctr;
-	byte overtaking;        ///< Set to #RVSB_DRIVE_SIDE when overtaking, otherwise 0.
-	byte overtaking_ctr;    ///< The length of the current overtake attempt.
+	uint8_t overtaking;        ///< Set to #RVSB_DRIVE_SIDE when overtaking, otherwise 0.
+	uint8_t overtaking_ctr;    ///< The length of the current overtake attempt.
 	uint16_t crashed_ctr;     ///< Animation counter when the vehicle has crashed. @see RoadVehIsCrashed
-	byte reverse_ctr;
+	uint8_t reverse_ctr;
 
 	RoadType roadtype;              //!< Roadtype of this vehicle.
 	RoadTypes compatible_roadtypes; //!< Roadtypes this consist is powered on.
@@ -201,7 +201,7 @@ protected: // These functions should not be called outside acceleration code.
 	 * Allows to know the tractive effort value that this vehicle will use.
 	 * @return Tractive effort value from the engine.
 	 */
-	inline byte GetTractiveEffort() const
+	inline uint8_t GetTractiveEffort() const
 	{
 		/* The tractive effort coefficient is in units of 1/256.  */
 		return GetVehicleProperty(this, PROP_ROADVEH_TRACTIVE_EFFORT, RoadVehInfo(this->engine_type)->tractive_effort);
@@ -211,7 +211,7 @@ protected: // These functions should not be called outside acceleration code.
 	 * Gets the area used for calculating air drag.
 	 * @return Area of the engine in m^2.
 	 */
-	inline byte GetAirDragArea() const
+	inline uint8_t GetAirDragArea() const
 	{
 		return 6;
 	}
@@ -220,7 +220,7 @@ protected: // These functions should not be called outside acceleration code.
 	 * Gets the air drag coefficient of this vehicle.
 	 * @return Air drag value from the engine.
 	 */
-	inline byte GetAirDrag() const
+	inline uint8_t GetAirDrag() const
 	{
 		return RoadVehInfo(this->engine_type)->air_drag;
 	}

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -1005,7 +1005,7 @@ found_best_track:;
 }
 
 struct RoadDriveEntry {
-	byte x, y;
+	uint8_t x, y;
 };
 
 #include "table/roadveh_movement.h"
@@ -1066,7 +1066,7 @@ static Trackdir FollowPreviousRoadVehicle(const RoadVehicle *v, const RoadVehicl
 		return _road_reverse_table[entry_dir];
 	}
 
-	byte prev_state = prev->state;
+	uint8_t prev_state = prev->state;
 	Trackdir dir;
 
 	if (prev_state == RVSB_WORMHOLE || prev_state == RVSB_IN_DEPOT) {
@@ -1338,7 +1338,7 @@ again:
 			TileIndex old_tile = v->tile;
 
 			v->tile = tile;
-			v->state = (byte)dir;
+			v->state = (uint8_t)dir;
 			v->frame = start_frame;
 			RoadTramType rtt = GetRoadTramType(v->roadtype);
 			if (GetRoadType(old_tile, rtt) != GetRoadType(tile, rtt)) {

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -188,7 +188,7 @@ static void UpdateExclusiveRights()
 	 */
 }
 
-static const byte convert_currency[] = {
+static const uint8_t convert_currency[] = {
 	 0,  1, 12,  8,  3,
 	10, 14, 19,  4,  5,
 	 9, 11, 13,  6, 17,
@@ -490,12 +490,12 @@ static uint FixVehicleInclination(Vehicle *v, Direction dir)
 		case INVALID_DIR: break;
 		default: NOT_REACHED();
 	}
-	byte entry_z = GetSlopePixelZ(entry_x, entry_y, true);
+	uint8_t entry_z = GetSlopePixelZ(entry_x, entry_y, true);
 
 	/* Compute middle of the tile. */
 	int middle_x = (v->x_pos & ~TILE_UNIT_MASK) + TILE_SIZE / 2;
 	int middle_y = (v->y_pos & ~TILE_UNIT_MASK) + TILE_SIZE / 2;
-	byte middle_z = GetSlopePixelZ(middle_x, middle_y, true);
+	uint8_t middle_z = GetSlopePixelZ(middle_x, middle_y, true);
 
 	/* middle_z == entry_z, no height change. */
 	if (middle_z == entry_z) return 0;
@@ -2129,7 +2129,7 @@ bool AfterLoadGame()
 			}
 
 			/* Use old layout randomizer code */
-			byte layout = TileHash(TileX(t->xy), TileY(t->xy)) % 6;
+			uint8_t layout = TileHash(TileX(t->xy), TileY(t->xy)) % 6;
 			switch (layout) {
 				default: break;
 				case 5: layout = 1; break;
@@ -2365,8 +2365,8 @@ bool AfterLoadGame()
 	/* Airport tile animation uses animation frame instead of other graphics id */
 	if (IsSavegameVersionBefore(SLV_137)) {
 		struct AirportTileConversion {
-			byte old_start;
-			byte num_frames;
+			uint8_t old_start;
+			uint8_t num_frames;
 		};
 		static const AirportTileConversion atc[] = {
 			{31,  12}, // APT_RADAR_GRASS_FENCE_SW
@@ -2382,7 +2382,7 @@ bool AfterLoadGame()
 		for (auto t : Map::Iterate()) {
 			if (IsAirportTile(t)) {
 				StationGfx old_gfx = GetStationGfx(t);
-				byte offset = 0;
+				uint8_t offset = 0;
 				for (uint i = 0; i < lengthof(atc); i++) {
 					if (old_gfx < atc[i].old_start) {
 						SetStationGfx(t, old_gfx - offset);
@@ -2535,9 +2535,9 @@ bool AfterLoadGame()
 			const DiagDirection vdir = DirToDiagDir(v->direction);
 
 			/* Have we passed the visibility "switch" state already? */
-			byte pos = (DiagDirToAxis(vdir) == AXIS_X ? v->x_pos : v->y_pos) & TILE_UNIT_MASK;
-			byte frame = (vdir == DIAGDIR_NE || vdir == DIAGDIR_NW) ? TILE_SIZE - 1 - pos : pos;
-			extern const byte _tunnel_visibility_frame[DIAGDIR_END];
+			uint8_t pos = (DiagDirToAxis(vdir) == AXIS_X ? v->x_pos : v->y_pos) & TILE_UNIT_MASK;
+			uint8_t frame = (vdir == DIAGDIR_NE || vdir == DIAGDIR_NW) ? TILE_SIZE - 1 - pos : pos;
+			extern const uint8_t _tunnel_visibility_frame[DIAGDIR_END];
 
 			/* Should the vehicle be hidden or not? */
 			bool hidden;
@@ -2583,7 +2583,7 @@ bool AfterLoadGame()
 
 			bool loading = rv->current_order.IsType(OT_LOADING) || rv->current_order.IsType(OT_LEAVESTATION);
 			if (HasBit(rv->state, RVS_IN_ROAD_STOP)) {
-				extern const byte _road_stop_stop_frame[];
+				extern const uint8_t _road_stop_stop_frame[];
 				SB(rv->state, RVS_ENTERED_STOP, 1, loading || rv->frame > _road_stop_stop_frame[rv->state - RVSB_IN_ROAD_STOP + (_settings_game.vehicle.road_side << RVS_DRIVE_SIDE)]);
 			} else if (HasBit(rv->state, RVS_IN_DT_ROAD_STOP)) {
 				SB(rv->state, RVS_ENTERED_STOP, 1, loading || rv->frame > RVC_DRIVE_THROUGH_STOP_FRAME);

--- a/src/saveload/gamelog_sl.cpp
+++ b/src/saveload/gamelog_sl.cpp
@@ -348,7 +348,7 @@ public:
 	void Load(LoggedAction *la) const override
 	{
 		if (IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY)) {
-			byte type;
+			uint8_t type;
 			while ((type = SlReadByte()) != GLCT_NONE) {
 				if (type >= GLCT_END) SlErrorCorrupt("Invalid gamelog change type");
 				LoadChange(la, (GamelogChangeType)type);
@@ -384,7 +384,7 @@ struct GLOGChunkHandler : ChunkHandler {
 		const std::vector<SaveLoad> slt = SlCompatTableHeader(_gamelog_desc, _gamelog_sl_compat);
 
 		if (IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY)) {
-			byte type;
+			uint8_t type;
 			while ((type = SlReadByte()) != GLAT_NONE) {
 				if (type >= GLAT_END) SlErrorCorrupt("Invalid gamelog action type");
 

--- a/src/saveload/map_sl.cpp
+++ b/src/saveload/map_sl.cpp
@@ -71,7 +71,7 @@ struct MAPTChunkHandler : ChunkHandler {
 
 	void Load() const override
 	{
-		std::array<byte, MAP_SL_BUF_SIZE> buf;
+		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
@@ -82,7 +82,7 @@ struct MAPTChunkHandler : ChunkHandler {
 
 	void Save() const override
 	{
-		std::array<byte, MAP_SL_BUF_SIZE> buf;
+		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
 		SlSetLength(size);
@@ -98,7 +98,7 @@ struct MAPHChunkHandler : ChunkHandler {
 
 	void Load() const override
 	{
-		std::array<byte, MAP_SL_BUF_SIZE> buf;
+		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
@@ -109,7 +109,7 @@ struct MAPHChunkHandler : ChunkHandler {
 
 	void Save() const override
 	{
-		std::array<byte, MAP_SL_BUF_SIZE> buf;
+		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
 		SlSetLength(size);
@@ -125,7 +125,7 @@ struct MAPOChunkHandler : ChunkHandler {
 
 	void Load() const override
 	{
-		std::array<byte, MAP_SL_BUF_SIZE> buf;
+		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
@@ -136,7 +136,7 @@ struct MAPOChunkHandler : ChunkHandler {
 
 	void Save() const override
 	{
-		std::array<byte, MAP_SL_BUF_SIZE> buf;
+		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
 		SlSetLength(size);
@@ -182,7 +182,7 @@ struct M3LOChunkHandler : ChunkHandler {
 
 	void Load() const override
 	{
-		std::array<byte, MAP_SL_BUF_SIZE> buf;
+		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
@@ -193,7 +193,7 @@ struct M3LOChunkHandler : ChunkHandler {
 
 	void Save() const override
 	{
-		std::array<byte, MAP_SL_BUF_SIZE> buf;
+		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
 		SlSetLength(size);
@@ -209,7 +209,7 @@ struct M3HIChunkHandler : ChunkHandler {
 
 	void Load() const override
 	{
-		std::array<byte, MAP_SL_BUF_SIZE> buf;
+		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
@@ -220,7 +220,7 @@ struct M3HIChunkHandler : ChunkHandler {
 
 	void Save() const override
 	{
-		std::array<byte, MAP_SL_BUF_SIZE> buf;
+		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
 		SlSetLength(size);
@@ -236,7 +236,7 @@ struct MAP5ChunkHandler : ChunkHandler {
 
 	void Load() const override
 	{
-		std::array<byte, MAP_SL_BUF_SIZE> buf;
+		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
@@ -247,7 +247,7 @@ struct MAP5ChunkHandler : ChunkHandler {
 
 	void Save() const override
 	{
-		std::array<byte, MAP_SL_BUF_SIZE> buf;
+		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
 		SlSetLength(size);
@@ -263,7 +263,7 @@ struct MAPEChunkHandler : ChunkHandler {
 
 	void Load() const override
 	{
-		std::array<byte, MAP_SL_BUF_SIZE> buf;
+		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
 		if (IsSavegameVersionBefore(SLV_42)) {
@@ -287,7 +287,7 @@ struct MAPEChunkHandler : ChunkHandler {
 
 	void Save() const override
 	{
-		std::array<byte, MAP_SL_BUF_SIZE> buf;
+		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
 		SlSetLength(size);
@@ -303,7 +303,7 @@ struct MAP7ChunkHandler : ChunkHandler {
 
 	void Load() const override
 	{
-		std::array<byte, MAP_SL_BUF_SIZE> buf;
+		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
@@ -314,7 +314,7 @@ struct MAP7ChunkHandler : ChunkHandler {
 
 	void Save() const override
 	{
-		std::array<byte, MAP_SL_BUF_SIZE> buf;
+		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
 		SlSetLength(size);

--- a/src/saveload/misc_sl.cpp
+++ b/src/saveload/misc_sl.cpp
@@ -28,7 +28,7 @@
 
 extern TileIndex _cur_tileloop_tile;
 extern uint16_t _disaster_delay;
-extern byte _trees_tick_ctr;
+extern uint8_t _trees_tick_ctr;
 
 /* Keep track of current game position */
 int _saved_scrollpos_x;
@@ -76,7 +76,7 @@ void ResetViewportAfterLoadGame()
 	MarkWholeScreenDirty();
 }
 
-byte _age_cargo_skip_counter; ///< Skip aging of cargo? Used before savegame version 162.
+uint8_t _age_cargo_skip_counter; ///< Skip aging of cargo? Used before savegame version 162.
 extern TimeoutTimer<TimerGameTick> _new_competitor_timeout;
 
 static const SaveLoad _date_desc[] = {

--- a/src/saveload/oldloader.cpp
+++ b/src/saveload/oldloader.cpp
@@ -33,10 +33,10 @@ static inline OldChunkType GetOldChunkType(OldChunkType type)     {return (OldCh
 static inline OldChunkType GetOldChunkVarType(OldChunkType type)  {return (OldChunkType)(GB(type, 8, 8) << 8);}
 static inline OldChunkType GetOldChunkFileType(OldChunkType type) {return (OldChunkType)(GB(type, 16, 8) << 16);}
 
-static inline byte CalcOldVarLen(OldChunkType type)
+static inline uint8_t CalcOldVarLen(OldChunkType type)
 {
-	static const byte type_mem_size[] = {0, 1, 1, 2, 2, 4, 4, 8};
-	byte length = GB(type, 8, 8);
+	static const uint8_t type_mem_size[] = {0, 1, 1, 2, 2, 4, 4, 8};
+	uint8_t length = GB(type, 8, 8);
 	assert(length != 0 && length < lengthof(type_mem_size));
 	return type_mem_size[length];
 }
@@ -46,7 +46,7 @@ static inline byte CalcOldVarLen(OldChunkType type)
  * Reads a byte from a file (do not call yourself, use ReadByte())
  *
  */
-static byte ReadByteFromFile(LoadgameState *ls)
+static uint8_t ReadByteFromFile(LoadgameState *ls)
 {
 	/* To avoid slow reads, we read BUFFER_SIZE of bytes per time
 	and just return a byte per time */
@@ -73,7 +73,7 @@ static byte ReadByteFromFile(LoadgameState *ls)
  * Reads a byte from the buffer and decompress if needed
  *
  */
-byte ReadByte(LoadgameState *ls)
+uint8_t ReadByte(LoadgameState *ls)
 {
 	/* Old savegames have a nice compression algorithm (RLE)
 	which means that we have a chunk, which starts with a length
@@ -116,8 +116,8 @@ bool LoadChunk(LoadgameState *ls, void *base, const OldChunks *chunks)
 			continue;
 		}
 
-		byte *ptr = (byte*)chunk->ptr;
-		if (chunk->type & OC_DEREFERENCE_POINTER) ptr = *(byte**)ptr;
+		uint8_t *ptr = (uint8_t*)chunk->ptr;
+		if (chunk->type & OC_DEREFERENCE_POINTER) ptr = *(uint8_t**)ptr;
 
 		for (uint i = 0; i < chunk->amount; i++) {
 			/* Handle simple types */
@@ -155,7 +155,7 @@ bool LoadChunk(LoadgameState *ls, void *base, const OldChunks *chunks)
 				if (base == nullptr && chunk->ptr == nullptr) continue;
 
 				/* Chunk refers to a struct member, get address in base. */
-				if (chunk->ptr == nullptr) ptr = (byte *)chunk->offset(base);
+				if (chunk->ptr == nullptr) ptr = (uint8_t *)chunk->offset(base);
 
 				/* Write the data */
 				switch (GetOldChunkVarType(chunk->type)) {

--- a/src/saveload/oldloader.h
+++ b/src/saveload/oldloader.h
@@ -22,11 +22,11 @@ struct LoadgameState {
 	uint chunk_size;
 
 	bool decoding;
-	byte decode_char;
+	uint8_t decode_char;
 
 	uint buffer_count;
 	uint buffer_cur;
-	byte buffer[BUFFER_SIZE];
+	uint8_t buffer[BUFFER_SIZE];
 
 	uint total_read;
 };
@@ -94,7 +94,7 @@ struct OldChunks {
 };
 
 extern uint _bump_assert_value;
-byte ReadByte(LoadgameState *ls);
+uint8_t ReadByte(LoadgameState *ls);
 bool LoadChunk(LoadgameState *ls, void *base, const OldChunks *chunks);
 
 bool LoadTTDMain(LoadgameState *ls);
@@ -102,7 +102,7 @@ bool LoadTTOMain(LoadgameState *ls);
 
 inline uint16_t ReadUint16(LoadgameState *ls)
 {
-	byte x = ReadByte(ls);
+	uint8_t x = ReadByte(ls);
 	return x | ReadByte(ls) << 8;
 }
 

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -41,7 +41,7 @@
 
 static bool _read_ttdpatch_flags;    ///< Have we (tried to) read TTDPatch extra flags?
 static uint16_t _old_extra_chunk_nums; ///< Number of extra TTDPatch chunks
-static byte _old_vehicle_multiplier; ///< TTDPatch vehicle multiplier
+static uint8_t _old_vehicle_multiplier; ///< TTDPatch vehicle multiplier
 
 void FixOldMapArray()
 {
@@ -111,7 +111,7 @@ static void FixTTDDepots()
 
 #define FIXNUM(x, y, z) (((((x) << 16) / (y)) + 1) << z)
 
-static uint32_t RemapOldTownName(uint32_t townnameparts, byte old_town_name_type)
+static uint32_t RemapOldTownName(uint32_t townnameparts, uint8_t old_town_name_type)
 {
 	switch (old_town_name_type) {
 		case 0: case 3: // English, American
@@ -304,7 +304,7 @@ static bool FixTTOMapArray()
 
 			case MP_TUNNELBRIDGE:
 				if (HasBit(tile.m5(), 7)) { // bridge
-					byte m5 = tile.m5();
+					uint8_t m5 = tile.m5();
 					tile.m5() = m5 & 0xE1; // copy bits 7..5, 1
 					if (GB(m5, 1, 2) == 1) tile.m5() |= 0x02; // road bridge
 					if (GB(m5, 1, 2) == 3) tile.m2() |= 0xA0; // monorail bridge -> tubular, steel bridge
@@ -1281,7 +1281,7 @@ bool LoadOldVehicle(LoadgameState *ls, int num)
 
 			switch (v->type) {
 				case VEH_TRAIN: {
-					static const byte spriteset_rail[] = {
+					static const uint8_t spriteset_rail[] = {
 						  0,   2,   4,   4,   8,  10,  12,  14,  16,  18,  20,  22,  40,  42,  44,  46,
 						 48,  52,  54,  66,  68,  70,  72,  74,  76,  78,  80,  82,  84,  86, 120, 122,
 						124, 126, 128, 130, 132, 134, 136, 138, 140
@@ -1508,7 +1508,7 @@ static bool LoadOldMapPart1(LoadgameState *ls, int)
 		}
 		auto range = Map::Iterate();
 		for (auto it = range.begin(); it != range.end(); /* nothing. */) {
-			byte b = ReadByte(ls);
+			uint8_t b = ReadByte(ls);
 			for (int i = 0; i < 8; i += 2, ++it) (*it).m6() = GB(b, i, 2);
 		}
 	}
@@ -1586,8 +1586,8 @@ static bool LoadTTDPatchExtraChunks(LoadgameState *ls, int)
 
 extern TileIndex _cur_tileloop_tile;
 extern uint16_t _disaster_delay;
-extern byte _trees_tick_ctr;
-extern byte _age_cargo_skip_counter; // From misc_sl.cpp
+extern uint8_t _trees_tick_ctr;
+extern uint8_t _age_cargo_skip_counter; // From misc_sl.cpp
 extern uint8_t _old_diff_level;
 extern uint8_t _old_units;
 static const OldChunks main_chunk[] = {
@@ -1808,7 +1808,7 @@ bool LoadTTOMain(LoadgameState *ls)
 
 	_read_ttdpatch_flags = false;
 
-	std::array<byte, 103 * sizeof(Engine)> engines; // we don't want to call Engine constructor here
+	std::array<uint8_t, 103 * sizeof(Engine)> engines; // we don't want to call Engine constructor here
 	_old_engines = (Engine *)engines.data();
 	std::array<StringID, 800> vehnames;
 	_old_vehicle_names = vehnames.data();

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -674,7 +674,7 @@ enum VarTypes {
 typedef uint32_t VarType;
 
 /** Type of data saved. */
-enum SaveLoadType : byte {
+enum SaveLoadType : uint8_t {
 	SL_VAR         =  0, ///< Save/load a variable.
 	SL_REF         =  1, ///< Save/load a reference.
 	SL_STRUCT      =  2, ///< Save/load a struct.
@@ -1212,10 +1212,10 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @param minor Minor number of the version to check against. If \a minor is 0 or not specified, only the major number is checked.
  * @return Savegame version is earlier than the specified version.
  */
-inline bool IsSavegameVersionBefore(SaveLoadVersion major, byte minor = 0)
+inline bool IsSavegameVersionBefore(SaveLoadVersion major, uint8_t minor = 0)
 {
 	extern SaveLoadVersion _sl_version;
-	extern byte            _sl_minor_version;
+	extern uint8_t            _sl_minor_version;
 	return _sl_version < major || (minor > 0 && _sl_version == major && _sl_minor_version < minor);
 }
 
@@ -1278,8 +1278,8 @@ void SlSetLength(size_t length);
 size_t SlCalcObjMemberLength(const void *object, const SaveLoad &sld);
 size_t SlCalcObjLength(const void *object, const SaveLoadTable &slt);
 
-byte SlReadByte();
-void SlWriteByte(byte b);
+uint8_t SlReadByte();
+void SlWriteByte(uint8_t b);
 
 void SlGlobList(const SaveLoadTable &slt);
 void SlCopy(void *object, size_t length, VarType conv);

--- a/src/saveload/saveload_filter.h
+++ b/src/saveload/saveload_filter.h
@@ -34,7 +34,7 @@ struct LoadFilter {
 	 * @param len The number of bytes to read.
 	 * @return The number of actually read bytes.
 	 */
-	virtual size_t Read(byte *buf, size_t len) = 0;
+	virtual size_t Read(uint8_t *buf, size_t len) = 0;
 
 	/**
 	 * Reset this filter to read from the beginning of the file.
@@ -78,7 +78,7 @@ struct SaveFilter {
 	 * @param buf The bytes to write.
 	 * @param len The number of bytes to write.
 	 */
-	virtual void Write(byte *buf, size_t len) = 0;
+	virtual void Write(uint8_t *buf, size_t len) = 0;
 
 	/**
 	 * Prepare everything to finish writing the savegame.
@@ -95,7 +95,7 @@ struct SaveFilter {
  * @param compression_level The requested level of compression.
  * @tparam T                The type of save filter to create.
  */
-template <typename T> std::shared_ptr<SaveFilter> CreateSaveFilter(std::shared_ptr<SaveFilter> chain, byte compression_level)
+template <typename T> std::shared_ptr<SaveFilter> CreateSaveFilter(std::shared_ptr<SaveFilter> chain, uint8_t compression_level)
 {
 	return std::make_shared<T>(chain, compression_level);
 }

--- a/src/saveload/strings_sl.cpp
+++ b/src/saveload/strings_sl.cpp
@@ -70,7 +70,7 @@ std::string CopyFromOldName(StringID id)
 		std::ostringstream tmp;
 		std::ostreambuf_iterator<char> strto(tmp);
 		for (; *strfrom != '\0'; strfrom++) {
-			char32_t c = (byte)*strfrom;
+			char32_t c = (uint8_t)*strfrom;
 
 			/* Map from non-ISO8859-15 characters to UTF-8. */
 			switch (c) {

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -249,7 +249,7 @@ static void CheckValidVehicles()
 	}
 }
 
-extern byte _age_cargo_skip_counter; // From misc_sl.cpp
+extern uint8_t _age_cargo_skip_counter; // From misc_sl.cpp
 
 /** Called after load to update coordinates */
 void AfterLoadVehicles(bool part_of_load)

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -99,7 +99,7 @@ static_assert(sizeof(BitmapInfoHeader) == 40);
 
 /** Format of palette data in BMP header */
 struct RgbQuad {
-	byte blue, green, red, reserved;
+	uint8_t blue, green, red, reserved;
 };
 static_assert(sizeof(RgbQuad) == 4);
 
@@ -201,7 +201,7 @@ static bool MakeBMPImage(const char *name, ScreenshotCallback *callb, void *user
 				/* Convert from 'native' 32bpp to BMP-like 24bpp.
 				 * Works for both big and little endian machines */
 				Colour *src = ((Colour *)buff) + n * w;
-				byte *dst = line;
+				uint8_t *dst = line;
 				for (uint i = 0; i < w; i++) {
 					dst[i * 3    ] = src[i].b;
 					dst[i * 3 + 1] = src[i].g;
@@ -407,21 +407,21 @@ static bool MakePNGImage(const char *name, ScreenshotCallback *callb, void *user
 
 /** Definition of a PCX file header. */
 struct PcxHeader {
-	byte manufacturer;
-	byte version;
-	byte rle;
-	byte bpp;
+	uint8_t manufacturer;
+	uint8_t version;
+	uint8_t rle;
+	uint8_t bpp;
 	uint32_t unused;
 	uint16_t xmax, ymax;
 	uint16_t hdpi, vdpi;
-	byte pal_small[16 * 3];
-	byte reserved;
-	byte planes;
+	uint8_t pal_small[16 * 3];
+	uint8_t reserved;
+	uint8_t planes;
 	uint16_t pitch;
 	uint16_t cpal;
 	uint16_t width;
 	uint16_t height;
-	byte filler[54];
+	uint8_t filler[54];
 };
 static_assert(sizeof(PcxHeader) == 128);
 
@@ -496,7 +496,7 @@ static bool MakePCXImage(const char *name, ScreenshotCallback *callb, void *user
 		/* write them to pcx */
 		for (i = 0; i != n; i++) {
 			const uint8_t *bufp = buff + i * w;
-			byte runchar = bufp[0];
+			uint8_t runchar = bufp[0];
 			uint runcount = 1;
 			uint j;
 
@@ -548,7 +548,7 @@ static bool MakePCXImage(const char *name, ScreenshotCallback *callb, void *user
 	}
 
 	/* Palette is word-aligned, copy it to a temporary byte array */
-	byte tmp[256 * 3];
+	uint8_t tmp[256 * 3];
 
 	for (uint i = 0; i < 256; i++) {
 		tmp[i * 3 + 0] = palette[i].r;
@@ -818,7 +818,7 @@ static bool MakeLargeWorldScreenshot(ScreenshotType t, uint32_t width = 0, uint3
  */
 static void HeightmapCallback(void *, void *buffer, uint y, uint, uint n)
 {
-	byte *buf = (byte *)buffer;
+	uint8_t *buf = (uint8_t *)buffer;
 	while (n > 0) {
 		TileIndex ti = TileXY(Map::MaxX(), y);
 		for (uint x = Map::MaxX(); true; x--) {
@@ -1002,7 +1002,7 @@ static void MinimapScreenCallback(void *, void *buf, uint y, uint pitch, uint n)
 		uint col = (Map::SizeX() - 1) - (i % pitch);
 
 		TileIndex tile = TileXY(col, row);
-		byte val = GetSmallMapOwnerPixels(tile, GetTileType(tile), IncludeHeightmap::Never) & 0xFF;
+		uint8_t val = GetSmallMapOwnerPixels(tile, GetTileType(tile), IncludeHeightmap::Never) & 0xFF;
 
 		uint32_t colour_buf = 0;
 		colour_buf  = (_cur_palette.palette[val].b << 0);

--- a/src/script/api/script_bridgelist.cpp
+++ b/src/script/api/script_bridgelist.cpp
@@ -16,14 +16,14 @@
 
 ScriptBridgeList::ScriptBridgeList()
 {
-	for (byte j = 0; j < MAX_BRIDGES; j++) {
+	for (uint8_t j = 0; j < MAX_BRIDGES; j++) {
 		if (ScriptBridge::IsValidBridge(j)) this->AddItem(j);
 	}
 }
 
 ScriptBridgeList_Length::ScriptBridgeList_Length(SQInteger length)
 {
-	for (byte j = 0; j < MAX_BRIDGES; j++) {
+	for (uint8_t j = 0; j < MAX_BRIDGES; j++) {
 		if (ScriptBridge::IsValidBridge(j)) {
 			if (length >= ScriptBridge::GetMinLength(j) && length <= ScriptBridge::GetMaxLength(j)) this->AddItem(j);
 		}

--- a/src/script/api/script_company.cpp
+++ b/src/script/api/script_company.cpp
@@ -32,7 +32,7 @@
 {
 	if (company == COMPANY_SELF) {
 		if (!::Company::IsValidID(_current_company)) return COMPANY_INVALID;
-		return (CompanyID)((byte)_current_company);
+		return (CompanyID)((uint8_t)_current_company);
 	}
 
 	return ::Company::IsValidID(company) ? company : COMPANY_INVALID;

--- a/src/script/api/script_company.hpp
+++ b/src/script/api/script_company.hpp
@@ -99,7 +99,7 @@ public:
 	 * Types of expenses.
 	 * @api -ai
 	 */
-	enum ExpensesType : byte {
+	enum ExpensesType : uint8_t {
 		EXPENSES_CONSTRUCTION = ::EXPENSES_CONSTRUCTION,     ///< Construction costs.
 		EXPENSES_NEW_VEHICLES = ::EXPENSES_NEW_VEHICLES,     ///< New vehicles.
 		EXPENSES_TRAIN_RUN    = ::EXPENSES_TRAIN_RUN,        ///< Running costs trains.

--- a/src/script/api/script_goal.hpp
+++ b/src/script/api/script_goal.hpp
@@ -36,7 +36,7 @@ public:
 	/**
 	 * Goal types that can be given to a goal.
 	 */
-	enum GoalType : byte {
+	enum GoalType : uint8_t {
 		/* Note: these values represent part of the in-game GoalType enum */
 		GT_NONE     = ::GT_NONE,     ///< Destination is not linked.
 		GT_TILE     = ::GT_TILE,     ///< Destination is a tile.

--- a/src/script/api/script_industry.cpp
+++ b/src/script/api/script_industry.cpp
@@ -262,7 +262,7 @@
 	auto company_id = ::Industry::Get(industry_id)->exclusive_supplier;
 	if (!::Company::IsValidID(company_id)) return ScriptCompany::COMPANY_INVALID;
 
-	return (ScriptCompany::CompanyID)((byte)company_id);
+	return (ScriptCompany::CompanyID)((uint8_t)company_id);
 }
 
 /* static */ bool ScriptIndustry::SetExclusiveSupplier(IndustryID industry_id, ScriptCompany::CompanyID company_id)
@@ -282,7 +282,7 @@
 	auto company_id = ::Industry::Get(industry_id)->exclusive_consumer;
 	if (!::Company::IsValidID(company_id)) return ScriptCompany::COMPANY_INVALID;
 
-	return (ScriptCompany::CompanyID)((byte)company_id);
+	return (ScriptCompany::CompanyID)((uint8_t)company_id);
 }
 
 /* static */ bool ScriptIndustry::SetExclusiveConsumer(IndustryID industry_id, ScriptCompany::CompanyID company_id)

--- a/src/script/api/script_league.hpp
+++ b/src/script/api/script_league.hpp
@@ -42,7 +42,7 @@ public:
 	/**
 	 * The type of a link.
 	 */
-	enum LinkType : byte {
+	enum LinkType : uint8_t {
 		LINK_NONE = ::LT_NONE,             ///< No link
 		LINK_TILE = ::LT_TILE,             ///< Link a tile
 		LINK_INDUSTRY = ::LT_INDUSTRY,     ///< Link an industry

--- a/src/script/api/script_rail.hpp
+++ b/src/script/api/script_rail.hpp
@@ -40,7 +40,7 @@ public:
 	/**
 	 * Types of rail known to the game.
 	 */
-	enum RailType : byte {
+	enum RailType : uint8_t {
 		/* Note: these values represent part of the in-game static values */
 		RAILTYPE_INVALID  = ::INVALID_RAILTYPE, ///< Invalid RailType.
 	};

--- a/src/script/api/script_road.cpp
+++ b/src/script/api/script_road.cpp
@@ -245,13 +245,13 @@ static int32_t LookupWithBuildOnSlopes(::Slope slope, const Array<> &existing, i
 		SLOPE_W,    SLOPE_EW,  SLOPE_SW,  SLOPE_WSE,
 		SLOPE_W,    SLOPE_SW,  SLOPE_EW,  SLOPE_WSE,
 		SLOPE_SW,   SLOPE_WSE, SLOPE_WSE};
-	static const byte base_rotates[] = {0, 0, 1, 0, 2, 0, 1, 0, 3, 3, 2, 3, 2, 2, 1};
+	static const uint8_t base_rotates[] = {0, 0, 1, 0, 2, 0, 1, 0, 3, 3, 2, 3, 2, 2, 1};
 
 	if (slope >= (::Slope)lengthof(base_slopes)) {
 		/* This slope is an invalid slope, so ignore it. */
 		return -1;
 	}
-	byte base_rotate = base_rotates[slope];
+	uint8_t base_rotate = base_rotates[slope];
 	slope = base_slopes[slope];
 
 	/* Some slopes don't need rotating, so return early when we know we do

--- a/src/script/api/script_story_page.hpp
+++ b/src/script/api/script_story_page.hpp
@@ -57,7 +57,7 @@ public:
 	/**
 	 * Story page element types.
 	 */
-	enum StoryPageElementType : byte {
+	enum StoryPageElementType : uint8_t {
 		SPET_TEXT = ::SPET_TEXT,                     ///< An element that displays a block of text.
 		SPET_LOCATION = ::SPET_LOCATION,             ///< An element that displays a single line of text along with a button to view the referenced location.
 		SPET_GOAL = ::SPET_GOAL,                     ///< An element that displays a goal.
@@ -75,7 +75,7 @@ public:
 	 * Formatting and layout flags for story page buttons.
 	 * The SPBF_FLOAT_LEFT and SPBF_FLOAT_RIGHT flags can not be combined.
 	 */
-	enum StoryPageButtonFlags : byte {
+	enum StoryPageButtonFlags : uint8_t {
 		SPBF_NONE        = ::SPBF_NONE,        ///< No special formatting for button.
 		SPBF_FLOAT_LEFT  = ::SPBF_FLOAT_LEFT,  ///< Button is placed to the left of the following paragraph.
 		SPBF_FLOAT_RIGHT = ::SPBF_FLOAT_RIGHT, ///< Button is placed to the right of the following paragraph.
@@ -84,7 +84,7 @@ public:
 	/**
 	 * Mouse cursors usable by story page buttons.
 	 */
-	enum StoryPageButtonCursor : byte {
+	enum StoryPageButtonCursor : uint8_t {
 		SPBC_MOUSE          = ::SPBC_MOUSE,
 		SPBC_ZZZ            = ::SPBC_ZZZ,
 		SPBC_BUOY           = ::SPBC_BUOY,
@@ -146,7 +146,7 @@ public:
 	 * Colour codes usable for story page button elements.
 	 * Place a colour value in the lowest 8 bits of the \c reference parameter to the button.
 	 */
-	enum StoryPageButtonColour : byte {
+	enum StoryPageButtonColour : uint8_t {
 		SPBC_DARK_BLUE  = ::COLOUR_DARK_BLUE,
 		SPBC_PALE_GREEN = ::COLOUR_PALE_GREEN,
 		SPBC_PINK       = ::COLOUR_PINK,

--- a/src/script/api/script_subsidy.cpp
+++ b/src/script/api/script_subsidy.cpp
@@ -47,7 +47,7 @@
 {
 	if (!IsAwarded(subsidy_id)) return ScriptCompany::COMPANY_INVALID;
 
-	return (ScriptCompany::CompanyID)((byte)::Subsidy::Get(subsidy_id)->awarded);
+	return (ScriptCompany::CompanyID)((uint8_t)::Subsidy::Get(subsidy_id)->awarded);
 }
 
 /* static */ ScriptDate::Date ScriptSubsidy::GetExpireDate(SubsidyID subsidy_id)

--- a/src/script/api/script_tile.cpp
+++ b/src/script/api/script_tile.cpp
@@ -209,7 +209,7 @@
 	if (::IsTileType(tile, MP_HOUSE)) return ScriptCompany::COMPANY_INVALID;
 	if (::IsTileType(tile, MP_INDUSTRY)) return ScriptCompany::COMPANY_INVALID;
 
-	return ScriptCompany::ResolveCompanyID((ScriptCompany::CompanyID)(byte)::GetTileOwner(tile));
+	return ScriptCompany::ResolveCompanyID((ScriptCompany::CompanyID)(uint8_t)::GetTileOwner(tile));
 }
 
 /* static */ bool ScriptTile::HasTransportType(TileIndex tile, TransportType transport_type)

--- a/src/script/api/script_town.cpp
+++ b/src/script/api/script_town.cpp
@@ -294,7 +294,7 @@
 		EnforcePrecondition(false, layout >= ROAD_LAYOUT_ORIGINAL && layout <= ROAD_LAYOUT_RANDOM);
 	} else {
 		/* The layout parameter is ignored for AIs when custom layouts is disabled. */
-		layout = (RoadLayout) (byte)_settings_game.economy.town_layout;
+		layout = (RoadLayout) (uint8_t)_settings_game.economy.town_layout;
 	}
 
 	std::string text;

--- a/src/script/api/script_types.hpp
+++ b/src/script/api/script_types.hpp
@@ -87,7 +87,7 @@
 
 /* Define all types here, so we don't have to include the whole _type.h maze */
 typedef uint BridgeType;     ///< Internal name, not of any use for you.
-typedef byte CargoID;        ///< The ID of a cargo.
+typedef uint8_t CargoID;        ///< The ID of a cargo.
 class CommandCost;           ///< The cost of a command.
 typedef uint16_t EngineID;     ///< The ID of an engine.
 typedef uint16_t GoalID;       ///< The ID of a goal.

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -353,7 +353,7 @@
 	if (!IsValidVehicle(vehicle_id)) return ScriptVehicle::VS_INVALID;
 
 	const Vehicle *v = ::Vehicle::Get(vehicle_id);
-	byte vehstatus = v->vehstatus;
+	uint8_t vehstatus = v->vehstatus;
 
 	if (vehstatus & ::VS_CRASHED) return ScriptVehicle::VS_CRASHED;
 	if (v->breakdown_ctr != 0) return ScriptVehicle::VS_BROKEN;

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -344,7 +344,7 @@ ScriptLogTypes::LogData &ScriptInstance::GetLogData()
  *  - null:    No data.
  */
 
-static byte _script_sl_byte; ///< Used as source/target by the script saveload code to store/load a single byte.
+static uint8_t _script_sl_byte; ///< Used as source/target by the script saveload code to store/load a single byte.
 
 /** SaveLoad array that saves/loads exactly one byte. */
 static const SaveLoad _script_byte[] = {
@@ -386,7 +386,7 @@ static const SaveLoad _script_byte[] = {
 				return false;
 			}
 			if (!test) {
-				_script_sl_byte = (byte)len;
+				_script_sl_byte = (uint8_t)len;
 				SlObject(nullptr, _script_byte);
 				SlCopy(const_cast<char *>(buf), len, SLE_CHAR);
 			}

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -307,7 +307,7 @@ static bool LoadIntList(const char *str, void *array, int nelems, VarType type)
 		case SLE_VAR_BL:
 		case SLE_VAR_I8:
 		case SLE_VAR_U8:
-			for (i = 0; i != nitems; i++) ((byte*)array)[i] = items[i];
+			for (i = 0; i != nitems; i++) ((uint8_t*)array)[i] = items[i];
 			break;
 
 		case SLE_VAR_I16:
@@ -337,7 +337,7 @@ static bool LoadIntList(const char *str, void *array, int nelems, VarType type)
  */
 std::string ListSettingDesc::FormatValue(const void *object) const
 {
-	const byte *p = static_cast<const byte *>(GetVariableAddress(object, this->save));
+	const uint8_t *p = static_cast<const uint8_t *>(GetVariableAddress(object, this->save));
 
 	std::string result;
 	for (size_t i = 0; i != this->save.length; i++) {

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -820,7 +820,7 @@ struct GameOptionsWindow : Window {
 
 			case WID_GO_BASE_SFX_VOLUME:
 			case WID_GO_BASE_MUSIC_VOLUME: {
-				byte &vol = (widget == WID_GO_BASE_MUSIC_VOLUME) ? _settings_client.music.music_vol : _settings_client.music.effect_vol;
+				uint8_t &vol = (widget == WID_GO_BASE_MUSIC_VOLUME) ? _settings_client.music.music_vol : _settings_client.music.effect_vol;
 				if (ClickSliderWidget(this->GetWidget<NWidgetBase>(widget)->GetCurrentRect(), pt, 0, INT8_MAX, vol)) {
 					if (widget == WID_GO_BASE_MUSIC_VOLUME) {
 						MusicDriver::GetInstance()->SetVolume(vol);
@@ -1224,13 +1224,13 @@ struct SettingFilter {
 
 /** Data structure describing a single setting in a tab */
 struct BaseSettingEntry {
-	byte flags; ///< Flags of the setting entry. @see SettingEntryFlags
-	byte level; ///< Nesting level of this setting entry
+	uint8_t flags; ///< Flags of the setting entry. @see SettingEntryFlags
+	uint8_t level; ///< Nesting level of this setting entry
 
 	BaseSettingEntry() : flags(0), level(0) {}
 	virtual ~BaseSettingEntry() = default;
 
-	virtual void Init(byte level = 0);
+	virtual void Init(uint8_t level = 0);
 	virtual void FoldAll() {}
 	virtual void UnFoldAll() {}
 	virtual void ResetAll() = 0;
@@ -1268,13 +1268,13 @@ struct SettingEntry : BaseSettingEntry {
 
 	SettingEntry(const char *name);
 
-	void Init(byte level = 0) override;
+	void Init(uint8_t level = 0) override;
 	void ResetAll() override;
 	uint Length() const override;
 	uint GetMaxHelpHeight(int maxw) override;
 	bool UpdateFilterState(SettingFilter &filter, bool force_visible) override;
 
-	void SetButtons(byte new_val);
+	void SetButtons(uint8_t new_val);
 
 protected:
 	void DrawSetting(GameSettings *settings_ptr, int left, int right, int y, bool highlight) const override;
@@ -1295,7 +1295,7 @@ struct SettingsContainer {
 		return item;
 	}
 
-	void Init(byte level = 0);
+	void Init(uint8_t level = 0);
 	void ResetAll();
 	void FoldAll();
 	void UnFoldAll();
@@ -1318,7 +1318,7 @@ struct SettingsPage : BaseSettingEntry, SettingsContainer {
 
 	SettingsPage(StringID title);
 
-	void Init(byte level = 0) override;
+	void Init(uint8_t level = 0) override;
 	void ResetAll() override;
 	void FoldAll() override;
 	void UnFoldAll() override;
@@ -1343,7 +1343,7 @@ protected:
  * Initialization of a setting entry
  * @param level      Page nesting level of this entry
  */
-void BaseSettingEntry::Init(byte level)
+void BaseSettingEntry::Init(uint8_t level)
 {
 	this->level = level;
 }
@@ -1453,7 +1453,7 @@ SettingEntry::SettingEntry(const char *name)
  * Initialization of a setting entry
  * @param level      Page nesting level of this entry
  */
-void SettingEntry::Init(byte level)
+void SettingEntry::Init(uint8_t level)
 {
 	BaseSettingEntry::Init(level);
 	this->setting = GetSettingFromName(this->name)->AsIntSetting();
@@ -1470,7 +1470,7 @@ void SettingEntry::ResetAll()
  * @param new_val New value for the button flags
  * @see SettingEntryFlags
  */
-void SettingEntry::SetButtons(byte new_val)
+void SettingEntry::SetButtons(uint8_t new_val)
 {
 	assert((new_val & ~SEF_BUTTONS_MASK) == 0); // Should not touch any flags outside the buttons
 	this->flags = (this->flags & ~SEF_BUTTONS_MASK) | new_val;
@@ -1627,7 +1627,7 @@ void SettingEntry::DrawSetting(GameSettings *settings_ptr, int left, int right, 
  * Initialization of an entire setting page
  * @param level Nesting level of this page (internal variable, do not provide a value for it when calling)
  */
-void SettingsContainer::Init(byte level)
+void SettingsContainer::Init(uint8_t level)
 {
 	for (auto &it : this->entries) {
 		it->Init(level);
@@ -1785,7 +1785,7 @@ SettingsPage::SettingsPage(StringID title)
  * Initialization of an entire setting page
  * @param level Nesting level of this page (internal variable, do not provide a value for it when calling)
  */
-void SettingsPage::Init(byte level)
+void SettingsPage::Init(uint8_t level)
 {
 	BaseSettingEntry::Init(level);
 	SettingsContainer::Init(level + 1);
@@ -2907,7 +2907,7 @@ void ShowGameSettings()
  * @param clickable_left is the left button clickable?
  * @param clickable_right is the right button clickable?
  */
-void DrawArrowButtons(int x, int y, Colours button_colour, byte state, bool clickable_left, bool clickable_right)
+void DrawArrowButtons(int x, int y, Colours button_colour, uint8_t state, bool clickable_left, bool clickable_right)
 {
 	int colour = GetColourGradient(button_colour, SHADE_DARKER);
 	Dimension dim = NWidgetScrollbar::GetHorizontalDimension();

--- a/src/settings_gui.h
+++ b/src/settings_gui.h
@@ -18,7 +18,7 @@
 /** Height of setting buttons */
 #define SETTING_BUTTON_HEIGHT ((int)NWidgetScrollbar::GetHorizontalDimension().height)
 
-void DrawArrowButtons(int x, int y, Colours button_colour, byte state, bool clickable_left, bool clickable_right);
+void DrawArrowButtons(int x, int y, Colours button_colour, uint8_t state, bool clickable_left, bool clickable_right);
 void DrawDropDownButton(int x, int y, Colours button_colour, bool state, bool clickable);
 void DrawBoolButton(int x, int y, bool state, bool clickable);
 

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -246,11 +246,11 @@ struct SoundSettings {
 
 /** Settings related to music. */
 struct MusicSettings {
-	byte playlist;     ///< The playlist (number) to play
-	byte music_vol;    ///< The requested music volume
-	byte effect_vol;   ///< The requested effects volume
-	byte custom_1[33]; ///< The order of the first custom playlist
-	byte custom_2[33]; ///< The order of the second custom playlist
+	uint8_t playlist;     ///< The playlist (number) to play
+	uint8_t music_vol;    ///< The requested music volume
+	uint8_t effect_vol;   ///< The requested effects volume
+	uint8_t custom_1[33]; ///< The order of the first custom playlist
+	uint8_t custom_2[33]; ///< The order of the second custom playlist
 	bool playing;      ///< Whether music is playing
 	bool shuffle;      ///< Whether to shuffle the music
 };

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -467,8 +467,8 @@ static uint ShipAccelerate(Vehicle *v)
 	const uint advance_speed = v->GetAdvanceSpeed(speed);
 	const uint number_of_steps = (advance_speed + v->progress) / v->GetAdvanceDistance();
 	const uint remainder = (advance_speed + v->progress) % v->GetAdvanceDistance();
-	assert(remainder <= std::numeric_limits<byte>::max());
-	v->progress = static_cast<byte>(remainder);
+	assert(remainder <= std::numeric_limits<uint8_t>::max());
+	v->progress = static_cast<uint8_t>(remainder);
 	return number_of_steps;
 }
 
@@ -559,8 +559,8 @@ static inline TrackBits GetAvailShipTracks(TileIndex tile, DiagDirection dir)
 
 /** Structure for ship sub-coordinate data for moving into a new tile via a Diagdir onto a Track. */
 struct ShipSubcoordData {
-	byte x_subcoord; ///< New X sub-coordinate on the new tile
-	byte y_subcoord; ///< New Y sub-coordinate on the new tile
+	uint8_t x_subcoord; ///< New X sub-coordinate on the new tile
+	uint8_t y_subcoord; ///< New Y sub-coordinate on the new tile
 	Direction dir;   ///< New Direction to move in on the new track
 };
 /** Ship sub-coordinate data for moving into a new tile via a Diagdir onto a Track.

--- a/src/signal_func.h
+++ b/src/signal_func.h
@@ -19,9 +19,9 @@
  * Maps a trackdir to the bit that stores its status in the map arrays, in the
  * direction along with the trackdir.
  */
-inline byte SignalAlongTrackdir(Trackdir trackdir)
+inline uint8_t SignalAlongTrackdir(Trackdir trackdir)
 {
-	extern const byte _signal_along_trackdir[TRACKDIR_END];
+	extern const uint8_t _signal_along_trackdir[TRACKDIR_END];
 	return _signal_along_trackdir[trackdir];
 }
 
@@ -29,9 +29,9 @@ inline byte SignalAlongTrackdir(Trackdir trackdir)
  * Maps a trackdir to the bit that stores its status in the map arrays, in the
  * direction against the trackdir.
  */
-inline byte SignalAgainstTrackdir(Trackdir trackdir)
+inline uint8_t SignalAgainstTrackdir(Trackdir trackdir)
 {
-	extern const byte _signal_against_trackdir[TRACKDIR_END];
+	extern const uint8_t _signal_against_trackdir[TRACKDIR_END];
 	return _signal_against_trackdir[trackdir];
 }
 
@@ -39,9 +39,9 @@ inline byte SignalAgainstTrackdir(Trackdir trackdir)
  * Maps a Track to the bits that store the status of the two signals that can
  * be present on the given track.
  */
-inline byte SignalOnTrack(Track track)
+inline uint8_t SignalOnTrack(Track track)
 {
-	extern const byte _signal_on_track[TRACK_END];
+	extern const uint8_t _signal_on_track[TRACK_END];
 	return _signal_on_track[track];
 }
 

--- a/src/signal_type.h
+++ b/src/signal_type.h
@@ -13,14 +13,14 @@
 #include "core/enum_type.hpp"
 
 /** Variant of the signal, i.e. how does the signal look? */
-enum SignalVariant : byte {
+enum SignalVariant : uint8_t {
 	SIG_ELECTRIC  = 0, ///< Light signal
 	SIG_SEMAPHORE = 1, ///< Old-fashioned semaphore signal
 };
 
 
 /** Type of signal, i.e. how does the signal behave? */
-enum SignalType : byte {
+enum SignalType : uint8_t {
 	SIGTYPE_BLOCK      = 0, ///< block signal
 	SIGTYPE_ENTRY      = 1, ///< presignal block entry
 	SIGTYPE_EXIT       = 2, ///< presignal block exit

--- a/src/slope_func.h
+++ b/src/slope_func.h
@@ -414,7 +414,7 @@ inline Foundation SpecialRailFoundation(Corner corner)
  */
 inline uint SlopeToSpriteOffset(Slope s)
 {
-	extern const byte _slope_to_sprite_offset[32];
+	extern const uint8_t _slope_to_sprite_offset[32];
 	return _slope_to_sprite_offset[s];
 }
 

--- a/src/slope_type.h
+++ b/src/slope_type.h
@@ -45,7 +45,7 @@ enum Corner {
  * slopes would mean that it is not a steep slope as halftile
  * slopes only span one height level.
  */
-enum Slope : byte {
+enum Slope : uint8_t {
 	SLOPE_FLAT     = 0x00,                                  ///< a flat tile
 	SLOPE_W        = 0x01,                                  ///< the west corner of the tile is raised
 	SLOPE_S        = 0x02,                                  ///< the south corner of the tile is raised

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -406,7 +406,7 @@ static const AndOr _smallmap_vehicles_andor[] = {
 };
 
 /** Mapping of tile type to importance of the tile (higher number means more interesting to show). */
-static const byte _tiletype_importance[] = {
+static const uint8_t _tiletype_importance[] = {
 	2, // MP_CLEAR
 	8, // MP_RAILWAY
 	7, // MP_ROAD
@@ -607,12 +607,12 @@ uint32_t GetSmallMapOwnerPixels(TileIndex tile, TileType t, IncludeHeightmap inc
 }
 
 /** Vehicle colours in #SMT_VEHICLES mode. Indexed by #VehicleType. */
-static const byte _vehicle_type_colours[6] = {
+static const uint8_t _vehicle_type_colours[6] = {
 	PC_RED, PC_YELLOW, PC_LIGHT_BLUE, PC_WHITE, PC_BLACK, PC_RED
 };
 
 /** Types of legends in the #WID_SM_LEGEND widget. */
-enum SmallMapType : byte {
+enum SmallMapType : uint8_t {
 	SMT_CONTOUR,
 	SMT_VEHICLES,
 	SMT_INDUSTRY,
@@ -972,7 +972,7 @@ protected:
 			}
 
 			/* Calculate pointer to pixel and the colour */
-			byte colour = (this->map_type == SMT_VEHICLES) ? _vehicle_type_colours[v->type] : PC_WHITE;
+			uint8_t colour = (this->map_type == SMT_VEHICLES) ? _vehicle_type_colours[v->type] : PC_WHITE;
 
 			/* And draw either one or two pixels depending on clipping */
 			blitter->SetPixel(dpi->dst_ptr, x, y, colour);

--- a/src/sortlist_type.h
+++ b/src/sortlist_type.h
@@ -29,12 +29,12 @@ DECLARE_ENUM_AS_BIT_SET(SortListFlags)
 /** Data structure describing how to show the list (what sort direction and criteria). */
 struct Listing {
 	bool order;    ///< Ascending/descending
-	byte criteria; ///< Sorting criteria
+	uint8_t criteria; ///< Sorting criteria
 };
 /** Data structure describing what to show in the list (filter criteria). */
 struct Filtering {
 	bool state;    ///< Filter on/off
-	byte criteria; ///< Filtering criteria
+	uint8_t criteria; ///< Filtering criteria
 };
 
 /**

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -194,10 +194,10 @@ static void StartSound(SoundID sound_id, float pan, uint volume)
 }
 
 
-static const byte _vol_factor_by_zoom[] = {255, 255, 255, 190, 134, 87};
+static const uint8_t _vol_factor_by_zoom[] = {255, 255, 255, 190, 134, 87};
 static_assert(lengthof(_vol_factor_by_zoom) == ZOOM_LVL_END);
 
-static const byte _sound_base_vol[] = {
+static const uint8_t _sound_base_vol[] = {
 	128,  90, 128, 128, 128, 128, 128, 128,
 	128,  90,  90, 128, 128, 128, 128, 128,
 	128, 128, 128,  80, 128, 128, 128, 128,
@@ -210,7 +210,7 @@ static const byte _sound_base_vol[] = {
 	 90,
 };
 
-static const byte _sound_idx[] = {
+static const uint8_t _sound_idx[] = {
 	 2,  3,  4,  5,  6,  7,  8,  9,
 	10, 11, 12, 13, 14, 15, 16, 17,
 	18, 19, 20, 21, 22, 23, 24, 25,

--- a/src/sound_type.h
+++ b/src/sound_type.h
@@ -19,7 +19,7 @@ struct SoundEntry {
 	uint8_t channels;
 	uint8_t volume;
 	uint8_t priority;
-	byte grf_container_ver; ///< NewGRF container version if the sound is from a NewGRF.
+	uint8_t grf_container_ver; ///< NewGRF container version if the sound is from a NewGRF.
 };
 
 /**

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -26,9 +26,9 @@ struct DrawTileSeqStruct {
 	int8_t delta_x; ///< \c 0x80 is sequence terminator
 	int8_t delta_y;
 	int8_t delta_z; ///< \c 0x80 identifies child sprites
-	byte size_x;
-	byte size_y;
-	byte size_z;
+	uint8_t size_x;
+	uint8_t size_y;
+	uint8_t size_z;
 	PalSpriteID image;
 
 	/** Make this struct a sequence terminator. */
@@ -40,13 +40,13 @@ struct DrawTileSeqStruct {
 	/** Check whether this is a sequence terminator. */
 	bool IsTerminator() const
 	{
-		return (byte)this->delta_x == 0x80;
+		return (uint8_t)this->delta_x == 0x80;
 	}
 
 	/** Check whether this is a parent sprite with a boundingbox. */
 	bool IsParentSprite() const
 	{
-		return (byte)this->delta_z != 0x80;
+		return (uint8_t)this->delta_z != 0x80;
 	}
 };
 
@@ -67,12 +67,12 @@ struct DrawTileSprites {
 struct DrawBuildingsTileStruct {
 	PalSpriteID ground;
 	PalSpriteID building;
-	byte subtile_x;
-	byte subtile_y;
-	byte width;
-	byte height;
-	byte dz;
-	byte draw_proc;  // this allows to specify a special drawing procedure.
+	uint8_t subtile_x;
+	uint8_t subtile_y;
+	uint8_t width;
+	uint8_t height;
+	uint8_t dz;
+	uint8_t draw_proc;  // this allows to specify a special drawing procedure.
 };
 
 /** Iterate through all DrawTileSeqStructs in DrawTileSprites. */

--- a/src/spritecache.h
+++ b/src/spritecache.h
@@ -19,7 +19,7 @@ struct Sprite {
 	uint16_t width;  ///< Width of the sprite.
 	int16_t x_offs;  ///< Number of pixels to shift the sprite to the right.
 	int16_t y_offs;  ///< Number of pixels to shift the sprite downwards.
-	byte data[];   ///< Sprite data.
+	uint8_t data[];   ///< Sprite data.
 };
 
 enum SpriteCacheCtrlFlags {
@@ -50,10 +50,10 @@ inline const Sprite *GetSprite(SpriteID sprite, SpriteType type)
 	return (Sprite*)GetRawSprite(sprite, type);
 }
 
-inline const byte *GetNonSprite(SpriteID sprite, SpriteType type)
+inline const uint8_t *GetNonSprite(SpriteID sprite, SpriteType type)
 {
 	assert(type == SpriteType::Recolour);
-	return (byte*)GetRawSprite(sprite, type);
+	return (uint8_t*)GetRawSprite(sprite, type);
 }
 
 void GfxInitSpriteMem();
@@ -66,7 +66,7 @@ SpriteFile &OpenCachedSpriteFile(const std::string &filename, Subdirectory subdi
 void ReadGRFSpriteOffsets(SpriteFile &file);
 size_t GetGRFSpriteOffset(uint32_t id);
 bool LoadNextSprite(int load_index, SpriteFile &file, uint file_sprite_id);
-bool SkipSpriteData(SpriteFile &file, byte type, uint16_t num);
+bool SkipSpriteData(SpriteFile &file, uint8_t type, uint16_t num);
 void DupSprite(SpriteID old_spr, SpriteID new_spr);
 
 #endif /* SPRITECACHE_H */

--- a/src/spritecache_internal.h
+++ b/src/spritecache_internal.h
@@ -28,7 +28,7 @@ struct SpriteCache {
 	int16_t lru;
 	SpriteType type;     ///< In some cases a single sprite is misused by two NewGRFs. Once as real sprite and once as recolour sprite. If the recolour sprite gets into the cache it might be drawn as real sprite which causes enormous trouble.
 	bool warned;         ///< True iff the user has been warned about incorrect use of this sprite
-	byte control_flags;  ///< Control flags, see SpriteCacheCtrlFlags
+	uint8_t control_flags;  ///< Control flags, see SpriteCacheCtrlFlags
 };
 
 inline bool IsMapgenSpriteID(SpriteID sprite)

--- a/src/spriteloader/grf.cpp
+++ b/src/spriteloader/grf.cpp
@@ -22,7 +22,7 @@
 
 #include "../safeguards.h"
 
-extern const byte _palmap_w2d[];
+extern const uint8_t _palmap_w2d[];
 
 /**
  * We found a corrupted sprite. This means that the sprite itself
@@ -34,7 +34,7 @@ extern const byte _palmap_w2d[];
  */
 static bool WarnCorruptSprite(const SpriteFile &file, size_t file_pos, int line)
 {
-	static byte warning_level = 0;
+	static uint8_t warning_level = 0;
 	if (warning_level == 0) {
 		SetDParamStr(0, file.GetSimplifiedFilename());
 		ShowErrorMessage(STR_NEWGRF_ERROR_CORRUPT_SPRITE, INVALID_STRING_ID, WL_ERROR);
@@ -57,7 +57,7 @@ static bool WarnCorruptSprite(const SpriteFile &file, size_t file_pos, int line)
  * @param container_format Container format of the GRF this sprite is in.
  * @return True if the sprite was successfully loaded.
  */
-bool DecodeSingleSprite(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, int64_t num, byte type, ZoomLevel zoom_lvl, byte colour_fmt, byte container_format)
+bool DecodeSingleSprite(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, int64_t num, uint8_t type, ZoomLevel zoom_lvl, uint8_t colour_fmt, uint8_t container_format)
 {
 	/*
 	 * Original sprite height was max 255 pixels, with 4x extra zoom => 1020 pixels.
@@ -68,8 +68,8 @@ bool DecodeSingleSprite(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t f
 	 */
 	if (num < 0 || num > 64 * 1024 * 1024) return WarnCorruptSprite(file, file_pos, __LINE__);
 
-	std::unique_ptr<byte[]> dest_orig(new byte[num]);
-	byte *dest = dest_orig.get();
+	std::unique_ptr<uint8_t[]> dest_orig(new uint8_t[num]);
+	uint8_t *dest = dest_orig.get();
 	const int64_t dest_size = num;
 
 	/* Read the file, which has some kind of compression */
@@ -165,7 +165,7 @@ bool DecodeSingleSprite(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t f
 					if (colour_fmt & SCC_PAL) {
 						switch (sprite_type) {
 							case SpriteType::Normal: data->m = file.NeedsPaletteRemap() ? _palmap_w2d[*dest] : *dest; break;
-							case SpriteType::Font:   data->m = std::min<byte>(*dest, 2u); break;
+							case SpriteType::Font:   data->m = std::min<uint8_t>(*dest, 2u); break;
 							default:        data->m = *dest; break;
 						}
 						/* Magic blue. */
@@ -183,7 +183,7 @@ bool DecodeSingleSprite(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t f
 		}
 
 		if (dest_size > sprite_size) {
-			static byte warning_level = 0;
+			static uint8_t warning_level = 0;
 			Debug(sprite, warning_level, "Ignoring {} unused extra bytes from the sprite from {} at position {}", dest_size - sprite_size, file.GetSimplifiedFilename(), file_pos);
 			warning_level = 6;
 		}
@@ -191,7 +191,7 @@ bool DecodeSingleSprite(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t f
 		dest = dest_orig.get();
 
 		for (int i = 0; i < sprite->width * sprite->height; i++) {
-			byte *pixel = &dest[i * bpp];
+			uint8_t *pixel = &dest[i * bpp];
 
 			if (colour_fmt & SCC_RGB) {
 				sprite->data[i].r = *pixel++;
@@ -202,7 +202,7 @@ bool DecodeSingleSprite(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t f
 			if (colour_fmt & SCC_PAL) {
 				switch (sprite_type) {
 					case SpriteType::Normal: sprite->data[i].m = file.NeedsPaletteRemap() ? _palmap_w2d[*pixel] : *pixel; break;
-					case SpriteType::Font:   sprite->data[i].m = std::min<byte>(*pixel, 2u); break;
+					case SpriteType::Font:   sprite->data[i].m = std::min<uint8_t>(*pixel, 2u); break;
 					default:        sprite->data[i].m = *pixel; break;
 				}
 				/* Magic blue. */
@@ -225,7 +225,7 @@ uint8_t LoadSpriteV1(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, s
 
 	/* Read the size and type */
 	int num = file.ReadWord();
-	byte type = file.ReadByte();
+	uint8_t type = file.ReadByte();
 
 	/* Type 0xFF indicates either a colourmap or some other non-sprite info; we do not handle them here */
 	if (type == 0xFF) return 0;
@@ -252,7 +252,7 @@ uint8_t LoadSpriteV1(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, s
 	return 0;
 }
 
-uint8_t LoadSpriteV2(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, byte control_flags)
+uint8_t LoadSpriteV2(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, uint8_t control_flags)
 {
 	static const ZoomLevel zoom_lvl_map[6] = {ZOOM_LVL_OUT_4X, ZOOM_LVL_NORMAL, ZOOM_LVL_OUT_2X, ZOOM_LVL_OUT_8X, ZOOM_LVL_OUT_16X, ZOOM_LVL_OUT_32X};
 
@@ -268,13 +268,13 @@ uint8_t LoadSpriteV2(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, s
 	do {
 		int64_t num = file.ReadDword();
 		size_t start_pos = file.GetPos();
-		byte type = file.ReadByte();
+		uint8_t type = file.ReadByte();
 
 		/* Type 0xFF indicates either a colourmap or some other non-sprite info; we do not handle them here. */
 		if (type == 0xFF) return 0;
 
-		byte colour = type & SCC_MASK;
-		byte zoom = file.ReadByte();
+		uint8_t colour = type & SCC_MASK;
+		uint8_t zoom = file.ReadByte();
 
 		bool is_wanted_colour_depth = (colour != 0 && (load_32bpp ? colour != SCC_PAL : colour == SCC_PAL));
 		bool is_wanted_zoom_lvl;
@@ -350,7 +350,7 @@ uint8_t LoadSpriteV2(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, s
 	return loaded_sprites;
 }
 
-uint8_t SpriteLoaderGrf::LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, byte control_flags)
+uint8_t SpriteLoaderGrf::LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, uint8_t control_flags)
 {
 	if (this->container_ver >= 2) {
 		return LoadSpriteV2(sprite, file, file_pos, sprite_type, load_32bpp, control_flags);

--- a/src/spriteloader/grf.hpp
+++ b/src/spriteloader/grf.hpp
@@ -14,10 +14,10 @@
 
 /** Sprite loader for graphics coming from a (New)GRF. */
 class SpriteLoaderGrf : public SpriteLoader {
-	byte container_ver;
+	uint8_t container_ver;
 public:
-	SpriteLoaderGrf(byte container_ver) : container_ver(container_ver) {}
-	uint8_t LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, byte control_flags) override;
+	SpriteLoaderGrf(uint8_t container_ver) : container_ver(container_ver) {}
+	uint8_t LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, uint8_t control_flags) override;
 };
 
 #endif /* SPRITELOADER_GRF_HPP */

--- a/src/spriteloader/sprite_file.cpp
+++ b/src/spriteloader/sprite_file.cpp
@@ -11,13 +11,13 @@
 #include "sprite_file_type.hpp"
 
 /** Signature of a container version 2 GRF. */
-extern const byte _grf_cont_v2_sig[8] = {'G', 'R', 'F', 0x82, 0x0D, 0x0A, 0x1A, 0x0A};
+extern const uint8_t _grf_cont_v2_sig[8] = {'G', 'R', 'F', 0x82, 0x0D, 0x0A, 0x1A, 0x0A};
 
 /**
  * Get the container version of the currently opened GRF file.
  * @return Container version of the GRF file or 0 if the file is corrupt/no GRF file.
  */
-static byte GetGRFContainerVersion(SpriteFile &file)
+static uint8_t GetGRFContainerVersion(SpriteFile &file)
 {
 	size_t pos = file.GetPos();
 

--- a/src/spriteloader/sprite_file_type.hpp
+++ b/src/spriteloader/sprite_file_type.hpp
@@ -18,7 +18,7 @@
  */
 class SpriteFile : public RandomAccessFile {
 	bool palette_remap;     ///< Whether or not a remap of the palette is required for this file.
-	byte container_version; ///< Container format of the sprite file.
+	uint8_t container_version; ///< Container format of the sprite file.
 	size_t content_begin;   ///< The begin of the content of the sprite file, i.e. after the container metadata.
 public:
 	SpriteFile(const std::string &filename, Subdirectory subdir, bool palette_remap);
@@ -35,7 +35,7 @@ public:
 	 * Get the version number of container type used by the file.
 	 * @return The version.
 	 */
-	byte GetContainerVersion() const { return this->container_version; }
+	uint8_t GetContainerVersion() const { return this->container_version; }
 
 	/**
 	 * Seek to the begin of the content, i.e. the position just after the container version has been determined.

--- a/src/spriteloader/spriteloader.hpp
+++ b/src/spriteloader/spriteloader.hpp
@@ -80,7 +80,7 @@ public:
 	 * @param control_flags Control flags, see SpriteCacheCtrlFlags.
 	 * @return Bit mask of the zoom levels successfully loaded or 0 if no sprite could be loaded.
 	 */
-	virtual uint8_t LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, byte control_flags) = 0;
+	virtual uint8_t LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, uint8_t control_flags) = 0;
 
 	virtual ~SpriteLoader() = default;
 };

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -168,7 +168,7 @@ void BaseStation::PostDestructor(size_t)
 	InvalidateWindowData(WC_SELECT_STATION, 0, 0);
 }
 
-void BaseStation::SetRoadStopTileData(TileIndex tile, byte data, bool animation)
+void BaseStation::SetRoadStopTileData(TileIndex tile, uint8_t data, bool animation)
 {
 	for (RoadStopTileData &tile_data : this->custom_roadstop_tile_data) {
 		if (tile_data.tile == tile) {

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -214,7 +214,7 @@ struct GoodsEntry {
 	NodeID node{INVALID_NODE}; ///< ID of node in link graph referring to this goods entry.
 	LinkGraphID link_graph{INVALID_LINK_GRAPH}; ///< Link graph this station belongs to.
 
-	byte status{0}; ///< Status of this cargo, see #GoodsEntryStatus.
+	uint8_t status{0}; ///< Status of this cargo, see #GoodsEntryStatus.
 
 	/**
 	 * Number of rating-intervals (up to 255) since the last vehicle tried to load this cargo.
@@ -291,8 +291,8 @@ struct Airport : public TileArea {
 	Airport() : TileArea(INVALID_TILE, 0, 0) {}
 
 	uint64_t flags;       ///< stores which blocks on the airport are taken. was 16 bit earlier on, then 32
-	byte type;          ///< Type of this airport, @see AirportTypes
-	byte layout;        ///< Airport layout number.
+	uint8_t type;          ///< Type of this airport, @see AirportTypes
+	uint8_t layout;        ///< Airport layout number.
 	Direction rotation; ///< How this airport is rotated.
 
 	PersistentStorage *psa; ///< Persistent storage for NewGRF airports.
@@ -463,10 +463,10 @@ public:
 
 	StationHadVehicleOfType had_vehicle_of_type;
 
-	byte time_since_load;
-	byte time_since_unload;
+	uint8_t time_since_load;
+	uint8_t time_since_unload;
 
-	byte last_vehicle_type;
+	uint8_t last_vehicle_type;
 	std::list<Vehicle *> loading_vehicles;
 	GoodsEntry goods[NUM_CARGO];  ///< Goods at this station
 	CargoTypes always_accepted;       ///< Bitmask of always accepted cargo types (by houses, HQs, industry tiles when industry doesn't accept cargo)
@@ -519,7 +519,7 @@ public:
 		return IsAirportTile(tile) && GetStationIndex(tile) == this->index;
 	}
 
-	uint32_t GetNewGRFVariable(const ResolverObject &object, byte variable, byte parameter, bool *available) const override;
+	uint32_t GetNewGRFVariable(const ResolverObject &object, uint8_t variable, uint8_t parameter, bool *available) const override;
 
 	void GetTileArea(TileArea *ta, StationType type) const override;
 };

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -877,7 +877,7 @@ static CommandCost CheckFlatLandAirport(AirportTileTableIterator tile_iter, DoCo
  * @param numtracks Number of platforms.
  * @return The cost in case of success, or an error code if it failed.
  */
-static CommandCost CheckFlatLandRailStation(TileArea tile_area, DoCommandFlag flags, Axis axis, StationID *station, RailType rt, std::vector<Train *> &affected_vehicles, StationClassID spec_class, uint16_t spec_index, byte plat_len, byte numtracks)
+static CommandCost CheckFlatLandRailStation(TileArea tile_area, DoCommandFlag flags, Axis axis, StationID *station, RailType rt, std::vector<Train *> &affected_vehicles, StationClassID spec_class, uint16_t spec_index, uint8_t plat_len, uint8_t numtracks)
 {
 	CommandCost cost(EXPENSES_CONSTRUCTION);
 	int allowed_z = -1;
@@ -1096,7 +1096,7 @@ CommandCost CanExpandRailStation(const BaseStation *st, TileArea &new_ta)
 	return CommandCost();
 }
 
-static inline byte *CreateSingle(byte *layout, int n)
+static inline uint8_t *CreateSingle(uint8_t *layout, int n)
 {
 	int i = n;
 	do *layout++ = 0; while (--i);
@@ -1104,7 +1104,7 @@ static inline byte *CreateSingle(byte *layout, int n)
 	return layout;
 }
 
-static inline byte *CreateMulti(byte *layout, int n, byte b)
+static inline uint8_t *CreateMulti(uint8_t *layout, int n, uint8_t b)
 {
 	int i = n;
 	do *layout++ = b; while (--i);
@@ -1122,7 +1122,7 @@ static inline byte *CreateMulti(byte *layout, int n, byte b)
  * @param plat_len  The length of the platforms.
  * @param statspec  The specification of the station to (possibly) get the layout from.
  */
-void GetStationLayout(byte *layout, uint numtracks, uint plat_len, const StationSpec *statspec)
+void GetStationLayout(uint8_t *layout, uint numtracks, uint plat_len, const StationSpec *statspec)
 {
 	if (statspec != nullptr && statspec->layouts.size() >= plat_len &&
 			statspec->layouts[plat_len - 1].size() >= numtracks &&
@@ -1260,11 +1260,11 @@ static void RestoreTrainReservation(Train *v)
  * @param numtracks Number of platforms.
  * @return The cost in case of success, or an error code if it failed.
  */
-static CommandCost CalculateRailStationCost(TileArea tile_area, DoCommandFlag flags, Axis axis, StationID *station, RailType rt, std::vector<Train *> &affected_vehicles, StationClassID spec_class, uint16_t spec_index, byte plat_len, byte numtracks)
+static CommandCost CalculateRailStationCost(TileArea tile_area, DoCommandFlag flags, Axis axis, StationID *station, RailType rt, std::vector<Train *> &affected_vehicles, StationClassID spec_class, uint16_t spec_index, uint8_t plat_len, uint8_t numtracks)
 {
 	CommandCost cost(EXPENSES_CONSTRUCTION);
 	bool length_price_ready = true;
-	byte tracknum = 0;
+	uint8_t tracknum = 0;
 	for (TileIndex cur_tile : tile_area) {
 		/* Clear the land below the station. */
 		CommandCost ret = CheckFlatLandRailStation(TileArea(cur_tile, 1, 1), flags, axis, station, rt, affected_vehicles, spec_class, spec_index, plat_len, numtracks);
@@ -1309,7 +1309,7 @@ static CommandCost CalculateRailStationCost(TileArea tile_area, DoCommandFlag fl
  * @param adjacent allow stations directly adjacent to other stations.
  * @return the cost of this operation or an error
  */
-CommandCost CmdBuildRailStation(DoCommandFlag flags, TileIndex tile_org, RailType rt, Axis axis, byte numtracks, byte plat_len, StationClassID spec_class, uint16_t spec_index, StationID station_to_join, bool adjacent)
+CommandCost CmdBuildRailStation(DoCommandFlag flags, TileIndex tile_org, RailType rt, Axis axis, uint8_t numtracks, uint8_t plat_len, StationClassID spec_class, uint16_t spec_index, StationID station_to_join, bool adjacent)
 {
 	/* Does the authority allow this? */
 	CommandCost ret = CheckIfAuthorityAllowsNewStation(tile_org, flags);
@@ -1383,7 +1383,7 @@ CommandCost CmdBuildRailStation(DoCommandFlag flags, TileIndex tile_org, RailTyp
 
 	if (flags & DC_EXEC) {
 		TileIndexDiff tile_delta;
-		byte numtracks_orig;
+		uint8_t numtracks_orig;
 		Track track;
 
 		st->train_station = new_location;
@@ -1400,7 +1400,7 @@ CommandCost CmdBuildRailStation(DoCommandFlag flags, TileIndex tile_org, RailTyp
 		tile_delta = (axis == AXIS_X ? TileDiffXY(1, 0) : TileDiffXY(0, 1));
 		track = AxisToTrack(axis);
 
-		std::vector<byte> layouts(numtracks * plat_len);
+		std::vector<uint8_t> layouts(numtracks * plat_len);
 		GetStationLayout(layouts.data(), numtracks, plat_len, statspec);
 
 		numtracks_orig = numtracks;
@@ -1412,7 +1412,7 @@ CommandCost CmdBuildRailStation(DoCommandFlag flags, TileIndex tile_org, RailTyp
 			TileIndex tile = tile_track;
 			int w = plat_len;
 			do {
-				byte layout = layouts[layout_idx++];
+				uint8_t layout = layouts[layout_idx++];
 				if (IsRailStationTile(tile) && HasStationReservation(tile)) {
 					/* Check for trains having a reservation for this tile. */
 					Train *v = GetTrainForReservation(tile, AxisToTrack(GetRailStationAxis(tile)));
@@ -1430,7 +1430,7 @@ CommandCost CmdBuildRailStation(DoCommandFlag flags, TileIndex tile_org, RailTyp
 
 				/* Remove animation if overbuilding */
 				DeleteAnimatedTile(tile);
-				byte old_specindex = HasStationTileRail(tile) ? GetCustomStationSpecIndex(tile) : 0;
+				uint8_t old_specindex = HasStationTileRail(tile) ? GetCustomStationSpecIndex(tile) : 0;
 				MakeRailStation(tile, st->owner, st->index, axis, layout & ~1, rt);
 				/* Free the spec if we overbuild something */
 				DeallocateSpecFromStation(st, old_specindex);
@@ -2384,7 +2384,7 @@ void UpdateAirportsNoise()
  * @param allow_adjacent allow airports directly adjacent to other airports.
  * @return the cost of this operation or an error
  */
-CommandCost CmdBuildAirport(DoCommandFlag flags, TileIndex tile, byte airport_type, byte layout, StationID station_to_join, bool allow_adjacent)
+CommandCost CmdBuildAirport(DoCommandFlag flags, TileIndex tile, uint8_t airport_type, uint8_t layout, StationID station_to_join, bool allow_adjacent)
 {
 	bool reuse = (station_to_join != NEW_STATION);
 	if (!reuse) station_to_join = INVALID_STATION;
@@ -2638,8 +2638,8 @@ static const TileIndexDiffC _dock_tileoffs_chkaround[] = {
 	{ 0,  0},
 	{ 0, -1}
 };
-static const byte _dock_w_chk[4] = { 2, 1, 2, 1 };
-static const byte _dock_h_chk[4] = { 1, 2, 1, 2 };
+static const uint8_t _dock_w_chk[4] = { 2, 1, 2, 1 };
+static const uint8_t _dock_h_chk[4] = { 1, 2, 1, 2 };
 
 /**
  * Build a dock/haven.
@@ -2866,7 +2866,7 @@ static CommandCost RemoveDock(TileIndex tile, DoCommandFlag flags)
 
 #include "table/station_land.h"
 
-const DrawTileSprites *GetStationTileLayout(StationType st, byte gfx)
+const DrawTileSprites *GetStationTileLayout(StationType st, uint8_t gfx)
 {
 	return &_station_display_datas[st][gfx];
 }
@@ -3597,9 +3597,9 @@ static bool StationHandleBigTick(BaseStation *st)
 	return true;
 }
 
-static inline void byte_inc_sat(byte *p)
+static inline void byte_inc_sat(uint8_t *p)
 {
-	byte b = *p + 1;
+	uint8_t b = *p + 1;
 	if (b != 0) *p = b;
 }
 
@@ -3698,7 +3698,7 @@ static void UpdateStationRating(Station *st)
 				int b = ge->last_speed - 85;
 				if (b >= 0) rating += b >> 2;
 
-				byte waittime = ge->time_since_pickup;
+				uint8_t waittime = ge->time_since_pickup;
 				if (st->last_vehicle_type == VEH_SHIP) waittime >>= 2;
 				if (waittime <= 21) rating += 25;
 				if (waittime <= 12) rating += 25;
@@ -3715,7 +3715,7 @@ static void UpdateStationRating(Station *st)
 
 			if (Company::IsValidID(st->owner) && HasBit(st->town->statues, st->owner)) rating += 26;
 
-			byte age = ge->last_age;
+			uint8_t age = ge->last_age;
 			if (age < 3) rating += 10;
 			if (age < 2) rating += 10;
 			if (age < 1) rating += 13;
@@ -3983,7 +3983,7 @@ static void StationHandleSmallTick(BaseStation *st)
 {
 	if ((st->facilities & FACIL_WAYPOINT) != 0 || !st->IsInUse()) return;
 
-	byte b = st->delete_ctr + 1;
+	uint8_t b = st->delete_ctr + 1;
 	if (b >= Ticks::STATION_RATING_TICKS) b = 0;
 	st->delete_ctr = b;
 

--- a/src/station_cmd.h
+++ b/src/station_cmd.h
@@ -13,15 +13,15 @@
 #include "command_type.h"
 #include "station_type.h"
 
-enum StationClassID : byte;
-enum RoadStopClassID : byte;
+enum StationClassID : uint8_t;
+enum RoadStopClassID : uint8_t;
 
 extern Town *AirportGetNearestTown(const struct AirportSpec *as, Direction rotation, TileIndex tile, TileIterator &&it, uint &mindist);
 extern uint8_t GetAirportNoiseLevelForDistance(const struct AirportSpec *as, uint distance);
 
-CommandCost CmdBuildAirport(DoCommandFlag flags, TileIndex tile, byte airport_type, byte layout, StationID station_to_join, bool allow_adjacent);
+CommandCost CmdBuildAirport(DoCommandFlag flags, TileIndex tile, uint8_t airport_type, uint8_t layout, StationID station_to_join, bool allow_adjacent);
 CommandCost CmdBuildDock(DoCommandFlag flags, TileIndex tile, StationID station_to_join, bool adjacent);
-CommandCost CmdBuildRailStation(DoCommandFlag flags, TileIndex tile_org, RailType rt, Axis axis, byte numtracks, byte plat_len, StationClassID spec_class, uint16_t spec_index, StationID station_to_join, bool adjacent);
+CommandCost CmdBuildRailStation(DoCommandFlag flags, TileIndex tile_org, RailType rt, Axis axis, uint8_t numtracks, uint8_t plat_len, StationClassID spec_class, uint16_t spec_index, StationID station_to_join, bool adjacent);
 CommandCost CmdRemoveFromRailStation(DoCommandFlag flags, TileIndex start, TileIndex end, bool keep_rail);
 CommandCost CmdBuildRoadStop(DoCommandFlag flags, TileIndex tile, uint8_t width, uint8_t length, RoadStopType stop_type, bool is_drive_through, DiagDirection ddir, RoadType rt, RoadStopClassID spec_class, uint16_t spec_index, StationID station_to_join, bool adjacent);
 CommandCost CmdRemoveRoadStop(DoCommandFlag flags, TileIndex tile, uint8_t width, uint8_t height, RoadStopType stop_type, bool remove_road);

--- a/src/station_func.h
+++ b/src/station_func.h
@@ -33,7 +33,7 @@ void UpdateStationAcceptance(Station *st, bool show_msg);
 CargoTypes GetAcceptanceMask(const Station *st);
 CargoTypes GetEmptyMask(const Station *st);
 
-const DrawTileSprites *GetStationTileLayout(StationType st, byte gfx);
+const DrawTileSprites *GetStationTileLayout(StationType st, uint8_t gfx);
 void StationPickerDrawSprite(int x, int y, StationType st, RailType railtype, RoadType roadtype, int image);
 
 bool HasStationInUse(StationID station, bool include_company, CompanyID company);

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -172,7 +172,7 @@ void CheckRedrawWaypointCoverage(const Window *)
  * @param amount Cargo amount
  * @param rating ratings data for that particular cargo
  */
-static void StationsWndShowStationRating(int left, int right, int y, CargoID type, uint amount, byte rating)
+static void StationsWndShowStationRating(int left, int right, int y, CargoID type, uint amount, uint8_t rating)
 {
 	static const uint units_full  = 576; ///< number of units to show station as 'full'
 	static const uint rating_full = 224; ///< rating needed so it is shown as 'full'
@@ -220,7 +220,7 @@ protected:
 	/* Runtime saved values */
 	struct FilterState {
 		Listing last_sorting;
-		byte facilities; ///< types of stations of interest
+		uint8_t facilities; ///< types of stations of interest
 		bool include_no_rating; ///< Whether we should include stations with no cargo rating.
 		CargoTypes cargoes; ///< bitmap of cargo types to include
 	};
@@ -332,8 +332,8 @@ protected:
 	/** Sort stations by their rating */
 	static bool StationRatingMaxSorter(const Station * const &a, const Station * const &b, const CargoTypes &cargo_filter)
 	{
-		byte maxr1 = 0;
-		byte maxr2 = 0;
+		uint8_t maxr1 = 0;
+		uint8_t maxr2 = 0;
 
 		for (CargoID j : SetCargoBitIterator(cargo_filter)) {
 			if (a->goods[j].HasRating()) maxr1 = std::max(maxr1, a->goods[j].rating);
@@ -346,8 +346,8 @@ protected:
 	/** Sort stations by their rating */
 	static bool StationRatingMinSorter(const Station * const &a, const Station * const &b, const CargoTypes &cargo_filter)
 	{
-		byte minr1 = 255;
-		byte minr2 = 255;
+		uint8_t minr1 = 255;
+		uint8_t minr2 = 255;
 
 		for (CargoID j : SetCargoBitIterator(cargo_filter)) {
 			if (a->goods[j].HasRating()) minr1 = std::min(minr1, a->goods[j].rating);
@@ -849,7 +849,7 @@ enum SortOrder {
 
 class CargoDataEntry;
 
-enum class CargoSortType : byte {
+enum class CargoSortType : uint8_t {
 	AsGrouping,    ///< by the same principle the entries are being grouped
 	Count,         ///< by amount of cargo
 	StationString, ///< by station name

--- a/src/station_map.h
+++ b/src/station_map.h
@@ -17,7 +17,7 @@
 #include "rail.h"
 #include "road.h"
 
-typedef byte StationGfx; ///< Index of station graphics. @see _station_display_datas
+typedef uint8_t StationGfx; ///< Index of station graphics. @see _station_display_datas
 
 /**
  * Get StationID from a tile
@@ -534,7 +534,7 @@ inline bool IsCustomStationSpecIndex(Tile t)
  * @param specindex The new spec.
  * @pre HasStationTileRail(t)
  */
-inline void SetCustomStationSpecIndex(Tile t, byte specindex)
+inline void SetCustomStationSpecIndex(Tile t, uint8_t specindex)
 {
 	assert(HasStationTileRail(t));
 	t.m4() = specindex;
@@ -570,7 +570,7 @@ inline bool IsCustomRoadStopSpecIndex(Tile t)
  * @param specindex The new spec.
  * @pre IsRoadStopTile(t)
  */
-inline void SetCustomRoadStopSpecIndex(Tile t, byte specindex)
+inline void SetCustomRoadStopSpecIndex(Tile t, uint8_t specindex)
 {
 	assert(IsRoadStopTile(t));
 	SB(t.m8(), 0, 6, specindex);
@@ -594,7 +594,7 @@ inline uint GetCustomRoadStopSpecIndex(Tile t)
  * @param random_bits The random bits.
  * @pre IsTileType(t, MP_STATION)
  */
-inline void SetStationTileRandomBits(Tile t, byte random_bits)
+inline void SetStationTileRandomBits(Tile t, uint8_t random_bits)
 {
 	assert(IsTileType(t, MP_STATION));
 	SB(t.m3(), 4, 4, random_bits);
@@ -606,7 +606,7 @@ inline void SetStationTileRandomBits(Tile t, byte random_bits)
  * @pre IsTileType(t, MP_STATION)
  * @return The random bits for this station tile.
  */
-inline byte GetStationTileRandomBits(Tile t)
+inline uint8_t GetStationTileRandomBits(Tile t)
 {
 	assert(IsTileType(t, MP_STATION));
 	return GB(t.m3(), 4, 4);
@@ -621,7 +621,7 @@ inline byte GetStationTileRandomBits(Tile t)
  * @param section the StationGfx to be used for this tile
  * @param wc The water class of the station
  */
-inline void MakeStation(Tile t, Owner o, StationID sid, StationType st, byte section, WaterClass wc = WATER_CLASS_INVALID)
+inline void MakeStation(Tile t, Owner o, StationID sid, StationType st, uint8_t section, WaterClass wc = WATER_CLASS_INVALID)
 {
 	SetTileType(t, MP_STATION);
 	SetTileOwner(t, o);
@@ -646,7 +646,7 @@ inline void MakeStation(Tile t, Owner o, StationID sid, StationType st, byte sec
  * @param section the StationGfx to be used for this tile
  * @param rt the railtype of this tile
  */
-inline void MakeRailStation(Tile t, Owner o, StationID sid, Axis a, byte section, RailType rt)
+inline void MakeRailStation(Tile t, Owner o, StationID sid, Axis a, uint8_t section, RailType rt)
 {
 	MakeStation(t, o, sid, STATION_RAIL, section + a);
 	SetRailType(t, rt);
@@ -662,7 +662,7 @@ inline void MakeRailStation(Tile t, Owner o, StationID sid, Axis a, byte section
  * @param section the StationGfx to be used for this tile
  * @param rt the railtype of this tile
  */
-inline void MakeRailWaypoint(Tile t, Owner o, StationID sid, Axis a, byte section, RailType rt)
+inline void MakeRailWaypoint(Tile t, Owner o, StationID sid, Axis a, uint8_t section, RailType rt)
 {
 	MakeStation(t, o, sid, STATION_WAYPOINT, section + a);
 	SetRailType(t, rt);
@@ -715,7 +715,7 @@ inline void MakeDriveThroughRoadStop(Tile t, Owner station, Owner road, Owner tr
  * @param section the StationGfx to be used for this tile
  * @param wc the type of water on this tile
  */
-inline void MakeAirport(Tile t, Owner o, StationID sid, byte section, WaterClass wc)
+inline void MakeAirport(Tile t, Owner o, StationID sid, uint8_t section, WaterClass wc)
 {
 	MakeStation(t, o, sid, STATION_AIRPORT, section, wc);
 }

--- a/src/station_type.h
+++ b/src/station_type.h
@@ -40,14 +40,14 @@ enum StationType {
 };
 
 /** Types of RoadStops */
-enum RoadStopType : byte {
+enum RoadStopType : uint8_t {
 	ROADSTOP_BUS,    ///< A standard stop for buses
 	ROADSTOP_TRUCK,  ///< A standard stop for trucks
 	ROADSTOP_END,    ///< End of valid types
 };
 
 /** The facilities a station might be having */
-enum StationFacility : byte {
+enum StationFacility : uint8_t {
 	FACIL_NONE       = 0,      ///< The station has no facilities at all
 	FACIL_TRAIN      = 1 << 0, ///< Station with train station
 	FACIL_TRUCK_STOP = 1 << 1, ///< Station with truck stops
@@ -59,7 +59,7 @@ enum StationFacility : byte {
 DECLARE_ENUM_AS_BIT_SET(StationFacility)
 
 /** The vehicles that may have visited a station */
-enum StationHadVehicleOfType : byte {
+enum StationHadVehicleOfType : uint8_t {
 	HVOT_NONE     = 0,      ///< Station has seen no vehicles
 	HVOT_TRAIN    = 1 << 1, ///< Station has seen a train
 	HVOT_BUS      = 1 << 2, ///< Station has seen a bus

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -262,8 +262,6 @@
 #define debug_inline inline
 #endif
 
-typedef uint8_t byte;
-
 /* This is already defined in unix, but not in QNX Neutrino (6.x) or Cygwin. */
 #if (!defined(UNIX) && !defined(__HAIKU__)) || defined(__QNXNTO__) || defined(__CYGWIN__)
 	typedef unsigned int uint;

--- a/src/story.cpp
+++ b/src/story.cpp
@@ -178,7 +178,7 @@ bool StoryPageButtonData::ValidateColour() const
 
 bool StoryPageButtonData::ValidateFlags() const
 {
-	byte flags = GB(this->referenced_id, 24, 8);
+	uint8_t flags = GB(this->referenced_id, 24, 8);
 	/* Don't allow float left and right together */
 	if ((flags & SPBF_FLOAT_LEFT) && (flags & SPBF_FLOAT_RIGHT)) return false;
 	/* Don't allow undefined flags */
@@ -195,7 +195,7 @@ bool StoryPageButtonData::ValidateCursor() const
 /** Verity that the data stored a valid VehicleType value */
 bool StoryPageButtonData::ValidateVehicleType() const
 {
-	byte vehtype = GB(this->referenced_id, 16, 8);
+	uint8_t vehtype = GB(this->referenced_id, 16, 8);
 	return vehtype == VEH_INVALID || vehtype < VEH_COMPANY_END;
 }
 

--- a/src/story_base.h
+++ b/src/story_base.h
@@ -27,7 +27,7 @@ extern uint32_t _story_page_next_sort_value;
 /*
  * Each story page element is one of these types.
  */
-enum StoryPageElementType : byte {
+enum StoryPageElementType : uint8_t {
 	SPET_TEXT = 0,       ///< A text element.
 	SPET_LOCATION,       ///< An element that references a tile along with a one-line text.
 	SPET_GOAL,           ///< An element that references a goal.
@@ -39,7 +39,7 @@ enum StoryPageElementType : byte {
 };
 
 /** Flags available for buttons */
-enum StoryPageButtonFlags : byte {
+enum StoryPageButtonFlags : uint8_t {
 	SPBF_NONE        = 0,
 	SPBF_FLOAT_LEFT  = 1 << 0,
 	SPBF_FLOAT_RIGHT = 1 << 1,
@@ -47,7 +47,7 @@ enum StoryPageButtonFlags : byte {
 DECLARE_ENUM_AS_BIT_SET(StoryPageButtonFlags)
 
 /** Mouse cursors usable by story page buttons. */
-enum StoryPageButtonCursor : byte {
+enum StoryPageButtonCursor : uint8_t {
 	SPBC_MOUSE,
 	SPBC_ZZZ,
 	SPBC_BUOY,

--- a/src/story_type.h
+++ b/src/story_type.h
@@ -16,7 +16,7 @@ typedef uint16_t StoryPageElementID; ///< ID of a story page element
 typedef uint16_t StoryPageID; ///< ID of a story page
 struct StoryPageElement;
 struct StoryPage;
-enum StoryPageElementType : byte;
+enum StoryPageElementType : uint8_t;
 
 static const StoryPageElementID INVALID_STORY_PAGE_ELEMENT = 0xFFFF; ///< Constant representing a non-existing story page element.
 static const StoryPageID INVALID_STORY_PAGE = 0xFFFF; ///< Constant representing a non-existing story page.

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -295,7 +295,7 @@ struct LanguageFileWriter : LanguageWriter, FileWriter {
 
 	void WriteHeader(const LanguagePackHeader *header) override
 	{
-		this->Write((const byte *)header, sizeof(*header));
+		this->Write((const uint8_t *)header, sizeof(*header));
 	}
 
 	void Finalise() override
@@ -304,7 +304,7 @@ struct LanguageFileWriter : LanguageWriter, FileWriter {
 		this->FileWriter::Finalise();
 	}
 
-	void Write(const byte *buffer, size_t length) override
+	void Write(const uint8_t *buffer, size_t length) override
 	{
 		this->output_stream.write((const char *)buffer, length);
 	}

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -118,7 +118,7 @@ struct LanguageWriter {
 	 * @param buffer The buffer to write.
 	 * @param length The amount of byte to write.
 	 */
-	virtual void Write(const byte *buffer, size_t length) = 0;
+	virtual void Write(const uint8_t *buffer, size_t length) = 0;
 
 	/**
 	 * Finalise writing the file.

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -175,12 +175,12 @@ static ParsedCommandStruct _cur_pcs;
 static int _cur_argidx;
 
 /** The buffer for writing a single string. */
-struct Buffer : std::vector<byte> {
+struct Buffer : std::vector<uint8_t> {
 	/**
 	 * Convenience method for adding a byte.
 	 * @param value The value to add.
 	 */
-	void AppendByte(byte value)
+	void AppendByte(uint8_t value)
 	{
 		this->push_back(value);
 	}
@@ -318,7 +318,7 @@ static int TranslateArgumentIdx(int arg, int offset = 0);
 static void EmitWordList(Buffer *buffer, const std::vector<const char *> &words, uint nw)
 {
 	buffer->AppendByte(nw);
-	for (uint i = 0; i < nw; i++) buffer->AppendByte((byte)strlen(words[i]) + 1);
+	for (uint i = 0; i < nw; i++) buffer->AppendByte((uint8_t)strlen(words[i]) + 1);
 	for (uint i = 0; i < nw; i++) {
 		for (uint j = 0; words[i][j] != '\0'; j++) buffer->AppendByte(words[i][j]);
 		buffer->AppendByte(0);
@@ -881,7 +881,7 @@ void LanguageWriter::WriteLength(uint length)
 		buffer[offs++] = (length >> 8) | 0xC0;
 	}
 	buffer[offs++] = length & 0xFF;
-	this->Write((byte*)buffer, offs);
+	this->Write((uint8_t*)buffer, offs);
 }
 
 /**
@@ -953,7 +953,7 @@ void LanguageWriter::WriteLang(const StringData &data)
 				 * <0x9E> <NUM CASES> <CASE1> <LEN1> <STRING1> <CASE2> <LEN2> <STRING2> <CASE3> <LEN3> <STRING3> <STRINGDEFAULT>
 				 * Each LEN is printed using 2 bytes in big endian order. */
 				buffer.AppendUtf8(SCC_SWITCH_CASE);
-				buffer.AppendByte((byte)ls->translated_cases.size());
+				buffer.AppendByte((uint8_t)ls->translated_cases.size());
 
 				/* Write each case */
 				for (const Case &c : ls->translated_cases) {

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -85,7 +85,7 @@ char *strecpy(char *dst, const char *src, const char *last)
  * @param data Array to format
  * @return Converted string.
  */
-std::string FormatArrayAsHex(std::span<const byte> data)
+std::string FormatArrayAsHex(std::span<const uint8_t> data)
 {
 	std::string str;
 	str.reserve(data.size() * 2 + 1);

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -19,7 +19,7 @@
 
 char *strecpy(char *dst, const char *src, const char *last) NOACCESS(3);
 
-std::string FormatArrayAsHex(std::span<const byte> data);
+std::string FormatArrayAsHex(std::span<const uint8_t> data);
 
 void StrMakeValidInPlace(char *str, const char *last, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK) NOACCESS(2);
 [[nodiscard]] std::string StrMakeValid(std::string_view str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -690,11 +690,11 @@ static int DeterminePluralForm(int64_t count, int plural_form)
 static const char *ParseStringChoice(const char *b, uint form, StringBuilder &builder)
 {
 	/* <NUM> {Length of each string} {each string} */
-	uint n = (byte)*b++;
+	uint n = (uint8_t)*b++;
 	uint pos, i, mypos = 0;
 
 	for (i = pos = 0; i != n; i++) {
-		uint len = (byte)*b++;
+		uint len = (uint8_t)*b++;
 		if (i == form) mypos = pos;
 		pos += len;
 	}
@@ -847,7 +847,7 @@ static const Units _units_time_years_or_minutes[] = {
  */
 static const Units GetVelocityUnits(VehicleType type)
 {
-	byte setting = (type == VEH_SHIP || type == VEH_AIRCRAFT) ? _settings_game.locale.units_velocity_nautical : _settings_game.locale.units_velocity;
+	uint8_t setting = (type == VEH_SHIP || type == VEH_AIRCRAFT) ? _settings_game.locale.units_velocity_nautical : _settings_game.locale.units_velocity;
 
 	assert(setting < lengthof(_units_velocity_calendar));
 	assert(setting < lengthof(_units_velocity_realtime));
@@ -1064,7 +1064,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 
 				case SCC_GENDER_LIST: { // {G 0 Der Die Das}
 					/* First read the meta data from the language file. */
-					size_t offset = orig_offset + (byte)*str++;
+					size_t offset = orig_offset + (uint8_t)*str++;
 					int gender = 0;
 					if (!dry_run && args.GetTypeAtOffset(offset) != 0) {
 						/* Now we need to figure out what text to resolve, i.e.
@@ -1087,7 +1087,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 						const char *s = buffer.c_str();
 						char32_t c = Utf8Consume(&s);
 						/* Does this string have a gender, if so, set it */
-						if (c == SCC_GENDER_INDEX) gender = (byte)s[0];
+						if (c == SCC_GENDER_INDEX) gender = (uint8_t)s[0];
 					}
 					str = ParseStringChoice(str, gender, builder);
 					break;
@@ -1106,30 +1106,30 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 
 				case SCC_PLURAL_LIST: { // {P}
 					int plural_form = *str++;          // contains the plural form for this string
-					size_t offset = orig_offset + (byte)*str++;
+					size_t offset = orig_offset + (uint8_t)*str++;
 					int64_t v = args.GetParam(offset); // contains the number that determines plural
 					str = ParseStringChoice(str, DeterminePluralForm(v, plural_form), builder);
 					break;
 				}
 
 				case SCC_ARG_INDEX: { // Move argument pointer
-					args.SetOffset(orig_offset + (byte)*str++);
+					args.SetOffset(orig_offset + (uint8_t)*str++);
 					break;
 				}
 
 				case SCC_SET_CASE: { // {SET_CASE}
 					/* This is a pseudo command, it's outputted when someone does {STRING.ack}
 					 * The modifier is added to all subsequent GetStringWithArgs that accept the modifier. */
-					next_substr_case_index = (byte)*str++;
+					next_substr_case_index = (uint8_t)*str++;
 					break;
 				}
 
 				case SCC_SWITCH_CASE: { // {Used to implement case switching}
 					/* <0x9E> <NUM CASES> <CASE1> <LEN1> <STRING1> <CASE2> <LEN2> <STRING2> <CASE3> <LEN3> <STRING3> <STRINGDEFAULT>
 					 * Each LEN is printed using 2 bytes in big endian order. */
-					uint num = (byte)*str++;
+					uint num = (uint8_t)*str++;
 					while (num) {
-						if ((byte)str[0] == case_index) {
+						if ((uint8_t)str[0] == case_index) {
 							/* Found the case, adjust str pointer and continue */
 							str += 3;
 							break;
@@ -1939,17 +1939,17 @@ bool ReadLanguagePack(const LanguageMetadata *lang)
 
 	/* Fill offsets */
 	char *s = lang_pack->data;
-	len = (byte)*s++;
+	len = (uint8_t)*s++;
 	for (uint i = 0; i < count; i++) {
 		if (s + len >= end) return false;
 
 		if (len >= 0xC0) {
-			len = ((len & 0x3F) << 8) + (byte)*s++;
+			len = ((len & 0x3F) << 8) + (uint8_t)*s++;
 			if (s + len >= end) return false;
 		}
 		offs[i] = s;
 		s += len;
-		len = (byte)*s;
+		len = (uint8_t)*s;
 		*s++ = '\0'; // zero terminate the string
 	}
 
@@ -2041,7 +2041,7 @@ const char *GetCurrentLocale(const char *param);
  * @param newgrflangid NewGRF languages ID to check.
  * @return The language's metadata, or nullptr if it is not known.
  */
-const LanguageMetadata *GetLanguage(byte newgrflangid)
+const LanguageMetadata *GetLanguage(uint8_t newgrflangid)
 {
 	for (const LanguageMetadata &lang : _languages) {
 		if (newgrflangid == lang.newgrflangid) return &lang;

--- a/src/subsidy_type.h
+++ b/src/subsidy_type.h
@@ -13,7 +13,7 @@
 #include "core/enum_type.hpp"
 
 /** What part of a subsidy is something? */
-enum PartOfSubsidy : byte {
+enum PartOfSubsidy : uint8_t {
 	POS_NONE =     0, ///< nothing
 	POS_SRC = 1 << 0, ///< bit 0 set -> town/industry is source of subsidised path
 	POS_DST = 1 << 1, ///< bit 1 set -> town/industry is destination of subsidised path

--- a/src/table/airport_movement.h
+++ b/src/table/airport_movement.h
@@ -16,10 +16,10 @@
  * Finite sTate mAchine --> FTA
  */
 struct AirportFTAbuildup {
-	byte position; ///< The position that an airplane is at.
-	byte heading;  ///< The current orders (eg. TAKEOFF, HANGAR, ENDLANDING, etc.).
+	uint8_t position; ///< The position that an airplane is at.
+	uint8_t heading;  ///< The current orders (eg. TAKEOFF, HANGAR, ENDLANDING, etc.).
 	uint64_t block;  ///< The block this position is on on the airport (st->airport.flags).
-	byte next;     ///< Next position from this position.
+	uint8_t next;     ///< Next position from this position.
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -407,7 +407,7 @@ static const AirportMovingData _airport_moving_data_oilrig[9] = {
 
 ///////////////////////////////////////////////////////////////////////
 /////**********Movement Machine on Airports*********************///////
-static const byte _airport_entries_dummy[] = {0, 1, 2, 3};
+static const uint8_t _airport_entries_dummy[] = {0, 1, 2, 3};
 static const AirportFTAbuildup _airport_fta_dummy[] = {
 	{ 0, TO_ALL, 0, 3},
 	{ 1, TO_ALL, 0, 0},
@@ -419,8 +419,8 @@ static const AirportFTAbuildup _airport_fta_dummy[] = {
 /* First element of terminals array tells us how many depots there are (to know size of array)
  * this may be changed later when airports are moved to external file  */
 static const HangarTileTable _airport_depots_country[] = { {{3, 0}, DIR_SE, 0} };
-static const byte _airport_terminal_country[] = {1, 2};
-static const byte _airport_entries_country[] = {16, 15, 18, 17};
+static const uint8_t _airport_terminal_country[] = {1, 2};
+static const uint8_t _airport_entries_country[] = {16, 15, 18, 17};
 static const AirportFTAbuildup _airport_fta_country[] = {
 	{  0, HANGAR, NOTHING_block, 1 },
 	{  1, TERMGROUP, AIRPORT_BUSY_block, 0 }, { 1, HANGAR, 0, 0 }, { 1, TERM1, TERM1_block, 2 }, { 1, TERM2, 0, 4 }, { 1, HELITAKEOFF, 0, 19 }, { 1, TO_ALL, 0, 6 },
@@ -451,8 +451,8 @@ static const AirportFTAbuildup _airport_fta_country[] = {
 };
 
 static const HangarTileTable _airport_depots_commuter[] = { {{4, 0}, DIR_SE, 0} };
-static const byte _airport_terminal_commuter[] = { 1, 3 };
-static const byte _airport_entries_commuter[] = {22, 21, 24, 23};
+static const uint8_t _airport_terminal_commuter[] = { 1, 3 };
+static const uint8_t _airport_entries_commuter[] = {22, 21, 24, 23};
 static const AirportFTAbuildup _airport_fta_commuter[] = {
 	{  0, HANGAR, NOTHING_block, 1 }, { 0, HELITAKEOFF, TAXIWAY_BUSY_block, 1 }, { 0, TO_ALL, 0, 1 },
 	{  1, TERMGROUP, TAXIWAY_BUSY_block, 0 }, { 1, HANGAR, 0, 0 }, { 1, TAKEOFF, 0, 11 }, { 1, TERM1, TAXIWAY_BUSY_block, 10 }, { 1, TERM2, TAXIWAY_BUSY_block, 10 }, { 1, TERM3, TAXIWAY_BUSY_block, 10 }, { 1, HELIPAD1, TAXIWAY_BUSY_block, 10 }, { 1, HELIPAD2, TAXIWAY_BUSY_block, 10 }, { 1, HELITAKEOFF, TAXIWAY_BUSY_block, 37 }, { 1, TO_ALL, 0, 0 },
@@ -502,8 +502,8 @@ static const AirportFTAbuildup _airport_fta_commuter[] = {
 };
 
 static const HangarTileTable _airport_depots_city[] = { {{5, 0}, DIR_SE, 0} };
-static const byte _airport_terminal_city[] = { 1, 3 };
-static const byte _airport_entries_city[] = {26, 29, 27, 28};
+static const uint8_t _airport_terminal_city[] = { 1, 3 };
+static const uint8_t _airport_entries_city[] = {26, 29, 27, 28};
 static const AirportFTAbuildup _airport_fta_city[] = {
 	{  0, HANGAR, NOTHING_block, 1 }, { 0, TAKEOFF, OUT_WAY_block, 1 }, { 0, TO_ALL, 0, 1 },
 	{  1, TERMGROUP, TAXIWAY_BUSY_block, 0 }, { 1, HANGAR, 0, 0 }, { 1, TERM2, 0, 6 }, { 1, TERM3, 0, 6 }, { 1, TO_ALL, 0, 7 }, // for all else, go to 7
@@ -543,8 +543,8 @@ static const AirportFTAbuildup _airport_fta_city[] = {
 };
 
 static const HangarTileTable _airport_depots_metropolitan[] = { {{5, 0}, DIR_SE, 0} };
-static const byte _airport_terminal_metropolitan[] = { 1, 3 };
-static const byte _airport_entries_metropolitan[] = {20, 19, 22, 21};
+static const uint8_t _airport_terminal_metropolitan[] = { 1, 3 };
+static const uint8_t _airport_entries_metropolitan[] = {20, 19, 22, 21};
 static const AirportFTAbuildup _airport_fta_metropolitan[] = {
 	{  0, HANGAR, NOTHING_block, 1 },
 	{  1, TERMGROUP, TAXIWAY_BUSY_block, 0 }, { 1, HANGAR, 0, 0 }, { 1, TERM2, 0, 6 }, { 1, TERM3, 0, 6 }, { 1, TO_ALL, 0, 7 }, // for all else, go to 7
@@ -582,8 +582,8 @@ static const AirportFTAbuildup _airport_fta_metropolitan[] = {
 };
 
 static const HangarTileTable _airport_depots_international[] = { {{0, 3}, DIR_SE, 0}, {{6, 1}, DIR_SE, 1} };
-static const byte _airport_terminal_international[] = { 2, 3, 3 };
-static const byte _airport_entries_international[] = { 38, 37, 40, 39 };
+static const uint8_t _airport_terminal_international[] = { 2, 3, 3 };
+static const uint8_t _airport_entries_international[] = { 38, 37, 40, 39 };
 static const AirportFTAbuildup _airport_fta_international[] = {
 	{  0, HANGAR, NOTHING_block, 2 }, { 0, TERMGROUP, TERM_GROUP1_block, 0 }, { 0, TERMGROUP, TERM_GROUP2_ENTER1_block, 1 }, { 0, HELITAKEOFF, AIRPORT_ENTRANCE_block, 2 }, { 0, TO_ALL, 0, 2 },
 	{  1, HANGAR, NOTHING_block, 3 }, { 1, TERMGROUP, HANGAR2_AREA_block, 1 }, { 1, HELITAKEOFF, HANGAR2_AREA_block, 3 }, { 1, TO_ALL, 0, 3 },
@@ -649,8 +649,8 @@ static const AirportFTAbuildup _airport_fta_international[] = {
 
 /* intercontinental */
 static const HangarTileTable _airport_depots_intercontinental[] = { {{0, 5}, DIR_SE, 0}, {{8, 4}, DIR_SE, 1} };
-static const byte _airport_terminal_intercontinental[] = { 2, 4, 4 };
-static const byte _airport_entries_intercontinental[] = { 44, 43, 46, 45 };
+static const uint8_t _airport_terminal_intercontinental[] = { 2, 4, 4 };
+static const uint8_t _airport_entries_intercontinental[] = { 44, 43, 46, 45 };
 static const AirportFTAbuildup _airport_fta_intercontinental[] = {
 	{  0, HANGAR, NOTHING_block, 2 }, { 0, TERMGROUP, HANGAR1_AREA_block | TERM_GROUP1_block, 0 }, { 0, TERMGROUP, HANGAR1_AREA_block | TERM_GROUP1_block, 1 }, { 0, TAKEOFF, HANGAR1_AREA_block | TERM_GROUP1_block, 2 }, { 0, TO_ALL, 0, 2 },
 	{  1, HANGAR, NOTHING_block, 3 }, { 1, TERMGROUP, HANGAR2_AREA_block, 1 }, { 1, TERMGROUP, HANGAR2_AREA_block, 0 }, { 1, TO_ALL, 0, 3 },
@@ -742,7 +742,7 @@ static const AirportFTAbuildup _airport_fta_intercontinental[] = {
 
 
 /* heliports, oilrigs don't have depots */
-static const byte _airport_entries_heliport[] = { 7, 7, 7, 7 };
+static const uint8_t _airport_entries_heliport[] = { 7, 7, 7, 7 };
 static const AirportFTAbuildup _airport_fta_heliport[] = {
 	{ 0, HELIPAD1, HELIPAD1_block, 1 },
 	{ 1, HELITAKEOFF, NOTHING_block, 0 }, // takeoff
@@ -761,7 +761,7 @@ static const AirportFTAbuildup _airport_fta_heliport[] = {
 
 /* helidepots */
 static const HangarTileTable _airport_depots_helidepot[] = { {{1, 0}, DIR_SE, 0} };
-static const byte _airport_entries_helidepot[] = { 4, 4, 4, 4 };
+static const uint8_t _airport_entries_helidepot[] = { 4, 4, 4, 4 };
 static const AirportFTAbuildup _airport_fta_helidepot[] = {
 	{  0, HANGAR, NOTHING_block, 1 },
 	{  1, TERMGROUP, HANGAR2_AREA_block, 0 }, { 1, HANGAR, 0, 0 }, { 1, HELIPAD1, HELIPAD1_block, 14 }, { 1, HELITAKEOFF, 0, 15 }, { 1, TO_ALL, 0, 0 },
@@ -790,7 +790,7 @@ static const AirportFTAbuildup _airport_fta_helidepot[] = {
 
 /* helistation */
 static const HangarTileTable _airport_depots_helistation[] = { {{0, 0}, DIR_SE, 0} };
-static const byte _airport_entries_helistation[] = { 25, 25, 25, 25 };
+static const uint8_t _airport_entries_helistation[] = { 25, 25, 25, 25 };
 static const AirportFTAbuildup _airport_fta_helistation[] = {
 	{  0, HANGAR, NOTHING_block, 8 },    { 0, HELIPAD1, 0, 1 }, { 0, HELIPAD2, 0, 1 }, { 0, HELIPAD3, 0, 1 }, { 0, HELITAKEOFF, 0, 1 }, { 0, TO_ALL, 0, 0 },
 	{  1, TERMGROUP, HANGAR2_AREA_block, 0 },  { 1, HANGAR, 0, 0 }, { 1, HELITAKEOFF, 0, 3 }, { 1, TO_ALL, 0, 4 },

--- a/src/table/clear_land.h
+++ b/src/table/clear_land.h
@@ -18,28 +18,28 @@ static const SpriteID _landscape_clear_sprites_rough[8] = {
 	SPR_FLAT_ROUGH_LAND_2,
 };
 
-static const byte _fence_mod_by_tileh_sw[32] = {
+static const uint8_t _fence_mod_by_tileh_sw[32] = {
 	0, 2, 4, 0, 0, 2, 4, 0,
 	0, 2, 4, 0, 0, 2, 4, 0,
 	0, 2, 4, 0, 0, 2, 4, 4,
 	0, 2, 4, 2, 0, 2, 4, 0,
 };
 
-static const byte _fence_mod_by_tileh_se[32] = {
+static const uint8_t _fence_mod_by_tileh_se[32] = {
 	1, 1, 5, 5, 3, 3, 1, 1,
 	1, 1, 5, 5, 3, 3, 1, 1,
 	1, 1, 5, 5, 3, 3, 1, 5,
 	1, 1, 5, 5, 3, 3, 3, 1,
 };
 
-static const byte _fence_mod_by_tileh_ne[32] = {
+static const uint8_t _fence_mod_by_tileh_ne[32] = {
 	0, 0, 0, 0, 4, 4, 4, 4,
 	2, 2, 2, 2, 0, 0, 0, 0,
 	0, 0, 0, 0, 4, 4, 4, 4,
 	2, 2, 2, 2, 0, 2, 4, 0,
 };
 
-static const byte _fence_mod_by_tileh_nw[32] = {
+static const uint8_t _fence_mod_by_tileh_nw[32] = {
 	1, 5, 1, 5, 1, 5, 1, 5,
 	3, 1, 3, 1, 3, 1, 3, 1,
 	1, 5, 1, 5, 1, 5, 1, 5,

--- a/src/table/elrail_data.h
+++ b/src/table/elrail_data.h
@@ -40,7 +40,7 @@ enum TileSource {
 static const uint NUM_TRACKS_AT_PCP = 6;
 
 /** Which PPPs are possible at all on a given PCP */
-static const byte AllowedPPPonPCP[DIAGDIR_END] = {
+static const uint8_t AllowedPPPonPCP[DIAGDIR_END] = {
 	1 << DIR_N | 1 << DIR_E  | 1 << DIR_SE | 1 << DIR_S | 1 << DIR_W  | 1 << DIR_NW,
 	1 << DIR_N | 1 << DIR_NE | 1 << DIR_E  | 1 << DIR_S | 1 << DIR_SW | 1 << DIR_W,
 	1 << DIR_N | 1 << DIR_E  | 1 << DIR_SE | 1 << DIR_S | 1 << DIR_W  | 1 << DIR_NW,
@@ -52,7 +52,7 @@ static const byte AllowedPPPonPCP[DIAGDIR_END] = {
  * the following system is used: if you rotate the PCP so that it is in the
  * north, the eastern PPP belongs to the tile.
  */
-static const byte OwnedPPPonPCP[DIAGDIR_END] = {
+static const uint8_t OwnedPPPonPCP[DIAGDIR_END] = {
 	1 << DIR_SE | 1 << DIR_S  | 1 << DIR_SW | 1 << DIR_W,
 	1 << DIR_N  | 1 << DIR_SW | 1 << DIR_W  | 1 << DIR_NW,
 	1 << DIR_N  | 1 << DIR_NE | 1 << DIR_E  | 1 << DIR_NW,
@@ -76,7 +76,7 @@ static const DiagDirection PCPpositions[TRACK_END][2] = {
  * which are not on either end of the track are fully preferred.
  * @see PCPpositions
  */
-static const byte PreferredPPPofTrackAtPCP[TRACK_END][DIAGDIR_END] = {
+static const uint8_t PreferredPPPofTrackAtPCP[TRACK_END][DIAGDIR_END] = {
 	{    // X
 		1 << DIR_NE | 1 << DIR_SE | 1 << DIR_NW, // NE
 		PCP_NOT_ON_TRACK,                        // SE
@@ -119,7 +119,7 @@ static const byte PreferredPPPofTrackAtPCP[TRACK_END][DIAGDIR_END] = {
  * so there are certain tiles which we ignore. A straight line is found if
  * we have exactly two PPPs.
  */
-static const byte IgnoredPCP[NUM_IGNORE_GROUPS][TLG_END][DIAGDIR_END] = {
+static const uint8_t IgnoredPCP[NUM_IGNORE_GROUPS][TLG_END][DIAGDIR_END] = {
 	{   // Ignore group 1, X and Y tracks
 		{     // X even, Y even
 			IGNORE_NONE,
@@ -194,7 +194,7 @@ static const byte IgnoredPCP[NUM_IGNORE_GROUPS][TLG_END][DIAGDIR_END] = {
 #undef NO_IGNORE
 
 /** Which pylons can definitely NOT be built */
-static const byte DisallowedPPPofTrackAtPCP[TRACK_END][DIAGDIR_END] = {
+static const uint8_t DisallowedPPPofTrackAtPCP[TRACK_END][DIAGDIR_END] = {
 	{1 << DIR_SW | 1 << DIR_NE, 0,           1 << DIR_SW | 1 << DIR_NE, 0          }, // X
 	{0,           1 << DIR_NW | 1 << DIR_SE, 0,           1 << DIR_NW | 1 << DIR_SE}, // Y
 	{1 << DIR_W | 1 << DIR_E,  0,           0,           1 << DIR_W | 1 << DIR_E }, // UPPER

--- a/src/table/industry_land.h
+++ b/src/table/industry_land.h
@@ -17,9 +17,9 @@
  */
 struct DrawIndustryAnimationStruct {
 	int x;        ///< coordinate x of the first image offset
-	byte image_1; ///< image offset 1
-	byte image_2; ///< image offset 2
-	byte image_3; ///< image offset 3
+	uint8_t image_1; ///< image offset 1
+	uint8_t image_2; ///< image offset 2
+	uint8_t image_3; ///< image offset 3
 };
 
 /**
@@ -27,8 +27,8 @@ struct DrawIndustryAnimationStruct {
  * industries animations
  */
 struct DrawIndustryCoordinates {
-	byte x;  ///< coordinate x of the pair
-	byte y;  ///< coordinate y of the pair
+	uint8_t x;  ///< coordinate x of the pair
+	uint8_t y;  ///< coordinate y of the pair
 };
 
 /**
@@ -924,7 +924,7 @@ static const DrawIndustryAnimationStruct _industry_anim_offs_toys[] = {
 #undef MD
 
 /* this is ONLY used for Toffee Quarry*/
-static const byte _industry_anim_offs_toffee[] = {
+static const uint8_t _industry_anim_offs_toffee[] = {
 	255,   0,   0,   0,   2,   4,   6,   8,  10,   9,
 	  7,   5,   3,   1, 255,   0,   0,   0,   2,   4,
 	  6,   8,  10,   9,   7,   5,   3,   1, 255,   0,
@@ -935,7 +935,7 @@ static const byte _industry_anim_offs_toffee[] = {
 };
 
 /* this is ONLY used for the Bubble Generator*/
-static const byte _industry_anim_offs_bubbles[] = {
+static const uint8_t _industry_anim_offs_bubbles[] = {
 	68, 69, 71, 74, 77, 80, 83, 85, 86, 86,
 	86, 86, 86, 86, 86, 86, 86, 86, 86, 86,
 	86, 86, 85, 84, 83, 82, 81, 80, 79, 78,

--- a/src/table/palette_convert.h
+++ b/src/table/palette_convert.h
@@ -8,7 +8,7 @@
 /** @file palette_convert.h Translation tables from one GRF to another GRF. */
 
 /** Converting from the Windows palette to the DOS palette */
-extern const byte _palmap_w2d[] = {
+extern const uint8_t _palmap_w2d[] = {
 	  0,   1,   2,   3,   4,   5,   6,   7, //   0..7
 	  8,   9,  10,  11,  12,  13,  14,  15, //   8..15
 	 16,  17,  18,  19,  20,  21,  22,  23, //  16..23
@@ -44,7 +44,7 @@ extern const byte _palmap_w2d[] = {
 };
 
 /** Converting from the DOS palette to the Windows palette */
-static const byte _palmap_d2w[] = {
+static const uint8_t _palmap_d2w[] = {
 	  0, 215, 216, 136,  88, 106,  32,  33, //   0..7
 	 40, 245,  10,  11,  12,  13,  14,  15, //   8..15
 	 16,  17,  18,  19,  20,  21,  22,  23, //  16..23

--- a/src/table/roadveh_movement.h
+++ b/src/table/roadveh_movement.h
@@ -1084,7 +1084,7 @@ static const RoadDriveEntry * const _road_road_drive_data[] = {
 };
 
 /** Table of road stop stop frames, when to stop at a road stop. */
-extern const byte _road_stop_stop_frame[] = {
+extern const uint8_t _road_stop_stop_frame[] = {
 	/* Duplicated left and right because of "entered stop" bit */
 	20, 20, 16, 16,  20, 20, 16, 16,
 	19, 19, 15, 15,  19, 19, 15, 15,

--- a/src/table/string_colours.h
+++ b/src/table/string_colours.h
@@ -8,7 +8,7 @@
 /** @file string_colours.h The colour translation of GRF's strings. */
 
 /** Colour mapping for #TextColour. */
-static const byte _string_colourmap[17] = {
+static const uint8_t _string_colourmap[17] = {
 	150, // TC_BLUE
 	 12, // TC_SILVER
 	189, // TC_GOLD

--- a/src/table/train_sprites.h
+++ b/src/table/train_sprites.h
@@ -22,7 +22,7 @@ static const SpriteID _engine_sprite_base[] = {
 
 /* For how many directions do we have sprites? (8 or 4; if 4, the other 4
  * directions are symmetric. */
-static const byte _engine_sprite_and[] = {
+static const uint8_t _engine_sprite_and[] = {
 7, 7, 7, 7, 3, 3, 7, 7,
 7, 7, 7, 7, 7, 7, 7, 3,
 7, 7, 3, 7, 3, 7, 7, 7,
@@ -36,7 +36,7 @@ static const byte _engine_sprite_and[] = {
 };
 
 /* Non-zero for multihead trains. */
-static const byte _engine_sprite_add[] = {
+static const uint8_t _engine_sprite_add[] = {
 0, 0, 0, 0, 0, 0, 0, 4,
 0, 4, 0, 4, 0, 0, 0, 0,
 0, 4, 0, 0, 0, 0, 4, 0,
@@ -50,7 +50,7 @@ static const byte _engine_sprite_add[] = {
 };
 
 
-static const byte _wagon_full_adder[] = {
+static const uint8_t _wagon_full_adder[] = {
 	 0,  0,  0,  0,  0,  0,  0,  0,
 	 0,  0,  0,  0,  0,  0,  0,  0,
 	 0,  0,  0,  0,  0,  0,  0,  0,

--- a/src/table/tree_land.h
+++ b/src/table/tree_land.h
@@ -10,8 +10,8 @@
 #ifndef TREE_LAND_H
 #define TREE_LAND_H
 
-static const byte _tree_base_by_landscape[4] = {0, 12, 20, 32};
-static const byte _tree_count_by_landscape[4] = {12, 8, 12, 9};
+static const uint8_t _tree_base_by_landscape[4] = {0, 12, 20, 32};
+static const uint8_t _tree_count_by_landscape[4] = {12, 8, 12, 9};
 
 struct TreePos {
 	uint8_t x;

--- a/src/table/unicode.h
+++ b/src/table/unicode.h
@@ -9,10 +9,10 @@
 
 struct DefaultUnicodeMapping {
 	char32_t code; ///< Unicode value
-	byte key;   ///< Character index of sprite
+	uint8_t key;   ///< Character index of sprite
 };
 
-static const byte CLRA = 0; ///< Identifier to clear all glyphs at this codepoint
+static const uint8_t CLRA = 0; ///< Identifier to clear all glyphs at this codepoint
 
 /* Default unicode mapping table for sprite based glyphs.
  * This table allows us use unicode characters even though the glyphs don't

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -388,7 +388,7 @@ Window *ShowTerraformToolbar(Window *link)
 	return w;
 }
 
-static byte _terraform_size = 1;
+static uint8_t _terraform_size = 1;
 
 /**
  * Raise/Lower a bigger chunk of land at the same time in the editor. When

--- a/src/tests/string_func.cpp
+++ b/src/tests/string_func.cpp
@@ -338,9 +338,9 @@ TEST_CASE("StrEndsWithIgnoreCase - std::string_view")
 
 TEST_CASE("FormatArrayAsHex")
 {
-	CHECK(FormatArrayAsHex(std::array<byte, 0>{}) == "");
-	CHECK(FormatArrayAsHex(std::array<byte, 1>{0x12}) == "12");
-	CHECK(FormatArrayAsHex(std::array<byte, 4>{0x13, 0x38, 0x42, 0xAF}) == "133842AF");
+	CHECK(FormatArrayAsHex(std::array<uint8_t, 0>{}) == "");
+	CHECK(FormatArrayAsHex(std::array<uint8_t, 1>{0x12}) == "12");
+	CHECK(FormatArrayAsHex(std::array<uint8_t, 4>{0x13, 0x38, 0x42, 0xAF}) == "133842AF");
 }
 
 TEST_CASE("ConvertHexToBytes")

--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -177,7 +177,7 @@ bool Textbuf::InsertString(const char *str, bool marked, const char *caret, cons
 	for (const char *ptr = str; (c = Utf8Consume(&ptr)) != '\0';) {
 		if (!IsValidChar(c, this->afilter)) break;
 
-		byte len = Utf8CharLen(c);
+		uint8_t len = Utf8CharLen(c);
 		if (this->bytes + bytes + len > this->max_bytes) break;
 		if (this->chars + chars + 1   > this->max_chars) break;
 

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -664,10 +664,10 @@ void TextfileWindow::ScrollToLine(size_t line)
  * When decompressing fails, *bufp is set to nullptr and *sizep to 0. The
  * compressed buffer passed in is still freed in this case.
  */
-static void Gunzip(byte **bufp, size_t *sizep)
+static void Gunzip(uint8_t **bufp, size_t *sizep)
 {
 	static const int BLOCKSIZE  = 8192;
-	byte             *buf       = nullptr;
+	uint8_t             *buf       = nullptr;
 	size_t           alloc_size = 0;
 	z_stream         z;
 	int              res;
@@ -720,10 +720,10 @@ static void Gunzip(byte **bufp, size_t *sizep)
  * When decompressing fails, *bufp is set to nullptr and *sizep to 0. The
  * compressed buffer passed in is still freed in this case.
  */
-static void Xunzip(byte **bufp, size_t *sizep)
+static void Xunzip(uint8_t **bufp, size_t *sizep)
 {
 	static const int BLOCKSIZE  = 8192;
-	byte             *buf       = nullptr;
+	uint8_t             *buf       = nullptr;
 	size_t           alloc_size = 0;
 	lzma_stream      z = LZMA_STREAM_INIT;
 	int              res;
@@ -789,12 +789,12 @@ static void Xunzip(byte **bufp, size_t *sizep)
 
 #if defined(WITH_ZLIB)
 	/* In-place gunzip */
-	if (textfile.ends_with(".gz")) Gunzip((byte**)&buf, &filesize);
+	if (textfile.ends_with(".gz")) Gunzip((uint8_t**)&buf, &filesize);
 #endif
 
 #if defined(WITH_LIBLZMA)
 	/* In-place xunzip */
-	if (textfile.ends_with(".xz")) Xunzip((byte**)&buf, &filesize);
+	if (textfile.ends_with(".xz")) Xunzip((uint8_t**)&buf, &filesize);
 #endif
 
 	if (buf == nullptr) return;

--- a/src/tgp.cpp
+++ b/src/tgp.cpp
@@ -579,7 +579,7 @@ static void HeightMapCurves(uint level)
 	float factor = sqrt((float)_height_map.size_x / (float)_height_map.size_y);
 	uint sx = Clamp((int)(((1 << level) * factor) + 0.5), 1, 128);
 	uint sy = Clamp((int)(((1 << level) / factor) + 0.5), 1, 128);
-	std::vector<byte> c(static_cast<size_t>(sx) * sy);
+	std::vector<uint8_t> c(static_cast<size_t>(sx) * sy);
 
 	for (uint i = 0; i < sx * sy; i++) {
 		c[i] = Random() % lengthof(curve_maps);
@@ -880,7 +880,7 @@ static void HeightMapNormalize()
 
 	HeightMapAdjustWaterLevel(water_percent, h_max_new);
 
-	byte water_borders = _settings_game.construction.freeform_edges ? _settings_game.game_creation.water_borders : 0xF;
+	uint8_t water_borders = _settings_game.construction.freeform_edges ? _settings_game.game_creation.water_borders : 0xF;
 	if (water_borders == BORDERS_RANDOM) water_borders = GB(Random(), 0, 4);
 
 	HeightMapCoastLines(water_borders);

--- a/src/tile_map.h
+++ b/src/tile_map.h
@@ -247,7 +247,7 @@ inline TropicZone GetTropicZone(Tile tile)
  * @pre IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) ||IsTileType(t, MP_STATION)
  * @return frame number
  */
-inline byte GetAnimationFrame(Tile t)
+inline uint8_t GetAnimationFrame(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) ||IsTileType(t, MP_STATION));
 	return t.m7();
@@ -259,7 +259,7 @@ inline byte GetAnimationFrame(Tile t)
  * @param frame the new frame number
  * @pre IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) ||IsTileType(t, MP_STATION)
  */
-inline void SetAnimationFrame(Tile t, byte frame)
+inline void SetAnimationFrame(Tile t, uint8_t frame)
 {
 	assert(IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) ||IsTileType(t, MP_STATION));
 	t.m7() = frame;

--- a/src/tilehighlight_type.h
+++ b/src/tilehighlight_type.h
@@ -55,11 +55,11 @@ struct TileHighlightData {
 	Point new_pos;       ///< New value for \a pos; used to determine whether to redraw the selection.
 	Point new_size;      ///< New value for \a size; used to determine whether to redraw the selection.
 	Point new_outersize; ///< New value for \a outersize; used to determine whether to redraw the selection.
-	byte dirty;          ///< Whether the build station window needs to redraw due to the changed selection.
+	uint8_t dirty;          ///< Whether the build station window needs to redraw due to the changed selection.
 
 	Point selstart;      ///< The location where the dragging started.
 	Point selend;        ///< The location where the drag currently ends.
-	byte sizelimit;      ///< Whether the selection is limited in length, and what the maximum length is.
+	uint8_t sizelimit;      ///< Whether the selection is limited in length, and what the maximum length is.
 
 	HighLightStyle drawstyle;      ///< Lower bits 0-3 are reserved for detailed highlight information.
 	HighLightStyle next_drawstyle; ///< Queued, but not yet drawn style.

--- a/src/town.h
+++ b/src/town.h
@@ -59,7 +59,7 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 	std::string name;                ///< Custom town name. If empty, the town was not renamed and uses the generated name.
 	mutable std::string cached_name; ///< NOSAVE: Cache of the resolved name of the town, if not using a custom town name
 
-	byte flags;                    ///< See #TownFlags.
+	uint8_t flags;                    ///< See #TownFlags.
 
 	uint16_t noise_reached;          ///< level of noise that all the airports are generating
 
@@ -78,7 +78,7 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 
 	std::string text; ///< General text with additional information.
 
-	inline byte GetPercentTransported(CargoID cid) const
+	inline uint8_t GetPercentTransported(CargoID cid) const
 	{
 		if (!IsValidCargoID(cid)) return 0;
 		return this->supplied[cid].old_act * 256 / (this->supplied[cid].old_max + 1);
@@ -91,8 +91,8 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 	uint16_t grow_counter;             ///< counter to count when to grow, value is smaller than or equal to growth_rate
 	uint16_t growth_rate;              ///< town growth rate
 
-	byte fund_buildings_months;      ///< fund buildings program in action?
-	byte road_build_months;          ///< fund road reconstruction in action?
+	uint8_t fund_buildings_months;      ///< fund buildings program in action?
+	uint8_t road_build_months;          ///< fund road reconstruction in action?
 
 	bool larger_town;                ///< if this is a larger town and should grow more quickly
 	TownLayout layout;               ///< town specific road layout
@@ -238,7 +238,7 @@ TownActions GetMaskOfTownActions(CompanyID cid, const Town *t);
 bool GenerateTowns(TownLayout layout);
 const CargoSpec *FindFirstCargoWithTownAcceptanceEffect(TownAcceptanceEffect effect);
 
-extern const byte _town_action_costs[TACT_COUNT];
+extern const uint8_t _town_action_costs[TACT_COUNT];
 
 /**
  * Set the default name for a depot/waypoint

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1303,7 +1303,7 @@ static bool GrowTownWithBridge(const Town *t, const TileIndex tile, const DiagDi
 	if (slope != SLOPE_FLAT && CircularTileSearch(&search, bridge_length, 0, 0, RedundantBridgeExistsNearby, &direction_to_match)) return false;
 
 	for (uint8_t times = 0; times <= 22; times++) {
-		byte bridge_type = RandomRange(MAX_BRIDGES - 1);
+		uint8_t bridge_type = RandomRange(MAX_BRIDGES - 1);
 
 		/* Can we actually build the bridge? */
 		RoadType rt = GetTownRoadType();
@@ -2092,12 +2092,12 @@ std::tuple<CommandCost, Money, TownID> CmdFoundTown(DoCommandFlag flags, TileInd
 		if (ret.Failed()) return { ret, 0, INVALID_TOWN };
 	}
 
-	static const byte price_mult[][TSZ_RANDOM + 1] = {{ 15, 25, 40, 25 }, { 20, 35, 55, 35 }};
+	static const uint8_t price_mult[][TSZ_RANDOM + 1] = {{ 15, 25, 40, 25 }, { 20, 35, 55, 35 }};
 	/* multidimensional arrays have to have defined length of non-first dimension */
 	static_assert(lengthof(price_mult[0]) == 4);
 
 	CommandCost cost(EXPENSES_OTHER, _price[PR_BUILD_TOWN]);
-	byte mult = price_mult[city][size];
+	uint8_t mult = price_mult[city][size];
 
 	cost.MultiplyCost(mult);
 
@@ -2318,7 +2318,7 @@ static Town *CreateRandomTown(uint attempts, uint32_t townnameparts, TownSize si
 	return nullptr;
 }
 
-static const byte _num_initial_towns[4] = {5, 11, 23, 46};  // very low, low, normal, high
+static const uint8_t _num_initial_towns[4] = {5, 11, 23, 46};  // very low, low, normal, high
 
 /**
  * Generate a number of towns with a given layout.
@@ -2407,7 +2407,7 @@ HouseZonesBits GetTownRadiusGroup(const Town *t, TileIndex tile)
  * @param random_bits Random bits for newgrf houses to use.
  * @pre The house can be built here.
  */
-static inline void ClearMakeHouseTile(TileIndex tile, Town *t, byte counter, byte stage, HouseID type, byte random_bits)
+static inline void ClearMakeHouseTile(TileIndex tile, Town *t, uint8_t counter, uint8_t stage, HouseID type, uint8_t random_bits)
 {
 	[[maybe_unused]] CommandCost cc = Command<CMD_LANDSCAPE_CLEAR>::Do(DC_EXEC | DC_AUTO | DC_NO_WATER, tile);
 	assert(cc.Succeeded());
@@ -2430,7 +2430,7 @@ static inline void ClearMakeHouseTile(TileIndex tile, Town *t, byte counter, byt
  * @param random_bits Random bits for newgrf houses to use.
  * @pre The house can be built here.
  */
-static void MakeTownHouse(TileIndex tile, Town *t, byte counter, byte stage, HouseID type, byte random_bits)
+static void MakeTownHouse(TileIndex tile, Town *t, uint8_t counter, uint8_t stage, HouseID type, uint8_t random_bits)
 {
 	BuildingFlags size = HouseSpec::Get(type)->building_flags;
 
@@ -2742,7 +2742,7 @@ static bool BuildTownHouse(Town *t, TileIndex tile)
 			/* 1x1 house checks are already done */
 		}
 
-		byte random_bits = Random();
+		uint8_t random_bits = Random();
 
 		if (HasBit(hs->callback_mask, CBM_HOUSE_ALLOW_CONSTRUCTION)) {
 			uint16_t callback_res = GetHouseCallback(CBID_HOUSE_ALLOW_CONSTRUCTION, 0, 0, house, t, tile, true, random_bits);
@@ -2755,8 +2755,8 @@ static bool BuildTownHouse(Town *t, TileIndex tile)
 		/* Special houses that there can be only one of. */
 		t->flags |= oneof;
 
-		byte construction_counter = 0;
-		byte construction_stage = 0;
+		uint8_t construction_counter = 0;
+		uint8_t construction_stage = 0;
 
 		if (_generating_world || _game_mode == GM_EDITOR) {
 			uint32_t construction_random = Random();
@@ -3168,7 +3168,7 @@ CommandCost CmdDeleteTown(DoCommandFlag flags, TownID town_id)
  * Factor in the cost of each town action.
  * @see TownActions
  */
-const byte _town_action_costs[TACT_COUNT] = {
+const uint8_t _town_action_costs[TACT_COUNT] = {
 	2, 4, 9, 35, 48, 53, 117, 175
 };
 

--- a/src/town_cmd.h
+++ b/src/town_cmd.h
@@ -14,7 +14,7 @@
 #include "company_type.h"
 #include "town_type.h"
 
-enum TownAcceptanceEffect : byte;
+enum TownAcceptanceEffect : uint8_t;
 
 std::tuple<CommandCost, Money, TownID> CmdFoundTown(DoCommandFlag flags, TileIndex tile, TownSize size, bool city, TownLayout layout, bool random_location, uint32_t townnameparts, const std::string &text);
 CommandCost CmdRenameTown(DoCommandFlag flags, TownID town_id, const std::string &text);

--- a/src/town_map.h
+++ b/src/town_map.h
@@ -91,7 +91,7 @@ inline bool LiftHasDestination(Tile t)
  * @param t the tile
  * @param dest new destination
  */
-inline void SetLiftDestination(Tile t, byte dest)
+inline void SetLiftDestination(Tile t, uint8_t dest)
 {
 	SetBit(t.m7(), 0);
 	SB(t.m7(), 1, 3, dest);
@@ -102,7 +102,7 @@ inline void SetLiftDestination(Tile t, byte dest)
  * @param t the tile
  * @return destination
  */
-inline byte GetLiftDestination(Tile t)
+inline uint8_t GetLiftDestination(Tile t)
 {
 	return GB(t.m7(), 1, 3);
 }
@@ -123,7 +123,7 @@ inline void HaltLift(Tile t)
  * @param t the tile
  * @return position, from 0 to 36
  */
-inline byte GetLiftPosition(Tile t)
+inline uint8_t GetLiftPosition(Tile t)
 {
 	return GB(t.m6(), 2, 6);
 }
@@ -133,7 +133,7 @@ inline byte GetLiftPosition(Tile t)
  * @param t the tile
  * @param pos position, from 0 to 36
  */
-inline void SetLiftPosition(Tile t, byte pos)
+inline void SetLiftPosition(Tile t, uint8_t pos)
 {
 	SB(t.m6(), 2, 6, pos);
 }
@@ -181,10 +181,10 @@ inline void SetHouseCompleted(Tile t, bool status)
  * @pre IsTileType(t, MP_HOUSE)
  * @return the building stage of the house
  */
-inline byte GetHouseBuildingStage(Tile t)
+inline uint8_t GetHouseBuildingStage(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	return IsHouseCompleted(t) ? (byte)TOWN_HOUSE_COMPLETED : GB(t.m5(), 3, 2);
+	return IsHouseCompleted(t) ? (uint8_t)TOWN_HOUSE_COMPLETED : GB(t.m5(), 3, 2);
 }
 
 /**
@@ -193,7 +193,7 @@ inline byte GetHouseBuildingStage(Tile t)
  * @pre IsTileType(t, MP_HOUSE)
  * @return the construction stage of the house
  */
-inline byte GetHouseConstructionTick(Tile t)
+inline uint8_t GetHouseConstructionTick(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	return IsHouseCompleted(t) ? 0 : GB(t.m5(), 0, 3);
@@ -260,7 +260,7 @@ inline TimerGameCalendar::Year GetHouseAge(Tile t)
  * @param random the new random bits
  * @pre IsTileType(t, MP_HOUSE)
  */
-inline void SetHouseRandomBits(Tile t, byte random)
+inline void SetHouseRandomBits(Tile t, uint8_t random)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	t.m1() = random;
@@ -273,7 +273,7 @@ inline void SetHouseRandomBits(Tile t, byte random)
  * @pre IsTileType(t, MP_HOUSE)
  * @return random bits
  */
-inline byte GetHouseRandomBits(Tile t)
+inline uint8_t GetHouseRandomBits(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	return t.m1();
@@ -286,7 +286,7 @@ inline byte GetHouseRandomBits(Tile t)
  * @param triggers the activated triggers
  * @pre IsTileType(t, MP_HOUSE)
  */
-inline void SetHouseTriggers(Tile t, byte triggers)
+inline void SetHouseTriggers(Tile t, uint8_t triggers)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	SB(t.m3(), 0, 5, triggers);
@@ -299,7 +299,7 @@ inline void SetHouseTriggers(Tile t, byte triggers)
  * @pre IsTileType(t, MP_HOUSE)
  * @return triggers
  */
-inline byte GetHouseTriggers(Tile t)
+inline uint8_t GetHouseTriggers(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	return GB(t.m3(), 0, 5);
@@ -311,7 +311,7 @@ inline byte GetHouseTriggers(Tile t)
  * @pre IsTileType(t, MP_HOUSE)
  * @return time remaining
  */
-inline byte GetHouseProcessingTime(Tile t)
+inline uint8_t GetHouseProcessingTime(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	return GB(t.m6(), 2, 6);
@@ -323,7 +323,7 @@ inline byte GetHouseProcessingTime(Tile t)
  * @param time the time to be set
  * @pre IsTileType(t, MP_HOUSE)
  */
-inline void SetHouseProcessingTime(Tile t, byte time)
+inline void SetHouseProcessingTime(Tile t, uint8_t time)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	SB(t.m6(), 2, 6, time);
@@ -350,7 +350,7 @@ inline void DecHouseProcessingTime(Tile t)
  * @param random_bits required for newgrf houses
  * @pre IsTileType(t, MP_CLEAR)
  */
-inline void MakeHouseTile(Tile t, TownID tid, byte counter, byte stage, HouseID type, byte random_bits)
+inline void MakeHouseTile(Tile t, TownID tid, uint8_t counter, uint8_t stage, HouseID type, uint8_t random_bits)
 {
 	assert(IsTileType(t, MP_CLEAR));
 

--- a/src/town_type.h
+++ b/src/town_type.h
@@ -16,7 +16,7 @@ typedef uint16_t TownID;
 struct Town;
 
 /** Supported initial town sizes */
-enum TownSize : byte {
+enum TownSize : uint8_t {
 	TSZ_SMALL,  ///< Small town.
 	TSZ_MEDIUM, ///< Medium town.
 	TSZ_LARGE,  ///< Large town.
@@ -77,7 +77,7 @@ enum Ratings {
 };
 
 /** Town Layouts. It needs to be 8bits, because we save and load it as such */
-enum TownLayout : byte {
+enum TownLayout : uint8_t {
 	TL_BEGIN = 0,
 	TL_ORIGINAL = 0,     ///< Original algorithm (min. 1 distance between roads)
 	TL_BETTER_ROADS,     ///< Extended original algorithm (min. 2 distance between roads)
@@ -91,7 +91,7 @@ enum TownLayout : byte {
 DECLARE_ENUM_AS_ADDABLE(TownLayout)
 
 /** Town founding setting values. It needs to be 8bits, because we save and load it as such */
-enum TownFounding : byte {
+enum TownFounding : uint8_t {
 	TF_BEGIN = 0,     ///< Used for iterations and limit testing
 	TF_FORBIDDEN = 0, ///< Forbidden
 	TF_ALLOWED,       ///< Allowed
@@ -100,7 +100,7 @@ enum TownFounding : byte {
 };
 
 /** Town cargo generation modes */
-enum TownCargoGenMode : byte {
+enum TownCargoGenMode : uint8_t {
 	TCGM_BEGIN = 0,
 	TCGM_ORIGINAL = 0,  ///< Original algorithm (quadratic cargo by population)
 	TCGM_BITCOUNT,      ///< Bit-counted algorithm (normal distribution from individual house population)

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -166,7 +166,7 @@ bool GenerateTownName(Randomizer &randomizer, uint32_t *townnameparts, TownNames
  * @param seed seed
  * @return seed transformed to a number from given range
  */
-static inline uint32_t SeedChance(byte shift_by, int max, uint32_t seed)
+static inline uint32_t SeedChance(uint8_t shift_by, int max, uint32_t seed)
 {
 	return (GB(seed, shift_by, 16) * max) >> 16;
 }
@@ -179,7 +179,7 @@ static inline uint32_t SeedChance(byte shift_by, int max, uint32_t seed)
  * @param seed seed
  * @return seed transformed to a number from given range
  */
-static inline uint32_t SeedModChance(byte shift_by, int max, uint32_t seed)
+static inline uint32_t SeedModChance(uint8_t shift_by, int max, uint32_t seed)
 {
 	/* This actually gives *MUCH* more even distribution of the values
 	 * than SeedChance(), which is absolutely horrible in that. If
@@ -202,7 +202,7 @@ static inline uint32_t SeedModChance(byte shift_by, int max, uint32_t seed)
  * @param bias minimum value that can be returned
  * @return seed transformed to a number from given range
  */
-static inline int32_t SeedChanceBias(byte shift_by, int max, uint32_t seed, int bias)
+static inline int32_t SeedChanceBias(uint8_t shift_by, int max, uint32_t seed, int bias)
 {
 	return SeedChance(shift_by, max + bias, seed) - bias;
 }

--- a/src/townname_type.h
+++ b/src/townname_type.h
@@ -33,7 +33,7 @@ struct TownNameParams {
 	 * Initializes this struct from language ID
 	 * @param town_name town name 'language' ID
 	 */
-	TownNameParams(byte town_name)
+	TownNameParams(uint8_t town_name)
 	{
 		bool grf = town_name >= BUILTIN_TOWNNAME_GENERATOR_COUNT;
 		this->grfid = grf ? GetGRFTownNameId(town_name - BUILTIN_TOWNNAME_GENERATOR_COUNT) : 0;

--- a/src/track_type.h
+++ b/src/track_type.h
@@ -16,7 +16,7 @@
  * These are used to specify a single track.
  * Can be translated to a trackbit with TrackToTrackbit
  */
-enum Track : byte {
+enum Track : uint8_t {
 	TRACK_BEGIN = 0,        ///< Used for iterations
 	TRACK_X     = 0,        ///< Track along the x-axis (north-east to south-west)
 	TRACK_Y     = 1,        ///< Track along the y-axis (north-west to south-east)
@@ -32,7 +32,7 @@ enum Track : byte {
 DECLARE_POSTFIX_INCREMENT(Track)
 
 /** Bitfield corresponding to Track */
-enum TrackBits : byte {
+enum TrackBits : uint8_t {
 	TRACK_BIT_NONE    = 0U,                                                 ///< No track
 	TRACK_BIT_X       = 1U << TRACK_X,                                      ///< X-axis track
 	TRACK_BIT_Y       = 1U << TRACK_Y,                                      ///< Y-axis track
@@ -64,7 +64,7 @@ DECLARE_ENUM_AS_BIT_SET(TrackBits)
  * reversing track dirs are not considered to be 'valid' except in a small
  * corner in the road vehicle controller.
  */
-enum Trackdir : byte {
+enum Trackdir : uint8_t {
 	TRACKDIR_BEGIN    =  0,         ///< Used for iterations
 	TRACKDIR_X_NE     =  0,         ///< X-axis and direction to north-east
 	TRACKDIR_Y_SE     =  1,         ///< Y-axis and direction to south-east

--- a/src/train.h
+++ b/src/train.h
@@ -34,7 +34,7 @@ enum VehicleRailFlags {
 };
 
 /** Modes for ignoring signals. */
-enum TrainForceProceeding : byte {
+enum TrainForceProceeding : uint8_t {
 	TFP_NONE   = 0,    ///< Normal operation.
 	TFP_STUCK  = 1,    ///< Proceed till next signal, but ignore being stuck till then. This includes force leaving depots.
 	TFP_SIGNAL = 2,    ///< Ignore next signal, after the signal ignore being stuck.
@@ -54,7 +54,7 @@ enum ConsistChangeFlags {
 };
 DECLARE_ENUM_AS_BIT_SET(ConsistChangeFlags)
 
-byte FreightWagonMult(CargoID cargo);
+uint8_t FreightWagonMult(CargoID cargo);
 
 void CheckTrainsLengths();
 
@@ -77,7 +77,7 @@ struct TrainCache {
 	bool cached_tilt;           ///< train can tilt; feature provides a bonus in curves
 	int cached_curve_speed_mod; ///< curve speed modifier of the entire train
 
-	byte user_def_data;         ///< Cached property 0x25. Can be set by Callback 0x36.
+	uint8_t user_def_data;         ///< Cached property 0x25. Can be set by Callback 0x36.
 
 	/* cached max. speed / acceleration data */
 	int cached_max_curve_speed; ///< max consist speed limited by curves
@@ -243,7 +243,7 @@ protected: // These functions should not be called outside acceleration code.
 	 * Allows to know the tractive effort value that this vehicle will use.
 	 * @return Tractive effort value from the engine.
 	 */
-	inline byte GetTractiveEffort() const
+	inline uint8_t GetTractiveEffort() const
 	{
 		return GetVehicleProperty(this, PROP_TRAIN_TRACTIVE_EFFORT, RailVehInfo(this->engine_type)->tractive_effort);
 	}
@@ -252,7 +252,7 @@ protected: // These functions should not be called outside acceleration code.
 	 * Gets the area used for calculating air drag.
 	 * @return Area of the engine in m^2.
 	 */
-	inline byte GetAirDragArea() const
+	inline uint8_t GetAirDragArea() const
 	{
 		/* Air drag is higher in tunnels due to the limited cross-section. */
 		return (this->track == TRACK_BIT_WORMHOLE && this->vehstatus & VS_HIDDEN) ? 28 : 14;
@@ -262,7 +262,7 @@ protected: // These functions should not be called outside acceleration code.
 	 * Gets the air drag coefficient of this vehicle.
 	 * @return Air drag value from the engine.
 	 */
-	inline byte GetAirDrag() const
+	inline uint8_t GetAirDrag() const
 	{
 		return RailVehInfo(this->engine_type)->air_drag;
 	}

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -52,8 +52,8 @@ static TileIndex TrainApproachingCrossingTile(const Train *v);
 static void CheckIfTrainNeedsService(Train *v);
 static void CheckNextTrainTile(Train *v);
 
-static const byte _vehicle_initial_x_fract[4] = {10, 8, 4,  8};
-static const byte _vehicle_initial_y_fract[4] = { 8, 4, 8, 10};
+static const uint8_t _vehicle_initial_x_fract[4] = {10, 8, 4,  8};
+static const uint8_t _vehicle_initial_y_fract[4] = { 8, 4, 8, 10};
 
 template <>
 bool IsValidImageIndex<VEH_TRAIN>(uint8_t image_index)
@@ -67,7 +67,7 @@ bool IsValidImageIndex<VEH_TRAIN>(uint8_t image_index)
  * @param cargo Cargo type to get multiplier for
  * @return Cargo weight multiplier
  */
-byte FreightWagonMult(CargoID cargo)
+uint8_t FreightWagonMult(CargoID cargo)
 {
 	if (!CargoSpec::Get(cargo)->is_freight) return 1;
 	return _settings_game.vehicle.freight_trains;
@@ -2449,7 +2449,7 @@ void FreeTrainTrackReservation(const Train *v)
 	}
 }
 
-static const byte _initial_tile_subcoord[6][4][3] = {
+static const uint8_t _initial_tile_subcoord[6][4][3] = {
 {{ 15, 8, 1 }, { 0, 0, 0 }, { 0, 8, 5 }, { 0,  0, 0 }},
 {{  0, 0, 0 }, { 8, 0, 3 }, { 0, 0, 0 }, { 8, 15, 7 }},
 {{  0, 0, 0 }, { 7, 0, 2 }, { 0, 7, 6 }, { 0,  0, 0 }},
@@ -3037,10 +3037,10 @@ static inline bool CheckCompatibleRail(const Train *v, TileIndex tile)
 
 /** Data structure for storing engine speed changes of an acceleration type. */
 struct AccelerationSlowdownParams {
-	byte small_turn; ///< Speed change due to a small turn.
-	byte large_turn; ///< Speed change due to a large turn.
-	byte z_up;       ///< Fraction to remove when moving up.
-	byte z_down;     ///< Fraction to add when moving down.
+	uint8_t small_turn; ///< Speed change due to a small turn.
+	uint8_t large_turn; ///< Speed change due to a large turn.
+	uint8_t z_up;       ///< Fraction to remove when moving up.
+	uint8_t z_down;     ///< Fraction to add when moving down.
 };
 
 /** Speed update fractions for each acceleration type. */
@@ -3442,7 +3442,7 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 						chosen_track == TRACK_BIT_LEFT  || chosen_track == TRACK_BIT_RIGHT);
 
 				/* Update XY to reflect the entrance to the new tile, and select the direction to use */
-				const byte *b = _initial_tile_subcoord[FindFirstBit(chosen_track)][enterdir];
+				const uint8_t *b = _initial_tile_subcoord[FindFirstBit(chosen_track)][enterdir];
 				gp.x = (gp.x & ~0xF) | b[0];
 				gp.y = (gp.y & ~0xF) | b[1];
 				Direction chosen_dir = (Direction)b[2];

--- a/src/transparency.h
+++ b/src/transparency.h
@@ -37,7 +37,7 @@ typedef uint TransparencyOptionBits; ///< transparency option bits
 extern TransparencyOptionBits _transparency_opt;
 extern TransparencyOptionBits _transparency_lock;
 extern TransparencyOptionBits _invisibility_opt;
-extern byte _display_opt;
+extern uint8_t _display_opt;
 
 /**
  * Check if the transparency option bit is set

--- a/src/transparency_gui.cpp
+++ b/src/transparency_gui.cpp
@@ -23,7 +23,7 @@
 TransparencyOptionBits _transparency_opt;  ///< The bits that should be transparent.
 TransparencyOptionBits _transparency_lock; ///< Prevent these bits from flipping with X.
 TransparencyOptionBits _invisibility_opt;  ///< The bits that should be invisible.
-byte _display_opt; ///< What do we want to draw/do?
+uint8_t _display_opt; ///< What do we want to draw/do?
 
 class TransparenciesWindow : public Window
 {

--- a/src/transport_type.h
+++ b/src/transport_type.h
@@ -16,7 +16,7 @@
 typedef uint16_t UnitID;
 
 /** Available types of transport */
-enum TransportType : byte {
+enum TransportType : uint8_t {
 	/* These constants are for now linked to the representation of bridges
 	 * and tunnels, so they can be used by GetTileTrackStatus_TunnelBridge.
 	 * In an ideal world, these constants would be used everywhere when

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -52,7 +52,7 @@ enum ExtraTreePlacement {
 };
 
 /** Determines when to consider building more trees. */
-byte _trees_tick_ctr;
+uint8_t _trees_tick_ctr;
 
 static const uint16_t DEFAULT_TREE_STEPS = 1000;             ///< Default number of attempts for placing trees.
 static const uint16_t DEFAULT_RAINFOREST_TREE_STEPS = 15000; ///< Default number of attempts for placing extra trees at rainforest in tropic.
@@ -166,7 +166,7 @@ static void PlaceTree(TileIndex tile, uint32_t r)
 	TreeType tree = GetRandomTreeType(tile, GB(r, 24, 8));
 
 	if (tree != TREE_INVALID) {
-		PlantTreesOnTile(tile, tree, GB(r, 22, 2), std::min<byte>(GB(r, 16, 3), 6));
+		PlantTreesOnTile(tile, tree, GB(r, 22, 2), std::min<uint8_t>(GB(r, 16, 3), 6));
 		MarkTileDirtyByTile(tile);
 
 		/* Rerandomize ground, if neither snow nor shore */
@@ -385,7 +385,7 @@ void GenerateTrees()
  * @param diagonal Whether to use the Orthogonal (false) or Diagonal (true) iterator.
  * @return the cost of this operation or an error
  */
-CommandCost CmdPlantTree(DoCommandFlag flags, TileIndex tile, TileIndex start_tile, byte tree_to_plant, bool diagonal)
+CommandCost CmdPlantTree(DoCommandFlag flags, TileIndex tile, TileIndex start_tile, uint8_t tree_to_plant, bool diagonal)
 {
 	StringID msg = INVALID_STRING_ID;
 	CommandCost cost(EXPENSES_OTHER);
@@ -512,7 +512,7 @@ CommandCost CmdPlantTree(DoCommandFlag flags, TileIndex tile, TileIndex start_ti
 }
 
 struct TreeListEnt : PalSpriteID {
-	byte x, y;
+	uint8_t x, y;
 };
 
 static void DrawTile_Trees(TileInfo *ti)
@@ -819,10 +819,10 @@ static void TileLoop_Trees(TileIndex tile)
 bool DecrementTreeCounter()
 {
 	/* Ensure _trees_tick_ctr can be decremented past zero only once for the largest map size. */
-	static_assert(2 * (MAX_MAP_SIZE_BITS - MIN_MAP_SIZE_BITS) - 4 <= std::numeric_limits<byte>::digits);
+	static_assert(2 * (MAX_MAP_SIZE_BITS - MIN_MAP_SIZE_BITS) - 4 <= std::numeric_limits<uint8_t>::digits);
 
 	/* byte underflow */
-	byte old_trees_tick_ctr = _trees_tick_ctr;
+	uint8_t old_trees_tick_ctr = _trees_tick_ctr;
 	_trees_tick_ctr -= Map::ScaleBySize(1);
 	return old_trees_tick_ctr <= _trees_tick_ctr;
 }

--- a/src/tree_cmd.h
+++ b/src/tree_cmd.h
@@ -12,7 +12,7 @@
 
 #include "command_type.h"
 
-CommandCost CmdPlantTree(DoCommandFlag flags, TileIndex tile, TileIndex start_tile, byte tree_to_plant, bool diagonal);
+CommandCost CmdPlantTree(DoCommandFlag flags, TileIndex tile, TileIndex start_tile, uint8_t tree_to_plant, bool diagonal);
 
 DEF_CMD_TRAIT(CMD_PLANT_TREE, CmdPlantTree, CMD_AUTO, CMDT_LANDSCAPE_CONSTRUCTION)
 

--- a/src/tree_gui.cpp
+++ b/src/tree_gui.cpp
@@ -258,13 +258,13 @@ public:
  */
 static std::unique_ptr<NWidgetBase> MakeTreeTypeButtons()
 {
-	const byte type_base = _tree_base_by_landscape[_settings_game.game_creation.landscape];
-	const byte type_count = _tree_count_by_landscape[_settings_game.game_creation.landscape];
+	const uint8_t type_base = _tree_base_by_landscape[_settings_game.game_creation.landscape];
+	const uint8_t type_count = _tree_count_by_landscape[_settings_game.game_creation.landscape];
 
 	/* Toyland has 9 tree types, which look better in 3x3 than 4x3 */
 	const int num_columns = type_count == 9 ? 3 : 4;
 	const int num_rows = CeilDiv(type_count, num_columns);
-	byte cur_type = type_base;
+	uint8_t cur_type = type_base;
 
 	auto vstack = std::make_unique<NWidgetVertical>(NC_EQUALSIZE);
 	vstack->SetPIP(0, 1, 0);

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -258,7 +258,7 @@ static Money TunnelBridgeClearCost(TileIndex tile, Price base_price)
  * @param road_rail_type rail type or road types.
  * @return the cost of this operation or an error
  */
-CommandCost CmdBuildBridge(DoCommandFlag flags, TileIndex tile_end, TileIndex tile_start, TransportType transport_type, BridgeType bridge_type, byte road_rail_type)
+CommandCost CmdBuildBridge(DoCommandFlag flags, TileIndex tile_end, TileIndex tile_start, TransportType transport_type, BridgeType bridge_type, uint8_t road_rail_type)
 {
 	CompanyID company = _current_company;
 
@@ -620,7 +620,7 @@ CommandCost CmdBuildBridge(DoCommandFlag flags, TileIndex tile_end, TileIndex ti
  * @param road_rail_type railtype or roadtype
  * @return the cost of this operation or an error
  */
-CommandCost CmdBuildTunnel(DoCommandFlag flags, TileIndex start_tile, TransportType transport_type, byte road_rail_type)
+CommandCost CmdBuildTunnel(DoCommandFlag flags, TileIndex start_tile, TransportType transport_type, uint8_t road_rail_type)
 {
 	CompanyID company = _current_company;
 
@@ -1880,7 +1880,7 @@ static void PrepareToEnterBridge(T *gv)
  * frame on a tile, so the sound is played shortly after entering the tunnel
  * tile, while the vehicle is still visible.
  */
-static const byte TUNNEL_SOUND_FRAME = 1;
+static const uint8_t TUNNEL_SOUND_FRAME = 1;
 
 /**
  * Frame when a vehicle should be hidden in a tunnel with a certain direction.
@@ -1890,7 +1890,7 @@ static const byte TUNNEL_SOUND_FRAME = 1;
  * When leaving a tunnel, show the vehicle when it is one frame further
  * to the 'outside', i.e. at (TILE_SIZE-1) - (frame) + 1
  */
-extern const byte _tunnel_visibility_frame[DIAGDIR_END] = {12, 8, 8, 12};
+extern const uint8_t _tunnel_visibility_frame[DIAGDIR_END] = {12, 8, 8, 12};
 
 static VehicleEnterTileStatus VehicleEnter_TunnelBridge(Vehicle *v, TileIndex tile, int x, int y)
 {
@@ -1902,9 +1902,9 @@ static VehicleEnterTileStatus VehicleEnter_TunnelBridge(Vehicle *v, TileIndex ti
 	/* Direction of the vehicle */
 	const DiagDirection vdir = DirToDiagDir(v->direction);
 	/* New position of the vehicle on the tile */
-	byte pos = (DiagDirToAxis(vdir) == AXIS_X ? x : y) & TILE_UNIT_MASK;
+	uint8_t pos = (DiagDirToAxis(vdir) == AXIS_X ? x : y) & TILE_UNIT_MASK;
 	/* Number of units moved by the vehicle since entering the tile */
-	byte frame = (vdir == DIAGDIR_NE || vdir == DIAGDIR_NW) ? TILE_SIZE - 1 - pos : pos;
+	uint8_t frame = (vdir == DIAGDIR_NE || vdir == DIAGDIR_NW) ? TILE_SIZE - 1 - pos : pos;
 
 	if (IsTunnel(tile)) {
 		if (v->type == VEH_TRAIN) {

--- a/src/tunnelbridge_cmd.h
+++ b/src/tunnelbridge_cmd.h
@@ -14,12 +14,12 @@
 #include "transport_type.h"
 #include "bridge.h"
 
-CommandCost CmdBuildBridge(DoCommandFlag flags, TileIndex tile_end, TileIndex tile_start, TransportType transport_type, BridgeType bridge_type, byte road_rail_type);
-CommandCost CmdBuildTunnel(DoCommandFlag flags, TileIndex start_tile, TransportType transport_type, byte road_rail_type);
+CommandCost CmdBuildBridge(DoCommandFlag flags, TileIndex tile_end, TileIndex tile_start, TransportType transport_type, BridgeType bridge_type, uint8_t road_rail_type);
+CommandCost CmdBuildTunnel(DoCommandFlag flags, TileIndex start_tile, TransportType transport_type, uint8_t road_rail_type);
 
 DEF_CMD_TRAIT(CMD_BUILD_BRIDGE, CmdBuildBridge, CMD_DEITY | CMD_AUTO | CMD_NO_WATER, CMDT_LANDSCAPE_CONSTRUCTION)
 DEF_CMD_TRAIT(CMD_BUILD_TUNNEL, CmdBuildTunnel, CMD_DEITY | CMD_AUTO,                CMDT_LANDSCAPE_CONSTRUCTION)
 
-void CcBuildBridge(Commands cmd, const CommandCost &result, TileIndex end_tile, TileIndex tile_start, TransportType transport_type, BridgeType, byte);
+void CcBuildBridge(Commands cmd, const CommandCost &result, TileIndex end_tile, TileIndex tile_start, TransportType transport_type, BridgeType, uint8_t);
 
 #endif /* TUNNELBRIDGE_CMD_H */

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1300,7 +1300,7 @@ void DecreaseVehicleValue(Vehicle *v)
 	SetWindowDirty(WC_VEHICLE_DETAILS, v->index);
 }
 
-static const byte _breakdown_chance[64] = {
+static const uint8_t _breakdown_chance[64] = {
 	  3,   3,   3,   3,   3,   3,   3,   3,
 	  4,   4,   5,   5,   6,   6,   7,   7,
 	  8,   8,   9,   9,  10,  10,  11,  11,
@@ -1905,7 +1905,7 @@ UnitID GetFreeUnitNumber(VehicleType type)
  * @return true if there is any reason why you may build
  *         the infrastructure for the given vehicle type
  */
-bool CanBuildVehicleInfrastructure(VehicleType type, byte subtype)
+bool CanBuildVehicleInfrastructure(VehicleType type, uint8_t subtype)
 {
 	assert(IsCompanyBuildableVehicleType(type));
 
@@ -2047,7 +2047,7 @@ LiveryScheme GetEngineLiveryScheme(EngineID engine_type, EngineID parent_engine_
  * @param livery_setting The livery settings to use for acquiring the livery information.
  * @return livery to use
  */
-const Livery *GetEngineLivery(EngineID engine_type, CompanyID company, EngineID parent_engine_type, const Vehicle *v, byte livery_setting)
+const Livery *GetEngineLivery(EngineID engine_type, CompanyID company, EngineID parent_engine_type, const Vehicle *v, uint8_t livery_setting)
 {
 	const Company *c = Company::Get(company);
 	LiveryScheme scheme = LS_DEFAULT;
@@ -2643,7 +2643,7 @@ void Vehicle::UpdateVisualEffect(bool allow_power_change)
 	const Engine *e = this->GetEngine();
 
 	/* Evaluate properties */
-	byte visual_effect;
+	uint8_t visual_effect;
 	switch (e->type) {
 		case VEH_TRAIN: visual_effect = e->u.rail.visual_effect; break;
 		case VEH_ROAD:  visual_effect = e->u.road.visual_effect; break;

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -124,7 +124,7 @@ struct VehicleCache {
 	uint16_t cached_max_speed;        ///< Maximum speed of the consist (minimum of the max speed of all vehicles in the consist).
 	uint16_t cached_cargo_age_period; ///< Number of ticks before carried cargo is aged.
 
-	byte cached_vis_effect;  ///< Visual effect to show (see #VisualEffect)
+	uint8_t cached_vis_effect;  ///< Visual effect to show (see #VisualEffect)
 };
 
 /** Sprite sequence for a vehicle part. */
@@ -292,10 +292,10 @@ public:
 	TimerGameCalendar::Date date_of_last_service_newgrf; ///< Last calendar date the vehicle had a service at a depot, unchanged by the date cheat to protect against unsafe NewGRF behavior.
 	uint16_t reliability;                 ///< Reliability.
 	uint16_t reliability_spd_dec;         ///< Reliability decrease speed.
-	byte breakdown_ctr;                 ///< Counter for managing breakdown events. @see Vehicle::HandleBreakdown
-	byte breakdown_delay;               ///< Counter for managing breakdown length.
-	byte breakdowns_since_last_service; ///< Counter for the amount of breakdowns.
-	byte breakdown_chance;              ///< Current chance of breakdowns.
+	uint8_t breakdown_ctr;                 ///< Counter for managing breakdown events. @see Vehicle::HandleBreakdown
+	uint8_t breakdown_delay;               ///< Counter for managing breakdown length.
+	uint8_t breakdowns_since_last_service; ///< Counter for the amount of breakdowns.
+	uint8_t breakdown_chance;              ///< Current chance of breakdowns.
 
 	int32_t x_pos;                        ///< x coordinate.
 	int32_t y_pos;                        ///< y coordinate.
@@ -308,10 +308,10 @@ public:
 	 * 0xfd == custom sprite, 0xfe == custom second head sprite
 	 * 0xff == reserved for another custom sprite
 	 */
-	byte spritenum;
-	byte x_extent;                      ///< x-extent of vehicle bounding box
-	byte y_extent;                      ///< y-extent of vehicle bounding box
-	byte z_extent;                      ///< z-extent of vehicle bounding box
+	uint8_t spritenum;
+	uint8_t x_extent;                      ///< x-extent of vehicle bounding box
+	uint8_t y_extent;                      ///< y-extent of vehicle bounding box
+	uint8_t z_extent;                      ///< z-extent of vehicle bounding box
 	int8_t x_bb_offs;                     ///< x offset of vehicle bounding box
 	int8_t y_bb_offs;                     ///< y offset of vehicle bounding box
 	int8_t x_offs;                        ///< x offset for vehicle sprite
@@ -322,31 +322,31 @@ public:
 	UnitID unitnumber;                  ///< unit number, for display purposes only
 
 	uint16_t cur_speed;                   ///< current speed
-	byte subspeed;                      ///< fractional speed
-	byte acceleration;                  ///< used by train & aircraft
+	uint8_t subspeed;                      ///< fractional speed
+	uint8_t acceleration;                  ///< used by train & aircraft
 	uint32_t motion_counter;              ///< counter to occasionally play a vehicle sound.
-	byte progress;                      ///< The percentage (if divided by 256) this vehicle already crossed the tile unit.
+	uint8_t progress;                      ///< The percentage (if divided by 256) this vehicle already crossed the tile unit.
 
 	uint16_t random_bits; ///< Bits used for randomized variational spritegroups.
-	byte waiting_triggers;              ///< Triggers to be yet matched before rerandomizing the random bits.
+	uint8_t waiting_triggers;              ///< Triggers to be yet matched before rerandomizing the random bits.
 
 	StationID last_station_visited;     ///< The last station we stopped at.
 	StationID last_loading_station;     ///< Last station the vehicle has stopped at and could possibly leave from with any cargo loaded.
 	TimerGameTick::TickCounter last_loading_tick; ///< Last TimerGameTick::counter tick that the vehicle has stopped at a station and could possibly leave with any cargo loaded.
 
 	CargoID cargo_type;                 ///< type of cargo this vehicle is carrying
-	byte cargo_subtype;                 ///< Used for livery refits (NewGRF variations)
+	uint8_t cargo_subtype;                 ///< Used for livery refits (NewGRF variations)
 	uint16_t cargo_cap;                   ///< total capacity
 	uint16_t refit_cap;                   ///< Capacity left over from before last refit.
 	VehicleCargoList cargo;             ///< The cargo this vehicle is carrying
 	uint16_t cargo_age_counter;           ///< Ticks till cargo is aged next.
 	int8_t trip_occupancy;                ///< NOSAVE: Occupancy of vehicle of the current trip (updated after leaving a station).
 
-	byte day_counter;                   ///< Increased by one for each day
-	byte tick_counter;                  ///< Increased by one for each tick
-	byte running_ticks;                 ///< Number of ticks this vehicle was not stopped this day
+	uint8_t day_counter;                   ///< Increased by one for each day
+	uint8_t tick_counter;                  ///< Increased by one for each tick
+	uint8_t running_ticks;                 ///< Number of ticks this vehicle was not stopped this day
 
-	byte vehstatus;                     ///< Status
+	uint8_t vehstatus;                     ///< Status
 	Order current_order;                ///< The current order (+ status, like: loading)
 
 	union {
@@ -356,7 +356,7 @@ public:
 
 	uint16_t load_unload_ticks;           ///< Ticks to wait before starting next cycle.
 	GroupID group_id;                   ///< Index of group Pool array
-	byte subtype;                       ///< subtype (Filled with values from #AircraftSubType/#DisasterSubType/#EffectVehicleType/#GroundVehicleSubtypeFlags)
+	uint8_t subtype;                       ///< subtype (Filled with values from #AircraftSubType/#DisasterSubType/#EffectVehicleType/#GroundVehicleSubtypeFlags)
 
 	NewGRFCache grf_cache;              ///< Cache of often used calculated NewGRF values
 	VehicleCache vcache;                ///< Cache of often used vehicle values.

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -267,7 +267,7 @@ CommandCost CmdSellVehicle(DoCommandFlag flags, VehicleID v_id, bool sell_chain,
  * @param[out] auto_refit_allowed The refit is allowed as an auto-refit.
  * @return Price for refitting
  */
-static int GetRefitCostFactor(const Vehicle *v, EngineID engine_type, CargoID new_cid, byte new_subtype, bool *auto_refit_allowed)
+static int GetRefitCostFactor(const Vehicle *v, EngineID engine_type, CargoID new_cid, uint8_t new_subtype, bool *auto_refit_allowed)
 {
 	/* Prepare callback param with info about the new cargo type. */
 	const Engine *e = Engine::Get(engine_type);
@@ -299,7 +299,7 @@ static int GetRefitCostFactor(const Vehicle *v, EngineID engine_type, CargoID ne
  * @param[out] auto_refit_allowed The refit is allowed as an auto-refit.
  * @return Price for refitting
  */
-static CommandCost GetRefitCost(const Vehicle *v, EngineID engine_type, CargoID new_cid, byte new_subtype, bool *auto_refit_allowed)
+static CommandCost GetRefitCost(const Vehicle *v, EngineID engine_type, CargoID new_cid, uint8_t new_subtype, bool *auto_refit_allowed)
 {
 	ExpensesType expense_type;
 	const Engine *e = Engine::Get(engine_type);
@@ -341,7 +341,7 @@ struct RefitResult {
 	Vehicle *v;         ///< Vehicle to refit
 	uint capacity;      ///< New capacity of vehicle
 	uint mail_capacity; ///< New mail capacity of aircraft
-	byte subtype;       ///< cargo subtype to refit to
+	uint8_t subtype;       ///< cargo subtype to refit to
 };
 
 /**
@@ -356,7 +356,7 @@ struct RefitResult {
  * @param auto_refit   Refitting is done as automatic refitting outside a depot.
  * @return Refit cost + refittet capacity + mail capacity (aircraft).
  */
-static std::tuple<CommandCost, uint, uint16_t, CargoArray> RefitVehicle(Vehicle *v, bool only_this, uint8_t num_vehicles, CargoID new_cid, byte new_subtype, DoCommandFlag flags, bool auto_refit)
+static std::tuple<CommandCost, uint, uint16_t, CargoArray> RefitVehicle(Vehicle *v, bool only_this, uint8_t num_vehicles, CargoID new_cid, uint8_t new_subtype, DoCommandFlag flags, bool auto_refit)
 {
 	CommandCost cost(v->GetExpenseType(false));
 	uint total_capacity = 0;
@@ -374,7 +374,7 @@ static std::tuple<CommandCost, uint, uint16_t, CargoArray> RefitVehicle(Vehicle 
 	std::vector<RefitResult> refit_result;
 
 	v->InvalidateNewGRFCacheOfChain();
-	byte actual_subtype = new_subtype;
+	uint8_t actual_subtype = new_subtype;
 	for (; v != nullptr; v = (only_this ? nullptr : v->Next())) {
 		/* Reset actual_subtype for every new vehicle */
 		if (!v->IsArticulatedPart()) actual_subtype = new_subtype;
@@ -400,7 +400,7 @@ static std::tuple<CommandCost, uint, uint16_t, CargoArray> RefitVehicle(Vehicle 
 
 		/* Back up the vehicle's cargo type */
 		CargoID temp_cid = v->cargo_type;
-		byte temp_subtype = v->cargo_subtype;
+		uint8_t temp_subtype = v->cargo_subtype;
 		if (refittable) {
 			v->cargo_type = new_cid;
 			v->cargo_subtype = actual_subtype;
@@ -487,7 +487,7 @@ static std::tuple<CommandCost, uint, uint16_t, CargoArray> RefitVehicle(Vehicle 
  *                     Only used if "refit only this vehicle" is false.
  * @return the cost of this operation or an error
  */
-std::tuple<CommandCost, uint, uint16_t, CargoArray> CmdRefitVehicle(DoCommandFlag flags, VehicleID veh_id, CargoID new_cid, byte new_subtype, bool auto_refit, bool only_this, uint8_t num_vehicles)
+std::tuple<CommandCost, uint, uint16_t, CargoArray> CmdRefitVehicle(DoCommandFlag flags, VehicleID veh_id, CargoID new_cid, uint8_t new_subtype, bool auto_refit, bool only_this, uint8_t num_vehicles)
 {
 	Vehicle *v = Vehicle::GetIfValid(veh_id);
 	if (v == nullptr) return { CMD_ERROR, 0, 0, {} };
@@ -778,7 +778,7 @@ static void CloneVehicleName(const Vehicle *src, Vehicle *dst)
 
 	/* Format buffer and determine starting number. */
 	long num;
-	byte padding = 0;
+	uint8_t padding = 0;
 	if (number_position == src->name.length()) {
 		/* No digit at the end, so start at number 2. */
 		buf = src->name;
@@ -790,7 +790,7 @@ static void CloneVehicleName(const Vehicle *src, Vehicle *dst)
 		buf = src->name.substr(0, number_position);
 
 		auto num_str = src->name.substr(number_position);
-		padding = (byte)num_str.length();
+		padding = (uint8_t)num_str.length();
 
 		std::istringstream iss(num_str);
 		iss >> num;
@@ -944,7 +944,7 @@ std::tuple<CommandCost, VehicleID> CmdCloneVehicle(DoCommandFlag flags, TileInde
 				assert(w != nullptr);
 
 				/* Find out what's the best sub type */
-				byte subtype = GetBestFittingSubType(v, w, v->cargo_type);
+				uint8_t subtype = GetBestFittingSubType(v, w, v->cargo_type);
 				if (w->cargo_type != v->cargo_type || w->cargo_subtype != subtype) {
 					CommandCost cost = std::get<0>(Command<CMD_REFIT_VEHICLE>::Do(flags, w->index, v->cargo_type, subtype, false, true, 0));
 					if (cost.Succeeded()) total_cost.AddCost(cost);

--- a/src/vehicle_cmd.h
+++ b/src/vehicle_cmd.h
@@ -19,7 +19,7 @@
 
 std::tuple<CommandCost, VehicleID, uint, uint16_t, CargoArray> CmdBuildVehicle(DoCommandFlag flags, TileIndex tile, EngineID eid, bool use_free_vehicles, CargoID cargo, ClientID client_id);
 CommandCost CmdSellVehicle(DoCommandFlag flags, VehicleID v_id, bool sell_chain, bool backup_order, ClientID client_id);
-std::tuple<CommandCost, uint, uint16_t, CargoArray> CmdRefitVehicle(DoCommandFlag flags, VehicleID veh_id, CargoID new_cid, byte new_subtype, bool auto_refit, bool only_this, uint8_t num_vehicles);
+std::tuple<CommandCost, uint, uint16_t, CargoArray> CmdRefitVehicle(DoCommandFlag flags, VehicleID veh_id, CargoID new_cid, uint8_t new_subtype, bool auto_refit, bool only_this, uint8_t num_vehicles);
 CommandCost CmdSendVehicleToDepot(DoCommandFlag flags, VehicleID veh_id, DepotCommand depot_cmd, const VehicleListIdentifier &vli);
 CommandCost CmdChangeServiceInt(DoCommandFlag flags, VehicleID veh_id, uint16_t serv_int, bool is_custom, bool is_percent);
 CommandCost CmdRenameVehicle(DoCommandFlag flags, VehicleID veh_id, const std::string &text);

--- a/src/vehicle_func.h
+++ b/src/vehicle_func.h
@@ -53,7 +53,7 @@ void VehicleLengthChanged(const Vehicle *u);
 void ResetVehicleHash();
 void ResetVehicleColourMap();
 
-byte GetBestFittingSubType(Vehicle *v_from, Vehicle *v_for, CargoID dest_cargo_type);
+uint8_t GetBestFittingSubType(Vehicle *v_from, Vehicle *v_for, CargoID dest_cargo_type);
 
 void ViewportAddVehicles(DrawPixelInfo *dpi);
 
@@ -71,7 +71,7 @@ UnitID GetFreeUnitNumber(VehicleType type);
 
 void VehicleEnterDepot(Vehicle *v);
 
-bool CanBuildVehicleInfrastructure(VehicleType type, byte subtype = 0);
+bool CanBuildVehicleInfrastructure(VehicleType type, uint8_t subtype = 0);
 
 /** Position information of a vehicle after it moved */
 struct GetNewVehiclePosResult {
@@ -112,7 +112,7 @@ inline bool IsCompanyBuildableVehicleType(const BaseVehicle *v)
 }
 
 LiveryScheme GetEngineLiveryScheme(EngineID engine_type, EngineID parent_engine_type, const Vehicle *v);
-const struct Livery *GetEngineLivery(EngineID engine_type, CompanyID company, EngineID parent_engine_type, const Vehicle *v, byte livery_setting);
+const struct Livery *GetEngineLivery(EngineID engine_type, CompanyID company, EngineID parent_engine_type, const Vehicle *v, uint8_t livery_setting);
 
 SpriteID GetEnginePalette(EngineID engine_type, CompanyID company);
 SpriteID GetVehiclePalette(const Vehicle *v);

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -515,7 +515,7 @@ static const uint MAX_REFIT_CYCLE = 256;
  * @param dest_cargo_type Destination cargo type.
  * @return the best sub type
  */
-byte GetBestFittingSubType(Vehicle *v_from, Vehicle *v_for, CargoID dest_cargo_type)
+uint8_t GetBestFittingSubType(Vehicle *v_from, Vehicle *v_for, CargoID dest_cargo_type)
 {
 	v_from = v_from->GetFirstEnginePart();
 	v_for = v_for->GetFirstEnginePart();
@@ -529,7 +529,7 @@ byte GetBestFittingSubType(Vehicle *v_from, Vehicle *v_for, CargoID dest_cargo_t
 		include(subtypes, GetCargoSubtypeText(v_from));
 	}
 
-	byte ret_refit_cyc = 0;
+	uint8_t ret_refit_cyc = 0;
 	bool success = false;
 	if (!subtypes.empty()) {
 		/* Check whether any articulated part is refittable to 'dest_cargo_type' with a subtype listed in 'subtypes' */
@@ -539,7 +539,7 @@ byte GetBestFittingSubType(Vehicle *v_from, Vehicle *v_for, CargoID dest_cargo_t
 			if (!HasBit(e->info.refit_mask, dest_cargo_type) && v->cargo_type != dest_cargo_type) continue;
 
 			CargoID old_cargo_type = v->cargo_type;
-			byte old_cargo_subtype = v->cargo_subtype;
+			uint8_t old_cargo_subtype = v->cargo_subtype;
 
 			/* Set the 'destination' cargo */
 			v->cargo_type = dest_cargo_type;
@@ -581,7 +581,7 @@ byte GetBestFittingSubType(Vehicle *v_from, Vehicle *v_for, CargoID dest_cargo_t
 /** Option to refit a vehicle chain */
 struct RefitOption {
 	CargoID cargo;    ///< Cargo to refit to
-	byte subtype;     ///< Subcargo to use
+	uint8_t subtype;     ///< Subcargo to use
 	StringID string;  ///< GRF-local String to display for the cargo
 
 	/**
@@ -709,7 +709,7 @@ struct RefitWindow : public Window {
 			if (v->type == VEH_TRAIN && std::find(vehicles_to_refit.begin(), vehicles_to_refit.end(), v->index) == vehicles_to_refit.end()) continue;
 			const Engine *e = v->GetEngine();
 			CargoTypes cmask = e->info.refit_mask;
-			byte callback_mask = e->info.callback_mask;
+			uint8_t callback_mask = e->info.callback_mask;
 
 			/* Skip this engine if it does not carry anything */
 			if (!e->CanCarryCargo()) continue;
@@ -737,7 +737,7 @@ struct RefitWindow : public Window {
 					/* Make a note of the original cargo type. It has to be
 					 * changed to test the cargo & subtype... */
 					CargoID temp_cargo = v->cargo_type;
-					byte temp_subtype  = v->cargo_subtype;
+					uint8_t temp_subtype  = v->cargo_subtype;
 
 					v->cargo_type = cid;
 

--- a/src/vehicle_gui.h
+++ b/src/vehicle_gui.h
@@ -22,7 +22,7 @@
 void ShowVehicleRefitWindow(const Vehicle *v, VehicleOrderID order, Window *parent, bool auto_refit = false);
 
 /** The tabs in the train details window */
-enum TrainDetailsWindowTabs : byte {
+enum TrainDetailsWindowTabs : uint8_t {
 	TDW_TAB_CARGO = 0, ///< Tab with cargo carried by the vehicles
 	TDW_TAB_INFO,      ///< Tab with name and value of the vehicles
 	TDW_TAB_CAPACITY,  ///< Tab with cargo capacity of the vehicles

--- a/src/vehicle_gui_base.h
+++ b/src/vehicle_gui_base.h
@@ -66,7 +66,7 @@ typedef GUIList<GUIVehicleGroup, std::nullptr_t, CargoID> GUIVehicleGroupList;
 
 struct BaseVehicleListWindow : public Window {
 
-	enum GroupBy : byte {
+	enum GroupBy : uint8_t {
 		GB_NONE,
 		GB_SHARED_ORDERS,
 
@@ -77,7 +77,7 @@ struct BaseVehicleListWindow : public Window {
 	VehicleList vehicles;                       ///< List of vehicles.  This is the buffer for `vehgroups` to point into; if this is structurally modified, `vehgroups` must be rebuilt.
 	GUIVehicleGroupList vehgroups;              ///< List of (groups of) vehicles.  This stores iterators of `vehicles`, and should be rebuilt if `vehicles` is structurally changed.
 	Listing *sorting;                           ///< Pointer to the vehicle type related sorting.
-	byte unitnumber_digits;                     ///< The number of digits of the highest unit number.
+	uint8_t unitnumber_digits;                     ///< The number of digits of the highest unit number.
 	Scrollbar *vscroll;
 	VehicleListIdentifier vli;                  ///< Identifier of the vehicle list we want to currently show.
 	VehicleID vehicle_sel;                      ///< Selected vehicle
@@ -116,7 +116,7 @@ struct BaseVehicleListWindow : public Window {
 	void UpdateVehicleGroupBy(GroupBy group_by);
 	void SortVehicleList();
 	void BuildVehicleList();
-	void SetCargoFilter(byte index);
+	void SetCargoFilter(uint8_t index);
 	void SetCargoFilterArray();
 	void FilterVehicleList();
 	StringID GetCargoFilterLabel(CargoID cid) const;

--- a/src/vehicle_type.h
+++ b/src/vehicle_type.h
@@ -18,7 +18,7 @@ typedef uint32_t VehicleID;
 static const int GROUND_ACCELERATION = 9800; ///< Acceleration due to gravity, 9.8 m/s^2
 
 /** Available vehicle types. It needs to be 8bits, because we save and load it as such */
-enum VehicleType : byte {
+enum VehicleType : uint8_t {
 	VEH_BEGIN,
 
 	VEH_TRAIN = VEH_BEGIN,        ///< %Train vehicle type.
@@ -61,7 +61,7 @@ enum VehiclePathFinders {
 };
 
 /** Flags for goto depot commands. */
-enum class DepotCommand : byte {
+enum class DepotCommand : uint8_t {
 	None         = 0,         ///< No special flags.
 	Service      = (1U << 0), ///< The vehicle will leave the depot right after arrival (service only)
 	MassSend     = (1U << 1), ///< Tells that it's a mass send to depot command (type in VLW flag)

--- a/src/vehiclelist.cpp
+++ b/src/vehiclelist.cpp
@@ -22,7 +22,7 @@
  */
 uint32_t VehicleListIdentifier::Pack() const
 {
-	byte c = this->company == OWNER_NONE ? 0xF : (byte)this->company;
+	uint8_t c = this->company == OWNER_NONE ? 0xF : (uint8_t)this->company;
 	assert(c             < (1 <<  4));
 	assert(this->vtype   < (1 <<  2));
 	assert(this->index   < (1 << 20));
@@ -39,7 +39,7 @@ uint32_t VehicleListIdentifier::Pack() const
  */
 bool VehicleListIdentifier::UnpackIfValid(uint32_t data)
 {
-	byte c        = GB(data, 28, 4);
+	uint8_t c        = GB(data, 28, 4);
 	this->company = c == 0xF ? OWNER_NONE : (CompanyID)c;
 	this->type    = (VehicleListType)GB(data, 23, 3);
 	this->vtype   = (VehicleType)GB(data, 26, 2);

--- a/src/vehiclelist.h
+++ b/src/vehiclelist.h
@@ -15,7 +15,7 @@
 #include "tile_type.h"
 
 /** Vehicle List type flags */
-enum VehicleListType : byte {
+enum VehicleListType : uint8_t {
 	VL_STANDARD,
 	VL_SHARED_ORDERS,
 	VL_STATION_LIST,

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -200,7 +200,7 @@ static bool CreateMainSurface(uint w, uint h)
 	_allegro_screen = create_bitmap_ex(bpp, screen->cr - screen->cl, screen->cb - screen->ct);
 	_screen.width = _allegro_screen->w;
 	_screen.height = _allegro_screen->h;
-	_screen.pitch = ((byte*)screen->line[1] - (byte*)screen->line[0]) / (bpp / 8);
+	_screen.pitch = ((uint8_t*)screen->line[1] - (uint8_t*)screen->line[0]) / (bpp / 8);
 	_screen.dst_ptr = _allegro_screen->line[0];
 
 	/* Initialise the screen so we don't blit garbage to the screen */
@@ -247,8 +247,8 @@ std::vector<int> VideoDriver_Allegro::GetListOfMonitorRefreshRates()
 
 struct AllegroVkMapping {
 	uint16_t vk_from;
-	byte vk_count;
-	byte map_to;
+	uint8_t vk_count;
+	uint8_t map_to;
 };
 
 #define AS(x, z) {x, 0, z}

--- a/src/video/cocoa/cocoa_keys.h
+++ b/src/video/cocoa/cocoa_keys.h
@@ -134,7 +134,7 @@
 
 struct CocoaVkMapping {
 	unsigned short vk_from;
-	byte map_to;
+	uint8_t map_to;
 };
 
 #define AS(x, z) {x, z}

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -108,7 +108,7 @@ const char *VideoDriver_Dedicated::Start(const StringList &)
 	this->UpdateAutoResolution();
 
 	int bpp = BlitterFactory::GetCurrentBlitter()->GetScreenDepth();
-	_dedicated_video_mem = (bpp == 0) ? nullptr : MallocT<byte>(static_cast<size_t>(_cur_resolution.width) * _cur_resolution.height * (bpp / 8));
+	_dedicated_video_mem = (bpp == 0) ? nullptr : MallocT<uint8_t>(static_cast<size_t>(_cur_resolution.width) * _cur_resolution.height * (bpp / 8));
 
 	_screen.width  = _screen.pitch = _cur_resolution.width;
 	_screen.height = _cur_resolution.height;

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -194,8 +194,8 @@ static bool IsOpenGLExtensionSupported(const char *extension)
 	return false;
 }
 
-static byte _gl_major_ver = 0; ///< Major OpenGL version.
-static byte _gl_minor_ver = 0; ///< Minor OpenGL version.
+static uint8_t _gl_major_ver = 0; ///< Major OpenGL version.
+static uint8_t _gl_minor_ver = 0; ///< Minor OpenGL version.
 
 /**
  * Check if the current OpenGL version is equal or higher than a given one.
@@ -204,7 +204,7 @@ static byte _gl_minor_ver = 0; ///< Minor OpenGL version.
  * @pre OpenGL was initialized.
  * @return True if the OpenGL version is equal or higher than the requested one.
  */
-bool IsOpenGLVersionAtLeast(byte major, byte minor)
+bool IsOpenGLVersionAtLeast(uint8_t major, uint8_t minor)
 {
 	return (_gl_major_ver > major) || (_gl_major_ver == major && _gl_minor_ver >= minor);
 }
@@ -944,10 +944,10 @@ bool OpenGLBackend::Resize(int w, int h, bool force)
 		}
 	} else if (bpp == 8) {
 		if (_glClearBufferSubData != nullptr) {
-			byte b = 0;
+			uint8_t b = 0;
 			_glClearBufferSubData(GL_PIXEL_UNPACK_BUFFER, GL_R8, 0, line_pixel_count, GL_RED, GL_UNSIGNED_BYTE, &b);
 		} else {
-			ClearPixelBuffer<byte>(line_pixel_count, 0);
+			ClearPixelBuffer<uint8_t>(line_pixel_count, 0);
 		}
 	}
 
@@ -975,10 +975,10 @@ bool OpenGLBackend::Resize(int w, int h, bool force)
 
 		/* Initialize buffer as 0 == no remap. */
 		if (_glClearBufferSubData != nullptr) {
-			byte b = 0;
+			uint8_t b = 0;
 			_glClearBufferSubData(GL_PIXEL_UNPACK_BUFFER, GL_R8, 0, line_pixel_count, GL_RED, GL_UNSIGNED_BYTE, &b);
 		} else {
-			ClearPixelBuffer<byte>(line_pixel_count, 0);
+			ClearPixelBuffer<uint8_t>(line_pixel_count, 0);
 		}
 
 		_glBindTexture(GL_TEXTURE_2D, this->anim_texture);

--- a/src/video/opengl.h
+++ b/src/video/opengl.h
@@ -19,7 +19,7 @@
 typedef void (*OGLProc)();
 typedef OGLProc (*GetOGLProcAddressProc)(const char *proc);
 
-bool IsOpenGLVersionAtLeast(byte major, byte minor);
+bool IsOpenGLVersionAtLeast(uint8_t major, uint8_t minor);
 const char *FindStringInExtensionList(const char *string, const char *substring);
 
 class OpenGLSprite;

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -241,15 +241,15 @@ std::vector<int> VideoDriver_SDL_Base::GetListOfMonitorRefreshRates()
 
 struct SDLVkMapping {
 	SDL_Keycode vk_from;
-	byte vk_count;
-	byte map_to;
+	uint8_t vk_count;
+	uint8_t map_to;
 	bool unprintable;
 };
 
 #define AS(x, z) {x, 0, z, false}
-#define AM(x, y, z, w) {x, (byte)(y - x), z, false}
+#define AM(x, y, z, w) {x, (uint8_t)(y - x), z, false}
 #define AS_UP(x, z) {x, 0, z, true}
-#define AM_UP(x, y, z, w) {x, (byte)(y - x), z, true}
+#define AM_UP(x, y, z, w) {x, (uint8_t)(y - x), z, true}
 
 static const SDLVkMapping _vk_mapping[] = {
 	/* Pageup stuff + up/down */

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -374,12 +374,12 @@ bool VideoDriver_SDL::ClaimMousePointer()
 
 struct SDLVkMapping {
 	uint16_t vk_from;
-	byte vk_count;
-	byte map_to;
+	uint8_t vk_count;
+	uint8_t map_to;
 };
 
 #define AS(x, z) {x, 0, z}
-#define AM(x, y, z, w) {x, (byte)(y - x), z}
+#define AM(x, y, z, w) {x, (uint8_t)(y - x), z}
 
 static const SDLVkMapping _vk_mapping[] = {
 	/* Pageup stuff + up/down */

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -56,9 +56,9 @@ bool VideoDriver_Win32Base::ClaimMousePointer()
 }
 
 struct Win32VkMapping {
-	byte vk_from;
-	byte vk_count;
-	byte map_to;
+	uint8_t vk_from;
+	uint8_t vk_count;
+	uint8_t map_to;
 };
 
 #define AS(x, z) {x, 0, z}

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1694,7 +1694,7 @@ static void ViewportDrawDirtyBlocks()
 
 	dst = dpi->dst_ptr;
 
-	byte bo = UnScaleByZoom(dpi->left + dpi->top, dpi->zoom) & 1;
+	uint8_t bo = UnScaleByZoom(dpi->left + dpi->top, dpi->zoom) & 1;
 	do {
 		for (int i = (bo ^= 1); i < right; i += 2) blitter->SetPixel(dst, i, 0, (uint8_t)colour);
 		dst = blitter->MoveTo(dst, 0, 1);
@@ -2892,7 +2892,7 @@ static int CalcHeightdiff(HighLightStyle style, uint distance, TileIndex start_t
 
 			/* In the case of an area we can determine whether we were dragging south or
 			 * east by checking the X-coordinates of the tiles */
-			byte style_t = (byte)(TileX(end_tile) > TileX(start_tile));
+			uint8_t style_t = (uint8_t)(TileX(end_tile) > TileX(start_tile));
 			start_tile = TileAdd(start_tile, ToTileIndexDiff(heightdiff_area_by_dir[style_t]));
 			end_tile   = TileAdd(end_tile, ToTileIndexDiff(heightdiff_area_by_dir[2 + style_t]));
 			[[fallthrough]];
@@ -2926,7 +2926,7 @@ static int CalcHeightdiff(HighLightStyle style, uint distance, TileIndex start_t
 			if (swap && distance == 0) style = flip_style_direction[style];
 
 			/* Use lookup table for start-tile based on HighLightStyle direction */
-			byte style_t = style * 2;
+			uint8_t style_t = style * 2;
 			assert(style_t < lengthof(heightdiff_line_by_dir) - 13);
 			h0 = TileHeight(TileAdd(start_tile, ToTileIndexDiff(heightdiff_line_by_dir[style_t])));
 			uint ht = TileHeight(TileAdd(start_tile, ToTileIndexDiff(heightdiff_line_by_dir[style_t + 1])));
@@ -3168,7 +3168,7 @@ static void CalcRaildirsDrawstyle(int x, int y, int method)
 		TileIndex t0 = TileVirtXY(_thd.selstart.x, _thd.selstart.y);
 		TileIndex t1 = TileVirtXY(x, y);
 		uint distance = DistanceManhattan(t0, t1) + 1;
-		byte index = 0;
+		uint8_t index = 0;
 
 		if (distance != 1) {
 			int heightdiff = CalcHeightdiff(b, distance, t0, t1);
@@ -3264,7 +3264,7 @@ calc_heightdiff_single_direction:;
 				TileIndex t0 = TileVirtXY(sx, sy);
 				TileIndex t1 = TileVirtXY(x, y);
 				uint distance = DistanceManhattan(t0, t1) + 1;
-				byte index = 0;
+				uint8_t index = 0;
 
 				if (distance != 1) {
 					/* With current code passing a HT_LINE style to calculate the height
@@ -3298,7 +3298,7 @@ calc_heightdiff_single_direction:;
 				TileIndex t1 = TileVirtXY(x, y);
 				uint dx = Delta(TileX(t0), TileX(t1)) + 1;
 				uint dy = Delta(TileY(t0), TileY(t1)) + 1;
-				byte index = 0;
+				uint8_t index = 0;
 
 				/* If dragging an area (eg dynamite tool) and it is actually a single
 				 * row/column, change the type to 'line' to get proper calculation for height */

--- a/src/viewport_type.h
+++ b/src/viewport_type.h
@@ -139,7 +139,7 @@ enum ViewportDragDropSelectionProcess {
 /**
  * Target of the viewport scrolling GS method
  */
-enum ViewportScrollTarget : byte {
+enum ViewportScrollTarget : uint8_t {
 	VST_EVERYONE, ///< All players
 	VST_COMPANY,  ///< All players in specific company
 	VST_CLIENT,   ///< Single player

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -892,7 +892,7 @@ void DrawShoreTile(Slope tileh)
 {
 	/* Converts the enum Slope into an offset based on SPR_SHORE_BASE.
 	 * This allows to calculate the proper sprite to display for this Slope */
-	static const byte tileh_to_shoresprite[32] = {
+	static const uint8_t tileh_to_shoresprite[32] = {
 		0, 1, 2, 3, 4, 16, 6, 7, 8, 9, 17, 11, 12, 13, 14, 0,
 		0, 0, 0, 0, 0,  0, 0, 0, 0, 0,  0,  5,  0, 10, 15, 0,
 	};

--- a/src/water_map.h
+++ b/src/water_map.h
@@ -44,7 +44,7 @@ enum WaterTileType {
 };
 
 /** classes of water (for #WATER_TILE_CLEAR water tile type). */
-enum WaterClass : byte {
+enum WaterClass : uint8_t {
 	WATER_CLASS_SEA,     ///< Sea.
 	WATER_CLASS_CANAL,   ///< Canal.
 	WATER_CLASS_RIVER,   ///< River.
@@ -326,7 +326,7 @@ inline DiagDirection GetLockDirection(Tile t)
  * @return The part.
  * @pre IsTileType(t, MP_WATER) && IsLock(t)
  */
-inline byte GetLockPart(Tile t)
+inline uint8_t GetLockPart(Tile t)
 {
 	assert(IsLock(t));
 	return GB(t.m5(), WBL_LOCK_PART_BEGIN, WBL_LOCK_PART_COUNT);
@@ -338,7 +338,7 @@ inline byte GetLockPart(Tile t)
  * @return Random bits of the tile.
  * @pre IsTileType(t, MP_WATER)
  */
-inline byte GetWaterTileRandomBits(Tile t)
+inline uint8_t GetWaterTileRandomBits(Tile t)
 {
 	assert(IsTileType(t, MP_WATER));
 	return t.m4();

--- a/src/waypoint_base.h
+++ b/src/waypoint_base.h
@@ -32,7 +32,7 @@ struct Waypoint final : SpecializedStation<Waypoint, true> {
 		return IsRailWaypointTile(tile) && GetStationIndex(tile) == this->index;
 	}
 
-	uint32_t GetNewGRFVariable(const struct ResolverObject &object, byte variable, byte parameter, bool *available) const override;
+	uint32_t GetNewGRFVariable(const struct ResolverObject &object, uint8_t variable, uint8_t parameter, bool *available) const override;
 
 	void GetTileArea(TileArea *ta, StationType type) const override;
 

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -155,7 +155,7 @@ static CommandCost IsValidTileForWaypoint(TileIndex tile, Axis axis, StationID *
 	return CommandCost();
 }
 
-extern void GetStationLayout(byte *layout, uint numtracks, uint plat_len, const StationSpec *statspec);
+extern void GetStationLayout(uint8_t *layout, uint numtracks, uint plat_len, const StationSpec *statspec);
 extern CommandCost FindJoiningWaypoint(StationID existing_station, StationID station_to_join, bool adjacent, TileArea ta, Waypoint **wp);
 extern CommandCost CanExpandRailStation(const BaseStation *st, TileArea &new_ta);
 
@@ -173,7 +173,7 @@ extern CommandCost CanExpandRailStation(const BaseStation *st, TileArea &new_ta)
  * @param adjacent allow waypoints directly adjacent to other waypoints.
  * @return the cost of this operation or an error
  */
-CommandCost CmdBuildRailWaypoint(DoCommandFlag flags, TileIndex start_tile, Axis axis, byte width, byte height, StationClassID spec_class, uint16_t spec_index, StationID station_to_join, bool adjacent)
+CommandCost CmdBuildRailWaypoint(DoCommandFlag flags, TileIndex start_tile, Axis axis, uint8_t width, uint8_t height, StationClassID spec_class, uint16_t spec_index, StationID station_to_join, bool adjacent)
 {
 	if (!IsValidAxis(axis)) return CMD_ERROR;
 	/* Check if the given station class is valid */
@@ -181,7 +181,7 @@ CommandCost CmdBuildRailWaypoint(DoCommandFlag flags, TileIndex start_tile, Axis
 	if (spec_index >= StationClass::Get(spec_class)->GetSpecCount()) return CMD_ERROR;
 
 	/* The number of parts to build */
-	byte count = axis == AXIS_X ? height : width;
+	uint8_t count = axis == AXIS_X ? height : width;
 
 	if ((axis == AXIS_X ? width : height) != 1) return CMD_ERROR;
 	if (count == 0 || count > _settings_game.station.station_spread) return CMD_ERROR;
@@ -258,17 +258,17 @@ CommandCost CmdBuildRailWaypoint(DoCommandFlag flags, TileIndex start_tile, Axis
 		wp->UpdateVirtCoord();
 
 		const StationSpec *spec = StationClass::Get(spec_class)->GetSpec(spec_index);
-		std::vector<byte> layout(count);
+		std::vector<uint8_t> layout(count);
 		if (spec != nullptr) {
 			/* For NewGRF waypoints we like to have their style. */
 			GetStationLayout(layout.data(), count, 1, spec);
 		}
-		byte map_spec_index = AllocateSpecToStation(spec, wp, true);
+		uint8_t map_spec_index = AllocateSpecToStation(spec, wp, true);
 
 		Company *c = Company::Get(wp->owner);
 		for (int i = 0; i < count; i++) {
 			TileIndex tile = start_tile + i * offset;
-			byte old_specindex = HasStationTileRail(tile) ? GetCustomStationSpecIndex(tile) : 0;
+			uint8_t old_specindex = HasStationTileRail(tile) ? GetCustomStationSpecIndex(tile) : 0;
 			if (!HasStationTileRail(tile)) c->infrastructure.station++;
 			bool reserved = IsTileType(tile, MP_RAILWAY) ?
 					HasBit(GetRailReservationTrackBits(tile), AxisToTrack(axis)) :

--- a/src/waypoint_cmd.h
+++ b/src/waypoint_cmd.h
@@ -13,9 +13,9 @@
 #include "command_type.h"
 #include "station_type.h"
 
-enum StationClassID : byte;
+enum StationClassID : uint8_t;
 
-CommandCost CmdBuildRailWaypoint(DoCommandFlag flags, TileIndex start_tile, Axis axis, byte width, byte height, StationClassID spec_class, uint16_t spec_index, StationID station_to_join, bool adjacent);
+CommandCost CmdBuildRailWaypoint(DoCommandFlag flags, TileIndex start_tile, Axis axis, uint8_t width, uint8_t height, StationClassID spec_class, uint16_t spec_index, StationID station_to_join, bool adjacent);
 CommandCost CmdRemoveFromRailWaypoint(DoCommandFlag flags, TileIndex start, TileIndex end, bool keep_rail);
 CommandCost CmdBuildBuoy(DoCommandFlag flags, TileIndex tile);
 CommandCost CmdRenameWaypoint(DoCommandFlag flags, StationID waypoint_id, const std::string &text);

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -44,7 +44,7 @@ struct DropdownWindow : Window {
 	Rect wi_rect;                 ///< Rect of the button that opened the dropdown.
 	DropDownList list;            ///< List with dropdown menu items.
 	int selected_result;          ///< Result value of the selected item in the list.
-	byte click_delay = 0;         ///< Timer to delay selection.
+	uint8_t click_delay = 0;         ///< Timer to delay selection.
 	bool drag_mode = true;
 	bool instant_close;           ///< Close the window when the mouse button is raised.
 	bool persist;                 ///< Persist dropdown menu.

--- a/src/widgets/slider_func.h
+++ b/src/widgets/slider_func.h
@@ -16,7 +16,7 @@
 void DrawSliderWidget(Rect r, int min_value, int max_value, int value, const std::map<int, StringID> &labels);
 bool ClickSliderWidget(Rect r, Point pt, int min_value, int max_value, int &value);
 
-inline bool ClickSliderWidget(Rect r, Point pt, int min_value, int max_value, byte &value)
+inline bool ClickSliderWidget(Rect r, Point pt, int min_value, int max_value, uint8_t &value)
 {
 	int tmp_value = value;
 	if (!ClickSliderWidget(r, pt, min_value, max_value, tmp_value)) return false;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -85,7 +85,7 @@ Point _cursorpos_drag_start;
 
 int _scrollbar_start_pos;
 int _scrollbar_size;
-byte _scroller_click_timeout = 0;
+uint8_t _scroller_click_timeout = 0;
 
 bool _scrolling_viewport;  ///< A viewport is being scrolled with the mouse.
 bool _mouse_hovering;      ///< The mouse is hovering over the same point.

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -476,7 +476,7 @@ public:
 	 * Marks a widget as raised and dirty (redraw), when it is marked as lowered.
 	 * @param widget_index index of this widget in the window
 	 */
-	inline void RaiseWidgetWhenLowered(byte widget_index)
+	inline void RaiseWidgetWhenLowered(uint8_t widget_index)
 	{
 		if (this->IsWidgetLowered(widget_index)) {
 			this->RaiseWidget(widget_index);
@@ -1025,7 +1025,7 @@ extern Point _cursorpos_drag_start;
 
 extern int _scrollbar_start_pos;
 extern int _scrollbar_size;
-extern byte _scroller_click_timeout;
+extern uint8_t _scroller_click_timeout;
 
 extern bool _scrolling_viewport;
 extern bool _mouse_hovering;

--- a/src/zoom_type.h
+++ b/src/zoom_type.h
@@ -16,7 +16,7 @@ static uint const ZOOM_LVL_SHIFT = 2;
 static uint const ZOOM_LVL_BASE  = 1 << ZOOM_LVL_SHIFT;
 
 /** All zoom levels we know. */
-enum ZoomLevel : byte {
+enum ZoomLevel : uint8_t {
 	/* Our possible zoom-levels */
 	ZOOM_LVL_BEGIN  = 0, ///< Begin for iteration.
 	ZOOM_LVL_NORMAL = 0, ///< The normal zoom level.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

A bit too often we have an discussion about `byte` vs `uint8_t` in PR reviews. This totally distracts from the actual conversation, as both are the same, just named differently.

Additionally, it is confusing to new contributors. Our usage of `byte` vs `uint8_t` is about fifty/fifty, making it very hard to know what to use when/where/how.

To fix both problems, name them to one form.

Read; TrueBrain is done having the same conversation about silly shit, so he is fixing this once and for all.

## Description

I went for `uint8_t` instead of `byte` for three reasons:

1) `byte` and `std::byte` are easily confused, but totally different.
2) we also don't use `short`, `long` etc; consistency ftw
3) `uint8_t` is just more explicit.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

As "byte" is also used a lot in sentences, like "byte-array", or "2 bytes", it wasn't as easy as `sed s/byte/uint8_t/`. But VSCode did its best to find all references to `byte`.

3rdparty libraries are untouched, except for two (squirrel and md5). They were needed as in the way they are used in our code, they also enjoy the safeguard restrictions.

As with other renames, I took no attempt of aligning comments correctly. Just a plain rename.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
