### PR TITLE
Codechange: use std::size instead of lengthof for town names

### DIFF
--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -166,9 +166,9 @@ bool GenerateTownName(Randomizer &randomizer, uint32_t *townnameparts, TownNames
  * @param seed seed
  * @return seed transformed to a number from given range
  */
-static inline uint32_t SeedChance(uint8_t shift_by, int max, uint32_t seed)
+static inline uint32_t SeedChance(uint8_t shift_by, size_t max, uint32_t seed)
 {
-	return (GB(seed, shift_by, 16) * max) >> 16;
+	return (GB(seed, shift_by, 16) * ClampTo<uint16_t>(max)) >> 16;
 }
 
 
@@ -179,7 +179,7 @@ static inline uint32_t SeedChance(uint8_t shift_by, int max, uint32_t seed)
  * @param seed seed
  * @return seed transformed to a number from given range
  */
-static inline uint32_t SeedModChance(uint8_t shift_by, int max, uint32_t seed)
+static inline uint32_t SeedModChance(uint8_t shift_by, size_t max, uint32_t seed)
 {
 	/* This actually gives *MUCH* more even distribution of the values
 	 * than SeedChance(), which is absolutely horrible in that. If
@@ -202,7 +202,7 @@ static inline uint32_t SeedModChance(uint8_t shift_by, int max, uint32_t seed)
  * @param bias minimum value that can be returned
  * @return seed transformed to a number from given range
  */
-static inline int32_t SeedChanceBias(uint8_t shift_by, int max, uint32_t seed, int bias)
+static inline int32_t SeedChanceBias(uint8_t shift_by, size_t max, uint32_t seed, int bias)
 {
 	return SeedChance(shift_by, max + bias, seed) - bias;
 }
@@ -252,17 +252,17 @@ static void MakeEnglishOriginalTownName(StringBuilder &builder, uint32_t seed)
 	size_t start = builder.CurrentIndex();
 
 	/* optional first segment */
-	int i = SeedChanceBias(0, lengthof(_name_original_english_1), seed, 50);
+	int i = SeedChanceBias(0, std::size(_name_original_english_1), seed, 50);
 	if (i >= 0) builder += _name_original_english_1[i];
 
 	/* mandatory middle segments */
-	builder += _name_original_english_2[SeedChance(4,  lengthof(_name_original_english_2), seed)];
-	builder += _name_original_english_3[SeedChance(7,  lengthof(_name_original_english_3), seed)];
-	builder += _name_original_english_4[SeedChance(10, lengthof(_name_original_english_4), seed)];
-	builder += _name_original_english_5[SeedChance(13, lengthof(_name_original_english_5), seed)];
+	builder += _name_original_english_2[SeedChance(4,  std::size(_name_original_english_2), seed)];
+	builder += _name_original_english_3[SeedChance(7,  std::size(_name_original_english_3), seed)];
+	builder += _name_original_english_4[SeedChance(10, std::size(_name_original_english_4), seed)];
+	builder += _name_original_english_5[SeedChance(13, std::size(_name_original_english_5), seed)];
 
 	/* optional last segment */
-	i = SeedChanceBias(15, lengthof(_name_original_english_6), seed, 60);
+	i = SeedChanceBias(15, std::size(_name_original_english_6), seed, 60);
 	if (i >= 0) builder += _name_original_english_6[i];
 
 	/* Ce, Ci => Ke, Ki */
@@ -285,25 +285,25 @@ static void MakeEnglishAdditionalTownName(StringBuilder &builder, uint32_t seed)
 	size_t start = builder.CurrentIndex();
 
 	/* optional first segment */
-	int i = SeedChanceBias(0, lengthof(_name_additional_english_prefix), seed, 50);
+	int i = SeedChanceBias(0, std::size(_name_additional_english_prefix), seed, 50);
 	if (i >= 0) builder += _name_additional_english_prefix[i];
 
 	if (SeedChance(3, 20, seed) >= 14) {
-		builder += _name_additional_english_1a[SeedChance(6, lengthof(_name_additional_english_1a), seed)];
+		builder += _name_additional_english_1a[SeedChance(6, std::size(_name_additional_english_1a), seed)];
 	} else {
-		builder += _name_additional_english_1b1[SeedChance(6, lengthof(_name_additional_english_1b1), seed)];
-		builder += _name_additional_english_1b2[SeedChance(9, lengthof(_name_additional_english_1b2), seed)];
+		builder += _name_additional_english_1b1[SeedChance(6, std::size(_name_additional_english_1b1), seed)];
+		builder += _name_additional_english_1b2[SeedChance(9, std::size(_name_additional_english_1b2), seed)];
 		if (SeedChance(11, 20, seed) >= 4) {
-			builder += _name_additional_english_1b3a[SeedChance(12, lengthof(_name_additional_english_1b3a), seed)];
+			builder += _name_additional_english_1b3a[SeedChance(12, std::size(_name_additional_english_1b3a), seed)];
 		} else {
-			builder += _name_additional_english_1b3b[SeedChance(12, lengthof(_name_additional_english_1b3b), seed)];
+			builder += _name_additional_english_1b3b[SeedChance(12, std::size(_name_additional_english_1b3b), seed)];
 		}
 	}
 
-	builder += _name_additional_english_2[SeedChance(14, lengthof(_name_additional_english_2), seed)];
+	builder += _name_additional_english_2[SeedChance(14, std::size(_name_additional_english_2), seed)];
 
 	/* optional last segment */
-	i = SeedChanceBias(15, lengthof(_name_additional_english_3), seed, 60);
+	i = SeedChanceBias(15, std::size(_name_additional_english_3), seed, 60);
 	if (i >= 0) builder += _name_additional_english_3[i];
 
 	assert(builder.CurrentIndex() - start >= 4);
@@ -319,7 +319,7 @@ static void MakeEnglishAdditionalTownName(StringBuilder &builder, uint32_t seed)
 static void MakeAustrianTownName(StringBuilder &builder, uint32_t seed)
 {
 	/* Bad, Maria, Gross, ... */
-	int i = SeedChanceBias(0, lengthof(_name_austrian_a1), seed, 15);
+	int i = SeedChanceBias(0, std::size(_name_austrian_a1), seed, 15);
 	if (i >= 0) builder += _name_austrian_a1[i];
 
 	int j = 0;
@@ -327,27 +327,27 @@ static void MakeAustrianTownName(StringBuilder &builder, uint32_t seed)
 	i = SeedChance(4, 6, seed);
 	if (i >= 4) {
 		/* Kaisers-kirchen */
-		builder += _name_austrian_a2[SeedChance( 7, lengthof(_name_austrian_a2), seed)];
-		builder += _name_austrian_a3[SeedChance(13, lengthof(_name_austrian_a3), seed)];
+		builder += _name_austrian_a2[SeedChance( 7, std::size(_name_austrian_a2), seed)];
+		builder += _name_austrian_a3[SeedChance(13, std::size(_name_austrian_a3), seed)];
 	} else if (i >= 2) {
 		/* St. Johann */
-		builder += _name_austrian_a5[SeedChance( 7, lengthof(_name_austrian_a5), seed)];
-		builder += _name_austrian_a6[SeedChance( 9, lengthof(_name_austrian_a6), seed)];
+		builder += _name_austrian_a5[SeedChance( 7, std::size(_name_austrian_a5), seed)];
+		builder += _name_austrian_a6[SeedChance( 9, std::size(_name_austrian_a6), seed)];
 		j = 1; // More likely to have a " an der " or " am "
 	} else {
 		/* Zell */
-		builder += _name_austrian_a4[SeedChance( 7, lengthof(_name_austrian_a4), seed)];
+		builder += _name_austrian_a4[SeedChance( 7, std::size(_name_austrian_a4), seed)];
 	}
 
 	i = SeedChance(1, 6, seed);
 	if (i >= 4 - j) {
 		/* an der Donau (rivers) */
-		builder += _name_austrian_f1[SeedChance(4, lengthof(_name_austrian_f1), seed)];
-		builder += _name_austrian_f2[SeedChance(5, lengthof(_name_austrian_f2), seed)];
+		builder += _name_austrian_f1[SeedChance(4, std::size(_name_austrian_f1), seed)];
+		builder += _name_austrian_f2[SeedChance(5, std::size(_name_austrian_f2), seed)];
 	} else if (i >= 2 - j) {
 		/* am Dachstein (mountains) */
-		builder += _name_austrian_b1[SeedChance(4, lengthof(_name_austrian_b1), seed)];
-		builder += _name_austrian_b2[SeedChance(5, lengthof(_name_austrian_b2), seed)];
+		builder += _name_austrian_b1[SeedChance(4, std::size(_name_austrian_b1), seed)];
+		builder += _name_austrian_b2[SeedChance(5, std::size(_name_austrian_b2), seed)];
 	}
 }
 
@@ -363,30 +363,30 @@ static void MakeGermanTownName(StringBuilder &builder, uint32_t seed)
 
 	/* optional prefix */
 	if (seed_derivative == 12 || seed_derivative == 19) {
-		uint i = SeedChance(2, lengthof(_name_german_pre), seed);
+		uint i = SeedChance(2, std::size(_name_german_pre), seed);
 		builder += _name_german_pre[i];
 	}
 
 	/* mandatory middle segments including option of hardcoded name */
-	uint i = SeedChance(3, lengthof(_name_german_real) + lengthof(_name_german_1), seed);
-	if (i < lengthof(_name_german_real)) {
+	uint i = SeedChance(3, std::size(_name_german_real) + std::size(_name_german_1), seed);
+	if (i < std::size(_name_german_real)) {
 		builder += _name_german_real[i];
 	} else {
-		builder += _name_german_1[i - lengthof(_name_german_real)];
+		builder += _name_german_1[i - std::size(_name_german_real)];
 
-		i = SeedChance(5, lengthof(_name_german_2), seed);
+		i = SeedChance(5, std::size(_name_german_2), seed);
 		builder += _name_german_2[i];
 	}
 
 	/* optional suffix */
 	if (seed_derivative == 24) {
-		i = SeedChance(9, lengthof(_name_german_4_an_der) + lengthof(_name_german_4_am), seed);
-		if (i < lengthof(_name_german_4_an_der)) {
+		i = SeedChance(9, std::size(_name_german_4_an_der) + std::size(_name_german_4_am), seed);
+		if (i < std::size(_name_german_4_an_der)) {
 			builder += _name_german_3_an_der[0];
 			builder += _name_german_4_an_der[i];
 		} else {
 			builder += _name_german_3_am[0];
-			builder += _name_german_4_am[i - lengthof(_name_german_4_an_der)];
+			builder += _name_german_4_am[i - std::size(_name_german_4_an_der)];
 		}
 	}
 }
@@ -399,7 +399,7 @@ static void MakeGermanTownName(StringBuilder &builder, uint32_t seed)
  */
 static void MakeSpanishTownName(StringBuilder &builder, uint32_t seed)
 {
-	builder += _name_spanish_real[SeedChance(0, lengthof(_name_spanish_real), seed)];
+	builder += _name_spanish_real[SeedChance(0, std::size(_name_spanish_real), seed)];
 }
 
 
@@ -410,7 +410,7 @@ static void MakeSpanishTownName(StringBuilder &builder, uint32_t seed)
  */
 static void MakeFrenchTownName(StringBuilder &builder, uint32_t seed)
 {
-	builder += _name_french_real[SeedChance(0, lengthof(_name_french_real), seed)];
+	builder += _name_french_real[SeedChance(0, std::size(_name_french_real), seed)];
 }
 
 
@@ -421,8 +421,8 @@ static void MakeFrenchTownName(StringBuilder &builder, uint32_t seed)
  */
 static void MakeSillyTownName(StringBuilder &builder, uint32_t seed)
 {
-	builder += _name_silly_1[SeedChance( 0, lengthof(_name_silly_1), seed)];
-	builder += _name_silly_2[SeedChance(16, lengthof(_name_silly_2), seed)];
+	builder += _name_silly_1[SeedChance( 0, std::size(_name_silly_1), seed)];
+	builder += _name_silly_2[SeedChance(16, std::size(_name_silly_2), seed)];
 }
 
 
@@ -434,19 +434,19 @@ static void MakeSillyTownName(StringBuilder &builder, uint32_t seed)
 static void MakeSwedishTownName(StringBuilder &builder, uint32_t seed)
 {
 	/* optional first segment */
-	int i = SeedChanceBias(0, lengthof(_name_swedish_1), seed, 50);
+	int i = SeedChanceBias(0, std::size(_name_swedish_1), seed, 50);
 	if (i >= 0) builder += _name_swedish_1[i];
 
 	/* mandatory middle segments including option of hardcoded name */
 	if (SeedChance(4, 5, seed) >= 3) {
-		builder += _name_swedish_2[SeedChance( 7, lengthof(_name_swedish_2), seed)];
+		builder += _name_swedish_2[SeedChance( 7, std::size(_name_swedish_2), seed)];
 	} else {
-		builder += _name_swedish_2a[SeedChance( 7, lengthof(_name_swedish_2a), seed)];
-		builder += _name_swedish_2b[SeedChance(10, lengthof(_name_swedish_2b), seed)];
-		builder += _name_swedish_2c[SeedChance(13, lengthof(_name_swedish_2c), seed)];
+		builder += _name_swedish_2a[SeedChance( 7, std::size(_name_swedish_2a), seed)];
+		builder += _name_swedish_2b[SeedChance(10, std::size(_name_swedish_2b), seed)];
+		builder += _name_swedish_2c[SeedChance(13, std::size(_name_swedish_2c), seed)];
 	}
 
-	builder += _name_swedish_3[SeedChance(16, lengthof(_name_swedish_3), seed)];
+	builder += _name_swedish_3[SeedChance(16, std::size(_name_swedish_3), seed)];
 }
 
 
@@ -458,18 +458,18 @@ static void MakeSwedishTownName(StringBuilder &builder, uint32_t seed)
 static void MakeDutchTownName(StringBuilder &builder, uint32_t seed)
 {
 	/* optional first segment */
-	int i = SeedChanceBias(0, lengthof(_name_dutch_1), seed, 50);
+	int i = SeedChanceBias(0, std::size(_name_dutch_1), seed, 50);
 	if (i >= 0) builder += _name_dutch_1[i];
 
 	/* mandatory middle segments including option of hardcoded name */
 	if (SeedChance(6, 9, seed) > 4) {
-		builder += _name_dutch_2[SeedChance( 9, lengthof(_name_dutch_2), seed)];
+		builder += _name_dutch_2[SeedChance( 9, std::size(_name_dutch_2), seed)];
 	} else {
-		builder += _name_dutch_3[SeedChance( 9, lengthof(_name_dutch_3), seed)];
-		builder += _name_dutch_4[SeedChance(12, lengthof(_name_dutch_4), seed)];
+		builder += _name_dutch_3[SeedChance( 9, std::size(_name_dutch_3), seed)];
+		builder += _name_dutch_4[SeedChance(12, std::size(_name_dutch_4), seed)];
 	}
 
-	builder += _name_dutch_5[SeedChance(15, lengthof(_name_dutch_5), seed)];
+	builder += _name_dutch_5[SeedChance(15, std::size(_name_dutch_5), seed)];
 }
 
 
@@ -484,7 +484,7 @@ static void MakeFinnishTownName(StringBuilder &builder, uint32_t seed)
 
 	/* Select randomly if town name should consists of one or two parts. */
 	if (SeedChance(0, 15, seed) >= 10) {
-		builder += _name_finnish_real[SeedChance(2, lengthof(_name_finnish_real), seed)];
+		builder += _name_finnish_real[SeedChance(2, std::size(_name_finnish_real), seed)];
 		return;
 	}
 
@@ -492,7 +492,7 @@ static void MakeFinnishTownName(StringBuilder &builder, uint32_t seed)
 		/* A two-part name by combining one of _name_finnish_1 + "la"/"lä"
 		 * The reason for not having the contents of _name_finnish_{1,2} in the same table is
 		 * that the ones in _name_finnish_2 are not good for this purpose. */
-		uint sel = SeedChance( 0, lengthof(_name_finnish_1), seed);
+		uint sel = SeedChance( 0, std::size(_name_finnish_1), seed);
 		builder += _name_finnish_1[sel];
 		size_t last = builder.CurrentIndex() - 1;
 		if (builder[last] == 'i') builder[last] = 'e';
@@ -508,14 +508,14 @@ static void MakeFinnishTownName(StringBuilder &builder, uint32_t seed)
 
 	/* A two-part name by combining one of _name_finnish_{1,2} + _name_finnish_3.
 	 * Why aren't _name_finnish_{1,2} just one table? See above. */
-	uint sel = SeedChance(2, lengthof(_name_finnish_1) + lengthof(_name_finnish_2), seed);
-	if (sel >= lengthof(_name_finnish_1)) {
-		builder += _name_finnish_2[sel - lengthof(_name_finnish_1)];
+	uint sel = SeedChance(2, std::size(_name_finnish_1) + std::size(_name_finnish_2), seed);
+	if (sel >= std::size(_name_finnish_1)) {
+		builder += _name_finnish_2[sel - std::size(_name_finnish_1)];
 	} else {
 		builder += _name_finnish_1[sel];
 	}
 
-	builder += _name_finnish_3[SeedChance(10, lengthof(_name_finnish_3), seed)];
+	builder += _name_finnish_3[SeedChance(10, std::size(_name_finnish_3), seed)];
 }
 
 
@@ -528,53 +528,53 @@ static void MakePolishTownName(StringBuilder &builder, uint32_t seed)
 {
 	/* optional first segment */
 	uint i = SeedChance(0,
-			lengthof(_name_polish_2_o) + lengthof(_name_polish_2_m) +
-			lengthof(_name_polish_2_f) + lengthof(_name_polish_2_n),
+			std::size(_name_polish_2_o) + std::size(_name_polish_2_m) +
+			std::size(_name_polish_2_f) + std::size(_name_polish_2_n),
 			seed);
 	uint j = SeedChance(2, 20, seed);
 
 
-	if (i < lengthof(_name_polish_2_o)) {
-		builder += _name_polish_2_o[SeedChance(3, lengthof(_name_polish_2_o), seed)];
+	if (i < std::size(_name_polish_2_o)) {
+		builder += _name_polish_2_o[SeedChance(3, std::size(_name_polish_2_o), seed)];
 		return;
 	}
 
-	if (i < lengthof(_name_polish_2_m) + lengthof(_name_polish_2_o)) {
+	if (i < std::size(_name_polish_2_m) + std::size(_name_polish_2_o)) {
 		if (j < 4) {
-			builder += _name_polish_1_m[SeedChance(5, lengthof(_name_polish_1_m), seed)];
+			builder += _name_polish_1_m[SeedChance(5, std::size(_name_polish_1_m), seed)];
 		}
 
-		builder += _name_polish_2_m[SeedChance(7, lengthof(_name_polish_2_m), seed)];
+		builder += _name_polish_2_m[SeedChance(7, std::size(_name_polish_2_m), seed)];
 
 		if (j >= 4 && j < 16) {
-			builder += _name_polish_3_m[SeedChance(10, lengthof(_name_polish_3_m), seed)];
+			builder += _name_polish_3_m[SeedChance(10, std::size(_name_polish_3_m), seed)];
 		}
 
 		return;
 	}
 
-	if (i < lengthof(_name_polish_2_f) + lengthof(_name_polish_2_m) + lengthof(_name_polish_2_o)) {
+	if (i < std::size(_name_polish_2_f) + std::size(_name_polish_2_m) + std::size(_name_polish_2_o)) {
 		if (j < 4) {
-			builder += _name_polish_1_f[SeedChance(5, lengthof(_name_polish_1_f), seed)];
+			builder += _name_polish_1_f[SeedChance(5, std::size(_name_polish_1_f), seed)];
 		}
 
-		builder += _name_polish_2_f[SeedChance(7, lengthof(_name_polish_2_f), seed)];
+		builder += _name_polish_2_f[SeedChance(7, std::size(_name_polish_2_f), seed)];
 
 		if (j >= 4 && j < 16) {
-			builder += _name_polish_3_f[SeedChance(10, lengthof(_name_polish_3_f), seed)];
+			builder += _name_polish_3_f[SeedChance(10, std::size(_name_polish_3_f), seed)];
 		}
 
 		return;
 	}
 
 	if (j < 4) {
-		builder += _name_polish_1_n[SeedChance(5, lengthof(_name_polish_1_n), seed)];
+		builder += _name_polish_1_n[SeedChance(5, std::size(_name_polish_1_n), seed)];
 	}
 
-	builder += _name_polish_2_n[SeedChance(7, lengthof(_name_polish_2_n), seed)];
+	builder += _name_polish_2_n[SeedChance(7, std::size(_name_polish_2_n), seed)];
 
 	if (j >= 4 && j < 16) {
-		builder += _name_polish_3_n[SeedChance(10, lengthof(_name_polish_3_n), seed)];
+		builder += _name_polish_3_n[SeedChance(10, std::size(_name_polish_3_n), seed)];
 	}
 
 	return;
@@ -590,7 +590,7 @@ static void MakeCzechTownName(StringBuilder &builder, uint32_t seed)
 {
 	/* 1:3 chance to use a real name. */
 	if (SeedModChance(0, 4, seed) == 0) {
-		builder += _name_czech_real[SeedModChance(4, lengthof(_name_czech_real), seed)];
+		builder += _name_czech_real[SeedModChance(4, std::size(_name_czech_real), seed)];
 		return;
 	}
 
@@ -603,57 +603,57 @@ static void MakeCzechTownName(StringBuilder &builder, uint32_t seed)
 
 	/* IDs of the respective parts */
 	int prefix = 0, ending = 0, suffix = 0;
-	uint postfix = 0;
-	uint stem;
+	size_t postfix = 0;
+	size_t stem;
 
 	/* The select criteria. */
 	CzechGender gender;
 	CzechChoose choose;
 	CzechAllow allow;
 
-	if (do_prefix) prefix = SeedModChance(5, lengthof(_name_czech_adj) * 12, seed) / 12;
-	if (do_suffix) suffix = SeedModChance(7, lengthof(_name_czech_suffix), seed);
+	if (do_prefix) prefix = SeedModChance(5, std::size(_name_czech_adj) * 12, seed) / 12;
+	if (do_suffix) suffix = SeedModChance(7, std::size(_name_czech_suffix), seed);
 	/* 3:1 chance 3:1 to use dynamic substantive */
 	stem = SeedModChance(9,
-			lengthof(_name_czech_subst_full) + 3 * lengthof(_name_czech_subst_stem),
+			std::size(_name_czech_subst_full) + 3 * std::size(_name_czech_subst_stem),
 			seed);
-	if (stem < lengthof(_name_czech_subst_full)) {
+	if (stem < std::size(_name_czech_subst_full)) {
 		/* That was easy! */
 		dynamic_subst = false;
 		gender = _name_czech_subst_full[stem].gender;
 		choose = _name_czech_subst_full[stem].choose;
 		allow = _name_czech_subst_full[stem].allow;
 	} else {
-		uint map[lengthof(_name_czech_subst_ending)];
+		uint map[std::size(_name_czech_subst_ending)];
 		int ending_start = -1, ending_stop = -1;
 
 		/* Load the substantive */
 		dynamic_subst = true;
-		stem -= lengthof(_name_czech_subst_full);
-		stem %= lengthof(_name_czech_subst_stem);
+		stem -= std::size(_name_czech_subst_full);
+		stem %= std::size(_name_czech_subst_stem);
 		gender = _name_czech_subst_stem[stem].gender;
 		choose = _name_czech_subst_stem[stem].choose;
 		allow = _name_czech_subst_stem[stem].allow;
 
 		/* Load the postfix (1:1 chance that a postfix will be inserted) */
-		postfix = SeedModChance(14, lengthof(_name_czech_subst_postfix) * 2, seed);
+		postfix = SeedModChance(14, std::size(_name_czech_subst_postfix) * 2, seed);
 
 		if (choose & CZC_POSTFIX) {
 			/* Always get a real postfix. */
-			postfix %= lengthof(_name_czech_subst_postfix);
+			postfix %= std::size(_name_czech_subst_postfix);
 		}
 		if (choose & CZC_NOPOSTFIX) {
 			/* Always drop a postfix. */
-			postfix += lengthof(_name_czech_subst_postfix);
+			postfix += std::size(_name_czech_subst_postfix);
 		}
-		if (postfix < lengthof(_name_czech_subst_postfix)) {
+		if (postfix < std::size(_name_czech_subst_postfix)) {
 			choose |= CZC_POSTFIX;
 		} else {
 			choose |= CZC_NOPOSTFIX;
 		}
 
 		/* Localize the array segment containing a good gender */
-		for (ending = 0; ending < (int)lengthof(_name_czech_subst_ending); ending++) {
+		for (ending = 0; ending < (int)std::size(_name_czech_subst_ending); ending++) {
 			const CzechNameSubst *e = &_name_czech_subst_ending[ending];
 
 			if (gender == CZG_FREE ||
@@ -719,7 +719,7 @@ static void MakeCzechTownName(StringBuilder &builder, uint32_t seed)
 
 	if (dynamic_subst) {
 		builder += _name_czech_subst_stem[stem].name;
-		if (postfix < lengthof(_name_czech_subst_postfix)) {
+		if (postfix < std::size(_name_czech_subst_postfix)) {
 			const char *poststr = _name_czech_subst_postfix[postfix];
 			const char *endstr = _name_czech_subst_ending[ending].name;
 
@@ -763,7 +763,7 @@ static void MakeCzechTownName(StringBuilder &builder, uint32_t seed)
  */
 static void MakeRomanianTownName(StringBuilder &builder, uint32_t seed)
 {
-	builder += _name_romanian_real[SeedChance(0, lengthof(_name_romanian_real), seed)];
+	builder += _name_romanian_real[SeedChance(0, std::size(_name_romanian_real), seed)];
 }
 
 
@@ -774,7 +774,7 @@ static void MakeRomanianTownName(StringBuilder &builder, uint32_t seed)
  */
 static void MakeSlovakTownName(StringBuilder &builder, uint32_t seed)
 {
-	builder += _name_slovak_real[SeedChance(0, lengthof(_name_slovak_real), seed)];
+	builder += _name_slovak_real[SeedChance(0, std::size(_name_slovak_real), seed)];
 }
 
 
@@ -789,14 +789,14 @@ static void MakeNorwegianTownName(StringBuilder &builder, uint32_t seed)
 	 * have a real name 3/16 chance.  Bit 0-3 */
 	if (SeedChance(0, 15, seed) < 3) {
 		/* Use 7bit for the realname table index.  Bit 4-10 */
-		builder += _name_norwegian_real[SeedChance(4, lengthof(_name_norwegian_real), seed)];
+		builder += _name_norwegian_real[SeedChance(4, std::size(_name_norwegian_real), seed)];
 		return;
 	}
 
 	/* Use 7bit for the first fake part.  Bit 4-10 */
-	builder += _name_norwegian_1[SeedChance(4, lengthof(_name_norwegian_1), seed)];
+	builder += _name_norwegian_1[SeedChance(4, std::size(_name_norwegian_1), seed)];
 	/* Use 7bit for the last fake part.  Bit 11-17 */
-	builder += _name_norwegian_2[SeedChance(11, lengthof(_name_norwegian_2), seed)];
+	builder += _name_norwegian_2[SeedChance(11, std::size(_name_norwegian_2), seed)];
 }
 
 
@@ -808,21 +808,21 @@ static void MakeNorwegianTownName(StringBuilder &builder, uint32_t seed)
 static void MakeHungarianTownName(StringBuilder &builder, uint32_t seed)
 {
 	if (SeedChance(12, 15, seed) < 3) {
-		builder += _name_hungarian_real[SeedChance(0, lengthof(_name_hungarian_real), seed)];
+		builder += _name_hungarian_real[SeedChance(0, std::size(_name_hungarian_real), seed)];
 		return;
 	}
 
 	/* optional first segment */
-	uint i = SeedChance(3, lengthof(_name_hungarian_1) * 3, seed);
-	if (i < lengthof(_name_hungarian_1)) builder += _name_hungarian_1[i];
+	uint i = SeedChance(3, std::size(_name_hungarian_1) * 3, seed);
+	if (i < std::size(_name_hungarian_1)) builder += _name_hungarian_1[i];
 
 	/* mandatory middle segments */
-	builder += _name_hungarian_2[SeedChance(3, lengthof(_name_hungarian_2), seed)];
-	builder += _name_hungarian_3[SeedChance(6, lengthof(_name_hungarian_3), seed)];
+	builder += _name_hungarian_2[SeedChance(3, std::size(_name_hungarian_2), seed)];
+	builder += _name_hungarian_3[SeedChance(6, std::size(_name_hungarian_3), seed)];
 
 	/* optional last segment */
-	i = SeedChance(10, lengthof(_name_hungarian_4) * 3, seed);
-	if (i < lengthof(_name_hungarian_4)) {
+	i = SeedChance(10, std::size(_name_hungarian_4) * 3, seed);
+	if (i < std::size(_name_hungarian_4)) {
 		builder += _name_hungarian_4[i];
 	}
 }
@@ -835,7 +835,7 @@ static void MakeHungarianTownName(StringBuilder &builder, uint32_t seed)
  */
 static void MakeSwissTownName(StringBuilder &builder, uint32_t seed)
 {
-	builder += _name_swiss_real[SeedChance(0, lengthof(_name_swiss_real), seed)];
+	builder += _name_swiss_real[SeedChance(0, std::size(_name_swiss_real), seed)];
 }
 
 
@@ -847,12 +847,12 @@ static void MakeSwissTownName(StringBuilder &builder, uint32_t seed)
 static void MakeDanishTownName(StringBuilder &builder, uint32_t seed)
 {
 	/* optional first segment */
-	int i = SeedChanceBias(0, lengthof(_name_danish_1), seed, 50);
+	int i = SeedChanceBias(0, std::size(_name_danish_1), seed, 50);
 	if (i >= 0) builder += _name_danish_1[i];
 
 	/* middle segments removed as this algorithm seems to create much more realistic names */
-	builder += _name_danish_2[SeedChance( 7, lengthof(_name_danish_2), seed)];
-	builder += _name_danish_3[SeedChance(16, lengthof(_name_danish_3), seed)];
+	builder += _name_danish_2[SeedChance( 7, std::size(_name_danish_2), seed)];
+	builder += _name_danish_3[SeedChance(16, std::size(_name_danish_3), seed)];
 }
 
 
@@ -867,24 +867,24 @@ static void MakeTurkishTownName(StringBuilder &builder, uint32_t seed)
 
 	switch (i) {
 		case 0:
-			builder += _name_turkish_prefix[SeedModChance( 2, lengthof(_name_turkish_prefix), seed)];
+			builder += _name_turkish_prefix[SeedModChance( 2, std::size(_name_turkish_prefix), seed)];
 
 			/* middle segment */
-			builder += _name_turkish_middle[SeedModChance( 4, lengthof(_name_turkish_middle), seed)];
+			builder += _name_turkish_middle[SeedModChance( 4, std::size(_name_turkish_middle), seed)];
 
 			/* optional suffix */
 			if (SeedModChance(0, 7, seed) == 0) {
-				builder += _name_turkish_suffix[SeedModChance( 10, lengthof(_name_turkish_suffix), seed)];
+				builder += _name_turkish_suffix[SeedModChance( 10, std::size(_name_turkish_suffix), seed)];
 			}
 			break;
 
 		case 1: case 2:
-			builder += _name_turkish_prefix[SeedModChance( 2, lengthof(_name_turkish_prefix), seed)];
-			builder += _name_turkish_suffix[SeedModChance( 4, lengthof(_name_turkish_suffix), seed)];
+			builder += _name_turkish_prefix[SeedModChance( 2, std::size(_name_turkish_prefix), seed)];
+			builder += _name_turkish_suffix[SeedModChance( 4, std::size(_name_turkish_suffix), seed)];
 			break;
 
 		default:
-			builder += _name_turkish_real[SeedModChance( 4, lengthof(_name_turkish_real), seed)];
+			builder += _name_turkish_real[SeedModChance( 4, std::size(_name_turkish_real), seed)];
 			break;
 	}
 }
@@ -898,7 +898,7 @@ static void MakeTurkishTownName(StringBuilder &builder, uint32_t seed)
 static void MakeItalianTownName(StringBuilder &builder, uint32_t seed)
 {
 	if (SeedModChance(0, 6, seed) == 0) { // real city names
-		builder += _name_italian_real[SeedModChance(4, lengthof(_name_italian_real), seed)];
+		builder += _name_italian_real[SeedModChance(4, std::size(_name_italian_real), seed)];
 		return;
 	}
 
@@ -908,29 +908,29 @@ static void MakeItalianTownName(StringBuilder &builder, uint32_t seed)
 	};
 
 	if (SeedModChance(0, 8, seed) == 0) { // prefix
-		builder += _name_italian_pref[SeedModChance(11, lengthof(_name_italian_pref), seed)];
+		builder += _name_italian_pref[SeedModChance(11, std::size(_name_italian_pref), seed)];
 	}
 
 	uint i = SeedChance(0, 2, seed);
 	if (i == 0) { // masculine form
-		builder += _name_italian_1m[SeedModChance(4, lengthof(_name_italian_1m), seed)];
+		builder += _name_italian_1m[SeedModChance(4, std::size(_name_italian_1m), seed)];
 	} else { // feminine form
-		builder += _name_italian_1f[SeedModChance(4, lengthof(_name_italian_1f), seed)];
+		builder += _name_italian_1f[SeedModChance(4, std::size(_name_italian_1f), seed)];
 	}
 
 	if (SeedModChance(3, 3, seed) == 0) {
-		builder += _name_italian_2[SeedModChance(11, lengthof(_name_italian_2), seed)];
+		builder += _name_italian_2[SeedModChance(11, std::size(_name_italian_2), seed)];
 		builder += mascul_femin_italian[i];
 	} else {
-		builder += _name_italian_2i[SeedModChance(16, lengthof(_name_italian_2i), seed)];
+		builder += _name_italian_2i[SeedModChance(16, std::size(_name_italian_2i), seed)];
 	}
 
 	if (SeedModChance(15, 4, seed) == 0) {
 		if (SeedModChance(5, 2, seed) == 0) { // generic suffix
-			builder += _name_italian_3[SeedModChance(4, lengthof(_name_italian_3), seed)];
+			builder += _name_italian_3[SeedModChance(4, std::size(_name_italian_3), seed)];
 		} else { // river name suffix
-			builder += _name_italian_river1[SeedModChance(4, lengthof(_name_italian_river1), seed)];
-			builder += _name_italian_river2[SeedModChance(16, lengthof(_name_italian_river2), seed)];
+			builder += _name_italian_river1[SeedModChance(4, std::size(_name_italian_river1), seed)];
+			builder += _name_italian_river2[SeedModChance(16, std::size(_name_italian_river2), seed)];
 		}
 	}
 }
@@ -944,28 +944,28 @@ static void MakeItalianTownName(StringBuilder &builder, uint32_t seed)
 static void MakeCatalanTownName(StringBuilder &builder, uint32_t seed)
 {
 	if (SeedModChance(0, 3, seed) == 0) { // real city names
-		builder += _name_catalan_real[SeedModChance(4, lengthof(_name_catalan_real), seed)];
+		builder += _name_catalan_real[SeedModChance(4, std::size(_name_catalan_real), seed)];
 		return;
 	}
 
 	if (SeedModChance(0, 2, seed) == 0) { // prefix
-		builder += _name_catalan_pref[SeedModChance(11, lengthof(_name_catalan_pref), seed)];
+		builder += _name_catalan_pref[SeedModChance(11, std::size(_name_catalan_pref), seed)];
 	}
 
 	uint i = SeedChance(0, 2, seed);
 	if (i == 0) { // masculine form
-		builder += _name_catalan_1m[SeedModChance(4, lengthof(_name_catalan_1m), seed)];
-		builder += _name_catalan_2m[SeedModChance(11, lengthof(_name_catalan_2m), seed)];
+		builder += _name_catalan_1m[SeedModChance(4, std::size(_name_catalan_1m), seed)];
+		builder += _name_catalan_2m[SeedModChance(11, std::size(_name_catalan_2m), seed)];
 	} else { // feminine form
-		builder += _name_catalan_1f[SeedModChance(4, lengthof(_name_catalan_1f), seed)];
-		builder += _name_catalan_2f[SeedModChance(11, lengthof(_name_catalan_2f), seed)];
+		builder += _name_catalan_1f[SeedModChance(4, std::size(_name_catalan_1f), seed)];
+		builder += _name_catalan_2f[SeedModChance(11, std::size(_name_catalan_2f), seed)];
 	}
 
 	if (SeedModChance(15, 5, seed) == 0) {
 		if (SeedModChance(5, 2, seed) == 0) { // generic suffix
-			builder += _name_catalan_3[SeedModChance(4, lengthof(_name_catalan_3), seed)];
+			builder += _name_catalan_3[SeedModChance(4, std::size(_name_catalan_3), seed)];
 		} else { // river name suffix
-			builder += _name_catalan_river1[SeedModChance(4, lengthof(_name_catalan_river1), seed)];
+			builder += _name_catalan_river1[SeedModChance(4, std::size(_name_catalan_river1), seed)];
 		}
 	}
 }
@@ -1012,6 +1012,6 @@ static TownNameGenerator *_town_name_generators[] = {
  */
 void GenerateTownNameString(StringBuilder &builder, size_t lang, uint32_t seed)
 {
-	assert(lang < lengthof(_town_name_generators));
+	assert(lang < std::size(_town_name_generators));
 	return _town_name_generators[lang](builder, seed);
 }


### PR DESCRIPTION
## Motivation / Problem

Use C++ `std::size` over C-style `lengthof` macro in the town names.


## Description

Most of the code in the town name generators do some form of "get random index into some array", where it passed `lengthof` into the function as `int`. This parameter is now changed to `size_t` and it's passing the result of `std::size`.


## Limitations

There are more places where `int` or `uint` could be replaced with `size_t`, but that's beyond the scope for this. After all, this is already big enough as it is.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
