### PR TITLE
Fix #12831: Delay vehicle cache initialisation to after map upgrades in load

### DIFF
--- a/src/elrail.cpp
+++ b/src/elrail.cpp
@@ -598,7 +598,11 @@ void DrawRailCatenary(const TileInfo *ti)
 void SettingsDisableElrail(int32_t new_value)
 {
 	bool disable = (new_value != 0);
+	UpdateDisableElrailSettingState(disable, true);
+}
 
+void UpdateDisableElrailSettingState(bool disable, bool update_vehicles)
+{
 	/* pick appropriate railtype for elrail engines depending on setting */
 	const RailType new_railtype = disable ? RAILTYPE_RAIL : RAILTYPE_ELECTRIC;
 
@@ -626,10 +630,12 @@ void SettingsDisableElrail(int32_t new_value)
 	}
 
 	/* Fix the total power and acceleration for trains */
-	for (Train *t : Train::Iterate()) {
-		/* power and acceleration is cached only for front engines */
-		if (t->IsFrontEngine()) {
-			t->ConsistChanged(CCF_TRACK);
+	if (update_vehicles) {
+		for (Train *t : Train::Iterate()) {
+			/* power and acceleration is cached only for front engines */
+			if (t->IsFrontEngine()) {
+				t->ConsistChanged(CCF_TRACK);
+			}
 		}
 	}
 

--- a/src/elrail_func.h
+++ b/src/elrail_func.h
@@ -37,5 +37,6 @@ void DrawRailCatenaryOnTunnel(const TileInfo *ti);
 void DrawRailCatenaryOnBridge(const TileInfo *ti);
 
 void SettingsDisableElrail(int32_t new_value); ///< _settings_game.disable_elrail callback
+void UpdateDisableElrailSettingState(bool disable, bool update_vehicles);
 
 #endif /* ELRAIL_FUNC_H */

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -258,7 +258,7 @@ void DeleteOrder(Vehicle *v, VehicleOrderID sel_ord);
  */
 struct OrderList : OrderListPool::PoolItem<&_orderlist_pool> {
 private:
-	friend void AfterLoadVehicles(bool part_of_load); ///< For instantiating the shared vehicle chain
+	friend void AfterLoadVehiclesPhase1(bool part_of_load); ///< For instantiating the shared vehicle chain
 	friend SaveLoadTable GetOrderListDescription(); ///< Saving and loading of order lists.
 
 	VehicleOrderID num_orders;        ///< NOSAVE: How many orders there are in the list.

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -828,8 +828,8 @@ bool AfterLoadGame()
 		}
 	}
 
-	/* Update all vehicles */
-	AfterLoadVehicles(true);
+	/* Update all vehicles: Phase 1 */
+	AfterLoadVehiclesPhase1(true);
 
 	/* make sure there is a town in the game */
 	if (_game_mode == GM_NORMAL && Town::GetNumItems() == 0) {
@@ -1356,11 +1356,6 @@ bool AfterLoadGame()
 					break;
 			}
 		}
-
-		for (Train *v : Train::Iterate()) {
-			if (v->IsFrontEngine() || v->IsFreeWagon()) v->ConsistChanged(CCF_TRACK);
-		}
-
 	}
 
 	/* In version 16.1 of the savegame a company can decide if trains, which get
@@ -1493,7 +1488,7 @@ bool AfterLoadGame()
 	 * preference of a user, let elrails enabled; it can be disabled manually */
 	if (IsSavegameVersionBefore(SLV_38)) _settings_game.vehicle.disable_elrails = false;
 	/* do the same as when elrails were enabled/disabled manually just now */
-	SettingsDisableElrail(_settings_game.vehicle.disable_elrails);
+	UpdateDisableElrailSettingState(_settings_game.vehicle.disable_elrails, false);
 	InitializeRailGUI();
 
 	/* From version 53, the map array was changed for house tiles to allow
@@ -2815,9 +2810,6 @@ bool AfterLoadGame()
 		}
 	}
 
-	/* The center of train vehicles was changed, fix up spacing. */
-	if (IsSavegameVersionBefore(SLV_164)) FixupTrainLengths();
-
 	if (IsSavegameVersionBefore(SLV_165)) {
 		for (Town *t : Town::Iterate()) {
 			/* Set the default cargo requirement for town growth */
@@ -2924,6 +2916,14 @@ bool AfterLoadGame()
 			}
 		}
 	}
+
+	/* Beyond this point, tile types which can be accessed by vehicles must be in a valid state. */
+
+	/* Update all vehicles: Phase 2 */
+	AfterLoadVehiclesPhase2(true);
+
+	/* The center of train vehicles was changed, fix up spacing. */
+	if (IsSavegameVersionBefore(SLV_164)) FixupTrainLengths();
 
 	/* In version 2.2 of the savegame, we have new airports, so status of all aircraft is reset.
 	 * This has to be called after all map array updates */
@@ -3342,7 +3342,8 @@ void ReloadNewGRFData()
 	RecomputePrices();
 	/* reload vehicles */
 	ResetVehicleHash();
-	AfterLoadVehicles(false);
+	AfterLoadVehiclesPhase1(false);
+	AfterLoadVehiclesPhase2(false);
 	StartupEngines();
 	GroupStatistics::UpdateAfterLoad();
 	/* update station graphics */

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -817,17 +817,6 @@ bool AfterLoadGame()
 	 * filled; and that could eventually lead to desyncs. */
 	CargoPacket::AfterLoad();
 
-	/* Oilrig was moved from id 15 to 9. We have to do this conversion
-	 * here as AfterLoadVehicles can check it indirectly via the newgrf
-	 * code. */
-	if (IsSavegameVersionBefore(SLV_139)) {
-		for (Station *st : Station::Iterate()) {
-			if (st->airport.tile != INVALID_TILE && st->airport.type == 15) {
-				st->airport.type = AT_OILRIG;
-			}
-		}
-	}
-
 	/* Update all vehicles: Phase 1 */
 	AfterLoadVehiclesPhase1(true);
 
@@ -2389,6 +2378,15 @@ bool AfterLoadGame()
 					}
 					offset += atc.num_frames - 1;
 				}
+			}
+		}
+	}
+
+	/* Oilrig was moved from id 15 to 9. */
+	if (IsSavegameVersionBefore(SLV_139)) {
+		for (Station *st : Station::Iterate()) {
+			if (st->airport.tile != INVALID_TILE && st->airport.type == 15) {
+				st->airport.type = AT_OILRIG;
 			}
 		}
 	}

--- a/src/saveload/saveload_internal.h
+++ b/src/saveload/saveload_internal.h
@@ -24,7 +24,8 @@ void ResetOldWaypoints();
 void MoveBuoysToWaypoints();
 void MoveWaypointsToBaseStations();
 
-void AfterLoadVehicles(bool part_of_load);
+void AfterLoadVehiclesPhase1(bool part_of_load);
+void AfterLoadVehiclesPhase2(bool part_of_load);
 void FixupTrainLengths();
 void AfterLoadStations();
 void AfterLoadRoadStops();

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -251,8 +251,8 @@ static void CheckValidVehicles()
 
 extern uint8_t _age_cargo_skip_counter; // From misc_sl.cpp
 
-/** Called after load to update coordinates */
-void AfterLoadVehicles(bool part_of_load)
+/** Called after load for phase 1 of vehicle initialisation */
+void AfterLoadVehiclesPhase1(bool part_of_load)
 {
 	for (Vehicle *v : Vehicle::Iterate()) {
 		/* Reinstate the previous pointer */
@@ -408,9 +408,13 @@ void AfterLoadVehicles(bool part_of_load)
 	}
 
 	CheckValidVehicles();
+}
 
+/** Called after load for phase 2 of vehicle initialisation */
+void AfterLoadVehiclesPhase2(bool part_of_load)
+{
 	for (Vehicle *v : Vehicle::Iterate()) {
-		assert(v->first != nullptr);
+		assert(v->First() != nullptr);
 
 		v->trip_occupancy = CalcPercentVehicleFilled(v, nullptr);
 

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -254,7 +254,7 @@ private:
 
 public:
 	friend void FixOldVehicles();
-	friend void AfterLoadVehicles(bool part_of_load);             ///< So we can set the #previous and #first pointers while loading
+	friend void AfterLoadVehiclesPhase1(bool part_of_load);       ///< So we can set the #previous and #first pointers while loading
 	friend bool LoadOldVehicle(LoadgameState *ls, int num);       ///< So we can set the proper next pointer while loading
 	/* So we can use private/protected variables in the saveload code */
 	friend class SlVehicleCommon;


### PR DESCRIPTION
## Motivation / Problem

#12831 and other potential bugs in the same general category.

## Description

Split AfterLoadVehicles into two functions.
Vehicle cache initialisation and related setup requiring that the map has already been suitably upgraded is in the second function. This is called later in the load process.

Minor re-orderings of FixupTrainLengths, and the SLV_139 fixup (this no longer needs to be done early).
Updating the disable elrails setting during load no longer updates all train caches.

## Limitations

New function names are not very creative.
Could do with testing on a wide variety of savegame versions to ensure that there are no regressions.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
