### PR TITLE
Codechange: Remove unused GenWorldStatus::next_update

### DIFF
--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -1348,7 +1348,6 @@ struct GenWorldStatus {
 	StringID cls;
 	uint current;
 	uint total;
-	std::chrono::steady_clock::time_point next_update;
 };
 
 static GenWorldStatus _gws;
@@ -1456,7 +1455,6 @@ void PrepareGenerateWorldProgress()
 	_gws.current = 0;
 	_gws.total = 0;
 	_gws.percent = 0;
-	_gws.next_update = std::chrono::steady_clock::now();
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

`GenWorldStatus::next_update` is written but never read, since 970fedd78cef3f5ef7a26fcaf4fd9db0f6abbe4b, #8830.

## Description

Remove it.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
