### PR TITLE
Change: De-template BaseSetTextfileWindow.

### DIFF
--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -92,24 +92,21 @@ static uint GetCurrentResolutionIndex()
 static void ShowCustCurrency();
 
 /** Window for displaying the textfile of a BaseSet. */
-template <class TBaseSet>
 struct BaseSetTextfileWindow : public TextfileWindow {
-	const TBaseSet *baseset; ///< View the textfile of this BaseSet.
-	StringID content_type;   ///< STR_CONTENT_TYPE_xxx for title.
+	const std::string name; ///< Name of the content.
+	const StringID content_type; ///< STR_CONTENT_TYPE_xxx for title.
 
-	BaseSetTextfileWindow(TextfileType file_type, const TBaseSet *baseset, StringID content_type) : TextfileWindow(file_type), baseset(baseset), content_type(content_type)
+	BaseSetTextfileWindow(TextfileType file_type, const std::string &name, const std::string &textfile, StringID content_type) : TextfileWindow(file_type), name(name), content_type(content_type)
 	{
 		this->ConstructWindow();
-
-		auto textfile = this->baseset->GetTextfile(file_type);
-		this->LoadTextfile(textfile.value(), BASESET_DIR);
+		this->LoadTextfile(textfile, BASESET_DIR);
 	}
 
 	void SetStringParameters(WidgetID widget) const override
 	{
 		if (widget == WID_TF_CAPTION) {
 			SetDParam(0, content_type);
-			SetDParamStr(1, this->baseset->name);
+			SetDParamStr(1, this->name);
 		}
 	}
 };
@@ -124,7 +121,7 @@ template <class TBaseSet>
 void ShowBaseSetTextfileWindow(TextfileType file_type, const TBaseSet *baseset, StringID content_type)
 {
 	CloseWindowById(WC_TEXTFILE, file_type);
-	new BaseSetTextfileWindow<TBaseSet>(file_type, baseset, content_type);
+	new BaseSetTextfileWindow(file_type, baseset->name, *baseset->GetTextfile(file_type), content_type);
 }
 
 template <class T>


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Three separate versions of `BaseSetTextfileWindow` exist, one for each `BaseSet` type, as we pass the BaseSet to the window so that it get the info it needs. However it only actually needs the set name, and the appropriate text file.

Related symbols in master:

```
0000000000891120 W BaseSetTextfileWindow<GraphicsSet>::BaseSetTextfileWindow(TextfileType, GraphicsSet const*, unsigned int)
00000000008912d0 W BaseSetTextfileWindow<GraphicsSet>::~BaseSetTextfileWindow()
00000000008914c0 W BaseSetTextfileWindow<MusicSet>::BaseSetTextfileWindow(TextfileType, MusicSet const*, unsigned int)
00000000008915d0 W BaseSetTextfileWindow<MusicSet>::~BaseSetTextfileWindow()
0000000000891350 W BaseSetTextfileWindow<SoundsSet>::BaseSetTextfileWindow(TextfileType, SoundsSet const*, unsigned int)
0000000000891440 W BaseSetTextfileWindow<SoundsSet>::~BaseSetTextfileWindow()
00000000008912f0 W BaseSetTextfileWindow<GraphicsSet>::SetStringParameters(int) const
00000000008915f0 W BaseSetTextfileWindow<MusicSet>::SetStringParameters(int) const
0000000000891460 W BaseSetTextfileWindow<SoundsSet>::SetStringParameters(int) const
0000000000891330 W non-virtual thunk to BaseSetTextfileWindow<GraphicsSet>::~BaseSetTextfileWindow()
0000000000891320 W non-virtual thunk to BaseSetTextfileWindow<GraphicsSet>::~BaseSetTextfileWindow()
0000000000891630 W non-virtual thunk to BaseSetTextfileWindow<MusicSet>::~BaseSetTextfileWindow()
0000000000891620 W non-virtual thunk to BaseSetTextfileWindow<MusicSet>::~BaseSetTextfileWindow()
00000000008914a0 W non-virtual thunk to BaseSetTextfileWindow<SoundsSet>::~BaseSetTextfileWindow()
0000000000891490 W non-virtual thunk to BaseSetTextfileWindow<SoundsSet>::~BaseSetTextfileWindow()
0000000000bc5ec8 V typeinfo for BaseSetTextfileWindow<GraphicsSet>
0000000000bc6338 V typeinfo for BaseSetTextfileWindow<MusicSet>
0000000000bc6100 V typeinfo for BaseSetTextfileWindow<SoundsSet>
0000000000a0fc88 V typeinfo name for BaseSetTextfileWindow<GraphicsSet>
0000000000a0fcd3 V typeinfo name for BaseSetTextfileWindow<MusicSet>
0000000000a0fcaf V typeinfo name for BaseSetTextfileWindow<SoundsSet>
0000000000bc5ca8 V vtable for BaseSetTextfileWindow<GraphicsSet>
0000000000bc6118 V vtable for BaseSetTextfileWindow<MusicSet>
0000000000bc5ee0 V vtable for BaseSetTextfileWindow<SoundsSet>
```

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

The BaseSet type is not needed after the window is constructed, only the filename and name are required, which can be passed as parameters from `ShowBaseSetTextfileWindow()` instead.

Doing this avoids compiling three instances of `BaseSetTextfileWindow`.

Related symbols with this change:

```
0000000000896e60 W void ShowBaseSetTextfileWindow<GraphicsSet>(TextfileType, GraphicsSet const*, unsigned int)
00000000008971c0 W void ShowBaseSetTextfileWindow<MusicSet>(TextfileType, MusicSet const*, unsigned int)
0000000000897000 W void ShowBaseSetTextfileWindow<SoundsSet>(TextfileType, SoundsSet const*, unsigned int)
0000000000897520 W BaseSetTextfileWindow::~BaseSetTextfileWindow()
0000000000897540 W BaseSetTextfileWindow::SetStringParameters(int) const
0000000000897580 W non-virtual thunk to BaseSetTextfileWindow::~BaseSetTextfileWindow()
0000000000897570 W non-virtual thunk to BaseSetTextfileWindow::~BaseSetTextfileWindow()
0000000000bcd398 V typeinfo for BaseSetTextfileWindow
0000000000a15f18 V typeinfo name for BaseSetTextfileWindow
0000000000bcd178 V vtable for BaseSetTextfileWindow
```

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

The rest of `TextfileWindow` is separate anyway, so this only really affects the constructor. Not really a big amount of code...

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
