### PR TITLE
Codechange: rename CargoID to CargoType and amend related variables/comments

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -309,10 +309,10 @@ CommandCost CmdBuildAircraft(DoCommandFlag flags, TileIndex tile, const Engine *
 		u->refit_cap = 0;
 
 		v->cargo_type = e->GetDefaultCargoType();
-		assert(IsValidCargoID(v->cargo_type));
+		assert(IsValidCargoType(v->cargo_type));
 
-		CargoID mail = GetCargoIDByLabel(CT_MAIL);
-		if (IsValidCargoID(mail)) {
+		CargoType mail = GetCargoTypeByLabel(CT_MAIL);
+		if (IsValidCargoType(mail)) {
 			u->cargo_type = mail;
 			u->cargo_cap = avi->mail_capacity;
 		}

--- a/src/articulated_vehicles.h
+++ b/src/articulated_vehicles.h
@@ -19,7 +19,7 @@ CargoTypes GetCargoTypesOfArticulatedParts(EngineID engine);
 void AddArticulatedParts(Vehicle *first);
 void GetArticulatedRefitMasks(EngineID engine, bool include_initial_cargo_type, CargoTypes *union_mask, CargoTypes *intersection_mask);
 CargoTypes GetUnionOfArticulatedRefitMasks(EngineID engine, bool include_initial_cargo_type);
-CargoTypes GetCargoTypesOfArticulatedVehicle(const Vehicle *v, CargoID *cargo_type);
+CargoTypes GetCargoTypesOfArticulatedVehicle(const Vehicle *v, CargoType *cargo_type);
 bool IsArticulatedVehicleRefittable(EngineID engine);
 bool IsArticulatedEngine(EngineID engine_type);
 void CheckConsistencyOfArticulatedVehicle(const Vehicle *v);

--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -187,7 +187,7 @@ static bool VerifyAutoreplaceRefitForOrders(const Vehicle *v, EngineID engine_ty
 	const Vehicle *u = (v->type == VEH_TRAIN) ? v->First() : v;
 	for (const Order *o : u->Orders()) {
 		if (!o->IsRefit() || o->IsAutoRefit()) continue;
-		CargoID cargo_type = o->GetRefitCargo();
+		CargoType cargo_type = o->GetRefitCargo();
 
 		if (!HasBit(union_refit_mask_a, cargo_type)) continue;
 		if (!HasBit(union_refit_mask_b, cargo_type)) return false;
@@ -229,14 +229,14 @@ static int GetIncompatibleRefitOrderIdForAutoreplace(const Vehicle *v, EngineID 
  *    CARGO_NO_REFIT is returned if no refit is needed
  *    INVALID_CARGO is returned when both old and new vehicle got cargo capacity and refitting the new one to the old one's cargo type isn't possible
  */
-static CargoID GetNewCargoTypeForReplace(Vehicle *v, EngineID engine_type, bool part_of_chain)
+static CargoType GetNewCargoTypeForReplace(Vehicle *v, EngineID engine_type, bool part_of_chain)
 {
 	CargoTypes available_cargo_types, union_mask;
 	GetArticulatedRefitMasks(engine_type, true, &union_mask, &available_cargo_types);
 
 	if (union_mask == 0) return CARGO_NO_REFIT; // Don't try to refit an engine with no cargo capacity
 
-	CargoID cargo_type;
+	CargoType cargo_type;
 	CargoTypes cargo_mask = GetCargoTypesOfArticulatedVehicle(v, &cargo_type);
 	if (!HasAtMostOneBit(cargo_mask)) {
 		CargoTypes new_engine_default_cargoes = GetCargoTypesOfArticulatedParts(engine_type);
@@ -247,7 +247,7 @@ static CargoID GetNewCargoTypeForReplace(Vehicle *v, EngineID engine_type, bool 
 		return INVALID_CARGO; // We cannot refit to mixed cargoes in an automated way
 	}
 
-	if (!IsValidCargoID(cargo_type)) {
+	if (!IsValidCargoType(cargo_type)) {
 		if (v->type != VEH_TRAIN) return CARGO_NO_REFIT; // If the vehicle does not carry anything at all, every replacement is fine.
 
 		if (!part_of_chain) return CARGO_NO_REFIT;
@@ -330,8 +330,8 @@ static CommandCost BuildReplacementVehicle(Vehicle *old_veh, Vehicle **new_vehic
 	if (e == INVALID_ENGINE) return CommandCost(); // neither autoreplace is set, nor autorenew is triggered
 
 	/* Does it need to be refitted */
-	CargoID refit_cargo = GetNewCargoTypeForReplace(old_veh, e, part_of_chain);
-	if (!IsValidCargoID(refit_cargo)) {
+	CargoType refit_cargo = GetNewCargoTypeForReplace(old_veh, e, part_of_chain);
+	if (!IsValidCargoType(refit_cargo)) {
 		if (!IsLocalCompany() || (flags & DC_EXEC) == 0) return CommandCost();
 
 		VehicleID old_veh_id = (old_veh->type == VEH_TRAIN) ? Train::From(old_veh)->First()->index : old_veh->index;

--- a/src/cargo_type.h
+++ b/src/cargo_type.h
@@ -19,7 +19,7 @@ using CargoLabel = StrongType::Typedef<uint32_t, struct CargoLabelTag, StrongTyp
 /**
  * Cargo slots to indicate a cargo type within a game.
  */
-using CargoID = uint8_t;
+using CargoType = uint8_t;
 
 /**
  * Available types of cargo
@@ -70,14 +70,14 @@ static constexpr CargoLabel CT_NONE = CT_PASSENGERS;
 
 static constexpr CargoLabel CT_INVALID{UINT32_MAX}; ///< Invalid cargo type.
 
-static const CargoID NUM_ORIGINAL_CARGO = 12; ///< Original number of cargo types.
-static const CargoID NUM_CARGO = 64; ///< Maximum number of cargo types in a game.
+static const CargoType NUM_ORIGINAL_CARGO = 12; ///< Original number of cargo types.
+static const CargoType NUM_CARGO = 64; ///< Maximum number of cargo types in a game.
 
 /* CARGO_AUTO_REFIT and CARGO_NO_REFIT are stored in save-games for refit-orders, so should not be changed. */
-static const CargoID CARGO_AUTO_REFIT = 0xFD; ///< Automatically choose cargo type when doing auto refitting.
-static const CargoID CARGO_NO_REFIT = 0xFE; ///< Do not refit cargo of a vehicle (used in vehicle orders and auto-replace/auto-renew).
+static const CargoType CARGO_AUTO_REFIT = 0xFD; ///< Automatically choose cargo type when doing auto refitting.
+static const CargoType CARGO_NO_REFIT = 0xFE; ///< Do not refit cargo of a vehicle (used in vehicle orders and auto-replace/auto-renew).
 
-static const CargoID INVALID_CARGO = UINT8_MAX;
+static const CargoType INVALID_CARGO = UINT8_MAX;
 
 /** Mixed cargo types for definitions with cargo that can vary depending on climate. */
 enum MixedCargoType {
@@ -91,18 +91,18 @@ enum MixedCargoType {
  * These are used by user interface code only and must not be assigned to any entity. Not all values are valid for every UI filter.
  */
 namespace CargoFilterCriteria {
-	static constexpr CargoID CF_ANY     = NUM_CARGO;     ///< Show all items independent of carried cargo (i.e. no filtering)
-	static constexpr CargoID CF_NONE    = NUM_CARGO + 1; ///< Show only items which do not carry cargo (e.g. train engines)
-	static constexpr CargoID CF_ENGINES = NUM_CARGO + 2; ///< Show only engines (for rail vehicles only)
-	static constexpr CargoID CF_FREIGHT = NUM_CARGO + 3; ///< Show only vehicles which carry any freight (non-passenger) cargo
+	static constexpr CargoType CF_ANY     = NUM_CARGO;     ///< Show all items independent of carried cargo (i.e. no filtering)
+	static constexpr CargoType CF_NONE    = NUM_CARGO + 1; ///< Show only items which do not carry cargo (e.g. train engines)
+	static constexpr CargoType CF_ENGINES = NUM_CARGO + 2; ///< Show only engines (for rail vehicles only)
+	static constexpr CargoType CF_FREIGHT = NUM_CARGO + 3; ///< Show only vehicles which carry any freight (non-passenger) cargo
 
-	static constexpr CargoID CF_NO_RATING   = NUM_CARGO + 4; ///< Show items with no rating (station list)
-	static constexpr CargoID CF_SELECT_ALL  = NUM_CARGO + 5; ///< Select all items (station list)
-	static constexpr CargoID CF_EXPAND_LIST = NUM_CARGO + 6; ///< Expand list to show all items (station list)
+	static constexpr CargoType CF_NO_RATING   = NUM_CARGO + 4; ///< Show items with no rating (station list)
+	static constexpr CargoType CF_SELECT_ALL  = NUM_CARGO + 5; ///< Select all items (station list)
+	static constexpr CargoType CF_EXPAND_LIST = NUM_CARGO + 6; ///< Expand list to show all items (station list)
 };
 
 /** Test whether cargo type is not INVALID_CARGO */
-inline bool IsValidCargoID(CargoID t) { return t != INVALID_CARGO; }
+inline bool IsValidCargoType(CargoType t) { return t != INVALID_CARGO; }
 
 typedef uint64_t CargoTypes;
 

--- a/src/cargoaction.h
+++ b/src/cargoaction.h
@@ -40,9 +40,9 @@ class CargoDelivery : public CargoRemoval<VehicleCargoList> {
 protected:
 	TileIndex current_tile; ///< Current tile cargo delivery is happening.
 	CargoPayment *payment; ///< Payment object where payments will be registered.
-	CargoID cargo; ///< The cargo type of the cargo.
+	CargoType cargo; ///< The cargo type of the cargo.
 public:
-	CargoDelivery(VehicleCargoList *source, uint max_move, CargoID cargo, CargoPayment *payment, TileIndex current_tile) :
+	CargoDelivery(VehicleCargoList *source, uint max_move, CargoType cargo, CargoPayment *payment, TileIndex current_tile) :
 			CargoRemoval<VehicleCargoList>(source, max_move), current_tile(current_tile), payment(payment), cargo(cargo) {}
 	bool operator()(CargoPacket *cp);
 };

--- a/src/cargomonitor.cpp
+++ b/src/cargomonitor.cpp
@@ -115,7 +115,7 @@ int32_t GetPickupAmount(CargoMonitorID monitor, bool keep_monitoring)
  * @param st station where the cargo is delivered to.
  * @param dest industry index where the cargo is delivered to.
  */
-void AddCargoDelivery(CargoID cargo_type, CompanyID company, uint32_t amount, SourceType src_type, SourceID src, const Station *st, IndustryID dest)
+void AddCargoDelivery(CargoType cargo_type, CompanyID company, uint32_t amount, SourceType src_type, SourceID src, const Station *st, IndustryID dest)
 {
 	if (amount == 0) return;
 

--- a/src/cargomonitor.h
+++ b/src/cargomonitor.h
@@ -55,7 +55,7 @@ static_assert(MAX_COMPANIES <= (1 << CCB_COMPANY_LENGTH));
  * @param ind %Industry providing or accepting the cargo.
  * @return The encoded cargo/company/industry number.
  */
-inline CargoMonitorID EncodeCargoIndustryMonitor(CompanyID company, CargoID ctype, IndustryID ind)
+inline CargoMonitorID EncodeCargoIndustryMonitor(CompanyID company, CargoType ctype, IndustryID ind)
 {
 	assert(ctype < (1 << CCB_CARGO_TYPE_LENGTH));
 	assert(company < (1 << CCB_COMPANY_LENGTH));
@@ -75,7 +75,7 @@ inline CargoMonitorID EncodeCargoIndustryMonitor(CompanyID company, CargoID ctyp
  * @param town %Town providing or accepting the cargo.
  * @return The encoded cargo/company/town number.
  */
-inline CargoMonitorID EncodeCargoTownMonitor(CompanyID company, CargoID ctype, TownID town)
+inline CargoMonitorID EncodeCargoTownMonitor(CompanyID company, CargoType ctype, TownID town)
 {
 	assert(ctype < (1 << CCB_CARGO_TYPE_LENGTH));
 	assert(company < (1 << CCB_COMPANY_LENGTH));
@@ -102,7 +102,7 @@ inline CompanyID DecodeMonitorCompany(CargoMonitorID num)
  * @param num Cargo monitoring number to decode.
  * @return The extracted cargo type.
  */
-inline CargoID DecodeMonitorCargoType(CargoMonitorID num)
+inline CargoType DecodeMonitorCargoType(CargoMonitorID num)
 {
 	return GB(num, CCB_CARGO_TYPE_START, CCB_CARGO_TYPE_LENGTH);
 }
@@ -143,6 +143,6 @@ void ClearCargoPickupMonitoring(CompanyID company = INVALID_OWNER);
 void ClearCargoDeliveryMonitoring(CompanyID company = INVALID_OWNER);
 int32_t GetDeliveryAmount(CargoMonitorID monitor, bool keep_monitoring);
 int32_t GetPickupAmount(CargoMonitorID monitor, bool keep_monitoring);
-void AddCargoDelivery(CargoID cargo_type, CompanyID company, uint32_t amount, SourceType src_type, SourceID src, const Station *st, IndustryID dest = INVALID_INDUSTRY);
+void AddCargoDelivery(CargoType cargo_type, CompanyID company, uint32_t amount, SourceType src_type, SourceID src, const Station *st, IndustryID dest = INVALID_INDUSTRY);
 
 #endif /* CARGOMONITOR_H */

--- a/src/cargopacket.cpp
+++ b/src/cargopacket.cpp
@@ -437,7 +437,7 @@ void VehicleCargoList::AgeCargo()
  * @param current_tile Current tile the cargo handling is happening on.
  * return If any cargo will be unloaded.
  */
-bool VehicleCargoList::Stage(bool accepted, StationID current_station, StationIDStack next_station, uint8_t order_flags, const GoodsEntry *ge, CargoID cargo, CargoPayment *payment, TileIndex current_tile)
+bool VehicleCargoList::Stage(bool accepted, StationID current_station, StationIDStack next_station, uint8_t order_flags, const GoodsEntry *ge, CargoType cargo, CargoPayment *payment, TileIndex current_tile)
 {
 	this->AssertCountConsistency();
 	assert(this->action_counts[MTA_LOAD] == 0);
@@ -628,7 +628,7 @@ uint VehicleCargoList::Shift(uint max_move, VehicleCargoList *dest)
  * @param current_tile Current tile the cargo handling is happening on.
  * @return Amount of cargo actually unloaded.
  */
-uint VehicleCargoList::Unload(uint max_move, StationCargoList *dest, CargoID cargo, CargoPayment *payment, TileIndex current_tile)
+uint VehicleCargoList::Unload(uint max_move, StationCargoList *dest, CargoType cargo, CargoPayment *payment, TileIndex current_tile)
 {
 	uint moved = 0;
 	if (this->action_counts[MTA_TRANSFER] > 0) {

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -478,7 +478,7 @@ public:
 
 	void InvalidateCache();
 
-	bool Stage(bool accepted, StationID current_station, StationIDStack next_station, uint8_t order_flags, const GoodsEntry *ge, CargoID cargo, CargoPayment *payment, TileIndex current_tile);
+	bool Stage(bool accepted, StationID current_station, StationIDStack next_station, uint8_t order_flags, const GoodsEntry *ge, CargoType cargo, CargoPayment *payment, TileIndex current_tile);
 
 	/**
 	 * Marks all cargo in the vehicle as to be kept. This is mostly useful for
@@ -498,7 +498,7 @@ public:
 	template <MoveToAction Tfrom, MoveToAction Tto>
 	uint Reassign(uint max_move);
 	uint Return(uint max_move, StationCargoList *dest, StationID next_station, TileIndex current_tile);
-	uint Unload(uint max_move, StationCargoList *dest, CargoID cargo, CargoPayment *payment, TileIndex current_tile);
+	uint Unload(uint max_move, StationCargoList *dest, CargoType cargo, CargoPayment *payment, TileIndex current_tile);
 	uint Shift(uint max_move, VehicleCargoList *dest);
 	uint Truncate(uint max_move = UINT_MAX);
 	uint Reroute(uint max_move, VehicleCargoList *dest, StationID avoid, StationID avoid2, const GoodsEntry *ge);

--- a/src/cargotype.cpp
+++ b/src/cargotype.cpp
@@ -46,7 +46,7 @@ static std::vector<CargoLabel> _default_cargo_labels;
 /**
  * Default cargo translation for upto version 7 NewGRFs.
  * This maps the original 12 cargo slots to their original label. If a climate dependent cargo is not present it will
- * map to CT_INVALID. For default cargoes this ends up as a 1:1 mapping via climate slot -> label -> cargo ID.
+ * map to CT_INVALID. For default cargoes this ends up as a 1:1 mapping via climate slot -> label -> cargo type.
  */
 static std::array<CargoLabel, 12> _climate_dependent_cargo_labels;
 
@@ -146,12 +146,12 @@ void BuildCargoLabelMap()
 
 /**
  * Test if a cargo is a default cargo type.
- * @param cid Cargo ID.
+ * @param cargo_type Cargo type.
  * @returns true iff the cargo type is a default cargo type.
  */
-bool IsDefaultCargo(CargoID cid)
+bool IsDefaultCargo(CargoType cargo_type)
 {
-	auto cs = CargoSpec::Get(cid);
+	auto cs = CargoSpec::Get(cargo_type);
 	if (!cs->IsValid()) return false;
 
 	CargoLabel label = cs->label;
@@ -188,7 +188,7 @@ SpriteID CargoSpec::GetCargoIcon() const
 	return sprite;
 }
 
-std::array<uint8_t, NUM_CARGO> _sorted_cargo_types; ///< Sort order of cargoes by cargo ID.
+std::array<uint8_t, NUM_CARGO> _sorted_cargo_types; ///< Sort order of cargoes by cargo type.
 std::vector<const CargoSpec *> _sorted_cargo_specs;   ///< Cargo specifications sorted alphabetically by name.
 std::span<const CargoSpec *> _sorted_standard_cargo_specs; ///< Standard cargo specifications sorted alphabetically by name.
 
@@ -276,15 +276,15 @@ std::optional<std::string> BuildCargoAcceptanceString(const CargoArray &acceptan
 
 	bool found = false;
 	for (const CargoSpec *cs : _sorted_cargo_specs) {
-		CargoID cid = cs->Index();
-		if (acceptance[cid] > 0) {
+		CargoType cargo_type = cs->Index();
+		if (acceptance[cargo_type] > 0) {
 			/* Add a comma between each item. */
 			if (found) line << list_separator;
 			found = true;
 
 			/* If the accepted value is less than 8, show it in 1/8:ths */
-			if (acceptance[cid] < 8) {
-				SetDParam(0, acceptance[cid]);
+			if (acceptance[cargo_type] < 8) {
+				SetDParam(0, acceptance[cargo_type]);
 				SetDParam(1, cs->name);
 				line << GetString(STR_LAND_AREA_INFORMATION_CARGO_EIGHTS);
 			} else {

--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -107,7 +107,7 @@ struct CargoSpec {
 	 * Determines index of this cargospec
 	 * @return index (in the CargoSpec::array array)
 	 */
-	inline CargoID Index() const
+	inline CargoType Index() const
 	{
 		return this - CargoSpec::array;
 	}
@@ -132,9 +132,9 @@ struct CargoSpec {
 	}
 
 	/**
-	 * Retrieve cargo details for the given cargo ID
+	 * Retrieve cargo details for the given cargo type
 	 * @param index ID of cargo
-	 * @pre index is a valid cargo ID
+	 * @pre index is a valid cargo type
 	 */
 	static inline CargoSpec *Get(size_t index)
 	{
@@ -199,11 +199,11 @@ struct CargoSpec {
 
 private:
 	static CargoSpec array[NUM_CARGO]; ///< Array holding all CargoSpecs
-	static inline std::map<CargoLabel, CargoID> label_map{}; ///< Translation map from CargoLabel to Cargo ID.
+	static inline std::map<CargoLabel, CargoType> label_map{}; ///< Translation map from CargoLabel to Cargo type.
 
 	friend void SetupCargoForClimate(LandscapeID l);
 	friend void BuildCargoLabelMap();
-	friend inline CargoID GetCargoIDByLabel(CargoLabel ct);
+	friend inline CargoType GetCargoTypeByLabel(CargoLabel ct);
 	friend void FinaliseCargoArray();
 };
 
@@ -211,12 +211,12 @@ extern CargoTypes _cargo_mask;
 extern CargoTypes _standard_cargo_mask;
 
 void SetupCargoForClimate(LandscapeID l);
-bool IsDefaultCargo(CargoID cid);
+bool IsDefaultCargo(CargoType cargo_type);
 void BuildCargoLabelMap();
 
 std::optional<std::string> BuildCargoAcceptanceString(const CargoArray &acceptance, StringID label);
 
-inline CargoID GetCargoIDByLabel(CargoLabel label)
+inline CargoType GetCargoTypeByLabel(CargoLabel label)
 {
 	auto found = CargoSpec::label_map.find(label);
 	if (found != std::end(CargoSpec::label_map)) return found->second;
@@ -236,16 +236,16 @@ extern std::span<const CargoSpec *> _sorted_standard_cargo_specs;
  * @param cc Cargo class.
  * @return The type fits in the class.
  */
-inline bool IsCargoInClass(CargoID c, CargoClass cc)
+inline bool IsCargoInClass(CargoType c, CargoClass cc)
 {
 	return (CargoSpec::Get(c)->classes & cc) != 0;
 }
 
-using SetCargoBitIterator = SetBitIterator<CargoID, CargoTypes>;
+using SetCargoBitIterator = SetBitIterator<CargoType, CargoTypes>;
 
-/** Comparator to sort CargoID by according to desired order. */
-struct CargoIDComparator {
-	bool operator() (const CargoID &lhs, const CargoID &rhs) const { return _sorted_cargo_types[lhs] < _sorted_cargo_types[rhs]; }
+/** Comparator to sort CargoType by according to desired order. */
+struct CargoTypeComparator {
+	bool operator() (const CargoType &lhs, const CargoType &rhs) const { return _sorted_cargo_types[lhs] < _sorted_cargo_types[rhs]; }
 };
 
 #endif /* CARGOTYPE_H */

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -889,7 +889,7 @@ struct DepotWindow : Window {
 		details.clear();
 
 		for (const CargoSpec *cs : _sorted_cargo_specs) {
-			CargoID cargo_type = cs->Index();
+			CargoType cargo_type = cs->Index();
 			if (capacity[cargo_type] == 0) continue;
 
 			SetDParam(0, cargo_type);           // {CARGO} #1

--- a/src/economy_base.h
+++ b/src/economy_base.h
@@ -36,8 +36,8 @@ struct CargoPayment : CargoPaymentPool::PoolItem<&_cargo_payment_pool> {
 	CargoPayment(Vehicle *front);
 	~CargoPayment();
 
-	Money PayTransfer(CargoID cargo, const CargoPacket *cp, uint count, TileIndex current_tile);
-	void PayFinalDelivery(CargoID cargo, const CargoPacket *cp, uint count, TileIndex current_tile);
+	Money PayTransfer(CargoType cargo, const CargoPacket *cp, uint count, TileIndex current_tile);
+	void PayFinalDelivery(CargoType cargo, const CargoPacket *cp, uint count, TileIndex current_tile);
 };
 
 #endif /* ECONOMY_BASE_H */

--- a/src/economy_func.h
+++ b/src/economy_func.h
@@ -30,8 +30,8 @@ extern Prices _price;
 int UpdateCompanyRatingAndValue(Company *c, bool update);
 void StartupIndustryDailyChanges(bool init_counter);
 
-Money GetTransportedGoodsIncome(uint num_pieces, uint dist, uint16_t transit_periods, CargoID cargo_type);
-uint MoveGoodsToStation(CargoID type, uint amount, SourceType source_type, SourceID source_id, const StationList &all_stations, Owner exclusivity = INVALID_OWNER);
+Money GetTransportedGoodsIncome(uint num_pieces, uint dist, uint16_t transit_periods, CargoType cargo_type);
+uint MoveGoodsToStation(CargoType type, uint amount, SourceType source_type, SourceID source_id, const StationList &all_stations, Owner exclusivity = INVALID_OWNER);
 
 void PrepareUnload(Vehicle *front_v);
 void LoadUnloadStation(Station *st);

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -187,7 +187,7 @@ bool Engine::CanCarryCargo() const
 
 		default: NOT_REACHED();
 	}
-	return IsValidCargoID(this->GetDefaultCargoType());
+	return IsValidCargoType(this->GetDefaultCargoType());
 }
 
 
@@ -206,8 +206,8 @@ uint Engine::DetermineCapacity(const Vehicle *v, uint16_t *mail_capacity) const
 	if (!this->CanCarryCargo()) return 0;
 
 	bool new_multipliers = HasBit(this->info.misc_flags, EF_NO_DEFAULT_CARGO_MULTIPLIER);
-	CargoID default_cargo = this->GetDefaultCargoType();
-	CargoID cargo_type = (v != nullptr) ? v->cargo_type : default_cargo;
+	CargoType default_cargo = this->GetDefaultCargoType();
+	CargoType cargo_type = (v != nullptr) ? v->cargo_type : default_cargo;
 
 	if (mail_capacity != nullptr && this->type == VEH_AIRCRAFT && IsCargoInClass(cargo_type, CC_PASSENGERS)) {
 		*mail_capacity = GetEngineProperty(this->index, PROP_AIRCRAFT_MAIL_CAPACITY, this->u.air.mail_capacity, v);
@@ -244,10 +244,10 @@ uint Engine::DetermineCapacity(const Vehicle *v, uint16_t *mail_capacity) const
 			if (!IsCargoInClass(cargo_type, CC_PASSENGERS)) {
 				extra_mail_cap = GetEngineProperty(this->index, PROP_AIRCRAFT_MAIL_CAPACITY, this->u.air.mail_capacity, v);
 			}
-			if (IsValidCargoID(GetCargoIDByLabel(CT_MAIL))) {
-				if (!new_multipliers && cargo_type == GetCargoIDByLabel(CT_MAIL)) return capacity + extra_mail_cap;
+			if (IsValidCargoType(GetCargoTypeByLabel(CT_MAIL))) {
+				if (!new_multipliers && cargo_type == GetCargoTypeByLabel(CT_MAIL)) return capacity + extra_mail_cap;
 			}
-			default_cargo = GetCargoIDByLabel(CT_PASSENGERS); // Always use 'passengers' wrt. cargo multipliers
+			default_cargo = GetCargoTypeByLabel(CT_PASSENGERS); // Always use 'passengers' wrt. cargo multipliers
 			break;
 
 		default: NOT_REACHED();
@@ -264,8 +264,8 @@ uint Engine::DetermineCapacity(const Vehicle *v, uint16_t *mail_capacity) const
 		uint16_t default_multiplier = new_multipliers ? 0x100 : CargoSpec::Get(default_cargo)->multiplier;
 		uint16_t cargo_multiplier = CargoSpec::Get(cargo_type)->multiplier;
 		capacity *= cargo_multiplier;
-		if (extra_mail_cap > 0 && IsValidCargoID(GetCargoIDByLabel(CT_MAIL))) {
-			uint mail_multiplier = CargoSpec::Get(GetCargoIDByLabel(CT_MAIL))->multiplier;
+		if (extra_mail_cap > 0 && IsValidCargoType(GetCargoTypeByLabel(CT_MAIL))) {
+			uint mail_multiplier = CargoSpec::Get(GetCargoTypeByLabel(CT_MAIL))->multiplier;
 			capacity += (default_multiplier * extra_mail_cap * cargo_multiplier + mail_multiplier / 2) / mail_multiplier;
 		}
 		capacity = (capacity + default_multiplier / 2) / default_multiplier;
@@ -1309,10 +1309,10 @@ bool IsEngineRefittable(EngineID engine)
 	if (HasBit(ei->callback_mask, CBM_VEHICLE_CARGO_SUFFIX)) return true;
 
 	/* Is there any cargo except the default cargo? */
-	CargoID default_cargo = e->GetDefaultCargoType();
+	CargoType default_cargo = e->GetDefaultCargoType();
 	CargoTypes default_cargo_mask = 0;
 	SetBit(default_cargo_mask, default_cargo);
-	return IsValidCargoID(default_cargo) && ei->refit_mask != default_cargo_mask;
+	return IsValidCargoType(default_cargo) && ei->refit_mask != default_cargo_mask;
 }
 
 /**

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -18,7 +18,7 @@
 
 struct WagonOverride {
 	std::vector<EngineID> engines;
-	CargoID cargo;
+	CargoType cargo;
 	const SpriteGroup *group;
 };
 
@@ -97,7 +97,7 @@ struct Engine : EnginePool::PoolItem<&_engine_pool> {
 	 * @return The default cargo type.
 	 * @see CanCarryCargo
 	 */
-	CargoID GetDefaultCargoType() const
+	CargoType GetDefaultCargoType() const
 	{
 		return this->info.cargo_type;
 	}

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -192,7 +192,7 @@ static StringID GetTrainEngineInfoString(const Engine *e)
 
 static StringID GetAircraftEngineInfoString(const Engine *e)
 {
-	CargoID cargo = e->GetDefaultCargoType();
+	CargoType cargo = e->GetDefaultCargoType();
 	uint16_t mail_capacity;
 	uint capacity = e->GetDisplayDefaultCapacity(&mail_capacity);
 	uint16_t range = e->GetRange();
@@ -211,7 +211,7 @@ static StringID GetAircraftEngineInfoString(const Engine *e)
 	SetDParam(9, mail_capacity > 0 ? STR_ENGINE_PREVIEW_CAPACITY_2 : STR_ENGINE_PREVIEW_CAPACITY);
 	SetDParam(10, cargo);
 	SetDParam(11, capacity);
-	SetDParam(12, GetCargoIDByLabel(CT_MAIL));
+	SetDParam(12, GetCargoTypeByLabel(CT_MAIL));
 	SetDParam(13, mail_capacity);
 
 	return STR_ENGINE_PREVIEW_TEXT4;

--- a/src/engine_gui.h
+++ b/src/engine_gui.h
@@ -27,7 +27,7 @@ struct GUIEngineListItem {
 	GUIEngineListItem(EngineID engine_id, EngineID variant_id, EngineDisplayFlags flags, uint8_t indent) : engine_id(engine_id), variant_id(variant_id), flags(flags), indent(indent), level_mask(0) {}
 };
 
-typedef GUIList<GUIEngineListItem, std::nullptr_t, CargoID> GUIEngineList;
+typedef GUIList<GUIEngineListItem, std::nullptr_t, CargoType> GUIEngineList;
 
 typedef bool EngList_SortTypeFunction(const GUIEngineListItem&, const GUIEngineListItem&); ///< argument type for #EngList_Sort.
 void EngList_Sort(GUIEngineList &el, EngList_SortTypeFunction compare);

--- a/src/engine_type.h
+++ b/src/engine_type.h
@@ -152,7 +152,7 @@ struct EngineInfo {
 	uint8_t decay_speed;
 	uint8_t load_amount;
 	uint8_t climates;      ///< Climates supported by the engine.
-	CargoID cargo_type;
+	CargoType cargo_type;
 	std::variant<CargoLabel, MixedCargoType> cargo_label;
 	CargoTypes refit_mask;
 	uint8_t refit_cost;

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -1518,7 +1518,7 @@ struct IndustryProductionGraphWindow : BaseGraphWindow {
 		int count = 0;
 		const Industry *i = Industry::Get(window_number);
 		for (const auto &p : i->produced) {
-			if (!IsValidCargoID(p.cargo)) continue;
+			if (!IsValidCargoType(p.cargo)) continue;
 			count++;
 		}
 		this->vscroll->SetCount(count);
@@ -1544,7 +1544,7 @@ struct IndustryProductionGraphWindow : BaseGraphWindow {
 
 		const Industry *i = Industry::Get(this->window_number);
 		for (const auto &p : i->produced) {
-			if (!IsValidCargoID(p.cargo)) continue;
+			if (!IsValidCargoType(p.cargo)) continue;
 			if (HasBit(_legend_excluded_cargo_production_history, p.cargo)) SetBit(this->excluded_data, p.cargo);
 		}
 	}
@@ -1559,7 +1559,7 @@ struct IndustryProductionGraphWindow : BaseGraphWindow {
 		const Industry *i = Industry::Get(this->window_number);
 		const CargoSpec *cs;
 		for (const auto &p : i->produced) {
-			if (!IsValidCargoID(p.cargo)) continue;
+			if (!IsValidCargoType(p.cargo)) continue;
 
 			cs = CargoSpec::Get(p.cargo);
 			SetDParam(0, cs->name);
@@ -1593,7 +1593,7 @@ struct IndustryProductionGraphWindow : BaseGraphWindow {
 		const CargoSpec *cs;
 
 		for (const auto &p : i->produced) {
-			if (!IsValidCargoID(p.cargo)) continue;
+			if (!IsValidCargoType(p.cargo)) continue;
 
 			if (pos-- > 0) continue;
 			if (--max < 0) break;
@@ -1634,7 +1634,7 @@ struct IndustryProductionGraphWindow : BaseGraphWindow {
 				/* Add all cargoes to the excluded lists. */
 				const Industry *i = Industry::Get(this->window_number);
 				for (const auto &p : i->produced) {
-					if (!IsValidCargoID(p.cargo)) continue;
+					if (!IsValidCargoType(p.cargo)) continue;
 
 					SetBit(_legend_excluded_cargo_production_history, p.cargo);
 					SetBit(this->excluded_data, p.cargo);
@@ -1649,7 +1649,7 @@ struct IndustryProductionGraphWindow : BaseGraphWindow {
 
 				const Industry *i = Industry::Get(this->window_number);
 				for (const auto &p : i->produced) {
-					if (!IsValidCargoID(p.cargo)) continue;
+					if (!IsValidCargoType(p.cargo)) continue;
 					if (row-- > 0) continue;
 
 					ToggleBit(_legend_excluded_cargo_production_history, p.cargo);
@@ -1700,7 +1700,7 @@ struct IndustryProductionGraphWindow : BaseGraphWindow {
 
 		this->data.clear();
 		for (const auto &p : i->produced) {
-			if (!IsValidCargoID(p.cargo)) continue;
+			if (!IsValidCargoType(p.cargo)) continue;
 			const CargoSpec *cs = CargoSpec::Get(p.cargo);
 
 			DataSet &produced = this->data.emplace_back();

--- a/src/house.h
+++ b/src/house.h
@@ -100,7 +100,7 @@ struct HouseSpec {
 	uint16_t remove_rating_decrease;            ///< rating decrease if removed
 	uint8_t mail_generation;                     ///< mail generation multiplier (tile based, as the acceptances below)
 	uint8_t cargo_acceptance[HOUSE_NUM_ACCEPTS]; ///< acceptance level for the cargo slots
-	CargoID accepts_cargo[HOUSE_NUM_ACCEPTS]; ///< input cargo slots
+	CargoType accepts_cargo[HOUSE_NUM_ACCEPTS]; ///< input cargo slots
 	BuildingFlags building_flags;             ///< some flags that describe the house (size, stadium etc...)
 	HouseZones building_availability;         ///< where can it be built (climates, zones)
 	bool enabled;                             ///< the house is available to build (true by default, but can be disabled by newgrf)

--- a/src/industry.h
+++ b/src/industry.h
@@ -76,14 +76,14 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 	};
 
 	struct ProducedCargo {
-		CargoID cargo; ///< Cargo type
+		CargoType cargo; ///< Cargo type
 		uint16_t waiting; ///< Amount of cargo produced
 		uint8_t rate; ///< Production rate
 		std::array<ProducedHistory, 25> history; ///< History of cargo produced and transported for this month and 24 previous months
 	};
 
 	struct AcceptedCargo {
-		CargoID cargo; ///< Cargo type
+		CargoType cargo; ///< Cargo type
 		uint16_t waiting; ///< Amount of cargo waiting to processed
 		TimerGameEconomy::Date last_accepted; ///< Last day cargo was accepted by this industry
 	};
@@ -161,45 +161,45 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 
 	/**
 	 * Get produced cargo slot for a specific cargo type.
-	 * @param cargo CargoID to find.
+	 * @param cargo CargoType to find.
 	 * @return Iterator pointing to produced cargo slot if it exists, or the end iterator.
 	 */
-	inline ProducedCargoes::iterator GetCargoProduced(CargoID cargo)
+	inline ProducedCargoes::iterator GetCargoProduced(CargoType cargo)
 	{
-		if (!IsValidCargoID(cargo)) return std::end(this->produced);
+		if (!IsValidCargoType(cargo)) return std::end(this->produced);
 		return std::ranges::find(this->produced, cargo, &ProducedCargo::cargo);
 	}
 
 	/**
 	 * Get produced cargo slot for a specific cargo type (const-variant).
-	 * @param cargo CargoID to find.
+	 * @param cargo CargoType to find.
 	 * @return Iterator pointing to produced cargo slot if it exists, or the end iterator.
 	 */
-	inline ProducedCargoes::const_iterator GetCargoProduced(CargoID cargo) const
+	inline ProducedCargoes::const_iterator GetCargoProduced(CargoType cargo) const
 	{
-		if (!IsValidCargoID(cargo)) return std::end(this->produced);
+		if (!IsValidCargoType(cargo)) return std::end(this->produced);
 		return std::ranges::find(this->produced, cargo, &ProducedCargo::cargo);
 	}
 
 	/**
 	 * Get accepted cargo slot for a specific cargo type.
-	 * @param cargo CargoID to find.
+	 * @param cargo CargoType to find.
 	 * @return Iterator pointing to accepted cargo slot if it exists, or the end iterator.
 	 */
-	inline AcceptedCargoes::iterator GetCargoAccepted(CargoID cargo)
+	inline AcceptedCargoes::iterator GetCargoAccepted(CargoType cargo)
 	{
-		if (!IsValidCargoID(cargo)) return std::end(this->accepted);
+		if (!IsValidCargoType(cargo)) return std::end(this->accepted);
 		return std::ranges::find(this->accepted, cargo, &AcceptedCargo::cargo);
 	}
 
 	/**
 	 * Get accepted cargo slot for a specific cargo type (const-variant).
-	 * @param cargo CargoID to find.
+	 * @param cargo CargoType to find.
 	 * @return Iterator pointing to accepted cargo slot if it exists, or the end iterator.
 	 */
-	inline AcceptedCargoes::const_iterator GetCargoAccepted(CargoID cargo) const
+	inline AcceptedCargoes::const_iterator GetCargoAccepted(CargoType cargo) const
 	{
-		if (!IsValidCargoID(cargo)) return std::end(this->accepted);
+		if (!IsValidCargoType(cargo)) return std::end(this->accepted);
 		return std::ranges::find(this->accepted, cargo, &AcceptedCargo::cargo);
 	}
 
@@ -207,27 +207,27 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 	 * Test if this industry accepts any cargo.
 	 * @return true iff the industry accepts any cargo.
 	 */
-	bool IsCargoAccepted() const { return std::any_of(std::begin(this->accepted), std::end(this->accepted), [](const auto &a) { return IsValidCargoID(a.cargo); }); }
+	bool IsCargoAccepted() const { return std::any_of(std::begin(this->accepted), std::end(this->accepted), [](const auto &a) { return IsValidCargoType(a.cargo); }); }
 
 	/**
 	 * Test if this industry produces any cargo.
 	 * @return true iff the industry produces any cargo.
 	 */
-	bool IsCargoProduced() const { return std::any_of(std::begin(this->produced), std::end(this->produced), [](const auto &p) { return IsValidCargoID(p.cargo); }); }
+	bool IsCargoProduced() const { return std::any_of(std::begin(this->produced), std::end(this->produced), [](const auto &p) { return IsValidCargoType(p.cargo); }); }
 
 	/**
 	 * Test if this industry accepts a specific cargo.
 	 * @param cargo Cargo type to test.
 	 * @return true iff the industry accepts the given cargo type.
 	 */
-	bool IsCargoAccepted(CargoID cargo) const { return std::any_of(std::begin(this->accepted), std::end(this->accepted), [&cargo](const auto &a) { return a.cargo == cargo; }); }
+	bool IsCargoAccepted(CargoType cargo) const { return std::any_of(std::begin(this->accepted), std::end(this->accepted), [&cargo](const auto &a) { return a.cargo == cargo; }); }
 
 	/**
 	 * Test if this industry produces a specific cargo.
 	 * @param cargo Cargo type to test.
 	 * @return true iff the industry produces the given cargo types.
 	 */
-	bool IsCargoProduced(CargoID cargo) const { return std::any_of(std::begin(this->produced), std::end(this->produced), [&cargo](const auto &p) { return p.cargo == cargo; }); }
+	bool IsCargoProduced(CargoType cargo) const { return std::any_of(std::begin(this->produced), std::end(this->produced), [&cargo](const auto &p) { return p.cargo == cargo; }); }
 
 	/**
 	 * Get the industry of the given tile

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -161,7 +161,7 @@ static inline void GetAllCargoSuffixes(CargoSuffixInOut use_input, CargoSuffixTy
 	if (indspec->behaviour & INDUSTRYBEH_CARGOTYPES_UNLIMITED) {
 		/* Reworked behaviour with new many-in-many-out scheme */
 		for (uint j = 0; j < lengthof(suffixes); j++) {
-			if (IsValidCargoID(cargoes[j])) {
+			if (IsValidCargoType(cargoes[j])) {
 				uint8_t local_id = indspec->grf_prop.grffile->cargo_map[cargoes[j]]; // should we check the value for valid?
 				uint cargotype = local_id << 16 | use_input;
 				GetCargoSuffix(cargotype, cst, ind, ind_type, indspec, suffixes[j]);
@@ -179,14 +179,14 @@ static inline void GetAllCargoSuffixes(CargoSuffixInOut use_input, CargoSuffixTy
 		switch (use_input) {
 			case CARGOSUFFIX_OUT:
 				// Handle INDUSTRY_ORIGINAL_NUM_OUTPUTS cargoes
-				if (IsValidCargoID(cargoes[0])) GetCargoSuffix(3, cst, ind, ind_type, indspec, suffixes[0]);
-				if (IsValidCargoID(cargoes[1])) GetCargoSuffix(4, cst, ind, ind_type, indspec, suffixes[1]);
+				if (IsValidCargoType(cargoes[0])) GetCargoSuffix(3, cst, ind, ind_type, indspec, suffixes[0]);
+				if (IsValidCargoType(cargoes[1])) GetCargoSuffix(4, cst, ind, ind_type, indspec, suffixes[1]);
 				break;
 			case CARGOSUFFIX_IN:
 				// Handle INDUSTRY_ORIGINAL_NUM_INPUTS cargoes
-				if (IsValidCargoID(cargoes[0])) GetCargoSuffix(0, cst, ind, ind_type, indspec, suffixes[0]);
-				if (IsValidCargoID(cargoes[1])) GetCargoSuffix(1, cst, ind, ind_type, indspec, suffixes[1]);
-				if (IsValidCargoID(cargoes[2])) GetCargoSuffix(2, cst, ind, ind_type, indspec, suffixes[2]);
+				if (IsValidCargoType(cargoes[0])) GetCargoSuffix(0, cst, ind, ind_type, indspec, suffixes[0]);
+				if (IsValidCargoType(cargoes[1])) GetCargoSuffix(1, cst, ind, ind_type, indspec, suffixes[1]);
+				if (IsValidCargoType(cargoes[2])) GetCargoSuffix(2, cst, ind, ind_type, indspec, suffixes[2]);
 				break;
 			default:
 				NOT_REACHED();
@@ -205,11 +205,11 @@ static inline void GetAllCargoSuffixes(CargoSuffixInOut use_input, CargoSuffixTy
  * @param slot accepts/produced slot number, used for old-style 3-in/2-out industries.
  * @param suffix is filled with the suffix
  */
-void GetCargoSuffix(CargoSuffixInOut use_input, CargoSuffixType cst, const Industry *ind, IndustryType ind_type, const IndustrySpec *indspec, CargoID cargo, uint8_t slot, CargoSuffix &suffix)
+void GetCargoSuffix(CargoSuffixInOut use_input, CargoSuffixType cst, const Industry *ind, IndustryType ind_type, const IndustrySpec *indspec, CargoType cargo, uint8_t slot, CargoSuffix &suffix)
 {
 	suffix.text.clear();
 	suffix.display = CSD_CARGO;
-	if (!IsValidCargoID(cargo)) return;
+	if (!IsValidCargoType(cargo)) return;
 	if (indspec->behaviour & INDUSTRYBEH_CARGOTYPES_UNLIMITED) {
 		uint8_t local_id = indspec->grf_prop.grffile->cargo_map[cargo]; // should we check the value for valid?
 		uint cargotype = local_id << 16 | use_input;
@@ -364,13 +364,13 @@ class BuildIndustryWindow : public Window {
 	 *  - This cargo list uses the order defined by the industry, rather than alphabetic.
 	 *  - NewGRF-supplied suffix strings can be attached to each cargo.
 	 *
-	 * @param cargolist    Array of CargoID to display
+	 * @param cargolist    Array of CargoType to display
 	 * @param cargo_suffix Array of suffixes to attach to each cargo
 	 * @param cargolistlen Length of arrays
 	 * @param prefixstr    String to use for the first item
 	 * @return A formatted raw string
 	 */
-	std::string MakeCargoListString(const std::span<const CargoID> cargolist, const std::span<const CargoSuffix> cargo_suffix, StringID prefixstr) const
+	std::string MakeCargoListString(const std::span<const CargoType> cargolist, const std::span<const CargoSuffix> cargo_suffix, StringID prefixstr) const
 	{
 		assert(cargolist.size() == cargo_suffix.size());
 
@@ -379,7 +379,7 @@ class BuildIndustryWindow : public Window {
 		size_t firstcargo = 0;
 
 		for (size_t j = 0; j < cargolist.size(); j++) {
-			if (!IsValidCargoID(cargolist[j])) continue;
+			if (!IsValidCargoType(cargolist[j])) continue;
 			numcargo++;
 			if (numcargo == 1) {
 				firstcargo = j;
@@ -858,10 +858,10 @@ public:
 		}
 	}
 
-	void DrawCargoIcon(const Rect &r, CargoID cid) const
+	void DrawCargoIcon(const Rect &r, CargoType cargo_type) const
 	{
 		bool rtl = _current_text_dir == TD_RTL;
-		SpriteID icon = CargoSpec::Get(cid)->GetCargoIcon();
+		SpriteID icon = CargoSpec::Get(cargo_type)->GetCargoIcon();
 		Dimension d = GetSpriteSize(icon);
 		Rect ir = r.WithWidth(this->cargo_icon_size.width, rtl).WithHeight(GetCharacterHeight(FS_NORMAL));
 		DrawSprite(icon, PAL_NONE, CenterBounds(ir.left, ir.right, d.width), CenterBounds(ir.top, ir.bottom, this->cargo_icon_size.height));
@@ -890,7 +890,7 @@ public:
 		bool stockpiling = HasBit(ind->callback_mask, CBM_IND_PRODUCTION_CARGO_ARRIVAL) || HasBit(ind->callback_mask, CBM_IND_PRODUCTION_256_TICKS);
 
 		for (const auto &a : i->accepted) {
-			if (!IsValidCargoID(a.cargo)) continue;
+			if (!IsValidCargoType(a.cargo)) continue;
 			has_accept = true;
 			if (first) {
 				DrawString(ir, STR_INDUSTRY_VIEW_REQUIRES);
@@ -935,7 +935,7 @@ public:
 		int button_y_offset = (line_height - SETTING_BUTTON_HEIGHT) / 2;
 		first = true;
 		for (const auto &p : i->produced) {
-			if (!IsValidCargoID(p.cargo)) continue;
+			if (!IsValidCargoType(p.cargo)) continue;
 			if (first) {
 				if (has_accept) ir.top += WidgetDimensions::scaled.vsep_wide;
 				DrawString(ir, TimerGameEconomy::UsingWallclockUnits() ? STR_INDUSTRY_VIEW_PRODUCTION_LAST_MINUTE_TITLE : STR_INDUSTRY_VIEW_PRODUCTION_LAST_MONTH_TITLE);
@@ -1036,7 +1036,7 @@ public:
 						if (pt.y >= this->production_offset_y) {
 							int row = (pt.y - this->production_offset_y) / this->cheat_line_height;
 							for (auto itp = std::begin(i->produced); itp != std::end(i->produced); ++itp) {
-								if (!IsValidCargoID(itp->cargo)) continue;
+								if (!IsValidCargoType(itp->cargo)) continue;
 								row--;
 								if (row < 0) {
 									line = (InfoLine)(IL_RATE1 + (itp - std::begin(i->produced)));
@@ -1206,7 +1206,7 @@ static void UpdateIndustryProduction(Industry *i)
 	if (indspec->UsesOriginalEconomy()) i->RecomputeProductionMultipliers();
 
 	for (auto &p : i->produced) {
-		if (IsValidCargoID(p.cargo)) {
+		if (IsValidCargoType(p.cargo)) {
 			p.history[LAST_MONTH].production = ScaleByCargoScale(8 * p.rate, false);
 		}
 	}
@@ -1282,7 +1282,7 @@ static constexpr NWidgetPart _nested_industry_directory_widgets[] = {
 	EndContainer(),
 };
 
-typedef GUIList<const Industry *, const CargoID &, const std::pair<CargoID, CargoID> &> GUIIndustryList;
+typedef GUIList<const Industry *, const CargoType &, const std::pair<CargoType, CargoType> &> GUIIndustryList;
 
 /** Cargo filter functions */
 /**
@@ -1291,7 +1291,7 @@ typedef GUIList<const Industry *, const CargoID &, const std::pair<CargoID, Carg
  * @param cargoes The accepted and produced cargo pair to look for.
  * @return bool Whether the given cargoes accepted and produced by the industry.
  */
-static bool CargoFilter(const Industry * const *industry, const std::pair<CargoID, CargoID> &cargoes)
+static bool CargoFilter(const Industry * const *industry, const std::pair<CargoType, CargoType> &cargoes)
 {
 	auto accepted_cargo = cargoes.first;
 	auto produced_cargo = cargoes.second;
@@ -1358,9 +1358,9 @@ protected:
 	Scrollbar *vscroll;
 	Scrollbar *hscroll;
 
-	CargoID produced_cargo_filter_criteria;     ///< Selected produced cargo filter index
-	CargoID accepted_cargo_filter_criteria;     ///< Selected accepted cargo filter index
-	static CargoID produced_cargo_filter;
+	CargoType produced_cargo_filter_criteria;     ///< Selected produced cargo filter index
+	CargoType accepted_cargo_filter_criteria;     ///< Selected accepted cargo filter index
+	static CargoType produced_cargo_filter;
 
 	const int MAX_FILTER_LENGTH = 16;           ///< The max length of the filter, in chars
 	StringFilter string_filter;                 ///< Filter for industries
@@ -1375,12 +1375,12 @@ protected:
 
 	/**
 	 * Set produced cargo filter for the industry list.
-	 * @param cid The cargo to be set
+	 * @param cargo_type The cargo to be set
 	 */
-	void SetProducedCargoFilter(CargoID cid)
+	void SetProducedCargoFilter(CargoType cargo_type)
 	{
-		if (this->produced_cargo_filter_criteria != cid) {
-			this->produced_cargo_filter_criteria = cid;
+		if (this->produced_cargo_filter_criteria != cargo_type) {
+			this->produced_cargo_filter_criteria = cargo_type;
 			/* deactivate filter if criteria is 'Show All', activate it otherwise */
 			bool is_filtering_necessary = this->produced_cargo_filter_criteria != CargoFilterCriteria::CF_ANY || this->accepted_cargo_filter_criteria != CargoFilterCriteria::CF_ANY;
 
@@ -1394,10 +1394,10 @@ protected:
 	 * Set accepted cargo filter for the industry list.
 	 * @param index The cargo to be set
 	 */
-	void SetAcceptedCargoFilter(CargoID cid)
+	void SetAcceptedCargoFilter(CargoType cargo_type)
 	{
-		if (this->accepted_cargo_filter_criteria != cid) {
-			this->accepted_cargo_filter_criteria = cid;
+		if (this->accepted_cargo_filter_criteria != cargo_type) {
+			this->accepted_cargo_filter_criteria = cargo_type;
 			/* deactivate filter if criteria is 'Show All', activate it otherwise */
 			bool is_filtering_necessary = this->produced_cargo_filter_criteria != CargoFilterCriteria::CF_ANY || this->accepted_cargo_filter_criteria != CargoFilterCriteria::CF_ANY;
 
@@ -1407,12 +1407,12 @@ protected:
 		}
 	}
 
-	StringID GetCargoFilterLabel(CargoID cid) const
+	StringID GetCargoFilterLabel(CargoType cargo_type) const
 	{
-		switch (cid) {
+		switch (cargo_type) {
 			case CargoFilterCriteria::CF_ANY: return STR_INDUSTRY_DIRECTORY_FILTER_ALL_TYPES;
 			case CargoFilterCriteria::CF_NONE: return STR_INDUSTRY_DIRECTORY_FILTER_NONE;
-			default: return CargoSpec::Get(cid)->name;
+			default: return CargoSpec::Get(cargo_type)->name;
 		}
 	}
 
@@ -1485,7 +1485,7 @@ protected:
 	 */
 	static inline int GetCargoTransportedPercentsIfValid(const Industry::ProducedCargo &p)
 	{
-		if (!IsValidCargoID(p.cargo)) return -1;
+		if (!IsValidCargoType(p.cargo)) return -1;
 		return ToPercent8(p.history[LAST_MONTH].PctTransported());
 	}
 
@@ -1498,7 +1498,7 @@ protected:
 	 */
 	static int GetCargoTransportedSortValue(const Industry *i)
 	{
-		CargoID filter = IndustryDirectoryWindow::produced_cargo_filter;
+		CargoType filter = IndustryDirectoryWindow::produced_cargo_filter;
 		if (filter == CargoFilterCriteria::CF_NONE) return 0;
 
 		int percentage = 0, produced_cargo_count = 0;
@@ -1522,7 +1522,7 @@ protected:
 	}
 
 	/** Sort industries by name */
-	static bool IndustryNameSorter(const Industry * const &a, const Industry * const &b, const CargoID &)
+	static bool IndustryNameSorter(const Industry * const &a, const Industry * const &b, const CargoType &)
 	{
 		int r = StrNaturalCompare(a->GetCachedName(), b->GetCachedName()); // Sort by name (natural sorting).
 		if (r == 0) return a->index < b->index;
@@ -1530,7 +1530,7 @@ protected:
 	}
 
 	/** Sort industries by type and name */
-	static bool IndustryTypeSorter(const Industry * const &a, const Industry * const &b, const CargoID &filter)
+	static bool IndustryTypeSorter(const Industry * const &a, const Industry * const &b, const CargoType &filter)
 	{
 		int it_a = 0;
 		while (it_a != NUM_INDUSTRYTYPES && a->type != _sorted_industry_types[it_a]) it_a++;
@@ -1541,17 +1541,17 @@ protected:
 	}
 
 	/** Sort industries by production and name */
-	static bool IndustryProductionSorter(const Industry * const &a, const Industry * const &b, const CargoID &filter)
+	static bool IndustryProductionSorter(const Industry * const &a, const Industry * const &b, const CargoType &filter)
 	{
 		if (filter == CargoFilterCriteria::CF_NONE) return IndustryTypeSorter(a, b, filter);
 
 		uint prod_a = 0, prod_b = 0;
 		if (filter == CargoFilterCriteria::CF_ANY) {
 			for (const auto &pa : a->produced) {
-				if (IsValidCargoID(pa.cargo)) prod_a += pa.history[LAST_MONTH].production;
+				if (IsValidCargoType(pa.cargo)) prod_a += pa.history[LAST_MONTH].production;
 			}
 			for (const auto &pb : b->produced) {
-				if (IsValidCargoID(pb.cargo)) prod_b += pb.history[LAST_MONTH].production;
+				if (IsValidCargoType(pb.cargo)) prod_b += pb.history[LAST_MONTH].production;
 			}
 		} else {
 			if (auto ita = a->GetCargoProduced(filter); ita != std::end(a->produced)) prod_a = ita->history[LAST_MONTH].production;
@@ -1563,7 +1563,7 @@ protected:
 	}
 
 	/** Sort industries by transported cargo and name */
-	static bool IndustryTransportedCargoSorter(const Industry * const &a, const Industry * const &b, const CargoID &filter)
+	static bool IndustryTransportedCargoSorter(const Industry * const &a, const Industry * const &b, const CargoType &filter)
 	{
 		int r = GetCargoTransportedSortValue(a) - GetCargoTransportedSortValue(b);
 		return (r == 0) ? IndustryNameSorter(a, b, filter) : r < 0;
@@ -1582,19 +1582,19 @@ protected:
 		/* Industry name */
 		SetDParam(p++, i->index);
 
-		/* Get industry productions (CargoID, production, suffix, transported) */
+		/* Get industry productions (CargoType, production, suffix, transported) */
 		struct CargoInfo {
-			CargoID cargo_id; ///< Cargo ID.
+			CargoType cargo_type; ///< Cargo type.
 			uint16_t production; ///< Production last month.
 			uint transported; ///< Percent transported last month.
 			std::string suffix; ///< Cargo suffix.
 
-			CargoInfo(CargoID cargo_id, uint16_t production, uint transported, std::string &&suffix) : cargo_id(cargo_id), production(production), transported(transported), suffix(std::move(suffix)) {}
+			CargoInfo(CargoType cargo_type, uint16_t production, uint transported, std::string &&suffix) : cargo_type(cargo_type), production(production), transported(transported), suffix(std::move(suffix)) {}
 		};
 		std::vector<CargoInfo> cargos;
 
 		for (auto itp = std::begin(i->produced); itp != std::end(i->produced); ++itp) {
-			if (!IsValidCargoID(itp->cargo)) continue;
+			if (!IsValidCargoType(itp->cargo)) continue;
 			CargoSuffix cargo_suffix;
 			GetCargoSuffix(CARGOSUFFIX_OUT, CST_DIR, i, i->type, indsp, itp->cargo, itp - std::begin(i->produced), cargo_suffix);
 			cargos.emplace_back(itp->cargo, itp->history[LAST_MONTH].production, ToPercent8(itp->history[LAST_MONTH].PctTransported()), std::move(cargo_suffix.text));
@@ -1622,9 +1622,9 @@ protected:
 
 		/* If the produced cargo filter is active then move the filtered cargo to the beginning of the list,
 		 * because this is the one the player interested in, and that way it is not hidden in the 'n' more cargos */
-		const CargoID cid = this->produced_cargo_filter_criteria;
-		if (cid != CargoFilterCriteria::CF_ANY && cid != CargoFilterCriteria::CF_NONE) {
-			auto filtered_ci = std::ranges::find(cargos, cid, &CargoInfo::cargo_id);
+		const CargoType cargo_type = this->produced_cargo_filter_criteria;
+		if (cargo_type != CargoFilterCriteria::CF_ANY && cargo_type != CargoFilterCriteria::CF_NONE) {
+			auto filtered_ci = std::ranges::find(cargos, cargo_type, &CargoInfo::cargo_type);
 			if (filtered_ci != cargos.end()) {
 				std::rotate(cargos.begin(), filtered_ci, filtered_ci + 1);
 			}
@@ -1634,7 +1634,7 @@ protected:
 		for (size_t j = 0; j < std::min<size_t>(3, cargos.size()); j++) {
 			CargoInfo &ci = cargos[j];
 			SetDParam(p++, STR_INDUSTRY_DIRECTORY_ITEM_INFO);
-			SetDParam(p++, ci.cargo_id);
+			SetDParam(p++, ci.cargo_type);
 			SetDParam(p++, ci.production);
 			SetDParamStr(p++, std::move(ci.suffix));
 			SetDParam(p++, ci.transported);
@@ -1730,13 +1730,13 @@ public:
 					DrawString(ir, STR_INDUSTRY_DIRECTORY_NONE);
 					break;
 				}
-				const CargoID acf_cid = this->accepted_cargo_filter_criteria;
+				const CargoType acf_cargo_type = this->accepted_cargo_filter_criteria;
 				auto [first, last] = this->vscroll->GetVisibleRangeIterators(this->industries);
 				for (auto it = first; it != last; ++it) {
 					TextColour tc = TC_FROMSTRING;
-					if (acf_cid != CargoFilterCriteria::CF_ANY && acf_cid != CargoFilterCriteria::CF_NONE) {
+					if (acf_cargo_type != CargoFilterCriteria::CF_ANY && acf_cargo_type != CargoFilterCriteria::CF_NONE) {
 						Industry *ind = const_cast<Industry *>(*it);
-						if (IndustryTemporarilyRefusesCargo(ind, acf_cid)) {
+						if (IndustryTemporarilyRefusesCargo(ind, acf_cargo_type)) {
 							tc = TC_GREY | TC_FORCED;
 						}
 					}
@@ -1935,7 +1935,7 @@ const std::initializer_list<GUIIndustryList::SortFunction * const> IndustryDirec
 	&IndustryTransportedCargoSorter
 };
 
-CargoID IndustryDirectoryWindow::produced_cargo_filter = CargoFilterCriteria::CF_ANY;
+CargoType IndustryDirectoryWindow::produced_cargo_filter = CargoFilterCriteria::CF_ANY;
 
 
 /** Window definition of the industry directory gui */
@@ -2023,11 +2023,11 @@ struct CargoesField {
 	union {
 		struct {
 			IndustryType ind_type;                 ///< Industry type (#NUM_INDUSTRYTYPES means 'houses').
-			CargoID other_produced[MAX_CARGOES];   ///< Cargoes produced but not used in this figure.
-			CargoID other_accepted[MAX_CARGOES];   ///< Cargoes accepted but not used in this figure.
+			CargoType other_produced[MAX_CARGOES];   ///< Cargoes produced but not used in this figure.
+			CargoType other_accepted[MAX_CARGOES];   ///< Cargoes accepted but not used in this figure.
 		} industry; ///< Industry data (for #CFT_INDUSTRY).
 		struct {
-			CargoID vertical_cargoes[MAX_CARGOES]; ///< Cargoes running from top to bottom (cargo ID or #INVALID_CARGO).
+			CargoType vertical_cargoes[MAX_CARGOES]; ///< Cargoes running from top to bottom (cargo type or #INVALID_CARGO).
 			Cargoes supp_cargoes; ///< Cargoes in \c vertical_cargoes entering from the left.
 			Cargoes cust_cargoes; ///< Cargoes in \c vertical_cargoes leaving to the right.
 			uint8_t num_cargoes;                   ///< Number of cargoes.
@@ -2035,7 +2035,7 @@ struct CargoesField {
 			uint8_t bottom_end;                    ///< Stop at the bottom of the vertical cargoes.
 		} cargo; ///< Cargo data (for #CFT_CARGO).
 		struct {
-			CargoID cargoes[MAX_CARGOES];          ///< Cargoes to display (or #INVALID_CARGO).
+			CargoType cargoes[MAX_CARGOES];          ///< Cargoes to display (or #INVALID_CARGO).
 			bool left_align;                       ///< Align all cargo texts to the left (else align to the right).
 		} cargo_label;   ///< Label data (for #CFT_CARGO_LABEL).
 		StringID header; ///< Header text (for #CFT_HEADER).
@@ -2069,10 +2069,10 @@ struct CargoesField {
 	 * @param producer Cargo is produced (if \c false, cargo is assumed to be accepted).
 	 * @return Horizontal connection index, or \c -1 if not accepted at all.
 	 */
-	int ConnectCargo(CargoID cargo, bool producer)
+	int ConnectCargo(CargoType cargo, bool producer)
 	{
 		assert(this->type == CFT_CARGO);
-		if (!IsValidCargoID(cargo)) return -1;
+		if (!IsValidCargoType(cargo)) return -1;
 
 		/* Find the vertical cargo column carrying the cargo. */
 		int column = -1;
@@ -2107,16 +2107,16 @@ struct CargoesField {
 
 	/**
 	 * Make a piece of cargo column.
-	 * @param cargoes Span of #CargoID (may contain #INVALID_CARGO).
+	 * @param cargoes Span of #CargoType (may contain #INVALID_CARGO).
 	 * @note #supp_cargoes and #cust_cargoes should be filled in later.
 	 */
-	void MakeCargo(const std::span<const CargoID> cargoes)
+	void MakeCargo(const std::span<const CargoType> cargoes)
 	{
 		this->type = CFT_CARGO;
 		assert(std::size(cargoes) <= std::size(this->u.cargo.vertical_cargoes));
-		auto insert = std::copy_if(std::begin(cargoes), std::end(cargoes), std::begin(this->u.cargo.vertical_cargoes), IsValidCargoID);
+		auto insert = std::copy_if(std::begin(cargoes), std::end(cargoes), std::begin(this->u.cargo.vertical_cargoes), IsValidCargoType);
 		this->u.cargo.num_cargoes = static_cast<uint8_t>(std::distance(std::begin(this->u.cargo.vertical_cargoes), insert));
-		CargoIDComparator comparator;
+		CargoTypeComparator comparator;
 		std::sort(std::begin(this->u.cargo.vertical_cargoes), insert, comparator);
 		std::fill(insert, std::end(this->u.cargo.vertical_cargoes), INVALID_CARGO);
 		this->u.cargo.top_end = false;
@@ -2127,10 +2127,10 @@ struct CargoesField {
 
 	/**
 	 * Make a field displaying cargo type names.
-	 * @param cargoes    Span of #CargoID (may contain #INVALID_CARGO).
+	 * @param cargoes    Span of #CargoType (may contain #INVALID_CARGO).
 	 * @param left_align ALign texts to the left (else to the right).
 	 */
-	void MakeCargoLabel(const std::span<const CargoID> cargoes, bool left_align)
+	void MakeCargoLabel(const std::span<const CargoType> cargoes, bool left_align)
 	{
 		this->type = CFT_CARGO_LABEL;
 		assert(std::size(cargoes) <= std::size(this->u.cargo_label.cargoes));
@@ -2205,7 +2205,7 @@ struct CargoesField {
 				}
 
 				/* Draw the other_produced/other_accepted cargoes. */
-				std::span<const CargoID> other_right, other_left;
+				std::span<const CargoType> other_right, other_left;
 				if (_current_text_dir == TD_RTL) {
 					other_right = this->u.industry.other_accepted;
 					other_left  = this->u.industry.other_produced;
@@ -2215,13 +2215,13 @@ struct CargoesField {
 				}
 				ypos1 += CargoesField::cargo_border.height + (GetCharacterHeight(FS_NORMAL) - CargoesField::cargo_line.height) / 2;
 				for (uint i = 0; i < CargoesField::max_cargoes; i++) {
-					if (IsValidCargoID(other_right[i])) {
+					if (IsValidCargoType(other_right[i])) {
 						const CargoSpec *csp = CargoSpec::Get(other_right[i]);
 						int xp = xpos + industry_width + CargoesField::cargo_stub.width;
 						DrawHorConnection(xpos + industry_width, xp - 1, ypos1, csp);
 						GfxDrawLine(xp, ypos1, xp, ypos1 + CargoesField::cargo_line.height - 1, CARGO_LINE_COLOUR);
 					}
-					if (IsValidCargoID(other_left[i])) {
+					if (IsValidCargoType(other_left[i])) {
 						const CargoSpec *csp = CargoSpec::Get(other_left[i]);
 						int xp = xpos - CargoesField::cargo_stub.width;
 						DrawHorConnection(xp + 1, xpos - 1, ypos1, csp);
@@ -2289,7 +2289,7 @@ struct CargoesField {
 			case CFT_CARGO_LABEL:
 				ypos += CargoesField::cargo_border.height + vert_inter_industry_space / 2;
 				for (uint i = 0; i < MAX_CARGOES; i++) {
-					if (IsValidCargoID(this->u.cargo_label.cargoes[i])) {
+					if (IsValidCargoType(this->u.cargo_label.cargoes[i])) {
 						const CargoSpec *csp = CargoSpec::Get(this->u.cargo_label.cargoes[i]);
 						DrawString(xpos + WidgetDimensions::scaled.framerect.left, xpos + industry_width - 1 - WidgetDimensions::scaled.framerect.right, ypos, csp->name, TC_WHITE,
 								(this->u.cargo_label.left_align) ? SA_LEFT : SA_RIGHT);
@@ -2310,7 +2310,7 @@ struct CargoesField {
 	 * @param pt    Click position in the cargo field.
 	 * @return Cargo clicked at, or #INVALID_CARGO if none.
 	 */
-	CargoID CargoClickedAt(const CargoesField *left, const CargoesField *right, Point pt) const
+	CargoType CargoClickedAt(const CargoesField *left, const CargoesField *right, Point pt) const
 	{
 		assert(this->type == CFT_CARGO);
 
@@ -2368,7 +2368,7 @@ struct CargoesField {
 	 * @param pt Click position in the cargo label field.
 	 * @return Cargo clicked at, or #INVALID_CARGO if none.
 	 */
-	CargoID CargoLabelClickedAt(Point pt) const
+	CargoType CargoLabelClickedAt(Point pt) const
 	{
 		assert(this->type == CFT_CARGO_LABEL);
 
@@ -2437,7 +2437,7 @@ struct CargoesRow {
 		std::fill(std::begin(ind_fld->u.industry.other_produced), std::end(ind_fld->u.industry.other_produced), INVALID_CARGO);
 
 		if (ind_fld->u.industry.ind_type < NUM_INDUSTRYTYPES) {
-			CargoID others[MAX_CARGOES]; // Produced cargoes not carried in the cargo column.
+			CargoType others[MAX_CARGOES]; // Produced cargoes not carried in the cargo column.
 			int other_count = 0;
 
 			const IndustrySpec *indsp = GetIndustrySpec(ind_fld->u.industry.ind_type);
@@ -2454,9 +2454,9 @@ struct CargoesRow {
 		} else {
 			/* Houses only display cargo that towns produce. */
 			for (uint i = 0; i < cargo_fld->u.cargo.num_cargoes; i++) {
-				CargoID cid = cargo_fld->u.cargo.vertical_cargoes[i];
-				TownProductionEffect tpe = CargoSpec::Get(cid)->town_production_effect;
-				if (tpe == TPE_PASSENGERS || tpe == TPE_MAIL) cargo_fld->ConnectCargo(cid, true);
+				CargoType cargo_type = cargo_fld->u.cargo.vertical_cargoes[i];
+				TownProductionEffect tpe = CargoSpec::Get(cargo_type)->town_production_effect;
+				if (tpe == TPE_PASSENGERS || tpe == TPE_MAIL) cargo_fld->ConnectCargo(cargo_type, true);
 			}
 		}
 	}
@@ -2468,7 +2468,7 @@ struct CargoesRow {
 	 */
 	void MakeCargoLabel(int column, bool accepting)
 	{
-		CargoID cargoes[MAX_CARGOES];
+		CargoType cargoes[MAX_CARGOES];
 		std::fill(std::begin(cargoes), std::end(cargoes), INVALID_CARGO);
 
 		CargoesField *label_fld = this->columns + column;
@@ -2496,7 +2496,7 @@ struct CargoesRow {
 		std::fill(std::begin(ind_fld->u.industry.other_accepted), std::end(ind_fld->u.industry.other_accepted), INVALID_CARGO);
 
 		if (ind_fld->u.industry.ind_type < NUM_INDUSTRYTYPES) {
-			CargoID others[MAX_CARGOES]; // Accepted cargoes not carried in the cargo column.
+			CargoType others[MAX_CARGOES]; // Accepted cargoes not carried in the cargo column.
 			int other_count = 0;
 
 			const IndustrySpec *indsp = GetIndustrySpec(ind_fld->u.industry.ind_type);
@@ -2561,7 +2561,7 @@ struct IndustryCargoesWindow : public Window {
 	typedef std::vector<CargoesRow> Fields;
 
 	Fields fields;  ///< Fields to display in the #WID_IC_PANEL.
-	uint ind_cargo; ///< If less than #NUM_INDUSTRYTYPES, an industry type, else a cargo id + NUM_INDUSTRYTYPES.
+	uint ind_cargo; ///< If less than #NUM_INDUSTRYTYPES, an industry type, else a cargo type + NUM_INDUSTRYTYPES.
 	Dimension cargo_textsize; ///< Size to hold any cargo text, as well as STR_INDUSTRY_CARGOES_SELECT_CARGO.
 	Dimension ind_textsize;   ///< Size to hold any industry type text, as well as STR_INDUSTRY_CARGOES_SELECT_INDUSTRY.
 	Scrollbar *vscroll;
@@ -2615,8 +2615,8 @@ struct IndustryCargoesWindow : public Window {
 			const IndustrySpec *indsp = GetIndustrySpec(it);
 			if (!indsp->enabled) continue;
 			this->ind_textsize = maxdim(this->ind_textsize, GetStringBoundingBox(indsp->name));
-			CargoesField::max_cargoes = std::max<uint>(CargoesField::max_cargoes, std::ranges::count_if(indsp->accepts_cargo, IsValidCargoID));
-			CargoesField::max_cargoes = std::max<uint>(CargoesField::max_cargoes, std::ranges::count_if(indsp->produced_cargo, IsValidCargoID));
+			CargoesField::max_cargoes = std::max<uint>(CargoesField::max_cargoes, std::ranges::count_if(indsp->accepts_cargo, IsValidCargoType));
+			CargoesField::max_cargoes = std::max<uint>(CargoesField::max_cargoes, std::ranges::count_if(indsp->produced_cargo, IsValidCargoType));
 		}
 		d.width = std::max(d.width, this->ind_textsize.width);
 		d.height = this->ind_textsize.height;
@@ -2682,12 +2682,12 @@ struct IndustryCargoesWindow : public Window {
 	 * @param cargoes2 Span of the second cargo list.
 	 * @return Arrays have at least one valid cargo in common.
 	 */
-	static bool HasCommonValidCargo(const std::span<const CargoID> cargoes1, const std::span<const CargoID> cargoes2)
+	static bool HasCommonValidCargo(const std::span<const CargoType> cargoes1, const std::span<const CargoType> cargoes2)
 	{
-		for (const CargoID cid1 : cargoes1) {
-			if (!IsValidCargoID(cid1)) continue;
-			for (const CargoID cid2 : cargoes2) {
-				if (cid1 == cid2) return true;
+		for (const CargoType cargo_type1 : cargoes1) {
+			if (!IsValidCargoType(cargo_type1)) continue;
+			for (const CargoType cargo_type2 : cargoes2) {
+				if (cargo_type1 == cargo_type2) return true;
 			}
 		}
 		return false;
@@ -2698,11 +2698,11 @@ struct IndustryCargoesWindow : public Window {
 	 * @param cargoes Span of cargo list.
 	 * @return Houses can supply at least one of the cargoes.
 	 */
-	static bool HousesCanSupply(const std::span<const CargoID> cargoes)
+	static bool HousesCanSupply(const std::span<const CargoType> cargoes)
 	{
-		for (const CargoID cid : cargoes) {
-			if (!IsValidCargoID(cid)) continue;
-			TownProductionEffect tpe = CargoSpec::Get(cid)->town_production_effect;
+		for (const CargoType cargo_type : cargoes) {
+			if (!IsValidCargoType(cargo_type)) continue;
+			TownProductionEffect tpe = CargoSpec::Get(cargo_type)->town_production_effect;
 			if (tpe == TPE_PASSENGERS || tpe == TPE_MAIL) return true;
 		}
 		return false;
@@ -2713,7 +2713,7 @@ struct IndustryCargoesWindow : public Window {
 	 * @param cargoes Span of cargo list.
 	 * @return Houses can accept at least one of the cargoes.
 	 */
-	static bool HousesCanAccept(const std::span<const CargoID> cargoes)
+	static bool HousesCanAccept(const std::span<const CargoType> cargoes)
 	{
 		HouseZones climate_mask;
 		switch (_settings_game.game_creation.landscape) {
@@ -2723,14 +2723,14 @@ struct IndustryCargoesWindow : public Window {
 			case LT_TOYLAND:   climate_mask = HZ_TOYLND; break;
 			default: NOT_REACHED();
 		}
-		for (const CargoID cid : cargoes) {
-			if (!IsValidCargoID(cid)) continue;
+		for (const CargoType cargo_type : cargoes) {
+			if (!IsValidCargoType(cargo_type)) continue;
 
 			for (const auto &hs : HouseSpec::Specs()) {
 				if (!hs.enabled || !(hs.building_availability & climate_mask)) continue;
 
 				for (uint j = 0; j < lengthof(hs.accepts_cargo); j++) {
-					if (hs.cargo_acceptance[j] > 0 && cid == hs.accepts_cargo[j]) return true;
+					if (hs.cargo_acceptance[j] > 0 && cargo_type == hs.accepts_cargo[j]) return true;
 				}
 			}
 		}
@@ -2742,7 +2742,7 @@ struct IndustryCargoesWindow : public Window {
 	 * @param cargoes Cargoes to search.
 	 * @return Number of industries that have an accepted cargo in common with the supplied set.
 	 */
-	static int CountMatchingAcceptingIndustries(const std::span<const CargoID> cargoes)
+	static int CountMatchingAcceptingIndustries(const std::span<const CargoType> cargoes)
 	{
 		int count = 0;
 		for (IndustryType it = 0; it < NUM_INDUSTRYTYPES; it++) {
@@ -2759,7 +2759,7 @@ struct IndustryCargoesWindow : public Window {
 	 * @param cargoes Cargoes to search.
 	 * @return Number of industries that have a produced cargo in common with the supplied set.
 	 */
-	static int CountMatchingProducingIndustries(const std::span<const CargoID> cargoes)
+	static int CountMatchingProducingIndustries(const std::span<const CargoType> cargoes)
 	{
 		int count = 0;
 		for (IndustryType it = 0; it < NUM_INDUSTRYTYPES; it++) {
@@ -2900,13 +2900,13 @@ struct IndustryCargoesWindow : public Window {
 	}
 
 	/**
-	 * Compute what and where to display for cargo id \a cid.
-	 * @param cid Cargo id to display.
+	 * Compute what and where to display for cargo type \a cargo_type.
+	 * @param cargo_type Cargo type to display.
 	 */
-	void ComputeCargoDisplay(CargoID cid)
+	void ComputeCargoDisplay(CargoType cargo_type)
 	{
 		this->GetWidget<NWidgetCore>(WID_IC_CAPTION)->SetString(STR_INDUSTRY_CARGOES_CARGO_CAPTION);
-		this->ind_cargo = cid + NUM_INDUSTRYTYPES;
+		this->ind_cargo = cargo_type + NUM_INDUSTRYTYPES;
 		_displayed_industries.reset();
 
 		this->fields.clear();
@@ -2917,7 +2917,7 @@ struct IndustryCargoesWindow : public Window {
 		first_row.columns[3].MakeEmpty(CFT_SMALL_EMPTY);
 		first_row.columns[4].MakeEmpty(CFT_SMALL_EMPTY);
 
-		auto cargoes = std::span(&cid, 1);
+		auto cargoes = std::span(&cargo_type, 1);
 		bool houses_supply = HousesCanSupply(cargoes);
 		bool houses_accept = HousesCanAccept(cargoes);
 		int num_supp = CountMatchingProducingIndustries(cargoes) + houses_supply + 1; // Ensure room for the cargo label.
@@ -3087,14 +3087,14 @@ struct IndustryCargoesWindow : public Window {
 					case CFT_CARGO: {
 						CargoesField *lft = (fieldxy.x > 0) ? this->fields[fieldxy.y].columns + fieldxy.x - 1 : nullptr;
 						CargoesField *rgt = (fieldxy.x < 4) ? this->fields[fieldxy.y].columns + fieldxy.x + 1 : nullptr;
-						CargoID cid = fld->CargoClickedAt(lft, rgt, xy);
-						if (IsValidCargoID(cid)) this->ComputeCargoDisplay(cid);
+						CargoType cargo_type = fld->CargoClickedAt(lft, rgt, xy);
+						if (IsValidCargoType(cargo_type)) this->ComputeCargoDisplay(cargo_type);
 						break;
 					}
 
 					case CFT_CARGO_LABEL: {
-						CargoID cid = fld->CargoLabelClickedAt(xy);
-						if (IsValidCargoID(cid)) this->ComputeCargoDisplay(cid);
+						CargoType cargo_type = fld->CargoLabelClickedAt(xy);
+						if (IsValidCargoType(cargo_type)) this->ComputeCargoDisplay(cargo_type);
 						break;
 					}
 
@@ -3167,17 +3167,17 @@ struct IndustryCargoesWindow : public Window {
 		if (!CalculatePositionInWidget(pt, &fieldxy, &xy)) return false;
 
 		const CargoesField *fld = this->fields[fieldxy.y].columns + fieldxy.x;
-		CargoID cid = INVALID_CARGO;
+		CargoType cargo_type = INVALID_CARGO;
 		switch (fld->type) {
 			case CFT_CARGO: {
 				CargoesField *lft = (fieldxy.x > 0) ? this->fields[fieldxy.y].columns + fieldxy.x - 1 : nullptr;
 				CargoesField *rgt = (fieldxy.x < 4) ? this->fields[fieldxy.y].columns + fieldxy.x + 1 : nullptr;
-				cid = fld->CargoClickedAt(lft, rgt, xy);
+				cargo_type = fld->CargoClickedAt(lft, rgt, xy);
 				break;
 			}
 
 			case CFT_CARGO_LABEL: {
-				cid = fld->CargoLabelClickedAt(xy);
+				cargo_type = fld->CargoLabelClickedAt(xy);
 				break;
 			}
 
@@ -3190,8 +3190,8 @@ struct IndustryCargoesWindow : public Window {
 			default:
 				break;
 		}
-		if (IsValidCargoID(cid) && (this->ind_cargo < NUM_INDUSTRYTYPES || cid != this->ind_cargo - NUM_INDUSTRYTYPES)) {
-			const CargoSpec *csp = CargoSpec::Get(cid);
+		if (IsValidCargoType(cargo_type) && (this->ind_cargo < NUM_INDUSTRYTYPES || cargo_type != this->ind_cargo - NUM_INDUSTRYTYPES)) {
+			const CargoSpec *csp = CargoSpec::Get(cargo_type);
 			SetDParam(0, csp->name);
 			GuiShowTooltips(this, STR_INDUSTRY_CARGOES_CARGO_TOOLTIP, close_cond, 1);
 			return true;

--- a/src/industrytype.h
+++ b/src/industrytype.h
@@ -105,14 +105,14 @@ struct IndustrySpec {
 	uint32_t prospecting_chance;                  ///< Chance prospecting succeeds
 	IndustryType conflicting[3];                ///< Industries this industry cannot be close to
 	uint8_t check_proc;                            ///< Index to a procedure to check for conflicting circumstances
-	std::array<CargoID, INDUSTRY_NUM_OUTPUTS> produced_cargo;
+	std::array<CargoType, INDUSTRY_NUM_OUTPUTS> produced_cargo;
 	uint8_t production_rate[INDUSTRY_NUM_OUTPUTS];
 	/**
 	 * minimum amount of cargo transported to the stations.
 	 * If the waiting cargo is less than this number, no cargo is moved to it.
 	 */
 	uint8_t minimal_cargo;
-	std::array<CargoID, INDUSTRY_NUM_INPUTS> accepts_cargo; ///< 16 accepted cargoes.
+	std::array<CargoType, INDUSTRY_NUM_INPUTS> accepts_cargo; ///< 16 accepted cargoes.
 	uint16_t input_cargo_multiplier[INDUSTRY_NUM_INPUTS][INDUSTRY_NUM_OUTPUTS]; ///< Input cargo multipliers (multiply amount of incoming cargo for the produced cargoes)
 	IndustryLifeType life_type;                 ///< This is also known as Industry production flag, in newgrf specs
 	uint8_t climate_availability;                  ///< Bitmask, giving landscape enums as bit position
@@ -147,7 +147,7 @@ struct IndustrySpec {
  * @note A tile can at most accept 3 types of cargo, even if an industry as a whole can accept more types.
  */
 struct IndustryTileSpec {
-	std::array<CargoID, INDUSTRY_NUM_INPUTS> accepts_cargo; ///< Cargo accepted by this tile
+	std::array<CargoType, INDUSTRY_NUM_INPUTS> accepts_cargo; ///< Cargo accepted by this tile
 	std::array<int8_t, INDUSTRY_NUM_INPUTS> acceptance; ///< Level of acceptance per cargo type (signed, may be negative!)
 	Slope slopes_refused;                 ///< slope pattern on which this tile cannot be built
 	uint8_t anim_production;                 ///< Animation frame to start when goods are produced

--- a/src/linkgraph/demands.cpp
+++ b/src/linkgraph/demands.cpp
@@ -263,7 +263,7 @@ DemandCalculator::DemandCalculator(LinkGraphJob &job) :
 	base_distance(IntSqrt(DistanceMaxPlusManhattan(TileXY(0,0), TileXY(Map::MaxX(), Map::MaxY()))))
 {
 	const LinkGraphSettings &settings = job.Settings();
-	CargoID cargo = job.Cargo();
+	CargoType cargo = job.Cargo();
 
 	this->accuracy = settings.accuracy;
 	this->mod_dist = settings.demand_distance;

--- a/src/linkgraph/linkgraph.h
+++ b/src/linkgraph/linkgraph.h
@@ -194,7 +194,7 @@ public:
 	 * Real constructor.
 	 * @param cargo Cargo the link graph is about.
 	 */
-	LinkGraph(CargoID cargo) : cargo(cargo), last_compression(TimerGameEconomy::date) {}
+	LinkGraph(CargoType cargo) : cargo(cargo), last_compression(TimerGameEconomy::date) {}
 
 	void Init(uint size);
 	void ShiftDates(TimerGameEconomy::Date interval);
@@ -236,10 +236,10 @@ public:
 	inline TimerGameEconomy::Date LastCompression() const { return this->last_compression; }
 
 	/**
-	 * Get the cargo ID this component's link graph refers to.
-	 * @return Cargo ID.
+	 * Get the cargo type this component's link graph refers to.
+	 * @return Cargo type.
 	 */
-	inline CargoID Cargo() const { return this->cargo; }
+	inline CargoType Cargo() const { return this->cargo; }
 
 	/**
 	 * Scale a value to its monthly equivalent, based on last compression.
@@ -261,7 +261,7 @@ protected:
 	friend class SlLinkgraphEdge;
 	friend class LinkGraphJob;
 
-	CargoID cargo;         ///< Cargo of this component's link graph.
+	CargoType cargo;         ///< Cargo of this component's link graph.
 	TimerGameEconomy::Date last_compression; ///< Last time the capacities and supplies were compressed.
 	NodeVector nodes;      ///< Nodes in the component.
 };

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -86,7 +86,7 @@ void LinkGraphOverlay::RebuildCache()
 		StationLinkMap &seen_links = this->cached_links[from];
 
 		uint supply = 0;
-		for (CargoID c : SetCargoBitIterator(this->cargo_mask)) {
+		for (CargoType c : SetCargoBitIterator(this->cargo_mask)) {
 			if (!CargoSpec::Get(c)->IsValid()) continue;
 			if (!LinkGraph::IsValidID(sta->goods[c].link_graph)) continue;
 			const LinkGraph &lg = *LinkGraph::Get(sta->goods[c].link_graph);
@@ -212,7 +212,7 @@ inline bool LinkGraphOverlay::IsLinkVisible(Point pta, Point ptb, const DrawPixe
  */
 void LinkGraphOverlay::AddLinks(const Station *from, const Station *to)
 {
-	for (CargoID c : SetCargoBitIterator(this->cargo_mask)) {
+	for (CargoType c : SetCargoBitIterator(this->cargo_mask)) {
 		if (!CargoSpec::Get(c)->IsValid()) continue;
 		const GoodsEntry &ge = from->goods[c];
 		if (!LinkGraph::IsValidID(ge.link_graph) ||
@@ -241,7 +241,7 @@ void LinkGraphOverlay::AddLinks(const Station *from, const Station *to)
  * @param new_shared If the new link is shared.
  * @param cargo LinkProperties to write the information to.
  */
-/* static */ void LinkGraphOverlay::AddStats(CargoID new_cargo, uint new_cap, uint new_usg, uint new_plan, uint32_t time, bool new_shared, LinkProperties &cargo)
+/* static */ void LinkGraphOverlay::AddStats(CargoType new_cargo, uint new_cap, uint new_usg, uint new_plan, uint32_t time, bool new_shared, LinkProperties &cargo)
 {
 	/* multiply the numbers by 32 in order to avoid comparing to 0 too often. */
 	if (cargo.capacity == 0 ||

--- a/src/linkgraph/linkgraph_gui.h
+++ b/src/linkgraph/linkgraph_gui.h
@@ -26,7 +26,7 @@ struct LinkProperties {
 	/** Return the usage of the link to display. */
 	uint Usage() const { return std::max(this->usage, this->planned); }
 
-	CargoID cargo; ///< Cargo type of the link.
+	CargoType cargo; ///< Cargo type of the link.
 	uint capacity; ///< Capacity of the link.
 	uint usage;    ///< Actual usage of the link.
 	uint planned;  ///< Planned usage of the link.
@@ -94,7 +94,7 @@ protected:
 	void GetWidgetDpi(DrawPixelInfo *dpi) const;
 	void RebuildCache();
 
-	static void AddStats(CargoID new_cargo, uint new_cap, uint new_usg, uint new_flow, uint32_t time, bool new_shared, LinkProperties &cargo);
+	static void AddStats(CargoType new_cargo, uint new_cap, uint new_usg, uint new_flow, uint32_t time, bool new_shared, LinkProperties &cargo);
 	static void DrawVertex(int x, int y, int size, int colour, int border_colour);
 };
 

--- a/src/linkgraph/linkgraphjob.h
+++ b/src/linkgraph/linkgraphjob.h
@@ -248,7 +248,7 @@ public:
 	 * Get the cargo of the underlying link graph.
 	 * @return Cargo.
 	 */
-	inline CargoID Cargo() const { return this->link_graph.Cargo(); }
+	inline CargoType Cargo() const { return this->link_graph.Cargo(); }
 
 	/**
 	 * Get the date when the underlying link graph was last compressed.

--- a/src/linkgraph/refresh.cpp
+++ b/src/linkgraph/refresh.cpp
@@ -85,7 +85,7 @@ LinkRefresher::LinkRefresher(Vehicle *vehicle, HopSet *seen_hops, bool allow_mer
  * @param refit_cargo Cargo to refit to.
  * @return True if any vehicle was refit; false if none was.
  */
-bool LinkRefresher::HandleRefit(CargoID refit_cargo)
+bool LinkRefresher::HandleRefit(CargoType refit_cargo)
 {
 	this->cargo = refit_cargo;
 	RefitList::iterator refit_it = this->refit_capacities.begin();
@@ -99,7 +99,7 @@ bool LinkRefresher::HandleRefit(CargoID refit_cargo)
 		any_refit = true;
 
 		/* Back up the vehicle's cargo type */
-		CargoID temp_cid = v->cargo_type;
+		CargoType temp_cargo_type = v->cargo_type;
 		uint8_t temp_subtype = v->cargo_subtype;
 		v->cargo_type = this->cargo;
 		v->cargo_subtype = GetBestFittingSubType(v, v, this->cargo);
@@ -108,7 +108,7 @@ bool LinkRefresher::HandleRefit(CargoID refit_cargo)
 		uint amount = e->DetermineCapacity(v, &mail_capacity);
 
 		/* Restore the original cargo type */
-		v->cargo_type = temp_cid;
+		v->cargo_type = temp_cargo_type;
 		v->cargo_subtype = temp_subtype;
 
 		/* Skip on next refit. */
@@ -202,7 +202,7 @@ void LinkRefresher::RefreshStats(const Order *cur, const Order *next)
 	Station *st = Station::GetIfValid(cur->GetDestination());
 	if (st != nullptr && next_station != INVALID_STATION && next_station != st->index) {
 		Station *st_to = Station::Get(next_station);
-		for (CargoID c = 0; c < NUM_CARGO; c++) {
+		for (CargoType c = 0; c < NUM_CARGO; c++) {
 			/* Refresh the link and give it a minimum capacity. */
 
 			uint cargo_quantity = this->capacities[c];
@@ -271,7 +271,7 @@ void LinkRefresher::RefreshLinks(const Order *cur, const Order *next, uint8_t fl
 			} else if (!HasBit(flags, IN_AUTOREFIT)) {
 				SetBit(flags, IN_AUTOREFIT);
 				LinkRefresher backup(*this);
-				for (CargoID c = 0; c != NUM_CARGO; ++c) {
+				for (CargoType c = 0; c != NUM_CARGO; ++c) {
 					if (CargoSpec::Get(c)->IsValid() && this->HandleRefit(c)) {
 						this->RefreshLinks(cur, next, flags, num_hops);
 						*this = backup;

--- a/src/linkgraph/refresh.h
+++ b/src/linkgraph/refresh.h
@@ -37,10 +37,10 @@ protected:
 	 * Simulated cargo type and capacity for prediction of future links.
 	 */
 	struct RefitDesc {
-		CargoID cargo;    ///< Cargo type the vehicle will be carrying.
+		CargoType cargo;    ///< Cargo type the vehicle will be carrying.
 		uint16_t capacity;  ///< Capacity the vehicle will have.
 		uint16_t remaining; ///< Capacity remaining from before the previous refit.
-		RefitDesc(CargoID cargo, uint16_t capacity, uint16_t remaining) :
+		RefitDesc(CargoType cargo, uint16_t capacity, uint16_t remaining) :
 				cargo(cargo), capacity(capacity), remaining(remaining) {}
 	};
 
@@ -56,7 +56,7 @@ protected:
 	struct Hop {
 		OrderID from;  ///< Last order where vehicle could interact with cargo or absolute first order.
 		OrderID to;    ///< Next order to be processed.
-		CargoID cargo; ///< Cargo the consist is probably carrying or INVALID_CARGO if unknown.
+		CargoType cargo; ///< Cargo the consist is probably carrying or INVALID_CARGO if unknown.
 
 		/**
 		 * Default constructor should not be called but has to be visible for
@@ -70,7 +70,7 @@ protected:
 		 * @param to Second order of the hop.
 		 * @param cargo Cargo the consist is probably carrying when passing the hop.
 		 */
-		Hop(OrderID from, OrderID to, CargoID cargo) : from(from), to(to), cargo(cargo) {}
+		Hop(OrderID from, OrderID to, CargoType cargo) : from(from), to(to), cargo(cargo) {}
 		bool operator<(const Hop &other) const;
 	};
 
@@ -78,16 +78,16 @@ protected:
 	typedef std::set<Hop> HopSet;
 
 	Vehicle *vehicle;           ///< Vehicle for which the links should be refreshed.
-	CargoArray capacities{}; ///< Current added capacities per cargo ID in the consist.
+	CargoArray capacities{}; ///< Current added capacities per cargo type in the consist.
 	RefitList refit_capacities; ///< Current state of capacity remaining from previous refits versus overall capacity per vehicle in the consist.
 	HopSet *seen_hops;          ///< Hops already seen. If the same hop is seen twice we stop the algorithm. This is shared between all Refreshers of the same run.
-	CargoID cargo;              ///< Cargo given in last refit order.
+	CargoType cargo;              ///< Cargo given in last refit order.
 	bool allow_merge;           ///< If the refresher is allowed to merge or extend link graphs.
 	bool is_full_loading;       ///< If the vehicle is full loading.
 
 	LinkRefresher(Vehicle *v, HopSet *seen_hops, bool allow_merge, bool is_full_loading);
 
-	bool HandleRefit(CargoID refit_cargo);
+	bool HandleRefit(CargoType refit_cargo);
 	void ResetRefit();
 	void RefreshStats(const Order *cur, const Order *next);
 	const Order *PredictNextOrder(const Order *cur, const Order *next, uint8_t flags, uint num_hops = 0);

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -964,8 +964,8 @@ static CargoTypes TranslateRefitMask(uint32_t refit_mask)
 {
 	CargoTypes result = 0;
 	for (uint8_t bit : SetBitIterator(refit_mask)) {
-		CargoID cargo = GetCargoTranslation(bit, _cur.grffile, true);
-		if (IsValidCargoID(cargo)) SetBit(result, cargo);
+		CargoType cargo = GetCargoTranslation(bit, _cur.grffile, true);
+		if (IsValidCargoType(cargo)) SetBit(result, cargo);
 	}
 	return result;
 }
@@ -1322,8 +1322,8 @@ static ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, B
 				CargoTypes &ctt = prop == 0x2C ? _gted[e->index].ctt_include_mask : _gted[e->index].ctt_exclude_mask;
 				ctt = 0;
 				while (count--) {
-					CargoID ctype = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
-					if (IsValidCargoID(ctype)) SetBit(ctt, ctype);
+					CargoType ctype = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
+					if (IsValidCargoType(ctype)) SetBit(ctt, ctype);
 				}
 				break;
 			}
@@ -1531,8 +1531,8 @@ static ChangeInfoResult RoadVehicleChangeInfo(uint first, uint last, int prop, B
 				CargoTypes &ctt = prop == 0x24 ? _gted[e->index].ctt_include_mask : _gted[e->index].ctt_exclude_mask;
 				ctt = 0;
 				while (count--) {
-					CargoID ctype = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
-					if (IsValidCargoID(ctype)) SetBit(ctt, ctype);
+					CargoType ctype = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
+					if (IsValidCargoType(ctype)) SetBit(ctt, ctype);
 				}
 				break;
 			}
@@ -1714,8 +1714,8 @@ static ChangeInfoResult ShipVehicleChangeInfo(uint first, uint last, int prop, B
 				CargoTypes &ctt = prop == 0x1E ? _gted[e->index].ctt_include_mask : _gted[e->index].ctt_exclude_mask;
 				ctt = 0;
 				while (count--) {
-					CargoID ctype = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
-					if (IsValidCargoID(ctype)) SetBit(ctt, ctype);
+					CargoType ctype = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
+					if (IsValidCargoType(ctype)) SetBit(ctt, ctype);
 				}
 				break;
 			}
@@ -1887,8 +1887,8 @@ static ChangeInfoResult AircraftVehicleChangeInfo(uint first, uint last, int pro
 				CargoTypes &ctt = prop == 0x1D ? _gted[e->index].ctt_include_mask : _gted[e->index].ctt_exclude_mask;
 				ctt = 0;
 				while (count--) {
-					CargoID ctype = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
-					if (IsValidCargoID(ctype)) SetBit(ctt, ctype);
+					CargoType ctype = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
+					if (IsValidCargoType(ctype)) SetBit(ctt, ctype);
 				}
 				break;
 			}
@@ -2484,9 +2484,9 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 					 * climate. This can cause problems when copying the properties
 					 * of a house that accepts food, where the new house is valid
 					 * in the temperate climate. */
-					CargoID cid = housespec->accepts_cargo[2];
-					if (!IsValidCargoID(cid)) cid = GetCargoIDByLabel(housespec->accepts_cargo_label[2]);
-					if (!IsValidCargoID(cid)) {
+					CargoType cargo_type = housespec->accepts_cargo[2];
+					if (!IsValidCargoType(cargo_type)) cargo_type = GetCargoTypeByLabel(housespec->accepts_cargo_label[2]);
+					if (!IsValidCargoType(cargo_type)) {
 						housespec->cargo_acceptance[2] = 0;
 					}
 				}
@@ -2522,13 +2522,13 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 
 				/* If value of goods is negative, it means in fact food or, if in toyland, fizzy_drink acceptance.
 				 * Else, we have "standard" 3rd cargo type, goods or candy, for toyland once more */
-				CargoID cid = (goods >= 0) ? ((_settings_game.game_creation.landscape == LT_TOYLAND) ? GetCargoIDByLabel(CT_CANDY) : GetCargoIDByLabel(CT_GOODS)) :
-						((_settings_game.game_creation.landscape == LT_TOYLAND) ? GetCargoIDByLabel(CT_FIZZY_DRINKS) : GetCargoIDByLabel(CT_FOOD));
+				CargoType cargo_type = (goods >= 0) ? ((_settings_game.game_creation.landscape == LT_TOYLAND) ? GetCargoTypeByLabel(CT_CANDY) : GetCargoTypeByLabel(CT_GOODS)) :
+						((_settings_game.game_creation.landscape == LT_TOYLAND) ? GetCargoTypeByLabel(CT_FIZZY_DRINKS) : GetCargoTypeByLabel(CT_FOOD));
 
 				/* Make sure the cargo type is valid in this climate. */
-				if (!IsValidCargoID(cid)) goods = 0;
+				if (!IsValidCargoType(cargo_type)) goods = 0;
 
-				housespec->accepts_cargo[2] = cid;
+				housespec->accepts_cargo[2] = cargo_type;
 				housespec->accepts_cargo_label[2] = CT_INVALID;
 				housespec->cargo_acceptance[2] = abs(goods); // but we do need positive value here
 				break;
@@ -2610,9 +2610,9 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 				for (uint j = 0; j < HOUSE_ORIGINAL_NUM_ACCEPTS; j++) {
 					/* Get the cargo number from the 'list' */
 					uint8_t cargo_part = GB(cargotypes, 8 * j, 8);
-					CargoID cargo = GetCargoTranslation(cargo_part, _cur.grffile);
+					CargoType cargo = GetCargoTranslation(cargo_part, _cur.grffile);
 
-					if (!IsValidCargoID(cargo)) {
+					if (!IsValidCargoType(cargo)) {
 						/* Disable acceptance of invalid cargo type */
 						housespec->cargo_acceptance[j] = 0;
 					} else {
@@ -2630,8 +2630,8 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 			case 0x20: { // Cargo acceptance watch list
 				uint8_t count = buf.ReadByte();
 				for (uint8_t j = 0; j < count; j++) {
-					CargoID cargo = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
-					if (IsValidCargoID(cargo)) SetBit(housespec->watched_cargoes, cargo);
+					CargoType cargo = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
+					if (IsValidCargoType(cargo)) SetBit(housespec->watched_cargoes, cargo);
 				}
 				break;
 			}
@@ -3856,7 +3856,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 				}
 				for (size_t i = 0; i < std::size(indsp->produced_cargo); i++) {
 					if (i < num_cargoes) {
-						CargoID cargo = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
+						CargoType cargo = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
 						indsp->produced_cargo[i] = cargo;
 					} else {
 						indsp->produced_cargo[i] = INVALID_CARGO;
@@ -3875,7 +3875,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 				}
 				for (size_t i = 0; i < std::size(indsp->accepts_cargo); i++) {
 					if (i < num_cargoes) {
-						CargoID cargo = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
+						CargoType cargo = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
 						indsp->accepts_cargo[i] = cargo;
 					} else {
 						indsp->accepts_cargo[i] = INVALID_CARGO;
@@ -5536,8 +5536,8 @@ static void NewSpriteGroup(ByteReader &buf)
 						}
 						for (uint i = 0; i < group->num_input; i++) {
 							uint8_t rawcargo = buf.ReadByte();
-							CargoID cargo = GetCargoTranslation(rawcargo, _cur.grffile);
-							if (!IsValidCargoID(cargo)) {
+							CargoType cargo = GetCargoTranslation(rawcargo, _cur.grffile);
+							if (!IsValidCargoType(cargo)) {
 								/* The mapped cargo is invalid. This is permitted at this point,
 								 * as long as the result is not used. Mark it invalid so this
 								 * can be tested later. */
@@ -5558,8 +5558,8 @@ static void NewSpriteGroup(ByteReader &buf)
 						}
 						for (uint i = 0; i < group->num_output; i++) {
 							uint8_t rawcargo = buf.ReadByte();
-							CargoID cargo = GetCargoTranslation(rawcargo, _cur.grffile);
-							if (!IsValidCargoID(cargo)) {
+							CargoType cargo = GetCargoTranslation(rawcargo, _cur.grffile);
+							if (!IsValidCargoType(cargo)) {
 								/* Mark this result as invalid to use */
 								group->version = 0xFF;
 							} else if (std::find(group->cargo_output, group->cargo_output + i, cargo) != group->cargo_output + i) {
@@ -5603,7 +5603,7 @@ std::span<const CargoLabel> GetCargoTranslationTable(const GRFFile &grffile)
 	return GetClimateIndependentCargoTranslationTable();
 }
 
-static CargoID TranslateCargo(uint8_t feature, uint8_t ctype)
+static CargoType TranslateCargo(uint8_t feature, uint8_t ctype)
 {
 	/* Special cargo types for purchase list and stations */
 	if ((feature == GSF_STATIONS || feature == GSF_ROADSTOPS) && ctype == 0xFE) return SpriteGroupCargo::SG_DEFAULT_NA;
@@ -5624,14 +5624,14 @@ static CargoID TranslateCargo(uint8_t feature, uint8_t ctype)
 		return INVALID_CARGO;
 	}
 
-	CargoID cid = GetCargoIDByLabel(cl);
-	if (!IsValidCargoID(cid)) {
+	CargoType cargo_type = GetCargoTypeByLabel(cl);
+	if (!IsValidCargoType(cargo_type)) {
 		GrfMsg(5, "TranslateCargo: Cargo '{:c}{:c}{:c}{:c}' unsupported, skipping.", GB(cl.base(), 24, 8), GB(cl.base(), 16, 8), GB(cl.base(), 8, 8), GB(cl.base(), 0, 8));
 		return INVALID_CARGO;
 	}
 
-	GrfMsg(6, "TranslateCargo: Cargo '{:c}{:c}{:c}{:c}' mapped to cargo type {}.", GB(cl.base(), 24, 8), GB(cl.base(), 16, 8), GB(cl.base(), 8, 8), GB(cl.base(), 0, 8), cid);
-	return cid;
+	GrfMsg(6, "TranslateCargo: Cargo '{:c}{:c}{:c}{:c}' mapped to cargo type {}.", GB(cl.base(), 24, 8), GB(cl.base(), 16, 8), GB(cl.base(), 8, 8), GB(cl.base(), 0, 8), cargo_type);
+	return cargo_type;
 }
 
 
@@ -5690,8 +5690,8 @@ static void VehicleMapSpriteGroup(ByteReader &buf, uint8_t feature, uint8_t idco
 
 		GrfMsg(8, "VehicleMapSpriteGroup: * [{}] Cargo type 0x{:X}, group id 0x{:02X}", c, ctype, groupid);
 
-		CargoID cid = TranslateCargo(feature, ctype);
-		if (!IsValidCargoID(cid)) continue;
+		CargoType cargo_type = TranslateCargo(feature, ctype);
+		if (!IsValidCargoType(cargo_type)) continue;
 
 		for (uint i = 0; i < idcount; i++) {
 			EngineID engine = engines[i];
@@ -5699,9 +5699,9 @@ static void VehicleMapSpriteGroup(ByteReader &buf, uint8_t feature, uint8_t idco
 			GrfMsg(7, "VehicleMapSpriteGroup: [{}] Engine {}...", i, engine);
 
 			if (wagover) {
-				SetWagonOverrideSprites(engine, cid, _cur.spritegroups[groupid], last_engines);
+				SetWagonOverrideSprites(engine, cargo_type, _cur.spritegroups[groupid], last_engines);
 			} else {
-				SetCustomEngineSprites(engine, cid, _cur.spritegroups[groupid]);
+				SetCustomEngineSprites(engine, cargo_type, _cur.spritegroups[groupid]);
 			}
 		}
 	}
@@ -5770,7 +5770,7 @@ static void StationMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 		if (!IsValidGroupID(groupid, "StationMapSpriteGroup")) continue;
 
 		ctype = TranslateCargo(GSF_STATIONS, ctype);
-		if (!IsValidCargoID(ctype)) continue;
+		if (!IsValidCargoType(ctype)) continue;
 
 		for (auto &station : stations) {
 			StationSpec *statspec = station >= _cur.grffile->stations.size() ? nullptr : _cur.grffile->stations[station].get();
@@ -5920,13 +5920,13 @@ static void CargoMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 	uint16_t groupid = buf.ReadWord();
 	if (!IsValidGroupID(groupid, "CargoMapSpriteGroup")) return;
 
-	for (auto &cid : cargoes) {
-		if (cid >= NUM_CARGO) {
-			GrfMsg(1, "CargoMapSpriteGroup: Cargo ID {} out of range, skipping", cid);
+	for (auto &cargo_type : cargoes) {
+		if (cargo_type >= NUM_CARGO) {
+			GrfMsg(1, "CargoMapSpriteGroup: Cargo type {} out of range, skipping", cargo_type);
 			continue;
 		}
 
-		CargoSpec *cs = CargoSpec::Get(cid);
+		CargoSpec *cs = CargoSpec::Get(cargo_type);
 		cs->grffile = _cur.grffile;
 		cs->group = _cur.spritegroups[groupid];
 	}
@@ -6142,7 +6142,7 @@ static void RoadStopMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 		if (!IsValidGroupID(groupid, "RoadStopMapSpriteGroup")) continue;
 
 		ctype = TranslateCargo(GSF_ROADSTOPS, ctype);
-		if (!IsValidCargoID(ctype)) continue;
+		if (!IsValidCargoType(ctype)) continue;
 
 		for (auto &roadstop : roadstops) {
 			RoadStopSpec *roadstopspec = roadstop >= _cur.grffile->roadstops.size() ? nullptr : _cur.grffile->roadstops[roadstop].get();
@@ -6913,9 +6913,9 @@ static void SkipIf(ByteReader &buf)
 	if (condtype >= 0x0B) {
 		/* Tests that ignore 'param' */
 		switch (condtype) {
-			case 0x0B: result = !IsValidCargoID(GetCargoIDByLabel(CargoLabel(BSWAP32(cond_val))));
+			case 0x0B: result = !IsValidCargoType(GetCargoTypeByLabel(CargoLabel(BSWAP32(cond_val))));
 				break;
-			case 0x0C: result = IsValidCargoID(GetCargoIDByLabel(CargoLabel(BSWAP32(cond_val))));
+			case 0x0C: result = IsValidCargoType(GetCargoTypeByLabel(CargoLabel(BSWAP32(cond_val))));
 				break;
 			case 0x0D: result = GetRailTypeByLabel(BSWAP32(cond_val)) == INVALID_RAILTYPE;
 				break;
@@ -8963,8 +8963,8 @@ GRFFile::GRFFile(const GRFConfig *config)
 static CargoLabel GetActiveCargoLabel(const std::initializer_list<CargoLabel> &labels)
 {
 	for (const CargoLabel &label : labels) {
-		CargoID cid = GetCargoIDByLabel(label);
-		if (cid != INVALID_CARGO) return label;
+		CargoType cargo_type = GetCargoTypeByLabel(label);
+		if (cargo_type != INVALID_CARGO) return label;
 	}
 	return CT_INVALID;
 }
@@ -8998,8 +8998,8 @@ static CargoLabel GetActiveCargoLabel(const std::variant<CargoLabel, MixedCargoT
 static void CalculateRefitMasks()
 {
 	CargoTypes original_known_cargoes = 0;
-	for (CargoID cid = 0; cid != NUM_CARGO; ++cid) {
-		if (IsDefaultCargo(cid)) SetBit(original_known_cargoes, cid);
+	for (CargoType cargo_type = 0; cargo_type != NUM_CARGO; ++cargo_type) {
+		if (IsDefaultCargo(cargo_type)) SetBit(original_known_cargoes, cargo_type);
 	}
 
 	for (Engine *e : Engine::Iterate()) {
@@ -9008,8 +9008,8 @@ static void CalculateRefitMasks()
 		bool only_defaultcargo; ///< Set if the vehicle shall carry only the default cargo
 
 		/* Apply default cargo translation map if cargo type hasn't been set, either explicitly or by aircraft cargo handling. */
-		if (!IsValidCargoID(e->info.cargo_type)) {
-			e->info.cargo_type = GetCargoIDByLabel(GetActiveCargoLabel(e->info.cargo_label));
+		if (!IsValidCargoType(e->info.cargo_type)) {
+			e->info.cargo_type = GetCargoTypeByLabel(GetActiveCargoLabel(e->info.cargo_label));
 		}
 
 		/* If the NewGRF did not set any cargo properties, we apply default values. */
@@ -9094,7 +9094,7 @@ static void CalculateRefitMasks()
 			}
 			_gted[engine].UpdateRefittability(_gted[engine].cargo_allowed != 0);
 
-			if (IsValidCargoID(ei->cargo_type)) ClrBit(_gted[engine].ctt_exclude_mask, ei->cargo_type);
+			if (IsValidCargoType(ei->cargo_type)) ClrBit(_gted[engine].ctt_exclude_mask, ei->cargo_type);
 		}
 
 		/* Compute refittability */
@@ -9142,24 +9142,24 @@ static void CalculateRefitMasks()
 		}
 
 		/* Clear invalid cargoslots (from default vehicles or pre-NewCargo GRFs) */
-		if (IsValidCargoID(ei->cargo_type) && !HasBit(_cargo_mask, ei->cargo_type)) ei->cargo_type = INVALID_CARGO;
+		if (IsValidCargoType(ei->cargo_type) && !HasBit(_cargo_mask, ei->cargo_type)) ei->cargo_type = INVALID_CARGO;
 
 		/* Ensure that the vehicle is either not refittable, or that the default cargo is one of the refittable cargoes.
 		 * Note: Vehicles refittable to no cargo are handle differently to vehicle refittable to a single cargo. The latter might have subtypes. */
-		if (!only_defaultcargo && (e->type != VEH_SHIP || e->u.ship.old_refittable) && IsValidCargoID(ei->cargo_type) && !HasBit(ei->refit_mask, ei->cargo_type)) {
+		if (!only_defaultcargo && (e->type != VEH_SHIP || e->u.ship.old_refittable) && IsValidCargoType(ei->cargo_type) && !HasBit(ei->refit_mask, ei->cargo_type)) {
 			ei->cargo_type = INVALID_CARGO;
 		}
 
 		/* Check if this engine's cargo type is valid. If not, set to the first refittable
 		 * cargo type. Finally disable the vehicle, if there is still no cargo. */
-		if (!IsValidCargoID(ei->cargo_type) && ei->refit_mask != 0) {
+		if (!IsValidCargoType(ei->cargo_type) && ei->refit_mask != 0) {
 			/* Figure out which CTT to use for the default cargo, if it is 'first refittable'. */
 			const GRFFile *file = _gted[engine].defaultcargo_grf;
 			if (file == nullptr) file = e->GetGRF();
 			if (file != nullptr && file->grf_version >= 8 && !file->cargo_list.empty()) {
 				/* Use first refittable cargo from cargo translation table */
 				uint8_t best_local_slot = UINT8_MAX;
-				for (CargoID cargo_type : SetCargoBitIterator(ei->refit_mask)) {
+				for (CargoType cargo_type : SetCargoBitIterator(ei->refit_mask)) {
 					uint8_t local_slot = file->cargo_map[cargo_type];
 					if (local_slot < best_local_slot) {
 						best_local_slot = local_slot;
@@ -9168,20 +9168,20 @@ static void CalculateRefitMasks()
 				}
 			}
 
-			if (!IsValidCargoID(ei->cargo_type)) {
+			if (!IsValidCargoType(ei->cargo_type)) {
 				/* Use first refittable cargo slot */
-				ei->cargo_type = (CargoID)FindFirstBit(ei->refit_mask);
+				ei->cargo_type = (CargoType)FindFirstBit(ei->refit_mask);
 			}
 		}
-		if (!IsValidCargoID(ei->cargo_type) && e->type == VEH_TRAIN && e->u.rail.railveh_type != RAILVEH_WAGON && e->u.rail.capacity == 0) {
+		if (!IsValidCargoType(ei->cargo_type) && e->type == VEH_TRAIN && e->u.rail.railveh_type != RAILVEH_WAGON && e->u.rail.capacity == 0) {
 			/* For train engines which do not carry cargo it does not matter if their cargo type is invalid.
 			 * Fallback to the first available instead, if the cargo type has not been changed (as indicated by
 			 * cargo_label not being CT_INVALID). */
 			if (GetActiveCargoLabel(ei->cargo_label) != CT_INVALID) {
-				ei->cargo_type = static_cast<CargoID>(FindFirstBit(_standard_cargo_mask));
+				ei->cargo_type = static_cast<CargoType>(FindFirstBit(_standard_cargo_mask));
 			}
 		}
-		if (!IsValidCargoID(ei->cargo_type)) ei->climates = 0;
+		if (!IsValidCargoType(ei->cargo_type)) ei->climates = 0;
 
 		/* Clear refit_mask for not refittable ships */
 		if (e->type == VEH_SHIP && !e->u.ship.old_refittable) {
@@ -9421,9 +9421,9 @@ static void FinaliseHouseArray()
 
 		/* Apply default cargo translation map for unset cargo slots */
 		for (uint i = 0; i < lengthof(hs->accepts_cargo_label); ++i) {
-			if (!IsValidCargoID(hs->accepts_cargo[i])) hs->accepts_cargo[i] = GetCargoIDByLabel(hs->accepts_cargo_label[i]);
+			if (!IsValidCargoType(hs->accepts_cargo[i])) hs->accepts_cargo[i] = GetCargoTypeByLabel(hs->accepts_cargo_label[i]);
 			/* Disable acceptance if cargo type is invalid. */
-			if (!IsValidCargoID(hs->accepts_cargo[i])) hs->cargo_acceptance[i] = 0;
+			if (!IsValidCargoType(hs->accepts_cargo[i])) hs->cargo_acceptance[i] = 0;
 		}
 	}
 
@@ -9476,17 +9476,17 @@ static void FinaliseIndustriesArray()
 
 		/* Apply default cargo translation map for unset cargo slots */
 		for (size_t i = 0; i < std::size(indsp.produced_cargo_label); ++i) {
-			if (!IsValidCargoID(indsp.produced_cargo[i])) indsp.produced_cargo[i] = GetCargoIDByLabel(GetActiveCargoLabel(indsp.produced_cargo_label[i]));
+			if (!IsValidCargoType(indsp.produced_cargo[i])) indsp.produced_cargo[i] = GetCargoTypeByLabel(GetActiveCargoLabel(indsp.produced_cargo_label[i]));
 		}
 		for (size_t i = 0; i < std::size(indsp.accepts_cargo_label); ++i) {
-			if (!IsValidCargoID(indsp.accepts_cargo[i])) indsp.accepts_cargo[i] = GetCargoIDByLabel(GetActiveCargoLabel(indsp.accepts_cargo_label[i]));
+			if (!IsValidCargoType(indsp.accepts_cargo[i])) indsp.accepts_cargo[i] = GetCargoTypeByLabel(GetActiveCargoLabel(indsp.accepts_cargo_label[i]));
 		}
 	}
 
 	for (auto &indtsp : _industry_tile_specs) {
 		/* Apply default cargo translation map for unset cargo slots */
 		for (size_t i = 0; i < std::size(indtsp.accepts_cargo_label); ++i) {
-			if (!IsValidCargoID(indtsp.accepts_cargo[i])) indtsp.accepts_cargo[i] = GetCargoIDByLabel(GetActiveCargoLabel(indtsp.accepts_cargo_label[i]));
+			if (!IsValidCargoType(indtsp.accepts_cargo[i])) indtsp.accepts_cargo[i] = GetCargoTypeByLabel(GetActiveCargoLabel(indtsp.accepts_cargo_label[i]));
 		}
 	}
 }

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -127,7 +127,7 @@ struct GRFFile : ZeroedMemoryAllocator {
 	std::vector<GRFLabel> labels;                   ///< List of labels
 
 	std::vector<CargoLabel> cargo_list;             ///< Cargo translation table (local ID -> label)
-	std::array<uint8_t, NUM_CARGO> cargo_map{}; ///< Inverse cargo translation table (CargoID -> local ID)
+	std::array<uint8_t, NUM_CARGO> cargo_map{}; ///< Inverse cargo translation table (CargoType -> local ID)
 
 	std::vector<RailTypeLabel> railtype_list;       ///< Railtype translation table
 	std::array<RailType, RAILTYPE_END> railtype_map{};

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -296,7 +296,7 @@ void AnimateAirportTile(TileIndex tile)
 	AirportTileAnimationBase::AnimateTile(ats, Station::GetByTile(tile), tile, HasBit(ats->animation_special_flags, 0));
 }
 
-void AirportTileAnimationTrigger(Station *st, TileIndex tile, AirpAnimationTrigger trigger, CargoID cargo_type)
+void AirportTileAnimationTrigger(Station *st, TileIndex tile, AirpAnimationTrigger trigger, CargoType cargo_type)
 {
 	const AirportTileSpec *ats = AirportTileSpec::GetByTile(tile);
 	if (!HasBit(ats->animation.triggers, trigger)) return;
@@ -304,7 +304,7 @@ void AirportTileAnimationTrigger(Station *st, TileIndex tile, AirpAnimationTrigg
 	AirportTileAnimationBase::ChangeAnimationFrame(CBID_AIRPTILE_ANIM_START_STOP, ats, st, tile, Random(), (uint8_t)trigger | (cargo_type << 8));
 }
 
-void AirportAnimationTrigger(Station *st, AirpAnimationTrigger trigger, CargoID cargo_type)
+void AirportAnimationTrigger(Station *st, AirpAnimationTrigger trigger, CargoType cargo_type)
 {
 	if (st->airport.tile == INVALID_TILE) return;
 

--- a/src/newgrf_airporttiles.h
+++ b/src/newgrf_airporttiles.h
@@ -85,8 +85,8 @@ private:
 };
 
 void AnimateAirportTile(TileIndex tile);
-void AirportTileAnimationTrigger(Station *st, TileIndex tile, AirpAnimationTrigger trigger, CargoID cargo_type = INVALID_CARGO);
-void AirportAnimationTrigger(Station *st, AirpAnimationTrigger trigger, CargoID cargo_type = INVALID_CARGO);
+void AirportTileAnimationTrigger(Station *st, TileIndex tile, AirpAnimationTrigger trigger, CargoType cargo_type = INVALID_CARGO);
+void AirportAnimationTrigger(Station *st, AirpAnimationTrigger trigger, CargoType cargo_type = INVALID_CARGO);
 bool DrawNewAirportTile(TileInfo *ti, Station *st, const AirportTileSpec *airts);
 
 #endif /* NEWGRF_AIRPORTTILES_H */

--- a/src/newgrf_cargo.cpp
+++ b/src/newgrf_cargo.cpp
@@ -69,15 +69,15 @@ uint16_t GetCargoCallback(CallbackID callback, uint32_t param1, uint32_t param2,
 }
 
 /**
- * Translate a GRF-local cargo slot/bitnum into a CargoID.
+ * Translate a GRF-local cargo slot/bitnum into a CargoType.
  * @param cargo   GRF-local cargo slot/bitnum.
  * @param grffile Originating GRF file.
  * @param usebit  Defines the meaning of \a cargo for GRF version < 7.
  *                If true, then \a cargo is a bitnum. If false, then \a cargo is a cargoslot.
  *                For GRF version >= 7 \a cargo is always a translated cargo bit.
- * @return CargoID or INVALID_CARGO if the cargo is not available.
+ * @return CargoType or INVALID_CARGO if the cargo is not available.
  */
-CargoID GetCargoTranslation(uint8_t cargo, const GRFFile *grffile, bool usebit)
+CargoType GetCargoTranslation(uint8_t cargo, const GRFFile *grffile, bool usebit)
 {
 	/* We can't use GetCargoTranslationTable here as the usebit flag changes behviour. */
 	/* Pre-version 7 uses the bitnum lookup from (standard in v8) instead of climate dependent in some places.. */
@@ -90,6 +90,6 @@ CargoID GetCargoTranslation(uint8_t cargo, const GRFFile *grffile, bool usebit)
 		cargo_list = GetClimateIndependentCargoTranslationTable();
 	}
 
-	if (cargo < cargo_list.size()) return GetCargoIDByLabel(cargo_list[cargo]);
+	if (cargo < cargo_list.size()) return GetCargoTypeByLabel(cargo_list[cargo]);
 	return INVALID_CARGO;
 }

--- a/src/newgrf_cargo.h
+++ b/src/newgrf_cargo.h
@@ -20,9 +20,9 @@
  * e.g. in purchase lists, or if no specific cargo type sprite group is supplied.
  */
 namespace SpriteGroupCargo {
-	static constexpr CargoID SG_DEFAULT    = NUM_CARGO;     ///< Default type used when no more-specific cargo matches.
-	static constexpr CargoID SG_PURCHASE   = NUM_CARGO + 1; ///< Used in purchase lists before an item exists.
-	static constexpr CargoID SG_DEFAULT_NA = NUM_CARGO + 2; ///< Used only by stations and roads when no more-specific cargo matches.
+	static constexpr CargoType SG_DEFAULT    = NUM_CARGO;     ///< Default type used when no more-specific cargo matches.
+	static constexpr CargoType SG_PURCHASE   = NUM_CARGO + 1; ///< Used in purchase lists before an item exists.
+	static constexpr CargoType SG_DEFAULT_NA = NUM_CARGO + 2; ///< Used only by stations and roads when no more-specific cargo matches.
 };
 
 /* Forward declarations of structs used */
@@ -31,7 +31,7 @@ struct GRFFile;
 
 SpriteID GetCustomCargoSprite(const CargoSpec *cs);
 uint16_t GetCargoCallback(CallbackID callback, uint32_t param1, uint32_t param2, const CargoSpec *cs);
-CargoID GetCargoTranslation(uint8_t cargo, const GRFFile *grffile, bool usebit = false);
+CargoType GetCargoTranslation(uint8_t cargo, const GRFFile *grffile, bool usebit = false);
 
 std::span<const CargoLabel> GetClimateDependentCargoTranslationTable();
 std::span<const CargoLabel> GetClimateIndependentCargoTranslationTable();

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -494,7 +494,7 @@ struct NewGRFInspectWindow : Window {
 						break;
 
 					case NIT_CARGO:
-						string = IsValidCargoID(value) ? CargoSpec::Get(value)->name : STR_QUANTITY_N_A;
+						string = IsValidCargoType(value) ? CargoSpec::Get(value)->name : STR_QUANTITY_N_A;
 						break;
 
 					default:

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -27,7 +27,7 @@
 
 #include "safeguards.h"
 
-void SetWagonOverrideSprites(EngineID engine, CargoID cargo, const SpriteGroup *group, std::span<EngineID> engine_ids)
+void SetWagonOverrideSprites(EngineID engine, CargoType cargo, const SpriteGroup *group, std::span<EngineID> engine_ids)
 {
 	Engine *e = Engine::Get(engine);
 
@@ -39,7 +39,7 @@ void SetWagonOverrideSprites(EngineID engine, CargoID cargo, const SpriteGroup *
 	wo->engines.assign(engine_ids.begin(), engine_ids.end());
 }
 
-const SpriteGroup *GetWagonOverrideSpriteSet(EngineID engine, CargoID cargo, EngineID overriding_engine)
+const SpriteGroup *GetWagonOverrideSpriteSet(EngineID engine, CargoType cargo, EngineID overriding_engine)
 {
 	const Engine *e = Engine::Get(engine);
 
@@ -50,7 +50,7 @@ const SpriteGroup *GetWagonOverrideSpriteSet(EngineID engine, CargoID cargo, Eng
 	return nullptr;
 }
 
-void SetCustomEngineSprites(EngineID engine, CargoID cargo, const SpriteGroup *group)
+void SetCustomEngineSprites(EngineID engine, CargoType cargo, const SpriteGroup *group)
 {
 	Engine *e = Engine::Get(engine);
 	assert(cargo < std::size(e->grf_prop.spritegroup));
@@ -453,7 +453,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 				/* Pick the most common cargo type */
 				auto cargo_it = std::max_element(std::begin(common_cargoes), std::end(common_cargoes));
 				/* Return INVALID_CARGO if nothing is carried */
-				CargoID common_cargo_type = (*cargo_it == 0) ? INVALID_CARGO : static_cast<CargoID>(std::distance(std::begin(common_cargoes), cargo_it));
+				CargoType common_cargo_type = (*cargo_it == 0) ? INVALID_CARGO : static_cast<CargoType>(std::distance(std::begin(common_cargoes), cargo_it));
 
 				/* Count subcargo types of common_cargo_type */
 				std::array<uint8_t, UINT8_MAX + 1> common_subtypes{};
@@ -476,7 +476,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 			}
 
 			/* The cargo translation is specific to the accessing GRF, and thus cannot be cached. */
-			CargoID common_cargo_type = (v->grf_cache.consist_cargo_information >> 8) & 0xFF;
+			CargoType common_cargo_type = (v->grf_cache.consist_cargo_information >> 8) & 0xFF;
 
 			/* Note:
 			 *  - Unlike everywhere else the cargo translation table is only used since grf version 8, not 7.
@@ -949,8 +949,8 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 			case 0x46: return 0;               // Motion counter
 			case 0x47: { // Vehicle cargo info
 				const Engine *e = Engine::Get(this->self_type);
-				CargoID cargo_type = e->GetDefaultCargoType();
-				if (IsValidCargoID(cargo_type)) {
+				CargoType cargo_type = e->GetDefaultCargoType();
+				if (IsValidCargoType(cargo_type)) {
 					const CargoSpec *cs = CargoSpec::Get(cargo_type);
 					return (cs->classes << 16) | (cs->weight << 8) | this->ro.grffile->cargo_map[cargo_type];
 				} else {
@@ -1062,7 +1062,7 @@ VehicleResolverObject::VehicleResolverObject(EngineID engine_type, const Vehicle
 
 		if (this->root_spritegroup == nullptr) {
 			const Engine *e = Engine::Get(engine_type);
-			CargoID cargo = v != nullptr ? v->cargo_type : SpriteGroupCargo::SG_PURCHASE;
+			CargoType cargo = v != nullptr ? v->cargo_type : SpriteGroupCargo::SG_PURCHASE;
 			assert(cargo < std::size(e->grf_prop.spritegroup));
 			this->root_spritegroup = e->grf_prop.spritegroup[cargo] != nullptr ? e->grf_prop.spritegroup[cargo] : e->grf_prop.spritegroup[SpriteGroupCargo::SG_DEFAULT];
 		}

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -76,9 +76,9 @@ static const uint VEHICLEINFO_FULL_VEHICLE_WIDTH    = 32;
 
 struct VehicleSpriteSeq;
 
-void SetWagonOverrideSprites(EngineID engine, CargoID cargo, const struct SpriteGroup *group, std::span<EngineID> engine_ids);
-const SpriteGroup *GetWagonOverrideSpriteSet(EngineID engine, CargoID cargo, EngineID overriding_engine);
-void SetCustomEngineSprites(EngineID engine, CargoID cargo, const struct SpriteGroup *group);
+void SetWagonOverrideSprites(EngineID engine, CargoType cargo, const struct SpriteGroup *group, std::span<EngineID> engine_ids);
+const SpriteGroup *GetWagonOverrideSpriteSet(EngineID engine, CargoType cargo, EngineID overriding_engine);
+void SetCustomEngineSprites(EngineID engine, CargoType cargo, const struct SpriteGroup *group);
 
 void GetCustomEngineSprite(EngineID engine, const Vehicle *v, Direction direction, EngineImageType image_type, VehicleSpriteSeq *result);
 #define GetCustomVehicleSprite(v, direction, image_type, result) GetCustomEngineSprite(v->engine_type, v, direction, image_type, result)

--- a/src/newgrf_generic.cpp
+++ b/src/newgrf_generic.cpp
@@ -19,7 +19,7 @@
 
 /** Scope resolver for generic objects and properties. */
 struct GenericScopeResolver : public ScopeResolver {
-	CargoID cargo_type;
+	CargoType cargo_type;
 	uint8_t default_selection;
 	uint8_t src_industry;        ///< Source industry substitute type. 0xFF for "town", 0xFE for "unknown".
 	uint8_t dst_industry;        ///< Destination industry substitute type. 0xFF for "town", 0xFE for "unknown".
@@ -203,7 +203,7 @@ static uint16_t GetGenericCallbackResult(uint8_t feature, ResolverObject &object
  * @param[out] file Optionally returns the GRFFile which made the final decision for the callback result. May be nullptr if not required.
  * @return callback value if successful or CALLBACK_FAILED
  */
-uint16_t GetAiPurchaseCallbackResult(uint8_t feature, CargoID cargo_type, uint8_t default_selection, IndustryType src_industry, IndustryType dst_industry, uint8_t distance, AIConstructionEvent event, uint8_t count, uint8_t station_size, const GRFFile **file)
+uint16_t GetAiPurchaseCallbackResult(uint8_t feature, CargoType cargo_type, uint8_t default_selection, IndustryType src_industry, IndustryType dst_industry, uint8_t distance, AIConstructionEvent event, uint8_t count, uint8_t station_size, const GRFFile **file)
 {
 	GenericResolverObject object(true, CBID_GENERIC_AI_PURCHASE_SELECTION);
 

--- a/src/newgrf_generic.h
+++ b/src/newgrf_generic.h
@@ -47,7 +47,7 @@ static const IndustryType IT_AI_TOWN    = 0xFF; ///< The AI actually wants to tr
 void ResetGenericCallbacks();
 void AddGenericCallback(uint8_t feature, const GRFFile *file, const SpriteGroup *group);
 
-uint16_t GetAiPurchaseCallbackResult(uint8_t feature, CargoID cargo_type, uint8_t default_selection, IndustryType src_industry, IndustryType dst_industry, uint8_t distance, AIConstructionEvent event, uint8_t count, uint8_t station_size, const GRFFile **file);
+uint16_t GetAiPurchaseCallbackResult(uint8_t feature, CargoType cargo_type, uint8_t default_selection, IndustryType src_industry, IndustryType dst_industry, uint8_t distance, AIConstructionEvent event, uint8_t count, uint8_t station_size, const GRFFile **file);
 void AmbientSoundEffectCallback(TileIndex tile);
 
 /** Play an ambient sound effect for an empty tile. */

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -446,8 +446,8 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex tile, Ho
 
 		/* Cargo acceptance history of nearby stations */
 		case 0x64: {
-			CargoID cid = GetCargoTranslation(parameter, this->ro.grffile);
-			if (!IsValidCargoID(cid)) return 0;
+			CargoType cargo_type = GetCargoTranslation(parameter, this->ro.grffile);
+			if (!IsValidCargoType(cargo_type)) return 0;
 
 			/* Extract tile offset. */
 			int8_t x_offs = GB(GetRegister(0x100), 0, 8);
@@ -459,14 +459,14 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex tile, Ho
 			/* Collect acceptance stats. */
 			uint32_t res = 0;
 			for (Station *st : stations.GetStations()) {
-				if (HasBit(st->goods[cid].status, GoodsEntry::GES_EVER_ACCEPTED))    SetBit(res, 0);
-				if (HasBit(st->goods[cid].status, GoodsEntry::GES_LAST_MONTH))       SetBit(res, 1);
-				if (HasBit(st->goods[cid].status, GoodsEntry::GES_CURRENT_MONTH))    SetBit(res, 2);
-				if (HasBit(st->goods[cid].status, GoodsEntry::GES_ACCEPTED_BIGTICK)) SetBit(res, 3);
+				if (HasBit(st->goods[cargo_type].status, GoodsEntry::GES_EVER_ACCEPTED))    SetBit(res, 0);
+				if (HasBit(st->goods[cargo_type].status, GoodsEntry::GES_LAST_MONTH))       SetBit(res, 1);
+				if (HasBit(st->goods[cargo_type].status, GoodsEntry::GES_CURRENT_MONTH))    SetBit(res, 2);
+				if (HasBit(st->goods[cargo_type].status, GoodsEntry::GES_ACCEPTED_BIGTICK)) SetBit(res, 3);
 			}
 
 			/* Cargo triggered CB 148? */
-			if (HasBit(this->watched_cargo_triggers, cid)) SetBit(res, 4);
+			if (HasBit(this->watched_cargo_triggers, cargo_type)) SetBit(res, 4);
 
 			return res;
 		}

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -322,8 +322,8 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t param_setID, uint8_
 		case 0x6D:
 		case 0x70:
 		case 0x71: {
-			CargoID cargo = GetCargoTranslation(parameter, this->ro.grffile);
-			if (!IsValidCargoID(cargo)) return 0;
+			CargoType cargo = GetCargoTranslation(parameter, this->ro.grffile);
+			if (!IsValidCargoType(cargo)) return 0;
 			auto it = this->industry->GetCargoProduced(cargo);
 			if (it == std::end(this->industry->produced)) return 0; // invalid cargo
 			switch (variable) {
@@ -341,8 +341,8 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t param_setID, uint8_
 
 		case 0x6E:
 		case 0x6F: {
-			CargoID cargo = GetCargoTranslation(parameter, this->ro.grffile);
-			if (!IsValidCargoID(cargo)) return 0;
+			CargoType cargo = GetCargoTranslation(parameter, this->ro.grffile);
+			if (!IsValidCargoType(cargo)) return 0;
 			auto it = this->industry->GetCargoAccepted(cargo);
 			if (it == std::end(this->industry->accepted)) return 0; // invalid cargo
 			if (variable == 0x6E) return it->last_accepted.base();
@@ -644,11 +644,11 @@ void IndustryProductionCallback(Industry *ind, int reason)
 		if (group->version < 2) {
 			/* Callback parameters map directly to industry cargo slot indices */
 			for (uint i = 0; i < group->num_input && i < ind->accepted.size(); i++) {
-				if (!IsValidCargoID(ind->accepted[i].cargo)) continue;
+				if (!IsValidCargoType(ind->accepted[i].cargo)) continue;
 				ind->accepted[i].waiting = ClampTo<uint16_t>(ind->accepted[i].waiting - DerefIndProd(group->subtract_input[i], deref) * multiplier);
 			}
 			for (uint i = 0; i < group->num_output && i < ind->produced.size(); i++) {
-				if (!IsValidCargoID(ind->produced[i].cargo)) continue;
+				if (!IsValidCargoType(ind->produced[i].cargo)) continue;
 				ind->produced[i].waiting = ClampTo<uint16_t>(ind->produced[i].waiting + std::max(DerefIndProd(group->add_output[i], deref), 0) * multiplier);
 			}
 		} else {
@@ -681,7 +681,7 @@ void IndustryProductionCallback(Industry *ind, int reason)
  * @pre cargo_type is in ind->accepts_cargo.
  * @return Whether the given industry refuses to accept this cargo type.
  */
-bool IndustryTemporarilyRefusesCargo(Industry *ind, CargoID cargo_type)
+bool IndustryTemporarilyRefusesCargo(Industry *ind, CargoType cargo_type)
 {
 	assert(ind->IsCargoAccepted(cargo_type));
 

--- a/src/newgrf_industries.h
+++ b/src/newgrf_industries.h
@@ -91,7 +91,7 @@ uint32_t GetIndustryIDAtOffset(TileIndex new_tile, const Industry *i, uint32_t c
 void IndustryProductionCallback(Industry *ind, int reason);
 CommandCost CheckIfCallBackAllowsCreation(TileIndex tile, IndustryType type, size_t layout, uint32_t seed, uint16_t initial_random_bits, Owner founder, IndustryAvailabilityCallType creation_type);
 uint32_t GetIndustryProbabilityCallback(IndustryType type, IndustryAvailabilityCallType creation_type, uint32_t default_prob);
-bool IndustryTemporarilyRefusesCargo(Industry *ind, CargoID cargo_type);
+bool IndustryTemporarilyRefusesCargo(Industry *ind, CargoType cargo_type);
 
 IndustryType MapNewGRFIndustryType(IndustryType grf_type, uint32_t grf_id);
 

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -222,7 +222,7 @@ RoadStopResolverObject::RoadStopResolverObject(const RoadStopSpec *roadstopspec,
 		CallbackID callback, uint32_t param1, uint32_t param2)
 	: ResolverObject(roadstopspec->grf_prop.grffile, callback, param1, param2), roadstop_scope(*this, st, roadstopspec, tile, roadtype, type, view)
 {
-	CargoID ctype = SpriteGroupCargo::SG_DEFAULT_NA;
+	CargoType ctype = SpriteGroupCargo::SG_DEFAULT_NA;
 
 	if (st == nullptr) {
 		/* No station, so we are in a purchase list */
@@ -365,7 +365,7 @@ void AnimateRoadStopTile(TileIndex tile)
 	RoadStopAnimationBase::AnimateTile(ss, BaseStation::GetByTile(tile), tile, HasBit(ss->flags, RSF_CB141_RANDOM_BITS));
 }
 
-void TriggerRoadStopAnimation(BaseStation *st, TileIndex trigger_tile, StationAnimationTrigger trigger, CargoID cargo_type)
+void TriggerRoadStopAnimation(BaseStation *st, TileIndex trigger_tile, StationAnimationTrigger trigger, CargoType cargo_type)
 {
 	/* Get Station if it wasn't supplied */
 	if (st == nullptr) st = BaseStation::GetByTile(trigger_tile);
@@ -378,8 +378,8 @@ void TriggerRoadStopAnimation(BaseStation *st, TileIndex trigger_tile, StationAn
 	auto process_tile = [&](TileIndex cur_tile) {
 		const RoadStopSpec *ss = GetRoadStopSpec(cur_tile);
 		if (ss != nullptr && HasBit(ss->animation.triggers, trigger)) {
-			CargoID cargo;
-			if (!IsValidCargoID(cargo_type)) {
+			CargoType cargo;
+			if (!IsValidCargoType(cargo_type)) {
 				cargo = INVALID_CARGO;
 			} else {
 				cargo = ss->grf_prop.grffile->cargo_map[cargo_type];
@@ -405,14 +405,14 @@ void TriggerRoadStopAnimation(BaseStation *st, TileIndex trigger_tile, StationAn
  * @param trigger trigger type
  * @param cargo_type cargo type causing the trigger
  */
-void TriggerRoadStopRandomisation(Station *st, TileIndex tile, RoadStopRandomTrigger trigger, CargoID cargo_type)
+void TriggerRoadStopRandomisation(Station *st, TileIndex tile, RoadStopRandomTrigger trigger, CargoType cargo_type)
 {
 	if (st == nullptr) st = Station::GetByTile(tile);
 
 	/* Check the cached cargo trigger bitmask to see if we need
 	 * to bother with any further processing. */
 	if (st->cached_roadstop_cargo_triggers == 0) return;
-	if (IsValidCargoID(cargo_type) && !HasBit(st->cached_roadstop_cargo_triggers, cargo_type)) return;
+	if (IsValidCargoType(cargo_type) && !HasBit(st->cached_roadstop_cargo_triggers, cargo_type)) return;
 
 	SetBit(st->waiting_triggers, trigger);
 
@@ -432,7 +432,7 @@ void TriggerRoadStopRandomisation(Station *st, TileIndex tile, RoadStopRandomTri
 			if ((ss->cargo_triggers & ~empty_mask) != 0) return;
 		}
 
-		if (!IsValidCargoID(cargo_type) || HasBit(ss->cargo_triggers, cargo_type)) {
+		if (!IsValidCargoType(cargo_type) || HasBit(ss->cargo_triggers, cargo_type)) {
 			RoadStopResolverObject object(ss, st, cur_tile, INVALID_ROADTYPE, GetStationType(cur_tile), GetStationGfx(cur_tile));
 			object.waiting_triggers = st->waiting_triggers;
 

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -90,7 +90,7 @@ struct RoadStopScopeResolver : public ScopeResolver {
 	TileIndex tile;                             ///< %Tile of the station.
 	struct BaseStation *st;                     ///< Instance of the station.
 	const struct RoadStopSpec *roadstopspec;    ///< Station (type) specification.
-	CargoID cargo_type;                         ///< Type of cargo of the station.
+	CargoType cargo_type;                         ///< Type of cargo of the station.
 	StationType type;                           ///< Station type.
 	uint8_t view;                                 ///< Station axis.
 	RoadType roadtype;                          ///< Road type (used when no tile)
@@ -180,8 +180,8 @@ uint16_t GetRoadStopCallback(CallbackID callback, uint32_t param1, uint32_t para
 
 void AnimateRoadStopTile(TileIndex tile);
 uint8_t GetRoadStopTileAnimationSpeed(TileIndex tile);
-void TriggerRoadStopAnimation(BaseStation *st, TileIndex tile, StationAnimationTrigger trigger, CargoID cargo_type = INVALID_CARGO);
-void TriggerRoadStopRandomisation(Station *st, TileIndex tile, RoadStopRandomTrigger trigger, CargoID cargo_type = INVALID_CARGO);
+void TriggerRoadStopAnimation(BaseStation *st, TileIndex tile, StationAnimationTrigger trigger, CargoType cargo_type = INVALID_CARGO);
+void TriggerRoadStopRandomisation(Station *st, TileIndex tile, RoadStopRandomTrigger trigger, CargoType cargo_type = INVALID_CARGO);
 
 bool GetIfNewStopsByType(RoadStopType rs, RoadType roadtype);
 bool GetIfClassHasNewStopsByType(const RoadStopClass *roadstopclass, RoadStopType rs, RoadType roadtype);

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -260,10 +260,10 @@ struct IndustryProductionSpriteGroup : SpriteGroup {
 	uint8_t version;                              ///< Production callback version used, or 0xFF if marked invalid
 	uint8_t num_input;                            ///< How many subtract_input values are valid
 	int16_t subtract_input[INDUSTRY_NUM_INPUTS];  ///< Take this much of the input cargo (can be negative, is indirect in cb version 1+)
-	CargoID cargo_input[INDUSTRY_NUM_INPUTS];   ///< Which input cargoes to take from (only cb version 2)
+	CargoType cargo_input[INDUSTRY_NUM_INPUTS];   ///< Which input cargoes to take from (only cb version 2)
 	uint8_t num_output;                           ///< How many add_output values are valid
 	uint16_t add_output[INDUSTRY_NUM_OUTPUTS];    ///< Add this much output cargo when successful (unsigned, is indirect in cb version 1+)
-	CargoID cargo_output[INDUSTRY_NUM_OUTPUTS]; ///< Which output cargoes to add to (only cb version 2)
+	CargoType cargo_output[INDUSTRY_NUM_OUTPUTS]; ///< Which output cargoes to add to (only cb version 2)
 	uint8_t again;
 
 };

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -422,9 +422,9 @@ uint32_t Station::GetNewGRFVariable(const ResolverObject &object, uint8_t variab
 
 	/* Handle cargo variables with parameter, 0x60 to 0x65 and 0x69 */
 	if ((variable >= 0x60 && variable <= 0x65) || variable == 0x69) {
-		CargoID c = GetCargoTranslation(parameter, object.grffile);
+		CargoType c = GetCargoTranslation(parameter, object.grffile);
 
-		if (!IsValidCargoID(c)) {
+		if (!IsValidCargoType(c)) {
 			switch (variable) {
 				case 0x62: return 0xFFFFFFFF;
 				case 0x64: return 0xFF00;
@@ -577,7 +577,7 @@ StationResolverObject::StationResolverObject(const StationSpec *statspec, BaseSt
 	/* Invalidate all cached vars */
 	_svc.valid = 0;
 
-	CargoID ctype = SpriteGroupCargo::SG_DEFAULT_NA;
+	CargoType ctype = SpriteGroupCargo::SG_DEFAULT_NA;
 
 	if (this->station_scope.st == nullptr) {
 		/* No station, so we are in a purchase list */
@@ -878,7 +878,7 @@ void AnimateStationTile(TileIndex tile)
 	StationAnimationBase::AnimateTile(ss, BaseStation::GetByTile(tile), tile, HasBit(ss->flags, SSF_CB141_RANDOM_BITS));
 }
 
-void TriggerStationAnimation(BaseStation *st, TileIndex trigger_tile, StationAnimationTrigger trigger, CargoID cargo_type)
+void TriggerStationAnimation(BaseStation *st, TileIndex trigger_tile, StationAnimationTrigger trigger, CargoType cargo_type)
 {
 	/* List of coverage areas for each animation trigger */
 	static const TriggerArea tas[] = {
@@ -900,8 +900,8 @@ void TriggerStationAnimation(BaseStation *st, TileIndex trigger_tile, StationAni
 		if (st->TileBelongsToRailStation(tile)) {
 			const StationSpec *ss = GetStationSpec(tile);
 			if (ss != nullptr && HasBit(ss->animation.triggers, trigger)) {
-				CargoID cargo;
-				if (!IsValidCargoID(cargo_type)) {
+				CargoType cargo;
+				if (!IsValidCargoType(cargo_type)) {
 					cargo = INVALID_CARGO;
 				} else {
 					cargo = ss->grf_prop.grffile->cargo_map[cargo_type];
@@ -919,7 +919,7 @@ void TriggerStationAnimation(BaseStation *st, TileIndex trigger_tile, StationAni
  * @param trigger trigger type
  * @param cargo_type cargo type causing trigger
  */
-void TriggerStationRandomisation(Station *st, TileIndex trigger_tile, StationRandomTrigger trigger, CargoID cargo_type)
+void TriggerStationRandomisation(Station *st, TileIndex trigger_tile, StationRandomTrigger trigger, CargoType cargo_type)
 {
 	/* List of coverage areas for each animation trigger */
 	static const TriggerArea tas[] = {
@@ -932,7 +932,7 @@ void TriggerStationRandomisation(Station *st, TileIndex trigger_tile, StationRan
 	/* Check the cached cargo trigger bitmask to see if we need
 	 * to bother with any further processing. */
 	if (st->cached_cargo_triggers == 0) return;
-	if (IsValidCargoID(cargo_type) && !HasBit(st->cached_cargo_triggers, cargo_type)) return;
+	if (IsValidCargoType(cargo_type) && !HasBit(st->cached_cargo_triggers, cargo_type)) return;
 
 	uint32_t whole_reseed = 0;
 	ETileArea area = ETileArea(st, trigger_tile, tas[trigger]);
@@ -956,7 +956,7 @@ void TriggerStationRandomisation(Station *st, TileIndex trigger_tile, StationRan
 				if ((ss->cargo_triggers & ~empty_mask) != 0) continue;
 			}
 
-			if (!IsValidCargoID(cargo_type) || HasBit(ss->cargo_triggers, cargo_type)) {
+			if (!IsValidCargoType(cargo_type) || HasBit(ss->cargo_triggers, cargo_type)) {
 				StationResolverObject object(ss, st, tile, CBID_RANDOM_TRIGGER, 0);
 				object.waiting_triggers = st->waiting_triggers;
 

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -26,7 +26,7 @@ struct StationScopeResolver : public ScopeResolver {
 	TileIndex tile;                     ///< %Tile of the station.
 	struct BaseStation *st;             ///< Instance of the station.
 	const struct StationSpec *statspec; ///< Station (type) specification.
-	CargoID cargo_type;                 ///< Type of cargo of the station.
+	CargoType cargo_type;                 ///< Type of cargo of the station.
 	Axis axis;                          ///< Station axis, used only for the slope check callback.
 
 	/**
@@ -219,8 +219,8 @@ void DeallocateSpecFromStation(BaseStation *st, uint8_t specindex);
 bool DrawStationTile(int x, int y, RailType railtype, Axis axis, StationClassID sclass, uint station);
 
 void AnimateStationTile(TileIndex tile);
-void TriggerStationAnimation(BaseStation *st, TileIndex tile, StationAnimationTrigger trigger, CargoID cargo_type = INVALID_CARGO);
-void TriggerStationRandomisation(Station *st, TileIndex tile, StationRandomTrigger trigger, CargoID cargo_type = INVALID_CARGO);
+void TriggerStationAnimation(BaseStation *st, TileIndex tile, StationAnimationTrigger trigger, CargoType cargo_type = INVALID_CARGO);
+void TriggerStationRandomisation(Station *st, TileIndex tile, StationRandomTrigger trigger, CargoType cargo_type = INVALID_CARGO);
 void StationUpdateCachedTriggers(BaseStation *st);
 
 #endif /* NEWGRF_STATION_H */

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -924,7 +924,7 @@ char32_t RemapNewGRFStringControlCode(char32_t scc, const char **str, StringPara
 				break;
 
 			case SCC_NEWGRF_PRINT_WORD_CARGO_NAME: {
-				CargoID cargo = GetCargoTranslation(_newgrf_textrefstack.PopUnsignedWord(), _newgrf_textrefstack.grffile);
+				CargoType cargo = GetCargoTranslation(_newgrf_textrefstack.PopUnsignedWord(), _newgrf_textrefstack.grffile);
 				parameters.SetParam(0, cargo < NUM_CARGO ? 1ULL << cargo : 0);
 				break;
 			}

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -22,7 +22,7 @@
 		return UINT_MAX;
 	}
 
-	CargoID cid;
+	CargoType cargo_type;
 	switch (variable) {
 		/* Larger towns */
 		case 0x40:
@@ -87,24 +87,24 @@
 		case 0xB2: return this->t->statues;
 		case 0xB6: return ClampTo<uint16_t>(this->t->cache.num_houses);
 		case 0xB9: return this->t->growth_rate / Ticks::TOWN_GROWTH_TICKS;
-		case 0xBA: cid = GetCargoIDByLabel(CT_PASSENGERS); return IsValidCargoID(cid) ? ClampTo<uint16_t>(this->t->supplied[cid].new_max) : 0;
-		case 0xBB: cid = GetCargoIDByLabel(CT_PASSENGERS); return IsValidCargoID(cid) ? GB(ClampTo<uint16_t>(this->t->supplied[cid].new_max), 8, 8) : 0;
-		case 0xBC: cid = GetCargoIDByLabel(CT_MAIL); return IsValidCargoID(cid) ? ClampTo<uint16_t>(this->t->supplied[cid].new_max) : 0;
-		case 0xBD: cid = GetCargoIDByLabel(CT_MAIL); return IsValidCargoID(cid) ? GB(ClampTo<uint16_t>(this->t->supplied[cid].new_max), 8, 8) : 0;
-		case 0xBE: cid = GetCargoIDByLabel(CT_PASSENGERS); return IsValidCargoID(cid) ? ClampTo<uint16_t>(this->t->supplied[cid].new_act) : 0;
-		case 0xBF: cid = GetCargoIDByLabel(CT_PASSENGERS); return IsValidCargoID(cid) ? GB(ClampTo<uint16_t>(this->t->supplied[cid].new_act), 8, 8) : 0;
-		case 0xC0: cid = GetCargoIDByLabel(CT_MAIL); return IsValidCargoID(cid) ? ClampTo<uint16_t>(this->t->supplied[cid].new_act) : 0;
-		case 0xC1: cid = GetCargoIDByLabel(CT_MAIL); return IsValidCargoID(cid) ? GB(ClampTo<uint16_t>(this->t->supplied[cid].new_act), 8, 8) : 0;
-		case 0xC2: cid = GetCargoIDByLabel(CT_PASSENGERS); return IsValidCargoID(cid) ? ClampTo<uint16_t>(this->t->supplied[cid].old_max) : 0;
-		case 0xC3: cid = GetCargoIDByLabel(CT_PASSENGERS); return IsValidCargoID(cid) ? GB(ClampTo<uint16_t>(this->t->supplied[cid].old_max), 8, 8) : 0;
-		case 0xC4: cid = GetCargoIDByLabel(CT_MAIL); return IsValidCargoID(cid) ? ClampTo<uint16_t>(this->t->supplied[cid].old_max) : 0;
-		case 0xC5: cid = GetCargoIDByLabel(CT_MAIL); return IsValidCargoID(cid) ? GB(ClampTo<uint16_t>(this->t->supplied[cid].old_max), 8, 8) : 0;
-		case 0xC6: cid = GetCargoIDByLabel(CT_PASSENGERS); return IsValidCargoID(cid) ? ClampTo<uint16_t>(this->t->supplied[cid].old_act) : 0;
-		case 0xC7: cid = GetCargoIDByLabel(CT_PASSENGERS); return IsValidCargoID(cid) ? GB(ClampTo<uint16_t>(this->t->supplied[cid].old_act), 8, 8) : 0;
-		case 0xC8: cid = GetCargoIDByLabel(CT_MAIL); return IsValidCargoID(cid) ? ClampTo<uint16_t>(this->t->supplied[cid].old_act) : 0;
-		case 0xC9: cid = GetCargoIDByLabel(CT_MAIL); return IsValidCargoID(cid) ? GB(ClampTo<uint16_t>(this->t->supplied[cid].old_act), 8, 8) : 0;
-		case 0xCA: return this->t->GetPercentTransported(GetCargoIDByLabel(CT_PASSENGERS));
-		case 0xCB: return this->t->GetPercentTransported(GetCargoIDByLabel(CT_MAIL));
+		case 0xBA: cargo_type = GetCargoTypeByLabel(CT_PASSENGERS); return IsValidCargoType(cargo_type) ? ClampTo<uint16_t>(this->t->supplied[cargo_type].new_max) : 0;
+		case 0xBB: cargo_type = GetCargoTypeByLabel(CT_PASSENGERS); return IsValidCargoType(cargo_type) ? GB(ClampTo<uint16_t>(this->t->supplied[cargo_type].new_max), 8, 8) : 0;
+		case 0xBC: cargo_type = GetCargoTypeByLabel(CT_MAIL); return IsValidCargoType(cargo_type) ? ClampTo<uint16_t>(this->t->supplied[cargo_type].new_max) : 0;
+		case 0xBD: cargo_type = GetCargoTypeByLabel(CT_MAIL); return IsValidCargoType(cargo_type) ? GB(ClampTo<uint16_t>(this->t->supplied[cargo_type].new_max), 8, 8) : 0;
+		case 0xBE: cargo_type = GetCargoTypeByLabel(CT_PASSENGERS); return IsValidCargoType(cargo_type) ? ClampTo<uint16_t>(this->t->supplied[cargo_type].new_act) : 0;
+		case 0xBF: cargo_type = GetCargoTypeByLabel(CT_PASSENGERS); return IsValidCargoType(cargo_type) ? GB(ClampTo<uint16_t>(this->t->supplied[cargo_type].new_act), 8, 8) : 0;
+		case 0xC0: cargo_type = GetCargoTypeByLabel(CT_MAIL); return IsValidCargoType(cargo_type) ? ClampTo<uint16_t>(this->t->supplied[cargo_type].new_act) : 0;
+		case 0xC1: cargo_type = GetCargoTypeByLabel(CT_MAIL); return IsValidCargoType(cargo_type) ? GB(ClampTo<uint16_t>(this->t->supplied[cargo_type].new_act), 8, 8) : 0;
+		case 0xC2: cargo_type = GetCargoTypeByLabel(CT_PASSENGERS); return IsValidCargoType(cargo_type) ? ClampTo<uint16_t>(this->t->supplied[cargo_type].old_max) : 0;
+		case 0xC3: cargo_type = GetCargoTypeByLabel(CT_PASSENGERS); return IsValidCargoType(cargo_type) ? GB(ClampTo<uint16_t>(this->t->supplied[cargo_type].old_max), 8, 8) : 0;
+		case 0xC4: cargo_type = GetCargoTypeByLabel(CT_MAIL); return IsValidCargoType(cargo_type) ? ClampTo<uint16_t>(this->t->supplied[cargo_type].old_max) : 0;
+		case 0xC5: cargo_type = GetCargoTypeByLabel(CT_MAIL); return IsValidCargoType(cargo_type) ? GB(ClampTo<uint16_t>(this->t->supplied[cargo_type].old_max), 8, 8) : 0;
+		case 0xC6: cargo_type = GetCargoTypeByLabel(CT_PASSENGERS); return IsValidCargoType(cargo_type) ? ClampTo<uint16_t>(this->t->supplied[cargo_type].old_act) : 0;
+		case 0xC7: cargo_type = GetCargoTypeByLabel(CT_PASSENGERS); return IsValidCargoType(cargo_type) ? GB(ClampTo<uint16_t>(this->t->supplied[cargo_type].old_act), 8, 8) : 0;
+		case 0xC8: cargo_type = GetCargoTypeByLabel(CT_MAIL); return IsValidCargoType(cargo_type) ? ClampTo<uint16_t>(this->t->supplied[cargo_type].old_act) : 0;
+		case 0xC9: cargo_type = GetCargoTypeByLabel(CT_MAIL); return IsValidCargoType(cargo_type) ? GB(ClampTo<uint16_t>(this->t->supplied[cargo_type].old_act), 8, 8) : 0;
+		case 0xCA: return this->t->GetPercentTransported(GetCargoTypeByLabel(CT_PASSENGERS));
+		case 0xCB: return this->t->GetPercentTransported(GetCargoTypeByLabel(CT_MAIL));
 		case 0xCC: return this->t->received[TAE_FOOD].new_act;
 		case 0xCD: return GB(this->t->received[TAE_FOOD].new_act, 8, 8);
 		case 0xCE: return this->t->received[TAE_WATER].new_act;

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -630,8 +630,8 @@ static void AddAcceptedCargo_Object(TileIndex tile, CargoArray &acceptance, Carg
 
 	/* Top town building generates 10, so to make HQ interesting, the top
 	 * type makes 20. */
-	CargoID pass = GetCargoIDByLabel(CT_PASSENGERS);
-	if (IsValidCargoID(pass)) {
+	CargoType pass = GetCargoTypeByLabel(CT_PASSENGERS);
+	if (IsValidCargoType(pass)) {
 		acceptance[pass] += std::max(1U, level);
 		SetBit(always_accepted, pass);
 	}
@@ -640,8 +640,8 @@ static void AddAcceptedCargo_Object(TileIndex tile, CargoArray &acceptance, Carg
 	 * proportion passengers:mail is different because such a huge
 	 * commercial building generates unusually high amount of mail
 	 * correspondence per physical visitor. */
-	CargoID mail = GetCargoIDByLabel(CT_MAIL);
-	if (IsValidCargoID(mail)) {
+	CargoType mail = GetCargoTypeByLabel(CT_MAIL);
+	if (IsValidCargoType(mail)) {
 		acceptance[mail] += std::max(1U, level / 2);
 		SetBit(always_accepted, mail);
 	}
@@ -651,10 +651,10 @@ static void AddProducedCargo_Object(TileIndex tile, CargoArray &produced)
 {
 	if (!IsObjectType(tile, OBJECT_HQ)) return;
 
-	CargoID pass = GetCargoIDByLabel(CT_PASSENGERS);
-	if (IsValidCargoID(pass)) produced[pass]++;
-	CargoID mail = GetCargoIDByLabel(CT_MAIL);
-	if (IsValidCargoID(mail)) produced[mail]++;
+	CargoType pass = GetCargoTypeByLabel(CT_PASSENGERS);
+	if (IsValidCargoType(pass)) produced[pass]++;
+	CargoType mail = GetCargoTypeByLabel(CT_MAIL);
+	if (IsValidCargoType(mail)) produced[mail]++;
 }
 
 
@@ -694,8 +694,8 @@ static void TileLoop_Object(TileIndex tile)
 
 	uint r = Random();
 	/* Top town buildings generate 250, so the top HQ type makes 256. */
-	CargoID pass = GetCargoIDByLabel(CT_PASSENGERS);
-	if (IsValidCargoID(pass) && GB(r, 0, 8) < (256 / 4 / (6 - level))) {
+	CargoType pass = GetCargoTypeByLabel(CT_PASSENGERS);
+	if (IsValidCargoType(pass) && GB(r, 0, 8) < (256 / 4 / (6 - level))) {
 		uint amt = GB(r, 0, 8) / 8 / 4 + 1;
 
 		/* Production is halved during recessions. */
@@ -710,8 +710,8 @@ static void TileLoop_Object(TileIndex tile)
 	/* Top town building generates 90, HQ can make up to 196. The
 	 * proportion passengers:mail is about the same as in the acceptance
 	 * equations. */
-	 CargoID mail = GetCargoIDByLabel(CT_MAIL);
-	if (IsValidCargoID(mail) && GB(r, 8, 8) < (196 / 4 / (6 - level))) {
+	 CargoType mail = GetCargoTypeByLabel(CT_MAIL);
+	if (IsValidCargoType(mail) && GB(r, 8, 8) < (196 / 4 / (6 - level))) {
 		uint amt = GB(r, 8, 8) / 8 / 4 + 1;
 
 		/* Production is halved during recessions. */

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -49,7 +49,7 @@ private:
 	uint8_t flags = 0; ///< Load/unload types, depot order/action types.
 	DestinationID dest = 0; ///< The destination of the order.
 
-	CargoID refit_cargo = CARGO_NO_REFIT; ///< Refit CargoID
+	CargoType refit_cargo = CARGO_NO_REFIT; ///< Refit CargoType
 
 	uint16_t wait_time = 0; ///< How long in ticks to wait at the destination.
 	uint16_t travel_time = 0; ///< How long in ticks the journey to this destination should take.
@@ -78,7 +78,7 @@ public:
 	void Free();
 
 	void MakeGoToStation(StationID destination);
-	void MakeGoToDepot(DepotID destination, OrderDepotTypeFlags order, OrderNonStopFlags non_stop_type = ONSF_NO_STOP_AT_INTERMEDIATE_STATIONS, OrderDepotActionFlags action = ODATF_SERVICE_ONLY, CargoID cargo = CARGO_NO_REFIT);
+	void MakeGoToDepot(DepotID destination, OrderDepotTypeFlags order, OrderNonStopFlags non_stop_type = ONSF_NO_STOP_AT_INTERMEDIATE_STATIONS, OrderDepotActionFlags action = ODATF_SERVICE_ONLY, CargoType cargo = CARGO_NO_REFIT);
 	void MakeGoToWaypoint(StationID destination);
 	void MakeLoading(bool ordered);
 	void MakeLeaveStation();
@@ -128,9 +128,9 @@ public:
 	 * @pre IsType(OT_GOTO_DEPOT) || IsType(OT_GOTO_STATION)
 	 * @return the cargo type.
 	 */
-	inline CargoID GetRefitCargo() const { return this->refit_cargo; }
+	inline CargoType GetRefitCargo() const { return this->refit_cargo; }
 
-	void SetRefit(CargoID cargo);
+	void SetRefit(CargoType cargo);
 
 	/** How must the consist be loaded? */
 	inline OrderLoadFlags GetLoadType() const { return (OrderLoadFlags)GB(this->flags, 4, 3); }

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -87,7 +87,7 @@ void Order::MakeGoToStation(StationID destination)
  * @param action        what to do in the depot?
  * @param cargo         the cargo type to change to.
  */
-void Order::MakeGoToDepot(DepotID destination, OrderDepotTypeFlags order, OrderNonStopFlags non_stop_type, OrderDepotActionFlags action, CargoID cargo)
+void Order::MakeGoToDepot(DepotID destination, OrderDepotTypeFlags order, OrderNonStopFlags non_stop_type, OrderDepotActionFlags action, CargoType cargo)
 {
 	this->type = OT_GOTO_DEPOT;
 	this->SetDepotOrderType(order);
@@ -162,7 +162,7 @@ void Order::MakeImplicit(StationID destination)
  * @param cargo   the cargo type to change to.
  * @pre IsType(OT_GOTO_DEPOT) || IsType(OT_GOTO_STATION).
  */
-void Order::SetRefit(CargoID cargo)
+void Order::SetRefit(CargoType cargo)
 {
 	this->refit_cargo = cargo;
 }
@@ -1654,10 +1654,10 @@ CommandCost CmdCloneOrder(DoCommandFlag flags, CloneOptions action, VehicleID ve
  * @param flags operation to perform
  * @param veh VehicleIndex of the vehicle having the order
  * @param order_number number of order to modify
- * @param cargo CargoID
+ * @param cargo CargoType
  * @return the cost of this operation or an error
  */
-CommandCost CmdOrderRefit(DoCommandFlag flags, VehicleID veh, VehicleOrderID order_number, CargoID cargo)
+CommandCost CmdOrderRefit(DoCommandFlag flags, VehicleID veh, VehicleOrderID order_number, CargoType cargo)
 {
 	if (cargo >= NUM_CARGO && cargo != CARGO_NO_REFIT && cargo != CARGO_AUTO_REFIT) return CMD_ERROR;
 

--- a/src/order_cmd.h
+++ b/src/order_cmd.h
@@ -18,7 +18,7 @@ CommandCost CmdModifyOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID se
 CommandCost CmdSkipToOrder(DoCommandFlag flags, VehicleID veh_id, VehicleOrderID sel_ord);
 CommandCost CmdDeleteOrder(DoCommandFlag flags, VehicleID veh_id, VehicleOrderID sel_ord);
 CommandCost CmdInsertOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID sel_ord, const Order &new_order);
-CommandCost CmdOrderRefit(DoCommandFlag flags, VehicleID veh, VehicleOrderID order_number, CargoID cargo);
+CommandCost CmdOrderRefit(DoCommandFlag flags, VehicleID veh, VehicleOrderID order_number, CargoType cargo);
 CommandCost CmdCloneOrder(DoCommandFlag flags, CloneOptions action, VehicleID veh_dst, VehicleID veh_src);
 CommandCost CmdMoveOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID moving_order, VehicleOrderID target_order);
 CommandCost CmdClearOrderBackup(DoCommandFlag flags, TileIndex tile, ClientID user_id);

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -285,7 +285,7 @@ CommandCost CmdBuildRoadVehicle(DoCommandFlag flags, TileIndex tile, const Engin
 
 		v->spritenum = rvi->image_index;
 		v->cargo_type = e->GetDefaultCargoType();
-		assert(IsValidCargoID(v->cargo_type));
+		assert(IsValidCargoType(v->cargo_type));
 		v->cargo_cap = rvi->capacity;
 		v->refit_cap = 0;
 

--- a/src/roadveh_gui.cpp
+++ b/src/roadveh_gui.cpp
@@ -55,16 +55,16 @@ void DrawRoadVehDetails(const Vehicle *v, const Rect &r)
 
 		bool first = true;
 		for (const CargoSpec *cs : _sorted_cargo_specs) {
-			CargoID cid = cs->Index();
-			if (max_cargo[cid] > 0) {
+			CargoType cargo_type = cs->Index();
+			if (max_cargo[cargo_type] > 0) {
 				if (!first) capacity += list_separator;
 
-				SetDParam(0, cid);
-				SetDParam(1, max_cargo[cid]);
+				SetDParam(0, cargo_type);
+				SetDParam(1, max_cargo[cargo_type]);
 				AppendStringInPlace(capacity, STR_JUST_CARGO);
 
-				if (subtype_text[cid] != STR_NULL) {
-					AppendStringInPlace(capacity, subtype_text[cid]);
+				if (subtype_text[cargo_type] != STR_NULL) {
+					AppendStringInPlace(capacity, subtype_text[cargo_type]);
 				}
 
 				first = false;

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3081,7 +3081,7 @@ bool AfterLoadGame()
 			/* Make sure last_cargo_accepted_at is copied to elements for every valid input cargo.
 			 * The loading routine should put the original singular value into the first array element. */
 			for (auto &a : i->accepted) {
-				if (IsValidCargoID(a.cargo)) {
+				if (IsValidCargoType(a.cargo)) {
 					a.last_accepted = i->GetAccepted(0).last_accepted;
 				} else {
 					a.last_accepted = EconomyTime::MIN_DATE;

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -31,7 +31,7 @@ public:
 	std::vector<Industry::AcceptedCargo> &GetVector(Industry *i) const override { return i->accepted; }
 
 	/* Old array structure used by INDYChunkHandler for savegames before SLV_INDUSTRY_CARGO_REORGANISE. */
-	static inline std::array<CargoID, INDUSTRY_NUM_INPUTS> old_cargo;
+	static inline std::array<CargoType, INDUSTRY_NUM_INPUTS> old_cargo;
 	static inline std::array<uint16_t, INDUSTRY_NUM_INPUTS> old_waiting;
 	static inline std::array<TimerGameEconomy::Date, INDUSTRY_NUM_INPUTS> old_last_accepted;
 
@@ -53,7 +53,7 @@ public:
 
 	void Save(Industry::ProducedCargo *p) const override
 	{
-		if (!IsValidCargoID(p->cargo)) {
+		if (!IsValidCargoType(p->cargo)) {
 			/* Don't save any history if cargo slot isn't used. */
 			SlSetStructListLength(0);
 			return;
@@ -90,7 +90,7 @@ public:
 	std::vector<Industry::ProducedCargo> &GetVector(Industry *i) const override { return i->produced; }
 
 	/* Old array structure used by INDYChunkHandler for savegames before SLV_INDUSTRY_CARGO_REORGANISE. */
-	static inline std::array<CargoID, INDUSTRY_NUM_OUTPUTS> old_cargo;
+	static inline std::array<CargoType, INDUSTRY_NUM_OUTPUTS> old_cargo;
 	static inline std::array<uint16_t, INDUSTRY_NUM_OUTPUTS> old_waiting;
 	static inline std::array<uint8_t, INDUSTRY_NUM_OUTPUTS> old_rate;
 	static inline std::array<uint16_t, INDUSTRY_NUM_OUTPUTS> old_this_month_production;

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -1462,7 +1462,7 @@ static bool LoadOldSubsidy(LoadgameState *ls, int num)
 {
 	Subsidy *s = new (num) Subsidy();
 	bool ret = LoadChunk(ls, s, subsidy_chunk);
-	if (!IsValidCargoID(s->cargo_type)) delete s;
+	if (!IsValidCargoType(s->cargo_type)) delete s;
 	return ret;
 }
 

--- a/src/script/api/script_cargo.cpp
+++ b/src/script/api/script_cargo.cpp
@@ -18,7 +18,7 @@
 
 #include "../../safeguards.h"
 
-/* static */ bool ScriptCargo::IsValidCargo(CargoID cargo_type)
+/* static */ bool ScriptCargo::IsValidCargo(CargoType cargo_type)
 {
 	return (cargo_type < NUM_CARGO && ::CargoSpec::Get(cargo_type)->IsValid());
 }
@@ -28,7 +28,7 @@
 	return (towneffect_type >= (TownEffect)TAE_BEGIN && towneffect_type < (TownEffect)TAE_END);
 }
 
-/* static */ std::optional<std::string> ScriptCargo::GetName(CargoID cargo_type)
+/* static */ std::optional<std::string> ScriptCargo::GetName(CargoType cargo_type)
 {
 	if (!IsValidCargo(cargo_type)) return std::nullopt;
 
@@ -36,7 +36,7 @@
 	return GetString(STR_JUST_CARGO_LIST);
 }
 
-/* static */ std::optional<std::string> ScriptCargo::GetCargoLabel(CargoID cargo_type)
+/* static */ std::optional<std::string> ScriptCargo::GetCargoLabel(CargoType cargo_type)
 {
 	if (!IsValidCargo(cargo_type)) return std::nullopt;
 	const CargoSpec *cargo = ::CargoSpec::Get(cargo_type);
@@ -50,27 +50,27 @@
 	return cargo_label;
 }
 
-/* static */ bool ScriptCargo::IsFreight(CargoID cargo_type)
+/* static */ bool ScriptCargo::IsFreight(CargoType cargo_type)
 {
 	if (!IsValidCargo(cargo_type)) return false;
 	const CargoSpec *cargo = ::CargoSpec::Get(cargo_type);
 	return cargo->is_freight;
 }
 
-/* static */ bool ScriptCargo::HasCargoClass(CargoID cargo_type, CargoClass cargo_class)
+/* static */ bool ScriptCargo::HasCargoClass(CargoType cargo_type, CargoClass cargo_class)
 {
 	if (!IsValidCargo(cargo_type)) return false;
 	return ::IsCargoInClass(cargo_type, (::CargoClass)cargo_class);
 }
 
-/* static */ ScriptCargo::TownEffect ScriptCargo::GetTownEffect(CargoID cargo_type)
+/* static */ ScriptCargo::TownEffect ScriptCargo::GetTownEffect(CargoType cargo_type)
 {
 	if (!IsValidCargo(cargo_type)) return TE_NONE;
 
 	return (ScriptCargo::TownEffect)::CargoSpec::Get(cargo_type)->town_acceptance_effect;
 }
 
-/* static */ Money ScriptCargo::GetCargoIncome(CargoID cargo_type, SQInteger distance, SQInteger days_in_transit)
+/* static */ Money ScriptCargo::GetCargoIncome(CargoType cargo_type, SQInteger distance, SQInteger days_in_transit)
 {
 	if (!IsValidCargo(cargo_type)) return -1;
 
@@ -79,13 +79,13 @@
 	return ::GetTransportedGoodsIncome(1, distance, Clamp(days_in_transit * 2 / 5, 0, UINT16_MAX), cargo_type);
 }
 
-/* static */ ScriptCargo::DistributionType ScriptCargo::GetDistributionType(CargoID cargo_type)
+/* static */ ScriptCargo::DistributionType ScriptCargo::GetDistributionType(CargoType cargo_type)
 {
 	if (!ScriptCargo::IsValidCargo(cargo_type)) return INVALID_DISTRIBUTION_TYPE;
 	return (ScriptCargo::DistributionType)_settings_game.linkgraph.GetDistributionType(cargo_type);
 }
 
-/* static */ SQInteger ScriptCargo::GetWeight(CargoID cargo_type, SQInteger amount)
+/* static */ SQInteger ScriptCargo::GetWeight(CargoType cargo_type, SQInteger amount)
 {
 	if (!IsValidCargo(cargo_type)) return -1;
 

--- a/src/script/api/script_cargo.hpp
+++ b/src/script/api/script_cargo.hpp
@@ -53,7 +53,7 @@ public:
 	/**
 	 * Special cargo types.
 	 */
-	enum SpecialCargoID {
+	enum SpecialCargoType {
 		/* Note: these values represent part of the in-game CargoTypes enum */
 		CT_AUTO_REFIT = ::CARGO_AUTO_REFIT, ///< Automatically choose cargo type when doing auto-refitting.
 		CT_NO_REFIT   = ::CARGO_NO_REFIT, ///< Do not refit cargo of a vehicle.
@@ -75,7 +75,7 @@ public:
 	 * @param cargo_type The cargo to check.
 	 * @return True if and only if the cargo type is valid.
 	 */
-	static bool IsValidCargo(CargoID cargo_type);
+	static bool IsValidCargo(CargoType cargo_type);
 
 	/**
 	 * Checks whether the given town effect type is valid.
@@ -90,7 +90,7 @@ public:
 	 * @pre IsValidCargo(cargo_type).
 	 * @return The name of the cargo type.
 	 */
-	static std::optional<std::string> GetName(CargoID cargo_type);
+	static std::optional<std::string> GetName(CargoType cargo_type);
 
 	/**
 	 * Gets the string representation of the cargo label.
@@ -107,7 +107,7 @@ public:
 	 *  - In other words: Only use the cargo label, if you know more about the behaviour
 	 *    of a specific cargo from a specific industry set, than the API methods can tell you.
 	 */
-	static std::optional<std::string> GetCargoLabel(CargoID cargo_type);
+	static std::optional<std::string> GetCargoLabel(CargoType cargo_type);
 
 	/**
 	 * Checks whether the give cargo is a freight or not.
@@ -117,7 +117,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo_type).
 	 * @return True if and only if the cargo is freight.
 	 */
-	static bool IsFreight(CargoID cargo_type);
+	static bool IsFreight(CargoType cargo_type);
 
 	/**
 	 * Check if this cargo is in the requested cargo class.
@@ -126,7 +126,7 @@ public:
 	 * @param cargo_class The class to check for.
 	 * @return True if and only if the cargo is in the cargo class.
 	 */
-	static bool HasCargoClass(CargoID cargo_type, CargoClass cargo_class);
+	static bool HasCargoClass(CargoType cargo_type, CargoClass cargo_class);
 
 	/**
 	 * Get the effect this cargo has on a town.
@@ -134,7 +134,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo_type).
 	 * @return The effect this cargo has on a town, or TE_NONE if it has no effect.
 	 */
-	static TownEffect GetTownEffect(CargoID cargo_type);
+	static TownEffect GetTownEffect(CargoType cargo_type);
 
 	/**
 	 * Get the income for transporting a piece of cargo over the
@@ -147,14 +147,14 @@ public:
 	 *                        The max value of this variable is 637. Any value higher returns the same as 637 would.
 	 * @return The amount of money that would be earned by this trip.
 	 */
-	static Money GetCargoIncome(CargoID cargo_type, SQInteger distance, SQInteger days_in_transit);
+	static Money GetCargoIncome(CargoType cargo_type, SQInteger distance, SQInteger days_in_transit);
 
 	/**
 	 * Get the cargo distribution type for a cargo.
 	 * @param cargo_type The cargo to check on.
 	 * @return The cargo distribution type for the given cargo.
 	 */
-	static DistributionType GetDistributionType(CargoID cargo_type);
+	static DistributionType GetDistributionType(CargoType cargo_type);
 
 	/**
 	 * Get the weight in tonnes for the given amount of
@@ -165,7 +165,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo_type).
 	 * @return The weight in tonnes for that quantity of cargo.
 	 */
-	static SQInteger GetWeight(CargoID cargo_type, SQInteger amount);
+	static SQInteger GetWeight(CargoType cargo_type, SQInteger amount);
 };
 
 #endif /* SCRIPT_CARGO_HPP */

--- a/src/script/api/script_cargolist.cpp
+++ b/src/script/api/script_cargolist.cpp
@@ -30,7 +30,7 @@ ScriptCargoList_IndustryAccepting::ScriptCargoList_IndustryAccepting(IndustryID 
 
 	const Industry *ind = ::Industry::Get(industry_id);
 	for (const auto &a : ind->accepted) {
-		if (::IsValidCargoID(a.cargo)) {
+		if (::IsValidCargoType(a.cargo)) {
 			this->AddItem(a.cargo);
 		}
 	}
@@ -42,7 +42,7 @@ ScriptCargoList_IndustryProducing::ScriptCargoList_IndustryProducing(IndustryID 
 
 	const Industry *ind = ::Industry::Get(industry_id);
 	for (const auto &p : ind->produced) {
-		if (::IsValidCargoID(p.cargo)) {
+		if (::IsValidCargoType(p.cargo)) {
 			this->AddItem(p.cargo);
 		}
 	}
@@ -53,7 +53,7 @@ ScriptCargoList_StationAccepting::ScriptCargoList_StationAccepting(StationID sta
 	if (!ScriptStation::IsValidStation(station_id)) return;
 
 	const Station *st = ::Station::Get(station_id);
-	for (CargoID i = 0; i < NUM_CARGO; i++) {
+	for (CargoType i = 0; i < NUM_CARGO; i++) {
 		if (HasBit(st->goods[i].status, GoodsEntry::GES_ACCEPTANCE)) this->AddItem(i);
 	}
 }

--- a/src/script/api/script_cargomonitor.cpp
+++ b/src/script/api/script_cargomonitor.cpp
@@ -15,7 +15,7 @@
 
 #include "../../safeguards.h"
 
-/* static */ SQInteger ScriptCargoMonitor::GetTownDeliveryAmount(ScriptCompany::CompanyID company, CargoID cargo, TownID town_id, bool keep_monitoring)
+/* static */ SQInteger ScriptCargoMonitor::GetTownDeliveryAmount(ScriptCompany::CompanyID company, CargoType cargo, TownID town_id, bool keep_monitoring)
 {
 	CompanyID cid = static_cast<CompanyID>(company);
 	if (cid >= MAX_COMPANIES) return -1;
@@ -26,7 +26,7 @@
 	return GetDeliveryAmount(monitor, keep_monitoring);
 }
 
-/* static */ SQInteger ScriptCargoMonitor::GetIndustryDeliveryAmount(ScriptCompany::CompanyID company, CargoID cargo, IndustryID industry_id, bool keep_monitoring)
+/* static */ SQInteger ScriptCargoMonitor::GetIndustryDeliveryAmount(ScriptCompany::CompanyID company, CargoType cargo, IndustryID industry_id, bool keep_monitoring)
 {
 	CompanyID cid = static_cast<CompanyID>(company);
 	if (cid >= MAX_COMPANIES) return -1;
@@ -37,7 +37,7 @@
 	return GetDeliveryAmount(monitor, keep_monitoring);
 }
 
-/* static */ SQInteger ScriptCargoMonitor::GetTownPickupAmount(ScriptCompany::CompanyID company, CargoID cargo, TownID town_id, bool keep_monitoring)
+/* static */ SQInteger ScriptCargoMonitor::GetTownPickupAmount(ScriptCompany::CompanyID company, CargoType cargo, TownID town_id, bool keep_monitoring)
 {
 	CompanyID cid = static_cast<CompanyID>(company);
 	if (cid >= MAX_COMPANIES) return -1;
@@ -48,7 +48,7 @@
 	return GetPickupAmount(monitor, keep_monitoring);
 }
 
-/* static */ SQInteger ScriptCargoMonitor::GetIndustryPickupAmount(ScriptCompany::CompanyID company, CargoID cargo, IndustryID industry_id, bool keep_monitoring)
+/* static */ SQInteger ScriptCargoMonitor::GetIndustryPickupAmount(ScriptCompany::CompanyID company, CargoType cargo, IndustryID industry_id, bool keep_monitoring)
 {
 	CompanyID cid = static_cast<CompanyID>(company);
 	if (cid >= MAX_COMPANIES) return -1;

--- a/src/script/api/script_cargomonitor.hpp
+++ b/src/script/api/script_cargomonitor.hpp
@@ -51,7 +51,7 @@ public:
 	 * @return Amount of delivered cargo of the given cargo type to the given town by the given company since the last call, or
 	 * \c -1 if a parameter is out-of-bound.
 	 */
-	static SQInteger GetTownDeliveryAmount(ScriptCompany::CompanyID company, CargoID cargo, TownID town_id, bool keep_monitoring);
+	static SQInteger GetTownDeliveryAmount(ScriptCompany::CompanyID company, CargoType cargo, TownID town_id, bool keep_monitoring);
 
 	/**
 	 * Get the amount of cargo delivered to an industry by a company since the last query, and update the monitoring state.
@@ -62,7 +62,7 @@ public:
 	 * @return Amount of delivered cargo of the given cargo type to the given industry by the given company since the last call, or
 	 * \c -1 if a parameter is out-of-bound.
 	 */
-	static SQInteger GetIndustryDeliveryAmount(ScriptCompany::CompanyID company, CargoID cargo, IndustryID industry_id, bool keep_monitoring);
+	static SQInteger GetIndustryDeliveryAmount(ScriptCompany::CompanyID company, CargoType cargo, IndustryID industry_id, bool keep_monitoring);
 
 	/**
 	 * Get the amount of cargo picked up (and delivered) from a town by a company since the last query, and update the monitoring state.
@@ -74,7 +74,7 @@ public:
 	 * \c -1 if a parameter is out-of-bound.
 	 * @note Amounts of picked-up cargo are added during final delivery of it, to prevent users from getting credit for picking up without delivering it.
 	 */
-	static SQInteger GetTownPickupAmount(ScriptCompany::CompanyID company, CargoID cargo, TownID town_id, bool keep_monitoring);
+	static SQInteger GetTownPickupAmount(ScriptCompany::CompanyID company, CargoType cargo, TownID town_id, bool keep_monitoring);
 
 	/**
 	 * Get the amount of cargo picked up (and delivered) from an industry by a company since the last query, and update the monitoring state.
@@ -86,7 +86,7 @@ public:
 	 * \c -1 if a parameter is out-of-bound.
 	 * @note Amounts of picked-up cargo are added during final delivery of it, to prevent users from getting credit for picking up without delivering it.
 	 */
-	static SQInteger GetIndustryPickupAmount(ScriptCompany::CompanyID company, CargoID cargo, IndustryID industry_id, bool keep_monitoring);
+	static SQInteger GetIndustryPickupAmount(ScriptCompany::CompanyID company, CargoType cargo, IndustryID industry_id, bool keep_monitoring);
 
 	/** Stop monitoring everything. */
 	static void StopAllMonitoring();

--- a/src/script/api/script_engine.cpp
+++ b/src/script/api/script_engine.cpp
@@ -50,7 +50,7 @@
 	return GetString(STR_ENGINE_NAME);
 }
 
-/* static */ CargoID ScriptEngine::GetCargoType(EngineID engine_id)
+/* static */ CargoType ScriptEngine::GetCargoType(EngineID engine_id)
 {
 	if (!IsValidEngine(engine_id)) return INVALID_CARGO;
 
@@ -59,24 +59,24 @@
 	auto it = std::max_element(std::cbegin(cap), std::cend(cap));
 	if (*it == 0) return INVALID_CARGO;
 
-	return CargoID(std::distance(std::cbegin(cap), it));
+	return CargoType(std::distance(std::cbegin(cap), it));
 }
 
-/* static */ bool ScriptEngine::CanRefitCargo(EngineID engine_id, CargoID cargo_id)
+/* static */ bool ScriptEngine::CanRefitCargo(EngineID engine_id, CargoType cargo_type)
 {
 	if (!IsValidEngine(engine_id)) return false;
-	if (!ScriptCargo::IsValidCargo(cargo_id)) return false;
+	if (!ScriptCargo::IsValidCargo(cargo_type)) return false;
 
-	return HasBit(::GetUnionOfArticulatedRefitMasks(engine_id, true), cargo_id);
+	return HasBit(::GetUnionOfArticulatedRefitMasks(engine_id, true), cargo_type);
 }
 
-/* static */ bool ScriptEngine::CanPullCargo(EngineID engine_id, CargoID cargo_id)
+/* static */ bool ScriptEngine::CanPullCargo(EngineID engine_id, CargoType cargo_type)
 {
 	if (!IsValidEngine(engine_id)) return false;
 	if (GetVehicleType(engine_id) != ScriptVehicle::VT_RAIL) return false;
-	if (!ScriptCargo::IsValidCargo(cargo_id)) return false;
+	if (!ScriptCargo::IsValidCargo(cargo_type)) return false;
 
-	return (::RailVehInfo(engine_id)->ai_passenger_only != 1) || ScriptCargo::HasCargoClass(cargo_id, ScriptCargo::CC_PASSENGERS);
+	return (::RailVehInfo(engine_id)->ai_passenger_only != 1) || ScriptCargo::HasCargoClass(cargo_type, ScriptCargo::CC_PASSENGERS);
 }
 
 

--- a/src/script/api/script_engine.hpp
+++ b/src/script/api/script_engine.hpp
@@ -53,7 +53,7 @@ public:
 	 * @pre IsValidEngine(engine_id).
 	 * @return The cargo-type of the engine.
 	 */
-	static CargoID GetCargoType(EngineID engine_id);
+	static CargoType GetCargoType(EngineID engine_id);
 
 	/**
 	 * Check if the cargo of an engine can be refitted to your requested. If
@@ -61,26 +61,26 @@ public:
 	 *  In case of articulated vehicles the function decides whether at least one
 	 *  part can carry the cargo.
 	 * @param engine_id The engine to check for refitting.
-	 * @param cargo_id The cargo to check for refitting.
+	 * @param cargo_type The cargo to check for refitting.
 	 * @pre IsValidEngine(engine_id).
-	 * @pre ScriptCargo::IsValidCargo(cargo_id).
+	 * @pre ScriptCargo::IsValidCargo(cargo_type).
 	 * @return True if the engine can carry this cargo, either via refit, or
 	 *  by default.
 	 */
-	static bool CanRefitCargo(EngineID engine_id, CargoID cargo_id);
+	static bool CanRefitCargo(EngineID engine_id, CargoType cargo_type);
 
 	/**
 	 * Check if the engine can pull a wagon with the given cargo.
 	 * @param engine_id The engine to check.
-	 * @param cargo_id The cargo to check.
+	 * @param cargo_type The cargo to check.
 	 * @pre IsValidEngine(engine_id).
 	 * @pre GetVehicleType(engine_id) == ScriptVehicle::VT_RAIL.
-	 * @pre ScriptCargo::IsValidCargo(cargo_id).
+	 * @pre ScriptCargo::IsValidCargo(cargo_type).
 	 * @return True if the engine can pull wagons carrying this cargo.
 	 * @note This function is not exhaustive; a true here does not mean
 	 *  that the vehicle can pull the wagons, a false does mean it can't.
 	 */
-	static bool CanPullCargo(EngineID engine_id, CargoID cargo_id);
+	static bool CanPullCargo(EngineID engine_id, CargoType cargo_type);
 
 	/**
 	 * Get the capacity of an engine. In case it can transport multiple cargoes, it

--- a/src/script/api/script_event_types.cpp
+++ b/src/script/api/script_event_types.cpp
@@ -37,7 +37,7 @@ std::optional<std::string> ScriptEventEnginePreview::GetName()
 	return GetString(STR_ENGINE_NAME);
 }
 
-CargoID ScriptEventEnginePreview::GetCargoType()
+CargoType ScriptEventEnginePreview::GetCargoType()
 {
 	if (!this->IsEngineValid()) return INVALID_CARGO;
 	CargoArray cap = ::GetCapacityOfArticulatedParts(this->engine);
@@ -45,7 +45,7 @@ CargoID ScriptEventEnginePreview::GetCargoType()
 	auto it = std::max_element(std::cbegin(cap), std::cend(cap));
 	if (*it == 0) return INVALID_CARGO;
 
-	return CargoID(std::distance(std::cbegin(cap), it));
+	return CargoType(std::distance(std::cbegin(cap), it));
 }
 
 int32_t ScriptEventEnginePreview::GetCapacity()

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -255,7 +255,7 @@ public:
 	 *  returns the first/main.
 	 * @return The cargo-type of the engine.
 	 */
-	CargoID GetCargoType();
+	CargoType GetCargoType();
 
 	/**
 	 * Get the capacity of the offered engine. In case it can transport multiple cargoes, it

--- a/src/script/api/script_industry.cpp
+++ b/src/script/api/script_industry.cpp
@@ -66,67 +66,67 @@
 	return ScriptObject::Command<CMD_INDUSTRY_SET_TEXT>::Do(industry_id, text != nullptr ? text->GetEncodedText() : std::string{});
 }
 
-/* static */ ScriptIndustry::CargoAcceptState ScriptIndustry::IsCargoAccepted(IndustryID industry_id, CargoID cargo_id)
+/* static */ ScriptIndustry::CargoAcceptState ScriptIndustry::IsCargoAccepted(IndustryID industry_id, CargoType cargo_type)
 {
 	if (!IsValidIndustry(industry_id)) return CAS_NOT_ACCEPTED;
-	if (!ScriptCargo::IsValidCargo(cargo_id)) return CAS_NOT_ACCEPTED;
+	if (!ScriptCargo::IsValidCargo(cargo_type)) return CAS_NOT_ACCEPTED;
 
 	/* Not const because IndustryTemporarilyRefusesCargo tests a callback which needs a non-const object. */
 	Industry *i = ::Industry::Get(industry_id);
 
-	if (!i->IsCargoAccepted(cargo_id)) return CAS_NOT_ACCEPTED;
-	if (IndustryTemporarilyRefusesCargo(i, cargo_id)) return CAS_TEMP_REFUSED;
+	if (!i->IsCargoAccepted(cargo_type)) return CAS_NOT_ACCEPTED;
+	if (IndustryTemporarilyRefusesCargo(i, cargo_type)) return CAS_TEMP_REFUSED;
 
 	return CAS_ACCEPTED;
 }
 
-/* static */ SQInteger ScriptIndustry::GetStockpiledCargo(IndustryID industry_id, CargoID cargo_id)
+/* static */ SQInteger ScriptIndustry::GetStockpiledCargo(IndustryID industry_id, CargoType cargo_type)
 {
 	if (!IsValidIndustry(industry_id)) return -1;
-	if (!ScriptCargo::IsValidCargo(cargo_id)) return -1;
+	if (!ScriptCargo::IsValidCargo(cargo_type)) return -1;
 
 	const Industry *i = ::Industry::Get(industry_id);
 
-	auto it = i->GetCargoAccepted(cargo_id);
+	auto it = i->GetCargoAccepted(cargo_type);
 	if (it == std::end(i->accepted)) return -1;
 
 	return it->waiting;
 }
 
-/* static */ SQInteger ScriptIndustry::GetLastMonthProduction(IndustryID industry_id, CargoID cargo_id)
+/* static */ SQInteger ScriptIndustry::GetLastMonthProduction(IndustryID industry_id, CargoType cargo_type)
 {
 	if (!IsValidIndustry(industry_id)) return -1;
-	if (!ScriptCargo::IsValidCargo(cargo_id)) return -1;
+	if (!ScriptCargo::IsValidCargo(cargo_type)) return -1;
 
 	const Industry *i = ::Industry::Get(industry_id);
 
-	auto it = i->GetCargoProduced(cargo_id);
+	auto it = i->GetCargoProduced(cargo_type);
 	if (it == std::end(i->produced)) return -1;
 
 	return it->history[LAST_MONTH].production;
 }
 
-/* static */ SQInteger ScriptIndustry::GetLastMonthTransported(IndustryID industry_id, CargoID cargo_id)
+/* static */ SQInteger ScriptIndustry::GetLastMonthTransported(IndustryID industry_id, CargoType cargo_type)
 {
 	if (!IsValidIndustry(industry_id)) return -1;
-	if (!ScriptCargo::IsValidCargo(cargo_id)) return -1;
+	if (!ScriptCargo::IsValidCargo(cargo_type)) return -1;
 
 	const Industry *i = ::Industry::Get(industry_id);
 
-	auto it = i->GetCargoProduced(cargo_id);
+	auto it = i->GetCargoProduced(cargo_type);
 	if (it == std::end(i->produced)) return -1;
 
 	return it->history[LAST_MONTH].transported;
 }
 
-/* static */ SQInteger ScriptIndustry::GetLastMonthTransportedPercentage(IndustryID industry_id, CargoID cargo_id)
+/* static */ SQInteger ScriptIndustry::GetLastMonthTransportedPercentage(IndustryID industry_id, CargoType cargo_type)
 {
 	if (!IsValidIndustry(industry_id)) return -1;
-	if (!ScriptCargo::IsValidCargo(cargo_id)) return -1;
+	if (!ScriptCargo::IsValidCargo(cargo_type)) return -1;
 
 	const Industry *i = ::Industry::Get(industry_id);
 
-	auto it = i->GetCargoProduced(cargo_id);
+	auto it = i->GetCargoProduced(cargo_type);
 	if (it == std::end(i->produced)) return -1;
 
 	return ::ToPercent8(it->history[LAST_MONTH].PctTransported());
@@ -226,12 +226,12 @@
 	return i->last_prod_year.base();
 }
 
-/* static */ ScriptDate::Date ScriptIndustry::GetCargoLastAcceptedDate(IndustryID industry_id, CargoID cargo_type)
+/* static */ ScriptDate::Date ScriptIndustry::GetCargoLastAcceptedDate(IndustryID industry_id, CargoType cargo_type)
 {
 	const Industry *i = Industry::GetIfValid(industry_id);
 	if (i == nullptr) return ScriptDate::DATE_INVALID;
 
-	if (!::IsValidCargoID(cargo_type)) {
+	if (!::IsValidCargoType(cargo_type)) {
 		auto it = std::max_element(std::begin(i->accepted), std::end(i->accepted), [](const auto &a, const auto &b) { return a.last_accepted < b.last_accepted; });
 		return (ScriptDate::Date)it->last_accepted.base();
 	} else {

--- a/src/script/api/script_industry.hpp
+++ b/src/script/api/script_industry.hpp
@@ -23,9 +23,9 @@ class ScriptIndustry : public ScriptObject {
 public:
 	/** Ways for an industry to accept a cargo. */
 	enum CargoAcceptState {
-		CAS_NOT_ACCEPTED, ///< The CargoID is not accepted by this industry.
-		CAS_ACCEPTED,     ///< The industry currently accepts this CargoID.
-		CAS_TEMP_REFUSED, ///< The industry temporarily refuses to accept this CargoID but may do so again in the future.
+		CAS_NOT_ACCEPTED, ///< The CargoType is not accepted by this industry.
+		CAS_ACCEPTED,     ///< The industry currently accepts this CargoType.
+		CAS_TEMP_REFUSED, ///< The industry temporarily refuses to accept this CargoType but may do so again in the future.
 	};
 
 	/**
@@ -109,55 +109,55 @@ public:
 	/**
 	 * See whether an industry currently accepts a certain cargo.
 	 * @param industry_id The index of the industry.
-	 * @param cargo_id The index of the cargo.
+	 * @param cargo_type The index of the cargo.
 	 * @pre IsValidIndustry(industry_id).
-	 * @pre ScriptCargo::IsValidCargo(cargo_id).
+	 * @pre ScriptCargo::IsValidCargo(cargo_type).
 	 * @return Whether the industry accepts, temporarily refuses or never accepts this cargo.
 	 */
-	static CargoAcceptState IsCargoAccepted(IndustryID industry_id, CargoID cargo_id);
+	static CargoAcceptState IsCargoAccepted(IndustryID industry_id, CargoType cargo_type);
 
 	/**
 	 * Get the amount of cargo stockpiled for processing.
 	 * @param industry_id The index of the industry.
-	 * @param cargo_id The index of the cargo.
+	 * @param cargo_type The index of the cargo.
 	 * @pre IsValidIndustry(industry_id).
-	 * @pre ScriptCargo::IsValidCargo(cargo_id).
+	 * @pre ScriptCargo::IsValidCargo(cargo_type).
 	 * @return The amount of cargo that is waiting for processing.
 	 */
-	static SQInteger GetStockpiledCargo(IndustryID industry_id, CargoID cargo_id);
+	static SQInteger GetStockpiledCargo(IndustryID industry_id, CargoType cargo_type);
 
 	/**
 	 * Get the total last economy-month's production of the given cargo at an industry.
 	 * @param industry_id The index of the industry.
-	 * @param cargo_id The index of the cargo.
+	 * @param cargo_type The index of the cargo.
 	 * @pre IsValidIndustry(industry_id).
-	 * @pre ScriptCargo::IsValidCargo(cargo_id).
+	 * @pre ScriptCargo::IsValidCargo(cargo_type).
 	 * @return The last economy-month's production of the given cargo for this industry.
 	 * @see \ref ScriptEconomyTime
 	 */
-	static SQInteger GetLastMonthProduction(IndustryID industry_id, CargoID cargo_id);
+	static SQInteger GetLastMonthProduction(IndustryID industry_id, CargoType cargo_type);
 
 	/**
 	 * Get the total amount of cargo transported from an industry last economy-month.
 	 * @param industry_id The index of the industry.
-	 * @param cargo_id The index of the cargo.
+	 * @param cargo_type The index of the cargo.
 	 * @pre IsValidIndustry(industry_id).
-	 * @pre ScriptCargo::IsValidCargo(cargo_id).
+	 * @pre ScriptCargo::IsValidCargo(cargo_type).
 	 * @return The amount of given cargo transported from this industry last economy-month.
 	 * @see \ref ScriptEconomyTime
 	 */
-	static SQInteger GetLastMonthTransported(IndustryID industry_id, CargoID cargo_id);
+	static SQInteger GetLastMonthTransported(IndustryID industry_id, CargoType cargo_type);
 
 	/**
 	 * Get the percentage of cargo transported from an industry last economy-month.
 	 * @param industry_id The index of the industry.
-	 * @param cargo_id The index of the cargo.
+	 * @param cargo_type The index of the cargo.
 	 * @pre IsValidIndustry(industry_id).
-	 * @pre ScriptCargo::IsValidCargo(cargo_id).
+	 * @pre ScriptCargo::IsValidCargo(cargo_type).
 	 * @return The percentage of given cargo transported from this industry last economy-month.
 	 * @see \ref ScriptEconomyTime
 	 */
-	static SQInteger GetLastMonthTransportedPercentage(IndustryID industry_id, CargoID cargo_id);
+	static SQInteger GetLastMonthTransportedPercentage(IndustryID industry_id, CargoType cargo_type);
 
 	/**
 	 * Gets the location of the industry.
@@ -269,7 +269,7 @@ public:
 	 * @see \ref ScriptEconomyTime
 	 * @api -ai
 	 */
-	static ScriptDate::Date GetCargoLastAcceptedDate(IndustryID industry_id, CargoID cargo_type);
+	static ScriptDate::Date GetCargoLastAcceptedDate(IndustryID industry_id, CargoType cargo_type);
 
 	/**
 	 * Get the current control flags for an industry.

--- a/src/script/api/script_industrylist.cpp
+++ b/src/script/api/script_industrylist.cpp
@@ -18,16 +18,16 @@ ScriptIndustryList::ScriptIndustryList(HSQUIRRELVM vm)
 	ScriptList::FillList<Industry>(vm, this);
 }
 
-ScriptIndustryList_CargoAccepting::ScriptIndustryList_CargoAccepting(CargoID cargo_id)
+ScriptIndustryList_CargoAccepting::ScriptIndustryList_CargoAccepting(CargoType cargo_type)
 {
 	ScriptList::FillList<Industry>(this,
-		[cargo_id](const Industry *i) { return i->IsCargoAccepted(cargo_id); }
+		[cargo_type](const Industry *i) { return i->IsCargoAccepted(cargo_type); }
 	);
 }
 
-ScriptIndustryList_CargoProducing::ScriptIndustryList_CargoProducing(CargoID cargo_id)
+ScriptIndustryList_CargoProducing::ScriptIndustryList_CargoProducing(CargoType cargo_type)
 {
 	ScriptList::FillList<Industry>(this,
-		[cargo_id](const Industry *i) { return i->IsCargoProduced(cargo_id); }
+		[cargo_type](const Industry *i) { return i->IsCargoProduced(cargo_type); }
 	);
 }

--- a/src/script/api/script_industrylist.hpp
+++ b/src/script/api/script_industrylist.hpp
@@ -58,9 +58,9 @@ public:
 class ScriptIndustryList_CargoAccepting : public ScriptList {
 public:
 	/**
-	 * @param cargo_id The cargo this industry should accept.
+	 * @param cargo_type The cargo this industry should accept.
 	 */
-	ScriptIndustryList_CargoAccepting(CargoID cargo_id);
+	ScriptIndustryList_CargoAccepting(CargoType cargo_type);
 };
 
 /**
@@ -72,9 +72,9 @@ public:
 class ScriptIndustryList_CargoProducing : public ScriptList {
 public:
 	/**
-	 * @param cargo_id The cargo this industry should produce.
+	 * @param cargo_type The cargo this industry should produce.
 	 */
-	ScriptIndustryList_CargoProducing(CargoID cargo_id);
+	ScriptIndustryList_CargoProducing(CargoType cargo_type);
 };
 
 #endif /* SCRIPT_INDUSTRYLIST_HPP */

--- a/src/script/api/script_industrytype.cpp
+++ b/src/script/api/script_industrytype.cpp
@@ -71,8 +71,8 @@
 	const IndustrySpec *ins = ::GetIndustrySpec(industry_type);
 
 	ScriptList *list = new ScriptList();
-	for (const CargoID &c : ins->produced_cargo) {
-		if (::IsValidCargoID(c)) list->AddItem(c);
+	for (const CargoType &c : ins->produced_cargo) {
+		if (::IsValidCargoType(c)) list->AddItem(c);
 	}
 
 	return list;
@@ -85,8 +85,8 @@
 	const IndustrySpec *ins = ::GetIndustrySpec(industry_type);
 
 	ScriptList *list = new ScriptList();
-	for (const CargoID &c : ins->accepts_cargo) {
-		if (::IsValidCargoID(c)) list->AddItem(c);
+	for (const CargoType &c : ins->accepts_cargo) {
+		if (::IsValidCargoType(c)) list->AddItem(c);
 	}
 
 	return list;

--- a/src/script/api/script_industrytype.hpp
+++ b/src/script/api/script_industrytype.hpp
@@ -42,22 +42,22 @@ public:
 	static std::optional<std::string> GetName(IndustryType industry_type);
 
 	/**
-	 * Get a list of CargoID possible produced by this industry-type.
+	 * Get a list of CargoType possible produced by this industry-type.
 	 * @warning This function only returns the default cargoes of the industry type.
 	 *          Industries can specify new cargotypes on construction.
-	 * @param industry_type The type to get the CargoIDs for.
+	 * @param industry_type The type to get the CargoTypes for.
 	 * @pre IsValidIndustryType(industry_type).
-	 * @return The CargoIDs of all cargotypes this industry could produce.
+	 * @return The CargoTypes of all cargotypes this industry could produce.
 	 */
 	static ScriptList *GetProducedCargo(IndustryType industry_type);
 
 	/**
-	 * Get a list of CargoID accepted by this industry-type.
+	 * Get a list of CargoType accepted by this industry-type.
 	 * @warning This function only returns the default cargoes of the industry type.
 	 *          Industries can specify new cargotypes on construction.
-	 * @param industry_type The type to get the CargoIDs for.
+	 * @param industry_type The type to get the CargoTypes for.
 	 * @pre IsValidIndustryType(industry_type).
-	 * @return The CargoIDs of all cargotypes this industry accepts.
+	 * @return The CargoTypes of all cargotypes this industry accepts.
 	 */
 	static ScriptList *GetAcceptedCargo(IndustryType industry_type);
 

--- a/src/script/api/script_order.cpp
+++ b/src/script/api/script_order.cpp
@@ -370,7 +370,7 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 	return (ScriptOrder::StopLocation)order->GetStopLocation();
 }
 
-/* static */ CargoID ScriptOrder::GetOrderRefit(VehicleID vehicle_id, OrderPosition order_position)
+/* static */ CargoType ScriptOrder::GetOrderRefit(VehicleID vehicle_id, OrderPosition order_position)
 {
 	if (!IsValidVehicleOrder(vehicle_id, order_position)) return CARGO_NO_REFIT;
 	if (order_position != ORDER_CURRENT && !IsGotoStationOrder(vehicle_id, order_position) && !IsGotoDepotOrder(vehicle_id, order_position)) return CARGO_NO_REFIT;
@@ -437,7 +437,7 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 	return ScriptObject::Command<CMD_MODIFY_ORDER>::Do(0, vehicle_id, order_pos, MOF_STOP_LOCATION, stop_location);
 }
 
-/* static */ bool ScriptOrder::SetOrderRefit(VehicleID vehicle_id, OrderPosition order_position, CargoID refit_cargo)
+/* static */ bool ScriptOrder::SetOrderRefit(VehicleID vehicle_id, OrderPosition order_position, CargoType refit_cargo)
 {
 	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicleOrder(vehicle_id, order_position));

--- a/src/script/api/script_order.hpp
+++ b/src/script/api/script_order.hpp
@@ -348,7 +348,7 @@ public:
 	 *  in the orderlist, but they can be the current order of a vehicle.
 	 * @return The refit cargo of the order or CT_NO_REFIT if no refit is set.
 	 */
-	static CargoID GetOrderRefit(VehicleID vehicle_id, OrderPosition order_position);
+	static CargoType GetOrderRefit(VehicleID vehicle_id, OrderPosition order_position);
 
 	/**
 	 * Sets the OrderPosition to jump to if the check succeeds of the given order for the given vehicle.
@@ -427,7 +427,7 @@ public:
 	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return Whether the order has been/can be changed.
 	 */
-	static bool SetOrderRefit(VehicleID vehicle_id, OrderPosition order_position, CargoID refit_cargo);
+	static bool SetOrderRefit(VehicleID vehicle_id, OrderPosition order_position, CargoType refit_cargo);
 
 	/**
 	 * Appends an order to the end of the vehicle's order list.

--- a/src/script/api/script_rail.cpp
+++ b/src/script/api/script_rail.cpp
@@ -162,7 +162,7 @@
 	return ScriptObject::Command<CMD_BUILD_RAIL_STATION>::Do(tile, (::RailType)GetCurrentRailType(), direction == RAILTRACK_NW_SE ? AXIS_Y : AXIS_X, num_platforms, platform_length, STAT_CLASS_DFLT, 0, ScriptStation::IsValidStation(station_id) ? station_id : INVALID_STATION, adjacent);
 }
 
-/* static */ bool ScriptRail::BuildNewGRFRailStation(TileIndex tile, RailTrack direction, SQInteger num_platforms, SQInteger platform_length, StationID station_id, CargoID cargo_id, IndustryType source_industry, IndustryType goal_industry, SQInteger distance, bool source_station)
+/* static */ bool ScriptRail::BuildNewGRFRailStation(TileIndex tile, RailTrack direction, SQInteger num_platforms, SQInteger platform_length, StationID station_id, CargoType cargo_type, IndustryType source_industry, IndustryType goal_industry, SQInteger distance, bool source_station)
 {
 	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
@@ -171,14 +171,14 @@
 	EnforcePrecondition(false, platform_length > 0 && platform_length <= 0xFF);
 	EnforcePrecondition(false, IsRailTypeAvailable(GetCurrentRailType()));
 	EnforcePrecondition(false, station_id == ScriptStation::STATION_NEW || station_id == ScriptStation::STATION_JOIN_ADJACENT || ScriptStation::IsValidStation(station_id));
-	EnforcePrecondition(false, ScriptCargo::IsValidCargo(cargo_id));
+	EnforcePrecondition(false, ScriptCargo::IsValidCargo(cargo_type));
 	EnforcePrecondition(false, source_industry == ScriptIndustryType::INDUSTRYTYPE_UNKNOWN || source_industry == ScriptIndustryType::INDUSTRYTYPE_TOWN || ScriptIndustryType::IsValidIndustryType(source_industry));
 	EnforcePrecondition(false, goal_industry   == ScriptIndustryType::INDUSTRYTYPE_UNKNOWN || goal_industry   == ScriptIndustryType::INDUSTRYTYPE_TOWN || ScriptIndustryType::IsValidIndustryType(goal_industry));
 
 	const GRFFile *file;
 	uint16_t res = GetAiPurchaseCallbackResult(
 		GSF_STATIONS,
-		cargo_id,
+		cargo_type,
 		0,
 		source_industry,
 		goal_industry,

--- a/src/script/api/script_rail.hpp
+++ b/src/script/api/script_rail.hpp
@@ -276,7 +276,7 @@ public:
 	 * @param num_platforms The number of platforms to build.
 	 * @param platform_length The length of each platform.
 	 * @param station_id The station to join, ScriptStation::STATION_NEW or ScriptStation::STATION_JOIN_ADJACENT.
-	 * @param cargo_id The CargoID of the cargo that will be transported from / to this station.
+	 * @param cargo_type The CargoType of the cargo that will be transported from / to this station.
 	 * @param source_industry The IndustryType of the industry you'll transport goods from, ScriptIndustryType::INDUSTRYTYPE_UNKNOWN or ScriptIndustryType::INDUSTRYTYPE_TOWN.
 	 * @param goal_industry The IndustryType of the industry you'll transport goods to, ScriptIndustryType::INDUSTRYTYPE_UNKNOWN or ScriptIndustryType::INDUSTRYTYPE_TOWN.
 	 * @param distance The manhattan distance you'll transport the cargo over.
@@ -299,7 +299,7 @@ public:
 	 * @exception ScriptStation::ERR_STATION_TOO_MANY_STATIONS_IN_TOWN
 	 * @return Whether the station has been/can be build or not.
 	 */
-	static bool BuildNewGRFRailStation(TileIndex tile, RailTrack direction, SQInteger num_platforms, SQInteger platform_length, StationID station_id, CargoID cargo_id, IndustryType source_industry, IndustryType goal_industry, SQInteger distance, bool source_station);
+	static bool BuildNewGRFRailStation(TileIndex tile, RailTrack direction, SQInteger num_platforms, SQInteger platform_length, StationID station_id, CargoType cargo_type, IndustryType source_industry, IndustryType goal_industry, SQInteger distance, bool source_station);
 
 	/**
 	 * Build a rail waypoint.

--- a/src/script/api/script_road.cpp
+++ b/src/script/api/script_road.cpp
@@ -20,7 +20,7 @@
 
 #include "../../safeguards.h"
 
-/* static */ ScriptRoad::RoadVehicleType ScriptRoad::GetRoadVehicleTypeForCargo(CargoID cargo_type)
+/* static */ ScriptRoad::RoadVehicleType ScriptRoad::GetRoadVehicleTypeForCargo(CargoType cargo_type)
 {
 	return ScriptCargo::HasCargoClass(cargo_type, ScriptCargo::CC_PASSENGERS) ? ROADVEHTYPE_BUS : ROADVEHTYPE_TRUCK;
 }

--- a/src/script/api/script_road.hpp
+++ b/src/script/api/script_road.hpp
@@ -100,7 +100,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo_type).
 	 * @return The road vehicle type needed to transport the cargo.
 	 */
-	static RoadVehicleType GetRoadVehicleTypeForCargo(CargoID cargo_type);
+	static RoadVehicleType GetRoadVehicleTypeForCargo(CargoType cargo_type);
 
 	/**
 	 * Checks whether the given tile is actually a tile with road that can be

--- a/src/script/api/script_station.cpp
+++ b/src/script/api/script_station.cpp
@@ -41,25 +41,25 @@
 
 template <bool Tfrom, bool Tvia>
 /* static */ bool ScriptStation::IsCargoRequestValid(StationID station_id,
-		StationID from_station_id, StationID via_station_id, CargoID cargo_id)
+		StationID from_station_id, StationID via_station_id, CargoType cargo_type)
 {
 	if (!IsValidStation(station_id)) return false;
 	if (Tfrom && !IsValidStation(from_station_id) && from_station_id != STATION_INVALID) return false;
 	if (Tvia && !IsValidStation(via_station_id) && via_station_id != STATION_INVALID) return false;
-	if (!ScriptCargo::IsValidCargo(cargo_id)) return false;
+	if (!ScriptCargo::IsValidCargo(cargo_type)) return false;
 	return true;
 }
 
 template <bool Tfrom, bool Tvia>
 /* static */ SQInteger ScriptStation::CountCargoWaiting(StationID station_id,
-		StationID from_station_id, StationID via_station_id, CargoID cargo_id)
+		StationID from_station_id, StationID via_station_id, CargoType cargo_type)
 {
 	if (!ScriptStation::IsCargoRequestValid<Tfrom, Tvia>(station_id, from_station_id,
-			via_station_id, cargo_id)) {
+			via_station_id, cargo_type)) {
 		return -1;
 	}
 
-	const ::GoodsEntry &goods = ::Station::Get(station_id)->goods[cargo_id];
+	const ::GoodsEntry &goods = ::Station::Get(station_id)->goods[cargo_type];
 	if (!goods.HasData()) return 0;
 
 	const StationCargoList &cargo_list = goods.GetData().cargo;
@@ -78,39 +78,39 @@ template <bool Tfrom, bool Tvia>
 	return cargo_count;
 }
 
-/* static */ SQInteger ScriptStation::GetCargoWaiting(StationID station_id, CargoID cargo_id)
+/* static */ SQInteger ScriptStation::GetCargoWaiting(StationID station_id, CargoType cargo_type)
 {
-	return CountCargoWaiting<false, false>(station_id, STATION_INVALID, STATION_INVALID, cargo_id);
+	return CountCargoWaiting<false, false>(station_id, STATION_INVALID, STATION_INVALID, cargo_type);
 }
 
 /* static */ SQInteger ScriptStation::GetCargoWaitingFrom(StationID station_id,
-		StationID from_station_id, CargoID cargo_id)
+		StationID from_station_id, CargoType cargo_type)
 {
-	return CountCargoWaiting<true, false>(station_id, from_station_id, STATION_INVALID, cargo_id);
+	return CountCargoWaiting<true, false>(station_id, from_station_id, STATION_INVALID, cargo_type);
 }
 
 /* static */ SQInteger ScriptStation::GetCargoWaitingVia(StationID station_id,
-		StationID via_station_id, CargoID cargo_id)
+		StationID via_station_id, CargoType cargo_type)
 {
-	return CountCargoWaiting<false, true>(station_id, STATION_INVALID, via_station_id, cargo_id);
+	return CountCargoWaiting<false, true>(station_id, STATION_INVALID, via_station_id, cargo_type);
 }
 
 /* static */ SQInteger ScriptStation::GetCargoWaitingFromVia(StationID station_id,
-		StationID from_station_id, StationID via_station_id, CargoID cargo_id)
+		StationID from_station_id, StationID via_station_id, CargoType cargo_type)
 {
-	return CountCargoWaiting<true, true>(station_id, from_station_id, via_station_id, cargo_id);
+	return CountCargoWaiting<true, true>(station_id, from_station_id, via_station_id, cargo_type);
 }
 
 template <bool Tfrom, bool Tvia>
 /* static */ SQInteger ScriptStation::CountCargoPlanned(StationID station_id,
-		StationID from_station_id, StationID via_station_id, CargoID cargo_id)
+		StationID from_station_id, StationID via_station_id, CargoType cargo_type)
 {
 	if (!ScriptStation::IsCargoRequestValid<Tfrom, Tvia>(station_id, from_station_id,
-			via_station_id, cargo_id)) {
+			via_station_id, cargo_type)) {
 		return -1;
 	}
 
-	const ::GoodsEntry &goods = ::Station::Get(station_id)->goods[cargo_id];
+	const ::GoodsEntry &goods = ::Station::Get(station_id)->goods[cargo_type];
 	if (!goods.HasData()) return 0;
 
 	const FlowStatMap &flows = goods.GetData().flows;
@@ -122,42 +122,42 @@ template <bool Tfrom, bool Tvia>
 	}
 }
 
-/* static */ SQInteger ScriptStation::GetCargoPlanned(StationID station_id, CargoID cargo_id)
+/* static */ SQInteger ScriptStation::GetCargoPlanned(StationID station_id, CargoType cargo_type)
 {
-	return CountCargoPlanned<false, false>(station_id, STATION_INVALID, STATION_INVALID, cargo_id);
+	return CountCargoPlanned<false, false>(station_id, STATION_INVALID, STATION_INVALID, cargo_type);
 }
 
 /* static */ SQInteger ScriptStation::GetCargoPlannedFrom(StationID station_id,
-		StationID from_station_id, CargoID cargo_id)
+		StationID from_station_id, CargoType cargo_type)
 {
-	return CountCargoPlanned<true, false>(station_id, from_station_id, STATION_INVALID, cargo_id);
+	return CountCargoPlanned<true, false>(station_id, from_station_id, STATION_INVALID, cargo_type);
 }
 
 /* static */ SQInteger ScriptStation::GetCargoPlannedVia(StationID station_id,
-		StationID via_station_id, CargoID cargo_id)
+		StationID via_station_id, CargoType cargo_type)
 {
-	return CountCargoPlanned<false, true>(station_id, STATION_INVALID, via_station_id, cargo_id);
+	return CountCargoPlanned<false, true>(station_id, STATION_INVALID, via_station_id, cargo_type);
 }
 
 /* static */ SQInteger ScriptStation::GetCargoPlannedFromVia(StationID station_id,
-		StationID from_station_id, StationID via_station_id, CargoID cargo_id)
+		StationID from_station_id, StationID via_station_id, CargoType cargo_type)
 {
-	return CountCargoPlanned<true, true>(station_id, from_station_id, via_station_id, cargo_id);
+	return CountCargoPlanned<true, true>(station_id, from_station_id, via_station_id, cargo_type);
 }
 
-/* static */ bool ScriptStation::HasCargoRating(StationID station_id, CargoID cargo_id)
+/* static */ bool ScriptStation::HasCargoRating(StationID station_id, CargoType cargo_type)
 {
 	if (!IsValidStation(station_id)) return false;
-	if (!ScriptCargo::IsValidCargo(cargo_id)) return false;
+	if (!ScriptCargo::IsValidCargo(cargo_type)) return false;
 
-	return ::Station::Get(station_id)->goods[cargo_id].HasRating();
+	return ::Station::Get(station_id)->goods[cargo_type].HasRating();
 }
 
-/* static */ SQInteger ScriptStation::GetCargoRating(StationID station_id, CargoID cargo_id)
+/* static */ SQInteger ScriptStation::GetCargoRating(StationID station_id, CargoType cargo_type)
 {
-	if (!ScriptStation::HasCargoRating(station_id, cargo_id)) return -1;
+	if (!ScriptStation::HasCargoRating(station_id, cargo_type)) return -1;
 
-	return ::ToPercent8(::Station::Get(station_id)->goods[cargo_id].rating);
+	return ::ToPercent8(::Station::Get(station_id)->goods[cargo_type].rating);
 }
 
 /* static */ SQInteger ScriptStation::GetCoverageRadius(ScriptStation::StationType station_type)

--- a/src/script/api/script_station.hpp
+++ b/src/script/api/script_station.hpp
@@ -79,88 +79,88 @@ public:
 	/**
 	 * See how much cargo there is waiting on a station.
 	 * @param station_id The station to get the cargo-waiting of.
-	 * @param cargo_id The cargo to get the cargo-waiting of.
+	 * @param cargo_type The cargo to get the cargo-waiting of.
 	 * @pre IsValidStation(station_id).
-	 * @pre IsValidCargo(cargo_id).
+	 * @pre IsValidCargo(cargo_type).
 	 * @return The amount of units waiting at the station.
 	 */
-	static SQInteger GetCargoWaiting(StationID station_id, CargoID cargo_id);
+	static SQInteger GetCargoWaiting(StationID station_id, CargoType cargo_type);
 
 	/**
 	 * See how much cargo with a specific source station there is waiting on a station.
 	 * @param station_id The station to get the cargo-waiting of.
 	 * @param from_station_id The source station of the cargo. Pass STATION_INVALID to get cargo of which the source has been deleted.
-	 * @param cargo_id The cargo to get the cargo-waiting of.
+	 * @param cargo_type The cargo to get the cargo-waiting of.
 	 * @pre IsValidStation(station_id).
 	 * @pre IsValidStation(from_station_id) || from_station_id == STATION_INVALID.
-	 * @pre IsValidCargo(cargo_id).
+	 * @pre IsValidCargo(cargo_type).
 	 * @return The amount of units waiting at the station originating from from_station_id.
 	 * @note source station means, the station where cargo was first loaded.
 	 */
-	static SQInteger GetCargoWaitingFrom(StationID station_id, StationID from_station_id, CargoID cargo_id);
+	static SQInteger GetCargoWaitingFrom(StationID station_id, StationID from_station_id, CargoType cargo_type);
 
 	/**
 	 * See how much cargo with a specific via-station there is waiting on a station.
 	 * @param station_id The station to get the cargo-waiting of.
 	 * @param via_station_id The next station the cargo is going to. Pass STATION_INVALID to get waiting cargo for "via any station".
-	 * @param cargo_id The cargo to get the cargo-waiting of.
+	 * @param cargo_type The cargo to get the cargo-waiting of.
 	 * @pre IsValidStation(station_id).
 	 * @pre IsValidStation(via_station_id) || via_station_id == STATION_INVALID.
-	 * @pre IsValidCargo(cargo_id).
+	 * @pre IsValidCargo(cargo_type).
 	 * @return The amount of units waiting at the station with via_station_id as next hop.
-	 * @note if ScriptCargo.GetCargoDistributionType(cargo_id) == ScriptCargo.DT_MANUAL, then all waiting cargo will have STATION_INVALID as next hop.
+	 * @note if ScriptCargo.GetCargoDistributionType(cargo_type) == ScriptCargo.DT_MANUAL, then all waiting cargo will have STATION_INVALID as next hop.
 	 */
-	static SQInteger GetCargoWaitingVia(StationID station_id, StationID via_station_id, CargoID cargo_id);
+	static SQInteger GetCargoWaitingVia(StationID station_id, StationID via_station_id, CargoType cargo_type);
 
 	/**
 	 * See how much cargo with a specific via-station and source station there is waiting on a station.
 	 * @param station_id The station to get the cargo-waiting of.
 	 * @param from_station_id The source station of the cargo. Pass STATION_INVALID to get cargo of which the source has been deleted.
 	 * @param via_station_id The next station the cargo is going to. Pass STATION_INVALID to get waiting cargo for "via any station".
-	 * @param cargo_id The cargo to get the cargo-waiting of.
+	 * @param cargo_type The cargo to get the cargo-waiting of.
 	 * @pre IsValidStation(station_id).
 	 * @pre IsValidStation(from_station_id) || from_station_id == STATION_INVALID.
 	 * @pre IsValidStation(via_station_id) || via_station_id == STATION_INVALID.
-	 * @pre IsValidCargo(cargo_id).
+	 * @pre IsValidCargo(cargo_type).
 	 * @return The amount of units waiting at the station with from_station_id as source and via_station_id as next hop.
-	 * @note if ScriptCargo.GetCargoDistributionType(cargo_id) == ScriptCargo.DT_MANUAL, then all waiting cargo will have STATION_INVALID as next hop.
+	 * @note if ScriptCargo.GetCargoDistributionType(cargo_type) == ScriptCargo.DT_MANUAL, then all waiting cargo will have STATION_INVALID as next hop.
 	 */
-	static SQInteger GetCargoWaitingFromVia(StationID station_id, StationID from_station_id, StationID via_station_id, CargoID cargo_id);
+	static SQInteger GetCargoWaitingFromVia(StationID station_id, StationID from_station_id, StationID via_station_id, CargoType cargo_type);
 
 	/**
 	 * See how much cargo was planned to pass (including production and consumption) this station per month.
 	 * @param station_id The station to get the planned flow for.
-	 * @param cargo_id The cargo type to get the planned flow for.
+	 * @param cargo_type The cargo type to get the planned flow for.
 	 * @pre IsValidStation(station_id).
-	 * @pre IsValidCargo(cargo_id).
+	 * @pre IsValidCargo(cargo_type).
 	 * @return The amount of cargo units planned to pass the station per month.
 	 */
-	static SQInteger GetCargoPlanned(StationID station_id, CargoID cargo_id);
+	static SQInteger GetCargoPlanned(StationID station_id, CargoType cargo_type);
 
 	/**
 	 * See how much cargo from the specified origin was planned to pass (including production and consumption) this station per month.
 	 * @param station_id The station to get the planned flow for.
 	 * @param from_station_id The station the cargo originates at.
-	 * @param cargo_id The cargo type to get the planned flow for.
+	 * @param cargo_type The cargo type to get the planned flow for.
 	 * @pre IsValidStation(station_id).
 	 * @pre IsValidStation(from_station_id) || from_station_id == STATION_INVALID.
-	 * @pre IsValidCargo(cargo_id).
+	 * @pre IsValidCargo(cargo_type).
 	 * @return The amount of cargo units from the specified origin planned to pass the station per month.
 	 */
-	static SQInteger GetCargoPlannedFrom(StationID station_id, StationID from_station_id, CargoID cargo_id);
+	static SQInteger GetCargoPlannedFrom(StationID station_id, StationID from_station_id, CargoType cargo_type);
 
 	/**
 	 * See how much cargo was planned to pass (including production and consumption) this station per month, heading for the specified next hop.
 	 * @param station_id The station to get the planned flow for.
 	 * @param via_station_id The next station the cargo will go on to.
-	 * @param cargo_id The cargo type to get the planned flow for.
+	 * @param cargo_type The cargo type to get the planned flow for.
 	 * @pre IsValidStation(station_id).
 	 * @pre IsValidStation(via_station_id) || via_station_id == STATION_INVALID.
-	 * @pre IsValidCargo(cargo_id).
+	 * @pre IsValidCargo(cargo_type).
 	 * @return The amount of cargo units planned to pass the station per month, going via the specified next hop.
 	 * @note Cargo planned to go "via" the same station that's being queried is actually planned to be consumed there.
 	 */
-	static SQInteger GetCargoPlannedVia(StationID station_id, StationID via_station_id, CargoID cargo_id);
+	static SQInteger GetCargoPlannedVia(StationID station_id, StationID via_station_id, CargoType cargo_type);
 
 	/**
 	 * See how much cargo from the specified origin was planned to pass this station per month,
@@ -168,37 +168,37 @@ public:
 	 * @param station_id The station to get the planned flow for.
 	 * @param from_station_id The station the cargo originates at.
 	 * @param via_station_id The next station the cargo will go on to.
-	 * @param cargo_id The cargo type to get the planned flow for.
+	 * @param cargo_type The cargo type to get the planned flow for.
 	 * @pre IsValidStation(station_id).
 	 * @pre IsValidStation(from_station_id) || from_station_id == STATION_INVALID.
 	 * @pre IsValidStation(via_station_id) || via_station_id == STATION_INVALID.
-	 * @pre IsValidCargo(cargo_id).
+	 * @pre IsValidCargo(cargo_type).
 	 * @return The amount of cargo units from the specified origin planned to pass the station per month, going via the specified next hop.
 	 * @note Cargo planned to go "via" the same station that's being queried is actually planned to be consumed there.
 	 * @note Cargo planned to pass "from" the same station that's being queried is actually produced there.
 	 */
-	static SQInteger GetCargoPlannedFromVia(StationID station_id, StationID from_station_id, StationID via_station_id, CargoID cargo_id);
+	static SQInteger GetCargoPlannedFromVia(StationID station_id, StationID from_station_id, StationID via_station_id, CargoType cargo_type);
 
 	/**
 	 * Check whether the given cargo at the given station a rating.
 	 * @param station_id The station to get the cargo-rating state of.
-	 * @param cargo_id The cargo to get the cargo-rating state of.
+	 * @param cargo_type The cargo to get the cargo-rating state of.
 	 * @pre IsValidStation(station_id).
-	 * @pre IsValidCargo(cargo_id).
+	 * @pre IsValidCargo(cargo_type).
 	 * @return True if the cargo has a rating, otherwise false.
 	 */
-	static bool HasCargoRating(StationID station_id, CargoID cargo_id);
+	static bool HasCargoRating(StationID station_id, CargoType cargo_type);
 
 	/**
 	 * See how high the rating is of a cargo on a station.
 	 * @param station_id The station to get the cargo-rating of.
-	 * @param cargo_id The cargo to get the cargo-rating of.
+	 * @param cargo_type The cargo to get the cargo-rating of.
 	 * @pre IsValidStation(station_id).
-	 * @pre IsValidCargo(cargo_id).
-	 * @pre HasCargoRating(station_id, cargo_id).
+	 * @pre IsValidCargo(cargo_type).
+	 * @pre HasCargoRating(station_id, cargo_type).
 	 * @return The rating in percent of the cargo on the station.
 	 */
-	static SQInteger GetCargoRating(StationID station_id, CargoID cargo_id);
+	static SQInteger GetCargoRating(StationID station_id, CargoType cargo_type);
 
 	/**
 	 * Get the coverage radius of this type of station.
@@ -299,15 +299,15 @@ public:
 private:
 	template <bool Tfrom, bool Tvia>
 	static bool IsCargoRequestValid(StationID station_id, StationID from_station_id,
-			StationID via_station_id, CargoID cargo_id);
+			StationID via_station_id, CargoType cargo_type);
 
 	template <bool Tfrom, bool Tvia>
 	static SQInteger CountCargoWaiting(StationID station_id, StationID from_station_id,
-			StationID via_station_id, CargoID cargo_id);
+			StationID via_station_id, CargoType cargo_type);
 
 	template <bool Tfrom, bool Tvia>
 	static SQInteger CountCargoPlanned(StationID station_id, StationID from_station_id,
-			StationID via_station_id, CargoID cargo_id);
+			StationID via_station_id, CargoType cargo_type);
 
 };
 

--- a/src/script/api/script_stationlist.cpp
+++ b/src/script/api/script_stationlist.cpp
@@ -40,7 +40,7 @@ ScriptStationList_Vehicle::ScriptStationList_Vehicle(VehicleID vehicle_id)
 }
 
 ScriptStationList_Cargo::ScriptStationList_Cargo(ScriptStationList_Cargo::CargoMode mode,
-		ScriptStationList_Cargo::CargoSelector selector, StationID station_id, CargoID cargo,
+		ScriptStationList_Cargo::CargoSelector selector, StationID station_id, CargoType cargo,
 		StationID other_station)
 {
 	switch (mode) {
@@ -56,7 +56,7 @@ ScriptStationList_Cargo::ScriptStationList_Cargo(ScriptStationList_Cargo::CargoM
 }
 
 ScriptStationList_CargoWaiting::ScriptStationList_CargoWaiting(
-		ScriptStationList_Cargo::CargoSelector selector, StationID station_id, CargoID cargo,
+		ScriptStationList_Cargo::CargoSelector selector, StationID station_id, CargoType cargo,
 		StationID other_station)
 {
 	switch (selector) {
@@ -78,7 +78,7 @@ ScriptStationList_CargoWaiting::ScriptStationList_CargoWaiting(
 }
 
 ScriptStationList_CargoPlanned::ScriptStationList_CargoPlanned(
-		ScriptStationList_Cargo::CargoSelector selector, StationID station_id, CargoID cargo,
+		ScriptStationList_Cargo::CargoSelector selector, StationID station_id, CargoType cargo,
 		StationID other_station)
 {
 	switch (selector) {
@@ -101,7 +101,7 @@ ScriptStationList_CargoPlanned::ScriptStationList_CargoPlanned(
 
 class CargoCollector {
 public:
-	CargoCollector(ScriptStationList_Cargo *parent, StationID station_id, CargoID cargo,
+	CargoCollector(ScriptStationList_Cargo *parent, StationID station_id, CargoType cargo,
 			StationID other);
 	~CargoCollector() ;
 
@@ -121,7 +121,7 @@ private:
 };
 
 CargoCollector::CargoCollector(ScriptStationList_Cargo *parent,
-		StationID station_id, CargoID cargo, StationID other) :
+		StationID station_id, CargoType cargo, StationID other) :
 	list(parent), ge(nullptr), other_station(other), last_key(INVALID_STATION), amount(0)
 {
 	if (!ScriptStation::IsValidStation(station_id)) return;
@@ -175,7 +175,7 @@ void CargoCollector::Update(StationID from, StationID via, uint amount)
 
 
 template <ScriptStationList_Cargo::CargoSelector Tselector>
-void ScriptStationList_CargoWaiting::Add(StationID station_id, CargoID cargo, StationID other_station)
+void ScriptStationList_CargoWaiting::Add(StationID station_id, CargoType cargo, StationID other_station)
 {
 	CargoCollector collector(this, station_id, cargo, other_station);
 	if (collector.GE() == nullptr) return;
@@ -190,7 +190,7 @@ void ScriptStationList_CargoWaiting::Add(StationID station_id, CargoID cargo, St
 
 
 template <ScriptStationList_Cargo::CargoSelector Tselector>
-void ScriptStationList_CargoPlanned::Add(StationID station_id, CargoID cargo, StationID other_station)
+void ScriptStationList_CargoPlanned::Add(StationID station_id, CargoType cargo, StationID other_station)
 {
 	CargoCollector collector(this, station_id, cargo, other_station);
 	if (collector.GE() == nullptr) return;
@@ -210,13 +210,13 @@ void ScriptStationList_CargoPlanned::Add(StationID station_id, CargoID cargo, St
 }
 
 ScriptStationList_CargoWaitingByFrom::ScriptStationList_CargoWaitingByFrom(StationID station_id,
-		CargoID cargo)
+		CargoType cargo)
 {
 	this->Add<CS_BY_FROM>(station_id, cargo);
 }
 
 ScriptStationList_CargoWaitingViaByFrom::ScriptStationList_CargoWaitingViaByFrom(
-		StationID station_id, CargoID cargo, StationID via)
+		StationID station_id, CargoType cargo, StationID via)
 {
 	CargoCollector collector(this, station_id, cargo, via);
 	if (collector.GE() == nullptr) return;
@@ -231,39 +231,39 @@ ScriptStationList_CargoWaitingViaByFrom::ScriptStationList_CargoWaitingViaByFrom
 
 
 ScriptStationList_CargoWaitingByVia::ScriptStationList_CargoWaitingByVia(StationID station_id,
-		CargoID cargo)
+		CargoType cargo)
 {
 	this->Add<CS_BY_VIA>(station_id, cargo);
 }
 
 ScriptStationList_CargoWaitingFromByVia::ScriptStationList_CargoWaitingFromByVia(
-		StationID station_id, CargoID cargo, StationID from)
+		StationID station_id, CargoType cargo, StationID from)
 {
 	this->Add<CS_FROM_BY_VIA>(station_id, cargo, from);
 }
 
 ScriptStationList_CargoPlannedByFrom::ScriptStationList_CargoPlannedByFrom(StationID station_id,
-		CargoID cargo)
+		CargoType cargo)
 {
 	this->Add<CS_BY_FROM>(station_id, cargo);
 }
 
 ScriptStationList_CargoPlannedViaByFrom::ScriptStationList_CargoPlannedViaByFrom(
-		StationID station_id, CargoID cargo, StationID via)
+		StationID station_id, CargoType cargo, StationID via)
 {
 	this->Add<CS_VIA_BY_FROM>(station_id, cargo, via);
 }
 
 
 ScriptStationList_CargoPlannedByVia::ScriptStationList_CargoPlannedByVia(StationID station_id,
-		CargoID cargo)
+		CargoType cargo)
 {
 	this->Add<CS_BY_VIA>(station_id, cargo);
 }
 
 
 ScriptStationList_CargoPlannedFromByVia::ScriptStationList_CargoPlannedFromByVia(
-		StationID station_id, CargoID cargo, StationID from)
+		StationID station_id, CargoType cargo, StationID from)
 {
 	CargoCollector collector(this, station_id, cargo, from);
 	if (collector.GE() == nullptr) return;

--- a/src/script/api/script_stationlist.hpp
+++ b/src/script/api/script_stationlist.hpp
@@ -61,7 +61,7 @@ public:
 	 * @param cargo Cargo type to query for.
 	 * @param other_station Other station to restrict the query with.
 	 */
-	ScriptStationList_Cargo(ScriptStationList_Cargo::CargoMode mode, ScriptStationList_Cargo::CargoSelector selector, StationID station_id, CargoID cargo, StationID other_station);
+	ScriptStationList_Cargo(ScriptStationList_Cargo::CargoMode mode, ScriptStationList_Cargo::CargoSelector selector, StationID station_id, CargoType cargo, StationID other_station);
 
 protected:
 
@@ -93,7 +93,7 @@ protected:
 	 * @param other_station Other station to restrict the query with.
 	 */
 	template <CargoSelector Tselector>
-	void Add(StationID station_id, CargoID cargo, StationID other_station = INVALID_STATION);
+	void Add(StationID station_id, CargoType cargo, StationID other_station = INVALID_STATION);
 
 public:
 
@@ -105,7 +105,7 @@ public:
 	 * @param cargo Cargo type to query for.
 	 * @param other_station Other station to restrict the query with.
 	 */
-	ScriptStationList_CargoWaiting(ScriptStationList_Cargo::CargoSelector selector, StationID station_id, CargoID cargo, StationID other_station);
+	ScriptStationList_CargoWaiting(ScriptStationList_Cargo::CargoSelector selector, StationID station_id, CargoType cargo, StationID other_station);
 };
 
 /**
@@ -130,7 +130,7 @@ protected:
 	 * @param other_station Other station to restrict the query with.
 	 */
 	template <CargoSelector Tselector>
-	void Add(StationID station_id, CargoID cargo, StationID other_station = INVALID_STATION);
+	void Add(StationID station_id, CargoType cargo, StationID other_station = INVALID_STATION);
 
 public:
 
@@ -142,7 +142,7 @@ public:
 	 * @param cargo Cargo type to query for.
 	 * @param other_station Other station to restrict the query with.
 	 */
-	ScriptStationList_CargoPlanned(ScriptStationList_Cargo::CargoSelector selector, StationID station_id, CargoID cargo, StationID other_station);
+	ScriptStationList_CargoPlanned(ScriptStationList_Cargo::CargoSelector selector, StationID station_id, CargoType cargo, StationID other_station);
 };
 
 /**
@@ -157,7 +157,7 @@ public:
 	 * @param station_id Station to query for waiting cargo.
 	 * @param cargo Cargo type to query for.
 	 */
-	ScriptStationList_CargoWaitingByFrom(StationID station_id, CargoID cargo);
+	ScriptStationList_CargoWaitingByFrom(StationID station_id, CargoType cargo);
 };
 
 /**
@@ -173,7 +173,7 @@ public:
 	 * @param cargo Cargo type to query for.
 	 * @param via Next hop to restrict the query with.
 	 */
-	ScriptStationList_CargoWaitingViaByFrom(StationID station_id, CargoID cargo, StationID via);
+	ScriptStationList_CargoWaitingViaByFrom(StationID station_id, CargoType cargo, StationID via);
 };
 
 /**
@@ -188,7 +188,7 @@ public:
 	 * @param station_id Station to query for waiting cargo.
 	 * @param cargo Cargo type to query for.
 	 */
-	ScriptStationList_CargoWaitingByVia(StationID station_id, CargoID cargo);
+	ScriptStationList_CargoWaitingByVia(StationID station_id, CargoType cargo);
 };
 
 /**
@@ -204,7 +204,7 @@ public:
 	 * @param cargo Cargo type to query for.
 	 * @param from Origin station to restrict the query with.
 	 */
-	ScriptStationList_CargoWaitingFromByVia(StationID station_id, CargoID cargo, StationID from);
+	ScriptStationList_CargoWaitingFromByVia(StationID station_id, CargoType cargo, StationID from);
 };
 
 /**
@@ -219,7 +219,7 @@ public:
 	 * @param station_id Station to query for planned flows.
 	 * @param cargo Cargo type to query for.
 	 */
-	ScriptStationList_CargoPlannedByFrom(StationID station_id, CargoID cargo);
+	ScriptStationList_CargoPlannedByFrom(StationID station_id, CargoType cargo);
 };
 
 /**
@@ -235,7 +235,7 @@ public:
 	 * @param cargo Cargo type to query for.
 	 * @param via Next hop to restrict the query with.
 	 */
-	ScriptStationList_CargoPlannedViaByFrom(StationID station_id, CargoID cargo, StationID via);
+	ScriptStationList_CargoPlannedViaByFrom(StationID station_id, CargoType cargo, StationID via);
 };
 
 /**
@@ -251,7 +251,7 @@ public:
 	 * @param station_id Station to query for planned flows.
 	 * @param cargo Cargo type to query for.
 	 */
-	ScriptStationList_CargoPlannedByVia(StationID station_id, CargoID cargo);
+	ScriptStationList_CargoPlannedByVia(StationID station_id, CargoType cargo);
 };
 
 /**
@@ -268,7 +268,7 @@ public:
 	 * @param cargo Cargo type to query for.
 	 * @param from Origin station to restrict the query with.
 	 */
-	ScriptStationList_CargoPlannedFromByVia(StationID station_id, CargoID cargo, StationID from);
+	ScriptStationList_CargoPlannedFromByVia(StationID station_id, CargoType cargo, StationID from);
 };
 
 /**

--- a/src/script/api/script_subsidy.cpp
+++ b/src/script/api/script_subsidy.cpp
@@ -31,7 +31,7 @@
 	return ::Subsidy::Get(subsidy_id)->IsAwarded();
 }
 
-/* static */ bool ScriptSubsidy::Create(CargoID cargo_type, SubsidyParticipantType from_type, SQInteger from_id, SubsidyParticipantType to_type, SQInteger to_id)
+/* static */ bool ScriptSubsidy::Create(CargoType cargo_type, SubsidyParticipantType from_type, SQInteger from_id, SubsidyParticipantType to_type, SQInteger to_id)
 {
 	EnforceDeityMode(false);
 	EnforcePrecondition(false, ScriptCargo::IsValidCargo(cargo_type));
@@ -63,7 +63,7 @@
 	return (ScriptDate::Date)TimerGameEconomy::ConvertYMDToDate(ymd.year, ymd.month, ymd.day).base();
 }
 
-/* static */ CargoID ScriptSubsidy::GetCargoType(SubsidyID subsidy_id)
+/* static */ CargoType ScriptSubsidy::GetCargoType(SubsidyID subsidy_id)
 {
 	if (!IsValidSubsidy(subsidy_id)) return INVALID_CARGO;
 

--- a/src/script/api/script_subsidy.hpp
+++ b/src/script/api/script_subsidy.hpp
@@ -63,7 +63,7 @@ public:
 	 * @pre (to_type   == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(to_id))   || (to_type   == SPT_TOWN && ScriptTown::IsValidTown(to_id))
 	 * @api -ai
 	 */
-	static bool Create(CargoID cargo_type, SubsidyParticipantType from_type, SQInteger from_id, SubsidyParticipantType to_type, SQInteger to_id);
+	static bool Create(CargoType cargo_type, SubsidyParticipantType from_type, SQInteger from_id, SubsidyParticipantType to_type, SQInteger to_id);
 
 	/**
 	 * Get the company index of the company this subsidy is awarded to.
@@ -93,7 +93,7 @@ public:
 	 * @pre IsValidSubsidy(subsidy_id).
 	 * @return The cargo type to transport.
 	 */
-	static CargoID GetCargoType(SubsidyID subsidy_id);
+	static CargoType GetCargoType(SubsidyID subsidy_id);
 
 	/**
 	 * Returns the type of source of subsidy.

--- a/src/script/api/script_tile.cpp
+++ b/src/script/api/script_tile.cpp
@@ -224,7 +224,7 @@
 	}
 }
 
-/* static */ SQInteger ScriptTile::GetCargoAcceptance(TileIndex tile, CargoID cargo_type, SQInteger width, SQInteger height, SQInteger radius)
+/* static */ SQInteger ScriptTile::GetCargoAcceptance(TileIndex tile, CargoType cargo_type, SQInteger width, SQInteger height, SQInteger radius)
 {
 	if (!::IsValidTile(tile) || width <= 0 || height <= 0 || radius < 0 || !ScriptCargo::IsValidCargo(cargo_type)) return -1;
 
@@ -232,7 +232,7 @@
 	return acceptance[cargo_type];
 }
 
-/* static */ SQInteger ScriptTile::GetCargoProduction(TileIndex tile, CargoID cargo_type, SQInteger width, SQInteger height, SQInteger radius)
+/* static */ SQInteger ScriptTile::GetCargoProduction(TileIndex tile, CargoType cargo_type, SQInteger width, SQInteger height, SQInteger radius)
 {
 	if (!::IsValidTile(tile) || width <= 0 || height <= 0 || radius < 0 || !ScriptCargo::IsValidCargo(cargo_type)) return -1;
 

--- a/src/script/api/script_tile.hpp
+++ b/src/script/api/script_tile.hpp
@@ -376,7 +376,7 @@ public:
 	 * @pre radius >= 0.
 	 * @return Values below 8 mean no acceptance; the more the better.
 	 */
-	static SQInteger GetCargoAcceptance(TileIndex tile, CargoID cargo_type, SQInteger width, SQInteger height, SQInteger radius);
+	static SQInteger GetCargoAcceptance(TileIndex tile, CargoType cargo_type, SQInteger width, SQInteger height, SQInteger radius);
 
 	/**
 	 * Checks how many producers in the radius produces this cargo.
@@ -393,7 +393,7 @@ public:
 	 * @pre radius >= 0.
 	 * @return The number of producers that produce this cargo within radius of the tile.
 	 */
-	static SQInteger GetCargoProduction(TileIndex tile, CargoID cargo_type, SQInteger width, SQInteger height, SQInteger radius);
+	static SQInteger GetCargoProduction(TileIndex tile, CargoType cargo_type, SQInteger width, SQInteger height, SQInteger radius);
 
 	/**
 	 * Get the manhattan distance from the tile to the tile.

--- a/src/script/api/script_tilelist.cpp
+++ b/src/script/api/script_tilelist.cpp
@@ -95,7 +95,7 @@ ScriptTileList_IndustryAccepting::ScriptTileList_IndustryAccepting(IndustryID in
 		/* Only add the tile if it accepts the cargo (sometimes just 1 tile of an
 		 *  industry triggers the acceptance). */
 		CargoArray acceptance = ::GetAcceptanceAroundTiles(cur_tile, 1, 1, radius);
-		if (std::none_of(std::begin(i->accepted), std::end(i->accepted), [&acceptance](const auto &a) { return ::IsValidCargoID(a.cargo) && acceptance[a.cargo] != 0; })) continue;
+		if (std::none_of(std::begin(i->accepted), std::end(i->accepted), [&acceptance](const auto &a) { return ::IsValidCargoType(a.cargo) && acceptance[a.cargo] != 0; })) continue;
 
 		this->AddTile(cur_tile);
 	}

--- a/src/script/api/script_town.cpp
+++ b/src/script/api/script_town.cpp
@@ -86,33 +86,33 @@
 	return t->xy;
 }
 
-/* static */ SQInteger ScriptTown::GetLastMonthProduction(TownID town_id, CargoID cargo_id)
+/* static */ SQInteger ScriptTown::GetLastMonthProduction(TownID town_id, CargoType cargo_type)
 {
 	if (!IsValidTown(town_id)) return -1;
-	if (!ScriptCargo::IsValidCargo(cargo_id)) return -1;
+	if (!ScriptCargo::IsValidCargo(cargo_type)) return -1;
 
 	const Town *t = ::Town::Get(town_id);
 
-	return t->supplied[cargo_id].old_max;
+	return t->supplied[cargo_type].old_max;
 }
 
-/* static */ SQInteger ScriptTown::GetLastMonthSupplied(TownID town_id, CargoID cargo_id)
+/* static */ SQInteger ScriptTown::GetLastMonthSupplied(TownID town_id, CargoType cargo_type)
 {
 	if (!IsValidTown(town_id)) return -1;
-	if (!ScriptCargo::IsValidCargo(cargo_id)) return -1;
+	if (!ScriptCargo::IsValidCargo(cargo_type)) return -1;
 
 	const Town *t = ::Town::Get(town_id);
 
-	return t->supplied[cargo_id].old_act;
+	return t->supplied[cargo_type].old_act;
 }
 
-/* static */ SQInteger ScriptTown::GetLastMonthTransportedPercentage(TownID town_id, CargoID cargo_id)
+/* static */ SQInteger ScriptTown::GetLastMonthTransportedPercentage(TownID town_id, CargoType cargo_type)
 {
 	if (!IsValidTown(town_id)) return -1;
-	if (!ScriptCargo::IsValidCargo(cargo_id)) return -1;
+	if (!ScriptCargo::IsValidCargo(cargo_type)) return -1;
 
 	const Town *t = ::Town::Get(town_id);
-	return ::ToPercent8(t->GetPercentTransported(cargo_id));
+	return ::ToPercent8(t->GetPercentTransported(cargo_type));
 }
 
 /* static */ SQInteger ScriptTown::GetLastMonthReceived(TownID town_id, ScriptCargo::TownEffect towneffect_id)

--- a/src/script/api/script_town.hpp
+++ b/src/script/api/script_town.hpp
@@ -196,42 +196,42 @@ public:
 	/**
 	 * Get the total last economy-month's production of the given cargo at a town.
 	 * @param town_id The index of the town.
-	 * @param cargo_id The index of the cargo.
+	 * @param cargo_type The index of the cargo.
 	 * @pre IsValidTown(town_id).
-	 * @pre ScriptCargo::IsValidCargo(cargo_id).
+	 * @pre ScriptCargo::IsValidCargo(cargo_type).
 	 * @return The last economy-month's production of the given cargo for this town.
 	 * @see \ref ScriptEconomyTime
 	 */
-	static SQInteger GetLastMonthProduction(TownID town_id, CargoID cargo_id);
+	static SQInteger GetLastMonthProduction(TownID town_id, CargoType cargo_type);
 
 	/**
 	 * Get the total amount of cargo supplied from a town last economy-month.
 	 * @param town_id The index of the town.
-	 * @param cargo_id The index of the cargo.
+	 * @param cargo_type The index of the cargo.
 	 * @pre IsValidTown(town_id).
-	 * @pre ScriptCargo::IsValidCargo(cargo_id).
+	 * @pre ScriptCargo::IsValidCargo(cargo_type).
 	 * @return The amount of cargo supplied for transport from this town last economy-month.
 	 * @see \ref ScriptEconomyTime
 	 */
-	static SQInteger GetLastMonthSupplied(TownID town_id, CargoID cargo_id);
+	static SQInteger GetLastMonthSupplied(TownID town_id, CargoType cargo_type);
 
 	/**
 	 * Get the percentage of transported production of the given cargo at a town last economy-month.
 	 * @param town_id The index of the town.
-	 * @param cargo_id The index of the cargo.
+	 * @param cargo_type The index of the cargo.
 	 * @pre IsValidTown(town_id).
-	 * @pre ScriptCargo::IsValidCargo(cargo_id).
+	 * @pre ScriptCargo::IsValidCargo(cargo_type).
 	 * @return The percentage of given cargo transported from this town last economy-month.
 	 * @see \ref ScriptEconomyTime
 	 */
-	static SQInteger GetLastMonthTransportedPercentage(TownID town_id, CargoID cargo_id);
+	static SQInteger GetLastMonthTransportedPercentage(TownID town_id, CargoType cargo_type);
 
 	/**
 	 * Get the total amount of cargo effects received by a town last economy-month.
 	 * @param town_id The index of the town.
 	 * @param towneffect_id The index of the cargo.
 	 * @pre IsValidTown(town_id).
-	 * @pre ScriptCargo::IsValidTownEffect(cargo_id).
+	 * @pre ScriptCargo::IsValidTownEffect(cargo_type).
 	 * @return The amount of cargo received by this town last economy-month for this cargo effect.
 	 * @see \ref ScriptEconomyTime
 	 */

--- a/src/script/api/script_types.hpp
+++ b/src/script/api/script_types.hpp
@@ -25,7 +25,7 @@
  *                           <td> introduction \ref newgrf_changes "(1)"            </td>
  *                           <td> never \ref newgrf_changes "(1)"                   </td>
  *                           <td> no \ref newgrf_changes "(1)"                      </td></tr>
- * <tr><td>#CargoID     </td><td> cargo type                                        </td>
+ * <tr><td>#CargoType   </td><td> cargo type                                        </td>
  *                           <td> game start \ref newgrf_changes "(1)"              </td>
  *                           <td> never \ref newgrf_changes "(1)"                   </td>
  *                           <td> no \ref newgrf_changes "(1)"                      </td></tr>
@@ -111,7 +111,7 @@
 
 /* Define all types here, so they are added to the API docs. */
 typedef uint BridgeType;       ///< The ID of a bridge type.
-typedef uint8_t CargoID;       ///< The ID of a cargo.
+typedef uint8_t CargoType;     ///< The ID of a cargo type.
 typedef uint16_t EngineID;     ///< The ID of an engine.
 typedef uint16_t GoalID;       ///< The ID of a goal.
 typedef uint16_t GroupID;      ///< The ID of a group.

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -71,11 +71,11 @@
 	return v->IsGroundVehicle() ? v->GetGroundVehicleCache()->cached_total_length : -1;
 }
 
-/* static */ VehicleID ScriptVehicle::_BuildVehicleInternal(TileIndex depot, EngineID engine_id, CargoID cargo)
+/* static */ VehicleID ScriptVehicle::_BuildVehicleInternal(TileIndex depot, EngineID engine_id, CargoType cargo)
 {
 	EnforceCompanyModeValid(VEHICLE_INVALID);
 	EnforcePrecondition(VEHICLE_INVALID, ScriptEngine::IsBuildable(engine_id));
-	EnforcePrecondition(VEHICLE_INVALID, !::IsValidCargoID(cargo) || ScriptCargo::IsValidCargo(cargo));
+	EnforcePrecondition(VEHICLE_INVALID, !::IsValidCargoType(cargo) || ScriptCargo::IsValidCargo(cargo));
 
 	::VehicleType type = ::Engine::Get(engine_id)->type;
 
@@ -92,13 +92,13 @@
 	return _BuildVehicleInternal(depot, engine_id, INVALID_CARGO);
 }
 
-/* static */ VehicleID ScriptVehicle::BuildVehicleWithRefit(TileIndex depot, EngineID engine_id, CargoID cargo)
+/* static */ VehicleID ScriptVehicle::BuildVehicleWithRefit(TileIndex depot, EngineID engine_id, CargoType cargo)
 {
 	EnforcePrecondition(VEHICLE_INVALID, ScriptCargo::IsValidCargo(cargo));
 	return _BuildVehicleInternal(depot, engine_id, cargo);
 }
 
-/* static */ SQInteger ScriptVehicle::GetBuildWithRefitCapacity(TileIndex depot, EngineID engine_id, CargoID cargo)
+/* static */ SQInteger ScriptVehicle::GetBuildWithRefitCapacity(TileIndex depot, EngineID engine_id, CargoType cargo)
 {
 	if (!ScriptEngine::IsBuildable(engine_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo)) return -1;
@@ -147,7 +147,7 @@
 	return _MoveWagonInternal(source_vehicle_id, source_wagon, true, dest_vehicle_id, dest_wagon);
 }
 
-/* static */ SQInteger ScriptVehicle::GetRefitCapacity(VehicleID vehicle_id, CargoID cargo)
+/* static */ SQInteger ScriptVehicle::GetRefitCapacity(VehicleID vehicle_id, CargoType cargo)
 {
 	if (!IsValidVehicle(vehicle_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo)) return -1;
@@ -156,7 +156,7 @@
 	return res.Succeeded() ? refit_capacity : -1;
 }
 
-/* static */ bool ScriptVehicle::RefitVehicle(VehicleID vehicle_id, CargoID cargo)
+/* static */ bool ScriptVehicle::RefitVehicle(VehicleID vehicle_id, CargoType cargo)
 {
 	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicle(vehicle_id) && ScriptCargo::IsValidCargo(cargo));
@@ -412,7 +412,7 @@
 	return (ScriptRoad::RoadType)(int)(::RoadVehicle::Get(vehicle_id))->roadtype;
 }
 
-/* static */ SQInteger ScriptVehicle::GetCapacity(VehicleID vehicle_id, CargoID cargo)
+/* static */ SQInteger ScriptVehicle::GetCapacity(VehicleID vehicle_id, CargoType cargo)
 {
 	if (!IsValidVehicle(vehicle_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo)) return -1;
@@ -425,7 +425,7 @@
 	return amount;
 }
 
-/* static */ SQInteger ScriptVehicle::GetCargoLoad(VehicleID vehicle_id, CargoID cargo)
+/* static */ SQInteger ScriptVehicle::GetCargoLoad(VehicleID vehicle_id, CargoType cargo)
 {
 	if (!IsValidVehicle(vehicle_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo)) return -1;

--- a/src/script/api/script_vehicle.hpp
+++ b/src/script/api/script_vehicle.hpp
@@ -357,7 +357,7 @@ public:
 	 *   as the vehicle isn't really built yet. Build it for real first before
 	 *   assigning orders.
 	 */
-	static VehicleID BuildVehicleWithRefit(TileIndex depot, EngineID engine_id, CargoID cargo);
+	static VehicleID BuildVehicleWithRefit(TileIndex depot, EngineID engine_id, CargoType cargo);
 
 	/**
 	 * Gets the capacity of a vehicle built at the given depot with the given engine and refitted to the given cargo.
@@ -370,7 +370,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo).
 	 * @return The capacity the vehicle will have when refited.
 	 */
-	static SQInteger GetBuildWithRefitCapacity(TileIndex depot, EngineID engine_id, CargoID cargo);
+	static SQInteger GetBuildWithRefitCapacity(TileIndex depot, EngineID engine_id, CargoType cargo);
 
 	/**
 	 * Clones a vehicle at the given depot, copying or cloning its orders.
@@ -431,7 +431,7 @@ public:
 	 * @pre The vehicle must be stopped in the depot.
 	 * @return The capacity the vehicle will have when refited.
 	 */
-	static SQInteger GetRefitCapacity(VehicleID vehicle_id, CargoID cargo);
+	static SQInteger GetRefitCapacity(VehicleID vehicle_id, CargoType cargo);
 
 	/**
 	 * Refits a vehicle to the given cargo type.
@@ -447,7 +447,7 @@ public:
 	 * @exception ScriptVehicle::ERR_VEHICLE_NOT_IN_DEPOT
 	 * @return True if and only if the refit succeeded.
 	 */
-	static bool RefitVehicle(VehicleID vehicle_id, CargoID cargo);
+	static bool RefitVehicle(VehicleID vehicle_id, CargoType cargo);
 
 	/**
 	 * Sells the given vehicle.
@@ -546,7 +546,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo).
 	 * @return The maximum amount of the given cargo the vehicle can transport.
 	 */
-	static SQInteger GetCapacity(VehicleID vehicle_id, CargoID cargo);
+	static SQInteger GetCapacity(VehicleID vehicle_id, CargoType cargo);
 
 	/**
 	 * Get the length of a the total vehicle in 1/16's of a tile.
@@ -565,7 +565,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo).
 	 * @return The amount of the given cargo the vehicle is currently transporting.
 	 */
-	static SQInteger GetCargoLoad(VehicleID vehicle_id, CargoID cargo);
+	static SQInteger GetCargoLoad(VehicleID vehicle_id, CargoType cargo);
 
 	/**
 	 * Get the group of a given vehicle.
@@ -619,7 +619,7 @@ private:
 	/**
 	 * Internal function used by BuildVehicle(WithRefit).
 	 */
-	static VehicleID _BuildVehicleInternal(TileIndex depot, EngineID engine_id, CargoID cargo);
+	static VehicleID _BuildVehicleInternal(TileIndex depot, EngineID engine_id, CargoType cargo);
 
 	/**
 	 * Internal function used by SellWagon(Chain).

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -551,7 +551,7 @@ struct LinkGraphSettings {
 	uint8_t demand_distance;                  ///< influence of distance between stations on the demand function
 	uint8_t short_path_saturation;            ///< percentage up to which short paths are saturated before saturating most capacious paths
 
-	inline DistributionType GetDistributionType(CargoID cargo) const
+	inline DistributionType GetDistributionType(CargoType cargo) const
 	{
 		if (IsCargoInClass(cargo, CC_PASSENGERS)) return this->distribution_pax;
 		if (IsCargoInClass(cargo, CC_MAIL)) return this->distribution_mail;

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -917,7 +917,7 @@ CommandCost CmdBuildShip(DoCommandFlag flags, TileIndex tile, const Engine *e, V
 
 		v->spritenum = svi->image_index;
 		v->cargo_type = e->GetDefaultCargoType();
-		assert(IsValidCargoID(v->cargo_type));
+		assert(IsValidCargoType(v->cargo_type));
 		v->cargo_cap = svi->capacity;
 		v->refit_cap = 0;
 

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -99,7 +99,7 @@ Station::~Station()
 		if (a->targetairport == this->index) a->targetairport = INVALID_STATION;
 	}
 
-	for (CargoID c = 0; c < NUM_CARGO; ++c) {
+	for (CargoType c = 0; c < NUM_CARGO; ++c) {
 		LinkGraph *lg = LinkGraph::GetIfValid(this->goods[c].link_graph);
 		if (lg == nullptr) continue;
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -181,7 +181,7 @@ static bool CMSAMine(TileIndex tile)
 	for (const auto &p : ind->produced) {
 		/* The industry extracts something non-liquid, i.e. no oil or plastic, so it is a mine.
 		 * Also the production of passengers and mail is ignored. */
-		if (IsValidCargoID(p.cargo) &&
+		if (IsValidCargoType(p.cargo) &&
 				(CargoSpec::Get(p.cargo)->classes & (CC_LIQUID | CC_PASSENGERS | CC_MAIL)) == 0) {
 			return true;
 		}
@@ -566,7 +566,7 @@ CargoArray GetProductionAroundTiles(TileIndex north_tile, int w, int h, int rad)
 		if (i->neutral_station != nullptr && !_settings_game.station.serve_neutral_industries) continue;
 
 		for (const auto &p : i->produced) {
-			if (IsValidCargoID(p.cargo)) produced[p.cargo]++;
+			if (IsValidCargoType(p.cargo)) produced[p.cargo]++;
 		}
 	}
 
@@ -634,7 +634,7 @@ void UpdateStationAcceptance(Station *st, bool show_msg)
 	}
 
 	/* Adjust in case our station only accepts fewer kinds of goods */
-	for (CargoID i = 0; i < NUM_CARGO; i++) {
+	for (CargoType i = 0; i < NUM_CARGO; i++) {
 		uint amt = acceptance[i];
 
 		/* Make sure the station can accept the goods type. */
@@ -3759,8 +3759,8 @@ void TriggerWatchedCargoCallbacks(Station *st)
 {
 	/* Collect cargoes accepted since the last big tick. */
 	CargoTypes cargoes = 0;
-	for (CargoID cid = 0; cid < NUM_CARGO; cid++) {
-		if (HasBit(st->goods[cid].status, GoodsEntry::GES_ACCEPTED_BIGTICK)) SetBit(cargoes, cid);
+	for (CargoType cargo_type = 0; cargo_type < NUM_CARGO; cargo_type++) {
+		if (HasBit(st->goods[cargo_type].status, GoodsEntry::GES_ACCEPTED_BIGTICK)) SetBit(cargoes, cargo_type);
 	}
 
 	/* Anything to do? */
@@ -3999,7 +3999,7 @@ static void UpdateStationRating(Station *st)
  * @param avoid Original next hop of cargo, avoid this.
  * @param avoid2 Another station to be avoided when rerouting.
  */
-void RerouteCargo(Station *st, CargoID c, StationID avoid, StationID avoid2)
+void RerouteCargo(Station *st, CargoType c, StationID avoid, StationID avoid2)
 {
 	GoodsEntry &ge = st->goods[c];
 
@@ -4025,7 +4025,7 @@ void RerouteCargo(Station *st, CargoID c, StationID avoid, StationID avoid2)
  */
 void DeleteStaleLinks(Station *from)
 {
-	for (CargoID c = 0; c < NUM_CARGO; ++c) {
+	for (CargoType c = 0; c < NUM_CARGO; ++c) {
 		const bool auto_distributed = (_settings_game.linkgraph.GetDistributionType(c) != DT_MANUAL);
 		GoodsEntry &ge = from->goods[c];
 		LinkGraph *lg = LinkGraph::GetIfValid(ge.link_graph);
@@ -4117,7 +4117,7 @@ void DeleteStaleLinks(Station *from)
  * @param usage Usage to add to link stat.
  * @param mode Update mode to be applied.
  */
-void IncreaseStats(Station *st, CargoID cargo, StationID next_station_id, uint capacity, uint usage, uint32_t time, EdgeUpdateMode mode)
+void IncreaseStats(Station *st, CargoType cargo, StationID next_station_id, uint capacity, uint usage, uint32_t time, EdgeUpdateMode mode)
 {
 	GoodsEntry &ge1 = st->goods[cargo];
 	Station *st2 = Station::Get(next_station_id);
@@ -4248,7 +4248,7 @@ void ModifyStationRatingAround(TileIndex tile, Owner owner, int amount, uint rad
 	});
 }
 
-static uint UpdateStationWaiting(Station *st, CargoID type, uint amount, SourceType source_type, SourceID source_id)
+static uint UpdateStationWaiting(Station *st, CargoType type, uint amount, SourceType source_type, SourceID source_id)
 {
 	/* We can't allocate a CargoPacket? Then don't do anything
 	 * at all; i.e. just discard the incoming cargo. */
@@ -4372,7 +4372,7 @@ const StationList &StationFinder::GetStations()
 }
 
 
-static bool CanMoveGoodsToStation(const Station *st, CargoID type)
+static bool CanMoveGoodsToStation(const Station *st, CargoType type)
 {
 	/* Is the station reserved exclusively for somebody else? */
 	if (st->owner != OWNER_NONE && st->town->exclusive_counter > 0 && st->town->exclusivity != st->owner) return false;
@@ -4393,7 +4393,7 @@ static bool CanMoveGoodsToStation(const Station *st, CargoID type)
 	return true;
 }
 
-uint MoveGoodsToStation(CargoID type, uint amount, SourceType source_type, SourceID source_id, const StationList &all_stations, Owner exclusivity)
+uint MoveGoodsToStation(CargoType type, uint amount, SourceType source_type, SourceID source_id, const StationList &all_stations, Owner exclusivity)
 {
 	/* Return if nothing to do. Also the rounding below fails for 0. */
 	if (all_stations.empty()) return 0;

--- a/src/station_func.h
+++ b/src/station_func.h
@@ -49,8 +49,8 @@ void UpdateAirportsNoise();
 bool SplitGroundSpriteForOverlay(const TileInfo *ti, SpriteID *ground, RailTrackOffset *overlay_offset);
 
 void IncreaseStats(Station *st, const Vehicle *v, StationID next_station_id, uint32_t time);
-void IncreaseStats(Station *st, CargoID cargo, StationID next_station_id, uint capacity, uint usage, uint32_t time, EdgeUpdateMode mode);
-void RerouteCargo(Station *st, CargoID c, StationID avoid, StationID avoid2);
+void IncreaseStats(Station *st, CargoType cargo, StationID next_station_id, uint capacity, uint usage, uint32_t time, EdgeUpdateMode mode);
+void RerouteCargo(Station *st, CargoType c, StationID avoid, StationID avoid2);
 
 /**
  * Calculates the maintenance cost of a number of station tiles.

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -87,7 +87,7 @@ int DrawStationCoverageAreaText(int left, int right, int top, StationCoverageTyp
 		}
 
 		/* Convert cargo counts to a set of cargo bits, and draw the result. */
-		for (CargoID i = 0; i < NUM_CARGO; i++) {
+		for (CargoType i = 0; i < NUM_CARGO; i++) {
 			switch (sct) {
 				case SCT_PASSENGERS_ONLY: if (!IsCargoInClass(i, CC_PASSENGERS)) continue; break;
 				case SCT_NON_PASSENGERS_ONLY: if (IsCargoInClass(i, CC_PASSENGERS)) continue; break;
@@ -217,7 +217,7 @@ void CheckRedrawRoadWaypointCoverage(const Window *)
  * @param amount Cargo amount
  * @param rating ratings data for that particular cargo
  */
-static void StationsWndShowStationRating(int left, int right, int y, CargoID type, uint amount, uint8_t rating)
+static void StationsWndShowStationRating(int left, int right, int y, CargoType type, uint amount, uint8_t rating)
 {
 	static const uint units_full  = 576; ///< number of units to show station as 'full'
 	static const uint rating_full = 224; ///< rating needed so it is shown as 'full'
@@ -316,10 +316,10 @@ protected:
 				if (st->owner == owner || (st->owner == OWNER_NONE && HasStationInUse(st->index, true, owner))) {
 					bool has_rating = false;
 					/* Add to the station/cargo counts. */
-					for (CargoID j = 0; j < NUM_CARGO; j++) {
+					for (CargoType j = 0; j < NUM_CARGO; j++) {
 						if (st->goods[j].HasRating()) this->stations_per_cargo_type[j]++;
 					}
-					for (CargoID j = 0; j < NUM_CARGO; j++) {
+					for (CargoType j = 0; j < NUM_CARGO; j++) {
 						if (st->goods[j].HasRating()) {
 							has_rating = true;
 							if (HasBit(this->filter.cargoes, j)) {
@@ -361,7 +361,7 @@ protected:
 	{
 		int diff = 0;
 
-		for (CargoID j : SetCargoBitIterator(cargo_filter)) {
+		for (CargoType j : SetCargoBitIterator(cargo_filter)) {
 			diff += (a->goods[j].HasData() ? a->goods[j].GetData().cargo.TotalCount() : 0) - (b->goods[j].HasData() ? b->goods[j].GetData().cargo.TotalCount() : 0);
 		}
 
@@ -373,7 +373,7 @@ protected:
 	{
 		int diff = 0;
 
-		for (CargoID j : SetCargoBitIterator(cargo_filter)) {
+		for (CargoType j : SetCargoBitIterator(cargo_filter)) {
 			diff += (a->goods[j].HasData() ? a->goods[j].GetData().cargo.AvailableCount() : 0) - (b->goods[j].HasData() ? b->goods[j].GetData().cargo.AvailableCount() : 0);
 		}
 
@@ -386,7 +386,7 @@ protected:
 		uint8_t maxr1 = 0;
 		uint8_t maxr2 = 0;
 
-		for (CargoID j : SetCargoBitIterator(cargo_filter)) {
+		for (CargoType j : SetCargoBitIterator(cargo_filter)) {
 			if (a->goods[j].HasRating()) maxr1 = std::max(maxr1, a->goods[j].rating);
 			if (b->goods[j].HasRating()) maxr2 = std::max(maxr2, b->goods[j].rating);
 		}
@@ -400,7 +400,7 @@ protected:
 		uint8_t minr1 = 255;
 		uint8_t minr2 = 255;
 
-		for (CargoID j : SetCargoBitIterator(cargo_filter)) {
+		for (CargoType j : SetCargoBitIterator(cargo_filter)) {
 			if (a->goods[j].HasRating()) minr1 = std::min(minr1, a->goods[j].rating);
 			if (b->goods[j].HasRating()) minr2 = std::min(minr2, b->goods[j].rating);
 		}
@@ -526,8 +526,8 @@ public:
 
 					/* show cargo waiting and station ratings */
 					for (const CargoSpec *cs : _sorted_standard_cargo_specs) {
-						CargoID cid = cs->Index();
-						if (st->goods[cid].HasRating()) {
+						CargoType cargo_type = cs->Index();
+						if (st->goods[cargo_type].HasRating()) {
 							/* For RTL we work in exactly the opposite direction. So
 							 * decrement the space needed first, then draw to the left
 							 * instead of drawing to the left and then incrementing
@@ -536,7 +536,7 @@ public:
 								x -= rating_width + rating_spacing;
 								if (x < tr.left) break;
 							}
-							StationsWndShowStationRating(x, x + rating_width, tr.top, cid, st->goods[cid].HasData() ? st->goods[cid].GetData().cargo.TotalCount() : 0, st->goods[cid].rating);
+							StationsWndShowStationRating(x, x + rating_width, tr.top, cargo_type, st->goods[cargo_type].HasData() ? st->goods[cargo_type].GetData().cargo.TotalCount() : 0, st->goods[cargo_type].rating);
 							if (!rtl) {
 								x += rating_width + rating_spacing;
 								if (x > tr.right) break;
@@ -864,7 +864,7 @@ static constexpr NWidgetPart _nested_station_view_widgets[] = {
  * @param right right most coordinate to draw on
  * @param y y coordinate
  */
-static void DrawCargoIcons(CargoID i, uint waiting, int left, int right, int y)
+static void DrawCargoIcons(CargoType i, uint waiting, int left, int right, int y)
 {
 	int width = ScaleSpriteTrad(10);
 	uint num = std::min<uint>((waiting + (width / 2)) / width, (right - left) / width); // maximum is width / 10 icons so it won't overflow
@@ -891,7 +891,7 @@ enum class CargoSortType : uint8_t {
 	Count,         ///< by amount of cargo
 	StationString, ///< by station name
 	StationID,     ///< by station id
-	CargoID,       ///< by cargo id
+	CargoType,     ///< by cargo type
 };
 
 class CargoSorter {
@@ -933,13 +933,13 @@ public:
 	}
 
 	/**
-	 * Insert a new child or retrieve an existing child using a cargo ID as ID.
-	 * @param cargo ID of the cargo for which an entry shall be created or retrieved
+	 * Insert a new child or retrieve an existing child using a cargo type as ID.
+	 * @param cargo type of the cargo for which an entry shall be created or retrieved
 	 * @return a child entry associated with the given cargo.
 	 */
-	CargoDataEntry *InsertOrRetrieve(CargoID cargo)
+	CargoDataEntry *InsertOrRetrieve(CargoType cargo)
 	{
-		return this->InsertOrRetrieve<CargoID>(cargo);
+		return this->InsertOrRetrieve<CargoType>(cargo);
 	}
 
 	void Update(uint count);
@@ -956,9 +956,9 @@ public:
 
 	/**
 	 * Remove a child associated with the given cargo.
-	 * @param cargo ID of the cargo for which the child should be removed.
+	 * @param cargo type of the cargo for which the child should be removed.
 	 */
-	void Remove(CargoID cargo)
+	void Remove(CargoType cargo)
 	{
 		CargoDataEntry t(cargo);
 		this->Remove(&t);
@@ -977,10 +977,10 @@ public:
 
 	/**
 	 * Retrieve a child for the given cargo. Return nullptr if it doesn't exist.
-	 * @param cargo ID of the cargo the child we're looking for is associated with.
+	 * @param cargo type of the cargo the child we're looking for is associated with.
 	 * @return a child entry for the given cargo or nullptr.
 	 */
-	CargoDataEntry *Retrieve(CargoID cargo) const
+	CargoDataEntry *Retrieve(CargoType cargo) const
 	{
 		CargoDataEntry t(cargo);
 		return this->Retrieve(this->children->find(&t));
@@ -994,9 +994,9 @@ public:
 	StationID GetStation() const { return this->station; }
 
 	/**
-	 * Get the cargo ID for this entry.
+	 * Get the cargo type for this entry.
 	 */
-	CargoID GetCargo() const { return this->cargo; }
+	CargoType GetCargo() const { return this->cargo; }
 
 	/**
 	 * Get the cargo count for this entry.
@@ -1037,9 +1037,9 @@ public:
 private:
 
 	CargoDataEntry(StationID st, uint c, CargoDataEntry *p);
-	CargoDataEntry(CargoID car, uint c, CargoDataEntry *p);
+	CargoDataEntry(CargoType car, uint c, CargoDataEntry *p);
 	CargoDataEntry(StationID st);
-	CargoDataEntry(CargoID car);
+	CargoDataEntry(CargoType car);
 
 	CargoDataEntry *Retrieve(CargoDataSet::iterator i) const;
 
@@ -1053,7 +1053,7 @@ private:
 	const union {
 		StationID station;    ///< ID of the station this entry is associated with.
 		struct {
-			CargoID cargo;    ///< ID of the cargo this entry is associated with.
+			CargoType cargo;    ///< ID of the cargo this entry is associated with.
 			bool transfers;   ///< If there are transfers for this cargo.
 		};
 	};
@@ -1067,10 +1067,10 @@ CargoDataEntry::CargoDataEntry() :
 	station(INVALID_STATION),
 	num_children(0),
 	count(0),
-	children(new CargoDataSet(CargoSorter(CargoSortType::CargoID)))
+	children(new CargoDataSet(CargoSorter(CargoSortType::CargoType)))
 {}
 
-CargoDataEntry::CargoDataEntry(CargoID cargo, uint count, CargoDataEntry *parent) :
+CargoDataEntry::CargoDataEntry(CargoType cargo, uint count, CargoDataEntry *parent) :
 	parent(parent),
 	cargo(cargo),
 	num_children(0),
@@ -1094,7 +1094,7 @@ CargoDataEntry::CargoDataEntry(StationID station) :
 	children(nullptr)
 {}
 
-CargoDataEntry::CargoDataEntry(CargoID cargo) :
+CargoDataEntry::CargoDataEntry(CargoType cargo) :
 	parent(nullptr),
 	cargo(cargo),
 	num_children(0),
@@ -1142,7 +1142,7 @@ void CargoDataEntry::Remove(CargoDataEntry *child)
 
 /**
  * Retrieve a subentry or insert it if it doesn't exist, yet.
- * @tparam ID type of ID: either StationID or CargoID
+ * @tparam ID type of ID: either StationID or CargoType
  * @param child_id ID of the child to be inserted or retrieved.
  * @return the new or retrieved subentry
  */
@@ -1203,8 +1203,8 @@ bool CargoSorter::operator()(const CargoDataEntry *cd1, const CargoDataEntry *cd
 	switch (this->type) {
 		case CargoSortType::StationID:
 			return this->SortId<StationID>(cd1->GetStation(), cd2->GetStation());
-		case CargoSortType::CargoID:
-			return this->SortId<CargoID>(cd1->GetCargo(), cd2->GetCargo());
+		case CargoSortType::CargoType:
+			return this->SortId<CargoType>(cd1->GetCargo(), cd2->GetCargo());
 		case CargoSortType::Count:
 			return this->SortCount(cd1, cd2);
 		case CargoSortType::StationString:
@@ -1258,7 +1258,7 @@ struct StationViewWindow : public Window {
 	 */
 	struct RowDisplay {
 		RowDisplay(CargoDataEntry *f, StationID n) : filter(f), next_station(n) {}
-		RowDisplay(CargoDataEntry *f, CargoID n) : filter(f), next_cargo(n) {}
+		RowDisplay(CargoDataEntry *f, CargoType n) : filter(f), next_cargo(n) {}
 
 		/**
 		 * Parent of the cargo entry belonging to the row.
@@ -1273,7 +1273,7 @@ struct StationViewWindow : public Window {
 			/**
 			 * ID of the cargo belonging to the entry actually displayed if it's cargo.
 			 */
-			CargoID next_cargo;
+			CargoType next_cargo;
 		};
 	};
 
@@ -1385,16 +1385,16 @@ struct StationViewWindow : public Window {
 	}
 
 	/**
-	 * Show a certain cargo entry characterized by source/next/dest station, cargo ID and amount of cargo at the
+	 * Show a certain cargo entry characterized by source/next/dest station, cargo type and amount of cargo at the
 	 * right place in the cargo view. I.e. update as many rows as are expanded following that characterization.
 	 * @param data Root entry of the tree.
-	 * @param cargo Cargo ID of the entry to be shown.
+	 * @param cargo Cargo type of the entry to be shown.
 	 * @param source Source station of the entry to be shown.
 	 * @param next Next station the cargo to be shown will visit.
 	 * @param dest Final destination of the cargo to be shown.
 	 * @param count Amount of cargo to be shown.
 	 */
-	void ShowCargo(CargoDataEntry *data, CargoID cargo, StationID source, StationID next, StationID dest, uint count)
+	void ShowCargo(CargoDataEntry *data, CargoType cargo, StationID source, StationID next, StationID dest, uint count)
 	{
 		if (count == 0) return;
 		bool auto_distributed = _settings_game.linkgraph.GetDistributionType(cargo) != DT_MANUAL;
@@ -1528,7 +1528,7 @@ struct StationViewWindow : public Window {
 	 * even if we actually don't know the destination of a certain packet from just looking at it.
 	 * @param i Cargo to recalculate the cache for.
 	 */
-	void RecalcDestinations(CargoID i)
+	void RecalcDestinations(CargoType i)
 	{
 		const Station *st = Station::Get(this->window_number);
 		CargoDataEntry *cargo_entry = cached_destinations.InsertOrRetrieve(i);
@@ -1556,13 +1556,13 @@ struct StationViewWindow : public Window {
 	/**
 	 * Estimate the amounts of cargo per final destination for a given cargo, source station and next hop and
 	 * save the result as children of the given CargoDataEntry.
-	 * @param cargo ID of the cargo to estimate destinations for.
+	 * @param cargo type of the cargo to estimate destinations for.
 	 * @param source Source station of the given batch of cargo.
 	 * @param next Intermediate hop to start the calculation at ("next hop").
 	 * @param count Size of the batch of cargo.
 	 * @param dest CargoDataEntry to save the results in.
 	 */
-	void EstimateDestinations(CargoID cargo, StationID source, StationID next, uint count, CargoDataEntry *dest)
+	void EstimateDestinations(CargoType cargo, StationID source, StationID next, uint count, CargoDataEntry *dest)
 	{
 		if (Station::IsValidID(next) && Station::IsValidID(source)) {
 			GoodsEntry &ge = Station::Get(next)->goods[cargo];
@@ -1618,7 +1618,7 @@ struct StationViewWindow : public Window {
 	 * @param flows The current station's flows for that cargo.
 	 * @param cargo The CargoDataEntry to save the results in.
 	 */
-	void BuildFlowList(CargoID i, const FlowStatMap &flows, CargoDataEntry *cargo)
+	void BuildFlowList(CargoType i, const FlowStatMap &flows, CargoDataEntry *cargo)
 	{
 		const CargoDataEntry *source_dest = this->cached_destinations.Retrieve(i);
 		for (FlowStatMap::const_iterator it = flows.begin(); it != flows.end(); ++it) {
@@ -1641,7 +1641,7 @@ struct StationViewWindow : public Window {
 	 * @param packets The current station's cargo list for that cargo.
 	 * @param cargo The CargoDataEntry to save the result in.
 	 */
-	void BuildCargoList(CargoID i, const StationCargoList &packets, CargoDataEntry *cargo)
+	void BuildCargoList(CargoType i, const StationCargoList &packets, CargoDataEntry *cargo)
 	{
 		const CargoDataEntry *source_dest = this->cached_destinations.Retrieve(i);
 		for (StationCargoList::ConstIterator it = packets.Packets()->begin(); it != packets.Packets()->end(); it++) {
@@ -1690,7 +1690,7 @@ struct StationViewWindow : public Window {
 	 */
 	void BuildCargoList(CargoDataEntry *cargo, const Station *st)
 	{
-		for (CargoID i = 0; i < NUM_CARGO; i++) {
+		for (CargoType i = 0; i < NUM_CARGO; i++) {
 
 			if (this->cached_destinations.Retrieve(i) == nullptr) {
 				this->RecalcDestinations(i);
@@ -1726,7 +1726,7 @@ struct StationViewWindow : public Window {
 			parent = parent->GetParent();
 		}
 
-		CargoID cargo = parent->GetCargo();
+		CargoType cargo = parent->GetCargo();
 		CargoDataEntry *filter = this->expanded_rows.Retrieve(cargo);
 		while (!stations.empty()) {
 			filter = filter->Retrieve(stations.back());
@@ -1802,7 +1802,7 @@ struct StationViewWindow : public Window {
 	 * @param cargo Current cargo being drawn (if cargo column has been passed).
 	 * @return row (in "pos" counting) after the one we have last drawn to.
 	 */
-	int DrawEntries(CargoDataEntry *entry, const Rect &r, int pos, int maxrows, int column, CargoID cargo = INVALID_CARGO)
+	int DrawEntries(CargoDataEntry *entry, const Rect &r, int pos, int maxrows, int column, CargoType cargo = INVALID_CARGO)
 	{
 		if (this->sortings[column] == CargoSortType::AsGrouping) {
 			if (this->groupings[column] != GR_CARGO) {
@@ -1961,7 +1961,7 @@ struct StationViewWindow : public Window {
 		} else {
 			RowDisplay &display = this->displayed_rows[row];
 			if (display.filter == &this->expanded_rows) {
-				this->HandleCargoWaitingClick<CargoID>(display.filter, display.next_cargo);
+				this->HandleCargoWaitingClick<CargoType>(display.filter, display.next_cargo);
 			} else {
 				this->HandleCargoWaitingClick<StationID>(display.filter, display.next_station);
 			}
@@ -2025,7 +2025,7 @@ struct StationViewWindow : public Window {
 			case WID_SV_SORT_BY: {
 				/* The initial selection is composed of current mode and
 				 * sorting criteria for columns 1, 2, and 3. Column 0 is always
-				 * sorted by cargo ID. The others can theoretically be sorted
+				 * sorted by cargo type. The others can theoretically be sorted
 				 * by different things but there is no UI for that. */
 				ShowDropDownMenu(this, StationViewWindow::sort_names,
 						this->current_mode * 2 + (this->sortings[1] == CargoSortType::Count ? 1 : 0),
@@ -2157,14 +2157,14 @@ struct StationViewWindow : public Window {
 
 	/**
 	 * Some data on this window has become invalid. Invalidate the cache for the given cargo if necessary.
-	 * @param data Information about the changed data. If it's a valid cargo ID, invalidate the cargo data.
+	 * @param data Information about the changed data. If it's a valid cargo type, invalidate the cargo data.
 	 * @param gui_scope Whether the call is done from GUI scope. You may not do everything when not in GUI scope. See #InvalidateWindowData() for details.
 	 */
 	void OnInvalidateData([[maybe_unused]] int data = 0, [[maybe_unused]] bool gui_scope = true) override
 	{
 		if (gui_scope) {
 			if (data >= 0 && data < NUM_CARGO) {
-				this->cached_destinations.Remove((CargoID)data);
+				this->cached_destinations.Remove((CargoType)data);
 			} else {
 				this->ReInit();
 			}

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1261,7 +1261,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 					/* Tiny description of cargotypes. Layout:
 					 * param 1: cargo type
 					 * param 2: cargo count */
-					CargoID cargo = args.GetNextParameter<CargoID>();
+					CargoType cargo = args.GetNextParameter<CargoType>();
 					if (cargo >= CargoSpec::GetArraySize()) break;
 
 					StringID cargo_str = CargoSpec::Get(cargo)->units_volume;
@@ -1289,7 +1289,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 					/* Short description of cargotypes. Layout:
 					 * param 1: cargo type
 					 * param 2: cargo count */
-					CargoID cargo = args.GetNextParameter<CargoID>();
+					CargoType cargo = args.GetNextParameter<CargoType>();
 					if (cargo >= CargoSpec::GetArraySize()) break;
 
 					StringID cargo_str = CargoSpec::Get(cargo)->units_volume;
@@ -1321,10 +1321,10 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 
 				case SCC_CARGO_LONG: { // {CARGO_LONG}
 					/* First parameter is cargo type, second parameter is cargo count */
-					CargoID cargo = args.GetNextParameter<CargoID>();
-					if (IsValidCargoID(cargo) && cargo >= CargoSpec::GetArraySize()) break;
+					CargoType cargo = args.GetNextParameter<CargoType>();
+					if (IsValidCargoType(cargo) && cargo >= CargoSpec::GetArraySize()) break;
 
-					StringID cargo_str = !IsValidCargoID(cargo) ? STR_QUANTITY_N_A : CargoSpec::Get(cargo)->quantifier;
+					StringID cargo_str = !IsValidCargoType(cargo) ? STR_QUANTITY_N_A : CargoSpec::Get(cargo)->quantifier;
 					auto tmp_args = MakeParameters(args.GetNextParameter<int64_t>());
 					GetStringWithArgs(builder, cargo_str, tmp_args);
 					break;

--- a/src/subsidy_base.h
+++ b/src/subsidy_base.h
@@ -20,7 +20,7 @@ extern SubsidyPool _subsidy_pool;
 
 /** Struct about subsidies, offered and awarded */
 struct Subsidy : SubsidyPool::PoolItem<&_subsidy_pool> {
-	CargoID cargo_type;  ///< Cargo type involved in this subsidy, INVALID_CARGO for invalid subsidy
+	CargoType cargo_type;  ///< Cargo type involved in this subsidy, INVALID_CARGO for invalid subsidy
 	uint16_t remaining;    ///< Remaining months when this subsidy is valid
 	CompanyID awarded;   ///< Subsidy is awarded to this company; INVALID_COMPANY if it's not awarded to anyone
 	SourceType src_type; ///< Source of subsidised path (SourceType::Industry or SourceType::Town)

--- a/src/subsidy_cmd.h
+++ b/src/subsidy_cmd.h
@@ -13,7 +13,7 @@
 #include "command_type.h"
 #include "cargo_type.h"
 
-CommandCost CmdCreateSubsidy(DoCommandFlag flags, CargoID cid, SourceType src_type, SourceID src, SourceType dst_type, SourceID dst);
+CommandCost CmdCreateSubsidy(DoCommandFlag flags, CargoType cargo_type, SourceType src_type, SourceID src, SourceType dst_type, SourceID dst);
 
 DEF_CMD_TRAIT(CMD_CREATE_SUBSIDY, CmdCreateSubsidy, CMD_DEITY, CMDT_OTHER_MANAGEMENT)
 

--- a/src/subsidy_func.h
+++ b/src/subsidy_func.h
@@ -19,7 +19,7 @@
 
 std::pair<NewsReferenceType, NewsReferenceType> SetupSubsidyDecodeParam(const struct Subsidy *s, SubsidyDecodeParamType mode, uint parameter_offset = 0);
 void DeleteSubsidyWith(SourceType type, SourceID index);
-bool CheckSubsidised(CargoID cargo_type, CompanyID company, SourceType src_type, SourceID src, const Station *st);
+bool CheckSubsidised(CargoType cargo_type, CompanyID company, SourceType src_type, SourceID src, const Station *st);
 void RebuildSubsidisedSourceAndDestinationCache();
 
 #endif /* SUBSIDY_FUNC_H */

--- a/src/subsidy_gui.cpp
+++ b/src/subsidy_gui.cpp
@@ -144,10 +144,10 @@ struct SubsidyListWindow : Window {
 		size = maxdim(size, d);
 	}
 
-	void DrawCargoIcon(const Rect &r, int y_offset, CargoID cid) const
+	void DrawCargoIcon(const Rect &r, int y_offset, CargoType cargo_type) const
 	{
 		bool rtl = _current_text_dir == TD_RTL;
-		SpriteID icon = CargoSpec::Get(cid)->GetCargoIcon();
+		SpriteID icon = CargoSpec::Get(cargo_type)->GetCargoIcon();
 		Dimension d = GetSpriteSize(icon);
 		Rect ir = r.WithWidth(this->cargo_icon_size.width, rtl).WithHeight(GetCharacterHeight(FS_NORMAL));
 		DrawSprite(icon, PAL_NONE, CenterBounds(ir.left, ir.right, d.width), CenterBounds(ir.top, ir.bottom, this->cargo_icon_size.height) + y_offset);

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -277,8 +277,8 @@ static const NIFeature _nif_industrytile = {
 
 
 /*** NewGRF industries ***/
-#define NIP_PRODUCED_CARGO(prop, base, slot, type, name) { name, [] (const void *b) -> const void * { return std::addressof(static_cast<const base *>(b)->GetProduced(slot).cargo); }, sizeof(CargoID), prop, type }
-#define NIP_ACCEPTED_CARGO(prop, base, slot, type, name) { name, [] (const void *b) -> const void * { return std::addressof(static_cast<const base *>(b)->GetAccepted(slot).cargo); }, sizeof(CargoID), prop, type }
+#define NIP_PRODUCED_CARGO(prop, base, slot, type, name) { name, [] (const void *b) -> const void * { return std::addressof(static_cast<const base *>(b)->GetProduced(slot).cargo); }, sizeof(CargoType), prop, type }
+#define NIP_ACCEPTED_CARGO(prop, base, slot, type, name) { name, [] (const void *b) -> const void * { return std::addressof(static_cast<const base *>(b)->GetAccepted(slot).cargo); }, sizeof(CargoType), prop, type }
 
 static const NIProperty _nip_industries[] = {
 	NIP_PRODUCED_CARGO(0x25, Industry,  0, NIT_CARGO, "produced cargo 0"),

--- a/src/table/town_land.h
+++ b/src/table/town_land.h
@@ -1799,14 +1799,14 @@ static_assert(lengthof(_town_draw_tile_data) == (NEW_HOUSE_OFFSET) * 4 * 4);
  * @param bn  building name
  * @param rr  rating decrease if removed
  * @param mg  mail generation multiplier
- * @param ca1 acceptance for 1st CargoID
- * @param ca2 acceptance for 2nd CargoID
- * @param ca3 acceptance for 3rd CargoID
+ * @param ca1 acceptance for 1st CargoType
+ * @param ca2 acceptance for 2nd CargoType
+ * @param ca3 acceptance for 3rd CargoType
  * @param bf  building flags (size, stadium etc...)
  * @param ba  building availability (zone, climate...)
- * @param cg1 1st CargoID available
- * @param cg2 2nd CargoID available
- * @param cg3 3rd CargoID available
+ * @param cg1 1st CargoType available
+ * @param cg2 2nd CargoType available
+ * @param cg3 3rd CargoType available
  * @see HouseSpec
  */
 #define MS(mnd, mxd, p, rc, bn, rr, mg, ca1, ca2, ca3, bf, ba, cg1, cg2, cg3) \
@@ -1820,16 +1820,16 @@ extern const HouseSpec _original_house_specs[] = {
 	/**
 	 *                                                                              remove_rating_decrease
 	 *                                                                              |    mail_generation
-	 *     min_year                                                                 |    |    1st CargoID acceptance
-	 *     |         CalendarTime::MAX_YEAR                                                       |    |    |    2nd CargoID acceptance
-	 *     |         |    population                                                |    |    |    |    3th CargoID acceptance
+	 *     min_year                                                                 |    |    1st CargoType acceptance
+	 *     |         CalendarTime::MAX_YEAR                                         |    |    |    2nd CargoType acceptance
+	 *     |         |    population                                                |    |    |    |    3th CargoType acceptance
 	 *     |         |    |    removal_cost                                         |    |    |    |    |
 	 *     |         |    |    |    building_name                                   |    |    |    |    |
 	 *     |         |    |    |    |                                               |    |    |    |    |
 	 *     |         |    |    |    |                                               |    |    |    |    |
 	 * +-building_flags   |    |    |                                               |    |    |    |    |
 	 * +-building_availability |    |                                               |    |    |    |    |
-	 * +-cargoID accepted |    |    |                                               |    |    |    |    |
+	 * +-cargo type accepted   |    |                                               |    |    |    |    |
 	 * |   |         |    |    |    |                                               |    |    |    |    |
 	 */
 	MS(1963, CalendarTime::MAX_YEAR, 187, 150, STR_TOWN_BUILDING_NAME_TALL_OFFICE_BLOCK_1,      140,  70,   8,   3,   4,

--- a/src/town.h
+++ b/src/town.h
@@ -80,10 +80,10 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 
 	std::string text; ///< General text with additional information.
 
-	inline uint8_t GetPercentTransported(CargoID cid) const
+	inline uint8_t GetPercentTransported(CargoType cargo_type) const
 	{
-		if (!IsValidCargoID(cid)) return 0;
-		return this->supplied[cid].old_act * 256 / (this->supplied[cid].old_max + 1);
+		if (!IsValidCargoType(cargo_type)) return 0;
+		return this->supplied[cargo_type].old_act * 256 / (this->supplied[cargo_type].old_max + 1);
 	}
 
 	StationList stations_near;       ///< NOSAVE: List of nearby stations.

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -419,10 +419,10 @@ public:
 
 		for (auto tpe : {TPE_PASSENGERS, TPE_MAIL}) {
 			for (const CargoSpec *cs : CargoSpec::town_production_cargoes[tpe]) {
-				CargoID cid = cs->Index();
-				SetDParam(0, 1ULL << cid);
-				SetDParam(1, this->town->supplied[cid].old_act);
-				SetDParam(2, this->town->supplied[cid].old_max);
+				CargoType cargo_type = cs->Index();
+				SetDParam(0, 1ULL << cargo_type);
+				SetDParam(1, this->town->supplied[cargo_type].old_act);
+				SetDParam(2, this->town->supplied[cargo_type].old_max);
 				DrawString(tr, str_last_period);
 				tr.top += GetCharacterHeight(FS_NORMAL);
 			}

--- a/src/train.h
+++ b/src/train.h
@@ -54,7 +54,7 @@ enum ConsistChangeFlags {
 };
 DECLARE_ENUM_AS_BIT_SET(ConsistChangeFlags)
 
-uint8_t FreightWagonMult(CargoID cargo);
+uint8_t FreightWagonMult(CargoType cargo);
 
 void CheckTrainsLengths();
 

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -66,7 +66,7 @@ bool IsValidImageIndex<VEH_TRAIN>(uint8_t image_index)
  * @param cargo Cargo type to get multiplier for
  * @return Cargo weight multiplier
  */
-uint8_t FreightWagonMult(CargoID cargo)
+uint8_t FreightWagonMult(CargoType cargo)
 {
 	if (!CargoSpec::Get(cargo)->is_freight) return 1;
 	return _settings_game.vehicle.freight_trains;
@@ -649,7 +649,7 @@ static CommandCost CmdBuildRailWagon(DoCommandFlag flags, TileIndex tile, const 
 		InvalidateWindowData(WC_VEHICLE_DEPOT, v->tile);
 
 		v->cargo_type = e->GetDefaultCargoType();
-		assert(IsValidCargoID(v->cargo_type));
+		assert(IsValidCargoType(v->cargo_type));
 		v->cargo_cap = rvi->capacity;
 		v->refit_cap = 0;
 
@@ -774,7 +774,7 @@ CommandCost CmdBuildRailVehicle(DoCommandFlag flags, TileIndex tile, const Engin
 		v->vehstatus = VS_HIDDEN | VS_STOPPED | VS_DEFPAL;
 		v->spritenum = rvi->image_index;
 		v->cargo_type = e->GetDefaultCargoType();
-		assert(IsValidCargoID(v->cargo_type));
+		assert(IsValidCargoType(v->cargo_type));
 		v->cargo_cap = rvi->capacity;
 		v->refit_cap = 0;
 		v->last_station_visited = INVALID_STATION;

--- a/src/train_cmd.h
+++ b/src/train_cmd.h
@@ -25,6 +25,6 @@ DEF_CMD_TRAIT(CMD_MOVE_RAIL_VEHICLE,       CmdMoveRailVehicle,       CMD_LOCATIO
 DEF_CMD_TRAIT(CMD_FORCE_TRAIN_PROCEED,     CmdForceTrainProceed,     CMD_LOCATION, CMDT_VEHICLE_MANAGEMENT)
 DEF_CMD_TRAIT(CMD_REVERSE_TRAIN_DIRECTION, CmdReverseTrainDirection, CMD_LOCATION, CMDT_VEHICLE_MANAGEMENT)
 
-void CcBuildWagon(Commands cmd, const CommandCost &result, VehicleID new_veh_id, uint, uint16_t, CargoArray, TileIndex tile, EngineID, bool, CargoID, ClientID);
+void CcBuildWagon(Commands cmd, const CommandCost &result, VehicleID new_veh_id, uint, uint16_t, CargoArray, TileIndex tile, EngineID, bool, CargoType, ClientID);
 
 #endif /* TRAIN_CMD_H */

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -26,7 +26,7 @@
  * @param new_veh_id ID of the ne vehicle.
  * @param tile   The tile the command was executed on.
  */
-void CcBuildWagon(Commands, const CommandCost &result, VehicleID new_veh_id, uint, uint16_t, CargoArray, TileIndex tile, EngineID, bool, CargoID, ClientID)
+void CcBuildWagon(Commands, const CommandCost &result, VehicleID new_veh_id, uint, uint16_t, CargoArray, TileIndex tile, EngineID, bool, CargoType, ClientID)
 {
 	if (result.Failed()) return;
 
@@ -173,7 +173,7 @@ void DrawTrainImage(const Train *v, const Rect &r, VehicleID selection, EngineIm
 
 /** Helper struct for the cargo details information */
 struct CargoSummaryItem {
-	CargoID cargo;    ///< The cargo that is carried
+	CargoType cargo;    ///< The cargo that is carried
 	StringID subtype; ///< STR_EMPTY if none
 	uint capacity;    ///< Amount that can be carried
 	uint amount;      ///< Amount that is carried
@@ -218,7 +218,7 @@ static void TrainDetailsCargoTab(const CargoSummaryItem *item, int left, int rig
 		SetDParam(3, _settings_game.vehicle.freight_trains);
 		str = FreightWagonMult(item->cargo) > 1 ? STR_VEHICLE_DETAILS_CARGO_FROM_MULT : STR_VEHICLE_DETAILS_CARGO_FROM;
 	} else {
-		str = !IsValidCargoID(item->cargo) ? STR_QUANTITY_N_A : STR_VEHICLE_DETAILS_CARGO_EMPTY;
+		str = !IsValidCargoType(item->cargo) ? STR_QUANTITY_N_A : STR_VEHICLE_DETAILS_CARGO_EMPTY;
 	}
 
 	DrawString(left, right, y, str, TC_LIGHT_BLUE);
@@ -257,7 +257,7 @@ static void TrainDetailsInfoTab(const Vehicle *v, int left, int right, int y)
 static void TrainDetailsCapacityTab(const CargoSummaryItem *item, int left, int right, int y)
 {
 	StringID str;
-	if (IsValidCargoID(item->cargo)) {
+	if (IsValidCargoType(item->cargo)) {
 		SetDParam(0, item->cargo);
 		SetDParam(1, item->capacity);
 		SetDParam(4, item->subtype);
@@ -285,7 +285,7 @@ static void GetCargoSummaryOfArticulatedVehicle(const Train *v, CargoSummary &su
 		CargoSummaryItem new_item;
 		new_item.cargo = v->cargo_cap > 0 ? v->cargo_type : INVALID_CARGO;
 		new_item.subtype = GetCargoSubtypeText(v);
-		if (!IsValidCargoID(new_item.cargo) && new_item.subtype == STR_EMPTY) continue;
+		if (!IsValidCargoType(new_item.cargo) && new_item.subtype == STR_EMPTY) continue;
 
 		auto item = std::ranges::find(summary, new_item);
 		if (item == std::end(summary)) {
@@ -458,14 +458,14 @@ void DrawTrainDetails(const Train *v, const Rect &r, int vscroll_pos, uint16_t v
 		/* Indent the total cargo capacity details */
 		Rect ir = r.Indent(WidgetDimensions::scaled.hsep_indent, rtl);
 		for (const CargoSpec *cs : _sorted_cargo_specs) {
-			CargoID cid = cs->Index();
-			if (max_cargo[cid] > 0 && --vscroll_pos < 0 && vscroll_pos > -vscroll_cap) {
-				SetDParam(0, cid);            // {CARGO} #1
-				SetDParam(1, act_cargo[cid]); // {CARGO} #2
-				SetDParam(2, cid);            // {SHORTCARGO} #1
-				SetDParam(3, max_cargo[cid]); // {SHORTCARGO} #2
+			CargoType cargo_type = cs->Index();
+			if (max_cargo[cargo_type] > 0 && --vscroll_pos < 0 && vscroll_pos > -vscroll_cap) {
+				SetDParam(0, cargo_type);            // {CARGO} #1
+				SetDParam(1, act_cargo[cargo_type]); // {CARGO} #2
+				SetDParam(2, cargo_type);            // {SHORTCARGO} #1
+				SetDParam(3, max_cargo[cargo_type]); // {SHORTCARGO} #2
 				SetDParam(4, _settings_game.vehicle.freight_trains);
-				DrawString(ir.left, ir.right, y + text_y_offset, FreightWagonMult(cid) > 1 ? STR_VEHICLE_DETAILS_TRAIN_TOTAL_CAPACITY_MULT : STR_VEHICLE_DETAILS_TRAIN_TOTAL_CAPACITY);
+				DrawString(ir.left, ir.right, y + text_y_offset, FreightWagonMult(cargo_type) > 1 ? STR_VEHICLE_DETAILS_TRAIN_TOTAL_CAPACITY_MULT : STR_VEHICLE_DETAILS_TRAIN_TOTAL_CAPACITY);
 				y += line_height;
 			}
 		}

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -236,7 +236,7 @@ bool Vehicle::NeedsServicing() const
 		GetArticulatedRefitMasks(new_engine, true, &union_mask, &available_cargo_types);
 		/* Is there anything to refit? */
 		if (union_mask != 0) {
-			CargoID cargo_type;
+			CargoType cargo_type;
 			CargoTypes cargo_mask = GetCargoTypesOfArticulatedVehicle(v, &cargo_type);
 			if (!HasAtMostOneBit(cargo_mask)) {
 				CargoTypes new_engine_default_cargoes = GetCargoTypesOfArticulatedParts(new_engine);
@@ -247,7 +247,7 @@ bool Vehicle::NeedsServicing() const
 				/* engine_type is already a mixed cargo type which matches the incoming vehicle by default, no refit required */
 			} else {
 				/* Did the old vehicle carry anything? */
-				if (IsValidCargoID(cargo_type)) {
+				if (IsValidCargoType(cargo_type)) {
 					/* We can't refit the vehicle to carry the cargo we want */
 					if (!HasBit(available_cargo_types, cargo_type)) continue;
 				}
@@ -1969,7 +1969,7 @@ bool CanBuildVehicleInfrastructure(VehicleType type, uint8_t subtype)
  */
 LiveryScheme GetEngineLiveryScheme(EngineID engine_type, EngineID parent_engine_type, const Vehicle *v)
 {
-	CargoID cargo_type = v == nullptr ? INVALID_CARGO : v->cargo_type;
+	CargoType cargo_type = v == nullptr ? INVALID_CARGO : v->cargo_type;
 	const Engine *e = Engine::Get(engine_type);
 	switch (e->type) {
 		default: NOT_REACHED();
@@ -1982,9 +1982,9 @@ LiveryScheme GetEngineLiveryScheme(EngineID engine_type, EngineID parent_engine_
 				/* Note: Luckily cargo_type is not needed for engines */
 			}
 
-			if (!IsValidCargoID(cargo_type)) cargo_type = e->GetDefaultCargoType();
-			if (!IsValidCargoID(cargo_type)) cargo_type = GetCargoIDByLabel(CT_GOODS); // The vehicle does not carry anything, let's pick some freight cargo
-			assert(IsValidCargoID(cargo_type));
+			if (!IsValidCargoType(cargo_type)) cargo_type = e->GetDefaultCargoType();
+			if (!IsValidCargoType(cargo_type)) cargo_type = GetCargoTypeByLabel(CT_GOODS); // The vehicle does not carry anything, let's pick some freight cargo
+			assert(IsValidCargoType(cargo_type));
 			if (e->u.rail.railveh_type == RAILVEH_WAGON) {
 				if (!CargoSpec::Get(cargo_type)->is_freight) {
 					if (parent_engine_type == INVALID_ENGINE) {
@@ -2023,9 +2023,9 @@ LiveryScheme GetEngineLiveryScheme(EngineID engine_type, EngineID parent_engine_
 				e = Engine::Get(engine_type);
 				cargo_type = v->First()->cargo_type;
 			}
-			if (!IsValidCargoID(cargo_type)) cargo_type = e->GetDefaultCargoType();
-			if (!IsValidCargoID(cargo_type)) cargo_type = GetCargoIDByLabel(CT_GOODS); // The vehicle does not carry anything, let's pick some freight cargo
-			assert(IsValidCargoID(cargo_type));
+			if (!IsValidCargoType(cargo_type)) cargo_type = e->GetDefaultCargoType();
+			if (!IsValidCargoType(cargo_type)) cargo_type = GetCargoTypeByLabel(CT_GOODS); // The vehicle does not carry anything, let's pick some freight cargo
+			assert(IsValidCargoType(cargo_type));
 
 			/* Important: Use Tram Flag of front part. Luckily engine_type refers to the front part here. */
 			if (HasBit(e->info.misc_flags, EF_ROAD_TRAM)) {
@@ -2037,9 +2037,9 @@ LiveryScheme GetEngineLiveryScheme(EngineID engine_type, EngineID parent_engine_
 			}
 
 		case VEH_SHIP:
-			if (!IsValidCargoID(cargo_type)) cargo_type = e->GetDefaultCargoType();
-			if (!IsValidCargoID(cargo_type)) cargo_type = GetCargoIDByLabel(CT_GOODS); // The vehicle does not carry anything, let's pick some freight cargo
-			assert(IsValidCargoID(cargo_type));
+			if (!IsValidCargoType(cargo_type)) cargo_type = e->GetDefaultCargoType();
+			if (!IsValidCargoType(cargo_type)) cargo_type = GetCargoTypeByLabel(CT_GOODS); // The vehicle does not carry anything, let's pick some freight cargo
+			assert(IsValidCargoType(cargo_type));
 			return IsCargoInClass(cargo_type, CC_PASSENGERS) ? LS_PASSENGER_SHIP : LS_FREIGHT_SHIP;
 
 		case VEH_AIRCRAFT:

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -216,10 +216,10 @@ struct GRFFile;
  * Simulated cargo type and capacity for prediction of future links.
  */
 struct RefitDesc {
-	CargoID cargo;    ///< Cargo type the vehicle will be carrying.
+	CargoType cargo;    ///< Cargo type the vehicle will be carrying.
 	uint16_t capacity;  ///< Capacity the vehicle will have.
 	uint16_t remaining; ///< Capacity remaining from before the previous refit.
-	RefitDesc(CargoID cargo, uint16_t capacity, uint16_t remaining) :
+	RefitDesc(CargoType cargo, uint16_t capacity, uint16_t remaining) :
 			cargo(cargo), capacity(capacity), remaining(remaining) {}
 };
 
@@ -339,7 +339,7 @@ public:
 	TimerGameTick::TickCounter last_loading_tick; ///< Last TimerGameTick::counter tick that the vehicle has stopped at a station and could possibly leave with any cargo loaded.
 
 	VehicleCargoList cargo;             ///< The cargo this vehicle is carrying
-	CargoID cargo_type;                 ///< type of cargo this vehicle is carrying
+	CargoType cargo_type;                 ///< type of cargo this vehicle is carrying
 	uint8_t cargo_subtype;                 ///< Used for livery refits (NewGRF variations)
 	uint16_t cargo_cap;                   ///< total capacity
 	uint16_t refit_cap;                   ///< Capacity left over from before last refit.

--- a/src/vehicle_cmd.h
+++ b/src/vehicle_cmd.h
@@ -17,9 +17,9 @@
 #include "vehiclelist_cmd.h"
 #include "cargo_type.h"
 
-std::tuple<CommandCost, VehicleID, uint, uint16_t, CargoArray> CmdBuildVehicle(DoCommandFlag flags, TileIndex tile, EngineID eid, bool use_free_vehicles, CargoID cargo, ClientID client_id);
+std::tuple<CommandCost, VehicleID, uint, uint16_t, CargoArray> CmdBuildVehicle(DoCommandFlag flags, TileIndex tile, EngineID eid, bool use_free_vehicles, CargoType cargo, ClientID client_id);
 CommandCost CmdSellVehicle(DoCommandFlag flags, VehicleID v_id, bool sell_chain, bool backup_order, ClientID client_id);
-std::tuple<CommandCost, uint, uint16_t, CargoArray> CmdRefitVehicle(DoCommandFlag flags, VehicleID veh_id, CargoID new_cid, uint8_t new_subtype, bool auto_refit, bool only_this, uint8_t num_vehicles);
+std::tuple<CommandCost, uint, uint16_t, CargoArray> CmdRefitVehicle(DoCommandFlag flags, VehicleID veh_id, CargoType new_cargo_type, uint8_t new_subtype, bool auto_refit, bool only_this, uint8_t num_vehicles);
 CommandCost CmdSendVehicleToDepot(DoCommandFlag flags, VehicleID veh_id, DepotCommand depot_cmd, const VehicleListIdentifier &vli);
 CommandCost CmdChangeServiceInt(DoCommandFlag flags, VehicleID veh_id, uint16_t serv_int, bool is_custom, bool is_percent);
 CommandCost CmdRenameVehicle(DoCommandFlag flags, VehicleID veh_id, const std::string &text);

--- a/src/vehicle_func.h
+++ b/src/vehicle_func.h
@@ -53,7 +53,7 @@ void VehicleLengthChanged(const Vehicle *u);
 void ResetVehicleHash();
 void ResetVehicleColourMap();
 
-uint8_t GetBestFittingSubType(Vehicle *v_from, Vehicle *v_for, CargoID dest_cargo_type);
+uint8_t GetBestFittingSubType(Vehicle *v_from, Vehicle *v_for, CargoType dest_cargo_type);
 
 void ViewportAddVehicles(DrawPixelInfo *dpi);
 

--- a/src/vehicle_gui.h
+++ b/src/vehicle_gui.h
@@ -41,7 +41,7 @@ enum VehicleInvalidateWindowData {
 /** Extra information about refitted cargo and capacity */
 struct TestedEngineDetails {
 	Money cost;           ///< Refit cost
-	CargoID cargo;        ///< Cargo type
+	CargoType cargo;        ///< Cargo type
 	uint capacity;        ///< Cargo capacity
 	uint16_t mail_capacity; ///< Mail capacity if available
 	CargoArray all_capacities{}; ///< Capacities for all cargoes

--- a/src/vehicle_gui_base.h
+++ b/src/vehicle_gui_base.h
@@ -19,7 +19,7 @@
 #include "window_gui.h"
 #include "dropdown_type.h"
 
-typedef GUIList<const Vehicle*, std::nullptr_t, CargoID> GUIVehicleList;
+typedef GUIList<const Vehicle*, std::nullptr_t, CargoType> GUIVehicleList;
 
 struct GUIVehicleGroup {
 	VehicleList::const_iterator vehicles_begin;    ///< Pointer to beginning element of this vehicle group.
@@ -62,7 +62,7 @@ struct GUIVehicleGroup {
 	}
 };
 
-typedef GUIList<GUIVehicleGroup, std::nullptr_t, CargoID> GUIVehicleGroupList;
+typedef GUIList<GUIVehicleGroup, std::nullptr_t, CargoType> GUIVehicleGroupList;
 
 struct BaseVehicleListWindow : public Window {
 
@@ -81,7 +81,7 @@ struct BaseVehicleListWindow : public Window {
 	Scrollbar *vscroll;
 	VehicleListIdentifier vli;                  ///< Identifier of the vehicle list we want to currently show.
 	VehicleID vehicle_sel;                      ///< Selected vehicle
-	CargoID cargo_filter_criteria;              ///< Selected cargo filter index
+	CargoType cargo_filter_criteria;              ///< Selected cargo filter index
 	uint order_arrow_width;                     ///< Width of the arrow in the small order list.
 	CargoTypes used_cargoes;
 
@@ -119,7 +119,7 @@ struct BaseVehicleListWindow : public Window {
 	void SetCargoFilter(uint8_t index);
 	void SetCargoFilterArray();
 	void FilterVehicleList();
-	StringID GetCargoFilterLabel(CargoID cid) const;
+	StringID GetCargoFilterLabel(CargoType cargo_type) const;
 	DropDownList BuildCargoDropDownList(bool full) const;
 	Dimension GetActionDropdownSize(bool show_autoreplace, bool show_group, bool show_create);
 	DropDownList BuildActionDropdownList(bool show_autoreplace, bool show_group, bool show_create);
@@ -142,17 +142,17 @@ struct BaseVehicleListWindow : public Window {
 struct CargoIconOverlay {
 	int left;
 	int right;
-	CargoID cargo_type;
+	CargoType cargo_type;
 	uint cargo_cap;
 
-	constexpr CargoIconOverlay(int left, int right, CargoID cargo_type, uint cargo_cap)
+	constexpr CargoIconOverlay(int left, int right, CargoType cargo_type, uint cargo_cap)
 		: left(left), right(right), cargo_type(cargo_type), cargo_cap(cargo_cap)
 	{ }
 };
 
 bool ShowCargoIconOverlay();
 void AddCargoIconOverlay(std::vector<CargoIconOverlay> &overlays, int x, int width, const Vehicle *v);
-void DrawCargoIconOverlay(int x, int y, CargoID cid);
+void DrawCargoIconOverlay(int x, int y, CargoType cargo_type);
 void DrawCargoIconOverlays(std::span<const CargoIconOverlay> overlays, int y);
 
 uint GetVehicleListHeight(VehicleType type, uint divisor = 1);


### PR DESCRIPTION
## Motivation / Problem

https://github.com/OpenTTD/OpenTTD/pull/13352#issuecomment-2606468122

Generically we have `...Type` for the different variants of `...`, whereas `...ID` is used for the different instances. For example `IndustryType` describes the sort of industry (i.e. the specification), whereas `IndustryID` is the identifier of a unique instance.

What is now called `CargoID` is actually more a `Type` in that sense, so should be named appropriately.


## Description

Mostly mass renames such as:
* CargoID -> CargoType
* Cargo ID -> Cargo type
* cargo ID -> cargo type
* cargo_id -> cargo_type
* cid -> cargo_type (with lot of manual vetting)


## Limitations

Conflicts with #13352. Massive diff. Doing the renames separately does not appreciably reduce the diffs, because it's often both the type and parameter name on the same line so you'd just end up with seeing most blocks multiple times.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
