### PR TITLE
Change: Convert Magic Bulldozer to settings

### DIFF
--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -172,7 +172,7 @@ static int32_t ClickChangeMaxHlCheat(int32_t new_value, int32_t)
 enum CheatNumbers : uint8_t {
 	CHT_MONEY,           ///< Change amount of money.
 	CHT_CHANGE_COMPANY,  ///< Switch company.
-	CHT_EXTRA_DYNAMITE,  ///< Dynamite anything.
+	CHT_EXTRA_DYNAMITE,  ///< UNUSED: Dynamite anything.
 	CHT_CROSSINGTUNNELS, ///< Allow tunnels to cross each other.
 	CHT_NO_JETCRASH,     ///< Disable jet-airplane crashes.
 	CHT_SETUP_PROD,      ///< Allow manually editing of industry production.
@@ -206,7 +206,6 @@ struct CheatEntry {
 static const CheatEntry _cheats_ui[] = {
 	{SLE_INT32, STR_CHEAT_MONEY,           &_money_cheat_amount,                          &_cheats.money.been_used,            &ClickMoneyCheat         },
 	{SLE_UINT8, STR_CHEAT_CHANGE_COMPANY,  &_local_company,                               &_cheats.switch_company.been_used,   &ClickChangeCompanyCheat },
-	{SLE_BOOL,  STR_CHEAT_EXTRA_DYNAMITE,  &_cheats.magic_bulldozer.value,                &_cheats.magic_bulldozer.been_used,  nullptr                  },
 	{SLE_BOOL,  STR_CHEAT_CROSSINGTUNNELS, &_cheats.crossing_tunnels.value,               &_cheats.crossing_tunnels.been_used, nullptr                  },
 	{SLE_BOOL,  STR_CHEAT_NO_JETCRASH,     &_cheats.no_jetcrash.value,                    &_cheats.no_jetcrash.been_used,      nullptr                  },
 	{SLE_BOOL,  STR_CHEAT_SETUP_PROD,      &_cheats.setup_prod.value,                     &_cheats.setup_prod.been_used,       &ClickSetProdCheat       },
@@ -215,7 +214,7 @@ static const CheatEntry _cheats_ui[] = {
 	{SLE_INT32, STR_CHEAT_CHANGE_DATE,     &TimerGameCalendar::year,                      &_cheats.change_date.been_used,      &ClickChangeDateCheat    },
 };
 
-static_assert(CHT_NUM_CHEATS == lengthof(_cheats_ui));
+static_assert(CHT_NUM_CHEATS == lengthof(_cheats_ui) + 1); // Removed from the UI: Magic Bulldozer.
 
 /** Widget definitions of the cheat GUI. */
 static constexpr std::initializer_list<NWidgetPart> _nested_cheat_widgets = {

--- a/src/cheat_type.h
+++ b/src/cheat_type.h
@@ -24,7 +24,7 @@ struct Cheat {
  * Only add new entries at the end of the struct!
  */
 struct Cheats {
-	Cheat magic_bulldozer{}; ///< dynamite industries, objects
+	Cheat magic_bulldozer{}; ///< REMOVED: dynamite industries, objects
 	Cheat switch_company{};  ///< change to another company
 	Cheat money{}; ///< get rich or poor
 	Cheat crossing_tunnels{}; ///< allow tunnels that cross each other

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -492,22 +492,37 @@ static CommandCost ClearTile_Industry(TileIndex tile, DoCommandFlags flags)
 	Industry *i = Industry::GetByTile(tile);
 	const IndustrySpec *indspec = GetIndustrySpec(i->type);
 
-	/* water can destroy industries
-	 * in editor you can bulldoze industries
-	 * with magic_bulldozer cheat you can destroy industries
-	 * (area around OILRIG is water, so water shouldn't flood it
-	 */
-	if ((_current_company != OWNER_WATER && _game_mode != GM_EDITOR &&
-			!_cheats.magic_bulldozer.value) ||
-			flags.Test(DoCommandFlag::Auto) ||
-			(_current_company == OWNER_WATER &&
-				(indspec->behaviour.Test(IndustryBehaviour::BuiltOnWater) ||
-				HasBit(GetIndustryTileSpec(GetIndustryGfx(tile))->slopes_refused, 5)))) {
+	/* Flooding can always destroy industries. */
+	bool flooding = _current_company == OWNER_WATER && (indspec->behaviour.Test(IndustryBehaviour::BuiltOnWater) || HasBit(GetIndustryTileSpec(GetIndustryGfx(tile))->slopes_refused, 5));
 
-		if (flags.Test(DoCommandFlag::Auto)) {
-			return CommandCostWithParam(STR_ERROR_GENERIC_OBJECT_IN_THE_WAY, indspec->name);
+	/* Check if the player can bulldoze the industry. */
+	if (!flooding) {
+		switch (_settings_game.construction.bulldoze_industries) {
+			/* If we can't bulldoze industries at all, return the proper error. */
+			default:
+			case BulldozeIndustries::None:
+				/* If we are attempting to clear the tile to build something else, tell the player that the industry is in their way. */
+				if (flags.Test(DoCommandFlag::Auto)) return CommandCostWithParam(STR_ERROR_GENERIC_OBJECT_IN_THE_WAY, indspec->name);
+
+				/* Player is trying to bulldoze the industry. */
+				return CommandCost(STR_ERROR_INDUSTRIES_CANNOT_BE_REMOVED);
+
+			case BulldozeIndustries::Unserved:
+				/* Don't bulldoze industries that have recently had any cargo transported...*/
+				for (const auto &p : i->produced) {
+					if (p.history[LAST_MONTH].PctTransported() > 0) return CommandCost(STR_ERROR_INDUSTRY_IN_USE);
+				}
+
+				/* ...or received. */
+				for (const auto &a : i->accepted) {
+					if (a.last_accepted + EconomyTime::DAYS_IN_ECONOMY_YEAR > TimerGameEconomy::date) return CommandCost(STR_ERROR_INDUSTRY_IN_USE);
+				}
+				break;
+
+			case BulldozeIndustries::All:
+				/* Allow the industry to be demolished. */
+				break;
 		}
-		return CommandCost(INVALID_STRING_ID);
 	}
 
 	if (flags.Test(DoCommandFlag::Execute)) {

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -504,10 +504,10 @@ static CommandCost ClearTile_Industry(TileIndex tile, DoCommandFlags flags)
 				(indspec->behaviour.Test(IndustryBehaviour::BuiltOnWater) ||
 				HasBit(GetIndustryTileSpec(GetIndustryGfx(tile))->slopes_refused, 5)))) {
 
-		if (flags.Test(DoCommandFlag::Auto)) {
-			return CommandCostWithParam(STR_ERROR_GENERIC_OBJECT_IN_THE_WAY, indspec->name);
+			case BulldozeIndustries::All:
+				/* Allow the industry to be demolished. */
+				break;
 		}
-		return CommandCost(INVALID_STRING_ID);
 	}
 
 	if (flags.Test(DoCommandFlag::Execute)) {

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2318,7 +2318,6 @@ STR_HELP_WINDOW_COMMUNITY                                       :{BLACK}Communit
 STR_CHEATS                                                      :{WHITE}Sandbox Options
 STR_CHEAT_MONEY                                                 :{LTBLUE}Increase money by {CURRENCY_LONG}
 STR_CHEAT_CHANGE_COMPANY                                        :{LTBLUE}Playing as company: {ORANGE}{COMMA}
-STR_CHEAT_EXTRA_DYNAMITE                                        :{LTBLUE}Magic bulldozer (remove industries, unmovable objects): {ORANGE}{STRING}
 STR_CHEAT_CROSSINGTUNNELS                                       :{LTBLUE}Tunnels may cross each other: {ORANGE}{STRING}
 STR_CHEAT_NO_JETCRASH                                           :{LTBLUE}Jetplanes will not crash (frequently) on small airports: {ORANGE}{STRING}
 STR_CHEAT_EDIT_MAX_HL                                           :{LTBLUE}Edit the maximum map height: {ORANGE}{NUM}

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1436,6 +1436,13 @@ STR_CONFIG_SETTING_INDUSTRY_PLATFORM_HELPTEXT                   :Amount of flat 
 STR_CONFIG_SETTING_MULTIPINDTOWN                                :Allow multiple similar industries per town: {STRING2}
 STR_CONFIG_SETTING_MULTIPINDTOWN_HELPTEXT                       :Normally, a town does not want more than one industry of each type. With this setting, it will allow several industries of the same type in the same town
 
+STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES                          :Allow bulldozing industries: {STRING2}
+STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES_HELPTEXT                 :Allow industries to be demolished
+###length 3
+STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES_NONE                     :None
+STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES_UNSERVED                 :Unserved only
+STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES_ALL                      :All
+
 STR_CONFIG_SETTING_SIGNALSIDE                                   :Show signals: {STRING2}
 STR_CONFIG_SETTING_SIGNALSIDE_HELPTEXT                          :Select on which side of the track to place signals
 ###length 3
@@ -5102,6 +5109,8 @@ STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION                        :land sloped in 
 STR_ERROR_CAN_T_DO_THIS                                         :Can't do this...
 STR_ERROR_BUILDING_MUST_BE_DEMOLISHED                           :building must be demolished first
 STR_ERROR_BUILDING_IS_PROTECTED                                 :building is protected
+STR_ERROR_INDUSTRY_IN_USE                                       :industry is in use
+STR_ERROR_INDUSTRIES_CANNOT_BE_REMOVED                          :industries cannot be removed
 STR_ERROR_CAN_T_CLEAR_THIS_AREA                                 :Can't clear this area...
 STR_ERROR_SITE_UNSUITABLE                                       :site unsuitable
 STR_ERROR_ALREADY_BUILT                                         :already built

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1443,6 +1443,9 @@ STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES_NONE                     :None
 STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES_UNSERVED                 :Unserved only
 STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES_ALL                      :All
 
+STR_CONFIG_SETTING_BULLDOZE_OBJECTS                             :Allow bulldozing immovable objects
+STR_CONFIG_SETTING_BULLDOZE_OBJECTS_HELPTEXT                    :Allow lighthouses, transmitters, and NewGRF objects to be demolished
+
 STR_CONFIG_SETTING_SIGNALSIDE                                   :Show signals: {STRING2}
 STR_CONFIG_SETTING_SIGNALSIDE_HELPTEXT                          :Select on which side of the track to place signals
 ###length 3

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2325,7 +2325,6 @@ STR_HELP_WINDOW_COMMUNITY                                       :{BLACK}Communit
 STR_CHEATS                                                      :{WHITE}Sandbox Options
 STR_CHEAT_MONEY                                                 :{LTBLUE}Increase money by {CURRENCY_LONG}
 STR_CHEAT_CHANGE_COMPANY                                        :{LTBLUE}Playing as company: {ORANGE}{COMMA}
-STR_CHEAT_EXTRA_DYNAMITE                                        :{LTBLUE}Magic bulldozer (remove industries, unmovable objects): {ORANGE}{STRING}
 STR_CHEAT_CROSSINGTUNNELS                                       :{LTBLUE}Tunnels may cross each other: {ORANGE}{STRING}
 STR_CHEAT_NO_JETCRASH                                           :{LTBLUE}Jetplanes will not crash (frequently) on small airports: {ORANGE}{STRING}
 STR_CHEAT_EDIT_MAX_HL                                           :{LTBLUE}Edit the maximum map height: {ORANGE}{NUM}

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1444,6 +1444,9 @@ STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES_NONE                     :None
 STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES_UNSERVED                 :Unserved only
 STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES_ALL                      :All
 
+STR_CONFIG_SETTING_BULLDOZE_OBJECTS                             :Allow bulldozing immovable objects
+STR_CONFIG_SETTING_BULLDOZE_OBJECTS_HELPTEXT                    :Allow lighthouses, transmitters, and NewGRF objects to be demolished
+
 STR_CONFIG_SETTING_SIGNALSIDE                                   :Show signals: {STRING2}
 STR_CONFIG_SETTING_SIGNALSIDE_HELPTEXT                          :Select on which side of the track to place signals
 ###length 3

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1437,6 +1437,13 @@ STR_CONFIG_SETTING_INDUSTRY_PLATFORM_HELPTEXT                   :Amount of flat 
 STR_CONFIG_SETTING_MULTIPINDTOWN                                :Allow multiple similar industries per town: {STRING2}
 STR_CONFIG_SETTING_MULTIPINDTOWN_HELPTEXT                       :Normally, a town does not want more than one industry of each type. With this setting, it will allow several industries of the same type in the same town
 
+STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES                          :Allow bulldozing industries: {STRING2}
+STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES_HELPTEXT                 :Allow industries to be demolished
+###length 3
+STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES_NONE                     :None
+STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES_UNSERVED                 :Unserved only
+STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES_ALL                      :All
+
 STR_CONFIG_SETTING_SIGNALSIDE                                   :Show signals: {STRING2}
 STR_CONFIG_SETTING_SIGNALSIDE_HELPTEXT                          :Select on which side of the track to place signals
 ###length 3
@@ -5111,6 +5118,8 @@ STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION                        :land sloped in 
 STR_ERROR_CAN_T_DO_THIS                                         :Can't do this...
 STR_ERROR_BUILDING_MUST_BE_DEMOLISHED                           :building must be demolished first
 STR_ERROR_BUILDING_IS_PROTECTED                                 :building is protected
+STR_ERROR_INDUSTRY_IN_USE                                       :industry is in use
+STR_ERROR_INDUSTRIES_CANNOT_BE_REMOVED                          :industries cannot be removed
 STR_ERROR_CAN_T_CLEAR_THIS_AREA                                 :Can't clear this area...
 STR_ERROR_SITE_UNSUITABLE                                       :site unsuitable
 STR_ERROR_ALREADY_BUILT                                         :already built

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -568,13 +568,13 @@ static CommandCost ClearTile_Object(TileIndex tile, DoCommandFlags flags)
 			/* No further limitations for the editor. */
 		} else if (GetTileOwner(tile) == OWNER_NONE) {
 			/* Owned by nobody and unremovable, so we can only remove it with brute force! */
-			if (!_cheats.magic_bulldozer.value && spec->flags.Test(ObjectFlag::CannotRemove)) return CMD_ERROR;
+			if (!_settings_game.construction.bulldoze_objects && spec->flags.Test(ObjectFlag::CannotRemove)) return CMD_ERROR;
 		} else if (CommandCost ret = CheckTileOwnership(tile); ret.Failed()) {
 			/* We don't own it!. */
 			return ret;
 		} else if (spec->flags.Test(ObjectFlag::CannotRemove) && !spec->flags.Test(ObjectFlag::Autoremove)) {
-			/* In the game editor or with cheats we can remove, otherwise we can't. */
-			if (!_cheats.magic_bulldozer.value) {
+			/* We might be allowed to remove immovable objects. */
+			if (!_settings_game.construction.bulldoze_objects) {
 				if (type == OBJECT_HQ) return CommandCost(STR_ERROR_COMPANY_HEADQUARTERS_IN);
 				return CMD_ERROR;
 			}

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -272,8 +272,6 @@ CommandCost CheckAllowRemoveRoad(TileIndex tile, RoadBits remove, Owner owner, R
 
 	if (!town_check) return CommandCost();
 
-	if (_cheats.magic_bulldozer.value) return CommandCost();
-
 	Town *t = ClosestTownFromTile(tile, UINT_MAX);
 	if (t == nullptr) return CommandCost();
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -66,6 +66,7 @@
 #include "../timer/timer_game_economy.h"
 #include "../timer/timer_game_tick.h"
 #include "../picker_func.h"
+#include "../cheat_type.h"
 
 #include "saveload_internal.h"
 
@@ -796,6 +797,12 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SLV_LINKGRAPH_SECONDS)) {
 		_settings_game.linkgraph.recalc_interval *= CalendarTime::SECONDS_PER_DAY;
 		_settings_game.linkgraph.recalc_time     *= CalendarTime::SECONDS_PER_DAY;
+	}
+
+	/* Convert the Magic Bulldozer cheat to settings. */
+	if (IsSavegameVersionBefore(SLV_REMOVE_MAGIC_BULLDOZER)) {
+		_settings_game.construction.bulldoze_industries = _cheats.magic_bulldozer.value ? BulldozeIndustries::All : BulldozeIndustries::None;
+		_settings_game.construction.bulldoze_objects = _cheats.magic_bulldozer.value;
 	}
 
 	/* Load the sprites */

--- a/src/saveload/cheat_sl.cpp
+++ b/src/saveload/cheat_sl.cpp
@@ -17,8 +17,8 @@
 #include "../safeguards.h"
 
 static const SaveLoad _cheats_desc[] = {
-	SLE_VAR(Cheats, magic_bulldozer.been_used, SLE_BOOL),
-	SLE_VAR(Cheats, magic_bulldozer.value, SLE_BOOL),
+	SLE_CONDVAR(Cheats, magic_bulldozer.been_used, SLE_BOOL, SL_MIN_VERSION, SLV_REMOVE_MAGIC_BULLDOZER),
+	SLE_CONDVAR(Cheats, magic_bulldozer.value, SLE_BOOL, SL_MIN_VERSION, SLV_REMOVE_MAGIC_BULLDOZER),
 	SLE_VAR(Cheats, switch_company.been_used, SLE_BOOL),
 	SLE_VAR(Cheats, switch_company.value, SLE_BOOL),
 	SLE_VAR(Cheats, money.been_used, SLE_BOOL),

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -416,6 +416,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_BUOYS_AT_0_0,                       ///< 364  PR#14983 Allow to build buoys at (0x0).
 
 	SLV_DRIVE_BACKWARDS,                    ///< 365  PR#15379 Trains can drive backwards.
+	SLV_REMOVE_MAGIC_BULLDOZER,             ///< 366  PR#13265 Remove Magic Bulldozer cheat.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -417,6 +417,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_BUOYS_AT_0_0,                       ///< 364  PR#14983 Allow to build buoys at (0x0).
 
 	SLV_DRIVE_BACKWARDS,                    ///< 365  PR#15379 Trains can drive backwards.
+	SLV_REMOVE_MAGIC_BULLDOZER,             ///< 366  PR#13265 Remove Magic Bulldozer cheat.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -756,6 +756,7 @@ SettingsContainer &GetSettingsTree()
 			limitations->Add(new SettingEntry("construction.autoslope"));
 			limitations->Add(new SettingEntry("construction.extra_dynamite"));
 			limitations->Add(new SettingEntry("construction.bulldoze_industries"));
+			limitations->Add(new SettingEntry("construction.bulldoze_objects"));
 			limitations->Add(new SettingEntry("construction.map_height_limit"));
 			limitations->Add(new SettingEntry("construction.max_bridge_length"));
 			limitations->Add(new SettingEntry("construction.max_bridge_height"));

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -755,6 +755,7 @@ SettingsContainer &GetSettingsTree()
 			limitations->Add(new SettingEntry("construction.command_pause_level"));
 			limitations->Add(new SettingEntry("construction.autoslope"));
 			limitations->Add(new SettingEntry("construction.extra_dynamite"));
+			limitations->Add(new SettingEntry("construction.bulldoze_industries"));
 			limitations->Add(new SettingEntry("construction.map_height_limit"));
 			limitations->Add(new SettingEntry("construction.max_bridge_length"));
 			limitations->Add(new SettingEntry("construction.max_bridge_height"));

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -757,6 +757,7 @@ SettingsContainer &GetSettingsTree()
 			limitations->Add(new SettingEntry("construction.autoslope"));
 			limitations->Add(new SettingEntry("construction.extra_dynamite"));
 			limitations->Add(new SettingEntry("construction.bulldoze_industries"));
+			limitations->Add(new SettingEntry("construction.bulldoze_objects"));
 			limitations->Add(new SettingEntry("construction.map_height_limit"));
 			limitations->Add(new SettingEntry("construction.max_bridge_length"));
 			limitations->Add(new SettingEntry("construction.max_bridge_height"));

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -756,6 +756,7 @@ SettingsContainer &GetSettingsTree()
 			limitations->Add(new SettingEntry("construction.command_pause_level"));
 			limitations->Add(new SettingEntry("construction.autoslope"));
 			limitations->Add(new SettingEntry("construction.extra_dynamite"));
+			limitations->Add(new SettingEntry("construction.bulldoze_industries"));
 			limitations->Add(new SettingEntry("construction.map_height_limit"));
 			limitations->Add(new SettingEntry("construction.max_bridge_length"));
 			limitations->Add(new SettingEntry("construction.max_bridge_height"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -151,6 +151,13 @@ enum class TrainFlipReversingAllowed : uint8_t {
 	None, ///< Trains cannot flip anywhere and must back up if the track ends.
 };
 
+/** Settings related to bulldozing industries. */
+enum class BulldozeIndustries : uint8_t {
+	None = 0, ///< Do not allow bulldozing industries.
+	Unserved, ///< Allow bulldozing unserved industries only.
+	All, ///< Allow bulldozing all industries.
+};
+
 /** Settings related to the difficulty of the game */
 struct DifficultySettings {
 	uint8_t competitor_start_time; ///< Unused value, used to load old savegames.
@@ -464,6 +471,7 @@ struct ConstructionSettings {
 	bool crossing_with_competitor; ///< allow building of level crossings with competitor roads or rails
 	uint8_t raw_industry_construction; ///< type of (raw) industry construction (none, "normal", prospecting)
 	uint8_t industry_platform; ///< the amount of flat land around an industry
+	BulldozeIndustries bulldoze_industries; ///< whether players can bulldoze industries
 	bool freeform_edges; ///< allow terraforming the tiles at the map edges
 	uint8_t extra_tree_placement; ///< (dis)allow building extra trees in-game
 	CommandPauseLevel command_pause_level; ///< level/amount of commands that can't be executed while paused

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -472,6 +472,7 @@ struct ConstructionSettings {
 	uint8_t raw_industry_construction; ///< type of (raw) industry construction (none, "normal", prospecting)
 	uint8_t industry_platform; ///< the amount of flat land around an industry
 	BulldozeIndustries bulldoze_industries; ///< whether players can bulldoze industries
+	bool bulldoze_objects; ///< whether players can bulldoze immovable objects
 	bool freeform_edges; ///< allow terraforming the tiles at the map edges
 	uint8_t extra_tree_placement; ///< (dis)allow building extra trees in-game
 	CommandPauseLevel command_pause_level; ///< level/amount of commands that can't be executed while paused

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -514,6 +514,7 @@ struct ConstructionSettings {
 	uint8_t raw_industry_construction; ///< type of (raw) industry construction (none, "normal", prospecting)
 	uint8_t industry_platform; ///< the amount of flat land around an industry
 	BulldozeIndustries bulldoze_industries; ///< whether players can bulldoze industries
+	bool bulldoze_objects; ///< whether players can bulldoze immovable objects
 	bool freeform_edges; ///< allow terraforming the tiles at the map edges
 	uint8_t extra_tree_placement; ///< (dis)allow building extra trees in-game
 	CommandPauseLevel command_pause_level; ///< level/amount of commands that can't be executed while paused

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -152,6 +152,13 @@ enum class TrainFlipReversingAllowed : uint8_t {
 	None, ///< Trains cannot flip anywhere and must back up if the track ends.
 };
 
+/** Settings related to bulldozing industries. */
+enum class BulldozeIndustries : uint8_t {
+	None = 0, ///< Do not allow bulldozing industries.
+	Unserved, ///< Allow bulldozing unserved industries only.
+	All, ///< Allow bulldozing all industries.
+};
+
 /** Settings related to the difficulty of the game */
 struct DifficultySettings {
 	uint8_t competitor_start_time; ///< Unused value, used to load old savegames.
@@ -506,6 +513,7 @@ struct ConstructionSettings {
 	bool crossing_with_competitor; ///< allow building of level crossings with competitor roads or rails
 	uint8_t raw_industry_construction; ///< type of (raw) industry construction (none, "normal", prospecting)
 	uint8_t industry_platform; ///< the amount of flat land around an industry
+	BulldozeIndustries bulldoze_industries; ///< whether players can bulldoze industries
 	bool freeform_edges; ///< allow terraforming the tiles at the map edges
 	uint8_t extra_tree_placement; ///< (dis)allow building extra trees in-game
 	CommandPauseLevel command_pause_level; ///< level/amount of commands that can't be executed while paused

--- a/src/table/settings/world_settings.ini
+++ b/src/table/settings/world_settings.ini
@@ -596,6 +596,13 @@ strval   = STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES_NONE
 cat      = SC_BASIC
 
 [SDT_BOOL]
+var      = construction.bulldoze_objects
+def      = false
+str      = STR_CONFIG_SETTING_BULLDOZE_OBJECTS
+strhelp  = STR_CONFIG_SETTING_BULLDOZE_OBJECTS_HELPTEXT
+cat      = SC_BASIC
+
+[SDT_BOOL]
 var      = construction.freeform_edges
 from     = SLV_111
 def      = true

--- a/src/table/settings/world_settings.ini
+++ b/src/table/settings/world_settings.ini
@@ -14,6 +14,8 @@ static bool CheckMaxHeightLevel(int32_t &new_value);
 static bool CheckFreeformEdges(int32_t &new_value);
 static void UpdateFreeformEdges(int32_t new_value);
 
+static constexpr std::initializer_list<std::string_view> _bulldoze_industries{"none"sv, "unserved only"sv, "all"sv};
+
 static const SettingVariant _world_settings_table[] = {
 [post-amble]
 };
@@ -579,6 +581,19 @@ str      = STR_CONFIG_SETTING_INDUSTRY_PLATFORM
 strhelp  = STR_CONFIG_SETTING_INDUSTRY_PLATFORM_HELPTEXT
 strval   = STR_CONFIG_SETTING_TILE_LENGTH
 cat      = SC_EXPERT
+
+[SDT_OMANY]
+var      = construction.bulldoze_industries
+type     = SLE_UINT8
+flags    = SettingFlag::GuiDropdown
+def      = BulldozeIndustries::None
+min      = BulldozeIndustries::None
+max      = BulldozeIndustries::All
+full     = _bulldoze_industries
+str      = STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES
+strhelp  = STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES_HELPTEXT
+strval   = STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES_NONE
+cat      = SC_BASIC
 
 [SDT_BOOL]
 var      = construction.freeform_edges

--- a/src/table/settings/world_settings.ini
+++ b/src/table/settings/world_settings.ini
@@ -596,6 +596,13 @@ strval   = STR_CONFIG_SETTING_BULLDOZE_INDUSTRIES_NONE
 cat      = SC_BASIC
 
 [SDT_BOOL]
+var      = construction.bulldoze_objects
+def      = false
+str      = STR_CONFIG_SETTING_BULLDOZE_OBJECTS
+strhelp  = STR_CONFIG_SETTING_BULLDOZE_OBJECTS_HELPTEXT
+cat      = SC_BASIC
+
+[SDT_BOOL]
 var      = construction.freeform_edges
 from     = SLV_FREEFORM_EDGES
 def      = true

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -707,7 +707,7 @@ static CommandCost ClearTile_Town(TileIndex tile, DoCommandFlags flags)
 	Town *t = Town::GetByTile(tile);
 
 	if (Company::IsValidID(_current_company)) {
-		if (!_cheats.magic_bulldozer.value && !flags.Test(DoCommandFlag::NoTestTownRating)) {
+		if (!flags.Test(DoCommandFlag::NoTestTownRating)) {
 			/* NewGRFs can add indestructible houses. */
 			if (rating > RATING_MAXIMUM) {
 				return CommandCost(STR_ERROR_BUILDING_IS_PROTECTED);
@@ -4078,12 +4078,8 @@ static int GetRating(const Town *t)
  */
 void ChangeTownRating(Town *t, int add, int max, DoCommandFlags flags)
 {
-	/* if magic_bulldozer cheat is active, town doesn't penalize for removing stuff */
-	if (t == nullptr || flags.Test(DoCommandFlag::NoModifyTownRating) ||
-			!Company::IsValidID(_current_company) ||
-			(_cheats.magic_bulldozer.value && add < 0)) {
-		return;
-	}
+	if (t == nullptr || !Company::IsValidID(_current_company)) return;
+	if (flags.Test(DoCommandFlag::NoModifyTownRating)) return;
 
 	int rating = GetRating(t);
 	if (add < 0) {
@@ -4115,11 +4111,8 @@ void ChangeTownRating(Town *t, int add, int max, DoCommandFlags flags)
  */
 CommandCost CheckforTownRating(DoCommandFlags flags, Town *t, TownRatingCheckType type)
 {
-	/* if magic_bulldozer cheat is active, town doesn't restrict your destructive actions */
-	if (t == nullptr || !Company::IsValidID(_current_company) ||
-			_cheats.magic_bulldozer.value || flags.Test(DoCommandFlag::NoTestTownRating)) {
-		return CommandCost();
-	}
+	if (t == nullptr || !Company::IsValidID(_current_company)) return CommandCost();
+	if (flags.Test(DoCommandFlag::NoTestTownRating)) return CommandCost();
 
 	/* minimum rating needed to be allowed to remove stuff */
 	static const int needed_rating[][to_underlying(TownRatingCheckType::End)] = {

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -705,7 +705,7 @@ static CommandCost ClearTile_Town(TileIndex tile, DoCommandFlags flags)
 	Town *t = Town::GetByTile(tile);
 
 	if (Company::IsValidID(_current_company)) {
-		if (!_cheats.magic_bulldozer.value && !flags.Test(DoCommandFlag::NoTestTownRating)) {
+		if (!flags.Test(DoCommandFlag::NoTestTownRating)) {
 			/* NewGRFs can add indestructible houses. */
 			if (rating > RATING_MAXIMUM) {
 				return CommandCost(STR_ERROR_BUILDING_IS_PROTECTED);
@@ -4070,12 +4070,8 @@ static int GetRating(const Town *t)
  */
 void ChangeTownRating(Town *t, int add, int max, DoCommandFlags flags)
 {
-	/* if magic_bulldozer cheat is active, town doesn't penalize for removing stuff */
-	if (t == nullptr || flags.Test(DoCommandFlag::NoModifyTownRating) ||
-			!Company::IsValidID(_current_company) ||
-			(_cheats.magic_bulldozer.value && add < 0)) {
-		return;
-	}
+	if (t == nullptr || !Company::IsValidID(_current_company)) return;
+	if (flags.Test(DoCommandFlag::NoModifyTownRating)) return;
 
 	int rating = GetRating(t);
 	if (add < 0) {
@@ -4107,11 +4103,8 @@ void ChangeTownRating(Town *t, int add, int max, DoCommandFlags flags)
  */
 CommandCost CheckforTownRating(DoCommandFlags flags, Town *t, TownRatingCheckType type)
 {
-	/* if magic_bulldozer cheat is active, town doesn't restrict your destructive actions */
-	if (t == nullptr || !Company::IsValidID(_current_company) ||
-			_cheats.magic_bulldozer.value || flags.Test(DoCommandFlag::NoTestTownRating)) {
-		return CommandCost();
-	}
+	if (t == nullptr || !Company::IsValidID(_current_company)) return CommandCost();
+	if (flags.Test(DoCommandFlag::NoTestTownRating)) return CommandCost();
 
 	/* minimum rating needed to be allowed to remove stuff */
 	static const int needed_rating[][to_underlying(TownRatingCheckType::End)] = {

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -827,7 +827,7 @@ static inline CommandCost CheckAllowRemoveTunnelBridge(TileIndex tile)
 			if (tram_rt != INVALID_ROADTYPE) tram_owner = GetRoadOwner(tile, RoadTramType::Tram);
 
 			/* We can remove unowned road and if the town allows it */
-			if (road_owner == OWNER_TOWN && _current_company != OWNER_TOWN && !(_settings_game.construction.extra_dynamite || _cheats.magic_bulldozer.value)) {
+			if (road_owner == OWNER_TOWN && _current_company != OWNER_TOWN && !(_settings_game.construction.extra_dynamite)) {
 				/* Town does not allow */
 				return CheckTileOwnership(tile);
 			}


### PR DESCRIPTION
## Motivation / Problem

Because cheats are not available in network games, there is no way for players to remove industries or immovable objects (transmitters and lighthouses, or potentially some NewGRF objects).

There's also been discussion of converting cheats to settings.

## Description

* Add a setting to allow players to bulldoze immovable objects
* Add a setting to allow players to bulldoze industries, with three options:
  * Off (no bulldozing allowed)
  * Unserved
    * For produced cargos: >0% transported for any cargo, which is displayed in the industry window. This is based on the station rating and takes over an in-game year to drop to 0.
    * For received cargos: Date last serviced over 1 economy year (12 minutes) ago.
  * On (bulldoze whatever industries you want)
* Delete the magic bulldozer cheat. If it was used in a savegame, enable the aforementioned settings so there is no change in functionality.

## Limitations

* These should be added to the sandbox options window by adding the setting flag, but dropdown settings are not currently supported.
* My removal of the cheat might not be the cleanest possible. This is what it took to load savegames and remember which cheats were enabled.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
