### PR TITLE
Fix #11345: Use correct default button value for vehicle service interval setting

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1832,7 +1832,11 @@ STR_CONFIG_SETTING_SERVINT_AIRCRAFT                             :Default service
 STR_CONFIG_SETTING_SERVINT_AIRCRAFT_HELPTEXT                    :Set the default service interval for new aircraft, if no explicit service interval is set for the vehicle
 STR_CONFIG_SETTING_SERVINT_SHIPS                                :Default service interval for ships: {STRING2}
 STR_CONFIG_SETTING_SERVINT_SHIPS_HELPTEXT                       :Set the default service interval for new ships, if no explicit service interval is set for the vehicle
-STR_CONFIG_SETTING_SERVINT_VALUE                                :{COMMA}{NBSP}Day{P 0 "" s}/Minute{P 0 "" s}/%
+###length 3
+STR_CONFIG_SETTING_SERVINT_VALUE_DAYS                           :{COMMA}{NBSP}Day{P 0 "" s}
+STR_CONFIG_SETTING_SERVINT_VALUE_MINUTES                        :{COMMA}{NBSP}Minute{P 0 "" s}
+STR_CONFIG_SETTING_SERVINT_VALUE_PERCENTAGE                     :{COMMA}{NBSP}%
+
 ###setting-zero-is-special
 STR_CONFIG_SETTING_SERVINT_DISABLED                             :Disabled
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2737,6 +2737,7 @@ struct GameSettingsWindow : Window {
 			value = ClampTo<int32_t>(llvalue);
 		} else {
 			value = sd->def;
+			if (sd->get_def_cb != nullptr) sd->get_def_cb(value);
 		}
 
 		SetSettingValue(this->valuewindow_entry->setting, value);

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2501,7 +2501,9 @@ struct GameSettingsWindow : Window {
 					DrawString(tr, STR_CONFIG_SETTING_TYPE);
 					tr.top += GetCharacterHeight(FS_NORMAL);
 
-					sd->SetValueDParams(0, sd->def);
+					int32_t def_val = sd->def;
+					if (sd->get_def_cb != nullptr) sd->get_def_cb(def_val);
+					sd->SetValueDParams(0, def_val);
 					DrawString(tr, STR_CONFIG_SETTING_DEFAULT_VALUE);
 					tr.top += GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.vsep_normal;
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2501,8 +2501,7 @@ struct GameSettingsWindow : Window {
 					DrawString(tr, STR_CONFIG_SETTING_TYPE);
 					tr.top += GetCharacterHeight(FS_NORMAL);
 
-					int32_t def_val = sd->def;
-					if (sd->get_def_cb != nullptr) sd->get_def_cb(def_val);
+					int32_t def_val = sd->get_def_cb != nullptr ? sd->get_def_cb() : sd->def;
 					sd->SetValueDParams(0, def_val);
 					DrawString(tr, STR_CONFIG_SETTING_DEFAULT_VALUE);
 					tr.top += GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.vsep_normal;
@@ -2737,9 +2736,10 @@ struct GameSettingsWindow : Window {
 			if (sd->flags & SF_GUI_CURRENCY) llvalue /= GetCurrency().rate;
 
 			value = ClampTo<int32_t>(llvalue);
+		} else if (sd->get_def_cb != nullptr) {
+			value = sd->get_def_cb();
 		} else {
 			value = sd->def;
-			if (sd->get_def_cb != nullptr) sd->get_def_cb(value);
 		}
 
 		SetSettingValue(this->valuewindow_entry->setting, value);

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -169,7 +169,7 @@ struct IntSettingDesc : SettingDesc {
 	 * units or expressed as a percentage.
 	 * @param value The prospective new value for the setting.
 	 */
-	typedef void GetDefaultValueCallback(int32_t &value);
+	typedef int32_t GetDefaultValueCallback();
 
 	template <
 		typename Tdef,

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -165,9 +165,9 @@ struct IntSettingDesc : SettingDesc {
 	 */
 	typedef void PostChangeCallback(int32_t value);
 	/**
-	 * A callback to set the correct default value, in case it can be measured in time
+	 * A callback to get the correct default value. For example a default that can be measured in time
 	 * units or expressed as a percentage.
-	 * @param value The prospective new value for the setting.
+	 * @return The correct default value for the setting.
 	 */
 	typedef int32_t GetDefaultValueCallback();
 

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -266,7 +266,7 @@ static void UpdateServiceInterval(VehicleType type, int32_t new_value)
  * Checks if the service intervals in the settings are specified as percentages and corrects the default value accordingly.
  * @param new_value Contains the service interval's default value in days, or 50 (default in percentage).
  */
-static void GetDefaultServiceInterval(VehicleType type, int32_t &new_value)
+static int32_t GetDefaultServiceInterval(VehicleType type)
 {
 	VehicleDefaultSettings *vds;
 	if (_game_mode == GM_MENU || !Company::IsValidID(_current_company)) {
@@ -275,6 +275,7 @@ static void GetDefaultServiceInterval(VehicleType type, int32_t &new_value)
 		vds = &Company::Get(_current_company)->settings.vehicle;
 	}
 
+	int32_t new_value;
 	if (vds->servint_ispercent) {
 		new_value = DEF_SERVINT_PERCENT;
 	} else if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU)) {
@@ -285,7 +286,17 @@ static void GetDefaultServiceInterval(VehicleType type, int32_t &new_value)
 			case VEH_SHIP:     new_value = DEF_SERVINT_MINUTES_SHIPS; break;
 			default: NOT_REACHED();
 		}
+	} else {
+		switch (type) {
+			case VEH_TRAIN:    new_value = DEF_SERVINT_DAYS_TRAINS; break;
+			case VEH_ROAD:     new_value = DEF_SERVINT_DAYS_ROADVEH; break;
+			case VEH_AIRCRAFT: new_value = DEF_SERVINT_DAYS_AIRCRAFT; break;
+			case VEH_SHIP:     new_value = DEF_SERVINT_DAYS_SHIPS; break;
+			default: NOT_REACHED();
+		}
 	}
+
+	return new_value;
 }
 
 static void TrainAccelerationModelChanged(int32_t)

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -116,6 +116,28 @@ static void SettingsValueAbsolute(const IntSettingDesc &sd, uint first_param, in
 	SetDParam(first_param + 1, abs(value));
 }
 
+/** Service Interval Settings Default Value displays the correct units or as a percentage */
+static void ServiceIntervalSettingsValueText(const IntSettingDesc &sd, uint first_param, int32_t value)
+{
+	VehicleDefaultSettings *vds;
+	if (_game_mode == GM_MENU || !Company::IsValidID(_current_company)) {
+		vds = &_settings_client.company.vehicle;
+	} else {
+		vds = &Company::Get(_current_company)->settings.vehicle;
+	}
+
+	if (value == 0) {
+		SetDParam(first_param, sd.str_val + 3);
+	} else if (vds->servint_ispercent) {
+		SetDParam(first_param, sd.str_val + 2);
+	} else if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU)) {
+		SetDParam(first_param, sd.str_val + 1);
+	} else {
+		SetDParam(first_param, sd.str_val);
+	}
+	SetDParam(first_param + 1, value);
+}
+
 /** Reposition the main toolbar as the setting changed. */
 static void v_PositionMainToolbar(int32_t)
 {

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -240,6 +240,32 @@ static void UpdateServiceInterval(VehicleType type, int32_t new_value)
 	SetWindowClassesDirty(WC_VEHICLE_DETAILS);
 }
 
+/**
+ * Checks if the service intervals in the settings are specified as percentages and corrects the default value accordingly.
+ * @param new_value Contains the service interval's default value in days, or 50 (default in percentage).
+ */
+static void GetDefaultServiceInterval(VehicleType type, int32_t &new_value)
+{
+	VehicleDefaultSettings *vds;
+	if (_game_mode == GM_MENU || !Company::IsValidID(_current_company)) {
+		vds = &_settings_client.company.vehicle;
+	} else {
+		vds = &Company::Get(_current_company)->settings.vehicle;
+	}
+
+	if (vds->servint_ispercent) {
+		new_value = DEF_SERVINT_PERCENT;
+	} else if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU)) {
+		switch (type) {
+			case VEH_TRAIN:    new_value = DEF_SERVINT_MINUTES_TRAINS; break;
+			case VEH_ROAD:     new_value = DEF_SERVINT_MINUTES_ROADVEH; break;
+			case VEH_AIRCRAFT: new_value = DEF_SERVINT_MINUTES_AIRCRAFT; break;
+			case VEH_SHIP:     new_value = DEF_SERVINT_MINUTES_SHIPS; break;
+			default: NOT_REACHED();
+		}
+	}
+}
+
 static void TrainAccelerationModelChanged(int32_t)
 {
 	for (Train *t : Train::Iterate()) {

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -58,11 +58,11 @@ static StringID SettingHelpWallclock(const IntSettingDesc &sd);
 
 /* Macros for various objects to go in the configuration file.
  * This section is for global variables */
-#define SDTG_VAR(name, type, flags, var, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, from, to, cat, extra, startup)\
-	NSD(Int, SLEG_GENERAL(name, SL_VAR, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook)
+#define SDTG_VAR(name, type, flags, var, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
+	NSD(Int, SLEG_GENERAL(name, SL_VAR, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
 
-#define SDTG_BOOL(name, flags, var, def, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, from, to, cat, extra, startup)\
-	NSD(Bool, SLEG_GENERAL(name, SL_VAR, var, SLE_BOOL, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook)
+#define SDTG_BOOL(name, flags, var, def, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
+	NSD(Bool, SLEG_GENERAL(name, SL_VAR, var, SLE_BOOL, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
 
 #define SDTG_LIST(name, type, flags, var, def, length, from, to, cat, extra, startup)\
 	NSD(List, SLEG_GENERAL(name, SL_ARR, var, type, length, from, to, extra),flags, startup, def)
@@ -70,22 +70,22 @@ static StringID SettingHelpWallclock(const IntSettingDesc &sd);
 #define SDTG_SSTR(name, type, flags, var, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
 	NSD(String, SLEG_GENERAL(name, SL_STDSTR, var, type, sizeof(var), from, to, extra), flags, startup, def, max_length, pre_check, post_callback)
 
-#define SDTG_OMANY(name, type, flags, var, def, max, full, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, from, to, cat, extra, startup)\
-	NSD(OneOfMany, SLEG_GENERAL(name, SL_VAR, var, type, 1, from, to, extra), flags, startup, def, max, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, full, nullptr)
+#define SDTG_OMANY(name, type, flags, var, def, max, full, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
+	NSD(OneOfMany, SLEG_GENERAL(name, SL_VAR, var, type, 1, from, to, extra), flags, startup, def, max, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, full, nullptr)
 
-#define SDTG_MMANY(name, type, flags, var, def, full, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, from, to, cat, extra, startup)\
-	NSD(ManyOfMany, SLEG_GENERAL(name, SL_VAR, var, type, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, full, nullptr)
+#define SDTG_MMANY(name, type, flags, var, def, full, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
+	NSD(ManyOfMany, SLEG_GENERAL(name, SL_VAR, var, type, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, full, nullptr)
 
 /* Macros for various objects to go in the configuration file.
  * This section is for structures where their various members are saved */
-#define SDT_VAR(base, var, type, flags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, from, to, cat, extra, startup)\
-	NSD(Int, SLE_GENERAL(SL_VAR, base, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook)
+#define SDT_VAR(base, var, type, flags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
+	NSD(Int, SLE_GENERAL(SL_VAR, base, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
 
-#define SDT_VAR_NAME(base, var, type, flags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, from, to, cat, extra, startup, name)\
-	NSD(Int, SLE_GENERAL_NAME(SL_VAR, name, base, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook)
+#define SDT_VAR_NAME(base, var, type, flags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup, name)\
+	NSD(Int, SLE_GENERAL_NAME(SL_VAR, name, base, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
 
-#define SDT_BOOL(base, var, flags, def, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, from, to, cat, extra, startup)\
-	NSD(Bool, SLE_GENERAL(SL_VAR, base, var, SLE_BOOL, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook)
+#define SDT_BOOL(base, var, flags, def, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
+	NSD(Bool, SLE_GENERAL(SL_VAR, base, var, SLE_BOOL, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
 
 #define SDT_LIST(base, var, type, flags, def, from, to, cat, extra, startup)\
 	NSD(List, SLE_GENERAL(SL_ARR, base, var, type, lengthof(((base*)8)->var), from, to, extra), flags, startup, def)
@@ -93,18 +93,18 @@ static StringID SettingHelpWallclock(const IntSettingDesc &sd);
 #define SDT_SSTR(base, var, type, flags, def, pre_check, post_callback, from, to, cat, extra, startup)\
 	NSD(String, SLE_GENERAL(SL_STDSTR, base, var, type, sizeof(((base*)8)->var), from, to, extra), flags, startup, def, 0, pre_check, post_callback)
 
-#define SDT_OMANY(base, var, type, flags, def, max, full, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, from, to, load, cat, extra, startup)\
-	NSD(OneOfMany, SLE_GENERAL(SL_VAR, base, var, type, 1, from, to, extra), flags, startup, def, max, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, full, load)
+#define SDT_OMANY(base, var, type, flags, def, max, full, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, load, cat, extra, startup)\
+	NSD(OneOfMany, SLE_GENERAL(SL_VAR, base, var, type, 1, from, to, extra), flags, startup, def, max, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, full, load)
 
-#define SDT_MMANY(base, var, type, flags, def, full, str, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, strhelp, strval, from, to, cat, extra, startup)\
-	NSD(ManyOfMany, SLE_GENERAL(SL_VAR, base, var, type, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, full, nullptr)
+#define SDT_MMANY(base, var, type, flags, def, full, str, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, strhelp, strval, from, to, cat, extra, startup)\
+	NSD(ManyOfMany, SLE_GENERAL(SL_VAR, base, var, type, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, full, nullptr)
 
 
-#define SDTC_VAR(var, type, flags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, from, to, cat, extra, startup)\
-	SDTG_VAR(#var, type, flags, _settings_client.var, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, from, to, cat, extra, startup)
+#define SDTC_VAR(var, type, flags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
+	SDTG_VAR(#var, type, flags, _settings_client.var, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)
 
-#define SDTC_BOOL(var, flags, def, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, from, to, cat, extra, startup)\
-	SDTG_BOOL(#var, flags, _settings_client.var, def, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, from, to, cat, extra, startup)
+#define SDTC_BOOL(var, flags, def, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
+	SDTG_BOOL(#var, flags, _settings_client.var, def, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)
 
 #define SDTC_LIST(var, type, flags, def, from, to, cat, extra, startup)\
 	SDTG_LIST(#var, type, flags, _settings_client.var, def, lengthof(_settings_client.var), from, to, cat, extra, startup)
@@ -112,5 +112,5 @@ static StringID SettingHelpWallclock(const IntSettingDesc &sd);
 #define SDTC_SSTR(var, type, flags, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
 	SDTG_SSTR(#var, type, flags, _settings_client.var, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
 
-#define SDTC_OMANY(var, type, flags, def, max, full, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, from, to, cat, extra, startup)\
-	SDTG_OMANY(#var, type, flags, _settings_client.var, def, max, full, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, from, to, cat, extra, startup)
+#define SDTC_OMANY(var, type, flags, def, max, full, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
+	SDTG_OMANY(#var, type, flags, _settings_client.var, def, max, full, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)

--- a/src/table/settings/company_settings.ini
+++ b/src/table/settings/company_settings.ini
@@ -12,6 +12,7 @@ static void UpdateAllServiceInterval(int32_t new_value);
 static bool CanUpdateServiceInterval(VehicleType type, int32_t &new_value);
 static void UpdateServiceInterval(VehicleType type, int32_t new_value);
 static void SettingsValueAbsolute(const IntSettingDesc &sd, uint first_param, int32_t value);
+static void GetDefaultServiceInterval(VehicleType type, int32_t &new_value);
 
 static const SettingVariant _company_settings_table[] = {
 [post-amble]
@@ -98,6 +99,7 @@ strhelp  = STR_CONFIG_SETTING_SERVINT_TRAINS_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE
 pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_TRAIN, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_TRAIN, new_value); }
+def_cb   = [](auto &new_value) { GetDefaultServiceInterval(VEH_TRAIN, new_value); }
 
 [SDT_VAR]
 var      = vehicle.servint_roadveh
@@ -112,6 +114,7 @@ strhelp  = STR_CONFIG_SETTING_SERVINT_ROAD_VEHICLES_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE
 pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_ROAD, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_ROAD, new_value); }
+def_cb   = [](auto &new_value) { GetDefaultServiceInterval(VEH_ROAD, new_value); }
 
 [SDT_VAR]
 var      = vehicle.servint_ships
@@ -126,6 +129,7 @@ strhelp  = STR_CONFIG_SETTING_SERVINT_SHIPS_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE
 pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_SHIP, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_SHIP, new_value); }
+def_cb   = [](auto &new_value) { GetDefaultServiceInterval(VEH_SHIP, new_value); }
 
 [SDT_VAR]
 var      = vehicle.servint_aircraft
@@ -140,3 +144,4 @@ strhelp  = STR_CONFIG_SETTING_SERVINT_AIRCRAFT_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE
 pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_AIRCRAFT, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_AIRCRAFT, new_value); }
+def_cb   = [](auto &new_value) { GetDefaultServiceInterval(VEH_AIRCRAFT, new_value); }

--- a/src/table/settings/company_settings.ini
+++ b/src/table/settings/company_settings.ini
@@ -13,7 +13,7 @@ static bool CanUpdateServiceInterval(VehicleType type, int32_t &new_value);
 static void UpdateServiceInterval(VehicleType type, int32_t new_value);
 static void SettingsValueAbsolute(const IntSettingDesc &sd, uint first_param, int32_t value);
 static void ServiceIntervalSettingsValueText(const IntSettingDesc &sd, uint first_param, int32_t value);
-static void GetDefaultServiceInterval(VehicleType type, int32_t &new_value);
+static int32_t GetDefaultServiceInterval(VehicleType type);
 
 static const SettingVariant _company_settings_table[] = {
 [post-amble]
@@ -100,7 +100,7 @@ strhelp  = STR_CONFIG_SETTING_SERVINT_TRAINS_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE_DAYS
 pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_TRAIN, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_TRAIN, new_value); }
-def_cb   = [](auto &new_value) { GetDefaultServiceInterval(VEH_TRAIN, new_value); }
+def_cb   = []() { return GetDefaultServiceInterval(VEH_TRAIN); }
 val_cb   = ServiceIntervalSettingsValueText
 
 [SDT_VAR]
@@ -116,7 +116,7 @@ strhelp  = STR_CONFIG_SETTING_SERVINT_ROAD_VEHICLES_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE_DAYS
 pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_ROAD, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_ROAD, new_value); }
-def_cb   = [](auto &new_value) { GetDefaultServiceInterval(VEH_ROAD, new_value); }
+def_cb   = []() { return GetDefaultServiceInterval(VEH_ROAD); }
 val_cb   = ServiceIntervalSettingsValueText
 
 [SDT_VAR]
@@ -132,7 +132,7 @@ strhelp  = STR_CONFIG_SETTING_SERVINT_SHIPS_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE_DAYS
 pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_SHIP, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_SHIP, new_value); }
-def_cb   = [](auto &new_value) { GetDefaultServiceInterval(VEH_SHIP, new_value); }
+def_cb   = []() { return GetDefaultServiceInterval(VEH_SHIP); }
 val_cb   = ServiceIntervalSettingsValueText
 
 [SDT_VAR]
@@ -148,5 +148,5 @@ strhelp  = STR_CONFIG_SETTING_SERVINT_AIRCRAFT_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE_DAYS
 pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_AIRCRAFT, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_AIRCRAFT, new_value); }
-def_cb   = [](auto &new_value) { GetDefaultServiceInterval(VEH_AIRCRAFT, new_value); }
+def_cb   = []() { return GetDefaultServiceInterval(VEH_AIRCRAFT); }
 val_cb   = ServiceIntervalSettingsValueText

--- a/src/table/settings/company_settings.ini
+++ b/src/table/settings/company_settings.ini
@@ -17,8 +17,8 @@ static const SettingVariant _company_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDT_BOOL = SDT_BOOL(CompanySettings, $var,        $flags, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $cat, $extra, $startup),
-SDT_VAR  =  SDT_VAR(CompanySettings, $var, $type, $flags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $cat, $extra, $startup),
+SDT_BOOL = SDT_BOOL(CompanySettings, $var,        $flags, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
+SDT_VAR  =  SDT_VAR(CompanySettings, $var, $type, $flags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for CompanySettings.$var exceeds storage size");
@@ -34,6 +34,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/company_settings.ini
+++ b/src/table/settings/company_settings.ini
@@ -12,6 +12,7 @@ static void UpdateAllServiceInterval(int32_t new_value);
 static bool CanUpdateServiceInterval(VehicleType type, int32_t &new_value);
 static void UpdateServiceInterval(VehicleType type, int32_t new_value);
 static void SettingsValueAbsolute(const IntSettingDesc &sd, uint first_param, int32_t value);
+static void ServiceIntervalSettingsValueText(const IntSettingDesc &sd, uint first_param, int32_t value);
 static void GetDefaultServiceInterval(VehicleType type, int32_t &new_value);
 
 static const SettingVariant _company_settings_table[] = {
@@ -96,10 +97,11 @@ max      = MAX_SERVINT_DAYS
 interval = 1
 str      = STR_CONFIG_SETTING_SERVINT_TRAINS
 strhelp  = STR_CONFIG_SETTING_SERVINT_TRAINS_HELPTEXT
-strval   = STR_CONFIG_SETTING_SERVINT_VALUE
+strval   = STR_CONFIG_SETTING_SERVINT_VALUE_DAYS
 pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_TRAIN, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_TRAIN, new_value); }
 def_cb   = [](auto &new_value) { GetDefaultServiceInterval(VEH_TRAIN, new_value); }
+val_cb   = ServiceIntervalSettingsValueText
 
 [SDT_VAR]
 var      = vehicle.servint_roadveh
@@ -111,10 +113,11 @@ max      = MAX_SERVINT_DAYS
 interval = 1
 str      = STR_CONFIG_SETTING_SERVINT_ROAD_VEHICLES
 strhelp  = STR_CONFIG_SETTING_SERVINT_ROAD_VEHICLES_HELPTEXT
-strval   = STR_CONFIG_SETTING_SERVINT_VALUE
+strval   = STR_CONFIG_SETTING_SERVINT_VALUE_DAYS
 pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_ROAD, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_ROAD, new_value); }
 def_cb   = [](auto &new_value) { GetDefaultServiceInterval(VEH_ROAD, new_value); }
+val_cb   = ServiceIntervalSettingsValueText
 
 [SDT_VAR]
 var      = vehicle.servint_ships
@@ -126,10 +129,11 @@ max      = MAX_SERVINT_DAYS
 interval = 1
 str      = STR_CONFIG_SETTING_SERVINT_SHIPS
 strhelp  = STR_CONFIG_SETTING_SERVINT_SHIPS_HELPTEXT
-strval   = STR_CONFIG_SETTING_SERVINT_VALUE
+strval   = STR_CONFIG_SETTING_SERVINT_VALUE_DAYS
 pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_SHIP, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_SHIP, new_value); }
 def_cb   = [](auto &new_value) { GetDefaultServiceInterval(VEH_SHIP, new_value); }
+val_cb   = ServiceIntervalSettingsValueText
 
 [SDT_VAR]
 var      = vehicle.servint_aircraft
@@ -141,7 +145,8 @@ max      = MAX_SERVINT_DAYS
 interval = 1
 str      = STR_CONFIG_SETTING_SERVINT_AIRCRAFT
 strhelp  = STR_CONFIG_SETTING_SERVINT_AIRCRAFT_HELPTEXT
-strval   = STR_CONFIG_SETTING_SERVINT_VALUE
+strval   = STR_CONFIG_SETTING_SERVINT_VALUE_DAYS
 pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_AIRCRAFT, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_AIRCRAFT, new_value); }
 def_cb   = [](auto &new_value) { GetDefaultServiceInterval(VEH_AIRCRAFT, new_value); }
+val_cb   = ServiceIntervalSettingsValueText

--- a/src/table/settings/currency_settings.ini
+++ b/src/table/settings/currency_settings.ini
@@ -11,7 +11,7 @@ static const SettingVariant _currency_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDT_VAR  = SDT_VAR (CurrencySpec, $var, $type, $flags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $cat, $extra, $startup),
+SDT_VAR  = SDT_VAR (CurrencySpec, $var, $type, $flags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
 SDT_SSTR = SDT_SSTR(CurrencySpec, $var, $type, $flags, $def,                                                 $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
@@ -28,6 +28,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/difficulty_settings.ini
+++ b/src/table/settings/difficulty_settings.ini
@@ -20,9 +20,9 @@ static const SettingVariant _difficulty_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDTG_VAR   =   SDTG_VAR($name,              $type, $flags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
-SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
-SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_VAR   =   SDTG_VAR($name,              $type, $flags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDT_VAR    =   SDT_VAR (GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -39,6 +39,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -16,8 +16,8 @@ static const SettingVariant _economy_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
-SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
+SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDT_VAR    =   SDT_VAR (GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for GameSettings.$var exceeds storage size");
@@ -33,6 +33,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/game_settings.ini
+++ b/src/table/settings/game_settings.ini
@@ -26,12 +26,12 @@ static const SettingVariant _game_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDTG_BOOL  =  SDTG_BOOL($name,                     $flags, $var, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
-SDTG_VAR   =   SDTG_VAR($name,              $type, $flags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
-SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
-SDT_OMANY  =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $load, $cat, $extra, $startup),
-SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_BOOL  =  SDTG_BOOL($name,                     $flags, $var, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_VAR   =   SDTG_VAR($name,              $type, $flags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDT_OMANY  =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $load, $cat, $extra, $startup),
+SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -49,6 +49,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -25,9 +25,9 @@ static const SettingVariant _gui_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTC_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -44,6 +44,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/linkgraph_settings.ini
+++ b/src/table/settings/linkgraph_settings.ini
@@ -12,7 +12,7 @@ static const SettingVariant _linkgraph_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
+SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for GameSettings.$var exceeds storage size");
@@ -28,6 +28,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/locale_settings.ini
+++ b/src/table/settings/locale_settings.ini
@@ -21,8 +21,8 @@ static const SettingVariant _locale_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDTG_OMANY = SDTG_OMANY($name,              $type, $flags, $var, $def,       $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
-SDT_OMANY  =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $load, $cat, $extra, $startup),
+SDTG_OMANY = SDTG_OMANY($name,              $type, $flags, $var, $def,       $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDT_OMANY  =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $load, $cat, $extra, $startup),
 SDT_SSTR   =   SDT_SSTR(GameSettings, $var, $type, $flags, $def,                                                       $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
@@ -40,6 +40,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/misc_settings.ini
+++ b/src/table/settings/misc_settings.ini
@@ -25,11 +25,11 @@ static const SettingVariant _misc_settings_table[] = {
 };
 [templates]
 SDTG_LIST  =  SDTG_LIST($name, $type, $flags, $var, $def,       $length,                                                            $from, $to, $cat, $extra, $startup),
-SDTG_MMANY = SDTG_MMANY($name, $type, $flags, $var, $def,                        $full, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $cat, $extra, $startup),
-SDTG_OMANY = SDTG_OMANY($name, $type, $flags, $var, $def,       $max,            $full, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $cat, $extra, $startup),
+SDTG_MMANY = SDTG_MMANY($name, $type, $flags, $var, $def,                        $full, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
+SDTG_OMANY = SDTG_OMANY($name, $type, $flags, $var, $def,       $max,            $full, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
 SDTG_SSTR  =  SDTG_SSTR($name, $type, $flags, $var, $def,       0,                                               $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDTG_BOOL  =  SDTG_BOOL($name,        $flags, $var, $def,                               $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $cat, $extra, $startup),
-SDTG_VAR   =   SDTG_VAR($name, $type, $flags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $cat, $extra, $startup),
+SDTG_BOOL  =  SDTG_BOOL($name,        $flags, $var, $def,                               $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
+SDTG_VAR   =   SDTG_VAR($name, $type, $flags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -46,6 +46,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/multimedia_settings.ini
+++ b/src/table/settings/multimedia_settings.ini
@@ -12,9 +12,9 @@ static const SettingVariant _multimedia_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 SDTC_LIST  =  SDTC_LIST(              $var, $type, $flags, $def,                                                                          $from, $to,        $cat, $extra, $startup),
-SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTC_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -30,6 +30,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/network_private_settings.ini
+++ b/src/table/settings/network_private_settings.ini
@@ -14,8 +14,8 @@ static const SettingVariant _network_private_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 SDTC_SSTR  =  SDTC_SSTR(              $var, $type, $flags, $def,             $length,                                  $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
@@ -32,6 +32,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/network_settings.ini
+++ b/src/table/settings/network_settings.ini
@@ -16,9 +16,9 @@ static const SettingVariant _network_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTC_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -35,6 +35,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/news_display_settings.ini
+++ b/src/table/settings/news_display_settings.ini
@@ -13,7 +13,7 @@ static const SettingVariant _news_display_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTC_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -29,6 +29,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/old_gameopt_settings.ini
+++ b/src/table/settings/old_gameopt_settings.ini
@@ -31,12 +31,12 @@ static const SettingVariant _old_gameopt_settings_table[] = {
 };
 [templates]
 SDTG_LIST    =  SDTG_LIST($name,              $type, $flags, $var, $def, $length, $from, $to, $cat, $extra, $startup),
-SDTG_VAR     =   SDTG_VAR($name,              $type, $flags, $var, $def, $min, $max, $interval,  $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $cat, $extra, $startup),
-SDT_NULL     =   SDT_NULL(                                                          $length,                                                            $from, $to),
-SDTC_OMANY   = SDTC_OMANY(              $var, $type, $flags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
-SDTG_OMANY   = SDTG_OMANY($name,              $type, $flags, $var, $def, $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
-SDT_OMANY    =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $load, $cat, $extra, $startup),
-SDT_VAR      =    SDT_VAR(GameSettings, $var, $type, $flags, $def, $min, $max,        $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_VAR     =   SDTG_VAR($name,              $type, $flags, $var, $def, $min, $max, $interval,  $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
+SDT_NULL     =   SDT_NULL(                                                          $length,                                                                                      $from, $to),
+SDTC_OMANY   = SDTC_OMANY(              $var, $type, $flags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_OMANY   = SDTG_OMANY($name,              $type, $flags, $var, $def, $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDT_OMANY    =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $load, $cat, $extra, $startup),
+SDT_VAR      =    SDT_VAR(GameSettings, $var, $type, $flags, $def, $min, $max,        $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -56,6 +56,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/pathfinding_settings.ini
+++ b/src/table/settings/pathfinding_settings.ini
@@ -14,8 +14,8 @@ static const SettingVariant _pathfinding_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
-SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
+SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for GameSettings.$var exceeds storage size");
@@ -31,6 +31,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/script_settings.ini
+++ b/src/table/settings/script_settings.ini
@@ -13,9 +13,9 @@ static const SettingVariant _script_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
-SDT_OMANY  =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $load, $cat, $extra, $startup),
-SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
+SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDT_OMANY  =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $load, $cat, $extra, $startup),
+SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDT_OMANY = static_assert($max <= MAX_$type, "Maximum value for GameSettings.$var exceeds storage size");
@@ -32,6 +32,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/win32_settings.ini
+++ b/src/table/settings/win32_settings.ini
@@ -17,8 +17,8 @@ static const SettingVariant _win32_settings_table[] = {
 };
 #endif /* _WIN32 */
 [templates]
-SDTG_BOOL = SDTG_BOOL($name,        $flags, $var, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $cat, $extra, $startup),
-SDTG_VAR  =  SDTG_VAR($name, $type, $flags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $cat, $extra, $startup),
+SDTG_BOOL = SDTG_BOOL($name,        $flags, $var, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
+SDTG_VAR  =  SDTG_VAR($name, $type, $flags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -34,6 +34,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/window_settings.ini
+++ b/src/table/settings/window_settings.ini
@@ -13,8 +13,8 @@ static const SettingVariant _window_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDT_BOOL = SDT_BOOL(WindowDesc, $var,        $flags, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $cat, $extra, $startup),
-SDT_VAR  =  SDT_VAR(WindowDesc, $var, $type, $flags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $cat, $extra, $startup),
+SDT_BOOL = SDT_BOOL(WindowDesc, $var,        $flags, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
+SDT_VAR  =  SDT_VAR(WindowDesc, $var, $type, $flags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for WindowDesc.$var exceeds storage size");
@@ -30,6 +30,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/world_settings.ini
+++ b/src/table/settings/world_settings.ini
@@ -18,9 +18,9 @@ static const SettingVariant _world_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
-SDT_OMANY  =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to, $load, $cat, $extra, $startup),
-SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $from, $to,        $cat, $extra, $startup),
+SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDT_OMANY  =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $load, $cat, $extra, $startup),
+SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDT_OMANY = static_assert($max <= MAX_$type, "Maximum value for GameSettings.$var exceeds storage size");
@@ -37,6 +37,7 @@ post_cb  = nullptr
 str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
+def_cb   = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION


### PR DESCRIPTION
## Motivation / Problem

Fixes #11345

The Default button reads the value in `sd->def`, which only allows one value to be stored. Thus, it tries to reset to the default value in days, which is not possible when service interval are in other units.

The Default Value Text also reads the value in `sd->def` and always displays the same string, which can be confusing.

## Description

A callback is added to correct the value read from `sd->def`.

The `set_value_dparams_cb` callback is also used to supply the correct value string.

![CleanShot 2024-03-25 at 17 43 31](https://github.com/OpenTTD/OpenTTD/assets/138728580/21a7cb32-e87a-450d-9229-dcf3c2c3ead0)

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
