### PR TITLE
Codechange: use std::optional<std::string> over char * for text query result

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1853,11 +1853,11 @@ struct BuildVehicleWindow : Window {
 		}
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (str == nullptr) return;
+		if (!str.has_value()) return;
 
-		Command<CMD_RENAME_ENGINE>::Post(STR_ERROR_CAN_T_RENAME_TRAIN_TYPE + this->vehicle_type, this->rename_engine, str);
+		Command<CMD_RENAME_ENGINE>::Post(STR_ERROR_CAN_T_RENAME_TRAIN_TYPE + this->vehicle_type, this->rename_engine, *str);
 	}
 
 	void OnDropdownSelect(WidgetID widget, int index) override

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -404,14 +404,14 @@ struct CheatWindow : Window {
 		this->SetDirty();
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
 		/* Was 'cancel' pressed or nothing entered? */
-		if (str == nullptr || StrEmpty(str)) return;
+		if (!str.has_value() || str->empty()) return;
 
 		const CheatEntry *ce = &_cheats_ui[clicked_widget];
 		int oldvalue = (int32_t)ReadValue(ce->variable, ce->type);
-		int value = atoi(str);
+		int value = atoi(str->c_str());
 		*ce->been_used = true;
 		value = ce->proc(value, value - oldvalue);
 

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -1686,12 +1686,12 @@ public:
 		}
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (str == nullptr) return;
+		if (!str.has_value()) return;
 		/* Set a new company manager face number */
-		if (!StrEmpty(str)) {
-			this->face = std::strtoul(str, nullptr, 10);
+		if (!str->empty()) {
+			this->face = std::strtoul(str->c_str(), nullptr, 10);
 			ScaleAllCompanyManagerFaceBits(this->face);
 			ShowErrorMessage(STR_FACE_FACECODE_SET, INVALID_STRING_ID, WL_INFO);
 			this->UpdateData();
@@ -2520,25 +2520,25 @@ struct CompanyWindow : Window
 		this->RaiseButtons();
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (str == nullptr) return;
+		if (!str.has_value()) return;
 
 		switch (this->query_widget) {
 			default: NOT_REACHED();
 
 			case WID_C_GIVE_MONEY: {
-				Money money = std::strtoull(str, nullptr, 10) / GetCurrency().rate;
+				Money money = std::strtoull(str->c_str(), nullptr, 10) / GetCurrency().rate;
 				Command<CMD_GIVE_MONEY>::Post(STR_ERROR_CAN_T_GIVE_MONEY, money, (CompanyID)this->window_number);
 				break;
 			}
 
 			case WID_C_PRESIDENT_NAME:
-				Command<CMD_RENAME_PRESIDENT>::Post(STR_ERROR_CAN_T_CHANGE_PRESIDENT, str);
+				Command<CMD_RENAME_PRESIDENT>::Post(STR_ERROR_CAN_T_CHANGE_PRESIDENT, *str);
 				break;
 
 			case WID_C_COMPANY_NAME:
-				Command<CMD_RENAME_COMPANY>::Post(STR_ERROR_CAN_T_CHANGE_COMPANY_NAME, str);
+				Command<CMD_RENAME_COMPANY>::Post(STR_ERROR_CAN_T_CHANGE_COMPANY_NAME, *str);
 				break;
 		}
 	}

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -831,12 +831,12 @@ struct DepotWindow : Window {
 		}
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (str == nullptr) return;
+		if (!str.has_value()) return;
 
 		/* Do depot renaming */
-		Command<CMD_RENAME_DEPOT>::Post(STR_ERROR_CAN_T_RENAME_DEPOT, this->GetDepotIndex(), str);
+		Command<CMD_RENAME_DEPOT>::Post(STR_ERROR_CAN_T_RENAME_DEPOT, this->GetDepotIndex(), *str);
 	}
 
 	bool OnRightClick([[maybe_unused]] Point pt, WidgetID widget) override

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -368,10 +368,10 @@ struct GSConfigWindow : public Window {
 		}
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (StrEmpty(str)) return;
-		int32_t value = atoi(str);
+		if (!str.has_value() || str->empty()) return;
+		int32_t value = atoi(str->c_str());
 		SetValue(value);
 	}
 

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -935,14 +935,14 @@ struct GenerateLandscapeWindow : public Window {
 		this->InvalidateData();
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
 		/* Was 'cancel' pressed? */
-		if (str == nullptr) return;
+		if (!str.has_value()) return;
 
 		int32_t value;
-		if (!StrEmpty(str)) {
-			value = atoi(str);
+		if (!str->empty()) {
+			value = atoi(str->c_str());
 		} else {
 			/* An empty string means revert to the default */
 			switch (this->widget_id) {
@@ -1229,25 +1229,25 @@ struct CreateScenarioWindow : public Window
 		this->SetDirty();
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (!StrEmpty(str)) {
-			int32_t value = atoi(str);
+		if (!str.has_value() || str->empty()) return;
 
-			switch (this->widget_id) {
-				case WID_CS_START_DATE_TEXT:
-					this->SetWidgetDirty(WID_CS_START_DATE_TEXT);
-					_settings_newgame.game_creation.starting_year = Clamp(TimerGameCalendar::Year(value), CalendarTime::MIN_YEAR, CalendarTime::MAX_YEAR);
-					break;
+		int32_t value = atoi(str->c_str());
 
-				case WID_CS_FLAT_LAND_HEIGHT_TEXT:
-					this->SetWidgetDirty(WID_CS_FLAT_LAND_HEIGHT_TEXT);
-					_settings_newgame.game_creation.se_flat_world_height = Clamp(value, 0, GetMapHeightLimit());
-					break;
-			}
+		switch (this->widget_id) {
+			case WID_CS_START_DATE_TEXT:
+				this->SetWidgetDirty(WID_CS_START_DATE_TEXT);
+				_settings_newgame.game_creation.starting_year = Clamp(TimerGameCalendar::Year(value), CalendarTime::MIN_YEAR, CalendarTime::MAX_YEAR);
+				break;
 
-			this->SetDirty();
+			case WID_CS_FLAT_LAND_HEIGHT_TEXT:
+				this->SetWidgetDirty(WID_CS_FLAT_LAND_HEIGHT_TEXT);
+				_settings_newgame.game_creation.se_flat_world_height = Clamp(value, 0, GetMapHeightLimit());
+				break;
 		}
+
+		this->SetDirty();
 	}
 };
 

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -972,9 +972,9 @@ public:
 		_cursor.vehchain = false;
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (str != nullptr) Command<CMD_ALTER_GROUP>::Post(STR_ERROR_GROUP_CAN_T_RENAME, AlterGroupMode::Rename, this->group_rename, 0, str);
+		if (str.has_value()) Command<CMD_ALTER_GROUP>::Post(STR_ERROR_GROUP_CAN_T_RENAME, AlterGroupMode::Rename, this->group_rename, 0, *str);
 		this->group_rename = INVALID_GROUP;
 	}
 

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1138,12 +1138,12 @@ public:
 		}
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (StrEmpty(str)) return;
+		if (!str.has_value() || str->empty()) return;
 
 		Industry *i = Industry::Get(this->window_number);
-		uint value = atoi(str);
+		uint value = atoi(str->c_str());
 		switch (this->editbox_line) {
 			case IL_NONE: NOT_REACHED();
 

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -1039,7 +1039,7 @@ struct QueryStringWindow : public Window
 		if (!this->editbox.handled && this->parent != nullptr) {
 			Window *parent = this->parent;
 			this->parent = nullptr; // so parent doesn't try to close us again
-			parent->OnQueryTextFinished(nullptr);
+			parent->OnQueryTextFinished(std::nullopt);
 		}
 		this->Window::Close();
 	}

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -836,13 +836,13 @@ public:
 		}
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (!StrEmpty(str)) {
-			_settings_client.network.connect_to_ip = str;
-			NetworkAddServer(str);
-			NetworkRebuildHostList();
-		}
+		if (!str.has_value() || str->empty()) return;
+
+		_settings_client.network.connect_to_ip = std::move(*str);
+		NetworkAddServer(_settings_client.network.connect_to_ip);
+		NetworkRebuildHostList();
 	}
 
 	void OnResize() override
@@ -1135,14 +1135,14 @@ struct NetworkStartServerWindow : public Window {
 		this->RaiseWidgetsWhenLowered(WID_NSS_CLIENTS_BTND, WID_NSS_CLIENTS_BTNU, WID_NSS_COMPANIES_BTND, WID_NSS_COMPANIES_BTNU);
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (str == nullptr) return;
+		if (!str.has_value()) return;
 
 		if (this->widget_id == WID_NSS_SETPWD) {
-			_settings_client.network.server_password = str;
+			_settings_client.network.server_password = std::move(*str);
 		} else {
-			int32_t value = atoi(str);
+			int32_t value = atoi(str->c_str());
 			this->SetWidgetDirty(this->widget_id);
 			switch (this->widget_id) {
 				default: NOT_REACHED();
@@ -1868,9 +1868,9 @@ public:
 		this->SetDirty();
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (str == nullptr) return;
+		if (!str.has_value()) return;
 
 		switch (this->query_widget) {
 			default: NOT_REACHED();
@@ -1878,13 +1878,13 @@ public:
 			case WID_CL_SERVER_NAME_EDIT: {
 				if (!_network_server) break;
 
-				SetSettingValue(GetSettingFromName("network.server_name")->AsStringSetting(), str);
+				SetSettingValue(GetSettingFromName("network.server_name")->AsStringSetting(), *str);
 				this->InvalidateData();
 				break;
 			}
 
 			case WID_CL_CLIENT_NAME_EDIT: {
-				SetSettingValue(GetSettingFromName("network.client_name")->AsStringSetting(), str);
+				SetSettingValue(GetSettingFromName("network.client_name")->AsStringSetting(), *str);
 				this->InvalidateData();
 				break;
 			}
@@ -2169,14 +2169,14 @@ struct NetworkJoinStatusWindow : Window {
 		}
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (StrEmpty(str) || this->request == nullptr) {
+		if (!str.has_value() || str->empty() || this->request == nullptr) {
 			NetworkDisconnect();
 			return;
 		}
 
-		this->request->Reply(str);
+		this->request->Reply(*str);
 	}
 };
 

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -595,11 +595,11 @@ struct NewGRFInspectWindow : Window {
 		}
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (StrEmpty(str)) return;
+		if (!str.has_value() || str->empty()) return;
 
-		NewGRFInspectWindow::var60params[GetFeatureNum(this->window_number)][this->current_edit_param - 0x60] = std::strtol(str, nullptr, 16);
+		NewGRFInspectWindow::var60params[GetFeatureNum(this->window_number)][this->current_edit_param - 0x60] = std::strtol(str->c_str(), nullptr, 16);
 		this->SetDirty();
 	}
 
@@ -1074,11 +1074,11 @@ struct SpriteAlignerWindow : Window {
 		}
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (StrEmpty(str)) return;
+		if (!str.has_value() || str->empty()) return;
 
-		this->current_sprite = atoi(str);
+		this->current_sprite = atoi(str->c_str());
 		if (this->current_sprite >= GetMaxSpriteID()) this->current_sprite = 0;
 		while (GetSpriteType(this->current_sprite) != SpriteType::Normal) {
 			this->current_sprite = (this->current_sprite + 1) % GetMaxSpriteID();

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -443,10 +443,10 @@ struct NewGRFParametersWindow : public Window {
 		}
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (StrEmpty(str)) return;
-		int32_t value = atoi(str);
+		if (!str.has_value() || str->empty()) return;
+		int32_t value = atoi(str->c_str());
 		GRFParameterInfo &par_info = this->GetParameterInfo(this->clicked_row);
 		uint32_t val = Clamp<uint32_t>(value, par_info.min_value, par_info.max_value);
 		par_info.SetValue(this->grf_config, val);
@@ -1195,11 +1195,11 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		this->InvalidateData(GOID_NEWGRF_CHANGES_MADE);
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (str == nullptr) return;
+		if (!str.has_value()) return;
 
-		SaveGRFPresetToConfig(str, this->actives);
+		SaveGRFPresetToConfig(str->c_str(), this->actives);
 		this->grf_presets = GetGRFPresetList();
 
 		/* Switch to this preset */

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -1375,27 +1375,27 @@ public:
 		}
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (!StrEmpty(str)) {
-			VehicleOrderID sel = this->OrderGetSel();
-			uint value = atoi(str);
+		if (!str.has_value() || str->empty()) return;
 
-			switch (this->vehicle->GetOrder(sel)->GetConditionVariable()) {
-				case OCV_MAX_SPEED:
-					value = ConvertDisplaySpeedToSpeed(value, this->vehicle->type);
-					break;
+		VehicleOrderID sel = this->OrderGetSel();
+		uint value = atoi(str->c_str());
 
-				case OCV_RELIABILITY:
-				case OCV_LOAD_PERCENTAGE:
-					value = Clamp(value, 0, 100);
-					break;
+		switch (this->vehicle->GetOrder(sel)->GetConditionVariable()) {
+			case OCV_MAX_SPEED:
+				value = ConvertDisplaySpeedToSpeed(value, this->vehicle->type);
+				break;
 
-				default:
-					break;
-			}
-			Command<CMD_MODIFY_ORDER>::Post(STR_ERROR_CAN_T_MODIFY_THIS_ORDER, this->vehicle->tile, this->vehicle->index, sel, MOF_COND_VALUE, Clamp(value, 0, 2047));
+			case OCV_RELIABILITY:
+			case OCV_LOAD_PERCENTAGE:
+				value = Clamp(value, 0, 100);
+				break;
+
+			default:
+				break;
 		}
+		Command<CMD_MODIFY_ORDER>::Post(STR_ERROR_CAN_T_MODIFY_THIS_ORDER, this->vehicle->tile, this->vehicle->index, sel, MOF_COND_VALUE, Clamp(value, 0, 2047));
 	}
 
 	void OnDropdownSelect(WidgetID widget, int index) override

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -515,10 +515,10 @@ struct ScriptSettingsWindow : public Window {
 		}
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (StrEmpty(str)) return;
-		int32_t value = atoi(str);
+		if (!str.has_value() || str->empty()) return;
+		int32_t value = atoi(str->c_str());
 
 		SetValue(value);
 	}

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2726,17 +2726,17 @@ struct GameSettingsWindow : Window {
 		}
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
 		/* The user pressed cancel */
-		if (str == nullptr) return;
+		if (!str.has_value()) return;
 
 		assert(this->valuewindow_entry != nullptr);
 		const IntSettingDesc *sd = this->valuewindow_entry->setting;
 
 		int32_t value;
-		if (!StrEmpty(str)) {
-			long long llvalue = atoll(str);
+		if (!str->empty()) {
+			long long llvalue = atoll(str->c_str());
 
 			/* Save the correct currency-translated value */
 			if (sd->flags & SF_GUI_CURRENCY) llvalue /= GetCurrency().rate;
@@ -3128,29 +3128,29 @@ struct CustomCurrencyWindow : Window {
 		this->SetDirty();
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (str == nullptr) return;
+		if (!str.has_value()) return;
 
 		switch (this->query_widget) {
 			case WID_CC_RATE:
-				GetCustomCurrency().rate = Clamp(atoi(str), 1, UINT16_MAX);
+				GetCustomCurrency().rate = Clamp(atoi(str->c_str()), 1, UINT16_MAX);
 				break;
 
 			case WID_CC_SEPARATOR: // Thousands separator
-				GetCustomCurrency().separator = str;
+				GetCustomCurrency().separator = std::move(*str);
 				break;
 
 			case WID_CC_PREFIX:
-				GetCustomCurrency().prefix = str;
+				GetCustomCurrency().prefix = std::move(*str);
 				break;
 
 			case WID_CC_SUFFIX:
-				GetCustomCurrency().suffix = str;
+				GetCustomCurrency().suffix = std::move(*str);
 				break;
 
 			case WID_CC_YEAR: { // Year to switch to euro
-				TimerGameCalendar::Year val = atoi(str);
+				TimerGameCalendar::Year val = atoi(str->c_str());
 
 				GetCustomCurrency().to_euro = (val < MIN_EURO_YEAR ? CF_NOEURO : std::min(val, CalendarTime::MAX_YEAR));
 				break;

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -2134,11 +2134,11 @@ struct StationViewWindow : public Window {
 		}
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (str == nullptr) return;
+		if (!str.has_value()) return;
 
-		Command<CMD_RENAME_STATION>::Post(STR_ERROR_CAN_T_RENAME_STATION, this->window_number, str);
+		Command<CMD_RENAME_STATION>::Post(STR_ERROR_CAN_T_RENAME_STATION, this->window_number, *str);
 	}
 
 	void OnResize() override

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -740,12 +740,12 @@ struct TimetableWindow : Window {
 		this->SetDirty();
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (str == nullptr) return;
+		if (!str.has_value()) return;
 
 		const Vehicle *v = this->vehicle;
-		uint64_t val = StrEmpty(str) ? 0 : std::strtoul(str, nullptr, 10);
+		uint64_t val = str->empty() ? 0 : std::strtoul(str->c_str(), nullptr, 10);
 		auto [order_id, mtf] = PackTimetableArgs(v, this->sel_index, query_widget == WID_VT_CHANGE_SPEED);
 
 		switch (query_widget) {

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2458,14 +2458,14 @@ struct ScenarioEditorToolbarWindow : Window {
 		HandleZoomMessage(this, GetMainWindow()->viewport, WID_TE_ZOOM_IN, WID_TE_ZOOM_OUT);
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
 		/* Was 'cancel' pressed? */
-		if (str == nullptr) return;
+		if (!str.has_value()) return;
 
 		TimerGameCalendar::Year value;
-		if (!StrEmpty(str)) {
-			value = atoi(str);
+		if (!str->empty()) {
+			value = atoi(str->c_str());
 		} else {
 			/* An empty string means revert to the default */
 			value = CalendarTime::DEF_START_YEAR.base();

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -607,11 +607,11 @@ public:
 		this->ResizeWindowAsNeeded();
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (str == nullptr) return;
+		if (!str.has_value()) return;
 
-		Command<CMD_RENAME_TOWN>::Post(STR_ERROR_CAN_T_RENAME_TOWN, this->window_number, str);
+		Command<CMD_RENAME_TOWN>::Post(STR_ERROR_CAN_T_RENAME_TOWN, this->window_number, *str);
 	}
 
 	IntervalTimer<TimerGameCalendar> daily_interval = {{TimerGameCalendar::DAY, TimerGameCalendar::Priority::NONE}, [this](auto) {

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -3301,11 +3301,11 @@ public:
 		return Window::OnHotkey(hotkey);
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (str == nullptr) return;
+		if (!str.has_value()) return;
 
-		Command<CMD_RENAME_VEHICLE>::Post(STR_ERROR_CAN_T_RENAME_TRAIN + Vehicle::Get(this->window_number)->type, this->window_number, str);
+		Command<CMD_RENAME_VEHICLE>::Post(STR_ERROR_CAN_T_RENAME_TRAIN + Vehicle::Get(this->window_number)->type, this->window_number, *str);
 	}
 
 	void OnMouseOver([[maybe_unused]] Point pt, WidgetID widget) override

--- a/src/waypoint_gui.cpp
+++ b/src/waypoint_gui.cpp
@@ -176,11 +176,11 @@ public:
 		}
 	}
 
-	void OnQueryTextFinished(char *str) override
+	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (str == nullptr) return;
+		if (!str.has_value()) return;
 
-		Command<CMD_RENAME_WAYPOINT>::Post(STR_ERROR_CAN_T_CHANGE_WAYPOINT_NAME, this->window_number, str);
+		Command<CMD_RENAME_WAYPOINT>::Post(STR_ERROR_CAN_T_CHANGE_WAYPOINT_NAME, this->window_number, *str);
 	}
 
 };

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -775,11 +775,11 @@ public:
 
 	/**
 	 * The query window opened from this window has closed.
-	 * @param str the new value of the string, nullptr if the window
+	 * @param str the new value of the string, \c std::nullopt if the window
 	 *            was cancelled or an empty string when the default
-	 *            button was pressed, i.e. StrEmpty(str).
+	 *            button was pressed, i.e. \c str->empty().
 	 */
-	virtual void OnQueryTextFinished([[maybe_unused]] char *str) {}
+	virtual void OnQueryTextFinished([[maybe_unused]] std::optional<std::string> str) {}
 
 	/**
 	 * Some data on this window has become invalid.


### PR DESCRIPTION
## Motivation / Problem

`OnQueryTextFinished` gets a `char *` which in many places gets passed into `StrEmpty`.

The `char *` fulfils multiple meanings; when it's `nullptr` it means the window was closed and there is no string, when the string is empty (`str[0] == '\0'`) this denotes the default value (also functionally; clearing the company name and then pressing OK will give you the default name), and then anything non-empty is considered valid data.

Since we're moving towards a more C++-styled codebase, convert this `char *` into `std::optional<std::string>` instead.


## Description

Convert the parameter type of `OnQueryTextFinished`.


## Limitations

This introduces quite a few `->c_str()`s because many places use `atoi` and friends. Replacing `atoi` with a more modern variant is beyond the scope of this PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
