### PR TITLE
Fix #12388: Vehicle::CopyVehicleConfigAndStatistics not releasing unit number

### DIFF
--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -1336,8 +1336,7 @@ CommandCost CmdMoveRailVehicle(DoCommandFlag flags, VehicleID src_veh, VehicleID
 			}
 			/* Remove stuff not valid anymore for non-front engines. */
 			DeleteVehicleOrders(src);
-			Company::Get(src->owner)->freeunits[src->type].ReleaseID(src->unitnumber);
-			src->unitnumber = 0;
+			src->ReleaseUnitNumber();
 			src->name.clear();
 		}
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2402,6 +2402,15 @@ void Vehicle::ResetRefitCaps()
 }
 
 /**
+ * Release the vehicle's unit number.
+ */
+void Vehicle::ReleaseUnitNumber()
+{
+	Company::Get(this->owner)->freeunits[this->type].ReleaseID(this->unitnumber);
+	this->unitnumber = 0;
+}
+
+/**
  * Handle the loading of the vehicle; when not it skips through dummy
  * orders and does nothing in all other cases.
  * @param mode is the non-first call for this vehicle in this tick?

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -750,6 +750,8 @@ public:
 
 	void ResetRefitCaps();
 
+	void ReleaseUnitNumber();
+
 	/**
 	 * Copy certain configurations and statistics of a vehicle after successful autoreplace/renew
 	 * The function shall copy everything that cannot be copied by a command (like orders / group etc),
@@ -760,6 +762,7 @@ public:
 	{
 		this->CopyConsistPropertiesFrom(src);
 
+		this->ReleaseUnitNumber();
 		this->unitnumber = src->unitnumber;
 
 		this->current_order = src->current_order;


### PR DESCRIPTION
## Motivation / Problem

#12388
Vehicle::CopyVehicleConfigAndStatistics does not release the current unit number before move-assigning the unit number of the source vehicle

## Description

Fix the above

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
