### PR TITLE
Codechange: Replace colour_dropdown array with StringID arithmetic.

### DIFF
--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -551,26 +551,6 @@ void ShowCompanyFinances(CompanyID company)
 	new CompanyFinancesWindow(&_company_finances_desc, company);
 }
 
-/* List of colours for the livery window */
-static const StringID _colour_dropdown[] = {
-	STR_COLOUR_DARK_BLUE,
-	STR_COLOUR_PALE_GREEN,
-	STR_COLOUR_PINK,
-	STR_COLOUR_YELLOW,
-	STR_COLOUR_RED,
-	STR_COLOUR_LIGHT_BLUE,
-	STR_COLOUR_GREEN,
-	STR_COLOUR_DARK_GREEN,
-	STR_COLOUR_BLUE,
-	STR_COLOUR_CREAM,
-	STR_COLOUR_MAUVE,
-	STR_COLOUR_PURPLE,
-	STR_COLOUR_ORANGE,
-	STR_COLOUR_BROWN,
-	STR_COLOUR_GREY,
-	STR_COLOUR_WHITE,
-};
-
 /* Association of liveries to livery classes */
 static const LiveryClass _livery_class[LS_END] = {
 	LC_OTHER,
@@ -588,7 +568,7 @@ static const LiveryClass _livery_class[LS_END] = {
 template <SpriteID TSprite = SPR_SQUARE>
 class DropDownListColourItem : public DropDownIcon<DropDownString<DropDownListItem>> {
 public:
-	DropDownListColourItem(int colour, bool masked) : DropDownIcon<DropDownString<DropDownListItem>>(TSprite, GENERAL_SPRITE_COLOUR(colour % COLOUR_END), colour < COLOUR_END ? _colour_dropdown[colour] : STR_COLOUR_DEFAULT, colour, masked)
+	DropDownListColourItem(int colour, bool masked) : DropDownIcon<DropDownString<DropDownListItem>>(TSprite, GENERAL_SPRITE_COLOUR(colour % COLOUR_END), colour < COLOUR_END ? (STR_COLOUR_DARK_BLUE + colour) : STR_COLOUR_DEFAULT, colour, masked)
 	{
 	}
 };
@@ -646,8 +626,8 @@ private:
 			default_col = (primary ? default_livery->colour1 : default_livery->colour2) + COLOUR_END;
 			list.push_back(std::make_unique<DropDownListColourItem<>>(default_col, false));
 		}
-		for (uint i = 0; i < lengthof(_colour_dropdown); i++) {
-			list.push_back(std::make_unique<DropDownListColourItem<>>(i, HasBit(used_colours, i)));
+		for (Colours colour = COLOUR_BEGIN; colour != COLOUR_END; colour++) {
+			list.push_back(std::make_unique<DropDownListColourItem<>>(colour, HasBit(used_colours, colour)));
 		}
 
 		uint8_t sel;
@@ -781,8 +761,8 @@ public:
 			case WID_SCL_PRI_COL_DROPDOWN: {
 				this->square = GetSpriteSize(SPR_SQUARE);
 				int string_padding = this->square.width + WidgetDimensions::scaled.hsep_normal + padding.width;
-				for (const StringID *id = _colour_dropdown; id != endof(_colour_dropdown); id++) {
-					size->width = std::max(size->width, GetStringBoundingBox(*id).width + string_padding);
+				for (Colours colour = COLOUR_BEGIN; colour != COLOUR_END; colour++) {
+					size->width = std::max(size->width, GetStringBoundingBox(STR_COLOUR_DARK_BLUE + colour).width + string_padding);
 				}
 				size->width = std::max(size->width, GetStringBoundingBox(STR_COLOUR_DEFAULT).width + string_padding);
 				break;


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

The colour selection dropdown uses a C-style array of StringIDs for each colour, along with old C-style array looping.

Any other place that deals with colour string just uses `STR_COLOUR_DARK_BLUE + colour`, as they are already in sequence that way.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Replace `_colour_dropdown` array with StringID arithmetic. This assumes that the string colours are in order, but that is already assumed elsewhere.

Removes old C-style array access.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
