### PR TITLE
Codechange: Use GetVisibleRangeIterators to draw script settings.

### DIFF
--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -178,11 +178,6 @@ struct GSConfigWindow : public Window {
 				break;
 			}
 			case WID_GSC_SETTINGS: {
-				ScriptConfig *config = this->gs_config;
-				VisibleSettingsList::const_iterator it = this->visible_settings.begin();
-				int i = 0;
-				for (; !this->vscroll->IsVisible(i); i++) it++;
-
 				Rect ir = r.Shrink(WidgetDimensions::scaled.framerect);
 				bool rtl = _current_text_dir == TD_RTL;
 				Rect br = ir.WithWidth(SETTING_BUTTON_WIDTH, rtl);
@@ -191,9 +186,11 @@ struct GSConfigWindow : public Window {
 				int y = r.top;
 				int button_y_offset = (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
 				int text_y_offset = (this->line_height - GetCharacterHeight(FS_NORMAL)) / 2;
-				for (; this->vscroll->IsVisible(i) && it != visible_settings.end(); i++, it++) {
+
+				const auto [first, last] = this->vscroll->GetVisibleRangeIterators(this->visible_settings);
+				for (auto it = first; it != last; ++it) {
 					const ScriptConfigItem &config_item = **it;
-					int current_value = config->GetSetting((config_item).name);
+					int current_value = this->gs_config->GetSetting(config_item.name);
 					bool editable = this->IsEditableItem(config_item);
 
 					StringID str;
@@ -212,6 +209,7 @@ struct GSConfigWindow : public Window {
 						DrawBoolButton(br.left, y + button_y_offset, current_value != 0, editable);
 						SetDParam(idx++, current_value == 0 ? STR_CONFIG_SETTING_OFF : STR_CONFIG_SETTING_ON);
 					} else {
+						int i = static_cast<int>(std::distance(std::begin(this->visible_settings), it));
 						if (config_item.complete_labels) {
 							DrawDropDownButton(br.left, y + button_y_offset, COLOUR_YELLOW, this->clicked_row == i && clicked_dropdown, editable);
 						} else {

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -356,11 +356,6 @@ struct ScriptSettingsWindow : public Window {
 	{
 		if (widget != WID_SCRS_BACKGROUND) return;
 
-		ScriptConfig *config = this->script_config;
-		VisibleSettingsList::const_iterator it = this->visible_settings.begin();
-		int i = 0;
-		for (; !this->vscroll->IsVisible(i); i++) it++;
-
 		Rect ir = r.Shrink(WidgetDimensions::scaled.framerect);
 		bool rtl = _current_text_dir == TD_RTL;
 		Rect br = ir.WithWidth(SETTING_BUTTON_WIDTH, rtl);
@@ -369,9 +364,11 @@ struct ScriptSettingsWindow : public Window {
 		int y = r.top;
 		int button_y_offset = (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
 		int text_y_offset = (this->line_height - GetCharacterHeight(FS_NORMAL)) / 2;
-		for (; this->vscroll->IsVisible(i) && it != visible_settings.end(); i++, it++) {
+
+		const auto [first, last] = this->vscroll->GetVisibleRangeIterators(this->visible_settings);
+		for (auto it = first; it != last; ++it) {
 			const ScriptConfigItem &config_item = **it;
-			int current_value = config->GetSetting((config_item).name);
+			int current_value = this->script_config->GetSetting(config_item.name);
 			bool editable = this->IsEditableItem(config_item);
 
 			StringID str;
@@ -390,6 +387,7 @@ struct ScriptSettingsWindow : public Window {
 				DrawBoolButton(br.left, y + button_y_offset, current_value != 0, editable);
 				SetDParam(idx++, current_value == 0 ? STR_CONFIG_SETTING_OFF : STR_CONFIG_SETTING_ON);
 			} else {
+				int i = static_cast<int>(std::distance(std::begin(this->visible_settings), it));
 				if (config_item.complete_labels) {
 					DrawDropDownButton(br.left, y + button_y_offset, COLOUR_YELLOW, this->clicked_row == i && clicked_dropdown, editable);
 				} else {


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When drawing script settings (game or AI) a mildly obscure(d) method is used to get the range of items to draw.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Simplify by using `Scrollbar::GetVisibleRangeIterators()` instead.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
