### PR TITLE
Change: Don't distinguish between bus and truck stops when removing them

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -2323,7 +2323,7 @@ static CommandCost RemoveGenericRoadStop(DoCommandFlag flags, const TileArea &ro
 
 	for (TileIndex cur_tile : roadstop_area) {
 		/* Make sure the specified tile is a road stop of the correct type */
-		if (!IsTileType(cur_tile, MP_STATION) || !IsAnyRoadStop(cur_tile) || GetStationType(cur_tile) != station_type) continue;
+		if (!IsTileType(cur_tile, MP_STATION) || !IsAnyRoadStop(cur_tile)) continue;
 
 		/* Save information on to-be-restored roads before the stop is removed. */
 		RoadBits road_bits = ROAD_NONE;


### PR DESCRIPTION
## Motivation / Problem

Just imagine: you are creating a route for trucks carrying something. But when creating the vehicle orders you discover that you've built bus stops instead of truck stops. You whisper a few cusswords while you quickly go back to the road construction window. You click the truck stop button and hit R to remove the bus stop which you want to replace. After you've done that you can hit R again and build the correct road stop.

Except that you can't, because you can't remove the bus stop using the "build truck stop + demolish"-tool:
![image](https://github.com/user-attachments/assets/ee21b5e5-0f88-42b4-8dca-ad834e1c36c5)
... so you have to go click the bus stop button, hit R, remove the bus stop, click the truck stop station again, and build the new one.

## Description

Although not entirely the same situation, we do allow the user to remove e.g. electrified rail using the maglev removal tool. The situation explained above feels similar, and IMO there is no good reason for the limitation. So I removed it.

(I also realize that having the ability to overbuild would be nice, but that deserves its own PR)

## Limitations

This realize could very well be a _me_-problem. 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
