### PR TITLE
Fix #12668: Crash opening picker window with filter when no results available.

### DIFF
--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -475,8 +475,20 @@ void PickerWindow::EnsureSelectedClassIsValid()
 	int class_index = this->callbacks.GetSelectedClass();
 	if (std::binary_search(std::begin(this->classes), std::end(this->classes), class_index)) return;
 
-	class_index = this->classes.front();
+	if (!this->classes.empty()) {
+		class_index = this->classes.front();
+	} else {
+		/* Classes can be empty if filters are enabled, find the first usable class. */
+		int count = this->callbacks.GetClassCount();
+		for (int i = 0; i < count; i++) {
+			if (this->callbacks.GetClassName(i) == INVALID_STRING_ID) continue;
+			class_index = i;
+			break;
+		}
+	}
+
 	this->callbacks.SetSelectedClass(class_index);
+	this->types.ForceRebuild();
 }
 
 void PickerWindow::EnsureSelectedClassIsVisible()
@@ -569,8 +581,18 @@ void PickerWindow::EnsureSelectedTypeIsValid()
 	int index = this->callbacks.GetSelectedType();
 	if (std::any_of(std::begin(this->types), std::end(this->types), [class_index, index](const auto &item) { return item.class_index == class_index && item.index == index; })) return;
 
-	class_index = this->types.front().class_index;
-	index = this->types.front().index;
+	if (!this->types.empty()) {
+		class_index = this->types.front().class_index;
+		index = this->types.front().index;
+	} else {
+		/* Types can be empty if filters are enabled, find the first usable type. */
+		int count = this->callbacks.GetTypeCount(class_index);
+		for (int i = 0; i < count; i++) {
+			if (this->callbacks.GetTypeName(class_index, i) == INVALID_STRING_ID) continue;
+			index = i;
+			break;
+		}
+	}
 	this->callbacks.SetSelectedClass(class_index);
 	this->callbacks.SetSelectedType(index);
 }


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As per #12668.

When first opening the picker window, we attempt to find a valid class and type to select. If the picker window was closed with filters enabled, there may not be anything list that is usable.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Resolve this by using callbacks to find the first usable type when no types are listed.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
