### PR TITLE
Fix #13155: Set number of parameters when assigning from GRFConfig to GRFFile.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -9007,7 +9007,8 @@ GRFFile::GRFFile(const GRFConfig *config)
 	 * 'Uninitialised' parameters are zeroed as that is their default value when dynamically creating them. */
 	this->param = {};
 
-	auto last = std::begin(config->param) + std::min<size_t>(std::size(config->param), GRFConfig::MAX_NUM_PARAMS);
+	this->param_end = std::min<uint>(static_cast<uint>(std::size(config->param)), GRFConfig::MAX_NUM_PARAMS);
+	auto last = std::begin(config->param) + this->param_end;
 	std::copy(std::begin(config->param), last, std::begin(this->param));
 }
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As per #13155, parameters are no longer set up properly when tranfering from GRFConfig to GRFFile.

Although the parameter values are assigned, the number of parameters is left at zero.


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Set the `param_end` value to the number of parameters copied.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Untested.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
