### PR TITLE
Fix #12391: Fixed console save message timings and altered when they appear.

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -402,13 +402,7 @@ DEF_CONSOLE_CMD(ConSave)
 	if (argc == 2) {
 		std::string filename = argv[1];
 		filename += ".sav";
-		IConsolePrint(CC_DEFAULT, "Saving map...");
-
-		if (SaveOrLoad(filename, SLO_SAVE, DFT_GAME_FILE, SAVE_DIR) != SL_OK) {
-			IConsolePrint(CC_ERROR, "Saving map failed.");
-		} else {
-			IConsolePrint(CC_INFO, "Map successfully saved to '{}'.", filename);
-		}
+		SaveOrLoad(filename, SLO_SAVE, DFT_GAME_FILE, SAVE_DIR);
 		return true;
 	}
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -21,7 +21,6 @@
  */
 
 #include "../stdafx.h"
-#include "../console_func.h"
 #include "../debug.h"
 #include "../station_base.h"
 #include "../thread.h"
@@ -2832,7 +2831,7 @@ static SaveOrLoadResult SaveFileToDisk(bool threaded, const std::string &filenam
 
 		if (threaded) SetAsyncSaveFinish(SaveFileDone);
 
-		IConsolePrint(CC_INFO, "Saved successfully as '{}'.", filename);
+		Debug(sl, 1, "Map saved as '{}'.", filename);
 
 		return SL_OK;
 	} catch (...) {
@@ -2854,7 +2853,6 @@ static SaveOrLoadResult SaveFileToDisk(bool threaded, const std::string &filenam
 			asfp();
 		}
 
-		IConsolePrint(CC_ERROR, "Saving map failed.");
 		return SL_ERROR;
 	}
 }
@@ -3154,7 +3152,6 @@ SaveOrLoadResult SaveOrLoad(const std::string &filename, SaveLoadOperation fop, 
 		}
 
 		if (fop == SLO_SAVE) { // SAVE game
-			IConsolePrint(CC_DEFAULT, "Saving map...");
 			Debug(desync, 1, "save: {:08x}; {:02x}; {}", TimerGameEconomy::date, TimerGameEconomy::date_fract, filename);
 			if (!_settings_client.gui.threaded_saves) threaded = false;
 


### PR DESCRIPTION
## Motivation / Problem

Issue #12391

## Description

Each of the saving messages on the console appear at the correct times now. The started saving message appears when starting a save, and the two outcome messages of saving are at the end now. A couple of functions needed to be altered to take the filename for this. Since these are put in the save process as a whole now you can see them in the console even if not saving via console command.

## Limitations

Save filters don't appear to use a filename, so they use default which is set to have the name string empty. 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
