### PR TITLE
Fix 07fba75: Immediately convert terraformed ground tiles into water tiles during river generation

### DIFF
--- a/src/landscape.h
+++ b/src/landscape.h
@@ -137,5 +137,6 @@ void RunTileLoop();
 
 void InitializeLandscape();
 bool GenerateLandscape(uint8_t mode);
+extern bool _river_terraform;
 
 #endif /* LANDSCAPE_H */

--- a/src/terraform_cmd.cpp
+++ b/src/terraform_cmd.cpp
@@ -19,6 +19,8 @@
 #include "core/backup_type.hpp"
 #include "terraform_cmd.h"
 #include "landscape_cmd.h"
+#include "water.h"
+#include "landscape.h"
 
 #include "table/strings.h"
 
@@ -295,6 +297,14 @@ std::tuple<CommandCost, Money, TileIndex> CmdTerraformLand(DoCommandFlag flags, 
 			int height = it.second;
 
 			SetTileHeight(t, (uint)height);
+		}
+
+		if (_river_terraform) {
+			for (const auto &t : ts.dirty_tiles) {
+				/* Immediately convert ground tiles into water tiles during river generation. */
+				ConvertGroundTileIntoWaterTile(t);
+				MarkTileDirtyByTile(t);
+			}
 		}
 
 		if (c != nullptr) c->terraform_limit -= (uint32_t)ts.tile_to_new_height.size() << 16;

--- a/src/water.h
+++ b/src/water.h
@@ -29,6 +29,7 @@ void ClearNeighbourNonFloodingStates(TileIndex tile);
 void TileLoop_Water(TileIndex tile);
 bool FloodHalftile(TileIndex t);
 
+void ConvertGroundTileIntoWaterTile(TileIndex tile);
 void ConvertGroundTilesIntoWaterTiles();
 
 void DrawShipDepotSprite(int x, int y, Axis axis, DepotPart part);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
When `FlowRiver` tries to detect whether a river ends at sea, it is doing so by using `IsWaterTile`. `RiverMakeWider` uses the terraform command which could leave some tiles at sea level without water, waiting to be flooded.
07fba75 attempted to solve the waiting to be flooded issue after all rivers are widened, but unfortunately, this detection happens as the river is being widened.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Instead of doing one global conversion of ground tiles into water at the end of river generation, do it from the terraform command itself, for the tiles that are changed around the river in the widening process.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
#8492 has a similar issue, but for towns, and while this code could actually solve the problem presented in that PR, it has other issues when towns are at height 0 when placed via the scenario editor, for example. It would trigger unwanted floodings.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
