### PR TITLE
Doc: Re-order release instructions to not tell the world prematurely

### DIFF
--- a/docs/releasing_openttd.md
+++ b/docs/releasing_openttd.md
@@ -38,8 +38,7 @@ This guide is for OpenTTD developers/maintainers, to release a new version of Op
 
 1. Go to https://github.com/OpenTTD/OpenTTD/releases/new and create a new tag matching the release number. For the body of the release, copy in the changelog. "Set as a pre-release" for a beta or RC.
 2. Wait for the OpenTTD release workflow to be complete.
-3. Merge the website PR. This will publish the release post.
-4. If this is a full release:
+3. If this is a full release:
    * for `Steam`: under Steamworks -> SteamPipe -> Builds, set the "testing" branch live on the "default" branch. This will request 2FA validation.
    * for `GOG`: under Builds, "Publish" the freshly uploaded builds to `Master`, `GOG-use only` and `Testing`.
    * for `Microsoft Store`: ask orudge to publish the new release.
@@ -50,4 +49,5 @@ For help and/or access to either or both, please contact TrueBrain.
 
 ## Step 4: Tell the world
 
-1. Make announcements on social media and store pages. You may need to coordinate with other developers who can make posts on TT-Forums, Twitter, Reddit, Fosstodon, Discord, Steam, GOG, Microsoft Store, etc.
+1. Merge the website PR. This will publish the release post.
+2. Make announcements on social media and store pages. You may need to coordinate with other developers who can make posts on TT-Forums, Twitter, Reddit, Fosstodon, Discord, Steam, GOG, Microsoft Store, etc.


### PR DESCRIPTION
## Motivation / Problem

I almost merged a website PR too soon.

## Description

We should probably not tell the world to get the latest OpenTTD from their favorite store page until it is actually available from said store page.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
