### PR TITLE
Fix: x-axis direction of industry production graph in wallclock timekeeping mode

### DIFF
--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -199,7 +199,7 @@ protected:
 	/* These values are used if the graph is being plotted against values
 	 * rather than the dates specified by month and year. */
 	uint16_t x_values_start;
-	int16_t x_values_increment;
+	uint16_t x_values_increment;
 
 	StringID format_str_y_axis;
 	uint8_t colours[GRAPH_MAX_DATASETS];
@@ -1429,8 +1429,8 @@ struct IndustryProductionGraphWindow : BaseGraphWindow {
 		this->num_on_x_axis = GRAPH_NUM_MONTHS;
 		this->num_vert_lines = GRAPH_NUM_MONTHS;
 		this->month_increment = 1;
-		this->x_values_start = GRAPH_NUM_MONTHS;
-		this->x_values_increment = -ECONOMY_MONTH_MINUTES;
+		this->x_values_start = ECONOMY_MONTH_MINUTES;
+		this->x_values_increment = ECONOMY_MONTH_MINUTES;
 		this->draw_dates = !TimerGameEconomy::UsingWallclockUnits();
 
 		this->CreateNestedTree();


### PR DESCRIPTION
## Motivation / Problem

In wallclock timekeeping mode, the x-axis of the industry production graph runs in the wrong direction (opposite to all the other graphs).

![image](https://github.com/user-attachments/assets/a4444876-490a-4bee-b1b6-947977ec3ccd)

See: #10541.

## Description

Fix the above.
`BaseGraphWindow::x_values_increment` is changed back to be unsigned to fix signed/unsigned mismatches.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
