### PR TITLE
Codechange: remove direct access to Textbuf's buffer

### DIFF
--- a/src/autocompletion.cpp
+++ b/src/autocompletion.cpp
@@ -21,7 +21,7 @@ bool AutoCompletion::AutoComplete()
 {
 	// We are pressing TAB for the first time after reset.
 	if (this->suggestions.empty()) {
-		this->InitSuggestions(this->textbuf->buf);
+		this->InitSuggestions(this->textbuf->GetText());
 		if (this->suggestions.empty()) {
 			return false;
 		}

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1893,7 +1893,7 @@ struct BuildVehicleWindow : Window {
 	void OnEditboxChanged(WidgetID wid) override
 	{
 		if (wid == WID_BV_FILTER) {
-			this->string_filter.SetFilterTerm(this->vehicle_editbox.text.buf);
+			this->string_filter.SetFilterTerm(this->vehicle_editbox.text.GetText());
 			this->InvalidateData();
 		}
 	}

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -118,11 +118,7 @@ IConsoleModes _iconsole_mode;
 
 static void IConsoleClearCommand()
 {
-	memset(_iconsole_cmdline.buf, 0, ICON_CMDLN_SIZE);
-	_iconsole_cmdline.chars = _iconsole_cmdline.bytes = 1; // only terminating zero
-	_iconsole_cmdline.pixels = 0;
-	_iconsole_cmdline.caretpos = 0;
-	_iconsole_cmdline.caretxoffs = 0;
+	_iconsole_cmdline.DeleteAll();
 	_iconsole_tab_completion.Reset();
 	SetWindowDirty(WC_CONSOLE, 0);
 }

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -212,7 +212,7 @@ struct IConsoleWindow : Window
 		/* If we have a marked area, draw a background highlight. */
 		if (_iconsole_cmdline.marklength != 0) GfxFillRect(this->line_offset + delta + _iconsole_cmdline.markxoffs, this->height - this->line_height, this->line_offset + delta + _iconsole_cmdline.markxoffs + _iconsole_cmdline.marklength, this->height - 1, PC_DARK_RED);
 
-		DrawString(this->line_offset + delta, right, this->height - this->line_height, _iconsole_cmdline.buf, (TextColour)CC_COMMAND, SA_LEFT | SA_FORCE);
+		DrawString(this->line_offset + delta, right, this->height - this->line_height, _iconsole_cmdline.GetText(), static_cast<TextColour>(CC_COMMAND), SA_LEFT | SA_FORCE);
 
 		if (_focused_window == this && _iconsole_cmdline.caret) {
 			DrawString(this->line_offset + delta + _iconsole_cmdline.caretxoffs, right, this->height - this->line_height, "_", TC_WHITE, SA_LEFT | SA_FORCE);
@@ -276,8 +276,8 @@ struct IConsoleWindow : Window
 				/* We always want the ] at the left side; we always force these strings to be left
 				 * aligned anyway. So enforce this in all cases by adding a left-to-right marker,
 				 * otherwise it will be drawn at the wrong side with right-to-left texts. */
-				IConsolePrint(CC_COMMAND, LRM "] {}", _iconsole_cmdline.buf);
-				const char *cmd = IConsoleHistoryAdd(_iconsole_cmdline.buf);
+				IConsolePrint(CC_COMMAND, LRM "] {}", _iconsole_cmdline.GetText());
+				const char *cmd = IConsoleHistoryAdd(_iconsole_cmdline.GetText());
 				IConsoleClearCommand();
 
 				if (cmd != nullptr) IConsoleCmdExec(cmd);
@@ -345,8 +345,8 @@ struct IConsoleWindow : Window
 	{
 		int delta = std::min<int>(this->width - this->line_offset - _iconsole_cmdline.pixels - ICON_RIGHT_BORDERWIDTH, 0);
 
-		const auto p1 = GetCharPosInString(_iconsole_cmdline.buf, from, FS_NORMAL);
-		const auto p2 = from != to ? GetCharPosInString(_iconsole_cmdline.buf, to, FS_NORMAL) : p1;
+		const auto p1 = GetCharPosInString(_iconsole_cmdline.GetText(), from, FS_NORMAL);
+		const auto p2 = from != to ? GetCharPosInString(_iconsole_cmdline.GetText(), to, FS_NORMAL) : p1;
 
 		Rect r = {this->line_offset + delta + p1.left, this->height - this->line_height, this->line_offset + delta + p2.right, this->height};
 		return r;
@@ -358,7 +358,7 @@ struct IConsoleWindow : Window
 
 		if (!IsInsideMM(pt.y, this->height - this->line_height, this->height)) return -1;
 
-		return GetCharAtPosition(_iconsole_cmdline.buf, pt.x - delta);
+		return GetCharAtPosition(_iconsole_cmdline.GetText(), pt.x - delta);
 	}
 
 	void OnMouseWheel(int wheel) override

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -814,7 +814,7 @@ public:
 		if (this->fop != SLO_SAVE) return;
 
 		if (this->IsWidgetLowered(WID_SL_DELETE_SELECTION)) { // Delete button clicked
-			if (!FiosDelete(this->filename_editbox.text.buf)) {
+			if (!FiosDelete(this->filename_editbox.text.GetText())) {
 				ShowErrorMessage(STR_ERROR_UNABLE_TO_DELETE_FILE, INVALID_STRING_ID, WL_ERROR);
 			} else {
 				this->InvalidateData(SLIWD_RESCAN_FILES);
@@ -823,14 +823,14 @@ public:
 			}
 		} else if (this->IsWidgetLowered(WID_SL_SAVE_GAME)) { // Save button clicked
 			if (this->abstract_filetype == FT_SAVEGAME || this->abstract_filetype == FT_SCENARIO) {
-				_file_to_saveload.name = FiosMakeSavegameName(this->filename_editbox.text.buf);
+				_file_to_saveload.name = FiosMakeSavegameName(this->filename_editbox.text.GetText());
 				if (FioCheckFileExists(_file_to_saveload.name, Subdirectory::SAVE_DIR)) {
 					ShowQuery(STR_SAVELOAD_OVERWRITE_TITLE, STR_SAVELOAD_OVERWRITE_WARNING, this, SaveLoadWindow::SaveGameConfirmationCallback);
 				} else {
 					_switch_mode = SM_SAVE_GAME;
 				}
 			} else {
-				_file_to_saveload.name = FiosMakeHeightmapName(this->filename_editbox.text.buf);
+				_file_to_saveload.name = FiosMakeHeightmapName(this->filename_editbox.text.GetText());
 				if (FioCheckFileExists(_file_to_saveload.name, Subdirectory::SAVE_DIR)) {
 					ShowQuery(STR_SAVELOAD_OVERWRITE_TITLE, STR_SAVELOAD_OVERWRITE_WARNING, this, SaveLoadWindow::SaveHeightmapConfirmationCallback);
 				} else {
@@ -940,7 +940,7 @@ public:
 	void OnEditboxChanged(WidgetID wid) override
 	{
 		if (wid == WID_SL_FILTER) {
-			this->string_filter.SetFilterTerm(this->filter_editbox.text.buf);
+			this->string_filter.SetFilterTerm(this->filter_editbox.text.GetText());
 			this->InvalidateData(SLIWD_FILTER_CHANGES);
 		}
 	}

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1866,7 +1866,7 @@ public:
 	void OnEditboxChanged(WidgetID wid) override
 	{
 		if (wid == WID_ID_FILTER) {
-			this->string_filter.SetFilterTerm(this->industry_editbox.text.buf);
+			this->string_filter.SetFilterTerm(this->industry_editbox.text.GetText());
 			this->InvalidateData(IDIWD_FORCE_REBUILD);
 		}
 	}

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -819,7 +819,7 @@ void QueryString::DrawEditBox(const Window *w, WidgetID wid) const
 	/* If we have a marked area, draw a background highlight. */
 	if (tb->marklength != 0) GfxFillRect(fr.left + tb->markxoffs, fr.top, fr.left + tb->markxoffs + tb->marklength - 1, fr.bottom, PC_GREY);
 
-	DrawString(fr.left, fr.right, CenterBounds(fr.top, fr.bottom, GetCharacterHeight(FS_NORMAL)), tb->buf, TC_YELLOW);
+	DrawString(fr.left, fr.right, CenterBounds(fr.top, fr.bottom, GetCharacterHeight(FS_NORMAL)), tb->GetText(), TC_YELLOW);
 	bool focussed = w->IsWidgetGloballyFocused(wid) || IsOSKOpenedFor(w, wid);
 	if (focussed && tb->caret) {
 		int caret_width = GetCaretWidth();
@@ -882,8 +882,8 @@ Rect QueryString::GetBoundingRect(const Window *w, WidgetID wid, const char *fro
 	r = ScrollEditBoxTextRect(r, *tb);
 
 	/* Get location of first and last character. */
-	const auto p1 = GetCharPosInString(tb->buf, from, FS_NORMAL);
-	const auto p2 = from != to ? GetCharPosInString(tb->buf, to, FS_NORMAL) : p1;
+	const auto p1 = GetCharPosInString(tb->GetText(), from, FS_NORMAL);
+	const auto p2 = from != to ? GetCharPosInString(tb->GetText(), to, FS_NORMAL) : p1;
 
 	return { Clamp(r.left + p1.left, r.left, r.right), r.top, Clamp(r.left + p2.right, r.left, r.right), r.bottom };
 }
@@ -913,7 +913,7 @@ ptrdiff_t QueryString::GetCharAtPosition(const Window *w, WidgetID wid, const Po
 	const Textbuf *tb = &this->text;
 	r = ScrollEditBoxTextRect(r, *tb);
 
-	return ::GetCharAtPosition(tb->buf, pt.x - r.left);
+	return ::GetCharAtPosition(tb->GetText(), pt.x - r.left);
 }
 
 void QueryString::ClickEditBox(Window *w, Point pt, WidgetID wid, int click_count, bool focus_changed)
@@ -956,7 +956,7 @@ struct QueryStringWindow : public Window
 	{
 		this->editbox.text.Assign(str);
 
-		if ((flags & QSF_ACCEPT_UNCHANGED) == 0) this->editbox.orig = this->editbox.text.buf;
+		if ((flags & QSF_ACCEPT_UNCHANGED) == 0) this->editbox.orig = this->editbox.text.GetText();
 
 		this->querystrings[WID_QS_TEXT] = &this->editbox;
 		this->editbox.caption = caption;
@@ -989,10 +989,10 @@ struct QueryStringWindow : public Window
 
 	void OnOk()
 	{
-		if (!this->editbox.orig.has_value() || this->editbox.text.buf != this->editbox.orig) {
+		if (!this->editbox.orig.has_value() || this->editbox.text.GetText() != this->editbox.orig) {
 			assert(this->parent != nullptr);
 
-			this->parent->OnQueryTextFinished(this->editbox.text.buf);
+			this->parent->OnQueryTextFinished(this->editbox.text.GetText());
 			this->editbox.handled = true;
 		}
 	}

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -376,7 +376,7 @@ struct NetworkChatWindow : public Window {
 	{
 		switch (widget) {
 			case WID_NC_SENDBUTTON: /* Send */
-				SendChat(this->message_editbox.text.buf, this->dtype, this->dest);
+				SendChat(this->message_editbox.text.GetText(), this->dtype, this->dest);
 				[[fallthrough]];
 
 			case WID_NC_CLOSE: /* Cancel */

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -373,7 +373,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 			url += "do=searchtext&q=";
 
 			/* Escape search term */
-			for (const char *search = this->filter_editbox.text.buf; *search != '\0'; search++) {
+			for (const char *search = this->filter_editbox.text.GetText(); *search != '\0'; search++) {
 				/* Remove quotes */
 				if (*search == '\'' || *search == '"') continue;
 
@@ -926,7 +926,7 @@ public:
 	void OnEditboxChanged(WidgetID wid) override
 	{
 		if (wid == WID_NCL_FILTER) {
-			this->filter_data.string_filter.SetFilterTerm(this->filter_editbox.text.buf);
+			this->filter_data.string_filter.SetFilterTerm(this->filter_editbox.text.GetText());
 			this->UpdateFilterState();
 			this->content.ForceRebuild();
 			this->InvalidateData();

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -228,7 +228,7 @@ protected:
 
 		/* Apply the filter condition immediately, if a search string has been provided. */
 		StringFilter sf;
-		sf.SetFilterTerm(this->filter_editbox.text.buf);
+		sf.SetFilterTerm(this->filter_editbox.text.GetText());
 
 		if (!sf.IsEmpty()) {
 			this->servers.SetFilterState(true);
@@ -837,7 +837,7 @@ public:
 			case WID_NG_CLIENT:
 				/* Validation of the name will happen once the user tries to join or start a game, as getting
 				 * error messages while typing (e.g. when you clear the name) defeats the purpose of the check. */
-				_settings_client.network.client_name = this->name_editbox.text.buf;
+				_settings_client.network.client_name = this->name_editbox.text.GetText();
 				break;
 		}
 	}
@@ -1129,7 +1129,7 @@ struct NetworkStartServerWindow : public Window {
 
 	bool CheckServerName()
 	{
-		std::string str = this->name_editbox.text.buf;
+		std::string str = this->name_editbox.text.GetText();
 		if (!NetworkValidateServerName(str)) return false;
 
 		SetSettingValue(GetSettingFromName("network.server_name")->AsStringSetting(), str);

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1363,7 +1363,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		if (!this->editable) return;
 
 		if (widget == WID_NS_FILTER) {
-			string_filter.SetFilterTerm(this->filter_editbox.text.buf);
+			string_filter.SetFilterTerm(this->filter_editbox.text.GetText());
 			this->avails.SetFilterState(!string_filter.IsEmpty());
 			this->avails.ForceRebuild();
 			this->InvalidateData(0);
@@ -2155,7 +2155,7 @@ struct SavePresetWindow : public Window {
 
 			case WID_SVP_SAVE: {
 				Window *w = FindWindowById(WC_GAME_OPTIONS, WN_GAME_OPTIONS_NEWGRF_STATE);
-				if (w != nullptr && !StrEmpty(this->presetname_editbox.text.buf)) w->OnQueryTextFinished(this->presetname_editbox.text.buf);
+				if (w != nullptr && !StrEmpty(this->presetname_editbox.text.GetText())) w->OnQueryTextFinished(this->presetname_editbox.text.GetText());
 				this->Close();
 				break;
 			}

--- a/src/osk_gui.cpp
+++ b/src/osk_gui.cpp
@@ -58,7 +58,7 @@ struct OskWindow : public Window {
 		this->querystrings[WID_OSK_TEXT] = this->qs;
 
 		/* make a copy in case we need to reset later */
-		this->orig_str = this->qs->text.buf;
+		this->orig_str = this->qs->text.GetText();
 
 		this->InitNested(0);
 		this->SetFocusedWidget(WID_OSK_TEXT);
@@ -157,7 +157,7 @@ struct OskWindow : public Window {
 				break;
 
 			case WID_OSK_OK:
-				if (!this->qs->orig.has_value() || this->qs->text.buf != this->qs->orig) {
+				if (!this->qs->orig.has_value() || this->qs->text.GetText() != this->qs->orig) {
 					/* pass information by simulating a button press on parent window */
 					if (this->qs->ok_button >= 0) {
 						this->parent->OnClick(pt, this->qs->ok_button, 1);
@@ -412,7 +412,7 @@ void UpdateOSKOriginalText(const Window *parent, WidgetID button)
 	OskWindow *osk = dynamic_cast<OskWindow *>(FindWindowById(WC_OSK, 0));
 	if (osk == nullptr || osk->parent != parent || osk->text_btn != button) return;
 
-	osk->orig_str = osk->qs->text.buf;
+	osk->orig_str = osk->qs->text.GetText();
 
 	osk->SetDirty();
 }

--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -189,7 +189,7 @@ void PickerWindow::ConstructWindow()
 	}
 
 	this->class_editbox.cancel_button = QueryString::ACTION_CLEAR;
-	this->class_string_filter.SetFilterTerm(this->class_editbox.text.buf);
+	this->class_string_filter.SetFilterTerm(this->class_editbox.text.GetText());
 	this->class_string_filter.callbacks = &this->callbacks;
 
 	this->classes.SetListing(this->callbacks.class_last_sorting);
@@ -224,7 +224,7 @@ void PickerWindow::ConstructWindow()
 	}
 
 	this->type_editbox.cancel_button = QueryString::ACTION_CLEAR;
-	this->type_string_filter.SetFilterTerm(this->type_editbox.text.buf);
+	this->type_string_filter.SetFilterTerm(this->type_editbox.text.GetText());
 	this->type_string_filter.callbacks = &this->callbacks;
 
 	this->types.SetListing(this->callbacks.type_last_sorting);
@@ -431,13 +431,13 @@ void PickerWindow::OnEditboxChanged(WidgetID wid)
 {
 	switch (wid) {
 		case WID_PW_CLASS_FILTER:
-			this->class_string_filter.SetFilterTerm(this->class_editbox.text.buf);
+			this->class_string_filter.SetFilterTerm(this->class_editbox.text.GetText());
 			this->classes.SetFilterState(!class_string_filter.IsEmpty());
 			this->InvalidateData(PFI_CLASS);
 			break;
 
 		case WID_PW_TYPE_FILTER:
-			this->type_string_filter.SetFilterTerm(this->type_editbox.text.buf);
+			this->type_string_filter.SetFilterTerm(this->type_editbox.text.GetText());
 			this->types.SetFilterState(!type_string_filter.IsEmpty());
 			this->InvalidateData(PFI_TYPE);
 			break;

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -1109,7 +1109,7 @@ struct ScriptDebugWindow : public Window {
 		if (wid != WID_SCRD_BREAK_STR_EDIT_BOX) return;
 
 		/* Save the current string to static member so it can be restored next time the window is opened. */
-		this->filter.break_string = this->break_editbox.text.buf;
+		this->filter.break_string = this->break_editbox.text.GetText();
 		this->break_string_filter.SetFilterTerm(this->filter.break_string);
 	}
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2841,7 +2841,7 @@ struct GameSettingsWindow : Window {
 	void OnEditboxChanged(WidgetID wid) override
 	{
 		if (wid == WID_GS_FILTER) {
-			this->filter.string.SetFilterTerm(this->filter_editbox.text.buf);
+			this->filter.string.SetFilterTerm(this->filter_editbox.text.GetText());
 			if (!this->filter.string.IsEmpty() && !this->manually_changed_folding) {
 				/* User never expanded/collapsed single pages and entered a filter term.
 				 * Expand everything, to save weird expand clicks, */

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -294,7 +294,7 @@ struct SignListWindow : Window, SignList {
 
 	void OnEditboxChanged(WidgetID widget) override
 	{
-		if (widget == WID_SIL_FILTER_TEXT) this->SetFilterString(this->filter_editbox.text.buf);
+		if (widget == WID_SIL_FILTER_TEXT) this->SetFilterString(this->filter_editbox.text.GetText());
 	}
 
 	void BuildSortSignList()
@@ -513,7 +513,7 @@ struct SignWindow : Window, SignList {
 				break;
 
 			case WID_QES_OK:
-				if (RenameSign(this->cur_sign, this->name_editbox.text.buf)) break;
+				if (RenameSign(this->cur_sign, this->name_editbox.text.GetText())) break;
 				[[fallthrough]];
 
 			case WID_QES_CANCEL:

--- a/src/textbuf_type.h
+++ b/src/textbuf_type.h
@@ -29,7 +29,6 @@ enum HandleKeyPressResult
 /** Helper/buffer for input fields. */
 struct Textbuf {
 	CharSetFilter afilter;    ///< Allowed characters
-	char * const buf;         ///< buffer in which text is saved
 	uint16_t max_bytes;         ///< the maximum size of the buffer in bytes (including terminating '\0')
 	uint16_t max_chars;         ///< the maximum size of the buffer in characters (including terminating '\0')
 	uint16_t bytes;             ///< the current size of the string in bytes (including terminating '\0')
@@ -68,6 +67,7 @@ struct Textbuf {
 	const char *GetText() const;
 
 private:
+	char * const buf; ///< buffer in which text is saved
 	std::unique_ptr<StringIterator> char_iter;
 
 	bool CanDelChar(bool backspace);

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1019,7 +1019,7 @@ public:
 	void OnEditboxChanged(WidgetID wid) override
 	{
 		if (wid == WID_TD_FILTER) {
-			this->string_filter.SetFilterTerm(this->townname_editbox.text.buf);
+			this->string_filter.SetFilterTerm(this->townname_editbox.text.GetText());
 			this->InvalidateData(TDIWD_FORCE_REBUILD);
 		}
 	}
@@ -1240,11 +1240,11 @@ public:
 		std::string name;
 
 		if (!this->townnamevalid) {
-			name = this->townname_editbox.text.buf;
+			name = this->townname_editbox.text.GetText();
 		} else {
 			/* If user changed the name, send it */
 			std::string original_name = GetTownName(&this->params, this->townnameparts);
-			if (original_name != this->townname_editbox.text.buf) name = this->townname_editbox.text.buf;
+			if (original_name != this->townname_editbox.text.GetText()) name = this->townname_editbox.text.GetText();
 		}
 
 		bool success = Command<CMD_FOUND_TOWN>::Post(errstr, cc,


### PR DESCRIPTION
## Motivation / Problem

Users of the `Textbuf` should not be able to mess with the content of its buffer, when there are many preconditions that need to be observed for it.

Also, the code base accessing the buffer directly makes changing its implementation more difficult.


## Description

There is one situation where the buffer was changed: `IConsoleClearCommand`. Here it cleared the buffer and a number of other variables in the class, but this can easily be done by calling `DeleteAll`. This has the added benefit that the later added string iterator gets (re)initialized correctly as well.

Next to that there is a `GetText()` function that returns a `const char *` (`buffer` was `char *`), which is the perfect replacement and it was already used in many other places.


## Limitations

None I can think of. Well.. except that there are still many more fields that are `public`, but that's definitely not for this PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
