### PR TITLE
Cleanup: Remove GetUnitsPerEM and units_per_em.

### DIFF
--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -33,8 +33,7 @@ FontCacheSettings _fcsettings;
  * @param fs The size of the font.
  */
 FontCache::FontCache(FontSize fs) : parent(FontCache::Get(fs)), fs(fs), height(_default_font_height[fs]),
-		ascender(_default_font_ascender[fs]), descender(_default_font_ascender[fs] - _default_font_height[fs]),
-		units_per_em(1)
+		ascender(_default_font_ascender[fs]), descender(_default_font_ascender[fs] - _default_font_height[fs])
 {
 	assert(this->parent == nullptr || this->fs == this->parent->fs);
 	FontCache::caches[this->fs] = this;

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -26,7 +26,6 @@ protected:
 	int height;                       ///< The height of the font.
 	int ascender;                     ///< The ascender value of the font.
 	int descender;                    ///< The descender value of the font.
-	int units_per_em;                 ///< The units per EM value of the font.
 
 public:
 	FontCache(FontSize fs);
@@ -59,12 +58,6 @@ public:
 	 * @return The descender value of the font.
 	 */
 	inline int GetDescender() const{ return this->descender; }
-
-	/**
-	 * Get the units per EM value of the font.
-	 * @return The units per EM value of the font.
-	 */
-	inline int GetUnitsPerEM() const { return this->units_per_em; }
 
 	/**
 	 * Get the nominal font size of the font.

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -105,7 +105,6 @@ void FreeTypeFontCache::SetFontSize(FontSize, FT_Face, int pixels)
 	}
 
 	if (err == FT_Err_Ok) {
-		this->units_per_em = this->face->units_per_EM;
 		this->ascender     = this->face->size->metrics.ascender >> 6;
 		this->descender    = this->face->size->metrics.descender >> 6;
 		this->height       = this->ascender - this->descender;

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -166,7 +166,6 @@ void CoreTextFontCache::SetFontSize(int pixels)
 	/* Query the font metrics we needed. We generally round all values up to
 	 * make sure we don't inadvertently cut off a row or column of pixels,
 	 * except when determining glyph to glyph advances. */
-	this->units_per_em = CTFontGetUnitsPerEm(this->font.get());
 	this->ascender = (int)std::ceil(CTFontGetAscent(this->font.get()));
 	this->descender = -(int)std::ceil(CTFontGetDescent(this->font.get()));
 	this->height = this->ascender - this->descender;

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -168,7 +168,6 @@ void Win32FontCache::SetFontSize(int pixels)
 	POUTLINETEXTMETRIC otm = (POUTLINETEXTMETRIC)new BYTE[otmSize];
 	GetOutlineTextMetrics(this->dc, otmSize, otm);
 
-	this->units_per_em = otm->otmEMSquare;
 	this->ascender = otm->otmTextMetrics.tmAscent;
 	this->descender = otm->otmTextMetrics.tmDescent;
 	this->height = this->ascender + this->descender;


### PR DESCRIPTION

<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Fontcache member `units_per_em` is initialised when loading a font, and only used by `GetUnitsPerEM()`, which is never called.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Remove both `GetUnitsPerEM()` and `units_per_em`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
