### PR TITLE
Codechange: Allow ConvertibleThroughBase types to be used as settings.

### DIFF
--- a/src/core/convertible_through_base.hpp
+++ b/src/core/convertible_through_base.hpp
@@ -21,4 +21,12 @@ concept ConvertibleThroughBase = requires(T const a) {
 	{ a.base() } noexcept -> std::convertible_to<int64_t>;
 };
 
+/**
+ * Type is convertible to TTo, either directly or through ConvertibleThroughBase.
+ * @tparam T The type under consideration.
+ * @tparam TTo The type to convert to.
+ */
+template <typename T, typename TTo>
+concept ConvertibleThroughBaseOrTo = std::is_convertible_v<T, TTo> || ConvertibleThroughBase<T>;
+
 #endif /* CONVERTIBLE_THROUGH_BASE_HPP */

--- a/src/core/strong_typedef_type.hpp
+++ b/src/core/strong_typedef_type.hpp
@@ -12,9 +12,6 @@
 
 #include "../3rdparty/fmt/format.h"
 
-/** Non-templated base for #StrongType::Typedef for use with type trait queries. */
-struct StrongTypedefBase {};
-
 namespace StrongType {
 	/**
 	 * Mix-in which makes the new Typedef comparable with itself and its base type.
@@ -147,7 +144,7 @@ namespace StrongType {
 	 * @tparam TProperties A list of mixins to add to the class.
 	 */
 	template <typename TBaseType, typename TTag, typename... TProperties>
-	struct EMPTY_BASES Typedef : public StrongTypedefBase, public TProperties::template mixin<Typedef<TBaseType, TTag, TProperties...>, TBaseType>... {
+	struct EMPTY_BASES Typedef : public TProperties::template mixin<Typedef<TBaseType, TTag, TProperties...>, TBaseType>... {
 		using BaseType = TBaseType;
 
 		constexpr Typedef() = default;

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -167,16 +167,7 @@ struct IntSettingDesc : SettingDesc {
 	 */
 	typedef void PostChangeCallback(int32_t value);
 
-	template <
-		typename Tdef,
-		typename Tmin,
-		typename Tmax,
-		typename Tinterval,
-		std::enable_if_t<std::disjunction_v<std::is_convertible<Tdef, int32_t>, std::is_base_of<StrongTypedefBase, Tdef>>, int> = 0,
-		std::enable_if_t<std::disjunction_v<std::is_convertible<Tmin, int32_t>, std::is_base_of<StrongTypedefBase, Tmin>>, int> = 0,
-		std::enable_if_t<std::disjunction_v<std::is_convertible<Tmax, uint32_t>, std::is_base_of<StrongTypedefBase, Tmax>>, int> = 0,
-		std::enable_if_t<std::disjunction_v<std::is_convertible<Tinterval, int32_t>, std::is_base_of<StrongTypedefBase, Tinterval>>, int> = 0
-	>
+	template <ConvertibleThroughBaseOrTo<int32_t> Tdef, ConvertibleThroughBaseOrTo<int32_t> Tmin, ConvertibleThroughBaseOrTo<uint32_t> Tmax, ConvertibleThroughBaseOrTo<int32_t> Tinterval>
 	IntSettingDesc(const SaveLoad &save, SettingFlags flags, bool startup, Tdef def,
 			Tmin min, Tmax max, Tinterval interval, StringID str, StringID str_help, StringID str_val,
 			SettingCategory cat, PreChangeCheck pre_check, PostChangeCallback post_callback,
@@ -187,25 +178,25 @@ struct IntSettingDesc : SettingDesc {
 			post_callback(post_callback),
 			get_title_cb(get_title_cb), get_help_cb(get_help_cb), set_value_dparams_cb(set_value_dparams_cb),
 			get_def_cb(get_def_cb), get_range_cb(get_range_cb) {
-		if constexpr (std::is_base_of_v<StrongTypedefBase, Tdef>) {
+		if constexpr (ConvertibleThroughBase<Tdef>) {
 			this->def = def.base();
 		} else {
 			this->def = def;
 		}
 
-		if constexpr (std::is_base_of_v<StrongTypedefBase, Tmin>) {
+		if constexpr (ConvertibleThroughBase<Tmin>) {
 			this->min = min.base();
 		} else {
 			this->min = min;
 		}
 
-		if constexpr (std::is_base_of_v<StrongTypedefBase, Tmax>) {
+		if constexpr (ConvertibleThroughBase<Tmax>) {
 			this->max = max.base();
 		} else {
 			this->max = max;
 		}
 
-		if constexpr (std::is_base_of_v<StrongTypedefBase, Tinterval>) {
+		if constexpr (ConvertibleThroughBase<Tinterval>) {
 			this->interval = interval.base();
 		} else {
 			this->interval = interval;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`IntSettingDesc` allows StrongTypes to be used as setting default values and limits, and uses .base() to set them.

This can be made more generic by allowing any `ConvertibleThroughBase` type instead.

This removes the last remaining user of 'StrongTypeBase' which can be removed.


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Change `IntSettingDesc` template signature to allow `ConvertibleThroughBase` types to be used.

Remove `StrongTypeBase`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Probably needs a better name for the `ConvertibleThroughBaseOrStd` concept.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
