### PR TITLE
Change: replace liblzma with libarchive for OTTX savegame format

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -53,12 +53,12 @@ jobs:
 
         echo "::group::Install dependencies"
         sudo apt-get install -y --no-install-recommends \
+          libarchive-dev \
           liballegro4-dev \
           libcurl4-openssl-dev \
           libfontconfig-dev \
           libharfbuzz-dev \
           libicu-dev \
-          liblzma-dev \
           liblzo2-dev \
           ${{ inputs.libraries }} \
           zlib1g-dev \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,12 +47,12 @@ jobs:
 
         echo "::group::Install dependencies"
         sudo apt-get install -y --no-install-recommends \
+          libarchive-dev \
           liballegro4-dev \
           libcurl4-openssl-dev \
           libfontconfig-dev \
           libharfbuzz-dev \
           libicu-dev \
-          liblzma-dev \
           liblzo2-dev \
           libsdl2-dev \
           zlib1g-dev \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,9 +121,9 @@ set(CMAKE_THREAD_PREFER_PTHREAD YES)
 find_package(Threads REQUIRED)
 
 find_package(ZLIB)
-find_package(LibLZMA)
 find_package(LZO)
 find_package(PNG)
+find_package(LibArchive)
 
 if(WIN32 OR EMSCRIPTEN)
     # Windows uses WinHttp for HTTP requests.
@@ -310,7 +310,7 @@ process_compile_flags()
 include(LinkPackage)
 link_package(PNG TARGET PNG::PNG ENCOURAGED)
 link_package(ZLIB TARGET ZLIB::ZLIB ENCOURAGED)
-link_package(LIBLZMA TARGET LibLZMA::LibLZMA ENCOURAGED)
+link_package(LibArchive TARGET LibArchive::LibArchive ENCOURAGED)
 link_package(LZO)
 
 if(NOT WIN32 AND NOT EMSCRIPTEN)

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -7,7 +7,7 @@ OpenTTD makes use of the following external libraries:
 - (encouraged) breakpad: creates minidumps on crash
 - (encouraged) zlib: (de)compressing of old (0.3.0-1.0.5) savegames, content downloads,
    heightmaps
-- (encouraged) liblzma: (de)compressing of savegames (1.1.0 and later)
+- (encouraged) libarchive: (de)compressing of savegames (1.1.0 and later)
 - (encouraged) libpng: making screenshots and loading heightmaps
 - (optional) liblzo2: (de)compressing of old (pre 0.3.0) savegames
 
@@ -24,7 +24,7 @@ For Linux, the following additional libraries are used:
 If you are building a dedicated-server only, you don't need the last four.
 
 OpenTTD does not require any of the libraries to be present, but without
-liblzma you cannot open most recent savegames and without zlib you cannot
+libarchive you cannot open most recent savegames and without zlib you cannot
 open most older savegames or use the content downloading system.
 
 ## Windows
@@ -51,7 +51,7 @@ After this, you can install the dependencies OpenTTD needs. We advise to use
 the `static` versions, and OpenTTD currently needs the following dependencies:
 
 - breakpad
-- liblzma
+- libarchive
 - libpng
 - lzo
 - zlib

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -287,7 +287,7 @@ INCLUDE_PATH           =
 INCLUDE_FILE_PATTERNS  =
 PREDEFINED             = WITH_ZLIB \
                          WITH_LZO \
-                         WITH_LIBLZMA \
+                         WITH_LIBARCHIVE \
                          WITH_SDL \
                          WITH_PNG \
                          WITH_FONTCONFIG \

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -141,7 +141,7 @@ struct PacketWriter : SaveFilter {
 		return false;
 	}
 
-	void Write(uint8_t *buf, size_t size) override
+	void Write(const uint8_t *buf, size_t size) override
 	{
 		std::lock_guard<std::mutex> lock(this->mutex);
 

--- a/src/saveload/saveload_filter.h
+++ b/src/saveload/saveload_filter.h
@@ -78,7 +78,7 @@ struct SaveFilter {
 	 * @param buf The bytes to write.
 	 * @param len The number of bytes to write.
 	 */
-	virtual void Write(uint8_t *buf, size_t len) = 0;
+	virtual void Write(const uint8_t *buf, size_t len) = 0;
 
 	/**
 	 * Prepare everything to finish writing the savegame.

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -149,13 +149,6 @@
 #		endif
 #	endif
 
-	/* liblzma from vcpkg (before 5.2.4-2) used to patch lzma.h to define LZMA_API_STATIC for static builds */
-#	if defined(WITH_LIBLZMA)
-#		if !defined(LZMA_API_STATIC)
-#			define LZMA_API_STATIC
-#		endif
-#	endif
-
 	/* MSVC doesn't have these :( */
 #	define S_ISDIR(mode) (mode & S_IFDIR)
 #	define S_ISREG(mode) (mode & S_IFREG)

--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -57,8 +57,8 @@
 #ifdef WITH_ICU_I18N
 #	include <unicode/uversion.h>
 #endif /* WITH_ICU_I18N */
-#ifdef WITH_LIBLZMA
-#	include <lzma.h>
+#ifdef WITH_LIBARCHIVE
+#	include <archive.h>
 #endif
 #ifdef WITH_LZO
 #include <lzo/lzo1x.h>
@@ -429,8 +429,8 @@ void SurveyLibraries(nlohmann::json &survey)
 	survey["icu_i18n"] = buf;
 #endif /* WITH_ICU_I18N */
 
-#ifdef WITH_LIBLZMA
-	survey["lzma"] = lzma_version_string();
+#ifdef WITH_LIBARCHIVE
+	survey["archive"] = archive_version_string();
 #endif
 
 #ifdef WITH_LZO

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -34,7 +34,11 @@
       "platform": "linux"
     },
     {
-      "name": "liblzma"
+      "name": "libarchive",
+      "default-features": false,
+      "features": [
+        "lzma"
+      ]
     },
     {
       "name": "libpng"


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Current context: xz has a backdoor in 5.6.0 which exploits sshd (and only sshd, as far as we currently known). OpenTTD shouldn't be affected at all, but in an abundance of caution GitHub closed down the xz repository while investigating how big the damage actually is.

In result, vcpkg (our package manager) currently cannot install liblzma, meaning we cannot release, neither 14.0 nor any nightly.

There are two solutions here:
1) wait it out, till GitHub (and the community as a whole) wraps up their investigation, and vcpkg resolves the issue so liblzma can be installed again.
2) use an alternative library to load/save lzma (`OTTX`) savegames.

The first can take N time, where N is totally unknown. The hopes are that it will be wrapped up before weeks end, but really, nobody knows.

This implements the second.

## Description

This is a drop-in replacement. Savegames with both can be read by both.

Initially I was more curious how screwed we would be if the result of the investigation would be: you can never trust liblzma again, find another way. In other words, how vendor-locked-in are we actually. Turns out: we aren't. As I had the code to proof that anyway, it was a very small effort to actually wrap it up in a PR.

Do note, I am not saying we should be doing this, as I think we should wait at least a few more days. But just to be prepared, I also wanted to get this ball rolling. To not put all our eggs in a single basket (it has been Easter, please give me this pun ;) ).

PS: in general, libarchive might be a good library to use for our compression, as it supports many other formats. For example, also `zstd`. It would make switching and supporting them all trivial, and could collapse our whole saveload into a much simpler structure. But that is far far out of scope of this PR, as this PR just aims to replace liblzma.

## Limitations

I dropped `tar.xz` support for the TextGui. It was new code (for 14.0) anyway, and I didn't feel like replacing that code. If anyone does so, feel free.
I couldn't find any NewGRF that currently uses `.tar.xz`, but that might be my lack of searching for it. But mostly, I tried to minimize the amount of lines I had to add, as we most likely want to backport this to 14.0 (if we want this at all), where less lines is better.

Emscripten won't support OTTX savegames with this, as it depended on a custom patched liblzma support. It would require some effort to hook libarchive into Emscripten, although it is known it does work.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
