### PR TITLE
Doc: Updated Visual Studio, cpp standard and Cmake version

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -29,7 +29,7 @@ open most older savegames or use the content downloading system.
 
 ## Windows
 
-You need Microsoft Visual Studio 2017 or more recent.
+You need Microsoft Visual Studio 2022 or more recent.
 
 You can download the free Visual Studio Community Edition from Microsoft at
 https://visualstudio.microsoft.com/vs/community/.
@@ -65,7 +65,7 @@ To install both the x64 (64bit) and x86 (32bit) variants (though only one is nec
 
 You can open the folder (as a CMake project). CMake will be detected, and you can compile from there.
 If libraries are installed but not found, you need to set VCPKG_TARGET_TRIPLET in CMake parameters.
-For Visual Studio 2017 you also need to set CMAKE_TOOLCHAIN_FILE.
+For Visual Studio 2022 you also need to set CMAKE_TOOLCHAIN_FILE.
 (Typical values are shown in the MSVC project file command line example)
 
 Alternatively, you can create a MSVC project file via CMake. For this
@@ -75,7 +75,7 @@ that comes with vcpkg. After that, you can run something similar to this:
 ```powershell
 mkdir build
 cd build
-cmake.exe .. -G"Visual Studio 16 2019" -DCMAKE_TOOLCHAIN_FILE="<location of vcpkg>\vcpkg\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET="x64-windows-static"
+cmake.exe .. -G"Visual Studio 17 2022" -DCMAKE_TOOLCHAIN_FILE="<location of vcpkg>\vcpkg\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET="x64-windows-static"
 ```
 
 Change `<location of vcpkg>` to where you have installed vcpkg. After this
@@ -83,7 +83,7 @@ in the build folder are MSVC project files. MSVC can rebuild the project
 files himself via the `ZERO_CHECK` project.
 
 ## All other platforms
-Minimum required version of CMake is 3.9.
+Minimum required version of CMake is 3.16.
 By default this produces a Debug build with assertations enabled.
 This is a far slower build than release builds.
 
@@ -115,9 +115,9 @@ builds.
 
 ## Supported compilers
 
-Every compiler that is supported by CMake and supports C++17, should be
+Every compiler that is supported by CMake and supports C++20, should be
 able to compile OpenTTD. As the exact list of compilers changes constantly,
-we refer to the compiler manual to see if it supports C++17, and to CMake
+we refer to the compiler manual to see if it supports C++20, and to CMake
 to see if it supports your compiler.
 
 ## Compilation of base sets


### PR DESCRIPTION
## Motivation / Problem

We recently dropped MSVC 2019 support and started compiling with C++20.

## Description

Updated the versions in compiling.md. The CMake version was also wrong, changed that as well.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
