### PR TITLE
Codechange: add unit test against enum over optimisation

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_test_files(
     bitmath_func.cpp
+    enum_over_optimisation.cpp
     landscape_partial_pixel_z.cpp
     math_func.cpp
     mock_environment.h

--- a/src/tests/enum_over_optimisation.cpp
+++ b/src/tests/enum_over_optimisation.cpp
@@ -1,0 +1,31 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file enum_over_optimisation.cpp Test whether we do not trigger an over optimisation of enums.
+ *
+ * For more details, see http://gcc.gnu.org/PR43680 and PR#5246.
+ */
+
+#include "../stdafx.h"
+
+#include "../3rdparty/catch2/catch.hpp"
+
+enum TestEnum : int8_t {
+	ZERO,
+	ONE,
+	TWO
+};
+
+TEST_CASE("EnumOverOptimisation_BoundsCheck")
+{
+	TestEnum negative_one = static_cast<TestEnum>(-1);
+	CHECK(negative_one < ZERO);
+
+	TestEnum three = static_cast<TestEnum>(3);
+	CHECK(TWO < three);
+}


### PR DESCRIPTION
## Motivation / Problem

#13369 is about an over optimisation bug in GCC for which we added a workaround that might be too broad and not broad enough. Too broad as it disables too many optimisations in GCC, not broad enough as it might not disable the optimisation in Clang.

Note that since the underlying bug report in GCC there has been a change in the specification that makes bounds checking with an unspecified enum value undefined behaviour.

In any case, it would be really nice to know that the over optimisation might be enabled in a build by just having a few unit tests that try to actually trigger them.


## Description

Add unit test.

See https://godbolt.org/z/r3Po5Mfce for it failing with GCC 4.5.3, though not with catch2 as that doesn't compile with that version of GCC.


## Limitations

It's far from fool-proof, as I'm not sure when the compiler exactly considers removing the guards and when not. It does work at least for the known-bad situation that was in GCC 4.5.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
