### PR TITLE
Add: Setting to disable news message for old vehicles

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1488,6 +1488,9 @@ STR_CONFIG_SETTING_WARN_INCOME_LESS                             :Warn if a vehic
 STR_CONFIG_SETTING_WARN_INCOME_LESS_HELPTEXT                    :When enabled, a news message gets sent when a vehicle has not made any profit within a year
 STR_CONFIG_SETTING_WARN_INCOME_LESS_HELPTEXT_PERIOD             :When enabled, a news message gets sent when a vehicle has not made any profit within a period
 
+STR_CONFIG_SETTING_WARN_OLD_VEHICLE                             :Warn if a vehicle is getting old: {STRING2}
+STR_CONFIG_SETTING_WARN_OLD_VEHICLE_HELPTEXT                    :When enabled, a news message gets sent when a vehicle is getting old
+
 STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES                        :Vehicles never expire: {STRING2}
 STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES_HELPTEXT               :When enabled, all vehicle models remain available forever after their introduction
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2074,6 +2074,7 @@ static SettingsContainer &GetSettingsTree()
 			advisors->Add(new SettingEntry("gui.order_review_system"));
 			advisors->Add(new SettingEntry("gui.vehicle_income_warn"));
 			advisors->Add(new SettingEntry("gui.lost_vehicle_warn"));
+			advisors->Add(new SettingEntry("gui.old_vehicle_warn"));
 			advisors->Add(new SettingEntry("gui.show_finances"));
 			advisors->Add(new SettingEntry("news_display.economy"));
 			advisors->Add(new SettingEntry("news_display.subsidies"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -132,6 +132,7 @@ struct GUISettings {
 	bool   lost_vehicle_warn;                ///< if a vehicle can't find its destination, show a warning
 	uint8_t  order_review_system;              ///< perform order reviews on vehicles
 	bool   vehicle_income_warn;              ///< if a vehicle isn't generating income, show a warning
+	bool   old_vehicle_warn;                 ///< if a vehicle is getting old, show a warning
 	bool   show_finances;                    ///< show finances at end of year
 	bool   sg_new_nonstop;                   ///< ttdpatch compatible nonstop handling read from pre v93 savegames
 	bool   new_nonstop;                      ///< ttdpatch compatible nonstop handling

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -592,6 +592,13 @@ str      = STR_CONFIG_SETTING_WARN_LOST_VEHICLE
 strhelp  = STR_CONFIG_SETTING_WARN_LOST_VEHICLE_HELPTEXT
 
 [SDTC_BOOL]
+var      = gui.old_vehicle_warn
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
+def      = true
+str      = STR_CONFIG_SETTING_WARN_OLD_VEHICLE
+strhelp  = STR_CONFIG_SETTING_WARN_OLD_VEHICLE_HELPTEXT
+
+[SDTC_BOOL]
 var      = gui.new_nonstop
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1454,6 +1454,9 @@ void AgeVehicle(Vehicle *v)
 
 	SetWindowDirty(WC_VEHICLE_DETAILS, v->index);
 
+	/* Don't warn if warnings are disabled */
+	if (!_settings_client.gui.old_vehicle_warn) return;
+
 	/* Don't warn about vehicles which are non-primary (e.g., part of an articulated vehicle), don't belong to us, are crashed, or are stopped */
 	if (v->Previous() != nullptr || v->owner != _local_company || (v->vehstatus & VS_CRASHED) != 0 || (v->vehstatus & VS_STOPPED) != 0) return;
 


### PR DESCRIPTION
## Motivation / Problem
When playing without breakdowns (which is [quite common](https://survey.openttd.org/summaries/2024/wk20/14.1#game.settings.difficulty.vehicle_breakdowns)), vehicles getting old matters less. However, news messages about this still keep appearing, and it is not possible to disable them without also disabling other useful messages like lost, stuck, negative income, etc.

## Description
Add a setting to disable the news messages about vehicles getting old.

## Limitations
The whole set of news settings are a bit of a mess -- there are settings to control whole news types (off/summary/full), then settings to control a few specific triggers. A better system of filtering might be nice.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
