### PR TITLE
Codechange: use std::vector over ReallocT for dirty blocks

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -8,7 +8,6 @@
 /** @file gfx.cpp Handling of drawing text and other gfx related stuff. */
 
 #include "stdafx.h"
-#include "core/alloc_func.hpp"
 #include "gfx_layout.h"
 #include "progress.h"
 #include "zoom_func.h"
@@ -79,7 +78,7 @@ static const uint DIRTY_BLOCK_HEIGHT   = 8;
 static const uint DIRTY_BLOCK_WIDTH    = 64;
 
 static uint _dirty_bytes_per_line = 0;
-static uint8_t *_dirty_blocks = nullptr;
+static std::vector<uint8_t> _dirty_blocks;
 extern uint _dirty_block_colour;
 
 void GfxScroll(int left, int top, int width, int height, int xo, int yo)
@@ -1273,7 +1272,7 @@ std::pair<uint8_t, uint8_t> GetBroadestDigit(FontSize size)
 void ScreenSizeChanged()
 {
 	_dirty_bytes_per_line = CeilDiv(_screen.width, DIRTY_BLOCK_WIDTH);
-	_dirty_blocks = ReallocT<uint8_t>(_dirty_blocks, static_cast<size_t>(_dirty_bytes_per_line) * CeilDiv(_screen.height, DIRTY_BLOCK_HEIGHT));
+	_dirty_blocks.resize(static_cast<size_t>(_dirty_bytes_per_line) * CeilDiv(_screen.height, DIRTY_BLOCK_HEIGHT));
 
 	/* check the dirty rect */
 	if (_invalid_rect.right >= _screen.width) _invalid_rect.right = _screen.width;
@@ -1401,7 +1400,7 @@ void RedrawScreenRect(int left, int top, int right, int bottom)
  */
 void DrawDirtyBlocks()
 {
-	uint8_t *b = _dirty_blocks;
+	uint8_t *b = _dirty_blocks.data();
 	const int w = Align(_screen.width,  DIRTY_BLOCK_WIDTH);
 	const int h = Align(_screen.height, DIRTY_BLOCK_HEIGHT);
 	int x;
@@ -1509,7 +1508,7 @@ void AddDirtyBlock(int left, int top, int right, int bottom)
 	left /= DIRTY_BLOCK_WIDTH;
 	top  /= DIRTY_BLOCK_HEIGHT;
 
-	b = _dirty_blocks + top * _dirty_bytes_per_line + left;
+	b = _dirty_blocks.data() + top * _dirty_bytes_per_line + left;
 
 	width  = ((right  - 1) / DIRTY_BLOCK_WIDTH)  - left + 1;
 	height = ((bottom - 1) / DIRTY_BLOCK_HEIGHT) - top  + 1;


### PR DESCRIPTION
## Motivation / Problem

Use of C-style memory management.


## Description

* Replace the `ReallocT`-ed table with a `std::vector`.
* Replace the `uint8_t*` instances with the vector's iterator.
* Replace a simple for loop for filling some elements with `std::fill`.

With the old logic, iterators would be made beyond the bounds of the vector which is something MSVC's iterators check for. This means either not using the vector's iterator, or rewriting the logic. I chose for rewriting as that could add some improvements in locality. 
The old code have rows first, then columns but the coalescing of blocks went column first then row. So by swapping the order of the axis in the data, it became possible to use `std::find_if_not` / `std::fill` greatly shortening the code and making it easier to see the overall logic.


## Limitations

Does use potentially more memory than strictly necessary, because of the resize/capacity behaviour of `std::vector`. Having said that, at 1920x1080 we are talking about allocating 4050 bytes, when `std::vector` would likely allocate 4096 bytes. On the other hand, when resizing we do not need to continuously reallocate memory.

I have looked into using `std::vector<bool>` for some memory savings, but performance is slower (+3% with `AddDirtyBlock`, +2.5% with `DrawDirtyBlocks`) on the same game for 250.000 ticks at 1920x1080.

Some bits of code could be made simpler when `std::mdspan` (C++23) and especially `std::submdspan` (potentially C++26) could be used, but that's still half a decade out from being really supportable by OpenTTD.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
