### PR TITLE
Codechange: make script and internal NEW_STATION have the same value

### DIFF
--- a/src/script/api/script_basestation.hpp
+++ b/src/script/api/script_basestation.hpp
@@ -12,6 +12,7 @@
 
 #include "script_text.hpp"
 #include "script_date.hpp"
+#include "../../station_type.h"
 
 /**
  * Base class for stations and waypoints.
@@ -19,15 +20,9 @@
  */
 class ScriptBaseStation : public ScriptObject {
 public:
-	/**
-	 * Special station IDs for building adjacent/new stations when
-	 * the adjacent/distant join features are enabled.
-	 */
-	enum SpecialStationIDs {
-		STATION_NEW = 0xFFFD,           ///< Build a new station
-		STATION_JOIN_ADJACENT = 0xFFFE, ///< Join an neighbouring station if one exists
-		STATION_INVALID = 0xFFFF,       ///< Invalid station id.
-	};
+	static const StationID STATION_NEW = ::NEW_STATION; ///< Build a new station
+	static const StationID STATION_JOIN_ADJACENT = ::ADJACENT_STATION; ///< Join an neighbouring station if one exists
+	static const StationID STATION_INVALID = ::INVALID_STATION; ///< Invalid station id.
 
 	/**
 	 * Checks whether the given basestation is valid and owned by you.

--- a/src/station_type.h
+++ b/src/station_type.h
@@ -22,7 +22,8 @@ struct RoadStop;
 struct StationSpec;
 struct Waypoint;
 
-static const StationID NEW_STATION = 0xFFFE;
+static const StationID NEW_STATION = 0xFFFD;
+static const StationID ADJACENT_STATION = 0xFFFE;
 static const StationID INVALID_STATION = 0xFFFF;
 
 typedef SmallStack<StationID, StationID, INVALID_STATION, 8, 0xFFFD> StationIDStack;


### PR DESCRIPTION
## Motivation / Problem

In the script API there is a `STATION_NEW` with value `0xFFFD`, in the internal code there is a `NEW_STATION` with value `0xFFFE`. The script API then also has `STATION_ADJACENT` with value `0xFFFE`.

All in all values with quite similar meanings but slightly different values. Can't they be just the same? Yes they can.


## Description

Change value of `NEW_STATION` to `0xFFFD` and introduce `ADJACENT_STATION` with value `0xFFFE` in the internal code.
Replace the `SpecialStationIDs` enumeration with  just constants of `StationID` linked to the same internal values.

The internal values are changed to prevent issues with script APIs that might have stored the value of these constants. Internally it's only used in the GUI and the commands called from the GUI to not join stations.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
