### PR TITLE
Change: Rainforest is one word

### DIFF
--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -64,7 +64,7 @@
       <tr bgcolor="#CCCCCC"><td colspan="2">Only meaningful in tropic climate. It contains the definition of the available zones</td></tr>
       <tr><td style="width: 5em;"><tt>00</tt></td><td>normal</td></tr>
       <tr><td><tt>01</tt></td><td>desert</td></tr>
-      <tr><td><tt>02</tt></td><td>rain forest</td></tr>
+      <tr><td><tt>02</tt></td><td>rainforest</td></tr>
      </table>
      In any other climate these 2 bits are theoretically free of use, however using them does not seem useful.
     </li>

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1375,7 +1375,7 @@ static CommandCost CheckNewIndustry_Water(TileIndex tile)
 }
 
 /**
- * Check the conditions of #CHECK_LUMBERMILL (Industry should be in the rain forest).
+ * Check the conditions of #CHECK_LUMBERMILL (Industry should be in the rainforest).
  * @param tile %Tile to perform the checking.
  * @return Succeeded or failed command.
  */

--- a/src/industrytype.h
+++ b/src/industrytype.h
@@ -38,7 +38,7 @@ enum CheckProc : uint8_t {
 	CHECK_FARM,       ///< %Industry should be below snow-line in arctic.
 	CHECK_PLANTATION, ///< %Industry should NOT be in the desert.
 	CHECK_WATER,      ///< %Industry should be in the desert.
-	CHECK_LUMBERMILL, ///< %Industry should be in the rain forest.
+	CHECK_LUMBERMILL, ///< %Industry should be in the rainforest.
 	CHECK_BUBBLEGEN,  ///< %Industry should be in low land.
 	CHECK_OIL_RIG,    ///< Industries at sea should be positioned near edge of the map.
 	CHECK_END,        ///< End marker of the industry check procedures.

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1997,7 +1997,7 @@ STR_CONFIG_SETTING_EXTRA_TREE_PLACEMENT                         :In game placeme
 STR_CONFIG_SETTING_EXTRA_TREE_PLACEMENT_HELPTEXT                :Control random appearance of trees during the game. This might affect industries which rely on tree growth, for example lumber mills
 ###length 4
 STR_CONFIG_SETTING_EXTRA_TREE_PLACEMENT_NO_SPREAD               :Grow but don't spread {RED}(breaks lumber mill)
-STR_CONFIG_SETTING_EXTRA_TREE_PLACEMENT_SPREAD_RAINFOREST       :Grow but only spread in rain forests
+STR_CONFIG_SETTING_EXTRA_TREE_PLACEMENT_SPREAD_RAINFOREST       :Grow but only spread in rainforests
 STR_CONFIG_SETTING_EXTRA_TREE_PLACEMENT_SPREAD_ALL              :Grow and spread everywhere
 STR_CONFIG_SETTING_EXTRA_TREE_PLACEMENT_NO_GROWTH_NO_SPREAD     :Don't grow, don't spread {RED}(breaks lumber mill)
 

--- a/src/table/genland.h
+++ b/src/table/genland.h
@@ -5,7 +5,7 @@
  * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** @file genland.h Table used to generate deserts and/or rain forests. */
+/** @file genland.h Table used to generate deserts and/or rainforests. */
 
 #define M(x, y) {x,  y}
 

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -442,9 +442,9 @@ CommandCost CmdPlantTree(DoCommandFlag flags, TileIndex tile, TileIndex start_ti
 				if (_settings_game.game_creation.landscape == LandscapeType::Tropic && treetype != TREE_INVALID && (
 						/* No cacti outside the desert */
 						(treetype == TREE_CACTUS && GetTropicZone(current_tile) != TROPICZONE_DESERT) ||
-						/* No rain forest trees outside the rain forest, except in the editor mode where it makes those tiles rain forest tile */
+						/* No rainforest trees outside the rainforest, except in the editor mode where it makes those tiles rainforest tile */
 						(IsInsideMM(treetype, TREE_RAINFOREST, TREE_CACTUS) && GetTropicZone(current_tile) != TROPICZONE_RAINFOREST && _game_mode != GM_EDITOR) ||
-						/* And no subtropical trees in the desert/rain forest */
+						/* And no subtropical trees in the desert/rainforest */
 						(IsInsideMM(treetype, TREE_SUB_TROPICAL, TREE_TOYLAND) && GetTropicZone(current_tile) != TROPICZONE_NORMAL))) {
 					msg = STR_ERROR_TREE_WRONG_TERRAIN_FOR_TREE_TYPE;
 					continue;


### PR DESCRIPTION
## Motivation / Problem

Searching the Settings menu (or source code) for "rainforest" misses some results that are inconsistently spelled "rain forest".

## Description

Standardize spelling to "rainforest".

## Limitations

* Several references to "rain forest" still exist in the changelog, because we typically don't update old changelog items.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
