### PR TITLE
Fix #12945: Relative paths passed to -c were not made absolute on non-Windows

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -822,11 +822,11 @@ void DetermineBasePaths(const char *exe)
 		if (end == std::string::npos) {
 			/* _config_file is not in a folder, so use current directory. */
 			tmp = cwd;
-			AppendPathSeparator(tmp);
-			_searchpaths[SP_WORKING_DIR] = tmp;
 		} else {
-			_searchpaths[SP_WORKING_DIR] = _config_file.substr(0, end + 1);
+			tmp = FS2OTTD(std::filesystem::weakly_canonical(std::filesystem::path(OTTD2FS(_config_file))).parent_path());
 		}
+		AppendPathSeparator(tmp);
+		_searchpaths[SP_WORKING_DIR] = tmp;
 	}
 
 	/* Change the working directory to that one of the executable */


### PR DESCRIPTION
## Motivation / Problem

#12945

## Description

Non-Windows:
Make paths passed to the -c switch absolute and with `.`, `..` segments removed by means of `std::filesystem::weakly_canonical`.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
