### PR TITLE
Fix d8771b3: Scenario Editor construction state gone wrong

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2687,7 +2687,7 @@ static void BuildTownHouse(Town *t, TileIndex tile, const HouseSpec *hs, HouseID
 	uint8_t construction_counter = 0;
 	uint8_t construction_stage = 0;
 
-	if (_generating_world) {
+	if (_generating_world || _game_mode == GM_EDITOR) {
 		uint32_t construction_random = Random();
 
 		construction_stage = TOWN_HOUSE_COMPLETED;

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2691,7 +2691,7 @@ static void BuildTownHouse(Town *t, TileIndex tile, const HouseSpec *hs, HouseID
 		uint32_t construction_random = Random();
 
 		construction_stage = TOWN_HOUSE_COMPLETED;
-		if (Chance16(1, 7)) construction_stage = GB(construction_random, 0, 2);
+		if (_generating_world && Chance16(1, 7)) construction_stage = GB(construction_random, 0, 2);
 
 		if (construction_stage == TOWN_HOUSE_COMPLETED) {
 			ChangePopulation(t, hs->population);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

In #12730 I tried to make houses in Scenario Editor spawn fully-constructed. I did the opposite (houses spawn in their first construction state) and somehow didn't notice. 

I remember testing this PR, so I have no idea how this happened. All I can figure is that I didn't build before testing, and tested an unmodified build where I got lucky with my dice rolls for random construction state. 

## Description

Revert the original commit and fix it properly this time.

## Limitations

Please check the preview and make sure it works this time, I think I'm losing my mind. 😬

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
