### PR TITLE
Fix: server's client is shown incorrectly in some cases

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1005,6 +1005,12 @@ void NetworkOnGameStart()
 		NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(CLIENT_ID_SERVER);
 		if (c != nullptr && ci != nullptr) {
 			ci->client_playas = c->index;
+
+			/*
+			 * If the company has not been named yet, the company was just started.
+			 * Otherwise it would have gotten a name already, so announce it as a new company.
+			 */
+			if (c->name_1 == STR_SV_UNNAMED && c->name.empty()) NetworkServerNewCompany(c, ci);
 		}
 
 		ShowClientList();

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -884,7 +884,7 @@ static void NetworkInitGameInfo()
 	/* There should be always space for the server. */
 	assert(NetworkClientInfo::CanAllocateItem());
 	NetworkClientInfo *ci = new NetworkClientInfo(CLIENT_ID_SERVER);
-	ci->client_playas = _network_dedicated ? COMPANY_SPECTATOR : COMPANY_FIRST;
+	ci->client_playas = COMPANY_SPECTATOR;
 
 	ci->client_name = _settings_client.network.client_name;
 }
@@ -985,6 +985,30 @@ bool NetworkServerStart()
 	if (_network_dedicated) ServerNetworkAdminSocketHandler::WelcomeAll();
 
 	return true;
+}
+
+/**
+ * Perform tasks when the server is started. This consists of things
+ * like putting the server's client in a valid company and resetting the restart time.
+ */
+void NetworkOnGameStart()
+{
+	if (!_network_server) return;
+
+	/* Update the static game info to set the values from the new game. */
+	NetworkServerUpdateGameInfo();
+
+	ChangeNetworkRestartTime(true);
+
+	if (!_network_dedicated) {
+		Company *c = Company::GetIfValid(GetFirstPlayableCompanyID());
+		NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(CLIENT_ID_SERVER);
+		if (c != nullptr && ci != nullptr) {
+			ci->client_playas = c->index;
+		}
+
+		ShowClientList();
+	}
 }
 
 /* The server is rebooting...

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -64,6 +64,8 @@ void NetworkPrintClients();
 std::string_view NetworkGetPublicKeyOfClient(ClientID client_id);
 void NetworkHandlePauseChange(PauseMode prev_mode, PauseMode changed_mode);
 
+void NetworkOnGameStart();
+
 /*** Commands ran by the server ***/
 void NetworkServerSendConfigUpdate();
 void NetworkServerUpdateGameInfo();

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -34,7 +34,6 @@
 #include "console_func.h"
 #include "screenshot.h"
 #include "network/network.h"
-#include "network/network_server.h"
 #include "network/network_func.h"
 #include "ai/ai.hpp"
 #include "ai/ai_config.hpp"
@@ -859,8 +858,8 @@ static void OnStartGame(bool dedicated_server)
 	 * or in the case of a dedicated server, a spectator */
 	SetLocalCompany(dedicated_server ? COMPANY_SPECTATOR : GetFirstPlayableCompanyID());
 
-	/* Update the static game info to set the values from the new game. */
-	NetworkServerUpdateGameInfo();
+	NetworkOnGameStart();
+
 	/* Execute the game-start script */
 	IConsoleCmdExec("exec scripts/game_start.scr 0");
 }
@@ -911,12 +910,6 @@ static void MakeNewGameDone()
 	CheckEngines();
 	CheckIndustries();
 	MarkWholeScreenDirty();
-
-	if (_network_server) {
-		ChangeNetworkRestartTime(true);
-
-		if (!_network_dedicated) ShowClientList();
-	}
 }
 
 static void MakeNewGame(bool from_heightmap, bool reset_settings)


### PR DESCRIPTION
## Motivation / Problem

Create a save that has companies, but no company with id 0. Start a server from the GUI and load this save. The client will now play as company with id 1, but be shown as an invalid company in the client list. In other words `ci->client_playas` is incorrect.

![Tester Transport, 2035-01-01](https://github.com/OpenTTD/OpenTTD/assets/13785744/b8a119e7-923b-4b61-adba-62505362d46a)


Tangentially related to this, if you load a scenario or save, the client list won't be opened. It will open the client list for a new game and heightmap though. Similarly when loading saves the restart timer won't be reset, so if you prepare saves for your server the restart times becomes non-functional.

Furthermore, new companies in network games get their company named by the client. Except for server games, where this does not happen.


## Description

* Initialise the client's `ci->client_playas` always as spectator.
* In `OnGameStart` call a new routine to properly initialise the `ci->client_playas` to the actually loaded company.
* Move any network related things that should happen for game starts to this new routine, like opening the client list.
* Call `NetworkServerNewCompany` when the company created for the server is still unnamed.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
