### PR TITLE
Codechange: replace cpp_lengthof with safe alternatives

### DIFF
--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -2380,8 +2380,8 @@ private:
 	}
 };
 
-static_assert(MAX_CARGOES >= cpp_lengthof(IndustrySpec, produced_cargo));
-static_assert(MAX_CARGOES >= cpp_lengthof(IndustrySpec, accepts_cargo));
+static_assert(MAX_CARGOES >= std::tuple_size_v<decltype(IndustrySpec::produced_cargo)>);
+static_assert(MAX_CARGOES >= std::tuple_size_v<decltype(IndustrySpec::accepts_cargo)>);
 
 Dimension CargoesField::legend;       ///< Dimension of the legend blob.
 Dimension CargoesField::cargo_border; ///< Dimensions of border between cargo lines and industry boxes.

--- a/src/newgrf_storage.h
+++ b/src/newgrf_storage.h
@@ -206,6 +206,6 @@ struct PersistentStorage : PersistentStorageArray<int32_t, 256>, PersistentStora
 	}
 };
 
-static_assert(cpp_lengthof(OldPersistentStorage, storage) <= cpp_lengthof(PersistentStorage, storage));
+static_assert(std::tuple_size_v<decltype(OldPersistentStorage::storage)> <= std::tuple_size_v<decltype(PersistentStorage::storage)>);
 
 #endif /* NEWGRF_STORAGE_H */

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -301,14 +301,6 @@ char (&ArraySizeHelper(T (&array)[N]))[N];
  */
 #define cpp_sizeof(base, variable) (sizeof(std::declval<base>().variable))
 
-/**
- * Gets the length of an array variable within a class.
- * @param base     The class the variable is in.
- * @param variable The array variable to get the size of.
- * @return the length of the array
- */
-#define cpp_lengthof(base, variable) (cpp_sizeof(base, variable) / cpp_sizeof(base, variable[0]))
-
 
 /* take care of some name clashes on MacOS */
 #if defined(__APPLE__)


### PR DESCRIPTION
## Motivation / Problem

The macro `cpp_lengthof` has the same issue that `lengthof` used to have, i.e. that it might seemingly work when it isn't actually doing what you expect it to do.

Imagine there being a `std::vector<int>` in a struct. `cpp_lengthof` will happily return a value that is supposedly a length, namely `sizeof(std::vector) / sizeof(int)`. Given a vector is often 24 bytes, this will yield a length of `6`. In other words, it will return something but it is actually broken.

So, use C++ constructs that provide a safer way to get the size/length an array by breaking when the type gets changed from array to vector.


## Description

Replace `cpp_lengthof` with `std::tuple_size_v` returns the number of elements from a `std::array` as compile time constant. It also works for `std::tuple` and `std::pair`, in which case the number of elements is still correct although there might be different types, and as such (array) iteration won't work and we likely will not run into any issues.

Remove `cpp_lengthof` from stdafx.h.


## Limitations

Could also put this code in the macro, but expanding the macro makes it simpler to see what's actually happening. And it's not like the macro is used all over the place.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
