### PR TITLE
Codechange: Use snake_case and structured binding for layouters' font map.

### DIFF
--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -68,11 +68,11 @@ static inline void GetLayouter(Layouter::LineCacheItem &line, std::string_view s
 	typename T::CharType *buff_begin = MallocT<typename T::CharType>(str.size() + 1);
 	const typename T::CharType *buffer_last = buff_begin + str.size() + 1;
 	typename T::CharType *buff = buff_begin;
-	FontMap &fontMapping = line.runs;
+	FontMap &font_mapping = line.runs;
 	Font *f = Layouter::GetFont(state.fontsize, state.cur_colour);
 
 	line.buffer = buff_begin;
-	fontMapping.clear();
+	font_mapping.clear();
 
 	auto cur = str.begin();
 
@@ -105,8 +105,8 @@ static inline void GetLayouter(Layouter::LineCacheItem &line, std::string_view s
 			continue;
 		}
 
-		if (fontMapping.empty() || fontMapping.back().first != buff - buff_begin) {
-			fontMapping.emplace_back(buff - buff_begin, f);
+		if (font_mapping.empty() || font_mapping.back().first != buff - buff_begin) {
+			font_mapping.emplace_back(buff - buff_begin, f);
 		}
 		f = Layouter::GetFont(state.fontsize, state.cur_colour);
 	}
@@ -114,10 +114,10 @@ static inline void GetLayouter(Layouter::LineCacheItem &line, std::string_view s
 	/* Better safe than sorry. */
 	*buff = '\0';
 
-	if (fontMapping.empty() || fontMapping.back().first != buff - buff_begin) {
-		fontMapping.emplace_back(buff - buff_begin, f);
+	if (font_mapping.empty() || font_mapping.back().first != buff - buff_begin) {
+		font_mapping.emplace_back(buff - buff_begin, f);
 	}
-	line.layout = T::GetParagraphLayout(buff_begin, buff, fontMapping);
+	line.layout = T::GetParagraphLayout(buff_begin, buff, font_mapping);
 	line.state_after = state;
 }
 

--- a/src/gfx_layout_fallback.cpp
+++ b/src/gfx_layout_fallback.cpp
@@ -79,12 +79,12 @@ public:
  * Get the actual ParagraphLayout for the given buffer.
  * @param buff The begin of the buffer.
  * @param buff_end The location after the last element in the buffer.
- * @param fontMapping THe mapping of the fonts.
+ * @param font_mapping The mapping of the fonts.
  * @return The ParagraphLayout instance.
  */
-/* static */ std::unique_ptr<ParagraphLayouter> FallbackParagraphLayoutFactory::GetParagraphLayout(char32_t *buff, char32_t *buff_end, FontMap &fontMapping)
+/* static */ std::unique_ptr<ParagraphLayouter> FallbackParagraphLayoutFactory::GetParagraphLayout(char32_t *buff, char32_t *buff_end, FontMap &font_mapping)
 {
-	return std::make_unique<FallbackParagraphLayout>(buff, buff_end - buff, fontMapping);
+	return std::make_unique<FallbackParagraphLayout>(buff, buff_end - buff, font_mapping);
 }
 
 /**

--- a/src/gfx_layout_fallback.h
+++ b/src/gfx_layout_fallback.h
@@ -22,7 +22,7 @@ public:
 	/** Helper for GetLayouter, to get whether the layouter supports RTL. */
 	static const bool SUPPORTS_RTL = false;
 
-	static std::unique_ptr<ParagraphLayouter> GetParagraphLayout(char32_t *buff, char32_t *buff_end, FontMap &fontMapping);
+	static std::unique_ptr<ParagraphLayouter> GetParagraphLayout(char32_t *buff, char32_t *buff_end, FontMap &font_mapping);
 	static size_t AppendToBuffer(char32_t *buff, const char32_t *buffer_last, char32_t c);
 };
 

--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -338,12 +338,12 @@ std::vector<ICURun> ItemizeStyle(std::vector<ICURun> &runs_current, FontMap &fon
 
 	int cur_pos = 0;
 	auto cur_run = runs_current.begin();
-	for (auto const &font_map : font_mapping) {
-		while (cur_pos < font_map.first && cur_run != runs_current.end()) {
-			int stop_pos = std::min(font_map.first, cur_run->start + cur_run->length);
+	for (auto const &[position, font] : font_mapping) {
+		while (cur_pos < position && cur_run != runs_current.end()) {
+			int stop_pos = std::min(position, cur_run->start + cur_run->length);
 			assert(stop_pos - cur_pos > 0);
 
-			runs.emplace_back(cur_pos, stop_pos - cur_pos, cur_run->level, cur_run->script, font_map.second);
+			runs.emplace_back(cur_pos, stop_pos - cur_pos, cur_run->level, cur_run->script, font);
 
 			if (stop_pos == cur_run->start + cur_run->length) cur_run++;
 			cur_pos = stop_pos;
@@ -360,8 +360,8 @@ std::vector<ICURun> ItemizeStyle(std::vector<ICURun> &runs_current, FontMap &fon
 	if (length == 0) return nullptr;
 
 	/* Can't layout our in-built sprite fonts. */
-	for (auto const &pair : font_mapping) {
-		if (pair.second->fc->IsBuiltInFont()) return nullptr;
+	for (auto const &[position, font] : font_mapping) {
+		if (font->fc->IsBuiltInFont()) return nullptr;
 	}
 
 	auto runs = ItemizeBidi(buff, length);

--- a/src/gfx_layout_icu.h
+++ b/src/gfx_layout_icu.h
@@ -25,7 +25,7 @@ public:
 	/** Helper for GetLayouter, to get whether the layouter supports RTL. */
 	static const bool SUPPORTS_RTL = true;
 
-	static std::unique_ptr<ParagraphLayouter> GetParagraphLayout(UChar *buff, UChar *buff_end, FontMap &fontMapping);
+	static std::unique_ptr<ParagraphLayouter> GetParagraphLayout(UChar *buff, UChar *buff_end, FontMap &font_mapping);
 	static size_t AppendToBuffer(UChar *buff, const UChar *buffer_last, char32_t c);
 
 	static void InitializeLayouter();

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -157,8 +157,8 @@ static CTRunDelegateCallbacks _sprite_font_callback = {
 	if (length == 0) return nullptr;
 
 	/* Can't layout our in-built sprite fonts. */
-	for (const auto &i : font_mapping) {
-		if (i.second->fc->IsBuiltInFont()) return nullptr;
+	for (const auto &[position, font] : font_mapping) {
+		if (font->fc->IsBuiltInFont()) return nullptr;
 	}
 
 	/* Make attributed string with embedded font information. */
@@ -174,35 +174,35 @@ static CTRunDelegateCallbacks _sprite_font_callback = {
 	/* Apply font and colour ranges to our string. This is important to make sure
 	 * that we get proper glyph boundaries on style changes. */
 	int last = 0;
-	for (const auto &i : font_mapping) {
-		if (i.first - last == 0) continue;
+	for (const auto &[position, font] : font_mapping) {
+		if (position - last == 0) continue;
 
-		CTFontRef font = (CTFontRef)i.second->fc->GetOSHandle();
-		if (font == nullptr) {
-			if (!_font_cache[i.second->fc->GetSize()]) {
+		CTFontRef font_handle = static_cast<CTFontRef>(font->fc->GetOSHandle());
+		if (font_handle == nullptr) {
+			if (!_font_cache[font->fc->GetSize()]) {
 				/* Cache font information. */
-				CFAutoRelease<CFStringRef> font_name(CFStringCreateWithCString(kCFAllocatorDefault, i.second->fc->GetFontName().c_str(), kCFStringEncodingUTF8));
-				_font_cache[i.second->fc->GetSize()].reset(CTFontCreateWithName(font_name.get(), i.second->fc->GetFontSize(), nullptr));
+				CFAutoRelease<CFStringRef> font_name(CFStringCreateWithCString(kCFAllocatorDefault, font->fc->GetFontName().c_str(), kCFStringEncodingUTF8));
+				_font_cache[font->fc->GetSize()].reset(CTFontCreateWithName(font_name.get(), font->fc->GetFontSize(), nullptr));
 			}
-			font = _font_cache[i.second->fc->GetSize()].get();
+			font_handle = _font_cache[font->fc->GetSize()].get();
 		}
-		CFAttributedStringSetAttribute(str.get(), CFRangeMake(last, i.first - last), kCTFontAttributeName, font);
+		CFAttributedStringSetAttribute(str.get(), CFRangeMake(last, position - last), kCTFontAttributeName, font_handle);
 
-		CGColorRef color = CGColorCreateGenericGray((uint8_t)i.second->colour / 255.0f, 1.0f); // We don't care about the real colours, just that they are different.
-		CFAttributedStringSetAttribute(str.get(), CFRangeMake(last, i.first - last), kCTForegroundColorAttributeName, color);
+		CGColorRef color = CGColorCreateGenericGray((uint8_t)font->colour / 255.0f, 1.0f); // We don't care about the real colours, just that they are different.
+		CFAttributedStringSetAttribute(str.get(), CFRangeMake(last, position - last), kCTForegroundColorAttributeName, color);
 		CGColorRelease(color);
 
 		/* Install a size callback for our special private-use sprite glyphs in case the font does not provide them. */
-		for (ssize_t c = last; c < i.first; c++) {
-			if (buff[c] >= SCC_SPRITE_START && buff[c] <= SCC_SPRITE_END && i.second->fc->MapCharToGlyph(buff[c], false) == 0) {
-				CFAutoRelease<CTRunDelegateRef> del(CTRunDelegateCreate(&_sprite_font_callback, (void *)(size_t)(buff[c] | (i.second->fc->GetSize() << 24))));
+		for (ssize_t c = last; c < position; c++) {
+			if (buff[c] >= SCC_SPRITE_START && buff[c] <= SCC_SPRITE_END && font->fc->MapCharToGlyph(buff[c], false) == 0) {
+				CFAutoRelease<CTRunDelegateRef> del(CTRunDelegateCreate(&_sprite_font_callback, (void *)(size_t)(buff[c] | (font->fc->GetSize() << 24))));
 				/* According to the offical documentation, if a run delegate is used, the char should always be 0xFFFC. */
 				CFAttributedStringReplaceString(str.get(), CFRangeMake(c, 1), replacment_str.get());
 				CFAttributedStringSetAttribute(str.get(), CFRangeMake(c, 1), kCTRunDelegateAttributeName, del.get());
 			}
 		}
 
-		last = i.first;
+		last = position;
 	}
 	CFAttributedStringEndEditing(str.get());
 

--- a/src/os/macosx/string_osx.h
+++ b/src/os/macosx/string_osx.h
@@ -49,10 +49,10 @@ public:
 	 * Get the actual ParagraphLayout for the given buffer.
 	 * @param buff The begin of the buffer.
 	 * @param buff_end The location after the last element in the buffer.
-	 * @param fontMapping THe mapping of the fonts.
+	 * @param font_mapping The mapping of the fonts.
 	 * @return The ParagraphLayout instance.
 	 */
-	static std::unique_ptr<ParagraphLayouter> GetParagraphLayout(CharType *buff, CharType *buff_end, FontMap &fontMapping);
+	static std::unique_ptr<ParagraphLayouter> GetParagraphLayout(CharType *buff, CharType *buff_end, FontMap &font_mapping);
 
 	/**
 	 * Append a wide character to the internal buffer.

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -276,14 +276,14 @@ static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutF
 	return items;
 }
 
-/* static */ std::unique_ptr<ParagraphLayouter> UniscribeParagraphLayoutFactory::GetParagraphLayout(CharType *buff, CharType *buff_end, FontMap &fontMapping)
+/* static */ std::unique_ptr<ParagraphLayouter> UniscribeParagraphLayoutFactory::GetParagraphLayout(CharType *buff, CharType *buff_end, FontMap &font_mapping)
 {
 	int32_t length = buff_end - buff;
 	/* Can't layout an empty string. */
 	if (length == 0) return nullptr;
 
 	/* Can't layout our in-built sprite fonts. */
-	for (auto const &pair : fontMapping) {
+	for (auto const &pair : font_mapping) {
 		if (pair.second->fc->IsBuiltInFont()) return nullptr;
 	}
 
@@ -297,7 +297,7 @@ static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutF
 
 	int cur_pos = 0;
 	std::vector<SCRIPT_ITEM>::iterator cur_item = items.begin();
-	for (auto const &i : fontMapping) {
+	for (auto const &i : font_mapping) {
 		while (cur_pos < i.first && cur_item != items.end() - 1) {
 			/* Add a range that spans the intersection of the remaining item and font run. */
 			int stop_pos = std::min(i.first, (cur_item + 1)->iCharPos);

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -283,8 +283,8 @@ static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutF
 	if (length == 0) return nullptr;
 
 	/* Can't layout our in-built sprite fonts. */
-	for (auto const &pair : font_mapping) {
-		if (pair.second->fc->IsBuiltInFont()) return nullptr;
+	for (auto const &[position, font] : font_mapping) {
+		if (font->fc->IsBuiltInFont()) return nullptr;
 	}
 
 	/* Itemize text. */
@@ -297,12 +297,12 @@ static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutF
 
 	int cur_pos = 0;
 	std::vector<SCRIPT_ITEM>::iterator cur_item = items.begin();
-	for (auto const &i : font_mapping) {
-		while (cur_pos < i.first && cur_item != items.end() - 1) {
+	for (auto const &[position, font] : font_mapping) {
+		while (cur_pos < position && cur_item != items.end() - 1) {
 			/* Add a range that spans the intersection of the remaining item and font run. */
-			int stop_pos = std::min(i.first, (cur_item + 1)->iCharPos);
+			int stop_pos = std::min(position, (cur_item + 1)->iCharPos);
 			assert(stop_pos - cur_pos > 0);
-			ranges.emplace_back(cur_pos, stop_pos - cur_pos, i.second, cur_item->a);
+			ranges.emplace_back(cur_pos, stop_pos - cur_pos, font, cur_item->a);
 
 			/* Shape the range. */
 			if (!UniscribeShapeRun(buff, ranges.back())) {

--- a/src/os/windows/string_uniscribe.h
+++ b/src/os/windows/string_uniscribe.h
@@ -31,10 +31,10 @@ public:
 	 * Get the actual ParagraphLayout for the given buffer.
 	 * @param buff The begin of the buffer.
 	 * @param buff_end The location after the last element in the buffer.
-	 * @param fontMapping THe mapping of the fonts.
+	 * @param font_mapping The mapping of the fonts.
 	 * @return The ParagraphLayout instance.
 	 */
-	static std::unique_ptr<ParagraphLayouter> GetParagraphLayout(CharType *buff, CharType *buff_end, FontMap &fontMapping);
+	static std::unique_ptr<ParagraphLayouter> GetParagraphLayout(CharType *buff, CharType *buff_end, FontMap &font_mapping);
 
 	/**
 	 * Append a wide character to the internal buffer.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

* Use of camelCase instead of snake_case for the FontMap variables/parameters.
* When iterating FontMap, lots of `.first` and `.second` access.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

* Change `fontMapping` to `font_mapping`
* Use structured binding to make code clearer.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
