### PR TITLE
Codechange: 3 steps of std::min/max with 2 elements are faster than 1 single step with 4

### DIFF
--- a/src/tile_map.cpp
+++ b/src/tile_map.cpp
@@ -120,12 +120,14 @@ int GetTileZ(TileIndex tile)
 	uint x2 = std::min(x1 + 1, Map::MaxX());
 	uint y2 = std::min(y1 + 1, Map::MaxY());
 
-	return std::min({
-		TileHeight(tile),           // N corner
-		TileHeight(TileXY(x2, y1)), // W corner
-		TileHeight(TileXY(x1, y2)), // E corner
-		TileHeight(TileXY(x2, y2)), // S corner
-	});
+	return std::min(
+		std::min(
+			TileHeight(tile),            // N corner
+			TileHeight(TileXY(x2, y1))), // W corner
+		std::min(
+			TileHeight(TileXY(x1, y2)),  // E corner
+			TileHeight(TileXY(x2, y2)))  // S corner
+	);
 }
 
 /**
@@ -140,10 +142,12 @@ int GetTileMaxZ(TileIndex t)
 	uint x2 = std::min(x1 + 1, Map::MaxX());
 	uint y2 = std::min(y1 + 1, Map::MaxY());
 
-	return std::max({
-		TileHeight(t),              // N corner
-		TileHeight(TileXY(x2, y1)), // W corner
-		TileHeight(TileXY(x1, y2)), // E corner
-		TileHeight(TileXY(x2, y2)), // S corner
-	});
+	return std::max(
+		std::max(
+			TileHeight(t),               // N corner
+			TileHeight(TileXY(x2, y1))), // W corner
+		std::max(
+			TileHeight(TileXY(x1, y2)),  // E corner
+			TileHeight(TileXY(x2, y2)))  // S corner
+	);
 }


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
When `GetTileZ` and `GetTileMaxZ` were updated to use `std::min` and `std::max`, they apparently became slow.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Turns out that it's faster to use 3 steps of `std::min` or `std::max` with 2 elements rather than 1 single step with an `std::initializer_list` with 4 elements.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
