### PR TITLE
Codechange: Pass std::string_view from drivers/blitters instead of char *.

### DIFF
--- a/src/blitter/32bpp_anim.hpp
+++ b/src/blitter/32bpp_anim.hpp
@@ -47,7 +47,7 @@ public:
 	void PaletteAnimate(const Palette &palette) override;
 	Blitter::PaletteAnimation UsePaletteAnimation() override;
 
-	const char *GetName() override { return "32bpp-anim"; }
+	std::string_view GetName() override { return "32bpp-anim"; }
 	void PostResize() override;
 
 	/**

--- a/src/blitter/32bpp_anim_sse2.hpp
+++ b/src/blitter/32bpp_anim_sse2.hpp
@@ -31,7 +31,7 @@
 class Blitter_32bppSSE2_Anim : public Blitter_32bppAnim {
 public:
 	void PaletteAnimate(const Palette &palette) override;
-	const char *GetName() override { return "32bpp-sse2-anim"; }
+	std::string_view GetName() override { return "32bpp-sse2-anim"; }
 };
 
 /** Factory for the partially 32bpp blitter with animation. */

--- a/src/blitter/32bpp_anim_sse4.hpp
+++ b/src/blitter/32bpp_anim_sse4.hpp
@@ -42,7 +42,7 @@ public:
 	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator) override {
 		return Blitter_32bppSSE_Base::Encode(sprite, allocator);
 	}
-	const char *GetName() override { return "32bpp-sse4-anim"; }
+	std::string_view GetName() override { return "32bpp-sse4-anim"; }
 	using Blitter_32bppSSE2_Anim::LookupColourInPalette;
 };
 

--- a/src/blitter/32bpp_optimized.hpp
+++ b/src/blitter/32bpp_optimized.hpp
@@ -24,7 +24,7 @@ public:
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
 	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator) override;
 
-	const char *GetName() override { return "32bpp-optimized"; }
+	std::string_view GetName() override { return "32bpp-optimized"; }
 
 	template <BlitterMode mode, bool Tpal_to_rgb = false> void Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom);
 

--- a/src/blitter/32bpp_simple.hpp
+++ b/src/blitter/32bpp_simple.hpp
@@ -28,7 +28,7 @@ public:
 	void DrawColourMappingRect(void *dst, int width, int height, PaletteID pal) override;
 	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator) override;
 
-	const char *GetName() override { return "32bpp-simple"; }
+	std::string_view GetName() override { return "32bpp-simple"; }
 };
 
 /** Factory for the simple 32 bpp blitter. */

--- a/src/blitter/32bpp_sse2.hpp
+++ b/src/blitter/32bpp_sse2.hpp
@@ -92,7 +92,7 @@ public:
 		return Blitter_32bppSSE_Base::Encode(sprite, allocator);
 	}
 
-	const char *GetName() override { return "32bpp-sse2"; }
+	std::string_view GetName() override { return "32bpp-sse2"; }
 };
 
 /** Factory for the SSE2 32 bpp blitter (without palette animation). */

--- a/src/blitter/32bpp_sse4.hpp
+++ b/src/blitter/32bpp_sse4.hpp
@@ -32,7 +32,7 @@ public:
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
 	template <BlitterMode mode, Blitter_32bppSSE_Base::ReadMode read_mode, Blitter_32bppSSE_Base::BlockType bt_last, bool translucent>
 	void Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom);
-	const char *GetName() override { return "32bpp-sse4"; }
+	std::string_view GetName() override { return "32bpp-sse4"; }
 };
 
 /** Factory for the SSE4 32 bpp blitter (without palette animation). */

--- a/src/blitter/32bpp_ssse3.hpp
+++ b/src/blitter/32bpp_ssse3.hpp
@@ -32,7 +32,7 @@ public:
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
 	template <BlitterMode mode, Blitter_32bppSSE_Base::ReadMode read_mode, Blitter_32bppSSE_Base::BlockType bt_last, bool translucent>
 	void Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom);
-	const char *GetName() override { return "32bpp-ssse3"; }
+	std::string_view GetName() override { return "32bpp-ssse3"; }
 };
 
 /** Factory for the SSSE3 32 bpp blitter (without palette animation). */

--- a/src/blitter/40bpp_anim.hpp
+++ b/src/blitter/40bpp_anim.hpp
@@ -32,7 +32,7 @@ public:
 	Blitter::PaletteAnimation UsePaletteAnimation() override;
 	bool NeedsAnimationBuffer() override;
 
-	const char *GetName()  override { return "40bpp-anim"; }
+	std::string_view GetName()  override { return "40bpp-anim"; }
 
 	template <BlitterMode mode> void Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom);
 

--- a/src/blitter/8bpp_optimized.hpp
+++ b/src/blitter/8bpp_optimized.hpp
@@ -25,7 +25,7 @@ public:
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
 	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator) override;
 
-	const char *GetName() override { return "8bpp-optimized"; }
+	std::string_view GetName() override { return "8bpp-optimized"; }
 };
 
 /** Factory for the 8bpp blitter optimised for speed. */

--- a/src/blitter/8bpp_simple.hpp
+++ b/src/blitter/8bpp_simple.hpp
@@ -19,7 +19,7 @@ public:
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
 	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator) override;
 
-	const char *GetName() override { return "8bpp-simple"; }
+	std::string_view GetName() override { return "8bpp-simple"; }
 };
 
 /** Factory for the most trivial 8bpp blitter. */

--- a/src/blitter/base.hpp
+++ b/src/blitter/base.hpp
@@ -197,7 +197,7 @@ public:
 	/**
 	 * Get the name of the blitter, the same as the Factory-instance returns.
 	 */
-	virtual const char *GetName() = 0;
+	virtual std::string_view GetName() = 0;
 
 	/**
 	 * Post resize event

--- a/src/blitter/factory.hpp
+++ b/src/blitter/factory.hpp
@@ -159,7 +159,7 @@ public:
 	/**
 	 * Get the long, human readable, name for the Blitter-class.
 	 */
-	const std::string &GetName() const
+	std::string_view GetName() const
 	{
 		return this->name;
 	}
@@ -167,7 +167,7 @@ public:
 	/**
 	 * Get a nice description of the blitter-class.
 	 */
-	const std::string &GetDescription() const
+	std::string_view GetDescription() const
 	{
 		return this->description;
 	}

--- a/src/blitter/null.hpp
+++ b/src/blitter/null.hpp
@@ -31,7 +31,7 @@ public:
 	void PaletteAnimate(const Palette &) override { };
 	Blitter::PaletteAnimation UsePaletteAnimation() override { return Blitter::PALETTE_ANIMATION_NONE; };
 
-	const char *GetName() override { return "null"; }
+	std::string_view GetName() override { return "null"; }
 };
 
 /** Factory for the blitter that does nothing. */

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -148,15 +148,15 @@ bool DriverFactoryBase::SelectDriverImpl(const std::string &name, Driver::Type t
 				Driver *newd = d->CreateInstance();
 				*GetActiveDriver(type) = newd;
 
-				const char *err = newd->Start({});
-				if (err == nullptr) {
+				auto err = newd->Start({});
+				if (!err) {
 					Debug(driver, 1, "Successfully probed {} driver '{}'", GetDriverTypeName(type), d->name);
 					delete oldd;
 					return true;
 				}
 
 				*GetActiveDriver(type) = oldd;
-				Debug(driver, 1, "Probing {} driver '{}' failed with error: {}", GetDriverTypeName(type), d->name, err);
+				Debug(driver, 1, "Probing {} driver '{}' failed with error: {}", GetDriverTypeName(type), d->name, *err);
 				delete newd;
 
 				if (type == Driver::DT_VIDEO && _video_hw_accel && d->UsesHardwareAcceleration()) {
@@ -192,10 +192,10 @@ bool DriverFactoryBase::SelectDriverImpl(const std::string &name, Driver::Type t
 			/* Found our driver, let's try it */
 			Driver *newd = d->CreateInstance();
 
-			const char *err = newd->Start(parms);
-			if (err != nullptr) {
+			auto err = newd->Start(parms);
+			if (err) {
 				delete newd;
-				UserError("Unable to load driver '{}'. The error was: {}", d->name, err);
+				UserError("Unable to load driver '{}'. The error was: {}", d->name, *err);
 			}
 
 			Debug(driver, 1, "Successfully loaded {} driver '{}'", GetDriverTypeName(type), d->name);

--- a/src/driver.h
+++ b/src/driver.h
@@ -23,9 +23,9 @@ public:
 	/**
 	 * Start this driver.
 	 * @param parm Parameters passed to the driver.
-	 * @return nullptr if everything went okay, otherwise an error message.
+	 * @return std::nullopt if everything went okay, otherwise an error message.
 	 */
-	virtual const char *Start(const StringList &parm) = 0;
+	virtual std::optional<std::string_view> Start(const StringList &parm) = 0;
 
 	/**
 	 * Stop this driver.
@@ -47,7 +47,7 @@ public:
 	 * Get the name of this driver.
 	 * @return The name of the driver.
 	 */
-	virtual const char *GetName() const = 0;
+	virtual std::string_view GetName() const = 0;
 };
 
 DECLARE_POSTFIX_INCREMENT(Driver::Type)
@@ -62,8 +62,8 @@ private:
 
 	Driver::Type type;       ///< The type of driver.
 	int priority;            ///< The priority of this factory.
-	const char *name;        ///< The name of the drivers of this factory.
-	const char *description; ///< The description of this driver.
+	std::string_view name;        ///< The name of the drivers of this factory.
+	std::string_view description; ///< The description of this driver.
 
 	typedef std::map<std::string, DriverFactoryBase *> Drivers; ///< Type for a map of drivers.
 
@@ -92,9 +92,9 @@ private:
 	 * @param type The type of driver to get the name of.
 	 * @return The name of the type.
 	 */
-	static const char *GetDriverTypeName(Driver::Type type)
+	static std::string_view GetDriverTypeName(Driver::Type type)
 	{
-		static const char * const driver_type_name[] = { "music", "sound", "video" };
+		static const std::string_view driver_type_name[] = { "music", "sound", "video" };
 		return driver_type_name[type];
 	}
 
@@ -135,7 +135,7 @@ public:
 	 * Get a nice description of the driver-class.
 	 * @return The description.
 	 */
-	const char *GetDescription() const
+	std::string_view GetDescription() const
 	{
 		return this->description;
 	}

--- a/src/music/allegro_m.cpp
+++ b/src/music/allegro_m.cpp
@@ -26,7 +26,7 @@ static MIDI *_midi = nullptr;
  */
 extern int _allegro_instance_count;
 
-const char *MusicDriver_Allegro::Start(const StringList &)
+std::optional<std::string_view> MusicDriver_Allegro::Start(const StringList &)
 {
 	if (_allegro_instance_count == 0 && install_allegro(SYSTEM_AUTODETECT, &errno, nullptr)) {
 		Debug(driver, 0, "allegro: install_allegro failed '{}'", allegro_error);
@@ -46,7 +46,7 @@ const char *MusicDriver_Allegro::Start(const StringList &)
 		return "No sound card found";
 	}
 
-	return nullptr;
+	return std::nullopt;
 }
 
 void MusicDriver_Allegro::Stop()

--- a/src/music/allegro_m.h
+++ b/src/music/allegro_m.h
@@ -15,7 +15,7 @@
 /** Allegro's music player. */
 class MusicDriver_Allegro : public MusicDriver {
 public:
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
 
@@ -26,7 +26,7 @@ public:
 	bool IsSongPlaying() override;
 
 	void SetVolume(uint8_t vol) override;
-	const char *GetName() const override { return "allegro"; }
+	std::string_view GetName() const override { return "allegro"; }
 };
 
 /** Factory for allegro's music player. */

--- a/src/music/bemidi.cpp
+++ b/src/music/bemidi.cpp
@@ -18,9 +18,9 @@
 /** Factory for BeOS' midi player. */
 static FMusicDriver_BeMidi iFMusicDriver_BeMidi;
 
-const char *MusicDriver_BeMidi::Start(const StringList &parm)
+std::optional<std::string_view> MusicDriver_BeMidi::Start(const StringList &parm)
 {
-	return nullptr;
+	return std::nullopt;
 }
 
 void MusicDriver_BeMidi::Stop()

--- a/src/music/bemidi.h
+++ b/src/music/bemidi.h
@@ -18,7 +18,7 @@
 /** The midi player for BeOS. */
 class MusicDriver_BeMidi : public MusicDriver {
 public:
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
 
@@ -29,7 +29,7 @@ public:
 	bool IsSongPlaying() override;
 
 	void SetVolume(uint8_t vol) override;
-	const char *GetName() const override { return "bemidi"; }
+	std::string_view GetName() const override { return "bemidi"; }
 
 private:
 	BMidiSynthFile *midi_synth_file = nullptr;

--- a/src/music/cocoa_m.cpp
+++ b/src/music/cocoa_m.cpp
@@ -79,11 +79,11 @@ static void DoSetVolume()
 /**
  * Initialized the MIDI player, including QuickTime initialization.
  */
-const char *MusicDriver_Cocoa::Start(const StringList &)
+std::optional<std::string_view> MusicDriver_Cocoa::Start(const StringList &)
 {
 	if (NewMusicPlayer(&_player) != noErr) return "failed to create music player";
 
-	return nullptr;
+	return std::nullopt;
 }
 
 

--- a/src/music/cocoa_m.h
+++ b/src/music/cocoa_m.h
@@ -14,7 +14,7 @@
 
 class MusicDriver_Cocoa : public MusicDriver {
 public:
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
 
@@ -25,7 +25,7 @@ public:
 	bool IsSongPlaying() override;
 
 	void SetVolume(uint8_t vol) override;
-	const char *GetName() const override { return "cocoa"; }
+	std::string_view GetName() const override { return "cocoa"; }
 };
 
 class FMusicDriver_Cocoa : public DriverFactoryBase {

--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -1072,7 +1072,7 @@ static const char *LoadDefaultDLSFile(const char *user_dls)
 }
 
 
-const char *MusicDriver_DMusic::Start(const StringList &parm)
+std::optional<std::string_view> MusicDriver_DMusic::Start(const StringList &parm)
 {
 	/* Initialize COM */
 	if (FAILED(CoInitializeEx(nullptr, COINIT_MULTITHREADED))) return "COM initialization failed";
@@ -1153,7 +1153,7 @@ const char *MusicDriver_DMusic::Start(const StringList &parm)
 
 	if (!StartNewThread(&_dmusic_thread, "ottd:dmusic", &MidiThreadProc)) return "Can't create MIDI output thread";
 
-	return nullptr;
+	return std::nullopt;
 }
 
 

--- a/src/music/dmusic.h
+++ b/src/music/dmusic.h
@@ -17,7 +17,7 @@ class MusicDriver_DMusic : public MusicDriver {
 public:
 	virtual ~MusicDriver_DMusic();
 
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
 
@@ -28,7 +28,7 @@ public:
 	bool IsSongPlaying() override;
 
 	void SetVolume(uint8_t vol) override;
-	const char *GetName() const override { return "dmusic"; }
+	std::string_view GetName() const override { return "dmusic"; }
 };
 
 /** Factory for the DirectX music player. */

--- a/src/music/extmidi.cpp
+++ b/src/music/extmidi.cpp
@@ -35,10 +35,10 @@
 /** Factory for the midi player that uses external players. */
 static FMusicDriver_ExtMidi iFMusicDriver_ExtMidi;
 
-const char *MusicDriver_ExtMidi::Start(const StringList &parm)
+std::optional<std::string_view> MusicDriver_ExtMidi::Start(const StringList &parm)
 {
-	if (strcmp(VideoDriver::GetInstance()->GetName(), "allegro") == 0 ||
-			strcmp(SoundDriver::GetInstance()->GetName(), "allegro") == 0) {
+	if (VideoDriver::GetInstance()->GetName() == "allegro" ||
+			SoundDriver::GetInstance()->GetName() == "allegro") {
 		return "the extmidi driver does not work when Allegro is loaded.";
 	}
 
@@ -62,7 +62,7 @@ const char *MusicDriver_ExtMidi::Start(const StringList &parm)
 
 	this->song.clear();
 	this->pid = -1;
-	return nullptr;
+	return std::nullopt;
 }
 
 void MusicDriver_ExtMidi::Stop()

--- a/src/music/extmidi.h
+++ b/src/music/extmidi.h
@@ -22,7 +22,7 @@ private:
 	void DoStop();
 
 public:
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
 
@@ -33,7 +33,7 @@ public:
 	bool IsSongPlaying() override;
 
 	void SetVolume(uint8_t vol) override;
-	const char *GetName() const override { return "extmidi"; }
+	std::string_view GetName() const override { return "extmidi"; }
 };
 
 class FMusicDriver_ExtMidi : public DriverFactoryBase {

--- a/src/music/fluidsynth.cpp
+++ b/src/music/fluidsynth.cpp
@@ -58,7 +58,7 @@ static void RenderMusicStream(int16_t *buffer, size_t samples)
 	fluid_synth_write_s16(_midi.synth, samples, buffer, 0, 2, buffer, 1, 2);
 }
 
-const char *MusicDriver_FluidSynth::Start(const StringList &param)
+std::optional<std::string_view> MusicDriver_FluidSynth::Start(const StringList &param)
 {
 	std::lock_guard<std::mutex> lock{ _midi.synth_mutex };
 
@@ -110,7 +110,7 @@ const char *MusicDriver_FluidSynth::Start(const StringList &param)
 
 	_midi.player = nullptr;
 
-	return nullptr;
+	return std::nullopt;
 }
 
 void MusicDriver_FluidSynth::Stop()

--- a/src/music/fluidsynth.h
+++ b/src/music/fluidsynth.h
@@ -15,7 +15,7 @@
 /** Music driver making use of FluidSynth. */
 class MusicDriver_FluidSynth : public MusicDriver {
 public:
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
 
@@ -26,7 +26,7 @@ public:
 	bool IsSongPlaying() override;
 
 	void SetVolume(uint8_t vol) override;
-	const char *GetName() const override { return "fluidsynth"; }
+	std::string_view GetName() const override { return "fluidsynth"; }
 };
 
 /** Factory for the fluidsynth driver. */

--- a/src/music/null_m.h
+++ b/src/music/null_m.h
@@ -15,7 +15,7 @@
 /** The music player that does nothing. */
 class MusicDriver_Null : public MusicDriver {
 public:
-	const char *Start(const StringList &) override { return nullptr; }
+	std::optional<std::string_view> Start(const StringList &) override { return std::nullopt; }
 
 	void Stop() override { }
 
@@ -26,7 +26,7 @@ public:
 	bool IsSongPlaying() override { return true; }
 
 	void SetVolume(uint8_t) override { }
-	const char *GetName() const override { return "null"; }
+	std::string_view GetName() const override { return "null"; }
 };
 
 /** Factory for the null music player. */

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -367,7 +367,7 @@ void MusicDriver_Win32::SetVolume(uint8_t vol)
 	_midi.new_volume = vol;
 }
 
-const char *MusicDriver_Win32::Start(const StringList &parm)
+std::optional<std::string_view> MusicDriver_Win32::Start(const StringList &parm)
 {
 	Debug(driver, 2, "Win32-MIDI: Start: initializing");
 
@@ -416,7 +416,7 @@ const char *MusicDriver_Win32::Start(const StringList &parm)
 		if (timeBeginPeriod(_midi.time_period) == MMSYSERR_NOERROR) {
 			/* success */
 			Debug(driver, 2, "Win32-MIDI: Start: timer resolution is {}", _midi.time_period);
-			return nullptr;
+			return std::nullopt;
 		}
 	}
 	midiOutClose(_midi.midi_out);

--- a/src/music/win32_m.h
+++ b/src/music/win32_m.h
@@ -15,7 +15,7 @@
 /** The Windows music player. */
 class MusicDriver_Win32 : public MusicDriver {
 public:
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
 
@@ -26,7 +26,7 @@ public:
 	bool IsSongPlaying() override;
 
 	void SetVolume(uint8_t vol) override;
-	const char *GetName() const override { return "win32"; }
+	std::string_view GetName() const override { return "win32"; }
 };
 
 /** Factory for Windows' music player. */

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -579,7 +579,7 @@ struct GameOptionsWindow : Window {
 				break;
 
 			case WID_GO_VIDEO_DRIVER_INFO:
-				SetDParamStr(0, VideoDriver::GetInstance()->GetInfoString());
+				SetDParamStr(0, std::string{VideoDriver::GetInstance()->GetInfoString()});
 				DrawStringMultiLine(r, STR_GAME_OPTIONS_VIDEO_DRIVER_INFO);
 				break;
 
@@ -641,7 +641,7 @@ struct GameOptionsWindow : Window {
 		changed |= wid->UpdateVerticalSize(y);
 
 		wid = this->GetWidget<NWidgetResizeBase>(WID_GO_VIDEO_DRIVER_INFO);
-		SetDParamStr(0, VideoDriver::GetInstance()->GetInfoString());
+		SetDParamStr(0, std::string{VideoDriver::GetInstance()->GetInfoString()});
 		y = GetStringHeight(STR_GAME_OPTIONS_VIDEO_DRIVER_INFO, wid->current_x);
 		changed |= wid->UpdateVerticalSize(y);
 

--- a/src/sound/allegro_s.cpp
+++ b/src/sound/allegro_s.cpp
@@ -50,7 +50,7 @@ void SoundDriver_Allegro::MainLoop()
  */
 extern int _allegro_instance_count;
 
-const char *SoundDriver_Allegro::Start(const StringList &parm)
+std::optional<std::string_view> SoundDriver_Allegro::Start(const StringList &parm)
 {
 	if (_allegro_instance_count == 0 && install_allegro(SYSTEM_AUTODETECT, &errno, nullptr)) {
 		Debug(driver, 0, "allegro: install_allegro failed '{}'", allegro_error);
@@ -74,7 +74,7 @@ const char *SoundDriver_Allegro::Start(const StringList &parm)
 	_buffer_size = GetDriverParamInt(parm, "samples", 1024) * hz / 11025;
 	_stream = play_audio_stream(_buffer_size, 16, true, hz, 255, 128);
 	MxInitialize(hz);
-	return nullptr;
+	return std::nullopt;
 }
 
 void SoundDriver_Allegro::Stop()

--- a/src/sound/allegro_s.h
+++ b/src/sound/allegro_s.h
@@ -15,12 +15,12 @@
 /** Implementation of the allegro sound driver. */
 class SoundDriver_Allegro : public SoundDriver {
 public:
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
 
 	void MainLoop() override;
-	const char *GetName() const override { return "allegro"; }
+	std::string_view GetName() const override { return "allegro"; }
 };
 
 /** Factory for the allegro sound driver. */

--- a/src/sound/cocoa_s.cpp
+++ b/src/sound/cocoa_s.cpp
@@ -44,7 +44,7 @@ static OSStatus audioCallback(void *, AudioUnitRenderActionFlags *, const AudioT
 }
 
 
-const char *SoundDriver_Cocoa::Start(const StringList &parm)
+std::optional<std::string_view> SoundDriver_Cocoa::Start(const StringList &parm)
 {
 	struct AURenderCallbackStruct callback;
 	AudioStreamBasicDescription requestedDesc;
@@ -108,7 +108,7 @@ const char *SoundDriver_Cocoa::Start(const StringList &parm)
 	}
 
 	/* We're running! */
-	return nullptr;
+	return std::nullopt;
 }
 
 

--- a/src/sound/cocoa_s.h
+++ b/src/sound/cocoa_s.h
@@ -14,10 +14,10 @@
 
 class SoundDriver_Cocoa : public SoundDriver {
 public:
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
-	const char *GetName() const override { return "cocoa"; }
+	std::string_view GetName() const override { return "cocoa"; }
 };
 
 class FSoundDriver_Cocoa : public DriverFactoryBase {

--- a/src/sound/null_s.h
+++ b/src/sound/null_s.h
@@ -15,10 +15,10 @@
 /** Implementation of the null sound driver. */
 class SoundDriver_Null : public SoundDriver {
 public:
-	const char *Start(const StringList &) override { return nullptr; }
+	std::optional<std::string_view> Start(const StringList &) override { return std::nullopt; }
 
 	void Stop() override { }
-	const char *GetName() const override { return "null"; }
+	std::string_view GetName() const override { return "null"; }
 	bool HasOutput() const override { return false; }
 };
 

--- a/src/sound/sdl2_s.cpp
+++ b/src/sound/sdl2_s.cpp
@@ -30,7 +30,7 @@ static void CDECL fill_sound_buffer(void *, Uint8 *stream, int len)
 	MxMixSamples(stream, len / 4);
 }
 
-const char *SoundDriver_SDL::Start(const StringList &parm)
+std::optional<std::string_view> SoundDriver_SDL::Start(const StringList &parm)
 {
 	SDL_AudioSpec spec;
 	SDL_AudioSpec spec_actual;
@@ -52,7 +52,7 @@ const char *SoundDriver_SDL::Start(const StringList &parm)
 	SDL_AudioDeviceID dev = SDL_OpenAudioDevice(nullptr, 0, &spec, &spec_actual, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
 	MxInitialize(spec_actual.freq);
 	SDL_PauseAudioDevice(dev, 0);
-	return nullptr;
+	return std::nullopt;
 }
 
 void SoundDriver_SDL::Stop()

--- a/src/sound/sdl_s.cpp
+++ b/src/sound/sdl_s.cpp
@@ -30,7 +30,7 @@ static void CDECL fill_sound_buffer(void *, Uint8 *stream, int len)
 	MxMixSamples(stream, len / 4);
 }
 
-const char *SoundDriver_SDL::Start(const StringList &parm)
+std::optional<std::string_view> SoundDriver_SDL::Start(const StringList &parm)
 {
 	SDL_AudioSpec spec;
 
@@ -51,7 +51,7 @@ const char *SoundDriver_SDL::Start(const StringList &parm)
 	MxInitialize(spec.freq);
 	SDL_OpenAudio(&spec, &spec);
 	SDL_PauseAudio(0);
-	return nullptr;
+	return std::nullopt;
 }
 
 void SoundDriver_SDL::Stop()

--- a/src/sound/sdl_s.h
+++ b/src/sound/sdl_s.h
@@ -15,10 +15,10 @@
 /** Implementation of the SDL sound driver. */
 class SoundDriver_SDL : public SoundDriver {
 public:
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
-	const char *GetName() const override { return "sdl"; }
+	std::string_view GetName() const override { return "sdl"; }
 };
 
 /** Factory for the SDL sound driver. */

--- a/src/sound/win32_s.cpp
+++ b/src/sound/win32_s.cpp
@@ -59,7 +59,7 @@ static DWORD WINAPI SoundThread(LPVOID)
 	return 0;
 }
 
-const char *SoundDriver_Win32::Start(const StringList &parm)
+std::optional<std::string_view> SoundDriver_Win32::Start(const StringList &parm)
 {
 	WAVEFORMATEX wfex;
 	wfex.wFormatTag = WAVE_FORMAT_PCM;
@@ -89,7 +89,7 @@ const char *SoundDriver_Win32::Start(const StringList &parm)
 		return error;
 	}
 
-	return nullptr;
+	return std::nullopt;
 }
 
 void SoundDriver_Win32::Stop()

--- a/src/sound/win32_s.h
+++ b/src/sound/win32_s.h
@@ -15,10 +15,10 @@
 /** Implementation of the sound driver for Windows. */
 class SoundDriver_Win32 : public SoundDriver {
 public:
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
-	const char *GetName() const override { return "win32"; }
+	std::string_view GetName() const override { return "win32"; }
 };
 
 /** Factory for the sound driver for Windows. */

--- a/src/sound/xaudio2_s.cpp
+++ b/src/sound/xaudio2_s.cpp
@@ -135,10 +135,10 @@ static HRESULT CreateXAudio(API_XAudio2Create xAudio2Create)
  * Initialises the XAudio2 driver.
  *
  * @param parm Driver parameters.
- * @return An error message if unsuccessful, or nullptr otherwise.
+ * @return An error message if unsuccessful, or std::nullopt otherwise.
  *
  */
-const char *SoundDriver_XAudio2::Start(const StringList &parm)
+std::optional<std::string_view> SoundDriver_XAudio2::Start(const StringList &parm)
 {
 	HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
 
@@ -257,7 +257,7 @@ const char *SoundDriver_XAudio2::Start(const StringList &parm)
 		return "Failed to submit the first audio buffer";
 	}
 
-	return nullptr;
+	return std::nullopt;
 }
 
 /**

--- a/src/sound/xaudio2_s.h
+++ b/src/sound/xaudio2_s.h
@@ -15,10 +15,10 @@
 /** Implementation of the XAudio2 sound driver. */
 class SoundDriver_XAudio2 : public SoundDriver {
 public:
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
-	const char *GetName() const override { return "xaudio2"; }
+	std::string_view GetName() const override { return "xaudio2"; }
 };
 
 /** Factory for the XAudio2 sound driver. */

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -420,7 +420,7 @@ bool VideoDriver_Allegro::PollEvent()
  */
 int _allegro_instance_count = 0;
 
-const char *VideoDriver_Allegro::Start(const StringList &param)
+std::optional<std::string_view> VideoDriver_Allegro::Start(const StringList &param)
 {
 	if (_allegro_instance_count == 0 && install_allegro(SYSTEM_AUTODETECT, &errno, nullptr)) {
 		Debug(driver, 0, "allegro: install_allegro failed '{}'", allegro_error);
@@ -450,7 +450,7 @@ const char *VideoDriver_Allegro::Start(const StringList &param)
 
 	this->is_game_threaded = !GetDriverParamBool(param, "no_threads") && !GetDriverParamBool(param, "no_thread");
 
-	return nullptr;
+	return std::nullopt;
 }
 
 void VideoDriver_Allegro::Stop()

--- a/src/video/allegro_v.h
+++ b/src/video/allegro_v.h
@@ -15,7 +15,7 @@
 /** The allegro video driver. */
 class VideoDriver_Allegro : public VideoDriver {
 public:
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
 
@@ -33,7 +33,7 @@ public:
 
 	std::vector<int> GetListOfMonitorRefreshRates() override;
 
-	const char *GetName() const override { return "allegro"; }
+	std::string_view GetName() const override { return "allegro"; }
 
 protected:
 	void InputLoop() override;

--- a/src/video/cocoa/cocoa_ogl.h
+++ b/src/video/cocoa/cocoa_ogl.h
@@ -20,12 +20,12 @@ class VideoDriver_CocoaOpenGL : public VideoDriver_Cocoa {
 	uint8_t *anim_buffer; ///< Animation buffer from OpenGL back-end.
 	std::string driver_info; ///< Information string about selected driver.
 
-	const char *AllocateContext(bool allow_software);
+	std::optional<std::string_view> AllocateContext(bool allow_software);
 
 public:
 	VideoDriver_CocoaOpenGL() : VideoDriver_Cocoa(true), gl_context(nullptr), anim_buffer(nullptr), driver_info(this->GetName()) {}
 
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 	void Stop() override;
 
 	bool HasEfficient8Bpp() const override { return true; }
@@ -40,9 +40,9 @@ public:
 	uint8_t *GetAnimBuffer() override { return this->anim_buffer; }
 
 	/** Return driver name */
-	const char *GetName() const override { return "cocoa-opengl"; }
+	std::string_view GetName() const override { return "cocoa-opengl"; }
 
-	const char *GetInfoString() const override { return this->driver_info.c_str(); }
+	std::string_view GetInfoString() const override { return this->driver_info; }
 
 	void AllocateBackingStore(bool force = false) override;
 

--- a/src/video/cocoa/cocoa_ogl.mm
+++ b/src/video/cocoa/cocoa_ogl.mm
@@ -185,10 +185,10 @@ static bool _allowSoftware;
 static FVideoDriver_CocoaOpenGL iFVideoDriver_CocoaOpenGL;
 
 
-const char *VideoDriver_CocoaOpenGL::Start(const StringList &param)
+std::optional<std::string_view> VideoDriver_CocoaOpenGL::Start(const StringList &param)
 {
-	const char *err = this->Initialize();
-	if (err != nullptr) return err;
+	auto err = this->Initialize();
+	if (err) return err;
 
 	int bpp = BlitterFactory::GetCurrentBlitter()->GetScreenDepth();
 	if (bpp != 8 && bpp != 32) {
@@ -198,7 +198,7 @@ const char *VideoDriver_CocoaOpenGL::Start(const StringList &param)
 
 	/* Try to allocate GL context. */
 	err = this->AllocateContext(GetDriverParamBool(param, "software"));
-	if (err != nullptr) {
+	if (err) {
 		this->Stop();
 		return err;
 	}
@@ -224,7 +224,7 @@ const char *VideoDriver_CocoaOpenGL::Start(const StringList &param)
 
 	this->is_game_threaded = !GetDriverParamBool(param, "no_threads") && !GetDriverParamBool(param, "no_thread");
 
-	return nullptr;
+	return std::nullopt;
 
 }
 
@@ -252,7 +252,7 @@ void VideoDriver_CocoaOpenGL::ClearSystemSprites()
 	OpenGLBackend::Get()->ClearCursorCache();
 }
 
-const char *VideoDriver_CocoaOpenGL::AllocateContext(bool allow_software)
+std::optional<std::string_view> VideoDriver_CocoaOpenGL::AllocateContext(bool allow_software)
 {
 	[ OTTD_CGLLayer setAllowSoftware:allow_software ];
 

--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -72,7 +72,7 @@ protected:
 
 	void GameSizeChanged();
 
-	const char *Initialize();
+	std::optional<std::string_view> Initialize();
 
 	void UpdateVideoModes();
 
@@ -109,11 +109,11 @@ public:
 
 	VideoDriver_CocoaQuartz();
 
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 	void Stop() override;
 
 	/** Return driver name */
-	const char *GetName() const override { return "cocoa"; }
+	std::string_view GetName() const override { return "cocoa"; }
 
 	void AllocateBackingStore(bool force = false) override;
 

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -122,7 +122,7 @@ void VideoDriver_Cocoa::Stop()
 }
 
 /** Common driver initialization. */
-const char *VideoDriver_Cocoa::Initialize()
+std::optional<std::string_view> VideoDriver_Cocoa::Initialize()
 {
 	if (!MacOSVersionIsAtLeast(10, 7, 0)) return "The Cocoa video driver requires Mac OS X 10.7 or later.";
 
@@ -130,12 +130,12 @@ const char *VideoDriver_Cocoa::Initialize()
 	_cocoa_video_started = true;
 
 	/* Don't create a window or enter fullscreen if we're just going to show a dialog. */
-	if (!CocoaSetupApplication()) return nullptr;
+	if (!CocoaSetupApplication()) return std::nullopt;
 
 	this->UpdateAutoResolution();
 	this->orig_res = _cur_resolution;
 
-	return nullptr;
+	return std::nullopt;
 }
 
 /**
@@ -589,10 +589,10 @@ VideoDriver_CocoaQuartz::VideoDriver_CocoaQuartz()
 	this->cgcontext     = nullptr;
 }
 
-const char *VideoDriver_CocoaQuartz::Start(const StringList &param)
+std::optional<std::string_view> VideoDriver_CocoaQuartz::Start(const StringList &param)
 {
-	const char *err = this->Initialize();
-	if (err != nullptr) return err;
+	auto err = this->Initialize();
+	if (err) return err;
 
 	int bpp = BlitterFactory::GetCurrentBlitter()->GetScreenDepth();
 	if (bpp != 8 && bpp != 32) {
@@ -615,7 +615,7 @@ const char *VideoDriver_CocoaQuartz::Start(const StringList &param)
 
 	this->is_game_threaded = !GetDriverParamBool(param, "no_threads") && !GetDriverParamBool(param, "no_thread");
 
-	return nullptr;
+	return std::nullopt;
 
 }
 

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -103,7 +103,7 @@ extern bool SafeLoad(const std::string &filename, SaveLoadOperation fop, Detaile
 static FVideoDriver_Dedicated iFVideoDriver_Dedicated;
 
 
-const char *VideoDriver_Dedicated::Start(const StringList &)
+std::optional<std::string_view> VideoDriver_Dedicated::Start(const StringList &)
 {
 	this->UpdateAutoResolution();
 
@@ -131,7 +131,7 @@ const char *VideoDriver_Dedicated::Start(const StringList &)
 #endif
 
 	Debug(driver, 1, "Loading dedicated server");
-	return nullptr;
+	return std::nullopt;
 }
 
 void VideoDriver_Dedicated::Stop()

--- a/src/video/dedicated_v.h
+++ b/src/video/dedicated_v.h
@@ -15,7 +15,7 @@
 /** The dedicated server video driver. */
 class VideoDriver_Dedicated : public VideoDriver {
 public:
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
 
@@ -26,7 +26,7 @@ public:
 	bool ChangeResolution(int w, int h) override;
 
 	bool ToggleFullscreen(bool fullscreen) override;
-	const char *GetName() const override { return "dedicated"; }
+	std::string_view GetName() const override { return "dedicated"; }
 	bool HasGUI() const override { return false; }
 };
 

--- a/src/video/null_v.cpp
+++ b/src/video/null_v.cpp
@@ -19,7 +19,7 @@
 /** Factory for the null video driver. */
 static FVideoDriver_Null iFVideoDriver_Null;
 
-const char *VideoDriver_Null::Start(const StringList &parm)
+std::optional<std::string_view> VideoDriver_Null::Start(const StringList &parm)
 {
 #ifdef _MSC_VER
 	/* Disable the MSVC assertion message box. */
@@ -39,7 +39,7 @@ const char *VideoDriver_Null::Start(const StringList &parm)
 	/* Do not render, nor blit */
 	Debug(misc, 1, "Forcing blitter 'null'...");
 	BlitterFactory::SelectBlitter("null");
-	return nullptr;
+	return std::nullopt;
 }
 
 void VideoDriver_Null::Stop() { }

--- a/src/video/null_v.h
+++ b/src/video/null_v.h
@@ -18,7 +18,7 @@ private:
 	uint ticks; ///< Amount of ticks to run.
 
 public:
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
 
@@ -29,7 +29,7 @@ public:
 	bool ChangeResolution(int w, int h) override;
 
 	bool ToggleFullscreen(bool fullscreen) override;
-	const char *GetName() const override { return "null"; }
+	std::string_view GetName() const override { return "null"; }
 	bool HasGUI() const override { return false; }
 };
 

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -462,9 +462,9 @@ void SetupDebugOutput()
  * Create and initialize the singleton back-end class.
  * @param get_proc Callback to get an OpenGL function from the OS driver.
  * @param screen_res Current display resolution.
- * @return nullptr on success, error message otherwise.
+ * @return std::nullopt on success, error message otherwise.
  */
-/* static */ const char *OpenGLBackend::Create(GetOGLProcAddressProc get_proc, const Dimension &screen_res)
+/* static */ std::optional<std::string_view> OpenGLBackend::Create(GetOGLProcAddressProc get_proc, const Dimension &screen_res)
 {
 	if (OpenGLBackend::instance != nullptr) OpenGLBackend::Destroy();
 
@@ -520,9 +520,9 @@ OpenGLBackend::~OpenGLBackend()
 /**
  * Check for the needed OpenGL functionality and allocate all resources.
  * @param screen_res Current display resolution.
- * @return Error string or nullptr if successful.
+ * @return Error string or std::nullopt if successful.
  */
-const char *OpenGLBackend::Init(const Dimension &screen_res)
+std::optional<std::string_view> OpenGLBackend::Init(const Dimension &screen_res)
 {
 	if (!BindBasicInfoProcs()) return "OpenGL not supported";
 
@@ -729,7 +729,7 @@ const char *OpenGLBackend::Init(const Dimension &screen_res)
 	this->PrepareContext();
 	(void)_glGetError(); // Clear errors.
 
-	return nullptr;
+	return std::nullopt;
 }
 
 void OpenGLBackend::PrepareContext()

--- a/src/video/opengl.h
+++ b/src/video/opengl.h
@@ -72,7 +72,7 @@ private:
 	OpenGLBackend();
 	~OpenGLBackend();
 
-	const char *Init(const Dimension &screen_res);
+	std::optional<std::string_view> Init(const Dimension &screen_res);
 	bool InitShaders();
 
 	void InternalClearCursorCache();
@@ -85,7 +85,7 @@ public:
 	{
 		return OpenGLBackend::instance;
 	}
-	static const char *Create(GetOGLProcAddressProc get_proc, const Dimension &screen_res);
+	static std::optional<std::string_view> Create(GetOGLProcAddressProc get_proc, const Dimension &screen_res);
 	static void Destroy();
 
 	void PrepareContext();

--- a/src/video/sdl2_default_v.h
+++ b/src/video/sdl2_default_v.h
@@ -15,7 +15,7 @@
 /** The SDL video driver using default SDL backend. */
 class VideoDriver_SDL_Default : public VideoDriver_SDL_Base {
 public:
-	const char *GetName() const override { return "sdl"; }
+	std::string_view GetName() const override { return "sdl"; }
 
 protected:
 	bool AllocateBackingStore(int w, int h, bool force = false) override;

--- a/src/video/sdl2_opengl_v.cpp
+++ b/src/video/sdl2_opengl_v.cpp
@@ -53,13 +53,13 @@ bool VideoDriver_SDL_OpenGL::CreateMainWindow(uint w, uint h, uint flags)
 	return this->VideoDriver_SDL_Base::CreateMainWindow(w, h, flags | SDL_WINDOW_OPENGL);
 }
 
-const char *VideoDriver_SDL_OpenGL::Start(const StringList &param)
+std::optional<std::string_view> VideoDriver_SDL_OpenGL::Start(const StringList &param)
 {
-	const char *error = VideoDriver_SDL_Base::Start(param);
-	if (error != nullptr) return error;
+	auto error = VideoDriver_SDL_Base::Start(param);
+	if (error) return error;
 
 	error = this->AllocateContext();
-	if (error != nullptr) {
+	if (error) {
 		this->Stop();
 		return error;
 	}
@@ -81,7 +81,7 @@ const char *VideoDriver_SDL_OpenGL::Start(const StringList &param)
 	/* Main loop expects to start with the buffer unmapped. */
 	this->ReleaseVideoPointer();
 
-	return nullptr;
+	return std::nullopt;
 }
 
 void VideoDriver_SDL_OpenGL::Stop()
@@ -105,7 +105,7 @@ void VideoDriver_SDL_OpenGL::ToggleVsync(bool vsync)
 	SDL_GL_SetSwapInterval(vsync);
 }
 
-const char *VideoDriver_SDL_OpenGL::AllocateContext()
+std::optional<std::string_view> VideoDriver_SDL_OpenGL::AllocateContext()
 {
 	SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
 	SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);

--- a/src/video/sdl2_opengl_v.h
+++ b/src/video/sdl2_opengl_v.h
@@ -14,7 +14,7 @@ class VideoDriver_SDL_OpenGL : public VideoDriver_SDL_Base {
 public:
 	VideoDriver_SDL_OpenGL() : VideoDriver_SDL_Base(true), gl_context(nullptr), anim_buffer(nullptr) {}
 
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
 
@@ -31,7 +31,7 @@ public:
 
 	void ToggleVsync(bool vsync) override;
 
-	const char *GetName() const override { return "sdl-opengl"; }
+	std::string_view GetName() const override { return "sdl-opengl"; }
 
 protected:
 	bool AllocateBackingStore(int w, int h, bool force = false) override;
@@ -44,7 +44,7 @@ private:
 	void  *gl_context;  ///< OpenGL context.
 	uint8_t *anim_buffer; ///< Animation buffer from OpenGL back-end.
 
-	const char *AllocateContext();
+	std::optional<std::string_view> AllocateContext();
 	void DestroyContext();
 };
 

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -503,34 +503,34 @@ bool VideoDriver_SDL_Base::PollEvent()
 	return true;
 }
 
-static const char *InitializeSDL()
+static std::optional<std::string_view> InitializeSDL()
 {
 	/* Check if the video-driver is already initialized. */
-	if (SDL_WasInit(SDL_INIT_VIDEO) != 0) return nullptr;
+	if (SDL_WasInit(SDL_INIT_VIDEO) != 0) return std::nullopt;
 
 	if (SDL_InitSubSystem(SDL_INIT_VIDEO) < 0) return SDL_GetError();
-	return nullptr;
+	return std::nullopt;
 }
 
-const char *VideoDriver_SDL_Base::Initialize()
+std::optional<std::string_view> VideoDriver_SDL_Base::Initialize()
 {
 	this->UpdateAutoResolution();
 
-	const char *error = InitializeSDL();
-	if (error != nullptr) return error;
+	auto error = InitializeSDL();
+	if (error) return error;
 
 	FindResolutions();
 	Debug(driver, 2, "Resolution for display: {}x{}", _cur_resolution.width, _cur_resolution.height);
 
-	return nullptr;
+	return std::nullopt;
 }
 
-const char *VideoDriver_SDL_Base::Start(const StringList &param)
+std::optional<std::string_view> VideoDriver_SDL_Base::Start(const StringList &param)
 {
 	if (BlitterFactory::GetCurrentBlitter()->GetScreenDepth() == 0) return "Only real blitters supported";
 
-	const char *error = this->Initialize();
-	if (error != nullptr) return error;
+	auto error = this->Initialize();
+	if (error) return error;
 
 #ifdef SDL_HINT_MOUSE_AUTO_CAPTURE
 	if (GetDriverParamBool(param, "no_mouse_capture")) {
@@ -566,7 +566,7 @@ const char *VideoDriver_SDL_Base::Start(const StringList &param)
 	this->is_game_threaded = !GetDriverParamBool(param, "no_threads") && !GetDriverParamBool(param, "no_thread");
 #endif
 
-	return nullptr;
+	return std::nullopt;
 }
 
 void VideoDriver_SDL_Base::Stop()

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -19,7 +19,7 @@ class VideoDriver_SDL_Base : public VideoDriver {
 public:
 	VideoDriver_SDL_Base(bool uses_hardware_acceleration = false) : VideoDriver(uses_hardware_acceleration), sdl_window(nullptr), buffer_locked(false) {}
 
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
 
@@ -41,7 +41,7 @@ public:
 
 	std::vector<int> GetListOfMonitorRefreshRates() override;
 
-	const char *GetInfoString() const override { return this->driver_info.c_str(); }
+	std::string_view GetInfoString() const override { return this->driver_info; }
 
 protected:
 	struct SDL_Window *sdl_window; ///< Main SDL window.
@@ -73,7 +73,7 @@ private:
 	void LoopOnce();
 	void MainLoopCleanup();
 	bool CreateMainSurface(uint w, uint h, bool resize);
-	const char *Initialize();
+	std::optional<std::string_view> Initialize();
 
 #ifdef __EMSCRIPTEN__
 	/* Convert a constant pointer back to a non-constant pointer to a member function. */

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -576,7 +576,7 @@ bool VideoDriver_SDL::PollEvent()
 	return true;
 }
 
-const char *VideoDriver_SDL::Start(const StringList &param)
+std::optional<std::string_view> VideoDriver_SDL::Start(const StringList &param)
 {
 	char buf[30];
 	_use_hwpalette = GetDriverParamInt(param, "hw_palette", 2);
@@ -607,7 +607,7 @@ const char *VideoDriver_SDL::Start(const StringList &param)
 
 	this->is_game_threaded = !GetDriverParamBool(param, "no_threads") && !GetDriverParamBool(param, "no_thread");
 
-	return nullptr;
+	return std::nullopt;
 }
 
 void VideoDriver_SDL::SetupKeyboard()

--- a/src/video/sdl_v.h
+++ b/src/video/sdl_v.h
@@ -15,7 +15,7 @@
 /** The SDL video driver. */
 class VideoDriver_SDL : public VideoDriver {
 public:
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
 
@@ -31,7 +31,7 @@ public:
 
 	bool ClaimMousePointer() override;
 
-	const char *GetName() const override { return "sdl"; }
+	std::string_view GetName() const override { return "sdl"; }
 
 protected:
 	void InputLoop() override;

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -174,7 +174,7 @@ public:
 		return Clamp(dpi_scale * 100, MIN_INTERFACE_SCALE, MAX_INTERFACE_SCALE);
 	}
 
-	virtual const char *GetInfoString() const
+	virtual std::string_view GetInfoString() const
 	{
 		return this->GetName();
 	}

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1030,7 +1030,7 @@ void VideoDriver_Win32Base::UnlockVideoBuffer()
 
 static FVideoDriver_Win32GDI iFVideoDriver_Win32GDI;
 
-const char *VideoDriver_Win32GDI::Start(const StringList &param)
+std::optional<std::string_view> VideoDriver_Win32GDI::Start(const StringList &param)
 {
 	if (BlitterFactory::GetCurrentBlitter()->GetScreenDepth() == 0) return "Only real blitters supported";
 
@@ -1044,7 +1044,7 @@ const char *VideoDriver_Win32GDI::Start(const StringList &param)
 
 	this->is_game_threaded = !GetDriverParamBool(param, "no_threads") && !GetDriverParamBool(param, "no_thread");
 
-	return nullptr;
+	return std::nullopt;
 }
 
 void VideoDriver_Win32GDI::Stop()
@@ -1237,9 +1237,9 @@ static OGLProc GetOGLProcAddressCallback(const char *proc)
 /**
  * Set the pixel format of a window-
  * @param dc Device context to set the pixel format of.
- * @return nullptr on success, error message otherwise.
+ * @return std::nullopt on success, error message otherwise.
  */
-static const char *SelectPixelFormat(HDC dc)
+static std::optional<std::string_view> SelectPixelFormat(HDC dc)
 {
 	PIXELFORMATDESCRIPTOR pfd = {
 		sizeof(PIXELFORMATDESCRIPTOR), // Size of this struct.
@@ -1265,7 +1265,7 @@ static const char *SelectPixelFormat(HDC dc)
 	if (format == 0) return "No suitable pixel format found";
 	if (!SetPixelFormat(dc, format, &pfd)) return "Can't set pixel format";
 
-	return nullptr;
+	return std::nullopt;
 }
 
 /** Bind all WGL extension functions we need. */
@@ -1280,7 +1280,7 @@ static void LoadWGLExtensions()
 	HDC dc = GetDC(wnd);
 
 	/* Set pixel format of the window. */
-	if (SelectPixelFormat(dc) == nullptr) {
+	if (SelectPixelFormat(dc) == std::nullopt) {
 		/* Create rendering context. */
 		HGLRC rc = wglCreateContext(dc);
 		if (rc != nullptr) {
@@ -1320,7 +1320,7 @@ static void LoadWGLExtensions()
 
 static FVideoDriver_Win32OpenGL iFVideoDriver_Win32OpenGL;
 
-const char *VideoDriver_Win32OpenGL::Start(const StringList &param)
+std::optional<std::string_view> VideoDriver_Win32OpenGL::Start(const StringList &param)
 {
 	if (BlitterFactory::GetCurrentBlitter()->GetScreenDepth() == 0) return "Only real blitters supported";
 
@@ -1332,8 +1332,8 @@ const char *VideoDriver_Win32OpenGL::Start(const StringList &param)
 	this->MakeWindow(_fullscreen);
 
 	/* Create and initialize OpenGL context. */
-	const char *err = this->AllocateContext();
-	if (err != nullptr) {
+	auto err = this->AllocateContext();
+	if (err) {
 		this->Stop();
 		_cur_resolution = old_res;
 		return err;
@@ -1358,7 +1358,7 @@ const char *VideoDriver_Win32OpenGL::Start(const StringList &param)
 
 	this->is_game_threaded = !GetDriverParamBool(param, "no_threads") && !GetDriverParamBool(param, "no_thread");
 
-	return nullptr;
+	return std::nullopt;
 }
 
 void VideoDriver_Win32OpenGL::Stop()
@@ -1391,12 +1391,12 @@ void VideoDriver_Win32OpenGL::ToggleVsync(bool vsync)
 	}
 }
 
-const char *VideoDriver_Win32OpenGL::AllocateContext()
+std::optional<std::string_view> VideoDriver_Win32OpenGL::AllocateContext()
 {
 	this->dc = GetDC(this->main_wnd);
 
-	const char *err = SelectPixelFormat(this->dc);
-	if (err != nullptr) return err;
+	auto err = SelectPixelFormat(this->dc);
+	if (err) return err;
 
 	HGLRC rc = nullptr;
 
@@ -1438,7 +1438,7 @@ bool VideoDriver_Win32OpenGL::ToggleFullscreen(bool full_screen)
 	if (_screen.dst_ptr != nullptr) this->ReleaseVideoPointer();
 	this->DestroyContext();
 	bool res = this->VideoDriver_Win32Base::ToggleFullscreen(full_screen);
-	res &= this->AllocateContext() == nullptr;
+	res &= this->AllocateContext() == std::nullopt;
 	this->ClientSizeChanged(this->width, this->height, true);
 	return res;
 }

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -79,13 +79,13 @@ class VideoDriver_Win32GDI : public VideoDriver_Win32Base {
 public:
 	VideoDriver_Win32GDI() : dib_sect(nullptr), gdi_palette(nullptr), buffer_bits(nullptr) {}
 
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
 
 	bool AfterBlitterChange() override;
 
-	const char *GetName() const override { return "win32"; }
+	std::string_view GetName() const override { return "win32"; }
 
 protected:
 	HBITMAP  dib_sect;      ///< System bitmap object referencing our rendering buffer.
@@ -120,7 +120,7 @@ class VideoDriver_Win32OpenGL : public VideoDriver_Win32Base {
 public:
 	VideoDriver_Win32OpenGL() : VideoDriver_Win32Base(true), dc(nullptr), gl_rc(nullptr), anim_buffer(nullptr), driver_info(this->GetName()) {}
 
-	const char *Start(const StringList &param) override;
+	std::optional<std::string_view> Start(const StringList &param) override;
 
 	void Stop() override;
 
@@ -141,9 +141,9 @@ public:
 
 	void ToggleVsync(bool vsync) override;
 
-	const char *GetName() const override { return "win32-opengl"; }
+	std::string_view GetName() const override { return "win32-opengl"; }
 
-	const char *GetInfoString() const override { return this->driver_info.c_str(); }
+	std::string_view GetInfoString() const override { return this->driver_info; }
 
 protected:
 	HDC    dc;          ///< Window device context.
@@ -160,7 +160,7 @@ protected:
 	void ReleaseVideoPointer() override;
 	void PaletteChanged(HWND) override {}
 
-	const char *AllocateContext();
+	std::optional<std::string_view> AllocateContext();
 	void DestroyContext();
 };
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Driver/blitter functions return C-style `const char *`.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Return more modern `std::string_vew` instead. Gets rid of 12% of `const char *`s.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

`std::string_view` can't be `nullptr`, but can be `empty()`.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
