### PR TITLE
Change: Show unbunching action in timetable window

### DIFF
--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -337,8 +337,8 @@ void DrawOrderString(const Vehicle *v, const Order *order, int order_index, int 
 				SetDParam(6, CargoSpec::Get(order->GetRefitCargo())->name);
 			}
 
-			/* Do not show unbunching in the depot in the timetable window. */
-			if (!timetable && (order->GetDepotActionType() & ODATFB_UNBUNCH)) {
+			/* Show unbunching depot in both order and timetable windows. */
+			if (order->GetDepotActionType() & ODATFB_UNBUNCH) {
 				SetDParam(8, STR_ORDER_WAIT_TO_UNBUNCH);
 			}
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

A vehicle's order list is shown in both the order and timetable windows. The timetable window does not list depot actions, since they are not relevant to the timetable.

When a vehicle is unbunched in a depot, it sets itself on-time when it departs the depot. This is relevant to the timetable and should be indicated in the timetable window. 

For example, I have a personal use case: Even with unbunching, I sometimes add extra station waiting time to keep vehicles spaced out across a long route. This is often at the far end of the route where the vehicle reverses, halfway through its route. For this I need to know the origin point of the timetable: the unbunching depot.

## Description

Draw the unbunching action in the timetable window, not just the order window.

I've marked this for backporting because unbunching is a new feature in 14.0. If someone disagrees, feel free to remove the label. 🙂 

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
