### PR TITLE
Fix: Don't let CT_INVALID map to valid cargo type.

### DIFF
--- a/src/cargotype.cpp
+++ b/src/cargotype.cpp
@@ -95,7 +95,7 @@ void BuildCargoLabelMap()
 	CargoSpec::label_map.clear();
 	for (const CargoSpec &cs : CargoSpec::array) {
 		/* During initialization, CargoSpec can be marked valid before the label has been set. */
-		if (!cs.IsValid() || cs.label == CargoLabel{0}) continue;
+		if (!cs.IsValid() || cs.label == CargoLabel{0} || cs.label == CT_INVALID) continue;
 		/* Label already exists, don't addd again. */
 		if (CargoSpec::label_map.count(cs.label) != 0) continue;
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Defining a cargo type without a label meant that a different cargo type was now mapped to CT_INVALID instead of INVALID_CARGO.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/70c3f86e-2ea6-4081-aa11-5b9ecbe6a34d)


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Fixed by also excluding cargo with an unset label (which matches CT_INVALID) from being mapped to a valid cargo.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/a8162643-f621-4e06-9dbc-cbfadb6122a7)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations


<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
