### PR TITLE
Codechange: Store GRFConfig parameters in a vector.

### DIFF
--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -663,7 +663,7 @@ void Gamelog::GRFUpdate(const GRFConfig *oldc, const GRFConfig *newc)
 				this->GRFCompatible(&nl[n]->ident);
 			}
 
-			if (og->num_params != ng->num_params || og->param == ng->param) {
+			if (og->param != ng->param) {
 				this->GRFParameters(ol[o]->ident.grfid);
 			}
 

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -191,7 +191,7 @@ static void LoadSpriteTables()
 
 	/* Baseset extra graphics */
 	GRFConfig *extra = new GRFConfig(used_set->GetOrCreateExtraConfig());
-	if (extra->num_params == 0) extra->SetParameterDefaults();
+	if (extra->param.empty()) extra->SetParameterDefaults();
 	ClrBit(extra->flags, GCF_INIT_ONLY);
 
 	extra->next = top;
@@ -397,7 +397,7 @@ bool GraphicsSet::IsConfigurable() const
 void GraphicsSet::CopyCompatibleConfig(const GraphicsSet &src)
 {
 	const GRFConfig *src_cfg = src.GetExtraConfig();
-	if (src_cfg == nullptr || src_cfg->num_params == 0) return;
+	if (src_cfg == nullptr || src_cfg->param.empty()) return;
 	GRFConfig &dest_cfg = this->GetOrCreateExtraConfig();
 	if (dest_cfg.IsCompatible(src_cfg->version)) return;
 	dest_cfg.CopyParams(*src_cfg);

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -152,6 +152,8 @@ struct GRFParameterInfo {
 
 /** Information about GRF, used in the game and (part of it) in savegames */
 struct GRFConfig : ZeroedMemoryAllocator {
+	static constexpr uint8_t MAX_NUM_PARAMS = 0x80;
+
 	GRFConfig(const std::string &filename = std::string{});
 	GRFConfig(const GRFConfig &config);
 
@@ -171,17 +173,16 @@ struct GRFConfig : ZeroedMemoryAllocator {
 	uint8_t flags; ///< NOSAVE: GCF_Flags, bitset
 	GRFStatus status; ///< NOSAVE: GRFStatus, enum
 	uint32_t grf_bugs; ///< NOSAVE: bugs in this GRF in this run, @see enum GRFBugs
-	std::array<uint32_t, 0x80> param; ///< GRF parameters
-	uint8_t num_params; ///< Number of used parameters
 	uint8_t num_valid_params; ///< NOSAVE: Number of valid parameters (action 0x14)
 	uint8_t palette; ///< GRFPalette, bitset
-	std::vector<std::optional<GRFParameterInfo>> param_info; ///< NOSAVE: extra information about the parameters
 	bool has_param_defaults; ///< NOSAVE: did this newgrf specify any defaults for it's parameters
+	std::vector<std::optional<GRFParameterInfo>> param_info; ///< NOSAVE: extra information about the parameters
+	std::vector<uint32_t> param; ///< GRF parameters
 
 	struct GRFConfig *next; ///< NOSAVE: Next item in the linked list
 
 	bool IsCompatible(uint32_t old_version) const;
-	void SetParams(const std::vector<uint32_t> &pars);
+	void SetParams(std::span<const uint32_t> pars);
 	void CopyParams(const GRFConfig &src);
 
 	uint32_t GetValue(const GRFParameterInfo &info) const;

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -1196,8 +1196,9 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @param name     The name of the field.
  * @param variable Name of the global variable.
  * @param type     Storage of the data in memory and in the savegame.
+ * @param length   Number of elements in the array.
  */
-#define SLEG_ARR(name, variable, type) SLEG_CONDARR(name, variable, type, lengthof(variable), SL_MIN_VERSION, SL_MAX_VERSION)
+#define SLEG_ARR(name, variable, type, length) SLEG_CONDARR(name, variable, type, length, SL_MIN_VERSION, SL_MAX_VERSION)
 
 /**
  * Storage of a global \c std::string in every savegame version.

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1220,7 +1220,7 @@ static void GraphicsSetSaveConfig(IniFile &ini)
 	group.GetOrCreateItem("shortname").SetValue(fmt::format("{:08X}", BSWAP32(used_set->shortname)));
 
 	const GRFConfig *extra_cfg = used_set->GetExtraConfig();
-	if (extra_cfg != nullptr && extra_cfg->num_params > 0) {
+	if (extra_cfg != nullptr && !extra_cfg->param.empty()) {
 		group.GetOrCreateItem("extra_version").SetValue(fmt::format("{}", extra_cfg->version));
 		group.GetOrCreateItem("extra_params").SetValue(GRFBuildParamList(extra_cfg));
 	}

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -814,7 +814,7 @@ struct GameOptionsWindow : Window {
 				auto *used_set = BaseGraphics::GetUsedSet();
 				if (used_set == nullptr || !used_set->IsConfigurable()) break;
 				GRFConfig &extra_cfg = used_set->GetOrCreateExtraConfig();
-				if (extra_cfg.num_params == 0) extra_cfg.SetParameterDefaults();
+				if (extra_cfg.param.empty()) extra_cfg.SetParameterDefaults();
 				OpenGRFParameterWindow(true, &extra_cfg, _game_mode == GM_MENU);
 				if (_game_mode == GM_MENU) this->reload = true;
 				break;

--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -273,8 +273,8 @@ void SurveyConfiguration(nlohmann::json &survey)
 	if (BaseGraphics::GetUsedSet() != nullptr) {
 		survey["graphics_set"] = fmt::format("{}.{}", BaseGraphics::GetUsedSet()->name, BaseGraphics::GetUsedSet()->version);
 		const GRFConfig *extra_cfg = BaseGraphics::GetUsedSet()->GetExtraConfig();
-		if (extra_cfg != nullptr && extra_cfg->num_params > 0) {
-			survey["graphics_set_parameters"] = std::span<const uint32_t>(extra_cfg->param.data(), extra_cfg->num_params);
+		if (extra_cfg != nullptr && !extra_cfg->param.empty()) {
+			survey["graphics_set_parameters"] = std::span<const uint32_t>(extra_cfg->param);
 		} else {
 			survey["graphics_set_parameters"] = std::span<const uint32_t>();
 		}
@@ -370,7 +370,7 @@ void SurveyGrfs(nlohmann::json &survey)
 		if ((c->palette & GRFP_BLT_MASK) == GRFP_BLT_32BPP) grf["blitter"] = "32bpp";
 
 		grf["is_static"] = HasBit(c->flags, GCF_STATIC);
-		grf["parameters"] = std::span<const uint32_t>(c->param.data(), c->num_params);
+		grf["parameters"] = std::span<const uint32_t>(c->param);
 	}
 }
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

All GRFConfigs have space allocated for parameters, but only configured GRFConfigs need them.

As there are 128 32-bit parameters, each GRFConfig has 512 bytes allocated that mostly aren't used. If you have many NewGRFs available (not selected for use) then this will add up.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Replace the fixed array with a vector. Using a vector instead means that space is only used when parameters are used.

Also fixes the "have the parameters changed" test for the Gamelog.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Care needs to be taken to ensure access to the vector is within bounds, but GRFConfig's `GetValue`/`GetValue` go a long make this safe.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
