### PR TITLE
Codechange: improve desync documentation

### DIFF
--- a/docs/desync.md
+++ b/docs/desync.md
@@ -195,10 +195,11 @@ Last updated: 2014-02-23
      'src/network/network_func.h'.
      (DEBUG_FAILED_DUMP_COMMANDS is explained later)
    - Put the 'commands-out.log' into the root save folder, and rename
-      it to 'commands.log'.
-   - Run 'openttd -D -d desync=3 -g startsavegame.sav'.
-     This replays the server log and creates new 'commands-out.log'
-     and 'dmp_cmds_*.sav' in your autosave folder.
+      it to 'commands.log'. Strip everything and including the "newgame"
+      entry from the log.
+   - Run 'openttd -D -d desync=0 -g startsavegame.sav'.
+     This replays the server log. Use "-d desync=3" to also create a
+     new 'commands-out.log' and 'dmp_cmds_*.sav' in your autosave folder.
 
 ## 3.2) Evaluation of the replay
 
@@ -226,7 +227,7 @@ Last updated: 2014-02-23
   savegames with your own ones from the replay. You can also comment/disable
   the 'NOT_REACHED' mentioned above, to get another 'dmp_cmds_*.sav' from
   the replay after the mismatch has already been detected.
-  See Section 3.2 on how to compare savegames.
+  See Section 3.3 on how to compare savegames.
   If the saves differ you have located the Desync between the last dmp_cmds
   that match and the first one that does not. The difference of the saves
   may point you in the direction of what causes it.
@@ -252,16 +253,14 @@ Last updated: 2014-02-23
      are replayed. Their internal state will thus not change in the
      replay and will differ.
 
-  To compare savegame more semantically, there exist some ugly hackish
-  tools at:
-     http://devs.openttd.org/~frosch/texts/zpipe.c
-     http://devs.openttd.org/~frosch/texts/printhunk.c
+  To compare savegame more semantically, easiest is to first export them
+  to a JSON format with for example:
 
-  The first one decompresses OpenTTD savegames. The second one creates
-  a textual representation of an uncompressed savegame, by parsing hunks
-  and arrays and such. With both tools you need to be a bit careful
-  since they work on stdin and stdout, which may not deal well with
-  binary data.
+  https://github.com/TrueBrain/OpenTTD-savegame-reader
 
-  If you have the textual representation of the savegames, you can
-  compare them with regular diff tools.
+  By running:
+
+  python -m savegame_reader --export-json dmp_cmds_NNN.sav | jq . > NNN.json
+
+  Now you can use any (JSON) diff tool to compare the two savegames in a
+  somewhat human readable way.

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -51,7 +51,7 @@
  * Used to load the desync debug logs, i.e. for reproducing a desync.
  * There's basically no need to ever enable this, unless you really know what
  * you are doing, i.e. debugging a desync.
- * See docs/desync.txt for details. */
+ * See docs/desync.md for details. */
 bool _ddc_fastforward = true;
 #endif /* DEBUG_DUMP_COMMANDS */
 

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -12,7 +12,7 @@
 
 /**
  * Uncomment the following define to enable command replaying.
- * See docs/desync.txt for details.
+ * See docs/desync.md for details.
  */
 // #define DEBUG_DUMP_COMMANDS
 // #define DEBUG_FAILED_DUMP_COMMANDS


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Documentation around desync needed some minor polish.

## Description

- Replaying with `-ddesync=3` is just a waste of CPU and IO if you already have the savegames. In many cases you will be fine with `-ddesync=0`, so suggest that as the default.
- For analyzing savegames we can convert them first to JSON these days, avoiding the awkward step of comparing binary blobs etc.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
