### PR TITLE
Codechange: Avoid unnecessary re-reads/seeks in RandomAccessFile::ReadBlock

### DIFF
--- a/src/random_access_file.cpp
+++ b/src/random_access_file.cpp
@@ -144,7 +144,15 @@ uint32_t RandomAccessFile::ReadDword()
  */
 void RandomAccessFile::ReadBlock(void *ptr, size_t size)
 {
-	this->SeekTo(this->GetPos(), SEEK_SET);
+	if (this->buffer != this->buffer_end) {
+		size_t to_copy = std::min<size_t>(size, this->buffer_end - this->buffer);
+		memcpy(ptr, this->buffer, to_copy);
+		this->buffer += to_copy;
+		size -= to_copy;
+		if (size == 0) return;
+		ptr = static_cast<char *>(ptr) + to_copy;
+	}
+
 	this->pos += fread(ptr, 1, size, *this->file_handle);
 }
 


### PR DESCRIPTION
## Motivation / Problem

Typically the data which is to be read by RandomAccessFile::ReadBlock is already in the read buffer, so throwing the whole read buffer away and doing another fseek + fread is an unnecessary pessimisation.
This also leads to needing to call fread immediately after calling RandomAccessFile::ReadBlock, even if that data was previously in the read buffer.

## Description

Use data remaining in the read buffer to satisfy RandomAccessFile::ReadBlock, do not unnecessarily throw the read buffer away.

## Limitations

Much the same changes can also be applied to calls to SeekTo, but this is less straightforward so not included in this PR.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
