### PR TITLE
Codefix: Avoid type-casting function pointer with incorrect type.

### DIFF
--- a/src/saveload/ai_sl.cpp
+++ b/src/saveload/ai_sl.cpp
@@ -41,9 +41,9 @@ static const SaveLoad _ai_running_desc[] = {
 	 SLEG_CONDVAR("running_version",  _ai_saveload_version,  SLE_UINT32, SLV_AI_LOCAL_CONFIG, SL_MAX_VERSION),
 };
 
-static void SaveReal_AIPL(int *index_ptr)
+static void SaveReal_AIPL(int arg)
 {
-	CompanyID index = (CompanyID)*index_ptr;
+	CompanyID index = static_cast<CompanyID>(arg);
 	AIConfig *config = AIConfig::GetConfig(index, AIConfig::SSS_FORCE_GAME);
 
 	if (config->HasScript()) {
@@ -162,7 +162,7 @@ struct AIPLChunkHandler : ChunkHandler {
 
 		for (int i = COMPANY_FIRST; i < MAX_COMPANIES; i++) {
 			SlSetArrayIndex(i);
-			SlAutolength((AutolengthProc *)SaveReal_AIPL, &i);
+			SlAutolength(SaveReal_AIPL, i);
 		}
 	}
 };

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -32,7 +32,7 @@ static const SaveLoad _game_script_desc[] = {
 	    SLEG_VAR("version",   _game_saveload_version,   SLE_UINT32),
 };
 
-static void SaveReal_GSDT(int *)
+static void SaveReal_GSDT(int)
 {
 	GameConfig *config = GameConfig::GetConfig();
 
@@ -109,7 +109,7 @@ struct GSDTChunkHandler : ChunkHandler {
 	{
 		SlTableHeader(_game_script_desc);
 		SlSetArrayIndex(0);
-		SlAutolength((AutolengthProc *)SaveReal_GSDT, nullptr);
+		SlAutolength(SaveReal_GSDT, 0);
 	}
 };
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1925,7 +1925,7 @@ void SlGlobList(const SaveLoadTable &slt)
  * @param proc The callback procedure that is called
  * @param arg The variable that will be used for the callback procedure
  */
-void SlAutolength(AutolengthProc *proc, void *arg)
+void SlAutolength(AutolengthProc *proc, int arg)
 {
 	assert(_sl.action == SLA_SAVE);
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -436,7 +436,7 @@ void DoAutoOrNetsave(FiosNumberedSaveName &counter);
 SaveOrLoadResult SaveWithFilter(std::shared_ptr<struct SaveFilter> writer, bool threaded);
 SaveOrLoadResult LoadWithFilter(std::shared_ptr<struct LoadFilter> reader);
 
-typedef void AutolengthProc(void *arg);
+typedef void AutolengthProc(int);
 
 /** Type of a chunk. */
 enum ChunkType {
@@ -1290,7 +1290,7 @@ int SlIterateArray();
 void SlSetStructListLength(size_t length);
 size_t SlGetStructListLength(size_t limit);
 
-void SlAutolength(AutolengthProc *proc, void *arg);
+void SlAutolength(AutolengthProc *proc, int arg);
 size_t SlGetFieldLength();
 void SlSetLength(size_t length);
 size_t SlCalcObjMemberLength(const void *object, const SaveLoad &sld);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

The function pointer prototype `AutolengthProc` is defined as taking a `void *` argument, however all two implementations take an `int *` (and only one of them uses it.)

Because this does not match, there is a C-style cast to `AutolengthProc` which hides the incorrect pointer type.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

As the only user of the argument takes an integer, make `AutolengthProc` take `int` instead of `void *`, avoiding pointer parameters and casting.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
