### PR TITLE
Codechange: use range-based for loops and let count be correct count

### DIFF
--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -251,8 +251,8 @@ struct AllegroVkMapping {
 	uint8_t map_to;
 };
 
-#define AS(x, z) {x, 0, z}
-#define AM(x, y, z, w) {x, y - x, z}
+#define AS(x, z) {x, 1, z}
+#define AM(x, y, z, w) {x, y - x + 1, z}
 
 static const AllegroVkMapping _vk_mapping[] = {
 	/* Pageup stuff + up/down */
@@ -312,12 +312,11 @@ static uint32_t ConvertAllegroKeyIntoMy(char32_t *character)
 	int scancode;
 	int unicode = ureadkey(&scancode);
 
-	const AllegroVkMapping *map;
 	uint key = 0;
 
-	for (map = _vk_mapping; map != endof(_vk_mapping); ++map) {
-		if ((uint)(scancode - map->vk_from) <= map->vk_count) {
-			key = scancode - map->vk_from + map->map_to;
+	for (const auto &map : _vk_mapping) {
+		if (IsInsideBS(scancode, map.vk_from, map.vk_count)) {
+			key = scancode - map.vk_from + map.map_to;
 			break;
 		}
 	}

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -246,10 +246,10 @@ struct SDLVkMapping {
 	bool unprintable;
 };
 
-#define AS(x, z) {x, 0, z, false}
-#define AM(x, y, z, w) {x, (uint8_t)(y - x), z, false}
-#define AS_UP(x, z) {x, 0, z, true}
-#define AM_UP(x, y, z, w) {x, (uint8_t)(y - x), z, true}
+#define AS(x, z) {x, 1, z, false}
+#define AM(x, y, z, w) {x, (uint8_t)(y - x + 1), z, false}
+#define AS_UP(x, z) {x, 1, z, true}
+#define AM_UP(x, y, z, w) {x, (uint8_t)(y - x + 1), z, true}
 
 static const SDLVkMapping _vk_mapping[] = {
 	/* Pageup stuff + up/down */
@@ -306,14 +306,13 @@ static const SDLVkMapping _vk_mapping[] = {
 
 static uint ConvertSdlKeyIntoMy(SDL_Keysym *sym, char32_t *character)
 {
-	const SDLVkMapping *map;
 	uint key = 0;
 	bool unprintable = false;
 
-	for (map = _vk_mapping; map != endof(_vk_mapping); ++map) {
-		if ((uint)(sym->sym - map->vk_from) <= map->vk_count) {
-			key = sym->sym - map->vk_from + map->map_to;
-			unprintable = map->unprintable;
+	for (const auto &map : _vk_mapping) {
+		if (IsInsideBS(sym, map.vk_from, map.vk_count)) {
+			key = sym->sym - map.vk_from + map.map_to;
+			unprintable = map.unprintable;
 			break;
 		}
 	}
@@ -346,12 +345,11 @@ static uint ConvertSdlKeyIntoMy(SDL_Keysym *sym, char32_t *character)
  */
 static uint ConvertSdlKeycodeIntoMy(SDL_Keycode kc)
 {
-	const SDLVkMapping *map;
 	uint key = 0;
 
-	for (map = _vk_mapping; map != endof(_vk_mapping); ++map) {
-		if ((uint)(kc - map->vk_from) <= map->vk_count) {
-			key = kc - map->vk_from + map->map_to;
+	for (const auto &map : _vk_mapping) {
+		if (IsInsideBS(kc, map.vk_from, map.vk_count)) {
+			key = kc - map.vk_from + map.map_to;
 			break;
 		}
 	}

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -378,8 +378,8 @@ struct SDLVkMapping {
 	uint8_t map_to;
 };
 
-#define AS(x, z) {x, 0, z}
-#define AM(x, y, z, w) {x, (uint8_t)(y - x), z}
+#define AS(x, z) {x, 1, z}
+#define AM(x, y, z, w) {x, (uint8_t)(y - x + 1), z}
 
 static const SDLVkMapping _vk_mapping[] = {
 	/* Pageup stuff + up/down */
@@ -435,12 +435,11 @@ static const SDLVkMapping _vk_mapping[] = {
 
 static uint ConvertSdlKeyIntoMy(SDL_keysym *sym, char32_t *character)
 {
-	const SDLVkMapping *map;
 	uint key = 0;
 
-	for (map = _vk_mapping; map != endof(_vk_mapping); ++map) {
-		if ((uint)(sym->sym - map->vk_from) <= map->vk_count) {
-			key = sym->sym - map->vk_from + map->map_to;
+	for (const auto &map : _vk_mapping) {
+		if (IsInsideBS(sym, map.vk_from, map.vk_count)) {
+			key = sym->sym - map.vk_from + map.map_to;
 			break;
 		}
 	}

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -61,8 +61,8 @@ struct Win32VkMapping {
 	uint8_t map_to;
 };
 
-#define AS(x, z) {x, 0, z}
-#define AM(x, y, z, w) {x, y - x, z}
+#define AS(x, z) {x, 1, z}
+#define AM(x, y, z, w) {x, y - x + 1, z}
 
 static const Win32VkMapping _vk_mapping[] = {
 	/* Pageup stuff + up/down */
@@ -107,12 +107,11 @@ static const Win32VkMapping _vk_mapping[] = {
 
 static uint MapWindowsKey(uint sym)
 {
-	const Win32VkMapping *map;
 	uint key = 0;
 
-	for (map = _vk_mapping; map != endof(_vk_mapping); ++map) {
-		if ((uint)(sym - map->vk_from) <= map->vk_count) {
-			key = sym - map->vk_from + map->map_to;
+	for (const auto &map : _vk_mapping) {
+		if (IsInsideBS(sym, map.vk_from, map.vk_count)) {
+			key = sym - map.vk_from + map.map_to;
 			break;
 		}
 	}


### PR DESCRIPTION
## Motivation / Problem

Most video drivers use the `endof` macro to iterate over the mapping of keys, instead of simpler range-based for loops.
Most video drivers have a mapping structure that has a count, which is consistently one too low.


## Description

Replace C-style array loop with range-based for loops.
Let the count of the `VkMapping` structures be an actual count (instead of count - 1), and use `IsInsideBS` instead of a custom version.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
