### PR TITLE
Codechange: Avoid unnecessary allocation of temporaries in layout line cache

### DIFF
--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -388,7 +388,7 @@ Layouter::LineCacheItem &Layouter::GetCachedParagraphLayout(std::string_view str
 	LineCacheKey key;
 	key.state_before = state;
 	key.str.assign(str);
-	return (*linecache)[key];
+	return (*linecache)[std::move(key)];
 }
 
 /**

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -132,7 +132,7 @@ class Layouter : public std::vector<std::unique_ptr<const ParagraphLayouter::Lin
 	};
 
 	struct LineCacheQuery {
-		FontState state_before;  ///< Font state at the beginning of the line.
+		const FontState &state_before; ///< Font state at the beginning of the line.
 		std::string_view str;    ///< Source string of the line (including colour and font size codes).
 	};
 


### PR DESCRIPTION
## Motivation / Problem

`class Layouter` has a non-owning `LineCacheQuery` struct to use for lookups in `LineCache`, which uses `LineCacheKey` as the key type.
Both of the members of `LineCacheKey` are owning (`FontState` contains a std::vector), however `LineCacheQuery` currently only uses a non-owning type for the other member.

In `Layouter::GetCachedParagraphLayout`, when adding an entry to `LineCache`, a temporary `LineCacheKey` is created, allocating and copying a new vector and string. Inserting this into the `LineCache` does the allocation and copying of the vector and string a second time, which is unnecessary.

## Description

Don't unnecessarily copy/allocate `FontState` in `LineCacheQuery`.
Avoid unnecessary duplication of `LineCacheKey` members in `Layouter::GetCachedParagraphLayout`.

## Limitations

I haven't bothered benchmarking this, as the absolute reduction in overhead is likely to be small and lost in the noise.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
