### PR TITLE
Fix #12648: Ensure all uses of std::filesystem::path use native encoding.

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -489,7 +489,7 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 
 	_tar_list[this->subdir][filename] = std::string{};
 
-	std::string filename_base = std::filesystem::path(filename).filename().string();
+	std::string filename_base = FS2OTTD(std::filesystem::path(OTTD2FS(filename)).filename());
 	SimplifyFileName(filename_base);
 
 	TarHeader th;

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -386,7 +386,7 @@ void ReconsiderGameScriptLanguage()
 {
 	if (_current_data == nullptr) return;
 
-	std::string language = _current_language->file.stem().string();
+	std::string language = FS2OTTD(_current_language->file.stem());
 	for (auto &p : _current_data->compiled_strings) {
 		if (p.language == language) {
 			_current_data->cur_language = &p;

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -578,7 +578,7 @@ int openttd_main(std::span<char * const> arguments)
 			if (mgo.opt != nullptr) {
 				_file_to_saveload.name = mgo.opt;
 
-				std::string extension = std::filesystem::path(_file_to_saveload.name).extension().string();
+				std::string extension = FS2OTTD(std::filesystem::path(OTTD2FS(_file_to_saveload.name)).extension());
 				auto [ft, _] = FiosGetSavegameListCallback(SLO_LOAD, _file_to_saveload.name, extension);
 				if (ft == FIOS_TYPE_INVALID) {
 					std::tie(ft, _) = FiosGetScenarioListCallback(SLO_LOAD, _file_to_saveload.name, extension);
@@ -612,7 +612,7 @@ int openttd_main(std::span<char * const> arguments)
 				return ret;
 			}
 
-			std::string extension = std::filesystem::path(mgo.opt).extension().string();
+			std::string extension = FS2OTTD(std::filesystem::path(OTTD2FS(mgo.opt)).extension());
 			auto [_, title] = FiosGetSavegameListCallback(SLO_LOAD, mgo.opt, extension);
 
 			_load_check_data.Clear();

--- a/src/signature.cpp
+++ b/src/signature.cpp
@@ -245,7 +245,7 @@ static bool _ValidateSignatureFile(const std::string &filename)
 		return false;
 	}
 
-	std::string dirname = std::filesystem::path(filename).parent_path().string();
+	std::string dirname = FS2OTTD(std::filesystem::path(OTTD2FS(filename)).parent_path());
 
 	for (auto &signature : signatures["files"]) {
 		const std::string sig_filename = dirname + PATHSEPCHAR + signature["filename"].get<std::string>();

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1904,7 +1904,7 @@ bool ReadLanguagePack(const LanguageMetadata *lang)
 {
 	/* Current language pack */
 	size_t len = 0;
-	std::unique_ptr<LanguagePack, LanguagePackDeleter> lang_pack(reinterpret_cast<LanguagePack *>(ReadFileToMem(lang->file.string(), len, 1U << 20).release()));
+	std::unique_ptr<LanguagePack, LanguagePackDeleter> lang_pack(reinterpret_cast<LanguagePack *>(ReadFileToMem(FS2OTTD(lang->file), len, 1U << 20).release()));
 	if (!lang_pack) return false;
 
 	/* End of read data (+ terminating zero added in ReadFileToMem()) */
@@ -1953,7 +1953,7 @@ bool ReadLanguagePack(const LanguageMetadata *lang)
 
 	_current_language = lang;
 	_current_text_dir = (TextDirection)_current_language->text_dir;
-	_config_language_file = _current_language->file.filename().string();
+	_config_language_file = FS2OTTD(_current_language->file.filename());
 	SetCurrentGrfLangID(_current_language->newgrflangid);
 
 #ifdef _WIN32
@@ -2079,13 +2079,13 @@ static void FillLanguageList(const std::string &path)
 		if (dir_entry.path().extension() != ".lng") continue;
 
 		LanguageMetadata lmd;
-		lmd.file = FS2OTTD(dir_entry.path());
+		lmd.file = dir_entry.path();
 
 		/* Check whether the file is of the correct version */
-		if (!GetLanguageFileHeader(lmd.file.string(), &lmd)) {
-			Debug(misc, 3, "{} is not a valid language file", lmd.file);
+		if (!GetLanguageFileHeader(FS2OTTD(lmd.file), &lmd)) {
+			Debug(misc, 3, "{} is not a valid language file", FS2OTTD(lmd.file));
 		} else if (GetLanguage(lmd.newgrflangid) != nullptr) {
-			Debug(misc, 3, "{}'s language ID is already known", lmd.file);
+			Debug(misc, 3, "{}'s language ID is already known", FS2OTTD(lmd.file));
 		} else {
 			_languages.push_back(lmd);
 		}
@@ -2119,7 +2119,7 @@ void InitializeLanguagePacks()
 		/* We are trying to find a default language. The priority is by
 		 * configuration file, local environment and last, if nothing found,
 		 * English. */
-		if (_config_language_file == lng.file.filename()) {
+		if (_config_language_file == FS2OTTD(lng.file.filename())) {
 			chosen_language = &lng;
 			break;
 		}
@@ -2139,7 +2139,7 @@ void InitializeLanguagePacks()
 		chosen_language = (language_fallback != nullptr) ? language_fallback : en_GB_fallback;
 	}
 
-	if (!ReadLanguagePack(chosen_language)) UserError("Can't read language pack '{}'", chosen_language->file);
+	if (!ReadLanguagePack(chosen_language)) UserError("Can't read language pack '{}'", FS2OTTD(chosen_language->file));
 }
 
 /**

--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -258,7 +258,7 @@ void SurveyConfiguration(nlohmann::json &survey)
 {
 	survey["network"] = _networking ? (_network_server ? "server" : "client") : "no";
 	if (_current_language != nullptr) {
-		survey["language"]["filename"] = _current_language->file.filename().string();
+		survey["language"]["filename"] = FS2OTTD(_current_language->file.filename());
 		survey["language"]["name"] = _current_language->name;
 		survey["language"]["isocode"] = _current_language->isocode;
 	}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

std::filesystem::path does not expect UTF-8 strings, and it seems may produce invalid results when done so, so they must be converted to native format first (and back to utf-8 after.)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Ensure strings passed to std::filesystem::path go through OTTD2FS conversion, and back to UTF-8 with FS2OTTD after.

Sadly std::filesystem::path will implicitly convert a std::string, so it's difficult to catch all case.

This is not the correct way to deal with this situation. C++20 would like us to use std::u8string everything, but that is not really feasible. So this is a quick & dirty fix without adding too much code.

Maybe fixes #12648 .

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
