### PR TITLE
Codechange: Shrink GUIList vectors less often, reserve before use.

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1546,7 +1546,6 @@ struct BuildVehicleWindow : Window {
 			case VEH_TRAIN:
 				this->GenerateBuildTrainList(list);
 				GUIEngineListAddChildren(this->eng_list, list);
-				this->eng_list.shrink_to_fit();
 				this->eng_list.RebuildDone();
 				return;
 			case VEH_ROAD:
@@ -1584,7 +1583,6 @@ struct BuildVehicleWindow : Window {
 
 		this->eng_list.swap(list);
 		GUIEngineListAddChildren(this->eng_list, list, INVALID_ENGINE, 0);
-		this->eng_list.shrink_to_fit();
 		this->eng_list.RebuildDone();
 	}
 

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -650,7 +650,6 @@ private:
 			BuildGuiGroupList(this->groups, false, owner, vtype);
 		}
 
-		this->groups.shrink_to_fit();
 		this->groups.RebuildDone();
 	}
 

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -374,8 +374,6 @@ static void FiosGetFileList(SaveLoadOperation fop, bool show_dirs, FiosGetTypeAn
 
 	/* Show drives */
 	FiosGetDrives(file_list);
-
-	file_list.shrink_to_fit();
 }
 
 /**

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -224,7 +224,6 @@ private:
 
 		BuildGuiGroupList(this->groups, true, owner, this->vli.vtype);
 
-		this->groups.shrink_to_fit();
 		this->groups.RebuildDone();
 	}
 

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1423,6 +1423,7 @@ protected:
 	{
 		if (this->industries.NeedRebuild()) {
 			this->industries.clear();
+			this->industries.reserve(Industry::GetNumItems());
 
 			for (const Industry *i : Industry::Iterate()) {
 				if (this->string_filter.IsEmpty()) {
@@ -1434,7 +1435,6 @@ protected:
 				if (this->string_filter.GetState()) this->industries.push_back(i);
 			}
 
-			this->industries.shrink_to_fit();
 			this->industries.RebuildDone();
 
 			auto filter = std::make_pair(this->accepted_cargo_filter_criteria, this->produced_cargo_filter_criteria);

--- a/src/league_gui.cpp
+++ b/src/league_gui.cpp
@@ -70,12 +70,12 @@ private:
 		if (!this->companies.NeedRebuild()) return;
 
 		this->companies.clear();
+		this->companies.reserve(Company::GetNumItems());
 
 		for (const Company *c : Company::Iterate()) {
 			this->companies.push_back(c);
 		}
 
-		this->companies.shrink_to_fit();
 		this->companies.RebuildDone();
 	}
 

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -421,7 +421,6 @@ class NetworkContentListWindow : public Window, ContentCallback {
 		this->SetWidgetDisabledState(WID_NCL_SEARCH_EXTERNAL, this->auto_select && all_available);
 
 		this->FilterContentList();
-		this->content.shrink_to_fit();
 		this->content.RebuildDone();
 		this->SortContentList();
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -240,7 +240,6 @@ protected:
 			this->servers.SetFilterState(false);
 		}
 
-		this->servers.shrink_to_fit();
 		this->servers.RebuildDone();
 		this->vscroll->SetCount(this->servers.size());
 

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1499,7 +1499,6 @@ private:
 		}
 
 		this->avails.Filter(this->string_filter);
-		this->avails.shrink_to_fit();
 		this->avails.RebuildDone();
 		this->avails.Sort();
 

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -144,6 +144,7 @@ public:
 		if (!this->object_classes.NeedRebuild()) return;
 
 		this->object_classes.clear();
+		this->object_classes.reserve(ObjectClass::GetClassCount());
 
 		for (const auto &cls : ObjectClass::Classes()) {
 			if (cls.GetUISpecCount() == 0) continue; // Is this needed here?
@@ -151,7 +152,6 @@ public:
 		}
 
 		this->object_classes.Filter(this->string_filter);
-		this->object_classes.shrink_to_fit();
 		this->object_classes.RebuildDone();
 		this->object_classes.Sort();
 

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1108,6 +1108,7 @@ public:
 		if (!this->station_classes.NeedRebuild()) return;
 
 		this->station_classes.clear();
+		this->station_classes.reserve(StationClass::GetClassCount());
 
 		for (const auto &cls : StationClass::Classes()) {
 			/* Skip waypoints. */
@@ -1118,7 +1119,6 @@ public:
 
 		if (_railstation.newstations) {
 			this->station_classes.Filter(this->string_filter);
-			this->station_classes.shrink_to_fit();
 			this->station_classes.RebuildDone();
 			this->station_classes.Sort();
 

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1263,6 +1263,7 @@ public:
 		if (!this->roadstop_classes.NeedRebuild()) return;
 
 		this->roadstop_classes.clear();
+		this->roadstop_classes.reserve(RoadStopClass::GetClassCount());
 
 		for (const auto &cls : RoadStopClass::Classes()) {
 			/* Skip waypoints. */
@@ -1272,7 +1273,6 @@ public:
 
 		if (this->ShowNewStops()) {
 			this->roadstop_classes.Filter(this->string_filter);
-			this->roadstop_classes.shrink_to_fit();
 			this->roadstop_classes.RebuildDone();
 			this->roadstop_classes.Sort();
 

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -63,12 +63,12 @@ struct SignList {
 		Debug(misc, 3, "Building sign list");
 
 		this->signs.clear();
+		this->signs.reserve(Sign::GetNumItems());
 
 		for (const Sign *si : Sign::Iterate()) this->signs.push_back(si);
 
 		this->signs.SetFilterState(true);
 		this->FilterSignList();
-		this->signs.shrink_to_fit();
 		this->signs.RebuildDone();
 	}
 

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -296,7 +296,6 @@ protected:
 			}
 		}
 
-		this->stations.shrink_to_fit();
 		this->stations.RebuildDone();
 
 		this->vscroll->SetCount(this->stations.size()); // Update the scrollbar

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -77,7 +77,6 @@ protected:
 				}
 			}
 
-			this->story_pages.shrink_to_fit();
 			this->story_pages.RebuildDone();
 		}
 
@@ -105,7 +104,6 @@ protected:
 				}
 			}
 
-			this->story_page_elements.shrink_to_fit();
 			this->story_page_elements.RebuildDone();
 		}
 

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -734,6 +734,7 @@ private:
 	{
 		if (this->towns.NeedRebuild()) {
 			this->towns.clear();
+			this->towns.reserve(Town::GetNumItems());
 
 			for (const Town *t : Town::Iterate()) {
 				if (this->string_filter.IsEmpty()) {
@@ -745,7 +746,6 @@ private:
 				if (this->string_filter.GetState()) this->towns.push_back(t);
 			}
 
-			this->towns.shrink_to_fit();
 			this->towns.RebuildDone();
 			this->vscroll->SetCount(this->towns.size()); // Update scrollbar as well.
 		}

--- a/src/vehiclelist.cpp
+++ b/src/vehiclelist.cpp
@@ -108,11 +108,6 @@ void BuildDepotVehicleList(VehicleType type, TileIndex tile, VehicleList *engine
 
 	BuildDepotVehicleListData bdvld{engines, wagons, type, individual_wagons};
 	FindVehicleOnPos(tile, &bdvld, BuildDepotVehicleListProc);
-
-	/* Ensure the lists are not wasting too much space. If the lists are fresh
-	 * (i.e. built within a command) then this will actually do nothing. */
-	engines->shrink_to_fit();
-	if (wagons != nullptr && wagons != engines) wagons->shrink_to_fit();
 }
 
 /**
@@ -176,6 +171,5 @@ bool GenerateVehicleSortList(VehicleList *list, const VehicleListIdentifier &vli
 		default: return false;
 	}
 
-	list->shrink_to_fit();
 	return true;
 }


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

After sorting and filter lists for GUI, we often `shrink_to_fit()` them to reduce size. However this has very little benefit:

1) The memory has already been allocated, so it doesn't prevent that memory being required.
2) It causes a new allocation and copy when the vector is shrunk, actually using more memory.
3) The list is in window state, so the lifetime is only while the window is open.
4) When a filter is clearer, the original size will be needed again, which will cause another allocation.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

In fact it is beneficial to `reserve()` to the known maximum in most cases, so do that instead.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
