### PR TITLE
Fix #13105, Fix #12333: Ship pathfinder always considers reversing

### DIFF
--- a/src/pathfinder/yapf/yapf.h
+++ b/src/pathfinder/yapf/yapf.h
@@ -20,11 +20,10 @@
 /**
  * Finds the best path for given ship using YAPF.
  * @param v        the ship that needs to find a path
- * @param tile     the tile to find the path from (should be next tile the ship is about to enter)
  * @param path_found [out] Whether a path has been found (true) or has been guessed (false)
- * @return         the best trackdir for next turn or INVALID_TRACK if the path could not be found
+ * @return         the best trackdir for next turn. This includes potential reverse directions.
  */
-Track YapfShipChooseTrack(const Ship *v, TileIndex tile, bool &path_found, ShipPathCache &path_cache);
+Trackdir YapfShipChooseTrack(const Ship *v, bool &path_found, ShipPathCache &path_cache);
 
 /**
  * Returns true if it is better to reverse the ship before leaving depot using YAPF.
@@ -32,7 +31,7 @@ Track YapfShipChooseTrack(const Ship *v, TileIndex tile, bool &path_found, ShipP
  * @param trackdir [out] the best of all possible reversed trackdirs
  * @return true if reversing is better
  */
-bool YapfShipCheckReverse(const Ship *v, Trackdir *trackdir);
+bool YapfShipCheckReverse(const Ship *v, Trackdir &trackdir);
 
 /**
  * Finds the best path for given road vehicle using YAPF.

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -367,7 +367,7 @@ static Vehicle *EnsureNoMovingShipProc(Vehicle *v, void *)
 	return v->type == VEH_SHIP && v->cur_speed != 0 ? v : nullptr;
 }
 
-static bool CheckReverseShip(const Ship *v, Trackdir *trackdir = nullptr)
+static bool CheckReverseShip(const Ship *v, Trackdir &trackdir)
 {
 	/* Ask pathfinder for best direction */
 	return YapfShipCheckReverse(v, trackdir);
@@ -405,7 +405,8 @@ static bool CheckShipLeaveDepot(Ship *v)
 	TrackBits north_tracks = DiagdirReachesTracks(north_dir) & GetTileShipTrackStatus(north_neighbour);
 	TrackBits south_tracks = DiagdirReachesTracks(south_dir) & GetTileShipTrackStatus(south_neighbour);
 	if (north_tracks && south_tracks) {
-		if (CheckReverseShip(v)) north_tracks = TRACK_BIT_NONE;
+		Trackdir dummy_trackdir;
+		if (CheckReverseShip(v, dummy_trackdir)) north_tracks = TRACK_BIT_NONE;
 	}
 
 	if (north_tracks) {
@@ -488,54 +489,39 @@ static void ShipArrivesAt(const Vehicle *v, Station *st)
  * Runs the pathfinder to choose a track to continue along.
  *
  * @param v Ship to navigate
- * @param tile Tile, the ship is about to enter
- * @param tracks Available track choices on \a tile
- * @return Track to choose, or INVALID_TRACK when to reverse.
+ * @param trackdirs Available trackdir choices on the vehicle's type
+ * @return Trackdir to choose
  */
-static Track ChooseShipTrack(Ship *v, TileIndex tile, TrackBits tracks)
+static Trackdir ChooseShipTrack(Ship *v, TrackdirBits trackdirs)
 {
 	bool path_found = true;
-	Track track;
+	Trackdir trackdir;
 
 	if (v->dest_tile == 0) {
 		/* No destination, don't invoke pathfinder. */
-		track = TrackBitsToTrack(v->state);
-		if (!IsDiagonalTrack(track)) track = TrackToOppositeTrack(track);
-		if (!HasBit(tracks, track)) track = FindFirstTrack(tracks);
+		trackdir = FindFirstTrackdir(trackdirs);
+		if (trackdir == INVALID_TRACKDIR) trackdir = ReverseTrackdir(v->GetVehicleTrackdir());
 		path_found = false;
 	} else {
 		/* Attempt to follow cached path. */
 		if (!v->path.empty()) {
-			track = TrackdirToTrack(v->path.back().trackdir);
+			trackdir = v->path.back().trackdir;
 
-			if (HasBit(tracks, track)) {
+			if (HasBit(trackdirs, trackdir)) {
 				v->path.pop_back();
 				/* HandlePathfindResult() is not called here because this is not a new pathfinder result. */
-				return track;
+				return trackdir;
 			}
 
 			/* Cached path is invalid so continue with pathfinder. */
 			v->path.clear();
 		}
 
-		track = YapfShipChooseTrack(v, tile, path_found, v->path);
+		trackdir = YapfShipChooseTrack(v, path_found, v->path);
 	}
 
 	v->HandlePathfindingResult(path_found);
-	return track;
-}
-
-/**
- * Get the available water tracks on a tile for a ship entering a tile.
- * @param tile The tile about to enter.
- * @param dir The entry direction.
- * @return The available trackbits on the next tile.
- */
-static inline TrackBits GetAvailShipTracks(TileIndex tile, DiagDirection dir)
-{
-	TrackBits tracks = GetTileShipTrackStatus(tile) & DiagdirReachesTracks(dir);
-
-	return tracks;
+	return trackdir;
 }
 
 /** Structure for ship sub-coordinate data for moving into a new tile via a Diagdir onto a Track. */
@@ -705,7 +691,8 @@ static void ShipController(Ship *v)
 
 	if (v->vehstatus & VS_STOPPED) return;
 
-	if (ProcessOrders(v) && CheckReverseShip(v)) return ReverseShip(v);
+	Trackdir best_reverse_dir = INVALID_TRACKDIR;
+	if (ProcessOrders(v) && CheckReverseShip(v, best_reverse_dir)) return ReverseShipIntoTrackdir(v, best_reverse_dir);
 
 	v->HandleLoading();
 
@@ -793,19 +780,14 @@ static void ShipController(Ship *v)
 
 				const DiagDirection diagdir = DiagdirBetweenTiles(gp.old_tile, gp.new_tile);
 				assert(diagdir != INVALID_DIAGDIR);
-				const TrackBits tracks = GetAvailShipTracks(gp.new_tile, diagdir);
-				if (tracks == TRACK_BIT_NONE) {
-					Trackdir trackdir = INVALID_TRACKDIR;
-					CheckReverseShip(v, &trackdir);
-					if (trackdir == INVALID_TRACKDIR) return ReverseShip(v);
-					return ReverseShipIntoTrackdir(v, trackdir);
-				}
+				const TrackdirBits forward_trackdirs = TrackBitsToTrackdirBits(GetTileShipTrackStatus(gp.new_tile)) & DiagdirReachesTrackdirs(diagdir);
 
-				/* Choose a direction, and continue if we find one */
-				const Track track = ChooseShipTrack(v, gp.new_tile, tracks);
-				if (track == INVALID_TRACK) return ReverseShip(v);
+				/* Choose a direction, which might require a reversal */
+				const Trackdir new_trackdir = ChooseShipTrack(v, forward_trackdirs);
+				assert(new_trackdir != INVALID_TRACKDIR);
+				if (!HasBit(forward_trackdirs, new_trackdir)) return ReverseShipIntoTrackdir(v, new_trackdir);
 
-				const ShipSubcoordData &b = _ship_subcoord[diagdir][track];
+				const ShipSubcoordData &b = _ship_subcoord[diagdir][TrackdirToTrack(new_trackdir)];
 
 				gp.x = (gp.x & ~0xF) | b.x_subcoord;
 				gp.y = (gp.y & ~0xF) | b.y_subcoord;
@@ -816,7 +798,7 @@ static void ShipController(Ship *v)
 
 				if (!HasBit(r, VETS_ENTERED_WORMHOLE)) {
 					v->tile = gp.new_tile;
-					v->state = TrackToTrackBits(track);
+					v->state = TrackToTrackBits(TrackdirToTrack(new_trackdir));
 
 					/* Update ship cache when the water class changes. Aqueducts are always canals. */
 					if (GetEffectiveWaterClass(gp.old_tile) != GetEffectiveWaterClass(gp.new_tile)) v->UpdateCache();


### PR DESCRIPTION
## Motivation / Problem

I've already attempted this in #12335 . I bit off too much to chew and there were some problems with my solution. This is attempt number two. Most of the text is also repurposed from that PR.

Fixes #13105, #12333, and to some extent even #13164, although that one still looks a bit clumsy.


## Description

Except for specific situations such as leaving a dock, the low-level ship pathfinder only considers the forward direction as an option. However, the high-level pathfinder doesn't (and can't) take the ship direction into account, it only knows whether tiles of water are interconnected or not. This means that there are certain situations where there high-level pathfinder returns a path that requires a reversal, but the low-level pathfinder doesn't consider that reversal to be an option.

The solution is to always give the ship the option to reverse. A slight penalty was added to make ships prefer moving forward, mostly because a ship turning in a circle looks nicer than turning on the spot.

## Limitations

- In theory ships can now turn around whenever they want, even mid-journey between two docks for example. I ran some tests and never saw this happen, but that doesn't mean it couldn't happen
- An unintended consequence of this change is that ships are now able to turn around in long canals / rivers if you decide to skip the order. Previously they had to go all the way to the end of the canal before they could turn around. IMO it's an improvement, but it might be considered "changing the gameplay".
- Things are different -> pitchforks

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
