### PR TITLE
Codechange: replace magic numbers with named constants

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -190,7 +190,6 @@ bool HaveDParamChanged(const std::span<const StringParameterData> backup)
 }
 
 static void StationGetSpecialString(StringBuilder &builder, StationFacility x);
-static void GetSpecialTownNameString(StringBuilder &builder, int ind, uint32_t seed);
 static bool GetSpecialNameString(StringBuilder &builder, StringID string, StringParameters &args);
 
 static void FormatString(StringBuilder &builder, const char *str, StringParameters &args, uint case_index = 0, bool game_script = false, bool dry_run = false);
@@ -266,9 +265,9 @@ void GetStringWithArgs(StringBuilder &builder, StringID string, StringParameters
 
 	switch (tab) {
 		case TEXT_TAB_TOWN:
-			if (index >= 0xC0 && !game_script) {
+			if (IsInsideMM(string, SPECSTR_TOWNNAME_START, SPECSTR_TOWNNAME_END) && !game_script) {
 				try {
-					GetSpecialTownNameString(builder, index.base() - 0xC0, args.GetNextParameter<uint32_t>());
+					GenerateTownNameString(builder, string - SPECSTR_TOWNNAME_START, args.GetNextParameter<uint32_t>());
 				} catch (const std::runtime_error &e) {
 					Debug(misc, 0, "GetStringWithArgs: {}", e.what());
 					builder += "(invalid string parameter)";
@@ -1762,11 +1761,6 @@ static void StationGetSpecialString(StringBuilder &builder, StationFacility x)
 	if ((x & FACIL_AIRPORT) != 0) builder.Utf8Encode(SCC_PLANE);
 }
 
-static void GetSpecialTownNameString(StringBuilder &builder, int ind, uint32_t seed)
-{
-	GenerateTownNameString(builder, ind, seed);
-}
-
 static const char * const _silly_company_names[] = {
 	"Bloggs Brothers",
 	"Tiny Transport Ltd.",
@@ -1891,7 +1885,7 @@ static bool GetSpecialNameString(StringBuilder &builder, StringID string, String
 
 	/* TownName Transport company names, with the appropriate town name. */
 	if (IsInsideMM(string, SPECSTR_COMPANY_NAME_START, SPECSTR_COMPANY_NAME_END)) {
-		GetSpecialTownNameString(builder, string - SPECSTR_COMPANY_NAME_START, args.GetNextParameter<uint32_t>());
+		GenerateTownNameString(builder, string - SPECSTR_COMPANY_NAME_START, args.GetNextParameter<uint32_t>());
 		builder += " Transport";
 		return true;
 	}


### PR DESCRIPTION
## Motivation / Problem

Missed that `GetStringWithArgs` does some of the same magic tricks as was fixed in #13274.


## Description

Compare the `StringID` against named constants, instead of a magic constant against `StringIndexInTab`.
Remove unneeded indirection.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
