### PR TITLE
Codechange: use different structure for TileIndexDiff in debug

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -62,25 +62,6 @@
 	AllocateWaterRegions();
 }
 
-
-#ifdef _DEBUG
-TileIndex TileAdd(TileIndex tile, TileIndexDiff offset)
-{
-	int dx = offset & Map::MaxX();
-	if (dx >= (int)Map::SizeX() / 2) dx -= Map::SizeX();
-	int dy = (offset - dx) / (int)Map::SizeX();
-
-	uint32_t x = TileX(tile) + dx;
-	uint32_t y = TileY(tile) + dy;
-
-	assert(x < Map::SizeX());
-	assert(y < Map::SizeY());
-	assert(TileXY(x, y) == Map::WrapToMap(tile + offset));
-
-	return TileXY(x, y);
-}
-#endif
-
 /**
  * This function checks if we add addx/addy to tile, if we
  * do wrap around the edges. For example, tile = (10,2) and

--- a/src/map_type.h
+++ b/src/map_type.h
@@ -10,17 +10,7 @@
 #ifndef MAP_TYPE_H
 #define MAP_TYPE_H
 
-/**
- * An offset value between two tiles.
- *
- * This value is used for the difference between
- * two tiles. It can be added to a TileIndex to get
- * the resulting TileIndex of the start tile applied
- * with this saved difference.
- *
- * @see TileDiffXY(int, int)
- */
-typedef int32_t TileIndexDiff;
+struct TileIndexDiff;
 
 /**
  * A pair-construct of a TileIndexDiff.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Someone complaining about asserts being triggered in `TileAdd`.
But also debug builds triggering an assertion with maps of 64x64 and station spread of 64 when building stations in some places.

This is all caused because an assumption is made when doing the assertion that the offset is at most 50% of the X-axis, either negatively or positively. It cannot discern between -40% and +60%, so a cut-off has been chosen and that's wrong in some cases such as the before mentioned station spread.


## Description

Make `TileIndexDiff` a structure with different behaviour in `_DEBUG` builds. Specifically, in `_DEBUG` builds it acts more like `TileIndexDiffC` where the offset in `x` and `y` are stored separately. When applying this offset to `TileIndex`, the X and Y coordinates of the tile are determine, the new X and Y are calculated and validated that they fall within the range for those coordinates. In other words, it support -100% to +100%.

When built without `_DEBUG`, the old behaviour of a single numeric offset is used and everything behaves as it did.


## Limitations

Previously the assertion only happened for `TileAdd`, now all additions/subtractions with `TileIndexDiff` will get the checks. I have not found anything that's failing yet, but debug builds could be more likely to trigger some of the new range checks. `TileAdd` could be replaced by `operator+`, but that's for another PR.

`TileIndexDiff` is a weird/bad name, it should probably be `TileOffset`. Similarly to `TileIndexDiffC`, and variables with `TileOffs` ought to be renamed.
It could be considered to get rid of the `TileIndexXY` function and just call the two parameter constructor (make that public).
These are also things to consider for another PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
