### PR TITLE
Add: Implement road type label conversion

### DIFF
--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3362,6 +3362,7 @@ void ReloadNewGRFData()
 	RecomputePrices();
 	/* reload vehicles */
 	ResetVehicleHash();
+	AfterLoadLabelMaps();
 	AfterLoadVehiclesPhase1(false);
 	AfterLoadVehiclesPhase2(false);
 	StartupEngines();

--- a/src/saveload/labelmaps_sl.cpp
+++ b/src/saveload/labelmaps_sl.cpp
@@ -130,11 +130,27 @@ static void ConvertRoadTypes()
 	}
 }
 
+/** Populate label lists with current values. */
+static void SetCurrentLabelLists()
+{
+	_railtype_list.clear();
+	for (RailType rt = RAILTYPE_BEGIN; rt != RAILTYPE_END; rt++) {
+		_railtype_list.push_back({GetRailTypeInfo(rt)->label, 0});
+	}
+
+	_roadtype_list.clear();
+	for (RoadType rt = ROADTYPE_BEGIN; rt != ROADTYPE_END; rt++) {
+		_roadtype_list.push_back({GetRoadTypeInfo(rt)->label, GetRoadTramType(rt)});
+	}
+}
+
 /** Perform rail type and road type conversion if necessary. */
 void AfterLoadLabelMaps()
 {
 	ConvertRailTypes();
 	ConvertRoadTypes();
+
+	SetCurrentLabelLists();
 }
 
 void ResetLabelMaps()

--- a/src/saveload/labelmaps_sl.cpp
+++ b/src/saveload/labelmaps_sl.cpp
@@ -13,12 +13,22 @@
 #include "compat/labelmaps_sl_compat.h"
 
 #include "saveload_internal.h"
+#include "../rail.h"
+#include "../road.h"
 #include "../station_map.h"
 #include "../tunnelbridge_map.h"
 
 #include "../safeguards.h"
 
-static std::vector<RailTypeLabel> _railtype_list;
+/** Container for a label for rail or road type conversion. */
+template <typename T>
+struct LabelObject {
+	T label = {}; ///< Label of rail or road type.
+	uint8_t subtype = 0; ///< Subtype of type (road or tram).
+};
+
+static std::vector<LabelObject<RailTypeLabel>> _railtype_list;
+static std::vector<LabelObject<RoadTypeLabel>> _roadtype_list;
 
 /**
  * Test if any saved rail type labels are different to the currently loaded
@@ -30,7 +40,7 @@ static void ConvertRailTypes()
 	bool needs_conversion = false;
 
 	for (auto it = std::begin(_railtype_list); it != std::end(_railtype_list); ++it) {
-		RailType rt = GetRailTypeByLabel(*it);
+		RailType rt = GetRailTypeByLabel(it->label);
 		if (rt == INVALID_RAILTYPE) {
 			rt = RAILTYPE_RAIL;
 		}
@@ -38,7 +48,7 @@ static void ConvertRailTypes()
 		railtype_conversion_map.push_back(rt);
 
 		/* Conversion is needed if the rail type is in a different position than the list. */
-		if (*it != 0 && rt != std::distance(std::begin(_railtype_list), it)) needs_conversion = true;
+		if (it->label != 0 && rt != std::distance(std::begin(_railtype_list), it)) needs_conversion = true;
 	}
 	if (!needs_conversion) return;
 
@@ -72,58 +82,146 @@ static void ConvertRailTypes()
 	}
 }
 
+/**
+ * Test if any saved road type labels are different to the currently loaded
+ * road types. Road types stored in the map will be converted if necessary.
+ */
+static void ConvertRoadTypes()
+{
+	std::vector<RoadType> roadtype_conversion_map;
+	bool needs_conversion = false;
+	for (auto it = std::begin(_roadtype_list); it != std::end(_roadtype_list); ++it) {
+		RoadType rt = GetRoadTypeByLabel(it->label);
+		if (rt == INVALID_ROADTYPE || GetRoadTramType(rt) != it->subtype) {
+			rt = it->subtype ? ROADTYPE_TRAM : ROADTYPE_ROAD;
+		}
+
+		roadtype_conversion_map.push_back(rt);
+
+		/* Conversion is needed if the road type is in a different position than the list. */
+		if (it->label != 0 && rt != std::distance(std::begin(_roadtype_list), it)) needs_conversion = true;
+	}
+	if (!needs_conversion) return;
+
+	for (TileIndex t : Map::Iterate()) {
+		switch (GetTileType(t)) {
+			case MP_ROAD:
+				if (RoadType rt = GetRoadTypeRoad(t); rt != INVALID_ROADTYPE) SetRoadTypeRoad(t, roadtype_conversion_map[rt]);
+				if (RoadType rt = GetRoadTypeTram(t); rt != INVALID_ROADTYPE) SetRoadTypeTram(t, roadtype_conversion_map[rt]);
+				break;
+
+			case MP_STATION:
+				if (IsStationRoadStop(t) || IsRoadWaypoint(t)) {
+					if (RoadType rt = GetRoadTypeRoad(t); rt != INVALID_ROADTYPE) SetRoadTypeRoad(t, roadtype_conversion_map[rt]);
+					if (RoadType rt = GetRoadTypeTram(t); rt != INVALID_ROADTYPE) SetRoadTypeTram(t, roadtype_conversion_map[rt]);
+				}
+				break;
+
+			case MP_TUNNELBRIDGE:
+				if (GetTunnelBridgeTransportType(t) == TRANSPORT_ROAD) {
+					if (RoadType rt = GetRoadTypeRoad(t); rt != INVALID_ROADTYPE) SetRoadTypeRoad(t, roadtype_conversion_map[rt]);
+					if (RoadType rt = GetRoadTypeTram(t); rt != INVALID_ROADTYPE) SetRoadTypeTram(t, roadtype_conversion_map[rt]);
+				}
+				break;
+
+			default:
+				break;
+		}
+	}
+}
+
+/** Perform rail type and road type conversion if necessary. */
 void AfterLoadLabelMaps()
 {
 	ConvertRailTypes();
+	ConvertRoadTypes();
 }
 
 void ResetLabelMaps()
 {
 	_railtype_list.clear();
+	_roadtype_list.clear();
 }
-
-/** Container for a label for SaveLoad system */
-struct LabelObject {
-	uint32_t label;
-};
-
-static const SaveLoad _label_object_desc[] = {
-	SLE_VAR(LabelObject, label, SLE_UINT32),
-};
 
 struct RAILChunkHandler : ChunkHandler {
 	RAILChunkHandler() : ChunkHandler('RAIL', CH_TABLE) {}
 
+	static inline const SaveLoad description[] = {
+		SLE_VAR(LabelObject<RailTypeLabel>, label, SLE_UINT32),
+	};
+
 	void Save() const override
 	{
-		SlTableHeader(_label_object_desc);
+		SlTableHeader(description);
 
-		LabelObject lo;
-
+		LabelObject<RailTypeLabel> lo;
 		for (RailType r = RAILTYPE_BEGIN; r != RAILTYPE_END; r++) {
 			lo.label = GetRailTypeInfo(r)->label;
 
 			SlSetArrayIndex(r);
-			SlObject(&lo, _label_object_desc);
+			SlObject(&lo, description);
 		}
 	}
 
 	void Load() const override
 	{
-		const std::vector<SaveLoad> slt = SlCompatTableHeader(_label_object_desc, _label_object_sl_compat);
+		const std::vector<SaveLoad> slt = SlCompatTableHeader(description, _label_object_sl_compat);
 
-		LabelObject lo;
+		_railtype_list.reserve(RAILTYPE_END);
+
+		LabelObject<RailTypeLabel> lo;
 
 		while (SlIterateArray() != -1) {
 			SlObject(&lo, slt);
-			_railtype_list.push_back((RailTypeLabel)lo.label);
+			_railtype_list.push_back(lo);
+		}
+	}
+};
+
+struct ROTTChunkHandler : ChunkHandler {
+	ROTTChunkHandler() : ChunkHandler('ROTT', CH_TABLE) {}
+
+	static inline const SaveLoad description[] = {
+		SLE_VAR(LabelObject<RoadTypeLabel>, label, SLE_UINT32),
+		SLE_VAR(LabelObject<RoadTypeLabel>, subtype, SLE_UINT8),
+	};
+
+	void Save() const override
+	{
+		SlTableHeader(description);
+
+		LabelObject<RoadTypeLabel> lo;
+		for (RoadType r = ROADTYPE_BEGIN; r != ROADTYPE_END; r++) {
+			const RoadTypeInfo *rti = GetRoadTypeInfo(r);
+			lo.label = rti->label;
+			lo.subtype = GetRoadTramType(r);
+
+			SlSetArrayIndex(r);
+			SlObject(&lo, description);
+		}
+	}
+
+	void Load() const override
+	{
+		const std::vector<SaveLoad> slt = SlCompatTableHeader(description, _label_object_sl_compat);
+
+		_roadtype_list.reserve(ROADTYPE_END);
+
+		LabelObject<RoadTypeLabel> lo;
+
+		while (SlIterateArray() != -1) {
+			SlObject(&lo, slt);
+			_roadtype_list.push_back(lo);
 		}
 	}
 };
 
 static const RAILChunkHandler RAIL;
+static const ROTTChunkHandler ROTT;
+
 static const ChunkHandlerRef labelmaps_chunk_handlers[] = {
 	RAIL,
+	ROTT,
 };
 
 extern const ChunkHandlerTable _labelmaps_chunk_handlers(labelmaps_chunk_handlers);

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -389,6 +389,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_COMPANY_ALLOW_LIST_V2,              ///< 341  PR#12908 Fixed savegame format for saving of list of client keys that are allowed to join this company.
 	SLV_WATER_TILE_TYPE,                    ///< 342  PR#13030 Simplify water tile type.
 	SLV_PRODUCTION_HISTORY,                 ///< 343  PR#10541 Industry production history.
+	SLV_ROAD_TYPE_LABEL_MAP,                ///< 344  PR#13021 Add road type label map to allow upgrade/conversion of road types.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When saving games, a railtype list is saved with the game. This is checked when loading the game, and if any types are different the rail type stored on the map is updated to either a new position, or a default rail type. This reduces the chance of broken savegames when updating NewGRFs.

This facility was never implemented for road types.

Additionally, the conversion is only applied when loading a game, not if NewGRFs are changed mid game.

This change does not mean that changing rail or road types mid-game is supported. But it will make it 1) more obvious that things have changed, at the map is updated immediately, an 2) reduce the chances of crashes happening later due to invalid rail/road types or mismatched road/tram vehicles.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This PR implements the missing road type label conversion, storing the road type label, along with its road/tram state.

This allows the same mapping to applied to road types as for rail types. Missing road types (or mismatching road/tram state) are mapped to ROADTYPE_ROAD, and missing tram types are mapped to ROADTYPE_TRAM.

Additionally, this conversion is now also performed if NewGRFs are changed mid game.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
