### PR TITLE
Add: Improving town-owned bridges increases company rating

### DIFF
--- a/src/town_type.h
+++ b/src/town_type.h
@@ -53,6 +53,7 @@ static constexpr int RATING_GROWTH_MAXIMUM = RATING_MEDIOCRE; ///< ... up to RAT
 static constexpr int RATING_STATION_UP_STEP = 12; ///< when a town grows, company gains reputation for all well serviced stations ...
 static constexpr int RATING_STATION_DOWN_STEP = -15; ///< ... but loses for badly serviced stations
 
+static constexpr int RATING_TUNNEL_BRIDGE_UP_STEP = 50; ///< rating increase for improving a town-owned bridge
 static constexpr int RATING_TUNNEL_BRIDGE_DOWN_STEP = -250; ///< penalty for removing town owned tunnel or bridge
 static constexpr int RATING_TUNNEL_BRIDGE_MINIMUM = 0; ///< minimum rating after removing tunnel or bridge
 static constexpr int RATING_TUNNEL_BRIDGE_NEEDED_LENIENT = 144; ///< rating needed, "Lenient" difficulty settings


### PR DESCRIPTION
## Motivation / Problem

OpenTTD specifically allows players to *upgrade* but not downgrade town-owned bridges, which implies local authorities show some gratitude for this act of civic improvement, but this is not reflected in any change to company rating. This feels like an oversight to me.

## Description

I added what felt like a fair change to company rating for the act of upgrading a town-owned bridge. I also performed some minor refactoring on the code in this area: in particular, it seemed to make sense to perform the check for replacing a bridge with an identical type of bridge before the check for a town-owned bridge, since not doing so could create an exploit where the player repeatedly fails to upgrade a town-owned bridge and gets the increased rating for free.

## Limitations

This is my first time contributing to OpenTTD; I did my best to adhere to the coding style and contributing guidelines, but I am not perfect. In particular, I didn't use the git hooks as instructed because I do not have the spoons to work out how to translate a use of `ln` to the equivalent command on Windows. I hope this isn't a problem.

This provides another way for players to increase their company rating without servicing stations in the local authority's catchment area; it seemed inoffensive to me since there's already a fairly widely recommended practice of "spamming" trees to increase company rating, and town-owned bridges aren't too common.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
