### PR TITLE
Codechange: replace last cases of endof with other (safer) constructs

### DIFF
--- a/src/newgrf_airport.h
+++ b/src/newgrf_airport.h
@@ -130,8 +130,8 @@ struct AirportSpec {
 	/** Get the index of this spec. */
 	uint8_t GetIndex() const
 	{
-		assert(this >= specs && this < endof(specs));
-		return (uint8_t)(this - specs);
+		assert(this >= std::begin(specs) && this < std::end(specs));
+		return static_cast<uint8_t>(std::distance(std::cbegin(specs), this));
 	}
 
 	static const AirportSpec dummy; ///< The dummy airport.

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -287,14 +287,6 @@ char (&ArraySizeHelper(T (&array)[N]))[N];
 #define lengthof(array) (sizeof(ArraySizeHelper(array)))
 
 /**
- * Get the end element of an fixed size array.
- *
- * @param x The pointer to the first element of the array
- * @return The pointer past to the last element of the array
- */
-#define endof(x) (&x[lengthof(x)])
-
-/**
  * Get the last element of an fixed size array.
  *
  * @param x The pointer to the first element of the array


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`endof` does not play nice with C++ containers. It will return something, but that's likely not correct.


## Description

Basically use `std::end` instead of `endof`.

For newgrf_airport and saveload also explicitly use `std::begin` to be more future proof.

For landscape rewrite the logic so it uses `std::none_of` with `std::begin` and `std::end`, so what the intention of the code is becomes clearer as well.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
