### PR TITLE
Codefix: access pool via PoolItem, not the pool itself

### DIFF
--- a/src/story.cpp
+++ b/src/story.cpp
@@ -214,7 +214,7 @@ std::tuple<CommandCost, StoryPageID> CmdCreateStoryPage(DoCommandFlag flags, Com
 	if (company != INVALID_COMPANY && !Company::IsValidID(company)) return { CMD_ERROR, INVALID_STORY_PAGE };
 
 	if (flags & DC_EXEC) {
-		if (_story_page_pool.items == 0) {
+		if (StoryPage::GetNumItems() == 0) {
 			/* Initialize the next sort value variable. */
 			_story_page_next_sort_value = 0;
 		}
@@ -262,7 +262,7 @@ std::tuple<CommandCost, StoryPageElementID> CmdCreateStoryPageElement(DoCommandF
 
 
 	if (flags & DC_EXEC) {
-		if (_story_page_element_pool.items == 0) {
+		if (StoryPageElement::GetNumItems() == 0) {
 			/* Initialize the next sort value variable. */
 			_story_page_element_next_sort_value = 0;
 		}

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -133,8 +133,8 @@ protected:
 	 */
 	StoryPage *GetSelPage() const
 	{
-		if (!_story_page_pool.IsValidID(selected_page_id)) return nullptr;
-		return _story_page_pool.Get(selected_page_id);
+		if (!StoryPage::IsValidID(selected_page_id)) return nullptr;
+		return StoryPage::Get(selected_page_id);
 	}
 
 	/**
@@ -159,7 +159,7 @@ protected:
 	bool IsFirstPageSelected()
 	{
 		/* Verify that the selected page exist. */
-		if (!_story_page_pool.IsValidID(this->selected_page_id)) return false;
+		if (!StoryPage::IsValidID(this->selected_page_id)) return false;
 
 		return this->story_pages.front()->index == this->selected_page_id;
 	}
@@ -170,7 +170,7 @@ protected:
 	bool IsLastPageSelected()
 	{
 		/* Verify that the selected page exist. */
-		if (!_story_page_pool.IsValidID(this->selected_page_id)) return false;
+		if (!StoryPage::IsValidID(this->selected_page_id)) return false;
 
 		if (this->story_pages.size() <= 1) return true;
 		const StoryPage *last = this->story_pages.back();
@@ -205,7 +205,7 @@ protected:
 	 */
 	void SelectPrevPage()
 	{
-		if (!_story_page_pool.IsValidID(this->selected_page_id)) return;
+		if (!StoryPage::IsValidID(this->selected_page_id)) return;
 
 		/* Find the last available page which is previous to the current selected page. */
 		const StoryPage *last_available;
@@ -225,7 +225,7 @@ protected:
 	 */
 	void SelectNextPage()
 	{
-		if (!_story_page_pool.IsValidID(this->selected_page_id)) return;
+		if (!StoryPage::IsValidID(this->selected_page_id)) return;
 
 		/* Find selected page. */
 		for (auto iter = this->story_pages.begin(); iter != this->story_pages.end(); iter++) {
@@ -872,7 +872,7 @@ public:
 			}
 
 			/* Verify page selection. */
-			if (!_story_page_pool.IsValidID(this->selected_page_id)) {
+			if (!StoryPage::IsValidID(this->selected_page_id)) {
 				this->selected_page_id = INVALID_STORY_PAGE;
 			}
 			if (this->selected_page_id == INVALID_STORY_PAGE && !this->story_pages.empty()) {


### PR DESCRIPTION
## Motivation / Problem

Everything does `Object::IsValid`, except for stories where it's `_story_page_pool.IsValid`.


## Description

Use `StoryPage::XYZ` over `_story_page_pool.XYZ`, and the same for `StoryPageElement`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
