### PR TITLE
Codechange: make Company mask a BitSet

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1070,7 +1070,7 @@ void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_li
 		const uint num_engines = GetGroupNumEngines(_local_company, selected_group, item.engine_id);
 
 		const Engine *e = Engine::Get(item.engine_id);
-		bool hidden = HasBit(e->company_hidden, _local_company);
+		bool hidden = e->company_hidden.Test(_local_company);
 		StringID str = hidden ? STR_HIDDEN_ENGINE_NAME : STR_ENGINE_NAME;
 		TextColour tc = (item.engine_id == selected_id) ? TC_WHITE : ((hidden | shaded) ? (TC_GREY | TC_FORCED | TC_NO_SHADE) : TC_BLACK);
 

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -126,7 +126,7 @@ struct CompanyProperties {
 		: name_2(0), name_1(0), president_name_1(0), president_name_2(0),
 		  face(0), money(0), money_fraction(0), current_loan(0), max_loan(COMPANY_MAX_LOAN_DEFAULT),
 		  colour(COLOUR_BEGIN), block_preview(0), location_of_HQ(0), last_build_coordinate(0), inaugurated_year(0),
-		  months_of_bankruptcy(0), bankrupt_asked(0), bankrupt_timeout(0), bankrupt_value(0),
+		  months_of_bankruptcy(0), bankrupt_asked(), bankrupt_timeout(0), bankrupt_value(0),
 		  terraform_limit(0), clear_limit(0), tree_limit(0), build_object_limit(0), is_ai(false), engine_renew_list(nullptr) {}
 };
 

--- a/src/company_type.h
+++ b/src/company_type.h
@@ -47,7 +47,13 @@ static const uint MAX_COMPETITORS_INTERVAL = 500; ///< The maximum interval (in 
 
 typedef Owner CompanyID;
 
-typedef uint16_t CompanyMask;
+class CompanyMask : public BaseBitSet<CompanyMask, CompanyID, uint16_t> {
+public:
+	constexpr CompanyMask() : BaseBitSet<CompanyMask, CompanyID, uint16_t>() {}
+	static constexpr size_t DecayValueType(CompanyID value) { return to_underlying(value); }
+
+	constexpr auto operator <=>(const CompanyMask &) const noexcept = default;
+};
 
 struct Company;
 typedef uint32_t CompanyManagerFace; ///< Company manager face bits, info see in company_manager_face.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -3,6 +3,7 @@ add_files(
     alloc_func.hpp
     alloc_type.hpp
     backup_type.hpp
+    base_bitset_type.hpp
     bitmath_func.hpp
     convertible_through_base.hpp
     endian_func.hpp

--- a/src/core/base_bitset_type.hpp
+++ b/src/core/base_bitset_type.hpp
@@ -1,0 +1,140 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file base_bitset_type.hpp Base for bitset types that accept strong types,
+ * i.e. types that need some casting like StrongType and enum class.
+ */
+
+#ifndef BASE_BITSET_TYPE_HPP
+#define BASE_BITSET_TYPE_HPP
+
+/**
+ * Base for bit set wrapper.
+ * Allows wrapping strong type values as a bit set. Methods are loosely modelled on std::bitset.
+ * @tparam Tvalue_type Type of values to wrap.
+ * @tparam Tstorage Storage type required to hold values.
+ */
+template <typename Timpl, typename Tvalue_type, typename Tstorage>
+class BaseBitSet {
+public:
+	using ValueType = Tvalue_type; ///< Value type of this BaseBitSet.
+	using BaseType = Tstorage; ///< Storage type of this BaseBitSet, be ConvertibleThroughBase
+
+	constexpr BaseBitSet() : data(0) {}
+	explicit constexpr BaseBitSet(Tstorage data) : data(data) {}
+
+	constexpr auto operator <=>(const BaseBitSet &) const noexcept = default;
+
+	/**
+	 * Set the value-th bit.
+	 * @param value Bit to set.
+	 * @returns The bit set
+	 */
+	inline constexpr Timpl &Set(Tvalue_type value)
+	{
+		this->data |= (1ULL << Timpl::DecayValueType(value));
+		return static_cast<Timpl&>(*this);
+	}
+
+	/**
+	 * Reset the value-th bit.
+	 * @param value Bit to reset.
+	 * @returns The bit set
+	 */
+	inline constexpr Timpl &Reset(Tvalue_type value)
+	{
+		this->data &= ~(1ULL << Timpl::DecayValueType(value));
+		return static_cast<Timpl&>(*this);
+	}
+
+	/**
+	 * Flip the value-th bit.
+	 * @param value Bit to flip.
+	 * @returns The bit set
+	 */
+	inline constexpr Timpl &Flip(Tvalue_type value)
+	{
+		if (this->Test(value)) {
+			return this->Reset(value);
+		} else {
+			return this->Set(value);
+		}
+	}
+
+	/**
+	 * Test if the value-th bit is set.
+	 * @param value Bit to check.
+	 * @returns true iff the requested bit is set.
+	 */
+	inline constexpr bool Test(Tvalue_type value) const
+	{
+		return (this->data & (1ULL << Timpl::DecayValueType(value))) != 0;
+	}
+
+	/**
+	 * Test if all of the values are set.
+	 * @param other BitSet of values to test.
+	 * @returns true iff all of the values are set.
+	 */
+	inline constexpr bool All(const Timpl &other) const
+	{
+		return (this->data & other.data) == other.data;
+	}
+
+	/**
+	 * Test if any of the given values are set.
+	 * @param other BitSet of values to test.
+	 * @returns true iff any of the given values are set.
+	 */
+	inline constexpr bool Any(const Timpl &other) const
+	{
+		return (this->data & other.data) != 0;
+	}
+
+	/**
+	 * Test if any of the values are set.
+	 * @returns true iff any of the values are set.
+	 */
+	inline constexpr bool Any() const
+	{
+		return this->data != 0;
+	}
+
+	/**
+	 * Test if none of the values are set.
+	 * @returns true iff none of the values are set.
+	 */
+	inline constexpr bool None() const
+	{
+		return this->data == 0;
+	}
+
+	inline constexpr Timpl operator |(const Timpl &other) const
+	{
+		return Timpl{static_cast<Tstorage>(this->data | other.data)};
+	}
+
+	inline constexpr Timpl operator &(const Timpl &other) const
+	{
+		return Timpl{static_cast<Tstorage>(this->data & other.data)};
+	}
+
+	/**
+	 * Retrieve the raw value behind this bit set.
+	 * @returns the raw value.
+	 */
+	inline constexpr Tstorage base() const noexcept
+	{
+		return this->data;
+	}
+
+private:
+	Tstorage data; ///< Bitmask of values.
+};
+
+#endif /* BASE_BITSET_TYPE_HPP */

--- a/src/core/base_bitset_type.hpp
+++ b/src/core/base_bitset_type.hpp
@@ -42,6 +42,17 @@ public:
 	}
 
 	/**
+	 * Assign the value-th bit.
+	 * @param value Bit to assign to.
+	 * @param set true if the bit should be set, false if the bit should be reset.
+	 * @returns The EnumBitset
+	 */
+	inline constexpr Timpl &Set(Tvalue_type value, bool set)
+	{
+		return set ? this->Set(value) : this->Reset(value);
+	}
+
+	/**
 	 * Reset the value-th bit.
 	 * @param value Bit to reset.
 	 * @returns The bit set

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -140,7 +140,7 @@ struct Engine : EnginePool::PoolItem<&_engine_pool> {
 	 */
 	inline bool IsHidden(CompanyID c) const
 	{
-		return c < MAX_COMPANIES && HasBit(this->company_hidden, c);
+		return c < MAX_COMPANIES && this->company_hidden.Test(c);
 	}
 
 	/**

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -72,7 +72,7 @@ void LinkGraphOverlay::RebuildCache()
 {
 	this->cached_links.clear();
 	this->cached_stations.clear();
-	if (this->company_mask == 0) return;
+	if (this->company_mask.None()) return;
 
 	DrawPixelInfo dpi;
 	this->GetWidgetDpi(&dpi);
@@ -103,7 +103,7 @@ void LinkGraphOverlay::RebuildCache()
 				assert(sta != stb);
 
 				/* Show links between stations of selected companies or "neutral" ones like oilrigs. */
-				if (stb->owner != OWNER_NONE && sta->owner != OWNER_NONE && !HasBit(this->company_mask, stb->owner)) continue;
+				if (stb->owner != OWNER_NONE && sta->owner != OWNER_NONE && !this->company_mask.Test(stb->owner)) continue;
 				if (stb->rect.IsEmpty()) continue;
 
 				if (!this->IsLinkVisible(pta, this->GetStationMiddle(stb), &dpi)) continue;
@@ -568,9 +568,9 @@ void LinkGraphLegendWindow::SetOverlay(std::shared_ptr<LinkGraphOverlay> overlay
 {
 	this->overlay = overlay;
 	CompanyMask companies = this->overlay->GetCompanyMask();
-	for (uint c = 0; c < MAX_COMPANIES; c++) {
+	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
 		if (!this->IsWidgetDisabled(WID_LGL_COMPANY_FIRST + c)) {
-			this->SetWidgetLoweredState(WID_LGL_COMPANY_FIRST + c, HasBit(companies, c));
+			this->SetWidgetLoweredState(WID_LGL_COMPANY_FIRST + c, companies.Test(c));
 		}
 	}
 	CargoTypes cargoes = this->overlay->GetCargoMask();
@@ -662,11 +662,11 @@ bool LinkGraphLegendWindow::OnTooltip([[maybe_unused]] Point, WidgetID widget, T
  */
 void LinkGraphLegendWindow::UpdateOverlayCompanies()
 {
-	uint32_t mask = 0;
+	CompanyMask mask;
 	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
 		if (this->IsWidgetDisabled(WID_LGL_COMPANY_FIRST + c)) continue;
 		if (!this->IsWidgetLowered(WID_LGL_COMPANY_FIRST + c)) continue;
-		SetBit(mask, c);
+		mask.Set(c);
 	}
 	this->overlay->SetCompanyMask(mask);
 }

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -218,7 +218,7 @@ struct MainWindow : Window
 		NWidgetViewport *nvp = this->GetWidget<NWidgetViewport>(WID_M_VIEWPORT);
 		nvp->InitializeViewport(this, TileXY(32, 32), ScaleZoomGUI(ZOOM_LVL_VIEWPORT));
 
-		this->viewport->overlay = std::make_shared<LinkGraphOverlay>(this, WID_M_VIEWPORT, 0, 0, 2);
+		this->viewport->overlay = std::make_shared<LinkGraphOverlay>(this, WID_M_VIEWPORT, 0, CompanyMask{}, 2);
 		this->refresh_timeout.Reset();
 	}
 
@@ -226,7 +226,7 @@ struct MainWindow : Window
 	void RefreshLinkGraph()
 	{
 		if (this->viewport->overlay->GetCargoMask() == 0 ||
-				this->viewport->overlay->GetCompanyMask() == 0) {
+				this->viewport->overlay->GetCompanyMask().None()) {
 			return;
 		}
 

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -83,8 +83,8 @@
 		case 0xAB: return GB(this->t->ratings[6], 8, 8);
 		case 0xAC: return this->t->ratings[7];
 		case 0xAD: return GB(this->t->ratings[7], 8, 8);
-		case 0xAE: return this->t->have_ratings;
-		case 0xB2: return this->t->statues;
+		case 0xAE: return this->t->have_ratings.base();
+		case 0xB2: return this->t->statues.base();
 		case 0xB6: return ClampTo<uint16_t>(this->t->cache.num_houses);
 		case 0xB9: return this->t->growth_rate / Ticks::TOWN_GROWTH_TICKS;
 		case 0xBA: cargo_type = GetCargoTypeByLabel(CT_PASSENGERS); return IsValidCargoType(cargo_type) ? ClampTo<uint16_t>(this->t->supplied[cargo_type].new_max) : 0;

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -602,7 +602,7 @@ static CommandCost ClearTile_Object(TileIndex tile, DoCommandFlag flags)
 		case OBJECT_STATUE:
 			if (flags & DC_EXEC) {
 				Town *town = o->town;
-				ClrBit(town->statues, GetTileOwner(tile));
+				town->statues.Reset(GetTileOwner(tile));
 				SetWindowDirty(WC_TOWN_AUTHORITY, town->index);
 			}
 			break;
@@ -887,10 +887,10 @@ static void ChangeTileOwner_Object(TileIndex tile, Owner old_owner, Owner new_ow
 		}
 	} else if (type == OBJECT_STATUE) {
 		Town *t = Object::GetByTile(tile)->town;
-		ClrBit(t->statues, old_owner);
-		if (new_owner != INVALID_OWNER && !HasBit(t->statues, new_owner)) {
+		t->statues.Reset(old_owner);
+		if (new_owner != INVALID_OWNER && !t->statues.Test(new_owner)) {
 			/* Transfer ownership to the new company */
-			SetBit(t->statues, new_owner);
+			t->statues.Set(new_owner);
 			SetTileOwner(tile, new_owner);
 		} else {
 			do_clear = true;

--- a/src/rail.cpp
+++ b/src/rail.cpp
@@ -256,7 +256,7 @@ RailTypes GetCompanyRailTypes(CompanyID company, bool introduces)
 		const EngineInfo *ei = &e->info;
 
 		if (ei->climates.Test(_settings_game.game_creation.landscape) &&
-				(HasBit(e->company_avail, company) || TimerGameCalendar::date >= e->intro_date + CalendarTime::DAYS_IN_YEAR)) {
+				(e->company_avail.Test(company) || TimerGameCalendar::date >= e->intro_date + CalendarTime::DAYS_IN_YEAR)) {
 			const RailVehicleInfo *rvi = &e->u.rail;
 
 			if (rvi->railveh_type != RAILVEH_WAGON) {

--- a/src/road.cpp
+++ b/src/road.cpp
@@ -204,7 +204,7 @@ RoadTypes GetCompanyRoadTypes(CompanyID company, bool introduces)
 		const EngineInfo *ei = &e->info;
 
 		if (ei->climates.Test(_settings_game.game_creation.landscape) &&
-				(HasBit(e->company_avail, company) || TimerGameCalendar::date >= e->intro_date + CalendarTime::DAYS_IN_YEAR)) {
+				(e->company_avail.Test(company) || TimerGameCalendar::date >= e->intro_date + CalendarTime::DAYS_IN_YEAR)) {
 			const RoadVehicleInfo *rvi = &e->u.road;
 			assert(rvi->roadtype < ROADTYPE_END);
 			if (introduces) {

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2041,15 +2041,15 @@ bool AfterLoadGame()
 
 		/* More companies ... */
 		for (Company *c : Company::Iterate()) {
-			if (c->bankrupt_asked == 0xFF) c->bankrupt_asked = std::numeric_limits<CompanyMask>::max();
+			if (c->bankrupt_asked.base() == 0xFF) c->bankrupt_asked = std::numeric_limits<CompanyMask>::max();
 		}
 
 		for (Engine *e : Engine::Iterate()) {
-			if (e->company_avail == 0xFF) e->company_avail = std::numeric_limits<CompanyMask>::max();
+			if (e->company_avail.base() == 0xFF) e->company_avail = std::numeric_limits<CompanyMask>::max();
 		}
 
 		for (Town *t : Town::Iterate()) {
-			if (t->have_ratings == 0xFF) t->have_ratings = std::numeric_limits<CompanyMask>::max();
+			if (t->have_ratings.base() == 0xFF) t->have_ratings = std::numeric_limits<CompanyMask>::max();
 			for (uint i = 8; i != MAX_COMPANIES; i++) t->ratings[i] = RATING_INITIAL;
 		}
 	}

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3197,16 +3197,16 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SLV_GROUP_REPLACE_WAGON_REMOVAL)) {
 		/* Propagate wagon removal flag for compatibility */
 		/* Temporary bitmask of company wagon removal setting */
-		uint16_t wagon_removal = 0;
+		CompanyMask wagon_removal{};
 		for (const Company *c : Company::Iterate()) {
-			if (c->settings.renew_keep_length) SetBit(wagon_removal, c->index);
+			if (c->settings.renew_keep_length) wagon_removal.Set(c->index);
 		}
 		for (Group *g : Group::Iterate()) {
 			if (g->flags != GroupFlags{}) {
 				/* Convert old replace_protection value to flag. */
 				g->flags = GroupFlag::ReplaceProtection;
 			}
-			if (HasBit(wagon_removal, g->owner)) g->flags.Set(GroupFlag::ReplaceWagonRemoval);
+			if (wagon_removal.Test(g->owner)) g->flags.Set(GroupFlag::ReplaceWagonRemoval);
 		}
 	}
 

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -425,12 +425,12 @@ static bool FixTTOEngines()
 			e->duration_phase_3    = oe->duration_phase_3;
 			e->flags               = oe->flags;
 
-			e->company_avail = 0;
+			e->company_avail = CompanyMask{};
 
 			/* One or more engines were remapped to this one. Make this engine available
 			 * if at least one of them was available. */
 			for (uint j = 0; j < lengthof(tto_to_ttd); j++) {
-				if (tto_to_ttd[j] == i && _old_engines[j].company_avail != 0) {
+				if (tto_to_ttd[j] == i && _old_engines[j].company_avail.Any()) {
 					e->company_avail = std::numeric_limits<CompanyMask>::max();
 					e->flags.Set(EngineFlag::Available);
 					break;

--- a/src/script/api/script_enginelist.cpp
+++ b/src/script/api/script_enginelist.cpp
@@ -19,6 +19,6 @@ ScriptEngineList::ScriptEngineList(ScriptVehicle::VehicleType vehicle_type)
 	bool is_deity = ScriptCompanyMode::IsDeity();
 	::CompanyID owner = ScriptObject::GetCompany();
 	for (const Engine *e : Engine::IterateType((::VehicleType)vehicle_type)) {
-		if (is_deity || HasBit(e->company_avail, owner)) this->AddItem(e->index);
+		if (is_deity || e->company_avail.Test(owner)) this->AddItem(e->index);
 	}
 }

--- a/src/script/api/script_town.cpp
+++ b/src/script/api/script_town.cpp
@@ -214,7 +214,7 @@
 	EnforceCompanyModeValid(false);
 	if (!IsValidTown(town_id)) return false;
 
-	return ::HasBit(::Town::Get(town_id)->statues, ScriptObject::GetCompany());
+	return ::Town::Get(town_id)->statues.Test(ScriptObject::GetCompany());
 }
 
 /* static */ bool ScriptTown::IsCity(TownID town_id)
@@ -319,7 +319,7 @@
 
 	::CompanyID c = ScriptCompany::FromScriptCompanyID(company);
 	const Town *t = ::Town::Get(town_id);
-	if (!HasBit(t->have_ratings, c)) {
+	if (!t->have_ratings.Test(c)) {
 		return TOWN_RATING_NONE;
 	} else if (t->ratings[c] <= RATING_APPALLING) {
 		return TOWN_RATING_APPALLING;

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -724,7 +724,7 @@ protected:
 	 */
 	inline CompanyMask GetOverlayCompanyMask() const
 	{
-		return Company::IsValidID(_local_company) ? 1U << _local_company : std::numeric_limits<CompanyMask>::max();
+		return Company::IsValidID(_local_company) ? CompanyMask{}.Set(_local_company) : std::numeric_limits<CompanyMask>::max();
 	}
 
 	/** Blink the industries (if selected) on a regular interval. */

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -720,7 +720,7 @@ static CommandCost BuildStationPart(Station **st, DoCommandFlag flags, bool reus
 			(*st)->string_id = GenerateStationName(*st, area.tile, name_class);
 
 			if (Company::IsValidID(_current_company)) {
-				SetBit((*st)->town->have_ratings, _current_company);
+				(*st)->town->have_ratings.Set(_current_company);
 			}
 		}
 	}
@@ -3918,7 +3918,7 @@ static void UpdateStationRating(Station *st)
 				if (ge->max_waiting_cargo <= 100) rating += 10;
 			}
 
-			if (Company::IsValidID(st->owner) && HasBit(st->town->statues, st->owner)) rating += 26;
+			if (Company::IsValidID(st->owner) && st->town->statues.Test(st->owner)) rating += 26;
 
 			uint8_t age = ge->last_age;
 			if (age < 3) rating += 10;

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -151,7 +151,7 @@ static const int CTMN_SPECTATOR   = -3; ///< Show a company window as spectator
  * @param widget The button widget id.
  * @param grey A bitmask of which companies to mark as disabled.
  */
-static void PopupMainCompanyToolbMenu(Window *w, WidgetID widget, CompanyMask grey = 0)
+static void PopupMainCompanyToolbMenu(Window *w, WidgetID widget, CompanyMask grey = {})
 {
 	DropDownList list;
 
@@ -177,7 +177,7 @@ static void PopupMainCompanyToolbMenu(Window *w, WidgetID widget, CompanyMask gr
 
 	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
 		if (!Company::IsValidID(c)) continue;
-		list.push_back(std::make_unique<DropDownListCompanyItem>(c, HasBit(grey, c)));
+		list.push_back(std::make_unique<DropDownListCompanyItem>(c, grey.Test(c)));
 	}
 
 	PopupMainToolbarMenu(w, widget, std::move(list), _local_company == COMPANY_SPECTATOR ? (widget == WID_TN_COMPANIES ? CTMN_CLIENT_LIST : CTMN_SPECTATOR) : (int)_local_company);
@@ -571,7 +571,7 @@ static CallBackFunction MenuClickFinances(int index)
 
 static CallBackFunction ToolbarCompaniesClick(Window *w)
 {
-	PopupMainCompanyToolbMenu(w, WID_TN_COMPANIES, 0);
+	PopupMainCompanyToolbMenu(w, WID_TN_COMPANIES);
 	return CBF_NONE;
 }
 
@@ -607,7 +607,7 @@ static CallBackFunction MenuClickCompany(int index)
 
 static CallBackFunction ToolbarStoryClick(Window *w)
 {
-	PopupMainCompanyToolbMenu(w, WID_TN_STORY, 0);
+	PopupMainCompanyToolbMenu(w, WID_TN_STORY);
 	return CBF_NONE;
 }
 
@@ -627,7 +627,7 @@ static CallBackFunction MenuClickStory(int index)
 
 static CallBackFunction ToolbarGoalClick(Window *w)
 {
-	PopupMainCompanyToolbMenu(w, WID_TN_GOAL, 0);
+	PopupMainCompanyToolbMenu(w, WID_TN_GOAL);
 	return CBF_NONE;
 }
 
@@ -768,10 +768,10 @@ static CallBackFunction MenuClickIndustry(int index)
 
 static void ToolbarVehicleClick(Window *w, VehicleType veh)
 {
-	CompanyMask dis = 0;
+	CompanyMask dis{};
 
 	for (const Company *c : Company::Iterate()) {
-		if (c->group_all[veh].num_vehicle == 0) SetBit(dis, c->index);
+		if (c->group_all[veh].num_vehicle == 0) dis.Set(c->index);
 	}
 	PopupMainCompanyToolbMenu(w, WID_TN_VEHICLE_START + veh, dis);
 }

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2059,10 +2059,10 @@ static void DoCreateTown(Town *t, TileIndex tile, uint32_t townnameparts, TownSi
 
 	for (uint i = 0; i != MAX_COMPANIES; i++) t->ratings[i] = RATING_INITIAL;
 
-	t->have_ratings = 0;
+	t->have_ratings = {};
 	t->exclusivity = INVALID_COMPANY;
 	t->exclusive_counter = 0;
-	t->statues = 0;
+	t->statues = {};
 
 	{
 		TownNameParams tnp(_settings_game.game_creation.town_name);
@@ -3479,7 +3479,7 @@ static CommandCost TownActionBuildStatue(Town *t, DoCommandFlag flags)
 		Command<CMD_LANDSCAPE_CLEAR>::Do(DC_EXEC, statue_data.best_position);
 		cur_company.Restore();
 		BuildObject(OBJECT_STATUE, statue_data.best_position, _current_company, t);
-		SetBit(t->statues, _current_company); // Once found and built, "inform" the Town.
+		t->statues.Set(_current_company); // Once found and built, "inform" the Town.
 		MarkTileDirtyByTile(statue_data.best_position);
 	}
 	return CommandCost();
@@ -3649,7 +3649,7 @@ TownActions GetMaskOfTownActions(CompanyID cid, const Town *t)
 			if (cur == TACT_ROAD_REBUILD && !_settings_game.economy.fund_roads) continue;
 
 			/* Is the company not able to build a statue ? */
-			if (cur == TACT_BUILD_STATUE && HasBit(t->statues, cid)) continue;
+			if (cur == TACT_BUILD_STATUE && t->statues.Test(cid)) continue;
 
 			if (avail >= _town_action_costs[i] * _price[PR_TOWN_ACTION] >> 8) {
 				buttons |= cur;
@@ -4006,7 +4006,7 @@ void ChangeTownRating(Town *t, int add, int max, DoCommandFlag flags)
 	if (_town_rating_test) {
 		_town_test_ratings[t] = rating;
 	} else {
-		SetBit(t->have_ratings, _current_company);
+		t->have_ratings.Set(_current_company);
 		t->ratings[_current_company] = rating;
 		SetWindowDirty(WC_TOWN_AUTHORITY, t->index);
 	}

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -186,7 +186,7 @@ public:
 
 		/* Draw list of companies */
 		for (const Company *c : Company::Iterate()) {
-			if ((HasBit(this->town->have_ratings, c->index) || this->town->exclusivity == c->index)) {
+			if ((this->town->have_ratings.Test(c->index) || this->town->exclusivity == c->index)) {
 				DrawCompanyIcon(c->index, icon.left, text.top + icon_y_offset);
 
 				SetDParam(0, c->index);
@@ -793,8 +793,8 @@ private:
 		bool before = !order; // Value to get 'a' before 'b'.
 
 		/* Towns without rating are always after towns with rating. */
-		if (HasBit(a->have_ratings, _local_company)) {
-			if (HasBit(b->have_ratings, _local_company)) {
+		if (a->have_ratings.Test(_local_company)) {
+			if (b->have_ratings.Test(_local_company)) {
 				int16_t a_rating = a->ratings[_local_company];
 				int16_t b_rating = b->ratings[_local_company];
 				if (a_rating == b_rating) return TownDirectoryWindow::TownNameSorter(a, b, order);
@@ -802,7 +802,7 @@ private:
 			}
 			return before;
 		}
-		if (HasBit(b->have_ratings, _local_company)) return !before;
+		if (b->have_ratings.Test(_local_company)) return !before;
 
 		/* Sort unrated towns always on ascending town name. */
 		if (before) return TownDirectoryWindow::TownNameSorter(a, b, order);
@@ -881,7 +881,7 @@ public:
 					assert(t->xy != INVALID_TILE);
 
 					/* Draw rating icon. */
-					if (_game_mode == GM_EDITOR || !HasBit(t->have_ratings, _local_company)) {
+					if (_game_mode == GM_EDITOR || !t->have_ratings.Test(_local_company)) {
 						DrawSprite(SPR_TOWN_RATING_NA, PAL_NONE, icon_x, tr.top + (this->resize.step_height - icon_size.height) / 2);
 					} else {
 						SpriteID icon = SPR_TOWN_RATING_APALLING;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -227,7 +227,7 @@ bool Vehicle::NeedsServicing() const
 		EngineID new_engine = EngineReplacementForCompany(c, v->engine_type, v->group_id, &replace_when_old);
 
 		/* Check engine availability */
-		if (new_engine == INVALID_ENGINE || !HasBit(Engine::Get(new_engine)->company_avail, v->owner)) continue;
+		if (new_engine == INVALID_ENGINE || !Engine::Get(new_engine)->company_avail.Test(v->owner)) continue;
 		/* Is the vehicle old if we are not always replacing? */
 		if (replace_when_old && !v->NeedsAutorenewing(c, false)) continue;
 
@@ -1462,7 +1462,7 @@ void AgeVehicle(Vehicle *v)
 
 	const Company *c = Company::Get(v->owner);
 	/* Don't warn if a renew is active */
-	if (c->settings.engine_renew && v->GetEngine()->company_avail != 0) return;
+	if (c->settings.engine_renew && v->GetEngine()->company_avail.Any()) return;
 	/* Don't warn if a replacement is active */
 	if (EngineHasReplacementForCompany(c, v->engine_type, v->group_id)) return;
 
@@ -1945,7 +1945,7 @@ bool CanBuildVehicleInfrastructure(VehicleType type, uint8_t subtype)
 		/* Can we actually build the vehicle type? */
 		for (const Engine *e : Engine::IterateType(type)) {
 			if (type == VEH_ROAD && GetRoadTramType(e->u.road.roadtype) != (RoadTramType)subtype) continue;
-			if (HasBit(e->company_avail, _local_company)) return true;
+			if (e->company_avail.Test(_local_company)) return true;
 		}
 		return false;
 	}

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1840,7 +1840,7 @@ void ViewportDoDraw(const Viewport *vp, int left, int top, int right, int bottom
 	dp.height = UnScaleByZoom(dp.height, zoom);
 	_cur_dpi = &dp;
 
-	if (vp->overlay != nullptr && vp->overlay->GetCargoMask() != 0 && vp->overlay->GetCompanyMask() != 0) {
+	if (vp->overlay != nullptr && vp->overlay->GetCargoMask() != 0 && vp->overlay->GetCompanyMask().Any()) {
 		/* translate to window coordinates */
 		dp.left = x;
 		dp.top = y;
@@ -2507,7 +2507,7 @@ bool HandleViewportClicked(const Viewport *vp, int x, int y)
 void RebuildViewportOverlay(Window *w)
 {
 	if (w->viewport->overlay != nullptr &&
-			w->viewport->overlay->GetCompanyMask() != 0 &&
+			w->viewport->overlay->GetCompanyMask().Any() &&
 			w->viewport->overlay->GetCargoMask() != 0) {
 		w->viewport->overlay->SetDirty();
 		w->SetDirty();


### PR DESCRIPTION
## Motivation / Problem

For my project to make all `Pool` IDs strongly typed to reduce the chance of mismanaging things, `CompanyID` will become strongly typed. That makes `CompanyMask` cumbersome as you'll need `.base()` (or `static_cast`) for each and every `HasBit`/`SetBit`/`ToggleBit` etc, which in turn makes strongly typing `CompanyID` quite a big change.

Recently PeterN has been making enums stronger by using `enum class`, which also resulted in basically the same issues. For that `EnumBitSet` was introduced, which does basically all that would be needed for `CompanyMask`. `CompanyID` is currently even an enum.

However, it makes sense to keep `EnumBitSet` only for those cases where the enum actually enumerates everything, which isn't the case for `CompanyID` and one of the reasons why `CompanyID` should not be an enum in the future. That however means that a separate implementation must be made.


## Description

Extract the useful parts for a `BaseBitSet` from `EnumBitSet` and let `EnumBitSet` extend from that. Also introduce the `Any()` and `None()` functions that check for any or none of the bits being set, like `std::bitset` does.

Make `CompanyMask` extend from `BaseBitSet` and update all users.


## Limitations

The might be some hidden `CompanyMask`s, i.e. places that still use `uint16_t` over `CompanyMask`. Converting those is not part of this PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
