### PR TITLE
Codechange: always do StringID + offset, instead of offset + StringID

### DIFF
--- a/src/date_gui.cpp
+++ b/src/date_gui.cpp
@@ -132,8 +132,8 @@ struct SetDateWindow : Window {
 	void SetStringParameters(WidgetID widget) const override
 	{
 		switch (widget) {
-			case WID_SD_DAY:   SetDParam(0, this->date.day - 1 + STR_DAY_NUMBER_1ST); break;
-			case WID_SD_MONTH: SetDParam(0, this->date.month + STR_MONTH_JAN); break;
+			case WID_SD_DAY:   SetDParam(0, STR_DAY_NUMBER_1ST + this->date.day - 1); break;
+			case WID_SD_MONTH: SetDParam(0, STR_MONTH_JAN + this->date.month); break;
 			case WID_SD_YEAR:  SetDParam(0, this->date.year); break;
 		}
 	}

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -427,7 +427,7 @@ protected:
 			TimerGameEconomy::Month month = this->month;
 			TimerGameEconomy::Year year = this->year;
 			for (int i = 0; i < this->num_on_x_axis; i++) {
-				SetDParam(0, month + STR_MONTH_ABBREV_JAN);
+				SetDParam(0, STR_MONTH_ABBREV_JAN + month);
 				SetDParam(1, year);
 				DrawStringMultiLine(x, x + x_sep, y, this->height, month == 0 ? STR_GRAPH_X_LABEL_MONTH_YEAR : STR_GRAPH_X_LABEL_MONTH, GRAPH_AXIS_LABEL_COLOUR, SA_LEFT);
 
@@ -566,7 +566,7 @@ public:
 					TimerGameEconomy::Month month = this->month;
 					TimerGameEconomy::Year year = this->year;
 					for (int i = 0; i < this->num_on_x_axis; i++) {
-						SetDParam(0, month + STR_MONTH_ABBREV_JAN);
+						SetDParam(0, STR_MONTH_ABBREV_JAN + month);
 						SetDParam(1, year);
 						x_label_width = std::max(x_label_width, GetStringBoundingBox(month == 0 ? STR_GRAPH_X_LABEL_MONTH_YEAR : STR_GRAPH_X_LABEL_MONTH).width);
 

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -285,7 +285,7 @@ void DrawOrderString(const Vehicle *v, const Order *order, int order_index, int 
 				if (v->type == VEH_TRAIN && (order->GetNonStopType() & ONSF_NO_STOP_AT_DESTINATION_STATION) == 0) {
 					/* Only show the stopping location if other than the default chosen by the player. */
 					if (order->GetStopLocation() != (OrderStopLocation)(_settings_client.gui.stop_location)) {
-						SetDParam(5, order->GetStopLocation() + STR_ORDER_STOP_LOCATION_NEAR_END);
+						SetDParam(5, STR_ORDER_STOP_LOCATION_NEAR_END + order->GetStopLocation());
 					} else {
 						SetDParam(5, STR_EMPTY);
 					}

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -496,7 +496,7 @@ static void FormatYmdString(StringBuilder &builder, TimerGameCalendar::Date date
 {
 	TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(date);
 
-	auto tmp_params = MakeParameters(ymd.day + STR_DAY_NUMBER_1ST - 1, STR_MONTH_ABBREV_JAN + ymd.month, ymd.year);
+	auto tmp_params = MakeParameters(STR_DAY_NUMBER_1ST + ymd.day - 1, STR_MONTH_ABBREV_JAN + ymd.month, ymd.year);
 	FormatString(builder, GetStringPtr(STR_FORMAT_DATE_LONG), tmp_params, case_index);
 }
 


### PR DESCRIPTION
## Motivation / Problem

Inconsistent order of adding a `StringID` and an offset. Especially egregious is strings.cpp:499 where both orderings are used in the same line.
Furthermore, conceptually, you add the offset to a `StringID` and not the other way around.


## Description

Swap LHS & RHS of the `+` operator.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
