### PR TITLE
Codechange: Remove redundant NewsStringData data.

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2207,10 +2207,8 @@ CommandCost CmdIndustrySetProduction(DoCommandFlag flags, IndustryID ind_id, uin
 			}
 
 			/* Set parameters of news string */
-			NewsAllocatedData *data = nullptr;
 			if (str == STR_NEWS_CUSTOM_ITEM) {
-				NewsStringData *news = new NewsStringData(custom_news);
-				SetDParamStr(0, news->string);
+				SetDParamStr(0, custom_news);
 			} else if (str > STR_LAST_STRINGID) {
 				SetDParam(0, STR_TOWN_NAME);
 				SetDParam(1, ind->town->index);
@@ -2218,7 +2216,7 @@ CommandCost CmdIndustrySetProduction(DoCommandFlag flags, IndustryID ind_id, uin
 			} else {
 				SetDParam(0, ind->index);
 			}
-			AddIndustryNewsItem(str, nt, ind->index, data);
+			AddIndustryNewsItem(str, nt, ind->index);
 		}
 	}
 

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -33,6 +33,7 @@
 #include "group_gui.h"
 #include "zoom_func.h"
 #include "news_cmd.h"
+#include "news_func.h"
 #include "timer/timer.h"
 #include "timer/timer_window.h"
 #include "timer/timer_game_calendar.h"
@@ -890,9 +891,8 @@ CommandCost CmdCustomNewsItem(DoCommandFlag flags, NewsType type, NewsReferenceT
 	if (company != INVALID_OWNER && company != _local_company) return CommandCost();
 
 	if (flags & DC_EXEC) {
-		NewsStringData *news = new NewsStringData(text);
-		SetDParamStr(0, news->string);
-		AddNewsItem(STR_NEWS_CUSTOM_ITEM, type, NF_NORMAL, reftype1, reference, NR_NONE, UINT32_MAX, news);
+		SetDParamStr(0, text);
+		AddNewsItem(STR_NEWS_CUSTOM_ITEM, type, NF_NORMAL, reftype1, reference, NR_NONE, UINT32_MAX);
 	}
 
 	return CommandCost();

--- a/src/news_type.h
+++ b/src/news_type.h
@@ -144,12 +144,6 @@ struct NewsItem {
 	NewsItem(StringID string_id, NewsType type, NewsFlag flags, NewsReferenceType reftype1, uint32_t ref1, NewsReferenceType reftype2, uint32_t ref2, const NewsAllocatedData *data);
 };
 
-/** Container for a single string to be passed as NewsAllocatedData. */
-struct NewsStringData : NewsAllocatedData {
-	std::string string; ///< The string to retain.
-	NewsStringData(const std::string &str) : string(str) {}
-};
-
 /**
  * Data that needs to be stored for company news messages.
  * The problem with company news messages are the custom name

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -48,17 +48,16 @@ void Subsidy::AwardTo(CompanyID company)
 	this->remaining = _settings_game.difficulty.subsidy_duration * CalendarTime::MONTHS_IN_YEAR;
 
 	SetDParam(0, company);
-	NewsStringData *company_name = new NewsStringData(GetString(STR_COMPANY_NAME));
+	std::string company_name = GetString(STR_COMPANY_NAME);
 
 	/* Add a news item */
 	std::pair<NewsReferenceType, NewsReferenceType> reftype = SetupSubsidyDecodeParam(this, SubsidyDecodeParamType::NewsAwarded, 1);
 
-	SetDParamStr(0, company_name->string);
+	SetDParamStr(0, company_name);
 	AddNewsItem(
 		STR_NEWS_SERVICE_SUBSIDY_AWARDED_HALF + _settings_game.difficulty.subsidy_multiplier,
 		NT_SUBSIDIES, NF_NORMAL,
-		reftype.first, this->src, reftype.second, this->dst,
-		company_name
+		reftype.first, this->src, reftype.second, this->dst
 	);
 	AI::BroadcastNewEvent(new ScriptEventSubsidyAwarded(this->index));
 	Game::NewEvent(new ScriptEventSubsidyAwarded(this->index));

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2192,12 +2192,12 @@ std::tuple<CommandCost, Money, TownID> CmdFoundTown(DoCommandFlag flags, TileInd
 				AddTileNewsItem(STR_NEWS_NEW_TOWN_UNSPONSORED, NT_INDUSTRY_OPEN, tile);
 			} else {
 				SetDParam(0, _current_company);
-				NewsStringData *company_name = new NewsStringData(GetString(STR_COMPANY_NAME));
+				std::string company_name = GetString(STR_COMPANY_NAME);
 
-				SetDParamStr(0, company_name->string);
+				SetDParamStr(0, company_name);
 				SetDParam(1, t->index);
 
-				AddTileNewsItem(STR_NEWS_NEW_TOWN, NT_INDUSTRY_OPEN, tile, company_name);
+				AddTileNewsItem(STR_NEWS_NEW_TOWN, NT_INDUSTRY_OPEN, tile);
 			}
 			AI::BroadcastNewEvent(new ScriptEventTownFounded(t->index));
 			Game::NewEvent(new ScriptEventTownFounded(t->index));
@@ -3342,14 +3342,14 @@ static CommandCost TownActionRoadRebuild(Town *t, DoCommandFlag flags)
 		t->road_build_months = 6;
 
 		SetDParam(0, _current_company);
-		NewsStringData *company_name = new NewsStringData(GetString(STR_COMPANY_NAME));
+		std::string company_name = GetString(STR_COMPANY_NAME);
 
 		SetDParam(0, t->index);
-		SetDParamStr(1, company_name->string);
+		SetDParamStr(1, company_name);
 
 		AddNewsItem(
 			TimerGameEconomy::UsingWallclockUnits() ? STR_NEWS_ROAD_REBUILDING_MINUTES : STR_NEWS_ROAD_REBUILDING_MONTHS,
-			NT_GENERAL, NF_NORMAL, NR_TOWN, t->index, NR_NONE, UINT32_MAX, company_name);
+			NT_GENERAL, NF_NORMAL, NR_TOWN, t->index, NR_NONE, UINT32_MAX);
 		AI::BroadcastNewEvent(new ScriptEventRoadReconstruction((ScriptCompany::CompanyID)(Owner)_current_company, t->index));
 		Game::NewEvent(new ScriptEventRoadReconstruction((ScriptCompany::CompanyID)(Owner)_current_company, t->index));
 	}


### PR DESCRIPTION

<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

The `NewsStringData` class exists to maintain a copy of a C-style string allocation for using later in the news message. The data in the class is not accessed directly, only by `SetDParamStr()` having a pointer to it.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Since SetDParamStr() now always owns a copy of the string, there is no need to make another copy of it to keep it around while the news item exists. Remove `NewsStringData`.

This also fixes a leak in `CmdIndustrySetProduction` as the allocated data wasn't passed to AddIndustryNewsItem.


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
