### PR TITLE
Codefix: use INVALID_VEHICLE where more appropriate

### DIFF
--- a/src/disaster_vehicle.h
+++ b/src/disaster_vehicle.h
@@ -42,7 +42,7 @@ struct DisasterVehicle final : public SpecializedVehicle<DisasterVehicle, VEH_DI
 
 	/** For use by saveload. */
 	DisasterVehicle() : SpecializedVehicleBase() {}
-	DisasterVehicle(int x, int y, Direction direction, DisasterSubType subtype, VehicleID big_ufo_destroyer_target = VEH_INVALID);
+	DisasterVehicle(int x, int y, Direction direction, DisasterSubType subtype, VehicleID big_ufo_destroyer_target = INVALID_VEHICLE);
 	/** We want to 'destruct' the right class. */
 	virtual ~DisasterVehicle() = default;
 

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -1017,7 +1017,7 @@ public:
 						break;
 					case ADI_SERVICE: // Send for servicing
 					case ADI_DEPOT: { // Send to Depots
-						Command<CMD_SEND_VEHICLE_TO_DEPOT>::Post(GetCmdSendToDepotMsg(this->vli.vtype), 0, DepotCommand::MassSend | (index == ADI_SERVICE ? DepotCommand::Service : DepotCommand::None), this->vli);
+						Command<CMD_SEND_VEHICLE_TO_DEPOT>::Post(GetCmdSendToDepotMsg(this->vli.vtype), INVALID_VEHICLE, DepotCommand::MassSend | (index == ADI_SERVICE ? DepotCommand::Service : DepotCommand::None), this->vli);
 						break;
 					}
 

--- a/src/script/api/script_order.cpp
+++ b/src/script/api/script_order.cpp
@@ -680,7 +680,7 @@ static void _DoCommandReturnSetOrderFlags(class ScriptInstance *instance)
 	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ScriptVehicle::IsPrimaryVehicle(vehicle_id));
 
-	return ScriptObject::Command<CMD_CLONE_ORDER>::Do(0, CO_UNSHARE, vehicle_id, 0);
+	return ScriptObject::Command<CMD_CLONE_ORDER>::Do(0, CO_UNSHARE, vehicle_id, ::INVALID_VEHICLE);
 }
 
 /* static */ SQInteger ScriptOrder::GetOrderDistance(ScriptVehicle::VehicleType vehicle_type, TileIndex origin_tile, TileIndex dest_tile)

--- a/src/script/api/script_vehicle.hpp
+++ b/src/script/api/script_vehicle.hpp
@@ -93,7 +93,7 @@ public:
 		VS_INVALID = 0xFF, ///< An invalid vehicle state.
 	};
 
-	static const VehicleID VEHICLE_INVALID = 0xFFFFF; ///< Invalid VehicleID.
+	static const VehicleID VEHICLE_INVALID = ::INVALID_VEHICLE; ///< Invalid VehicleID.
 
 	/**
 	 * Checks whether the given vehicle is valid and owned by you.

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -557,7 +557,7 @@ protected:
 				this->SetTimeout();
 				this->SetWidgetDirty(WID_SB_PAGE_PANEL);
 
-				Command<CMD_STORY_PAGE_BUTTON>::Post(TileIndex{}, pe.index, 0);
+				Command<CMD_STORY_PAGE_BUTTON>::Post(TileIndex{}, pe.index, INVALID_VEHICLE);
 				break;
 
 			case SPET_BUTTON_TILE:
@@ -906,7 +906,7 @@ public:
 			return;
 		}
 
-		Command<CMD_STORY_PAGE_BUTTON>::Post(tile, pe->index, 0);
+		Command<CMD_STORY_PAGE_BUTTON>::Post(tile, pe->index, INVALID_VEHICLE);
 		ResetObjectToPlace();
 	}
 

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2245,7 +2245,7 @@ public:
 						break;
 					case ADI_SERVICE: // Send for servicing
 					case ADI_DEPOT: // Send to Depots
-						Command<CMD_SEND_VEHICLE_TO_DEPOT>::Post(GetCmdSendToDepotMsg(this->vli.vtype), 0, DepotCommand::MassSend | (index == ADI_SERVICE ? DepotCommand::Service : DepotCommand::None), this->vli);
+						Command<CMD_SEND_VEHICLE_TO_DEPOT>::Post(GetCmdSendToDepotMsg(this->vli.vtype), INVALID_VEHICLE, DepotCommand::MassSend | (index == ADI_SERVICE ? DepotCommand::Service : DepotCommand::None), this->vli);
 						break;
 
 					case ADI_CREATE_GROUP: // Create group


### PR DESCRIPTION
## Motivation / Problem

While trying to make `Vehicle` an enum, my compiler started complaining about the constructor of `DisasterVehicle`. It was assigning a `VehicleType` enum value to a `VehicleID`, specifically `VEH_INVALID` or `0xFF` as the target for the big UFO destroyer. That's not an invalid vehicle, it could be valid!

Associated with that are few `0`s that get converted into `VehicleID`. Wouldn't it be better to pass `VEHICLE_INVALID` to really denote you really mean it to be not a valid vehicle?


## Description

Actually use `VEHICLE_INVALID` over the 'alternatives'.


## Limitations

Technically save games still have the bad destroyer target, but nothing was harmed by that so leave it as is. After all, only the big UFO destroyer uses that field and if/when you want to use that field for other disaster vehicles, you have to account for way more garbage that could have been written into there in the past.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
