### PR TITLE
Codefix: Use SpriteID when passing sprite IDs.

### DIFF
--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -43,10 +43,10 @@ static const SpriteID * const _landscape_spriteindexes[] = {
  * @param needs_palette_remap Whether the colours in the GRF file need a palette remap.
  * @return The number of loaded sprites.
  */
-static uint LoadGrfFile(const std::string &filename, uint load_index, bool needs_palette_remap)
+static uint LoadGrfFile(const std::string &filename, SpriteID load_index, bool needs_palette_remap)
 {
-	uint load_index_org = load_index;
-	uint sprite_id = 0;
+	SpriteID load_index_org = load_index;
+	SpriteID sprite_id = 0;
 
 	SpriteFile &file = OpenCachedSpriteFile(filename, BASESET_DIR, needs_palette_remap);
 

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -6469,7 +6469,7 @@ static void GraphicsNew(ByteReader &buf)
 
 	for (; num > 0; num--) {
 		_cur.nfo_line++;
-		int load_index = (replace == 0 ? _cur.spriteid++ : replace++);
+		SpriteID load_index = (replace == 0 ? _cur.spriteid++ : replace++);
 		LoadNextSprite(load_index, *_cur.file, _cur.nfo_line);
 		if (dup_oneway_sprites) {
 			DupSprite(load_index, load_index + SPR_ONEWAY_SLOPE_N_OFFSET);
@@ -7084,7 +7084,7 @@ static void SpriteReplace(ByteReader &buf)
 		}
 
 		for (uint j = 0; j < num_sprites; j++) {
-			int load_index = first_sprite + j;
+			SpriteID load_index = first_sprite + j;
 			_cur.nfo_line++;
 			LoadNextSprite(load_index, *_cur.file, _cur.nfo_line); // XXX
 
@@ -10014,7 +10014,7 @@ static void AfterLoadGRFs()
  * @param load_index The offset for the first sprite to add.
  * @param num_baseset Number of NewGRFs at the front of the list to look up in the baseset dir instead of the newgrf dir.
  */
-void LoadNewGRF(uint load_index, uint num_baseset)
+void LoadNewGRF(SpriteID load_index, uint num_baseset)
 {
 	/* In case of networking we need to "sync" the start values
 	 * so all NewGRFs are loaded equally. For this we use the

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -196,7 +196,7 @@ inline bool HasGrfMiscBit(GrfMiscBit bit)
 extern GRFLoadedFeatures _loaded_newgrf_features;
 
 void LoadNewGRFFile(struct GRFConfig *config, GrfLoadingStage stage, Subdirectory subdir, bool temporary);
-void LoadNewGRF(uint load_index, uint num_baseset);
+void LoadNewGRF(SpriteID load_index, uint num_baseset);
 void ReloadNewGRFData(); // in saveload/afterload.cpp
 void ResetNewGRFData();
 void ResetPersistentNewGRFData();

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -573,7 +573,7 @@ void ReadGRFSpriteOffsets(SpriteFile &file)
 
 		/* Loop over all sprite section entries and store the file
 		 * offset for each newly encountered ID. */
-		uint32_t id, prev_id = 0;
+		SpriteID id, prev_id = 0;
 		while ((id = file.ReadDword()) != 0) {
 			if (id != prev_id) {
 				_grf_sprite_offsets[prev_id] = offset;
@@ -615,7 +615,7 @@ void ReadGRFSpriteOffsets(SpriteFile &file)
  * @param container_version Container version of the GRF.
  * @return True if a valid sprite was loaded, false on any error.
  */
-bool LoadNextSprite(int load_index, SpriteFile &file, uint file_sprite_id)
+bool LoadNextSprite(SpriteID load_index, SpriteFile &file, uint file_sprite_id)
 {
 	size_t file_pos = file.GetPos();
 
@@ -661,7 +661,7 @@ bool LoadNextSprite(int load_index, SpriteFile &file, uint file_sprite_id)
 
 	if (type == SpriteType::Invalid) return false;
 
-	if (static_cast<uint>(load_index) >= MAX_SPRITES) {
+	if (load_index >= MAX_SPRITES) {
 		UserError("Tried to load too many sprites (#{}; max {})", load_index, MAX_SPRITES);
 	}
 

--- a/src/spritecache.h
+++ b/src/spritecache.h
@@ -77,7 +77,7 @@ std::span<const std::unique_ptr<SpriteFile>> GetCachedSpriteFiles();
 
 void ReadGRFSpriteOffsets(SpriteFile &file);
 size_t GetGRFSpriteOffset(uint32_t id);
-bool LoadNextSprite(int load_index, SpriteFile &file, uint file_sprite_id);
+bool LoadNextSprite(SpriteID load_index, SpriteFile &file, uint file_sprite_id);
 bool SkipSpriteData(SpriteFile &file, uint8_t type, uint16_t num);
 void DupSprite(SpriteID old_spr, SpriteID new_spr);
 

--- a/src/tests/mock_spritecache.cpp
+++ b/src/tests/mock_spritecache.cpp
@@ -15,7 +15,7 @@
 #include "../spritecache_internal.h"
 #include "../table/sprites.h"
 
-static bool MockLoadNextSprite(int load_index)
+static bool MockLoadNextSprite(SpriteID load_index)
 {
 	SimpleSpriteAllocator allocator;
 	static Sprite *sprite = allocator.Allocate<Sprite>(sizeof(*sprite));
@@ -33,7 +33,7 @@ static bool MockLoadNextSprite(int load_index)
 	sc->control_flags = 0;
 
 	/* Fill with empty sprites up until the default sprite count. */
-	return (uint)load_index < SPR_OPENTTD_BASE + OPENTTD_SPRITE_COUNT;
+	return load_index < SPR_OPENTTD_BASE + OPENTTD_SPRITE_COUNT;
 }
 
 void MockGfxLoadSprites()
@@ -43,7 +43,7 @@ void MockGfxLoadSprites()
 
 	GfxInitSpriteMem();
 
-	int load_index = 0;
+	SpriteID load_index = 0;
 	while (MockLoadNextSprite(load_index)) {
 		load_index++;
 	}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When loading sprites and NewGRFs, we pass a signed integer to refer the "load index", which is where sprites shall be "placed". This is otherwise known as a `SpriteID`.

We don't allow loading sprites with a negative index.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use `SpriteID` type instead of `int`. This removes type ambiguity.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
