### PR TITLE
Codechange: Use find_if to get default writeable saveload format.

### DIFF
--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2680,14 +2680,15 @@ static const SaveLoadFormat _saveload_formats[] = {
  * uncompressed, or another type
  * @param full_name Name of the savegame format. If empty it picks the first available one
  * @param compression_level Output for telling what compression level we want.
- * @return Pointer to SaveLoadFormat struct giving all characteristics of this type of savegame
+ * @return Reference to SaveLoadFormat struct giving all characteristics of this type of savegame
  */
-static const SaveLoadFormat *GetSavegameFormat(const std::string &full_name, uint8_t *compression_level)
+static const SaveLoadFormat &GetSavegameFormat(const std::string &full_name, uint8_t *compression_level)
 {
-	const SaveLoadFormat *def = lastof(_saveload_formats);
+	/* Find default savegame format, the highest one with which files can be written. */
+	auto it = std::find_if(std::rbegin(_saveload_formats), std::rend(_saveload_formats), [](const auto &slf) { return slf.init_write != nullptr; });
+	if (it == std::rend(_saveload_formats)) SlError(STR_GAME_SAVELOAD_ERROR_BROKEN_INTERNAL_ERROR, "no writeable savegame formats");
 
-	/* find default savegame format, the highest one with which files can be written */
-	while (!def->init_write) def--;
+	const SaveLoadFormat &def = *it;
 
 	if (!full_name.empty()) {
 		/* Get the ":..." of the compression level out of the way */
@@ -2711,15 +2712,15 @@ static const SaveLoadFormat *GetSavegameFormat(const std::string &full_name, uin
 						*compression_level = level;
 					}
 				}
-				return &slf;
+				return slf;
 			}
 		}
 
 		SetDParamStr(0, name);
-		SetDParamStr(1, def->name);
+		SetDParamStr(1, def.name);
 		ShowErrorMessage(STR_CONFIG_ERROR, STR_CONFIG_ERROR_INVALID_SAVEGAME_COMPRESSION_ALGORITHM, WL_CRITICAL);
 	}
-	*compression_level = def->default_compression;
+	*compression_level = def.default_compression;
 	return def;
 }
 
@@ -2805,13 +2806,13 @@ static SaveOrLoadResult SaveFileToDisk(bool threaded)
 {
 	try {
 		uint8_t compression;
-		const SaveLoadFormat *fmt = GetSavegameFormat(_savegame_format, &compression);
+		const SaveLoadFormat &fmt = GetSavegameFormat(_savegame_format, &compression);
 
 		/* We have written our stuff to memory, now write it to file! */
-		uint32_t hdr[2] = { fmt->tag, TO_BE32(SAVEGAME_VERSION << 16) };
+		uint32_t hdr[2] = { fmt.tag, TO_BE32(SAVEGAME_VERSION << 16) };
 		_sl.sf->Write((uint8_t*)hdr, sizeof(hdr));
 
-		_sl.sf = fmt->init_write(_sl.sf, compression);
+		_sl.sf = fmt.init_write(_sl.sf, compression);
 		_sl.dumper->Flush(_sl.sf);
 
 		ClearSaveLoadState();

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -286,14 +286,6 @@ char (&ArraySizeHelper(T (&array)[N]))[N];
 #define lengthof(array) (sizeof(ArraySizeHelper(array)))
 
 /**
- * Get the last element of an fixed size array.
- *
- * @param x The pointer to the first element of the array
- * @return The pointer to the last element of the array
- */
-#define lastof(x) (&x[lengthof(x) - 1])
-
-/**
  * Gets the size of a variable within a class.
  * @param base     The class the variable is in.
  * @param variable The variable to get the size of.

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -1420,7 +1420,7 @@ public:
 		uint spacer_i = 0;
 		uint button_i = 0;
 
-		/* Index into the arrangement indices. The macro lastof cannot be used here! */
+		/* Index into the arrangement indices. */
 		const WidgetID *slotp = rtl ? &arrangement[arrangable_count - 1] : arrangement;
 		for (uint i = 0; i < arrangable_count; i++) {
 			uint slot = lookup[*slotp];


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`GetSaveloadFormat()` uses a loop to search for the last writeable saveload format, using `lastof()` to start at the end, and manually decrementing in a loop. This loop assumes there is always a writeable saveload format and does not test for bounds of the `_saveload_formats` array.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Replace the search with a call to `std::find_if` using reverse iterators to start at the end. While at it, call `SlError()` if no writeable saveload format exists (very unlikely) and replace the return pointer with reference, as the saveload format must exist.

This removes the last use of `lastof()`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
