### PR TITLE
Fix: Timetable precision

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4747,6 +4747,7 @@ STR_TIMETABLE_AND_TRAVEL_FOR_ESTIMATED                          :(travel for {ST
 STR_TIMETABLE_STAY_FOR                                          :and stay for {STRING1}
 STR_TIMETABLE_AND_TRAVEL_FOR                                    :and travel for {STRING1}
 
+STR_TIMETABLE_APPROX_TIME                                       :{BLACK}This timetable will take approximately {STRING1} to complete
 STR_TIMETABLE_TOTAL_TIME                                        :{BLACK}This timetable will take {STRING1} to complete
 STR_TIMETABLE_TOTAL_TIME_INCOMPLETE                             :{BLACK}This timetable will take at least {STRING1} to complete (not all timetabled)
 

--- a/src/timetable_cmd.cpp
+++ b/src/timetable_cmd.cpp
@@ -519,7 +519,8 @@ void UpdateVehicleTimetable(Vehicle *v, bool travelling)
 	/* Before modifying waiting times, check whether we want to preserve bigger ones. */
 	if (!real_current_order->IsType(OT_CONDITIONAL) &&
 			(travelling || time_taken > real_current_order->GetWaitTime() || remeasure_wait_time)) {
-		/* Round up to the smallest unit of time commonly shown in the GUI (seconds) to avoid confusion.
+		/* Round up to the unit currently shown in the GUI for days and seconds.
+		 * Round up to seconds if currently used display style is ticks.
 		 * Players timetabling in Ticks can adjust later.
 		 * For trains/aircraft multiple movement cycles are done in one
 		 * tick. This makes it possible to leave the station and process
@@ -527,7 +528,8 @@ void UpdateVehicleTimetable(Vehicle *v, bool travelling)
 		 * the timetable entry like is done for road vehicles/ships.
 		 * Thus always make sure at least one tick is used between the
 		 * processing of different orders when filling the timetable. */
-		uint time_to_set = CeilDiv(std::max(time_taken, 1), Ticks::TICKS_PER_SECOND) * Ticks::TICKS_PER_SECOND;
+		uint factor = _settings_client.gui.timetable_mode == TimetableMode::Days ? Ticks::DAY_TICKS : Ticks::TICKS_PER_SECOND;
+		uint time_to_set = CeilDiv(std::max(time_taken, 1), factor) * factor;
 
 		if (travelling && (autofilling || !real_current_order->IsTravelTimetabled())) {
 			ChangeTimetable(v, v->cur_real_order_index, time_to_set, MTF_TRAVEL_TIME, autofilling);

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -565,7 +565,13 @@ struct TimetableWindow : Window {
 		TimerGameTick::Ticks total_time = v->orders != nullptr ? v->orders->GetTimetableDurationIncomplete() : 0;
 		if (total_time != 0) {
 			SetTimetableParams(0, 1, total_time);
-			DrawString(tr, v->orders->IsCompleteTimetable() ? STR_TIMETABLE_TOTAL_TIME : STR_TIMETABLE_TOTAL_TIME_INCOMPLETE);
+			if (!v->orders->IsCompleteTimetable()) {
+				DrawString(tr, STR_TIMETABLE_TOTAL_TIME_INCOMPLETE);
+			} else if (total_time % TicksPerTimetableUnit() == 0) {
+				DrawString(tr, STR_TIMETABLE_TOTAL_TIME);
+			} else {
+				DrawString(tr, STR_TIMETABLE_APPROX_TIME);
+			}
 		}
 		tr.top += GetCharacterHeight(FS_NORMAL);
 


### PR DESCRIPTION
## Motivation / Problem

When using days as display style for the timetable, two lines with the same total timetable duration may run out of sync. The internal precision in the timetable calculation is done in seconds even if the display mode is days. The total duration can be one second (half a day) off without noticing due to rounding to full days in the GUI. Unless the client switches display style to seconds or ticks and checks all timetables.
![Timetable1](https://github.com/OpenTTD/OpenTTD/assets/61750128/2bbacf5c-7baa-40c8-acce-88e45201dd69)
![Timetable2](https://github.com/OpenTTD/OpenTTD/assets/61750128/b8f0942a-7737-496a-8907-07e7efad6026)


## Description

First, when using days as display style for timetables, set the internal precision also to days (74 ticks). This way the total duration will be exactly what is shown in the timetable. 
Second, for savegames where this problem already occurred and for cases, where the client manually altered the seconds or ticks of the timetable, perform a check if the displayed total duration is the exact duration. If not, insert an "approx." before the days/seconds in the GUI so the client knows that the actual duration differs slightly from the presented. The client can then correct the seconds or ticks if desired.
![Timetable3](https://github.com/OpenTTD/OpenTTD/assets/61750128/ff718d08-828c-4cac-8ca9-f3c2fbd2fc64)


## Limitations

The expression "approx." only appears for the total duration so far and not for each individual order to keep strings short and the timetable window narrow. This could still be added if desired. I would suggest defining a new "approx." string and insert it into existing strings if needed, rather than creating more duplicates.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
