### PR TITLE
Codechange: remove manual memory management in old string loading

### DIFF
--- a/src/saveload/oldloader.cpp
+++ b/src/saveload/oldloader.cpp
@@ -129,7 +129,6 @@ bool LoadChunk(LoadgameState *ls, void *base, const OldChunks *chunks)
 		}
 
 		uint8_t *ptr = (uint8_t*)chunk->ptr;
-		if (chunk->type & OC_DEREFERENCE_POINTER) ptr = *(uint8_t**)ptr;
 
 		for (uint i = 0; i < chunk->amount; i++) {
 			/* Handle simple types */

--- a/src/saveload/oldloader.h
+++ b/src/saveload/oldloader.h
@@ -70,12 +70,6 @@ enum OldChunkType : uint32_t {
 
 	OC_TILE      = OC_VAR_U32  | OC_FILE_U16,
 
-	/**
-	 * Dereference the pointer once before writing to it,
-	 * so we do not have to use big static arrays.
-	 */
-	OC_DEREFERENCE_POINTER = 1U << 31,
-
 	OC_END       = 0, ///< End of the whole chunk, all 32 bits set to zero
 };
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -929,6 +929,18 @@ static void FixSCCEncoded(std::string &str)
 }
 
 /**
+ * Read the given amount of bytes from the buffer into the string.
+ * @param str The string to write to.
+ * @param length The amount of bytes to read into the string.
+ * @note Does not perform any validation on validity of the string.
+ */
+void SlReadString(std::string &str, size_t length)
+{
+	str.resize(length);
+	SlCopyBytes(str.data(), length);
+}
+
+/**
  * Save/Load a \c std::string.
  * @param ptr the string being manipulated
  * @param conv must be SLE_FILE_STRING
@@ -953,8 +965,7 @@ static void SlStdString(void *ptr, VarType conv)
 				return;
 			}
 
-			str->resize(len);
-			SlCopyBytes(str->data(), len);
+			SlReadString(*str, len);
 
 			StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK;
 			if ((conv & SLF_ALLOW_CONTROL) != 0) {

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -1327,6 +1327,7 @@ size_t SlCalcObjMemberLength(const void *object, const SaveLoad &sld);
 size_t SlCalcObjLength(const void *object, const SaveLoadTable &slt);
 
 uint8_t SlReadByte();
+void SlReadString(std::string &str, size_t length);
 void SlWriteByte(uint8_t b);
 
 void SlGlobList(const SaveLoadTable &slt);

--- a/src/saveload/strings_sl.cpp
+++ b/src/saveload/strings_sl.cpp
@@ -18,9 +18,8 @@
 
 #include "../safeguards.h"
 
-static const int NUM_OLD_STRINGS     = 512; ///< The number of custom strings stored in old savegames.
-static const int LEN_OLD_STRINGS     =  32; ///< The number of characters per string.
-static const int LEN_OLD_STRINGS_TTO =  24; ///< The number of characters per string in TTO savegames.
+static const int NUM_OLD_STRINGS = 512; ///< The number of custom strings stored in old savegames.
+static const size_t LEN_OLD_STRINGS = 32; ///< The number of characters per string.
 
 /**
  * Remap a string ID from the old format to the new format
@@ -49,7 +48,7 @@ StringID RemapOldStringID(StringID s)
 }
 
 /** Location to load the old names to. */
-char *_old_name_array = nullptr;
+std::unique_ptr<std::string[]> _old_name_array;
 
 /**
  * Copy and convert old custom names to UTF-8.
@@ -64,13 +63,12 @@ std::string CopyFromOldName(StringID id)
 	if (GetStringTab(id) != TEXT_TAB_OLD_CUSTOM) return std::string();
 
 	if (IsSavegameVersionBefore(SLV_37)) {
-		uint offs = _savegame_type == SGT_TTO ? LEN_OLD_STRINGS_TTO * GB(id, 0, 8) : LEN_OLD_STRINGS * GB(id, 0, 9);
-		const char *strfrom = &_old_name_array[offs];
+		const std::string &strfrom = _old_name_array[GB(id, 0, 9)];
 
 		std::ostringstream tmp;
 		std::ostreambuf_iterator<char> strto(tmp);
-		for (; *strfrom != '\0'; strfrom++) {
-			char32_t c = (uint8_t)*strfrom;
+		for (char32_t c : strfrom) {
+			if (c == '\0') break;
 
 			/* Map from non-ISO8859-15 characters to UTF-8. */
 			switch (c) {
@@ -85,13 +83,13 @@ std::string CopyFromOldName(StringID id)
 				default: break;
 			}
 
-			Utf8Encode(strto, c);
+			if (IsPrintable(c)) Utf8Encode(strto, c);
 		}
 
 		return tmp.str();
 	} else {
 		/* Name will already be in UTF-8. */
-		return std::string(&_old_name_array[LEN_OLD_STRINGS * GB(id, 0, 9)]);
+		return StrMakeValid(_old_name_array[GB(id, 0, 9)]);
 	}
 }
 
@@ -101,7 +99,6 @@ std::string CopyFromOldName(StringID id)
  */
 void ResetOldNames()
 {
-	free(_old_name_array);
 	_old_name_array = nullptr;
 }
 
@@ -110,8 +107,7 @@ void ResetOldNames()
  */
 void InitializeOldNames()
 {
-	free(_old_name_array);
-	_old_name_array = CallocT<char>(NUM_OLD_STRINGS * LEN_OLD_STRINGS); // 200 * 24 would be enough for TTO savegames
+	_old_name_array = std::make_unique<std::string[]>(NUM_OLD_STRINGS); // 200 would be enough for TTO savegames
 }
 
 struct NAMEChunkHandler : ChunkHandler {
@@ -123,11 +119,10 @@ struct NAMEChunkHandler : ChunkHandler {
 
 		while ((index = SlIterateArray()) != -1) {
 			if (index >= NUM_OLD_STRINGS) SlErrorCorrupt("Invalid old name index");
-			if (SlGetFieldLength() > (uint)LEN_OLD_STRINGS) SlErrorCorrupt("Invalid old name length");
+			size_t length = SlGetFieldLength();
+			if (length > LEN_OLD_STRINGS) SlErrorCorrupt("Invalid old name length");
 
-			SlCopy(&_old_name_array[LEN_OLD_STRINGS * index], SlGetFieldLength(), SLE_UINT8);
-			/* Make sure the old name is null terminated */
-			_old_name_array[LEN_OLD_STRINGS * index + LEN_OLD_STRINGS - 1] = '\0';
+			SlReadString(_old_name_array[index], length);
 		}
 	}
 };


### PR DESCRIPTION
## Motivation / Problem

Usage of `CallocT` / `free`.

Allocating a massive swath of memory to put strings into at different offsets depending on the type of save game, i.e. with TTO there will be 200 strings of length 24, with TTD there will be 500 strings of length 32. So the offset of the string with index 1 will be 24 or 32.

Technically being able to pass non-printable/corrupted characters into the game.


## Description

Replace `CallocT`/`free` with `std::unique_ptr`.

Instead of allocating a massive array of chars, allocate an array of strings and fill these individually. Yes, this might be slightly slower but the code becomes simpler/more straight forward and who is going to repeatedly load old save games? And then TTD save games, as TTO has way fewer potential custom strings, and old OpenTTD will likely not be near the limit of allowed custom strings.

Rewrite the oldloader string reading to a function that gets called, instead of some magic 'dereference' flag in the loader's main code that is only used for these strings.

Remove the 'dereference' flag.

Ensure UTF-8 strings are valid by means  of `StrMakeValid`, and make non-UTF-8/ISO8859-15-ish valid by not allowing printable characters.


## Limitations

Only tested TTO and a version 28 save game. And darn is it an effort to get such and old OpenTTD to link.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
