### PR TITLE
Feature: Add font picker to the game settings.

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2233,7 +2233,7 @@ DEF_CONSOLE_CMD(ConFont)
 		FontCacheSubSetting *setting = GetFontCacheSubSetting(fs);
 		/* Make sure all non sprite fonts are loaded. */
 		if (!setting->font.empty() && !fc->HasParent()) {
-			InitFontCache(fs == FS_MONO);
+			InitFontCache();
 			fc = FontCache::Get(fs);
 		}
 		IConsolePrint(CC_DEFAULT, "{} font:", FontSizeToName(fs));

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -38,23 +38,24 @@ extern std::string _config_file;
 extern std::string _highscore_file;
 
 static const char * const _subdirs[] = {
-	"",
-	"save" PATHSEP,
-	"save" PATHSEP "autosave" PATHSEP,
-	"scenario" PATHSEP,
-	"scenario" PATHSEP "heightmap" PATHSEP,
-	"gm" PATHSEP,
-	"data" PATHSEP,
-	"baseset" PATHSEP,
-	"newgrf" PATHSEP,
-	"lang" PATHSEP,
-	"ai" PATHSEP,
-	"ai" PATHSEP "library" PATHSEP,
-	"game" PATHSEP,
-	"game" PATHSEP "library" PATHSEP,
-	"screenshot" PATHSEP,
-	"social_integration" PATHSEP,
+	"",                                     ///< BASE_DIR
+	"save" PATHSEP,                         ///< SAVE_DIR
+	"save" PATHSEP "autosave" PATHSEP,      ///< AUTOSAVE_DIR
+	"scenario" PATHSEP,                     ///< SCENARIO_DIR
+	"scenario" PATHSEP "heightmap" PATHSEP, ///< HEIGHTMAP_DIR
+	"gm" PATHSEP,                           ///< OLD_GM_DIR
+	"data" PATHSEP,                         ///< OLD_DATA_DIR
+	"baseset" PATHSEP,                      ///< BASESET_DIR
+	"newgrf" PATHSEP,                       ///< NEWGRF_DIR
+	"lang" PATHSEP,                         ///< LANG_DIR
+	"ai" PATHSEP,                           ///< AI_DIR
+	"ai" PATHSEP "library" PATHSEP,         ///< AI_LIBRARY_DIR
+	"game" PATHSEP,                         ///< GAME_DIR
+	"game" PATHSEP "library" PATHSEP,       ///< GAME_LIBRARY_DIR
+	"screenshot" PATHSEP,                   ///< SCREENSHOT_DIR
+	"social_integration" PATHSEP,           ///< SOCIAL_INTEGRATION_DIR
 };
+// This should line up with the "Subdirectory" enum defined in fileio_type.h
 static_assert(lengthof(_subdirs) == NUM_SUBDIRS);
 
 /**

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -54,6 +54,7 @@ static const char * const _subdirs[] = {
 	"game" PATHSEP "library" PATHSEP,       ///< GAME_LIBRARY_DIR
 	"screenshot" PATHSEP,                   ///< SCREENSHOT_DIR
 	"social_integration" PATHSEP,           ///< SOCIAL_INTEGRATION_DIR
+	"baseset" PATHSEP,                      ///< FONT_DIR
 };
 // This should line up with the "Subdirectory" enum defined in fileio_type.h
 static_assert(lengthof(_subdirs) == NUM_SUBDIRS);

--- a/src/fileio_type.h
+++ b/src/fileio_type.h
@@ -109,24 +109,24 @@ inline DetailedFileType GetDetailedFileType(FiosType fios_type)
  * The different kinds of subdirectories OpenTTD uses
  */
 enum Subdirectory {
-	BASE_DIR,      ///< Base directory for all subdirectories
-	SAVE_DIR,      ///< Base directory for all savegames
-	AUTOSAVE_DIR,  ///< Subdirectory of save for autosaves
-	SCENARIO_DIR,  ///< Base directory for all scenarios
-	HEIGHTMAP_DIR, ///< Subdirectory of scenario for heightmaps
-	OLD_GM_DIR,    ///< Old subdirectory for the music
-	OLD_DATA_DIR,  ///< Old subdirectory for the data.
-	BASESET_DIR,   ///< Subdirectory for all base data (base sets, intro game)
-	NEWGRF_DIR,    ///< Subdirectory for all NewGRFs
-	LANG_DIR,      ///< Subdirectory for all translation files
-	AI_DIR,        ///< Subdirectory for all %AI files
-	AI_LIBRARY_DIR,///< Subdirectory for all %AI libraries
-	GAME_DIR,      ///< Subdirectory for all game scripts
-	GAME_LIBRARY_DIR, ///< Subdirectory for all GS libraries
-	SCREENSHOT_DIR,   ///< Subdirectory for all screenshots
+	BASE_DIR,               ///< Base directory for all subdirectories
+	SAVE_DIR,               ///< Base directory for all savegames
+	AUTOSAVE_DIR,           ///< Subdirectory of save for autosaves
+	SCENARIO_DIR,           ///< Base directory for all scenarios
+	HEIGHTMAP_DIR,          ///< Subdirectory of scenario for heightmaps
+	OLD_GM_DIR,             ///< Old subdirectory for the music
+	OLD_DATA_DIR,           ///< Old subdirectory for the data.
+	BASESET_DIR,            ///< Subdirectory for all base data (base sets, intro game)
+	NEWGRF_DIR,             ///< Subdirectory for all NewGRFs
+	LANG_DIR,               ///< Subdirectory for all translation files
+	AI_DIR,                 ///< Subdirectory for all %AI files
+	AI_LIBRARY_DIR,         ///< Subdirectory for all %AI libraries
+	GAME_DIR,               ///< Subdirectory for all game scripts
+	GAME_LIBRARY_DIR,       ///< Subdirectory for all GS libraries
+	SCREENSHOT_DIR,         ///< Subdirectory for all screenshots
 	SOCIAL_INTEGRATION_DIR, ///< Subdirectory for all social integration plugins
-	NUM_SUBDIRS,   ///< Number of subdirectories
-	NO_DIRECTORY,  ///< A path without any base directory
+	NUM_SUBDIRS,            ///< Number of subdirectories
+	NO_DIRECTORY,           ///< A path without any base directory
 };
 
 /**
@@ -134,17 +134,17 @@ enum Subdirectory {
  */
 enum Searchpath : unsigned {
 	SP_FIRST_DIR,
-	SP_WORKING_DIR = SP_FIRST_DIR, ///< Search in the working directory
+	SP_WORKING_DIR = SP_FIRST_DIR,    ///< Search in the working directory
 #ifdef USE_XDG
-	SP_PERSONAL_DIR_XDG,           ///< Search in the personal directory from the XDG specification
+	SP_PERSONAL_DIR_XDG,              ///< Search in the personal directory from the XDG specification
 #endif
-	SP_PERSONAL_DIR,               ///< Search in the personal directory
-	SP_SHARED_DIR,                 ///< Search in the shared directory, like 'Shared Files' under Windows
-	SP_BINARY_DIR,                 ///< Search in the directory where the binary resides
-	SP_INSTALLATION_DIR,           ///< Search in the installation directory
-	SP_APPLICATION_BUNDLE_DIR,     ///< Search within the application bundle
-	SP_AUTODOWNLOAD_DIR,           ///< Search within the autodownload directory
-	SP_AUTODOWNLOAD_PERSONAL_DIR,  ///< Search within the autodownload directory located in the personal directory
+	SP_PERSONAL_DIR,                  ///< Search in the personal directory
+	SP_SHARED_DIR,                    ///< Search in the shared directory, like 'Shared Files' under Windows
+	SP_BINARY_DIR,                    ///< Search in the directory where the binary resides
+	SP_INSTALLATION_DIR,              ///< Search in the installation directory
+	SP_APPLICATION_BUNDLE_DIR,        ///< Search within the application bundle
+	SP_AUTODOWNLOAD_DIR,              ///< Search within the autodownload directory
+	SP_AUTODOWNLOAD_PERSONAL_DIR,     ///< Search within the autodownload directory located in the personal directory
 	SP_AUTODOWNLOAD_PERSONAL_DIR_XDG, ///< Search within the autodownload directory located in the personal directory (XDG variant)
 	NUM_SEARCHPATHS
 };

--- a/src/fileio_type.h
+++ b/src/fileio_type.h
@@ -40,6 +40,9 @@ enum DetailedFileType {
 	DFT_FIOS_DIR,    ///< A directory entry.
 	DFT_FIOS_DIRECT, ///< Direct filename.
 
+	/* Ending variable used for compile time check of this array against _fios_colours in fiose_gui.cpp */
+	DFT_END,
+
 	DFT_INVALID = 255, ///< Unknown or invalid file.
 };
 

--- a/src/fileio_type.h
+++ b/src/fileio_type.h
@@ -18,6 +18,7 @@ enum AbstractFileType {
 	FT_SAVEGAME,  ///< old or new savegame
 	FT_SCENARIO,  ///< old or new scenario
 	FT_HEIGHTMAP, ///< heightmap file
+	FT_FONT,      ///< font file
 
 	FT_INVALID = 7, ///< Invalid or unknown file type.
 	FT_NUMBITS = 3, ///< Number of bits required for storing a #AbstractFileType value.
@@ -34,6 +35,9 @@ enum DetailedFileType {
 	DFT_HEIGHTMAP_BMP, ///< BMP file.
 	DFT_HEIGHTMAP_PNG, ///< PNG file.
 
+	/* UI Resource files: */
+	DFT_FONT_FILE, ///< A font file
+
 	/* fios 'files' */
 	DFT_FIOS_DRIVE,  ///< A drive (letter) entry.
 	DFT_FIOS_PARENT, ///< A parent directory entry.
@@ -48,9 +52,13 @@ enum DetailedFileType {
 
 /** Operation performed on the file. */
 enum SaveLoadOperation {
-	SLO_CHECK,   ///< Load file for checking and/or preview.
-	SLO_LOAD,    ///< File is being loaded.
-	SLO_SAVE,    ///< File is being saved.
+	SLO_CHECK,                ///< Load file for checking and/or preview.
+	SLO_LOAD,                 ///< File is being loaded.
+	SLO_SAVE,                 ///< File is being saved.
+	SLO_LOAD_SMALL_FONT,      ///< Load small font
+	SLO_LOAD_MEDIUM_FONT,     ///< Load medium font
+	SLO_LOAD_LARGE_FONT,      ///< Load large font
+	SLO_LOAD_MONOSPACED_FONT, ///< Load monospaced font
 
 	SLO_INVALID, ///< Unknown file operation.
 };
@@ -79,6 +87,7 @@ enum FiosType {
 	FIOS_TYPE_OLD_SCENARIO = MAKE_FIOS_TYPE(FT_SCENARIO, DFT_OLD_GAME_FILE),
 	FIOS_TYPE_PNG          = MAKE_FIOS_TYPE(FT_HEIGHTMAP, DFT_HEIGHTMAP_PNG),
 	FIOS_TYPE_BMP          = MAKE_FIOS_TYPE(FT_HEIGHTMAP, DFT_HEIGHTMAP_BMP),
+	FIOS_TYPE_FONT         = MAKE_FIOS_TYPE(FT_FONT, DFT_FONT_FILE),
 
 	FIOS_TYPE_INVALID = MAKE_FIOS_TYPE(FT_INVALID, DFT_INVALID),
 };
@@ -125,6 +134,7 @@ enum Subdirectory {
 	GAME_LIBRARY_DIR,       ///< Subdirectory for all GS libraries
 	SCREENSHOT_DIR,         ///< Subdirectory for all screenshots
 	SOCIAL_INTEGRATION_DIR, ///< Subdirectory for all social integration plugins
+	FONT_DIR,               ///< Subdirectory for all of OpenTTD's fonts.
 	NUM_SUBDIRS,            ///< Number of subdirectories
 	NO_DIRECTORY,           ///< A path without any base directory
 };
@@ -146,6 +156,7 @@ enum Searchpath : unsigned {
 	SP_AUTODOWNLOAD_DIR,              ///< Search within the autodownload directory
 	SP_AUTODOWNLOAD_PERSONAL_DIR,     ///< Search within the autodownload directory located in the personal directory
 	SP_AUTODOWNLOAD_PERSONAL_DIR_XDG, ///< Search within the autodownload directory located in the personal directory (XDG variant)
+	SP_SYSTEM_FONT_PATH,              ///< Search within the system font directory
 	NUM_SEARCHPATHS
 };
 

--- a/src/fios.h
+++ b/src/fios.h
@@ -107,6 +107,7 @@ void ShowSaveLoadDialog(AbstractFileType abstract_filetype, SaveLoadOperation fo
 void FiosGetSavegameList(SaveLoadOperation fop, bool show_dirs, FileList &file_list);
 void FiosGetScenarioList(SaveLoadOperation fop, bool show_dirs, FileList &file_list);
 void FiosGetHeightmapList(SaveLoadOperation fop, bool show_dirs, FileList &file_list);
+void FiosGetFontList(SaveLoadOperation fop, bool show_dirs, FileList &file_list);
 
 bool FiosBrowseTo(const FiosItem *item);
 
@@ -119,6 +120,7 @@ std::string FiosMakeSavegameName(const char *name);
 std::tuple<FiosType, std::string> FiosGetSavegameListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext);
 std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext);
 std::tuple<FiosType, std::string> FiosGetHeightmapListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext);
+std::tuple<FiosType, std::string> FiosGetFontListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext);
 
 void ScanScenarios();
 const char *FindScenario(const ContentInfo *ci, bool md5sum);

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -238,7 +238,8 @@ static const TextColour _fios_colours[] = {
 	TC_DARK_GREEN,   // DFT_FIOS_DIR
 	TC_ORANGE,       // DFT_FIOS_DIRECT
 };
-
+/* This should align with the DetailedFileType enum defined in fileio_type.h */
+static_assert (lengthof(_fios_colours) == DFT_END);
 
 /**
  * Sort the collected list save games prior to displaying it in the save/load gui.

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -239,10 +239,13 @@ inline FontCacheSubSetting *GetFontCacheSubSetting(FontSize fs)
 	}
 }
 
-void InitFontCache(bool monospace);
+void DebugPrintFontSettings(const std::string& desc);
+
+void InitFontCache();
 void UninitFontCache();
 
 bool GetFontAAState();
 void SetFont(FontSize fontsize, const std::string &font, uint size);
+void ResizeFont(FontSize fontsize, uint size);
 
 #endif /* FONTCACHE_H */

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -115,7 +115,7 @@ void FreeTypeFontCache::SetFontSize(FontSize, FT_Face, int pixels)
 	}
 }
 
-static FT_Error LoadFont(FontSize fs, FT_Face face, const char *font_name, uint size)
+static FT_Error LoadFont(FontSize fs, FT_Face face, [[maybe_unused]] const char *font_name, uint size)
 {
 	Debug(fontcache, 2, "Requested '{}', using '{} {}'", font_name, face->family_name, face->style_name);
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -947,6 +947,8 @@ STR_GAME_OPTIONS_TAB_GENERAL                                    :General
 STR_GAME_OPTIONS_TAB_GENERAL_TT                                 :{BLACK}Choose general settings
 STR_GAME_OPTIONS_TAB_GRAPHICS                                   :Graphics
 STR_GAME_OPTIONS_TAB_GRAPHICS_TT                                :{BLACK}Choose graphics settings
+STR_GAME_OPTIONS_TAB_FONTS                                      :Fonts
+STR_GAME_OPTIONS_TAB_FONTS_TT                                   :{BLACK}Choose font settings
 STR_GAME_OPTIONS_TAB_SOUND                                      :Sound
 STR_GAME_OPTIONS_TAB_SOUND_TT                                   :{BLACK}Choose sound and music settings
 STR_GAME_OPTIONS_TAB_SOCIAL                                     :Social
@@ -1049,6 +1051,19 @@ STR_GAME_OPTIONS_GUI_SCALE_AUTO_TOOLTIP                         :{BLACK}Check th
 STR_GAME_OPTIONS_GUI_SCALE_BEVELS                               :{BLACK}Scale bevels
 STR_GAME_OPTIONS_GUI_SCALE_BEVELS_TOOLTIP                       :{BLACK}Check this box to scale bevels by interface size
 
+STR_GAME_OPTIONS_SMALL_FONT_FRAME                               :{BLACK}Small font
+STR_GAME_OPTIONS_LOAD_SMALL_FONT_TOOLTIP                        :{BLACK}Choose small font. Used in map legends and on graphs.
+STR_GAME_OPTIONS_SMALL_FONT_SIZE_SLIDER_TOOLTIP                 :{BLACK}Drag to change the small size
+STR_GAME_OPTIONS_MEDIUM_FONT_FRAME                              :{BLACK}Medium font
+STR_GAME_OPTIONS_LOAD_MEDIUM_FONT_TOOLTIP                       :{BLACK}Choose medium font. Most text is displayed using this font.
+STR_GAME_OPTIONS_MEDIUM_FONT_SIZE_SLIDER_TOOLTIP                :{BLACK}Drag to change the medium font size
+STR_GAME_OPTIONS_LARGE_FONT_FRAME                               :{BLACK}Large font
+STR_GAME_OPTIONS_LOAD_LARGE_FONT_TOOLTIP                        :{BLACK}Choose large font. Used to display News headlines.
+STR_GAME_OPTIONS_LARGE_FONT_SIZE_SLIDER_TOOLTIP                 :{BLACK}Drag to change the large font size
+STR_GAME_OPTIONS_MONOSPACED_FONT_FRAME                          :{BLACK}Monospaced font
+STR_GAME_OPTIONS_LOAD_MONOSPACED_FONT_TOOLTIP                   :{BLACK}Choose monospaced font.  Used to display the Readme and other documents.
+STR_GAME_OPTIONS_MONOSPACED_FONT_SIZE_SLIDER_TOOLTIP            :{BLACK}Drag to change the monospaced font size
+STR_GAME_OPTIONS_FONT_SIZE                                      :{BLACK}Size:
 STR_GAME_OPTIONS_GUI_FONT_SPRITE                                :{BLACK}Use traditional sprite font
 STR_GAME_OPTIONS_GUI_FONT_SPRITE_TOOLTIP                        :{BLACK}Check this box if you prefer to use the traditional fixed-size sprite font
 STR_GAME_OPTIONS_GUI_FONT_AA                                    :{BLACK}Anti-alias fonts
@@ -3257,6 +3272,10 @@ STR_SAVELOAD_SAVE_SCENARIO                                      :{WHITE}Save Sce
 STR_SAVELOAD_LOAD_SCENARIO                                      :{WHITE}Load Scenario
 STR_SAVELOAD_LOAD_HEIGHTMAP                                     :{WHITE}Load Heightmap
 STR_SAVELOAD_SAVE_HEIGHTMAP                                     :{WHITE}Save Heightmap
+STR_SAVELOAD_LOAD_SMALL_FONT_CAPTION                            :{WHITE}Load Small Font
+STR_SAVELOAD_LOAD_MEDIUM_FONT_CAPTION                           :{WHITE}Load Medium Font
+STR_SAVELOAD_LOAD_LARGE_FONT_CAPTION                            :{WHITE}Load Large Font
+STR_SAVELOAD_LOAD_MONOSPACED_FONT_CAPTION                       :{WHITE}Load Monospaced Font
 STR_SAVELOAD_HOME_BUTTON                                        :{BLACK}Click here to jump to the current default save/load directory
 STR_SAVELOAD_BYTES_FREE                                         :{BLACK}{BYTES} free
 STR_SAVELOAD_LIST_TOOLTIP                                       :{BLACK}List of drives, directories and saved-game files
@@ -3268,6 +3287,9 @@ STR_SAVELOAD_SAVE_TOOLTIP                                       :{BLACK}Save the
 STR_SAVELOAD_LOAD_BUTTON                                        :{BLACK}Load
 STR_SAVELOAD_LOAD_TOOLTIP                                       :{BLACK}Load the selected game
 STR_SAVELOAD_LOAD_HEIGHTMAP_TOOLTIP                             :{BLACK}Load the selected heightmap
+STR_SAVELOAD_LOAD_FONT_TOOLTIP                                  :{BLACK}Load the selected font
+STR_SAVELOAD_USE_DEFAULT_FONT                                   :{BLACK}Use Default Font
+STR_SAVELOAD_USE_DEFAULT_FONT_TOOLTIP                           :{BLACK}Use the default TTF font provided with OpenTTD.
 STR_SAVELOAD_DETAIL_CAPTION                                     :{BLACK}Game Details
 STR_SAVELOAD_DETAIL_NOT_AVAILABLE                               :{BLACK}No information available
 STR_SAVELOAD_DETAIL_COMPANY_INDEX                               :{SILVER}{COMMA}: {WHITE}{STRING1}

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -699,7 +699,7 @@ int openttd_main(std::span<char * const> arguments)
 	InitializeLanguagePacks();
 
 	/* Initialize the font cache */
-	InitFontCache(false);
+	InitFontCache();
 
 	/* This must be done early, since functions use the SetWindowDirty* calls */
 	InitWindowSystem();

--- a/src/os/unix/font_unix.cpp
+++ b/src/os/unix/font_unix.cpp
@@ -169,7 +169,7 @@ bool SetFallbackFont(FontCacheSettings *settings, const std::string &language_is
 		if (best_font != nullptr) {
 			ret = true;
 			callback->SetFontNames(settings, best_font, &best_index);
-			InitFontCache(callback->Monospace());
+			InitFontCache();
 		}
 
 		/* Clean up the list of filenames. */

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2157,7 +2157,7 @@ const char *GetCurrentLanguageIsoCode()
  */
 bool MissingGlyphSearcher::FindMissingGlyphs()
 {
-	InitFontCache(this->Monospace());
+	InitFontCache();
 	const Sprite *question_mark[FS_END];
 
 	for (FontSize size = this->Monospace() ? FS_MONO : FS_BEGIN; size < (this->Monospace() ? FS_END : FS_MONO); size++) {
@@ -2293,7 +2293,7 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 			/* Our fallback font does miss characters too, so keep the
 			 * user chosen font as that is more likely to be any good than
 			 * the wild guess we made */
-			InitFontCache(searcher->Monospace());
+			InitFontCache();
 		}
 	}
 #endif

--- a/src/widgets/fios_widget.h
+++ b/src/widgets/fios_widget.h
@@ -22,6 +22,7 @@ enum SaveLoadWidgets : WidgetID {
 	WID_SL_DRIVES_DIRECTORIES_LIST, ///< Drives list.
 	WID_SL_SCROLLBAR,               ///< Scrollbar of the file list.
 	WID_SL_CONTENT_DOWNLOAD,        ///< Content download button, only available for play scenario/heightmap.
+	WID_SL_USE_DEFAULT_FONT,        ///< Click to use the default TTF OpenTTD provided font for a given font size.
 	WID_SL_SAVE_OSK_TITLE,          ///< Title textbox, only available for save operations.
 	WID_SL_DELETE_SELECTION,        ///< Delete button, only available for save operations.
 	WID_SL_SAVE_GAME,               ///< Save button, only available for save operations.

--- a/src/widgets/settings_widget.h
+++ b/src/widgets/settings_widget.h
@@ -12,52 +12,63 @@
 
 /** Widgets of the #GameOptionsWindow class. */
 enum GameOptionsWidgets : WidgetID {
-	WID_GO_TAB_GENERAL,            ///< General tab.
-	WID_GO_TAB_GRAPHICS,           ///< Graphics tab.
-	WID_GO_TAB_SOUND,              ///< Sound tab.
-	WID_GO_TAB_SOCIAL,             ///< Social tab.
-	WID_GO_TAB_SELECTION,          ///< Background of the tab selection.
-	WID_GO_CURRENCY_DROPDOWN,      ///< Currency dropdown.
-	WID_GO_DISTANCE_DROPDOWN,      ///< Measuring unit dropdown.
-	WID_GO_AUTOSAVE_DROPDOWN,      ///< Dropdown to say how often to autosave.
-	WID_GO_LANG_DROPDOWN,          ///< Language dropdown.
-	WID_GO_RESOLUTION_DROPDOWN,    ///< Dropdown for the resolution.
-	WID_GO_FULLSCREEN_BUTTON,      ///< Toggle fullscreen.
-	WID_GO_GUI_SCALE,              ///< GUI Scale slider.
-	WID_GO_GUI_SCALE_AUTO,         ///< Autodetect GUI scale button.
-	WID_GO_GUI_SCALE_BEVEL_BUTTON, ///< Toggle for chunky bevels.
-	WID_GO_GUI_FONT_SPRITE,        ///< Toggle whether to prefer the sprite font over TTF fonts.
-	WID_GO_GUI_FONT_AA,            ///< Toggle whether to anti-alias fonts.
-	WID_GO_BASE_GRF_DROPDOWN,      ///< Use to select a base GRF.
-	WID_GO_BASE_GRF_PARAMETERS,    ///< Base GRF parameters.
-	WID_GO_BASE_GRF_OPEN_URL,      ///< Open base GRF URL.
-	WID_GO_BASE_GRF_TEXTFILE,      ///< Open base GRF readme, changelog (+1) or license (+2).
+	WID_GO_TAB_GENERAL,                      ///< General tab.
+	WID_GO_TAB_GRAPHICS,                     ///< Graphics tab.
+	WID_GO_TAB_FONTS,                        ///< Fonts tab.
+	WID_GO_TAB_SOUND,                        ///< Sound tab.
+	WID_GO_TAB_SOCIAL,                       ///< Social tab.
+	WID_GO_TAB_SELECTION,                    ///< Background of the tab selection.
+	WID_GO_CURRENCY_DROPDOWN,                ///< Currency dropdown.
+	WID_GO_DISTANCE_DROPDOWN,                ///< Measuring unit dropdown.
+	WID_GO_AUTOSAVE_DROPDOWN,                ///< Dropdown to say how often to autosave.
+	WID_GO_LANG_DROPDOWN,                    ///< Language dropdown.
+	WID_GO_RESOLUTION_DROPDOWN,              ///< Dropdown for the resolution.
+	WID_GO_FULLSCREEN_BUTTON,                ///< Toggle fullscreen.
+	WID_GO_GUI_SCALE,                        ///< GUI Scale slider.
+	WID_GO_GUI_SCALE_AUTO,                   ///< Autodetect GUI scale button.
+	WID_GO_GUI_SCALE_BEVEL_BUTTON,           ///< Toggle for chunky bevels.
+	WID_GO_FONT_SPRITE,                      ///< Toggle whether to prefer the sprite font over TTF fonts.
+	WID_GO_FONT_AA,                          ///< Toggle whether to anti-alias fonts.
+	WID_GO_TEXT_FONT,                        ///< Font label
+	WID_GO_TEXT_FONT_SIZE,                   ///< Font size label.
+	WID_GO_FONT_LOAD_MEDIUM_FONT,            ///< Load medium font button.
+	WID_GO_FONT_MEDIUM_FONT_SIZE_SLIDER,     ///< Medium font size slider.
+	WID_GO_FONT_LOAD_SMALL_FONT,             ///< Load small font button.
+	WID_GO_FONT_SMALL_FONT_SIZE_SLIDER,      ///< Small font size slider.
+	WID_GO_FONT_LOAD_LARGE_FONT,             ///< Load large font button.
+	WID_GO_FONT_LARGE_FONT_SIZE_SLIDER,      ///< Large font size slider.
+	WID_GO_FONT_LOAD_MONOSPACED_FONT,        ///< Load monospaced font button.
+	WID_GO_FONT_MONOSPACED_FONT_SIZE_SLIDER, ///< Monospaced font size slider.
+	WID_GO_BASE_GRF_DROPDOWN,                ///< Use to select a base GRF.
+	WID_GO_BASE_GRF_PARAMETERS,              ///< Base GRF parameters.
+	WID_GO_BASE_GRF_OPEN_URL,                ///< Open base GRF URL.
+	WID_GO_BASE_GRF_TEXTFILE,                ///< Open base GRF readme, changelog (+1) or license (+2).
 	WID_GO_BASE_GRF_DESCRIPTION = WID_GO_BASE_GRF_TEXTFILE + TFT_CONTENT_END,     ///< Description of selected base GRF.
-	WID_GO_BASE_SFX_DROPDOWN,      ///< Use to select a base SFX.
-	WID_GO_TEXT_SFX_VOLUME,        ///< Sound effects volume label.
-	WID_GO_BASE_SFX_VOLUME,        ///< Change sound effects volume.
-	WID_GO_BASE_SFX_OPEN_URL,      ///< Open base SFX URL.
-	WID_GO_BASE_SFX_TEXTFILE,      ///< Open base SFX readme, changelog (+1) or license (+2).
+	WID_GO_BASE_SFX_DROPDOWN,                ///< Use to select a base SFX.
+	WID_GO_TEXT_SFX_VOLUME,                  ///< Sound effects volume label.
+	WID_GO_BASE_SFX_VOLUME,                  ///< Change sound effects volume.
+	WID_GO_BASE_SFX_OPEN_URL,                ///< Open base SFX URL.
+	WID_GO_BASE_SFX_TEXTFILE,                ///< Open base SFX readme, changelog (+1) or license (+2).
 	WID_GO_BASE_SFX_DESCRIPTION = WID_GO_BASE_SFX_TEXTFILE + TFT_CONTENT_END,     ///< Description of selected base SFX.
-	WID_GO_BASE_MUSIC_DROPDOWN,    ///< Use to select a base music set.
-	WID_GO_TEXT_MUSIC_VOLUME,      ///< Music volume label.
-	WID_GO_BASE_MUSIC_VOLUME,      ///< Change music volume.
-	WID_GO_BASE_MUSIC_JUKEBOX,     ///< Open the jukebox.
-	WID_GO_BASE_MUSIC_OPEN_URL,    ///< Open base music URL.
-	WID_GO_BASE_MUSIC_TEXTFILE,    ///< Open base music readme, changelog (+1) or license (+2).
+	WID_GO_BASE_MUSIC_DROPDOWN,              ///< Use to select a base music set.
+	WID_GO_TEXT_MUSIC_VOLUME,                ///< Music volume label.
+	WID_GO_BASE_MUSIC_VOLUME,                ///< Change music volume.
+	WID_GO_BASE_MUSIC_JUKEBOX,               ///< Open the jukebox.
+	WID_GO_BASE_MUSIC_OPEN_URL,              ///< Open base music URL.
+	WID_GO_BASE_MUSIC_TEXTFILE,              ///< Open base music readme, changelog (+1) or license (+2).
 	WID_GO_BASE_MUSIC_DESCRIPTION = WID_GO_BASE_MUSIC_TEXTFILE + TFT_CONTENT_END, ///< Description of selected base music set.
-	WID_GO_VIDEO_ACCEL_BUTTON,     ///< Toggle for video acceleration.
-	WID_GO_VIDEO_VSYNC_BUTTON,     ///< Toggle for video vsync.
-	WID_GO_REFRESH_RATE_DROPDOWN,  ///< Dropdown for all available refresh rates.
-	WID_GO_VIDEO_DRIVER_INFO,      ///< Label showing details about the current video driver.
-	WID_GO_SURVEY_SEL,             ///< Selection to hide survey if no JSON library is compiled in.
-	WID_GO_SURVEY_PARTICIPATE_BUTTON, ///< Toggle for participating in the automated survey.
-	WID_GO_SURVEY_LINK_BUTTON,     ///< Button to open browser to go to the survey website.
-	WID_GO_SURVEY_PREVIEW_BUTTON,  ///< Button to open a preview window with the survey results
-	WID_GO_SOCIAL_PLUGINS,         ///< Main widget handling the social plugins.
-	WID_GO_SOCIAL_PLUGIN_TITLE,    ///< Title of the frame of the social plugin.
-	WID_GO_SOCIAL_PLUGIN_PLATFORM, ///< Platform of the social plugin.
-	WID_GO_SOCIAL_PLUGIN_STATE,    ///< State of the social plugin.
+	WID_GO_VIDEO_ACCEL_BUTTON,               ///< Toggle for video acceleration.
+	WID_GO_VIDEO_VSYNC_BUTTON,               ///< Toggle for video vsync.
+	WID_GO_REFRESH_RATE_DROPDOWN,            ///< Dropdown for all available refresh rates.
+	WID_GO_VIDEO_DRIVER_INFO,                ///< Label showing details about the current video driver.
+	WID_GO_SURVEY_SEL,                       ///< Selection to hide survey if no JSON library is compiled in.
+	WID_GO_SURVEY_PARTICIPATE_BUTTON,        ///< Toggle for participating in the automated survey.
+	WID_GO_SURVEY_LINK_BUTTON,               ///< Button to open browser to go to the survey website.
+	WID_GO_SURVEY_PREVIEW_BUTTON,            ///< Button to open a preview window with the survey results
+	WID_GO_SOCIAL_PLUGINS,                   ///< Main widget handling the social plugins.
+	WID_GO_SOCIAL_PLUGIN_TITLE,              ///< Title of the frame of the social plugin.
+	WID_GO_SOCIAL_PLUGIN_PLATFORM,           ///< Platform of the social plugin.
+	WID_GO_SOCIAL_PLUGIN_STATE,              ///< State of the social plugin.
 };
 
 /** Widgets of the #GameSettingsWindow class. */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Motivation for this is to allow the user to resize fonts in the game UI.  This is an issue for players on high resolution screens where the small font is unreadable. 
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

I added a new tab to the game options dialog. (Pictured below for reference:)

![image](https://github.com/OpenTTD/OpenTTD/assets/144490006/a8b202fd-65c1-49ac-a72c-86b62820a6fc)

I moved the two font related options from GUI to this tab.  Then added a section for each font. Each font has a slider to adjust the font size. Each font is rendered on a button that when clicked launches a font loading dialog pictured below:

![image](https://github.com/OpenTTD/OpenTTD/assets/144490006/35f3a462-8aea-46b1-9601-de716cc0c6f5)

The slider allows users to scale up/down fonts for readability.  The font chooser should hopefully help players who use languages that aren't completely supported by OpenTTD's base fonts.

For the Future:
*  I think removing font console command makes sense as it's no longer needed.
* I'd like to expand on the font chooser loading box. It could be smarter about looking at System directories for fonts.
* When the player clicks a font while on the font chooser dialog it would be cool to see that font rendered in the preview panel.  Right now there's just a text label describing where that is used in the game client.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Only looks for TTF fonts. (If this is a problem I could fix it.)

The sliders have limits for how small/large each font can be set.  I think this makes sense. I don't really see a point in allowing the user to set a font to be 96.  You can size font that high in office documents but I don't see a need for that in the game client. Or going the other way font size of 4 would just be unreadable. 

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
