### PR TITLE
Codechange: Deduplicate text effect strings.

### DIFF
--- a/.github/unused-strings.py
+++ b/.github/unused-strings.py
@@ -39,7 +39,6 @@ def read_language_file(filename, strings_found, errors):
     skip = SkipType.NONE
     length = 0
     common_prefix = ""
-    last_tiny_string = ""
 
     with open(filename) as fp:
         for line in fp.readlines():
@@ -113,17 +112,6 @@ def read_language_file(filename, strings_found, errors):
 
             name = line.split(":")[0].strip()
             strings_defined.append(name)
-
-            # If a string ends on _TINY or _SMALL, it can be the {TINY} variant.
-            # Check for this by some fuzzy matching.
-            if name.endswith(("_SMALL", "_TINY")):
-                last_tiny_string = name
-            elif last_tiny_string:
-                matching_name = "_".join(last_tiny_string.split("_")[:-1])
-                if name == matching_name:
-                    strings_found.add(last_tiny_string)
-            else:
-                last_tiny_string = ""
 
             if skip == SkipType.EXTERNAL:
                 strings_found.add(name)

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4451,12 +4451,7 @@ STR_VEHICLE_STATUS_CANNOT_REACH_DEPOT_VEL                       :{ORANGE}{1:VELO
 STR_VEHICLE_STATUS_CANNOT_REACH_DEPOT_SERVICE_VEL               :{LTBLUE}{1:VELOCITY} - Cannot reach {0:DEPOT}
 
 # Vehicle stopped/started animations
-###length 2
-STR_VEHICLE_COMMAND_STOPPED_SMALL                               :{TINY_FONT}{RED}Stopped
 STR_VEHICLE_COMMAND_STOPPED                                     :{RED}Stopped
-
-###length 2
-STR_VEHICLE_COMMAND_STARTED_SMALL                               :{TINY_FONT}{GREEN}Started
 STR_VEHICLE_COMMAND_STARTED                                     :{GREEN}Started
 
 # Vehicle details
@@ -4918,25 +4913,16 @@ STR_TEXTFILE_GAME_MANUAL_CAPTION                                :{WHITE}OpenTTD 
 
 
 # Vehicle loading indicators
-STR_PERCENT_UP_SMALL                                            :{TINY_FONT}{WHITE}{NUM}%{UP_ARROW}
 STR_PERCENT_UP                                                  :{WHITE}{NUM}%{UP_ARROW}
-STR_PERCENT_DOWN_SMALL                                          :{TINY_FONT}{WHITE}{NUM}%{DOWN_ARROW}
 STR_PERCENT_DOWN                                                :{WHITE}{NUM}%{DOWN_ARROW}
-STR_PERCENT_UP_DOWN_SMALL                                       :{TINY_FONT}{WHITE}{NUM}%{UP_ARROW}{DOWN_ARROW}
 STR_PERCENT_UP_DOWN                                             :{WHITE}{NUM}%{UP_ARROW}{DOWN_ARROW}
-STR_PERCENT_NONE_SMALL                                          :{TINY_FONT}{WHITE}{NUM}%
 STR_PERCENT_NONE                                                :{WHITE}{NUM}%
 
 # Income 'floats'
-STR_INCOME_FLOAT_COST_SMALL                                     :{TINY_FONT}{RED}Cost: {CURRENCY_LONG}
 STR_INCOME_FLOAT_COST                                           :{RED}Cost: {CURRENCY_LONG}
-STR_INCOME_FLOAT_INCOME_SMALL                                   :{TINY_FONT}{GREEN}Income: {CURRENCY_LONG}
 STR_INCOME_FLOAT_INCOME                                         :{GREEN}Income: {CURRENCY_LONG}
-STR_FEEDER_TINY                                                 :{TINY_FONT}{YELLOW}Transfer: {CURRENCY_LONG}
 STR_FEEDER                                                      :{YELLOW}Transfer: {CURRENCY_LONG}
-STR_FEEDER_INCOME_TINY                                          :{TINY_FONT}{YELLOW}Transfer: {CURRENCY_LONG}{WHITE} / {GREEN}Income: {CURRENCY_LONG}
 STR_FEEDER_INCOME                                               :{YELLOW}Transfer: {CURRENCY_LONG}{WHITE} / {GREEN}Income: {CURRENCY_LONG}
-STR_FEEDER_COST_TINY                                            :{TINY_FONT}{YELLOW}Transfer: {CURRENCY_LONG}{WHITE} / {RED}Cost: {CURRENCY_LONG}
 STR_FEEDER_COST                                                 :{YELLOW}Transfer: {CURRENCY_LONG}{WHITE} / {RED}Cost: {CURRENCY_LONG}
 STR_MESSAGE_ESTIMATED_COST                                      :{WHITE}Estimated Cost: {CURRENCY_LONG}
 STR_MESSAGE_ESTIMATED_INCOME                                    :{WHITE}Estimated Income: {CURRENCY_LONG}

--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -72,7 +72,7 @@ void UpdateTextEffect(TextEffectID te_id, StringID msg)
 	te.string_id = msg;
 	CopyOutDParam(te.params, 2);
 
-	te.UpdatePosition(te.center, te.top, te.string_id, te.string_id - 1);
+	te.UpdatePosition(te.center, te.top, te.string_id);
 }
 
 void UpdateAllTextEffectVirtCoords()
@@ -80,7 +80,7 @@ void UpdateAllTextEffectVirtCoords()
 	for (auto &te : _text_effects) {
 		if (te.string_id == INVALID_STRING_ID) continue;
 		CopyInDParam(te.params);
-		te.UpdatePosition(te.center, te.top, te.string_id, te.string_id - 1);
+		te.UpdatePosition(te.center, te.top, te.string_id);
 	}
 }
 
@@ -124,7 +124,7 @@ void DrawTextEffects(DrawPixelInfo *dpi)
 		if (te.string_id == INVALID_STRING_ID) continue;
 		if (te.mode == TE_RISING || _settings_client.gui.loading_indicators) {
 			CopyInDParam(te.params);
-			ViewportAddString(dpi, ZOOM_LVL_TEXT_EFFECT, &te, te.string_id, te.string_id - 1, STR_NULL);
+			ViewportAddString(dpi, ZOOM_LVL_TEXT_EFFECT, &te, te.string_id, te.string_id, STR_NULL);
 		}
 	}
 }


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Text effects are drawn with two different strings depending on the viewport zoom level.

While theoretically these could have different content, in reality they are the small string, just one is prefixed with `{TINY_FONT}`

When drawing the small versions of viewport text, it is drawn with `FS_SMALL` passed, so `{TINY_FONT}` is redundant. There is no need to duplicate text effect strings for both normal and small versions.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Remove the tiny version of text effect strings.

This gets rid of a mysterious `string_id - 1`, and also avoids an extra string format when text effect positions are updated.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

I didn't verify that ALL translations use the same content for normal and small versions.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
