### PR TITLE
Update: vcpkg baseline

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -53,5 +53,5 @@
       "name": "zlib"
     }
   ],
-  "builtin-baseline": "94cf042e6b7713913a3b3150f3ca3d0f4550f7c4"
+  "builtin-baseline": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c"
 }


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
manylinux_2_28 has been updated to use gcc14 (https://github.com/pypa/manylinux/pull/1730/files).
This update cause vcpkg to fail to build `breakpad`:
```
[85/90] /opt/rh/gcc-toolset-14/root/usr/bin/c++ -DHAVE_A_OUT_H -DHAVE_GETCONTEXT=1 -DNOMINMAX -DUNICODE -DWIN32_LEAN_AND_MEAN -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -I/vcpkg/buildtrees/breakpad/src/2023.01.27-5f635e6695.clean/src -isystem /Openttd/build/vcpkg_installed/x64-linux/include -fPIC -g -std=gnu++17 -MD -MT CMakeFiles/libbreakpad_client.dir/src/common/module.cc.o -MF CMakeFiles/libbreakpad_client.dir/src/common/module.cc.o.d -o CMakeFiles/libbreakpad_client.dir/src/common/module.cc.o -c /vcpkg/buildtrees/breakpad/src/2023.01.27-5f635e6695.clean/src/common/module.cc
FAILED: CMakeFiles/libbreakpad_client.dir/src/common/module.cc.o 
/opt/rh/gcc-toolset-14/root/usr/bin/c++ -DHAVE_A_OUT_H -DHAVE_GETCONTEXT=1 -DNOMINMAX -DUNICODE -DWIN32_LEAN_AND_MEAN -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -I/vcpkg/buildtrees/breakpad/src/2023.01.27-5f635e6695.clean/src -isystem /Openttd/build/vcpkg_installed/x64-linux/include -fPIC -g -std=gnu++17 -MD -MT CMakeFiles/libbreakpad_client.dir/src/common/module.cc.o -MF CMakeFiles/libbreakpad_client.dir/src/common/module.cc.o.d -o CMakeFiles/libbreakpad_client.dir/src/common/module.cc.o -c /vcpkg/buildtrees/breakpad/src/2023.01.27-5f635e6695.clean/src/common/module.cc
/vcpkg/buildtrees/breakpad/src/2023.01.27-5f635e6695.clean/src/common/module.cc: In member function ‘bool google_breakpad::Module::AddFunction(Function*)’:
/vcpkg/buildtrees/breakpad/src/2023.01.27-5f635e6695.clean/src/common/module.cc:171:52: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
  171 |     FunctionSet::iterator existing_function = std::find_if(
      |                                                    ^~~~~~~
      |                                                    find
```
Looks very similar to https://github.com/microsoft/vcpkg/issues/39054 and is fixed with https://github.com/microsoft/vcpkg/pull/39059, so why does it still happen? It's because our vcpkg baseline is from before the fixes (we still use version 2023.01.27 while 2023.06.01 is available and fixes are applied to it).
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Update the baseline to use the updated and fixed `breakpad`.
I decided to use the hash of https://github.com/microsoft/vcpkg/releases/tag/2024.11.16, it's recent and should be more stable than any hash from current master.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
