### PR TITLE
Change: Exclude parent item from directory sort in FiosGetFileList

### DIFF
--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -326,7 +326,7 @@ bool FiosFileScanner::AddFile(const std::string &filename, size_t, const std::st
  */
 static void FiosGetFileList(SaveLoadOperation fop, bool show_dirs, FiosGetTypeAndNameProc *callback_proc, Subdirectory subdir, FileList &file_list)
 {
-	size_t sort_start;
+	size_t sort_start = 0;
 
 	file_list.clear();
 
@@ -341,6 +341,7 @@ static void FiosGetFileList(SaveLoadOperation fop, bool show_dirs, FiosGetTypeAn
 			fios.name = "..";
 			SetDParamStr(0, "..");
 			fios.title = GetString(STR_SAVELOAD_PARENT_DIRECTORY);
+			sort_start = file_list.size();
 		}
 
 		/* Show subdirectories */
@@ -360,7 +361,7 @@ static void FiosGetFileList(SaveLoadOperation fop, bool show_dirs, FiosGetTypeAn
 		/* Sort the subdirs always by name, ascending, remember user-sorting order */
 		SortingBits order = _savegame_sort_order;
 		_savegame_sort_order = SORT_BY_NAME | SORT_ASCENDING;
-		std::sort(file_list.begin(), file_list.end());
+		std::sort(file_list.begin() + sort_start, file_list.end());
 		_savegame_sort_order = order;
 	}
 


### PR DESCRIPTION
## Motivation / Problem

The parent directory entry `..` was included in the directory sort in FiosGetFileList.
This resulted in it being sorted below directories starting with a `_`, for example.

## Description

Exclude the parent directory entry from the sort so that it always remains the first entry in the list/window.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
