### PR TITLE
Fix #12917: Write to negative array index for some string patterns.

### DIFF
--- a/src/3rdparty/icu/CMakeLists.txt
+++ b/src/3rdparty/icu/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(tests)
+
 add_files(
     scriptrun.cpp
     scriptrun.h

--- a/src/3rdparty/icu/scriptrun.cpp
+++ b/src/3rdparty/icu/scriptrun.cpp
@@ -184,13 +184,6 @@ UBool ScriptRun::next()
                     parenStack[++startSP].scriptCode = scriptCode;
                 }
             }
-
-            // if this character is a close paired character,
-            // pop it from the stack
-            if (pairIndex >= 0 && (pairIndex & 1) != 0 && parenSP >= 0) {
-                parenSP -= 1;
-                startSP -= 1;
-            }
         } else {
             // if the run broke on a surrogate pair,
             // end it before the high surrogate

--- a/src/3rdparty/icu/tests/CMakeLists.txt
+++ b/src/3rdparty/icu/tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_test_files(
+    test_srtest.cpp
+    CONDITION ICU_i18n_FOUND
+)

--- a/src/3rdparty/icu/tests/test_srtest.cpp
+++ b/src/3rdparty/icu/tests/test_srtest.cpp
@@ -1,0 +1,64 @@
+// © 2016 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+/*
+ * %W% %E%
+ *
+ * (C) Copyright IBM Corp. 2001-2016 - All Rights Reserved
+ *
+ */
+/** @file test_srtest.cpp Test icu::ScriptRun result. */
+
+#include "../../../3rdparty/catch2/catch.hpp"
+#include "../../../3rdparty/fmt/core.h"
+
+#include "../scriptrun.h"
+
+#include <span>
+#include <unicode/uscript.h>
+
+static void TestScriptRun(std::span<const char16_t> testChars, std::span<const std::string_view> testResults)
+{
+	icu::ScriptRun scriptRun(testChars.data(), 0, std::size(testChars));
+	size_t i = 0;
+
+	while (scriptRun.next()) {
+		int32_t start = scriptRun.getScriptStart();
+		int32_t end = scriptRun.getScriptEnd();
+		UScriptCode code = scriptRun.getScriptCode();
+
+		REQUIRE(i < std::size(testResults));
+		CHECK(fmt::format("Script '{}' from {} to {}.", uscript_getName(code), start, end) == testResults[i]);
+
+		++i;
+	}
+
+	REQUIRE(i == std::size(testResults));
+}
+
+TEST_CASE("ICU ScriptRun")
+{
+	/** Example string sequence as in srtest.cpp. */
+	static const char16_t testChars[] = {
+		0x0020, 0x0946, 0x0939, 0x093F, 0x0928, 0x094D, 0x0926, 0x0940, 0x0020,
+		0x0627, 0x0644, 0x0639, 0x0631, 0x0628, 0x064A, 0x0629, 0x0020,
+		0x0420, 0x0443, 0x0441, 0x0441, 0x043A, 0x0438, 0x0439, 0x0020,
+		'E', 'n', 'g', 'l', 'i', 's', 'h',  0x0020,
+		0x6F22, 0x5B75, 0x3068, 0x3072, 0x3089, 0x304C, 0x306A, 0x3068,
+		0x30AB, 0x30BF, 0x30AB, 0x30CA,
+		0xD801, 0xDC00, 0xD801, 0xDC01, 0xD801, 0xDC02, 0xD801, 0xDC03
+	};
+
+	/** Expected results from script run. */
+	static const std::string_view testResults[] = {
+		"Script 'Devanagari' from 0 to 9.",
+		"Script 'Arabic' from 9 to 17.",
+		"Script 'Cyrillic' from 17 to 25.",
+		"Script 'Latin' from 25 to 33.",
+		"Script 'Han' from 33 to 35.",
+		"Script 'Hiragana' from 35 to 41.",
+		"Script 'Katakana' from 41 to 45.",
+		"Script 'Deseret' from 45 to 53.",
+	};
+
+	TestScriptRun(testChars, testResults);
+}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As per #12917, an out-of-bounds write can occur with some string patterns. In my opinion this is caused by an error in the original https://github.com/unicode-org/icu/blob/main/icu4c/source/extra/scrptrun/scrptrun.cpp.

When encountering a closing pair, the opening pair is popped off the stack.

Then if the script type is unchanged, the already popped opening pair is popped off the stack again.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Don't pop opening pair from the parenthesis stack a second time.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

~~There's no unit tests for this, so not really clear on what the expected results are.~~

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
