### PR TITLE
Feature: Prevent towns from upgrading individually-placed houses

### DIFF
--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -721,7 +721,8 @@
         </ul>
        </li>
       </ul>
-     <li>m3 bits 6..5 : free</li>
+     <li>m3 bit 6 : free</li>
+     <li>m3 bit 5 : The house is protected from the town upgrading it</li>
      <li>m3 bits 4..0 : triggers activated <a href="#newhouses">(newhouses)</a></li>
      <li>m4 : free</li>
      <li>m5 : see m3 bit 7</li>

--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -156,7 +156,7 @@ the array so you can quickly see what is used and what is not.
       <td class="caption">finished house</td>
       <td class="bits" rowspan=2><span class="used" title="House random bits">XXXX XXXX</span></td>
       <td class="bits" rowspan=2><span class="pool" title="Town index on pool">XXXX XXXX XXXX XXXX</span></td>
-      <td class="bits"><span class="used" title="House is complete/in construction (see m5)">1</span><span class="free">OO</span><span class="usable" title="Activated triggers (bits 2..4 don't have a meaning)">X XX</span><span class="used" title="Activated triggers (bits 2..4 don't have a meaning)">XX</span></td>
+      <td class="bits"><span class="used" title="House is complete/in construction (see m5)">1</span><span class="free">O</span><span class="used" title="The house is protected from the town upgrading it.">X</span><span class="usable" title="Activated triggers (bits 2..4 don't have a meaning)">X XX</span><span class="used" title="Activated triggers (bits 2..4 don't have a meaning)">XX</span></td>
       <td class="bits" rowspan=2><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="used" title="Age in years, clamped at 255">XXXX XXXX</span></td>
       <td class="bits" rowspan=2><span class="abuse" title="Newhouses activated: periodic processing time remaining; if not, lift position for houses 04 and 05">XXXX XX</span><span class="used" title="Animated tile state">XX</span></td>
@@ -165,7 +165,7 @@ the array so you can quickly see what is used and what is not.
     </tr>
     <tr>
       <td class="caption">house under construction</td>
-      <td class="bits"><span class="used" title="House is complete/in construction (see m5)">O</span><span class="used" title="House type (m4 + m3[6])">X</span><span class="free">O</span><span class="usable" title="Activated triggers (bits 2..4 don't have a meaning)">X XX</span><span class="used" title="Activated triggers (bits 2..4 don't have a meaning)">XX</span></td>
+      <td class="bits"><span class="used" title="House is complete/in construction (see m5)">O</span><span class="used" title="House type (m4 + m3[6])">X</span><span class="used" title="The house is protected from the town upgrading it.">X</span><span class="usable" title="Activated triggers (bits 2..4 don't have a meaning)">X XX</span><span class="used" title="Activated triggers (bits 2..4 don't have a meaning)">XX</span></td>
       <td class="bits"><span class="free">OOO</span><span class="used" title="Construction stage">X X</span><span class="used" title="Construction counter">XXX</span></td>
     </tr>
     <tr>

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2866,6 +2866,11 @@ STR_HOUSE_PICKER_CLASS_ZONE3                                    :Outer Suburbs
 STR_HOUSE_PICKER_CLASS_ZONE4                                    :Inner Suburbs
 STR_HOUSE_PICKER_CLASS_ZONE5                                    :Town centre
 
+STR_HOUSE_PICKER_PROTECT_TITLE                                  :Prevent upgrades
+STR_HOUSE_PICKER_PROTECT_TOOLTIP                                :Choose whether this house will be protected from replacement as the town grows
+STR_HOUSE_PICKER_PROTECT_OFF                                    :Off
+STR_HOUSE_PICKER_PROTECT_ON                                     :On
+
 STR_STATION_CLASS_DFLT                                          :Default
 STR_STATION_CLASS_DFLT_STATION                                  :Default station
 STR_STATION_CLASS_DFLT_ROADSTOP                                 :Default road stop
@@ -3142,6 +3147,8 @@ STR_LANG_AREA_INFORMATION_TRAM_TYPE                             :{BLACK}Tram typ
 STR_LANG_AREA_INFORMATION_RAIL_SPEED_LIMIT                      :{BLACK}Rail speed limit: {LTBLUE}{VELOCITY}
 STR_LANG_AREA_INFORMATION_ROAD_SPEED_LIMIT                      :{BLACK}Road speed limit: {LTBLUE}{VELOCITY}
 STR_LANG_AREA_INFORMATION_TRAM_SPEED_LIMIT                      :{BLACK}Tram speed limit: {LTBLUE}{VELOCITY}
+STR_LAND_AREA_INFORMATION_TOWN_CAN_UPGRADE                      :{BLACK}Town can upgrade: {LTBLUE}Yes
+STR_LAND_AREA_INFORMATION_TOWN_CANNOT_UPGRADE                   :{BLACK}Town can upgrade: {LTBLUE}No
 
 # Description of land area of different tiles
 STR_LAI_CLEAR_DESCRIPTION_ROCKS                                 :Rocks

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -168,6 +168,7 @@ public:
 		td.road_speed = 0;
 		td.tramtype = STR_NULL;
 		td.tram_speed = 0;
+		td.town_can_upgrade = std::nullopt;
 
 		td.grf = nullptr;
 
@@ -298,6 +299,11 @@ public:
 		if (td.tram_speed != 0) {
 			SetDParam(0, PackVelocity(td.tram_speed, VEH_ROAD));
 			this->landinfo_data.push_back(GetString(STR_LANG_AREA_INFORMATION_TRAM_SPEED_LIMIT));
+		}
+
+		/* Tile protection status */
+		if (td.town_can_upgrade.has_value()) {
+			this->landinfo_data.push_back(GetString(td.town_can_upgrade.value() ? STR_LAND_AREA_INFORMATION_TOWN_CAN_UPGRADE : STR_LAND_AREA_INFORMATION_TOWN_CANNOT_UPGRADE));
 		}
 
 		/* NewGRF name */

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -622,7 +622,7 @@ bool CanDeleteHouse(TileIndex tile)
 		uint16_t callback_res = GetHouseCallback(CBID_HOUSE_DENY_DESTRUCTION, 0, 0, GetHouseType(tile), Town::GetByTile(tile), tile);
 		return (callback_res == CALLBACK_FAILED || !ConvertBooleanCallback(hs->grf_prop.grffile, CBID_HOUSE_DENY_DESTRUCTION, callback_res));
 	} else {
-		return !hs->extra_flags.Test(HouseExtraFlag::BuildingIsProtected);
+		return !IsHouseProtected(tile);
 	}
 }
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1548,6 +1548,16 @@ bool AfterLoadGame()
 		}
 	}
 
+	if (IsSavegameVersionBefore(SLV_PROTECT_PLACED_HOUSES)) {
+		for (auto t : Map::Iterate()) {
+			if (IsTileType(t, MP_HOUSE)) {
+				/* We now store house protection status in the map. Set this based on the house spec flags. */
+				const HouseSpec *hs = HouseSpec::Get(GetHouseType(t));
+				SetHouseProtected(t, hs->extra_flags.Test(HouseExtraFlag::BuildingIsProtected));
+			}
+		}
+	}
+
 	/* Check and update house and town values */
 	UpdateHousesAndTowns();
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -398,6 +398,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_COMPANY_INAUGURATED_PERIOD_V2,      ///< 349  PR#13448 Fix savegame storage for company inaugurated year in wallclock mode.
 
 	SLV_ENCODED_STRING_FORMAT,              ///< 350  PR#13499 Encoded String format changed.
+	SLV_PROTECT_PLACED_HOUSES,              ///< 351  PR#13270 Houses individually placed by players can be protected from town/AI removal.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/tile_cmd.h
+++ b/src/tile_cmd.h
@@ -67,6 +67,7 @@ struct TileDesc {
 	uint16_t road_speed;          ///< Speed limit of road (bridges and track)
 	StringID tramtype;          ///< Type of tram on the tile.
 	uint16_t tram_speed;          ///< Speed limit of tram (bridges and track)
+	std::optional<bool> town_can_upgrade; ///< Whether the town can upgrade this house during town growth.
 };
 
 /**

--- a/src/town_cmd.h
+++ b/src/town_cmd.h
@@ -26,7 +26,7 @@ CommandCost CmdTownCargoGoal(DoCommandFlag flags, TownID town_id, TownAcceptance
 CommandCost CmdTownSetText(DoCommandFlag flags, TownID town_id, const std::string &text);
 CommandCost CmdExpandTown(DoCommandFlag flags, TownID town_id, uint32_t grow_amount);
 CommandCost CmdDeleteTown(DoCommandFlag flags, TownID town_id);
-CommandCost CmdPlaceHouse(DoCommandFlag flags, TileIndex tile, HouseID house);
+CommandCost CmdPlaceHouse(DoCommandFlag flags, TileIndex tile, HouseID house, bool house_protected);
 
 DEF_CMD_TRAIT(CMD_FOUND_TOWN,       CmdFoundTown,      CMD_DEITY | CMD_NO_TEST,  CMDT_LANDSCAPE_CONSTRUCTION) // founding random town can fail only in exec run
 DEF_CMD_TRAIT(CMD_RENAME_TOWN,      CmdRenameTown,     CMD_DEITY | CMD_SERVER,   CMDT_OTHER_MANAGEMENT)

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1627,6 +1627,7 @@ public:
 
 struct BuildHouseWindow : public PickerWindow {
 	std::string house_info;
+	bool house_protected;
 
 	BuildHouseWindow(WindowDesc &desc, Window *parent) : PickerWindow(desc, parent, 0, HousePickerCallbacks::instance)
 	{
@@ -1680,7 +1681,7 @@ struct BuildHouseWindow : public PickerWindow {
 
 	/**
 	 * Get information string for a house.
-	 * @param hs HosueSpec to get information string for.
+	 * @param hs HouseSpec to get information string for.
 	 * @return Formatted string with information for house.
 	 */
 	static std::string GetHouseInformation(const HouseSpec *hs)
@@ -1714,6 +1715,14 @@ struct BuildHouseWindow : public PickerWindow {
 		return line.str();
 	}
 
+	void OnInit() override
+	{
+		this->SetWidgetLoweredState(WID_BH_PROTECT_OFF, !this->house_protected);
+		this->SetWidgetLoweredState(WID_BH_PROTECT_ON, this->house_protected);
+
+		this->PickerWindow::OnInit();
+	}
+
 	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget == WID_BH_INFO) {
@@ -1723,22 +1732,52 @@ struct BuildHouseWindow : public PickerWindow {
 		}
 	}
 
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
+	{
+		switch (widget) {
+			case WID_BH_PROTECT_OFF:
+			case WID_BH_PROTECT_ON:
+				this->house_protected = (widget == WID_BH_PROTECT_ON);
+				this->SetWidgetLoweredState(WID_BH_PROTECT_OFF, !this->house_protected);
+				this->SetWidgetLoweredState(WID_BH_PROTECT_ON, this->house_protected);
+
+				if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
+				this->SetDirty();
+				break;
+
+			default:
+				this->PickerWindow::OnClick(pt, widget, click_count);
+				break;
+		}
+	}
+
 	void OnInvalidateData(int data = 0, bool gui_scope = true) override
 	{
 		this->PickerWindow::OnInvalidateData(data, gui_scope);
 		if (!gui_scope) return;
 
+		const HouseSpec *spec = HouseSpec::Get(HousePickerCallbacks::sel_type);
+
 		if ((data & PickerWindow::PFI_POSITION) != 0) {
-			const HouseSpec *spec = HouseSpec::Get(HousePickerCallbacks::sel_type);
 			UpdateSelectSize(spec);
 			this->house_info = GetHouseInformation(spec);
 		}
+
+		/* If house spec already has the protected flag, handle it automatically and disable the buttons. */
+		bool hasflag = spec->extra_flags.Test(HouseExtraFlag::BuildingIsProtected);
+		if (hasflag) this->house_protected = true;
+
+		this->SetWidgetLoweredState(WID_BH_PROTECT_OFF, !this->house_protected);
+		this->SetWidgetLoweredState(WID_BH_PROTECT_ON, this->house_protected);
+
+		this->SetWidgetDisabledState(WID_BH_PROTECT_OFF, hasflag);
+		this->SetWidgetDisabledState(WID_BH_PROTECT_ON, hasflag);
 	}
 
 	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
 	{
 		const HouseSpec *spec = HouseSpec::Get(HousePickerCallbacks::sel_type);
-		Command<CMD_PLACE_HOUSE>::Post(STR_ERROR_CAN_T_BUILD_HOUSE, CcPlaySound_CONSTRUCTION_OTHER, tile, spec->Index());
+		Command<CMD_PLACE_HOUSE>::Post(STR_ERROR_CAN_T_BUILD_HOUSE, CcPlaySound_CONSTRUCTION_OTHER, tile, spec->Index(), this->house_protected);
 	}
 
 	IntervalTimer<TimerWindow> view_refresh_interval = {std::chrono::milliseconds(2500), [this](auto) {
@@ -1768,8 +1807,14 @@ static constexpr NWidgetPart _nested_build_house_widgets[] = {
 			NWidget(WWT_PANEL, COLOUR_DARK_GREEN),
 				NWidget(NWID_VERTICAL), SetPIP(0, WidgetDimensions::unscaled.vsep_picker, 0), SetPadding(WidgetDimensions::unscaled.picker),
 					NWidget(WWT_EMPTY, INVALID_COLOUR, WID_BH_INFO), SetFill(1, 1), SetMinimalTextLines(10, 0),
+					NWidget(WWT_LABEL, INVALID_COLOUR), SetStringTip(STR_HOUSE_PICKER_PROTECT_TITLE, STR_NULL), SetFill(1, 0),
+					NWidget(NWID_HORIZONTAL), SetPIPRatio(1, 0, 1),
+						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_BH_PROTECT_OFF), SetMinimalSize(60, 12), SetStringTip(STR_HOUSE_PICKER_PROTECT_OFF, STR_HOUSE_PICKER_PROTECT_TOOLTIP),
+						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_BH_PROTECT_ON), SetMinimalSize(60, 12), SetStringTip(STR_HOUSE_PICKER_PROTECT_ON, STR_HOUSE_PICKER_PROTECT_TOOLTIP),
+					EndContainer(),
 				EndContainer(),
 			EndContainer(),
+
 		EndContainer(),
 		NWidgetFunction(MakePickerTypeWidgets),
 	EndContainer(),

--- a/src/town_map.h
+++ b/src/town_map.h
@@ -75,6 +75,28 @@ inline void SetHouseType(Tile t, HouseID house_id)
 }
 
 /**
+ * Check if the house is protected from removal by towns.
+ * @param t The tile.
+ * @return If the house is protected from the town upgrading it.
+ */
+inline bool IsHouseProtected(Tile t)
+{
+	assert(IsTileType(t, MP_HOUSE));
+	return HasBit(t.m3(), 5);
+}
+
+/**
+ * Set a house as protected from removal by towns.
+ * @param t The tile.
+ * @param house_protected Whether the house is protected from the town upgrading it.
+ */
+inline void SetHouseProtected(Tile t, bool house_protected)
+{
+	assert(IsTileType(t, MP_HOUSE));
+	SB(t.m3(), 5, 1, house_protected ? 1 : 0);
+}
+
+/**
  * Check if the lift of this animated house has a destination
  * @param t the tile
  * @return has destination
@@ -347,9 +369,10 @@ inline void DecHouseProcessingTime(Tile t)
  * @param stage of construction (used for drawing)
  * @param type of house.  Index into house specs array
  * @param random_bits required for newgrf houses
+ * @param house_protected Whether the house is protected from the town upgrading it.
  * @pre IsTileType(t, MP_CLEAR)
  */
-inline void MakeHouseTile(Tile t, TownID tid, uint8_t counter, uint8_t stage, HouseID type, uint8_t random_bits)
+inline void MakeHouseTile(Tile t, TownID tid, uint8_t counter, uint8_t stage, HouseID type, uint8_t random_bits, bool house_protected)
 {
 	assert(IsTileType(t, MP_CLEAR));
 
@@ -360,6 +383,7 @@ inline void MakeHouseTile(Tile t, TownID tid, uint8_t counter, uint8_t stage, Ho
 	SetHouseType(t, type);
 	SetHouseCompleted(t, stage == TOWN_HOUSE_COMPLETED);
 	t.m5() = IsHouseCompleted(t) ? 0 : (stage << 3 | counter);
+	SetHouseProtected(t, house_protected);
 	SetAnimationFrame(t, 0);
 	SetHouseProcessingTime(t, HouseSpec::Get(type)->processing_time);
 }

--- a/src/widgets/town_widget.h
+++ b/src/widgets/town_widget.h
@@ -72,6 +72,8 @@ enum TownFoundingWidgets : WidgetID {
 /** Widgets of the #BuildHouseWindow class. */
 enum BuildHouseWidgets : WidgetID {
 	WID_BH_INFO, ///< Information panel of selected house.
+	WID_BH_PROTECT_OFF, ///< Button to protect the next house built.
+	WID_BH_PROTECT_ON, ///< Button to not protect the next house built.
 };
 
 #endif /* WIDGETS_TOWN_WIDGET_H */


### PR DESCRIPTION
## Motivation / Problem

Players who manually place houses might not want the town to remove them.

## Description

Add buttons to the house placer to select whether to protect the next house placed. This status is set automatically if the house GRF has the protected flag (and the buttons are disabled).

This protected status is stored in the map array.

![better](https://github.com/user-attachments/assets/76655c9a-1357-4605-a554-cd804ca22900)

Add the protection status of houses to the land info tool.

![land-info](https://github.com/user-attachments/assets/86a81585-ddee-42c4-bf50-e544450f23a4)

## Limitations

Please check my map bit changes carefully, I'm unclear if I did it properly. 🙂

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
