### PR TITLE
Codefix: prevent matrix overflows on high resolution monitors

### DIFF
--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -555,7 +555,7 @@ public:
 
 				resize.width = 0;
 				resize.height = 0;
-				this->GetWidget<NWidgetCore>(WID_GRAPH_RANGE_MATRIX)->SetMatrixDimension(1, ClampTo<uint8_t>(std::size(this->ranges)));
+				this->GetWidget<NWidgetCore>(WID_GRAPH_RANGE_MATRIX)->SetMatrixDimension(1, ClampTo<uint32_t>(std::size(this->ranges)));
 				break;
 
 			case WID_GRAPH_GRAPH: {

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -398,15 +398,15 @@ static inline void DrawInset(const Rect &r, Colours colour, TextColour text_colo
  * @param r       Rectangle of the matrix background.
  * @param colour  Colour of the background.
  * @param clicked Matrix is rendered lowered.
- * @param data    Data of the widget, number of rows and columns of the widget.
+ * @param num_columns The number of columns in the matrix.
+ * @param num_rows The number of rows in the matrix.
  * @param resize_x Matrix resize unit size.
  * @param resize_y Matrix resize unit size.
  */
-static inline void DrawMatrix(const Rect &r, Colours colour, bool clicked, uint16_t data, uint resize_x, uint resize_y)
+static inline void DrawMatrix(const Rect &r, Colours colour, bool clicked, uint32_t num_columns, uint32_t num_rows, uint resize_x, uint resize_y)
 {
 	DrawFrameRect(r.left, r.top, r.right, r.bottom, colour, (clicked) ? FR_LOWERED : FR_NONE);
 
-	int num_columns = GB(data, MAT_COL_START, MAT_COL_BITS);  // Lower 8 bits of the widget data: Number of columns in the matrix.
 	int column_width; // Width of a single column in the matrix.
 	if (num_columns == 0) {
 		column_width = resize_x;
@@ -415,7 +415,6 @@ static inline void DrawMatrix(const Rect &r, Colours colour, bool clicked, uint1
 		column_width = r.Width() / num_columns;
 	}
 
-	int num_rows = GB(data, MAT_ROW_START, MAT_ROW_BITS); // Upper 8 bits of the widget data: Number of rows in the matrix.
 	int row_height; // Height of a single row in the matrix.
 	if (num_rows == 0) {
 		row_height = resize_y;
@@ -1168,9 +1167,9 @@ void NWidgetCore::SetSpriteTip(SpriteID sprite, StringID tool_tip)
  * @param columns The number of columns in the matrix (0 for autoscaling).
  * @param rows The number of rows in the matrix (0 for autoscaling).
  */
-void NWidgetCore::SetMatrixDimension(uint8_t columns, uint8_t rows)
+void NWidgetCore::SetMatrixDimension(uint32_t columns, uint32_t rows)
 {
-	this->widget_data.matrix = static_cast<uint32_t>((rows << MAT_ROW_START) | (columns << MAT_COL_START));
+	this->widget_data.matrix = { columns, rows };
 }
 
 /**
@@ -3028,7 +3027,7 @@ void NWidgetLeaf::Draw(const Window *w)
 			break;
 
 		case WWT_MATRIX:
-			DrawMatrix(r, this->colour, clicked, this->widget_data.matrix, this->resize_x, this->resize_y);
+			DrawMatrix(r, this->colour, clicked, this->widget_data.matrix.width, this->widget_data.matrix.height, this->resize_x, this->resize_y);
 			break;
 
 		case WWT_EDITBOX: {

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -17,15 +17,6 @@
 #include "gfx_type.h"
 #include "window_type.h"
 
-/** Bits of the #WWT_MATRIX widget data. */
-/* Number of column bits of the WWT_MATRIX widget data. */
-static constexpr uint8_t MAT_COL_START = 0; ///< Lowest bit of the number of columns.
-static constexpr uint8_t MAT_COL_BITS = 8; ///< Number of bits for the number of columns in the matrix.
-
-/* Number of row bits of the WWT_MATRIX widget data. */
-static constexpr uint8_t MAT_ROW_START = 8; ///< Lowest bit of the number of rows.
-static constexpr uint8_t MAT_ROW_BITS = 8; ///< Number of bits for the number of rows in the matrix.
-
 /** Values for an arrow widget */
 enum ArrowWidgetValues : uint8_t {
 	AWV_DECREASE, ///< Arrow to the left or in case of RTL to the right
@@ -370,7 +361,7 @@ struct WidgetData {
 	SpriteID sprite{};
 	ArrowWidgetValues arrow_widget_type{};
 	ResizeWidgetValues resize_widget_type{};
-	uint32_t matrix{};
+	Dimension matrix{};
 };
 
 /**
@@ -385,7 +376,7 @@ public:
 	void SetStringTip(StringID string, StringID tool_tip);
 	void SetSprite(SpriteID sprite);
 	void SetSpriteTip(SpriteID sprite, StringID tool_tip);
-	void SetMatrixDimension(uint8_t columns, uint8_t rows);
+	void SetMatrixDimension(uint32_t columns, uint32_t rows);
 	void SetResizeWidgetType(ResizeWidgetValues type);
 	void SetToolTip(StringID tool_tip);
 	StringID GetToolTip() const;
@@ -1261,9 +1252,9 @@ constexpr NWidgetPart SetResizeWidgetTypeTip(ResizeWidgetValues widget_type, Str
  * @param tip  Tooltip of the widget.
  * @ingroup NestedWidgetParts
  */
-constexpr NWidgetPart SetMatrixDataTip(uint8_t cols, uint8_t rows, StringID tip = {})
+constexpr NWidgetPart SetMatrixDataTip(uint32_t cols, uint32_t rows, StringID tip = {})
 {
-	return NWidgetPart{WPT_DATATIP, NWidgetPartDataTip{{.matrix = static_cast<uint32_t>((rows << MAT_ROW_START) | (cols << MAT_COL_START))}, tip}};
+	return NWidgetPart{WPT_DATATIP, NWidgetPartDataTip{{.matrix{ cols, rows }}, tip}};
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

When setting the number of rows/columns manually in the matrix, you are limited to a maximum of 255 rows/columns. With a 8k resolution monitor (4320 pixels high) that is just 16 pixels per row, for reference multiplayer is 14 pixels per row at 1x scale. 
Note that this isn't an actual problem at the moment, because most windows do not manually set the matrix dimensions and if they do the values are small.

Furthermore we are manually bit-stuffing, where saving this information in a struct makes it easier to distinguish later on when the `widget_data` would be converted to a `std::variant`.


## Description

Replace the bit-stuffed variable with a `Dimension` and by doing so increase the theoretical limit to a few billion rows.


## Limitations

Includes #13235 (split widget_data) as this has been built on top of that.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
