### PR TITLE
Codechange: Simplify initialisation of default CargoLabels.

### DIFF
--- a/src/cargo_type.h
+++ b/src/cargo_type.h
@@ -27,48 +27,48 @@ using CargoID = uint8_t;
  */
 
 /* Temperate */
-static constexpr CargoLabel CT_PASSENGERS   = CargoLabel{'PASS'};
-static constexpr CargoLabel CT_COAL         = CargoLabel{'COAL'};
-static constexpr CargoLabel CT_MAIL         = CargoLabel{'MAIL'};
-static constexpr CargoLabel CT_OIL          = CargoLabel{'OIL_'};
-static constexpr CargoLabel CT_LIVESTOCK    = CargoLabel{'LVST'};
-static constexpr CargoLabel CT_GOODS        = CargoLabel{'GOOD'};
-static constexpr CargoLabel CT_GRAIN        = CargoLabel{'GRAI'};
-static constexpr CargoLabel CT_WOOD         = CargoLabel{'WOOD'};
-static constexpr CargoLabel CT_IRON_ORE     = CargoLabel{'IORE'};
-static constexpr CargoLabel CT_STEEL        = CargoLabel{'STEL'};
-static constexpr CargoLabel CT_VALUABLES    = CargoLabel{'VALU'};
+static constexpr CargoLabel CT_PASSENGERS{'PASS'};
+static constexpr CargoLabel CT_COAL{'COAL'};
+static constexpr CargoLabel CT_MAIL{'MAIL'};
+static constexpr CargoLabel CT_OIL{'OIL_'};
+static constexpr CargoLabel CT_LIVESTOCK{'LVST'};
+static constexpr CargoLabel CT_GOODS{'GOOD'};
+static constexpr CargoLabel CT_GRAIN{'GRAI'};
+static constexpr CargoLabel CT_WOOD{'WOOD'};
+static constexpr CargoLabel CT_IRON_ORE{'IORE'};
+static constexpr CargoLabel CT_STEEL{'STEL'};
+static constexpr CargoLabel CT_VALUABLES{'VALU'};
 
 /* Arctic */
-static constexpr CargoLabel CT_WHEAT        = CargoLabel{'WHEA'};
-static constexpr CargoLabel CT_PAPER        = CargoLabel{'PAPR'};
-static constexpr CargoLabel CT_GOLD         = CargoLabel{'GOLD'};
-static constexpr CargoLabel CT_FOOD         = CargoLabel{'FOOD'};
+static constexpr CargoLabel CT_WHEAT{'WHEA'};
+static constexpr CargoLabel CT_PAPER{'PAPR'};
+static constexpr CargoLabel CT_GOLD{'GOLD'};
+static constexpr CargoLabel CT_FOOD{'FOOD'};
 
 /* Tropic */
-static constexpr CargoLabel CT_RUBBER       = CargoLabel{'RUBR'};
-static constexpr CargoLabel CT_FRUIT        = CargoLabel{'FRUT'};
-static constexpr CargoLabel CT_MAIZE        = CargoLabel{'MAIZ'};
-static constexpr CargoLabel CT_COPPER_ORE   = CargoLabel{'CORE'};
-static constexpr CargoLabel CT_WATER        = CargoLabel{'WATR'};
-static constexpr CargoLabel CT_DIAMONDS     = CargoLabel{'DIAM'};
+static constexpr CargoLabel CT_RUBBER{'RUBR'};
+static constexpr CargoLabel CT_FRUIT{'FRUT'};
+static constexpr CargoLabel CT_MAIZE{'MAIZ'};
+static constexpr CargoLabel CT_COPPER_ORE{'CORE'};
+static constexpr CargoLabel CT_WATER{'WATR'};
+static constexpr CargoLabel CT_DIAMONDS{'DIAM'};
 
 /* Toyland */
-static constexpr CargoLabel CT_SUGAR        = CargoLabel{'SUGR'};
-static constexpr CargoLabel CT_TOYS         = CargoLabel{'TOYS'};
-static constexpr CargoLabel CT_BATTERIES    = CargoLabel{'BATT'};
-static constexpr CargoLabel CT_CANDY        = CargoLabel{'SWET'};
-static constexpr CargoLabel CT_TOFFEE       = CargoLabel{'TOFF'};
-static constexpr CargoLabel CT_COLA         = CargoLabel{'COLA'};
-static constexpr CargoLabel CT_COTTON_CANDY = CargoLabel{'CTCD'};
-static constexpr CargoLabel CT_BUBBLES      = CargoLabel{'BUBL'};
-static constexpr CargoLabel CT_PLASTIC      = CargoLabel{'PLST'};
-static constexpr CargoLabel CT_FIZZY_DRINKS = CargoLabel{'FZDR'};
+static constexpr CargoLabel CT_SUGAR{'SUGR'};
+static constexpr CargoLabel CT_TOYS{'TOYS'};
+static constexpr CargoLabel CT_BATTERIES{'BATT'};
+static constexpr CargoLabel CT_CANDY{'SWET'};
+static constexpr CargoLabel CT_TOFFEE{'TOFF'};
+static constexpr CargoLabel CT_COLA{'COLA'};
+static constexpr CargoLabel CT_COTTON_CANDY{'CTCD'};
+static constexpr CargoLabel CT_BUBBLES{'BUBL'};
+static constexpr CargoLabel CT_PLASTIC{'PLST'};
+static constexpr CargoLabel CT_FIZZY_DRINKS{'FZDR'};
 
 /** Dummy label for engines that carry no cargo; they actually carry 0 passengers. */
-static constexpr CargoLabel CT_NONE         = CT_PASSENGERS;
+static constexpr CargoLabel CT_NONE = CT_PASSENGERS;
 
-static constexpr CargoLabel CT_INVALID      = CargoLabel{UINT32_MAX}; ///< Invalid cargo type.
+static constexpr CargoLabel CT_INVALID{UINT32_MAX}; ///< Invalid cargo type.
 
 static const CargoID NUM_ORIGINAL_CARGO = 12; ///< Original number of cargo types.
 static const CargoID NUM_CARGO = 64; ///< Maximum number of cargo types in a game.

--- a/src/cargotype.cpp
+++ b/src/cargotype.cpp
@@ -136,7 +136,7 @@ void BuildCargoLabelMap()
 	CargoSpec::label_map.clear();
 	for (const CargoSpec &cs : CargoSpec::array) {
 		/* During initialization, CargoSpec can be marked valid before the label has been set. */
-		if (!cs.IsValid() || cs.label == CargoLabel{0} || cs.label == CT_INVALID) continue;
+		if (!cs.IsValid() || cs.label == CargoLabel{} || cs.label == CT_INVALID) continue;
 		/* Label already exists, don't addd again. */
 		if (CargoSpec::label_map.count(cs.label) != 0) continue;
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Unnecessarily verbose initialisation of default `CargoLabel`s.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use constructor initialisation without assignment to initialise default cargo labels.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
