### PR TITLE
Fix 77f27e08: Crash due to incorrect use of AirportSpec::GetIndex

### DIFF
--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -551,7 +551,7 @@ public:
 					if (as->IsAvailable()) {
 						_selected_airport_class = cls.Index();
 						this->vscroll->SetCount(cls.GetSpecCount());
-						this->SelectOtherAirport(as->GetIndex());
+						this->SelectOtherAirport(as->index);
 						return;
 					}
 				}


### PR DESCRIPTION
## Motivation / Problem

Crash due to incorrect use of AirportSpec::GetIndex, when BuildAirportWindow::SelectFirstAvailableAirport changes class.

## Description

Fix the above

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
