### PR TITLE
Codechange: Rename and return AyStarStatus instead of int

### DIFF
--- a/src/pathfinder/aystar.cpp
+++ b/src/pathfinder/aystar.cpp
@@ -89,7 +89,7 @@ void AyStar::CheckTile(AyStarNode *current, PathNode *parent)
  *  - #AYSTAR_FOUND_END_NODE : indicates we found the end. Path_found now is true, and in path is the path found.
  *  - #AYSTAR_STILL_BUSY : indicates we have done this tile, did not found the path yet, and have items left to try.
  */
-int AyStar::Loop()
+AyStarStatus AyStar::Loop()
 {
 	/* Get the best node from OpenList */
 	PathNode *current = this->nodes.PopBestOpenNode();
@@ -134,9 +134,10 @@ int AyStar::Loop()
  * @note When the algorithm is done (when the return value is not #AYSTAR_STILL_BUSY) #Clear() is called automatically.
  *       When you stop the algorithm halfway, you should call #Clear() yourself!
  */
-int AyStar::Main()
+AyStarStatus AyStar::Main()
 {
-	int r, i = 0;
+	AyStarStatus r = AYSTAR_FOUND_END_NODE;
+	int i = 0;
 	/* Loop through the OpenList
 	 *  Quit if result is no AYSTAR_STILL_BUSY or is more than loops_per_tick */
 	while ((r = this->Loop()) == AYSTAR_STILL_BUSY && (this->loops_per_tick == 0 || ++i < this->loops_per_tick)) { }

--- a/src/pathfinder/aystar.h
+++ b/src/pathfinder/aystar.h
@@ -28,7 +28,7 @@
 static const int AYSTAR_DEF_MAX_SEARCH_NODES = 10000; ///< Reference limit for #AyStar::max_search_nodes
 
 /** Return status of #AyStar methods. */
-enum AystarStatus {
+enum AyStarStatus {
 	AYSTAR_FOUND_END_NODE, ///< An end node was found.
 	AYSTAR_EMPTY_OPENLIST, ///< All items are tested, and no path has been found.
 	AYSTAR_STILL_BUSY,     ///< Some checking was done, but no path found yet, and there are still items left to try.
@@ -131,8 +131,8 @@ struct AyStar {
 	/* These will contain the methods for manipulating the AyStar. Only
 	 * Main() should be called externally */
 	void AddStartNode(AyStarNode *start_node, int g);
-	int Main();
-	int Loop();
+	AyStarStatus Main();
+	AyStarStatus Loop();
 	void CheckTile(AyStarNode *current, PathNode *parent);
 
 protected:


### PR DESCRIPTION
<!--
Commit message:
Codechange: Rename and return AyStarStatus instead of int
- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
- `AystarStatus` exists and has a lower case _s_ in _Star_!
- Functions AyStar::Main and AyStar:Loop are returning values from the enum `AystarStatus` as `int`.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
- Rename enum `AystarStatus` to `AyStarStatus`.
- Return `AyStarStatus` instead of `int` for `AyStar::Main` and `AyStar::Loop` functions.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
`AyStar::Main()` initializes with `AYSTAR_FOUND_END_NODE` instead of `0`, but `AYSTAR_FOUND_END_NODE` is `0`, so...
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
