### PR TITLE
Add: [NewGRF] Extended custom waypoint classes.

### DIFF
--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -188,7 +188,7 @@ void RoadStopUpdateCachedTriggers(BaseStation *st);
  */
 inline bool IsWaypointClass(const RoadStopClass &cls)
 {
-	return cls.global_id == ROADSTOP_CLASS_LABEL_WAYPOINT;
+	return cls.global_id == ROADSTOP_CLASS_LABEL_WAYPOINT || GB(cls.global_id, 24, 8) == UINT8_MAX;
 }
 
 #endif /* NEWGRF_ROADSTATION_H */

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -188,7 +188,7 @@ const StationSpec *GetStationSpec(TileIndex t);
  */
 inline bool IsWaypointClass(const StationClass &cls)
 {
-	return cls.global_id == STATION_CLASS_LABEL_WAYPOINT;
+	return cls.global_id == STATION_CLASS_LABEL_WAYPOINT || GB(cls.global_id, 24, 8) == UINT8_MAX;
 }
 
 /* Evaluate a tile's position within a station, and return the result a bitstuffed format. */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Authors have asked for more custom waypoint classes, as lumping all waypoints into just one class gives a very big list.

The simplest way to achieve this, instead of adding more properties, is to allow more classes to be treated as waypoints.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

With this PR, station class labels with the first byte set to 0xFF will be treated in the same way as the 'WAYP' class. Also applies to road stop waypoints, although those are not supported yet.

This allows waypoints to be split into categories just like stations, instead of all being lumped together.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/07ab67dc-3b02-48b5-aa00-a31a70f521f3)

Modified version of UK Waypoints for testing:

[UK_Waypoints-1.zip](https://github.com/OpenTTD/OpenTTD/files/15281355/UK_Waypoints-1.zip)
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

## Limitations

My review of all the custom station and roadstop NewGRF files I have available showed that they all use only ASCII characters for the class label. Therefore, the 0xFF marker was chosen because it minimises the chance of conflicts with existing NewGRFs... but it's not impossible.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review


Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
