### PR TITLE
Fix #12818: during Hostile Takeover, profit was calculated wrongly

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -184,7 +184,7 @@ Money CalculateHostileTakeoverValue(const Company *c)
 	}
 
 	for (int quarter = 0; quarter < 4; quarter++) {
-		value += std::max<Money>(c->old_economy[quarter].income - c->old_economy[quarter].expenses, 0) * 2;
+		value += std::max<Money>(c->old_economy[quarter].income + c->old_economy[quarter].expenses, 0) * 2;
 	}
 
 	return std::max<Money>(value, 1);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

#12818 reports Hostile Takeover amount seems to calculate profit incorrectly. That report is correct.

## Description

OpenTTD calculates "expenses" as: `c->cur_economy.expenses -= cost.GetCost();`. This means "expenses" is a negative value with the amount of money spent. This is a definition of "expenses" I did not expect when writing the initial code for Hostile Takeover, and I assumed it would be the total cost in that period (so a positive value if money was spent). But it is negative.

For profit calculation, to make Hostile Takeover more expensive for companies that are doing well, I used the commonly used formula: `income - expenses`.

Just because of the way OpenTTD defines `expenses`, in reality this become the amount of money earned of income PLUS the amount of money spent on infrastructure, vehicles, etc. Not sure how to call this number, but it isn't profit.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
