### PR TITLE
Codechange: Pass preformatted string when updating sign positions.

### DIFF
--- a/src/signs.cpp
+++ b/src/signs.cpp
@@ -49,8 +49,7 @@ void Sign::UpdateVirtCoord()
 
 	if (this->sign.kdtree_valid) _viewport_sign_kdtree.Remove(ViewportSignKdtreeItem::MakeSign(this->index));
 
-	SetDParam(0, this->index);
-	this->sign.UpdatePosition(pt.x, pt.y - 6 * ZOOM_BASE, STR_WHITE_SIGN);
+	this->sign.UpdatePosition(pt.x, pt.y - 6 * ZOOM_BASE, GetString(STR_WHITE_SIGN, this->index));
 
 	_viewport_sign_kdtree.Insert(ViewportSignKdtreeItem::MakeSign(this->index));
 }

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -448,9 +448,7 @@ void Station::UpdateVirtCoord()
 
 	if (this->sign.kdtree_valid) _viewport_sign_kdtree.Remove(ViewportSignKdtreeItem::MakeStation(this->index));
 
-	SetDParam(0, this->index);
-	SetDParam(1, this->facilities);
-	this->sign.UpdatePosition(pt.x, pt.y, STR_VIEWPORT_STATION, STR_STATION_NAME);
+	this->sign.UpdatePosition(pt.x, pt.y, GetString(STR_VIEWPORT_STATION, this->index, this->facilities), GetString(STR_STATION_NAME, this->index, this->facilities));
 
 	_viewport_sign_kdtree.Insert(ViewportSignKdtreeItem::MakeStation(this->index));
 

--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -59,7 +59,7 @@ TextEffectID AddTextEffect(StringID msg, int center, int y, uint8_t duration, Te
 
 	/* Make sure we only dirty the new area */
 	te.width_normal = 0;
-	te.UpdatePosition(center, y, msg);
+	te.UpdatePosition(center, y, GetString(te.string_id));
 
 	return static_cast<TextEffectID>(it - std::begin(_text_effects));
 }
@@ -72,7 +72,7 @@ void UpdateTextEffect(TextEffectID te_id, StringID msg)
 	te.string_id = msg;
 	CopyOutDParam(te.params, 2);
 
-	te.UpdatePosition(te.center, te.top, te.string_id);
+	te.UpdatePosition(te.center, te.top, GetString(te.string_id));
 }
 
 void UpdateAllTextEffectVirtCoords()
@@ -80,7 +80,7 @@ void UpdateAllTextEffectVirtCoords()
 	for (auto &te : _text_effects) {
 		if (te.string_id == INVALID_STRING_ID) continue;
 		CopyInDParam(te.params);
-		te.UpdatePosition(te.center, te.top, te.string_id);
+		te.UpdatePosition(te.center, te.top, GetString(te.string_id));
 	}
 }
 

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -412,11 +412,10 @@ void Town::UpdateVirtCoord()
 
 	if (this->cache.sign.kdtree_valid) _viewport_sign_kdtree.Remove(ViewportSignKdtreeItem::MakeTown(this->index));
 
-	SetDParam(0, this->index);
-	SetDParam(1, this->cache.population);
+	std::string town_string = GetString(STR_TOWN_NAME, this->index);
 	this->cache.sign.UpdatePosition(pt.x, pt.y - 24 * ZOOM_BASE,
-		_settings_client.gui.population_in_label ? STR_VIEWPORT_TOWN_POP : STR_TOWN_NAME,
-		STR_TOWN_NAME);
+		_settings_client.gui.population_in_label ? GetString(STR_VIEWPORT_TOWN_POP, this->index, this->cache.population) : town_string,
+		town_string);
 
 	_viewport_sign_kdtree.Insert(ViewportSignKdtreeItem::MakeTown(this->index));
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1515,23 +1515,20 @@ static void ViewportAddKdtreeSigns(DrawPixelInfo *dpi)
  * @param center the (preferred) center of the viewport sign
  * @param top    the new top of the sign
  * @param str    the string to show in the sign
- * @param str_small the string to show when zoomed out. STR_NULL means same as \a str
+ * @param str_small the string to show when zoomed out. If the string is emtpy then the \a str is used.
  */
-void ViewportSign::UpdatePosition(int center, int top, StringID str, StringID str_small)
+void ViewportSign::UpdatePosition(int center, int top, std::string_view str, std::string_view str_small)
 {
 	if (this->width_normal != 0) this->MarkDirty();
 
 	this->top = top;
 
-	std::string name = GetString(str);
-	this->width_normal = WidgetDimensions::scaled.fullbevel.left + Align(GetStringBoundingBox(name).width, 2) + WidgetDimensions::scaled.fullbevel.right;
+	this->width_normal = WidgetDimensions::scaled.fullbevel.left + Align(GetStringBoundingBox(str).width, 2) + WidgetDimensions::scaled.fullbevel.right;
 	this->center = center;
 
 	/* zoomed out version */
-	if (str_small != STR_NULL) {
-		name = GetString(str_small);
-	}
-	this->width_small = WidgetDimensions::scaled.fullbevel.left + Align(GetStringBoundingBox(name, FS_SMALL).width, 2) + WidgetDimensions::scaled.fullbevel.right;
+	if (str_small.empty()) str_small = str;
+	this->width_small = WidgetDimensions::scaled.fullbevel.left + Align(GetStringBoundingBox(str_small, FS_SMALL).width, 2) + WidgetDimensions::scaled.fullbevel.right;
 
 	this->MarkDirty();
 }

--- a/src/viewport_type.h
+++ b/src/viewport_type.h
@@ -54,7 +54,7 @@ struct ViewportSign {
 
 	auto operator<=>(const ViewportSign &) const = default;
 
-	void UpdatePosition(int center, int top, StringID str, StringID str_small = STR_NULL);
+	void UpdatePosition(int center, int top, std::string_view str, std::string_view str_small = {});
 	void MarkDirty(ZoomLevel maxzoom = ZOOM_LVL_MAX) const;
 };
 
@@ -68,7 +68,7 @@ struct TrackedViewportSign : ViewportSign {
 	 * Update the position of the viewport sign.
 	 * Note that this function hides the base class function.
 	 */
-	void UpdatePosition(int center, int top, StringID str, StringID str_small = STR_NULL)
+	void UpdatePosition(int center, int top, std::string_view str, std::string_view str_small = {})
 	{
 		this->kdtree_valid = true;
 		this->ViewportSign::UpdatePosition(center, top, str, str_small);

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -44,8 +44,7 @@ void Waypoint::UpdateVirtCoord()
 	Point pt = RemapCoords2(TileX(this->xy) * TILE_SIZE, TileY(this->xy) * TILE_SIZE);
 	if (this->sign.kdtree_valid) _viewport_sign_kdtree.Remove(ViewportSignKdtreeItem::MakeWaypoint(this->index));
 
-	SetDParam(0, this->index);
-	this->sign.UpdatePosition(pt.x, pt.y - 32 * ZOOM_BASE, STR_WAYPOINT_NAME);
+	this->sign.UpdatePosition(pt.x, pt.y - 32 * ZOOM_BASE, GetString(STR_WAYPOINT_NAME, this->index));
 
 	_viewport_sign_kdtree.Insert(ViewportSignKdtreeItem::MakeWaypoint(this->index));
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Part of removing global string parameters.

When updating viewport sign positions, global parameters are filled, and then a StringID is passed around, which is later formatted.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, preformat the string, with the new parameterised GetString(), and pass this as a std::string_view when updating viewport sign positions.

This ensures the correct parameters are used for the sign text, and keeps parameters and string formatting coupled together.

Requires #13479 

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
