### PR TITLE
Codechange: Use reusable temporary buffer in Win32FontCache.

### DIFF
--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -10,7 +10,6 @@
 #include "../../stdafx.h"
 #include "../../debug.h"
 #include "../../blitter/factory.hpp"
-#include "../../core/alloc_func.hpp"
 #include "../../core/math_func.hpp"
 #include "../../core/mem_func.hpp"
 #include "../../error_func.h"
@@ -209,7 +208,7 @@ void Win32FontCache::ClearFontCache()
 	if (width > MAX_GLYPH_DIM || height > MAX_GLYPH_DIM) UserError("Font glyph is too large");
 
 	/* Call GetGlyphOutline again with size to actually render the glyph. */
-	uint8_t *bmp = new uint8_t[size];
+	uint8_t *bmp = this->render_buffer.Allocate(size);
 	GetGlyphOutline(this->dc, key, GGO_GLYPH_INDEX | (aa ? GGO_GRAY8_BITMAP : GGO_BITMAP), &gm, size, bmp, &mat);
 
 	/* GDI has rendered the glyph, now we allocate a sprite and copy the image into it. */
@@ -258,8 +257,6 @@ void Win32FontCache::ClearFontCache()
 	new_glyph.width = gm.gmCellIncX;
 
 	this->SetGlyphPtr(key, &new_glyph);
-
-	delete[] bmp;
 
 	return new_glyph.sprite;
 }

--- a/src/os/windows/font_win32.h
+++ b/src/os/windows/font_win32.h
@@ -10,6 +10,7 @@
 #ifndef FONT_WIN32_H
 #define FONT_WIN32_H
 
+#include "../../core/alloc_type.hpp"
 #include "../../fontcache/truetypefontcache.h"
 #include "win32.h"
 
@@ -24,6 +25,8 @@ private:
 	HGDIOBJ old_font;     ///< Old font selected into the GDI context.
 	SIZE glyph_size;      ///< Maximum size of regular glyphs.
 	std::string fontname; ///< Cached copy of loaded font facename
+
+	ReusableBuffer<uint8_t> render_buffer; ///< Temporary buffer for rendering glyphs.
 
 	void SetFontSize(int pixels);
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Manual new[]/delete[] in Win32FontCache.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use ReusableBuffer instead. This removes the manual management (or at least moves it somewhere else...) and avoids allocating and deleting a temporary buffer for every glyph that is rendered into a sprite.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
