### PR TITLE
Codechange: use C++ constructs over MallocT/free

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -1668,7 +1668,7 @@ static void AircraftEventHandler_Flying(Aircraft *v, const AirportFTAClass *apc)
 		 * if it is an airplane, look for LANDING, for helicopter HELILANDING
 		 * it is possible to choose from multiple landing runways, so loop until a free one is found */
 		uint8_t landingtype = (v->subtype == AIR_HELICOPTER) ? HELILANDING : LANDING;
-		const AirportFTA *current = apc->layout[v->pos].next;
+		const AirportFTA *current = apc->layout[v->pos].next.get();
 		while (current != nullptr) {
 			if (current->heading == landingtype) {
 				/* save speed before, since if AirportHasBlock is false, it resets them to 0
@@ -1689,7 +1689,7 @@ static void AircraftEventHandler_Flying(Aircraft *v, const AirportFTAClass *apc)
 				v->cur_speed = tcur_speed;
 				v->subspeed = tsubspeed;
 			}
-			current = current->next;
+			current = current->next.get();
 		}
 	}
 	v->state = FLYING;
@@ -1843,7 +1843,7 @@ static bool AirportMove(Aircraft *v, const AirportFTAClass *apc)
 			} // move to next position
 			return false;
 		}
-		current = current->next;
+		current = current->next.get();
 	} while (current != nullptr);
 
 	Debug(misc, 0, "[Ap] cannot move further on Airport! (pos {} state {}) for vehicle {}", v->pos, v->state, v->index);
@@ -1893,13 +1893,13 @@ static bool AirportSetBlocks(Aircraft *v, const AirportFTA *current_pos, const A
 		/* search for all all elements in the list with the same state, and blocks != N
 		 * this means more blocks should be checked/set */
 		const AirportFTA *current = current_pos;
-		if (current == reference) current = current->next;
+		if (current == reference) current = current->next.get();
 		while (current != nullptr) {
 			if (current->heading == current_pos->heading && current->block != 0) {
 				airport_flags |= current->block;
 				break;
 			}
-			current = current->next;
+			current = current->next.get();
 		}
 
 		/* if the block to be checked is in the next position, then exclude that from
@@ -2000,7 +2000,7 @@ static bool AirportFindFreeTerminal(Aircraft *v, const AirportFTAClass *apc)
 	 */
 	if (apc->terminals[0] > 1) {
 		const Station *st = Station::Get(v->targetairport);
-		const AirportFTA *temp = apc->layout[v->pos].next;
+		const AirportFTA *temp = apc->layout[v->pos].next.get();
 
 		while (temp != nullptr) {
 			if (temp->heading == TERMGROUP) {
@@ -2025,7 +2025,7 @@ static bool AirportFindFreeTerminal(Aircraft *v, const AirportFTAClass *apc)
 				 * So we cannot move */
 				return false;
 			}
-			temp = temp->next;
+			temp = temp->next.get();
 		}
 	}
 

--- a/src/airport.h
+++ b/src/airport.h
@@ -139,6 +139,17 @@ AirportMovingData RotateAirportMovingData(const AirportMovingData *orig, Directi
 
 struct AirportFTAbuildup;
 
+/** Internal structure used in openttd - Finite sTate mAchine --> FTA */
+struct AirportFTA {
+	AirportFTA(const AirportFTAbuildup&);
+
+	std::unique_ptr<AirportFTA> next; ///< possible extra movement choices from this position
+	uint64_t block; ///< bitmap of blocks that could be reserved
+	uint8_t position; ///< the position that an airplane is at
+	uint8_t next_position; ///< next position from this position
+	uint8_t heading; ///< heading (current orders), guiding an airplane to its target on an airport
+};
+
 /** Finite sTate mAchine (FTA) of an airport. */
 struct AirportFTAClass {
 public:
@@ -160,8 +171,6 @@ public:
 		uint8_t delta_z
 	);
 
-	~AirportFTAClass();
-
 	/**
 	 * Get movement data at a position.
 	 * @param position Element number to get movement data about.
@@ -174,7 +183,7 @@ public:
 	}
 
 	const AirportMovingData *moving_data; ///< Movement data.
-	struct AirportFTA *layout;            ///< state machine for airport
+	std::vector<AirportFTA> layout; ///< state machine for airport
 	const uint8_t *terminals;                ///< %Array with the number of terminal groups, followed by the number of terminals in each group.
 	const uint8_t num_helipads;              ///< Number of helipads on this airport. When 0 helicopters will go to normal terminals.
 	Flags flags;                          ///< Flags for this airport type.
@@ -185,15 +194,6 @@ public:
 
 DECLARE_ENUM_AS_BIT_SET(AirportFTAClass::Flags)
 
-
-/** Internal structure used in openttd - Finite sTate mAchine --> FTA */
-struct AirportFTA {
-	AirportFTA *next;        ///< possible extra movement choices from this position
-	uint64_t block;            ///< 64 bit blocks (st->airport.flags), should be enough for the most complex airports
-	uint8_t position;           ///< the position that an airplane is at
-	uint8_t next_position;      ///< next position from this position
-	uint8_t heading;            ///< heading (current orders), guiding an airplane to its target on an airport
-};
 
 const AirportFTAClass *GetAirport(const uint8_t airport_type);
 uint8_t GetVehiclePosOnBuild(TileIndex hangar_tile);

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -852,7 +852,7 @@ void Vehicle::PreDestructor()
 		Aircraft *a = Aircraft::From(this);
 		Station *st = GetTargetAirportIfValid(a);
 		if (st != nullptr) {
-			const AirportFTA *layout = st->airport.GetFTA()->layout;
+			const auto &layout = st->airport.GetFTA()->layout;
 			CLRBITS(st->airport.flags, layout[a->previous_pos].block | layout[a->pos].block);
 		}
 	}


### PR DESCRIPTION
## Motivation / Problem

The airport FTA using `MallocT` and `free` for its memory management.

An airport's FTA is an array of states ('positions') an aircraft can be in with the outgoing options/alternatives. When there are multiple options/alternatives a linked list is constructed.


## Description

* Move `AirportFTA` because the type needs to be known for `std::vector`.
* Add constructor to `AirportFTA` so `emplace_back` / `std::make_unique` can be used.
* Replace the `MallocT`-ed array with `std::vector`, and replace the `MallocT`-ed linked list of options/alternatives with `std::unique_ptr`.
* Remove the destructor from `AirportFTAClass` as `std::vector` and `std::unique_ptr` do  the memory management now.


## Limitations

No significant ones; it will use a bit more memory due to `std::vector` also storing the length and capacity.

Well, except for scoping... a lot more things could be changed, but those are not in scope for this PR. For example replacing some raw points with `std::span`.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
