### PR TITLE
Codechange: Each town cache the number of each type of industry

### DIFF
--- a/src/cachecheck.cpp
+++ b/src/cachecheck.cpp
@@ -47,6 +47,7 @@ void CheckCaches()
 
 	RebuildTownCaches();
 	RebuildSubsidisedSourceAndDestinationCache();
+	RebuildTownIndustryCounts();
 
 	uint i = 0;
 	for (Town *t : Town::Iterate()) {

--- a/src/industry.h
+++ b/src/industry.h
@@ -343,4 +343,6 @@ enum IndustryDirectoryInvalidateWindowData {
 
 void TrimIndustryAcceptedProduced(Industry *ind);
 
+void RebuildTownIndustryCounts();
+
 #endif /* INDUSTRY_H */

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -311,6 +311,8 @@ static void InitializeWindowsAndCaches()
 
 	/* Rebuild the smallmap list of owners. */
 	BuildOwnerLegend();
+
+	RebuildTownIndustryCounts();
 }
 
 typedef void (CDECL *SignalHandlerPointer)(int);

--- a/src/town.h
+++ b/src/town.h
@@ -16,6 +16,7 @@
 #include "subsidy_type.h"
 #include "newgrf_storage.h"
 #include "cargotype.h"
+#include "industry_type.h"
 
 template <typename T>
 struct BuildingCounts {
@@ -46,6 +47,7 @@ struct TownCache {
 	PartOfSubsidy part_of_subsidy;            ///< Is this town a source/destination of a subsidy?
 	std::array<uint32_t, HZB_END> squared_town_zone_radius; ///< UpdateTownRadius updates this given the house count
 	BuildingCounts<uint16_t> building_counts;   ///< The number of each type of building in the town
+	uint16_t industry_counts[NUM_INDUSTRYTYPES]; ///< The number of each type of industry in the town
 
 	auto operator<=>(const TownCache &) const = default;
 };

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2059,6 +2059,7 @@ static void DoCreateTown(Town *t, TileIndex tile, uint32_t townnameparts, TownSi
 	UpdateTownGrowthRate(t);
 	UpdateTownMaxPass(t);
 	UpdateAirportsNoise();
+	std::ranges::fill(t->cache.industry_counts, 0);
 }
 
 /**


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
According to the [surveys](https://survey.openttd.org/summaries/2024/q3/14#game.settings.economy.multiple_industry_per_town), `game.settings.economy.multiple_industry_per_town` is disabled in the majority of times.
Generating industries with this setting disabled forces to iterate over all industries to check whether it is unique to the nearby town. This tends to slow down over time when more and more industries are generated, because each one of them has to also be unique.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Add a cache in each town that counts the number of each type of industry that belong to them. The cache is updated on industry creation and deletion.
This allows for a quick `FindTownForIndustry` without having to iterate over all industries.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Requires cache, prone to desyncs.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
