### PR TITLE
Codechange: use the appropriate type for OldWaypoint indices

### DIFF
--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -22,9 +22,11 @@
 
 #include "../safeguards.h"
 
+using OldWaypointID = uint16_t;
+
 /** Helper structure to convert from the old waypoint system. */
 struct OldWaypoint {
-	size_t index;
+	OldWaypointID index;
 	TileIndex xy;
 	TownID town_index;
 	Town *town;
@@ -38,7 +40,7 @@ struct OldWaypoint {
 	const StationSpec *spec;
 	Owner owner;
 
-	size_t new_index;
+	StationID new_index;
 };
 
 /** Temporary array with old waypoints. */
@@ -55,7 +57,7 @@ static void UpdateWaypointOrder(Order *o)
 	for (OldWaypoint &wp : _old_waypoints) {
 		if (wp.index != o->GetDestination()) continue;
 
-		o->SetDestination((DestinationID)wp.new_index);
+		o->SetDestination(wp.new_index);
 		return;
 	}
 }
@@ -76,7 +78,7 @@ void MoveWaypointsToBaseStations()
 
 			/* Waypoint indices were not added to the map prior to this. */
 			Tile tile = wp.xy;
-			tile.m2() = (StationID)wp.index;
+			tile.m2() = wp.index;
 
 			if (HasBit(tile.m3(), 4)) {
 				wp.spec = StationClass::Get(STAT_CLASS_WAYP)->GetSpec(tile.m4() + 1);
@@ -195,7 +197,7 @@ struct CHKPChunkHandler : ChunkHandler {
 		while ((index = SlIterateArray()) != -1) {
 			OldWaypoint *wp = &_old_waypoints.emplace_back();
 
-			wp->index = index;
+			wp->index = static_cast<OldWaypointID>(index);
 			SlObject(wp, _old_waypoint_desc);
 		}
 	}


### PR DESCRIPTION
## Motivation / Problem

In `OldWaypoint` there is `index` and `new_index` which are both `size_t`. This means that for any use there might be considerations for casting because you will be narrowing types.


## Description

Introduce `OldWaypointID` that is just a `uint16_t` like `StationID`.
Make `index` of type `OldWaypointID`, and `new_index` of type `StationID` (which by conceptual 'inheritance' is also `DestinationID`).


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
