### PR TITLE
Add: support for admin to change company allow lists

### DIFF
--- a/src/command_type.h
+++ b/src/command_type.h
@@ -295,7 +295,7 @@ enum Commands : uint16_t {
 
 	CMD_CREATE_SUBSIDY,               ///< create a new subsidy
 	CMD_COMPANY_CTRL,                 ///< used in multiplayer to create a new companies etc.
-	CMD_COMPANY_ADD_ALLOW_LIST, ///< Used in multiplayer to add a client's public key to the company's allow list.
+	CMD_COMPANY_ALLOW_LIST_CTRL, ///< Used in multiplayer to add/remove a client's public key to/from the company's allow list.
 	CMD_CUSTOM_NEWS_ITEM,             ///< create a custom news message
 	CMD_CREATE_GOAL,                  ///< create a new goal
 	CMD_REMOVE_GOAL,                  ///< remove a goal

--- a/src/company_cmd.h
+++ b/src/company_cmd.h
@@ -18,7 +18,7 @@ enum ClientID : uint32_t;
 enum Colours : uint8_t;
 
 CommandCost CmdCompanyCtrl(DoCommandFlag flags, CompanyCtrlAction cca, CompanyID company_id, CompanyRemoveReason reason, ClientID client_id);
-CommandCost CmdCompanyAddAllowList(DoCommandFlag flags, const std::string &public_key);
+CommandCost CmdCompanyAllowListCtrl(DoCommandFlag flags, CompanyAllowListCtrlAction action, const std::string &public_key);
 CommandCost CmdGiveMoney(DoCommandFlag flags, Money money, CompanyID dest_company);
 CommandCost CmdRenameCompany(DoCommandFlag flags, const std::string &text);
 CommandCost CmdRenamePresident(DoCommandFlag flags, const std::string &text);
@@ -26,7 +26,7 @@ CommandCost CmdSetCompanyManagerFace(DoCommandFlag flags, CompanyManagerFace cmf
 CommandCost CmdSetCompanyColour(DoCommandFlag flags, LiveryScheme scheme, bool primary, Colours colour);
 
 DEF_CMD_TRAIT(CMD_COMPANY_CTRL,             CmdCompanyCtrl,           CMD_SPECTATOR | CMD_CLIENT_ID | CMD_NO_EST, CMDT_SERVER_SETTING)
-DEF_CMD_TRAIT(CMD_COMPANY_ADD_ALLOW_LIST,   CmdCompanyAddAllowList,   CMD_NO_EST,                                 CMDT_SERVER_SETTING)
+DEF_CMD_TRAIT(CMD_COMPANY_ALLOW_LIST_CTRL,  CmdCompanyAllowListCtrl,  CMD_NO_EST,                                 CMDT_SERVER_SETTING)
 DEF_CMD_TRAIT(CMD_GIVE_MONEY,               CmdGiveMoney,             0,                                          CMDT_MONEY_MANAGEMENT)
 DEF_CMD_TRAIT(CMD_RENAME_COMPANY,           CmdRenameCompany,         0,                                          CMDT_COMPANY_SETTING)
 DEF_CMD_TRAIT(CMD_RENAME_PRESIDENT,         CmdRenamePresident,       0,                                          CMDT_COMPANY_SETTING)

--- a/src/company_type.h
+++ b/src/company_type.h
@@ -72,4 +72,12 @@ enum CompanyCtrlAction : uint8_t {
 	CCA_END,    ///< Sentinel for end.
 };
 
+/** The action to do with CMD_COMPANY_ALLOW_LIST_CTRL. */
+enum CompanyAllowListCtrlAction : uint8_t {
+	CALCA_ADD, ///< Create a public key.
+	CALCA_REMOVE, ///< Remove a public key.
+
+	CALCA_END,    ///< Sentinel for end.
+};
+
 #endif /* COMPANY_TYPE_H */

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1519,7 +1519,7 @@ private:
 	static void OnClickClientAuthorize([[maybe_unused]] NetworkClientListWindow *w, [[maybe_unused]] Point pt, ClientID client_id)
 	{
 		AutoRestoreBackup<CompanyID> cur_company(_current_company, NetworkClientInfo::GetByClientID(_network_own_client_id)->client_playas);
-		Command<CMD_COMPANY_ADD_ALLOW_LIST>::Post(NetworkClientInfo::GetByClientID(client_id)->public_key);
+		Command<CMD_COMPANY_ALLOW_LIST_CTRL>::Post(CALCA_ADD, NetworkClientInfo::GetByClientID(client_id)->public_key);
 	}
 
 	/**


### PR DESCRIPTION
## Motivation / Problem

#12337 only allows clients to add other clients to a company's allow list. However, it does not bring any tools for the server admin to remedy any issues created by bad actors.


## Description

Amend command for adding authorized keys to companies to also support removing authorized keys. Also do some more stringent checks on the received requests.

Add option to the "authorized_key" console command to list/add/remove authorized keys for companies as well.
This effectively meant rewriting the whole function to make it easier to also let this work for companies.


## Limitations

No UI for the less tech-savvy server owners.
No support for clients to remove other clients from companies due to griefing issues.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
