### PR TITLE
Codechange: do not implicitly convert during assignment to StrongType

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -927,7 +927,7 @@ static bool AircraftController(Aircraft *v)
 			u->cur_speed = 32;
 			int count = UpdateAircraftSpeed(v);
 			if (count > 0) {
-				v->tile = 0;
+				v->tile = TileIndex{};
 
 				int z_dest;
 				GetAircraftFlightLevelBounds(v, &z_dest, nullptr);
@@ -1100,7 +1100,7 @@ static bool AircraftController(Aircraft *v)
 
 		v->tile = gp.new_tile;
 		/* If vehicle is in the air, use tile coordinate 0. */
-		if (amd.flag & (AMED_TAKEOFF | AMED_SLOWTURN | AMED_LAND)) v->tile = 0;
+		if (amd.flag & (AMED_TAKEOFF | AMED_SLOWTURN | AMED_LAND)) v->tile = TileIndex{};
 
 		/* Adjust Z for land or takeoff? */
 		int z = v->z_pos;

--- a/src/articulated_vehicles.cpp
+++ b/src/articulated_vehicles.cpp
@@ -423,7 +423,7 @@ void AddArticulatedParts(Vehicle *first)
 		v->vehstatus = first->vehstatus & ~VS_STOPPED;
 
 		v->cargo_subtype = 0;
-		v->max_age = 0;
+		v->max_age = CalendarTime::MIN_DATE;
 		v->engine_type = engine_type;
 		v->value = 0;
 		v->sprite_cache.sprite_seq.Set(SPR_IMG_QUERY);

--- a/src/core/strong_typedef_type.hpp
+++ b/src/core/strong_typedef_type.hpp
@@ -158,7 +158,6 @@ namespace StrongType {
 
 		constexpr Typedef &operator =(const Typedef &rhs) { this->value = rhs.value; return *this; }
 		constexpr Typedef &operator =(Typedef &&rhs) { this->value = std::move(rhs.value); return *this; }
-		constexpr Typedef &operator =(const TBaseType &rhs) { this->value = rhs; return *this; }
 
 		/* Only allow conversion to BaseType via method. */
 		constexpr TBaseType base() const { return this->value; }

--- a/src/date_gui.cpp
+++ b/src/date_gui.cpp
@@ -166,7 +166,7 @@ struct SetDateWindow : Window {
 				break;
 
 			case WID_SD_YEAR:
-				this->date.year = index;
+				this->date.year = TimerGameEconomy::Year{index};
 				break;
 		}
 		this->SetDirty();

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -235,7 +235,7 @@ static bool DisasterTick_Zeppeliner(DisasterVehicle *v)
 		if (v->state == 1) {
 			if (++v->age == 38) {
 				v->state = 2;
-				v->age = 0;
+				v->age = CalendarTime::MIN_DATE;
 			}
 
 			if (GB(v->tick_counter, 0, 3) == 0) CreateEffectVehicleRel(v, 0, -17, 2, EV_CRASH_SMOKE);
@@ -243,7 +243,7 @@ static bool DisasterTick_Zeppeliner(DisasterVehicle *v)
 		} else if (v->state == 0) {
 			if (IsValidTile(v->tile) && IsAirportTile(v->tile)) {
 				v->state = 1;
-				v->age = 0;
+				v->age = CalendarTime::MIN_DATE;
 
 				SetDParam(0, GetStationIndex(v->tile));
 				AddTileNewsItem(STR_NEWS_DISASTER_ZEPPELIN, NT_ACCIDENT, v->tile);
@@ -297,7 +297,7 @@ static bool DisasterTick_Zeppeliner(DisasterVehicle *v)
 		}
 	} else if (v->age == 350) {
 		v->state = 3;
-		v->age = 0;
+		v->age = CalendarTime::MIN_DATE;
 	}
 
 	if (IsValidTile(v->tile) && IsAirportTile(v->tile)) {
@@ -354,8 +354,8 @@ static bool DisasterTick_Ufo(DisasterVehicle *v)
 					return false;
 				}
 				/* Target it. */
-				v->dest_tile = u->index;
-				v->age = 0;
+				v->dest_tile = TileIndex{u->index};
+				v->age = CalendarTime::MIN_DATE;
 				u->disaster_vehicle = v->index;
 				break;
 			}
@@ -460,7 +460,7 @@ static bool DisasterTick_Aircraft(DisasterVehicle *v, uint16_t image_override, b
 	} else if (v->state == 1) {
 		if (++v->age == 112) {
 			v->state = 2;
-			v->age = 0;
+			v->age = CalendarTime::MIN_DATE;
 
 			Industry *i = Industry::Get(v->dest_tile.base()); // Industry destructor calls ReleaseDisastersTargetingIndustry, so this is valid
 			DestructIndustry(i);
@@ -479,11 +479,11 @@ static bool DisasterTick_Aircraft(DisasterVehicle *v, uint16_t image_override, b
 		if (!IsTileType(tile, MP_INDUSTRY)) return true;
 
 		IndustryID ind = GetIndustryIndex(tile);
-		v->dest_tile = ind;
+		v->dest_tile = TileIndex{ind};
 
 		if (GetIndustrySpec(Industry::Get(ind)->type)->behaviour & industry_flag) {
 			v->state = 1;
-			v->age = 0;
+			v->age = CalendarTime::MIN_DATE;
 		}
 	}
 
@@ -611,7 +611,7 @@ static bool DisasterTick_Big_Ufo(DisasterVehicle *v)
 			if (is_valid_target(t) && (n-- == 0)) {
 				/* Target it. */
 				v->dest_tile = t->tile;
-				v->age = 0;
+				v->age = CalendarTime::MIN_DATE;
 				break;
 			}
 		}
@@ -991,7 +991,7 @@ void ReleaseDisasterVehicle(VehicleID vehicle)
 	v->state = 0;
 	v->dest_tile = RandomTile();
 	GetAircraftFlightLevelBounds(v, &v->z_pos, nullptr);
-	v->age = 0;
+	v->age = CalendarTime::MIN_DATE;
 }
 
 void DisasterVehicle::UpdateDeltaXY()

--- a/src/effectvehicle.cpp
+++ b/src/effectvehicle.cpp
@@ -572,7 +572,7 @@ EffectVehicle *CreateEffectVehicle(int x, int y, int z, EffectVehicleType type)
 	v->x_pos = x;
 	v->y_pos = y;
 	v->z_pos = z;
-	v->tile = 0;
+	v->tile = TileIndex{};
 	v->UpdateDeltaXY();
 	v->vehstatus = VS_UNCLICKABLE;
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -81,7 +81,7 @@ Engine::Engine(VehicleType type, EngineID base)
 		/* 'power' defaults to zero, so we also have to default to 'wagon' */
 		if (type == VEH_TRAIN) this->u.rail.railveh_type = RAILVEH_WAGON;
 		/* Set model life to maximum to make wagons available */
-		this->info.base_life = 0xFF;
+		this->info.base_life = TimerGameCalendar::Year{0xFF};
 		/* Set road vehicle tractive effort to the default value */
 		if (type == VEH_ROAD) this->u.road.tractive_effort = 0x4C;
 		/* Aircraft must have CT_INVALID as default, as there is no property */
@@ -116,7 +116,7 @@ Engine::Engine(VehicleType type, EngineID base)
 			this->info.string_id = STR_VEHICLE_NAME_TRAIN_ENGINE_RAIL_KIRBY_PAUL_TANK_STEAM + base;
 
 			/* Set the default model life of original wagons to "infinite" */
-			if (this->u.rail.railveh_type == RAILVEH_WAGON) this->info.base_life = 0xFF;
+			if (this->u.rail.railveh_type == RAILVEH_WAGON) this->info.base_life = TimerGameCalendar::Year{0xFF};
 
 			break;
 
@@ -693,7 +693,7 @@ void CalcEngineReliability(Engine *e, bool new_month)
 void SetYearEngineAgingStops()
 {
 	/* Determine last engine aging year, default to 2050 as previously. */
-	_year_engine_aging_stops = 2050;
+	_year_engine_aging_stops = TimerGameCalendar::Year{2050};
 
 	for (const Engine *e : Engine::Iterate()) {
 		const EngineInfo *ei = &e->info;

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -53,7 +53,7 @@ void LoadCheckData::Clear()
 	this->error_msg.clear();
 
 	this->map_size_x = this->map_size_y = 256; // Default for old savegames which do not store mapsize.
-	this->current_date = 0;
+	this->current_date = CalendarTime::MIN_DATE;
 	this->settings = {};
 
 	companies.clear();

--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -112,7 +112,7 @@ struct GoalListWindow : public Window {
 
 			case GT_TILE:
 				if (!IsValidTile(s->dst)) return;
-				xy = s->dst;
+				xy = TileIndex{s->dst};
 				break;
 
 			case GT_INDUSTRY:

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -3076,7 +3076,7 @@ static IntervalTimer<TimerGameEconomy> _economy_industries_monthly({TimerGameEco
 void InitializeIndustries()
 {
 	Industry::industries = {};
-	_industry_sound_tile = 0;
+	_industry_sound_tile = TileIndex{};
 
 	_industry_builder.Reset();
 }

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -800,7 +800,7 @@ void RunTileLoop()
 		_tile_type_procs[GetTileType(tile)]->tile_loop_proc(tile);
 
 		/* Get the next tile in sequence using a Galois LFSR. */
-		tile = (tile.base() >> 1) ^ (-(int32_t)(tile.base() & 1) & feedback);
+		tile = TileIndex{(tile.base() >> 1) ^ (-(int32_t)(tile.base() & 1) & feedback)};
 	}
 
 	_cur_tileloop_tile = tile;

--- a/src/league_gui.cpp
+++ b/src/league_gui.cpp
@@ -220,7 +220,7 @@ static void HandleLinkClick(Link link)
 
 		case LT_TILE:
 			if (!IsValidTile(link.target)) return;
-			xy = link.target;
+			xy = TileIndex{link.target};
 			break;
 
 		case LT_INDUSTRY:

--- a/src/linkgraph/linkgraph.cpp
+++ b/src/linkgraph/linkgraph.cpp
@@ -65,7 +65,7 @@ void LinkGraph::ShiftDates(TimerGameEconomy::Date interval)
 
 void LinkGraph::Compress()
 {
-	this->last_compression = (TimerGameEconomy::date + this->last_compression).base() / 2;
+	this->last_compression = TimerGameEconomy::Date{(TimerGameEconomy::date + this->last_compression).base() / 2};
 	for (NodeID node1 = 0; node1 < this->Size(); ++node1) {
 		this->nodes[node1].supply /= 2;
 		for (BaseEdge &edge : this->nodes[node1].edges) {

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -100,7 +100,7 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 	_pause_mode = PM_UNPAUSED;
 	_game_speed = 100;
 	TimerGameTick::counter = 0;
-	_cur_tileloop_tile = 1;
+	_cur_tileloop_tile = TileIndex{1};
 	_thd.redsq = INVALID_TILE;
 	if (reset_settings) MakeNewgameSettingsLive();
 

--- a/src/misc/endian_buffer.hpp
+++ b/src/misc/endian_buffer.hpp
@@ -146,7 +146,7 @@ public:
 		if constexpr (std::is_enum_v<T>) {
 			data = static_cast<T>(this->Read<std::underlying_type_t<T>>());
 		} else if constexpr (std::is_base_of_v<StrongTypedefBase, T>) {
-			data = this->Read<typename T::BaseType>();
+			data = T{this->Read<typename T::BaseType>()};
 		} else {
 			data = this->Read<T>();
 		}

--- a/src/network/core/network_game_info.cpp
+++ b/src/network/core/network_game_info.cpp
@@ -347,8 +347,8 @@ void DeserializeNetworkGameInfo(Packet &p, NetworkGameInfo &info, const GameInfo
 		}
 
 		case 3:
-			info.calendar_date = Clamp(p.Recv_uint32(), 0, CalendarTime::MAX_DATE.base());
-			info.calendar_start = Clamp(p.Recv_uint32(), 0, CalendarTime::MAX_DATE.base());
+			info.calendar_date = TimerGameCalendar::Date{Clamp(p.Recv_uint32(), 0, CalendarTime::MAX_DATE.base())};
+			info.calendar_start = TimerGameCalendar::Date{Clamp(p.Recv_uint32(), 0, CalendarTime::MAX_DATE.base())};
 			[[fallthrough]];
 
 		case 2:

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1026,11 +1026,11 @@ static ChangeInfoResult CommonVehicleChangeInfo(EngineInfo *ei, int prop, ByteRe
 			break;
 
 		case 0x03: // Vehicle life
-			ei->lifelength = buf.ReadByte();
+			ei->lifelength = TimerGameCalendar::Year{buf.ReadByte()};
 			break;
 
 		case 0x04: // Model life
-			ei->base_life = buf.ReadByte();
+			ei->base_life = TimerGameCalendar::Year{buf.ReadByte()};
 			break;
 
 		case 0x06: // Climates available
@@ -1307,7 +1307,7 @@ static ChangeInfoResult RailVehicleChangeInfo(uint engine, int numinfo, int prop
 				break;
 
 			case 0x2A: // Long format introduction date (days since year 0)
-				ei->base_intro = buf.ReadDWord();
+				ei->base_intro = TimerGameCalendar::Date(buf.ReadDWord());
 				break;
 
 			case PROP_TRAIN_CARGO_AGE_PERIOD: // 0x2B Cargo aging period
@@ -1498,7 +1498,7 @@ static ChangeInfoResult RoadVehicleChangeInfo(uint engine, int numinfo, int prop
 				break;
 
 			case 0x1F: // Long format introduction date (days since year 0)
-				ei->base_intro = buf.ReadDWord();
+				ei->base_intro = TimerGameCalendar::Date(buf.ReadDWord());
 				break;
 
 			case 0x20: // Alter purchase list sort order
@@ -1685,7 +1685,7 @@ static ChangeInfoResult ShipVehicleChangeInfo(uint engine, int numinfo, int prop
 				break;
 
 			case 0x1A: // Long format introduction date (days since year 0)
-				ei->base_intro = buf.ReadDWord();
+				ei->base_intro = TimerGameCalendar::Date(buf.ReadDWord());
 				break;
 
 			case 0x1B: // Alter purchase list sort order
@@ -1868,7 +1868,7 @@ static ChangeInfoResult AircraftVehicleChangeInfo(uint engine, int numinfo, int 
 				break;
 
 			case 0x1A: // Long format introduction date (days since year 0)
-				ei->base_intro = buf.ReadDWord();
+				ei->base_intro = TimerGameCalendar::Date(buf.ReadDWord());
 				break;
 
 			case 0x1B: // Alter purchase list sort order
@@ -2638,11 +2638,11 @@ static ChangeInfoResult TownHouseChangeInfo(uint hid, int numinfo, int prop, Byt
 			}
 
 			case 0x21: // long introduction year
-				housespec->min_year = buf.ReadWord();
+				housespec->min_year = TimerGameCalendar::Year{buf.ReadWord()};
 				break;
 
 			case 0x22: // long maximum year
-				housespec->max_year = buf.ReadWord();
+				housespec->max_year = TimerGameCalendar::Year{buf.ReadWord()};
 				if (housespec->max_year == UINT16_MAX) housespec->max_year = CalendarTime::MAX_YEAR;
 				break;
 
@@ -4045,8 +4045,8 @@ static ChangeInfoResult AirportChangeInfo(uint airport, int numinfo, int prop, B
 			}
 
 			case 0x0C:
-				as->min_year = buf.ReadWord();
-				as->max_year = buf.ReadWord();
+				as->min_year = TimerGameCalendar::Year{buf.ReadWord()};
+				as->max_year = TimerGameCalendar::Year{buf.ReadWord()};
 				if (as->max_year == 0xFFFF) as->max_year = CalendarTime::MAX_YEAR;
 				break;
 
@@ -4196,11 +4196,11 @@ static ChangeInfoResult ObjectChangeInfo(uint id, int numinfo, int prop, ByteRea
 				break;
 
 			case 0x0E: // Introduction date
-				spec->introduction_date = buf.ReadDWord();
+				spec->introduction_date = TimerGameCalendar::Date(buf.ReadDWord());
 				break;
 
 			case 0x0F: // End of life
-				spec->end_of_life_date = buf.ReadDWord();
+				spec->end_of_life_date = TimerGameCalendar::Date(buf.ReadDWord());
 				break;
 
 			case 0x10: // Flags
@@ -4363,7 +4363,7 @@ static ChangeInfoResult RailTypeChangeInfo(uint id, int numinfo, int prop, ByteR
 				break;
 
 			case 0x17: // Introduction date
-				rti->introduction_date = buf.ReadDWord();
+				rti->introduction_date = TimerGameCalendar::Date(buf.ReadDWord());
 				break;
 
 			case 0x1A: // Sort order
@@ -4570,7 +4570,7 @@ static ChangeInfoResult RoadTypeChangeInfo(uint id, int numinfo, int prop, ByteR
 				break;
 
 			case 0x17: // Introduction date
-				rti->introduction_date = buf.ReadDWord();
+				rti->introduction_date = TimerGameCalendar::Date(buf.ReadDWord());
 				break;
 
 			case 0x1A: // Sort order
@@ -9412,7 +9412,7 @@ static void EnsureEarlyHouse(HouseZones bitmask)
 	for (auto &hs : HouseSpec::Specs()) {
 		if (!hs.enabled) continue;
 		if ((hs.building_availability & bitmask) != bitmask) continue;
-		if (hs.min_year == min_year) hs.min_year = 0;
+		if (hs.min_year == min_year) hs.min_year = CalendarTime::MIN_YEAR;
 	}
 }
 
@@ -10136,7 +10136,7 @@ void LoadNewGRF(SpriteID load_index, uint num_baseset)
 		TimerGameCalendar::date = TimerGameCalendar::ConvertYMDToDate(TimerGameCalendar::year, 0, 1);
 		TimerGameCalendar::date_fract = 0;
 
-		TimerGameEconomy::year = _settings_game.game_creation.starting_year.base();
+		TimerGameEconomy::year = TimerGameEconomy::Year{_settings_game.game_creation.starting_year.base()};
 		TimerGameEconomy::date = TimerGameEconomy::ConvertYMDToDate(TimerGameEconomy::year, 0, 1);
 		TimerGameEconomy::date_fract = 0;
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -558,7 +558,7 @@ int openttd_main(std::span<char * const> arguments)
 			scanner->join_server_password = mgo.opt;
 			break;
 		case 'r': ParseResolution(&resolution, mgo.opt); break;
-		case 't': scanner->startyear = atoi(mgo.opt); break;
+		case 't': scanner->startyear = TimerGameCalendar::Year(atoi(mgo.opt)); break;
 		case 'd': {
 #if defined(_WIN32)
 				CreateConsole();

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -569,7 +569,7 @@ bool AfterLoadGame()
 
 	extern TileIndex _cur_tileloop_tile; // From landscape.cpp.
 	/* The LFSR used in RunTileLoop iteration cannot have a zeroed state, make it non-zeroed. */
-	if (_cur_tileloop_tile == 0) _cur_tileloop_tile = 1;
+	if (_cur_tileloop_tile == 0) _cur_tileloop_tile = TileIndex{1};
 
 	if (IsSavegameVersionBefore(SLV_98)) _gamelog.Oldver();
 
@@ -3084,7 +3084,7 @@ bool AfterLoadGame()
 				if (IsValidCargoID(a.cargo)) {
 					a.last_accepted = i->GetAccepted(0).last_accepted;
 				} else {
-					a.last_accepted = 0;
+					a.last_accepted = EconomyTime::MIN_DATE;
 				}
 			}
 		}
@@ -3299,7 +3299,7 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SLV_NEWGRF_LAST_SERVICE)) {
 		/* Set service date provided to NewGRF. */
 		for (Vehicle *v : Vehicle::Iterate()) {
-			v->date_of_last_service_newgrf = v->date_of_last_service.base();
+			v->date_of_last_service_newgrf = TimerGameCalendar::Date{v->date_of_last_service.base()};
 		}
 	}
 

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -190,7 +190,7 @@ void UpdateOldAircraft()
 			a->state = FLYING;
 			AircraftNextAirportPos_and_Order(a); // move it to the entry point of the airport
 			GetNewVehiclePosResult gp = GetNewVehiclePos(a);
-			a->tile = 0; // aircraft in air is tile=0
+			a->tile = TileIndex{}; // aircraft in air is tile=0
 
 			/* correct speed of helicopter-rotors */
 			if (a->subtype == AIR_HELICOPTER) a->Next()->Next()->cur_speed = 32;
@@ -403,7 +403,7 @@ void AfterLoadVehiclesPhase1(bool part_of_load)
 		if (IsSavegameVersionBefore(SLV_VEHICLE_ECONOMY_AGE)) {
 			/* Set vehicle economy age based on calendar age. */
 			for (Vehicle *v : Vehicle::Iterate()) {
-				v->economy_age = v->age.base();
+				v->economy_age = TimerGameEconomy::Date{v->age.base()};
 			}
 		}
 	}

--- a/src/script/api/script_story_page.cpp
+++ b/src/script/api/script_story_page.cpp
@@ -83,7 +83,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 	TileIndex reftile{};
 	switch (type) {
 		case SPET_LOCATION:
-			reftile = reference;
+			reftile = TileIndex(reference);
 			break;
 		case SPET_GOAL:
 		case SPET_BUTTON_PUSH:
@@ -132,7 +132,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 	TileIndex reftile{};
 	switch (type) {
 		case ::SPET_LOCATION:
-			reftile = reference;
+			reftile = TileIndex(reference);
 			break;
 		case ::SPET_GOAL:
 		case ::SPET_BUTTON_PUSH:

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -608,7 +608,7 @@ static void ChangeTimekeepingUnits(int32_t)
 			new_economy_date_fract = 0;
 		} else {
 			/* If the new mode is calendar units, sync the economy year with the calendar year. */
-			new_economy_date = TimerGameCalendar::date.base();
+			new_economy_date = TimerGameEconomy::Date{TimerGameCalendar::date.base()};
 			new_economy_date_fract = TimerGameCalendar::date_fract;
 		}
 

--- a/src/timer/timer_game_economy.cpp
+++ b/src/timer/timer_game_economy.cpp
@@ -50,7 +50,7 @@ TimerGameEconomy::DateFract TimerGameEconomy::date_fract = {};
 
 	/* If we're using wallclock units, economy months have 30 days and an economy year has 360 days. */
 	TimerGameEconomy::YearMonthDay ymd;
-	ymd.year = date.base() / EconomyTime::DAYS_IN_ECONOMY_YEAR;
+	ymd.year = Year{date.base() / EconomyTime::DAYS_IN_ECONOMY_YEAR};
 	ymd.month = (date.base() % EconomyTime::DAYS_IN_ECONOMY_YEAR) / EconomyTime::DAYS_IN_ECONOMY_MONTH;
 	ymd.day = (date.base() % EconomyTime::DAYS_IN_ECONOMY_MONTH) + 1;
 	return ymd;

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2465,10 +2465,10 @@ struct ScenarioEditorToolbarWindow : Window {
 
 		TimerGameCalendar::Year value;
 		if (!str->empty()) {
-			value = atoi(str->c_str());
+			value = TimerGameCalendar::Year{atoi(str->c_str())};
 		} else {
 			/* An empty string means revert to the default */
-			value = CalendarTime::DEF_START_YEAR.base();
+			value = TimerGameCalendar::Year{CalendarTime::DEF_START_YEAR.base()};
 		}
 		SetStartingYear(value);
 

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -627,7 +627,7 @@ CommandCost CmdBuildTunnel(DoCommandFlag flags, TileIndex start_tile, TransportT
 
 	RailType railtype = INVALID_RAILTYPE;
 	RoadType roadtype = INVALID_ROADTYPE;
-	_build_tunnel_endtile = 0;
+	_build_tunnel_endtile = TileIndex{};
 	switch (transport_type) {
 		case TRANSPORT_RAIL:
 			railtype = (RailType)road_rail_type;


### PR DESCRIPTION
## Motivation / Problem

Since we just removed the implicitly converting constructor from StrongType, also remove the implicitly converting assignment operator.


## Description

Replace some `0` unnamed constants with `MIN_YEAR`, `MIN_DATE`, `TileIndex{}`, etc.
Add explicit converting constructors where applicable.
Remove implicitly converting assignment.


## Limitations

Makes writing some bits of code a bit more cumbersome because you have to explicitly tell what to convert to, though that also makes it clear that some (weird) conversion might be taking place.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
