### PR TITLE
Change: Position caret at correct position on glyph for RTL languages.

### DIFF
--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -349,10 +349,10 @@ struct IConsoleWindow : Window
 	{
 		int delta = std::min<int>(this->width - this->line_offset - _iconsole_cmdline.pixels - ICON_RIGHT_BORDERWIDTH, 0);
 
-		Point p1 = GetCharPosInString(_iconsole_cmdline.buf, from, FS_NORMAL);
-		Point p2 = from != to ? GetCharPosInString(_iconsole_cmdline.buf, to, FS_NORMAL) : p1;
+		const auto p1 = GetCharPosInString(_iconsole_cmdline.buf, from, FS_NORMAL);
+		const auto p2 = from != to ? GetCharPosInString(_iconsole_cmdline.buf, to, FS_NORMAL) : p1;
 
-		Rect r = {this->line_offset + delta + p1.x, this->height - this->line_height, this->line_offset + delta + p2.x, this->height};
+		Rect r = {this->line_offset + delta + p1.left, this->height - this->line_height, this->line_offset + delta + p2.right, this->height};
 		return r;
 	}
 

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -17,6 +17,7 @@
 #include "string_func.h"
 #include "strings_func.h"
 #include "gfx_func.h"
+#include "gfx_layout.h"
 #include "settings_type.h"
 #include "console_func.h"
 #include "rev.h"

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -605,9 +605,9 @@ static int DrawLayoutLine(const ParagraphLayouter::Line &line, int y, int left, 
 				/* Not a valid glyph (empty) */
 				if (glyph == 0xFFFF) continue;
 
-				int begin_x = positions[i].x     + left - offset_x;
-				int end_x   = positions[i + 1].x + left - offset_x  - 1;
-				int top     = positions[i].y + y;
+				int begin_x = positions[i].left + left - offset_x;
+				int end_x = positions[i].right + left - offset_x;
+				int top = positions[i].top + y;
 
 				/* Truncated away. */
 				if (truncation && (begin_x < min_x || end_x > max_x)) continue;

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -896,39 +896,6 @@ Dimension GetStringListBoundingBox(std::span<const StringID> list, FontSize font
 }
 
 /**
- * Get the leading corner of a character in a single-line string relative
- * to the start of the string.
- * @param str String containing the character.
- * @param ch Pointer to the character in the string.
- * @param start_fontsize Font size to start the text with.
- * @return Upper left corner of the glyph associated with the character.
- */
-Point GetCharPosInString(std::string_view str, const char *ch, FontSize start_fontsize)
-{
-	/* Ensure "ch" is inside "str" or at the exact end. */
-	assert(ch >= str.data() && (ch - str.data()) <= static_cast<ptrdiff_t>(str.size()));
-	auto it_ch = str.begin() + (ch - str.data());
-
-	Layouter layout(str, INT32_MAX, start_fontsize);
-	return layout.GetCharPosition(it_ch);
-}
-
-/**
- * Get the character from a string that is drawn at a specific position.
- * @param str String to test.
- * @param x Position relative to the start of the string.
- * @param start_fontsize Font size to start the text with.
- * @return Index of the character position or -1 if there is no character at the position.
- */
-ptrdiff_t GetCharAtPosition(std::string_view str, int x, FontSize start_fontsize)
-{
-	if (x < 0) return -1;
-
-	Layouter layout(str, INT32_MAX, start_fontsize);
-	return layout.GetCharAtPosition(x, 0);
-}
-
-/**
  * Draw single character horizontally centered around (x,y)
  * @param c           Character (glyph) to draw
  * @param r           Rectangle to draw character within

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -142,8 +142,6 @@ int GetStringLineCount(StringID str, int maxw);
 Dimension GetStringMultiLineBoundingBox(StringID str, const Dimension &suggestion);
 Dimension GetStringMultiLineBoundingBox(std::string_view str, const Dimension &suggestion);
 void LoadStringWidthTable(bool monospace = false);
-Point GetCharPosInString(std::string_view str, const char *ch, FontSize start_fontsize = FS_NORMAL);
-ptrdiff_t GetCharAtPosition(std::string_view str, int x, FontSize start_fontsize = FS_NORMAL);
 
 void DrawDirtyBlocks();
 void AddDirtyBlock(int left, int top, int right, int bottom);

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -409,3 +409,36 @@ void Layouter::ReduceLineCache()
 		if (linecache->size() > 4096) ResetLineCache();
 	}
 }
+
+/**
+ * Get the leading corner of a character in a single-line string relative
+ * to the start of the string.
+ * @param str String containing the character.
+ * @param ch Pointer to the character in the string.
+ * @param start_fontsize Font size to start the text with.
+ * @return Upper left corner of the glyph associated with the character.
+ */
+Point GetCharPosInString(std::string_view str, const char *ch, FontSize start_fontsize)
+{
+	/* Ensure "ch" is inside "str" or at the exact end. */
+	assert(ch >= str.data() && (ch - str.data()) <= static_cast<ptrdiff_t>(str.size()));
+	auto it_ch = str.begin() + (ch - str.data());
+
+	Layouter layout(str, INT32_MAX, start_fontsize);
+	return layout.GetCharPosition(it_ch);
+}
+
+/**
+ * Get the character from a string that is drawn at a specific position.
+ * @param str String to test.
+ * @param x Position relative to the start of the string.
+ * @param start_fontsize Font size to start the text with.
+ * @return Index of the character position or -1 if there is no character at the position.
+ */
+ptrdiff_t GetCharAtPosition(std::string_view str, int x, FontSize start_fontsize)
+{
+	if (x < 0) return -1;
+
+	Layouter layout(str, INT32_MAX, start_fontsize);
+	return layout.GetCharAtPosition(x, 0);
+}

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -225,7 +225,7 @@ static bool IsConsumedFormattingCode(char32_t ch)
  * @return Upper left corner of the character relative to the start of the string.
  * @note Will only work right for single-line strings.
  */
-Point Layouter::GetCharPosition(std::string_view::const_iterator ch) const
+ParagraphLayouter::Position Layouter::GetCharPosition(std::string_view::const_iterator ch) const
 {
 	const auto &line = this->front();
 
@@ -245,8 +245,8 @@ Point Layouter::GetCharPosition(std::string_view::const_iterator ch) const
 	}
 
 	/* Initial position, returned if character not found. */
-	const Point initial_position = {_current_text_dir == TD_LTR ? 0 : line->GetWidth(), 0};
-	const Point *position = &initial_position;
+	const ParagraphLayouter::Position initial_position = Point{_current_text_dir == TD_LTR ? 0 : line->GetWidth(), 0};
+	const ParagraphLayouter::Position *position = &initial_position;
 
 	/* We couldn't find the code point index. */
 	if (str != ch) return *position;
@@ -303,8 +303,8 @@ ptrdiff_t Layouter::GetCharAtPosition(int x, size_t line_index) const
 			/* Not a valid glyph (empty). */
 			if (glyphs[i] == 0xFFFF) continue;
 
-			int begin_x = positions[i].x;
-			int end_x   = positions[i + 1].x;
+			int begin_x = positions[i].left;
+			int end_x   = positions[i].right + 1;
 
 			if (IsInsideMM(x, begin_x, end_x)) {
 				/* Found our glyph, now convert to UTF-8 string index. */
@@ -418,7 +418,7 @@ void Layouter::ReduceLineCache()
  * @param start_fontsize Font size to start the text with.
  * @return Upper left corner of the glyph associated with the character.
  */
-Point GetCharPosInString(std::string_view str, const char *ch, FontSize start_fontsize)
+ParagraphLayouter::Position GetCharPosInString(std::string_view str, const char *ch, FontSize start_fontsize)
 {
 	/* Ensure "ch" is inside "str" or at the exact end. */
 	assert(ch >= str.data() && (ch - str.data()) <= static_cast<ptrdiff_t>(str.size()));

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -185,4 +185,7 @@ public:
 	static void ReduceLineCache();
 };
 
+Point GetCharPosInString(std::string_view str, const char *ch, FontSize start_fontsize = FS_NORMAL);
+ptrdiff_t GetCharAtPosition(std::string_view str, int x, FontSize start_fontsize = FS_NORMAL);
+
 #endif /* GFX_LAYOUT_H */

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -90,6 +90,19 @@ class ParagraphLayouter {
 public:
 	virtual ~ParagraphLayouter() = default;
 
+	/** Position of a glyph within a VisualRun. */
+	class Position {
+	public:
+		int16_t left; ///< Left-most position of glyph.
+		int16_t right; ///< Right-most position of glyph.
+		int16_t top; ///< Top-most position of glyph.
+
+		constexpr inline Position(int16_t left, int16_t right, int16_t top) : left(left), right(right), top(top) { }
+
+		/** Conversion from a single point to a Position. */
+		constexpr inline Position(const Point &pt) : left(pt.x), right(pt.x), top(pt.y) { }
+	};
+
 	/** Visual run contains data about the bit of text with the same font. */
 	class VisualRun {
 	public:
@@ -97,7 +110,7 @@ public:
 		virtual const Font *GetFont() const = 0;
 		virtual int GetGlyphCount() const = 0;
 		virtual std::span<const GlyphID> GetGlyphs() const = 0;
-		virtual std::span<const Point> GetPositions() const = 0;
+		virtual std::span<const Position> GetPositions() const = 0;
 		virtual int GetLeading() const = 0;
 		virtual std::span<const int> GetGlyphToCharMap() const = 0;
 	};
@@ -176,7 +189,7 @@ public:
 
 	Layouter(std::string_view str, int maxw = INT32_MAX, FontSize fontsize = FS_NORMAL);
 	Dimension GetBounds();
-	Point GetCharPosition(std::string_view::const_iterator ch) const;
+	ParagraphLayouter::Position GetCharPosition(std::string_view::const_iterator ch) const;
 	ptrdiff_t GetCharAtPosition(int x, size_t line_index) const;
 
 	static void Initialize();
@@ -185,7 +198,7 @@ public:
 	static void ReduceLineCache();
 };
 
-Point GetCharPosInString(std::string_view str, const char *ch, FontSize start_fontsize = FS_NORMAL);
+ParagraphLayouter::Position GetCharPosInString(std::string_view str, const char *ch, FontSize start_fontsize = FS_NORMAL);
 ptrdiff_t GetCharAtPosition(std::string_view str, int x, FontSize start_fontsize = FS_NORMAL);
 
 #endif /* GFX_LAYOUT_H */

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -96,10 +96,10 @@ public:
 		virtual ~VisualRun() = default;
 		virtual const Font *GetFont() const = 0;
 		virtual int GetGlyphCount() const = 0;
-		virtual const std::vector<GlyphID> &GetGlyphs() const = 0;
-		virtual const std::vector<Point> &GetPositions() const = 0;
+		virtual std::span<const GlyphID> GetGlyphs() const = 0;
+		virtual std::span<const Point> GetPositions() const = 0;
 		virtual int GetLeading() const = 0;
-		virtual const std::vector<int> &GetGlyphToCharMap() const = 0;
+		virtual std::span<const int> GetGlyphToCharMap() const = 0;
 	};
 
 	/** A single line worth of VisualRuns. */

--- a/src/gfx_layout_fallback.cpp
+++ b/src/gfx_layout_fallback.cpp
@@ -49,10 +49,10 @@ public:
 		FallbackVisualRun(Font *font, const char32_t *chars, int glyph_count, int char_offset, int x);
 		const Font *GetFont() const override { return this->font; }
 		int GetGlyphCount() const override { return static_cast<int>(this->glyphs.size()); }
-		const std::vector<GlyphID> &GetGlyphs() const override { return this->glyphs; }
-		const std::vector<Point> &GetPositions() const override { return this->positions; }
+		std::span<const GlyphID> GetGlyphs() const override { return this->glyphs; }
+		std::span<const Point> GetPositions() const override { return this->positions; }
 		int GetLeading() const override { return this->GetFont()->fc->GetHeight(); }
-		const std::vector<int> &GetGlyphToCharMap() const override { return this->glyph_to_char; }
+		std::span<const int> GetGlyphToCharMap() const override { return this->glyph_to_char; }
 	};
 
 	/** A single line worth of VisualRuns. */

--- a/src/gfx_layout_fallback.cpp
+++ b/src/gfx_layout_fallback.cpp
@@ -40,7 +40,7 @@ public:
 	/** Visual run contains data about the bit of text with the same font. */
 	class FallbackVisualRun : public ParagraphLayouter::VisualRun {
 		std::vector<GlyphID> glyphs; ///< The glyphs we're drawing.
-		std::vector<Point> positions; ///< The positions of the glyphs.
+		std::vector<Position> positions; ///< The positions of the glyphs.
 		std::vector<int> glyph_to_char; ///< The char index of the glyphs.
 
 		Font *font;       ///< The font used to layout these.
@@ -50,7 +50,7 @@ public:
 		const Font *GetFont() const override { return this->font; }
 		int GetGlyphCount() const override { return static_cast<int>(this->glyphs.size()); }
 		std::span<const GlyphID> GetGlyphs() const override { return this->glyphs; }
-		std::span<const Point> GetPositions() const override { return this->positions; }
+		std::span<const Position> GetPositions() const override { return this->positions; }
 		int GetLeading() const override { return this->GetFont()->fc->GetHeight(); }
 		std::span<const int> GetGlyphToCharMap() const override { return this->glyph_to_char; }
 	};
@@ -116,25 +116,22 @@ FallbackParagraphLayout::FallbackVisualRun::FallbackVisualRun(Font *font, const 
 
 	this->glyphs.reserve(char_count);
 	this->glyph_to_char.reserve(char_count);
-
-	/* Positions contains the location of the begin of each of the glyphs, and the end of the last one. */
-	this->positions.reserve(char_count + 1);
+	this->positions.reserve(char_count);
 
 	int advance = x;
 	for (int i = 0; i < char_count; i++) {
 		const GlyphID &glyph_id = this->glyphs.emplace_back(font->fc->MapCharToGlyph(chars[i]));
+		int x_advance = font->fc->GetGlyphWidth(glyph_id);
 		if (isbuiltin) {
-			this->positions.emplace_back(advance, font->fc->GetAscender()); // Apply sprite font's ascender.
+			this->positions.emplace_back(advance, advance + x_advance - 1, font->fc->GetAscender()); // Apply sprite font's ascender.
 		} else if (chars[i] >= SCC_SPRITE_START && chars[i] <= SCC_SPRITE_END) {
-			this->positions.emplace_back(advance, (font->fc->GetHeight() - ScaleSpriteTrad(FontCache::GetDefaultFontHeight(font->fc->GetSize()))) / 2); // Align sprite font to centre
+			this->positions.emplace_back(advance, advance + x_advance - 1, (font->fc->GetHeight() - ScaleSpriteTrad(FontCache::GetDefaultFontHeight(font->fc->GetSize()))) / 2); // Align sprite font to centre
 		} else {
-			this->positions.emplace_back(advance, 0); // No ascender adjustment.
+			this->positions.emplace_back(advance, advance + x_advance - 1, 0); // No ascender adjustment.
 		}
-		advance += font->fc->GetGlyphWidth(glyph_id);
+		advance += x_advance;
 		this->glyph_to_char.push_back(char_offset + i);
 	}
-	/* End-of-run position. */
-	this->positions.emplace_back(advance, 0);
 }
 
 /**
@@ -165,7 +162,9 @@ int FallbackParagraphLayout::FallbackLine::GetWidth() const
 	 * the last run gives us the end of the line and thus the width.
 	 */
 	const auto &run = this->GetVisualRun(this->CountRuns() - 1);
-	return run.GetPositions().back().x;
+	const auto &positions = run.GetPositions();
+	if (positions.empty()) return 0;
+	return positions.back().right + 1;
 }
 
 /**

--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -71,9 +71,9 @@ public:
 	public:
 		ICUVisualRun(const ICURun &run, int x);
 
-		const std::vector<GlyphID> &GetGlyphs() const override { return this->glyphs; }
-		const std::vector<Point> &GetPositions() const override { return this->positions; }
-		const std::vector<int> &GetGlyphToCharMap() const override { return this->glyph_to_char; }
+		std::span<const GlyphID> GetGlyphs() const override { return this->glyphs; }
+		std::span<const Point> GetPositions() const override { return this->positions; }
+		std::span<const int> GetGlyphToCharMap() const override { return this->glyph_to_char; }
 
 		const Font *GetFont() const override { return this->font; }
 		int GetLeading() const override { return this->font->fc->GetHeight(); }

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -902,10 +902,10 @@ Rect QueryString::GetBoundingRect(const Window *w, WidgetID wid, const char *fro
 	r = ScrollEditBoxTextRect(r, *tb);
 
 	/* Get location of first and last character. */
-	Point p1 = GetCharPosInString(tb->buf, from, FS_NORMAL);
-	Point p2 = from != to ? GetCharPosInString(tb->buf, to, FS_NORMAL) : p1;
+	const auto p1 = GetCharPosInString(tb->buf, from, FS_NORMAL);
+	const auto p2 = from != to ? GetCharPosInString(tb->buf, to, FS_NORMAL) : p1;
 
-	return { Clamp(r.left + p1.x, r.left, r.right), r.top, Clamp(r.left + p2.x, r.left, r.right), r.bottom };
+	return { Clamp(r.left + p1.left, r.left, r.right), r.top, Clamp(r.left + p2.right, r.left, r.right), r.bottom };
 }
 
 /**

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -12,6 +12,7 @@
 #include "landscape.h"
 #include "error.h"
 #include "gui.h"
+#include "gfx_layout.h"
 #include "command_func.h"
 #include "company_func.h"
 #include "town.h"

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -81,9 +81,9 @@ public:
 		CoreTextVisualRun(CTRunRef run, Font *font, const CoreTextParagraphLayoutFactory::CharType *buff);
 		CoreTextVisualRun(CoreTextVisualRun &&other) = default;
 
-		const std::vector<GlyphID> &GetGlyphs() const override { return this->glyphs; }
-		const std::vector<Point> &GetPositions() const override { return this->positions; }
-		const std::vector<int> &GetGlyphToCharMap() const override { return this->glyph_to_char; }
+		std::span<const GlyphID> GetGlyphs() const override { return this->glyphs; }
+		std::span<const Point> GetPositions() const override { return this->positions; }
+		std::span<const int> GetGlyphToCharMap() const override { return this->glyph_to_char; }
 
 		const Font *GetFont() const override { return this->font;  }
 		int GetLeading() const override { return this->font->fc->GetHeight(); }

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -71,7 +71,7 @@ public:
 	class CoreTextVisualRun : public ParagraphLayouter::VisualRun {
 	private:
 		std::vector<GlyphID> glyphs;
-		std::vector<Point> positions;
+		std::vector<Position> positions;
 		std::vector<int> glyph_to_char;
 
 		int total_advance = 0;
@@ -82,7 +82,7 @@ public:
 		CoreTextVisualRun(CoreTextVisualRun &&other) = default;
 
 		std::span<const GlyphID> GetGlyphs() const override { return this->glyphs; }
-		std::span<const Point> GetPositions() const override { return this->positions; }
+		std::span<const Position> GetPositions() const override { return this->positions; }
 		std::span<const int> GetGlyphToCharMap() const override { return this->glyph_to_char; }
 
 		const Font *GetFont() const override { return this->font;  }
@@ -241,7 +241,9 @@ CoreTextParagraphLayout::CoreTextVisualRun::CoreTextVisualRun(CTRunRef run, Font
 
 	CGPoint pts[this->glyphs.size()];
 	CTRunGetPositions(run, CFRangeMake(0, 0), pts);
-	this->positions.reserve(this->glyphs.size() + 1);
+	CGSize advs[this->glyphs.size()];
+	CTRunGetAdvances(run, CFRangeMake(0, 0), advs);
+	this->positions.reserve(this->glyphs.size());
 
 	/* Convert glyph array to our data type. At the same time, substitute
 	 * the proper glyphs for our private sprite glyphs. */
@@ -251,15 +253,13 @@ CoreTextParagraphLayout::CoreTextVisualRun::CoreTextVisualRun(CTRunRef run, Font
 		if (buff[this->glyph_to_char[i]] >= SCC_SPRITE_START && buff[this->glyph_to_char[i]] <= SCC_SPRITE_END && (gl[i] == 0 || gl[i] == 3)) {
 			/* A glyph of 0 indidicates not found, while apparently 3 is what char 0xFFFC maps to. */
 			this->glyphs[i] = font->fc->MapCharToGlyph(buff[this->glyph_to_char[i]]);
-			this->positions.emplace_back(pts[i].x, (font->fc->GetHeight() - ScaleSpriteTrad(FontCache::GetDefaultFontHeight(font->fc->GetSize()))) / 2); // Align sprite font to centre
+			this->positions.emplace_back(pts[i].x, pts[i].x + advs[i].width - 1, (font->fc->GetHeight() - ScaleSpriteTrad(FontCache::GetDefaultFontHeight(font->fc->GetSize()))) / 2); // Align sprite font to centre
 		} else {
 			this->glyphs[i] = gl[i];
-			this->positions.emplace_back(pts[i].x, pts[i].y);
+			this->positions.emplace_back(pts[i].x, pts[i].x + advs[i].width - 1, pts[i].y);
 		}
 	}
 	this->total_advance = (int)std::ceil(CTRunGetTypographicBounds(run, CFRangeMake(0, 0), nullptr, nullptr, nullptr));
-	/* End-of-run position. */
-	this->positions.emplace_back(this->positions.front().x + this->total_advance, 0);
 }
 
 /**

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -88,9 +88,9 @@ public:
 		UniscribeVisualRun(const UniscribeRun &range, int x);
 		UniscribeVisualRun(UniscribeVisualRun &&other) noexcept;
 
-		const std::vector<GlyphID> &GetGlyphs() const override { return this->glyphs; }
-		const std::vector<Point> &GetPositions() const override { return this->positions; }
-		const std::vector<int> &GetGlyphToCharMap() const override;
+		std::span<const GlyphID> GetGlyphs() const override { return this->glyphs; }
+		std::span<const Point> GetPositions() const override { return this->positions; }
+		std::span<const int> GetGlyphToCharMap() const override;
 
 		const Font *GetFont() const override { return this->font;  }
 		int GetLeading() const override { return this->font->fc->GetHeight(); }
@@ -493,7 +493,7 @@ UniscribeParagraphLayout::UniscribeVisualRun::UniscribeVisualRun(UniscribeVisual
 {
 }
 
-const std::vector<int> &UniscribeParagraphLayout::UniscribeVisualRun::GetGlyphToCharMap() const
+std::span<const int> UniscribeParagraphLayout::UniscribeVisualRun::GetGlyphToCharMap() const
 {
 	if (this->glyph_to_char.empty()) {
 		this->glyph_to_char.resize(this->GetGlyphCount());

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -74,7 +74,7 @@ public:
 	class UniscribeVisualRun : public ParagraphLayouter::VisualRun {
 	private:
 		std::vector<GlyphID> glyphs;
-		std::vector<Point> positions;
+		std::vector<Position> positions;
 		std::vector<WORD> char_to_glyph;
 
 		int start_pos;
@@ -89,7 +89,7 @@ public:
 		UniscribeVisualRun(UniscribeVisualRun &&other) noexcept;
 
 		std::span<const GlyphID> GetGlyphs() const override { return this->glyphs; }
-		std::span<const Point> GetPositions() const override { return this->positions; }
+		std::span<const Position> GetPositions() const override { return this->positions; }
 		std::span<const int> GetGlyphToCharMap() const override;
 
 		const Font *GetFont() const override { return this->font;  }
@@ -474,16 +474,15 @@ int UniscribeParagraphLayout::UniscribeLine::GetWidth() const
 UniscribeParagraphLayout::UniscribeVisualRun::UniscribeVisualRun(const UniscribeRun &range, int x) : glyphs(range.ft_glyphs), char_to_glyph(range.char_to_glyph), start_pos(range.pos), total_advance(range.total_advance), font(range.font)
 {
 	this->num_glyphs = (int)glyphs.size();
-	this->positions.reserve(this->num_glyphs + 1);
+	this->positions.reserve(this->num_glyphs);
 
 	int advance = x;
 	for (int i = 0; i < this->num_glyphs; i++) {
-		this->positions.emplace_back(range.offsets[i].du + advance, range.offsets[i].dv);
+		int x_advance = range.advances[i];
+		this->positions.emplace_back(range.offsets[i].du + advance - 1, range.offsets[i].du + advance + x_advance, range.offsets[i].dv);
 
-		advance += range.advances[i];
+		advance += x_advance;
 	}
-	/* End-of-run position. */
-	this->positions.emplace_back(advance, 0);
 }
 
 UniscribeParagraphLayout::UniscribeVisualRun::UniscribeVisualRun(UniscribeVisualRun&& other) noexcept

--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -14,6 +14,7 @@
 #include "strings_func.h"
 #include "gfx_type.h"
 #include "gfx_func.h"
+#include "gfx_layout.h"
 #include "window_func.h"
 #include "core/alloc_func.hpp"
 

--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -309,15 +309,18 @@ void Textbuf::UpdateWidth()
 /** Update pixel position of the caret. */
 void Textbuf::UpdateCaretPosition()
 {
-	this->caretxoffs = this->chars > 1 ? GetCharPosInString(this->buf, this->buf + this->caretpos, FS_NORMAL).left : 0;
+	const auto pos = GetCharPosInString(this->buf, this->buf + this->caretpos, FS_NORMAL);
+	this->caretxoffs = _current_text_dir == TD_LTR ? pos.left : pos.right;
 }
 
 /** Update pixel positions of the marked text area. */
 void Textbuf::UpdateMarkedText()
 {
 	if (this->markend != 0) {
-		this->markxoffs  = GetCharPosInString(this->buf, this->buf + this->markpos, FS_NORMAL).left;
-		this->marklength = GetCharPosInString(this->buf, this->buf + this->markend, FS_NORMAL).left - this->markxoffs;
+		const auto pos = GetCharPosInString(this->buf, this->buf + this->markpos, FS_NORMAL);
+		const auto end = GetCharPosInString(this->buf, this->buf + this->markend, FS_NORMAL);
+		this->markxoffs = std::min(pos.left, end.left);
+		this->marklength = std::max(pos.right, end.right) - this->markxoffs;
 	} else {
 		this->markxoffs = this->marklength = 0;
 	}

--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -309,15 +309,15 @@ void Textbuf::UpdateWidth()
 /** Update pixel position of the caret. */
 void Textbuf::UpdateCaretPosition()
 {
-	this->caretxoffs = this->chars > 1 ? GetCharPosInString(this->buf, this->buf + this->caretpos, FS_NORMAL).x : 0;
+	this->caretxoffs = this->chars > 1 ? GetCharPosInString(this->buf, this->buf + this->caretpos, FS_NORMAL).left : 0;
 }
 
 /** Update pixel positions of the marked text area. */
 void Textbuf::UpdateMarkedText()
 {
 	if (this->markend != 0) {
-		this->markxoffs  = GetCharPosInString(this->buf, this->buf + this->markpos, FS_NORMAL).x;
-		this->marklength = GetCharPosInString(this->buf, this->buf + this->markend, FS_NORMAL).x - this->markxoffs;
+		this->markxoffs  = GetCharPosInString(this->buf, this->buf + this->markpos, FS_NORMAL).left;
+		this->marklength = GetCharPosInString(this->buf, this->buf + this->markend, FS_NORMAL).left - this->markxoffs;
 	} else {
 		this->markxoffs = this->marklength = 0;
 	}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Caret position is positioned based on the left-coordinate of the current character. This is correct for LTR languages, but not for RTL

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Set caret position to the right instead of left position of a glyph when the current language is RTL.

This requires altering all the layouters to store both the left and right positions, which is somewhat invasive as the right position information is only used for the caret position.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

I have not tested the Windows or mac OS changes.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
