### PR TITLE
Codechange: use EnumBitSet/enum classes for network-crypto related enums

### DIFF
--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -851,7 +851,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_AUTH_RESPONSE(P
 	if (this->status != ADMIN_STATUS_AUTHENTICATE) return this->SendError(NETWORK_ERROR_NOT_EXPECTED);
 
 	switch (this->authentication_handler->ReceiveResponse(p)) {
-		case NetworkAuthenticationServerHandler::AUTHENTICATED:
+		case NetworkAuthenticationServerHandler::ResponseResult::Authenticated:
 			Debug(net, 3, "[admin] '{}' ({}) authenticated", this->admin_name, this->admin_version);
 
 			this->SendEnableEncryption();
@@ -861,11 +861,11 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_AUTH_RESPONSE(P
 			this->authentication_handler = nullptr;
 			return this->SendProtocol();
 
-		case NetworkAuthenticationServerHandler::RETRY_NEXT_METHOD:
+		case NetworkAuthenticationServerHandler::ResponseResult::RetryNextMethod:
 			Debug(net, 6, "[admin] '{}' ({}) authentication failed, trying next method", this->admin_name, this->admin_version);
 			return this->SendAuthRequest();
 
-		case NetworkAuthenticationServerHandler::NOT_AUTHENTICATED:
+		case NetworkAuthenticationServerHandler::ResponseResult::NotAuthenticated:
 		default:
 			Debug(net, 3, "[admin] '{}' ({}) authentication failed", this->admin_name, this->admin_version);
 			return this->SendError(NETWORK_ERROR_WRONG_PASSWORD);

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -802,10 +802,10 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_JOIN_SECURE(Pac
 
 	this->admin_name = p.Recv_string(NETWORK_CLIENT_NAME_LENGTH);
 	this->admin_version = p.Recv_string(NETWORK_REVISION_LENGTH);
-	NetworkAuthenticationMethodMask method_mask = p.Recv_uint16();
+	NetworkAuthenticationMethodMask method_mask{p.Recv_uint16()};
 
 	/* Always exclude key exchange only, as that provides no credential checking. */
-	ClrBit(method_mask, NETWORK_AUTH_METHOD_X25519_KEY_EXCHANGE_ONLY);
+	method_mask.Reset(NetworkAuthenticationMethod::X25519_KeyExchangeOnly);
 
 	if (this->admin_name.empty() || this->admin_version.empty()) {
 		/* No name or version supplied. */

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -694,13 +694,13 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_AUTH_REQUEST(Pa
 				_settings_client.network.client_secret_key, _settings_client.network.client_public_key);
 	}
 	switch (this->authentication_handler->ReceiveRequest(p)) {
-		case NetworkAuthenticationClientHandler::READY_FOR_RESPONSE:
+		case NetworkAuthenticationClientHandler::RequestResult::ReadyForResponse:
 			return SendAuthResponse();
 
-		case NetworkAuthenticationClientHandler::AWAIT_USER_INPUT:
+		case NetworkAuthenticationClientHandler::RequestResult::AwaitUserInput:
 			return NETWORK_RECV_STATUS_OKAY;
 
-		case NetworkAuthenticationClientHandler::INVALID:
+		case NetworkAuthenticationClientHandler::RequestResult::Invalid:
 		default:
 			return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 	}

--- a/src/network/network_crypto.h
+++ b/src/network/network_crypto.h
@@ -222,10 +222,10 @@ public:
 class NetworkAuthenticationClientHandler : public NetworkAuthenticationHandler {
 public:
 	/** The processing result of receiving a request. */
-	enum RequestResult : uint8_t {
-		AWAIT_USER_INPUT, ///< We have requested some user input, but must wait on that.
-		READY_FOR_RESPONSE, ///< We do not have to wait for user input, and can immediately respond to the server.
-		INVALID, ///< We have received an invalid request.
+	enum class RequestResult : uint8_t {
+		AwaitUserInput, ///< We have requested some user input, but must wait on that.
+		ReadyForResponse, ///< We do not have to wait for user input, and can immediately respond to the server.
+		Invalid, ///< We have received an invalid request.
 	};
 
 	/**
@@ -258,10 +258,10 @@ public:
 class NetworkAuthenticationServerHandler : public NetworkAuthenticationHandler {
 public:
 	/** The processing result of receiving a response. */
-	enum ResponseResult : uint8_t {
-		AUTHENTICATED, ///< The client was authenticated successfully.
-		NOT_AUTHENTICATED, ///< All authentications for this handler have been exhausted.
-		RETRY_NEXT_METHOD, ///< The client failed to authenticate, but there is another method to try.
+	enum class ResponseResult : uint8_t {
+		Authenticated, ///< The client was authenticated successfully.
+		NotAuthenticated, ///< All authentications for this handler have been exhausted.
+		RetryNextMethod, ///< The client failed to authenticate, but there is another method to try.
 	};
 
 	/**

--- a/src/network/network_crypto.h
+++ b/src/network/network_crypto.h
@@ -174,15 +174,15 @@ public:
 
 
 /** The authentication method that can be used. */
-enum NetworkAuthenticationMethod : uint8_t {
-	NETWORK_AUTH_METHOD_X25519_KEY_EXCHANGE_ONLY, ///< No actual authentication is taking place, just perform a x25519 key exchange. This method is not supported for the admin connection.
-	NETWORK_AUTH_METHOD_X25519_PAKE, ///< Authentication using x25519 password-authenticated key agreement.
-	NETWORK_AUTH_METHOD_X25519_AUTHORIZED_KEY, ///< Authentication using x22519 key exchange and authorized keys.
-	NETWORK_AUTH_METHOD_END, ///< Must ALWAYS be on the end of this list!! (period)
+enum class NetworkAuthenticationMethod : uint8_t {
+	X25519_KeyExchangeOnly, ///< No actual authentication is taking place, just perform a x25519 key exchange. This method is not supported for the admin connection.
+	X25519_PAKE, ///< Authentication using x25519 password-authenticated key agreement.
+	X25519_AuthorizedKey, ///< Authentication using x22519 key exchange and authorized keys.
+	End, ///< Must ALWAYS be on the end of this list!! (period)
 };
 
 /** The mask of authentication methods that can be used. */
-using NetworkAuthenticationMethodMask = uint16_t;
+using NetworkAuthenticationMethodMask = EnumBitSet<NetworkAuthenticationMethod, uint16_t>;
 
 /**
  * Base class for cryptographic authentication handlers.
@@ -296,7 +296,7 @@ public:
 	 */
 	virtual std::string GetPeerPublicKey() const = 0;
 
-	static std::unique_ptr<NetworkAuthenticationServerHandler> Create(const NetworkAuthenticationPasswordProvider *password_provider, const NetworkAuthenticationAuthorizedKeyHandler *authorized_key_handler, NetworkAuthenticationMethodMask client_supported_method_mask = ~static_cast<NetworkAuthenticationMethodMask>(0));
+	static std::unique_ptr<NetworkAuthenticationServerHandler> Create(const NetworkAuthenticationPasswordProvider *password_provider, const NetworkAuthenticationAuthorizedKeyHandler *authorized_key_handler, NetworkAuthenticationMethodMask client_supported_method_mask = {NetworkAuthenticationMethod::X25519_KeyExchangeOnly, NetworkAuthenticationMethod::X25519_PAKE, NetworkAuthenticationMethod::X25519_AuthorizedKey});
 };
 
 #endif /* NETWORK_CRYPTO_H */

--- a/src/network/network_crypto_internal.h
+++ b/src/network/network_crypto_internal.h
@@ -140,7 +140,7 @@ public:
 	 */
 	X25519KeyExchangeOnlyClientHandler(const X25519SecretKey &secret_key) : X25519AuthenticationHandler(secret_key) {}
 
-	virtual RequestResult ReceiveRequest(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveRequest(p) ? READY_FOR_RESPONSE : INVALID; }
+	virtual RequestResult ReceiveRequest(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveRequest(p) ? RequestResult::ReadyForResponse : RequestResult::Invalid; }
 	virtual bool SendResponse(struct Packet &p) override { return this->X25519AuthenticationHandler::SendResponse(p, {}); }
 
 	virtual std::string_view GetName() const override { return "X25519-KeyExchangeOnly-client"; }
@@ -249,7 +249,7 @@ public:
 	 */
 	X25519AuthorizedKeyClientHandler(const X25519SecretKey &secret_key) : X25519AuthenticationHandler(secret_key) {}
 
-	virtual RequestResult ReceiveRequest(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveRequest(p) ? READY_FOR_RESPONSE : INVALID; }
+	virtual RequestResult ReceiveRequest(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveRequest(p) ? RequestResult::ReadyForResponse : RequestResult::Invalid; }
 	virtual bool SendResponse(struct Packet &p) override { return this->X25519AuthenticationHandler::SendResponse(p, {}); }
 
 	virtual std::string_view GetName() const override { return "X25519-AuthorizedKey-client"; }

--- a/src/network/network_crypto_internal.h
+++ b/src/network/network_crypto_internal.h
@@ -144,7 +144,7 @@ public:
 	virtual bool SendResponse(struct Packet &p) override { return this->X25519AuthenticationHandler::SendResponse(p, {}); }
 
 	virtual std::string_view GetName() const override { return "X25519-KeyExchangeOnly-client"; }
-	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NETWORK_AUTH_METHOD_X25519_KEY_EXCHANGE_ONLY; }
+	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NetworkAuthenticationMethod::X25519_KeyExchangeOnly; }
 
 	virtual bool ReceiveEnableEncryption(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveEnableEncryption(p); }
 	virtual std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateClientToServerEncryptionHandler(); }
@@ -168,7 +168,7 @@ public:
 	virtual ResponseResult ReceiveResponse(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveResponse(p, {}); }
 
 	virtual std::string_view GetName() const override { return "X25519-KeyExchangeOnly-server"; }
-	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NETWORK_AUTH_METHOD_X25519_KEY_EXCHANGE_ONLY; }
+	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NetworkAuthenticationMethod::X25519_KeyExchangeOnly; }
 	virtual bool CanBeUsed() const override { return true; }
 
 	virtual std::string GetPeerPublicKey() const override { return this->X25519AuthenticationHandler::GetPeerPublicKey(); }
@@ -198,7 +198,7 @@ public:
 	virtual bool SendResponse(struct Packet &p) override { return this->X25519AuthenticationHandler::SendResponse(p, this->handler->password); }
 
 	virtual std::string_view GetName() const override { return "X25519-PAKE-client"; }
-	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NETWORK_AUTH_METHOD_X25519_PAKE; }
+	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NetworkAuthenticationMethod::X25519_PAKE; }
 
 	virtual bool ReceiveEnableEncryption(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveEnableEncryption(p); }
 	virtual std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateClientToServerEncryptionHandler(); }
@@ -225,7 +225,7 @@ public:
 	virtual ResponseResult ReceiveResponse(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveResponse(p, this->password_provider->GetPassword()); }
 
 	virtual std::string_view GetName() const override { return "X25519-PAKE-server"; }
-	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NETWORK_AUTH_METHOD_X25519_PAKE; }
+	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NetworkAuthenticationMethod::X25519_PAKE; }
 	virtual bool CanBeUsed() const override { return !this->password_provider->GetPassword().empty(); }
 
 	virtual std::string GetPeerPublicKey() const override { return this->X25519AuthenticationHandler::GetPeerPublicKey(); }
@@ -253,7 +253,7 @@ public:
 	virtual bool SendResponse(struct Packet &p) override { return this->X25519AuthenticationHandler::SendResponse(p, {}); }
 
 	virtual std::string_view GetName() const override { return "X25519-AuthorizedKey-client"; }
-	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NETWORK_AUTH_METHOD_X25519_AUTHORIZED_KEY; }
+	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NetworkAuthenticationMethod::X25519_AuthorizedKey; }
 
 	virtual bool ReceiveEnableEncryption(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveEnableEncryption(p); }
 	virtual std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateClientToServerEncryptionHandler(); }
@@ -283,7 +283,7 @@ public:
 	virtual ResponseResult ReceiveResponse(struct Packet &p) override;
 
 	virtual std::string_view GetName() const override { return "X25519-AuthorizedKey-server"; }
-	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NETWORK_AUTH_METHOD_X25519_AUTHORIZED_KEY; }
+	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NetworkAuthenticationMethod::X25519_AuthorizedKey; }
 	virtual bool CanBeUsed() const override { return this->authorized_key_handler->CanBeUsed(); }
 
 	virtual std::string GetPeerPublicKey() const override { return this->X25519AuthenticationHandler::GetPeerPublicKey(); }

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -932,9 +932,9 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_IDENTIFY(Packet
 static NetworkErrorCode GetErrorForAuthenticationMethod(NetworkAuthenticationMethod method)
 {
 	switch (method) {
-		case NETWORK_AUTH_METHOD_X25519_PAKE:
+		case NetworkAuthenticationMethod::X25519_PAKE:
 			return NETWORK_ERROR_WRONG_PASSWORD;
-		case NETWORK_AUTH_METHOD_X25519_AUTHORIZED_KEY:
+		case NetworkAuthenticationMethod::X25519_AuthorizedKey:
 			return NETWORK_ERROR_NOT_ON_ALLOW_LIST;
 
 		default:

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -952,13 +952,13 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_AUTH_RESPONSE(P
 
 	auto authentication_method = this->authentication_handler->GetAuthenticationMethod();
 	switch (this->authentication_handler->ReceiveResponse(p)) {
-		case NetworkAuthenticationServerHandler::AUTHENTICATED:
+		case NetworkAuthenticationServerHandler::ResponseResult::Authenticated:
 			break;
 
-		case NetworkAuthenticationServerHandler::RETRY_NEXT_METHOD:
+		case NetworkAuthenticationServerHandler::ResponseResult::RetryNextMethod:
 			return this->SendAuthRequest();
 
-		case NetworkAuthenticationServerHandler::NOT_AUTHENTICATED:
+		case NetworkAuthenticationServerHandler::ResponseResult::NotAuthenticated:
 		default:
 			return this->SendError(GetErrorForAuthenticationMethod(authentication_method));
 	}


### PR DESCRIPTION
## Motivation / Problem

Yet still more `EnumBitSet` and `enum class`...


## Description

Use `EnumBitSet` for `NetworkAuthenticationMethodMask`.
Make `NetworkAuthenticationMethod`, `NetworkAuthenticationClientHandler::RequestResult` and `NetworkAuthenticationServerHandler::ResponseResult` `enum class`.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
