### PR TITLE
Codechange: add concept of ConvertibleThroughBase for strong types

### DIFF
--- a/.github/workflows/ci-emscripten.yml
+++ b/.github/workflows/ci-emscripten.yml
@@ -23,6 +23,13 @@ jobs:
       run: |
         git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
+    - name: Update to modern GCC
+      run: |
+        apt-get update
+        apt-get install -y gcc-12 g++-12
+        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100
+        update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100
+
     - name: Setup cache
       uses: actions/cache@v4
       with:

--- a/os/emscripten/Dockerfile
+++ b/os/emscripten/Dockerfile
@@ -1,3 +1,10 @@
 FROM emscripten/emsdk:3.1.57
 
+RUN apt-get update \
+    && apt-get install -y gcc-12 g++-12 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY ports/liblzma.py /emsdk/upstream/emscripten/tools/ports/contrib/liblzma.py

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -4,6 +4,7 @@ add_files(
     alloc_type.hpp
     backup_type.hpp
     bitmath_func.hpp
+    convertible_through_base.hpp
     endian_func.hpp
     enum_type.hpp
     format.hpp

--- a/src/core/convertible_through_base.hpp
+++ b/src/core/convertible_through_base.hpp
@@ -1,0 +1,24 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file convertible_through_base.hpp Concept for unifying the convert through 'base()' behaviour of several 'strong' types. */
+
+#ifndef CONVERTIBLE_THROUGH_BASE_HPP
+#define CONVERTIBLE_THROUGH_BASE_HPP
+
+/**
+ * A type is considered 'convertible through base()' when it has a 'base()'
+ * function that returns something that can be converted to int64_t.
+ * @tparam T The type under consideration.
+ */
+template <typename T>
+concept ConvertibleThroughBase = requires(T const a) {
+	typename T::BaseType;
+	{ a.base() } noexcept -> std::convertible_to<int64_t>;
+};
+
+#endif /* CONVERTIBLE_THROUGH_BASE_HPP */

--- a/src/core/enum_type.hpp
+++ b/src/core/enum_type.hpp
@@ -117,8 +117,8 @@ debug_inline constexpr void ToggleFlag(T &x, const T y)
 template <typename Tenum, typename Tstorage>
 class EnumBitSet {
 public:
-	using enum_type = Tenum; ///< Enum type of this EnumBitSet.
-	using storage_type = Tstorage; ///< Storage type of this EnumBitSet.
+	using EnumType = Tenum; ///< Enum type of this EnumBitSet.
+	using BaseType = Tstorage; ///< Storage type of this EnumBitSet, be ConvertibleThroughBase
 
 	constexpr EnumBitSet() : data(0) {}
 	constexpr EnumBitSet(Tenum value) : data(0) { this->Set(value); }

--- a/src/core/format.hpp
+++ b/src/core/format.hpp
@@ -11,11 +11,11 @@
 #define FORMAT_HPP
 
 #include "../3rdparty/fmt/format.h"
-#include "strong_typedef_type.hpp"
+#include "convertible_through_base.hpp"
 
-template <typename E, typename Char>
-struct fmt::formatter<E, Char, std::enable_if_t<std::is_enum<E>::value>> : fmt::formatter<typename std::underlying_type<E>::type> {
-	using underlying_type = typename std::underlying_type<E>::type;
+template <typename E, typename Char> requires std::is_enum_v<E>
+struct fmt::formatter<E, Char> : fmt::formatter<typename std::underlying_type_t<E>> {
+	using underlying_type = typename std::underlying_type_t<E>;
 	using parent = typename fmt::formatter<underlying_type>;
 
 	constexpr fmt::format_parse_context::iterator parse(fmt::format_parse_context &ctx)
@@ -23,14 +23,14 @@ struct fmt::formatter<E, Char, std::enable_if_t<std::is_enum<E>::value>> : fmt::
 		return parent::parse(ctx);
 	}
 
-	fmt::format_context::iterator format(const E &e, format_context &ctx) const
+	fmt::format_context::iterator format(const E &e, fmt::format_context &ctx) const
 	{
 		return parent::format(underlying_type(e), ctx);
 	}
 };
 
-template <typename T, typename Char>
-struct fmt::formatter<T, Char, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value>> : fmt::formatter<typename T::BaseType> {
+template <ConvertibleThroughBase T, typename Char>
+struct fmt::formatter<T, Char> : fmt::formatter<typename T::BaseType> {
 	using underlying_type = typename T::BaseType;
 	using parent = typename fmt::formatter<underlying_type>;
 
@@ -39,7 +39,7 @@ struct fmt::formatter<T, Char, std::enable_if_t<std::is_base_of<StrongTypedefBas
 		return parent::parse(ctx);
 	}
 
-	fmt::format_context::iterator format(const T &t, format_context &ctx) const
+	fmt::format_context::iterator format(const T &t, fmt::format_context &ctx) const
 	{
 		return parent::format(t.base(), ctx);
 	}

--- a/src/core/math_func.hpp
+++ b/src/core/math_func.hpp
@@ -10,7 +10,7 @@
 #ifndef MATH_FUNC_HPP
 #define MATH_FUNC_HPP
 
-#include "strong_typedef_type.hpp"
+#include "convertible_through_base.hpp"
 
 /**
  * Returns the absolute value of (scalar) variable.
@@ -217,8 +217,8 @@ constexpr To ClampTo(From value)
 /**
  * Specialization of ClampTo for #StrongType::Typedef.
  */
-template <typename To, typename From, std::enable_if_t<std::is_base_of<StrongTypedefBase, From>::value, int> = 0>
-constexpr To ClampTo(From value)
+template <typename To>
+constexpr To ClampTo(ConvertibleThroughBase auto value)
 {
 	return ClampTo<To>(value.base());
 }
@@ -264,15 +264,12 @@ constexpr bool IsInsideBS(const T x, const size_t base, const size_t size)
  * @param max The maximum of the interval
  * @see IsInsideBS()
  */
-template <typename T, std::enable_if_t<std::disjunction_v<std::is_convertible<T, size_t>, std::is_base_of<StrongTypedefBase, T>>, int> = 0>
-constexpr bool IsInsideMM(const T x, const size_t min, const size_t max) noexcept
+constexpr bool IsInsideMM(const size_t x, const size_t min, const size_t max) noexcept
 {
-	if constexpr (std::is_base_of_v<StrongTypedefBase, T>) {
-		return static_cast<size_t>(x.base() - min) < (max - min);
-	} else {
-		return static_cast<size_t>(x - min) < (max - min);
-	}
+	return static_cast<size_t>(x - min) < (max - min);
 }
+
+constexpr bool IsInsideMM(const ConvertibleThroughBase auto x, const size_t min, const size_t max) noexcept { return IsInsideMM(x.base(), min, max); }
 
 /**
  * Type safe swap operation

--- a/src/core/strong_typedef_type.hpp
+++ b/src/core/strong_typedef_type.hpp
@@ -160,7 +160,7 @@ namespace StrongType {
 		constexpr Typedef &operator =(Typedef &&rhs) { this->value = std::move(rhs.value); return *this; }
 
 		/* Only allow conversion to BaseType via method. */
-		constexpr TBaseType base() const { return this->value; }
+		constexpr TBaseType base() const noexcept { return this->value; }
 
 		/* Only allow TProperties classes access to the internal value. Everyone else needs to call .base(). */
 		friend struct Compare;

--- a/src/misc/endian_buffer.hpp
+++ b/src/misc/endian_buffer.hpp
@@ -35,9 +35,6 @@ public:
 	EndianBufferWriter &operator <<(std::string_view data) { this->Write(data); return *this; }
 	EndianBufferWriter &operator <<(bool data) { return *this << static_cast<uint8_t>(data ? 1 : 0); }
 
-	template <typename Tenum, typename Tstorage>
-	EndianBufferWriter &operator <<(const EnumBitSet<Tenum, Tstorage> &data) { return *this << data.base(); }
-
 	template <typename T>
 	EndianBufferWriter &operator <<(const OverflowSafeInt<T> &data) { return *this << static_cast<T>(data); };
 
@@ -135,9 +132,6 @@ public:
 
 	EndianBufferReader &operator >>(std::string &data) { data = this->ReadStr(); return *this; }
 	EndianBufferReader &operator >>(bool &data) { data = this->Read<uint8_t>() != 0; return *this; }
-
-	template <typename Tenum, typename Tstorage>
-	EndianBufferReader &operator >>(EnumBitSet<Tenum, Tstorage> &data) { data = Tenum{this->Read<Tstorage>()}; return *this; }
 
 	template <typename T>
 	EndianBufferReader &operator >>(OverflowSafeInt<T> &data) { data = this->Read<T>(); return *this; };

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1949,8 +1949,7 @@ static bool OrderConditionCompare(OrderConditionComparator occ, int variable, in
 	}
 }
 
-template <typename T, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value, int> = 0>
-static bool OrderConditionCompare(OrderConditionComparator occ, T variable, int value)
+static bool OrderConditionCompare(OrderConditionComparator occ, ConvertibleThroughBase auto variable, int value)
 {
 	return OrderConditionCompare(occ, variable.base(), value);
 }

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -14,7 +14,7 @@
 #include "string_type.h"
 #include "gfx_type.h"
 #include "core/bitmath_func.hpp"
-#include "core/strong_typedef_type.hpp"
+#include "core/convertible_through_base.hpp"
 #include "vehicle_type.h"
 
 /**
@@ -83,14 +83,12 @@ void SetDParam(size_t n, uint64_t v);
 void SetDParamMaxValue(size_t n, uint64_t max_value, uint min_count = 0, FontSize size = FS_NORMAL);
 void SetDParamMaxDigits(size_t n, uint count, FontSize size = FS_NORMAL);
 
-template <typename T, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value, int> = 0>
-void SetDParam(size_t n, T v)
+void SetDParam(size_t n, ConvertibleThroughBase auto v)
 {
 	SetDParam(n, v.base());
 }
 
-template <typename T, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value, int> = 0>
-void SetDParamMaxValue(size_t n, T max_value, uint min_count = 0, FontSize size = FS_NORMAL)
+void SetDParamMaxValue(size_t n, ConvertibleThroughBase auto max_value, uint min_count = 0, FontSize size = FS_NORMAL)
 {
 	SetDParamMaxValue(n, max_value.base(), min_count, size);
 }

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -167,8 +167,7 @@ public:
 		this->parameters[n].data = v;
 	}
 
-	template <typename T, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value, int> = 0>
-	void SetParam(size_t n, T v)
+	void SetParam(size_t n, ConvertibleThroughBase auto v)
 	{
 		SetParam(n, v.base());
 	}

--- a/src/window_func.h
+++ b/src/window_func.h
@@ -12,16 +12,15 @@
 
 #include "window_type.h"
 #include "company_type.h"
+#include "core/convertible_through_base.hpp"
 #include "core/geometry_type.hpp"
-#include "core/strong_typedef_type.hpp"
 
 Window *FindWindowById(WindowClass cls, WindowNumber number);
 Window *FindWindowByClass(WindowClass cls);
 Window *GetMainWindow();
 void ChangeWindowOwner(Owner old_owner, Owner new_owner);
 
-template <typename T, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value, int> = 0>
-Window *FindWindowById(WindowClass cls, T number)
+Window *FindWindowById(WindowClass cls, ConvertibleThroughBase auto number)
 {
 	return FindWindowById(cls, number.base());
 }
@@ -44,8 +43,7 @@ void InputLoop();
 void InvalidateWindowData(WindowClass cls, WindowNumber number, int data = 0, bool gui_scope = false);
 void InvalidateWindowClassesData(WindowClass cls, int data = 0, bool gui_scope = false);
 
-template <typename T, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value, int> = 0>
-void InvalidateWindowData(WindowClass cls, T number, int data = 0, bool gui_scope = false)
+void InvalidateWindowData(WindowClass cls, ConvertibleThroughBase auto number, int data = 0, bool gui_scope = false)
 {
 	InvalidateWindowData(cls, number.base(), data, gui_scope);
 }
@@ -67,8 +65,7 @@ void SetWindowWidgetDirty(WindowClass cls, WindowNumber number, WidgetID widget_
 void SetWindowDirty(WindowClass cls, WindowNumber number);
 void SetWindowClassesDirty(WindowClass cls);
 
-template <typename T, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value, int> = 0>
-void SetWindowDirty(WindowClass cls, T number)
+void SetWindowDirty(WindowClass cls, ConvertibleThroughBase auto number)
 {
 	SetWindowDirty(cls, number.base());
 }
@@ -76,8 +73,7 @@ void SetWindowDirty(WindowClass cls, T number)
 void CloseWindowById(WindowClass cls, WindowNumber number, bool force = true, int data = 0);
 void CloseWindowByClass(WindowClass cls, int data = 0);
 
-template <typename T, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value, int> = 0>
-void CloseWindowById(WindowClass cls, T number, bool force = true, int data = 0)
+void CloseWindowById(WindowClass cls, ConvertibleThroughBase auto number, bool force = true, int data = 0)
 {
 	CloseWindowById(cls, number.base(), force, data);
 }

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -348,8 +348,7 @@ public:
 	void CreateNestedTree();
 	void FinishInitNested(WindowNumber window_number = 0);
 
-	template <typename T, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value, int> = 0>
-	void FinishInitNested(T number)
+	void FinishInitNested(ConvertibleThroughBase auto number)
 	{
 		this->FinishInitNested(number.base());
 	}
@@ -996,8 +995,7 @@ public:
 Window *BringWindowToFrontById(WindowClass cls, WindowNumber number);
 Window *FindWindowFromPt(int x, int y);
 
-template <typename T, std::enable_if_t<std::is_base_of<StrongTypedefBase, T>::value, int> = 0>
-Window *BringWindowToFrontById(WindowClass cls, T number)
+Window *BringWindowToFrontById(WindowClass cls, ConvertibleThroughBase auto number)
 {
 	return BringWindowToFrontById(cls, number.base());
 }


### PR DESCRIPTION
## Motivation / Problem

We have `Strong::Typedef` and recently `EnumBitSet` that have a `.base()` function to get to the raw value, and soon I hope to introduce one for `PoolID`s (can't be typedef due to initialisation concerns). That would mean introducing more templated variants of functions that are basically the same. In other words, a lot of extra code would be needed for basically nothing.


## Description

With concepts you can constrain what a template picks up. In this case:
```
template <typename T>
concept ConvertibleThroughBase = requires(T const a) {
	typename T::BaseType;
	{ a.base() } noexcept -> std::convertible_to<int64_t>;
};
```
ConvertibleThroughBase is any type that provides a type with name `BaseType` and a `base()` function that is const and throws no exceptions. This essentially covers both the strong typedef and enum bitset, but also the future pool ID.

After adding this, the templates where there were guards using `std::is_base_of<StrongTypedefBase, X>` were replaced by this concept. This makes `fmt::format`-ing an `EnumBitSet` work out of the box, you can pass them through the EndianBuffer, and to `SetDParam` and friends.


## Limitations

The compiler needs to support this, so sadly GCC 11 has to be let go.

Functions with a `std::disjunction` were split into two versions. A few more lines of code, but much easier to read code.

Weirdly GCC started complaining about line 42 that `format_context` could not be found, when it worked before. Prefixing with `fmt::` solved the issue. No idea why it started failing now, when it worked before, but adding the `fmt::` seems like the right thing from the start. So maybe the question is, why don't the other compilers warn?


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
