### PR TITLE
Fix #12550: files were not saved in the right location when binary and configuration are in the same folder

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -84,7 +84,7 @@ static void FillValidSearchPaths(bool only_local_path)
 
 	std::set<std::string> seen{};
 	for (Searchpath sp = SP_FIRST_DIR; sp < NUM_SEARCHPATHS; sp++) {
-		if (sp == SP_WORKING_DIR) continue;
+		if (sp == SP_WORKING_DIR && !_do_scan_working_directory) continue;
 
 		if (only_local_path) {
 			switch (sp) {


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Fixes #12550.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

#11431 fixed an issue caused by #11363, but that causes screenshots/saves to not be stored in the folder with the configuration if the folder with configuration is also the binary folder.

#11431 effectively moves the priority of the 'working directory', which with '-c' is the folder with the configuration file, down. As a result of that the default configuration folder's location will be taken for the screenshots/saves.

There is all kinds of dark magic related to whether or not scan the 'working directory'. When '-c' is used, this variable is always true, so it retains the scanning. Not quite sure what exactly disables it for Emscripten.

The problem of #12550 seems to be solved by this change, and the preview build still seems to work... so maybe it solves both issues?

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This is throwing mud at the wall and hoping it sticks development.

I have no clue whether this breaks any other workflow, like #11363 and #11431 did before.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
