### PR TITLE
Feature: Set application name for SDL2

### DIFF
--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -523,6 +523,8 @@ static std::optional<std::string_view> InitializeSDL()
 	/* Check if the video-driver is already initialized. */
 	if (SDL_WasInit(SDL_INIT_VIDEO) != 0) return std::nullopt;
 
+	SDL_SetHint(SDL_HINT_APP_NAME, "OpenTTD");
+
 	if (SDL_InitSubSystem(SDL_INIT_VIDEO) < 0) return SDL_GetError();
 	return std::nullopt;
 }


### PR DESCRIPTION
This is used for e.g. screensaver inhibitor description.

## Motivation / Problem

This is how OpenTTD preventing sleep currently looks like in KDE Plasma:

![image](https://github.com/OpenTTD/OpenTTD/assets/16255906/68b0efdc-eb16-4921-aab9-398ad3486d1f)


## Description

This sets OpenTTD as the application name, which SDL2 then properly passes to system:

![image](https://github.com/OpenTTD/OpenTTD/assets/16255906/cbebbbd3-3fc1-4818-a1c1-bd011948c43f)


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
