### PR TITLE
Doc: Fix documentation of water tile non-flooding bit in landscape.html

### DIFF
--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -98,12 +98,6 @@
     </li>
    </ul>
   </li>
-  <li><span style="font-weight: bold;">m3:</span><br>
-    <ul>
-      <li>
-        Bit 0: Non-flooding state.
-      </li>
-    </ul>
   <li><span style="font-weight: bold;">m4:</span><br>
    <a name="RoadType"></a>
    Road roadtype. Used for all tiles with road (road, station, tunnelbridge).
@@ -1055,6 +1049,7 @@
      <li>m1 bits 6..5 : Water class (sea, canal or river)
      <li>m1 bits 4..0: <a href="#OwnershipInfo">owner</a> (for sea, rivers, and coasts normally <tt>11</tt>)</li>
      <li>m2: Depot index (for depots only)</li>
+     <li>m3 bit 0: Non-flooding state</li>
      <li>m4: Random data for canal or river tiles</li>
      <li>m5 bits 7..4: Water tile type:
       <table>


### PR DESCRIPTION
## Motivation / Problem

Documentation of water tile non-flooding bit in landscape.html is in the wrong section.

## Description

Move documentation of water tile non-flooding bit in landscape.html to the correct section.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
