### PR TITLE
Add: [Script] GSController::TriggerSave to trigger saves from game scripts

### DIFF
--- a/src/script/api/game/game_controller.hpp.sq
+++ b/src/script/api/game/game_controller.hpp.sq
@@ -21,6 +21,7 @@ void SQGSController_Register(Squirrel *engine)
 	SQGSController.DefSQStaticMethod(engine, &ScriptController::Break,             "Break",             2, ".s");
 	SQGSController.DefSQStaticMethod(engine, &ScriptController::GetSetting,        "GetSetting",        2, ".s");
 	SQGSController.DefSQStaticMethod(engine, &ScriptController::GetVersion,        "GetVersion",        1, ".");
+	SQGSController.DefSQStaticMethod(engine, &ScriptController::TriggerSave,       "TriggerSave",       2, ".s");
 	SQGSController.DefSQStaticMethod(engine, &ScriptController::Print,             "Print",             3, ".bs");
 
 	SQGSController.PostRegister(engine);

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -17,6 +17,9 @@
  *
  * This version is not yet released. The following changes are not set in stone yet.
  *
+ * API additions:
+ * \li GSController::TriggerSave
+ *
  * \b 14.0
  *
  * API additions:

--- a/src/script/api/script_controller.cpp
+++ b/src/script/api/script_controller.cpp
@@ -94,6 +94,11 @@ ScriptController::ScriptController(CompanyID company) :
 	return _openttd_newgrf_version;
 }
 
+/* static */ bool ScriptController::TriggerSave(const std::string &filename)
+{
+	return ScriptObject::GetActiveInstance()->TriggerSave(filename);
+}
+
 /* static */ HSQOBJECT ScriptController::Import(const std::string &library, const std::string &class_name, int version)
 {
 	ScriptController *controller = ScriptObject::GetActiveInstance()->GetController();

--- a/src/script/api/script_controller.hpp
+++ b/src/script/api/script_controller.hpp
@@ -148,6 +148,13 @@ public:
 	static uint GetVersion();
 
 	/**
+	 * Saves the current game to the savegame directory.
+	 * @param filename The filename to save to, not including the ".sav" extension
+	 * @return True if the saving was successful.
+	 */
+	static bool TriggerSave(const std::string &filename);
+
+	/**
 	 * Change the minimum amount of time the script should be put in suspend mode
 	 *   when you execute a command. Normally in SP this is 1, and in MP it is
 	 *   what ever delay the server has been programmed to delay commands

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -751,6 +751,11 @@ SQInteger ScriptInstance::GetOpsTillSuspend()
 	return this->engine->GetOpsTillSuspend();
 }
 
+bool ScriptInstance::TriggerSave(const std::string &filename)
+{
+	return SaveOrLoad(filename + ".sav", SLO_SAVE, DFT_GAME_FILE, SAVE_DIR) == SL_OK;
+}
+
 bool ScriptInstance::DoCommandCallback(const CommandCost &result, const CommandDataBuffer &data, CommandDataBuffer result_data, Commands cmd)
 {
 	ScriptObject::ActiveInstance active(this);

--- a/src/script/script_instance.hpp
+++ b/src/script/script_instance.hpp
@@ -214,6 +214,13 @@ public:
 	SQInteger GetOpsTillSuspend();
 
 	/**
+	 * Saves the current game to the savegame directory.
+	 * @param filename The filename to save to, not including the ".sav" extension
+	 * @return True if the saving was successful.
+	 */
+	bool TriggerSave(const std::string &filename);
+
+	/**
 	 * DoCommand callback function for all commands executed by scripts.
 	 * @param result The result of the command.
 	 * @param tile The tile on which the command was executed.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

The change in https://github.com/OpenTTD/OpenTTD/pull/10655, released as part of OpenTTD 14, changed how auto saving works from every X amount of game time, to every X amount of real time. This is an improvement for normal play, but there are cases where saving every X amount of game time is useful. For example when developing and comparing AIs, or using OpenTTD to conduct experiments such as via https://github.com/michalc/OpenTTDLab which extracts data from savegame files.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This change addresses this by adding the GSController::TriggerSave function to the GameScript API that allows game scripts to trigger a save, and with a specific file name. Because game script have access to the in-game date through GSDate.GetCurrentDate, and can sleep arbitrary amounts of ticks, it means they can approximate the pre OpenTTD 14 behaviour of saving every X amount of game time.

It also means that via game scripts, games can be saved immediately after game start, which wasn't possible with the previous autosave behaviour.

The name of the function is not Save to avoid conflict and confusion between the existing Save function that game scripts can implement to add custom data to savegame files.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

None known


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
