### PR TITLE
Codechange: Enhance industry count management and add KD-Trees

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -221,6 +221,8 @@ add_files(
     industry_cmd.cpp
     industry_cmd.h
     industry_gui.cpp
+    industry_kdtree.cpp
+    industry_kdtree.h
     industry_map.h
     industry_type.h
     industrytype.h

--- a/src/industry.h
+++ b/src/industry.h
@@ -18,6 +18,7 @@
 #include "station_base.h"
 #include "timer/timer_game_calendar.h"
 #include "timer/timer_game_economy.h"
+#include "industry_kdtree.h"
 #include "town.h"
 
 
@@ -245,74 +246,94 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 	static void PostDestructor(size_t index);
 
 	/**
+	 * Struct representing the cache of industries for a specific town.
+	 */
+	struct IndustryTownCache {
+		TownID town_id;                       ///< The ID of the town.
+		std::vector<IndustryID> industry_ids; ///< A vector of IDs of the industries associated with the town.
+	};
+
+	/**
+	 * Struct representing the cache of industry counts for a specific industry type.
+	 */
+	struct IndustryTypeCountCaches {
+		IndustryKdtree kdtree;                ///< A k-d tree for spatial indexing of industries.
+		std::vector<IndustryTownCache> towns; ///< A vector of IndustryTownCache entries, each representing a town and its associated industries.
+	};
+
+	/**
 	 * Increment the count of industries of the specified type in a town.
 	 *
-	 * @param ind Pointer to the Industry to increment its type count in the town.
-	 * @pre ind != nullptr
+	 * This function updates the k-d tree by inserting the industry's index and adjusts the
+	 * industry counts for the specific industry type in the corresponding town. If the industry
+	 * is not already in the town's list, it is added in the correct sorted position.
 	 */
-	static inline void IncIndustryTypeCount(const Industry *ind)
+	inline void IncIndustryTypeCount()
 	{
-		assert(ind != nullptr);
+		auto &kdtree = this->counts[this->type].kdtree;
+		kdtree.Insert(this->index);
 
 		/* Find the correct position to insert or update the town entry using lower_bound. */
-		auto &type_vector = counts[ind->type];
-		auto pair_it = std::ranges::lower_bound(type_vector, ind->town->index, {}, &std::pair<TownID, std::vector<IndustryID>>::first);
+		auto &type_vector = this->counts[this->type].towns;
+		auto pair_it = std::ranges::lower_bound(type_vector, this->town->index, {}, &IndustryTownCache::town_id);
 
-		if (pair_it != std::end(type_vector) && pair_it->first == ind->town->index) {
+		if (pair_it != std::end(type_vector) && pair_it->town_id == this->town->index) {
 			/* Create a reference to the town's industry list. */
-			auto &iid_vector = pair_it->second;
+			auto &iid_vector = pair_it->industry_ids;
 
 			/* Ensure the town's industry list is not empty. */
 			assert(!std::empty(iid_vector));
 
 			/* Ensure the industry is not already in the town's industry list. */
 			assert(std::ranges::all_of(iid_vector, [&](auto &iid) {
-				return iid != ind->index;
+				return iid != this->index;
 			}));
 
 			/* Find the correct position to insert the industry ID in sorted order. */
-			auto iid_it = std::ranges::lower_bound(iid_vector, ind->index);
+			auto iid_it = std::ranges::lower_bound(iid_vector, this->index);
 
 			/* Add the industry ID to the town's industry list in the correct position. */
-			iid_vector.insert(iid_it, ind->index);
+			iid_vector.insert(iid_it, this->index);
 		} else {
 			/* Create a new vector for the industry IDs and add the industry ID. */
 			std::vector<IndustryID> iid_vector;
-			iid_vector.emplace_back(ind->index);
+			iid_vector.emplace_back(this->index);
 
-			/* Insert the new pair (town index and vector of industry IDs) into the correct position. */
-			type_vector.emplace(pair_it, ind->town->index, std::move(iid_vector));
+			/* Insert the new entry (town index and vector of industry IDs) into the correct position. */
+			type_vector.emplace(pair_it, IndustryTownCache{ this->town->index, std::move(iid_vector) });
 		}
 	}
 
 	/**
 	 * Decrement the count of industries of the specified type in a town.
 	 *
-	 * @param ind Pointer to the Industry to decrement its type count in the town.
-	 * @pre ind != nullptr
+	 * This function updates the k-d tree by removing the industry's index and adjusts the
+	 * industry counts for the specific industry type in the corresponding town. If the town's
+	 * industry list becomes empty after removal, the town entry is removed from the list.
 	 */
-	static inline void DecIndustryTypeCount(const Industry *ind)
+	inline void DecIndustryTypeCount()
 	{
-		assert(ind != nullptr);
+		auto &kdtree = this->counts[this->type].kdtree;
+		kdtree.Remove(this->index);
 
 		/* Find the correct position of the town entry using lower_bound. */
-		auto &type_vector = counts[ind->type];
-		auto pair_it = std::ranges::lower_bound(type_vector, ind->town->index, {}, &std::pair<TownID, std::vector<IndustryID>>::first);
+		auto &type_vector = this->counts[this->type].towns;
+		auto pair_it = std::ranges::lower_bound(type_vector, this->town->index, {}, &IndustryTownCache::town_id);
 
 		/* Ensure the pair was found in the array. */
-		assert(pair_it != std::end(type_vector) && pair_it->first == ind->town->index);
+		assert(pair_it != std::end(type_vector) && pair_it->town_id == this->town->index);
 
 		/* Create a reference to the town's industry list. */
-		auto &iid_vector = pair_it->second;
+		auto &iid_vector = pair_it->industry_ids;
 
 		/* Ensure the town's industry list is not empty. */
 		assert(!std::empty(iid_vector));
 
 		/* Find the industry ID within the town's industry list. */
-		auto iid_it = std::ranges::lower_bound(iid_vector, ind->index);
+		auto iid_it = std::ranges::lower_bound(iid_vector, this->index);
 
 		/* Ensure the industry ID was found in the list. */
-		assert(iid_it != std::end(iid_vector) && *iid_it == ind->index);
+		assert(iid_it != std::end(iid_vector) && *iid_it == this->index);
 
 		/* Erase the industry ID from the town's industry list. */
 		iid_vector.erase(iid_it);
@@ -371,11 +392,12 @@ public:
 		uint16_t count = 0;
 		if (town != nullptr) {
 			/* Find the correct position of the town entry using lower_bound. */
-			auto pair_it = std::ranges::lower_bound(counts[type], town->index, {}, &std::pair<TownID, std::vector<IndustryID>>::first);
+			auto &type_vector = counts[type].towns;
+			auto pair_it = std::ranges::lower_bound(type_vector, town->index, {}, &IndustryTownCache::town_id);
 
-			if (pair_it != std::end(counts[type]) && pair_it->first == town->index) {
+			if (pair_it != std::end(type_vector) && pair_it->town_id == town->index) {
 				/* Create a reference to the town's industry list. */
-				auto &iid_vector = pair_it->second;
+				auto &iid_vector = pair_it->industry_ids;
 
 				/* Ensure the town's industry list is not empty. */
 				assert(!std::empty(iid_vector));
@@ -383,13 +405,13 @@ public:
 			}
 		} else {
 			/* Count industries in all towns. */
-			for (auto &pair : counts[type]) {
+			for (auto &pair : counts[type].towns) {
 				/* Create a reference to the town's industry list. */
-				auto &iid_vector = pair.second;
+				auto &iid_vector = pair.industry_ids;
 
 				/* Ensure the town's industry list is not empty. */
 				assert(!std::empty(iid_vector));
-				count += ProcessIndustries(iid_vector, Town::Get(pair.first), return_early, func);
+				count += ProcessIndustries(iid_vector, Town::Get(pair.town_id), return_early, func);
 				if (return_early && count != 0) break;
 			}
 		}
@@ -403,9 +425,13 @@ public:
 	 * @param type The type of industry to count.
 	 * @return uint16_t The count of industries of the specified type.
 	 */
-	static inline uint16_t GetIndustryTypeCount(IndustryType type)
+	static uint16_t GetIndustryTypeCount(IndustryType type)
 	{
-		return CountTownIndustriesOfTypeMatchingCondition(type, nullptr, false, [](const Industry *) { return true; });
+		uint16_t count = static_cast<uint16_t>(counts[type].kdtree.Count());
+
+		/* Sanity check. Both the Kdtree and the count of industries in all towns should match. */
+		assert(count == CountTownIndustriesOfTypeMatchingCondition(type, nullptr, false, [](const Industry *) { return true; }));
+		return count;
 	}
 
 	/**
@@ -425,13 +451,84 @@ public:
 	/**
 	 * Resets the industry counts for all industry types.
 	 *
-	 * Clears the vector of industry counts for each industry type,
+	 * Clears the vector of IndustryTownCache entries for each industry type,
 	 * effectively resetting the count of industries per type in all towns.
 	 */
 	static inline void ResetIndustryCounts()
 	{
 		/* Clear the vector for each industry type in the counts array. */
-		std::ranges::for_each(counts, [](auto &type) { type.clear(); });
+		std::ranges::for_each(counts, [](auto &type) { type.towns.clear(); });
+	}
+
+	/**
+	 * Rebuilds the k-d tree for each industry type.
+	 *
+	 * Iterates over all industries, categorizes them by type, and rebuilds the
+	 * k-d tree for each industry type using the collected industry IDs.
+	 */
+	static inline void RebuildIndustryKdtree()
+	{
+		std::array<std::vector<IndustryID>, NUM_INDUSTRYTYPES> industryids;
+		for (const Industry *industry : Industry::Iterate()) {
+			industryids[industry->type].push_back(industry->index);
+		}
+
+		for (IndustryType type = 0; type < NUM_INDUSTRYTYPES; type++) {
+			counts[type].kdtree.Build(industryids[type].begin(), industryids[type].end());
+		}
+	}
+
+	/**
+	 * Find all industries within a specified radius of a given tile.
+	 *
+	 * This function calculates the rectangular area around the given tile, constrained by the map boundaries,
+	 * and finds all industries contained within this area using the k-d tree.
+	 *
+	 * @param tile The central tile index.
+	 * @param type The industry type to search for.
+	 * @param radius The search radius around the tile.
+	 * @return std::vector<IndustryID> A vector of industry IDs found within the specified area.
+	 */
+	static inline std::vector<IndustryID> FindContained(TileIndex tile, IndustryType type, int radius)
+	{
+		static uint16_t x1, x2, y1, y2;
+		x1 = (uint16_t)std::max<int>(0, TileX(tile) - radius);
+		x2 = (uint16_t)std::min<int>(TileX(tile) + radius + 1, Map::SizeX());
+		y1 = (uint16_t)std::max<int>(0, TileY(tile) - radius);
+		y2 = (uint16_t)std::min<int>(TileY(tile) + radius + 1, Map::SizeY());
+
+		return counts[type].kdtree.FindContained(x1, y1, x2, y2);
+	}
+
+	/**
+	 * Find the industry nearest to a given tile.
+	 *
+	 * This function uses the k-d tree to find the industry of the specified type
+	 * that is closest to the given tile based on its coordinates.
+	 *
+	 * @param tile The tile index to search from.
+	 * @param type The industry type to search for.
+	 * @return IndustryID The ID of the nearest industry.
+	 */
+	static inline IndustryID FindNearest(TileIndex tile, IndustryType type)
+	{
+		return counts[type].kdtree.FindNearest(TileX(tile), TileY(tile));
+	}
+
+	/**
+	 * Find the industry nearest to a given tile, excluding a specified industry.
+	 *
+	 * This function uses the k-d tree to find the industry of the specified type
+	 * that is closest to the given tile, excluding the industry with the given ID.
+	 *
+	 * @param tile The tile index to search from.
+	 * @param type The industry type to search for.
+	 * @param iid The ID of the industry to exclude from the search.
+	 * @return IndustryID The ID of the nearest industry, excluding the specified one.
+	 */
+	static inline IndustryID FindNearestExcept(TileIndex tile, IndustryType type, IndustryID iid)
+	{
+		return counts[type].kdtree.FindNearestExcept(TileX(tile), TileY(tile), iid);
 	}
 
 	inline const std::string &GetCachedName() const
@@ -445,11 +542,14 @@ private:
 
 protected:
 	/**
-	 * Array containing vectors of industry types.
-	 * Each vector corresponds to a specific IndustryType and
-	 * contains pairs of TownIDs and their associated lists of IndustryIDs.
+	 * Array containing data for each industry type.
+	 * Each element corresponds to a specific IndustryType and contains:
+	 * - An IndustryKdtree for spatial indexing.
+	 * - A vector of IndustryTownCache entries, where each entry holds:
+	 *   - A TownID representing a town.
+	 *   - A vector of IndustryIDs associated with that town.
 	 */
-	static std::array<std::vector<std::pair<TownID, std::vector<IndustryID>>>, NUM_INDUSTRYTYPES> counts;
+	static std::array<IndustryTypeCountCaches, NUM_INDUSTRYTYPES> counts;
 };
 
 void ClearAllIndustryCachedNames();

--- a/src/industry_kdtree.cpp
+++ b/src/industry_kdtree.cpp
@@ -1,0 +1,16 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file industry_kdtree.cpp Implementation of the industry k-d tree functions */
+
+#include "industry_kdtree.h"
+#include "industry.h"
+
+uint16_t Kdtree_IndustryXYFunc::operator()(IndustryID iid, int dim)
+{
+	return (dim == 0) ? TileX(Industry::Get(iid)->location.tile) : TileY(Industry::Get(iid)->location.tile);
+}

--- a/src/industry_kdtree.h
+++ b/src/industry_kdtree.h
@@ -1,0 +1,25 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file industry_kdtree.h Declarations for accessing the k-d tree of industries */
+
+#ifndef INDUSTRY_KDTREE_H
+#define INDUSTRY_KDTREE_H
+
+#include "core/kdtree.hpp"
+#include "industry_type.h"
+
+/* Forward declaration of Industry struct */
+struct Industry;
+
+struct Kdtree_IndustryXYFunc {
+	uint16_t operator()(IndustryID iid, int dim);
+};
+
+using IndustryKdtree = Kdtree<IndustryID, Kdtree_IndustryXYFunc, uint16_t, int>;
+
+#endif

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -31,6 +31,7 @@
 #include "station_kdtree.h"
 #include "town_kdtree.h"
 #include "viewport_kdtree.h"
+#include "industry.h"
 #include "newgrf_profiling.h"
 #include "3rdparty/monocypher/monocypher.h"
 
@@ -126,6 +127,7 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 	RebuildStationKdtree();
 	RebuildTownKdtree();
 	RebuildViewportKdtree();
+	Industry::RebuildIndustryKdtree();
 
 	ResetPersistentNewGRFData();
 

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -145,12 +145,13 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t param_setID, uint8_
 	} else {
 		/* Count only those who match the same industry type and layout filter
 		 * Unfortunately, we have to do it manually */
-		for (const Industry *i : Industry::Iterate()) {
-			if (i->type == ind_index && i != current && (i->selected_layout == layout_filter || layout_filter == 0) && (!town_filter || i->town == current->town)) {
+		count = Industry::CountTownIndustriesOfTypeMatchingCondition(ind_index, town_filter ? current->town : nullptr, false, [&](const Industry *i) {
+			if (i != current && (layout_filter == 0 || i->selected_layout == layout_filter)) {
 				closest_dist = std::min(closest_dist, DistanceManhattan(current->location.tile, i->location.tile));
-				count++;
+				return true;
 			}
-		}
+			return false;
+		});
 	}
 
 	return count << 16 | GB(closest_dist, 0, 16);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -580,6 +580,7 @@ bool AfterLoadGame()
 	/* This needs to be done even before conversion, because some conversions will destroy objects
 	 * that otherwise won't exist in the tree. */
 	RebuildViewportKdtree();
+	Industry::RebuildIndustryKdtree();
 
 	if (IsSavegameVersionBefore(SLV_98)) _gamelog.GRFAddList(_grfconfig);
 

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -236,7 +236,7 @@ struct INDYChunkHandler : ChunkHandler {
 	{
 		for (Industry *i : Industry::Iterate()) {
 			SlObject(i, _industry_desc);
-			Industry::IncIndustryTypeCount(i);
+			i->IncIndustryTypeCount();
 		}
 	}
 };

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -229,7 +229,6 @@ struct INDYChunkHandler : ChunkHandler {
 			} else if (IsSavegameVersionBefore(SLV_INDUSTRY_CARGO_REORGANISE)) {
 				LoadMoveAcceptsProduced(i, INDUSTRY_NUM_INPUTS, INDUSTRY_NUM_OUTPUTS);
 			}
-			Industry::IncIndustryTypeCount(i->type);
 		}
 	}
 
@@ -237,6 +236,7 @@ struct INDYChunkHandler : ChunkHandler {
 	{
 		for (Industry *i : Industry::Iterate()) {
 			SlObject(i, _industry_desc);
+			Industry::IncIndustryTypeCount(i);
 		}
 	}
 };

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -874,7 +874,7 @@ static bool LoadOldIndustry(LoadgameState *ls, int num)
 			i->random_colour = RemapTTOColour(i->random_colour);
 		}
 
-		Industry::IncIndustryTypeCount(i);
+		i->IncIndustryTypeCount();
 	} else {
 		delete i;
 	}

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -874,7 +874,7 @@ static bool LoadOldIndustry(LoadgameState *ls, int num)
 			i->random_colour = RemapTTOColour(i->random_colour);
 		}
 
-		Industry::IncIndustryTypeCount(i->type);
+		Industry::IncIndustryTypeCount(i);
 	} else {
 		delete i;
 	}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Generating large amounts of industries can be slow.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
This PR aims at speeding up the process of industry generation. It starts off with changes on `Industry::counts`.

```
	/**
	 * Array containing data for each industry type.
	 * Each element corresponds to a specific IndustryType and contains:
	 * - An IndustryKdtree for spatial indexing.
	 * - A vector of IndustryTownCache entries, where each entry holds:
	 *   - A TownID representing a town.
	 *   - A vector of IndustryIDs associated with that town.
	 */
	static std::array<IndustryTypeCountCaches, NUM_INDUSTRYTYPES> counts;
```
It can now take care of which towns have which industries of a certain type on them with `IndustryTownCache`. The result of this is a significant improvement to `FindTownForIndustry` and to `GetCountAndDistanceOfClosestInstance` "else" part which can now check industries directly via `TownID`.

The kdtrees were added to further improve generation speed for functions which look for nearest industries of a specified type, such as `CheckIfFarEnoughFromConflictingIndustry` and `GetClosestIndustry`.

![image](https://github.com/user-attachments/assets/d81c4c5f-4fda-4796-834b-29d412711a69)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Other changes include an adaptation to the new industry count management system, which required a few changes in the game load, mainly the ordering of industry counts, due to missing town pointers at an early stage, and at `DoCreateNewIndustry`.

`FindNearestRecursive` in `Kdtree` has also been adapted to accept and deal with an optional element to be excluded from the search which impacts performance. The alternative was to duplicate this function to deal with it.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
