### PR TITLE
Codechange: Sort Engine ID mapping for fast lookups

### DIFF
--- a/src/core/container_func.hpp
+++ b/src/core/container_func.hpp
@@ -46,4 +46,19 @@ int find_index(Container const &container, typename Container::const_reference i
 	return -1;
 }
 
+/**
+ * Move elements between first and last to a new position, rotating elements in between as necessary.
+ * @param first Iterator to first element to move.
+ * @param last Iterator to (end-of) last element to move.
+ * @param position Iterator to where range should be moved to.
+ * @returns Iterators to first and last after being moved.
+ */
+template <typename TIter>
+auto Slide(TIter first, TIter last, TIter position) -> std::pair<TIter, TIter>
+{
+	if (last < position) return { std::rotate(first, last, position), position };
+	if (position < first) return { position, std::rotate(position, first, last) };
+	return { first, last };
+}
+
 #endif /* CONTAINER_FUNC_HPP */

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -8,6 +8,7 @@
 /** @file engine.cpp Base for all engine handling. */
 
 #include "stdafx.h"
+#include "core/container_func.hpp"
 #include "company_func.h"
 #include "command_func.h"
 #include "news_func.h"
@@ -66,8 +67,6 @@ const uint8_t _engine_offsets[4] = {
 };
 
 static_assert(lengthof(_orig_rail_vehicle_info) + lengthof(_orig_road_vehicle_info) + lengthof(_orig_ship_vehicle_info) + lengthof(_orig_aircraft_vehicle_info) == lengthof(_orig_engine_info));
-
-const uint EngineOverrideManager::NUM_DEFAULT_ENGINES = _engine_counts[VEH_TRAIN] + _engine_counts[VEH_ROAD] + _engine_counts[VEH_SHIP] + _engine_counts[VEH_AIRCRAFT];
 
 Engine::Engine(VehicleType type, EngineID base)
 {
@@ -508,10 +507,12 @@ bool Engine::IsVariantHidden(CompanyID c) const
  */
 void EngineOverrideManager::ResetToDefaultMapping()
 {
-	this->mappings.clear();
+	EngineID id = 0;
 	for (VehicleType type = VEH_TRAIN; type <= VEH_AIRCRAFT; type++) {
-		for (uint internal_id = 0; internal_id < _engine_counts[type]; internal_id++) {
-			this->mappings.emplace_back(INVALID_GRFID, internal_id, type, internal_id);
+		auto &map = this->mappings[type];
+		map.clear();
+		for (uint internal_id = 0; internal_id < _engine_counts[type]; internal_id++, id++) {
+			map.emplace_back(INVALID_GRFID, internal_id, type, internal_id, id);
 		}
 	}
 }
@@ -527,14 +528,52 @@ void EngineOverrideManager::ResetToDefaultMapping()
  */
 EngineID EngineOverrideManager::GetID(VehicleType type, uint16_t grf_local_id, uint32_t grfid)
 {
-	EngineID index = 0;
-	for (const EngineIDMapping &eid : this->mappings) {
-		if (eid.type == type && eid.grfid == grfid && eid.internal_id == grf_local_id) {
-			return index;
-		}
-		index++;
+	const auto &map = this->mappings[type];
+	const auto key = EngineIDMapping::Key(grfid, grf_local_id);
+	auto it = std::ranges::lower_bound(map, key, std::less{}, EngineIDMappingKeyProjection{});
+	if (it == std::end(map) || it->Key() != key) return INVALID_ENGINE;
+	return it->engine;
+}
+
+/**
+ * Look for an unreserved EngineID matching the local id, and reserve it if found.
+ * @param type Vehicle type
+ * @param grf_local_id The local id in the newgrf
+ * @param grfid The GrfID that defines the scope of grf_local_id.
+ *              If a newgrf overrides the engines of another newgrf, the "scope grfid" is the ID of the overridden newgrf.
+ *              If dynnamic_engines is disabled, all newgrf share the same ID scope identified by INVALID_GRFID.
+ * @param static_access Whether to actually reserve the EngineID.
+ * @return The engine ID if present and now reserved, or INVALID_ENGINE if not.
+ */
+EngineID EngineOverrideManager::UseUnreservedID(VehicleType type, uint16_t grf_local_id, uint32_t grfid, bool static_access)
+{
+	auto &map = _engine_mngr.mappings[type];
+	const auto key = EngineIDMapping::Key(INVALID_GRFID, grf_local_id);
+	auto it = std::ranges::lower_bound(map, key, std::less{}, EngineIDMappingKeyProjection{});
+	if (it == std::end(map) || it->Key() != key) return INVALID_ENGINE;
+
+	if (!static_access && grfid != INVALID_GRFID) {
+		/* Reserve the engine slot for the new grfid. */
+		it->grfid = grfid;
+
+		/* Relocate entry to its new position in the mapping list to keep it sorted. */
+		auto p = std::ranges::lower_bound(map, EngineIDMapping::Key(grfid, grf_local_id), std::less{}, EngineIDMappingKeyProjection{});
+		it = Slide(it, std::next(it), p).first;
 	}
-	return INVALID_ENGINE;
+
+	return it->engine;
+}
+
+void EngineOverrideManager::SetID(VehicleType type, uint16_t grf_local_id, uint32_t grfid, uint8_t substitute_id, EngineID engine)
+{
+	auto &map = this->mappings[type];
+	const auto key = EngineIDMapping::Key(grfid, grf_local_id);
+	auto it = std::ranges::lower_bound(map, key, std::less{}, EngineIDMappingKeyProjection{});
+	if (it == std::end(map) || it->Key() != key) {
+		map.emplace(it, grfid, grf_local_id, type, substitute_id, engine);
+	} else {
+		it->engine = engine;
+	}
 }
 
 /**
@@ -563,15 +602,15 @@ void SetupEngines()
 	CloseWindowByClass(WC_ENGINE_PREVIEW);
 	_engine_pool.CleanPool();
 
-	assert(_engine_mngr.mappings.size() >= EngineOverrideManager::NUM_DEFAULT_ENGINES);
-	[[maybe_unused]] uint index = 0;
-	for (const EngineIDMapping &eid : _engine_mngr.mappings) {
-		/* Assert is safe; there won't be more than 256 original vehicles
-		 * in any case, and we just cleaned the pool. */
-		assert(Engine::CanAllocateItem());
-		[[maybe_unused]] const Engine *e = new Engine(eid.type, eid.internal_id);
-		assert(e->index == index);
-		index++;
+	for (VehicleType type = VEH_BEGIN; type != VEH_COMPANY_END; type++) {
+		const auto &mapping = _engine_mngr.mappings[type];
+
+		/* Verify that the engine override manager has at least been set up with the default engines. */
+		assert(std::size(mapping) >= _engine_counts[type]);
+
+		for (const EngineIDMapping &eid : mapping) {
+			new (eid.engine) Engine(type, eid.internal_id);
+		}
 	}
 }
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -508,14 +508,10 @@ bool Engine::IsVariantHidden(CompanyID c) const
  */
 void EngineOverrideManager::ResetToDefaultMapping()
 {
-	this->clear();
+	this->mappings.clear();
 	for (VehicleType type = VEH_TRAIN; type <= VEH_AIRCRAFT; type++) {
 		for (uint internal_id = 0; internal_id < _engine_counts[type]; internal_id++) {
-			EngineIDMapping &eid = this->emplace_back();
-			eid.type            = type;
-			eid.grfid           = INVALID_GRFID;
-			eid.internal_id     = internal_id;
-			eid.substitute_id   = internal_id;
+			this->mappings.emplace_back(INVALID_GRFID, internal_id, type, internal_id);
 		}
 	}
 }
@@ -532,7 +528,7 @@ void EngineOverrideManager::ResetToDefaultMapping()
 EngineID EngineOverrideManager::GetID(VehicleType type, uint16_t grf_local_id, uint32_t grfid)
 {
 	EngineID index = 0;
-	for (const EngineIDMapping &eid : *this) {
+	for (const EngineIDMapping &eid : this->mappings) {
 		if (eid.type == type && eid.grfid == grfid && eid.internal_id == grf_local_id) {
 			return index;
 		}
@@ -567,9 +563,9 @@ void SetupEngines()
 	CloseWindowByClass(WC_ENGINE_PREVIEW);
 	_engine_pool.CleanPool();
 
-	assert(_engine_mngr.size() >= _engine_mngr.NUM_DEFAULT_ENGINES);
+	assert(_engine_mngr.mappings.size() >= EngineOverrideManager::NUM_DEFAULT_ENGINES);
 	[[maybe_unused]] uint index = 0;
-	for (const EngineIDMapping &eid : _engine_mngr) {
+	for (const EngineIDMapping &eid : _engine_mngr.mappings) {
 		/* Assert is safe; there won't be more than 256 original vehicles
 		 * in any case, and we just cleaned the pool. */
 		assert(Engine::CanAllocateItem());

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -194,17 +194,23 @@ struct Engine : EnginePool::PoolItem<&_engine_pool> {
 };
 
 struct EngineIDMapping {
-	uint32_t grfid;          ///< The GRF ID of the file the entity belongs to
-	uint16_t internal_id;    ///< The internal ID within the GRF file
-	VehicleType type;      ///< The engine type
-	uint8_t  substitute_id;  ///< The (original) entity ID to use if this GRF is not available (currently not used)
+	uint32_t grfid; ///< The GRF ID of the file the entity belongs to
+	uint16_t internal_id; ///< The internal ID within the GRF file
+	VehicleType type; ///< The engine type
+	uint8_t substitute_id; ///< The (original) entity ID to use if this GRF is not available (currently not used)
+
+	EngineIDMapping() {}
+	EngineIDMapping(uint32_t grfid, uint16_t internal_id, VehicleType type, uint8_t substitute_id)
+		: grfid(grfid), internal_id(internal_id),type(type), substitute_id(substitute_id) {}
 };
 
 /**
  * Stores the mapping of EngineID to the internal id of newgrfs.
  * Note: This is not part of Engine, as the data in the EngineOverrideManager and the engine pool get resetted in different cases.
  */
-struct EngineOverrideManager : std::vector<EngineIDMapping> {
+struct EngineOverrideManager {
+	std::vector<EngineIDMapping> mappings;
+
 	static const uint NUM_DEFAULT_ENGINES; ///< Number of default entries
 
 	void ResetToDefaultMapping();

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -483,8 +483,8 @@ static void GetTileDesc_Industry(TileIndex tile, TileDesc *td)
 		td->str = STR_LAI_TOWN_INDUSTRY_DESCRIPTION_UNDER_CONSTRUCTION;
 	}
 
-	if (is->grf_prop.grffile != nullptr) {
-		td->grf = GetGRFConfig(is->grf_prop.grffile->grfid)->GetName();
+	if (is->grf_prop.HasGrfFile()) {
+		td->grf = GetGRFConfig(is->grf_prop.grfid)->GetName();
 	}
 }
 
@@ -1826,7 +1826,7 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 		uint16_t res = GetIndustryCallback(CBID_INDUSTRY_PROD_CHANGE_BUILD, 0, Random(), i, type, INVALID_TILE);
 		if (res != CALLBACK_FAILED) {
 			if (res < PRODLEVEL_MINIMUM || res > PRODLEVEL_MAXIMUM) {
-				ErrorUnknownCallbackResult(indspec->grf_prop.grffile->grfid, CBID_INDUSTRY_PROD_CHANGE_BUILD, res);
+				ErrorUnknownCallbackResult(indspec->grf_prop.grfid, CBID_INDUSTRY_PROD_CHANGE_BUILD, res);
 			} else {
 				i->prod_level = res;
 				i->RecomputeProductionMultipliers();
@@ -1851,7 +1851,7 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 	if (HasBit(indspec->callback_mask, CBM_IND_DECIDE_COLOUR)) {
 		uint16_t res = GetIndustryCallback(CBID_INDUSTRY_DECIDE_COLOUR, 0, 0, i, type, INVALID_TILE);
 		if (res != CALLBACK_FAILED) {
-			if (GB(res, 4, 11) != 0) ErrorUnknownCallbackResult(indspec->grf_prop.grffile->grfid, CBID_INDUSTRY_DECIDE_COLOUR, res);
+			if (GB(res, 4, 11) != 0) ErrorUnknownCallbackResult(indspec->grf_prop.grfid, CBID_INDUSTRY_DECIDE_COLOUR, res);
 			i->random_colour = static_cast<Colours>(GB(res, 0, 4));
 		}
 	}
@@ -1865,7 +1865,7 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 			uint16_t res = GetIndustryCallback(CBID_INDUSTRY_INPUT_CARGO_TYPES, j, 0, i, type, INVALID_TILE);
 			if (res == CALLBACK_FAILED || GB(res, 0, 8) == UINT8_MAX) break;
 			if (indspec->grf_prop.grffile->grf_version >= 8 && res >= 0x100) {
-				ErrorUnknownCallbackResult(indspec->grf_prop.grffile->grfid, CBID_INDUSTRY_INPUT_CARGO_TYPES, res);
+				ErrorUnknownCallbackResult(indspec->grf_prop.grfid, CBID_INDUSTRY_INPUT_CARGO_TYPES, res);
 				break;
 			}
 			CargoID cargo = GetCargoTranslation(GB(res, 0, 8), indspec->grf_prop.grffile);
@@ -1881,12 +1881,12 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 			/* Verify valid cargo */
 			if (std::ranges::find(indspec->accepts_cargo, cargo) == std::end(indspec->accepts_cargo)) {
 				/* Cargo not in spec, error in NewGRF */
-				ErrorUnknownCallbackResult(indspec->grf_prop.grffile->grfid, CBID_INDUSTRY_INPUT_CARGO_TYPES, res);
+				ErrorUnknownCallbackResult(indspec->grf_prop.grfid, CBID_INDUSTRY_INPUT_CARGO_TYPES, res);
 				break;
 			}
 			if (std::any_of(std::begin(i->accepted), std::begin(i->accepted) + j, [&cargo](const auto &a) { return a.cargo == cargo; })) {
 				/* Duplicate cargo */
-				ErrorUnknownCallbackResult(indspec->grf_prop.grffile->grfid, CBID_INDUSTRY_INPUT_CARGO_TYPES, res);
+				ErrorUnknownCallbackResult(indspec->grf_prop.grfid, CBID_INDUSTRY_INPUT_CARGO_TYPES, res);
 				break;
 			}
 			Industry::AcceptedCargo &a = i->accepted.emplace_back();
@@ -1903,7 +1903,7 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 			uint16_t res = GetIndustryCallback(CBID_INDUSTRY_OUTPUT_CARGO_TYPES, j, 0, i, type, INVALID_TILE);
 			if (res == CALLBACK_FAILED || GB(res, 0, 8) == UINT8_MAX) break;
 			if (indspec->grf_prop.grffile->grf_version >= 8 && res >= 0x100) {
-				ErrorUnknownCallbackResult(indspec->grf_prop.grffile->grfid, CBID_INDUSTRY_OUTPUT_CARGO_TYPES, res);
+				ErrorUnknownCallbackResult(indspec->grf_prop.grfid, CBID_INDUSTRY_OUTPUT_CARGO_TYPES, res);
 				break;
 			}
 			CargoID cargo = GetCargoTranslation(GB(res, 0, 8), indspec->grf_prop.grffile);
@@ -1917,12 +1917,12 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 			/* Verify valid cargo */
 			if (std::ranges::find(indspec->produced_cargo, cargo) == std::end(indspec->produced_cargo)) {
 				/* Cargo not in spec, error in NewGRF */
-				ErrorUnknownCallbackResult(indspec->grf_prop.grffile->grfid, CBID_INDUSTRY_OUTPUT_CARGO_TYPES, res);
+				ErrorUnknownCallbackResult(indspec->grf_prop.grfid, CBID_INDUSTRY_OUTPUT_CARGO_TYPES, res);
 				break;
 			}
 			if (std::any_of(std::begin(i->produced), std::begin(i->produced) + j, [&cargo](const auto &p) { return p.cargo == cargo; })) {
 				/* Duplicate cargo */
-				ErrorUnknownCallbackResult(indspec->grf_prop.grffile->grfid, CBID_INDUSTRY_OUTPUT_CARGO_TYPES, res);
+				ErrorUnknownCallbackResult(indspec->grf_prop.grfid, CBID_INDUSTRY_OUTPUT_CARGO_TYPES, res);
 				break;
 			}
 			Industry::ProducedCargo &p = i->produced.emplace_back();
@@ -2812,7 +2812,7 @@ static void ChangeIndustryProduction(Industry *i, bool monthly)
 		if (res != CALLBACK_FAILED) { // failed callback means "do nothing"
 			suppress_message = HasBit(res, 7);
 			/* Get the custom message if any */
-			if (HasBit(res, 8)) str = MapGRFStringID(indspec->grf_prop.grffile->grfid, GB(GetRegister(0x100), 0, 16));
+			if (HasBit(res, 8)) str = MapGRFStringID(indspec->grf_prop.grfid, GB(GetRegister(0x100), 0, 16));
 			res = GB(res, 0, 4);
 			switch (res) {
 				default: NOT_REACHED();

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -104,12 +104,12 @@ static void GetCargoSuffix(uint cargo, CargoSuffixType cst, const Industry *ind,
 			if (GB(callback, 0, 8) == 0xFF) return;
 			if (callback < 0x400) {
 				StartTextRefStackUsage(indspec->grf_prop.grffile, 6);
-				suffix.text = GetString(GetGRFStringID(indspec->grf_prop.grffile->grfid, 0xD000 + callback));
+				suffix.text = GetString(GetGRFStringID(indspec->grf_prop.grfid, 0xD000 + callback));
 				StopTextRefStackUsage();
 				suffix.display = CSD_CARGO_AMOUNT_TEXT;
 				return;
 			}
-			ErrorUnknownCallbackResult(indspec->grf_prop.grffile->grfid, CBID_INDUSTRY_CARGO_SUFFIX, callback);
+			ErrorUnknownCallbackResult(indspec->grf_prop.grfid, CBID_INDUSTRY_CARGO_SUFFIX, callback);
 			return;
 
 		} else { // GRF version 8 or higher.
@@ -120,19 +120,19 @@ static void GetCargoSuffix(uint cargo, CargoSuffixType cst, const Industry *ind,
 			}
 			if (callback < 0x400) {
 				StartTextRefStackUsage(indspec->grf_prop.grffile, 6);
-				suffix.text = GetString(GetGRFStringID(indspec->grf_prop.grffile->grfid, 0xD000 + callback));
+				suffix.text = GetString(GetGRFStringID(indspec->grf_prop.grfid, 0xD000 + callback));
 				StopTextRefStackUsage();
 				suffix.display = CSD_CARGO_AMOUNT_TEXT;
 				return;
 			}
 			if (callback >= 0x800 && callback < 0xC00) {
 				StartTextRefStackUsage(indspec->grf_prop.grffile, 6);
-				suffix.text = GetString(GetGRFStringID(indspec->grf_prop.grffile->grfid, 0xD000 - 0x800 + callback));
+				suffix.text = GetString(GetGRFStringID(indspec->grf_prop.grfid, 0xD000 - 0x800 + callback));
 				StopTextRefStackUsage();
 				suffix.display = CSD_CARGO_TEXT;
 				return;
 			}
-			ErrorUnknownCallbackResult(indspec->grf_prop.grffile->grfid, CBID_INDUSTRY_CARGO_SUFFIX, callback);
+			ErrorUnknownCallbackResult(indspec->grf_prop.grfid, CBID_INDUSTRY_CARGO_SUFFIX, callback);
 			return;
 		}
 	}
@@ -477,7 +477,7 @@ public:
 					}
 					d = maxdim(d, strdim);
 
-					if (indsp->grf_prop.grffile != nullptr) {
+					if (indsp->grf_prop.HasGrfFile()) {
 						/* Reserve a few extra lines for text from an industry NewGRF. */
 						extra_lines_newgrf = 4;
 					}
@@ -588,9 +588,9 @@ public:
 					uint16_t callback_res = GetIndustryCallback(CBID_INDUSTRY_FUND_MORE_TEXT, 0, 0, nullptr, this->selected_type, INVALID_TILE);
 					if (callback_res != CALLBACK_FAILED && callback_res != 0x400) {
 						if (callback_res > 0x400) {
-							ErrorUnknownCallbackResult(indsp->grf_prop.grffile->grfid, CBID_INDUSTRY_FUND_MORE_TEXT, callback_res);
+							ErrorUnknownCallbackResult(indsp->grf_prop.grfid, CBID_INDUSTRY_FUND_MORE_TEXT, callback_res);
 						} else {
-							StringID str = GetGRFStringID(indsp->grf_prop.grffile->grfid, 0xD000 + callback_res);  // No. here's the new string
+							StringID str = GetGRFStringID(indsp->grf_prop.grfid, 0xD000 + callback_res);  // No. here's the new string
 							if (str != STR_UNDEFINED) {
 								StartTextRefStackUsage(indsp->grf_prop.grffile, 6);
 								DrawStringMultiLine(ir, str, TC_YELLOW);
@@ -981,9 +981,9 @@ public:
 			uint16_t callback_res = GetIndustryCallback(CBID_INDUSTRY_WINDOW_MORE_TEXT, 0, 0, i, i->type, i->location.tile);
 			if (callback_res != CALLBACK_FAILED && callback_res != 0x400) {
 				if (callback_res > 0x400) {
-					ErrorUnknownCallbackResult(ind->grf_prop.grffile->grfid, CBID_INDUSTRY_WINDOW_MORE_TEXT, callback_res);
+					ErrorUnknownCallbackResult(ind->grf_prop.grfid, CBID_INDUSTRY_WINDOW_MORE_TEXT, callback_res);
 				} else {
-					StringID message = GetGRFStringID(ind->grf_prop.grffile->grfid, 0xD000 + callback_res);
+					StringID message = GetGRFStringID(ind->grf_prop.grfid, 0xD000 + callback_res);
 					if (message != STR_NULL && message != STR_UNDEFINED) {
 						ir.top += WidgetDimensions::scaled.vsep_wide;
 

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -653,8 +653,8 @@ static Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t inte
 
 		/* Reserve the engine slot */
 		if (!static_access) {
-			EngineIDMapping *eid = _engine_mngr.data() + engine;
-			eid->grfid           = scope_grfid; // Note: this is INVALID_GRFID if dynamic_engines is disabled, so no reservation
+			EngineIDMapping &eid = _engine_mngr.mappings[engine];
+			eid.grfid = scope_grfid; // Note: this is INVALID_GRFID if dynamic_engines is disabled, so no reservation
 		}
 
 		return e;
@@ -675,13 +675,13 @@ static Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t inte
 	e->grf_prop.grffile = file;
 
 	/* Reserve the engine slot */
-	assert(_engine_mngr.size() == e->index);
-	_engine_mngr.push_back({
+	assert(_engine_mngr.mappings.size() == e->index);
+	_engine_mngr.mappings.emplace_back(
 			scope_grfid, // Note: this is INVALID_GRFID if dynamic_engines is disabled, so no reservation
 			internal_id,
 			type,
 			std::min<uint8_t>(internal_id, _engine_counts[type]) // substitute_id == _engine_counts[subtype] means "no substitute"
-	});
+	);
 
 	if (engine_pool_size != Engine::GetPoolSize()) {
 		/* Resize temporary engine data ... */
@@ -9214,7 +9214,7 @@ static void FinaliseEngineArray()
 {
 	for (Engine *e : Engine::Iterate()) {
 		if (e->GetGRF() == nullptr) {
-			const EngineIDMapping &eid = _engine_mngr[e->index];
+			const EngineIDMapping &eid = _engine_mngr.mappings[e->index];
 			if (eid.grfid != INVALID_GRFID || eid.internal_id != eid.substitute_id) {
 				e->info.string_id = STR_NEWGRF_INVALID_ENGINE;
 			}
@@ -9266,7 +9266,7 @@ static void FinaliseEngineArray()
 			/* Engine looped back on itself, so clear the variant. */
 			e->info.variant_id = INVALID_ENGINE;
 
-			GrfMsg(1, "FinaliseEngineArray: Variant of engine {:x} in '{}' loops back on itself", _engine_mngr[e->index].internal_id, e->GetGRF()->filename);
+			GrfMsg(1, "FinaliseEngineArray: Variant of engine {:x} in '{}' loops back on itself", _engine_mngr.mappings[e->index].internal_id, e->GetGRF()->filename);
 			break;
 		}
 

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -132,7 +132,7 @@ void BindAirportSpecs()
 
 void AirportOverrideManager::SetEntitySpec(AirportSpec *as)
 {
-	uint8_t airport_id = this->AddEntityID(as->grf_prop.local_id, as->grf_prop.grffile->grfid, as->grf_prop.subst_id);
+	uint8_t airport_id = this->AddEntityID(as->grf_prop.local_id, as->grf_prop.grfid, as->grf_prop.subst_id);
 
 	if (airport_id == this->invalid_id) {
 		GrfMsg(1, "Airport.SetEntitySpec: Too many airports allocated. Ignoring.");
@@ -145,7 +145,7 @@ void AirportOverrideManager::SetEntitySpec(AirportSpec *as)
 	for (int i = 0; i < this->max_offset; i++) {
 		AirportSpec *overridden_as = AirportSpec::GetWithoutOverride(i);
 
-		if (this->entity_overrides[i] != as->grf_prop.local_id || this->grfid_overrides[i] != as->grf_prop.grffile->grfid) continue;
+		if (this->entity_overrides[i] != as->grf_prop.local_id || this->grfid_overrides[i] != as->grf_prop.grfid) continue;
 
 		overridden_as->grf_prop.override = airport_id;
 		overridden_as->enabled = false;
@@ -277,9 +277,9 @@ StringID GetAirportTextCallback(const AirportSpec *as, uint8_t layout, uint16_t 
 	uint16_t cb_res = object.ResolveCallback();
 	if (cb_res == CALLBACK_FAILED || cb_res == 0x400) return STR_UNDEFINED;
 	if (cb_res > 0x400) {
-		ErrorUnknownCallbackResult(as->grf_prop.grffile->grfid, callback, cb_res);
+		ErrorUnknownCallbackResult(as->grf_prop.grfid, callback, cb_res);
 		return STR_UNDEFINED;
 	}
 
-	return GetGRFStringID(as->grf_prop.grffile->grfid, 0xD000 + cb_res);
+	return GetGRFStringID(as->grf_prop.grfid, 0xD000 + cb_res);
 }

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -66,7 +66,7 @@ void AirportTileSpec::ResetAirportTiles()
 
 void AirportTileOverrideManager::SetEntitySpec(const AirportTileSpec *airpts)
 {
-	StationGfx airpt_id = this->AddEntityID(airpts->grf_prop.local_id, airpts->grf_prop.grffile->grfid, airpts->grf_prop.subst_id);
+	StationGfx airpt_id = this->AddEntityID(airpts->grf_prop.local_id, airpts->grf_prop.grfid, airpts->grf_prop.subst_id);
 
 	if (airpt_id == this->invalid_id) {
 		GrfMsg(1, "AirportTile.SetEntitySpec: Too many airport tiles allocated. Ignoring.");
@@ -79,7 +79,7 @@ void AirportTileOverrideManager::SetEntitySpec(const AirportTileSpec *airpts)
 	for (int i = 0; i < this->max_offset; i++) {
 		AirportTileSpec *overridden_airpts = &AirportTileSpec::tiles[i];
 
-		if (this->entity_overrides[i] != airpts->grf_prop.local_id || this->grfid_overrides[i] != airpts->grf_prop.grffile->grfid) continue;
+		if (this->entity_overrides[i] != airpts->grf_prop.local_id || this->grfid_overrides[i] != airpts->grf_prop.grfid) continue;
 
 		overridden_airpts->grf_prop.override = airpt_id;
 		overridden_airpts->enabled = false;
@@ -141,7 +141,7 @@ static uint32_t GetAirportTileIDAtOffset(TileIndex tile, const Station *st, uint
 		/* Overridden */
 		const AirportTileSpec *tile_ovr = AirportTileSpec::Get(ats->grf_prop.override);
 
-		if (tile_ovr->grf_prop.grffile->grfid == cur_grfid) {
+		if (tile_ovr->grf_prop.grfid == cur_grfid) {
 			return tile_ovr->grf_prop.local_id; // same grf file
 		} else {
 			return 0xFFFE; // not the same grf file
@@ -149,7 +149,7 @@ static uint32_t GetAirportTileIDAtOffset(TileIndex tile, const Station *st, uint
 	}
 	/* Not an 'old type' tile */
 	if (ats->grf_prop.spritegroup[0] != nullptr) { // tile has a spritegroup ?
-		if (ats->grf_prop.grffile->grfid == cur_grfid) { // same airport, same grf ?
+		if (ats->grf_prop.grfid == cur_grfid) { // same airport, same grf ?
 			return ats->grf_prop.local_id;
 		} else {
 			return 0xFFFE; // Defined in another grf file

--- a/src/newgrf_animation_base.h
+++ b/src/newgrf_animation_base.h
@@ -58,7 +58,7 @@ struct AnimationBase {
 		if (HasBit(spec->callback_mask, Tbase::cbm_animation_speed)) {
 			uint16_t callback = GetCallback(Tbase::cb_animation_speed, 0, 0, spec, obj, tile, extra_data);
 			if (callback != CALLBACK_FAILED) {
-				if (callback >= 0x100 && spec->grf_prop.grffile->grf_version >= 8) ErrorUnknownCallbackResult(spec->grf_prop.grffile->grfid, Tbase::cb_animation_speed, callback);
+				if (callback >= 0x100 && spec->grf_prop.grffile->grf_version >= 8) ErrorUnknownCallbackResult(spec->grf_prop.grfid, Tbase::cb_animation_speed, callback);
 				animation_speed = Clamp(callback & 0xFF, 0, 16);
 			}
 		}

--- a/src/newgrf_class_func.h
+++ b/src/newgrf_class_func.h
@@ -131,7 +131,7 @@ const Tspec *NewGRFClass<Tspec, Tindex, Tmax>::GetByGrf(uint32_t grfid, uint16_t
 		for (const auto &spec : cls.spec) {
 			if (spec == nullptr) continue;
 			if (spec->grf_prop.local_id != local_id) continue;
-			if ((spec->grf_prop.grffile == nullptr ? 0 : spec->grf_prop.grffile->grfid) == grfid) return spec;
+			if (spec->grf_prop.grfid == grfid) return spec;
 		}
 	}
 

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -158,7 +158,7 @@ uint16_t OverrideManagerBase::GetSubstituteID(uint16_t entity_id) const
  */
 void HouseOverrideManager::SetEntitySpec(const HouseSpec *hs)
 {
-	HouseID house_id = this->AddEntityID(hs->grf_prop.local_id, hs->grf_prop.grffile->grfid, hs->grf_prop.subst_id);
+	HouseID house_id = this->AddEntityID(hs->grf_prop.local_id, hs->grf_prop.grfid, hs->grf_prop.subst_id);
 
 	if (house_id == this->invalid_id) {
 		GrfMsg(1, "House.SetEntitySpec: Too many houses allocated. Ignoring.");
@@ -175,7 +175,7 @@ void HouseOverrideManager::SetEntitySpec(const HouseSpec *hs)
 	for (int i = 0; i < this->max_offset; i++) {
 		HouseSpec *overridden_hs = HouseSpec::Get(i);
 
-		if (this->entity_overrides[i] != hs->grf_prop.local_id || this->grfid_overrides[i] != hs->grf_prop.grffile->grfid) continue;
+		if (this->entity_overrides[i] != hs->grf_prop.local_id || this->grfid_overrides[i] != hs->grf_prop.grfid) continue;
 
 		overridden_hs->grf_prop.override = house_id;
 		this->entity_overrides[i] = this->invalid_id;
@@ -222,7 +222,7 @@ uint16_t IndustryOverrideManager::AddEntityID(uint16_t grf_local_id, uint32_t gr
 		/* This industry must be one that is not available(enabled), mostly because of climate.
 		 * And it must not already be used by a grf (grffile == nullptr).
 		 * So reserve this slot here, as it is the chosen one */
-		if (!inds->enabled && inds->grf_prop.grffile == nullptr) {
+		if (!inds->enabled && !inds->grf_prop.HasGrfFile()) {
 			EntityIDMapping *map = &this->mappings[id];
 
 			if (map->entity_id == 0 && map->grfid == 0) {
@@ -247,14 +247,14 @@ uint16_t IndustryOverrideManager::AddEntityID(uint16_t grf_local_id, uint32_t gr
 void IndustryOverrideManager::SetEntitySpec(IndustrySpec *inds)
 {
 	/* First step : We need to find if this industry is already specified in the savegame data. */
-	IndustryType ind_id = this->GetID(inds->grf_prop.local_id, inds->grf_prop.grffile->grfid);
+	IndustryType ind_id = this->GetID(inds->grf_prop.local_id, inds->grf_prop.grfid);
 
 	if (ind_id == this->invalid_id) {
 		/* Not found.
 		 * Or it has already been overridden, so you've lost your place.
 		 * Or it is a simple substitute.
 		 * We need to find a free available slot */
-		ind_id = this->AddEntityID(inds->grf_prop.local_id, inds->grf_prop.grffile->grfid, inds->grf_prop.subst_id);
+		ind_id = this->AddEntityID(inds->grf_prop.local_id, inds->grf_prop.grfid, inds->grf_prop.subst_id);
 		inds->grf_prop.override = this->invalid_id;  // make sure it will not be detected as overridden
 	}
 
@@ -271,7 +271,7 @@ void IndustryOverrideManager::SetEntitySpec(IndustrySpec *inds)
 
 void IndustryTileOverrideManager::SetEntitySpec(const IndustryTileSpec *its)
 {
-	IndustryGfx indt_id = this->AddEntityID(its->grf_prop.local_id, its->grf_prop.grffile->grfid, its->grf_prop.subst_id);
+	IndustryGfx indt_id = this->AddEntityID(its->grf_prop.local_id, its->grf_prop.grfid, its->grf_prop.subst_id);
 
 	if (indt_id == this->invalid_id) {
 		GrfMsg(1, "IndustryTile.SetEntitySpec: Too many industry tiles allocated. Ignoring.");
@@ -284,7 +284,7 @@ void IndustryTileOverrideManager::SetEntitySpec(const IndustryTileSpec *its)
 	for (int i = 0; i < this->max_offset; i++) {
 		IndustryTileSpec *overridden_its = &_industry_tile_specs[i];
 
-		if (this->entity_overrides[i] != its->grf_prop.local_id || this->grfid_overrides[i] != its->grf_prop.grffile->grfid) continue;
+		if (this->entity_overrides[i] != its->grf_prop.local_id || this->grfid_overrides[i] != its->grf_prop.grfid) continue;
 
 		overridden_its->grf_prop.override = indt_id;
 		overridden_its->enabled = false;
@@ -302,14 +302,14 @@ void IndustryTileOverrideManager::SetEntitySpec(const IndustryTileSpec *its)
 void ObjectOverrideManager::SetEntitySpec(ObjectSpec *spec)
 {
 	/* First step : We need to find if this object is already specified in the savegame data. */
-	ObjectType type = this->GetID(spec->grf_prop.local_id, spec->grf_prop.grffile->grfid);
+	ObjectType type = this->GetID(spec->grf_prop.local_id, spec->grf_prop.grfid);
 
 	if (type == this->invalid_id) {
 		/* Not found.
 		 * Or it has already been overridden, so you've lost your place.
 		 * Or it is a simple substitute.
 		 * We need to find a free available slot */
-		type = this->AddEntityID(spec->grf_prop.local_id, spec->grf_prop.grffile->grfid, OBJECT_TRANSMITTER);
+		type = this->AddEntityID(spec->grf_prop.local_id, spec->grf_prop.grfid, OBJECT_TRANSMITTER);
 	}
 
 	if (type == this->invalid_id) {

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -309,8 +309,15 @@ bool Convert8bitBooleanCallback(const struct GRFFile *grffile, uint16_t cbid, ui
 template <size_t Tcnt>
 struct GRFFilePropsBase {
 	uint16_t local_id = 0; ///< id defined by the grf file for this entity
+	uint32_t grfid = 0; ///< grfid that introduced this entity.
 	const struct GRFFile *grffile = nullptr; ///< grf file that introduced this entity
 	std::array<const struct SpriteGroup *, Tcnt> spritegroup{}; ///< pointers to the different sprites of the entity
+
+	/**
+	 * Test if this entity was introduced by NewGRF.
+	 * @returns true iff the grfid property is set.
+	 */
+	inline bool HasGrfFile() const { return this->grffile != nullptr; }
 };
 
 /** Data related to the handling of grf files. */

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1311,8 +1311,8 @@ void AlterVehicleListOrder(EngineID engine, uint target)
  */
 static bool EnginePreSort(const EngineID &a, const EngineID &b)
 {
-	const EngineIDMapping &id_a = _engine_mngr.at(a);
-	const EngineIDMapping &id_b = _engine_mngr.at(b);
+	const EngineIDMapping &id_a = _engine_mngr.mappings.at(a);
+	const EngineIDMapping &id_b = _engine_mngr.mappings.at(b);
 
 	/* 1. Sort by engine type */
 	if (id_a.type != id_b.type) return (int)id_a.type < (int)id_b.type;
@@ -1341,10 +1341,10 @@ void CommitVehicleListOrderChanges()
 		EngineID source = it.engine;
 		uint local_target = it.target;
 
-		const EngineIDMapping *id_source = _engine_mngr.data() + source;
-		if (id_source->internal_id == local_target) continue;
+		const EngineIDMapping &id_source = _engine_mngr.mappings[source];
+		if (id_source.internal_id == local_target) continue;
 
-		EngineID target = _engine_mngr.GetID(id_source->type, local_target, id_source->grfid);
+		EngineID target = _engine_mngr.GetID(id_source.type, local_target, id_source.grfid);
 		if (target == INVALID_ENGINE) continue;
 
 		int source_index = find_index(ordering, source);

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -71,6 +71,7 @@ void SetCustomEngineSprites(EngineID engine, uint8_t cargo, const SpriteGroup *g
 void SetEngineGRF(EngineID engine, const GRFFile *file)
 {
 	Engine *e = Engine::Get(engine);
+	e->grf_prop.grfid = file->grfid;
 	e->grf_prop.grffile = file;
 }
 

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1311,17 +1311,17 @@ void AlterVehicleListOrder(EngineID engine, uint target)
  */
 static bool EnginePreSort(const EngineID &a, const EngineID &b)
 {
-	const EngineIDMapping &id_a = _engine_mngr.mappings.at(a);
-	const EngineIDMapping &id_b = _engine_mngr.mappings.at(b);
+	const Engine &engine_a = *Engine::Get(a);
+	const Engine &engine_b = *Engine::Get(b);
 
 	/* 1. Sort by engine type */
-	if (id_a.type != id_b.type) return (int)id_a.type < (int)id_b.type;
+	if (engine_a.type != engine_b.type) return static_cast<int>(engine_a.type) < static_cast<int>(engine_b.type);
 
 	/* 2. Sort by scope-GRFID */
-	if (id_a.grfid != id_b.grfid) return id_a.grfid < id_b.grfid;
+	if (engine_a.grf_prop.grfid != engine_b.grf_prop.grfid) return engine_a.grf_prop.grfid < engine_b.grf_prop.grfid;
 
 	/* 3. Sort by local ID */
-	return (int)id_a.internal_id < (int)id_b.internal_id;
+	return static_cast<int>(engine_a.grf_prop.local_id) < static_cast<int>(engine_b.grf_prop.local_id);
 }
 
 /**
@@ -1341,10 +1341,10 @@ void CommitVehicleListOrderChanges()
 		EngineID source = it.engine;
 		uint local_target = it.target;
 
-		const EngineIDMapping &id_source = _engine_mngr.mappings[source];
-		if (id_source.internal_id == local_target) continue;
+		Engine *engine_source = Engine::Get(source);
+		if (engine_source->grf_prop.local_id == local_target) continue;
 
-		EngineID target = _engine_mngr.GetID(id_source.type, local_target, id_source.grfid);
+		EngineID target = _engine_mngr.GetID(engine_source->type, local_target, engine_source->grf_prop.grfid);
 		if (target == INVALID_ENGINE) continue;
 
 		int source_index = find_index(ordering, source);

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -273,14 +273,14 @@ static bool SearchNearbyHouseID(TileIndex tile, void *user_data)
 	if (IsTileType(tile, MP_HOUSE)) {
 		HouseID house = GetHouseType(tile); // tile been examined
 		const HouseSpec *hs = HouseSpec::Get(house);
-		if (hs->grf_prop.grffile != nullptr) { // must be one from a grf file
+		if (hs->grf_prop.HasGrfFile()) { // must be one from a grf file
 			SearchNearbyHouseData *nbhd = (SearchNearbyHouseData *)user_data;
 
 			TileIndex north_tile = tile + GetHouseNorthPart(house); // modifies 'house'!
 			if (north_tile == nbhd->north_tile) return false; // Always ignore origin house
 
 			return hs->grf_prop.local_id == nbhd->hs->grf_prop.local_id &&  // same local id as the one requested
-				hs->grf_prop.grffile->grfid == nbhd->hs->grf_prop.grffile->grfid;  // from the same grf
+				hs->grf_prop.grfid == nbhd->hs->grf_prop.grfid;  // from the same grf
 		}
 	}
 	return false;
@@ -297,14 +297,14 @@ static bool SearchNearbyHouseClass(TileIndex tile, void *user_data)
 	if (IsTileType(tile, MP_HOUSE)) {
 		HouseID house = GetHouseType(tile); // tile been examined
 		const HouseSpec *hs = HouseSpec::Get(house);
-		if (hs->grf_prop.grffile != nullptr) { // must be one from a grf file
+		if (hs->grf_prop.HasGrfFile()) { // must be one from a grf file
 			SearchNearbyHouseData *nbhd = (SearchNearbyHouseData *)user_data;
 
 			TileIndex north_tile = tile + GetHouseNorthPart(house); // modifies 'house'!
 			if (north_tile == nbhd->north_tile) return false; // Always ignore origin house
 
 			return hs->class_id == nbhd->hs->class_id &&  // same classid as the one requested
-				hs->grf_prop.grffile->grfid == nbhd->hs->grf_prop.grffile->grfid;  // from the same grf
+				hs->grf_prop.grfid == nbhd->hs->grf_prop.grfid;  // from the same grf
 		}
 	}
 	return false;
@@ -321,13 +321,13 @@ static bool SearchNearbyHouseGRFID(TileIndex tile, void *user_data)
 	if (IsTileType(tile, MP_HOUSE)) {
 		HouseID house = GetHouseType(tile); // tile been examined
 		const HouseSpec *hs = HouseSpec::Get(house);
-		if (hs->grf_prop.grffile != nullptr) { // must be one from a grf file
+		if (hs->grf_prop.HasGrfFile()) { // must be one from a grf file
 			SearchNearbyHouseData *nbhd = (SearchNearbyHouseData *)user_data;
 
 			TileIndex north_tile = tile + GetHouseNorthPart(house); // modifies 'house'!
 			if (north_tile == nbhd->north_tile) return false; // Always ignore origin house
 
-			return hs->grf_prop.grffile->grfid == nbhd->hs->grf_prop.grffile->grfid;  // from the same grf
+			return hs->grf_prop.grfid == nbhd->hs->grf_prop.grfid;  // from the same grf
 		}
 	}
 	return false;
@@ -429,9 +429,9 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex tile, Ho
 		/* Building counts for new houses with id = parameter. */
 		case 0x61: {
 			const HouseSpec *hs = HouseSpec::Get(this->house_id);
-			if (hs->grf_prop.grffile == nullptr) return 0;
+			if (!hs->grf_prop.HasGrfFile()) return 0;
 
-			HouseID new_house = _house_mngr.GetID(parameter, hs->grf_prop.grffile->grfid);
+			HouseID new_house = _house_mngr.GetID(parameter, hs->grf_prop.grfid);
 			return new_house == INVALID_HOUSE_ID ? 0 : GetNumHouses(new_house, this->town);
 		}
 

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -71,7 +71,7 @@ uint32_t GetIndustryIDAtOffset(TileIndex tile, const Industry *i, uint32_t cur_g
 		/* Overridden */
 		const IndustryTileSpec *tile_ovr = GetIndustryTileSpec(indtsp->grf_prop.override);
 
-		if (tile_ovr->grf_prop.grffile->grfid == cur_grfid) {
+		if (tile_ovr->grf_prop.grfid == cur_grfid) {
 			return tile_ovr->grf_prop.local_id; // same grf file
 		} else {
 			return 0xFFFE; // not the same grf file
@@ -79,7 +79,7 @@ uint32_t GetIndustryIDAtOffset(TileIndex tile, const Industry *i, uint32_t cur_g
 	}
 	/* Not an 'old type' tile */
 	if (indtsp->grf_prop.spritegroup[0] != nullptr) { // tile has a spritegroup ?
-		if (indtsp->grf_prop.grffile->grfid == cur_grfid) { // same industry, same grf ?
+		if (indtsp->grf_prop.grfid == cur_grfid) { // same industry, same grf ?
 			return indtsp->grf_prop.local_id;
 		} else {
 			return 0xFFFE; // Defined in another grf file
@@ -126,7 +126,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t param_setID, uint8_
 			break;
 
 		case 0xFFFFFFFF: // current grf
-			GrfID = GetIndustrySpec(current->type)->grf_prop.grffile->grfid;
+			GrfID = GetIndustrySpec(current->type)->grf_prop.grfid;
 			[[fallthrough]];
 
 		default: // use the grfid specified in register 100h
@@ -284,7 +284,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t param_setID, uint8_
 		/* Distance of nearest industry of given type */
 		case 0x64: {
 			if (this->tile == INVALID_TILE) break;
-			IndustryType type = MapNewGRFIndustryType(parameter, indspec->grf_prop.grffile->grfid);
+			IndustryType type = MapNewGRFIndustryType(parameter, indspec->grf_prop.grfid);
 			if (type >= NUM_INDUSTRYTYPES) return UINT32_MAX;
 			return GetClosestIndustry(this->tile, type, this->industry);
 		}
@@ -443,9 +443,8 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t param_setID, uint8_
 
 		/* Create storage on first modification. */
 		const IndustrySpec *indsp = GetIndustrySpec(this->industry->type);
-		uint32_t grfid = (indsp->grf_prop.grffile != nullptr) ? indsp->grf_prop.grffile->grfid : 0;
 		assert(PersistentStorage::CanAllocateItem());
-		this->industry->psa = new PersistentStorage(grfid, GSF_INDUSTRIES, this->industry->location.tile);
+		this->industry->psa = new PersistentStorage(indsp->grf_prop.grfid, GSF_INDUSTRIES, this->industry->location.tile);
 	}
 
 	this->industry->psa->StoreValue(pos, value);
@@ -584,7 +583,7 @@ uint32_t GetIndustryProbabilityCallback(IndustryType type, IndustryAvailabilityC
 				if (res < 0x100) {
 					default_prob = res;
 				} else if (res > 0x100) {
-					ErrorUnknownCallbackResult(indspec->grf_prop.grffile->grfid, CBID_INDUSTRY_PROBABILITY, res);
+					ErrorUnknownCallbackResult(indspec->grf_prop.grfid, CBID_INDUSTRY_PROBABILITY, res);
 				}
 			}
 		}

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -173,11 +173,11 @@ static uint32_t GetObjectIDAtOffset(TileIndex tile, uint32_t cur_grfid)
 	const ObjectSpec *spec = ObjectSpec::Get(o->type);
 
 	/* Default objects have no associated NewGRF file */
-	if (spec->grf_prop.grffile == nullptr) {
+	if (!spec->grf_prop.HasGrfFile()) {
 		return 0xFFFE; // Defined in another grf file
 	}
 
-	if (spec->grf_prop.grffile->grfid == cur_grfid) { // same object, same grf ?
+	if (spec->grf_prop.grfid == cur_grfid) { // same object, same grf ?
 		return spec->grf_prop.local_id | o->view << 16;
 	}
 

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -570,7 +570,7 @@ int AllocateSpecToRoadStop(const RoadStopSpec *statspec, BaseStation *st, bool e
 	if (exec) {
 		if (i >= st->roadstop_speclist.size()) st->roadstop_speclist.resize(i + 1);
 		st->roadstop_speclist[i].spec     = statspec;
-		st->roadstop_speclist[i].grfid    = statspec->grf_prop.grffile->grfid;
+		st->roadstop_speclist[i].grfid    = statspec->grf_prop.grfid;
 		st->roadstop_speclist[i].localidx = statspec->grf_prop.local_id;
 
 		RoadStopUpdateCachedTriggers(st);

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -708,7 +708,7 @@ int AllocateSpecToStation(const StationSpec *statspec, BaseStation *st, bool exe
 	if (exec) {
 		if (i >= st->speclist.size()) st->speclist.resize(i + 1);
 		st->speclist[i].spec     = statspec;
-		st->speclist[i].grfid    = statspec->grf_prop.grffile->grfid;
+		st->speclist[i].grfid    = statspec->grf_prop.grfid;
 		st->speclist[i].localidx = statspec->grf_prop.local_id;
 
 		StationUpdateCachedTriggers(st);

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -112,7 +112,7 @@ void BuildObject(ObjectType type, TileIndex tile, CompanyID owner, Town *town, u
 	if (HasBit(spec->callback_mask, CBM_OBJ_COLOUR)) {
 		uint16_t res = GetObjectCallback(CBID_OBJECT_COLOUR, o->colour, 0, spec, o, tile);
 		if (res != CALLBACK_FAILED) {
-			if (res >= 0x100) ErrorUnknownCallbackResult(spec->grf_prop.grffile->grfid, CBID_OBJECT_COLOUR, res);
+			if (res >= 0x100) ErrorUnknownCallbackResult(spec->grf_prop.grfid, CBID_OBJECT_COLOUR, res);
 			o->colour = GB(res, 0, 8);
 		}
 	}
@@ -665,8 +665,8 @@ static void GetTileDesc_Object(TileIndex tile, TileDesc *td)
 	td->owner[0] = GetTileOwner(tile);
 	td->build_date = Object::GetByTile(tile)->build_date;
 
-	if (spec->grf_prop.grffile != nullptr) {
-		td->grf = GetGRFConfig(spec->grf_prop.grffile->grfid)->GetName();
+	if (spec->grf_prop.HasGrfFile()) {
+		td->grf = GetGRFConfig(spec->grf_prop.grfid)->GetName();
 	}
 }
 

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -86,7 +86,7 @@ public:
 	void DrawType(int x, int y, int cls_id, int id) const override
 	{
 		const auto *spec = this->GetSpec(cls_id, id);
-		if (spec->grf_prop.grffile == nullptr) {
+		if (!spec->grf_prop.HasGrfFile()) {
 			extern const DrawTileSprites _objects[];
 			const DrawTileSprites *dts = &_objects[spec->grf_prop.local_id];
 			DrawOrigTileSeqInGUI(x, y, dts, PAL_NONE);
@@ -207,7 +207,7 @@ public:
 					int x = (ir.Width()  - ScaleSpriteTrad(PREVIEW_WIDTH)) / 2 + ScaleSpriteTrad(PREVIEW_LEFT);
 					int y = (ir.Height() + ScaleSpriteTrad(PREVIEW_HEIGHT)) / 2 - ScaleSpriteTrad(PREVIEW_BOTTOM);
 
-					if (spec->grf_prop.grffile == nullptr) {
+					if (!spec->grf_prop.HasGrfFile()) {
 						extern const DrawTileSprites _objects[];
 						const DrawTileSprites *dts = &_objects[spec->grf_prop.local_id];
 						DrawOrigTileSeqInGUI(x, y, dts, PAL_NONE);
@@ -228,9 +228,9 @@ public:
 					uint16_t callback_res = GetObjectCallback(CBID_OBJECT_FUND_MORE_TEXT, 0, 0, spec, nullptr, INVALID_TILE, _object_gui.sel_view);
 					if (callback_res != CALLBACK_FAILED && callback_res != 0x400) {
 						if (callback_res > 0x400) {
-							ErrorUnknownCallbackResult(spec->grf_prop.grffile->grfid, CBID_OBJECT_FUND_MORE_TEXT, callback_res);
+							ErrorUnknownCallbackResult(spec->grf_prop.grfid, CBID_OBJECT_FUND_MORE_TEXT, callback_res);
 						} else {
-							StringID message = GetGRFStringID(spec->grf_prop.grffile->grfid, 0xD000 + callback_res);
+							StringID message = GetGRFStringID(spec->grf_prop.grfid, 0xD000 + callback_res);
 							if (message != STR_NULL && message != STR_UNDEFINED) {
 								StartTextRefStackUsage(spec->grf_prop.grffile, 6);
 								/* Use all the available space left from where we stand up to the

--- a/src/picker_gui.h
+++ b/src/picker_gui.h
@@ -113,7 +113,7 @@ public:
 	PickerItem GetPickerItem(const typename T::spec_type *spec, int cls_id = -1, int id = -1) const
 	{
 		if (spec == nullptr) return {0, 0, cls_id, id};
-		return {spec->grf_prop.grffile == nullptr ? 0 : spec->grf_prop.grffile->grfid, spec->grf_prop.local_id, spec->class_index, spec->index};
+		return {spec->grf_prop.grfid, spec->grf_prop.local_id, spec->class_index, spec->index};
 	}
 
 	PickerItem GetPickerItem(int cls_id, int id) const override

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -190,7 +190,7 @@ struct EIDSChunkHandler : ChunkHandler {
 		SlTableHeader(_engine_id_mapping_desc);
 
 		uint index = 0;
-		for (EngineIDMapping &eid : _engine_mngr) {
+		for (EngineIDMapping &eid : _engine_mngr.mappings) {
 			SlSetArrayIndex(index);
 			SlObject(&eid, _engine_id_mapping_desc);
 			index++;
@@ -201,10 +201,10 @@ struct EIDSChunkHandler : ChunkHandler {
 	{
 		const std::vector<SaveLoad> slt = SlCompatTableHeader(_engine_id_mapping_desc, _engine_id_mapping_sl_compat);
 
-		_engine_mngr.clear();
+		_engine_mngr.mappings.clear();
 
 		while (SlIterateArray() != -1) {
-			EngineIDMapping *eid = &_engine_mngr.emplace_back();
+			EngineIDMapping *eid = &_engine_mngr.mappings.emplace_back();
 			SlObject(eid, slt);
 		}
 	}

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -87,7 +87,7 @@ void MoveWaypointsToBaseStations()
 		 * from the GRF ID / station index. */
 		for (OldWaypoint &wp : _old_waypoints) {
 			const auto specs = StationClass::Get(STAT_CLASS_WAYP)->Specs();
-			auto found = std::ranges::find_if(specs, [&wp](const StationSpec *spec) { return spec != nullptr && spec->grf_prop.grffile->grfid == wp.grfid && spec->grf_prop.local_id == wp.localidx; });
+			auto found = std::ranges::find_if(specs, [&wp](const StationSpec *spec) { return spec != nullptr && spec->grf_prop.grfid == wp.grfid && spec->grf_prop.local_id == wp.localidx; });
 			if (found != std::end(specs)) wp.spec = *found;
 		}
 	}

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1479,7 +1479,7 @@ CommandCost CmdBuildRailStation(DoCommandFlag flags, TileIndex tile_org, RailTyp
 						if (callback <= UINT8_MAX) {
 							SetStationGfx(tile, (callback & ~1) + axis);
 						} else {
-							ErrorUnknownCallbackResult(statspec->grf_prop.grffile->grfid, CBID_STATION_BUILD_TILE_LAYOUT, callback);
+							ErrorUnknownCallbackResult(statspec->grf_prop.grfid, CBID_STATION_BUILD_TILE_LAYOUT, callback);
 						}
 					}
 
@@ -3503,8 +3503,8 @@ void FillTileDescRailStation(TileIndex tile, TileDesc *td)
 		td->station_class = StationClass::Get(spec->class_index)->name;
 		td->station_name  = spec->name;
 
-		if (spec->grf_prop.grffile != nullptr) {
-			const GRFConfig *gc = GetGRFConfig(spec->grf_prop.grffile->grfid);
+		if (spec->grf_prop.HasGrfFile()) {
+			const GRFConfig *gc = GetGRFConfig(spec->grf_prop.grfid);
 			td->grf = gc->GetName();
 		}
 	}
@@ -3523,11 +3523,11 @@ void FillTileDescAirport(TileIndex tile, TileDesc *td)
 	const AirportTileSpec *ats = AirportTileSpec::GetByTile(tile);
 	td->airport_tile_name = ats->name;
 
-	if (as->grf_prop.grffile != nullptr) {
-		const GRFConfig *gc = GetGRFConfig(as->grf_prop.grffile->grfid);
+	if (as->grf_prop.HasGrfFile()) {
+		const GRFConfig *gc = GetGRFConfig(as->grf_prop.grfid);
 		td->grf = gc->GetName();
-	} else if (ats->grf_prop.grffile != nullptr) {
-		const GRFConfig *gc = GetGRFConfig(ats->grf_prop.grffile->grfid);
+	} else if (ats->grf_prop.HasGrfFile()) {
+		const GRFConfig *gc = GetGRFConfig(ats->grf_prop.grfid);
 		td->grf = gc->GetName();
 	}
 }
@@ -3555,7 +3555,7 @@ static void GetTileDesc_Station(TileIndex tile, TileDesc *td)
 			const IndustrySpec *is = GetIndustrySpec(i->type);
 			td->owner[0] = i->owner;
 			str = is->name;
-			if (is->grf_prop.grffile != nullptr) td->grf = GetGRFConfig(is->grf_prop.grffile->grfid)->GetName();
+			if (is->grf_prop.HasGrfFile()) td->grf = GetGRFConfig(is->grf_prop.grfid)->GetName();
 			break;
 		}
 		case STATION_DOCK:     str = STR_LAI_STATION_DESCRIPTION_SHIP_DOCK; break;

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -141,7 +141,7 @@ class NIHStation : public NIHelper {
 	const void *GetInstance(uint ) const override        { return nullptr; }
 	const void *GetSpec(uint index) const override       { return GetStationSpec(index); }
 	void SetStringParameters(uint index) const override  { this->SetObjectAtStringParameters(STR_STATION_NAME, GetStationIndex(index), index); }
-	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? GetStationSpec(index)->grf_prop.grffile->grfid : 0; }
+	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? GetStationSpec(index)->grf_prop.grfid : 0; }
 
 	uint Resolve(uint index, uint var, uint param, bool &avail) const override
 	{
@@ -201,12 +201,12 @@ static const NIVariable _niv_house[] = {
 };
 
 class NIHHouse : public NIHelper {
-	bool IsInspectable(uint index) const override        { return HouseSpec::Get(GetHouseType(index))->grf_prop.grffile != nullptr; }
+	bool IsInspectable(uint index) const override        { return HouseSpec::Get(GetHouseType(index))->grf_prop.HasGrfFile(); }
 	uint GetParent(uint index) const override            { return GetInspectWindowNumber(GSF_FAKE_TOWNS, GetTownIndex(index)); }
 	const void *GetInstance(uint)const override          { return nullptr; }
 	const void *GetSpec(uint index) const override       { return HouseSpec::Get(GetHouseType(index)); }
 	void SetStringParameters(uint index) const override  { this->SetObjectAtStringParameters(STR_TOWN_NAME, GetTownIndex(index), index); }
-	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? HouseSpec::Get(GetHouseType(index))->grf_prop.grffile->grfid : 0; }
+	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? HouseSpec::Get(GetHouseType(index))->grf_prop.grfid : 0; }
 
 	uint Resolve(uint index, uint var, uint param, bool &avail) const override
 	{
@@ -251,12 +251,12 @@ static const NIVariable _niv_industrytiles[] = {
 };
 
 class NIHIndustryTile : public NIHelper {
-	bool IsInspectable(uint index) const override        { return GetIndustryTileSpec(GetIndustryGfx(index))->grf_prop.grffile != nullptr; }
+	bool IsInspectable(uint index) const override        { return GetIndustryTileSpec(GetIndustryGfx(index))->grf_prop.HasGrfFile(); }
 	uint GetParent(uint index) const override            { return GetInspectWindowNumber(GSF_INDUSTRIES, GetIndustryIndex(index)); }
 	const void *GetInstance(uint)const override          { return nullptr; }
 	const void *GetSpec(uint index) const override       { return GetIndustryTileSpec(GetIndustryGfx(index)); }
 	void SetStringParameters(uint index) const override  { this->SetObjectAtStringParameters(STR_INDUSTRY_NAME, GetIndustryIndex(index), index); }
-	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? GetIndustryTileSpec(GetIndustryGfx(index))->grf_prop.grffile->grfid : 0; }
+	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? GetIndustryTileSpec(GetIndustryGfx(index))->grf_prop.grfid : 0; }
 
 	uint Resolve(uint index, uint var, uint param, bool &avail) const override
 	{
@@ -364,12 +364,12 @@ static const NIVariable _niv_industries[] = {
 };
 
 class NIHIndustry : public NIHelper {
-	bool IsInspectable(uint index) const override        { return GetIndustrySpec(Industry::Get(index)->type)->grf_prop.grffile != nullptr; }
+	bool IsInspectable(uint index) const override        { return GetIndustrySpec(Industry::Get(index)->type)->grf_prop.HasGrfFile(); }
 	uint GetParent(uint index) const override            { return GetInspectWindowNumber(GSF_FAKE_TOWNS, Industry::Get(index)->town->index); }
 	const void *GetInstance(uint index)const override    { return Industry::Get(index); }
 	const void *GetSpec(uint index) const override       { return GetIndustrySpec(Industry::Get(index)->type); }
 	void SetStringParameters(uint index) const override  { this->SetSimpleStringParameters(STR_INDUSTRY_NAME, index); }
-	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? GetIndustrySpec(Industry::Get(index)->type)->grf_prop.grffile->grfid : 0; }
+	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? GetIndustrySpec(Industry::Get(index)->type)->grf_prop.grfid : 0; }
 
 	uint Resolve(uint index, uint var, uint param, bool &avail) const override
 	{
@@ -427,12 +427,12 @@ static const NIVariable _niv_objects[] = {
 };
 
 class NIHObject : public NIHelper {
-	bool IsInspectable(uint index) const override        { return ObjectSpec::GetByTile(index)->grf_prop.grffile != nullptr; }
+	bool IsInspectable(uint index) const override        { return ObjectSpec::GetByTile(index)->grf_prop.HasGrfFile(); }
 	uint GetParent(uint index) const override            { return GetInspectWindowNumber(GSF_FAKE_TOWNS, Object::GetByTile(index)->town->index); }
 	const void *GetInstance(uint index)const override    { return Object::GetByTile(index); }
 	const void *GetSpec(uint index) const override       { return ObjectSpec::GetByTile(index); }
 	void SetStringParameters(uint index) const override  { this->SetObjectAtStringParameters(STR_NEWGRF_INSPECT_CAPTION_OBJECT_AT_OBJECT, INVALID_STRING_ID, index); }
-	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? ObjectSpec::GetByTile(index)->grf_prop.grffile->grfid : 0; }
+	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? ObjectSpec::GetByTile(index)->grf_prop.grfid : 0; }
 
 	uint Resolve(uint index, uint var, uint param, bool &avail) const override
 	{
@@ -497,12 +497,12 @@ static const NICallback _nic_airporttiles[] = {
 };
 
 class NIHAirportTile : public NIHelper {
-	bool IsInspectable(uint index) const override        { return AirportTileSpec::Get(GetAirportGfx(index))->grf_prop.grffile != nullptr; }
+	bool IsInspectable(uint index) const override        { return AirportTileSpec::Get(GetAirportGfx(index))->grf_prop.HasGrfFile(); }
 	uint GetParent(uint index) const override            { return GetInspectWindowNumber(GSF_AIRPORTS, GetStationIndex(index)); }
 	const void *GetInstance(uint)const override          { return nullptr; }
 	const void *GetSpec(uint index) const override       { return AirportTileSpec::Get(GetAirportGfx(index)); }
 	void SetStringParameters(uint index) const override  { this->SetObjectAtStringParameters(STR_STATION_NAME, GetStationIndex(index), index); }
-	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? AirportTileSpec::Get(GetAirportGfx(index))->grf_prop.grffile->grfid : 0; }
+	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? AirportTileSpec::Get(GetAirportGfx(index))->grf_prop.grfid : 0; }
 
 	uint Resolve(uint index, uint var, uint param, bool &avail) const override
 	{
@@ -538,12 +538,12 @@ static const NIVariable _niv_airports[] = {
 };
 
 class NIHAirport : public NIHelper {
-	bool IsInspectable(uint index) const override        { return AirportSpec::Get(Station::Get(index)->airport.type)->grf_prop.grffile != nullptr; }
+	bool IsInspectable(uint index) const override        { return AirportSpec::Get(Station::Get(index)->airport.type)->grf_prop.HasGrfFile(); }
 	uint GetParent(uint index) const override            { return GetInspectWindowNumber(GSF_FAKE_TOWNS, Station::Get(index)->town->index); }
 	const void *GetInstance(uint index)const override    { return Station::Get(index); }
 	const void *GetSpec(uint index) const override       { return AirportSpec::Get(Station::Get(index)->airport.type); }
 	void SetStringParameters(uint index) const override  { this->SetObjectAtStringParameters(STR_STATION_NAME, index, Station::Get(index)->airport.tile); }
-	uint32_t GetGRFID(uint index) const override         { return (this->IsInspectable(index)) ? AirportSpec::Get(Station::Get(index)->airport.type)->grf_prop.grffile->grfid : 0; }
+	uint32_t GetGRFID(uint index) const override         { return (this->IsInspectable(index)) ? AirportSpec::Get(Station::Get(index)->airport.type)->grf_prop.grfid : 0; }
 
 	uint Resolve(uint index, uint var, uint param, bool &avail) const override
 	{
@@ -700,7 +700,7 @@ class NIHRoadStop : public NIHelper {
 	const void *GetInstance(uint)const override          { return nullptr; }
 	const void *GetSpec(uint index) const override       { return GetRoadStopSpec(index); }
 	void SetStringParameters(uint index) const override  { this->SetObjectAtStringParameters(STR_STATION_NAME, GetStationIndex(index), index); }
-	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? GetRoadStopSpec(index)->grf_prop.grffile->grfid : 0; }
+	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? GetRoadStopSpec(index)->grf_prop.grfid : 0; }
 
 	uint Resolve(uint index, uint var, uint32_t param, bool &avail) const override
 	{

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -842,9 +842,9 @@ static void GetTileDesc_Town(TileIndex tile, TileDesc *td)
 	uint16_t callback_res = GetHouseCallback(CBID_HOUSE_CUSTOM_NAME, house_completed ? 1 : 0, 0, house, Town::GetByTile(tile), tile);
 	if (callback_res != CALLBACK_FAILED && callback_res != 0x400) {
 		if (callback_res > 0x400) {
-			ErrorUnknownCallbackResult(hs->grf_prop.grffile->grfid, CBID_HOUSE_CUSTOM_NAME, callback_res);
+			ErrorUnknownCallbackResult(hs->grf_prop.grfid, CBID_HOUSE_CUSTOM_NAME, callback_res);
 		} else {
-			StringID new_name = GetGRFStringID(hs->grf_prop.grffile->grfid, 0xD000 + callback_res);
+			StringID new_name = GetGRFStringID(hs->grf_prop.grfid, 0xD000 + callback_res);
 			if (new_name != STR_NULL && new_name != STR_UNDEFINED) {
 				td->str = new_name;
 			}
@@ -856,8 +856,8 @@ static void GetTileDesc_Town(TileIndex tile, TileDesc *td)
 		td->str = STR_LAI_TOWN_INDUSTRY_DESCRIPTION_UNDER_CONSTRUCTION;
 	}
 
-	if (hs->grf_prop.grffile != nullptr) {
-		const GRFConfig *gc = GetGRFConfig(hs->grf_prop.grffile->grfid);
+	if (hs->grf_prop.HasGrfFile()) {
+		const GRFConfig *gc = GetGRFConfig(hs->grf_prop.grfid);
 		td->grf = gc->GetName();
 	}
 

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1506,8 +1506,8 @@ public:
 	PickerItem GetPickerItem(int cls_id, int id) const override
 	{
 		const auto *spec = HouseSpec::Get(id);
-		if (spec->grf_prop.grffile == nullptr) return {0, spec->Index(), cls_id, id};
-		return {spec->grf_prop.grffile->grfid, spec->grf_prop.local_id, cls_id, id};
+		if (!spec->grf_prop.HasGrfFile()) return {0, spec->Index(), cls_id, id};
+		return {spec->grf_prop.grfid, spec->grf_prop.local_id, cls_id, id};
 	}
 
 	int GetSelectedType() const override { return sel_type; }
@@ -1562,7 +1562,7 @@ public:
 				dst.insert(item);
 			} else {
 				/* Search for spec by grfid and local index. */
-				auto it = std::ranges::find_if(specs, [&item](const HouseSpec &spec) { return spec.grf_prop.grffile != nullptr && spec.grf_prop.grffile->grfid == item.grfid && spec.grf_prop.local_id == item.local_id; });
+				auto it = std::ranges::find_if(specs, [&item](const HouseSpec &spec) { return spec.grf_prop.grfid == item.grfid && spec.grf_prop.local_id == item.local_id; });
 				if (it == specs.end()) {
 					/* Not preset, hide from UI. */
 					dst.insert({item.grfid, item.local_id, -1, -1});

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -347,7 +347,7 @@ void VehicleLengthChanged(const Vehicle *u)
 {
 	/* show a warning once for each engine in whole game and once for each GRF after each game load */
 	const Engine *engine = u->GetEngine();
-	uint32_t grfid = engine->grf_prop.grffile->grfid;
+	uint32_t grfid = engine->grf_prop.grfid;
 	GRFConfig *grfconfig = GetGRFConfig(grfid);
 	if (_gamelog.GRFBugReverse(grfid, engine->grf_prop.local_id) || !HasBit(grfconfig->grf_bugs, GBUG_VEH_LENGTH)) {
 		ShowNewGrfVehicleError(u->engine_type, STR_NEWGRF_BROKEN, STR_NEWGRF_BROKEN_VEHICLE_LENGTH, GBUG_VEH_LENGTH, true);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

EngineOverrideManager records the grfid and localid of each engine, so that after save-load the correct engines are used again.

The looking up the EngineID, the complete list is traversed to find the entry by grfid and localid. As the list gets longer this takes more an more time.

An example of this Iron Horse which has approximately 10,000 engines.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Reorganise the list into 4 lists (one for each vehicle type) sorted by grfid and localid. This is built in a pre-sorted manner so that building the list itself can use a binary search instead of a linear scan. The overhead of moving the elements in the vector is tiny compared to performing a linear scan.

The original way of accessing the list with EngineID as the index is no longer possible, and now requires a linear scan to find it. Therefore as a prerequisite, some places that used to use the mapping now use the Engine's grfprops instead, which gains a grfid field.

These changes have no effect when no NewGRFs are loaded as in that case there no lookups during the game.

The performance impact depends on how often NewGRFs access information that needs the lookup, but in my testing there's an improvement of nearly 10,000x. With Iron Horse and several other vehicle NewGRFs loaded:

|       | Master | This PR |
| ----- | ------- | -------- |
| start game with iron horse | 865,156µs | 249µs | 
| per 100,000 calls | 637,596µs | 77µs |
| total over loading and 1 year | 19,765,466µs | 2,379µs |



<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

I didn't change the saveload format, so saving requires building a temporary list in EngineID order, and loading requires sorting the list into grfid/localid order (although the latter would always be needed for existing savegames.)

Loading now uses `_engine_mngr.SetID()` directly per entry, so it's automatically inserted into the correct order.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
