### PR TITLE
Codechange: Make GetDefaultValueCallback() more similar to other setting override callbacks

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -479,7 +479,7 @@ void IntSettingDesc::SetValueDParams(uint first_param, int32_t value) const
  */
 int32_t IntSettingDesc::GetDefaultValue() const
 {
-	return this->get_def_cb != nullptr ? this->get_def_cb() : this->def;
+	return this->get_def_cb != nullptr ? this->get_def_cb(*this) : this->def;
 }
 
 /**

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -149,6 +149,7 @@ struct IntSettingDesc : SettingDesc {
 	typedef StringID GetTitleCallback(const IntSettingDesc &sd);
 	typedef StringID GetHelpCallback(const IntSettingDesc &sd);
 	typedef void SetValueDParamsCallback(const IntSettingDesc &sd, uint first_param, int32_t value);
+	typedef int32_t GetDefaultValueCallback(const IntSettingDesc &sd);
 
 	/**
 	 * A check to be performed before the setting gets changed. The passed integer may be
@@ -164,12 +165,6 @@ struct IntSettingDesc : SettingDesc {
 	 * @param The new value for the setting.
 	 */
 	typedef void PostChangeCallback(int32_t value);
-	/**
-	 * A callback to get the correct default value. For example a default that can be measured in time
-	 * units or expressed as a percentage.
-	 * @return The correct default value for the setting.
-	 */
-	typedef int32_t GetDefaultValueCallback();
 
 	template <
 		typename Tdef,

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -265,9 +265,8 @@ static void UpdateServiceInterval(VehicleType type, int32_t new_value)
 
 /**
  * Checks if the service intervals in the settings are specified as percentages and corrects the default value accordingly.
- * @param new_value Contains the service interval's default value in days, or 50 (default in percentage).
  */
-static int32_t GetDefaultServiceInterval(VehicleType type)
+static int32_t GetDefaultServiceInterval(const IntSettingDesc &sd, VehicleType type)
 {
 	VehicleDefaultSettings *vds;
 	if (_game_mode == GM_MENU || !Company::IsValidID(_current_company)) {
@@ -276,28 +275,19 @@ static int32_t GetDefaultServiceInterval(VehicleType type)
 		vds = &Company::Get(_current_company)->settings.vehicle;
 	}
 
-	int32_t new_value;
-	if (vds->servint_ispercent) {
-		new_value = DEF_SERVINT_PERCENT;
-	} else if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU)) {
+	if (vds->servint_ispercent) return DEF_SERVINT_PERCENT;
+
+	if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU)) {
 		switch (type) {
-			case VEH_TRAIN:    new_value = DEF_SERVINT_MINUTES_TRAINS; break;
-			case VEH_ROAD:     new_value = DEF_SERVINT_MINUTES_ROADVEH; break;
-			case VEH_AIRCRAFT: new_value = DEF_SERVINT_MINUTES_AIRCRAFT; break;
-			case VEH_SHIP:     new_value = DEF_SERVINT_MINUTES_SHIPS; break;
-			default: NOT_REACHED();
-		}
-	} else {
-		switch (type) {
-			case VEH_TRAIN:    new_value = DEF_SERVINT_DAYS_TRAINS; break;
-			case VEH_ROAD:     new_value = DEF_SERVINT_DAYS_ROADVEH; break;
-			case VEH_AIRCRAFT: new_value = DEF_SERVINT_DAYS_AIRCRAFT; break;
-			case VEH_SHIP:     new_value = DEF_SERVINT_DAYS_SHIPS; break;
+			case VEH_TRAIN:    return DEF_SERVINT_MINUTES_TRAINS;
+			case VEH_ROAD:     return DEF_SERVINT_MINUTES_ROADVEH;
+			case VEH_AIRCRAFT: return DEF_SERVINT_MINUTES_AIRCRAFT;
+			case VEH_SHIP:     return DEF_SERVINT_MINUTES_SHIPS;
 			default: NOT_REACHED();
 		}
 	}
 
-	return new_value;
+	return sd.def;
 }
 
 static void TrainAccelerationModelChanged(int32_t)

--- a/src/table/settings/company_settings.ini
+++ b/src/table/settings/company_settings.ini
@@ -13,7 +13,7 @@ static bool CanUpdateServiceInterval(VehicleType type, int32_t &new_value);
 static void UpdateServiceInterval(VehicleType type, int32_t new_value);
 static void SettingsValueAbsolute(const IntSettingDesc &sd, uint first_param, int32_t value);
 static void ServiceIntervalSettingsValueText(const IntSettingDesc &sd, uint first_param, int32_t value);
-static int32_t GetDefaultServiceInterval(VehicleType type);
+static int32_t GetDefaultServiceInterval(const IntSettingDesc &sd, VehicleType type);
 
 static const SettingVariant _company_settings_table[] = {
 [post-amble]
@@ -100,7 +100,7 @@ strhelp  = STR_CONFIG_SETTING_SERVINT_TRAINS_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE_DAYS
 pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_TRAIN, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_TRAIN, new_value); }
-def_cb   = []() { return GetDefaultServiceInterval(VEH_TRAIN); }
+def_cb   = [](auto &sd) { return GetDefaultServiceInterval(sd, VEH_TRAIN); }
 val_cb   = ServiceIntervalSettingsValueText
 
 [SDT_VAR]
@@ -116,7 +116,7 @@ strhelp  = STR_CONFIG_SETTING_SERVINT_ROAD_VEHICLES_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE_DAYS
 pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_ROAD, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_ROAD, new_value); }
-def_cb   = []() { return GetDefaultServiceInterval(VEH_ROAD); }
+def_cb   = [](auto &sd) { return GetDefaultServiceInterval(sd, VEH_ROAD); }
 val_cb   = ServiceIntervalSettingsValueText
 
 [SDT_VAR]
@@ -132,7 +132,7 @@ strhelp  = STR_CONFIG_SETTING_SERVINT_SHIPS_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE_DAYS
 pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_SHIP, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_SHIP, new_value); }
-def_cb   = []() { return GetDefaultServiceInterval(VEH_SHIP); }
+def_cb   = [](auto &sd) { return GetDefaultServiceInterval(sd, VEH_SHIP); }
 val_cb   = ServiceIntervalSettingsValueText
 
 [SDT_VAR]
@@ -148,5 +148,5 @@ strhelp  = STR_CONFIG_SETTING_SERVINT_AIRCRAFT_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE_DAYS
 pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_AIRCRAFT, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_AIRCRAFT, new_value); }
-def_cb   = []() { return GetDefaultServiceInterval(VEH_AIRCRAFT); }
+def_cb   = [](auto &sd) { return GetDefaultServiceInterval(sd, VEH_AIRCRAFT); }
 val_cb   = ServiceIntervalSettingsValueText


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Callbacks for `str`, `str_help` and `str_val` are called with `const IntSettingDesc &sd`, this allows them to use static value from the setting itself.
Callback for `def` doesn't have this option.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Change `GetDefaultValueCallback()` signature to pass `const IntSettingDesc &sd` like other callbacks.
Rewrite `GetDefaultServiceInterval()` using the new ability.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
