### PR TITLE
Codechange: use std::array instead of C-style array for produced/accepts cargo

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1788,7 +1788,7 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 	i->type = type;
 	Industry::IncIndustryTypeCount(type);
 
-	for (size_t index = 0; index < lengthof(indspec->produced_cargo); ++index) {
+	for (size_t index = 0; index < std::size(indspec->produced_cargo); ++index) {
 		if (!IsValidCargoID(indspec->produced_cargo[index])) break;
 
 		Industry::ProducedCargo &p = i->produced.emplace_back();
@@ -1796,7 +1796,7 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 		p.rate = indspec->production_rate[index];
 	}
 
-	for (size_t index = 0; index < lengthof(indspec->accepts_cargo); ++index) {
+	for (size_t index = 0; index < std::size(indspec->accepts_cargo); ++index) {
 		if (!IsValidCargoID(indspec->accepts_cargo[index])) break;
 
 		Industry::AcceptedCargo &a = i->accepted.emplace_back();

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -155,7 +155,7 @@ enum CargoSuffixInOut {
 template <typename TC, typename TS>
 static inline void GetAllCargoSuffixes(CargoSuffixInOut use_input, CargoSuffixType cst, const Industry *ind, IndustryType ind_type, const IndustrySpec *indspec, const TC &cargoes, TS &suffixes)
 {
-	static_assert(lengthof(cargoes) <= lengthof(suffixes));
+	static_assert(std::tuple_size_v<std::remove_reference_t<decltype(cargoes)>> <= lengthof(suffixes));
 
 	if (indspec->behaviour & INDUSTRYBEH_CARGOTYPES_UNLIMITED) {
 		/* Reworked behaviour with new many-in-many-out scheme */
@@ -450,7 +450,7 @@ public:
 				Dimension d = {0, 0};
 				for (const auto &indtype : this->list) {
 					const IndustrySpec *indsp = GetIndustrySpec(indtype);
-					CargoSuffix cargo_suffix[lengthof(indsp->accepts_cargo)];
+					CargoSuffix cargo_suffix[std::tuple_size_v<decltype(indsp->accepts_cargo)>];
 
 					/* Measure the accepted cargoes, if any. */
 					GetAllCargoSuffixes(CARGOSUFFIX_IN, CST_FUND, nullptr, indtype, indsp, indsp->accepts_cargo, cargo_suffix);
@@ -566,7 +566,7 @@ public:
 					ir.top += GetCharacterHeight(FS_NORMAL);
 				}
 
-				CargoSuffix cargo_suffix[lengthof(indsp->accepts_cargo)];
+				CargoSuffix cargo_suffix[std::tuple_size_v<decltype(indsp->accepts_cargo)>];
 
 				/* Draw the accepted cargoes, if any. Otherwise, will print "Nothing". */
 				GetAllCargoSuffixes(CARGOSUFFIX_IN, CST_FUND, nullptr, this->selected_type, indsp, indsp->accepts_cargo, cargo_suffix);
@@ -2420,7 +2420,7 @@ struct CargoesRow {
 			int other_count = 0;
 
 			const IndustrySpec *indsp = GetIndustrySpec(ind_fld->u.industry.ind_type);
-			assert(CargoesField::max_cargoes <= lengthof(indsp->produced_cargo));
+			assert(CargoesField::max_cargoes <= std::size(indsp->produced_cargo));
 			for (uint i = 0; i < CargoesField::max_cargoes; i++) {
 				int col = cargo_fld->ConnectCargo(indsp->produced_cargo[i], true);
 				if (col < 0) others[other_count++] = indsp->produced_cargo[i];
@@ -2479,7 +2479,7 @@ struct CargoesRow {
 			int other_count = 0;
 
 			const IndustrySpec *indsp = GetIndustrySpec(ind_fld->u.industry.ind_type);
-			assert(CargoesField::max_cargoes <= lengthof(indsp->accepts_cargo));
+			assert(CargoesField::max_cargoes <= std::size(indsp->accepts_cargo));
 			for (uint i = 0; i < CargoesField::max_cargoes; i++) {
 				int col = cargo_fld->ConnectCargo(indsp->accepts_cargo[i], false);
 				if (col < 0) others[other_count++] = indsp->accepts_cargo[i];

--- a/src/industrytype.h
+++ b/src/industrytype.h
@@ -109,7 +109,7 @@ struct IndustrySpec {
 	uint32_t prospecting_chance;                  ///< Chance prospecting succeeds
 	IndustryType conflicting[3];                ///< Industries this industry cannot be close to
 	uint8_t check_proc;                            ///< Index to a procedure to check for conflicting circumstances
-	CargoID produced_cargo[INDUSTRY_NUM_OUTPUTS];
+	std::array<CargoID, INDUSTRY_NUM_OUTPUTS> produced_cargo;
 	std::variant<CargoLabel, MixedCargoType> produced_cargo_label[INDUSTRY_NUM_OUTPUTS];
 	uint8_t production_rate[INDUSTRY_NUM_OUTPUTS];
 	/**
@@ -117,7 +117,7 @@ struct IndustrySpec {
 	 * If the waiting cargo is less than this number, no cargo is moved to it.
 	 */
 	uint8_t minimal_cargo;
-	CargoID accepts_cargo[INDUSTRY_NUM_INPUTS]; ///< 16 accepted cargoes.
+	std::array<CargoID, INDUSTRY_NUM_INPUTS> accepts_cargo; ///< 16 accepted cargoes.
 	std::variant<CargoLabel, MixedCargoType> accepts_cargo_label[INDUSTRY_NUM_INPUTS];
 	uint16_t input_cargo_multiplier[INDUSTRY_NUM_INPUTS][INDUSTRY_NUM_OUTPUTS]; ///< Input cargo multipliers (multiply amount of incoming cargo for the produced cargoes)
 	IndustryLifeType life_type;                 ///< This is also known as Industry production flag, in newgrf specs

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -3787,12 +3787,12 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 
 			case 0x25: { // variable length produced cargoes
 				uint8_t num_cargoes = buf->ReadByte();
-				if (num_cargoes > lengthof(indsp->produced_cargo)) {
+				if (num_cargoes > std::size(indsp->produced_cargo)) {
 					GRFError *error = DisableGrf(STR_NEWGRF_ERROR_LIST_PROPERTY_TOO_LONG);
 					error->param_value[1] = prop;
 					return CIR_DISABLED;
 				}
-				for (uint i = 0; i < lengthof(indsp->produced_cargo); i++) {
+				for (size_t i = 0; i < std::size(indsp->produced_cargo); i++) {
 					if (i < num_cargoes) {
 						CargoID cargo = GetCargoTranslation(buf->ReadByte(), _cur.grffile);
 						indsp->produced_cargo[i] = cargo;
@@ -3806,12 +3806,12 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 
 			case 0x26: { // variable length accepted cargoes
 				uint8_t num_cargoes = buf->ReadByte();
-				if (num_cargoes > lengthof(indsp->accepts_cargo)) {
+				if (num_cargoes > std::size(indsp->accepts_cargo)) {
 					GRFError *error = DisableGrf(STR_NEWGRF_ERROR_LIST_PROPERTY_TOO_LONG);
 					error->param_value[1] = prop;
 					return CIR_DISABLED;
 				}
-				for (uint i = 0; i < lengthof(indsp->accepts_cargo); i++) {
+				for (size_t i = 0; i < std::size(indsp->accepts_cargo); i++) {
 					if (i < num_cargoes) {
 						CargoID cargo = GetCargoTranslation(buf->ReadByte(), _cur.grffile);
 						indsp->accepts_cargo[i] = cargo;
@@ -3843,13 +3843,13 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 			case 0x28: { // variable size input/output production multiplier table
 				uint8_t num_inputs = buf->ReadByte();
 				uint8_t num_outputs = buf->ReadByte();
-				if (num_inputs > lengthof(indsp->accepts_cargo) || num_outputs > lengthof(indsp->produced_cargo)) {
+				if (num_inputs > std::size(indsp->accepts_cargo) || num_outputs > std::size(indsp->produced_cargo)) {
 					GRFError *error = DisableGrf(STR_NEWGRF_ERROR_LIST_PROPERTY_TOO_LONG);
 					error->param_value[1] = prop;
 					return CIR_DISABLED;
 				}
-				for (uint i = 0; i < lengthof(indsp->accepts_cargo); i++) {
-					for (uint j = 0; j < lengthof(indsp->produced_cargo); j++) {
+				for (size_t i = 0; i < std::size(indsp->accepts_cargo); i++) {
+					for (size_t j = 0; j < std::size(indsp->produced_cargo); j++) {
 						uint16_t mult = 0;
 						if (i < num_inputs && j < num_outputs) mult = buf->ReadWord();
 						indsp->input_cargo_multiplier[i][j] = mult;
@@ -9489,10 +9489,10 @@ static void FinaliseIndustriesArray()
 		}
 
 		/* Apply default cargo translation map for unset cargo slots */
-		for (uint i = 0; i < lengthof(indsp.produced_cargo); ++i) {
+		for (size_t i = 0; i < std::size(indsp.produced_cargo); ++i) {
 			if (!IsValidCargoID(indsp.produced_cargo[i])) indsp.produced_cargo[i] = GetCargoIDByLabel(GetActiveCargoLabel(indsp.produced_cargo_label[i]));
 		}
-		for (uint i = 0; i < lengthof(indsp.accepts_cargo); ++i) {
+		for (size_t i = 0; i < std::size(indsp.accepts_cargo); ++i) {
 			if (!IsValidCargoID(indsp.accepts_cargo[i])) indsp.accepts_cargo[i] = GetCargoIDByLabel(GetActiveCargoLabel(indsp.accepts_cargo_label[i]));
 		}
 	}


### PR DESCRIPTION
## Motivation / Problem

I'd like to get rid of `lengthof`, but in the industry code there is a function to get suffices which (rightfully) uses `static_assert` on some array sizes. The bad thing is that `std::size` is not constant enough for these `static_assert`s to remain functioning, but with a `std::array` that's still possible.


## Description

Replace the C-style arrays with `std::array`.
Replace some `lengthof` with `std::tuple_size`, where compile time constantly sized arrays must be constructed.
Replace some `lengthof` with `std::size` where that's required.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
