### PR TITLE
Codechange: Store custom station layouts in a map instead of nested vectors.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -2042,14 +2042,14 @@ static ChangeInfoResult StationChangeInfo(uint stid, int numinfo, int prop, Byte
 
 					if (length == 0 || number == 0) break;
 
-					if (statspec->layouts.size() < length) statspec->layouts.resize(length);
-					if (statspec->layouts[length - 1].size() < number) statspec->layouts[length - 1].resize(number);
+					const uint8_t *buf_layout = buf.ReadBytes(length * number);
 
-					const uint8_t *layout = buf.ReadBytes(length * number);
-					statspec->layouts[length - 1][number - 1].assign(layout, layout + length * number);
+					/* Create entry in layouts and assign the layout to it. */
+					auto &layout = statspec->layouts[GetStationLayoutKey(number, length)];
+					layout.assign(buf_layout, buf_layout + length * number);
 
 					/* Ensure the first bit, axis, is zero. The rest of the value is validated during rendering, as we don't know the range yet. */
-					for (auto &tile : statspec->layouts[length - 1][number - 1]) {
+					for (auto &tile : layout) {
 						if ((tile & ~1U) != tile) {
 							GrfMsg(1, "StationChangeInfo: Invalid tile {} in layout {}x{}", tile, length, number);
 							tile &= ~1U;

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -170,15 +170,8 @@ struct StationSpec : NewGRFSpecBase<StationClassID> {
 
 	AnimationInfo animation;
 
-	/**
-	 * Custom platform layouts.
-	 * This is a 2D array containing an array of tiles.
-	 * 1st layer is platform lengths.
-	 * 2nd layer is tracks (width).
-	 * These can be sparsely populated, and the upper limit is not defined but
-	 * limited to 255.
-	 */
-	std::vector<std::vector<std::vector<uint8_t>>> layouts;
+	/** Custom platform layouts, keyed by platform and length combined. */
+	std::unordered_map<uint16_t, std::vector<uint8_t>> layouts;
 };
 DECLARE_ENUM_AS_BIT_SET(StationSpec::TileFlags);
 
@@ -186,6 +179,17 @@ DECLARE_ENUM_AS_BIT_SET(StationSpec::TileFlags);
 using StationClass = NewGRFClass<StationSpec, StationClassID, STAT_CLASS_MAX>;
 
 const StationSpec *GetStationSpec(TileIndex t);
+
+/**
+ * Get the station layout key for a given station layout size.
+ * @param platforms Number of platforms.
+ * @param length Length of platforms.
+ * @returns Key of station layout.
+ */
+inline uint16_t GetStationLayoutKey(uint8_t platforms, uint8_t length)
+{
+	return (length << 8U) | platforms;
+}
 
 /**
  * Test if a StationClass is the waypoint class.

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1127,13 +1127,13 @@ static inline uint8_t *CreateMulti(uint8_t *layout, int n, uint8_t b)
  */
 void GetStationLayout(uint8_t *layout, uint numtracks, uint plat_len, const StationSpec *statspec)
 {
-	if (statspec != nullptr && statspec->layouts.size() >= plat_len &&
-			statspec->layouts[plat_len - 1].size() >= numtracks &&
-			!statspec->layouts[plat_len - 1][numtracks - 1].empty()) {
-		/* Custom layout defined, follow it. */
-		memcpy(layout, statspec->layouts[plat_len - 1][numtracks - 1].data(),
-			static_cast<size_t>(plat_len) * numtracks);
-		return;
+	if (statspec != nullptr) {
+		auto found = statspec->layouts.find(GetStationLayoutKey(numtracks, plat_len));
+		if (found != std::end(statspec->layouts)) {
+			/* Custom layout defined, copy to buffer. */
+			std::copy(std::begin(found->second), std::end(found->second), layout);
+			return;
+		}
 	}
 
 	if (plat_len == 1) {


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Custom station layouts are stored in 3 layers of nested vectors, one for platforms, one for lengths, and finally the layout data itself.

This requires work to manage as each additional length of platform count requires resizing vectors, and searching for a specific size needs check if all 3 layers are in range and have data.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Replace with an `unordered_map` of vectors. The map key is the platforms and length combined, each of which is a `uint8_t`, so the key is a `uint16_t`.

This simplifies allocation and searching for layouts. Allocation is automatic by key, and searching for a specific size only needs to find the key.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

I did consider making the key a `std::pair<uint8_t, uint8_t>` but this isn't hashable by default.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
