### PR TITLE
Codechange: use -fno-strict-enums instead of -fno-tree-vrp

### DIFF
--- a/cmake/CompileFlags.cmake
+++ b/cmake/CompileFlags.cmake
@@ -80,6 +80,10 @@ macro(compile_flags)
 
             # We use 'ABCD' multichar for SaveLoad chunks identifiers
             -Wno-multichar
+
+            # Prevent optimisation supposing enums are in a range specified by the standard
+            # For details, see http://gcc.gnu.org/PR43680 and PR#5246.
+            -fno-strict-enums
         )
 
         # Ninja processes the output so the output from the compiler
@@ -105,10 +109,6 @@ macro(compile_flags)
                 # sure that they will not happen. It furthermore complains
                 # about its own optimized code in some places.
                 "-fno-strict-overflow"
-
-                # Prevent optimisation supposing enums are in a range specified by the standard
-                # For details, see http://gcc.gnu.org/PR43680
-                "-fno-tree-vrp"
 
                 # -flifetime-dse=2 (default since GCC 6) doesn't play
                 # well with our custom pool item allocator


### PR DESCRIPTION
-fno-tree-vrp is essentially a GCC implementation detail which controls a powerful source of optimisation information. The linked GCC bug from 2010(!) shows that -fno-strict-enums was added in response to the bug report, and we can use that instead. Clang supports it too. Use that instead.

## Motivation / Problem

Noticed this by chance when looking into something unrelated. It should improve optimisation of OpenTTD and also makes the intent far clearer.

## Description

Use `-fno-strict-enums` which was added to control precisely the behaviour needed rather than a broad-sweeping optimisation option.


## Limitations

I'm not aware of any. The testsuite passes also.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
