### PR TITLE
Codechange: use one RAII method to manage FILE*

### DIFF
--- a/src/dedicated.cpp
+++ b/src/dedicated.cpp
@@ -12,7 +12,7 @@
 #include "debug.h"
 
 std::string _log_file; ///< File to reroute output of a forked OpenTTD to
-std::unique_ptr<FILE, FileDeleter> _log_fd; ///< File to reroute output of a forked OpenTTD to
+AutoCloseFile _log_fd; ///< File to reroute output of a forked OpenTTD to
 
 #if defined(UNIX)
 

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -638,14 +638,14 @@ bool ExtractTar(const std::string &tar_filename, Subdirectory subdir)
 
 		/* First open the file in the .tar. */
 		size_t to_copy = 0;
-		std::unique_ptr<FILE, FileDeleter> in(FioFOpenFileTar(it2.second, &to_copy));
+		AutoCloseFile in(FioFOpenFileTar(it2.second, &to_copy));
 		if (!in) {
 			Debug(misc, 6, "Extracting {} failed; could not open {}", filename, tar_filename);
 			return false;
 		}
 
 		/* Now open the 'output' file. */
-		std::unique_ptr<FILE, FileDeleter> out(fopen(filename.c_str(), "wb"));
+		AutoCloseFile out(fopen(filename.c_str(), "wb"));
 		if (!out) {
 			Debug(misc, 6, "Extracting {} failed; could not open {}", filename, filename);
 			return false;

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -1038,20 +1038,18 @@ void SanitizeFilename(std::string &filename)
  */
 std::unique_ptr<char[]> ReadFileToMem(const std::string &filename, size_t &lenp, size_t maxsize)
 {
-	FILE *in = fopen(filename.c_str(), "rb");
+	AutoCloseFile in(fopen(filename.c_str(), "rb"));
 	if (in == nullptr) return nullptr;
 
-	FileCloser fc(in);
-
-	fseek(in, 0, SEEK_END);
-	size_t len = ftell(in);
-	fseek(in, 0, SEEK_SET);
+	fseek(in.get(), 0, SEEK_END);
+	size_t len = ftell(in.get());
+	fseek(in.get(), 0, SEEK_SET);
 	if (len > maxsize) return nullptr;
 
 	std::unique_ptr<char[]> mem = std::make_unique<char[]>(len + 1);
 
 	mem.get()[len] = 0;
-	if (fread(mem.get(), len, 1, in) != 1) return nullptr;
+	if (fread(mem.get(), len, 1, in.get()) != 1) return nullptr;
 
 	lenp = len;
 	return mem;

--- a/src/fileio_func.h
+++ b/src/fileio_func.h
@@ -81,18 +81,6 @@ public:
 
 DECLARE_ENUM_AS_BIT_SET(TarScanner::Mode)
 
-/** Auto-close a file upon scope exit. */
-class FileCloser {
-	FILE *f;
-
-public:
-	FileCloser(FILE *_f) : f(_f) {}
-	~FileCloser()
-	{
-		fclose(f);
-	}
-};
-
 /** Helper to manage a FILE with a \c std::unique_ptr. */
 struct FileDeleter {
 	void operator()(FILE *f)

--- a/src/fileio_func.h
+++ b/src/fileio_func.h
@@ -81,8 +81,8 @@ public:
 
 DECLARE_ENUM_AS_BIT_SET(TarScanner::Mode)
 
-/** Helper to manage a FILE with a \c std::unique_ptr. */
-struct FileDeleter {
+/** Helper to manage "deleting" a FILE for a \c std::unique_ptr. */
+struct FileCloser {
 	void operator()(FILE *f)
 	{
 		if (f != nullptr) fclose(f);
@@ -90,6 +90,6 @@ struct FileDeleter {
 };
 
 /** Helper type for RAII management of a FILE that gets closed when it goes out of scope. */
-using AutoCloseFile = std::unique_ptr<FILE, FileDeleter>;
+using AutoCloseFile = std::unique_ptr<FILE, FileCloser>;
 
 #endif /* FILEIO_FUNC_H */

--- a/src/fileio_func.h
+++ b/src/fileio_func.h
@@ -97,8 +97,11 @@ public:
 struct FileDeleter {
 	void operator()(FILE *f)
 	{
-		if (f) fclose(f);
+		if (f != nullptr) fclose(f);
 	}
 };
+
+/** Helper type for RAII management of a FILE that gets closed when it goes out of scope. */
+using AutoCloseFile = std::unique_ptr<FILE, FileDeleter>;
 
 #endif /* FILEIO_FUNC_H */

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -49,10 +49,8 @@ void CDECL StrgenFatalI(const std::string &msg)
 LanguageStrings ReadRawLanguageStrings(const std::string &file)
 {
 	size_t to_read;
-	FILE *fh = FioFOpenFile(file, "rb", GAME_DIR, &to_read);
+	AutoCloseFile fh(FioFOpenFile(file, "rb", GAME_DIR, &to_read));
 	if (fh == nullptr) return LanguageStrings();
-
-	FileCloser fhClose(fh);
 
 	auto pos = file.rfind(PATHSEPCHAR);
 	if (pos == std::string::npos) return LanguageStrings();
@@ -64,7 +62,7 @@ LanguageStrings ReadRawLanguageStrings(const std::string &file)
 	LanguageStrings ret(langname.substr(0, langname.find('.')));
 
 	char buffer[2048];
-	while (to_read != 0 && fgets(buffer, sizeof(buffer), fh) != nullptr) {
+	while (to_read != 0 && fgets(buffer, sizeof(buffer), fh.get()) != nullptr) {
 		size_t len = strlen(buffer);
 
 		/* Remove trailing spaces/newlines from the string. */

--- a/src/highscore.cpp
+++ b/src/highscore.cpp
@@ -122,7 +122,7 @@ int8_t SaveHighScoreValueNetwork()
 /** Save HighScore table to file */
 void SaveToHighScore()
 {
-	std::unique_ptr<FILE, FileDeleter> fp(fopen(_highscore_file.c_str(), "wb"));
+	AutoCloseFile fp(fopen(_highscore_file.c_str(), "wb"));
 	if (fp == nullptr) return;
 
 	/* Does not iterate through the complete array!. */
@@ -146,7 +146,7 @@ void LoadFromHighScore()
 {
 	std::fill(_highscore_table.begin(), _highscore_table.end(), HighScores{});
 
-	std::unique_ptr<FILE, FileDeleter> fp(fopen(_highscore_file.c_str(), "rb"));
+	AutoCloseFile fp(fopen(_highscore_file.c_str(), "rb"));
 	if (fp == nullptr) return;
 
 	/* Does not iterate through the complete array!. */

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -104,14 +104,13 @@ uint32_t NewGRFProfiler::Finish()
 	std::string filename = this->GetOutputFilename();
 	IConsolePrint(CC_DEBUG, "Finished profile of NewGRF [{:08X}], writing {} events to '{}'.", BSWAP32(this->grffile->grfid), this->calls.size(), filename);
 
-	FILE *f = FioFOpenFile(filename, "wt", Subdirectory::NO_DIRECTORY);
-	FileCloser fcloser(f);
+	AutoCloseFile f(FioFOpenFile(filename, "wt", Subdirectory::NO_DIRECTORY));
 
 	uint32_t total_microseconds = 0;
 
-	fmt::print(f, "Tick,Sprite,Feature,Item,CallbackID,Microseconds,Depth,Result\n");
+	fmt::print(f.get(), "Tick,Sprite,Feature,Item,CallbackID,Microseconds,Depth,Result\n");
 	for (const Call &c : this->calls) {
-		fmt::print(f, "{},{},{:#X},{},{:#X},{},{},{}\n", c.tick, c.root_sprite, c.feat, c.item, (uint)c.cb, c.time, c.subs, c.result);
+		fmt::print(f.get(), "{},{},{:#X},{},{:#X},{},{},{}\n", c.tick, c.root_sprite, c.feat, c.item, (uint)c.cb, c.time, c.subs, c.result);
 		total_microseconds += c.time;
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Preferably we'd be doing RAII with FILE*, so we do not need to manually manage them getting closed properly in all corner cases of a function.

However, OpenTTD has already sprouted two methods. One via `std::unique_ptr` and one variant where a new object is constructed on the stack to manage closing an already existing FILE*. The latter is close to RAII, but not quite... so I rather get rid of it and use the `std::unique_ptr` variant. Especially as reassigning something to the FILE* does not close the previous version, or could create a double `fclose` which the `std::unique_ptr` does not allow.


## Description

The `std::unique_ptr` variant requires template parameters for the 'deleter', i.e. the thing that releases the resources. To make this less bothersome a type alias `AutoCloseFile` is created and used at all current locations.
The `FileCloser`, the extra object to manage the lifetime of another object, is replaced by `AutoCloseFile`.
Finally rename `FileDeleter` to `FileCloser`, as it's more likely that you'd search for 'FileCloser' for some helper that automatically closes files than a deleter.


## Limitations

Using `std::unique_ptr` you'd need `.get()` to access the `FILE*`, which is somewhat ugly.

This does not add more places where `AutoCloseFile` is used, but a longer term goal should be that no more raw `fclose` calls are made on FILE*s.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
