### PR TITLE
Codefix f481c9fc: Incorrect references to previous items in DumpTarget

### DIFF
--- a/src/misc/dbg_helpers.h
+++ b/src/misc/dbg_helpers.h
@@ -156,7 +156,7 @@ struct DumpTarget {
 		std::string known_as;
 		if (FindKnownName(type_id, s, known_as)) {
 			/* We already know this one, no need to dump it. */
-			std::string known_as_str = std::string("known_as.") + name;
+			std::string known_as_str = std::string("known_as.") + known_as;
 			WriteValue(name, known_as_str);
 		} else {
 			/* Still unknown, dump it */
@@ -179,7 +179,7 @@ struct DumpTarget {
 		std::string known_as;
 		if (FindKnownName(type_id, s, known_as)) {
 			/* We already know this one, no need to dump it. */
-			std::string known_as_str = std::string("known_as.") + name;
+			std::string known_as_str = std::string("known_as.") + known_as;
 			WriteValue(name, known_as_str);
 		} else {
 			/* Still unknown, dump it */


### PR DESCRIPTION
## Motivation / Problem

References to previously output nodes in DumpTarget output were incorrect since f481c9fc.
The output could not be used to identify which of the previously output nodes was the one being referenced.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
