### PR TITLE
Codefix: missing space between close parenthesis and open curly brace

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1260,7 +1260,7 @@ struct BuildVehicleWindow : Window {
 
 		/* Select the first unshaded engine in the list as default when opening the window */
 		EngineID engine = INVALID_ENGINE;
-		auto it = std::find_if(this->eng_list.begin(), this->eng_list.end(), [&](GUIEngineListItem &item){ return (item.flags & EngineDisplayFlags::Shaded) == EngineDisplayFlags::None; });
+		auto it = std::find_if(this->eng_list.begin(), this->eng_list.end(), [&](GUIEngineListItem &item) { return (item.flags & EngineDisplayFlags::Shaded) == EngineDisplayFlags::None; });
 		if (it != this->eng_list.end()) engine = it->engine_id;
 		this->SelectEngine(engine);
 	}

--- a/src/newgrf_townname.cpp
+++ b/src/newgrf_townname.cpp
@@ -27,7 +27,7 @@ static std::vector<StringID> _grf_townname_names;
 
 GRFTownName *GetGRFTownName(uint32_t grfid)
 {
-	auto found = std::find_if(std::begin(_grf_townnames), std::end(_grf_townnames), [&grfid](const GRFTownName &t){ return t.grfid == grfid; });
+	auto found = std::find_if(std::begin(_grf_townnames), std::end(_grf_townnames), [&grfid](const GRFTownName &t) { return t.grfid == grfid; });
 	if (found != std::end(_grf_townnames)) return &*found;
 	return nullptr;
 }
@@ -44,7 +44,7 @@ GRFTownName *AddGRFTownName(uint32_t grfid)
 
 void DelGRFTownName(uint32_t grfid)
 {
-	_grf_townnames.erase(std::find_if(std::begin(_grf_townnames), std::end(_grf_townnames), [&grfid](const GRFTownName &t){ return t.grfid == grfid; }));
+	_grf_townnames.erase(std::find_if(std::begin(_grf_townnames), std::end(_grf_townnames), [&grfid](const GRFTownName &t) { return t.grfid == grfid; }));
 }
 
 static void RandomPart(StringBuilder &builder, const GRFTownName *t, uint32_t seed, uint8_t id)

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2299,7 +2299,7 @@ static void SetDefaultRailGui()
 		case 0: {
 			/* Use first available type */
 			std::vector<RailType>::const_iterator it = std::find_if(_sorted_railtypes.begin(), _sorted_railtypes.end(),
-					[](RailType r){ return HasRailTypeAvail(_local_company, r); });
+					[](RailType r) { return HasRailTypeAvail(_local_company, r); });
 			rt = it != _sorted_railtypes.end() ? *it : RAILTYPE_BEGIN;
 			break;
 		}

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -985,7 +985,7 @@ static CommandCost CheckFlatLandRoadStop(TileIndex cur_tile, int &allowed_z, DoC
 				return ClearTile_Station(cur_tile, DC_AUTO); // Get error message.
 			}
 			/* Drive-through station in the wrong direction. */
-			if (is_drive_through && IsDriveThroughStopTile(cur_tile) && DiagDirToAxis(GetRoadStopDir(cur_tile)) != axis){
+			if (is_drive_through && IsDriveThroughStopTile(cur_tile) && DiagDirToAxis(GetRoadStopDir(cur_tile)) != axis) {
 				return_cmd_error(STR_ERROR_DRIVE_THROUGH_DIRECTION);
 			}
 			StationID st = GetStationIndex(cur_tile);

--- a/src/tgp.cpp
+++ b/src/tgp.cpp
@@ -444,7 +444,7 @@ static int *HeightMapMakeHistogram(Height h_min, [[maybe_unused]] Height h_max, 
 	int *hist = hist_buf - h_min;
 
 	/* Count the heights and fill the histogram */
-	for (const Height &h : _height_map.h){
+	for (const Height &h : _height_map.h) {
 		assert(h >= h_min);
 		assert(h <= h_max);
 		hist[h]++;

--- a/src/timer/timer_game_common.h
+++ b/src/timer/timer_game_common.h
@@ -23,7 +23,7 @@
  * Other than that, make sure you only set one callback per priority.
  *
  * For example:
- *   IntervalTimer<TimerGameCalendar>({TimerGameCalendar::DAY, TimerGameCalendar::Priority::NONE}, [](uint count){});
+ *   IntervalTimer<TimerGameCalendar>({TimerGameCalendar::DAY, TimerGameCalendar::Priority::NONE}, [](uint count) {});
  *
  * @note Callbacks are executed in the game-thread.
  */


### PR DESCRIPTION
## Motivation / Problem

Coding style is to have a space between the closing parenthesis and curly brace of while loops and if statements.
Similarly the coding style is to have a space between the function parameters and function body, if they are put onto the same line. However, for some lambdas this is not the case even when they are essentially function parameters and a function body.


## Description

Add the missing spaces.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
