### PR TITLE
Codechange: use C++ containers for the colour schemes

### DIFF
--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -274,17 +274,16 @@ static const LegendAndColour * const _legend_table[] = {
 
 /** Colour scheme of the smallmap. */
 struct SmallMapColourScheme {
-	uint32_t *height_colours;            ///< Cached colours for each level in a map.
-	const uint32_t *height_colours_base; ///< Base table for determining the colours
-	size_t colour_count;               ///< The number of colours.
+	std::vector<uint32_t> height_colours; ///< Cached colours for each level in a map.
+	std::span<const uint32_t> height_colours_base; ///< Base table for determining the colours
 	uint32_t default_colour;             ///< Default colour of the land.
 };
 
 /** Available colour schemes for height maps. */
 static SmallMapColourScheme _heightmap_schemes[] = {
-	{nullptr, _green_map_heights,      lengthof(_green_map_heights),      MKCOLOUR_XXXX(0x54)}, ///< Green colour scheme.
-	{nullptr, _dark_green_map_heights, lengthof(_dark_green_map_heights), MKCOLOUR_XXXX(0x62)}, ///< Dark green colour scheme.
-	{nullptr, _violet_map_heights,     lengthof(_violet_map_heights),     MKCOLOUR_XXXX(0x81)}, ///< Violet colour scheme.
+	{{}, _green_map_heights,      MKCOLOUR_XXXX(0x54)}, ///< Green colour scheme.
+	{{}, _dark_green_map_heights, MKCOLOUR_XXXX(0x62)}, ///< Dark green colour scheme.
+	{{}, _violet_map_heights,     MKCOLOUR_XXXX(0x81)}, ///< Violet colour scheme.
 };
 
 /**
@@ -293,7 +292,7 @@ static SmallMapColourScheme _heightmap_schemes[] = {
 void BuildLandLegend()
 {
 	/* The smallmap window has never been initialized, so no need to change the legend. */
-	if (_heightmap_schemes[0].height_colours == nullptr) return;
+	if (_heightmap_schemes[0].height_colours.empty()) return;
 
 	/*
 	 * The general idea of this function is to fill the legend with an appropriate evenly spaced
@@ -749,11 +748,11 @@ protected:
 
 		for (auto &heightmap_scheme : _heightmap_schemes) {
 			/* The heights go from 0 up to and including maximum. */
-			int heights = _settings_game.construction.map_height_limit + 1;
-			heightmap_scheme.height_colours = ReallocT<uint32_t>(heightmap_scheme.height_colours, heights);
+			size_t heights = _settings_game.construction.map_height_limit + 1;
+			heightmap_scheme.height_colours.resize(heights);
 
-			for (int z = 0; z < heights; z++) {
-				size_t access_index = (heightmap_scheme.colour_count * z) / heights;
+			for (size_t z = 0; z < heights; z++) {
+				size_t access_index = (heightmap_scheme.height_colours_base.size() * z) / heights;
 
 				/* Choose colour by mapping the range (0..max heightlevel) on the complete colour table. */
 				heightmap_scheme.height_colours[z] = heightmap_scheme.height_colours_base[access_index];


### PR DESCRIPTION
## Motivation / Problem

Using a pointer and size field instead of a `std::span`.
Using manual memory management, over a C++ container.


## Description

Replace the point and size field with `std::span`.
Replace the manual `ReallocT` memory management with a `std::vector` and `resize`.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
