### PR TITLE
Codechange: use std::string as backing for textbuf

### DIFF
--- a/src/string_func.h
+++ b/src/string_func.h
@@ -76,9 +76,11 @@ inline size_t ttd_strnlen(const char *str, size_t maxlen)
 bool IsValidChar(char32_t key, CharSetFilter afilter);
 
 size_t Utf8Decode(char32_t *c, const char *s);
+inline size_t Utf8Decode(char32_t *c, std::string::iterator &s) { return Utf8Decode(c, &*s); }
 size_t Utf8Encode(char *buf, char32_t c);
 size_t Utf8Encode(std::ostreambuf_iterator<char> &buf, char32_t c);
 size_t Utf8Encode(std::back_insert_iterator<std::string> &buf, char32_t c);
+inline size_t Utf8Encode(std::string::iterator &s, char32_t c) { return Utf8Encode(&*s, c); }
 size_t Utf8TrimString(char *s, size_t maxlen);
 
 
@@ -158,6 +160,13 @@ inline const char *Utf8PrevChar(const char *s)
 	const char *ret = s;
 	while (IsUtf8Part(*--ret)) {}
 	return ret;
+}
+
+inline std::string::iterator Utf8PrevChar(std::string::iterator &s)
+{
+	auto *cur = &*s;
+	auto *prev = Utf8PrevChar(cur);
+	return s - (cur - prev);
 }
 
 size_t Utf8StringLength(const char *s);

--- a/src/textbuf_type.h
+++ b/src/textbuf_type.h
@@ -31,7 +31,6 @@ struct Textbuf {
 	CharSetFilter afilter;    ///< Allowed characters
 	uint16_t max_bytes;         ///< the maximum size of the buffer in bytes (including terminating '\0')
 	uint16_t max_chars;         ///< the maximum size of the buffer in characters (including terminating '\0')
-	uint16_t bytes;             ///< the current size of the string in bytes (including terminating '\0')
 	uint16_t chars;             ///< the current size of the string in characters (including terminating '\0')
 	uint16_t pixels;            ///< the current size of the string in pixels
 	bool caret;               ///< is the caret ("_") visible or not
@@ -43,7 +42,6 @@ struct Textbuf {
 	uint16_t marklength;        ///< the length of the marked area in pixels
 
 	explicit Textbuf(uint16_t max_bytes, uint16_t max_chars = UINT16_MAX);
-	~Textbuf();
 
 	void Assign(const std::string_view text);
 
@@ -66,7 +64,7 @@ struct Textbuf {
 	const char *GetText() const;
 
 private:
-	char * const buf; ///< buffer in which text is saved
+	std::string buf; ///< buffer in which text is saved
 	std::unique_ptr<StringIterator> char_iter;
 
 	bool CanDelChar(bool backspace);


### PR DESCRIPTION
## Motivation / Problem

`Textbuf` uses a manually managed C-style string buffer.


## Description

Primarily replace the `MallocT`-ed buffer with `std::string`, but given the modifications to the text being done in `Textbuf` it's involved.
* removing the `MallocT` also means removing the destructor with `free`.
* `std::string` has a `size()`, so we do not need to account for that ourselves, but the old one included the `\0` whereas the new one doesn't.
* `UpdateSize` is using `Utf8StringLength` now, instead of its own implementation.
* In `Assign` the trimming to number of characters is rewritten to make it simpler and faster; it now iterates through the characters like `Utf8StringLength` does, but stops at the moment the limit is reached. That way we have a reference to the first from where we need to chop of, instead of `while (Utf8StringLength(x) > limit) removeOneUtf8CharFromBack(x));`.


## Limitations

Not been able to test it on MacOS.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
