### PR TITLE
Fix: [Win32] Force font mapper to only use TrueType fonts

### DIFF
--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -115,10 +115,6 @@ bool SetFallbackFont(FontCacheSettings *settings, const std::string &, int winla
 }
 
 
-#ifndef ANTIALIASED_QUALITY
-#define ANTIALIASED_QUALITY     4
-#endif
-
 /**
  * Create a new Win32FontCache.
  * @param fs      The font size that is going to be cached.
@@ -171,7 +167,8 @@ void Win32FontCache::SetFontSize(int pixels)
 	/* Create GDI font handle. */
 	this->logfont.lfHeight = -pixels;
 	this->logfont.lfWidth = 0;
-	this->logfont.lfOutPrecision = ANTIALIASED_QUALITY;
+	this->logfont.lfOutPrecision = OUT_TT_ONLY_PRECIS;
+	this->logfont.lfQuality = ANTIALIASED_QUALITY;
 
 	if (this->font != nullptr) {
 		SelectObject(dc, this->old_font);


### PR DESCRIPTION
Maybe fix #12404
Maybe fix #12125 
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
`this->logfont.lfOutPrecision` is set with a "wrong" value (`ANTIALIASED_QUALITY` has the same value as `OUT_TT_PRECIS`)

`OUT_TT_PRECIS`  instructs the font mapper to choose a TrueType font when the system contains multiple fonts with the same name, which means it might select a non TrueType font if the system doesn't have any TrueType font for the given name.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Use `ANTIALIASED_QUALITY` for the right member (`lfQuality`). While at it remove the unneeded manual definition of the macro.

Use `OUT_TT_ONLY_PRECIS` to tell the font mapper to choose from only TrueType fonts.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
