### PR TITLE
Codechange: Use function-static instance of WindowDesc list.

### DIFF
--- a/src/tests/test_window_desc.cpp
+++ b/src/tests/test_window_desc.cpp
@@ -19,7 +19,7 @@
  * List of WindowDescs. Defined in window.cpp but not exposed as this unit-test is the only other place that needs it.
  * WindowDesc is a self-registering class so all WindowDescs will be included in the list.
  */
-extern std::vector<WindowDesc*> *_window_descs;
+extern std::vector<WindowDesc *> &GetWindowDescs();
 
 
 class WindowDescTestsFixture {
@@ -32,7 +32,7 @@ TEST_CASE("WindowDesc - ini_key uniqueness")
 {
 	std::set<std::string> seen;
 
-	for (const WindowDesc *window_desc : *_window_descs) {
+	for (const WindowDesc *window_desc : GetWindowDescs()) {
 
 		if (window_desc->ini_key == nullptr) continue;
 
@@ -45,7 +45,7 @@ TEST_CASE("WindowDesc - ini_key uniqueness")
 
 TEST_CASE("WindowDesc - ini_key validity")
 {
-	const WindowDesc *window_desc = GENERATE(from_range(std::begin(*_window_descs), std::end(*_window_descs)));
+	const WindowDesc *window_desc = GENERATE(from_range(std::begin(GetWindowDescs()), std::end(GetWindowDescs())));
 
 	bool has_inikey = window_desc->ini_key != nullptr;
 	bool has_widget = std::any_of(window_desc->nwid_begin, window_desc->nwid_end, [](const NWidgetPart &part) { return part.type == WWT_DEFSIZEBOX || part.type == WWT_STICKYBOX; });
@@ -76,7 +76,7 @@ static bool IsNWidgetTreeClosed(const NWidgetPart *nwid_begin, const NWidgetPart
 
 TEST_CASE("WindowDesc - NWidgetParts properly closed")
 {
-	const WindowDesc *window_desc = GENERATE(from_range(std::begin(*_window_descs), std::end(*_window_descs)));
+	const WindowDesc *window_desc = GENERATE(from_range(std::begin(GetWindowDescs()), std::end(GetWindowDescs())));
 
 	INFO(fmt::format("{}:{}", window_desc->source_location.file_name(), window_desc->source_location.line()));
 
@@ -85,7 +85,7 @@ TEST_CASE("WindowDesc - NWidgetParts properly closed")
 
 TEST_CASE_METHOD(WindowDescTestsFixture, "WindowDesc - NWidgetPart validity")
 {
-	const WindowDesc *window_desc = GENERATE(from_range(std::begin(*_window_descs), std::end(*_window_descs)));
+	const WindowDesc *window_desc = GENERATE(from_range(std::begin(GetWindowDescs()), std::end(GetWindowDescs())));
 
 	INFO(fmt::format("{}:{}", window_desc->source_location.file_name(), window_desc->source_location.line()));
 

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -194,7 +194,7 @@ private:
 
 	/**
 	 * Delete copy constructor to prevent compilers from
-	 * copying the structure, which fails due to _window_descs.
+	 * copying the structure, which fails due to WindowDesc registration.
 	 */
 	WindowDesc(const WindowDesc &) = delete;
 	WindowDesc& operator=(const WindowDesc &) = delete;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

The WindowDesc list `_window_descs` is a pointer to a vector with manual initialisation with `new` on first use, as long as it's used correctly.

This was done to ensure correct static initialisation order.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, use a function-static instance. This can only be accessed by calling the `GetWindowDescs()`, which automatically initialises the vector on first use.

This ensures the list cannot be accessed incorrectly and avoids manual life-time management.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
