### PR TITLE
Codechange: make some types used as ID in pools enums

### DIFF
--- a/src/cargomonitor.cpp
+++ b/src/cargomonitor.cpp
@@ -122,7 +122,7 @@ void AddCargoDelivery(CargoType cargo_type, CompanyID company, uint32_t amount, 
 		/* Handle pickup update. */
 		switch (src.type) {
 			case SourceType::Industry: {
-				CargoMonitorID num = EncodeCargoIndustryMonitor(company, cargo_type, src.id);
+				CargoMonitorID num = EncodeCargoIndustryMonitor(company, cargo_type, static_cast<IndustryID>(src.id));
 				CargoMonitorMap::iterator iter = _cargo_pickups.find(num);
 				if (iter != _cargo_pickups.end()) iter->second += amount;
 				break;

--- a/src/cargomonitor.cpp
+++ b/src/cargomonitor.cpp
@@ -128,7 +128,7 @@ void AddCargoDelivery(CargoType cargo_type, CompanyID company, uint32_t amount, 
 				break;
 			}
 			case SourceType::Town: {
-				CargoMonitorID num = EncodeCargoTownMonitor(company, cargo_type, src.id);
+				CargoMonitorID num = EncodeCargoTownMonitor(company, cargo_type, static_cast<TownID>(src.id));
 				CargoMonitorMap::iterator iter = _cargo_pickups.find(num);
 				if (iter != _cargo_pickups.end()) iter->second += amount;
 				break;

--- a/src/cargomonitor.h
+++ b/src/cargomonitor.h
@@ -125,7 +125,7 @@ inline bool MonitorMonitorsIndustry(CargoMonitorID num)
 inline IndustryID DecodeMonitorIndustry(CargoMonitorID num)
 {
 	if (!MonitorMonitorsIndustry(num)) return INVALID_INDUSTRY;
-	return GB(num, CCB_TOWN_IND_NUMBER_START, CCB_TOWN_IND_NUMBER_LENGTH);
+	return static_cast<IndustryID>(GB(num, CCB_TOWN_IND_NUMBER_START, CCB_TOWN_IND_NUMBER_LENGTH));
 }
 
 /**

--- a/src/cargomonitor.h
+++ b/src/cargomonitor.h
@@ -136,7 +136,7 @@ inline IndustryID DecodeMonitorIndustry(CargoMonitorID num)
 inline TownID DecodeMonitorTown(CargoMonitorID num)
 {
 	if (MonitorMonitorsIndustry(num)) return INVALID_TOWN;
-	return GB(num, CCB_TOWN_IND_NUMBER_START, CCB_TOWN_IND_NUMBER_LENGTH);
+	return static_cast<TownID>(GB(num, CCB_TOWN_IND_NUMBER_START, CCB_TOWN_IND_NUMBER_LENGTH));
 }
 
 void ClearCargoPickupMonitoring(CompanyID company = INVALID_OWNER);

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -1017,7 +1017,7 @@ public:
 			}
 		} else {
 			/* Setting group livery */
-			Command<CMD_SET_GROUP_LIVERY>::Post(this->sel, widget == WID_SCL_PRI_COL_DROPDOWN, colour);
+			Command<CMD_SET_GROUP_LIVERY>::Post(static_cast<GroupID>(this->sel), widget == WID_SCL_PRI_COL_DROPDOWN, colour);
 		}
 	}
 

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -899,7 +899,7 @@ struct DepotWindow : Window {
 		}
 
 		/* Show tooltip window */
-		SetDParam(0, whole_chain ? num : v->engine_type);
+		SetDParam(0, whole_chain ? num : static_cast<uint>(v->engine_type));
 		SetDParamStr(1, details);
 		GuiShowTooltips(this, whole_chain ? STR_DEPOT_VEHICLE_TOOLTIP_CHAIN : STR_DEPOT_VEHICLE_TOOLTIP, TCC_RIGHT_CLICK, 2);
 

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1114,7 +1114,7 @@ static Money DeliverGoods(int num_pieces, CargoType cargo_type, StationID dest, 
 	Station *st = Station::Get(dest);
 
 	/* Give the goods to the industry. */
-	uint accepted_ind = DeliverGoodsToIndustry(st, cargo_type, num_pieces, src.type == SourceType::Industry ? src.id : INVALID_INDUSTRY, company->index);
+	uint accepted_ind = DeliverGoodsToIndustry(st, cargo_type, num_pieces, src.type == SourceType::Industry ? static_cast<IndustryID>(src.id) : INVALID_INDUSTRY, company->index);
 
 	/* If this cargo type is always accepted, accept all */
 	uint accepted_total = HasBit(st->always_accepted, cargo_type) ? num_pieces : accepted_ind;

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -508,7 +508,7 @@ bool Engine::IsVariantHidden(CompanyID c) const
  */
 void EngineOverrideManager::ResetToDefaultMapping()
 {
-	EngineID id = 0;
+	EngineID id = ENGINE_BEGIN;
 	for (VehicleType type = VEH_TRAIN; type <= VEH_AIRCRAFT; type++) {
 		auto &map = this->mappings[type];
 		map.clear();

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -32,7 +32,7 @@ enum class EngineDisplayFlag : uint8_t {
 
 using EngineDisplayFlags = EnumBitSet<EngineDisplayFlag, uint8_t>;
 
-typedef Pool<Engine, EngineID, 64, 64000> EnginePool;
+typedef Pool<Engine, EngineID, 64, ENGINE_END> EnginePool;
 extern EnginePool _engine_pool;
 
 struct Engine : EnginePool::PoolItem<&_engine_pool> {

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -83,7 +83,7 @@ struct EnginePreviewWindow : Window {
 		if (widget != WID_EP_QUESTION) return;
 
 		/* Get size of engine sprite, on loan from depot_gui.cpp */
-		EngineID engine = this->window_number;
+		EngineID engine = static_cast<EngineID>(this->window_number);
 		EngineImageType image_type = EIT_PURCHASE;
 		uint x, y;
 		int x_offs, y_offs;
@@ -109,7 +109,7 @@ struct EnginePreviewWindow : Window {
 	{
 		if (widget != WID_EP_QUESTION) return;
 
-		EngineID engine = this->window_number;
+		EngineID engine = static_cast<EngineID>(this->window_number);
 		SetDParam(0, GetEngineCategoryName(engine));
 		int y = DrawStringMultiLine(r, STR_ENGINE_PREVIEW_MESSAGE, TC_FROMSTRING, SA_HOR_CENTER | SA_TOP) + WidgetDimensions::scaled.vsep_wide;
 
@@ -127,7 +127,7 @@ struct EnginePreviewWindow : Window {
 	{
 		switch (widget) {
 			case WID_EP_YES:
-				Command<CMD_WANT_ENGINE_PREVIEW>::Post(this->window_number);
+				Command<CMD_WANT_ENGINE_PREVIEW>::Post(static_cast<EngineID>(this->window_number));
 				[[fallthrough]];
 			case WID_EP_NO:
 				if (!_shift_pressed) this->Close();
@@ -139,7 +139,7 @@ struct EnginePreviewWindow : Window {
 	{
 		if (!gui_scope) return;
 
-		EngineID engine = this->window_number;
+		EngineID engine = static_cast<EngineID>(this->window_number);
 		if (Engine::Get(engine)->preview_company != _local_company) this->Close();
 	}
 };

--- a/src/engine_type.h
+++ b/src/engine_type.h
@@ -20,7 +20,13 @@
 #include "sound_type.h"
 #include "strings_type.h"
 
-typedef uint16_t EngineID; ///< Unique identification number of an engine.
+/** Unique identification number of an engine. */
+enum EngineID : uint16_t {
+	ENGINE_BEGIN = 0,
+	ENGINE_END = 64000,
+	INVALID_ENGINE = 0xFFFF ///< Constant denoting an invalid engine.
+};
+DECLARE_INCREMENT_DECREMENT_OPERATORS(EngineID)
 
 struct Engine;
 
@@ -212,7 +218,5 @@ inline uint64_t PackEngineNameDParam(EngineID engine_id, EngineNameContext conte
 }
 
 static const uint MAX_LENGTH_ENGINE_NAME_CHARS = 32; ///< The maximum length of an engine name in characters including '\0'
-
-static const EngineID INVALID_ENGINE = 0xFFFF; ///< Constant denoting an invalid engine.
 
 #endif /* ENGINE_TYPE_H */

--- a/src/group.h
+++ b/src/group.h
@@ -17,7 +17,7 @@
 #include "engine_type.h"
 #include "livery.h"
 
-typedef Pool<Group, GroupID, 16, 64000> GroupPool;
+typedef Pool<Group, GroupID, 16, GROUP_END> GroupPool;
 extern GroupPool _group_pool; ///< Pool of groups.
 
 /** Statistics and caches on the vehicles in a group. */

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -986,7 +986,7 @@ public:
 
 	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (str.has_value()) Command<CMD_ALTER_GROUP>::Post(STR_ERROR_GROUP_CAN_T_RENAME, AlterGroupMode::Rename, this->group_rename, 0, *str);
+		if (str.has_value()) Command<CMD_ALTER_GROUP>::Post(STR_ERROR_GROUP_CAN_T_RENAME, AlterGroupMode::Rename, this->group_rename, INVALID_GROUP, *str);
 		this->group_rename = INVALID_GROUP;
 	}
 

--- a/src/group_type.h
+++ b/src/group_type.h
@@ -10,12 +10,14 @@
 #ifndef GROUP_TYPE_H
 #define GROUP_TYPE_H
 
-typedef uint16_t GroupID; ///< Type for all group identifiers.
-
-static const GroupID NEW_GROUP     = 0xFFFC; ///< Sentinel for a to-be-created group.
-static const GroupID ALL_GROUP     = 0xFFFD; ///< All vehicles are in this group.
-static const GroupID DEFAULT_GROUP = 0xFFFE; ///< Ungrouped vehicles are in this group.
-static const GroupID INVALID_GROUP = 0xFFFF; ///< Sentinel for invalid groups.
+enum GroupID : uint16_t {
+	GROUP_BEGIN = 0,
+	GROUP_END = 64000,
+	NEW_GROUP = 0xFFFC, ///< Sentinel for a to-be-created group.
+	ALL_GROUP = 0xFFFD, ///< All vehicles are in this group.
+	DEFAULT_GROUP = 0xFFFE, ///< Ungrouped vehicles are in this group.
+	INVALID_GROUP = 0xFFFF ///< Sentinel for invalid groups.
+};
 
 static const uint MAX_LENGTH_GROUP_NAME_CHARS = 32; ///< The maximum length of a group name in characters including '\0'
 

--- a/src/industry.h
+++ b/src/industry.h
@@ -20,7 +20,7 @@
 #include "timer/timer_game_economy.h"
 
 
-typedef Pool<Industry, IndustryID, 64, 64000> IndustryPool;
+typedef Pool<Industry, IndustryID, 64, INDUSTRY_END> IndustryPool;
 extern IndustryPool _industry_pool;
 
 static const TimerGameEconomy::Year PROCESSING_INDUSTRY_ABANDONMENT_YEARS{5}; ///< If a processing industry doesn't produce for this many consecutive economy years, it may close.

--- a/src/industry_map.h
+++ b/src/industry_map.h
@@ -63,7 +63,7 @@ enum IndustryGraphics : uint8_t {
 inline IndustryID GetIndustryIndex(Tile t)
 {
 	assert(IsTileType(t, MP_INDUSTRY));
-	return t.m2();
+	return static_cast<IndustryID>(t.m2());
 }
 
 /**

--- a/src/industry_type.h
+++ b/src/industry_type.h
@@ -10,15 +10,18 @@
 #ifndef INDUSTRY_TYPE_H
 #define INDUSTRY_TYPE_H
 
-typedef uint16_t IndustryID;
+enum IndustryID : uint16_t {
+	INDUSTRY_BEGIN = 0,
+	INDUSTRY_END = 64000,
+	INVALID_INDUSTRY = 0xFFFF
+};
+
 typedef uint16_t IndustryGfx;
 typedef uint8_t IndustryType;
 struct Industry;
 
 struct IndustrySpec;
 struct IndustryTileSpec;
-
-static const IndustryID INVALID_INDUSTRY = 0xFFFF;
 
 static const IndustryType NUM_INDUSTRYTYPES_PER_GRF = 128;            ///< maximum number of industry types per NewGRF; limited to 128 because bit 7 has a special meaning in some variables/callbacks (see MapNewGRFIndustryType).
 

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -141,7 +141,7 @@ struct SelectGameWindow : public Window {
 				for (char c : match[2].str()) {
 					if (isdigit(c)) {
 						if (id_type == ID_VEHICLE) {
-							vc.vehicle = vc.vehicle * 10 + (c - '0');
+							vc.vehicle = static_cast<VehicleID>(vc.vehicle * 10 + (c - '0'));
 						}
 					} else {
 						id_type = ID_NONE;
@@ -155,7 +155,7 @@ struct SelectGameWindow : public Window {
 							case 'C': vc.align_h = IntroGameViewportCommand::CENTRE; break;
 							case 'R': vc.align_h = IntroGameViewportCommand::RIGHT; break;
 							case 'P': vc.pan_to_next = true; break;
-							case 'V': id_type = ID_VEHICLE; vc.vehicle = 0; break;
+							case 'V': id_type = ID_VEHICLE; vc.vehicle = VEHICLE_BEGIN; break;
 						}
 					}
 				}

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1336,7 +1336,7 @@ static ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, B
 				break;
 
 			case 0x2F: // Engine variant
-				ei->variant_id = buf.ReadWord();
+				ei->variant_id = static_cast<EngineID>(buf.ReadWord());
 				break;
 
 			case 0x30: // Extra miscellaneous flags
@@ -1547,7 +1547,7 @@ static ChangeInfoResult RoadVehicleChangeInfo(uint first, uint last, int prop, B
 			}
 
 			case 0x26: // Engine variant
-				ei->variant_id = buf.ReadWord();
+				ei->variant_id = static_cast<EngineID>(buf.ReadWord());
 				break;
 
 			case 0x27: // Extra miscellaneous flags
@@ -1736,7 +1736,7 @@ static ChangeInfoResult ShipVehicleChangeInfo(uint first, uint last, int prop, B
 			}
 
 			case 0x20: // Engine variant
-				ei->variant_id = buf.ReadWord();
+				ei->variant_id = static_cast<EngineID>(buf.ReadWord());
 				break;
 
 			case 0x21: // Extra miscellaneous flags
@@ -1919,7 +1919,7 @@ static ChangeInfoResult AircraftVehicleChangeInfo(uint first, uint last, int pro
 				break;
 
 			case 0x20: // Engine variant
-				ei->variant_id = buf.ReadWord();
+				ei->variant_id = static_cast<EngineID>(buf.ReadWord());
 				break;
 
 			case 0x21: // Extra miscellaneous flags

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1333,7 +1333,7 @@ void CommitVehicleListOrderChanges()
 {
 	/* Build a list of EngineIDs. EngineIDs are sequential from 0 up to the number of pool items with no gaps. */
 	std::vector<EngineID> ordering(Engine::GetNumItems());
-	std::iota(std::begin(ordering), std::end(ordering), 0);
+	std::iota(std::begin(ordering), std::end(ordering), ENGINE_BEGIN);
 
 	/* Pre-sort engines by scope-grfid and local index */
 	std::ranges::sort(ordering, EnginePreSort);

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -458,7 +458,7 @@ struct NewsWindow : Window {
 
 			case WID_N_VEH_INFO: {
 				assert(this->ni->reftype1 == NewsReferenceType::Engine);
-				EngineID engine = this->ni->ref1;
+				EngineID engine = static_cast<EngineID>(this->ni->ref1);
 				str = GetEngineInfoString(engine);
 				break;
 			}
@@ -542,14 +542,14 @@ struct NewsWindow : Window {
 
 			case WID_N_VEH_SPR: {
 				assert(this->ni->reftype1 == NewsReferenceType::Engine);
-				EngineID engine = this->ni->ref1;
+				EngineID engine = static_cast<EngineID>(this->ni->ref1);
 				DrawVehicleEngine(r.left, r.right, CenterBounds(r.left, r.right, 0), CenterBounds(r.top, r.bottom, 0), engine, GetEnginePalette(engine, _local_company), EIT_PREVIEW);
 				GfxFillRect(r.left, r.top, r.right, r.bottom, PALETTE_NEWSPAPER, FILLRECT_RECOLOUR);
 				break;
 			}
 			case WID_N_VEH_INFO: {
 				assert(this->ni->reftype1 == NewsReferenceType::Engine);
-				EngineID engine = this->ni->ref1;
+				EngineID engine = static_cast<EngineID>(this->ni->ref1);
 				DrawStringMultiLine(r.left, r.right, r.top, r.bottom, GetEngineInfoString(engine), TC_FROMSTRING, SA_CENTER);
 				break;
 			}
@@ -678,7 +678,7 @@ private:
 	StringID GetNewVehicleMessageString(WidgetID widget) const
 	{
 		assert(this->ni->reftype1 == NewsReferenceType::Engine);
-		EngineID engine = this->ni->ref1;
+		EngineID engine = static_cast<EngineID>(this->ni->ref1);
 
 		switch (widget) {
 			case WID_N_VEH_TITLE:

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1008,7 +1008,7 @@ bool AfterLoadGame()
 					if ((GB(t.m5(), 4, 2) == ROAD_TILE_CROSSING ? (Owner)t.m3() : GetTileOwner(t)) == OWNER_TOWN) {
 						SetTownIndex(t, CalcClosestTownFromTile(t)->index);
 					} else {
-						SetTownIndex(t, 0);
+						SetTownIndex(t, TOWN_BEGIN);
 					}
 					break;
 
@@ -1232,7 +1232,7 @@ bool AfterLoadGame()
 								GetRailType(t)
 							);
 						} else {
-							TownID town = IsTileOwner(t, OWNER_TOWN) ? ClosestTownFromTile(t, UINT_MAX)->index : 0;
+							TownID town = IsTileOwner(t, OWNER_TOWN) ? ClosestTownFromTile(t, UINT_MAX)->index : TOWN_BEGIN;
 
 							/* MakeRoadNormal */
 							SetTileType(t, MP_ROAD);

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -101,7 +101,7 @@ struct ENGNChunkHandler : ChunkHandler {
 		 * engine pool after processing NewGRFs by CopyTempEngineData(). */
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			Engine *e = GetTempDataEngine(index);
+			Engine *e = GetTempDataEngine(static_cast<EngineID>(index));
 			SlObject(e, slt);
 
 			if (IsSavegameVersionBefore(SLV_179)) {
@@ -167,7 +167,7 @@ struct ENGSChunkHandler : ChunkHandler {
 		SlCopy(names, lengthof(names), SLE_STRINGID);
 
 		/* Copy each string into the temporary engine array. */
-		for (EngineID engine = 0; engine < lengthof(names); engine++) {
+		for (EngineID engine = ENGINE_BEGIN; engine < lengthof(names); engine++) {
 			Engine *e = GetTempDataEngine(engine);
 			e->name = CopyFromOldName(names[engine]);
 		}
@@ -221,7 +221,7 @@ struct EIDSChunkHandler : ChunkHandler {
 		while ((index = SlIterateArray()) != -1) {
 			EngineIDMapping eid;
 			SlObject(&eid, slt);
-			_engine_mngr.SetID(eid.type, eid.internal_id, eid.grfid, eid.substitute_id, index);
+			_engine_mngr.SetID(eid.type, eid.internal_id, eid.grfid, eid.substitute_id, static_cast<EngineID>(index));
 		}
 	}
 };

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -381,7 +381,7 @@ static bool FixTTOEngines()
 
 	/* Load the default engine set. Many of them will be overridden later */
 	{
-		uint j = 0;
+		EngineID j = ENGINE_BEGIN;
 		for (uint16_t i = 0; i < lengthof(_orig_rail_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_TRAIN, i);
 		for (uint16_t i = 0; i < lengthof(_orig_road_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_ROAD, i);
 		for (uint16_t i = 0; i < lengthof(_orig_ship_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_SHIP, i);
@@ -391,7 +391,7 @@ static bool FixTTOEngines()
 	TimerGameCalendar::Date aging_date = std::min(TimerGameCalendar::date + CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR, TimerGameCalendar::ConvertYMDToDate(TimerGameCalendar::Year{2050}, 0, 1));
 	TimerGameCalendar::YearMonthDay aging_ymd = TimerGameCalendar::ConvertDateToYMD(aging_date);
 
-	for (EngineID i = 0; i < 256; i++) {
+	for (EngineID i = ENGINE_BEGIN; i < 256; i++) {
 		OldEngineID oi = ttd_to_tto[i];
 		Engine *e = GetTempDataEngine(i);
 
@@ -1458,13 +1458,13 @@ static const OldChunks engine_chunk[] = {
 
 static bool LoadOldEngine(LoadgameState *ls, int num)
 {
-	Engine *e = _savegame_type == SGT_TTO ? &_old_engines[num] : GetTempDataEngine(num);
+	Engine *e = _savegame_type == SGT_TTO ? &_old_engines[num] : GetTempDataEngine(static_cast<EngineID>(num));
 	return LoadChunk(ls, e, engine_chunk);
 }
 
 static bool LoadOldEngineName(LoadgameState *ls, int num)
 {
-	Engine *e = GetTempDataEngine(num);
+	Engine *e = GetTempDataEngine(static_cast<EngineID>(num));
 	e->name = CopyFromOldName(RemapOldStringID(ReadUint16(ls)));
 	return true;
 }

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -1253,7 +1253,7 @@ bool LoadOldVehicle(LoadgameState *ls, int num)
 	ReadTTDPatchFlags();
 
 	for (uint i = 0; i < _old_vehicle_multiplier; i++) {
-		_current_vehicle_id = num * _old_vehicle_multiplier + i;
+		_current_vehicle_id = static_cast<VehicleID>(num * _old_vehicle_multiplier + i);
 
 		Vehicle *v;
 

--- a/src/script/api/script_goal.cpp
+++ b/src/script/api/script_goal.cpp
@@ -36,7 +36,7 @@
 	if (type == GT_STORY_PAGE && ScriptStoryPage::IsValidStoryPage(static_cast<StoryPageID>(destination))) story_page = ::StoryPage::Get(static_cast<StoryPageID>(destination));
 	return (type == GT_NONE && destination == 0) ||
 			(type == GT_TILE && ScriptMap::IsValidTile(::TileIndex(destination))) ||
-			(type == GT_INDUSTRY && ScriptIndustry::IsValidIndustry(destination)) ||
+			(type == GT_INDUSTRY && ScriptIndustry::IsValidIndustry(static_cast<IndustryID>(destination))) ||
 			(type == GT_TOWN && ScriptTown::IsValidTown(destination)) ||
 			(type == GT_COMPANY && ScriptCompany::ResolveCompanyID((ScriptCompany::CompanyID)destination) != ScriptCompany::COMPANY_INVALID) ||
 			(type == GT_STORY_PAGE && story_page != nullptr && (c == INVALID_COMPANY ? story_page->company == INVALID_COMPANY : story_page->company == INVALID_COMPANY || story_page->company == c));

--- a/src/script/api/script_goal.cpp
+++ b/src/script/api/script_goal.cpp
@@ -37,7 +37,7 @@
 	return (type == GT_NONE && destination == 0) ||
 			(type == GT_TILE && ScriptMap::IsValidTile(::TileIndex(destination))) ||
 			(type == GT_INDUSTRY && ScriptIndustry::IsValidIndustry(static_cast<IndustryID>(destination))) ||
-			(type == GT_TOWN && ScriptTown::IsValidTown(destination)) ||
+			(type == GT_TOWN && ScriptTown::IsValidTown(static_cast<TownID>(destination))) ||
 			(type == GT_COMPANY && ScriptCompany::ResolveCompanyID((ScriptCompany::CompanyID)destination) != ScriptCompany::COMPANY_INVALID) ||
 			(type == GT_STORY_PAGE && story_page != nullptr && (c == INVALID_COMPANY ? story_page->company == INVALID_COMPANY : story_page->company == INVALID_COMPANY || story_page->company == c));
 }

--- a/src/script/api/script_group.cpp
+++ b/src/script/api/script_group.cpp
@@ -36,7 +36,7 @@
 	if (!ScriptObject::Command<CMD_CREATE_GROUP>::Do(&ScriptInstance::DoCommandReturnGroupID, (::VehicleType)vehicle_type, parent_group_id)) return GROUP_INVALID;
 
 	/* In case of test-mode, we return GroupID 0 */
-	return static_cast<GroupID>(0);
+	return ::GROUP_BEGIN;
 }
 
 /* static */ bool ScriptGroup::DeleteGroup(GroupID group_id)
@@ -65,7 +65,7 @@
 	EnforcePreconditionEncodedText(false, text);
 	EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_GROUP_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG);
 
-	return ScriptObject::Command<CMD_ALTER_GROUP>::Do(AlterGroupMode::Rename, group_id, 0, text);
+	return ScriptObject::Command<CMD_ALTER_GROUP>::Do(AlterGroupMode::Rename, group_id, ::INVALID_GROUP, text);
 }
 
 /* static */ std::optional<std::string> ScriptGroup::GetName(GroupID group_id)

--- a/src/script/api/script_news.cpp
+++ b/src/script/api/script_news.cpp
@@ -34,7 +34,7 @@
 	                           (ref_type == NR_TILE     && ScriptMap::IsValidTile(::TileIndex(reference))) ||
 	                           (ref_type == NR_STATION  && ScriptStation::IsValidStation(reference)) ||
 	                           (ref_type == NR_INDUSTRY && ScriptIndustry::IsValidIndustry(static_cast<IndustryID>(reference))) ||
-	                           (ref_type == NR_TOWN     && ScriptTown::IsValidTown(reference)));
+	                           (ref_type == NR_TOWN     && ScriptTown::IsValidTown(static_cast<TownID>(reference))));
 
 	uint8_t c = company;
 	if (company == ScriptCompany::COMPANY_INVALID) c = INVALID_COMPANY;

--- a/src/script/api/script_news.cpp
+++ b/src/script/api/script_news.cpp
@@ -33,7 +33,7 @@
 	EnforcePrecondition(false, (ref_type == NR_NONE) ||
 	                           (ref_type == NR_TILE     && ScriptMap::IsValidTile(::TileIndex(reference))) ||
 	                           (ref_type == NR_STATION  && ScriptStation::IsValidStation(reference)) ||
-	                           (ref_type == NR_INDUSTRY && ScriptIndustry::IsValidIndustry(reference)) ||
+	                           (ref_type == NR_INDUSTRY && ScriptIndustry::IsValidIndustry(static_cast<IndustryID>(reference))) ||
 	                           (ref_type == NR_TOWN     && ScriptTown::IsValidTown(reference)));
 
 	uint8_t c = company;

--- a/src/script/api/script_sign.cpp
+++ b/src/script/api/script_sign.cpp
@@ -84,5 +84,5 @@
 	if (!ScriptObject::Command<CMD_PLACE_SIGN>::Do(&ScriptInstance::DoCommandReturnSignID, location, text)) return INVALID_SIGN;
 
 	/* In case of test-mode, we return SignID 0 */
-	return 0;
+	return ::SIGN_BEGIN;
 }

--- a/src/script/api/script_subsidy.cpp
+++ b/src/script/api/script_subsidy.cpp
@@ -37,8 +37,8 @@
 	EnforcePrecondition(false, ScriptCargo::IsValidCargo(cargo_type));
 	EnforcePrecondition(false, from_type == SPT_INDUSTRY || from_type == SPT_TOWN);
 	EnforcePrecondition(false, to_type == SPT_INDUSTRY || to_type == SPT_TOWN);
-	EnforcePrecondition(false, (from_type == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(static_cast<IndustryID>(from_id))) || (from_type == SPT_TOWN && ScriptTown::IsValidTown(from_id)));
-	EnforcePrecondition(false, (to_type == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(static_cast<IndustryID>(to_id))) || (to_type == SPT_TOWN && ScriptTown::IsValidTown(to_id)));
+	EnforcePrecondition(false, (from_type == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(static_cast<IndustryID>(from_id))) || (from_type == SPT_TOWN && ScriptTown::IsValidTown(static_cast<TownID>(from_id))));
+	EnforcePrecondition(false, (to_type == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(static_cast<IndustryID>(to_id))) || (to_type == SPT_TOWN && ScriptTown::IsValidTown(static_cast<TownID>(to_id))));
 
 	Source from{static_cast<SourceID>(from_id), static_cast<SourceType>(from_type)};
 	Source to{static_cast<SourceID>(to_id), static_cast<SourceType>(to_type)};

--- a/src/script/api/script_subsidy.cpp
+++ b/src/script/api/script_subsidy.cpp
@@ -37,8 +37,8 @@
 	EnforcePrecondition(false, ScriptCargo::IsValidCargo(cargo_type));
 	EnforcePrecondition(false, from_type == SPT_INDUSTRY || from_type == SPT_TOWN);
 	EnforcePrecondition(false, to_type == SPT_INDUSTRY || to_type == SPT_TOWN);
-	EnforcePrecondition(false, (from_type == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(from_id)) || (from_type == SPT_TOWN && ScriptTown::IsValidTown(from_id)));
-	EnforcePrecondition(false, (to_type == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(to_id)) || (to_type == SPT_TOWN && ScriptTown::IsValidTown(to_id)));
+	EnforcePrecondition(false, (from_type == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(static_cast<IndustryID>(from_id))) || (from_type == SPT_TOWN && ScriptTown::IsValidTown(from_id)));
+	EnforcePrecondition(false, (to_type == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(static_cast<IndustryID>(to_id))) || (to_type == SPT_TOWN && ScriptTown::IsValidTown(to_id)));
 
 	Source from{static_cast<SourceID>(from_id), static_cast<SourceType>(from_type)};
 	Source to{static_cast<SourceID>(to_id), static_cast<SourceType>(to_type)};

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -84,7 +84,7 @@
 	if (!ScriptObject::Command<CMD_BUILD_VEHICLE>::Do(&ScriptInstance::DoCommandReturnVehicleID, depot, engine_id, true, cargo, INVALID_CLIENT_ID)) return VEHICLE_INVALID;
 
 	/* In case of test-mode, we return VehicleID 0 */
-	return 0;
+	return ::VEHICLE_BEGIN;
 }
 
 /* static */ VehicleID ScriptVehicle::BuildVehicle(TileIndex depot, EngineID engine_id)
@@ -115,16 +115,16 @@
 	if (!ScriptObject::Command<CMD_CLONE_VEHICLE>::Do(&ScriptInstance::DoCommandReturnVehicleID, depot, vehicle_id, share_orders)) return VEHICLE_INVALID;
 
 	/* In case of test-mode, we return VehicleID 0 */
-	return 0;
+	return ::VEHICLE_BEGIN;
 }
 
 /* static */ bool ScriptVehicle::_MoveWagonInternal(VehicleID source_vehicle_id, SQInteger source_wagon, bool move_attached_wagons, SQInteger dest_vehicle_id, SQInteger dest_wagon)
 {
 	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicle(source_vehicle_id) && source_wagon < GetNumWagons(source_vehicle_id));
-	EnforcePrecondition(false, dest_vehicle_id == -1 || (IsValidVehicle(dest_vehicle_id) && dest_wagon < GetNumWagons(dest_vehicle_id)));
+	EnforcePrecondition(false, dest_vehicle_id == -1 || (IsValidVehicle(static_cast<VehicleID>(dest_vehicle_id)) && dest_wagon < GetNumWagons(static_cast<VehicleID>(dest_vehicle_id))));
 	EnforcePrecondition(false, ::Vehicle::Get(source_vehicle_id)->type == VEH_TRAIN);
-	EnforcePrecondition(false, dest_vehicle_id == -1 || ::Vehicle::Get(dest_vehicle_id)->type == VEH_TRAIN);
+	EnforcePrecondition(false, dest_vehicle_id == -1 || ::Vehicle::Get(static_cast<VehicleID>(dest_vehicle_id))->type == VEH_TRAIN);
 
 	const Train *v = ::Train::Get(source_vehicle_id);
 	while (source_wagon-- > 0) v = v->GetNextUnit();

--- a/src/signs_base.h
+++ b/src/signs_base.h
@@ -15,7 +15,7 @@
 #include "core/pool_type.hpp"
 #include "company_type.h"
 
-typedef Pool<Sign, SignID, 16, 64000> SignPool;
+typedef Pool<Sign, SignID, 16, SIGN_END> SignPool;
 extern SignPool _sign_pool;
 
 struct Sign : SignPool::PoolItem<&_sign_pool> {

--- a/src/signs_type.h
+++ b/src/signs_type.h
@@ -11,10 +11,13 @@
 #define SIGNS_TYPE_H
 
 /** The type of the IDs of signs. */
-typedef uint16_t SignID;
-struct Sign;
+enum SignID : uint16_t {
+	SIGN_BEGIN = 0,
+	SIGN_END = 64000,
+	INVALID_SIGN = 0xFFFF ///< Sentinel for an invalid sign.
+};
 
-static const SignID INVALID_SIGN = 0xFFFF; ///< Sentinel for an invalid sign.
+struct Sign;
 
 static const uint MAX_LENGTH_SIGN_NAME_CHARS = 32; ///< The maximum length of a sign name in characters including '\0'
 

--- a/src/town.h
+++ b/src/town.h
@@ -33,7 +33,7 @@ static const uint TOWN_GROWTH_DESERT = 0xFFFFFFFF; ///< The town needs the cargo
 static const uint16_t TOWN_GROWTH_RATE_NONE = 0xFFFF; ///< Special value for Town::growth_rate to disable town growth.
 static const uint16_t MAX_TOWN_GROWTH_TICKS = 930; ///< Max amount of original town ticks that still fit into uint16_t, about equal to UINT16_MAX / TOWN_GROWTH_TICKS but slightly less to simplify calculations
 
-typedef Pool<Town, TownID, 64, 64000> TownPool;
+typedef Pool<Town, TownID, 64, TOWN_END> TownPool;
 extern TownPool _town_pool;
 
 /** Data structure with cached data of towns. */

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -326,7 +326,7 @@ public:
 			}
 
 			case WID_TA_EXECUTE:
-				Command<CMD_DO_TOWN_ACTION>::Post(STR_ERROR_CAN_T_DO_THIS, this->town->xy, this->window_number, this->sel_index);
+				Command<CMD_DO_TOWN_ACTION>::Post(STR_ERROR_CAN_T_DO_THIS, this->town->xy, static_cast<TownID>(this->window_number), this->sel_index);
 				break;
 		}
 	}
@@ -521,12 +521,12 @@ public:
 				break;
 
 			case WID_TV_EXPAND: { // expand town - only available on Scenario editor
-				Command<CMD_EXPAND_TOWN>::Post(STR_ERROR_CAN_T_EXPAND_TOWN, this->window_number, 0);
+				Command<CMD_EXPAND_TOWN>::Post(STR_ERROR_CAN_T_EXPAND_TOWN, static_cast<TownID>(this->window_number), 0);
 				break;
 			}
 
 			case WID_TV_DELETE: // delete town - only available on Scenario editor
-				Command<CMD_DELETE_TOWN>::Post(STR_ERROR_TOWN_CAN_T_DELETE, this->window_number);
+				Command<CMD_DELETE_TOWN>::Post(STR_ERROR_TOWN_CAN_T_DELETE, static_cast<TownID>(this->window_number));
 				break;
 		}
 	}
@@ -615,7 +615,7 @@ public:
 	{
 		if (!str.has_value()) return;
 
-		Command<CMD_RENAME_TOWN>::Post(STR_ERROR_CAN_T_RENAME_TOWN, this->window_number, *str);
+		Command<CMD_RENAME_TOWN>::Post(STR_ERROR_CAN_T_RENAME_TOWN, static_cast<TownID>(this->window_number), *str);
 	}
 
 	IntervalTimer<TimerGameCalendar> daily_interval = {{TimerGameCalendar::DAY, TimerGameCalendar::Priority::NONE}, [this](auto) {

--- a/src/town_map.h
+++ b/src/town_map.h
@@ -23,7 +23,7 @@
 inline TownID GetTownIndex(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE) || (IsTileType(t, MP_ROAD) && !IsRoadDepot(t)));
-	return t.m2();
+	return static_cast<TownID>(t.m2());
 }
 
 /**

--- a/src/town_type.h
+++ b/src/town_type.h
@@ -12,8 +12,11 @@
 
 #include "core/enum_type.hpp"
 
-typedef uint16_t TownID;
-static const TownID INVALID_TOWN = 0xFFFF;
+enum TownID : uint16_t {
+	TOWN_BEGIN = 0,
+	TOWN_END = 64000,
+	INVALID_TOWN = 0xFFFF
+};
 
 struct Town;
 

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -196,7 +196,7 @@ struct MutableSpriteCache {
 };
 
 /** A vehicle pool for a little over 1 million vehicles. */
-typedef Pool<Vehicle, VehicleID, 512, 0xFF000> VehiclePool;
+typedef Pool<Vehicle, VehicleID, 512, VEHICLE_END> VehiclePool;
 extern VehiclePool _vehicle_pool;
 
 /* Some declarations of functions, so we can make them friendly */

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -3391,7 +3391,7 @@ public:
 	{
 		if (!str.has_value()) return;
 
-		Command<CMD_RENAME_VEHICLE>::Post(STR_ERROR_CAN_T_RENAME_TRAIN + Vehicle::Get(this->window_number)->type, this->window_number, *str);
+		Command<CMD_RENAME_VEHICLE>::Post(STR_ERROR_CAN_T_RENAME_TRAIN + Vehicle::Get(this->window_number)->type, static_cast<VehicleID>(this->window_number), *str);
 	}
 
 	void OnMouseOver([[maybe_unused]] Point pt, WidgetID widget) override

--- a/src/vehicle_type.h
+++ b/src/vehicle_type.h
@@ -13,7 +13,11 @@
 #include "core/enum_type.hpp"
 
 /** The type all our vehicle IDs have. */
-typedef uint32_t VehicleID;
+enum VehicleID : uint32_t {
+	VEHICLE_BEGIN = 0,
+	VEHICLE_END = 0xFF000,
+	INVALID_VEHICLE = 0xFFFFF ///< Constant representing a non-existing vehicle.
+};
 
 static const int GROUND_ACCELERATION = 9800; ///< Acceleration due to gravity, 9.8 m/s^2
 
@@ -50,8 +54,6 @@ struct BaseVehicle
 {
 	VehicleType type; ///< Type of vehicle
 };
-
-static const VehicleID INVALID_VEHICLE = 0xFFFFF; ///< Constant representing a non-existing vehicle.
 
 /** Flags for goto depot commands. */
 enum class DepotCommandFlag : uint8_t {


### PR DESCRIPTION
## Motivation / Problem

To get any further with migrating to a more C++-style of code, we should get rid of some custom built `std::variant` implementations. However, (almost) all the 'types' we use for pool IDs are just typedefs of integer types, which for `std::variant` are all the same. You can have that in a variant, but then you need to access the value by index which is definitely not making the code any better.

So, you actually want some types that are considered different. One option are enums, but these pool IDs are not really an enumeration. The other option are strong types, and that is where the 'fun' begins. 
* The strong typedef cannot be used, because it initialises the value upon construction. By doing that, it overwrites the index that the (placement) new put in there.
* For the viewport kd tree, there is a union with station, town and sign IDs. You  can't put the strong type in a union, so that needs to become a `std::variant` but that cannot happen before all the types are non just typedefs. In other words, those three types and this union need to be converted in one single commit.
Could be circumvented by de-union-ising that bit, but that would be like removing something to put it back later.
* For the vehicle list, there are vehicles, stations, depots and groups as types with their index, which basically means it's a variant that again can only be converted when all are over. Or there is a need for a massive amount of ugly casting, e.g. `GroupID{static_cast<uint16_t>(vli.index)}` because `vli.index` is 32 bits and it would be a narrowing cast.
Could be circumvented by implicit conversion operators, but that requires a lot of tricky shenanigans on the pools with overloads and having to disambiguate those.
* For news references, there are engines, industries, stations, towns and vehicle which should be part of a variant. Could be circumvented by a lot of calls to `.base()` that need to be removed again when the functions are changed to accept `std::variant`.

So in short, going for a strong type ends up in a massive chicken-egg problem that needs resolving. This can be done by using enums in a step by step manner, where the enums are first introduced, then conversions to variants can take place before switching over to strong types.
There has been considerations to use `enum class`, but that idea has been rejected because it would require adding many helper functions in the pool code as there is no automatic conversion to `size_t` any more. Next to this, it would require massive renaming and when going to strong types there is no way to keep the same signature, because you can't add `static constexpr` variables to a class that are the same type of the class (it worked in some versions of GCC, but not the others), so it would require yet another massive change to the code.


## Description

Change the integer typedefs for depot, engine, group, industry, sign, station, town and vehicle IDs to enums.

Each of these enums has at least a `X_BEGIN`, `X_END` and `INVALID_X`. The `X_END` is the same as the size of the pool, the `X_BEGIN` is just 0 but added to ensure all valid pool values are within the range of the enumeration (preventing any optimisation shenanigans.


## Limitations

There are many more to come and it's just stop-gap solution to unravel this chicken-egg problem.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
