### PR TITLE
Codechange: change DestinationID into class with conversion helpers

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -136,7 +136,7 @@ static StationID FindNearestHangar(const Aircraft *v)
 		if (v->current_order.IsType(OT_GOTO_STATION) ||
 				(v->current_order.IsType(OT_GOTO_DEPOT) && (v->current_order.GetDepotActionType() & ODATFB_NEAREST_DEPOT) == 0)) {
 			last_dest = Station::GetIfValid(v->last_station_visited);
-			next_dest = Station::GetIfValid(v->current_order.GetDestination());
+			next_dest = Station::GetIfValid(v->current_order.GetDestination().ToStationID());
 		} else {
 			last_dest = GetTargetAirportIfValid(v);
 			next_dest = Station::GetIfValid(v->GetNextStoppingStation().value);
@@ -424,7 +424,7 @@ static void CheckIfAircraftNeedsService(Aircraft *v)
 	 * we don't want to consider going to a depot too. */
 	if (!v->current_order.IsType(OT_GOTO_DEPOT) && !v->current_order.IsType(OT_GOTO_STATION)) return;
 
-	const Station *st = Station::Get(v->current_order.GetDestination());
+	const Station *st = Station::Get(v->current_order.GetDestination().ToStationID());
 
 	assert(st != nullptr);
 
@@ -1447,7 +1447,7 @@ static void AircraftLandAirplane(Aircraft *v)
 void AircraftNextAirportPos_and_Order(Aircraft *v)
 {
 	if (v->current_order.IsType(OT_GOTO_STATION) || v->current_order.IsType(OT_GOTO_DEPOT)) {
-		v->targetairport = v->current_order.GetDestination();
+		v->targetairport = v->current_order.GetDestination().ToStationID();
 	}
 
 	const Station *st = GetTargetAirportIfValid(v);
@@ -2101,7 +2101,7 @@ static bool AircraftEventHandler(Aircraft *v, int loop)
 		/* Check the distance to the next destination. This code works because the target
 		 * airport is only updated after take off and not on the ground. */
 		Station *cur_st = Station::GetIfValid(v->targetairport);
-		Station *next_st = v->current_order.IsType(OT_GOTO_STATION) || v->current_order.IsType(OT_GOTO_DEPOT) ? Station::GetIfValid(v->current_order.GetDestination()) : nullptr;
+		Station *next_st = v->current_order.IsType(OT_GOTO_STATION) || v->current_order.IsType(OT_GOTO_DEPOT) ? Station::GetIfValid(v->current_order.GetDestination().ToStationID()) : nullptr;
 
 		if (cur_st != nullptr && cur_st->airport.tile != INVALID_TILE && next_st != nullptr && next_st->airport.tile != INVALID_TILE) {
 			uint dist = DistanceSquare(cur_st->airport.tile, next_st->airport.tile);

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2741,7 +2741,7 @@ int WhoCanServiceIndustry(Industry *ind)
 		for (const Order *o : v->Orders()) {
 			if (o->IsType(OT_GOTO_STATION) && !(o->GetUnloadType() & OUFB_TRANSFER)) {
 				/* Vehicle visits a station to load or unload */
-				Station *st = Station::Get(o->GetDestination());
+				Station *st = Station::Get(o->GetDestination().ToStationID());
 				assert(st != nullptr);
 
 				/* Same cargo produced by industry is dropped here => not serviced by vehicle v */

--- a/src/linkgraph/refresh.cpp
+++ b/src/linkgraph/refresh.cpp
@@ -198,8 +198,8 @@ const Order *LinkRefresher::PredictNextOrder(const Order *cur, const Order *next
  */
 void LinkRefresher::RefreshStats(const Order *cur, const Order *next)
 {
-	StationID next_station = next->GetDestination();
-	Station *st = Station::GetIfValid(cur->GetDestination());
+	StationID next_station = next->GetDestination().ToStationID();
+	Station *st = Station::GetIfValid(cur->GetDestination().ToStationID());
 	if (st != nullptr && next_station != INVALID_STATION && next_station != st->index) {
 		Station *st_to = Station::Get(next_station);
 		for (CargoType c = 0; c < NUM_CARGO; c++) {

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -734,7 +734,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 		case 0x08: break; // not implemented
 		case 0x09: break; // not implemented
 		case 0x0A: return v->current_order.MapOldOrder();
-		case 0x0B: return v->current_order.GetDestination();
+		case 0x0B: return v->current_order.GetDestination().value;
 		case 0x0C: return v->GetNumOrders();
 		case 0x0D: return v->cur_real_order_index;
 		case 0x0E: break; // not implemented

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -47,7 +47,7 @@ private:
 
 	uint8_t type = 0; ///< The type of order + non-stop flags
 	uint8_t flags = 0; ///< Load/unload types, depot order/action types.
-	DestinationID dest = 0; ///< The destination of the order.
+	DestinationID dest{}; ///< The destination of the order.
 
 	CargoType refit_cargo = CARGO_NO_REFIT; ///< Refit CargoType
 
@@ -145,13 +145,13 @@ public:
 	/** What are we going to do when in the depot. */
 	inline OrderDepotActionFlags GetDepotActionType() const { return (OrderDepotActionFlags)GB(this->flags, 3, 4); }
 	/** What variable do we have to compare? */
-	inline OrderConditionVariable GetConditionVariable() const { return (OrderConditionVariable)GB(this->dest, 11, 5); }
+	inline OrderConditionVariable GetConditionVariable() const { return static_cast<OrderConditionVariable>(GB(this->dest.value, 11, 5)); }
 	/** What is the comparator to use? */
 	inline OrderConditionComparator GetConditionComparator() const { return (OrderConditionComparator)GB(this->type, 5, 3); }
 	/** Get the order to skip to. */
 	inline VehicleOrderID GetConditionSkipToOrder() const { return this->flags; }
 	/** Get the value to base the skip on. */
-	inline uint16_t GetConditionValue() const { return GB(this->dest, 0, 11); }
+	inline uint16_t GetConditionValue() const { return GB(this->dest.value, 0, 11); }
 
 	/** Set how the consist must be loaded. */
 	inline void SetLoadType(OrderLoadFlags load_type) { SB(this->flags, 4, 3, load_type); }
@@ -166,13 +166,13 @@ public:
 	/** Set what we are going to do in the depot. */
 	inline void SetDepotActionType(OrderDepotActionFlags depot_service_type) { SB(this->flags, 3, 4, depot_service_type); }
 	/** Set variable we have to compare. */
-	inline void SetConditionVariable(OrderConditionVariable condition_variable) { SB(this->dest, 11, 5, condition_variable); }
+	inline void SetConditionVariable(OrderConditionVariable condition_variable) { SB(this->dest.value, 11, 5, condition_variable); }
 	/** Set the comparator to use. */
 	inline void SetConditionComparator(OrderConditionComparator condition_comparator) { SB(this->type, 5, 3, condition_comparator); }
 	/** Get the order to skip to. */
 	inline void SetConditionSkipToOrder(VehicleOrderID order_id) { this->flags = order_id; }
 	/** Set the value to base the skip on. */
-	inline void SetConditionValue(uint16_t value) { SB(this->dest, 0, 11, value); }
+	inline void SetConditionValue(uint16_t value) { SB(this->dest.value, 0, 11, value); }
 
 	/* As conditional orders write their "skip to" order all over the flags, we cannot check the
 	 * flags to find out if timetabling is enabled. However, as conditional orders are never

--- a/src/order_cmd.h
+++ b/src/order_cmd.h
@@ -35,12 +35,12 @@ DEF_CMD_TRAIT(CMD_CLEAR_ORDER_BACKUP, CmdClearOrderBackup,  CMD_CLIENT_ID, CMDT_
 template <typename Tcont, typename Titer>
 inline EndianBufferWriter<Tcont, Titer> &operator <<(EndianBufferWriter<Tcont, Titer> &buffer, const Order &order)
 {
-	return buffer << order.type << order.flags << order.dest << order.refit_cargo << order.wait_time << order.travel_time << order.max_speed;
+	return buffer << order.type << order.flags << order.dest.value << order.refit_cargo << order.wait_time << order.travel_time << order.max_speed;
 }
 
 inline EndianBufferReader &operator >>(EndianBufferReader &buffer, Order &order)
 {
-	return buffer >> order.type >> order.flags >> order.dest >> order.refit_cargo >> order.wait_time >> order.travel_time >> order.max_speed;
+	return buffer >> order.type >> order.flags >> order.dest.value >> order.refit_cargo >> order.wait_time >> order.travel_time >> order.max_speed;
 }
 
 #endif /* ORDER_CMD_H */

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -262,7 +262,7 @@ void DrawOrderString(const Vehicle *v, const Order *order, int order_index, int 
 		case OT_GOTO_STATION: {
 			OrderLoadFlags load = order->GetLoadType();
 			OrderUnloadFlags unload = order->GetUnloadType();
-			bool valid_station = CanVehicleUseStation(v, Station::Get(order->GetDestination()));
+			bool valid_station = CanVehicleUseStation(v, Station::Get(order->GetDestination().ToStationID()));
 
 			SetDParam(0, valid_station ? STR_ORDER_GO_TO_STATION : STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION);
 			SetDParam(1, STR_ORDER_GO_TO + (v->IsGroundVehicle() ? order->GetNonStopType() : 0));

--- a/src/order_type.h
+++ b/src/order_type.h
@@ -11,11 +11,32 @@
 #define ORDER_TYPE_H
 
 #include "core/enum_type.hpp"
+#include "depot_type.h"
+#include "station_type.h"
 
 typedef uint8_t VehicleOrderID;  ///< The index of an order within its current vehicle (not pool related)
 typedef uint32_t OrderID;
 typedef uint16_t OrderListID;
-typedef uint16_t DestinationID;
+
+struct DestinationID {
+	using BaseType = uint16_t;
+	BaseType value = 0;
+
+	explicit DestinationID() = default;
+	constexpr DestinationID(size_t index) : value(static_cast<BaseType>(index)) {}
+
+	constexpr DepotID ToDepotID() const noexcept { return static_cast<DepotID>(this->value); }
+	constexpr StationID ToStationID() const noexcept { return static_cast<StationID>(this->value); }
+	constexpr BaseType base() const noexcept { return this->value; }
+
+	constexpr bool operator ==(const DestinationID &destination) const { return this->value == destination.value; }
+	constexpr bool operator !=(const DestinationID &destination) const { return this->value != destination.value; }
+	constexpr bool operator ==(const StationID &station) const { return this->value == station; }
+	constexpr bool operator !=(const StationID &station) const { return this->value != station; }
+};
+
+constexpr bool operator ==(const StationID &station, const DestinationID &destination) { return destination == station; }
+constexpr bool operator !=(const StationID &station, const DestinationID &destination) { return destination != station; }
 
 /** Invalid vehicle order index (sentinel) */
 static const VehicleOrderID INVALID_VEH_ORDER_ID = 0xFF;

--- a/src/pathfinder/yapf/yapf_costrail.hpp
+++ b/src/pathfinder/yapf/yapf_costrail.hpp
@@ -404,7 +404,7 @@ no_entry_cost: // jump here at the beginning if the node has no parent (it is th
 			} else if (cur.tile_type == MP_STATION && IsRailWaypoint(cur.tile)) {
 				if (v->current_order.IsType(OT_GOTO_WAYPOINT) &&
 						GetStationIndex(cur.tile) == v->current_order.GetDestination() &&
-						!Waypoint::Get(v->current_order.GetDestination())->IsSingleTile()) {
+						!Waypoint::Get(v->current_order.GetDestination().ToStationID())->IsSingleTile()) {
 					/* This waypoint is our destination; maybe this isn't an unreserved
 					 * one, so check that and if so see that as the last signal being
 					 * red. This way waypoints near stations should work better. */

--- a/src/pathfinder/yapf/yapf_destrail.hpp
+++ b/src/pathfinder/yapf/yapf_destrail.hpp
@@ -135,7 +135,7 @@ public:
 		this->any_depot = false;
 		switch (v->current_order.GetType()) {
 			case OT_GOTO_WAYPOINT:
-				if (!Waypoint::Get(v->current_order.GetDestination())->IsSingleTile()) {
+				if (!Waypoint::Get(v->current_order.GetDestination().ToStationID())->IsSingleTile()) {
 					/* In case of 'complex' waypoints we need to do a look
 					 * ahead. This look ahead messes a bit about, which
 					 * means that it 'corrupts' the cache. To prevent this
@@ -146,8 +146,8 @@ public:
 				[[fallthrough]];
 
 			case OT_GOTO_STATION:
-				this->dest_tile = CalcClosestStationTile(v->current_order.GetDestination(), v->tile, v->current_order.IsType(OT_GOTO_STATION) ? StationType::Rail : StationType::RailWaypoint);
-				this->dest_station_id = v->current_order.GetDestination();
+				this->dest_tile = CalcClosestStationTile(v->current_order.GetDestination().ToStationID(), v->tile, v->current_order.IsType(OT_GOTO_STATION) ? StationType::Rail : StationType::RailWaypoint);
+				this->dest_station_id = v->current_order.GetDestination().ToStationID();
 				this->dest_trackdirs = INVALID_TRACKDIR_BIT;
 				break;
 

--- a/src/pathfinder/yapf/yapf_road.cpp
+++ b/src/pathfinder/yapf/yapf_road.cpp
@@ -241,13 +241,13 @@ public:
 	void SetDestination(const RoadVehicle *v)
 	{
 		if (v->current_order.IsType(OT_GOTO_STATION)) {
-			this->dest_station = v->current_order.GetDestination();
+			this->dest_station = v->current_order.GetDestination().ToStationID();
 			this->station_type = v->IsBus() ? StationType::Bus : StationType::Truck;
 			this->dest_tile = CalcClosestStationTile(this->dest_station, v->tile, this->station_type);
 			this->non_artic = !v->HasArticulatedPart();
 			this->dest_trackdirs = INVALID_TRACKDIR_BIT;
 		} else if (v->current_order.IsType(OT_GOTO_WAYPOINT)) {
-			this->dest_station = v->current_order.GetDestination();
+			this->dest_station = v->current_order.GetDestination().ToStationID();
 			this->station_type = StationType::RoadWaypoint;
 			this->dest_tile = CalcClosestStationTile(this->dest_station, v->tile, this->station_type);
 			this->non_artic = !v->HasArticulatedPart();

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -45,7 +45,7 @@ public:
 	void SetDestination(const Ship *v)
 	{
 		if (v->current_order.IsType(OT_GOTO_STATION)) {
-			this->dest_station = v->current_order.GetDestination();
+			this->dest_station = v->current_order.GetDestination().ToStationID();
 			this->dest_tile = CalcClosestStationTile(this->dest_station, v->tile, StationType::Dock);
 			this->dest_trackdirs = INVALID_TRACKDIR_BIT;
 		} else {

--- a/src/pathfinder/yapf/yapf_ship_regions.cpp
+++ b/src/pathfinder/yapf/yapf_ship_regions.cpp
@@ -185,7 +185,7 @@ public:
 		pf.SetDestination(start_water_region_patch);
 
 		if (v->current_order.IsType(OT_GOTO_STATION)) {
-			DestinationID station_id = v->current_order.GetDestination();
+			StationID station_id = v->current_order.GetDestination().ToStationID();
 			const BaseStation *station = BaseStation::Get(station_id);
 			TileArea tile_area;
 			station->GetTileArea(&tile_area, StationType::Dock);

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -1369,7 +1369,7 @@ bool LoadOldVehicle(LoadgameState *ls, int num)
 		v->current_order.AssignOrder(UnpackOldOrder(_old_order));
 
 		if (v->type == VEH_DISASTER) {
-			DisasterVehicle::From(v)->state = UnpackOldOrder(_old_order).GetDestination();
+			DisasterVehicle::From(v)->state = UnpackOldOrder(_old_order).GetDestination().value;
 		}
 
 		v->next = (Vehicle *)(size_t)_old_next_ptr;

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -32,10 +32,10 @@ static void UpdateWaypointOrder(Order *o)
 {
 	if (!o->IsType(OT_GOTO_STATION)) return;
 
-	const Station *st = Station::Get(o->GetDestination());
+	const Station *st = Station::Get(o->GetDestination().ToStationID());
 	if ((st->had_vehicle_of_type & HVOT_WAYPOINT) == 0) return;
 
-	o->MakeGoToWaypoint(o->GetDestination());
+	o->MakeGoToWaypoint(o->GetDestination().ToStationID());
 }
 
 /**

--- a/src/script/api/script_order.cpp
+++ b/src/script/api/script_order.cpp
@@ -252,15 +252,15 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 			/* We don't know where the nearest depot is... (yet) */
 			if (order->GetDepotActionType() & ODATFB_NEAREST_DEPOT) return INVALID_TILE;
 
-			if (v->type != VEH_AIRCRAFT) return ::Depot::Get(order->GetDestination())->xy;
+			if (v->type != VEH_AIRCRAFT) return ::Depot::Get(order->GetDestination().ToDepotID())->xy;
 			/* Aircraft's hangars are referenced by StationID, not DepotID */
-			const Station *st = ::Station::Get(order->GetDestination());
+			const Station *st = ::Station::Get(order->GetDestination().ToStationID());
 			if (!st->airport.HasHangar()) return INVALID_TILE;
 			return st->airport.GetHangarTile(0);
 		}
 
 		case OT_GOTO_STATION: {
-			const Station *st = ::Station::Get(order->GetDestination());
+			const Station *st = ::Station::Get(order->GetDestination().ToStationID());
 			if (st->train_station.tile != INVALID_TILE) {
 				for (TileIndex t : st->train_station) {
 					if (st->TileBelongsToRailStation(t)) return t;
@@ -282,7 +282,7 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 		}
 
 		case OT_GOTO_WAYPOINT: {
-			const Waypoint *wp = ::Waypoint::Get(order->GetDestination());
+			const Waypoint *wp = ::Waypoint::Get(order->GetDestination().ToStationID());
 			if (wp->train_station.tile != INVALID_TILE) {
 				for (TileIndex t : wp->train_station) {
 					if (wp->TileBelongsToRailStation(t)) return t;

--- a/src/script/api/script_stationlist.cpp
+++ b/src/script/api/script_stationlist.cpp
@@ -35,7 +35,7 @@ ScriptStationList_Vehicle::ScriptStationList_Vehicle(VehicleID vehicle_id)
 	const Vehicle *v = ::Vehicle::Get(vehicle_id);
 
 	for (Order *o = v->GetFirstOrder(); o != nullptr; o = o->next) {
-		if (o->IsType(OT_GOTO_STATION)) this->AddItem(o->GetDestination());
+		if (o->IsType(OT_GOTO_STATION)) this->AddItem(o->GetDestination().ToStationID());
 	}
 }
 

--- a/src/script/api/script_waypointlist.cpp
+++ b/src/script/api/script_waypointlist.cpp
@@ -35,6 +35,6 @@ ScriptWaypointList_Vehicle::ScriptWaypointList_Vehicle(VehicleID vehicle_id)
 	const Vehicle *v = ::Vehicle::Get(vehicle_id);
 
 	for (const Order *o = v->GetFirstOrder(); o != nullptr; o = o->next) {
-		if (o->IsType(OT_GOTO_WAYPOINT)) this->AddItem(o->GetDestination());
+		if (o->IsType(OT_GOTO_WAYPOINT)) this->AddItem(o->GetDestination().ToStationID());
 	}
 }

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -773,7 +773,7 @@ static void ShipController(Ship *v)
 							}
 						} else if (v->current_order.IsType(OT_GOTO_STATION) && IsDockingTile(gp.new_tile)) {
 							/* Process station in the orderlist. */
-							Station *st = Station::Get(v->current_order.GetDestination());
+							Station *st = Station::Get(v->current_order.GetDestination().ToStationID());
 							if (st->docking_station.Contains(gp.new_tile) && IsShipDestinationTile(gp.new_tile, st->index)) {
 								v->last_station_visited = st->index;
 								if (st->facilities & FACIL_DOCK) { // ugly, ugly workaround for problem with ships able to drop off cargo at wrong stations

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -4194,7 +4194,7 @@ void Train::OnNewEconomyDay()
 
 		/* update destination */
 		if (this->current_order.IsType(OT_GOTO_STATION)) {
-			TileIndex tile = Station::Get(this->current_order.GetDestination())->train_station.tile;
+			TileIndex tile = Station::Get(this->current_order.GetDestination().ToStationID())->train_station.tile;
 			if (tile != INVALID_TILE) this->dest_tile = tile;
 		}
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2635,7 +2635,7 @@ CommandCost Vehicle::SendToDepot(DoCommandFlag flags, DepotCommandFlags command)
 		}
 
 		this->SetDestTile(closestDepot.location);
-		this->current_order.MakeGoToDepot(closestDepot.destination, ODTF_MANUAL);
+		this->current_order.MakeGoToDepot(closestDepot.destination.ToDepotID(), ODTF_MANUAL);
 		if (!command.Test(DepotCommandFlag::Service)) this->current_order.SetDepotActionType(ODATFB_HALT);
 		SetWindowWidgetDirty(WC_VEHICLE_VIEW, this->index, WID_VV_START_STOP);
 

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -228,13 +228,12 @@ struct RefitDesc {
  * and whether it could be found.
  */
 struct ClosestDepot {
-	TileIndex location;
-	DestinationID destination; ///< The DestinationID as used for orders.
-	bool reverse;
-	bool found;
+	TileIndex location = INVALID_TILE;
+	DestinationID destination{}; ///< The DestinationID as used for orders.
+	bool reverse = false;
+	bool found = false;
 
-	ClosestDepot() :
-		location(INVALID_TILE), destination(0), reverse(false), found(false) {}
+	ClosestDepot() = default;
 
 	ClosestDepot(TileIndex location, DestinationID destination, bool reverse = false) :
 		location(location), destination(destination), reverse(reverse), found(true) {}


### PR DESCRIPTION
## Motivation / Problem

When doing the conversion to stronger types, we run into a problem with both `SourceID` and `DestinationID` which are not really types, but rather groups of types. Either a `StationID` and `DepotID` are `DestinationID`, and for `SourceID` those would be `CompanyID` (HQ), `IndustryID` or `TownID`. 

This would mean a lot of casts need to be added throughout the code for things like comparisons and assignments. That's both cumbersome and ugly. In most cases automatic conversions do work, but not all cases and those are very complicated to solve reliably when we are still in a migration to stronger types.


## Description

Change the `typedef` of `DestinationID` to a strong-ish type with `.ToStationID()` and `.ToDepotID()`, similar to #13440. This hides all the casting within `DestinationID`, making it possible to strengthen the behaviour at a later date (actually testing whether what we read was a `StationID` or `DepotID`). However, that requires those types to become strong types first. 

When adding those strong types, new constructors for those types need to be made, as well as comparison operators for those types. That way three lines of code prevent dozens of `static_cast` / `.base()` calls.


## Limitations

This is not complete, because the `StationID` and `DepotID are not strongly typed. However, I'm proposing this now to not first add dozens of casts and then replace all those with these conversion functions. Better do 95% of the work now to save a lot of review work.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
