### PR TITLE
Codechange: use StoryPageID instead of uint16_t

### DIFF
--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -136,7 +136,7 @@ struct GoalListWindow : public Window {
 				CompanyID story_company = StoryPage::Get(s->dst)->company;
 				if (goal_company == INVALID_COMPANY ? story_company != INVALID_COMPANY : story_company != INVALID_COMPANY && story_company != goal_company) return;
 
-				ShowStoryBook((CompanyID)this->window_number, s->dst);
+				ShowStoryBook(static_cast<CompanyID>(this->window_number), static_cast<StoryPageID>(s->dst));
 				return;
 			}
 

--- a/src/gui.h
+++ b/src/gui.h
@@ -65,7 +65,7 @@ void ShowGoalsList(CompanyID company);
 void ShowGoalQuestion(uint16_t id, uint8_t type, uint32_t button_mask, const std::string &question);
 
 /* story_gui.cpp */
-void ShowStoryBook(CompanyID company, uint16_t page_id = INVALID_STORY_PAGE, bool centered = false);
+void ShowStoryBook(CompanyID company, StoryPageID page_id = INVALID_STORY_PAGE, bool centered = false);
 
 /* viewport_gui.cpp */
 void ShowExtraViewportWindow(TileIndex tile = INVALID_TILE);

--- a/src/league_gui.cpp
+++ b/src/league_gui.cpp
@@ -240,7 +240,7 @@ static void HandleLinkClick(Link link)
 		case LT_STORY_PAGE: {
 			if (!StoryPage::IsValidID(link.target)) return;
 			CompanyID story_company = StoryPage::Get(link.target)->company;
-			ShowStoryBook(story_company, link.target);
+			ShowStoryBook(story_company, static_cast<StoryPageID>(link.target));
 			return;
 		}
 

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -630,7 +630,7 @@ public:
 	 * Sets the selected page.
 	 * @param page_index pool index of the page to select.
 	 */
-	void SetSelectedPage(uint16_t page_index)
+	void SetSelectedPage(StoryPageID page_index)
 	{
 		if (this->selected_page_id != page_index) {
 			if (this->active_button_id) ResetObjectToPlace();
@@ -845,7 +845,7 @@ public:
 		if (widget != WID_SB_SEL_PAGE) return;
 
 		/* index (which is set in BuildDropDownList) is the page id. */
-		this->SetSelectedPage(index);
+		this->SetSelectedPage(static_cast<StoryPageID>(index));
 	}
 
 	/**
@@ -1048,7 +1048,7 @@ static CursorID TranslateStoryPageButtonCursor(StoryPageButtonCursor cursor)
  * @param page_id Page to open, may be #INVALID_STORY_PAGE.
  * @param centered Whether to open the window centered.
  */
-void ShowStoryBook(CompanyID company, uint16_t page_id, bool centered)
+void ShowStoryBook(CompanyID company, StoryPageID page_id, bool centered)
 {
 	if (!Company::IsValidID(company)) company = (CompanyID)INVALID_COMPANY;
 


### PR DESCRIPTION
## Motivation / Problem

Using `uint16_t` when `StoryPageID` is meant.


## Description

Change `uint16_t` to `StoryPageID` in a few functions.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
