### PR TITLE
Codechange: Make GroupFlags an enum class.

### DIFF
--- a/src/autoreplace.cpp
+++ b/src/autoreplace.cpp
@@ -65,7 +65,7 @@ void RemoveAllEngineReplacement(EngineRenewList *erl)
 EngineID EngineReplacement(EngineRenewList erl, EngineID engine, GroupID group, bool *replace_when_old)
 {
 	const EngineRenew *er = GetEngineReplacement(erl, engine, group);
-	if (er == nullptr && (group == DEFAULT_GROUP || (Group::IsValidID(group) && !HasBit(Group::Get(group)->flags, GroupFlags::GF_REPLACE_PROTECTION)))) {
+	if (er == nullptr && (group == DEFAULT_GROUP || (Group::IsValidID(group) && !HasFlag(Group::Get(group)->flags, GroupFlags::ReplaceProtection)))) {
 		/* We didn't find anything useful in the vehicle's own group so we will try ALL_GROUP */
 		er = GetEngineReplacement(erl, engine, ALL_GROUP);
 	}

--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -754,7 +754,7 @@ CommandCost CmdAutoreplaceVehicle(DoCommandFlag flags, VehicleID veh_id)
 	bool wagon_removal = c->settings.renew_keep_length;
 
 	const Group *g = Group::GetIfValid(v->group_id);
-	if (g != nullptr) wagon_removal = HasBit(g->flags, GroupFlags::GF_REPLACE_WAGON_REMOVAL);
+	if (g != nullptr) wagon_removal = HasFlag(g->flags, GroupFlags::ReplaceWagonRemoval);
 
 	/* Test whether any replacement is set, before issuing a whole lot of commands that would end in nothing changed */
 	Vehicle *w = v;

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -405,7 +405,7 @@ public:
 				bool remove_wagon;
 				const Group *g = Group::GetIfValid(this->sel_group);
 				if (g != nullptr) {
-					remove_wagon = HasBit(g->flags, GroupFlags::GF_REPLACE_WAGON_REMOVAL);
+					remove_wagon = HasFlag(g->flags, GroupFlags::ReplaceWagonRemoval);
 					SetDParam(0, STR_GROUP_NAME);
 					SetDParam(1, sel_group);
 				} else {
@@ -554,7 +554,7 @@ public:
 			case WID_RV_TRAIN_WAGONREMOVE_TOGGLE: {
 				const Group *g = Group::GetIfValid(this->sel_group);
 				if (g != nullptr) {
-					Command<CMD_SET_GROUP_FLAG>::Post(this->sel_group, GroupFlags::GF_REPLACE_WAGON_REMOVAL, !HasBit(g->flags, GroupFlags::GF_REPLACE_WAGON_REMOVAL), _ctrl_pressed);
+					Command<CMD_SET_GROUP_FLAG>::Post(this->sel_group, GroupFlags::ReplaceWagonRemoval, !HasFlag(g->flags, GroupFlags::ReplaceWagonRemoval), _ctrl_pressed);
 				} else {
 					// toggle renew_keep_length
 					Command<CMD_CHANGE_COMPANY_SETTING>::Post("company.renew_keep_length", Company::Get(_local_company)->settings.renew_keep_length ? 0 : 1);

--- a/src/group.h
+++ b/src/group.h
@@ -62,11 +62,12 @@ struct GroupStatistics {
 	static void UpdateAutoreplace(CompanyID company);
 };
 
-enum GroupFlags : uint8_t {
-	GF_REPLACE_PROTECTION,    ///< If set to true, the global autoreplace has no effect on the group
-	GF_REPLACE_WAGON_REMOVAL, ///< If set, autoreplace will perform wagon removal on vehicles in this group.
-	GF_END,
+enum class GroupFlags : uint8_t {
+	None = 0,
+	ReplaceProtection = 1U << 0, ///< If set, the global autoreplace has no effect on the group
+	ReplaceWagonRemoval = 1U << 1, ///< If set, autoreplace will perform wagon removal on vehicles in this group.
 };
+DECLARE_ENUM_AS_BIT_SET(GroupFlags)
 
 /** Group data. */
 struct Group : GroupPool::PoolItem<&_group_pool> {
@@ -74,7 +75,7 @@ struct Group : GroupPool::PoolItem<&_group_pool> {
 	Owner owner;                ///< Group Owner
 	VehicleType vehicle_type;   ///< Vehicle type of the group
 
-	uint8_t flags;                ///< Group flags
+	GroupFlags flags = GroupFlags::None; ///< Group flags
 	Livery livery;              ///< Custom colour scheme for vehicles in this group
 	GroupStatistics statistics; ///< NOSAVE: Statistics and caches on the vehicles in the group.
 

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -355,7 +355,7 @@ std::tuple<CommandCost, GroupID> CmdCreateGroup(DoCommandFlag flags, VehicleType
 		if (pg == nullptr) {
 			g->livery.colour1 = c->livery[LS_DEFAULT].colour1;
 			g->livery.colour2 = c->livery[LS_DEFAULT].colour2;
-			if (c->settings.renew_keep_length) SetBit(g->flags, GroupFlags::GF_REPLACE_WAGON_REMOVAL);
+			if (c->settings.renew_keep_length) g->flags |= GroupFlags::ReplaceWagonRemoval;
 		} else {
 			g->parent = pg->index;
 			g->livery.colour1 = pg->livery.colour1;
@@ -698,9 +698,9 @@ CommandCost CmdSetGroupLivery(DoCommandFlag flags, GroupID group_id, bool primar
 static void SetGroupFlag(Group *g, GroupFlags flag, bool set, bool children)
 {
 	if (set) {
-		SetBit(g->flags, flag);
+		g->flags |= flag;
 	} else {
-		ClrBit(g->flags, flag);
+		g->flags &= ~flag;
 	}
 
 	if (!children) return;
@@ -724,7 +724,7 @@ CommandCost CmdSetGroupFlag(DoCommandFlag flags, GroupID group_id, GroupFlags fl
 	Group *g = Group::GetIfValid(group_id);
 	if (g == nullptr || g->owner != _current_company) return CMD_ERROR;
 
-	if (flag >= GroupFlags::GF_END) return CMD_ERROR;
+	if (flag != GroupFlags::ReplaceProtection && flag != GroupFlags::ReplaceWagonRemoval) return CMD_ERROR;
 
 	if (flags & DC_EXEC) {
 		SetGroupFlag(g, flag, value, recursive);

--- a/src/group_cmd.h
+++ b/src/group_cmd.h
@@ -17,7 +17,7 @@
 #include "vehiclelist_cmd.h"
 
 enum Colours : uint8_t;
-enum GroupFlags : uint8_t;
+enum class GroupFlags : uint8_t;
 
 /** Action for \c CmdAlterGroup. */
 enum class AlterGroupMode : uint8_t {

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -584,7 +584,7 @@ public:
 
 		/* If not a default group and the group has replace protection, show an enabled replace sprite. */
 		uint16_t protect_sprite = SPR_GROUP_REPLACE_OFF_TRAIN;
-		if (!IsDefaultGroupID(this->vli.index) && !IsAllGroupID(this->vli.index) && HasBit(Group::Get(this->vli.index)->flags, GroupFlags::GF_REPLACE_PROTECTION)) protect_sprite = SPR_GROUP_REPLACE_ON_TRAIN;
+		if (!IsDefaultGroupID(this->vli.index) && !IsAllGroupID(this->vli.index) && HasFlag(Group::Get(this->vli.index)->flags, GroupFlags::ReplaceProtection)) protect_sprite = SPR_GROUP_REPLACE_ON_TRAIN;
 		this->GetWidget<NWidgetCore>(WID_GL_REPLACE_PROTECTION)->SetSprite(protect_sprite + this->vli.vtype);
 
 		/* Set text of "group by" dropdown widget. */
@@ -650,7 +650,7 @@ public:
 
 					assert(g->owner == this->owner);
 
-					DrawGroupInfo(y1, r.left, r.right, g->index, it->level_mask, it->indent, HasBit(g->flags, GroupFlags::GF_REPLACE_PROTECTION), g->folded || (std::next(it) != std::end(this->groups) && std::next(it)->indent > it->indent));
+					DrawGroupInfo(y1, r.left, r.right, g->index, it->level_mask, it->indent, HasFlag(g->flags, GroupFlags::ReplaceProtection), g->folded || (std::next(it) != std::end(this->groups) && std::next(it)->indent > it->indent));
 
 					y1 += this->tiny_step_height;
 				}
@@ -868,7 +868,7 @@ public:
 			case WID_GL_REPLACE_PROTECTION: {
 				const Group *g = Group::GetIfValid(this->vli.index);
 				if (g != nullptr) {
-					Command<CMD_SET_GROUP_FLAG>::Post(this->vli.index, GroupFlags::GF_REPLACE_PROTECTION, !HasBit(g->flags, GroupFlags::GF_REPLACE_PROTECTION), _ctrl_pressed);
+					Command<CMD_SET_GROUP_FLAG>::Post(this->vli.index, GroupFlags::ReplaceProtection, !HasFlag(g->flags, GroupFlags::ReplaceProtection), _ctrl_pressed);
 				}
 				break;
 			}

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3201,12 +3201,11 @@ bool AfterLoadGame()
 			if (c->settings.renew_keep_length) SetBit(wagon_removal, c->index);
 		}
 		for (Group *g : Group::Iterate()) {
-			if (g->flags != 0) {
+			if (to_underlying(g->flags) != 0) {
 				/* Convert old replace_protection value to flag. */
-				g->flags = 0;
-				SetBit(g->flags, GroupFlags::GF_REPLACE_PROTECTION);
+				g->flags = GroupFlags::ReplaceProtection;
 			}
-			if (HasBit(wagon_removal, g->owner)) SetBit(g->flags, GroupFlags::GF_REPLACE_WAGON_REMOVAL);
+			if (HasBit(wagon_removal, g->owner)) g->flags |= GroupFlags::ReplaceWagonRemoval;
 		}
 	}
 

--- a/src/script/api/script_group.cpp
+++ b/src/script/api/script_group.cpp
@@ -98,14 +98,14 @@
 	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidGroup(group_id));
 
-	return ScriptObject::Command<CMD_SET_GROUP_FLAG>::Do(group_id, GroupFlags::GF_REPLACE_PROTECTION, enable, false);
+	return ScriptObject::Command<CMD_SET_GROUP_FLAG>::Do(group_id, GroupFlags::ReplaceProtection, enable, false);
 }
 
 /* static */ bool ScriptGroup::GetAutoReplaceProtection(GroupID group_id)
 {
 	if (!IsValidGroup(group_id)) return false;
 
-	return HasBit(::Group::Get(group_id)->flags, GroupFlags::GF_REPLACE_PROTECTION);
+	return HasFlag(::Group::Get(group_id)->flags, GroupFlags::ReplaceProtection);
 }
 
 /* static */ SQInteger ScriptGroup::GetNumEngines(GroupID group_id, EngineID engine_id)


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

GF_END is 'reserved' in some Windows APIs.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead of working around it, make GroupFlags an enum class.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
