### PR TITLE
Codechange: Unify where rail station tile flags are set.

### DIFF
--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2878,19 +2878,7 @@ bool AfterLoadGame()
 		/* Station blocked, wires and pylon flags need to be stored in the map. This is effectively cached data, so no
 		 * version check is necessary. This is done here as the SLV_182 check below needs the blocked status. */
 		for (auto t : Map::Iterate()) {
-			if (HasStationTileRail(t)) {
-				StationGfx gfx = GetStationGfx(t);
-				const StationSpec *statspec = GetStationSpec(t);
-
-				bool blocked = statspec != nullptr && HasBit(statspec->blocked, gfx);
-				/* Default stations do not draw pylons under roofs (gfx >= 4) */
-				bool pylons = statspec != nullptr ? HasBit(statspec->pylons, gfx) : gfx < 4;
-				bool wires = statspec == nullptr || !HasBit(statspec->wires, gfx);
-
-				SetStationTileBlocked(t, blocked);
-				SetStationTileHavePylons(t, pylons);
-				SetStationTileHaveWires(t, wires);
-			}
+			if (HasStationTileRail(t)) SetRailStationTileFlags(t, GetStationSpec(t));
 		}
 	}
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1295,6 +1295,24 @@ static CommandCost CalculateRailStationCost(TileArea tile_area, DoCommandFlag fl
 }
 
 /**
+ * Set rail station tile flags for the given tile.
+ * @param tile Tile to set flags on.
+ * @param statspec Statspec of the tile.
+ */
+void SetRailStationTileFlags(TileIndex tile, const StationSpec *statspec)
+{
+	const StationGfx gfx = GetStationGfx(tile);
+	bool blocked = statspec != nullptr && HasBit(statspec->blocked, gfx);
+	/* Default stations do not draw pylons under roofs (gfx >= 4) */
+	bool pylons = statspec != nullptr ? HasBit(statspec->pylons, gfx) : gfx < 4;
+	bool wires = statspec == nullptr || !HasBit(statspec->wires, gfx);
+
+	SetStationTileBlocked(tile, blocked);
+	SetStationTileHavePylons(tile, pylons);
+	SetStationTileHaveWires(tile, wires);
+}
+
+/**
  * Build rail station
  * @param flags operation to perform
  * @param tile_org northern most position of station dragging/placement
@@ -1456,18 +1474,9 @@ CommandCost CmdBuildRailStation(DoCommandFlag flags, TileIndex tile_org, RailTyp
 					TriggerStationAnimation(st, tile, SAT_BUILT);
 				}
 
-				/* Should be the same as layout but axis component could be wrong... */
-				StationGfx gfx = GetStationGfx(tile);
-				bool blocked = statspec != nullptr && HasBit(statspec->blocked, gfx);
-				/* Default stations do not draw pylons under roofs (gfx >= 4) */
-				bool pylons = statspec != nullptr ? HasBit(statspec->pylons, gfx) : gfx < 4;
-				bool wires = statspec == nullptr || !HasBit(statspec->wires, gfx);
+				SetRailStationTileFlags(tile, statspec);
 
-				SetStationTileBlocked(tile, blocked);
-				SetStationTileHavePylons(tile, pylons);
-				SetStationTileHaveWires(tile, wires);
-
-				if (!blocked) c->infrastructure.rail[rt]++;
+				if (!IsStationTileBlocked(tile)) c->infrastructure.rail[rt]++;
 				c->infrastructure.station++;
 
 				tile += tile_delta;

--- a/src/station_func.h
+++ b/src/station_func.h
@@ -33,6 +33,7 @@ void UpdateStationAcceptance(Station *st, bool show_msg);
 CargoTypes GetAcceptanceMask(const Station *st);
 CargoTypes GetEmptyMask(const Station *st);
 
+void SetRailStationTileFlags(TileIndex tile, const StationSpec *statspec);
 const DrawTileSprites *GetStationTileLayout(StationType st, uint8_t gfx);
 void StationPickerDrawSprite(int x, int y, StationType st, RailType railtype, RoadType roadtype, int image);
 

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -276,16 +276,7 @@ CommandCost CmdBuildRailWaypoint(DoCommandFlag flags, TileIndex start_tile, Axis
 			MakeRailWaypoint(tile, wp->owner, wp->index, axis, layout[i], GetRailType(tile));
 			SetCustomStationSpecIndex(tile, map_spec_index);
 
-			/* Should be the same as layout but axis component could be wrong... */
-			StationGfx gfx = GetStationGfx(tile);
-			bool blocked = spec != nullptr && HasBit(spec->blocked, gfx);
-			/* Default stations do not draw pylons under roofs (gfx >= 4) */
-			bool pylons = spec != nullptr ? HasBit(spec->pylons, gfx) : gfx < 4;
-			bool wires = spec == nullptr || !HasBit(spec->wires, gfx);
-
-			SetStationTileBlocked(tile, blocked);
-			SetStationTileHavePylons(tile, pylons);
-			SetStationTileHaveWires(tile, wires);
+			SetRailStationTileFlags(tile, spec);
 
 			SetRailStationReservation(tile, reserved);
 			MarkTileDirtyByTile(tile);


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Rail station has three per-tile flags, (pylons, wires and blocked) which are set on build of stations, on build of waypoints, and during load.

Each location repeats the logic used for setting these flags.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Unify where rail station tile flags are set. This avoids repeating the logic in three places.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
