### PR TITLE
Codechange: split GetRoadDir as bays have DiagDir and drive throughs have Axis

### DIFF
--- a/src/autoslope.h
+++ b/src/autoslope.h
@@ -16,7 +16,7 @@
 
 /**
  * Autoslope check for tiles with an entrance on an edge.
- * E.g. depots and non-drive-through-road-stops.
+ * E.g. depots and bay road-stops.
  *
  * The test succeeds if the slope is not steep and at least one corner of the entrance edge is on the TileMaxZ() level.
  *
@@ -32,6 +32,27 @@ inline bool AutoslopeCheckForEntranceEdge(TileIndex tile, int z_new, Slope tileh
 {
 	if (GetTileMaxZ(tile) != z_new + GetSlopeMaxZ(tileh_new)) return false;
 	return ((tileh_new == SLOPE_FLAT) || CanBuildDepotByTileh(entrance, tileh_new));
+}
+
+/**
+ * Autoslope check for tiles with something built along an axis.
+ * E.g. railway stations and drive through road stops.
+ *
+ * The test succeeds if the slope is not steep and at least one corner at either of the entrance edges is on the TileMaxZ() level.
+ *
+ * @note The test does not check if autoslope is enabled at all.
+ *
+ * @param tile The tile.
+ * @param z_new New TileZ.
+ * @param tileh_new New TileSlope.
+ * @param axis The axis.
+ * @return true iff terraforming is allowed.
+ */
+inline bool AutoslopeCheckForAxis(TileIndex tile, int z_new, Slope tileh_new, Axis axis)
+{
+	DiagDirection direction = AxisToDiagDir(axis);
+	return AutoslopeCheckForEntranceEdge(tile, z_new, tileh_new, direction) &&
+		AutoslopeCheckForEntranceEdge(tile, z_new, tileh_new, ReverseDiagDir(direction));
 }
 
 /**

--- a/src/pathfinder/follow_track.hpp
+++ b/src/pathfinder/follow_track.hpp
@@ -250,7 +250,7 @@ protected:
 	{
 		/* road stop can be left at one direction only unless it's a drive-through stop */
 		if (IsRoadTT() && IsBayRoadStopTile(m_old_tile)) {
-			DiagDirection exitdir = GetRoadStopDir(m_old_tile);
+			DiagDirection exitdir = GetBayRoadStopDir(m_old_tile);
 			if (exitdir != m_exitdir) {
 				m_err = EC_NO_WAY;
 				return false;
@@ -282,7 +282,7 @@ protected:
 	{
 		if (IsRoadTT() && IsBayRoadStopTile(m_new_tile)) {
 			/* road stop can be entered from one direction only unless it's a drive-through stop */
-			DiagDirection exitdir = GetRoadStopDir(m_new_tile);
+			DiagDirection exitdir = GetBayRoadStopDir(m_new_tile);
 			if (ReverseDiagDir(exitdir) != m_exitdir) {
 				m_err = EC_NO_WAY;
 				return false;
@@ -404,7 +404,7 @@ protected:
 
 		/* Single tram bits and standard road stops cause reversing. */
 		if (IsRoadTT() && ((IsTram() && GetSingleTramBit(m_old_tile) == ReverseDiagDir(m_exitdir)) ||
-				(IsBayRoadStopTile(m_old_tile) && GetRoadStopDir(m_old_tile) == ReverseDiagDir(m_exitdir)))) {
+				(IsBayRoadStopTile(m_old_tile) && GetBayRoadStopDir(m_old_tile) == ReverseDiagDir(m_exitdir)))) {
 			/* reverse */
 			m_new_tile = m_old_tile;
 			m_new_td_bits = TrackdirToTrackdirBits(ReverseTrackdir(m_old_td));

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -791,7 +791,7 @@ CommandCost CmdBuildRoad(DoCommandFlag flags, TileIndex tile, RoadBits pieces, R
 			if ((GetAnyRoadBits(tile, rtt) & pieces) == pieces) return_cmd_error(STR_ERROR_ALREADY_BUILT);
 			if (!IsDriveThroughStopTile(tile)) goto do_clear;
 
-			RoadBits curbits = AxisToRoadBits(DiagDirToAxis(GetRoadStopDir(tile)));
+			RoadBits curbits = AxisToRoadBits(GetDriveThroughStopAxis(tile));
 			if (pieces & ~curbits) goto do_clear;
 			pieces = curbits; // we need to pay for both roadbits
 
@@ -1463,10 +1463,10 @@ void DrawRoadCatenary(const TileInfo *ti)
 	} else if (IsTileType(ti->tile, MP_STATION)) {
 		if (IsAnyRoadStop(ti->tile)) {
 			if (IsDriveThroughStopTile(ti->tile)) {
-				Axis axis = GetRoadStopDir(ti->tile) == DIAGDIR_NE ? AXIS_X : AXIS_Y;
+				Axis axis = GetDriveThroughStopAxis(ti->tile);
 				tram = road = (axis == AXIS_X ? ROAD_X : ROAD_Y);
 			} else {
-				tram = road = DiagDirToRoadBits(GetRoadStopDir(ti->tile));
+				tram = road = DiagDirToRoadBits(GetBayRoadStopDir(ti->tile));
 			}
 		}
 	} else {

--- a/src/road_map.cpp
+++ b/src/road_map.cpp
@@ -45,8 +45,8 @@ RoadBits GetAnyRoadBits(Tile tile, RoadTramType rtt, bool straight_tunnel_bridge
 
 		case MP_STATION:
 			if (!IsAnyRoadStopTile(tile)) return ROAD_NONE;
-			if (IsDriveThroughStopTile(tile)) return (GetRoadStopDir(tile) == DIAGDIR_NE) ? ROAD_X : ROAD_Y;
-			return DiagDirToRoadBits(GetRoadStopDir(tile));
+			if (IsDriveThroughStopTile(tile)) return AxisToRoadBits(GetDriveThroughStopAxis(tile));
+			return DiagDirToRoadBits(GetBayRoadStopDir(tile));
 
 		case MP_TUNNELBRIDGE:
 			if (GetTunnelBridgeTransportType(tile) != TRANSPORT_ROAD) return ROAD_NONE;

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -897,7 +897,7 @@ static Trackdir RoadFindPathToDest(RoadVehicle *v, TileIndex tile, DiagDirection
 	} else if (IsTileType(tile, MP_STATION) && IsBayRoadStopTile(tile)) {
 		/* Standard road stop (drive-through stops are treated as normal road) */
 
-		if (!IsTileOwner(tile, v->owner) || GetRoadStopDir(tile) == enterdir || v->HasArticulatedPart()) {
+		if (!IsTileOwner(tile, v->owner) || GetBayRoadStopDir(tile) == enterdir || v->HasArticulatedPart()) {
 			/* different station owner or wrong orientation or the vehicle has articulated parts */
 			trackdirs = TRACKDIR_BIT_NONE;
 		} else {
@@ -1746,7 +1746,7 @@ Trackdir RoadVehicle::GetVehicleTrackdir() const
 
 	if (IsBayRoadStopTile(this->tile)) {
 		/* We'll assume the road vehicle is facing outwards */
-		return DiagDirToDiagTrackdir(GetRoadStopDir(this->tile)); // Road vehicle in a station
+		return DiagDirToDiagTrackdir(GetBayRoadStopDir(this->tile)); // Road vehicle in a station
 	}
 
 	/* Drive through road stops / wormholes (tunnels) */

--- a/src/script/api/script_road.cpp
+++ b/src/script/api/script_road.cpp
@@ -442,7 +442,7 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 
 		case MP_STATION:
 			if (::IsDriveThroughStopTile(neighbour_tile)) {
-				return (::DiagDirToAxis(neighbour) == ::DiagDirToAxis(::GetRoadStopDir(neighbour_tile)));
+				return ::DiagDirToAxis(neighbour) == ::GetDriveThroughStopAxis(neighbour_tile);
 			}
 			return false;
 
@@ -478,14 +478,16 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 {
 	if (!IsRoadStationTile(station)) return INVALID_TILE;
 
-	return station + ::TileOffsByDiagDir(::GetRoadStopDir(station));
+	if (::IsBayRoadStopTile(station)) return station + ::TileOffsByDiagDir(::GetBayRoadStopDir(station));
+
+	return station - ::TileOffsByAxis(::GetDriveThroughStopAxis(station));
 }
 
 /* static */ TileIndex ScriptRoad::GetDriveThroughBackTile(TileIndex station)
 {
 	if (!IsDriveThroughRoadStationTile(station)) return INVALID_TILE;
 
-	return station + ::TileOffsByDiagDir(::ReverseDiagDir(::GetRoadStopDir(station)));
+	return station + ::TileOffsByAxis(::GetDriveThroughStopAxis(station));
 }
 
 /* static */ bool ScriptRoad::_BuildRoadInternal(TileIndex start, TileIndex end, bool one_way, bool full)

--- a/src/station_map.h
+++ b/src/station_map.h
@@ -336,20 +336,27 @@ inline StationGfx GetAirportGfx(Tile t)
 }
 
 /**
- * Gets the direction the road stop entrance points towards.
+ * Gets the direction the bay road stop entrance points towards.
  * @param t the tile of the road stop
- * @pre IsAnyRoadStopTile(t)
+ * @pre IsBayRoadStopTile(t)
  * @return the direction of the entrance
  */
-inline DiagDirection GetRoadStopDir(Tile t)
+inline DiagDirection GetBayRoadStopDir(Tile t)
 {
-	StationGfx gfx = GetStationGfx(t);
-	assert(IsAnyRoadStopTile(t));
-	if (gfx < GFX_TRUCK_BUS_DRIVETHROUGH_OFFSET) {
-		return (DiagDirection)(gfx);
-	} else {
-		return (DiagDirection)(gfx - GFX_TRUCK_BUS_DRIVETHROUGH_OFFSET);
-	}
+	assert(IsBayRoadStopTile(t));
+	return static_cast<DiagDirection>(GetStationGfx(t));
+}
+
+/**
+ * Gets the axis of the drive through stop.
+ * @param t the tile of the road stop
+ * @pre IsDriveThroughStopTile(t)
+ * @return the axis the drive through is in
+ */
+inline Axis GetDriveThroughStopAxis(Tile t)
+{
+	assert(IsDriveThroughStopTile(t));
+	return static_cast<Axis>(GetStationGfx(t) - GFX_TRUCK_BUS_DRIVETHROUGH_OFFSET);
 }
 
 /**

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1252,7 +1252,9 @@ static bool CanRoadContinueIntoNextTile(const Town *t, const TileIndex tile, con
 	/* If the next tile is a station, allow if it's a road station facing the proper direction. Otherwise return false. */
 	if (IsTileType(next_tile, MP_STATION)) {
 		/* If the next tile is a road station, allow if it can be entered by the new tunnel/bridge, otherwise disallow. */
-		return IsAnyRoadStop(next_tile) && (GetRoadStopDir(next_tile) == ReverseDiagDir(road_dir) || (IsDriveThroughStopTile(next_tile) && GetRoadStopDir(next_tile) == road_dir));
+		if (IsDriveThroughStopTile(next_tile)) return GetDriveThroughStopAxis(next_tile) == DiagDirToAxis(road_dir);
+		if (IsBayRoadStopTile(next_tile)) return GetBayRoadStopDir(next_tile) == ReverseDiagDir(road_dir);
+		return false;
 	}
 
 	/* If the next tile is a road depot, allow if it's facing the right way. */

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -123,7 +123,7 @@ Axis GetAxisForNewRailWaypoint(TileIndex tile)
 Axis GetAxisForNewRoadWaypoint(TileIndex tile)
 {
 	/* The axis for existing road waypoints is easy. */
-	if (IsRoadWaypointTile(tile)) return DiagDirToAxis(GetRoadStopDir(tile));
+	if (IsRoadWaypointTile(tile)) return GetDriveThroughStopAxis(tile);
 
 	/* Non-plain road type, no valid axis for waypoints. */
 	if (!IsNormalRoadTile(tile)) return INVALID_AXIS;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When saving bay road stops to the map, we save the `DiagDirection` of the entry. When saving drive through road stops to the map, we save the `Axis` of the stop.
However, when reading orientation from the map, we always get a `DiagDirection`.

This means unneeded `DiagDirToAxis` conversions, manual conversions, getting the 'absolute' value of an offset acquired via `TileOffsByDiagDir` and similar weird constructs.


## Description

Add `GetBayRoadStopDir` that returns a `DiagDirection` and `GetDriveThroughStopAxis` that returns an `Axis`, and use these to replace `GetRoadStopDir`.

In most places we already know whether we get a bay or drive through road stop, so the check in `GetRoadStopDir` for the underlying type can be omitted. 
It does mean that in some places branches are made for bay and drive through stops, but I think these make the code clearer/simpler to understand as we just check for either `Axis` or `DiagDirection` instead of implicitly for `Axis` by checking the given `DiagDirection` and the one that has gone through `ReverseDiagDir`.


## Limitations

Conflicts with #13026, as some of those cases will now get an `Axis` from the map getter and as such no `DiagDirToAxis` conversion is needed in this PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
