### PR TITLE
Codefix: follow coding style

### DIFF
--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -269,7 +269,7 @@ std::string TranslateTTDPatchCodes(uint32_t grfid, uint8_t language_id, bool all
 				continue;
 			}
 		} else {
-			c = (uint8_t)*src++;
+			c = static_cast<uint8_t>(*src++);
 		}
 
 		if (c == '\0') break;
@@ -305,8 +305,8 @@ std::string TranslateTTDPatchCodes(uint32_t grfid, uint8_t language_id, bool all
 			{
 				if (src[0] == '\0' || src[1] == '\0') goto string_end;
 				StringID string;
-				string = ((uint8_t)* src++);
-				string |= ((uint8_t)* src++) << 8;
+				string = static_cast<uint8_t>(*src++);
+				string |= static_cast<uint8_t>(*src++) << 8;
 				Utf8Encode(d, SCC_NEWGRF_STRINL);
 				Utf8Encode(d, MapGRFStringID(grfid, string));
 				break;
@@ -350,8 +350,8 @@ std::string TranslateTTDPatchCodes(uint32_t grfid, uint8_t language_id, bool all
 					case 0x03:
 					{
 						if (src[0] == '\0' || src[1] == '\0') goto string_end;
-						uint16_t tmp = ((uint8_t)* src++);
-						tmp |= ((uint8_t)* src++) << 8;
+						uint16_t tmp = static_cast<uint8_t>(*src++);
+						tmp |= static_cast<uint8_t>(*src++) << 8;
 						Utf8Encode(d, SCC_NEWGRF_PUSH_WORD);
 						Utf8Encode(d, tmp);
 						break;

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -94,7 +94,7 @@ void FindStationsAroundSelection()
 
 	/* If the current tile is already a station, then it must be the nearest station. */
 	if (IsTileType(location.tile, MP_STATION) && GetTileOwner(location.tile) == _local_company) {
-		T* st = T::GetByTile(location.tile);
+		T *st = T::GetByTile(location.tile);
 		if (st != nullptr) {
 			SetViewportCatchmentSpecializedStation<T>(st, true);
 			return;

--- a/src/tile_map.h
+++ b/src/tile_map.h
@@ -244,12 +244,12 @@ inline TropicZone GetTropicZone(Tile tile)
 /**
  * Get the current animation frame
  * @param t the tile
- * @pre IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) ||IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_STATION)
  * @return frame number
  */
 inline uint8_t GetAnimationFrame(Tile t)
 {
-	assert(IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) ||IsTileType(t, MP_STATION));
+	assert(IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_STATION));
 	return t.m7();
 }
 
@@ -257,11 +257,11 @@ inline uint8_t GetAnimationFrame(Tile t)
  * Set a new animation frame
  * @param t the tile
  * @param frame the new frame number
- * @pre IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) ||IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_STATION)
  */
 inline void SetAnimationFrame(Tile t, uint8_t frame)
 {
-	assert(IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) ||IsTileType(t, MP_STATION));
+	assert(IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_STATION));
 	t.m7() = frame;
 }
 


### PR DESCRIPTION
## Motivation / Problem

Some coding style violations.
* `X* y` => `X *y`.
* `x ||y` => `x || y`
* `((x)* y++)` => `static_cast<x>(*y++)` (it's weird to see a space after a pointer dereference asterisk)

## Description

Fix them.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
