### PR TITLE
Codechange: add and use GetToolTip instead of direct access

### DIFF
--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1155,6 +1155,15 @@ void NWidgetCore::SetToolTip(StringID tool_tip)
 }
 
 /**
+ * Get the tool tip of the nested widget.
+ * @return The tool tip string.
+ */
+StringID NWidgetCore::GetToolTip() const
+{
+	return this->tool_tip;
+}
+
+/**
  * Set the text/image alignment of the nested widget.
  * @param align Alignment to use.
  */

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -377,6 +377,7 @@ public:
 	void SetSpriteTip(SpriteID sprite, StringID tool_tip) { this->SetDataTip(sprite, tool_tip); }
 	void SetMatrixDataTip(uint8_t cols, uint8_t rows, StringID tip) { this->SetDataTip(static_cast<uint32_t>((rows << MAT_ROW_START) | (cols << MAT_COL_START)), tip); }
 	void SetToolTip(StringID tool_tip);
+	StringID GetToolTip() const;
 	void SetTextStyle(TextColour colour, FontSize size);
 	void SetAlignment(StringAlignment align);
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -756,8 +756,8 @@ static void DispatchRightClickEvent(Window *w, int x, int y)
 	} else if (_settings_client.gui.right_click_wnd_close == RCC_YES_EXCEPT_STICKY && (w->flags & WF_STICKY) == 0 && (w->window_desc.flags & WDF_NO_CLOSE) == 0) {
 		/* Right-click close is enabled, but excluding sticky windows. */
 		w->Close();
-	} else if (_settings_client.gui.hover_delay_ms == 0 && !w->OnTooltip(pt, wid->index, TCC_RIGHT_CLICK) && wid->tool_tip != 0) {
-		GuiShowTooltips(w, wid->tool_tip, TCC_RIGHT_CLICK);
+	} else if (_settings_client.gui.hover_delay_ms == 0 && !w->OnTooltip(pt, wid->index, TCC_RIGHT_CLICK) && wid->GetToolTip() != STR_NULL) {
+		GuiShowTooltips(w, wid->GetToolTip(), TCC_RIGHT_CLICK);
 	}
 }
 
@@ -777,8 +777,8 @@ static void DispatchHoverEvent(Window *w, int x, int y)
 	Point pt = { x, y };
 
 	/* Show the tooltip if there is any */
-	if (!w->OnTooltip(pt, wid->index, TCC_HOVER) && wid->tool_tip != 0) {
-		GuiShowTooltips(w, wid->tool_tip, TCC_HOVER);
+	if (!w->OnTooltip(pt, wid->index, TCC_HOVER) && wid->GetToolTip() != STR_NULL) {
+		GuiShowTooltips(w, wid->GetToolTip(), TCC_HOVER);
 		return;
 	}
 


### PR DESCRIPTION
## Motivation / Problem

LordAro asking whether `tool_tip` and `widget_data` access can be `private` in #13243.
Also `0` being used instead of `STR_NULL`.


## Description

Add `GetToolTip` and use it, and replace some `0`s with `STR_NULL` where they were used to compare against `GetToolTip`.


## Limitations

Can't make `tool_tip` private yet, as that requires #13243 as that covers the cases where the tooltip is set.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
