### PR TITLE
Codechange: [Script] replace some enums with constexpr values

### DIFF
--- a/cmake/scripts/SquirrelExport.cmake
+++ b/cmake/scripts/SquirrelExport.cmake
@@ -574,6 +574,10 @@ foreach(LINE IN LISTS SOURCE_LINES)
         list(APPEND CONST_VALUES "${CMAKE_MATCH_1}")
         continue()
     endif()
+    if("${LINE}" MATCHES "^[ 	]*static constexpr [^ ]+ ([^ ]+) = -?\\(?[^ ]*\\)?[^ ]+;")
+        list(APPEND CONST_VALUES "${CMAKE_MATCH_1}")
+        continue()
+    endif()
 
     # Add a method to the list
     if("${LINE}" MATCHES "^.*\\(.*\\).*$")

--- a/src/script/api/script_goal.cpp
+++ b/src/script/api/script_goal.cpp
@@ -33,7 +33,7 @@
 	CompanyID c = (::CompanyID)company;
 	if (company == ScriptCompany::COMPANY_INVALID) c = INVALID_COMPANY;
 	StoryPage *story_page = nullptr;
-	if (type == GT_STORY_PAGE && ScriptStoryPage::IsValidStoryPage((ScriptStoryPage::StoryPageID)destination)) story_page = ::StoryPage::Get((ScriptStoryPage::StoryPageID)destination);
+	if (type == GT_STORY_PAGE && ScriptStoryPage::IsValidStoryPage(static_cast<StoryPageID>(destination))) story_page = ::StoryPage::Get(static_cast<StoryPageID>(destination));
 	return (type == GT_NONE && destination == 0) ||
 			(type == GT_TILE && ScriptMap::IsValidTile(::TileIndex(destination))) ||
 			(type == GT_INDUSTRY && ScriptIndustry::IsValidIndustry(destination)) ||
@@ -42,7 +42,7 @@
 			(type == GT_STORY_PAGE && story_page != nullptr && (c == INVALID_COMPANY ? story_page->company == INVALID_COMPANY : story_page->company == INVALID_COMPANY || story_page->company == c));
 }
 
-/* static */ ScriptGoal::GoalID ScriptGoal::New(ScriptCompany::CompanyID company, Text *goal, GoalType type, SQInteger destination)
+/* static */ GoalID ScriptGoal::New(ScriptCompany::CompanyID company, Text *goal, GoalType type, SQInteger destination)
 {
 	ScriptObjectRef counter(goal);
 
@@ -56,7 +56,7 @@
 	if (!ScriptObject::Command<CMD_CREATE_GOAL>::Do(&ScriptInstance::DoCommandReturnGoalID, (::CompanyID)company, (::GoalType)type, destination, text)) return GOAL_INVALID;
 
 	/* In case of test-mode, we return GoalID 0 */
-	return (ScriptGoal::GoalID)0;
+	return static_cast<GoalID>(0);
 }
 
 /* static */ bool ScriptGoal::Remove(GoalID goal_id)

--- a/src/script/api/script_goal.hpp
+++ b/src/script/api/script_goal.hpp
@@ -25,13 +25,7 @@
  */
 class ScriptGoal : public ScriptObject {
 public:
-	/**
-	 * The goal IDs.
-	 */
-	enum GoalID : uint16_t {
-		/* Note: these values represent part of the in-game GoalID enum */
-		GOAL_INVALID = ::INVALID_GOAL, ///< An invalid goal id.
-	};
+	static constexpr GoalID GOAL_INVALID = ::INVALID_GOAL; ///< An invalid goal id.
 
 	/**
 	 * Goal types that can be given to a goal.

--- a/src/script/api/script_group.cpp
+++ b/src/script/api/script_group.cpp
@@ -30,13 +30,13 @@
 	return g != nullptr && g->owner == ScriptObject::GetCompany();
 }
 
-/* static */ ScriptGroup::GroupID ScriptGroup::CreateGroup(ScriptVehicle::VehicleType vehicle_type, GroupID parent_group_id)
+/* static */ GroupID ScriptGroup::CreateGroup(ScriptVehicle::VehicleType vehicle_type, GroupID parent_group_id)
 {
 	EnforceCompanyModeValid(GROUP_INVALID);
 	if (!ScriptObject::Command<CMD_CREATE_GROUP>::Do(&ScriptInstance::DoCommandReturnGroupID, (::VehicleType)vehicle_type, parent_group_id)) return GROUP_INVALID;
 
 	/* In case of test-mode, we return GroupID 0 */
-	return (ScriptGroup::GroupID)0;
+	return static_cast<GroupID>(0);
 }
 
 /* static */ bool ScriptGroup::DeleteGroup(GroupID group_id)
@@ -85,12 +85,12 @@
 	return ScriptObject::Command<CMD_ALTER_GROUP>::Do(AlterGroupMode::SetParent, group_id, parent_group_id, {});
 }
 
-/* static */ ScriptGroup::GroupID ScriptGroup::GetParent(GroupID group_id)
+/* static */ GroupID ScriptGroup::GetParent(GroupID group_id)
 {
-	EnforcePrecondition((ScriptGroup::GroupID)INVALID_GROUP, IsValidGroup(group_id));
+	EnforcePrecondition(INVALID_GROUP, IsValidGroup(group_id));
 
 	const Group *g = ::Group::GetIfValid(group_id);
-	return (ScriptGroup::GroupID)g->parent;
+	return g->parent;
 }
 
 /* static */ bool ScriptGroup::EnableAutoReplaceProtection(GroupID group_id, bool enable)

--- a/src/script/api/script_group.hpp
+++ b/src/script/api/script_group.hpp
@@ -19,15 +19,9 @@
  */
 class ScriptGroup : public ScriptObject {
 public:
-	/**
-	 * The group IDs of some special groups.
-	 */
-	enum GroupID {
-		/* Note: these values represent part of the in-game static values */
-		GROUP_ALL     = ::ALL_GROUP,     ///< All vehicles are in this group.
-		GROUP_DEFAULT = ::DEFAULT_GROUP, ///< Vehicles not put in any other group are in this one.
-		GROUP_INVALID = ::INVALID_GROUP, ///< An invalid group id.
-	};
+	static constexpr GroupID GROUP_ALL = ::ALL_GROUP; ///< All vehicles are in this group.
+	static constexpr GroupID GROUP_DEFAULT = ::DEFAULT_GROUP; ///< Vehicles not put in any other group are in this one.
+	static constexpr GroupID GROUP_INVALID = ::INVALID_GROUP; ///< An invalid group id.
 
 	/**
 	 * Checks whether the given group is valid.

--- a/src/script/api/script_league.cpp
+++ b/src/script/api/script_league.cpp
@@ -24,7 +24,7 @@
 	return ::LeagueTable::IsValidID(table_id);
 }
 
-/* static */ ScriptLeagueTable::LeagueTableID ScriptLeagueTable::New(Text *title, Text *header, Text *footer)
+/* static */ LeagueTableID ScriptLeagueTable::New(Text *title, Text *header, Text *footer)
 {
 	ScriptObjectRef title_counter(title);
 	ScriptObjectRef header_counter(header);
@@ -41,7 +41,7 @@
 	if (!ScriptObject::Command<CMD_CREATE_LEAGUE_TABLE>::Do(&ScriptInstance::DoCommandReturnLeagueTableID, encoded_title, encoded_header, encoded_footer)) return LEAGUE_TABLE_INVALID;
 
 	/* In case of test-mode, we return LeagueTableID 0 */
-	return (ScriptLeagueTable::LeagueTableID)0;
+	return static_cast<LeagueTableID>(0);
 }
 
 /* static */ bool ScriptLeagueTable::IsValidLeagueTableElement(LeagueTableElementID element_id)
@@ -49,7 +49,7 @@
 	return ::LeagueTableElement::IsValidID(element_id);
 }
 
-/* static */ ScriptLeagueTable::LeagueTableElementID ScriptLeagueTable::NewElement(ScriptLeagueTable::LeagueTableID table, SQInteger rating, ScriptCompany::CompanyID company, Text *text, Text *score, LinkType link_type, SQInteger link_target)
+/* static */ LeagueTableElementID ScriptLeagueTable::NewElement(LeagueTableID table, SQInteger rating, ScriptCompany::CompanyID company, Text *text, Text *score, LinkType link_type, SQInteger link_target)
 {
 	ScriptObjectRef text_counter(text);
 	ScriptObjectRef score_counter(score);
@@ -75,7 +75,7 @@
 	if (!ScriptObject::Command<CMD_CREATE_LEAGUE_TABLE_ELEMENT>::Do(&ScriptInstance::DoCommandReturnLeagueTableElementID, table, rating, c, encoded_text, encoded_score, (::LinkType)link_type, (::LinkTargetID)link_target)) return LEAGUE_TABLE_ELEMENT_INVALID;
 
 	/* In case of test-mode, we return LeagueTableElementID 0 */
-	return (ScriptLeagueTable::LeagueTableElementID)0;
+	return static_cast<LeagueTableElementID>(0);
 }
 
 /* static */ bool ScriptLeagueTable::UpdateElementData(LeagueTableElementID element, ScriptCompany::CompanyID company, Text *text, LinkType link_type, SQInteger link_target)

--- a/src/script/api/script_league.hpp
+++ b/src/script/api/script_league.hpp
@@ -25,19 +25,9 @@
  */
 class ScriptLeagueTable : public ScriptObject {
 public:
-	/**
-	 * The league table IDs.
-	 */
-	enum LeagueTableID {
-		LEAGUE_TABLE_INVALID = ::INVALID_LEAGUE_TABLE, ///< An invalid league table id.
-	};
+	static constexpr LeagueTableID LEAGUE_TABLE_INVALID = ::INVALID_LEAGUE_TABLE; ///< An invalid league table id.
 
-	/**
-	 * The league table element IDs.
-	 */
-	enum LeagueTableElementID {
-		LEAGUE_TABLE_ELEMENT_INVALID = ::INVALID_LEAGUE_TABLE_ELEMENT, ///< An invalid league table element id.
-	};
+	static constexpr LeagueTableElementID LEAGUE_TABLE_ELEMENT_INVALID = ::INVALID_LEAGUE_TABLE_ELEMENT; ///< An invalid league table element id.
 
 	/**
 	 * The type of a link.

--- a/src/script/api/script_story_page.cpp
+++ b/src/script/api/script_story_page.cpp
@@ -43,7 +43,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 	return type == SPET_TEXT || type == SPET_LOCATION || type == SPET_GOAL || type == SPET_BUTTON_PUSH || type == SPET_BUTTON_TILE || type == SPET_BUTTON_VEHICLE;
 }
 
-/* static */ ScriptStoryPage::StoryPageID ScriptStoryPage::New(ScriptCompany::CompanyID company, Text *title)
+/* static */ StoryPageID ScriptStoryPage::New(ScriptCompany::CompanyID company, Text *title)
 {
 	ScriptObjectRef counter(title);
 
@@ -57,10 +57,10 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 		(::CompanyID)c, title != nullptr ? title->GetEncodedText() : std::string{})) return STORY_PAGE_INVALID;
 
 	/* In case of test-mode, we return StoryPageID 0 */
-	return (ScriptStoryPage::StoryPageID)0;
+	return static_cast<StoryPageID>(0);
 }
 
-/* static */ ScriptStoryPage::StoryPageElementID ScriptStoryPage::NewElement(StoryPageID story_page_id, StoryPageElementType type, SQInteger reference, Text *text)
+/* static */ StoryPageElementID ScriptStoryPage::NewElement(StoryPageID story_page_id, StoryPageElementType type, SQInteger reference, Text *text)
 {
 	ScriptObjectRef counter(text);
 
@@ -76,7 +76,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 		EnforcePreconditionEncodedText(STORY_PAGE_ELEMENT_INVALID, encoded_text);
 	}
 	EnforcePrecondition(STORY_PAGE_ELEMENT_INVALID, type != SPET_LOCATION || ::IsValidTile((::TileIndex)reference));
-	EnforcePrecondition(STORY_PAGE_ELEMENT_INVALID, type != SPET_GOAL || ScriptGoal::IsValidGoal((ScriptGoal::GoalID)reference));
+	EnforcePrecondition(STORY_PAGE_ELEMENT_INVALID, type != SPET_GOAL || ScriptGoal::IsValidGoal(static_cast<::GoalID>(reference)));
 	EnforcePrecondition(STORY_PAGE_ELEMENT_INVALID, type != SPET_GOAL || !(StoryPage::Get(story_page_id)->company == INVALID_COMPANY && Goal::Get(reference)->company != INVALID_COMPANY));
 
 	uint32_t refid = 0;
@@ -104,7 +104,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 			encoded_text)) return STORY_PAGE_ELEMENT_INVALID;
 
 	/* In case of test-mode, we return StoryPageElementID 0 */
-	return (ScriptStoryPage::StoryPageElementID)0;
+	return static_cast<StoryPageElementID>(0);
 }
 
 /* static */ bool ScriptStoryPage::UpdateElement(StoryPageElementID story_page_element_id, SQInteger reference, Text *text)
@@ -125,7 +125,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 		EnforcePreconditionEncodedText(false, encoded_text);
 	}
 	EnforcePrecondition(false, type != ::SPET_LOCATION || ::IsValidTile((::TileIndex)reference));
-	EnforcePrecondition(false, type != ::SPET_GOAL || ScriptGoal::IsValidGoal((ScriptGoal::GoalID)reference));
+	EnforcePrecondition(false, type != ::SPET_GOAL || ScriptGoal::IsValidGoal(static_cast<::GoalID>(reference)));
 	EnforcePrecondition(false, type != ::SPET_GOAL || !(p->company == INVALID_COMPANY && Goal::Get(reference)->company != INVALID_COMPANY));
 
 	uint32_t refid = 0;

--- a/src/script/api/script_story_page.hpp
+++ b/src/script/api/script_story_page.hpp
@@ -38,21 +38,8 @@
  */
 class ScriptStoryPage : public ScriptObject {
 public:
-	/**
-	 * The story page IDs.
-	 */
-	enum StoryPageID {
-		/* Note: these values represent part of the in-game StoryPageID enum */
-		STORY_PAGE_INVALID = ::INVALID_STORY_PAGE, ///< An invalid story page id.
-	};
-
-	/**
-	 * The story page element IDs.
-	 */
-	enum StoryPageElementID {
-		/* Note: these values represent part of the in-game StoryPageElementID enum */
-		STORY_PAGE_ELEMENT_INVALID = ::INVALID_STORY_PAGE_ELEMENT, ///< An invalid story page element id.
-	};
+	static constexpr StoryPageID STORY_PAGE_INVALID = ::INVALID_STORY_PAGE; ///< An invalid story page id.
+	static constexpr StoryPageElementID STORY_PAGE_ELEMENT_INVALID = ::INVALID_STORY_PAGE_ELEMENT; ///< An invalid story page element id.
 
 	/**
 	 * Story page element types.

--- a/src/script/api/script_storypageelementlist.cpp
+++ b/src/script/api/script_storypageelementlist.cpp
@@ -13,7 +13,7 @@
 
 #include "../../safeguards.h"
 
-ScriptStoryPageElementList::ScriptStoryPageElementList(ScriptStoryPage::StoryPageID story_page_id)
+ScriptStoryPageElementList::ScriptStoryPageElementList(StoryPageID story_page_id)
 {
 	if (!ScriptStoryPage::IsValidStoryPage(story_page_id)) return;
 

--- a/src/script/api/script_storypageelementlist.hpp
+++ b/src/script/api/script_storypageelementlist.hpp
@@ -24,7 +24,7 @@ public:
 	/**
 	 * @param story_page_id The page id of the story page of which all page elements should be included in the list.
 	 */
-	ScriptStoryPageElementList(ScriptStoryPage::StoryPageID story_page_id);
+	ScriptStoryPageElementList(StoryPageID story_page_id);
 };
 
 #endif /* SCRIPT_STORYPAGEELEMENTLIST_HPP */

--- a/src/script/api/script_vehiclelist.cpp
+++ b/src/script/api/script_vehiclelist.cpp
@@ -107,7 +107,7 @@ ScriptVehicleList_SharedOrders::ScriptVehicleList_SharedOrders(VehicleID vehicle
 ScriptVehicleList_Group::ScriptVehicleList_Group(GroupID group_id)
 {
 	EnforceCompanyModeValid_Void();
-	if (!ScriptGroup::IsValidGroup((ScriptGroup::GroupID)group_id)) return;
+	if (!ScriptGroup::IsValidGroup(group_id)) return;
 
 	CompanyID owner = ScriptObject::GetCompany();
 


### PR DESCRIPTION
## Motivation / Problem

In the script API some IDs are redefined as an enum, sometimes with a different size than in the main code. This causes confusing and unneeded casting.


## Description

Replace the enums with the internal types, and provide constants for the removed enumerations.


## Limitations

It's not solved in all cases, but this is already a sizeable chunk.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
