### PR TITLE
Change: Log changes to sandbox settings.

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1604,7 +1604,7 @@ void IntSettingDesc::ChangeValue(const void *object, int32_t newval) const
 	this->Write(object, newval);
 	if (this->post_callback != nullptr) this->post_callback(newval);
 
-	if (this->flags & SF_NO_NETWORK) {
+	if (HasFlag(this->flags, SF_NO_NETWORK) || HasFlag(this->flags, SF_SANDBOX)) {
 		_gamelog.StartAction(GLAT_SETTING);
 		_gamelog.Setting(this->GetName(), oldval, newval);
 		_gamelog.StopAction();

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -27,6 +27,7 @@ enum SettingFlag : uint16_t {
 	SF_NOT_IN_SAVE             = 1 << 10, ///< Do not save with savegame, basically client-based.
 	SF_NOT_IN_CONFIG           = 1 << 11, ///< Do not save to config file.
 	SF_NO_NETWORK_SYNC         = 1 << 12, ///< Do not synchronize over network (but it is saved if SF_NOT_IN_SAVE is not set).
+	SF_SANDBOX                 = 1 << 13, ///< This setting is a sandbox setting.
 };
 DECLARE_ENUM_AS_BIT_SET(SettingFlag)
 

--- a/src/table/settings/difficulty_settings.ini
+++ b/src/table/settings/difficulty_settings.ini
@@ -301,6 +301,7 @@ cat      = SC_BASIC
 
 [SDT_BOOL]
 var      = difficulty.infinite_money
+flags    = SF_SANDBOX
 def      = false
 str      = STR_CONFIG_SETTING_INFINITE_MONEY
 strhelp  = STR_CONFIG_SETTING_INFINITE_MONEY_HELPTEXT


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

One of the features of cheats is that there is a record of a cheat being used.

As cheats are slowly ending up in settings instead, this system is no longer used, and because these settings can be changed mid-game, the change of setting isn't logged in the gamelog.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add a flag to settings so that changes to sandbox settings are logged in the gamelog.

This adds the flag only to the existing `infinite_money` settings, though there are probably other settings that might be considered sandbox.

![image](https://github.com/user-attachments/assets/e6a541e9-7b85-48d3-a460-37396a993c57)

This change does not really serve much purpose other than satisfying one of the complaints against removing cheats which was that there is "evidence" that they've been used.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This is probably a bit spammy for settings that have a large range of values, changing that would require deferring the change until the player stops interacting with the setting.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
