### PR TITLE
Fix 2955ff3: CMake atomic check fails due to chosen compiler

### DIFF
--- a/cmake/3rdparty/llvm/CheckAtomic.cmake
+++ b/cmake/3rdparty/llvm/CheckAtomic.cmake
@@ -56,6 +56,8 @@ else()
   check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITHOUT_LIB)
   # If not, check if the library exists, and atomics work with it.
   if(NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
+    # check_library_exists requires the C-compiler as the atomic functions are built-in declared.
+    enable_language(C)
     check_library_exists(atomic __atomic_fetch_add_4 "" HAVE_LIBATOMIC)
     if(HAVE_LIBATOMIC)
       list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
@@ -77,6 +79,8 @@ else()
   check_working_cxx_atomics64(HAVE_CXX_ATOMICS64_WITHOUT_LIB)
   # If not, check if the library exists, and atomics work with it.
   if(NOT HAVE_CXX_ATOMICS64_WITHOUT_LIB)
+    # check_library_exists requires the C-compiler as the atomic functions are built-in declared.
+    enable_language(C)
     check_library_exists(atomic __atomic_load_8 "" HAVE_CXX_LIBATOMICS64)
     if(HAVE_CXX_LIBATOMICS64)
       list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")


### PR DESCRIPTION
## Motivation / Problem

CMake stage failing on some esoteric platforms that require libatomic to be linked.
There are at least 3 Debian platforms that fail to compile now. I have researched this on PowerPC via QEMU.

What happens in the tested case is that `__atomic_load_8` will be defined in a `extern "C"` block as `char __atomic_load_8();`. In the main `__atomic_load_8();` will be called. However, a built-in `long long unsigned int __atomic_load_8(const volatile void*, int)` is also present and when the C++ compiler is used the built-in function takes precedence.  That results in a compilation error about the wrong number of parameters, and the test fails saying there is no library.

```
        Run Build Command(s): /usr/bin/cmake -E env VERBOSE=1 /usr/bin/gmake -f Makefile cmTC_26255/fast
        /usr/bin/gmake  -f CMakeFiles/cmTC_26255.dir/build.make CMakeFiles/cmTC_26255.dir/build
        gmake[1]: Entering directory '/home/debian/OpenTTD/build2/CMakeFiles/CMakeScratch/TryCompile-O86cMh'
        Building CXX object CMakeFiles/cmTC_26255.dir/CheckFunctionExists.cxx.o
        /usr/bin/c++   -DCHECK_FUNCTION_EXISTS=__atomic_load_8 -std=c++20 -o CMakeFiles/cmTC_26255.dir/CheckFunctionExists.cxx.o -c /home/debian/OpenTTD/build2/CMakeFiles/CMakeScratch/TryCompile-O86cMh/CheckFunctionExists.cxx
        <command-line>: error: new declaration 'char __atomic_load_8()' ambiguates built-in declaration 'long long unsigned int __atomic_load_8(const volatile void*, int)' [-fpermissive]
        /home/debian/OpenTTD/build2/CMakeFiles/CMakeScratch/TryCompile-O86cMh/CheckFunctionExists.cxx:7:3: note: in expansion of macro 'CHECK_FUNCTION_EXISTS'
            7 |   CHECK_FUNCTION_EXISTS(void);
              |   ^~~~~~~~~~~~~~~~~~~~~
        /home/debian/OpenTTD/build2/CMakeFiles/CMakeScratch/TryCompile-O86cMh/CheckFunctionExists.cxx: In function 'int main(int, char**)':
        /home/debian/OpenTTD/build2/CMakeFiles/CMakeScratch/TryCompile-O86cMh/CheckFunctionExists.cxx:17:24: error: too few arguments to function 'long long unsigned int __atomic_load_8(const volatile void*, int)'
           17 |   CHECK_FUNCTION_EXISTS();
        gmake[1]: *** [CMakeFiles/cmTC_26255.dir/build.make:78: CMakeFiles/cmTC_26255.dir/CheckFunctionExists.cxx.o] Error 1
        gmake[1]: Leaving directory '/home/debian/OpenTTD/build2/CMakeFiles/CMakeScratch/TryCompile-O86cMh'
        gmake: *** [Makefile:127: cmTC_26255/fast] Error 2
```


## Description

Enable the C compiler for the atomic library check.


## Limitations

Note that when running CMake a check for the C-compiler is done  way before reaching one of the branches. This is already happening without this PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
