### PR TITLE
Change: Treat extended waypoint classes as 'WAYP' class.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1937,8 +1937,9 @@ static ChangeInfoResult StationChangeInfo(uint stid, int numinfo, int prop, Byte
 				}
 
 				/* Swap classid because we read it in BE meaning WAYP or DFLT */
-				uint32_t classid = buf->ReadDWord();
-				statspec->cls_id = StationClass::Allocate(BSWAP32(classid));
+				uint32_t classid = BSWAP32(buf->ReadDWord());
+				if (GB(classid, 24, 8) == 0xFF) classid = 'WAYP';
+				statspec->cls_id = StationClass::Allocate(classid);
 				break;
 			}
 
@@ -4838,8 +4839,9 @@ static ChangeInfoResult RoadStopChangeInfo(uint id, int numinfo, int prop, ByteR
 					rs = _cur.grffile->roadstops[id + i].get();
 				}
 
-				uint32_t classid = buf->ReadDWord();
-				rs->cls_id = RoadStopClass::Allocate(BSWAP32(classid));
+				uint32_t classid = BSWAP32(buf->ReadDWord());
+				if (GB(classid, 24, 8) == 0xFF) classid = 'WAYP';
+				rs->cls_id = RoadStopClass::Allocate(classid);
 				rs->spec_id = id + i;
 				break;
 			}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Authors have asked for more custom waypoint classes, as lumping all waypoints into just one class gives a very big list.

My plan on the easiest way to achieve this is to treat all classes with the MSB as 0xFF as a waypoint class.

WIth #12595, this is almost implemented. However, to use the feature requires support from NewGRFs, and if they add this support then they will not work properly in 14.x

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

So this PR is intended to provide a little "forward-compatibility" for 14.x, by translating new waypoint classes to the standard 'WAYP' class.

This maps the extended custom waypoint clases (where the first byte of the label is 0xFF) to the standard 'WAYP' label, allowing use of them before the feature exists.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This also assumes that more-waypoint-classes plan with 0xFF as MSB is reasonable.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
