### PR TITLE
[NewGRF] More options for setting vehicle refit masks

### DIFF
--- a/src/newgrf_callbacks.h
+++ b/src/newgrf_callbacks.h
@@ -285,6 +285,12 @@ enum CallbackID {
 
 	/** Called to determine probability during build. */
 	CBID_VEHICLE_BUILD_PROBABILITY       = 0x162, // 15 bit callback
+
+	/**
+	 * Called to get custom engine refit mask. Called once
+	 * for each defined cargo after all NewGRFs are loaded.
+	 */
+	CBID_VEHICLE_CUSTOM_REFIT            = 0x0163, // 15 bit callback
 };
 
 /**
@@ -301,6 +307,7 @@ enum VehicleCallbackMask {
 	CBM_VEHICLE_COLOUR_REMAP   = 6, ///< Change colour mapping of vehicle
 	CBM_VEHICLE_SOUND_EFFECT   = 7, ///< Vehicle uses custom sound effects
 	CBM_VEHICLE_NAME           = 8, ///< Engine name
+	CBM_VEHICLE_CUSTOM_REFIT   = 9, ///< Custom refit mask
 };
 
 /**


### PR DESCRIPTION
## Motivation / Problem

The existing properties to define vehicle refittability based on cargo classes are limiting.
There are properties for OR, AND NOT, and XOR, but no AND or any other boolean logic.

## Description

This PR adds a new property to filter the allowed refits based on an AND of cargo classes, i.e. only cargos that have all cargo classes from the prop are added as an allowed refit.
In detail, the existing prop 28/1D/18/18 select a candidate list of refittable cargos that have at least one of the cargo classes from the prop set. The new prop then filters this list by only allowing cargos that have all of the cargo classes from the new prop set.

To future-proof the refit calculations, there's an additional new callback introduced that is run once for each vehicle type and defined cargo after NewGRF load that allows overriding the prop-based refit mask. The callback is passed the cargo classes and the local cargo ID and will either allow, disallow, or not change the refittability of each cargo.

These two features are fully independent, so there would be no problem dropping one of them.

## Limitations

The new callback is run only once after NewGRF load and not cached, so a potential desync hazard if e.g. the date is included in the CB.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
