### PR TITLE
Fix #12305: Crash with large positive sprite x offset in engine preview window

### DIFF
--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -98,7 +98,7 @@ struct EnginePreviewWindow : Window {
 		}
 		this->vehicle_space = std::max<int>(ScaleSpriteTrad(40), y - y_offs);
 
-		size->width = std::max(size->width, x - x_offs);
+		size->width = std::max(size->width, x + std::abs(x_offs));
 		SetDParam(0, GetEngineCategoryName(engine));
 		size->height = GetStringHeight(STR_ENGINE_PREVIEW_MESSAGE, size->width) + WidgetDimensions::scaled.vsep_wide + GetCharacterHeight(FS_NORMAL) + this->vehicle_space;
 		SetDParam(0, engine);


### PR DESCRIPTION
## Motivation / Problem

#12305: The engine preview window crashes when vehicle sprites have a positive sprite x offset larger than the sprite width.

## Description

The use of `x - x_offs` only seems to me to make sense for negative values of `x_offs`.
Therefore, use `x + std::abs(x_offs)` instead, which (to me) makes sense for both positive and negative values of `x_offs`.

## Limitations

The original code makes little sense to me, so I may be missing something implicit.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
