### PR TITLE
Fix #13202: Rail station tile flags were not set early enough.

### DIFF
--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2920,14 +2920,6 @@ bool AfterLoadGame()
 		}
 	}
 
-	{
-		/* Station blocked, wires and pylon flags need to be stored in the map. This is effectively cached data, so no
-		 * version check is necessary. This is done here as the SLV_182 check below needs the blocked status. */
-		for (const auto t : Map::Iterate()) {
-			if (HasStationTileRail(t)) SetRailStationTileFlags(t, GetStationSpec(t));
-		}
-	}
-
 	if (IsSavegameVersionBefore(SLV_182)) {
 		/* Aircraft acceleration variable was bonkers */
 		for (Aircraft *v : Aircraft::Iterate()) {

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -130,6 +130,12 @@ void AfterLoadStations()
 		StationUpdateCachedTriggers(st);
 		RoadStopUpdateCachedTriggers(st);
 	}
+
+	/* Station blocked, wires and pylon flags need to be stored in the map. This is effectively cached data, so no
+	 * version check is necessary. */
+	for (const auto t : Map::Iterate()) {
+		if (HasStationTileRail(t)) SetRailStationTileFlags(t, GetStationSpec(t));
+	}
 }
 
 /**


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Rail station tile flags now use bits that were (long ago) used to store railtype.

During Afterload, there are some calls that need the state of station tile flags to be correct which were executed before the station tile flags were set.

These flags were always set too late, but it was not as noticeable before as the bits used would always be clear.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Set station tile flags in AfterLoadStations() instead of later during AfterLoadGame().

This is the earliest point that NewGRF station specs are mapped correctly to stations, and also occurs after the station's railtype has been moved from m3 to m8.

Fixes #13202 

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

It is still possible for issues to occur if station NewGRFs are changed and a train is on a tile now marked as blocked, but that case is at least due to changing NewGRFs.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
