### PR TITLE
Fix #12411: [Admin] Send Network Welcome Packet to admin port after game creation completed

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -936,9 +936,6 @@ bool NetworkServerStart()
 	/* if the server is dedicated ... add some other script */
 	if (_network_dedicated) IConsoleCmdExec("exec scripts/on_dedicated.scr 0");
 
-	/* welcome possibly still connected admins - this can only happen on a dedicated server. */
-	if (_network_dedicated) ServerNetworkAdminSocketHandler::WelcomeAll();
-
 	return true;
 }
 
@@ -969,6 +966,9 @@ void NetworkOnGameStart()
 		}
 
 		ShowClientList();
+	} else {
+		/* welcome possibly still connected admins - this can only happen on a dedicated server. */
+		ServerNetworkAdminSocketHandler::WelcomeAll();
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem
ADMIN_PACKET_SERVER_WELCOME is sent too early when a newgame is issued with an external bot already connected through AdminPort.

See #12411.

## Description
Move the sending of the packet to a better appropriate place when the game creation is over : `NetworkOnGameStart`

Closes #12411.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested') : **No**
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md) : **No**
* This PR affects the save game format? (label 'savegame upgrade') : **No**
* This PR affects the GS/AI API? (label 'needs review: Script API') : **No**
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF') : **No**
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)