### PR TITLE
Fix #12477: Use std::filesystem::rename instead of Windows API call.

### DIFF
--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -22,11 +22,7 @@
 # include <fcntl.h>
 #endif
 
-#ifdef _WIN32
-# include <windows.h>
-# include <shellapi.h>
-# include "core/mem_func.hpp"
-#endif
+#include <filesystem>
 
 #include "safeguards.h"
 
@@ -91,30 +87,11 @@ bool IniFile::SaveToDisk(const std::string &filename)
 	if (ret != 0) return false;
 #endif
 
-#if defined(_WIN32)
-	/* Allocate space for one more \0 character. */
-	wchar_t tfilename[MAX_PATH + 1], tfile_new[MAX_PATH + 1];
-	wcsncpy(tfilename, OTTD2FS(filename).c_str(), MAX_PATH);
-	wcsncpy(tfile_new, OTTD2FS(file_new).c_str(), MAX_PATH);
-	/* SHFileOperation wants a double '\0' terminated string. */
-	tfilename[MAX_PATH - 1] = '\0';
-	tfile_new[MAX_PATH - 1] = '\0';
-	tfilename[wcslen(tfilename) + 1] = '\0';
-	tfile_new[wcslen(tfile_new) + 1] = '\0';
-
-	/* Rename file without any user confirmation. */
-	SHFILEOPSTRUCT shfopt;
-	MemSetT(&shfopt, 0);
-	shfopt.wFunc  = FO_MOVE;
-	shfopt.fFlags = FOF_NOCONFIRMATION | FOF_NOCONFIRMMKDIR | FOF_NOERRORUI | FOF_SILENT;
-	shfopt.pFrom  = tfile_new;
-	shfopt.pTo    = tfilename;
-	SHFileOperation(&shfopt);
-#else
-	if (rename(file_new.c_str(), filename.c_str()) < 0) {
-		Debug(misc, 0, "Renaming {} to {} failed; configuration not saved", file_new, filename);
+	std::error_code ec;
+	std::filesystem::rename(OTTD2FS(file_new), OTTD2FS(filename), ec);
+	if (ec) {
+		Debug(misc, 0, "Renaming {} to {} failed; configuration not saved: {}", file_new, filename, ec.message());
 	}
-#endif
 
 #ifdef __EMSCRIPTEN__
 	EM_ASM(if (window["openttd_syncfs"]) openttd_syncfs());


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

On Windows we issue a Shell File Operation to rename the ini file on save, as the old `rename()` function does not allow overwriting existing functions. This can cause Shell-type things to happen, and our WndProc can be called again when we do not expect it.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

It is now 2024, and `std::filesystem::rename()` exists, which seems to specify how renaming to an existing filename should behave.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Works on Linux, completely untested on Windows. Not sure how `std::filesystem::rename()` handles Unicode filenames.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
