### PR TITLE
Fix #7982: Show existing coverage with unambiguous adjacent station

### DIFF
--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -92,6 +92,15 @@ void FindStationsAroundSelection()
 	/* Tile area for TileHighlightData */
 	TileArea location(TileVirtXY(_thd.pos.x, _thd.pos.y), _thd.size.x / TILE_SIZE - 1, _thd.size.y / TILE_SIZE - 1);
 
+	/* If the current tile is already a station, then it must be the nearest station. */
+	if (IsTileType(location.tile, MP_STATION) && GetTileOwner(location.tile) == _local_company) {
+		T* st = T::GetByTile(location.tile);
+		if (st != nullptr) {
+			SetViewportCatchmentSpecializedStation<T>(st, true);
+			return;
+		}
+	}
+
 	/* Extended area by one tile */
 	uint x = TileX(location.tile);
 	uint y = TileY(location.tile);


### PR DESCRIPTION
## Motivation / Problem
Fixes #7982.

Hovering a station which is adjacent to both a station with the same ID, and a station with a different ID results in only the hovered station's coverage being shown instead of the combined coverage.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

![image](https://github.com/OpenTTD/OpenTTD/assets/25364469/841c239b-ed91-481d-accc-cbc21decf6b5)

## Description
Changes coverage display to check for a station on the hovered tile and another tile in the area containing a station with the same ID.

Convenient test save with a few station layouts:
[Test Stations.sav.tar.gz](https://github.com/OpenTTD/OpenTTD/files/14693877/Test.Stations.sav.tar.gz)

![image](https://github.com/OpenTTD/OpenTTD/assets/25364469/cf7d3b5c-21a0-4909-b0ce-9c210676661c)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
This feels like a bit of a hack. I'm sure there's a better way of implementing this, but I think the whole function would need a rewrite.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review
Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
