### PR TITLE
Codechange: Replace GetSavegameFormat's compression output pointer with std::pair return.

### DIFF
--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2679,10 +2679,10 @@ static const SaveLoadFormat _saveload_formats[] = {
  * Return the savegameformat of the game. Whether it was created with ZLIB compression
  * uncompressed, or another type
  * @param full_name Name of the savegame format. If empty it picks the first available one
- * @param compression_level Output for telling what compression level we want.
+ * @param[out] compression_level Output for telling what compression level we want.
  * @return Reference to SaveLoadFormat struct giving all characteristics of this type of savegame
  */
-static const SaveLoadFormat &GetSavegameFormat(const std::string &full_name, uint8_t *compression_level)
+static const SaveLoadFormat &GetSavegameFormat(const std::string &full_name, uint8_t &compression_level)
 {
 	/* Find default savegame format, the highest one with which files can be written. */
 	auto it = std::find_if(std::rbegin(_saveload_formats), std::rend(_saveload_formats), [](const auto &slf) { return slf.init_write != nullptr; });
@@ -2698,7 +2698,7 @@ static const SaveLoadFormat &GetSavegameFormat(const std::string &full_name, uin
 
 		for (const auto &slf : _saveload_formats) {
 			if (slf.init_write != nullptr && name.compare(slf.name) == 0) {
-				*compression_level = slf.default_compression;
+				compression_level = slf.default_compression;
 				if (has_comp_level) {
 					const std::string complevel(full_name, separator + 1);
 
@@ -2709,7 +2709,7 @@ static const SaveLoadFormat &GetSavegameFormat(const std::string &full_name, uin
 						SetDParamStr(0, complevel);
 						ShowErrorMessage(STR_CONFIG_ERROR, STR_CONFIG_ERROR_INVALID_SAVEGAME_COMPRESSION_LEVEL, WL_CRITICAL);
 					} else {
-						*compression_level = level;
+						compression_level = level;
 					}
 				}
 				return slf;
@@ -2720,7 +2720,7 @@ static const SaveLoadFormat &GetSavegameFormat(const std::string &full_name, uin
 		SetDParamStr(1, def.name);
 		ShowErrorMessage(STR_CONFIG_ERROR, STR_CONFIG_ERROR_INVALID_SAVEGAME_COMPRESSION_ALGORITHM, WL_CRITICAL);
 	}
-	*compression_level = def.default_compression;
+	compression_level = def.default_compression;
 	return def;
 }
 
@@ -2806,7 +2806,7 @@ static SaveOrLoadResult SaveFileToDisk(bool threaded)
 {
 	try {
 		uint8_t compression;
-		const SaveLoadFormat &fmt = GetSavegameFormat(_savegame_format, &compression);
+		const SaveLoadFormat &fmt = GetSavegameFormat(_savegame_format, compression);
 
 		/* We have written our stuff to memory, now write it to file! */
 		uint32_t hdr[2] = { fmt.tag, TO_BE32(SAVEGAME_VERSION << 16) };

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2679,10 +2679,9 @@ static const SaveLoadFormat _saveload_formats[] = {
  * Return the savegameformat of the game. Whether it was created with ZLIB compression
  * uncompressed, or another type
  * @param full_name Name of the savegame format. If empty it picks the first available one
- * @param[out] compression_level Output for telling what compression level we want.
- * @return Reference to SaveLoadFormat struct giving all characteristics of this type of savegame
+ * @return Pair containing reference to SaveLoadFormat struct giving all characteristics of this type of savegame, and a compression level to use.
  */
-static const SaveLoadFormat &GetSavegameFormat(const std::string &full_name, uint8_t &compression_level)
+static std::pair<const SaveLoadFormat &, uint8_t> GetSavegameFormat(const std::string &full_name)
 {
 	/* Find default savegame format, the highest one with which files can be written. */
 	auto it = std::find_if(std::rbegin(_saveload_formats), std::rend(_saveload_formats), [](const auto &slf) { return slf.init_write != nullptr; });
@@ -2698,7 +2697,6 @@ static const SaveLoadFormat &GetSavegameFormat(const std::string &full_name, uin
 
 		for (const auto &slf : _saveload_formats) {
 			if (slf.init_write != nullptr && name.compare(slf.name) == 0) {
-				compression_level = slf.default_compression;
 				if (has_comp_level) {
 					const std::string complevel(full_name, separator + 1);
 
@@ -2709,10 +2707,10 @@ static const SaveLoadFormat &GetSavegameFormat(const std::string &full_name, uin
 						SetDParamStr(0, complevel);
 						ShowErrorMessage(STR_CONFIG_ERROR, STR_CONFIG_ERROR_INVALID_SAVEGAME_COMPRESSION_LEVEL, WL_CRITICAL);
 					} else {
-						compression_level = level;
+						return {slf, ClampTo<uint8_t>(level)};
 					}
 				}
-				return slf;
+				return {slf, slf.default_compression};
 			}
 		}
 
@@ -2720,8 +2718,7 @@ static const SaveLoadFormat &GetSavegameFormat(const std::string &full_name, uin
 		SetDParamStr(1, def.name);
 		ShowErrorMessage(STR_CONFIG_ERROR, STR_CONFIG_ERROR_INVALID_SAVEGAME_COMPRESSION_ALGORITHM, WL_CRITICAL);
 	}
-	compression_level = def.default_compression;
-	return def;
+	return {def, def.default_compression};
 }
 
 /* actual loader/saver function */
@@ -2805,8 +2802,7 @@ static void SaveFileError()
 static SaveOrLoadResult SaveFileToDisk(bool threaded)
 {
 	try {
-		uint8_t compression;
-		const SaveLoadFormat &fmt = GetSavegameFormat(_savegame_format, compression);
+		auto [fmt, compression] = GetSavegameFormat(_savegame_format);
 
 		/* We have written our stuff to memory, now write it to file! */
 		uint32_t hdr[2] = { fmt.tag, TO_BE32(SAVEGAME_VERSION << 16) };


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`GetSaveloadFormat()` has a return parameter 'compression' that is passed as a pointer. This pointer is not checked for validity.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Remove pointer output parameter, and return both values as a std::pair.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
