### PR TITLE
Codechange: also add prefix increment/decrement for enums when requested

### DIFF
--- a/src/bridge.h
+++ b/src/bridge.h
@@ -30,7 +30,7 @@ enum BridgePieces {
 	NUM_BRIDGE_PIECES,
 };
 
-DECLARE_POSTFIX_INCREMENT(BridgePieces)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(BridgePieces)
 
 static const uint MAX_BRIDGES = 13; ///< Maximal number of available bridge specs.
 constexpr uint SPRITES_PER_BRIDGE_PIECE = 32; ///< Number of sprites there are per bridge piece.

--- a/src/company_manager_face.h
+++ b/src/company_manager_face.h
@@ -50,7 +50,7 @@ enum CompanyManagerFaceVariable {
 	CMFV_GLASSES,
 	CMFV_END,
 };
-DECLARE_POSTFIX_INCREMENT(CompanyManagerFaceVariable)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(CompanyManagerFaceVariable)
 
 /** Information about the valid values of CompanyManagerFace bitgroups as well as the sprites to draw */
 struct CompanyManagerFaceBitsInfo {

--- a/src/company_type.h
+++ b/src/company_type.h
@@ -34,7 +34,7 @@ enum Owner : uint8_t {
 	COMPANY_NEW_COMPANY     = 254, ///< The client wants a new company
 	COMPANY_SPECTATOR       = 255, ///< The client is spectating
 };
-DECLARE_POSTFIX_INCREMENT(Owner)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(Owner)
 DECLARE_ENUM_AS_ADDABLE(Owner)
 
 static const uint MAX_LENGTH_PRESIDENT_NAME_CHARS = 32; ///< The maximum length of a president name in characters including '\0'

--- a/src/core/enum_type.hpp
+++ b/src/core/enum_type.hpp
@@ -14,21 +14,54 @@
 template <typename enum_type>
 constexpr std::underlying_type_t<enum_type> to_underlying(enum_type e) { return static_cast<std::underlying_type_t<enum_type>>(e); }
 
+/** Trait to enable prefix/postfix incrementing operators. */
+template <typename enum_type>
+struct is_enum_incrementable {
+	static constexpr bool value = false;
+};
+
+template <typename enum_type>
+constexpr bool is_enum_incrementable_v = is_enum_incrementable<enum_type>::value;
+
+/** Prefix increment. */
+template <typename enum_type, std::enable_if_t<is_enum_incrementable_v<enum_type>, bool> = true>
+inline constexpr enum_type &operator ++(enum_type &e)
+{
+	e = static_cast<enum_type>(to_underlying(e) + 1);
+	return e;
+}
+
+/** Postfix increment, uses prefix increment. */
+template <typename enum_type, std::enable_if_t<is_enum_incrementable_v<enum_type>, bool> = true>
+inline constexpr enum_type operator ++(enum_type &e, int)
+{
+	enum_type e_org = e;
+	++e;
+	return e_org;
+}
+
+/** Prefix decrement. */
+template <typename enum_type, std::enable_if_t<is_enum_incrementable_v<enum_type>, bool> = true>
+inline constexpr enum_type &operator --(enum_type &e)
+{
+	e = static_cast<enum_type>(to_underlying(e) - 1);
+	return e;
+}
+
+/** Postfix decrement, uses prefix decrement. */
+template <typename enum_type, std::enable_if_t<is_enum_incrementable_v<enum_type>, bool> = true>
+inline constexpr enum_type operator --(enum_type &e, int)
+{
+	enum_type e_org = e;
+	--e;
+	return e_org;
+}
+
 /** Some enums need to have allowed incrementing (i.e. StationClassID) */
 #define DECLARE_POSTFIX_INCREMENT(enum_type) \
-	inline constexpr enum_type operator ++(enum_type& e, int) \
-	{ \
-		enum_type e_org = e; \
-		e = static_cast<enum_type>(to_underlying(e) + 1); \
-		return e_org; \
-	} \
-	inline constexpr enum_type operator --(enum_type& e, int) \
-	{ \
-		enum_type e_org = e; \
-		e = static_cast<enum_type>(to_underlying(e) - 1); \
-		return e_org; \
-	}
-
+	template <> struct is_enum_incrementable<enum_type> { \
+		static const bool value = true; \
+	};
 
 
 /** Operators to allow to work with enum as with type safe bit set in C++ */

--- a/src/core/enum_type.hpp
+++ b/src/core/enum_type.hpp
@@ -57,8 +57,8 @@ inline constexpr enum_type operator --(enum_type &e, int)
 	return e_org;
 }
 
-/** Some enums need to have allowed incrementing (i.e. StationClassID) */
-#define DECLARE_POSTFIX_INCREMENT(enum_type) \
+/** For some enums it is useful to have pre/post increment/decrement operators */
+#define DECLARE_INCREMENT_DECREMENT_OPERATORS(enum_type) \
 	template <> struct is_enum_incrementable<enum_type> { \
 		static const bool value = true; \
 	};

--- a/src/direction_type.h
+++ b/src/direction_type.h
@@ -36,7 +36,7 @@ enum Direction : uint8_t {
 };
 
 /** Allow incrementing of Direction variables */
-DECLARE_POSTFIX_INCREMENT(Direction)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(Direction)
 
 /**
  * Enumeration for the difference between two directions.
@@ -79,7 +79,7 @@ enum DiagDirection : uint8_t {
 	DIAGDIR_END,            ///< Used for iterations
 	INVALID_DIAGDIR = 0xFF, ///< Flag for an invalid DiagDirection
 };
-DECLARE_POSTFIX_INCREMENT(DiagDirection)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(DiagDirection)
 DECLARE_ENUM_AS_ADDABLE(DiagDirection)
 
 /**
@@ -102,7 +102,7 @@ enum DiagDirDiff {
 };
 
 /** Allow incrementing of DiagDirDiff variables */
-DECLARE_POSTFIX_INCREMENT(DiagDirDiff)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(DiagDirDiff)
 
 
 /**

--- a/src/driver.h
+++ b/src/driver.h
@@ -50,7 +50,7 @@ public:
 	virtual std::string_view GetName() const = 0;
 };
 
-DECLARE_POSTFIX_INCREMENT(Driver::Type)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(Driver::Type)
 
 
 /** Base for all driver factories. */

--- a/src/economy_type.h
+++ b/src/economy_type.h
@@ -74,7 +74,7 @@ enum ScoreID {
 	SCORE_MAX = 1000,      ///< The max score that can be in the performance history
 	/* the scores together of score_info is allowed to be more! */
 };
-DECLARE_POSTFIX_INCREMENT(ScoreID)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(ScoreID)
 
 /** Data structure for storing how the score is computed for a single score id. */
 struct ScoreInfo {
@@ -163,7 +163,7 @@ enum Price : uint8_t {
 	PR_END,
 	INVALID_PRICE = 0xFF
 };
-DECLARE_POSTFIX_INCREMENT(Price)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(Price)
 
 typedef Money Prices[PR_END]; ///< Prices of everything. @see Price
 typedef int8_t PriceMultipliers[PR_END];

--- a/src/fileio_type.h
+++ b/src/fileio_type.h
@@ -153,7 +153,7 @@ enum Searchpath : unsigned {
 	NUM_SEARCHPATHS
 };
 
-DECLARE_POSTFIX_INCREMENT(Searchpath)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(Searchpath)
 
 class FileHandle {
 public:

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -77,7 +77,7 @@ enum PerformanceElement {
 	PFE_AI14,          ///< AI execution for player slot 15
 	PFE_MAX,           ///< End of enum, must be last.
 };
-DECLARE_POSTFIX_INCREMENT(PerformanceElement)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(PerformanceElement)
 
 /** Type used to hold a performance timing measurement */
 typedef uint64_t TimingMeasurement;

--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -214,7 +214,7 @@ enum FontSize {
 
 	FS_BEGIN = FS_NORMAL, ///< First font.
 };
-DECLARE_POSTFIX_INCREMENT(FontSize)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(FontSize)
 
 inline const char *FontSizeToName(FontSize fs)
 {
@@ -253,7 +253,7 @@ enum Colours : uint8_t {
 	COLOUR_END,
 	INVALID_COLOUR = 0xFF,
 };
-DECLARE_POSTFIX_INCREMENT(Colours)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(Colours)
 DECLARE_ENUM_AS_ADDABLE(Colours)
 
 /** Colour of the strings, see _string_colourmap in table/string_colours.h or docs/ottd-colourtext-palette.png */

--- a/src/house.h
+++ b/src/house.h
@@ -61,7 +61,7 @@ enum HouseZonesBits : uint8_t {
 };
 static_assert(HZB_END == 5);
 
-DECLARE_POSTFIX_INCREMENT(HouseZonesBits)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(HouseZonesBits)
 
 enum HouseZones : uint16_t {
 	HZ_NOZNS             = 0x0000,  ///<       0          This is just to get rid of zeros, meaning none

--- a/src/livery.h
+++ b/src/livery.h
@@ -57,7 +57,7 @@ enum LiveryScheme : uint8_t {
 	LS_END
 };
 
-DECLARE_POSTFIX_INCREMENT(LiveryScheme)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(LiveryScheme)
 
 /** List of different livery classes, used only by the livery GUI. */
 enum LiveryClass : uint8_t {

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -42,7 +42,7 @@
 
 /* This file handles all the server-commands */
 
-DECLARE_POSTFIX_INCREMENT(ClientID)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(ClientID)
 /** The identifier counter for new clients (is never decreased) */
 static ClientID _network_client_id = CLIENT_ID_FIRST;
 

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -52,7 +52,7 @@ enum GrfLoadingStage {
 	GLS_END,
 };
 
-DECLARE_POSTFIX_INCREMENT(GrfLoadingStage)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(GrfLoadingStage)
 
 enum GrfMiscBit {
 	GMB_DESERT_TREES_FIELDS    = 0, // Unsupported.

--- a/src/newgrf_airport.h
+++ b/src/newgrf_airport.h
@@ -77,7 +77,7 @@ enum AirportClassID {
 };
 
 /** Allow incrementing of AirportClassID variables */
-DECLARE_POSTFIX_INCREMENT(AirportClassID)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(AirportClassID)
 
 /** TTDP airport types. Used to map our types to TTDPatch's */
 enum TTDPAirportType {

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -51,7 +51,7 @@ enum ObjectClassID : uint16_t {
 	INVALID_OBJECT_CLASS = UINT16_MAX, ///< Class for the less fortunate.
 };
 /** Allow incrementing of ObjectClassID variables */
-DECLARE_POSTFIX_INCREMENT(ObjectClassID)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(ObjectClassID)
 
 /** An object that isn't use for transport, industries or houses.
  * @note If you change this struct, adopt the initialization of

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -31,7 +31,7 @@ enum RoadStopClassID : uint16_t {
 	ROADSTOP_CLASS_WAYP, ///< Waypoint class.
 	ROADSTOP_CLASS_MAX = UINT16_MAX, ///< Maximum number of classes.
 };
-DECLARE_POSTFIX_INCREMENT(RoadStopClassID)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(RoadStopClassID)
 
 /* Some Triggers etc. */
 enum RoadStopRandomTrigger {

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -103,7 +103,7 @@ enum VarSpriteGroupScope : uint8_t {
 
 	VSG_END
 };
-DECLARE_POSTFIX_INCREMENT(VarSpriteGroupScope)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(VarSpriteGroupScope)
 
 enum DeterministicSpriteGroupSize : uint8_t {
 	DSG_SIZE_BYTE,

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -91,7 +91,7 @@ enum StationClassID : uint16_t {
 };
 
 /** Allow incrementing of StationClassID variables */
-DECLARE_POSTFIX_INCREMENT(StationClassID)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(StationClassID)
 
 enum StationSpecFlags {
 	SSF_SEPARATE_GROUND,      ///< Use different sprite set for ground sprites.

--- a/src/palette_func.h
+++ b/src/palette_func.h
@@ -81,7 +81,7 @@ enum ColourShade : uint8_t {
 	SHADE_LIGHTEREST,
 	SHADE_END,
 };
-DECLARE_POSTFIX_INCREMENT(ColourShade)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(ColourShade)
 
 uint8_t GetColourGradient(Colours colour, ColourShade shade);
 void SetColourGradient(Colours colour, ColourShade shade, uint8_t palette_colour);

--- a/src/rail_type.h
+++ b/src/rail_type.h
@@ -35,7 +35,7 @@ enum RailType : uint8_t {
 };
 
 /** Allow incrementing of Track variables */
-DECLARE_POSTFIX_INCREMENT(RailType)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(RailType)
 
 /**
  * The different railtypes we support, but then a bitmask of them.

--- a/src/road_type.h
+++ b/src/road_type.h
@@ -29,7 +29,7 @@ enum RoadType : uint8_t {
 	ROADTYPE_END     = 63,   ///< Used for iterations
 	INVALID_ROADTYPE = 63,   ///< flag for invalid roadtype
 };
-DECLARE_POSTFIX_INCREMENT(RoadType)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(RoadType)
 
 /**
  * The different roadtypes we support, but then a bitmask of them.

--- a/src/script/api/Doxyfile_AI.in
+++ b/src/script/api/Doxyfile_AI.in
@@ -137,7 +137,7 @@ EXCLUDE_SYMLINKS       = NO
 EXCLUDE_PATTERNS       = ai_includes.hpp
 EXCLUDE_SYMBOLS        = GetClassName \
                          DECLARE_ENUM_AS_BIT_SET \
-                         DECLARE_POSTFIX_INCREMENT
+                         DECLARE_INCREMENT_DECREMENT_OPERATORS
 EXAMPLE_PATH           =
 EXAMPLE_PATTERNS       = *
 EXAMPLE_RECURSIVE      = NO

--- a/src/script/api/Doxyfile_GS.in
+++ b/src/script/api/Doxyfile_GS.in
@@ -137,7 +137,7 @@ EXCLUDE_SYMLINKS       = NO
 EXCLUDE_PATTERNS       = game_includes.hpp
 EXCLUDE_SYMBOLS        = GetClassName \
                          DECLARE_ENUM_AS_BIT_SET \
-                         DECLARE_POSTFIX_INCREMENT
+                         DECLARE_INCREMENT_DECREMENT_OPERATORS
 EXAMPLE_PATH           =
 EXAMPLE_PATTERNS       = *
 EXAMPLE_RECURSIVE      = NO

--- a/src/script/api/script_company.hpp
+++ b/src/script/api/script_company.hpp
@@ -450,6 +450,6 @@ public:
 	static ScriptCompany::Colours GetSecondaryLiveryColour(LiveryScheme scheme);
 };
 
-DECLARE_POSTFIX_INCREMENT(ScriptCompany::CompanyID)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(ScriptCompany::CompanyID)
 
 #endif /* SCRIPT_COMPANY_HPP */

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1227,7 +1227,7 @@ enum RestrictionMode {
 	RM_CHANGED_AGAINST_NEW,              ///< Show only settings which are different compared to the user's new game setting values.
 	RM_END,                              ///< End for iteration.
 };
-DECLARE_POSTFIX_INCREMENT(RestrictionMode)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(RestrictionMode)
 
 /** Filter for settings list. */
 struct SettingFilter {

--- a/src/textfile_type.h
+++ b/src/textfile_type.h
@@ -25,7 +25,7 @@ enum TextfileType {
 
 	TFT_END,
 };
-DECLARE_POSTFIX_INCREMENT(TextfileType)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(TextfileType)
 DECLARE_ENUM_AS_ADDABLE(TextfileType)
 
 #endif /* TEXTFILE_TYPE_H */

--- a/src/track_type.h
+++ b/src/track_type.h
@@ -29,7 +29,7 @@ enum Track : uint8_t {
 };
 
 /** Allow incrementing of Track variables */
-DECLARE_POSTFIX_INCREMENT(Track)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(Track)
 
 /** Bitfield corresponding to Track */
 enum TrackBits : uint8_t {
@@ -87,7 +87,7 @@ enum Trackdir : uint8_t {
 };
 
 /** Allow incrementing of Trackdir variables */
-DECLARE_POSTFIX_INCREMENT(Trackdir)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(Trackdir)
 
 /**
  * Enumeration of bitmasks for the TrackDirs

--- a/src/vehicle_type.h
+++ b/src/vehicle_type.h
@@ -34,7 +34,7 @@ enum VehicleType : uint8_t {
 	VEH_END,
 	VEH_INVALID = 0xFF,           ///< Non-existing type of vehicle.
 };
-DECLARE_POSTFIX_INCREMENT(VehicleType)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(VehicleType)
 DECLARE_ENUM_AS_ADDABLE(VehicleType)
 
 struct Vehicle;

--- a/src/zoom_type.h
+++ b/src/zoom_type.h
@@ -41,7 +41,7 @@ enum ZoomLevel : uint8_t {
 	ZOOM_LVL_MIN      = ZOOM_LVL_IN_4X, ///< Minimum zoom level.
 	ZOOM_LVL_MAX      = ZOOM_LVL_OUT_8X, ///< Maximum zoom level.
 };
-DECLARE_POSTFIX_INCREMENT(ZoomLevel)
+DECLARE_INCREMENT_DECREMENT_OPERATORS(ZoomLevel)
 DECLARE_ENUM_AS_ADDABLE(ZoomLevel)
 
 static uint const ZOOM_BASE_SHIFT = static_cast<uint>(ZOOM_LVL_NORMAL);


### PR DESCRIPTION
## Motivation / Problem

There is a macro `DECLARE_POSTFIX_INCREMENT` that adds postfix incrementing and decrementing to enums.

Technically prefix incrementing is better, i.e. `++var` over `var++`, because there is no need to make a copy of the original state of the variable.

In our code we do not use the prefix incrementing because it did not work, i.e. it's not exposed for the enumeration so you fall back to the postfix increment. However standard code, for example `std::iota`, is more likely to use the prefix increment/decrement due to it being conceptually the better.


## Description

Add prefix increment/decrement to the macro.

Rename `DECLARE_POSTFIX_INCREMENT` to `DECLARE_INCREMENT_DECREMENT_OPERATORS`, so the name of the macro and the action do match up.


## Limitations

Nothing uses this (yet).


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
