### PR TITLE
Codefix: GSText incorrectly uses StringID

### DIFF
--- a/src/script/api/script_text.hpp
+++ b/src/script/api/script_text.hpp
@@ -132,13 +132,13 @@ private:
 	using Param = std::variant<SQInteger, std::string, ScriptTextRef>;
 
 	struct ParamCheck {
-		StringID owner;
+		uint owner;
 		int idx;
 		Param *param;
 		bool used = false;
 		const char *cmd = nullptr;
 
-		ParamCheck(StringID owner, int idx, Param *param) : owner(owner), idx(idx), param(param) {}
+		ParamCheck(uint owner, int idx, Param *param) : owner(owner), idx(idx), param(param) {}
 
 		void Encode(std::back_insert_iterator<std::string> &output, const char *cmd);
 	};
@@ -146,7 +146,7 @@ private:
 	using ParamList = std::vector<ParamCheck>;
 	using ParamSpan = std::span<ParamCheck>;
 
-	StringID string;
+	uint string;
 	std::array<Param, SCRIPT_TEXT_MAX_PARAMETERS> param = {};
 	int paramc = 0;
 

--- a/src/script/script_storage.hpp
+++ b/src/script/script_storage.hpp
@@ -17,6 +17,7 @@
 #include "../goal_type.h"
 #include "../story_type.h"
 
+#include "script_types.hpp"
 #include "script_log_types.hpp"
 
 #include "table/strings.h"
@@ -49,7 +50,7 @@ private:
 
 	CommandCost costs;               ///< The costs the script is tracking.
 	Money last_cost;                 ///< The last cost of the command.
-	uint last_error;                 ///< The last error of the command.
+	ScriptErrorType last_error{}; ///< The last error of the command.
 	bool last_command_res;           ///< The last result of the command.
 
 	CommandDataBuffer last_data;     ///< The last data passed to a command.
@@ -76,7 +77,6 @@ public:
 		allow_do_command  (true),
 		/* costs (can't be set) */
 		last_cost         (0),
-		last_error        (STR_NULL),
 		last_command_res  (true),
 		last_cmd          (CMD_END),
 		/* calback_value (can't be set) */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

GSText treats is string parameter as a StringID. But it is not a real StringID as it needs to be translated.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Change GSText to use uint instead of StringID.

Maybe it should be GSStringID?

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
