### PR TITLE
Codechange: Use Recv/Send_bytes for md5sum.

### DIFF
--- a/src/network/core/network_game_info.cpp
+++ b/src/network/core/network_game_info.cpp
@@ -375,9 +375,7 @@ void DeserializeNetworkGameInfo(Packet &p, NetworkGameInfo &info, const GameInfo
 void SerializeGRFIdentifier(Packet &p, const GRFIdentifier &grf)
 {
 	p.Send_uint32(grf.grfid);
-	for (size_t j = 0; j < grf.md5sum.size(); j++) {
-		p.Send_uint8(grf.md5sum[j]);
-	}
+	p.Send_bytes(grf.md5sum);
 }
 
 /**
@@ -388,9 +386,7 @@ void SerializeGRFIdentifier(Packet &p, const GRFIdentifier &grf)
 void DeserializeGRFIdentifier(Packet &p, GRFIdentifier &grf)
 {
 	grf.grfid = p.Recv_uint32();
-	for (size_t j = 0; j < grf.md5sum.size(); j++) {
-		grf.md5sum[j] = p.Recv_uint8();
-	}
+	p.Recv_bytes(grf.md5sum);
 }
 
 /**

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -63,9 +63,7 @@ bool ClientNetworkContentSocketHandler::Receive_SERVER_INFO(Packet &p)
 	ci->description = p.Recv_string(NETWORK_CONTENT_DESC_LENGTH, SVS_REPLACE_WITH_QUESTION_MARK | SVS_ALLOW_NEWLINE);
 
 	ci->unique_id = p.Recv_uint32();
-	for (size_t j = 0; j < ci->md5sum.size(); j++) {
-		ci->md5sum[j] = p.Recv_uint8();
-	}
+	p.Recv_bytes(ci->md5sum);
 
 	uint dependency_count = p.Recv_uint8();
 	ci->dependencies.reserve(dependency_count);
@@ -276,10 +274,7 @@ void ClientNetworkContentSocketHandler::RequestContentList(ContentVector *cv, bo
 		p->Send_uint8((uint8_t)ci->type);
 		p->Send_uint32(ci->unique_id);
 		if (!send_md5sum) continue;
-
-		for (size_t j = 0; j < ci->md5sum.size(); j++) {
-			p->Send_uint8(ci->md5sum[j]);
-		}
+		p->Send_bytes(ci->md5sum);
 	}
 
 	this->SendPacket(std::move(p));


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When sending md5sum in network packets, we loop through each element and send or receive it into the packet buffer byte-by-byte.

But `Send_bytes()` and `Recv_bytes()` exist which can do this for us.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use existing `Send_bytes()` and `Recv_bytes()` functions to handle serialisation of md5sum arrays instead of indexed for-loop.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
