### PR TITLE
Codechange: make direct access to tooltip/widget_data protected

### DIFF
--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -3142,7 +3142,7 @@ static bool IsAttributeWidgetPartType(WidgetType tp)
  * @param dest NWidget to apply attribute to.
  * @pre NWidgetPart must be an attribute NWidgetPart.
  */
-static void ApplyNWidgetPartAttribute(const NWidgetPart &nwid, NWidgetBase *dest)
+void ApplyNWidgetPartAttribute(const NWidgetPart &nwid, NWidgetBase *dest)
 {
 	switch (nwid.type) {
 		case WPT_RESIZE: {

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -400,14 +400,18 @@ public:
 
 	NWidgetDisplay disp_flags; ///< Flags that affect display and interaction with the widget.
 	Colours colour;            ///< Colour of this widget.
+protected:
 	const WidgetID index;      ///< Index of the nested widget (\c -1 means 'not used').
 	WidgetData widget_data; ///< Data of the widget. @see Widget::data
-	StringID tool_tip;         ///< Tooltip of the widget. @see Widget::tootips
+	StringID tool_tip; ///< Tooltip of the widget. @see Widget::tool_tips
 	WidgetID scrollbar_index;  ///< Index of an attached scrollbar.
 	TextColour highlight_colour; ///< Colour of highlight.
 	TextColour text_colour;    ///< Colour of text within widget.
 	FontSize text_size;        ///< Size of text within widget.
 	StringAlignment align;     ///< Alignment of text/image within widget.
+
+	/* This function constructs the widgets, so it should be able to write the variables. */
+	friend void ApplyNWidgetPartAttribute(const struct NWidgetPart &nwid, NWidgetBase *dest);
 };
 
 /**


### PR DESCRIPTION
## Motivation / Problem

[It is now feasible to make (most) of the instance variables of `NWidgetCore` protected.](https://github.com/OpenTTD/OpenTTD/pull/13243#pullrequestreview-2528439046)


## Description

Make most instance variables of `NWidgetCore` protected.
Fix a small typo.


## Limitations

Had to make `ApplyNWidgetPartAttribute` friend as that applies the extra widget configurations to the classes, and as such touches `widget_data` and others. Technically it could have been made a function of `NWidgetCore`, but it also handles classes that are not a descendent and a class knowing about its own subclasses isn't the best design either.

Especially `disp_flags` requires a lot of extra functions, or returning a modifiable reference which would defeat the point of making it protected. So it and `colours` will remain public for now.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
