### PR TITLE
Doc: Change MapSize to Map::Size

### DIFF
--- a/src/tgp.cpp
+++ b/src/tgp.cpp
@@ -84,7 +84,7 @@
  *
  * I will try to explain it on the example below:
  *
- * Have a map of 4 x 4 tiles, our simplified noise generator produces only two
+ * Have a map of 4x4 tiles, our simplified noise generator produces only two
  * values -1 and +1, use 3 octaves with wave length 1, 2 and 4, with amplitudes
  * 3, 2, 1. Original algorithm produces:
  *
@@ -157,7 +157,7 @@ static const int HEIGHT_DECIMAL_BITS = 4;
 using Amplitude = int;
 static const int AMPLITUDE_DECIMAL_BITS = 10;
 
-/** Height map - allocated array of heights (Map::SizeX() + 1) x (Map::SizeY() + 1) */
+/** Height map - allocated array of heights (Map::SizeX() + 1) * (Map::SizeY() + 1) */
 struct HeightMap
 {
 	std::vector<Height> h; //< array of heights

--- a/src/tgp.cpp
+++ b/src/tgp.cpp
@@ -157,7 +157,7 @@ static const int HEIGHT_DECIMAL_BITS = 4;
 using Amplitude = int;
 static const int AMPLITUDE_DECIMAL_BITS = 10;
 
-/** Height map - allocated array of heights (MapSizeX() + 1) x (MapSizeY() + 1) */
+/** Height map - allocated array of heights (Map::SizeX() + 1) x (Map::SizeY() + 1) */
 struct HeightMap
 {
 	std::vector<Height> h; //< array of heights
@@ -312,7 +312,7 @@ static inline bool IsValidXY(int x, int y)
 
 
 /**
- * Allocate array of (MapSizeX()+1)*(MapSizeY()+1) heights and init the _height_map structure members
+ * Allocate array of (Map::SizeX() + 1) * (Map::SizeY() + 1) heights and init the _height_map structure members
  * @return true on success
  */
 static inline bool AllocHeightMap()


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
`MapSizeX` and `MapSizeY` is no longer in use.
We have `4 x 4` map size notation and `64x64` and `4096x4096`.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Change to `Map::SizeX` and `Map::SizeY`. Also add some spacing where appropriate.
Standardize map size notation:
- `4x4` if not referring to code. Use `x` without spacing
- `(Map::SizeX() + 1) * (Map::SizeY() + 1)`. Use ` * ` with spacing when referring code.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
None.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
