### PR TITLE
Codechange: replace magic numbers with enumeration

### DIFF
--- a/src/script/api/script_road.cpp
+++ b/src/script/api/script_road.cpp
@@ -367,12 +367,19 @@ static int32_t LookupWithBuildOnSlopes(::Slope slope, const Array<> &existing, i
  */
 static bool NormaliseTileOffset(int32_t *tile)
 {
-		if (*tile == 1 || *tile == -1) return true;
-		if (*tile == ::TileDiffXY(0, -1)) {
+		if (*tile == ScriptMap::GetTileIndex(-1, 0)) {
+			*tile = -1;
+			return true;
+		}
+		if (*tile == ScriptMap::GetTileIndex(1, 0)) {
+			*tile = 1;
+			return true;
+		}
+		if (*tile == ScriptMap::GetTileIndex(0, -1)) {
 			*tile = -2;
 			return true;
 		}
-		if (*tile == ::TileDiffXY(0, 1)) {
+		if (*tile == ScriptMap::GetTileIndex(0, 1)) {
 			*tile = 2;
 			return true;
 		}
@@ -405,8 +412,12 @@ static bool NormaliseTileOffset(int32_t *tile)
 	if (!::IsValidTile(tile) || !::IsValidTile(start) || !::IsValidTile(end)) return -1;
 	if (::DistanceManhattan(tile, start) != 1 || ::DistanceManhattan(tile, end) != 1) return -1;
 
-	/*                                           ROAD_NW              ROAD_SW             ROAD_SE             ROAD_NE */
-	const TileIndexDiff neighbours[] = {::TileDiffXY(0, -1), ::TileDiffXY(1, 0), ::TileDiffXY(0, 1), ::TileDiffXY(-1, 0)};
+	const TileIndex neighbours[] = {
+		ScriptMap::GetTileIndex(0, -1), // ROAD_NW
+		ScriptMap::GetTileIndex(1, 0),  // ROAD_SW
+		ScriptMap::GetTileIndex(0, 1),  // ROAD_SE
+		ScriptMap::GetTileIndex(-1, 0), // ROAD_NE
+	};
 
 	::RoadBits rb = ::ROAD_NONE;
 	if (::IsNormalRoadTile(tile)) {
@@ -417,7 +428,7 @@ static bool NormaliseTileOffset(int32_t *tile)
 
 	Array<> existing;
 	for (uint i = 0; i < lengthof(neighbours); i++) {
-		if (HasBit(rb, i)) existing.emplace_back(neighbours[i]);
+		if (HasBit(rb, i)) existing.emplace_back(neighbours[i].base());
 	}
 
 	return ScriptRoad::CanBuildConnectedRoadParts(ScriptTile::GetSlope(tile), std::move(existing), start - tile, end - tile);

--- a/src/script/api/script_road.hpp
+++ b/src/script/api/script_road.hpp
@@ -248,7 +248,7 @@ public:
 	 *         they are build or 2 when building the first part automatically
 	 *         builds the second part. -1 means the preconditions are not met.
 	 */
-	static SQInteger CanBuildConnectedRoadParts(ScriptTile::Slope slope, Array<> &&existing, TileIndex start, TileIndex end);
+	static SQInteger CanBuildConnectedRoadParts(ScriptTile::Slope slope, Array<TileIndex> &&existing, TileIndex start, TileIndex end);
 
 	/**
 	 * Lookup function for building road parts independent of whether the


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

[A comment on #13017](https://github.com/OpenTTD/OpenTTD/pull/13017#issuecomment-2429526615) triggered me to wonder what the magic numbers -2, -1, 1 and 2 would actually mean, and what the actual type should be.

Long story short, I do not think we should not "normalise" the data in place and go from `TileIndex` to `RoadPartOrientation`, but rather treat them as two different types.


## Description

Replace the magic numbers associated with what I've called "RoadPartOrientation". Where not directly possible, create helper functions to preserve the functionality. 

Also pass `TileIndex` as parameter type instead of `int32_t` in the passed array. This should solve the comparing signed-vs-unsigned comment.


## Limitations

This is built upon #13017, so the content of that PR is included in this PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
