### PR TITLE
Codefix: Implement explicit ByteReader::PeekDWord() instead of type-punning pointer.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -9,6 +9,7 @@
 
 #include "stdafx.h"
 
+#include "core/backup_type.hpp"
 #include "core/container_func.hpp"
 #include "debug.h"
 #include "fileio_func.h"
@@ -257,6 +258,12 @@ public:
 		return val | (ReadWord() << 16);
 	}
 
+	uint32_t PeekDWord()
+	{
+		AutoRestoreBackup backup(this->data, this->data);
+		return this->ReadDWord();
+	}
+
 	uint32_t ReadVarSize(uint8_t size)
 	{
 		switch (size) {
@@ -288,11 +295,6 @@ public:
 	inline bool HasData(size_t count = 1) const
 	{
 		return data + count <= end;
-	}
-
-	inline uint8_t *Data()
-	{
-		return data;
 	}
 
 	inline void Skip(size_t len)
@@ -1962,7 +1964,7 @@ static ChangeInfoResult StationChangeInfo(uint stid, int numinfo, int prop, Byte
 					NewGRFSpriteLayout *dts = &statspec->renderdata.emplace_back();
 					dts->consistent_max_offset = UINT16_MAX; // Spritesets are unknown, so no limit.
 
-					if (buf.HasData(4) && *(uint32_t*)buf.Data() == 0) {
+					if (buf.HasData(4) && buf.PeekDWord() == 0) {
 						buf.Skip(4);
 						extern const DrawTileSprites _station_display_datas_rail[8];
 						dts->Clone(&_station_display_datas_rail[t % 8]);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When reading station sprite layouts, we 'peek' the dword ahead to determine if we should bother properly reading it.

This is done by casting a `uint8_t` pointer to `uint32_t` and checking if it's non-zero.

This could result in unaligned pointer access, and is just a little bit dirty.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, implement a specific `PeekDWord()` method of `ByteReader` which calls `ReadDWord() but uses `AutoRestoreBackup` to ensure the read position is restored.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
