### PR TITLE
Fix: crash to desktop when attempting to join a company while not joined (yet)

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -921,13 +921,19 @@ DEF_CONSOLE_CMD(ConJoinCompany)
 
 	CompanyID company_id = (CompanyID)(atoi(argv[1]) <= MAX_COMPANIES ? atoi(argv[1]) - 1 : atoi(argv[1]));
 
+	const NetworkClientInfo *info = NetworkClientInfo::GetByClientID(_network_own_client_id);
+	if (info == nullptr) {
+		IConsolePrint(CC_ERROR, "You have not joined the game yet!");
+		return true;
+	}
+
 	/* Check we have a valid company id! */
 	if (!Company::IsValidID(company_id) && company_id != COMPANY_SPECTATOR) {
 		IConsolePrint(CC_ERROR, "Company does not exist. Company-id must be between 1 and {}.", MAX_COMPANIES);
 		return true;
 	}
 
-	if (NetworkClientInfo::GetByClientID(_network_own_client_id)->client_playas == company_id) {
+	if (info->client_playas == company_id) {
 		IConsolePrint(CC_ERROR, "You are already there!");
 		return true;
 	}

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -798,6 +798,7 @@ public:
 		Debug(net, 9, "Client::OnConnect(): connection_string={}", this->connection_string);
 
 		_networking = true;
+		_network_own_client_id = ClientID{};
 		new ClientNetworkGameSocketHandler(s, this->connection_string);
 		IConsoleCmdExec("exec scripts/on_client.scr 0");
 		NetworkClient_Connected();


### PR DESCRIPTION
## Motivation / Problem

Make server with password.

Start OpenTTD, open console, open network list, resize network list and join the server.
Then, when the password request is open, type `join 1` in the console and you crash to desktop.

Got triggered about this by CodeQL in #12337.


## Description

Check whether the returned `NetworkClientInfo` is not `nullptr` before dereferencing.
For good measure reset the `_network_own_client_id` to zero, as that's not used unless over 4 billion clients have joined the server.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
