### PR TITLE
Codechange: Use std::endian instead of TTD_ENDIAN defines.

### DIFF
--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -71,7 +71,7 @@ struct ScreenshotFormat {
 	ScreenshotHandlerProc *proc; ///< Function for writing the screenshot.
 };
 
-#define MKCOLOUR(x)         TO_LE32X(x)
+#define MKCOLOUR(x)         TO_LE32(x)
 
 /*************************************************
  **** SCREENSHOT CODE FOR WINDOWS BITMAP (.BMP)
@@ -360,12 +360,12 @@ static bool MakePNGImage(const char *name, ScreenshotCallback *callb, void *user
 		sig_bit.gray  = 8;
 		png_set_sBIT(png_ptr, info_ptr, &sig_bit);
 
-#if TTD_ENDIAN == TTD_LITTLE_ENDIAN
-		png_set_bgr(png_ptr);
-		png_set_filler(png_ptr, 0, PNG_FILLER_AFTER);
-#else
-		png_set_filler(png_ptr, 0, PNG_FILLER_BEFORE);
-#endif /* TTD_ENDIAN == TTD_LITTLE_ENDIAN */
+		if constexpr (std::endian::native == std::endian::little) {
+			png_set_bgr(png_ptr);
+			png_set_filler(png_ptr, 0, PNG_FILLER_AFTER);
+		} else {
+			png_set_filler(png_ptr, 0, PNG_FILLER_BEFORE);
+		}
 	}
 
 	/* use by default 64k temp memory */

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -137,15 +137,15 @@ static bool SetBankSource(MixerChannel *mc, const SoundEntry *sound)
 		}
 	}
 
-#if TTD_ENDIAN == TTD_BIG_ENDIAN
-	if (sound->bits_per_sample == 16) {
-		uint num_samples = sound->file_size / 2;
-		int16_t *samples = (int16_t *)mem;
-		for (uint i = 0; i < num_samples; i++) {
-			samples[i] = BSWAP16(samples[i]);
+	if constexpr (std::endian::native == std::endian::big) {
+		if (sound->bits_per_sample == 16) {
+			size_t num_samples = sound->file_size / 2;
+			int16_t *samples = reinterpret_cast<int16_t *>(mem);
+			for (size_t i = 0; i < num_samples; i++) {
+				samples[i] = BSWAP16(samples[i]);
+			}
 		}
 	}
-#endif
 
 	assert(sound->bits_per_sample == 8 || sound->bits_per_sample == 16);
 	assert(sound->channels == 1);

--- a/src/sound/cocoa_s.cpp
+++ b/src/sound/cocoa_s.cpp
@@ -20,7 +20,6 @@
 #include "../debug.h"
 #include "../driver.h"
 #include "../mixer.h"
-#include "../core/endian_type.hpp"
 #include "cocoa_s.h"
 
 #define Rect        OTTDRect
@@ -58,9 +57,9 @@ std::optional<std::string_view> SoundDriver_Cocoa::Start(const StringList &parm)
 	requestedDesc.mBitsPerChannel = 16;
 	requestedDesc.mFormatFlags |= kLinearPCMFormatFlagIsSignedInteger;
 
-#if TTD_ENDIAN == TTD_BIG_ENDIAN
-	requestedDesc.mFormatFlags |= kLinearPCMFormatFlagIsBigEndian;
-#endif /* TTD_ENDIAN == TTD_BIG_ENDIAN */
+	if constexpr (std::endian::native == std::endian::big) {
+		requestedDesc.mFormatFlags |= kLinearPCMFormatFlagIsBigEndian;
+	}
 
 	requestedDesc.mFramesPerPacket = 1;
 	requestedDesc.mBytesPerFrame = requestedDesc.mBitsPerChannel * requestedDesc.mChannelsPerFrame / 8;

--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -219,13 +219,8 @@ void SurveyOpenTTD(nlohmann::json &survey)
 			32
 #endif
 		;
-	survey["endian"] =
-#if (TTD_ENDIAN == TTD_LITTLE_ENDIAN)
-			"little"
-#else
-			"big"
-#endif
-		;
+	if constexpr (std::endian::native == std::endian::little) survey["endian"] = "little";
+	if constexpr (std::endian::native == std::endian::big) survey["endian"] = "big";
 	survey["dedicated_build"] =
 #ifdef DEDICATED
 			"yes"


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Tricks and defines to work out what the endianness is.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use constexpr `std::endian::native` comparisons instead.

`union Colour` is a bit scary as it's not quite so simple to shuffle members around. I went for three separate implementations with the correct one aliased with `using Colour =`...

This removes the need for CMake endian testing and our own TTD_ENDIAN defines.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Probably needs testing to ensure it does do the the right thing on various little-and big-endian platforms.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
