### PR TITLE
Codechange: Move two way signal EOL to a more logical place

### DIFF
--- a/src/pathfinder/yapf/yapf_common.hpp
+++ b/src/pathfinder/yapf/yapf_common.hpp
@@ -69,7 +69,6 @@ protected:
 	TileIndex reverse_tile; ///< second (reverse) origin tile
 	Trackdir reverse_td; ///< second (reverse) origin trackdir
 	int reverse_penalty; ///< penalty to be added for using the reverse origin
-	bool treat_first_red_two_way_signal_as_eol; ///< in some cases (leaving station) we need to handle first two-way signal differently
 
 	/** to access inherited path finder */
 	inline Tpf &Yapf()
@@ -79,14 +78,13 @@ protected:
 
 public:
 	/** set origin (tiles, trackdirs, etc.) */
-	void SetOrigin(TileIndex tile, Trackdir td, TileIndex tiler = INVALID_TILE, Trackdir tdr = INVALID_TRACKDIR, int reverse_penalty = 0, bool treat_first_red_two_way_signal_as_eol = true)
+	void SetOrigin(TileIndex tile, Trackdir td, TileIndex tiler = INVALID_TILE, Trackdir tdr = INVALID_TRACKDIR, int reverse_penalty = 0)
 	{
 		this->origin_tile = tile;
 		this->origin_td = td;
 		this->reverse_tile = tiler;
 		this->reverse_td = tdr;
 		this->reverse_penalty = reverse_penalty;
-		this->treat_first_red_two_way_signal_as_eol = treat_first_red_two_way_signal_as_eol;
 	}
 
 	/** Called when YAPF needs to place origin nodes into open list */
@@ -103,12 +101,6 @@ public:
 			n2.cost = this->reverse_penalty;
 			Yapf().AddStartupNode(n2);
 		}
-	}
-
-	/** return true if first two-way signal should be treated as dead end */
-	inline bool TreatFirstRedTwoWaySignalAsEOL()
-	{
-		return Yapf().PfGetSettings().rail_firstred_twoway_eol && this->treat_first_red_two_way_signal_as_eol;
 	}
 };
 

--- a/src/pathfinder/yapf/yapf_costrail.hpp
+++ b/src/pathfinder/yapf/yapf_costrail.hpp
@@ -45,17 +45,18 @@ protected:
 	 * @note maximum cost doesn't work with caching enabled
 	 * @todo fix maximum cost failing with caching (e.g. FS#2900)
 	 */
-	int max_cost;
-	bool disable_cache;
-	std::vector<int> sig_look_ahead_costs;
+	int max_cost = 0;
+	bool disable_cache = false;
+	std::vector<int> sig_look_ahead_costs = {};
+	bool treat_first_red_two_way_signal_as_eol = false;
 
 public:
-	bool stopped_on_first_two_way_signal;
+	bool stopped_on_first_two_way_signal = false;
 
 protected:
 	static constexpr int MAX_SEGMENT_COST = 10000;
 
-	CYapfCostRailT() : max_cost(0), disable_cache(false), stopped_on_first_two_way_signal(false)
+	CYapfCostRailT()
 	{
 		/* pre-compute look-ahead penalties into array */
 		int p0 = Yapf().PfGetSettings().rail_look_ahead_signal_p0;
@@ -75,6 +76,18 @@ protected:
 	}
 
 public:
+	/** Sets whether the first two-way signal should be treated as a dead end */
+	void SetTreatFirstRedTwoWaySignalAsEOL(bool enabled)
+	{
+		this->treat_first_red_two_way_signal_as_eol = enabled;
+	}
+
+	/** Returns whether the first two-way signal should be treated as a dead end */
+	inline bool TreatFirstRedTwoWaySignalAsEOL()
+	{
+		return Yapf().PfGetSettings().rail_firstred_twoway_eol && this->treat_first_red_two_way_signal_as_eol;
+	}
+
 	inline int SlopeCost(TileIndex tile, Trackdir td)
 	{
 		if (!stSlopeCost(tile, td)) return 0;

--- a/src/pathfinder/yapf/yapf_rail.cpp
+++ b/src/pathfinder/yapf/yapf_rail.cpp
@@ -268,7 +268,8 @@ public:
 	inline FindDepotData FindNearestDepotTwoWay(const Train *v, TileIndex t1, Trackdir td1, TileIndex t2, Trackdir td2, int max_penalty, int reverse_penalty)
 	{
 		/* set origin and destination nodes */
-		Yapf().SetOrigin(t1, td1, t2, td2, reverse_penalty, true);
+		Yapf().SetOrigin(t1, td1, t2, td2, reverse_penalty);
+		Yapf().SetTreatFirstRedTwoWaySignalAsEOL(true);
 		Yapf().SetDestination(v);
 		Yapf().SetMaxCost(max_penalty);
 
@@ -351,6 +352,7 @@ public:
 	{
 		/* Set origin and destination. */
 		Yapf().SetOrigin(t1, td);
+		Yapf().SetTreatFirstRedTwoWaySignalAsEOL(false);
 		Yapf().SetDestination(v, override_railtype);
 
 		if (!Yapf().FindPath(v)) return false;
@@ -437,7 +439,8 @@ public:
 
 		/* set origin and destination nodes */
 		PBSTileInfo origin = FollowTrainReservation(v);
-		Yapf().SetOrigin(origin.tile, origin.trackdir, INVALID_TILE, INVALID_TRACKDIR, 1, true);
+		Yapf().SetOrigin(origin.tile, origin.trackdir, INVALID_TILE, INVALID_TRACKDIR, 1);
+		Yapf().SetTreatFirstRedTwoWaySignalAsEOL(true);
 		Yapf().SetDestination(v);
 
 		/* find the best path */
@@ -501,7 +504,8 @@ public:
 	{
 		/* create pathfinder instance
 		 * set origin and destination nodes */
-		Yapf().SetOrigin(t1, td1, t2, td2, reverse_penalty, false);
+		Yapf().SetOrigin(t1, td1, t2, td2, reverse_penalty);
+		Yapf().SetTreatFirstRedTwoWaySignalAsEOL(false);
 		Yapf().SetDestination(v);
 
 		/* find the best path */


### PR DESCRIPTION
## Motivation / Problem

While messing around with the YAPF ship pathfinder I came across this TreatFirstRedTwoWaySignalAsEOL setting in one of the shared YAPF origin classes. This setting only applies to the rail pathfinder, and is totally unrelated to the origin to begin with.

## Description

I moved it to yapf_cost_rail where it belongs, since that's where it is actually used. As a result only the rail YAPF implementation know about it.

## Limitations

It would be quite easy to forget to call SetTreatFirstRedTwoWaySignalAsEOL. But IMO the risk is not really any higher compared to an obscure function parameter that's defaulted and in the wrong place :)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
