### PR TITLE
Codechange: add and use TileOffsByAxis(...) over TileOffsByDir(DiagDirToAxis(...))

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -108,6 +108,12 @@ TileIndex TileAddWrap(TileIndex tile, int addx, int addy)
 	return TileXY(x, y);
 }
 
+/** 'Lookup table' for tile offsets given an Axis */
+extern const TileIndexDiffC _tileoffs_by_axis[] = {
+	{ 1,  0}, ///< AXIS_X
+	{ 0,  1}, ///< AXIS_Y
+};
+
 /** 'Lookup table' for tile offsets given a DiagDirection */
 extern const TileIndexDiffC _tileoffs_by_diagdir[] = {
 	{-1,  0}, ///< DIAGDIR_NE

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -544,6 +544,20 @@ uint DistanceFromEdge(TileIndex); ///< shortest distance from any edge of the ma
 uint DistanceFromEdgeDir(TileIndex, DiagDirection); ///< distance from the map edge in given direction
 
 /**
+ * Convert an Axis to a TileIndexDiff
+ *
+ * @param axis The Axis
+ * @return The resulting TileIndexDiff in southern direction (either SW or SE).
+ */
+inline TileIndexDiff TileOffsByAxis(Axis axis)
+{
+	extern const TileIndexDiffC _tileoffs_by_axis[];
+
+	assert(IsValidAxis(axis));
+	return ToTileIndexDiff(_tileoffs_by_axis[axis]);
+}
+
+/**
  * Convert a DiagDirection to a TileIndexDiff
  *
  * @param dir The DiagDirection

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -70,7 +70,7 @@ struct ETileArea : TileArea {
 			case TA_PLATFORM: {
 				TileIndex start, end;
 				Axis axis = GetRailStationAxis(tile);
-				TileIndexDiff delta = TileOffsByDiagDir(AxisToDiagDir(axis));
+				TileIndexDiff delta = TileOffsByAxis(axis);
 
 				for (end = tile; IsRailStationTile(end + delta) && IsCompatibleTrainStationTile(end + delta, tile); end += delta) { /* Nothing */ }
 				for (start = tile; IsRailStationTile(start - delta) && IsCompatibleTrainStationTile(start - delta, tile); start -= delta) { /* Nothing */ }

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -233,7 +233,7 @@ CommandCost CmdBuildRailWaypoint(DoCommandFlag flags, TileIndex start_tile, Axis
 	StationID est = INVALID_STATION;
 
 	/* Check whether the tiles we're building on are valid rail or not. */
-	TileIndexDiff offset = TileOffsByDiagDir(AxisToDiagDir(OtherAxis(axis)));
+	TileIndexDiff offset = TileOffsByAxis(OtherAxis(axis));
 	for (int i = 0; i < count; i++) {
 		TileIndex tile = start_tile + i * offset;
 		CommandCost ret = IsValidTileForWaypoint(tile, axis, &est);
@@ -373,7 +373,7 @@ CommandCost CmdBuildRoadWaypoint(DoCommandFlag flags, TileIndex start_tile, Axis
 	if (ret.Failed()) return ret;
 
 	/* Check if there is an already existing, deleted, waypoint close to us that we can reuse. */
-	TileIndex center_tile = start_tile + (count / 2) * TileOffsByDiagDir(AxisToDiagDir(OtherAxis(axis)));;
+	TileIndex center_tile = start_tile + (count / 2) * TileOffsByAxis(OtherAxis(axis));
 	if (wp == nullptr && reuse) wp = FindDeletedWaypointCloseTo(center_tile, STR_SV_STNAME_WAYPOINT, _current_company, true);
 
 	if (wp != nullptr) {


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

In a number of places `TileOffsByDir(DiagDirToAxis(...))` is done. Why not make that a direct function, which is intended to be used even more often in another PR.


## Description

Add `TileOffsByAxis` and use it where appropriate.


## Limitations

Could also make `TileOffsByAxis` be nothing more than `return TileOffsByDiagDir(AxisToDiagDir(axis))`.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
