### PR TITLE
Codechange: allow passing extra parameters through AllocateWindowDescFront

### DIFF
--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -842,7 +842,7 @@ CommandCost CmdSetAutoReplace(DoCommandFlag flags, GroupID id_g, EngineID old_en
 		if (IsLocalCompany()) SetWindowDirty(WC_REPLACE_VEHICLE, Engine::Get(old_engine_type)->type);
 
 		const VehicleType vt = Engine::Get(old_engine_type)->type;
-		SetWindowDirty(GetWindowClassForVehicleType(vt), VehicleListIdentifier(VL_GROUP_LIST, vt, _current_company).Pack());
+		SetWindowDirty(GetWindowClassForVehicleType(vt), VehicleListIdentifier(VL_GROUP_LIST, vt, _current_company).ToWindowNumber());
 	}
 	if ((flags & DC_EXEC) && IsLocalCompany()) InvalidateAutoreplaceWindow(old_engine_type, id_g);
 

--- a/src/depot.cpp
+++ b/src/depot.cpp
@@ -45,5 +45,5 @@ Depot::~Depot()
 
 	/* Delete the depot list */
 	VehicleType vt = GetDepotVehicleType(this->xy);
-	CloseWindowById(GetWindowClassForVehicleType(vt), VehicleListIdentifier(VL_DEPOT_LIST, vt, GetTileOwner(this->xy), this->index).Pack());
+	CloseWindowById(GetWindowClassForVehicleType(vt), VehicleListIdentifier(VL_DEPOT_LIST, vt, GetTileOwner(this->xy), this->index).ToWindowNumber());
 }

--- a/src/depot_cmd.cpp
+++ b/src/depot_cmd.cpp
@@ -72,7 +72,7 @@ CommandCost CmdRenameDepot(DoCommandFlag flags, DepotID depot_id, const std::str
 
 		/* Update the depot list */
 		VehicleType vt = GetDepotVehicleType(d->xy);
-		SetWindowDirty(GetWindowClassForVehicleType(vt), VehicleListIdentifier(VL_DEPOT_LIST, vt, GetTileOwner(d->xy), d->index).Pack());
+		SetWindowDirty(GetWindowClassForVehicleType(vt), VehicleListIdentifier(VL_DEPOT_LIST, vt, GetTileOwner(d->xy), d->index).ToWindowNumber());
 	}
 	return CommandCost();
 }

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -299,7 +299,7 @@ struct DepotWindow : Window {
 	void Close([[maybe_unused]] int data = 0) override
 	{
 		CloseWindowById(WC_BUILD_VEHICLE, this->window_number);
-		CloseWindowById(GetWindowClassForVehicleType(this->type), VehicleListIdentifier(VL_DEPOT_LIST, this->type, this->owner, this->GetDepotIndex()).Pack(), false);
+		CloseWindowById(GetWindowClassForVehicleType(this->type), VehicleListIdentifier(VL_DEPOT_LIST, this->type, this->owner, this->GetDepotIndex()).ToWindowNumber(), false);
 		OrderBackup::Reset(TileIndex(this->window_number));
 		this->Window::Close();
 	}

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -1030,7 +1030,7 @@ void ShowFramerateWindow()
 void ShowFrametimeGraphWindow(PerformanceElement elem)
 {
 	if (elem < PFE_FIRST || elem >= PFE_MAX) return; // maybe warn?
-	AllocateWindowDescFront<FrametimeGraphWindow>(_frametime_graph_window_desc, elem, true);
+	AllocateWindowDescFront<FrametimeGraphWindow>(_frametime_graph_window_desc, elem);
 }
 
 /** Print performance statistics to game console */

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -1030,7 +1030,7 @@ static void _ShowGenerateLandscape(GenerateLandscapeWindowMode mode)
 	}
 
 	WindowDesc &desc = (mode == GLWM_HEIGHTMAP) ? _heightmap_load_desc : _generate_landscape_desc;
-	GenerateLandscapeWindow *w = AllocateWindowDescFront<GenerateLandscapeWindow>(desc, mode, true);
+	GenerateLandscapeWindow *w = AllocateWindowDescFront<GenerateLandscapeWindow, true>(desc, mode);
 
 	if (mode == GLWM_HEIGHTMAP) {
 		w->x = x;

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -363,7 +363,7 @@ std::tuple<CommandCost, GroupID> CmdCreateGroup(DoCommandFlag flags, VehicleType
 			g->flags = pg->flags;
 		}
 
-		InvalidateWindowData(GetWindowClassForVehicleType(vt), VehicleListIdentifier(VL_GROUP_LIST, vt, _current_company).Pack());
+		InvalidateWindowData(GetWindowClassForVehicleType(vt), VehicleListIdentifier(VL_GROUP_LIST, vt, _current_company).ToWindowNumber());
 		InvalidateWindowData(WC_COMPANY_COLOUR, g->owner, g->vehicle_type);
 
 		return { CommandCost(), g->index };
@@ -415,7 +415,7 @@ CommandCost CmdDeleteGroup(DoCommandFlag flags, GroupID group_id)
 		CloseWindowById(WC_REPLACE_VEHICLE, g->vehicle_type);
 		delete g;
 
-		InvalidateWindowData(GetWindowClassForVehicleType(vt), VehicleListIdentifier(VL_GROUP_LIST, vt, _current_company).Pack());
+		InvalidateWindowData(GetWindowClassForVehicleType(vt), VehicleListIdentifier(VL_GROUP_LIST, vt, _current_company).ToWindowNumber());
 		InvalidateWindowData(WC_COMPANY_COLOUR, _current_company, vt);
 	}
 
@@ -485,7 +485,7 @@ CommandCost CmdAlterGroup(DoCommandFlag flags, AlterGroupMode mode, GroupID grou
 
 	if (flags & DC_EXEC) {
 		InvalidateWindowData(WC_REPLACE_VEHICLE, g->vehicle_type, 1);
-		InvalidateWindowData(GetWindowClassForVehicleType(g->vehicle_type), VehicleListIdentifier(VL_GROUP_LIST, g->vehicle_type, _current_company).Pack());
+		InvalidateWindowData(GetWindowClassForVehicleType(g->vehicle_type), VehicleListIdentifier(VL_GROUP_LIST, g->vehicle_type, _current_company).ToWindowNumber());
 		InvalidateWindowData(WC_COMPANY_COLOUR, g->owner, g->vehicle_type);
 		InvalidateWindowClassesData(WC_VEHICLE_VIEW);
 		InvalidateWindowClassesData(WC_VEHICLE_DETAILS);
@@ -590,7 +590,7 @@ std::tuple<CommandCost, GroupID> CmdAddVehicleGroup(DoCommandFlag flags, GroupID
 
 		/* Update the Replace Vehicle Windows */
 		SetWindowDirty(WC_REPLACE_VEHICLE, vtype);
-		InvalidateWindowData(GetWindowClassForVehicleType(vtype), VehicleListIdentifier(VL_GROUP_LIST, vtype, _current_company).Pack());
+		InvalidateWindowData(GetWindowClassForVehicleType(vtype), VehicleListIdentifier(VL_GROUP_LIST, vtype, _current_company).ToWindowNumber());
 	}
 
 	return { CommandCost(), new_g };
@@ -621,7 +621,7 @@ CommandCost CmdAddSharedVehicleGroup(DoCommandFlag flags, GroupID id_g, VehicleT
 			}
 		}
 
-		InvalidateWindowData(GetWindowClassForVehicleType(type), VehicleListIdentifier(VL_GROUP_LIST, type, _current_company).Pack());
+		InvalidateWindowData(GetWindowClassForVehicleType(type), VehicleListIdentifier(VL_GROUP_LIST, type, _current_company).ToWindowNumber());
 	}
 
 	return CommandCost();
@@ -651,7 +651,7 @@ CommandCost CmdRemoveAllVehiclesGroup(DoCommandFlag flags, GroupID group_id)
 			}
 		}
 
-		InvalidateWindowData(GetWindowClassForVehicleType(g->vehicle_type), VehicleListIdentifier(VL_GROUP_LIST, g->vehicle_type, _current_company).Pack());
+		InvalidateWindowData(GetWindowClassForVehicleType(g->vehicle_type), VehicleListIdentifier(VL_GROUP_LIST, g->vehicle_type, _current_company).ToWindowNumber());
 	}
 
 	return CommandCost();
@@ -729,7 +729,7 @@ CommandCost CmdSetGroupFlag(DoCommandFlag flags, GroupID group_id, GroupFlag fla
 	if (flags & DC_EXEC) {
 		SetGroupFlag(g, flag, value, recursive);
 
-		SetWindowDirty(GetWindowClassForVehicleType(g->vehicle_type), VehicleListIdentifier(VL_GROUP_LIST, g->vehicle_type, _current_company).Pack());
+		SetWindowDirty(GetWindowClassForVehicleType(g->vehicle_type), VehicleListIdentifier(VL_GROUP_LIST, g->vehicle_type, _current_company).ToWindowNumber());
 		InvalidateWindowData(WC_REPLACE_VEHICLE, g->vehicle_type);
 	}
 

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -1182,16 +1182,28 @@ static WindowDesc _vehicle_group_desc[] = {
  * @param company The company to show the window for.
  * @param vehicle_type The type of vehicle to show it for.
  * @param group The group to be selected. Defaults to INVALID_GROUP.
- * @param need_existing_window Whether the existing window is needed. Defaults to false.
+ * @tparam Tneed_existing_window Whether the existing window is needed.
  */
-void ShowCompanyGroup(CompanyID company, VehicleType vehicle_type, GroupID group, bool need_existing_window)
+template <bool Tneed_existing_window>
+static void ShowCompanyGroupInternal(CompanyID company, VehicleType vehicle_type, GroupID group)
 {
 	if (!Company::IsValidID(company)) return;
 
 	assert(vehicle_type < std::size(_vehicle_group_desc));
 	const WindowNumber num = VehicleListIdentifier(VL_GROUP_LIST, vehicle_type, company).Pack();
-	VehicleGroupWindow *w = AllocateWindowDescFront<VehicleGroupWindow>(_vehicle_group_desc[vehicle_type], num, need_existing_window);
+	VehicleGroupWindow *w = AllocateWindowDescFront<VehicleGroupWindow, Tneed_existing_window>(_vehicle_group_desc[vehicle_type], num);
 	if (w != nullptr) w->SelectGroup(group);
+}
+
+/**
+ * Show the group window for the given company and vehicle type.
+ * @param company The company to show the window for.
+ * @param vehicle_type The type of vehicle to show it for.
+ * @param group The group to be selected. Defaults to INVALID_GROUP.
+ */
+void ShowCompanyGroup(CompanyID company, VehicleType vehicle_type, GroupID group)
+{
+	ShowCompanyGroupInternal<false>(company, vehicle_type, group);
 }
 
 /**
@@ -1200,7 +1212,7 @@ void ShowCompanyGroup(CompanyID company, VehicleType vehicle_type, GroupID group
  */
 void ShowCompanyGroupForVehicle(const Vehicle *v)
 {
-	ShowCompanyGroup(v->owner, v->type, v->group_id, true);
+	ShowCompanyGroupInternal<true>(v->owner, v->type, v->group_id);
 }
 
 /**

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -388,7 +388,7 @@ private:
 	}
 
 public:
-	VehicleGroupWindow(WindowDesc &desc, WindowNumber window_number) : BaseVehicleListWindow(desc, window_number)
+	VehicleGroupWindow(WindowDesc &desc, WindowNumber window_number, const VehicleListIdentifier &vli) : BaseVehicleListWindow(desc, vli)
 	{
 		this->CreateNestedTree();
 
@@ -1190,8 +1190,8 @@ static void ShowCompanyGroupInternal(CompanyID company, VehicleType vehicle_type
 	if (!Company::IsValidID(company)) return;
 
 	assert(vehicle_type < std::size(_vehicle_group_desc));
-	const WindowNumber num = VehicleListIdentifier(VL_GROUP_LIST, vehicle_type, company).Pack();
-	VehicleGroupWindow *w = AllocateWindowDescFront<VehicleGroupWindow, Tneed_existing_window>(_vehicle_group_desc[vehicle_type], num);
+	VehicleListIdentifier vli(VL_GROUP_LIST, vehicle_type, company);
+	VehicleGroupWindow *w = AllocateWindowDescFront<VehicleGroupWindow, Tneed_existing_window>(_vehicle_group_desc[vehicle_type], vli.Pack(), vli);
 	if (w != nullptr) w->SelectGroup(group);
 }
 

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -1191,7 +1191,7 @@ static void ShowCompanyGroupInternal(CompanyID company, VehicleType vehicle_type
 
 	assert(vehicle_type < std::size(_vehicle_group_desc));
 	VehicleListIdentifier vli(VL_GROUP_LIST, vehicle_type, company);
-	VehicleGroupWindow *w = AllocateWindowDescFront<VehicleGroupWindow, Tneed_existing_window>(_vehicle_group_desc[vehicle_type], vli.Pack(), vli);
+	VehicleGroupWindow *w = AllocateWindowDescFront<VehicleGroupWindow, Tneed_existing_window>(_vehicle_group_desc[vehicle_type], vli.ToWindowNumber(), vli);
 	if (w != nullptr) w->SelectGroup(group);
 }
 
@@ -1223,7 +1223,7 @@ void ShowCompanyGroupForVehicle(const Vehicle *v)
  */
 static inline VehicleGroupWindow *FindVehicleGroupWindow(VehicleType vt, Owner owner)
 {
-	return dynamic_cast<VehicleGroupWindow *>(FindWindowById(GetWindowClassForVehicleType(vt), VehicleListIdentifier(VL_GROUP_LIST, vt, owner).Pack()));
+	return dynamic_cast<VehicleGroupWindow *>(FindWindowById(GetWindowClassForVehicleType(vt), VehicleListIdentifier(VL_GROUP_LIST, vt, owner).ToWindowNumber()));
 }
 
 /**

--- a/src/group_gui.h
+++ b/src/group_gui.h
@@ -13,7 +13,7 @@
 #include "company_type.h"
 #include "vehicle_type.h"
 
-void ShowCompanyGroup(CompanyID company, VehicleType veh, GroupID group = INVALID_GROUP, bool need_existing_window = false);
+void ShowCompanyGroup(CompanyID company, VehicleType veh, GroupID group = INVALID_GROUP);
 void ShowCompanyGroupForVehicle(const Vehicle *v);
 void DeleteGroupHighlightOfVehicle(const Vehicle *v);
 

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -723,7 +723,7 @@ void ShowNewGRFInspectWindow(GrfSpecFeature feature, uint index, const uint32_t 
 
 	WindowNumber wno = GetInspectWindowNumber(feature, index);
 	WindowDesc &desc = (feature == GSF_TRAINS || feature == GSF_ROADVEHICLES) ? _newgrf_inspect_chain_desc : _newgrf_inspect_desc;
-	NewGRFInspectWindow *w = AllocateWindowDescFront<NewGRFInspectWindow>(desc, wno, true);
+	NewGRFInspectWindow *w = AllocateWindowDescFront<NewGRFInspectWindow, true>(desc, wno);
 	w->SetCallerGRFID(grfid);
 }
 

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -52,10 +52,10 @@ BaseStation::~BaseStation()
 {
 	if (CleaningPool()) return;
 
-	CloseWindowById(WC_TRAINS_LIST,   VehicleListIdentifier(VL_STATION_LIST, VEH_TRAIN,    this->owner, this->index).Pack());
-	CloseWindowById(WC_ROADVEH_LIST,  VehicleListIdentifier(VL_STATION_LIST, VEH_ROAD,     this->owner, this->index).Pack());
-	CloseWindowById(WC_SHIPS_LIST,    VehicleListIdentifier(VL_STATION_LIST, VEH_SHIP,     this->owner, this->index).Pack());
-	CloseWindowById(WC_AIRCRAFT_LIST, VehicleListIdentifier(VL_STATION_LIST, VEH_AIRCRAFT, this->owner, this->index).Pack());
+	CloseWindowById(WC_TRAINS_LIST,   VehicleListIdentifier(VL_STATION_LIST, VEH_TRAIN,    this->owner, this->index).ToWindowNumber());
+	CloseWindowById(WC_ROADVEH_LIST,  VehicleListIdentifier(VL_STATION_LIST, VEH_ROAD,     this->owner, this->index).ToWindowNumber());
+	CloseWindowById(WC_SHIPS_LIST,    VehicleListIdentifier(VL_STATION_LIST, VEH_SHIP,     this->owner, this->index).ToWindowNumber());
+	CloseWindowById(WC_AIRCRAFT_LIST, VehicleListIdentifier(VL_STATION_LIST, VEH_AIRCRAFT, this->owner, this->index).ToWindowNumber());
 
 	this->sign.MarkDirty();
 }

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -1375,10 +1375,10 @@ struct StationViewWindow : public Window {
 
 	void Close([[maybe_unused]] int data = 0) override
 	{
-		CloseWindowById(WC_TRAINS_LIST,   VehicleListIdentifier(VL_STATION_LIST, VEH_TRAIN,    this->owner, this->window_number).Pack(), false);
-		CloseWindowById(WC_ROADVEH_LIST,  VehicleListIdentifier(VL_STATION_LIST, VEH_ROAD,     this->owner, this->window_number).Pack(), false);
-		CloseWindowById(WC_SHIPS_LIST,    VehicleListIdentifier(VL_STATION_LIST, VEH_SHIP,     this->owner, this->window_number).Pack(), false);
-		CloseWindowById(WC_AIRCRAFT_LIST, VehicleListIdentifier(VL_STATION_LIST, VEH_AIRCRAFT, this->owner, this->window_number).Pack(), false);
+		CloseWindowById(WC_TRAINS_LIST,   VehicleListIdentifier(VL_STATION_LIST, VEH_TRAIN,    this->owner, this->window_number).ToWindowNumber(), false);
+		CloseWindowById(WC_ROADVEH_LIST,  VehicleListIdentifier(VL_STATION_LIST, VEH_ROAD,     this->owner, this->window_number).ToWindowNumber(), false);
+		CloseWindowById(WC_SHIPS_LIST,    VehicleListIdentifier(VL_STATION_LIST, VEH_SHIP,     this->owner, this->window_number).ToWindowNumber(), false);
+		CloseWindowById(WC_AIRCRAFT_LIST, VehicleListIdentifier(VL_STATION_LIST, VEH_AIRCRAFT, this->owner, this->window_number).ToWindowNumber(), false);
 
 		SetViewportCatchmentStation(Station::Get(this->window_number), false);
 		this->Window::Close();

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -1052,6 +1052,6 @@ void ShowStoryBook(CompanyID company, StoryPageID page_id, bool centered)
 {
 	if (!Company::IsValidID(company)) company = (CompanyID)INVALID_COMPANY;
 
-	StoryBookWindow *w = AllocateWindowDescFront<StoryBookWindow>(centered ? _story_book_gs_desc : _story_book_desc, company, true);
+	StoryBookWindow *w = AllocateWindowDescFront<StoryBookWindow, true>(centered ? _story_book_gs_desc : _story_book_desc, company);
 	if (page_id != INVALID_STORY_PAGE) w->SetSelectedPage(page_id);
 }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3005,12 +3005,12 @@ void Vehicle::RemoveFromShared()
 
 	if (this->orders->GetNumVehicles() == 1) {
 		/* When there is only one vehicle, remove the shared order list window. */
-		CloseWindowById(GetWindowClassForVehicleType(this->type), vli.Pack());
+		CloseWindowById(GetWindowClassForVehicleType(this->type), vli.ToWindowNumber());
 		InvalidateVehicleOrder(this->FirstShared(), VIWD_MODIFY_ORDERS);
 	} else if (were_first) {
 		/* If we were the first one, update to the new first one.
 		 * Note: FirstShared() is already the new first */
-		InvalidateWindowData(GetWindowClassForVehicleType(this->type), vli.Pack(), this->FirstShared()->index | (1U << 31));
+		InvalidateWindowData(GetWindowClassForVehicleType(this->type), vli.ToWindowNumber(), this->FirstShared()->index | (1U << 31));
 	}
 
 	this->next_shared     = nullptr;

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -162,7 +162,7 @@ const StringID BaseVehicleListWindow::vehicle_depot_name[] = {
 	STR_VEHICLE_LIST_SEND_AIRCRAFT_TO_HANGAR
 };
 
-BaseVehicleListWindow::BaseVehicleListWindow(WindowDesc &desc, WindowNumber wno) : Window(desc), vli(VehicleListIdentifier::UnPack(wno))
+BaseVehicleListWindow::BaseVehicleListWindow(WindowDesc &desc, const VehicleListIdentifier &vli) : Window(desc), vli(vli)
 {
 	this->vehicle_sel = INVALID_VEHICLE;
 	this->grouping = _grouping[vli.type][vli.vtype];
@@ -1924,12 +1924,7 @@ void BaseVehicleListWindow::UpdateVehicleGroupBy(GroupBy group_by)
 
 /**
  * Window for the (old) vehicle listing.
- *
- * bitmask for w->window_number
- * 0-7 CompanyID (owner)
- * 8-10 window type (use flags in vehicle_gui.h)
- * 11-15 vehicle type (using VEH_, but can be compressed to fewer bytes if needed)
- * 16-31 StationID or OrderID depending on window type (bit 8-10)
+ * See #VehicleListIdentifier::Pack for the contents of the window number.
  */
 struct VehicleListWindow : public BaseVehicleListWindow {
 private:
@@ -1946,7 +1941,7 @@ private:
 	};
 
 public:
-	VehicleListWindow(WindowDesc &desc, WindowNumber window_number) : BaseVehicleListWindow(desc, window_number)
+	VehicleListWindow(WindowDesc &desc, WindowNumber window_number, const VehicleListIdentifier &vli) : BaseVehicleListWindow(desc, vli)
 	{
 		this->CreateNestedTree();
 
@@ -2332,8 +2327,8 @@ static void ShowVehicleListWindowLocal(CompanyID company, VehicleListType vlt, V
 	if (!Company::IsValidID(company) && company != OWNER_NONE) return;
 
 	assert(vehicle_type < std::size(_vehicle_list_desc));
-	WindowNumber num = VehicleListIdentifier(vlt, vehicle_type, company, unique_number).Pack();
-	AllocateWindowDescFront<VehicleListWindow>(_vehicle_list_desc[vehicle_type], num);
+	VehicleListIdentifier vli(vlt, vehicle_type, company, unique_number);
+	AllocateWindowDescFront<VehicleListWindow>(_vehicle_list_desc[vehicle_type], vli.Pack(), vli);
 }
 
 void ShowVehicleListWindow(CompanyID company, VehicleType vehicle_type)

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2281,7 +2281,7 @@ public:
 		if (!gui_scope && HasBit(data, 31) && this->vli.type == VL_SHARED_ORDERS) {
 			/* Needs to be done in command-scope, so everything stays valid */
 			this->vli.index = GB(data, 0, 20);
-			this->window_number = this->vli.Pack();
+			this->window_number = this->vli.ToWindowNumber();
 			this->vehgroups.ForceRebuild();
 			return;
 		}
@@ -2328,7 +2328,7 @@ static void ShowVehicleListWindowLocal(CompanyID company, VehicleListType vlt, V
 
 	assert(vehicle_type < std::size(_vehicle_list_desc));
 	VehicleListIdentifier vli(vlt, vehicle_type, company, unique_number);
-	AllocateWindowDescFront<VehicleListWindow>(_vehicle_list_desc[vehicle_type], vli.Pack(), vli);
+	AllocateWindowDescFront<VehicleListWindow>(_vehicle_list_desc[vehicle_type], vli.ToWindowNumber(), vli);
 }
 
 void ShowVehicleListWindow(CompanyID company, VehicleType vehicle_type)

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2205,7 +2205,7 @@ public:
 				break;
 
 			case WID_VL_MANAGE_VEHICLES_DROPDOWN: {
-				ShowDropDownList(this, this->BuildActionDropdownList(VehicleListIdentifier::UnPack(this->window_number).type == VL_STANDARD, false, true), 0, WID_VL_MANAGE_VEHICLES_DROPDOWN);
+				ShowDropDownList(this, this->BuildActionDropdownList(this->vli.type == VL_STANDARD, false, true), 0, WID_VL_MANAGE_VEHICLES_DROPDOWN);
 				break;
 			}
 

--- a/src/vehicle_gui_base.h
+++ b/src/vehicle_gui_base.h
@@ -106,7 +106,7 @@ struct BaseVehicleListWindow : public Window {
 	static const std::initializer_list<VehicleGroupSortFunction * const> vehicle_group_none_sorter_funcs;
 	static const std::initializer_list<VehicleGroupSortFunction * const> vehicle_group_shared_orders_sorter_funcs;
 
-	BaseVehicleListWindow(WindowDesc &desc, WindowNumber wno);
+	BaseVehicleListWindow(WindowDesc &desc, const VehicleListIdentifier &vli);
 
 	void OnInit() override;
 

--- a/src/vehiclelist.cpp
+++ b/src/vehiclelist.cpp
@@ -32,34 +32,6 @@ uint32_t VehicleListIdentifier::Pack() const
 	return c << 28 | this->type << 23 | this->vtype << 26 | this->index;
 }
 
-/**
- * Unpack a VehicleListIdentifier from a single uint32.
- * @param data The data to unpack.
- * @return true iff the data was valid (enough).
- */
-bool VehicleListIdentifier::UnpackIfValid(uint32_t data)
-{
-	uint8_t c        = GB(data, 28, 4);
-	this->company = c == 0xF ? OWNER_NONE : (CompanyID)c;
-	this->type    = (VehicleListType)GB(data, 23, 3);
-	this->vtype   = (VehicleType)GB(data, 26, 2);
-	this->index   = GB(data, 0, 20);
-
-	return this->type < VLT_END;
-}
-
-/**
- * Decode a packed vehicle list identifier into a new one.
- * @param data The data to unpack.
- */
-/* static */ VehicleListIdentifier VehicleListIdentifier::UnPack(uint32_t data)
-{
-	VehicleListIdentifier result;
-	[[maybe_unused]] bool ret = result.UnpackIfValid(data);
-	assert(ret);
-	return result;
-}
-
 /** Data for building a depot vehicle list. */
 struct BuildDepotVehicleListData
 {

--- a/src/vehiclelist.cpp
+++ b/src/vehiclelist.cpp
@@ -17,10 +17,10 @@
 #include "safeguards.h"
 
 /**
- * Pack a VehicleListIdentifier in a single uint32.
- * @return The packed identifier.
+ * Pack a VehicleListIdentifier in 32 bits so it can be used as unique WindowNumber.
+ * @return The window number.
  */
-uint32_t VehicleListIdentifier::Pack() const
+WindowNumber VehicleListIdentifier::ToWindowNumber() const
 {
 	uint8_t c = this->company == OWNER_NONE ? 0xF : (uint8_t)this->company;
 	assert(c             < (1 <<  4));

--- a/src/vehiclelist.h
+++ b/src/vehiclelist.h
@@ -32,8 +32,6 @@ struct VehicleListIdentifier {
 	uint32_t index;         ///< A vehicle list type specific index.
 
 	uint32_t Pack() const;
-	bool UnpackIfValid(uint32_t data);
-	static VehicleListIdentifier UnPack(uint32_t data);
 
 	bool Valid() const { return this->type < VLT_END; }
 

--- a/src/vehiclelist.h
+++ b/src/vehiclelist.h
@@ -13,6 +13,7 @@
 #include "vehicle_type.h"
 #include "company_type.h"
 #include "tile_type.h"
+#include "window_type.h"
 
 /** Vehicle List type flags */
 enum VehicleListType : uint8_t {
@@ -31,7 +32,7 @@ struct VehicleListIdentifier {
 	CompanyID company;    ///< The company associated with this list.
 	uint32_t index;         ///< A vehicle list type specific index.
 
-	uint32_t Pack() const;
+	WindowNumber ToWindowNumber() const;
 
 	bool Valid() const { return this->type < VLT_END; }
 

--- a/src/waypoint_gui.cpp
+++ b/src/waypoint_gui.cpp
@@ -104,7 +104,7 @@ public:
 
 	void Close([[maybe_unused]] int data = 0) override
 	{
-		CloseWindowById(GetWindowClassForVehicleType(this->vt), VehicleListIdentifier(VL_STATION_LIST, this->vt, this->owner, this->window_number).Pack(), false);
+		CloseWindowById(GetWindowClassForVehicleType(this->vt), VehicleListIdentifier(VL_STATION_LIST, this->vt, this->owner, this->window_number).ToWindowNumber(), false);
 		SetViewportCatchmentWaypoint(Waypoint::Get(this->window_number), false);
 		this->Window::Close();
 	}

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -1006,14 +1006,15 @@ Window *BringWindowToFrontById(WindowClass cls, ConvertibleThroughBase auto numb
  * @tparam Treturn_existing If set, also return the window if it already existed.
  * @param desc The pointer to the WindowDesc to be created
  * @param window_number the window number of the new window
+ * @param extra_arguments optional extra arguments to pass to the window's constructor.
  * @return %Window pointer of the newly created window, or the existing one if \a Treturn_existing is set, or \c nullptr.
  */
-template <typename Twindow, bool Treturn_existing = false>
-Twindow *AllocateWindowDescFront(WindowDesc &desc, WindowNumber window_number)
+template <typename Twindow, bool Treturn_existing = false, typename... Targs>
+Twindow *AllocateWindowDescFront(WindowDesc &desc, WindowNumber window_number, Targs... extra_arguments)
 {
 	Twindow *w = static_cast<Twindow *>(BringWindowToFrontById(desc.cls, window_number));
 	if (w != nullptr) return Treturn_existing ? w : nullptr;
-	return new Twindow(desc, window_number);
+	return new Twindow(desc, window_number, std::forward<Targs>(extra_arguments)...);
 }
 
 void RelocateAllWindows(int neww, int newh);

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -1002,18 +1002,18 @@ Window *BringWindowToFrontById(WindowClass cls, ConvertibleThroughBase auto numb
 
 /**
  * Open a new window.
- * @tparam Wcls %Window class to use if the window does not exist.
+ * @tparam Twindow %Window class to use if the window does not exist.
+ * @tparam Treturn_existing If set, also return the window if it already existed.
  * @param desc The pointer to the WindowDesc to be created
  * @param window_number the window number of the new window
- * @param return_existing If set, also return the window if it already existed.
- * @return %Window pointer of the newly created window, or the existing one if \a return_existing is set, or \c nullptr.
+ * @return %Window pointer of the newly created window, or the existing one if \a Treturn_existing is set, or \c nullptr.
  */
-template <typename Wcls>
-Wcls *AllocateWindowDescFront(WindowDesc &desc, int window_number, bool return_existing = false)
+template <typename Twindow, bool Treturn_existing = false>
+Twindow *AllocateWindowDescFront(WindowDesc &desc, WindowNumber window_number)
 {
-	Wcls *w = static_cast<Wcls *>(BringWindowToFrontById(desc.cls, window_number));
-	if (w != nullptr) return return_existing ? w : nullptr;
-	return new Wcls(desc, window_number);
+	Twindow *w = static_cast<Twindow *>(BringWindowToFrontById(desc.cls, window_number));
+	if (w != nullptr) return Treturn_existing ? w : nullptr;
+	return new Twindow(desc, window_number);
 }
 
 void RelocateAllWindows(int neww, int newh);


### PR DESCRIPTION
## Motivation / Problem

`VehicleListIdentifier` packs its data to be passed as `WindowNumber` to the window that is constructed using `AllocateWindowDescFront`, and this is then unpacked. Why can't we just pass extra parameters through `AllocateWindowDescFront` to the constructor?


## Description

* Move the third (rarely used) parameter to be a template parameter, so it doesn't conflict with the extra parameters.
* Make `AllocateWindowDescFront` has an arbitrary number of extra parameters that are forwarded to the constructor.
* Pass the `VehicleListIdentifier` as reference through the constructor and replace the unpacking with simple assignment.
* Remove the now unused unpacking methods.
* Rename `Pack` to `ToWindowNumber` to make clear what the function is intended for: create an unique window number.


## Limitations

There are more windows that could use this, e.g. `BuyCompanyWindow`, `DepotWindow`, `OrdersWindow`, and some others. But actually using it in other windows is beyond the scope of this PR.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
