### PR TITLE
Codefix 37a03b5: the return value of maxdim should always be assigned

### DIFF
--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -368,7 +368,7 @@ public:
 
 			case WID_RV_START_REPLACE: {
 				Dimension d = GetStringBoundingBox(STR_REPLACE_VEHICLES_START);
-				maxdim(d, GetStringListBoundingBox(_start_replace_dropdown));
+				d = maxdim(d, GetStringListBoundingBox(_start_replace_dropdown));
 				d.width += padding.width;
 				d.height += padding.height;
 				size = maxdim(size, d);

--- a/src/core/geometry_func.hpp
+++ b/src/core/geometry_func.hpp
@@ -12,7 +12,7 @@
 
 #include "geometry_type.hpp"
 
-Dimension maxdim(const Dimension &d1, const Dimension &d2);
+[[nodiscard]] Dimension maxdim(const Dimension &d1, const Dimension &d2);
 
 /**
  * Check if a rectangle is empty.

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -660,7 +660,7 @@ struct GenerateLandscapeWindow : public Window {
 			default:
 				return;
 		}
-		maxdim(d, GetStringListBoundingBox(strs));
+		d = maxdim(d, GetStringListBoundingBox(strs));
 		d.width += padding.width;
 		d.height += padding.height;
 		size = maxdim(size, d);


### PR DESCRIPTION
## Motivation / Problem

https://github.com/OpenTTD/OpenTTD/pull/12588/files#r1582242071


## Description

Assign the result of `maxdim` and make it `nodiscard`.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
