### PR TITLE
Add: Setting to allow placing houses manually in-game

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1987,6 +1987,13 @@ STR_CONFIG_SETTING_TOWN_FOUNDING_FORBIDDEN                      :Forbidden
 STR_CONFIG_SETTING_TOWN_FOUNDING_ALLOWED                        :Allowed
 STR_CONFIG_SETTING_TOWN_FOUNDING_ALLOWED_CUSTOM_LAYOUT          :Allowed, custom town layout
 
+STR_CONFIG_SETTING_HOUSE_PLACER                                 :Placing individual town houses: {STRING2}
+STR_CONFIG_SETTING_HOUSE_PLACER_HELPTEXT                        :Enabling this setting allows players to place town houses manually
+###length 3
+STR_CONFIG_SETTING_HOUSE_PLACER_FORBIDDEN                       :Forbidden
+STR_CONFIG_SETTING_HOUSE_PLACER_ALLOWED                         :Allowed
+STR_CONFIG_SETTING_HOUSE_PLACER_FULLY_CONSTRUCTED               :Allowed, fully constructed
+
 STR_CONFIG_SETTING_TOWN_CARGOGENMODE                            :Town cargo generation: {STRING2}
 STR_CONFIG_SETTING_TOWN_CARGOGENMODE_HELPTEXT                   :How much cargo is produced by houses in towns, relative to the overall population of the town.{}Quadratic growth: A town twice the size generates four times as many passengers.{}Linear growth: A town twice the size generates twice the amount of passengers
 ###length 2

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2219,6 +2219,7 @@ static SettingsContainer &GetSettingsTree()
 				towns->Add(new SettingEntry("economy.allow_town_roads"));
 				towns->Add(new SettingEntry("economy.allow_town_level_crossings"));
 				towns->Add(new SettingEntry("economy.found_town"));
+				towns->Add(new SettingEntry("economy.place_houses"));
 				towns->Add(new SettingEntry("economy.town_layout"));
 				towns->Add(new SettingEntry("economy.larger_towns"));
 				towns->Add(new SettingEntry("economy.initial_city_size"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -91,6 +91,13 @@ enum RightClickClose : uint8_t {
 	RCC_YES_EXCEPT_STICKY,
 };
 
+/** Possible values for "place_houses" setting. */
+enum PlaceHouses : uint8_t {
+	PH_FORBIDDEN = 0,
+	PH_ALLOWED,
+	PH_ALLOWED_CONSTRUCTED,
+};
+
 /** Settings related to the difficulty of the game */
 struct DifficultySettings {
 	uint8_t competitor_start_time;            ///< Unused value, used to load old savegames.
@@ -529,6 +536,7 @@ struct EconomySettings {
 	TownCargoGenMode town_cargogen_mode;     ///< algorithm for generating cargo from houses, @see TownCargoGenMode
 	bool   allow_town_roads;                 ///< towns are allowed to build roads (always allowed when generating world / in SE)
 	TownFounding found_town;                 ///< town founding.
+	PlaceHouses place_houses;                ///< players are allowed to place town houses.
 	bool   station_noise_level;              ///< build new airports when the town noise level is still within accepted limits
 	uint16_t town_noise_population[4];         ///< population to base decision on noise evaluation (@see town_council_tolerance)
 	bool   allow_town_level_crossings;       ///< towns are allowed to build level crossings

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -12,6 +12,8 @@ static void TownFoundingChanged(int32_t new_value);
 static void ChangeTimekeepingUnits(int32_t new_value);
 static void ChangeMinutesPerYear(int32_t new_value);
 
+static constexpr std::initializer_list<const char*> _place_houses{"forbidden", "allowed", "fully constructed"};
+
 static const SettingVariant _economy_settings_table[] = {
 [post-amble]
 };
@@ -79,6 +81,19 @@ strhelp  = STR_CONFIG_SETTING_TOWN_FOUNDING_HELPTEXT
 strval   = STR_CONFIG_SETTING_TOWN_FOUNDING_FORBIDDEN
 post_cb  = TownFoundingChanged
 cat      = SC_BASIC
+
+[SDT_VAR]
+var      = economy.place_houses
+type     = SLE_UINT8
+flags    = SettingFlag::GuiDropdown
+def      = PH_FORBIDDEN
+min      = PH_FORBIDDEN
+max      = PH_ALLOWED_CONSTRUCTED
+full     = _place_houses
+str      = STR_CONFIG_SETTING_HOUSE_PLACER
+strhelp  = STR_CONFIG_SETTING_HOUSE_PLACER_HELPTEXT
+strval   = STR_CONFIG_SETTING_HOUSE_PLACER_FORBIDDEN
+cat      = SC_ADVANCED
 
 [SDT_BOOL]
 var      = economy.allow_town_level_crossings

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -481,13 +481,21 @@ static CallBackFunction MenuClickMap(int index)
 
 /* --- Town button menu --- */
 
+enum TownMenuEntries {
+	TME_SHOW_DIRECTORY = 0,
+	TME_SHOW_FOUND_TOWN,
+	TME_SHOW_PLACE_HOUSES,
+};
+
 static CallBackFunction ToolbarTownClick(Window *w)
 {
-	if (_settings_game.economy.found_town == TF_FORBIDDEN) {
-		PopupMainToolbarMenu(w, WID_TN_TOWNS, {STR_TOWN_MENU_TOWN_DIRECTORY});
-	} else {
-		PopupMainToolbarMenu(w, WID_TN_TOWNS, {STR_TOWN_MENU_TOWN_DIRECTORY, STR_TOWN_MENU_FOUND_TOWN});
-	}
+	DropDownList list;
+	list.push_back(MakeDropDownListStringItem(STR_TOWN_MENU_TOWN_DIRECTORY, TME_SHOW_DIRECTORY));
+	if (_settings_game.economy.found_town != TF_FORBIDDEN) list.push_back(MakeDropDownListStringItem(STR_TOWN_MENU_FOUND_TOWN, TME_SHOW_FOUND_TOWN));
+	if (_settings_game.economy.place_houses != PH_FORBIDDEN) list.push_back(MakeDropDownListStringItem(STR_SCENEDIT_TOWN_MENU_PACE_HOUSE, TME_SHOW_PLACE_HOUSES));
+
+	PopupMainToolbarMenu(w, WID_TN_TOWNS, std::move(list), 0);
+
 	return CBF_NONE;
 }
 
@@ -500,9 +508,12 @@ static CallBackFunction ToolbarTownClick(Window *w)
 static CallBackFunction MenuClickTown(int index)
 {
 	switch (index) {
-		case 0: ShowTownDirectory(); break;
-		case 1: // setting could be changed when the dropdown was open
+		case TME_SHOW_DIRECTORY: ShowTownDirectory(); break;
+		case TME_SHOW_FOUND_TOWN: // Setting could be changed when the dropdown was open
 			if (_settings_game.economy.found_town != TF_FORBIDDEN) ShowFoundTownWindow();
+			break;
+		case TME_SHOW_PLACE_HOUSES: // Setting could be changed when the dropdown was open
+			if (_settings_game.economy.place_houses != PH_FORBIDDEN) ShowBuildHousePicker(nullptr);
 			break;
 	}
 	return CBF_NONE;


### PR DESCRIPTION
## Motivation / Problem

Thanks to @PeterN, we have a house placer in Scenario Editor. I want to use it while playing sandbox games.

## Description

Add a setting to enable the house placer in regular games. 

## Limitations

* The setting helptext could use some creativity...
* Unlike objects, the NewGRF house spec doesn't have a price for constructing the house. Houses do have a cost to demolish, but so do objects, and this is separate from price. I don't want to use this for the construction price and be out-of-sync with how we handle objects. Since this is a "sandbox option", let's let the player place houses for free. 🙂 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
