### PR TITLE
Change: Don't use house construction states in Scenario Editor

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2681,7 +2681,7 @@ static void BuildTownHouse(Town *t, TileIndex tile, const HouseSpec *hs, HouseID
 	uint8_t construction_counter = 0;
 	uint8_t construction_stage = 0;
 
-	if (_generating_world || _game_mode == GM_EDITOR) {
+	if (_generating_world) {
 		uint32_t construction_random = Random();
 
 		construction_stage = TOWN_HOUSE_COMPLETED;


### PR DESCRIPTION
## Motivation / Problem

![construction](https://github.com/OpenTTD/OpenTTD/assets/55058389/c2a0eab9-7e7f-41ed-b584-f194b2949e4b)

Now that we can place houses in Scenario Editor (#12661), it's odd to pick a house, place it, and have a dirty hole appear in the ground appear instead of the house I was expecting.

I don't think houses placed in Scenario Editor should randomly appear as construction sprites.

## Description

Leave construction sprites for map generation (and of course, growth during gameplay).

## Limitations

Yes, I'm just scratching an itch. 😉 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
