### PR TITLE
Fix #10044: Cursor being poorly managed on macOS in fullscreen mode

### DIFF
--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -206,9 +206,6 @@ bool VideoDriver_Cocoa::ToggleFullscreen(bool full_screen)
 	if ([ this->window respondsToSelector:@selector(toggleFullScreen:) ]) {
 		[ this->window performSelector:@selector(toggleFullScreen:) withObject:this->window ];
 
-		/* Hide the menu bar and the dock */
-		[ NSMenu setMenuBarVisible:!full_screen ];
-
 		this->UpdateVideoModes();
 		InvalidateWindowClassesData(WC_GAME_OPTIONS, 3);
 		return true;

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -1288,7 +1288,7 @@ void CocoaDialog(const char *title, const char *message, const char *buttonLabel
 /** Presentation options to use for full screen mode. */
 - (NSApplicationPresentationOptions)window:(NSWindow *)window willUseFullScreenPresentationOptions:(NSApplicationPresentationOptions)proposedOptions
 {
-	return NSApplicationPresentationFullScreen | NSApplicationPresentationHideMenuBar | NSApplicationPresentationHideDock;
+	return NSApplicationPresentationFullScreen | NSApplicationPresentationAutoHideMenuBar;
 }
 
 @end


### PR DESCRIPTION
## Motivation / Problem
As reported in #10044, macOS doesn't reliably switch between the in game and system cursor when going over the Menu Bar or Dock.

## Description
This bug appears to be caused by the fact these are forcefully hidden, despite this being uncommon behavior (I mostly went through my Steam library, testing BAD END THEATER, Factorio and Terraria, all games that don't fully hide the cursor. None of these games hid the Menu Bar or Dock fully, instead letting the OS decide, which relies on user settings).
As such, this changes the settings used for fullscreen mode on macOS to instead automatically hide things if possible, instead of requiring them to be hidden, like how most apps and a lot of games do.

Closes #10044.

## Limitations
PR #8789, where the change was introduced for the most part, forcefully hid the Menu Bar particularly to prevent it rolling over when pressing a button at the top.
Testing this on my own MacBook Air, I failed to replicate that problem, although I have no idea if this might be caused by the fact it reserves a lot of space at the top of the screen.
I do not have an external monitor with me to test this at the minute, and I don't even know if this behavior is different because that author was running macOS Catalina and I'm running Sonoma.
Even despite this mostly fixing the bug, at times I managed to still make the cursor look wrong, perhaps pointing to an issue related to how it's updated, although with everything acting more alike how other games act in fullscreen, this bug happened a lot less frequently.

Frankly, this might be a problem with screen safe zones instead of the menu bar rolling over, perhaps at some point it might be worth adding a setting to add some spacing between the screen edges and the buttons up top.



## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
