### PR TITLE
Fix: Nullptr dereference in GetGameStringPtr when there are no GS strings

### DIFF
--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -319,7 +319,7 @@ GameStrings *_current_data = nullptr;
  */
 const char *GetGameStringPtr(uint id)
 {
-	if (id >= _current_data->cur_language->lines.size()) return GetStringPtr(STR_UNDEFINED);
+	if (_current_data == nullptr || _current_data->cur_language == nullptr || id >= _current_data->cur_language->lines.size()) return GetStringPtr(STR_UNDEFINED);
 	return _current_data->cur_language->lines[id].c_str();
 }
 


### PR DESCRIPTION
## Motivation / Problem

GetGameStringPtr assumes that _current_data is non-nullptr. This is not the case for GSs which have no texts, for example the town growth resetter GS.

Changing the GS to this type of GS when GS texts exist in the game (e.g. the storybook, league table, town windows), results in the below when the GS texts are displayed.

```
Thread 1 "openttd" received signal SIGSEGV, Segmentation fault.
0x0000555555a68d1d in GetGameStringPtr (id=120) at /home/jgr/openttd/trunk/src/game/game_text.cpp:322
322		if (id >= _current_data->cur_language->lines.size()) return GetStringPtr(STR_UNDEFINED);
(gdb) bt
#0  0x0000555555a68d1d in GetGameStringPtr(unsigned int) (id=120) at /home/jgr/openttd/trunk/src/game/game_text.cpp:322
#1  0x000055555605ef6f in GetStringWithArgs(StringBuilder&, unsigned int, StringParameters&, unsigned int, bool) (builder=..., string=<optimised out>, args=..., case_index=1, game_script=<optimised out>)
    at /home/jgr/openttd/trunk/src/strings.cpp:294
#2  0x000055555605d639 in FormatString(StringBuilder&, char const*, StringParameters&, uint, bool, bool) (builder=..., str_arg=<optimised out>, args=..., case_index=0, game_script=false, dry_run=true)
    at /home/jgr/openttd/trunk/src/strings.cpp:1044
#3  0x000055555605b009 in FormatString(StringBuilder&, char const*, StringParameters&, uint, bool, bool) (builder=..., str_arg=<optimised out>, args=..., case_index=0, game_script=false, dry_run=false)
    at /home/jgr/openttd/trunk/src/strings.cpp:935
#4  0x000055555605b8a8 in FormatString(StringBuilder&, char const*, StringParameters&, uint, bool, bool) (builder=..., str_arg=<optimised out>, args=..., case_index=0, game_script=false, dry_run=true)
    at /home/jgr/openttd/trunk/src/strings.cpp:1154
#5  0x000055555605b009 in FormatString(StringBuilder&, char const*, StringParameters&, uint, bool, bool) (builder=..., str_arg=<optimised out>, args=..., case_index=0, game_script=false, dry_run=false)
    at /home/jgr/openttd/trunk/src/strings.cpp:935
#6  0x000055555605f64b in GetStringWithArgs[abi:cxx11](unsigned int, StringParameters&) (args=..., string=4294955088) at /home/jgr/openttd/trunk/src/strings.cpp:343
#7  GetString[abi:cxx11](unsigned int) (string=<optimised out>) at /home/jgr/openttd/trunk/src/strings.cpp:330
#8  0x0000555555de6370 in GetStringBoundingBox(unsigned int, FontSize) (strid=<optimised out>, start_fontsize=start_fontsize@entry=FS_NORMAL) at /home/jgr/openttd/trunk/src/gfx.cpp:865
#9  0x0000555555dfcabf in GoalListWindow::OnPaint() (this=0x5555572949b0) at /home/jgr/openttd/trunk/src/goal_gui.cpp:248
#10 0x000055555613451b in DrawOverlappedWindowForAll(int, int, int, int) (left=left@entry=0, top=top@entry=16, right=right@entry=512, bottom=bottom@entry=140) at /home/jgr/openttd/trunk/src/window.cpp:931
#11 0x0000555555de5320 in RedrawScreenRect(int, int, int, int) (left=0, top=16, right=512, bottom=140) at /home/jgr/openttd/trunk/src/gfx.cpp:1385
#12 0x0000555555de549e in DrawDirtyBlocks() () at /home/jgr/openttd/trunk/src/gfx.cpp:1460
#13 0x0000555556136c83 in UpdateWindows() () at /home/jgr/openttd/trunk/src/window.cpp:3074
#14 0x0000555555cde170 in VideoDriver::Tick() (this=this@entry=0x5555567f0ae0) at /home/jgr/openttd/trunk/src/video/video_driver.cpp:151
#15 0x0000555555cd264e in VideoDriver_SDL_Base::LoopOnce() (this=0x5555567f0ae0) at /home/jgr/openttd/trunk/src/video/sdl2_v.cpp:646
#16 VideoDriver_SDL_Base::LoopOnce() (this=0x5555567f0ae0) at /home/jgr/openttd/trunk/src/video/sdl2_v.cpp:619
#17 VideoDriver_SDL_Base::MainLoop() (this=0x5555567f0ae0) at /home/jgr/openttd/trunk/src/video/sdl2_v.cpp:664
#18 0x0000555555f46b12 in openttd_main(std::span<char* const, 18446744073709551615ul>)Python Exception <class 'gdb.error'>: value has been optimised out
 (arguments=) at /home/jgr/openttd/trunk/src/openttd.cpp:811
#19 0x00007ffff6f81d90 in __libc_start_call_main (main=main@entry=0x555555801170 <main(int, char**)>, argc=argc@entry=2, argv=argv@entry=0x7fffffffdb58) at ../sysdeps/nptl/libc_start_call_main.h:58
#20 0x00007ffff6f81e40 in __libc_start_main_impl (main=0x555555801170 <main(int, char**)>, argc=2, argv=0x7fffffffdb58, init=<optimised out>, fini=<optimised out>, rtld_fini=<optimised out>, stack_end=0x7fffffffdb48)
    at ../csu/libc-start.c:392
#21 0x0000555555879045 in _start ()
```

## Description

Fix the above

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
