### PR TITLE
Codechange: Use string_view in IniItem/IniGroup/IniFile.

### DIFF
--- a/src/ini_type.h
+++ b/src/ini_type.h
@@ -25,9 +25,9 @@ struct IniItem {
 	std::optional<std::string> value; ///< The value of this item
 	std::string comment;              ///< The comment associated with this item
 
-	IniItem(const std::string &name);
+	IniItem(std::string_view name);
 
-	void SetValue(const std::string_view value);
+	void SetValue(std::string_view value);
 };
 
 /** A group within an ini file. */
@@ -37,12 +37,12 @@ struct IniGroup {
 	std::string name;    ///< name of group
 	std::string comment; ///< comment for group
 
-	IniGroup(const std::string &name, IniGroupType type);
+	IniGroup(std::string_view name, IniGroupType type);
 
-	const IniItem *GetItem(const std::string &name) const;
-	IniItem &GetOrCreateItem(const std::string &name);
-	IniItem &CreateItem(const std::string &name);
-	void RemoveItem(const std::string &name);
+	const IniItem *GetItem(std::string_view name) const;
+	IniItem &GetOrCreateItem(std::string_view name);
+	IniItem &CreateItem(std::string_view name);
+	void RemoveItem(std::string_view name);
 	void Clear();
 };
 
@@ -58,11 +58,11 @@ struct IniLoadFile {
 	IniLoadFile(const IniGroupNameList &list_group_names = {}, const IniGroupNameList &seq_group_names = {});
 	virtual ~IniLoadFile() { }
 
-	const IniGroup *GetGroup(const std::string &name) const;
-	IniGroup *GetGroup(const std::string &name);
-	IniGroup &GetOrCreateGroup(const std::string &name);
-	IniGroup &CreateGroup(const std::string &name);
-	void RemoveGroup(const std::string &name);
+	const IniGroup *GetGroup(std::string_view name) const;
+	IniGroup *GetGroup(std::string_view name);
+	IniGroup &GetOrCreateGroup(std::string_view name);
+	IniGroup &CreateGroup(std::string_view name);
+	void RemoveGroup(std::string_view name);
 
 	void LoadFromDisk(const std::string &filename, Subdirectory subdir);
 


### PR DESCRIPTION

<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

I'm still learning. A while back I switched the Ini file system from `char *` to `std::string`, not giving any consideration to `std::string_view`. However after reviewing it, I can see there are places where `std::string`s are constructed from `char *`. These temporary strings are then either thrown away, or copied again, and... thrown away.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use `std::string_view` in IniItem/IniGroup/IniFile. This avoids making extra copies of strings.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
