### PR TITLE
Codechange: pass command line arguments as std::span to openttd_main

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -502,11 +502,10 @@ static std::vector<OptionData> CreateOptions()
 
 /**
  * Main entry point for this lovely game.
- * @param argc The number of arguments passed to this game.
- * @param argv The values of the arguments.
+ * @param arguments The command line arguments passed to the application.
  * @return 0 when there is no error.
  */
-int openttd_main(int argc, char *argv[])
+int openttd_main(std::span<char * const> arguments)
 {
 	_game_session_stats.start_time = std::chrono::steady_clock::now();
 	_game_session_stats.savegame_size = std::nullopt;
@@ -530,7 +529,7 @@ int openttd_main(int argc, char *argv[])
 	_switch_mode = SM_MENU;
 
 	auto options = CreateOptions();
-	GetOptData mgo(std::span(argv + 1, argc - 1), options);
+	GetOptData mgo(arguments.subspan(1), options);
 	int ret = 0;
 
 	int i;
@@ -614,7 +613,7 @@ int openttd_main(int argc, char *argv[])
 			}
 			break;
 		case 'q': {
-			DeterminePaths(argv[0], only_local_path);
+			DeterminePaths(arguments[0], only_local_path);
 			if (StrEmpty(mgo.opt)) {
 				ret = 1;
 				return ret;
@@ -660,7 +659,7 @@ int openttd_main(int argc, char *argv[])
 		 *
 		 * The next two functions are needed to list the graphics sets. We can't do them earlier
 		 * because then we cannot show it on the debug console as that hasn't been configured yet. */
-		DeterminePaths(argv[0], only_local_path);
+		DeterminePaths(arguments[0], only_local_path);
 		TarScanner::DoScan(TarScanner::BASESET);
 		BaseGraphics::FindSets();
 		BaseSounds::FindSets();
@@ -669,7 +668,7 @@ int openttd_main(int argc, char *argv[])
 		return ret;
 	}
 
-	DeterminePaths(argv[0], only_local_path);
+	DeterminePaths(arguments[0], only_local_path);
 	TarScanner::DoScan(TarScanner::BASESET);
 
 	if (dedicated) Debug(net, 3, "Starting dedicated server, version {}", _openttd_revision);

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -87,7 +87,7 @@ extern PauseMode _pause_mode;
 void AskExitGame();
 void AskExitToGameMenu();
 
-int openttd_main(int argc, char *argv[]);
+int openttd_main(std::span<char * const> arguments);
 void StateGameLoop();
 void HandleExitGameRequest();
 

--- a/src/os/macosx/osx_main.cpp
+++ b/src/os/macosx/osx_main.cpp
@@ -41,7 +41,7 @@ int CDECL main(int argc, char *argv[])
 
 	signal(SIGPIPE, SIG_IGN);
 
-	int ret = openttd_main(argc, argv);
+	int ret = openttd_main(std::span(argv, argc));
 
 	CocoaReleaseAutoreleasePool();
 

--- a/src/os/unix/unix_main.cpp
+++ b/src/os/unix/unix_main.cpp
@@ -29,5 +29,5 @@ int CDECL main(int argc, char *argv[])
 
 	signal(SIGPIPE, SIG_IGN);
 
-	return openttd_main(argc, argv);
+	return openttd_main(std::span(argv, argc));
 }

--- a/src/os/windows/win32_main.cpp
+++ b/src/os/windows/win32_main.cpp
@@ -18,11 +18,10 @@
 
 #include "../../safeguards.h"
 
-static int ParseCommandLine(char *line, char **argv, int max_argc)
+static auto ParseCommandLine(char *line)
 {
-	int n = 0;
-
-	do {
+	std::vector<char *> arguments;
+	for (;;) {
 		/* skip whitespace */
 		while (*line == ' ' || *line == '\t') line++;
 
@@ -31,22 +30,22 @@ static int ParseCommandLine(char *line, char **argv, int max_argc)
 
 		/* special handling when quoted */
 		if (*line == '"') {
-			argv[n++] = ++line;
+			arguments.push_back(++line);
 			while (*line != '"') {
-				if (*line == '\0') return n;
+				if (*line == '\0') return arguments;
 				line++;
 			}
 		} else {
-			argv[n++] = line;
+			arguments.push_back(line);
 			while (*line != ' ' && *line != '\t') {
-				if (*line == '\0') return n;
+				if (*line == '\0') return arguments;
 				line++;
 			}
 		}
 		*line++ = '\0';
-	} while (n != max_argc);
+	};
 
-	return n;
+	return arguments;
 }
 
 void CreateConsole();
@@ -73,13 +72,12 @@ int APIENTRY WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
 	/* setup random seed to something quite random */
 	SetRandomSeed(GetTickCount());
 
-	char *argv[64]; // max 64 command line arguments
-	int argc = ParseCommandLine(cmdline.data(), argv, lengthof(argv));
+	auto arguments = ParseCommandLine(cmdline.data());
 
 	/* Make sure our arguments contain only valid UTF-8 characters. */
-	for (int i = 0; i < argc; i++) StrMakeValidInPlace(argv[i]);
+	for (auto argument : arguments) StrMakeValidInPlace(argument);
 
-	int ret = openttd_main(argc, argv);
+	int ret = openttd_main(arguments);
 
 	/* Restore system timer resolution. */
 	timeEndPeriod(1);


### PR DESCRIPTION
## Motivation / Problem

Why pass a C-style span when it can be an actual span?
Why create a limited `char*[]` when that can just be a vector?


## Description

Use `std::span` for `openttd_main`.
In the Windows specific code, the `argc/argv` were extracted from a single string. Make this be extracted into a vector of `char*`, which can easily be passed as span.


## Limitations

Not using `std::string` or `std::string_view` as those do not play nice with the current further uses. Now it is a span, changing the span to be a `std::string` or `std::string_view` will become easier, but that's out of scope for this PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
