### PR TITLE
Codechange: Add EncodedStrings and use for tooltips and texteffects.

### DIFF
--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -674,10 +674,9 @@ public:
 		if (widget != WID_RV_TRAIN_WAGONREMOVE_TOGGLE) return false;
 
 		if (Group::IsValidID(this->sel_group)) {
-			SetDParam(0, STR_REPLACE_REMOVE_WAGON_TOOLTIP);
-			GuiShowTooltips(this, STR_REPLACE_REMOVE_WAGON_GROUP_HELP, close_cond, 1);
+			GuiShowTooltips(this, GetEncodedString(STR_REPLACE_REMOVE_WAGON_GROUP_HELP, STR_REPLACE_REMOVE_WAGON_TOOLTIP), close_cond);
 		} else {
-			GuiShowTooltips(this, STR_REPLACE_REMOVE_WAGON_TOOLTIP, close_cond);
+			GuiShowTooltips(this, GetEncodedString(STR_REPLACE_REMOVE_WAGON_TOOLTIP), close_cond);
 		}
 		return true;
 	}

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -584,7 +584,7 @@ struct CheatWindow : Window {
 
 		const SettingDesc *desc = this->sandbox_settings[row];
 		const IntSettingDesc *sd = desc->AsIntSetting();
-		GuiShowTooltips(this, sd->GetHelp(), close_cond);
+		GuiShowTooltips(this, GetEncodedString(sd->GetHelp()), close_cond);
 
 		return true;
 	}

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -899,9 +899,11 @@ struct DepotWindow : Window {
 		}
 
 		/* Show tooltip window */
-		SetDParam(0, whole_chain ? num : v->engine_type);
-		SetDParamStr(1, details);
-		GuiShowTooltips(this, whole_chain ? STR_DEPOT_VEHICLE_TOOLTIP_CHAIN : STR_DEPOT_VEHICLE_TOOLTIP, TCC_RIGHT_CLICK, 2);
+		if (whole_chain) {
+			GuiShowTooltips(this, GetEncodedString(STR_DEPOT_VEHICLE_TOOLTIP_CHAIN, num, details), TCC_RIGHT_CLICK);
+		} else {
+			GuiShowTooltips(this, GetEncodedString(STR_DEPOT_VEHICLE_TOOLTIP, v->engine_type, details), TCC_RIGHT_CLICK);
+		}
 
 		return true;
 	}

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -3181,7 +3181,7 @@ struct IndustryCargoesWindow : public Window {
 
 			case CFT_INDUSTRY:
 				if (fld->u.industry.ind_type < NUM_INDUSTRYTYPES && (this->ind_cargo >= NUM_INDUSTRYTYPES || fieldxy.x != 2)) {
-					GuiShowTooltips(this, STR_INDUSTRY_CARGOES_INDUSTRY_TOOLTIP, close_cond);
+					GuiShowTooltips(this, GetEncodedString(STR_INDUSTRY_CARGOES_INDUSTRY_TOOLTIP), close_cond);
 				}
 				return true;
 
@@ -3190,8 +3190,7 @@ struct IndustryCargoesWindow : public Window {
 		}
 		if (IsValidCargoType(cargo_type) && (this->ind_cargo < NUM_INDUSTRYTYPES || cargo_type != this->ind_cargo - NUM_INDUSTRYTYPES)) {
 			const CargoSpec *csp = CargoSpec::Get(cargo_type);
-			SetDParam(0, csp->name);
-			GuiShowTooltips(this, STR_INDUSTRY_CARGOES_CARGO_TOOLTIP, close_cond, 1);
+			GuiShowTooltips(this, GetEncodedString(STR_INDUSTRY_CARGOES_CARGO_TOOLTIP, csp->name), close_cond);
 			return true;
 		}
 

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -396,20 +396,15 @@ bool LinkGraphOverlay::ShowTooltip(Point pt, TooltipCloseCondition close_cond)
 					SetDParam(0, time);
 					AppendStringInPlace(tooltip_extension, STR_LINKGRAPH_STATS_TOOLTIP_TIME_EXTENSION);
 				}
-				SetDParam(0, link.cargo);
-				SetDParam(1, link.Usage());
-				SetDParam(2, i->first);
-				SetDParam(3, j->first);
-				SetDParam(4, link.Usage() * 100 / (link.capacity + 1));
-				SetDParamStr(5, tooltip_extension);
 				GuiShowTooltips(this->window,
-					TimerGameEconomy::UsingWallclockUnits() ? STR_LINKGRAPH_STATS_TOOLTIP_MINUTE : STR_LINKGRAPH_STATS_TOOLTIP_MONTH,
-					close_cond, 7);
+					GetEncodedString(TimerGameEconomy::UsingWallclockUnits() ? STR_LINKGRAPH_STATS_TOOLTIP_MINUTE : STR_LINKGRAPH_STATS_TOOLTIP_MONTH,
+						link.cargo, link.Usage(), i->first, j->first, link.Usage() * 100 / (link.capacity + 1), tooltip_extension),
+					close_cond);
 				return true;
 			}
 		}
 	}
-	GuiShowTooltips(this->window, STR_NULL, close_cond);
+	GuiShowTooltips(this->window, {}, close_cond);
 	return false;
 }
 
@@ -641,17 +636,19 @@ bool LinkGraphLegendWindow::OnTooltip([[maybe_unused]] Point, WidgetID widget, T
 {
 	if (IsInsideMM(widget, WID_LGL_COMPANY_FIRST, WID_LGL_COMPANY_LAST + 1)) {
 		if (this->IsWidgetDisabled(widget)) {
-			GuiShowTooltips(this, STR_LINKGRAPH_LEGEND_SELECT_COMPANIES, close_cond);
+			GuiShowTooltips(this, GetEncodedString(STR_LINKGRAPH_LEGEND_SELECT_COMPANIES), close_cond);
 		} else {
-			SetDParam(0, STR_LINKGRAPH_LEGEND_SELECT_COMPANIES);
-			SetDParam(1, (CompanyID)(widget - WID_LGL_COMPANY_FIRST));
-			GuiShowTooltips(this, STR_LINKGRAPH_LEGEND_COMPANY_TOOLTIP, close_cond, 2);
+			GuiShowTooltips(this,
+				GetEncodedString(STR_LINKGRAPH_LEGEND_COMPANY_TOOLTIP,
+					STR_LINKGRAPH_LEGEND_SELECT_COMPANIES,
+					widget - WID_LGL_COMPANY_FIRST),
+				close_cond);
 		}
 		return true;
 	}
 	if (IsInsideMM(widget, WID_LGL_CARGO_FIRST, WID_LGL_CARGO_LAST + 1)) {
 		const CargoSpec *cargo = _sorted_cargo_specs[widget - WID_LGL_CARGO_FIRST];
-		GuiShowTooltips(this, cargo->name, close_cond);
+		GuiShowTooltips(this, GetEncodedString(cargo->name), close_cond);
 		return true;
 	}
 	return false;

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -565,8 +565,7 @@ void ShowCostOrIncomeAnimation(int x, int y, int z, Money cost)
 		cost = -cost;
 		msg = STR_INCOME_FLOAT_INCOME;
 	}
-	SetDParam(0, cost);
-	AddTextEffect(msg, pt.x, pt.y, Ticks::DAY_TICKS, TE_RISING);
+	AddTextEffect(GetEncodedString(msg, cost), pt.x, pt.y, Ticks::DAY_TICKS, TE_RISING);
 }
 
 /**
@@ -581,17 +580,15 @@ void ShowFeederIncomeAnimation(int x, int y, int z, Money transfer, Money income
 {
 	Point pt = RemapCoords(x, y, z);
 
-	SetDParam(0, transfer);
 	if (income == 0) {
-		AddTextEffect(STR_FEEDER, pt.x, pt.y, Ticks::DAY_TICKS, TE_RISING);
+		AddTextEffect(GetEncodedString(STR_FEEDER, transfer), pt.x, pt.y, Ticks::DAY_TICKS, TE_RISING);
 	} else {
 		StringID msg = STR_FEEDER_COST;
 		if (income < 0) {
 			income = -income;
 			msg = STR_FEEDER_INCOME;
 		}
-		SetDParam(1, income);
-		AddTextEffect(msg, pt.x, pt.y, Ticks::DAY_TICKS, TE_RISING);
+		AddTextEffect(GetEncodedString(msg, transfer, income), pt.x, pt.y, Ticks::DAY_TICKS, TE_RISING);
 	}
 }
 
@@ -610,8 +607,7 @@ TextEffectID ShowFillingPercent(int x, int y, int z, uint8_t percent, StringID s
 
 	assert(string != STR_NULL);
 
-	SetDParam(0, percent);
-	return AddTextEffect(string, pt.x, pt.y, 0, TE_STATIC);
+	return AddTextEffect(GetEncodedString(string, percent), pt.x, pt.y, 0, TE_STATIC);
 }
 
 /**
@@ -623,8 +619,7 @@ void UpdateFillingPercent(TextEffectID te_id, uint8_t percent, StringID string)
 {
 	assert(string != STR_NULL);
 
-	SetDParam(0, percent);
-	UpdateTextEffect(te_id, string);
+	UpdateTextEffect(te_id, GetEncodedString(string, percent));
 }
 
 /**

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1785,10 +1785,10 @@ public:
 
 				if (IsInsideMM(pt.x, player_icon_x, player_icon_x + d2.width)) {
 					if (index == this->player_self_index) {
-						GuiShowTooltips(this, STR_NETWORK_CLIENT_LIST_PLAYER_ICON_SELF_TOOLTIP, close_cond);
+						GuiShowTooltips(this, GetEncodedString(STR_NETWORK_CLIENT_LIST_PLAYER_ICON_SELF_TOOLTIP), close_cond);
 						return true;
 					} else if (index == this->player_host_index) {
-						GuiShowTooltips(this, STR_NETWORK_CLIENT_LIST_PLAYER_ICON_HOST_TOOLTIP, close_cond);
+						GuiShowTooltips(this, GetEncodedString(STR_NETWORK_CLIENT_LIST_PLAYER_ICON_HOST_TOOLTIP), close_cond);
 						return true;
 					}
 				}
@@ -1796,7 +1796,7 @@ public:
 				ButtonCommon *button = this->GetButtonAtPoint(pt);
 				if (button == nullptr) return false;
 
-				GuiShowTooltips(this, button->tooltip, close_cond);
+				GuiShowTooltips(this, GetEncodedString(button->tooltip), close_cond);
 				return true;
 			};
 		}

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -492,7 +492,7 @@ struct BuildRailToolbarWindow : Window {
 
 		if (std::ranges::find(can_build_widgets, widget) == std::end(can_build_widgets)) return false;
 
-		GuiShowTooltips(this, STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE, close_cond);
+		GuiShowTooltips(this, GetEncodedString(STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE), close_cond);
 		return true;
 	}
 

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -100,6 +100,7 @@ static bool IsSccEncodedCode(char32_t c)
 	switch (c) {
 		case SCC_RECORD_SEPARATOR:
 		case SCC_ENCODED:
+		case SCC_ENCODED_INTERNAL:
 		case SCC_ENCODED_NUMERIC:
 		case SCC_ENCODED_STRING:
 			return true;

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -95,6 +95,65 @@ const StringParameter &StringParameters::GetNextParameterReference()
 	return param;
 }
 
+/**
+ * Encode a string with no parameters into an encoded string.
+ * @param str The StringID to format.
+ * @returns The encoded string.
+ */
+EncodedString GetEncodedString(StringID str)
+{
+	return GetEncodedStringWithArgs(str, {});
+}
+
+/**
+ * Encode a string with its parameters into an encoded string.
+ * The encoded string can be stored and decoded later without requiring parameters to be stored separately.
+ * @param str The StringID to format.
+ * @param params The parameters of the string.
+ * @returns The encoded string.
+ */
+EncodedString GetEncodedStringWithArgs(StringID str, std::span<const StringParameter> params)
+{
+	std::string result;
+	auto output = std::back_inserter(result);
+	Utf8Encode(output, SCC_ENCODED_INTERNAL);
+	fmt::format_to(output, "{:X}", str);
+
+	struct visitor {
+		std::back_insert_iterator<std::string> &output;
+
+		void operator()(const std::monostate &) {}
+
+		void operator()(const uint64_t &arg)
+		{
+			Utf8Encode(output, SCC_ENCODED_NUMERIC);
+			fmt::format_to(this->output, "{:X}", arg);
+		}
+
+		void operator()(const std::string &value)
+		{
+			Utf8Encode(output, SCC_ENCODED_STRING);
+			fmt::format_to(this->output, "{}", value);
+		}
+	};
+
+	visitor v{output};
+	for (const auto &param : params) {
+		*output = SCC_RECORD_SEPARATOR;
+		std::visit(v, param.data);
+	}
+
+	return EncodedString{std::move(result)};
+}
+
+/**
+ * Decode the encoded string.
+ * @returns Decoded raw string.
+ */
+std::string EncodedString::GetDecodedString() const
+{
+	return GetString(STR_JUST_RAW_STRING, this->string);
+}
 
 /**
  * Set a string parameter \a v at index \a n in the global string parameter array.
@@ -956,10 +1015,11 @@ uint ConvertDisplaySpeedToKmhishSpeed(uint speed, VehicleType type)
 /**
  * Decodes an encoded string during FormatString.
  * @param str The buffer of the encoded string.
+ * @param game_script Set if decoding a GameScript-encoded string. This affects how string IDs are handled.
  * @param builder The string builder to write the string to.
  * @returns Updated position position in input buffer.
  */
-static const char *DecodeEncodedString(const char *str, StringBuilder &builder)
+static const char *DecodeEncodedString(const char *str, bool game_script, StringBuilder &builder)
 {
 	ArrayStringParameters<20> sub_args;
 
@@ -970,7 +1030,7 @@ static const char *DecodeEncodedString(const char *str, StringBuilder &builder)
 		builder += "(invalid SCC_ENCODED)";
 		return p;
 	}
-	if (id >= TAB_SIZE_GAMESCRIPT) {
+	if (game_script && id >= TAB_SIZE_GAMESCRIPT) {
 		while (*p != '\0') p++;
 		builder += "(invalid StringID)";
 		return p;
@@ -983,6 +1043,12 @@ static const char *DecodeEncodedString(const char *str, StringBuilder &builder)
 
 		/* Find end of the parameter. */
 		for (; *p != '\0' && *p != SCC_RECORD_SEPARATOR; ++p) {}
+
+		if (s == p) {
+			/* This is an empty parameter. */
+			sub_args.SetParam(i++, std::monostate{});
+			continue;
+		}
 
 		/* Get the parameter type. */
 		char32_t parameter_type;
@@ -1014,13 +1080,13 @@ static const char *DecodeEncodedString(const char *str, StringBuilder &builder)
 			}
 
 			default:
-				/* Skip unknown parameter. */
-				i++;
+				/* Unknown parameter, make it blank. */
+				sub_args.SetParam(i++, std::monostate{});
 				break;
 		}
 	}
 
-	StringID stringid = MakeStringID(TEXT_TAB_GAMESCRIPT_START, id);
+	StringID stringid = game_script ? MakeStringID(TEXT_TAB_GAMESCRIPT_START, id) : StringID{id.base()};
 	GetStringWithArgs(builder, stringid, sub_args, true);
 
 	return p;
@@ -1092,7 +1158,8 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 			args.SetTypeOfNextParameter(b);
 			switch (b) {
 				case SCC_ENCODED:
-					str = DecodeEncodedString(str, builder);
+				case SCC_ENCODED_INTERNAL:
+					str = DecodeEncodedString(str, b == SCC_ENCODED, builder);
 					break;
 
 				case SCC_NEWGRF_STRINL: {

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -135,6 +135,22 @@ std::string GetString(StringID string, Args &&... args)
 	return GetStringWithArgs(string, params);
 }
 
+EncodedString GetEncodedString(StringID str);
+EncodedString GetEncodedStringWithArgs(StringID str, std::span<const StringParameter> params);
+
+/**
+ * Get an encoded string with parameters.
+ * @param string String ID to encode.
+ * @param args The parameters to set.
+ * @return The encoded string.
+ */
+template <typename... Args>
+EncodedString GetEncodedString(StringID string, const Args&... args)
+{
+	auto params = MakeParameters(std::forward<const Args&>(args)...);
+	return GetEncodedStringWithArgs(string, params);
+}
+
 /**
  * A searcher for missing glyphs.
  */

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -83,6 +83,7 @@ public:
 	uint64_t GetNextParameter()
 	{
 		struct visitor {
+			uint64_t operator()(const std::monostate &) { throw std::out_of_range("Attempt to read uninitialised parameter as integer"); }
 			uint64_t operator()(const uint64_t &arg) { return arg; }
 			uint64_t operator()(const std::string &) { throw std::out_of_range("Attempt to read string parameter as integer"); }
 		};
@@ -113,11 +114,12 @@ public:
 	const char *GetNextParameterString()
 	{
 		struct visitor {
+			const char *operator()(const std::monostate &) { throw std::out_of_range("Attempt to read uninitialised parameter as string"); }
 			const char *operator()(const uint64_t &) { throw std::out_of_range("Attempt to read integer parameter as string"); }
 			const char *operator()(const std::string &arg) { return arg.c_str(); }
 		};
 
-		const auto &param = GetNextParameterReference();
+		const auto &param = this->GetNextParameterReference();
 		return std::visit(visitor{}, param.data);
 	}
 

--- a/src/strings_type.h
+++ b/src/strings_type.h
@@ -72,7 +72,7 @@ static constexpr StringID SPECSTR_SILLY_NAME = 0x70E5; ///< Special string for s
 static constexpr StringID SPECSTR_ANDCO_NAME = 0x70E6; ///< Special string for Surname & Co company names.
 static constexpr StringID SPECSTR_PRESIDENT_NAME = 0x70E7; ///< Special string for the president's name.
 
-using StringParameterData = std::variant<uint64_t, std::string>;
+using StringParameterData = std::variant<std::monostate, uint64_t, std::string>;
 
 /** The data required to format and validate a single parameter of a string. */
 struct StringParameter {
@@ -82,6 +82,7 @@ struct StringParameter {
 	StringParameter() = default;
 	inline StringParameter(StringParameterData &&data) : data(std::move(data)), type(0) {}
 
+	inline StringParameter(const std::monostate &data) : data(data), type(0) {}
 	inline StringParameter(uint64_t data) : data(data), type(0) {}
 
 	inline StringParameter(const char *data) : data(std::string{data}), type(0) {}

--- a/src/strings_type.h
+++ b/src/strings_type.h
@@ -92,4 +92,27 @@ struct StringParameter {
 	inline StringParameter(const ConvertibleThroughBase auto &data) : data(static_cast<uint64_t>(data.base())), type(0) {}
 };
 
+/**
+ * Container for an encoded string, created by GetEncodedString.
+ */
+class EncodedString {
+public:
+	EncodedString() = default;
+
+	auto operator<=>(const EncodedString &) const = default;
+
+	std::string GetDecodedString() const;
+
+	inline void clear() { this->string.clear(); }
+	inline bool empty() const { return this->string.empty(); }
+
+private:
+	std::string string; ///< The encoded string.
+
+	/* An EncodedString can only be created by GetEncodedStringWithArgs(). */
+	explicit EncodedString(std::string &&string) : string(std::move(string)) {}
+
+	friend EncodedString GetEncodedStringWithArgs(StringID str, std::span<const StringParameter> params);
+};
+
 #endif /* STRINGS_TYPE_H */

--- a/src/table/control_codes.h
+++ b/src/table/control_codes.h
@@ -25,7 +25,7 @@ enum StringControlCode : uint16_t {
 
 	/* All SCC_ENCODED* control codes must have stable ids are they are stored in strings that are saved in savegames. */
 	SCC_ENCODED = SCC_CONTROL_START, ///< Encoded string marker and sub-string parameter.
-	SCC_ENCODED_RESERVED, ///< Reserved for future non-GS encoded strings.
+	SCC_ENCODED_INTERNAL, ///< Encoded text from OpenTTD.
 	SCC_ENCODED_NUMERIC, ///< Encoded numeric parameter.
 	SCC_ENCODED_STRING, ///< Encoded string parameter.
 

--- a/src/texteff.hpp
+++ b/src/texteff.hpp
@@ -18,6 +18,7 @@
  * Text effect modes.
  */
 enum TextEffectMode : uint8_t {
+	TE_INVALID, ///< Text effect is invalid.
 	TE_RISING, ///< Make the text effect slowly go upwards
 	TE_STATIC, ///< Keep the text effect static
 };
@@ -26,10 +27,10 @@ using TextEffectID = uint16_t;
 
 static const TextEffectID INVALID_TE_ID = UINT16_MAX;
 
-TextEffectID AddTextEffect(StringID msg, int x, int y, uint8_t duration, TextEffectMode mode);
+TextEffectID AddTextEffect(EncodedString &&msg, int x, int y, uint8_t duration, TextEffectMode mode);
 void InitTextEffects();
 void DrawTextEffects(DrawPixelInfo *dpi);
-void UpdateTextEffect(TextEffectID effect_id, StringID msg);
+void UpdateTextEffect(TextEffectID effect_id, EncodedString &&msg);
 void RemoveTextEffect(TextEffectID effect_id);
 void UpdateAllTextEffectVirtCoords();
 

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2981,7 +2981,7 @@ void CcStartStopVehicle(Commands, const CommandCost &result, VehicleID veh_id, b
 
 	StringID msg = (v->vehstatus & VS_STOPPED) ? STR_VEHICLE_COMMAND_STOPPED : STR_VEHICLE_COMMAND_STARTED;
 	Point pt = RemapCoords(v->x_pos, v->y_pos, v->z_pos);
-	AddTextEffect(msg, pt.x, pt.y, Ticks::DAY_TICKS, TE_RISING);
+	AddTextEffect(GetEncodedString(msg), pt.x, pt.y, Ticks::DAY_TICKS, TE_RISING);
 }
 
 /**

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2818,7 +2818,7 @@ struct VehicleDetailsWindow : Window {
 			} else {
 				tool_tip = widget == WID_VD_INCREASE_SERVICING_INTERVAL ? STR_VEHICLE_DETAILS_INCREASE_SERVICING_INTERVAL_TOOLTIP_DAYS : STR_VEHICLE_DETAILS_DECREASE_SERVICING_INTERVAL_TOOLTIP_DAYS;
 			}
-			GuiShowTooltips(this, tool_tip, close_cond);
+			GuiShowTooltips(this, GetEncodedString(tool_tip), close_cond);
 			return true;
 		}
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -754,7 +754,7 @@ static void DispatchRightClickEvent(Window *w, int x, int y)
 		/* Right-click close is enabled, but excluding sticky windows. */
 		w->Close();
 	} else if (_settings_client.gui.hover_delay_ms == 0 && !w->OnTooltip(pt, wid->GetIndex(), TCC_RIGHT_CLICK) && wid->GetToolTip() != STR_NULL) {
-		GuiShowTooltips(w, wid->GetToolTip(), TCC_RIGHT_CLICK);
+		GuiShowTooltips(w, GetEncodedString(wid->GetToolTip()), TCC_RIGHT_CLICK);
 	}
 }
 
@@ -775,7 +775,7 @@ static void DispatchHoverEvent(Window *w, int x, int y)
 
 	/* Show the tooltip if there is any */
 	if (!w->OnTooltip(pt, wid->GetIndex(), TCC_HOVER) && wid->GetToolTip() != STR_NULL) {
-		GuiShowTooltips(w, wid->GetToolTip(), TCC_HOVER);
+		GuiShowTooltips(w, GetEncodedString(wid->GetToolTip()), TCC_HOVER);
 		return;
 	}
 

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -1008,7 +1008,7 @@ Twindow *AllocateWindowDescFront(WindowDesc &desc, WindowNumber window_number, T
 
 void RelocateAllWindows(int neww, int newh);
 
-void GuiShowTooltips(Window *parent, StringID str, TooltipCloseCondition close_tooltip, uint paramcount = 0);
+void GuiShowTooltips(Window *parent, EncodedString &&text, TooltipCloseCondition close_tooltip);
 
 /* widget.cpp */
 WidgetID GetWidgetFromPos(const Window *w, int x, int y);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

__Part ~~1~~ something... of my exterminate-global-parameters series.__

Global parameters, and local parameter storage. Global parameters have long been an issue. They are not cleared between calls and could contain stale data that causes formatting issues and crashes. Trying to fix this by simply clearing the global parameters everywhere is an impossible task because it cannot really be forced.

Local parameter storage...

When creating tooltips and texteffects, we set string parameters in global parameters, and then the tooltip/texteffect systems copy the global parameters into local storage, which is hopefully big enough -- it's a vector but we don't really know how many parameters there will be.

When layouting/drawing the tooltip/texteffect, the local storage needs to be copied back to global parameters, and formatted.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead of fiddling with saving and loading parameters, introduce encoded strings for regular strings. This system already exists for Game Script text. For clarify and safety, the EncodedString class contains strings encoded by GetEncodedString().

The advantage of EncodedStrings over raw strings is they use current language and parameter values at the point of decoding.

Tooltips and texteffects now accept and store an EncodedString. No separate storage or guessing of parameter count is needed.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This is less efficient when there are no parameters, as previously just a 32 bit StringID was used, but with EncodedStrings we need to encode this into the encoded string by itself.

EncodedStrings will be used in more places but the changes for that are larger.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
