### PR TITLE
Feature: Allow manually placing town buildings in scenario editor.

### DIFF
--- a/src/command_type.h
+++ b/src/command_type.h
@@ -283,6 +283,7 @@ enum Commands : uint16_t {
 	CMD_TOWN_SET_TEXT,                ///< set the custom text of a town
 	CMD_EXPAND_TOWN,                  ///< expand a town
 	CMD_DELETE_TOWN,                  ///< delete a town
+	CMD_PLACE_HOUSE,                  ///< place a house
 
 	CMD_ORDER_REFIT,                  ///< change the refit information of an order (for "goto depot" )
 	CMD_CLONE_ORDER,                  ///< clone (and share) an order

--- a/src/house.h
+++ b/src/house.h
@@ -32,7 +32,7 @@ static const HouseID INVALID_HOUSE_ID = 0xFFFF;
 static const uint HOUSE_NUM_ACCEPTS = 16; ///< Max number of cargoes accepted by a tile
 static const uint HOUSE_ORIGINAL_NUM_ACCEPTS = 3; ///< Original number of accepted cargo types.
 
-enum BuildingFlags {
+enum BuildingFlags : uint8_t {
 	TILE_NO_FLAG         =       0,
 	TILE_SIZE_1x1        = 1U << 0,
 	TILE_NOT_SLOPED      = 1U << 1,
@@ -50,7 +50,7 @@ enum BuildingFlags {
 };
 DECLARE_ENUM_AS_BIT_SET(BuildingFlags)
 
-enum HouseZonesBits {
+enum HouseZonesBits : uint8_t {
 	HZB_BEGIN     = 0,
 	HZB_TOWN_EDGE = 0,
 	HZB_TOWN_OUTSKIRT,
@@ -63,7 +63,7 @@ static_assert(HZB_END == 5);
 
 DECLARE_POSTFIX_INCREMENT(HouseZonesBits)
 
-enum HouseZones {                  ///< Bit  Value       Meaning
+enum HouseZones : uint16_t {
 	HZ_NOZNS             = 0x0000,  ///<       0          This is just to get rid of zeros, meaning none
 	HZ_ZON1              = 1U << HZB_TOWN_EDGE,    ///< 0..4 1,2,4,8,10  which town zones the building can be built in, Zone1 been the further suburb
 	HZ_ZON2              = 1U << HZB_TOWN_OUTSKIRT,
@@ -80,7 +80,7 @@ enum HouseZones {                  ///< Bit  Value       Meaning
 };
 DECLARE_ENUM_AS_BIT_SET(HouseZones)
 
-enum HouseExtraFlags {
+enum HouseExtraFlags : uint8_t {
 	NO_EXTRA_FLAG            =       0,
 	BUILDING_IS_HISTORICAL   = 1U << 0,  ///< this house will only appear during town generation in random games, thus the historical
 	BUILDING_IS_PROTECTED    = 1U << 1,  ///< towns and AI will not remove this house, while human players will be able to

--- a/src/house.h
+++ b/src/house.h
@@ -136,4 +136,6 @@ inline HouseID GetTranslatedHouseID(HouseID hid)
 	return hs->grf_prop.override == INVALID_HOUSE_ID ? hid : hs->grf_prop.override;
 }
 
+void ShowBuildHousePicker(struct Window *);
+
 #endif /* HOUSE_H */

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -437,6 +437,9 @@ STR_SCENEDIT_FILE_MENU_QUIT_EDITOR                              :Abandon scenari
 STR_SCENEDIT_FILE_MENU_SEPARATOR                                :
 STR_SCENEDIT_FILE_MENU_QUIT                                     :Exit
 
+STR_SCENEDIT_TOWN_MENU_BUILD_TOWN                               :Generate towns
+STR_SCENEDIT_TOWN_MENU_PACE_HOUSE                               :Place houses
+
 # Settings menu
 ###length 16
 STR_SETTINGS_MENU_GAME_OPTIONS                                  :Game options
@@ -2814,6 +2817,16 @@ STR_PICKER_ROADSTOP_TRUCK_CLASS_TOOLTIP                         :Select a lorry 
 STR_PICKER_ROADSTOP_TRUCK_TYPE_TOOLTIP                          :Select a lorry station type to build. Ctrl+Click to add or remove in saved items
 STR_PICKER_OBJECT_CLASS_TOOLTIP                                 :Select an object class to display
 STR_PICKER_OBJECT_TYPE_TOOLTIP                                  :Select an object type to build. Ctrl+Click to add or remove in saved items. Ctrl+Click+Drag to select the area diagonally. Also press Shift to show cost estimate only
+STR_PICKER_HOUSE_CLASS_TOOLTIP                                  :Select a town zone to display
+STR_PICKER_HOUSE_TYPE_TOOLTIP                                   :Select a house type to build. Ctrl+Click to add or remove in saved items
+
+STR_HOUSE_PICKER_CAPTION                                        :House Selection
+
+STR_HOUSE_PICKER_CLASS_ZONE1                                    :Edge
+STR_HOUSE_PICKER_CLASS_ZONE2                                    :Outskirts
+STR_HOUSE_PICKER_CLASS_ZONE3                                    :Outer Suburbs
+STR_HOUSE_PICKER_CLASS_ZONE4                                    :Inner Suburbs
+STR_HOUSE_PICKER_CLASS_ZONE5                                    :Town centre
 
 STR_STATION_CLASS_DFLT                                          :Default
 STR_STATION_CLASS_DFLT_STATION                                  :Default station
@@ -5001,6 +5014,7 @@ STR_ERROR_NO_SPACE_FOR_TOWN                                     :{WHITE}... ther
 STR_ERROR_ROAD_WORKS_IN_PROGRESS                                :{WHITE}Road works in progress
 STR_ERROR_TOWN_CAN_T_DELETE                                     :{WHITE}Can't delete this town...{}A station or depot is referring to the town or a town owned tile can't be removed
 STR_ERROR_STATUE_NO_SUITABLE_PLACE                              :{WHITE}... there is no suitable place for a statue in the centre of this town
+STR_ERROR_CAN_T_BUILD_HOUSE                                     :{WHITE}Can't build house...
 
 # Industry related errors
 STR_ERROR_TOO_MANY_INDUSTRIES                                   :{WHITE}... too many industries

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -173,6 +173,15 @@ void InitializeBuildingCounts()
 }
 
 /**
+ * Get read-only span of total HouseID building counts.
+ * @return span of HouseID building counts.
+ */
+std::span<const uint> GetBuildingHouseIDCounts()
+{
+	return _building_counts.id_count;
+}
+
+/**
  * IncreaseBuildingCount()
  * Increase the count of a building when it has been added by a town.
  * @param t The town that the building is being built in

--- a/src/newgrf_house.h
+++ b/src/newgrf_house.h
@@ -24,6 +24,7 @@ struct HouseScopeResolver : public ScopeResolver {
 	bool not_yet_constructed;      ///< True for construction check.
 	uint16_t initial_random_bits;    ///< Random bits during construction checks.
 	CargoTypes watched_cargo_triggers; ///< Cargo types that triggered the watched cargo callback.
+	int view; ///< View when house does yet exist.
 
 	/**
 	 * Constructor of a house scope resolver.
@@ -36,9 +37,9 @@ struct HouseScopeResolver : public ScopeResolver {
 	 * @param watched_cargo_triggers Cargo types that triggered the watched cargo callback.
 	 */
 	HouseScopeResolver(ResolverObject &ro, HouseID house_id, TileIndex tile, Town *town,
-			bool not_yet_constructed, uint8_t initial_random_bits, CargoTypes watched_cargo_triggers)
+			bool not_yet_constructed, uint8_t initial_random_bits, CargoTypes watched_cargo_triggers, int view)
 		: ScopeResolver(ro), house_id(house_id), tile(tile), town(town), not_yet_constructed(not_yet_constructed),
-		initial_random_bits(initial_random_bits), watched_cargo_triggers(watched_cargo_triggers)
+		initial_random_bits(initial_random_bits), watched_cargo_triggers(watched_cargo_triggers), view(view)
 	{
 	}
 
@@ -54,7 +55,7 @@ struct HouseResolverObject : public ResolverObject {
 
 	HouseResolverObject(HouseID house_id, TileIndex tile, Town *town,
 			CallbackID callback = CBID_NO_CALLBACK, uint32_t param1 = 0, uint32_t param2 = 0,
-			bool not_yet_constructed = false, uint8_t initial_random_bits = 0, CargoTypes watched_cargo_triggers = 0);
+			bool not_yet_constructed = false, uint8_t initial_random_bits = 0, CargoTypes watched_cargo_triggers = 0, int view = 0);
 
 	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override
 	{
@@ -94,13 +95,14 @@ void InitializeBuildingCounts();
 void InitializeBuildingCounts(Town *t);
 void IncreaseBuildingCount(Town *t, HouseID house_id);
 void DecreaseBuildingCount(Town *t, HouseID house_id);
+std::span<const uint> GetBuildingHouseIDCounts();
 
 void DrawNewHouseTile(TileInfo *ti, HouseID house_id);
 void AnimateNewHouseTile(TileIndex tile);
 void AnimateNewHouseConstruction(TileIndex tile);
 
 uint16_t GetHouseCallback(CallbackID callback, uint32_t param1, uint32_t param2, HouseID house_id, Town *town, TileIndex tile,
-		bool not_yet_constructed = false, uint8_t initial_random_bits = 0, CargoTypes watched_cargo_triggers = 0);
+		bool not_yet_constructed = false, uint8_t initial_random_bits = 0, CargoTypes watched_cargo_triggers = 0, int view = 0);
 void WatchedCargoCallback(TileIndex tile, CargoTypes trigger_cargoes);
 
 bool CanDeleteHouse(TileIndex tile);

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -12,6 +12,7 @@
 #include "clear_map.h"
 #include "company_func.h"
 #include "company_base.h"
+#include "house.h"
 #include "gui.h"
 #include "window_gui.h"
 #include "window_func.h"

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -16,6 +16,7 @@
 #include "dropdown_type.h"
 #include "dropdown_func.h"
 #include "dropdown_common_type.h"
+#include "house.h"
 #include "vehicle_gui.h"
 #include "rail_gui.h"
 #include "road.h"
@@ -1211,12 +1212,18 @@ static CallBackFunction ToolbarScenGenLand(Window *w)
 	return CBF_NONE;
 }
 
-
-static CallBackFunction ToolbarScenGenTown(Window *w)
+static CallBackFunction ToolbarScenGenTownClick(Window *w)
 {
-	w->HandleButtonClick(WID_TE_TOWN_GENERATE);
-	if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
-	ShowFoundTownWindow();
+	PopupMainToolbarMenu(w, WID_TE_TOWN_GENERATE, {STR_SCENEDIT_TOWN_MENU_BUILD_TOWN, STR_SCENEDIT_TOWN_MENU_PACE_HOUSE});
+	return CBF_NONE;
+}
+
+static CallBackFunction ToolbarScenGenTown(int index)
+{
+	switch (index) {
+		case 0: ShowFoundTownWindow(); break;
+		case 1: ShowBuildHousePicker(nullptr); break;
+	}
 	return CBF_NONE;
 }
 
@@ -2223,7 +2230,7 @@ static MenuClickedProc * const _scen_toolbar_dropdown_procs[] = {
 	nullptr,              // 9
 	nullptr,              // 10
 	nullptr,              // 11
-	nullptr,              // 12
+	ToolbarScenGenTown,   // 12
 	nullptr,              // 13
 	ToolbarScenBuildRoad, // 14
 	ToolbarScenBuildTram, // 15
@@ -2249,7 +2256,7 @@ static ToolbarButtonProc * const _scen_toolbar_button_procs[] = {
 	ToolbarZoomInClick,
 	ToolbarZoomOutClick,
 	ToolbarScenGenLand,
-	ToolbarScenGenTown,
+	ToolbarScenGenTownClick,
 	ToolbarScenGenIndustry,
 	ToolbarScenBuildRoadClick,
 	ToolbarScenBuildTramClick,
@@ -2376,7 +2383,7 @@ struct ScenarioEditorToolbarWindow : Window {
 			case MTEHK_SETTINGS:               ShowGameOptions(); break;
 			case MTEHK_SAVEGAME:               MenuClickSaveLoad(); break;
 			case MTEHK_GENLAND:                ToolbarScenGenLand(this); break;
-			case MTEHK_GENTOWN:                ToolbarScenGenTown(this); break;
+			case MTEHK_GENTOWN:                ToolbarScenGenTownClick(this); break;
 			case MTEHK_GENINDUSTRY:            ToolbarScenGenIndustry(this); break;
 			case MTEHK_BUILD_ROAD:             ToolbarScenBuildRoadClick(this); break;
 			case MTEHK_BUILD_TRAM:             ToolbarScenBuildTramClick(this); break;

--- a/src/town.h
+++ b/src/town.h
@@ -320,5 +320,6 @@ inline uint16_t TownTicksToGameTicks(uint16_t ticks)
 
 RoadType GetTownRoadType();
 bool CheckTownRoadTypes();
+std::span<const DrawBuildingsTileStruct> GetTownDrawTileData();
 
 #endif /* TOWN_H */

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -4066,3 +4066,8 @@ extern const TileTypeProcs _tile_type_town_procs = {
 	GetFoundation_Town,      // get_foundation_proc
 	TerraformTile_Town,      // terraform_tile_proc
 };
+
+std::span<const DrawBuildingsTileStruct> GetTownDrawTileData()
+{
+	return _town_draw_tile_data;
+}

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -232,7 +232,7 @@ enum TownGrowthResult {
 //	GROWTH_SEARCH_RUNNING >=  1
 };
 
-static bool BuildTownHouse(Town *t, TileIndex tile);
+static bool TryBuildTownHouse(Town *t, TileIndex tile);
 static Town *CreateRandomTown(uint attempts, uint32_t townnameparts, TownSize size, bool city, TownLayout layout);
 
 static void TownDrawHouseLift(const TileInfo *ti)
@@ -694,7 +694,7 @@ static void TileLoop_Town(TileIndex tile)
 				}
 			}
 
-			BuildTownHouse(t, tile);
+			TryBuildTownHouse(t, tile);
 		}
 	}
 
@@ -1183,7 +1183,7 @@ static bool GrowTownWithExtraHouse(Town *t, TileIndex tile)
 
 		/* If there are enough neighbors stop here */
 		if (counter >= 3) {
-			if (BuildTownHouse(t, tile)) {
+			if (TryBuildTownHouse(t, tile)) {
 				_grow_town_result = GROWTH_SUCCEED;
 				return true;
 			}
@@ -1668,7 +1668,7 @@ static void GrowTownInTile(TileIndex *tile_ptr, RoadBits cur_rb, DiagDirection t
 
 				/* And build a house.
 				 * Set result to -1 if we managed to build it. */
-				if (BuildTownHouse(t1, house_tile)) {
+				if (TryBuildTownHouse(t1, house_tile)) {
 					_grow_town_result = GROWTH_SUCCEED;
 				}
 			}
@@ -2672,7 +2672,7 @@ static bool CheckTownBuild2x2House(TileIndex *tile, Town *t, int maxz, bool nosl
  * @param tile The tile to try building on.
  * @return false iff no house can be built on this tile.
  */
-static bool BuildTownHouse(Town *t, TileIndex tile)
+static bool TryBuildTownHouse(Town *t, TileIndex tile)
 {
 	/* forbidden building here by town layout */
 	if (!TownLayoutAllowsHouseHere(t, tile)) return false;

--- a/src/town_cmd.h
+++ b/src/town_cmd.h
@@ -15,6 +15,7 @@
 #include "town_type.h"
 
 enum TownAcceptanceEffect : uint8_t;
+using HouseID = uint16_t;
 
 std::tuple<CommandCost, Money, TownID> CmdFoundTown(DoCommandFlag flags, TileIndex tile, TownSize size, bool city, TownLayout layout, bool random_location, uint32_t townnameparts, const std::string &text);
 CommandCost CmdRenameTown(DoCommandFlag flags, TownID town_id, const std::string &text);
@@ -25,6 +26,7 @@ CommandCost CmdTownCargoGoal(DoCommandFlag flags, TownID town_id, TownAcceptance
 CommandCost CmdTownSetText(DoCommandFlag flags, TownID town_id, const std::string &text);
 CommandCost CmdExpandTown(DoCommandFlag flags, TownID town_id, uint32_t grow_amount);
 CommandCost CmdDeleteTown(DoCommandFlag flags, TownID town_id);
+CommandCost CmdPlaceHouse(DoCommandFlag flags, TileIndex tile, HouseID house);
 
 DEF_CMD_TRAIT(CMD_FOUND_TOWN,       CmdFoundTown,      CMD_DEITY | CMD_NO_TEST,  CMDT_LANDSCAPE_CONSTRUCTION) // founding random town can fail only in exec run
 DEF_CMD_TRAIT(CMD_RENAME_TOWN,      CmdRenameTown,     CMD_DEITY | CMD_SERVER,   CMDT_OTHER_MANAGEMENT)
@@ -35,6 +37,7 @@ DEF_CMD_TRAIT(CMD_TOWN_RATING,      CmdTownRating,     CMD_DEITY,               
 DEF_CMD_TRAIT(CMD_TOWN_SET_TEXT,    CmdTownSetText,    CMD_DEITY | CMD_STR_CTRL, CMDT_OTHER_MANAGEMENT)
 DEF_CMD_TRAIT(CMD_EXPAND_TOWN,      CmdExpandTown,     CMD_DEITY,                CMDT_LANDSCAPE_CONSTRUCTION)
 DEF_CMD_TRAIT(CMD_DELETE_TOWN,      CmdDeleteTown,     CMD_OFFLINE,              CMDT_LANDSCAPE_CONSTRUCTION)
+DEF_CMD_TRAIT(CMD_PLACE_HOUSE,      CmdPlaceHouse,     CMD_DEITY,                CMDT_OTHER_MANAGEMENT)
 
 CommandCallback CcFoundTown;
 void CcFoundRandomTown(Commands cmd, const CommandCost &result, Money, TownID town_id);

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -376,6 +376,12 @@ enum WindowClass {
 	WC_BUILD_OBJECT,
 
 	/**
+	 * Build house; %Window numbers:
+	 *   - 0 = #BuildHouseWidgets
+	 */
+	WC_BUILD_HOUSE,
+
+	/**
 	 * Build vehicle; %Window numbers:
 	 *   - #VehicleType = #BuildVehicleWidgets
 	 *   - #TileIndex = #BuildVehicleWidgets


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Very little manual control over where houses are placed in towns. This is mostly to be expected as the game is meant to manage towns itself, however some manual control in the Scenario Editor (and perhaps a Sandbox mode) might be useful.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

* Add a network command to manually place houses. (Not strictly necessary for Scenario Editor but very useful for a sandbox mode.)
* Allow Houses to be resolved without a Town and Tile.
* Add a Town House builder to the Scenario Editor. This is accessed from the Landscaping toolbar as there is no town toolbar.

Once placed these houses behave like any other and can be removed by players and towns.

Uses the unified picker system, so also supports used/saved favourites. As town building don't have class labels, town zones are use to imitate them.

Houses sometimes have up to 4 variations, selected psuedo randomly based on tile. The House Selection window does not provide a way to choose between these, as there is no manual control, so in order to represent them in the UI it will cycle through each variation every 2.5 seconds.

"Some highly advanced town planning"
![image](https://github.com/OpenTTD/OpenTTD/assets/639850/1bedfaa7-d996-43ca-869b-be04a7d5f560)

More of the same, with NewGRFs...
![image](https://github.com/OpenTTD/OpenTTD/assets/639850/9660ce1e-e76b-4e0c-8963-6292a0f9cf4b)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This is limited to Scenario Editor only. No sandbox mode as been implemented as the Sandbox Settings window is still using the old cheats system.

Once that is changed to use normal settings, not much effort is required to enable this.


<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
