### PR TITLE
Codechange: Remove ZeroedMemoryAllocator from WindowDesc

### DIFF
--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -1150,20 +1150,32 @@ public:
 
 };
 
-
-static WindowDesc _other_group_desc(
-	WDP_AUTO, "list_groups", 460, 246,
-	WC_INVALID, WC_NONE,
-	0,
-	_nested_group_widgets
-);
-
-static WindowDesc _train_group_desc(
-	WDP_AUTO, "list_groups_train", 525, 246,
-	WC_TRAINS_LIST, WC_NONE,
-	0,
-	_nested_group_widgets
-);
+static WindowDesc _vehicle_group_desc[] = {
+	{
+		WDP_AUTO, "list_groups_train", 525, 246,
+		WC_TRAINS_LIST, WC_NONE,
+		0,
+		_nested_group_widgets
+	},
+	{
+		WDP_AUTO, "list_groups_roadveh", 460, 246,
+		WC_ROADVEH_LIST, WC_NONE,
+		0,
+		_nested_group_widgets
+	},
+	{
+		WDP_AUTO, "list_groups_ship", 460, 246,
+		WC_SHIPS_LIST, WC_NONE,
+		0,
+		_nested_group_widgets
+	},
+	{
+		WDP_AUTO, "list_groups_aircraft", 460, 246,
+		WC_AIRCRAFT_LIST, WC_NONE,
+		0,
+		_nested_group_widgets
+	},
+};
 
 /**
  * Show the group window for the given company and vehicle type.
@@ -1176,14 +1188,9 @@ void ShowCompanyGroup(CompanyID company, VehicleType vehicle_type, GroupID group
 {
 	if (!Company::IsValidID(company)) return;
 
+	assert(vehicle_type < std::size(_vehicle_group_desc));
 	const WindowNumber num = VehicleListIdentifier(VL_GROUP_LIST, vehicle_type, company).Pack();
-	VehicleGroupWindow *w;
-	if (vehicle_type == VEH_TRAIN) {
-		w = AllocateWindowDescFront<VehicleGroupWindow>(_train_group_desc, num, need_existing_window);
-	} else {
-		_other_group_desc.cls = GetWindowClassForVehicleType(vehicle_type);
-		w = AllocateWindowDescFront<VehicleGroupWindow>(_other_group_desc, num, need_existing_window);
-	}
+	VehicleGroupWindow *w = AllocateWindowDescFront<VehicleGroupWindow>(_vehicle_group_desc[vehicle_type], num, need_existing_window);
 	if (w != nullptr) w->SelectGroup(group);
 }
 

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2300,31 +2300,40 @@ public:
 	}
 };
 
-static WindowDesc _vehicle_list_other_desc(
-	WDP_AUTO, "list_vehicles", 260, 246,
-	WC_INVALID, WC_NONE,
-	0,
-	_nested_vehicle_list
-);
-
-static WindowDesc _vehicle_list_train_desc(
-	WDP_AUTO, "list_vehicles_train", 325, 246,
-	WC_TRAINS_LIST, WC_NONE,
-	0,
-	_nested_vehicle_list
-);
+static WindowDesc _vehicle_list_desc[] = {
+	{
+		WDP_AUTO, "list_vehicles_train", 325, 246,
+		WC_TRAINS_LIST, WC_NONE,
+		0,
+		_nested_vehicle_list
+	},
+	{
+		WDP_AUTO, "list_vehicles_roadveh", 260, 246,
+		WC_INVALID, WC_NONE,
+		0,
+		_nested_vehicle_list
+	},
+	{
+		WDP_AUTO, "list_vehicles_ship", 260, 246,
+		WC_INVALID, WC_NONE,
+		0,
+		_nested_vehicle_list
+	},
+	{
+		WDP_AUTO, "list_vehicles_aircraft", 260, 246,
+		WC_INVALID, WC_NONE,
+		0,
+		_nested_vehicle_list
+	}
+};
 
 static void ShowVehicleListWindowLocal(CompanyID company, VehicleListType vlt, VehicleType vehicle_type, uint32_t unique_number)
 {
 	if (!Company::IsValidID(company) && company != OWNER_NONE) return;
 
+	assert(vehicle_type < std::size(_vehicle_list_desc));
 	WindowNumber num = VehicleListIdentifier(vlt, vehicle_type, company, unique_number).Pack();
-	if (vehicle_type == VEH_TRAIN) {
-		AllocateWindowDescFront<VehicleListWindow>(_vehicle_list_train_desc, num);
-	} else {
-		_vehicle_list_other_desc.cls = GetWindowClassForVehicleType(vehicle_type);
-		AllocateWindowDescFront<VehicleListWindow>(_vehicle_list_other_desc, num);
-	}
+	AllocateWindowDescFront<VehicleListWindow>(_vehicle_list_desc[vehicle_type], num);
 }
 
 void ShowVehicleListWindow(CompanyID company, VehicleType vehicle_type)

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -114,9 +114,6 @@ WindowDesc::WindowDesc(WindowPosition def_pos, const char *ini_key, int16_t def_
 	flags(flags),
 	nwid_parts(nwid_parts),
 	hotkeys(hotkeys),
-	pref_sticky(false),
-	pref_width(0),
-	pref_height(0),
 	default_width_trad(def_width_trad),
 	default_height_trad(def_height_trad)
 {

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -156,7 +156,7 @@ struct HotkeyList;
 /**
  * High level window description
  */
-struct WindowDesc : ZeroedMemoryAllocator {
+struct WindowDesc {
 
 	WindowDesc(WindowPosition default_pos, const char *ini_key, int16_t def_width_trad, int16_t def_height_trad,
 			WindowClass window_class, WindowClass parent_class, uint32_t flags,
@@ -166,17 +166,17 @@ struct WindowDesc : ZeroedMemoryAllocator {
 	~WindowDesc();
 
 	const std::source_location source_location; ///< Source location of this definition
-	WindowPosition default_pos;    ///< Preferred position of the window. @see WindowPosition()
-	WindowClass cls;               ///< Class of the window, @see WindowClass.
-	WindowClass parent_cls;        ///< Class of the parent window. @see WindowClass
-	const char *ini_key;           ///< Key to store window defaults in openttd.cfg. \c nullptr if nothing shall be stored.
-	uint32_t flags;                  ///< Flags. @see WindowDefaultFlag
+	const WindowPosition default_pos; ///< Preferred position of the window. @see WindowPosition()
+	const WindowClass cls; ///< Class of the window, @see WindowClass.
+	const WindowClass parent_cls; ///< Class of the parent window. @see WindowClass
+	const char *ini_key; ///< Key to store window defaults in openttd.cfg. \c nullptr if nothing shall be stored.
+	const uint32_t flags; ///< Flags. @see WindowDefaultFlag
 	const std::span<const NWidgetPart> nwid_parts; ///< Span of nested widget parts describing the window.
-	HotkeyList *hotkeys;           ///< Hotkeys for the window.
+	const HotkeyList *hotkeys; ///< Hotkeys for the window.
 
-	bool pref_sticky;              ///< Preferred stickyness.
-	int16_t pref_width;              ///< User-preferred width of the window. Zero if unset.
-	int16_t pref_height;             ///< User-preferred height of the window. Zero if unset.
+	bool pref_sticky = false; ///< Preferred stickyness.
+	int16_t pref_width = 0; ///< User-preferred width of the window. Zero if unset.
+	int16_t pref_height = 0; ///< User-preferred height of the window. Zero if unset.
 
 	int16_t GetDefaultWidth() const;
 	int16_t GetDefaultHeight() const;
@@ -185,8 +185,8 @@ struct WindowDesc : ZeroedMemoryAllocator {
 	static void SaveToConfig();
 
 private:
-	int16_t default_width_trad;      ///< Preferred initial width of the window (pixels at 1x zoom).
-	int16_t default_height_trad;     ///< Preferred initial height of the window (pixels at 1x zoom).
+	const int16_t default_width_trad; ///< Preferred initial width of the window (pixels at 1x zoom).
+	const int16_t default_height_trad; ///< Preferred initial height of the window (pixels at 1x zoom).
 
 	/**
 	 * Delete copy constructor to prevent compilers from


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`WindowDesc` uses `ZeroedMemoryAllocator` for legacy reasons.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Fully initialise `WindowDesc` via constructor initialiser.

Most of the member variables are not intended to be changed and so are now marked `const` -- this means that the compiler provides a warning if the constructor does not initialise them.

Some existing users of `WindowDesc` did actually modify some of those members. These are split out into separate WindowDescs to avoid that.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
