### PR TITLE
Codechange: make strongtype constructor explicit

### DIFF
--- a/src/core/strong_typedef_type.hpp
+++ b/src/core/strong_typedef_type.hpp
@@ -127,8 +127,8 @@ namespace StrongType {
 			friend constexpr bool operator >=(const TType &lhs, TCompatibleType rhs) { return lhs.value >= static_cast<TBaseType>(rhs); }
 			friend constexpr bool operator >(const TType &lhs, TCompatibleType rhs) { return lhs.value > static_cast<TBaseType>(rhs); }
 
-			friend constexpr TType operator +(const TType &lhs, TCompatibleType rhs) { return { static_cast<TBaseType>(lhs.value + rhs) }; }
-			friend constexpr TType operator -(const TType &lhs, TCompatibleType rhs) { return { static_cast<TBaseType>(lhs.value - rhs) }; }
+			friend constexpr TType operator +(const TType &lhs, TCompatibleType rhs) { return TType{ static_cast<TBaseType>(lhs.value + rhs) }; }
+			friend constexpr TType operator -(const TType &lhs, TCompatibleType rhs) { return TType{ static_cast<TBaseType>(lhs.value - rhs) }; }
 		};
 	};
 
@@ -154,7 +154,7 @@ namespace StrongType {
 		constexpr Typedef(const Typedef &) = default;
 		constexpr Typedef(Typedef &&) = default;
 
-		constexpr Typedef(const TBaseType &value) : value(value) {}
+		explicit constexpr Typedef(const TBaseType &value) : value(value) {}
 
 		constexpr Typedef &operator =(const Typedef &rhs) { this->value = rhs.value; return *this; }
 		constexpr Typedef &operator =(Typedef &&rhs) { this->value = std::move(rhs.value); return *this; }

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -442,6 +442,9 @@ inline TileIndexDiff ToTileIndexDiff(TileIndexDiffC tidc)
 	return TileDiffXY(tidc.x, tidc.y);
 }
 
+/* Helper functions to provide explicit +=/-= operators for TileIndex and TileIndexDiff. */
+constexpr TileIndex &operator+=(TileIndex &tile, TileIndexDiff offset) { tile = tile + TileIndex(offset); return tile; }
+constexpr TileIndex &operator-=(TileIndex &tile, TileIndexDiff offset) { tile = tile - TileIndex(offset); return tile; }
 
 /**
  * Adds a given offset to a tile.

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -76,7 +76,7 @@ void UpdateHousesAndTowns()
 	}
 
 	/* Check for cases when a NewGRF has set a wrong house substitute type. */
-	for (const auto t : Map::Iterate()) {
+	for (const TileIndex &t : Map::Iterate()) {
 		if (!IsTileType(t, MP_HOUSE)) continue;
 
 		HouseID house_type = GetCleanHouseType(t);


### PR DESCRIPTION
## Motivation / Problem

The implicit constructor of the StrongTypes can cause unforeseen issues due to operator overloading. It is better to make the conversions explicit, to not be burned by the hidden implicit ones.


## Description

This is a bit of a hodge-pot of small titbits to make the constructor explicit.

StrongType's + and - operators should use the constructor explicitly to return the right object.
Make StrongType's 'base type value' constructor explicit.
Add a few helper functions for `+=` and `-=` for `TileIndex` +/- `TileIndexDiff`, so they do not use the implicit constructor any more.
Explicitly choosing `TileIndex` over `auto` in one map iteration.


## Limitations

The assignment operator is not explicit, but that's beyond the scope of this set of PRs.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
