### PR TITLE
Codechange: Optimize FindSpring

### DIFF
--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -992,29 +992,26 @@ static void CreateDesertOrRainForest(uint desert_tropic_line)
  */
 static bool FindSpring(TileIndex tile, void *)
 {
-	int reference_height;
-	if (!IsTileFlat(tile, &reference_height) || IsWaterTile(tile)) return false;
-
 	/* In the tropics rivers start in the rainforest. */
 	if (_settings_game.game_creation.landscape == LT_TROPIC && GetTropicZone(tile) != TROPICZONE_RAINFOREST) return false;
 
+	int reference_height;
+	if (IsWaterTile(tile) || !IsTileFlat(tile, &reference_height)) return false;
+
 	/* Are there enough higher tiles to warrant a 'spring'? */
 	uint num = 0;
-	for (int dx = -1; dx <= 1; dx++) {
-		for (int dy = -1; dy <= 1; dy++) {
-			TileIndex t = TileAddWrap(tile, dx, dy);
-			if (t != INVALID_TILE && GetTileMaxZ(t) > reference_height) num++;
-		}
+	for (Direction d = DIR_BEGIN; d != DIR_END; d++) {
+		TileIndex t = AddTileIndexDiffCWrap(tile, TileIndexDiffCByDir(d));
+		if (IsValidTile(t) && GetTileMaxZ(t) > reference_height) num++;
+		if (num == 4) break;
 	}
-
 	if (num < 4) return false;
 
 	/* Are we near the top of a hill? */
-	for (int dx = -16; dx <= 16; dx++) {
-		for (int dy = -16; dy <= 16; dy++) {
-			TileIndex t = TileAddWrap(tile, dx, dy);
-			if (t != INVALID_TILE && GetTileMaxZ(t) > reference_height + 2) return false;
-		}
+	reference_height += 2;
+	TileArea tile_area = TileArea(tile, 1, 1).Expand(16);
+	for (TileIndex t : tile_area) {
+		if (!IsTileType(t, MP_VOID) && GetTileMaxZ(t) > reference_height) return false;
 	}
 
 	return true;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
The ordering of checks can be improved. Some functions are more expensive than others.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
- For `FindSpring`, check for `TropicZone` first before all other checks.
- Swap `IsWaterTile` with `IsTileFlat` as computing `IsTileFlat` is more expensive.
- Replace the code that warrants a spring which is using 2 loops `for` `dx` and `dy` with equivalent `Direction` loop using `TileIndexDiffCByDir` offsets and `break` as early as once the `num` of warranted tiles is met.
- Replace the code checking if we're near the top of the hill with equivalent `TileArea` based code which reduces the number of tile checks when near map edges.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
In theory, the new code should still generate the same spring locations, but didn't yet confirm. I don't think it's that important. EDIT: Tested: Rivers are still generated with the same springs locations.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
