### PR TITLE
Codechange: [Script] do not redefine types in the script API

### DIFF
--- a/src/script/api/script_airport.hpp
+++ b/src/script/api/script_airport.hpp
@@ -12,6 +12,7 @@
 
 #include "script_object.hpp"
 #include "../../airport.h"
+#include "../../station_type.h"
 
 /**
  * Class that handles all airport related functions.

--- a/src/script/api/script_basestation.hpp
+++ b/src/script/api/script_basestation.hpp
@@ -12,6 +12,7 @@
 
 #include "script_text.hpp"
 #include "script_date.hpp"
+#include "../../station_type.h"
 
 /**
  * Base class for stations and waypoints.

--- a/src/script/api/script_bridge.hpp
+++ b/src/script/api/script_bridge.hpp
@@ -11,6 +11,7 @@
 #define SCRIPT_BRIDGE_HPP
 
 #include "script_vehicle.hpp"
+#include "../../bridge.h"
 
 /**
  * Class that handles all bridge related functions.

--- a/src/script/api/script_cargolist.hpp
+++ b/src/script/api/script_cargolist.hpp
@@ -11,6 +11,8 @@
 #define SCRIPT_CARGOLIST_HPP
 
 #include "script_list.hpp"
+#include "../../industry_type.h"
+#include "../../station_type.h"
 
 /**
  * Creates a list of cargoes that can be produced in the current game.

--- a/src/script/api/script_controller.hpp
+++ b/src/script/api/script_controller.hpp
@@ -11,6 +11,7 @@
 #define SCRIPT_CONTROLLER_HPP
 
 #include "script_types.hpp"
+#include "../../company_type.h"
 
 /**
  * The Controller, the class each Script should extend. It creates the Script,

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -13,6 +13,12 @@
 #include "script_event.hpp"
 #include "script_goal.hpp"
 #include "script_window.hpp"
+#include "../../engine_type.h"
+#include "../../industry_type.h"
+#include "../../station_type.h"
+#include "../../story_type.h"
+#include "../../subsidy_type.h"
+#include "../../vehicle_type.h"
 
 /**
  * Event Vehicle Crash, indicating a vehicle of yours is crashed.

--- a/src/script/api/script_industrytype.hpp
+++ b/src/script/api/script_industrytype.hpp
@@ -11,6 +11,7 @@
 #define SCRIPT_INDUSTRYTYPE_HPP
 
 #include "script_list.hpp"
+#include "../../industry_type.h"
 
 /**
  * Class that handles all industry-type related functions.

--- a/src/script/api/script_marine.hpp
+++ b/src/script/api/script_marine.hpp
@@ -11,6 +11,7 @@
 #define SCRIPT_MARINE_HPP
 
 #include "script_error.hpp"
+#include "../../station_type.h"
 
 /**
  * Class that handles all marine related functions.

--- a/src/script/api/script_rail.hpp
+++ b/src/script/api/script_rail.hpp
@@ -11,7 +11,9 @@
 #define SCRIPT_RAIL_HPP
 
 #include "script_tile.hpp"
+#include "../../industry_type.h"
 #include "../../signal_type.h"
+#include "../../station_type.h"
 #include "../../track_type.h"
 
 /**

--- a/src/script/api/script_sign.hpp
+++ b/src/script/api/script_sign.hpp
@@ -12,6 +12,7 @@
 
 #include "script_company.hpp"
 #include "script_error.hpp"
+#include "../../signs_type.h"
 
 /**
  * Class that handles all sign related functions.

--- a/src/script/api/script_subsidy.hpp
+++ b/src/script/api/script_subsidy.hpp
@@ -12,6 +12,7 @@
 
 #include "script_company.hpp"
 #include "script_date.hpp"
+#include "../../subsidy_type.h"
 
 /**
  * Class that handles all subsidy related functions.

--- a/src/script/api/script_tilelist.hpp
+++ b/src/script/api/script_tilelist.hpp
@@ -12,6 +12,7 @@
 
 #include "script_station.hpp"
 #include "script_list.hpp"
+#include "../../industry_type.h"
 
 /**
  * Creates an empty list, in which you can add tiles.

--- a/src/script/api/script_types.hpp
+++ b/src/script/api/script_types.hpp
@@ -108,24 +108,24 @@
 
 #ifdef DOXYGEN_API
 /* Define all types here, so they are added to the API docs. */
-typedef uint BridgeType;       ///< The ID of a bridge type.
-typedef uint8_t CargoType;     ///< The ID of a cargo type.
-typedef uint16_t EngineID;     ///< The ID of an engine.
-typedef uint16_t GoalID;       ///< The ID of a goal.
-typedef uint16_t GroupID;      ///< The ID of a group.
-typedef uint16_t IndustryID;   ///< The ID of an industry.
-typedef uint8_t IndustryType;  ///< The ID of an industry-type.
-typedef int64_t Money;         ///< Money, stored in a 32bit/64bit safe way. For scripts money is always in pounds.
-typedef uint16_t ObjectType;   ///< The ID of an object-type.
-typedef uint16_t SignID;       ///< The ID of a sign.
-typedef uint16_t StationID;    ///< The ID of a station.
-typedef uint32_t StringID;     ///< The ID of a string.
-typedef uint16_t SubsidyID;    ///< The ID of a subsidy.
-typedef uint16_t StoryPageID;  ///< The ID of a story page.
-typedef uint16_t StoryPageElementID; ///< The ID of a story page element.
-typedef uint32_t TileIndex;    ///< The ID of a map location.
-typedef uint16_t TownID;       ///< The ID of a town.
-typedef uint32_t VehicleID;    ///< The ID of a vehicle.
+using BridgeType = uint32_t; ///< The ID of a bridge type.
+using CargoType = uint8_t; ///< The ID of a cargo type.
+using EngineID = uint16_t; ///< The ID of an engine.
+using GoalID = uint16_t; ///< The ID of a goal.
+using GroupID = uint16_t; ///< The ID of a group.
+using IndustryID = uint16_t; ///< The ID of an industry.
+using IndustryType = uint8_t; ///< The ID of an industry-type.
+using Money = int64_t; ///< Money, stored in a 32bit/64bit safe way. For scripts money is always in pounds.
+using ObjectType = uint16_t; ///< The ID of an object-type.
+using SignID = uint16_t; ///< The ID of a sign.
+using StationID = uint16_t; ///< The ID of a station.
+using StringID = uint32_t; ///< The ID of a string.
+using SubsidyID = uint16_t; ///< The ID of a subsidy.
+using StoryPageID = uint16_t; ///< The ID of a story page.
+using StoryPageElementID = uint16_t; ///< The ID of a story page element.
+using TileIndex = uint32_t; ///< The ID of a map location.
+using TownID = uint16_t; ///< The ID of a town.
+using VehicleID = uint32_t; ///< The ID of a vehicle.
 #endif /* DOXYGEN_API */
 
 /**
@@ -133,6 +133,6 @@ typedef uint32_t VehicleID;    ///< The ID of a vehicle.
  *
  * Possible value are defined inside each API class in an ErrorMessages enum.
  */
-typedef uint ScriptErrorType;
+using ScriptErrorType = uint32_t;
 
 #endif /* SCRIPT_TYPES_HPP */

--- a/src/script/api/script_types.hpp
+++ b/src/script/api/script_types.hpp
@@ -104,11 +104,9 @@
 #ifndef SCRIPT_TYPES_HPP
 #define SCRIPT_TYPES_HPP
 
-#include "../../core/overflowsafe_type.hpp"
-#include "../../company_type.h"
-#include "../../tile_type.h"
 #include <squirrel.h>
 
+#ifdef DOXYGEN_API
 /* Define all types here, so they are added to the API docs. */
 typedef uint BridgeType;       ///< The ID of a bridge type.
 typedef uint8_t CargoType;     ///< The ID of a cargo type.
@@ -117,11 +115,7 @@ typedef uint16_t GoalID;       ///< The ID of a goal.
 typedef uint16_t GroupID;      ///< The ID of a group.
 typedef uint16_t IndustryID;   ///< The ID of an industry.
 typedef uint8_t IndustryType;  ///< The ID of an industry-type.
-#ifdef DOXYGEN_API
 typedef int64_t Money;         ///< Money, stored in a 32bit/64bit safe way. For scripts money is always in pounds.
-#else
-typedef OverflowSafeInt64 Money;
-#endif /* DOXYGEN_API */
 typedef uint16_t ObjectType;   ///< The ID of an object-type.
 typedef uint16_t SignID;       ///< The ID of a sign.
 typedef uint16_t StationID;    ///< The ID of a station.
@@ -129,11 +123,10 @@ typedef uint32_t StringID;     ///< The ID of a string.
 typedef uint16_t SubsidyID;    ///< The ID of a subsidy.
 typedef uint16_t StoryPageID;  ///< The ID of a story page.
 typedef uint16_t StoryPageElementID; ///< The ID of a story page element.
-#ifdef DOXYGEN_API
 typedef uint32_t TileIndex;    ///< The ID of a map location.
-#endif /* DOXYGEN_API */
 typedef uint16_t TownID;       ///< The ID of a town.
 typedef uint32_t VehicleID;    ///< The ID of a vehicle.
+#endif /* DOXYGEN_API */
 
 /**
  * The types of errors inside the script framework.

--- a/src/script/api/script_types.hpp
+++ b/src/script/api/script_types.hpp
@@ -29,6 +29,14 @@
  *                           <td> game start \ref newgrf_changes "(1)"              </td>
  *                           <td> never \ref newgrf_changes "(1)"                   </td>
  *                           <td> no \ref newgrf_changes "(1)"                      </td></tr>
+ * <tr><td>#ClientID    </td><td> network client (player)                           </td>
+ *                           <td> joining server                                    </td>
+ *                           <td> leaving server                                    </td>
+ *                           <td> no                                                </td></tr>
+ * <tr><td>#CompanyID   </td><td> company                                           </td>
+ *                           <td> launch                                            </td>
+ *                           <td> merger, bankruptcy                                </td>
+ *                           <td> yes                                               </td></tr>
  * <tr><td>#EngineID    </td><td> engine type                                       </td>
  *                           <td> introduction, preview \ref dynamic_engines "(2)"  </td>
  *                           <td> engines retires \ref dynamic_engines "(2)"        </td>
@@ -49,6 +57,14 @@
  *                           <td> game start \ref newgrf_changes "(1)"              </td>
  *                           <td> never \ref newgrf_changes "(1)"                   </td>
  *                           <td> no                                                </td></tr>
+ * <tr><td>#LeagueTableID</td><td> league table                                     </td>
+ *                           <td> creation                                          </td>
+ *                           <td> deletion                                          </td>
+ *                           <td> yes                                               </td></tr>
+ * <tr><td>#LeagueTableElementID</td><td> element of a league table                 </td>
+ *                           <td> creation                                          </td>
+ *                           <td> deletion                                          </td>
+ *                           <td> yes                                               </td></tr>
  * <tr><td>#ObjectType  </td><td> NewGRF object type                                </td>
  *                           <td> game start \ref newgrf_changes "(1)"              </td>
  *                           <td> never \ref newgrf_changes "(1)"                   </td>
@@ -110,12 +126,16 @@
 /* Define all types here, so they are added to the API docs. */
 using BridgeType = uint32_t; ///< The ID of a bridge type.
 using CargoType = uint8_t; ///< The ID of a cargo type.
+using ClientID = uint32_t; //< The ID of a (network) client.
+using CompanyID = uint8_t; ///< The ID of a company.
 using EngineID = uint16_t; ///< The ID of an engine.
 using GoalID = uint16_t; ///< The ID of a goal.
 using GroupID = uint16_t; ///< The ID of a group.
 using IndustryID = uint16_t; ///< The ID of an industry.
 using IndustryType = uint8_t; ///< The ID of an industry-type.
 using Money = int64_t; ///< Money, stored in a 32bit/64bit safe way. For scripts money is always in pounds.
+using LeagueTableID = uint8_t; ///< The ID of a league table.
+using LeagueTableElementID = uint16_t; ///< The ID of an element of a league table.
 using ObjectType = uint16_t; ///< The ID of an object-type.
 using SignID = uint16_t; ///< The ID of a sign.
 using StationID = uint16_t; ///< The ID of a station.

--- a/src/script/api/script_vehicle.hpp
+++ b/src/script/api/script_vehicle.hpp
@@ -11,6 +11,8 @@
 #define SCRIPT_VEHICLE_HPP
 
 #include "script_road.hpp"
+#include "../../engine_type.h"
+#include "../../group_type.h"
 
 /**
  * Class that handles all vehicle related functions.


### PR DESCRIPTION
## Motivation / Problem

In `script_types.hpp` there are quite a few types that are `typedef`-ed when there are also `typedef`-ed in another place in the source code.

This has been done primarily so the types get documented in the documentation. However, `TileIndex` is only defined when creating the documentation, and for `Money` it has different behaviour between normal and documentation.

Also some types are `#include`d in `script_types.hpp`, but not all. Which makes it highly inconsistent, and it would mean that any change to a header included there causes all of the script code to be recompiled.


## Description

* Move all the `typedef`s into an `#ifdef` so they are only visible when the documentation is generated.
* Remove all non-Squirrel headers from `script_types.hpp`
* Include `..._type.h` in the appropriate places.


## Limitations

~~Is built upon #13352, so that needs to be merged first or needs to be merged in combination with this. It is required as the difference between `BridgeID` and `BridgeType` needs to be reconciled.~~


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
