### PR TITLE
Add: Use macOS Game Mode identification

### DIFF
--- a/os/macosx/Info.plist.in
+++ b/os/macosx/Info.plist.in
@@ -33,5 +33,7 @@
         <string>True</string>
         <key>LSMinimumSystemVersion</key>
         <string>10.13.0</string>
+        <key>LSApplicationCategoryType</key>
+        <string>public.app-category.games</string>
 </dict>
 </plist>

--- a/os/macosx/Info.plist.in
+++ b/os/macosx/Info.plist.in
@@ -34,6 +34,6 @@
         <key>LSMinimumSystemVersion</key>
         <string>10.13.0</string>
         <key>LSApplicationCategoryType</key>
-        <string>public.app-category.games</string>
+        <string>public.app-category.simulation-games</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Motivation / Problem
macOS 14 Sonoma introduced [Game Mode](https://support.apple.com/en-ca/105118), a feature that promises to "prioritize the performance of your game for smoother, more consistent frame rates and improved in-game responsiveness".

## Description
This adds `LSApplicationCategoryType` to the app bundle's `Info.plist`, identifying it as an `public.app-category.games`.
When fullscreen mode is activated now, it properly turns on Game Mode.
This also properly identifies what type of app OpenTTD is, perhaps helping people sorting by categories, which also makes Launchpad automatically add OpenTTD to the "Games" folder for people with many games installed.

## Limitations
Slow viewers might miss some of that performance.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
