### PR TITLE
Fix #10452: Disconnection of rivers

### DIFF
--- a/src/terraform_cmd.cpp
+++ b/src/terraform_cmd.cpp
@@ -19,6 +19,7 @@
 #include "core/backup_type.hpp"
 #include "terraform_cmd.h"
 #include "landscape_cmd.h"
+#include "water.h"
 
 #include "table/strings.h"
 
@@ -295,6 +296,13 @@ std::tuple<CommandCost, Money, TileIndex> CmdTerraformLand(DoCommandFlag flags, 
 			int height = it.second;
 
 			SetTileHeight(t, (uint)height);
+		}
+
+		if (_generating_world && _settings_game.game_creation.land_generator != LG_ORIGINAL && _settings_game.game_creation.amount_of_rivers != 0) {
+			for (const auto &t : ts.dirty_tiles) {
+				/* Immediately convert ground tiles into water tiles during the river widening process. */
+				ConvertGroundTileIntoWaterTile(t);
+			}
 		}
 
 		if (c != nullptr) c->terraform_limit -= (uint32_t)ts.tile_to_new_height.size() << 16;

--- a/src/water.h
+++ b/src/water.h
@@ -29,6 +29,7 @@ void ClearNeighbourNonFloodingStates(TileIndex tile);
 void TileLoop_Water(TileIndex tile);
 bool FloodHalftile(TileIndex t);
 
+void ConvertGroundTileIntoWaterTile(TileIndex tile);
 void ConvertGroundTilesIntoWaterTiles();
 
 void DrawShipDepotSprite(int x, int y, Axis axis, DepotPart part);

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -1297,38 +1297,45 @@ void TileLoop_Water(TileIndex tile)
 	}
 }
 
+void ConvertGroundTileIntoWaterTile(TileIndex tile)
+{
+	assert(tile < Map::Size());
+
+	auto [slope, z] = GetTileSlopeZ(tile);
+	if (IsTileType(tile, MP_CLEAR) && z == 0) {
+		/* Make both water for tiles at level 0
+		 * and make shore, as that looks much better
+		 * during the generation. */
+		switch (slope) {
+			case SLOPE_FLAT:
+				MakeSea(tile);
+				break;
+
+			case SLOPE_N:
+			case SLOPE_E:
+			case SLOPE_S:
+			case SLOPE_W:
+				MakeShore(tile);
+				break;
+
+			default:
+				for (Direction dir : SetBitIterator<Direction>(_flood_from_dirs[slope & ~SLOPE_STEEP])) {
+					TileIndex dest = TileAddByDir(tile, dir);
+					Slope slope_dest = GetTileSlope(dest) & ~SLOPE_STEEP;
+					if (slope_dest == SLOPE_FLAT || IsSlopeWithOneCornerRaised(slope_dest) || IsTileType(dest, MP_VOID)) {
+						MakeShore(tile);
+						break;
+					}
+				}
+				break;
+		}
+	}
+}
+
 void ConvertGroundTilesIntoWaterTiles()
 {
 	for (TileIndex tile = 0; tile < Map::Size(); ++tile) {
-		auto [slope, z] = GetTileSlopeZ(tile);
-		if (IsTileType(tile, MP_CLEAR) && z == 0) {
-			/* Make both water for tiles at level 0
-			 * and make shore, as that looks much better
-			 * during the generation. */
-			switch (slope) {
-				case SLOPE_FLAT:
-					MakeSea(tile);
-					break;
-
-				case SLOPE_N:
-				case SLOPE_E:
-				case SLOPE_S:
-				case SLOPE_W:
-					MakeShore(tile);
-					break;
-
-				default:
-					for (Direction dir : SetBitIterator<Direction>(_flood_from_dirs[slope & ~SLOPE_STEEP])) {
-						TileIndex dest = TileAddByDir(tile, dir);
-						Slope slope_dest = GetTileSlope(dest) & ~SLOPE_STEEP;
-						if (slope_dest == SLOPE_FLAT || IsSlopeWithOneCornerRaised(slope_dest) || IsTileType(dest, MP_VOID)) {
-							MakeShore(tile);
-							break;
-						}
-					}
-					break;
-			}
-		}
+		ConvertGroundTileIntoWaterTile(tile);
 	}
 }
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
During the widening process of rivers, the terraform command can leave the river in a disconnected state.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
- Pre-mark river tiles at all begin and end points with canals to prevent the terraform command in `RiverMakeWider` from possibly disconnecting the river. They will be turned into river at a later stage in `CreateRiver`.
- Allow `BuildRiver` to return a boolean value. Should it fail to build the river in one of the flow segments, interrupt the generation of subsequent flow segments at the point of disconnect instead of continuing generating uphill.
- Immediately convert ground tiles into water tiles during the river widening process.
- Assert the river connectivity is intact by issuing a second pathfinding check.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
I'm exploiting canal tiles as a hacky solution. They prevent the terraform command from demolishing them.


<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
