### PR TITLE
Fix: Smooth outliers in unbunching round trip calculations

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1666,7 +1666,14 @@ void VehicleEnterDepot(Vehicle *v)
 
 		/* If we've entered our unbunching depot, record the round trip duration. */
 		if (v->current_order.GetDepotActionType() & ODATFB_UNBUNCH && v->depot_unbunching_last_departure > 0) {
-			v->round_trip_time = (TimerGameTick::counter - v->depot_unbunching_last_departure);
+			TimerGameTick::Ticks measured_round_trip = TimerGameTick::counter - v->depot_unbunching_last_departure;
+			if (v->round_trip_time == 0) {
+				/* This might be our first round trip. */
+				v->round_trip_time = measured_round_trip;
+			} else {
+				/* If we have a previous trip, smooth the effects of outlier trip calculations caused by jams or other interference. */
+				v->round_trip_time = Clamp(measured_round_trip, (v->round_trip_time / 2), ClampTo<TimerGameTick::Ticks>(v->round_trip_time * 2));
+			}
 		}
 
 		v->current_order.MakeDummy();


### PR DESCRIPTION
## Motivation / Problem

Unbunching intervals are based on the measured round trip times of the vehicles in the shared order group.

When trains are severely delayed by a jam, this measurement can be an extreme outlier.

Let's take a hypothetical example:
* Two trains are on a route that takes 2 minutes. The interval is a train every 1 minute.
* A different gets lost and jams up a junction. The player is AFK and doesn't notice for two hours. When they return, they resolve the jam.
* When these trains next enter their unbunching depot, they've measured a round trip of 2 hours. This means the separation interval is 1 hour.
* They sit in the depot saying `Waiting to unbunch` for the next hour, confusing the player.

## Description

Smooth the effect of any outliers by limiting how much the stored trip time can change from the previous measurement.

I considered ignoring outliers, but route changes could legitimately change the round trip time by a large amount, and then the unbunching would never catch up. It's better to slowly adjust to whatever is measured to avoid corner cases.

## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
