### PR TITLE
Fix 12643: _is_water_region_valid is not cleared/reset in AllocateWat…

### DIFF
--- a/src/pathfinder/water_regions.cpp
+++ b/src/pathfinder/water_regions.cpp
@@ -405,6 +405,7 @@ void AllocateWaterRegions()
 	_water_regions.clear();
 	_water_regions.reserve(number_of_regions);
 
+	_is_water_region_valid.clear();
 	_is_water_region_valid.resize(number_of_regions, false);
 
 	Debug(map, 2, "Allocating {} x {} water regions", GetWaterRegionMapSizeX(), GetWaterRegionMapSizeY());


### PR DESCRIPTION
## Motivation / Problem

Fixes #12643

## Description

The content of _is_water_region_valid was never properly cleared. This could lead to strange pathfinder behavior when starting a new game, and desyncs during a multiplayer game.

The solution is to simply clear the vector and then resize to the desired size. This sets all elements of the vector to false, which is the desired behavior.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
