### PR TITLE
Codechange: make WindowNumber a very converty object

### DIFF
--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -119,7 +119,7 @@ class ReplaceVehicleWindow : public Window {
 	{
 		std::vector<EngineID> variants;
 		EngineID selected_engine = INVALID_ENGINE;
-		VehicleType type = (VehicleType)this->window_number;
+		VehicleType type = this->window_number;
 		uint8_t side = draw_left ? 0 : 1;
 
 		GUIEngineList list;
@@ -304,7 +304,7 @@ public:
 
 			case WID_RV_LEFT_MATRIX:
 			case WID_RV_RIGHT_MATRIX:
-				resize.height = GetEngineListHeight((VehicleType)this->window_number);
+				resize.height = GetEngineListHeight(this->window_number);
 				size.height = (this->window_number <= VEH_ROAD ? 8 : 4) * resize.height;
 				break;
 
@@ -463,7 +463,7 @@ public:
 				int side = (widget == WID_RV_LEFT_MATRIX) ? 0 : 1;
 
 				/* Do the actual drawing */
-				DrawEngineList((VehicleType)this->window_number, r, this->engines[side], *this->vscroll[side], this->sel_engine[side], side == 0, this->sel_group);
+				DrawEngineList(this->window_number, r, this->engines[side], *this->vscroll[side], this->sel_engine[side], side == 0, this->sel_group);
 				break;
 			}
 		}
@@ -532,7 +532,7 @@ public:
 				break;
 
 			case WID_RV_SORT_DROPDOWN:
-				DisplayVehicleSortDropDown(this, static_cast<VehicleType>(this->window_number), this->sort_criteria, WID_RV_SORT_DROPDOWN);
+				DisplayVehicleSortDropDown(this, this->window_number, this->sort_criteria, WID_RV_SORT_DROPDOWN);
 				break;
 
 			case WID_RV_TRAIN_ENGINEWAGON_DROPDOWN: {
@@ -599,7 +599,7 @@ public:
 						Engine *engine = Engine::Get(item.variant_id);
 						engine->display_flags.Flip(EngineDisplayFlag::IsFolded);
 
-						InvalidateWindowData(WC_REPLACE_VEHICLE, (VehicleType)this->window_number, 0); // Update the autoreplace window
+						InvalidateWindowData(WC_REPLACE_VEHICLE, this->window_number, 0); // Update the autoreplace window
 						InvalidateWindowClassesData(WC_BUILD_VEHICLE); // The build windows needs updating as well
 						return;
 					}

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -346,7 +346,7 @@ struct CompanyFinancesWindow : Window {
 		this->SetupWidgets();
 		this->FinishInitNested(company);
 
-		this->owner = (Owner)this->window_number;
+		this->owner = this->window_number;
 		this->InvalidateData();
 	}
 
@@ -354,24 +354,24 @@ struct CompanyFinancesWindow : Window {
 	{
 		switch (widget) {
 			case WID_CF_CAPTION:
-				SetDParam(0, (CompanyID)this->window_number);
-				SetDParam(1, (CompanyID)this->window_number);
+				SetDParam(0, this->window_number);
+				SetDParam(1, this->window_number);
 				break;
 
 			case WID_CF_BALANCE_VALUE: {
-				const Company *c = Company::Get((CompanyID)this->window_number);
+				const Company *c = Company::Get(this->window_number);
 				SetDParam(0, c->money);
 				break;
 			}
 
 			case WID_CF_LOAN_VALUE: {
-				const Company *c = Company::Get((CompanyID)this->window_number);
+				const Company *c = Company::Get(this->window_number);
 				SetDParam(0, c->current_loan);
 				break;
 			}
 
 			case WID_CF_OWN_VALUE: {
-				const Company *c = Company::Get((CompanyID)this->window_number);
+				const Company *c = Company::Get(this->window_number);
 				SetDParam(0, c->money - c->current_loan);
 				break;
 			}
@@ -381,7 +381,7 @@ struct CompanyFinancesWindow : Window {
 				break;
 
 			case WID_CF_MAXLOAN_VALUE: {
-				const Company *c = Company::Get((CompanyID)this->window_number);
+				const Company *c = Company::Get(this->window_number);
 				SetDParam(0, c->GetMaxLoan());
 				break;
 			}
@@ -433,7 +433,7 @@ struct CompanyFinancesWindow : Window {
 				int period = widget - WID_CF_EXPS_PRICE1;
 				if (period < this->first_visible) break;
 
-				const Company *c = Company::Get((CompanyID)this->window_number);
+				const Company *c = Company::Get(this->window_number);
 				const auto &expenses = c->yearly_expenses[NUM_PERIODS - period - 1];
 				DrawYearColumn(r, TimerGameEconomy::year - (NUM_PERIODS - period - 1), expenses);
 				break;
@@ -455,7 +455,7 @@ struct CompanyFinancesWindow : Window {
 		this->GetWidget<NWidgetStacked>(WID_CF_SEL_PANEL)->SetDisplayedPlane(plane);
 		this->GetWidget<NWidgetStacked>(WID_CF_SEL_MAXLOAN)->SetDisplayedPlane(plane);
 
-		CompanyID company = (CompanyID)this->window_number;
+		CompanyID company = this->window_number;
 		plane = (company != _local_company) ? SZSP_NONE : 0;
 		this->GetWidget<NWidgetStacked>(WID_CF_SEL_BUTTONS)->SetDisplayedPlane(plane);
 	}
@@ -473,7 +473,7 @@ struct CompanyFinancesWindow : Window {
 			}
 
 			/* Check that the loan buttons are shown only when the user owns the company. */
-			CompanyID company = (CompanyID)this->window_number;
+			CompanyID company = this->window_number;
 			int req_plane = (company != _local_company) ? SZSP_NONE : 0;
 			if (req_plane != this->GetWidget<NWidgetStacked>(WID_CF_SEL_BUTTONS)->shown_plane) {
 				this->SetupWidgets();
@@ -513,7 +513,7 @@ struct CompanyFinancesWindow : Window {
 				break;
 
 			case WID_CF_INFRASTRUCTURE: // show infrastructure details
-				ShowCompanyInfrastructure((CompanyID)this->window_number);
+				ShowCompanyInfrastructure(this->window_number);
 				break;
 		}
 	}
@@ -521,7 +521,7 @@ struct CompanyFinancesWindow : Window {
 	void RefreshVisibleColumns()
 	{
 		for (uint period = 0; period < this->first_visible; ++period) {
-			const Company *c = Company::Get((CompanyID)this->window_number);
+			const Company *c = Company::Get(this->window_number);
 			const Expenses &expenses = c->yearly_expenses[NUM_PERIODS - period - 1];
 			/* Show expenses column if it has any non-zero value in it. */
 			if (std::ranges::any_of(expenses, [](const Money &value) { return value != 0; })) {
@@ -541,7 +541,7 @@ struct CompanyFinancesWindow : Window {
 	 * If it has, rescale the window to fit the new amount.
 	 */
 	IntervalTimer<TimerWindow> rescale_interval = {std::chrono::seconds(3), [this](auto) {
-		const Company *c = Company::Get((CompanyID)this->window_number);
+		const Company *c = Company::Get(this->window_number);
 		if (c->money > CompanyFinancesWindow::max_money) {
 			CompanyFinancesWindow::max_money = std::max(c->money * 2, CompanyFinancesWindow::max_money * 4);
 			this->SetupWidgets();
@@ -620,7 +620,7 @@ private:
 			}
 		}
 
-		const Company *c = Company::Get((CompanyID)this->window_number);
+		const Company *c = Company::Get(this->window_number);
 
 		if (this->livery_class < LC_GROUP_RAIL) {
 			/* Get the first selected livery to use as the default dropdown item */
@@ -751,7 +751,7 @@ public:
 
 				/* And group names */
 				for (const Group *g : Group::Iterate()) {
-					if (g->owner == (CompanyID)this->window_number) {
+					if (g->owner == this->window_number) {
 						SetDParam(0, g->index);
 						d = maxdim(d, GetStringBoundingBox(STR_GROUP_NAME));
 					}
@@ -793,14 +793,14 @@ public:
 
 	void OnPaint() override
 	{
-		bool local = (CompanyID)this->window_number == _local_company;
+		bool local = this->window_number == _local_company;
 
 		/* Disable dropdown controls if no scheme is selected */
 		bool disabled = this->livery_class < LC_GROUP_RAIL ? (this->sel == 0) : (this->sel == INVALID_GROUP);
 		this->SetWidgetDisabledState(WID_SCL_PRI_COL_DROPDOWN, !local || disabled);
 		this->SetWidgetDisabledState(WID_SCL_SEC_COL_DROPDOWN, !local || disabled);
 
-		this->BuildGroupList((CompanyID)this->window_number);
+		this->BuildGroupList(this->window_number);
 
 		this->DrawWidgets();
 	}
@@ -809,12 +809,12 @@ public:
 	{
 		switch (widget) {
 			case WID_SCL_CAPTION:
-				SetDParam(0, (CompanyID)this->window_number);
+				SetDParam(0, this->window_number);
 				break;
 
 			case WID_SCL_PRI_COL_DROPDOWN:
 			case WID_SCL_SEC_COL_DROPDOWN: {
-				const Company *c = Company::Get((CompanyID)this->window_number);
+				const Company *c = Company::Get(this->window_number);
 				bool primary = widget == WID_SCL_PRI_COL_DROPDOWN;
 				StringID colour = STR_COLOUR_DEFAULT;
 
@@ -891,7 +891,7 @@ public:
 			y += this->line_height;
 		};
 
-		const Company *c = Company::Get((CompanyID)this->window_number);
+		const Company *c = Company::Get(this->window_number);
 
 		if (livery_class < LC_GROUP_RAIL) {
 			int pos = this->vscroll->GetPosition();
@@ -946,7 +946,7 @@ public:
 				} else {
 					this->sel = INVALID_GROUP;
 					this->groups.ForceRebuild();
-					this->BuildGroupList((CompanyID)this->window_number);
+					this->BuildGroupList(this->window_number);
 
 					if (!this->groups.empty()) {
 						this->sel = this->groups[0].group->index;
@@ -1001,7 +1001,7 @@ public:
 
 	void OnDropdownSelect(WidgetID widget, int index) override
 	{
-		bool local = (CompanyID)this->window_number == _local_company;
+		bool local = this->window_number == _local_company;
 		if (!local) return;
 
 		Colours colour = static_cast<Colours>(index);
@@ -1034,7 +1034,7 @@ public:
 			/* data contains a VehicleType, rebuild list if it displayed */
 			if (this->livery_class == data + LC_GROUP_RAIL) {
 				this->groups.ForceRebuild();
-				this->BuildGroupList((CompanyID)this->window_number);
+				this->BuildGroupList(this->window_number);
 				this->SetRows();
 
 				if (!Group::IsValidID(this->sel)) {
@@ -1378,8 +1378,8 @@ public:
 		this->SelectDisplayPlanes(this->advanced);
 		this->FinishInitNested(parent->window_number);
 		this->parent = parent;
-		this->owner = (Owner)this->window_number;
-		this->face = Company::Get((CompanyID)this->window_number)->face;
+		this->owner = this->window_number;
+		this->face = Company::Get(this->window_number)->face;
 
 		this->UpdateData();
 	}
@@ -1594,7 +1594,7 @@ public:
 	{
 		switch (widget) {
 			case WID_SCMF_FACE:
-				DrawCompanyManagerFace(this->face, Company::Get((CompanyID)this->window_number)->colour, r);
+				DrawCompanyManagerFace(this->face, Company::Get(this->window_number)->colour, r);
 				break;
 		}
 	}
@@ -1739,7 +1739,7 @@ static WindowDesc _select_company_manager_face_desc(
  */
 static void DoSelectCompanyManagerFace(Window *parent)
 {
-	if (!Company::IsValidID((CompanyID)parent->window_number)) return;
+	if (!Company::IsValidID(parent->window_number)) return;
 
 	if (BringWindowToFrontById(WC_COMPANY_MANAGER_FACE, parent->window_number)) return;
 	new SelectCompanyManagerFaceWindow(_select_company_manager_face_desc, parent);
@@ -1797,7 +1797,7 @@ struct CompanyInfrastructureWindow : Window
 		this->UpdateRailRoadTypes();
 
 		this->InitNested(window_number);
-		this->owner = (Owner)this->window_number;
+		this->owner = this->window_number;
 	}
 
 	void UpdateRailRoadTypes()
@@ -1830,7 +1830,7 @@ struct CompanyInfrastructureWindow : Window
 	/** Get total infrastructure maintenance cost. */
 	Money GetTotalMaintenanceCost() const
 	{
-		const Company *c = Company::Get((CompanyID)this->window_number);
+		const Company *c = Company::Get(this->window_number);
 		Money total;
 
 		uint32_t rail_total = c->infrastructure.GetRailTotal();
@@ -1856,14 +1856,14 @@ struct CompanyInfrastructureWindow : Window
 	{
 		switch (widget) {
 			case WID_CI_CAPTION:
-				SetDParam(0, (CompanyID)this->window_number);
+				SetDParam(0, this->window_number);
 				break;
 		}
 	}
 
 	void UpdateWidgetSize(WidgetID widget, Dimension &size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension &fill, [[maybe_unused]] Dimension &resize) override
 	{
-		const Company *c = Company::Get((CompanyID)this->window_number);
+		const Company *c = Company::Get(this->window_number);
 
 		switch (widget) {
 			case WID_CI_RAIL_DESC: {
@@ -1991,7 +1991,7 @@ struct CompanyInfrastructureWindow : Window
 
 	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
-		const Company *c = Company::Get((CompanyID)this->window_number);
+		const Company *c = Company::Get(this->window_number);
 
 		int y = r.top;
 
@@ -2221,13 +2221,13 @@ struct CompanyWindow : Window
 	CompanyWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{
 		this->InitNested(window_number);
-		this->owner = (Owner)this->window_number;
+		this->owner = this->window_number;
 		this->OnInvalidateData();
 	}
 
 	void OnPaint() override
 	{
-		const Company *c = Company::Get((CompanyID)this->window_number);
+		const Company *c = Company::Get(this->window_number);
 		bool local = this->window_number == _local_company;
 
 		if (!this->IsShaded()) {
@@ -2385,7 +2385,7 @@ struct CompanyWindow : Window
 
 	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
-		const Company *c = Company::Get((CompanyID)this->window_number);
+		const Company *c = Company::Get(this->window_number);
 		switch (widget) {
 			case WID_C_FACE:
 				DrawCompanyManagerFace(c->face, c->colour, r);
@@ -2418,8 +2418,8 @@ struct CompanyWindow : Window
 	{
 		switch (widget) {
 			case WID_C_CAPTION:
-				SetDParam(0, (CompanyID)this->window_number);
-				SetDParam(1, (CompanyID)this->window_number);
+				SetDParam(0, this->window_number);
+				SetDParam(1, this->window_number);
 				break;
 
 			case WID_C_DESC_INAUGURATION:
@@ -2434,7 +2434,7 @@ struct CompanyWindow : Window
 				break;
 
 			case WID_C_DESC_COMPANY_VALUE:
-				SetDParam(0, CalculateCompanyValue(Company::Get((CompanyID)this->window_number)));
+				SetDParam(0, CalculateCompanyValue(Company::Get(this->window_number)));
 				break;
 		}
 	}
@@ -2453,7 +2453,7 @@ struct CompanyWindow : Window
 			case WID_C_NEW_FACE: DoSelectCompanyManagerFace(this); break;
 
 			case WID_C_COLOUR_SCHEME:
-				ShowCompanyLiveryWindow((CompanyID)this->window_number, INVALID_GROUP);
+				ShowCompanyLiveryWindow(this->window_number, INVALID_GROUP);
 				break;
 
 			case WID_C_PRESIDENT_NAME:
@@ -2469,7 +2469,7 @@ struct CompanyWindow : Window
 				break;
 
 			case WID_C_VIEW_HQ: {
-				TileIndex tile = Company::Get((CompanyID)this->window_number)->location_of_HQ;
+				TileIndex tile = Company::Get(this->window_number)->location_of_HQ;
 				if (_ctrl_pressed) {
 					ShowExtraViewportWindow(tile);
 				} else {
@@ -2479,7 +2479,7 @@ struct CompanyWindow : Window
 			}
 
 			case WID_C_BUILD_HQ:
-				if ((uint8_t)this->window_number != _local_company) return;
+				if (this->window_number != _local_company) return;
 				if (this->IsWidgetLowered(WID_C_BUILD_HQ)) {
 					ResetObjectToPlace();
 					this->RaiseButtons();
@@ -2504,7 +2504,7 @@ struct CompanyWindow : Window
 				break;
 
 			case WID_C_VIEW_INFRASTRUCTURE:
-				ShowCompanyInfrastructure((CompanyID)this->window_number);
+				ShowCompanyInfrastructure(this->window_number);
 				break;
 
 			case WID_C_GIVE_MONEY:
@@ -2513,12 +2513,12 @@ struct CompanyWindow : Window
 				break;
 
 			case WID_C_HOSTILE_TAKEOVER:
-				ShowBuyCompanyDialog((CompanyID)this->window_number, true);
+				ShowBuyCompanyDialog(this->window_number, true);
 				break;
 
 			case WID_C_COMPANY_JOIN: {
 				this->query_widget = WID_C_COMPANY_JOIN;
-				CompanyID company = (CompanyID)this->window_number;
+				CompanyID company = this->window_number;
 				if (_network_server) {
 					NetworkServerDoMove(CLIENT_ID_SERVER, company);
 					MarkWholeScreenDirty();
@@ -2558,7 +2558,7 @@ struct CompanyWindow : Window
 
 			case WID_C_GIVE_MONEY: {
 				Money money = std::strtoull(str->c_str(), nullptr, 10) / GetCurrency().rate;
-				Command<CMD_GIVE_MONEY>::Post(STR_ERROR_CAN_T_GIVE_MONEY, money, (CompanyID)this->window_number);
+				Command<CMD_GIVE_MONEY>::Post(STR_ERROR_CAN_T_GIVE_MONEY, money, this->window_number);
 				break;
 			}
 
@@ -2614,7 +2614,7 @@ struct BuyCompanyWindow : Window {
 	{
 		this->InitNested(window_number);
 
-		const Company *c = Company::Get((CompanyID)this->window_number);
+		const Company *c = Company::Get(this->window_number);
 		this->company_value = hostile_takeover ? CalculateHostileTakeoverValue(c) : c->bankrupt_value;
 	}
 
@@ -2626,7 +2626,7 @@ struct BuyCompanyWindow : Window {
 				break;
 
 			case WID_BC_QUESTION:
-				const Company *c = Company::Get((CompanyID)this->window_number);
+				const Company *c = Company::Get(this->window_number);
 				SetDParam(0, c->index);
 				SetDParam(1, this->company_value);
 				size.height = GetStringHeight(this->hostile_takeover ? STR_BUY_COMPANY_HOSTILE_TAKEOVER : STR_BUY_COMPANY_MESSAGE, size.width);
@@ -2639,7 +2639,7 @@ struct BuyCompanyWindow : Window {
 		switch (widget) {
 			case WID_BC_CAPTION:
 				SetDParam(0, STR_COMPANY_NAME);
-				SetDParam(1, Company::Get((CompanyID)this->window_number)->index);
+				SetDParam(1, Company::Get(this->window_number)->index);
 				break;
 		}
 	}
@@ -2648,13 +2648,13 @@ struct BuyCompanyWindow : Window {
 	{
 		switch (widget) {
 			case WID_BC_FACE: {
-				const Company *c = Company::Get((CompanyID)this->window_number);
+				const Company *c = Company::Get(this->window_number);
 				DrawCompanyManagerFace(c->face, c->colour, r);
 				break;
 			}
 
 			case WID_BC_QUESTION: {
-				const Company *c = Company::Get((CompanyID)this->window_number);
+				const Company *c = Company::Get(this->window_number);
 				SetDParam(0, c->index);
 				SetDParam(1, this->company_value);
 				DrawStringMultiLine(r.left, r.right, r.top, r.bottom, this->hostile_takeover ? STR_BUY_COMPANY_HOSTILE_TAKEOVER : STR_BUY_COMPANY_MESSAGE, TC_FROMSTRING, SA_CENTER);
@@ -2671,7 +2671,7 @@ struct BuyCompanyWindow : Window {
 				break;
 
 			case WID_BC_YES:
-				Command<CMD_BUY_COMPANY>::Post(STR_ERROR_CAN_T_BUY_COMPANY, (CompanyID)this->window_number, this->hostile_takeover);
+				Command<CMD_BUY_COMPANY>::Post(STR_ERROR_CAN_T_BUY_COMPANY, this->window_number, this->hostile_takeover);
 				break;
 		}
 	}
@@ -2683,7 +2683,7 @@ struct BuyCompanyWindow : Window {
 		/* Value can't change when in bankruptcy. */
 		if (!this->hostile_takeover) return;
 
-		const Company *c = Company::Get((CompanyID)this->window_number);
+		const Company *c = Company::Get(this->window_number);
 		auto new_value = CalculateHostileTakeoverValue(c);
 		if (new_value != this->company_value) {
 			this->company_value = new_value;

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -330,7 +330,7 @@ static void StartGeneratingLandscape(GenerateLandscapeWindowMode mode)
 
 static void LandscapeGenerationCallback(Window *w, bool confirmed)
 {
-	if (confirmed) StartGeneratingLandscape((GenerateLandscapeWindowMode)w->window_number);
+	if (confirmed) StartGeneratingLandscape(w->window_number);
 }
 
 static DropDownList BuildMapsizeDropDown()
@@ -397,7 +397,7 @@ struct GenerateLandscapeWindow : public Window {
 
 		this->LowerWidget(to_underlying(_settings_newgame.game_creation.landscape) + WID_GL_TEMPERATE);
 
-		this->mode = (GenerateLandscapeWindowMode)this->window_number;
+		this->mode = this->window_number;
 
 		/* Disable town and industry in SE */
 		this->SetWidgetDisabledState(WID_GL_TOWN_PULLDOWN,     _game_mode == GM_EDITOR);

--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -45,7 +45,7 @@ struct GoalListWindow : public Window {
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_GOAL_SCROLLBAR);
 		this->FinishInitNested(window_number);
-		this->owner = (Owner)this->window_number;
+		this->owner = this->window_number;
 		NWidgetStacked *wi = this->GetWidget<NWidgetStacked>(WID_GOAL_SELECT_BUTTONS);
 		wi->SetDisplayedPlane(window_number == INVALID_COMPANY ? 1 : 0);
 		this->OnInvalidateData(0);

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -730,7 +730,7 @@ public:
 	void OnGameTick() override
 	{
 		if (this->stations.NeedResort()) {
-			Debug(misc, 3, "Periodic rebuild station list company {}", this->window_number);
+			Debug(misc, 3, "Periodic rebuild station list company {}", static_cast<int>(this->window_number));
 			this->SetDirty();
 		}
 	}

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -433,7 +433,7 @@ public:
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_STL_SCROLLBAR);
 		this->FinishInitNested(window_number);
-		this->owner = (Owner)this->window_number;
+		this->owner = this->window_number;
 
 		if (this->filter.cargoes == ALL_CARGOTYPES) this->filter.cargoes = _cargo_mask;
 
@@ -487,7 +487,7 @@ public:
 
 	void OnPaint() override
 	{
-		this->BuildStationsList((Owner)this->window_number);
+		this->BuildStationsList(this->window_number);
 		this->SortStationsList();
 
 		this->DrawWidgets();
@@ -620,7 +620,7 @@ public:
 
 				const Station *st = *it;
 				/* do not check HasStationInUse - it is slow and may be invalid */
-				assert(st->owner == (Owner)this->window_number || st->owner == OWNER_NONE);
+				assert(st->owner == this->window_number || st->owner == OWNER_NONE);
 
 				if (_ctrl_pressed) {
 					ShowExtraViewportWindow(st->xy);
@@ -2018,7 +2018,7 @@ struct StationViewWindow : public Window {
 			case WID_SV_SHIPS:    // Show list of scheduled ships to this station
 			case WID_SV_PLANES: { // Show list of scheduled aircraft to this station
 				Owner owner = Station::Get(this->window_number)->owner;
-				ShowVehicleListWindow(owner, (VehicleType)(widget - WID_SV_TRAINS), (StationID)this->window_number);
+				ShowVehicleListWindow(owner, (VehicleType)(widget - WID_SV_TRAINS), static_cast<StationID>(this->window_number));
 				break;
 			}
 

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -548,7 +548,7 @@ protected:
 				break;
 
 			case SPET_GOAL:
-				ShowGoalsList((CompanyID)this->window_number);
+				ShowGoalsList(this->window_number);
 				break;
 
 			case SPET_BUTTON_PUSH:
@@ -604,7 +604,7 @@ public:
 		/* story_page_elements will get built by SetSelectedPage */
 
 		this->FinishInitNested(window_number);
-		this->owner = (Owner)this->window_number;
+		this->owner = this->window_number;
 
 		/* Initialize selected vars. */
 		this->selected_generic_title.clear();

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -194,7 +194,7 @@ static void FillTimetableArrivalDepartureTable(const Vehicle *v, VehicleOrderID 
  */
 static void ChangeTimetableStartCallback(const Window *w, TimerGameEconomy::Date date, void *data)
 {
-	Command<CMD_SET_TIMETABLE_START>::Post(STR_ERROR_CAN_T_TIMETABLE_VEHICLE, (VehicleID)w->window_number, reinterpret_cast<std::uintptr_t>(data) != 0, GetStartTickFromDate(date));
+	Command<CMD_SET_TIMETABLE_START>::Post(STR_ERROR_CAN_T_TIMETABLE_VEHICLE, w->window_number, reinterpret_cast<std::uintptr_t>(data) != 0, GetStartTickFromDate(date));
 }
 
 

--- a/src/window_func.h
+++ b/src/window_func.h
@@ -12,18 +12,12 @@
 
 #include "window_type.h"
 #include "company_type.h"
-#include "core/convertible_through_base.hpp"
 #include "core/geometry_type.hpp"
 
 Window *FindWindowById(WindowClass cls, WindowNumber number);
 Window *FindWindowByClass(WindowClass cls);
 Window *GetMainWindow();
 void ChangeWindowOwner(Owner old_owner, Owner new_owner);
-
-Window *FindWindowById(WindowClass cls, ConvertibleThroughBase auto number)
-{
-	return FindWindowById(cls, number.base());
-}
 
 void ResizeWindow(Window *w, int x, int y, bool clamp_to_screen = true, bool schedule_resize = true);
 int PositionMainToolbar(Window *w);
@@ -43,11 +37,6 @@ void InputLoop();
 void InvalidateWindowData(WindowClass cls, WindowNumber number, int data = 0, bool gui_scope = false);
 void InvalidateWindowClassesData(WindowClass cls, int data = 0, bool gui_scope = false);
 
-void InvalidateWindowData(WindowClass cls, ConvertibleThroughBase auto number, int data = 0, bool gui_scope = false)
-{
-	InvalidateWindowData(cls, number.base(), data, gui_scope);
-}
-
 void CloseNonVitalWindows();
 void CloseAllNonVitalWindows();
 void DeleteAllMessages();
@@ -65,18 +54,8 @@ void SetWindowWidgetDirty(WindowClass cls, WindowNumber number, WidgetID widget_
 void SetWindowDirty(WindowClass cls, WindowNumber number);
 void SetWindowClassesDirty(WindowClass cls);
 
-void SetWindowDirty(WindowClass cls, ConvertibleThroughBase auto number)
-{
-	SetWindowDirty(cls, number.base());
-}
-
 void CloseWindowById(WindowClass cls, WindowNumber number, bool force = true, int data = 0);
 void CloseWindowByClass(WindowClass cls, int data = 0);
-
-void CloseWindowById(WindowClass cls, ConvertibleThroughBase auto number, bool force = true, int data = 0)
-{
-	CloseWindowById(cls, number.base(), force, data);
-}
 
 bool EditBoxInGlobalFocus();
 bool FocusedWindowIsConsole();

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -348,11 +348,6 @@ public:
 	void CreateNestedTree();
 	void FinishInitNested(WindowNumber window_number = 0);
 
-	void FinishInitNested(ConvertibleThroughBase auto number)
-	{
-		this->FinishInitNested(number.base());
-	}
-
 	/**
 	 * Set the timeout flag of the window and initiate the timer.
 	 */
@@ -994,11 +989,6 @@ public:
 
 Window *BringWindowToFrontById(WindowClass cls, WindowNumber number);
 Window *FindWindowFromPt(int x, int y);
-
-Window *BringWindowToFrontById(WindowClass cls, ConvertibleThroughBase auto number)
-{
-	return BringWindowToFrontById(cls, number.base());
-}
 
 /**
  * Open a new window.

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -10,6 +10,8 @@
 #ifndef WINDOW_TYPE_H
 #define WINDOW_TYPE_H
 
+#include "core/convertible_through_base.hpp"
+
 /**
  * Widget ID.
  * Even though the ID is signed, actual IDs must be non-negative.
@@ -736,8 +738,32 @@ enum GameOptionsInvalidationData : uint8_t {
 
 struct Window;
 
-/** Number to differentiate different windows of the same class */
-typedef int32_t WindowNumber;
+/**
+ * Number to differentiate different windows of the same class. This number generally
+ * implicitly passes some information, e.g. the TileIndex or Company associated with
+ * the window. To ease this use, the window number is lenient with what it accepts and
+ * broad with what it returns.
+ *
+ * Anything that converts into a number and ConvertibleThroughBase types will be accepted.
+ * When it's being used it returns int32_t or any other type when that's specifically
+ * requested, e.g. `VehicleType type = window_number` or `GetEngineListHeight(window_number)`
+ * in which the returned value will be a `VehicleType`.
+ */
+struct WindowNumber {
+private:
+	int32_t value = 0;
+public:
+	WindowNumber() = default;
+	WindowNumber(int32_t value) : value(value) {}
+	WindowNumber(ConvertibleThroughBase auto value) : value(value.base()) {}
+
+	/* Automatically convert to int32_t. */
+	operator int32_t() const { return value; }
+
+	/* Automatically convert to any other type that might be requested. */
+	template <typename T> requires (std::is_enum_v<T> || std::is_class_v<T>)
+	operator T() const { return static_cast<T>(value); };
+};
 
 /** State of handling an event. */
 enum EventState : uint8_t {


### PR DESCRIPTION
## Motivation / Problem

In many-many places we have `WindowNumber`s that are being fed by indices of pools, or other enumerations. The special case about `WindowNumber` is that there are currently 6 functions already that have a `ConvertibleThroughBase` alternative implementation to make passing such types less cumbersome, and there are a few more that would be getting those alternatives. That's a lot of duplicated code that makes things more complicated.

Similarly, on the other side when reading data from a `WindowNumber` there are a lot of casts that need to be done (67 at the moment) to get the right object.


## Description

Make `WindowNumber` a struct with that behaves like it did before... but:
* also allows any `ConvertibleThroughBase` object in the constructor.
* provides a user defined conversion to basically anything (that it can be `static_casted` to).

Remove all now unneeded `ConvertibleThroughBase` alternatives in window_func and window_gui.

Remove all unneeded casts (separate commit).


## Limitations

In theory one could cast the data to the wrong 'type', but if you were to be needed casts you could just as easily read the compiler warning and introduced the incorrect cast manually. So I don't think that's a really significant issue.

The casts could be kept as they do that the window number was supposed to be used as that type, but that would imply adding much more casts when making the types stronger (i.e. not a typedef of an integral).

In places where this automatic casting would cause ambiguous overloads casting is still needed. There is simply no way around that.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
