### PR TITLE
Feature: Allow base sounds set to be changed mid-game.

### DIFF
--- a/src/mixer.h
+++ b/src/mixer.h
@@ -27,6 +27,7 @@ MixerChannel *MxAllocateChannel();
 void MxSetChannelRawSrc(MixerChannel *mc, int8_t *mem, size_t size, uint rate, bool is16bit);
 void MxSetChannelVolume(MixerChannel *mc, uint volume, float pan);
 void MxActivateChannel(MixerChannel*);
+void MxCloseAllChannels();
 
 uint32_t MxSetMusicSource(MxStreamCallback music_callback);
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -47,6 +47,7 @@
 #include "network/network_survey.h"
 #include "video/video_driver.hpp"
 #include "social_integration.h"
+#include "sound_func.h"
 
 #include "safeguards.h"
 
@@ -940,13 +941,7 @@ struct GameOptionsWindow : Window {
 				break;
 
 			case WID_GO_BASE_SFX_DROPDOWN:
-				if (_game_mode == GM_MENU) {
-					auto set = BaseSounds::GetSet(index);
-					BaseSounds::ini_set = set->name;
-					BaseSounds::SetSet(set);
-					this->reload = true;
-					this->InvalidateData();
-				}
+				ChangeSoundSet(index);
 				break;
 
 			case WID_GO_BASE_MUSIC_DROPDOWN:
@@ -982,7 +977,6 @@ struct GameOptionsWindow : Window {
 #endif /* HAS_TRUETYPE_FONT */
 
 		this->SetWidgetDisabledState(WID_GO_BASE_GRF_DROPDOWN, _game_mode != GM_MENU);
-		this->SetWidgetDisabledState(WID_GO_BASE_SFX_DROPDOWN, _game_mode != GM_MENU);
 
 		this->SetWidgetDisabledState(WID_GO_BASE_GRF_PARAMETERS, BaseGraphics::GetUsedSet() == nullptr || !BaseGraphics::GetUsedSet()->IsConfigurable());
 

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -234,6 +234,34 @@ void SndCopyToPool()
 }
 
 /**
+ * Change the configured sound set and reset sounds.
+ * @param index Index of sound set to switch to.
+ */
+void ChangeSoundSet(int index)
+{
+	if (BaseSounds::GetIndexOfUsedSet() == index) return;
+
+	auto set = BaseSounds::GetSet(index);
+	BaseSounds::ini_set = set->name;
+	BaseSounds::SetSet(set);
+
+	MxCloseAllChannels();
+	InitializeSound();
+
+	/* Replace baseset sounds in the pool with the updated original sounds. This is safe to do as
+	 * any sound still playing owns its sample data. */
+	for (uint i = 0; i < ORIGINAL_SAMPLE_COUNT; i++) {
+		SoundEntry *sound = GetSound(i);
+		/* GRF Container 0 means the sound comes from the baseset, and isn't overridden by NewGRF. */
+		if (sound == nullptr || sound->grf_container_ver != 0) continue;
+
+		*sound = _original_sounds[_sound_idx[i]];
+		sound->volume = _sound_base_vol[i];
+		sound->priority = 0;
+	}
+}
+
+/**
  * Decide 'where' (between left and right speaker) to play the sound effect.
  * Note: Callers must determine if sound effects are enabled. This plays a sound regardless of the setting.
  * @param sound Sound effect to play

--- a/src/sound_func.h
+++ b/src/sound_func.h
@@ -14,6 +14,8 @@
 #include "vehicle_type.h"
 #include "tile_type.h"
 
+void ChangeSoundSet(int index);
+
 void SndPlayTileFx(SoundID sound, TileIndex tile);
 void SndPlayVehicleFx(SoundID sound, const Vehicle *v);
 void SndPlayFx(SoundID sound);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Baseset sounds cannot be changed while a game is running.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Allow changing base sounds during the game from the Game Options window.

This is achieved by stopping all currently playing sounds, reloading the `_original_sounds` array with the new baseset, and then updating the 'sound pool' to replace the baseset (non-NewGRF) sound information.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations



<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
