### PR TITLE
Fix: IntSettingDesc may have a callback for default value

### DIFF
--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1478,7 +1478,7 @@ void SettingEntry::Init(uint8_t level)
 /* Sets the given setting entry to its default value */
 void SettingEntry::ResetAll()
 {
-	SetSettingValue(this->setting, this->setting->def);
+	SetSettingValue(this->setting, this->setting->GetDefaultValue());
 }
 
 /**
@@ -1532,7 +1532,7 @@ bool SettingEntry::IsVisibleByRestrictionMode(RestrictionMode mode) const
 		/* This entry shall only be visible, if the value deviates from its default value. */
 
 		/* Read the default value. */
-		filter_value = sd->def;
+		filter_value = sd->GetDefaultValue();
 	} else {
 		assert(mode == RM_CHANGED_AGAINST_NEW);
 		/* This entry shall only be visible, if the value deviates from
@@ -2508,8 +2508,7 @@ struct GameSettingsWindow : Window {
 					DrawString(tr, STR_CONFIG_SETTING_TYPE);
 					tr.top += GetCharacterHeight(FS_NORMAL);
 
-					int32_t def_val = sd->get_def_cb != nullptr ? sd->get_def_cb() : sd->def;
-					sd->SetValueDParams(0, def_val);
+					sd->SetValueDParams(0, sd->GetDefaultValue());
 					DrawString(tr, STR_CONFIG_SETTING_DEFAULT_VALUE);
 					tr.top += GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.vsep_normal;
 
@@ -2743,10 +2742,8 @@ struct GameSettingsWindow : Window {
 			if (sd->flags & SF_GUI_CURRENCY) llvalue /= GetCurrency().rate;
 
 			value = ClampTo<int32_t>(llvalue);
-		} else if (sd->get_def_cb != nullptr) {
-			value = sd->get_def_cb();
 		} else {
-			value = sd->def;
+			value = sd->GetDefaultValue();
 		}
 
 		SetSettingValue(this->valuewindow_entry->setting, value);

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -234,6 +234,7 @@ struct IntSettingDesc : SettingDesc {
 	StringID GetTitle() const;
 	StringID GetHelp() const;
 	void SetValueDParams(uint first_param, int32_t value) const;
+	int32_t GetDefaultValue() const;
 
 	/**
 	 * Check whether this setting is a boolean type setting.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
https://github.com/OpenTTD/OpenTTD/pull/12376 introduced a callback mechanism for default value of int settings. But `SetDefaultCompanySettings()` doesn't know about it and still relies on static default value, which means AI ships default to 360 minutes service interval in wallclock mode.
Many other locations use `def` without checking `get_def_cb`.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Add a `GetDefaultValue()` wrapper to always use the default value callback if it exists.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
