### PR TITLE
Cleanup: remove unused Aystar variables

### DIFF
--- a/src/pathfinder/aystar.cpp
+++ b/src/pathfinder/aystar.cpp
@@ -130,17 +130,12 @@ void AyStar::CheckTile(AyStarNode *current, OpenListNode *parent)
 	/* Check if this item is already in the OpenList */
 	check = this->OpenListIsInList(current);
 	if (check != nullptr) {
-		uint i;
 		/* Yes, check if this g value is lower.. */
 		if (new_g > check->g) return;
 		this->openlist_queue.Delete(check, 0);
 		/* It is lower, so change it to this item */
 		check->g = new_g;
 		check->path.parent = closedlist_parent;
-		/* Copy user data, will probably have changed */
-		for (i = 0; i < lengthof(current->user_data); i++) {
-			check->path.node.user_data[i] = current->user_data[i];
-		}
 		/* Re-add it in the openlist_queue. */
 		this->openlist_queue.Push(check, new_f);
 	} else {

--- a/src/pathfinder/aystar.h
+++ b/src/pathfinder/aystar.h
@@ -38,7 +38,6 @@ static const int AYSTAR_INVALID_NODE = -1; ///< Item is not valid (for example, 
 struct AyStarNode {
 	TileIndex tile;
 	Trackdir direction;
-	uint user_data[2];
 };
 
 /** A path of nodes. */
@@ -115,7 +114,7 @@ typedef void AyStar_FoundEndNode(AyStar *aystar, OpenListNode *current);
  */
 struct AyStar {
 /* These fields should be filled before initing the AyStar, but not changed
- * afterwards (except for user_data and user_path)! (free and init again to change them) */
+ * afterwards (except for user_data)! (free and init again to change them) */
 
 	/* These should point to the application specific routines that do the
 	 * actual work */
@@ -131,7 +130,6 @@ struct AyStar {
 	 * afterwards, user_target should typically contain information about
 	 * what you where looking for, and user_data can contain just about
 	 * everything */
-	void *user_path;
 	void *user_target;
 	void *user_data;
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Some, now, unused variables in the Aystar structures.


## Description

Remove them.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
