### PR TITLE
Cleanup: [CI] Inconsistent usage of runners in workflows

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -80,10 +80,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - os: windows-latest
-          arch: x86
-        - os: windows-latest
-          arch: x64
+        - arch: x86
+        - arch: x64
 
     name: Windows (${{ matrix.arch }})
 
@@ -91,7 +89,6 @@ jobs:
     secrets: inherit
 
     with:
-      os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
 
   check_annotations:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,8 +26,8 @@ jobs:
       matrix:
         include:
         - name: Clang
-          compiler: clang-15
-          cxxcompiler: clang++-15
+          compiler: clang
+          cxxcompiler: clang++
           libraries: libsdl2-dev
         - name: GCC - SDL2
           compiler: gcc

--- a/.github/workflows/ci-emscripten.yml
+++ b/.github/workflows/ci-emscripten.yml
@@ -10,7 +10,7 @@ jobs:
   emscripten:
     name: CI
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       # If you change this version, change the number in the cache step too.
       image: emscripten/emsdk:3.1.57

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -23,7 +23,7 @@ jobs:
   linux:
     name: CI
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       CC: ${{ inputs.compiler }}
       CXX: ${{ inputs.cxxcompiler }}

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -21,7 +21,7 @@ jobs:
   macos:
     name: CI
 
-    runs-on: macos-14
+    runs-on: macos-latest
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.13
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -6,9 +6,6 @@ on:
       arch:
         required: true
         type: string
-      os:
-        required: true
-        type: string
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
@@ -17,7 +14,7 @@ jobs:
   windows:
     name: CI
 
-    runs-on: ${{ inputs.os }}
+    runs-on: windows-latest
 
     steps:
     - name: Checkout

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -11,7 +11,7 @@ jobs:
   docs:
     name: Docs
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Download source

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -12,7 +12,7 @@ jobs:
   macos:
     name: MacOS
 
-    runs-on: macos-14
+    runs-on: macos-latest
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.13
 

--- a/.github/workflows/release-source.yml
+++ b/.github/workflows/release-source.yml
@@ -18,7 +18,7 @@ jobs:
   source:
     name: Source
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     outputs:
       version: ${{ steps.metadata.outputs.version }}

--- a/.github/workflows/upload-gog.yml
+++ b/.github/workflows/upload-gog.yml
@@ -11,7 +11,7 @@ jobs:
   upload:
     name: Upload (GOG)
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Download source

--- a/.github/workflows/upload-steam.yml
+++ b/.github/workflows/upload-steam.yml
@@ -14,7 +14,7 @@ jobs:
   upload:
     name: Upload (Steam)
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Download source


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Some workflows are still using `ubuntu-20.04`.
`macos-latest` is now `macos-14`, but we still use `macos-14`.
`os` input for ci-windows is unneeded since #12254.
`ubuntu-latest` is transitioning from `ubuntu-22.04` to `ubuntu-24.04` and CI fails when 24.04 is picked.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Use `-latest` runner everywhere.
Remove `os` input for ci-windows.

While ubuntu-latest is transitioning from ubuntu-22.04 to ubuntu-24.04, the one we actually run on is random.
Our code requires clang version 15+.
`ubuntu-22.04` has `clang13`, `clang` (14) and `clang15`
`ubuntu-24.04` has `clang16`, `clang17` and `clang` (18)
So our workflow can work with 22.04 (using clang15) or 24.04 (using clang), but not both at the same time.
So just force 24.04 for now.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
We will forget to change back to `ubuntu-latest` after the transition is complete.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
