### PR TITLE
Fix #12987: Historical houses now always spawn completed

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2734,7 +2734,7 @@ static void BuildTownHouse(Town *t, TileIndex tile, const HouseSpec *hs, HouseID
 		uint32_t construction_random = Random();
 
 		construction_stage = TOWN_HOUSE_COMPLETED;
-		if (_generating_world && Chance16(1, 7)) construction_stage = GB(construction_random, 0, 2);
+		if (_generating_world && !HasFlag(hs->extra_flags, HouseExtraFlags::BUILDING_IS_HISTORICAL) && Chance16(1, 7)) construction_stage = GB(construction_random, 0, 2);
 
 		if (construction_stage == TOWN_HOUSE_COMPLETED) {
 			ChangePopulation(t, hs->population);


### PR DESCRIPTION
## Motivation / Problem
Fixes #12987, ensuring that historical houses are never spawned under construction. 

## Description
There is now an additional check when attempting to build a house while generating a world to ensure that only houses without the "historical" bit set are allowed to spawn with a randomised (i.e., incomplete) construction state. 

## Limitations
None that I know of, although as I am rather inexperienced with C++ there may have been something that slipped through.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
