### PR TITLE
Codechange: Pass AirportSpec instead of index to airport resolver object.

### DIFF
--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -183,7 +183,7 @@ GrfSpecFeature AirportResolverObject::GetFeature() const
 
 uint32_t AirportResolverObject::GetDebugID() const
 {
-	return AirportSpec::Get(this->airport_scope.airport_id)->grf_prop.local_id;
+	return this->airport_scope.spec->grf_prop.local_id;
 }
 
 /* virtual */ uint32_t AirportScopeResolver::GetRandomBits() const
@@ -236,22 +236,22 @@ TownScopeResolver *AirportResolverObject::GetTown()
  * Constructor of the airport resolver.
  * @param tile %Tile for the callback, only valid for airporttile callbacks.
  * @param st %Station of the airport for which the callback is run, or \c nullptr for build gui.
- * @param airport_id Type of airport for which the callback is run.
+ * @param spec AirportSpec for which the callback is run.
  * @param layout Layout of the airport to build.
  * @param callback Callback ID.
  * @param param1 First parameter (var 10) of the callback.
  * @param param2 Second parameter (var 18) of the callback.
  */
-AirportResolverObject::AirportResolverObject(TileIndex tile, Station *st, uint8_t airport_id, uint8_t layout,
+AirportResolverObject::AirportResolverObject(TileIndex tile, Station *st, const AirportSpec *spec, uint8_t layout,
 		CallbackID callback, uint32_t param1, uint32_t param2)
-	: ResolverObject(AirportSpec::Get(airport_id)->grf_prop.grffile, callback, param1, param2), airport_scope(*this, tile, st, airport_id, layout)
+	: ResolverObject(spec->grf_prop.grffile, callback, param1, param2), airport_scope(*this, tile, st, spec, layout)
 {
-	this->root_spritegroup = AirportSpec::Get(airport_id)->grf_prop.spritegroup[0];
+	this->root_spritegroup = spec->grf_prop.spritegroup[0];
 }
 
 SpriteID GetCustomAirportSprite(const AirportSpec *as, uint8_t layout)
 {
-	AirportResolverObject object(INVALID_TILE, nullptr, as->GetIndex(), layout);
+	AirportResolverObject object(INVALID_TILE, nullptr, as, layout);
 	const SpriteGroup *group = object.Resolve();
 	if (group == nullptr) return as->preview_sprite;
 
@@ -260,7 +260,7 @@ SpriteID GetCustomAirportSprite(const AirportSpec *as, uint8_t layout)
 
 uint16_t GetAirportCallback(CallbackID callback, uint32_t param1, uint32_t param2, Station *st, TileIndex tile)
 {
-	AirportResolverObject object(tile, st, st->airport.type, st->airport.layout, callback, param1, param2);
+	AirportResolverObject object(tile, st, AirportSpec::Get(st->airport.type), st->airport.layout, callback, param1, param2);
 	return object.ResolveCallback();
 }
 
@@ -273,7 +273,7 @@ uint16_t GetAirportCallback(CallbackID callback, uint32_t param1, uint32_t param
  */
 StringID GetAirportTextCallback(const AirportSpec *as, uint8_t layout, uint16_t callback)
 {
-	AirportResolverObject object(INVALID_TILE, nullptr, as->GetIndex(), layout, (CallbackID)callback);
+	AirportResolverObject object(INVALID_TILE, nullptr, as, layout, (CallbackID)callback);
 	uint16_t cb_res = object.ResolveCallback();
 	if (cb_res == CALLBACK_FAILED || cb_res == 0x400) return STR_UNDEFINED;
 	if (cb_res > 0x400) {

--- a/src/newgrf_airport.h
+++ b/src/newgrf_airport.h
@@ -149,7 +149,7 @@ void BindAirportSpecs();
 /** Resolver for the airport scope. */
 struct AirportScopeResolver : public ScopeResolver {
 	struct Station *st; ///< Station of the airport for which the callback is run, or \c nullptr for build gui.
-	uint8_t airport_id;    ///< Type of airport for which the callback is run.
+	const AirportSpec *spec; ///< AirportSpec for which the callback is run.
 	uint8_t layout;        ///< Layout of the airport to build.
 	TileIndex tile;     ///< Tile for the callback, only valid for airporttile callbacks.
 
@@ -158,11 +158,11 @@ struct AirportScopeResolver : public ScopeResolver {
 	 * @param ro Surrounding resolver.
 	 * @param tile %Tile for the callback, only valid for airporttile callbacks.
 	 * @param st %Station of the airport for which the callback is run, or \c nullptr for build gui.
-	 * @param airport_id Type of airport for which the callback is run.
+	 * @param spec AirportSpec for which the callback is run.
 	 * @param layout Layout of the airport to build.
 	 */
-	AirportScopeResolver(ResolverObject &ro, TileIndex tile, Station *st, uint8_t airport_id, uint8_t layout)
-		: ScopeResolver(ro), st(st), airport_id(airport_id), layout(layout), tile(tile)
+	AirportScopeResolver(ResolverObject &ro, TileIndex tile, Station *st, const AirportSpec *spec, uint8_t layout)
+		: ScopeResolver(ro), st(st), spec(spec), layout(layout), tile(tile)
 	{
 	}
 
@@ -177,7 +177,7 @@ struct AirportResolverObject : public ResolverObject {
 	AirportScopeResolver airport_scope;
 	std::optional<TownScopeResolver> town_scope = std::nullopt; ///< The town scope resolver (created on the first call).
 
-	AirportResolverObject(TileIndex tile, Station *st, uint8_t airport_id, uint8_t layout,
+	AirportResolverObject(TileIndex tile, Station *st, const AirportSpec *spec, uint8_t layout,
 			CallbackID callback = CBID_NO_CALLBACK, uint32_t callback_param1 = 0, uint32_t callback_param2 = 0);
 
 	TownScopeResolver *GetTown();

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -216,7 +216,7 @@ AirportTileResolverObject::AirportTileResolverObject(const AirportTileSpec *ats,
 		CallbackID callback, uint32_t callback_param1, uint32_t callback_param2)
 	: ResolverObject(ats->grf_prop.grffile, callback, callback_param1, callback_param2),
 		tiles_scope(*this, ats, tile, st),
-		airport_scope(*this, tile, st, st != nullptr ? st->airport.type : (uint8_t)AT_DUMMY, st != nullptr ? st->airport.layout : 0)
+		airport_scope(*this, tile, st, st != nullptr ? AirportSpec::Get(st->airport.type) : nullptr, st != nullptr ? st->airport.layout : 0)
 {
 	this->root_spritegroup = ats->grf_prop.spritegroup[0];
 }

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -548,7 +548,7 @@ class NIHAirport : public NIHelper {
 	uint Resolve(uint index, uint var, uint param, bool &avail) const override
 	{
 		Station *st = Station::Get(index);
-		AirportResolverObject ro(st->airport.tile, st, st->airport.type, st->airport.layout);
+		AirportResolverObject ro(st->airport.tile, st, AirportSpec::Get(st->airport.type), st->airport.layout);
 		return ro.GetScope(VSG_SCOPE_SELF)->GetVariable(var, param, avail);
 	}
 


### PR DESCRIPTION

<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When resolving graphics and callbacks for airports, the global AirportSpec index is passed so that the AirportSpec can be looked up, even though the AirportSpec is often already available.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Pass AirportSpec instead of index to airport resolver object.

This avoids retrieving AirportSpec again when it is already available.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
