### PR TITLE
Codechange: Removed unused yapf PfNodeCachFlush function

### DIFF
--- a/src/pathfinder/yapf/yapf_base.hpp
+++ b/src/pathfinder/yapf/yapf_base.hpp
@@ -227,10 +227,6 @@ public:
 
 		bool bValid = Yapf().PfCalcCost(n, &tf);
 
-		if (bCached) {
-			Yapf().PfNodeCacheFlush(n);
-		}
-
 		if (bValid) bValid = Yapf().PfCalcEstimate(n);
 
 		/* have the cost or estimate callbacks marked this node as invalid? */


### PR DESCRIPTION
## Motivation / Problem

Let's remove some functionality that hasn't been used for a long time.

## Description

None of the different YAPF implementations actually used PfNodeCachFlush, it even says so in the comments. It probably hasn't been used ever, so let's throw it out.

I also restructured the CYapfSegmentCostCacheGlobalT class a bit to further reduce code bloat.

## Limitations

None

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
