### PR TITLE
Fix: Excessively fast ships on aqueducts fail to move at correct speed

### DIFF
--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -849,7 +849,7 @@ static void ShipController(Ship *v)
 				v->y_pos = gp.y;
 				v->UpdatePosition();
 				if ((v->vehstatus & VS_HIDDEN) == 0) v->Vehicle::UpdateViewport(true);
-				return;
+				continue;
 			}
 
 			/* Ship is back on the bridge head, we need to consume its path


### PR DESCRIPTION
## Motivation / Problem

Excessively fast ships (since #10734) fail to move at correct speed on aqueducts

## Description

Fix the above

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
