### PR TITLE
Codechange: move knowledge about 'packed' orders to the saveload code

### DIFF
--- a/src/order_base.h
+++ b/src/order_base.h
@@ -45,23 +45,22 @@ private:
 	friend EndianBufferWriter<Tcont, Titer> &operator <<(EndianBufferWriter<Tcont, Titer> &buffer, const Order &data);
 	friend class EndianBufferReader &operator >>(class EndianBufferReader &buffer, Order &order);
 
-	uint8_t type;           ///< The type of order + non-stop flags
-	uint8_t flags;          ///< Load/unload types, depot order/action types.
-	DestinationID dest;   ///< The destination of the order.
+	uint8_t type = 0; ///< The type of order + non-stop flags
+	uint8_t flags = 0; ///< Load/unload types, depot order/action types.
+	DestinationID dest = 0; ///< The destination of the order.
 
-	CargoID refit_cargo;  ///< Refit CargoID
+	CargoID refit_cargo = CARGO_NO_REFIT; ///< Refit CargoID
 
-	uint16_t wait_time;    ///< How long in ticks to wait at the destination.
-	uint16_t travel_time;  ///< How long in ticks the journey to this destination should take.
-	uint16_t max_speed;    ///< How fast the vehicle may go on the way to the destination.
+	uint16_t wait_time = 0; ///< How long in ticks to wait at the destination.
+	uint16_t travel_time = 0; ///< How long in ticks the journey to this destination should take.
+	uint16_t max_speed = UINT16_MAX; ///< How fast the vehicle may go on the way to the destination.
 
 public:
-	Order *next;          ///< Pointer to next order. If nullptr, end of list
+	Order *next = nullptr; ///< Pointer to next order. If nullptr, end of list
 
-	Order() : flags(0), refit_cargo(CARGO_NO_REFIT), wait_time(0), travel_time(0), max_speed(UINT16_MAX) {}
+	Order() {}
+	Order(uint8_t type, uint8_t flags, DestinationID dest) : type(type), flags(flags), dest(dest) {}
 	~Order();
-
-	Order(uint32_t packed);
 
 	/**
 	 * Check whether this order is of the given type.

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -228,22 +228,6 @@ uint16_t Order::MapOldOrder() const
 }
 
 /**
- * Create an order based on a packed representation of that order.
- * @param packed the packed representation.
- */
-Order::Order(uint32_t packed)
-{
-	this->type    = (OrderType)GB(packed,  0,  8);
-	this->flags   = GB(packed,  8,  8);
-	this->dest    = GB(packed, 16, 16);
-	this->next    = nullptr;
-	this->refit_cargo   = CARGO_NO_REFIT;
-	this->wait_time     = 0;
-	this->travel_time   = 0;
-	this->max_speed     = UINT16_MAX;
-}
-
-/**
  *
  * Updates the widgets of a vehicle which contains the order-data
  *

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -386,10 +386,8 @@ void DrawOrderString(const Vehicle *v, const Order *order, int order_index, int 
  */
 static Order GetOrderCmdFromTile(const Vehicle *v, TileIndex tile)
 {
-	/* Hack-ish; unpack order 0, so everything gets initialised with either zero
-	 * or a suitable default value for the variable. Then also override the index
-	 * as it is not coming from a pool, so would be initialised. */
-	Order order(0);
+	/* Override the index as it is not coming from a pool, so would not be initialised correctly. */
+	Order order;
 	order.index = 0;
 
 	/* check depot first */

--- a/src/saveload/order_sl.cpp
+++ b/src/saveload/order_sl.cpp
@@ -81,7 +81,7 @@ void Order::ConvertFromOldSavegame()
  */
 static Order UnpackVersion4Order(uint16_t packed)
 {
-	return Order(GB(packed, 8, 8) << 16 | GB(packed, 4, 4) << 8 | GB(packed, 0, 4));
+	return Order(GB(packed, 0, 4), GB(packed, 4, 4), GB(packed, 8, 8));
 }
 
 /**
@@ -158,7 +158,7 @@ struct ORDRChunkHandler : ChunkHandler {
 				SlCopy(&orders[0], len, SLE_UINT32);
 
 				for (size_t i = 0; i < len; ++i) {
-					new (i) Order(orders[i]);
+					new (i) Order(GB(orders[i], 0, 8), GB(orders[i], 8, 8), GB(orders[i], 16, 16));
 				}
 			}
 


### PR DESCRIPTION
## Motivation / Problem

There is a 'packed' version of the `Order` constructor which is (essentially) only called from saveload for versions less that `SLV_5`. That smells a lot like saveload specific code to me, and as such belongs there.


## Description

Default initialise everything in `Order`.
Replace the 'packed' constructor with one that just has the three unpacked parameters.
Replace GUI call that required a properly initialised `Order` to just use the default constructor, that initialises everything.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
