### PR TITLE
Codechange: Improve performance of unchanging animated tiles.

### DIFF
--- a/src/animated_tile.cpp
+++ b/src/animated_tile.cpp
@@ -32,13 +32,13 @@ void DeleteAnimatedTile(TileIndex tile)
 }
 
 /**
- * Add the given tile to the animated tile table (if it does not exist
- * on that table yet). Also increases the size of the table if necessary.
+ * Add the given tile to the animated tile table (if it does not exist yet).
  * @param tile the tile to make animated
+ * @param mark_dirty whether to also mark the tile dirty.
  */
-void AddAnimatedTile(TileIndex tile)
+void AddAnimatedTile(TileIndex tile, bool mark_dirty)
 {
-	MarkTileDirtyByTile(tile);
+	if (mark_dirty) MarkTileDirtyByTile(tile);
 	include(_animated_tiles, tile);
 }
 

--- a/src/animated_tile.cpp
+++ b/src/animated_tile.cpp
@@ -28,7 +28,6 @@ void DeleteAnimatedTile(TileIndex tile)
 	if (to_remove != _animated_tiles.end()) {
 		/* The order of the remaining elements must stay the same, otherwise the animation loop may miss a tile. */
 		_animated_tiles.erase(to_remove);
-		MarkTileDirtyByTile(tile);
 	}
 }
 

--- a/src/animated_tile_func.h
+++ b/src/animated_tile_func.h
@@ -12,7 +12,7 @@
 
 #include "tile_type.h"
 
-void AddAnimatedTile(TileIndex tile);
+void AddAnimatedTile(TileIndex tile, bool mark_dirty = true);
 void DeleteAnimatedTile(TileIndex tile);
 void AnimateAnimatedTiles();
 void InitializeAnimatedTiles();

--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -196,11 +196,11 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 	}
 
 private:
-	void SetRoadStopTileData(TileIndex tile, uint8_t data, bool animation);
+	bool SetRoadStopTileData(TileIndex tile, uint8_t data, bool animation);
 
 public:
 	inline void SetRoadStopRandomBits(TileIndex tile, uint8_t random_bits) { this->SetRoadStopTileData(tile, random_bits, false); }
-	inline void SetRoadStopAnimationFrame(TileIndex tile, uint8_t frame) { this->SetRoadStopTileData(tile, frame, true); }
+	inline bool SetRoadStopAnimationFrame(TileIndex tile, uint8_t frame) { return this->SetRoadStopTileData(tile, frame, true); }
 	void RemoveRoadStopTileData(TileIndex tile);
 
 	static void PostDestructor(size_t index);

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -603,8 +603,8 @@ static void AnimatePowerPlantSparks(TileIndex tile)
 		DeleteAnimatedTile(tile);
 	} else {
 		SetAnimationFrame(tile, m + 1);
-		MarkTileDirtyByTile(tile);
 	}
+	MarkTileDirtyByTile(tile);
 }
 
 static void AnimateToyFactory(TileIndex tile)
@@ -649,8 +649,8 @@ static void AnimateOilWell(TileIndex tile, IndustryGfx gfx)
 	} else {
 		SetAnimationFrame(tile, m);
 		SetIndustryGfx(tile, gfx);
-		MarkTileDirtyByTile(tile);
 	}
+	MarkTileDirtyByTile(tile);
 }
 
 static void AnimateMineTower(TileIndex tile)
@@ -906,6 +906,7 @@ static void TileLoop_Industry(TileIndex tile)
 			SetIndustryCompleted(tile);
 			SetIndustryConstructionStage(tile, 3);
 			DeleteAnimatedTile(tile);
+			MarkTileDirtyByTile(tile);
 		}
 		break;
 

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -800,7 +800,7 @@ static void MakeIndustryTileBigger(TileIndex tile)
 	case GFX_PLASTIC_FOUNTAIN_ANIMATED_3: case GFX_PLASTIC_FOUNTAIN_ANIMATED_4:
 	case GFX_PLASTIC_FOUNTAIN_ANIMATED_5: case GFX_PLASTIC_FOUNTAIN_ANIMATED_6:
 	case GFX_PLASTIC_FOUNTAIN_ANIMATED_7: case GFX_PLASTIC_FOUNTAIN_ANIMATED_8:
-		AddAnimatedTile(tile);
+		AddAnimatedTile(tile, false);
 		break;
 	}
 }

--- a/src/newgrf_animation_base.h
+++ b/src/newgrf_animation_base.h
@@ -20,7 +20,14 @@
 template <typename Tobj>
 struct TileAnimationFrameAnimationHelper {
 	static uint8_t Get(Tobj *, TileIndex tile) { return GetAnimationFrame(tile); }
-	static void Set(Tobj *, TileIndex tile, uint8_t frame) { SetAnimationFrame(tile, frame); }
+	static bool Set(Tobj *, TileIndex tile, uint8_t frame)
+	{
+		uint8_t prev_frame = GetAnimationFrame(tile);
+		if (prev_frame == frame) return false;
+
+		SetAnimationFrame(tile, frame);
+		return true;
+	}
 };
 
 /**
@@ -105,8 +112,8 @@ struct AnimationBase {
 			}
 		}
 
-		Tframehelper::Set(obj, tile, frame);
-		MarkTileDirtyByTile(tile);
+		bool changed = Tframehelper::Set(obj, tile, frame);
+		if (changed) MarkTileDirtyByTile(tile);
 	}
 
 	/**
@@ -131,8 +138,8 @@ struct AnimationBase {
 			case 0xFE: AddAnimatedTile(tile, false); break;
 			case 0xFF: DeleteAnimatedTile(tile); break;
 			default:
-				Tframehelper::Set(obj, tile, callback);
-				AddAnimatedTile(tile);
+				bool changed = Tframehelper::Set(obj, tile, callback);
+				AddAnimatedTile(tile, changed);
 				break;
 		}
 

--- a/src/newgrf_animation_base.h
+++ b/src/newgrf_animation_base.h
@@ -128,7 +128,7 @@ struct AnimationBase {
 
 		switch (callback & 0xFF) {
 			case 0xFD: /* Do nothing. */         break;
-			case 0xFE: AddAnimatedTile(tile);    break;
+			case 0xFE: AddAnimatedTile(tile, false); break;
 			case 0xFF: DeleteAnimatedTile(tile); break;
 			default:
 				Tframehelper::Set(obj, tile, callback);

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -344,7 +344,7 @@ uint16_t GetAnimRoadStopCallback(CallbackID callback, uint32_t param1, uint32_t 
 
 struct RoadStopAnimationFrameAnimationHelper {
 	static uint8_t Get(BaseStation *st, TileIndex tile) { return st->GetRoadStopAnimationFrame(tile); }
-	static void Set(BaseStation *st, TileIndex tile, uint8_t frame) { st->SetRoadStopAnimationFrame(tile, frame); }
+	static bool Set(BaseStation *st, TileIndex tile, uint8_t frame) { return st->SetRoadStopAnimationFrame(tile, frame); }
 };
 
 /** Helper class for animation control. */

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -168,16 +168,14 @@ void BaseStation::PostDestructor(size_t)
 	InvalidateWindowData(WC_SELECT_STATION, 0, 0);
 }
 
-void BaseStation::SetRoadStopTileData(TileIndex tile, uint8_t data, bool animation)
+bool BaseStation::SetRoadStopTileData(TileIndex tile, uint8_t data, bool animation)
 {
 	for (RoadStopTileData &tile_data : this->custom_roadstop_tile_data) {
 		if (tile_data.tile == tile) {
-			if (animation) {
-				tile_data.animation_frame = data;
-			} else {
-				tile_data.random_bits = data;
-			}
-			return;
+			uint8_t &v = animation ? tile_data.animation_frame : tile_data.random_bits;
+			if (v == data) return false;
+			v = data;
+			return true;
 		}
 	}
 	RoadStopTileData tile_data;
@@ -185,6 +183,7 @@ void BaseStation::SetRoadStopTileData(TileIndex tile, uint8_t data, bool animati
 	tile_data.animation_frame = animation ? data : 0;
 	tile_data.random_bits = animation ? 0 : data;
 	this->custom_roadstop_tile_data.push_back(tile_data);
+	return data != 0;
 }
 
 void BaseStation::RemoveRoadStopTileData(TileIndex tile)

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2466,7 +2466,7 @@ static inline void ClearMakeHouseTile(TileIndex tile, Town *t, uint8_t counter, 
 
 	IncreaseBuildingCount(t, type);
 	MakeHouseTile(tile, t->index, counter, stage, type, random_bits);
-	if (HouseSpec::Get(type)->building_flags & BUILDING_IS_ANIMATED) AddAnimatedTile(tile);
+	if (HouseSpec::Get(type)->building_flags & BUILDING_IS_ANIMATED) AddAnimatedTile(tile, false);
 
 	MarkTileDirtyByTile(tile);
 }


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When add or deleting tiles to the global animated tile list, we automatically mark the tile as dirty.

Often the tile itself does not need to be refreshed, as the animation frame itself is not being changed.

Some animation-heavy NewGRFs can cause the game to run slowly as nearly the whole screen becomes refreshed every tick, even though it is not visible changed.

Partially addresses #10192.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This is a set of changes loosely backported from JGRPP. They are not direct cherry-picks, but derived from looking at changes from master:

When deleting animation frames, don't mark tiles dirty at all. Callers of the function will know better if the tile needs to be marked dirty, and in many cases are already doing so.

Allow adding animated tiles without marking the tile dirty. This is often the case when a tile has just been changed, or an animation is triggered.

Finally, when updating an animation frame, also test if the frame has changed from its previous value. If not then don't mark the tile dirty.

This can significantly improve rendering performance in a savegame where lots of "invisible" animated frames exist. Further performance gains are achievable but this is just a first step without many changes.

Tested with `JR, Feb 20th, 1974.sav` available from https://fuzzle.org/~petern/ottd/JR,%20Feb%2020th,%201974.sav. Save is 26MB.

Performance of `JR, Feb 20th, 1974.sav` with OpenTTD 14.1:

![image](https://github.com/user-attachments/assets/57c33bae-6008-49c4-b118-803705bf3bea)

Performance of `JR, Feb 20th, 1974.sav` with this PR applied:

![image](https://github.com/user-attachments/assets/045de187-2fd3-499f-9856-33589deff304)


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
