### PR TITLE
Codechange: Pass NWidgetParts as span instead of begin/end pointers.

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -86,7 +86,7 @@ static WindowDesc _ai_config_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_GAME_OPTIONS, WC_NONE,
 	0,
-	std::begin(_nested_ai_config_widgets), std::end(_nested_ai_config_widgets)
+	_nested_ai_config_widgets
 );
 
 /**

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -212,7 +212,7 @@ static WindowDesc _air_toolbar_desc(
 	WDP_ALIGN_TOOLBAR, "toolbar_air", 0, 0,
 	WC_BUILD_TOOLBAR, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_air_toolbar_widgets), std::end(_nested_air_toolbar_widgets),
+	_nested_air_toolbar_widgets,
 	&BuildAirToolbarWindow::hotkeys
 );
 
@@ -621,7 +621,7 @@ static WindowDesc _build_airport_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_BUILD_STATION, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_airport_widgets), std::end(_nested_build_airport_widgets)
+	_nested_build_airport_widgets
 );
 
 static void ShowBuildAirportPicker(Window *parent)

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -766,7 +766,7 @@ static WindowDesc _replace_rail_vehicle_desc(
 	WDP_AUTO, "replace_vehicle_train", 500, 140,
 	WC_REPLACE_VEHICLE, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_replace_rail_vehicle_widgets), std::end(_nested_replace_rail_vehicle_widgets)
+	_nested_replace_rail_vehicle_widgets
 );
 
 static constexpr NWidgetPart _nested_replace_road_vehicle_widgets[] = {
@@ -824,7 +824,7 @@ static WindowDesc _replace_road_vehicle_desc(
 	WDP_AUTO, "replace_vehicle_road", 500, 140,
 	WC_REPLACE_VEHICLE, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_replace_road_vehicle_widgets), std::end(_nested_replace_road_vehicle_widgets)
+	_nested_replace_road_vehicle_widgets
 );
 
 static constexpr NWidgetPart _nested_replace_vehicle_widgets[] = {
@@ -878,7 +878,7 @@ static WindowDesc _replace_vehicle_desc(
 	WDP_AUTO, "replace_vehicle", 456, 118,
 	WC_REPLACE_VEHICLE, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_replace_vehicle_widgets), std::end(_nested_replace_vehicle_widgets)
+	_nested_replace_vehicle_widgets
 );
 
 /**

--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -44,7 +44,7 @@ static WindowDesc _background_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_BOOTSTRAP, WC_NONE,
 	WDF_NO_CLOSE,
-	std::begin(_background_widgets), std::end(_background_widgets)
+	_background_widgets
 );
 
 /** The background for the game. */
@@ -80,7 +80,7 @@ static WindowDesc _bootstrap_errmsg_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_BOOTSTRAP, WC_NONE,
 	WDF_MODAL | WDF_NO_CLOSE,
-	std::begin(_nested_bootstrap_errmsg_widgets), std::end(_nested_bootstrap_errmsg_widgets)
+	_nested_bootstrap_errmsg_widgets
 );
 
 /** The window for a failed bootstrap. */
@@ -137,7 +137,7 @@ static WindowDesc _bootstrap_download_status_window_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_NETWORK_STATUS_WINDOW, WC_NONE,
 	WDF_MODAL | WDF_NO_CLOSE,
-	std::begin(_nested_bootstrap_download_status_window_widgets), std::end(_nested_bootstrap_download_status_window_widgets)
+	_nested_bootstrap_download_status_window_widgets
 );
 
 
@@ -189,7 +189,7 @@ static WindowDesc _bootstrap_query_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_CONFIRM_POPUP_QUERY, WC_NONE,
 	WDF_NO_CLOSE,
-	std::begin(_bootstrap_query_widgets), std::end(_bootstrap_query_widgets)
+	_bootstrap_query_widgets
 );
 
 /** The window for the query. It can't use the generic query window as that uses sprites that don't exist yet. */

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -338,7 +338,7 @@ static WindowDesc _build_bridge_desc(
 	WDP_AUTO, "build_bridge", 200, 114,
 	WC_BUILD_BRIDGE, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_bridge_widgets), std::end(_nested_build_bridge_widgets)
+	_nested_build_bridge_widgets
 );
 
 /**

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1922,7 +1922,7 @@ static WindowDesc _build_vehicle_desc(
 	WDP_AUTO, "build_vehicle", 240, 268,
 	WC_BUILD_VEHICLE, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_vehicle_widgets), std::end(_nested_build_vehicle_widgets),
+	_nested_build_vehicle_widgets,
 	&BuildVehicleWindow::hotkeys
 );
 

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -429,7 +429,7 @@ static WindowDesc _cheats_desc(
 	WDP_AUTO, "cheats", 0, 0,
 	WC_CHEATS, WC_NONE,
 	0,
-	std::begin(_nested_cheat_widgets), std::end(_nested_cheat_widgets)
+	_nested_cheat_widgets
 );
 
 /** Open cheat window. */

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -535,7 +535,7 @@ static WindowDesc _company_finances_desc(
 	WDP_AUTO, "company_finances", 0, 0,
 	WC_FINANCES, WC_NONE,
 	0,
-	std::begin(_nested_company_finances_widgets), std::end(_nested_company_finances_widgets)
+	_nested_company_finances_widgets
 );
 
 /**
@@ -1082,7 +1082,7 @@ static WindowDesc _select_company_livery_desc(
 	WDP_AUTO, "company_color_scheme", 0, 0,
 	WC_COMPANY_COLOUR, WC_NONE,
 	0,
-	std::begin(_nested_select_company_livery_widgets), std::end(_nested_select_company_livery_widgets)
+	_nested_select_company_livery_widgets
 );
 
 void ShowCompanyLiveryWindow(CompanyID company, GroupID group)
@@ -1707,7 +1707,7 @@ static WindowDesc _select_company_manager_face_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_COMPANY_MANAGER_FACE, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_select_company_manager_face_widgets), std::end(_nested_select_company_manager_face_widgets)
+	_nested_select_company_manager_face_widgets
 );
 
 /**
@@ -2084,7 +2084,7 @@ static WindowDesc _company_infrastructure_desc(
 	WDP_AUTO, "company_infrastructure", 0, 0,
 	WC_COMPANY_INFRASTRUCTURE, WC_NONE,
 	0,
-	std::begin(_nested_company_infrastructure_widgets), std::end(_nested_company_infrastructure_widgets)
+	_nested_company_infrastructure_widgets
 );
 
 /**
@@ -2556,7 +2556,7 @@ static WindowDesc _company_desc(
 	WDP_AUTO, "company", 0, 0,
 	WC_COMPANY, WC_NONE,
 	0,
-	std::begin(_nested_company_widgets), std::end(_nested_company_widgets)
+	_nested_company_widgets
 );
 
 /**
@@ -2690,7 +2690,7 @@ static WindowDesc _buy_company_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_BUY_COMPANY, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_buy_company_widgets), std::end(_nested_buy_company_widgets)
+	_nested_buy_company_widgets
 );
 
 /**

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -144,7 +144,7 @@ static WindowDesc _console_window_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_CONSOLE, WC_NONE,
 	0,
-	std::begin(_nested_console_window_widgets), std::end(_nested_console_window_widgets)
+	_nested_console_window_widgets
 );
 
 struct IConsoleWindow : Window

--- a/src/date_gui.cpp
+++ b/src/date_gui.cpp
@@ -200,7 +200,7 @@ static WindowDesc _set_date_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_SET_DATE, WC_NONE,
 	0,
-	std::begin(_nested_set_date_widgets), std::end(_nested_set_date_widgets)
+	_nested_set_date_widgets
 );
 
 /**

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -89,28 +89,28 @@ static WindowDesc _train_depot_desc(
 	WDP_AUTO, "depot_train", 362, 123,
 	WC_VEHICLE_DEPOT, WC_NONE,
 	0,
-	std::begin(_nested_train_depot_widgets), std::end(_nested_train_depot_widgets)
+	_nested_train_depot_widgets
 );
 
 static WindowDesc _road_depot_desc(
 	WDP_AUTO, "depot_roadveh", 316, 97,
 	WC_VEHICLE_DEPOT, WC_NONE,
 	0,
-	std::begin(_nested_train_depot_widgets), std::end(_nested_train_depot_widgets)
+	_nested_train_depot_widgets
 );
 
 static WindowDesc _ship_depot_desc(
 	WDP_AUTO, "depot_ship", 306, 99,
 	WC_VEHICLE_DEPOT, WC_NONE,
 	0,
-	std::begin(_nested_train_depot_widgets), std::end(_nested_train_depot_widgets)
+	_nested_train_depot_widgets
 );
 
 static WindowDesc _aircraft_depot_desc(
 	WDP_AUTO, "depot_aircraft", 332, 99,
 	WC_VEHICLE_DEPOT, WC_NONE,
 	0,
-	std::begin(_nested_train_depot_widgets), std::end(_nested_train_depot_widgets)
+	_nested_train_depot_widgets
 );
 
 extern void DepotSortList(VehicleList *list);

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -348,7 +348,7 @@ static WindowDesc _build_docks_toolbar_desc(
 	WDP_ALIGN_TOOLBAR, "toolbar_water", 0, 0,
 	WC_BUILD_TOOLBAR, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_docks_toolbar_widgets), std::end(_nested_build_docks_toolbar_widgets),
+	_nested_build_docks_toolbar_widgets,
 	&BuildDocksToolbarWindow::hotkeys
 );
 
@@ -392,7 +392,7 @@ static WindowDesc _build_docks_scen_toolbar_desc(
 	WDP_AUTO, "toolbar_water_scen", 0, 0,
 	WC_SCEN_BUILD_TOOLBAR, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_docks_scen_toolbar_widgets), std::end(_nested_build_docks_scen_toolbar_widgets)
+	_nested_build_docks_scen_toolbar_widgets
 );
 
 /**
@@ -502,7 +502,7 @@ static WindowDesc _build_dock_station_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_BUILD_STATION, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_dock_station_widgets), std::end(_nested_build_dock_station_widgets)
+	_nested_build_dock_station_widgets
 );
 
 static void ShowBuildDockStationPicker(Window *parent)
@@ -597,7 +597,7 @@ static WindowDesc _build_docks_depot_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_BUILD_DEPOT, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_docks_depot_widgets), std::end(_nested_build_docks_depot_widgets)
+	_nested_build_docks_depot_widgets
 );
 
 

--- a/src/dropdown.cpp
+++ b/src/dropdown.cpp
@@ -65,7 +65,7 @@ static WindowDesc _dropdown_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_DROPDOWN_MENU, WC_NONE,
 	WDF_NO_FOCUS,
-	std::begin(_nested_dropdown_menu_widgets), std::end(_nested_dropdown_menu_widgets)
+	_nested_dropdown_menu_widgets
 );
 
 /** Drop-down menu window */

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -148,7 +148,7 @@ static WindowDesc _engine_preview_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_ENGINE_PREVIEW, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_engine_preview_widgets), std::end(_nested_engine_preview_widgets)
+	_nested_engine_preview_widgets
 );
 
 

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -47,7 +47,7 @@ static WindowDesc _errmsg_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_ERRMSG, WC_NONE,
 	0,
-	std::begin(_nested_errmsg_widgets), std::end(_nested_errmsg_widgets)
+	_nested_errmsg_widgets
 );
 
 static constexpr NWidgetPart _nested_errmsg_face_widgets[] = {
@@ -67,7 +67,7 @@ static WindowDesc _errmsg_face_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_ERRMSG, WC_NONE,
 	0,
-	std::begin(_nested_errmsg_face_widgets), std::end(_nested_errmsg_face_widgets)
+	_nested_errmsg_face_widgets
 );
 
 /**

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -887,7 +887,7 @@ static WindowDesc _load_dialog_desc(
 	WDP_CENTER, "load_game", 500, 294,
 	WC_SAVELOAD, WC_NONE,
 	0,
-	std::begin(_nested_load_dialog_widgets), std::end(_nested_load_dialog_widgets)
+	_nested_load_dialog_widgets
 );
 
 /** Load heightmap */
@@ -895,7 +895,7 @@ static WindowDesc _load_heightmap_dialog_desc(
 	WDP_CENTER, "load_heightmap", 257, 320,
 	WC_SAVELOAD, WC_NONE,
 	0,
-	std::begin(_nested_load_heightmap_dialog_widgets), std::end(_nested_load_heightmap_dialog_widgets)
+	_nested_load_heightmap_dialog_widgets
 );
 
 /** Save game/scenario */
@@ -903,7 +903,7 @@ static WindowDesc _save_dialog_desc(
 	WDP_CENTER, "save_game", 500, 294,
 	WC_SAVELOAD, WC_NONE,
 	0,
-	std::begin(_nested_save_dialog_widgets), std::end(_nested_save_dialog_widgets)
+	_nested_save_dialog_widgets
 );
 
 /**

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -730,7 +730,7 @@ static WindowDesc _framerate_display_desc(
 	WDP_AUTO, "framerate_display", 0, 0,
 	WC_FRAMERATE_DISPLAY, WC_NONE,
 	0,
-	std::begin(_framerate_window_widgets), std::end(_framerate_window_widgets)
+	_framerate_window_widgets
 );
 
 
@@ -1021,7 +1021,7 @@ static WindowDesc _frametime_graph_window_desc(
 	WDP_AUTO, "frametime_graph", 140, 90,
 	WC_FRAMETIME_GRAPH, WC_NONE,
 	0,
-	std::begin(_frametime_graph_window_widgets), std::end(_frametime_graph_window_widgets)
+	_frametime_graph_window_widgets
 );
 
 

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -78,7 +78,7 @@ static WindowDesc _gs_config_desc(
 	WDP_CENTER, "settings_gs_config", 500, 350,
 	WC_GAME_OPTIONS, WC_NONE,
 	0,
-	std::begin(_nested_gs_config_widgets), std::end(_nested_gs_config_widgets)
+	_nested_gs_config_widgets
 );
 
 /**

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -1004,14 +1004,14 @@ static WindowDesc _generate_landscape_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_GENERATE_LANDSCAPE, WC_NONE,
 	0,
-	std::begin(_nested_generate_landscape_widgets), std::end(_nested_generate_landscape_widgets)
+	_nested_generate_landscape_widgets
 );
 
 static WindowDesc _heightmap_load_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_GENERATE_LANDSCAPE, WC_NONE,
 	0,
-	std::begin(_nested_heightmap_load_widgets), std::end(_nested_heightmap_load_widgets)
+	_nested_heightmap_load_widgets
 );
 
 static void _ShowGenerateLandscape(GenerateLandscapeWindowMode mode)
@@ -1314,7 +1314,7 @@ static WindowDesc _create_scenario_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_GENERATE_LANDSCAPE, WC_NONE,
 	0,
-	std::begin(_nested_create_scenario_widgets), std::end(_nested_create_scenario_widgets)
+	_nested_create_scenario_widgets
 );
 
 /** Show the window to create a scenario. */
@@ -1340,7 +1340,7 @@ static WindowDesc _generate_progress_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_MODAL_PROGRESS, WC_NONE,
 	0,
-	std::begin(_nested_generate_progress_widgets), std::end(_nested_generate_progress_widgets)
+	_nested_generate_progress_widgets
 );
 
 struct GenWorldStatus {

--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -306,7 +306,7 @@ static WindowDesc _goals_list_desc(
 	WDP_AUTO, "list_goals", 500, 127,
 	WC_GOALS_LIST, WC_NONE,
 	0,
-	std::begin(_nested_goals_list_widgets), std::end(_nested_goals_list_widgets)
+	_nested_goals_list_widgets
 );
 
 /**
@@ -450,25 +450,25 @@ static WindowDesc _goal_question_list_desc[] = {
 		WDP_CENTER, nullptr, 0, 0,
 		WC_GOAL_QUESTION, WC_NONE,
 		WDF_CONSTRUCTION,
-		std::begin(_nested_goal_question_widgets_question), std::end(_nested_goal_question_widgets_question),
+		_nested_goal_question_widgets_question,
 	},
 	{
 		WDP_CENTER, nullptr, 0, 0,
 		WC_GOAL_QUESTION, WC_NONE,
 		WDF_CONSTRUCTION,
-		std::begin(_nested_goal_question_widgets_info), std::end(_nested_goal_question_widgets_info),
+		_nested_goal_question_widgets_info,
 	},
 	{
 		WDP_CENTER, nullptr, 0, 0,
 		WC_GOAL_QUESTION, WC_NONE,
 		WDF_CONSTRUCTION,
-		std::begin(_nested_goal_question_widgets_warning), std::end(_nested_goal_question_widgets_warning),
+		_nested_goal_question_widgets_warning,
 	},
 	{
 		WDP_CENTER, nullptr, 0, 0,
 		WC_GOAL_QUESTION, WC_NONE,
 		WDF_CONSTRUCTION,
-		std::begin(_nested_goal_question_widgets_error), std::end(_nested_goal_question_widgets_error),
+		_nested_goal_question_widgets_error,
 	},
 };
 

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -146,7 +146,7 @@ static WindowDesc _graph_legend_desc(
 	WDP_AUTO, "graph_legend", 0, 0,
 	WC_GRAPH_LEGEND, WC_NONE,
 	0,
-	std::begin(_nested_graph_legend_widgets), std::end(_nested_graph_legend_widgets)
+	_nested_graph_legend_widgets
 );
 
 static void ShowGraphLegend()
@@ -696,7 +696,7 @@ static WindowDesc _operating_profit_desc(
 	WDP_AUTO, "graph_operating_profit", 0, 0,
 	WC_OPERATING_PROFIT, WC_NONE,
 	0,
-	std::begin(_nested_operating_profit_widgets), std::end(_nested_operating_profit_widgets)
+	_nested_operating_profit_widgets
 );
 
 
@@ -755,7 +755,7 @@ static WindowDesc _income_graph_desc(
 	WDP_AUTO, "graph_income", 0, 0,
 	WC_INCOME_GRAPH, WC_NONE,
 	0,
-	std::begin(_nested_income_graph_widgets), std::end(_nested_income_graph_widgets)
+	_nested_income_graph_widgets
 );
 
 void ShowIncomeGraph()
@@ -812,7 +812,7 @@ static WindowDesc _delivered_cargo_graph_desc(
 	WDP_AUTO, "graph_delivered_cargo", 0, 0,
 	WC_DELIVERED_CARGO, WC_NONE,
 	0,
-	std::begin(_nested_delivered_cargo_graph_widgets), std::end(_nested_delivered_cargo_graph_widgets)
+	_nested_delivered_cargo_graph_widgets
 );
 
 void ShowDeliveredCargoGraph()
@@ -876,7 +876,7 @@ static WindowDesc _performance_history_desc(
 	WDP_AUTO, "graph_performance", 0, 0,
 	WC_PERFORMANCE_HISTORY, WC_NONE,
 	0,
-	std::begin(_nested_performance_history_widgets), std::end(_nested_performance_history_widgets)
+	_nested_performance_history_widgets
 );
 
 void ShowPerformanceHistoryGraph()
@@ -933,7 +933,7 @@ static WindowDesc _company_value_graph_desc(
 	WDP_AUTO, "graph_company_value", 0, 0,
 	WC_COMPANY_VALUE, WC_NONE,
 	0,
-	std::begin(_nested_company_value_graph_widgets), std::end(_nested_company_value_graph_widgets)
+	_nested_company_value_graph_widgets
 );
 
 void ShowCompanyValueGraph()
@@ -1170,7 +1170,7 @@ static WindowDesc _cargo_payment_rates_desc(
 	WDP_AUTO, "graph_cargo_payment_rates", 0, 0,
 	WC_PAYMENT_RATES, WC_NONE,
 	0,
-	std::begin(_nested_cargo_payment_rates_widgets), std::end(_nested_cargo_payment_rates_widgets)
+	_nested_cargo_payment_rates_widgets
 );
 
 
@@ -1465,7 +1465,7 @@ static WindowDesc _performance_rating_detail_desc(
 	WDP_AUTO, "league_details", 0, 0,
 	WC_PERFORMANCE_DETAIL, WC_NONE,
 	0,
-	std::begin(_nested_performance_rating_detail_widgets), std::end(_nested_performance_rating_detail_widgets)
+	_nested_performance_rating_detail_widgets
 );
 
 void ShowPerformanceRatingDetail()

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -1146,14 +1146,14 @@ static WindowDesc _other_group_desc(
 	WDP_AUTO, "list_groups", 460, 246,
 	WC_INVALID, WC_NONE,
 	0,
-	std::begin(_nested_group_widgets), std::end(_nested_group_widgets)
+	_nested_group_widgets
 );
 
 static WindowDesc _train_group_desc(
 	WDP_AUTO, "list_groups_train", 525, 246,
 	WC_TRAINS_LIST, WC_NONE,
 	0,
-	std::begin(_nested_group_widgets), std::end(_nested_group_widgets)
+	_nested_group_widgets
 );
 
 /**

--- a/src/help_gui.cpp
+++ b/src/help_gui.cpp
@@ -197,7 +197,7 @@ static WindowDesc _helpwin_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_HELPWIN, WC_NONE,
 	0,
-	std::begin(_nested_helpwin_widgets), std::end(_nested_helpwin_widgets)
+	_nested_helpwin_widgets
 );
 
 void ShowHelpWindow()

--- a/src/highscore_gui.cpp
+++ b/src/highscore_gui.cpp
@@ -218,14 +218,14 @@ static WindowDesc _highscore_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_HIGHSCORE, WC_NONE,
 	0,
-	std::begin(_nested_highscore_widgets), std::end(_nested_highscore_widgets)
+	_nested_highscore_widgets
 );
 
 static WindowDesc _endgame_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_ENDSCREEN, WC_NONE,
 	0,
-	std::begin(_nested_highscore_widgets), std::end(_nested_highscore_widgets)
+	_nested_highscore_widgets
 );
 
 /**

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -299,7 +299,7 @@ static WindowDesc _build_industry_desc(
 	WDP_AUTO, "build_industry", 170, 212,
 	WC_BUILD_INDUSTRY, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_industry_widgets), std::end(_nested_build_industry_widgets)
+	_nested_build_industry_widgets
 );
 
 /** Build (fund or prospect) a new industry, */
@@ -1221,7 +1221,7 @@ static WindowDesc _industry_view_desc(
 	WDP_AUTO, "view_industry", 260, 120,
 	WC_INDUSTRY_VIEW, WC_NONE,
 	0,
-	std::begin(_nested_industry_view_widgets), std::end(_nested_industry_view_widgets)
+	_nested_industry_view_widgets
 );
 
 void ShowIndustryViewWindow(int industry)
@@ -1919,7 +1919,7 @@ static WindowDesc _industry_directory_desc(
 	WDP_AUTO, "list_industries", 428, 190,
 	WC_INDUSTRY_DIRECTORY, WC_NONE,
 	0,
-	std::begin(_nested_industry_directory_widgets), std::end(_nested_industry_directory_widgets),
+	_nested_industry_directory_widgets,
 	&IndustryDirectoryWindow::hotkeys
 );
 
@@ -1958,7 +1958,7 @@ static WindowDesc _industry_cargoes_desc(
 	WDP_AUTO, "industry_cargoes", 300, 210,
 	WC_INDUSTRY_CARGOES, WC_NONE,
 	0,
-	std::begin(_nested_industry_cargoes_widgets), std::end(_nested_industry_cargoes_widgets)
+	_nested_industry_cargoes_widgets
 );
 
 /** Available types of field. */

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -460,7 +460,7 @@ static WindowDesc _select_game_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_SELECT_GAME, WC_NONE,
 	WDF_NO_CLOSE,
-	std::begin(_nested_select_game_widgets), std::end(_nested_select_game_widgets)
+	_nested_select_game_widgets
 );
 
 void ShowSelectGameWindow()

--- a/src/league_gui.cpp
+++ b/src/league_gui.cpp
@@ -204,7 +204,7 @@ static WindowDesc _performance_league_desc(
 	WDP_AUTO, "performance_league", 0, 0,
 	WC_COMPANY_LEAGUE, WC_NONE,
 	0,
-	std::begin(_nested_performance_league_widgets), std::end(_nested_performance_league_widgets)
+	_nested_performance_league_widgets
 );
 
 void ShowPerformanceLeagueTable()
@@ -439,7 +439,7 @@ static WindowDesc _script_league_desc(
 	WDP_AUTO, "script_league", 0, 0,
 	WC_COMPANY_LEAGUE, WC_NONE,
 	0,
-	std::begin(_nested_script_league_widgets), std::end(_nested_script_league_widgets)
+	_nested_script_league_widgets
 );
 
 void ShowScriptLeagueTable(LeagueTableID table)

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -540,7 +540,7 @@ static WindowDesc _linkgraph_legend_desc(
 	WDP_AUTO, "toolbar_linkgraph", 0, 0,
 	WC_LINKGRAPH_LEGEND, WC_NONE,
 	0,
-	std::begin(_nested_linkgraph_legend_widgets), std::end(_nested_linkgraph_legend_widgets)
+	_nested_linkgraph_legend_widgets
 );
 
 /**

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -517,7 +517,7 @@ static WindowDesc _main_window_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_MAIN_WINDOW, WC_NONE,
 	WDF_NO_CLOSE,
-	std::begin(_nested_main_window_widgets), std::end(_nested_main_window_widgets),
+	_nested_main_window_widgets,
 	&MainWindow::hotkeys
 );
 

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -64,7 +64,7 @@ static WindowDesc _land_info_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_LAND_INFO, WC_NONE,
 	0,
-	std::begin(_nested_land_info_widgets), std::end(_nested_land_info_widgets)
+	_nested_land_info_widgets
 );
 
 class LandInfoWindow : public Window {
@@ -402,7 +402,7 @@ static WindowDesc _about_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_GAME_OPTIONS, WC_NONE,
 	0,
-	std::begin(_nested_about_widgets), std::end(_nested_about_widgets)
+	_nested_about_widgets
 );
 
 static const std::initializer_list<const std::string_view> _credits = {
@@ -661,7 +661,7 @@ static WindowDesc _tool_tips_desc(
 	WDP_MANUAL, nullptr, 0, 0, // Coordinates and sizes are not used,
 	WC_TOOLTIPS, WC_NONE,
 	WDF_NO_FOCUS | WDF_NO_CLOSE,
-	std::begin(_nested_tooltips_widgets), std::end(_nested_tooltips_widgets)
+	_nested_tooltips_widgets
 );
 
 /** Window for displaying a tooltip. */
@@ -1064,7 +1064,7 @@ static WindowDesc _query_string_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_QUERY_STRING, WC_NONE,
 	0,
-	std::begin(_nested_query_string_widgets), std::end(_nested_query_string_widgets)
+	_nested_query_string_widgets
 );
 
 /**
@@ -1207,7 +1207,7 @@ static WindowDesc _query_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_CONFIRM_POPUP_QUERY, WC_NONE,
 	WDF_MODAL,
-	std::begin(_nested_query_widgets), std::end(_nested_query_widgets)
+	_nested_query_widgets
 );
 
 /**

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -671,7 +671,7 @@ static WindowDesc _music_track_selection_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_MUSIC_TRACK_SELECTION, WC_NONE,
 	0,
-	std::begin(_nested_music_track_selection_widgets), std::end(_nested_music_track_selection_widgets)
+	_nested_music_track_selection_widgets
 );
 
 static void ShowMusicTrackSelection()
@@ -930,7 +930,7 @@ static WindowDesc _music_window_desc(
 	WDP_AUTO, "music", 0, 0,
 	WC_MUSIC_WINDOW, WC_NONE,
 	0,
-	std::begin(_nested_music_window_widgets), std::end(_nested_music_window_widgets)
+	_nested_music_window_widgets
 );
 
 void ShowMusicWindow()

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -433,7 +433,7 @@ static WindowDesc _chat_window_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_SEND_NETWORK_MSG, WC_NONE,
 	0,
-	std::begin(_nested_chat_window_widgets), std::end(_nested_chat_window_widgets)
+	_nested_chat_window_widgets
 );
 
 

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -98,7 +98,7 @@ static WindowDesc _network_content_download_status_window_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_NETWORK_STATUS_WINDOW, WC_NONE,
 	WDF_MODAL,
-	std::begin(_nested_network_content_download_status_window_widgets), std::end(_nested_network_content_download_status_window_widgets)
+	_nested_network_content_download_status_window_widgets
 );
 
 BaseNetworkContentDownloadStatusWindow::BaseNetworkContentDownloadStatusWindow(WindowDesc &desc) :
@@ -1116,7 +1116,7 @@ static WindowDesc _network_content_list_desc(
 	WDP_CENTER, "list_content", 630, 460,
 	WC_NETWORK_WINDOW, WC_NONE,
 	0,
-	std::begin(_nested_network_content_list_widgets), std::end(_nested_network_content_list_widgets)
+	_nested_network_content_list_widgets
 );
 
 /**

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -959,7 +959,7 @@ static WindowDesc _network_game_window_desc(
 	WDP_CENTER, "list_servers", 1000, 730,
 	WC_NETWORK_WINDOW, WC_NONE,
 	0,
-	std::begin(_nested_network_game_widgets), std::end(_nested_network_game_widgets)
+	_nested_network_game_widgets
 );
 
 void ShowNetworkGameWindow()
@@ -1226,7 +1226,7 @@ static WindowDesc _network_start_server_window_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_NETWORK_WINDOW, WC_NONE,
 	0,
-	std::begin(_nested_network_start_server_window_widgets), std::end(_nested_network_start_server_window_widgets)
+	_nested_network_start_server_window_widgets
 );
 
 static void ShowNetworkStartServerWindow()
@@ -1300,7 +1300,7 @@ static WindowDesc _client_list_desc(
 	WDP_AUTO, "list_clients", 220, 300,
 	WC_CLIENT_LIST, WC_NONE,
 	0,
-	std::begin(_nested_client_list_widgets), std::end(_nested_client_list_widgets)
+	_nested_client_list_widgets
 );
 
 /**
@@ -2195,7 +2195,7 @@ static WindowDesc _network_join_status_window_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_NETWORK_STATUS_WINDOW, WC_NONE,
 	WDF_MODAL,
-	std::begin(_nested_network_join_status_window_widgets), std::end(_nested_network_join_status_window_widgets)
+	_nested_network_join_status_window_widgets
 );
 
 void ShowJoinStatusWindow()
@@ -2312,7 +2312,7 @@ static WindowDesc _network_ask_relay_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_NETWORK_ASK_RELAY, WC_NONE,
 	WDF_MODAL,
-	std::begin(_nested_network_ask_relay_widgets), std::end(_nested_network_ask_relay_widgets)
+	_nested_network_ask_relay_widgets
 );
 
 /**
@@ -2410,7 +2410,7 @@ static WindowDesc _network_ask_survey_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_NETWORK_ASK_SURVEY, WC_NONE,
 	WDF_MODAL,
-	std::begin(_nested_network_ask_survey_widgets), std::end(_nested_network_ask_survey_widgets)
+	_nested_network_ask_survey_widgets
 );
 
 /**

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -673,14 +673,14 @@ static WindowDesc _newgrf_inspect_chain_desc(
 	WDP_AUTO, "newgrf_inspect_chain", 400, 300,
 	WC_NEWGRF_INSPECT, WC_NONE,
 	0,
-	std::begin(_nested_newgrf_inspect_chain_widgets), std::end(_nested_newgrf_inspect_chain_widgets)
+	_nested_newgrf_inspect_chain_widgets
 );
 
 static WindowDesc _newgrf_inspect_desc(
 	WDP_AUTO, "newgrf_inspect", 400, 300,
 	WC_NEWGRF_INSPECT, WC_NONE,
 	0,
-	std::begin(_nested_newgrf_inspect_widgets), std::end(_nested_newgrf_inspect_widgets)
+	_nested_newgrf_inspect_widgets
 );
 
 /**
@@ -1204,7 +1204,7 @@ static WindowDesc _sprite_aligner_desc(
 	WDP_AUTO, "sprite_aligner", 400, 300,
 	WC_SPRITE_ALIGNER, WC_NONE,
 	0,
-	std::begin(_nested_sprite_aligner_widgets), std::end(_nested_sprite_aligner_widgets)
+	_nested_sprite_aligner_widgets
 );
 
 /**

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -545,7 +545,7 @@ static WindowDesc _newgrf_parameters_desc(
 	WDP_CENTER, "settings_newgrf_config", 500, 208,
 	WC_GRF_PARAMETERS, WC_NONE,
 	0,
-	std::begin(_nested_newgrf_parameter_widgets), std::end(_nested_newgrf_parameter_widgets)
+	_nested_newgrf_parameter_widgets
 );
 
 void OpenGRFParameterWindow(bool is_baseset, GRFConfig *c, bool editable)
@@ -1940,9 +1940,9 @@ static constexpr NWidgetPart _nested_newgrf_infopanel_widgets[] = {
 /** Construct nested container widget for managing the lists and the info panel of the NewGRF GUI. */
 std::unique_ptr<NWidgetBase> NewGRFDisplay()
 {
-	std::unique_ptr<NWidgetBase> avs = MakeNWidgets(std::begin(_nested_newgrf_availables_widgets), std::end(_nested_newgrf_availables_widgets), nullptr);
-	std::unique_ptr<NWidgetBase> acs = MakeNWidgets(std::begin(_nested_newgrf_actives_widgets), std::end(_nested_newgrf_actives_widgets), nullptr);
-	std::unique_ptr<NWidgetBase> inf = MakeNWidgets(std::begin(_nested_newgrf_infopanel_widgets), std::end(_nested_newgrf_infopanel_widgets), nullptr);
+	std::unique_ptr<NWidgetBase> avs = MakeNWidgets(_nested_newgrf_availables_widgets, nullptr);
+	std::unique_ptr<NWidgetBase> acs = MakeNWidgets(_nested_newgrf_actives_widgets, nullptr);
+	std::unique_ptr<NWidgetBase> inf = MakeNWidgets(_nested_newgrf_infopanel_widgets, nullptr);
 
 	return std::make_unique<NWidgetNewGRFDisplay>(std::move(avs), std::move(acs), std::move(inf));
 }
@@ -1969,7 +1969,7 @@ static WindowDesc _newgrf_desc(
 	WDP_CENTER, "settings_newgrf", 300, 263,
 	WC_GAME_OPTIONS, WC_NONE,
 	0,
-	std::begin(_nested_newgrf_widgets), std::end(_nested_newgrf_widgets)
+	_nested_newgrf_widgets
 );
 
 /**
@@ -2053,7 +2053,7 @@ static WindowDesc _save_preset_desc(
 	WDP_CENTER, "save_preset", 140, 110,
 	WC_SAVE_PRESET, WC_GAME_OPTIONS,
 	WDF_MODAL,
-	std::begin(_nested_save_preset_widgets), std::end(_nested_save_preset_widgets)
+	_nested_save_preset_widgets
 );
 
 /** Class for the save preset window. */
@@ -2198,7 +2198,7 @@ static WindowDesc _scan_progress_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_MODAL_PROGRESS, WC_NONE,
 	0,
-	std::begin(_nested_scan_progress_widgets), std::end(_nested_scan_progress_widgets)
+	_nested_scan_progress_widgets
 );
 
 /** Window for showing the progress of NewGRF scanning. */

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -116,7 +116,7 @@ static WindowDesc _normal_news_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	0,
-	std::begin(_nested_normal_news_widgets), std::end(_nested_normal_news_widgets)
+	_nested_normal_news_widgets
 );
 
 /* New vehicles news items. */
@@ -143,7 +143,7 @@ static WindowDesc _vehicle_news_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	0,
-	std::begin(_nested_vehicle_news_widgets), std::end(_nested_vehicle_news_widgets)
+	_nested_vehicle_news_widgets
 );
 
 /* Company news items. */
@@ -171,7 +171,7 @@ static WindowDesc _company_news_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	0,
-	std::begin(_nested_company_news_widgets), std::end(_nested_company_news_widgets)
+	_nested_company_news_widgets
 );
 
 /* Thin news items. */
@@ -194,7 +194,7 @@ static WindowDesc _thin_news_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	0,
-	std::begin(_nested_thin_news_widgets), std::end(_nested_thin_news_widgets)
+	_nested_thin_news_widgets
 );
 
 /* Small news items. */
@@ -220,7 +220,7 @@ static WindowDesc _small_news_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	0,
-	std::begin(_nested_small_news_widgets), std::end(_nested_small_news_widgets)
+	_nested_small_news_widgets
 );
 
 /**
@@ -1201,7 +1201,7 @@ static WindowDesc _message_history_desc(
 	WDP_AUTO, "list_news", 400, 140,
 	WC_MESSAGE_HISTORY, WC_NONE,
 	0,
-	std::begin(_nested_message_history), std::end(_nested_message_history)
+	_nested_message_history
 );
 
 /** Display window with news messages history */

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -401,7 +401,7 @@ static WindowDesc _build_object_desc(
 	WDP_AUTO, "build_object", 0, 0,
 	WC_BUILD_OBJECT, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_object_widgets), std::end(_nested_build_object_widgets),
+	_nested_build_object_widgets,
 	&BuildObjectWindow::hotkeys
 );
 

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -1677,7 +1677,7 @@ static WindowDesc _orders_train_desc(
 	WDP_AUTO, "view_vehicle_orders_train", 384, 100,
 	WC_VEHICLE_ORDERS, WC_VEHICLE_VIEW,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_orders_train_widgets), std::end(_nested_orders_train_widgets),
+	_nested_orders_train_widgets,
 	&OrdersWindow::hotkeys
 );
 
@@ -1750,7 +1750,7 @@ static WindowDesc _orders_desc(
 	WDP_AUTO, "view_vehicle_orders", 384, 100,
 	WC_VEHICLE_ORDERS, WC_VEHICLE_VIEW,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_orders_widgets), std::end(_nested_orders_widgets),
+	_nested_orders_widgets,
 	&OrdersWindow::hotkeys
 );
 
@@ -1777,7 +1777,7 @@ static WindowDesc _other_orders_desc(
 	WDP_AUTO, "view_vehicle_orders_competitor", 384, 86,
 	WC_VEHICLE_ORDERS, WC_VEHICLE_VIEW,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_other_orders_widgets), std::end(_nested_other_orders_widgets),
+	_nested_other_orders_widgets,
 	&OrdersWindow::hotkeys
 );
 

--- a/src/osk_gui.cpp
+++ b/src/osk_gui.cpp
@@ -339,7 +339,7 @@ static WindowDesc _osk_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_OSK, WC_NONE,
 	0,
-	std::begin(_nested_osk_widgets), std::end(_nested_osk_widgets)
+	_nested_osk_widgets
 );
 
 /**

--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -635,7 +635,7 @@ std::unique_ptr<NWidgetBase> MakePickerClassWidgets()
 		EndContainer(),
 	};
 
-	return MakeNWidgets(std::begin(picker_class_widgets), std::end(picker_class_widgets), nullptr);
+	return MakeNWidgets(picker_class_widgets, nullptr);
 }
 
 /** Create nested widgets for the type picker widgets. */
@@ -671,5 +671,5 @@ std::unique_ptr<NWidgetBase> MakePickerTypeWidgets()
 		EndContainer(),
 	};
 
-	return MakeNWidgets(std::begin(picker_type_widgets), std::end(picker_type_widgets), nullptr);
+	return MakeNWidgets(picker_type_widgets, nullptr);
 }

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -901,7 +901,7 @@ static WindowDesc _build_rail_desc(
 	WDP_ALIGN_TOOLBAR, "toolbar_rail", 0, 0,
 	WC_BUILD_TOOLBAR, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_rail_widgets), std::end(_nested_build_rail_widgets),
+	_nested_build_rail_widgets,
 	&BuildRailToolbarWindow::hotkeys
 );
 
@@ -1430,7 +1430,7 @@ static WindowDesc _station_builder_desc(
 	WDP_AUTO, "build_station_rail", 0, 0,
 	WC_BUILD_STATION, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_station_builder_widgets), std::end(_nested_station_builder_widgets),
+	_nested_station_builder_widgets,
 	&BuildRailStationWindow::hotkeys
 );
 
@@ -1686,7 +1686,7 @@ static WindowDesc _signal_builder_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_BUILD_SIGNAL, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_signal_builder_widgets), std::end(_nested_signal_builder_widgets)
+	_nested_signal_builder_widgets
 );
 
 /**
@@ -1767,7 +1767,7 @@ static WindowDesc _build_depot_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_BUILD_DEPOT, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_depot_widgets), std::end(_nested_build_depot_widgets)
+	_nested_build_depot_widgets
 );
 
 static void ShowBuildTrainDepotPicker(Window *parent)
@@ -1878,7 +1878,7 @@ static WindowDesc _build_waypoint_desc(
 	WDP_AUTO, "build_waypoint", 0, 0,
 	WC_BUILD_WAYPOINT, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_waypoint_widgets), std::end(_nested_build_waypoint_widgets),
+	_nested_build_waypoint_widgets,
 	&BuildRailWaypointWindow::hotkeys
 );
 

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -858,7 +858,7 @@ static WindowDesc _build_road_desc(
 	WDP_ALIGN_TOOLBAR, "toolbar_road", 0, 0,
 	WC_BUILD_TOOLBAR, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_road_widgets), std::end(_nested_build_road_widgets),
+	_nested_build_road_widgets,
 	&BuildRoadToolbarWindow::road_hotkeys
 );
 
@@ -899,7 +899,7 @@ static WindowDesc _build_tramway_desc(
 	WDP_ALIGN_TOOLBAR, "toolbar_tramway", 0, 0,
 	WC_BUILD_TOOLBAR, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_tramway_widgets), std::end(_nested_build_tramway_widgets),
+	_nested_build_tramway_widgets,
 	&BuildRoadToolbarWindow::tram_hotkeys
 );
 
@@ -954,7 +954,7 @@ static WindowDesc _build_road_scen_desc(
 	WDP_AUTO, "toolbar_road_scen", 0, 0,
 	WC_SCEN_BUILD_TOOLBAR, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_road_scen_widgets), std::end(_nested_build_road_scen_widgets),
+	_nested_build_road_scen_widgets,
 	&BuildRoadToolbarWindow::road_hotkeys
 );
 
@@ -989,7 +989,7 @@ static WindowDesc _build_tramway_scen_desc(
 	WDP_AUTO, "toolbar_tram_scen", 0, 0,
 	WC_SCEN_BUILD_TOOLBAR, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_tramway_scen_widgets), std::end(_nested_build_tramway_scen_widgets),
+	_nested_build_tramway_scen_widgets,
 	&BuildRoadToolbarWindow::tram_hotkeys
 );
 
@@ -1086,7 +1086,7 @@ static WindowDesc _build_road_depot_desc(
 	WDP_AUTO, nullptr, 0, 0,
 	WC_BUILD_DEPOT, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_road_depot_widgets), std::end(_nested_build_road_depot_widgets)
+	_nested_build_road_depot_widgets
 );
 
 static void ShowRoadDepotPicker(Window *parent)
@@ -1464,7 +1464,7 @@ static WindowDesc _road_station_picker_desc(
 	WDP_AUTO, "build_station_road", 0, 0,
 	WC_BUS_STATION, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_road_station_picker_widgets), std::end(_nested_road_station_picker_widgets),
+	_nested_road_station_picker_widgets,
 	&BuildRoadStationWindow::road_hotkeys
 );
 
@@ -1504,7 +1504,7 @@ static WindowDesc _tram_station_picker_desc(
 	WDP_AUTO, "build_station_tram", 0, 0,
 	WC_BUS_STATION, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_tram_station_picker_widgets), std::end(_nested_tram_station_picker_widgets),
+	_nested_tram_station_picker_widgets,
 	&BuildRoadStationWindow::tram_hotkeys
 );
 

--- a/src/screenshot_gui.cpp
+++ b/src/screenshot_gui.cpp
@@ -68,7 +68,7 @@ static WindowDesc _screenshot_window_desc(
 	WDP_AUTO, "take_a_screenshot", 200, 100,
 	WC_SCREENSHOT, WC_NONE,
 	0,
-	std::begin(_nested_screenshot), std::end(_nested_screenshot)
+	_nested_screenshot
 );
 
 void ShowScreenshotWindow()

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -266,7 +266,7 @@ static WindowDesc _script_list_desc(
 	WDP_CENTER, "settings_script_list", 200, 234,
 	WC_SCRIPT_LIST, WC_NONE,
 	0,
-	std::begin(_nested_script_list_widgets), std::end(_nested_script_list_widgets)
+	_nested_script_list_widgets
 );
 
 /**
@@ -611,7 +611,7 @@ static WindowDesc _script_settings_desc(
 	WDP_CENTER, "settings_script", 500, 208,
 	WC_SCRIPT_SETTINGS, WC_NONE,
 	0,
-	std::begin(_nested_script_settings_widgets), std::end(_nested_script_settings_widgets)
+	_nested_script_settings_widgets
 );
 
 /**
@@ -1293,7 +1293,7 @@ static WindowDesc _script_debug_desc(
 	WDP_AUTO, "script_debug", 600, 450,
 	WC_SCRIPT_DEBUG, WC_NONE,
 	0,
-	std::begin(_nested_script_debug_widgets), std::end(_nested_script_debug_widgets),
+	_nested_script_debug_widgets,
 	&ScriptDebugWindow::hotkeys
 );
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -203,11 +203,11 @@ public:
 		this->plugins = SocialIntegration::GetPlugins();
 
 		if (this->plugins.empty()) {
-			auto widget = MakeNWidgets(std::begin(_nested_social_plugins_none_widgets), std::end(_nested_social_plugins_none_widgets), nullptr);
+			auto widget = MakeNWidgets(_nested_social_plugins_none_widgets, nullptr);
 			this->Add(std::move(widget));
 		} else {
 			for (size_t i = 0; i < this->plugins.size(); i++) {
-				auto widget = MakeNWidgets(std::begin(_nested_social_plugins_widgets), std::end(_nested_social_plugins_widgets), nullptr);
+				auto widget = MakeNWidgets(_nested_social_plugins_widgets, nullptr);
 				this->Add(std::move(widget));
 			}
 		}
@@ -1192,7 +1192,7 @@ static WindowDesc _game_options_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_GAME_OPTIONS, WC_NONE,
 	0,
-	std::begin(_nested_game_options_widgets), std::end(_nested_game_options_widgets)
+	_nested_game_options_widgets
 );
 
 /** Open the game options window. */
@@ -2902,7 +2902,7 @@ static WindowDesc _settings_selection_desc(
 	WDP_CENTER, "settings", 510, 450,
 	WC_GAME_OPTIONS, WC_NONE,
 	0,
-	std::begin(_nested_settings_selection_widgets), std::end(_nested_settings_selection_widgets)
+	_nested_settings_selection_widgets
 );
 
 /** Open advanced settings window. */
@@ -3210,7 +3210,7 @@ static WindowDesc _cust_currency_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_CUSTOM_CURRENCY, WC_NONE,
 	0,
-	std::begin(_nested_cust_currency_widgets), std::end(_nested_cust_currency_widgets)
+	_nested_cust_currency_widgets
 );
 
 /** Open custom currency window. */

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -387,7 +387,7 @@ static WindowDesc _sign_list_desc(
 	WDP_AUTO, "list_signs", 358, 138,
 	WC_SIGN_LIST, WC_NONE,
 	0,
-	std::begin(_nested_sign_list_widgets), std::end(_nested_sign_list_widgets),
+	_nested_sign_list_widgets,
 	&SignListWindow::hotkeys
 );
 
@@ -553,7 +553,7 @@ static WindowDesc _query_sign_edit_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_QUERY_STRING, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_query_sign_edit_widgets), std::end(_nested_query_sign_edit_widgets)
+	_nested_query_sign_edit_widgets
 );
 
 /**

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -1950,8 +1950,8 @@ static std::unique_ptr<NWidgetBase> SmallMapDisplay()
 {
 	std::unique_ptr<NWidgetBase> map_display = std::make_unique<NWidgetSmallmapDisplay>();
 
-	map_display = MakeNWidgets(std::begin(_nested_smallmap_display), std::end(_nested_smallmap_display), std::move(map_display));
-	map_display = MakeNWidgets(std::begin(_nested_smallmap_bar), std::end(_nested_smallmap_bar), std::move(map_display));
+	map_display = MakeNWidgets(_nested_smallmap_display, std::move(map_display));
+	map_display = MakeNWidgets(_nested_smallmap_bar, std::move(map_display));
 	return map_display;
 }
 
@@ -1986,7 +1986,7 @@ static WindowDesc _smallmap_desc(
 	WDP_AUTO, "smallmap", 484, 314,
 	WC_SMALLMAP, WC_NONE,
 	0,
-	std::begin(_nested_smallmap_widgets), std::end(_nested_smallmap_widgets)
+	_nested_smallmap_widgets
 );
 
 /**

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -769,7 +769,7 @@ static WindowDesc _company_stations_desc(
 	WDP_AUTO, "list_stations", 358, 162,
 	WC_STATION_LIST, WC_NONE,
 	0,
-	std::begin(_nested_company_stations_widgets), std::end(_nested_company_stations_widgets)
+	_nested_company_stations_widgets
 );
 
 /**
@@ -2133,7 +2133,7 @@ static WindowDesc _station_view_desc(
 	WDP_AUTO, "view_station", 249, 117,
 	WC_STATION_VIEW, WC_NONE,
 	0,
-	std::begin(_nested_station_view_widgets), std::end(_nested_station_view_widgets)
+	_nested_station_view_widgets
 );
 
 /**
@@ -2391,7 +2391,7 @@ static WindowDesc _select_station_desc(
 	WDP_AUTO, "build_station_join", 200, 180,
 	WC_SELECT_STATION, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_select_station_widgets), std::end(_nested_select_station_widgets)
+	_nested_select_station_widgets
 );
 
 

--- a/src/statusbar_gui.cpp
+++ b/src/statusbar_gui.cpp
@@ -232,7 +232,7 @@ static WindowDesc _main_status_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_STATUS_BAR, WC_NONE,
 	WDF_NO_FOCUS | WDF_NO_CLOSE,
-	std::begin(_nested_main_status_widgets), std::end(_nested_main_status_widgets)
+	_nested_main_status_widgets
 );
 
 /**

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -970,14 +970,14 @@ static WindowDesc _story_book_desc(
 	WDP_AUTO, "view_story", 400, 300,
 	WC_STORY_BOOK, WC_NONE,
 	0,
-	std::begin(_nested_story_book_widgets), std::end(_nested_story_book_widgets)
+	_nested_story_book_widgets
 );
 
 static WindowDesc _story_book_gs_desc(
 	WDP_CENTER, "view_story_gs", 400, 300,
 	WC_STORY_BOOK, WC_NONE,
 	0,
-	std::begin(_nested_story_book_widgets), std::end(_nested_story_book_widgets)
+	_nested_story_book_widgets
 );
 
 static CursorID TranslateStoryPageButtonCursor(StoryPageButtonCursor cursor)

--- a/src/subsidy_gui.cpp
+++ b/src/subsidy_gui.cpp
@@ -271,7 +271,7 @@ static WindowDesc _subsidies_list_desc(
 	WDP_AUTO, "list_subsidies", 500, 127,
 	WC_SUBSIDIES_LIST, WC_NONE,
 	0,
-	std::begin(_nested_subsidies_list_widgets), std::end(_nested_subsidies_list_widgets)
+	_nested_subsidies_list_widgets
 );
 
 

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -356,7 +356,7 @@ static WindowDesc _terraform_desc(
 	WDP_MANUAL, "toolbar_landscape", 0, 0,
 	WC_SCEN_LAND_GEN, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_terraform_widgets), std::end(_nested_terraform_widgets),
+	_nested_terraform_widgets,
 	&TerraformToolbarWindow::hotkeys
 );
 
@@ -740,7 +740,7 @@ static WindowDesc _scen_edit_land_gen_desc(
 	WDP_AUTO, "toolbar_landscape_scen", 0, 0,
 	WC_SCEN_LAND_GEN, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_scen_edit_land_gen_widgets), std::end(_nested_scen_edit_land_gen_widgets),
+	_nested_scen_edit_land_gen_widgets,
 	&ScenarioEditorLandscapeGenerationWindow::hotkeys
 );
 

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -79,7 +79,7 @@ static WindowDesc _textfile_desc(
 	WDP_CENTER, "textfile", 630, 460,
 	WC_TEXTFILE, WC_NONE,
 	0,
-	std::begin(_nested_textfile_widgets), std::end(_nested_textfile_widgets)
+	_nested_textfile_widgets
 );
 
 TextfileWindow::TextfileWindow(TextfileType file_type) : Window(_textfile_desc), file_type(file_type)

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -856,7 +856,7 @@ static WindowDesc _timetable_desc(
 	WDP_AUTO, "view_vehicle_timetable", 400, 130,
 	WC_VEHICLE_TIMETABLE, WC_VEHICLE_VIEW,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_timetable_widgets), std::end(_nested_timetable_widgets)
+	_nested_timetable_widgets
 );
 
 /**

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2210,7 +2210,7 @@ static WindowDesc _toolb_normal_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_MAIN_TOOLBAR, WC_NONE,
 	WDF_NO_FOCUS | WDF_NO_CLOSE,
-	std::begin(_nested_toolbar_normal_widgets), std::end(_nested_toolbar_normal_widgets),
+	_nested_toolbar_normal_widgets,
 	&MainToolbarWindow::hotkeys
 );
 
@@ -2539,7 +2539,7 @@ static constexpr NWidgetPart _nested_toolb_scen_inner_widgets[] = {
 
 static std::unique_ptr<NWidgetBase> MakeScenarioToolbar()
 {
-	return MakeNWidgets(std::begin(_nested_toolb_scen_inner_widgets), std::end(_nested_toolb_scen_inner_widgets), std::make_unique<NWidgetScenarioToolbarContainer>());
+	return MakeNWidgets(_nested_toolb_scen_inner_widgets, std::make_unique<NWidgetScenarioToolbarContainer>());
 }
 
 static constexpr NWidgetPart _nested_toolb_scen_widgets[] = {
@@ -2550,7 +2550,7 @@ static WindowDesc _toolb_scen_desc(
 	WDP_MANUAL, nullptr, 0, 0,
 	WC_MAIN_TOOLBAR, WC_NONE,
 	WDF_NO_FOCUS | WDF_NO_CLOSE,
-	std::begin(_nested_toolb_scen_widgets), std::end(_nested_toolb_scen_widgets),
+	_nested_toolb_scen_widgets,
 	&ScenarioEditorToolbarWindow::hotkeys
 );
 

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -346,7 +346,7 @@ static WindowDesc _town_authority_desc(
 	WDP_AUTO, "view_town_authority", 317, 222,
 	WC_TOWN_AUTHORITY, WC_NONE,
 	0,
-	std::begin(_nested_town_authority_widgets), std::end(_nested_town_authority_widgets)
+	_nested_town_authority_widgets
 );
 
 static void ShowTownAuthorityWindow(uint town)
@@ -640,7 +640,7 @@ static WindowDesc _town_game_view_desc(
 	WDP_AUTO, "view_town", 260, TownViewWindow::WID_TV_HEIGHT_NORMAL,
 	WC_TOWN_VIEW, WC_NONE,
 	0,
-	std::begin(_nested_town_game_view_widgets), std::end(_nested_town_game_view_widgets)
+	_nested_town_game_view_widgets
 );
 
 static constexpr NWidgetPart _nested_town_editor_view_widgets[] = {
@@ -671,7 +671,7 @@ static WindowDesc _town_editor_view_desc(
 	WDP_AUTO, "view_town_scen", 260, TownViewWindow::WID_TV_HEIGHT_NORMAL,
 	WC_TOWN_VIEW, WC_NONE,
 	0,
-	std::begin(_nested_town_editor_view_widgets), std::end(_nested_town_editor_view_widgets)
+	_nested_town_editor_view_widgets
 );
 
 void ShowTownViewWindow(TownID town)
@@ -1060,7 +1060,7 @@ static WindowDesc _town_directory_desc(
 	WDP_AUTO, "list_towns", 208, 202,
 	WC_TOWN_DIRECTORY, WC_NONE,
 	0,
-	std::begin(_nested_town_directory_widgets), std::end(_nested_town_directory_widgets),
+	_nested_town_directory_widgets,
 	&TownDirectoryWindow::hotkeys
 );
 
@@ -1294,7 +1294,7 @@ static WindowDesc _found_town_desc(
 	WDP_AUTO, "build_town", 160, 162,
 	WC_FOUND_TOWN, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_found_town_widgets), std::end(_nested_found_town_widgets)
+	_nested_found_town_widgets
 );
 
 void ShowFoundTownWindow()
@@ -1632,7 +1632,7 @@ static WindowDesc _build_house_desc(
 	WDP_AUTO, "build_house", 0, 0,
 	WC_BUILD_HOUSE, WC_BUILD_TOOLBAR,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_house_widgets), std::end(_nested_build_house_widgets),
+	_nested_build_house_widgets,
 	&BuildHouseWindow::hotkeys
 );
 

--- a/src/transparency_gui.cpp
+++ b/src/transparency_gui.cpp
@@ -152,7 +152,7 @@ static WindowDesc _transparency_desc(
 	WDP_MANUAL, "toolbar_transparency", 0, 0,
 	WC_TRANSPARENCY_TOOLBAR, WC_NONE,
 	0,
-	std::begin(_nested_transparency_widgets), std::end(_nested_transparency_widgets)
+	_nested_transparency_widgets
 );
 
 /**

--- a/src/tree_gui.cpp
+++ b/src/tree_gui.cpp
@@ -314,7 +314,7 @@ static WindowDesc _build_trees_desc(
 	WDP_AUTO, "build_tree", 0, 0,
 	WC_BUILD_TREES, WC_NONE,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_build_trees_widgets), std::end(_nested_build_trees_widgets)
+	_nested_build_trees_widgets
 );
 
 void ShowBuildTreesToolbar()

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1280,7 +1280,7 @@ static WindowDesc _vehicle_refit_desc(
 	WDP_AUTO, "view_vehicle_refit", 240, 174,
 	WC_VEHICLE_REFIT, WC_VEHICLE_VIEW,
 	WDF_CONSTRUCTION,
-	std::begin(_nested_vehicle_refit_widgets), std::end(_nested_vehicle_refit_widgets)
+	_nested_vehicle_refit_widgets
 );
 
 /**
@@ -2220,14 +2220,14 @@ static WindowDesc _vehicle_list_other_desc(
 	WDP_AUTO, "list_vehicles", 260, 246,
 	WC_INVALID, WC_NONE,
 	0,
-	std::begin(_nested_vehicle_list), std::end(_nested_vehicle_list)
+	_nested_vehicle_list
 );
 
 static WindowDesc _vehicle_list_train_desc(
 	WDP_AUTO, "list_vehicles_train", 325, 246,
 	WC_TRAINS_LIST, WC_NONE,
 	0,
-	std::begin(_nested_vehicle_list), std::end(_nested_vehicle_list)
+	_nested_vehicle_list
 );
 
 static void ShowVehicleListWindowLocal(CompanyID company, VehicleListType vlt, VehicleType vehicle_type, uint32_t unique_number)
@@ -2779,7 +2779,7 @@ static WindowDesc _train_vehicle_details_desc(
 	WDP_AUTO, "view_vehicle_details_train", 405, 178,
 	WC_VEHICLE_DETAILS, WC_VEHICLE_VIEW,
 	0,
-	std::begin(_nested_train_vehicle_details_widgets), std::end(_nested_train_vehicle_details_widgets)
+	_nested_train_vehicle_details_widgets
 );
 
 /** Vehicle details window descriptor for other vehicles than a train. */
@@ -2787,7 +2787,7 @@ static WindowDesc _nontrain_vehicle_details_desc(
 	WDP_AUTO, "view_vehicle_details", 405, 113,
 	WC_VEHICLE_DETAILS, WC_VEHICLE_VIEW,
 	0,
-	std::begin(_nested_nontrain_vehicle_details_widgets), std::end(_nested_nontrain_vehicle_details_widgets)
+	_nested_nontrain_vehicle_details_widgets
 );
 
 /** Shows the vehicle details window of the given vehicle. */
@@ -3386,7 +3386,7 @@ static WindowDesc _vehicle_view_desc(
 	WDP_AUTO, "view_vehicle", 250, 116,
 	WC_VEHICLE_VIEW, WC_NONE,
 	0,
-	std::begin(_nested_vehicle_view_widgets), std::end(_nested_vehicle_view_widgets),
+	_nested_vehicle_view_widgets,
 	&VehicleViewWindow::hotkeys
 );
 
@@ -3398,7 +3398,7 @@ static WindowDesc _train_view_desc(
 	WDP_AUTO, "view_vehicle_train", 250, 134,
 	WC_VEHICLE_VIEW, WC_NONE,
 	0,
-	std::begin(_nested_vehicle_view_widgets), std::end(_nested_vehicle_view_widgets),
+	_nested_vehicle_view_widgets,
 	&VehicleViewWindow::hotkeys
 );
 

--- a/src/viewport_gui.cpp
+++ b/src/viewport_gui.cpp
@@ -146,7 +146,7 @@ static WindowDesc _extra_viewport_desc(
 	WDP_AUTO, "extra_viewport", 300, 268,
 	WC_EXTRA_VIEWPORT, WC_NONE,
 	0,
-	std::begin(_nested_extra_viewport_widgets), std::end(_nested_extra_viewport_widgets)
+	_nested_extra_viewport_widgets
 );
 
 /**

--- a/src/waypoint_gui.cpp
+++ b/src/waypoint_gui.cpp
@@ -187,7 +187,7 @@ static WindowDesc _waypoint_view_desc(
 	WDP_AUTO, "view_waypoint", 260, 118,
 	WC_WAYPOINT_VIEW, WC_NONE,
 	0,
-	std::begin(_nested_waypoint_view_widgets), std::end(_nested_waypoint_view_widgets)
+	_nested_waypoint_view_widgets
 );
 
 /**

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -1332,8 +1332,8 @@ constexpr NWidgetPart NWidgetFunction(NWidgetFunctionType *func_ptr)
 }
 
 bool IsContainerWidgetType(WidgetType tp);
-std::unique_ptr<NWidgetBase> MakeNWidgets(const NWidgetPart *nwid_begin, const NWidgetPart *nwid_end, std::unique_ptr<NWidgetBase> &&container);
-std::unique_ptr<NWidgetBase> MakeWindowNWidgetTree(const NWidgetPart *nwid_begin, const NWidgetPart *nwid_end, NWidgetStacked **shade_select);
+std::unique_ptr<NWidgetBase> MakeNWidgets(std::span<const NWidgetPart> nwid_parts, std::unique_ptr<NWidgetBase> &&container);
+std::unique_ptr<NWidgetBase> MakeWindowNWidgetTree(std::span<const NWidgetPart> nwid_parts, NWidgetStacked **shade_select);
 
 std::unique_ptr<NWidgetBase> MakeCompanyButtonRows(WidgetID widget_first, WidgetID widget_last, Colours button_colour, int max_length, StringID button_tooltip, bool resizable = true);
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -104,7 +104,7 @@ std::string _windows_file;
 /** Window description constructor. */
 WindowDesc::WindowDesc(WindowPosition def_pos, const char *ini_key, int16_t def_width_trad, int16_t def_height_trad,
 			WindowClass window_class, WindowClass parent_class, uint32_t flags,
-			const NWidgetPart *nwid_begin, const NWidgetPart *nwid_end, HotkeyList *hotkeys,
+			const std::span<const NWidgetPart> nwid_parts, HotkeyList *hotkeys,
 			const std::source_location location) :
 	source_location(location),
 	default_pos(def_pos),
@@ -112,8 +112,7 @@ WindowDesc::WindowDesc(WindowPosition def_pos, const char *ini_key, int16_t def_
 	parent_cls(parent_class),
 	ini_key(ini_key),
 	flags(flags),
-	nwid_begin(nwid_begin),
-	nwid_end(nwid_end),
+	nwid_parts(nwid_parts),
 	hotkeys(hotkeys),
 	pref_sticky(false),
 	pref_width(0),
@@ -1723,7 +1722,7 @@ static Point LocalGetWindowPlacement(const WindowDesc &desc, int16_t sm_width, i
  */
 void Window::CreateNestedTree()
 {
-	this->nested_root = MakeWindowNWidgetTree(this->window_desc.nwid_begin, this->window_desc.nwid_end, &this->shade_select);
+	this->nested_root = MakeWindowNWidgetTree(this->window_desc.nwid_parts, &this->shade_select);
 	this->nested_root->FillWidgetLookup(this->widget_lookup);
 }
 

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -163,7 +163,7 @@ struct WindowDesc : ZeroedMemoryAllocator {
 
 	WindowDesc(WindowPosition default_pos, const char *ini_key, int16_t def_width_trad, int16_t def_height_trad,
 			WindowClass window_class, WindowClass parent_class, uint32_t flags,
-			const NWidgetPart *nwid_begin, const NWidgetPart *nwid_end, HotkeyList *hotkeys = nullptr,
+			const std::span<const NWidgetPart> nwid_parts, HotkeyList *hotkeys = nullptr,
 			const std::source_location location = std::source_location::current());
 
 	~WindowDesc();
@@ -174,8 +174,7 @@ struct WindowDesc : ZeroedMemoryAllocator {
 	WindowClass parent_cls;        ///< Class of the parent window. @see WindowClass
 	const char *ini_key;           ///< Key to store window defaults in openttd.cfg. \c nullptr if nothing shall be stored.
 	uint32_t flags;                  ///< Flags. @see WindowDefaultFlag
-	const NWidgetPart *nwid_begin; ///< Beginning of nested widget parts describing the window.
-	const NWidgetPart *nwid_end; ///< Ending of nested widget parts describing the window.
+	const std::span<const NWidgetPart> nwid_parts; ///< Span of nested widget parts describing the window.
 	HotkeyList *hotkeys;           ///< Hotkeys for the window.
 
 	bool pref_sticky;              ///< Preferred stickyness.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`WindowDesc` has two pointers, `nwid_begin` and `nwid_end` that point to the first and last `NWidgetPart`s of the window's widget layout. This looks strangely similar to a span...

I originally made it use begin and end not that long ago, as that was better than begin and count, but it was before the switch to C++20, so std::span was not available. std::span handles what we do here in a simpler and more robust way.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Replace `WindowDesc`'s `nwid_begin` and `nwid_end` members with a `std::span`, removing the use of pointers (which could potentially be null, but unit tests would catch that.)

Simplifies WindowDesc constructor callers a bit.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
