### PR TITLE
Fix #13022: Ensure minimum size of scrollbar slider.

### DIFF
--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -145,15 +145,17 @@ static Point HandleScrollbarHittest(const Scrollbar *sb, int top, int bottom, bo
 	top += button_size;    // top    points to just below the up-button
 	bottom -= button_size; // bottom points to top of the down-button
 
-	int height = (bottom - top);
-	int pos = sb->GetPosition();
 	int count = sb->GetCount();
 	int cap = sb->GetCapacity();
 
-	if (count != 0) top += height * pos / count;
+	if (count > cap) {
+		int height = (bottom - top);
+		int slider_height = std::max(button_size, cap * height / count);
+		height -= slider_height;
 
-	if (cap > count) cap = count;
-	if (count != 0) bottom -= (count - pos - cap) * height / count;
+		top += height * sb->GetPosition() / (count - cap);
+		bottom = top + slider_height;
+	}
 
 	Point pt;
 	if (horizontal && _current_text_dir == TD_RTL) {
@@ -216,7 +218,7 @@ static void ScrollbarClickPositioning(Window *w, NWidgetScrollbar *sb, int x, in
 			changed = sb->UpdatePosition(rtl ? -1 : 1, Scrollbar::SS_BIG);
 		} else {
 			_scrollbar_start_pos = pt.x - mi - button_size;
-			_scrollbar_size = ma - mi - button_size * 2;
+			_scrollbar_size = ma - mi - button_size * 2 - (pt.y - pt.x);
 			w->mouse_capture_widget = sb->index;
 			_cursorpos_drag_start = _cursor.pos;
 		}

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2308,8 +2308,10 @@ static void HandleScrollbarScrolling(Window *w)
 	}
 
 	/* Find the item we want to move to. SetPosition will make sure it's inside bounds. */
-	int pos = RoundDivSU((i + _scrollbar_start_pos) * sb->GetCount(), _scrollbar_size);
-	if (rtl) pos = sb->GetCount() - sb->GetCapacity() - pos;
+	int range = sb->GetCount() - sb->GetCapacity();
+
+	int pos = RoundDivSU((i + _scrollbar_start_pos) * range, _scrollbar_size);
+	if (rtl) pos = range - pos;
 	if (sb->SetPosition(pos)) w->SetDirty();
 }
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As per #13022, when there are many more items than fit in a list, the scrollbar slider scales to fit but there is no minimum size. It becomes too small to click on and use.

![image](https://github.com/user-attachments/assets/b98185e8-a01c-4ca0-913b-117bb0c4099d)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Ensure scrollbar slider is at least the same size as the buttons either end. This size was chosen as the minimum scrollbar size is already 3 times the button size.

![image](https://github.com/user-attachments/assets/098b9470-1af1-4fd7-b66d-7751be2a7476)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Clicking on the scrollbar slider on a very long list will move the position even if the cursor isn't moved, as the position will be rounded to the nearest position that meets the pixel position. This is not really a problem, and not new, it was just much harder to click on the slider before.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
