### PR TITLE
Fix #12608: SDL keycode to vkey mapping

### DIFF
--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -246,7 +246,7 @@ struct SDLVkMapping {
 	const bool unprintable;
 
 	constexpr SDLVkMapping(SDL_Keycode vk_first, SDL_Keycode vk_last, uint8_t map_first, [[maybe_unused]] uint8_t map_last, bool unprintable)
-		: vk_from(vk_first), vk_count(vk_first - vk_last + 1), map_to(map_first), unprintable(unprintable)
+		: vk_from(vk_first), vk_count(vk_last - vk_first + 1), map_to(map_first), unprintable(unprintable)
 	{
 		assert((vk_last - vk_first) == (map_last - map_first));
 	}

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -378,7 +378,7 @@ struct SDLVkMapping {
 	const uint8_t map_to;
 
 	constexpr SDLVkMapping(SDLKey vk_first, SDLKey vk_last, uint8_t map_first, [[maybe_unused]] uint8_t map_last)
-		: vk_from(vk_first), vk_count(vk_first - vk_last + 1), map_to(map_first)
+		: vk_from(vk_first), vk_count(vk_last - vk_first + 1), map_to(map_first)
 	{
 		assert((vk_last - vk_first) == (map_last - map_first));
 	}


### PR DESCRIPTION
## Motivation / Problem

SDL keycode to vkey mapping was incorrect/partially functional due to #12608.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
