### PR TITLE
Codechange: use std::unique_ptr over CallocT for tiles

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -24,8 +24,8 @@
 /* static */ uint Map::size;      ///< The number of tiles on the map
 /* static */ uint Map::tile_mask; ///< _map_size - 1 (to mask the mapsize)
 
-/* static */ Tile::TileBase *Tile::base_tiles = nullptr;         ///< Base tiles of the map
-/* static */ Tile::TileExtended *Tile::extended_tiles = nullptr; ///< Extended tiles of the map
+/* static */ std::unique_ptr<Tile::TileBase[]> Tile::base_tiles; ///< Base tiles of the map
+/* static */ std::unique_ptr<Tile::TileExtended[]> Tile::extended_tiles; ///< Extended tiles of the map
 
 
 /**
@@ -53,11 +53,8 @@
 	Map::size = size_x * size_y;
 	Map::tile_mask = Map::size - 1;
 
-	free(Tile::base_tiles);
-	free(Tile::extended_tiles);
-
-	Tile::base_tiles = CallocT<Tile::TileBase>(Map::size);
-	Tile::extended_tiles = CallocT<Tile::TileExtended>(Map::size);
+	Tile::base_tiles = std::make_unique<Tile::TileBase[]>(Map::size);
+	Tile::extended_tiles = std::make_unique<Tile::TileExtended[]>(Map::size);
 
 	AllocateWaterRegions();
 }

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -30,13 +30,13 @@ private:
 	 * Look at docs/landscape.html for the exact meaning of the members.
 	 */
 	struct TileBase {
-		uint8_t   type;   ///< The type (bits 4..7), bridges (2..3), rainforest/desert (0..1)
-		uint8_t   height; ///< The height of the northern corner.
-		uint16_t m2;     ///< Primarily used for indices to towns, industries and stations
-		uint8_t   m1;     ///< Primarily used for ownership information
-		uint8_t   m3;     ///< General purpose
-		uint8_t   m4;     ///< General purpose
-		uint8_t   m5;     ///< General purpose
+		uint8_t type = 0; ///< The type (bits 4..7), bridges (2..3), rainforest/desert (0..1)
+		uint8_t height = 0; ///< The height of the northern corner.
+		uint16_t m2 = 0; ///< Primarily used for indices to towns, industries and stations
+		uint8_t m1 = 0; ///< Primarily used for ownership information
+		uint8_t m3 = 0; ///< General purpose
+		uint8_t m4 = 0; ///< General purpose
+		uint8_t m5 = 0; ///< General purpose
 	};
 
 	static_assert(sizeof(TileBase) == 8);
@@ -46,13 +46,13 @@ private:
 	 * Look at docs/landscape.html for the exact meaning of the members.
 	 */
 	struct TileExtended {
-		uint8_t m6;   ///< General purpose
-		uint8_t m7;   ///< Primarily used for newgrf support
-		uint16_t m8; ///< General purpose
+		uint8_t m6 = 0; ///< General purpose
+		uint8_t m7 = 0; ///< Primarily used for newgrf support
+		uint16_t m8 = 0; ///< General purpose
 	};
 
-	static TileBase *base_tiles;         ///< Pointer to the tile-array.
-	static TileExtended *extended_tiles; ///< Pointer to the extended tile-array.
+	static std::unique_ptr<TileBase[]> base_tiles; ///< Pointer to the tile-array.
+	static std::unique_ptr<TileExtended[]> extended_tiles; ///< Pointer to the extended tile-array.
 
 	TileIndex tile; ///< The tile to access the map data for.
 


### PR DESCRIPTION
## Motivation / Problem

We use `CallocT` and `free`.


## Description

Use `std::unique_ptr` and `std::make_unique` instead, and force default/value initialisation.


## Limitations

There are more remaining `CallocT`s, but... small nibbles.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
