### PR TITLE
Fix #9056: [interface] missing scrollbar on infrastructure window.

### DIFF
--- a/src/widgets/company_widget.h
+++ b/src/widgets/company_widget.h
@@ -170,18 +170,8 @@ enum SelectCompanyManagerFaceWidgets : WidgetID {
 /** Widgets of the #CompanyInfrastructureWindow class. */
 enum CompanyInfrastructureWidgets : WidgetID {
 	WID_CI_CAPTION,       ///< Caption of window.
-	WID_CI_RAIL_DESC,     ///< Description of rail.
-	WID_CI_RAIL_COUNT,    ///< Count of rail.
-	WID_CI_ROAD_DESC,     ///< Description of road.
-	WID_CI_ROAD_COUNT,    ///< Count of road.
-	WID_CI_TRAM_DESC,     ///< Description of tram.
-	WID_CI_TRAM_COUNT,    ///< Count of tram.
-	WID_CI_WATER_DESC,    ///< Description of water.
-	WID_CI_WATER_COUNT,   ///< Count of water.
-	WID_CI_STATION_DESC,  ///< Description of station.
-	WID_CI_STATION_COUNT, ///< Count of station.
-	WID_CI_TOTAL_DESC,    ///< Description of total.
-	WID_CI_TOTAL,         ///< Count of total.
+	WID_CI_LIST,          ///< Infrastructure list.
+	WID_CI_SCROLLBAR,     ///< Infrastructure list scroll bar.
 };
 
 /** Widgets of the #BuyCompanyWindow class. */


### PR DESCRIPTION
## Motivation / Problem
As per [#9056](https://github.com/OpenTTD/OpenTTD/issues/9056), when there are many NewGRFs for railroads, trams, and roads installed, the infrastructure list in the company infrastructure window grows out of screen. In this case the infrastructure list is partially displayed and the total maintenance cost is not visible.

![image](https://github.com/user-attachments/assets/349780db-a855-4db6-932c-c95adb2626c0)


## Description
A scrollbar has been added to the company infrastructure window and the maximum auto resize height set to a limit of only 24 lines. The player can manually resize the height to fit the list or use the scroll bar.

![image](https://github.com/user-attachments/assets/426d5a3a-1724-4d1a-9e44-7d5fbe52aba1)

## Limitations
The player has to manually resize the infrastructure window to fit the list. 
An auto expand behavior in settings would be nice to have especially for players using high resolutions where the whole list fits.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
