### PR TITLE
Change: When player joins network company, use its name instead of number in chat

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2630,7 +2630,7 @@ STR_NETWORK_SERVER_MESSAGE_GAME_REASON_LINK_GRAPH               :waiting for lin
 STR_NETWORK_MESSAGE_CLIENT_LEAVING                              :leaving
 STR_NETWORK_MESSAGE_CLIENT_JOINED                               :*** {RAW_STRING} has joined the game
 STR_NETWORK_MESSAGE_CLIENT_JOINED_ID                            :*** {0:RAW_STRING} has joined the game (Client #{2:NUM})
-STR_NETWORK_MESSAGE_CLIENT_COMPANY_JOIN                         :*** {0:RAW_STRING} has joined company #{2:NUM}
+STR_NETWORK_MESSAGE_CLIENT_COMPANY_JOIN                         :*** {RAW_STRING} has joined {RAW_STRING}
 STR_NETWORK_MESSAGE_CLIENT_COMPANY_SPECTATE                     :*** {RAW_STRING} has joined spectators
 STR_NETWORK_MESSAGE_CLIENT_COMPANY_NEW                          :*** {0:RAW_STRING} has started a new company (#{2:NUM})
 STR_NETWORK_MESSAGE_CLIENT_LEFT                                 :*** {0:RAW_STRING} has left the game ({2:STRING})

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -2002,11 +2002,18 @@ void NetworkServerDoMove(ClientID client_id, CompanyID company_id)
 		cs->SendMove(client_id, company_id);
 	}
 
-	/* announce the client's move */
+	/* Announce the client's move. */
 	NetworkUpdateClientInfo(client_id);
 
-	NetworkAction action = (company_id == COMPANY_SPECTATOR) ? NETWORK_ACTION_COMPANY_SPECTATOR : NETWORK_ACTION_COMPANY_JOIN;
-	NetworkServerSendChat(action, DESTTYPE_BROADCAST, 0, "", client_id, company_id + 1);
+	if (company_id == COMPANY_SPECTATOR) {
+		/* The client has joined spectators. */
+		NetworkServerSendChat(NETWORK_ACTION_COMPANY_SPECTATOR, DESTTYPE_BROADCAST, 0, "", client_id);
+	} else {
+		/* The client has joined another company. */
+		SetDParam(0, company_id);
+		std::string company_name = GetString(STR_COMPANY_NAME);
+		NetworkServerSendChat(NETWORK_ACTION_COMPANY_JOIN, DESTTYPE_BROADCAST, 0, company_name, client_id);
+	}
 
 	InvalidateWindowData(WC_CLIENT_LIST, 0);
 }


### PR DESCRIPTION
## Motivation / Problem

When playing a network game where players frequently change companies (common in collaborative games with trusted friends), the chat message `2TallTyler joined company #2` doesn't really give any useful information.

## Description

Using the company name, as in `2TallTyler joined JNR North`, is much more descriptive.

This intentionally breaks translations due to the string code changes (I tested). This is necessary because the CompanyID is not sent in the network command anymore.

The company number is still used when a player creates a new company, since all new companies are `Unnamed` until the player builds something to autogenerate a name, or chooses one.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
