### PR TITLE
Codechange: add automation for (re)setting the 'work: needs rebase' label on PRs

### DIFF
--- a/.github/workflows/rebase-checker.yml
+++ b/.github/workflows/rebase-checker.yml
@@ -1,0 +1,19 @@
+name: "Update 'work: needs rebase' label status"
+on:
+  # So that PRs touching the same files as the push are updated
+  push:
+  # So that the `dirtyLabel` is removed if conflicts are resolve
+  # We recommend `pull_request_target` so that github secrets are available.
+  # In `pull_request` we wouldn't be able to change labels of fork PRs
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check if prs are in need of a rebase
+        uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: "work: needs rebase"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Motivation / Problem

It is hard to quickly see whether a rebase (due to a merge conflict) is needed for your own PRs as you need to manually check them all separately. We do have a 'work: needs rebase' label, but that needs to be manually managed.


## Description

Configure https://github.com/eps1lon/actions-label-merge-conflict for the OpenTTD repository.


## Limitations

I have no clue whether this is going to work. I took the example and tweaked it.

I also do not have a clue how this can be tested, except "in production". Or should I just push this to master in my own repo and make a PR with a merge conflict there?


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
