### PR TITLE
Fix #10028: Ensure stopped RVs do not prevent overtakes

### DIFF
--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -772,7 +772,17 @@ static Vehicle *EnumFindVehBlockingOvertake(Vehicle *v, void *data)
 {
 	const OvertakeData *od = (OvertakeData*)data;
 
-	return (v->type == VEH_ROAD && v->First() == v && v != od->u && v != od->v) ? v : nullptr;
+	/**
+	* first ensure that the vehicle we are looking at is a road vehicle
+	* also ensure that the vehicle we are looking at is neither of the vehicles stored in OvertakeData
+	* 
+	* A block can only happen if more than two vehicles are involved, so we can skip past this if there are only two
+	*/
+	if ((v->type == VEH_ROAD && v->First() == v) && (v != od->u && v != od->v)) {
+		/* ensure that third vehicle overtaking does not get stuck in place by allowing it to overtake */
+		return (((RoadVehicle *)v)->overtaking && v->cur_speed == 0) ? v : nullptr;
+	}
+	return nullptr;
 }
 
 /**


### PR DESCRIPTION

<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
RV overtaking would fail in certain circumstances if multiple vehicles were driving closely, usually if the stopped RV was between tiles.

Closes #10028.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Added an extra condition in the check in EnumFindVehBlockingOvertake in roadveh_cmd.cpp that checks to see if the vehicle is currently attempting to overtake but was blocked by a stopped vehicle stuck between two tiles, forcing its speed to be 0, which causes the overtake to occur anyway.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
The road vehicle may sometimes overtake in a scenario where it shouldn't, such as if another car is traveling in the opposite direction, causing a potential accident. I can't really pinpoint what exactly causes that to happen and didn't have too much time to test it, but that is one notable edge case.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
