### PR TITLE
Codechange: make some pool item indices strongly typed

### DIFF
--- a/src/autoreplace_base.h
+++ b/src/autoreplace_base.h
@@ -15,14 +15,14 @@
 #include "engine_type.h"
 #include "group_type.h"
 
-typedef uint16_t EngineRenewID;
+using EngineRenewID = PoolID<uint16_t, struct EngineRenewIDTag, 64000, 0xFFFF>;
 
 /**
  * Memory pool for engine renew elements. DO NOT USE outside of engine.c. Is
  * placed here so the only exception to this rule, the saveload code, can use
  * it.
  */
-typedef Pool<EngineRenew, EngineRenewID, 16, 64000> EngineRenewPool;
+using EngineRenewPool = Pool<EngineRenew, EngineRenewID, 16, EngineRenewID::End().base()>;
 extern EngineRenewPool _enginerenew_pool;
 
 /**

--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -241,7 +241,7 @@ struct SpecializedStation : public BaseStation {
 	 * @param index tested index
 	 * @return is this index valid index of T?
 	 */
-	static inline bool IsValidID(size_t index)
+	static inline bool IsValidID(auto index)
 	{
 		return BaseStation::IsValidID(index) && IsExpected(BaseStation::Get(index));
 	}
@@ -250,7 +250,7 @@ struct SpecializedStation : public BaseStation {
 	 * Gets station with given index
 	 * @return pointer to station with given index casted to T *
 	 */
-	static inline T *Get(size_t index)
+	static inline T *Get(auto index)
 	{
 		return (T *)BaseStation::Get(index);
 	}
@@ -259,7 +259,7 @@ struct SpecializedStation : public BaseStation {
 	 * Returns station if the index is a valid index for this station type
 	 * @return pointer to station with given index if it's a station of this type
 	 */
-	static inline T *GetIfValid(size_t index)
+	static inline T *GetIfValid(auto index)
 	{
 		return IsValidID(index) ? Get(index) : nullptr;
 	}

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -20,11 +20,11 @@
 #include "saveload/saveload.h"
 
 /** Unique identifier for a single cargo packet. */
-typedef uint32_t CargoPacketID;
+using CargoPacketID = PoolID<uint32_t, struct CargoPacketIDTag, 0xFFF000, 0xFFFFFF>;
 struct CargoPacket;
 
 /** Type of the pool for cargo packets for a little over 16 million packets. */
-using CargoPacketPool = Pool<CargoPacket, CargoPacketID, 1024, 0xFFF000, PoolType::Normal, true, false>;
+using CargoPacketPool = Pool<CargoPacket, CargoPacketID, 1024, CargoPacketID::End().base(), PoolType::Normal, true, false>;
 /** The actual pool with cargo packets. */
 extern CargoPacketPool _cargopacket_pool;
 

--- a/src/core/pool_func.hpp
+++ b/src/core/pool_func.hpp
@@ -124,7 +124,12 @@ DEFINE_POOL_METHOD(inline void *)::AllocateItem(size_t size, size_t index)
 	}
 	this->data[index] = item;
 	SetBit(this->used_bitmap[index / BITMAP_SIZE], index % BITMAP_SIZE);
-	item->index = (Tindex)(uint)index;
+	if constexpr (std::is_base_of_v<PoolIDBase, Tindex>) {
+		/* MSVC complains about casting to narrower type, so first cast to the base type... then to the strong type. */
+		item->index = static_cast<Tindex>(static_cast<Tindex::BaseType>(index));
+	} else {
+		item->index = static_cast<Tindex>(index);
+	}
 	return item;
 }
 

--- a/src/economy_base.h
+++ b/src/economy_base.h
@@ -14,7 +14,7 @@
 #include "company_type.h"
 
 /** Type of pool to store cargo payments in; little over 1 million. */
-typedef Pool<CargoPayment, CargoPaymentID, 512, 0xFF000> CargoPaymentPool;
+using CargoPaymentPool = Pool<CargoPayment, CargoPaymentID, 512, CargoPaymentID::End().base()>;
 /** The actual pool to store cargo payments in. */
 extern CargoPaymentPool _cargo_payment_pool;
 

--- a/src/economy_type.h
+++ b/src/economy_type.h
@@ -12,6 +12,7 @@
 
 #include "core/overflowsafe_type.hpp"
 #include "core/enum_type.hpp"
+#include "core/pool_type.hpp"
 
 typedef OverflowSafeInt64 Money;
 
@@ -254,6 +255,6 @@ static const uint ROAD_STOP_TRACKBIT_FACTOR = 2;
 static const uint LOCK_DEPOT_TILE_FACTOR = 2;
 
 struct CargoPayment;
-typedef uint32_t CargoPaymentID;
+using CargoPaymentID = PoolID<uint32_t, struct CargoPaymentIDTag, 0xFF000, 0xFFFFF>;
 
 #endif /* ECONOMY_TYPE_H */

--- a/src/goal_base.h
+++ b/src/goal_base.h
@@ -14,7 +14,7 @@
 #include "goal_type.h"
 #include "core/pool_type.hpp"
 
-typedef Pool<Goal, GoalID, 64, 64000> GoalPool;
+using GoalPool = Pool<Goal, GoalID, 64, GoalID::End().base()>;
 extern GoalPool _goal_pool;
 
 /** Struct about goals, current and completed */

--- a/src/goal_type.h
+++ b/src/goal_type.h
@@ -11,6 +11,7 @@
 #define GOAL_TYPE_H
 
 #include "core/enum_type.hpp"
+#include "core/pool_type.hpp"
 
 static const uint32_t GOAL_QUESTION_BUTTON_COUNT = 18; ///< Amount of buttons available.
 
@@ -34,8 +35,10 @@ enum GoalType : uint8_t {
 
 typedef uint32_t GoalTypeID; ///< Contains either tile, industry ID, town ID, company ID, or story page ID
 
-typedef uint16_t GoalID; ///< ID of a goal
+/** ID of a goal */
+using GoalID = PoolID<uint16_t, struct GoalIDTag, 64000, 0xFFFF>;
+
 struct Goal;
-static const GoalID INVALID_GOAL = 0xFFFF; ///< Constant representing a non-existing goal.
+static constexpr GoalID INVALID_GOAL = GoalID::Invalid(); ///< Constant representing a non-existing goal.
 
 #endif /* GOAL_TYPE_H */

--- a/src/league_base.h
+++ b/src/league_base.h
@@ -17,10 +17,10 @@
 
 bool IsValidLink(Link link);
 
-typedef Pool<LeagueTableElement, LeagueTableElementID, 64, 64000> LeagueTableElementPool;
+using LeagueTableElementPool = Pool<LeagueTableElement, LeagueTableElementID, 64, LeagueTableElementID::End().base()>;
 extern LeagueTableElementPool _league_table_element_pool;
 
-typedef Pool<LeagueTable, LeagueTableID, 4, 255> LeagueTablePool;
+using LeagueTablePool = Pool<LeagueTable, LeagueTableID, 4, LeagueTableID::End().base()>;
 extern LeagueTablePool _league_table_pool;
 
 

--- a/src/league_gui.cpp
+++ b/src/league_gui.cpp
@@ -298,9 +298,8 @@ private:
 	}
 
 public:
-	ScriptLeagueWindow(WindowDesc &desc, LeagueTableID table) : Window(desc)
+	ScriptLeagueWindow(WindowDesc &desc, WindowNumber table) : Window(desc), table(table)
 	{
-		this->table = table;
 		this->BuildTable();
 		this->InitNested(table);
 	}

--- a/src/league_type.h
+++ b/src/league_type.h
@@ -10,6 +10,8 @@
 #ifndef LEAGUE_TYPE_H
 #define LEAGUE_TYPE_H
 
+#include "core/pool_type.hpp"
+
 /** Types of the possible link targets. */
 enum LinkType : uint8_t {
 	LT_NONE = 0,         ///< No link
@@ -29,12 +31,12 @@ struct Link {
 	Link(): Link(LT_NONE, 0) {}
 };
 
-typedef uint8_t LeagueTableID; ///< ID of a league table
+using LeagueTableID = PoolID<uint8_t, struct LeagueTableIDTag, 255, 0xFF>; ///< ID of a league table
 struct LeagueTable;
-static const LeagueTableID INVALID_LEAGUE_TABLE = 0xFF; ///< Invalid/unknown index of LeagueTable
+static constexpr LeagueTableID INVALID_LEAGUE_TABLE = LeagueTableID::Invalid(); ///< Invalid/unknown index of LeagueTable
 
-typedef uint16_t LeagueTableElementID; ///< ID of a league table element
+using LeagueTableElementID = PoolID<uint16_t, struct LeagueTableElementIDTag, 64000, 0xFFFF>; ///< ID of a league table
 struct LeagueTableElement;
-static const LeagueTableElementID INVALID_LEAGUE_TABLE_ELEMENT = 0xFFFF; ///< Invalid/unknown index of LeagueTableElement
+static constexpr LeagueTableElementID INVALID_LEAGUE_TABLE_ELEMENT = LeagueTableElementID::Invalid(); ///< Invalid/unknown index of LeagueTableElement
 
 #endif /* LEAGUE_TYPE_H */

--- a/src/linkgraph/linkgraph.h
+++ b/src/linkgraph/linkgraph.h
@@ -24,7 +24,7 @@ class LinkGraph;
  * Type of the pool for link graph components. Each station can be in at up to
  * 32 link graphs. So we allow for plenty of them to be created.
  */
-typedef Pool<LinkGraph, LinkGraphID, 32, 0xFFFF> LinkGraphPool;
+using LinkGraphPool = Pool<LinkGraph, LinkGraphID, 32, LinkGraphID::End().base()>;
 /** The actual pool with link graphs. */
 extern LinkGraphPool _link_graph_pool;
 

--- a/src/linkgraph/linkgraph_type.h
+++ b/src/linkgraph/linkgraph_type.h
@@ -10,11 +10,13 @@
 #ifndef LINKGRAPH_TYPE_H
 #define LINKGRAPH_TYPE_H
 
-typedef uint16_t LinkGraphID;
-static const LinkGraphID INVALID_LINK_GRAPH = UINT16_MAX;
+#include "../core/pool_type.hpp"
 
-typedef uint16_t LinkGraphJobID;
-static const LinkGraphJobID INVALID_LINK_GRAPH_JOB = UINT16_MAX;
+using LinkGraphID = PoolID<uint16_t, struct LinkGraphIDTag, 0xFFFF, 0xFFFF>;
+static constexpr LinkGraphID INVALID_LINK_GRAPH = LinkGraphID::Invalid();
+
+using LinkGraphJobID = PoolID<uint16_t, struct LinkGraphJobIDTag, 0xFFFF, 0xFFFF>;
+static constexpr LinkGraphJobID INVALID_LINK_GRAPH_JOB = LinkGraphJobID::Invalid();
 
 typedef uint16_t NodeID;
 static const NodeID INVALID_NODE = UINT16_MAX;

--- a/src/linkgraph/linkgraphjob.h
+++ b/src/linkgraph/linkgraphjob.h
@@ -19,7 +19,7 @@ class Path;
 typedef std::list<Path *> PathList;
 
 /** Type of the pool for link graph jobs. */
-typedef Pool<LinkGraphJob, LinkGraphJobID, 32, 0xFFFF> LinkGraphJobPool;
+using LinkGraphJobPool = Pool<LinkGraphJob, LinkGraphJobID, 32, LinkGraphJobID::End().base()>;
 /** The actual pool with link graph jobs. */
 extern LinkGraphJobPool _link_graph_job_pool;
 

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -44,13 +44,13 @@ enum SpriteGroupType : uint8_t {
 };
 
 struct SpriteGroup;
-typedef uint32_t SpriteGroupID;
 struct ResolverObject;
 
 /* SPRITE_WIDTH is 24. ECS has roughly 30 sprite groups per real sprite.
  * Adding an 'extra' margin would be assuming 64 sprite groups per real
  * sprite. 64 = 2^6, so 2^30 should be enough (for now) */
-using SpriteGroupPool = Pool<SpriteGroup, SpriteGroupID, 1024, 1U << 30, PoolType::Data>;
+using SpriteGroupID = PoolID<uint32_t, struct SpriteGroupIDTag, 1U << 30, 0xFFFFFFFF>;
+using SpriteGroupPool = Pool<SpriteGroup, SpriteGroupID, 1024, SpriteGroupID::End().base(), PoolType::Data>;
 extern SpriteGroupPool _spritegroup_pool;
 
 /* Common wrapper for all the different sprite group types */

--- a/src/newgrf_storage.h
+++ b/src/newgrf_storage.h
@@ -186,10 +186,10 @@ void AddChangedPersistentStorage(BasePersistentStorageArray *storage);
 
 typedef PersistentStorageArray<int32_t, 16> OldPersistentStorage;
 
-typedef uint32_t PersistentStorageID;
+using PersistentStorageID = PoolID<uint32_t, struct PersistentStorageIDTag, 0xFF000, 0xFFFFF>;
 
 struct PersistentStorage;
-typedef Pool<PersistentStorage, PersistentStorageID, 1, 0xFF000> PersistentStoragePool;
+using PersistentStoragePool = Pool<PersistentStorage, PersistentStorageID, 1, PersistentStorageID::End().base()>;
 
 extern PersistentStoragePool _persistent_storage_pool;
 

--- a/src/object_base.h
+++ b/src/object_base.h
@@ -16,7 +16,7 @@
 #include "town_type.h"
 #include "timer/timer_game_calendar.h"
 
-typedef Pool<Object, ObjectID, 64, 0xFF0000> ObjectPool;
+using ObjectPool = Pool<Object, ObjectID, 64, ObjectID::End().base()>;
 extern ObjectPool _object_pool;
 
 /** An object, such as transmitter, on the map. */

--- a/src/object_map.h
+++ b/src/object_map.h
@@ -47,7 +47,7 @@ inline bool IsObjectTypeTile(Tile t, ObjectType type)
 inline ObjectID GetObjectIndex(Tile t)
 {
 	assert(IsTileType(t, MP_OBJECT));
-	return t.m2() | t.m5() << 16;
+	return ObjectID(t.m2() | t.m5() << 16);
 }
 
 /**
@@ -76,10 +76,10 @@ inline void MakeObject(Tile t, Owner o, ObjectID index, WaterClass wc, uint8_t r
 	SetTileType(t, MP_OBJECT);
 	SetTileOwner(t, o);
 	SetWaterClass(t, wc);
-	t.m2() = index;
+	t.m2() = index.base();
 	t.m3() = random;
 	t.m4() = 0;
-	t.m5() = index >> 16;
+	t.m5() = index.base() >> 16;
 	SB(t.m6(), 2, 4, 0);
 	t.m7() = 0;
 }

--- a/src/object_type.h
+++ b/src/object_type.h
@@ -10,6 +10,8 @@
 #ifndef OBJECT_TYPE_H
 #define OBJECT_TYPE_H
 
+#include "core/pool_type.hpp"
+
 /** Types of objects. */
 typedef uint16_t ObjectType;
 
@@ -25,11 +27,11 @@ static const ObjectType NUM_OBJECTS_PER_GRF = NUM_OBJECTS; ///< Number of suppor
 static const ObjectType INVALID_OBJECT_TYPE = 0xFFFF; ///< An invalid object
 
 /** Unique identifier for an object. */
-typedef uint32_t ObjectID;
+using ObjectID = PoolID<uint32_t, struct ObjectIDTag, 0xFF0000, 0xFFFFFFFF>;
 
 struct Object;
 struct ObjectSpec;
 
-static const ObjectID INVALID_OBJECT = 0xFFFFFFFF; ///< An invalid object
+static constexpr ObjectID INVALID_OBJECT = ObjectID::Invalid(); ///< An invalid object
 
 #endif /* OBJECT_TYPE_H */

--- a/src/order_backup.h
+++ b/src/order_backup.h
@@ -18,11 +18,11 @@
 #include "saveload/saveload.h"
 
 /** Unique identifier for an order backup. */
-typedef uint8_t OrderBackupID;
+using OrderBackupID = PoolID<uint8_t, struct OrderBackupIDTag, 255, 0xFF>;
 struct OrderBackup;
 
 /** The pool type for order backups. */
-typedef Pool<OrderBackup, OrderBackupID, 1, 256> OrderBackupPool;
+using OrderBackupPool = Pool<OrderBackup, OrderBackupID, 1, OrderBackupID::End().base()>;
 /** The pool with order backups. */
 extern OrderBackupPool _order_backup_pool;
 

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -20,8 +20,8 @@
 #include "timer/timer_game_tick.h"
 #include "saveload/saveload.h"
 
-typedef Pool<Order, OrderID, 256, 0xFF0000> OrderPool;
-typedef Pool<OrderList, OrderListID, 128, 64000> OrderListPool;
+using OrderPool = Pool<Order, OrderID, 256, OrderID::End().base()>;
+using OrderListPool = Pool<OrderList, OrderListID, 128, OrderListID::End().base()>;
 extern OrderPool _order_pool;
 extern OrderListPool _orderlist_pool;
 

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -380,7 +380,7 @@ static Order GetOrderCmdFromTile(const Vehicle *v, TileIndex tile)
 {
 	/* Override the index as it is not coming from a pool, so would not be initialised correctly. */
 	Order order;
-	order.index = 0;
+	order.index = OrderID::Begin();
 
 	/* check depot first */
 	if (IsDepotTypeTile(tile, (TransportType)(uint)v->type) && IsTileOwner(tile, _local_company)) {
@@ -665,7 +665,7 @@ private:
 	{
 		Order order;
 		order.next = nullptr;
-		order.index = 0;
+		order.index = OrderID::Begin();
 		order.MakeGoToDepot(INVALID_DEPOT, ODTFB_PART_OF_ORDERS,
 				_settings_client.gui.new_nonstop && this->vehicle->IsGroundVehicle() ? ONSF_NO_STOP_AT_INTERMEDIATE_STATIONS : ONSF_STOP_EVERYWHERE);
 		order.SetDepotActionType(ODATFB_NEAREST_DEPOT);
@@ -1221,7 +1221,7 @@ public:
 					if (order_id != INVALID_VEH_ORDER_ID) {
 						Order order;
 						order.next = nullptr;
-						order.index = 0;
+						order.index = OrderID::Begin();
 						order.MakeConditional(order_id);
 
 						Command<CMD_INSERT_ORDER>::Post(STR_ERROR_CAN_T_INSERT_NEW_ORDER, this->vehicle->tile, this->vehicle->index, this->OrderGetSel(), order);

--- a/src/order_type.h
+++ b/src/order_type.h
@@ -12,11 +12,12 @@
 
 #include "core/enum_type.hpp"
 #include "depot_type.h"
+#include "core/pool_type.hpp"
 #include "station_type.h"
 
 typedef uint8_t VehicleOrderID;  ///< The index of an order within its current vehicle (not pool related)
-typedef uint32_t OrderID;
-typedef uint16_t OrderListID;
+using OrderID = PoolID<uint32_t, struct OrderIDTag, 0xFF0000, 0xFFFFFF>;
+using OrderListID = PoolID<uint16_t, struct OrderListIDTag, 64000, 0xFFFF>;
 
 struct DestinationID {
 	using BaseType = uint16_t;
@@ -39,7 +40,7 @@ static const VehicleOrderID INVALID_VEH_ORDER_ID = 0xFF;
 static const VehicleOrderID MAX_VEH_ORDER_ID     = INVALID_VEH_ORDER_ID - 1;
 
 /** Invalid order (sentinel) */
-static const OrderID INVALID_ORDER = 0xFFFFFF;
+static constexpr OrderID INVALID_ORDER = OrderID::Invalid();
 
 /**
  * Maximum number of orders in implicit-only lists before we start searching

--- a/src/roadstop_base.h
+++ b/src/roadstop_base.h
@@ -15,7 +15,7 @@
 #include "core/bitmath_func.hpp"
 #include "vehicle_type.h"
 
-typedef Pool<RoadStop, RoadStopID, 32, 64000> RoadStopPool;
+using RoadStopPool = Pool<RoadStop, RoadStopID, 32, RoadStopID::End().base()>;
 extern RoadStopPool _roadstop_pool;
 
 /** A Stop for a Road Vehicle */

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2113,7 +2113,7 @@ bool AfterLoadGame()
 					o->location.h    = size;
 					o->build_date    = TimerGameCalendar::date;
 					o->town          = type == OBJECT_STATUE ? Town::Get(t.m2()) : CalcClosestTownFromTile(t, UINT_MAX);
-					t.m2() = o->index;
+					t.m2() = o->index.base();
 					Object::IncTypeCount(type);
 				} else {
 					/* We're at an offset, so get the ID from our "root". */

--- a/src/saveload/order_sl.cpp
+++ b/src/saveload/order_sl.cpp
@@ -164,7 +164,7 @@ struct ORDRChunkHandler : ChunkHandler {
 
 			/* Update all the next pointer */
 			for (Order *o : Order::Iterate()) {
-				size_t order_index = o->index;
+				size_t order_index = o->index.base();
 				/* Delete invalid orders */
 				if (o->IsType(OT_NOTHING)) {
 					delete o;

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -1316,6 +1316,7 @@ int64_t ReadValue(const void *ptr, VarType conv);
 void WriteValue(void *ptr, VarType conv, int64_t val);
 
 void SlSetArrayIndex(uint index);
+static void SlSetArrayIndex(const ConvertibleThroughBase auto &index) { SlSetArrayIndex(index.base()); }
 int SlIterateArray();
 
 void SlSetStructListLength(size_t length);

--- a/src/script/api/script_goal.cpp
+++ b/src/script/api/script_goal.cpp
@@ -55,7 +55,7 @@
 	if (!ScriptObject::Command<CMD_CREATE_GOAL>::Do(&ScriptInstance::DoCommandReturnGoalID, ScriptCompany::FromScriptCompanyID(company), (::GoalType)type, destination, text)) return GOAL_INVALID;
 
 	/* In case of test-mode, we return GoalID 0 */
-	return static_cast<GoalID>(0);
+	return GoalID::Begin();
 }
 
 /* static */ bool ScriptGoal::Remove(GoalID goal_id)

--- a/src/script/api/script_league.cpp
+++ b/src/script/api/script_league.cpp
@@ -41,7 +41,7 @@
 	if (!ScriptObject::Command<CMD_CREATE_LEAGUE_TABLE>::Do(&ScriptInstance::DoCommandReturnLeagueTableID, encoded_title, encoded_header, encoded_footer)) return LEAGUE_TABLE_INVALID;
 
 	/* In case of test-mode, we return LeagueTableID 0 */
-	return static_cast<LeagueTableID>(0);
+	return LeagueTableID::Begin();
 }
 
 /* static */ bool ScriptLeagueTable::IsValidLeagueTableElement(LeagueTableElementID element_id)
@@ -74,7 +74,7 @@
 	if (!ScriptObject::Command<CMD_CREATE_LEAGUE_TABLE_ELEMENT>::Do(&ScriptInstance::DoCommandReturnLeagueTableElementID, table, rating, c, encoded_text, encoded_score, (::LinkType)link_type, (::LinkTargetID)link_target)) return LEAGUE_TABLE_ELEMENT_INVALID;
 
 	/* In case of test-mode, we return LeagueTableElementID 0 */
-	return static_cast<LeagueTableElementID>(0);
+	return LeagueTableElementID::Begin();
 }
 
 /* static */ bool ScriptLeagueTable::UpdateElementData(LeagueTableElementID element, ScriptCompany::CompanyID company, Text *text, LinkType link_type, SQInteger link_target)

--- a/src/script/api/script_list.hpp
+++ b/src/script/api/script_list.hpp
@@ -43,13 +43,19 @@ private:
 	int modifications;            ///< Number of modification that has been done. To prevent changing data while valuating.
 
 protected:
+	/* Temporary helper functions to get the raw index from either strongly and non-strongly typed pool items. */
+	template <typename T>
+	static auto GetRawIndex(const T &index) { return index; }
+	template <ConvertibleThroughBase T>
+	static auto GetRawIndex(const T &index) { return index.base(); }
+
 	template <typename T, class ItemValid, class ItemFilter>
 	static void FillList(ScriptList *list, ItemValid item_valid, ItemFilter item_filter)
 	{
 		for (const T *item : T::Iterate()) {
 			if (!item_valid(item)) continue;
 			if (!item_filter(item)) continue;
-			list->AddItem(item->index);
+			list->AddItem(GetRawIndex(item->index));
 		}
 	}
 
@@ -99,7 +105,7 @@ protected:
 					/* Push the root table as instance object, this is what squirrel does for meta-functions. */
 					sq_pushroottable(vm);
 					/* Push all arguments for the valuator function. */
-					sq_pushinteger(vm, item->index);
+					sq_pushinteger(vm, GetRawIndex(item->index));
 					for (int i = 0; i < nparam - 1; i++) {
 						sq_push(vm, i + 3);
 					}

--- a/src/script/api/script_story_page.cpp
+++ b/src/script/api/script_story_page.cpp
@@ -56,7 +56,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 		c, title != nullptr ? title->GetEncodedText() : std::string{})) return STORY_PAGE_INVALID;
 
 	/* In case of test-mode, we return StoryPageID 0 */
-	return static_cast<StoryPageID>(0);
+	return StoryPageID::Begin();
 }
 
 /* static */ StoryPageElementID ScriptStoryPage::NewElement(StoryPageID story_page_id, StoryPageElementType type, SQInteger reference, Text *text)
@@ -103,7 +103,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 			encoded_text)) return STORY_PAGE_ELEMENT_INVALID;
 
 	/* In case of test-mode, we return StoryPageElementID 0 */
-	return static_cast<StoryPageElementID>(0);
+	return StoryPageElementID::Begin();
 }
 
 /* static */ bool ScriptStoryPage::UpdateElement(StoryPageElementID story_page_element_id, SQInteger reference, Text *text)

--- a/src/script/squirrel.hpp
+++ b/src/script/squirrel.hpp
@@ -11,6 +11,7 @@
 #define SQUIRREL_HPP
 
 #include <squirrel.h>
+#include "../core/convertible_through_base.hpp"
 
 /** The type of script we're working with, i.e. for who is it? */
 enum class ScriptType : uint8_t {
@@ -110,6 +111,8 @@ public:
 	 */
 	void AddConst(const char *var_name, uint value) { this->AddConst(var_name, (int)value); }
 
+	void AddConst(const char *var_name, const ConvertibleThroughBase auto &value) { this->AddConst(var_name, static_cast<int>(value.base())); }
+
 	/**
 	 * Adds a const to the stack. Depending on the current state this means
 	 *  either a const to a class or to the global space.
@@ -152,6 +155,7 @@ public:
 	void InsertResult(bool result);
 	void InsertResult(int result);
 	void InsertResult(uint result) { this->InsertResult((int)result); }
+	void InsertResult(ConvertibleThroughBase auto result) { this->InsertResult(static_cast<int>(result.base())); }
 
 	/**
 	 * Call a method of an instance, in various flavors.

--- a/src/station_type.h
+++ b/src/station_type.h
@@ -10,11 +10,12 @@
 #ifndef STATION_TYPE_H
 #define STATION_TYPE_H
 
+#include "core/pool_type.hpp"
 #include "core/smallstack_type.hpp"
 #include "tilearea_type.h"
 
 typedef uint16_t StationID;
-typedef uint16_t RoadStopID;
+using RoadStopID = PoolID<uint16_t, struct RoadStopIDTag, 64000, 0xFFFF>;
 
 struct BaseStation;
 struct Station;

--- a/src/story.cpp
+++ b/src/story.cpp
@@ -105,7 +105,7 @@ static void UpdateElement(StoryPageElement &pe, TileIndex tile, uint32_t referen
 			pe.referenced_id = tile.base();
 			break;
 		case SPET_GOAL:
-			pe.referenced_id = (GoalID)reference;
+			pe.referenced_id = reference;
 			break;
 		case SPET_BUTTON_PUSH:
 		case SPET_BUTTON_TILE:

--- a/src/story_base.h
+++ b/src/story_base.h
@@ -17,8 +17,8 @@
 #include "vehicle_type.h"
 #include "core/pool_type.hpp"
 
-typedef Pool<StoryPageElement, StoryPageElementID, 64, 64000> StoryPageElementPool;
-typedef Pool<StoryPage, StoryPageID, 64, 64000> StoryPagePool;
+using StoryPageElementPool = Pool<StoryPageElement, StoryPageElementID, 64, StoryPageElementID::End().base()>;
+using StoryPagePool = Pool<StoryPage, StoryPageID, 64, StoryPageID::End().base()>;
 extern StoryPageElementPool _story_page_element_pool;
 extern StoryPagePool _story_page_pool;
 extern uint32_t _story_page_element_next_sort_value;

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -251,11 +251,11 @@ protected:
 		for (const StoryPage *p : this->story_pages) {
 			bool current_page = p->index == this->selected_page_id;
 			if (!p->title.empty()) {
-				list.push_back(MakeDropDownListStringItem(p->title, p->index, current_page));
+				list.push_back(MakeDropDownListStringItem(p->title, p->index.base(), current_page));
 			} else {
 				/* No custom title => use a generic page title with page number. */
 				SetDParam(0, page_num);
-				list.push_back(MakeDropDownListStringItem(STR_STORY_BOOK_GENERIC_PAGE_ITEM, p->index, current_page));
+				list.push_back(MakeDropDownListStringItem(STR_STORY_BOOK_GENERIC_PAGE_ITEM, p->index.base(), current_page));
 			}
 			page_num++;
 		}
@@ -633,7 +633,7 @@ public:
 	void SetSelectedPage(StoryPageID page_index)
 	{
 		if (this->selected_page_id != page_index) {
-			if (this->active_button_id) ResetObjectToPlace();
+			if (this->active_button_id != 0) ResetObjectToPlace();
 			this->active_button_id = INVALID_STORY_PAGE_ELEMENT;
 			this->selected_page_id = page_index;
 			this->RefreshSelectedPage();

--- a/src/story_type.h
+++ b/src/story_type.h
@@ -11,15 +11,16 @@
 #define STORY_TYPE_H
 
 #include "core/enum_type.hpp"
+#include "core/pool_type.hpp"
 
-typedef uint16_t StoryPageElementID; ///< ID of a story page element
-typedef uint16_t StoryPageID; ///< ID of a story page
+using StoryPageElementID = PoolID<uint16_t, struct StoryPageElementIDTag, 64000, 0xFFFF>; ///< ID of a story page element
+using StoryPageID = PoolID<uint16_t, struct StoryPageIDTag, 64000, 0xFFFF>; ///< ID of a story page
 struct StoryPageElement;
 struct StoryPage;
 enum StoryPageElementType : uint8_t;
 
-static const StoryPageElementID INVALID_STORY_PAGE_ELEMENT = 0xFFFF; ///< Constant representing a non-existing story page element.
-static const StoryPageID INVALID_STORY_PAGE = 0xFFFF; ///< Constant representing a non-existing story page.
+static constexpr StoryPageElementID INVALID_STORY_PAGE_ELEMENT = StoryPageElementID::Invalid(); ///< Constant representing a non-existing story page element.
+static constexpr StoryPageID INVALID_STORY_PAGE = StoryPageID::Invalid(); ///< Constant representing a non-existing story page.
 
 #endif /* STORY_TYPE_H */
 

--- a/src/subsidy_base.h
+++ b/src/subsidy_base.h
@@ -15,7 +15,7 @@
 #include "subsidy_type.h"
 #include "core/pool_type.hpp"
 
-typedef Pool<Subsidy, SubsidyID, 1, 256> SubsidyPool;
+using SubsidyPool = Pool<Subsidy, SubsidyID, 1, SubsidyID::End().base()>;
 extern SubsidyPool _subsidy_pool;
 
 /** Struct about subsidies, offered and awarded */

--- a/src/subsidy_type.h
+++ b/src/subsidy_type.h
@@ -20,7 +20,7 @@ enum PartOfSubsidy : uint8_t {
 };
 DECLARE_ENUM_AS_BIT_SET(PartOfSubsidy)
 
-typedef uint16_t SubsidyID; ///< ID of a subsidy
+using SubsidyID = PoolID<uint16_t, struct SubsidyIDTag, 256, 0xFFFF>; ///< ID of a subsidy
 struct Subsidy;
 
 #endif /* SUBSIDY_TYPE_H */

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -278,7 +278,7 @@ struct TimetableWindow : Window {
 	int GetOrderFromTimetableWndPt(int y, [[maybe_unused]] const Vehicle *v)
 	{
 		int32_t sel = this->vscroll->GetScrolledRowFromWidget(y, this, WID_VT_TIMETABLE_PANEL, WidgetDimensions::scaled.framerect.top);
-		if (sel == INT32_MAX) return INVALID_ORDER;
+		if (sel == INT32_MAX) return INVALID_ORDER.base();
 		assert(IsInsideBS(sel, 0, v->GetNumOrders() * 2));
 		return sel;
 	}
@@ -645,7 +645,7 @@ struct TimetableWindow : Window {
 				int selected = GetOrderFromTimetableWndPt(pt.y, v);
 
 				this->CloseChildWindows();
-				this->sel_index = (selected == INVALID_ORDER || selected == this->sel_index) ? -1 : selected;
+				this->sel_index = (selected == INVALID_ORDER.base() || selected == this->sel_index) ? -1 : selected;
 				break;
 			}
 

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -663,7 +663,7 @@ static void AddDropDownLeagueTableOptions(DropDownList &list)
 {
 	if (LeagueTable::GetNumItems() > 0) {
 		for (LeagueTable *lt : LeagueTable::Iterate()) {
-			list.push_back(MakeDropDownListStringItem(lt->title, lt->index));
+			list.push_back(MakeDropDownListStringItem(lt->title, lt->index.base()));
 		}
 	} else {
 		list.push_back(MakeDropDownListStringItem(STR_GRAPH_MENU_COMPANY_LEAGUE_TABLE, LTMN_PERFORMANCE_LEAGUE));

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -1177,7 +1177,7 @@ struct SpecializedVehicle : public Vehicle {
 	 * @param index tested index
 	 * @return is this index valid index of T?
 	 */
-	static inline bool IsValidID(size_t index)
+	static inline bool IsValidID(auto index)
 	{
 		return Vehicle::IsValidID(index) && Vehicle::Get(index)->type == Type;
 	}
@@ -1186,7 +1186,7 @@ struct SpecializedVehicle : public Vehicle {
 	 * Gets vehicle with given index
 	 * @return pointer to vehicle with given index casted to T *
 	 */
-	static inline T *Get(size_t index)
+	static inline T *Get(auto index)
 	{
 		return (T *)Vehicle::Get(index);
 	}
@@ -1195,7 +1195,7 @@ struct SpecializedVehicle : public Vehicle {
 	 * Returns vehicle if the index is a valid index for this vehicle type
 	 * @return pointer to vehicle with given index if it's a vehicle of this type
 	 */
-	static inline T *GetIfValid(size_t index)
+	static inline T *GetIfValid(auto index)
 	{
 		return IsValidID(index) ? Get(index) : nullptr;
 	}

--- a/src/window_func.h
+++ b/src/window_func.h
@@ -36,6 +36,7 @@ void InputLoop();
 
 void InvalidateWindowData(WindowClass cls, WindowNumber number, int data = 0, bool gui_scope = false);
 void InvalidateWindowClassesData(WindowClass cls, int data = 0, bool gui_scope = false);
+void InvalidateWindowClassesData(WindowClass cls, ConvertibleThroughBase auto data, bool gui_scope = false) { InvalidateWindowClassesData(cls, data.base(), gui_scope); }
 
 void CloseNonVitalWindows();
 void CloseAllNonVitalWindows();


### PR DESCRIPTION
## Motivation / Problem

Pool item indices, e.g. GoalID, are currently weakly typed meaning these cannot be used in things like `std::variant`. Next to that making the indices strongly typed makes it less likely that things are assigned/passed incorrectly as parameters to a function.


## Description

* Introduce a new `PoolID` type that is similar to a strong typedef, but simpler and more importantly... it doesn't default construct the `index` field. This is required so the constructor of the types do not overwrite the pool item's index (everything would be getting index 0).
* Add some helper functions in the pool and some other places that allow PoolID types to be passed as parameters instead of only `size_t` or other integral values.
* PoolID provides a `::Begin()`, `::End()` and `::Invalid()` making these values coupled to the type and behaviour somewhat like an `enum class`, but as functions and not actual constants.
Preferably there would not be functions, but to define constants in other classes (e.g. the script API), they need to be `constexpr`. For constants to be `constexpr`, the must be of a literal type but because you are defining them within that literal type, the type isn't deemed literal yet. Also when you make a simple templated POD class, you cannot add `constexpr` constants (except in some versions of GCC).
* Convert all PoolID types except those that would be caught up in `NewsReference`, `ViewportKDTree` or `VehicleListIdentifier` and those related to the network (requires some type renaming for consistency, other PR).

Note that by adding `::End()` to  the mixin, once all pool item indices have been converted that parameter can be removed from the pool template and deduced from the passed index type. For now it means an ugly `.base()` to return an integral value though.


## Limitations

Does not convert every PoolID type, namely: CompanyID, DepotID, EngineID, GroupID, IndustryID, SignID, StationID, TownID, VehicleID, AdminID (AdminIndex), ClientPoolID (ClientIndex).
However, that is something for another PR as they are much more involved that these changes. They would also increase the size of this PR too much.

There are many `INVALID_XXX` constants left around. I have deliberately done that, as those blow up the size of the PR, though are trivial to perform. I suggest doing them in a separate PR as those are simply mass renames.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
