### PR TITLE
Codechange: Add AssignBit function to assign the value of a single bit

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -1085,7 +1085,7 @@ CommandCost CmdSetCompanyColour(DoCommandFlag flags, LiveryScheme scheme, bool p
 
 	if (flags & DC_EXEC) {
 		if (primary) {
-			if (scheme != LS_DEFAULT) SB(c->livery[scheme].in_use, 0, 1, colour != INVALID_COLOUR);
+			if (scheme != LS_DEFAULT) AssignBit(c->livery[scheme].in_use, 0, colour != INVALID_COLOUR);
 			if (colour == INVALID_COLOUR) colour = c->livery[LS_DEFAULT].colour1;
 			c->livery[scheme].colour1 = colour;
 
@@ -1098,7 +1098,7 @@ CommandCost CmdSetCompanyColour(DoCommandFlag flags, LiveryScheme scheme, bool p
 				CompanyAdminUpdate(c);
 			}
 		} else {
-			if (scheme != LS_DEFAULT) SB(c->livery[scheme].in_use, 1, 1, colour != INVALID_COLOUR);
+			if (scheme != LS_DEFAULT) AssignBit(c->livery[scheme].in_use, 1, colour != INVALID_COLOUR);
 			if (colour == INVALID_COLOUR) colour = c->livery[LS_DEFAULT].colour2;
 			c->livery[scheme].colour2 = colour;
 

--- a/src/core/bitmath_func.hpp
+++ b/src/core/bitmath_func.hpp
@@ -184,6 +184,25 @@ constexpr T ToggleBit(T &x, const uint8_t y)
 }
 
 /**
+ * Assigns a bit in a variable.
+ *
+ * This function assigns a single bit in a variable. The variable is
+ * changed and the value is also returned. Parameter y defines the bit
+ * to assign and starts at the LSB with 0.
+ *
+ * @param x The variable to assign the bit
+ * @param y The bit position to assign
+ * @param value The new bit value
+ * @pre y < sizeof(T) * 8
+ * @return The new value of the old value with the bit assigned
+ */
+template <typename T>
+constexpr T AssignBit(T &x, const uint8_t y, bool value)
+{
+	return SB<T>(x, y, 1, value ? 1 : 0);
+}
+
+/**
  * Search the first set bit in a value.
  * When no bit is set, it returns 0.
  *

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -987,7 +987,7 @@ CommandCost CmdSetVehicleVisibility(DoCommandFlag flags, EngineID engine_id, boo
 	if (!IsEngineBuildable(e->index, e->type, _current_company)) return CMD_ERROR;
 
 	if ((flags & DC_EXEC) != 0) {
-		SB(e->company_hidden, _current_company, 1, hide ? 1 : 0);
+		AssignBit(e->company_hidden, _current_company, hide);
 		AddRemoveEngineFromAutoreplaceAndBuildWindows(e->type);
 	}
 

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -674,11 +674,11 @@ CommandCost CmdSetGroupLivery(DoCommandFlag flags, GroupID group_id, bool primar
 
 	if (flags & DC_EXEC) {
 		if (primary) {
-			SB(g->livery.in_use, 0, 1, colour != INVALID_COLOUR);
+			AssignBit(g->livery.in_use, 0, colour != INVALID_COLOUR);
 			if (colour == INVALID_COLOUR) colour = GetParentLivery(g)->colour1;
 			g->livery.colour1 = colour;
 		} else {
-			SB(g->livery.in_use, 1, 1, colour != INVALID_COLOUR);
+			AssignBit(g->livery.in_use, 1, colour != INVALID_COLOUR);
 			if (colour == INVALID_COLOUR) colour = GetParentLivery(g)->colour2;
 			g->livery.colour2 = colour;
 		}

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -141,7 +141,7 @@ static void GuiGroupListAddChildren(GUIGroupList &dst, const GUIGroupList &src, 
 	uint16_t level_mask = 0;
 	for (auto it = std::rbegin(dst); std::next(it) != std::rend(dst); ++it) {
 		auto next_it = std::next(it);
-		SB(level_mask, it->indent, 1, it->indent <= next_it->indent);
+		AssignBit(level_mask, it->indent, it->indent <= next_it->indent);
 		next_it->level_mask = level_mask;
 	}
 }

--- a/src/industry_map.h
+++ b/src/industry_map.h
@@ -88,7 +88,7 @@ IndustryType GetIndustryType(Tile tile);
 inline void SetIndustryCompleted(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
-	SB(tile.m1(), 7, 1, 1);
+	SetBit(tile.m1(), 7);
 }
 
 /**

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1793,7 +1793,7 @@ static ChangeInfoResult AircraftVehicleChangeInfo(uint engine, int numinfo, int 
 				break;
 
 			case 0x0A: // Large
-				SB(avi->subtype, 1, 1, (buf.ReadByte() != 0 ? 1 : 0)); // AIR_FAST
+				AssignBit(avi->subtype, 1, buf.ReadByte() != 0); // AIR_FAST
 				break;
 
 			case PROP_AIRCRAFT_COST_FACTOR: // 0x0B Cost factor

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -201,9 +201,9 @@ public:
 	inline uint16_t GetMaxSpeed() const { return this->max_speed; }
 
 	/** Set if the wait time is explicitly timetabled (unless the order is conditional). */
-	inline void SetWaitTimetabled(bool timetabled) { if (!this->IsType(OT_CONDITIONAL)) SB(this->flags, 3, 1, timetabled ? 1 : 0); }
+	inline void SetWaitTimetabled(bool timetabled) { if (!this->IsType(OT_CONDITIONAL)) AssignBit(this->flags, 3, timetabled); }
 	/** Set if the travel time is explicitly timetabled (unless the order is conditional). */
-	inline void SetTravelTimetabled(bool timetabled) { if (!this->IsType(OT_CONDITIONAL)) SB(this->flags, 7, 1, timetabled ? 1 : 0); }
+	inline void SetTravelTimetabled(bool timetabled) { if (!this->IsType(OT_CONDITIONAL)) AssignBit(this->flags, 7, timetabled); }
 
 	/**
 	 * Set the time in ticks to wait at the destination.

--- a/src/rail_map.h
+++ b/src/rail_map.h
@@ -83,7 +83,7 @@ inline bool HasSignals(Tile t)
 inline void SetHasSignals(Tile tile, bool signals)
 {
 	assert(IsPlainRailTile(tile));
-	SB(tile.m5(), 6, 1, signals);
+	AssignBit(tile.m5(), 6, signals);
 }
 
 /**
@@ -213,7 +213,7 @@ inline void SetTrackReservation(Tile t, TrackBits b)
 	assert(!TracksOverlap(b));
 	Track track = RemoveFirstTrack(&b);
 	SB(t.m2(), 8, 3, track == INVALID_TRACK ? 0 : track + 1);
-	SB(t.m2(), 11, 1, (uint8_t)(b != TRACK_BIT_NONE));
+	AssignBit(t.m2(), 11, b != TRACK_BIT_NONE);
 }
 
 /**
@@ -270,7 +270,7 @@ inline bool HasDepotReservation(Tile t)
 inline void SetDepotReservation(Tile t, bool b)
 {
 	assert(IsRailDepot(t));
-	SB(t.m5(), 4, 1, (uint8_t)b);
+	AssignBit(t.m5(), 4, b);
 }
 
 /**

--- a/src/road_map.h
+++ b/src/road_map.h
@@ -393,7 +393,7 @@ inline bool HasCrossingReservation(Tile t)
 inline void SetCrossingReservation(Tile t, bool b)
 {
 	assert(IsLevelCrossingTile(t));
-	SB(t.m5(), 4, 1, b ? 1 : 0);
+	AssignBit(t.m5(), 4, b);
 }
 
 /**
@@ -428,7 +428,7 @@ inline bool IsCrossingBarred(Tile t)
 inline void SetCrossingBarred(Tile t, bool barred)
 {
 	assert(IsLevelCrossing(t));
-	SB(t.m5(), 5, 1, barred ? 1 : 0);
+	AssignBit(t.m5(), 5, barred);
 }
 
 /**

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1512,7 +1512,7 @@ bool AfterLoadGame()
 				} else {
 					/* The "lift has destination" bit has been moved from
 					 * m5[7] to m7[0]. */
-					SB(t.m7(), 0, 1, HasBit(t.m5(), 7));
+					AssignBit(t.m7(), 0, HasBit(t.m5(), 7));
 					ClrBit(t.m5(), 7);
 
 					/* The "lift is moving" bit has been removed, as it does

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -723,8 +723,8 @@ static bool LoadOldGood(LoadgameState *ls, int num)
 
 	if (!LoadChunk(ls, ge, goods_chunk)) return false;
 
-	SB(ge->status, GoodsEntry::GES_ACCEPTANCE, 1, HasBit(_waiting_acceptance, 15));
-	SB(ge->status, GoodsEntry::GES_RATING, 1, _cargo_source != 0xFF);
+	AssignBit(ge->status, GoodsEntry::GES_ACCEPTANCE, HasBit(_waiting_acceptance, 15));
+	AssignBit(ge->status, GoodsEntry::GES_RATING, _cargo_source != 0xFF);
 	if (GB(_waiting_acceptance, 0, 12) != 0 && CargoPacket::CanAllocateItem()) {
 		ge->cargo.Append(new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, (_cargo_source == 0xFF) ? INVALID_STATION : _cargo_source, INVALID_TILE, 0),
 				INVALID_STATION);

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -414,7 +414,7 @@ public:
 					/* Don't construct the packet with station here, because that'll fail with old savegames */
 					CargoPacket *cp = new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, source, _cargo_source_xy, _cargo_feeder_share);
 					ge.cargo.Append(cp, INVALID_STATION);
-					SB(ge.status, GoodsEntry::GES_RATING, 1, 1);
+					SetBit(ge.status, GoodsEntry::GES_RATING);
 				}
 			}
 		}

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -400,7 +400,7 @@ public:
 				SwapPackets(&ge);
 			}
 			if (IsSavegameVersionBefore(SLV_68)) {
-				SB(ge.status, GoodsEntry::GES_ACCEPTANCE, 1, HasBit(_waiting_acceptance, 15));
+				AssignBit(ge.status, GoodsEntry::GES_ACCEPTANCE, HasBit(_waiting_acceptance, 15));
 				if (GB(_waiting_acceptance, 0, 12) != 0) {
 					/* In old versions, enroute_from used 0xFF as INVALID_STATION */
 					StationID source = (IsSavegameVersionBefore(SLV_7) && _cargo_source == 0xFF) ? INVALID_STATION : _cargo_source;

--- a/src/station_map.h
+++ b/src/station_map.h
@@ -436,7 +436,7 @@ inline bool IsStationTileBlocked(Tile t)
 inline void SetStationTileBlocked(Tile t, bool b)
 {
 	assert(HasStationRail(t));
-	SB(t.m6(), 0, 1, b ? 1 : 0);
+	AssignBit(t.m6(), 0, b);
 }
 
 /**
@@ -460,7 +460,7 @@ inline bool CanStationTileHaveWires(Tile t)
 inline void SetStationTileHaveWires(Tile t, bool b)
 {
 	assert(HasStationRail(t));
-	SB(t.m6(), 1, 1, b ? 1 : 0);
+	AssignBit(t.m6(), 1, b);
 }
 
 /**
@@ -484,7 +484,7 @@ inline bool CanStationTileHavePylons(Tile t)
 inline void SetStationTileHavePylons(Tile t, bool b)
 {
 	assert(HasStationRail(t));
-	SB(t.m6(), 7, 1, b ? 1 : 0);
+	AssignBit(t.m6(), 7, b);
 }
 
 /**
@@ -564,7 +564,7 @@ inline bool HasStationReservation(Tile t)
 inline void SetRailStationReservation(Tile t, bool b)
 {
 	assert(HasStationRail(t));
-	SB(t.m6(), 2, 1, b ? 1 : 0);
+	AssignBit(t.m6(), 2, b);
 }
 
 /**

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -2630,7 +2630,7 @@ public:
 		this->v->current_order = this->old_order;
 		this->v->dest_tile = this->old_dest_tile;
 		this->v->last_station_visited = this->old_last_station_visited;
-		SB(this->v->gv_flags, GVF_SUPPRESS_IMPLICIT_ORDERS, 1, suppress_implicit_orders ? 1: 0);
+		AssignBit(this->v->gv_flags, GVF_SUPPRESS_IMPLICIT_ORDERS, suppress_implicit_orders);
 		this->restored = true;
 	}
 

--- a/src/tunnelbridge_map.h
+++ b/src/tunnelbridge_map.h
@@ -105,7 +105,7 @@ inline void SetTunnelBridgeReservation(Tile t, bool b)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
 	assert(GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL);
-	SB(t.m5(), 4, 1, b ? 1 : 0);
+	AssignBit(t.m5(), 4, b);
 }
 
 /**

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -825,9 +825,9 @@ public:
 
 	inline bool ServiceIntervalIsPercent() const { return HasBit(this->vehicle_flags, VF_SERVINT_IS_PERCENT); }
 
-	inline void SetServiceIntervalIsCustom(bool on) { SB(this->vehicle_flags, VF_SERVINT_IS_CUSTOM, 1, on); }
+	inline void SetServiceIntervalIsCustom(bool on) { AssignBit(this->vehicle_flags, VF_SERVINT_IS_CUSTOM, on); }
 
-	inline void SetServiceIntervalIsPercent(bool on) { SB(this->vehicle_flags, VF_SERVINT_IS_PERCENT, 1, on); }
+	inline void SetServiceIntervalIsPercent(bool on) { AssignBit(this->vehicle_flags, VF_SERVINT_IS_PERCENT, on); }
 
 	bool HasFullLoadOrder() const;
 	bool HasConditionalOrder() const;

--- a/src/water_map.h
+++ b/src/water_map.h
@@ -364,7 +364,7 @@ inline bool HasTileWaterGround(Tile t)
 inline void SetDockingTile(Tile t, bool b)
 {
 	assert(IsTileType(t, MP_WATER) || IsTileType(t, MP_RAILWAY) || IsTileType(t, MP_STATION) || IsTileType(t, MP_TUNNELBRIDGE));
-	SB(t.m1(), 7, 1, b ? 1 : 0);
+	AssignBit(t.m1(), 7, b);
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

The current pattern to assign the value of a bit is: `SB(value, bit_number, 1, bit_value ? 1 : 0)`.
This has more visual clutter than necessary. The `? 1 : 0` part is not always consistently applied.
It also lacks symmetry with the other functions used for the same bits: `HasBit`, `SetBit`, `ClrBit`, `ToggleBit`.

## Description

Add an `AssignBit` function to assign the value of a single bit.
Replace applicable uses of `SB`.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
