### PR TITLE
Fix #12973: Don't exclude high score after using sandbox options

### DIFF
--- a/src/cheat.cpp
+++ b/src/cheat.cpp
@@ -20,20 +20,3 @@ void InitializeCheats()
 {
 	memset(&_cheats, 0, sizeof(Cheats));
 }
-
-/**
- * Return true if any cheat has been used, false otherwise
- * @return has a cheat been used?
- */
-bool CheatHasBeenUsed()
-{
-	/* Cannot use lengthof because _cheats is of type Cheats, not Cheat */
-	const Cheat *cht = (Cheat*)&_cheats;
-	const Cheat *cht_last = &cht[sizeof(_cheats) / sizeof(Cheat)];
-
-	for (; cht != cht_last; cht++) {
-		if (cht->been_used) return true;
-	}
-
-	return false;
-}

--- a/src/cheat_func.h
+++ b/src/cheat_func.h
@@ -16,6 +16,5 @@ extern Cheats _cheats;
 
 void ShowCheatWindow();
 
-bool CheatHasBeenUsed();
 
 #endif /* CHEAT_FUNC_H */

--- a/src/highscore.cpp
+++ b/src/highscore.cpp
@@ -56,9 +56,6 @@ StringID EndGameGetPerformanceTitleFromValue(uint value)
  */
 int8_t SaveHighScoreValue(const Company *c)
 {
-	/* Exclude cheaters from the honour of being in the highscore table */
-	if (CheatHasBeenUsed()) return -1;
-
 	auto &highscores = _highscore_table[SP_CUSTOM];
 	uint16_t score = c->old_economy[0].performance_history;
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

#12973 Score excluded from highscore when using sandbox
Using the sandbox options now no longer excludes you from the highscore list


## Description
Check for using cheats removed from highscore
All has_been_used flags for cheats have been removed
Using the sandbox options now no longer excludes you from the highscore list

Closes #12973.

## Limitations

None that I am aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
