### PR TITLE
Fix: Station/industry nearby list checks in CheckCaches

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1362,7 +1362,10 @@ static void CheckCaches()
 	for (Town *t : Town::Iterate()) old_town_stations_near.push_back(t->stations_near);
 
 	std::vector<StationList> old_industry_stations_near;
-	for (Industry *ind : Industry::Iterate())  old_industry_stations_near.push_back(ind->stations_near);
+	for (Industry *ind : Industry::Iterate()) old_industry_stations_near.push_back(ind->stations_near);
+
+	std::vector<IndustryList> old_station_industries_near;
+	for (Station *st : Station::Iterate()) old_station_industries_near.push_back(st->industries_near);
 
 	for (Station *st : Station::Iterate()) {
 		for (GoodsEntry &ge : st->goods) {
@@ -1388,13 +1391,17 @@ static void CheckCaches()
 				Debug(desync, 2, "docking tile mismatch: tile {}", tile);
 			}
 		}
+	}
 
-		/* Check industries_near */
-		IndustryList industries_near = st->industries_near;
-		st->RecomputeCatchment();
-		if (st->industries_near != industries_near) {
+	Station::RecomputeCatchmentForAll();
+
+	/* Check industries_near */
+	i = 0;
+	for (Station *st : Station::Iterate()) {
+		if (st->industries_near != old_station_industries_near[i]) {
 			Debug(desync, 2, "station industries near mismatch: station {}", st->index);
 		}
+		i++;
 	}
 
 	/* Check stations_near */


### PR DESCRIPTION
## Motivation / Problem

The station/industry nearby list checks were only partially effective (due to #12129).

## Description

Fix the station/industry nearby list checks.

To be rebased over #[12507](https://github.com/OpenTTD/OpenTTD/pull/12507) when that is merged.

## Limitations

Doesn't add or expand much upon the caches that could be checked in CheckCaches.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
