### PR TITLE
Fix #12840, ff3be45: "Show industry names" blank panel not initialized properly

### DIFF
--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -1457,7 +1457,7 @@ public:
 	{
 		_smallmap_industry_highlight = INVALID_INDUSTRYTYPE;
 		this->overlay = std::make_unique<LinkGraphOverlay>(this, WID_SM_MAP, 0, this->GetOverlayCompanyMask(), 1);
-		this->InitNested(window_number);
+		this->CreateNestedTree();
 		this->LowerWidget(WID_SM_CONTOUR + this->map_type);
 
 		this->RebuildColourIndexIfNecessary();
@@ -1468,6 +1468,7 @@ public:
 		this->SetWidgetLoweredState(WID_SM_SHOW_IND_NAMES, this->show_ind_names);
 
 		this->SetupWidgetData();
+		this->FinishInitNested(window_number);
 
 		this->SetZoomLevel(ZLC_INITIALIZE, nullptr);
 		this->SmallMapCenterOnCurrentPos();


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

As described in #12840, the "show industry names" panel does not initialise properly, causing the small map UI to display a hole.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

In this PR, we removed the call to the nested-tree init short-hand…

https://github.com/OpenTTD/OpenTTD/blob/cd4233bedcc5733d0cc05eb1331e8390391c1ba9/src/window.cpp#L1742-L1750

…and split them into separate calls. This is so that `SetupWidgetData()` is "wrapped" between these two methods, or more precisely, ensures `FinishInitNested(…)` is called after setting the displayed plane to `SZSP_NONE`.

This is a pattern observed by searching for existing usages of `SetDisplayedPlane(SZSP_NONE)` in constructors –  `VehicleListWindow`, `BuildVehicleWindow`, `CompanyFinancesWindow`, etc. all share this "wrapping" pattern:

https://github.com/OpenTTD/OpenTTD/blob/cd4233bedcc5733d0cc05eb1331e8390391c1ba9/src/company_gui.cpp#L342-L344

Since `SmallMapWindow` had no usage of `SZSP_*` until #12770 introduced it, calling `InitNested(…)` all-at-once (and ahead of the `SetDisplayedPlane(…)` call is not longer sufficient.

Calling `FinishInitNested(…)` after the `SetDisplayedPlane(SZSP_NONE)` calls fixes the issue.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


In this PR, the existing method calls that are now "wrapped" does not appear to be impacted by the late call to `SetWidgetLoweredState(…)`, e.g.

https://github.com/OpenTTD/OpenTTD/blob/cd4233bedcc5733d0cc05eb1331e8390391c1ba9/src/smallmap_gui.cpp#L1465

In my code inspection and local testing, it appears that multiple calls to `FinishInitNested(…)` is not invalid. So I'm making the assumption that a late call simply defers the layout calculations (and does not cause methods like `SetWidgetLoweredState` to be invalid). Illustratively:

```
// Before
this->CreateNestedTree(); 
this->FinishInitNested(window_number); 
…
this->SetWidgetLoweredState(WID_SM_SHOW_HEIGHT, true);
stacked_sel->SetDisplayedPlane(SZSP_NONE);
…
```

```
// After
this->CreateNestedTree(); 
…
this->SetWidgetLoweredState(WID_SM_SHOW_HEIGHT, true);
stacked_sel->SetDisplayedPlane(SZSP_NONE);
…
this->FinishInitNested(window_number); 
```

Please let me know if there's a better way! :)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
