### PR TITLE
Codechange: Simplify storage of WaterTileType in map.

### DIFF
--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -1050,98 +1050,92 @@
      <li>m1 bits 4..0: <a href="#OwnershipInfo">owner</a> (for sea, rivers, and coasts normally <tt>11</tt>)</li>
      <li>m2: Depot index (for depots only)</li>
      <li>m4: Random data for canal or river tiles</li>
-     <li>m5: tile type:
+     <li>m5 bits 7..4: Water tile type:
       <table>
-       <tr>
-        <td nowrap valign=top><tt>00</tt>&nbsp; </td>
-        <td align=left>water, canal or river</td>
-       </tr>
-
-       <tr>
-        <td nowrap valign=top><tt>01</tt>&nbsp; </td>
-        <td align=left>coast or riverbank</td>
-       </tr>
-
-       <tr>
-        <td nowrap valign=top><tt>10</tt>..<tt>1B</tt>&nbsp; </td>
-        <td align=left>canal locks
-         <table>
-          <tr>
-           <td nowrap valign=top><tt>10</tt>&nbsp; </td>
-           <td align=left>middle part, (SW-NE direction)</td>
-          </tr>
-          <tr>
-           <td nowrap valign=top><tt>11</tt>&nbsp; </td>
-           <td align=left>middle part, (NW-SE direction)</td>
-          </tr>
-          <tr>
-           <td nowrap valign=top><tt>12</tt>&nbsp; </td>
-           <td align=left>middle part, (NE-SW direction)</td>
-          </tr>
-          <tr>
-           <td nowrap valign=top><tt>13</tt>&nbsp; </td>
-           <td align=left>middle part, (SE-NW direction)</td>
-          </tr>
-          <tr>
-           <td nowrap valign=top><tt>14</tt>&nbsp; </td>
-           <td align=left>lower part, (SW-NE direction)</td>
-          </tr>
-          <tr>
-           <td nowrap valign=top><tt>15</tt>&nbsp; </td>
-           <td align=left>lower part, (NW-SE direction)</td>
-          </tr>
-          <tr>
-           <td nowrap valign=top><tt>16</tt>&nbsp; </td>
-           <td align=left>lower part, (NE-SW direction)</td>
-          </tr>
-          <tr>
-           <td nowrap valign=top><tt>17</tt>&nbsp; </td>
-           <td align=left>lower part, (SE-NW direction)</td>
-          </tr>
-          <tr>
-           <td nowrap valign=top><tt>18</tt>&nbsp; </td>
-           <td align=left>upper part, (SW-NE direction)</td>
-          </tr>
-          <tr>
-           <td nowrap valign=top><tt>19</tt>&nbsp; </td>
-           <td align=left>upper part, (NW-SE direction)</td>
-          </tr>
-          <tr>
-           <td nowrap valign=top><tt>1A</tt>&nbsp; </td>
-           <td align=left>upper part, (NE-SW direction)</td>
-          </tr>
-          <tr>
-           <td nowrap valign=top><tt>1B</tt>&nbsp; </td>
-           <td align=left>upper part, (SE-NW direction)</td>
-          </tr>
-         </table>
-        </td>
-       </tr>
-
-       <tr>
-        <td nowrap valign=top><tt>80</tt>..<tt>83</tt>&nbsp; </td>
-        <td align=left>ship depots
-         <table>
-          <tr>
-           <td nowrap valign=top><tt>80</tt>&nbsp; </td>
-           <td align=left>ship depot, NE part (X direction)</td>
-          </tr>
-          <tr>
-           <td nowrap valign=top><tt>81</tt>&nbsp; </td>
-           <td align=left>ship depot, SW part (X direction)</td>
-          </tr>
-          <tr>
-           <td nowrap valign=top><tt>82</tt>&nbsp; </td>
-           <td align=left>ship depot, NW part (Y direction)</td>
-          </tr>
-          <tr>
-           <td nowrap valign=top><tt>83</tt>&nbsp; </td>
-           <td align=left>ship depot, SE part (Y direction)</td>
-          </tr>
-         </table>
-        </td>
-       </tr>
-      </table>
+        <tr>
+         <td><tt>0</tt>&nbsp; </td>
+         <td>water, canal or river</td>
+        </tr>
+        <tr>
+         <td><tt>1</tt>&nbsp; </td>
+         <td>coast or riverbank</td>
+        </tr>
+        <tr>
+         <td nowrap valign=top><tt>2</tt>&nbsp; </td>
+         <td>canal lock<br>
+          <ul>
+           <li>m5 bits 3..2: Lock part
+            <table>
+             <tr>
+              <td><tt>0</tt>&nbsp; </td>
+              <td>Middle part</td>
+             </tr>
+             <tr>
+              <td><tt>1</tt>&nbsp; </td>
+              <td>Lower part</td>
+             </tr>
+             <tr>
+              <td><tt>2</tt>&nbsp; </td>
+              <td>Upper part</td>
+             </tr>
+            </table>
+           </li>
+           <li>m5 bits 1..0: Lock direction
+            <table>
+             <tr>
+              <td><tt>0</tt>&nbsp; </td>
+              <td>NE raised</td>
+             </tr>
+             <tr>
+              <td><tt>1</tt>&nbsp; </td>
+              <td>SE raised</td>
+             </tr>
+             <tr>
+              <td><tt>2</tt>&nbsp; </td>
+              <td>SW raised</td>
+             </tr>
+             <tr>
+              <td><tt>3</tt>&nbsp; </td>
+              <td>NW raised</td>
+             </tr>
+            </table>
+           </li>
+          </ul>
+         </td>
+        </tr>
+        <tr>
+         <td nowrap valign=top><tt>3</tt>&nbsp; </td>
+         <td>depot<br>
+          <ul>
+           <li>m5 bit 1: Depot axis
+            <table>
+             <tr>
+              <td><tt>0</tt>&nbsp; </td>
+              <td>X direction (NE-SW)</td>
+             </tr>
+             <tr>
+              <td><tt>1</tt>&nbsp; </td>
+              <td>Y direction (NW-SE)</td>
+             </tr>
+            </table>
+           </li>
+           <li>m5 bit 0: Depot part
+            <table>
+             <tr>
+              <td><tt>0</tt>&nbsp; </td>
+              <td>North part</td>
+             </tr>
+             <tr>
+              <td><tt>1</tt>&nbsp; </td>
+              <td>South part</td>
+             </tr>
+            </table>
+           </li>
+          </ul>
+         </td>
+        </tr>
+       </table>
+      </li>
      </li>
     </ul>
    </td>

--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -240,32 +240,37 @@ the array so you can quickly see what is used and what is not.
       <td class="bits"><span class="free">OOOO OOOO</span></td>
     </tr>
     <tr>
-      <td rowspan=4>6</td>
-      <td class="caption">sea, shore</td>
-      <td class="bits" rowspan=4><span class="used" title="Ship docking tile status">X</span> <span class="used" title="Water class">XX</span> <span class="used" title="Owner">XXXXX</span></td>
-      <td class="bits" rowspan=3><span class="free">OOOO OOOO OOOO OOOO</span></td>
-      <td class="bits" rowspan=4><span class="free">OOOO OOOO</span></td>
-      <td class="bits"><span class="free">OOOO OOOO</span></td>
-      <td class="bits"><span class="used" title="Water tile type: coast, clear, lock, depot">O<span class="usable">OO</span>O</span> <span class="free">OOO</span><span class="used" title="Sea shore flag">X</span></td>
-      <td class="bits" rowspan=4><span class="free">OOOO OOOO</span></td>
-      <td class="bits" rowspan=4><span class="free">OOOO OOOO</td>
+      <td rowspan=5>6</td>
+      <td class="caption">sea</td>
+      <td class="bits" rowspan=5><span class="used" title="Ship docking tile status">X</span> <span class="used" title="Water class">XX</span> <span class="used" title="Owner">XXXXX</span></td>
       <td class="bits" rowspan=4><span class="free">OOOO OOOO OOOO OOOO</span></td>
+      <td class="bits" rowspan=5><span class="free">OOOO OOOO</span></td>
+      <td class="bits"><span class="free">OOOO OOOO</span></td>
+      <td class="bits"><span class="used" title="Water tile type: coast, clear, lock, depot">0000</span> <span class="free">OOO0</span></td>
+      <td class="bits" rowspan=5><span class="free">OOOO OOOO</span></td>
+      <td class="bits" rowspan=5><span class="free">OOOO OOOO</td>
+      <td class="bits" rowspan=5><span class="free">OOOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td class="caption">canal, river</td>
       <td class="bits"><span class="used" title="Canal/river random bits">XXXX XXXX</span></td>
-      <td class="bits"><span class="used" title="Water tile type: coast, clear, lock, depot">O<span class="usable">OO</span>O</span> <span class="free">OOOO</span></td>
+      <td class="bits"><span class="used" title="Water tile type: coast, clear, lock, depot">0000</span> <span class="free">OOOO</span></td>
+    </tr>
+    <tr>
+      <td class="caption">shore</td>
+      <td class="bits"><span class="free">OOOO OOOO</span></td>
+      <td class="bits"><span class="used" title="Water tile type: coast, clear, lock, depot">0001</span> <span class="free">OOOO</span></td>
     </tr>
     <tr>
       <td class="caption">lock</td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
-      <td class="bits"><span class="used" title="Water tile type: coast, clear, lock, depot">O<span class="usable">OO</span>1</span> <span class="used" title="Lock part">XX</span> <span class="used" title="Lock orientation m5[1..0]">XX</span></td>
+      <td class="bits"><span class="used" title="Water tile type: coast, clear, lock, depot">0010</span> <span class="used" title="Lock part">XX</span><span class="used" title="Lock orientation m5[1..0]">XX</span></td>
     </tr>
     <tr>
       <td class="caption">shipdepot</td>
       <td class="bits"><span class="pool" title="Depot index on pool">XXXX XXXX XXXX XXXX</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
-      <td class="bits"><span class="used" title="Water tile type: coast, clear, lock, depot">1<span class="usable">OOO</span></span> <span class="free">OO</span><span class="used" title="Depot axis">X</span> <span class="used" title="Depot part">X</span></td>
+      <td class="bits"><span class="used" title="Water tile type: coast, clear, lock, depot">0011</span> <span class="free">OO</span><span class="used" title="Depot axis">X</span><span class="used" title="Depot part">X</span></td>
     </tr>
     <tr>
       <td rowspan=2>8</td>

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -387,6 +387,7 @@ enum SaveLoadVersion : uint16_t {
 
 	SLV_ROAD_STOP_TILE_DATA,                ///< 340  PR#12883 Move storage of road stop tile data, also save for road waypoints.
 	SLV_COMPANY_ALLOW_LIST_V2,              ///< 341  PR#12908 Fixed savegame format for saving of list of client keys that are allowed to join this company.
+	SLV_WATER_TILE_TYPE,                    ///< 342  PR#13030 Simplify water tile type.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Water tile type is not stored directly in the map, it has to under go conversion every time it is looked up,

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead of doing the conversion every time `GetWaterTileType()` is called, do the conversion on map load. This replaces the special values with values from the `WaterTileType` instead, and `GetWaterTileType()` becomes a simple accessor.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Needs a savegame bump.

WBL_TYPE_COUNT could maybe be reduced to 2 as only 4 values are used.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
