### PR TITLE
Fix: Mark vehicle status bars dirty when a vehicle leaves unbunching depot

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2538,6 +2538,7 @@ void Vehicle::LeaveUnbunchingDepot()
 		if (u->vehstatus & (VS_STOPPED | VS_CRASHED)) continue;
 
 		u->depot_unbunching_next_departure = next_departure;
+		SetWindowDirty(WC_VEHICLE_VIEW, u->index);
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem

When a vehicle leaves its unbunching depot, it sets the next departure time for all vehicles in its shared order group. If other vehicles are also trying to leave but have been blocked by a path reservation, their status bar will show `Waiting for free path` until one successfully leaves. Then they switch back to `Waiting to unbunch` until the next departure time.

This change of status bar text doesn't mark the window dirty, so the text can be partially redrawn and jumbled.

## Description

When a vehicle leaves its unbunching depot, dirty the vehicle view windows of all other vehicles in the shared order group.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
