### PR TITLE
Fix: allow only 255 league tables, as 255 is the invalid id sentinel

### DIFF
--- a/src/league_base.h
+++ b/src/league_base.h
@@ -20,7 +20,7 @@ bool IsValidLink(Link link);
 typedef Pool<LeagueTableElement, LeagueTableElementID, 64, 64000> LeagueTableElementPool;
 extern LeagueTableElementPool _league_table_element_pool;
 
-typedef Pool<LeagueTable, LeagueTableID, 4, 256> LeagueTablePool;
+typedef Pool<LeagueTable, LeagueTableID, 4, 255> LeagueTablePool;
 extern LeagueTablePool _league_table_pool;
 
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

While reviewing #12541, the maximum size check and comment for pool size were not in sync which yielded a search for what is valid.

The result: with the league table pool you can add/allocate 256 elements. These will be numbered 0 to 255. 0xFF (or 255) is also used for as sentinel for an invalid league table pool id and as such should not be allowed to be allocated by the pool.


## Description

Reduce the league table pool size by 1.


## Limitations

Might, in theory, cause some issues with scripts that can't create 256 elements any more. However, they were not allowed to change or use the 256th element afterwards, as that would be flagged as an invalid id.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
