### PR TITLE
Codechange: Tidy up GRFParameterInfo.

### DIFF
--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -116,7 +116,7 @@ struct GRFError {
 };
 
 /** The possible types of a newgrf parameter. */
-enum GRFParameterType {
+enum GRFParameterType : uint8_t {
 	PTYPE_UINT_ENUM, ///< The parameter allows a range of numbers, each of which can have a special name
 	PTYPE_BOOL,      ///< The parameter is either 0 or 1
 	PTYPE_END,       ///< Invalid parameter type
@@ -124,21 +124,29 @@ enum GRFParameterType {
 
 /** Information about one grf parameter. */
 struct GRFParameterInfo {
-	GRFParameterInfo(uint nr);
-	GRFTextList name;      ///< The name of this parameter
-	GRFTextList desc;      ///< The description of this parameter
-	GRFParameterType type; ///< The type of this parameter
-	uint32_t min_value;      ///< The minimal value this parameter can have
-	uint32_t max_value;      ///< The maximal value of this parameter
-	uint32_t def_value;      ///< Default value of this parameter
-	uint8_t param_nr;         ///< GRF parameter to store content in
-	uint8_t first_bit;        ///< First bit to use in the GRF parameter
-	uint8_t num_bit;          ///< Number of bits to use for this parameter
-	std::map<uint32_t, GRFTextList> value_names; ///< Names for each value.
-	bool complete_labels;  ///< True if all values have a label.
+	/**
+	 * Create a new empty GRFParameterInfo object.
+	 * @param nr The newgrf parameter that is changed.
+	 */
+	explicit GRFParameterInfo(uint nr) : param_nr(nr) {}
 
-	uint32_t GetValue(struct GRFConfig *config) const;
-	void SetValue(struct GRFConfig *config, uint32_t value);
+	GRFTextList name = {}; ///< The name of this parameter
+	GRFTextList desc = {}; ///< The description of this parameter
+
+	uint32_t min_value = 0; ///< The minimal value this parameter can have
+	uint32_t max_value = UINT32_MAX; ///< The maximal value of this parameter
+	uint32_t def_value = 0; ///< Default value of this parameter
+
+	GRFParameterType type = PTYPE_UINT_ENUM; ///< The type of this parameter
+
+	uint8_t param_nr; ///< GRF parameter to store content in
+	uint8_t first_bit = 0; ///< First bit to use in the GRF parameter
+	uint8_t num_bit = 32; ///< Number of bits to use for this parameter
+
+	bool complete_labels = false; ///< True if all values have a label.
+
+	std::map<uint32_t, GRFTextList> value_names = {}; ///< Names for each value.
+
 	void Finalize();
 };
 
@@ -175,6 +183,9 @@ struct GRFConfig : ZeroedMemoryAllocator {
 	bool IsCompatible(uint32_t old_version) const;
 	void SetParams(const std::vector<uint32_t> &pars);
 	void CopyParams(const GRFConfig &src);
+
+	uint32_t GetValue(const GRFParameterInfo &info) const;
+	void SetValue(const GRFParameterInfo &info, uint32_t value);
 
 	std::optional<std::string> GetTextfile(TextfileType type) const;
 	const char *GetName() const;

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -284,12 +284,12 @@ struct NewGRFParametersWindow : public Window {
 		int text_y_offset = (this->line_height - GetCharacterHeight(FS_NORMAL)) / 2;
 		for (int32_t i = this->vscroll->GetPosition(); this->vscroll->IsVisible(i) && i < this->vscroll->GetCount(); i++) {
 			GRFParameterInfo &par_info = this->GetParameterInfo(i);
-			uint32_t current_value = par_info.GetValue(this->grf_config);
+			uint32_t current_value = this->grf_config->GetValue(par_info);
 			bool selected = (i == this->clicked_row);
 
 			if (par_info.type == PTYPE_BOOL) {
 				DrawBoolButton(buttons_left, ir.top + button_y_offset, current_value != 0, this->editable);
-				SetDParam(2, par_info.GetValue(this->grf_config) == 0 ? STR_CONFIG_SETTING_OFF : STR_CONFIG_SETTING_ON);
+				SetDParam(2, this->grf_config->GetValue(par_info) == 0 ? STR_CONFIG_SETTING_OFF : STR_CONFIG_SETTING_ON);
 			} else if (par_info.type == PTYPE_UINT_ENUM) {
 				if (par_info.complete_labels) {
 					DrawDropDownButton(buttons_left, ir.top + button_y_offset, COLOUR_YELLOW, this->clicked_row == i && this->clicked_dropdown, this->editable);
@@ -371,7 +371,7 @@ struct NewGRFParametersWindow : public Window {
 				GRFParameterInfo &par_info = this->GetParameterInfo(num);
 
 				/* One of the arrows is clicked */
-				uint32_t old_val = par_info.GetValue(this->grf_config);
+				uint32_t old_val = this->grf_config->GetValue(par_info);
 				if (par_info.type != PTYPE_BOOL && IsInsideMM(x, 0, SETTING_BUTTON_WIDTH) && par_info.complete_labels) {
 					if (this->clicked_dropdown) {
 						/* unclick the dropdown */
@@ -416,7 +416,7 @@ struct NewGRFParametersWindow : public Window {
 						}
 					}
 					if (val != old_val) {
-						par_info.SetValue(this->grf_config, val);
+						this->grf_config->SetValue(par_info, val);
 
 						this->clicked_button = num;
 						this->unclick_timeout.Reset();
@@ -448,8 +448,7 @@ struct NewGRFParametersWindow : public Window {
 		if (!str.has_value() || str->empty()) return;
 		int32_t value = atoi(str->c_str());
 		GRFParameterInfo &par_info = this->GetParameterInfo(this->clicked_row);
-		uint32_t val = Clamp<uint32_t>(value, par_info.min_value, par_info.max_value);
-		par_info.SetValue(this->grf_config, val);
+		this->grf_config->SetValue(par_info, value);
 		this->SetDirty();
 	}
 
@@ -458,7 +457,7 @@ struct NewGRFParametersWindow : public Window {
 		if (widget != WID_NP_SETTING_DROPDOWN) return;
 		assert(this->clicked_dropdown);
 		GRFParameterInfo &par_info = this->GetParameterInfo(this->clicked_row);
-		par_info.SetValue(this->grf_config, index);
+		this->grf_config->SetValue(par_info, index);
 		this->SetDirty();
 	}
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

I was switching GRFParameterInfo to use member-initialisation to simplify it, and noticed how the SetValue/GetValue methods, work.

GRFParameterInfo contains data about how to set a GRFConfig parameter, but doesn't contain the parameter itself.

These two methods actually change the state of the GRFConfig passed to it, not the GRFParameterInfo, so it seemed inverted to me.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Tidy up GRFParameterInfo, use member-initialisation, reorder members to reduce space, and prefer references.

The SetValue/GetValue methods are moved to GRFConfig, taking GRFParameterInfo as a parameter instead, as they set the config's parameter values.

This seems clearer to me as we are setting the GRFConfig's parameter based on the GRFParameterInfo, not setting GRFParameterInfo based on the GRFConfig.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
