### PR TITLE
Codechange: the "no revision detected" string is with four zeros (norev0000)

### DIFF
--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -165,7 +165,7 @@ protected:
 
 	/**
 	 * Try to join the server:
-	 * string   OpenTTD revision (norev000 if no revision).
+	 * string   OpenTTD revision (norev0000 if no revision).
 	 * uint32_t NewGRF version (added in 1.2).
 	 * string   Name of the client (max NETWORK_NAME_LENGTH) (removed in 15).
 	 * uint8_t  ID of the company to play as (1..MAX_COMPANIES) (removed in 15).

--- a/src/rev.cpp.in
+++ b/src/rev.cpp.in
@@ -28,7 +28,7 @@ bool IsReleasedVersion()
  * - "<tag>", like "<major>.<minor>.<build>[-RC<rc>]",
  * - "<commitdate>-g<shorthash><modified>" in "master",
  * - "<commitdate>-<branch>-g<shorthash><modified>" in other branches, or
- * - "norev000", if the version is unknown.
+ * - "norev0000", if the version is unknown.
  *
  * The major, minor and build are the numbers that describe releases of
  * OpenTTD (like 0.5.3). "-RC" is used to flag release candidates.


### PR DESCRIPTION

<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

A small typo let to a lot of "wtf wtf wtf" on my side. Let's address the typo.

## Description

Make sure we actually copy/paste properly :) `FindVersion.cmake` says:

`set(REV_VERSION "norev0000")`

So I took that as ground-truth. Although it is the only place that actually uses four zeros. The rest all used 3.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
