### PR TITLE
Codechange: remove parameter which value can always be deduced

### DIFF
--- a/src/roadstop.cpp
+++ b/src/roadstop.cpp
@@ -360,17 +360,15 @@ static DiagDirection GetEntryDirection(bool east, Axis axis)
 /**
  * Rebuild, from scratch, the vehicles and other metadata on this stop.
  * @param rs   the roadstop this entry is part of
- * @param side the side of the road stop to look at
  */
-void RoadStop::Entry::Rebuild(const RoadStop *rs, int side)
+void RoadStop::Entry::Rebuild(const RoadStop *rs)
 {
 	assert(HasBit(rs->status, RSSFB_BASE_ENTRY));
 
 	Axis axis = GetDriveThroughStopAxis(rs->xy);
-	if (side == -1) side = (rs->east == this);
 
 	RoadStopEntryRebuilderHelper rserh;
-	rserh.dir = GetEntryDirection(side, axis);
+	rserh.dir = GetEntryDirection(rs->east == this, axis);
 
 	this->length = 0;
 	TileIndexDiff offset = TileOffsByAxis(axis);
@@ -399,6 +397,6 @@ void RoadStop::Entry::CheckIntegrity(const RoadStop *rs) const
 	assert(!IsDriveThroughRoadStopContinuation(rs->xy, rs->xy - TileOffsByAxis(GetDriveThroughStopAxis(rs->xy))));
 
 	Entry temp;
-	temp.Rebuild(rs, rs->east == this);
+	temp.Rebuild(rs);
 	if (temp.length != this->length || temp.occupied != this->occupied) NOT_REACHED();
 }

--- a/src/roadstop_base.h
+++ b/src/roadstop_base.h
@@ -61,7 +61,7 @@ struct RoadStop : RoadStopPool::PoolItem<&_roadstop_pool> {
 		void Leave(const RoadVehicle *rv);
 		void Enter(const RoadVehicle *rv);
 		void CheckIntegrity(const RoadStop *rs) const;
-		void Rebuild(const RoadStop *rs, int side = -1);
+		void Rebuild(const RoadStop *rs);
 	};
 
 	uint8_t status; ///< Current status of the Stop, @see RoadStopSatusFlag. Access using *Bay and *Busy functions.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`RoadStop::Entry::Rebuild` has an `int` parameter `side` that is, by default `-1`, and in the one case where it is set to `rs->east == this`. When `-1` is used, `side` is also set to `rs->east == this` in the function itself. In other words, after that assignment it's always `rs->east == this` making the existence of the parameter pointless.

To add insult to injury, side is later evaluated as a `bool`.


## Description

Remove the `side` parameter and use `rs->east == this` in the one place `side` was used.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
