### PR TITLE
Codechange: Remove redundant checks in FindClosestTrainDepot

### DIFF
--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -2167,11 +2167,6 @@ static FindDepotData FindClosestTrainDepot(Train *v, int max_distance)
 {
 	assert(!(v->vehstatus & VS_CRASHED));
 
-	if (IsRailDepotTile(v->tile)) return FindDepotData(v->tile, 0);
-
-	PBSTileInfo origin = FollowTrainReservation(v);
-	if (IsRailDepotTile(origin.tile)) return FindDepotData(origin.tile, 0);
-
 	return YapfTrainFindNearestDepot(v, max_distance);
 }
 


### PR DESCRIPTION
## Motivation / Problem

Until #12217 , YAPF did not properly consider any of the start nodes as potential destination nodes. This led to special treatment of cases where the vehicle is already at the destination. After the fix these special cases should no longer be needed.

## Description

I've removed the two reduntant checks. I went back to the changes done for #12217, and there removing the cases caused problems of trains getting lost in certain situations. After applying #12217 there were no more lost trains no matter what I tried.

## Limitations

As with any obscure pathfinding-related changes, there might be side effects...

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
