### PR TITLE
Codechange: [CMake] Hide errors when breakpad is not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ endif()
 
 # Breakpad doesn't support emscripten.
 if(NOT EMSCRIPTEN)
-    find_package(unofficial-breakpad)
+    find_package(unofficial-breakpad NO_MODULE)
 endif()
 
 if(NOT OPTION_DEDICATED)
@@ -317,7 +317,7 @@ if(NOT WIN32 AND NOT EMSCRIPTEN)
 endif()
 
 if(NOT EMSCRIPTEN)
-    link_package(unofficial-breakpad TARGET unofficial::breakpad::libbreakpad_client ENCOURAGED)
+    link_package(unofficial-breakpad TARGET unofficial::breakpad::libbreakpad_client)
 endif()
 
 if(NOT OPTION_DEDICATED)


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

`breakpad` is a dependency that's only relevant for our own official builds, so having it be so noisy for everyone else feels a bit excessive


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

Remove 'ENCOURAGED' from the link_package call, and stop cmake from searching for a Find*.cmake file that will never exist (the actual package uses unofficial-breakpadConfig.cmake)


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

It's now not mentioned at all if it's not found, which isn't strictly ideal. Can't find a way of getting it to just have a short "Could NOT find..." message like the others though

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
