### PR TITLE
Change: replace company passwords with allowlist

### DIFF
--- a/docs/openttd.6
+++ b/docs/openttd.6
@@ -20,7 +20,6 @@
 .Op Fl M Ar musicset
 .Op Fl n Ar host Ns Oo : Ns Ar port Oc Ns Op # Ns Ar company
 .Op Fl p Ar password
-.Op Fl P Ar password
 .Op Fl q Ar savegame
 .Op Fl r Ar width Ns x Ns Ar height
 .Op Fl s Ar driver
@@ -98,10 +97,6 @@ Join a network game, optionally specifying a port to connect to and company to
 play as.
 .It Fl p Ar password
 Password used to join server.
-Only useful with
-.Fl n .
-.It Fl P Ar password
-Password used to join company.
 Only useful with
 .Fl n .
 .It Fl q Ar savegame

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -294,6 +294,7 @@ enum Commands : uint16_t {
 
 	CMD_CREATE_SUBSIDY,               ///< create a new subsidy
 	CMD_COMPANY_CTRL,                 ///< used in multiplayer to create a new companies etc.
+	CMD_COMPANY_ADD_ALLOW_LIST, ///< Used in multiplayer to add a client's public key to the company's allow list.
 	CMD_CUSTOM_NEWS_ITEM,             ///< create a custom news message
 	CMD_CREATE_GOAL,                  ///< create a new goal
 	CMD_REMOVE_GOAL,                  ///< remove a goal

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -75,6 +75,8 @@ struct CompanyProperties {
 	uint32_t president_name_2;         ///< Parameter of #president_name_1
 	std::string president_name;      ///< Name of the president if the user changed it.
 
+	NetworkAuthorizedKeys allow_list; ///< Public keys of clients that are allowed to join this company.
+
 	CompanyManagerFace face;         ///< Face description of the president.
 
 	Money money;                     ///< Money owned by the company.

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -890,8 +890,6 @@ CommandCost CmdCompanyCtrl(DoCommandFlag flags, CompanyCtrlAction cca, CompanyID
 				break;
 			}
 
-			/* Send new companies, before potentially setting the password. Otherwise,
-			 * the password update could be sent when the company is not yet known. */
 			NetworkAdminCompanyNew(c);
 			NetworkServerNewCompany(c, ci);
 
@@ -899,9 +897,6 @@ CommandCost CmdCompanyCtrl(DoCommandFlag flags, CompanyCtrlAction cca, CompanyID
 			if (client_id == _network_own_client_id) {
 				assert(_local_company == COMPANY_SPECTATOR);
 				SetLocalCompany(c->index);
-				if (!_settings_client.network.default_company_pass.empty()) {
-					NetworkChangeCompanyPassword(_local_company, _settings_client.network.default_company_pass);
-				}
 
 				/* In network games, we need to try setting the company manager face here to sync it to all clients.
 				 * If a favorite company manager face is selected, choose it. Otherwise, use a random face. */

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -981,6 +981,24 @@ CommandCost CmdCompanyCtrl(DoCommandFlag flags, CompanyCtrlAction cca, CompanyID
 }
 
 /**
+ * Add the given public key to the allow list of this company.
+ * @param flags Operation to perform.
+ * @param public_key The public key of the client to add.
+ * @return The cost of this operation or an error.
+ */
+CommandCost CmdCompanyAddAllowList(DoCommandFlag flags, const std::string &public_key)
+{
+	if (flags & DC_EXEC) {
+		if (Company::Get(_current_company)->allow_list.Add(public_key)) {
+			InvalidateWindowData(WC_CLIENT_LIST, 0);
+			SetWindowDirty(WC_COMPANY, _current_company);
+		}
+	}
+
+	return CommandCost();
+}
+
+/**
  * Change the company manager's face.
  * @param flags operation to perform
  * @param cmf face bitmasked

--- a/src/company_cmd.h
+++ b/src/company_cmd.h
@@ -18,6 +18,7 @@ enum ClientID : uint32_t;
 enum Colours : uint8_t;
 
 CommandCost CmdCompanyCtrl(DoCommandFlag flags, CompanyCtrlAction cca, CompanyID company_id, CompanyRemoveReason reason, ClientID client_id);
+CommandCost CmdCompanyAddAllowList(DoCommandFlag flags, const std::string &public_key);
 CommandCost CmdGiveMoney(DoCommandFlag flags, Money money, CompanyID dest_company);
 CommandCost CmdRenameCompany(DoCommandFlag flags, const std::string &text);
 CommandCost CmdRenamePresident(DoCommandFlag flags, const std::string &text);
@@ -25,6 +26,7 @@ CommandCost CmdSetCompanyManagerFace(DoCommandFlag flags, CompanyManagerFace cmf
 CommandCost CmdSetCompanyColour(DoCommandFlag flags, LiveryScheme scheme, bool primary, Colours colour);
 
 DEF_CMD_TRAIT(CMD_COMPANY_CTRL,             CmdCompanyCtrl,           CMD_SPECTATOR | CMD_CLIENT_ID | CMD_NO_EST, CMDT_SERVER_SETTING)
+DEF_CMD_TRAIT(CMD_COMPANY_ADD_ALLOW_LIST,   CmdCompanyAddAllowList,   CMD_NO_EST,                                 CMDT_SERVER_SETTING)
 DEF_CMD_TRAIT(CMD_GIVE_MONEY,               CmdGiveMoney,             0,                                          CMDT_MONEY_MANAGEMENT)
 DEF_CMD_TRAIT(CMD_RENAME_COMPANY,           CmdRenameCompany,         0,                                          CMDT_OTHER_MANAGEMENT)
 DEF_CMD_TRAIT(CMD_RENAME_PRESIDENT,         CmdRenamePresident,       0,                                          CMDT_OTHER_MANAGEMENT)

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -2517,9 +2517,6 @@ struct CompanyWindow : Window
 				if (_network_server) {
 					NetworkServerDoMove(CLIENT_ID_SERVER, company);
 					MarkWholeScreenDirty();
-				} else if (NetworkCompanyIsPassworded(company)) {
-					/* ask for the password */
-					ShowQueryString(STR_EMPTY, STR_NETWORK_NEED_COMPANY_PASSWORD_CAPTION, NETWORK_PASSWORD_LENGTH, this, CS_ALPHANUMERAL, QSF_PASSWORD);
 				} else {
 					/* just send the join command */
 					NetworkClientRequestMove(company);
@@ -2566,10 +2563,6 @@ struct CompanyWindow : Window
 
 			case WID_C_COMPANY_NAME:
 				Command<CMD_RENAME_COMPANY>::Post(STR_ERROR_CAN_T_CHANGE_COMPANY_NAME, str);
-				break;
-
-			case WID_C_COMPANY_JOIN:
-				NetworkClientRequestMove((CompanyID)this->window_number, str);
 				break;
 		}
 	}

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1907,53 +1907,6 @@ DEF_CONSOLE_CMD(ConSayClient)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConCompanyPassword)
-{
-	if (argc == 0) {
-		if (_network_dedicated) {
-			IConsolePrint(CC_HELP, "Change the password of a company. Usage: 'company_pw <company-no> \"<password>\".");
-		} else if (_network_server) {
-			IConsolePrint(CC_HELP, "Change the password of your or any other company. Usage: 'company_pw [<company-no>] \"<password>\"'.");
-		} else {
-			IConsolePrint(CC_HELP, "Change the password of your company. Usage: 'company_pw \"<password>\"'.");
-		}
-
-		IConsolePrint(CC_HELP, "Use \"*\" to disable the password.");
-		return true;
-	}
-
-	CompanyID company_id;
-	std::string password;
-	const char *errormsg;
-
-	if (argc == 2) {
-		company_id = _local_company;
-		password = argv[1];
-		errormsg = "You have to own a company to make use of this command.";
-	} else if (argc == 3 && _network_server) {
-		company_id = (CompanyID)(atoi(argv[1]) - 1);
-		password = argv[2];
-		errormsg = "You have to specify the ID of a valid human controlled company.";
-	} else {
-		return false;
-	}
-
-	if (!Company::IsValidHumanID(company_id)) {
-		IConsolePrint(CC_ERROR, errormsg);
-		return false;
-	}
-
-	password = NetworkChangeCompanyPassword(company_id, password);
-
-	if (password.empty()) {
-		IConsolePrint(CC_INFO, "Company password cleared.");
-	} else {
-		IConsolePrint(CC_INFO, "Company password changed to '{}'.", password);
-	}
-
-	return true;
-}
-
 /** All the known authorized keys with their name. */
 static std::vector<std::pair<std::string_view, NetworkAuthorizedKeys *>> _console_cmd_authorized_keys{
 	{ "rcon", &_settings_client.network.rcon_authorized_keys },
@@ -2801,9 +2754,6 @@ void IConsoleStdLibRegister()
 
 	IConsole::CmdRegister("authorized_key", ConNetworkAuthorizedKey, ConHookServerOnly);
 	IConsole::AliasRegister("ak", "authorized_key %+");
-
-	IConsole::CmdRegister("company_pw",              ConCompanyPassword,  ConHookNeedNetwork);
-	IConsole::AliasRegister("company_password",      "company_pw %+");
 
 	IConsole::AliasRegister("net_frame_freq",        "setting frame_freq %+");
 	IConsole::AliasRegister("net_sync_freq",         "setting sync_freq %+");

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -914,7 +914,7 @@ DEF_CONSOLE_CMD(ConClientNickChange)
 DEF_CONSOLE_CMD(ConJoinCompany)
 {
 	if (argc < 2) {
-		IConsolePrint(CC_HELP, "Request joining another company. Usage: 'join <company-id> [<password>]'.");
+		IConsolePrint(CC_HELP, "Request joining another company. Usage: 'join <company-id>'.");
 		IConsolePrint(CC_HELP, "For valid company-id see company list, use 255 for spectator.");
 		return true;
 	}
@@ -943,9 +943,8 @@ DEF_CONSOLE_CMD(ConJoinCompany)
 		return true;
 	}
 
-	/* Check if the company requires a password */
-	if (NetworkCompanyIsPassworded(company_id) && argc < 3) {
-		IConsolePrint(CC_ERROR, "Company {} requires a password to join.", company_id + 1);
+	if (!info->CanJoinCompany(company_id)) {
+		IConsolePrint(CC_ERROR, "You are not allowed to join this company.");
 		return true;
 	}
 
@@ -953,7 +952,7 @@ DEF_CONSOLE_CMD(ConJoinCompany)
 	if (_network_server) {
 		NetworkServerDoMove(CLIENT_ID_SERVER, company_id);
 	} else {
-		NetworkClientRequestMove(company_id, NetworkCompanyIsPassworded(company_id) ? argv[2] : "");
+		NetworkClientRequestMove(company_id);
 	}
 
 	return true;

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1829,13 +1829,6 @@ DEF_CONSOLE_CMD(ConCompanies)
 		SetDParam(0, c->index);
 		std::string company_name = GetString(STR_COMPANY_NAME);
 
-		const char *password_state = "";
-		if (c->is_ai) {
-			password_state = "AI";
-		} else if (_network_server) {
-			password_state = _network_company_states[c->index].password.empty() ? "unprotected" : "protected";
-		}
-
 		std::string colour = GetString(STR_COLOUR_DARK_BLUE + _company_colours[c->index]);
 		IConsolePrint(CC_INFO, "#:{}({}) Company Name: '{}'  Year Founded: {}  Money: {}  Loan: {}  Value: {}  (T:{}, R:{}, P:{}, S:{}) {}",
 			c->index + 1, colour, company_name,
@@ -1844,7 +1837,7 @@ DEF_CONSOLE_CMD(ConCompanies)
 			c->group_all[VEH_ROAD].num_vehicle,
 			c->group_all[VEH_AIRCRAFT].num_vehicle,
 			c->group_all[VEH_SHIP].num_vehicle,
-			password_state);
+			c->is_ai ? "AI" : "");
 	}
 
 	return true;
@@ -2828,7 +2821,6 @@ void IConsoleStdLibRegister()
 	IConsole::AliasRegister("pause_on_join",         "setting pause_on_join %+");
 	IConsole::AliasRegister("autoclean_companies",   "setting autoclean_companies %+");
 	IConsole::AliasRegister("autoclean_protected",   "setting autoclean_protected %+");
-	IConsole::AliasRegister("autoclean_unprotected", "setting autoclean_unprotected %+");
 	IConsole::AliasRegister("restart_game_year",     "setting restart_game_year %+");
 	IConsole::AliasRegister("min_players",           "setting min_active_clients %+");
 	IConsole::AliasRegister("reload_cfg",            "setting reload_cfg %+");

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -308,7 +308,6 @@ STR_SHOW_HIDDEN_ENGINES_VEHICLE_AIRCRAFT_TOOLTIP                :{BLACK}By enabl
 STR_BUTTON_DEFAULT                                              :{BLACK}Default
 STR_BUTTON_CANCEL                                               :{BLACK}Cancel
 STR_BUTTON_OK                                                   :{BLACK}OK
-STR_WARNING_PASSWORD_SECURITY                                   :{YELLOW}Warning: Server administrators may be able to read any text entered here.
 
 # On screen keyboard window
 STR_OSK_KEYBOARD_LAYOUT                                         :`1234567890-=\qwertyuiop[]asdfghjkl;'  zxcvbnm,./ .

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2487,6 +2487,7 @@ STR_NETWORK_CLIENT_LIST_PLAYER_NAME_QUERY_CAPTION               :Your player nam
 STR_NETWORK_CLIENT_LIST_ADMIN_CLIENT_TOOLTIP                    :{BLACK}Administrative actions to perform for this client
 STR_NETWORK_CLIENT_LIST_ADMIN_COMPANY_TOOLTIP                   :{BLACK}Administrative actions to perform for this company
 STR_NETWORK_CLIENT_LIST_JOIN_TOOLTIP                            :{BLACK}Join this company
+STR_NETWORK_CLIENT_LIST_COMPANY_AUTHORIZE_TOOLTIP               :{BLACK}Authorize this client to join your company
 STR_NETWORK_CLIENT_LIST_CHAT_CLIENT_TOOLTIP                     :{BLACK}Send a message to this player
 STR_NETWORK_CLIENT_LIST_CHAT_COMPANY_TOOLTIP                    :{BLACK}Send a message to all players of this company
 STR_NETWORK_CLIENT_LIST_CHAT_SPECTATOR_TOOLTIP                  :{BLACK}Send a message to all spectators

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2510,13 +2510,11 @@ STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE_TURN             :{BLACK}Via rela
 STR_NETWORK_CLIENT_LIST_ADMIN_CLIENT_KICK                       :Kick
 STR_NETWORK_CLIENT_LIST_ADMIN_CLIENT_BAN                        :Ban
 STR_NETWORK_CLIENT_LIST_ADMIN_COMPANY_RESET                     :Delete
-STR_NETWORK_CLIENT_LIST_ADMIN_COMPANY_UNLOCK                    :Password unlock
 
 STR_NETWORK_CLIENT_LIST_ASK_CAPTION                             :{WHITE}Admin action
 STR_NETWORK_CLIENT_LIST_ASK_CLIENT_KICK                         :{YELLOW}Are you sure you want to kick player '{RAW_STRING}'?
 STR_NETWORK_CLIENT_LIST_ASK_CLIENT_BAN                          :{YELLOW}Are you sure you want to ban player '{RAW_STRING}'?
 STR_NETWORK_CLIENT_LIST_ASK_COMPANY_RESET                       :{YELLOW}Are you sure you want to delete company '{COMPANY}'?
-STR_NETWORK_CLIENT_LIST_ASK_COMPANY_UNLOCK                      :{YELLOW}Are you sure you want to reset the password of company '{COMPANY}'?
 
 STR_NETWORK_ASK_RELAY_CAPTION                                   :{WHITE}Use relay?
 STR_NETWORK_ASK_RELAY_TEXT                                      :{YELLOW}Failed to establish a connection between you and server '{RAW_STRING}'.{}Would you like to relay this session via '{RAW_STRING}'?
@@ -2533,19 +2531,9 @@ STR_NETWORK_ASK_SURVEY_YES                                      :Yes
 
 STR_NETWORK_SPECTATORS                                          :Spectators
 
-# Network set password
-STR_COMPANY_PASSWORD_CANCEL                                     :{BLACK}Do not save the entered password
-STR_COMPANY_PASSWORD_OK                                         :{BLACK}Give the company the new password
-STR_COMPANY_PASSWORD_CAPTION                                    :{WHITE}Company password
-STR_COMPANY_PASSWORD_MAKE_DEFAULT                               :{BLACK}Default company password
-STR_COMPANY_PASSWORD_MAKE_DEFAULT_TOOLTIP                       :{BLACK}Use this company password as default for new companies
-
 # Network company info join/password
 STR_COMPANY_VIEW_JOIN                                           :{BLACK}Join
 STR_COMPANY_VIEW_JOIN_TOOLTIP                                   :{BLACK}Join and play as this company
-STR_COMPANY_VIEW_PASSWORD                                       :{BLACK}Password
-STR_COMPANY_VIEW_PASSWORD_TOOLTIP                               :{BLACK}Password-protect your company to prevent unauthorised users from joining
-STR_COMPANY_VIEW_SET_PASSWORD                                   :{BLACK}Set company password
 
 # Network chat
 STR_NETWORK_CHAT_SEND                                           :{BLACK}Send

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2460,7 +2460,6 @@ STR_NETWORK_CONNECTING_SPECIAL_2                                :{BLACK}Fetching
 STR_NETWORK_CONNECTION_DISCONNECT                               :{BLACK}Disconnect
 
 STR_NETWORK_NEED_GAME_PASSWORD_CAPTION                          :{WHITE}Server is protected. Enter password
-STR_NETWORK_NEED_COMPANY_PASSWORD_CAPTION                       :{WHITE}Company is protected. Enter password
 
 # Network company list added strings
 STR_NETWORK_COMPANY_LIST_CLIENT_LIST                            :Online players

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -948,7 +948,6 @@ struct QueryStringWindow : public Window
 {
 	QueryString editbox;    ///< Editbox.
 	QueryStringFlags flags; ///< Flags controlling behaviour of the window.
-	Dimension warning_size; ///< How much space to use for the warning text
 
 	QueryStringWindow(StringID str, StringID caption, uint max_bytes, uint max_chars, WindowDesc *desc, Window *parent, CharSetFilter afilter, QueryStringFlags flags) :
 			Window(desc), editbox(max_bytes, max_chars)
@@ -965,25 +964,10 @@ struct QueryStringWindow : public Window
 		this->flags = flags;
 
 		this->InitNested(WN_QUERY_STRING);
-		this->UpdateWarningStringSize();
 
 		this->parent = parent;
 
 		this->SetFocusedWidget(WID_QS_TEXT);
-	}
-
-	void UpdateWarningStringSize()
-	{
-		if (this->flags & QSF_PASSWORD) {
-			assert(this->nested_root->smallest_x > 0);
-			this->warning_size.width = this->nested_root->current_x - WidgetDimensions::scaled.frametext.Horizontal() - WidgetDimensions::scaled.framerect.Horizontal();
-			this->warning_size.height = GetStringHeight(STR_WARNING_PASSWORD_SECURITY, this->warning_size.width);
-			this->warning_size.height += WidgetDimensions::scaled.frametext.Vertical() + WidgetDimensions::scaled.framerect.Vertical();
-		} else {
-			this->warning_size = Dimension{ 0, 0 };
-		}
-
-		this->ReInit();
 	}
 
 	void UpdateWidgetSize(WidgetID widget, Dimension &size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension &fill, [[maybe_unused]] Dimension &resize) override
@@ -993,20 +977,6 @@ struct QueryStringWindow : public Window
 			fill.width = 0;
 			resize.width = 0;
 			size.width = 0;
-		}
-
-		if (widget == WID_QS_WARNING) {
-			size = this->warning_size;
-		}
-	}
-
-	void DrawWidget(const Rect &r, WidgetID widget) const override
-	{
-		if (widget != WID_QS_WARNING) return;
-
-		if (this->flags & QSF_PASSWORD) {
-			DrawStringMultiLine(r.Shrink(WidgetDimensions::scaled.framerect).Shrink(WidgetDimensions::scaled.frametext),
-				STR_WARNING_PASSWORD_SECURITY, TC_FROMSTRING, SA_CENTER);
 		}
 	}
 
@@ -1061,7 +1031,6 @@ static constexpr NWidgetPart _nested_query_string_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_GREY),
 		NWidget(WWT_EDITBOX, COLOUR_GREY, WID_QS_TEXT), SetMinimalSize(256, 12), SetFill(1, 1), SetPadding(2, 2, 2, 2),
 	EndContainer(),
-	NWidget(WWT_PANEL, COLOUR_GREY, WID_QS_WARNING), EndContainer(),
 	NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),
 		NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_QS_DEFAULT), SetMinimalSize(87, 12), SetFill(1, 1), SetDataTip(STR_BUTTON_DEFAULT, STR_NULL),
 		NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_QS_CANCEL), SetMinimalSize(86, 12), SetFill(1, 1), SetDataTip(STR_BUTTON_CANCEL, STR_NULL),

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -96,5 +96,10 @@ static const uint NETWORK_MAX_GRF_COUNT             =   255;
  * This is related to \c X25519_KEY_SIZE in the network crypto internals.
  */
 static const uint NETWORK_SECRET_KEY_LENGTH = 32 * 2 + 1;
+/**
+ * The maximum length of the hexadecimal encoded public keys, in bytes including '\0'.
+ * This is related to \c X25519_KEY_SIZE in the network crypto internals.
+ */
+static const uint NETWORK_PUBLIC_KEY_LENGTH = 32 * 2 + 1;
 
 #endif /* NETWORK_CORE_CONFIG_H */

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -54,9 +54,8 @@ static const uint NETWORK_NAME_LENGTH               =   80;           ///< The m
 static const uint NETWORK_COMPANY_NAME_LENGTH       =  128;           ///< The maximum length of the company name, in bytes including '\0'
 static const uint NETWORK_HOSTNAME_LENGTH           =   80;           ///< The maximum length of the host name, in bytes including '\0'
 static const uint NETWORK_HOSTNAME_PORT_LENGTH      =   80 + 6;       ///< The maximum length of the host name + port, in bytes including '\0'. The extra six is ":" + port number (with a max of 65536)
-static const uint NETWORK_SERVER_ID_LENGTH          =   33;           ///< The maximum length of the network id of the servers, in bytes including '\0'
 static const uint NETWORK_REVISION_LENGTH           =   33;           ///< The maximum length of the revision, in bytes including '\0'
-static const uint NETWORK_PASSWORD_LENGTH           =   33;           ///< The maximum length of the password, in bytes including '\0' (must be >= NETWORK_SERVER_ID_LENGTH)
+static const uint NETWORK_PASSWORD_LENGTH           =   33;           ///< The maximum length of the password, in bytes including '\0'
 static const uint NETWORK_CLIENT_NAME_LENGTH        =   25;           ///< The maximum length of a client's name, in bytes including '\0'
 static const uint NETWORK_RCONCOMMAND_LENGTH        =  500;           ///< The maximum length of a rconsole command, in bytes including '\0'
 static const uint NETWORK_GAMESCRIPT_JSON_LENGTH    = 9000;           ///< The maximum length of a receiving gamescript json string, in bytes including '\0'.

--- a/src/network/core/tcp_admin.h
+++ b/src/network/core/tcp_admin.h
@@ -333,7 +333,7 @@ protected:
 	 * string  Name of the company.
 	 * string  Name of the companies manager.
 	 * uint8_t   Main company colour.
-	 * bool    Company is password protected.
+	 * bool    Company is protected.
 	 * uint32_t  Year the company was inaugurated.
 	 * bool    Company is an AI.
 	 * @param p The packet that was just received.
@@ -347,7 +347,7 @@ protected:
 	 * string  Name of the company.
 	 * string  Name of the companies manager.
 	 * uint8_t   Main company colour.
-	 * bool    Company is password protected.
+	 * bool    Company is protected.
 	 * uint8_t   Quarters of bankruptcy.
 	 * uint8_t   Owner of share 1.
 	 * uint8_t   Owner of share 2.

--- a/src/network/core/tcp_game.cpp
+++ b/src/network/core/tcp_game.cpp
@@ -83,10 +83,8 @@ NetworkRecvStatus NetworkGameSocketHandler::HandlePacket(Packet &p)
 		case PACKET_SERVER_CLIENT_INFO:           return this->Receive_SERVER_CLIENT_INFO(p);
 		case PACKET_CLIENT_IDENTIFY:              return this->Receive_CLIENT_IDENTIFY(p);
 		case PACKET_SERVER_AUTH_REQUEST:          return this->Receive_SERVER_AUTH_REQUEST(p);
-		case PACKET_SERVER_NEED_COMPANY_PASSWORD: return this->Receive_SERVER_NEED_COMPANY_PASSWORD(p);
 		case PACKET_CLIENT_AUTH_RESPONSE:         return this->Receive_CLIENT_AUTH_RESPONSE(p);
 		case PACKET_SERVER_ENABLE_ENCRYPTION:     return this->Receive_SERVER_ENABLE_ENCRYPTION(p);
-		case PACKET_CLIENT_COMPANY_PASSWORD:      return this->Receive_CLIENT_COMPANY_PASSWORD(p);
 		case PACKET_SERVER_WELCOME:               return this->Receive_SERVER_WELCOME(p);
 		case PACKET_CLIENT_GETMAP:                return this->Receive_CLIENT_GETMAP(p);
 		case PACKET_SERVER_WAIT:                  return this->Receive_SERVER_WAIT(p);
@@ -104,7 +102,6 @@ NetworkRecvStatus NetworkGameSocketHandler::HandlePacket(Packet &p)
 		case PACKET_CLIENT_CHAT:                  return this->Receive_CLIENT_CHAT(p);
 		case PACKET_SERVER_CHAT:                  return this->Receive_SERVER_CHAT(p);
 		case PACKET_SERVER_EXTERNAL_CHAT:         return this->Receive_SERVER_EXTERNAL_CHAT(p);
-		case PACKET_CLIENT_SET_PASSWORD:          return this->Receive_CLIENT_SET_PASSWORD(p);
 		case PACKET_CLIENT_SET_NAME:              return this->Receive_CLIENT_SET_NAME(p);
 		case PACKET_CLIENT_QUIT:                  return this->Receive_CLIENT_QUIT(p);
 		case PACKET_CLIENT_ERROR:                 return this->Receive_CLIENT_ERROR(p);
@@ -118,7 +115,6 @@ NetworkRecvStatus NetworkGameSocketHandler::HandlePacket(Packet &p)
 		case PACKET_CLIENT_NEWGRFS_CHECKED:       return this->Receive_CLIENT_NEWGRFS_CHECKED(p);
 		case PACKET_SERVER_MOVE:                  return this->Receive_SERVER_MOVE(p);
 		case PACKET_CLIENT_MOVE:                  return this->Receive_CLIENT_MOVE(p);
-		case PACKET_SERVER_COMPANY_UPDATE:        return this->Receive_SERVER_COMPANY_UPDATE(p);
 		case PACKET_SERVER_CONFIG_UPDATE:         return this->Receive_SERVER_CONFIG_UPDATE(p);
 
 		default:
@@ -166,10 +162,8 @@ NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_GAME_INFO(Packet &) {
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_CLIENT_INFO(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_CLIENT_INFO); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_IDENTIFY(Packet &) { return this->ReceiveInvalidPacket(PACKET_CLIENT_IDENTIFY); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_AUTH_REQUEST(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_AUTH_REQUEST); }
-NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_NEED_COMPANY_PASSWORD(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_NEED_COMPANY_PASSWORD); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_AUTH_RESPONSE(Packet &) { return this->ReceiveInvalidPacket(PACKET_CLIENT_AUTH_RESPONSE); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_ENABLE_ENCRYPTION(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_ENABLE_ENCRYPTION); }
-NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_COMPANY_PASSWORD(Packet &) { return this->ReceiveInvalidPacket(PACKET_CLIENT_COMPANY_PASSWORD); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_WELCOME(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_WELCOME); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_GETMAP(Packet &) { return this->ReceiveInvalidPacket(PACKET_CLIENT_GETMAP); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_WAIT(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_WAIT); }
@@ -187,7 +181,6 @@ NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_COMMAND(Packet &) { r
 NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_CHAT(Packet &) { return this->ReceiveInvalidPacket(PACKET_CLIENT_CHAT); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_CHAT(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_CHAT); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_EXTERNAL_CHAT(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_EXTERNAL_CHAT); }
-NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_SET_PASSWORD(Packet &) { return this->ReceiveInvalidPacket(PACKET_CLIENT_SET_PASSWORD); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_SET_NAME(Packet &) { return this->ReceiveInvalidPacket(PACKET_CLIENT_SET_NAME); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_QUIT(Packet &) { return this->ReceiveInvalidPacket(PACKET_CLIENT_QUIT); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_ERROR(Packet &) { return this->ReceiveInvalidPacket(PACKET_CLIENT_ERROR); }
@@ -201,7 +194,6 @@ NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_CHECK_NEWGRFS(Packet 
 NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_NEWGRFS_CHECKED(Packet &) { return this->ReceiveInvalidPacket(PACKET_CLIENT_NEWGRFS_CHECKED); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_MOVE(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_MOVE); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_MOVE(Packet &) { return this->ReceiveInvalidPacket(PACKET_CLIENT_MOVE); }
-NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_COMPANY_UPDATE(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_COMPANY_UPDATE); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_CONFIG_UPDATE(Packet &) { return this->ReceiveInvalidPacket(PACKET_SERVER_CONFIG_UPDATE); }
 
 void NetworkGameSocketHandler::DeferDeletion()

--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -202,7 +202,8 @@ protected:
 	 * Send information about a client:
 	 * uint32_t  ID of the client (always unique on a server. 1 = server, 0 is invalid).
 	 * uint8_t   ID of the company the client is playing as (255 for spectators).
-	 * string  Name of the client.
+	 * string Name of the client.
+	 * string Public key of the client.
 	 * @param p The packet that was just received.
 	 */
 	virtual NetworkRecvStatus Receive_SERVER_CLIENT_INFO(Packet &p);

--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -71,10 +71,6 @@ enum PacketGameType : uint8_t {
 	PACKET_SERVER_CHECK_NEWGRFS,         ///< Server sends NewGRF IDs and MD5 checksums for the client to check.
 	PACKET_CLIENT_NEWGRFS_CHECKED,       ///< Client acknowledges that it has all required NewGRFs.
 
-	/* Checking the company passwords. */
-	PACKET_SERVER_NEED_COMPANY_PASSWORD, ///< Server requests the (hashed) company password.
-	PACKET_CLIENT_COMPANY_PASSWORD,      ///< Client sends the (hashed) company password.
-
 	/* The server welcomes the authenticated client and sends information of other clients. */
 	PACKET_SERVER_WELCOME,               ///< Server welcomes you and gives you your #ClientID.
 	PACKET_SERVER_CLIENT_INFO,           ///< Server sends you information about a client.
@@ -119,9 +115,7 @@ enum PacketGameType : uint8_t {
 	PACKET_SERVER_MOVE,                  ///< Server tells everyone that someone is moved to another company.
 
 	/* Configuration updates. */
-	PACKET_CLIENT_SET_PASSWORD,          ///< A client (re)sets its company's password.
 	PACKET_CLIENT_SET_NAME,              ///< A client changes its name.
-	PACKET_SERVER_COMPANY_UPDATE,        ///< Information (password) of a company changed.
 	PACKET_SERVER_CONFIG_UPDATE,         ///< Some network configuration important to the client changed.
 
 	/* A client quitting. */
@@ -226,14 +220,6 @@ protected:
 	virtual NetworkRecvStatus Receive_SERVER_AUTH_REQUEST(Packet &p);
 
 	/**
-	 * Indication to the client that the server needs a company password:
-	 * uint32_t  Generation seed.
-	 * string  Network ID of the server.
-	 * @param p The packet that was just received.
-	 */
-	virtual NetworkRecvStatus Receive_SERVER_NEED_COMPANY_PASSWORD(Packet &p);
-
-	/**
 	 * Send the response to the authentication request:
 	 * 32 * uint8_t Public key of the client.
 	 * 16 * uint8_t Message authentication code.
@@ -251,18 +237,8 @@ protected:
 	virtual NetworkRecvStatus Receive_SERVER_ENABLE_ENCRYPTION(Packet &p);
 
 	/**
-	 * Send a password to the server to authorize
-	 * uint8_t   Password type (see NetworkPasswordType).
-	 * string  The password.
-	 * @param p The packet that was just received.
-	 */
-	virtual NetworkRecvStatus Receive_CLIENT_COMPANY_PASSWORD(Packet &p);
-
-	/**
 	 * The client is joined and ready to receive their map:
 	 * uint32_t  Own client ID.
-	 * uint32_t  Generation seed.
-	 * string  Network ID of the server.
 	 * @param p The packet that was just received.
 	 */
 	virtual NetworkRecvStatus Receive_SERVER_WELCOME(Packet &p);
@@ -403,13 +379,6 @@ protected:
 	virtual NetworkRecvStatus Receive_SERVER_EXTERNAL_CHAT(Packet &p);
 
 	/**
-	 * Set the password for the clients current company:
-	 * string  The password.
-	 * @param p The packet that was just received.
-	 */
-	virtual NetworkRecvStatus Receive_CLIENT_SET_PASSWORD(Packet &p);
-
-	/**
 	 * Gives the client a new name:
 	 * string  New name of the client.
 	 * @param p The packet that was just received.
@@ -498,17 +467,9 @@ protected:
 	/**
 	 * Request the server to move this client into another company:
 	 * uint8_t   ID of the company the client wants to join.
-	 * string  Password, if the company is password protected.
 	 * @param p The packet that was just received.
 	 */
 	virtual NetworkRecvStatus Receive_CLIENT_MOVE(Packet &p);
-
-	/**
-	 * Update the clients knowledge of which company is password protected:
-	 * uint16_t  Bitwise representation of each company
-	 * @param p The packet that was just received.
-	 */
-	virtual NetworkRecvStatus Receive_SERVER_COMPANY_UPDATE(Packet &p);
 
 	/**
 	 * Update the clients knowledge of the max settings:

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -127,6 +127,28 @@ NetworkClientInfo::~NetworkClientInfo()
 }
 
 /**
+ * Returns whether the given company can be joined by this client.
+ * @param company_id The id of the company.
+ * @return \c true when this company is allowed to join, otherwise \c false.
+ */
+bool NetworkClientInfo::CanJoinCompany(CompanyID company_id) const
+{
+	Company *c = Company::GetIfValid(company_id);
+	return c != nullptr && c->allow_list.Contains(this->public_key);
+}
+
+/**
+ * Returns whether the given company can be joined by this client.
+ * @param company_id The id of the company.
+ * @return \c true when this company is allowed to join, otherwise \c false.
+ */
+bool NetworkCanJoinCompany(CompanyID company_id)
+{
+	NetworkClientInfo *info = NetworkClientInfo::GetByClientID(_network_own_client_id);
+	return info != nullptr && info->CanJoinCompany(company_id);
+}
+
+/**
  * Return the client state given it's client-identifier
  * @param client_id the ClientID to search for
  * @return return a pointer to the corresponding NetworkClientSocket struct or nullptr when not found
@@ -889,6 +911,9 @@ static void NetworkInitGameInfo()
 	ci->client_playas = COMPANY_SPECTATOR;
 
 	ci->client_name = _settings_client.network.client_name;
+
+	NetworkAuthenticationClientHandler::EnsureValidSecretKeyAndUpdatePublicKey(_settings_client.network.client_secret_key, _settings_client.network.client_public_key);
+	ci->public_key = _settings_client.network.client_public_key;
 }
 
 /**

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -165,10 +165,12 @@ bool NetworkAuthorizedKeys::Contains(std::string_view key) const
 /**
  * Add the given key to the authorized keys, when it is not already contained.
  * @param key The key to add.
- * @return \c true when the key was added, \c false when the key already existed.
+ * @return \c true when the key was added, \c false when the key already existed or the key was empty.
  */
 bool NetworkAuthorizedKeys::Add(std::string_view key)
 {
+	if (key.empty()) return false;
+
 	auto iter = FindKey(this, key);
 	if (iter != this->end()) return false;
 

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -228,25 +228,6 @@ uint8_t NetworkSpectatorCount()
 }
 
 /**
- * Change the company password of a given company.
- * @param company_id ID of the company the password should be changed for.
- * @param password The unhashed password we like to set ('*' or '' resets the password)
- * @return The password.
- */
-std::string NetworkChangeCompanyPassword(CompanyID company_id, std::string password)
-{
-	if (password.compare("*") == 0) password = "";
-
-	if (_network_server) {
-		NetworkServerSetCompanyPassword(company_id, password, false);
-	} else {
-		NetworkClientSetCompanyPassword(password);
-	}
-
-	return password;
-}
-
-/**
  * Hash the given password using server ID and game seed.
  * @param password Password to hash.
  * @param password_server_id Server ID.

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -67,7 +67,6 @@ bool _network_server;     ///< network-server is active
 bool _network_available;  ///< is network mode available?
 bool _network_dedicated;  ///< are we a dedicated server?
 bool _is_network_server;  ///< Does this client wants to be a network-server?
-NetworkCompanyState *_network_company_states = nullptr; ///< Statistics about some companies.
 ClientID _network_own_client_id;      ///< Our client identifier.
 ClientID _redirect_console_to_client; ///< If not invalid, redirect the console output to a client.
 uint8_t _network_reconnect;             ///< Reconnect timeout
@@ -85,7 +84,6 @@ uint32_t _sync_seed_2;                  ///< Second part of the seed.
 #endif
 uint32_t _sync_frame;                   ///< The frame to perform the sync check.
 bool _network_first_time;             ///< Whether we have finished joining or not.
-CompanyMask _network_company_passworded; ///< Bitmask of the password status of all companies.
 
 static_assert((int)NETWORK_COMPANY_NAME_LENGTH == MAX_LENGTH_COMPANY_NAME_CHARS * MAX_CHAR_LENGTH);
 
@@ -287,9 +285,9 @@ std::string GenerateCompanyPasswordHash(const std::string &password, const std::
  * @param company_id id of the company we want to check the 'passworded' flag for.
  * @return true if the company requires a password.
  */
-bool NetworkCompanyIsPassworded(CompanyID company_id)
+bool NetworkCompanyIsPassworded([[maybe_unused]] CompanyID company_id)
 {
-	return HasBit(_network_company_passworded, company_id);
+	return false;
 }
 
 /* This puts a text-message to the console, or in the future, the chat-box,
@@ -687,10 +685,6 @@ void NetworkClose(bool close_admins)
 
 	NetworkFreeLocalCommandQueue();
 
-	delete[] _network_company_states;
-	_network_company_states = nullptr;
-	_network_company_passworded = 0;
-
 	InitializeNetworkPools(close_admins);
 }
 
@@ -985,7 +979,6 @@ bool NetworkServerStart()
 	Debug(net, 5, "Starting listeners for incoming server queries");
 	NetworkUDPServerListen();
 
-	_network_company_states = new NetworkCompanyState[MAX_COMPANIES];
 	_network_server = true;
 	_networking = true;
 	_frame_counter = 0;
@@ -995,7 +988,6 @@ bool NetworkServerStart()
 	_network_own_client_id = CLIENT_ID_SERVER;
 
 	_network_clients_connected = 0;
-	_network_company_passworded = 0;
 
 	NetworkInitGameInfo();
 

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -831,7 +831,7 @@ public:
 
 /**
  * Join a client to the server at with the given connection string.
- * The default for the passwords is \c nullptr. When the server or company needs a
+ * The default for the passwords is \c nullptr. When the server needs a
  * password and none is given, the user is asked to enter the password in the GUI.
  * This function will return false whenever some information required to join is not
  * correct such as the company number or the client's name, or when there is not
@@ -843,10 +843,9 @@ public:
  * @param connection_string     The IP address, port and company number to join as.
  * @param default_company       The company number to join as when none is given.
  * @param join_server_password  The password for the server.
- * @param join_company_password The password for the company.
  * @return Whether the join has started.
  */
-bool NetworkClientConnectGame(const std::string &connection_string, CompanyID default_company, const std::string &join_server_password, const std::string &join_company_password)
+bool NetworkClientConnectGame(const std::string &connection_string, CompanyID default_company, const std::string &join_server_password)
 {
 	Debug(net, 9, "NetworkClientConnectGame(): connection_string={}", connection_string);
 
@@ -859,7 +858,6 @@ bool NetworkClientConnectGame(const std::string &connection_string, CompanyID de
 	_network_join.connection_string = resolved_connection_string;
 	_network_join.company = join_as;
 	_network_join.server_password = join_server_password;
-	_network_join.company_password = join_company_password;
 
 	if (_game_mode == GM_MENU) {
 		/* From the menu we can immediately continue with the actual join. */

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -328,7 +328,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyInfo(const Company
 	SetDParam(0, c->index);
 	p->Send_string(GetString(STR_PRESIDENT_NAME));
 	p->Send_uint8 (c->colour);
-	p->Send_bool  (NetworkCompanyIsPassworded(c->index));
+	p->Send_bool  (true);
 	p->Send_uint32(c->inaugurated_year.base());
 	p->Send_bool  (c->is_ai);
 	p->Send_uint8 (CeilDiv(c->months_of_bankruptcy, 3)); // send as quarters_of_bankruptcy
@@ -353,7 +353,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyUpdate(const Compa
 	SetDParam(0, c->index);
 	p->Send_string(GetString(STR_PRESIDENT_NAME));
 	p->Send_uint8 (c->colour);
-	p->Send_bool  (NetworkCompanyIsPassworded(c->index));
+	p->Send_bool  (true);
 	p->Send_uint8 (CeilDiv(c->months_of_bankruptcy, 3)); // send as quarters_of_bankruptcy
 
 	this->SendPacket(std::move(p));

--- a/src/network/network_base.h
+++ b/src/network/network_base.h
@@ -24,6 +24,7 @@ extern NetworkClientInfoPool _networkclientinfo_pool;
 struct NetworkClientInfo : NetworkClientInfoPool::PoolItem<&_networkclientinfo_pool> {
 	ClientID client_id;      ///< Client identifier (same as ClientState->client_id)
 	std::string client_name; ///< Name of the client
+	std::string public_key; ///< The public key of the client.
 	CompanyID client_playas; ///< As which company is this client playing (CompanyID)
 	TimerGameEconomy::Date join_date; ///< Gamedate the client has joined
 

--- a/src/network/network_base.h
+++ b/src/network/network_base.h
@@ -36,6 +36,8 @@ struct NetworkClientInfo : NetworkClientInfoPool::PoolItem<&_networkclientinfo_p
 	~NetworkClientInfo();
 
 	static NetworkClientInfo *GetByClientID(ClientID client_id);
+
+	bool CanJoinCompany(CompanyID company_id) const;
 };
 
 #endif /* NETWORK_BASE_H */

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -709,7 +709,7 @@ class ClientGamePasswordRequestHandler : public NetworkAuthenticationPasswordReq
 		if (!_network_join.server_password.empty()) {
 			request->Reply(_network_join.server_password);
 		} else {
-			ShowNetworkNeedPassword(NETWORK_GAME_PASSWORD, request);
+			ShowNetworkNeedPassword(request);
 		}
 	}
 };

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -608,6 +608,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_CLIENT_INFO(Pac
 	Debug(net, 9, "Client::Receive_SERVER_CLIENT_INFO(): client_id={}, playas={}", client_id, playas);
 
 	std::string name = p.Recv_string(NETWORK_NAME_LENGTH);
+	std::string public_key = p.Recv_string(NETWORK_PUBLIC_KEY_LENGTH);
 
 	if (this->status < STATUS_AUTHORIZED) return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 	if (this->HasClientQuit()) return NETWORK_RECV_STATUS_CLIENT_QUIT;
@@ -632,6 +633,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_CLIENT_INFO(Pac
 
 		ci->client_playas = playas;
 		ci->client_name = name;
+		ci->public_key = public_key;
 
 		InvalidateWindowData(WC_CLIENT_LIST, 0);
 
@@ -651,6 +653,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_CLIENT_INFO(Pac
 	if (client_id == _network_own_client_id) this->SetInfo(ci);
 
 	ci->client_name = name;
+	ci->public_key = public_key;
 
 	InvalidateWindowData(WC_CLIENT_LIST, 0);
 

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -321,9 +321,6 @@ std::string _network_server_name;
 /** Information about the game to join to. */
 NetworkJoinInfo _network_join;
 
-/** Make sure the server ID length is the same as a md5 hash. */
-static_assert(NETWORK_SERVER_ID_LENGTH == MD5_HASH_BYTES * 2 + 1);
-
 /***********
  * Sending functions
  ************/

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -1261,12 +1261,10 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_CONFIG_UPDATE(P
 	return NETWORK_RECV_STATUS_OKAY;
 }
 
-NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_COMPANY_UPDATE(Packet &p)
+NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_COMPANY_UPDATE(Packet &)
 {
 	if (this->status < STATUS_ACTIVE) return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 
-	static_assert(sizeof(_network_company_passworded) <= sizeof(uint16_t));
-	_network_company_passworded = p.Recv_uint16();
 	SetWindowClassesDirty(WC_COMPANY);
 
 	Debug(net, 9, "Client::Receive_SERVER_COMPANY_UPDATE()");

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -1249,10 +1249,8 @@ void NetworkClientSendRcon(const std::string &password, const std::string &comma
 /**
  * Notify the server of this client wanting to be moved to another company.
  * @param company_id id of the company the client wishes to be moved to.
- * @param pass the password, is only checked on the server end if a password is needed.
- * @return void
  */
-void NetworkClientRequestMove(CompanyID company_id, [[maybe_unused]] const std::string &pass)
+void NetworkClientRequestMove(CompanyID company_id)
 {
 	MyClient::SendMove(company_id);
 }

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -1363,14 +1363,6 @@ void NetworkClientSendChat(NetworkAction action, DestType type, int dest, const 
 }
 
 /**
- * Set/Reset company password on the client side.
- * @param password Password to be set.
- */
-void NetworkClientSetCompanyPassword([[maybe_unused]] const std::string &password)
-{
-}
-
-/**
  * Tell whether the client has team members who they can chat to.
  * @param cio client to check members of.
  * @return true if there is at least one team member.

--- a/src/network/network_client.h
+++ b/src/network/network_client.h
@@ -27,7 +27,6 @@ private:
 		STATUS_AUTH_GAME,     ///< Last action was requesting game (server) password.
 		STATUS_ENCRYPTED,     ///< The game authentication has completed and from here on the connection to the server is encrypted.
 		STATUS_NEWGRFS_CHECK, ///< Last action was checking NewGRFs.
-		STATUS_AUTH_COMPANY,  ///< Last action was requesting company password.
 		STATUS_AUTHORIZED,    ///< The client is authorized at the server.
 		STATUS_MAP_WAIT,      ///< The client is waiting as someone else is downloading the map.
 		STATUS_MAP,           ///< The client is downloading the map.
@@ -48,7 +47,6 @@ protected:
 	NetworkRecvStatus Receive_SERVER_CLIENT_INFO(Packet &p) override;
 	NetworkRecvStatus Receive_SERVER_AUTH_REQUEST(Packet &p) override;
 	NetworkRecvStatus Receive_SERVER_ENABLE_ENCRYPTION(Packet &p) override;
-	NetworkRecvStatus Receive_SERVER_NEED_COMPANY_PASSWORD(Packet &p) override;
 	NetworkRecvStatus Receive_SERVER_WELCOME(Packet &p) override;
 	NetworkRecvStatus Receive_SERVER_WAIT(Packet &p) override;
 	NetworkRecvStatus Receive_SERVER_MAP_BEGIN(Packet &p) override;
@@ -68,7 +66,6 @@ protected:
 	NetworkRecvStatus Receive_SERVER_RCON(Packet &p) override;
 	NetworkRecvStatus Receive_SERVER_CHECK_NEWGRFS(Packet &p) override;
 	NetworkRecvStatus Receive_SERVER_MOVE(Packet &p) override;
-	NetworkRecvStatus Receive_SERVER_COMPANY_UPDATE(Packet &p) override;
 	NetworkRecvStatus Receive_SERVER_CONFIG_UPDATE(Packet &p) override;
 
 	static NetworkRecvStatus SendNewGRFsOk();
@@ -90,13 +87,11 @@ public:
 	static NetworkRecvStatus SendAck();
 
 	static NetworkRecvStatus SendAuthResponse();
-	static NetworkRecvStatus SendCompanyPassword(const std::string &password);
 
 	static NetworkRecvStatus SendChat(NetworkAction action, DestType type, int dest, const std::string &msg, int64_t data);
-	static NetworkRecvStatus SendSetPassword(const std::string &password);
 	static NetworkRecvStatus SendSetName(const std::string &name);
 	static NetworkRecvStatus SendRCon(const std::string &password, const std::string &command);
-	static NetworkRecvStatus SendMove(CompanyID company, const std::string &password);
+	static NetworkRecvStatus SendMove(CompanyID company);
 
 	static bool IsConnected();
 

--- a/src/network/network_client.h
+++ b/src/network/network_client.h
@@ -112,7 +112,6 @@ struct NetworkJoinInfo {
 	std::string connection_string; ///< The address of the server to join.
 	CompanyID company;             ///< The company to join.
 	std::string server_password;   ///< The password of the server to join.
-	std::string company_password;  ///< The password of the company to join.
 };
 
 extern NetworkJoinInfo _network_join;

--- a/src/network/network_client.h
+++ b/src/network/network_client.h
@@ -104,7 +104,6 @@ public:
 typedef ClientNetworkGameSocketHandler MyClient;
 
 void NetworkClient_Connected();
-void NetworkClientSetCompanyPassword(const std::string &password);
 
 /** Information required to join a server. */
 struct NetworkJoinInfo {

--- a/src/network/network_crypto.cpp
+++ b/src/network/network_crypto.cpp
@@ -443,6 +443,15 @@ void CombinedAuthenticationServerHandler::Add(CombinedAuthenticationServerHandle
 	this->SendResponse();
 }
 
+/**
+ * Ensures that the given secret key is valid, and when not overwrite it with a valid secret key. Then update the public key to be associated with the secret key.
+ * @param secret_key The location where the secret key is stored; can be overwritten when invalid.
+ * @param public_key The location where the public key is stored; can be overwritten when invalid.
+ */
+/* static */ void NetworkAuthenticationClientHandler::EnsureValidSecretKeyAndUpdatePublicKey(std::string &secret_key, std::string &public_key)
+{
+	X25519AuthorizedKeyClientHandler::GetValidSecretKeyAndUpdatePublicKey(secret_key, public_key);
+}
 
 /**
  * Create a NetworkAuthenticationClientHandler.

--- a/src/network/network_crypto.h
+++ b/src/network/network_crypto.h
@@ -248,6 +248,7 @@ public:
 	 */
 	virtual bool ReceiveEnableEncryption(struct Packet &p) = 0;
 
+	static void EnsureValidSecretKeyAndUpdatePublicKey(std::string &secret_key, std::string &public_key);
 	static std::unique_ptr<NetworkAuthenticationClientHandler> Create(std::shared_ptr<NetworkAuthenticationPasswordRequestHandler> password_handler, std::string &secret_key, std::string &public_key);
 };
 

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -39,7 +39,6 @@ bool NetworkValidateServerName(std::string &server_name);
 void NetworkUpdateClientName(const std::string &client_name);
 void NetworkUpdateServerGameType();
 bool NetworkCompanyHasClients(CompanyID company);
-std::string NetworkChangeCompanyPassword(CompanyID company_id, std::string password);
 void NetworkReboot();
 void NetworkDisconnect(bool close_admins = true);
 void NetworkGameLoop();

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -54,7 +54,6 @@ void NetworkClientRequestMove(CompanyID company);
 void NetworkClientSendRcon(const std::string &password, const std::string &command);
 void NetworkClientSendChat(NetworkAction action, DestType type, int dest, const std::string &msg, int64_t data = 0);
 bool NetworkClientPreferTeamChat(const NetworkClientInfo *cio);
-bool NetworkCompanyIsPassworded(CompanyID company_id);
 uint NetworkMaxCompaniesAllowed();
 bool NetworkMaxCompaniesReached();
 void NetworkPrintClients();

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -51,7 +51,7 @@ void NetworkUpdateClientInfo(ClientID client_id);
 void NetworkClientsToSpectators(CompanyID cid);
 bool NetworkClientConnectGame(const std::string &connection_string, CompanyID default_company, const std::string &join_server_password = "");
 void NetworkClientJoinGame();
-void NetworkClientRequestMove(CompanyID company, const std::string &pass = "");
+void NetworkClientRequestMove(CompanyID company);
 void NetworkClientSendRcon(const std::string &password, const std::string &command);
 void NetworkClientSendChat(NetworkAction action, DestType type, int dest, const std::string &msg, int64_t data = 0);
 bool NetworkClientPreferTeamChat(const NetworkClientInfo *cio);

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -75,6 +75,7 @@ void NetworkServerNewCompany(const Company *company, NetworkClientInfo *ci);
 bool NetworkServerChangeClientName(ClientID client_id, const std::string &new_name);
 
 
+bool NetworkCanJoinCompany(CompanyID company_id);
 void NetworkServerDoMove(ClientID client_id, CompanyID company_id);
 void NetworkServerSendRcon(ClientID client_id, TextColour colour_code, const std::string &string);
 void NetworkServerSendChat(NetworkAction action, DestType type, int dest, const std::string &msg, ClientID from_id, int64_t data = 0, bool from_admin = false);

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -24,8 +24,6 @@
 #include "../company_type.h"
 #include "../string_type.h"
 
-extern NetworkCompanyState *_network_company_states;
-
 extern ClientID _network_own_client_id;
 extern ClientID _redirect_console_to_client;
 extern uint8_t _network_reconnect;

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -49,7 +49,7 @@ void NetworkPopulateCompanyStats(NetworkCompanyStats *stats);
 
 void NetworkUpdateClientInfo(ClientID client_id);
 void NetworkClientsToSpectators(CompanyID cid);
-bool NetworkClientConnectGame(const std::string &connection_string, CompanyID default_company, const std::string &join_server_password = "", const std::string &join_company_password = "");
+bool NetworkClientConnectGame(const std::string &connection_string, CompanyID default_company, const std::string &join_server_password = "");
 void NetworkClientJoinGame();
 void NetworkClientRequestMove(CompanyID company, const std::string &pass = "");
 void NetworkClientSendRcon(const std::string &password, const std::string &command);

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1536,6 +1536,12 @@ private:
 		ShowNetworkChatQueryWindow(DESTTYPE_CLIENT, client_id);
 	}
 
+	static void OnClickClientAuthorize([[maybe_unused]] NetworkClientListWindow *w, [[maybe_unused]] Point pt, ClientID client_id)
+	{
+		AutoRestoreBackup<CompanyID> cur_company(_current_company, NetworkClientInfo::GetByClientID(_network_own_client_id)->client_playas);
+		Command<CMD_COMPANY_ADD_ALLOW_LIST>::Post(NetworkClientInfo::GetByClientID(client_id)->public_key);
+	}
+
 	/**
 	 * Part of RebuildList() to create the information for a single company.
 	 * @param company_id The company to build the list for.
@@ -1558,6 +1564,7 @@ private:
 
 			if (_network_server) this->buttons[line_count].push_back(std::make_unique<ClientButton>(SPR_ADMIN, STR_NETWORK_CLIENT_LIST_ADMIN_CLIENT_TOOLTIP, COLOUR_RED, ci->client_id, &NetworkClientListWindow::OnClickClientAdmin, _network_own_client_id == ci->client_id));
 			if (_network_own_client_id != ci->client_id) this->buttons[line_count].push_back(std::make_unique<ClientButton>(SPR_CHAT, STR_NETWORK_CLIENT_LIST_CHAT_CLIENT_TOOLTIP, COLOUR_ORANGE, ci->client_id, &NetworkClientListWindow::OnClickClientChat));
+			if (_network_own_client_id != ci->client_id && client_playas != COMPANY_SPECTATOR && !ci->CanJoinCompany(client_playas)) this->buttons[line_count].push_back(std::make_unique<ClientButton>(SPR_JOIN, STR_NETWORK_CLIENT_LIST_COMPANY_AUTHORIZE_TOOLTIP, COLOUR_GREEN, ci->client_id, &NetworkClientListWindow::OnClickClientAuthorize));
 
 			if (ci->client_id == _network_own_client_id) {
 				this->player_self_index = this->line_count;

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -2208,19 +2208,13 @@ void ShowJoinStatusWindow()
 	new NetworkJoinStatusWindow(&_network_join_status_window_desc);
 }
 
-void ShowNetworkNeedPassword(NetworkPasswordType npt, std::shared_ptr<NetworkAuthenticationPasswordRequest> request)
+void ShowNetworkNeedPassword(std::shared_ptr<NetworkAuthenticationPasswordRequest> request)
 {
 	NetworkJoinStatusWindow *w = dynamic_cast<NetworkJoinStatusWindow *>(FindWindowById(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN));
 	if (w == nullptr) return;
 	w->request = request;
 
-	StringID caption;
-	switch (npt) {
-		default: NOT_REACHED();
-		case NETWORK_GAME_PASSWORD:    caption = STR_NETWORK_NEED_GAME_PASSWORD_CAPTION; break;
-		case NETWORK_COMPANY_PASSWORD: caption = STR_NETWORK_NEED_COMPANY_PASSWORD_CAPTION; break;
-	}
-	ShowQueryString(STR_EMPTY, caption, NETWORK_PASSWORD_LENGTH, w, CS_ALPHANUMERAL, QSF_PASSWORD);
+	ShowQueryString(STR_EMPTY, STR_NETWORK_NEED_GAME_PASSWORD_CAPTION, NETWORK_PASSWORD_LENGTH, w, CS_ALPHANUMERAL, QSF_NONE);
 }
 
 /**

--- a/src/network/network_gui.h
+++ b/src/network/network_gui.h
@@ -22,7 +22,6 @@ void ShowNetworkChatQueryWindow(DestType type, int dest);
 void ShowJoinStatusWindow();
 void ShowNetworkGameWindow();
 void ShowClientList();
-void ShowNetworkCompanyPasswordWindow(Window *parent);
 void ShowNetworkAskRelay(const std::string &server_connection_string, const std::string &relay_connection_string, const std::string &token);
 void ShowNetworkAskSurvey();
 void ShowSurveyResultTextfileWindow();

--- a/src/network/network_gui.h
+++ b/src/network/network_gui.h
@@ -17,7 +17,7 @@
 #include "network_type.h"
 #include "network_gamelist.h"
 
-void ShowNetworkNeedPassword(NetworkPasswordType npt, std::shared_ptr<class NetworkAuthenticationPasswordRequest> request);
+void ShowNetworkNeedPassword(std::shared_ptr<class NetworkAuthenticationPasswordRequest> request);
 void ShowNetworkChatQueryWindow(DestType type, int dest);
 void ShowJoinStatusWindow();
 void ShowNetworkGameWindow();

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -114,7 +114,6 @@ void NetworkTextMessage(NetworkAction action, TextColour colour, bool self_send,
 uint NetworkCalculateLag(const NetworkClientSocket *cs);
 StringID GetNetworkErrorMsg(NetworkErrorCode err);
 bool NetworkMakeClientNameUnique(std::string &new_name);
-std::string GenerateCompanyPasswordHash(const std::string &password, const std::string &password_server_id, uint32_t password_game_seed);
 
 std::string_view ParseCompanyFromConnectionString(const std::string &connection_string, CompanyID *company_id);
 NetworkAddress ParseConnectionString(const std::string &connection_string, uint16_t default_port);

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -80,8 +80,6 @@ extern std::string _network_server_name;
 
 extern uint8_t _network_reconnect;
 
-extern CompanyMask _network_company_passworded;
-
 void NetworkQueryServer(const std::string &connection_string);
 
 void GetBindAddresses(NetworkAddressList *addresses, uint16_t port);

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1668,16 +1668,6 @@ bool NetworkServerChangeClientName(ClientID client_id, const std::string &new_na
 }
 
 /**
- * Set/Reset a company password on the server end.
- * @param company_id ID of the company the password should be changed for.
- * @param password The new password.
- * @param already_hashed Is the given password already hashed?
- */
-void NetworkServerSetCompanyPassword([[maybe_unused]] CompanyID company_id, [[maybe_unused]] const std::string &password, [[maybe_unused]] bool already_hashed)
-{
-}
-
-/**
  * Handle the command-queue of a socket.
  * @param cs The socket to handle the queue for.
  */
@@ -1981,20 +1971,6 @@ void NetworkServerSendConfigUpdate()
 void NetworkServerUpdateGameInfo()
 {
 	if (_network_server) FillStaticNetworkServerGameInfo();
-}
-
-/**
- * Tell that a particular company is (not) passworded.
- * @param company_id The company that got/removed the password.
- * @param passworded Whether the password was received or removed.
- */
-void NetworkServerUpdateCompanyPassworded(CompanyID company_id, bool passworded)
-{
-	if (NetworkCompanyIsPassworded(company_id) == passworded) return;
-
-	SetWindowClassesDirty(WC_COMPANY);
-
-	NetworkAdminCompanyUpdate(Company::GetIfValid(company_id));
 }
 
 /**

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -30,13 +30,11 @@ protected:
 	NetworkRecvStatus Receive_CLIENT_IDENTIFY(Packet &p) override;
 	NetworkRecvStatus Receive_CLIENT_GAME_INFO(Packet &p) override;
 	NetworkRecvStatus Receive_CLIENT_AUTH_RESPONSE(Packet &p) override;
-	NetworkRecvStatus Receive_CLIENT_COMPANY_PASSWORD(Packet &p) override;
 	NetworkRecvStatus Receive_CLIENT_GETMAP(Packet &p) override;
 	NetworkRecvStatus Receive_CLIENT_MAP_OK(Packet &p) override;
 	NetworkRecvStatus Receive_CLIENT_ACK(Packet &p) override;
 	NetworkRecvStatus Receive_CLIENT_COMMAND(Packet &p) override;
 	NetworkRecvStatus Receive_CLIENT_CHAT(Packet &p) override;
-	NetworkRecvStatus Receive_CLIENT_SET_PASSWORD(Packet &p) override;
 	NetworkRecvStatus Receive_CLIENT_SET_NAME(Packet &p) override;
 	NetworkRecvStatus Receive_CLIENT_QUIT(Packet &p) override;
 	NetworkRecvStatus Receive_CLIENT_ERROR(Packet &p) override;
@@ -49,7 +47,6 @@ protected:
 	NetworkRecvStatus SendWelcome();
 	NetworkRecvStatus SendAuthRequest();
 	NetworkRecvStatus SendEnableEncryption();
-	NetworkRecvStatus SendNeedCompanyPassword();
 
 public:
 	/** Status of a client */
@@ -58,7 +55,6 @@ public:
 		STATUS_AUTH_GAME,     ///< The client is authorizing with game (server) password.
 		STATUS_IDENTIFY,      ///< The client is identifying itself.
 		STATUS_NEWGRFS_CHECK, ///< The client is checking NewGRFs.
-		STATUS_AUTH_COMPANY,  ///< The client is authorizing with company password.
 		STATUS_AUTHORIZED,    ///< The client is authorized.
 		STATUS_MAP_WAIT,      ///< The client is waiting as someone else is downloading the map.
 		STATUS_MAP,           ///< The client is downloading the map.
@@ -104,7 +100,6 @@ public:
 	NetworkRecvStatus SendFrame();
 	NetworkRecvStatus SendSync();
 	NetworkRecvStatus SendCommand(const CommandPacket &cp);
-	NetworkRecvStatus SendCompanyUpdate();
 	NetworkRecvStatus SendConfigUpdate();
 
 	static void Send();

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -123,7 +123,5 @@ public:
 
 void NetworkServer_Tick(bool send_frame);
 void ChangeNetworkRestartTime(bool reset);
-void NetworkServerSetCompanyPassword(CompanyID company_id, const std::string &password, bool already_hashed = true);
-void NetworkServerUpdateCompanyPassworded(CompanyID company_id, bool passworded);
 
 #endif /* NETWORK_SERVER_H */

--- a/src/network/network_type.h
+++ b/src/network/network_type.h
@@ -70,11 +70,6 @@ struct NetworkCompanyStats {
 	bool ai;                                        ///< Is this company an AI
 };
 
-/** Some state information of a company, especially for servers */
-struct NetworkCompanyState {
-	std::string password; ///< The password for the company
-};
-
 struct NetworkClientInfo;
 
 /** The type of password we're asking for. */

--- a/src/network/network_type.h
+++ b/src/network/network_type.h
@@ -72,12 +72,6 @@ struct NetworkCompanyStats {
 
 struct NetworkClientInfo;
 
-/** The type of password we're asking for. */
-enum NetworkPasswordType {
-	NETWORK_GAME_PASSWORD,    ///< The password of the game.
-	NETWORK_COMPANY_PASSWORD, ///< The password of the company.
-};
-
 /**
  * Destination of our chat messages.
  * @warning The values of the enum items are part of the admin network API. Only append at the end.

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -168,7 +168,6 @@ static void ShowHelp()
 		"  -G seed             = Set random seed\n"
 		"  -n host[:port][#company]= Join network game\n"
 		"  -p password         = Password to join server\n"
-		"  -P password         = Password to join company\n"
 		"  -D [host][:port]    = Start dedicated server\n"
 #if !defined(_WIN32)
 		"  -f                  = Fork into the background (dedicated only)\n"
@@ -384,7 +383,6 @@ struct AfterNewGRFScan : NewGRFScanCallback {
 	uint16_t dedicated_port = 0;                  ///< Port for the dedicated server.
 	std::string connection_string;              ///< Information about the server to connect to
 	std::string join_server_password;           ///< The password to join the server with.
-	std::string join_company_password;          ///< The password to join the company with.
 	bool save_config = true;                    ///< The save config setting.
 
 	/**
@@ -448,7 +446,7 @@ struct AfterNewGRFScan : NewGRFScanCallback {
 			LoadIntroGame();
 			_switch_mode = SM_NONE;
 
-			NetworkClientConnectGame(connection_string, COMPANY_NEW_COMPANY, join_server_password, join_company_password);
+			NetworkClientConnectGame(connection_string, COMPANY_NEW_COMPANY, join_server_password);
 		}
 
 		/* After the scan we're not used anymore. */
@@ -485,7 +483,7 @@ static std::vector<OptionData> CreateOptions()
 {
 	std::vector<OptionData> options;
 	/* Options that require a parameter. */
-	for (char c : "GIMPSbcmnpqrstv") options.push_back({ .type = ODF_HAS_VALUE, .id = c, .shortname = c });
+	for (char c : "GIMSbcmnpqrstv") options.push_back({ .type = ODF_HAS_VALUE, .id = c, .shortname = c });
 #if !defined(_WIN32)
 	options.push_back({ .type = ODF_HAS_VALUE, .id = 'f', .shortname = 'f' });
 #endif
@@ -557,9 +555,6 @@ int openttd_main(std::span<char * const> arguments)
 			break;
 		case 'p':
 			scanner->join_server_password = mgo.opt;
-			break;
-		case 'P':
-			scanner->join_company_password = mgo.opt;
 			break;
 		case 'r': ParseResolution(&resolution, mgo.opt); break;
 		case 't': scanner->startyear = atoi(mgo.opt); break;

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -894,12 +894,6 @@ static void MakeNewGameDone()
 	InitializeRailGUI();
 	InitializeRoadGUI();
 
-	/* We are the server, we start a new company (not dedicated),
-	 * so set the default password *if* needed. */
-	if (_network_server && !_settings_client.network.default_company_pass.empty()) {
-		NetworkChangeCompanyPassword(_local_company, _settings_client.network.default_company_pass);
-	}
-
 	if (_settings_client.gui.pause_on_newgame) Command<CMD_PAUSE>::Post(PM_PAUSED_NORMAL, true);
 
 	CheckEngines();

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -450,6 +450,8 @@ static const SaveLoad _company_desc[] = {
 	    SLE_VAR(CompanyProperties, president_name_2, SLE_UINT32),
 	SLE_CONDSSTR(CompanyProperties, president_name,  SLE_STR | SLF_ALLOW_CONTROL, SLV_84, SL_MAX_VERSION),
 
+	SLE_CONDVECTOR(CompanyProperties, allow_list, SLE_STR, SLV_COMPANY_ALLOW_LIST, SL_MAX_VERSION),
+
 	    SLE_VAR(CompanyProperties, face,            SLE_UINT32),
 
 	/* money was changed to a 64 bit field in savegame version 1. */

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -379,6 +379,8 @@ enum SaveLoadVersion : uint16_t {
 	SLV_SCRIPT_RANDOMIZER,                  ///< 333  PR#12063 v14.0-RC1 Save script randomizers.
 	SLV_VEHICLE_ECONOMY_AGE,                ///< 334  PR#12141 v14.0 Add vehicle age in economy year, for profit stats minimum age
 
+	SLV_COMPANY_ALLOW_LIST,                 ///< 335  PR#12337 Saving of list of client keys that are allowed to join this company.
+
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -945,6 +945,16 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
 #define SLE_CONDDEQUE(base, variable, type, from, to) SLE_GENERAL(SL_DEQUE, base, variable, type, 0, from, to, 0)
 
 /**
+ * Storage of a vector of #SL_VAR elements in some savegame versions.
+ * @param base     Name of the class or struct containing the list.
+ * @param variable Name of the variable in the class or struct referenced by \a base.
+ * @param type     Storage of the data in memory and in the savegame.
+ * @param from     First savegame version that has the list.
+ * @param to       Last savegame version that has the list.
+ */
+#define SLE_CONDVECTOR(base, variable, type, from, to) SLE_GENERAL(SL_VECTOR, base, variable, type, 0, from, to, 0)
+
+/**
  * Storage of a variable in every version of a savegame.
  * @param base     Name of the class or struct containing the variable.
  * @param variable Name of the variable in the class or struct referenced by \a base.

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -324,8 +324,7 @@ struct NetworkSettings {
 	std::string connect_to_ip;                            ///< default for the "Add server" query
 	std::string network_id;                               ///< network ID for servers
 	bool        autoclean_companies;                      ///< automatically remove companies that are not in use
-	uint8_t       autoclean_unprotected;                    ///< remove passwordless companies after this many months
-	uint8_t       autoclean_protected;                      ///< remove the password from passworded companies after this many months
+	uint8_t       autoclean_protected; ///< Remove companies after this many months.
 	uint8_t       autoclean_novehicles;                     ///< remove companies with no vehicles after this many months
 	uint8_t       max_companies;                            ///< maximum amount of companies
 	uint8_t       max_clients;                              ///< maximum amount of clients

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -320,9 +320,7 @@ struct NetworkSettings {
 	std::string client_name;                              ///< name of the player (as client)
 	std::string client_secret_key; ///< The secret key of the client for authorized key logins.
 	std::string client_public_key; ///< The public key of the client for authorized key logins.
-	std::string default_company_pass;                     ///< default password for new companies in encrypted form
 	std::string connect_to_ip;                            ///< default for the "Add server" query
-	std::string network_id;                               ///< network ID for servers
 	bool        autoclean_companies;                      ///< automatically remove companies that are not in use
 	uint8_t       autoclean_protected; ///< Remove companies after this many months.
 	uint8_t       autoclean_novehicles;                     ///< remove companies with no vehicles after this many months

--- a/src/table/settings/network_secrets_settings.ini
+++ b/src/table/settings/network_secrets_settings.ini
@@ -80,20 +80,6 @@ def      = nullptr
 pre_cb   = [](auto) { return false; }
 
 [SDTC_SSTR]
-var      = network.default_company_pass
-type     = SLE_STR
-length   = NETWORK_PASSWORD_LENGTH
-flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
-def      = nullptr
-
-[SDTC_SSTR]
-var      = network.network_id
-type     = SLE_STR
-length   = NETWORK_SERVER_ID_LENGTH
-flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
-def      = nullptr
-
-[SDTC_SSTR]
 var      = network.server_invite_code
 type     = SLE_STR
 length   = NETWORK_INVITE_CODE_LENGTH

--- a/src/table/settings/network_settings.ini
+++ b/src/table/settings/network_settings.ini
@@ -194,14 +194,6 @@ flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = false
 
 [SDTC_VAR]
-var      = network.autoclean_unprotected
-type     = SLE_UINT8
-flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_0_IS_SPECIAL | SF_NETWORK_ONLY
-def      = 12
-min      = 0
-max      = 240
-
-[SDTC_VAR]
 var      = network.autoclean_protected
 type     = SLE_UINT8
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_0_IS_SPECIAL | SF_NETWORK_ONLY

--- a/src/tests/test_network_crypto.cpp
+++ b/src/tests/test_network_crypto.cpp
@@ -18,6 +18,7 @@
 
 /* The length of the hexadecimal representation of a X25519 key must fit in the key length. */
 static_assert(NETWORK_SECRET_KEY_LENGTH >= X25519_KEY_SIZE * 2 + 1);
+static_assert(NETWORK_PUBLIC_KEY_LENGTH >= X25519_KEY_SIZE * 2 + 1);
 
 class MockNetworkSocketHandler : public NetworkSocketHandler {
 public:

--- a/src/textbuf_gui.h
+++ b/src/textbuf_gui.h
@@ -20,7 +20,6 @@ enum QueryStringFlags {
 	QSF_ACCEPT_UNCHANGED = 0x01, ///< return success even when the text didn't change
 	QSF_ENABLE_DEFAULT   = 0x02, ///< enable the 'Default' button ("\0" is returned)
 	QSF_LEN_IN_CHARS     = 0x04, ///< the length of the string is counted in characters
-	QSF_PASSWORD         = 0x08, ///< password entry box, show warning about password security
 };
 
 DECLARE_ENUM_AS_BIT_SET(QueryStringFlags)

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -97,7 +97,7 @@ static CallBackFunction _last_started_action = CBF_NONE; ///< Last started user 
  */
 class DropDownListCompanyItem : public DropDownIcon<DropDownIcon<DropDownString<DropDownListItem>, true>> {
 public:
-	DropDownListCompanyItem(CompanyID company, bool shaded) : DropDownIcon<DropDownIcon<DropDownString<DropDownListItem>, true>>(SPR_COMPANY_ICON, COMPANY_SPRITE_COLOUR(company), NetworkCompanyIsPassworded(company) ? SPR_LOCK : SPR_EMPTY, PAL_NONE, STR_NULL, company, false, shaded)
+	DropDownListCompanyItem(CompanyID company, bool shaded) : DropDownIcon<DropDownIcon<DropDownString<DropDownListItem>, true>>(SPR_COMPANY_ICON, COMPANY_SPRITE_COLOUR(company), NetworkCanJoinCompany(company) ? SPR_EMPTY : SPR_LOCK, PAL_NONE, STR_NULL, company, false, shaded)
 	{
 		SetDParam(0, company);
 		SetDParam(1, company);

--- a/src/widgets/company_widget.h
+++ b/src/widgets/company_widget.h
@@ -47,9 +47,7 @@ enum CompanyWidgets : WidgetID {
 	WID_C_SELECT_HOSTILE_TAKEOVER,    ///< Selection widget for the hostile takeover button.
 	WID_C_HOSTILE_TAKEOVER,           ///< Button to hostile takeover another company.
 
-	WID_C_HAS_PASSWORD,               ///< Has company password lock.
 	WID_C_SELECT_MULTIPLAYER,         ///< Multiplayer selection panel.
-	WID_C_COMPANY_PASSWORD,           ///< Button to set company password.
 	WID_C_COMPANY_JOIN,               ///< Button to join company.
 };
 

--- a/src/widgets/misc_widget.h
+++ b/src/widgets/misc_widget.h
@@ -32,7 +32,6 @@ enum AboutWidgets : WidgetID {
 enum QueryStringWidgets : WidgetID {
 	WID_QS_CAPTION, ///< Caption of the window.
 	WID_QS_TEXT,    ///< Text of the query.
-	WID_QS_WARNING, ///< Warning label about password security
 	WID_QS_DEFAULT, ///< Default button.
 	WID_QS_CANCEL,  ///< Cancel button.
 	WID_QS_OK,      ///< OK button.

--- a/src/widgets/network_widget.h
+++ b/src/widgets/network_widget.h
@@ -86,7 +86,6 @@ enum ClientListWidgets : WidgetID {
 	WID_CL_CLIENT_NAME_EDIT,           ///< Edit button for client name.
 	WID_CL_MATRIX,                     ///< Company/client list.
 	WID_CL_SCROLLBAR,                  ///< Scrollbar for company/client list.
-	WID_CL_COMPANY_JOIN,               ///< Used for QueryWindow when a company has a password.
 	WID_CL_CLIENT_COMPANY_COUNT,       ///< Count of clients and companies.
 };
 

--- a/src/widgets/network_widget.h
+++ b/src/widgets/network_widget.h
@@ -96,17 +96,6 @@ enum NetworkJoinStatusWidgets : WidgetID {
 	WID_NJS_CANCELOK,      ///< Cancel / OK button.
 };
 
-/** Widgets of the #NetworkCompanyPasswordWindow class. */
-enum NetworkCompanyPasswordWidgets : WidgetID {
-	WID_NCP_BACKGROUND,               ///< Background of the window.
-	WID_NCP_LABEL,                    ///< Label in front of the password field.
-	WID_NCP_PASSWORD,                 ///< Input field for the password.
-	WID_NCP_SAVE_AS_DEFAULT_PASSWORD, ///< Toggle 'button' for saving the current password as default password.
-	WID_NCP_WARNING,                  ///< Warning text about password security
-	WID_NCP_CANCEL,                   ///< Close the window without changing anything.
-	WID_NCP_OK,                       ///< Safe the password etc.
-};
-
 /** Widgets of the #NetworkAskRelayWindow class. */
 enum NetworkAskRelayWidgets : WidgetID {
 	WID_NAR_CAPTION,    ///< Caption of the window.

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -503,13 +503,6 @@ enum WindowClass {
 	WC_SEND_NETWORK_MSG,
 
 	/**
-	 * Company password query; %Window numbers:
-	 *   - 0 = #NetworkCompanyPasswordWidgets
-	 */
-	WC_COMPANY_PASSWORD_WINDOW,
-
-
-	/**
 	 * Industry cargoes chain; %Window numbers:
 	 *   - 0 = #IndustryCargoesWidgets
 	 */


### PR DESCRIPTION
## Motivation / Problem

Passwords are not necessarily bad, but the fact that they are not stored in the save is causing a lot of complaints in the community.

With recent changes we added authorized key support for joining the game, and with that comes a public key for which we know the client also knows the private key. This public key can easily be used to create an allow list that is saved and as such survives server restarts.


## Description

This removes company passwords and everything associated with that, and replaces that with an allow list of clients that may join a company. This allow list is saved in the saves and as such survives reloading the game (Closes #8391, related to #10999).

Things that got removed:
* auto clean unprotected: all companies are now protected.
* lot of UI for company passwords.
* default company password.
* network_id, game seed and custom password hashing.

Added:
* saving of an allow list.
* the client making the company gets automatically added to the allow list of that company.
* in the client list there is a green "join" button for clients that are not on the allow list for your company, that you can allow to join your company.
In the example below `Tester #1` is on the allow list for company `Unnamed`, and `Howdy` is not.
![clients](https://github.com/OpenTTD/OpenTTD/assets/13785744/68dc51fe-c7b7-442d-9320-11a05c0e59cb)
* in the client/company list, the join button is only shown when you are on the allow list; the server owner is by design always granted access, even though not on the allow list.


## Limitations

This does not:
* provide (UI for) management of allow lists (including removal from allow list).
* provide options to export and import allow lists.
* provide owner/admin vs user for allow list management; when you're allowed in the company, you can allow others.
* provide requesting of access to a company (use chat for that).
* provide option for automatically allowing everyone into companies, i.e. making them essentially unprotected again.
* add moved clients to the allow list automatically

All because these would balloon this PR significantly. The current set of functionality seems to be the minimal viable product, and it already quite big so better not make it any bigger.

I'm not sure whether much of the PR can be split into separate PRs, as that would create a weird Frankenstein-state with both passwords and authorized keys that's not really useful or has loads of dead code.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
