### PR TITLE
Codechange: Optimize FlowRiver

### DIFF
--- a/src/core/strong_typedef_type.hpp
+++ b/src/core/strong_typedef_type.hpp
@@ -158,4 +158,31 @@ namespace StrongType {
 	};
 }
 
+/**
+ * Implementation of std::hash for StrongType::Typedef.
+ *
+ * This specialization of std::hash allows hashing of StrongType::Typedef instances
+ * by leveraging the hash of the base type.
+ *
+ * Example Usage:
+ *   using MyType = StrongType::Typedef<int, struct MyTypeTag>;
+ *   std::unordered_map<MyType, std::string> my_map;
+ *
+ * @tparam TBaseType The underlying type of the StrongType::Typedef.
+ * @tparam TProperties Additional properties for the StrongType::Typedef.
+ */
+template <typename TBaseType, typename... TProperties>
+struct std::hash<StrongType::Typedef<TBaseType, TProperties...>> {
+	/**
+	 * Computes the hash value for a StrongType::Typedef instance.
+	 *
+	 * @param t The StrongType::Typedef instance to hash.
+	 * @return The hash value of the base type of t.
+	 */
+	std::size_t operator()(const StrongType::Typedef<TBaseType, TProperties...> &t) const noexcept
+	{
+		return std::hash<TBaseType>()(t.base());
+	}
+};
+
 #endif /* STRONG_TYPEDEF_TYPE_HPP */


### PR DESCRIPTION
<!--
Commit message:
- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
- The ordering of checks can be improved.
- `std::set` is slow.
- `std::list` is slow.
- `count` of tiles for lake is unnecessary.
- Picking of n-th tile from the start of the container to make `lake_centre`, but the tiles in the container are sorted by `TileIndex` and not in order they were inserted.
- `IsTileFlat` can also return tile height.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
- Make all `height_tile` `int` to allow comparison between heights generated from `TileHeight` and heights generated from `IsTileFlat`.
- Make the first check `IsWaterTile` as that is the first thing that should be checked for `FlowRiver` recursive calls. Swaps position with `height_begin`.
- Change `std::set` to `std::unordered_set` which is faster at the `contains` function.
- Change `std::list` to `std::vector` to be a queue, but do not pop items from it when advancing the queue. The tiles in it are ordered by insertion which is what's needed for the n-th tile to make `lake_centre`.
- `count` is not required. It can be extracted from either the unordered set or the vector.
- Swap the order of checks for determining the validity of `lake_centre` tile, making `IsTileFlat` and `DistanceManhattan` the last ones to check as I believe are the most computational.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Does not generate the same rivers due to the picking of n-th tile as `lake_centre` being different.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
