### PR TITLE
Codechange: Use std::variant instead of type and union to evaluate Action 14.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -8375,79 +8375,15 @@ typedef bool (*BranchHandler)(ByteReader &);        ///< Type of callback functi
  * 3. Text leaf nodes (identified by 'T').
  */
 struct AllowedSubtags {
-	/** Create empty subtags object used to identify the end of a list. */
-	AllowedSubtags() :
-		id(0),
-		type(0)
-	{}
+	/** Custom 'span' of subtags. Required because std::span with an incomplete type is UB. */
+	using Span = std::pair<const AllowedSubtags *, const AllowedSubtags *>;
 
-	/**
-	 * Create a binary leaf node.
-	 * @param id The id for this node.
-	 * @param handler The callback function to call.
-	 */
-	AllowedSubtags(uint32_t id, DataHandler handler) :
-		id(id),
-		type('B')
-	{
-		this->handler.data = handler;
-	}
-
-	/**
-	 * Create a text leaf node.
-	 * @param id The id for this node.
-	 * @param handler The callback function to call.
-	 */
-	AllowedSubtags(uint32_t id, TextHandler handler) :
-		id(id),
-		type('T')
-	{
-		this->handler.text = handler;
-	}
-
-	/**
-	 * Create a branch node with a callback handler
-	 * @param id The id for this node.
-	 * @param handler The callback function to call.
-	 */
-	AllowedSubtags(uint32_t id, BranchHandler handler) :
-		id(id),
-		type('C')
-	{
-		this->handler.call_handler = true;
-		this->handler.u.branch = handler;
-	}
-
-	/**
-	 * Create a branch node with a list of sub-nodes.
-	 * @param id The id for this node.
-	 * @param subtags Array with all valid subtags.
-	 */
-	AllowedSubtags(uint32_t id, AllowedSubtags *subtags) :
-		id(id),
-		type('C')
-	{
-		this->handler.call_handler = false;
-		this->handler.u.subtags = subtags;
-	}
-
-	uint32_t id; ///< The identifier for this node
-	uint8_t type; ///< The type of the node, must be one of 'C', 'B' or 'T'.
-	union {
-		DataHandler data; ///< Callback function for a binary node, only valid if type == 'B'.
-		TextHandler text; ///< Callback function for a text node, only valid if type == 'T'.
-		struct {
-			union {
-				BranchHandler branch;    ///< Callback function for a branch node, only valid if type == 'C' && call_handler.
-				AllowedSubtags *subtags; ///< Pointer to a list of subtags, only valid if type == 'C' && !call_handler.
-			} u;
-			bool call_handler; ///< True if there is a callback function for this node, false if there is a list of subnodes.
-		};
-	} handler;
+	uint32_t id; ///< The identifier for this node.
+	std::variant<DataHandler, TextHandler, BranchHandler, Span> handler; ///< The handler for this node.
 };
 
 static bool SkipUnknownInfo(ByteReader &buf, uint8_t type);
-static bool HandleNodes(ByteReader &buf, AllowedSubtags *tags);
+static bool HandleNodes(ByteReader &buf, std::span<const AllowedSubtags> tags);
 
 /**
  * Callback function for 'INFO'->'PARA'->param_num->'VALU' to set the names
@@ -8485,15 +8421,14 @@ static bool ChangeGRFParamValueNames(ByteReader &buf)
 }
 
 /** Action14 parameter tags */
-AllowedSubtags _tags_parameters[] = {
-	AllowedSubtags('NAME', ChangeGRFParamName),
-	AllowedSubtags('DESC', ChangeGRFParamDescription),
-	AllowedSubtags('TYPE', ChangeGRFParamType),
-	AllowedSubtags('LIMI', ChangeGRFParamLimits),
-	AllowedSubtags('MASK', ChangeGRFParamMask),
-	AllowedSubtags('VALU', ChangeGRFParamValueNames),
-	AllowedSubtags('DFLT', ChangeGRFParamDefault),
-	AllowedSubtags()
+static constexpr AllowedSubtags _tags_parameters[] = {
+	AllowedSubtags{'NAME', ChangeGRFParamName},
+	AllowedSubtags{'DESC', ChangeGRFParamDescription},
+	AllowedSubtags{'TYPE', ChangeGRFParamType},
+	AllowedSubtags{'LIMI', ChangeGRFParamLimits},
+	AllowedSubtags{'MASK', ChangeGRFParamMask},
+	AllowedSubtags{'VALU', ChangeGRFParamValueNames},
+	AllowedSubtags{'DFLT', ChangeGRFParamDefault},
 };
 
 /**
@@ -8529,23 +8464,21 @@ static bool HandleParameterInfo(ByteReader &buf)
 }
 
 /** Action14 tags for the INFO node */
-AllowedSubtags _tags_info[] = {
-	AllowedSubtags('NAME', ChangeGRFName),
-	AllowedSubtags('DESC', ChangeGRFDescription),
-	AllowedSubtags('URL_', ChangeGRFURL),
-	AllowedSubtags('NPAR', ChangeGRFNumUsedParams),
-	AllowedSubtags('PALS', ChangeGRFPalette),
-	AllowedSubtags('BLTR', ChangeGRFBlitter),
-	AllowedSubtags('VRSN', ChangeGRFVersion),
-	AllowedSubtags('MINV', ChangeGRFMinVersion),
-	AllowedSubtags('PARA', HandleParameterInfo),
-	AllowedSubtags()
+static constexpr AllowedSubtags _tags_info[] = {
+	AllowedSubtags{'NAME', ChangeGRFName},
+	AllowedSubtags{'DESC', ChangeGRFDescription},
+	AllowedSubtags{'URL_', ChangeGRFURL},
+	AllowedSubtags{'NPAR', ChangeGRFNumUsedParams},
+	AllowedSubtags{'PALS', ChangeGRFPalette},
+	AllowedSubtags{'BLTR', ChangeGRFBlitter},
+	AllowedSubtags{'VRSN', ChangeGRFVersion},
+	AllowedSubtags{'MINV', ChangeGRFMinVersion},
+	AllowedSubtags{'PARA', HandleParameterInfo},
 };
 
 /** Action14 root tags */
-AllowedSubtags _tags_root[] = {
-	AllowedSubtags('INFO', _tags_info),
-	AllowedSubtags()
+static constexpr AllowedSubtags _tags_root[] = {
+	AllowedSubtags{'INFO', std::make_pair(std::begin(_tags_info), std::end(_tags_info))},
 };
 
 
@@ -8595,34 +8528,49 @@ static bool SkipUnknownInfo(ByteReader &buf, uint8_t type)
  * @param subtags Allowed subtags.
  * @return Whether all tags could be handled.
  */
-static bool HandleNode(uint8_t type, uint32_t id, ByteReader &buf, AllowedSubtags subtags[])
+static bool HandleNode(uint8_t type, uint32_t id, ByteReader &buf, std::span<const AllowedSubtags> subtags)
 {
-	uint i = 0;
-	AllowedSubtags *tag;
-	while ((tag = &subtags[i++])->type != 0) {
-		if (tag->id != BSWAP32(id) || tag->type != type) continue;
-		switch (type) {
-			default: NOT_REACHED();
+	/* Visitor to get a subtag handler's type. */
+	struct type_visitor {
+		char operator()(const DataHandler &) { return 'B'; }
+		char operator()(const TextHandler &) { return 'T'; }
+		char operator()(const BranchHandler &) { return 'C'; }
+		char operator()(const AllowedSubtags::Span &) { return 'C'; }
+	};
 
-			case 'T': {
-				uint8_t langid = buf.ReadByte();
-				return tag->handler.text(langid, buf.ReadString());
-			}
+	/* Visitor to evaluate a subtag handler. */
+	struct evaluate_visitor {
+		ByteReader &buf;
 
-			case 'B': {
-				size_t len = buf.ReadWord();
-				if (buf.Remaining() < len) return false;
-				return tag->handler.data(len, buf);
-			}
-
-			case 'C': {
-				if (tag->handler.call_handler) {
-					return tag->handler.u.branch(buf);
-				}
-				return HandleNodes(buf, tag->handler.u.subtags);
-			}
+		bool operator()(const DataHandler &handler)
+		{
+			size_t len = buf.ReadWord();
+			if (buf.Remaining() < len) return false;
+			return handler(len, buf);
 		}
+
+		bool operator()(const TextHandler &handler)
+		{
+			uint8_t langid = buf.ReadByte();
+			return handler(langid, buf.ReadString());
+		}
+
+		bool operator()(const BranchHandler &handler)
+		{
+			return handler(buf);
+		}
+
+		bool operator()(const AllowedSubtags::Span &subtags)
+		{
+			return HandleNodes(buf, {subtags.first, subtags.second});
+		}
+	};
+
+	for (const auto &tag : subtags) {
+		if (tag.id != BSWAP32(id) || std::visit(type_visitor{}, tag.handler) != type) continue;
+		return std::visit(evaluate_visitor{buf}, tag.handler);
 	}
+
 	GrfMsg(2, "StaticGRFInfo: unknown type/id combination found, type={:c}, id={:x}", type, id);
 	return SkipUnknownInfo(buf, type);
 }
@@ -8633,7 +8581,7 @@ static bool HandleNode(uint8_t type, uint32_t id, ByteReader &buf, AllowedSubtag
  * @param subtags List of subtags.
  * @return Whether the nodes could all be handled.
  */
-static bool HandleNodes(ByteReader &buf, AllowedSubtags subtags[])
+static bool HandleNodes(ByteReader &buf, std::span<const AllowedSubtags> subtags)
 {
 	uint8_t type = buf.ReadByte();
 	while (type != 0) {


### PR DESCRIPTION




<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Evaluating NewGRF Action 14 records involves a union-of-union and checking a type field.

It also involves iterating an array by pointer and using a special terminator record to detect the end.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use `std::variant` instead of type and union to evaluate Action 14 instead.

AllowedSubtags are now passed by span, so no terminator is required, and are now static constexpr.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
