### PR TITLE
Codechange: Store animated tile state in map to improve performance.

### DIFF
--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -892,6 +892,9 @@
        </tr>
       </table>
      </li>
+     <li>m3 bit 2: rail station / waypoint may have catenary pylons</li>
+     <li>m3 bit 1: rail station / waypoint may have catenary wires</li>
+     <li>m3 bit 0: rail station / waypoint is blocked</li>
      <li>m4: custom station id; 0 means standard graphics</li>
      <li>m4: <a href="#RoadType">Roadtype</a> for road stops</li>
      <li>m5: graphics index (range from 0..255 for each station type):
@@ -1021,11 +1024,8 @@
        </tr>
       </table>
      </li>
-     <li>m6 bit 7: rail station / waypoint may have catenary pylons</li>
      <li>m6 bits 6..3: the station type (rail, airport, truck, bus, oilrig, dock, buoy, waypoint, road waypoint)</li>
      <li>m6 bit 2: pbs reservation state for railway stations/waypoints</li>
-     <li>m6 bit 1: rail station / waypoint may have catenary wires</li>
-     <li>m6 bit 0: rail station / waypoint is blocked</li>
 
      <li>m7 bits 4..0: <a href="#OwnershipInfo">owner</a> of road (road stops)</li>
      <li>m7: animation frame (railway stations/waypoints, airports)</li>

--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -740,6 +740,7 @@
        </li>
       </ul>
      </li>
+     <li>m6: bits 1..0: animated tile state</li>
      <li>m7 :
       <ul>
        <li>If <a href="#newhouses">newhouses</a> is activated
@@ -1026,6 +1027,7 @@
      </li>
      <li>m6 bits 6..3: the station type (rail, airport, truck, bus, oilrig, dock, buoy, waypoint, road waypoint)</li>
      <li>m6 bit 2: pbs reservation state for railway stations/waypoints</li>
+     <li>m6 bits 1..0: animated tile state</li>
 
      <li>m7 bits 4..0: <a href="#OwnershipInfo">owner</a> of road (road stops)</li>
      <li>m7: animation frame (railway stations/waypoints, airports)</li>
@@ -1479,6 +1481,7 @@
      </li>
      <li>m6 bits 5..3: random triggers (NewGRF)</li>
      <li>m6 bit 2: bit 8 of type (see m5)</li>
+     <li>m6 bits 1..0: animated tile state</li>
      <li>m7: animation frame</li>
     </ul>
    </td>
@@ -1651,6 +1654,7 @@
      <li>m2: index into the array of objects, bits 0 to 15 (upper bits in m5)</li>
      <li>m3: random bits</li>
      <li>m5: index into the array of objects, bits 16 to 23 (lower bits in m2)</li>
+     <li>m6 bits 1..0: animated tile state</li>
      <li>m7: animation counter</li>
     </ul>
    </td>

--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -159,7 +159,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits"><span class="used" title="House is complete/in construction (see m5)">1</span> <span class="used" title="House type (m4 + m3[6])">X</span><span class="free">O</span><span class="usable" title="Activated triggers (bits 2..4 don't have a meaning)">XXX</span><span class="used" title="Activated triggers (bits 2..4 don't have a meaning)">XX</span></td>
       <td class="bits" rowspan=2><span class="used" title="House type (m4 + m3[6])">XXXX XXXX</span></td>
       <td class="bits"><span class="used" title="Age in years, clamped at 255">XXXX XXXX</span></td>
-      <td class="bits" rowspan=2><span class="abuse" title="Newhouses activated: periodic processing time remaining; if not, lift position for houses 04 and 05">XXXX XX</span><span class="free">OO</span></td>
+      <td class="bits" rowspan=2><span class="abuse" title="Newhouses activated: periodic processing time remaining; if not, lift position for houses 04 and 05">XXXX XX</span><span class="used" title="Animated tile state">XX</span></td>
       <td class="bits" rowspan=2><span class="abuse" title="If newhouses active, m7 is the current animation frame">XXXX</span> <span class="abuse" title="If newhouses active, m7 is the current animantion frame; if not, lift behaviour for houses 04 and 05">XXXX</span></td>
       <td class="bits" rowspan=2><span class="free">OOOO OOOO OOOO OOOO</span></td>
     </tr>
@@ -188,7 +188,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits" rowspan=2><span class="used" title="Random bits">XXXX</span> <span class="free">O</span><span class="used" title="May have pylons">X</span><span class="used" title="May have wires">X</span><span class="used" title="Tile is blocked">X</span></td>
       <td class="bits" rowspan=2><span class="used" title="Custom station specifications ID">XXXX XXXX</span></td>
       <td class="bits"><span class="used" title="Graphics index">XXXX XXXX</span></td>
-      <td class="bits" rowspan=2><span class="free">O</span><span class="used" title="Station type">XXX X</span><span class="used" title="Reserved track">X</span><span class="free">OO</span></td>
+      <td class="bits" rowspan=2><span class="free">O</span><span class="used" title="Station type">XXX X</span><span class="used" title="Reserved track">X</span><span class="used" title="Animated tile state">XX</span></td>
       <td class="bits" rowspan=2><span class="used" title="Animation frame">XXXX XXXX</span></td>
       <td class="bits" rowspan=2><span class="free">OOOO OOOO OO</span><span class="used" title="Railway type">XX XXXX</span></td>
     </tr>
@@ -201,7 +201,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits"><span class="used" title="Owner of tram">XXXX</span> <span class="free">OOOO</span></td>
       <td class="bits" rowspan=2><span class="free">OO</span><span class="used" title="Roadtype for road stop">XX XXXX</span></td>
       <td class="bits" rowspan=2><span class="usable" title="Graphics index">OOOO O</span><span class="used" title="Graphics index: 00 (exit towards NE), 01 (exit towards SE), 02 (exit towards SW), 03 (exit towards NW), 04 (drive through X), 05 (drive through Y)">XXX</span></td>
-      <td class="bits" rowspan=6><span class="free">O</span><span class="used" title="Station type">XXX X</span><span class="free">OOO</span></td>
+      <td class="bits" rowspan=6><span class="free">O</span><span class="used" title="Station type">XXX X</span><span class="free">O</span><span class="used" title="Animated tile state">XX</span></td>
       <td class="bits" rowspan=2><span class="free">OOO</span><span class="used" title="Owner of road">X XXXX</span></td>
       <td class="bits"><span class="free">OOOO</span> <span class="used" title="Tram type">XXXX XX</span> <span class="used" title="Custom road stops specifications ID">XXXXXX</span></td>
     </tr>
@@ -280,7 +280,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits" rowspan=2><span class="used" title="Random bits">XXXX XXXX</span></td>
       <td class="bits" rowspan=2><span class="used" title="Animation loop">XXXX XXXX</span></td>
       <td class="bits" rowspan=2><span class="used" title="Industry graphics ID (m5 + m6[2])">XXXX XXXX</span></td>
-      <td class="bits" rowspan=2><span class="free">OO</span><span class="used" title="Random triggers (NewGRF)">XXX</span> <span class="used" title="Industry graphics ID (m5 + m6[2])">X</span><span class="free">OO</span></td>
+      <td class="bits" rowspan=2><span class="free">OO</span><span class="used" title="Random triggers (NewGRF)">XXX</span> <span class="used" title="Industry graphics ID (m5 + m6[2])">X</span><span class="used" title="Animated tile state">XX</span></td>
       <td class="bits" rowspan=2><span class="used" title="Animation frame">XXXX XXXX</span></td>
       <td class="bits" rowspan=2><span class="free">OOOO OOOO OOOO OOOO</span></td>
     </tr>
@@ -313,7 +313,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits"><span class="used" title="Random bits">XXXX XXXX</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="pool" title="Object index on pool (m2 + m5)">XXXX XXXX</span></td>
-      <td class="bits"><span class="free">OOOO OOOO</span></td>
+      <td class="bits"><span class="free">OOOO OO</span><span class="used" title="Animated tile state">XX</span></td>
       <td class="bits"><span class="used" title="Animation counter">XXXX XXXX</span></td>
       <td class="bits" rowspan=1><span class="free">OOOO OOOO OOOO OOOO</span></td>
     </tr>

--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -185,10 +185,10 @@ the array so you can quickly see what is used and what is not.
       <td class="caption">rail station</td>
       <td class="bits" rowspan=8><span class="free">O</span><span class="used" title="Water class">XX</span> <span class="used" title="Owner">XXXXX</span></td>
       <td class="bits" rowspan=8><span class="pool" title="Station index on pool">XXXX XXXX XXXX XXXX</span></td>
-      <td class="bits" rowspan=2><span class="used" title="Random bits">XXXX</span> <span class="free">OOOO</span></td>
+      <td class="bits" rowspan=2><span class="used" title="Random bits">XXXX</span> <span class="free">O</span><span class="used" title="May have pylons">X</span><span class="used" title="May have wires">X</span><span class="used" title="Tile is blocked">X</span></td>
       <td class="bits" rowspan=2><span class="used" title="Custom station specifications ID">XXXX XXXX</span></td>
       <td class="bits"><span class="used" title="Graphics index">XXXX XXXX</span></td>
-      <td class="bits" rowspan=2><span class="used" title="May have pylons">X</span><span class="used" title="Station type">XXXX</span> <span class="used" title="Reserved track">X</span><span class="used" title="May have wires">X</span><span class="used" title="Tile is blocked">X</span></td>
+      <td class="bits" rowspan=2><span class="free">O</span><span class="used" title="Station type">XXX X</span><span class="used" title="Reserved track">X</span><span class="free">OO</span></td>
       <td class="bits" rowspan=2><span class="used" title="Animation frame">XXXX XXXX</span></td>
       <td class="bits" rowspan=2><span class="free">OOOO OOOO OO</span><span class="used" title="Railway type">XX XXXX</span></td>
     </tr>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,7 @@ add_files(
     airport_gui.cpp
     animated_tile.cpp
     animated_tile_func.h
+    animated_tile_map.h
     articulated_vehicles.cpp
     articulated_vehicles.h
     autocompletion.cpp

--- a/src/animated_tile_map.h
+++ b/src/animated_tile_map.h
@@ -1,0 +1,44 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file animated_tile_map.h Maps accessors for animated tiles. */
+
+#ifndef ANIMATED_TILE_MAP_H
+#define ANIMATED_TILE_MAP_H
+
+#include "core/bitmath_func.hpp"
+#include "map_func.h"
+
+/**
+ * Animation state of a possibly-animated tile.
+ */
+enum class AnimatedTileState : uint8_t {
+	None = 0, ///< Tile is not animated.
+	Deleted = 1, ///< Tile was animated but should be removed.
+	Animated = 3, ///< Tile is animated.
+};
+
+/**
+ * Get the animated state of a tile.
+ * @param t The tile.
+ * @returns true iff the tile is animated.
+ */
+inline AnimatedTileState GetAnimatedTileState(Tile t)
+{
+	return static_cast<AnimatedTileState>(GB(t.m6(), 0, 2));
+}
+
+/**
+ * Set the animated state of a tile.
+ * @param t The tile.
+ */
+inline void SetAnimatedTileState(Tile t, AnimatedTileState state)
+{
+	SB(t.m6(), 0, 2, to_underlying(state));
+}
+
+#endif /* ANIMATED_TILE_MAP_H */

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -530,7 +530,7 @@ void DrawFoundation(TileInfo *ti, Foundation f)
 void DoClearSquare(TileIndex tile)
 {
 	/* If the tile can have animation and we clear it, delete it from the animated tile list. */
-	if (_tile_type_procs[GetTileType(tile)]->animate_tile_proc != nullptr) DeleteAnimatedTile(tile);
+	if (MayAnimateTile(tile)) DeleteAnimatedTile(tile);
 
 	bool remove = IsDockingTile(tile);
 	MakeClear(tile, CLEAR_GRASS, _generating_world ? 3 : 0);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -43,6 +43,7 @@
 #include "../game/game.hpp"
 #include "../town.h"
 #include "../economy_base.h"
+#include "../animated_tile_map.h"
 #include "../animated_tile_func.h"
 #include "../subsidy_base.h"
 #include "../subsidy_func.h"
@@ -2222,6 +2223,23 @@ bool AfterLoadGame()
 		for (auto t : Map::Iterate()) {
 			if (!IsTileType(t, MP_WATER)) continue;
 			SetNonFloodingWaterTile(t, false);
+		}
+	}
+
+	if (IsSavegameVersionBefore(SLV_ANIMATED_TILE_STATE_IN_MAP)) {
+		/* Animated tile state is stored in the map array, allowing
+		 * quicker addition and deletion of animated tiles. */
+
+		extern std::vector<TileIndex> _animated_tiles;
+
+		for (auto t : Map::Iterate()) {
+			/* Ensure there is no spurious animated tile state. */
+			if (MayAnimateTile(t)) SetAnimatedTileState(t, AnimatedTileState::None);
+		}
+
+		/* Set animated flag for all valid animated tiles. */
+		for (const TileIndex &tile : _animated_tiles) {
+			if (tile != INVALID_TILE) SetAnimatedTileState(tile, AnimatedTileState::Animated);
 		}
 	}
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2203,7 +2203,7 @@ bool AfterLoadGame()
 
 		for (auto tile = _animated_tiles.begin(); tile < _animated_tiles.end(); /* Nothing */) {
 			/* Remove if tile is not animated */
-			bool remove = _tile_type_procs[GetTileType(*tile)]->animate_tile_proc == nullptr;
+			bool remove = !MayAnimateTile(*tile);
 
 			/* and remove if duplicate */
 			for (auto j = _animated_tiles.begin(); !remove && j < tile; j++) {

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -393,6 +393,7 @@ enum SaveLoadVersion : uint16_t {
 
 	SLV_NONFLOODING_WATER_TILES,            ///< 345  PR#13013 Store water tile non-flooding state.
 	SLV_PATH_CACHE_FORMAT,                  ///< 346  PR#12345 Vehicle path cache format changed.
+	SLV_ANIMATED_TILE_STATE_IN_MAP,         ///< 347  PR#13082 Animated tile state saved for improved performance.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/station_map.h
+++ b/src/station_map.h
@@ -431,7 +431,7 @@ inline bool IsHangarTile(Tile t)
 inline bool IsStationTileBlocked(Tile t)
 {
 	assert(HasStationRail(t));
-	return HasBit(t.m6(), 0);
+	return HasBit(t.m3(), 0);
 }
 
 /**
@@ -443,7 +443,7 @@ inline bool IsStationTileBlocked(Tile t)
 inline void SetStationTileBlocked(Tile t, bool b)
 {
 	assert(HasStationRail(t));
-	AssignBit(t.m6(), 0, b);
+	AssignBit(t.m3(), 0, b);
 }
 
 /**
@@ -455,7 +455,7 @@ inline void SetStationTileBlocked(Tile t, bool b)
 inline bool CanStationTileHaveWires(Tile t)
 {
 	assert(HasStationRail(t));
-	return HasBit(t.m6(), 1);
+	return HasBit(t.m3(), 1);
 }
 
 /**
@@ -467,7 +467,7 @@ inline bool CanStationTileHaveWires(Tile t)
 inline void SetStationTileHaveWires(Tile t, bool b)
 {
 	assert(HasStationRail(t));
-	AssignBit(t.m6(), 1, b);
+	AssignBit(t.m3(), 1, b);
 }
 
 /**
@@ -479,7 +479,7 @@ inline void SetStationTileHaveWires(Tile t, bool b)
 inline bool CanStationTileHavePylons(Tile t)
 {
 	assert(HasStationRail(t));
-	return HasBit(t.m6(), 7);
+	return HasBit(t.m3(), 2);
 }
 
 /**
@@ -491,7 +491,7 @@ inline bool CanStationTileHavePylons(Tile t)
 inline void SetStationTileHavePylons(Tile t, bool b)
 {
 	assert(HasStationRail(t));
-	AssignBit(t.m6(), 7, b);
+	AssignBit(t.m3(), 2, b);
 }
 
 /**

--- a/src/tile_cmd.h
+++ b/src/tile_cmd.h
@@ -194,6 +194,16 @@ inline void AddProducedCargo(TileIndex tile, CargoArray &produced)
 	proc(tile, produced);
 }
 
+/**
+ * Test if a tile may be animated.
+ * @param tile Tile to test.
+ * @returns True iff the type of the tile has a handler for tile animation.
+ */
+inline bool MayAnimateTile(TileIndex tile)
+{
+	return _tile_type_procs[GetTileType(tile)]->animate_tile_proc != nullptr;
+}
+
 inline void AnimateTile(TileIndex tile)
 {
 	AnimateTileProc *proc = _tile_type_procs[GetTileType(tile)]->animate_tile_proc;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

A game can become sluggish with lots (tens of thousands) of animated tiles.

Adding an animated tile involves searching a list to see if it's already present, before adding it.
Removing an animated tile again involves searching for list, and then also requires removing an element from anywhere in the vector.

If a game has many animated tile, the cost of this can be considerable.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Store animated tile state in map to improve performance.

This allows animated tiles to be added and removed without searching in the animated tile list, providing a performance improvement when there are lots of animated tiles.

Additionally, now that deleting animated tiles no longer happens immediately, they can be removed from the list by swapping with back of the list. Each delete is now a swap-and-pop operation which does not require removing from the middle of the list.

Map bits used by station tile flags are moved so that m6 bits 1..0 are available for all animated tiles.

Save game version is bumped so that animated tile state can be converted.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

We're still slower than JGRPP...

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
