### PR TITLE
Fix: Social plugins not working on macOS

### DIFF
--- a/cmake/PackageBundle.cmake
+++ b/cmake/PackageBundle.cmake
@@ -4,6 +4,7 @@ set(CPACK_BUNDLE_NAME "OpenTTD")
 set(CPACK_BUNDLE_ICON "${CMAKE_SOURCE_DIR}/os/macosx/openttd.icns")
 set(CPACK_BUNDLE_PLIST "${CMAKE_CURRENT_BINARY_DIR}/Info.plist")
 set(CPACK_DMG_BACKGROUND_IMAGE "${CMAKE_SOURCE_DIR}/os/macosx/splash.png")
+set(CPACK_BUNDLE_APPLE_ENTITLEMENTS "${CMAKE_SOURCE_DIR}/os/macosx/openttd.entitlements")
 set(CPACK_DMG_FORMAT "UDBZ")
 
 # Create a temporary Info.plist.in, where we will fill in the version via

--- a/os/macosx/openttd.entitlements
+++ b/os/macosx/openttd.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- As requested in https://partner.steamgames.com/doc/store/application/platforms, allows arbitrary plugin loads on hardened runtime -->
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Motivation / Problem
Applications running on the Hardened Runtime get skillchecked by System Integrity Protection when loading dynamic libraries that are signed with certificates belonging to a different Team ID.
Apple describes this as preventing code injection.

This happens particularly in the case of Steam, whose dynamic library for Steamworks is signed by Valve, not us, therefore triggering the protection mechanism and preventing `dlopen` from functioning.
Steam also relies on environment variables to inject the in game overlay, which is also blocked for the same reason.

This causes something like this to be output to stdout:
```
[2024-05-18 11:40:44] dbg: [driver:0] Could not change to foreground application. Error -50
dlopen failed trying to load: [...]/steamclient.dylib
with error:
dlopen([...]/steamclient.dylib, 0x0002): tried: '[...]/steamclient.dylib' (code signature in [...] '[...]/steamclient.dylib' not valid for use in >process: mapping process and mapped file (non-platform) have different Team IDs), [more of the same but for different paths])

[S_API] SteamAPI_Init(): Failed to load module '[...]/steamclient.dylib'
[2024-05-18 11:40:44] dbg: [misc:0] [Social Integration: steam/libsteam-social.dylib] Failed to initialize
```

This is Bad. However, Steamworks has a solution, which is adding entitlements to the application that allow it to bypass these limits set out by the Hardened Runtime.

## Description
Adds entitlements needed to load arbitrary plugins correctly (Steam particularly) during codesigning.

## Limitations
This could possibly allow bad actors to perform code injection on OpenTTD with malicious plugins. ~~Kinda goes against "social" if you ask me.~~

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
