### PR TITLE
Codechange: add unit test against over optimisation of enum-bitmasks

### DIFF
--- a/src/tests/enum_over_optimisation.cpp
+++ b/src/tests/enum_over_optimisation.cpp
@@ -13,6 +13,8 @@
 
 #include "../stdafx.h"
 
+#include "../core/enum_type.hpp"
+
 #include "../3rdparty/catch2/catch.hpp"
 
 enum TestEnum : int8_t {
@@ -28,4 +30,18 @@ TEST_CASE("EnumOverOptimisation_BoundsCheck")
 
 	TestEnum three = static_cast<TestEnum>(3);
 	CHECK(TWO < three);
+}
+
+enum class TestEnumFlags : uint8_t {
+	Zero = 0,
+	One = 1 << 0,
+	Two = 1 << 1,
+};
+DECLARE_ENUM_AS_BIT_SET(TestEnumFlags)
+
+TEST_CASE("EnumOverOptimisation_Bitmask")
+{
+	TestEnumFlags three = TestEnumFlags::One | TestEnumFlags::Two;
+	CHECK(HasFlag(three, TestEnumFlags::One));
+	CHECK(HasFlag(three, TestEnumFlags::Two));
 }


### PR DESCRIPTION
## Motivation / Problem

[CWG 1766](https://cplusplus.github.io/CWG/issues/1766.html) states that the behaviour of converting an integral to an enum is undefined when the integral is not in the range of the enum.

When using bitmask enums we often just define the singular masks, but an 'all' mask would have a value that is technically outside of the range of the enum and would be undefined behaviour.

Having said this, the undefined behaviour observed so far is that it does not do any conversion and the bitmask enums work just fine. So, it was suggested to just add a simple test to be fairly certain this isn't causing problems.


## Description

Add a simple unit test that creates a flag that is outside of the range of the enum and check whether `HasFlag` still functions as expected.


## Limitations

There is absolutely no guarantee that a compiler does not inject undefined behaviour when this test succeeds. However, we are sure it does when the test fails. So basically, it's better than having nothing at all.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
