### PR TITLE
Cleanup: Remove GetFontTable from FontCache.

### DIFF
--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -107,14 +107,6 @@ public:
 	virtual GlyphID MapCharToGlyph(char32_t key, bool fallback = true) = 0;
 
 	/**
-	 * Read a font table from the font.
-	 * @param tag The of the table to load.
-	 * @param length The length of the read data.
-	 * @return The loaded table data.
-	 */
-	virtual const void *GetFontTable(uint32_t tag, size_t &length) = 0;
-
-	/**
 	 * Get the native OS font handle, if there is one.
 	 * @return Opaque OS font handle.
 	 */

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -34,7 +34,6 @@ private:
 	FT_Face face;  ///< The font face associated with this font.
 
 	void SetFontSize(int pixels);
-	const void *InternalGetFontTable(uint32_t tag, size_t &length) override;
 	const Sprite *InternalGetGlyph(GlyphID key, bool aa) override;
 
 public:
@@ -322,22 +321,6 @@ GlyphID FreeTypeFontCache::MapCharToGlyph(char32_t key, bool allow_fallback)
 	}
 
 	return glyph;
-}
-
-const void *FreeTypeFontCache::InternalGetFontTable(uint32_t tag, size_t &length)
-{
-	FT_ULong len = 0;
-	FT_Byte *result = nullptr;
-
-	FT_Load_Sfnt_Table(this->face, tag, 0, nullptr, &len);
-
-	if (len > 0) {
-		result = MallocT<FT_Byte>(len);
-		FT_Load_Sfnt_Table(this->face, tag, 0, result, &len);
-	}
-
-	length = len;
-	return result;
 }
 
 /**

--- a/src/fontcache/spritefontcache.h
+++ b/src/fontcache/spritefontcache.h
@@ -30,7 +30,6 @@ public:
 	uint GetGlyphWidth(GlyphID key) override;
 	bool GetDrawGlyphShadow() override;
 	GlyphID MapCharToGlyph(char32_t key, [[maybe_unused]] bool allow_fallback = true) override { assert(IsPrintable(key)); return SPRITE_GLYPH | key; }
-	const void *GetFontTable(uint32_t, size_t &length) override { length = 0; return nullptr; }
 	std::string GetFontName() override { return "sprite"; }
 	bool IsBuiltInFont() override { return true; }
 };

--- a/src/fontcache/truetypefontcache.cpp
+++ b/src/fontcache/truetypefontcache.cpp
@@ -33,10 +33,6 @@ TrueTypeFontCache::~TrueTypeFontCache()
 {
 	/* Virtual functions get called statically in destructors, so make it explicit to remove any confusion. */
 	this->TrueTypeFontCache::ClearFontCache();
-
-	for (auto &iter : this->font_tables) {
-		free(iter.second.second);
-	}
 }
 
 /**
@@ -163,18 +159,4 @@ const Sprite *TrueTypeFontCache::GetGlyph(GlyphID key)
 	}
 
 	return this->InternalGetGlyph(key, GetFontAAState());
-}
-
-const void *TrueTypeFontCache::GetFontTable(uint32_t tag, size_t &length)
-{
-	const auto iter = this->font_tables.find(tag);
-	if (iter != this->font_tables.end()) {
-		length = iter->second.first;
-		return iter->second.second;
-	}
-
-	const void *result = this->InternalGetFontTable(tag, length);
-
-	this->font_tables[tag] = std::pair<size_t, const void *>(length, result);
-	return result;
 }

--- a/src/fontcache/truetypefontcache.h
+++ b/src/fontcache/truetypefontcache.h
@@ -27,9 +27,6 @@ protected:
 	int req_size;  ///< Requested font size.
 	int used_size; ///< Used font size.
 
-	using FontTable = std::map<uint32_t, std::pair<size_t, const void *>>; ///< Table with font table cache
-	FontTable font_tables; ///< Cached font tables.
-
 	/** Container for information about a glyph. */
 	struct GlyphEntry {
 		Sprite *sprite; ///< The loaded sprite.
@@ -55,7 +52,6 @@ protected:
 	GlyphEntry *GetGlyphPtr(GlyphID key);
 	void SetGlyphPtr(GlyphID key, const GlyphEntry *glyph, bool duplicate = false);
 
-	virtual const void *InternalGetFontTable(uint32_t tag, size_t &length) = 0;
 	virtual const Sprite *InternalGetGlyph(GlyphID key, bool aa) = 0;
 
 public:
@@ -65,7 +61,6 @@ public:
 	void SetUnicodeGlyph(char32_t key, SpriteID sprite) override { this->parent->SetUnicodeGlyph(key, sprite); }
 	void InitializeUnicodeGlyphMap() override { this->parent->InitializeUnicodeGlyphMap(); }
 	const Sprite *GetGlyph(GlyphID key) override;
-	const void *GetFontTable(uint32_t tag, size_t &length) override;
 	void ClearFontCache() override;
 	uint GetGlyphWidth(GlyphID key) override;
 	bool GetDrawGlyphShadow() override;

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -204,18 +204,6 @@ GlyphID CoreTextFontCache::MapCharToGlyph(char32_t key, bool allow_fallback)
 	return 0;
 }
 
-const void *CoreTextFontCache::InternalGetFontTable(uint32_t tag, size_t &length)
-{
-	CFAutoRelease<CFDataRef> data(CTFontCopyTable(this->font.get(), (CTFontTableTag)tag, kCTFontTableOptionNoOptions));
-	if (!data) return nullptr;
-
-	length = CFDataGetLength(data.get());
-	auto buf = MallocT<UInt8>(length);
-
-	CFDataGetBytes(data.get(), CFRangeMake(0, (CFIndex)length), buf);
-	return buf;
-}
-
 const Sprite *CoreTextFontCache::InternalGetGlyph(GlyphID key, bool use_aa)
 {
 	/* Get glyph size. */

--- a/src/os/macosx/font_osx.h
+++ b/src/os/macosx/font_osx.h
@@ -23,7 +23,6 @@ class CoreTextFontCache : public TrueTypeFontCache {
 
 	void SetFontSize(int pixels);
 	const Sprite *InternalGetGlyph(GlyphID key, bool use_aa) override;
-	const void *InternalGetFontTable(uint32_t tag, size_t &length) override;
 public:
 	CoreTextFontCache(FontSize fs, CFAutoRelease<CTFontDescriptorRef> &&font, int pixels);
 	~CoreTextFontCache() {}

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -284,20 +284,6 @@ void Win32FontCache::ClearFontCache()
 	return allow_fallback && key >= SCC_SPRITE_START && key <= SCC_SPRITE_END ? this->parent->MapCharToGlyph(key) : 0;
 }
 
-/* virtual */ const void *Win32FontCache::InternalGetFontTable(uint32_t tag, size_t &length)
-{
-	DWORD len = GetFontData(this->dc, tag, 0, nullptr, 0);
-
-	void *result = nullptr;
-	if (len != GDI_ERROR && len > 0) {
-		result = MallocT<BYTE>(len);
-		GetFontData(this->dc, tag, 0, result, len);
-	}
-
-	length = len;
-	return result;
-}
-
 
 static bool TryLoadFontFromFile(const std::string &font_name, LOGFONT &logfont)
 {

--- a/src/os/windows/font_win32.h
+++ b/src/os/windows/font_win32.h
@@ -28,7 +28,6 @@ private:
 	void SetFontSize(int pixels);
 
 protected:
-	const void *InternalGetFontTable(uint32_t tag, size_t &length) override;
 	const Sprite *InternalGetGlyph(GlyphID key, bool aa) override;
 
 public:

--- a/src/tests/mock_fontcache.h
+++ b/src/tests/mock_fontcache.h
@@ -30,7 +30,6 @@ public:
 	uint GetGlyphWidth(GlyphID) override { return this->height / 2; }
 	bool GetDrawGlyphShadow() override { return false; }
 	GlyphID MapCharToGlyph(char32_t key, [[maybe_unused]] bool allow_fallback = true) override { return key; }
-	const void *GetFontTable(uint32_t, size_t &length) override { length = 0; return nullptr; }
 	std::string GetFontName() override { return "mock"; }
 	bool IsBuiltInFont() override { return true; }
 


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

While cleaning up GetFontTable (it uses malloc, and passes length as return parameter) I then noticed that it is actually never called.

Presumably the code that used it no longer does.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Remove GetFontTable from FontCache.

This interface is no longer used, so does not need to be implemented.

Removes manual memory management with malloc/free.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
