### PR TITLE
Fix b1ab1b9f06: [Script] Don't use AI types for GS compat scripts

### DIFF
--- a/bin/game/compat_1.10.nut
+++ b/bin/game/compat_1.10.nut
@@ -28,4 +28,4 @@ GSRoad.HasRoadType <- function(tile, road_type)
 }
 
 /* 15 renames GetBridgeID */
-AIBridge.GetBridgeID <- AIBridge.GetBridgeType;
+GSBridge.GetBridgeID <- GSBridge.GetBridgeType;

--- a/bin/game/compat_1.11.nut
+++ b/bin/game/compat_1.11.nut
@@ -21,4 +21,4 @@ GSRoad.HasRoadType <- function(tile, road_type)
 }
 
 /* 15 renames GetBridgeID */
-AIBridge.GetBridgeID <- AIBridge.GetBridgeType;
+GSBridge.GetBridgeID <- GSBridge.GetBridgeType;

--- a/bin/game/compat_1.2.nut
+++ b/bin/game/compat_1.2.nut
@@ -50,4 +50,4 @@ GSRoad.HasRoadType <- function(tile, road_type)
 }
 
 /* 15 renames GetBridgeID */
-AIBridge.GetBridgeID <- AIBridge.GetBridgeType;
+GSBridge.GetBridgeID <- GSBridge.GetBridgeType;

--- a/bin/game/compat_1.3.nut
+++ b/bin/game/compat_1.3.nut
@@ -50,4 +50,4 @@ GSRoad.HasRoadType <- function(tile, road_type)
 }
 
 /* 15 renames GetBridgeID */
-AIBridge.GetBridgeID <- AIBridge.GetBridgeType;
+GSBridge.GetBridgeID <- GSBridge.GetBridgeType;

--- a/bin/game/compat_1.4.nut
+++ b/bin/game/compat_1.4.nut
@@ -42,4 +42,4 @@ GSRoad.HasRoadType <- function(tile, road_type)
 }
 
 /* 15 renames GetBridgeID */
-AIBridge.GetBridgeID <- AIBridge.GetBridgeType;
+GSBridge.GetBridgeID <- GSBridge.GetBridgeType;

--- a/bin/game/compat_1.5.nut
+++ b/bin/game/compat_1.5.nut
@@ -35,4 +35,4 @@ GSRoad.HasRoadType <- function(tile, road_type)
 }
 
 /* 15 renames GetBridgeID */
-AIBridge.GetBridgeID <- AIBridge.GetBridgeType;
+GSBridge.GetBridgeID <- GSBridge.GetBridgeType;

--- a/bin/game/compat_1.6.nut
+++ b/bin/game/compat_1.6.nut
@@ -35,4 +35,4 @@ GSRoad.HasRoadType <- function(tile, road_type)
 }
 
 /* 15 renames GetBridgeID */
-AIBridge.GetBridgeID <- AIBridge.GetBridgeType;
+GSBridge.GetBridgeID <- GSBridge.GetBridgeType;

--- a/bin/game/compat_1.7.nut
+++ b/bin/game/compat_1.7.nut
@@ -35,4 +35,4 @@ GSRoad.HasRoadType <- function(tile, road_type)
 }
 
 /* 15 renames GetBridgeID */
-AIBridge.GetBridgeID <- AIBridge.GetBridgeType;
+GSBridge.GetBridgeID <- GSBridge.GetBridgeType;

--- a/bin/game/compat_1.8.nut
+++ b/bin/game/compat_1.8.nut
@@ -35,4 +35,4 @@ GSRoad.HasRoadType <- function(tile, road_type)
 }
 
 /* 15 renames GetBridgeID */
-AIBridge.GetBridgeID <- AIBridge.GetBridgeType;
+GSBridge.GetBridgeID <- GSBridge.GetBridgeType;

--- a/bin/game/compat_1.9.nut
+++ b/bin/game/compat_1.9.nut
@@ -28,4 +28,4 @@ GSRoad.HasRoadType <- function(tile, road_type)
 }
 
 /* 15 renames GetBridgeID */
-AIBridge.GetBridgeID <- AIBridge.GetBridgeType;
+GSBridge.GetBridgeID <- GSBridge.GetBridgeType;

--- a/bin/game/compat_12.nut
+++ b/bin/game/compat_12.nut
@@ -21,4 +21,4 @@ GSRoad.HasRoadType <- function(tile, road_type)
 }
 
 /* 15 renames GetBridgeID */
-AIBridge.GetBridgeID <- AIBridge.GetBridgeType;
+GSBridge.GetBridgeID <- GSBridge.GetBridgeType;

--- a/bin/game/compat_13.nut
+++ b/bin/game/compat_13.nut
@@ -8,4 +8,4 @@
 GSLog.Info("13 API compatibility in effect.");
 
 /* 15 renames GetBridgeID */
-AIBridge.GetBridgeID <- AIBridge.GetBridgeType;
+GSBridge.GetBridgeID <- GSBridge.GetBridgeType;

--- a/bin/game/compat_14.nut
+++ b/bin/game/compat_14.nut
@@ -8,4 +8,4 @@
 GSLog.Info("14 API compatibility in effect.");
 
 /* 15 renames GetBridgeID */
-AIBridge.GetBridgeID <- AIBridge.GetBridgeType;
+GSBridge.GetBridgeID <- GSBridge.GetBridgeType;


### PR DESCRIPTION
## Motivation / Problem

![image](https://github.com/user-attachments/assets/1ce7cba5-e5d4-4a8c-926c-3adb13aabb8d)

Using `AIBridge` in game script compat scripts.


## Description

Use the right type.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
