### PR TITLE
Codechange: Split GoodsEntry cargo and flows data to unique_ptr.

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -1387,7 +1387,7 @@ static void MaybeCrashAirplane(Aircraft *v)
 	/* Crash the airplane. Remove all goods stored at the station. */
 	for (GoodsEntry &ge : st->goods) {
 		ge.rating = 1;
-		ge.cargo.Truncate();
+		if (ge.HasData()) ge.GetData().cargo.Truncate();
 	}
 
 	CrashAirplane(v);

--- a/src/cachecheck.cpp
+++ b/src/cachecheck.cpp
@@ -170,11 +170,14 @@ void CheckCaches()
 
 	for (Station *st : Station::Iterate()) {
 		for (GoodsEntry &ge : st->goods) {
-			[[maybe_unused]] const auto a = ge.cargo.PeriodsInTransit();
-			[[maybe_unused]] const auto b = ge.cargo.TotalCount();
-			ge.cargo.InvalidateCache();
-			assert(a == ge.cargo.PeriodsInTransit());
-			assert(b == ge.cargo.TotalCount());
+			if (!ge.HasData()) continue;
+
+			StationCargoList &cargo_list = ge.GetData().cargo;
+			[[maybe_unused]] const auto a = cargo_list.PeriodsInTransit();
+			[[maybe_unused]] const auto b = cargo_list.TotalCount();
+			cargo_list.InvalidateCache();
+			assert(a == cargo_list.PeriodsInTransit());
+			assert(b == cargo_list.TotalCount());
 		}
 
 		/* Check docking tiles */

--- a/src/cargopacket.cpp
+++ b/src/cargopacket.cpp
@@ -446,6 +446,9 @@ bool VehicleCargoList::Stage(bool accepted, StationID current_station, StationID
 	Iterator it = this->packets.begin();
 	uint sum = 0;
 
+	static const FlowStatMap EMPTY_FLOW_STAT_MAP = {};
+	const FlowStatMap &flows = ge->HasData() ? ge->GetData().flows : EMPTY_FLOW_STAT_MAP;
+
 	bool force_keep = (order_flags & OUFB_NO_UNLOAD) != 0;
 	bool force_unload = (order_flags & OUFB_UNLOAD) != 0;
 	bool force_transfer = (order_flags & (OUFB_TRANSFER | OUFB_UNLOAD)) != 0;
@@ -464,8 +467,8 @@ bool VehicleCargoList::Stage(bool accepted, StationID current_station, StationID
 			action = MTA_TRANSFER;
 			/* We cannot send the cargo to any of the possible next hops and
 			 * also not to the current station. */
-			FlowStatMap::const_iterator flow_it(ge->flows.find(cp->first_station));
-			if (flow_it == ge->flows.end()) {
+			FlowStatMap::const_iterator flow_it(flows.find(cp->first_station));
+			if (flow_it == flows.end()) {
 				cargo_next = INVALID_STATION;
 			} else {
 				FlowStat new_shares = flow_it->second;
@@ -483,12 +486,12 @@ bool VehicleCargoList::Stage(bool accepted, StationID current_station, StationID
 		} else {
 			/* Rewrite an invalid source station to some random other one to
 			 * avoid keeping the cargo in the vehicle forever. */
-			if (cp->first_station == INVALID_STATION && !ge->flows.empty()) {
-				cp->first_station = ge->flows.begin()->first;
+			if (cp->first_station == INVALID_STATION && !flows.empty()) {
+				cp->first_station = flows.begin()->first;
 			}
 			bool restricted = false;
-			FlowStatMap::const_iterator flow_it(ge->flows.find(cp->first_station));
-			if (flow_it == ge->flows.end()) {
+			FlowStatMap::const_iterator flow_it(flows.find(cp->first_station));
+			if (flow_it == flows.end()) {
 				cargo_next = INVALID_STATION;
 			} else {
 				cargo_next = flow_it->second.GetViaWithRestricted(restricted);

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -223,7 +223,7 @@ void LinkGraphOverlay::AddLinks(const Station *from, const Station *to)
 		if (lg[ge.node].HasEdgeTo(to->goods[c].node)) {
 			ConstEdge &edge = lg[ge.node][to->goods[c].node];
 			this->AddStats(c, lg.Monthly(edge.capacity), lg.Monthly(edge.usage),
-					ge.flows.GetFlowVia(to->index),
+					ge.HasData() ? ge.GetData().flows.GetFlowVia(to->index) : 0,
 					edge.TravelTime() / Ticks::DAY_TICKS,
 					from->owner == OWNER_NONE || to->owner == OWNER_NONE,
 					this->cached_links[from->index][to->index]);

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -232,7 +232,7 @@ RoadStopResolverObject::RoadStopResolverObject(const RoadStopSpec *roadstopspec,
 		/* Pick the first cargo that we have waiting */
 		for (const CargoSpec *cs : CargoSpec::Iterate()) {
 			if (roadstopspec->grf_prop.spritegroup[cs->Index()] != nullptr &&
-					station->goods[cs->Index()].cargo.TotalCount() > 0) {
+					station->goods[cs->Index()].HasData() && station->goods[cs->Index()].GetData().cargo.TotalCount() > 0) {
 				ctype = cs->Index();
 				break;
 			}

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1730,7 +1730,7 @@ bool AfterLoadGame()
 		for (Station *st : Station::Iterate()) {
 			for (GoodsEntry &ge : st->goods) {
 				ge.last_speed = 0;
-				if (ge.cargo.AvailableCount() != 0) SetBit(ge.status, GoodsEntry::GES_RATING);
+				if (ge.HasData() && ge.GetData().cargo.AvailableCount() != 0) SetBit(ge.status, GoodsEntry::GES_RATING);
 			}
 		}
 	}

--- a/src/saveload/cargopacket_sl.cpp
+++ b/src/saveload/cargopacket_sl.cpp
@@ -44,7 +44,8 @@
 		 * station */
 		for (Station *st : Station::Iterate()) {
 			for (GoodsEntry &ge : st->goods) {
-				const StationCargoPacketMap *packets = ge.cargo.Packets();
+				if (!ge.HasData()) continue;
+				const StationCargoPacketMap *packets = ge.GetData().cargo.Packets();
 				for (StationCargoList::ConstIterator it(packets->begin()); it != packets->end(); it++) {
 					CargoPacket *cp = *it;
 					cp->source_xy = Station::IsValidID(cp->first_station) ? Station::Get(cp->first_station)->xy : st->xy;
@@ -67,7 +68,10 @@
 		for (Vehicle *v : Vehicle::Iterate()) v->cargo.InvalidateCache();
 
 		for (Station *st : Station::Iterate()) {
-			for (GoodsEntry &ge : st->goods) ge.cargo.InvalidateCache();
+			for (GoodsEntry &ge : st->goods) {
+				if (!ge.HasData()) continue;
+				ge.GetData().cargo.InvalidateCache();
+			}
 		}
 	}
 
@@ -80,7 +84,9 @@
 		/* Update the cargo-traveled in stations as if they arrived from the source tile. */
 		for (Station *st : Station::Iterate()) {
 			for (GoodsEntry &ge : st->goods) {
-				for (auto it = ge.cargo.Packets()->begin(); it != ge.cargo.Packets()->end(); ++it) {
+				if (!ge.HasData()) continue;
+				StationCargoList &cargo_list = ge.GetData().cargo;
+				for (auto it = cargo_list.Packets()->begin(); it != cargo_list.Packets()->end(); ++it) {
 					for (CargoPacket *cp : it->second) {
 						if (cp->source_xy != INVALID_TILE && cp->source_xy != st->xy) {
 							cp->travelled.x = TileX(cp->source_xy) - TileX(st->xy);

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -726,7 +726,7 @@ static bool LoadOldGood(LoadgameState *ls, int num)
 	AssignBit(ge->status, GoodsEntry::GES_ACCEPTANCE, HasBit(_waiting_acceptance, 15));
 	AssignBit(ge->status, GoodsEntry::GES_RATING, _cargo_source != 0xFF);
 	if (GB(_waiting_acceptance, 0, 12) != 0 && CargoPacket::CanAllocateItem()) {
-		ge->cargo.Append(new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, (_cargo_source == 0xFF) ? INVALID_STATION : _cargo_source, INVALID_TILE, 0),
+		ge->GetOrCreateData().cargo.Append(new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, (_cargo_source == 0xFF) ? INVALID_STATION : _cargo_source, INVALID_TILE, 0),
 				INVALID_STATION);
 	}
 

--- a/src/script/api/script_station.cpp
+++ b/src/script/api/script_station.cpp
@@ -59,7 +59,10 @@ template<bool Tfrom, bool Tvia>
 		return -1;
 	}
 
-	const StationCargoList &cargo_list = ::Station::Get(station_id)->goods[cargo_id].cargo;
+	const ::GoodsEntry &goods = ::Station::Get(station_id)->goods[cargo_id];
+	if (!goods.HasData()) return 0;
+
+	const StationCargoList &cargo_list = goods.GetData().cargo;
 	if (!Tfrom && !Tvia) return cargo_list.TotalCount();
 
 	uint16_t cargo_count = 0;
@@ -107,7 +110,10 @@ template<bool Tfrom, bool Tvia>
 		return -1;
 	}
 
-	const FlowStatMap &flows = ::Station::Get(station_id)->goods[cargo_id].flows;
+	const ::GoodsEntry &goods = ::Station::Get(station_id)->goods[cargo_id];
+	if (!goods.HasData()) return 0;
+
+	const FlowStatMap &flows = goods.GetData().flows;
 	if (Tfrom) {
 		return Tvia ? flows.GetFlowFromVia(from_station_id, via_station_id) :
 					  flows.GetFlowFrom(from_station_id);

--- a/src/script/api/script_stationlist.cpp
+++ b/src/script/api/script_stationlist.cpp
@@ -179,9 +179,10 @@ void ScriptStationList_CargoWaiting::Add(StationID station_id, CargoID cargo, St
 {
 	CargoCollector collector(this, station_id, cargo, other_station);
 	if (collector.GE() == nullptr) return;
+	if (!collector.GE()->HasData()) return;
 
-	StationCargoList::ConstIterator iter = collector.GE()->cargo.Packets()->begin();
-	StationCargoList::ConstIterator end = collector.GE()->cargo.Packets()->end();
+	StationCargoList::ConstIterator iter = collector.GE()->GetData().cargo.Packets()->begin();
+	StationCargoList::ConstIterator end = collector.GE()->GetData().cargo.Packets()->end();
 	for (; iter != end; ++iter) {
 		collector.Update<Tselector>((*iter)->GetFirstStation(), iter.GetKey(), (*iter)->Count());
 	}
@@ -193,9 +194,10 @@ void ScriptStationList_CargoPlanned::Add(StationID station_id, CargoID cargo, St
 {
 	CargoCollector collector(this, station_id, cargo, other_station);
 	if (collector.GE() == nullptr) return;
+	if (!collector.GE()->HasData()) return;
 
-	FlowStatMap::const_iterator iter = collector.GE()->flows.begin();
-	FlowStatMap::const_iterator end = collector.GE()->flows.end();
+	FlowStatMap::const_iterator iter = collector.GE()->GetData().flows.begin();
+	FlowStatMap::const_iterator end = collector.GE()->GetData().flows.end();
 	for (; iter != end; ++iter) {
 		const FlowStat::SharesMap *shares = iter->second.GetShares();
 		uint prev = 0;
@@ -218,9 +220,10 @@ ScriptStationList_CargoWaitingViaByFrom::ScriptStationList_CargoWaitingViaByFrom
 {
 	CargoCollector collector(this, station_id, cargo, via);
 	if (collector.GE() == nullptr) return;
+	if (!collector.GE()->HasData()) return;
 
 	std::pair<StationCargoList::ConstIterator, StationCargoList::ConstIterator> range =
-			collector.GE()->cargo.Packets()->equal_range(via);
+			collector.GE()->GetData().cargo.Packets()->equal_range(via);
 	for (StationCargoList::ConstIterator iter = range.first; iter != range.second; ++iter) {
 		collector.Update<CS_VIA_BY_FROM>((*iter)->GetFirstStation(), iter.GetKey(), (*iter)->Count());
 	}
@@ -264,9 +267,10 @@ ScriptStationList_CargoPlannedFromByVia::ScriptStationList_CargoPlannedFromByVia
 {
 	CargoCollector collector(this, station_id, cargo, from);
 	if (collector.GE() == nullptr) return;
+	if (!collector.GE()->HasData()) return;
 
-	FlowStatMap::const_iterator iter = collector.GE()->flows.find(from);
-	if (iter == collector.GE()->flows.end()) return;
+	FlowStatMap::const_iterator iter = collector.GE()->GetData().flows.find(from);
+	if (iter == collector.GE()->GetData().flows.end()) return;
 	const FlowStat::SharesMap *shares = iter->second.GetShares();
 	uint prev = 0;
 	for (FlowStat::SharesMap::const_iterator flow_iter = shares->begin();

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -84,7 +84,8 @@ Station::~Station()
 {
 	if (CleaningPool()) {
 		for (GoodsEntry &ge : this->goods) {
-			ge.cargo.OnCleanPool();
+			if (!ge.HasData()) continue;
+			ge.GetData().cargo.OnCleanPool();
 		}
 		return;
 	}
@@ -104,9 +105,10 @@ Station::~Station()
 
 		for (NodeID node = 0; node < lg->Size(); ++node) {
 			Station *st = Station::Get((*lg)[node].station);
-			st->goods[c].flows.erase(this->index);
+			if (!st->goods[c].HasData()) continue;
+			st->goods[c].GetData().flows.erase(this->index);
 			if ((*lg)[node].HasEdgeTo(this->goods[c].node) && (*lg)[node][this->goods[c].node].LastUpdate() != EconomyTime::INVALID_DATE) {
-				st->goods[c].flows.DeleteFlows(this->index);
+				st->goods[c].GetData().flows.DeleteFlows(this->index);
 				RerouteCargo(st, c, this->index, st->index);
 			}
 		}
@@ -149,7 +151,8 @@ Station::~Station()
 	DeleteStationNews(this->index);
 
 	for (GoodsEntry &ge : this->goods) {
-		ge.cargo.Truncate();
+		if (!ge.HasData()) continue;
+		ge.GetData().cargo.Truncate();
 	}
 
 	CargoPacket::InvalidateAllFrom(this->index);

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2337,7 +2337,7 @@ void Vehicle::CancelReservation(StationID next, Station *st)
 		VehicleCargoList &cargo = v->cargo;
 		if (cargo.ActionCount(VehicleCargoList::MTA_LOAD) > 0) {
 			Debug(misc, 1, "cancelling cargo reservation");
-			cargo.Return(UINT_MAX, &st->goods[v->cargo_type].cargo, next, v->tile);
+			cargo.Return(UINT_MAX, &st->goods[v->cargo_type].GetOrCreateData().cargo, next, v->tile);
 		}
 		cargo.KeepAll();
 	}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Because someone™ long ago thought 64 cargo types was a reasonable idea, some data structures since then are huge.

GoodsEntry is 136 bytes which is not much, but when there are 64 of them, that is 8,704 bytes allocated to a station just in case cargo is transported to/from the station. Even if there are only 11 cargos defined.

This makes a single station use nearly 10KiB of memory to just exist.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Split GoodsEntry cargo and flows data to unique_ptr.

This allows cargo packets and cargo flow data to be empty if not in use, which is the case for the majority of station goods entries, and data is allocated when needed.

This reduces GoodsEntry down to 24 bytes, and the initial size of a Station from 9192 bytes to 2024 bytes (on 64 bit platforms), although an allocation of 120 bytes is made for each active cargo type at a station.

Based on similar changes in JGRPP.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Only had brief testing so far. It's not exactly the same as the JGRPP changes (it can't be...) so I might have missed something.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
