### PR TITLE
Change: [Script] rename BridgeID to BridgeType in the script API

### DIFF
--- a/bin/ai/compat_0.7.nut
+++ b/bin/ai/compat_0.7.nut
@@ -392,3 +392,6 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/ai/compat_1.0.nut
+++ b/bin/ai/compat_1.0.nut
@@ -144,3 +144,6 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/ai/compat_1.1.nut
+++ b/bin/ai/compat_1.1.nut
@@ -81,3 +81,6 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/ai/compat_1.10.nut
+++ b/bin/ai/compat_1.10.nut
@@ -19,3 +19,6 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/ai/compat_1.11.nut
+++ b/bin/ai/compat_1.11.nut
@@ -19,3 +19,6 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/ai/compat_1.2.nut
+++ b/bin/ai/compat_1.2.nut
@@ -33,3 +33,6 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/ai/compat_1.3.nut
+++ b/bin/ai/compat_1.3.nut
@@ -33,3 +33,6 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/ai/compat_1.4.nut
+++ b/bin/ai/compat_1.4.nut
@@ -33,3 +33,6 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/ai/compat_1.5.nut
+++ b/bin/ai/compat_1.5.nut
@@ -33,3 +33,6 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/ai/compat_1.6.nut
+++ b/bin/ai/compat_1.6.nut
@@ -33,3 +33,6 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/ai/compat_1.7.nut
+++ b/bin/ai/compat_1.7.nut
@@ -33,3 +33,6 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/ai/compat_1.8.nut
+++ b/bin/ai/compat_1.8.nut
@@ -33,3 +33,6 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/ai/compat_1.9.nut
+++ b/bin/ai/compat_1.9.nut
@@ -19,3 +19,6 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/ai/compat_12.nut
+++ b/bin/ai/compat_12.nut
@@ -19,3 +19,6 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/ai/compat_13.nut
+++ b/bin/ai/compat_13.nut
@@ -6,3 +6,6 @@
  */
 
 AILog.Info("13 API compatibility in effect.");
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/ai/compat_14.nut
+++ b/bin/ai/compat_14.nut
@@ -6,3 +6,6 @@
  */
 
 AILog.Info("14 API compatibility in effect.");
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/game/compat_1.10.nut
+++ b/bin/game/compat_1.10.nut
@@ -26,3 +26,6 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/game/compat_1.11.nut
+++ b/bin/game/compat_1.11.nut
@@ -19,3 +19,6 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/game/compat_1.2.nut
+++ b/bin/game/compat_1.2.nut
@@ -48,3 +48,6 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/game/compat_1.3.nut
+++ b/bin/game/compat_1.3.nut
@@ -48,3 +48,6 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/game/compat_1.4.nut
+++ b/bin/game/compat_1.4.nut
@@ -40,3 +40,6 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/game/compat_1.5.nut
+++ b/bin/game/compat_1.5.nut
@@ -33,3 +33,6 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/game/compat_1.6.nut
+++ b/bin/game/compat_1.6.nut
@@ -33,3 +33,6 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/game/compat_1.7.nut
+++ b/bin/game/compat_1.7.nut
@@ -33,3 +33,6 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/game/compat_1.8.nut
+++ b/bin/game/compat_1.8.nut
@@ -33,3 +33,6 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/game/compat_1.9.nut
+++ b/bin/game/compat_1.9.nut
@@ -26,3 +26,6 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/game/compat_12.nut
+++ b/bin/game/compat_12.nut
@@ -19,3 +19,6 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/game/compat_13.nut
+++ b/bin/game/compat_13.nut
@@ -6,3 +6,6 @@
  */
 
 GSLog.Info("13 API compatibility in effect.");
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/bin/game/compat_14.nut
+++ b/bin/game/compat_14.nut
@@ -6,3 +6,6 @@
  */
 
 GSLog.Info("14 API compatibility in effect.");
+
+/* 15 renames GetBridgeID */
+AIBridge.GetBridgeID <- AIBridge.GetBridgeType;

--- a/regression/regression/main.nut
+++ b/regression/regression/main.nut
@@ -265,15 +265,15 @@ function Regression::Bridge()
 	print("  Valid Bridges:        " + j);
 
 	print("  IsBridgeTile():       " + AIBridge.IsBridgeTile(33160));
-	print("  GetBridgeID():        " + AIBridge.GetBridgeID(33160));
+	print("  GetBridgeType():      " + AIBridge.GetBridgeType(33160));
 	print("  RemoveBridge():       " + AIBridge.RemoveBridge(33155));
 	print("  GetLastErrorString(): " + AIError.GetLastErrorString());
 	print("  GetOtherBridgeEnd():  " + AIBridge.GetOtherBridgeEnd(33160));
 	print("  BuildBridge():        " + AIBridge.BuildBridge(AIVehicle.VT_ROAD, 5, 33160, 33155));
 	print("  IsBridgeTile():       " + AIBridge.IsBridgeTile(33160));
-	print("  GetBridgeID():        " + AIBridge.GetBridgeID(33160));
+	print("  GetBridgeType():      " + AIBridge.GetBridgeType(33160));
 	print("  IsBridgeTile():       " + AIBridge.IsBridgeTile(33155));
-	print("  GetBridgeID():        " + AIBridge.GetBridgeID(33155));
+	print("  GetBridgeType():      " + AIBridge.GetBridgeType(33155));
 	print("  GetOtherBridgeEnd():  " + AIBridge.GetOtherBridgeEnd(33160));
 	print("  BuildBridge():        " + AIBridge.BuildBridge(AIVehicle.VT_ROAD, 5, 33160, 33155));
 	print("  GetLastErrorString(): " + AIError.GetLastErrorString());

--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -1051,15 +1051,15 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetMinLength():     -1
   Valid Bridges:        10
   IsBridgeTile():       false
-  GetBridgeID():        -1
+  GetBridgeType():      -1
   RemoveBridge():       false
   GetLastErrorString(): ERR_PRECONDITION_FAILED
   GetOtherBridgeEnd():  -1
   BuildBridge():        true
   IsBridgeTile():       true
-  GetBridgeID():        5
+  GetBridgeType():      5
   IsBridgeTile():       true
-  GetBridgeID():        5
+  GetBridgeType():      5
   GetOtherBridgeEnd():  33155
   BuildBridge():        false
   GetLastErrorString(): ERR_ALREADY_BUILT

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -22,6 +22,9 @@
  * \li AIEventCompanyRenamed
  * \li AIEventPresidentRenamed
  *
+ * Other changes:
+ * \li AIBridge::GetBridgeID renamed to AIBridge::GetBridgeType
+ *
  * \b 14.0
  *
  * API additions:

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -22,6 +22,9 @@
  * \li GSEventCompanyRenamed
  * \li GSEventPresidentRenamed
  *
+ * Other changes:
+ * \li GSBridge::GetBridgeID renamed to GSBridge::GetBridgeType
+ *
  * \b 14.0
  *
  * API additions:

--- a/src/script/api/script_bridge.cpp
+++ b/src/script/api/script_bridge.cpp
@@ -21,9 +21,9 @@
 
 #include "../../safeguards.h"
 
-/* static */ bool ScriptBridge::IsValidBridge(BridgeID bridge_id)
+/* static */ bool ScriptBridge::IsValidBridge(BridgeType bridge_type)
 {
-	return bridge_id < MAX_BRIDGES && ::GetBridgeSpec(bridge_id)->avail_year <= TimerGameCalendar::year;
+	return bridge_type < MAX_BRIDGES && ::GetBridgeSpec(bridge_type)->avail_year <= TimerGameCalendar::year;
 }
 
 /* static */ bool ScriptBridge::IsBridgeTile(TileIndex tile)
@@ -32,10 +32,10 @@
 	return ::IsBridgeTile(tile);
 }
 
-/* static */ BridgeID ScriptBridge::GetBridgeID(TileIndex tile)
+/* static */ BridgeType ScriptBridge::GetBridgeType(TileIndex tile)
 {
-	if (!IsBridgeTile(tile)) return (BridgeID)-1;
-	return (BridgeID)::GetBridgeType(tile);
+	if (!IsBridgeTile(tile)) return (BridgeType)-1;
+	return (BridgeType)::GetBridgeType(tile);
 }
 
 /**
@@ -70,7 +70,7 @@ static void _DoCommandReturnBuildBridge1(class ScriptInstance *instance)
 	NOT_REACHED();
 }
 
-/* static */ bool ScriptBridge::BuildBridge(ScriptVehicle::VehicleType vehicle_type, BridgeID bridge_id, TileIndex start, TileIndex end)
+/* static */ bool ScriptBridge::BuildBridge(ScriptVehicle::VehicleType vehicle_type, BridgeType bridge_type, TileIndex start, TileIndex end)
 {
 	EnforceDeityOrCompanyModeValid(false);
 	EnforcePrecondition(false, start != end);
@@ -85,11 +85,11 @@ static void _DoCommandReturnBuildBridge1(class ScriptInstance *instance)
 		case ScriptVehicle::VT_ROAD:
 			ScriptObject::SetCallbackVariable(0, start.base());
 			ScriptObject::SetCallbackVariable(1, end.base());
-			return ScriptObject::Command<CMD_BUILD_BRIDGE>::Do(&::_DoCommandReturnBuildBridge1, end, start, TRANSPORT_ROAD, bridge_id, ScriptRoad::GetCurrentRoadType());
+			return ScriptObject::Command<CMD_BUILD_BRIDGE>::Do(&::_DoCommandReturnBuildBridge1, end, start, TRANSPORT_ROAD, bridge_type, ScriptRoad::GetCurrentRoadType());
 		case ScriptVehicle::VT_RAIL:
-			return ScriptObject::Command<CMD_BUILD_BRIDGE>::Do(end, start, TRANSPORT_RAIL, bridge_id, ScriptRail::GetCurrentRailType());
+			return ScriptObject::Command<CMD_BUILD_BRIDGE>::Do(end, start, TRANSPORT_RAIL, bridge_type, ScriptRail::GetCurrentRailType());
 		case ScriptVehicle::VT_WATER:
-			return ScriptObject::Command<CMD_BUILD_BRIDGE>::Do(end, start, TRANSPORT_WATER, bridge_id, 0);
+			return ScriptObject::Command<CMD_BUILD_BRIDGE>::Do(end, start, TRANSPORT_WATER, bridge_type, 0);
 		default: NOT_REACHED();
 	}
 }
@@ -129,42 +129,42 @@ static void _DoCommandReturnBuildBridge1(class ScriptInstance *instance)
 	return ScriptObject::Command<CMD_LANDSCAPE_CLEAR>::Do(tile);
 }
 
-/* static */ std::optional<std::string> ScriptBridge::GetName(BridgeID bridge_id, ScriptVehicle::VehicleType vehicle_type)
+/* static */ std::optional<std::string> ScriptBridge::GetName(BridgeType bridge_type, ScriptVehicle::VehicleType vehicle_type)
 {
 	EnforcePrecondition(std::nullopt, vehicle_type == ScriptVehicle::VT_ROAD || vehicle_type == ScriptVehicle::VT_RAIL || vehicle_type == ScriptVehicle::VT_WATER);
-	if (!IsValidBridge(bridge_id)) return std::nullopt;
+	if (!IsValidBridge(bridge_type)) return std::nullopt;
 
-	return GetString(vehicle_type == ScriptVehicle::VT_WATER ? STR_LAI_BRIDGE_DESCRIPTION_AQUEDUCT : ::GetBridgeSpec(bridge_id)->transport_name[vehicle_type]);
+	return GetString(vehicle_type == ScriptVehicle::VT_WATER ? STR_LAI_BRIDGE_DESCRIPTION_AQUEDUCT : ::GetBridgeSpec(bridge_type)->transport_name[vehicle_type]);
 }
 
-/* static */ SQInteger ScriptBridge::GetMaxSpeed(BridgeID bridge_id)
+/* static */ SQInteger ScriptBridge::GetMaxSpeed(BridgeType bridge_type)
 {
-	if (!IsValidBridge(bridge_id)) return -1;
+	if (!IsValidBridge(bridge_type)) return -1;
 
-	return ::GetBridgeSpec(bridge_id)->speed; // km-ish/h
+	return ::GetBridgeSpec(bridge_type)->speed; // km-ish/h
 }
 
-/* static */ Money ScriptBridge::GetPrice(BridgeID bridge_id, SQInteger length)
+/* static */ Money ScriptBridge::GetPrice(BridgeType bridge_type, SQInteger length)
 {
-	if (!IsValidBridge(bridge_id)) return -1;
+	if (!IsValidBridge(bridge_type)) return -1;
 
 	length = Clamp<SQInteger>(length, 0, INT32_MAX);
 
-	return ::CalcBridgeLenCostFactor(length) * _price[PR_BUILD_BRIDGE] * ::GetBridgeSpec(bridge_id)->price >> 8;
+	return ::CalcBridgeLenCostFactor(length) * _price[PR_BUILD_BRIDGE] * ::GetBridgeSpec(bridge_type)->price >> 8;
 }
 
-/* static */ SQInteger ScriptBridge::GetMaxLength(BridgeID bridge_id)
+/* static */ SQInteger ScriptBridge::GetMaxLength(BridgeType bridge_type)
 {
-	if (!IsValidBridge(bridge_id)) return -1;
+	if (!IsValidBridge(bridge_type)) return -1;
 
-	return std::min<SQInteger>(::GetBridgeSpec(bridge_id)->max_length, _settings_game.construction.max_bridge_length) + 2;
+	return std::min<SQInteger>(::GetBridgeSpec(bridge_type)->max_length, _settings_game.construction.max_bridge_length) + 2;
 }
 
-/* static */ SQInteger ScriptBridge::GetMinLength(BridgeID bridge_id)
+/* static */ SQInteger ScriptBridge::GetMinLength(BridgeType bridge_type)
 {
-	if (!IsValidBridge(bridge_id)) return -1;
+	if (!IsValidBridge(bridge_type)) return -1;
 
-	return static_cast<SQInteger>(::GetBridgeSpec(bridge_id)->min_length) + 2;
+	return static_cast<SQInteger>(::GetBridgeSpec(bridge_type)->min_length) + 2;
 }
 
 /* static */ TileIndex ScriptBridge::GetOtherBridgeEnd(TileIndex tile)

--- a/src/script/api/script_bridge.hpp
+++ b/src/script/api/script_bridge.hpp
@@ -42,10 +42,10 @@ public:
 
 	/**
 	 * Checks whether the given bridge type is valid.
-	 * @param bridge_id The bridge to check.
+	 * @param bridge_type The bridge to check.
 	 * @return True if and only if the bridge type is valid.
 	 */
-	static bool IsValidBridge(BridgeID bridge_id);
+	static bool IsValidBridge(BridgeType bridge_type);
 
 	/**
 	 * Checks whether the given tile is actually a bridge start or end tile.
@@ -56,59 +56,59 @@ public:
 	static bool IsBridgeTile(TileIndex tile);
 
 	/**
-	 * Get the BridgeID of a bridge at a given tile.
-	 * @param tile The tile to get the BridgeID from.
+	 * Get the BridgeType of a bridge at a given tile.
+	 * @param tile The tile to get the BridgeType from.
 	 * @pre IsBridgeTile(tile).
-	 * @return The BridgeID from the bridge at tile 'tile'.
+	 * @return The BridgeType from the bridge at tile 'tile'.
 	 */
-	static BridgeID GetBridgeID(TileIndex tile);
+	static BridgeType GetBridgeType(TileIndex tile);
 
 	/**
 	 * Get the name of a bridge.
-	 * @param bridge_id The bridge to get the name of.
+	 * @param bridge_type The bridge to get the name of.
 	 * @param vehicle_type The vehicle-type of bridge to get the name of.
-	 * @pre IsValidBridge(bridge_id).
+	 * @pre IsValidBridge(bridge_type).
 	 * @pre vehicle_type == ScriptVehicle::VT_ROAD || vehicle_type == ScriptVehicle::VT_RAIL || vehicle_type == ScriptVehicle::VT_WATER
 	 * @return The name the bridge has.
 	 */
-	static std::optional<std::string> GetName(BridgeID bridge_id, ScriptVehicle::VehicleType vehicle_type);
+	static std::optional<std::string> GetName(BridgeType bridge_type, ScriptVehicle::VehicleType vehicle_type);
 
 	/**
 	 * Get the maximum speed of a bridge.
-	 * @param bridge_id The bridge to get the maximum speed of.
-	 * @pre IsValidBridge(bridge_id).
+	 * @param bridge_type The bridge to get the maximum speed of.
+	 * @pre IsValidBridge(bridge_type).
 	 * @return The maximum speed the bridge has.
 	 * @note The speed is in OpenTTD's internal speed unit.
 	 *       This is mph / 1.6, which is roughly km/h.
 	 *       To get km/h multiply this number by 1.00584.
 	 */
-	static SQInteger GetMaxSpeed(BridgeID bridge_id);
+	static SQInteger GetMaxSpeed(BridgeType bridge_type);
 
 	/**
 	 * Get the new cost of a bridge, excluding the road and/or rail.
-	 * @param bridge_id The bridge to get the new cost of.
+	 * @param bridge_type The bridge to get the new cost of.
 	 * @param length The length of the bridge.
 	 *               The value will be clamped to 0 .. MAX(int32_t).
-	 * @pre IsValidBridge(bridge_id).
+	 * @pre IsValidBridge(bridge_type).
 	 * @return The new cost the bridge has.
 	 */
-	static Money GetPrice(BridgeID bridge_id, SQInteger length);
+	static Money GetPrice(BridgeType bridge_type, SQInteger length);
 
 	/**
 	 * Get the maximum length of a bridge.
-	 * @param bridge_id The bridge to get the maximum length of.
-	 * @pre IsValidBridge(bridge_id).
+	 * @param bridge_type The bridge to get the maximum length of.
+	 * @pre IsValidBridge(bridge_type).
 	 * @returns The maximum length the bridge has.
 	 */
-	static SQInteger GetMaxLength(BridgeID bridge_id);
+	static SQInteger GetMaxLength(BridgeType bridge_type);
 
 	/**
 	 * Get the minimum length of a bridge.
-	 * @param bridge_id The bridge to get the minimum length of.
-	 * @pre IsValidBridge(bridge_id).
+	 * @param bridge_type The bridge to get the minimum length of.
+	 * @pre IsValidBridge(bridge_type).
 	 * @returns The minimum length the bridge has.
 	 */
-	static SQInteger GetMinLength(BridgeID bridge_id);
+	static SQInteger GetMinLength(BridgeType bridge_type);
 
 	/**
 	 * Internal function to help BuildBridge in case of road.
@@ -128,7 +128,7 @@ public:
 	 *  each end of the bridge, making it easier for you to connect it to your
 	 *  network.
 	 * @param vehicle_type The vehicle-type of bridge to build.
-	 * @param bridge_id The bridge-type to build.
+	 * @param bridge_type The bridge-type to build.
 	 * @param start Where to start the bridge.
 	 * @param end Where to end the bridge.
 	 * @pre ScriptMap::IsValidTile(start).
@@ -152,7 +152,7 @@ public:
 	 * @note No matter if the road pieces were build or not, if building the
 	 *  bridge succeeded, this function returns true.
 	 */
-	static bool BuildBridge(ScriptVehicle::VehicleType vehicle_type, BridgeID bridge_id, TileIndex start, TileIndex end);
+	static bool BuildBridge(ScriptVehicle::VehicleType vehicle_type, BridgeType bridge_type, TileIndex start, TileIndex end);
 
 	/**
 	 * Removes a bridge, by executing it on either the start or end tile.

--- a/src/script/api/script_types.hpp
+++ b/src/script/api/script_types.hpp
@@ -21,7 +21,7 @@
  *                           <th> acquired                                          </th>
  *                           <th> released                                          </th>
  *                           <th> reused                                            </th></tr>
- * <tr><td>#BridgeID    </td><td> bridge type                                       </td>
+ * <tr><td>#BridgeType  </td><td> bridge type                                       </td>
  *                           <td> introduction \ref newgrf_changes "(1)"            </td>
  *                           <td> never \ref newgrf_changes "(1)"                   </td>
  *                           <td> no \ref newgrf_changes "(1)"                      </td></tr>
@@ -110,7 +110,7 @@
 #include <squirrel.h>
 
 /* Define all types here, so they are added to the API docs. */
-typedef uint BridgeID;         ///< The ID of a bridge type.
+typedef uint BridgeType;       ///< The ID of a bridge type.
 typedef uint8_t CargoID;       ///< The ID of a cargo.
 typedef uint16_t EngineID;     ///< The ID of an engine.
 typedef uint16_t GoalID;       ///< The ID of a goal.


### PR DESCRIPTION
## Motivation / Problem

In the game we have `BridgeType`, but in script-land it's called `BridgeID`.

Generically we have `...Type` for the different variants of `...`, whereas `...ID` is used for the different instances. For example `IndustryType` describes the sort of industry (i.e. the specification), whereas `IndustryID` is the identifier of a unique instance.

This holds true for every of the `typedef`s in 'script_type.hpp', except for bridges. In the normal game code it is correctly named `BridgeType` but in the script world it has become `BridgeID`.

Side note: it makes things much easier when the types in the game and script world are the same.


## Description

Rename `BridgeID` to `BridgeType` in the API, including function names.
This change is added to the compatibility layer.


## Limitations

Scripts running on 'compat-version' 15 that do use `GetBridgeID` will be broken. But then the documentation clearly states the API is not stable yet.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
