### PR TITLE
Codechange: remove synthesized operators

### DIFF
--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -168,7 +168,6 @@ struct CargoSpec {
 		};
 
 		bool operator==(const Iterator &other) const { return this->index == other.index; }
-		bool operator!=(const Iterator &other) const { return !(*this == other); }
 		CargoSpec * operator*() const { return CargoSpec::Get(this->index); }
 		Iterator & operator++() { this->index++; this->ValidateIndex(); return *this; }
 

--- a/src/core/bitmath_func.hpp
+++ b/src/core/bitmath_func.hpp
@@ -315,7 +315,6 @@ struct SetBitIterator {
 		{
 			return this->bitset == other.bitset;
 		}
-		bool operator!=(const Iterator &other) const { return !(*this == other); }
 		Tbitpos operator*() const { return this->bitpos; }
 		Iterator & operator++() { this->Next(); this->Validate(); return *this; }
 

--- a/src/core/multimap.hpp
+++ b/src/core/multimap.hpp
@@ -181,94 +181,38 @@ public:
 		this->operator--();
 		return tmp;
 	}
+	/**
+	 * Compare two MultiMap iterators. Iterators are equal if
+	 * 1. Their map iterators are equal.
+	 * 2. They agree about list_valid.
+	 * 3. If list_valid they agree about list_iter.
+	 * Lots of template parameters to make all possible const and non-const types of MultiMap iterators
+	 * (on maps with const and non-const values) comparable to each other.
+	 * @param other Other iterator to compare to.
+	 * @return If other is equal to this.
+	 */
+	template <class Tmap_iter_other, class Tlist_iter_other, class Tvalue_other>
+	bool operator==(const MultiMapIterator<Tmap_iter_other, Tlist_iter_other, Tkey, Tvalue_other, Tcompare> &other) const
+	{
+		if (this->GetMapIter() != other.GetMapIter()) return false;
+		if (!this->ListValid()) return !other.ListValid();
+		return other.ListValid() ?
+				this->GetListIter() == other.GetListIter() : false;
+	}
+
+	/**
+	 * Check if a MultiMap iterator is at the begin of a list pointed to by the given map iterator.
+	 * Lots of template parameters to make all possible const and non-const types of MultiMap iterators
+	 * (on maps with const and non-const values) comparable to all possible types of map iterators.
+	 * @param iter Map iterator.
+	 * @return If this points to the begin of the list pointed to by iter.
+	 */
+	template <class Titer>
+	bool operator==(const Titer &iter) const
+	{
+		return !this->ListValid() && this->GetMapIter() == iter;
+	}
 };
-
-/* Generic comparison functions for const/non-const MultiMap iterators and map iterators */
-
-/**
- * Compare two MultiMap iterators. Iterators are equal if
- * 1. Their map iterators are equal.
- * 2. They agree about list_valid.
- * 3. If list_valid they agree about list_iter.
- * Lots of template parameters to make all possible const and non-const types of MultiMap iterators
- * (on maps with const and non-const values) comparable to each other.
- * @param iter1 First iterator to compare.
- * @param iter2 Second iterator to compare.
- * @return If iter1 and iter2 are equal.
- */
-template <class Tmap_iter1, class Tlist_iter1, class Tmap_iter2, class Tlist_iter2, class Tkey, class Tvalue1, class Tvalue2, class Tcompare>
-bool operator==(const MultiMapIterator<Tmap_iter1, Tlist_iter1, Tkey, Tvalue1, Tcompare> &iter1, const MultiMapIterator<Tmap_iter2, Tlist_iter2, Tkey, Tvalue2, Tcompare> &iter2)
-{
-	if (iter1.GetMapIter() != iter2.GetMapIter()) return false;
-	if (!iter1.ListValid()) return !iter2.ListValid();
-	return iter2.ListValid() ?
-			iter1.GetListIter() == iter2.GetListIter() : false;
-}
-
-/**
- * Inverse of operator==().
- * Lots of template parameters to make all possible const and non-const types of MultiMap iterators
- * (on maps with const and non-const values) comparable to each other.
- * @param iter1 First iterator to compare.
- * @param iter2 Second iterator to compare.
- * @return If iter1 and iter2 are not equal.
- */
-template <class Tmap_iter1, class Tlist_iter1, class Tmap_iter2, class Tlist_iter2, class Tkey, class Tvalue1, class Tvalue2, class Tcompare>
-bool operator!=(const MultiMapIterator<Tmap_iter1, Tlist_iter1, Tkey, Tvalue1, Tcompare> &iter1, const MultiMapIterator<Tmap_iter2, Tlist_iter2, Tkey, Tvalue2, Tcompare> &iter2)
-{
-	return !(iter1 == iter2);
-}
-
-/**
- * Check if a MultiMap iterator is at the begin of a list pointed to by the given map iterator.
- * Lots of template parameters to make all possible const and non-const types of MultiMap iterators
- * (on maps with const and non-const values) comparable to all possible types of map iterators.
- * @param iter1 MultiMap iterator.
- * @param iter2 Map iterator.
- * @return If iter1 points to the begin of the list pointed to by iter2.
- */
-template <class Tmap_iter1, class Tlist_iter1, class Tmap_iter2, class Tkey, class Tvalue, class Tcompare >
-bool operator==(const MultiMapIterator<Tmap_iter1, Tlist_iter1, Tkey, Tvalue, Tcompare> &iter1, const Tmap_iter2 &iter2)
-{
-	return !iter1.ListValid() && iter1.GetMapIter() == iter2;
-}
-
-/**
- * Inverse of operator==() with same signature.
- * @param iter1 MultiMap iterator.
- * @param iter2 Map iterator.
- * @return If iter1 doesn't point to the begin of the list pointed to by iter2.
- */
-template <class Tmap_iter1, class Tlist_iter1, class Tmap_iter2, class Tkey, class Tvalue, class Tcompare >
-bool operator!=(const MultiMapIterator<Tmap_iter1, Tlist_iter1, Tkey, Tvalue, Tcompare> &iter1, const Tmap_iter2 &iter2)
-{
-	return iter1.ListValid() || iter1.GetMapIter() != iter2;
-}
-
-/**
- * Same as operator==() with reversed order of arguments.
- * @param iter2 Map iterator.
- * @param iter1 MultiMap iterator.
- * @return If iter1 points to the begin of the list pointed to by iter2.
- */
-template <class Tmap_iter1, class Tlist_iter1, class Tmap_iter2, class Tkey, class Tvalue, class Tcompare >
-bool operator==(const Tmap_iter2 &iter2, const MultiMapIterator<Tmap_iter1, Tlist_iter1, Tkey, Tvalue, Tcompare> &iter1)
-{
-	return !iter1.ListValid() && iter1.GetMapIter() == iter2;
-}
-
-/**
- * Same as operator!=() with reversed order of arguments.
- * @param iter2 Map iterator.
- * @param iter1 MultiMap iterator.
- * @return If iter1 doesn't point to the begin of the list pointed to by iter2.
- */
-template <class Tmap_iter1, class Tlist_iter1, class Tmap_iter2, class Tkey, class Tvalue, class Tcompare >
-bool operator!=(const Tmap_iter2 &iter2, const MultiMapIterator<Tmap_iter1, Tlist_iter1, Tkey, Tvalue, Tcompare> &iter1)
-{
-	return iter1.ListValid() || iter1.GetMapIter() != iter2;
-}
-
 
 /**
  * Hand-rolled multimap as map of lists. Behaves mostly like a list, but is sorted

--- a/src/core/overflowsafe_type.hpp
+++ b/src/core/overflowsafe_type.hpp
@@ -162,19 +162,11 @@ public:
 
 	/* Operators for (in)equality when comparing overflow safe ints. */
 	inline constexpr bool operator == (const OverflowSafeInt& other) const { return this->m_value == other.m_value; }
-	inline constexpr bool operator != (const OverflowSafeInt& other) const { return !(*this == other); }
-	inline constexpr bool operator >  (const OverflowSafeInt& other) const { return this->m_value > other.m_value; }
-	inline constexpr bool operator >= (const OverflowSafeInt& other) const { return this->m_value >= other.m_value; }
-	inline constexpr bool operator <  (const OverflowSafeInt& other) const { return !(*this >= other); }
-	inline constexpr bool operator <= (const OverflowSafeInt& other) const { return !(*this > other); }
+	inline constexpr auto operator <=>(const OverflowSafeInt& other) const { return this->m_value <=> other.m_value; }
 
 	/* Operators for (in)equality when comparing non-overflow safe ints. */
 	inline constexpr bool operator == (const int other) const { return this->m_value == other; }
-	inline constexpr bool operator != (const int other) const { return !(*this == other); }
-	inline constexpr bool operator >  (const int other) const { return this->m_value > other; }
-	inline constexpr bool operator >= (const int other) const { return this->m_value >= other; }
-	inline constexpr bool operator <  (const int other) const { return !(*this >= other); }
-	inline constexpr bool operator <= (const int other) const { return !(*this > other); }
+	inline constexpr auto operator <=>(const int other) const { return this->m_value <=> other; }
 
 	inline constexpr operator T () const { return this->m_value; }
 

--- a/src/core/pool_type.hpp
+++ b/src/core/pool_type.hpp
@@ -162,7 +162,6 @@ public:
 		};
 
 		bool operator==(const PoolIterator &other) const { return this->index == other.index; }
-		bool operator!=(const PoolIterator &other) const { return !(*this == other); }
 		T * operator*() const { return T::Get(this->index); }
 		PoolIterator & operator++() { this->index++; this->ValidateIndex(); return *this; }
 
@@ -206,7 +205,6 @@ public:
 		};
 
 		bool operator==(const PoolIteratorFiltered &other) const { return this->index == other.index; }
-		bool operator!=(const PoolIteratorFiltered &other) const { return !(*this == other); }
 		T * operator*() const { return T::Get(this->index); }
 		PoolIteratorFiltered & operator++() { this->index++; this->ValidateIndex(); return *this; }
 

--- a/src/core/strong_typedef_type.hpp
+++ b/src/core/strong_typedef_type.hpp
@@ -22,20 +22,8 @@ namespace StrongType {
 			friend constexpr bool operator ==(const TType &lhs, const TType &rhs) { return lhs.value == rhs.value; }
 			friend constexpr bool operator ==(const TType &lhs, const TBaseType &rhs) { return lhs.value == rhs; }
 
-			friend constexpr bool operator !=(const TType &lhs, const TType &rhs) { return lhs.value != rhs.value; }
-			friend constexpr bool operator !=(const TType &lhs, const TBaseType &rhs) { return lhs.value != rhs; }
-
-			friend constexpr bool operator <=(const TType &lhs, const TType &rhs) { return lhs.value <= rhs.value; }
-			friend constexpr bool operator <=(const TType &lhs, const TBaseType &rhs) { return lhs.value <= rhs; }
-
-			friend constexpr bool operator <(const TType &lhs, const TType &rhs) { return lhs.value < rhs.value; }
-			friend constexpr bool operator <(const TType &lhs, const TBaseType &rhs) { return lhs.value < rhs; }
-
-			friend constexpr bool operator >=(const TType &lhs, const TType &rhs) { return lhs.value >= rhs.value; }
-			friend constexpr bool operator >=(const TType &lhs, const TBaseType &rhs) { return lhs.value >= rhs; }
-
-			friend constexpr bool operator >(const TType &lhs, const TType &rhs) { return lhs.value > rhs.value; }
-			friend constexpr bool operator >(const TType &lhs, const TBaseType &rhs) { return lhs.value > rhs; }
+			friend constexpr auto operator <=>(const TType &lhs, const TType &rhs) { return lhs.value <=> rhs.value; }
+			friend constexpr auto operator <=>(const TType &lhs, const TBaseType &rhs) { return lhs.value <=> rhs; }
 		};
 	};
 
@@ -117,12 +105,7 @@ namespace StrongType {
 		template <typename TType, typename TBaseType>
 		struct mixin {
 			friend constexpr bool operator ==(const TType &lhs, TCompatibleType rhs) { return lhs.value == static_cast<TBaseType>(rhs); }
-			friend constexpr bool operator !=(const TType &lhs, TCompatibleType rhs) { return lhs.value != static_cast<TBaseType>(rhs); }
-
-			friend constexpr bool operator <=(const TType &lhs, TCompatibleType rhs) { return lhs.value <= static_cast<TBaseType>(rhs); }
-			friend constexpr bool operator <(const TType &lhs, TCompatibleType rhs) { return lhs.value < static_cast<TBaseType>(rhs); }
-			friend constexpr bool operator >=(const TType &lhs, TCompatibleType rhs) { return lhs.value >= static_cast<TBaseType>(rhs); }
-			friend constexpr bool operator >(const TType &lhs, TCompatibleType rhs) { return lhs.value > static_cast<TBaseType>(rhs); }
+			friend constexpr auto operator <=>(const TType &lhs, TCompatibleType rhs) { return lhs.value <=> static_cast<TBaseType>(rhs); }
 
 			friend constexpr TType operator +(const TType &lhs, TCompatibleType rhs) { return TType(lhs.value + rhs); }
 			friend constexpr TType operator -(const TType &lhs, TCompatibleType rhs) { return TType(lhs.value - rhs); }

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -618,11 +618,6 @@ struct ScenarioIdentifier {
 	{
 		return this->scenid == other.scenid && this->md5sum == other.md5sum;
 	}
-
-	bool operator != (const ScenarioIdentifier &other) const
-	{
-		return !(*this == other);
-	}
 };
 
 /**

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -217,7 +217,6 @@ private:
 
 		explicit Iterator(TileIndex index) : index(index) {}
 		bool operator==(const Iterator &other) const { return this->index == other.index; }
-		bool operator!=(const Iterator &other) const { return !(*this == other); }
 		Tile operator*() const { return this->index; }
 		Iterator & operator++() { this->index++; return *this; }
 	private:

--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -150,23 +150,14 @@ public:
 	{
 		return const_cast<NetworkAddress*>(this)->CompareTo(address) == 0;
 	}
-	/**
-	 * Compare the address of this class with the address of another.
-	 * @param address the other address.
-	 * @return true if both do not match.
-	 */
-	bool operator != (NetworkAddress address) const
-	{
-		return const_cast<NetworkAddress*>(this)->CompareTo(address) != 0;
-	}
 
 	/**
 	 * Compare the address of this class with the address of another.
 	 * @param address the other address.
 	 */
-	bool operator < (NetworkAddress &address)
+	auto operator <=>(NetworkAddress &address)
 	{
-		return this->CompareTo(address) < 0;
+		return this->CompareTo(address) <=> 0;
 	}
 
 	void Listen(int socktype, SocketList *sockets);

--- a/src/order_type.h
+++ b/src/order_type.h
@@ -30,13 +30,8 @@ struct DestinationID {
 	constexpr BaseType base() const noexcept { return this->value; }
 
 	constexpr bool operator ==(const DestinationID &destination) const { return this->value == destination.value; }
-	constexpr bool operator !=(const DestinationID &destination) const { return this->value != destination.value; }
 	constexpr bool operator ==(const StationID &station) const { return this->value == station; }
-	constexpr bool operator !=(const StationID &station) const { return this->value != station; }
 };
-
-constexpr bool operator ==(const StationID &station, const DestinationID &destination) { return destination == station; }
-constexpr bool operator !=(const StationID &station, const DestinationID &destination) { return destination != station; }
 
 /** Invalid vehicle order index (sentinel) */
 static const VehicleOrderID INVALID_VEH_ORDER_ID = 0xFF;

--- a/src/pathfinder/water_regions.h
+++ b/src/pathfinder/water_regions.h
@@ -30,7 +30,6 @@ struct WaterRegionPatchDesc
 	TWaterRegionPatchLabel label; ///< Unique label identifying the patch within the region
 
 	bool operator==(const WaterRegionPatchDesc &other) const { return x == other.x && y == other.y && label == other.label; }
-	bool operator!=(const WaterRegionPatchDesc &other) const { return !(*this == other); }
 };
 
 
@@ -46,7 +45,6 @@ struct WaterRegionDesc
 	WaterRegionDesc(const WaterRegionPatchDesc &water_region_patch) : x(water_region_patch.x), y(water_region_patch.y) {}
 
 	bool operator==(const WaterRegionDesc &other) const { return x == other.x && y == other.y; }
-	bool operator!=(const WaterRegionDesc &other) const { return !(*this == other); }
 };
 
 int CalculateWaterRegionPatchHash(const WaterRegionPatchDesc &water_region_patch);

--- a/src/tilearea_type.h
+++ b/src/tilearea_type.h
@@ -152,13 +152,6 @@ public:
 	{
 		return this->tile == rhs.tile;
 	}
-	/**
-	 * Inequality comparison.
-	 */
-	bool operator !=(const TileIterator &rhs) const
-	{
-		return this->tile != rhs.tile;
-	}
 
 	/**
 	 * Equality comparison.
@@ -166,13 +159,6 @@ public:
 	bool operator ==(const TileIndex &rhs) const
 	{
 		return this->tile == rhs;
-	}
-	/**
-	 * Inequality comparison.
-	 */
-	bool operator !=(const TileIndex &rhs) const
-	{
-		return this->tile != rhs;
 	}
 
 	static std::unique_ptr<TileIterator> Create(TileIndex corner1, TileIndex corner2, bool diagonal);

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -179,12 +179,6 @@ struct CargoSummaryItem {
 	uint amount;      ///< Amount that is carried
 	StationID source; ///< One of the source stations
 
-	/** Used by CargoSummary::Find() and similar functions */
-	inline bool operator != (const CargoSummaryItem &other) const
-	{
-		return this->cargo != other.cargo || this->subtype != other.subtype;
-	}
-
 	/** Used by std::find() and similar functions */
 	inline bool operator == (const CargoSummaryItem &other) const
 	{

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -141,11 +141,6 @@ struct VehicleSpriteSeq {
 		return this->count == other.count && MemCmpT<PalSpriteID>(this->seq, other.seq, this->count) == 0;
 	}
 
-	bool operator!=(const VehicleSpriteSeq &other) const
-	{
-		return !this->operator==(other);
-	}
-
 	/**
 	 * Check whether the sequence contains any sprites.
 	 */
@@ -1050,7 +1045,6 @@ public:
 		}
 
 		bool operator==(const OrderIterator &other) const { return this->order == other.order; }
-		bool operator!=(const OrderIterator &other) const { return !(*this == other); }
 		Order * operator*() const { return this->order; }
 		OrderIterator & operator++()
 		{

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -666,16 +666,6 @@ struct RefitOption {
 	StringID string;  ///< GRF-local String to display for the cargo
 
 	/**
-	 * Inequality operator for #RefitOption.
-	 * @param other Compare to this #RefitOption.
-	 * @return True if both #RefitOption are different.
-	 */
-	inline bool operator != (const RefitOption &other) const
-	{
-		return other.cargo != this->cargo || other.string != this->string;
-	}
-
-	/**
 	 * Equality operator for #RefitOption.
 	 * @param other Compare to this #RefitOption.
 	 * @return True if both #RefitOption are equal.

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -872,7 +872,6 @@ public:
 		explicit WindowIterator(const Window *w) : it(w->z_position) {}
 
 		bool operator==(const WindowIterator &other) const { return this->it == other.it; }
-		bool operator!=(const WindowIterator &other) const { return !(*this == other); }
 		Window * operator*() const { return *this->it; }
 		WindowIterator & operator++() { this->Next(); this->Validate(); return *this; }
 


### PR DESCRIPTION
## Motivation / Problem

Yesterday I learned...
* if you ` = default` a `operator<=>`, the compiler also synthesizes `==` and `!=` next to `<`, `<=`, `>=` and `>`.
* if you implement `operator<=>`, the compiler only synthesizes `<`, `<=`, `>=` and `>`, not `==` or `!=`.
* if you implement `operator==`, the compiler synthesizes `!=`.
* if you implement `operator==`/`operator<=>` in a class with a different parameter type. Lets say in `class C` and `operator==(const P&)`, the compiler will synthesize `operator==(const C&, const P&)` and `operator==(const P&, const C&)`.


## Description

`MultiMap` implemented `operator==` and `operator!=` free standing, and both `operator==(const C&, const P&)` and `operator==(const P&, const C&)`. Move the required ones into the `MultiMap` class, and remove the ones that will be synthesized (keep 2 of 6).

`OverflowSafeInt` and `StrongTypedef` defined all comparison operators. Just implement `operator==` and `operator<=>` and let the rest be synthesized. Similarly `NetworkAddress` implemented `operator!=` and `operator<`, so remove the former and implement the latter via `operator<=>`.

A number of primarily `Iterator` classes implemented `operator!=` that could just be synthesized by the compiler, so remove them. The `operator!=` in `CargoSummaryItem` is actually different, but does not seem to be used any more since the `operator==` has been implemented for `std::find`. Even then, `operator==` and `operator!=` should be mutually exclusive, i.e. there should be no combination where both `==` and `!=` result in the same.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
