### PR TITLE
Codechange: use ranged for loops

### DIFF
--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -925,16 +925,17 @@ static const Disaster _disasters[] = {
 
 static void DoDisaster()
 {
-	uint8_t buf[lengthof(_disasters)];
+	std::vector<DisasterInitProc *> available_disasters;
 
-	uint8_t j = 0;
-	for (size_t i = 0; i != lengthof(_disasters); i++) {
-		if (TimerGameCalendar::year >= _disasters[i].min_year && TimerGameCalendar::year < _disasters[i].max_year) buf[j++] = (uint8_t)i;
+	for (auto &disaster : _disasters) {
+		if (TimerGameCalendar::year >= disaster.min_year && TimerGameCalendar::year < disaster.max_year) {
+			available_disasters.push_back(disaster.init_proc);
+		}
 	}
 
-	if (j == 0) return;
+	if (available_disasters.empty()) return;
 
-	_disasters[buf[RandomRange(j)]].init_proc();
+	available_disasters[RandomRange(static_cast<uint32_t>(available_disasters.size()))]();
 }
 
 

--- a/src/league_gui.cpp
+++ b/src/league_gui.cpp
@@ -141,11 +141,11 @@ public:
 		this->ordinal_width += WidgetDimensions::scaled.hsep_wide; // Keep some extra spacing
 
 		uint widest_width = 0;
-		uint widest_title = 0;
-		for (uint i = 0; i < lengthof(_performance_titles); i++) {
-			uint width = GetStringBoundingBox(_performance_titles[i]).width;
+		StringID widest_title = STR_NULL;
+		for (auto title : _performance_titles) {
+			uint width = GetStringBoundingBox(title).width;
 			if (width > widest_width) {
-				widest_title = i;
+				widest_title = title;
 				widest_width = width;
 			}
 		}
@@ -156,7 +156,7 @@ public:
 		for (const Company *c : Company::Iterate()) {
 			SetDParam(0, c->index);
 			SetDParam(1, c->index);
-			SetDParam(2, _performance_titles[widest_title]);
+			SetDParam(2, widest_title);
 			widest_width = std::max(widest_width, GetStringBoundingBox(STR_COMPANY_LEAGUE_COMPANY_NAME).width);
 		}
 

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -257,9 +257,9 @@ public:
 				}
 
 				/* Determine the pixel heights. */
-				for (size_t i = 0; i < lengthof(height); i++) {
-					height[i] *= ScaleGUITrad(TILE_HEIGHT);
-					height[i] += ScaleGUITrad(TILE_PIXELS) + 2 * this->object_margin;
+				for (auto &h : height) {
+					h *= ScaleGUITrad(TILE_HEIGHT);
+					h += ScaleGUITrad(TILE_PIXELS) + 2 * this->object_margin;
 				}
 
 				/* Now determine the size of the minimum widgets. When there are two columns, then


### PR DESCRIPTION
## Motivation / Problem

There are some for loops that use `lengthof` that could be simplified by using ranged for loops.


## Description

These are not all direct conversions, as some situations were using the indices after the for loop. In these cases some further refactoring was done to not need to have access to these indices.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
