### PR TITLE
Fix: server shutdown and newgame packets should be stable

### DIFF
--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -24,10 +24,9 @@
  */
 enum PacketGameType : uint8_t {
 	/*
-	 * These first four pair of packets (thus eight in
-	 * total) must remain in this order for backward
-	 * and forward compatibility between clients that
-	 * are trying to join directly.
+	 * These first ten packets must remain in this order for backward and forward compatibility
+	 * between clients that are trying to join directly. These packets can be received and/or sent
+	 * by the server before the server has processed the 'join' packet from the client.
 	 */
 
 	/* Packets sent by socket accepting code without ever constructing a client socket instance. */
@@ -45,6 +44,10 @@ enum PacketGameType : uint8_t {
 	/* Packets used to get the game info. */
 	PACKET_SERVER_GAME_INFO,             ///< Information about the server.
 	PACKET_CLIENT_GAME_INFO,             ///< Request information about the server.
+
+	/* A server quitting this game. */
+	PACKET_SERVER_NEWGAME,               ///< The server is preparing to start a new game.
+	PACKET_SERVER_SHUTDOWN,              ///< The server is shutting down.
 
 	/*
 	 * Packets after here assume that the client
@@ -120,10 +123,6 @@ enum PacketGameType : uint8_t {
 	PACKET_CLIENT_SET_NAME,              ///< A client changes its name.
 	PACKET_SERVER_COMPANY_UPDATE,        ///< Information (password) of a company changed.
 	PACKET_SERVER_CONFIG_UPDATE,         ///< Some network configuration important to the client changed.
-
-	/* A server quitting this game. */
-	PACKET_SERVER_NEWGAME,               ///< The server is preparing to start a new game.
-	PACKET_SERVER_SHUTDOWN,              ///< The server is shutting down.
 
 	/* A client quitting. */
 	PACKET_CLIENT_QUIT,                  ///< A client tells the server it is going to quit.


### PR DESCRIPTION
## Motivation / Problem

The server sends shutdown and new game (reboot) packets to any connected client. This can be useful, so you can tell clients that are trying to join that the server is restarting. However, that means that packets can be sent before a version check has been done.

So, these packets should be in the stable packet range instead of the one that is unstable and guarded by a version check.


## Description

Move the packets to the stable range.


## Limitations

This somewhat breaks the assumption of earlier clients, but then those were using the "unstable" range of packets so they have already been broken a number of times. For example about 3 years ago when external chat got added, and more recently when x25519 authentication was added to the game.

This will break 'py-protocol', but that was already broken by adding the x25519 authentication, so it would be better to break it in such a manner that it will keep working in the future.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
