### PR TITLE
Codefix: Avoiding passing new raw pointer into a smart pointer.

### DIFF
--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -370,7 +370,7 @@ bool GraphicsSet::FillSetDetails(const IniFile &ini, const std::string &path, co
 GRFConfig &GraphicsSet::GetOrCreateExtraConfig() const
 {
 	if (!this->extra_cfg) {
-		this->extra_cfg.reset(new GRFConfig(this->files[GFT_EXTRA].filename));
+		this->extra_cfg = std::make_unique<GRFConfig>(this->files[GFT_EXTRA].filename);
 
 		/* We know the palette of the base set, so if the base NewGRF is not
 		 * setting one, use the palette of the base set and not the global

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -521,7 +521,7 @@ void AddGRFTextToList(GRFTextList &list, uint8_t langid, uint32_t grfid, bool al
  */
 void AddGRFTextToList(GRFTextWrapper &list, uint8_t langid, uint32_t grfid, bool allow_newlines, std::string_view text_to_add)
 {
-	if (!list) list.reset(new GRFTextList());
+	if (list == nullptr) list = std::make_shared<GRFTextList>();
 	AddGRFTextToList(*list, langid, grfid, allow_newlines, text_to_add);
 }
 
@@ -533,7 +533,7 @@ void AddGRFTextToList(GRFTextWrapper &list, uint8_t langid, uint32_t grfid, bool
  */
 void AddGRFTextToList(GRFTextWrapper &list, std::string_view text_to_add)
 {
-	if (!list) list.reset(new GRFTextList());
+	if (list == nullptr) list = std::make_shared<GRFTextList>();
 	AddGRFTextToList(*list, GRFLX_UNSPECIFIED, text_to_add);
 }
 

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -37,7 +37,7 @@ static void OpenBankFile(const std::string &filename)
 	/* If there is no sound file (nosound set), don't load anything */
 	if (filename.empty()) return;
 
-	original_sound_file.reset(new RandomAccessFile(filename, BASESET_DIR));
+	original_sound_file = std::make_unique<RandomAccessFile>(filename, BASESET_DIR);
 	size_t pos = original_sound_file->GetPos();
 	uint count = original_sound_file->ReadDword();
 


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Avoiding passing new raw pointer into a smart pointer, as this temporarily creates an unmanaged object first.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use `std::make_shared` or `std::make_unique` instead of `reset(new ...)`.

There are some left over where the raw pointer to an object is passed from a library instead, and there's no much we can do about that.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
