### PR TITLE
Codefix: Reorder comments of HasPowerOnRoad/Rail and IsCompatibleRail.

### DIFF
--- a/src/rail.h
+++ b/src/rail.h
@@ -315,9 +315,9 @@ inline const RailTypeInfo *GetRailTypeInfo(RailType railtype)
  * Checks if an engine of the given RailType can drive on a tile with a given
  * RailType. This would normally just be an equality check, but for electric
  * rails (which also support non-electric engines).
- * @return Whether the engine can drive on this tile.
  * @param  enginetype The RailType of the engine we are considering.
  * @param  tiletype   The RailType of the tile we are considering.
+ * @return Whether the engine can drive on this tile.
  */
 inline bool IsCompatibleRail(RailType enginetype, RailType tiletype)
 {
@@ -328,9 +328,9 @@ inline bool IsCompatibleRail(RailType enginetype, RailType tiletype)
  * Checks if an engine of the given RailType got power on a tile with a given
  * RailType. This would normally just be an equality check, but for electric
  * rails (which also support non-electric engines).
- * @return Whether the engine got power on this tile.
  * @param  enginetype The RailType of the engine we are considering.
  * @param  tiletype   The RailType of the tile we are considering.
+ * @return Whether the engine got power on this tile.
  */
 inline bool HasPowerOnRail(RailType enginetype, RailType tiletype)
 {

--- a/src/road.h
+++ b/src/road.h
@@ -235,9 +235,9 @@ inline const RoadTypeInfo *GetRoadTypeInfo(RoadType roadtype)
  * Checks if an engine of the given RoadType got power on a tile with a given
  * RoadType. This would normally just be an equality check, but for electrified
  * roads (which also support non-electric vehicles).
- * @return Whether the engine got power on this tile.
  * @param  enginetype The RoadType of the engine we are considering.
  * @param  tiletype   The RoadType of the tile we are considering.
+ * @return Whether the engine got power on this tile.
  */
 inline bool HasPowerOnRoad(RoadType enginetype, RoadType tiletype)
 {


### PR DESCRIPTION
## Motivation / Problem

Usually the "@return" lines in documentation of functions are placed after the "@param" lines.

## Description

Change the order of @param and @return lines in some functions.

## Limitations

None

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
