### PR TITLE
Codechange: replace for loops with endof with range-based for loops

### DIFF
--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2678,23 +2678,23 @@ static const SaveLoadFormat *GetSavegameFormat(const std::string &full_name, uin
 		bool has_comp_level = separator != std::string::npos;
 		const std::string name(full_name, 0, has_comp_level ? separator : full_name.size());
 
-		for (const SaveLoadFormat *slf = &_saveload_formats[0]; slf != endof(_saveload_formats); slf++) {
-			if (slf->init_write != nullptr && name.compare(slf->name) == 0) {
-				*compression_level = slf->default_compression;
+		for (const auto &slf : _saveload_formats) {
+			if (slf.init_write != nullptr && name.compare(slf.name) == 0) {
+				*compression_level = slf.default_compression;
 				if (has_comp_level) {
 					const std::string complevel(full_name, separator + 1);
 
 					/* Get the level and determine whether all went fine. */
 					size_t processed;
 					long level = std::stol(complevel, &processed, 10);
-					if (processed == 0 || level != Clamp(level, slf->min_compression, slf->max_compression)) {
+					if (processed == 0 || level != Clamp(level, slf.min_compression, slf.max_compression)) {
 						SetDParamStr(0, complevel);
 						ShowErrorMessage(STR_CONFIG_ERROR, STR_CONFIG_ERROR_INVALID_SAVEGAME_COMPRESSION_LEVEL, WL_CRITICAL);
 					} else {
 						*compression_level = level;
 					}
 				}
-				return slf;
+				return &slf;
 			}
 		}
 

--- a/src/sound/win32_s.cpp
+++ b/src/sound/win32_s.cpp
@@ -45,10 +45,10 @@ static DWORD WINAPI SoundThread(LPVOID)
 	SetCurrentThreadName("ottd:win-sound");
 
 	do {
-		for (WAVEHDR *hdr = _wave_hdr; hdr != endof(_wave_hdr); hdr++) {
-			if ((hdr->dwFlags & WHDR_INQUEUE) != 0) continue;
-			MxMixSamples(hdr->lpData, hdr->dwBufferLength / 4);
-			if (waveOutWrite(_waveout, hdr, sizeof(WAVEHDR)) != MMSYSERR_NOERROR) {
+		for (auto &hdr : _wave_hdr) {
+			if ((hdr.dwFlags & WHDR_INQUEUE) != 0) continue;
+			MxMixSamples(hdr.lpData, hdr.dwBufferLength / 4);
+			if (waveOutWrite(_waveout, &hdr, sizeof(WAVEHDR)) != MMSYSERR_NOERROR) {
 				MessageBox(nullptr, L"Sounds are disabled until restart.", L"waveOutWrite failed", MB_ICONINFORMATION);
 				return 0;
 			}

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -337,25 +337,25 @@ int CDECL main(int argc, char *argv[])
 		switch (i) {
 			case 'C':
 				fmt::print("args\tflags\tcommand\treplacement\n");
-				for (const CmdStruct *cs = _cmd_structs; cs < endof(_cmd_structs); cs++) {
+				for (const auto &cs : _cmd_structs) {
 					char flags;
-					if (cs->proc == EmitGender) {
+					if (cs.proc == EmitGender) {
 						flags = 'g'; // Command needs number of parameters defined by number of genders
-					} else if (cs->proc == EmitPlural) {
+					} else if (cs.proc == EmitPlural) {
 						flags = 'p'; // Command needs number of parameters defined by plural value
-					} else if (cs->flags & C_DONTCOUNT) {
+					} else if (cs.flags & C_DONTCOUNT) {
 						flags = 'i'; // Command may be in the translation when it is not in base
 					} else {
 						flags = '0'; // Command needs no parameters
 					}
-					fmt::print("{}\t{:c}\t\"{}\"\t\"{}\"\n", cs->consumes, flags, cs->cmd, strstr(cs->cmd, "STRING") ? "STRING" : cs->cmd);
+					fmt::print("{}\t{:c}\t\"{}\"\t\"{}\"\n", cs.consumes, flags, cs.cmd, strstr(cs.cmd, "STRING") ? "STRING" : cs.cmd);
 				}
 				return 0;
 
 			case 'L':
 				fmt::print("count\tdescription\tnames\n");
-				for (const PluralForm *pf = _plural_forms; pf < endof(_plural_forms); pf++) {
-					fmt::print("{}\t\"{}\"\t{}\n", pf->plural_count, pf->description, pf->names);
+				for (const auto &pf : _plural_forms) {
+					fmt::print("{}\t\"{}\"\t{}\n", pf.plural_count, pf.description, pf.names);
 				}
 				return 0;
 

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -420,8 +420,8 @@ void EmitGender(Buffer *buffer, char *buf, int)
 
 static const CmdStruct *FindCmd(const char *s, int len)
 {
-	for (const CmdStruct *cs = _cmd_structs; cs != endof(_cmd_structs); cs++) {
-		if (strncmp(cs->cmd, s, len) == 0 && cs->cmd[len] == '\0') return cs;
+	for (const auto &cs : _cmd_structs) {
+		if (strncmp(cs.cmd, s, len) == 0 && cs.cmd[len] == '\0') return &cs;
 	}
 	return nullptr;
 }

--- a/src/terraform_cmd.cpp
+++ b/src/terraform_cmd.cpp
@@ -136,8 +136,6 @@ static std::tuple<CommandCost, TileIndex> TerraformTileHeight(TerraformerState *
 
 	/* Recurse to neighboured corners if height difference is larger than 1 */
 	{
-		const TileIndexDiffC *ttm;
-
 		TileIndex orig_tile = tile;
 		static const TileIndexDiffC _terraform_tilepos[] = {
 			{ 1,  0}, // move to tile in SE
@@ -146,8 +144,8 @@ static std::tuple<CommandCost, TileIndex> TerraformTileHeight(TerraformerState *
 			{ 0, -2}  // undo last move, and move to tile in NE
 		};
 
-		for (ttm = _terraform_tilepos; ttm != endof(_terraform_tilepos); ttm++) {
-			tile += ToTileIndexDiff(*ttm);
+		for (const auto &ttm : _terraform_tilepos) {
+			tile += ToTileIndexDiff(ttm);
 
 			if (tile >= Map::Size()) continue;
 			/* Make sure we don't wrap around the map */

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1398,8 +1398,8 @@ static inline bool RoadTypesAllowHouseHere(TileIndex t)
 	static const TileIndexDiffC tiles[] = { {-1, -1}, {-1, 0}, {-1, 1}, {0, -1}, {0, 1}, {1, -1}, {1, 0}, {1, 1} };
 	bool allow = false;
 
-	for (const TileIndexDiffC *ptr = tiles; ptr != endof(tiles); ++ptr) {
-		TileIndex cur_tile = t + ToTileIndexDiff(*ptr);
+	for (const auto &ptr : tiles) {
+		TileIndex cur_tile = t + ToTileIndexDiff(ptr);
 		if (!IsValidTile(cur_tile)) continue;
 
 		if (!(IsTileType(cur_tile, MP_ROAD) || IsRoadStopTile(cur_tile))) continue;
@@ -1826,21 +1826,20 @@ static bool GrowTown(Town *t)
 	TileIndex tile = t->xy; // The tile we are working with ATM
 
 	/* Find a road that we can base the construction on. */
-	const TileIndexDiffC *ptr;
-	for (ptr = _town_coord_mod; ptr != endof(_town_coord_mod); ++ptr) {
+	for (const auto &ptr : _town_coord_mod) {
 		if (GetTownRoadBits(tile) != ROAD_NONE) {
 			bool success = GrowTownAtRoad(t, tile);
 			cur_company.Restore();
 			return success;
 		}
-		tile = TileAdd(tile, ToTileIndexDiff(*ptr));
+		tile = TileAdd(tile, ToTileIndexDiff(ptr));
 	}
 
 	/* No road available, try to build a random road block by
 	 * clearing some land and then building a road there. */
 	if (TownAllowedToBuildRoads()) {
 		tile = t->xy;
-		for (ptr = _town_coord_mod; ptr != endof(_town_coord_mod); ++ptr) {
+		for (const auto &ptr : _town_coord_mod) {
 			/* Only work with plain land that not already has a house */
 			if (!IsTileType(tile, MP_HOUSE) && IsTileFlat(tile)) {
 				if (Command<CMD_LANDSCAPE_CLEAR>::Do(DC_AUTO | DC_NO_WATER, tile).Succeeded()) {
@@ -1850,7 +1849,7 @@ static bool GrowTown(Town *t)
 					return true;
 				}
 			}
-			tile = TileAdd(tile, ToTileIndexDiff(*ptr));
+			tile = TileAdd(tile, ToTileIndexDiff(ptr));
 		}
 	}
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`endof` does not play nice with C++ containers. It will return something, but that's likely not correct.


## Description

Replace some for loops with range based for loops, so `endof` is not needed.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
