### PR TITLE
Improve Script API docs

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -3,6 +3,8 @@
 # OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 # See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
 
+# Doxyfile 1.9.4
+
 #---------------------------------------------------------------------------
 # Project related configuration options
 #---------------------------------------------------------------------------
@@ -13,6 +15,7 @@ PROJECT_BRIEF          =
 PROJECT_LOGO           =
 OUTPUT_DIRECTORY       = ${CPACK_BINARY_DIR}/docs/source/
 CREATE_SUBDIRS         = YES
+CREATE_SUBDIRS_LEVEL   = 8
 ALLOW_UNICODE_NAMES    = NO
 OUTPUT_LANGUAGE        = English
 BRIEF_MEMBER_DESC      = YES
@@ -35,8 +38,10 @@ STRIP_FROM_PATH        = ./
 STRIP_FROM_INC_PATH    =
 SHORT_NAMES            = NO
 JAVADOC_AUTOBRIEF      = YES
+JAVADOC_BANNER         = NO
 QT_AUTOBRIEF           = NO
 MULTILINE_CPP_IS_BRIEF = NO
+PYTHON_DOCSTRING       = YES
 INHERIT_DOCS           = YES
 SEPARATE_MEMBER_PAGES  = NO
 TAB_SIZE               = 2
@@ -45,6 +50,7 @@ OPTIMIZE_OUTPUT_FOR_C  = YES
 OPTIMIZE_OUTPUT_JAVA   = NO
 OPTIMIZE_FOR_FORTRAN   = NO
 OPTIMIZE_OUTPUT_VHDL   = NO
+OPTIMIZE_OUTPUT_SLICE  = NO
 EXTENSION_MAPPING      =
 MARKDOWN_SUPPORT       = YES
 TOC_INCLUDE_HEADINGS   = 0
@@ -60,16 +66,19 @@ INLINE_GROUPED_CLASSES = NO
 INLINE_SIMPLE_STRUCTS  = NO
 TYPEDEF_HIDES_STRUCT   = NO
 LOOKUP_CACHE_SIZE      = 0
+NUM_PROC_THREADS       = 1
 #---------------------------------------------------------------------------
 # Build related configuration options
 #---------------------------------------------------------------------------
 EXTRACT_ALL            = NO
 EXTRACT_PRIVATE        = YES
+EXTRACT_PRIV_VIRTUAL   = NO
 EXTRACT_PACKAGE        = NO
 EXTRACT_STATIC         = YES
 EXTRACT_LOCAL_CLASSES  = YES
 EXTRACT_LOCAL_METHODS  = YES
 EXTRACT_ANON_NSPACES   = YES
+RESOLVE_UNNAMED_PARAMS = YES
 HIDE_UNDOC_MEMBERS     = NO
 HIDE_UNDOC_CLASSES     = NO
 HIDE_FRIEND_COMPOUNDS  = NO
@@ -78,6 +87,7 @@ INTERNAL_DOCS          = NO
 CASE_SENSE_NAMES       = YES
 HIDE_SCOPE_NAMES       = NO
 HIDE_COMPOUND_REFERENCE= NO
+SHOW_HEADERFILE        = YES
 SHOW_INCLUDE_FILES     = YES
 SHOW_GROUPED_MEMB_INC  = NO
 FORCE_LOCAL_INCLUDES   = NO
@@ -107,9 +117,11 @@ QUIET                  = NO
 WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = YES
 WARN_IF_DOC_ERROR      = YES
+WARN_IF_INCOMPLETE_DOC = YES
 WARN_NO_PARAMDOC       = NO
 WARN_AS_ERROR          = NO
 WARN_FORMAT            = "$file:$line: $text"
+WARN_LINE_FORMAT       = "at line $line of file $file"
 WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
@@ -150,6 +162,10 @@ REFERENCES_LINK_SOURCE = YES
 SOURCE_TOOLTIPS        = YES
 USE_HTAGS              = NO
 VERBATIM_HEADERS       = YES
+CLANG_ASSISTED_PARSING = NO
+CLANG_ADD_INC_PATHS    = YES
+CLANG_OPTIONS          =
+CLANG_DATABASE_PATH    =
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
@@ -175,6 +191,7 @@ HTML_DYNAMIC_SECTIONS  = NO
 HTML_INDEX_NUM_ENTRIES = 100
 GENERATE_DOCSET        = NO
 DOCSET_FEEDNAME        = "Doxygen generated docs"
+DOCSET_FEEDURL         =
 DOCSET_BUNDLE_ID       = org.doxygen.Project
 DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
 DOCSET_PUBLISHER_NAME  = Publisher
@@ -197,12 +214,17 @@ GENERATE_ECLIPSEHELP   = NO
 ECLIPSE_DOC_ID         = org.doxygen.Project
 DISABLE_INDEX          = NO
 GENERATE_TREEVIEW      = YES
+FULL_SIDEBAR           = NO
 ENUM_VALUES_PER_LINE   = 4
 TREEVIEW_WIDTH         = 250
 EXT_LINKS_IN_WINDOW    = NO
+OBFUSCATE_EMAILS       = YES
+HTML_FORMULA_FORMAT    = png
 FORMULA_FONTSIZE       = 10
 FORMULA_TRANSPARENT    = YES
+FORMULA_MACROFILE      =
 USE_MATHJAX            = NO
+MATHJAX_VERSION        = MathJax_2
 MATHJAX_FORMAT         = HTML-CSS
 MATHJAX_RELPATH        = https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/
 MATHJAX_EXTENSIONS     =
@@ -221,6 +243,7 @@ GENERATE_LATEX         = NO
 LATEX_OUTPUT           = latex
 LATEX_CMD_NAME         = latex
 MAKEINDEX_CMD_NAME     = makeindex
+LATEX_MAKEINDEX_CMD    = makeindex
 COMPACT_LATEX          = NO
 PAPER_TYPE             = a4
 EXTRA_PACKAGES         =
@@ -232,9 +255,9 @@ PDF_HYPERLINKS         = NO
 USE_PDFLATEX           = NO
 LATEX_BATCHMODE        = NO
 LATEX_HIDE_INDICES     = NO
-LATEX_SOURCE_CODE      = NO
 LATEX_BIB_STYLE        = plain
 LATEX_TIMESTAMP        = NO
+LATEX_EMOJI_DIRECTORY  =
 #---------------------------------------------------------------------------
 # Configuration options related to the RTF output
 #---------------------------------------------------------------------------
@@ -244,7 +267,6 @@ COMPACT_RTF            = NO
 RTF_HYPERLINKS         = NO
 RTF_STYLESHEET_FILE    =
 RTF_EXTENSIONS_FILE    =
-RTF_SOURCE_CODE        = NO
 #---------------------------------------------------------------------------
 # Configuration options related to the man page output
 #---------------------------------------------------------------------------
@@ -259,12 +281,12 @@ MAN_LINKS              = NO
 GENERATE_XML           = NO
 XML_OUTPUT             = xml
 XML_PROGRAMLISTING     = YES
+XML_NS_MEMB_FILE_SCOPE = NO
 #---------------------------------------------------------------------------
 # Configuration options related to the DOCBOOK output
 #---------------------------------------------------------------------------
 GENERATE_DOCBOOK       = NO
 DOCBOOK_OUTPUT         = docbook
-DOCBOOK_PROGRAMLISTING = NO
 #---------------------------------------------------------------------------
 # Configuration options for the AutoGen Definitions output
 #---------------------------------------------------------------------------
@@ -311,7 +333,6 @@ EXTERNAL_PAGES         = YES
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
-CLASS_DIAGRAMS         = YES
 DIA_PATH               =
 HIDE_UNDOC_RELATIONS   = YES
 HAVE_DOT               = NO
@@ -324,6 +345,8 @@ COLLABORATION_GRAPH    = YES
 GROUP_GRAPHS           = YES
 UML_LOOK               = NO
 UML_LIMIT_NUM_FIELDS   = 10
+DOT_UML_DETAILS        = NO
+DOT_WRAP_THRESHOLD     = 17
 TEMPLATE_RELATIONS     = NO
 INCLUDE_GRAPH          = YES
 INCLUDED_BY_GRAPH      = YES
@@ -331,6 +354,7 @@ CALL_GRAPH             = NO
 CALLER_GRAPH           = NO
 GRAPHICAL_HIERARCHY    = YES
 DIRECTORY_GRAPH        = YES
+DIR_GRAPH_MAX_DEPTH    = 1
 DOT_IMAGE_FORMAT       = png
 INTERACTIVE_SVG        = NO
 DOT_PATH               =

--- a/src/script/api/Doxyfile_AI.in
+++ b/src/script/api/Doxyfile_AI.in
@@ -3,7 +3,7 @@
 # OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 # See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
 
-# Doxyfile 1.5.4
+# Doxyfile 1.9.4
 
 #---------------------------------------------------------------------------
 # Project related configuration options
@@ -11,14 +11,18 @@
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "OpenTTD AI API"
 PROJECT_NUMBER         = ${REV_VERSION}
+PROJECT_BRIEF          =
+PROJECT_LOGO           =
 OUTPUT_DIRECTORY       = ${CPACK_BINARY_DIR}/docs/ai-api/
 CREATE_SUBDIRS         = NO
+CREATE_SUBDIRS_LEVEL   = 8
+ALLOW_UNICODE_NAMES    = NO
 OUTPUT_LANGUAGE        = English
 BRIEF_MEMBER_DESC      = YES
 REPEAT_BRIEF           = YES
-ABBREVIATE_BRIEF       = "The $name class " \
-                         "The $name widget " \
-                         "The $name file " \
+ABBREVIATE_BRIEF       = "The $name class" \
+                         "The $name widget" \
+                         "The $name file" \
                          is \
                          provides \
                          specifies \
@@ -34,29 +38,47 @@ STRIP_FROM_PATH        = ./
 STRIP_FROM_INC_PATH    =
 SHORT_NAMES            = NO
 JAVADOC_AUTOBRIEF      = YES
+JAVADOC_BANNER         = NO
 QT_AUTOBRIEF           = NO
 MULTILINE_CPP_IS_BRIEF = NO
+PYTHON_DOCSTRING       = YES
 INHERIT_DOCS           = YES
 SEPARATE_MEMBER_PAGES  = NO
 TAB_SIZE               = 2
 ALIASES                =
 OPTIMIZE_OUTPUT_FOR_C  = YES
 OPTIMIZE_OUTPUT_JAVA   = NO
+OPTIMIZE_FOR_FORTRAN   = NO
+OPTIMIZE_OUTPUT_VHDL   = NO
+OPTIMIZE_OUTPUT_SLICE  = NO
+EXTENSION_MAPPING      =
+MARKDOWN_SUPPORT       = YES
+TOC_INCLUDE_HEADINGS   = 5
+AUTOLINK_SUPPORT       = YES
 BUILTIN_STL_SUPPORT    = NO
 CPP_CLI_SUPPORT        = NO
 SIP_SUPPORT            = NO
+IDL_PROPERTY_SUPPORT   = YES
 DISTRIBUTE_GROUP_DOC   = NO
+GROUP_NESTED_COMPOUNDS = NO
 SUBGROUPING            = YES
+INLINE_GROUPED_CLASSES = NO
+INLINE_SIMPLE_STRUCTS  = NO
 TYPEDEF_HIDES_STRUCT   = NO
+LOOKUP_CACHE_SIZE      = 0
+NUM_PROC_THREADS       = 1
 #---------------------------------------------------------------------------
 # Build related configuration options
 #---------------------------------------------------------------------------
 EXTRACT_ALL            = NO
 EXTRACT_PRIVATE        = NO
+EXTRACT_PRIV_VIRTUAL   = NO
+EXTRACT_PACKAGE        = NO
 EXTRACT_STATIC         = YES
 EXTRACT_LOCAL_CLASSES  = YES
 EXTRACT_LOCAL_METHODS  = YES
 EXTRACT_ANON_NSPACES   = NO
+RESOLVE_UNNAMED_PARAMS = YES
 HIDE_UNDOC_MEMBERS     = NO
 HIDE_UNDOC_CLASSES     = NO
 HIDE_FRIEND_COMPOUNDS  = NO
@@ -64,11 +86,18 @@ HIDE_IN_BODY_DOCS      = YES
 INTERNAL_DOCS          = YES
 CASE_SENSE_NAMES       = YES
 HIDE_SCOPE_NAMES       = NO
+HIDE_COMPOUND_REFERENCE= NO
+SHOW_HEADERFILE        = YES
 SHOW_INCLUDE_FILES     = NO
+SHOW_GROUPED_MEMB_INC  = NO
+FORCE_LOCAL_INCLUDES   = NO
 INLINE_INFO            = YES
 SORT_MEMBER_DOCS       = YES
 SORT_BRIEF_DOCS        = NO
+SORT_MEMBERS_CTORS_1ST = NO
+SORT_GROUP_NAMES       = YES
 SORT_BY_SCOPE_NAME     = NO
+STRICT_PROTO_MATCHING  = NO
 GENERATE_TODOLIST      = NO
 GENERATE_TESTLIST      = NO
 GENERATE_BUGLIST       = NO
@@ -76,21 +105,29 @@ GENERATE_DEPRECATEDLIST= NO
 ENABLED_SECTIONS       =
 MAX_INITIALIZER_LINES  = 30
 SHOW_USED_FILES        = NO
+SHOW_FILES             = YES
+SHOW_NAMESPACES        = YES
 FILE_VERSION_FILTER    =
+LAYOUT_FILE            =
+CITE_BIB_FILES         =
 #---------------------------------------------------------------------------
-# configuration options related to warning and progress messages
+# Configuration options related to warning and progress messages
 #---------------------------------------------------------------------------
 QUIET                  = NO
 WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = YES
 WARN_IF_DOC_ERROR      = YES
+WARN_IF_INCOMPLETE_DOC = YES
 WARN_NO_PARAMDOC       = YES
-WARN_FORMAT            = "$file:$line: $text "
+WARN_AS_ERROR          = NO
+WARN_FORMAT            = "$file:$line: $text"
+WARN_LINE_FORMAT       = "at line $line of file $file"
 WARN_LOGFILE           =
 #---------------------------------------------------------------------------
-# configuration options related to the input files
+# Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = . ${FIND_VERSION_BINARY_DIR}/script/api
+INPUT                  = . \
+                         ${FIND_VERSION_BINARY_DIR}/script/api
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = script_*.hpp \
                          ai_*.hpp
@@ -98,7 +135,9 @@ RECURSIVE              = YES
 EXCLUDE                =
 EXCLUDE_SYMLINKS       = NO
 EXCLUDE_PATTERNS       = ai_includes.hpp
-EXCLUDE_SYMBOLS        = GetClassName DECLARE_ENUM_AS_BIT_SET DECLARE_POSTFIX_INCREMENT
+EXCLUDE_SYMBOLS        = GetClassName \
+                         DECLARE_ENUM_AS_BIT_SET \
+                         DECLARE_POSTFIX_INCREMENT
 EXAMPLE_PATH           =
 EXAMPLE_PATTERNS       = *
 EXAMPLE_RECURSIVE      = NO
@@ -106,8 +145,10 @@ IMAGE_PATH             =
 INPUT_FILTER           = "./doxygen_filter.sh AI"
 FILTER_PATTERNS        =
 FILTER_SOURCE_FILES    = NO
+FILTER_SOURCE_PATTERNS =
+USE_MDFILE_AS_MAINPAGE =
 #---------------------------------------------------------------------------
-# configuration options related to source browsing
+# Configuration options related to source browsing
 #---------------------------------------------------------------------------
 SOURCE_BROWSER         = NO
 INLINE_SOURCES         = NO
@@ -115,15 +156,20 @@ STRIP_CODE_COMMENTS    = YES
 REFERENCED_BY_RELATION = NO
 REFERENCES_RELATION    = NO
 REFERENCES_LINK_SOURCE = YES
+SOURCE_TOOLTIPS        = YES
 USE_HTAGS              = NO
 VERBATIM_HEADERS       = NO
+CLANG_ASSISTED_PARSING = NO
+CLANG_ADD_INC_PATHS    = YES
+CLANG_OPTIONS          =
+CLANG_DATABASE_PATH    =
 #---------------------------------------------------------------------------
-# configuration options related to the alphabetical class index
+# Configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
 ALPHABETICAL_INDEX     = NO
 IGNORE_PREFIX          =
 #---------------------------------------------------------------------------
-# configuration options related to the HTML output
+# Configuration options related to the HTML output
 #---------------------------------------------------------------------------
 GENERATE_HTML          = YES
 HTML_OUTPUT            = html
@@ -131,34 +177,86 @@ HTML_FILE_EXTENSION    = .html
 HTML_HEADER            =
 HTML_FOOTER            =
 HTML_STYLESHEET        =
-GENERATE_HTMLHELP      = NO
+HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_FILES       =
+HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_SAT    = 100
+HTML_COLORSTYLE_GAMMA  = 80
+HTML_TIMESTAMP         = NO
+HTML_DYNAMIC_MENUS     = YES
 HTML_DYNAMIC_SECTIONS  = NO
+HTML_INDEX_NUM_ENTRIES = 100
+GENERATE_DOCSET        = NO
+DOCSET_FEEDNAME        = "Doxygen generated docs"
+DOCSET_FEEDURL         =
+DOCSET_BUNDLE_ID       = org.doxygen.Project
+DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
+DOCSET_PUBLISHER_NAME  = Publisher
+GENERATE_HTMLHELP      = NO
 CHM_FILE               =
 HHC_LOCATION           =
 GENERATE_CHI           = NO
+CHM_INDEX_ENCODING     =
 BINARY_TOC             = NO
 TOC_EXPAND             = NO
+GENERATE_QHP           = NO
+QCH_FILE               =
+QHP_NAMESPACE          = org.doxygen.Project
+QHP_VIRTUAL_FOLDER     = doc
+QHP_CUST_FILTER_NAME   =
+QHP_CUST_FILTER_ATTRS  =
+QHP_SECT_FILTER_ATTRS  =
+QHG_LOCATION           =
+GENERATE_ECLIPSEHELP   = NO
+ECLIPSE_DOC_ID         = org.doxygen.Project
 DISABLE_INDEX          = NO
-ENUM_VALUES_PER_LINE   = 1
 GENERATE_TREEVIEW      = NO
+FULL_SIDEBAR           = NO
+ENUM_VALUES_PER_LINE   = 1
 TREEVIEW_WIDTH         = 250
+EXT_LINKS_IN_WINDOW    = NO
+OBFUSCATE_EMAILS       = YES
+HTML_FORMULA_FORMAT    = png
+FORMULA_FONTSIZE       = 10
+FORMULA_TRANSPARENT    = YES
+FORMULA_MACROFILE      =
+USE_MATHJAX            = NO
+MATHJAX_VERSION        = MathJax_2
+MATHJAX_FORMAT         = HTML-CSS
+MATHJAX_RELPATH        =
+MATHJAX_EXTENSIONS     =
+MATHJAX_CODEFILE       =
+SEARCHENGINE           = NO
+SERVER_BASED_SEARCH    = NO
+EXTERNAL_SEARCH        = NO
+SEARCHENGINE_URL       =
+SEARCHDATA_FILE        = searchdata.xml
+EXTERNAL_SEARCH_ID     =
+EXTRA_SEARCH_MAPPINGS  =
 #---------------------------------------------------------------------------
-# configuration options related to the LaTeX output
+# Configuration options related to the LaTeX output
 #---------------------------------------------------------------------------
 GENERATE_LATEX         = NO
 LATEX_OUTPUT           = latex
 LATEX_CMD_NAME         = latex
 MAKEINDEX_CMD_NAME     = makeindex
+LATEX_MAKEINDEX_CMD    = makeindex
 COMPACT_LATEX          = NO
 PAPER_TYPE             = a4
 EXTRA_PACKAGES         =
 LATEX_HEADER           =
+LATEX_FOOTER           =
+LATEX_EXTRA_STYLESHEET =
+LATEX_EXTRA_FILES      =
 PDF_HYPERLINKS         = NO
 USE_PDFLATEX           = NO
 LATEX_BATCHMODE        = NO
 LATEX_HIDE_INDICES     = NO
+LATEX_BIB_STYLE        = plain
+LATEX_TIMESTAMP        = NO
+LATEX_EMOJI_DIRECTORY  =
 #---------------------------------------------------------------------------
-# configuration options related to the RTF output
+# Configuration options related to the RTF output
 #---------------------------------------------------------------------------
 GENERATE_RTF           = NO
 RTF_OUTPUT             = rtf
@@ -167,24 +265,31 @@ RTF_HYPERLINKS         = NO
 RTF_STYLESHEET_FILE    =
 RTF_EXTENSIONS_FILE    =
 #---------------------------------------------------------------------------
-# configuration options related to the man page output
+# Configuration options related to the man page output
 #---------------------------------------------------------------------------
 GENERATE_MAN           = NO
 MAN_OUTPUT             = man
 MAN_EXTENSION          = .3
+MAN_SUBDIR             =
 MAN_LINKS              = NO
 #---------------------------------------------------------------------------
-# configuration options related to the XML output
+# Configuration options related to the XML output
 #---------------------------------------------------------------------------
 GENERATE_XML           = NO
 XML_OUTPUT             = xml
 XML_PROGRAMLISTING     = YES
+XML_NS_MEMB_FILE_SCOPE = NO
 #---------------------------------------------------------------------------
-# configuration options for the AutoGen Definitions output
+# Configuration options related to the DOCBOOK output
+#---------------------------------------------------------------------------
+GENERATE_DOCBOOK       = NO
+DOCBOOK_OUTPUT         = docbook
+#---------------------------------------------------------------------------
+# Configuration options for the AutoGen Definitions output
 #---------------------------------------------------------------------------
 GENERATE_AUTOGEN_DEF   = NO
 #---------------------------------------------------------------------------
-# configuration options related to the Perl module output
+# Configuration options related to the Perl module output
 #---------------------------------------------------------------------------
 GENERATE_PERLMOD       = NO
 PERLMOD_LATEX          = NO
@@ -203,22 +308,30 @@ PREDEFINED             = DOXYGEN_API
 EXPAND_AS_DEFINED      = DEF_COMMAND
 SKIP_FUNCTION_MACROS   = YES
 #---------------------------------------------------------------------------
-# Configuration::additions related to external references
+# Configuration options related to external references
 #---------------------------------------------------------------------------
 TAGFILES               =
 GENERATE_TAGFILE       = ${CPACK_BINARY_DIR}/docs/openttd_ai_api.tag
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
+EXTERNAL_PAGES         = YES
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
-CLASS_DIAGRAMS         = YES
+DIA_PATH               =
 HIDE_UNDOC_RELATIONS   = YES
 HAVE_DOT               = NO
+DOT_NUM_THREADS        = 0
+DOT_FONTNAME           = Helvetica
+DOT_FONTSIZE           = 10
+DOT_FONTPATH           =
 CLASS_GRAPH            = YES
 COLLABORATION_GRAPH    = YES
 GROUP_GRAPHS           = YES
 UML_LOOK               = NO
+UML_LIMIT_NUM_FIELDS   = 10
+DOT_UML_DETAILS        = NO
+DOT_WRAP_THRESHOLD     = 17
 TEMPLATE_RELATIONS     = NO
 INCLUDE_GRAPH          = YES
 INCLUDED_BY_GRAPH      = YES
@@ -226,16 +339,19 @@ CALL_GRAPH             = NO
 CALLER_GRAPH           = NO
 GRAPHICAL_HIERARCHY    = YES
 DIRECTORY_GRAPH        = YES
+DIR_GRAPH_MAX_DEPTH    = 1
 DOT_IMAGE_FORMAT       = png
+INTERACTIVE_SVG        = NO
 DOT_PATH               =
 DOTFILE_DIRS           =
+MSCFILE_DIRS           =
+DIAFILE_DIRS           =
+PLANTUML_JAR_PATH      =
+PLANTUML_CFG_FILE      =
+PLANTUML_INCLUDE_PATH  =
 DOT_GRAPH_MAX_NODES    = 50
 MAX_DOT_GRAPH_DEPTH    = 1000
 DOT_TRANSPARENT        = NO
 DOT_MULTI_TARGETS      = NO
 GENERATE_LEGEND        = NO
 DOT_CLEANUP            = YES
-#---------------------------------------------------------------------------
-# Configuration::additions related to the search engine
-#---------------------------------------------------------------------------
-SEARCHENGINE           = NO

--- a/src/script/api/Doxyfile_GS.in
+++ b/src/script/api/Doxyfile_GS.in
@@ -3,7 +3,7 @@
 # OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 # See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
 
-# Doxyfile 1.5.4
+# Doxyfile 1.9.4
 
 #---------------------------------------------------------------------------
 # Project related configuration options
@@ -11,14 +11,18 @@
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "OpenTTD GameScript API"
 PROJECT_NUMBER         = ${REV_VERSION}
+PROJECT_BRIEF          =
+PROJECT_LOGO           =
 OUTPUT_DIRECTORY       = ${CPACK_BINARY_DIR}/docs/gs-api/
 CREATE_SUBDIRS         = NO
+CREATE_SUBDIRS_LEVEL   = 8
+ALLOW_UNICODE_NAMES    = NO
 OUTPUT_LANGUAGE        = English
 BRIEF_MEMBER_DESC      = YES
 REPEAT_BRIEF           = YES
-ABBREVIATE_BRIEF       = "The $name class " \
-                         "The $name widget " \
-                         "The $name file " \
+ABBREVIATE_BRIEF       = "The $name class" \
+                         "The $name widget" \
+                         "The $name file" \
                          is \
                          provides \
                          specifies \
@@ -34,29 +38,47 @@ STRIP_FROM_PATH        = ./
 STRIP_FROM_INC_PATH    =
 SHORT_NAMES            = NO
 JAVADOC_AUTOBRIEF      = YES
+JAVADOC_BANNER         = NO
 QT_AUTOBRIEF           = NO
 MULTILINE_CPP_IS_BRIEF = NO
+PYTHON_DOCSTRING       = YES
 INHERIT_DOCS           = YES
 SEPARATE_MEMBER_PAGES  = NO
 TAB_SIZE               = 2
 ALIASES                =
 OPTIMIZE_OUTPUT_FOR_C  = YES
 OPTIMIZE_OUTPUT_JAVA   = NO
+OPTIMIZE_FOR_FORTRAN   = NO
+OPTIMIZE_OUTPUT_VHDL   = NO
+OPTIMIZE_OUTPUT_SLICE  = NO
+EXTENSION_MAPPING      =
+MARKDOWN_SUPPORT       = YES
+TOC_INCLUDE_HEADINGS   = 5
+AUTOLINK_SUPPORT       = YES
 BUILTIN_STL_SUPPORT    = NO
 CPP_CLI_SUPPORT        = NO
 SIP_SUPPORT            = NO
+IDL_PROPERTY_SUPPORT   = YES
 DISTRIBUTE_GROUP_DOC   = NO
+GROUP_NESTED_COMPOUNDS = NO
 SUBGROUPING            = YES
+INLINE_GROUPED_CLASSES = NO
+INLINE_SIMPLE_STRUCTS  = NO
 TYPEDEF_HIDES_STRUCT   = NO
+LOOKUP_CACHE_SIZE      = 0
+NUM_PROC_THREADS       = 1
 #---------------------------------------------------------------------------
 # Build related configuration options
 #---------------------------------------------------------------------------
 EXTRACT_ALL            = NO
 EXTRACT_PRIVATE        = NO
+EXTRACT_PRIV_VIRTUAL   = NO
+EXTRACT_PACKAGE        = NO
 EXTRACT_STATIC         = YES
 EXTRACT_LOCAL_CLASSES  = YES
 EXTRACT_LOCAL_METHODS  = YES
 EXTRACT_ANON_NSPACES   = NO
+RESOLVE_UNNAMED_PARAMS = YES
 HIDE_UNDOC_MEMBERS     = NO
 HIDE_UNDOC_CLASSES     = NO
 HIDE_FRIEND_COMPOUNDS  = NO
@@ -64,11 +86,18 @@ HIDE_IN_BODY_DOCS      = YES
 INTERNAL_DOCS          = YES
 CASE_SENSE_NAMES       = YES
 HIDE_SCOPE_NAMES       = NO
+HIDE_COMPOUND_REFERENCE= NO
+SHOW_HEADERFILE        = YES
 SHOW_INCLUDE_FILES     = NO
+SHOW_GROUPED_MEMB_INC  = NO
+FORCE_LOCAL_INCLUDES   = NO
 INLINE_INFO            = YES
 SORT_MEMBER_DOCS       = YES
 SORT_BRIEF_DOCS        = NO
+SORT_MEMBERS_CTORS_1ST = NO
+SORT_GROUP_NAMES       = NO
 SORT_BY_SCOPE_NAME     = NO
+STRICT_PROTO_MATCHING  = NO
 GENERATE_TODOLIST      = NO
 GENERATE_TESTLIST      = NO
 GENERATE_BUGLIST       = NO
@@ -76,21 +105,29 @@ GENERATE_DEPRECATEDLIST= NO
 ENABLED_SECTIONS       =
 MAX_INITIALIZER_LINES  = 30
 SHOW_USED_FILES        = NO
+SHOW_FILES             = YES
+SHOW_NAMESPACES        = YES
 FILE_VERSION_FILTER    =
+LAYOUT_FILE            =
+CITE_BIB_FILES         =
 #---------------------------------------------------------------------------
-# configuration options related to warning and progress messages
+# Configuration options related to warning and progress messages
 #---------------------------------------------------------------------------
 QUIET                  = NO
 WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = YES
 WARN_IF_DOC_ERROR      = YES
+WARN_IF_INCOMPLETE_DOC = YES
 WARN_NO_PARAMDOC       = YES
-WARN_FORMAT            = "$file:$line: $text "
+WARN_AS_ERROR          = NO
+WARN_FORMAT            = "$file:$line: $text"
+WARN_LINE_FORMAT       = "at line $line of file $file"
 WARN_LOGFILE           =
 #---------------------------------------------------------------------------
-# configuration options related to the input files
+# Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = . ${FIND_VERSION_BINARY_DIR}/script/api
+INPUT                  = . \
+                         ${FIND_VERSION_BINARY_DIR}/script/api
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = script_*.hpp \
                          game_*.hpp
@@ -98,7 +135,9 @@ RECURSIVE              = YES
 EXCLUDE                =
 EXCLUDE_SYMLINKS       = NO
 EXCLUDE_PATTERNS       = game_includes.hpp
-EXCLUDE_SYMBOLS        = GetClassName DECLARE_ENUM_AS_BIT_SET DECLARE_POSTFIX_INCREMENT
+EXCLUDE_SYMBOLS        = GetClassName \
+                         DECLARE_ENUM_AS_BIT_SET \
+                         DECLARE_POSTFIX_INCREMENT
 EXAMPLE_PATH           =
 EXAMPLE_PATTERNS       = *
 EXAMPLE_RECURSIVE      = NO
@@ -106,8 +145,10 @@ IMAGE_PATH             =
 INPUT_FILTER           = "./doxygen_filter.sh GS"
 FILTER_PATTERNS        =
 FILTER_SOURCE_FILES    = NO
+FILTER_SOURCE_PATTERNS =
+USE_MDFILE_AS_MAINPAGE =
 #---------------------------------------------------------------------------
-# configuration options related to source browsing
+# Configuration options related to source browsing
 #---------------------------------------------------------------------------
 SOURCE_BROWSER         = NO
 INLINE_SOURCES         = NO
@@ -115,15 +156,20 @@ STRIP_CODE_COMMENTS    = YES
 REFERENCED_BY_RELATION = NO
 REFERENCES_RELATION    = NO
 REFERENCES_LINK_SOURCE = YES
+SOURCE_TOOLTIPS        = YES
 USE_HTAGS              = NO
 VERBATIM_HEADERS       = NO
+CLANG_ASSISTED_PARSING = NO
+CLANG_ADD_INC_PATHS    = YES
+CLANG_OPTIONS          =
+CLANG_DATABASE_PATH    =
 #---------------------------------------------------------------------------
-# configuration options related to the alphabetical class index
+# Configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
 ALPHABETICAL_INDEX     = NO
 IGNORE_PREFIX          =
 #---------------------------------------------------------------------------
-# configuration options related to the HTML output
+# Configuration options related to the HTML output
 #---------------------------------------------------------------------------
 GENERATE_HTML          = YES
 HTML_OUTPUT            = html
@@ -131,34 +177,86 @@ HTML_FILE_EXTENSION    = .html
 HTML_HEADER            =
 HTML_FOOTER            =
 HTML_STYLESHEET        =
-GENERATE_HTMLHELP      = NO
+HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_FILES       =
+HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_SAT    = 100
+HTML_COLORSTYLE_GAMMA  = 80
+HTML_TIMESTAMP         = NO
+HTML_DYNAMIC_MENUS     = YES
 HTML_DYNAMIC_SECTIONS  = NO
+HTML_INDEX_NUM_ENTRIES = 100
+GENERATE_DOCSET        = NO
+DOCSET_FEEDNAME        = "Doxygen generated docs"
+DOCSET_FEEDURL         =
+DOCSET_BUNDLE_ID       = org.doxygen.Project
+DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
+DOCSET_PUBLISHER_NAME  = Publisher
+GENERATE_HTMLHELP      = NO
 CHM_FILE               =
 HHC_LOCATION           =
 GENERATE_CHI           = NO
+CHM_INDEX_ENCODING     =
 BINARY_TOC             = NO
 TOC_EXPAND             = NO
+GENERATE_QHP           = NO
+QCH_FILE               =
+QHP_NAMESPACE          = org.doxygen.Project
+QHP_VIRTUAL_FOLDER     = doc
+QHP_CUST_FILTER_NAME   =
+QHP_CUST_FILTER_ATTRS  =
+QHP_SECT_FILTER_ATTRS  =
+QHG_LOCATION           =
+GENERATE_ECLIPSEHELP   = NO
+ECLIPSE_DOC_ID         = org.doxygen.Project
 DISABLE_INDEX          = NO
-ENUM_VALUES_PER_LINE   = 1
 GENERATE_TREEVIEW      = NO
+FULL_SIDEBAR           = NO
+ENUM_VALUES_PER_LINE   = 1
 TREEVIEW_WIDTH         = 250
+EXT_LINKS_IN_WINDOW    = NO
+OBFUSCATE_EMAILS       = YES
+HTML_FORMULA_FORMAT    = png
+FORMULA_FONTSIZE       = 10
+FORMULA_TRANSPARENT    = YES
+FORMULA_MACROFILE      =
+USE_MATHJAX            = NO
+MATHJAX_VERSION        = MathJax_2
+MATHJAX_FORMAT         = HTML-CSS
+MATHJAX_RELPATH        =
+MATHJAX_EXTENSIONS     =
+MATHJAX_CODEFILE       =
+SEARCHENGINE           = NO
+SERVER_BASED_SEARCH    = NO
+EXTERNAL_SEARCH        = NO
+SEARCHENGINE_URL       =
+SEARCHDATA_FILE        = searchdata.xml
+EXTERNAL_SEARCH_ID     =
+EXTRA_SEARCH_MAPPINGS  =
 #---------------------------------------------------------------------------
-# configuration options related to the LaTeX output
+# Configuration options related to the LaTeX output
 #---------------------------------------------------------------------------
 GENERATE_LATEX         = NO
 LATEX_OUTPUT           = latex
 LATEX_CMD_NAME         = latex
 MAKEINDEX_CMD_NAME     = makeindex
+LATEX_MAKEINDEX_CMD    = makeindex
 COMPACT_LATEX          = NO
 PAPER_TYPE             = a4
 EXTRA_PACKAGES         =
 LATEX_HEADER           =
+LATEX_FOOTER           =
+LATEX_EXTRA_STYLESHEET =
+LATEX_EXTRA_FILES      =
 PDF_HYPERLINKS         = NO
 USE_PDFLATEX           = NO
 LATEX_BATCHMODE        = NO
 LATEX_HIDE_INDICES     = NO
+LATEX_BIB_STYLE        = plain
+LATEX_TIMESTAMP        = NO
+LATEX_EMOJI_DIRECTORY  =
 #---------------------------------------------------------------------------
-# configuration options related to the RTF output
+# Configuration options related to the RTF output
 #---------------------------------------------------------------------------
 GENERATE_RTF           = NO
 RTF_OUTPUT             = rtf
@@ -167,24 +265,31 @@ RTF_HYPERLINKS         = NO
 RTF_STYLESHEET_FILE    =
 RTF_EXTENSIONS_FILE    =
 #---------------------------------------------------------------------------
-# configuration options related to the man page output
+# Configuration options related to the man page output
 #---------------------------------------------------------------------------
 GENERATE_MAN           = NO
 MAN_OUTPUT             = man
 MAN_EXTENSION          = .3
+MAN_SUBDIR             =
 MAN_LINKS              = NO
 #---------------------------------------------------------------------------
-# configuration options related to the XML output
+# Configuration options related to the XML output
 #---------------------------------------------------------------------------
 GENERATE_XML           = NO
 XML_OUTPUT             = xml
 XML_PROGRAMLISTING     = YES
+XML_NS_MEMB_FILE_SCOPE = NO
 #---------------------------------------------------------------------------
-# configuration options for the AutoGen Definitions output
+# Configuration options related to the DOCBOOK output
+#---------------------------------------------------------------------------
+GENERATE_DOCBOOK       = NO
+DOCBOOK_OUTPUT         = docbook
+#---------------------------------------------------------------------------
+# Configuration options for the AutoGen Definitions output
 #---------------------------------------------------------------------------
 GENERATE_AUTOGEN_DEF   = NO
 #---------------------------------------------------------------------------
-# configuration options related to the Perl module output
+# Configuration options related to the Perl module output
 #---------------------------------------------------------------------------
 GENERATE_PERLMOD       = NO
 PERLMOD_LATEX          = NO
@@ -203,22 +308,30 @@ PREDEFINED             = DOXYGEN_API
 EXPAND_AS_DEFINED      = DEF_COMMAND
 SKIP_FUNCTION_MACROS   = YES
 #---------------------------------------------------------------------------
-# Configuration::additions related to external references
+# Configuration options related to external references
 #---------------------------------------------------------------------------
 TAGFILES               =
 GENERATE_TAGFILE       = ${CPACK_BINARY_DIR}/docs/openttd_gs_api.tag
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
+EXTERNAL_PAGES         = YES
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
-CLASS_DIAGRAMS         = YES
+DIA_PATH               =
 HIDE_UNDOC_RELATIONS   = YES
 HAVE_DOT               = NO
+DOT_NUM_THREADS        = 0
+DOT_FONTNAME           = Helvetica
+DOT_FONTSIZE           = 10
+DOT_FONTPATH           =
 CLASS_GRAPH            = YES
 COLLABORATION_GRAPH    = YES
 GROUP_GRAPHS           = YES
 UML_LOOK               = NO
+UML_LIMIT_NUM_FIELDS   = 10
+DOT_UML_DETAILS        = NO
+DOT_WRAP_THRESHOLD     = 17
 TEMPLATE_RELATIONS     = NO
 INCLUDE_GRAPH          = YES
 INCLUDED_BY_GRAPH      = YES
@@ -226,16 +339,19 @@ CALL_GRAPH             = NO
 CALLER_GRAPH           = NO
 GRAPHICAL_HIERARCHY    = YES
 DIRECTORY_GRAPH        = YES
+DIR_GRAPH_MAX_DEPTH    = 1
 DOT_IMAGE_FORMAT       = png
+INTERACTIVE_SVG        = NO
 DOT_PATH               =
 DOTFILE_DIRS           =
+MSCFILE_DIRS           =
+DIAFILE_DIRS           =
+PLANTUML_JAR_PATH      =
+PLANTUML_CFG_FILE      =
+PLANTUML_INCLUDE_PATH  =
 DOT_GRAPH_MAX_NODES    = 50
 MAX_DOT_GRAPH_DEPTH    = 1000
 DOT_TRANSPARENT        = NO
 DOT_MULTI_TARGETS      = NO
 GENERATE_LEGEND        = NO
 DOT_CLEANUP            = YES
-#---------------------------------------------------------------------------
-# Configuration::additions related to the search engine
-#---------------------------------------------------------------------------
-SEARCHENGINE           = NO

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -6,7 +6,7 @@
  */
 
 /**
- * @file ai_changelog.hpp Lists all changes / additions to the API.
+ * @page ai_changelog Lists all changes / additions to the API.
  *
  * Only new / renamed / deleted api functions will be listed here. A list of
  * bug fixes can be found in the normal changelog. Note that removed API
@@ -456,4 +456,18 @@
  *
  * \b 0.7.0
  * \li First stable release with the NoAI framework.
+ */
+
+/**
+ * @mainpage
+ *
+ * What's new?
+ * \li \ref ai_changelog
+ *
+ * Main classes:
+ * \li \ref AIInfo
+ * \li \ref AIController
+ *
+ * Detail topics:
+ * \li \ref script_ids
  */

--- a/src/script/api/doxygen_filter.awk
+++ b/src/script/api/doxygen_filter.awk
@@ -24,7 +24,10 @@ BEGIN {
 }
 
 {
+	# replace Script with AI/GS, except for ScriptErrorType
 	gsub(/Script/, api)
+	gsub(/AIErrorType/, "ScriptErrorType")
+	gsub(/GSErrorType/, "ScriptErrorType")
 }
 
 {
@@ -245,7 +248,7 @@ BEGIN {
 }
 
 # Add a const (non-enum) value
-/^[ 	]*static const \w+ \w+ = -?\(?\w*\)?\w+;/ {
+/^[ 	]*static const \w+ \w+ = [^;]+;/ {
 	if (api_selected == "") api_selected = cls_in_api
 	if (api_selected == "false") {
 		api_selected = ""

--- a/src/script/api/doxygen_filter.awk
+++ b/src/script/api/doxygen_filter.awk
@@ -136,6 +136,16 @@ BEGIN {
 	next
 }
 
+# Convert/unify type names
+{
+	gsub(/\<SQInteger\>/, "int")
+	gsub(/\<SquirrelTable\>/, "table")
+	gsub(/\<u?int[0-9]*(_t)?\>/, "int")
+	gsub(/\<HSQOBJECT\>/, "object")
+	gsub(/std::optional<std::string>/, "string")
+	gsub(/(const )?std::string *[*&]?/, "string ")
+}
+
 # Store comments
 /\/\*\*.*\*\//   { comment_buffer = $0; comment = "false"; next; }
 /\/\*.*\*\//     { comment_buffer = ""; comment = "false"; next; }

--- a/src/script/api/doxygen_filter.sh
+++ b/src/script/api/doxygen_filter.sh
@@ -21,6 +21,7 @@ fi
 case $2 in
 	*ai_changelog.hpp) cat $2; exit 0;;
 	*game_changelog.hpp) cat $2; exit 0;;
+	*script_types.hpp) cat $2; exit 0;;
 esac
 
 ${AWK} -v api=$1 -f doxygen_filter.awk $2

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -6,7 +6,7 @@
  */
 
 /**
- * @file game_changelog.hpp Lists all changes / additions to the API.
+ * @page game_changelog Lists all changes / additions to the API.
  *
  * Only new / renamed / deleted api functions will be listed here. A list of
  * bug fixes can be found in the normal changelog. Note that removed API
@@ -300,4 +300,18 @@
  *
  * \b 1.2.0
  * \li First stable release with the NoGo framework.
+ */
+
+/**
+ * @mainpage
+ *
+ * What's new?
+ * \li \ref game_changelog
+ *
+ * Main classes:
+ * \li \ref GSInfo
+ * \li \ref GSController
+ *
+ * Detail topics:
+ * \li \ref script_ids
  */

--- a/src/script/api/script_admin.hpp
+++ b/src/script/api/script_admin.hpp
@@ -27,13 +27,13 @@ public:
 	/**
 	 * Send information to the AdminPort. The information can be anything
 	 *  as long as it isn't a class or instance thereof.
-	 * @param table The information to send, in a table. For example: { param = "param" }.
+	 * @param data The information to send, in a table. For example: { param = "param" }.
 	 * @return True if and only if the data was successfully converted to JSON
 	 *  and send to the AdminPort.
 	 * @note If the resulting JSON of your table is larger than 1450 bytes,
 	 *   nothing will be sent (and false will be returned).
 	 */
-	static bool Send(void *table);
+	static bool Send(table data);
 #endif /* DOXYGEN_API */
 };
 

--- a/src/script/api/script_airport.hpp
+++ b/src/script/api/script_airport.hpp
@@ -204,7 +204,8 @@ public:
 	 * Get the monthly maintenance cost of an airport type.
 	 * @param type The airport type to get the monthly maintenance cost of.
 	 * @pre IsAirportInformationAvailable(type)
-	 * @return Monthly maintenance cost of the airport type.
+	 * @return Maintenance cost of the airport type per economy-month.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static Money GetMonthlyMaintenanceCost(AirportType type);
 

--- a/src/script/api/script_basestation.hpp
+++ b/src/script/api/script_basestation.hpp
@@ -68,9 +68,10 @@ public:
 	static TileIndex GetLocation(StationID station_id);
 
 	/**
-	 * Get the last date a station part was added to this station.
+	 * Get the last calendar-date a station part was added to this station.
 	 * @param station_id The station to look at.
-	 * @return The last date some part of this station was build.
+	 * @return The last calendar-date some part of this station was build.
+	 * @see \ref ScriptCalendarTime
 	 */
 	static ScriptDate::Date GetConstructionDate(StationID station_id);
 };

--- a/src/script/api/script_bridge.hpp
+++ b/src/script/api/script_bridge.hpp
@@ -20,6 +20,8 @@ class ScriptBridge : public ScriptObject {
 public:
 	/**
 	 * All bridge related error messages.
+	 *
+	 * @see ScriptErrorType
 	 */
 	enum ErrorMessages {
 		/** Base for bridge related errors */

--- a/src/script/api/script_client.hpp
+++ b/src/script/api/script_client.hpp
@@ -56,10 +56,11 @@ public:
 	static ScriptCompany::CompanyID GetCompany(ClientID client);
 
 	/**
-	 * Get the game date when the given client has joined.
+	 * Get the economy-date when the given client has joined.
 	 * @param client The client to get joining date for.
 	 * @pre ResolveClientID(client) != CLIENT_INVALID.
-	 * @return The date when client has joined.
+	 * @return The economy-date when client has joined.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static ScriptDate::Date GetJoinDate(ClientID client);
 };

--- a/src/script/api/script_company.hpp
+++ b/src/script/api/script_company.hpp
@@ -281,59 +281,64 @@ public:
 	static bool ChangeBankBalance(CompanyID company, Money delta, ExpensesType expenses_type, TileIndex tile);
 
 	/**
-	 * Get the income of the company in the given quarter.
+	 * Get the income of the company in the given economy-quarter.
 	 * Note that this function only considers recurring income from vehicles;
 	 * it does not include one-time income from selling stuff.
 	 * @param company The company to get the quarterly income of.
-	 * @param quarter The quarter to get the income of.
+	 * @param quarter The economy-quarter to get the income of.
 	 * @pre ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @pre quarter <= EARLIEST_QUARTER.
-	 * @return The gross income of the company in the given quarter.
+	 * @return The gross income of the company in the given economy-quarter.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static Money GetQuarterlyIncome(CompanyID company, SQInteger quarter);
 
 	/**
-	 * Get the expenses of the company in the given quarter.
+	 * Get the expenses of the company in the given economy-quarter.
 	 * Note that this function only considers recurring expenses from vehicle
 	 * running cost, maintenance and interests; it does not include one-time
 	 * expenses from construction and buying stuff.
 	 * @param company The company to get the quarterly expenses of.
-	 * @param quarter The quarter to get the expenses of.
+	 * @param quarter The economy-quarter to get the expenses of.
 	 * @pre ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @pre quarter <= EARLIEST_QUARTER.
-	 * @return The expenses of the company in the given quarter.
+	 * @return The expenses of the company in the given economy-quarter.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static Money GetQuarterlyExpenses(CompanyID company, SQInteger quarter);
 
 	/**
-	 * Get the amount of cargo delivered by the given company in the given quarter.
+	 * Get the amount of cargo delivered by the given company in the given economy-quarter.
 	 * @param company The company to get the amount of delivered cargo of.
-	 * @param quarter The quarter to get the amount of delivered cargo of.
+	 * @param quarter The economy-quarter to get the amount of delivered cargo of.
 	 * @pre ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @pre quarter <= EARLIEST_QUARTER.
-	 * @return The amount of cargo delivered by the given company in the given quarter.
+	 * @return The amount of cargo delivered by the given company in the given economy-quarter.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static SQInteger GetQuarterlyCargoDelivered(CompanyID company, SQInteger quarter);
 
 	/**
-	 * Get the performance rating of the given company in the given quarter.
+	 * Get the performance rating of the given company in the given economy-quarter.
 	 * @param company The company to get the performance rating of.
-	 * @param quarter The quarter to get the performance rating of.
+	 * @param quarter The economy-quarter to get the performance rating of.
 	 * @pre ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @pre quarter <= EARLIEST_QUARTER.
 	 * @pre quarter != CURRENT_QUARTER.
-	 * @note The performance rating is calculated after every quarter, so the value for CURRENT_QUARTER is undefined.
-	 * @return The performance rating of the given company in the given quarter.
+	 * @note The performance rating is calculated after every economy-quarter, so the value for CURRENT_QUARTER is undefined.
+	 * @return The performance rating of the given company in the given economy-quarter.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static SQInteger GetQuarterlyPerformanceRating(CompanyID company, SQInteger quarter);
 
 	/**
-	 * Get the value of the company in the given quarter.
+	 * Get the value of the company in the given economy-quarter.
 	 * @param company The company to get the value of.
-	 * @param quarter The quarter to get the value of.
+	 * @param quarter The economy-quarter to get the value of.
 	 * @pre ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @pre quarter <= EARLIEST_QUARTER.
-	 * @return The value of the company in the given quarter.
+	 * @return The value of the company in the given economy-quarter.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static Money GetQuarterlyCompanyValue(CompanyID company, SQInteger quarter);
 
@@ -377,10 +382,11 @@ public:
 
 	/**
 	 * Set the number of months before/after max age to autorenew an engine for your company.
-	 * @param months The new months between autorenew.
+	 * @param months The number of calendar-months before/after max age of engine.
 	 *               The value will be clamped to MIN(int16_t) .. MAX(int16_t).
 	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if autorenew months has been modified.
+	 * @see \ref ScriptCalendarTime
 	 */
 	static bool SetAutoRenewMonths(SQInteger months);
 
@@ -388,7 +394,8 @@ public:
 	 * Return the number of months before/after max age to autorenew an engine for a company.
 	 * @param company The company to get the autorenew months of.
 	 * @pre ResolveCompanyID(company) != COMPANY_INVALID.
-	 * @return The months before/after max age of engine.
+	 * @return The number of calendar-months before/after max age of engine.
+	 * @see \ref ScriptCalendarTime
 	 */
 	static SQInteger GetAutoRenewMonths(CompanyID company);
 

--- a/src/script/api/script_companymode.hpp
+++ b/src/script/api/script_companymode.hpp
@@ -52,7 +52,7 @@ public:
 	 * Check whether a company mode is valid. In other words, are commands
 	 * being executed under some company and does the company still exist?
 	 * @return true When a company mode is valid.
-	 * @post !ScriptCompanyMode::IsDeity().
+	 * @post If IsValid() is true, then IsDeity() is false.
 	 */
 	static bool IsValid();
 
@@ -60,7 +60,7 @@ public:
 	 * Check whether the company mode is not active, i.e. whether we are a deity.
 	 * In other words, are commands are not being executed under some company.
 	 * @return true When we are a deity, i.e. company mode is not active.
-	 * @post !ScriptCompanyMode::IsValid().
+	 * @post if IsDeity() is true, then IsValid() is false.
 	 */
 	static bool IsDeity();
 };

--- a/src/script/api/script_controller.hpp
+++ b/src/script/api/script_controller.hpp
@@ -92,7 +92,7 @@ public:
 	 *
 	 * @return Data of the script that should be stored in the save game.
 	 */
-	SquirrelTable Save();
+	table Save();
 
 	/**
 	 * Load saved data just before calling #Start.
@@ -100,7 +100,7 @@ public:
 	 * @param version Version number of the script that created the \a data.
 	 * @param data Data that was saved (return value of #Save).
 	 */
-	void Load(int version, SquirrelTable data);
+	void Load(int version, table data);
 #endif /* DOXYGEN_API */
 
 	/**

--- a/src/script/api/script_date.hpp
+++ b/src/script/api/script_date.hpp
@@ -23,6 +23,30 @@
  * @note Dates can be used to determine the number of days between
  *       two different moments in time because they count the number
  *       of days since the year 0.
+ *
+ * \anchor ScriptCalendarTime
+ * \b Calendar-Time
+ *
+ * Calendar time measures the technological progression in the game.
+ * \li The calendar date is shown in the status bar.
+ * \li The calendar date affects engine model introduction and expiration.
+ * \li Progression of calendar time can be slowed or even halted via game settings.
+ *
+ * Calendar time uses the Gregorian calendar with 365 or 366 days per year.
+ *
+ * \anchor ScriptEconomyTime
+ * \b Economy-Time
+ *
+ * Economy time measures the in-game time progression, while the game is not paused.
+ * \li Cargo production and consumption follows economy time.
+ * \li Recurring income and expenses follow economy time.
+ * \li Production and income statistics and balances are created per economy month/quarter/year.
+ *
+ * Depending on game settings economy time is represented differently:
+ * \li Calendar-based timekeeping: Economy- and calendar-time use the identical Gregorian calendar.
+ * \li Wallclock-based timekeeping: Economy- and calendar-time are separate.
+ *     Economy-time will use a 360 day calendar (12 months with 30 days each), which runs at a constant speed of one economy-month per realtime-minute.
+ *     Calendar-time will use a Gregorian calendar, which can be slowed to stopped via game settings.
  */
 class ScriptDate : public ScriptObject {
 public:

--- a/src/script/api/script_engine.hpp
+++ b/src/script/api/script_engine.hpp
@@ -125,8 +125,8 @@ public:
 	 * Get the maximum age of a brand new engine.
 	 * @param engine_id The engine to get the maximum age of.
 	 * @pre IsValidEngine(engine_id).
-	 * @returns The maximum age of a new engine in days.
-	 * @note Age is in days; divide by 366 to get per year.
+	 * @returns The maximum age of a new engine in calendar-days.
+	 * @see \ref ScriptCalendarTime
 	 */
 	static SQInteger GetMaxAge(EngineID engine_id);
 
@@ -134,8 +134,8 @@ public:
 	 * Get the running cost of an engine.
 	 * @param engine_id The engine to get the running cost of.
 	 * @pre IsValidEngine(engine_id).
-	 * @return The running cost of a vehicle per year.
-	 * @note Cost is per year; divide by 365 to get per day.
+	 * @return The running cost of a vehicle per economy-year.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static Money GetRunningCost(EngineID engine_id);
 
@@ -167,10 +167,11 @@ public:
 	static SQInteger GetMaxTractiveEffort(EngineID engine_id);
 
 	/**
-	 * Get the date this engine was designed.
+	 * Get the calendar-date this engine was designed.
 	 * @param engine_id The engine to get the design date of.
 	 * @pre IsValidEngine(engine_id).
-	 * @return The date this engine was designed.
+	 * @return The calendar-date this engine was designed.
+	 * @see \ref ScriptCalendarTime
 	 */
 	static ScriptDate::Date GetDesignDate(EngineID engine_id);
 

--- a/src/script/api/script_error.hpp
+++ b/src/script/api/script_error.hpp
@@ -120,6 +120,8 @@ public:
 
 	/**
 	 * All general related error messages.
+	 *
+	 * @see ScriptErrorType
 	 */
 	enum ErrorMessages {
 		/** Initial error value */

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -272,8 +272,8 @@ public:
 
 	/**
 	 * Get the running cost of the offered engine.
-	 * @return The running cost of the vehicle per year.
-	 * @note Cost is per year; divide by 365 to get per day.
+	 * @return The running cost of the vehicle per economy-year.
+	 * @see \ref ScriptEconomyTime
 	 */
 	Money GetRunningCost();
 

--- a/src/script/api/script_group.hpp
+++ b/src/script/api/script_group.hpp
@@ -222,7 +222,8 @@ public:
 	 * Get the current profit of a group.
 	 * @param group_id The group to get the profit of.
 	 * @pre IsValidGroup(group_id).
-	 * @return The current profit the group has.
+	 * @return The profit the vehicles in this group have made this economy-year so far.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static Money GetProfitThisYear(GroupID group_id);
 
@@ -230,7 +231,8 @@ public:
 	 * Get the profit of last year of a group.
 	 * @param group_id The group to get the profit of.
 	 * @pre IsValidGroup(group_id).
-	 * @return The current profit the group had last year.
+	 * @return The profit the vehicles in this group  made in the previous economy-year.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static Money GetProfitLastYear(GroupID group_id);
 

--- a/src/script/api/script_grouplist.hpp
+++ b/src/script/api/script_grouplist.hpp
@@ -29,20 +29,22 @@ public:
 	/**
 	 * Apply a filter when building the list.
 	 * @param filter_function The function which will be doing the filtering.
-	 * @param params The params to give to the filters (minus the first param,
+	 * @param ... The params to give to the filters (minus the first param,
 	 *  which is always the index-value).
 	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @note You can write your own filters and use them. Just remember that
 	 *  the first parameter should be the index-value, and it should return
 	 *  a bool.
 	 * @note Example:
+	 * @code
 	 *  function IsType(group_id, type)
 	 *  {
 	 *    return ScriptGroup.GetVehicleType(group_id) == type;
 	 *  }
-	 *  ScriptGroupList(IsType, ScriptVehicle.VT_ROAD);
+	 *  local rv_groups = ScriptGroupList(IsType, ScriptVehicle.VT_ROAD);
+	 * @endcode
 	 */
-	ScriptGroupList(void *filter_function, int params, ...);
+	ScriptGroupList(function filter_function, ...);
 #else
 	/**
 	 * The constructor wrapper from Squirrel.

--- a/src/script/api/script_industry.hpp
+++ b/src/script/api/script_industry.hpp
@@ -86,10 +86,11 @@ public:
 	static std::optional<std::string> GetName(IndustryID industry_id);
 
 	/**
-	 * Get the construction date of an industry.
+	 * Get the construction calendar-date of an industry.
 	 * @param industry_id The index of the industry.
 	 * @pre IsValidIndustry(industry_id).
-	 * @return Date the industry was constructed.
+	 * @return Calendar-date the industry was constructed.
+	 * @see \ref ScriptCalendarTime
 	 * @api -ai
 	 */
 	static ScriptDate::Date GetConstructionDate(IndustryID industry_id);
@@ -126,32 +127,35 @@ public:
 	static SQInteger GetStockpiledCargo(IndustryID industry_id, CargoID cargo_id);
 
 	/**
-	 * Get the total last month's production of the given cargo at an industry.
+	 * Get the total last economy-month's production of the given cargo at an industry.
 	 * @param industry_id The index of the industry.
 	 * @param cargo_id The index of the cargo.
 	 * @pre IsValidIndustry(industry_id).
 	 * @pre ScriptCargo::IsValidCargo(cargo_id).
-	 * @return The last month's production of the given cargo for this industry.
+	 * @return The last economy-month's production of the given cargo for this industry.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static SQInteger GetLastMonthProduction(IndustryID industry_id, CargoID cargo_id);
 
 	/**
-	 * Get the total amount of cargo transported from an industry last month.
+	 * Get the total amount of cargo transported from an industry last economy-month.
 	 * @param industry_id The index of the industry.
 	 * @param cargo_id The index of the cargo.
 	 * @pre IsValidIndustry(industry_id).
 	 * @pre ScriptCargo::IsValidCargo(cargo_id).
-	 * @return The amount of given cargo transported from this industry last month.
+	 * @return The amount of given cargo transported from this industry last economy-month.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static SQInteger GetLastMonthTransported(IndustryID industry_id, CargoID cargo_id);
 
 	/**
-	 * Get the percentage of cargo transported from an industry last month.
+	 * Get the percentage of cargo transported from an industry last economy-month.
 	 * @param industry_id The index of the industry.
 	 * @param cargo_id The index of the cargo.
 	 * @pre IsValidIndustry(industry_id).
 	 * @pre ScriptCargo::IsValidCargo(cargo_id).
-	 * @return The percentage of given cargo transported from this industry last month.
+	 * @return The percentage of given cargo transported from this industry last economy-month.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static SQInteger GetLastMonthTransportedPercentage(IndustryID industry_id, CargoID cargo_id);
 
@@ -246,21 +250,23 @@ public:
 	static IndustryType GetIndustryType(IndustryID industry_id);
 
 	/**
-	 * Get the last year this industry had any production output.
+	 * Get the last economy-year this industry had any production output.
 	 * @param industry_id The index of the industry.
 	 * @pre IsValidIndustry(industry_id).
-	 * @return Year the industry last had production, 0 if error.
+	 * @return Economy-year the industry last had production, 0 if error.
+	 * @see \ref ScriptEconomyTime
 	 * @api -ai
 	 */
 	static SQInteger GetLastProductionYear(IndustryID industry_id);
 
 	/**
-	 * Get the last date this industry accepted any cargo delivery.
+	 * Get the last economy-date this industry accepted any cargo delivery.
 	 * @param industry_id The index of the industry.
 	 * @param cargo_type The cargo to query, or INVALID_CARGO to query latest of all accepted cargoes.
 	 * @pre IsValidIndustry(industry_id).
 	 * @pre IsValidCargo(cargo_type) || cargo_type == INVALID_CARGO.
-	 * @return Date the industry last received cargo from a delivery, or ScriptDate::DATE_INVALID on error.
+	 * @return Economy-date the industry last received cargo from a delivery, or ScriptDate::DATE_INVALID on error.
+	 * @see \ref ScriptEconomyTime
 	 * @api -ai
 	 */
 	static ScriptDate::Date GetCargoLastAcceptedDate(IndustryID industry_id, CargoID cargo_type);

--- a/src/script/api/script_industrylist.hpp
+++ b/src/script/api/script_industrylist.hpp
@@ -25,20 +25,23 @@ public:
 	/**
 	 * Apply a filter when building the list.
 	 * @param filter_function The function which will be doing the filtering.
-	 * @param params The params to give to the filters (minus the first param,
+	 * @param ... The params to give to the filters (minus the first param,
 	 *  which is always the index-value).
 	 * @note You can write your own filters and use them. Just remember that
 	 *  the first parameter should be the index-value, and it should return
 	 *  a bool.
 	 * @note Example:
-	 *  ScriptIndustryList(ScriptIndustry.HasDock);
+	 * @code
+	 *  local water_industries = ScriptIndustryList(ScriptIndustry.HasDock);
+	 *
 	 *  function IsType(industry_id, type)
 	 *  {
 	 *    return ScriptIndustry.GetIndustryType(industry_id) == type;
 	 *  }
-	 *  ScriptIndustryList(IsType, 0);
+	 *  local industries = ScriptIndustryList(IsType, 0);
+	 * @endcode
 	 */
-	ScriptIndustryList(void *filter_function, int params, ...);
+	ScriptIndustryList(function filter_function, ...);
 #else
 	/**
 	 * The constructor wrapper from Squirrel.

--- a/src/script/api/script_info_docs.hpp
+++ b/src/script/api/script_info_docs.hpp
@@ -252,5 +252,5 @@ public:
 	 * @note This is a function provided by OpenTTD, you don't have to
 	 * include it in your Script but should just call it from GetSettings.
 	 */
-	void AddLabels(const char *setting_name, table value_names);
+	void AddLabels(string setting_name, table value_names);
 };

--- a/src/script/api/script_infrastructure.hpp
+++ b/src/script/api/script_infrastructure.hpp
@@ -58,7 +58,8 @@ public:
 	 * Return the monthly maintenance costs of a specific rail type for a company.
 	 * @param company The company to get the monthly cost for.
 	 * @param railtype Rail type to get the cost of.
-	 * @return Monthly maintenance cost for the rail type.
+	 * @return Maintenance cost for the rail type per economy-month.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static Money GetMonthlyRailCosts(ScriptCompany::CompanyID company, ScriptRail::RailType railtype);
 
@@ -66,7 +67,8 @@ public:
 	 * Return the monthly maintenance costs of a specific road type for a company.
 	 * @param company The company to get the monthly cost for.
 	 * @param roadtype Road type to get the cost of.
-	 * @return Monthly maintenance cost for the road type.
+	 * @return Maintenance cost for the road type per economy-month.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static Money GetMonthlyRoadCosts(ScriptCompany::CompanyID company, ScriptRoad::RoadType roadtype);
 
@@ -74,8 +76,9 @@ public:
 	 * Return the monthly maintenance costs of an infrastructure category for a company.
 	 * @param company The company to get the monthly cost for.
 	 * @param infra_type Infrastructure category to get the cost of.
-	 * @return Monthly maintenance cost for the wanted category.
+	 * @return Maintenance cost for the wanted category per economy-month.
 	 * @note #INFRASTRUCTURE_RAIL and #INFRASTRUCTURE_ROAD return the total cost for all rail/road types.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static Money GetMonthlyInfrastructureCosts(ScriptCompany::CompanyID company, Infrastructure infra_type);
 };

--- a/src/script/api/script_league.cpp
+++ b/src/script/api/script_league.cpp
@@ -49,7 +49,7 @@
 	return ::LeagueTableElement::IsValidID(element_id);
 }
 
-/* static */ ScriptLeagueTable::LeagueTableElementID ScriptLeagueTable::NewElement(ScriptLeagueTable::LeagueTableID table, SQInteger rating, ScriptCompany::CompanyID company, Text *text, Text *score, LinkType link_type, LinkTargetID link_target)
+/* static */ ScriptLeagueTable::LeagueTableElementID ScriptLeagueTable::NewElement(ScriptLeagueTable::LeagueTableID table, SQInteger rating, ScriptCompany::CompanyID company, Text *text, Text *score, LinkType link_type, SQInteger link_target)
 {
 	CCountedPtr<Text> text_counter(text);
 	CCountedPtr<Text> score_counter(score);
@@ -78,7 +78,7 @@
 	return (ScriptLeagueTable::LeagueTableElementID)0;
 }
 
-/* static */ bool ScriptLeagueTable::UpdateElementData(LeagueTableElementID element, ScriptCompany::CompanyID company, Text *text, LinkType link_type, LinkTargetID link_target)
+/* static */ bool ScriptLeagueTable::UpdateElementData(LeagueTableElementID element, ScriptCompany::CompanyID company, Text *text, LinkType link_type, SQInteger link_target)
 {
 	CCountedPtr<Text> text_counter(text);
 

--- a/src/script/api/script_league.hpp
+++ b/src/script/api/script_league.hpp
@@ -92,7 +92,7 @@ public:
 	 * @pre score != null && len(score) != 0.
 	 * @pre IsValidLink(Link(link_type, link_target)).
 	 */
-	static LeagueTableElementID NewElement(LeagueTableID table, SQInteger rating, ScriptCompany::CompanyID company, Text *text, Text *score, LinkType link_type, LinkTargetID link_target);
+	static LeagueTableElementID NewElement(LeagueTableID table, SQInteger rating, ScriptCompany::CompanyID company, Text *text, Text *score, LinkType link_type, SQInteger link_target);
 
 	/**
 	 * Update the attributes of a league table element.
@@ -107,7 +107,7 @@ public:
 	 * @pre text != null && len(text) != 0.
 	 * @pre IsValidLink(Link(link_type, link_target)).
 	 */
-	static bool UpdateElementData(LeagueTableElementID element, ScriptCompany::CompanyID company, Text *text, LinkType link_type, LinkTargetID link_target);
+	static bool UpdateElementData(LeagueTableElementID element, ScriptCompany::CompanyID company, Text *text, LinkType link_type, SQInteger link_target);
 
 	/**
 	 * Create a new league table element.

--- a/src/script/api/script_list.hpp
+++ b/src/script/api/script_list.hpp
@@ -370,7 +370,7 @@ public:
 	/**
 	 * Give all items a value defined by the valuator you give.
 	 * @param valuator_function The function which will be doing the valuation.
-	 * @param params The params to give to the valuators (minus the first param,
+	 * @param ... The params to give to the valuators (minus the first param,
 	 *  which is always the index-value we are valuating).
 	 * @note You may not add, remove or change (setting the value of) items while
 	 *  valuating. You may also not (re)sort while valuating.
@@ -378,6 +378,7 @@ public:
 	 *  the first parameter should be the index-value, and it should return
 	 *  an integer.
 	 * @note Example:
+	 * @code
 	 *  list.Valuate(ScriptBridge.GetPrice, 5);
 	 *  list.Valuate(ScriptBridge.GetMaxLength);
 	 *  function MyVal(bridge_id, myparam)
@@ -385,8 +386,9 @@ public:
 	 *    return myparam * bridge_id; // This is silly
 	 *  }
 	 *  list.Valuate(MyVal, 12);
+	 * @endcode
 	 */
-	void Valuate(void *valuator_function, int params, ...);
+	void Valuate(function valuator_function, ...);
 #endif /* DOXYGEN_API */
 };
 

--- a/src/script/api/script_marine.hpp
+++ b/src/script/api/script_marine.hpp
@@ -20,6 +20,8 @@ class ScriptMarine : public ScriptObject {
 public:
 	/**
 	 * All marine related error messages.
+	 *
+	 * @see ScriptErrorType
 	 */
 	enum ErrorMessages {
 		/** Base for marine related errors */

--- a/src/script/api/script_order.hpp
+++ b/src/script/api/script_order.hpp
@@ -21,6 +21,8 @@ class ScriptOrder : public ScriptObject {
 public:
 	/**
 	 * All order related error messages.
+	 *
+	 * @see ScriptErrorType
 	 */
 	enum ErrorMessages {
 		/** Base for all order related errors */

--- a/src/script/api/script_order.hpp
+++ b/src/script/api/script_order.hpp
@@ -93,10 +93,10 @@ public:
 		OC_RELIABILITY         = ::OCV_RELIABILITY,        ///< Skip based on the reliability, value is percent (0..100).
 		OC_MAX_RELIABILITY     = ::OCV_MAX_RELIABILITY,    ///< Skip based on the maximum reliability.  Value in percent
 		OC_MAX_SPEED           = ::OCV_MAX_SPEED,          ///< Skip based on the maximum speed, value is in OpenTTD's internal speed unit, see ScriptEngine::GetMaxSpeed.
-		OC_AGE                 = ::OCV_AGE,                ///< Skip based on the age, value is in years.
+		OC_AGE                 = ::OCV_AGE,                ///< Skip based on the age, value is in calender-years. @see \ref ScriptCalendarTime
 		OC_REQUIRES_SERVICE    = ::OCV_REQUIRES_SERVICE,   ///< Skip when the vehicle requires service, no value.
 		OC_UNCONDITIONALLY     = ::OCV_UNCONDITIONALLY,    ///< Always skip, no compare function, no value.
-		OC_REMAINING_LIFETIME  = ::OCV_REMAINING_LIFETIME, ///< Skip based on the remaining lifetime
+		OC_REMAINING_LIFETIME  = ::OCV_REMAINING_LIFETIME, ///< Skip based on the remaining lifetime in calendar-years. @see \ref ScriptCalendarTime
 
 		/* Custom added value, only valid for this API */
 		OC_INVALID             = -1,                       ///< An invalid condition, do not use.

--- a/src/script/api/script_priorityqueue.hpp
+++ b/src/script/api/script_priorityqueue.hpp
@@ -42,21 +42,21 @@ public:
 	 * @param priority The priority to assign the item.
 	 * @return True if the item was inserted, false if it was already in the queue.
 	 */
-	bool Insert(void *item, SQInteger priority);
+	bool Insert(object item, SQInteger priority);
 
 	/**
 	 * Remove and return the item with the lowest priority.
 	 * @return The item with the lowest priority, removed from the queue. Returns null on an empty queue.
 	 * @pre !IsEmpty()
 	 */
-	void *Pop();
+	object Pop();
 
 	/**
 	 * Get the item with the lowest priority, keeping it in the queue.
 	 * @return The item with the lowest priority. Returns null on an empty queue.
 	 * @pre !IsEmpty()
 	 */
-	void *Peek();
+	object Peek();
 
 	/**
 	 * Check if an items is already included in the queue.
@@ -64,7 +64,7 @@ public:
 	 * @return true if the items is already in the queue.
 	 * @note Performance is O(n), use only when absolutely required.
 	 */
-	bool Exists(void *item);
+	bool Exists(object item);
 
 	/**
 	 * Clear the queue, making Count() returning 0 and IsEmpty() returning true.

--- a/src/script/api/script_rail.hpp
+++ b/src/script/api/script_rail.hpp
@@ -22,6 +22,8 @@ class ScriptRail : public ScriptObject {
 public:
 	/**
 	 * All rail related error messages.
+	 *
+	 * @see ScriptErrorType
 	 */
 	enum ErrorMessages {
 		/** Base for rail building / maintaining errors */

--- a/src/script/api/script_road.hpp
+++ b/src/script/api/script_road.hpp
@@ -22,6 +22,8 @@ class ScriptRoad : public ScriptObject {
 public:
 	/**
 	 * All road related error messages.
+	 *
+	 * @see ScriptErrorType
 	 */
 	enum ErrorMessages {
 		/** Base for road building / maintaining errors */

--- a/src/script/api/script_sign.hpp
+++ b/src/script/api/script_sign.hpp
@@ -21,6 +21,8 @@ class ScriptSign : public ScriptObject {
 public:
 	/**
 	 * All sign related error messages.
+	 *
+	 * @see ScriptErrorType
 	 */
 	enum ErrorMessages {
 

--- a/src/script/api/script_signlist.hpp
+++ b/src/script/api/script_signlist.hpp
@@ -25,20 +25,22 @@ public:
 	/**
 	 * Apply a filter when building the list.
 	 * @param filter_function The function which will be doing the filtering.
-	 * @param params The params to give to the filters (minus the first param,
+	 * @param ... The params to give to the filters (minus the first param,
 	 *  which is always the index-value).
 	 * @note You can write your own filters and use them. Just remember that
 	 *  the first parameter should be the index-value, and it should return
 	 *  a bool.
 	 * @note Example:
+	 * @code
 	 *  function Contains(sign_id, str)
 	 *  {
 	 *    local name = ScriptSign.GetName(sign_id);
 	 *    return name != null && name.find(str) != null;
 	 *  }
-	 *  ScriptSignList(Contains, "something");
+	 *  local signs = ScriptSignList(Contains, "something");
+	 * @endcode
 	 */
-	ScriptSignList(void *filter_function, int params, ...);
+	ScriptSignList(function filter_function, ...);
 #else
 	ScriptSignList(HSQUIRRELVM);
 #endif /* DOXYGEN_API */

--- a/src/script/api/script_station.hpp
+++ b/src/script/api/script_station.hpp
@@ -22,6 +22,8 @@ class ScriptStation : public ScriptBaseStation {
 public:
 	/**
 	 * All station related error messages.
+	 *
+	 * @see ScriptErrorType
 	 */
 	enum ErrorMessages {
 		/** Base for station related errors */

--- a/src/script/api/script_story_page.hpp
+++ b/src/script/api/script_story_page.hpp
@@ -265,18 +265,20 @@ public:
 	/**
 	 * Get the page date which is displayed at the top of each page.
 	 * @param story_page_id The story page to get the date of.
-	 * @return The date
+	 * @return The calendar-date
 	 * @pre IsValidStoryPage(story_page_id).
+	 * @see \ref ScriptCalendarTime
 	 */
 	static ScriptDate::Date GetDate(StoryPageID story_page_id);
 
 	/**
 	 * Update date of a story page. The date is shown in the top left of the page
 	 * @param story_page_id The story page to set the date for.
-	 * @param date Date to display at the top of story page or ScriptDate::DATE_INVALID to disable showing date on this page. (also, @see ScriptDate)
+	 * @param date Calendar-date to display at the top of story page or ScriptDate::DATE_INVALID to disable showing date on this page. (also, @see ScriptDate)
 	 * @return True if the action succeeded.
 	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre IsValidStoryPage(story_page_id).
+	 * @see \ref ScriptCalendarTime
 	 */
 	static bool SetDate(StoryPageID story_page_id, ScriptDate::Date date);
 

--- a/src/script/api/script_story_page.hpp
+++ b/src/script/api/script_story_page.hpp
@@ -203,8 +203,8 @@ public:
 	 * @param reference A reference value to the object that is referred to by some page element types.
 	 *                  When type is SPET_GOAL, this is the goal ID.
 	 *                  When type is SPET_LOCATION, this is the TileIndex.
-	 *                  When type is a button, this is additional parameters for the button,
-	 *                  use the #BuildPushButtonReference, #BuildTileButtonReference, or #BuildVehicleButtonReference functions to make the values.
+	 *                  When type is a button, this is the ID returned by
+	 *                  #MakePushButtonReference, #MakeTileButtonReference, or #MakeVehicleButtonReference.
 	 * @param text The body text of page elements that allow custom text. (SPET_TEXT and SPET_LOCATION)
 	 * @return The new StoryPageElementID, or STORY_PAGE_ELEMENT_INVALID if it failed.
 	 * @pre ScriptCompanyMode::IsDeity().
@@ -329,14 +329,14 @@ public:
 
 	/**
 	* Check whether this is a valid story page button flag.
-	* @param colour The StoryPageButtonFlags to check.
+	* @param flags The StoryPageButtonFlags to check.
 	* @return True if and only if this story page button flag is valid.
 	*/
 	static bool IsValidStoryPageButtonFlags(StoryPageButtonFlags flags);
 
 	/**
 	 * Check whether this is a valid story page button cursor.
-	 * @param colour The StoryPageButtonCursor to check.
+	 * @param cursor The StoryPageButtonCursor to check.
 	 * @return True if and only if this story page button cursor is valid.
 	 */
 	static bool IsValidStoryPageButtonCursor(StoryPageButtonCursor cursor);

--- a/src/script/api/script_subsidy.cpp
+++ b/src/script/api/script_subsidy.cpp
@@ -54,15 +54,13 @@
 {
 	if (!IsValidSubsidy(subsidy_id)) return ScriptDate::DATE_INVALID;
 
-	int year = ScriptDate::GetYear(ScriptDate::GetCurrentDate());
-	int month = ScriptDate::GetMonth(ScriptDate::GetCurrentDate());
+	TimerGameEconomy::YearMonthDay ymd = TimerGameEconomy::ConvertDateToYMD(TimerGameEconomy::date);
+	ymd.day = 1;
+	auto m = ymd.month + ::Subsidy::Get(subsidy_id)->remaining;
+	ymd.month = (m - 1) % 12 + 1;
+	ymd.year += (m - 1) / 12;
 
-	month += ::Subsidy::Get(subsidy_id)->remaining;
-
-	year += (month - 1) / 12;
-	month = ((month - 1) % 12) + 1;
-
-	return ScriptDate::GetDate(year, month, 1);
+	return (ScriptDate::Date)TimerGameEconomy::ConvertYMDToDate(ymd.year, ymd.month, ymd.day).base();
 }
 
 /* static */ CargoID ScriptSubsidy::GetCargoType(SubsidyID subsidy_id)

--- a/src/script/api/script_subsidy.hpp
+++ b/src/script/api/script_subsidy.hpp
@@ -74,14 +74,15 @@ public:
 	static ScriptCompany::CompanyID GetAwardedTo(SubsidyID subsidy_id);
 
 	/**
-	 * Get the date this subsidy expires. In case the subsidy is already
-	 *  awarded, return the date the subsidy expires, else, return the date the
+	 * Get the economy-date this subsidy expires. In case the subsidy is already
+	 *  awarded, return the economy-date the subsidy expires, else, return the economy-date the
 	 *  offer expires.
 	 * @param subsidy_id The SubsidyID to check.
 	 * @pre IsValidSubsidy(subsidy_id).
-	 * @return The last valid date of this subsidy.
+	 * @return The last valid economy-date of this subsidy.
 	 * @note The return value of this function will change if the subsidy is
 	 *  awarded.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static ScriptDate::Date GetExpireDate(SubsidyID subsidy_id);
 

--- a/src/script/api/script_subsidylist.hpp
+++ b/src/script/api/script_subsidylist.hpp
@@ -25,19 +25,21 @@ public:
 	/**
 	 * Apply a filter when building the list.
 	 * @param filter_function The function which will be doing the filtering.
-	 * @param params The params to give to the filters (minus the first param,
+	 * @param ... The params to give to the filters (minus the first param,
 	 *  which is always the index-value).
 	 * @note You can write your own filters and use them. Just remember that
 	 *  the first parameter should be the index-value, and it should return
 	 *  a bool.
 	 * @note Example:
+	 * @code
 	 *  function IsType(subsidy_id, type)
 	 *  {
 	 *    return ScriptSubsidy.GetSourceType(subsidy_id) == type;
 	 *  }
-	 *  ScriptSubsidyList(IsType, ScriptSubsidy.SPT_TOWN);
+	 *  local town_subs = ScriptSubsidyList(IsType, ScriptSubsidy.SPT_TOWN);
+	 * @endcode
 	 */
-	ScriptSubsidyList(void *filter_function, int params, ...);
+	ScriptSubsidyList(function filter_function, ...);
 #else
 	ScriptSubsidyList(HSQUIRRELVM vm);
 #endif /* DOXYGEN_API */

--- a/src/script/api/script_text.hpp
+++ b/src/script/api/script_text.hpp
@@ -112,14 +112,14 @@ public:
 	 * @param parameter Which parameter to set.
 	 * @param value The value of the parameter. Has to be string, integer or an instance of the class ScriptText.
 	 */
-	void SetParam(int parameter, Object value);
+	void SetParam(int parameter, object value);
 
 	/**
 	 * Add a value as parameter (appending it).
 	 * @param value The value of the parameter. Has to be string, integer or an instance of the class ScriptText.
 	 * @return The same object as on which this is called, so you can chain.
 	 */
-	ScriptText *AddParam(Object value);
+	ScriptText *AddParam(object value);
 #endif /* DOXYGEN_API */
 
 	/**

--- a/src/script/api/script_tile.hpp
+++ b/src/script/api/script_tile.hpp
@@ -23,6 +23,8 @@ class ScriptTile : public ScriptObject {
 public:
 	/**
 	 * Error messages related to modifying tiles.
+	 *
+	 * @see ScriptErrorType
 	 */
 	enum ErrorMessages {
 

--- a/src/script/api/script_town.hpp
+++ b/src/script/api/script_town.hpp
@@ -48,7 +48,8 @@ public:
 		TOWN_ACTION_ADVERTISE_LARGE  = 2,
 
 		/**
-		 * Rebuild the roads of this town for 6 months.
+		 * Rebuild the roads of this town for 6 economy-months.
+		 * @see \ref ScriptEconomyTime
 		 */
 		TOWN_ACTION_ROAD_REBUILD     = 3,
 
@@ -58,12 +59,14 @@ public:
 		TOWN_ACTION_BUILD_STATUE     = 4,
 
 		/**
-		 * Fund the creation of extra buildings for 3 months.
+		 * Fund the creation of extra buildings for 3 economy-months.
+		 * @see \ref ScriptEconomyTime
 		 */
 		TOWN_ACTION_FUND_BUILDINGS   = 5,
 
 		/**
-		 * Buy exclusive rights for this town for 12 months.
+		 * Buy exclusive rights for this town for 12 economy-months.
+		 * @see \ref ScriptEconomyTime
 		 */
 		TOWN_ACTION_BUY_RIGHTS       = 6,
 
@@ -191,92 +194,100 @@ public:
 	static TileIndex GetLocation(TownID town_id);
 
 	/**
-	 * Get the total last month's production of the given cargo at a town.
+	 * Get the total last economy-month's production of the given cargo at a town.
 	 * @param town_id The index of the town.
 	 * @param cargo_id The index of the cargo.
 	 * @pre IsValidTown(town_id).
 	 * @pre ScriptCargo::IsValidCargo(cargo_id).
-	 * @return The last month's production of the given cargo for this town.
+	 * @return The last economy-month's production of the given cargo for this town.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static SQInteger GetLastMonthProduction(TownID town_id, CargoID cargo_id);
 
 	/**
-	 * Get the total amount of cargo supplied from a town last month.
+	 * Get the total amount of cargo supplied from a town last economy-month.
 	 * @param town_id The index of the town.
 	 * @param cargo_id The index of the cargo.
 	 * @pre IsValidTown(town_id).
 	 * @pre ScriptCargo::IsValidCargo(cargo_id).
-	 * @return The amount of cargo supplied for transport from this town last month.
+	 * @return The amount of cargo supplied for transport from this town last economy-month.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static SQInteger GetLastMonthSupplied(TownID town_id, CargoID cargo_id);
 
 	/**
-	 * Get the percentage of transported production of the given cargo at a town.
+	 * Get the percentage of transported production of the given cargo at a town last economy-month.
 	 * @param town_id The index of the town.
 	 * @param cargo_id The index of the cargo.
 	 * @pre IsValidTown(town_id).
 	 * @pre ScriptCargo::IsValidCargo(cargo_id).
-	 * @return The percentage of given cargo transported from this town last month.
+	 * @return The percentage of given cargo transported from this town last economy-month.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static SQInteger GetLastMonthTransportedPercentage(TownID town_id, CargoID cargo_id);
 
 	/**
-	 * Get the total amount of cargo effects received by a town last month.
+	 * Get the total amount of cargo effects received by a town last economy-month.
 	 * @param town_id The index of the town.
 	 * @param towneffect_id The index of the cargo.
 	 * @pre IsValidTown(town_id).
 	 * @pre ScriptCargo::IsValidTownEffect(cargo_id).
-	 * @return The amount of cargo received by this town last month for this cargo effect.
+	 * @return The amount of cargo received by this town last economy-month for this cargo effect.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static SQInteger GetLastMonthReceived(TownID town_id, ScriptCargo::TownEffect towneffect_id);
 
 	/**
-	 * Set the goal of a cargo for this town.
+	 * Set the goal of a cargo per economy-month for this town.
 	 * @param town_id The index of the town.
 	 * @param towneffect_id The index of the towneffect.
-	 * @param goal The new goal.
+	 * @param goal The new goal amount for cargo delivered per economy-month.
 	 *             The value will be clamped to 0 .. MAX(uint32_t).
 	 * @pre IsValidTown(town_id).
 	 * @pre ScriptCargo::IsValidTownEffect(towneffect_id).
 	 * @pre ScriptCompanyMode::IsDeity().
 	 * @return True if the action succeeded.
+	 * @see \ref ScriptEconomyTime
 	 * @api -ai
 	 */
 	static bool SetCargoGoal(TownID town_id, ScriptCargo::TownEffect towneffect_id, SQInteger goal);
 
 	/**
-	 * Get the amount of cargo that needs to be delivered (per TownEffect) for a
+	 * Get the amount of cargo per economy-month that needs to be delivered (per TownEffect) for a
 	 *  town to grow. All goals need to be reached before a town will grow.
 	 * @param town_id The index of the town.
 	 * @param towneffect_id The index of the towneffect.
 	 * @pre IsValidTown(town_id).
 	 * @pre ScriptCargo::IsValidTownEffect(towneffect_id).
-	 * @return The goal of the cargo.
+	 * @return The goal of the cargo (amount per economy-month).
 	 * @note Goals can change over time. For example with a changing snowline, or
 	 *  with a growing town.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static SQInteger GetCargoGoal(TownID town_id, ScriptCargo::TownEffect towneffect_id);
 
 	/**
-	 * Set the amount of days between town growth.
+	 * Set the amount of economy-days between town growth.
 	 * @param town_id The index of the town.
-	 * @param days_between_town_growth The amount of days between town growth, TOWN_GROWTH_NONE or TOWN_GROWTH_NORMAL.
+	 * @param days_between_town_growth The amount of economy-days between town growth, TOWN_GROWTH_NONE or TOWN_GROWTH_NORMAL.
 	 * @pre IsValidTown(town_id).
 	 * @pre days_between_town_growth <= 880 || days_between_town_growth == TOWN_GROWTH_NONE || days_between_town_growth == TOWN_GROWTH_NORMAL.
 	 * @return True if the action succeeded.
 	 * @note Even when setting a growth rate, towns only grow when the conditions for growth (SetCargoCoal) are met,
 	 *       and the game settings (economy.town_growth_rate) allow town growth at all.
 	 * @note When changing the growth rate, the relative progress is preserved and scaled to the new rate.
+	 * @see \ref ScriptEconomyTime
 	 * @api -ai
 	 */
 	static bool SetGrowthRate(TownID town_id, SQInteger days_between_town_growth);
 
 	/**
-	 * Get the amount of days between town growth.
+	 * Get the amount of economy-days between town growth.
 	 * @param town_id The index of the town.
 	 * @pre IsValidTown(town_id).
-	 * @return Amount of days between town growth, or TOWN_GROWTH_NONE.
+	 * @return Amount of economy-days between town growth, or TOWN_GROWTH_NONE.
 	 * @note This function does not indicate when it will grow next. It only tells you the time between growths.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static SQInteger GetGrowthRate(TownID town_id);
 
@@ -332,8 +343,9 @@ public:
 	 * Find out how long the town is undergoing road reconstructions.
 	 * @param town_id The town to check.
 	 * @pre IsValidTown(town_id).
-	 * @return The number of months the road reworks are still going to take.
+	 * @return The number of economy-months the road reworks are still going to take.
 	 *         The value 0 means that there are currently no road reworks.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static SQInteger GetRoadReworkDuration(TownID town_id);
 
@@ -341,8 +353,9 @@ public:
 	 * Find out how long new buildings are still being funded in a town.
 	 * @param town_id The town to check.
 	 * @pre IsValidTown(town_id).
-	 * @return The number of months building construction is still funded.
+	 * @return The number of economy-months building construction is still funded.
 	 *         The value 0 means that there is currently no funding.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static SQInteger GetFundBuildingsDuration(TownID town_id);
 
@@ -361,9 +374,10 @@ public:
 	 * Find out how long the town is under influence of the exclusive rights.
 	 * @param town_id The town to check.
 	 * @pre IsValidTown(town_id).
-	 * @return The number of months the exclusive rights hold.
+	 * @return The number of economy-months the exclusive rights hold.
 	 *         The value 0 means that there are currently no exclusive rights
 	 *         given out to anyone.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static SQInteger GetExclusiveRightsDuration(TownID town_id);
 

--- a/src/script/api/script_townlist.hpp
+++ b/src/script/api/script_townlist.hpp
@@ -25,20 +25,23 @@ public:
 	/**
 	 * Apply a filter when building the list.
 	 * @param filter_function The function which will be doing the filtering.
-	 * @param params The params to give to the filters (minus the first param,
+	 * @param ... The params to give to the filters (minus the first param,
 	 *  which is always the index-value).
 	 * @note You can write your own filters and use them. Just remember that
 	 *  the first parameter should be the index-value, and it should return
 	 *  a bool.
 	 * @note Example:
-	 *  ScriptTownList(ScriptTown.IsActionAvailable, ScriptTown.TOWN_ACTION_BRIBE);
+	 * @code
+	 *  local bribeable_towns = ScriptTownList(ScriptTown.IsActionAvailable, ScriptTown.TOWN_ACTION_BRIBE);
+	 *
 	 *  function MinPopulation(town_id, pop)
 	 *  {
 	 *    return ScriptTown.GetPopulation(town_id) >= pop;
 	 *  }
-	 *  ScriptTownList(MinPopulation, 1000);
+	 *  local proper_towns = ScriptTownList(MinPopulation, 1000);
+	 * @endcode
 	 */
-	ScriptTownList(void *filter_function, int params, ...);
+	ScriptTownList(function filter_function, ...);
 #else
 	ScriptTownList(HSQUIRRELVM vm);
 #endif /* DOXYGEN_API */

--- a/src/script/api/script_tunnel.hpp
+++ b/src/script/api/script_tunnel.hpp
@@ -20,6 +20,8 @@ class ScriptTunnel : public ScriptObject {
 public:
 	/**
 	 * All tunnel related errors.
+	 *
+	 * @see ScriptErrorType
 	 */
 	enum ErrorMessages {
 

--- a/src/script/api/script_types.hpp
+++ b/src/script/api/script_types.hpp
@@ -46,6 +46,14 @@
  *                           <td> game start \ref newgrf_changes "(1)"              </td>
  *                           <td> never \ref newgrf_changes "(1)"                   </td>
  *                           <td> no                                                </td></tr>
+ * <tr><td>#ObjectType  </td><td> NewGRF object type                                </td>
+ *                           <td> game start \ref newgrf_changes "(1)"              </td>
+ *                           <td> never \ref newgrf_changes "(1)"                   </td>
+ *                           <td> no                                                </td></tr>
+ * <tr><td>#ScriptErrorType</td><td> error message                                  </td>
+ *                           <td> OpenTTD start \ref transient_id "(3)"             </td>
+ *                           <td> OpenTTD exit                                      </td>
+ *                           <td> no                                                </td></tr>
  * <tr><td>#SignID      </td><td> sign                                              </td>
  *                           <td> construction                                      </td>
  *                           <td> deletion                                          </td>
@@ -54,9 +62,21 @@
  *                           <td> construction                                      </td>
  *                           <td> expiration of 'grey' station sign after deletion  </td>
  *                           <td> yes                                               </td></tr>
+ * <tr><td>#StringID    </td><td> translatable text                                 </td>
+ *                           <td> OpenTTD start \ref transient_id "(3)"             </td>
+ *                           <td> OpenTTD exit                                      </td>
+ *                           <td> no                                                </td></tr>
  * <tr><td>#SubsidyID   </td><td> subsidy                                           </td>
  *                           <td> offer announcement                                </td>
  *                           <td> (offer) expiration                                </td>
+ *                           <td> yes                                               </td></tr>
+ * <tr><td>#StoryPageID </td><td> story page                                        </td>
+ *                           <td> creation                                          </td>
+ *                           <td> deletion                                          </td>
+ *                           <td> yes                                               </td></tr>
+ * <tr><td>#StoryPageElementID</td><td> story page element                          </td>
+ *                           <td> creation                                          </td>
+ *                           <td> deletion                                          </td>
  *                           <td> yes                                               </td></tr>
  * <tr><td>#TileIndex   </td><td> tile on map                                       </td>
  *                           <td> game start                                        </td>
@@ -75,6 +95,7 @@
  * @remarks
  *  \li \anchor newgrf_changes  (1) in-game changes of newgrfs may reassign/invalidate IDs (will also cause other trouble though).
  *  \li \anchor dynamic_engines (2) engine IDs are reassigned/invalidated on changing 'allow multiple newgrf engine sets' (only allowed as long as no vehicles are built).
+ *  \li \anchor transient_id    (3) string/error IDs are only valid during a session, and may be reassigned/invalidated when loading savegames (so you cannot store them).
  */
 
 #ifndef SCRIPT_TYPES_HPP

--- a/src/script/api/script_types.hpp
+++ b/src/script/api/script_types.hpp
@@ -7,7 +7,10 @@
 
 /**
  * @file script_types.hpp Defines all the types of the game, like IDs of various objects.
- *
+ */
+
+/**
+ * @page script_ids Identifying game object
  * IDs are used to identify certain objects. They are only unique within the object type, so for example a vehicle may have VehicleID 2009,
  * while a station has StationID 2009 at the same time. Also IDs are assigned arbitrary, you cannot assume them to be consecutive.
  * Also note that some IDs are static and never change, while others are allocated dynamically and might be

--- a/src/script/api/script_types.hpp
+++ b/src/script/api/script_types.hpp
@@ -85,27 +85,32 @@
 #include "../../tile_type.h"
 #include <squirrel.h>
 
-/* Define all types here, so we don't have to include the whole _type.h maze */
-typedef uint BridgeType;     ///< Internal name, not of any use for you.
-typedef uint8_t CargoID;        ///< The ID of a cargo.
-class CommandCost;           ///< The cost of a command.
+/* Define all types here, so they are added to the API docs. */
+typedef uint BridgeID;         ///< The ID of a bridge type.
+typedef uint8_t CargoID;       ///< The ID of a cargo.
 typedef uint16_t EngineID;     ///< The ID of an engine.
 typedef uint16_t GoalID;       ///< The ID of a goal.
 typedef uint16_t GroupID;      ///< The ID of a group.
 typedef uint16_t IndustryID;   ///< The ID of an industry.
 typedef uint8_t IndustryType;  ///< The ID of an industry-type.
-typedef OverflowSafeInt64 Money; ///< Money, stored in a 32bit/64bit safe way. For scripts money is always in pounds.
+#ifdef DOXYGEN_API
+typedef int64_t Money;         ///< Money, stored in a 32bit/64bit safe way. For scripts money is always in pounds.
+#else
+typedef OverflowSafeInt64 Money;
+#endif /* DOXYGEN_API */
+typedef uint16_t ObjectType;   ///< The ID of an object-type.
 typedef uint16_t SignID;       ///< The ID of a sign.
 typedef uint16_t StationID;    ///< The ID of a station.
 typedef uint32_t StringID;     ///< The ID of a string.
 typedef uint16_t SubsidyID;    ///< The ID of a subsidy.
 typedef uint16_t StoryPageID;  ///< The ID of a story page.
 typedef uint16_t StoryPageElementID; ///< The ID of a story page element.
+#ifdef DOXYGEN_API
+typedef uint32_t TileIndex;    ///< The ID of a map location.
+#endif /* DOXYGEN_API */
 typedef uint16_t TownID;       ///< The ID of a town.
 typedef uint32_t VehicleID;    ///< The ID of a vehicle.
 
-/* Types we defined ourself, as the OpenTTD core doesn't have them (yet) */
 typedef uint ScriptErrorType;///< The types of errors inside the script framework.
-typedef BridgeType BridgeID; ///< The ID of a bridge.
 
 #endif /* SCRIPT_TYPES_HPP */

--- a/src/script/api/script_types.hpp
+++ b/src/script/api/script_types.hpp
@@ -135,6 +135,11 @@ typedef uint32_t TileIndex;    ///< The ID of a map location.
 typedef uint16_t TownID;       ///< The ID of a town.
 typedef uint32_t VehicleID;    ///< The ID of a vehicle.
 
-typedef uint ScriptErrorType;///< The types of errors inside the script framework.
+/**
+ * The types of errors inside the script framework.
+ *
+ * Possible value are defined inside each API class in an ErrorMessages enum.
+ */
+typedef uint ScriptErrorType;
 
 #endif /* SCRIPT_TYPES_HPP */

--- a/src/script/api/script_vehicle.hpp
+++ b/src/script/api/script_vehicle.hpp
@@ -20,6 +20,8 @@ class ScriptVehicle : public ScriptObject {
 public:
 	/**
 	 * All vehicle related error messages.
+	 *
+	 * @see ScriptErrorType
 	 */
 	enum ErrorMessages {
 		/** Base for vehicle related errors */

--- a/src/script/api/script_vehicle.hpp
+++ b/src/script/api/script_vehicle.hpp
@@ -188,8 +188,8 @@ public:
 	 * Get the current age of a vehicle.
 	 * @param vehicle_id The vehicle to get the age of.
 	 * @pre IsValidVehicle(vehicle_id).
-	 * @return The current age the vehicle has.
-	 * @note The age is in days.
+	 * @return The current age of the vehicle in calendar-days.
+	 * @see \ref ScriptCalendarTime
 	 */
 	static SQInteger GetAge(VehicleID vehicle_id);
 
@@ -199,8 +199,8 @@ public:
 	 * @param wagon The wagon in the vehicle to get the age of.
 	 * @pre IsValidVehicle(vehicle_id).
 	 * @pre wagon < GetNumWagons(vehicle_id).
-	 * @return The current age the vehicle has.
-	 * @note The age is in days.
+	 * @return The current age of the vehicle in calendar-days.
+	 * @see \ref ScriptCalendarTime
 	 */
 	static SQInteger GetWagonAge(VehicleID vehicle_id, SQInteger wagon);
 
@@ -208,8 +208,8 @@ public:
 	 * Get the maximum age of a vehicle.
 	 * @param vehicle_id The vehicle to get the age of.
 	 * @pre IsPrimaryVehicle(vehicle_id).
-	 * @return The maximum age the vehicle has.
-	 * @note The age is in days.
+	 * @return The maximum age for the vehicle in calendar-days.
+	 * @see \ref ScriptCalendarTime
 	 */
 	static SQInteger GetMaxAge(VehicleID vehicle_id);
 
@@ -217,8 +217,8 @@ public:
 	 * Get the age a vehicle has left (maximum - current).
 	 * @param vehicle_id The vehicle to get the age of.
 	 * @pre IsPrimaryVehicle(vehicle_id).
-	 * @return The age the vehicle has left.
-	 * @note The age is in days.
+	 * @return The remaining age of the vehicle in calendar-days.
+	 * @see \ref ScriptCalendarTime
 	 */
 	static SQInteger GetAgeLeft(VehicleID vehicle_id);
 
@@ -245,10 +245,10 @@ public:
 	 * Get the running cost of this vehicle.
 	 * @param vehicle_id The vehicle to get the running cost of.
 	 * @pre IsPrimaryVehicle(vehicle_id).
-	 * @return The running cost of the vehicle per year.
-	 * @note Cost is per year; divide by 365 to get per day.
+	 * @return The running cost of the vehicle per economy-year.
 	 * @note This is not equal to ScriptEngine::GetRunningCost for Trains, because
 	 *   wagons and second engines can add up in the calculation too.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static Money GetRunningCost(VehicleID vehicle_id);
 
@@ -256,7 +256,8 @@ public:
 	 * Get the current profit of a vehicle.
 	 * @param vehicle_id The vehicle to get the profit of.
 	 * @pre IsPrimaryVehicle(vehicle_id).
-	 * @return The current profit the vehicle has.
+	 * @return The profit the vehicle has made this economy-year so far.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static Money GetProfitThisYear(VehicleID vehicle_id);
 
@@ -264,7 +265,8 @@ public:
 	 * Get the profit of last year of a vehicle.
 	 * @param vehicle_id The vehicle to get the profit of.
 	 * @pre IsPrimaryVehicle(vehicle_id).
-	 * @return The profit the vehicle had last year.
+	 * @return The profit the vehicle made in the previous economy-year.
+	 * @see \ref ScriptEconomyTime
 	 */
 	static Money GetProfitLastYear(VehicleID vehicle_id);
 

--- a/src/script/api/script_vehiclelist.hpp
+++ b/src/script/api/script_vehiclelist.hpp
@@ -26,20 +26,23 @@ public:
 	/**
 	 * Apply a filter when building the list.
 	 * @param filter_function The function which will be doing the filtering.
-	 * @param params The params to give to the filters (minus the first param,
+	 * @param ... The params to give to the filters (minus the first param,
 	 *  which is always the index-value).
 	 * @note You can write your own filters and use them. Just remember that
 	 *  the first parameter should be the index-value, and it should return
 	 *  a bool.
 	 * @note Example:
-	 *  ScriptVehicleList(ScriptVehicle.IsInDepot);
+	 * @code
+	 *  local vehs_in_depot = ScriptVehicleList(ScriptVehicle.IsInDepot);
+	 *
 	 *  function IsType(vehicle_id, type)
 	 *  {
 	 *    return ScriptVehicle.GetVehicleType(vehicle_id) == type;
 	 *  }
-	 *  ScriptVehicleList(IsType, ScriptVehicle.VT_ROAD);
+	 *  local road_vehs = ScriptVehicleList(IsType, ScriptVehicle.VT_ROAD);
+	 * @endcode
 	 */
-	ScriptVehicleList(void *filter_function, int params, ...);
+	ScriptVehicleList(function filter_function, ...);
 #else
 	/**
 	 * The constructor wrapper from Squirrel.

--- a/src/script/api/script_waypoint.hpp
+++ b/src/script/api/script_waypoint.hpp
@@ -22,6 +22,8 @@ class ScriptWaypoint : public ScriptBaseStation {
 public:
 	/**
 	 * All waypoint related error messages.
+	 *
+	 * @see ScriptErrorType
 	 */
 	enum ErrorMessages {
 		/** Base for waypoint related errors */


### PR DESCRIPTION
This PR includes #12372 as prerequisite.

## Motivation / Problem

* #12339 asks for better API documentation about timekeeping.
* Various other parts of the docs needed improving too.

## Description

* Add main pages to the AI/GS docs.
* Fix doxygen syntax errors and broken links.
* Complete and fix the game ID documentation.
* Document timekeeping and which method returns economy- or calendar-time.
    * The methods link to documentation sections "ScriptEconomyDate" and "ScriptCalendarDate". These can be turned into classes with the same name later.
* Replace C++ types with squirrel-like types in signatures:
    * ``char *``, ``std::string``, ``std::optional<std::string>``, ... should all just be ``string`` in the API docs.
    * ``SQInteger``, ``uint``, ``int16_t``, ... should all just be ``int`` in the API docs.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
