### PR TITLE
Codechange: Replace separate EffectVehicle arrays.

### DIFF
--- a/src/effectvehicle.cpp
+++ b/src/effectvehicle.cpp
@@ -527,61 +527,33 @@ static bool BubbleTick(EffectVehicle *v)
 	return true;
 }
 
+struct EffectProcs {
+	using InitProc = void(EffectVehicle *);
+	using TickProc = bool(EffectVehicle *);
 
-typedef void EffectInitProc(EffectVehicle *v);
-typedef bool EffectTickProc(EffectVehicle *v);
+	InitProc *init_proc; ///< Function to initialise an effect vehicle after construction.
+	TickProc *tick_proc; ///< Functions for controlling effect vehicles at each tick.
+	TransparencyOption transparency; ///< Transparency option affecting the effect.
 
-/** Functions to initialise an effect vehicle after construction. */
-static EffectInitProc * const _effect_init_procs[] = {
-	ChimneySmokeInit,   // EV_CHIMNEY_SMOKE
-	SteamSmokeInit,     // EV_STEAM_SMOKE
-	DieselSmokeInit,    // EV_DIESEL_SMOKE
-	ElectricSparkInit,  // EV_ELECTRIC_SPARK
-	SmokeInit,          // EV_CRASH_SMOKE
-	ExplosionLargeInit, // EV_EXPLOSION_LARGE
-	BreakdownSmokeInit, // EV_BREAKDOWN_SMOKE
-	ExplosionSmallInit, // EV_EXPLOSION_SMALL
-	BulldozerInit,      // EV_BULLDOZER
-	BubbleInit,         // EV_BUBBLE
-	SmokeInit,          // EV_BREAKDOWN_SMOKE_AIRCRAFT
-	SmokeInit,          // EV_COPPER_MINE_SMOKE
+	constexpr EffectProcs(InitProc *init_proc, TickProc *tick_proc, TransparencyOption transparency)
+		: init_proc(init_proc), tick_proc(tick_proc), transparency(transparency) {}
 };
-static_assert(lengthof(_effect_init_procs) == EV_END);
 
-/** Functions for controlling effect vehicles at each tick. */
-static EffectTickProc * const _effect_tick_procs[] = {
-	ChimneySmokeTick,   // EV_CHIMNEY_SMOKE
-	SteamSmokeTick,     // EV_STEAM_SMOKE
-	DieselSmokeTick,    // EV_DIESEL_SMOKE
-	ElectricSparkTick,  // EV_ELECTRIC_SPARK
-	SmokeTick,          // EV_CRASH_SMOKE
-	ExplosionLargeTick, // EV_EXPLOSION_LARGE
-	BreakdownSmokeTick, // EV_BREAKDOWN_SMOKE
-	ExplosionSmallTick, // EV_EXPLOSION_SMALL
-	BulldozerTick,      // EV_BULLDOZER
-	BubbleTick,         // EV_BUBBLE
-	SmokeTick,          // EV_BREAKDOWN_SMOKE_AIRCRAFT
-	SmokeTick,          // EV_COPPER_MINE_SMOKE
-};
-static_assert(lengthof(_effect_tick_procs) == EV_END);
-
-/** Transparency options affecting the effects. */
-static const TransparencyOption _effect_transparency_options[] = {
-	TO_INDUSTRIES,      // EV_CHIMNEY_SMOKE
-	TO_INVALID,         // EV_STEAM_SMOKE
-	TO_INVALID,         // EV_DIESEL_SMOKE
-	TO_INVALID,         // EV_ELECTRIC_SPARK
-	TO_INVALID,         // EV_CRASH_SMOKE
-	TO_INVALID,         // EV_EXPLOSION_LARGE
-	TO_INVALID,         // EV_BREAKDOWN_SMOKE
-	TO_INVALID,         // EV_EXPLOSION_SMALL
-	TO_INVALID,         // EV_BULLDOZER
-	TO_INDUSTRIES,      // EV_BUBBLE
-	TO_INVALID,         // EV_BREAKDOWN_SMOKE_AIRCRAFT
-	TO_INDUSTRIES,      // EV_COPPER_MINE_SMOKE
-};
-static_assert(lengthof(_effect_transparency_options) == EV_END);
-
+/** Per-EffectVehicleType handling. */
+static std::array<EffectProcs, EV_END> _effect_procs = {{
+	{ ChimneySmokeInit,   ChimneySmokeTick,   TO_INDUSTRIES }, // EV_CHIMNEY_SMOKE
+	{ SteamSmokeInit,     SteamSmokeTick,     TO_INVALID    }, // EV_STEAM_SMOKE
+	{ DieselSmokeInit,    DieselSmokeTick,    TO_INVALID    }, // EV_DIESEL_SMOKE
+	{ ElectricSparkInit,  ElectricSparkTick,  TO_INVALID    }, // EV_ELECTRIC_SPARK
+	{ SmokeInit,          SmokeTick,          TO_INVALID    }, // EV_CRASH_SMOKE
+	{ ExplosionLargeInit, ExplosionLargeTick, TO_INVALID    }, // EV_EXPLOSION_LARGE
+	{ BreakdownSmokeInit, BreakdownSmokeTick, TO_INVALID    }, // EV_BREAKDOWN_SMOKE
+	{ ExplosionSmallInit, ExplosionSmallTick, TO_INVALID    }, // EV_EXPLOSION_SMALL
+	{ BulldozerInit,      BulldozerTick,      TO_INVALID    }, // EV_BULLDOZER
+	{ BubbleInit,         BubbleTick,         TO_INDUSTRIES }, // EV_BUBBLE
+	{ SmokeInit,          SmokeTick,          TO_INVALID    }, // EV_BREAKDOWN_SMOKE_AIRCRAFT
+	{ SmokeInit,          SmokeTick,          TO_INDUSTRIES }, // EV_COPPER_MINE_SMOKE
+}};
 
 /**
  * Create an effect vehicle at a particular location.
@@ -604,7 +576,7 @@ EffectVehicle *CreateEffectVehicle(int x, int y, int z, EffectVehicleType type)
 	v->UpdateDeltaXY();
 	v->vehstatus = VS_UNCLICKABLE;
 
-	_effect_init_procs[type](v);
+	_effect_procs[type].init_proc(v);
 
 	v->UpdatePositionAndViewport();
 
@@ -642,7 +614,7 @@ EffectVehicle *CreateEffectVehicleRel(const Vehicle *v, int x, int y, int z, Eff
 
 bool EffectVehicle::Tick()
 {
-	return _effect_tick_procs[this->subtype](this);
+	return _effect_procs[this->subtype].tick_proc(this);
 }
 
 void EffectVehicle::UpdateDeltaXY()
@@ -660,5 +632,5 @@ void EffectVehicle::UpdateDeltaXY()
  */
 TransparencyOption EffectVehicle::GetTransparencyOption() const
 {
-	return _effect_transparency_options[this->subtype];
+	return _effect_procs[this->subtype].transparency;
 }


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Three separate arrays to determine how EffectVehicles should behave, each with lengthof to ensure it's the correct length.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Combine 3 separate arrays into a single struct. This keeps related data together, and avoids needing to check that each array is same length.

Use of constexpr constructor ensures data in the array is not default-initialised.

Removes lengthof.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
