### PR TITLE
Codechange: use RandomTile over Random() when looking for a random tile

### DIFF
--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -733,7 +733,7 @@ static void Disaster_Zeppeliner_Init()
 	if (!Vehicle::CanAllocateItem(2)) return;
 
 	/* Pick a random place, unless we find a small airport */
-	int x = TileX(Random()) * TILE_SIZE + TILE_SIZE / 2;
+	int x = TileX(RandomTile()) * TILE_SIZE + TILE_SIZE / 2;
 
 	for (const Station *st : Station::Iterate()) {
 		if (st->airport.tile != INVALID_TILE && (st->airport.type == AT_SMALL || st->airport.type == AT_LARGE)) {
@@ -757,7 +757,7 @@ static void Disaster_Small_Ufo_Init()
 {
 	if (!Vehicle::CanAllocateItem(2)) return;
 
-	int x = TileX(Random()) * TILE_SIZE + TILE_SIZE / 2;
+	int x = TileX(RandomTile()) * TILE_SIZE + TILE_SIZE / 2;
 	DisasterVehicle *v = new DisasterVehicle(x, 0, DIR_SE, ST_SMALL_UFO);
 	v->dest_tile = TileXY(Map::SizeX() / 2, Map::SizeY() / 2);
 
@@ -827,7 +827,7 @@ static void Disaster_Big_Ufo_Init()
 {
 	if (!Vehicle::CanAllocateItem(2)) return;
 
-	int x = TileX(Random()) * TILE_SIZE + TILE_SIZE / 2;
+	int x = TileX(RandomTile()) * TILE_SIZE + TILE_SIZE / 2;
 	int y = Map::MaxX() * TILE_SIZE - 1;
 
 	DisasterVehicle *v = new DisasterVehicle(x, y, DIR_NW, ST_BIG_UFO);
@@ -846,7 +846,7 @@ static void Disaster_Submarine_Init(DisasterSubType subtype)
 	int y;
 	Direction dir;
 	uint32_t r = Random();
-	int x = TileX(r) * TILE_SIZE + TILE_SIZE / 2;
+	int x = TileX(RandomTileSeed(r)) * TILE_SIZE + TILE_SIZE / 2;
 
 	if (HasBit(r, 31)) {
 		y = Map::MaxY() * TILE_SIZE - TILE_SIZE / 2 - 1;


### PR DESCRIPTION
## Motivation / Problem

Doing `TileX(Random())` is weird, as you're passing something that's not a tile into a function that expects a tile. Only by 'luck' it works right, but for `TileY` it would not.


## Description

Use `RandomTile()` instead of `Random()` when trying to get the X-coordinate of a random tile.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
