### PR TITLE
Codechange: replace loops with lengthof with more C++-style solutions

### DIFF
--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -303,33 +303,32 @@ struct CheatWindow : Window {
 		if (widget != WID_C_PANEL) return;
 
 		uint width = 0;
-		for (int i = 0; i != lengthof(_cheats_ui); i++) {
-			const CheatEntry *ce = &_cheats_ui[i];
-			switch (ce->type) {
+		for (const auto &ce : _cheats_ui) {
+			switch (ce.type) {
 				case SLE_BOOL:
 					SetDParam(0, STR_CONFIG_SETTING_ON);
-					width = std::max(width, GetStringBoundingBox(ce->str).width);
+					width = std::max(width, GetStringBoundingBox(ce.str).width);
 					SetDParam(0, STR_CONFIG_SETTING_OFF);
-					width = std::max(width, GetStringBoundingBox(ce->str).width);
+					width = std::max(width, GetStringBoundingBox(ce.str).width);
 					break;
 
 				default:
-					switch (ce->str) {
+					switch (ce.str) {
 						/* Display date for change date cheat */
 						case STR_CHEAT_CHANGE_DATE:
 							SetDParam(0, TimerGameCalendar::ConvertYMDToDate(CalendarTime::MAX_YEAR, 11, 31));
-							width = std::max(width, GetStringBoundingBox(ce->str).width);
+							width = std::max(width, GetStringBoundingBox(ce.str).width);
 							break;
 
 						/* Draw coloured flag for change company cheat */
 						case STR_CHEAT_CHANGE_COMPANY:
 							SetDParamMaxValue(0, MAX_COMPANIES);
-							width = std::max(width, GetStringBoundingBox(ce->str).width + WidgetDimensions::scaled.hsep_wide);
+							width = std::max(width, GetStringBoundingBox(ce.str).width + WidgetDimensions::scaled.hsep_wide);
 							break;
 
 						default:
 							SetDParam(0, INT64_MAX);
-							width = std::max(width, GetStringBoundingBox(ce->str).width);
+							width = std::max(width, GetStringBoundingBox(ce.str).width);
 							break;
 					}
 					break;

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -2272,8 +2272,8 @@ struct CompanyWindow : Window
 
 			case WID_C_DESC_VEHICLE_COUNTS:
 				SetDParamMaxValue(0, 5000); // Maximum number of vehicles
-				for (uint i = 0; i < lengthof(_company_view_vehicle_count_strings); i++) {
-					size.width = std::max(size.width, GetStringBoundingBox(_company_view_vehicle_count_strings[i]).width + padding.width);
+				for (const auto &count_string : _company_view_vehicle_count_strings) {
+					size.width = std::max(size.width, GetStringBoundingBox(count_string).width + padding.width);
 				}
 				break;
 

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -1008,9 +1008,9 @@ void DeterminePaths(const char *exe, bool only_local_path)
 				};
 
 			config_dir.clear();
-			for (uint i = 0; i < lengthof(new_openttd_cfg_order); i++) {
-				if (IsValidSearchPath(new_openttd_cfg_order[i])) {
-					config_dir = _searchpaths[new_openttd_cfg_order[i]];
+			for (const auto &searchpath : new_openttd_cfg_order) {
+				if (IsValidSearchPath(searchpath)) {
+					config_dir = _searchpaths[searchpath];
 					break;
 				}
 			}
@@ -1061,8 +1061,8 @@ void DeterminePaths(const char *exe, bool only_local_path)
 		SAVE_DIR, AUTOSAVE_DIR, SCENARIO_DIR, HEIGHTMAP_DIR, BASESET_DIR, NEWGRF_DIR, AI_DIR, AI_LIBRARY_DIR, GAME_DIR, GAME_LIBRARY_DIR, SCREENSHOT_DIR, SOCIAL_INTEGRATION_DIR
 	};
 
-	for (uint i = 0; i < lengthof(default_subdirs); i++) {
-		FioCreateDirectory(_personal_dir + _subdirs[default_subdirs[i]]);
+	for (const auto &default_subdir : default_subdirs) {
+		FioCreateDirectory(_personal_dir + _subdirs[default_subdir]);
 	}
 
 	/* If we have network we make a directory for the autodownloading of content */
@@ -1072,9 +1072,9 @@ void DeterminePaths(const char *exe, bool only_local_path)
 	FillValidSearchPaths(only_local_path);
 
 	/* Create the directory for each of the types of content */
-	const Subdirectory dirs[] = { SCENARIO_DIR, HEIGHTMAP_DIR, BASESET_DIR, NEWGRF_DIR, AI_DIR, AI_LIBRARY_DIR, GAME_DIR, GAME_LIBRARY_DIR, SOCIAL_INTEGRATION_DIR };
-	for (uint i = 0; i < lengthof(dirs); i++) {
-		FioCreateDirectory(FioGetDirectory(SP_AUTODOWNLOAD_DIR, dirs[i]));
+	const Subdirectory subdirs[] = { SCENARIO_DIR, HEIGHTMAP_DIR, BASESET_DIR, NEWGRF_DIR, AI_DIR, AI_LIBRARY_DIR, GAME_DIR, GAME_LIBRARY_DIR, SOCIAL_INTEGRATION_DIR };
+	for (const auto &subdir : subdirs) {
+		FioCreateDirectory(FioGetDirectory(SP_AUTODOWNLOAD_DIR, subdir));
 	}
 
 	extern std::string _log_file;

--- a/src/fontcache/spritefontcache.cpp
+++ b/src/fontcache/spritefontcache.cpp
@@ -84,16 +84,16 @@ void SpriteFontCache::InitializeUnicodeGlyphMap()
 		this->SetUnicodeGlyph(i + SCC_SPRITE_START, sprite);
 	}
 
-	for (uint i = 0; i < lengthof(_default_unicode_map); i++) {
-		uint8_t key = _default_unicode_map[i].key;
+	for (const auto &unicode_map : _default_unicode_map) {
+		uint8_t key = unicode_map.key;
 		if (key == CLRA) {
 			/* Clear the glyph. This happens if the glyph at this code point
 			 * is non-standard and should be accessed by an SCC_xxx enum
 			 * entry only. */
-			this->SetUnicodeGlyph(_default_unicode_map[i].code, 0);
+			this->SetUnicodeGlyph(unicode_map.code, 0);
 		} else {
 			SpriteID sprite = base + key - ASCII_LETTERSTART;
-			this->SetUnicodeGlyph(_default_unicode_map[i].code, sprite);
+			this->SetUnicodeGlyph(unicode_map.code, sprite);
 		}
 	}
 }

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -240,8 +240,8 @@ private:
 		this->column_size[VGC_PROFIT].width = 0;
 		this->column_size[VGC_PROFIT].height = 0;
 		static const SpriteID profit_sprites[] = {SPR_PROFIT_NA, SPR_PROFIT_NEGATIVE, SPR_PROFIT_SOME, SPR_PROFIT_LOT};
-		for (uint i = 0; i < lengthof(profit_sprites); i++) {
-			Dimension d = GetSpriteSize(profit_sprites[i]);
+		for (const auto &profit_sprite : profit_sprites) {
+			Dimension d = GetSpriteSize(profit_sprite);
 			this->column_size[VGC_PROFIT] = maxdim(this->column_size[VGC_PROFIT], d);
 		}
 		this->tiny_step_height = std::max(this->tiny_step_height, this->column_size[VGC_PROFIT].height);

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -775,13 +775,7 @@ static void UpdateIndustryProduction(Industry *i);
 static inline bool IsProductionAlterable(const Industry *i)
 {
 	const IndustrySpec *is = GetIndustrySpec(i->type);
-	bool has_prod = false;
-	for (size_t j = 0; j < lengthof(is->production_rate); j++) {
-		if (is->production_rate[j] != 0) {
-			has_prod = true;
-			break;
-		}
-	}
+	bool has_prod = std::any_of(std::begin(is->production_rate), std::end(is->production_rate), [](auto rate) { return rate != 0; });
 	return ((_game_mode == GM_EDITOR || _cheats.setup_prod.value) &&
 			(has_prod || is->IsRawIndustry()) &&
 			!_networking);

--- a/src/linkgraph/linkgraphschedule.cpp
+++ b/src/linkgraph/linkgraphschedule.cpp
@@ -86,9 +86,9 @@ void LinkGraphSchedule::JoinNext()
  */
 /* static */ void LinkGraphSchedule::Run(LinkGraphJob *job)
 {
-	for (uint i = 0; i < lengthof(instance.handlers); ++i) {
+	for (const auto &handler : instance.handlers) {
 		if (job->IsJobAborted()) return;
-		instance.handlers[i]->Run(*job);
+		handler->Run(*job);
 	}
 
 	/*
@@ -157,8 +157,8 @@ LinkGraphSchedule::LinkGraphSchedule()
 LinkGraphSchedule::~LinkGraphSchedule()
 {
 	this->Clear();
-	for (uint i = 0; i < lengthof(this->handlers); ++i) {
-		delete this->handlers[i];
+	for (const auto &handler : this->handlers) {
+		delete handler;
 	}
 }
 

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -106,7 +106,7 @@ void MusicSystem::BuildPlaylists()
 	const MusicSet *set = BaseMusic::GetUsedSet();
 
 	/* Clear current playlists */
-	for (size_t i = 0; i < lengthof(this->standard_playlists); ++i) this->standard_playlists[i].clear();
+	for (auto &playlist : this->standard_playlists) playlist.clear();
 	this->music_set.clear();
 
 	/* Build standard playlists, and a list of available music */

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1394,11 +1394,11 @@ void FillNewGRFVehicleCache(const Vehicle *v)
 	static_assert(NCVV_END == lengthof(cache_entries));
 
 	/* Resolve all the variables, so their caches are set. */
-	for (size_t i = 0; i < lengthof(cache_entries); i++) {
+	for (const auto &cache_entry : cache_entries) {
 		/* Only resolve when the cache isn't valid. */
-		if (HasBit(v->grf_cache.cache_valid, cache_entries[i][1])) continue;
+		if (HasBit(v->grf_cache.cache_valid, cache_entry[1])) continue;
 		bool stub;
-		ro.GetScope(VSG_SCOPE_SELF)->GetVariable(cache_entries[i][0], 0, &stub);
+		ro.GetScope(VSG_SCOPE_SELF)->GetVariable(cache_entry[0], 0, &stub);
 	}
 
 	/* Make sure really all bits are set. */

--- a/src/newgrf_generic.cpp
+++ b/src/newgrf_generic.cpp
@@ -93,8 +93,8 @@ static GenericCallbackList _gcl[GSF_END];
  */
 void ResetGenericCallbacks()
 {
-	for (uint8_t feature = 0; feature < lengthof(_gcl); feature++) {
-		_gcl[feature].clear();
+	for (auto &gcl : _gcl) {
+		gcl.clear();
 	}
 }
 

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -846,8 +846,8 @@ public:
 
 			case WID_O_COND_VARIABLE: {
 				Dimension d = {0, 0};
-				for (uint i = 0; i < lengthof(_order_conditional_variable); i++) {
-					d = maxdim(d, GetStringBoundingBox(STR_ORDER_CONDITIONAL_LOAD_PERCENTAGE + _order_conditional_variable[i]));
+				for (const auto &ocv : _order_conditional_variable) {
+					d = maxdim(d, GetStringBoundingBox(STR_ORDER_CONDITIONAL_LOAD_PERCENTAGE + ocv));
 				}
 				d.width += padding.width;
 				d.height += padding.height;
@@ -1349,8 +1349,8 @@ public:
 
 			case WID_O_COND_VARIABLE: {
 				DropDownList list;
-				for (uint i = 0; i < lengthof(_order_conditional_variable); i++) {
-					list.push_back(MakeDropDownListStringItem(STR_ORDER_CONDITIONAL_LOAD_PERCENTAGE + _order_conditional_variable[i], _order_conditional_variable[i]));
+				for (const auto &ocv : _order_conditional_variable) {
+					list.push_back(MakeDropDownListStringItem(STR_ORDER_CONDITIONAL_LOAD_PERCENTAGE + ocv, ocv));
 				}
 				ShowDropDownList(this, std::move(list), this->vehicle->GetOrder(this->OrderGetSel())->GetConditionVariable(), WID_O_COND_VARIABLE);
 				break;

--- a/src/pathfinder/npf/queue.cpp
+++ b/src/pathfinder/npf/queue.cpp
@@ -284,11 +284,9 @@ void Hash::PrintStatistics() const
 	uint used_buckets = 0;
 	uint max_collision = 0;
 	uint max_usage = 0;
-	uint usage[200];
-	uint i;
+	uint usage[200] = {};
 
-	for (i = 0; i < lengthof(usage); i++) usage[i] = 0;
-	for (i = 0; i < this->num_buckets; i++) {
+	for (uint i = 0; i < this->num_buckets; i++) {
 		uint collision = 0;
 		if (this->buckets_in_use[i]) {
 			const HashNode *node;
@@ -308,7 +306,7 @@ void Hash::PrintStatistics() const
 	);
 	std::string line;
 	line += "{ ";
-	for (i = 0; i <= max_collision; i++) {
+	for (uint i = 0; i <= max_collision; i++) {
 		if (usage[i] > 0) {
 			fmt::format_to(std::back_inserter(line), "{}:{} ", i, usage[i]);
 #if 0

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2369,7 +2369,7 @@ bool AfterLoadGame()
 			uint8_t old_start;
 			uint8_t num_frames;
 		};
-		static const AirportTileConversion atc[] = {
+		static const AirportTileConversion atcs[] = {
 			{31,  12}, // APT_RADAR_GRASS_FENCE_SW
 			{50,   4}, // APT_GRASS_FENCE_NE_FLAG
 			{62,   2}, // 1 unused tile
@@ -2384,17 +2384,17 @@ bool AfterLoadGame()
 			if (IsAirportTile(t)) {
 				StationGfx old_gfx = GetStationGfx(t);
 				uint8_t offset = 0;
-				for (uint i = 0; i < lengthof(atc); i++) {
-					if (old_gfx < atc[i].old_start) {
+				for (const auto &atc : atcs) {
+					if (old_gfx < atc.old_start) {
 						SetStationGfx(t, old_gfx - offset);
 						break;
 					}
-					if (old_gfx < atc[i].old_start + atc[i].num_frames) {
-						SetAnimationFrame(t, old_gfx - atc[i].old_start);
-						SetStationGfx(t, atc[i].old_start - offset);
+					if (old_gfx < atc.old_start + atc.num_frames) {
+						SetAnimationFrame(t, old_gfx - atc.old_start);
+						SetStationGfx(t, atc.old_start - offset);
 						break;
 					}
-					offset += atc[i].num_frames - 1;
+					offset += atc.num_frames - 1;
 				}
 			}
 		}

--- a/src/script/script_info.cpp
+++ b/src/script/script_info.cpp
@@ -47,8 +47,8 @@ bool ScriptInfo::CheckMethod(const char *name) const
 		"GetDate",
 		"CreateInstance",
 	};
-	for (size_t i = 0; i < lengthof(required_functions); i++) {
-		if (!info->CheckMethod(required_functions[i])) return SQ_ERROR;
+	for (const auto &required_function : required_functions) {
+		if (!info->CheckMethod(required_function)) return SQ_ERROR;
 	}
 
 	/* Get location information of the scanner */

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2380,8 +2380,8 @@ struct GameSettingsWindow : Window {
 					STR_CONFIG_SETTING_TYPE_COMPANY_MENU, STR_CONFIG_SETTING_TYPE_COMPANY_INGAME,
 					STR_CONFIG_SETTING_TYPE_GAME_MENU, STR_CONFIG_SETTING_TYPE_GAME_INGAME,
 				};
-				for (uint i = 0; i < lengthof(setting_types); i++) {
-					SetDParam(0, setting_types[i]);
+				for (const auto &setting_type : setting_types) {
+					SetDParam(0, setting_type);
 					size.width = std::max(size.width, GetStringBoundingBox(STR_CONFIG_SETTING_TYPE).width + padding.width);
 				}
 				size.height = 2 * GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.vsep_normal +

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -747,16 +747,16 @@ protected:
 		/* Rebuild colour indices if necessary. */
 		if (SmallMapWindow::map_height_limit == _settings_game.construction.map_height_limit) return;
 
-		for (uint n = 0; n < lengthof(_heightmap_schemes); n++) {
+		for (auto &heightmap_scheme : _heightmap_schemes) {
 			/* The heights go from 0 up to and including maximum. */
 			int heights = _settings_game.construction.map_height_limit + 1;
-			_heightmap_schemes[n].height_colours = ReallocT<uint32_t>(_heightmap_schemes[n].height_colours, heights);
+			heightmap_scheme.height_colours = ReallocT<uint32_t>(heightmap_scheme.height_colours, heights);
 
 			for (int z = 0; z < heights; z++) {
-				size_t access_index = (_heightmap_schemes[n].colour_count * z) / heights;
+				size_t access_index = (heightmap_scheme.colour_count * z) / heights;
 
 				/* Choose colour by mapping the range (0..max heightlevel) on the complete colour table. */
-				_heightmap_schemes[n].height_colours[z] = _heightmap_schemes[n].height_colours_base[access_index];
+				heightmap_scheme.height_colours[z] = heightmap_scheme.height_colours_base[access_index];
 			}
 		}
 

--- a/src/spriteloader/sprite_file.cpp
+++ b/src/spriteloader/sprite_file.cpp
@@ -24,8 +24,8 @@ static uint8_t GetGRFContainerVersion(SpriteFile &file)
 	if (file.ReadWord() == 0) {
 		/* Check for GRF container version 2, which is identified by the bytes
 		 * '47 52 46 82 0D 0A 1A 0A' at the start of the file. */
-		for (uint i = 0; i < lengthof(_grf_cont_v2_sig); i++) {
-			if (file.ReadByte() != _grf_cont_v2_sig[i]) return 0; // Invalid format
+		for (const auto &expected_sig_byte : _grf_cont_v2_sig) {
+			if (file.ReadByte() != expected_sig_byte) return 0; // Invalid format
 		}
 
 		return 2;

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -361,9 +361,9 @@ int CDECL main(int argc, char *argv[])
 
 			case 'P':
 				fmt::print("name\tflags\tdefault\tdescription\n");
-				for (size_t j = 0; j < lengthof(_pragmas); j++) {
+				for (const auto &pragma : _pragmas) {
 					fmt::print("\"{}\"\t{}\t\"{}\"\t\"{}\"\n",
-							_pragmas[j][0], _pragmas[j][1], _pragmas[j][2], _pragmas[j][3]);
+							pragma[0], pragma[1], pragma[2], pragma[3]);
 				}
 				return 0;
 

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2440,8 +2440,8 @@ struct VehicleDetailsWindow : Window {
 					STR_VEHICLE_INFO_PROFIT_THIS_PERIOD_LAST_PERIOD_MIN_PERFORMANCE,
 					STR_VEHICLE_INFO_RELIABILITY_BREAKDOWNS
 				};
-				for (uint i = 0; i < lengthof(info_strings); i++) {
-					dim = maxdim(dim, GetStringBoundingBox(info_strings[i]));
+				for (const auto &info_string : info_strings) {
+					dim = maxdim(dim, GetStringBoundingBox(info_string));
 				}
 				SetDParam(0, STR_VEHICLE_INFO_AGE);
 				dim = maxdim(dim, GetStringBoundingBox(TimerGameEconomy::UsingWallclockUnits() ? STR_VEHICLE_INFO_AGE_RUNNING_COST_PERIOD : STR_VEHICLE_INFO_AGE_RUNNING_COST_YR));

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -182,9 +182,9 @@ static void GetVideoModes()
 
 	_all_modes = (SDL_ListModes(nullptr, SDL_SWSURFACE | (_fullscreen ? SDL_FULLSCREEN : 0)) == (void*)-1);
 	if (modes == (void*)-1) {
-		for (uint i = 0; i < lengthof(_default_resolutions); i++) {
-			if (SDL_VideoModeOK(_default_resolutions[i].width, _default_resolutions[i].height, 8, SDL_FULLSCREEN) != 0) {
-				_resolutions.push_back(_default_resolutions[i]);
+		for (const auto &default_resolution : _default_resolutions) {
+			if (SDL_VideoModeOK(default_resolution.width, default_resolution.height, 8, SDL_FULLSCREEN) != 0) {
+				_resolutions.push_back(default_resolution);
 			}
 		}
 	} else {

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -3517,9 +3517,9 @@ static ViewportSSCSS _vp_sprite_sorters[] = {
 /** Choose the "best" sprite sorter and set _vp_sprite_sorter. */
 void InitializeSpriteSorter()
 {
-	for (uint i = 0; i < lengthof(_vp_sprite_sorters); i++) {
-		if (_vp_sprite_sorters[i].fct_checker()) {
-			_vp_sprite_sorter = _vp_sprite_sorters[i].fct_sorter;
+	for (const auto &sprite_sorter : _vp_sprite_sorters) {
+		if (sprite_sorter.fct_checker()) {
+			_vp_sprite_sorter = sprite_sorter.fct_sorter;
 			break;
 		}
 	}


### PR DESCRIPTION
## Motivation / Problem

`lengthof` is troublesome as it might return values you do not expect it to return.


## Description

Mostly `for (uint i = 0; i < lengthof(values); i++)` loops changed to `for (const auto &value : values)`.
In some cases using zero-initialization or `std::any_of`.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
