### PR TITLE
Feature: Draw infinite water when all borders are water

### DIFF
--- a/src/heightmap.cpp
+++ b/src/heightmap.cpp
@@ -9,6 +9,7 @@
 
 #include "stdafx.h"
 #include "heightmap.h"
+#include "landscape.h"
 #include "clear_map.h"
 #include "strings_func.h"
 #include "void_map.h"
@@ -523,6 +524,10 @@ bool LoadHeightmap(DetailedFileType dft, std::string_view filename)
 	GreyscaleToMapHeights(x, y, map);
 
 	FixSlopes();
+
+	/* If all map borders are water, we will draw infinite water. */
+	_settings_game.construction.freeform_edges = !IsMapSurroundedByWater();
+
 	MarkWholeScreenDirty();
 
 	return true;

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -638,6 +638,36 @@ void ClearSnowLine()
 }
 
 /**
+ * Check if all tiles on the map edge should be considered water borders.
+ * @return true If the edge of the map is flat and height 0, allowing for infinite water borders.
+ */
+bool IsMapSurroundedByWater()
+{
+	auto check_tile = [](uint x, uint y) -> bool {
+		auto [slope, h] = GetTilePixelSlopeOutsideMap(x, y);
+		return ((slope == SLOPE_FLAT) && (h == 0));
+	};
+
+	/* Check the map corners. */
+	if (!check_tile(0, 0)) return false;
+	if (!check_tile(0, Map::SizeY())) return false;
+	if (!check_tile(Map::SizeX(), 0)) return false;
+	if (!check_tile(Map::SizeX(), Map::SizeY())) return false;
+
+	/* Check the map edges.*/
+	for (uint x = 0; x <= Map::SizeX(); x++) {
+		if (!check_tile(x, 0)) return false;
+		if (!check_tile(x, Map::SizeY())) return false;
+	}
+	for (uint y = 1; y < Map::SizeY(); y++) {
+		if (!check_tile(0, y)) return false;
+		if (!check_tile(Map::SizeX(), y)) return false;
+	}
+
+	return true;
+}
+
+/**
  * Clear a piece of landscape
  * @param flags of operation to conduct
  * @param tile tile to clear

--- a/src/landscape.h
+++ b/src/landscape.h
@@ -33,6 +33,8 @@ uint8_t HighestSnowLine();
 uint8_t LowestSnowLine();
 void ClearSnowLine();
 
+bool IsMapSurroundedByWater();
+
 int GetSlopeZInCorner(Slope tileh, Corner corner);
 std::tuple<Slope, int> GetFoundationSlope(TileIndex tile);
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3428,8 +3428,11 @@ STR_MAPGEN_SOUTHWEST                                            :{BLACK}Southwes
 STR_MAPGEN_BORDER_FREEFORM                                      :{BLACK}Freeform
 STR_MAPGEN_BORDER_WATER                                         :{BLACK}Water
 STR_MAPGEN_BORDER_RANDOM                                        :{BLACK}Random
-STR_MAPGEN_BORDER_RANDOMIZE                                     :{BLACK}Random
-STR_MAPGEN_BORDER_MANUAL                                        :{BLACK}Manual
+
+###length 3
+STR_MAPGEN_BORDER_RANDOMIZE                                     :Random
+STR_MAPGEN_BORDER_MANUAL                                        :Manual
+STR_MAPGEN_BORDER_INFINITE_WATER                                :Infinite Water
 
 STR_MAPGEN_HEIGHTMAP_ROTATION                                   :{BLACK}Heightmap rotation:
 STR_MAPGEN_HEIGHTMAP_NAME                                       :{BLACK}Heightmap name:

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -253,6 +253,11 @@ CommandCost CmdBuildObject(DoCommandFlags flags, TileIndex tile, ObjectType type
 					Owner o = GetTileOwner(t);
 					if (o != OWNER_NONE && o != OWNER_WATER) cost.AddCost(CheckOwnership(o, t));
 
+					/* If freeform edges are disabled, don't allow building on edge tiles. */
+					if (!_settings_game.construction.freeform_edges && (!IsInsideMM(TileX(t), 1, Map::MaxX() - 1) || !IsInsideMM(TileY(t), 1, Map::MaxY() - 1))) {
+						return CommandCost(STR_ERROR_TOO_CLOSE_TO_EDGE_OF_MAP);
+					}
+
 					/* However, the tile has to be clear of vehicles. */
 					cost.AddCost(EnsureNoVehicleOnGround(t));
 				}

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -64,6 +64,13 @@ enum IndustryDensity : uint8_t {
 	ID_END,       ///< Number of industry density settings.
 };
 
+/** Possible options for the Borders pulldown in the Genworld GUI. */
+enum BorderFlagPresets : uint8_t {
+	BFP_RANDOM = 0,
+	BFP_MANUAL,
+	BFP_INFINITE_WATER,
+};
+
 /** Possible values for the "timekeeping_units" setting. */
 enum TimekeepingUnits : uint8_t {
 	TKU_CALENDAR = 0,
@@ -375,6 +382,7 @@ struct GameCreationSettings {
 	uint8_t town_name;                        ///< the town name generator used for town names
 	LandscapeType landscape;                        ///< the landscape we're currently in
 	BorderFlags water_borders;                    ///< bitset of the borders that are water
+	BorderFlagPresets water_border_presets;    ///< presets for map border options
 	uint16_t custom_town_number;               ///< manually entered number of towns
 	uint16_t custom_industry_number;           ///< manually entered number of industries
 	uint8_t variety;                          ///< variety level applied to TGP

--- a/src/table/settings/world_settings.ini
+++ b/src/table/settings/world_settings.ini
@@ -269,6 +269,13 @@ min      = 0
 max      = 16
 
 [SDT_VAR]
+var      = game_creation.water_border_presets
+type     = SLE_UINT8
+def      = BFP_RANDOM
+min      = BFP_RANDOM
+max      = BFP_INFINITE_WATER
+
+[SDT_VAR]
 var      = game_creation.custom_town_number
 type     = SLE_UINT16
 from     = SLV_115

--- a/src/void_cmd.cpp
+++ b/src/void_cmd.cpp
@@ -21,7 +21,12 @@
 
 static void DrawTile_Void(TileInfo *ti)
 {
-	DrawGroundSprite(SPR_FLAT_BARE_LAND + SlopeToSpriteOffset(ti->tileh), PALETTE_ALL_BLACK);
+	/* If freeform edges are off, draw infinite water off the edges of the map. */
+	if (!_settings_game.construction.freeform_edges) {
+		DrawGroundSprite(SPR_FLAT_WATER_TILE + SlopeToSpriteOffset(ti->tileh), PAL_NONE);
+	} else {
+		DrawGroundSprite(SPR_FLAT_BARE_LAND + SlopeToSpriteOffset(ti->tileh), PALETTE_ALL_BLACK);
+	}
 }
 
 

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -454,6 +454,13 @@ CommandCost CmdBuildLock(DoCommandFlags flags, TileIndex tile)
 	DiagDirection dir = GetInclinedSlopeDirection(GetTileSlope(tile));
 	if (dir == INVALID_DIAGDIR) return CommandCost(STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
 
+	TileIndex lower_tile = TileAddByDiagDir(tile, ReverseDiagDir(dir));
+
+	/* If freeform edges are disabled, don't allow building on edge tiles. */
+	if (!_settings_game.construction.freeform_edges && (!IsInsideMM(TileX(lower_tile), 1, Map::MaxX() - 1) || !IsInsideMM(TileY(lower_tile), 1, Map::MaxY() - 1))) {
+		return CommandCost(STR_ERROR_TOO_CLOSE_TO_EDGE_OF_MAP);
+	}
+
 	return DoBuildLock(tile, dir, flags);
 }
 

--- a/src/widgets/genworld_widget.h
+++ b/src/widgets/genworld_widget.h
@@ -54,7 +54,7 @@ enum GenerateLandscapeWidgets : WidgetID {
 	WID_GL_SMOOTHNESS_PULLDOWN,         ///< Dropdown 'Smoothness'.
 	WID_GL_VARIETY_PULLDOWN,            ///< Dropdown 'Variety distribution'.
 
-	WID_GL_BORDERS_RANDOM,              ///< 'Random'/'Manual' borders.
+	WID_GL_BORDERS_PULLDOWN,            ///< Dropdown 'Map edges'.
 	WID_GL_WATER_NW,                    ///< NW 'Water'/'Freeform'.
 	WID_GL_WATER_NE,                    ///< NE 'Water'/'Freeform'.
 	WID_GL_WATER_SE,                    ///< SE 'Water'/'Freeform'.


### PR DESCRIPTION
## Motivation / Problem

JGRPP has a feature to show areas beyond the map as water, if the edges are sea level. It's cool.

## Description

![water](https://github.com/user-attachments/assets/540d0d74-5666-4912-9579-a58e51aa9817)

In World Generation, a player can set the map edges to All Water. This draws tiles beyond the map as infinite water and restricts terraforming of edge tiles. as well as construction of water infrastructure and objects.

When importing a heightmap, check the map edges and if they are sea level, set the map borders automatically.

Existing games cannot be upgraded unless `freeform_edges` is set to false, in which case they are automatically changed. (This is the setting which actually handles the drawing, as there are pre-existing protections against modifying tiles near the map edge.)

This PR intentionally does not change the smallmap, which still shows black off the edge of the map. I could change this if desired, but I figured it's a good way to easily see the playable area. After much discussion (see below) I've decided to draw the same old water sprite outside the map border, rather than try to visualize it somehow.

All changes are in separate commits for ease of review, I will squash into a single `Feature:` commit when merging.

## Limitations

* It's not possible to upgrade existing maps.
* Old savegames with `freeform_edges` disabled get changed automatically.
* Terraforming map edges is no longer allowed when all map borders are water. This is a behavior change, although I don't know why you'd set your map edges to water if you plan on terraforming...
* If we ever do deep water (#7924), this might force maps to have max depth at the edges to extend infinitely.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
