### PR TITLE
Codefix: cargo_(dis)allowed for default refit masks are cargo classes, not CargoTypes.

### DIFF
--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -45,7 +45,7 @@ enum TownProductionEffect : uint8_t {
 };
 
 /** Cargo classes. */
-enum CargoClass {
+enum CargoClass : uint16_t {
 	CC_NOAVAILABLE  = 0,       ///< No cargo class has been specified
 	CC_PASSENGERS   = 1 <<  0, ///< Passengers
 	CC_MAIL         = 1 <<  1, ///< Mail
@@ -60,6 +60,9 @@ enum CargoClass {
 	CC_SPECIAL      = 1 << 15, ///< Special bit used for livery refit tricks instead of normal cargoes.
 };
 
+/** Bitmask of cargo classes. */
+using CargoClasses = uint16_t;
+
 static const uint8_t INVALID_CARGO_BITNUM = 0xFF; ///< Constant representing invalid cargo
 
 static const uint TOWN_PRODUCTION_DIVISOR = 256;
@@ -72,7 +75,7 @@ struct CargoSpec {
 	uint8_t rating_colour;
 	uint8_t weight;                    ///< Weight of a single unit of this cargo type in 1/16 ton (62.5 kg).
 	uint16_t multiplier = 0x100; ///< Capacity multiplier for vehicles. (8 fractional bits)
-	uint16_t classes;                  ///< Classes of this cargo type. @see CargoClass
+	CargoClasses classes; ///< Classes of this cargo type. @see CargoClass
 	int32_t initial_payment;           ///< Initial payment rate before inflation is applied.
 	uint8_t transit_periods[2];
 

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -318,8 +318,8 @@ struct GRFTempEngineData {
 		NONEMPTY,       ///< GRF defined the vehicle as refittable. If the refitmask is empty after translation (cargotypes not available), disable the vehicle.
 	};
 
-	uint16_t cargo_allowed;
-	uint16_t cargo_disallowed;
+	CargoClasses cargo_allowed;
+	CargoClasses cargo_disallowed;
 	RailTypeLabel railtypelabel;
 	uint8_t roadtramtype;
 	const GRFFile *defaultcargo_grf; ///< GRF defining the cargo translation table to use if the default cargo is the 'first refittable'.
@@ -9001,8 +9001,8 @@ static void CalculateRefitMasks()
 				static const struct DefaultRefitMasks {
 					uint8_t climate;
 					CargoLabel cargo_label;
-					CargoTypes cargo_allowed;
-					CargoTypes cargo_disallowed;
+					CargoClasses cargo_allowed;
+					CargoClasses cargo_disallowed;
 				} _default_refit_masks[] = {
 					{T | A | S | Y, CT_PASSENGERS, CC_PASSENGERS,               0},
 					{T | A | S    , CT_MAIL,       CC_MAIL,                     0},


### PR DESCRIPTION

<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

The `cargo_allowed` and `cargo_disallowed` members of `DefaultRefitMasks` are incorrectly defined as `CargoTypes`, when they actually hold cargo classes.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

CargoClasses are stored in a `uint16_t`, so create an alias for it and use it where CargoClasses are stored.

CargoClass itself is a bitmask enum but this cannot be used for storage as ORing values together would need to be cast from int.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
