### PR TITLE
Codechange: use (better) named constants for the bridge sprite table

### DIFF
--- a/src/bridge.h
+++ b/src/bridge.h
@@ -27,12 +27,13 @@ enum BridgePieces {
 	BRIDGE_PIECE_MIDDLE_ODD,
 	BRIDGE_PIECE_MIDDLE_EVEN,
 	BRIDGE_PIECE_HEAD,
-	BRIDGE_PIECE_INVALID,
+	NUM_BRIDGE_PIECES,
 };
 
 DECLARE_POSTFIX_INCREMENT(BridgePieces)
 
 static const uint MAX_BRIDGES = 13; ///< Maximal number of available bridge specs.
+constexpr uint SPRITES_PER_BRIDGE_PIECE = 32; ///< Number of sprites there are per bridge piece.
 
 typedef uint BridgeType; ///< Bridge spec number.
 

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -2292,21 +2292,21 @@ static ChangeInfoResult BridgeChangeInfo(uint brid, int numinfo, int prop, ByteR
 
 				if (bridge->sprite_table == nullptr) {
 					/* Allocate memory for sprite table pointers and zero out */
-					bridge->sprite_table = CallocT<PalSpriteID*>(7);
+					bridge->sprite_table = CallocT<PalSpriteID*>(NUM_BRIDGE_PIECES);
 				}
 
 				for (; numtables-- != 0; tableid++) {
-					if (tableid >= 7) { // skip invalid data
-						GrfMsg(1, "BridgeChangeInfo: Table {} >= 7, skipping", tableid);
-						for (uint8_t sprite = 0; sprite < 32; sprite++) buf.ReadDWord();
+					if (tableid >= NUM_BRIDGE_PIECES) { // skip invalid data
+						GrfMsg(1, "BridgeChangeInfo: Table {} >= {}, skipping", tableid, NUM_BRIDGE_PIECES);
+						for (uint8_t sprite = 0; sprite < SPRITES_PER_BRIDGE_PIECE; sprite++) buf.ReadDWord();
 						continue;
 					}
 
 					if (bridge->sprite_table[tableid] == nullptr) {
-						bridge->sprite_table[tableid] = MallocT<PalSpriteID>(32);
+						bridge->sprite_table[tableid] = MallocT<PalSpriteID>(SPRITES_PER_BRIDGE_PIECE);
 					}
 
-					for (uint8_t sprite = 0; sprite < 32; sprite++) {
+					for (uint8_t sprite = 0; sprite < SPRITES_PER_BRIDGE_PIECE; sprite++) {
 						SpriteID image = buf.ReadWord();
 						PaletteID pal  = buf.ReadWord();
 

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -88,7 +88,7 @@ void ResetBridges()
 	/* First, free sprite table data */
 	for (BridgeType i = 0; i < MAX_BRIDGES; i++) {
 		if (_bridge[i].sprite_table != nullptr) {
-			for (BridgePieces j = BRIDGE_PIECE_NORTH; j < BRIDGE_PIECE_INVALID; j++) free(_bridge[i].sprite_table[j]);
+			for (BridgePieces j = BRIDGE_PIECE_NORTH; j < NUM_BRIDGE_PIECES; j++) free(_bridge[i].sprite_table[j]);
 			free(_bridge[i].sprite_table);
 		}
 	}
@@ -152,7 +152,7 @@ bool HasBridgeFlatRamp(Slope tileh, Axis axis)
 static inline const PalSpriteID *GetBridgeSpriteTable(int index, BridgePieces table)
 {
 	const BridgeSpec *bridge = GetBridgeSpec(index);
-	assert(table < BRIDGE_PIECE_INVALID);
+	assert(table < NUM_BRIDGE_PIECES);
 	if (bridge->sprite_table == nullptr || bridge->sprite_table[table] == nullptr) {
 		return _bridge_sprite_table[index][table];
 	} else {


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`BRIDGE_PIECE_INVALID` is used as `NUM_BRIDGE_PIECES`; all cases are for the count, not a constant implying invalid. Furthermore its underlying value is used a few times, instead of a named constant.

There is no named constant for the number of sprites that need to be defined for a `BridgePiece`.


## Description

Rename `BRIDGE_PIECE_INVALID` to `NUM_BRIDGE_PIECES`, and use this in a few more cases.
Introduce `SPRITES_PER_BRIDGE_PIECE` and use that where applicable.


## Limitations

Yes, I have seen the manual memory management. That was actually the first thing I wanted to tackle, but making the `sprite_table` in `BridgeSpec` a `unique_ptr` causes some complications with resetting/restoring the information to the original state in `ResetBridges`. `unique_ptr` disallows copying, which is fine... except that in `_orig_bridges` they would all be `nullptr`, so no memory sharing.
Alas, I have no idea how to copy the original state without manually defining which fields to copy, so I was left with just this part. Except for splitting the sprite tables from the `BridgeSpec`, but I'm not sure that would make things any better.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
