### PR TITLE
Codefix: some minor errors in tcp-game protocol documentation

### DIFF
--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -211,14 +211,14 @@ protected:
 	/**
 	 * The client tells the server about the identity of the client:
 	 * string  Name of the client (max NETWORK_NAME_LENGTH).
-	 * uint8_t ID of the company to play as (1..MAX_COMPANIES).
+	 * uint8_t ID of the company to play as (1..MAX_COMPANIES, or COMPANY_SPECTATOR).
 	 * @param p The packet that was just received.
 	 */
 	virtual NetworkRecvStatus Receive_CLIENT_IDENTIFY(Packet &p);
 
 	/**
 	 * Indication to the client that it needs to authenticate:
-	 * bool Whether to use the password in the key exchange.
+	 * uint8_t The \c NetworkAuthenticationMethod to use.
 	 * 32 * uint8_t Public key of the server.
 	 * 24 * uint8_t Nonce for the key exchange.
 	 * @param p The packet that was just received.
@@ -236,8 +236,8 @@ protected:
 	/**
 	 * Send the response to the authentication request:
 	 * 32 * uint8_t Public key of the client.
-	 *  8 * uint8_t Random message that got encoded and signed.
 	 * 16 * uint8_t Message authentication code.
+	 *  8 * uint8_t Random message that got encoded and signed.
 	 * @param p The packet that was just received.
 	 */
 	virtual NetworkRecvStatus Receive_CLIENT_AUTH_RESPONSE(Packet &p);
@@ -267,7 +267,6 @@ protected:
 
 	/**
 	 * Request the map from the server.
-	 * uint32_t  NewGRF version (release versions of OpenTTD only).
 	 * @param p The packet that was just received.
 	 */
 	virtual NetworkRecvStatus Receive_CLIENT_GETMAP(Packet &p);


### PR DESCRIPTION
## Motivation / Problem

Some out-of-date documentation of the tcp game protocol.


## Description

Amend documentation.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
