### PR TITLE
Feature: authorized key authentication for rcon

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -836,6 +836,7 @@ DEF_CONSOLE_CMD(ConRcon)
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Remote control the server from another client. Usage: 'rcon <password> <command>'.");
 		IConsolePrint(CC_HELP, "Remember to enclose the command in quotes, otherwise only the first parameter is sent.");
+		IConsolePrint(CC_HELP, "When your client's public key is in the 'authorized keys' for 'rcon', the password is not checked and may be '*'.");
 		return true;
 	}
 

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -24,6 +24,7 @@ extern NetworkClientSocketPool _networkclientsocket_pool;
 class ServerNetworkGameSocketHandler : public NetworkClientSocketPool::PoolItem<&_networkclientsocket_pool>, public NetworkGameSocketHandler, public TCPListenHandler<ServerNetworkGameSocketHandler, PACKET_SERVER_FULL, PACKET_SERVER_BANNED> {
 protected:
 	std::unique_ptr<class NetworkAuthenticationServerHandler> authentication_handler; ///< The handler for the authentication.
+	std::string peer_public_key; ///< The public key of our client.
 
 	NetworkRecvStatus Receive_CLIENT_JOIN(Packet &p) override;
 	NetworkRecvStatus Receive_CLIENT_IDENTIFY(Packet &p) override;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -138,6 +138,7 @@ private:
 		"servers",
 		"server_bind_addresses",
 		"server_authorized_keys",
+		"rcon_authorized_keys",
 	};
 
 public:
@@ -1287,6 +1288,7 @@ static void HandleSettingDescs(IniFile &generic_ini, IniFile &private_ini, IniFi
 		proc_list(private_ini, "servers", _network_host_list);
 		proc_list(private_ini, "bans", _network_ban_list);
 		proc_list(private_ini, "server_authorized_keys", _settings_client.network.server_authorized_keys);
+		proc_list(private_ini, "rcon_authorized_keys", _settings_client.network.rcon_authorized_keys);
 	}
 }
 

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -315,6 +315,7 @@ struct NetworkSettings {
 	std::string server_password;                          ///< password for joining this server
 	std::vector<std::string> server_authorized_keys; ///< Public keys of clients that are authorized to connect to the game.
 	std::string rcon_password;                            ///< password for rconsole (server side)
+	std::vector<std::string> rcon_authorized_keys; ///< Public keys of clients that are authorized to use the rconsole (server side).
 	std::string admin_password;                           ///< password for the admin network
 	std::string client_name;                              ///< name of the player (as client)
 	std::string client_secret_key; ///< The secret key of the client for authorized key logins.


### PR DESCRIPTION
## Motivation / Problem

Having to type the password each time you are using rcon will get cumbersome. Since we have authorized keys for the game login, which not add that to rcon as well?


## Description

Skim the peer/client's public key during the game authentication phase and store it in the server's socket handler.

When a rcon command is received, first check the public key against the authorized keys for rcon. If that fails, fall back to the normal password validation.

This means that the rcon password is not checked any more when using authorized keys, however you still need to enter something as I did not want to introduce a difficult dance of back-and-forth communication to later request the rcon password when the client's public key was not in the authorized key list. That something can be as simple as just `*`, e.g. `rcon * "say hi"`.


## Limitations

Built on top of #12300 and everything that's built upon, so it cannot be merged directly.

There is no in game (console) management of the authorized keys yet, so it authorized keys can only be set via the configuration file. This management should be a separate PR, which could work the same for authorized keys of game, rcon, companies and the admin port.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
