### PR TITLE
Add: Toggle for showing industry names in small map

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -802,9 +802,11 @@ STR_SMALLMAP_TOWN                                               :{TINY_FONT}{WHI
 STR_SMALLMAP_DISABLE_ALL                                        :{BLACK}Disable all
 STR_SMALLMAP_ENABLE_ALL                                         :{BLACK}Enable all
 STR_SMALLMAP_SHOW_HEIGHT                                        :{BLACK}Show height
+STR_SMALLMAP_SHOW_INDUSTRY_NAMES                                :{BLACK}Show industry names
 STR_SMALLMAP_TOOLTIP_DISABLE_ALL_INDUSTRIES                     :{BLACK}Display no industries on the map
 STR_SMALLMAP_TOOLTIP_ENABLE_ALL_INDUSTRIES                      :{BLACK}Display all industries on the map
 STR_SMALLMAP_TOOLTIP_SHOW_HEIGHT                                :{BLACK}Toggle display of heightmap
+STR_SMALLMAP_TOOLTIP_SHOW_INDUSTRY_NAMES                        :{BLACK}Toggle display of industry names
 STR_SMALLMAP_TOOLTIP_DISABLE_ALL_COMPANIES                      :{BLACK}Display no company property on the map
 STR_SMALLMAP_TOOLTIP_ENABLE_ALL_COMPANIES                       :{BLACK}Display all company property on the map
 STR_SMALLMAP_TOOLTIP_DISABLE_ALL_CARGOS                         :{BLACK}Display no cargoes on the map

--- a/src/widgets/smallmap_widget.h
+++ b/src/widgets/smallmap_widget.h
@@ -32,6 +32,8 @@ enum SmallMapWidgets : WidgetID {
 	WID_SM_ENABLE_ALL,     ///< Button to enable display of all legend entries.
 	WID_SM_DISABLE_ALL,    ///< Button to disable display of all legend entries.
 	WID_SM_SHOW_HEIGHT,    ///< Show heightmap toggle button.
+	WID_SM_SHOW_IND_NAMES, ///< Show industry names toggle button.
+	WID_SM_SHOW_IND_NAMES_SEL, ///< Container for the 'show industry names' button, which can be hidden.
 };
 
 #endif /* WIDGETS_SMALLMAP_WIDGET_H */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

# Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

* For features or gameplay changes:
    * What was the motivation to develop this feature?
      * Came across a fellow player who is visually impaired who'd like to see industry names in the small map similar to town names: [Reddit](https://web.archive.org/web/20240610032237/https://old.reddit.com/r/openttd/comments/1d9v3a9/im_visually_impaired_i_like_i_can_scale_up_the_ui/)
    * Does this address any problem with the gameplay or interface?
      * Interface only
    * Which group of players do you think would enjoy this feature?
      * All players, especially visually impaired like OP, or players with mild colour-blindness like myself

# Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

## What does this feature do?
A new "Show industry names" toggle button and a tooltip are added to the industry view in the small map:
<img width="944" alt="screenshot of the toggle button and tooltip" src="https://github.com/OpenTTD/OpenTTD/assets/1967998/cf38c6a6-8f68-444b-9600-19fe33445923">

When toggled on, industry names are drawn below each tile area of the industry:
<img width="944" alt="screenshot of small map displayed with industry names" src="https://github.com/OpenTTD/OpenTTD/assets/1967998/d2f82f38-b494-4b49-9542-ba6d0851de31">

When an industry legend is selected, the names on the map follow the enabled/disabled statuses:
<img width="944" alt="screenshot of small map displayed with some industry names, as toggled in the industries legend" src="https://github.com/OpenTTD/OpenTTD/assets/1967998/ce349c77-60cd-4b72-aad3-d651330086de">

When an industry legend is hovered over, each industry name blinks together with the industry tile area:
![animated image showing blinking behaviour](https://github.com/OpenTTD/OpenTTD/assets/1967998/077b1cbd-854a-4afe-ad73-968a3336ab8f)

When toggled off (the default), there's no difference to the behaviour today:
<img width="944" alt="screenshot showing a small map without industry names when the new toggle is off" src="https://github.com/OpenTTD/OpenTTD/assets/1967998/16927942-066f-4bf6-9d33-95a234ef24ec">

When switched to other views that isn't "Industries", the toggle and the industry names are not displayed (except the ones mentioned under Limitations):
<img width="944" alt="screenshot showing a small map in 'Vehicles' view" src="https://github.com/OpenTTD/OpenTTD/assets/1967998/bdba6d2b-16b6-4614-9096-bf96a7c04192">


## How does it improve/solve the situation described under 'motivation'?

> The main goals of the official branch are:
> […]
> Improve the user interface
> […]

# Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

* Is the problem solved in all scenarios?
  * Yes. Although when used together with "show town names", the text labels appears crowded with no visual distinction between industry and town names:
  * <img width="944" alt="a screenshot showing the small map with both industry and town names" src="https://github.com/OpenTTD/OpenTTD/assets/1967998/5d86d23c-2118-4f9b-a00c-046458d1b7ae">
* Is this feature complete? Are there things that could be added in the future?
  * Maybe showing the specific name of each industry? e.g. "Slawood Factory", "Lothill Farm", etc. That might be a solution to showing industry and town names together.
* Are there things that are intentionally left out?
  * The text colour could potentially follow the industry colour; tho industries such as Forest in a temperate map would be hard to read as they'd show up as low-contrast green-on-green.
* Do you know of a bug or corner case that does not work?
  * Yes. I need help hiding the button in other views. Current implementation just disables the button in cargo flow and land owner views (and could appear 'stuck' in the lowered state under irrelevant views). Please see the inline comment in the code
  * <img width="728" alt="screenshot showing a disabled 'show industry names' toggle button in land owner view" src="https://github.com/OpenTTD/OpenTTD/assets/1967998/336f64f5-0228-44ce-9aa1-6afd1f317a17">
  * <img width="671" alt="screenshot showing a disabled and lowered 'show industry names' toggle button in cargo flow view" src="https://github.com/OpenTTD/OpenTTD/assets/1967998/a3adb880-caa2-4734-b433-d5fe4dfb0d18">
  * Update: resolved. Button is now only shown in industry map type. See https://github.com/OpenTTD/OpenTTD/pull/12770#discussion_r1650212639


# Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
  * N/A
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
  * Yes. [I want to add a new string.](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md#i-want-to-add-a-new-string)
    > Add the new string somewhere in english.txt, where it fits with the neighbouring strings. Don't touch the translations, even if you can speak some of the languages.
* This PR affects the save game format? (label 'savegame upgrade')
  * No
* This PR affects the GS/AI API? (label 'needs review: Script API')
  * No
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
  * No