### PR TITLE
Change: Allow bribing local authority when other company has exclusive rights

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -3575,8 +3575,17 @@ TownActions GetMaskOfTownActions(CompanyID cid, const Town *t)
 		for (uint i = 0; i != lengthof(_town_action_costs); i++) {
 			const TownActions cur = (TownActions)(1 << i);
 
-			/* Is the company not able to bribe ? */
-			if (cur == TACT_BRIBE && (!_settings_game.economy.bribe || t->ratings[cid] >= RATING_BRIBE_MAXIMUM)) continue;
+			/* Is the company prohibited from bribing ? */
+			if (cur == TACT_BRIBE) {
+				/* Company can't bribe if setting is disabled */
+				if (!_settings_game.economy.bribe) continue;
+				/* Company can bribe if another company has exclusive transport rights,
+				 * or its standing with the town is less than outstanding. */
+				if (t->ratings[cid] >= RATING_BRIBE_MAXIMUM) {
+					if (t->exclusivity == _current_company) continue;
+					if (t->exclusive_counter == 0) continue;
+				}
+			}
 
 			/* Is the company not able to buy exclusive rights ? */
 			if (cur == TACT_BUY_RIGHTS && (!_settings_game.economy.exclusive_rights || t->exclusive_counter != 0)) continue;


### PR DESCRIPTION
## Motivation / Problem

A bribe can void an Exclusive Transport Rights constract,
but it is not possible to bribe a town that already has
an outstanding opinion of you. This causes a lockout where
a popular company can not attempt to void a contract,
making it much easier to use exclusive transport rights
in an offensive manner than as a defensive measure.

## Description

This fixes so that bribing is possible if:
- The bribery setting is enabled AND
- You have a lower than Outstanding rating in the town OR
  - Someone else currently has an Exclusive Transport Rights
    contract with the town.

## Limitations

N/A



## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
