### PR TITLE
Doc: cross-reference Emscripten version number locations

### DIFF
--- a/.github/workflows/ci-emscripten.yml
+++ b/.github/workflows/ci-emscripten.yml
@@ -12,7 +12,8 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      # If you change this version, change the number in the cache step too.
+      # If you change this version, change the numbers in the cache step,
+      # .github/workflows/preview-build.yml (2x) and os/emscripten/Dockerfile too.
       image: emscripten/emsdk:3.1.57
 
     steps:
@@ -33,6 +34,8 @@ jobs:
     - name: Setup cache
       uses: actions/cache@v4
       with:
+        # If you change this version, change the numbers in the image configuration step,
+        # .github/workflows/preview-build.yml (2x) and os/emscripten/Dockerfile too.
         path: /emsdk/upstream/emscripten/cache
         key: 3.1.57-${{ runner.os }}
 

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -20,7 +20,8 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      # If you change this version, change the number in the cache step too.
+      # If you change this version, change the numbers in the cache step,
+      # .github/workflows/ci-emscripten.yml (2x) and os/emscripten/Dockerfile too.
       image: emscripten/emsdk:3.1.57
 
     steps:
@@ -38,6 +39,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /emsdk/upstream/emscripten/cache
+        # If you change this version, change the numbers in the image configuration step,
+        # .github/workflows/ci-emscripten.yml (2x) and os/emscripten/Dockerfile too.
         key: 3.1.57-${{ runner.os }}
 
     - name: Add liblzma support

--- a/os/emscripten/Dockerfile
+++ b/os/emscripten/Dockerfile
@@ -1,3 +1,5 @@
+# If you change this version, change the numbers in .github/workflows/ci-emscripten.yml (2x)
+# and .github/workflows/preview-build.yml (2x) too.
 FROM emscripten/emsdk:3.1.57
 
 RUN apt-get update \


### PR DESCRIPTION
## Motivation / Problem

In #13426 I was told I forgotten a location when changing the version number, #13438 tells there is another location. However, the documentation before the version number only mentioned another location in the file, which is why it is so easy too overlook.


## Description

Document/cross-reference where the other Emscripten versions are written in the configuration files.


## Limitations

It might not solve forgetting this when changing other parts of the configuration, but at least there is a somewhat higher chance of getting it right as the other configuration locations are documented in the file.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
