### PR TITLE
Codechange: remove unused Pack from Order

### DIFF
--- a/src/order_base.h
+++ b/src/order_base.h
@@ -244,7 +244,6 @@ public:
 	void AssignOrder(const Order &other);
 	bool Equals(const Order &other) const;
 
-	uint32_t Pack() const;
 	uint16_t MapOldOrder() const;
 	void ConvertFromOldSavegame();
 };

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -190,17 +190,6 @@ bool Order::Equals(const Order &other) const
 }
 
 /**
- * Pack this order into a 32 bits integer, or actually only
- * the type, flags and destination.
- * @return the packed representation.
- * @note unpacking is done in the constructor.
- */
-uint32_t Order::Pack() const
-{
-	return this->dest << 16 | this->flags << 8 | this->type;
-}
-
-/**
  * Pack this order into a 16 bits integer as close to the TTD
  * representation as possible.
  * @return the TTD-like packed representation.


### PR DESCRIPTION
## Motivation / Problem

Unused code.


## Description

Order Order to Pack Pack and leave ;)


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
