### PR TITLE
Codechange: use single function returning std::span over two functions that return size and begin

### DIFF
--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -181,25 +181,14 @@ public:
 	}
 
 	/**
-	 * Allows to know the size of the persistent storage.
+	 * Gets the span containing the persistent storage.
 	 * @param index Index of the item.
 	 * @param grfid Parameter for the PSA. Only required for items with parameters.
-	 * @return Size of the persistent storage in indices.
+	 * @return Span of the storage array or an empty span when not present.
 	 */
-	virtual uint GetPSASize([[maybe_unused]] uint index, [[maybe_unused]] uint32_t grfid) const
+	virtual const std::span<int32_t> GetPSA([[maybe_unused]] uint index, [[maybe_unused]] uint32_t grfid) const
 	{
-		return 0;
-	}
-
-	/**
-	 * Gets the first position of the array containing the persistent storage.
-	 * @param index Index of the item.
-	 * @param grfid Parameter for the PSA. Only required for items with parameters.
-	 * @return Pointer to the first position of the storage array or nullptr if not present.
-	 */
-	virtual const int32_t *GetPSAFirstPosition([[maybe_unused]] uint index, [[maybe_unused]] uint32_t grfid) const
-	{
-		return nullptr;
+		return {};
 	}
 
 protected:
@@ -472,17 +461,16 @@ struct NewGRFInspectWindow : Window {
 			}
 		}
 
-		uint psa_size = nih->GetPSASize(index, this->caller_grfid);
-		const int32_t *psa = nih->GetPSAFirstPosition(index, this->caller_grfid);
-		if (psa_size != 0 && psa != nullptr) {
+		auto psa = nih->GetPSA(index, this->caller_grfid);
+		if (!psa.empty()) {
 			if (nih->PSAWithParameter()) {
 				this->DrawString(r, i++, fmt::format("Persistent storage [{:08X}]:", BSWAP32(this->caller_grfid)));
 			} else {
 				this->DrawString(r, i++, "Persistent storage:");
 			}
-			assert(psa_size % 4 == 0);
-			for (uint j = 0; j < psa_size; j += 4, psa += 4) {
-				this->DrawString(r, i++, fmt::format("  {}: {} {} {} {}", j, psa[0], psa[1], psa[2], psa[3]));
+			assert(psa.size() % 4 == 0);
+			for (size_t j = 0; j < psa.size(); j += 4) {
+				this->DrawString(r, i++, fmt::format("  {}: {} {} {} {}", j, psa[j], psa[j + 1], psa[j + 2], psa[j + 3]));
 			}
 		}
 

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -378,13 +378,11 @@ class NIHIndustry : public NIHelper {
 		return ro.GetScope(VSG_SCOPE_SELF)->GetVariable(var, param, avail);
 	}
 
-	uint GetPSASize(uint, uint32_t) const override { return cpp_lengthof(PersistentStorage, storage); }
-
-	const int32_t *GetPSAFirstPosition(uint index, uint32_t) const override
+	const std::span<int32_t> GetPSA(uint index, uint32_t) const override
 	{
 		const Industry *i = (const Industry *)this->GetInstance(index);
-		if (i->psa == nullptr) return nullptr;
-		return (int32_t *)(&i->psa->storage);
+		if (i->psa == nullptr) return {};
+		return i->psa->storage;
 	}
 };
 
@@ -554,13 +552,11 @@ class NIHAirport : public NIHelper {
 		return ro.GetScope(VSG_SCOPE_SELF)->GetVariable(var, param, avail);
 	}
 
-	uint GetPSASize(uint, uint32_t) const override { return cpp_lengthof(PersistentStorage, storage); }
-
-	const int32_t *GetPSAFirstPosition(uint index, uint32_t) const override
+	const std::span<int32_t> GetPSA(uint index, uint32_t) const override
 	{
 		const Station *st = (const Station *)this->GetInstance(index);
-		if (st->airport.psa == nullptr) return nullptr;
-		return (int32_t *)(&st->airport.psa->storage);
+		if (st->airport.psa == nullptr) return {};
+		return st->airport.psa->storage;
 	}
 };
 
@@ -595,7 +591,6 @@ class NIHTown : public NIHelper {
 	void SetStringParameters(uint index) const override  { this->SetSimpleStringParameters(STR_TOWN_NAME, index); }
 	uint32_t GetGRFID(uint) const override               { return 0; }
 	bool PSAWithParameter() const override               { return true; }
-	uint GetPSASize(uint, uint32_t) const override       { return cpp_lengthof(PersistentStorage, storage); }
 
 	uint Resolve(uint index, uint var, uint param, bool *avail) const override
 	{
@@ -603,15 +598,15 @@ class NIHTown : public NIHelper {
 		return ro.GetScope(VSG_SCOPE_SELF)->GetVariable(var, param, avail);
 	}
 
-	const int32_t *GetPSAFirstPosition(uint index, uint32_t grfid) const override
+	const std::span<int32_t> GetPSA(uint index, uint32_t grfid) const override
 	{
 		Town *t = Town::Get(index);
 
 		for (const auto &it : t->psa_list) {
-			if (it->grfid == grfid) return &it->storage[0];
+			if (it->grfid == grfid) return it->storage;
 		}
 
-		return nullptr;
+		return {};
 	}
 };
 


### PR DESCRIPTION
## Motivation / Problem

`cpp_lengthof` is a disaster waiting to happen.

Given `struct A { std::vector<int> b; }`, then `cpp_lengthof(A, b)` returns something like 6, since `sizeof(std::vector)` is 24 and `sizeof(int)` is 4.

With the NewGRF debug UI, `cpp_lengthof` was used to return the size of a (now) `std::array`, and with a separate function the begin of the array was returned. Now we have `std::span`, returning both in a `std::span` would be much simpler.


## Description

Replace the two separate functions with a function returning a `std::span` and by doing so remove half of the `cpp_lengthof` users.


## Limitations

The other half of the `cpp_lengthof` users still exist, but that ought to be done in a separate PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
