### PR TITLE
Codefix: Remove dead code for WID_SIL_FILTER_ENTER_BTN in sign window

### DIFF
--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -243,13 +243,6 @@ struct SignListWindow : Window, SignList {
 				break;
 			}
 
-			case WID_SIL_FILTER_ENTER_BTN:
-				if (this->signs.size() >= 1) {
-					const Sign *si = this->signs[0];
-					ScrollMainWindowToTile(TileVirtXY(si->x, si->y));
-				}
-				break;
-
 			case WID_SIL_FILTER_MATCH_CASE_BTN:
 				SignList::match_case = !SignList::match_case; // Toggle match case
 				this->SetWidgetLoweredState(WID_SIL_FILTER_MATCH_CASE_BTN, SignList::match_case); // Toggle button pushed state

--- a/src/widgets/sign_widget.h
+++ b/src/widgets/sign_widget.h
@@ -18,7 +18,6 @@ enum SignListWidgets : WidgetID {
 	WID_SIL_SCROLLBAR,             ///< Scrollbar of list.
 	WID_SIL_FILTER_TEXT,           ///< Text box for typing a filter string.
 	WID_SIL_FILTER_MATCH_CASE_BTN, ///< Button to toggle if case sensitive filtering should be used.
-	WID_SIL_FILTER_ENTER_BTN,      ///< Scroll to first sign.
 };
 
 /** Widgets of the #SignWindow class. */


### PR DESCRIPTION
## Motivation / Problem

WID_SIL_FILTER_ENTER_BTN and its click handler in the sign list window have been dead code since 01dae23dc7c2c6d5bcdb9c1c8d7c04808dd7b1e7.

## Description

Remove the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
