### PR TITLE
Feature: Engine expiry setting to keep owned engines available for purchase

### DIFF
--- a/src/engine_type.h
+++ b/src/engine_type.h
@@ -195,6 +195,15 @@ enum EngineNameContext : uint8_t {
 	AutoreplaceVehicleInUse = 0x22, ///< Name is show in the autoreplace window 'Vehicles in use' panel.
 };
 
+/**
+ * Possible values of the "engine_expiry" setting.
+ */
+enum EngineExpiryMode : uint8_t {
+	Off = 0,   ///< Engines expire normally.
+	Never = 1, ///< Engines never expire.
+	Owned = 2, ///< Engines which are currently owned by any company never expire. Unowned vehicles expire normally.
+};
+
 /** Combine an engine ID and a name context to an engine name dparam. */
 inline uint64_t PackEngineNameDParam(EngineID engine_id, EngineNameContext context, uint32_t extra_data = 0)
 {

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1492,7 +1492,12 @@ STR_CONFIG_SETTING_WARN_INCOME_LESS_HELPTEXT                    :When enabled, a
 STR_CONFIG_SETTING_WARN_INCOME_LESS_HELPTEXT_PERIOD             :When enabled, a news message gets sent when a vehicle has not made any profit within a period
 
 STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES                        :Vehicles never expire: {STRING2}
-STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES_HELPTEXT               :When enabled, all vehicle models remain available forever after their introduction
+STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES_HELPTEXT               :Choose if vehicle models remain available forever after their introduction
+
+###length 3
+STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES_OFF                    :Off
+STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES_NEVER                  :All available forever
+STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES_OWNED                  :Owned vehicles available forever
 
 STR_CONFIG_SETTING_TIMEKEEPING_UNITS                            :Timekeeping: {STRING2}
 STR_CONFIG_SETTING_TIMEKEEPING_UNITS_HELPTEXT                   :Select the timekeeping units of the game. This cannot be changed later.{}{}Calendar-based is the classic OpenTTD experience, with a year consisting of 12 months, and each month having 28-31 days.{}{}In Wallclock-based time, cargo production and financials are instead based on one-minute increments, which is about as long as a 30 day month takes in Calendar-based mode. These are grouped into 12-minute periods, equivalent to a year in Calendar-based mode.{}{}In either mode there is always a classic calendar, which is used for introduction dates of vehicles, houses, and other infrastructure

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -795,6 +795,11 @@ bool AfterLoadGame()
 		_settings_game.linkgraph.recalc_time     *= CalendarTime::SECONDS_PER_DAY;
 	}
 
+	/* Convert old engine expiry setting. */
+	if (IsSavegameVersionBefore(SLV_ENGINE_EXPIRY_OWNED)) {
+		_settings_game.vehicle.engine_expiry = _settings_game.vehicle.never_expire_vehicles ? EngineExpiryMode::Never : EngineExpiryMode::Off;
+	}
+
 	/* Load the sprites */
 	GfxLoadSprites();
 	LoadStringWidthTable();

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -379,6 +379,8 @@ enum SaveLoadVersion : uint16_t {
 	SLV_SCRIPT_RANDOMIZER,                  ///< 333  PR#12063 v14.0-RC1 Save script randomizers.
 	SLV_VEHICLE_ECONOMY_AGE,                ///< 334  PR#12141 v14.0 Add vehicle age in economy year, for profit stats minimum age
 
+	SLV_ENGINE_EXPIRY_OWNED,                ///< 335  PR#12598 Add engine expiry mode to keep owned engines available for purchase.
+
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2144,7 +2144,7 @@ static SettingsContainer &GetSettingsTree()
 			limitations->Add(new SettingEntry("construction.max_bridge_height"));
 			limitations->Add(new SettingEntry("construction.max_tunnel_length"));
 			limitations->Add(new SettingEntry("station.never_expire_airports"));
-			limitations->Add(new SettingEntry("vehicle.never_expire_vehicles"));
+			limitations->Add(new SettingEntry("vehicle.engine_expiry"));
 			limitations->Add(new SettingEntry("vehicle.max_trains"));
 			limitations->Add(new SettingEntry("vehicle.max_roadveh"));
 			limitations->Add(new SettingEntry("vehicle.max_aircraft"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -14,6 +14,7 @@
 #include "economy_type.h"
 #include "town_type.h"
 #include "transport_type.h"
+#include "engine_type.h"
 #include "network/network_type.h"
 #include "company_type.h"
 #include "cargotype.h"
@@ -516,6 +517,8 @@ struct OrderSettings {
 
 /** Settings related to vehicles. */
 struct VehicleSettings {
+	bool never_expire_vehicles;              ///< Unused value, used to load old savegames.
+
 	uint8_t  max_train_length;                 ///< maximum length for trains
 	uint8_t  smoke_amount;                     ///< amount of smoke/sparks locomotives produce
 	uint8_t  train_acceleration_model;         ///< realistic acceleration for trains
@@ -531,7 +534,7 @@ struct VehicleSettings {
 	uint8_t  plane_speed;                      ///< divisor for speed of aircraft
 	uint8_t  freight_trains;                   ///< value to multiply the weight of cargo by
 	bool   dynamic_engines;                  ///< enable dynamic allocation of engine data
-	bool   never_expire_vehicles;            ///< never expire vehicles
+	EngineExpiryMode engine_expiry;           ///< engine expiry
 	uint8_t extend_vehicle_life;              ///< extend vehicle life by this many years
 	uint8_t road_side;                        ///< the side of the road vehicles drive on
 	uint8_t  plane_crashes;                    ///< number of plane crashes, 0 = none, 1 = reduced, 2 = normal

--- a/src/table/settings/game_settings.ini
+++ b/src/table/settings/game_settings.ini
@@ -10,6 +10,7 @@
 
 [pre-amble]
 static constexpr std::initializer_list<const char*> _roadsides{"left", "right"};
+static constexpr std::initializer_list<const char*> _engine_expiry_modes{"off", "never", "owned"};
 
 static void StationSpreadChanged(int32_t new_value);
 static void UpdateConsists(int32_t new_value);
@@ -243,8 +244,21 @@ strval   = STR_CONFIG_SETTING_NONE
 var      = vehicle.never_expire_vehicles
 flags    = SF_NO_NETWORK
 def      = false
+to       = SLV_ENGINE_EXPIRY_OWNED
+
+[SDT_OMANY]
+var      = vehicle.engine_expiry
+type     = SLE_UINT8
+from     = SLV_ENGINE_EXPIRY_OWNED
+flags    = SF_GUI_DROPDOWN | SF_NO_NETWORK
+def      = EngineExpiryMode::Off
+min      = EngineExpiryMode::Off
+max      = EngineExpiryMode::Owned
+full     = _engine_expiry_modes
 str      = STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES
 strhelp  = STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES_HELPTEXT
+strval   = STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES_OFF
+cat      = SC_BASIC
 
 [SDT_VAR]
 var      = vehicle.max_trains


### PR DESCRIPTION
## Motivation / Problem

@andythenorth and others want to roleplay with their favorite trains forever, yet continue the passage of time.

We have "vehicles never expire" for this, but it's too big a hammer with a GRF like Iron Horse.

## Description

Extend the vehicle expiry setting to add a third option: Engines that are owned by any company remain available for purchase, while unowned vehicles expire normally.

While I'm renaming things, this setting is about engine expiry, not vehicle expiry. 😃 

## Limitations

Iterating through all vehicles every time `CalcEngineReliability()` is called feels expensive. We should probably cache a list of currently-owned engines and update it using a timer, once per economy month (about a minute). I could use some help determining the proper way to do this. 🙂 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
