### PR TITLE
Codechange: Use std::unordered_map for storing TrueTypeFontCache's GlyphEntry map.

### DIFF
--- a/src/blitter/32bpp_anim_sse4.hpp
+++ b/src/blitter/32bpp_anim_sse4.hpp
@@ -39,7 +39,7 @@ public:
 	template <BlitterMode mode, Blitter_32bppSSE_Base::ReadMode read_mode, Blitter_32bppSSE_Base::BlockType bt_last, bool translucent, bool animated>
 	void Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom);
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
-	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator) override {
+	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override {
 		return Blitter_32bppSSE_Base::Encode(sprite, allocator);
 	}
 	std::string_view GetName() override { return "32bpp-sse4-anim"; }

--- a/src/blitter/32bpp_optimized.cpp
+++ b/src/blitter/32bpp_optimized.cpp
@@ -285,7 +285,7 @@ void Blitter_32bppOptimized::Draw(Blitter::BlitterParams *bp, BlitterMode mode, 
 	this->Draw<false>(bp, mode, zoom);
 }
 
-template <bool Tpal_to_rgb> Sprite *Blitter_32bppOptimized::EncodeInternal(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator)
+template <bool Tpal_to_rgb> Sprite *Blitter_32bppOptimized::EncodeInternal(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator)
 {
 	/* streams of pixels (a, r, g, b channels)
 	 *
@@ -414,7 +414,7 @@ template <bool Tpal_to_rgb> Sprite *Blitter_32bppOptimized::EncodeInternal(const
 		len += lengths[z][0] + lengths[z][1];
 	}
 
-	Sprite *dest_sprite = (Sprite *)allocator(sizeof(*dest_sprite) + sizeof(SpriteData) + len);
+	Sprite *dest_sprite = allocator.Allocate<Sprite>(sizeof(*dest_sprite) + sizeof(SpriteData) + len);
 
 	dest_sprite->height = sprite[ZOOM_LVL_MIN].height;
 	dest_sprite->width  = sprite[ZOOM_LVL_MIN].width;
@@ -438,10 +438,10 @@ template <bool Tpal_to_rgb> Sprite *Blitter_32bppOptimized::EncodeInternal(const
 	return dest_sprite;
 }
 
-template Sprite *Blitter_32bppOptimized::EncodeInternal<true>(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator);
-template Sprite *Blitter_32bppOptimized::EncodeInternal<false>(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator);
+template Sprite *Blitter_32bppOptimized::EncodeInternal<true>(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator);
+template Sprite *Blitter_32bppOptimized::EncodeInternal<false>(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator);
 
-Sprite *Blitter_32bppOptimized::Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator)
+Sprite *Blitter_32bppOptimized::Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator)
 {
 	return this->EncodeInternal<true>(sprite, allocator);
 }

--- a/src/blitter/32bpp_optimized.hpp
+++ b/src/blitter/32bpp_optimized.hpp
@@ -22,7 +22,7 @@ public:
 	};
 
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
-	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator) override;
+	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
 
 	std::string_view GetName() override { return "32bpp-optimized"; }
 
@@ -30,7 +30,7 @@ public:
 
 protected:
 	template <bool Tpal_to_rgb> void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom);
-	template <bool Tpal_to_rgb> Sprite *EncodeInternal(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator);
+	template <bool Tpal_to_rgb> Sprite *EncodeInternal(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator);
 };
 
 /** Factory for the optimised 32 bpp blitter (without palette animation). */

--- a/src/blitter/32bpp_simple.cpp
+++ b/src/blitter/32bpp_simple.cpp
@@ -115,10 +115,10 @@ void Blitter_32bppSimple::DrawColourMappingRect(void *dst, int width, int height
 	Debug(misc, 0, "32bpp blitter doesn't know how to draw this colour table ('{}')", pal);
 }
 
-Sprite *Blitter_32bppSimple::Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator)
+Sprite *Blitter_32bppSimple::Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator)
 {
 	Blitter_32bppSimple::Pixel *dst;
-	Sprite *dest_sprite = static_cast<Sprite *>(allocator(sizeof(*dest_sprite) + static_cast<size_t>(sprite[ZOOM_LVL_MIN].height) * static_cast<size_t>(sprite[ZOOM_LVL_MIN].width) * sizeof(*dst)));
+	Sprite *dest_sprite = allocator.Allocate<Sprite>(sizeof(*dest_sprite) + static_cast<size_t>(sprite[ZOOM_LVL_MIN].height) * static_cast<size_t>(sprite[ZOOM_LVL_MIN].width) * sizeof(*dst));
 
 	dest_sprite->height = sprite[ZOOM_LVL_MIN].height;
 	dest_sprite->width  = sprite[ZOOM_LVL_MIN].width;

--- a/src/blitter/32bpp_simple.hpp
+++ b/src/blitter/32bpp_simple.hpp
@@ -26,7 +26,7 @@ class Blitter_32bppSimple : public Blitter_32bppBase {
 public:
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
 	void DrawColourMappingRect(void *dst, int width, int height, PaletteID pal) override;
-	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator) override;
+	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
 
 	std::string_view GetName() override { return "32bpp-simple"; }
 };

--- a/src/blitter/32bpp_sse2.cpp
+++ b/src/blitter/32bpp_sse2.cpp
@@ -20,7 +20,7 @@
 /** Instantiation of the SSE2 32bpp blitter factory. */
 static FBlitter_32bppSSE2 iFBlitter_32bppSSE2;
 
-Sprite *Blitter_32bppSSE_Base::Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator)
+Sprite *Blitter_32bppSSE_Base::Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator)
 {
 	/* First uint32_t of a line = the number of transparent pixels from the left.
 	 * Second uint32_t of a line = the number of transparent pixels from the right.
@@ -51,7 +51,7 @@ Sprite *Blitter_32bppSSE_Base::Encode(const SpriteLoader::SpriteCollection &spri
 		all_sprites_size += rgba_size + mv_size;
 	}
 
-	Sprite *dst_sprite = (Sprite *) allocator(sizeof(Sprite) + sizeof(SpriteData) + all_sprites_size);
+	Sprite *dst_sprite = allocator.Allocate<Sprite>(sizeof(Sprite) + sizeof(SpriteData) + all_sprites_size);
 	dst_sprite->height = sprite[ZOOM_LVL_MIN].height;
 	dst_sprite->width  = sprite[ZOOM_LVL_MIN].width;
 	dst_sprite->x_offs = sprite[ZOOM_LVL_MIN].x_offs;

--- a/src/blitter/32bpp_sse2.hpp
+++ b/src/blitter/32bpp_sse2.hpp
@@ -76,7 +76,7 @@ public:
 		uint8_t data[]; ///< Data, all zoomlevels.
 	};
 
-	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator);
+	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator);
 };
 
 DECLARE_ENUM_AS_BIT_SET(Blitter_32bppSSE_Base::SpriteFlags);
@@ -88,7 +88,7 @@ public:
 	template <BlitterMode mode, Blitter_32bppSSE_Base::ReadMode read_mode, Blitter_32bppSSE_Base::BlockType bt_last, bool translucent>
 	void Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom);
 
-	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator) override {
+	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override {
 		return Blitter_32bppSSE_Base::Encode(sprite, allocator);
 	}
 

--- a/src/blitter/40bpp_anim.cpp
+++ b/src/blitter/40bpp_anim.cpp
@@ -397,7 +397,7 @@ void Blitter_40bppAnim::DrawColourMappingRect(void *dst, int width, int height, 
 	}
 }
 
-Sprite *Blitter_40bppAnim::Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator)
+Sprite *Blitter_40bppAnim::Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator)
 {
 	return this->EncodeInternal<false>(sprite, allocator);
 }

--- a/src/blitter/40bpp_anim.hpp
+++ b/src/blitter/40bpp_anim.hpp
@@ -27,7 +27,7 @@ public:
 	void ScrollBuffer(void *video, int &left, int &top, int &width, int &height, int scroll_x, int scroll_y) override;
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
 	void DrawColourMappingRect(void *dst, int width, int height, PaletteID pal) override;
-	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator) override;
+	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
 	size_t BufferSize(uint width, uint height) override;
 	Blitter::PaletteAnimation UsePaletteAnimation() override;
 	bool NeedsAnimationBuffer() override;

--- a/src/blitter/8bpp_optimized.cpp
+++ b/src/blitter/8bpp_optimized.cpp
@@ -120,7 +120,7 @@ void Blitter_8bppOptimized::Draw(Blitter::BlitterParams *bp, BlitterMode mode, Z
 	}
 }
 
-Sprite *Blitter_8bppOptimized::Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator)
+Sprite *Blitter_8bppOptimized::Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator)
 {
 	/* Make memory for all zoom-levels */
 	uint memory = sizeof(SpriteData);
@@ -219,7 +219,7 @@ Sprite *Blitter_8bppOptimized::Encode(const SpriteLoader::SpriteCollection &spri
 	assert(size < memory);
 
 	/* Allocate the exact amount of memory we need */
-	Sprite *dest_sprite = (Sprite *)allocator(sizeof(*dest_sprite) + size);
+	Sprite *dest_sprite = allocator.Allocate<Sprite>(sizeof(*dest_sprite) + size);
 
 	dest_sprite->height = sprite[ZOOM_LVL_MIN].height;
 	dest_sprite->width  = sprite[ZOOM_LVL_MIN].width;

--- a/src/blitter/8bpp_optimized.hpp
+++ b/src/blitter/8bpp_optimized.hpp
@@ -23,7 +23,7 @@ public:
 	};
 
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
-	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator) override;
+	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
 
 	std::string_view GetName() override { return "8bpp-optimized"; }
 };

--- a/src/blitter/8bpp_simple.cpp
+++ b/src/blitter/8bpp_simple.cpp
@@ -61,10 +61,10 @@ void Blitter_8bppSimple::Draw(Blitter::BlitterParams *bp, BlitterMode mode, Zoom
 	}
 }
 
-Sprite *Blitter_8bppSimple::Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator)
+Sprite *Blitter_8bppSimple::Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator)
 {
 	Sprite *dest_sprite;
-	dest_sprite = static_cast<Sprite *>(allocator(sizeof(*dest_sprite) + static_cast<size_t>(sprite[ZOOM_LVL_MIN].height) * static_cast<size_t>(sprite[ZOOM_LVL_MIN].width)));
+	dest_sprite = allocator.Allocate<Sprite>(sizeof(*dest_sprite) + static_cast<size_t>(sprite[ZOOM_LVL_MIN].height) * static_cast<size_t>(sprite[ZOOM_LVL_MIN].width));
 
 	dest_sprite->height = sprite[ZOOM_LVL_MIN].height;
 	dest_sprite->width  = sprite[ZOOM_LVL_MIN].width;

--- a/src/blitter/8bpp_simple.hpp
+++ b/src/blitter/8bpp_simple.hpp
@@ -17,7 +17,7 @@
 class Blitter_8bppSimple final : public Blitter_8bppBase {
 public:
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
-	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator) override;
+	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
 
 	std::string_view GetName() override { return "8bpp-simple"; }
 };

--- a/src/blitter/null.cpp
+++ b/src/blitter/null.cpp
@@ -15,10 +15,10 @@
 /** Instantiation of the null blitter factory. */
 static FBlitter_Null iFBlitter_Null;
 
-Sprite *Blitter_Null::Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator)
+Sprite *Blitter_Null::Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator)
 {
 	Sprite *dest_sprite;
-	dest_sprite = (Sprite *)allocator(sizeof(*dest_sprite));
+	dest_sprite = allocator.Allocate<Sprite>(sizeof(*dest_sprite));
 
 	dest_sprite->height = sprite[ZOOM_LVL_MIN].height;
 	dest_sprite->width  = sprite[ZOOM_LVL_MIN].width;

--- a/src/blitter/null.hpp
+++ b/src/blitter/null.hpp
@@ -18,7 +18,7 @@ public:
 	uint8_t GetScreenDepth() override { return 0; }
 	void Draw(Blitter::BlitterParams *, BlitterMode, ZoomLevel) override {};
 	void DrawColourMappingRect(void *, int, int, PaletteID) override {};
-	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator) override;
+	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
 	void *MoveTo(void *, int, int) override { return nullptr; };
 	void SetPixel(void *, int, int, uint8_t) override {};
 	void DrawRect(void *, int, int, uint8_t) override {};

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -273,14 +273,14 @@ const Sprite *FreeTypeFontCache::InternalGetGlyph(GlyphID key, bool aa)
 		}
 	}
 
+	UniquePtrSpriteAllocator allocator;
+	BlitterFactory::GetCurrentBlitter()->Encode(spritecollection, allocator);
+
 	GlyphEntry new_glyph;
-	SimpleSpriteAllocator allocator;
-	new_glyph.sprite = BlitterFactory::GetCurrentBlitter()->Encode(spritecollection, allocator);
-	new_glyph.width  = slot->advance.x >> 6;
+	new_glyph.data = std::move(allocator.data);
+	new_glyph.width = slot->advance.x >> 6;
 
-	this->SetGlyphPtr(key, &new_glyph);
-
-	return new_glyph.sprite;
+	return this->SetGlyphPtr(key, std::move(new_glyph)).GetSprite();
 }
 
 

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -274,7 +274,8 @@ const Sprite *FreeTypeFontCache::InternalGetGlyph(GlyphID key, bool aa)
 	}
 
 	GlyphEntry new_glyph;
-	new_glyph.sprite = BlitterFactory::GetCurrentBlitter()->Encode(spritecollection, SimpleSpriteAlloc);
+	SimpleSpriteAllocator allocator;
+	new_glyph.sprite = BlitterFactory::GetCurrentBlitter()->Encode(spritecollection, allocator);
 	new_glyph.width  = slot->advance.x >> 6;
 
 	this->SetGlyphPtr(key, &new_glyph);

--- a/src/fontcache/truetypefontcache.cpp
+++ b/src/fontcache/truetypefontcache.cpp
@@ -10,7 +10,6 @@
 #include "../stdafx.h"
 #include "../debug.h"
 #include "../fontcache.h"
-#include "../blitter/factory.hpp"
 #include "../core/bitmath_func.hpp"
 #include "../gfx_layout.h"
 #include "truetypefontcache.h"

--- a/src/fontcache/truetypefontcache.cpp
+++ b/src/fontcache/truetypefontcache.cpp
@@ -21,7 +21,7 @@
  * @param fs     The font size that is going to be cached.
  * @param pixels The number of pixels this font should be high.
  */
-TrueTypeFontCache::TrueTypeFontCache(FontSize fs, int pixels) : FontCache(fs), req_size(pixels), glyph_to_sprite(nullptr)
+TrueTypeFontCache::TrueTypeFontCache(FontSize fs, int pixels) : FontCache(fs), req_size(pixels)
 {
 }
 
@@ -39,47 +39,22 @@ TrueTypeFontCache::~TrueTypeFontCache()
  */
 void TrueTypeFontCache::ClearFontCache()
 {
-	if (this->glyph_to_sprite == nullptr) return;
-
-	for (int i = 0; i < 256; i++) {
-		if (this->glyph_to_sprite[i] == nullptr) continue;
-
-		for (int j = 0; j < 256; j++) {
-			free(this->glyph_to_sprite[i][j].sprite);
-		}
-
-		free(this->glyph_to_sprite[i]);
-	}
-
-	free(this->glyph_to_sprite);
-	this->glyph_to_sprite = nullptr;
-
+	this->glyph_to_sprite_map.clear();
 	Layouter::ResetFontCache(this->fs);
 }
 
 
 TrueTypeFontCache::GlyphEntry *TrueTypeFontCache::GetGlyphPtr(GlyphID key)
 {
-	if (this->glyph_to_sprite == nullptr) return nullptr;
-	if (this->glyph_to_sprite[GB(key, 8, 8)] == nullptr) return nullptr;
-	return &this->glyph_to_sprite[GB(key, 8, 8)][GB(key, 0, 8)];
+	auto found = this->glyph_to_sprite_map.find(key);
+	if (found == std::end(this->glyph_to_sprite_map)) return nullptr;
+	return &found->second;
 }
 
-void TrueTypeFontCache::SetGlyphPtr(GlyphID key, const GlyphEntry *glyph)
+TrueTypeFontCache::GlyphEntry &TrueTypeFontCache::SetGlyphPtr(GlyphID key, GlyphEntry &&glyph)
 {
-	if (this->glyph_to_sprite == nullptr) {
-		Debug(fontcache, 3, "Allocating root glyph cache for size {}", this->fs);
-		this->glyph_to_sprite = CallocT<GlyphEntry*>(256);
-	}
-
-	if (this->glyph_to_sprite[GB(key, 8, 8)] == nullptr) {
-		Debug(fontcache, 3, "Allocating glyph cache for range 0x{:02X}00, size {}", GB(key, 8, 8), this->fs);
-		this->glyph_to_sprite[GB(key, 8, 8)] = CallocT<GlyphEntry>(256);
-	}
-
-	Debug(fontcache, 4, "Set glyph for unicode character 0x{:04X}, size {}", key, this->fs);
-	this->glyph_to_sprite[GB(key, 8, 8)][GB(key, 0, 8)].sprite = glyph->sprite;
-	this->glyph_to_sprite[GB(key, 8, 8)][GB(key, 0, 8)].width = glyph->width;
+	this->glyph_to_sprite_map[key] = std::move(glyph);
+	return this->glyph_to_sprite_map[key];
 }
 
 bool TrueTypeFontCache::GetDrawGlyphShadow()
@@ -92,7 +67,7 @@ uint TrueTypeFontCache::GetGlyphWidth(GlyphID key)
 	if ((key & SPRITE_GLYPH) != 0) return this->parent->GetGlyphWidth(key);
 
 	GlyphEntry *glyph = this->GetGlyphPtr(key);
-	if (glyph == nullptr || glyph->sprite == nullptr) {
+	if (glyph == nullptr || glyph->data == nullptr) {
 		this->GetGlyph(key);
 		glyph = this->GetGlyphPtr(key);
 	}
@@ -106,7 +81,7 @@ const Sprite *TrueTypeFontCache::GetGlyph(GlyphID key)
 
 	/* Check for the glyph in our cache */
 	GlyphEntry *glyph = this->GetGlyphPtr(key);
-	if (glyph != nullptr && glyph->sprite != nullptr) return glyph->sprite;
+	if (glyph != nullptr && glyph->data != nullptr) return glyph->GetSprite();
 
 	return this->InternalGetGlyph(key, GetFontAAState());
 }

--- a/src/fontcache/truetypefontcache.h
+++ b/src/fontcache/truetypefontcache.h
@@ -29,27 +29,16 @@ protected:
 
 	/** Container for information about a glyph. */
 	struct GlyphEntry {
-		Sprite *sprite; ///< The loaded sprite.
-		uint8_t width; ///< The width of the glyph.
+		std::unique_ptr<uint8_t[]> data; ///< The loaded sprite.
+		uint8_t width = 0; ///< The width of the glyph.
+
+		Sprite *GetSprite() { return reinterpret_cast<Sprite *>(data.get()); }
 	};
 
-	/**
-	 * The glyph cache. This is structured to reduce memory consumption.
-	 * 1) There is a 'segment' table for each font size.
-	 * 2) Each segment table is a discrete block of characters.
-	 * 3) Each block contains 256 (aligned) characters sequential characters.
-	 *
-	 * The cache is accessed in the following way:
-	 * For character 0x0041  ('A'): glyph_to_sprite[0x00][0x41]
-	 * For character 0x20AC (Euro): glyph_to_sprite[0x20][0xAC]
-	 *
-	 * Currently only 256 segments are allocated, "limiting" us to 65536 characters.
-	 * This can be simply changed in the two functions Get & SetGlyphPtr.
-	 */
-	GlyphEntry **glyph_to_sprite;
+	std::unordered_map<GlyphID, GlyphEntry> glyph_to_sprite_map{};
 
 	GlyphEntry *GetGlyphPtr(GlyphID key);
-	void SetGlyphPtr(GlyphID key, const GlyphEntry *glyph);
+	GlyphEntry &SetGlyphPtr(GlyphID key, GlyphEntry &&glyph);
 
 	virtual const Sprite *InternalGetGlyph(GlyphID key, bool aa) = 0;
 

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -277,7 +277,8 @@ const Sprite *CoreTextFontCache::InternalGetGlyph(GlyphID key, bool use_aa)
 	}
 
 	GlyphEntry new_glyph;
-	new_glyph.sprite = BlitterFactory::GetCurrentBlitter()->Encode(spritecollection, SimpleSpriteAlloc);
+	SimpleSpriteAllocator allocator;
+	new_glyph.sprite = BlitterFactory::GetCurrentBlitter()->Encode(spritecollection, allocator);
 	new_glyph.width = (uint8_t)std::round(CTFontGetAdvancesForGlyphs(this->font.get(), kCTFontOrientationDefault, &glyph, nullptr, 1));
 	this->SetGlyphPtr(key, &new_glyph);
 

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -276,13 +276,14 @@ const Sprite *CoreTextFontCache::InternalGetGlyph(GlyphID key, bool use_aa)
 		}
 	}
 
-	GlyphEntry new_glyph;
-	SimpleSpriteAllocator allocator;
-	new_glyph.sprite = BlitterFactory::GetCurrentBlitter()->Encode(spritecollection, allocator);
-	new_glyph.width = (uint8_t)std::round(CTFontGetAdvancesForGlyphs(this->font.get(), kCTFontOrientationDefault, &glyph, nullptr, 1));
-	this->SetGlyphPtr(key, &new_glyph);
+	UniquePtrSpriteAllocator allocator;
+	BlitterFactory::GetCurrentBlitter()->Encode(spritecollection, allocator);
 
-	return new_glyph.sprite;
+	GlyphEntry new_glyph;
+	new_glyph.data = std::move(allocator.data);
+	new_glyph.width = (uint8_t)std::round(CTFontGetAdvancesForGlyphs(this->font.get(), kCTFontOrientationDefault, &glyph, nullptr, 1));
+
+	return this->SetGlyphPtr(key, std::move(new_glyph)).GetSprite();
 }
 
 static CTFontDescriptorRef LoadFontFromFile(const std::string &font_name)

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -253,7 +253,8 @@ void Win32FontCache::ClearFontCache()
 	}
 
 	GlyphEntry new_glyph;
-	new_glyph.sprite = BlitterFactory::GetCurrentBlitter()->Encode(spritecollection, SimpleSpriteAlloc);
+	SimpleSpriteAllocator allocator;
+	new_glyph.sprite = BlitterFactory::GetCurrentBlitter()->Encode(spritecollection, allocator);
 	new_glyph.width = gm.gmCellIncX;
 
 	this->SetGlyphPtr(key, &new_glyph);

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -252,14 +252,14 @@ void Win32FontCache::ClearFontCache()
 		}
 	}
 
+	UniquePtrSpriteAllocator allocator;
+	BlitterFactory::GetCurrentBlitter()->Encode(spritecollection, allocator);
+
 	GlyphEntry new_glyph;
-	SimpleSpriteAllocator allocator;
-	new_glyph.sprite = BlitterFactory::GetCurrentBlitter()->Encode(spritecollection, allocator);
+	new_glyph.data = std::move(allocator.data);
 	new_glyph.width = gm.gmCellIncX;
 
-	this->SetGlyphPtr(key, &new_glyph);
-
-	return new_glyph.sprite;
+	return this->SetGlyphPtr(key, std::move(new_glyph)).GetSprite();
 }
 
 /* virtual */ GlyphID Win32FontCache::MapCharToGlyph(char32_t key, bool allow_fallback)

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -894,6 +894,12 @@ void *SimpleSpriteAllocator::AllocatePtr(size_t size)
 	return MallocT<uint8_t>(size);
 }
 
+void *UniquePtrSpriteAllocator::AllocatePtr(size_t size)
+{
+	this->data = std::make_unique<uint8_t[]>(size);
+	return this->data.get();
+}
+
 /**
  * Handles the case when a sprite of different type is requested than is present in the SpriteCache.
  * For SpriteType::Font sprites, it is normal. In other cases, default sprite is loaded instead.

--- a/src/spritecache.h
+++ b/src/spritecache.h
@@ -37,6 +37,14 @@ protected:
 	void *AllocatePtr(size_t size) override;
 };
 
+/** SpriteAllocator that allocates memory via a unique_ptr array. */
+class UniquePtrSpriteAllocator : public SpriteAllocator {
+public:
+	std::unique_ptr<uint8_t[]> data;
+protected:
+	void *AllocatePtr(size_t size) override;
+};
+
 void *GetRawSprite(SpriteID sprite, SpriteType type, SpriteAllocator *allocator = nullptr, SpriteEncoder *encoder = nullptr);
 bool SpriteExists(SpriteID sprite);
 

--- a/src/spritecache.h
+++ b/src/spritecache.h
@@ -31,10 +31,13 @@ enum SpriteCacheCtrlFlags {
 
 extern uint _sprite_cache_size;
 
-typedef void *AllocatorProc(size_t size);
+/** SpriteAllocate that uses malloc to allocate memory. */
+class SimpleSpriteAllocator : public SpriteAllocator {
+protected:
+	void *AllocatePtr(size_t size) override;
+};
 
-void *SimpleSpriteAlloc(size_t size);
-void *GetRawSprite(SpriteID sprite, SpriteType type, AllocatorProc *allocator = nullptr, SpriteEncoder *encoder = nullptr);
+void *GetRawSprite(SpriteID sprite, SpriteType type, SpriteAllocator *allocator = nullptr, SpriteEncoder *encoder = nullptr);
 bool SpriteExists(SpriteID sprite);
 
 SpriteType GetSpriteType(SpriteID sprite);

--- a/src/spritecache_internal.h
+++ b/src/spritecache_internal.h
@@ -31,12 +31,17 @@ struct SpriteCache {
 	uint8_t control_flags;  ///< Control flags, see SpriteCacheCtrlFlags
 };
 
+/** SpriteAllocator that allocates memory from the sprite cache. */
+class CacheSpriteAllocator : public SpriteAllocator {
+protected:
+	void *AllocatePtr(size_t size) override;
+};
+
 inline bool IsMapgenSpriteID(SpriteID sprite)
 {
 	return IsInsideMM(sprite, SPR_MAPGEN_BEGIN, SPR_MAPGEN_END);
 }
 
-void *AllocSprite(size_t mem_req);
 SpriteCache *AllocateSpriteCache(uint index);
 
 #endif /* SPRITECACHE_INTERNAL_H */

--- a/src/spriteloader/spriteloader.hpp
+++ b/src/spriteloader/spriteloader.hpp
@@ -16,7 +16,6 @@
 #include "sprite_file_type.hpp"
 
 struct Sprite;
-typedef void *AllocatorProc(size_t size);
 
 /** The different colour components a sprite can have. */
 enum SpriteColourComponent {
@@ -85,6 +84,32 @@ public:
 	virtual ~SpriteLoader() = default;
 };
 
+/** Interface for something that can allocate memory for a sprite. */
+class SpriteAllocator {
+public:
+	virtual ~SpriteAllocator() = default;
+
+	/**
+	 * Allocate memory for a sprite.
+	 * @tparam T Type to return memory as.
+	 * @param size Size of memory to allocate in bytes.
+	 * @return Pointer to allocated memory.
+	 */
+	template <typename T>
+	T *Allocate(size_t size)
+	{
+		return static_cast<T *>(this->AllocatePtr(size));
+	}
+
+protected:
+	/**
+	 * Allocate memory for a sprite.
+	 * @param size Size of memory to allocate.
+	 * @return Pointer to allocated memory.
+	 */
+	virtual void *AllocatePtr(size_t size) = 0;
+};
+
 /** Interface for something that can encode a sprite. */
 class SpriteEncoder {
 public:
@@ -99,7 +124,7 @@ public:
 	/**
 	 * Convert a sprite from the loader to our own format.
 	 */
-	virtual Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator) = 0;
+	virtual Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) = 0;
 
 	/**
 	 * Get the value which the height and width on a sprite have to be aligned by.

--- a/src/tests/mock_spritecache.cpp
+++ b/src/tests/mock_spritecache.cpp
@@ -17,7 +17,8 @@
 
 static bool MockLoadNextSprite(int load_index)
 {
-	static Sprite *sprite = (Sprite *)AllocSprite(sizeof(*sprite));
+	SimpleSpriteAllocator allocator;
+	static Sprite *sprite = allocator.Allocate<Sprite>(sizeof(*sprite));
 
 	bool is_mapgen = IsMapgenSpriteID(load_index);
 

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -1105,7 +1105,8 @@ void OpenGLBackend::PopulateCursorCache()
 		this->cursor_sprites.emplace_back(sc);
 
 		if (!this->cursor_cache.Contains(sc.image.sprite)) {
-			Sprite *old = this->cursor_cache.Insert(sc.image.sprite, (Sprite *)GetRawSprite(sc.image.sprite, SpriteType::Normal, &SimpleSpriteAlloc, this));
+			SimpleSpriteAllocator allocator;
+			Sprite *old = this->cursor_cache.Insert(sc.image.sprite, static_cast<Sprite *>(GetRawSprite(sc.image.sprite, SpriteType::Normal, &allocator, this)));
 			if (old != nullptr) {
 				OpenGLSprite *gl_sprite = (OpenGLSprite *)old->data;
 				gl_sprite->~OpenGLSprite();
@@ -1257,10 +1258,10 @@ void OpenGLBackend::ReleaseAnimBuffer(const Rect &update_rect)
 	}
 }
 
-/* virtual */ Sprite *OpenGLBackend::Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator)
+/* virtual */ Sprite *OpenGLBackend::Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator)
 {
 	/* Allocate and construct sprite data. */
-	Sprite *dest_sprite = (Sprite *)allocator(sizeof(*dest_sprite) + sizeof(OpenGLSprite));
+	Sprite *dest_sprite = allocator.Allocate<Sprite>(sizeof(*dest_sprite) + sizeof(OpenGLSprite));
 
 	OpenGLSprite *gl_sprite = (OpenGLSprite *)dest_sprite->data;
 	new (gl_sprite) OpenGLSprite(sprite[ZOOM_LVL_MIN].width, sprite[ZOOM_LVL_MIN].height, sprite[ZOOM_LVL_MIN].type == SpriteType::Font ? 1 : ZOOM_LVL_END, sprite[ZOOM_LVL_MIN].colours);

--- a/src/video/opengl.h
+++ b/src/video/opengl.h
@@ -107,7 +107,7 @@ public:
 
 	bool Is32BppSupported() override { return true; }
 	uint GetSpriteAlignment() override { return 1u << (ZOOM_LVL_END - 1); }
-	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, AllocatorProc *allocator) override;
+	Sprite *Encode(const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
 };
 
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Similar to #12724, TrueTypeFontCache has yet-another-implementation of a 'sparse' array using blocks of malloc'd arrays.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Replace with manually managed pointers and arrays with a `std::unordered_map`.

GlyphEntry previously shared sprite data for unknown glyphs, and freeing this memory was specially handled in the clean up loops when cleaning the glyph map. This is not simple to replicate with a destructor (as the destructor is always called, not just for glyph map entries), so I elected to not share the memory instead.

This required refactoring how sprite memory is allocated using a stateful helper instead of function pointers. This first change is the same as in #11495.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
