### PR TITLE
Codefix: EngineID is used when it's not an actual EngineID

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -68,16 +68,16 @@ const uint8_t _engine_offsets[4] = {
 
 static_assert(lengthof(_orig_rail_vehicle_info) + lengthof(_orig_road_vehicle_info) + lengthof(_orig_ship_vehicle_info) + lengthof(_orig_aircraft_vehicle_info) == lengthof(_orig_engine_info));
 
-Engine::Engine(VehicleType type, EngineID base)
+Engine::Engine(VehicleType type, uint16_t local_id)
 {
 	this->type = type;
-	this->grf_prop.local_id = base;
-	this->list_position = base;
+	this->grf_prop.local_id = local_id;
+	this->list_position = local_id;
 	this->preview_company = INVALID_COMPANY;
 	this->display_last_variant = INVALID_ENGINE;
 
 	/* Check if this base engine is within the original engine data range */
-	if (base >= _engine_counts[type]) {
+	if (local_id >= _engine_counts[type]) {
 		/* 'power' defaults to zero, so we also have to default to 'wagon' */
 		if (type == VEH_TRAIN) this->u.rail.railveh_type = RAILVEH_WAGON;
 		/* Set model life to maximum to make wagons available */
@@ -104,16 +104,16 @@ Engine::Engine(VehicleType type, EngineID base)
 	}
 
 	/* Copy the original engine info for this slot */
-	this->info = _orig_engine_info[_engine_offsets[type] + base];
+	this->info = _orig_engine_info[_engine_offsets[type] + local_id];
 
 	/* Copy the original engine data for this slot */
 	switch (type) {
 		default: NOT_REACHED();
 
 		case VEH_TRAIN:
-			this->u.rail = _orig_rail_vehicle_info[base];
+			this->u.rail = _orig_rail_vehicle_info[local_id];
 			this->original_image_index = this->u.rail.image_index;
-			this->info.string_id = STR_VEHICLE_NAME_TRAIN_ENGINE_RAIL_KIRBY_PAUL_TANK_STEAM + base;
+			this->info.string_id = STR_VEHICLE_NAME_TRAIN_ENGINE_RAIL_KIRBY_PAUL_TANK_STEAM + local_id;
 
 			/* Set the default model life of original wagons to "infinite" */
 			if (this->u.rail.railveh_type == RAILVEH_WAGON) this->info.base_life = TimerGameCalendar::Year{0xFF};
@@ -121,21 +121,21 @@ Engine::Engine(VehicleType type, EngineID base)
 			break;
 
 		case VEH_ROAD:
-			this->u.road = _orig_road_vehicle_info[base];
+			this->u.road = _orig_road_vehicle_info[local_id];
 			this->original_image_index = this->u.road.image_index;
-			this->info.string_id = STR_VEHICLE_NAME_ROAD_VEHICLE_MPS_REGAL_BUS + base;
+			this->info.string_id = STR_VEHICLE_NAME_ROAD_VEHICLE_MPS_REGAL_BUS + local_id;
 			break;
 
 		case VEH_SHIP:
-			this->u.ship = _orig_ship_vehicle_info[base];
+			this->u.ship = _orig_ship_vehicle_info[local_id];
 			this->original_image_index = this->u.ship.image_index;
-			this->info.string_id = STR_VEHICLE_NAME_SHIP_MPS_OIL_TANKER + base;
+			this->info.string_id = STR_VEHICLE_NAME_SHIP_MPS_OIL_TANKER + local_id;
 			break;
 
 		case VEH_AIRCRAFT:
-			this->u.air = _orig_aircraft_vehicle_info[base];
+			this->u.air = _orig_aircraft_vehicle_info[local_id];
 			this->original_image_index = this->u.air.image_index;
-			this->info.string_id = STR_VEHICLE_NAME_AIRCRAFT_SAMPSON_U52 + base;
+			this->info.string_id = STR_VEHICLE_NAME_AIRCRAFT_SAMPSON_U52 + local_id;
 			break;
 	}
 }

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -83,7 +83,7 @@ struct Engine : EnginePool::PoolItem<&_engine_pool> {
 	std::vector<WagonOverride> overrides;
 
 	Engine() {}
-	Engine(VehicleType type, EngineID base);
+	Engine(VehicleType type, uint16_t local_id);
 	bool IsEnabled() const;
 
 	/**

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -381,10 +381,10 @@ static bool FixTTOEngines()
 	/* Load the default engine set. Many of them will be overridden later */
 	{
 		uint j = 0;
-		for (uint i = 0; i < lengthof(_orig_rail_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_TRAIN, i);
-		for (uint i = 0; i < lengthof(_orig_road_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_ROAD, i);
-		for (uint i = 0; i < lengthof(_orig_ship_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_SHIP, i);
-		for (uint i = 0; i < lengthof(_orig_aircraft_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_AIRCRAFT, i);
+		for (uint16_t i = 0; i < lengthof(_orig_rail_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_TRAIN, i);
+		for (uint16_t i = 0; i < lengthof(_orig_road_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_ROAD, i);
+		for (uint16_t i = 0; i < lengthof(_orig_ship_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_SHIP, i);
+		for (uint16_t i = 0; i < lengthof(_orig_aircraft_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_AIRCRAFT, i);
 	}
 
 	TimerGameCalendar::Date aging_date = std::min(TimerGameCalendar::date + CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR, TimerGameCalendar::ConvertYMDToDate(TimerGameCalendar::Year{2050}, 0, 1));

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -342,8 +342,9 @@ static Engine *_old_engines;
 
 static bool FixTTOEngines()
 {
+	using OldEngineID = uint8_t;
 	/** TTD->TTO remapping of engines; 255 means there is no equivalent. SVXConverter uses (almost) the same table. */
-	static const EngineID ttd_to_tto[] = {
+	static const OldEngineID ttd_to_tto[] = {
 		  0, 255, 255, 255, 255, 255, 255, 255,   5,   7,   8,   9,  10,  11,  12,  13,
 		255, 255, 255, 255, 255, 255,  15,  16,  17,  18,  19,  20,  21,  22,  23,  24,
 		25,   26,  27,  29,  28,  30, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -363,7 +364,7 @@ static bool FixTTOEngines()
 	};
 
 	/** TTO->TTD remapping of engines. SVXConverter uses the same table. */
-	static const EngineID tto_to_ttd[] = {
+	static const OldEngineID tto_to_ttd[] = {
 		  0,   0,   8,   8,   8,   8,   8,   9,  10,  11,  12,  13,  14,  15,  15,  22,
 		 23,  24,  25,  26,  27,  29,  28,  30,  31,  32,  33,  34,  35,  36,  37,  55,
 		 57,  59,  58,  60,  61,  62,  63,  64,  65,  66,  67, 116, 116, 117, 118, 123,
@@ -375,7 +376,7 @@ static bool FixTTOEngines()
 
 	for (Vehicle *v : Vehicle::Iterate()) {
 		if (v->engine_type >= lengthof(tto_to_ttd)) return false;
-		v->engine_type = tto_to_ttd[v->engine_type];
+		v->engine_type = static_cast<EngineID>(tto_to_ttd[v->engine_type]);
 	}
 
 	/* Load the default engine set. Many of them will be overridden later */
@@ -391,7 +392,7 @@ static bool FixTTOEngines()
 	TimerGameCalendar::YearMonthDay aging_ymd = TimerGameCalendar::ConvertDateToYMD(aging_date);
 
 	for (EngineID i = 0; i < 256; i++) {
-		int oi = ttd_to_tto[i];
+		OldEngineID oi = ttd_to_tto[i];
 		Engine *e = GetTempDataEngine(i);
 
 		if (oi == 255) {


### PR DESCRIPTION
## Motivation / Problem

Using `EngineID` when you do not actually mean an `EngineID`, as in an ID of `Engine`. This becomes especially annoying when making `EngineID` an `enum`.

For example `Engine`'s constructor has a `base` parameter of type `EngineID` that is usually not the same as `Engine::Index` (the `EngineID`). It is stored in `grf_prop.local_id` and compared/used within the constructor as if it is an offset from the first engine per `VehicleType`.

Similarly in the old loader the `EngineID` is used for a mapping between TTO/TTD engines. These values are not always the same as the proper `EngineID`s, so rather use a different type to denote the distinction.


## Description

Use `uint16_t` or define `OldEngineID` to not use `EngineID`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
