### PR TITLE
Codechange: use functions described in documentation, instead of related other functions

### DIFF
--- a/src/script/api/script_road.cpp
+++ b/src/script/api/script_road.cpp
@@ -367,12 +367,19 @@ static int32_t LookupWithBuildOnSlopes(::Slope slope, const Array<> &existing, i
  */
 static bool NormaliseTileOffset(int32_t *tile)
 {
-		if (*tile == 1 || *tile == -1) return true;
-		if (*tile == ::TileDiffXY(0, -1)) {
+		if (*tile == ScriptMap::GetTileIndex(-1, 0)) {
+			*tile = -1;
+			return true;
+		}
+		if (*tile == ScriptMap::GetTileIndex(1, 0)) {
+			*tile = 1;
+			return true;
+		}
+		if (*tile == ScriptMap::GetTileIndex(0, -1)) {
 			*tile = -2;
 			return true;
 		}
-		if (*tile == ::TileDiffXY(0, 1)) {
+		if (*tile == ScriptMap::GetTileIndex(0, 1)) {
 			*tile = 2;
 			return true;
 		}
@@ -405,8 +412,12 @@ static bool NormaliseTileOffset(int32_t *tile)
 	if (!::IsValidTile(tile) || !::IsValidTile(start) || !::IsValidTile(end)) return -1;
 	if (::DistanceManhattan(tile, start) != 1 || ::DistanceManhattan(tile, end) != 1) return -1;
 
-	/*                                           ROAD_NW              ROAD_SW             ROAD_SE             ROAD_NE */
-	const TileIndexDiff neighbours[] = {::TileDiffXY(0, -1), ::TileDiffXY(1, 0), ::TileDiffXY(0, 1), ::TileDiffXY(-1, 0)};
+	const TileIndex neighbours[] = {
+		ScriptMap::GetTileIndex(0, -1), // ROAD_NW
+		ScriptMap::GetTileIndex(1, 0),  // ROAD_SW
+		ScriptMap::GetTileIndex(0, 1),  // ROAD_SE
+		ScriptMap::GetTileIndex(-1, 0), // ROAD_NE
+	};
 
 	::RoadBits rb = ::ROAD_NONE;
 	if (::IsNormalRoadTile(tile)) {
@@ -417,7 +428,7 @@ static bool NormaliseTileOffset(int32_t *tile)
 
 	Array<> existing;
 	for (uint i = 0; i < lengthof(neighbours); i++) {
-		if (HasBit(rb, i)) existing.emplace_back(neighbours[i]);
+		if (HasBit(rb, i)) existing.emplace_back(neighbours[i].base());
 	}
 
 	return ScriptRoad::CanBuildConnectedRoadParts(ScriptTile::GetSlope(tile), std::move(existing), start - tile, end - tile);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

In `ScriptRoad` some functions get passed/use something resembling `TileIndexDiff`, which would technically be correct. However, the documentation clearly states how to construct these values using `ScriptMap::GetTileIndex`. So, to prevent any subtle API changes in the future, `ScriptMap::GetTileIndex` should be used instead.


## Description

Make the proposed change by using `ScriptMap::GetTileIndex` over `TileIndexDiff`. Also do not assume values 1 and -1 will forever mean what they mean now.


## Limitations

Technically, the right type/function to use would be the `TileIndexDiff` related ones. However, first converting from `TileIndex` to `TileIndexDiff` to then do another conversion seems a bit over the top.
Also, changing the script APIs on this point would add a huge burden for relatively minor type correctness.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
