### PR TITLE
Codechange: use C++ containers for parsing the settings int lists

### DIFF
--- a/src/table/settings/misc_settings.ini
+++ b/src/table/settings/misc_settings.ini
@@ -148,7 +148,7 @@ cat      = SC_BASIC
 ; workaround for implicit lengthof() in SDTG_LIST
 [SDTG_LIST]
 name     = ""resolution""
-type     = SLE_INT
+type     = SLE_UINT
 length   = 2
 var      = _cur_resolution
 def      = ""0,0""


### PR DESCRIPTION
## Motivation / Problem

In #12432 I used a hacky method to get rid of a bad `lengthof` and added a to-do. Now it's time to get rid of that to-do.


## Description

In the past you passed `ParseIntList` a pointer and a number of elements. This works fine for C-style arrays or `std::array`, but it's cumbersome with `std::vector` as you need to preallocate memory in the hope that it's right.
Furthermore some other magic was performed to clamp values to be within a specific range. This could have unexpected side effects, for example `2**32-1` would not be within the bounds of `signed long` and clamped to `2**31-1` before later being converted back to an uint32.

Now `ParseIntList` returns an optional vector with uint32s. Each of the current user is either uint32 (NewGRF parameters, base graphics parameters, resolution) or uint8 (custom music playlist).

Also simplify the code a bit by:
* using `memset` directly on the array, instead of `memset` on a temporary table and then copying values over.
* removing arbitrary 64 element limit.
* using saveload's `WriteValue` instead of our own version.

Finally the resolution's configuration suggests it's a signed integer, but it's stored in `Dimension` which uses `uint`. So, change the configuration to that as well.


## Limitations

`ParseIntList` does not support all `VarType`s, but given its limited use implementing support for that seems pointless. If it's needed at a later point, it shouldn't be too hard to add by going to parse a 64 bit integer. But out of scope for now.

I haven't put much thought into the best performance, as this is only used when reading the configuration file, so any gains would be really minimal over maintainability of the code..


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
