### PR TITLE
Codefix: Debug fmt strings in ItemizeBidi (ICU layout)

### DIFF
--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -256,14 +256,14 @@ std::vector<ICURun> ItemizeBidi(UChar *buff, size_t length)
 	UErrorCode err = U_ZERO_ERROR;
 	ubidi_setPara(ubidi, buff, length, parLevel, nullptr, &err);
 	if (U_FAILURE(err)) {
-		Debug(fontcache, 0, "Failed to set paragraph: %s", u_errorName(err));
+		Debug(fontcache, 0, "Failed to set paragraph: {}", u_errorName(err));
 		ubidi_close(ubidi);
 		return std::vector<ICURun>();
 	}
 
 	int32_t count = ubidi_countRuns(ubidi, &err);
 	if (U_FAILURE(err)) {
-		Debug(fontcache, 0, "Failed to count runs: %s", u_errorName(err));
+		Debug(fontcache, 0, "Failed to count runs: {}", u_errorName(err));
 		ubidi_close(ubidi);
 		return std::vector<ICURun>();
 	}


### PR DESCRIPTION
## Motivation / Problem

Some format specifiers in ItemizeBidi (ICU layout) were not converted when moving from printf to fmt syntax.

## Description

Fix the above.
I've been doing some experiments to find this automatically: https://github.com/JGRennison/OpenTTD-patches/commit/f13c2c03583866822ffe9e45a2a85030963243b0.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
