### PR TITLE
Change: Use default NewGRF cargo translation table.

### DIFF
--- a/src/cargotype.cpp
+++ b/src/cargotype.cpp
@@ -42,6 +42,20 @@ CargoTypes _standard_cargo_mask;
 static std::vector<CargoLabel> _default_cargo_labels;
 
 /**
+ * Default cargo translation for upto version 7 NewGRFs.
+ * This maps the original 12 cargo slots to their original label. If a climate dependent cargo is not present it will
+ * map to CT_INVALID. For default cargoes this ends up as a 1:1 mapping via climate slot -> label -> cargo ID.
+ */
+static std::array<CargoLabel, 12> _v7_cargo_labels;
+
+/**
+ * Default cargo translation for version 8+ NewGRFs.
+ * This maps the 32 "bitnum" cargo slots to their original label. If a bitnum is not present it will
+ * map to CT_INVALID.
+ */
+static std::array<CargoLabel, 32> _v8_cargo_labels;
+
+/**
  * Set up the default cargo types for the given landscape type.
  * @param l Landscape
  */
@@ -51,6 +65,8 @@ void SetupCargoForClimate(LandscapeID l)
 
 	_cargo_mask = 0;
 	_default_cargo_labels.clear();
+	_v7_cargo_labels.fill(CT_INVALID);
+	_v8_cargo_labels.fill(CT_INVALID);
 
 	/* Copy from default cargo by label or index. */
 	auto insert = std::begin(CargoSpec::array);
@@ -75,6 +91,8 @@ void SetupCargoForClimate(LandscapeID l)
 		if (insert->IsValid()) {
 			SetBit(_cargo_mask, insert->Index());
 			_default_cargo_labels.push_back(insert->label);
+			_v7_cargo_labels[insert->Index()] = insert->label;
+			_v8_cargo_labels[insert->bitnum] = insert->label;
 		}
 		++insert;
 	}
@@ -83,6 +101,17 @@ void SetupCargoForClimate(LandscapeID l)
 	std::fill(insert, std::end(CargoSpec::array), CargoSpec{});
 
 	BuildCargoLabelMap();
+}
+
+/**
+ * Get default cargo translation table for a NewGRF, used if the NewGRF does not provide its own.
+ * @param grf_version GRF version of translation table.
+ * @return Default translation table for GRF version.
+ */
+std::span<const CargoLabel> GetDefaultCargoTranslationTable(uint8_t grf_version)
+{
+	if (grf_version < 8) return _v7_cargo_labels;
+	return _v8_cargo_labels;
 }
 
 /**
@@ -128,23 +157,6 @@ Dimension GetLargestCargoIconSize()
 		size = maxdim(size, GetSpriteSize(cs->GetCargoIcon()));
 	}
 	return size;
-}
-
-/**
- * Find the CargoID of a 'bitnum' value.
- * @param bitnum 'bitnum' to find.
- * @return First CargoID with the given bitnum, or #INVALID_CARGO if not found or if the provided \a bitnum is invalid.
- */
-CargoID GetCargoIDByBitnum(uint8_t bitnum)
-{
-	if (bitnum == INVALID_CARGO_BITNUM) return INVALID_CARGO;
-
-	for (const CargoSpec *cs : CargoSpec::Iterate()) {
-		if (cs->bitnum == bitnum) return cs->Index();
-	}
-
-	/* No matching label was found, so it is invalid */
-	return INVALID_CARGO;
 }
 
 /**

--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -205,7 +205,6 @@ extern CargoTypes _standard_cargo_mask;
 void SetupCargoForClimate(LandscapeID l);
 bool IsDefaultCargo(CargoID cid);
 void BuildCargoLabelMap();
-CargoID GetCargoIDByBitnum(uint8_t bitnum);
 
 inline CargoID GetCargoIDByLabel(CargoLabel label)
 {

--- a/src/newgrf_cargo.cpp
+++ b/src/newgrf_cargo.cpp
@@ -9,6 +9,7 @@
 
 #include "stdafx.h"
 #include "debug.h"
+#include "newgrf_cargo.h"
 #include "newgrf_spritegroup.h"
 
 #include "safeguards.h"
@@ -78,21 +79,14 @@ uint16_t GetCargoCallback(CallbackID callback, uint32_t param1, uint32_t param2,
  */
 CargoID GetCargoTranslation(uint8_t cargo, const GRFFile *grffile, bool usebit)
 {
-	/* Pre-version 7 uses the 'climate dependent' ID in callbacks and properties, i.e. cargo is the cargo ID */
-	if (grffile->grf_version < 7 && !usebit) {
-		if (cargo >= CargoSpec::GetArraySize() || !CargoSpec::Get(cargo)->IsValid()) return INVALID_CARGO;
-		return cargo;
+	/* Pre-version 7 uses the bitnum lookup from (standard in v8) instead of climate dependent in some places.. */
+	if (grffile->grf_version < 7 && usebit) {
+		auto default_table = GetDefaultCargoTranslationTable(8);
+		if (cargo < default_table.size()) return GetCargoIDByLabel(default_table[cargo]);
+		return INVALID_CARGO;
 	}
 
-	/* Other cases use (possibly translated) cargobits */
-
-	if (!grffile->cargo_list.empty()) {
-		/* ...and the cargo is in bounds, then get the cargo ID for
-		 * the label */
-		if (cargo < grffile->cargo_list.size()) return GetCargoIDByLabel(grffile->cargo_list[cargo]);
-	} else {
-		/* Else the cargo value is a 'climate independent' 'bitnum' */
-		return GetCargoIDByBitnum(cargo);
-	}
+	/* Look in translation table. */
+	if (cargo < grffile->cargo_list.size()) return GetCargoIDByLabel(grffile->cargo_list[cargo]);
 	return INVALID_CARGO;
 }

--- a/src/newgrf_cargo.h
+++ b/src/newgrf_cargo.h
@@ -33,4 +33,6 @@ SpriteID GetCustomCargoSprite(const CargoSpec *cs);
 uint16_t GetCargoCallback(CallbackID callback, uint32_t param1, uint32_t param2, const CargoSpec *cs);
 CargoID GetCargoTranslation(uint8_t cargo, const GRFFile *grffile, bool usebit = false);
 
+std::span<const CargoLabel> GetDefaultCargoTranslationTable(uint8_t grf_version);
+
 #endif /* NEWGRF_CARGO_H */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When loading NewGRFs without cargo translation table, we have to check to see if we need to perform a bitnum lookup or just treat the slot as a climate dependent cargo type.

This requires multiple special cases, and always assumes that cargo slots are in their original positions, which is not always the case.

This can result in unexpected behaviour when mixing old sets (Ikarus Buses) with modern sets (FIRS 5):

![image](https://github.com/user-attachments/assets/cb21725b-71e9-4145-9325-38c8b6d41ec9)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead of falling back to bitnum lookup or climate-dependent cargo types, install a default cargo translation table that performs either of these functions instead.

A NewGRF can still install its own translation table and there will be no change in this case.

This allows better mapping of climate-dependent or bitnum cargo slots, falling back to INVALID_CARGO if they are not defined, and reduces special-casing.

Because everything is now mapped via label, this should allow cargo types to be moved to different slots (as is permitted for default vehicles/houses/industries and anything that installs its own translation table.)

This gives better results mixing old (Ikarus) and new (FIRS 5):

![image](https://github.com/user-attachments/assets/b83cf980-a143-448e-9e7c-65bba61a3500)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Well... I think this breaks everything using pre-cargo-label cargo sets, but it's entirely possible they are already broken in 14.x. (Seem to be broken in at least 1.11.2, so probably nothing to be concerned with...)

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
