### PR TITLE
Codefix: [Win32] Truncated stack trace symbols were not null-terminated

### DIFF
--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -235,9 +235,12 @@ static const uint MAX_FRAMES     = 64;
 		CONTEXT ctx;
 		memcpy(&ctx, ep->ContextRecord, sizeof(ctx));
 
-		/* Allocate space for symbol info. */
-		char sym_info_raw[sizeof(IMAGEHLP_SYMBOL64) + MAX_SYMBOL_LEN - 1];
-		IMAGEHLP_SYMBOL64 *sym_info = (IMAGEHLP_SYMBOL64*)sym_info_raw;
+		/* Allocate space for symbol info.
+		 * The total initialised size must be sufficient for a null-terminating char at sym_info->Name[sym_info->MaxNameLength],
+		 * SymGetSymFromAddr64 is not required to write a null-terminating char.
+		 * sizeof(IMAGEHLP_SYMBOL64) includes at least one char of the Name buffer. */
+		std::array<char, sizeof(IMAGEHLP_SYMBOL64) + MAX_SYMBOL_LEN> sym_info_raw{};
+		IMAGEHLP_SYMBOL64 *sym_info = reinterpret_cast<IMAGEHLP_SYMBOL64*>(sym_info_raw.data());
 		sym_info->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
 		sym_info->MaxNameLength = MAX_SYMBOL_LEN;
 


### PR DESCRIPTION
## Motivation / Problem

SymGetSymFromAddr64 does not null-terminate symbols stored in IMAGEHLP_SYMBOL64 with lengths >= the name buffer size.
The documentation is a bit ambiguous whether it does this, however testing and at least one other [bug report](https://bugs.openjdk.org/browse/JDK-8185712?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aworklog-tabpanel#) indicate that it doesn't.

This could result in rubbish ending up in the stack trace output, which is problematic when serialising JSON crash logs, etc.

## Description

Ensure that the symbol name is null-terminated.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
