### PR TITLE
Codechange: Use local parameters for formatting settings values.

### DIFF
--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -344,7 +344,7 @@ struct CheatWindow : Window {
 		/* We do not allow changes of some items when we are a client in a network game */
 		bool editable = sd->IsEditable();
 
-		SetDParam(0, STR_CONFIG_SETTING_VALUE);
+		auto [min_val, max_val] = sd->GetRange();
 		int32_t value = sd->Read(&GetGameSettings());
 		if (sd->IsBoolSetting()) {
 			/* Draw checkbox for boolean-value either on/off */
@@ -355,10 +355,10 @@ struct CheatWindow : Window {
 		} else {
 			/* Draw [<][>] boxes for settings of an integer-type */
 			DrawArrowButtons(buttons.left, buttons.top, COLOUR_YELLOW, state,
-					editable && value != (sd->flags.Test(SettingFlag::GuiZeroIsSpecial) ? 0 : sd->min), editable && static_cast<uint32_t>(value) != sd->max);
+					editable && value != (sd->flags.Test(SettingFlag::GuiZeroIsSpecial) ? 0 : min_val), editable && static_cast<uint32_t>(value) != max_val);
 		}
-		sd->SetValueDParams(1, value);
-		DrawString(text.left, text.right, text.top, sd->GetTitle(), TC_LIGHT_BLUE);
+		auto [param1, param2] = sd->GetValueParams(value);
+		DrawString(text.left, text.right, text.top, GetString(sd->GetTitle(), STR_CONFIG_SETTING_VALUE, param1, param2), TC_LIGHT_BLUE);
 	}
 
 	void UpdateWidgetSize(WidgetID widget, Dimension &size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension &fill, [[maybe_unused]] Dimension &resize) override
@@ -417,9 +417,8 @@ struct CheatWindow : Window {
 		for (const auto &desc : this->sandbox_settings) {
 			const IntSettingDesc *sd = desc->AsIntSetting();
 
-			SetDParam(0, STR_CONFIG_SETTING_VALUE);
-			sd->SetValueDParams(1, sd->max);
-			width = std::max(width, GetStringBoundingBox(sd->GetTitle()).width);
+			auto [param1, param2] = sd->GetValueParams(sd->GetDefaultValue());
+			width = std::max(width, GetStringBoundingBox(GetString(sd->GetTitle(), STR_CONFIG_SETTING_VALUE, param1, param2)).width);
 		}
 
 		size.width = width + WidgetDimensions::scaled.hsep_wide * 2 + SETTING_BUTTON_WIDTH;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -453,25 +453,25 @@ StringID IntSettingDesc::GetHelp() const
 }
 
 /**
- * Set the DParams for drawing the value of the setting.
- * @param first_param First DParam to use
+ * Get parameters for drawing the value of the setting.
  * @param value Setting value to set params for.
  */
-void IntSettingDesc::SetValueDParams(uint first_param, int32_t value) const
+std::pair<StringParameter, StringParameter> IntSettingDesc::GetValueParams(int32_t value) const
 {
-	auto [min_val, _] = this->GetRange();
-	if (this->set_value_dparams_cb != nullptr) {
-		this->set_value_dparams_cb(*this, first_param, value);
-	} else if (this->IsBoolSetting()) {
-		SetDParam(first_param++, value != 0 ? STR_CONFIG_SETTING_ON : STR_CONFIG_SETTING_OFF);
-	} else {
-		if (this->flags.Test(SettingFlag::GuiDropdown)) {
-			SetDParam(first_param++, this->str_val - min_val + value);
-		} else {
-			SetDParam(first_param++, this->str_val + ((value == 0 && this->flags.Test(SettingFlag::GuiZeroIsSpecial)) ? 1 : 0));
-		}
-		SetDParam(first_param++, value);
+	if (this->get_value_params_cb != nullptr) {
+		return this->get_value_params_cb(*this, value);
 	}
+
+	if (this->IsBoolSetting()) {
+		return {value != 0 ? STR_CONFIG_SETTING_ON : STR_CONFIG_SETTING_OFF, {}};
+	}
+
+	if (this->flags.Test(SettingFlag::GuiDropdown)) {
+		auto [min_val, _] = this->GetRange();
+		return {this->str_val - min_val + value, value};
+	}
+
+	return {this->str_val + ((value == 0 && this->flags.Test(SettingFlag::GuiZeroIsSpecial)) ? 1 : 0), value};
 }
 
 /**

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1620,7 +1620,6 @@ void SettingEntry::DrawSetting(GameSettings *settings_ptr, int left, int right, 
 	/* We do not allow changes of some items when we are a client in a networkgame */
 	bool editable = sd->IsEditable();
 
-	SetDParam(0, STR_CONFIG_SETTING_VALUE);
 	auto [min_val, max_val] = sd->GetRange();
 	int32_t value = sd->Read(ResolveObject(settings_ptr, sd));
 	if (sd->IsBoolSetting()) {
@@ -1634,8 +1633,8 @@ void SettingEntry::DrawSetting(GameSettings *settings_ptr, int left, int right, 
 		DrawArrowButtons(buttons_left, button_y, COLOUR_YELLOW, state,
 				editable && value != (sd->flags.Test(SettingFlag::GuiZeroIsSpecial) ? 0 : min_val), editable && static_cast<uint32_t>(value) != max_val);
 	}
-	sd->SetValueDParams(1, value);
-	DrawString(text_left, text_right, y + (SETTING_HEIGHT - GetCharacterHeight(FS_NORMAL)) / 2, sd->GetTitle(), highlight ? TC_WHITE : TC_LIGHT_BLUE);
+	auto [param1, param2] = sd->GetValueParams(value);
+	DrawString(text_left, text_right, y + (SETTING_HEIGHT - GetCharacterHeight(FS_NORMAL)) / 2, GetString(sd->GetTitle(), STR_CONFIG_SETTING_VALUE, param1, param2), highlight ? TC_WHITE : TC_LIGHT_BLUE);
 }
 
 /* == SettingsContainer methods == */
@@ -2509,8 +2508,8 @@ struct GameSettingsWindow : Window {
 					DrawString(tr, STR_CONFIG_SETTING_TYPE);
 					tr.top += GetCharacterHeight(FS_NORMAL);
 
-					sd->SetValueDParams(0, sd->GetDefaultValue());
-					DrawString(tr, STR_CONFIG_SETTING_DEFAULT_VALUE);
+					auto [param1, param2] = sd->GetValueParams(sd->GetDefaultValue());
+					DrawString(tr, GetString(STR_CONFIG_SETTING_DEFAULT_VALUE, param1, param2));
 					tr.top += GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.vsep_normal;
 
 					DrawStringMultiLine(tr, sd->GetHelp(), TC_WHITE);
@@ -2641,8 +2640,8 @@ struct GameSettingsWindow : Window {
 
 					DropDownList list;
 					for (int32_t i = min_val; i <= static_cast<int32_t>(max_val); i++) {
-						sd->SetValueDParams(0, i);
-						list.push_back(MakeDropDownListStringItem(STR_JUST_STRING2, i));
+						auto [param1, param2] = sd->GetValueParams(i);
+						list.push_back(MakeDropDownListStringItem(GetString(STR_JUST_STRING1, param1, param2), i));
 					}
 
 					ShowDropDownListAt(this, std::move(list), value, WID_GS_SETTING_DROPDOWN, wi_rect, COLOUR_ORANGE);

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -146,11 +146,11 @@ struct SettingDesc {
 
 /** Base integer type, including boolean, settings. Only these are shown in the settings UI. */
 struct IntSettingDesc : SettingDesc {
-	typedef StringID GetTitleCallback(const IntSettingDesc &sd);
-	typedef StringID GetHelpCallback(const IntSettingDesc &sd);
-	typedef void SetValueDParamsCallback(const IntSettingDesc &sd, uint first_param, int32_t value);
-	typedef int32_t GetDefaultValueCallback(const IntSettingDesc &sd);
-	typedef std::tuple<int32_t, uint32_t> GetRangeCallback(const IntSettingDesc &sd);
+	using GetTitleCallback = StringID(const IntSettingDesc &sd);
+	using GetHelpCallback = StringID(const IntSettingDesc &sd);
+	using GetValueParamsCallback = std::pair<StringParameter, StringParameter>(const IntSettingDesc &sd, int32_t value);
+	using GetDefaultValueCallback = int32_t(const IntSettingDesc &sd);
+	using GetRangeCallback = std::tuple<int32_t, uint32_t>(const IntSettingDesc &sd);
 
 	/**
 	 * A check to be performed before the setting gets changed. The passed integer may be
@@ -160,23 +160,23 @@ struct IntSettingDesc : SettingDesc {
 	 * @param value The prospective new value for the setting.
 	 * @return True when the setting is accepted.
 	 */
-	typedef bool PreChangeCheck(int32_t &value);
+	using PreChangeCheck = bool(int32_t &value);
 	/**
 	 * A callback to denote that a setting has been changed.
 	 * @param The new value for the setting.
 	 */
-	typedef void PostChangeCallback(int32_t value);
+	using PostChangeCallback = void(int32_t value);
 
 	template <ConvertibleThroughBaseOrTo<int32_t> Tdef, ConvertibleThroughBaseOrTo<int32_t> Tmin, ConvertibleThroughBaseOrTo<uint32_t> Tmax, ConvertibleThroughBaseOrTo<int32_t> Tinterval>
 	IntSettingDesc(const SaveLoad &save, SettingFlags flags, bool startup, Tdef def,
 			Tmin min, Tmax max, Tinterval interval, StringID str, StringID str_help, StringID str_val,
 			SettingCategory cat, PreChangeCheck pre_check, PostChangeCallback post_callback,
-			GetTitleCallback get_title_cb, GetHelpCallback get_help_cb, SetValueDParamsCallback set_value_dparams_cb,
+			GetTitleCallback get_title_cb, GetHelpCallback get_help_cb, GetValueParamsCallback get_value_params_cb,
 			GetDefaultValueCallback get_def_cb, GetRangeCallback get_range_cb) :
 		SettingDesc(save, flags, startup),
 			str(str), str_help(str_help), str_val(str_val), cat(cat), pre_check(pre_check),
 			post_callback(post_callback),
-			get_title_cb(get_title_cb), get_help_cb(get_help_cb), set_value_dparams_cb(set_value_dparams_cb),
+			get_title_cb(get_title_cb), get_help_cb(get_help_cb), get_value_params_cb(get_value_params_cb),
 			get_def_cb(get_def_cb), get_range_cb(get_range_cb) {
 		if constexpr (ConvertibleThroughBase<Tdef>) {
 			this->def = def.base();
@@ -215,13 +215,13 @@ struct IntSettingDesc : SettingDesc {
 	PostChangeCallback *post_callback; ///< Callback when the setting has been changed.
 	GetTitleCallback *get_title_cb;
 	GetHelpCallback *get_help_cb;
-	SetValueDParamsCallback *set_value_dparams_cb;
+	GetValueParamsCallback *get_value_params_cb;
 	GetDefaultValueCallback *get_def_cb; ///< Callback to set the correct default value
 	GetRangeCallback *get_range_cb;
 
 	StringID GetTitle() const;
 	StringID GetHelp() const;
-	void SetValueDParams(uint first_param, int32_t value) const;
+	std::pair<StringParameter, StringParameter> GetValueParams(int32_t value) const;
 	int32_t GetDefaultValue() const;
 	std::tuple<int32_t, uint32_t> GetRange() const;
 
@@ -253,10 +253,10 @@ struct BoolSettingDesc : IntSettingDesc {
 	BoolSettingDesc(const SaveLoad &save, SettingFlags flags, bool startup, bool def,
 			StringID str, StringID str_help, StringID str_val, SettingCategory cat,
 			PreChangeCheck pre_check, PostChangeCallback post_callback,
-			GetTitleCallback get_title_cb, GetHelpCallback get_help_cb, SetValueDParamsCallback set_value_dparams_cb,
+			GetTitleCallback get_title_cb, GetHelpCallback get_help_cb, GetValueParamsCallback get_value_params_cb,
 			GetDefaultValueCallback get_def_cb) :
 		IntSettingDesc(save, flags, startup, def ? 1 : 0, 0, 1, 0, str, str_help, str_val, cat,
-			pre_check, post_callback, get_title_cb, get_help_cb, set_value_dparams_cb, get_def_cb, nullptr) {}
+			pre_check, post_callback, get_title_cb, get_help_cb, get_value_params_cb, get_def_cb, nullptr) {}
 
 	static std::optional<bool> ParseSingleValue(const char *str);
 
@@ -272,10 +272,10 @@ struct OneOfManySettingDesc : IntSettingDesc {
 	OneOfManySettingDesc(const SaveLoad &save, SettingFlags flags, bool startup, int32_t def,
 			int32_t max, StringID str, StringID str_help, StringID str_val, SettingCategory cat,
 			PreChangeCheck pre_check, PostChangeCallback post_callback,
-			GetTitleCallback get_title_cb, GetHelpCallback get_help_cb, SetValueDParamsCallback set_value_dparams_cb,
+			GetTitleCallback get_title_cb, GetHelpCallback get_help_cb, GetValueParamsCallback get_value_params_cb,
 			GetDefaultValueCallback get_def_cb, std::initializer_list<const char *> many, OnConvert *many_cnvt) :
 		IntSettingDesc(save, flags, startup, def, 0, max, 0, str, str_help, str_val, cat,
-			pre_check, post_callback, get_title_cb, get_help_cb, set_value_dparams_cb, get_def_cb, nullptr), many_cnvt(many_cnvt)
+			pre_check, post_callback, get_title_cb, get_help_cb, get_value_params_cb, get_def_cb, nullptr), many_cnvt(many_cnvt)
 	{
 		for (auto one : many) this->many.push_back(one);
 	}
@@ -295,10 +295,10 @@ struct ManyOfManySettingDesc : OneOfManySettingDesc {
 	ManyOfManySettingDesc(const SaveLoad &save, SettingFlags flags, bool startup,
 		int32_t def, StringID str, StringID str_help, StringID str_val, SettingCategory cat,
 		PreChangeCheck pre_check, PostChangeCallback post_callback,
-		GetTitleCallback get_title_cb, GetHelpCallback get_help_cb, SetValueDParamsCallback set_value_dparams_cb,
+		GetTitleCallback get_title_cb, GetHelpCallback get_help_cb, GetValueParamsCallback get_value_params_cb,
 		GetDefaultValueCallback get_def_cb, std::initializer_list<const char *> many, OnConvert *many_cnvt) :
 		OneOfManySettingDesc(save, flags, startup, def, (1 << many.size()) - 1, str, str_help,
-			str_val, cat, pre_check, post_callback, get_title_cb, get_help_cb, set_value_dparams_cb, get_def_cb, many, many_cnvt) {}
+			str_val, cat, pre_check, post_callback, get_title_cb, get_help_cb, get_value_params_cb, get_def_cb, many, many_cnvt) {}
 
 	size_t ParseValue(const char *str) const override;
 	std::string FormatValue(const void *object) const override;

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -96,7 +96,7 @@ static StringID SettingHelpWallclock(const IntSettingDesc &sd)
 }
 
 /** Setting values for velocity unit localisation */
-static void SettingsValueVelocityUnit(const IntSettingDesc &, uint first_param, int32_t value)
+static std::pair<StringParameter, StringParameter> SettingsValueVelocityUnit(const IntSettingDesc &, int32_t value)
 {
 	StringID val;
 	switch (value) {
@@ -107,18 +107,17 @@ static void SettingsValueVelocityUnit(const IntSettingDesc &, uint first_param, 
 		case 4: val = STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_KNOTS; break;
 		default: NOT_REACHED();
 	}
-	SetDParam(first_param, val);
+	return {val, {}};
 }
 
 /** A negative value has another string (the one after "strval"). */
-static void SettingsValueAbsolute(const IntSettingDesc &sd, uint first_param, int32_t value)
+static std::pair<StringParameter, StringParameter> SettingsValueAbsolute(const IntSettingDesc &sd, int32_t value)
 {
-	SetDParam(first_param, sd.str_val + ((value >= 0) ? 1 : 0));
-	SetDParam(first_param + 1, abs(value));
+	return {sd.str_val + ((value >= 0) ? 1 : 0), abs(value)};
 }
 
 /** Service Interval Settings Default Value displays the correct units or as a percentage */
-static void ServiceIntervalSettingsValueText(const IntSettingDesc &sd, uint first_param, int32_t value)
+static std::pair<StringParameter, StringParameter>  ServiceIntervalSettingsValueText(const IntSettingDesc &sd, int32_t value)
 {
 	VehicleDefaultSettings *vds;
 	if (_game_mode == GM_MENU || !Company::IsValidID(_current_company)) {
@@ -127,16 +126,17 @@ static void ServiceIntervalSettingsValueText(const IntSettingDesc &sd, uint firs
 		vds = &Company::Get(_current_company)->settings.vehicle;
 	}
 
+	StringID str;
 	if (value == 0) {
-		SetDParam(first_param, sd.str_val + 3);
+		str = sd.str_val + 3;
 	} else if (vds->servint_ispercent) {
-		SetDParam(first_param, sd.str_val + 2);
+		str = sd.str_val + 2;
 	} else if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU)) {
-		SetDParam(first_param, sd.str_val + 1);
+		str = sd.str_val + 1;
 	} else {
-		SetDParam(first_param, sd.str_val);
+		str = sd.str_val;
 	}
-	SetDParam(first_param + 1, value);
+	return {str, value};
 }
 
 /** Reposition the main toolbar as the setting changed. */

--- a/src/table/settings/company_settings.ini
+++ b/src/table/settings/company_settings.ini
@@ -11,8 +11,8 @@
 static void UpdateAllServiceInterval(int32_t new_value);
 static bool CanUpdateServiceInterval(VehicleType type, int32_t &new_value);
 static void UpdateServiceInterval(VehicleType type, int32_t new_value);
-static void SettingsValueAbsolute(const IntSettingDesc &sd, uint first_param, int32_t value);
-static void ServiceIntervalSettingsValueText(const IntSettingDesc &sd, uint first_param, int32_t value);
+static std::pair<StringParameter, StringParameter> SettingsValueAbsolute(const IntSettingDesc &sd, int32_t value);
+static std::pair<StringParameter, StringParameter> ServiceIntervalSettingsValueText(const IntSettingDesc &sd, int32_t value);
 static int32_t GetDefaultServiceInterval(const IntSettingDesc &sd, VehicleType type);
 static std::tuple<int32_t, uint32_t> GetServiceIntervalRange(const IntSettingDesc &sd);
 

--- a/src/table/settings/locale_settings.ini
+++ b/src/table/settings/locale_settings.ini
@@ -8,7 +8,7 @@
 ; in the savegame PATS chunk. These settings are not sync'd over the network.
 
 [pre-amble]
-static void SettingsValueVelocityUnit(const IntSettingDesc &sd, uint first_param, int32_t value);
+static std::pair<StringParameter, StringParameter> SettingsValueVelocityUnit(const IntSettingDesc &sd, int32_t value);
 
 uint8_t _old_units;                                      ///< Old units from old savegames
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Part of removing global string parameters.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Return local parameters when formatting strings for game settings, instead of storing the parameters in various places as global parameters.

This allows the string formatting to use parameterised `GetString()`.


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
