### PR TITLE
Codefix 043d1ac: [Win32] Restore virtual destructor of StreamingVoiceContext

### DIFF
--- a/src/sound/xaudio2_s.cpp
+++ b/src/sound/xaudio2_s.cpp
@@ -57,6 +57,8 @@ public:
 		this->buffer.resize(buffer_length);
 	}
 
+	virtual ~StreamingVoiceContext() = default;
+
 	HRESULT SubmitBuffer()
 	{
 		// Ensure we do have a valid voice


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
https://github.com/OpenTTD/OpenTTD/commit/043d1ac111ffb3ec62e3bcd263f1294726a7389e removed the virtual destructor of `StreamingVoiceContext` and `clang-cl` doesn't like that:
```
12:02:00:375	  [629/839] Building CXX object CMakeFiles\openttd_lib.dir\src\sound\xaudio2_s.cpp.obj
12:02:00:376	  In file included from <built-in>:1:
12:02:00:376	  In file included from E:\OpenTTD Visual Studio\SamuXarick\OpenTTD\out\build\x64-Clang-Release\CMakeFiles\openttd_lib.dir\cmake_pch.hxx:5:
12:02:00:377	  In file included from E:\OpenTTD Visual Studio\SamuXarick\OpenTTD\src\stdafx.h:64:
12:02:00:378	C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.41.34120\include\memory(3302,9): warning : delete called on non-final 'StreamingVoiceContext' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
12:02:00:378	   3302 |         delete _Ptr;
12:02:00:378	        |         ^
12:02:00:379	  C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.41.34120\include\memory(3412,13): note: in instantiation of member function 'std::default_delete<StreamingVoiceContext>::operator()' requested here
12:02:00:379	   3412 |             _Mypair._Get_first()(_Mypair._Myval2);
12:02:00:379	        |             ^
12:02:02:424	  E:\OpenTTD Visual Studio\SamuXarick\OpenTTD\src\sound\xaudio2_s.cpp(110,47): note: in instantiation of member function 'std::unique_ptr<StreamingVoiceContext>::~unique_ptr' requested here
12:02:02:424	    110 | static std::unique_ptr<StreamingVoiceContext> _voice_context;
12:02:02:424	        |                                               ^
12:02:02:424	  1 warning generated.
```
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Restore the virtual destructor.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
