### PR TITLE
Change: [RoadStop] For DriveThroughRoadStop, calculate the occupied level based on actual vehicles in the stop in that tick.

### DIFF
--- a/src/pathfinder/npf/npf.cpp
+++ b/src/pathfinder/npf/npf.cpp
@@ -368,7 +368,7 @@ static int32_t NPFRoadPathCost(AyStar *, AyStarNode *current, OpenListNode *)
 					/* When we're the first road stop in a 'queue' of them we increase
 					 * cost based on the fill percentage of the whole queue. */
 					const RoadStop::Entry *entry = rs->GetEntry(dir);
-					cost += entry->GetOccupied() * _settings_game.pf.npf.npf_road_dt_occupied_penalty / entry->GetLength();
+					cost += entry->GetOccupied(rs, dir) * _settings_game.pf.npf.npf_road_dt_occupied_penalty / entry->GetLength();
 				}
 			} else {
 				/* Increase cost for filled road stops */

--- a/src/pathfinder/yapf/yapf_road.cpp
+++ b/src/pathfinder/yapf/yapf_road.cpp
@@ -75,11 +75,11 @@ protected:
 						/* Increase the cost for drive-through road stops */
 						cost += Yapf().PfGetSettings().road_stop_penalty;
 						DiagDirection dir = TrackdirToExitdir(trackdir);
-						if (!RoadStop::IsDriveThroughRoadStopContinuation(tile, tile - TileOffsByDiagDir(dir))) {
-							/* When we're the first road stop in a 'queue' of them we increase
-							 * cost based on the fill percentage of the whole queue. */
+						if (Yapf().PfDetectDestinationTile(tile, trackdir)){
+							/* We've found the destination file so get the occupied
+							 * level from the Entry object. */
 							const RoadStop::Entry *entry = rs->GetEntry(dir);
-							cost += entry->GetOccupied() * Yapf().PfGetSettings().road_stop_occupied_penalty / entry->GetLength();
+							cost += entry->GetOccupied(rs, dir) * Yapf().PfGetSettings().road_stop_occupied_penalty / entry->GetLength();
 						}
 					} else {
 						/* Increase cost for filled road stops */

--- a/src/roadstop_base.h
+++ b/src/roadstop_base.h
@@ -32,13 +32,12 @@ struct RoadStop : RoadStopPool::PoolItem<&_roadstop_pool> {
 	struct Entry {
 	private:
 		int length;      ///< The length of the stop in tile 'units'
-		int occupied;    ///< The amount of occupied stop in tile 'units'
 
 	public:
 		friend struct RoadStop; ///< Oh yeah, the road stop may play with me.
 
 		/** Create an entry */
-		Entry() : length(0), occupied(0) {}
+		Entry() : length(0) {}
 
 		/**
 		 * Get the length of this drive through stop.
@@ -49,19 +48,9 @@ struct RoadStop : RoadStopPool::PoolItem<&_roadstop_pool> {
 			return this->length;
 		}
 
-		/**
-		 * Get the amount of occupied space in this drive through stop.
-		 * @return the occupied space in tile units.
-		 */
-		inline int GetOccupied() const
-		{
-			return this->occupied;
-		}
-
-		void Leave(const RoadVehicle *rv);
-		void Enter(const RoadVehicle *rv);
+		int GetOccupied(const RoadStop *rs, const DiagDirection dir) const;
 		void CheckIntegrity(const RoadStop *rs) const;
-		void Rebuild(const RoadStop *rs, int side = -1);
+		void Rebuild(const RoadStop *rs);
 	};
 
 	TileIndex       xy;     ///< Position on the map


### PR DESCRIPTION
## Motivation / Problem

Previous attempts at solving this: #12290, #12402.

The `occupied` counter in RoadStop::Entry does not consider that free space in front a road vehicle loading in a road stop, while vacant might be inaccessible.
In turn, `GetOccupied` would under-report the occupied level to YAPF and road vehicles would drive like lemmings into road stops that didn't actually have any available space.

This change causes RoadStop tiles in front of a road vehicle that is loading to be considered to be occupied regardless of whether they have a vehicle on them or not. 

## Description
This uses a `FindVehicleOnPos` function to check vehicles on the tile when `GetOccupied` is called.

The result is slightly more accurate `cost` values in the YAPF, enough to improve the distribution of road vehicles where multiple entries to a RoadStop are available.

## Limitations

This does come at a small cost to Cargo handling and Road vehicle ticks frame rates, but I believe the improvement in YAPF performance to be worth the cost to fix `GetOccupied`.

Articulated RVs will still try to drive in to road stops that don't have enough space for their full length. This PR however sets up the change to test adding cost penalty when the available space is less than the vehicle length, in a future PR.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
