### PR TITLE
Fix: Crash when pressing arrow keys in bootstrap mode

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2761,8 +2761,10 @@ static void HandleKeyScrolling()
 	if (_dirkeys && !EditBoxInGlobalFocus()) {
 		int factor = _shift_pressed ? 50 : 10;
 
-		/* Key scrolling stops following a vehicle. */
-		GetMainWindow()->viewport->follow_vehicle = INVALID_VEHICLE;
+		if (_game_mode != GM_MENU && _game_mode != GM_BOOTSTRAP) {
+			/* Key scrolling stops following a vehicle. */
+			GetMainWindow()->viewport->follow_vehicle = INVALID_VEHICLE;
+		}
 
 		ScrollMainViewport(scrollamt[_dirkeys][0] * factor, scrollamt[_dirkeys][1] * factor);
 	}


### PR DESCRIPTION
## Motivation / Problem

A crash occurs when pressing the arrow keys in bootstrap mode due to #12808.
GetMainWindow() is only usable when a main window is present.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
