### PR TITLE
Codechange: use unique_ptr over CallocT and avoid copying table

### DIFF
--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -93,7 +93,7 @@ static const uint TILE_UPDATE_FREQUENCY = 1 << TILE_UPDATE_FREQUENCY_LOG;  ///< 
  * @ingroup SnowLineGroup
  * @see GetSnowLine() GameCreationSettings
  */
-static SnowLine *_snow_line = nullptr;
+static std::unique_ptr<SnowLine> _snow_line;
 
 /**
  * Map 2D viewport or smallmap coordinate to 3D world or tile coordinate.
@@ -584,21 +584,12 @@ bool IsSnowLineSet()
 
 /**
  * Set a variable snow line, as loaded from a newgrf file.
- * @param table the 12 * 32 byte table containing the snowline for each day
+ * @param snow_line The new snow line configuration.
  * @ingroup SnowLineGroup
  */
-void SetSnowLine(uint8_t table[SNOW_LINE_MONTHS][SNOW_LINE_DAYS])
+void SetSnowLine(std::unique_ptr<SnowLine> &&snow_line)
 {
-	_snow_line = CallocT<SnowLine>(1);
-	_snow_line->lowest_value = 0xFF;
-	memcpy(_snow_line->table, table, sizeof(_snow_line->table));
-
-	for (uint i = 0; i < SNOW_LINE_MONTHS; i++) {
-		for (uint j = 0; j < SNOW_LINE_DAYS; j++) {
-			_snow_line->highest_value = std::max(_snow_line->highest_value, table[i][j]);
-			_snow_line->lowest_value = std::min(_snow_line->lowest_value, table[i][j]);
-		}
-	}
+	_snow_line = std::move(snow_line);
 }
 
 /**
@@ -640,7 +631,6 @@ uint8_t LowestSnowLine()
  */
 void ClearSnowLine()
 {
-	free(_snow_line);
 	_snow_line = nullptr;
 }
 

--- a/src/landscape.h
+++ b/src/landscape.h
@@ -22,12 +22,12 @@ static const uint SNOW_LINE_DAYS   = 32; ///< Number of days in each month in th
  */
 struct SnowLine {
 	uint8_t table[SNOW_LINE_MONTHS][SNOW_LINE_DAYS]; ///< Height of the snow line each day of the year
-	uint8_t highest_value; ///< Highest snow line of the year
-	uint8_t lowest_value;  ///< Lowest snow line of the year
+	uint8_t highest_value = 0; ///< Highest snow line of the year
+	uint8_t lowest_value = UINT8_MAX; ///< Lowest snow line of the year
 };
 
 bool IsSnowLineSet();
-void SetSnowLine(uint8_t table[SNOW_LINE_MONTHS][SNOW_LINE_DAYS]);
+void SetSnowLine(std::unique_ptr<SnowLine> &&snow_line);
 uint8_t GetSnowLine();
 uint8_t HighestSnowLine();
 uint8_t LowestSnowLine();


### PR DESCRIPTION
## Motivation / Problem

Usage of `CallocT`, especially to set one field to zero, in snow lines.
Copying a table (of 384 bytes) when that would not be needed.


## Description

* Use `std::unique_ptr` to manage memory for the snow lines.
* Allocate the `SnowLine` in the NewGRF code and `std::move` the whole thing, instead of copying it.
* Move the loop for setting min/max to the already existing loop in the NewGRF code.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
