### PR TITLE
Codechange: introduce ReferenceThroughBaseContainer

### DIFF
--- a/src/core/convertible_through_base.hpp
+++ b/src/core/convertible_through_base.hpp
@@ -29,4 +29,18 @@ concept ConvertibleThroughBase = requires(T const a) {
 template <typename T, typename TTo>
 concept ConvertibleThroughBaseOrTo = std::is_convertible_v<T, TTo> || ConvertibleThroughBase<T>;
 
+/**
+ * A sort-of mixin that adds 'at(pos)' and 'operator[](pos)' implementations for 'ConvertibleThroughBase' types.
+ * This to prevent having to call '.base()' for many container accesses.
+ */
+template <typename Container>
+class ReferenceThroughBaseContainer : public Container {
+public:
+	Container::reference at(ConvertibleThroughBase auto pos) { return this->Container::at(pos.base()); }
+	Container::const_reference at(ConvertibleThroughBase auto pos) const { return this->Container::at(pos.base()); }
+
+	Container::reference operator[](ConvertibleThroughBase auto pos) { return this->Container::operator[](pos.base()); }
+	Container::const_reference operator[](ConvertibleThroughBase auto pos) const { return this->Container::operator[](pos.base()); }
+};
+
 #endif /* CONVERTIBLE_THROUGH_BASE_HPP */

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -318,7 +318,7 @@ GameStrings *_current_data = nullptr;
 const char *GetGameStringPtr(StringIndexInTab id)
 {
 	if (_current_data == nullptr || _current_data->cur_language == nullptr || id.base() >= _current_data->cur_language->lines.size()) return GetStringPtr(STR_UNDEFINED);
-	return _current_data->cur_language->lines[id.base()].c_str();
+	return _current_data->cur_language->lines[id].c_str();
 }
 
 /**
@@ -332,7 +332,7 @@ const StringParams &GetGameStringParams(StringIndexInTab id)
 	static StringParams empty;
 
 	if (id.base() >= _current_data->string_params.size()) return empty;
-	return _current_data->string_params[id.base()];
+	return _current_data->string_params[id];
 }
 
 /**
@@ -346,7 +346,7 @@ const std::string &GetGameStringName(StringIndexInTab id)
 	static const std::string undefined = "STR_UNDEFINED";
 
 	if (id.base() >= _current_data->string_names.size()) return undefined;
-	return _current_data->string_names[id.base()];
+	return _current_data->string_names[id];
 }
 
 /**

--- a/src/game/game_text.hpp
+++ b/src/game/game_text.hpp
@@ -38,7 +38,7 @@ void ReconsiderGameScriptLanguage();
 /** Container for the raw (unencoded) language strings of a language. */
 struct LanguageStrings {
 	std::string language; ///< Name of the language (base filename). Empty string if invalid.
-	StringList  lines;    ///< The lines of the file to pass into the parser/encoder.
+	ReferenceThroughBaseContainer<StringList> lines; ///< The lines of the file to pass into the parser/encoder.
 
 	LanguageStrings() {}
 	LanguageStrings(const std::string &lang) : language(lang) {}
@@ -55,8 +55,8 @@ struct GameStrings {
 
 	std::vector<LanguageStrings> raw_strings;      ///< The raw strings per language, first must be English/the master language!.
 	std::vector<LanguageStrings> compiled_strings; ///< The compiled strings per language, first must be English/the master language!.
-	StringList string_names;                       ///< The names of the compiled strings.
-	StringParamsList string_params;                ///< The parameters for the strings.
+	ReferenceThroughBaseContainer<StringList> string_names; ///< The names of the compiled strings.
+	ReferenceThroughBaseContainer<StringParamsList> string_params; ///< The parameters for the strings.
 
 	void Compile();
 

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -71,7 +71,7 @@ struct GRFTextEntry {
 };
 
 
-static std::vector<GRFTextEntry> _grf_text;
+static ReferenceThroughBaseContainer<std::vector<GRFTextEntry>> _grf_text;
 static uint8_t _currentLangID = GRFLX_ENGLISH;  ///< by default, english is used.
 
 /**
@@ -639,13 +639,13 @@ const char *GetGRFStringFromGRFText(const GRFTextWrapper &text)
 const char *GetGRFStringPtr(StringIndexInTab stringid)
 {
 	assert(stringid.base() < _grf_text.size());
-	assert(_grf_text[stringid.base()].grfid != 0);
+	assert(_grf_text[stringid].grfid != 0);
 
-	const char *str = GetGRFStringFromGRFText(_grf_text[stringid.base()].textholder);
+	const char *str = GetGRFStringFromGRFText(_grf_text[stringid].textholder);
 	if (str != nullptr) return str;
 
 	/* Use the default string ID if the fallback string isn't available */
-	return GetStringPtr(_grf_text[stringid.base()].def_string);
+	return GetStringPtr(_grf_text[stringid].def_string);
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

When making a Pool ID, for example `EngineID`, strongly typed in a way that does not automatically decay to `size_t`, then when you start accessing elements in containers (`std::vector`/`std::array`) you need to add a lot of calls to `.base()`.

At the moment `StringIndexInTab` is the only one that runs into this issue, but with `EngineID` and `CompanyID` there will be literally hundreds of extra `.base()` calls.


## Description

This adds  `ReferenceThroughBaseContainer` which extends a templated container, while implementing 'at(pos)' and 'operator[](pos)' versions for `ConvertibleThroughBase`.


## Limitations

The map array could use this treatment as well, but those are `std::unique_ptr` which isn't really a `Container`.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
