### PR TITLE
Codechange: settingsgen's CopyFile actually appends.

### DIFF
--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -322,11 +322,11 @@ static void DumpSections(const IniLoadFile &ifile)
 }
 
 /**
- * Copy a file to the output.
- * @param fname Filename of file to copy.
+ * Append a file to the output stream.
+ * @param fname Filename of file to append.
  * @param out_fp Output stream to write to.
  */
-static void CopyFile(const char *fname, FILE *out_fp)
+static void AppendFile(const char *fname, FILE *out_fp)
 {
 	if (fname == nullptr) return;
 
@@ -476,10 +476,10 @@ int CDECL main(int argc, char *argv[])
 
 	/* Write output. */
 	if (output_file == nullptr) {
-		CopyFile(before_file, stdout);
+		AppendFile(before_file, stdout);
 		_stored_output.Write(stdout);
 		_post_amble_output.Write(stdout);
-		CopyFile(after_file, stdout);
+		AppendFile(after_file, stdout);
 	} else {
 		static const char * const tmp_output = "tmp2.xxx";
 
@@ -487,10 +487,10 @@ int CDECL main(int argc, char *argv[])
 		if (fp == nullptr) {
 			FatalError("Cannot open file {}", tmp_output);
 		}
-		CopyFile(before_file, fp);
+		AppendFile(before_file, fp);
 		_stored_output.Write(fp);
 		_post_amble_output.Write(fp);
-		CopyFile(after_file, fp);
+		AppendFile(after_file, fp);
 		fclose(fp);
 
 		if (CompareFiles(tmp_output, output_file)) {


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

settingsgen has a function call CopyFile. I started wondering if this could just be a called to `std::filesystem::copy_file`, however it actually isn't what it says it is...

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

The function actually appends the content of the provided filename to an existing output file handle.

Rename the function to `AppendFile` to make this a bit clearer.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
