### PR TITLE
Codechange: replace last usage of SetDataTip with specific variant

### DIFF
--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1124,17 +1124,6 @@ NWidgetCore::NWidgetCore(WidgetType tp, Colours colour, WidgetID index, uint fil
 }
 
 /**
- * Set data and tool tip of the nested widget.
- * @param widget_data Data to use.
- * @param tool_tip    Tool tip string to use.
- */
-void NWidgetCore::SetDataTip(uint32_t widget_data, StringID tool_tip)
-{
-	this->widget_data = widget_data;
-	this->tool_tip = tool_tip;
-}
-
-/**
  * Set string of the nested widget.
  * @param string The new string.
  */
@@ -1182,6 +1171,15 @@ void NWidgetCore::SetSpriteTip(SpriteID sprite, StringID tool_tip)
 void NWidgetCore::SetMatrixDimension(uint8_t columns, uint8_t rows)
 {
 	this->widget_data = static_cast<uint32_t>((rows << MAT_ROW_START) | (columns << MAT_COL_START));
+}
+
+/**
+ * Set the resize widget type of the nested widget.
+ * @param type The new resize widget.
+ */
+void NWidgetCore::SetResizeWidgetType(ResizeWidgetValues type)
+{
+	this->widget_data = type;
 }
 
 /**
@@ -2770,7 +2768,8 @@ NWidgetLeaf::NWidgetLeaf(WidgetType tp, Colours colour, WidgetID index, uint32_t
 		case WWT_RESIZEBOX:
 			this->SetFill(0, 0);
 			this->SetMinimalSize(WidgetDimensions::WD_RESIZEBOX_WIDTH, 12);
-			this->SetDataTip(RWV_SHOW_BEVEL, STR_TOOLTIP_RESIZE);
+			this->SetResizeWidgetType(RWV_SHOW_BEVEL);
+			this->SetToolTip(STR_TOOLTIP_RESIZE);
 			break;
 
 		case WWT_CLOSEBOX:

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -372,12 +372,12 @@ class NWidgetCore : public NWidgetResizeBase {
 public:
 	NWidgetCore(WidgetType tp, Colours colour, WidgetID index, uint fill_x, uint fill_y, uint32_t widget_data, StringID tool_tip);
 
-	void SetDataTip(uint32_t widget_data, StringID tool_tip);
 	void SetString(StringID string);
 	void SetStringTip(StringID string, StringID tool_tip);
 	void SetSprite(SpriteID sprite);
 	void SetSpriteTip(SpriteID sprite, StringID tool_tip);
 	void SetMatrixDimension(uint8_t columns, uint8_t rows);
+	void SetResizeWidgetType(ResizeWidgetValues type);
 	void SetToolTip(StringID tool_tip);
 	StringID GetToolTip() const;
 	void SetTextStyle(TextColour colour, FontSize size);


### PR DESCRIPTION
## Motivation / Problem

For #13235 we want to get rid of `SetDataTip`, or at least have variants for each of the specific types of data that can be stored in a widget. There is still one user of `SetDataTip`, so migrate that to a new function for that specific type.


## Description

Add `SetResizeWidgetType` akin `SetString` and `SetSprite`, and use it.
Remove `SetDataTip`.


## Limitations

None I'm aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
