### PR TITLE
Codechange: Detemplatise uint64_t version of GetNextParameters().

### DIFF
--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -80,16 +80,28 @@ public:
 	 * will be read.
 	 * @return The next parameter's value.
 	 */
-	template <typename T>
-	T GetNextParameter()
+	uint64_t GetNextParameter()
 	{
 		struct visitor {
 			uint64_t operator()(const uint64_t &arg) { return arg; }
 			uint64_t operator()(const std::string &) { throw std::out_of_range("Attempt to read string parameter as integer"); }
 		};
 
-		const auto &param = GetNextParameterReference();
-		return static_cast<T>(std::visit(visitor{}, param.data));
+		const auto &param = this->GetNextParameterReference();
+		return std::visit(visitor{}, param.data);
+	}
+
+	/**
+	 * Get the next parameter from our parameters.
+	 * This updates the offset, so the next time this is called the next parameter
+	 * will be read.
+	 * @tparam T The return type of the parameter.
+	 * @return The next parameter's value.
+	 */
+	template <typename T>
+	T GetNextParameter()
+	{
+		return static_cast<T>(this->GetNextParameter());
 	}
 
 	/**


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`GetNextParameters()` is a templated function that contains a visitor struct.

The visitor itself does not depend on the template, but some compilers may choose to create multiple versions of it.

This was included as part of removing global string parameters as expanding the variant `StringParameterData` there seems to raise this behaviour.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Detemplatise `uint64_t` version of `GetNextParameters()`.

This helps ensure the visitor is not duplicated for the different types pass to `GetNextParamters<T>()`, which now is only concerned with casting the result.

It might still be if the compiler decides to inline it anyway, mind you.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
