### PR TITLE
Add: Press Ctrl to build diagonal canals in game mode

### DIFF
--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -152,7 +152,11 @@ struct BuildDocksToolbarWindow : Window {
 	{
 		switch (widget) {
 			case WID_DT_CANAL: // Build canal button
-				HandlePlacePushButton(this, WID_DT_CANAL, SPR_CURSOR_CANAL, HT_RECT);
+				if (_game_mode == GM_EDITOR) {
+					HandlePlacePushButton(this, WID_DT_CANAL, SPR_CURSOR_CANAL, HT_RECT);
+				} else {
+					HandlePlacePushButton(this, WID_DT_CANAL, SPR_CURSOR_CANAL, HT_RECT | HT_DIAGONAL);
+				}
 				break;
 
 			case WID_DT_LOCK: // Build lock button
@@ -255,7 +259,11 @@ struct BuildDocksToolbarWindow : Window {
 					GUIPlaceProcDragXY(select_proc, start_tile, end_tile);
 					break;
 				case DDSP_CREATE_WATER:
-					Command<CMD_BUILD_CANAL>::Post(STR_ERROR_CAN_T_BUILD_CANALS, CcPlaySound_CONSTRUCTION_WATER, end_tile, start_tile, (_game_mode == GM_EDITOR && _ctrl_pressed) ? WATER_CLASS_SEA : WATER_CLASS_CANAL, false);
+					if (_game_mode == GM_EDITOR) {
+						Command<CMD_BUILD_CANAL>::Post(STR_ERROR_CAN_T_BUILD_CANALS, CcPlaySound_CONSTRUCTION_WATER, end_tile, start_tile, _ctrl_pressed ? WATER_CLASS_SEA : WATER_CLASS_CANAL, false);
+					} else {
+						Command<CMD_BUILD_CANAL>::Post(STR_ERROR_CAN_T_BUILD_CANALS, CcPlaySound_CONSTRUCTION_WATER, end_tile, start_tile, WATER_CLASS_CANAL, _ctrl_pressed);
+					}
 					break;
 				case DDSP_CREATE_RIVER:
 					Command<CMD_BUILD_CANAL>::Post(STR_ERROR_CAN_T_PLACE_RIVERS, CcPlaySound_CONSTRUCTION_WATER, end_tile, start_tile, WATER_CLASS_RIVER, _ctrl_pressed);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2950,7 +2950,7 @@ STR_STATION_BUILD_CARGO_TRAM_ORIENTATION_TOOLTIP                :{BLACK}Select f
 # Waterways toolbar (last two for SE only)
 STR_WATERWAYS_TOOLBAR_CAPTION                                   :{WHITE}Waterways Construction
 STR_WATERWAYS_TOOLBAR_CAPTION_SE                                :{WHITE}Waterways
-STR_WATERWAYS_TOOLBAR_BUILD_CANALS_TOOLTIP                      :{BLACK}Build canals. Also press Shift to show cost estimate only
+STR_WATERWAYS_TOOLBAR_BUILD_CANALS_TOOLTIP                      :{BLACK}Build canals. Ctrl+Click+Drag to select the area diagonally. Also press Shift to show cost estimate only
 STR_WATERWAYS_TOOLBAR_BUILD_LOCKS_TOOLTIP                       :{BLACK}Build locks. Also press Shift to show cost estimate only
 STR_WATERWAYS_TOOLBAR_BUILD_DEPOT_TOOLTIP                       :{BLACK}Build ship depot (for buying and servicing ships). Also press Shift to show cost estimate only
 STR_WATERWAYS_TOOLBAR_BUILD_DOCK_TOOLTIP                        :{BLACK}Build ship dock. Ctrl+Click to select another station to join. Also press Shift to show cost estimate only


### PR DESCRIPTION
Fix #13431: Press Ctrl to build diagonal canals in game mode

Enable diagonal build shape for canals in game mode when Ctrl is pressed down.

In editor mode we keep current behaviour.


## Motivation / Problem

In game mode we cannot build diagonal canal by holding Ctrl, but diagonal landscape shaping (raise and lower land) or diagonal tree planting is possible when Ctrl is held down.

I think we should maintain consistent behaviour, and if Ctrl is held down while building we should build/modify diagonally. Ships can move diagonally, so building diagonal canals makes sense.


## Description

Allow to build diagonal canals when Ctrl is pressed down in game mode.
In editor mode we do not change behavior, because Ctrl switch tile type to sea.


## Limitations

In editor mode, when canal is built and Ctrl is held down, then Sea tile type is placed (if tile is on sea level). I tried to change that behaviour and use Shift to place Sea tile, but Shift held down while building shows information with build cost (which is weird in editor mode). Alternatively, maybe we can use Alt for Sea tile, but it is a bigger change. Therefore, I left current/old behaviour in edtior mode.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')

No.

* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)

Yes.

* This PR affects the save game format? (label 'savegame upgrade')

No.

* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.

No.

* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)

No.
