### PR TITLE
Codefix: Missing this-> in Kdtree

### DIFF
--- a/src/core/kdtree.hpp
+++ b/src/core/kdtree.hpp
@@ -84,7 +84,7 @@ class Kdtree {
 		} else if (count == 1) {
 			return this->AddNode(*begin);
 		} else if (count > 1) {
-			CoordT split_coord = SelectSplitCoord(begin, end, level);
+			CoordT split_coord = this->SelectSplitCoord(begin, end, level);
 			It split = std::partition(begin, end, [&](T v) { return TxyFunc()(v, level % 2) < split_coord; });
 			size_t newidx = this->AddNode(*split);
 			this->nodes[newidx].left = this->BuildSubtree(begin, split, level + 1);
@@ -247,7 +247,7 @@ class Kdtree {
 		/* Coordinate of element splitting at this node */
 		CoordT c = TxyFunc()(n.element, dim);
 		/* This node's distance to target */
-		DistT thisdist = ManhattanDistance(n.element, xy[0], xy[1]);
+		DistT thisdist = this->ManhattanDistance(n.element, xy[0], xy[1]);
 		/* Assume this node is the best choice for now */
 		node_distance best = std::make_pair(n.element, thisdist);
 
@@ -299,7 +299,7 @@ class Kdtree {
 	{
 		if (node_idx == INVALID_NODE) return 0;
 		const node &n = this->nodes[node_idx];
-		return CountValue(element, n.left) + CountValue(element, n.right) + ((n.element == element) ? 1 : 0);
+		return this->CountValue(element, n.left) + this->CountValue(element, n.right) + ((n.element == element) ? 1 : 0);
 	}
 
 	void IncrementUnbalanced(size_t amount = 1)
@@ -331,12 +331,12 @@ class Kdtree {
 
 		if (level % 2 == 0) {
 			// split in dimension 0 = x
-			CheckInvariant(n.left,  level + 1, min_x, cx, min_y, max_y);
-			CheckInvariant(n.right, level + 1, cx, max_x, min_y, max_y);
+			this->CheckInvariant(n.left,  level + 1, min_x, cx, min_y, max_y);
+			this->CheckInvariant(n.right, level + 1, cx, max_x, min_y, max_y);
 		} else {
 			// split in dimension 1 = y
-			CheckInvariant(n.left,  level + 1, min_x, max_x, min_y, cy);
-			CheckInvariant(n.right, level + 1, min_x, max_x, cy, max_y);
+			this->CheckInvariant(n.left,  level + 1, min_x, max_x, min_y, cy);
+			this->CheckInvariant(n.right, level + 1, min_x, max_x, cy, max_y);
 		}
 	}
 
@@ -344,7 +344,7 @@ class Kdtree {
 	void CheckInvariant() const
 	{
 #ifdef KDTREE_DEBUG
-		CheckInvariant(this->root, 0, std::numeric_limits<CoordT>::min(), std::numeric_limits<CoordT>::max(), std::numeric_limits<CoordT>::min(), std::numeric_limits<CoordT>::max());
+		this->CheckInvariant(this->root, 0, std::numeric_limits<CoordT>::min(), std::numeric_limits<CoordT>::max(), std::numeric_limits<CoordT>::min(), std::numeric_limits<CoordT>::max());
 #endif
 	}
 
@@ -368,7 +368,7 @@ public:
 		this->nodes.reserve(end - begin);
 
 		this->root = this->BuildSubtree(begin, end, 0);
-		CheckInvariant();
+		this->CheckInvariant();
 	}
 
 	/**
@@ -404,7 +404,7 @@ public:
 				this->InsertRecursive(element, this->root, 0);
 				this->IncrementUnbalanced();
 			}
-			CheckInvariant();
+			this->CheckInvariant();
 		}
 	}
 
@@ -423,7 +423,7 @@ public:
 			this->root = this->RemoveRecursive(element, this->root, 0);
 			this->IncrementUnbalanced();
 		}
-		CheckInvariant();
+		this->CheckInvariant();
 	}
 
 	/** Get number of elements stored in tree */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Code style. Missing `this->` in Kdtree class.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Add missing `this->`.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Not sure lines 258 and 268 need `this->` on them, as the function is `static`.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
