### PR TITLE
Codechange: remove (unused) tooltip from function to set matrix dimensions

### DIFF
--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -286,7 +286,7 @@ struct DepotWindow : Window {
 		/* Don't show 'rename button' of aircraft hangar */
 		this->GetWidget<NWidgetStacked>(WID_D_SHOW_RENAME)->SetDisplayedPlane(type == VEH_AIRCRAFT ? SZSP_NONE : 0);
 		/* Only train depots have a horizontal scrollbar and a 'sell chain' button */
-		if (type == VEH_TRAIN) this->GetWidget<NWidgetCore>(WID_D_MATRIX)->widget_data = 1 << MAT_COL_START;
+		if (type == VEH_TRAIN) this->GetWidget<NWidgetCore>(WID_D_MATRIX)->SetMatrixDimension(1, 0 /* auto-scale */);
 		this->GetWidget<NWidgetStacked>(WID_D_SHOW_H_SCROLL)->SetDisplayedPlane(type == VEH_TRAIN ? 0 : SZSP_HORIZONTAL);
 		this->GetWidget<NWidgetStacked>(WID_D_SHOW_SELL_CHAIN)->SetDisplayedPlane(type == VEH_TRAIN ? 0 : SZSP_NONE);
 		this->SetupWidgetData(type);

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -555,7 +555,7 @@ public:
 
 				resize.width = 0;
 				resize.height = 0;
-				this->GetWidget<NWidgetCore>(WID_GRAPH_RANGE_MATRIX)->SetMatrixDataTip(1, ClampTo<uint8_t>(std::size(this->ranges)), STR_NULL);
+				this->GetWidget<NWidgetCore>(WID_GRAPH_RANGE_MATRIX)->SetMatrixDimension(1, ClampTo<uint8_t>(std::size(this->ranges)));
 				break;
 
 			case WID_GRAPH_GRAPH: {

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1175,6 +1175,16 @@ void NWidgetCore::SetSpriteTip(SpriteID sprite, StringID tool_tip)
 }
 
 /**
+ * Set the matrix dimension.
+ * @param columns The number of columns in the matrix (0 for autoscaling).
+ * @param rows The number of rows in the matrix (0 for autoscaling).
+ */
+void NWidgetCore::SetMatrixDimension(uint8_t columns, uint8_t rows)
+{
+	this->widget_data = static_cast<uint32_t>((rows << MAT_ROW_START) | (columns << MAT_COL_START));
+}
+
+/**
  * Set the text style of the nested widget.
  * @param colour TextColour to use.
  * @param size Font size to use.

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -377,7 +377,7 @@ public:
 	void SetStringTip(StringID string, StringID tool_tip);
 	void SetSprite(SpriteID sprite);
 	void SetSpriteTip(SpriteID sprite, StringID tool_tip);
-	void SetMatrixDataTip(uint8_t cols, uint8_t rows, StringID tip) { this->SetDataTip(static_cast<uint32_t>((rows << MAT_ROW_START) | (cols << MAT_COL_START)), tip); }
+	void SetMatrixDimension(uint8_t columns, uint8_t rows);
 	void SetToolTip(StringID tool_tip);
 	StringID GetToolTip() const;
 	void SetTextStyle(TextColour colour, FontSize size);


### PR DESCRIPTION
## Motivation / Problem

`SetMatrixDataTip` is only called with `STR_NULL` as tooltip, making the tooltip part practically useless. It could also use a slightly more descriptive name, and there is a direct access to `widget_data` that is not going through this accessor.


## Description

Remove tooltip parameter.
Rename to `SetMatrixDimension` and move implementation to widget.cpp.
Replace direct modification of `widget_data` with call to `SetMatrixDimension`.


## Limitations

The limit of 255 rows/columns remains for now.
Also a call to `SetDataTip` in the accessor function was changed to directly change `widget_data`, kinda undoing some work, but also making it possible to remove `SetDataTip` in the future.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
