### PR TITLE
Fix #13392: Signs of removed stations are no longer visible.

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -457,6 +457,7 @@ STR_SETTINGS_MENU_STATION_NAMES_LORRY                           :Lorry stops
 STR_SETTINGS_MENU_STATION_NAMES_BUS                             :Bus stops
 STR_SETTINGS_MENU_STATION_NAMES_SHIP                            :Docks
 STR_SETTINGS_MENU_STATION_NAMES_PLANE                           :Airports
+STR_SETTINGS_MENU_STATION_NAMES_GHOST                           :Ghost
 STR_SETTINGS_MENU_WAYPOINTS_DISPLAYED                           :Waypoint names displayed
 STR_SETTINGS_MENU_SIGNS_DISPLAYED                               :Signs displayed
 STR_SETTINGS_MENU_SHOW_COMPETITOR_SIGNS                         :Competitor signs and names displayed

--- a/src/station_type.h
+++ b/src/station_type.h
@@ -60,6 +60,9 @@ enum StationFacility : uint8_t {
 };
 DECLARE_ENUM_AS_BIT_SET(StationFacility)
 
+/** Fake 'facility' to allow toggling display of recently-removed station signs. */
+static constexpr StationFacility FACIL_GHOST{1U << 6};
+
 /** The vehicles that may have visited a station */
 enum StationHadVehicleOfType : uint8_t {
 	HVOT_NONE     = 0,      ///< Station has seen no vehicles

--- a/src/table/settings/misc_settings.ini
+++ b/src/table/settings/misc_settings.ini
@@ -12,7 +12,7 @@ extern std::string _config_language_file;
 
 static constexpr std::initializer_list<const char*> _support8bppmodes{"no", "system", "hardware"};
 static constexpr std::initializer_list<const char*> _display_opt_modes{"SHOW_TOWN_NAMES", "SHOW_STATION_NAMES", "SHOW_SIGNS", "FULL_ANIMATION", "", "FULL_DETAIL", "WAYPOINTS", "SHOW_COMPETITOR_SIGNS"};
-static constexpr std::initializer_list<const char*> _facility_display_opt_modes{"TRAIN", "TRUCK_STOP", "BUS_STOP", "AIRPORT", "DOCK"};
+static constexpr std::initializer_list<const char*> _facility_display_opt_modes{"TRAIN", "TRUCK_STOP", "BUS_STOP", "AIRPORT", "DOCK", "", "GHOST"};
 
 #ifdef WITH_COCOA
 extern bool _allow_hidpi_window;
@@ -69,7 +69,7 @@ full     = _display_opt_modes
 name     = ""facility_display_opt""
 type     = SLE_UINT8
 var      = _facility_display_opt
-def      = (1 << FACIL_TRAIN | 1 << FACIL_TRUCK_STOP | 1 << FACIL_BUS_STOP | 1 << FACIL_AIRPORT | 1 << FACIL_DOCK)
+def      = (FACIL_TRAIN | FACIL_TRUCK_STOP | FACIL_BUS_STOP | FACIL_AIRPORT | FACIL_DOCK | FACIL_GHOST)
 full     = _facility_display_opt_modes
 
 [SDTG_BOOL]

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -241,6 +241,7 @@ enum OptionMenuEntries {
 	OME_SHOW_STATIONNAMES_BUS,
 	OME_SHOW_STATIONNAMES_SHIP,
 	OME_SHOW_STATIONNAMES_PLANE,
+	OME_SHOW_STATIONNAMES_GHOST,
 	OME_SHOW_WAYPOINTNAMES,
 	OME_SHOW_SIGNS,
 	OME_SHOW_COMPETITOR_SIGNS,
@@ -281,6 +282,7 @@ static CallBackFunction ToolbarOptionsClick(Window *w)
 	list.push_back(MakeDropDownListCheckedItem((_facility_display_opt & FACIL_BUS_STOP) != 0, STR_SETTINGS_MENU_STATION_NAMES_BUS, OME_SHOW_STATIONNAMES_BUS, false, false, 1));
 	list.push_back(MakeDropDownListCheckedItem((_facility_display_opt & FACIL_DOCK) != 0, STR_SETTINGS_MENU_STATION_NAMES_SHIP, OME_SHOW_STATIONNAMES_SHIP, false, false, 1));
 	list.push_back(MakeDropDownListCheckedItem((_facility_display_opt & FACIL_AIRPORT) != 0, STR_SETTINGS_MENU_STATION_NAMES_PLANE, OME_SHOW_STATIONNAMES_PLANE, false, false, 1));
+	list.push_back(MakeDropDownListCheckedItem((_facility_display_opt & FACIL_GHOST) != 0, STR_SETTINGS_MENU_STATION_NAMES_GHOST, OME_SHOW_STATIONNAMES_GHOST, false, false, 1));
 	list.push_back(MakeDropDownListCheckedItem(HasBit(_display_opt, DO_SHOW_WAYPOINT_NAMES), STR_SETTINGS_MENU_WAYPOINTS_DISPLAYED, OME_SHOW_WAYPOINTNAMES));
 	list.push_back(MakeDropDownListCheckedItem(HasBit(_display_opt, DO_SHOW_SIGNS), STR_SETTINGS_MENU_SIGNS_DISPLAYED, OME_SHOW_SIGNS));
 	list.push_back(MakeDropDownListCheckedItem(HasBit(_display_opt, DO_SHOW_COMPETITOR_SIGNS), STR_SETTINGS_MENU_SHOW_COMPETITOR_SIGNS, OME_SHOW_COMPETITOR_SIGNS));
@@ -331,6 +333,7 @@ static CallBackFunction MenuClickSettings(int index)
 		case OME_SHOW_STATIONNAMES_BUS: ToggleFacilityDisplay(FACIL_BUS_STOP); break;
 		case OME_SHOW_STATIONNAMES_SHIP: ToggleFacilityDisplay(FACIL_DOCK); break;
 		case OME_SHOW_STATIONNAMES_PLANE: ToggleFacilityDisplay(FACIL_AIRPORT); break;
+		case OME_SHOW_STATIONNAMES_GHOST: ToggleFacilityDisplay(FACIL_GHOST); break;
 		case OME_SHOW_WAYPOINTNAMES:   ToggleBit(_display_opt, DO_SHOW_WAYPOINT_NAMES); break;
 		case OME_SHOW_SIGNS:           ToggleBit(_display_opt, DO_SHOW_SIGNS);          break;
 		case OME_SHOW_COMPETITOR_SIGNS:

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1448,7 +1448,12 @@ static void ViewportAddKdtreeSigns(DrawPixelInfo *dpi)
 			case ViewportSignKdtreeItem::VKI_STATION: {
 				if (!show_stations) break;
 				const BaseStation *st = BaseStation::Get(item.id.station);
-				if ((_facility_display_opt & st->facilities) == 0) break;
+
+				/* If no facilities are present the station is a ghost station. */
+				StationFacility facilities = st->facilities;
+				if (facilities == FACIL_NONE) facilities = FACIL_GHOST;
+
+				if ((_facility_display_opt & facilities) == 0) break;
 
 				/* Don't draw if station is owned by another company and competitor station names are hidden. Stations owned by none are never ignored. */
 				if (!show_competitors && _local_company != st->owner && st->owner != OWNER_NONE) break;


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

#13207 added per-facility station sign display options, but forgot that removed stations have no facility set, meaning they are no longer visible.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add a "Ghost" option for station sign visibility, allowed removed station signs to be visible.

This also fixes the default configuration for station facility, which incorrectly treated the `FACIL_*` enum values as bit numbers when they are always bit masks.

For new configurations, `FACIL_GHOST` will be enabled by default. For existing configurations, who knows, due to the above issue...

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

The "Ghost" wording is most likely terrible. But I wanted to avoid sitting on a stash for the next 18 months...

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
