### PR TITLE
Codefix cff48c0f6: unused variable remained after refactor

### DIFF
--- a/src/saveload/compat/station_sl_compat.h
+++ b/src/saveload/compat/station_sl_compat.h
@@ -32,12 +32,6 @@ const SaveLoadCompat _station_spec_list_sl_compat[] = {
 	SLC_VAR("localidx"),
 };
 
-/** Nominal field order for SlRoadStopSpecList. */
-const SaveLoadCompat _station_road_stop_spec_list_sl_compat[] = {
-	SLC_VAR("grfid"),
-	SLC_VAR("localidx"),
-};
-
 /** Original field order for SlStationCargo. */
 const SaveLoadCompat _station_cargo_sl_compat[] = {
 	SLC_VAR("first"),


### PR DESCRIPTION
## Motivation / Problem

CodeQL complaining about an unused variable. The variable used to exist when road stop and station speclists were distinct types, now they are the same (templated) type so one of the tables is not needed anymore. As such the other should have been removed, but wasn't removed.


## Description

Remove the unused variable.


## Limitations



## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
