### PR TITLE
Codechange: move 'months_empty' to CompanyProperties

### DIFF
--- a/src/company_base.h
+++ b/src/company_base.h
@@ -91,6 +91,7 @@ struct CompanyProperties {
 
 	TimerGameEconomy::Year inaugurated_year; ///< Economy year of starting the company.
 
+	uint8_t months_empty = 0; ///< NOSAVE: Number of months this company has not had a client in multiplayer.
 	uint8_t months_of_bankruptcy;       ///< Number of months that the company is unable to pay its debts
 	CompanyMask bankrupt_asked;      ///< which companies were asked about buying it?
 	int16_t bankrupt_timeout;          ///< If bigger than \c 0, amount of time to wait for an answer on an offer to buy this company.

--- a/src/network/network_type.h
+++ b/src/network/network_type.h
@@ -73,7 +73,6 @@ struct NetworkCompanyStats {
 /** Some state information of a company, especially for servers */
 struct NetworkCompanyState {
 	std::string password; ///< The password for the company
-	uint16_t months_empty;  ///< How many months the company is empty
 };
 
 struct NetworkClientInfo;


### PR DESCRIPTION
## Motivation / Problem

For 'autoclean' there is a `struct` with the company password and a `months_empty` field. When removing company passwords (#12337), this `struct` would only contain the months empty field and the vast majority would be accessed using `_network_company_states[c->index].months_empty`, so moving it to `c->months_empty` would simplify that code.

Furthermore the `months_empty` is a `uint16_t` where the maximum thresholds are `240`, so a `uint8_t` would be just fine (with some guarding).

## Description

Put the `months_empty` in `CompanyProperties` where it should not increase the size of the `CompanyProperties` object.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
