### PR TITLE
Add: Translatable list separator.

### DIFF
--- a/src/cargotype.cpp
+++ b/src/cargotype.cpp
@@ -268,6 +268,8 @@ uint64_t CargoSpec::WeightOfNUnitsInTrain(uint32_t n) const
  */
 std::optional<std::string> BuildCargoAcceptanceString(const CargoArray &acceptance, StringID label)
 {
+	std::string_view list_separator = GetListSeparator();
+
 	/* Cargo acceptance is displayed in a extra multiline */
 	std::stringstream line;
 	line << GetString(label);
@@ -277,7 +279,7 @@ std::optional<std::string> BuildCargoAcceptanceString(const CargoArray &acceptan
 		CargoID cid = cs->Index();
 		if (acceptance[cid] > 0) {
 			/* Add a comma between each item. */
-			if (found) line << ", ";
+			if (found) line << list_separator;
 			found = true;
 
 			/* If the accepted value is less than 8, show it in 1/8:ths */

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -266,6 +266,8 @@ STR_UNITS_MINUTES                                               :{NUM}{NBSP}minu
 STR_UNITS_YEARS                                                 :{NUM}{NBSP}year{P "" s}
 STR_UNITS_PERIODS                                               :{NUM}{NBSP}period{P "" s}
 
+STR_LIST_SEPARATOR                                              :,{SPACE}
+
 # Common window strings
 STR_LIST_FILTER_TITLE                                           :{BLACK}Filter:
 STR_LIST_FILTER_OSKTITLE                                        :{BLACK}Enter one or more keywords to filter the list for

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -739,6 +739,7 @@ public:
 		SetDParam(0, this->selected->filesize);
 		tr.top = DrawStringMultiLine(tr, STR_CONTENT_DETAIL_FILESIZE);
 
+		std::string_view list_separator = GetListSeparator();
 		if (!this->selected->dependencies.empty()) {
 			/* List dependencies */
 			std::string buf;
@@ -749,7 +750,7 @@ public:
 					const ContentInfo *ci = *iter;
 					if (ci->id != cid) continue;
 
-					if (!buf.empty()) buf += ", ";
+					if (!buf.empty()) buf += list_separator;
 					buf += (*iter)->name;
 					break;
 				}
@@ -762,7 +763,7 @@ public:
 			/* List all tags */
 			std::string buf;
 			for (auto &tag : this->selected->tags) {
-				if (!buf.empty()) buf += ", ";
+				if (!buf.empty()) buf += list_separator;
 				buf += tag;
 			}
 			SetDParamStr(0, buf);
@@ -778,7 +779,7 @@ public:
 			for (const ContentInfo *ci : tree) {
 				if (ci == this->selected || ci->state != ContentInfo::SELECTED) continue;
 
-				if (!buf.empty()) buf += ", ";
+				if (!buf.empty()) buf += list_separator;
 				buf += ci->name;
 			}
 			if (!buf.empty()) {

--- a/src/roadveh_gui.cpp
+++ b/src/roadveh_gui.cpp
@@ -51,12 +51,13 @@ void DrawRoadVehDetails(const Vehicle *v, const Rect &r)
 		}
 
 		std::string capacity = GetString(STR_VEHICLE_DETAILS_TRAIN_ARTICULATED_RV_CAPACITY);
+		std::string_view list_separator = GetListSeparator();
 
 		bool first = true;
 		for (const CargoSpec *cs : _sorted_cargo_specs) {
 			CargoID cid = cs->Index();
 			if (max_cargo[cid] > 0) {
-				if (!first) capacity += ", ";
+				if (!first) capacity += list_separator;
 
 				SetDParam(0, cid);
 				SetDParam(1, max_cargo[cid]);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -214,12 +214,22 @@ struct LoadedLanguagePack {
 
 	std::array<uint, TEXT_TAB_END> langtab_num;   ///< Offset into langpack offs
 	std::array<uint, TEXT_TAB_END> langtab_start; ///< Offset into langpack offs
+
+	std::string list_separator; ///< Current list separator string.
 };
 
 static LoadedLanguagePack _langpack;
 
 static bool _scan_for_gender_data = false;  ///< Are we scanning for the gender of the current string? (instead of formatting it)
 
+/**
+ * Get the list separator string for the current language.
+ * @returns string containing list separator to use.
+ */
+std::string_view GetListSeparator()
+{
+	return _langpack.list_separator;
+}
 
 const char *GetStringPtr(StringID string)
 {
@@ -1311,6 +1321,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 					CargoTypes cmask = args.GetNextParameter<CargoTypes>();
 					bool first = true;
 
+					std::string_view list_separator = GetListSeparator();
 					for (const auto &cs : _sorted_cargo_specs) {
 						if (!HasBit(cmask, cs->Index())) continue;
 
@@ -1318,7 +1329,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 							first = false;
 						} else {
 							/* Add a comma if this is not the first item */
-							builder += ", ";
+							builder += list_separator;
 						}
 
 						GetStringWithArgs(builder, cs->name, args, next_substr_case_index, game_script);
@@ -1964,6 +1975,7 @@ bool ReadLanguagePack(const LanguageMetadata *lang)
 	_current_text_dir = (TextDirection)_current_language->text_dir;
 	_config_language_file = FS2OTTD(_current_language->file.filename());
 	SetCurrentGrfLangID(_current_language->newgrflangid);
+	_langpack.list_separator = GetString(STR_LIST_SEPARATOR);
 
 #ifdef _WIN32
 	extern void Win32SetCurrentLocaleName(std::string iso_code);

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -109,6 +109,7 @@ extern TextDirection _current_text_dir; ///< Text direction of the currently sel
 
 void InitializeLanguagePacks();
 const char *GetCurrentLanguageIsoCode();
+std::string_view GetListSeparator();
 
 /**
  * A searcher for missing glyphs.

--- a/src/table/strgen_tables.h
+++ b/src/table/strgen_tables.h
@@ -127,6 +127,7 @@ static const CmdStruct _cmd_structs[] = {
 	{"COMPANY_NUM",       EmitSingleChar, SCC_COMPANY_NUM,        1, -1, C_NONE},
 	{"PRESIDENT_NAME",    EmitSingleChar, SCC_PRESIDENT_NAME,     1, -1, C_NONE | C_GENDER},
 
+	{"SPACE",             EmitSingleChar, ' ',                    0, -1, C_DONTCOUNT},
 	{"",                  EmitSingleChar, '\n',                   0, -1, C_DONTCOUNT},
 	{"{",                 EmitSingleChar, '{',                    0, -1, C_DONTCOUNT},
 	{"UP_ARROW",          EmitSingleChar, SCC_UP_ARROW,           0, -1, C_DONTCOUNT},


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Some languages should use a separator other than ", " to separate list items, but this is hardcoded in a few places to a literal ", ".

#11387 tried a more feature-full but complex approach, but didn't progress.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add a string, `STR_LIST_SEPARATOR`, to allow the ", " list separator to be translated. Because this string needs to end in a space, and most editors automatically remove trailing spaces, a new string code `{SPACE}` is also added to assist this.

No attempt is made to support any form of conjunction, disjunction, wide or narrow list formatting, to keep it simple.

The list separator string is 'loaded' when the language pack is loaded, to avoid repeatedly calling `GetString(STR_LIST_SEPARATOR)` when building lists, which turns out to be a bottleneck in some cases.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

I did this as a regular string instead of a pragma because it seemed simpler and more sensible.

Needs a language file to be modified to test it (I have tested it but of course that's not in the PR.)

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
