### PR TITLE
Fix: Restore ability to disable service interval

### DIFF
--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -151,6 +151,7 @@ struct IntSettingDesc : SettingDesc {
 	typedef StringID GetHelpCallback(const IntSettingDesc &sd);
 	typedef void SetValueDParamsCallback(const IntSettingDesc &sd, uint first_param, int32_t value);
 	typedef int32_t GetDefaultValueCallback(const IntSettingDesc &sd);
+	typedef std::tuple<int32_t, uint32_t> GetRangeCallback(const IntSettingDesc &sd);
 
 	/**
 	 * A check to be performed before the setting gets changed. The passed integer may be
@@ -181,12 +182,12 @@ struct IntSettingDesc : SettingDesc {
 			Tmin min, Tmax max, Tinterval interval, StringID str, StringID str_help, StringID str_val,
 			SettingCategory cat, PreChangeCheck pre_check, PostChangeCallback post_callback,
 			GetTitleCallback get_title_cb, GetHelpCallback get_help_cb, SetValueDParamsCallback set_value_dparams_cb,
-			GetDefaultValueCallback get_def_cb) :
+			GetDefaultValueCallback get_def_cb, GetRangeCallback get_range_cb) :
 		SettingDesc(save, flags, startup),
 			str(str), str_help(str_help), str_val(str_val), cat(cat), pre_check(pre_check),
 			post_callback(post_callback),
 			get_title_cb(get_title_cb), get_help_cb(get_help_cb), set_value_dparams_cb(set_value_dparams_cb),
-			get_def_cb(get_def_cb) {
+			get_def_cb(get_def_cb), get_range_cb(get_range_cb) {
 		if constexpr (std::is_base_of_v<StrongTypedefBase, Tdef>) {
 			this->def = def.base();
 		} else {
@@ -226,11 +227,13 @@ struct IntSettingDesc : SettingDesc {
 	GetHelpCallback *get_help_cb;
 	SetValueDParamsCallback *set_value_dparams_cb;
 	GetDefaultValueCallback *get_def_cb; ///< Callback to set the correct default value
+	GetRangeCallback *get_range_cb;
 
 	StringID GetTitle() const;
 	StringID GetHelp() const;
 	void SetValueDParams(uint first_param, int32_t value) const;
 	int32_t GetDefaultValue() const;
+	std::tuple<int32_t, uint32_t> GetRange() const;
 
 	/**
 	 * Check whether this setting is a boolean type setting.
@@ -263,7 +266,7 @@ struct BoolSettingDesc : IntSettingDesc {
 			GetTitleCallback get_title_cb, GetHelpCallback get_help_cb, SetValueDParamsCallback set_value_dparams_cb,
 			GetDefaultValueCallback get_def_cb) :
 		IntSettingDesc(save, flags, startup, def ? 1 : 0, 0, 1, 0, str, str_help, str_val, cat,
-			pre_check, post_callback, get_title_cb, get_help_cb, set_value_dparams_cb, get_def_cb) {}
+			pre_check, post_callback, get_title_cb, get_help_cb, set_value_dparams_cb, get_def_cb, nullptr) {}
 
 	static std::optional<bool> ParseSingleValue(const char *str);
 
@@ -282,7 +285,7 @@ struct OneOfManySettingDesc : IntSettingDesc {
 			GetTitleCallback get_title_cb, GetHelpCallback get_help_cb, SetValueDParamsCallback set_value_dparams_cb,
 			GetDefaultValueCallback get_def_cb, std::initializer_list<const char *> many, OnConvert *many_cnvt) :
 		IntSettingDesc(save, flags, startup, def, 0, max, 0, str, str_help, str_val, cat,
-			pre_check, post_callback, get_title_cb, get_help_cb, set_value_dparams_cb, get_def_cb), many_cnvt(many_cnvt)
+			pre_check, post_callback, get_title_cb, get_help_cb, set_value_dparams_cb, get_def_cb, nullptr), many_cnvt(many_cnvt)
 	{
 		for (auto one : many) this->many.push_back(one);
 	}

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -247,7 +247,7 @@ static bool CanUpdateServiceInterval(VehicleType, int32_t &new_value)
 
 	/* Test if the interval is valid */
 	int32_t interval = GetServiceIntervalClamped(new_value, vds->servint_ispercent);
-	return interval == new_value;
+	return new_value == 0 || interval == new_value;
 }
 
 static void UpdateServiceInterval(VehicleType type, int32_t new_value)
@@ -288,6 +288,24 @@ static int32_t GetDefaultServiceInterval(const IntSettingDesc &sd, VehicleType t
 	}
 
 	return sd.def;
+}
+
+static std::tuple<int32_t, uint32_t> GetServiceIntervalRange(const IntSettingDesc &)
+{
+	VehicleDefaultSettings *vds;
+	if (_game_mode == GM_MENU || !Company::IsValidID(_current_company)) {
+		vds = &_settings_client.company.vehicle;
+	} else {
+		vds = &Company::Get(_current_company)->settings.vehicle;
+	}
+
+	if (vds->servint_ispercent) return { MIN_SERVINT_PERCENT, MAX_SERVINT_PERCENT };
+
+	if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU)) {
+		return { MIN_SERVINT_MINUTES, MAX_SERVINT_MINUTES };
+	}
+
+	return { MIN_SERVINT_DAYS, MAX_SERVINT_DAYS };
 }
 
 static void TrainAccelerationModelChanged(int32_t)

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -58,8 +58,8 @@ static StringID SettingHelpWallclock(const IntSettingDesc &sd);
 
 /* Macros for various objects to go in the configuration file.
  * This section is for global variables */
-#define SDTG_VAR(name, type, flags, var, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
-	NSD(Int, SLEG_GENERAL(name, SL_VAR, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
+#define SDTG_VAR(name, type, flags, var, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, get_range_hook, from, to, cat, extra, startup)\
+	NSD(Int, SLEG_GENERAL(name, SL_VAR, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, get_range_hook)
 
 #define SDTG_BOOL(name, flags, var, def, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
 	NSD(Bool, SLEG_GENERAL(name, SL_VAR, var, SLE_BOOL, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
@@ -78,8 +78,8 @@ static StringID SettingHelpWallclock(const IntSettingDesc &sd);
 
 /* Macros for various objects to go in the configuration file.
  * This section is for structures where their various members are saved */
-#define SDT_VAR(base, var, type, flags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
-	NSD(Int, SLE_GENERAL(SL_VAR, base, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
+#define SDT_VAR(base, var, type, flags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, get_range_hook, from, to, cat, extra, startup)\
+	NSD(Int, SLE_GENERAL(SL_VAR, base, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, get_range_hook)
 
 #define SDT_VAR_NAME(base, var, type, flags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup, name)\
 	NSD(Int, SLE_GENERAL_NAME(SL_VAR, name, base, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
@@ -100,8 +100,8 @@ static StringID SettingHelpWallclock(const IntSettingDesc &sd);
 	NSD(ManyOfMany, SLE_GENERAL(SL_VAR, base, var, type, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, full, nullptr)
 
 
-#define SDTC_VAR(var, type, flags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
-	SDTG_VAR(#var, type, flags, _settings_client.var, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)
+#define SDTC_VAR(var, type, flags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, get_range_hook, from, to, cat, extra, startup)\
+	SDTG_VAR(#var, type, flags, _settings_client.var, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, get_range_hook, from, to, cat, extra, startup)
 
 #define SDTC_BOOL(var, flags, def, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
 	SDTG_BOOL(#var, flags, _settings_client.var, def, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)

--- a/src/table/settings/company_settings.ini
+++ b/src/table/settings/company_settings.ini
@@ -14,6 +14,7 @@ static void UpdateServiceInterval(VehicleType type, int32_t new_value);
 static void SettingsValueAbsolute(const IntSettingDesc &sd, uint first_param, int32_t value);
 static void ServiceIntervalSettingsValueText(const IntSettingDesc &sd, uint first_param, int32_t value);
 static int32_t GetDefaultServiceInterval(const IntSettingDesc &sd, VehicleType type);
+static std::tuple<int32_t, uint32_t> GetServiceIntervalRange(const IntSettingDesc &sd);
 
 static const SettingVariant _company_settings_table[] = {
 [post-amble]
@@ -103,6 +104,7 @@ pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_TRAIN, new_
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_TRAIN, new_value); }
 def_cb   = [](auto &sd) { return GetDefaultServiceInterval(sd, VEH_TRAIN); }
 val_cb   = ServiceIntervalSettingsValueText
+range_cb = GetServiceIntervalRange
 
 [SDT_VAR]
 var      = vehicle.servint_roadveh
@@ -119,6 +121,7 @@ pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_ROAD, new_v
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_ROAD, new_value); }
 def_cb   = [](auto &sd) { return GetDefaultServiceInterval(sd, VEH_ROAD); }
 val_cb   = ServiceIntervalSettingsValueText
+range_cb = GetServiceIntervalRange
 
 [SDT_VAR]
 var      = vehicle.servint_ships
@@ -135,6 +138,7 @@ pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_SHIP, new_v
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_SHIP, new_value); }
 def_cb   = [](auto &sd) { return GetDefaultServiceInterval(sd, VEH_SHIP); }
 val_cb   = ServiceIntervalSettingsValueText
+range_cb = GetServiceIntervalRange
 
 [SDT_VAR]
 var      = vehicle.servint_aircraft
@@ -151,3 +155,4 @@ pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_AIRCRAFT, n
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_AIRCRAFT, new_value); }
 def_cb   = [](auto &sd) { return GetDefaultServiceInterval(sd, VEH_AIRCRAFT); }
 val_cb   = ServiceIntervalSettingsValueText
+range_cb = GetServiceIntervalRange

--- a/src/table/settings/company_settings.ini
+++ b/src/table/settings/company_settings.ini
@@ -20,7 +20,7 @@ static const SettingVariant _company_settings_table[] = {
 };
 [templates]
 SDT_BOOL = SDT_BOOL(CompanySettings, $var,        $flags, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
-SDT_VAR  =  SDT_VAR(CompanySettings, $var, $type, $flags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
+SDT_VAR  =  SDT_VAR(CompanySettings, $var, $type, $flags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for CompanySettings.$var exceeds storage size");
@@ -37,6 +37,7 @@ str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
 def_cb   = nullptr
+range_cb = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/currency_settings.ini
+++ b/src/table/settings/currency_settings.ini
@@ -11,7 +11,7 @@ static const SettingVariant _currency_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDT_VAR  = SDT_VAR (CurrencySpec, $var, $type, $flags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
+SDT_VAR  = SDT_VAR (CurrencySpec, $var, $type, $flags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to, $cat, $extra, $startup),
 SDT_SSTR = SDT_SSTR(CurrencySpec, $var, $type, $flags, $def,                                                 $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
@@ -29,6 +29,7 @@ str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
 def_cb   = nullptr
+range_cb = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/difficulty_settings.ini
+++ b/src/table/settings/difficulty_settings.ini
@@ -20,9 +20,9 @@ static const SettingVariant _difficulty_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDTG_VAR   =   SDTG_VAR($name,              $type, $flags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_VAR   =   SDTG_VAR($name,              $type, $flags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to,        $cat, $extra, $startup),
 SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
-SDT_VAR    =   SDT_VAR (GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDT_VAR    =   SDT_VAR (GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -40,6 +40,7 @@ str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
 def_cb   = nullptr
+range_cb = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -17,7 +17,7 @@ static const SettingVariant _economy_settings_table[] = {
 };
 [templates]
 SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
-SDT_VAR    =   SDT_VAR (GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDT_VAR    =   SDT_VAR (GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for GameSettings.$var exceeds storage size");
@@ -34,6 +34,7 @@ str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
 def_cb   = nullptr
+range_cb = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/game_settings.ini
+++ b/src/table/settings/game_settings.ini
@@ -27,11 +27,11 @@ static const SettingVariant _game_settings_table[] = {
 };
 [templates]
 SDTG_BOOL  =  SDTG_BOOL($name,                     $flags, $var, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
-SDTG_VAR   =   SDTG_VAR($name,              $type, $flags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_VAR   =   SDTG_VAR($name,              $type, $flags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to,        $cat, $extra, $startup),
 SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 SDT_OMANY  =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $load, $cat, $extra, $startup),
-SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -50,6 +50,7 @@ str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
 def_cb   = nullptr
+range_cb = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -27,7 +27,7 @@ static const SettingVariant _gui_settings_table[] = {
 [templates]
 SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTC_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -45,6 +45,7 @@ str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
 def_cb   = nullptr
+range_cb = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/linkgraph_settings.ini
+++ b/src/table/settings/linkgraph_settings.ini
@@ -12,7 +12,7 @@ static const SettingVariant _linkgraph_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for GameSettings.$var exceeds storage size");
@@ -29,6 +29,7 @@ str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
 def_cb   = nullptr
+range_cb = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/misc_settings.ini
+++ b/src/table/settings/misc_settings.ini
@@ -29,7 +29,7 @@ SDTG_MMANY = SDTG_MMANY($name, $type, $flags, $var, $def,                       
 SDTG_OMANY = SDTG_OMANY($name, $type, $flags, $var, $def,       $max,            $full, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
 SDTG_SSTR  =  SDTG_SSTR($name, $type, $flags, $var, $def,       0,                                               $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 SDTG_BOOL  =  SDTG_BOOL($name,        $flags, $var, $def,                               $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
-SDTG_VAR   =   SDTG_VAR($name, $type, $flags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
+SDTG_VAR   =   SDTG_VAR($name, $type, $flags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -47,6 +47,7 @@ str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
 def_cb   = nullptr
+range_cb = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/multimedia_settings.ini
+++ b/src/table/settings/multimedia_settings.ini
@@ -14,7 +14,7 @@ static const SettingVariant _multimedia_settings_table[] = {
 [templates]
 SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 SDTC_LIST  =  SDTC_LIST(              $var, $type, $flags, $def,                                                                          $from, $to,        $cat, $extra, $startup),
-SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTC_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -31,6 +31,7 @@ str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
 def_cb   = nullptr
+range_cb = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/network_settings.ini
+++ b/src/table/settings/network_settings.ini
@@ -18,7 +18,7 @@ static const SettingVariant _network_settings_table[] = {
 [templates]
 SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTC_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -36,6 +36,7 @@ str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
 def_cb   = nullptr
+range_cb = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/old_gameopt_settings.ini
+++ b/src/table/settings/old_gameopt_settings.ini
@@ -31,12 +31,12 @@ static const SettingVariant _old_gameopt_settings_table[] = {
 };
 [templates]
 SDTG_LIST    =  SDTG_LIST($name,              $type, $flags, $var, $def, $length, $from, $to, $cat, $extra, $startup),
-SDTG_VAR     =   SDTG_VAR($name,              $type, $flags, $var, $def, $min, $max, $interval,  $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
+SDTG_VAR     =   SDTG_VAR($name,              $type, $flags, $var, $def, $min, $max, $interval,  $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to, $cat, $extra, $startup),
 SDT_NULL     =   SDT_NULL(                                                          $length,                                                                                      $from, $to),
 SDTC_OMANY   = SDTC_OMANY(              $var, $type, $flags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 SDTG_OMANY   = SDTG_OMANY($name,              $type, $flags, $var, $def, $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 SDT_OMANY    =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $load, $cat, $extra, $startup),
-SDT_VAR      =    SDT_VAR(GameSettings, $var, $type, $flags, $def, $min, $max,        $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDT_VAR      =    SDT_VAR(GameSettings, $var, $type, $flags, $def, $min, $max,        $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -57,6 +57,7 @@ str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
 def_cb   = nullptr
+range_cb = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/pathfinding_settings.ini
+++ b/src/table/settings/pathfinding_settings.ini
@@ -13,7 +13,7 @@ static const SettingVariant _pathfinding_settings_table[] = {
 };
 [templates]
 SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
-SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for GameSettings.$var exceeds storage size");
@@ -30,6 +30,7 @@ str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
 def_cb   = nullptr
+range_cb = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/script_settings.ini
+++ b/src/table/settings/script_settings.ini
@@ -15,7 +15,7 @@ static const SettingVariant _script_settings_table[] = {
 [templates]
 SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 SDT_OMANY  =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $load, $cat, $extra, $startup),
-SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDT_OMANY = static_assert($max <= MAX_$type, "Maximum value for GameSettings.$var exceeds storage size");
@@ -33,6 +33,7 @@ str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
 def_cb   = nullptr
+range_cb = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/win32_settings.ini
+++ b/src/table/settings/win32_settings.ini
@@ -18,7 +18,7 @@ static const SettingVariant _win32_settings_table[] = {
 #endif /* _WIN32 */
 [templates]
 SDTG_BOOL = SDTG_BOOL($name,        $flags, $var, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
-SDTG_VAR  =  SDTG_VAR($name, $type, $flags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
+SDTG_VAR  =  SDTG_VAR($name, $type, $flags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -35,6 +35,7 @@ str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
 def_cb   = nullptr
+range_cb = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/window_settings.ini
+++ b/src/table/settings/window_settings.ini
@@ -14,7 +14,7 @@ static const SettingVariant _window_settings_table[] = {
 };
 [templates]
 SDT_BOOL = SDT_BOOL(WindowDesc, $var,        $flags, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
-SDT_VAR  =  SDT_VAR(WindowDesc, $var, $type, $flags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $cat, $extra, $startup),
+SDT_VAR  =  SDT_VAR(WindowDesc, $var, $type, $flags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for WindowDesc.$var exceeds storage size");
@@ -31,6 +31,7 @@ str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
 def_cb   = nullptr
+range_cb = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/settings/world_settings.ini
+++ b/src/table/settings/world_settings.ini
@@ -20,7 +20,7 @@ static const SettingVariant _world_settings_table[] = {
 [templates]
 SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 SDT_OMANY  =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $load, $cat, $extra, $startup),
-SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
+SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDT_OMANY = static_assert($max <= MAX_$type, "Maximum value for GameSettings.$var exceeds storage size");
@@ -38,6 +38,7 @@ str_cb   = nullptr
 help_cb  = nullptr
 val_cb   = nullptr
 def_cb   = nullptr
+range_cb = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Since 12.0 it's not possible to disable service interval.
Main reason is static min/max in company_settings.ini is set to a [`MIN_SERVINT_MINUTES` (1), `MAX_SERVINT_DAYS` (800)] (so all possible ranges depending on `ispercent` or wallclock timekeeping are included), but the actual usable range is often more strict.
For instance, in percent mode the range is [`MIN_SERVINT_PERCENT` (5), `MAX_SERVINT_PERCENT` (90)] with 0 for disabled, GUI happily goes from 5 to 4 which is then rejected and setting is unchanged, while the expected result is an automatic translation of 4 into 0.
BTW `CanUpdateServiceInterval()` doesn't accept 0 at all.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Introduce a setting callback to get the correct range.
Tell `CanUpdateServiceInterval()` 0 is a valid value.
Use the callback for service interval min/max.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
