### PR TITLE
Fix: Road stop availability callback

### DIFF
--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -101,7 +101,7 @@ static bool IsRoadStopEverAvailable(const RoadStopSpec *spec, StationType type)
 static bool IsRoadStopAvailable(const RoadStopSpec *spec, StationType type)
 {
 	if (spec == nullptr) return true;
-	if (IsRoadStopEverAvailable(spec, type)) return true;
+	if (!IsRoadStopEverAvailable(spec, type)) return false;
 
 	if (!HasBit(spec->callback_mask, CBM_ROAD_STOP_AVAIL)) return true;
 


### PR DESCRIPTION
## Motivation / Problem

Road stop availability as queried via IsRoadStopAvailable always returned success without evaluating the callback since cdc356e7.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
