### PR TITLE
Feature: Alpine tree line in subarctic climate

### DIFF
--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1452,6 +1452,10 @@ static void CreateRivers()
  */
 static uint CalculateCoverageLine(uint coverage, uint edge_multiplier)
 {
+	/* We can take a shortcut at the extremes of the coverage. */
+	if (coverage == 0) return MAX_TILE_HEIGHT;
+	if (coverage == 100) return 0;
+
 	const DiagDirection neighbour_dir[] = {
 		DIAGDIR_NE,
 		DIAGDIR_SE,

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1436,7 +1436,7 @@ static void CreateRivers()
 /**
  * Calculate what height would be needed to cover N% of the landmass.
  *
- * The function allows both snow and desert/tropic line to be calculated. It
+ * The function allows snow, alpine tree line, and desert/tropic line to be calculated. It
  * tries to find the closests height which covers N% of the landmass; it can
  * be below or above it.
  *
@@ -1534,6 +1534,14 @@ static void CalculateSnowLine()
 {
 	/* We do not have snow sprites on coastal tiles, so never allow "1" as height. */
 	_settings_game.game_creation.snow_line_height = std::max(CalculateCoverageLine(_settings_game.game_creation.snow_coverage, 0), 2u);
+}
+
+/**
+ * Calculate the elevation line from which trees do not grow.
+ */
+void CalculateTreeLine()
+{
+	_settings_game.game_creation.tree_line_height = CalculateCoverageLine(_settings_game.game_creation.alpine_coverage, 0);
 }
 
 /**
@@ -1635,6 +1643,7 @@ bool GenerateLandscape(uint8_t mode)
 	switch (_settings_game.game_creation.landscape) {
 		case LT_ARCTIC:
 			CalculateSnowLine();
+			CalculateTreeLine();
 			break;
 
 		case LT_TROPIC: {

--- a/src/landscape.h
+++ b/src/landscape.h
@@ -32,6 +32,7 @@ uint8_t GetSnowLine();
 uint8_t HighestSnowLine();
 uint8_t LowestSnowLine();
 void ClearSnowLine();
+void CalculateTreeLine();
 
 int GetSlopeZInCorner(Slope tileh, Corner corner);
 std::tuple<Slope, int> GetFoundationSlope(TileIndex tile);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2979,11 +2979,12 @@ STR_OBJECT_BUILD_SIZE                                           :{BLACK}Size: {G
 STR_OBJECT_CLASS_LTHS                                           :Lighthouses
 STR_OBJECT_CLASS_TRNS                                           :Transmitters
 
-# Tree planting window (last eight for SE only)
+# Tree planting window (in-game and Scenario Editor)
 STR_PLANT_TREE_CAPTION                                          :{WHITE}Trees
 STR_PLANT_TREE_TOOLTIP                                          :{BLACK}Select tree type to plant. If the tile already has a tree, this will add more trees of mixed types independent of the selected type
 STR_TREES_RANDOM_TYPE                                           :{BLACK}Trees of random type
 STR_TREES_RANDOM_TYPE_TOOLTIP                                   :{BLACK}Place trees of random type. Ctrl+Click+Drag to select the area diagonally. Also press Shift to show cost estimate only
+# Tree planting window (Scenario Editor only)
 STR_TREES_RANDOM_TREES_BUTTON                                   :{BLACK}Random Trees
 STR_TREES_RANDOM_TREES_TOOLTIP                                  :{BLACK}Plant trees randomly throughout the landscape
 STR_TREES_MODE_NORMAL_BUTTON                                    :{BLACK}Normal
@@ -2992,6 +2993,10 @@ STR_TREES_MODE_FOREST_SM_BUTTON                                 :{BLACK}Grove
 STR_TREES_MODE_FOREST_SM_TOOLTIP                                :{BLACK}Plant small forests by dragging over the landscape
 STR_TREES_MODE_FOREST_LG_BUTTON                                 :{BLACK}Forest
 STR_TREES_MODE_FOREST_LG_TOOLTIP                                :{BLACK}Plant large forests by dragging over the landscape
+STR_BUILD_TREES_TREELINE_LABEL                                  :{BLACK}Tree line height:
+STR_BUILD_TREES_TREELINE_TOOLTIP                                :{BLACK}Choose the tree line height. Above this level, trees will not grow
+STR_BUILD_TREES_TREELINE_DECREASE_TOOLTIP                       :{BLACK}Decrease the tree line height
+STR_BUILD_TREES_TREELINE_INCREASE_TOOLTIP                       :{BLACK}Increase the tree line height
 
 # Land generation window (SE)
 STR_TERRAFORM_TOOLBAR_LAND_GENERATION_CAPTION                   :{WHITE}Land Generation

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1567,6 +1567,10 @@ STR_CONFIG_SETTING_SNOW_COVERAGE                                :Snow coverage: 
 STR_CONFIG_SETTING_SNOW_COVERAGE_HELPTEXT                       :Choose the approximate amount of snow on the sub-arctic landscape. Snow also affects industry generation and town growth requirements. Only used during map generation. Sea level and coast tiles never have snow
 STR_CONFIG_SETTING_SNOW_COVERAGE_VALUE                          :{NUM}%
 
+STR_CONFIG_SETTING_ALPINE_COVERAGE                              :Alpine coverage: {STRING2}
+STR_CONFIG_SETTING_ALPINE_COVERAGE_HELPTEXT                     :Choose the approximate amount of alpine terrain on the sub-arctic landscape. Alpine terrain is above the elevation where trees grow
+STR_CONFIG_SETTING_ALPINE_COVERAGE_VALUE                        :{NUM}%
+
 STR_CONFIG_SETTING_DESERT_COVERAGE                              :Desert coverage: {STRING2}
 STR_CONFIG_SETTING_DESERT_COVERAGE_HELPTEXT                     :Choose the approximate amount of desert on the tropical landscape. Desert also affects industry generation and town growth requirements. Only used during map generation
 STR_CONFIG_SETTING_DESERT_COVERAGE_VALUE                        :{NUM}%
@@ -5184,6 +5188,7 @@ STR_ERROR_CAN_T_BUILD_AQUEDUCT_HERE                             :{WHITE}Can't bu
 # Tree related errors
 STR_ERROR_TREE_ALREADY_HERE                                     :{WHITE}... tree already here
 STR_ERROR_TREE_WRONG_TERRAIN_FOR_TREE_TYPE                      :{WHITE}... wrong terrain for tree type
+STR_ERROR_TREE_ABOVE_TREELINE                                   :{WHITE}... can't plant trees above alpine tree line
 STR_ERROR_CAN_T_PLANT_TREE_HERE                                 :{WHITE}Can't plant tree here...
 
 # Bridge related errors

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2255,6 +2255,7 @@ static SettingsContainer &GetSettingsTree()
 			{
 				trees->Add(new SettingEntry("game_creation.tree_placer"));
 				trees->Add(new SettingEntry("construction.extra_tree_placement"));
+				trees->Add(new SettingEntry("game_creation.alpine_coverage"));
 			}
 		}
 

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -346,6 +346,8 @@ struct GameCreationSettings {
 	uint8_t oil_refinery_limit;               ///< distance oil refineries allowed from map edge
 	uint8_t snow_line_height;                 ///< the configured snow line height (deduced from "snow_coverage")
 	uint8_t snow_coverage;                    ///< the amount of snow coverage on the map
+	uint8_t tree_line_height;                 ///< the configured tree line height (deduced from "alpine_coverage")
+	uint8_t alpine_coverage;                  ///< the amount of alpine land on the map (no trees at high elevations)
 	uint8_t desert_coverage;                  ///< the amount of desert coverage on the map
 	uint8_t heightmap_height;                 ///< highest mountain for heightmap (towards what it scales)
 	uint8_t tgen_smoothness;                  ///< how rough is the terrain from 0-3

--- a/src/table/settings/world_settings.ini
+++ b/src/table/settings/world_settings.ini
@@ -110,6 +110,19 @@ strval   = STR_CONFIG_SETTING_SNOW_COVERAGE_VALUE
 cat      = SC_BASIC
 
 [SDT_VAR]
+var      = game_creation.alpine_coverage
+type     = SLE_UINT8
+def      = DEF_ALPINE_COVERAGE
+min      = 0
+max      = 100
+interval = 10
+str      = STR_CONFIG_SETTING_ALPINE_COVERAGE
+strhelp  = STR_CONFIG_SETTING_ALPINE_COVERAGE_HELPTEXT
+strval   = STR_CONFIG_SETTING_ALPINE_COVERAGE_VALUE
+post_cb  = [](auto) { CalculateTreeLine(); }
+cat      = SC_BASIC
+
+[SDT_VAR]
 var      = game_creation.desert_coverage
 type     = SLE_UINT8
 from     = SLV_MAPGEN_SETTINGS_REVAMP

--- a/src/tile_type.h
+++ b/src/tile_type.h
@@ -34,6 +34,7 @@ static const uint DEF_SNOWLINE_HEIGHT = 10;                    ///< Default snow
 static const uint MAX_SNOWLINE_HEIGHT = (MAX_TILE_HEIGHT - 2); ///< Maximum allowed snowline height
 
 static const uint DEF_SNOW_COVERAGE = 40;                      ///< Default snow coverage.
+static const uint DEF_ALPINE_COVERAGE = 0;                     ///< Default alpine coverage.
 static const uint DEF_DESERT_COVERAGE = 50;                    ///< Default desert coverage.
 
 

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -61,6 +61,7 @@ static const uint16_t EDITOR_TREE_DIV = 5;                   ///< Game editor tr
 /**
  * Tests if a tile can be converted to MP_TREES
  * This is true for clear ground without farms or rocks.
+ * This test also considers the tree line in the subarctic climate.
  *
  * @param tile the tile of interest
  * @param allow_desert Allow planting trees on CLEAR_DESERT?
@@ -68,6 +69,9 @@ static const uint16_t EDITOR_TREE_DIV = 5;                   ///< Game editor tr
  */
 static bool CanPlantTreesOnTile(TileIndex tile, bool allow_desert)
 {
+	/* Trees do not grow in alpine terrain, above the tree line. */
+	if (_settings_game.game_creation.landscape == LT_ARCTIC && GetTileZ(tile) >= _settings_game.game_creation.tree_line_height) return false;
+
 	switch (GetTileType(tile)) {
 		case MP_WATER:
 			return !IsBridgeAbove(tile) && IsCoast(tile) && !IsSlopeWithOneCornerRaised(GetTileSlope(tile));
@@ -433,6 +437,12 @@ CommandCost CmdPlantTree(DoCommandFlag flags, TileIndex tile, TileIndex start_ti
 			case MP_CLEAR: {
 				if (IsBridgeAbove(current_tile)) {
 					msg = STR_ERROR_SITE_UNSUITABLE;
+					continue;
+				}
+
+				/* Trees do not grow in alpine terrain, above the tree line. */
+				if (_settings_game.game_creation.landscape == LT_ARCTIC && GetTileZ(current_tile) >= _settings_game.game_creation.tree_line_height) {
+					msg = STR_ERROR_TREE_ABOVE_TREELINE;
 					continue;
 				}
 

--- a/src/tree_gui.cpp
+++ b/src/tree_gui.cpp
@@ -149,6 +149,12 @@ public:
 		if (_game_mode != GM_EDITOR) {
 			this->GetWidget<NWidgetStacked>(WID_BT_SE_PANE)->SetDisplayedPlane(SZSP_HORIZONTAL);
 		}
+
+		/* Only show tree line in subarctic climate. */
+		if (_settings_game.game_creation.landscape != LT_ARCTIC) {
+			this->GetWidget<NWidgetStacked>(WID_BT_TREELINE_PANE)->SetDisplayedPlane(SZSP_HORIZONTAL);
+		}
+
 		this->FinishInitNested(window_number);
 	}
 
@@ -159,6 +165,15 @@ public:
 			Dimension d = GetMaxTreeSpriteSize();
 			size.width = d.width + padding.width;
 			size.height = d.height + padding.height + ScaleGUITrad(BUTTON_BOTTOM_OFFSET); // we need some more space
+		}
+	}
+
+	void SetStringParameters(WidgetID widget) const override
+	{
+		switch (widget) {
+			case WID_BT_TREELINE_VALUE:
+				SetDParam(0, _settings_game.game_creation.tree_line_height);
+				break;
 		}
 	}
 
@@ -200,6 +215,18 @@ public:
 				assert(_game_mode == GM_EDITOR);
 				this->mode = PM_FOREST_LG;
 				this->UpdateMode();
+				break;
+
+			case WID_BT_TREELINE_DECREASE:
+				assert(_game_mode == GM_EDITOR);
+				_settings_game.game_creation.tree_line_height = Clamp(_settings_game.game_creation.tree_line_height - 1, 0, 100);
+				this->InvalidateData();
+				break;
+
+			case WID_BT_TREELINE_INCREASE:
+				assert(_game_mode == GM_EDITOR);
+				_settings_game.game_creation.tree_line_height = Clamp(_settings_game.game_creation.tree_line_height + 1, 0, 100);
+				this->InvalidateData();
 				break;
 
 			default:
@@ -304,6 +331,16 @@ static constexpr NWidgetPart _nested_build_trees_widgets[] = {
 						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_BT_MODE_FOREST_LG), SetFill(1, 0), SetDataTip(STR_TREES_MODE_FOREST_LG_BUTTON, STR_TREES_MODE_FOREST_LG_TOOLTIP),
 					EndContainer(),
 					NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_BT_MANY_RANDOM), SetDataTip(STR_TREES_RANDOM_TREES_BUTTON, STR_TREES_RANDOM_TREES_TOOLTIP),
+					NWidget(NWID_SELECTION, INVALID_COLOUR, WID_BT_TREELINE_PANE),
+						NWidget(NWID_HORIZONTAL), SetPadding(2), SetPIP(0, 1, 0),
+							NWidget(WWT_LABEL, COLOUR_DARK_GREEN, WID_BT_TREELINE_LABEL), SetDataTip(STR_BUILD_TREES_TREELINE_LABEL, STR_BUILD_TREES_TREELINE_TOOLTIP), SetFill(1, 1),
+							NWidget(WWT_LABEL, COLOUR_DARK_GREEN, WID_BT_TREELINE_VALUE), SetDataTip(STR_JUST_INT, STR_BUILD_TREES_TREELINE_TOOLTIP), SetTextStyle(TC_ORANGE), SetFill(1, 1),
+							NWidget(NWID_HORIZONTAL),
+								NWidget(WWT_PUSHARROWBTN, COLOUR_GREY, WID_BT_TREELINE_DECREASE), SetMinimalSize(9, 12), SetDataTip(AWV_DECREASE, STR_BUILD_TREES_TREELINE_DECREASE_TOOLTIP),
+								NWidget(WWT_PUSHARROWBTN, COLOUR_GREY, WID_BT_TREELINE_INCREASE), SetMinimalSize(9, 12), SetDataTip(AWV_INCREASE, STR_BUILD_TREES_TREELINE_INCREASE_TOOLTIP),
+							EndContainer(),
+						EndContainer(),
+					EndContainer(),
 				EndContainer(),
 			EndContainer(),
 		EndContainer(),

--- a/src/widgets/tree_widget.h
+++ b/src/widgets/tree_widget.h
@@ -18,6 +18,11 @@ enum BuildTreesWidgets : WidgetID {
 	WID_BT_MODE_FOREST_SM,  ///< Select small forest planting mode.
 	WID_BT_MODE_FOREST_LG,  ///< Select large forest planting mode.
 	WID_BT_MANY_RANDOM,     ///< Button to build many random trees.
+	WID_BT_TREELINE_PANE,   ///< Selection pane to show/hide the tree line height, only shown in subarctic climate.
+	WID_BT_TREELINE_LABEL,  ///< Label for the tree line title.
+	WID_BT_TREELINE_VALUE,  ///< Label for the tree line value.
+	WID_BT_TREELINE_DECREASE, ///< Button to decrease the tree line height.
+	WID_BT_TREELINE_INCREASE, ///< Button to increase the tree line height.
 	WID_BT_TYPE_BUTTON_FIRST, ///< First tree type selection button. (This must be last in the enum.)
 };
 


### PR DESCRIPTION
## Motivation / Problem

Alpine climate describes land above the tree line, where it is too cold (and/or too snowy) for trees to grow.

This is visually interesting in mountainous heightmaps, so I thought I'd add it to OpenTTD.

## Description

This PR adds a setting for the percent of tiles that are in the alpine climate (trees do not generate or spread, and cannot be planted). This is the same format as snow and desert coverage for consistency and so players can easily sync snow and alpine amounts.

The setting is only available in Settings, not in Generate World, like other tree-related settings.

Towns and industries can still generate above the tree line, and standard OpenTTD map generation tends to make plateaus at high elevations where this can happen. It looks odd (especially when Forest industries generate), so this feature works best with heightmaps.

Scenario Editor is currently a problem, see Limitations.

## To Do
- [ ] Add significantly more rocky tiles in alpine areas

## Limitations

When you open the Scenario Editor, you get a flat map. The way the percent-to-tiles scaling works, any value above 0% means no trees are allowed anywhere. Also, the tree line height does not get adjusted as you terraform the landscape. I added a direct control to the tree menu but this is an awful approach. I need suggestions for how to resolve this in flat tiles in SE. 🙂 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
