### PR TITLE
Codechange: use range-based for loop for debug levels and fix global variable naming

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -60,7 +60,7 @@ struct DebugLevel {
 };
 
 #define DEBUG_LEVEL(x) { #x, &_debug_##x##_level }
-	static const DebugLevel debug_level[] = {
+static const DebugLevel _debug_levels[] = {
 	DEBUG_LEVEL(driver),
 	DEBUG_LEVEL(grf),
 	DEBUG_LEVEL(map),
@@ -79,7 +79,7 @@ struct DebugLevel {
 #ifdef RANDOM_DEBUG
 	DEBUG_LEVEL(random),
 #endif
-	};
+};
 #undef DEBUG_LEVEL
 
 /**
@@ -89,13 +89,13 @@ struct DebugLevel {
 void DumpDebugFacilityNames(std::back_insert_iterator<std::string> &output_iterator)
 {
 	bool written = false;
-	for (const DebugLevel *i = debug_level; i != endof(debug_level); ++i) {
+	for (const auto &debug_level : _debug_levels) {
 		if (!written) {
 			fmt::format_to(output_iterator, "List of debug facility names:\n");
 		} else {
 			fmt::format_to(output_iterator, ", ");
 		}
-		fmt::format_to(output_iterator, "{}", i->name);
+		fmt::format_to(output_iterator, "{}", debug_level.name);
 		written = true;
 	}
 	if (written) {
@@ -153,13 +153,11 @@ void SetDebugString(const char *s, void (*error_func)(const std::string &))
 
 	/* Global debugging level? */
 	if (*s >= '0' && *s <= '9') {
-		const DebugLevel *i;
-
 		v = std::strtoul(s, &end, 0);
 		s = end;
 
-		for (i = debug_level; i != endof(debug_level); ++i) {
-			new_levels[i->name] = v;
+		for (const auto &debug_level : _debug_levels) {
+			new_levels[debug_level.name] = v;
 		}
 	}
 
@@ -174,9 +172,9 @@ void SetDebugString(const char *s, void (*error_func)(const std::string &))
 
 		/* check debugging levels */
 		const DebugLevel *found = nullptr;
-		for (const DebugLevel *i = debug_level; i != endof(debug_level); ++i) {
-			if (s == t + strlen(i->name) && strncmp(t, i->name, s - t) == 0) {
-				found = i;
+		for (const auto &debug_level : _debug_levels) {
+			if (s == t + strlen(debug_level.name) && strncmp(t, debug_level.name, s - t) == 0) {
+				found = &debug_level;
 				break;
 			}
 		}
@@ -194,10 +192,10 @@ void SetDebugString(const char *s, void (*error_func)(const std::string &))
 	}
 
 	/* Apply the changes after parse is successful */
-	for (const DebugLevel *i = debug_level; i != endof(debug_level); ++i) {
-		const auto &nl = new_levels.find(i->name);
+	for (const auto &debug_level : _debug_levels) {
+		const auto &nl = new_levels.find(debug_level.name);
 		if (nl != new_levels.end()) {
-			*i->level = nl->second;
+			*debug_level.level = nl->second;
 		}
 	}
 }
@@ -210,9 +208,9 @@ void SetDebugString(const char *s, void (*error_func)(const std::string &))
 std::string GetDebugString()
 {
 	std::string result;
-	for (const DebugLevel *i = debug_level; i != endof(debug_level); ++i) {
+	for (const auto &debug_level : _debug_levels) {
 		if (!result.empty()) result += ", ";
-		fmt::format_to(std::back_inserter(result), "{}={}", i->name, *i->level);
+		fmt::format_to(std::back_inserter(result), "{}={}", debug_level.name, *debug_level.level);
 	}
 	return result;
 }


### PR DESCRIPTION
## Motivation / Problem

I don't like `endof` since that might break when changing the underlying type.
The global variable with debug levels is called `debug_level`, i.e. missing the initial underscore and in singular.


## Description

Replace the for loops that used `endof` with range-based for loops.
Rename the global `debug_level` to `_debug_levels` and remove some incorrect indentation.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
