### PR TITLE
Change: Also add OnNewEconomyDay vehicle performance measurements to the frame rate statistics

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -454,6 +454,9 @@ void Aircraft::OnNewCalendarDay()
 void Aircraft::OnNewEconomyDay()
 {
 	if (!this->IsNormalAircraft()) return;
+
+	PerformanceAccumulator framerate(PFE_GL_AIRCRAFT);
+
 	EconomyAgeVehicle(this);
 
 	if ((++this->day_counter & 7) == 0) DecreaseVehicleValue(this);

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -1722,6 +1722,9 @@ void RoadVehicle::OnNewCalendarDay()
 void RoadVehicle::OnNewEconomyDay()
 {
 	if (!this->IsFrontEngine()) return;
+
+	PerformanceAccumulator framerate(PFE_GL_ROADVEHS);
+
 	EconomyAgeVehicle(this);
 
 	if ((++this->day_counter & 7) == 0) DecreaseVehicleValue(this);

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -259,6 +259,8 @@ void Ship::OnNewCalendarDay()
 /** Economy day handler. */
 void Ship::OnNewEconomyDay()
 {
+	PerformanceAccumulator framerate(PFE_GL_SHIPS);
+
 	EconomyAgeVehicle(this);
 
 	if ((++this->day_counter & 7) == 0) {

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -4166,6 +4166,8 @@ void Train::OnNewCalendarDay()
 /** Economy day handler. */
 void Train::OnNewEconomyDay()
 {
+	PerformanceAccumulator framerate(PFE_GL_TRAINS);
+
 	EconomyAgeVehicle(this);
 
 	if ((++this->day_counter & 7) == 0) DecreaseVehicleValue(this);

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -955,16 +955,17 @@ void CallVehicleTicks()
 {
 	_vehicles_to_autoreplace.clear();
 
+	PerformanceAccumulator::Reset(PFE_GL_TRAINS);
+	PerformanceAccumulator::Reset(PFE_GL_ROADVEHS);
+	PerformanceAccumulator::Reset(PFE_GL_SHIPS);
+	PerformanceAccumulator::Reset(PFE_GL_AIRCRAFT);
+
 	RunEconomyVehicleDayProc();
 
 	{
 		PerformanceMeasurer framerate(PFE_GL_ECONOMY);
 		for (Station *st : Station::Iterate()) LoadUnloadStation(st);
 	}
-	PerformanceAccumulator::Reset(PFE_GL_TRAINS);
-	PerformanceAccumulator::Reset(PFE_GL_ROADVEHS);
-	PerformanceAccumulator::Reset(PFE_GL_SHIPS);
-	PerformanceAccumulator::Reset(PFE_GL_AIRCRAFT);
 
 	for (Vehicle *v : Vehicle::Iterate()) {
 		[[maybe_unused]] VehicleID vehicle_index = v->index;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
While testing `CheckIfShipNeedsServicing`, I noticed the performance measurement wasn't being accounted in the "Ship ticks" category of the framerate window. Turns out this is simply because `CheckIfShipNeedsServicing ` is done on `v->OnNewEconomyDay()` and not on `v->Tick()` and the PerformanceAccumulator only accounts for `v->Tick()`.

Before: ![Unnamed, 1989-12-10](https://github.com/user-attachments/assets/bdd9127c-3437-4612-8372-5be27cf4ae51)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Also add `v->OnNewEconomyDay()` vehicle performance measurements to the frame rate statistics.

It's done for every vehicle type.
After: 
![Unnamed, 1989-12-06#1](https://github.com/user-attachments/assets/18ce854a-3cb1-495b-94a1-b74301aed0f9)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
I did not edit the strings. It still says "Ship ticks", "Aircraft ticks"... but changing that to "Ship ticks and on new economy day" just to be technically accurate isn't worth it, I think.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
