### PR TITLE
Change: Disable water flooding when water tiles have no floodable neighbours.

### DIFF
--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -98,6 +98,12 @@
     </li>
    </ul>
   </li>
+  <li><span style="font-weight: bold;">m3:</span><br>
+    <ul>
+      <li>
+        Bit 0: Non-flooding state.
+      </li>
+    </ul>
   <li><span style="font-weight: bold;">m4:</span><br>
    <a name="RoadType"></a>
    Road roadtype. Used for all tiles with road (road, station, tunnelbridge).

--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -244,7 +244,7 @@ the array so you can quickly see what is used and what is not.
       <td class="caption">sea</td>
       <td class="bits" rowspan=5><span class="used" title="Ship docking tile status">X</span> <span class="used" title="Water class">XX</span> <span class="used" title="Owner">XXXXX</span></td>
       <td class="bits" rowspan=4><span class="free">OOOO OOOO OOOO OOOO</span></td>
-      <td class="bits" rowspan=5><span class="free">OOOO OOOO</span></td>
+      <td class="bits" rowspan=5><span class="free">OOOO OOO</span><span class="used" title="Non-flooding state">X</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="used" title="Water tile type: coast, clear, lock, depot">0000</span> <span class="free">OOO0</span></td>
       <td class="bits" rowspan=5><span class="free">OOOO OOOO</span></td>

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -537,6 +537,7 @@ void DoClearSquare(TileIndex tile)
 	MarkTileDirtyByTile(tile);
 	if (remove) RemoveDockingTile(tile);
 
+	ClearNeighbourNonFloodingStates(tile);
 	InvalidateWaterRegion(tile);
 }
 
@@ -693,6 +694,7 @@ CommandCost CmdLandscapeClear(DoCommandFlag flags, TileIndex tile)
 				}
 			}
 			DoClearSquare(tile);
+			ClearNeighbourNonFloodingStates(tile);
 		}
 	}
 	return cost;

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -120,6 +120,8 @@ void BuildObject(ObjectType type, TileIndex tile, CompanyID owner, Town *town, u
 	assert(o->town != nullptr);
 
 	for (TileIndex t : ta) {
+		if (IsWaterTile(t)) ClearNeighbourNonFloodingStates(t);
+		if (HasTileWaterGround(t)) InvalidateWaterRegion(t);
 		WaterClass wc = (IsWaterTile(t) ? GetWaterClass(t) : WATER_CLASS_INVALID);
 		/* Update company infrastructure counts for objects build on canals owned by nobody. */
 		if (wc == WATER_CLASS_CANAL && owner != OWNER_NONE && (IsTileOwner(t, OWNER_NONE) || IsTileOwner(t, OWNER_WATER))) {
@@ -364,7 +366,6 @@ CommandCost CmdBuildObject(DoCommandFlag flags, TileIndex tile, ObjectType type,
 
 	if (flags & DC_EXEC) {
 		BuildObject(type, tile, _current_company == OWNER_DEITY ? OWNER_NONE : _current_company, nullptr, view);
-		for (TileIndex t : ta) InvalidateWaterRegion(t);
 
 		/* Make sure the HQ starts at the right size. */
 		if (type == OBJECT_HQ) UpdateCompanyHQ(tile, hq_score);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2218,6 +2218,13 @@ bool AfterLoadGame()
 		}
 	}
 
+	if (IsSavegameVersionBefore(SLV_NONFLOODING_WATER_TILES)) {
+		for (auto t : Map::Iterate()) {
+			if (!IsTileType(t, MP_WATER)) continue;
+			SetNonFloodingWaterTile(t, false);
+		}
+	}
+
 	if (IsSavegameVersionBefore(SLV_124) && !IsSavegameVersionBefore(SLV_1)) {
 		/* The train station tile area was added, but for really old (TTDPatch) it's already valid. */
 		for (Waypoint *wp : Waypoint::Iterate()) {

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -390,6 +390,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_WATER_TILE_TYPE,                    ///< 342  PR#13030 Simplify water tile type.
 	SLV_PRODUCTION_HISTORY,                 ///< 343  PR#10541 Industry production history.
 	SLV_ROAD_TYPE_LABEL_MAP,                ///< 344  PR#13021 Add road type label map to allow upgrade/conversion of road types.
+	SLV_NONFLOODING_WATER_TILES,            ///< 345  PR#13013 Store water tile non-flooding state.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -102,6 +102,7 @@ static void PlantTreesOnTile(TileIndex tile, TreeType treetype, uint count, Tree
 	switch (GetTileType(tile)) {
 		case MP_WATER:
 			ground = TREE_GROUND_SHORE;
+			ClearNeighbourNonFloodingStates(tile);
 			break;
 
 		case MP_CLEAR:

--- a/src/water.h
+++ b/src/water.h
@@ -24,6 +24,7 @@ enum FloodingBehaviour {
 };
 
 FloodingBehaviour GetFloodingBehaviour(TileIndex tile);
+void ClearNeighbourNonFloodingStates(TileIndex tile);
 
 void TileLoop_Water(TileIndex tile);
 bool FloodHalftile(TileIndex t);

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -1259,6 +1259,9 @@ void TileLoop_Water(TileIndex tile)
 				/* do not try to flood water tiles - increases performance a lot */
 				if (IsTileType(dest, MP_WATER)) continue;
 
+				/* Buoys and docks cannot be flooded, and when removed turn into flooding water. */
+				if (IsTileType(dest, MP_STATION) && (IsBuoy(dest) || IsDock(dest))) continue;
+
 				/* This neighbour tile might be floodable later if the tile is cleared, so allow flooding to continue. */
 				continue_flooding = true;
 

--- a/src/water_map.h
+++ b/src/water_map.h
@@ -516,4 +516,24 @@ inline void MakeLock(Tile t, Owner o, DiagDirection d, WaterClass wc_lower, Wate
 	MakeLockTile(upper_tile, IsWaterTile(upper_tile) ? GetTileOwner(upper_tile) : o, LOCK_PART_UPPER, d, wc_upper);
 }
 
+/**
+ * Set the non-flooding water tile state of a tile.
+ * @param t the tile
+ * @param b the non-flooding water tile state
+ */
+inline void SetNonFloodingWaterTile(Tile t, bool b)
+{
+	assert(IsTileType(t, MP_WATER));
+	AssignBit(t.m3(), 0, b);
+}
+/**
+ * Checks whether the tile is marked as a non-flooding water tile.
+ * @return true iff the tile is marked as a non-flooding water tile.
+ */
+inline bool IsNonFloodingWaterTile(Tile t)
+{
+	assert(IsTileType(t, MP_WATER));
+	return HasBit(t.m3(), 0);
+}
+
 #endif /* WATER_MAP_H */

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -505,6 +505,7 @@ CommandCost CmdBuildBuoy(DoCommandFlag flags, TileIndex tile)
 		MakeBuoy(tile, wp->index, GetWaterClass(tile));
 		CheckForDockingTile(tile);
 		MarkTileDirtyByTile(tile);
+		ClearNeighbourNonFloodingStates(tile);
 
 		wp->UpdateVirtCoord();
 		InvalidateWindowData(WC_WAYPOINT_VIEW, wp->index);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

On a map with a large number of water tiles, every water tile checks all either of its neighbours to see if they can be flooded.

In most cases flooding cannot happen.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

When processing a water tile for flooding, determine if any of the neighbouring tiles are floodable. If not, this state is stored in 1 bit the map, and no further flooding is attempted from this tile on future processing loops.

On a large map with lots of water tiles this can noticeably reduce game loop processing time.

Mostly ported from JGRPP.

---

On a fresh 4Kx4K map with 75% water:

* Master: 6.50ms
![image](https://github.com/user-attachments/assets/368d5362-9db0-4c4b-a1bc-7df93de15bfa)

* This PR: 2.25ms
![image](https://github.com/user-attachments/assets/acc050fd-1527-4860-9f66-a2fdbbec1cd7)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Can't be directly ported from JGRPP so could be some bits missing. And the test for whether to set the non-floodable state is changed.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
