### PR TITLE
Codechange: change Source into a class with conversion helpers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -427,6 +427,7 @@ add_files(
     soundloader_type.h
     soundloader_raw.cpp
     soundloader_wav.cpp
+    source_type.h
     sprite.cpp
     sprite.h
     spritecache.cpp

--- a/src/cargo_type.h
+++ b/src/cargo_type.h
@@ -130,23 +130,4 @@ struct CargoArray : std::array<uint, NUM_CARGO> {
 	}
 };
 
-
-/** Types of cargo source and destination */
-enum class SourceType : uint8_t {
-	Industry,     ///< Source/destination is an industry
-	Town,         ///< Source/destination is a town
-	Headquarters, ///< Source/destination are company headquarters
-};
-
-typedef uint16_t SourceID; ///< Contains either industry ID, town ID or company ID (or INVALID_SOURCE)
-static const SourceID INVALID_SOURCE = 0xFFFF; ///< Invalid/unknown index of source
-
-/** A location from where cargo can come from (or go to). Specifically industries, towns and headquarters. */
-struct Source {
-	SourceID id; ///< Index of industry/town/HQ, INVALID_SOURCE if unknown/invalid.
-	SourceType type; ///< Type of \c source_id.
-
-	auto operator<=>(const Source &source) const = default;
-};
-
 #endif /* CARGO_TYPE_H */

--- a/src/cargomonitor.cpp
+++ b/src/cargomonitor.cpp
@@ -118,17 +118,17 @@ void AddCargoDelivery(CargoType cargo_type, CompanyID company, uint32_t amount, 
 {
 	if (amount == 0) return;
 
-	if (src.id != INVALID_SOURCE) {
+	if (src.IsValid()) {
 		/* Handle pickup update. */
 		switch (src.type) {
 			case SourceType::Industry: {
-				CargoMonitorID num = EncodeCargoIndustryMonitor(company, cargo_type, src.id);
+				CargoMonitorID num = EncodeCargoIndustryMonitor(company, cargo_type, src.ToIndustryID());
 				CargoMonitorMap::iterator iter = _cargo_pickups.find(num);
 				if (iter != _cargo_pickups.end()) iter->second += amount;
 				break;
 			}
 			case SourceType::Town: {
-				CargoMonitorID num = EncodeCargoTownMonitor(company, cargo_type, src.id);
+				CargoMonitorID num = EncodeCargoTownMonitor(company, cargo_type, src.ToTownID());
 				CargoMonitorMap::iterator iter = _cargo_pickups.find(num);
 				if (iter != _cargo_pickups.end()) iter->second += amount;
 				break;

--- a/src/cargopacket.cpp
+++ b/src/cargopacket.cpp
@@ -132,7 +132,7 @@ void CargoPacket::Reduce(uint count)
 /* static */ void CargoPacket::InvalidateAllFrom(Source src)
 {
 	for (CargoPacket *cp : CargoPacket::Iterate()) {
-		if (cp->source == src) cp->source.id = INVALID_SOURCE;
+		if (cp->source == src) cp->source.MakeInvalid();
 	}
 }
 

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -15,6 +15,7 @@
 #include "station_type.h"
 #include "order_type.h"
 #include "cargo_type.h"
+#include "source_type.h"
 #include "vehicle_type.h"
 #include "core/multimap.hpp"
 #include "saveload/saveload.h"
@@ -53,7 +54,7 @@ private:
 	TileIndex source_xy = INVALID_TILE; ///< The origin of the cargo.
 	Vector travelled{0, 0}; ///< If cargo is in station: the vector from the unload tile to the source tile. If in vehicle: an intermediate value.
 
-	Source source{INVALID_SOURCE, SourceType::Industry}; ///< Source of the cargo
+	Source source{Source::Invalid, SourceType::Industry}; ///< Source of the cargo
 
 #ifdef WITH_ASSERT
 	bool in_vehicle = false; ///< NOSAVE: Whether this cargo is in a vehicle or not.
@@ -504,9 +505,8 @@ public:
 	{
 		return cp1->source_xy == cp2->source_xy &&
 				cp1->periods_in_transit == cp2->periods_in_transit &&
-				cp1->source.type == cp2->source.type &&
 				cp1->first_station == cp2->first_station &&
-				cp1->source.id == cp2->source.id;
+				cp1->source == cp2->source;
 	}
 };
 

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1114,7 +1114,7 @@ static Money DeliverGoods(int num_pieces, CargoType cargo_type, StationID dest, 
 	Station *st = Station::Get(dest);
 
 	/* Give the goods to the industry. */
-	uint accepted_ind = DeliverGoodsToIndustry(st, cargo_type, num_pieces, src.type == SourceType::Industry ? src.id : INVALID_INDUSTRY, company->index);
+	uint accepted_ind = DeliverGoodsToIndustry(st, cargo_type, num_pieces, src.type == SourceType::Industry ? src.ToIndustryID() : INVALID_INDUSTRY, company->index);
 
 	/* If this cargo type is always accepted, accept all */
 	uint accepted_total = HasBit(st->always_accepted, cargo_type) ? num_pieces : accepted_ind;

--- a/src/economy_func.h
+++ b/src/economy_func.h
@@ -16,6 +16,7 @@
 #include "vehicle_type.h"
 #include "company_type.h"
 #include "settings_type.h"
+#include "source_type.h"
 #include "core/random_func.hpp"
 
 void ResetPriceBaseMultipliers();

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2280,19 +2280,19 @@ bool AfterLoadGame()
 					case TAE_MAIL:
 						/* Town -> Town */
 						s->src.type = s->dst.type = SourceType::Town;
-						if (Town::IsValidID(s->src.id) && Town::IsValidID(s->dst.id)) continue;
+						if (Town::IsValidID(s->src.ToTownID()) && Town::IsValidID(s->dst.ToTownID())) continue;
 						break;
 					case TAE_GOODS:
 					case TAE_FOOD:
 						/* Industry -> Town */
 						s->src.type = SourceType::Industry;
 						s->dst.type = SourceType::Town;
-						if (Industry::IsValidID(s->src.id) && Town::IsValidID(s->dst.id)) continue;
+						if (Industry::IsValidID(s->src.ToIndustryID()) && Town::IsValidID(s->dst.ToTownID())) continue;
 						break;
 					default:
 						/* Industry -> Industry */
 						s->src.type = s->dst.type = SourceType::Industry;
-						if (Industry::IsValidID(s->src.id) && Industry::IsValidID(s->dst.id)) continue;
+						if (Industry::IsValidID(s->src.ToIndustryID()) && Industry::IsValidID(s->dst.ToIndustryID())) continue;
 						break;
 				}
 			} else {
@@ -2310,8 +2310,8 @@ bool AfterLoadGame()
 						if (ss != nullptr && sd != nullptr && ss->owner == sd->owner &&
 								Company::IsValidID(ss->owner)) {
 							s->src.type = s->dst.type = SourceType::Town;
-							s->src.id = ss->town->index;
-							s->dst.id = sd->town->index;
+							s->src.SetIndex(ss->town->index);
+							s->dst.SetIndex(sd->town->index);
 							s->awarded = ss->owner;
 							continue;
 						}

--- a/src/script/api/script_subsidy.cpp
+++ b/src/script/api/script_subsidy.cpp
@@ -82,7 +82,7 @@
 
 /* static */ SQInteger ScriptSubsidy::GetSourceIndex(SubsidyID subsidy_id)
 {
-	if (!IsValidSubsidy(subsidy_id)) return INVALID_SOURCE;
+	if (!IsValidSubsidy(subsidy_id)) return Source::Invalid;
 
 	return ::Subsidy::Get(subsidy_id)->src.id;
 }
@@ -96,7 +96,7 @@
 
 /* static */ SQInteger ScriptSubsidy::GetDestinationIndex(SubsidyID subsidy_id)
 {
-	if (!IsValidSubsidy(subsidy_id)) return INVALID_SOURCE;
+	if (!IsValidSubsidy(subsidy_id)) return Source::Invalid;
 
 	return ::Subsidy::Get(subsidy_id)->dst.id;
 }

--- a/src/source_type.h
+++ b/src/source_type.h
@@ -1,0 +1,48 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file source_type.h Type for the source of cargo. */
+
+#ifndef SOURCE_TYPE_H
+#define SOURCE_TYPE_H
+
+#include "company_type.h"
+#include "industry_type.h"
+#include "town_type.h"
+
+/** Types of cargo source and destination */
+enum class SourceType : uint8_t {
+	Industry = 0, ///< Source/destination is an industry
+	Town = 1, ///< Source/destination is a town
+	Headquarters = 2, ///< Source/destination are company headquarters
+};
+
+using SourceID = uint16_t; ///< Contains either industry ID, town ID or company ID (or Source::Invalid)
+static_assert(sizeof(SourceID) >= sizeof(CompanyID));
+static_assert(sizeof(SourceID) >= sizeof(IndustryID));
+static_assert(sizeof(SourceID) >= sizeof(TownID));
+
+/** A location from where cargo can come from (or go to). Specifically industries, towns and headquarters. */
+struct Source {
+public:
+	static constexpr SourceID Invalid = 0xFFFF; ///< Invalid/unknown index of source
+
+	SourceID id; ///< Index of industry/town/HQ, Source::Invalid if unknown/invalid.
+	SourceType type; ///< Type of \c source_id.
+
+	constexpr CompanyID ToCompanyID() const { assert(this->type == SourceType::Headquarters); return static_cast<CompanyID>(this->id); }
+	constexpr IndustryID ToIndustryID() const { assert(this->type == SourceType::Industry); return static_cast<IndustryID>(this->id); }
+	constexpr TownID ToTownID() const { assert(this->type == SourceType::Town); return static_cast<TownID>(this->id); }
+
+	constexpr void MakeInvalid() { this->id = Source::Invalid; }
+	constexpr void SetIndex(SourceID index) { this->id = index; }
+
+	constexpr bool IsValid() const noexcept { return this->id != Source::Invalid; }
+	auto operator<=>(const Source &source) const = default;
+};
+
+#endif /* SOURCE_TYPE_H */

--- a/src/subsidy_base.h
+++ b/src/subsidy_base.h
@@ -12,6 +12,7 @@
 
 #include "cargo_type.h"
 #include "company_type.h"
+#include "source_type.h"
 #include "subsidy_type.h"
 #include "core/pool_type.hpp"
 

--- a/src/subsidy_cmd.h
+++ b/src/subsidy_cmd.h
@@ -12,6 +12,7 @@
 
 #include "command_type.h"
 #include "cargo_type.h"
+#include "source_type.h"
 #include "misc/endian_buffer.hpp"
 
 CommandCost CmdCreateSubsidy(DoCommandFlag flags, CargoType cargo_type, Source src, Source dst);

--- a/src/subsidy_gui.cpp
+++ b/src/subsidy_gui.cpp
@@ -83,8 +83,8 @@ struct SubsidyListWindow : Window {
 		/* determine src coordinate for subsidy and try to scroll to it */
 		TileIndex xy;
 		switch (s->src.type) {
-			case SourceType::Industry: xy = Industry::Get(s->src.id)->location.tile; break;
-			case SourceType::Town:     xy =     Town::Get(s->src.id)->xy; break;
+			case SourceType::Industry: xy = Industry::Get(s->src.ToIndustryID())->location.tile; break;
+			case SourceType::Town:     xy =     Town::Get(s->src.ToTownID())->xy; break;
 			default: NOT_REACHED();
 		}
 
@@ -93,8 +93,8 @@ struct SubsidyListWindow : Window {
 
 			/* otherwise determine dst coordinate for subsidy and scroll to it */
 			switch (s->dst.type) {
-				case SourceType::Industry: xy = Industry::Get(s->dst.id)->location.tile; break;
-				case SourceType::Town:     xy =     Town::Get(s->dst.id)->xy; break;
+				case SourceType::Industry: xy = Industry::Get(s->dst.ToIndustryID())->location.tile; break;
+				case SourceType::Town:     xy =     Town::Get(s->dst.ToTownID())->xy; break;
 				default: NOT_REACHED();
 			}
 


### PR DESCRIPTION
## Motivation / Problem

Make `Source` behave like `DestinationID`, making the conversion to strongly typed pool IDs simpler.


## Description

Move `Source` to its own file. Add `ToIndustryID`, `ToCompanyID` and `ToTownID` accessors, as well as a `SetIndex`.

Hide most of the implementation details of making a `Source` invalid, i.e. add `IsValid` and `MakeInvalid`.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
