### PR TITLE
Codechange: remove ZeroedMemoryAllocator from NetworkGameSocketHandlers

### DIFF
--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -141,7 +141,7 @@ using CommandQueue = std::vector<CommandPacket>;
 class NetworkGameSocketHandler : public NetworkTCPSocketHandler {
 /* TODO: rewrite into a proper class */
 private:
-	NetworkClientInfo *info;          ///< Client info related to this socket
+	NetworkClientInfo *info = nullptr; ///< Client info related to this socket
 	bool is_pending_deletion = false; ///< Whether this socket is pending deletion
 
 protected:
@@ -483,9 +483,9 @@ protected:
 
 	NetworkGameSocketHandler(SOCKET s);
 public:
-	ClientID client_id;          ///< Client identifier
-	uint32_t last_frame;           ///< Last frame we have executed
-	uint32_t last_frame_server;    ///< Last frame the server has executed
+	ClientID client_id = INVALID_CLIENT_ID; ///< Client identifier
+	uint32_t last_frame = 0; ///< Last frame we have executed
+	uint32_t last_frame_server = 0; ///< Last frame the server has executed
 	CommandQueue incoming_queue; ///< The command-queue awaiting handling
 	std::chrono::steady_clock::time_point last_packet; ///< Time we received the last frame.
 

--- a/src/network/network_client.h
+++ b/src/network/network_client.h
@@ -13,12 +13,12 @@
 #include "network_internal.h"
 
 /** Class for handling the client side of the game connection. */
-class ClientNetworkGameSocketHandler : public ZeroedMemoryAllocator, public NetworkGameSocketHandler {
+class ClientNetworkGameSocketHandler : public NetworkGameSocketHandler {
 private:
 	std::unique_ptr<class NetworkAuthenticationClientHandler> authentication_handler; ///< The handler for the authentication.
 	std::string connection_string; ///< Address we are connected to.
 	std::shared_ptr<struct PacketReader> savegame; ///< Packet reader for reading the savegame.
-	uint8_t token;                    ///< The token we need to send back to the server to prove we're the right client.
+	uint8_t token = 0; ///< The token we need to send back to the server to prove we're the right client.
 
 	/** Status of the connection with the server. */
 	enum ServerStatus {

--- a/src/network/network_query.h
+++ b/src/network/network_query.h
@@ -13,7 +13,7 @@
 #include "network_internal.h"
 
 /** Class for handling the client side of quering a game server. */
-class QueryNetworkGameSocketHandler : public ZeroedMemoryAllocator, public NetworkGameSocketHandler {
+class QueryNetworkGameSocketHandler : public NetworkGameSocketHandler {
 private:
 	static std::vector<std::unique_ptr<QueryNetworkGameSocketHandler>> queries; ///< Pending queries.
 	std::string connection_string; ///< Address we are connected to.


### PR DESCRIPTION
## Motivation / Problem

`ZeroedMemoryAllocator` is and always has been a hack. Just properly initialize the values.


## Description

Remove usage of `ZeroedMemoryAllocator` and set a default value to some integers.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
