### PR TITLE
Codechange: rename AdminIndex to AdminID, ClientID to ClientPoolID

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -872,7 +872,7 @@ CommandCost CmdCompanyCtrl(DoCommandFlag flags, CompanyCtrlAction cca, CompanyID
 			/* This command is only executed in a multiplayer game */
 			if (!_networking) return CMD_ERROR;
 
-			/* Has the network client a correct ClientIndex? */
+			/* Has the network client a correct ClientID? */
 			if (!(flags & DC_EXEC)) return CommandCost();
 
 			NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(client_id);

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -29,7 +29,7 @@
 /* This file handles all the admin network commands. */
 
 /** Redirection of the (remote) console to the admin. */
-AdminIndex _redirect_console_to_admin = INVALID_ADMIN_ID;
+AdminID _redirect_console_to_admin = INVALID_ADMIN_ID;
 
 /** The pool with sockets/clients. */
 NetworkAdminSocketPool _networkadminsocket_pool("NetworkAdminSocket");
@@ -1000,7 +1000,7 @@ void NetworkAdminChat(NetworkAction action, DestType desttype, ClientID client_i
  * @param colour_code The colour of the string.
  * @param string      The string to show.
  */
-void NetworkServerSendAdminRcon(AdminIndex admin_index, TextColour colour_code, const std::string_view string)
+void NetworkServerSendAdminRcon(AdminID admin_index, TextColour colour_code, const std::string_view string)
 {
 	ServerNetworkAdminSocketHandler::Get(admin_index)->SendRcon(colour_code, string);
 }

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -31,9 +31,6 @@
 /** Redirection of the (remote) console to the admin. */
 AdminIndex _redirect_console_to_admin = INVALID_ADMIN_ID;
 
-/** The amount of admins connected. */
-uint8_t _network_admins_connected = 0;
-
 /** The pool with sockets/clients. */
 NetworkAdminSocketPool _networkadminsocket_pool("NetworkAdminSocket");
 INSTANTIATE_POOL_METHODS(NetworkAdminSocket)
@@ -67,7 +64,6 @@ static_assert(lengthof(_admin_update_type_frequencies) == ADMIN_UPDATE_END);
  */
 ServerNetworkAdminSocketHandler::ServerNetworkAdminSocketHandler(SOCKET s) : NetworkAdminSocketHandler(s)
 {
-	_network_admins_connected++;
 	this->status = ADMIN_STATUS_INACTIVE;
 	this->connect_time = std::chrono::steady_clock::now();
 }
@@ -77,7 +73,6 @@ ServerNetworkAdminSocketHandler::ServerNetworkAdminSocketHandler(SOCKET s) : Net
  */
 ServerNetworkAdminSocketHandler::~ServerNetworkAdminSocketHandler()
 {
-	_network_admins_connected--;
 	Debug(net, 3, "[admin] '{}' ({}) has disconnected", this->admin_name, this->admin_version);
 	if (_redirect_console_to_admin == this->index) _redirect_console_to_admin = INVALID_ADMIN_ID;
 
@@ -93,12 +88,7 @@ ServerNetworkAdminSocketHandler::~ServerNetworkAdminSocketHandler()
  */
 /* static */ bool ServerNetworkAdminSocketHandler::AllowConnection()
 {
-	bool accept = _settings_client.network.AdminAuthenticationConfigured() && _network_admins_connected < MAX_ADMINS;
-	/* We can't go over the MAX_ADMINS limit here. However, if we accept
-	 * the connection, there has to be space in the pool. */
-	static_assert(NetworkAdminSocketPool::MAX_SIZE == MAX_ADMINS);
-	assert(!accept || ServerNetworkAdminSocketHandler::CanAllocateItem());
-	return accept;
+	return _settings_client.network.AdminAuthenticationConfigured() && ServerNetworkAdminSocketHandler::CanAllocateItem();
 }
 
 /** Send the packets for the server sockets. */

--- a/src/network/network_admin.h
+++ b/src/network/network_admin.h
@@ -14,11 +14,11 @@
 #include "core/tcp_listen.h"
 #include "core/tcp_admin.h"
 
-extern AdminIndex _redirect_console_to_admin;
+extern AdminID _redirect_console_to_admin;
 
 class ServerNetworkAdminSocketHandler;
 /** Pool with all admin connections. */
-typedef Pool<ServerNetworkAdminSocketHandler, AdminIndex, 2, MAX_ADMINS, PT_NADMIN> NetworkAdminSocketPool;
+typedef Pool<ServerNetworkAdminSocketHandler, AdminID, 2, 16, PT_NADMIN> NetworkAdminSocketPool;
 extern NetworkAdminSocketPool _networkadminsocket_pool;
 
 /** Class for handling the server side of the game connection. */
@@ -115,7 +115,7 @@ void NetworkAdminCompanyRemove(CompanyID company_id, AdminCompanyRemoveReason bc
 
 void NetworkAdminChat(NetworkAction action, DestType desttype, ClientID client_id, const std::string &msg, int64_t data = 0, bool from_admin = false);
 void NetworkAdminUpdate(AdminUpdateFrequency freq);
-void NetworkServerSendAdminRcon(AdminIndex admin_index, TextColour colour_code, const std::string_view string);
+void NetworkServerSendAdminRcon(AdminID admin_index, TextColour colour_code, const std::string_view string);
 void NetworkAdminConsole(const std::string_view origin, const std::string_view string);
 void NetworkAdminGameScript(const std::string_view json);
 void NetworkAdminCmdLogging(const NetworkClientSocket *owner, const CommandPacket &cp);

--- a/src/network/network_base.h
+++ b/src/network/network_base.h
@@ -17,7 +17,7 @@
 #include "../timer/timer_game_economy.h"
 
 /** Type for the pool with client information. */
-typedef Pool<NetworkClientInfo, ClientIndex, 8, MAX_CLIENT_SLOTS, PT_NCLIENT> NetworkClientInfoPool;
+using NetworkClientInfoPool = Pool<NetworkClientInfo, ClientPoolID, 8, MAX_CLIENT_SLOTS, PT_NCLIENT>;
 extern NetworkClientInfoPool _networkclientinfo_pool;
 
 /** Container for all information known about a client. */

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -17,7 +17,7 @@ class ServerNetworkGameSocketHandler;
 /** Make the code look slightly nicer/simpler. */
 typedef ServerNetworkGameSocketHandler NetworkClientSocket;
 /** Pool with all client sockets. */
-typedef Pool<NetworkClientSocket, ClientIndex, 8, MAX_CLIENT_SLOTS, PT_NCLIENT> NetworkClientSocketPool;
+using NetworkClientSocketPool = Pool<NetworkClientSocket, ClientPoolID, 8, MAX_CLIENT_SLOTS, PT_NCLIENT>;
 extern NetworkClientSocketPool _networkclientsocket_pool;
 
 /** Class for handling the server side of the game connection. */

--- a/src/network/network_type.h
+++ b/src/network/network_type.h
@@ -56,12 +56,10 @@ enum ClientID : uint32_t {
 typedef uint8_t ClientIndex;
 
 /** Indices into the admin tables. */
-typedef uint8_t AdminIndex;
+typedef uint8_t AdminID;
 
-/** Maximum number of allowed admins. */
-static const AdminIndex MAX_ADMINS = 16;
 /** An invalid admin marker. */
-static const AdminIndex INVALID_ADMIN_ID = UINT8_MAX;
+static const AdminID INVALID_ADMIN_ID = UINT8_MAX;
 
 /** Simple calculated statistics of a company */
 struct NetworkCompanyStats {

--- a/src/network/network_type.h
+++ b/src/network/network_type.h
@@ -52,8 +52,8 @@ enum ClientID : uint32_t {
 	CLIENT_ID_FIRST   = 2, ///< The first client ID
 };
 
-/** Indices into the client tables */
-typedef uint8_t ClientIndex;
+/** Indices into the client related pools */
+typedef uint8_t ClientPoolID;
 
 /** Indices into the admin tables. */
 typedef uint8_t AdminID;


### PR DESCRIPTION
## Motivation / Problem

All types for pool index are called `XXXID` except for `AdminIndex` and `ClientIndex`.

There is a counter for the number of allocated admins that is compared to some constant maximum. That is equivalent to the pool's number of items and whether the admin pool can still allocate an element, so why have two counters?

There is a mention of `ClientIndex` in the some documentation when `ClientID` was meant.


## Description

Remove custom counting with call to `Pool::CanAllocateItem()`. Also most the value of that constant to the pool's definition.

Rename `AdminIndex` to `AdminID`.
Rename `ClientIndex` to `ClientPoolID` as there is already a `ClientID` that is used extensively in external APIs.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
