### PR TITLE
Codechange: Use std::optional for town parent scope resolver.

### DIFF
--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -219,7 +219,7 @@ uint32_t AirportResolverObject::GetDebugID() const
  */
 TownScopeResolver *AirportResolverObject::GetTown()
 {
-	if (!this->town_scope) {
+	if (!this->town_scope.has_value()) {
 		Town *t = nullptr;
 		if (this->airport_scope.st != nullptr) {
 			t = this->airport_scope.st->town;
@@ -227,9 +227,9 @@ TownScopeResolver *AirportResolverObject::GetTown()
 			t = ClosestTownFromTile(this->airport_scope.tile, UINT_MAX);
 		}
 		if (t == nullptr) return nullptr;
-		this->town_scope.reset(new TownScopeResolver(*this, t, this->airport_scope.st == nullptr));
+		this->town_scope.emplace(*this, t, this->airport_scope.st == nullptr);
 	}
-	return this->town_scope.get();
+	return &*this->town_scope;
 }
 
 /**

--- a/src/newgrf_airport.h
+++ b/src/newgrf_airport.h
@@ -174,7 +174,7 @@ struct AirportScopeResolver : public ScopeResolver {
 /** Resolver object for airports. */
 struct AirportResolverObject : public ResolverObject {
 	AirportScopeResolver airport_scope;
-	std::unique_ptr<TownScopeResolver> town_scope; ///< The town scope resolver (created on the first call).
+	std::optional<TownScopeResolver> town_scope = std::nullopt; ///< The town scope resolver (created on the first call).
 
 	AirportResolverObject(TileIndex tile, Station *st, uint8_t airport_id, uint8_t layout,
 			CallbackID callback = CBID_NO_CALLBACK, uint32_t callback_param1 = 0, uint32_t callback_param2 = 0);

--- a/src/newgrf_industries.h
+++ b/src/newgrf_industries.h
@@ -41,11 +41,10 @@ struct IndustriesScopeResolver : public ScopeResolver {
 /** Resolver for industries. */
 struct IndustriesResolverObject : public ResolverObject {
 	IndustriesScopeResolver industries_scope; ///< Scope resolver for the industry.
-	TownScopeResolver *town_scope;            ///< Scope resolver for the associated town (if needed and available, else \c nullptr).
+	std::optional<TownScopeResolver> town_scope = std::nullopt; ///< Scope resolver for the associated town (if needed and available, else \c std::nullopt).
 
 	IndustriesResolverObject(TileIndex tile, Industry *indus, IndustryType type, uint32_t random_bits = 0,
 			CallbackID callback = CBID_NO_CALLBACK, uint32_t callback_param1 = 0, uint32_t callback_param2 = 0);
-	~IndustriesResolverObject();
 
 	TownScopeResolver *GetTown();
 

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -378,14 +378,8 @@ ObjectResolverObject::ObjectResolverObject(const ObjectSpec *spec, Object *obj, 
 		CallbackID callback, uint32_t param1, uint32_t param2)
 	: ResolverObject(spec->grf_prop.grffile, callback, param1, param2), object_scope(*this, obj, spec, tile, view)
 {
-	this->town_scope = nullptr;
 	this->root_spritegroup = (obj == nullptr && spec->grf_prop.spritegroup[OBJECT_SPRITE_GROUP_PURCHASE] != nullptr) ?
 			spec->grf_prop.spritegroup[OBJECT_SPRITE_GROUP_PURCHASE] : spec->grf_prop.spritegroup[OBJECT_SPRITE_GROUP_DEFAULT];
-}
-
-ObjectResolverObject::~ObjectResolverObject()
-{
-	delete this->town_scope;
 }
 
 /**
@@ -395,7 +389,7 @@ ObjectResolverObject::~ObjectResolverObject()
  */
 TownScopeResolver *ObjectResolverObject::GetTown()
 {
-	if (this->town_scope == nullptr) {
+	if (!this->town_scope.has_value()) {
 		Town *t;
 		if (this->object_scope.obj != nullptr) {
 			t = this->object_scope.obj->town;
@@ -403,9 +397,9 @@ TownScopeResolver *ObjectResolverObject::GetTown()
 			t = ClosestTownFromTile(this->object_scope.tile, UINT_MAX);
 		}
 		if (t == nullptr) return nullptr;
-		this->town_scope = new TownScopeResolver(*this, t, this->object_scope.obj == nullptr);
+		this->town_scope.emplace(*this, t, this->object_scope.obj == nullptr);
 	}
-	return this->town_scope;
+	return &*this->town_scope;
 }
 
 GrfSpecFeature ObjectResolverObject::GetFeature() const

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -133,11 +133,10 @@ struct ObjectScopeResolver : public ScopeResolver {
 /** A resolver object to be used with feature 0F spritegroups. */
 struct ObjectResolverObject : public ResolverObject {
 	ObjectScopeResolver object_scope; ///< The object scope resolver.
-	TownScopeResolver *town_scope;    ///< The town scope resolver (created on the first call).
+	std::optional<TownScopeResolver> town_scope = std::nullopt; ///< The town scope resolver (created on the first call).
 
 	ObjectResolverObject(const ObjectSpec *spec, Object *o, TileIndex tile, uint8_t view = 0,
 			CallbackID callback = CBID_NO_CALLBACK, uint32_t param1 = 0, uint32_t param2 = 0);
-	~ObjectResolverObject();
 
 	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override
 	{

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -210,10 +210,7 @@ const SpriteGroup *RoadStopResolverObject::ResolveReal(const RealSpriteGroup *gr
 RoadStopResolverObject::RoadStopResolverObject(const RoadStopSpec *roadstopspec, BaseStation *st, TileIndex tile, RoadType roadtype, StationType type, uint8_t view,
 		CallbackID callback, uint32_t param1, uint32_t param2)
 	: ResolverObject(roadstopspec->grf_prop.grffile, callback, param1, param2), roadstop_scope(*this, st, roadstopspec, tile, roadtype, type, view)
-	{
-
-	this->town_scope = nullptr;
-
+{
 	CargoID ctype = SpriteGroupCargo::SG_DEFAULT_NA;
 
 	if (st == nullptr) {
@@ -240,14 +237,9 @@ RoadStopResolverObject::RoadStopResolverObject(const RoadStopSpec *roadstopspec,
 	this->root_spritegroup = roadstopspec->grf_prop.spritegroup[ctype];
 }
 
-RoadStopResolverObject::~RoadStopResolverObject()
-{
-	delete this->town_scope;
-}
-
 TownScopeResolver *RoadStopResolverObject::GetTown()
 {
-	if (this->town_scope == nullptr) {
+	if (!this->town_scope.has_value()) {
 		Town *t;
 		if (this->roadstop_scope.st != nullptr) {
 			t = this->roadstop_scope.st->town;
@@ -255,9 +247,9 @@ TownScopeResolver *RoadStopResolverObject::GetTown()
 			t = ClosestTownFromTile(this->roadstop_scope.tile, UINT_MAX);
 		}
 		if (t == nullptr) return nullptr;
-		this->town_scope = new TownScopeResolver(*this, t, this->roadstop_scope.st == nullptr);
+		this->town_scope.emplace(*this, t, this->roadstop_scope.st == nullptr);
 	}
-	return this->town_scope;
+	return &*this->town_scope;
 }
 
 uint16_t GetRoadStopCallback(CallbackID callback, uint32_t param1, uint32_t param2, const RoadStopSpec *roadstopspec, BaseStation *st, TileIndex tile, RoadType roadtype, StationType type, uint8_t view)

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -95,10 +95,9 @@ struct RoadStopScopeResolver : public ScopeResolver {
 /** Road stop resolver. */
 struct RoadStopResolverObject : public ResolverObject {
 	RoadStopScopeResolver roadstop_scope; ///< The stop scope resolver.
-	TownScopeResolver *town_scope;        ///< The town scope resolver (created on the first call).
+	std::optional<TownScopeResolver> town_scope = std::nullopt; ///< The town scope resolver (created on the first call).
 
 	RoadStopResolverObject(const RoadStopSpec *roadstopspec, BaseStation *st, TileIndex tile, RoadType roadtype, StationType type, uint8_t view, CallbackID callback = CBID_NO_CALLBACK, uint32_t param1 = 0, uint32_t param2 = 0);
-	~RoadStopResolverObject();
 
 	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override
 	{

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -49,11 +49,10 @@ struct StationScopeResolver : public ScopeResolver {
 /** Station resolver. */
 struct StationResolverObject : public ResolverObject {
 	StationScopeResolver station_scope; ///< The station scope resolver.
-	TownScopeResolver *town_scope;      ///< The town scope resolver (created on the first call).
+	std::optional<TownScopeResolver> town_scope = std::nullopt; ///< The town scope resolver (created on the first call).
 
 	StationResolverObject(const StationSpec *statspec, BaseStation *st, TileIndex tile,
 			CallbackID callback = CBID_NO_CALLBACK, uint32_t callback_param1 = 0, uint32_t callback_param2 = 0);
-	~StationResolverObject();
 
 	TownScopeResolver *GetTown();
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When resolving NewGRF, the parent town_scope is lazily initialised as it does not always need to be used.

But it uses a raw pointer so requires manual management with new/delete. Airports tried to use a unique_ptr, but still used new instead of make_unique.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

As TownScopeResolver is not large, replace the manually managed pointer with std::optional to simplify it.

Using std::optional also avoids extra memory allocation.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
