### PR TITLE
Add: [Script] GetEconomyAge and GetWagonEconomyAge

### DIFF
--- a/regression/regression/main.nut
+++ b/regression/regression/main.nut
@@ -2056,6 +2056,7 @@ function Regression::Vehicle()
 	print("    GetEngineType():     " + AIVehicle.GetEngineType(12));
 	print("    GetUnitNumber():     " + AIVehicle.GetUnitNumber(12));
 	print("    GetAge():            " + AIVehicle.GetAge(12));
+	print("    GetEconomyAge():     " + AIVehicle.GetEconomyAge(12));
 	print("    GetMaxAge():         " + AIVehicle.GetMaxAge(12));
 	print("    GetAgeLeft():        " + AIVehicle.GetAgeLeft(12));
 	print("    GetCurrentSpeed():   " + AIVehicle.GetCurrentSpeed(12));
@@ -2071,6 +2072,7 @@ function Regression::Vehicle()
 	print("    GetNumWagons():      " + AIVehicle.GetNumWagons(12));
 	print("    GetWagonEngineType(): " + AIVehicle.GetWagonEngineType(12, 0));
 	print("    GetWagonAge():       " + AIVehicle.GetWagonAge(12, 0));
+	print("    GetWagonEconomyAge(): " + AIVehicle.GetWagonEconomyAge(12, 0));
 	print("    GetLength():         " + AIVehicle.GetLength(12));
 
 	print("  GetOwner():           " + AITile.GetOwner(32119));
@@ -2099,12 +2101,16 @@ function Regression::Vehicle()
 	print("  GetLength():          " + AIVehicle.GetLength(17));
 	print("  GetWagonEngineType(): " + AIVehicle.GetWagonEngineType(17, 0));
 	print("  GetWagonAge():        " + AIVehicle.GetWagonAge(17, 0));
+	print("  GetWagonEconomyAge(): " + AIVehicle.GetWagonEconomyAge(17, 0));
 	print("  GetWagonEngineType(): " + AIVehicle.GetWagonEngineType(17, 1));
 	print("  GetWagonAge():        " + AIVehicle.GetWagonAge(17, 1));
-	print("  GetWagonEngineType(): " + AIVehicle.GetWagonEngineType(17 2));
+	print("  GetWagonEconomyAge(): " + AIVehicle.GetWagonEconomyAge(17, 1));
+	print("  GetWagonEngineType(): " + AIVehicle.GetWagonEngineType(17, 2));
 	print("  GetWagonAge():        " + AIVehicle.GetWagonAge(17, 2));
-	print("  GetWagonEngineType(): " + AIVehicle.GetWagonEngineType(17 3));
+	print("  GetWagonEconomyAge(): " + AIVehicle.GetWagonEconomyAge(17, 2));
+	print("  GetWagonEngineType(): " + AIVehicle.GetWagonEngineType(17, 3));
 	print("  GetWagonAge():        " + AIVehicle.GetWagonAge(17, 3));
+	print("  GetWagonEconomyAge(): " + AIVehicle.GetWagonEconomyAge(17, 3));
 
 	print("  --Refit--");
 	print("    GetBuildWithRefitCapacity(): " + AIVehicle.GetBuildWithRefitCapacity(28479, 211, 255));
@@ -2156,6 +2162,11 @@ function Regression::Vehicle()
 	}
 	list.Valuate(AIVehicle.GetAge);
 	print("  Age ListDump:");
+	for (local i = list.Begin(); !list.IsEnd(); i = list.Next()) {
+		print("    " + i + " => " + list.GetValue(i));
+	}
+	list.Valuate(AIVehicle.GetEconomyAge);
+	print("  EconomyAge ListDump:");
 	for (local i = list.Begin(); !list.IsEnd(); i = list.Next()) {
 		print("    " + i + " => " + list.GetValue(i));
 	}

--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -10539,6 +10539,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetEngineType():     153
     GetUnitNumber():     1
     GetAge():            0
+    GetEconomyAge():     0
     GetMaxAge():         5490
     GetAgeLeft():        5490
     GetCurrentSpeed():   7
@@ -10554,6 +10555,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetNumWagons():      1
     GetWagonEngineType(): 153
     GetWagonAge():       0
+    GetWagonEconomyAge(): 0
     GetLength():         8
   GetOwner():           1
   BuildVehicle():       14
@@ -10579,12 +10581,16 @@ ERROR: IsEnd() is invalid as Begin() is never called
   GetLength():          24
   GetWagonEngineType(): 9
   GetWagonAge():        0
+  GetWagonEconomyAge(): 0
   GetWagonEngineType(): 27
   GetWagonAge():        0
+  GetWagonEconomyAge(): 0
   GetWagonEngineType(): 27
   GetWagonAge():        0
+  GetWagonEconomyAge(): 0
   GetWagonEngineType(): 65535
   GetWagonAge():        -1
+  GetWagonEconomyAge(): -1
   --Refit--
     GetBuildWithRefitCapacity(): -1
     GetBuildWithRefitCapacity(): 0
@@ -10628,6 +10634,12 @@ ERROR: IsEnd() is invalid as Begin() is never called
     14 => 1
     12 => 1
   Age ListDump:
+    17 => 0
+    16 => 0
+    14 => 0
+    13 => 0
+    12 => 0
+  EconomyAge ListDump:
     17 => 0
     16 => 0
     14 => 0
@@ -10880,7 +10892,7 @@ CALLSTACK WITH LOCALS
 *FUNCTION [Valuate()] Valuate line [5]
   [args] ARRAY
   [this] INSTANCE
-*FUNCTION [Start()] regression/main.nut line [2412]
+*FUNCTION [Start()] regression/main.nut line [2423]
   [Infinite] CLOSURE
   [list] INSTANCE
   [this] INSTANCE

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -19,6 +19,10 @@
  *
  * This version is not yet released. The following changes are not set in stone yet.
  *
+ * API additions:
+ * \li AIVehicle::GetEconomyAge
+ * \li AIVehicle::GetWagonEconomyAge
+ *
  * \b 15.0
  *
  * API additions:

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -19,6 +19,10 @@
  *
  * This version is not yet released. The following changes are not set in stone yet.
  *
+ * API additions:
+ * \li GSVehicle::GetEconomyAge
+ * \li GSVehicle::GetWagonEconomyAge
+ *
  * \b 15.0
  *
  * API additions:

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -314,6 +314,13 @@
 	return ::Vehicle::Get(vehicle_id)->age.base();
 }
 
+/* static */ SQInteger ScriptVehicle::GetEconomyAge(VehicleID vehicle_id)
+{
+	if (!IsValidVehicle(vehicle_id)) return -1;
+
+	return ::Vehicle::Get(vehicle_id)->economy_age.base();
+}
+
 /* static */ SQInteger ScriptVehicle::GetWagonAge(VehicleID vehicle_id, SQInteger wagon)
 {
 	if (!IsValidVehicle(vehicle_id)) return -1;
@@ -324,6 +331,18 @@
 		while (wagon-- > 0) v = ::Train::From(v)->GetNextUnit();
 	}
 	return v->age.base();
+}
+
+/* static */ SQInteger ScriptVehicle::GetWagonEconomyAge(VehicleID vehicle_id, SQInteger wagon)
+{
+	if (!IsValidVehicle(vehicle_id)) return -1;
+	if (wagon >= GetNumWagons(vehicle_id)) return -1;
+
+	const Vehicle *v = ::Vehicle::Get(vehicle_id);
+	if (v->type == VEH_TRAIN) {
+		while (wagon-- > 0) v = ::Train::From(v)->GetNextUnit();
+	}
+	return v->economy_age.base();
 }
 
 /* static */ SQInteger ScriptVehicle::GetMaxAge(VehicleID vehicle_id)

--- a/src/script/api/script_vehicle.hpp
+++ b/src/script/api/script_vehicle.hpp
@@ -196,6 +196,15 @@ public:
 	static SQInteger GetAge(VehicleID vehicle_id);
 
 	/**
+	 * Get the current economy age of a vehicle.
+	 * @param vehicle_id The vehicle to get the economy age of.
+	 * @pre IsValidVehicle(vehicle_id).
+	 * @return The current economy age of the vehicle in economy-days.
+	 * @see \ref ScriptEconomyTime
+	 */
+	static SQInteger GetEconomyAge(VehicleID vehicle_id);
+
+	/**
 	 * Get the current age of a second (or third, etc.) engine in a train vehicle.
 	 * @param vehicle_id The vehicle to get the age of.
 	 * @param wagon The wagon in the vehicle to get the age of.
@@ -205,6 +214,17 @@ public:
 	 * @see \ref ScriptCalendarTime
 	 */
 	static SQInteger GetWagonAge(VehicleID vehicle_id, SQInteger wagon);
+
+	/**
+	 * Get the current economy age of a second (or third, etc.) engine in a train vehicle.
+	 * @param vehicle_id The vehicle to get the economy age of.
+	 * @param wagon The wagon in the vehicle to get the economy age of.
+	 * @pre IsValidVehicle(vehicle_id).
+	 * @pre wagon < GetNumWagons(vehicle_id).
+	 * @return The current economy age of the vehicle in economy-days.
+	 * @see \ref ScriptEconomyTime
+	 */
+	static SQInteger GetWagonEconomyAge(VehicleID vehicle_id, SQInteger wagon);
 
 	/**
 	 * Get the maximum age of a vehicle.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
In wallclock mode, `ScriptVehicle::GetAge` retrieves the age of a vehicle, but it is calendar time based, when I'm more interested in the time the vehicle has been out there to determine its profitability. In frozen time mode it's even worse, as this function simply return 0.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Add `ScriptVehicle::GetEconomyAge` and `ScriptVehicle::GetWagonEconomyAge` to retrieve the economy age of a vehicle, as this is the time mode that matters most for AIs in my opinion.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
None I can think of.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
