### PR TITLE
Fix: CHashTableT's Clear function doesn't set number of items back to zero

### DIFF
--- a/src/misc/hashtable.hpp
+++ b/src/misc/hashtable.hpp
@@ -183,6 +183,7 @@ public:
 	inline void Clear()
 	{
 		for (int i = 0; i < Tcapacity; i++) m_slots[i].Clear();
+		this->m_num_items = 0;
 	}
 
 	/** const item search */


### PR DESCRIPTION
## Motivation / Problem

Clear should reset the Hashmap to the initial state, but the number of items counter is not updated. 

## Description

The value is now set to 0 when Clear is called.

## Limitations

There could be unwanted side effects, although I believe the chances of that are very low. The only observable difference after this change is the value returned from the hashmap's Count() function, which is now correct even after a call to Clear. 

The CHashTableT class is used by the NodeList class, which in turn is used by both AyStar and YAPF. The hashmap's Count function is used to return the number of nodes on the open and closed list, both implemented as hashmaps. Both AyStar and YAPF instantiate a new NodeList for each pathfinder run, hence no calls to the Clear function and no risk of incorrect node counts even before this change.

The last usage of the hashmap is in CSegmentCostCacheT, which does in fact call Clear() in its Flush() function. It never seems to use the item count though, so this change shouldn't affect anything here.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
