### PR TITLE
Codechange: Use EnumBitSet for pool types

### DIFF
--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -24,7 +24,7 @@ typedef uint32_t CargoPacketID;
 struct CargoPacket;
 
 /** Type of the pool for cargo packets for a little over 16 million packets. */
-typedef Pool<CargoPacket, CargoPacketID, 1024, 0xFFF000, PT_NORMAL, true, false> CargoPacketPool;
+using CargoPacketPool = Pool<CargoPacket, CargoPacketID, 1024, 0xFFF000, PoolType::Normal, true, false>;
 /** The actual pool with cargo packets. */
 extern CargoPacketPool _cargopacket_pool;
 

--- a/src/core/pool_func.cpp
+++ b/src/core/pool_func.cpp
@@ -27,9 +27,9 @@
  * Clean all pools of given type.
  * @param pt pool types to clean.
  */
-/* static */ void PoolBase::Clean(PoolType pt)
+/* static */ void PoolBase::Clean(PoolTypes pt)
 {
 	for (PoolBase *pool : *PoolBase::GetPools()) {
-		if (pool->type & pt) pool->CleanPool();
+		if (pt.Test(pool->type)) pool->CleanPool();
 	}
 }

--- a/src/core/pool_type.hpp
+++ b/src/core/pool_type.hpp
@@ -13,15 +13,14 @@
 #include "enum_type.hpp"
 
 /** Various types of a pool. */
-enum PoolType : uint8_t {
-	PT_NONE    = 0x00, ///< No pool is selected.
-	PT_NORMAL  = 0x01, ///< Normal pool containing game objects.
-	PT_NCLIENT = 0x02, ///< Network client pools.
-	PT_NADMIN  = 0x04, ///< Network admin pool.
-	PT_DATA    = 0x08, ///< NewGRF or other data, that is not reset together with normal pools.
-	PT_ALL     = 0x0F, ///< All pool types.
+enum class PoolType : uint8_t {
+	Normal, ///< Normal pool containing game objects.
+	NetworkClient, ///< Network client pools.
+	NetworkAdmin, ///< Network admin pool.
+	Data, ///< NewGRF or other data, that is not reset together with normal pools.
 };
-DECLARE_ENUM_AS_BIT_SET(PoolType)
+using PoolTypes = EnumBitSet<PoolType, uint8_t>;
+static constexpr PoolTypes PT_ALL = {PoolType::Normal, PoolType::NetworkClient, PoolType::NetworkAdmin, PoolType::Data};
 
 typedef std::vector<struct PoolBase *> PoolVector; ///< Vector of pointers to PoolBase
 
@@ -39,7 +38,7 @@ struct PoolBase {
 		return pools;
 	}
 
-	static void Clean(PoolType);
+	static void Clean(PoolTypes);
 
 	/**
 	 * Constructor registers this object in the pool vector.
@@ -76,7 +75,7 @@ private:
  * @tparam Tzero        Whether to zero the memory
  * @warning when Tcache is enabled *all* instances of this pool's item must be of the same size.
  */
-template <class Titem, typename Tindex, size_t Tgrowth_step, size_t Tmax_size, PoolType Tpool_type = PT_NORMAL, bool Tcache = false, bool Tzero = true>
+template <class Titem, typename Tindex, size_t Tgrowth_step, size_t Tmax_size, PoolType Tpool_type = PoolType::Normal, bool Tcache = false, bool Tzero = true>
 struct Pool : PoolBase {
 private:
 	/** Some helper functions to get the maximum value of the provided index. */

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -121,7 +121,7 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 	}
 
 	LinkGraphSchedule::Clear();
-	PoolBase::Clean(PT_NORMAL);
+	PoolBase::Clean(PoolType::Normal);
 
 	RebuildStationKdtree();
 	RebuildTownKdtree();

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -582,7 +582,9 @@ NetworkAddress ParseConnectionString(const std::string &connection_string, uint1
  */
 static void InitializeNetworkPools(bool close_admins = true)
 {
-	PoolBase::Clean(PT_NCLIENT | (close_admins ? PT_NADMIN : PT_NONE));
+	PoolTypes to_clean{PoolType::NetworkClient};
+	if (close_admins) to_clean.Set(PoolType::NetworkAdmin);
+	PoolBase::Clean(to_clean);
 }
 
 /**

--- a/src/network/network_admin.h
+++ b/src/network/network_admin.h
@@ -18,7 +18,7 @@ extern AdminID _redirect_console_to_admin;
 
 class ServerNetworkAdminSocketHandler;
 /** Pool with all admin connections. */
-typedef Pool<ServerNetworkAdminSocketHandler, AdminID, 2, 16, PT_NADMIN> NetworkAdminSocketPool;
+using NetworkAdminSocketPool = Pool<ServerNetworkAdminSocketHandler, AdminID, 2, 16, PoolType::NetworkAdmin>;
 extern NetworkAdminSocketPool _networkadminsocket_pool;
 
 /** Class for handling the server side of the game connection. */

--- a/src/network/network_base.h
+++ b/src/network/network_base.h
@@ -17,7 +17,7 @@
 #include "../timer/timer_game_economy.h"
 
 /** Type for the pool with client information. */
-using NetworkClientInfoPool = Pool<NetworkClientInfo, ClientPoolID, 8, MAX_CLIENT_SLOTS, PT_NCLIENT>;
+using NetworkClientInfoPool = Pool<NetworkClientInfo, ClientPoolID, 8, MAX_CLIENT_SLOTS, PoolType::NetworkClient>;
 extern NetworkClientInfoPool _networkclientinfo_pool;
 
 /** Container for all information known about a client. */

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -17,7 +17,7 @@ class ServerNetworkGameSocketHandler;
 /** Make the code look slightly nicer/simpler. */
 typedef ServerNetworkGameSocketHandler NetworkClientSocket;
 /** Pool with all client sockets. */
-using NetworkClientSocketPool = Pool<NetworkClientSocket, ClientPoolID, 8, MAX_CLIENT_SLOTS, PT_NCLIENT>;
+using NetworkClientSocketPool = Pool<NetworkClientSocket, ClientPoolID, 8, MAX_CLIENT_SLOTS, PoolType::NetworkClient>;
 extern NetworkClientSocketPool _networkclientsocket_pool;
 
 /** Class for handling the server side of the game connection. */

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -50,7 +50,7 @@ struct ResolverObject;
 /* SPRITE_WIDTH is 24. ECS has roughly 30 sprite groups per real sprite.
  * Adding an 'extra' margin would be assuming 64 sprite groups per real
  * sprite. 64 = 2^6, so 2^30 should be enough (for now) */
-typedef Pool<SpriteGroup, SpriteGroupID, 1024, 1U << 30, PT_DATA> SpriteGroupPool;
+using SpriteGroupPool = Pool<SpriteGroup, SpriteGroupID, 1024, 1U << 30, PoolType::Data>;
 extern SpriteGroupPool _spritegroup_pool;
 
 /* Common wrapper for all the different sprite group types */


### PR DESCRIPTION
## Motivation / Problem

EnumBitSet and enum class.


## Description

Use `EnumBitSet` for `PoolType`.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
