### PR TITLE
Codefix: [CMake] use the UTC0 date for our ISODATE

### DIFF
--- a/cmake/scripts/FindVersion.cmake
+++ b/cmake/scripts/FindVersion.cmake
@@ -49,7 +49,8 @@ if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
     string(SUBSTRING "${FULLHASH}" 0 10 SHORTHASH)
 
     # Get the last commit date
-    execute_process(COMMAND ${GIT_EXECUTABLE} show -s --pretty=format:%ci HEAD
+    set(ENV{TZ} "UTC0")
+    execute_process(COMMAND ${GIT_EXECUTABLE} show -s --date=iso-local --pretty=format:%cd HEAD
                     OUTPUT_VARIABLE COMMITDATE
                     OUTPUT_STRIP_TRAILING_WHITESPACE
                     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When doing benchmarks on OpenTTD, I asked git: give me the last commit of 2023-12-31, and it told me: sure, that is f56a2d0f82b8e9b93754d1b. But after building OpenTTD it told me it was based on a commit in 2024-01-01.

This confused me, and this PR addresses that issue.

## Description

Turns out, we use the TZ of the commit, instead of UTC, when determining the date we show in our `_openttd_revision`. This is because git is very unclear in what it does when/what/where when it comes to timezones.

But with this fix, we force the TZ to be UTC, and to output the date in our local timezone, as an ISO date. This is what we assumed `%ci` would do, but clearly doesn't.

## Limitations

In theory this could mean we served a nightly build on date X, but has an internal reference of being on date X-1 or X+1. But given most of us work in EU times, this is not all that likely. But in theory it was possible!

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
