### PR TITLE
Change: Disallow using Action A to load sprites above the baseset unless reserved.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -376,7 +376,7 @@ struct GRFLocation {
 	}
 };
 
-static std::map<GRFLocation, SpriteID> _grm_sprites;
+static std::map<GRFLocation, std::pair<SpriteID, uint16_t>> _grm_sprites;
 typedef std::map<GRFLocation, std::vector<uint8_t>> GRFLineToSpriteOverride;
 static GRFLineToSpriteOverride _grf_line_to_action6_sprite_override;
 
@@ -7072,6 +7072,21 @@ static void GRFInfo(ByteReader *buf)
 	Debug(grf, 1, "GRFInfo: Loaded GRFv{} set {:08X} - {} (palette: {}, version: {})", version, BSWAP32(grfid), name, (_cur.grfconfig->palette & GRFP_USE_MASK) ? "Windows" : "DOS", _cur.grfconfig->version);
 }
 
+/**
+ * Check if a sprite ID range is within the GRM reversed range for the currently loading NewGRF.
+ * @param first_sprite First sprite of range.
+ * @param num_sprites Number of sprites in the range.
+ * @return True iff the NewGRF has reserved a range equal to or greater than the provided range.
+ */
+static bool IsGRMReservedSprite(SpriteID first_sprite, uint16_t num_sprites)
+{
+	for (const auto &grm_sprite : _grm_sprites) {
+		if (grm_sprite.first.grfid != _cur.grffile->grfid) continue;
+		if (grm_sprite.second.first <= first_sprite && grm_sprite.second.first + grm_sprite.second.second >= first_sprite + num_sprites) return true;
+	}
+	return false;
+}
+
 /* Action 0x0A */
 static void SpriteReplace(ByteReader *buf)
 {
@@ -7092,6 +7107,18 @@ static void SpriteReplace(ByteReader *buf)
 		GrfMsg(2, "SpriteReplace: [Set {}] Changing {} sprites, beginning with {}",
 			i, num_sprites, first_sprite
 		);
+
+		if (first_sprite + num_sprites >= SPR_OPENTTD_BASE) {
+			/* Outside allowed range, check for GRM sprite reservations. */
+			if (!IsGRMReservedSprite(first_sprite, num_sprites)) {
+				GrfMsg(0, "SpriteReplace: [Set {}] Changing {} sprites, beginning with {}, above limit of {} and not within reserved range, ignoring.",
+					i, num_sprites, first_sprite, SPR_OPENTTD_BASE);
+
+				/* Load the sprites at the current location so they will do nothing instead of appearing to work. */
+				first_sprite = _cur.spriteid;
+				_cur.spriteid += num_sprites;
+			}
+		}
 
 		for (uint j = 0; j < num_sprites; j++) {
 			int load_index = first_sprite + j;
@@ -7460,7 +7487,7 @@ static void ParamSet(ByteReader *buf)
 
 							/* Reserve space at the current sprite ID */
 							GrfMsg(4, "ParamSet: GRM: Allocated {} sprites at {}", count, _cur.spriteid);
-							_grm_sprites[GRFLocation(_cur.grffile->grfid, _cur.nfo_line)] = _cur.spriteid;
+							_grm_sprites[GRFLocation(_cur.grffile->grfid, _cur.nfo_line)] = std::make_pair(_cur.spriteid, count);
 							_cur.spriteid += count;
 						}
 					}
@@ -7494,7 +7521,7 @@ static void ParamSet(ByteReader *buf)
 							switch (op) {
 								case 0:
 									/* Return space reserved during reservation stage */
-									src1 = _grm_sprites[GRFLocation(_cur.grffile->grfid, _cur.nfo_line)];
+									src1 = _grm_sprites[GRFLocation(_cur.grffile->grfid, _cur.nfo_line)].first;
 									GrfMsg(4, "ParamSet: GRM: Using pre-allocated sprites at {}", src1);
 									break;
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Using Action A above the baseset is error prone as the sprites are not fixed and can be moved around.

Any NewGRF doing so is likely to break in the future, so force it to break instead.

The NewGRF specifications have always been very clear on this, but it seems authors are not reading the spec. https://newgrf-specs.tt-wiki.net/wiki/ActionA

There are some authors not properly reading the spec, and using Action A when they should be using Action 5. These NewGRFs do appear to work for them, but there's no guarantee they will continue to do so.


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

When loading sprites via Action A, check if the sprite ID is either in the permitted range (below SPR_OPENTTD_BASE), or if the NewGRF has reserved some SpriteIDs via GRM reservation.

If these conditions are satisfied, the sprites are loaded at the requested location.

Otherwise the sprites are loaded at the current location so that they have no effect, and a warning debug is output. It might be possible to skip the sprites, but it seems a bit tricky as we are mid-way into the Action A here so the usual way isn't available.

This effectively "breaks" the NewGRF  now, instead of at some possible time in the future when authors have moved on to other things.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

I know of at least one NewGRF that is affected by this change,  There may be others, but hopefully anything old enough to be affected and unmaintained will have been broken for a  while already...

There may be some other conditions I haven't considered where Action A is appropriate, but I can't think of any.

### NewGRFs known to be affected by this change

| file | reason | Status |
| ---- | ------ | ------ |
| asasignals-v5p1 | Using Action A to replace Action 5 sprites. | Author informed, has retracted NewGRF: https://github.com/j-n-dev/Asasignals |
| CZTR_Bridges-0.9.0 | Assumes contiguous ranges, and reservation is too small. | Broken before this change, and unlikely to be resolved: https://www.tt-forums.net/viewtopic.php?p=1257714#p1257714 |

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
