### PR TITLE
Codechange: Cache callback spritegroups.

### DIFF
--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -230,7 +230,7 @@ const SpriteGroup *DeterministicSpriteGroup::Resolve(ResolverObject &object) con
 	if (this->calculated_result) {
 		/* nvar == 0 is a special case -- we turn our value into a callback result */
 		if (value != CALLBACK_FAILED) value = GB(value, 0, 15);
-		static CallbackResultSpriteGroup nvarzero(0, true);
+		static CallbackResultSpriteGroup nvarzero(0);
 		nvarzero.result = value;
 		return &nvarzero;
 	}

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -211,20 +211,8 @@ struct CallbackResultSpriteGroup : SpriteGroup {
 	/**
 	 * Creates a spritegroup representing a callback result
 	 * @param value The value that was used to represent this callback result
-	 * @param grf_version8 True, if we are dealing with a new NewGRF which uses GRF version >= 8.
 	 */
-	CallbackResultSpriteGroup(uint16_t value, bool grf_version8) :
-		SpriteGroup(SGT_CALLBACK),
-		result(value)
-	{
-		/* Old style callback results (only valid for version < 8) have the highest byte 0xFF so signify it is a callback result.
-		 * New style ones only have the highest bit set (allows 15-bit results, instead of just 8) */
-		if (!grf_version8 && (this->result >> 8) == 0xFF) {
-			this->result &= ~0xFF00;
-		} else {
-			this->result &= ~0x8000;
-		}
-	}
+	explicit CallbackResultSpriteGroup(uint16_t value) : SpriteGroup(SGT_CALLBACK), result(value) {}
 
 	uint16_t result;
 	uint16_t GetCallbackResult() const override { return this->result; }


### PR DESCRIPTION

<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Each callback result requires a pool memory allocation, each of which is 24 bytes.

Many NewGRFs use callback results which have the same value, so if those callback sprite groups are reused then memory will be saved.


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Build a cache of results so that if the same result is used later it can refer to the same group.

The cache is implemented as a sorted vector of value and SpriteGroup index, so each entry is 8 bytes while NewGRFs are loading.

A quick test with Iron Horse 3.33 reveals that it has 80,345 callback results, but "only" 962 distinct results, with 79,383 callbacks reusing the same values.

By reusing the callback sprite group in this instance 1,905,192 bytes are saved.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
