### PR TITLE
Codechange: use constructor over assignment for constants

### DIFF
--- a/src/currency.h
+++ b/src/currency.h
@@ -14,9 +14,9 @@
 #include "settings_type.h"
 #include "strings_type.h"
 
-static constexpr TimerGameCalendar::Year CF_NOEURO = 0; ///< Currency never switches to the Euro (as far as known).
-static constexpr TimerGameCalendar::Year CF_ISEURO = 1; ///< Currency _is_ the Euro.
-static constexpr TimerGameCalendar::Year MIN_EURO_YEAR = 2000; ///< The earliest year custom currencies may switch to the Euro.
+static constexpr TimerGameCalendar::Year CF_NOEURO{0}; ///< Currency never switches to the Euro (as far as known).
+static constexpr TimerGameCalendar::Year CF_ISEURO{1}; ///< Currency _is_ the Euro.
+static constexpr TimerGameCalendar::Year MIN_EURO_YEAR{2000}; ///< The earliest year custom currencies may switch to the Euro.
 
 /**
  * This enum gives the currencies a unique id which must be maintained for

--- a/src/industry.h
+++ b/src/industry.h
@@ -23,7 +23,7 @@
 typedef Pool<Industry, IndustryID, 64, 64000> IndustryPool;
 extern IndustryPool _industry_pool;
 
-static const TimerGameEconomy::Year PROCESSING_INDUSTRY_ABANDONMENT_YEARS = 5; ///< If a processing industry doesn't produce for this many consecutive economy years, it may close.
+static const TimerGameEconomy::Year PROCESSING_INDUSTRY_ABANDONMENT_YEARS{5}; ///< If a processing industry doesn't produce for this many consecutive economy years, it may close.
 
 /*
  * Production level maximum, minimum and default values.

--- a/src/linkgraph/linkgraph.h
+++ b/src/linkgraph/linkgraph.h
@@ -170,10 +170,10 @@ public:
 	static const uint MIN_TIMEOUT_DISTANCE = 32;
 
 	/** Number of days before deleting links served only by vehicles stopped in depot. */
-	static constexpr TimerGameEconomy::Date STALE_LINK_DEPOT_TIMEOUT = 1024;
+	static constexpr TimerGameEconomy::Date STALE_LINK_DEPOT_TIMEOUT{1024};
 
 	/** Minimum number of days between subsequent compressions of a LG. */
-	static constexpr TimerGameEconomy::Date COMPRESSION_INTERVAL = 256;
+	static constexpr TimerGameEconomy::Date COMPRESSION_INTERVAL{256};
 
 	/**
 	 * Scale a value from a link graph of age orig_age for usage in one of age

--- a/src/network/core/network_game_info.cpp
+++ b/src/network/core/network_game_info.cpp
@@ -366,8 +366,8 @@ void DeserializeNetworkGameInfo(Packet &p, NetworkGameInfo &info, const GameInfo
 			info.clients_on     = p.Recv_uint8 ();
 			info.spectators_on  = p.Recv_uint8 ();
 			if (game_info_version < 3) { // 16 bits dates got scrapped and are read earlier
-				info.calendar_date = p.Recv_uint16() + CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR;
-				info.calendar_start = p.Recv_uint16() + CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR;
+				info.calendar_date = CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR + p.Recv_uint16();
+				info.calendar_start = CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR + p.Recv_uint16();
 			}
 			if (game_info_version < 6) while (p.Recv_uint8() != 0) {} // Used to contain the map-name.
 			info.map_width      = p.Recv_uint16();

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1018,7 +1018,7 @@ static ChangeInfoResult CommonVehicleChangeInfo(EngineInfo *ei, int prop, ByteRe
 {
 	switch (prop) {
 		case 0x00: // Introduction date
-			ei->base_intro = buf.ReadWord() + CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR;
+			ei->base_intro = CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR + buf.ReadWord();
 			break;
 
 		case 0x02: // Decay speed

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -905,7 +905,7 @@ char32_t RemapNewGRFStringControlCode(char32_t scc, const char **str, StringPara
 
 			/* Dates from NewGRFs have 1920-01-01 as their zero point, convert it to OpenTTD's epoch. */
 			case SCC_NEWGRF_PRINT_WORD_DATE_LONG:
-			case SCC_NEWGRF_PRINT_WORD_DATE_SHORT:  parameters.SetParam(0, _newgrf_textrefstack.PopUnsignedWord() + CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR); break;
+			case SCC_NEWGRF_PRINT_WORD_DATE_SHORT:  parameters.SetParam(0, CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR + _newgrf_textrefstack.PopUnsignedWord()); break;
 
 			case SCC_NEWGRF_DISCARD_WORD:           _newgrf_textrefstack.PopUnsignedWord(); break;
 

--- a/src/timer/timer_game_common.h
+++ b/src/timer/timer_game_common.h
@@ -160,37 +160,37 @@ public:
 	 */
 
 	/** The minimum starting year/base year of the original TTD */
-	static constexpr typename TimerGame<T>::Year ORIGINAL_BASE_YEAR = 1920;
+	static constexpr typename TimerGame<T>::Year ORIGINAL_BASE_YEAR{1920};
 	/** The original ending year */
-	static constexpr typename TimerGame<T>::Year ORIGINAL_END_YEAR = 2051;
+	static constexpr typename TimerGame<T>::Year ORIGINAL_END_YEAR{2051};
 	/** The maximum year of the original TTD */
-	static constexpr typename TimerGame<T>::Year ORIGINAL_MAX_YEAR = 2090;
+	static constexpr typename TimerGame<T>::Year ORIGINAL_MAX_YEAR{2090};
 
 	/**
 	 * MAX_YEAR, nicely rounded value of the number of years that can
 	 * be encoded in a single 32 bits date, about 2^31 / 366 years.
 	 */
-	static constexpr typename TimerGame<T>::Year MAX_YEAR = 5000000;
+	static constexpr typename TimerGame<T>::Year MAX_YEAR{5000000};
 
 	/** The absolute minimum year in OTTD */
-	static constexpr typename TimerGame<T>::Year MIN_YEAR = 0;
+	static constexpr typename TimerGame<T>::Year MIN_YEAR{0};
 
 	/** The default starting year */
-	static constexpr typename TimerGame<T>::Year DEF_START_YEAR = 1950;
+	static constexpr typename TimerGame<T>::Year DEF_START_YEAR{1950};
 	/** The default scoring end year */
-	static constexpr typename TimerGame<T>::Year DEF_END_YEAR = ORIGINAL_END_YEAR - 1;
+	static constexpr typename TimerGame<T>::Year DEF_END_YEAR{ORIGINAL_END_YEAR - 1};
 
 	/** The date of the first day of the original base year. */
-	static constexpr typename TimerGame<T>::Date DAYS_TILL_ORIGINAL_BASE_YEAR = TimerGame<T>::DateAtStartOfYear(ORIGINAL_BASE_YEAR);
+	static constexpr typename TimerGame<T>::Date DAYS_TILL_ORIGINAL_BASE_YEAR{TimerGame<T>::DateAtStartOfYear(ORIGINAL_BASE_YEAR)};
 
 	/** The date of the last day of the max year. */
-	static constexpr typename TimerGame<T>::Date MAX_DATE = TimerGame<T>::DateAtStartOfYear(MAX_YEAR + 1) - 1;
+	static constexpr typename TimerGame<T>::Date MAX_DATE{TimerGame<T>::DateAtStartOfYear(MAX_YEAR + 1) - 1};
 
 	/** The date on January 1, year 0. */
-	static constexpr typename TimerGame<T>::Date MIN_DATE = 0;
+	static constexpr typename TimerGame<T>::Date MIN_DATE{0};
 
-	static constexpr typename TimerGame<T>::Year INVALID_YEAR = -1; ///< Representation of an invalid year
-	static constexpr typename TimerGame<T>::Date INVALID_DATE = -1; ///< Representation of an invalid date
+	static constexpr typename TimerGame<T>::Year INVALID_YEAR{-1}; ///< Representation of an invalid year
+	static constexpr typename TimerGame<T>::Date INVALID_DATE{-1}; ///< Representation of an invalid date
 };
 
 #endif /* TIMER_GAME_COMMON_H */

--- a/src/timetable.h
+++ b/src/timetable.h
@@ -14,7 +14,7 @@
 #include "timer/timer_game_economy.h"
 #include "vehicle_type.h"
 
-static const TimerGameEconomy::Year MAX_TIMETABLE_START_YEARS = 15; ///< The maximum start date offset, in economy years.
+static const TimerGameEconomy::Year MAX_TIMETABLE_START_YEARS{15}; ///< The maximum start date offset, in economy years.
 
 enum class TimetableMode : uint8_t {
 	Days,

--- a/src/vehicle_func.h
+++ b/src/vehicle_func.h
@@ -25,7 +25,7 @@
 #define IS_CUSTOM_FIRSTHEAD_SPRITE(x) (x == 0xFD)
 #define IS_CUSTOM_SECONDHEAD_SPRITE(x) (x == 0xFE)
 
-static const TimerGameEconomy::Date VEHICLE_PROFIT_MIN_AGE = CalendarTime::DAYS_IN_YEAR * 2; ///< Only vehicles older than this have a meaningful profit.
+static const TimerGameEconomy::Date VEHICLE_PROFIT_MIN_AGE{CalendarTime::DAYS_IN_YEAR * 2}; ///< Only vehicles older than this have a meaningful profit.
 static const Money VEHICLE_PROFIT_THRESHOLD = 10000;        ///< Threshold for a vehicle to be considered making good profit.
 
 /**


### PR DESCRIPTION
## Motivation / Problem

The implicit constructor of the StrongTypes can cause unforeseen issues due to operator overloading. It is better to make the conversions explicit, to not be burned by the hidden implicit ones.


## Description

For years/dates there are many cases of constants in the form of `static const Year X = Y`, where `static const Year{Y}` would be preferred with the StrongTypes as that prevents an implicit conversion.
Furthermore by flipping some additions with these constants around, implicit conversion can be avoided.


## Limitations

Does not actually remove the implicit constructor, but it's roughly 10% of the way to removing StrongType's implicit constructor.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
