### PR TITLE
Codefix: narrowing conversion warning for MSVC x86

### DIFF
--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -329,7 +329,7 @@ void BuildLandLegend()
 		_legend_land_contours[i].col_break = j % rows == 0;
 		_legend_land_contours[i].end = false;
 		_legend_land_contours[i].height = j * delta;
-		_legend_land_contours[i].colour = _heightmap_schemes[_settings_client.gui.smallmap_land_colour].height_colours[j * delta];
+		_legend_land_contours[i].colour = static_cast<uint8_t>(_heightmap_schemes[_settings_client.gui.smallmap_land_colour].height_colours[_legend_land_contours[i].height]);
 		j++;
 	}
 	_legend_land_contours[i].end = true;
@@ -340,7 +340,7 @@ void BuildLandLegend()
  */
 void BuildOwnerLegend()
 {
-	_legend_land_owners[1].colour = _heightmap_schemes[_settings_client.gui.smallmap_land_colour].default_colour;
+	_legend_land_owners[1].colour = static_cast<uint8_t>(_heightmap_schemes[_settings_client.gui.smallmap_land_colour].default_colour);
 
 	int i = NUM_NO_COMPANY_ENTRIES;
 	for (const Company *c : Company::Iterate()) {


### PR DESCRIPTION
## Motivation / Problem

When working on strongly typed PoolIDs something a header triggers MSVC x86 to complain about narrowing on line 332 of smallmap_gui.cpp. Of course it doesn't for line 343 which is also a narrowing conversion; both from uint32_t to uint8_t.

Trying to fix that, CodeQL starts whining about 'Multiplication result converted to larger type' because we multiple two small numbers (that won't overflow) and then use that as an index, so it assumes it might overflow...


## Description

Add `static_cast<uint8_t>` for line 332 and 343.

Use the already calculated height (line 331) in 332, instead of recalculating and letting CodeQL whine about it overflowing.

## Limitations

The casting at lines 332 and 343 are used to just chop up the higher 24 bits which are likely set. The height colours values are actually 4 colours byte stuffed into a `uint32_t`. It can be rewritten using a `std::array` with `uint8_t` and `operator[]`, however the codegen of `ApplyMask` is worse to horrible compared to the original code with high optimisation. As such that was abandoned.
https://godbolt.org/z/bYh5E9b8T


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
