### PR TITLE
Codechange: use IndustryID instead of int

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -57,7 +57,7 @@
 IndustryPool _industry_pool("Industry");
 INSTANTIATE_POOL_METHODS(Industry)
 
-void ShowIndustryViewWindow(int industry);
+void ShowIndustryViewWindow(IndustryID industry);
 void BuildOilRig(TileIndex tile);
 
 static uint8_t _industry_sound_ctr;

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1243,7 +1243,7 @@ static WindowDesc _industry_view_desc(
 	_nested_industry_view_widgets
 );
 
-void ShowIndustryViewWindow(int industry)
+void ShowIndustryViewWindow(IndustryID industry)
 {
 	AllocateWindowDescFront<IndustryViewWindow>(_industry_view_desc, industry);
 }


### PR DESCRIPTION
## Motivation / Problem

An `IndustryID` is passed, so use `IndustryID` as type.


## Description

Use `IndustryID` instead.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
