### PR TITLE
Change: [Linkgraph] Improve distance scaling algorithm in demand scaler

### DIFF
--- a/src/linkgraph/demands.cpp
+++ b/src/linkgraph/demands.cpp
@@ -2,6 +2,7 @@
 
 #include "../stdafx.h"
 #include "demands.h"
+#include "../core/math_func.hpp"
 #include <queue>
 
 #include "../safeguards.h"
@@ -207,23 +208,26 @@ void DemandCalculator::CalcDemand(LinkGraphJob &job, Tscaler scaler)
 			int32_t supply = scaler.EffectiveSupply(job[from_id], job[to_id]);
 			assert(supply > 0);
 
-			/* Scale the distance by mod_dist around max_distance */
-			int32_t distance = this->max_distance - (this->max_distance -
-					(int32_t)DistanceMaxPlusManhattan(job[from_id].base.xy, job[to_id].base.xy)) *
-					this->mod_dist / 100;
+			constexpr int32_t divisor_scale = 16;
+
+			int32_t scaled_distance = this->base_distance;
+			if (this->mod_dist > 0) {
+				const int32_t distance = DistanceMaxPlusManhattan(job[from_id].base.xy, job[to_id].base.xy);
+				/* Scale distance around base_distance by (mod_dist * (100 / 1024)).
+				 * mod_dist may be > 1024, so clamp result to be non-negative */
+				scaled_distance = std::max(0, this->base_distance + (((distance - this->base_distance) * this->mod_dist) / 1024));
+			}
 
 			/* Scale the accuracy by distance around accuracy / 2 */
-			int32_t divisor = this->accuracy * (this->mod_dist - 50) / 100 +
-					this->accuracy * distance / this->max_distance + 1;
-
-			assert(divisor > 0);
+			const int32_t divisor = divisor_scale + ((this->accuracy * scaled_distance * divisor_scale) / (this->base_distance * 2));
+			assert(divisor >= divisor_scale);
 
 			uint demand_forw = 0;
-			if (divisor <= supply) {
+			if (divisor <= (supply * divisor_scale)) {
 				/* At first only distribute demand if
 				 * effective supply / accuracy divisor >= 1
 				 * Others are too small or too far away to be considered. */
-				demand_forw = supply / divisor;
+				demand_forw = (supply * divisor_scale) / divisor;
 			} else if (++chance > this->accuracy * num_demands * num_supplies) {
 				/* After some trying, if there is still supply left, distribute
 				 * demand also to other nodes. */
@@ -256,7 +260,7 @@ void DemandCalculator::CalcDemand(LinkGraphJob &job, Tscaler scaler)
  * @param job Job to calculate the demands for.
  */
 DemandCalculator::DemandCalculator(LinkGraphJob &job) :
-	max_distance(DistanceMaxPlusManhattan(TileXY(0,0), TileXY(Map::MaxX(), Map::MaxY())))
+	base_distance(IntSqrt(DistanceMaxPlusManhattan(TileXY(0,0), TileXY(Map::MaxX(), Map::MaxY()))))
 {
 	const LinkGraphSettings &settings = job.Settings();
 	CargoID cargo = job.Cargo();
@@ -264,9 +268,15 @@ DemandCalculator::DemandCalculator(LinkGraphJob &job) :
 	this->accuracy = settings.accuracy;
 	this->mod_dist = settings.demand_distance;
 	if (this->mod_dist > 100) {
-		/* Increase effect of mod_dist > 100 */
+		/* Increase effect of mod_dist > 100.
+		 * Quadratic:
+		 *   100 --> 100
+		 *   150 --> 308
+		 *   200 --> 933
+		 *   255 --> 2102
+		 */
 		int over100 = this->mod_dist - 100;
-		this->mod_dist = 100 + over100 * over100;
+		this->mod_dist = 100 + ((over100 * over100) / 12);
 	}
 
 	switch (settings.GetDistributionType(cargo)) {

--- a/src/linkgraph/demands.h
+++ b/src/linkgraph/demands.h
@@ -14,9 +14,9 @@ public:
 	DemandCalculator(LinkGraphJob &job);
 
 private:
-	int32_t max_distance; ///< Maximum distance possible on the map.
-	int32_t mod_dist;     ///< Distance modifier, determines how much demands decrease with distance.
-	int32_t accuracy;     ///< Accuracy of the calculation.
+	int32_t base_distance; ///< Base distance for scaling purposes.
+	int32_t mod_dist;      ///< Distance modifier, determines how much demands decrease with distance.
+	int32_t accuracy;      ///< Accuracy of the calculation.
 
 	template<class Tscaler>
 	void CalcDemand(LinkGraphJob &job, Tscaler scaler);


### PR DESCRIPTION
## Motivation / Problem

The current scaling algorithm produces poor quality results at values other than 0% and 100%.
At large values (e.g. > 200%) scaling is erratic does not produce results consistent with a large setting value.

This broadly is due to:
* The base distance scaling value is DistanceMaxPlusManhattan(map size), which is far too large.
* The "Increase effect of mod_dist > 100" adjustment is also far too large.
* At setting values < 100%, short distances are increased too much.
* At setting values > 100%, short distances become huge negative distances.
* At setting values > 100%, the accuracy part of the divisor term is far too large, as a result the algorithm is pushed almost entirely into the fallback path (`++chance > this->accuracy * num_demands * num_supplies`, etc) which leads to poor results.

## Description

Change the base distance value to IntSqrt(DistanceMaxPlusManhattan(map size)), which gives much more reasonable values and outputs, whilst still being responsive to variable map size.

Decrease the magnitude of the "Increase effect of mod_dist > 100" adjustment.

Change the scaling distance adjustment, such that it gives reasonable results with the now reduced range of mod_dist, and do not allow negative distances.

Scale divisor by a constant to reduce rounding losses.

The outputs are broadly the same as the existing algorithm at 0% and near 100%.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
