### PR TITLE
Codechange: [CI] Move release build CI to Mac OS

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,15 +25,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: Clang - Debug
+        - name: Clang
           compiler: clang-15
           cxxcompiler: clang++-15
           libraries: libsdl2-dev
-        - name: Clang - Release
-          compiler: clang-15
-          cxxcompiler: clang++-15
-          libraries: libsdl2-dev
-          extra-cmake-parameters: -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPTION_USE_ASSERTS=OFF
         - name: GCC - SDL2
           compiler: gcc
           cxxcompiler: g++
@@ -61,10 +56,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - arch: arm64
+        - name: arm64 - Debug
+          arch: arm64
           full_arch: arm64
+          extra-cmake-parameters: -DCMAKE_BUILD=Debug
+        - name: arm64 - Release
+          arch: arm64
+          full_arch: arm64
+          extra-cmake-parameters: -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPTION_USE_ASSERTS=OFF
 
-    name: Mac OS (${{ matrix.arch }})
+    name: Mac OS (${{ matrix.name }})
 
     uses: ./.github/workflows/ci-macos.yml
     secrets: inherit
@@ -72,6 +73,7 @@ jobs:
     with:
       arch: ${{ matrix.arch }}
       full_arch: ${{ matrix.full_arch }}
+      extra-cmake-parameters: ${{ matrix.extra-cmake-parameters }}
 
   windows:
     strategy:

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -9,6 +9,10 @@ on:
       full_arch:
         required: true
         type: string
+      extra-cmake-parameters:
+        required: false
+        type: string
+        default: ""
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
@@ -66,6 +70,7 @@ jobs:
           -DCMAKE_OSX_ARCHITECTURES=${{ inputs.full_arch }} \
           -DVCPKG_TARGET_TRIPLET=${{ inputs.arch }}-osx \
           -DCMAKE_TOOLCHAIN_FILE=${{ runner.temp }}/vcpkg/scripts/buildsystems/vcpkg.cmake \
+          ${{ inputs.extra-cmake-parameters }} \
           # EOF
         echo "::endgroup::"
 


### PR DESCRIPTION
## Motivation / Problem
- Mac OS is (at present) the fastest CI.
- Debug and release builds are built separately using Clang on Linux.

## Description
Move the building of release build to Mac OS. This saves a few minutes total PR-CI-time (~4 minutes).


## Limitations



## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
