### PR TITLE
Fix: Reverse left/right keypress when editing RTL text.

### DIFF
--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -323,6 +323,40 @@ void Textbuf::UpdateMarkedText()
 }
 
 /**
+ * Move to previous character position.
+ * @param what Move ITER_CHARACTER or ITER_WORD.
+ * @return true iff able to move.
+ */
+bool Textbuf::MovePrev(StringIterator::IterType what)
+{
+	if (this->caretpos == 0) return false;
+
+	size_t pos = this->char_iter->Prev(what);
+	if (pos == StringIterator::END) return true;
+
+	this->caretpos = static_cast<uint16_t>(pos);
+	this->UpdateCaretPosition();
+	return true;
+}
+
+/**
+ * Move to next character position.
+ * @param what Move ITER_CHARACTER or ITER_WORD.
+ * @return true iff able to move.
+ */
+bool Textbuf::MoveNext(StringIterator::IterType what)
+{
+	if (this->caretpos >= this->bytes - 1) return false;
+
+	size_t pos = this->char_iter->Next(what);
+	if (pos == StringIterator::END) return true;
+
+	this->caretpos = static_cast<uint16_t>(pos);
+	this->UpdateCaretPosition();
+	return true;
+}
+
+/**
  * Handle text navigation with arrow keys left/right.
  * This defines where the caret will blink and the next character interaction will occur
  * @param keycode Direction in which navigation occurs (WKC_CTRL |) WKC_LEFT, (WKC_CTRL |) WKC_RIGHT, WKC_END, WKC_HOME
@@ -333,26 +367,14 @@ bool Textbuf::MovePos(uint16_t keycode)
 	switch (keycode) {
 		case WKC_LEFT:
 		case WKC_CTRL | WKC_LEFT: {
-			if (this->caretpos == 0) break;
-
-			size_t pos = this->char_iter->Prev(keycode & WKC_CTRL ? StringIterator::ITER_WORD : StringIterator::ITER_CHARACTER);
-			if (pos == StringIterator::END) return true;
-
-			this->caretpos = (uint16_t)pos;
-			this->UpdateCaretPosition();
-			return true;
+			auto move_type = (keycode & WKC_CTRL) != 0 ? StringIterator::ITER_WORD : StringIterator::ITER_CHARACTER;
+			return (_current_text_dir == TD_LTR) ? this->MovePrev(move_type) : this->MoveNext(move_type);
 		}
 
 		case WKC_RIGHT:
 		case WKC_CTRL | WKC_RIGHT: {
-			if (this->caretpos >= this->bytes - 1) break;
-
-			size_t pos = this->char_iter->Next(keycode & WKC_CTRL ? StringIterator::ITER_WORD : StringIterator::ITER_CHARACTER);
-			if (pos == StringIterator::END) return true;
-
-			this->caretpos = (uint16_t)pos;
-			this->UpdateCaretPosition();
-			return true;
+			auto move_type = (keycode & WKC_CTRL) != 0 ? StringIterator::ITER_WORD : StringIterator::ITER_CHARACTER;
+			return (_current_text_dir == TD_LTR) ? this->MoveNext(move_type) : this->MovePrev(move_type);
 		}
 
 		case WKC_HOME:

--- a/src/textbuf_type.h
+++ b/src/textbuf_type.h
@@ -72,6 +72,9 @@ private:
 
 	bool CanDelChar(bool backspace);
 
+	bool MovePrev(StringIterator::IterType what);
+	bool MoveNext(StringIterator::IterType what);
+
 	void DeleteText(uint16_t from, uint16_t to, bool update);
 
 	void UpdateStringIter();


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When editing RTL text, the left cursor key moves right, and the right cursor key moves left.

Pressing left moves to the previous logical character position, which for RTL text is character to the right of the current character. Therefore, pressing left should increment instead of decrement the character position to move left, and vice versa.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Swap direction when pressing left or right cursor keys when editing RTL text, so that pressing left moves left.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

When editing mixed RTL/LTR text, the cursor direction will change direction depending on where the cursor is. This is not intuitive, but it is how other software (Google Chrome!) behaves, so it's not exactly unacceptable.

I believe changing this to always move consistently requires a different approach to cursor movement which would not easily be backportable.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
