### PR TITLE
Codechange: TileIndex constructor explicitly

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -831,7 +831,7 @@ static uint8_t AircraftGetEntryPoint(const Aircraft *v, const AirportFTAClass *a
 	/* In the case the station doesn't exit anymore, set target tile 0.
 	 * It doesn't hurt much, aircraft will go to next order, nearest hangar
 	 * or it will simply crash in next tick */
-	TileIndex tile = 0;
+	TileIndex tile{};
 
 	const Station *st = Station::GetIfValid(v->targetairport);
 	if (st != nullptr) {
@@ -1305,7 +1305,7 @@ TileIndex Aircraft::GetOrderStationLocation(StationID)
 	}
 
 	/* Aircraft do not use dest-tile */
-	return 0;
+	return TileIndex{};
 }
 
 void Aircraft::MarkDirty()

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1326,7 +1326,7 @@ struct BuildVehicleWindow : Window {
 
 		if (!this->listview_mode) {
 			/* Query for cost and refitted capacity */
-			auto [ret, veh_id, refit_capacity, refit_mail, cargo_capacities] = Command<CMD_BUILD_VEHICLE>::Do(DC_QUERY_COST, this->window_number, this->sel_engine, true, cargo, INVALID_CLIENT_ID);
+			auto [ret, veh_id, refit_capacity, refit_mail, cargo_capacities] = Command<CMD_BUILD_VEHICLE>::Do(DC_QUERY_COST, TileIndex(this->window_number), this->sel_engine, true, cargo, INVALID_CLIENT_ID);
 			if (ret.Succeeded()) {
 				this->te.cost          = ret.GetCost() - e->GetCost();
 				this->te.capacity      = refit_capacity;
@@ -1501,7 +1501,7 @@ struct BuildVehicleWindow : Window {
 
 		this->eng_list.clear();
 
-		const Station *st = this->listview_mode ? nullptr : Station::GetByTile(this->window_number);
+		const Station *st = this->listview_mode ? nullptr : Station::GetByTile(TileIndex(this->window_number));
 
 		/* Make list of all available planes.
 		 * Also check to see if the previously selected plane is still available,
@@ -1614,9 +1614,9 @@ struct BuildVehicleWindow : Window {
 		CargoID cargo = this->cargo_filter_criteria;
 		if (cargo == CargoFilterCriteria::CF_ANY || cargo == CargoFilterCriteria::CF_ENGINES || cargo == CargoFilterCriteria::CF_NONE) cargo = INVALID_CARGO;
 		if (this->vehicle_type == VEH_TRAIN && RailVehInfo(sel_eng)->railveh_type == RAILVEH_WAGON) {
-			Command<CMD_BUILD_VEHICLE>::Post(GetCmdBuildVehMsg(this->vehicle_type), CcBuildWagon, this->window_number, sel_eng, true, cargo, INVALID_CLIENT_ID);
+			Command<CMD_BUILD_VEHICLE>::Post(GetCmdBuildVehMsg(this->vehicle_type), CcBuildWagon, TileIndex(this->window_number), sel_eng, true, cargo, INVALID_CLIENT_ID);
 		} else {
-			Command<CMD_BUILD_VEHICLE>::Post(GetCmdBuildVehMsg(this->vehicle_type), CcBuildPrimaryVehicle, this->window_number, sel_eng, true, cargo, INVALID_CLIENT_ID);
+			Command<CMD_BUILD_VEHICLE>::Post(GetCmdBuildVehMsg(this->vehicle_type), CcBuildPrimaryVehicle, TileIndex(this->window_number), sel_eng, true, cargo, INVALID_CLIENT_ID);
 		}
 
 		/* Update last used variant in hierarchy and refresh if necessary. */

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -300,7 +300,7 @@ struct DepotWindow : Window {
 	{
 		CloseWindowById(WC_BUILD_VEHICLE, this->window_number);
 		CloseWindowById(GetWindowClassForVehicleType(this->type), VehicleListIdentifier(VL_DEPOT_LIST, this->type, this->owner, this->GetDepotIndex()).Pack(), false);
-		OrderBackup::Reset(this->window_number);
+		OrderBackup::Reset(TileIndex(this->window_number));
 		this->Window::Close();
 	}
 
@@ -715,7 +715,7 @@ struct DepotWindow : Window {
 		if (this->generate_list) {
 			/* Generate the vehicle list
 			 * It's ok to use the wagon pointers for non-trains as they will be ignored */
-			BuildDepotVehicleList(this->type, this->window_number, &this->vehicle_list, &this->wagon_list);
+			BuildDepotVehicleList(this->type, TileIndex(this->window_number), &this->vehicle_list, &this->wagon_list);
 			this->generate_list = false;
 			DepotSortList(&this->vehicle_list);
 
@@ -756,7 +756,7 @@ struct DepotWindow : Window {
 		}
 
 		/* Setup disabled buttons. */
-		TileIndex tile = this->window_number;
+		TileIndex tile(this->window_number);
 		this->SetWidgetsDisabledState(!IsTileOwner(tile, _local_company),
 			WID_D_STOP_ALL,
 			WID_D_START_ALL,
@@ -780,7 +780,7 @@ struct DepotWindow : Window {
 
 			case WID_D_BUILD: // Build vehicle
 				ResetObjectToPlace();
-				ShowBuildVehicleWindow(this->window_number, this->type);
+				ShowBuildVehicleWindow(TileIndex(this->window_number), this->type);
 				break;
 
 			case WID_D_CLONE: // Clone button
@@ -801,22 +801,22 @@ struct DepotWindow : Window {
 
 			case WID_D_LOCATION:
 				if (_ctrl_pressed) {
-					ShowExtraViewportWindow(this->window_number);
+					ShowExtraViewportWindow(TileIndex(this->window_number));
 				} else {
-					ScrollMainWindowToTile(this->window_number);
+					ScrollMainWindowToTile(TileIndex(this->window_number));
 				}
 				break;
 
 			case WID_D_RENAME: // Rename button
 				SetDParam(0, this->type);
-				SetDParam(1, Depot::GetByTile((TileIndex)this->window_number)->index);
+				SetDParam(1, Depot::GetByTile(TileIndex(this->window_number))->index);
 				ShowQueryString(STR_DEPOT_NAME, STR_DEPOT_RENAME_DEPOT_CAPTION, MAX_LENGTH_DEPOT_NAME_CHARS, this, CS_ALPHANUMERAL, QSF_ENABLE_DEFAULT | QSF_LEN_IN_CHARS);
 				break;
 
 			case WID_D_STOP_ALL:
 			case WID_D_START_ALL: {
 				VehicleListIdentifier vli(VL_DEPOT_LIST, this->type, this->owner);
-				Command<CMD_MASS_START_STOP>::Post(this->window_number, widget == WID_D_START_ALL, false, vli);
+				Command<CMD_MASS_START_STOP>::Post(TileIndex(this->window_number), widget == WID_D_START_ALL, false, vli);
 				break;
 			}
 
@@ -835,11 +835,11 @@ struct DepotWindow : Window {
 				break;
 
 			case WID_D_VEHICLE_LIST:
-				ShowVehicleListWindow(GetTileOwner(this->window_number), this->type, (TileIndex)this->window_number);
+				ShowVehicleListWindow(GetTileOwner(this->window_number), this->type, TileIndex(this->window_number));
 				break;
 
 			case WID_D_AUTOREPLACE:
-				Command<CMD_DEPOT_MASS_AUTOREPLACE>::Post(this->window_number, this->type);
+				Command<CMD_DEPOT_MASS_AUTOREPLACE>::Post(TileIndex(this->window_number), this->type);
 				break;
 
 		}
@@ -916,10 +916,10 @@ struct DepotWindow : Window {
 	{
 		if (_ctrl_pressed) {
 			/* Share-clone, do not open new viewport, and keep tool active */
-			Command<CMD_CLONE_VEHICLE>::Post(STR_ERROR_CAN_T_BUY_TRAIN + v->type, this->window_number, v->index, true);
+			Command<CMD_CLONE_VEHICLE>::Post(STR_ERROR_CAN_T_BUY_TRAIN + v->type, TileIndex(this->window_number), v->index, true);
 		} else {
 			/* Copy-clone, open viewport for new vehicle, and deselect the tool (assume player wants to change things on new vehicle) */
-			if (Command<CMD_CLONE_VEHICLE>::Post(STR_ERROR_CAN_T_BUY_TRAIN + v->type, CcCloneVehicle, this->window_number, v->index, false)) {
+			if (Command<CMD_CLONE_VEHICLE>::Post(STR_ERROR_CAN_T_BUY_TRAIN + v->type, CcCloneVehicle, TileIndex(this->window_number), v->index, false)) {
 				ResetObjectToPlace();
 			}
 		}
@@ -1150,7 +1150,7 @@ static void DepotSellAllConfirmationCallback(Window *win, bool confirmed)
 {
 	if (confirmed) {
 		DepotWindow *w = (DepotWindow*)win;
-		TileIndex tile = w->window_number;
+		TileIndex tile(w->window_number);
 		VehicleType vehtype = w->type;
 		Command<CMD_DEPOT_SELL_ALL_VEHICLES>::Post(tile, vehtype);
 	}

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -861,7 +861,7 @@ public:
 
 			case WID_GL_START_ALL:
 			case WID_GL_STOP_ALL: { // Start/stop all vehicles of the list
-				Command<CMD_MASS_START_STOP>::Post(0, widget == WID_GL_START_ALL, true, this->vli);
+				Command<CMD_MASS_START_STOP>::Post(TileIndex{}, widget == WID_GL_START_ALL, true, this->vli);
 				break;
 			}
 

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -682,7 +682,7 @@ public:
 			case WID_DPI_FUND_WIDGET: {
 				if (this->selected_type != INVALID_INDUSTRYTYPE) {
 					if (_game_mode != GM_EDITOR && _settings_game.construction.raw_industry_construction == 2 && GetIndustrySpec(this->selected_type)->IsRawIndustry()) {
-						Command<CMD_BUILD_INDUSTRY>::Post(STR_ERROR_CAN_T_CONSTRUCT_THIS_INDUSTRY, 0, this->selected_type, 0, false, InteractiveRandom());
+						Command<CMD_BUILD_INDUSTRY>::Post(STR_ERROR_CAN_T_CONSTRUCT_THIS_INDUSTRY, TileIndex{}, this->selected_type, 0, false, InteractiveRandom());
 						this->HandleButtonClick(WID_DPI_FUND_WIDGET);
 					} else {
 						HandlePlacePushButton(this, WID_DPI_FUND_WIDGET, SPR_CURSOR_INDUSTRY, HT_RECT);

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -792,7 +792,7 @@ void RunTileLoop()
 
 	/* Manually update tile 0 every TILE_UPDATE_FREQUENCY ticks - the LFSR never iterates over it itself.  */
 	if (TimerGameTick::counter % TILE_UPDATE_FREQUENCY == 0) {
-		_tile_type_procs[GetTileType(0)]->tile_loop_proc(0);
+		_tile_type_procs[GetTileType(0)]->tile_loop_proc(TileIndex{});
 		count--;
 	}
 

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -228,7 +228,7 @@ private:
 	 * Iterable ensemble of all Tiles
 	 */
 	struct IterateWrapper {
-		Iterator begin() { return Iterator(0); }
+		Iterator begin() { return Iterator(TileIndex{}); }
 		Iterator end() { return Iterator(Map::Size()); }
 		bool empty() { return false; }
 	};

--- a/src/order_backup.cpp
+++ b/src/order_backup.cpp
@@ -173,7 +173,7 @@ CommandCost CmdClearOrderBackup(DoCommandFlag flags, TileIndex tile, ClientID us
 		/* If it's not a backup of us, ignore it. */
 		if (ob->user != user) continue;
 
-		Command<CMD_CLEAR_ORDER_BACKUP>::Post(0, static_cast<ClientID>(user));
+		Command<CMD_CLEAR_ORDER_BACKUP>::Post(TileIndex{}, static_cast<ClientID>(user));
 		return;
 	}
 }

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1999,7 +1999,7 @@ bool UpdateOrderDest(Vehicle *v, const Order *order, int conditional_depth, bool
 {
 	if (conditional_depth > v->GetNumOrders()) {
 		v->current_order.Free();
-		v->SetDestTile(0);
+		v->SetDestTile(TileIndex{});
 		return false;
 	}
 
@@ -2093,7 +2093,7 @@ bool UpdateOrderDest(Vehicle *v, const Order *order, int conditional_depth, bool
 		}
 
 		default:
-			v->SetDestTile(0);
+			v->SetDestTile(TileIndex{});
 			return false;
 	}
 
@@ -2109,7 +2109,7 @@ bool UpdateOrderDest(Vehicle *v, const Order *order, int conditional_depth, bool
 
 	if (order == nullptr) {
 		v->current_order.Free();
-		v->SetDestTile(0);
+		v->SetDestTile(TileIndex{});
 		return false;
 	}
 
@@ -2184,7 +2184,7 @@ bool ProcessOrders(Vehicle *v)
 		}
 
 		v->current_order.Free();
-		v->SetDestTile(0);
+		v->SetDestTile(TileIndex{});
 		return false;
 	}
 

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -588,7 +588,7 @@ TileIndex RoadVehicle::GetOrderStationLocation(StationID station)
 	if (!CanVehicleUseStation(this, st)) {
 		/* There is no stop left at the station, so don't even TRY to go there */
 		this->IncrementRealOrderIndex();
-		return 0;
+		return TileIndex{};
 	}
 
 	return st->xy;

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -220,7 +220,7 @@ struct INDYChunkHandler : ChunkHandler {
 			if (IsSavegameVersionBefore(SLV_161) && !IsSavegameVersionBefore(SLV_76)) {
 				/* Store the old persistent storage. The GRFID will be added later. */
 				assert(PersistentStorage::CanAllocateItem());
-				i->psa = new PersistentStorage(0, 0, 0);
+				i->psa = new PersistentStorage(0, 0, TileIndex{});
 				std::copy(std::begin(_old_ind_persistent_storage.storage), std::end(_old_ind_persistent_storage.storage), std::begin(i->psa->storage));
 			}
 			if (IsSavegameVersionBefore(SLV_EXTEND_INDUSTRY_CARGO_SLOTS)) {

--- a/src/saveload/map_sl.cpp
+++ b/src/saveload/map_sl.cpp
@@ -74,7 +74,7 @@ struct MAPTChunkHandler : ChunkHandler {
 		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).type() = buf[j];
 		}
@@ -86,7 +86,7 @@ struct MAPTChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		SlSetLength(size);
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).type();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		}
@@ -101,7 +101,7 @@ struct MAPHChunkHandler : ChunkHandler {
 		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).height() = buf[j];
 		}
@@ -113,7 +113,7 @@ struct MAPHChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		SlSetLength(size);
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).height();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		}
@@ -128,7 +128,7 @@ struct MAPOChunkHandler : ChunkHandler {
 		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m1() = buf[j];
 		}
@@ -140,7 +140,7 @@ struct MAPOChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		SlSetLength(size);
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m1();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		}
@@ -155,7 +155,7 @@ struct MAP2ChunkHandler : ChunkHandler {
 		std::array<uint16_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE,
 				/* In those versions the m2 was 8 bits */
 				IsSavegameVersionBefore(SLV_5) ? SLE_FILE_U8 | SLE_VAR_U16 : SLE_UINT16
@@ -170,7 +170,7 @@ struct MAP2ChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		SlSetLength(static_cast<uint32_t>(size) * sizeof(uint16_t));
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m2();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT16);
 		}
@@ -185,7 +185,7 @@ struct M3LOChunkHandler : ChunkHandler {
 		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m3() = buf[j];
 		}
@@ -197,7 +197,7 @@ struct M3LOChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		SlSetLength(size);
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m3();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		}
@@ -212,7 +212,7 @@ struct M3HIChunkHandler : ChunkHandler {
 		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m4() = buf[j];
 		}
@@ -224,7 +224,7 @@ struct M3HIChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		SlSetLength(size);
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m4();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		}
@@ -239,7 +239,7 @@ struct MAP5ChunkHandler : ChunkHandler {
 		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m5() = buf[j];
 		}
@@ -251,7 +251,7 @@ struct MAP5ChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		SlSetLength(size);
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m5();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		}
@@ -267,7 +267,7 @@ struct MAPEChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		if (IsSavegameVersionBefore(SLV_42)) {
-			for (TileIndex i = 0; i != size;) {
+			for (TileIndex i{}; i != size;) {
 				/* 1024, otherwise we overflow on 64x64 maps! */
 				SlCopy(buf.data(), 1024, SLE_UINT8);
 				for (uint j = 0; j != 1024; j++) {
@@ -278,7 +278,7 @@ struct MAPEChunkHandler : ChunkHandler {
 				}
 			}
 		} else {
-			for (TileIndex i = 0; i != size;) {
+			for (TileIndex i{}; i != size;) {
 				SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 				for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m6() = buf[j];
 			}
@@ -291,7 +291,7 @@ struct MAPEChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		SlSetLength(size);
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m6();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		}
@@ -306,7 +306,7 @@ struct MAP7ChunkHandler : ChunkHandler {
 		std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m7() = buf[j];
 		}
@@ -318,7 +318,7 @@ struct MAP7ChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		SlSetLength(size);
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m7();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		}
@@ -333,7 +333,7 @@ struct MAP8ChunkHandler : ChunkHandler {
 		std::array<uint16_t, MAP_SL_BUF_SIZE> buf;
 		uint size = Map::Size();
 
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT16);
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m8() = buf[j];
 		}
@@ -345,7 +345,7 @@ struct MAP8ChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		SlSetLength(static_cast<uint32_t>(size) * sizeof(uint16_t));
-		for (TileIndex i = 0; i != size;) {
+		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m8();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT16);
 		}

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -538,7 +538,7 @@ static void ReadTTDPatchFlags()
 	_bump_assert_value = (_old_vehicle_multiplier - 1) * 850 * 128;
 
 	/* The first 17 bytes are used by TTDP1, which translates to the first 9 m3s and first 8 m4s. */
-	for (TileIndex i = 0; i <= 8; i++) { // check tile 0, too
+	for (TileIndex i{}; i <= 8; i++) { // check tile 0, too
 		Tile tile(i);
 		if (tile.m3() != 0 || (i != 8 && tile.m4() != 0)) _savegame_type = SGT_TTDP1;
 	}
@@ -555,7 +555,7 @@ static void ReadTTDPatchFlags()
 	_old_extra_chunk_nums = extra_chunk_tile.m3() | extra_chunk_tile.m4() << 8;
 
 	/* Clean the misused places */
-	for (TileIndex i = 0; i < 9; i++) ClearOldMap3(i);
+	for (TileIndex i{}; i < 9; i++) ClearOldMap3(i);
 	for (TileIndex i = TileXY(0, Map::MaxY()); i < Map::Size(); i++) ClearOldMap3(i);
 
 	if (_savegame_type == SGT_TTDP2) Debug(oldloader, 2, "Found TTDPatch game");

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -380,7 +380,7 @@ public:
 		if (IsSavegameVersionBefore(SLV_161) && !IsSavegameVersionBefore(SLV_145) && st->facilities & FACIL_AIRPORT) {
 			/* Store the old persistent storage. The GRFID will be added later. */
 			assert(PersistentStorage::CanAllocateItem());
-			st->airport.psa = new PersistentStorage(0, 0, 0);
+			st->airport.psa = new PersistentStorage(0, 0, TileIndex{});
 			std::copy(std::begin(_old_st_persistent_storage.storage), std::end(_old_st_persistent_storage.storage), std::begin(st->airport.psa->storage));
 		}
 

--- a/src/saveload/storage_sl.cpp
+++ b/src/saveload/storage_sl.cpp
@@ -35,7 +35,7 @@ struct PSACChunkHandler : ChunkHandler {
 
 		while ((index = SlIterateArray()) != -1) {
 			assert(PersistentStorage::CanAllocateItem());
-			PersistentStorage *ps = new (index) PersistentStorage(0, 0, 0);
+			PersistentStorage *ps = new (index) PersistentStorage(0, 0, TileIndex{});
 			SlObject(ps, slt);
 		}
 	}

--- a/src/script/api/script_industrytype.cpp
+++ b/src/script/api/script_industrytype.cpp
@@ -134,7 +134,7 @@
 	EnforcePrecondition(false, CanProspectIndustry(industry_type));
 
 	uint32_t seed = ScriptBase::Rand();
-	return ScriptObject::Command<CMD_BUILD_INDUSTRY>::Do(0, industry_type, 0, false, seed);
+	return ScriptObject::Command<CMD_BUILD_INDUSTRY>::Do(TileIndex{}, industry_type, 0, false, seed);
 }
 
 /* static */ bool ScriptIndustryType::IsBuiltOnWater(IndustryType industry_type)

--- a/src/script/api/script_story_page.cpp
+++ b/src/script/api/script_story_page.cpp
@@ -80,7 +80,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 	EnforcePrecondition(STORY_PAGE_ELEMENT_INVALID, type != SPET_GOAL || !(StoryPage::Get(story_page_id)->company == INVALID_COMPANY && Goal::Get(reference)->company != INVALID_COMPANY));
 
 	uint32_t refid = 0;
-	TileIndex reftile = 0;
+	TileIndex reftile{};
 	switch (type) {
 		case SPET_LOCATION:
 			reftile = reference;
@@ -129,7 +129,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 	EnforcePrecondition(false, type != ::SPET_GOAL || !(p->company == INVALID_COMPANY && Goal::Get(reference)->company != INVALID_COMPANY));
 
 	uint32_t refid = 0;
-	TileIndex reftile = 0;
+	TileIndex reftile{};
 	switch (type) {
 		case ::SPET_LOCATION:
 			reftile = reference;

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -324,7 +324,7 @@ TileIndex Ship::GetOrderStationLocation(StationID station)
 		return st->xy;
 	} else {
 		this->IncrementRealOrderIndex();
-		return 0;
+		return TileIndex{};
 	}
 }
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1838,7 +1838,7 @@ static CommandCost RemoveRailStation(TileIndex tile, DoCommandFlag flags)
 {
 	/* if there is flooding, remove platforms tile by tile */
 	if (_current_company == OWNER_WATER) {
-		return Command<CMD_REMOVE_FROM_RAIL_STATION>::Do(DC_EXEC, tile, 0, false);
+		return Command<CMD_REMOVE_FROM_RAIL_STATION>::Do(DC_EXEC, tile, TileIndex{}, false);
 	}
 
 	Station *st = Station::GetByTile(tile);
@@ -1859,7 +1859,7 @@ static CommandCost RemoveRailWaypoint(TileIndex tile, DoCommandFlag flags)
 {
 	/* if there is flooding, remove waypoints tile by tile */
 	if (_current_company == OWNER_WATER) {
-		return Command<CMD_REMOVE_FROM_RAIL_WAYPOINT>::Do(DC_EXEC, tile, 0, false);
+		return Command<CMD_REMOVE_FROM_RAIL_WAYPOINT>::Do(DC_EXEC, tile, TileIndex{}, false);
 	}
 
 	return RemoveRailStation(Waypoint::GetByTile(tile), flags, _price[PR_CLEAR_WAYPOINT_RAIL]);

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -557,7 +557,7 @@ protected:
 				this->SetTimeout();
 				this->SetWidgetDirty(WID_SB_PAGE_PANEL);
 
-				Command<CMD_STORY_PAGE_BUTTON>::Post(0, pe.index, 0);
+				Command<CMD_STORY_PAGE_BUTTON>::Post(TileIndex{}, pe.index, 0);
 				break;
 
 			case SPET_BUTTON_TILE:
@@ -925,7 +925,7 @@ public:
 		VehicleType wanted_vehtype = data.GetVehicleType();
 		if (wanted_vehtype != VEH_INVALID && wanted_vehtype != v->type) return false;
 
-		Command<CMD_STORY_PAGE_BUTTON>::Post(0, pe->index, v->index);
+		Command<CMD_STORY_PAGE_BUTTON>::Post(TileIndex{}, pe->index, v->index);
 		ResetObjectToPlace();
 		return true;
 	}

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -2956,7 +2956,7 @@ TileIndex Train::GetOrderStationLocation(StationID station)
 	if (!(st->facilities & FACIL_TRAIN)) {
 		/* The destination station has no trainstation tiles. */
 		this->IncrementRealOrderIndex();
-		return 0;
+		return TileIndex{};
 	}
 
 	return st->xy;

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2217,7 +2217,7 @@ public:
 
 			case WID_VL_STOP_ALL:
 			case WID_VL_START_ALL:
-				Command<CMD_MASS_START_STOP>::Post(0, widget == WID_VL_START_ALL, true, this->vli);
+				Command<CMD_MASS_START_STOP>::Post(TileIndex{}, widget == WID_VL_START_ALL, true, this->vli);
 				break;
 		}
 	}


### PR DESCRIPTION
## Motivation / Problem

The implicit constructor of the StrongTypes can cause unforeseen issues due to operator overloading. It is better to make the conversions explicit, to not be burned by the hidden implicit ones.


## Description

Use the TileIndex constructor explicitly for window_number being passed to commands, and `0` being passed to mostly commands, but also as return value and start of iterations.


## Limitations

Does not actually remove the implicit constructor, but it's roughly 25% of the way to removing StrongType's implicit constructor.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
