### PR TITLE
Codechange: use std::vector instead of malloced array

### DIFF
--- a/src/misc/binaryheap.hpp
+++ b/src/misc/binaryheap.hpp
@@ -50,8 +50,8 @@
 template <class T>
 class CBinaryHeapT {
 private:
-	uint items;    ///< Number of items in the heap
-	uint capacity; ///< Maximum number of items the heap can hold
+	size_t items;    ///< Number of items in the heap
+	size_t capacity; ///< Maximum number of items the heap can hold
 	T **data;      ///< The pointer to the heap item pointers
 
 public:
@@ -59,7 +59,7 @@ public:
 	 * Create a binary heap.
 	 * @param max_items The limit of the heap
 	 */
-	explicit CBinaryHeapT(uint max_items)
+	explicit CBinaryHeapT(size_t max_items)
 		: items(0)
 		, capacity(max_items)
 	{
@@ -83,12 +83,12 @@ protected:
 	 * @param item The proposed item for filling the gap
 	 * @return The (gap)position where the item fits
 	 */
-	inline uint HeapifyDown(uint gap, T *item)
+	inline size_t HeapifyDown(size_t gap, T *item)
 	{
 		assert(gap != 0);
 
 		/* The first child of the gap is at [parent * 2] */
-		uint child = gap * 2;
+		size_t child = gap * 2;
 
 		/* while children are valid */
 		while (child <= this->items) {
@@ -119,11 +119,11 @@ protected:
 	 * @param item The proposed item for filling the gap
 	 * @return The (gap)position where the item fits
 	 */
-	inline uint HeapifyUp(uint gap, T *item)
+	inline size_t HeapifyUp(size_t gap, T *item)
 	{
 		assert(gap != 0);
 
-		uint parent;
+		size_t parent;
 
 		while (gap > 1) {
 			/* compare [gap] with its parent */
@@ -142,8 +142,8 @@ protected:
 	/** Verify the heap consistency */
 	inline void CheckConsistency()
 	{
-		for (uint child = 2; child <= this->items; child++) {
-			uint parent = child / 2;
+		for (size_t child = 2; child <= this->items; child++) {
+			size_t parent = child / 2;
 			assert(!(*this->data[child] < *this->data[parent]));
 		}
 	}
@@ -155,7 +155,7 @@ public:
 	 *
 	 *  @return The number of items in the queue
 	 */
-	inline uint Length() const
+	inline size_t Length() const
 	{
 		return this->items;
 	}
@@ -218,7 +218,7 @@ public:
 		}
 
 		/* Make place for new item. A gap is now at the end of the tree. */
-		uint gap = this->HeapifyUp(++items, new_item);
+		size_t gap = this->HeapifyUp(++items, new_item);
 		this->data[gap] = new_item;
 		CHECK_CONSISTY();
 	}
@@ -238,7 +238,7 @@ public:
 		this->items--;
 		/* at index 1 we have a gap now */
 		T *last = this->End();
-		uint gap = this->HeapifyDown(1, last);
+		size_t gap = this->HeapifyDown(1, last);
 		/* move last item to the proper place */
 		if (!this->IsEmpty()) this->data[gap] = last;
 
@@ -251,7 +251,7 @@ public:
 	 *
 	 * @param index The position of the item in the heap
 	 */
-	inline void Remove(uint index)
+	inline void Remove(size_t index)
 	{
 		if (index < this->items) {
 			assert(index != 0);
@@ -260,7 +260,7 @@ public:
 
 			T *last = this->End();
 			/* Fix binary tree up and downwards */
-			uint gap = this->HeapifyUp(index, last);
+			size_t gap = this->HeapifyUp(index, last);
 			gap = this->HeapifyDown(gap, last);
 			/* move last item to the proper place */
 			if (!this->IsEmpty()) this->data[gap] = last;
@@ -279,7 +279,7 @@ public:
 	 * @param item The reference to the item
 	 * @return The index of the item or zero if not found
 	 */
-	inline uint FindIndex(const T &item) const
+	inline size_t FindIndex(const T &item) const
 	{
 		if (this->IsEmpty()) return 0;
 		for (T **ppI = this->data + 1, **ppLast = ppI + this->items; ppI <= ppLast; ppI++) {

--- a/src/pathfinder/yapf/nodelist.hpp
+++ b/src/pathfinder/yapf/nodelist.hpp
@@ -118,7 +118,7 @@ public:
 	inline Titem_ &PopOpenNode(const Key &key)
 	{
 		Titem_ &item = m_open.Pop(key);
-		uint idxPop = m_open_queue.FindIndex(item);
+		size_t idxPop = m_open_queue.FindIndex(item);
 		m_open_queue.Remove(idxPop);
 		return item;
 	}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Manual memory management in the binary heap used by YAPF.


## Description

Just use a `std::vector` as back end. Also replace `uint` with `size_t` where applicable.


## Limitations

This implementation does not actually use element 0 to keep the other logic much simpler (fewer potential off-by-one errors). I left the logic the same, as changing the logic will impact logic in other places of the code due to for example indices shifting.

I have tried replacing this implementation with `std::priority_queue`, but that is not feasible as for the current path finding purposes we want to be able to remove elements from the queue to insert another node with a lower cost. Or because the (previously best) node is only removed from the queue after a cycle of finding open nodes has been done.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
