### PR TITLE
Fix #8932: Changed Max Loan in Settings From Currency Value to Percentage

### DIFF
--- a/src/company_base.h
+++ b/src/company_base.h
@@ -195,7 +195,7 @@ struct Company : CompanyProperties, CompanyPool::PoolItem<&_company_pool> {
 */
 inline uint32_t GetMaxLoanFromPercentage()
 {
- 	return ((_settings_game.difficulty.max_loan_percentage / 100) * 300000) * GetCurrency().rate; 
+ 	return ((_settings_game.difficulty.max_loan_percentage / 100) * (300000 * GetCurrency().rate)); 
 }
 
 

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -17,6 +17,7 @@
 #include "timer/timer_game_economy.h"
 #include "settings_type.h"
 #include "group.h"
+#include "currency.h"
 
 static const Money COMPANY_MAX_LOAN_DEFAULT = INT64_MIN;
 
@@ -188,6 +189,15 @@ struct Company : CompanyProperties, CompanyPool::PoolItem<&_company_pool> {
 
 	static void PostDestructor(size_t index);
 };
+
+/**
+* Function to get the max loan from the saved percentage in the settings (inline makes it avoid many unwanted errors)
+*/
+inline uint32_t GetMaxLoanFromPercentage()
+{
+ 	return ((_settings_game.difficulty.max_loan_percentage / 100) * 300000) * GetCurrency().rate; 
+}
+
 
 Money CalculateCompanyValue(const Company *c, bool including_loan = true);
 Money CalculateHostileTakeoverValue(const Company *c);

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -33,6 +33,7 @@
 #include "sound_func.h"
 #include "autoreplace_func.h"
 #include "company_gui.h"
+#include "company_base.h"
 #include "signs_base.h"
 #include "subsidy_base.h"
 #include "subsidy_func.h"
@@ -762,7 +763,7 @@ bool AddInflation(bool check_year)
 void RecomputePrices()
 {
 	/* Setup maximum loan as a rounded down multiple of LOAN_INTERVAL. */
-	_economy.max_loan = ((uint64_t)_settings_game.difficulty.max_loan * _economy.inflation_prices >> 16) / LOAN_INTERVAL * LOAN_INTERVAL;
+	_economy.max_loan = ((uint64_t)GetMaxLoanFromPercentage() * _economy.inflation_prices >> 16) / LOAN_INTERVAL * LOAN_INTERVAL;
 
 	/* Setup price bases */
 	for (Price i = PR_BEGIN; i < PR_END; i++) {

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1273,9 +1273,9 @@ STR_CONFIG_SETTING_SECONDS_VALUE                                :{COMMA}{NBSP}se
 STR_CONFIG_SETTING_INFINITE_MONEY                               :Infinite money: {STRING2}
 STR_CONFIG_SETTING_INFINITE_MONEY_HELPTEXT                      :Allow unlimited spending and disable bankruptcy of companies
 
-STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN                         :Maximum initial loan: {STRING2}
-STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_HELPTEXT                :Maximum amount a company can loan (without taking inflation into account). If set to "No loan", no money will be available unless provided by a Game Script or the "Infinite money" setting
-STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_VALUE                   :{CURRENCY_LONG}
+STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN                         :Maximum initial loan percentage: {STRING2}
+STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_HELPTEXT                :Maximum percentage a company can loan. If set to "No loan", no money will be available unless provided by a Game Script or the "Infinite money" setting
+STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_VALUE                   :{NUM}%
 ###setting-zero-is-special
 STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_DISABLED                :No loan
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1274,7 +1274,7 @@ STR_CONFIG_SETTING_INFINITE_MONEY                               :Infinite money:
 STR_CONFIG_SETTING_INFINITE_MONEY_HELPTEXT                      :Allow unlimited spending and disable bankruptcy of companies
 
 STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN                         :Maximum initial loan percentage: {STRING2}
-STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_HELPTEXT                :Maximum percentage a company can loan. If set to "No loan", no money will be available unless provided by a Game Script or the "Infinite money" setting
+STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_HELPTEXT                :Sets the maximum loan a company can loan. Default maximum loan is at 100%. If set to "No loan", no money will be available unless provided by a Game Script or the "Infinite money" setting
 STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_VALUE                   :{NUM}%
 ###setting-zero-is-special
 STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_DISABLED                :No loan

--- a/src/lang/english_US.txt
+++ b/src/lang/english_US.txt
@@ -1273,9 +1273,9 @@ STR_CONFIG_SETTING_SECONDS_VALUE                                :{COMMA}{NBSP}se
 STR_CONFIG_SETTING_INFINITE_MONEY                               :Infinite money: {STRING}
 STR_CONFIG_SETTING_INFINITE_MONEY_HELPTEXT                      :Allow unlimited spending and disable bankruptcy of companies
 
-STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN                         :Maximum initial loan: {STRING}
-STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_HELPTEXT                :Maximum amount a company can loan (without taking inflation into account). If set to "No loan", no money will be available unless provided by a Game Script or the "Infinite money" setting
-STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_VALUE                   :{CURRENCY_LONG}
+STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN                         :Maximum initial loan percentage: {STRING}
+STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_HELPTEXT                :Sets the maximum loan a company can loan. Default maximum loan is at 100%. If set to "No loan", no money will be available unless provided by a Game Script or the "Infinite money" setting
+STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_VALUE                   :{NUM}%
 ###setting-zero-is-special
 STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_DISABLED                :No loan
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -62,6 +62,7 @@
 #include "../timer/timer_game_calendar.h"
 #include "../timer/timer_game_economy.h"
 #include "../timer/timer_game_tick.h"
+#include "../company_base.h"
 
 #include "saveload_internal.h"
 
@@ -2293,7 +2294,7 @@ bool AfterLoadGame()
 		 *       So taking the 16 bit fractional part into account there are plenty of bits left
 		 *       for unmodified savegames ...
 		 */
-		uint64_t aimed_inflation = (_economy.old_max_loan_unround << 16 | _economy.old_max_loan_unround_fract) / _settings_game.difficulty.max_loan;
+		uint64_t aimed_inflation = (_economy.old_max_loan_unround << 16 | _economy.old_max_loan_unround_fract) / GetMaxLoanFromPercentage();
 
 		/* ... well, just clamp it then. */
 		if (aimed_inflation > MAX_INFLATION) aimed_inflation = MAX_INFLATION;

--- a/src/saveload/compat/settings_sl_compat.h
+++ b/src/saveload/compat/settings_sl_compat.h
@@ -32,7 +32,7 @@ const SaveLoadCompat _settings_sl_compat[] = {
 	SLC_NULL(1, SLV_97, SLV_110),
 	SLC_VAR("difficulty.number_towns"),
 	SLC_VAR("difficulty.industry_density"),
-	SLC_VAR("difficulty.max_loan"),
+	SLC_VAR("difficulty.max_loan_percentage"),
 	SLC_VAR("difficulty.initial_interest"),
 	SLC_VAR("difficulty.vehicle_costs"),
 	SLC_VAR("difficulty.competitor_speed"),

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -1471,7 +1471,7 @@ static const OldChunks game_difficulty_chunk[] = {
 	OCL_NULL( 2), // competitor_start_time
 	OCL_SVAR( OC_FILE_U16 |  OC_VAR_U8, DifficultySettings, number_towns ),
 	OCL_SVAR( OC_FILE_U16 |  OC_VAR_U8, DifficultySettings, industry_density ),
-	OCL_SVAR( OC_FILE_U16 | OC_VAR_U32, DifficultySettings, max_loan ),
+	OCL_SVAR( OC_FILE_U16 | OC_VAR_U32, DifficultySettings, max_loan_percentage ),
 	OCL_SVAR( OC_FILE_U16 |  OC_VAR_U8, DifficultySettings, initial_interest ),
 	OCL_SVAR( OC_FILE_U16 |  OC_VAR_U8, DifficultySettings, vehicle_costs ),
 	OCL_SVAR( OC_FILE_U16 |  OC_VAR_U8, DifficultySettings, competitor_speed ),
@@ -1490,7 +1490,7 @@ static const OldChunks game_difficulty_chunk[] = {
 static bool LoadOldGameDifficulty(LoadgameState *ls, int)
 {
 	bool ret = LoadChunk(ls, &_settings_game.difficulty, game_difficulty_chunk);
-	_settings_game.difficulty.max_loan *= 1000;
+	_settings_game.difficulty.max_loan_percentage *= 1000;
 	return ret;
 }
 

--- a/src/saveload/settings_sl.cpp
+++ b/src/saveload/settings_sl.cpp
@@ -63,7 +63,7 @@ void HandleOldDiffCustom(bool savegame)
 			continue;
 		}
 
-		int32_t value = (int32_t)((name == "max_loan" ? 1000 : 1) * _old_diff_custom[i++]);
+		int32_t value = (int32_t)((name == "max_loan_percentage" ? 1000 : 1) * _old_diff_custom[i++]);
 		sd->AsIntSetting()->MakeValueValidAndWrite(savegame ? &_settings_game : &_settings_newgame, value);
 	}
 }

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2104,7 +2104,7 @@ static SettingsContainer &GetSettingsTree()
 			accounting->Add(new SettingEntry("difficulty.infinite_money"));
 			accounting->Add(new SettingEntry("economy.inflation"));
 			accounting->Add(new SettingEntry("difficulty.initial_interest"));
-			accounting->Add(new SettingEntry("difficulty.max_loan"));
+			accounting->Add(new SettingEntry("difficulty.max_loan_percentage"));
 			accounting->Add(new SettingEntry("difficulty.subsidy_multiplier"));
 			accounting->Add(new SettingEntry("difficulty.subsidy_duration"));
 			accounting->Add(new SettingEntry("economy.feeder_payment_share"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -101,6 +101,7 @@ struct DifficultySettings {
 	uint8_t number_towns;                     ///< the amount of towns
 	uint8_t industry_density;                 ///< The industry density. @see IndustryDensity
 	uint32_t max_loan;                         ///< the maximum initial loan
+	uint32_t max_loan_percentage;		   ///< the percentage increase/decrease of the default maximum intial loan
 	uint8_t initial_interest;                 ///< amount of interest (to pay over the loan)
 	uint8_t vehicle_costs;                    ///< amount of money spent on vehicle running cost
 	uint8_t competitor_speed;                 ///< the speed at which the AI builds

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -100,8 +100,7 @@ struct DifficultySettings {
 	uint16_t competitors_interval;             ///< the interval (in minutes) between adding competitors
 	uint8_t number_towns;                     ///< the amount of towns
 	uint8_t industry_density;                 ///< The industry density. @see IndustryDensity
-	uint32_t max_loan;                         ///< the maximum initial loan
-	uint32_t max_loan_percentage;		   ///< the percentage increase/decrease of the default maximum intial loan
+	uint32_t max_loan_percentage;		   ///< the percentage of the maximum intial loan
 	uint8_t initial_interest;                 ///< amount of interest (to pay over the loan)
 	uint8_t vehicle_costs;                    ///< amount of money spent on vehicle running cost
 	uint8_t competitor_speed;                 ///< the speed at which the AI builds
@@ -637,5 +636,6 @@ inline GameSettings &GetGameSettings()
 {
 	return (_game_mode == GM_MENU) ? _settings_newgame : _settings_game;
 }
+
 
 #endif /* SETTINGS_TYPE_H */

--- a/src/table/settings/difficulty_settings.ini
+++ b/src/table/settings/difficulty_settings.ini
@@ -111,11 +111,10 @@ type     = SLE_UINT32
 from     = SLV_97
 flags    = SF_NEWGAME_ONLY | SF_SCENEDIT_TOO | SF_GUI_0_IS_SPECIAL
 def      = 100
-min      = 10
+min      = 100
 max      = 6000000
 pre_cb   = [](auto &new_value) { new_value = (new_value + 10 / 2) / 10 * 10; return true; }
-post_cb  = [](auto) { _settings_game.difficulty.max_loan = ((_settings_game.difficulty.max_loan_percentage/100)* 300000) * GetCurrency().rate;}
-interval = 10
+interval = 100
 str      = STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN
 strhelp  = STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_HELPTEXT
 strval   = STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_VALUE

--- a/src/table/settings/difficulty_settings.ini
+++ b/src/table/settings/difficulty_settings.ini
@@ -114,7 +114,7 @@ def      = 100
 min      = 10
 max      = 6000000
 pre_cb   = [](auto &new_value) { new_value = (new_value + 10 / 2) / 10 * 10; return true; }
-post_cb  = [](auto &new_value) { difficulity.max_loan = ((new_value/100)* 300000) * GetCurrency().rate; return true;}
+post_cb  = [](auto) { _settings_game.difficulty.max_loan = ((_settings_game.difficulty.max_loan_percentage/100)* 300000) * GetCurrency().rate;}
 interval = 10
 str      = STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN
 strhelp  = STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_HELPTEXT

--- a/src/table/settings/difficulty_settings.ini
+++ b/src/table/settings/difficulty_settings.ini
@@ -113,7 +113,7 @@ flags    = SF_NEWGAME_ONLY | SF_SCENEDIT_TOO | SF_GUI_0_IS_SPECIAL
 def      = 100
 min      = 100
 max      = 6000000
-pre_cb   = [](auto &new_value) { new_value = (new_value + 10 / 2) / 10 * 10; return true; }
+pre_cb   = [](auto &new_value) { new_value = (new_value + 100 / 2) / 100 * 100; return true; }
 interval = 100
 str      = STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN
 strhelp  = STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_HELPTEXT

--- a/src/table/settings/difficulty_settings.ini
+++ b/src/table/settings/difficulty_settings.ini
@@ -8,7 +8,7 @@
 ; and in the savegame PATS chunk.
 
 [pre-amble]
-const std::array<std::string, GAME_DIFFICULTY_NUM> _old_diff_settings{"max_no_competitors", "competitor_start_time", "number_towns", "industry_density", "max_loan", "initial_interest", "vehicle_costs", "competitor_speed", "competitor_intelligence", "vehicle_breakdowns", "subsidy_multiplier", "construction_cost", "terrain_type", "quantity_sea_lakes", "economy", "line_reverse_mode", "disasters", "town_council_tolerance"};
+const std::array<std::string, GAME_DIFFICULTY_NUM> _old_diff_settings{"max_no_competitors", "competitor_start_time", "number_towns", "industry_density", "max_loan_percentage", "initial_interest", "vehicle_costs", "competitor_speed", "competitor_intelligence", "vehicle_breakdowns", "subsidy_multiplier", "construction_cost", "terrain_type", "quantity_sea_lakes", "economy", "line_reverse_mode", "disasters", "town_council_tolerance"};
 
 uint16_t _old_diff_custom[GAME_DIFFICULTY_NUM];
 uint8_t _old_diff_level;                                 ///< Old difficulty level from old savegames
@@ -106,15 +106,16 @@ strval   = STR_FUNDING_ONLY
 cat      = SC_BASIC
 
 [SDT_VAR]
-var      = difficulty.max_loan
+var      = difficulty.max_loan_percentage
 type     = SLE_UINT32
 from     = SLV_97
-flags    = SF_NEWGAME_ONLY | SF_SCENEDIT_TOO | SF_GUI_CURRENCY | SF_GUI_0_IS_SPECIAL
-def      = 300000
-min      = LOAN_INTERVAL
-max      = MAX_LOAN_LIMIT
-pre_cb   = [](auto &new_value) { new_value = (new_value + LOAN_INTERVAL / 2) / LOAN_INTERVAL * LOAN_INTERVAL; return true; }
-interval = LOAN_INTERVAL
+flags    = SF_NEWGAME_ONLY | SF_SCENEDIT_TOO | SF_GUI_0_IS_SPECIAL
+def      = 100
+min      = 10
+max      = 6000000
+pre_cb   = [](auto &new_value) { new_value = (new_value + 10 / 2) / 10 * 10; return true; }
+post_cb  = [](auto &new_value) { difficulity.max_loan = ((new_value/100)* 300000) * GetCurrency().rate; return true;}
+interval = 10
 str      = STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN
 strhelp  = STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_HELPTEXT
 strval   = STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_VALUE


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
As described in issue #8932, the value of maximum allowed loan in the settings wasn't the actual maximum loan in the game, since, with inflation enabled, that value can be different. There was a need to make it easier for the players to decide on a still value and not be surprised by a different value than what they set in the settings.
This issue seem to have appeared after the inflation change in #7589 

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
The solution , as [suggested](https://github.com/OpenTTD/OpenTTD/issues/8932#issuecomment-812704199) by @LordAro ,  was to have the setting allow the player to set the maximum value as a percentage instead of a currency value. Which is a better and simpler way for the player to decide to what extent they wish to increase the maximum loan in regards to whatever value the game's default is. And removes complication to why the value changes with inflation on.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

- The setting only allows changing the percentage in intervals of 100%, and does not allow any percentages in between (someone can change this to allow more specific percentages or intervals)
- The limit of percentage allowed in the setting is 6000000 (approximate to the normal currency limit)

Note:
- 100% is currently equal to 300,000 British pounds 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
