### PR TITLE
Codechange: do not use MallocT for newgrf commons

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -818,7 +818,7 @@ static void ReadSpriteLayoutRegisters(ByteReader &buf, TileLayoutFlags flags, bo
 {
 	if (!(flags & TLF_DRAWING_FLAGS)) return;
 
-	if (dts->registers == nullptr) dts->AllocateRegisters();
+	if (dts->registers.empty()) dts->AllocateRegisters();
 	TileLayoutRegisters &regs = const_cast<TileLayoutRegisters&>(dts->registers[index]);
 	regs.flags = flags & TLF_DRAWING_FLAGS;
 
@@ -943,9 +943,9 @@ static bool ReadSpriteLayout(ByteReader &buf, uint num_building_sprites, bool us
 	/* When the Action1 sets are unknown, everything should be 0 (no spriteset usage) or UINT16_MAX (some spriteset usage) */
 	assert(use_cur_spritesets || (is_consistent && (dts->consistent_max_offset == 0 || dts->consistent_max_offset == UINT16_MAX)));
 
-	if (!is_consistent || dts->registers != nullptr) {
+	if (!is_consistent || !dts->registers.empty()) {
 		dts->consistent_max_offset = 0;
-		if (dts->registers == nullptr) dts->AllocateRegisters();
+		if (dts->registers.empty()) dts->AllocateRegisters();
 
 		for (uint i = 0; i < num_building_sprites + 1; i++) {
 			TileLayoutRegisters &regs = const_cast<TileLayoutRegisters&>(dts->registers[i]);

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -2000,7 +2000,9 @@ static ChangeInfoResult StationChangeInfo(uint first, uint last, int prop, ByteR
 					if (buf.HasData(4) && buf.PeekDWord() == 0) {
 						buf.Skip(4);
 						extern const DrawTileSpriteSpan _station_display_datas_rail[8];
-						dts->Clone(&_station_display_datas_rail[t % 8]);
+						const DrawTileSpriteSpan &dtss = _station_display_datas_rail[t % 8];
+						dts->ground = dtss.ground;
+						dts->seq.insert(dts->seq.end(), dtss.GetSequence().begin(), dtss.GetSequence().end());
 						continue;
 					}
 
@@ -2050,8 +2052,7 @@ static ChangeInfoResult StationChangeInfo(uint first, uint last, int prop, ByteR
 				statspec->renderdata.reserve(srcstatspec->renderdata.size());
 
 				for (const auto &it : srcstatspec->renderdata) {
-					NewGRFSpriteLayout *dts = &statspec->renderdata.emplace_back();
-					dts->Clone(&it);
+					statspec->renderdata.emplace_back(it);
 				}
 				break;
 			}

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -566,16 +566,6 @@ bool Convert8bitBooleanCallback(const GRFFile *grffile, uint16_t cbid, uint16_t 
 
 /* static */ std::vector<DrawTileSeqStruct> NewGRFSpriteLayout::result_seq;
 
-/**
- * Clone a spritelayout.
- * @param source The spritelayout to copy.
- */
-void NewGRFSpriteLayout::Clone(const NewGRFSpriteLayout *source)
-{
-	this->Clone((const DrawTileSprites*)source);
-	this->registers = source->registers;
-}
-
 
 /**
  * Allocate a spritelayout for \a num_sprites building sprites.

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -573,14 +573,7 @@ bool Convert8bitBooleanCallback(const GRFFile *grffile, uint16_t cbid, uint16_t 
 void NewGRFSpriteLayout::Clone(const NewGRFSpriteLayout *source)
 {
 	this->Clone((const DrawTileSprites*)source);
-
-	if (source->registers != nullptr) {
-		size_t count = 1 + source->seq.size(); // 1 for the ground sprite
-
-		TileLayoutRegisters *regs = MallocT<TileLayoutRegisters>(count);
-		MemCpyT(regs, source->registers, count);
-		this->registers = regs;
-	}
+	this->registers = source->registers;
 }
 
 
@@ -601,10 +594,9 @@ void NewGRFSpriteLayout::Allocate(uint num_sprites)
 void NewGRFSpriteLayout::AllocateRegisters()
 {
 	assert(!this->seq.empty());
-	assert(this->registers == nullptr);
+	assert(this->registers.empty());
 
-	size_t count = 1 + this->seq.size(); // 1 for the ground sprite
-	this->registers = CallocT<TileLayoutRegisters>(count);
+	this->registers.resize(1 + this->seq.size(), {}); // 1 for the ground sprite
 }
 
 /**
@@ -635,7 +627,7 @@ uint32_t NewGRFSpriteLayout::PrepareLayout(uint32_t orig_offset, uint32_t newgrf
 	}
 	/* Determine the var10 values the action-1-2-3 chains needs to be resolved for,
 	 * and apply the default sprite offsets (unless disabled). */
-	const TileLayoutRegisters *regs = this->registers;
+	const TileLayoutRegisters *regs = this->registers.empty() ? nullptr : this->registers.data();
 	bool ground = true;
 	for (DrawTileSeqStruct result : result_seq) {
 		TileLayoutFlags flags = TLF_NOTHING;
@@ -688,7 +680,7 @@ uint32_t NewGRFSpriteLayout::PrepareLayout(uint32_t orig_offset, uint32_t newgrf
  */
 void NewGRFSpriteLayout::ProcessRegisters(uint8_t resolved_var10, uint32_t resolved_sprite, bool separate_ground) const
 {
-	const TileLayoutRegisters *regs = this->registers;
+	const TileLayoutRegisters *regs = this->registers.empty() ? nullptr : this->registers.data();
 	bool ground = true;
 	for (DrawTileSeqStruct &result : result_seq) {
 		TileLayoutFlags flags = TLF_NOTHING;

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -109,9 +109,9 @@ static const uint TLR_MAX_VAR10 = 7; ///< Maximum value for var 10.
  * In contrast to #DrawTileSprites this struct is for allocated
  * layouts on the heap. It allocates data and frees them on destruction.
  */
-struct NewGRFSpriteLayout : ZeroedMemoryAllocator, DrawTileSprites {
-	std::vector<DrawTileSeqStruct> seq;
-	std::vector<TileLayoutRegisters> registers;
+struct NewGRFSpriteLayout : DrawTileSprites {
+	std::vector<DrawTileSeqStruct> seq{};
+	std::vector<TileLayoutRegisters> registers{};
 
 	/**
 	 * Number of sprites in all referenced spritesets.

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -111,7 +111,7 @@ static const uint TLR_MAX_VAR10 = 7; ///< Maximum value for var 10.
  */
 struct NewGRFSpriteLayout : ZeroedMemoryAllocator, DrawTileSprites {
 	std::vector<DrawTileSeqStruct> seq;
-	const TileLayoutRegisters *registers;
+	std::vector<TileLayoutRegisters> registers;
 
 	/**
 	 * Number of sprites in all referenced spritesets.
@@ -137,11 +137,6 @@ struct NewGRFSpriteLayout : ZeroedMemoryAllocator, DrawTileSprites {
 		this->seq.insert(this->seq.end(), source_sequence.begin(), source_sequence.end());
 	}
 
-	virtual ~NewGRFSpriteLayout()
-	{
-		free(this->registers);
-	}
-
 	/**
 	 * Tests whether this spritelayout needs preprocessing by
 	 * #PrepareLayout() and #ProcessRegisters(), or whether it can be
@@ -150,7 +145,7 @@ struct NewGRFSpriteLayout : ZeroedMemoryAllocator, DrawTileSprites {
 	 */
 	bool NeedsPreprocessing() const
 	{
-		return this->registers != nullptr;
+		return !this->registers.empty();
 	}
 
 	uint32_t PrepareLayout(uint32_t orig_offset, uint32_t newgrf_ground_offset, uint32_t newgrf_offset, uint constr_stage, bool separate_ground) const;

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -121,21 +121,6 @@ struct NewGRFSpriteLayout : ZeroedMemoryAllocator, DrawTileSprites {
 
 	void Allocate(uint num_sprites);
 	void AllocateRegisters();
-	void Clone(const NewGRFSpriteLayout *source);
-
-	/**
-	 * Clone a spritelayout.
-	 * @param source The spritelayout to copy.
-	 */
-	void Clone(const DrawTileSprites *source)
-	{
-		assert(source != nullptr && this != source);
-
-		auto source_sequence = source->GetSequence();
-		assert(this->seq.empty() && !source_sequence.empty());
-		this->ground = source->ground;
-		this->seq.insert(this->seq.end(), source_sequence.begin(), source_sequence.end());
-	}
 
 	/**
 	 * Tests whether this spritelayout needs preprocessing by

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -44,7 +44,7 @@ struct DrawTileSeqStruct {
  * For allocated ones from NewGRF see #NewGRFSpriteLayout.
  */
 struct DrawTileSprites {
-	PalSpriteID ground; ///< Palette and sprite for the ground
+	PalSpriteID ground{}; ///< Palette and sprite for the ground
 
 	DrawTileSprites(PalSpriteID ground) : ground(ground) {}
 	DrawTileSprites() = default;


### PR DESCRIPTION
## Motivation / Problem

Use C++ memory management over C-style memory management, i.e. `MallocT` + `free`.

In this case in newgrf_commons's `NewGRFSpriteLayout` and everything that depends on it.


## Description

* Use `std::vector` for `NewGRFSpriteLayout`'s list of sprites and registers.
* By using `std::vector` / `std::span` there is no need any more for the `terminator` objects at the end of each sprite list.
* Remove `Clone(x)` as it's weird to 'clone' something into an object that already exists. In that case it should be called `CopyTo(x)` or something, or `Clone()` should return the new cloned object. In this case `Clone` used to be complicated due to the  C-style memory management, but now the default copy constructor/assignment operator does the right thing.

## Limitations

Quite big, so I'll split it up in several PRs. So this is primarily to show where those PRs are heading.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
