### PR TITLE
Fix #12509: Timer period modifications may violate invariants of TimerManager::base_timer_sorter std::set sorting

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -636,7 +636,7 @@ Company *DoStartupNewCompany(bool is_ai, CompanyID company = INVALID_COMPANY)
 }
 
 /** Start a new competitor company if possible. */
-TimeoutTimer<TimerGameTick> _new_competitor_timeout(0, []() {
+TimeoutTimer<TimerGameTick> _new_competitor_timeout({ TimerGameTick::Priority::COMPETITOR_TIMEOUT, 0 }, []() {
 	if (_game_mode == GM_MENU || !AI::CanStartNew()) return;
 	if (_networking && Company::GetNumItems() >= _settings_client.network.max_companies) return;
 
@@ -777,7 +777,7 @@ void OnTick_Companies()
 		/* Randomize a bit when the AI is actually going to start; ranges from 87.5% .. 112.5% of indicated value. */
 		timeout += ScriptObject::GetRandomizer(OWNER_NONE).Next(timeout / 4) - timeout / 8;
 
-		_new_competitor_timeout.Reset(std::max(1, timeout));
+		_new_competitor_timeout.Reset({ TimerGameTick::Priority::COMPETITOR_TIMEOUT, static_cast<uint>(std::max(1, timeout)) });
 	}
 
 	_cur_company_tick_index = (_cur_company_tick_index + 1) % MAX_COMPANIES;

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -157,7 +157,7 @@ std::string NewGRFProfiler::GetOutputFilename() const
 /**
  * Check whether profiling is active and should be finished.
  */
-static TimeoutTimer<TimerGameTick> _profiling_finish_timeout(0, []()
+static TimeoutTimer<TimerGameTick> _profiling_finish_timeout({ TimerGameTick::Priority::NONE, 0 }, []()
 {
 	NewGRFProfiler::FinishAll();
 });
@@ -167,7 +167,7 @@ static TimeoutTimer<TimerGameTick> _profiling_finish_timeout(0, []()
  */
 /* static */ void NewGRFProfiler::StartTimer(uint64_t ticks)
 {
-	_profiling_finish_timeout.Reset(ticks);
+	_profiling_finish_timeout.Reset({ TimerGameTick::Priority::NONE, static_cast<uint>(ticks) });
 }
 
 /**

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3255,7 +3255,7 @@ bool AfterLoadGame()
 		/* We did load the "period" of the timer, but not the fired/elapsed. We can deduce that here. */
 		extern TimeoutTimer<TimerGameTick> _new_competitor_timeout;
 		_new_competitor_timeout.storage.elapsed = 0;
-		_new_competitor_timeout.fired = _new_competitor_timeout.period == 0;
+		_new_competitor_timeout.fired = _new_competitor_timeout.period.value == 0;
 	}
 
 	if (IsSavegameVersionBefore(SLV_NEWGRF_LAST_SERVICE)) {

--- a/src/saveload/misc_sl.cpp
+++ b/src/saveload/misc_sl.cpp
@@ -99,9 +99,9 @@ static const SaveLoad _date_desc[] = {
 	SLEG_CONDVAR("pause_mode",             _pause_mode,             SLE_UINT8,                   SLV_4, SL_MAX_VERSION),
 	SLEG_CONDSSTR("id",                    _game_session_stats.savegame_id, SLE_STR,                     SLV_SAVEGAME_ID, SL_MAX_VERSION),
 	/* For older savegames, we load the current value as the "period"; afterload will set the "fired" and "elapsed". */
-	SLEG_CONDVAR("next_competitor_start",        _new_competitor_timeout.period,          SLE_FILE_U16 | SLE_VAR_U32,  SL_MIN_VERSION, SLV_109),
-	SLEG_CONDVAR("next_competitor_start",        _new_competitor_timeout.period,          SLE_UINT32,                  SLV_109, SLV_AI_START_DATE),
-	SLEG_CONDVAR("competitors_interval",         _new_competitor_timeout.period,          SLE_UINT32,                  SLV_AI_START_DATE, SL_MAX_VERSION),
+	SLEG_CONDVAR("next_competitor_start",        _new_competitor_timeout.period.value,    SLE_FILE_U16 | SLE_VAR_U32,  SL_MIN_VERSION, SLV_109),
+	SLEG_CONDVAR("next_competitor_start",        _new_competitor_timeout.period.value,    SLE_UINT32,                  SLV_109, SLV_AI_START_DATE),
+	SLEG_CONDVAR("competitors_interval",         _new_competitor_timeout.period.value,    SLE_UINT32,                  SLV_AI_START_DATE, SL_MAX_VERSION),
 	SLEG_CONDVAR("competitors_interval_elapsed", _new_competitor_timeout.storage.elapsed, SLE_UINT32,                  SLV_AI_START_DATE, SL_MAX_VERSION),
 	SLEG_CONDVAR("competitors_interval_fired",   _new_competitor_timeout.fired,           SLE_BOOL,                    SLV_AI_START_DATE, SL_MAX_VERSION),
 };

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -1701,7 +1701,7 @@ static const OldChunks main_chunk[] = {
 
 	OCL_ASSERT( OC_TTO, 0x496CE ),
 
-	OCL_VAR ( OC_FILE_U16 | OC_VAR_U32,   1, &_new_competitor_timeout.period ),
+	OCL_VAR ( OC_FILE_U16 | OC_VAR_U32,   1, &_new_competitor_timeout.period.value ),
 
 	OCL_CNULL( OC_TTO, 2 ),  ///< available monorail bitmask
 

--- a/src/timer/timer.h
+++ b/src/timer/timer.h
@@ -98,7 +98,7 @@ public:
 	 */
 	void SetInterval(const TPeriod interval, bool reset = true)
 	{
-		this->period = interval;
+		TimerManager<TTimerType>::ChangeRegisteredTimerPeriod(*this, interval);
 		if (reset) this->storage = {};
 	}
 
@@ -150,7 +150,7 @@ public:
 	 */
 	void Reset(const TPeriod timeout)
 	{
-		this->period = timeout;
+		TimerManager<TTimerType>::ChangeRegisteredTimerPeriod(*this, timeout);
 		this->fired = false;
 		this->storage = {};
 	}

--- a/src/timer/timer_game_tick.cpp
+++ b/src/timer/timer_game_tick.cpp
@@ -21,13 +21,13 @@ TimerGameTick::TickCounter TimerGameTick::counter = 0;
 template<>
 void IntervalTimer<TimerGameTick>::Elapsed(TimerGameTick::TElapsed delta)
 {
-	if (this->period == 0) return;
+	if (this->period.value == 0) return;
 
 	this->storage.elapsed += delta;
 
 	uint count = 0;
-	while (this->storage.elapsed >= this->period) {
-		this->storage.elapsed -= this->period;
+	while (this->storage.elapsed >= this->period.value) {
+		this->storage.elapsed -= this->period.value;
 		count++;
 	}
 
@@ -40,11 +40,11 @@ template<>
 void TimeoutTimer<TimerGameTick>::Elapsed(TimerGameTick::TElapsed delta)
 {
 	if (this->fired) return;
-	if (this->period == 0) return;
+	if (this->period.value == 0) return;
 
 	this->storage.elapsed += delta;
 
-	if (this->storage.elapsed >= this->period) {
+	if (this->storage.elapsed >= this->period.value) {
 		this->callback();
 		this->fired = true;
 	}
@@ -64,7 +64,16 @@ bool TimerManager<TimerGameTick>::Elapsed(TimerGameTick::TElapsed delta)
 
 #ifdef WITH_ASSERT
 template<>
-void TimerManager<TimerGameTick>::Validate(TimerGameTick::TPeriod)
+void TimerManager<TimerGameTick>::Validate(TimerGameTick::TPeriod period)
 {
+	if (period.priority == TimerGameTick::Priority::NONE) return;
+
+	/* Validate we didn't make a developer error and scheduled more than one
+	 * entry on the same priority. There can only be one timer on
+	 * a specific priority, to ensure we are deterministic, and to avoid
+	 * container sort order invariant issues with timer period saveload. */
+	for (const auto &timer : TimerManager<TimerGameTick>::GetTimers()) {
+		assert(timer->period.priority != period.priority);
+	}
 }
 #endif /* WITH_ASSERT */

--- a/src/timer/timer_game_tick.h
+++ b/src/timer/timer_game_tick.h
@@ -24,7 +24,34 @@ public:
 	using Ticks = int32_t; ///< The type to store ticks in
 	using TickCounter = uint64_t; ///< The type that the tick counter is stored in
 
-	using TPeriod = uint;
+	enum Priority {
+		NONE, ///< These timers can be executed in any order; the order is not relevant.
+
+		/* For all other priorities, the order is important.
+		 * For safety, you can only setup a single timer on a single priority. */
+		COMPETITOR_TIMEOUT,
+	};
+
+	struct TPeriod {
+		Priority priority;
+		uint value;
+
+		TPeriod(Priority priority, uint value) : priority(priority), value(value)
+		{}
+
+		bool operator < (const TPeriod &other) const
+		{
+			/* Sort by priority before value, such that changes in value for priorities other than NONE do not change the container order */
+			if (this->priority != other.priority) return this->priority < other.priority;
+			return this->value < other.value;
+		}
+
+		bool operator == (const TPeriod &other) const
+		{
+			return this->priority == other.priority && this->value == other.value;
+		}
+	};
+
 	using TElapsed = uint;
 	struct TStorage {
 		uint elapsed;

--- a/src/timer/timer_manager.h
+++ b/src/timer/timer_manager.h
@@ -56,6 +56,20 @@ public:
 		GetTimers().erase(&timer);
 	}
 
+	/**
+	 * Change the period of a registered timer.
+	 *
+	 * @param timer The timer to change the period of.
+	 * @param new_period The new period value.
+	 */
+	static void ChangeRegisteredTimerPeriod(BaseTimer<TTimerType> &timer, TPeriod new_period)
+	{
+		/* Unregistration and re-registration is necessary because the period is used as the sort key in base_timer_sorter */
+		UnregisterTimer(timer);
+		timer.period = new_period;
+		RegisterTimer(timer);
+	}
+
 #ifdef WITH_ASSERT
 	/**
 	 * Validate that a new period is actually valid.

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -799,7 +799,7 @@ struct TimetableWindow : Window {
 	/**
 	 * In real-time mode, the timetable GUI shows relative times and needs to be redrawn every second.
 	 */
-	IntervalTimer<TimerGameTick> redraw_interval = {Ticks::TICKS_PER_SECOND, [this](auto) {
+	IntervalTimer<TimerGameTick> redraw_interval = { { TimerGameTick::Priority::NONE, Ticks::TICKS_PER_SECOND }, [this](auto) {
 		if (_settings_client.gui.timetable_mode == TimetableMode::Seconds) {
 			this->SetDirty();
 		}


### PR DESCRIPTION
## Motivation / Problem

#12509

## Description

Add a priority field to TimerGameTick::TPeriod, such that saveload period changes to _new_competitor_timeout do not result in changes to the timer manager container sort order.

`TimeoutTimer::Reset(const TPeriod timeout)` and `IntervalTimer::SetInterval` now correctly maintain the manager container sort order invariants.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
