### PR TITLE
Fix: Picker window 'used' filter for rail waypoints

### DIFF
--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1840,7 +1840,7 @@ public:
 			}
 			for (const auto &sm : wp->speclist) {
 				if (sm.spec == nullptr) continue;
-				items.insert({0, 0, sm.spec->class_index, sm.spec->index});
+				items.insert({sm.grfid, sm.localidx, sm.spec->class_index, sm.spec->index});
 			}
 		}
 	}

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -960,7 +960,7 @@ static void HandleStationPlacement(TileIndex start, TileIndex end)
 static bool StationUsesDefaultType(const BaseStation *bst)
 {
 	for (TileIndex t : bst->train_station) {
-		if (bst->TileBelongsToRailStation(t) && IsRailStation(t) && GetCustomStationSpecIndex(t) == 0) return true;
+		if (bst->TileBelongsToRailStation(t) && HasStationRail(t) && GetCustomStationSpecIndex(t) == 0) return true;
 	}
 	return false;
 }


### PR DESCRIPTION
## Motivation /

The picker window 'used' filter for rail waypoints does not work.

The first two fields of struct PickerItem were not populated. These are required for set operations.
StationUsesDefaultType always returned false for rail waypoints.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
