### PR TITLE
Doc: mention that frozen production can yield varying production per period

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1924,7 +1924,10 @@ STR_CONFIG_SETTING_ENDING_YEAR_VALUE                            :{NUM}
 STR_CONFIG_SETTING_ENDING_YEAR_ZERO                             :Never
 
 STR_CONFIG_SETTING_ECONOMY_TYPE                                 :Economy type: {STRING2}
-STR_CONFIG_SETTING_ECONOMY_TYPE_HELPTEXT                        :Smooth economy makes production changes more often, and in smaller steps. Frozen economy stops production changes and industry closures. This setting may have no effect if industry types are provided by a NewGRF
+###length 2
+STR_CONFIG_SETTING_ECONOMY_TYPE_HELPTEXT                        :Smooth economy makes production changes more often, and in smaller steps. Frozen economy stops production changes and industry closures. This setting may have no effect if industry types are provided by a NewGRF.{}{}Industry production per month may still appear to vary if the economy is Frozen, because production is triggered at fixed intervals which do not exactly correspond to months
+STR_CONFIG_SETTING_ECONOMY_TYPE_HELPTEXT_PERIOD                 :Smooth economy makes production changes more often, and in smaller steps. Frozen economy stops production changes and industry closures. This setting may have no effect if industry types are provided by a NewGRF.{}{}Industry production per minute may still appear to vary if the economy is Frozen, because production is triggered at fixed intervals which do not exactly correspond to minutes
+
 ###length 3
 STR_CONFIG_SETTING_ECONOMY_TYPE_ORIGINAL                        :Original
 STR_CONFIG_SETTING_ECONOMY_TYPE_SMOOTH                          :Smooth

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -178,6 +178,7 @@ min      = ET_BEGIN
 max      = ET_END - 1
 str      = STR_CONFIG_SETTING_ECONOMY_TYPE
 strhelp  = STR_CONFIG_SETTING_ECONOMY_TYPE_HELPTEXT
+help_cb  = SettingHelpWallclock
 strval   = STR_CONFIG_SETTING_ECONOMY_TYPE_ORIGINAL
 post_cb  = [](auto) { InvalidateWindowClassesData(WC_INDUSTRY_VIEW); }
 cat      = SC_BASIC


### PR DESCRIPTION
## Motivation / Problem

Closes #13201


## Description

Document, in the economy type help text, that production does not happen per period (month/minute), but based on the game ticks and as such the production might seem to change when aggregated to those periods.

I got the feeling the text is way too technical for an end user, but I've played with the text for a while and this is the best I could come up with. Though maybe someone has a better suggestion?


## Limitations

Might not prevent all bug reports of this type, but it's the best we can do, I guess.

It's also not necessarily a "fix" for the observed problem, but just trying to change the perception of what a frozen economy means.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
