### PR TITLE
Fix: Allow changing size of default OpenTTD font.

### DIFF
--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -146,14 +146,14 @@ extern void LoadWin32Font(FontSize fs);
 extern void LoadCoreTextFont(FontSize fs);
 #endif
 
+#if defined(WITH_FREETYPE) || defined(_WIN32) || defined(WITH_COCOA)
 /**
  * Get name of default font file for a given font size.
  * @param fs Font size.
  * @return Name of default font file.
  */
-static std::string GetDefaultTruetypeFont([[maybe_unused]] FontSize fs)
+static std::string GetDefaultTruetypeFont(FontSize fs)
 {
-#if defined(WITH_FREETYPE) || defined(_WIN32) || defined(WITH_COCOA)
 	switch (fs) {
 		case FS_NORMAL: return "OpenTTD-Sans.ttf";
 		case FS_SMALL: return "OpenTTD-Small.ttf";
@@ -161,9 +161,8 @@ static std::string GetDefaultTruetypeFont([[maybe_unused]] FontSize fs)
 		case FS_MONO: return "OpenTTD-Mono.ttf";
 		default: NOT_REACHED();
 	}
-#endif /* defined(WITH_FREETYPE) || defined(_WIN32) || defined(WITH_COCOA) */
-	return {};
 }
+#endif /* defined(WITH_FREETYPE) || defined(_WIN32) || defined(WITH_COCOA) */
 
 /**
  * Get path of default font file for a given font size.
@@ -175,8 +174,9 @@ static std::string GetDefaultTruetypeFontFile([[maybe_unused]] FontSize fs)
 #if defined(WITH_FREETYPE) || defined(_WIN32) || defined(WITH_COCOA)
 	/* Find font file. */
 	return FioFindFullPath(BASESET_DIR, GetDefaultTruetypeFont(fs));
-#endif /* defined(WITH_FREETYPE) || defined(_WIN32) || defined(WITH_COCOA) */
+#else
 	return {};
+#endif /* defined(WITH_FREETYPE) || defined(_WIN32) || defined(WITH_COCOA) */
 }
 
 /**

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -239,6 +239,7 @@ inline FontCacheSubSetting *GetFontCacheSubSetting(FontSize fs)
 	}
 }
 
+std::string GetFontCacheFontName(FontSize fs);
 void InitFontCache(bool monospace);
 void UninitFontCache();
 

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -162,7 +162,8 @@ void LoadFreeTypeFont(FontSize fs)
 {
 	FontCacheSubSetting *settings = GetFontCacheSubSetting(fs);
 
-	if (settings->font.empty()) return;
+	std::string font = GetFontCacheFontName(fs);
+	if (font.empty()) return;
 
 	if (_library == nullptr) {
 		if (FT_Init_FreeType(&_library) != FT_Err_Ok) {
@@ -173,7 +174,7 @@ void LoadFreeTypeFont(FontSize fs)
 		Debug(fontcache, 2, "Initialized");
 	}
 
-	const char *font_name = settings->font.c_str();
+	const char *font_name = font.c_str();
 	FT_Face face = nullptr;
 
 	/* If font is an absolute path to a ttf, try loading that first. */
@@ -201,34 +202,6 @@ void LoadFreeTypeFont(FontSize fs)
 		FT_Done_Face(face);
 	}
 }
-
-/**
- * Load a TrueType font from a file.
- * @param fs The font size to load.
- * @param file_name Path to the font file.
- * @param size Requested font size.
- */
-void LoadFreeTypeFont(FontSize fs, const std::string &file_name, uint size)
-{
-	if (_library == nullptr) {
-		if (FT_Init_FreeType(&_library) != FT_Err_Ok) {
-			ShowInfo("Unable to initialize FreeType, using sprite fonts instead");
-			return;
-		}
-
-		Debug(fontcache, 2, "Initialized");
-	}
-
-	FT_Face face = nullptr;
-	int32_t index = 0;
-	FT_Error error = FT_New_Face(_library, file_name.c_str(), index, &face);
-	if (error == FT_Err_Ok) {
-		LoadFont(fs, face, file_name.c_str(), size);
-	} else {
-		FT_Done_Face(face);
-	}
-}
-
 
 /**
  * Free everything that was allocated for this font cache.

--- a/src/os/macosx/font_osx.h
+++ b/src/os/macosx/font_osx.h
@@ -36,6 +36,5 @@ public:
 };
 
 void LoadCoreTextFont(FontSize fs);
-void LoadCoreTextFont(FontSize fs, const std::string &file_name, uint size);
 
 #endif /* FONT_OSX_H */

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -399,8 +399,8 @@ void LoadWin32Font(FontSize fs)
 		logfont = *(const LOGFONT *)settings->os_handle;
 	} else if (strchr(font_name, '.') != nullptr) {
 		/* Might be a font file name, try load it. */
-		if (!TryLoadFontFromFile(settings->font, logfont)) {
-			ShowInfo("Unable to load file '{}' for {} font, using default windows font selection instead", font_name, FontSizeToName(fs));
+		if (!TryLoadFontFromFile(font, logfont)) {
+			ShowInfo("Unable to load file '{}' for {} font, using default windows font selection instead", font, FontSizeToName(fs));
 		}
 	}
 

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -384,9 +384,10 @@ void LoadWin32Font(FontSize fs)
 {
 	FontCacheSubSetting *settings = GetFontCacheSubSetting(fs);
 
-	if (settings->font.empty()) return;
+	std::string font = GetFontCacheFontName(fs);
+	if (font.empty()) return;
 
-	const char *font_name = settings->font.c_str();
+	const char *font_name = font.c_str();
 	LOGFONT logfont;
 	MemSetT(&logfont, 0);
 	logfont.lfPitchAndFamily = fs == FS_MONO ? FIXED_PITCH : VARIABLE_PITCH;
@@ -409,24 +410,4 @@ void LoadWin32Font(FontSize fs)
 	}
 
 	LoadWin32Font(fs, logfont, settings->size, font_name);
-}
-
-/**
- * Load a TrueType font from a file.
- * @param fs The font size to load.
- * @param file_name Path to the font file.
- * @param size Requested font size.
- */
-void LoadWin32Font(FontSize fs, const std::string &file_name, uint size)
-{
-	LOGFONT logfont;
-	MemSetT(&logfont, 0);
-	logfont.lfPitchAndFamily = fs == FS_MONO ? FIXED_PITCH : VARIABLE_PITCH;
-	logfont.lfCharSet = DEFAULT_CHARSET;
-	logfont.lfOutPrecision = OUT_OUTLINE_PRECIS;
-	logfont.lfClipPrecision = CLIP_DEFAULT_PRECIS;
-
-	if (TryLoadFontFromFile(file_name, logfont)) {
-		LoadWin32Font(fs, logfont, size, file_name.c_str());
-	}
 }

--- a/src/os/windows/font_win32.h
+++ b/src/os/windows/font_win32.h
@@ -41,6 +41,5 @@ public:
 };
 
 void LoadWin32Font(FontSize fs);
-void LoadWin32Font(FontSize fs, const std::string &file_name, uint size);
 
 #endif /* FONT_WIN32_H */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Size configuration for default font was ignored as a different code path to load the font was followed.

Size of default font could only be changed after manually setting the configured font to the default font name.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Resolved by removing this additional path and conditionally selecting the default font.

This allows the normal font size selection to occur, and reduces some special-casing for the default font.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
