### PR TITLE
Codechange: Null video driver: End on game exit

### DIFF
--- a/src/video/null_v.cpp
+++ b/src/video/null_v.cpp
@@ -50,7 +50,7 @@ void VideoDriver_Null::MainLoop()
 {
 	uint i;
 
-	for (i = 0; i < this->ticks; i++) {
+	for (i = 0; i < this->ticks && ! _exit_game; i++) {
 		::GameLoop();
 		::InputLoop();
 		::UpdateWindows();

--- a/src/video/null_v.cpp
+++ b/src/video/null_v.cpp
@@ -51,7 +51,10 @@ void VideoDriver_Null::MainLoop()
 	uint i;
 
 	for (i = 0; i < this->ticks && ! _exit_game; i++) {
-		::GameLoop();
+		{
+			std::lock_guard<std::mutex> lock(this->game_state_mutex);
+			::GameLoop();
+		}
 		::InputLoop();
 		::UpdateWindows();
 	}


### PR DESCRIPTION
The Null driver now exits when the game ends.

It also gains the ability to run for an unlimited number of ticks (using '-v null:ticks=0').

## Motivation / Problem

I was using the null video driver to run some automated tests and collided with the fact that the game either terminated early (after N ticks but my test needed some random larger number) or late (and didn't end the game for ages).

## Description

* The driver now obeys the `_exit_game` global and, well, exits.
* The null driver's "ticks" may now be set to zero, in which case it will run indefinitely (or until some other code sets the exit flag).

## Limitations

The null driver now defaults to running one tick longer than previously. I seriously doubt that this will affect anything.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
