### PR TITLE
Codechange: Replace FontMap's std::map with std::vector.

### DIFF
--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -105,8 +105,8 @@ static inline void GetLayouter(Layouter::LineCacheItem &line, std::string_view s
 			continue;
 		}
 
-		if (fontMapping.count(buff - buff_begin) == 0) {
-			fontMapping[buff - buff_begin] = f;
+		if (fontMapping.empty() || fontMapping.back().first != buff - buff_begin) {
+			fontMapping.emplace_back(buff - buff_begin, f);
 		}
 		f = Layouter::GetFont(state.fontsize, state.cur_colour);
 	}
@@ -114,8 +114,8 @@ static inline void GetLayouter(Layouter::LineCacheItem &line, std::string_view s
 	/* Better safe than sorry. */
 	*buff = '\0';
 
-	if (fontMapping.count(buff - buff_begin) == 0) {
-		fontMapping[buff - buff_begin] = f;
+	if (fontMapping.empty() || fontMapping.back().first != buff - buff_begin) {
+		fontMapping.emplace_back(buff - buff_begin, f);
 	}
 	line.layout = T::GetParagraphLayout(buff_begin, buff, fontMapping);
 	line.state_after = state;

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -81,7 +81,7 @@ public:
 };
 
 /** Mapping from index to font. The pointer is owned by FontColourMap. */
-using FontMap = std::map<int, Font *>;
+using FontMap = std::vector<std::pair<int, Font *>>;
 
 /**
  * Interface to glue fallback and normal layouter into one.

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -102,7 +102,7 @@ public:
 
 				/* Extract font information for this run. */
 				CFRange chars = CTRunGetStringRange(run);
-				auto map = fontMapping.upper_bound(chars.location);
+				auto map = std::ranges::upper_bound(fontMapping, chars.location, std::less{}, &std::pair<int, Font *>::first);
 
 				this->emplace_back(run, map->second, buff);
 			}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When layouting strings for display, each cached line item contains its own `std::map<pos, font>` from position to font style for style changes.

This is only ever created incrementally, and is never accessed by key, only iterated in order.

A `std::map` is therefore overkill for this.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Replace with `std::vector<std::pair<pos, font>>` instead. When adding to the list, only the end needs to be checked for the same position, and when iterating, nothing needs to change as it is still in order and is still std::pair.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
