### PR TITLE
Codefix 90029be: build failure for SDL 1.2

### DIFF
--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -377,15 +377,15 @@ struct SDLVkMapping {
 	const uint8_t vk_count;
 	const uint8_t map_to;
 
-	constexpr SDLVkMapping(SDL_Keycode vk_first, SDL_Keycode vk_last, uint8_t map_first, [[maybe_unused]] uint8_t map_last)
+	constexpr SDLVkMapping(SDLKey vk_first, SDLKey vk_last, uint8_t map_first, [[maybe_unused]] uint8_t map_last)
 		: vk_from(vk_first), vk_count(vk_first - vk_last + 1), map_to(map_first)
 	{
 		assert((vk_last - vk_first) == (map_last - map_first));
 	}
 };
 
-#define AS(x, z) {x, x, z, z, false}
-#define AM(x, y, z, w) {x, y, z, w, false}
+#define AS(x, z) {x, x, z, z}
+#define AM(x, y, z, w) {x, y, z, w}
 
 static constexpr SDLVkMapping _vk_mapping[] = {
 	/* Pageup stuff + up/down */


### PR DESCRIPTION
## Motivation / Problem

https://github.com/OpenTTD/OpenTTD/actions/runs/8933520459/job/24539037371#step:8:770


## Description

Use type that exists in SDL 1.2 and remove unused parameter from macro.


## Limitations

You can only build OpenTTD with either SDL 1.2 or SDL 2. So when you have SDL 1.2 and SDL 2 installed, it will find SDL 2 and not attempt to find SDL 2. So anyone thinking they got both versions installed... only one will be chosen.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
