### PR TITLE
Codechange: use infinite-fast-forward when rerunning command-log

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -37,6 +37,9 @@
 #include "../gfx_func.h"
 #include "../error.h"
 #include "../misc_cmd.h"
+#ifdef DEBUG_DUMP_COMMANDS
+#	include "../fileio_func.h"
+#endif
 #include <charconv>
 #include <sstream>
 #include <iomanip>
@@ -44,8 +47,11 @@
 #include "../safeguards.h"
 
 #ifdef DEBUG_DUMP_COMMANDS
-#include "../fileio_func.h"
-/** When running the server till the wait point, run as fast as we can! */
+/** Helper variable to make the dedicated server go fast until the (first) join.
+ * Used to load the desync debug logs, i.e. for reproducing a desync.
+ * There's basically no need to ever enable this, unless you really know what
+ * you are doing, i.e. debugging a desync.
+ * See docs/desync.txt for details. */
 bool _ddc_fastforward = true;
 #endif /* DEBUG_DUMP_COMMANDS */
 

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -37,19 +37,6 @@
 #define NETWORK_SEND_DOUBLE_SEED
 #endif /* RANDOM_DEBUG */
 
-/**
- * Helper variable to make the dedicated server go fast until the (first) join.
- * Used to load the desync debug logs, i.e. for reproducing a desync.
- * There's basically no need to ever enable this, unless you really know what
- * you are doing, i.e. debugging a desync.
- * See docs/desync.txt for details.
- */
-#ifdef DEBUG_DUMP_COMMANDS
-extern bool _ddc_fastforward;
-#else
-#define _ddc_fastforward (false)
-#endif /* DEBUG_DUMP_COMMANDS */
-
 typedef class ServerNetworkGameSocketHandler NetworkClientSocket;
 
 /** Status of the clients during joining. */

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -219,7 +219,6 @@ void VideoDriver_Dedicated::MainLoop()
 		if (!_dedicated_forks) DedicatedHandleKeyInput();
 		this->DrainCommandQueue();
 
-		ChangeGameSpeed(_ddc_fastforward);
 		this->Tick();
 		this->SleepTillNextTick();
 	}

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -16,6 +16,7 @@
 #include "../gfx_func.h"
 #include "../settings_type.h"
 #include "../zoom_type.h"
+#include "../network/network_func.h"
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -311,6 +312,12 @@ protected:
 
 	std::chrono::steady_clock::duration GetGameInterval()
 	{
+#ifdef DEBUG_DUMP_COMMANDS
+		/* When replaying, run as fast as we can. */
+		extern bool _ddc_fastforward;
+		if (_ddc_fastforward) return std::chrono::microseconds(0);
+#endif /* DEBUG_DUMP_COMMANDS */
+
 		/* If we are paused, run on normal speed. */
 		if (_pause_mode) return std::chrono::milliseconds(MILLISECONDS_PER_TICK);
 		/* Infinite speed, as quickly as you can. */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When replaying a desync command log, it uses fast-forward. Just this depends on a setting, and you need to know that a value of zero is special, meaning: AS FAST AS YOU CAN.

## Description

Don't depend on a setting when replaying: go as fast as you possibly can.

PS: this also removes `_ddc_fastforward` from even existing when the defines are not set.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
