### PR TITLE
Fix: Implement support for secure state coding on macOS

### DIFF
--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -261,6 +261,18 @@ static NSImage *NSImageFromSprite(SpriteID sprite_id, ZoomLevel zoom)
 {
 	[ [ NSNotificationCenter defaultCenter ] removeObserver:self ];
 }
+
+/**
+ * Indicates to AppKit that OpenTTD is compatible with secure state storage.
+ * Starting with macOS 12, macOS expects us to be better compatible with NSSecureCoding, as to prevent attacks through restorable storage.
+ * Starting with 14, macOS logs a warning if we don't implement this ourselves. Since OpenTTD does not (yet) make use of restorable state, we simply don't care what happens with it.
+ *
+ * Explained here: https://developer.apple.com/documentation/foundation/nssecurecoding
+ */
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication*) sender
+{
+	return YES;
+}
 @end
 
 /**


### PR DESCRIPTION
## Motivation / Problem
Since macOS 12, AppKit calls `NSApplicationDelegate::applicationSupportsSecureRestorableState` on the application's delegate. This function indicates whether the app is fine with AppKit using `NSSecureCoding` to encode and decode state in a more secure fashion, as explained in [Apple's documentation on `NSSecureCoding`](https://developer.apple.com/documentation/foundation/nssecurecoding).

## Description
Implementing `applicationSupportsSecureRestorableState` in the Cocoa driver to simply return true disables the warning and makes AppKit happy.

## Limitations
In case some cursed soul implemented support for restorable state without using secure coding, this could probably cause some problems. I think.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
