### PR TITLE
Codechange: Use vector/string instead of malloc when reading music cat file data.

### DIFF
--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -313,7 +313,7 @@ static const uint NUM_SONGS_AVAILABLE = 1 + NUM_SONG_CLASSES * NUM_SONGS_CLASS;
 static const uint NUM_SONGS_PLAYLIST  = 32;
 
 /* Functions to read DOS music CAT files, similar to but not quite the same as sound effect CAT files */
-char *GetMusicCatEntryName(const std::string &filename, size_t entrynum);
+std::optional<std::string> GetMusicCatEntryName(const std::string &filename, size_t entrynum);
 uint8_t *GetMusicCatEntryData(const std::string &filename, size_t entrynum, size_t &entrylen);
 
 enum MusicTrackType {

--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -314,7 +314,7 @@ static const uint NUM_SONGS_PLAYLIST  = 32;
 
 /* Functions to read DOS music CAT files, similar to but not quite the same as sound effect CAT files */
 std::optional<std::string> GetMusicCatEntryName(const std::string &filename, size_t entrynum);
-uint8_t *GetMusicCatEntryData(const std::string &filename, size_t entrynum, size_t &entrylen);
+std::optional<std::vector<uint8_t>> GetMusicCatEntryData(const std::string &filename, size_t entrynum);
 
 enum MusicTrackType {
 	MTT_STANDARDMIDI, ///< Standard MIDI file

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -8,6 +8,7 @@
 /** @file music.cpp The songs that OpenTTD knows. */
 
 #include "stdafx.h"
+#include "string_func.h"
 
 
 /** The type of set we're replacing */
@@ -22,26 +23,24 @@
  * Read the name of a music CAT file entry.
  * @param filename Name of CAT file to read from
  * @param entrynum Index of entry whose name to read
- * @return Pointer to string, caller is responsible for freeing memory,
- *         nullptr if entrynum does not exist.
+ * @return Name of CAT file entry if it could be read.
  */
-char *GetMusicCatEntryName(const std::string &filename, size_t entrynum)
+std::optional<std::string> GetMusicCatEntryName(const std::string &filename, size_t entrynum)
 {
-	if (!FioCheckFileExists(filename, BASESET_DIR)) return nullptr;
+	if (!FioCheckFileExists(filename, BASESET_DIR)) return std::nullopt;
 
 	RandomAccessFile file(filename, BASESET_DIR);
 	uint32_t ofs = file.ReadDword();
 	size_t entry_count = ofs / 8;
-	if (entrynum < entry_count) {
-		file.SeekTo(entrynum * 8, SEEK_SET);
-		file.SeekTo(file.ReadDword(), SEEK_SET);
-		uint8_t namelen = file.ReadByte();
-		char *name = MallocT<char>(namelen + 1);
-		file.ReadBlock(name, namelen);
-		name[namelen] = '\0';
-		return name;
-	}
-	return nullptr;
+	if (entrynum >= entry_count) return std::nullopt;
+
+	file.SeekTo(entrynum * 8, SEEK_SET);
+	file.SeekTo(file.ReadDword(), SEEK_SET);
+	uint8_t namelen = file.ReadByte();
+
+	std::string name(namelen, '\0');
+	file.ReadBlock(name.data(), namelen);
+	return StrMakeValid(name);
 }
 
 /**
@@ -138,13 +137,12 @@ bool MusicSet::FillSetDetails(const IniFile &ini, const std::string &path, const
 				/* Song has a CAT file index, assume it's MPS MIDI format */
 				this->songinfo[i].filetype = MTT_MPSMIDI;
 				this->songinfo[i].cat_index = atoi(item->value->c_str());
-				char *songname = GetMusicCatEntryName(filename, this->songinfo[i].cat_index);
-				if (songname == nullptr) {
+				auto songname = GetMusicCatEntryName(filename, this->songinfo[i].cat_index);
+				if (!songname.has_value()) {
 					Debug(grf, 0, "Base music set song missing from CAT file: {}/{}", filename, this->songinfo[i].cat_index);
 					continue;
 				}
-				this->songinfo[i].songname = songname;
-				free(songname);
+				this->songinfo[i].songname = *songname;
 			} else {
 				this->songinfo[i].filetype = MTT_STANDARDMIDI;
 			}

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -843,11 +843,9 @@ bool MidiFile::LoadSong(const MusicSongInfo &song)
 			return this->LoadFile(song.filename);
 		case MTT_MPSMIDI:
 		{
-			size_t songdatalen = 0;
-			uint8_t *songdata = GetMusicCatEntryData(song.filename, song.cat_index, songdatalen);
-			if (songdata != nullptr) {
-				bool result = this->LoadMpsData(songdata, songdatalen);
-				free(songdata);
+			auto songdata = GetMusicCatEntryData(song.filename, song.cat_index);
+			if (songdata.has_value()) {
+				bool result = this->LoadMpsData(songdata->data(), songdata->size());
 				return result;
 			} else {
 				return false;
@@ -1078,17 +1076,13 @@ std::string MidiFile::GetSMFFile(const MusicSongInfo &song)
 		return output_filename;
 	}
 
-	uint8_t *data;
-	size_t datalen;
-	data = GetMusicCatEntryData(song.filename, song.cat_index, datalen);
-	if (data == nullptr) return std::string();
+	auto songdata = GetMusicCatEntryData(song.filename, song.cat_index);
+	if (!songdata.has_value()) return std::string();
 
 	MidiFile midifile;
-	if (!midifile.LoadMpsData(data, datalen)) {
-		free(data);
+	if (!midifile.LoadMpsData(songdata->data(), songdata->size())) {
 		return std::string();
 	}
-	free(data);
 
 	if (midifile.WriteSMF(output_filename)) {
 		return output_filename;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`GetMusicCatEntryName()` and `GetMusicCatEntryData()` both allocate memory with malloc, which needs to be freed by the caller.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

## Description

Instead return the data as `std:;string` or `std::vector`, so no manual cleaning up is necessary.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
