### PR TITLE
Fix: [CMake] restore CMAKE_REQUIRED_FLAGS if you change it

### DIFF
--- a/cmake/FindSSE.cmake
+++ b/cmake/FindSSE.cmake
@@ -2,6 +2,7 @@
 # SSE version (SSE 2.0, SSSE 3.0).
 
 include(CheckCXXSourceCompiles)
+set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
 set(CMAKE_REQUIRED_FLAGS "")
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
@@ -15,3 +16,5 @@ check_cxx_source_compiles("
     int main() { return 0; }"
     SSE_FOUND
 )
+
+set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})

--- a/cmake/FindXaudio2.cmake
+++ b/cmake/FindXaudio2.cmake
@@ -1,6 +1,7 @@
 # Autodetect if xaudio2 can be used.
 
 include(CheckCXXSourceCompiles)
+set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
 set(CMAKE_REQUIRED_FLAGS "")
 
 check_cxx_source_compiles("
@@ -17,3 +18,5 @@ check_cxx_source_compiles("
     int main() { printf(\"%s\\\\n\", XAUDIO2_DLL_A); return 0; }"
     XAUDIO2_FOUND
 )
+
+set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})

--- a/os/emscripten/cmake/FindLibLZMA.cmake
+++ b/os/emscripten/cmake/FindLibLZMA.cmake
@@ -1,6 +1,7 @@
 # LibLZMA is a custom addition to the emscripten SDK, so it is possible
 # someone patched their SDK. Test out if the SDK supports LibLZMA.
 include(CheckCXXSourceCompiles)
+set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
 set(CMAKE_REQUIRED_FLAGS "--use-port=contrib.liblzma")
 
 check_cxx_source_compiles("
@@ -18,3 +19,5 @@ if (LIBLZMA_FOUND)
 else()
         message(WARNING "You are using an emscripten SDK without LibLZMA support. Many savegames won't be able to load in OpenTTD. Please copy liblzma.py to your ports/contrib folder in your local emsdk installation.")
 endif()
+
+set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})


### PR DESCRIPTION
## Motivation / Problem

https://github.com/OpenTTD/OpenTTD/pull/13372 showed that we have `Find` files that are not without side-effects. `CheckAtomic` already did this cleanly, and used an `OLD_` value to ensure the `CMAKE_REQUIRED_FLAGS` was restored with the original value.

## Description

Duplicate that behaviour for all other `Find` files that change `CMAKE_REQUIRED_FLAGS `.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
