### PR TITLE
Codechange: add conversion helpers to VehicleListIdentifier

### DIFF
--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -293,7 +293,7 @@ private:
 		if (g_id == NEW_GROUP) return;
 
 		/* draw the selected group in white, else we draw it in black */
-		TextColour colour = g_id == this->vli.index ? TC_WHITE : TC_BLACK;
+		TextColour colour = g_id == this->vli.ToGroupID() ? TC_WHITE : TC_BLACK;
 		const GroupStatistics &stats = GroupStatistics::Get(this->vli.company, g_id, this->vli.vtype);
 		bool rtl = _current_text_dir == TD_RTL;
 
@@ -503,7 +503,8 @@ public:
 			this->group_rename = INVALID_GROUP;
 		}
 
-		if (!(IsAllGroupID(this->vli.index) || IsDefaultGroupID(this->vli.index) || Group::IsValidID(this->vli.index))) {
+		GroupID group = this->vli.ToGroupID();
+		if (!(IsAllGroupID(group) || IsDefaultGroupID(group) || Group::IsValidID(group))) {
 			this->vli.index = ALL_GROUP;
 			this->CloseChildWindows(WC_DROPDOWN_MENU);
 		}
@@ -524,16 +525,16 @@ public:
 			case WID_GL_CAPTION:
 				/* If selected_group == DEFAULT_GROUP || ALL_GROUP, draw the standard caption
 				 * We list all vehicles or ungrouped vehicles */
-				if (IsDefaultGroupID(this->vli.index) || IsAllGroupID(this->vli.index)) {
+				if (IsDefaultGroupID(this->vli.ToGroupID()) || IsAllGroupID(this->vli.ToGroupID())) {
 					SetDParam(0, STR_COMPANY_NAME);
 					SetDParam(1, this->vli.company);
 					SetDParam(2, this->vehicles.size());
 					SetDParam(3, this->vehicles.size());
 				} else {
-					uint num_vehicle = GetGroupNumVehicle(this->vli.company, this->vli.index, this->vli.vtype);
+					uint num_vehicle = GetGroupNumVehicle(this->vli.company, this->vli.ToGroupID(), this->vli.vtype);
 
 					SetDParam(0, STR_GROUP_NAME);
-					SetDParam(1, this->vli.index);
+					SetDParam(1, this->vli.ToGroupID());
 					SetDParam(2, num_vehicle);
 					SetDParam(3, num_vehicle);
 				}
@@ -566,7 +567,8 @@ public:
 				WID_GL_MANAGE_VEHICLES_DROPDOWN);
 
 		/* Disable the group specific function when we select the default group or all vehicles */
-		this->SetWidgetsDisabledState(IsDefaultGroupID(this->vli.index) || IsAllGroupID(this->vli.index) || _local_company != this->vli.company,
+		GroupID group = this->vli.ToGroupID();
+		this->SetWidgetsDisabledState(IsDefaultGroupID(group) || IsAllGroupID(group) || _local_company != this->vli.company,
 				WID_GL_DELETE_GROUP,
 				WID_GL_RENAME_GROUP,
 				WID_GL_LIVERY_GROUP,
@@ -584,7 +586,7 @@ public:
 
 		/* If not a default group and the group has replace protection, show an enabled replace sprite. */
 		uint16_t protect_sprite = SPR_GROUP_REPLACE_OFF_TRAIN;
-		if (!IsDefaultGroupID(this->vli.index) && !IsAllGroupID(this->vli.index) && Group::Get(this->vli.index)->flags.Test(GroupFlag::ReplaceProtection)) protect_sprite = SPR_GROUP_REPLACE_ON_TRAIN;
+		if (!IsDefaultGroupID(group) && !IsAllGroupID(group) && Group::Get(group)->flags.Test(GroupFlag::ReplaceProtection)) protect_sprite = SPR_GROUP_REPLACE_ON_TRAIN;
 		this->GetWidget<NWidgetCore>(WID_GL_REPLACE_PROTECTION)->SetSprite(protect_sprite + this->vli.vtype);
 
 		/* Set text of "group by" dropdown widget. */
@@ -665,13 +667,13 @@ public:
 				break;
 
 			case WID_GL_LIST_VEHICLE:
-				if (this->vli.index != ALL_GROUP && this->grouping == GB_NONE) {
+				if (this->vli.ToGroupID() != ALL_GROUP && this->grouping == GB_NONE) {
 					/* Mark vehicles which are in sub-groups (only if we are not using shared order coalescing) */
 					Rect mr = r.WithHeight(this->resize.step_height);
 					auto [first, last] = this->vscroll->GetVisibleRangeIterators(this->vehgroups);
 					for (auto it = first; it != last; ++it) {
 						const Vehicle *v = it->GetSingleVehicle();
-						if (v->group_id != this->vli.index) {
+						if (v->group_id != this->vli.ToGroupID()) {
 							GfxFillRect(mr.Shrink(WidgetDimensions::scaled.bevel), GetColourGradient(COLOUR_GREY, SHADE_DARK), FILLRECT_CHECKER);
 						}
 						mr = mr.Translate(0, this->resize.step_height);
@@ -722,7 +724,7 @@ public:
 				break;
 
 			case WID_GL_ALL_VEHICLES: // All vehicles button
-				if (!IsAllGroupID(this->vli.index)) {
+				if (!IsAllGroupID(this->vli.ToGroupID())) {
 					this->vli.index = ALL_GROUP;
 					this->vehgroups.ForceRebuild();
 					this->SetDirty();
@@ -730,7 +732,7 @@ public:
 				break;
 
 			case WID_GL_DEFAULT_VEHICLES: // Ungrouped vehicles button
-				if (!IsDefaultGroupID(this->vli.index)) {
+				if (!IsDefaultGroupID(this->vli.ToGroupID())) {
 					this->vli.index = DEFAULT_GROUP;
 					this->vehgroups.ForceRebuild();
 					this->SetDirty();
@@ -749,7 +751,7 @@ public:
 							group_display->pos_x + WidgetDimensions::scaled.framerect.left + it->indent * WidgetDimensions::scaled.hsep_indent;
 					if (click_count > 1 || (pt.x >= x && pt.x < (int)(x + this->column_size[VGC_FOLD].width))) {
 
-						GroupID g = this->vli.index;
+						GroupID g = this->vli.ToGroupID();
 						if (!IsAllGroupID(g) && !IsDefaultGroupID(g)) {
 							do {
 								g = Group::Get(g)->parent;
@@ -832,22 +834,22 @@ public:
 			}
 
 			case WID_GL_CREATE_GROUP: { // Create a new group
-				Command<CMD_CREATE_GROUP>::Post(STR_ERROR_GROUP_CAN_T_CREATE, CcCreateGroup, this->vli.vtype, this->vli.index);
+				Command<CMD_CREATE_GROUP>::Post(STR_ERROR_GROUP_CAN_T_CREATE, CcCreateGroup, this->vli.vtype, this->vli.ToGroupID());
 				break;
 			}
 
 			case WID_GL_DELETE_GROUP: { // Delete the selected group
-				this->group_confirm = this->vli.index;
+				this->group_confirm = this->vli.ToGroupID();
 				ShowQuery(STR_QUERY_GROUP_DELETE_CAPTION, STR_GROUP_DELETE_QUERY_TEXT, this, DeleteGroupCallback);
 				break;
 			}
 
 			case WID_GL_RENAME_GROUP: // Rename the selected roup
-				this->ShowRenameGroupWindow(this->vli.index, false);
+				this->ShowRenameGroupWindow(this->vli.ToGroupID(), false);
 				break;
 
 			case WID_GL_LIVERY_GROUP: // Set group livery
-				ShowCompanyLiveryWindow(this->owner, this->vli.index);
+				ShowCompanyLiveryWindow(this->owner, this->vli.ToGroupID());
 				break;
 
 			case WID_GL_AVAILABLE_VEHICLES:
@@ -855,7 +857,7 @@ public:
 				break;
 
 			case WID_GL_MANAGE_VEHICLES_DROPDOWN: {
-				ShowDropDownList(this, this->BuildActionDropdownList(true, Group::IsValidID(this->vli.index), IsDefaultGroupID(this->vli.index)), -1, WID_GL_MANAGE_VEHICLES_DROPDOWN);
+				ShowDropDownList(this, this->BuildActionDropdownList(true, Group::IsValidID(this->vli.ToGroupID()), IsDefaultGroupID(this->vli.ToGroupID())), -1, WID_GL_MANAGE_VEHICLES_DROPDOWN);
 				break;
 			}
 
@@ -866,9 +868,9 @@ public:
 			}
 
 			case WID_GL_REPLACE_PROTECTION: {
-				const Group *g = Group::GetIfValid(this->vli.index);
+				const Group *g = Group::GetIfValid(this->vli.ToGroupID());
 				if (g != nullptr) {
-					Command<CMD_SET_GROUP_FLAG>::Post(this->vli.index, GroupFlag::ReplaceProtection, !g->flags.Test(GroupFlag::ReplaceProtection), _ctrl_pressed);
+					Command<CMD_SET_GROUP_FLAG>::Post(this->vli.ToGroupID(), GroupFlag::ReplaceProtection, !g->flags.Test(GroupFlag::ReplaceProtection), _ctrl_pressed);
 				}
 				break;
 			}
@@ -1013,7 +1015,7 @@ public:
 
 				switch (index) {
 					case ADI_REPLACE: // Replace window
-						ShowReplaceGroupVehicleWindow(this->vli.index, this->vli.vtype);
+						ShowReplaceGroupVehicleWindow(this->vli.ToGroupID(), this->vli.vtype);
 						break;
 					case ADI_SERVICE: // Send for servicing
 					case ADI_DEPOT: { // Send to Depots
@@ -1026,14 +1028,14 @@ public:
 						break;
 
 					case ADI_ADD_SHARED: // Add shared Vehicles
-						assert(Group::IsValidID(this->vli.index));
+						assert(Group::IsValidID(this->vli.ToGroupID()));
 
-						Command<CMD_ADD_SHARED_VEHICLE_GROUP>::Post(STR_ERROR_GROUP_CAN_T_ADD_SHARED_VEHICLE, this->vli.index, this->vli.vtype);
+						Command<CMD_ADD_SHARED_VEHICLE_GROUP>::Post(STR_ERROR_GROUP_CAN_T_ADD_SHARED_VEHICLE, this->vli.ToGroupID(), this->vli.vtype);
 						break;
 					case ADI_REMOVE_ALL: // Remove all Vehicles from the selected group
-						assert(Group::IsValidID(this->vli.index));
+						assert(Group::IsValidID(this->vli.ToGroupID()));
 
-						Command<CMD_REMOVE_ALL_VEHICLES_GROUP>::Post(STR_ERROR_GROUP_CAN_T_REMOVE_ALL_VEHICLES, this->vli.index);
+						Command<CMD_REMOVE_ALL_VEHICLES_GROUP>::Post(STR_ERROR_GROUP_CAN_T_REMOVE_ALL_VEHICLES, this->vli.ToGroupID());
 						break;
 					default: NOT_REACHED();
 				}
@@ -1125,7 +1127,7 @@ public:
 	 */
 	void SelectGroup(const GroupID g_id)
 	{
-		if (g_id == INVALID_GROUP || g_id == this->vli.index) return;
+		if (g_id == INVALID_GROUP || g_id == this->vli.ToGroupID()) return;
 
 		this->vli.index = g_id;
 		if (g_id != ALL_GROUP && g_id != DEFAULT_GROUP) {

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -395,7 +395,7 @@ public:
 		this->vscroll = this->GetScrollbar(WID_GL_LIST_VEHICLE_SCROLLBAR);
 		this->group_sb = this->GetScrollbar(WID_GL_LIST_GROUP_SCROLLBAR);
 
-		this->vli.index = ALL_GROUP;
+		this->vli.SetIndex(ALL_GROUP);
 		this->group_sel = INVALID_GROUP;
 		this->group_rename = INVALID_GROUP;
 		this->group_over = INVALID_GROUP;
@@ -505,7 +505,7 @@ public:
 
 		GroupID group = this->vli.ToGroupID();
 		if (!(IsAllGroupID(group) || IsDefaultGroupID(group) || Group::IsValidID(group))) {
-			this->vli.index = ALL_GROUP;
+			this->vli.SetIndex(ALL_GROUP);
 			this->CloseChildWindows(WC_DROPDOWN_MENU);
 		}
 		this->SetDirty();
@@ -689,7 +689,7 @@ public:
 	{
 		if (confirmed) {
 			VehicleGroupWindow *w = (VehicleGroupWindow*)win;
-			w->vli.index = ALL_GROUP;
+			w->vli.SetIndex(ALL_GROUP);
 			Command<CMD_DELETE_GROUP>::Post(STR_ERROR_GROUP_CAN_T_DELETE, w->group_confirm);
 		}
 	}
@@ -725,7 +725,7 @@ public:
 
 			case WID_GL_ALL_VEHICLES: // All vehicles button
 				if (!IsAllGroupID(this->vli.ToGroupID())) {
-					this->vli.index = ALL_GROUP;
+					this->vli.SetIndex(ALL_GROUP);
 					this->vehgroups.ForceRebuild();
 					this->SetDirty();
 				}
@@ -733,7 +733,7 @@ public:
 
 			case WID_GL_DEFAULT_VEHICLES: // Ungrouped vehicles button
 				if (!IsDefaultGroupID(this->vli.ToGroupID())) {
-					this->vli.index = DEFAULT_GROUP;
+					this->vli.SetIndex(DEFAULT_GROUP);
 					this->vehgroups.ForceRebuild();
 					this->SetDirty();
 				}
@@ -756,7 +756,7 @@ public:
 							do {
 								g = Group::Get(g)->parent;
 								if (g == it->group->index) {
-									this->vli.index = g;
+									this->vli.SetIndex(g);
 									break;
 								}
 							} while (g != INVALID_GROUP);
@@ -770,7 +770,8 @@ public:
 					}
 				}
 
-				this->group_sel = this->vli.index = it->group->index;
+				this->vli.SetIndex(it->group->index);
+				this->group_sel = it->group->index;
 
 				SetObjectToPlaceWnd(SPR_CURSOR_MOUSE, PAL_NONE, HT_DRAG, this);
 
@@ -1129,7 +1130,7 @@ public:
 	{
 		if (g_id == INVALID_GROUP || g_id == this->vli.ToGroupID()) return;
 
-		this->vli.index = g_id;
+		this->vli.SetIndex(g_id);
 		if (g_id != ALL_GROUP && g_id != DEFAULT_GROUP) {
 			const Group *g = Group::Get(g_id);
 

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2050,20 +2050,20 @@ public:
 
 					case VL_STANDARD: // Company Name
 						SetDParam(0, STR_COMPANY_NAME);
-						SetDParam(1, this->vli.index);
+						SetDParam(1, this->vli.ToCompanyID());
 						SetDParam(3, this->vehicles.size());
 						break;
 
 					case VL_STATION_LIST: // Station/Waypoint Name
-						SetDParam(0, Station::IsExpected(BaseStation::Get(this->vli.index)) ? STR_STATION_NAME : STR_WAYPOINT_NAME);
-						SetDParam(1, this->vli.index);
+						SetDParam(0, Station::IsExpected(BaseStation::Get(this->vli.ToStationID())) ? STR_STATION_NAME : STR_WAYPOINT_NAME);
+						SetDParam(1, this->vli.ToStationID());
 						SetDParam(3, this->vehicles.size());
 						break;
 
 					case VL_DEPOT_LIST:
 						SetDParam(0, STR_DEPOT_CAPTION);
 						SetDParam(1, this->vli.vtype);
-						SetDParam(2, this->vli.index);
+						SetDParam(2, this->vli.ToDestinationID());
 						SetDParam(3, this->vehicles.size());
 						break;
 					default: NOT_REACHED();
@@ -2259,7 +2259,7 @@ public:
 	void OnGameTick() override
 	{
 		if (this->vehgroups.NeedResort()) {
-			StationID station = (this->vli.type == VL_STATION_LIST) ? this->vli.index : INVALID_STATION;
+			StationID station = (this->vli.type == VL_STATION_LIST) ? this->vli.ToStationID() : INVALID_STATION;
 
 			Debug(misc, 3, "Periodic resort {} list company {} at station {}", this->vli.vtype, this->owner, station);
 			this->SetDirty();

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2280,7 +2280,7 @@ public:
 	{
 		if (!gui_scope && HasBit(data, 31) && this->vli.type == VL_SHARED_ORDERS) {
 			/* Needs to be done in command-scope, so everything stays valid */
-			this->vli.index = GB(data, 0, 20);
+			this->vli.SetIndex(GB(data, 0, 20));
 			this->window_number = this->vli.ToWindowNumber();
 			this->vehgroups.ForceRebuild();
 			return;

--- a/src/vehiclelist.cpp
+++ b/src/vehiclelist.cpp
@@ -96,14 +96,14 @@ bool GenerateVehicleSortList(VehicleList *list, const VehicleListIdentifier &vli
 		case VL_STATION_LIST:
 			FindVehiclesWithOrder(
 				[&vli](const Vehicle *v) { return v->type == vli.vtype; },
-				[&vli](const Order *order) { return (order->IsType(OT_GOTO_STATION) || order->IsType(OT_GOTO_WAYPOINT) || order->IsType(OT_IMPLICIT)) && order->GetDestination() == vli.index; },
+				[&vli](const Order *order) { return (order->IsType(OT_GOTO_STATION) || order->IsType(OT_GOTO_WAYPOINT) || order->IsType(OT_IMPLICIT)) && order->GetDestination() == vli.ToStationID(); },
 				[&list](const Vehicle *v) { list->push_back(v); }
 			);
 			break;
 
 		case VL_SHARED_ORDERS: {
 			/* Add all vehicles from this vehicle's shared order list */
-			const Vehicle *v = Vehicle::GetIfValid(vli.index);
+			const Vehicle *v = Vehicle::GetIfValid(vli.ToVehicleID());
 			if (v == nullptr || v->type != vli.vtype || !v->IsPrimaryVehicle()) return false;
 
 			for (; v != nullptr; v = v->NextShared()) {
@@ -113,10 +113,10 @@ bool GenerateVehicleSortList(VehicleList *list, const VehicleListIdentifier &vli
 		}
 
 		case VL_GROUP_LIST:
-			if (vli.index != ALL_GROUP) {
+			if (vli.ToGroupID() != ALL_GROUP) {
 				for (const Vehicle *v : Vehicle::Iterate()) {
 					if (v->type == vli.vtype && v->IsPrimaryVehicle() &&
-							v->owner == vli.company && GroupIsInGroup(v->group_id, vli.index)) {
+							v->owner == vli.company && GroupIsInGroup(v->group_id, vli.ToGroupID())) {
 						list->push_back(v);
 					}
 				}
@@ -135,7 +135,7 @@ bool GenerateVehicleSortList(VehicleList *list, const VehicleListIdentifier &vli
 		case VL_DEPOT_LIST:
 			FindVehiclesWithOrder(
 				[&vli](const Vehicle *v) { return v->type == vli.vtype; },
-				[&vli](const Order *order) { return order->IsType(OT_GOTO_DEPOT) && !(order->GetDepotActionType() & ODATFB_NEAREST_DEPOT) && order->GetDestination() == vli.index; },
+				[&vli](const Order *order) { return order->IsType(OT_GOTO_DEPOT) && !(order->GetDepotActionType() & ODATFB_NEAREST_DEPOT) && order->GetDestination() == vli.ToDestinationID(); },
 				[&list](const Vehicle *v) { list->push_back(v); }
 			);
 			break;

--- a/src/vehiclelist.h
+++ b/src/vehiclelist.h
@@ -45,6 +45,8 @@ struct VehicleListIdentifier {
 	constexpr StationID ToStationID() const { assert(this->type == VL_STATION_LIST); return StationID(this->index); }
 	constexpr VehicleID ToVehicleID() const { assert(this->type == VL_SHARED_ORDERS); return VehicleID(this->index); }
 
+	constexpr void SetIndex(uint32_t index) { this->index = index; }
+
 	/**
 	 * Create a simple vehicle list.
 	 * @param type    List type.

--- a/src/vehiclelist.h
+++ b/src/vehiclelist.h
@@ -10,18 +10,21 @@
 #ifndef VEHICLELIST_H
 #define VEHICLELIST_H
 
-#include "vehicle_type.h"
 #include "company_type.h"
+#include "group_type.h"
+#include "order_type.h"
+#include "station_type.h"
 #include "tile_type.h"
+#include "vehicle_type.h"
 #include "window_type.h"
 
 /** Vehicle List type flags */
 enum VehicleListType : uint8_t {
-	VL_STANDARD,
-	VL_SHARED_ORDERS,
-	VL_STATION_LIST,
-	VL_DEPOT_LIST,
-	VL_GROUP_LIST,
+	VL_STANDARD, ///< Index is the company.
+	VL_SHARED_ORDERS, ///< Index is the first vehicle of the shared orders.
+	VL_STATION_LIST, ///< Index is the station.
+	VL_DEPOT_LIST, ///< Index is the destination (station for hangar of aircraft, depot for others)
+	VL_GROUP_LIST, ///< Index is the group.
 	VLT_END
 };
 
@@ -36,6 +39,12 @@ struct VehicleListIdentifier {
 
 	bool Valid() const { return this->type < VLT_END; }
 
+	constexpr CompanyID ToCompanyID() const { assert(this->type == VL_STANDARD); return CompanyID(this->index); }
+	constexpr DestinationID ToDestinationID() const { assert(this->type == VL_DEPOT_LIST); return DestinationID(this->index); }
+	constexpr GroupID ToGroupID() const { assert(this->type == VL_GROUP_LIST); return GroupID(this->index); }
+	constexpr StationID ToStationID() const { assert(this->type == VL_STATION_LIST); return StationID(this->index); }
+	constexpr VehicleID ToVehicleID() const { assert(this->type == VL_SHARED_ORDERS); return VehicleID(this->index); }
+
 	/**
 	 * Create a simple vehicle list.
 	 * @param type    List type.
@@ -46,7 +55,7 @@ struct VehicleListIdentifier {
 	VehicleListIdentifier(VehicleListType type, VehicleType vtype, CompanyID company, uint index = 0) :
 		type(type), vtype(vtype), company(company), index(index) {}
 
-	VehicleListIdentifier() : type(), vtype(), company(), index() {}
+	VehicleListIdentifier() = default;
 };
 
 /** A list of vehicles. */


### PR DESCRIPTION
## Motivation / Problem

`VehicleListIdentifier`'s `index` is accessed quite a lot, and when adding stronger types we need to add a lot of casting to get this compiling. However, why not have accessor functions to help us with that.
So, `static_cast<GroupID>(vli.index)` vs `vli.ToGroupID()`, or `std::get<GroupID>(vli.index)` if we end up going with a `std::variant` internally.

Similarly, with stronger types we likely end up with something `ConvertibleThroughBase` and when there is an accessor function that support for such types is trivial to add.


## Description

Add and use wrapper functions.


## Limitations

Three raw accesses remain: two for the EndianBufferReader/Writer, and one for a debug message.

For depot lists the type is `DestinationID` as that is conceptually either `DepotID` or `StationID` and for depot orders hangars use station IDs.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
