### PR TITLE
Codechange: Use vectors instead of CallocT/free for cache checks.

### DIFF
--- a/src/cachecheck.cpp
+++ b/src/cachecheck.cpp
@@ -79,34 +79,29 @@ void CheckCaches()
 		rs->GetEntry(DIAGDIR_NW)->CheckIntegrity(rs);
 	}
 
+	std::vector<NewGRFCache> grf_cache;
+	std::vector<VehicleCache> veh_cache;
+	std::vector<GroundVehicleCache> gro_cache;
+	std::vector<TrainCache> tra_cache;
+
 	for (Vehicle *v : Vehicle::Iterate()) {
 		if (v != v->First() || v->vehstatus & VS_CRASHED || !v->IsPrimaryVehicle()) continue;
 
-		uint length = 0;
-		for (const Vehicle *u = v; u != nullptr; u = u->Next()) length++;
-
-		NewGRFCache        *grf_cache = CallocT<NewGRFCache>(length);
-		VehicleCache       *veh_cache = CallocT<VehicleCache>(length);
-		GroundVehicleCache *gro_cache = CallocT<GroundVehicleCache>(length);
-		TrainCache         *tra_cache = CallocT<TrainCache>(length);
-
-		length = 0;
 		for (const Vehicle *u = v; u != nullptr; u = u->Next()) {
 			FillNewGRFVehicleCache(u);
-			grf_cache[length] = u->grf_cache;
-			veh_cache[length] = u->vcache;
+			grf_cache.emplace_back(u->grf_cache);
+			veh_cache.emplace_back(u->vcache);
 			switch (u->type) {
 				case VEH_TRAIN:
-					gro_cache[length] = Train::From(u)->gcache;
-					tra_cache[length] = Train::From(u)->tcache;
+					gro_cache.emplace_back(Train::From(u)->gcache);
+					tra_cache.emplace_back(Train::From(u)->tcache);
 					break;
 				case VEH_ROAD:
-					gro_cache[length] = RoadVehicle::From(u)->gcache;
+					gro_cache.emplace_back(RoadVehicle::From(u)->gcache);
 					break;
 				default:
 					break;
 			}
-			length++;
 		}
 
 		switch (v->type) {
@@ -117,7 +112,7 @@ void CheckCaches()
 			default: break;
 		}
 
-		length = 0;
+		uint length = 0;
 		for (const Vehicle *u = v; u != nullptr; u = u->Next()) {
 			FillNewGRFVehicleCache(u);
 			if (grf_cache[length] != u->grf_cache) {
@@ -146,10 +141,10 @@ void CheckCaches()
 			length++;
 		}
 
-		free(grf_cache);
-		free(veh_cache);
-		free(gro_cache);
-		free(tra_cache);
+		grf_cache.clear();
+		veh_cache.clear();
+		gro_cache.clear();
+		tra_cache.clear();
 	}
 
 	/* Check whether the caches are still valid */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

calloc/free is used in `CheckCaches()` to allocate temporary storage to compare caches.

This is allocated and free for each vehicle chain, and the length of the memory to be allocated has to be predetermined.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use vectors instead. These are allocated automatically as needed and allow reuse of the allocated memory for each vehicle chain.

This removes manual memory allocation with calloc/free.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
