### PR TITLE
Dockerize openttd

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,3 +1,4 @@
+
 name: Docker Publish
 
 on:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,33 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [ "master" ]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1) Check out your repository code
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      # 2) Log in to Docker Hub
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      # 3) Build and push the Docker image
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          # Path to your Docker context (where Dockerfile is located)
+          context: .
+          # Build arguments or other build options can go here if needed
+          push: true
+          # Set image name(s) and tag(s); 'latest' is a simple default
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/openttd-server:latest, ${{ secrets.DOCKERHUB_USERNAME }}/openttd-server:$(date +%s)
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,155 @@
+# --------------------------------------------------------
+# 1) Base Image
+# --------------------------------------------------------
+FROM ubuntu:22.04
+
+LABEL maintainer="Santhosh Janardhanan <santhoshj@gmail.com>" \
+    description="Dockerfile to build and run the latest OpenTTD from source."
+ARG APPVER=14.1
+# --------------------------------------------------------
+# 2) Environment Variables for Server Configuration
+# --------------------------------------------------------
+# These can be overridden at 'docker run' or in a docker-compose.yml
+ENV SERVER_NAME="Docker OpenTTD" \
+    SERVER_PASSWORD="" \
+    COMPANY_PASSWORD="" \
+    START_YEAR="1950" \
+    PORT="3979"
+
+# --------------------------------------------------------
+# 3.1) Install Dependencies + Build Tools
+# --------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Tools for building breakpad, zlib, and openttd
+    git \
+    curl \
+    autoconf \
+    automake \
+    libtool \
+    pkg-config \
+    build-essential \
+    cmake \
+    wget\
+    xz-utils\
+    unzip\
+    ca-certificates\
+    # OpenTTD optional/encouraged libraries (dev packages, except zlib):
+    liblzma-dev \
+    libpng-dev \
+    liblzo2-dev \
+    libfreetype6-dev \
+    libfontconfig1-dev \
+    libicu-dev \
+    libharfbuzz-dev \
+    libcurl4-openssl-dev \
+    libsdl2-dev \
+    # Clean up apt lists
+    && rm -rf /var/lib/apt/lists/*
+
+# ------------------------------------------------------
+# 3.2) Build zlib from source
+# ------------------------------------------------------
+ENV ZLIB_VERSION=1.3.1
+WORKDIR /tmp
+RUN curl -LO "https://www.zlib.net/zlib-${ZLIB_VERSION}.tar.gz" \
+    && tar zxvf "zlib-${ZLIB_VERSION}.tar.gz" \
+    && cd "zlib-${ZLIB_VERSION}" \
+    && ./configure --prefix=/usr/local \
+    && make -j"$(nproc)" \
+    && make install \
+    && cd / && rm -rf /tmp/zlib*
+
+WORKDIR /tmp
+RUN git clone https://chromium.googlesource.com/breakpad/breakpad
+WORKDIR /tmp/breakpad/
+RUN git clone https://chromium.googlesource.com/linux-syscall-support
+RUN mkdir -p /tmp/breakpad/src/third_party/lss/ && mv linux-syscall-support/linux_syscall_support.h src/third_party/lss/
+WORKDIR /tmp/breakpad
+# Pull linux-syscall-support submodule
+RUN ./configure && make && \
+    make install
+# 'make install' is not provided by breakpad, so we do it manually:
+# mkdir -p /usr/local/include/breakpad && \
+# mkdir -p /usr/local/lib && \
+# cp -r src/* /usr/local/include/breakpad/ && \
+# find . -name '*.a' -exec cp {} /usr/local/lib/ \; && \
+# Cleanup
+# cd / && rm -rf /tmp/breakpad
+
+# --------------------------------------------------------
+# 4) Pull the Latest OpenTTD Source
+# --------------------------------------------------------
+WORKDIR /build
+RUN git clone --depth=1 --branch ${APPVER} https://github.com/OpenTTD/OpenTTD.git
+
+# --------------------------------------------------------
+# 5) Build OpenTTD (Release Mode)
+# --------------------------------------------------------
+WORKDIR /build/OpenTTD
+RUN mkdir build && cd build && \
+    cmake .. -DCMAKE_BUILD_TYPE=Release &&\
+    make -j"$(nproc)" && \
+    make install
+
+# --------------------------------------------------------
+# 6) Expose Ports (TCP & UDP)
+# --------------------------------------------------------
+EXPOSE 3979/tcp
+EXPOSE 3979/udp
+
+
+# ------------------------------------------------------
+# 1) Builder Stage: Compile OpenGFX
+# ------------------------------------------------------
+# FROM ubuntu:22.04 AS builder
+
+# Install system dependencies and tools for building OpenGFX
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    python3 \
+    python3-pip \
+    make \
+    imagemagick \
+    optipng grfcodec\
+    && rm -rf /var/lib/apt/lists/*
+
+# Install NML (required for compiling OpenGFX)
+RUN pip3 install nml
+
+# Clone the OpenGFX repository
+WORKDIR /build
+RUN git clone https://github.com/OpenTTD/OpenGFX.git
+
+# Compile OpenGFX via 'make'
+WORKDIR /build/OpenGFX
+RUN make
+
+
+
+# --------------------------------------------------------
+# 7) Default Command (Dedicated Server)
+# --------------------------------------------------------
+# We use 'sh -c' so that environment variables are expanded at runtime.
+# -D = Dedicated (no GUI)
+# -x <year> = Start year
+# -n 0.0.0.0:<port> = Listen on all interfaces at <port>
+#   (We combine that with the server name using a config approach or '-N' if supported.)
+#
+# In modern OpenTTD builds, there's no direct param for server_name; it typically reads openttd.cfg
+# or is set by environment variables in official Docker images. However, you could:
+#   - rely on openttd.cfg, or
+#   - pass '-N "MyServer"' if your build supports it.
+#
+# For demonstration, we show a somewhat "hybrid" approach using '-n' for net config
+# and a sample '-x' for start year. Adjust to your needs or configure openttd.cfg.
+
+# COPY --from=builder /build/OpenGFX/build/ /build/OpenTTD/build/
+
+# RUN cp -rvf /build/OpenGFX/* /build/OpenTTD/build/
+RUN tar xf /build/OpenGFX/opengfx-*-master-*.tar -C /build/OpenTTD/build/baseset/
+WORKDIR /build/OpenTTD
+RUN mkdir /config
+VOLUME [ "/config" ]
+CMD sh -c "\
+    echo 'Starting OpenTTD with server: ${SERVER_NAME}' && \
+    ./build/openttd -D -c /config/openttd.cfg"

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ To run the container, run, `docker run --rm -v ./openttd.cfg:/config/openttd.cfg
 
 Use the example file (openttd.cfg-example) as a starting point for customizing the server.
 
+As an alternative, use this prebuilt image: `docker pull moriartee/openttd-server`
+
 ## 2.0) Contact and Community
 
 'Official' channels

--- a/README.md
+++ b/README.md
@@ -3,18 +3,19 @@
 ## Table of contents
 
 - 1.0) [About](#10-about)
-    - 1.1) [Downloading OpenTTD](#11-downloading-openttd)
-    - 1.2) [OpenTTD gameplay manual](#12-openttd-gameplay-manual)
-    - 1.3) [Supported platforms](#13-supported-platforms)
-    - 1.4) [Installing and running OpenTTD](#14-installing-and-running-openttd)
-    - 1.5) [Add-on content / mods](#15-add-on-content--mods)
-    - 1.6) [OpenTTD directories](#16-openttd-directories)
-    - 1.7) [Compiling OpenTTD](#17-compiling-openttd)
+  - 1.1) [Downloading OpenTTD](#11-downloading-openttd)
+  - 1.2) [OpenTTD gameplay manual](#12-openttd-gameplay-manual)
+  - 1.3) [Supported platforms](#13-supported-platforms)
+  - 1.4) [Installing and running OpenTTD](#14-installing-and-running-openttd)
+  - 1.5) [Add-on content / mods](#15-add-on-content--mods)
+  - 1.6) [OpenTTD directories](#16-openttd-directories)
+  - 1.7) [Compiling OpenTTD](#17-compiling-openttd)
+  - 1.8) [Build docker image](#18-build-docker-image)
 - 2.0) [Contact and community](#20-contact-and-community)
-    - 2.1) [Multiplayer games](#21-multiplayer-games)
-    - 2.2) [Contributing to OpenTTD](#22-contributing-to-openttd)
-    - 2.3) [Reporting bugs](#23-reporting-bugs)
-    - 2.4) [Translating](#24-translating)
+  - 2.1) [Multiplayer games](#21-multiplayer-games)
+  - 2.2) [Contributing to OpenTTD](#22-contributing-to-openttd)
+  - 2.3) [Reporting bugs](#23-reporting-bugs)
+  - 2.4) [Translating](#24-translating)
 - 3.0) [Licensing](#30-licensing)
 - 4.0) [Credits](#40-credits)
 
@@ -37,11 +38,9 @@ Both 'stable' and 'nightly' versions are available for download:
 
 OpenTTD is also available for free on [Steam](https://store.steampowered.com/app/1536610/OpenTTD/), [GOG.com](https://www.gog.com/game/openttd), and the [Microsoft Store](https://www.microsoft.com/p/openttd-official/9ncjg5rvrr1c). On some platforms OpenTTD will be available via your OS package manager or a similar service.
 
-
 ## 1.2) OpenTTD gameplay manual
 
 OpenTTD has a [community-maintained wiki](https://wiki.openttd.org/), including a gameplay manual and tips.
-
 
 ## 1.3) Supported platforms
 
@@ -56,6 +55,7 @@ The currently supported platforms are:
 Other platforms may also work (in particular various BSD systems), but we don't actively test or maintain these.
 
 ### 1.3.1) Legacy support
+
 Platforms, languages and compilers change.
 We'll keep support going on old platforms as long as someone is interested in supporting them, except where it means the project can't move forward to keep up with language and compiler features.
 
@@ -72,7 +72,6 @@ For some platforms these will be downloaded during the installation process if r
 
 For some platforms, you will need to refer to [the installation guide](https://wiki.openttd.org/en/Manual/Installation).
 
-
 ### 1.4.1) Free graphics and sound files
 
 The free data files, split into OpenGFX for graphics, OpenSFX for sounds and
@@ -85,7 +84,6 @@ OpenMSX for music can be found at:
 Please follow the readme of these packages about the installation procedure.
 The Windows installer can optionally download and install these packages.
 
-
 ### 1.4.2) Original Transport Tycoon Deluxe graphics and sound files
 
 If you want to play with the original Transport Tycoon Deluxe data files you have to copy the data files from the CD-ROM into the baseset/ directory.
@@ -93,6 +91,7 @@ It does not matter whether you copy them from the DOS or Windows version of Tran
 The Windows install can optionally copy these files.
 
 You need to copy the following files:
+
 - sample.cat
 - trg1r.grf or TRG1.GRF
 - trgcr.grf or TRGC.GRF
@@ -100,14 +99,13 @@ You need to copy the following files:
 - trgir.grf or TRGI.GRF
 - trgtr.grf or TRGT.GRF
 
-
 ### 1.4.3) Original Transport Tycoon Deluxe music
 
 If you want the Transport Tycoon Deluxe music, copy the appropriate files from the original game into the baseset folder.
+
 - TTD for Windows: All files in the gm/ folder (gm_tt00.gm up to gm_tt21.gm)
 - TTD for DOS: The GM.CAT file
 - Transport Tycoon Original: The GM.CAT file, but rename it to GM-TTO.CAT
-
 
 ## 1.5) Add-on content / mods
 
@@ -117,7 +115,6 @@ Most types of add-on content can be downloaded within OpenTTD via the 'Check Onl
 
 Add-on content can also be installed manually, but that's more complicated; the [OpenTTD wiki](https://wiki.openttd.org/) may offer help with that, or the [OpenTTD directory structure guide](./docs/directory_structure.md).
 
-
 ### 1.5.1) Social Integration
 
 OpenTTD has the ability to load plugins to integrate with Social Platforms like Steam, Discord, etc.
@@ -125,7 +122,6 @@ OpenTTD has the ability to load plugins to integrate with Social Platforms like 
 To enable such integration, the plugin for the specific platform has to be downloaded and stored in the `social_integration` folder.
 
 See [OpenTTD's website](https://www.openttd.org), under Downloads, for what plugins are available.
-
 
 ### 1.6) OpenTTD directories
 
@@ -137,6 +133,13 @@ For more information, see the [directory structure guide](./docs/directory_struc
 
 If you want to compile OpenTTD from source, instructions can be found in [COMPILING.md](./COMPILING.md).
 
+### 1.8) Build docker image
+
+Run `docker build . -topenttd-server:<VERSION>`
+
+To run the container, run, `docker run --rm -v ./openttd.cfg:/config/openttd.cfg -p3979:3979 -p3979:3979/udp openttd-server`
+
+Use the example file (openttd.cfg-example) as a starting point for customizing the server.
 
 ## 2.0) Contact and Community
 
@@ -153,31 +156,26 @@ If you want to compile OpenTTD from source, instructions can be found in [COMPIL
 
 - the OpenTTD wiki has a [page listing OpenTTD communities](https://wiki.openttd.org/en/Community/Community) including some in languages other than English
 
-
 ### 2.1) Multiplayer games
 
 You can play OpenTTD with others, either cooperatively or competitively.
 
 See the [multiplayer documentation](./docs/multiplayer.md) for more details.
 
-
 ### 2.2) Contributing to OpenTTD
 
-We welcome contributors to OpenTTD.  More information for contributors can be found in [CONTRIBUTING.md](./CONTRIBUTING.md)
-
+We welcome contributors to OpenTTD. More information for contributors can be found in [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ### 2.3) Reporting bugs
 
-Good bug reports are very helpful.  We have a [guide to reporting bugs](./CONTRIBUTING.md#bug-reports) to help with this.
+Good bug reports are very helpful. We have a [guide to reporting bugs](./CONTRIBUTING.md#bug-reports) to help with this.
 
 Desyncs in multiplayer are complex to debug and report (some software development skils are required).
 Instructions can be found in [debugging and reporting desyncs](./docs/debugging_desyncs.md).
 
-
 ### 2.4) Translating
 
-OpenTTD is translated into many languages.  Translations are added and updated via the [online translation tool](https://translator.openttd.org).
-
+OpenTTD is translated into many languages. Translations are added and updated via the [online translation tool](https://translator.openttd.org).
 
 ## 3.0) Licensing
 

--- a/openttd.cfg-example
+++ b/openttd.cfg-example
@@ -1,0 +1,85 @@
+[server]
+# Password required for clients to join
+#server_password = "secretpassword"
+
+# Password for any company if used
+#company_password = "companypass"
+
+# Password for administration console (RCON)
+server_admin_password = "adminpass"
+
+# The port the server listens on for incoming connections (default is 3979)
+server_port = 3979
+
+# Whether or not to advertise this server (true/false)
+server_advertise = true
+
+# How many companies can exist in the game
+max_companies = 8
+
+# How many clients can be connected at once
+max_clients = 50
+
+# If true, the game starts paused, waiting for players
+start_paused = false
+
+# If false, the game continues running even if no players are connected
+pause_when_no_clients = false
+
+
+[network]
+# The maximum time (in milliseconds) the server waits for a response before disconnecting
+network_max_tcp_clients = 20
+
+# The name that appears in the multiplayer server list
+server_name = "OpenTTD Server (v14.1) on Docker"
+
+# Extra lines you can tweak, e.g.:
+# network_frame_freq = 2
+# network_sync_enable = true
+
+
+[game_creation]
+starting_year = 1990
+map_x = 10
+map_y = 10
+
+[misc]
+# Language file (if available)
+language = english.lng
+
+# Save autosaves to a dedicated folder
+# autosave_on_exit = true
+
+# Keep some number of autosave files
+# keep_all_autosave = false
+
+
+[gui]
+# If this is a dedicated server, the GUI sections aren’t typically used
+# but they can exist here for reference or local hosting with a GUI.
+fullscreen = false
+
+
+[difficulty]
+# Various difficulty settings (e.g., cost factors for building, vehicle running costs, etc.)
+# ...
+# max_no_competitors = 0
+# number_towns = 3
+# industry_density = 5
+# max_loan = 300000
+# initial_interest = 2
+# vehicle_costs = 0
+# competitor_speed = 2
+# vehicle_breakdowns = 1
+# subsidy_multiplier = 2
+# subsidy_duration = 1
+# construction_cost = 0
+# terrain_type = 1
+# quantity_sea_lakes = 0
+# economy = false
+# line_reverse_mode = false
+# disasters = false
+# town_council_tolerance = 0
+# competitors_interval = 10
+# infinite_money = false


### PR DESCRIPTION
## Commits
- [Dockerfile, example configuration file and documentation updated](https://github.com/OpenTTD/OpenTTD/commit/81b6aa603349db687e06ecd588ae2c1283d43589)
- [Updated readme with command to docker pull moriartee/openttd-server](https://github.com/OpenTTD/OpenTTD/commit/3ffe75b097a5fd8daa37d5a02b890b6ba50618dc)

## Motivation / Problem

I was trying to set up a dedicated server on an ubuntu server, without installing all the dev packages. So, I guess it will be a generic usecase to set up a completely customizable docker container.

## Description

* The dockerfile can be used to build any latest version of OpenTTD with minimum to no effort.
* All that we need to have is a copy of the openttd.cfg-example


## Limitations

* If the build file/path/patterns change, we may need to update the Dockerfile.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* This PR does not affect the gameplay or any in-game features.