### PR TITLE
Fix: Don't show train waiting for unbunching as waiting for free path

### DIFF
--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -3118,12 +3118,12 @@ public:
 			} else { // no train
 				str = STR_VEHICLE_STATUS_STOPPED;
 			}
+		} else if (v->IsInDepot() && v->IsWaitingForUnbunching()) {
+			str = STR_VEHICLE_STATUS_WAITING_UNBUNCHING;
 		} else if (v->type == VEH_TRAIN && HasBit(Train::From(v)->flags, VRF_TRAIN_STUCK) && !v->current_order.IsType(OT_LOADING)) {
 			str = STR_VEHICLE_STATUS_TRAIN_STUCK;
 		} else if (v->type == VEH_AIRCRAFT && HasBit(Aircraft::From(v)->flags, VAF_DEST_TOO_FAR) && !v->current_order.IsType(OT_LOADING)) {
 			str = STR_VEHICLE_STATUS_AIRCRAFT_TOO_FAR;
-		} else if (v->IsInDepot() && v->IsWaitingForUnbunching()) {
-			str = STR_VEHICLE_STATUS_WAITING_UNBUNCHING;
 		} else { // vehicle is in a "normal" state, show current order
 			if (mouse_over_start_stop) {
 				if (v->vehstatus & VS_STOPPED) {


### PR DESCRIPTION
## Motivation / Problem

When multiple trains waiting to unbunch all try to leave at once, but are blocked because the PBS block leaving the depot is occupied, they call `MarkTrainAsStuck(v);` to set their status bar to `Waiting for free path`.

When a train successfully leaves, it assigns the next departure time to the others, which go back to waiting for unbunching.

In the status bar GUI, this status is checked before the unbunching status is checked, so that a train waiting for unbunching is incorrectly marked as awaiting a free path. This is confusing to the player, who sees nothing blocking its path.

## Description

Alter the order that the string is chosen, so that a train waiting for unbunching is indicated accordingly in its status bar, regardless of if it has the stuck flag.

To test this: 
1. Load this savegame: [MarkedStuck.zip](https://github.com/OpenTTD/OpenTTD/files/15015530/MarkedStuck.zip)
2. Open windows for Trains 1-4 and see that they are all trying to leave but are blocked by Train 5.
3. Start Train 5. One of the waiting trains will leave and assign the others a future departure time.
4. In 14.0, these other trains will still show `Waiting for free path` but are actually unbunching. In this PR, the statusbar will go back to `Waiting to unbunch`.




## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
