### PR TITLE
Change: Include new cargo classes in dump cargo types console command

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2692,6 +2692,11 @@ static void ConDumpCargoTypes()
 	IConsolePrint(CC_DEFAULT, "    r = refrigerated");
 	IConsolePrint(CC_DEFAULT, "    h = hazardous");
 	IConsolePrint(CC_DEFAULT, "    c = covered/sheltered");
+	IConsolePrint(CC_DEFAULT, "    o = oversized");
+	IConsolePrint(CC_DEFAULT, "    d = powderized");
+	IConsolePrint(CC_DEFAULT, "    n = not pourable");
+	IConsolePrint(CC_DEFAULT, "    e = potable");
+	IConsolePrint(CC_DEFAULT, "    i = non-potable");
 	IConsolePrint(CC_DEFAULT, "    S = special");
 
 	std::map<uint32_t, const GRFFile *> grfs;
@@ -2703,7 +2708,7 @@ static void ConDumpCargoTypes()
 			grfid = grf->grfid;
 			grfs.emplace(grfid, grf);
 		}
-		IConsolePrint(CC_DEFAULT, "  {:02d} Bit: {:2d}, Label: {}, Callback mask: 0x{:02X}, Cargo class: {}{}{}{}{}{}{}{}{}{}{}, GRF: {:08X}, {}",
+		IConsolePrint(CC_DEFAULT, "  {:02d} Bit: {:2d}, Label: {}, Callback mask: 0x{:02X}, Cargo class: {}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}, GRF: {:08X}, {}",
 				spec->Index(),
 				spec->bitnum,
 				FormatLabel(spec->label.base()),
@@ -2718,6 +2723,11 @@ static void ConDumpCargoTypes()
 				(spec->classes & CC_REFRIGERATED) != 0 ? 'r' : '-',
 				(spec->classes & CC_HAZARDOUS)    != 0 ? 'h' : '-',
 				(spec->classes & CC_COVERED)      != 0 ? 'c' : '-',
+				(spec->classes & CC_OVERSIZED)    != 0 ? 'o' : '-',
+				(spec->classes & CC_POWDERIZED)   != 0 ? 'd' : '-',
+				(spec->classes & CC_NOT_POURABLE) != 0 ? 'n' : '-',
+				(spec->classes & CC_POTABLE)      != 0 ? 'e' : '-',
+				(spec->classes & CC_NON_POTABLE)  != 0 ? 'i' : '-',
 				(spec->classes & CC_SPECIAL)      != 0 ? 'S' : '-',
 				BSWAP32(grfid),
 				GetStringPtr(spec->name)


### PR DESCRIPTION
## Motivation / Problem

`dumpinfo cargotypes` does not include the new cargo classes.

## Description

Add the new cargo classes to `dumpinfo cargotypes`.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
