### PR TITLE
Codechange: Remove per font AA settings.

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2181,10 +2181,10 @@ DEF_CONSOLE_CMD(ConFont)
 		IConsolePrint(CC_HELP, "  Print out the fonts configuration.");
 		IConsolePrint(CC_HELP, "  The \"Currently active\" configuration is the one actually in effect (after interface scaling and replacing unavailable fonts).");
 		IConsolePrint(CC_HELP, "  The \"Requested\" configuration is the one requested via console command or config file.");
-		IConsolePrint(CC_HELP, "Usage 'font [medium|small|large|mono] [<font name>] [<size>] [aa|noaa]'.");
+		IConsolePrint(CC_HELP, "Usage 'font [medium|small|large|mono] [<font name>] [<size>]'.");
 		IConsolePrint(CC_HELP, "  Change the configuration for a font.");
 		IConsolePrint(CC_HELP, "  Omitting an argument will keep the current value.");
-		IConsolePrint(CC_HELP, "  Set <font name> to \"\" for the default font. Note that <size> and aa/noaa have no effect if the default font is in use, and fixed defaults are used instead.");
+		IConsolePrint(CC_HELP, "  Set <font name> to \"\" for the default font. Note that <size> has no effect if the default font is in use, and fixed defaults are used instead.");
 		IConsolePrint(CC_HELP, "  If the sprite font is enabled in Game Options, it is used instead of the default font.");
 		IConsolePrint(CC_HELP, "  The <size> is automatically multiplied by the current interface scaling.");
 		return true;
@@ -2202,38 +2202,23 @@ DEF_CONSOLE_CMD(ConFont)
 		FontCacheSubSetting *setting = GetFontCacheSubSetting(argfs);
 		std::string font = setting->font;
 		uint size = setting->size;
-		bool aa = setting->aa;
-
+		uint v;
 		uint8_t arg_index = 2;
-		/* We may encounter "aa" or "noaa" but it must be the last argument. */
-		if (StrEqualsIgnoreCase(argv[arg_index], "aa") || StrEqualsIgnoreCase(argv[arg_index], "noaa")) {
-			aa = !StrStartsWithIgnoreCase(argv[arg_index++], "no");
-			if (argc > arg_index) return false;
-		} else {
-			/* For <name> we want a string. */
-			uint v;
-			if (!GetArgumentInteger(&v, argv[arg_index])) {
-				font = argv[arg_index++];
-			}
+		/* For <name> we want a string. */
+
+		if (!GetArgumentInteger(&v, argv[arg_index])) {
+			font = argv[arg_index++];
 		}
 
 		if (argc > arg_index) {
 			/* For <size> we want a number. */
-			uint v;
 			if (GetArgumentInteger(&v, argv[arg_index])) {
 				size = v;
 				arg_index++;
 			}
 		}
 
-		if (argc > arg_index) {
-			/* Last argument must be "aa" or "noaa". */
-			if (!StrEqualsIgnoreCase(argv[arg_index], "aa") && !StrEqualsIgnoreCase(argv[arg_index], "noaa")) return false;
-			aa = !StrStartsWithIgnoreCase(argv[arg_index++], "no");
-			if (argc > arg_index) return false;
-		}
-
-		SetFont(argfs, font, size, aa);
+		SetFont(argfs, font, size);
 	}
 
 	for (FontSize fs = FS_BEGIN; fs < FS_END; fs++) {
@@ -2245,8 +2230,8 @@ DEF_CONSOLE_CMD(ConFont)
 			fc = FontCache::Get(fs);
 		}
 		IConsolePrint(CC_DEFAULT, "{} font:", FontSizeToName(fs));
-		IConsolePrint(CC_DEFAULT, "Currently active: \"{}\", size {}, {}", fc->GetFontName(), fc->GetFontSize(), GetFontAAState(fs) ? "aa" : "noaa");
-		IConsolePrint(CC_DEFAULT, "Requested: \"{}\", size {}, {}", setting->font, setting->size, setting->aa ? "aa" : "noaa");
+		IConsolePrint(CC_DEFAULT, "Currently active: \"{}\", size {}", fc->GetFontName(), fc->GetFontSize());
+		IConsolePrint(CC_DEFAULT, "Requested: \"{}\", size {}", setting->font, setting->size);
 	}
 
 	return true;

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -91,15 +91,15 @@ int GetCharacterHeight(FontSize size)
 }
 
 /* Check if a glyph should be rendered with anti-aliasing. */
-bool GetFontAAState(FontSize size, bool check_blitter)
+bool GetFontAAState()
 {
 	/* AA is only supported for 32 bpp */
-	if (check_blitter && BlitterFactory::GetCurrentBlitter()->GetScreenDepth() != 32) return false;
+	if (BlitterFactory::GetCurrentBlitter()->GetScreenDepth() != 32) return false;
 
-	return _fcsettings.global_aa || GetFontCacheSubSetting(size)->aa;
+	return _fcsettings.global_aa;
 }
 
-void SetFont(FontSize fontsize, const std::string &font, uint size, bool aa)
+void SetFont(FontSize fontsize, const std::string &font, uint size)
 {
 	FontCacheSubSetting *setting = GetFontCacheSubSetting(fontsize);
 	bool changed = false;
@@ -111,11 +111,6 @@ void SetFont(FontSize fontsize, const std::string &font, uint size, bool aa)
 
 	if (setting->size != size) {
 		setting->size = size;
-		changed = true;
-	}
-
-	if (setting->aa != aa) {
-		setting->aa = aa;
 		changed = true;
 	}
 
@@ -231,19 +226,6 @@ void UninitFontCache()
 #ifdef WITH_FREETYPE
 	UninitFreeType();
 #endif /* WITH_FREETYPE */
-}
-
-/**
- * Should any of the active fonts be anti-aliased?
- * @return True if any of the loaded fonts want anti-aliased drawing.
- */
-bool HasAntialiasedFonts()
-{
-	for (FontSize fs = FS_BEGIN; fs < FS_END; fs++) {
-		if (!FontCache::Get(fs)->IsBuiltInFont() && GetFontAAState(fs, false)) return true;
-	}
-
-	return false;
 }
 
 #if !defined(_WIN32) && !defined(__APPLE__) && !defined(WITH_FONTCONFIG) && !defined(WITH_COCOA)

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -207,7 +207,6 @@ inline bool GetDrawGlyphShadow(FontSize size)
 struct FontCacheSubSetting {
 	std::string font; ///< The name of the font, or path to the font.
 	uint size;        ///< The (requested) size of the font.
-	bool aa;          ///< Whether to do anti aliasing or not.
 
 	const void *os_handle = nullptr; ///< Optional native OS font info. Only valid during font search.
 };
@@ -242,9 +241,8 @@ inline FontCacheSubSetting *GetFontCacheSubSetting(FontSize fs)
 
 void InitFontCache(bool monospace);
 void UninitFontCache();
-bool HasAntialiasedFonts();
 
-bool GetFontAAState(FontSize size, bool check_blitter = true);
-void SetFont(FontSize fontsize, const std::string &font, uint size, bool aa);
+bool GetFontAAState();
+void SetFont(FontSize fontsize, const std::string &font, uint size);
 
 #endif /* FONTCACHE_H */

--- a/src/fontcache/truetypefontcache.cpp
+++ b/src/fontcache/truetypefontcache.cpp
@@ -91,7 +91,7 @@ void TrueTypeFontCache::SetGlyphPtr(GlyphID key, const GlyphEntry *glyph, bool d
 
 bool TrueTypeFontCache::GetDrawGlyphShadow()
 {
-	return this->fs == FS_NORMAL && GetFontAAState(FS_NORMAL);
+	return this->fs == FS_NORMAL && GetFontAAState();
 }
 
 uint TrueTypeFontCache::GetGlyphWidth(GlyphID key)
@@ -162,7 +162,7 @@ const Sprite *TrueTypeFontCache::GetGlyph(GlyphID key)
 		}
 	}
 
-	return this->InternalGetGlyph(key, GetFontAAState(this->fs));
+	return this->InternalGetGlyph(key, GetFontAAState());
 }
 
 const void *TrueTypeFontCache::GetFontTable(uint32_t tag, size_t &length)

--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -151,7 +151,7 @@ void ICURun::Shape(UChar *buff, size_t buff_length)
 {
 	auto hbfont = hb_ft_font_create_referenced(*(static_cast<const FT_Face *>(font->fc->GetOSHandle())));
 	/* Match the flags with how we render the glyphs. */
-	hb_ft_font_set_load_flags(hbfont, GetFontAAState(this->font->fc->GetSize()) ? FT_LOAD_TARGET_NORMAL : FT_LOAD_TARGET_MONO);
+	hb_ft_font_set_load_flags(hbfont, GetFontAAState() ? FT_LOAD_TARGET_NORMAL : FT_LOAD_TARGET_MONO);
 
 	/* ICU buffer is in UTF-16. */
 	auto hbbuf = hb_buffer_create();

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -266,7 +266,7 @@ static bool SwitchNewGRFBlitter()
 		if (c->palette & GRFP_BLT_32BPP) depth_wanted_by_grf = 32;
 	}
 	/* We need a 32bpp blitter for font anti-alias. */
-	if (HasAntialiasedFonts()) depth_wanted_by_grf = 32;
+	if (GetFontAAState()) depth_wanted_by_grf = 32;
 
 	/* Search the best blitter. */
 	static const struct {

--- a/src/table/settings/misc_settings.ini
+++ b/src/table/settings/misc_settings.ini
@@ -239,30 +239,6 @@ max      = 72
 
 [SDTG_BOOL]
 ifdef    = HAS_TRUETYPE_FONT
-name     = ""small_aa""
-var      = _fcsettings.small.aa
-def      = false
-
-[SDTG_BOOL]
-ifdef    = HAS_TRUETYPE_FONT
-name     = ""medium_aa""
-var      = _fcsettings.medium.aa
-def      = false
-
-[SDTG_BOOL]
-ifdef    = HAS_TRUETYPE_FONT
-name     = ""large_aa""
-var      = _fcsettings.large.aa
-def      = false
-
-[SDTG_BOOL]
-ifdef    = HAS_TRUETYPE_FONT
-name     = ""mono_aa""
-var      = _fcsettings.mono.aa
-def      = false
-
-[SDTG_BOOL]
-ifdef    = HAS_TRUETYPE_FONT
 name     = ""global_aa""
 var      = _fcsettings.global_aa
 def      = true


### PR DESCRIPTION
OpenTTD will use the global AA font setting for all fonts from now on.

<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link t
-->


## Description

Console font command allow users to change aa settings per font while the settings UI only allows AA to be enabled/disabled globally.

This change will resolve that inconsistency by removing the per font aa settings and amending the font console command.  The font console command was expanded with an option to toggle AA globally. AA state is now consistent across the UI and console output. 

## Limitations

There's a check to see if the current blitter supports AA.  It's not obvious to me when the blitter would be in a state where that would fail. That's not a new quirk though.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
