### PR TITLE
Fix 51bd344f10: Incorrect translation table used for older NewGRFs.

### DIFF
--- a/src/cargotype.cpp
+++ b/src/cargotype.cpp
@@ -46,14 +46,14 @@ static std::vector<CargoLabel> _default_cargo_labels;
  * This maps the original 12 cargo slots to their original label. If a climate dependent cargo is not present it will
  * map to CT_INVALID. For default cargoes this ends up as a 1:1 mapping via climate slot -> label -> cargo ID.
  */
-static std::array<CargoLabel, 12> _v7_cargo_labels;
+static std::array<CargoLabel, 12> _climate_dependent_cargo_labels;
 
 /**
  * Default cargo translation for version 8+ NewGRFs.
  * This maps the 32 "bitnum" cargo slots to their original label. If a bitnum is not present it will
  * map to CT_INVALID.
  */
-static std::array<CargoLabel, 32> _v8_cargo_labels;
+static std::array<CargoLabel, 32> _climate_independent_cargo_labels;
 
 /**
  * Set up the default cargo types for the given landscape type.
@@ -65,8 +65,8 @@ void SetupCargoForClimate(LandscapeID l)
 
 	_cargo_mask = 0;
 	_default_cargo_labels.clear();
-	_v7_cargo_labels.fill(CT_INVALID);
-	_v8_cargo_labels.fill(CT_INVALID);
+	_climate_dependent_cargo_labels.fill(CT_INVALID);
+	_climate_independent_cargo_labels.fill(CT_INVALID);
 
 	/* Copy from default cargo by label or index. */
 	auto insert = std::begin(CargoSpec::array);
@@ -94,8 +94,8 @@ void SetupCargoForClimate(LandscapeID l)
 		if (insert->IsValid()) {
 			SetBit(_cargo_mask, insert->Index());
 			_default_cargo_labels.push_back(insert->label);
-			_v7_cargo_labels[insert->Index()] = insert->label;
-			_v8_cargo_labels[insert->bitnum] = insert->label;
+			_climate_dependent_cargo_labels[insert->Index()] = insert->label;
+			_climate_independent_cargo_labels[insert->bitnum] = insert->label;
 		}
 		++insert;
 	}
@@ -107,14 +107,21 @@ void SetupCargoForClimate(LandscapeID l)
 }
 
 /**
- * Get default cargo translation table for a NewGRF, used if the NewGRF does not provide its own.
- * @param grf_version GRF version of translation table.
+ * Get default climate-dependent cargo translation table for a NewGRF, used if the NewGRF does not provide its own.
  * @return Default translation table for GRF version.
  */
-std::span<const CargoLabel> GetDefaultCargoTranslationTable(uint8_t grf_version)
+std::span<const CargoLabel> GetClimateDependentCargoTranslationTable()
 {
-	if (grf_version < 8) return _v7_cargo_labels;
-	return _v8_cargo_labels;
+	return _climate_dependent_cargo_labels;
+}
+
+/**
+ * Get default climate-independent cargo translation table for a NewGRF, used if the NewGRF does not provide its own.
+ * @return Default translation table for GRF version.
+ */
+std::span<const CargoLabel> GetClimateIndependentCargoTranslationTable()
+{
+	return _climate_independent_cargo_labels;
 }
 
 /**

--- a/src/newgrf_cargo.h
+++ b/src/newgrf_cargo.h
@@ -33,6 +33,7 @@ SpriteID GetCustomCargoSprite(const CargoSpec *cs);
 uint16_t GetCargoCallback(CallbackID callback, uint32_t param1, uint32_t param2, const CargoSpec *cs);
 CargoID GetCargoTranslation(uint8_t cargo, const GRFFile *grffile, bool usebit = false);
 
-std::span<const CargoLabel> GetDefaultCargoTranslationTable(uint8_t grf_version);
+std::span<const CargoLabel> GetClimateDependentCargoTranslationTable();
+std::span<const CargoLabel> GetClimateIndependentCargoTranslationTable();
 
 #endif /* NEWGRF_CARGO_H */


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Incorrect logic was used to select the default translation table for older GRFs in #12646.

A litany of incorrect logic.

* Selection of climate-dependent translation table for pre-v7 GRFs was incorrectly applied to pre-v8.
* Where the use of bitnum translation table was used for pre-v7 GRFs, it incorrectly used this instead of an installed translation table.
* Forcefully installing a default translation table meant that it was not actually possible to know if the translation table was installed by the NewGRF or if it is default.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

No longer force-install a translation table. We don't revert back to the old ways of different logic to select cargo, we now just pick a prebuilt default translation table instead of installing it.

Pick the correct translation depending depending on context. In most cases this is:

1) The installed table
2) If pre-v7 then the climate-dependent table.
3) Otherwise the climate-independent table.

In the one place where pre-v7 force uses the bitnums, then any installed table is ignored. This might not be correct, but it is the behaviour that was used prior to #12646.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
