### PR TITLE
Add: [SDL2] Driver parameter 'no_mouse_capture' to ease interactive debugging

### DIFF
--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -534,6 +534,15 @@ const char *VideoDriver_SDL_Base::Start(const StringList &param)
 	const char *error = this->Initialize();
 	if (error != nullptr) return error;
 
+#ifdef SDL_HINT_MOUSE_AUTO_CAPTURE
+	if (GetDriverParamBool(param, "no_mouse_capture")) {
+		/* By default SDL captures the mouse, while a button is pressed.
+		 * This is annoying during debugging, when OpenTTD is suspended while the button was pressed.
+		 */
+		if (!SDL_SetHint(SDL_HINT_MOUSE_AUTO_CAPTURE, "0")) return SDL_GetError();
+	}
+#endif
+
 	this->startup_display = FindStartupDisplay(GetDriverParamInt(param, "display", -1));
 
 	if (!CreateMainSurface(_cur_resolution.width, _cur_resolution.height, false)) {


### PR DESCRIPTION
## Motivation / Problem

SDL captures the mouse, while a mouse button is pressed.
Normally this is a good idea, because it allows dragging/scrolling, even when the cursor shortly leaves the window.

However, when debugging, this is annoying: The mouse won't be released, when a breakpoint is hit, and OpenTTD is suspended, while a mouse button is pressed. So you are left with keyboard only to interact with the debugger.

## Description

This PR allows disabling of mouse capture via driver parameters.

* Via command line: ``-v sdl:no_mouse_capture``
* Via ``openttd.cfg``: ``videodriver = "sdl:no_mouse_capture"``

This is in-line with other debug parameters, like ``no_threads``.

## Alternatives

It was considered to tie mouse-capture to debug/release builds, but sometimes you want to play with a debug build, and sometimes you want to debug a release build. So this idea was dropped.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
