### PR TITLE
Codechange: Use member initialisation for GRFConfig instead of ZeroedMemoryAllocator.

### DIFF
--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -29,19 +29,11 @@
 
 #include "safeguards.h"
 
-
-/**
- * Create a new GRFConfig.
- * @param filename Set the filename of this GRFConfig to filename.
- */
-GRFConfig::GRFConfig(const std::string &filename) : filename(filename), num_valid_params(MAX_NUM_PARAMS) {}
-
 /**
  * Create a new GRFConfig that is a deep copy of an existing config.
  * @param config The GRFConfig object to make a copy of.
  */
 GRFConfig::GRFConfig(const GRFConfig &config) :
-	ZeroedMemoryAllocator(),
 	ident(config.ident),
 	original_md5sum(config.original_md5sum),
 	filename(config.filename),

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -11,7 +11,6 @@
 #define NEWGRF_CONFIG_H
 
 #include "strings_type.h"
-#include "core/alloc_type.hpp"
 #include "fileio_type.h"
 #include "textfile_type.h"
 #include "newgrf_text.h"
@@ -152,35 +151,36 @@ struct GRFParameterInfo {
 };
 
 /** Information about GRF, used in the game and (part of it) in savegames */
-struct GRFConfig : ZeroedMemoryAllocator {
+struct GRFConfig {
 	static constexpr uint8_t MAX_NUM_PARAMS = 0x80;
 
-	GRFConfig(const std::string &filename = std::string{});
+	GRFConfig() = default;
+	GRFConfig(const std::string &filename) : filename(filename) {}
 	GRFConfig(const GRFConfig &config);
 
 	/* Remove the copy assignment, as the default implementation will not do the right thing. */
 	GRFConfig &operator=(GRFConfig &rhs) = delete;
 
-	GRFIdentifier ident; ///< grfid and md5sum to uniquely identify newgrfs
-	MD5Hash original_md5sum; ///< MD5 checksum of original file if only a 'compatible' file was loaded
-	std::string filename; ///< Filename - either with or without full path
-	GRFTextWrapper name; ///< NOSAVE: GRF name (Action 0x08)
-	GRFTextWrapper info; ///< NOSAVE: GRF info (author, copyright, ...) (Action 0x08)
-	GRFTextWrapper url; ///< NOSAVE: URL belonging to this GRF.
-	std::optional<GRFError> error; ///< NOSAVE: Error/Warning during GRF loading (Action 0x0B)
+	GRFIdentifier ident{}; ///< grfid and md5sum to uniquely identify newgrfs
+	MD5Hash original_md5sum{}; ///< MD5 checksum of original file if only a 'compatible' file was loaded
+	std::string filename{}; ///< Filename - either with or without full path
+	GRFTextWrapper name{}; ///< NOSAVE: GRF name (Action 0x08)
+	GRFTextWrapper info{}; ///< NOSAVE: GRF info (author, copyright, ...) (Action 0x08)
+	GRFTextWrapper url{}; ///< NOSAVE: URL belonging to this GRF.
+	std::optional<GRFError> error = std::nullopt; ///< NOSAVE: Error/Warning during GRF loading (Action 0x0B)
 
-	uint32_t version; ///< NOSAVE: Version a NewGRF can set so only the newest NewGRF is shown
-	uint32_t min_loadable_version; ///< NOSAVE: Minimum compatible version a NewGRF can define
-	uint8_t flags; ///< NOSAVE: GCF_Flags, bitset
-	GRFStatus status; ///< NOSAVE: GRFStatus, enum
-	uint32_t grf_bugs; ///< NOSAVE: bugs in this GRF in this run, @see enum GRFBugs
-	uint8_t num_valid_params; ///< NOSAVE: Number of valid parameters (action 0x14)
-	uint8_t palette; ///< GRFPalette, bitset
-	bool has_param_defaults; ///< NOSAVE: did this newgrf specify any defaults for it's parameters
+	uint32_t version = 0; ///< NOSAVE: Version a NewGRF can set so only the newest NewGRF is shown
+	uint32_t min_loadable_version = 0; ///< NOSAVE: Minimum compatible version a NewGRF can define
+	uint8_t flags = 0; ///< NOSAVE: GCF_Flags, bitset
+	GRFStatus status = GCS_UNKNOWN; ///< NOSAVE: GRFStatus, enum
+	uint32_t grf_bugs = 0; ///< NOSAVE: bugs in this GRF in this run, @see enum GRFBugs
+	uint8_t num_valid_params = MAX_NUM_PARAMS; ///< NOSAVE: Number of valid parameters (action 0x14)
+	uint8_t palette = 0; ///< GRFPalette, bitset
+	bool has_param_defaults = false; ///< NOSAVE: did this newgrf specify any defaults for it's parameters
 	std::vector<std::optional<GRFParameterInfo>> param_info; ///< NOSAVE: extra information about the parameters
 	std::vector<uint32_t> param; ///< GRF parameters
 
-	struct GRFConfig *next; ///< NOSAVE: Next item in the linked list
+	struct GRFConfig *next = nullptr; ///< NOSAVE: Next item in the linked list
 
 	bool IsCompatible(uint32_t old_version) const;
 	void SetParams(std::span<const uint32_t> pars);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`ZeroedMemoryAllocator` is a bit a of kludge.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Remove use of it for `GRFConfig`, prefer member initialisation instead.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
