### PR TITLE
Codechange: Replace C-casts in pool functions.

### DIFF
--- a/src/core/pool_func.hpp
+++ b/src/core/pool_func.hpp
@@ -115,17 +115,17 @@ DEFINE_POOL_METHOD(inline void *)::AllocateItem(size_t size, size_t index)
 	Titem *item;
 	if (Tcache && this->alloc_cache != nullptr) {
 		assert(sizeof(Titem) == size);
-		item = (Titem *)this->alloc_cache;
+		item = reinterpret_cast<Titem *>(this->alloc_cache);
 		this->alloc_cache = this->alloc_cache->next;
 		if (Tzero) {
 			/* Explicitly casting to (void *) prevents a clang warning -
 			 * we are actually memsetting a (not-yet-constructed) object */
-			memset((void *)item, 0, sizeof(Titem));
+			memset(static_cast<void *>(item), 0, sizeof(Titem));
 		}
 	} else if (Tzero) {
-		item = (Titem *)CallocT<uint8_t>(size);
+		item = reinterpret_cast<Titem *>(CallocT<uint8_t>(size));
 	} else {
-		item = (Titem *)MallocT<uint8_t>(size);
+		item = reinterpret_cast<Titem *>(MallocT<uint8_t>(size));
 	}
 	this->data[index] = item;
 	SetBit(this->used_bitmap[index / BITMAP_SIZE], index % BITMAP_SIZE);
@@ -188,7 +188,7 @@ DEFINE_POOL_METHOD(void)::FreeItem(size_t index)
 	assert(index < this->size);
 	assert(this->data[index] != nullptr);
 	if (Tcache) {
-		AllocCache *ac = (AllocCache *)this->data[index];
+		AllocCache *ac = reinterpret_cast<AllocCache *>(this->data[index]);
 		ac->next = this->alloc_cache;
 		this->alloc_cache = ac;
 	} else {

--- a/src/core/pool_type.hpp
+++ b/src/core/pool_type.hpp
@@ -78,8 +78,8 @@ private:
  */
 template <class Titem, typename Tindex, size_t Tgrowth_step, size_t Tmax_size, PoolType Tpool_type = PT_NORMAL, bool Tcache = false, bool Tzero = true>
 struct Pool : PoolBase {
-	/* Ensure Tmax_size is within the bounds of Tindex. */
-	static_assert((uint64_t)(Tmax_size - 1) >> 8 * sizeof(Tindex) == 0);
+	/* Ensure the highest possible index, i.e. Tmax_size -1, is within the bounds of Tindex. */
+	static_assert(Tmax_size - 1 <= MAX_UVALUE(Tindex));
 
 	static constexpr size_t MAX_SIZE = Tmax_size; ///< Make template parameter accessible from outside
 
@@ -259,7 +259,7 @@ struct Pool : PoolBase {
 		inline void operator delete(void *p)
 		{
 			if (p == nullptr) return;
-			Titem *pn = (Titem *)p;
+			Titem *pn = static_cast<Titem *>(p);
 			assert(pn == Tpool->Get(pn->index));
 			Tpool->FreeItem(pn->index);
 		}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

C-casts in pool functions.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Replace with `static_cast` or `reinterpret_cast`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
