### PR TITLE
Fix #13286: Viewport scrolling restricted by window edges with SDL2 video driver.

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -332,7 +332,7 @@ static void LoadIntroGame(bool load_newgrfs = true)
 
 	FixTitleGameZoom();
 	_pause_mode = PM_UNPAUSED;
-	_cursor.fix_at = false;
+	VideoDriver::GetInstance()->FixMousePointer(false);
 
 	CheckForMissingGlyphs();
 

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -9,6 +9,7 @@
 
 #include "stdafx.h"
 #include "core/backup_type.hpp"
+#include "video/video_driver.hpp"
 #include "clear_map.h"
 #include "industry.h"
 #include "station_map.h"
@@ -1866,7 +1867,9 @@ public:
 
 	void OnScroll(Point delta) override
 	{
-		if (_settings_client.gui.scroll_mode == VSM_VIEWPORT_RMB_FIXED || _settings_client.gui.scroll_mode == VSM_MAP_RMB_FIXED) _cursor.fix_at = true;
+		if (_settings_client.gui.scroll_mode == VSM_VIEWPORT_RMB_FIXED || _settings_client.gui.scroll_mode == VSM_MAP_RMB_FIXED) {
+			VideoDriver::GetInstance()->FixMousePointer(true);
+		}
 
 		/* While tile is at (delta.x, delta.y)? */
 		int sub;

--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -49,6 +49,7 @@ public:
 	void ClearSystemSprites() override;
 	void PopulateSystemSprites() override;
 
+	void FixMousePointer(bool fix_at) override;
 	void EditBoxLostFocus() override;
 
 	std::vector<int> GetListOfMonitorRefreshRates() override;

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -240,6 +240,15 @@ bool VideoDriver_Cocoa::AfterBlitterChange()
 	return true;
 }
 
+void VideoDriver_Cocoa::FixMousePointer(bool fix_at)
+{
+	if (_cursor.fix_at == fix_at) return;
+
+	this->VideoDriver::FixMousePointer(fix_at);
+
+	CGAssociateMouseAndMouseCursorPosition(!_cursor.fix_at);
+}
+
 /**
  * An edit box lost the input focus. Abort character compositing if necessary.
  */

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -674,15 +674,6 @@ void CocoaDialog(const char *title, const char *message, const char *buttonLabel
 	HandleMouseEvents();
 }
 
-- (void)internalMouseButtonEvent
-{
-	bool cur_fix = _cursor.fix_at;
-	HandleMouseEvents();
-
-	/* Cursor fix mode was changed, synchronize with OS. */
-	if (cur_fix != _cursor.fix_at) CGAssociateMouseAndMouseCursorPosition(!_cursor.fix_at);
-}
-
 - (BOOL)emulateRightButton:(NSEvent *)event
 {
 	uint32_t keymask = 0;
@@ -708,7 +699,7 @@ void CocoaDialog(const char *title, const char *message, const char *buttonLabel
 		[ self rightMouseDown:event ];
 	} else {
 		_left_button_down = true;
-		[ self internalMouseButtonEvent ];
+		HandleMouseEvents();
 	}
 }
 - (void)mouseUp:(NSEvent *)event
@@ -719,7 +710,7 @@ void CocoaDialog(const char *title, const char *message, const char *buttonLabel
 	} else {
 		_left_button_down = false;
 		_left_button_clicked = false;
-		[ self internalMouseButtonEvent ];
+		HandleMouseEvents();
 	}
 }
 
@@ -731,12 +722,12 @@ void CocoaDialog(const char *title, const char *message, const char *buttonLabel
 {
 	_right_button_down = true;
 	_right_button_clicked = true;
-	[ self internalMouseButtonEvent ];
+	HandleMouseEvents();
 }
 - (void)rightMouseUp:(NSEvent *)event
 {
 	_right_button_down = false;
-	[ self internalMouseButtonEvent ];
+	HandleMouseEvents();
 }
 
 - (void)scrollWheel:(NSEvent *)event

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -35,6 +35,8 @@ public:
 
 	bool ClaimMousePointer() override;
 
+	void FixMousePointer(bool fix_at) override;
+
 	void EditBoxGainedFocus() override;
 
 	void EditBoxLostFocus() override;

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -88,6 +88,11 @@ public:
 	}
 
 	/**
+	 * Fix the mouse position position.
+	 */
+	virtual void FixMousePointer(bool fix_at) { _cursor.fix_at = fix_at; }
+
+	/**
 	 * Get whether the mouse cursor is drawn by the video driver.
 	 * @return True if cursor drawing is done by the video driver.
 	 */

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2365,7 +2365,7 @@ static EventState HandleViewportScroll()
 	if (_last_scroll_window == nullptr) _last_scroll_window = FindWindowFromPt(_cursor.pos.x, _cursor.pos.y);
 
 	if (_last_scroll_window == nullptr || !((_settings_client.gui.scroll_mode != VSM_MAP_LMB && _right_button_down) || scrollwheel_scrolling || (_settings_client.gui.scroll_mode == VSM_MAP_LMB && _left_button_down))) {
-		_cursor.fix_at = false;
+		VideoDriver::GetInstance()->FixMousePointer(false);
 		_scrolling_viewport = false;
 		_last_scroll_window = nullptr;
 		return ES_NOT_HANDLED;
@@ -2820,7 +2820,7 @@ static void MouseLoop(MouseClick click, int mousewheel)
 	if (vp != nullptr) {
 		if (scrollwheel_scrolling && !(w->flags & WF_DISABLE_VP_SCROLL)) {
 			_scrolling_viewport = true;
-			_cursor.fix_at = true;
+			VideoDriver::GetInstance()->FixMousePointer(true);
 			return;
 		}
 
@@ -2831,7 +2831,7 @@ static void MouseLoop(MouseClick click, int mousewheel)
 				if (!(w->flags & WF_DISABLE_VP_SCROLL) &&
 						_settings_client.gui.scroll_mode == VSM_MAP_LMB) {
 					_scrolling_viewport = true;
-					_cursor.fix_at = false;
+					VideoDriver::GetInstance()->FixMousePointer(false);
 					return;
 				}
 				break;
@@ -2840,8 +2840,7 @@ static void MouseLoop(MouseClick click, int mousewheel)
 				if (!(w->flags & WF_DISABLE_VP_SCROLL) &&
 						_settings_client.gui.scroll_mode != VSM_MAP_LMB) {
 					_scrolling_viewport = true;
-					_cursor.fix_at = (_settings_client.gui.scroll_mode == VSM_VIEWPORT_RMB_FIXED ||
-							_settings_client.gui.scroll_mode == VSM_MAP_RMB_FIXED);
+					VideoDriver::GetInstance()->FixMousePointer(_settings_client.gui.scroll_mode == VSM_VIEWPORT_RMB_FIXED || _settings_client.gui.scroll_mode == VSM_MAP_RMB_FIXED);
 					DispatchRightClickEvent(w, x - w->left, y - w->top);
 					return;
 				}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As per #13286, viewport scrolling on Linux does not work very well as it clamped by the window/screen edges.

I originally closed that issue as it's a duplicate of an old issue, but then I decided to look into it anyway...

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This PR changes how `_cursor.fix_at` is set, instead of just changing the global, a call to the video driver is made so that the driver can action the state. This replaces existing code in the cocoa video driver which tested if the state is changed before and after calling `HandleMouseEvents()`

For SDL2, this new call forwards the call to `SDL_SetRelativeMouseMode()` which enable relative motion events, and then uses these events instead of absolute events when active. These relative motion events are not limited by the window/screen limits.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

I don't have mac OS so I haven't tested the change there.

Unsure if Windows has the same issue. Don't care about the SDL1 driver.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
