### PR TITLE
Codefix: Avoid divide by 0 in div/mod type varaction2 adjusts

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -5254,6 +5254,7 @@ static void NewSpriteGroup(ByteReader &buf)
 				if (adjust.type != DSGA_TYPE_NONE) {
 					adjust.add_val    = buf.ReadVarSize(varsize);
 					adjust.divmod_val = buf.ReadVarSize(varsize);
+					if (adjust.divmod_val == 0) adjust.divmod_val = 1; // Ensure that divide by zero cannot occur
 				} else {
 					adjust.add_val    = 0;
 					adjust.divmod_val = 0;


### PR DESCRIPTION
## Motivation / Problem

A divide by zero fault can occur when DeterministicSpriteGroupAdjust::divmod_val is 0, for DSGA_TYPE_DIV and DSGA_TYPE_MOD type adjusts.
The spec doesn't explicitly say that GRFs should provide a non-zero value, though this is fairly self evident.
The game should however not crash if a zero value is provided.

The attached GRF contains an example of the above.
[pr-13123-grf.zip](https://github.com/user-attachments/files/17906652/pr-13123-grf.zip)

## Description

If a zero value is provided, just change it to one, and don't crash.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
