### PR TITLE
Codefix: Incorrect documentation comments in StringBuilder

### DIFF
--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -252,8 +252,7 @@ public:
 
 	/**
 	 * Create the builder of an external buffer.
-	 * @param start The start location to write to.
-	 * @param last  The last location to write to.
+	 * @param string The string to write to.
 	 */
 	StringBuilder(std::string &string) : string(&string) {}
 
@@ -309,7 +308,6 @@ public:
 	/**
 	 * Remove the given amount of characters from the back of the string.
 	 * @param amount The amount of characters to remove.
-	 * @return true iff there was enough space and the character got added.
 	 */
 	void RemoveElementsFromBack(size_t amount)
 	{


### PR DESCRIPTION
## Motivation / Problem

Incorrect documentation comments in StringBuilder.

## Description

Correct the incorrect documentation comments in StringBuilder.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
