### PR TITLE
Codechange: use std::unique_ptr over manual memory management

### DIFF
--- a/src/blitter/32bpp_anim.cpp
+++ b/src/blitter/32bpp_anim.cpp
@@ -20,11 +20,6 @@
 /** Instantiation of the 32bpp with animation blitter factory. */
 static FBlitter_32bppAnim iFBlitter_32bppAnim;
 
-Blitter_32bppAnim::~Blitter_32bppAnim()
-{
-	free(this->anim_alloc);
-}
-
 template <BlitterMode mode>
 inline void Blitter_32bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom)
 {
@@ -545,13 +540,12 @@ void Blitter_32bppAnim::PostResize()
 	if (_screen.width != this->anim_buf_width || _screen.height != this->anim_buf_height ||
 			_screen.pitch != this->anim_buf_pitch) {
 		/* The size of the screen changed; we can assume we can wipe all data from our buffer */
-		free(this->anim_alloc);
 		this->anim_buf_width = _screen.width;
 		this->anim_buf_height = _screen.height;
 		this->anim_buf_pitch = (_screen.width + 7) & ~7;
-		this->anim_alloc = CallocT<uint16_t>(this->anim_buf_pitch * this->anim_buf_height + 8);
+		this->anim_alloc = std::make_unique<uint16_t[]>(this->anim_buf_pitch * this->anim_buf_height + 8);
 
 		/* align buffer to next 16 byte boundary */
-		this->anim_buf = reinterpret_cast<uint16_t *>((reinterpret_cast<uintptr_t>(this->anim_alloc) + 0xF) & (~0xF));
+		this->anim_buf = reinterpret_cast<uint16_t *>((reinterpret_cast<uintptr_t>(this->anim_alloc.get()) + 0xF) & (~0xF));
 	}
 }

--- a/src/blitter/32bpp_anim.hpp
+++ b/src/blitter/32bpp_anim.hpp
@@ -16,7 +16,7 @@
 class Blitter_32bppAnim : public Blitter_32bppOptimized {
 protected:
 	uint16_t *anim_buf;    ///< In this buffer we keep track of the 8bpp indexes so we can do palette animation
-	void *anim_alloc;    ///< The raw allocated buffer, not necessarily aligned correctly
+	std::unique_ptr<uint16_t[]> anim_alloc; ///< The raw allocated buffer, not necessarily aligned correctly
 	int anim_buf_width;  ///< The width of the animation buffer.
 	int anim_buf_height; ///< The height of the animation buffer.
 	int anim_buf_pitch;  ///< The pitch of the animation buffer (width rounded up to 16 byte boundary).
@@ -25,15 +25,12 @@ protected:
 public:
 	Blitter_32bppAnim() :
 		anim_buf(nullptr),
-		anim_alloc(nullptr),
 		anim_buf_width(0),
 		anim_buf_height(0),
 		anim_buf_pitch(0)
 	{
 		this->palette = _cur_palette;
 	}
-
-	~Blitter_32bppAnim();
 
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
 	void DrawColourMappingRect(void *dst, int width, int height, PaletteID pal) override;


### PR DESCRIPTION
## Motivation / Problem

Manual memory management when there are easier alternatives.


## Description

Replace the `CallocT`-ed and `free`d memory from the blitters.


## Limitations

None I can think of, except the ugliness of `reinterpret_cast`.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
