### PR TITLE
Add: Ukrainian Hryvnia currency

### DIFF
--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -71,6 +71,7 @@ static const std::array<CurrencySpec, CURRENCY_END> origin_currency_specs = {{
 	{    5, "", CF_NOEURO,                     "RM",       "",             "MYR", 0, STR_GAME_OPTIONS_CURRENCY_MYR    }, ///< Malaysian Ringgit
 	{    1, "", TimerGameCalendar::Year{2014}, "",         NBSP "Ls",      "LVL", 1, STR_GAME_OPTIONS_CURRENCY_LVL    }, ///< latvian lats
 	{  400, "", TimerGameCalendar::Year{2002}, "",         "$00",          "PTE", 1, STR_GAME_OPTIONS_CURRENCY_PTE    }, ///< portuguese escudo
+	{   50, "", CF_NOEURO,                     "",         NBSP "\u20B4",  "UAH", 1, STR_GAME_OPTIONS_CURRENCY_UAH    }, ///< ukrainian hryvnia
 }};
 
 /** Array of currencies used by the system */

--- a/src/currency.h
+++ b/src/currency.h
@@ -68,6 +68,7 @@ enum Currencies : uint8_t {
 	CURRENCY_MYR,       ///< Malaysian Ringgit
 	CURRENCY_LVL,       ///< Latvian Lats
 	CURRENCY_PTE,       ///< Portuguese Escudo
+	CURRENCY_UAH,       ///< Ukrainian Hryvnia
 	CURRENCY_END,       ///< always the last item
 };
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -979,7 +979,7 @@ STR_GAME_OPTIONS_CURRENCY_UNITS_DROPDOWN_TOOLTIP                :{BLACK}Currency
 
 STR_GAME_OPTIONS_CURRENCY_CODE                                  :{STRING} ({RAW_STRING})
 
-###length 44
+###length 45
 STR_GAME_OPTIONS_CURRENCY_GBP                                   :British Pound
 STR_GAME_OPTIONS_CURRENCY_USD                                   :American Dollar
 STR_GAME_OPTIONS_CURRENCY_EUR                                   :Euro
@@ -1024,6 +1024,7 @@ STR_GAME_OPTIONS_CURRENCY_IDR                                   :Indonesian Rupi
 STR_GAME_OPTIONS_CURRENCY_MYR                                   :Malaysian Ringgit
 STR_GAME_OPTIONS_CURRENCY_LVL                                   :Latvian Lats
 STR_GAME_OPTIONS_CURRENCY_PTE                                   :Portuguese Escudo
+STR_GAME_OPTIONS_CURRENCY_UAH                                   :Ukrainian Hryvnia
 
 STR_GAME_OPTIONS_AUTOSAVE_FRAME                                 :{BLACK}Autosave
 STR_GAME_OPTIONS_AUTOSAVE_DROPDOWN_TOOLTIP                      :{BLACK}Select interval between automatic game saves

--- a/src/table/settings/locale_settings.ini
+++ b/src/table/settings/locale_settings.ini
@@ -12,7 +12,7 @@ static void SettingsValueVelocityUnit(const IntSettingDesc &sd, uint first_param
 
 uint8_t _old_units;                                      ///< Old units from old savegames
 
-static constexpr std::initializer_list<const char*> _locale_currencies{"GBP", "USD", "EUR", "JPY", "ATS", "BEF", "CHF", "CZK", "DEM", "DKK", "ESP", "FIM", "FRF", "GRD", "HUF", "ISK", "ITL", "NLG", "NOK", "PLN", "RON", "RUR", "SIT", "SEK", "TRY", "SKK", "BRL", "EEK", "LTL", "KRW", "ZAR", "custom", "GEL", "IRR", "RUB", "MXN", "NTD", "CNY", "HKD", "INR", "IDR", "MYR", "LVL", "PTE"};
+static constexpr std::initializer_list<const char*> _locale_currencies{"GBP", "USD", "EUR", "JPY", "ATS", "BEF", "CHF", "CZK", "DEM", "DKK", "ESP", "FIM", "FRF", "GRD", "HUF", "ISK", "ITL", "NLG", "NOK", "PLN", "RON", "RUR", "SIT", "SEK", "TRY", "SKK", "BRL", "EEK", "LTL", "KRW", "ZAR", "custom", "GEL", "IRR", "RUB", "MXN", "NTD", "CNY", "HKD", "INR", "IDR", "MYR", "LVL", "PTE", "UAH"};
 static constexpr std::initializer_list<const char*> _locale_units{"imperial", "metric", "si", "gameunits", "knots"};
 
 static_assert(_locale_currencies.size() == CURRENCY_END);


### PR DESCRIPTION
- Add Ukrainian Hryvnia currency with rate of £1 = 50 ₴;
- Add currency name to the English localization.