### PR TITLE
Codechange: Define GRFConfigList alias and pass by reference.

### DIFF
--- a/src/fios.h
+++ b/src/fios.h
@@ -42,7 +42,7 @@ struct LoadCheckData {
 
 	CompanyPropertiesMap companies;               ///< Company information.
 
-	GRFConfig *grfconfig;                         ///< NewGrf configuration from save.
+	GRFConfigList grfconfig;                      ///< NewGrf configuration from save.
 	GRFListCompatibility grf_compatibility;       ///< Summary state of NewGrfs, whether missing files or only compatible found.
 
 	Gamelog gamelog; ///< Gamelog actions

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -60,7 +60,7 @@ void LoadCheckData::Clear()
 
 	this->gamelog.Reset();
 
-	ClearGRFConfigList(&this->grfconfig);
+	ClearGRFConfigList(this->grfconfig);
 }
 
 /** Load game/scenario with optional content download */
@@ -697,7 +697,7 @@ public:
 
 			case WID_SL_NEWGRF_INFO:
 				if (_load_check_data.HasNewGrfs()) {
-					ShowNewGRFSettings(false, false, false, &_load_check_data.grfconfig);
+					ShowNewGRFSettings(false, false, false, _load_check_data.grfconfig);
 				}
 				break;
 

--- a/src/gamelog.h
+++ b/src/gamelog.h
@@ -76,13 +76,13 @@ public:
 	void Oldver();
 	void Setting(const std::string &name, int32_t oldval, int32_t newval);
 
-	void GRFUpdate(const GRFConfig *oldg, const GRFConfig *newg);
-	void GRFAddList(const GRFConfig *newg);
+	void GRFUpdate(const GRFConfigList &oldg, const GRFConfigList &newg);
+	void GRFAddList(const GRFConfigList &newg);
 	void GRFRemove(uint32_t grfid);
-	void GRFAdd(const GRFConfig *newg);
+	void GRFAdd(const GRFConfig &newg);
 	void GRFBug(uint32_t grfid, uint8_t bug, uint64_t data);
 	bool GRFBugReverse(uint32_t grfid, uint16_t internal_id);
-	void GRFCompatible(const GRFIdentifier *newg);
+	void GRFCompatible(const GRFIdentifier &newg);
 	void GRFMove(uint32_t grfid, int32_t offset);
 	void GRFParameters(uint32_t grfid);
 
@@ -90,7 +90,7 @@ public:
 	void TestMode();
 
 	void Info(uint32_t *last_ottd_rev, uint8_t *ever_modified, bool *removed_newgrfs);
-	const GRFIdentifier *GetOverriddenIdentifier(const GRFConfig *c);
+	const GRFIdentifier &GetOverriddenIdentifier(const GRFConfig &c);
 
 	/* Saveload handler for gamelog needs access to internal data. */
 	friend struct GLOGChunkHandler;

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -862,7 +862,7 @@ struct GenerateLandscapeWindow : public Window {
 				break;
 
 			case WID_GL_NEWGRF_BUTTON: ///< NewGRF Settings
-				ShowNewGRFSettings(true, true, false, &_grfconfig_newgame);
+				ShowNewGRFSettings(true, true, false, _grfconfig_newgame);
 				break;
 		}
 	}

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -362,7 +362,7 @@ struct SelectGameWindow : public Window {
 			case WID_SGI_HIGHSCORE:       ShowHighscoreTable(); break;
 			case WID_SGI_HELP:            ShowHelpWindow(); break;
 			case WID_SGI_SETTINGS_OPTIONS:ShowGameSettings(); break;
-			case WID_SGI_GRF_SETTINGS:    ShowNewGRFSettings(true, true, false, &_grfconfig_newgame); break;
+			case WID_SGI_GRF_SETTINGS:    ShowNewGRFSettings(true, true, false, _grfconfig_newgame); break;
 			case WID_SGI_CONTENT_DOWNLOAD:
 				if (!_network_available) {
 					ShowErrorMessage(STR_NETWORK_ERROR_NOTAVAILABLE, INVALID_STRING_ID, WL_ERROR);

--- a/src/network/core/network_game_info.h
+++ b/src/network/core/network_game_info.h
@@ -94,7 +94,7 @@ enum NewGRFSerializationType {
  * The game information that is sent from the server to the client.
  */
 struct NetworkServerGameInfo {
-	GRFConfig *grfconfig;        ///< List of NewGRF files used
+	GRFConfigList grfconfig; ///< List of NewGRF files used
 	TimerGameCalendar::Date calendar_start; ///< When the game started.
 	TimerGameCalendar::Date calendar_date; ///< Current calendar date.
 	TimerGameTick::TickCounter ticks_playing; ///< Amount of ticks the game has been running unpaused.

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -696,7 +696,7 @@ NetworkGameList *NetworkAddServer(const std::string &connection_string, bool man
 	/* Ensure the item already exists in the list */
 	NetworkGameList *item = NetworkGameListAddItem(connection_string);
 	if (item->info.server_name.empty()) {
-		ClearGRFConfigList(&item->info.grfconfig);
+		ClearGRFConfigList(item->info.grfconfig);
 		item->info.server_name = connection_string;
 
 		UpdateNetworkGameWindow();

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -153,6 +153,6 @@ extern ClientNetworkContentSocketHandler _network_content_client;
 
 void ShowNetworkContentListWindow(ContentVector *cv = nullptr, ContentType type1 = CONTENT_TYPE_END, ContentType type2 = CONTENT_TYPE_END);
 
-void ShowMissingContentWindow(const struct GRFConfig *list);
+void ShowMissingContentWindow(const GRFConfigList &list);
 
 #endif /* NETWORK_CONTENT_H */

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -251,7 +251,7 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_LISTING(Packet &p)
 		NetworkGameList *item = NetworkGameListAddItem(connection_string);
 
 		/* Clear any existing GRFConfig chain. */
-		ClearGRFConfigList(&item->info.grfconfig);
+		ClearGRFConfigList(item->info.grfconfig);
 		/* Copy the new NetworkGameInfo info. */
 		item->info = ngi;
 		/* Check for compatability with the client. */

--- a/src/network/network_gamelist.cpp
+++ b/src/network/network_gamelist.cpp
@@ -73,7 +73,7 @@ void NetworkGameListRemoveItem(NetworkGameList *remove)
 			}
 
 			/* Remove GRFConfig information */
-			ClearGRFConfigList(&remove->info.grfconfig);
+			ClearGRFConfigList(remove->info.grfconfig);
 			delete remove;
 
 			NetworkRebuildHostList();
@@ -100,7 +100,7 @@ void NetworkGameListRemoveExpired()
 			*prev_item = item;
 
 			/* Remove GRFConfig information */
-			ClearGRFConfigList(&remove->info.grfconfig);
+			ClearGRFConfigList(remove->info.grfconfig);
 			delete remove;
 		} else {
 			prev_item = &item->next;

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -773,7 +773,7 @@ public:
 				break;
 
 			case WID_NG_NEWGRF: // NewGRF Settings
-				if (this->server != nullptr) ShowNewGRFSettings(false, false, false, &this->server->info.grfconfig);
+				if (this->server != nullptr) ShowNewGRFSettings(false, false, false, this->server->info.grfconfig);
 				break;
 
 			case WID_NG_NEWGRF_MISSING: // Find missing content online

--- a/src/network/network_query.cpp
+++ b/src/network/network_query.cpp
@@ -120,7 +120,7 @@ NetworkRecvStatus QueryNetworkGameSocketHandler::Receive_SERVER_GAME_INFO(Packet
 	NetworkGameList *item = NetworkGameListAddItem(this->connection_string);
 
 	/* Clear any existing GRFConfig chain. */
-	ClearGRFConfigList(&item->info.grfconfig);
+	ClearGRFConfigList(item->info.grfconfig);
 	/* Retrieve the NetworkGameInfo from the packet. */
 	DeserializeNetworkGameInfo(p, item->info);
 	/* Check for compatability with the client. */

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -199,6 +199,8 @@ struct GRFConfig {
 	void FinalizeParameterInfo();
 };
 
+using GRFConfigList = GRFConfig *;
+
 /** Method to find GRFs using FindGRFConfig */
 enum FindGRFConfigMode {
 	FGCM_EXACT,       ///< Only find Grfs matching md5sum
@@ -208,10 +210,10 @@ enum FindGRFConfigMode {
 	FGCM_ANY,         ///< Use first found
 };
 
-extern GRFConfig *_all_grfs;          ///< First item in list of all scanned NewGRFs
-extern GRFConfig *_grfconfig;         ///< First item in list of current GRF set up
-extern GRFConfig *_grfconfig_newgame; ///< First item in list of default GRF set up
-extern GRFConfig *_grfconfig_static;  ///< First item in list of static GRF set up
+extern GRFConfigList _all_grfs;          ///< First item in list of all scanned NewGRFs
+extern GRFConfigList _grfconfig;         ///< First item in list of current GRF set up
+extern GRFConfigList _grfconfig_newgame; ///< First item in list of default GRF set up
+extern GRFConfigList _grfconfig_static;  ///< First item in list of static GRF set up
 extern uint _missing_extra_graphics;  ///< Number of sprites provided by the fallback extra GRF, i.e. missing in the baseset.
 
 /** Callback for NewGRF scanning. */
@@ -227,17 +229,17 @@ size_t GRFGetSizeOfDataSection(FileHandle &f);
 void ScanNewGRFFiles(NewGRFScanCallback *callback);
 const GRFConfig *FindGRFConfig(uint32_t grfid, FindGRFConfigMode mode, const MD5Hash *md5sum = nullptr, uint32_t desired_version = 0);
 GRFConfig *GetGRFConfig(uint32_t grfid, uint32_t mask = 0xFFFFFFFF);
-GRFConfig **CopyGRFConfigList(GRFConfig **dst, const GRFConfig *src, bool init_only);
-void AppendStaticGRFConfigs(GRFConfig **dst);
-void AppendToGRFConfigList(GRFConfig **dst, GRFConfig *el);
-void ClearGRFConfigList(GRFConfig **config);
+void CopyGRFConfigList(GRFConfigList &dst, const GRFConfigList &src, bool init_only);
+void AppendStaticGRFConfigs(GRFConfigList &dst);
+void AppendToGRFConfigList(GRFConfigList &dst, GRFConfig *el);
+void ClearGRFConfigList(GRFConfigList &config);
 void ResetGRFConfig(bool defaults);
-GRFListCompatibility IsGoodGRFConfigList(GRFConfig *grfconfig);
+GRFListCompatibility IsGoodGRFConfigList(GRFConfigList &grfconfig);
 bool FillGRFDetails(GRFConfig *config, bool is_static, Subdirectory subdir = NEWGRF_DIR);
 std::string GRFBuildParamList(const GRFConfig *c);
 
 /* In newgrf_gui.cpp */
-void ShowNewGRFSettings(bool editable, bool show_params, bool exec_changes, GRFConfig **config);
+void ShowNewGRFSettings(bool editable, bool show_params, bool exec_changes, GRFConfigList &config);
 void OpenGRFParameterWindow(bool is_baseset, GRFConfig *c, bool editable);
 
 void UpdateNewGRFScanStatus(uint num, const char *name);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -389,9 +389,9 @@ static void CDECL HandleSavegameLoadCrash(int signum)
 
 		for (const GRFConfig *c = _grfconfig; c != nullptr; c = c->next) {
 			if (HasBit(c->flags, GCF_COMPATIBLE)) {
-				const GRFIdentifier *replaced = _gamelog.GetOverriddenIdentifier(c);
+				const GRFIdentifier &replaced = _gamelog.GetOverriddenIdentifier(*c);
 				fmt::format_to(std::back_inserter(message), "NewGRF {:08X} (checksum {}) not found.\n  Loaded NewGRF \"{}\" (checksum {}) with same GRF ID instead.\n",
-						BSWAP32(c->ident.grfid), FormatArrayAsHex(c->original_md5sum), c->filename, FormatArrayAsHex(replaced->md5sum));
+						BSWAP32(c->ident.grfid), FormatArrayAsHex(c->original_md5sum), c->filename, FormatArrayAsHex(replaced.md5sum));
 			}
 			if (c->status == GCS_NOT_FOUND) {
 				fmt::format_to(std::back_inserter(message), "NewGRF {:08X} ({}) not found; checksum {}.\n",
@@ -711,7 +711,7 @@ bool AfterLoadGame()
 		if (c->status == GCS_NOT_FOUND) {
 			_gamelog.GRFRemove(c->ident.grfid);
 		} else if (HasBit(c->flags, GCF_COMPATIBLE)) {
-			_gamelog.GRFCompatible(&c->ident);
+			_gamelog.GRFCompatible(c->ident);
 		}
 	}
 

--- a/src/saveload/newgrf_sl.cpp
+++ b/src/saveload/newgrf_sl.cpp
@@ -106,17 +106,17 @@ struct NGRFChunkHandler : ChunkHandler {
 		config.param.assign(std::begin(param), last);
 	}
 
-	void LoadCommon(GRFConfig *&grfconfig) const
+	void LoadCommon(GRFConfigList &grfconfig) const
 	{
 		const std::vector<SaveLoad> slt = SlCompatTableHeader(description, _grfconfig_sl_compat);
 
-		ClearGRFConfigList(&grfconfig);
+		ClearGRFConfigList(grfconfig);
 		while (SlIterateArray() != -1) {
 			GRFConfig *c = new GRFConfig();
 			SlObject(c, slt);
 			if (IsSavegameVersionBefore(SLV_101)) c->SetSuitablePalette();
 			this->LoadParameters(*c);
-			AppendToGRFConfigList(&grfconfig, c);
+			AppendToGRFConfigList(grfconfig, c);
 		}
 	}
 
@@ -132,7 +132,7 @@ struct NGRFChunkHandler : ChunkHandler {
 			ResetGRFConfig(false);
 		} else {
 			/* Append static NewGRF configuration */
-			AppendStaticGRFConfigs(&_grfconfig);
+			AppendStaticGRFConfigs(_grfconfig);
 		}
 	}
 

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -1554,7 +1554,7 @@ static bool LoadTTDPatchExtraChunks(LoadgameState *ls, int)
 				/* Skip the first element: TTDP hack for the Action D special variables (FFFF0000 01) */
 				ReadUint32(ls); ReadByte(ls); len -= 5;
 
-				ClearGRFConfigList(&_grfconfig);
+				ClearGRFConfigList(_grfconfig);
 				while (len != 0) {
 					uint32_t grfid = ReadUint32(ls);
 
@@ -1562,14 +1562,14 @@ static bool LoadTTDPatchExtraChunks(LoadgameState *ls, int)
 						GRFConfig *c = new GRFConfig("TTDP game, no information");
 						c->ident.grfid = grfid;
 
-						AppendToGRFConfigList(&_grfconfig, c);
+						AppendToGRFConfigList(_grfconfig, c);
 						Debug(oldloader, 3, "TTDPatch game using GRF file with GRFID {:08X}", BSWAP32(c->ident.grfid));
 					}
 					len -= 5;
 				}
 
 				/* Append static NewGRF configuration */
-				AppendStaticGRFConfigs(&_grfconfig);
+				AppendStaticGRFConfigs(_grfconfig);
 				break;
 			}
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -3063,7 +3063,7 @@ static SaveOrLoadResult DoLoad(std::shared_ptr<LoadFilter> reader, bool load_che
 			 * Note: this is done here because AfterLoadGame is also called
 			 * for TTO/TTD/TTDP savegames which have their own NewGRF logic.
 			 */
-			ClearGRFConfigList(&_grfconfig);
+			ClearGRFConfigList(_grfconfig);
 		}
 	}
 
@@ -3146,7 +3146,7 @@ SaveOrLoadResult SaveOrLoad(const std::string &filename, SaveLoadOperation fop, 
 			 * and if so a new NewGRF list will be made in LoadOldSaveGame.
 			 * Note: this is done here because AfterLoadGame is also called
 			 * for OTTD savegames which have their own NewGRF logic. */
-			ClearGRFConfigList(&_grfconfig);
+			ClearGRFConfigList(_grfconfig);
 			_gamelog.Reset();
 			if (!LoadOldSaveGame(filename)) return SL_REINIT;
 			_sl_version = SL_MIN_VERSION;

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -320,7 +320,7 @@ static CallBackFunction MenuClickSettings(int index)
 		case OME_SETTINGS:             ShowGameSettings();                              return CBF_NONE;
 		case OME_AI_SETTINGS:          ShowAIConfigWindow();                            return CBF_NONE;
 		case OME_GAMESCRIPT_SETTINGS:  ShowGSConfigWindow();                            return CBF_NONE;
-		case OME_NEWGRFSETTINGS:       ShowNewGRFSettings(!_networking && _settings_client.gui.UserIsAllowedToChangeNewGRFs(), true, true, &_grfconfig); return CBF_NONE;
+		case OME_NEWGRFSETTINGS:       ShowNewGRFSettings(!_networking && _settings_client.gui.UserIsAllowedToChangeNewGRFs(), true, true, _grfconfig); return CBF_NONE;
 		case OME_SANDBOX:              ShowCheatWindow();                               break;
 		case OME_TRANSPARENCIES:       ShowTransparencyToolbar();                       break;
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

GRFConfigs are (currently) held as a linked list.

This means that a list of GRF configs is passed as ` GRFConfig *`, and a single GRF config is passed as `GRFConfig *`.

This, obviously, can lead to confusion. Additionally some functions accept a `GRFConfig **`, which is always fun.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add an `GRFConfigList` as an alias of `GRFConfig *` and use it (with references instead of pointers) where lists are required.

This adds the distinction between a single GRFConfig and a GRFConfig list, and simplifies how GRFConfig lists are passed to various functions.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
