### PR TITLE
Codechange: simplify access to the current screenshot format

### DIFF
--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -32,8 +32,6 @@ bool MakeScreenshot(ScreenshotType t, std::string name, uint32_t width = 0, uint
 bool MakeMinimapWorldScreenshot();
 
 extern std::string _screenshot_format_name;
-extern uint _num_screenshot_formats;
-extern uint _cur_screenshot_format;
 extern std::string _full_screenshot_path;
 
 #endif /* SCREENSHOT_H */


### PR DESCRIPTION
## Motivation / Problem

screenshot.h has two global variables that aren't used outside of screenshot.cpp.
One of them is only written to and never read, the other is an index into an array of screenshot formats. This index is then only used to dereference into the array, so  why not keep it as a pointer to avoid the dereferencing?


## Description

So remove some variables, replace indexing with the current screenshot format index by just accessing the pointer, and use a ranged for loop to find the current screenshot format.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
