### PR TITLE
Codefix a6f412c6: Missing this-> in YAPF

### DIFF
--- a/src/pathfinder/yapf/yapf_costcache.hpp
+++ b/src/pathfinder/yapf/yapf_costcache.hpp
@@ -88,7 +88,7 @@ struct CSegmentCostCacheT : public CSegmentCostCacheBase {
 		Tsegment *item = this->map.Find(key);
 		if (item == nullptr) {
 			*found = false;
-			item = &heap.emplace_back(key);
+			item = &this->heap.emplace_back(key);
 			this->map.Push(*item);
 		} else {
 			*found = true;


### PR DESCRIPTION
## Motivation / Problem

a6f412c6/#13005 missed a `this->`.

## Description

This PR adds a `this`. This is per this project's code style.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
