### PR TITLE
Implement 2D scrolling under SDL2

### DIFF
--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -127,10 +127,10 @@ struct CursorVars {
 	int wheel;                    ///< mouse wheel movement
 	bool fix_at;                  ///< mouse is moving, but cursor is not (used for scrolling)
 
-	/* We need two different vars to keep track of how far the scrollwheel moved.
-	 * OSX uses this for scrolling around the map. */
-	int v_wheel;
-	int h_wheel;
+	/* 2D wheel scrolling for moving around the map */
+	bool wheel_moved;
+	float v_wheel;
+	float h_wheel;
 
 	/* Mouse appearance */
 	std::vector<CursorSprite> sprites; ///< Sprites comprising cursor.

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -763,8 +763,9 @@ void CocoaDialog(const char *title, const char *message, const char *buttonLabel
 		deltaY = [ event deltaY ] * 5;
 	}
 
-	_cursor.h_wheel -= (int)(deltaX * _settings_client.gui.scrollwheel_multiplier);
-	_cursor.v_wheel -= (int)(deltaY * _settings_client.gui.scrollwheel_multiplier);
+	_cursor.h_wheel -= static_cast<float>(deltaX * _settings_client.gui.scrollwheel_multiplier);
+	_cursor.v_wheel -= static_cast<float>(deltaY * _settings_client.gui.scrollwheel_multiplier);
+	_cursor.wheel_moved = true;
 }
 
 - (void)magnifyWithEvent:(NSEvent *)event

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -404,13 +404,25 @@ bool VideoDriver_SDL_Base::PollEvent()
 			break;
 		}
 
-		case SDL_MOUSEWHEEL:
+		case SDL_MOUSEWHEEL: {
 			if (ev.wheel.y > 0) {
 				_cursor.wheel--;
 			} else if (ev.wheel.y < 0) {
 				_cursor.wheel++;
 			}
+
+			/* Handle 2D scrolling. */
+			const float SCROLL_BUILTIN_MULTIPLIER = 14.0f;
+#if SDL_VERSION_ATLEAST(2, 18, 0)
+			_cursor.v_wheel -= ev.wheel.preciseY * SCROLL_BUILTIN_MULTIPLIER * _settings_client.gui.scrollwheel_multiplier;
+			_cursor.h_wheel += ev.wheel.preciseX * SCROLL_BUILTIN_MULTIPLIER * _settings_client.gui.scrollwheel_multiplier;
+#else
+			_cursor.v_wheel -= static_cast<float>(ev.wheel.y * SCROLL_BUILTIN_MULTIPLIER * _settings_client.gui.scrollwheel_multiplier);
+			_cursor.h_wheel += static_cast<float>(ev.wheel.x * SCROLL_BUILTIN_MULTIPLIER * _settings_client.gui.scrollwheel_multiplier);
+#endif
+			_cursor.wheel_moved = true;
 			break;
+		}
 
 		case SDL_MOUSEBUTTONDOWN:
 			if (_rightclick_emulate && SDL_GetModState() & KMOD_CTRL) {


### PR DESCRIPTION
## Motivation / Problem

Dragging map around with two fingers on touchpad feels really good (aka makes OpenTTD actually playable on it), but was restricted to Mac OS up until now. Since SDL2 supports 2D scrolling just fine, add it to the cross-platform driver.

Fixes #13167 and switches to floats for 2D scroll state tracking to ensure it's as smooth as possible.

## Description

Reworks 2D scrolling tracking to use floats - fractional parts are kept between frames, so a new bool is introduced to mark if there's a need to handle the scrolling (as opposed to just comparing to zero like before). SDL2 support itself is fairly straightforward, aside from needing to use a multiplier to make the configurable sensitivity range compatible with the existing option.

## Limitations

* Haven't tested this extensively - it definitely works, but extra testing is probably in order
* * Played with it for a while without running into any issues, but keep in mind I wasn't actively trying to break it either
* SDL2 < 2.18.0 does not support precise scrolling - it still works, but feels much less nice
* X11 does not support precise scrolling no matter what, so make sure to set `SDL_VIDEODRIVER=wayland` for smooth experience (see also: https://github.com/libsdl-org/SDL/pull/5382)
* Does not add support to any of the non-SDL2 drivers, of course
* I can't report how does default speed compare to that on Apple devices, only that it seems sensible to me

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
