### PR TITLE
Fix: Remove unwanted river artifacts after generation

### DIFF
--- a/src/pathfinder/yapf/yapf_river_builder.cpp
+++ b/src/pathfinder/yapf/yapf_river_builder.cpp
@@ -11,6 +11,7 @@
 
 #include "../../water.h"
 #include "../../genworld.h"
+#include "../../viewport_func.h"
 #include "yapf.hpp"
 
 #include "../../safeguards.h"
@@ -108,7 +109,8 @@ public:
 		for (Node *node = pf.GetBestNode(); node != nullptr; node = node->parent) {
 			TileIndex tile = node->GetTile();
 			if (!IsWaterTile(tile)) {
-				MakeRiverAndModifyDesertZoneAround(tile);
+				MakeRiver(tile, Random());
+				MarkTileDirtyByTile(tile);
 			}
 		}
 

--- a/src/water.h
+++ b/src/water.h
@@ -41,6 +41,7 @@ void CheckForDockingTile(TileIndex t);
 void MakeRiverAndModifyDesertZoneAround(TileIndex tile);
 void RiverMakeWider(TileIndex tile, TileIndex origin_tile);
 bool RiverFlowsDown(TileIndex begin, TileIndex end);
+void ModifyDesertZoneAroundRiver(TileIndex tile);
 static const uint RIVER_OFFSET_DESERT_DISTANCE = 5; ///< Circular tile search diameter to create non-desert around a river tile.
 
 bool IsWateredTile(TileIndex tile, Direction from);

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -480,6 +480,20 @@ void MakeRiverAndModifyDesertZoneAround(TileIndex tile)
 }
 
 /**
+ * Remove desert directly around a river tile.
+ * @param tile The tile to create non-desert around
+ */
+void ModifyDesertZoneAroundRiver(TileIndex tile)
+{
+	assert(IsTileType(tile, MP_WATER) && IsRiver(tile));
+
+	/* Remove desert directly around the river tile. */
+	for (auto t : SpiralTileSequence(tile, RIVER_OFFSET_DESERT_DISTANCE)) {
+		if (GetTropicZone(t) == TROPICZONE_DESERT) SetTropicZone(t, TROPICZONE_NORMAL);
+	}
+}
+
+/**
  * Build a piece of canal.
  * @param flags type of operation
  * @param tile end tile of stretch-dragging


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Artifacts left behind during river generation.
![Unnamed, 1935-01-01#18](https://github.com/user-attachments/assets/7d07c2a3-79f0-4116-84c2-5575a2f071b0)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Remove unwanted river artifacts after generation.
![Unnamed, 1935-01-01#19](https://github.com/user-attachments/assets/c3229b04-d5d4-4038-8a26-021f28663e3c)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
This requires postponing `ModifyDesertZoneAroundRiver` to after river generation.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
