### PR TITLE
Fix: do not use lengthof() for non C-style arrays

### DIFF
--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -2251,7 +2251,7 @@ struct NetworkCompanyPasswordWindow : public Window {
 	QueryString password_editbox; ///< Password editbox.
 	Dimension warning_size;       ///< How much space to use for the warning text
 
-	NetworkCompanyPasswordWindow(WindowDesc *desc, Window *parent) : Window(desc), password_editbox(lengthof(_settings_client.network.default_company_pass))
+	NetworkCompanyPasswordWindow(WindowDesc *desc, Window *parent) : Window(desc), password_editbox(NETWORK_PASSWORD_LENGTH)
 	{
 		this->InitNested(0);
 		this->UpdateWarningStringSize();

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -9499,7 +9499,7 @@ static void FinaliseIndustriesArray()
 
 	for (auto &indtsp : _industry_tile_specs) {
 		/* Apply default cargo translation map for unset cargo slots */
-		for (uint i = 0; i < lengthof(indtsp.accepts_cargo); ++i) {
+		for (size_t i = 0; i < indtsp.accepts_cargo.size(); ++i) {
 			if (!IsValidCargoID(indtsp.accepts_cargo[i])) indtsp.accepts_cargo[i] = GetCargoIDByLabel(GetActiveCargoLabel(indtsp.accepts_cargo_label[i]));
 		}
 	}

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1031,7 +1031,7 @@ static void GraphicsSetLoadConfig(IniFile &ini)
 
 		if (const IniItem *item = group->GetItem("extra_params"); item != nullptr && item->value) {
 			auto &extra_params = BaseGraphics::ini_data.extra_params;
-			extra_params.resize(lengthof(GRFConfig::param));
+			extra_params.resize(0x80); // TODO: make ParseIntList work nicely with C++ containers
 			int count = ParseIntList(item->value->c_str(), &extra_params.front(), extra_params.size());
 			if (count < 0) {
 				SetDParamStr(0, BaseGraphics::ini_data.name);

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -273,6 +273,9 @@ static_assert(SIZE_MAX >= UINT32_MAX);
 #define M_PI   3.14159265358979323846
 #endif /* M_PI_2 */
 
+template <typename T, size_t N>
+char (&ArraySizeHelper(T (&array)[N]))[N];
+
 /**
  * Return the length of an fixed size array.
  * Unlike sizeof this function returns the number of elements
@@ -281,7 +284,7 @@ static_assert(SIZE_MAX >= UINT32_MAX);
  * @param x The pointer to the first element of the array
  * @return The number of elements
  */
-#define lengthof(x) (sizeof(x) / sizeof(x[0]))
+#define lengthof(array) (sizeof(ArraySizeHelper(array)))
 
 /**
  * Get the end element of an fixed size array.


### PR DESCRIPTION
## Motivation / Problem

Using `lengthof` of C++-containers is all kinds of bad.


## Description

Replace the cases where `lengthof` was used incorrectly with a simple substitute. It's not the proper-proper fix, but that requires migrating more to proper C++-containers and that makes backporting this a lot harder.

Replace `lengthof` with a variant that simply causes compilation failures when a non C-style array is passed. It is the way the locations with problems were found.


## Limitations

Going fully C++ containers is the better way, but baby steps.
This is just trying to do the minimum to have something that can be backported easily.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
