### PR TITLE
Codechange: put SourceType and SourceID into Source struct

### DIFF
--- a/src/cargo_type.h
+++ b/src/cargo_type.h
@@ -141,4 +141,12 @@ enum class SourceType : uint8_t {
 typedef uint16_t SourceID; ///< Contains either industry ID, town ID or company ID (or INVALID_SOURCE)
 static const SourceID INVALID_SOURCE = 0xFFFF; ///< Invalid/unknown index of source
 
+/** A location from where cargo can come from (or go to). Specifically industries, towns and headquarters. */
+struct Source {
+	SourceID id; ///< Index of industry/town/HQ, INVALID_SOURCE if unknown/invalid.
+	SourceType type; ///< Type of \c source_id.
+
+	auto operator<=>(const Source &source) const = default;
+};
+
 #endif /* CARGO_TYPE_H */

--- a/src/cargomonitor.cpp
+++ b/src/cargomonitor.cpp
@@ -110,26 +110,25 @@ int32_t GetPickupAmount(CargoMonitorID monitor, bool keep_monitoring)
  * @param cargo_type type of cargo.
  * @param company company delivering the cargo.
  * @param amount Amount of cargo delivered.
- * @param src_type type of \a src.
- * @param src index of source.
+ * @param src source of cargo.
  * @param st station where the cargo is delivered to.
  * @param dest industry index where the cargo is delivered to.
  */
-void AddCargoDelivery(CargoType cargo_type, CompanyID company, uint32_t amount, SourceType src_type, SourceID src, const Station *st, IndustryID dest)
+void AddCargoDelivery(CargoType cargo_type, CompanyID company, uint32_t amount, Source src, const Station *st, IndustryID dest)
 {
 	if (amount == 0) return;
 
-	if (src != INVALID_SOURCE) {
+	if (src.id != INVALID_SOURCE) {
 		/* Handle pickup update. */
-		switch (src_type) {
+		switch (src.type) {
 			case SourceType::Industry: {
-				CargoMonitorID num = EncodeCargoIndustryMonitor(company, cargo_type, src);
+				CargoMonitorID num = EncodeCargoIndustryMonitor(company, cargo_type, src.id);
 				CargoMonitorMap::iterator iter = _cargo_pickups.find(num);
 				if (iter != _cargo_pickups.end()) iter->second += amount;
 				break;
 			}
 			case SourceType::Town: {
-				CargoMonitorID num = EncodeCargoTownMonitor(company, cargo_type, src);
+				CargoMonitorID num = EncodeCargoTownMonitor(company, cargo_type, src.id);
 				CargoMonitorMap::iterator iter = _cargo_pickups.find(num);
 				if (iter != _cargo_pickups.end()) iter->second += amount;
 				break;

--- a/src/cargomonitor.h
+++ b/src/cargomonitor.h
@@ -143,6 +143,6 @@ void ClearCargoPickupMonitoring(CompanyID company = INVALID_OWNER);
 void ClearCargoDeliveryMonitoring(CompanyID company = INVALID_OWNER);
 int32_t GetDeliveryAmount(CargoMonitorID monitor, bool keep_monitoring);
 int32_t GetPickupAmount(CargoMonitorID monitor, bool keep_monitoring);
-void AddCargoDelivery(CargoType cargo_type, CompanyID company, uint32_t amount, SourceType src_type, SourceID src, const Station *st, IndustryID dest = INVALID_INDUSTRY);
+void AddCargoDelivery(CargoType cargo_type, CompanyID company, uint32_t amount, Source src, const Station *st, IndustryID dest = INVALID_INDUSTRY);
 
 #endif /* CARGOMONITOR_H */

--- a/src/cargopacket.cpp
+++ b/src/cargopacket.cpp
@@ -26,8 +26,6 @@ INSTANTIATE_POOL_METHODS(CargoPacket)
  */
 CargoPacket::CargoPacket()
 {
-	this->source_type = SourceType::Industry;
-	this->source_id   = INVALID_SOURCE;
 }
 
 /**
@@ -35,14 +33,12 @@ CargoPacket::CargoPacket()
  *
  * @param first_station Source station of the packet.
  * @param count         Number of cargo entities to put in this packet.
- * @param source_type   'Type' of source the packet comes from (for subsidies).
- * @param source_id     Actual source of the packet (for subsidies).
+ * @param source        Source of the packet (for subsidies).
  * @pre count != 0
  */
-CargoPacket::CargoPacket(StationID first_station,uint16_t count, SourceType source_type, SourceID source_id) :
+CargoPacket::CargoPacket(StationID first_station,uint16_t count, Source source) :
 		count(count),
-		source_id(source_id),
-		source_type(source_type),
+		source(source),
 		first_station(first_station)
 {
 	assert(count != 0);
@@ -80,8 +76,7 @@ CargoPacket::CargoPacket(uint16_t count, Money feeder_share, CargoPacket &origin
 		feeder_share(feeder_share),
 		source_xy(original.source_xy),
 		travelled(original.travelled),
-		source_id(original.source_id),
-		source_type(original.source_type),
+		source(original.source),
 #ifdef WITH_ASSERT
 		in_vehicle(original.in_vehicle),
 #endif /* WITH_ASSERT */
@@ -134,10 +129,10 @@ void CargoPacket::Reduce(uint count)
  * @param src_type Type of source.
  * @param src Index of source.
  */
-/* static */ void CargoPacket::InvalidateAllFrom(SourceType src_type, SourceID src)
+/* static */ void CargoPacket::InvalidateAllFrom(Source src)
 {
 	for (CargoPacket *cp : CargoPacket::Iterate()) {
-		if (cp->source_type == src_type && cp->source_id == src) cp->source_id = INVALID_SOURCE;
+		if (cp->source == src) cp->source.id = INVALID_SOURCE;
 	}
 }
 

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -53,8 +53,7 @@ private:
 	TileIndex source_xy = INVALID_TILE; ///< The origin of the cargo.
 	Vector travelled{0, 0}; ///< If cargo is in station: the vector from the unload tile to the source tile. If in vehicle: an intermediate value.
 
-	SourceID source_id = INVALID_SOURCE; ///< Index of industry/town/HQ, INVALID_SOURCE if unknown/invalid.
-	SourceType source_type = SourceType::Industry; ///< Type of \c source_id.
+	Source source{INVALID_SOURCE, SourceType::Industry}; ///< Source of the cargo
 
 #ifdef WITH_ASSERT
 	bool in_vehicle = false; ///< NOSAVE: Whether this cargo is in a vehicle or not.
@@ -74,7 +73,7 @@ public:
 	static const uint16_t MAX_COUNT = UINT16_MAX;
 
 	CargoPacket();
-	CargoPacket(StationID first_station, uint16_t count, SourceType source_type, SourceID source_id);
+	CargoPacket(StationID first_station, uint16_t count, Source source);
 	CargoPacket(uint16_t count, uint16_t periods_in_transit, StationID first_station, TileIndex source_xy, Money feeder_share);
 	CargoPacket(uint16_t count, Money feeder_share, CargoPacket &original);
 
@@ -194,21 +193,12 @@ public:
 	}
 
 	/**
-	 * Gets the type of the cargo's source. industry, town or head quarter.
-	 * @return Source type.
+	 * Gets the source of the packet for subsidy purposes.
+	 * @return The source.
 	 */
-	inline SourceType GetSourceType() const
+	inline Source GetSource() const
 	{
-		return this->source_type;
-	}
-
-	/**
-	 * Gets the ID of the cargo's source. An IndustryID, TownID or CompanyID.
-	 * @return Source ID.
-	 */
-	inline SourceID GetSourceID() const
-	{
-		return this->source_id;
+		return this->source;
 	}
 
 	/**
@@ -270,7 +260,7 @@ public:
 		return this->next_hop;
 	}
 
-	static void InvalidateAllFrom(SourceType src_type, SourceID src);
+	static void InvalidateAllFrom(Source src);
 	static void InvalidateAllFrom(StationID sid);
 	static void AfterLoad();
 };
@@ -514,9 +504,9 @@ public:
 	{
 		return cp1->source_xy == cp2->source_xy &&
 				cp1->periods_in_transit == cp2->periods_in_transit &&
-				cp1->source_type == cp2->source_type &&
+				cp1->source.type == cp2->source.type &&
 				cp1->first_station == cp2->first_station &&
-				cp1->source_id == cp2->source_id;
+				cp1->source.id == cp2->source.id;
 	}
 };
 
@@ -547,7 +537,7 @@ public:
 	friend class CargoReturn;
 	friend class StationCargoReroute;
 
-	static void InvalidateAllFrom(SourceType src_type, SourceID src);
+	static void InvalidateAllFrom(Source src);
 
 	template <class Taction>
 	bool ShiftCargo(Taction &action, StationID next);
@@ -629,9 +619,8 @@ public:
 	{
 		return cp1->source_xy == cp2->source_xy &&
 				cp1->periods_in_transit == cp2->periods_in_transit &&
-				cp1->source_type == cp2->source_type &&
 				cp1->first_station == cp2->first_station &&
-				cp1->source_id == cp2->source_id;
+				cp1->source == cp2->source;
 	}
 };
 

--- a/src/economy_func.h
+++ b/src/economy_func.h
@@ -31,7 +31,7 @@ int UpdateCompanyRatingAndValue(Company *c, bool update);
 void StartupIndustryDailyChanges(bool init_counter);
 
 Money GetTransportedGoodsIncome(uint num_pieces, uint dist, uint16_t transit_periods, CargoType cargo_type);
-uint MoveGoodsToStation(CargoType type, uint amount, SourceType source_type, SourceID source_id, const StationList &all_stations, Owner exclusivity = INVALID_OWNER);
+uint MoveGoodsToStation(CargoType type, uint amount, Source source, const StationList &all_stations, Owner exclusivity = INVALID_OWNER);
 
 void PrepareUnload(Vehicle *front_v);
 void LoadUnloadStation(Station *st);

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -197,8 +197,9 @@ Industry::~Industry()
 	CloseWindowById(WC_INDUSTRY_VIEW, this->index);
 	DeleteNewGRFInspectWindow(GSF_INDUSTRIES, this->index);
 
-	DeleteSubsidyWith(SourceType::Industry, this->index);
-	CargoPacket::InvalidateAllFrom(SourceType::Industry, this->index);
+	Source src{this->index, SourceType::Industry};
+	DeleteSubsidyWith(src);
+	CargoPacket::InvalidateAllFrom(src);
 
 	for (Station *st : this->stations_near) {
 		st->RemoveIndustryToDeliver(this);
@@ -537,7 +538,7 @@ static bool TransportIndustryGoods(TileIndex tile)
 
 			p.history[THIS_MONTH].production += cw;
 
-			uint am = MoveGoodsToStation(p.cargo, cw, SourceType::Industry, i->index, i->stations_near, i->exclusive_consumer);
+			uint am = MoveGoodsToStation(p.cargo, cw, {i->index, SourceType::Industry}, i->stations_near, i->exclusive_consumer);
 			p.history[THIS_MONTH].transported += am;
 
 			moved_cargo |= (am != 0);

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -591,7 +591,7 @@ static CommandCost ClearTile_Object(TileIndex tile, DoCommandFlag flags)
 			if (flags & DC_EXEC) {
 				c->location_of_HQ = INVALID_TILE; // reset HQ position
 				SetWindowDirty(WC_COMPANY, c->index);
-				CargoPacket::InvalidateAllFrom(SourceType::Headquarters, c->index);
+				CargoPacket::InvalidateAllFrom({c->index, SourceType::Headquarters});
 			}
 
 			/* cost of relocating company is 1% of company value */
@@ -704,13 +704,13 @@ static void TileLoop_Object(TileIndex tile)
 		/* Scale by cargo scale setting. */
 		amt = ScaleByCargoScale(amt, true);
 
-		MoveGoodsToStation(pass, amt, SourceType::Headquarters, GetTileOwner(tile), stations.GetStations());
+		MoveGoodsToStation(pass, amt, {GetTileOwner(tile), SourceType::Headquarters}, stations.GetStations());
 	}
 
 	/* Top town building generates 90, HQ can make up to 196. The
 	 * proportion passengers:mail is about the same as in the acceptance
 	 * equations. */
-	 CargoType mail = GetCargoTypeByLabel(CT_MAIL);
+	CargoType mail = GetCargoTypeByLabel(CT_MAIL);
 	if (IsValidCargoType(mail) && GB(r, 8, 8) < (196 / 4 / (6 - level))) {
 		uint amt = GB(r, 8, 8) / 8 / 4 + 1;
 
@@ -720,7 +720,7 @@ static void TileLoop_Object(TileIndex tile)
 		/* Scale by cargo scale setting. */
 		amt = ScaleByCargoScale(amt, true);
 
-		MoveGoodsToStation(mail, amt, SourceType::Headquarters, GetTileOwner(tile), stations.GetStations());
+		MoveGoodsToStation(mail, amt, {GetTileOwner(tile), SourceType::Headquarters}, stations.GetStations());
 	}
 }
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2279,20 +2279,20 @@ bool AfterLoadGame()
 					case TAE_PASSENGERS:
 					case TAE_MAIL:
 						/* Town -> Town */
-						s->src_type = s->dst_type = SourceType::Town;
-						if (Town::IsValidID(s->src) && Town::IsValidID(s->dst)) continue;
+						s->src.type = s->dst.type = SourceType::Town;
+						if (Town::IsValidID(s->src.id) && Town::IsValidID(s->dst.id)) continue;
 						break;
 					case TAE_GOODS:
 					case TAE_FOOD:
 						/* Industry -> Town */
-						s->src_type = SourceType::Industry;
-						s->dst_type = SourceType::Town;
-						if (Industry::IsValidID(s->src) && Town::IsValidID(s->dst)) continue;
+						s->src.type = SourceType::Industry;
+						s->dst.type = SourceType::Town;
+						if (Industry::IsValidID(s->src.id) && Town::IsValidID(s->dst.id)) continue;
 						break;
 					default:
 						/* Industry -> Industry */
-						s->src_type = s->dst_type = SourceType::Industry;
-						if (Industry::IsValidID(s->src) && Industry::IsValidID(s->dst)) continue;
+						s->src.type = s->dst.type = SourceType::Industry;
+						if (Industry::IsValidID(s->src.id) && Industry::IsValidID(s->dst.id)) continue;
 						break;
 				}
 			} else {
@@ -2305,13 +2305,13 @@ bool AfterLoadGame()
 					case TAE_PASSENGERS:
 					case TAE_MAIL: {
 						/* Town -> Town */
-						const Station *ss = Station::GetIfValid(s->src);
-						const Station *sd = Station::GetIfValid(s->dst);
+						const Station *ss = Station::GetIfValid(s->src.id);
+						const Station *sd = Station::GetIfValid(s->dst.id);
 						if (ss != nullptr && sd != nullptr && ss->owner == sd->owner &&
 								Company::IsValidID(ss->owner)) {
-							s->src_type = s->dst_type = SourceType::Town;
-							s->src = ss->town->index;
-							s->dst = sd->town->index;
+							s->src.type = s->dst.type = SourceType::Town;
+							s->src.id = ss->town->index;
+							s->dst.id = sd->town->index;
 							s->awarded = ss->owner;
 							continue;
 						}

--- a/src/saveload/cargopacket_sl.cpp
+++ b/src/saveload/cargopacket_sl.cpp
@@ -134,8 +134,8 @@ SaveLoadTable GetCargoPacketDesc()
 		SLE_CONDVARNAME(CargoPacket, periods_in_transit, "days_in_transit", SLE_UINT16, SLV_MORE_CARGO_AGE, SLV_PERIODS_IN_TRANSIT_RENAME),
 		SLE_CONDVAR(CargoPacket, periods_in_transit, SLE_UINT16, SLV_PERIODS_IN_TRANSIT_RENAME, SL_MAX_VERSION),
 		SLE_VAR(CargoPacket, feeder_share,    SLE_INT64),
-		SLE_CONDVAR(CargoPacket, source_type,     SLE_UINT8,  SLV_125, SL_MAX_VERSION),
-		SLE_CONDVAR(CargoPacket, source_id,       SLE_UINT16, SLV_125, SL_MAX_VERSION),
+		SLE_CONDVARNAME(CargoPacket, source.type, "source_type", SLE_UINT8, SLV_125, SL_MAX_VERSION),
+		SLE_CONDVARNAME(CargoPacket, source.id, "source_id", SLE_UINT16, SLV_125, SL_MAX_VERSION),
 		SLE_CONDVAR(CargoPacket, travelled.x, SLE_INT16, SLV_CARGO_TRAVELLED, SL_MAX_VERSION),
 		SLE_CONDVAR(CargoPacket, travelled.y, SLE_INT16, SLV_CARGO_TRAVELLED, SL_MAX_VERSION),
 	};

--- a/src/saveload/subsidy_sl.cpp
+++ b/src/saveload/subsidy_sl.cpp
@@ -21,12 +21,12 @@ static const SaveLoad _subsidies_desc[] = {
 	SLE_CONDVAR(Subsidy, remaining,  SLE_FILE_U8 | SLE_VAR_U16, SL_MIN_VERSION, SLV_CUSTOM_SUBSIDY_DURATION),
 	SLE_CONDVAR(Subsidy, remaining,  SLE_UINT16,                SLV_CUSTOM_SUBSIDY_DURATION, SL_MAX_VERSION),
 	SLE_CONDVAR(Subsidy, awarded,    SLE_UINT8,                                     SLV_125, SL_MAX_VERSION),
-	SLE_CONDVAR(Subsidy, src_type,   SLE_UINT8,                                     SLV_125, SL_MAX_VERSION),
-	SLE_CONDVAR(Subsidy, dst_type,   SLE_UINT8,                                     SLV_125, SL_MAX_VERSION),
-	SLE_CONDVAR(Subsidy, src,        SLE_FILE_U8 | SLE_VAR_U16,                       SL_MIN_VERSION, SLV_5),
-	SLE_CONDVAR(Subsidy, src,        SLE_UINT16,                                      SLV_5, SL_MAX_VERSION),
-	SLE_CONDVAR(Subsidy, dst,        SLE_FILE_U8 | SLE_VAR_U16,                       SL_MIN_VERSION, SLV_5),
-	SLE_CONDVAR(Subsidy, dst,        SLE_UINT16,                                      SLV_5, SL_MAX_VERSION),
+	SLE_CONDVARNAME(Subsidy, src.type, "src_type", SLE_UINT8,                       SLV_125, SL_MAX_VERSION),
+	SLE_CONDVARNAME(Subsidy, dst.type, "dst_type", SLE_UINT8,                       SLV_125, SL_MAX_VERSION),
+	SLE_CONDVARNAME(Subsidy, src.id, "src",  SLE_FILE_U8 | SLE_VAR_U16,             SL_MIN_VERSION, SLV_5),
+	SLE_CONDVARNAME(Subsidy, src.id, "src",  SLE_UINT16,                            SLV_5, SL_MAX_VERSION),
+	SLE_CONDVARNAME(Subsidy, dst.id, "dst",  SLE_FILE_U8 | SLE_VAR_U16,             SL_MIN_VERSION, SLV_5),
+	SLE_CONDVARNAME(Subsidy, dst.id, "dst",  SLE_UINT16,                            SLV_5, SL_MAX_VERSION),
 };
 
 struct SUBSChunkHandler : ChunkHandler {

--- a/src/script/api/script_subsidy.cpp
+++ b/src/script/api/script_subsidy.cpp
@@ -40,7 +40,10 @@
 	EnforcePrecondition(false, (from_type == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(from_id)) || (from_type == SPT_TOWN && ScriptTown::IsValidTown(from_id)));
 	EnforcePrecondition(false, (to_type == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(to_id)) || (to_type == SPT_TOWN && ScriptTown::IsValidTown(to_id)));
 
-	return ScriptObject::Command<CMD_CREATE_SUBSIDY>::Do(cargo_type, (::SourceType)from_type, from_id, (::SourceType)to_type, to_id);
+	Source from{static_cast<SourceID>(from_id), static_cast<SourceType>(from_type)};
+	Source to{static_cast<SourceID>(to_id), static_cast<SourceType>(to_type)};
+
+	return ScriptObject::Command<CMD_CREATE_SUBSIDY>::Do(cargo_type, from, to);
 }
 
 /* static */ ScriptCompany::CompanyID ScriptSubsidy::GetAwardedTo(SubsidyID subsidy_id)
@@ -74,26 +77,26 @@
 {
 	if (!IsValidSubsidy(subsidy_id)) return SPT_INVALID;
 
-	return (SubsidyParticipantType)(uint)::Subsidy::Get(subsidy_id)->src_type;
+	return static_cast<SubsidyParticipantType>(::Subsidy::Get(subsidy_id)->src.type);
 }
 
 /* static */ SQInteger ScriptSubsidy::GetSourceIndex(SubsidyID subsidy_id)
 {
 	if (!IsValidSubsidy(subsidy_id)) return INVALID_SOURCE;
 
-	return ::Subsidy::Get(subsidy_id)->src;
+	return ::Subsidy::Get(subsidy_id)->src.id;
 }
 
 /* static */ ScriptSubsidy::SubsidyParticipantType ScriptSubsidy::GetDestinationType(SubsidyID subsidy_id)
 {
 	if (!IsValidSubsidy(subsidy_id)) return SPT_INVALID;
 
-	return (SubsidyParticipantType)(uint)::Subsidy::Get(subsidy_id)->dst_type;
+	return static_cast<SubsidyParticipantType>(::Subsidy::Get(subsidy_id)->dst.type);
 }
 
 /* static */ SQInteger ScriptSubsidy::GetDestinationIndex(SubsidyID subsidy_id)
 {
 	if (!IsValidSubsidy(subsidy_id)) return INVALID_SOURCE;
 
-	return ::Subsidy::Get(subsidy_id)->dst;
+	return ::Subsidy::Get(subsidy_id)->dst.id;
 }

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4246,7 +4246,7 @@ void ModifyStationRatingAround(TileIndex tile, Owner owner, int amount, uint rad
 	});
 }
 
-static uint UpdateStationWaiting(Station *st, CargoType type, uint amount, SourceType source_type, SourceID source_id)
+static uint UpdateStationWaiting(Station *st, CargoType type, uint amount, Source source)
 {
 	/* We can't allocate a CargoPacket? Then don't do anything
 	 * at all; i.e. just discard the incoming cargo. */
@@ -4261,7 +4261,7 @@ static uint UpdateStationWaiting(Station *st, CargoType type, uint amount, Sourc
 	if (amount == 0) return 0;
 
 	StationID next = ge.GetVia(st->index);
-	ge.GetOrCreateData().cargo.Append(new CargoPacket(st->index, amount, source_type, source_id), next);
+	ge.GetOrCreateData().cargo.Append(new CargoPacket(st->index, amount, source), next);
 	LinkGraph *lg = nullptr;
 	if (ge.link_graph == INVALID_LINK_GRAPH) {
 		if (LinkGraph::CanAllocateItem()) {
@@ -4391,7 +4391,7 @@ static bool CanMoveGoodsToStation(const Station *st, CargoType type)
 	return true;
 }
 
-uint MoveGoodsToStation(CargoType type, uint amount, SourceType source_type, SourceID source_id, const StationList &all_stations, Owner exclusivity)
+uint MoveGoodsToStation(CargoType type, uint amount, Source source, const StationList &all_stations, Owner exclusivity)
 {
 	/* Return if nothing to do. Also the rounding below fails for 0. */
 	if (all_stations.empty()) return 0;
@@ -4424,7 +4424,7 @@ uint MoveGoodsToStation(CargoType type, uint amount, SourceType source_type, Sou
 	if (used_stations.empty()) {
 		/* only one station around */
 		amount *= first_station->goods[type].rating + 1;
-		return UpdateStationWaiting(first_station, type, amount, source_type, source_id);
+		return UpdateStationWaiting(first_station, type, amount, source);
 	}
 
 	uint company_best[OWNER_NONE + 1] = {};  // best rating for each company, including OWNER_NONE
@@ -4470,7 +4470,7 @@ uint MoveGoodsToStation(CargoType type, uint amount, SourceType source_type, Sou
 
 	uint moved = 0;
 	for (auto &p : used_stations) {
-		moved += UpdateStationWaiting(p.first, type, p.second, source_type, source_id);
+		moved += UpdateStationWaiting(p.first, type, p.second, source);
 	}
 
 	return moved;

--- a/src/subsidy_base.h
+++ b/src/subsidy_base.h
@@ -23,10 +23,8 @@ struct Subsidy : SubsidyPool::PoolItem<&_subsidy_pool> {
 	CargoType cargo_type;  ///< Cargo type involved in this subsidy, INVALID_CARGO for invalid subsidy
 	uint16_t remaining;    ///< Remaining months when this subsidy is valid
 	CompanyID awarded;   ///< Subsidy is awarded to this company; INVALID_COMPANY if it's not awarded to anyone
-	SourceType src_type; ///< Source of subsidised path (SourceType::Industry or SourceType::Town)
-	SourceType dst_type; ///< Destination of subsidised path (SourceType::Industry or SourceType::Town)
-	SourceID src;        ///< Index of source. Either TownID or IndustryID
-	SourceID dst;        ///< Index of destination. Either TownID or IndustryID
+	Source src; ///< Source of subsidised path
+	Source dst; ///< Destination of subsidised path
 
 	/**
 	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)

--- a/src/subsidy_cmd.h
+++ b/src/subsidy_cmd.h
@@ -12,9 +12,22 @@
 
 #include "command_type.h"
 #include "cargo_type.h"
+#include "misc/endian_buffer.hpp"
 
-CommandCost CmdCreateSubsidy(DoCommandFlag flags, CargoType cargo_type, SourceType src_type, SourceID src, SourceType dst_type, SourceID dst);
+CommandCost CmdCreateSubsidy(DoCommandFlag flags, CargoType cargo_type, Source src, Source dst);
 
 DEF_CMD_TRAIT(CMD_CREATE_SUBSIDY, CmdCreateSubsidy, CMD_DEITY, CMDT_OTHER_MANAGEMENT)
+
+
+template <typename Tcont, typename Titer>
+inline EndianBufferWriter<Tcont, Titer> &operator <<(EndianBufferWriter<Tcont, Titer> &buffer, const Source &source)
+{
+	return buffer << source.id << source.type;
+}
+
+inline EndianBufferReader &operator >>(EndianBufferReader &buffer, Source &source)
+{
+	return buffer >> source.id >> source.type;
+}
 
 #endif /* SUBSIDY_CMD_H */

--- a/src/subsidy_func.h
+++ b/src/subsidy_func.h
@@ -18,8 +18,8 @@
 #include "subsidy_base.h"
 
 std::pair<NewsReferenceType, NewsReferenceType> SetupSubsidyDecodeParam(const struct Subsidy *s, SubsidyDecodeParamType mode, uint parameter_offset = 0);
-void DeleteSubsidyWith(SourceType type, SourceID index);
-bool CheckSubsidised(CargoType cargo_type, CompanyID company, SourceType src_type, SourceID src, const Station *st);
+void DeleteSubsidyWith(Source src);
+bool CheckSubsidised(CargoType cargo_type, CompanyID company, Source src, const Station *st);
 void RebuildSubsidisedSourceAndDestinationCache();
 
 #endif /* SUBSIDY_FUNC_H */

--- a/src/subsidy_gui.cpp
+++ b/src/subsidy_gui.cpp
@@ -82,9 +82,9 @@ struct SubsidyListWindow : Window {
 	{
 		/* determine src coordinate for subsidy and try to scroll to it */
 		TileIndex xy;
-		switch (s->src_type) {
-			case SourceType::Industry: xy = Industry::Get(s->src)->location.tile; break;
-			case SourceType::Town:     xy =     Town::Get(s->src)->xy; break;
+		switch (s->src.type) {
+			case SourceType::Industry: xy = Industry::Get(s->src.id)->location.tile; break;
+			case SourceType::Town:     xy =     Town::Get(s->src.id)->xy; break;
 			default: NOT_REACHED();
 		}
 
@@ -92,9 +92,9 @@ struct SubsidyListWindow : Window {
 			if (_ctrl_pressed) ShowExtraViewportWindow(xy);
 
 			/* otherwise determine dst coordinate for subsidy and scroll to it */
-			switch (s->dst_type) {
-				case SourceType::Industry: xy = Industry::Get(s->dst)->location.tile; break;
-				case SourceType::Town:     xy =     Town::Get(s->dst)->xy; break;
+			switch (s->dst.type) {
+				case SourceType::Industry: xy = Industry::Get(s->dst.id)->location.tile; break;
+				case SourceType::Town:     xy =     Town::Get(s->dst.id)->xy; break;
 				default: NOT_REACHED();
 			}
 

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -153,9 +153,10 @@ Town::~Town()
 	}
 	this->psa_list.clear();
 
-	DeleteSubsidyWith(SourceType::Town, this->index);
+	Source src{this->index, SourceType::Town};
+	DeleteSubsidyWith(src);
 	DeleteNewGRFInspectWindow(GSF_FAKE_TOWNS, this->index);
-	CargoPacket::InvalidateAllFrom(SourceType::Town, this->index);
+	CargoPacket::InvalidateAllFrom(src);
 	MarkWholeScreenDirty();
 }
 
@@ -548,7 +549,7 @@ static void TownGenerateCargo(Town *t, CargoType ct, uint amount, StationFinder 
 
 	/* Actually generate cargo and update town statistics. */
 	t->supplied[ct].new_max += amount;
-	t->supplied[ct].new_act += MoveGoodsToStation(ct, amount, SourceType::Town, t->index, stations.GetStations());;
+	t->supplied[ct].new_act += MoveGoodsToStation(ct, amount, {t->index, SourceType::Town}, stations.GetStations());;
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Almost everywhere where `SourceID` is used/passed, also `SourceType` is passed/used. Why not put them in a struct and pass that around? Fewer parameters, fewer comparisons needed, and so on.


## Description

Make `Source` struct with `SourceID` and `SourceType`.
Replace pairs of `SourceID` and `SourceType` with `Source` where applicable.


## Limitations

Of course I thought about `default`-ing the empty constructor for `CargoPacket`. I even did do that, but that'll have the nasty side-effect of clearing the `index` of cargo packets upon saveload.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
