### PR TITLE
Change: Path signals now show green on junction-less tracks by default

### DIFF
--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -15,6 +15,7 @@
 #include "viewport_func.h"
 #include "train.h"
 #include "company_base.h"
+#include "pbs.h"
 
 #include "safeguards.h"
 
@@ -251,6 +252,9 @@ enum SigFlags {
 	SF_GREEN2 = 1 << 4, ///< two or more green exits found
 	SF_FULL   = 1 << 5, ///< some of buffers was full, do not continue
 	SF_PBS    = 1 << 6, ///< pbs signal found
+	SF_SPLIT  = 1 << 7, ///< track merge/split found
+	SF_ENTER  = 1 << 8, ///< signal entering the block found
+	SF_ENTER2 = 1 << 9, ///< two or more signals entering the block found
 };
 
 DECLARE_ENUM_AS_BIT_SET(SigFlags)
@@ -305,6 +309,9 @@ static SigFlags ExploreSegment(Owner owner)
 					if (!(flags & SF_TRAIN) && HasVehicleOnPos(tile, nullptr, &TrainOnTileEnum)) flags |= SF_TRAIN;
 				}
 
+				/* Is this a track merge or split? */
+				if (!HasAtMostOneBit(tracks)) flags |= SF_SPLIT;
+
 				if (HasSignals(tile)) { // there is exactly one track - not zero, because there is exit from this tile
 					Track track = TrackBitsToTrack(tracks_masked); // mask TRACK_BIT_X and Y too
 					if (HasSignalOnTrack(tile, track)) { // now check whole track, not trackdir
@@ -315,11 +322,11 @@ static SigFlags ExploreSegment(Owner owner)
 						 * ANY conventional signal in REVERSE direction
 						 * (if it is a presignal EXIT and it changes, it will be added to 'to-be-done' set later) */
 						if (HasSignalOnTrackdir(tile, reversedir)) {
-							if (IsPbsSignal(sig)) {
-								flags |= SF_PBS;
-							} else if (!_tbuset.Add(tile, reversedir)) {
-								return flags | SF_FULL;
-							}
+							if (IsPbsSignal(sig)) flags |= SF_PBS;
+							if (flags & SF_ENTER) flags |= SF_ENTER2;
+							flags |= SF_ENTER;
+
+							if (!_tbuset.Add(tile, reversedir)) return flags | SF_FULL;
 						}
 						if (HasSignalOnTrackdir(tile, trackdir) && !IsOnewaySignal(tile, track)) flags |= SF_PBS;
 
@@ -411,12 +418,19 @@ static void UpdateSignalsAroundSegment(SigFlags flags)
 	while (_tbuset.Get(&tile, &trackdir)) {
 		assert(HasSignalOnTrackdir(tile, trackdir));
 
-		SignalType sig = GetSignalType(tile, TrackdirToTrack(trackdir));
+		Track track = TrackdirToTrack(trackdir);
+		SignalType sig = GetSignalType(tile, track);
 		SignalState newstate = SIGNAL_STATE_GREEN;
+
+		/* Signal state of reserved path signals is handled by the reserve/unreserve process. */
+		if (IsPbsSignal(sig) && (GetRailReservationTrackBits(tile) & TrackToTrackBits(track)) != TRACK_BIT_NONE) continue;
 
 		/* determine whether the new state is red */
 		if (flags & SF_TRAIN) {
 			/* train in the segment */
+			newstate = SIGNAL_STATE_RED;
+		} else if (IsPbsSignal(sig) && (flags & (SF_SPLIT | SF_ENTER2))) {
+			/* Turn path signals red if the segment has a junction or more than one way in. */
 			newstate = SIGNAL_STATE_RED;
 		} else {
 			/* is it a bidir combo? - then do not count its other signal direction as exit */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

It is well known that path signals are slower. After all, they show red all the time, and red is very much the colour for stop and not go in western cultures. Ergo, red signals are slow signals.

## Description

Make path signals "faster" by making path signals that point into a junction-less track segment show green by default.

This mostly matches how real-world automatic block signalling works. Straight runs of track without any switches are usually signalled in a way that does not require manual action from the signal man and default to green for free tracks. Junctions that would be manually signalled stay default-red with this PR, also matching real-world.

This is purely a visual change and has no effect on pathfinding or path reservations.


Note: PR title != commit message.

## Limitations

Signal state is not recalculated on load, so signals will stay red until a train causes a signal update to occur.

Path signals that are reserved from behind are turned red, as handling already reserved path signals with the normal signal algorithm is prone to race conditions if train A reserves a path and train B enters the block before train A. To simplify this, the state if already reserved path signals will not be updated by the signal handler.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
