### PR TITLE
Fix #12594: Give descriptive error when company takeover fails due to vehicle limit

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -668,12 +668,12 @@ void InitializeCompanies()
 }
 
 /**
- * May company \a cbig buy company \a csmall?
+ * Can company \a cbig buy company \a csmall without exceeding vehicle limits?
  * @param cbig   Company buying \a csmall.
  * @param csmall Company getting bought.
  * @return Return \c true if it is allowed.
  */
-bool MayCompanyTakeOver(CompanyID cbig, CompanyID csmall)
+bool CheckTakeoverVehicleLimit(CompanyID cbig, CompanyID csmall)
 {
 	const Company *c1 = Company::Get(cbig);
 	const Company *c2 = Company::Get(csmall);
@@ -725,7 +725,7 @@ static void HandleBankruptcyTakeover(Company *c)
 		if (c2->bankrupt_asked == 0 && // Don't ask companies going bankrupt themselves
 				!HasBit(c->bankrupt_asked, c2->index) &&
 				best_performance < c2->old_economy[1].performance_history &&
-				MayCompanyTakeOver(c2->index, c->index)) {
+				CheckTakeoverVehicleLimit(c2->index, c->index)) {
 			best_performance = c2->old_economy[1].performance_history;
 			best = c2;
 		}

--- a/src/company_func.h
+++ b/src/company_func.h
@@ -15,7 +15,7 @@
 #include "gfx_type.h"
 #include "vehicle_type.h"
 
-bool MayCompanyTakeOver(CompanyID cbig, CompanyID small);
+bool CheckTakeoverVehicleLimit(CompanyID cbig, CompanyID small);
 void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner);
 static const int OWNED_BY_OWNER_IN_PARAMETERS_OFFSET = 2; ///< The index in the parameters for the owner information.
 void SetDParamsForOwnedBy(Owner owner, TileIndex tile);

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -2066,8 +2066,8 @@ CommandCost CmdBuyCompany(DoCommandFlag flags, CompanyID target_company, bool ho
 	/* Do not allow companies to take over themselves */
 	if (target_company == _current_company) return CMD_ERROR;
 
-	/* Disable taking over when not allowed. */
-	if (!MayCompanyTakeOver(_current_company, target_company)) return CMD_ERROR;
+	/* Do not allow takeover if the resulting company would have too many vehicles. */
+	if (!CheckTakeoverVehicleLimit(_current_company, target_company)) return_cmd_error(STR_ERROR_TOO_MANY_VEHICLES_IN_GAME);
 
 	/* Get the cost here as the company is deleted in DoAcquireCompany.
 	 * For bankruptcy this amount is calculated when the offer was made;


### PR DESCRIPTION
## Motivation / Problem

As per #12594, company takeovers that fail due to vehicle limit do not explain why beyond an error, "Can't buy company..."

## Description

Clarify the reason with an existing error string and clarify the comment. Despite its broad name, `MayCompanyTakeOver()` only checks vehicle limits.

Closes #12594.

## Limitations

Does not strictly need backporting, but no languages are changed so I don't see a reason to exclude it.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
