### PR TITLE
Add: NewGRF Badges feature

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -273,6 +273,9 @@ add_files(
     newgrf_airporttiles.h
     newgrf_animation_base.h
     newgrf_animation_type.h
+    newgrf_badge.cpp
+    newgrf_badge.h
+    newgrf_badge_type.h
     newgrf_callbacks.h
     newgrf_canal.cpp
     newgrf_canal.h

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -21,6 +21,7 @@
 #include "company_base.h"
 #include "station_type.h"
 #include "newgrf_airport.h"
+#include "newgrf_badge.h"
 #include "newgrf_callbacks.h"
 #include "dropdown_type.h"
 #include "dropdown_func.h"
@@ -445,6 +446,7 @@ public:
 			}
 
 			/* strings such as 'Size' and 'Coverage Area' */
+			r.top = DrawBadgeNameList(r, as->badges, GSF_AIRPORTS) + WidgetDimensions::scaled.vsep_normal;
 			r.top = DrawStationCoverageAreaText(r, SCT_ALL, rad, false) + WidgetDimensions::scaled.vsep_normal;
 			r.top = DrawStationCoverageAreaText(r, SCT_ALL, rad, true);
 		}

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -10,6 +10,7 @@
 #include "stdafx.h"
 #include "command_func.h"
 #include "vehicle_gui.h"
+#include "newgrf_badge.h"
 #include "newgrf_engine.h"
 #include "rail.h"
 #include "road.h"
@@ -89,6 +90,7 @@ class ReplaceVehicleWindow : public Window {
 	RailType sel_railtype;        ///< Type of rail tracks selected. #INVALID_RAILTYPE to show all.
 	RoadType sel_roadtype;        ///< Type of road selected. #INVALID_ROADTYPE to show all.
 	Scrollbar *vscroll[2];
+	GUIBadgeClasses badge_classes;
 
 	/**
 	 * Figure out if an engine should be added to a list.
@@ -275,6 +277,8 @@ public:
 		this->sel_engine[0] = EngineID::Invalid();
 		this->sel_engine[1] = EngineID::Invalid();
 		this->show_hidden_engines = _engine_sort_show_hidden_engines[vehicletype];
+
+		this->badge_classes = GUIBadgeClasses(static_cast<GrfSpecFeature>(GSF_TRAINS + vehicletype));
 
 		this->CreateNestedTree();
 		this->vscroll[0] = this->GetScrollbar(WID_RV_LEFT_SCROLLBAR);
@@ -463,7 +467,7 @@ public:
 				int side = (widget == WID_RV_LEFT_MATRIX) ? 0 : 1;
 
 				/* Do the actual drawing */
-				DrawEngineList(this->window_number, r, this->engines[side], *this->vscroll[side], this->sel_engine[side], side == 0, this->sel_group);
+				DrawEngineList(this->window_number, r, this->engines[side], *this->vscroll[side], this->sel_engine[side], side == 0, this->sel_group, this->badge_classes);
 				break;
 			}
 		}

--- a/src/core/base_bitset_type.hpp
+++ b/src/core/base_bitset_type.hpp
@@ -13,6 +13,8 @@
 #ifndef BASE_BITSET_TYPE_HPP
 #define BASE_BITSET_TYPE_HPP
 
+#include "bitmath_func.hpp"
+
 /**
  * Base for bit set wrapper.
  * Allows wrapping strong type values as a bit set. Methods are loosely modelled on std::bitset.
@@ -205,6 +207,9 @@ public:
 	{
 		return (this->base() & Tmask) == this->base();
 	}
+
+	auto begin() const { return SetBitIterator<Tvalue_type>(this->data).begin(); }
+	auto end() const { return SetBitIterator<Tvalue_type>(this->data).end(); }
 
 private:
 	Tstorage data; ///< Bitmask of values.

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -82,6 +82,7 @@ struct Engine : EnginePool::PoolItem<&_engine_pool> {
 	 */
 	VariableGRFFileProps grf_prop;
 	std::vector<WagonOverride> overrides;
+	std::vector<BadgeID> badges;
 
 	Engine() {}
 	Engine(VehicleType type, uint16_t local_id);

--- a/src/engine_gui.h
+++ b/src/engine_gui.h
@@ -12,6 +12,7 @@
 
 #include "engine_type.h"
 #include "group_type.h"
+#include "newgrf_badge.h"
 #include "sortlist_type.h"
 #include "gfx_type.h"
 #include "vehicle_type.h"
@@ -52,7 +53,7 @@ extern EngList_SortTypeFunction * const _engine_sort_functions[][11];
 /* Functions in build_vehicle_gui.cpp */
 uint GetEngineListHeight(VehicleType type);
 void DisplayVehicleSortDropDown(Window *w, VehicleType vehicle_type, int selected, WidgetID button);
-void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_list, const Scrollbar &sb, EngineID selected_id, bool show_count, GroupID selected_group);
+void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_list, const Scrollbar &sb, EngineID selected_id, bool show_count, GroupID selected_group, const GUIBadgeClasses &badge_classes);
 void GUIEngineListAddChildren(GUIEngineList &dst, const GUIEngineList &src, EngineID parent = EngineID::Invalid(), uint8_t indent = 0);
 
 #endif /* ENGINE_GUI_H */

--- a/src/engine_type.h
+++ b/src/engine_type.h
@@ -19,6 +19,7 @@
 #include "timer/timer_game_calendar.h"
 #include "sound_type.h"
 #include "strings_type.h"
+#include "newgrf_badge_type.h"
 
 /** Unique identification number of an engine. */
 using EngineID = PoolID<uint16_t, struct EngineIDTag, 64000, 0xFFFF>;

--- a/src/house.h
+++ b/src/house.h
@@ -14,6 +14,7 @@
 #include "timer/timer_game_calendar.h"
 #include "house_type.h"
 #include "newgrf_animation_type.h"
+#include "newgrf_badge_type.h"
 #include "newgrf_callbacks.h"
 #include "newgrf_commons.h"
 
@@ -115,6 +116,7 @@ struct HouseSpec {
 	uint8_t processing_time;                     ///< Periodic refresh multiplier
 	uint8_t minimum_life;                        ///< The minimum number of years this house will survive before the town rebuilds it
 	CargoTypes watched_cargoes;               ///< Cargo types watched for acceptance.
+	std::vector<BadgeID> badges;
 
 	CargoLabel accepts_cargo_label[HOUSE_ORIGINAL_NUM_ACCEPTS]; ///< input landscape cargo slots
 

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -19,6 +19,7 @@
 #include "industry.h"
 #include "town.h"
 #include "cheat_type.h"
+#include "newgrf_badge.h"
 #include "newgrf_industries.h"
 #include "newgrf_text.h"
 #include "newgrf_debug.h"
@@ -578,6 +579,8 @@ public:
 				GetAllCargoSuffixes(CARGOSUFFIX_OUT, CST_FUND, nullptr, this->selected_type, indsp, indsp->produced_cargo, cargo_suffix);
 				cargostring = this->MakeCargoListString(indsp->produced_cargo, cargo_suffix, STR_INDUSTRY_VIEW_PRODUCES_N_CARGO);
 				ir.top = DrawStringMultiLine(ir, cargostring);
+
+				ir.top = DrawBadgeNameList(ir, indsp->badges, GSF_INDUSTRIES);
 
 				/* Get the additional purchase info text, if it has not already been queried. */
 				if (indsp->callback_mask.Test(IndustryCallbackMask::FundMoreText)) {

--- a/src/industrytype.h
+++ b/src/industrytype.h
@@ -16,6 +16,7 @@
 #include "landscape_type.h"
 #include "cargo_type.h"
 #include "newgrf_animation_type.h"
+#include "newgrf_badge_type.h"
 #include "newgrf_callbacks.h"
 #include "newgrf_commons.h"
 
@@ -132,6 +133,7 @@ struct IndustrySpec {
 	bool enabled;                               ///< entity still available (by default true).newgrf can disable it, though
 	GRFFileProps grf_prop;                      ///< properties related to the grf file
 	std::vector<uint8_t> random_sounds; ///< Random sounds;
+	std::vector<BadgeID> badges;
 
 	std::array<std::variant<CargoLabel, MixedCargoType>, INDUSTRY_ORIGINAL_NUM_OUTPUTS> produced_cargo_label; ///< Cargo labels of produced cargo for default industries.
 	std::array<std::variant<CargoLabel, MixedCargoType>, INDUSTRY_ORIGINAL_NUM_INPUTS> accepts_cargo_label; ///< Cargo labels of accepted cargo for default industries.
@@ -164,6 +166,7 @@ struct IndustryTileSpec {
 	IndustryTileSpecialFlags special_flags; ///< Bitmask of extra flags used by the tile
 	bool enabled;                         ///< entity still available (by default true).newgrf can disable it, though
 	GRFFileProps grf_prop;                ///< properties related to the grf file
+	std::vector<BadgeID> badges;
 
 	std::array<std::variant<CargoLabel, MixedCargoType>, INDUSTRY_ORIGINAL_NUM_INPUTS> accepts_cargo_label; ///< Cargo labels of accepted cargo for default industry tiles.
 };

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -5925,3 +5925,5 @@ STR_PLANE                                                       :{BLACK}{PLANE}
 STR_SHIP                                                        :{BLACK}{SHIP}
 
 STR_TOOLBAR_RAILTYPE_VELOCITY                                   :{STRING} ({VELOCITY})
+
+STR_BADGE_NAME_LIST                                             :{STRING}: {GOLD}{RAW_STRING}

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -6366,6 +6366,9 @@ static void FeatureNewName(ByteReader &buf)
 	GrfMsg(6, "FeatureNewName: About to rename engines {}..{} (feature 0x{:02X}) in language 0x{:02X}",
 	               id, endid, feature, lang);
 
+	/* Feature overlay to make non-generic strings unique in their feature. We use feature + 1 so that generic strings stay as they are. */
+	uint32_t feature_overlay = generic ? 0 : ((feature + 1) << 16);
+
 	for (; id < endid && buf.HasData(); id++) {
 		const std::string_view name = buf.ReadString();
 		GrfMsg(8, "FeatureNewName: 0x{:04X} <- {}", id, StrMakeValid(name));
@@ -6378,7 +6381,7 @@ static void FeatureNewName(ByteReader &buf)
 				if (!generic) {
 					Engine *e = GetNewEngine(_cur.grffile, (VehicleType)feature, id, _cur.grfconfig->flags.Test(GRFConfigFlag::Static));
 					if (e == nullptr) break;
-					StringID string = AddGRFString(_cur.grffile->grfid, GRFStringID{e->index.base()}, lang, new_scheme, false, name, e->info.string_id);
+					StringID string = AddGRFString(_cur.grffile->grfid, GRFStringID{feature_overlay | e->index.base()}, lang, new_scheme, false, name, e->info.string_id);
 					e->info.string_id = string;
 				} else {
 					AddGRFString(_cur.grffile->grfid, GRFStringID{id}, lang, new_scheme, true, name, STR_UNDEFINED);

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -14,6 +14,7 @@
 #include "rail_type.h"
 #include "road_type.h"
 #include "fileio_type.h"
+#include "newgrf_badge_type.h"
 #include "newgrf_callbacks.h"
 #include "newgrf_text_type.h"
 #include "core/bitmath_func.hpp"
@@ -87,6 +88,7 @@ enum GrfSpecFeature : uint8_t {
 	GSF_ROADTYPES,
 	GSF_TRAMTYPES,
 	GSF_ROADSTOPS,
+	GSF_BADGES,
 	GSF_END,
 
 	GSF_FAKE_TOWNS = GSF_END, ///< Fake town GrfSpecFeature for NewGRF debugging (parent scope)
@@ -94,6 +96,7 @@ enum GrfSpecFeature : uint8_t {
 
 	GSF_INVALID = 0xFF,       ///< An invalid spec feature
 };
+using GrfSpecFeatures = EnumBitSet<GrfSpecFeature, uint32_t, GrfSpecFeature::GSF_END>;
 
 static const uint32_t INVALID_GRFID = 0xFFFFFFFF;
 
@@ -129,6 +132,9 @@ struct GRFFile : ZeroedMemoryAllocator {
 
 	std::vector<CargoLabel> cargo_list;             ///< Cargo translation table (local ID -> label)
 	std::array<uint8_t, NUM_CARGO> cargo_map{}; ///< Inverse cargo translation table (CargoType -> local ID)
+
+	std::vector<BadgeID> badge_list; ///< Badge translation table (local index -> global index)
+	std::unordered_map<uint16_t, BadgeID> badge_map;
 
 	std::vector<RailTypeLabel> railtype_list;       ///< Railtype translation table
 	std::array<RailType, RAILTYPE_END> railtype_map{};

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -10,6 +10,7 @@
 #include "stdafx.h"
 #include "debug.h"
 #include "timer/timer_game_calendar.h"
+#include "newgrf_badge.h"
 #include "newgrf_spritegroup.h"
 #include "newgrf_text.h"
 #include "station_base.h"
@@ -158,6 +159,8 @@ void AirportOverrideManager::SetEntitySpec(AirportSpec *as)
 {
 	switch (variable) {
 		case 0x40: return this->layout;
+
+		case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, this->spec->badges, parameter);
 	}
 
 	if (this->st == nullptr) {

--- a/src/newgrf_airport.h
+++ b/src/newgrf_airport.h
@@ -12,6 +12,7 @@
 
 #include "airport.h"
 #include "timer/timer_game_calendar.h"
+#include "newgrf_badge_type.h"
 #include "newgrf_class.h"
 #include "newgrf_commons.h"
 #include "newgrf_spritegroup.h"
@@ -119,6 +120,7 @@ struct AirportSpec : NewGRFSpecBase<AirportClassID> {
 	/* Newgrf data */
 	bool enabled;                          ///< Entity still available (by default true). Newgrf can disable it, though.
 	struct GRFFileProps grf_prop;          ///< Properties related to the grf file.
+	std::vector<BadgeID> badges;
 
 	static const AirportSpec *Get(uint8_t type);
 	static AirportSpec *GetWithoutOverride(uint8_t type);

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -10,6 +10,7 @@
 #include "stdafx.h"
 #include "debug.h"
 #include "newgrf_airporttiles.h"
+#include "newgrf_badge.h"
 #include "newgrf_spritegroup.h"
 #include "newgrf_sound.h"
 #include "station_base.h"
@@ -190,6 +191,8 @@ static uint32_t GetAirportTileIDAtOffset(TileIndex tile, const Station *st, uint
 
 		/* Get airport tile ID at offset */
 		case 0x62: return GetAirportTileIDAtOffset(GetNearbyTile(parameter, this->tile), this->st, this->ro.grffile->grfid);
+
+		case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, this->ats->badges, parameter);
 	}
 
 	Debug(grf, 1, "Unhandled airport tile variable 0x{:X}", variable);

--- a/src/newgrf_airporttiles.h
+++ b/src/newgrf_airporttiles.h
@@ -13,6 +13,7 @@
 #include "airport.h"
 #include "station_map.h"
 #include "newgrf_animation_type.h"
+#include "newgrf_badge_type.h"
 #include "newgrf_callbacks.h"
 #include "newgrf_commons.h"
 #include "newgrf_spritegroup.h"
@@ -73,6 +74,7 @@ struct AirportTileSpec {
 	uint8_t animation_special_flags;        ///< Extra flags to influence the animation
 	bool enabled;                         ///< entity still available (by default true). newgrf can disable it, though
 	GRFFileProps grf_prop;                ///< properties related the the grf file
+	std::vector<BadgeID> badges;
 
 	static const AirportTileSpec *Get(StationGfx gfx);
 	static const AirportTileSpec *GetByTile(TileIndex tile);

--- a/src/newgrf_badge.cpp
+++ b/src/newgrf_badge.cpp
@@ -1,0 +1,516 @@
+ /*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file newgrf_badge.cpp Functionality for NewGRF badges. */
+
+#include "stdafx.h"
+#include "dropdown_type.h"
+#include "dropdown_common_type.h"
+#include "newgrf.h"
+#include "newgrf_badge.h"
+#include "newgrf_badge_type.h"
+#include "newgrf_spritegroup.h"
+#include "strings_func.h"
+#include "timer/timer_game_calendar.h"
+#include "window_gui.h"
+#include "zoom_func.h"
+
+#include "table/strings.h"
+
+#include "safeguards.h"
+
+/** Separator to identify badge classes from a label. */
+static constexpr char BADGE_CLASS_SEPARATOR = '/';
+
+/** Global state for badge definitions. */
+class Badges {
+public:
+	std::vector<BadgeID> classes; ///< List of known badge classes.
+	std::vector<Badge> specs; ///< List of known badges.
+};
+
+/** Static instance of badge state. */
+static Badges _badges = {};
+
+/**
+ * Assign a BadgeClassID to the given badge.
+ * @param index Badge ID of badge that should be assigned.
+ * @returns new or existing BadgeClassID.
+ */
+static BadgeClassID GetOrCreateBadgeClass(BadgeID index)
+{
+	auto it = std::ranges::find(_badges.classes, index);
+	if (it == std::end(_badges.classes)) {
+		it = _badges.classes.emplace(it, index);
+	}
+
+	return static_cast<BadgeClassID>(std::distance(std::begin(_badges.classes), it));
+}
+
+/**
+ * Reset badges to the default state.
+ */
+void ResetBadges()
+{
+	_badges = {};
+}
+
+/**
+ * Register a badge label and return its global index.
+ * @param label Badge label to register.
+ * @returns Global index of the badge.
+ */
+Badge &GetOrCreateBadge(std::string_view label)
+{
+	/* Check if the label exists. */
+	auto it = std::ranges::find(_badges.specs, label, &Badge::label);
+	if (it != std::end(_badges.specs)) return *it;
+
+	BadgeClassID class_index;
+
+	/* Extract class. */
+	auto sep = label.find_first_of(BADGE_CLASS_SEPARATOR);
+	if (sep != std::string_view::npos) {
+		/* There is a separator, find (and create if necessary) the class label. */
+		class_index = GetOrCreateBadge(label.substr(0, sep)).class_index;
+		it = std::end(_badges.specs);
+	}
+
+	BadgeID index = BadgeID(std::distance(std::begin(_badges.specs), it));
+	if (sep == std::string_view::npos) {
+		/* There is no separator, so this badge is a class badge. */
+		class_index = GetOrCreateBadgeClass(index);
+	}
+
+	it = _badges.specs.emplace(it, label, index, class_index);
+	return *it;
+}
+
+/**
+ * Get a badge if it exists.
+ * @param index Index of badge.
+ * @returns Badge with specified index, or nullptr if it does not exist.
+ */
+Badge *GetBadge(BadgeID index)
+{
+	if (index.base() >= std::size(_badges.specs)) return nullptr;
+	return &_badges.specs[index.base()];
+}
+
+/**
+ * Get a badge by label if it exists.
+ * @param label Label of badge.
+ * @returns Badge with specified label, or nullptr if it does not exist.
+ */
+Badge *GetBadgeByLabel(std::string_view label)
+{
+	auto it = std::ranges::find(_badges.specs, label, &Badge::label);
+	if (it == std::end(_badges.specs)) return nullptr;
+
+	return &*it;
+}
+
+/**
+ * Get the badge class of a badge label.
+ * @param label Label to get class of.
+ * @returns Badge class index of label.
+ */
+Badge *GetClassBadge(BadgeClassID class_index)
+{
+	if (class_index.base() >= std::size(_badges.classes)) return nullptr;
+	return GetBadge(_badges.classes[class_index.base()]);
+}
+
+/** Resolver for a badge scope. */
+struct BadgeScopeResolver : public ScopeResolver {
+	const Badge &badge;
+	const std::optional<TimerGameCalendar::Date> introduction_date;
+
+	/**
+	 * Scope resolver of a badge.
+	 * @param ro Surrounding resolver.
+	 * @param badge Badge to resolve.
+	 * @param introduction_date Introduction date of entity.
+	 */
+	BadgeScopeResolver(ResolverObject &ro, const Badge &badge, const std::optional<TimerGameCalendar::Date> introduction_date)
+		: ScopeResolver(ro), badge(badge), introduction_date(introduction_date) { }
+
+	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool &available) const override;
+};
+
+/* virtual */ uint32_t BadgeScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool &available) const
+{
+	switch (variable) {
+		case 0x40:
+			if (this->introduction_date.has_value()) return this->introduction_date->base();
+			return TimerGameCalendar::date.base();
+
+		default: break;
+	}
+
+	available = false;
+	return UINT_MAX;
+}
+
+/** Resolver of badges. */
+struct BadgeResolverObject : public ResolverObject {
+	BadgeScopeResolver self_scope;
+
+	BadgeResolverObject(const Badge &badge, GrfSpecFeature feature, std::optional<TimerGameCalendar::Date> introduction_date, CallbackID callback = CBID_NO_CALLBACK, uint32_t callback_param1 = 0, uint32_t callback_param2 = 0);
+
+	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override
+	{
+		switch (scope) {
+			case VSG_SCOPE_SELF: return &this->self_scope;
+			default: return ResolverObject::GetScope(scope, relative);
+		}
+	}
+
+	GrfSpecFeature GetFeature() const override;
+	uint32_t GetDebugID() const override;
+};
+
+GrfSpecFeature BadgeResolverObject::GetFeature() const
+{
+	return GSF_BADGES;
+}
+
+uint32_t BadgeResolverObject::GetDebugID() const
+{
+	return this->self_scope.badge.index.base();
+}
+
+/**
+ * Constructor of the badge resolver.
+ * @param badge Badge being resolved.
+ * @param feature GRF feature being used.
+ * @param introduction_date Optional introduction date of entity.
+ * @param callback Callback ID.
+ * @param callback_param1 First parameter (var 10) of the callback.
+ * @param callback_param2 Second parameter (var 18) of the callback.
+ */
+BadgeResolverObject::BadgeResolverObject(const Badge &badge, GrfSpecFeature feature, std::optional<TimerGameCalendar::Date> introduction_date, CallbackID callback, uint32_t callback_param1, uint32_t callback_param2)
+		: ResolverObject(badge.grf_prop.grffile, callback, callback_param1, callback_param2), self_scope(*this, badge, introduction_date)
+{
+	assert(feature <= GSF_END);
+	this->root_spritegroup = this->self_scope.badge.grf_prop.GetSpriteGroup(feature);
+	if (this->root_spritegroup == nullptr) this->root_spritegroup = this->self_scope.badge.grf_prop.GetSpriteGroup(GSF_END);
+}
+
+/**
+ * Test for a matching badge in a list of badges, returning the number of matching bits.
+ * @param grffile GRF file of the current varaction.
+ * @param badges List of badges to test.
+ * @param parameter GRF-local badge index.
+ * @returns true iff the badge is present.
+ */
+uint32_t GetBadgeVariableResult(const GRFFile &grffile, std::span<const BadgeID> badges, uint32_t parameter)
+{
+	if (parameter >= std::size(grffile.badge_list)) return UINT_MAX;
+
+	BadgeID index = grffile.badge_list[parameter];
+	return std::ranges::find(badges, index) != std::end(badges);
+}
+
+/**
+ * Mark a badge a seen (used) by a feature.
+ */
+void MarkBadgeSeen(BadgeID index, GrfSpecFeature feature)
+{
+	Badge *b = GetBadge(index);
+	assert(b != nullptr);
+	b->features.Set(feature);
+}
+
+/**
+ * Append copyable badges from a list onto another.
+ * Badges must exist and be marked with the Copy flag.
+ * @param dst Destination badge list.
+ * @param src Source badge list.
+ * @param feature Feature of list.
+ */
+void AppendCopyableBadgeList(std::vector<BadgeID> &dst, std::span<const BadgeID> src, GrfSpecFeature feature)
+{
+	for (const BadgeID &index : src) {
+		/* Is badge already present? */
+		if (std::ranges::find(dst, index) != std::end(dst)) continue;
+
+		/* Is badge copyable? */
+		Badge *badge = GetBadge(index);
+		if (badge == nullptr) continue;
+		if (!badge->flags.Test(BadgeFlag::Copy)) continue;
+
+		dst.push_back(index);
+		badge->features.Set(feature);
+	}
+}
+
+/** Apply features from all badges to their badge classes. */
+void ApplyBadgeFeaturesToClassBadges()
+{
+	for (const Badge &badge : _badges.specs) {
+		Badge *class_badge = GetClassBadge(badge.class_index);
+		assert(class_badge != nullptr);
+		class_badge->features.Set(badge.features);
+	}
+}
+
+static constexpr uint MAX_BADGE_HEIGHT = 12; ///< Maximal height of a badge sprite.
+static constexpr uint MAX_BADGE_WIDTH = MAX_BADGE_HEIGHT * 2; ///< Maximal width.
+
+/**
+ * Get sprite for the given badge.
+ * @param badge Badge being queried.
+ * @param feature GRF feature being used.
+ * @param introduction_date Introduction date of the item, if it has one.
+ * @param remap Palette remap to use if the flag is company-coloured.
+ * @returns Custom sprite to draw, or \c 0 if not available.
+ */
+static PalSpriteID GetBadgeSprite(const Badge &badge, GrfSpecFeature feature, std::optional<TimerGameCalendar::Date> introduction_date, PaletteID remap)
+{
+	BadgeResolverObject object(badge, feature, introduction_date);
+	const SpriteGroup *group = object.Resolve();
+	if (group == nullptr) return {0, PAL_NONE};
+
+	PaletteID pal = badge.flags.Test(BadgeFlag::UseCompanyColour) ? remap : PAL_NONE;
+
+	return {group->GetResult(), pal};
+}
+
+/**
+ * Get the largest badge size (within limits) for a badge class.
+ * @param badge_class Badge class.
+ * @param feature Feature being used.
+ * @returns Largest base size of the badge class for the feature.
+ */
+static Dimension GetBadgeMaximalDimension(BadgeClassID class_index, GrfSpecFeature feature)
+{
+	Dimension d = { 0, MAX_BADGE_HEIGHT };
+
+	for (const auto &badge : _badges.specs) {
+		if (badge.class_index != class_index) continue;
+
+		PalSpriteID ps = GetBadgeSprite(badge, feature, std::nullopt, PAL_NONE);
+		if (ps.sprite == 0) continue;
+
+		d.width = std::max(d.width, GetSpriteSize(ps.sprite, nullptr, ZOOM_LVL_NORMAL).width);
+		if (d.width > MAX_BADGE_WIDTH) break;
+	}
+
+	d.width = std::min(d.width, MAX_BADGE_WIDTH);
+	return d;
+}
+
+/** Utility class to create a list of badge classes used by a feature. */
+class UsedBadgeClasses {
+public:
+	/**
+	 * Create a list of used badge classes for a feature.
+	 * @param feature GRF feature being used.
+	 */
+	explicit UsedBadgeClasses(GrfSpecFeature feature)
+	{
+		for (auto index : _badges.classes) {
+			Badge *class_badge = GetBadge(index);
+			if (!class_badge->features.Test(feature)) continue;
+
+			this->classes.push_back(class_badge->class_index);
+		}
+
+		std::ranges::sort(this->classes, [](const BadgeClassID &a, const BadgeClassID &b)
+		{
+			return GetClassBadge(a)->label < GetClassBadge(b)->label;
+		});
+	}
+
+	std::span<const BadgeClassID> Classes() const { return this->classes; }
+
+private:
+	std::vector<BadgeClassID> classes; ///< List of badge classes.
+};
+
+static bool operator<(const GUIBadgeClasses::Element &a, const GUIBadgeClasses::Element &b)
+{
+	if (a.column_group != b.column_group) return a.column_group < b.column_group;
+	if (a.sort_order != b.sort_order) return a.sort_order < b.sort_order;
+	return a.label < b.label;
+}
+
+/**
+ * Construct of list of badge classes and column groups to display.
+ * @param feature feature being used.
+ */
+GUIBadgeClasses::GUIBadgeClasses(GrfSpecFeature feature)
+{
+	/* Get list of classes used by feature. */
+	UsedBadgeClasses used(feature);
+
+	uint max_column = 0;
+	for (BadgeClassID class_index : used.Classes()) {
+		Dimension size = GetBadgeMaximalDimension(class_index, feature);
+		if (size.width == 0) continue;
+
+		uint8_t column = 0;
+		bool visible = true;
+		uint sort_order = UINT_MAX;
+
+		std::string_view label = GetClassBadge(class_index)->label;
+
+		this->gui_classes.emplace_back(class_index, column, visible, sort_order, size, label);
+		if (visible) max_column = std::max<uint>(max_column, column);
+	}
+
+	std::sort(std::begin(this->gui_classes), std::end(this->gui_classes));
+
+	/* Determine total width of visible badge columns. */
+	this->column_widths.resize(max_column + 1);
+	for (const auto &el : this->gui_classes) {
+		if (!el.visible) continue;
+		this->column_widths[el.column_group] += ScaleGUITrad(el.size.width) + WidgetDimensions::scaled.hsep_normal;
+	}
+
+	/* Replace trailing `hsep_normal` spacer with wider `hsep_wide` spacer. */
+	for (uint &badge_width : this->column_widths) {
+		if (badge_width == 0) continue;
+		badge_width = badge_width - WidgetDimensions::scaled.hsep_normal + WidgetDimensions::scaled.hsep_wide;
+	}
+}
+
+/**
+ * Get total width of all columns.
+ * @returns sum of all column widths.
+ */
+uint GUIBadgeClasses::GetTotalColumnsWidth() const
+{
+	return std::accumulate(std::begin(this->column_widths), std::end(this->column_widths), 0U);
+}
+
+/**
+ * Draw names for a list of badge labels.
+ * @param r Rect to draw in.
+ * @param badges List of badges.
+ * @param feature GRF feature being used.
+ * @returns Vertical position after drawing is complete.
+ */
+int DrawBadgeNameList(Rect r, std::span<const BadgeID> badges, GrfSpecFeature)
+{
+	if (badges.empty()) return r.top;
+
+	std::set<BadgeClassID> classes;
+	for (const BadgeID &index : badges) classes.insert(GetBadge(index)->class_index);
+
+	for (const BadgeClassID &class_index : classes) {
+		const Badge *class_badge = GetClassBadge(class_index);
+		if (class_badge == nullptr || class_badge->name == STR_NULL) continue;
+
+		std::string s;
+		for (const BadgeID &index : badges) {
+			const Badge *badge = GetBadge(index);
+			if (badge == nullptr || badge->name == STR_NULL) continue;
+			if (badge->class_index != class_index) continue;
+
+			if (!s.empty()) {
+				if (badge->flags.Test(BadgeFlag::NameListFirstOnly)) continue;
+				s += ", ";
+			}
+			AppendStringInPlace(s, badge->name);
+			if (badge->flags.Test(BadgeFlag::NameListStop)) break;
+		}
+
+		if (s.empty()) continue;
+
+		SetDParam(0, class_badge->name);
+		SetDParamStr(1, std::move(s));
+		r.top = DrawStringMultiLine(r, STR_BADGE_NAME_LIST, TC_BLACK);
+	}
+
+	return r.top;
+}
+
+/**
+ * Draw a badge column group.
+ * @param r rect to draw within.
+ * @param column_group column to draw.
+ * @param badge_classes badge classes.
+ * @param badges badges to draw.
+ * @param feature feature being used.
+ * @param introduction_date introduction date of item.
+ * @param remap palette remap to for company-coloured badges.
+ */
+void DrawBadgeColumn(Rect r, int column_group, const GUIBadgeClasses &badge_classes, std::span<const BadgeID> badges, GrfSpecFeature feature, std::optional<TimerGameCalendar::Date> introduction_date, PaletteID remap)
+{
+	bool rtl = _current_text_dir == TD_RTL;
+	for (const auto &badge_class : badge_classes.GetClasses()) {
+		if (badge_class.column_group != column_group) continue;
+		if (!badge_class.visible) continue;
+
+		int width = ScaleGUITrad(badge_class.size.width);
+		for (const BadgeID &index : badges) {
+			const Badge &badge = *GetBadge(index);
+			if (badge.class_index != badge_class.badge_class) continue;
+
+			PalSpriteID ps = GetBadgeSprite(badge, feature, introduction_date, remap);
+			if (ps.sprite == 0) continue;
+
+			DrawSpriteIgnorePadding(ps.sprite, ps.pal, r.WithWidth(width, rtl), SA_CENTER);
+			break;
+		}
+
+		r = r.Indent(width + WidgetDimensions::scaled.hsep_normal, rtl);
+	}
+}
+
+/** Drop down element that draws a list of badges. */
+template <class TBase, bool TEnd = true, FontSize TFs = FS_NORMAL>
+class DropDownBadges : public TBase {
+public:
+	template <typename... Args>
+	explicit DropDownBadges(const std::shared_ptr<GUIBadgeClasses> &badge_classes, std::span<const BadgeID> badges, GrfSpecFeature feature, std::optional<TimerGameCalendar::Date> introduction_date, Args&&... args)
+		: TBase(std::forward<Args>(args)...), badge_classes(badge_classes), badges(badges), feature(feature), introduction_date(introduction_date)
+	{
+		for (const auto &badge_class : badge_classes->GetClasses()) {
+			if (badge_class.column_group != 0) continue;
+			dim.width += badge_class.size.width + WidgetDimensions::scaled.hsep_normal;
+			dim.height = std::max(dim.height, badge_class.size.height);
+		}
+	}
+
+	uint Height() const override { return std::max<uint>(this->dim.height, this->TBase::Height()); }
+	uint Width() const override { return this->dim.width + WidgetDimensions::scaled.hsep_wide + this->TBase::Width(); }
+
+	void Draw(const Rect &full, const Rect &r, bool sel, Colours bg_colour) const override
+	{
+		bool rtl = TEnd ^ (_current_text_dir == TD_RTL);
+
+		DrawBadgeColumn(r.WithWidth(this->dim.width, rtl), 0, *this->badge_classes, this->badges, this->feature, this->introduction_date, PAL_NONE);
+
+		this->TBase::Draw(full, r.Indent(this->dim.width + WidgetDimensions::scaled.hsep_wide, rtl), sel, bg_colour);
+	}
+
+private:
+	std::shared_ptr<GUIBadgeClasses> badge_classes;
+
+	const std::span<const BadgeID> badges;
+	const GrfSpecFeature feature;
+	const std::optional<TimerGameCalendar::Date> introduction_date;
+
+	Dimension dim{};
+
+};
+
+using DropDownListBadgeItem = DropDownBadges<DropDownListStringItem>;
+using DropDownListBadgeIconItem = DropDownBadges<DropDownListIconItem>;
+
+std::unique_ptr<DropDownListItem> MakeDropDownListBadgeItem(const std::shared_ptr<GUIBadgeClasses> &badge_classes, std::span<const BadgeID> badges, GrfSpecFeature feature, std::optional<TimerGameCalendar::Date> introduction_date, StringID str, int value, bool masked, bool shaded)
+{
+	return std::make_unique<DropDownListBadgeItem>(badge_classes, badges, feature, introduction_date, str, value, masked, shaded);
+}
+
+std::unique_ptr<DropDownListItem> MakeDropDownListBadgeIconItem(const std::shared_ptr<GUIBadgeClasses> &badge_classes, std::span<const BadgeID> badges, GrfSpecFeature feature, std::optional<TimerGameCalendar::Date> introduction_date, const Dimension &dim, SpriteID sprite, PaletteID palette, StringID str, int value, bool masked, bool shaded)
+{
+	return std::make_unique<DropDownListBadgeIconItem>(badge_classes, badges, feature, introduction_date, dim, sprite, palette, str, value, masked, shaded);
+}

--- a/src/newgrf_badge.h
+++ b/src/newgrf_badge.h
@@ -1,0 +1,80 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file newgrf_badge.h Functions related to NewGRF badges. */
+
+#ifndef NEWGRF_BADGE_H
+#define NEWGRF_BADGE_H
+
+#include "dropdown_type.h"
+#include "newgrf.h"
+#include "newgrf_badge_type.h"
+#include "newgrf_commons.h"
+#include "strings_type.h"
+#include "timer/timer_game_calendar.h"
+
+class Badge {
+public:
+	std::string label; ///< Label of badge.
+	BadgeID index; ///< Index assigned to badge.
+	BadgeClassID class_index; ///< Index of class this badge belongs to.
+	BadgeFlags flags = {}; ///< Display flags
+	StringID name = 0; ///< Short name.
+	GrfSpecFeatures features{}; ///< Bitmask of which features use this badge.
+	VariableGRFFileProps grf_prop; ///< Sprite information.
+
+	Badge(std::string_view label, BadgeID index, BadgeClassID class_index) : label(label), index(index), class_index(class_index) {}
+};
+
+void ResetBadges();
+
+Badge &GetOrCreateBadge(std::string_view label);
+void MarkBadgeSeen(BadgeID index, GrfSpecFeature feature);
+void AppendCopyableBadgeList(std::vector<BadgeID> &dst, std::span<const BadgeID> src, GrfSpecFeature feature);
+void ApplyBadgeFeaturesToClassBadges();
+
+Badge *GetBadge(BadgeID index);
+Badge *GetBadgeByLabel(std::string_view label);
+Badge *GetClassBadge(BadgeClassID class_index);
+
+class GUIBadgeClasses {
+public:
+	struct Element {
+		BadgeClassID badge_class; ///< Badge class index.
+		uint8_t column_group; ///< Column group in UI. 0 = left, 1 = centre, 2 = right.
+		bool visible; ///< Whether this element is visible.
+		uint sort_order; ///< Order of element.
+		Dimension size; ///< Maximal size of this element.
+		std::string_view label; ///< Class label (string owned by the class badge)
+
+		constexpr Element(BadgeClassID badge_class, uint8_t column_group, bool visible, uint sort_order, Dimension size, std::string_view label) :
+			badge_class(badge_class), column_group(column_group), visible(visible), sort_order(sort_order), size(size), label(label) {}
+	};
+
+	GUIBadgeClasses() = default;
+	explicit GUIBadgeClasses(GrfSpecFeature feature);
+
+	inline std::span<const Element> GetClasses() const { return this->gui_classes; }
+
+	inline std::span<const uint> GetColumnWidths() const { return this->column_widths; }
+
+	uint GetTotalColumnsWidth() const;
+
+private:
+	std::vector<Element> gui_classes{};
+	std::vector<uint> column_widths{};
+};
+
+int DrawBadgeNameList(Rect r, std::span<const BadgeID> badges, GrfSpecFeature feature);
+void DrawBadgeColumn(Rect r, int column_group, const GUIBadgeClasses &badge_classes, std::span<const BadgeID> badges, GrfSpecFeature feature, std::optional<TimerGameCalendar::Date> introduction_date, PaletteID remap);
+
+uint32_t GetBadgeVariableResult(const struct GRFFile &grffile, std::span<const BadgeID> badges, uint32_t parameter);
+
+std::unique_ptr<DropDownListItem> MakeDropDownListBadgeItem(const std::shared_ptr<GUIBadgeClasses> &gui_classes, std::span<const BadgeID> badges, GrfSpecFeature feature, std::optional<TimerGameCalendar::Date> introduction_date, StringID str, int value, bool masked = false, bool shaded = false);
+std::unique_ptr<DropDownListItem> MakeDropDownListBadgeIconItem(const std::shared_ptr<GUIBadgeClasses> &gui_classes, std::span<const BadgeID> badges, GrfSpecFeature feature, std::optional<TimerGameCalendar::Date> introduction_date, const Dimension &dim, SpriteID sprite, PaletteID palette, StringID str, int value, bool masked = false, bool shaded = false);
+
+#endif /* NEWGRF_BADGE_H */

--- a/src/newgrf_badge_type.h
+++ b/src/newgrf_badge_type.h
@@ -1,0 +1,27 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file newgrf_badge_type.h Types related to NewGRF badges. */
+
+#ifndef NEWGRF_BADGE_TYPE_H
+#define NEWGRF_BADGE_TYPE_H
+
+#include "core/enum_type.hpp"
+#include "core/strong_typedef_type.hpp"
+
+using BadgeID = StrongType::Typedef<uint16_t, struct BadgeIDTag, StrongType::Compare>;
+using BadgeClassID = StrongType::Typedef<uint16_t, struct BadgeClassIDTag, StrongType::Compare>;
+
+enum class BadgeFlag : uint8_t {
+	Copy              = 0, ///< Copy badge to related things.
+	NameListStop      = 1, ///< Stop adding names to the name list after this badge.
+	NameListFirstOnly = 2, ///< Don't add this name to the name list if not first.
+	UseCompanyColour  = 3, ///< Apply company colour palette to this badge.
+};
+using BadgeFlags = EnumBitSet<BadgeFlag, uint8_t>;
+
+#endif /* NEWGRF_BADGE_TYPE_H */

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -12,6 +12,7 @@
 #include "train.h"
 #include "roadveh.h"
 #include "company_func.h"
+#include "newgrf_badge.h"
 #include "newgrf_cargo.h"
 #include "newgrf_spritegroup.h"
 #include "timer/timer_game_calendar.h"
@@ -692,6 +693,8 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 				default: return 0x00;
 			}
 
+		case 0x7A: return GetBadgeVariableResult(*object->ro.grffile, v->GetEngine()->badges, parameter);
+
 		case 0xFE:
 		case 0xFF: {
 			uint16_t modflags = 0;
@@ -959,6 +962,9 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 			case 0x48: return Engine::Get(this->self_type)->flags.base(); // Vehicle Type Info
 			case 0x49: return TimerGameCalendar::year.base(); // 'Long' format build year
 			case 0x4B: return TimerGameCalendar::date.base(); // Long date of last service
+
+			case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, Engine::Get(this->self_type)->badges, parameter);
+
 			case 0x92: return ClampTo<uint16_t>(TimerGameCalendar::date - CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR); // Date of last service
 			case 0x93: return GB(ClampTo<uint16_t>(TimerGameCalendar::date - CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR), 8, 8);
 			case 0xC4: return (Clamp(TimerGameCalendar::year, CalendarTime::ORIGINAL_BASE_YEAR, CalendarTime::ORIGINAL_MAX_YEAR) - CalendarTime::ORIGINAL_BASE_YEAR).base(); // Build year

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -10,6 +10,7 @@
 #include "stdafx.h"
 #include "debug.h"
 #include "landscape.h"
+#include "newgrf_badge.h"
 #include "newgrf_house.h"
 #include "newgrf_spritegroup.h"
 #include "newgrf_town.h"
@@ -391,6 +392,8 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex tile, Ho
 			case 0x65: return 0;
 			case 0x66: return 0xFFFFFFFF; /* Class and ID of nearby house. */
 			case 0x67: return 0;
+
+			case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, HouseSpec::Get(this->house_id)->badges, parameter);
 		}
 
 		Debug(grf, 1, "Unhandled house variable 0x{:X}", variable);
@@ -507,6 +510,8 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex tile, Ho
 			 * in case the newgrf was removed. */
 			return _house_mngr.GetGRFID(house_id);
 		}
+
+		case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, HouseSpec::Get(this->house_id)->badges, parameter);
 	}
 
 	Debug(grf, 1, "Unhandled house variable 0x{:X}", variable);

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -10,6 +10,7 @@
 #include "stdafx.h"
 #include "debug.h"
 #include "industry.h"
+#include "newgrf_badge.h"
 #include "newgrf_industries.h"
 #include "newgrf_town.h"
 #include "newgrf_cargo.h"
@@ -166,6 +167,8 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t param_setID, uint8_
 		/* Variables available during construction check. */
 
 		switch (variable) {
+			case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, GetIndustrySpec(this->type)->badges, parameter);
+
 			case 0x80: return this->tile.base();
 			case 0x81: return GB(this->tile.base(), 8, 8);
 
@@ -349,6 +352,8 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t param_setID, uint8_
 			if (variable == 0x6F) return it->waiting;
 			NOT_REACHED();
 		}
+
+		case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, GetIndustrySpec(this->type)->badges, parameter);
 
 		/* Get a variable from the persistent storage */
 		case 0x7C: return (this->industry->psa != nullptr) ? this->industry->psa->GetValue(parameter) : 0;

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -10,6 +10,7 @@
 #include "stdafx.h"
 #include "debug.h"
 #include "landscape.h"
+#include "newgrf_badge.h"
 #include "newgrf_industrytiles.h"
 #include "newgrf_sound.h"
 #include "industry.h"
@@ -91,6 +92,8 @@ uint32_t GetRelativePosition(TileIndex tile, TileIndex ind_tile)
 
 		/* Get industry tile ID at offset */
 		case 0x62: return GetIndustryIDAtOffset(GetNearbyTile(parameter, this->tile), this->industry, this->ro.grffile->grfid);
+
+		case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, GetIndustryTileSpec(GetIndustryGfx(this->tile))->badges, parameter);
 	}
 
 	Debug(grf, 1, "Unhandled industry tile variable 0x{:X}", variable);

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -12,6 +12,7 @@
 #include "company_func.h"
 #include "debug.h"
 #include "genworld.h"
+#include "newgrf_badge.h"
 #include "newgrf_object.h"
 #include "newgrf_class_func.h"
 #include "newgrf_sound.h"
@@ -286,6 +287,8 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t local_id, uint32_t 
 			/* Object view */
 			case 0x48: return this->view;
 
+			case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, this->spec->badges, parameter);
+
 			/*
 			 * Disallow the rest:
 			 * 0x40: Relative position is passed as parameter during construction.
@@ -356,6 +359,8 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t local_id, uint32_t 
 
 		/* Count of object, distance of closest instance */
 		case 0x64: return GetCountAndDistanceOfClosestInstance(parameter, this->ro.grffile->grfid, this->tile, this->obj);
+
+		case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, this->spec->badges, parameter);
 	}
 
 unhandled:

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -17,6 +17,7 @@
 #include "timer/timer_game_calendar.h"
 #include "object_type.h"
 #include "newgrf_animation_type.h"
+#include "newgrf_badge_type.h"
 #include "newgrf_class.h"
 #include "newgrf_commons.h"
 
@@ -73,6 +74,7 @@ struct ObjectSpec : NewGRFSpecBase<ObjectClassID> {
 	uint8_t height;                 ///< The height of this structure, in heightlevels; max MAX_TILE_HEIGHT.
 	uint8_t views;                  ///< The number of views.
 	uint8_t generate_amount;        ///< Number of objects which are attempted to be generated per 256^2 map during world generation.
+	std::vector<BadgeID> badges;
 
 	/**
 	 * Test if this object is enabled.

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -11,6 +11,7 @@
 #include "debug.h"
 #include "station_base.h"
 #include "roadstop_base.h"
+#include "newgrf_badge.h"
 #include "newgrf_roadstop.h"
 #include "newgrf_class_func.h"
 #include "newgrf_cargo.h"
@@ -199,6 +200,8 @@ uint32_t RoadStopScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] u
 
 			return 0xFFFE;
 		}
+
+		case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, this->roadstopspec->badges, parameter);
 
 		case 0xF0: return this->st == nullptr ? 0 : this->st->facilities.base(); // facilities
 

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -14,6 +14,7 @@
 
 #include "newgrf_animation_type.h"
 #include "newgrf_spritegroup.h"
+#include "newgrf_badge_type.h"
 #include "newgrf_callbacks.h"
 #include "newgrf_class.h"
 #include "newgrf_commons.h"
@@ -157,6 +158,8 @@ struct RoadStopSpec : NewGRFSpecBase<RoadStopClassID> {
 
 	uint8_t build_cost_multiplier = 16;  ///< Build cost multiplier per tile.
 	uint8_t clear_cost_multiplier = 16;  ///< Clear cost multiplier per tile.
+
+	std::vector<BadgeID> badges;
 
 	/**
 	 * Get the cost for building a road stop of this type.

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -12,6 +12,7 @@
 #include "station_base.h"
 #include "waypoint_base.h"
 #include "roadstop_base.h"
+#include "newgrf_badge.h"
 #include "newgrf_cargo.h"
 #include "newgrf_station.h"
 #include "newgrf_spritegroup.h"
@@ -292,6 +293,8 @@ TownScopeResolver *StationResolverObject::GetTown()
 				}
 				break;
 
+			case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, this->statspec->badges, parameter);
+
 			case 0xFA: return ClampTo<uint16_t>(TimerGameCalendar::date - CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR); // Build date, clamped to a 16 bit value
 		}
 
@@ -392,6 +395,8 @@ TownScopeResolver *StationResolverObject::GetTown()
 
 			return 0xFFFE;
 		}
+
+		case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, this->statspec->badges, parameter);
 
 		/* General station variables */
 		case 0x82: return 50;

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -12,6 +12,7 @@
 
 #include "core/enum_type.hpp"
 #include "newgrf_animation_type.h"
+#include "newgrf_badge_type.h"
 #include "newgrf_callbacks.h"
 #include "newgrf_class.h"
 #include "newgrf_commons.h"
@@ -173,6 +174,8 @@ struct StationSpec : NewGRFSpecBase<StationClassID> {
 
 	/** Custom platform layouts, keyed by platform and length combined. */
 	std::unordered_map<uint16_t, std::vector<uint8_t>> layouts;
+
+	std::vector<BadgeID> badges;
 };
 
 /** Class containing information relating to station classes. */

--- a/src/newgrf_text_type.h
+++ b/src/newgrf_text_type.h
@@ -13,7 +13,7 @@
 #include "core/strong_typedef_type.hpp"
 
 /** Type for GRF-internal string IDs. */
-using GRFStringID = StrongType::Typedef<uint16_t, struct GRFStringIDTag, StrongType::Compare, StrongType::Integer>;
+using GRFStringID = StrongType::Typedef<uint32_t, struct GRFStringIDTag, StrongType::Compare, StrongType::Integer>;
 
 static constexpr GRFStringID GRFSTR_MISC_GRF_TEXT{0xD000}; ///< Miscellaneous GRF text range.
 

--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -9,9 +9,11 @@
 
 #include "stdafx.h"
 #include "core/backup_type.hpp"
+#include "company_func.h"
 #include "gui.h"
 #include "hotkeys.h"
 #include "ini_type.h"
+#include "newgrf_badge.h"
 #include "picker_gui.h"
 #include "querystring_gui.h"
 #include "settings_type.h"
@@ -234,6 +236,8 @@ void PickerWindow::ConstructWindow()
 
 	this->FinishInitNested(this->window_number);
 
+	this->badge_classes = GUIBadgeClasses(this->callbacks.GetFeature());
+
 	this->InvalidateData(PICKER_INVALIDATION_ALL);
 }
 
@@ -301,6 +305,12 @@ void PickerWindow::DrawWidget(const Rect &r, WidgetID widget) const
 				int y = (ir.Height() + ScaleSpriteTrad(PREVIEW_HEIGHT)) / 2 - ScaleSpriteTrad(PREVIEW_BOTTOM);
 
 				this->callbacks.DrawType(x, y, item.class_index, item.index);
+
+				int by = ir.Height() - ScaleGUITrad(12);
+
+				GrfSpecFeature feature = this->callbacks.GetFeature();
+				DrawBadgeColumn({0, by, ir.Width() - 1, ir.Height() - 1}, 0, this->badge_classes, this->callbacks.GetTypeBadges(item.class_index, item.index), feature, std::nullopt, PAL_NONE);
+
 				if (this->callbacks.saved.contains(item)) {
 					DrawSprite(SPR_BLOT, PALETTE_TO_YELLOW, 0, 0);
 				}

--- a/src/picker_gui.h
+++ b/src/picker_gui.h
@@ -10,6 +10,7 @@
 #ifndef PICKER_GUI_H
 #define PICKER_GUI_H
 
+#include "newgrf_badge.h"
 #include "querystring_gui.h"
 #include "sortlist_type.h"
 #include "stringfilter_type.h"
@@ -41,6 +42,7 @@ public:
 
 	virtual void Close(int) { }
 
+	virtual GrfSpecFeature GetFeature() const = 0;
 	/** Should picker class/type selection be enabled? */
 	virtual bool IsActive() const = 0;
 	/** Are there multiple classes to chose from? */
@@ -72,6 +74,8 @@ public:
 	virtual PickerItem GetPickerItem(int cls_id, int id) const = 0;
 	/** Get the item of a type. */
 	virtual StringID GetTypeName(int cls_id, int id) const = 0;
+	/** Get the item of a type. */
+	virtual std::span<const BadgeID> GetTypeBadges(int cls_id, int id) const = 0;
 	/** Test if an item is currently buildable. */
 	virtual bool IsTypeAvailable(int cls_id, int id) const = 0;
 	/** Draw preview image of an item. */
@@ -212,6 +216,8 @@ private:
 	void BuildPickerTypeList();
 	void EnsureSelectedTypeIsValid();
 	void EnsureSelectedTypeIsVisible();
+
+	GUIBadgeClasses badge_classes;
 
 	IntervalTimer<TimerGameCalendar> yearly_interval = {{TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [this](auto) {
 		this->SetDirty();

--- a/src/rail.h
+++ b/src/rail.h
@@ -21,6 +21,7 @@
 #include "timer/timer_game_calendar.h"
 #include "signal_type.h"
 #include "settings_type.h"
+#include "newgrf_badge_type.h"
 
 /** Railtype flag bit numbers. */
 enum class RailTypeFlag : uint8_t {
@@ -269,6 +270,8 @@ public:
 	 * Sprite groups for resolving sprites
 	 */
 	const SpriteGroup *group[RTSG_END];
+
+	std::vector<BadgeID> badges;
 
 	inline bool UsesOverlay() const
 	{

--- a/src/road.h
+++ b/src/road.h
@@ -17,6 +17,7 @@
 #include "timer/timer_game_calendar.h"
 #include "core/enum_type.hpp"
 #include "newgrf.h"
+#include "newgrf_badge_type.h"
 #include "economy_func.h"
 
 
@@ -180,6 +181,8 @@ public:
 	 * Sprite groups for resolving sprites
 	 */
 	const SpriteGroup *group[ROTSG_END];
+
+	std::vector<BadgeID> badges;
 
 	inline bool UsesOverlay() const
 	{

--- a/src/table/airport_defaults.h
+++ b/src/table/airport_defaults.h
@@ -378,7 +378,7 @@ static const std::initializer_list<AirportTileLayout> _tile_table_helistation = 
 
 /** General AirportSpec definition. */
 #define AS_GENERIC(fsm, layouts, depots, size_x, size_y, noise, catchment, min_year, max_year, maint_cost, ttdpatch_type, class_id, name, preview, enabled) \
-	{{class_id, 0}, fsm, layouts, depots, size_x, size_y, noise, catchment, TimerGameCalendar::Year{min_year}, TimerGameCalendar::Year{max_year}, name, ttdpatch_type, preview, maint_cost, enabled, GRFFileProps(AT_INVALID)}
+	{{class_id, 0}, fsm, layouts, depots, size_x, size_y, noise, catchment, TimerGameCalendar::Year{min_year}, TimerGameCalendar::Year{max_year}, name, ttdpatch_type, preview, maint_cost, enabled, GRFFileProps(AT_INVALID), {}}
 
 /** AirportSpec definition for airports without any depot. */
 #define AS_ND(ap_name, size_x, size_y, min_year, max_year, catchment, noise, maint_cost, ttdpatch_type, class_id, name, preview) \

--- a/src/table/airporttiles.h
+++ b/src/table/airporttiles.h
@@ -11,9 +11,9 @@
 #define AIRPORTTILES_H
 
 /** Writes all airport tile properties in the AirportTile struct */
-#define AT(num_frames, anim_speed) {{num_frames, ANIM_STATUS_LOOPING, anim_speed, 0}, STR_NULL, AirportTileCallbackMasks{}, 0, true, GRFFileProps(INVALID_AIRPORTTILE)}
+#define AT(num_frames, anim_speed) {{num_frames, ANIM_STATUS_LOOPING, anim_speed, 0}, STR_NULL, AirportTileCallbackMasks{}, 0, true, GRFFileProps(INVALID_AIRPORTTILE), {}}
 /** Writes an airport tile without animation in the AirportTile struct */
-#define AT_NOANIM {{0, ANIM_STATUS_NO_ANIMATION, 2, 0}, STR_NULL, AirportTileCallbackMasks{}, 0, true, GRFFileProps(INVALID_AIRPORTTILE)}
+#define AT_NOANIM {{0, ANIM_STATUS_NO_ANIMATION, 2, 0}, STR_NULL, AirportTileCallbackMasks{}, 0, true, GRFFileProps(INVALID_AIRPORTTILE), {}}
 
 /**
  * All default airport tiles.

--- a/src/table/build_industry.h
+++ b/src/table/build_industry.h
@@ -1133,7 +1133,7 @@ enum IndustryTypes : uint8_t {
 		{INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO}, \
 		{{im1, 0}, {im2, 0}, {im3, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}}, \
 		pr, clim, bev, col, in, intx, s1, s2, s3, STR_UNDEFINED, {ai1, ai2, ai3, ai4}, {ag1, ag2, ag3, ag4}, \
-		IndustryCallbackMasks{}, true, GRFFileProps(IT_INVALID), snd, \
+		IndustryCallbackMasks{}, true, GRFFileProps(IT_INVALID), snd, {}, \
 		{{p1, p2}}, {{a1, a2, a3}}}
 	/* Format:
 	   tile table                              count and sounds table
@@ -1533,7 +1533,7 @@ static const IndustrySpec _origin_industry_specs[NEW_INDUSTRYOFFSET] = {
  */
 #define MT(ca1, c1, ca2, c2, ca3, c3, sl, a1, a2, a3) { \
 	{INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO}, \
-	{ca1, ca2, ca3}, sl, a1, a2, a3, IndustryTileCallbackMasks{}, {0, ANIM_STATUS_NO_ANIMATION, 2, 0}, IndustryTileSpecialFlags{}, true, GRFFileProps(INVALID_INDUSTRYTILE), {c1, c2, c3} \
+	{ca1, ca2, ca3}, sl, a1, a2, a3, IndustryTileCallbackMasks{}, {0, ANIM_STATUS_NO_ANIMATION, 2, 0}, IndustryTileSpecialFlags{}, true, GRFFileProps(INVALID_INDUSTRYTILE), {}, {c1, c2, c3} \
 }
 static const IndustryTileSpec _origin_industry_tile_specs[NEW_INDUSTRYTILEOFFSET] = {
 	/* Coal Mine */

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -724,5 +724,6 @@ static const NIFeature * const _nifeatures[] = {
 	&_nif_tramtype,     // GSF_TRAMTYPES
 	&_nif_roadstop,     // GSF_ROADSTOPS
 	&_nif_town,         // GSF_FAKE_TOWNS
+	nullptr,
 };
 static_assert(lengthof(_nifeatures) == GSF_FAKE_END);

--- a/src/table/object_land.h
+++ b/src/table/object_land.h
@@ -104,7 +104,7 @@ static const DrawTileSpriteSpan _object_hq[] = {
 #undef TILE_SPRITE_LINE
 #undef TILE_SPRITE_LINE_NOTHING
 
-#define M(name, size, build_cost_multiplier, clear_cost_multiplier, height, climate, gen_amount, flags) {{INVALID_OBJECT_CLASS, 0}, FixedGRFFileProps<2>{}, {0, 0, 0, 0}, name, climate, size, build_cost_multiplier, clear_cost_multiplier, TimerGameCalendar::Date{}, CalendarTime::MAX_DATE + 1, flags, ObjectCallbackMasks{}, height, 1, gen_amount}
+#define M(name, size, build_cost_multiplier, clear_cost_multiplier, height, climate, gen_amount, flags) {{INVALID_OBJECT_CLASS, 0}, FixedGRFFileProps<2>{}, {0, 0, 0, 0}, name, climate, size, build_cost_multiplier, clear_cost_multiplier, TimerGameCalendar::Date{}, CalendarTime::MAX_DATE + 1, flags, ObjectCallbackMasks{}, height, 1, gen_amount, {}}
 
 /* Climates
  * T = Temperate

--- a/src/table/railtypes.h
+++ b/src/table/railtypes.h
@@ -112,6 +112,7 @@ static const RailTypeInfo _original_railtypes[] = {
 
 		{ nullptr },
 		{ nullptr },
+		{},
 	},
 
 	/** Electrified railway */
@@ -213,6 +214,7 @@ static const RailTypeInfo _original_railtypes[] = {
 
 		{ nullptr },
 		{ nullptr },
+		{},
 	},
 
 	/** Monorail */
@@ -310,6 +312,7 @@ static const RailTypeInfo _original_railtypes[] = {
 
 		{ nullptr },
 		{ nullptr },
+		{},
 	},
 
 	/** Maglev */
@@ -407,6 +410,7 @@ static const RailTypeInfo _original_railtypes[] = {
 
 		{ nullptr },
 		{ nullptr },
+		{},
 	},
 };
 

--- a/src/table/roadtypes.h
+++ b/src/table/roadtypes.h
@@ -95,6 +95,7 @@ static const RoadTypeInfo _original_roadtypes[] = {
 
 		{ nullptr },
 		{ nullptr },
+		{},
 	},
 
 	/* Electrified Tram */
@@ -175,6 +176,7 @@ static const RoadTypeInfo _original_roadtypes[] = {
 
 		{ nullptr },
 		{ nullptr },
+		{},
 	},
 };
 

--- a/src/table/town_land.h
+++ b/src/table/town_land.h
@@ -1814,7 +1814,7 @@ static_assert(lengthof(_town_draw_tile_data) == (NEW_HOUSE_OFFSET) * 4 * 4);
 	{ca1, ca2, ca3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, \
 	{INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO}, \
 	bf, ba, true, GRFFileProps(INVALID_HOUSE_ID), HouseCallbackMasks{}, {COLOUR_BEGIN, COLOUR_BEGIN, COLOUR_BEGIN, COLOUR_BEGIN}, \
-	16, HouseExtraFlags{}, HOUSE_NO_CLASS, {0, 2, 0, 0}, 0, 0, 0, {cg1, cg2, cg3}, }
+	16, HouseExtraFlags{}, HOUSE_NO_CLASS, {0, 2, 0, 0}, 0, 0, 0, {}, {cg1, cg2, cg3}, }
 /** House specifications from original data */
 extern const HouseSpec _original_house_specs[] = {
 	/**

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1524,6 +1524,8 @@ public:
 		STR_HOUSE_PICKER_CLASS_ZONE5,
 	};
 
+	GrfSpecFeature GetFeature() const override { return GSF_HOUSES; }
+
 	StringID GetClassTooltip() const override { return STR_PICKER_HOUSE_CLASS_TOOLTIP; }
 	StringID GetTypeTooltip() const override { return STR_PICKER_HOUSE_TYPE_TOOLTIP; }
 	bool IsActive() const override { return true; }
@@ -1572,6 +1574,21 @@ public:
 		}
 
 		return GetHouseName(spec);
+	}
+
+	std::span<const BadgeID> GetTypeBadges(int cls_id, int id) const override
+	{
+		const auto *spec = HouseSpec::Get(id);
+		if (spec == nullptr) return {};
+		if (!spec->enabled) return {};
+		if ((spec->building_availability & climate_mask) == 0) return {};
+		if (!HasBit(spec->building_availability, cls_id)) return {};
+		for (int i = 0; i < cls_id; i++) {
+			/* Don't include if it's already included in an earlier zone. */
+			if (HasBit(spec->building_availability, i)) return {};
+		}
+
+		return spec->badges;
 	}
 
 	bool IsTypeAvailable(int, int id) const override


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Authors of vehicle sets like to add symbols to preview sprites in purchase lists. However across sets they don't generally agree on what the symbols should be, how large they are, and where they are placed.

From a user perspective this can end up looking messy and cluttered.

As they are part of the preview sprite, there is no opportunity to filter on them, and they cannot be hidden.

![image](https://github.com/user-attachments/assets/f5fcc7a5-dbb3-4ced-bb3b-3630e404d290)


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Enter NewGRF 'badges'.

A badge is a string-based label that can be defined by any NewGRF, and applied to most NewGRF features by way of a label 'translation' table. Badges can be assigned even if they are not defined, in this case they are attached but do not have any visual appearance.

Badges are grouped by 'class', which is defined by the first part of the string label up to a `/` separator.

I settled on an non-conventional approach of using strings as it reduces problems of clashes (as badges are global), and it allows authors to drill down into whatever detail they like. This differs from existing label schemes that use 4 byte values (normally treated as 4 alphanumeric characters), which would require compromises.

Badges appear in purchase lists, grouped into columns. An feature item can have multiple badges assigned, if any of them are in the same class only the first badge of that class is displayed in the main purchase list, although all badge descriptions are displayed in the extra-text part.

![image](https://github.com/user-attachments/assets/3f7ece3d-6e19-4182-9742-3489b73cfffb)
![image](https://github.com/user-attachments/assets/0404f4fb-93ff-4452-8d7c-fcdec900163b)

Display of badges can be customised by players. There is a rudimentary way to do this for vehicle purchase lists, but other features currently need to be configured in a configuration file.

To make NewGRF badges useful for more just displaying symbols and filter the purchase list, it is also possible to query for them in var action chains when resolving sprites or callbacks. This allows badges (defined or undefined) to be used as generic metadata by NewGRFs.

The intention is to also have a set of default badges for authors to use. As that is currently a NewGRF generated by grf-py that is separate from this for now.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Needs a better way to get to user configuration which is currently only available for engines, even though badges are available on other features.

And maybe a better way to filter by badge other than by typing its name. A drop down list similar to cargo types, perhaps, but I don't know where/how to fit that in.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
