### PR TITLE
Codechange: A transparent FrameRect doesn't care about colours.

### DIFF
--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -282,16 +282,15 @@ WidgetID GetWidgetFromPos(const Window *w, int x, int y)
  */
 void DrawFrameRect(int left, int top, int right, int bottom, Colours colour, FrameFlags flags)
 {
-	assert(colour < COLOUR_END);
-
-	uint dark         = GetColourGradient(colour, SHADE_DARK);
-	uint medium_dark  = GetColourGradient(colour, SHADE_LIGHT);
-	uint medium_light = GetColourGradient(colour, SHADE_LIGHTER);
-	uint light        = GetColourGradient(colour, SHADE_LIGHTEST);
-
 	if (flags & FR_TRANSPARENT) {
 		GfxFillRect(left, top, right, bottom, PALETTE_TO_TRANSPARENT, FILLRECT_RECOLOUR);
 	} else {
+		assert(colour < COLOUR_END);
+
+		const uint dark         = GetColourGradient(colour, SHADE_DARK);
+		const uint medium_dark  = GetColourGradient(colour, SHADE_LIGHT);
+		const uint medium_light = GetColourGradient(colour, SHADE_LIGHTER);
+		const uint light        = GetColourGradient(colour, SHADE_LIGHTEST);
 		uint interior;
 
 		Rect outer = {left, top, right, bottom};                   // Outside rectangle


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When using `DrawFrameRect` with the `FR_TRANSPARENT` flag, a valid colour must be provided, even though no colour is used.

The different colour shades are also set up, and then not used.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Completely ignore the colour parameter when `FR_TRANSPARENT` is set, and only set the shades up when needed.

This doesn't really affect anything much currently, but I tripped over it when refactoring somewhere else.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
