### PR TITLE
Change: Implement GRFv9

### DIFF
--- a/docs/GRFv9_changes.md
+++ b/docs/GRFv9_changes.md
@@ -1,0 +1,71 @@
+## GRFv9 changes from GRFv8.
+
+* ALL existing Extended Byte fields are now Word fields.
+* Action 00:
+  * `num-info` is now a Word.
+  * Feature 00: Trains
+    * Property 05 `tracktype` is now a Word.
+    * Property 15 `cargotype` is now a Word.
+    * Property 1D `refitmask` is **removed**.
+    * Property 2C/2D `cttinclude`/`cttexclude` are now a Word followed by a list of Words.
+  * Feature 01: Road vehicles
+    * Property 05 `roadtramtype` is now a Word.
+    * Property 10 `cargotype` is now a Word.
+    * Property 12 `sfx` is now a Word.
+    * Property 16 `refitmask` is **removed**.
+    * Property 24/25 `cttinclude`/`cttexclude` are now a Word followed by a list of Words.
+  * Feature 02: Ships
+    * Property 0C `cargotype` is now a Word.
+    * Property 10 `sfx` is now a Word.
+    * Property 11 `refitmask` is **removed**.
+    * Property 1E/1F `cttinclude`/`cttexclude` are now a Word followed by a list of Words.
+  * Feature 03: Aircraft
+    * Property 12 `sfx` is now a Word.
+    * Property 13 `refitmask` is **removed**.
+    * Property 1D/1E `cttinclude`/`cttexclude` are now a Word followed by a list of Words.
+  * Feature 07: Houses
+    * Properties 0D, 0E, 0F and 1E are **removed**.
+    * Property 20 `watched cargoes` is now a Word followed by a list of Words.
+    * Property 23 `accepted cargoes` is now a Word followed by a list of (Word, Byte).
+  * Feature 09: Industry tiles
+    * Properties 0A, 0B and 0C are **removed**.
+    * Property 13 `cargo acceptance` is now a Word followed by a list of (Word, Byte).
+  * Feature 0A: Industries
+    * Properties 10, 11, 12, 13 are **removed**.
+    * Property 15 `sfx` is now a Word followed by a list of Words.
+    * Properties 1C, 1D and 1E are **removed**.
+    * Properties 25/16 `producedcargoes`/`acceptedcargoes` are now a Word followed by a list of Words.
+    * Property 27 `productionrates` is now a Word follow by a list of Bytes.
+  * Feature 10: Railtypes
+    * Properties 0E, 0F, 18, 19 and 1D are now a Word followed by a list of DWords.
+  * Feature 12/13: Roadtypes and Tramtypes
+    * Properties 0F, 18, 19 and 1D are now a Word followed by a list of DWords.
+* Action 02:
+  * `set-id` is now a Word. Maximum set-id is now 7FFF instead of FF.
+  * `subroutine` is now a Word.
+  * `parameter` is now a **DWord**.
+  * VariationalAction2 `nvar` is now a Word.
+  * RandomAction2 `nrand` is now a Word.
+* Action 03:
+  * `n-id` is now a Word.
+  * `ids...` are each now a Word.
+  * `num-cid` is now a Word.
+  * `cargo-type` is now a Word.
+* Action 04:
+  * `num-ent` is now a Word.
+  * `offset` is now always a Word, instead of varying depending on feature/flags.
+* Action 07/09:
+  * `num-sprites` is now a Word. If bit 15 is set, then this is a label instead of the number of sprites.
+* Action 0A:
+  * `num-sets` is now a Word.
+  * `num-sprites` is now a Word.
+* Action 0E:
+  * `num` is now a Word.
+* Action 10:
+  * `label` is now a Word. Labels MUST have bit 15 set. This means there is no longer any conflict with labels overlapping numbers.
+* Action 12:
+  * `num-def` is now a Word.
+  * `num-char` is now a Word.
+  * `base-char` is now a **DWord**. This allows custom glyphs between 0x10000 and 0x1FFFFD to be defined.
+* Action 13:
+  * `num-ent` is now a Word.

--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -113,7 +113,7 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 	 * @param available will return false if ever the variable asked for does not exist
 	 * @return the value stored in the corresponding variable
 	 */
-	virtual uint32_t GetNewGRFVariable(const struct ResolverObject &object, uint8_t variable, uint8_t parameter, bool &available) const = 0;
+	virtual uint32_t GetNewGRFVariable(const struct ResolverObject &object, uint8_t variable, uint32_t parameter, bool &available) const = 0;
 
 	/**
 	 * Update the coordinated of the sign (as shown in the viewport).

--- a/src/industrytype.h
+++ b/src/industrytype.h
@@ -130,7 +130,7 @@ struct IndustrySpec {
 	uint16_t callback_mask;                       ///< Bitmask of industry callbacks that have to be called
 	bool enabled;                               ///< entity still available (by default true).newgrf can disable it, though
 	GRFFileProps grf_prop;                      ///< properties related to the grf file
-	std::vector<uint8_t> random_sounds; ///< Random sounds;
+	std::vector<uint16_t> random_sounds; ///< Random sounds;
 
 	std::array<std::variant<CargoLabel, MixedCargoType>, INDUSTRY_ORIGINAL_NUM_OUTPUTS> produced_cargo_label; ///< Cargo labels of produced cargo for default industries.
 	std::array<std::variant<CargoLabel, MixedCargoType>, INDUSTRY_ORIGINAL_NUM_INPUTS> accepts_cargo_label; ///< Cargo labels of accepted cargo for default industries.

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1014,6 +1014,7 @@ enum ChangeInfoResult {
 	CIR_DISABLED,   ///< GRF was disabled due to error
 	CIR_UNHANDLED,  ///< Variable was parsed but unread
 	CIR_UNKNOWN,    ///< Variable is unknown
+	CIR_REMOVED, ///< Property did exist but has been removed.
 	CIR_INVALID_ID, ///< Attempt to modify an invalid ID
 };
 
@@ -1247,6 +1248,7 @@ static ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, B
 				break;
 
 			case 0x1D: { // Refit cargo
+				if (_cur.grf_version >= 9) return CIR_REMOVED;
 				uint32_t mask = buf.ReadDWord();
 				_gted[e->index].UpdateRefittability(mask != 0);
 				ei->refit_mask = TranslateRefitMask(mask);
@@ -1468,6 +1470,7 @@ static ChangeInfoResult RoadVehicleChangeInfo(uint first, uint last, int prop, B
 				break;
 
 			case 0x16: { // Cargoes available for refitting
+				if (_cur.grf_version >= 9) return CIR_REMOVED;
 				uint32_t mask = buf.ReadDWord();
 				_gted[e->index].UpdateRefittability(mask != 0);
 				ei->refit_mask = TranslateRefitMask(mask);
@@ -1656,6 +1659,7 @@ static ChangeInfoResult ShipVehicleChangeInfo(uint first, uint last, int prop, B
 				break;
 
 			case 0x11: { // Cargoes available for refitting
+				if (_cur.grf_version >= 9) return CIR_REMOVED;
 				uint32_t mask = buf.ReadDWord();
 				_gted[e->index].UpdateRefittability(mask != 0);
 				ei->refit_mask = TranslateRefitMask(mask);
@@ -1847,6 +1851,7 @@ static ChangeInfoResult AircraftVehicleChangeInfo(uint first, uint last, int pro
 				break;
 
 			case 0x13: { // Cargoes available for refitting
+				if (_cur.grf_version >= 9) return CIR_REMOVED;
 				uint32_t mask = buf.ReadDWord();
 				_gted[e->index].UpdateRefittability(mask != 0);
 				ei->refit_mask = TranslateRefitMask(mask);
@@ -2378,12 +2383,15 @@ static ChangeInfoResult IgnoreTownHouseProperty(int prop, ByteReader &buf)
 	ChangeInfoResult ret = CIR_SUCCESS;
 
 	switch (prop) {
-		case 0x09:
-		case 0x0B:
-		case 0x0C:
 		case 0x0D:
 		case 0x0E:
 		case 0x0F:
+			if (_cur.grf_version >= 9) return CIR_REMOVED;
+			[[fallthrough]];
+
+		case 0x09:
+		case 0x0B:
+		case 0x0C:
 		case 0x11:
 		case 0x14:
 		case 0x15:
@@ -2408,6 +2416,7 @@ static ChangeInfoResult IgnoreTownHouseProperty(int prop, ByteReader &buf)
 			break;
 
 		case 0x1E:
+			if (_cur.grf_version >= 9) return CIR_REMOVED;
 			buf.ReadDWord();
 			break;
 
@@ -2536,10 +2545,12 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 
 			case 0x0D: // Passenger acceptance
 			case 0x0E: // Mail acceptance
+				if (_cur.grf_version >= 9) return CIR_REMOVED;
 				housespec->cargo_acceptance[prop - 0x0D] = buf.ReadByte();
 				break;
 
 			case 0x0F: { // Goods/candy, food/fizzy drinks acceptance
+				if (_cur.grf_version >= 9) return CIR_REMOVED;
 				int8_t goods = buf.ReadByte();
 
 				/* If value of goods is negative, it means in fact food or, if in toyland, fizzy_drink acceptance.
@@ -2624,6 +2635,7 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 				break;
 
 			case 0x1E: { // Accepted cargo types
+				if (_cur.grf_version >= 9) return CIR_REMOVED;
 				uint32_t cargotypes = buf.ReadDWord();
 
 				/* Check if the cargo types should not be changed */
@@ -3305,6 +3317,9 @@ static ChangeInfoResult IgnoreIndustryTileProperty(int prop, ByteReader &buf)
 		case 0x0A:
 		case 0x0B:
 		case 0x0C:
+			if (_cur.grf_version >= 9) return CIR_REMOVED;
+			[[fallthrough]];
+
 		case 0x0F:
 			buf.ReadWord();
 			break;
@@ -3400,6 +3415,8 @@ static ChangeInfoResult IndustrytilesChangeInfo(uint first, uint last, int prop,
 			case 0x0A: // Tile acceptance
 			case 0x0B:
 			case 0x0C: {
+				if (_cur.grf_version >= 9) return CIR_REMOVED;
+
 				uint16_t acctp = buf.ReadWord();
 				tsp->accepts_cargo[prop - 0x0A] = GetCargoTranslation(GB(acctp, 0, 8), _cur.grffile);
 				tsp->acceptance[prop - 0x0A] = Clamp(GB(acctp, 8, 8), 0, 16);
@@ -3473,10 +3490,13 @@ static ChangeInfoResult IgnoreIndustryProperty(int prop, ByteReader &buf)
 	ChangeInfoResult ret = CIR_SUCCESS;
 
 	switch (prop) {
+		case 0x12:
+			if (_cur.grf_version >= 9) return CIR_REMOVED;
+			[[fallthrough]];
+
 		case 0x09:
 		case 0x0B:
 		case 0x0F:
-		case 0x12:
 		case 0x13:
 		case 0x14:
 		case 0x17:
@@ -3487,10 +3507,13 @@ static ChangeInfoResult IgnoreIndustryProperty(int prop, ByteReader &buf)
 			buf.ReadByte();
 			break;
 
+		case 0x10: // INDUSTRY_ORIGINAL_NUM_OUTPUTS bytes
+			if (_cur.grf_version >= 9) return CIR_REMOVED;
+			[[fallthrough]];
+
 		case 0x0C:
 		case 0x0D:
 		case 0x0E:
-		case 0x10: // INDUSTRY_ORIGINAL_NUM_OUTPUTS bytes
 		case 0x1B:
 		case 0x1F:
 		case 0x24:
@@ -3498,10 +3521,13 @@ static ChangeInfoResult IgnoreIndustryProperty(int prop, ByteReader &buf)
 			break;
 
 		case 0x11: // INDUSTRY_ORIGINAL_NUM_INPUTS bytes + 1
-		case 0x1A:
 		case 0x1C:
 		case 0x1D:
 		case 0x1E:
+			if (_cur.grf_version >= 9) return CIR_REMOVED;
+			[[fallthrough]];
+
+		case 0x1A:
 		case 0x20:
 		case 0x23:
 			buf.ReadDWord();
@@ -3788,6 +3814,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 				break;
 
 			case 0x10: // Production cargo types
+				if (_cur.grf_version >= 9) return CIR_REMOVED;
 				for (uint8_t j = 0; j < INDUSTRY_ORIGINAL_NUM_OUTPUTS; j++) {
 					indsp->produced_cargo[j] = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
 					indsp->produced_cargo_label[j] = CT_INVALID;
@@ -3795,6 +3822,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 				break;
 
 			case 0x11: // Acceptance cargo types
+				if (_cur.grf_version >= 9) return CIR_REMOVED;
 				for (uint8_t j = 0; j < INDUSTRY_ORIGINAL_NUM_INPUTS; j++) {
 					indsp->accepts_cargo[j] = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
 					indsp->accepts_cargo_label[j] = CT_INVALID;
@@ -3804,6 +3832,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 
 			case 0x12: // Production multipliers
 			case 0x13:
+				if (_cur.grf_version >= 9) return CIR_REMOVED;
 				indsp->production_rate[prop - 0x12] = buf.ReadByte();
 				break;
 
@@ -3851,11 +3880,12 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 			case 0x1C: // Input cargo multipliers for the three input cargo types
 			case 0x1D:
 			case 0x1E: {
-					uint32_t multiples = buf.ReadDWord();
-					indsp->input_cargo_multiplier[prop - 0x1C][0] = GB(multiples, 0, 16);
-					indsp->input_cargo_multiplier[prop - 0x1C][1] = GB(multiples, 16, 16);
-					break;
-				}
+				if (_cur.grf_version >= 9) return CIR_REMOVED;
+				uint32_t multiples = buf.ReadDWord();
+				indsp->input_cargo_multiplier[prop - 0x1C][0] = GB(multiples, 0, 16);
+				indsp->input_cargo_multiplier[prop - 0x1C][1] = GB(multiples, 16, 16);
+				break;
+			}
 
 			case 0x1F: // Industry name
 				AddStringForMapping(GRFStringID{buf.ReadWord()}, &indsp->name);
@@ -4967,6 +4997,10 @@ static bool HandleChangeInfoResult(const char *caller, ChangeInfoResult cir, uin
 		case CIR_UNHANDLED:
 			GrfMsg(1, "{}: Ignoring property 0x{:02X} of feature 0x{:02X} (not implemented)", caller, property, feature);
 			return false;
+
+		case CIR_REMOVED:
+			GrfMsg(0, "{}: Ignoring property 0x{:02X} of feature 0x{:02X} (removed)", caller, property, feature);
+			return true;
 
 		case CIR_UNKNOWN:
 			GrfMsg(0, "{}: Unknown property 0x{:02X} of feature 0x{:02X}, disabling", caller, property, feature);

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -97,11 +97,11 @@ enum GrfSpecFeature {
 static const uint32_t INVALID_GRFID = 0xFFFFFFFF;
 
 struct GRFLabel {
-	uint8_t label;
+	uint16_t label;
 	uint32_t nfo_line;
 	size_t pos;
 
-	GRFLabel(uint8_t label, uint32_t nfo_line, size_t pos) : label(label), nfo_line(nfo_line), pos(pos) {}
+	GRFLabel(uint16_t label, uint32_t nfo_line, size_t pos) : label(label), nfo_line(nfo_line), pos(pos) {}
 };
 
 /** Dynamic data of a loaded NewGRF */

--- a/src/newgrf_cargo.cpp
+++ b/src/newgrf_cargo.cpp
@@ -77,7 +77,7 @@ uint16_t GetCargoCallback(CallbackID callback, uint32_t param1, uint32_t param2,
  *                For GRF version >= 7 \a cargo is always a translated cargo bit.
  * @return CargoID or INVALID_CARGO if the cargo is not available.
  */
-CargoID GetCargoTranslation(uint8_t cargo, const GRFFile *grffile, bool usebit)
+CargoID GetCargoTranslation(uint16_t cargo, const GRFFile *grffile, bool usebit)
 {
 	/* We can't use GetCargoTranslationTable here as the usebit flag changes behviour. */
 	/* Pre-version 7 uses the bitnum lookup from (standard in v8) instead of climate dependent in some places.. */

--- a/src/newgrf_cargo.h
+++ b/src/newgrf_cargo.h
@@ -31,7 +31,7 @@ struct GRFFile;
 
 SpriteID GetCustomCargoSprite(const CargoSpec *cs);
 uint16_t GetCargoCallback(CallbackID callback, uint32_t param1, uint32_t param2, const CargoSpec *cs);
-CargoID GetCargoTranslation(uint8_t cargo, const GRFFile *grffile, bool usebit = false);
+CargoID GetCargoTranslation(uint16_t cargo, const GRFFile *grffile, bool usebit = false);
 
 std::span<const CargoLabel> GetClimateDependentCargoTranslationTable();
 std::span<const CargoLabel> GetClimateIndependentCargoTranslationTable();

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -268,7 +268,7 @@ const SpriteGroup *RandomizedSpriteGroup::Resolve(ResolverObject &object) const
 	}
 
 	uint32_t mask = ((uint)this->groups.size() - 1) << this->lowest_randbit;
-	uint8_t index = (scope->GetRandomBits() & mask) >> this->lowest_randbit;
+	uint16_t index = (scope->GetRandomBits() & mask) >> this->lowest_randbit;
 
 	return SpriteGroup::Resolve(this->groups[index], object, false);
 }

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -148,8 +148,8 @@ struct DeterministicSpriteGroupAdjust {
 	DeterministicSpriteGroupAdjustOperation operation;
 	DeterministicSpriteGroupAdjustType type;
 	uint8_t variable;
-	uint8_t parameter; ///< Used for variables between 0x60 and 0x7F inclusive.
 	uint8_t shift_num;
+	uint32_t parameter; ///< Used for variables between 0x60 and 0x7F inclusive.
 	uint32_t and_mask;
 	uint32_t add_val;
 	uint32_t divmod_val;

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -404,7 +404,7 @@ TownScopeResolver *StationResolverObject::GetTown()
 	return this->st->GetNewGRFVariable(this->ro, variable, parameter, available);
 }
 
-uint32_t Station::GetNewGRFVariable(const ResolverObject &object, uint8_t variable, uint8_t parameter, bool &available) const
+uint32_t Station::GetNewGRFVariable(const ResolverObject &object, uint8_t variable, uint32_t parameter, bool &available) const
 {
 	switch (variable) {
 		case 0x48: { // Accepted cargo types
@@ -470,7 +470,7 @@ uint32_t Station::GetNewGRFVariable(const ResolverObject &object, uint8_t variab
 	return UINT_MAX;
 }
 
-uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, uint8_t variable, [[maybe_unused]] uint8_t parameter, bool &available) const
+uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, uint8_t variable, [[maybe_unused]] uint32_t parameter, bool &available) const
 {
 	switch (variable) {
 		case 0x48: return 0; // Accepted cargo types

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -573,7 +573,7 @@ public:
 		return IsAirportTile(tile) && GetStationIndex(tile) == this->index;
 	}
 
-	uint32_t GetNewGRFVariable(const ResolverObject &object, uint8_t variable, uint8_t parameter, bool &available) const override;
+	uint32_t GetNewGRFVariable(const ResolverObject &object, uint8_t variable, uint32_t parameter, bool &available) const override;
 
 	void GetTileArea(TileArea *ta, StationType type) const override;
 };

--- a/src/table/build_industry.h
+++ b/src/table/build_industry.h
@@ -1032,16 +1032,16 @@ static const std::vector<IndustryTileLayout> _tile_table_sugar_mine {
 #undef MK
 
 /** Array with saw sound, for sawmill */
-static const std::initializer_list<uint8_t> _sawmill_sounds = { SND_28_SAWMILL };
+static const std::initializer_list<uint16_t> _sawmill_sounds = { SND_28_SAWMILL };
 
 /** Array with whistle sound, for factory */
-static const std::initializer_list<uint8_t> _factory_sounds = { SND_03_FACTORY };
+static const std::initializer_list<uint16_t> _factory_sounds = { SND_03_FACTORY };
 
 /** Array with 3 animal sounds, for farms */
-static const std::initializer_list<uint8_t> _farm_sounds = { SND_24_FARM_1, SND_25_FARM_2, SND_26_FARM_3 };
+static const std::initializer_list<uint16_t> _farm_sounds = { SND_24_FARM_1, SND_25_FARM_2, SND_26_FARM_3 };
 
 /** Array with... hem... a sound of toyland */
-static const std::initializer_list<uint8_t> _plastic_mine_sounds = { SND_33_PLASTIC_MINE };
+static const std::initializer_list<uint16_t> _plastic_mine_sounds = { SND_33_PLASTIC_MINE };
 
 enum IndustryTypes {
 	IT_COAL_MINE           =   0,

--- a/src/waypoint_base.h
+++ b/src/waypoint_base.h
@@ -41,7 +41,7 @@ struct Waypoint final : SpecializedStation<Waypoint, true> {
 		return IsRailWaypointTile(tile) && GetStationIndex(tile) == this->index;
 	}
 
-	uint32_t GetNewGRFVariable(const struct ResolverObject &object, uint8_t variable, uint8_t parameter, bool &available) const override;
+	uint32_t GetNewGRFVariable(const struct ResolverObject &object, uint8_t variable, uint32_t parameter, bool &available) const override;
 
 	void GetTileArea(TileArea *ta, StationType type) const override;
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

We keep listing changes to the GRF spec and saying "that can come in GRFv9".

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Well, here is an attempt to implement some changes, and call it GRFv9.

This is of course just a draft and is subject to improvements (or being scrapped...)

### GRFv9 changes from GRFv8

`Byte` means 8-bit value.
`Extended Byte` means an 8-bit value, or if the 8-bit value is 0xFF, an extra 16-bit value.
`Word` means a 16-bit value.
`DWord` means a 32-bit value.

* ALL existing Extended Byte fields are now Word fields.
* Action 00:
  * `num-info` is now a Word.
  * Feature 00: Trains
    * Property 05 `tracktype` is now a Word.
    * Property 15 `cargotype` is now a Word.
    * Property 1D `refitmask` is **removed**.
    * Property 2C/2D `cttinclude`/`cttexclude` are now a Word followed by a list of Words.
  * Feature 01: Road vehicles
    * Property 05 `roadtramtype` is now a Word.
    * Property 10 `cargotype` is now a Word.
    * Property 12 `sfx` is now a Word.
    * Property 16 `refitmask` is **removed**.
    * Property 24/25 `cttinclude`/`cttexclude` are now a Word followed by a list of Words.
  * Feature 02: Ships
    * Property 0C `cargotype` is now a Word.
    * Property 10 `sfx` is now a Word.
    * Property 11 `refitmask` is **removed**.
    * Property 1E/1F `cttinclude`/`cttexclude` are now a Word followed by a list of Words.
  * Feature 03: Aircraft
    * Property 12 `sfx` is now a Word.
    * Property 13 `refitmask` is **removed**.
    * Property 1D/1E `cttinclude`/`cttexclude` are now a Word followed by a list of Words.
  * Feature 07: Houses
    * Properties 0D, 0E, 0F and 1E are **removed**.
    * Property 20 `watched cargoes` is now a Word followed by a list of Words.
    * Property 23 `accepted cargoes` is now a Word followed by a list of (Word, Byte).
  * Feature 09: Industry tiles
    * Properties 0A, 0B and 0C are **removed**.
    * Property 13 `cargo acceptance` is now a Word followed by a list of (Word, Byte).
  * Feature 0A: Industries
    * Properties 10, 11, 12, 13 are **removed**.
    * Property 15 `sfx` is now a Word followed by a list of Words.
    * Properties 1C, 1D and 1E are **removed**.
    * Properties 25/16 `producedcargoes`/`acceptedcargoes` are now a Word followed by a list of Words.
    * Property 27 `productionrates` is now a Word follow by a list of Bytes.
  * Feature 10: Railtypes
    * Properties 0E, 0F, 18, 19 and 1D are now a Word followed by a list of DWords.
  * Feature 12/13: Roadtypes and Tramtypes
    * Properties 0F, 18, 19 and 1D are now a Word followed by a list of DWords.
* Action 02:
  * `set-id` is now a Word. Maximum set-id is now 7FFF instead of FF.
  * `subroutine` is now a Word.
  * `parameter` is now a **DWord**.
  * VariationalAction2 `nvar` is now a Word.
  * RandomAction2 `nrand` is now a Word.
* Action 03:
  * `n-id` is now a Word.
  * `ids...` are each now a Word.
  * `num-cid` is now a Word.
  * `cargo-type` is now a Word.
* Action 04:
  * `num-ent` is now a Word.
  * `offset` is now always a Word, instead of varying depending on feature/flags.
* Action 07/09:
  * `num-sprites` is now a Word. If bit 15 is set, then this is a label instead of the number of sprites.
* Action 0A:
  * `num-sets` is now a Word.
  * `num-sprites` is now a Word.
* Action 0E:
  * `num` is now a Word.
* Action 10:
  * `label` is now a Word. Labels MUST have bit 15 set. This means there is no longer any conflict with labels overlapping numbers.
* Action 12:
  * `num-def` is now a Word.
  * `num-char` is now a Word.
  * `base-char` is now a **DWord**. This allows custom glyphs between 0x10000 and 0x1FFFFD to be defined.
* Action 13:
  * `num-ent` is now a Word.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
