### PR TITLE
Remove: Hidden setting for adjacent stations

### DIFF
--- a/src/saveload/compat/settings_sl_compat.h
+++ b/src/saveload/compat/settings_sl_compat.h
@@ -129,7 +129,7 @@ const SaveLoadCompat _settings_sl_compat[] = {
 	SLC_VAR("order.gradual_loading"),
 	SLC_VAR("construction.road_stop_on_town_road"),
 	SLC_VAR("construction.road_stop_on_competitor_road"),
-	SLC_VAR("station.adjacent_stations"),
+	SLC_NULL(1, SLV_62, SLV_TABLE_CHUNKS),
 	SLC_VAR("economy.station_noise_level"),
 	SLC_VAR("station.distant_join_stations"),
 	SLC_VAR("economy.inflation"),

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -564,7 +564,6 @@ struct LinkGraphSettings {
 struct StationSettings {
 	bool   modified_catchment;               ///< different-size catchment areas
 	bool   serve_neutral_industries;         ///< company stations can serve industries with attached neutral stations
-	bool   adjacent_stations;                ///< allow stations to be built directly adjacent to other stations
 	bool   distant_join_stations;            ///< allow to join non-adjacent stations
 	bool   never_expire_airports;            ///< never expire airports
 	uint8_t station_spread;                  ///< amount a station may spread

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1167,24 +1167,22 @@ CommandCost FindJoiningBaseStation(StationID existing_station, StationID station
 	assert(*st == nullptr);
 	bool check_surrounding = true;
 
-	if (_settings_game.station.adjacent_stations) {
-		if (existing_station != INVALID_STATION) {
-			if (adjacent && existing_station != station_to_join) {
-				/* You can't build an adjacent station over the top of one that
-				 * already exists. */
-				return_cmd_error(error_message);
-			} else {
-				/* Extend the current station, and don't check whether it will
-				 * be near any other stations. */
-				T *candidate = T::GetIfValid(existing_station);
-				if (candidate != nullptr && filter(candidate)) *st = candidate;
-				check_surrounding = (*st == nullptr);
-			}
+	if (existing_station != INVALID_STATION) {
+		if (adjacent && existing_station != station_to_join) {
+			/* You can't build an adjacent station over the top of one that
+			 * already exists. */
+			return_cmd_error(error_message);
 		} else {
-			/* There's no station here. Don't check the tiles surrounding this
-			 * one if the company wanted to build an adjacent station. */
-			if (adjacent) check_surrounding = false;
+			/* Extend the current station, and don't check whether it will
+			 * be near any other stations. */
+			T *candidate = T::GetIfValid(existing_station);
+			if (candidate != nullptr && filter(candidate)) *st = candidate;
+			check_surrounding = (*st == nullptr);
 		}
+	} else {
+		/* There's no station here. Don't check the tiles surrounding this
+		 * one if the company wanted to build an adjacent station. */
+		if (adjacent) check_surrounding = false;
 	}
 
 	if (check_surrounding) {

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -2457,11 +2457,7 @@ static bool StationJoinerNeeded(TileArea ta, const StationPickerCmdProc &proc)
 	/* Now check if we could build there */
 	if (!proc(true, INVALID_STATION)) return false;
 
-	/* Test for adjacent station or station below selection.
-	 * If adjacent-stations is disabled and we are building next to a station, do not show the selection window.
-	 * but join the other station immediately. */
-	const BaseStation *st = FindStationsNearby<T>(ta, false);
-	return st == nullptr && (_settings_game.station.adjacent_stations || std::any_of(std::begin(_stations_nearby_list), std::end(_stations_nearby_list), [](StationID s) { return s != NEW_STATION; }));
+	return FindStationsNearby<T>(ta, false) == nullptr;
 }
 
 /**

--- a/src/table/settings/game_settings.ini
+++ b/src/table/settings/game_settings.ini
@@ -132,12 +132,6 @@ strhelp  = STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES_HELPTEXT
 post_cb  = StationCatchmentChanged
 
 [SDT_BOOL]
-var      = station.adjacent_stations
-from     = SLV_62
-def      = true
-cat      = SC_EXPERT
-
-[SDT_BOOL]
 var      = station.distant_join_stations
 from     = SLV_106
 def      = true


### PR DESCRIPTION
## Motivation / Problem

We have a hidden setting (not in the GUI) to block players from building two different stations on adjacent tiles.

The setting is unchanged for 99.9% of respondents to [the latest survey](https://survey.openttd.org/summaries/2024/wk28/14.1#game.settings.station.adjacent_stations).

I found this when reviewing #9577, which proposed to add a similar setting for depots for consistency. This PR is a cleanup project. 🙂 

## Description

Remove the setting and its effects.

## Limitations

workflow.png

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
