### PR TITLE
Documentation: Add missing road waypoint map bits to landscape documents

### DIFF
--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -973,6 +973,22 @@
        </tr>
 
        <tr>
+        <td nowrap valign=top><tt>04</tt>..<tt>05</tt>&nbsp; </td>
+        <td align=left>road waypoints
+         <table>
+          <tr>
+           <td><tt>04</tt>&nbsp; </td>
+           <td align=left>drive through X</td>
+          </tr>
+          <tr>
+           <td><tt>05</tt>&nbsp; </td>
+           <td align=left>drive through Y</td>
+          </tr>
+         </table>
+        </td>
+       </tr>
+
+       <tr>
         <td nowrap valign=top><tt>00</tt>..<tt>05</tt>&nbsp; </td>
         <td align=left>ship dock
          <table>
@@ -1016,7 +1032,7 @@
      <li>m8 bit 15: Snow or desert present (road waypoints)</li>
      <li>m8 bits 11..6: <a href="#TramType">Tramtype</a></li>
      <li>m8 bits 5..0: <a href="#TrackType">track type</a> for railway stations/waypoints</li>
-     <li>m8 bits 5..0: custom road stop id; 0 means standard graphics</li>
+     <li>m8 bits 5..0: custom road stop/waypoint id; 0 means standard graphics</li>
     </ul>
    </td>
   </tr>

--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -208,7 +208,7 @@ the array so you can quickly see what is used and what is not.
     <tr>
       <td class="caption">road waypoint</td>
       <td class="bits"><span class="used" title="Owner of tram">XXXX</span> <span class="used" title="Pavement type">XX</span><span class="free">OO</span></td>
-      <td class="bits"><span class="used" title="Snow/desert present">X</span><span class="free">OOO</span> <span class="used" title="Tram type">XXXX XX<span class="free">OO OOOO</span></td>
+      <td class="bits"><span class="used" title="Snow/desert present">X</span><span class="free">OOO</span> <span class="used" title="Tram type">XXXX XX</span> <span class="used" title="Custom road stops specifications ID">XXXXXX</span></td>
     </tr>
     <tr>
       <td class="caption">airport</td>


### PR DESCRIPTION
## Motivation / Problem

Missing road waypoint map bits in landscape documents.

## Description

Add missing road waypoint map bits to landscape documents.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
