### PR TITLE
Change: Draw company manager face jacket after collar

### DIFF
--- a/src/company_manager_face.h
+++ b/src/company_manager_face.h
@@ -44,8 +44,8 @@ enum CompanyManagerFaceVariable {
 	CMFV_LIPS,
 	CMFV_NOSE,
 	CMFV_HAIR,
-	CMFV_JACKET,
 	CMFV_COLLAR,
+	CMFV_JACKET,
 	CMFV_TIE_EARRING,
 	CMFV_GLASSES,
 	CMFV_END,
@@ -77,8 +77,8 @@ static const CompanyManagerFaceBitsInfo _cmf_info[] = {
 	/* CMFV_LIPS            */ { 13, 4, { 12, 10,  9,  9 }, { 0x35B, 0x351, 0x3A5, 0x3C8 } }, ///< Depends on !CMFV_HAS_MOUSTACHE
 	/* CMFV_NOSE            */ { 17, 3, {  8,  4,  4,  5 }, { 0x349, 0x34C, 0x393, 0x3B3 } }, ///< Depends on !CMFV_HAS_MOUSTACHE
 	/* CMFV_HAIR            */ { 20, 4, {  9,  5,  5,  5 }, { 0x382, 0x38B, 0x3D4, 0x3D9 } },
-	/* CMFV_JACKET          */ { 24, 2, {  3,  3,  3,  3 }, { 0x36B, 0x378, 0x36B, 0x378 } },
 	/* CMFV_COLLAR          */ { 26, 2, {  4,  4,  4,  4 }, { 0x36E, 0x37B, 0x36E, 0x37B } },
+	/* CMFV_JACKET          */ { 24, 2, {  3,  3,  3,  3 }, { 0x36B, 0x378, 0x36B, 0x378 } },
 	/* CMFV_TIE_EARRING     */ { 28, 3, {  6,  3,  6,  3 }, { 0x372, 0x37F, 0x372, 0x3D1 } }, ///< Depends on CMFV_HAS_TIE_EARRING
 	/* CMFV_GLASSES         */ { 31, 1, {  2,  2,  2,  2 }, { 0x347, 0x347, 0x3AE, 0x3AE } }  ///< Depends on CMFV_HAS_GLASSES
 };


### PR DESCRIPTION
## Motivation / Problem

The drawing order for the sprites making up the manager face has an oddity - the (shirt) collar is drawn after the jacket, meaning that naive sprites (ie. a person's body wearing a shirt, and a jacket with transparent regions to go on top of that) aren't suitable.

Existing graphics sets (original graphics, OpenGFX and NewGRFs) work around this by cutting off the edges of the shirt and collar to fit precisely into the jacket opening.

This imposes a significant design constraint for replacement of these sprites - all jackets have to have the same cutout shape to fit the shirt into.

## Description

Swapping the drawing order fixes this. Change the sprite drawing order defined by the `CompanyManagerFaceVariable` enum and `CompanyManagerFaceBitsInfo` sprite table.

![image](https://github.com/user-attachments/assets/e2550996-67c0-4944-a8c9-156552be21ff)

This example sprite-replacing NewGRF has a simple shirt sprite underlay and transparent jacket over the top. This is not possible with the original drawing order.
![ottd_mgr_wmn_eur_top3_00001_](https://github.com/user-attachments/assets/75880ade-b0f9-4f64-8003-450693d03622)
![ottd_mgr_wmn_eur_jacket2_00001_](https://github.com/user-attachments/assets/45acb28d-0387-4835-b8a7-a47b1d0e44d5)

## Limitations

This change does not impact any existing graphics that I am aware of. Tested with original graphics, OpenGFX1, OpenGFX2 and with the (only?) face-replacing NewGRF: Japan Set Faces. Because of the old draw order, it was a technical necessity to have the shirt shape match the jacket cutout, which is also compatible with reversed draw order.

Changes what is presumably an original TTD behaviour.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
