### PR TITLE
Codechange: replace MAX_UVALUE with std::numeric_limits::max

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -718,7 +718,7 @@ static void HandleBankruptcyTakeover(Company *c)
 	}
 
 	/* Did we ask everyone for bankruptcy? If so, bail out. */
-	if (c->bankrupt_asked == MAX_UVALUE(CompanyMask)) return;
+	if (c->bankrupt_asked == std::numeric_limits<CompanyMask>::max()) return;
 
 	Company *best = nullptr;
 	int32_t best_performance = -1;
@@ -736,7 +736,7 @@ static void HandleBankruptcyTakeover(Company *c)
 
 	/* Asked all companies? */
 	if (best_performance == -1) {
-		c->bankrupt_asked = MAX_UVALUE(CompanyMask);
+		c->bankrupt_asked = std::numeric_limits<CompanyMask>::max();
 		return;
 	}
 

--- a/src/core/pool_type.hpp
+++ b/src/core/pool_type.hpp
@@ -78,8 +78,15 @@ private:
  */
 template <class Titem, typename Tindex, size_t Tgrowth_step, size_t Tmax_size, PoolType Tpool_type = PT_NORMAL, bool Tcache = false, bool Tzero = true>
 struct Pool : PoolBase {
+private:
+	/** Some helper functions to get the maximum value of the provided index. */
+	template <typename T>
+	static constexpr size_t GetMaxIndexValue(T) { return std::numeric_limits<T>::max(); }
+	template <typename T> requires std::is_enum_v<T>
+	static constexpr size_t GetMaxIndexValue(T) { return std::numeric_limits<std::underlying_type_t<T>>::max(); }
+public:
 	/* Ensure the highest possible index, i.e. Tmax_size -1, is within the bounds of Tindex. */
-	static_assert(Tmax_size - 1 <= MAX_UVALUE(Tindex));
+	static_assert(Tmax_size - 1 <= GetMaxIndexValue(Tindex{}));
 
 	static constexpr size_t MAX_SIZE = Tmax_size; ///< Make template parameter accessible from outside
 
@@ -388,7 +395,7 @@ struct Pool : PoolBase {
 	};
 
 private:
-	static const size_t NO_FREE_ITEM = MAX_UVALUE(size_t); ///< Constant to indicate we can't allocate any more items
+	static const size_t NO_FREE_ITEM = std::numeric_limits<size_t>::max(); ///< Constant to indicate we can't allocate any more items
 
 	/**
 	 * Helper struct to cache 'freed' PoolItems so we

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -627,7 +627,7 @@ static void CompanyCheckBankrupt(Company *c)
 				 * is no THE-END, otherwise mark the client as spectator to make sure
 				 * they are no longer in control of this company. However... when you
 				 * join another company (cheat) the "unowned" company can bankrupt. */
-				c->bankrupt_asked = MAX_UVALUE(CompanyMask);
+				c->bankrupt_asked = std::numeric_limits<CompanyMask>::max();
 				break;
 			}
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -744,7 +744,7 @@ void StartupOneEngine(Engine *e, const TimerGameCalendar::YearMonthDay &aging_ym
 		int intro_months = intro_ymd.year.base() * 12 + intro_ymd.month;
 		if (intro_ymd.day > 1) intro_months++; // Engines are introduced at the first month start at/after intro date.
 		e->age = aging_months - intro_months;
-		e->company_avail = MAX_UVALUE(CompanyMask);
+		e->company_avail = std::numeric_limits<CompanyMask>::max();
 		e->flags.Set(EngineFlag::Available);
 	}
 
@@ -885,7 +885,7 @@ static void AcceptEnginePreview(EngineID eid, CompanyID company, int recursion_d
 	Engine *e = Engine::Get(eid);
 
 	e->preview_company = INVALID_COMPANY;
-	e->preview_asked = MAX_UVALUE(CompanyMask);
+	e->preview_asked = std::numeric_limits<CompanyMask>::max();
 
 	EnableEngineForCompany(eid, company);
 
@@ -980,7 +980,7 @@ static IntervalTimer<TimerGameCalendar> _calendar_engines_daily({TimerGameCalend
 				e->preview_company = GetPreviewCompany(e);
 
 				if (e->preview_company == INVALID_COMPANY) {
-					e->preview_asked = MAX_UVALUE(CompanyMask);
+					e->preview_asked = std::numeric_limits<CompanyMask>::max();
 					continue;
 				}
 
@@ -1109,7 +1109,7 @@ static void NewVehicleAvailable(Engine *e)
 	AddRemoveEngineFromAutoreplaceAndBuildWindows(e->type);
 
 	/* Now available for all companies */
-	e->company_avail = MAX_UVALUE(CompanyMask);
+	e->company_avail = std::numeric_limits<CompanyMask>::max();
 
 	/* Do not introduce new rail wagons */
 	if (IsWagon(index)) return;

--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -106,7 +106,7 @@ enum WindowKeyCodes : uint16_t {
 
 /** A single sprite of a list of animated cursors */
 struct AnimCursor {
-	static const CursorID LAST = MAX_UVALUE(CursorID);
+	static const CursorID LAST = std::numeric_limits<CursorID>::max();
 	CursorID sprite;   ///< Must be set to LAST_ANIM when it is the last sprite of the loop
 	uint8_t display_time; ///< Amount of ticks this sprite will be shown
 };

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -224,7 +224,7 @@ void Industry::PostDestructor(size_t)
 {
 	if (Industry::GetNumItems() == 0) return nullptr;
 	int num = RandomRange((uint16_t)Industry::GetNumItems());
-	size_t index = MAX_UVALUE(size_t);
+	size_t index = std::numeric_limits<size_t>::max();
 
 	while (num >= 0) {
 		num--;

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -38,7 +38,7 @@ AirportTileOverrideManager _airporttile_mngr(NEW_AIRPORTTILE_OFFSET, NUM_AIRPORT
 {
 	/* should be assert(gfx < lengthof(tiles)), but that gives compiler warnings
 	 * since it's always true if the following holds: */
-	static_assert(MAX_UVALUE(StationGfx) + 1 == lengthof(tiles));
+	static_assert(std::numeric_limits<StationGfx>::max() + 1 == lengthof(tiles));
 	return &AirportTileSpec::tiles[gfx];
 }
 

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -300,7 +300,7 @@ public:
 	{
 		switch (widget) {
 			case WID_BO_OBJECT_SPRITE:
-				if (_object_gui.sel_type != MAX_UVALUE(uint16_t)) {
+				if (_object_gui.sel_type != std::numeric_limits<uint16_t>::max()) {
 					_object_gui.sel_view = this->GetWidget<NWidgetBase>(widget)->GetParentWidget<NWidgetMatrix>()->GetCurrentElement();
 					this->InvalidateData(PickerWindow::PFI_POSITION);
 					if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2041,15 +2041,15 @@ bool AfterLoadGame()
 
 		/* More companies ... */
 		for (Company *c : Company::Iterate()) {
-			if (c->bankrupt_asked == 0xFF) c->bankrupt_asked = MAX_UVALUE(CompanyMask);
+			if (c->bankrupt_asked == 0xFF) c->bankrupt_asked = std::numeric_limits<CompanyMask>::max();
 		}
 
 		for (Engine *e : Engine::Iterate()) {
-			if (e->company_avail == 0xFF) e->company_avail = MAX_UVALUE(CompanyMask);
+			if (e->company_avail == 0xFF) e->company_avail = std::numeric_limits<CompanyMask>::max();
 		}
 
 		for (Town *t : Town::Iterate()) {
-			if (t->have_ratings == 0xFF) t->have_ratings = MAX_UVALUE(CompanyMask);
+			if (t->have_ratings == 0xFF) t->have_ratings = std::numeric_limits<CompanyMask>::max();
 			for (uint i = 8; i != MAX_COMPANIES; i++) t->ratings[i] = RATING_INITIAL;
 		}
 	}

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -109,7 +109,7 @@ struct ENGNChunkHandler : ChunkHandler {
 				 * Just cancel any previews. */
 				e->flags.Reset(EngineFlag{4}); // ENGINE_OFFER_WINDOW_OPEN
 				e->preview_company = INVALID_COMPANY;
-				e->preview_asked = MAX_UVALUE(CompanyMask);
+				e->preview_asked = std::numeric_limits<CompanyMask>::max();
 			}
 		}
 	}

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -406,7 +406,7 @@ static bool FixTTOEngines()
 			/* Make sure for example monorail and maglev are available when they should be */
 			if (TimerGameCalendar::date >= e->intro_date && HasBit(e->info.climates, 0)) {
 				e->flags.Set(EngineFlag::Available);
-				e->company_avail = MAX_UVALUE(CompanyMask);
+				e->company_avail = std::numeric_limits<CompanyMask>::max();
 				e->age = TimerGameCalendar::date > e->intro_date ? (TimerGameCalendar::date - e->intro_date).base() / 30 : 0;
 			}
 		} else {
@@ -431,7 +431,7 @@ static bool FixTTOEngines()
 			 * if at least one of them was available. */
 			for (uint j = 0; j < lengthof(tto_to_ttd); j++) {
 				if (tto_to_ttd[j] == i && _old_engines[j].company_avail != 0) {
-					e->company_avail = MAX_UVALUE(CompanyMask);
+					e->company_avail = std::numeric_limits<CompanyMask>::max();
 					e->flags.Set(EngineFlag::Available);
 					break;
 				}
@@ -441,7 +441,7 @@ static bool FixTTOEngines()
 		}
 
 		e->preview_company = INVALID_COMPANY;
-		e->preview_asked = MAX_UVALUE(CompanyMask);
+		e->preview_asked = std::numeric_limits<CompanyMask>::max();
 		e->preview_wait = 0;
 		e->name = std::string{};
 	}

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -724,7 +724,7 @@ protected:
 	 */
 	inline CompanyMask GetOverlayCompanyMask() const
 	{
-		return Company::IsValidID(_local_company) ? 1U << _local_company : MAX_UVALUE(CompanyMask);
+		return Company::IsValidID(_local_company) ? 1U << _local_company : std::numeric_limits<CompanyMask>::max();
 	}
 
 	/** Blink the industries (if selected) on a regular interval. */

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -333,12 +333,6 @@ inline void free(const void *ptr)
 	free(const_cast<void *>(ptr));
 }
 
-/**
- * The largest value that can be entered in a variable
- * @param type the type of the variable
- */
-#define MAX_UVALUE(type) (static_cast<type>(~static_cast<type>(0)))
-
 #if defined(_MSC_VER) && !defined(_DEBUG)
 #	define IGNORE_UNINITIALIZED_WARNING_START __pragma(warning(push)) __pragma(warning(disable:4700))
 #	define IGNORE_UNINITIALIZED_WARNING_STOP __pragma(warning(pop))

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -197,7 +197,7 @@ void Town::InitializeLayout(TownLayout layout)
 {
 	if (Town::GetNumItems() == 0) return nullptr;
 	int num = RandomRange((uint16_t)Town::GetNumItems());
-	size_t index = MAX_UVALUE(size_t);
+	size_t index = std::numeric_limits<size_t>::max();
 
 	while (num >= 0) {
 		num--;


### PR DESCRIPTION
## Motivation / Problem

Macro bad, C++ better.

Also making it C++ makes it easier to have the same functionality work with other types by means of overloads.


## Description

Replace `UVALUE(x)` with `std::numeric_limits<x>::max()`.

Do some faffing about in the pool code so it can get the maximum index value for both enums and integral types. Preferably the pool's indices would not be having different types of types (i.e. enum vs integral vs strong type), but that's something for another set of PRs.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
