### PR TITLE
Change: [NewGRF] Use deferred string mapping for bridge and currency names.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -2327,18 +2327,17 @@ static ChangeInfoResult BridgeChangeInfo(uint brid, int numinfo, int prop, ByteR
 				bridge->avail_year = Clamp(TimerGameCalendar::Year(buf.ReadDWord()), CalendarTime::MIN_YEAR, CalendarTime::MAX_YEAR);
 				break;
 
-			case 0x10: { // purchase string
-				StringID newone = GetGRFStringID(_cur.grffile->grfid, buf.ReadWord());
-				if (newone != STR_UNDEFINED) bridge->material = newone;
+			case 0x10: // purchase string
+				AddStringForMapping(buf.ReadWord(), &bridge->material);
 				break;
-			}
 
-			case 0x11: // description of bridge with rails or roads
-			case 0x12: {
-				StringID newone = GetGRFStringID(_cur.grffile->grfid, buf.ReadWord());
-				if (newone != STR_UNDEFINED) bridge->transport_name[prop - 0x11] = newone;
+			case 0x11: // description of bridge with rails
+				AddStringForMapping(buf.ReadWord(), &bridge->transport_name[0]);
 				break;
-			}
+
+			case 0x12: // description of bridge with roads
+				AddStringForMapping(buf.ReadWord(), &bridge->transport_name[1]);
+				break;
 
 			case 0x13: // 16 bits cost multiplier
 				bridge->price = buf.ReadWord();
@@ -2790,11 +2789,13 @@ static ChangeInfoResult GlobalVarChangeInfo(uint gvid, int numinfo, int prop, By
 
 			case 0x0A: { // Currency display names
 				uint curidx = GetNewgrfCurrencyIdConverted(gvid + i);
-				StringID newone = GetGRFStringID(_cur.grffile->grfid, buf.ReadWord());
-
-				if ((newone != STR_UNDEFINED) && (curidx < CURRENCY_END)) {
-					_currency_specs[curidx].name = newone;
-					_currency_specs[curidx].code.clear();
+				if (curidx < CURRENCY_END) {
+					AddStringForMapping(buf.ReadWord(), [curidx](StringID str) {
+						_currency_specs[curidx].name = str;
+						_currency_specs[curidx].code.clear();
+					});
+				} else {
+					buf.ReadWord();
 				}
 				break;
 			}


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

While tidying up users of AddStringForMapping, I noticed there are a few places where it is not used, and GRF strings are mapped directly.

This means that, for bridges and currencies, the strings must be defined before the properties that use them. While this isn't really a problem, all other string properties allow the string to defined later, so it is at least inconsistent.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Replace direct string mapping with calls to `AddStringForMapping()`.

This means that the strings can now be defined after the properties using them, as is the case with all other features.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
