### PR TITLE
Codechange: GetOpt refactor

### DIFF
--- a/src/misc/getoptdata.cpp
+++ b/src/misc/getoptdata.cpp
@@ -21,15 +21,14 @@
  */
 int GetOptData::GetOpt()
 {
-	char *s = this->cont;
+	const char *s = this->cont;
 	if (s == nullptr) {
-		if (this->numleft == 0) return -1; // No arguments left -> finished.
+		if (this->arguments.empty()) return -1; // No arguments left -> finished.
 
-		s = this->argv[0];
+		s = this->arguments[0];
 		if (*s != '-') return -1; // No leading '-' -> not an option -> finished.
 
-		this->argv++;
-		this->numleft--;
+		this->arguments = this->arguments.subspan(1);
 
 		/* Is it a long option? */
 		for (auto &option : this->options) {
@@ -68,14 +67,13 @@ int GetOptData::GetOpt(const OptionData &option)
 				return option.id;
 			}
 			/* No more arguments, either return an error or a value-less option. */
-			if (this->numleft == 0) return (option.type == ODF_HAS_VALUE) ? -2 : option.id;
+			if (this->arguments.empty()) return (option.type == ODF_HAS_VALUE) ? -2 : option.id;
 
 			/* Next argument looks like another option, let's not return it as option value. */
-			if (option.type == ODF_OPTIONAL_VALUE && this->argv[0][0] == '-') return option.id;
+			if (option.type == ODF_OPTIONAL_VALUE && this->arguments[0][0] == '-') return option.id;
 
-			this->opt = this->argv[0]; // Next argument is the option value.
-			this->argv++;
-			this->numleft--;
+			this->opt = this->arguments[0]; // Next argument is the option value.
+			this->arguments = this->arguments.subspan(1);
 			return option.id;
 
 		default: NOT_REACHED();

--- a/src/misc/getoptdata.cpp
+++ b/src/misc/getoptdata.cpp
@@ -21,7 +21,7 @@
  */
 int GetOptData::GetOpt()
 {
-	const OptionData *odata;
+	OptionSpan::iterator odata;
 
 	char *s = this->cont;
 	if (s == nullptr) {
@@ -34,7 +34,7 @@ int GetOptData::GetOpt()
 		this->numleft--;
 
 		/* Is it a long option? */
-		for (odata = this->options; odata->flags != ODF_END; odata++) {
+		for (odata = std::begin(this->options); odata != std::end(this->options); odata++) {
 			if (odata->longname != nullptr && !strcmp(odata->longname, s)) { // Long options always use the entire argument.
 				this->cont = nullptr;
 				goto set_optval;
@@ -45,13 +45,13 @@ int GetOptData::GetOpt()
 	}
 
 	/* Is it a short option? */
-	for (odata = this->options; odata->flags != ODF_END; odata++) {
+	for (odata = std::begin(this->options); odata != std::end(this->options); odata++) {
 		if (odata->shortname != '\0' && *s == odata->shortname) {
 			this->cont = (s[1] != '\0') ? s + 1 : nullptr;
 
 set_optval: // Handle option value of *odata .
 			this->opt = nullptr;
-			switch (odata->flags) {
+			switch (odata->type) {
 				case ODF_NO_VALUE:
 					return odata->id;
 
@@ -63,10 +63,10 @@ set_optval: // Handle option value of *odata .
 						return odata->id;
 					}
 					/* No more arguments, either return an error or a value-less option. */
-					if (this->numleft == 0) return (odata->flags == ODF_HAS_VALUE) ? -2 : odata->id;
+					if (this->numleft == 0) return (odata->type == ODF_HAS_VALUE) ? -2 : odata->id;
 
 					/* Next argument looks like another option, let's not return it as option value. */
-					if (odata->flags == ODF_OPTIONAL_VALUE && this->argv[0][0] == '-') return odata->id;
+					if (odata->type == ODF_OPTIONAL_VALUE && this->argv[0][0] == '-') return odata->id;
 
 					this->opt = this->argv[0]; // Next argument is the option value.
 					this->argv++;

--- a/src/misc/getoptdata.cpp
+++ b/src/misc/getoptdata.cpp
@@ -21,8 +21,6 @@
  */
 int GetOptData::GetOpt()
 {
-	OptionSpan::iterator odata;
-
 	char *s = this->cont;
 	if (s == nullptr) {
 		if (this->numleft == 0) return -1; // No arguments left -> finished.
@@ -34,10 +32,10 @@ int GetOptData::GetOpt()
 		this->numleft--;
 
 		/* Is it a long option? */
-		for (odata = std::begin(this->options); odata != std::end(this->options); odata++) {
-			if (odata->longname != nullptr && !strcmp(odata->longname, s)) { // Long options always use the entire argument.
+		for (auto &option : this->options) {
+			if (option.longname != nullptr && !strcmp(option.longname, s)) { // Long options always use the entire argument.
 				this->cont = nullptr;
-				goto set_optval;
+				return this->GetOpt(option);
 			}
 		}
 
@@ -45,39 +43,42 @@ int GetOptData::GetOpt()
 	}
 
 	/* Is it a short option? */
-	for (odata = std::begin(this->options); odata != std::end(this->options); odata++) {
-		if (odata->shortname != '\0' && *s == odata->shortname) {
+	for (auto &option : this->options) {
+		if (option.shortname != '\0' && *s == option.shortname) {
 			this->cont = (s[1] != '\0') ? s + 1 : nullptr;
-
-set_optval: // Handle option value of *odata .
-			this->opt = nullptr;
-			switch (odata->type) {
-				case ODF_NO_VALUE:
-					return odata->id;
-
-				case ODF_HAS_VALUE:
-				case ODF_OPTIONAL_VALUE:
-					if (this->cont != nullptr) { // Remainder of the argument is the option value.
-						this->opt = this->cont;
-						this->cont = nullptr;
-						return odata->id;
-					}
-					/* No more arguments, either return an error or a value-less option. */
-					if (this->numleft == 0) return (odata->type == ODF_HAS_VALUE) ? -2 : odata->id;
-
-					/* Next argument looks like another option, let's not return it as option value. */
-					if (odata->type == ODF_OPTIONAL_VALUE && this->argv[0][0] == '-') return odata->id;
-
-					this->opt = this->argv[0]; // Next argument is the option value.
-					this->argv++;
-					this->numleft--;
-					return odata->id;
-
-				default: NOT_REACHED();
-			}
+			return this->GetOpt(option);
 		}
 	}
 
 	return -2; // No other ways to interpret the text -> error.
+}
+
+int GetOptData::GetOpt(const OptionData &option)
+{
+	this->opt = nullptr;
+	switch (option.type) {
+		case ODF_NO_VALUE:
+			return option.id;
+
+		case ODF_HAS_VALUE:
+		case ODF_OPTIONAL_VALUE:
+			if (this->cont != nullptr) { // Remainder of the argument is the option value.
+				this->opt = this->cont;
+				this->cont = nullptr;
+				return option.id;
+			}
+			/* No more arguments, either return an error or a value-less option. */
+			if (this->numleft == 0) return (option.type == ODF_HAS_VALUE) ? -2 : option.id;
+
+			/* Next argument looks like another option, let's not return it as option value. */
+			if (option.type == ODF_OPTIONAL_VALUE && this->argv[0][0] == '-') return option.id;
+
+			this->opt = this->argv[0]; // Next argument is the option value.
+			this->argv++;
+			this->numleft--;
+			return option.id;
+
+		default: NOT_REACHED();
+	}
 }
 

--- a/src/misc/getoptdata.h
+++ b/src/misc/getoptdata.h
@@ -50,6 +50,7 @@ struct GetOptData {
 	}
 
 	int GetOpt();
+	int GetOpt(const OptionData &option);
 };
 
 #endif /* GETOPTDATA_H */

--- a/src/misc/getoptdata.h
+++ b/src/misc/getoptdata.h
@@ -11,27 +11,27 @@
 #define GETOPTDATA_H
 
 /** Flags of an option. */
-enum OptionDataFlags {
+enum OptionDataType : uint8_t {
 	ODF_NO_VALUE,       ///< A plain option (no value attached to it).
 	ODF_HAS_VALUE,      ///< An option with a value.
 	ODF_OPTIONAL_VALUE, ///< An option with an optional value.
-	ODF_END,            ///< Terminator (data is not parsed further).
 };
 
 /** Data of an option. */
 struct OptionData {
-	uint8_t id;              ///< Unique identification of this option data, often the same as #shortname.
-	char shortname;       ///< Short option letter if available, else use \c '\0'.
-	uint16_t flags;         ///< Option data flags. @see OptionDataFlags
-	const char *longname; ///< Long option name including '-'/'--' prefix, use \c nullptr if not available.
+	OptionDataType type; ///< The type of option.
+	char id; ///< Unique identification of this option data, often the same as #shortname.
+	char shortname = '\0'; ///< Short option letter if available, else use \c '\0'.
+	const char *longname = nullptr; ///< Long option name including '-'/'--' prefix, use \c nullptr if not available.
 };
 
 /** Data storage for parsing command line options. */
 struct GetOptData {
+	using OptionSpan = std::span<const OptionData>;
 	char *opt;                 ///< Option value, if available (else \c nullptr).
 	int numleft;               ///< Number of arguments left in #argv.
 	char **argv;               ///< Remaining command line arguments.
-	const OptionData *options; ///< Command line option descriptions.
+	OptionSpan options; ///< Command line option descriptions.
 	char *cont;                ///< Next call to #GetOpt should start here (in the middle of an argument).
 
 	/**
@@ -40,7 +40,7 @@ struct GetOptData {
 	 * @param argv Command line arguments, excluding the program name.
 	 * @param options Command line option descriptions.
 	 */
-	GetOptData(int argc, char **argv, const OptionData *options) :
+	GetOptData(int argc, char **argv, OptionSpan options) :
 			opt(nullptr),
 			numleft(argc),
 			argv(argv),
@@ -51,60 +51,5 @@ struct GetOptData {
 
 	int GetOpt();
 };
-
-/**
- * General macro for creating an option.
- * @param id        Identification of the option.
- * @param shortname Short option name. Use \c '\0' if not used.
- * @param longname  Long option name including leading '-' or '--'. Use \c nullptr if not used.
- * @param flags     Flags of the option.
- */
-#define GETOPT_GENERAL(id, shortname, longname, flags) { id, shortname, flags, longname }
-
-/**
- * Short option without value.
- * @param shortname Short option name. Use \c '\0' if not used.
- * @param longname  Long option name including leading '-' or '--'. Use \c nullptr if not used.
- */
-#define GETOPT_NOVAL(shortname, longname) GETOPT_GENERAL(shortname, shortname, longname, ODF_NO_VALUE)
-
-/**
- * Short option with value.
- * @param shortname Short option name. Use \c '\0' if not used.
- * @param longname  Long option name including leading '-' or '--'. Use \c nullptr if not used.
- */
-#define GETOPT_VALUE(shortname, longname) GETOPT_GENERAL(shortname, shortname, longname, ODF_HAS_VALUE)
-
-/**
- * Short option with optional value.
- * @param shortname Short option name. Use \c '\0' if not used.
- * @param longname  Long option name including leading '-' or '--'. Use \c nullptr if not used.
- * @note Options with optional values are hopelessly ambiguous, eg "-opt -value", avoid them.
- */
-#define GETOPT_OPTVAL(shortname, longname) GETOPT_GENERAL(shortname, shortname, longname, ODF_OPTIONAL_VALUE)
-
-
-/**
- * Short option without value.
- * @param shortname Short option name. Use \c '\0' if not used.
- */
-#define GETOPT_SHORT_NOVAL(shortname) GETOPT_NOVAL(shortname, nullptr)
-
-/**
- * Short option with value.
- * @param shortname Short option name. Use \c '\0' if not used.
- */
-#define GETOPT_SHORT_VALUE(shortname) GETOPT_VALUE(shortname, nullptr)
-
-/**
- * Short option with optional value.
- * @param shortname Short option name. Use \c '\0' if not used.
- * @note Options with optional values are hopelessly ambiguous, eg "-opt -value", avoid them.
- */
-#define GETOPT_SHORT_OPTVAL(shortname) GETOPT_OPTVAL(shortname, nullptr)
-
-/** Option terminator. */
-#define GETOPT_END() { '\0', '\0', ODF_END, nullptr}
-
 
 #endif /* GETOPTDATA_H */

--- a/src/misc/getoptdata.h
+++ b/src/misc/getoptdata.h
@@ -28,26 +28,19 @@ struct OptionData {
 /** Data storage for parsing command line options. */
 struct GetOptData {
 	using OptionSpan = std::span<const OptionData>;
-	char *opt;                 ///< Option value, if available (else \c nullptr).
-	int numleft;               ///< Number of arguments left in #argv.
-	char **argv;               ///< Remaining command line arguments.
-	OptionSpan options; ///< Command line option descriptions.
-	char *cont;                ///< Next call to #GetOpt should start here (in the middle of an argument).
+	using ArgumentSpan = std::span<char * const>;
+
+	ArgumentSpan arguments; ///< Remaining command line arguments.
+	const OptionSpan options; ///< Command line option descriptions.
+	const char *opt = nullptr; ///< Option value, if available (else \c nullptr).
+	const char *cont = nullptr; ///< Next call to #GetOpt should start here (in the middle of an argument).
 
 	/**
 	 * Constructor of the data store.
-	 * @param argc Number of command line arguments, excluding the program name.
-	 * @param argv Command line arguments, excluding the program name.
+	 * @param argument The command line arguments, excluding the program name.
 	 * @param options Command line option descriptions.
 	 */
-	GetOptData(int argc, char **argv, OptionSpan options) :
-			opt(nullptr),
-			numleft(argc),
-			argv(argv),
-			options(options),
-			cont(nullptr)
-	{
-	}
+	GetOptData(ArgumentSpan arguments, OptionSpan options) : arguments(arguments), options(options) {}
 
 	int GetOpt();
 	int GetOpt(const OptionData &option);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -478,36 +478,27 @@ void PostMainLoop()
 extern void DedicatedFork();
 #endif
 
-/** Options of OpenTTD. */
-static const OptionData _options[] = {
-	 GETOPT_SHORT_VALUE('I'),
-	 GETOPT_SHORT_VALUE('S'),
-	 GETOPT_SHORT_VALUE('M'),
-	 GETOPT_SHORT_VALUE('m'),
-	 GETOPT_SHORT_VALUE('s'),
-	 GETOPT_SHORT_VALUE('v'),
-	 GETOPT_SHORT_VALUE('b'),
-	GETOPT_SHORT_OPTVAL('D'),
-	 GETOPT_SHORT_VALUE('n'),
-	 GETOPT_SHORT_VALUE('p'),
-	 GETOPT_SHORT_VALUE('P'),
+/**
+ * Create all the options that OpenTTD supports. Each option is
+ * always a single character with no, an optional or a required value.
+ * @return The available options.
+ */
+static std::vector<OptionData> CreateOptions()
+{
+	std::vector<OptionData> options;
+	/* Options that require a parameter. */
+	for (char c : "GIMPSbcmnpqrstv") options.push_back({ .type = ODF_HAS_VALUE, .id = c, .shortname = c });
 #if !defined(_WIN32)
-	 GETOPT_SHORT_NOVAL('f'),
+	options.push_back({ .type = ODF_HAS_VALUE, .id = 'f', .shortname = 'f' });
 #endif
-	 GETOPT_SHORT_VALUE('r'),
-	 GETOPT_SHORT_VALUE('t'),
-	GETOPT_SHORT_OPTVAL('d'),
-	 GETOPT_SHORT_NOVAL('e'),
-	GETOPT_SHORT_OPTVAL('g'),
-	 GETOPT_SHORT_VALUE('G'),
-	 GETOPT_SHORT_VALUE('c'),
-	 GETOPT_SHORT_NOVAL('x'),
-	 GETOPT_SHORT_NOVAL('X'),
-	 GETOPT_SHORT_VALUE('q'),
-	 GETOPT_SHORT_NOVAL('h'),
-	 GETOPT_SHORT_NOVAL('Q'),
-	GETOPT_END()
-};
+
+	/* Options with an optional parameter. */
+	for (char c : "Ddg") options.push_back({ .type = ODF_OPTIONAL_VALUE, .id = c, .shortname = c });
+
+	/* Options without a parameter. */
+	for (char c : "QXehx") options.push_back({ .type = ODF_NO_VALUE, .id = c, .shortname = c });
+	return options;
+}
 
 /**
  * Main entry point for this lovely game.
@@ -538,7 +529,8 @@ int openttd_main(int argc, char *argv[])
 	_game_mode = GM_MENU;
 	_switch_mode = SM_MENU;
 
-	GetOptData mgo(argc - 1, argv + 1, _options);
+	auto options = CreateOptions();
+	GetOptData mgo(argc - 1, argv + 1, options);
 	int ret = 0;
 
 	int i;

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -530,7 +530,7 @@ int openttd_main(int argc, char *argv[])
 	_switch_mode = SM_MENU;
 
 	auto options = CreateOptions();
-	GetOptData mgo(argc - 1, argv + 1, options);
+	GetOptData mgo(std::span(argv + 1, argc - 1), options);
 	int ret = 0;
 
 	int i;
@@ -654,7 +654,7 @@ int openttd_main(int argc, char *argv[])
 		if (i == -2) break;
 	}
 
-	if (i == -2 || mgo.numleft > 0) {
+	if (i == -2 || !mgo.arguments.empty()) {
 		/* Either the user typed '-h', they made an error, or they added unrecognized command line arguments.
 		 * In all cases, print the help, and exit.
 		 *

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -385,12 +385,11 @@ static bool CompareFiles(const char *n1, const char *n2)
 
 /** Options of settingsgen. */
 static const OptionData _opts[] = {
-	  GETOPT_NOVAL(     'h', "--help"),
-	GETOPT_GENERAL('h', '?', nullptr, ODF_NO_VALUE),
-	  GETOPT_VALUE(     'o', "--output"),
-	  GETOPT_VALUE(     'b', "--before"),
-	  GETOPT_VALUE(     'a', "--after"),
-	GETOPT_END(),
+	{ .type = ODF_NO_VALUE, .id = 'h', .shortname = 'h', .longname = "--help" },
+	{ .type = ODF_NO_VALUE, .id = 'h', .shortname = '?' },
+	{ .type = ODF_HAS_VALUE, .id = 'o', .shortname = 'o', .longname = "--output" },
+	{ .type = ODF_HAS_VALUE, .id = 'b', .shortname = 'b', .longname = "--before" },
+	{ .type = ODF_HAS_VALUE, .id = 'a', .shortname = 'a', .longname = "--after" },
 };
 
 /**

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -435,7 +435,7 @@ int CDECL main(int argc, char *argv[])
 	const char *before_file = nullptr;
 	const char *after_file = nullptr;
 
-	GetOptData mgo(argc - 1, argv + 1, _opts);
+	GetOptData mgo(std::span(argv + 1, argc - 1), _opts);
 	for (;;) {
 		int i = mgo.GetOpt();
 		if (i == -1) break;
@@ -472,7 +472,7 @@ int CDECL main(int argc, char *argv[])
 	_stored_output.Clear();
 	_post_amble_output.Clear();
 
-	for (int i = 0; i < mgo.numleft; i++) ProcessIniFile(mgo.argv[i]);
+	for (auto &argument : mgo.arguments) ProcessIniFile(argument);
 
 	/* Write output. */
 	if (output_file == nullptr) {

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -328,7 +328,7 @@ int CDECL main(int argc, char *argv[])
 	std::filesystem::path src_dir(".");
 	std::filesystem::path dest_dir;
 
-	GetOptData mgo(argc - 1, argv + 1, _opts);
+	GetOptData mgo(std::span(argv + 1, argc - 1), _opts);
 	for (;;) {
 		int i = mgo.GetOpt();
 		if (i == -1) break;
@@ -412,7 +412,7 @@ int CDECL main(int argc, char *argv[])
 		 * strgen generates strings.h to the destination directory. If it is supplied
 		 * with a (free) parameter the program will translate that language to destination
 		 * directory. As input english.txt is parsed from the source directory */
-		if (mgo.numleft == 0) {
+		if (mgo.arguments.empty()) {
 			std::filesystem::path input_path = src_dir;
 			input_path /= "english.txt";
 
@@ -431,7 +431,7 @@ int CDECL main(int argc, char *argv[])
 			writer.WriteHeader(data);
 			writer.Finalise(data);
 			if (_errors != 0) return 1;
-		} else if (mgo.numleft >= 1) {
+		} else {
 			std::filesystem::path input_path = src_dir;
 			input_path /= "english.txt";
 
@@ -440,10 +440,10 @@ int CDECL main(int argc, char *argv[])
 			FileStringReader master_reader(data, input_path, true, false);
 			master_reader.ParseFile();
 
-			for (int i = 0; i < mgo.numleft; i++) {
+			for (auto &argument: mgo.arguments) {
 				data.FreeTranslation();
 
-				std::filesystem::path lang_file = mgo.argv[i];
+				std::filesystem::path lang_file = argument;
 				FileStringReader translation_reader(data, lang_file, false, lang_file.filename() != "english.txt");
 				translation_reader.ParseFile(); // target file
 				if (_errors != 0) return 1;

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -312,16 +312,15 @@ struct LanguageFileWriter : LanguageWriter, FileWriter {
 
 /** Options of strgen. */
 static const OptionData _opts[] = {
-	GETOPT_GENERAL('C', '\0', "-export-commands", ODF_NO_VALUE),
-	GETOPT_GENERAL('L', '\0', "-export-plurals",  ODF_NO_VALUE),
-	GETOPT_GENERAL('P', '\0', "-export-pragmas",  ODF_NO_VALUE),
-	  GETOPT_NOVAL(     't',  "--todo"),
-	  GETOPT_NOVAL(     'w',  "--warning"),
-	  GETOPT_NOVAL(     'h',  "--help"),
-	GETOPT_GENERAL('h', '?',  nullptr,            ODF_NO_VALUE),
-	  GETOPT_VALUE(     's',  "--source_dir"),
-	  GETOPT_VALUE(     'd',  "--dest_dir"),
-	GETOPT_END(),
+	{ .type = ODF_NO_VALUE, .id = 'C', .longname = "-export-commands" },
+	{ .type = ODF_NO_VALUE, .id = 'L', .longname = "-export-plurals" },
+	{ .type = ODF_NO_VALUE, .id = 'P', .longname = "-export-pragmas" },
+	{ .type = ODF_NO_VALUE, .id = 't', .shortname = 't', .longname = "--todo" },
+	{ .type = ODF_NO_VALUE, .id = 'w', .shortname = 'w', .longname = "--warning" },
+	{ .type = ODF_NO_VALUE, .id = 'h', .shortname = 'h', .longname = "--help" },
+	{ .type = ODF_NO_VALUE, .id = 'h', .shortname = '?' },
+	{ .type = ODF_HAS_VALUE, .id = 's', .shortname = 's', .longname = "--source_dir" },
+	{ .type = ODF_HAS_VALUE, .id = 'd', .shortname = 'd', .longname = "--dest_dir" },
 };
 
 int CDECL main(int argc, char *argv[])


### PR DESCRIPTION
## Motivation / Problem

`GetOpt` is the bit of code that handles the option parsing from the command line.
This uses all kinds of C-style constructs, like pointers plus lengths. When we want to use it in a more C++ environment, this quickly becomes troublesome.


## Description

Use designated initializers instead of a load of macros to construct the option data. For OpenTTD itself even fill a vector as writing down complete tables with massive amounts of copied data is not useful; there are three variants of parameters that all have just a short name.

Use a span instead of an array with an end-of-table sentinel for the option data, and use ranged for loops to iterate them.
Use a span instead of an array and count for the (remaining) arguments.
Replace a `goto` with a call to a function.


## Limitations

From the OSX/Unix/Windows mains we should actually be sending a span. However, to make proper use of that for Windows quite a few changes are required, making this PR bigger. So that improvement will be another PR.

There might be bits that are considered C-like, such as using `char*` instead of `std::string` or `std::string_view`. I do not think those changes make the code more readable, especially as we'd need to construct vectors of strings/views from the command line arguments before continuing. It can definitely be done, but for the sake of the reviewer I left that to another PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
