### PR TITLE
Fix #12856, e17c82e: Updating network settings does not invalidate data

### DIFF
--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -1188,7 +1188,8 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_CONFIG_UPDATE(P
 
 	_network_server_max_companies = p.Recv_uint8();
 	_network_server_name = p.Recv_string(NETWORK_NAME_LENGTH);
-	SetWindowClassesDirty(WC_CLIENT_LIST);
+
+	InvalidateWindowData(WC_CLIENT_LIST, 0);
 
 	Debug(net, 9, "Client::Receive_SERVER_CONFIG_UPDATE(): max_companies={}", _network_server_max_companies);
 

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -572,9 +572,10 @@ static void UpdateClientConfigValues()
 {
 	NetworkServerUpdateGameInfo();
 
+	InvalidateWindowData(WC_CLIENT_LIST, 0);
+
 	if (_network_server) {
 		NetworkServerSendConfigUpdate();
-		SetWindowClassesDirty(WC_CLIENT_LIST);
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem

Fix #12856. When a server changes `network.max_companies` setting, "(New company)" appears in the client list but "+" button does not. This happens because the window is refreshed by the data is not invalidated, therefore it is not re-computed. 

This bug also allows clients to create new companies if the server decreased the `network.max_companies` to equal or below the number of companies in the game. If the client did not refresh their client list window, they are still able to create a new company even if it will put the number of created companies above `network.max_companies`.

## Description

This bug was fixed by executing `InvalidateWindowData` for the client list window for both the server and the client when network.max_companies is changed.

## Limitations

No limitations were identified.
