### PR TITLE
Fix #12563: Race condition setting finish flag in WinHTTP

### DIFF
--- a/src/network/core/http_winhttp.cpp
+++ b/src/network/core/http_winhttp.cpp
@@ -121,8 +121,8 @@ void NetworkHTTPRequest::WinHttpCallback(DWORD code, void *info, DWORD length)
 			/* Make sure we are not in a redirect loop. */
 			if (this->depth++ > 5) {
 				Debug(net, 0, "HTTP request failed: too many redirects");
-				this->finished = true;
 				this->callback.OnFailure();
+				this->finished = true;
 				return;
 			}
 			break;
@@ -144,8 +144,8 @@ void NetworkHTTPRequest::WinHttpCallback(DWORD code, void *info, DWORD length)
 			if (status_code >= 400) {
 				/* No need to be verbose about rate limiting. */
 				Debug(net, status_code == HTTP_429_TOO_MANY_REQUESTS ? 1 : 0, "HTTP request failed: status-code {}", status_code);
-				this->finished = true;
 				this->callback.OnFailure();
+				this->finished = true;
 				return;
 			}
 
@@ -183,14 +183,14 @@ void NetworkHTTPRequest::WinHttpCallback(DWORD code, void *info, DWORD length)
 		case WINHTTP_CALLBACK_STATUS_SECURE_FAILURE:
 		case WINHTTP_CALLBACK_STATUS_REQUEST_ERROR:
 			Debug(net, 0, "HTTP request failed: {}", GetLastErrorAsString());
-			this->finished = true;
 			this->callback.OnFailure();
+			this->finished = true;
 			break;
 
 		default:
 			Debug(net, 0, "HTTP request failed: unexepected callback code 0x{:x}", code);
-			this->finished = true;
 			this->callback.OnFailure();
+			this->finished = true;
 			return;
 	}
 }
@@ -233,8 +233,8 @@ void NetworkHTTPRequest::Connect()
 	this->connection = WinHttpConnect(_winhttp_session, url_components.lpszHostName, url_components.nPort, 0);
 	if (this->connection == nullptr) {
 		Debug(net, 0, "HTTP request failed: {}", GetLastErrorAsString());
-		this->finished = true;
 		this->callback.OnFailure();
+		this->finished = true;
 		return;
 	}
 
@@ -243,8 +243,8 @@ void NetworkHTTPRequest::Connect()
 		WinHttpCloseHandle(this->connection);
 
 		Debug(net, 0, "HTTP request failed: {}", GetLastErrorAsString());
-		this->finished = true;
 		this->callback.OnFailure();
+		this->finished = true;
 		return;
 	}
 
@@ -267,8 +267,8 @@ bool NetworkHTTPRequest::Receive()
 {
 	if (this->callback.cancelled && !this->finished) {
 		Debug(net, 1, "HTTP request failed: cancelled by user");
-		this->finished = true;
 		this->callback.OnFailure();
+		this->finished = true;
 		/* Fall-through, as we are waiting for IsQueueEmpty() to happen. */
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Fixes #12563

## Description

Set finished flag after appending failure callback, instead of before (i.e. release semantics).

`NetworkHTTPRequest::Receive` is not required to be changed because it already has the required semantics.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
