### PR TITLE
Codechange: Add GetString() method that accepts parameters directly instead of via SetDParam().

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -25,7 +25,7 @@
 #include "newgrf_industrytiles.h"
 #include "autoslope.h"
 #include "water.h"
-#include "strings_internal.h"
+#include "strings_func.h"
 #include "window_func.h"
 #include "vehicle_func.h"
 #include "sound_func.h"

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -28,7 +28,7 @@
 #include "road_internal.h" /* For drawing catenary/checking road removal */
 #include "autoslope.h"
 #include "water.h"
-#include "strings_internal.h"
+#include "strings_func.h"
 #include "clear_func.h"
 #include "timer/timer_game_calendar.h"
 #include "vehicle_func.h"

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -123,6 +123,19 @@ auto MakeParameters(Args &&... args)
 }
 
 /**
+ * Get a parsed string with most special stringcodes replaced by the string parameters.
+ * @param string String ID to format.
+ * @param args The parameters to set.
+ * @return The parsed string.
+ */
+template <typename... Args>
+std::string GetString(StringID string, Args &&... args)
+{
+	auto params = MakeParameters(std::forward<Args &&>(args)...);
+	return GetStringWithArgs(string, params);
+}
+
+/**
  * A searcher for missing glyphs.
  */
 class MissingGlyphSearcher {

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -59,6 +59,7 @@ inline StringID MakeStringID(StringTab tab, StringIndexInTab index)
 	return (tab << TAB_SIZE_BITS) + index.base();
 }
 
+std::string GetStringWithArgs(StringID string, std::span<StringParameter> args);
 std::string GetString(StringID string);
 const char *GetStringPtr(StringID string);
 void AppendStringInPlace(std::string &result, StringID string);
@@ -108,6 +109,18 @@ extern TextDirection _current_text_dir; ///< Text direction of the currently sel
 void InitializeLanguagePacks();
 const char *GetCurrentLanguageIsoCode();
 std::string_view GetListSeparator();
+
+/**
+ * Helper to create the StringParameters with its own buffer with the given
+ * parameter values.
+ * @param args The parameters to set for the to be created StringParameters.
+ * @return The constructed StringParameters.
+ */
+template <typename... Args>
+auto MakeParameters(Args &&... args)
+{
+	return std::array<StringParameter, sizeof...(args)>({std::forward<StringParameter>(args)...});
+}
 
 /**
  * A searcher for missing glyphs.

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -13,12 +13,6 @@
 #include "strings_func.h"
 #include "string_func.h"
 
-/** The data required to format and validate a single parameter of a string. */
-struct StringParameter {
-	StringParameterData data; ///< The data of the parameter.
-	char32_t type; ///< The #StringControlCode to interpret this data with when it's the first parameter, otherwise '\0'.
-};
-
 class StringParameters {
 protected:
 	StringParameters *parent = nullptr; ///< If not nullptr, this instance references data from this parent instance.
@@ -26,10 +20,6 @@ protected:
 
 	size_t offset = 0; ///< Current offset in the parameters span.
 	char32_t next_type = 0; ///< The type of the next data that is retrieved.
-
-	StringParameters(std::span<StringParameter> parameters = {}) :
-		parameters(parameters)
-	{}
 
 	const StringParameter &GetNextParameterReference();
 
@@ -42,6 +32,8 @@ public:
 		parent(&parent),
 		parameters(parent.parameters.subspan(parent.offset, size))
 	{}
+
+	StringParameters(std::span<StringParameter> parameters = {}) : parameters(parameters) {}
 
 	void PrepareForNextRun();
 	void SetTypeOfNextParameter(char32_t type) { this->next_type = type; }
@@ -226,21 +218,6 @@ public:
 };
 
 /**
- * Helper to create the StringParameters with its own buffer with the given
- * parameter values.
- * @param args The parameters to set for the to be created StringParameters.
- * @return The constructed StringParameters.
- */
-template <typename... Args>
-static auto MakeParameters(const Args&... args)
-{
-	ArrayStringParameters<sizeof...(args)> parameters;
-	size_t index = 0;
-	(parameters.SetParam(index++, std::forward<const Args&>(args)), ...);
-	return parameters;
-}
-
-/**
  * Equivalent to the std::back_insert_iterator in function, with some
  * convenience helpers for string concatenation.
  */
@@ -339,6 +316,7 @@ public:
 };
 
 void GetStringWithArgs(StringBuilder &builder, StringID string, StringParameters &args, uint case_index = 0, bool game_script = false);
+void GetStringWithArgs(StringBuilder &builder, StringID string, std::span<StringParameter> params, uint case_index = 0, bool game_script = false);
 std::string GetStringWithArgs(StringID string, StringParameters &args);
 
 /* Do not leak the StringBuilder to everywhere. */

--- a/src/strings_type.h
+++ b/src/strings_type.h
@@ -10,6 +10,7 @@
 #ifndef STRINGS_TYPE_H
 #define STRINGS_TYPE_H
 
+#include "core/convertible_through_base.hpp"
 #include "core/strong_typedef_type.hpp"
 
 /**
@@ -72,5 +73,22 @@ static constexpr StringID SPECSTR_ANDCO_NAME = 0x70E6; ///< Special string for S
 static constexpr StringID SPECSTR_PRESIDENT_NAME = 0x70E7; ///< Special string for the president's name.
 
 using StringParameterData = std::variant<uint64_t, std::string>;
+
+/** The data required to format and validate a single parameter of a string. */
+struct StringParameter {
+	StringParameterData data; ///< The data of the parameter.
+	char32_t type; ///< The #StringControlCode to interpret this data with when it's the first parameter, otherwise '\0'.
+
+	StringParameter() = default;
+	inline StringParameter(StringParameterData &&data) : data(std::move(data)), type(0) {}
+
+	inline StringParameter(uint64_t data) : data(data), type(0) {}
+
+	inline StringParameter(const char *data) : data(std::string{data}), type(0) {}
+	inline StringParameter(std::string &&data) : data(std::move(data)), type(0) {}
+	inline StringParameter(const std::string &data) : data(data), type(0) {}
+
+	inline StringParameter(const ConvertibleThroughBase auto &data) : data(static_cast<uint64_t>(data.base())), type(0) {}
+};
 
 #endif /* STRINGS_TYPE_H */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

An effort to remove global string parameters.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This PR introduces variadic `GetString()` which takes a `StringID` and a variable number of string parameters.

These parameters are turned into a local `StringParameter` container, bypassing the global parameters and the `SetDParam` system.

The big advantage of this is that only the provided parameters can be consume by the string, accidentally using stale parameters is no longer possible.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This PR doesn't actually use the feature yet, it's just prep in breaking up the larger draft that does everything into manageable chunks.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
