### PR TITLE
Codefix 4c0dca1: [CI] Fix typo in workflow file

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -59,7 +59,7 @@ jobs:
         - name: arm64 - Debug
           arch: arm64
           full_arch: arm64
-          extra-cmake-parameters: -DCMAKE_BUILD=Debug
+          extra-cmake-parameters: -DCMAKE_BUILD_TYPE=Debug
         - name: arm64 - Release
           arch: arm64
           full_arch: arm64


### PR DESCRIPTION
## Motivation / Problem
`DCMAKE_BUILD=Debug` instead of `DCMAKE_BUILD_TYPE=Debug`

## Description
Fix it

## Limitations
My reading skills


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
