### PR TITLE
Codechange: Change internal format of encoded strings to improve robustness and allow expansion.

### DIFF
--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -397,6 +397,8 @@ enum SaveLoadVersion : uint16_t {
 	SLV_INCREASE_HOUSE_LIMIT,               ///< 348  PR#12288 Increase house limit to 4096.
 	SLV_COMPANY_INAUGURATED_PERIOD_V2,      ///< 349  PR#13448 Fix savegame storage for company inaugurated year in wallclock mode.
 
+	SLV_ENCODED_STRING_FORMAT,              ///< 350  PR#13499 Encoded String format changed.
+
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
 

--- a/src/script/api/script_text.cpp
+++ b/src/script/api/script_text.cpp
@@ -197,16 +197,26 @@ void ScriptText::ParamCheck::Encode(std::back_insert_iterator<std::string> &outp
 	struct visitor {
 		std::back_insert_iterator<std::string> &output;
 
-		void operator()(const std::string &value) { fmt::format_to(this->output, ":\"{}\"", value); }
-		void operator()(const SQInteger &value) { fmt::format_to(this->output, ":{:X}", value); }
+		void operator()(const std::string &value)
+		{
+			Utf8Encode(this->output, SCC_ENCODED_STRING);
+			fmt::format_to(this->output, "{}", value);
+		}
+
+		void operator()(const SQInteger &value)
+		{
+			Utf8Encode(this->output, SCC_ENCODED_NUMERIC);
+			fmt::format_to(this->output, "{:X}", value);
+		}
+
 		void operator()(const ScriptTextRef &value)
 		{
-			fmt::format_to(this->output, ":");
 			Utf8Encode(this->output, SCC_ENCODED);
 			fmt::format_to(this->output, "{:X}", value->string);
 		}
 	};
 
+	*output = SCC_RECORD_SEPARATOR;
 	std::visit(visitor{output}, *this->param);
 	this->used = true;
 }

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -90,6 +90,24 @@ std::string FormatArrayAsHex(std::span<const uint8_t> data)
 	return str;
 }
 
+/**
+ * Test if a character is (only) part of an encoded string.
+ * @param c Character to test.
+ * @returns True iff the character is an encoded string control code.
+ */
+static bool IsSccEncodedCode(char32_t c)
+{
+	switch (c) {
+		case SCC_RECORD_SEPARATOR:
+		case SCC_ENCODED:
+		case SCC_ENCODED_NUMERIC:
+		case SCC_ENCODED_STRING:
+			return true;
+
+		default:
+			return false;
+	}
+}
 
 /**
  * Copies the valid (UTF-8) characters from \c str up to \c last to the \c dst.
@@ -140,7 +158,7 @@ static void StrMakeValid(T &dst, const char *str, const char *last, StringValida
 			continue;
 		}
 
-		if ((IsPrintable(c) && (c < SCC_SPRITE_START || c > SCC_SPRITE_END)) || ((settings & SVS_ALLOW_CONTROL_CODE) != 0 && c == SCC_ENCODED)) {
+		if ((IsPrintable(c) && (c < SCC_SPRITE_START || c > SCC_SPRITE_END)) || ((settings & SVS_ALLOW_CONTROL_CODE) != 0 && IsSccEncodedCode(c))) {
 			/* Copy the character back. Even if dst is current the same as str
 			 * (i.e. no characters have been changed) this is quicker than
 			 * moving the pointers ahead by len */

--- a/src/table/control_codes.h
+++ b/src/table/control_codes.h
@@ -15,14 +15,19 @@
  * by strgen to generate the language files.
  */
 enum StringControlCode : uint16_t {
+	SCC_RECORD_SEPARATOR = 0x1E,
+
 	SCC_CONTROL_START = 0xE000,
 	SCC_CONTROL_END   = 0xE1FF,
 
 	SCC_SPRITE_START  = 0xE200,
 	SCC_SPRITE_END    = SCC_SPRITE_START + 0xFF,
 
-	/* This must be the first entry. It's encoded in strings that are saved. */
-	SCC_ENCODED = SCC_CONTROL_START,
+	/* All SCC_ENCODED* control codes must have stable ids are they are stored in strings that are saved in savegames. */
+	SCC_ENCODED = SCC_CONTROL_START, ///< Encoded string marker and sub-string parameter.
+	SCC_ENCODED_RESERVED, ///< Reserved for future non-GS encoded strings.
+	SCC_ENCODED_NUMERIC, ///< Encoded numeric parameter.
+	SCC_ENCODED_STRING, ///< Encoded string parameter.
 
 	/* Font selection codes, must be in same order as FontSize enum */
 	SCC_FIRST_FONT,

--- a/src/tests/string_func.cpp
+++ b/src/tests/string_func.cpp
@@ -12,6 +12,7 @@
 #include "../3rdparty/catch2/catch.hpp"
 
 #include "../string_func.h"
+#include "../table/control_codes.h"
 
 /**** String compare/equals *****/
 
@@ -408,3 +409,67 @@ TEST_CASE("StrTrimView") {
 	}
 }
 
+extern void FixSCCEncoded(std::string &str, bool fix_code);
+
+/* Helper to call FixSCCEncoded and return the result in a new string. */
+static std::string FixSCCEncodedWrapper(const std::string &str, bool fix_code)
+{
+	std::string result = str;
+	FixSCCEncoded(result, fix_code);
+	return result;
+}
+
+/* Helper to compose a string part from a unicode character */
+static void ComposePart(std::back_insert_iterator<std::string> &output, char32_t c)
+{
+	Utf8Encode(output, c);
+}
+
+/* Helper to compose a string part from a string. */
+static void ComposePart(std::back_insert_iterator<std::string> &output, const std::string &value)
+{
+	for (const auto &c : value) *output = c;
+}
+
+/* Helper to compose a string from unicde or string parts. */
+template <typename... Args>
+static std::string Compose(Args &&... args)
+{
+	std::string result;
+	auto output = std::back_inserter(result);
+	(ComposePart(output, args), ...);
+	return result;
+}
+
+TEST_CASE("FixSCCEncoded")
+{
+	/* Test conversion of empty string. */
+	CHECK(FixSCCEncodedWrapper("", false) == "");
+
+	/* Test conversion of old code to new code. */
+	CHECK(FixSCCEncodedWrapper("\uE0280", true) == Compose(SCC_ENCODED, "0"));
+
+	/* Test conversion of two old codes to new codes. */
+	CHECK(FixSCCEncodedWrapper("\uE0280:\uE0281", true) == Compose(SCC_ENCODED, "0", SCC_RECORD_SEPARATOR, SCC_ENCODED, "1"));
+
+	/* Test conversion with no parameter. */
+	CHECK(FixSCCEncodedWrapper("\uE0001", false) == Compose(SCC_ENCODED, "1"));
+
+	/* Test conversion with one numeric parameter. */
+	CHECK(FixSCCEncodedWrapper("\uE00022:1", false) == Compose(SCC_ENCODED, "22", SCC_RECORD_SEPARATOR, SCC_ENCODED_NUMERIC, "1"));
+
+	/* Test conversion with two numeric parameters. */
+	CHECK(FixSCCEncodedWrapper("\uE0003:12:2", false) == Compose(SCC_ENCODED, "3", SCC_RECORD_SEPARATOR, SCC_ENCODED_NUMERIC, "12", SCC_RECORD_SEPARATOR, SCC_ENCODED_NUMERIC, "2"));
+
+	/* Test conversion with one string parameter. */
+	CHECK(FixSCCEncodedWrapper("\uE0004:\"Foo\"", false) == Compose(SCC_ENCODED, "4", SCC_RECORD_SEPARATOR, SCC_ENCODED_STRING, "Foo"));
+
+	/* Test conversion with two string parameters. */
+	CHECK(FixSCCEncodedWrapper("\uE00055:\"Foo\":\"Bar\"", false) == Compose(SCC_ENCODED, "55", SCC_RECORD_SEPARATOR, SCC_ENCODED_STRING, "Foo", SCC_RECORD_SEPARATOR, SCC_ENCODED_STRING, "Bar"));
+
+	/* Test conversion with two string parameters surrounding a numeric parameter. */
+	CHECK(FixSCCEncodedWrapper("\uE0006:\"Foo\":7CA:\"Bar\"", false) == Compose(SCC_ENCODED, "6", SCC_RECORD_SEPARATOR, SCC_ENCODED_STRING, "Foo", SCC_RECORD_SEPARATOR, SCC_ENCODED_NUMERIC, "7CA", SCC_RECORD_SEPARATOR, SCC_ENCODED_STRING, "Bar"));
+
+	/* Test conversion with one sub-string and two string parameters. */
+	CHECK(FixSCCEncodedWrapper("\uE000777:\uE0008888:\"Foo\":\"BarBaz\"", false) == Compose(SCC_ENCODED, "777", SCC_RECORD_SEPARATOR, SCC_ENCODED, "8888", SCC_RECORD_SEPARATOR, SCC_ENCODED_STRING, "Foo", SCC_RECORD_SEPARATOR, SCC_ENCODED_STRING, "BarBaz"));
+}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

While adapting GameScript encoded strings to be used internally, I realised that when encoded, strings are not sufficiently escaped, and it is possible to inject parameters by composing a string with double-quote characters in it.

Additionally, decoding for strings is quite fragile, as it tries to handle escaped double-quotes, but fails because 1) they are never escaped properly in the first place 2) they are not unescaped properly when detected.

The current encoding is very simple. Parameters are separated by colons, and strings are wrapped in double-quotes. An encoded string with three parameters, string, number and finally string, should look like:

`E000<HEX>:"<STRING>":<HEX>:"<STRING>"`

This breaks down because no attempt is made to escape strings provided by scripts.

Fine: `GSText(0, "Foo", 1, "Bar")` => `E0000:"Foo":1:"Bar"`
Error: `GSTest(0, "Foo\"", 1, "\"Bar")` => `E000:"Foo"":1:""Bar"`
Oh dear: `GSTest(0, "Foo\":2:\"", 1, ":\"Bar")` => `E000:"Foo":2:":1:":"Bar"`

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead of trying to fix the escaping I decided to take a different approach and change the encoding scheme to not require escaping.

This is achieved by using a low-ASCII Record Separator character (0x1E) to separate parameters instead of a colon, and encoding an additional parameter type character into the string.

Encoding a string is not much different, only the separator is changed and the parameter type is encoded. Strings were not escaped before, and don't need to be escaped now, so that stays the same.

Decoded an encoded string is now much simpler, as we only have to search for Record Separator characters, decode the parameter type, and then the remaining data is the parameter itself.

Because GameScript strings are stored in savegames, this change requires a savegame conversion from old to new format. This is probably the most fiddly part, so there is a unit test for it. This doesn't attempt to match the original decoding behaviour as the escaping never worked in the first place.

[RS] is 0x1E
[NUMERIC] is \uE002
[STRING] is \uE003

Fine: `GSText(0, "Foo", 1, "Bar")` => `[E000]0[RS][STRING]Foo[RS][NUMERIC]1[RS][STRING]Bar`
Fine: `GSTest(0, "Foo\"", 1, "\"Bar")` => `[E000]0[RS][STRING]Foo"[RS][NUMERIC]1[RS][STRING]"Bar`
Fine: `GSTest(0, "Foo\":2:\"", 1, ":\"Bar")` => `[E000]0[RS][STRING]Foo":2:"[RS][NUMERIC]1[RS][STRING]:"Bar`

Elephant in the room: You can't encode a string with an [RS] character in it. But that can't really happen anyway as `StrMakeValid()` will strip this already.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

The new format does string slightly longer encoding for strings compared to the existing old format.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
