### PR TITLE
Fix #13002: Crash due to use of dangling types in picker GUI used/saved lists

### DIFF
--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -197,10 +197,14 @@ void PickerWindow::ConstructWindow()
 	this->classes.SetSortFuncs(_class_sorter_funcs);
 	this->classes.SetFilterFuncs(_class_filter_funcs);
 
+	/* Update saved type information. */
+	this->callbacks.saved = this->callbacks.UpdateSavedItems(this->callbacks.saved);
+
+	/* Clear used type information. */
+	this->callbacks.used.clear();
+
 	if (this->has_type_picker) {
-		/* Update used and saved type information. */
-		this->callbacks.saved = this->callbacks.UpdateSavedItems(this->callbacks.saved);
-		this->callbacks.used.clear();
+		/* Populate used type information. */
 		this->callbacks.FillUsedItems(this->callbacks.used);
 
 		SetWidgetDisabledState(WID_PW_MODE_ALL, !this->callbacks.HasClassChoice());


### PR DESCRIPTION
## Motivation / Problem

#13002.

## Description

Fix #13002.
Used type lists should be cleared when opening the picker window when has_type_picker is false.
Saved type lists should be updated even when has_type_picker is false, such that any dangling type references can be correctly cleared.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
