### PR TITLE
Codechange: use default virtual destructors over empty destructors

### DIFF
--- a/src/gamelog_internal.h
+++ b/src/gamelog_internal.h
@@ -30,7 +30,7 @@ using GrfIDMapping = std::map<uint32_t, GRFPresence>;
 
 struct LoggedChange {
 	LoggedChange(GamelogChangeType type = GLCT_NONE) : ct(type) {}
-	virtual ~LoggedChange() {}
+	virtual ~LoggedChange() = default;
 	virtual void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) = 0;
 
 	GamelogChangeType ct;

--- a/src/ini_type.h
+++ b/src/ini_type.h
@@ -56,7 +56,7 @@ struct IniLoadFile {
 	const IniGroupNameList seq_group_names;  ///< list of group names that are sequences.
 
 	IniLoadFile(const IniGroupNameList &list_group_names = {}, const IniGroupNameList &seq_group_names = {});
-	virtual ~IniLoadFile() { }
+	virtual ~IniLoadFile() = default;
 
 	const IniGroup *GetGroup(std::string_view name) const;
 	IniGroup *GetGroup(std::string_view name);

--- a/src/network/network_crypto.h
+++ b/src/network/network_crypto.h
@@ -40,7 +40,7 @@
  */
 class NetworkEncryptionHandler {
 public:
-	virtual ~NetworkEncryptionHandler() {}
+	virtual ~NetworkEncryptionHandler() = default;
 
 	/**
 	 * Get the size of the MAC (Message Authentication Code) used by the underlying encryption protocol.
@@ -70,7 +70,7 @@ public:
  */
 class NetworkAuthenticationPasswordRequest {
 public:
-	virtual ~NetworkAuthenticationPasswordRequest() {}
+	virtual ~NetworkAuthenticationPasswordRequest() = default;
 
 	/**
 	 * Reply to the request with the given password.
@@ -108,7 +108,7 @@ public:
  */
 class NetworkAuthenticationPasswordProvider {
 public:
-	virtual ~NetworkAuthenticationPasswordProvider() {}
+	virtual ~NetworkAuthenticationPasswordProvider() = default;
 
 	/**
 	 * Callback to return the password where to validate against.
@@ -139,7 +139,7 @@ public:
  */
 class NetworkAuthenticationAuthorizedKeyHandler {
 public:
-	virtual ~NetworkAuthenticationAuthorizedKeyHandler() {}
+	virtual ~NetworkAuthenticationAuthorizedKeyHandler() = default;
 
 	/**
 	 * Check whether the key handler can be used, i.e. whether there are authorized keys to check against.
@@ -189,7 +189,7 @@ using NetworkAuthenticationMethodMask = uint16_t;
  */
 class NetworkAuthenticationHandler {
 public:
-	virtual ~NetworkAuthenticationHandler() {}
+	virtual ~NetworkAuthenticationHandler() = default;
 
 	/**
 	 * Get the name of the handler for debug messages.

--- a/src/random_access_file_type.h
+++ b/src/random_access_file_type.h
@@ -40,7 +40,7 @@ public:
 	RandomAccessFile(const RandomAccessFile&) = delete;
 	void operator=(const RandomAccessFile&) = delete;
 
-	virtual ~RandomAccessFile() {}
+	virtual ~RandomAccessFile() = default;
 
 	const std::string &GetFilename() const;
 	const std::string &GetSimplifiedFilename() const;

--- a/src/saveload/saveload_filter.h
+++ b/src/saveload/saveload_filter.h
@@ -24,9 +24,7 @@ struct LoadFilter {
 	}
 
 	/** Make sure the writers are properly closed. */
-	virtual ~LoadFilter()
-	{
-	}
+	virtual ~LoadFilter() = default;
 
 	/**
 	 * Read a given number of bytes from the savegame.
@@ -69,9 +67,7 @@ struct SaveFilter {
 	}
 
 	/** Make sure the writers are properly closed. */
-	virtual ~SaveFilter()
-	{
-	}
+	virtual ~SaveFilter() = default;
 
 	/**
 	 * Write a given number of bytes into the savegame.

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -44,7 +44,7 @@ typedef bool (ScriptAsyncModeProc)();
 class SimpleCountedObject {
 public:
 	SimpleCountedObject() : ref_count(0) {}
-	virtual ~SimpleCountedObject() {}
+	virtual ~SimpleCountedObject() = default;
 
 	inline void AddRef() { ++this->ref_count; }
 	void Release();

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -62,7 +62,7 @@ struct StringReader {
 	bool translation; ///< Are we reading a translation, implies !master. However, the base translation will have this false.
 
 	StringReader(StringData &data, const std::string &file, bool master, bool translation);
-	virtual ~StringReader() {}
+	virtual ~StringReader() = default;
 	void HandleString(char *str);
 
 	/**

--- a/src/tilearea_type.h
+++ b/src/tilearea_type.h
@@ -115,10 +115,7 @@ protected:
 	}
 
 public:
-	/** Some compilers really like this. */
-	virtual ~TileIterator()
-	{
-	}
+	virtual ~TileIterator() = default;
 
 	/**
 	 * Get the tile we are currently at.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Inconsistent usage of `virtual ~Object() {}` and `virtual ~Object() = default;`.


## Description

Use `virtual ~Object() = default;` instead, as that's the version that's most commonly used in the code.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
