### PR TITLE
Codechange: Use unordered_map for NewGRF language_map.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -307,6 +307,7 @@ add_files(
     newgrf_storage.h
     newgrf_text.cpp
     newgrf_text.h
+    newgrf_text_type.h
     newgrf_town.cpp
     newgrf_town.h
     newgrf_townname.cpp

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -2644,7 +2644,12 @@ static ChangeInfoResult TownHouseChangeInfo(uint hid, int numinfo, int prop, Byt
 {
 	/* LanguageID "MAX_LANG", i.e. 7F is any. This language can't have a gender/case mapping, but has to be handled gracefully. */
 	const GRFFile *grffile = GetFileByGRFID(grfid);
-	return (grffile != nullptr && grffile->language_map != nullptr && language_id < MAX_LANG) ? &grffile->language_map[language_id] : nullptr;
+	if (grffile == nullptr) return nullptr;
+
+	auto it = grffile->language_map.find(language_id);
+	if (it == std::end(grffile->language_map)) return nullptr;
+
+	return &it->second;
 }
 
 /**
@@ -2858,8 +2863,6 @@ static ChangeInfoResult GlobalVarChangeInfo(uint gvid, int numinfo, int prop, By
 					}
 					break;
 				}
-
-				if (_cur.grffile->language_map == nullptr) _cur.grffile->language_map = new LanguageMap[MAX_LANG];
 
 				if (prop == 0x15) {
 					uint plural_form = buf->ReadByte();
@@ -8931,11 +8934,6 @@ GRFFile::GRFFile(const GRFConfig *config)
 	 * 'Uninitialised' parameters are zeroed as that is their default value when dynamically creating them. */
 	this->param = config->param;
 	this->param_end = config->num_params;
-}
-
-GRFFile::~GRFFile()
-{
-	delete[] this->language_map;
 }
 
 /**

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -14,6 +14,7 @@
 #include "rail_type.h"
 #include "road_type.h"
 #include "fileio_type.h"
+#include "newgrf_text_type.h"
 #include "core/bitmath_func.hpp"
 #include "core/alloc_type.hpp"
 #include "core/mem_func.hpp"
@@ -140,7 +141,7 @@ struct GRFFile : ZeroedMemoryAllocator {
 
 	CanalProperties canal_local_properties[CF_END]; ///< Canal properties as set by this NewGRF
 
-	struct LanguageMap *language_map; ///< Mappings related to the languages.
+	std::unordered_map<uint8_t, LanguageMap> language_map; ///< Mappings related to the languages.
 
 	int traininfo_vehicle_pitch;  ///< Vertical offset for drawing train images in depot GUI and vehicle details
 	uint traininfo_vehicle_width; ///< Width (in pixels) of a 8/8 train vehicle in depot GUI and vehicle details
@@ -149,7 +150,6 @@ struct GRFFile : ZeroedMemoryAllocator {
 	PriceMultipliers price_base_multipliers; ///< Price base multipliers as set by the grf.
 
 	GRFFile(const struct GRFConfig *config);
-	~GRFFile();
 
 	/** Get GRF Parameter with range checking */
 	uint32_t GetParam(uint number) const

--- a/src/newgrf_text.h
+++ b/src/newgrf_text.h
@@ -10,24 +10,9 @@
 #ifndef NEWGRF_TEXT_H
 #define NEWGRF_TEXT_H
 
-#include "string_type.h"
+#include "newgrf_text_type.h"
 #include "strings_type.h"
 #include "table/control_codes.h"
-#include <utility>
-
-/** This character, the thorn ('þ'), indicates a unicode string to NFO. */
-static const char32_t NFO_UTF8_IDENTIFIER = 0x00DE;
-
-/** A GRF text with associated language ID. */
-struct GRFText {
-	uint8_t langid;      ///< The language associated with this GRFText.
-	std::string text; ///< The actual (translated) text.
-};
-
-/** A GRF text with a list of translations. */
-typedef std::vector<GRFText> GRFTextList;
-/** Reference counted wrapper around a GRFText pointer. */
-typedef std::shared_ptr<GRFTextList> GRFTextWrapper;
 
 StringID AddGRFString(uint32_t grfid, uint16_t stringid, uint8_t langid, bool new_scheme, bool allow_newlines, std::string_view text_to_add, StringID def_string);
 StringID GetGRFStringID(uint32_t grfid, StringID stringid);
@@ -48,28 +33,5 @@ void StopTextRefStackUsage();
 bool UsingNewGRFTextStack();
 struct TextRefStack *CreateTextRefStackBackup();
 void RestoreTextRefStackBackup(struct TextRefStack *backup);
-
-/** Mapping of language data between a NewGRF and OpenTTD. */
-struct LanguageMap {
-	/** Mapping between NewGRF and OpenTTD IDs. */
-	struct Mapping {
-		uint8_t newgrf_id;  ///< NewGRF's internal ID for a case/gender.
-		uint8_t openttd_id; ///< OpenTTD's internal ID for a case/gender.
-	};
-
-	/* We need a vector and can't use SmallMap due to the fact that for "setting" a
-	 * gender of a string or requesting a case for a substring we want to map from
-	 * the NewGRF's internal ID to OpenTTD's ID whereas for the choice lists we map
-	 * the genders/cases/plural OpenTTD IDs to the NewGRF's internal IDs. In this
-	 * case a NewGRF developer/translator might want a different translation for
-	 * both cases. Thus we are basically implementing a multi-map. */
-	std::vector<Mapping> gender_map; ///< Mapping of NewGRF and OpenTTD IDs for genders.
-	std::vector<Mapping> case_map;   ///< Mapping of NewGRF and OpenTTD IDs for cases.
-	int plural_form;                 ///< The plural form used for this language.
-
-	int GetMapping(int newgrf_id, bool gender) const;
-	int GetReverseMapping(int openttd_id, bool gender) const;
-	static const LanguageMap *GetLanguageMap(uint32_t grfid, uint8_t language_id);
-};
 
 #endif /* NEWGRF_TEXT_H */

--- a/src/newgrf_text_type.h
+++ b/src/newgrf_text_type.h
@@ -1,0 +1,50 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file newgrf_text_type.h Header of Action 04 "universal holder" structure */
+
+#ifndef NEWGRF_TEXT_TYPE_H
+#define NEWGRF_TEXT_TYPE_H
+
+/** This character (thorn) indicates a unicode string to NFO. */
+static const char32_t NFO_UTF8_IDENTIFIER = 0x00DE;
+
+/** A GRF text with associated language ID. */
+struct GRFText {
+	uint8_t langid;      ///< The language associated with this GRFText.
+	std::string text; ///< The actual (translated) text.
+};
+
+/** A GRF text with a list of translations. */
+using GRFTextList = std::vector<GRFText>;
+/** Reference counted wrapper around a GRFText pointer. */
+using GRFTextWrapper = std::shared_ptr<GRFTextList>;
+
+/** Mapping of language data between a NewGRF and OpenTTD. */
+struct LanguageMap {
+	/** Mapping between NewGRF and OpenTTD IDs. */
+	struct Mapping {
+		uint8_t newgrf_id;  ///< NewGRF's internal ID for a case/gender.
+		uint8_t openttd_id; ///< OpenTTD's internal ID for a case/gender.
+	};
+
+	/* We need a vector and can't use SmallMap due to the fact that for "setting" a
+	 * gender of a string or requesting a case for a substring we want to map from
+	 * the NewGRF's internal ID to OpenTTD's ID whereas for the choice lists we map
+	 * the genders/cases/plural OpenTTD IDs to the NewGRF's internal IDs. In this
+	 * case a NewGRF developer/translator might want a different translation for
+	 * both cases. Thus we are basically implementing a multi-map. */
+	std::vector<Mapping> gender_map; ///< Mapping of NewGRF and OpenTTD IDs for genders.
+	std::vector<Mapping> case_map;   ///< Mapping of NewGRF and OpenTTD IDs for cases.
+	int plural_form;                 ///< The plural form used for this language.
+
+	int GetMapping(int newgrf_id, bool gender) const;
+	int GetReverseMapping(int openttd_id, bool gender) const;
+	static const LanguageMap *GetLanguageMap(uint32_t grfid, uint8_t language_id);
+};
+
+#endif /* NEWGRF_TEXT_TYPE_H */


### PR DESCRIPTION

<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Manual memory allocation of NewGRF langauge_map array with pointer and new/delete.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use unordered_map for NewGRF language_map.

NewGRFs only use a small subset of the available language IDs. Using an unordered_map allows only the reference languages to have space allocated.

This avoids manual new/delete of array.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
