### PR TITLE
Fix #12030: Water infrastructure totals when using DC_FORCE_CLEAR_TILE to remove objects on water

### DIFF
--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -30,6 +30,7 @@
 #include "core/random_func.hpp"
 #include "object_base.h"
 #include "company_func.h"
+#include "company_gui.h"
 #include "pathfinder/aystar.h"
 #include "saveload/saveload.h"
 #include "framerate_type.h"
@@ -680,7 +681,16 @@ CommandCost CmdLandscapeClear(DoCommandFlag flags, TileIndex tile)
 
 	if (flags & DC_EXEC) {
 		if (c != nullptr) c->clear_limit -= 1 << 16;
-		if (do_clear) DoClearSquare(tile);
+		if (do_clear) {
+			if (IsWaterTile(tile) && IsCanal(tile)) {
+				Owner owner = GetTileOwner(tile);
+				if (Company::IsValidID(owner)) {
+					Company::Get(owner)->infrastructure.water--;
+					DirtyCompanyInfrastructureWindows(owner);
+				}
+			}
+			DoClearSquare(tile);
+		}
 	}
 	return cost;
 }


### PR DESCRIPTION
## Motivation / Problem

#12030.

## Description

Fix incomplete special casing of tiles with water in CmdLandscapeClear when DC_FORCE_CLEAR_TILE flag is set.
Update water infrastructure total as required.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
