### PR TITLE
Codechange: [Script] Use helper function over direct casting CompanyID

### DIFF
--- a/src/script/api/script_cargomonitor.cpp
+++ b/src/script/api/script_cargomonitor.cpp
@@ -17,7 +17,7 @@
 
 /* static */ SQInteger ScriptCargoMonitor::GetTownDeliveryAmount(ScriptCompany::CompanyID company, CargoType cargo, TownID town_id, bool keep_monitoring)
 {
-	CompanyID cid = static_cast<CompanyID>(company);
+	::CompanyID cid = ScriptCompany::FromScriptCompanyID(ScriptCompany::ResolveCompanyID((company)));
 	if (cid >= MAX_COMPANIES) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo)) return -1;
 	if (!::Town::IsValidID(town_id)) return -1;
@@ -28,7 +28,7 @@
 
 /* static */ SQInteger ScriptCargoMonitor::GetIndustryDeliveryAmount(ScriptCompany::CompanyID company, CargoType cargo, IndustryID industry_id, bool keep_monitoring)
 {
-	CompanyID cid = static_cast<CompanyID>(company);
+	::CompanyID cid = ScriptCompany::FromScriptCompanyID(ScriptCompany::ResolveCompanyID((company)));
 	if (cid >= MAX_COMPANIES) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo)) return -1;
 	if (!::Industry::IsValidID(industry_id)) return -1;
@@ -39,7 +39,7 @@
 
 /* static */ SQInteger ScriptCargoMonitor::GetTownPickupAmount(ScriptCompany::CompanyID company, CargoType cargo, TownID town_id, bool keep_monitoring)
 {
-	CompanyID cid = static_cast<CompanyID>(company);
+	::CompanyID cid = ScriptCompany::FromScriptCompanyID(ScriptCompany::ResolveCompanyID((company)));
 	if (cid >= MAX_COMPANIES) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo)) return -1;
 	if (!::Town::IsValidID(town_id)) return -1;
@@ -50,7 +50,7 @@
 
 /* static */ SQInteger ScriptCargoMonitor::GetIndustryPickupAmount(ScriptCompany::CompanyID company, CargoType cargo, IndustryID industry_id, bool keep_monitoring)
 {
-	CompanyID cid = static_cast<CompanyID>(company);
+	::CompanyID cid = ScriptCompany::FromScriptCompanyID(ScriptCompany::ResolveCompanyID((company)));
 	if (cid >= MAX_COMPANIES) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo)) return -1;
 	if (!::Industry::IsValidID(industry_id)) return -1;

--- a/src/script/api/script_client.cpp
+++ b/src/script/api/script_client.cpp
@@ -43,7 +43,7 @@ static NetworkClientInfo *FindClientInfo(ScriptClient::ClientID client)
 {
 	NetworkClientInfo *ci = FindClientInfo(client);
 	if (ci == nullptr) return ScriptCompany::COMPANY_INVALID;
-	return (ScriptCompany::CompanyID)ci->client_playas;
+	return ScriptCompany::ToScriptCompanyID(ci->client_playas);
 }
 
 /* static */ ScriptDate::Date ScriptClient::GetJoinDate(ScriptClient::ClientID client)

--- a/src/script/api/script_clientlist.cpp
+++ b/src/script/api/script_clientlist.cpp
@@ -26,13 +26,13 @@ ScriptClientList::ScriptClientList()
 ScriptClientList_Company::ScriptClientList_Company(ScriptCompany::CompanyID company)
 {
 	if (!_networking) return;
-	CompanyID c;
+	::CompanyID c;
 	if (company == ScriptCompany::COMPANY_SPECTATOR) {
 		c = ::COMPANY_SPECTATOR;
 	} else {
 		company = ScriptCompany::ResolveCompanyID(company);
 		if (company == ScriptCompany::COMPANY_INVALID) return;
-		c = (CompanyID)company;
+		c = ScriptCompany::FromScriptCompanyID(company);
 	}
 
 	for (const NetworkClientInfo *ci : NetworkClientInfo::Iterate()) {

--- a/src/script/api/script_company.cpp
+++ b/src/script/api/script_company.cpp
@@ -28,20 +28,35 @@
 
 #include "../../safeguards.h"
 
+/* static */ ::CompanyID ScriptCompany::FromScriptCompanyID(ScriptCompany::CompanyID company)
+{
+	/* If this assert gets triggered, then ScriptCompany::ResolveCompanyID needed to be called before. */
+	assert(company != ScriptCompany::COMPANY_SELF && company != ScriptCompany::COMPANY_SPECTATOR);
+
+	if (company == ScriptCompany::COMPANY_INVALID) return ::INVALID_COMPANY;
+	return static_cast<::CompanyID>(company);
+}
+
+/* static */ ScriptCompany::CompanyID ScriptCompany::ToScriptCompanyID(::CompanyID company)
+{
+	if (company == ::INVALID_COMPANY) return ScriptCompany::COMPANY_INVALID;
+	return static_cast<::ScriptCompany::CompanyID>(company);
+}
+
 /* static */ ScriptCompany::CompanyID ScriptCompany::ResolveCompanyID(ScriptCompany::CompanyID company)
 {
-	if (company == COMPANY_SELF) {
-		if (!::Company::IsValidID(_current_company)) return COMPANY_INVALID;
-		return (CompanyID)((uint8_t)_current_company);
+	if (company == ScriptCompany::COMPANY_SELF) {
+		if (!::Company::IsValidID(_current_company)) return ScriptCompany::COMPANY_INVALID;
+		return ScriptCompany::ToScriptCompanyID(_current_company);
 	}
 
-	return ::Company::IsValidID(company) ? company : COMPANY_INVALID;
+	return ::Company::IsValidID(ScriptCompany::FromScriptCompanyID(company)) ? company : ScriptCompany::COMPANY_INVALID;
 }
 
 /* static */ bool ScriptCompany::IsMine(ScriptCompany::CompanyID company)
 {
 	EnforceCompanyModeValid(false);
-	return ResolveCompanyID(company) == ResolveCompanyID(COMPANY_SELF);
+	return ResolveCompanyID(company) == ResolveCompanyID(ScriptCompany::COMPANY_SELF);
 }
 
 /* static */ bool ScriptCompany::SetName(Text *name)
@@ -60,9 +75,9 @@
 /* static */ std::optional<std::string> ScriptCompany::GetName(ScriptCompany::CompanyID company)
 {
 	company = ResolveCompanyID(company);
-	if (company == COMPANY_INVALID) return std::nullopt;
+	if (company == ScriptCompany::COMPANY_INVALID) return std::nullopt;
 
-	::SetDParam(0, company);
+	::SetDParam(0, ScriptCompany::FromScriptCompanyID(company));
 	return GetString(STR_COMPANY_NAME);
 }
 
@@ -82,9 +97,9 @@
 /* static */ std::optional<std::string> ScriptCompany::GetPresidentName(ScriptCompany::CompanyID company)
 {
 	company = ResolveCompanyID(company);
-	if (company == COMPANY_INVALID) return std::nullopt;
+	if (company == ScriptCompany::COMPANY_INVALID) return std::nullopt;
 
-	::SetDParam(0, company);
+	::SetDParam(0, ScriptCompany::FromScriptCompanyID(company));
 	return GetString(STR_PRESIDENT_NAME);
 }
 
@@ -102,124 +117,124 @@
 	return ScriptObject::Command<CMD_SET_COMPANY_MANAGER_FACE>::Do(cmf);
 }
 
-/* static */ ScriptCompany::Gender ScriptCompany::GetPresidentGender(CompanyID company)
+/* static */ ScriptCompany::Gender ScriptCompany::GetPresidentGender(ScriptCompany::CompanyID company)
 {
 	company = ResolveCompanyID(company);
-	if (company == COMPANY_INVALID) return GENDER_INVALID;
+	if (company == ScriptCompany::COMPANY_INVALID) return GENDER_INVALID;
 
-	GenderEthnicity ge = (GenderEthnicity)GetCompanyManagerFaceBits(Company::Get(company)->face, CMFV_GEN_ETHN, GE_WM);
+	GenderEthnicity ge = (GenderEthnicity)GetCompanyManagerFaceBits(Company::Get(ScriptCompany::FromScriptCompanyID(company))->face, CMFV_GEN_ETHN, GE_WM);
 	return HasBit(ge, ::GENDER_FEMALE) ? GENDER_FEMALE : GENDER_MALE;
 }
 
 /* static */ Money ScriptCompany::GetQuarterlyIncome(ScriptCompany::CompanyID company, SQInteger quarter)
 {
 	company = ResolveCompanyID(company);
-	if (company == COMPANY_INVALID) return -1;
+	if (company == ScriptCompany::COMPANY_INVALID) return -1;
 	if (quarter > EARLIEST_QUARTER) return -1;
 	if (quarter < CURRENT_QUARTER) return -1;
 
 	if (quarter == CURRENT_QUARTER) {
-		return ::Company::Get(company)->cur_economy.income;
+		return ::Company::Get(ScriptCompany::FromScriptCompanyID(company))->cur_economy.income;
 	}
-	return ::Company::Get(company)->old_economy[quarter - 1].income;
+	return ::Company::Get(ScriptCompany::FromScriptCompanyID(company))->old_economy[quarter - 1].income;
 }
 
 /* static */ Money ScriptCompany::GetQuarterlyExpenses(ScriptCompany::CompanyID company, SQInteger quarter)
 {
 	company = ResolveCompanyID(company);
-	if (company == COMPANY_INVALID) return -1;
+	if (company == ScriptCompany::COMPANY_INVALID) return -1;
 	if (quarter > EARLIEST_QUARTER) return -1;
 	if (quarter < CURRENT_QUARTER) return -1;
 
 	if (quarter == CURRENT_QUARTER) {
-		return ::Company::Get(company)->cur_economy.expenses;
+		return ::Company::Get(ScriptCompany::FromScriptCompanyID(company))->cur_economy.expenses;
 	}
-	return ::Company::Get(company)->old_economy[quarter - 1].expenses;
+	return ::Company::Get(ScriptCompany::FromScriptCompanyID(company))->old_economy[quarter - 1].expenses;
 }
 
 /* static */ SQInteger ScriptCompany::GetQuarterlyCargoDelivered(ScriptCompany::CompanyID company, SQInteger quarter)
 {
 	company = ResolveCompanyID(company);
-	if (company == COMPANY_INVALID) return -1;
+	if (company == ScriptCompany::COMPANY_INVALID) return -1;
 	if (quarter > EARLIEST_QUARTER) return -1;
 	if (quarter < CURRENT_QUARTER) return -1;
 
 	if (quarter == CURRENT_QUARTER) {
-		return ::Company::Get(company)->cur_economy.delivered_cargo.GetSum<OverflowSafeInt32>();
+		return ::Company::Get(ScriptCompany::FromScriptCompanyID(company))->cur_economy.delivered_cargo.GetSum<OverflowSafeInt32>();
 	}
-	return ::Company::Get(company)->old_economy[quarter - 1].delivered_cargo.GetSum<OverflowSafeInt32>();
+	return ::Company::Get(ScriptCompany::FromScriptCompanyID(company))->old_economy[quarter - 1].delivered_cargo.GetSum<OverflowSafeInt32>();
 }
 
 /* static */ SQInteger ScriptCompany::GetQuarterlyPerformanceRating(ScriptCompany::CompanyID company, SQInteger quarter)
 {
 	company = ResolveCompanyID(company);
-	if (company == COMPANY_INVALID) return -1;
+	if (company == ScriptCompany::COMPANY_INVALID) return -1;
 	if (quarter > EARLIEST_QUARTER) return -1;
 	if (quarter <= CURRENT_QUARTER) return -1;
 
-	return ::Company::Get(company)->old_economy[quarter - 1].performance_history;
+	return ::Company::Get(ScriptCompany::FromScriptCompanyID(company))->old_economy[quarter - 1].performance_history;
 }
 
 /* static */ Money ScriptCompany::GetQuarterlyCompanyValue(ScriptCompany::CompanyID company, SQInteger quarter)
 {
 	company = ResolveCompanyID(company);
-	if (company == COMPANY_INVALID) return -1;
+	if (company == ScriptCompany::COMPANY_INVALID) return -1;
 	if (quarter > EARLIEST_QUARTER) return -1;
 	if (quarter < CURRENT_QUARTER) return -1;
 
 	if (quarter == CURRENT_QUARTER) {
-		return ::CalculateCompanyValue(::Company::Get(company));
+		return ::CalculateCompanyValue(::Company::Get(ScriptCompany::FromScriptCompanyID(company)));
 	}
-	return ::Company::Get(company)->old_economy[quarter - 1].company_value;
+	return ::Company::Get(ScriptCompany::FromScriptCompanyID(company))->old_economy[quarter - 1].company_value;
 }
 
 
 /* static */ Money ScriptCompany::GetBankBalance(ScriptCompany::CompanyID company)
 {
 	company = ResolveCompanyID(company);
-	if (company == COMPANY_INVALID) return -1;
+	if (company == ScriptCompany::COMPANY_INVALID) return -1;
 	/* If we return INT64_MAX as usual, overflows may occur in the script. So return a smaller value. */
 	if (_settings_game.difficulty.infinite_money) return INT32_MAX;
 
-	return GetAvailableMoney((::CompanyID)company);
+	return GetAvailableMoney(ScriptCompany::FromScriptCompanyID(company));
 }
 
 /* static */ Money ScriptCompany::GetLoanAmount()
 {
-	ScriptCompany::CompanyID company = ResolveCompanyID(COMPANY_SELF);
-	if (company == COMPANY_INVALID) return -1;
+	ScriptCompany::CompanyID company = ResolveCompanyID(ScriptCompany::COMPANY_SELF);
+	if (company == ScriptCompany::COMPANY_INVALID) return -1;
 
-	return ::Company::Get(company)->current_loan;
+	return ::Company::Get(ScriptCompany::FromScriptCompanyID(company))->current_loan;
 }
 
 /* static */ Money ScriptCompany::GetMaxLoanAmount()
 {
 	if (ScriptCompanyMode::IsDeity()) return _economy.max_loan;
 
-	ScriptCompany::CompanyID company = ResolveCompanyID(COMPANY_SELF);
-	if (company == COMPANY_INVALID) return -1;
+	ScriptCompany::CompanyID company = ResolveCompanyID(ScriptCompany::COMPANY_SELF);
+	if (company == ScriptCompany::COMPANY_INVALID) return -1;
 
-	return ::Company::Get(company)->GetMaxLoan();
+	return ::Company::Get(ScriptCompany::FromScriptCompanyID(company))->GetMaxLoan();
 }
 
-/* static */ bool ScriptCompany::SetMaxLoanAmountForCompany(CompanyID company, Money amount)
+/* static */ bool ScriptCompany::SetMaxLoanAmountForCompany(ScriptCompany::CompanyID company, Money amount)
 {
 	EnforceDeityMode(false);
 	EnforcePrecondition(false, amount >= 0 && amount <= (Money)MAX_LOAN_LIMIT);
 
 	company = ResolveCompanyID(company);
-	EnforcePrecondition(false, company != COMPANY_INVALID);
-	return ScriptObject::Command<CMD_SET_COMPANY_MAX_LOAN>::Do((::CompanyID)company, amount);
+	EnforcePrecondition(false, company != ScriptCompany::COMPANY_INVALID);
+	return ScriptObject::Command<CMD_SET_COMPANY_MAX_LOAN>::Do(ScriptCompany::FromScriptCompanyID(company), amount);
 }
 
-/* static */ bool ScriptCompany::ResetMaxLoanAmountForCompany(CompanyID company)
+/* static */ bool ScriptCompany::ResetMaxLoanAmountForCompany(ScriptCompany::CompanyID company)
 {
 	EnforceDeityMode(false);
 
 	company = ResolveCompanyID(company);
-	EnforcePrecondition(false, company != COMPANY_INVALID);
+	EnforcePrecondition(false, company != ScriptCompany::COMPANY_INVALID);
 
-	return ScriptObject::Command<CMD_SET_COMPANY_MAX_LOAN>::Do((::CompanyID)company, COMPANY_MAX_LOAN_DEFAULT);
+	return ScriptObject::Command<CMD_SET_COMPANY_MAX_LOAN>::Do(ScriptCompany::FromScriptCompanyID(company), COMPANY_MAX_LOAN_DEFAULT);
 }
 
 /* static */ Money ScriptCompany::GetLoanInterval()
@@ -233,7 +248,7 @@
 	EnforcePrecondition(false, loan >= 0);
 	EnforcePrecondition(false, ((int64_t)loan % GetLoanInterval()) == 0);
 	EnforcePrecondition(false, loan <= GetMaxLoanAmount());
-	EnforcePrecondition(false, (loan - GetLoanAmount() + GetBankBalance(COMPANY_SELF)) >= 0);
+	EnforcePrecondition(false, (loan - GetLoanAmount() + GetBankBalance(ScriptCompany::COMPANY_SELF)) >= 0);
 
 	if (loan == GetLoanAmount()) return true;
 
@@ -261,17 +276,17 @@
 	return GetLoanAmount() == loan;
 }
 
-/* static */ bool ScriptCompany::ChangeBankBalance(CompanyID company, Money delta, ExpensesType expenses_type, TileIndex tile)
+/* static */ bool ScriptCompany::ChangeBankBalance(ScriptCompany::CompanyID company, Money delta, ExpensesType expenses_type, TileIndex tile)
 {
 	EnforceDeityMode(false);
 	EnforcePrecondition(false, expenses_type < (ExpensesType)::EXPENSES_END);
 	EnforcePrecondition(false, tile == INVALID_TILE || ::IsValidTile(tile));
 
 	company = ResolveCompanyID(company);
-	EnforcePrecondition(false, company != COMPANY_INVALID);
+	EnforcePrecondition(false, company != ScriptCompany::COMPANY_INVALID);
 
 	/* Network commands only allow 0 to indicate invalid tiles, not INVALID_TILE */
-	return ScriptObject::Command<CMD_CHANGE_BANK_BALANCE>::Do(tile == INVALID_TILE ? (TileIndex)0U : tile, delta, (::CompanyID)company, (::ExpensesType)expenses_type);
+	return ScriptObject::Command<CMD_CHANGE_BANK_BALANCE>::Do(tile == INVALID_TILE ? (TileIndex)0U : tile, delta, ScriptCompany::FromScriptCompanyID(company), (::ExpensesType)expenses_type);
 }
 
 /* static */ bool ScriptCompany::BuildCompanyHQ(TileIndex tile)
@@ -282,12 +297,12 @@
 	return ScriptObject::Command<CMD_BUILD_OBJECT>::Do(tile, OBJECT_HQ, 0);
 }
 
-/* static */ TileIndex ScriptCompany::GetCompanyHQ(CompanyID company)
+/* static */ TileIndex ScriptCompany::GetCompanyHQ(ScriptCompany::CompanyID company)
 {
 	company = ResolveCompanyID(company);
-	if (company == COMPANY_INVALID) return INVALID_TILE;
+	if (company == ScriptCompany::COMPANY_INVALID) return INVALID_TILE;
 
-	TileIndex loc = ::Company::Get(company)->location_of_HQ;
+	TileIndex loc = ::Company::Get(ScriptCompany::FromScriptCompanyID(company))->location_of_HQ;
 	return (loc == 0) ? INVALID_TILE : loc;
 }
 
@@ -297,12 +312,12 @@
 	return ScriptObject::Command<CMD_CHANGE_COMPANY_SETTING>::Do("company.engine_renew", autorenew ? 1 : 0);
 }
 
-/* static */ bool ScriptCompany::GetAutoRenewStatus(CompanyID company)
+/* static */ bool ScriptCompany::GetAutoRenewStatus(ScriptCompany::CompanyID company)
 {
 	company = ResolveCompanyID(company);
-	if (company == COMPANY_INVALID) return false;
+	if (company == ScriptCompany::COMPANY_INVALID) return false;
 
-	return ::Company::Get(company)->settings.engine_renew;
+	return ::Company::Get(ScriptCompany::FromScriptCompanyID(company))->settings.engine_renew;
 }
 
 /* static */ bool ScriptCompany::SetAutoRenewMonths(SQInteger months)
@@ -313,12 +328,12 @@
 	return ScriptObject::Command<CMD_CHANGE_COMPANY_SETTING>::Do("company.engine_renew_months", months);
 }
 
-/* static */ SQInteger ScriptCompany::GetAutoRenewMonths(CompanyID company)
+/* static */ SQInteger ScriptCompany::GetAutoRenewMonths(ScriptCompany::CompanyID company)
 {
 	company = ResolveCompanyID(company);
-	if (company == COMPANY_INVALID) return 0;
+	if (company == ScriptCompany::COMPANY_INVALID) return 0;
 
-	return ::Company::Get(company)->settings.engine_renew_months;
+	return ::Company::Get(ScriptCompany::FromScriptCompanyID(company))->settings.engine_renew_months;
 }
 
 /* static */ bool ScriptCompany::SetAutoRenewMoney(Money money)
@@ -329,12 +344,12 @@
 	return ScriptObject::Command<CMD_CHANGE_COMPANY_SETTING>::Do("company.engine_renew_money", money);
 }
 
-/* static */ Money ScriptCompany::GetAutoRenewMoney(CompanyID company)
+/* static */ Money ScriptCompany::GetAutoRenewMoney(ScriptCompany::CompanyID company)
 {
 	company = ResolveCompanyID(company);
-	if (company == COMPANY_INVALID) return 0;
+	if (company == ScriptCompany::COMPANY_INVALID) return 0;
 
-	return ::Company::Get(company)->settings.engine_renew_money;
+	return ::Company::Get(ScriptCompany::FromScriptCompanyID(company))->settings.engine_renew_money;
 }
 
 /* static */ bool ScriptCompany::SetPrimaryLiveryColour(LiveryScheme scheme, Colours colour)

--- a/src/script/api/script_company.hpp
+++ b/src/script/api/script_company.hpp
@@ -39,6 +39,18 @@ public:
 		COMPANY_SPECTATOR = 255,               ///< Constant indicating that player is spectating (gets resolved to COMPANY_INVALID)
 	};
 
+	/**
+	 * Internal helper to convert from the script's company to the game's internal company.
+	 * @api none
+	 */
+	static ::CompanyID FromScriptCompanyID(ScriptCompany::CompanyID company);
+
+	/**
+	 * Internal helper to convert from the game's internal company to the script's company.
+	 * @api none
+	 */
+	static ScriptCompany::CompanyID ToScriptCompanyID(::CompanyID company);
+
 	/** Possible genders for company presidents. */
 	enum Gender {
 		GENDER_MALE,         ///< A male person.
@@ -124,7 +136,7 @@ public:
 	 * @param company The company index to resolve.
 	 * @return The resolved company index.
 	 */
-	static CompanyID ResolveCompanyID(CompanyID company);
+	static ScriptCompany::CompanyID ResolveCompanyID(ScriptCompany::CompanyID company);
 
 	/**
 	 * Check if a CompanyID is your CompanyID, to ease up checks.
@@ -132,7 +144,7 @@ public:
 	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if and only if this company is your CompanyID.
 	 */
-	static bool IsMine(CompanyID company);
+	static bool IsMine(ScriptCompany::CompanyID company);
 
 	/**
 	 * Set the name of your company.
@@ -150,7 +162,7 @@ public:
 	 * @pre ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @return The name of the given company.
 	 */
-	static std::optional<std::string> GetName(CompanyID company);
+	static std::optional<std::string> GetName(ScriptCompany::CompanyID company);
 
 	/**
 	 * Set the name of your president.
@@ -168,7 +180,7 @@ public:
 	 * @pre ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @return The name of the president of the given company.
 	 */
-	static std::optional<std::string> GetPresidentName(CompanyID company);
+	static std::optional<std::string> GetPresidentName(ScriptCompany::CompanyID company);
 
 	/**
 	 * Set the gender of the president of your company.
@@ -185,7 +197,7 @@ public:
 	 * @param company The company to get the presidents gender off.
 	 * @return The gender of the president.
 	 */
-	static Gender GetPresidentGender(CompanyID company);
+	static Gender GetPresidentGender(ScriptCompany::CompanyID company);
 
 	/**
 	 * Sets the amount to loan.
@@ -235,7 +247,7 @@ public:
 	 * @note Max loan value set with this method is not affected by inflation.
 	 * @api -ai
 	 */
-	static bool SetMaxLoanAmountForCompany(CompanyID company, Money amount);
+	static bool SetMaxLoanAmountForCompany(ScriptCompany::CompanyID company, Money amount);
 
 	/**
 	 * Makes the max amount of money company can loan follow the global max loan setting.
@@ -247,7 +259,7 @@ public:
 	 * @note You need to create your own news message to inform about max loan change.
 	 * @api -ai
 	 */
-	static bool ResetMaxLoanAmountForCompany(CompanyID company);
+	static bool ResetMaxLoanAmountForCompany(ScriptCompany::CompanyID company);
 
 	/**
 	 * Gets the interval/loan step.
@@ -263,7 +275,7 @@ public:
 	 * @pre ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @return The actual bank balance or INT32_MAX.
 	 */
-	static Money GetBankBalance(CompanyID company);
+	static Money GetBankBalance(ScriptCompany::CompanyID company);
 
 	/**
 	 * Changes the bank balance by a delta value. This method does not affect the loan but instead
@@ -278,7 +290,7 @@ public:
 	 * @note You need to create your own news message to inform about costs/gifts that you create using this command.
 	 * @api -ai
 	 */
-	static bool ChangeBankBalance(CompanyID company, Money delta, ExpensesType expenses_type, TileIndex tile);
+	static bool ChangeBankBalance(ScriptCompany::CompanyID company, Money delta, ExpensesType expenses_type, TileIndex tile);
 
 	/**
 	 * Get the income of the company in the given economy-quarter.
@@ -291,7 +303,7 @@ public:
 	 * @return The gross income of the company in the given economy-quarter.
 	 * @see \ref ScriptEconomyTime
 	 */
-	static Money GetQuarterlyIncome(CompanyID company, SQInteger quarter);
+	static Money GetQuarterlyIncome(ScriptCompany::CompanyID company, SQInteger quarter);
 
 	/**
 	 * Get the expenses of the company in the given economy-quarter.
@@ -305,7 +317,7 @@ public:
 	 * @return The expenses of the company in the given economy-quarter.
 	 * @see \ref ScriptEconomyTime
 	 */
-	static Money GetQuarterlyExpenses(CompanyID company, SQInteger quarter);
+	static Money GetQuarterlyExpenses(ScriptCompany::CompanyID company, SQInteger quarter);
 
 	/**
 	 * Get the amount of cargo delivered by the given company in the given economy-quarter.
@@ -316,7 +328,7 @@ public:
 	 * @return The amount of cargo delivered by the given company in the given economy-quarter.
 	 * @see \ref ScriptEconomyTime
 	 */
-	static SQInteger GetQuarterlyCargoDelivered(CompanyID company, SQInteger quarter);
+	static SQInteger GetQuarterlyCargoDelivered(ScriptCompany::CompanyID company, SQInteger quarter);
 
 	/**
 	 * Get the performance rating of the given company in the given economy-quarter.
@@ -329,7 +341,7 @@ public:
 	 * @return The performance rating of the given company in the given economy-quarter.
 	 * @see \ref ScriptEconomyTime
 	 */
-	static SQInteger GetQuarterlyPerformanceRating(CompanyID company, SQInteger quarter);
+	static SQInteger GetQuarterlyPerformanceRating(ScriptCompany::CompanyID company, SQInteger quarter);
 
 	/**
 	 * Get the value of the company in the given economy-quarter.
@@ -340,7 +352,7 @@ public:
 	 * @return The value of the company in the given economy-quarter.
 	 * @see \ref ScriptEconomyTime
 	 */
-	static Money GetQuarterlyCompanyValue(CompanyID company, SQInteger quarter);
+	static Money GetQuarterlyCompanyValue(ScriptCompany::CompanyID company, SQInteger quarter);
 
 	/**
 	 * Build your company's HQ on the given tile.
@@ -362,7 +374,7 @@ public:
 	 * @return The tile of the company's HQ, this tile is the most northern tile
 	 *  of that HQ, or ScriptMap::TILE_INVALID if there is no HQ yet.
 	 */
-	static TileIndex GetCompanyHQ(CompanyID company);
+	static TileIndex GetCompanyHQ(ScriptCompany::CompanyID company);
 
 	/**
 	 * Set whether autorenew is enabled for your company.
@@ -378,7 +390,7 @@ public:
 	 * @pre ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @return True if autorenew is enabled.
 	 */
-	static bool GetAutoRenewStatus(CompanyID company);
+	static bool GetAutoRenewStatus(ScriptCompany::CompanyID company);
 
 	/**
 	 * Set the number of months before/after max age to autorenew an engine for your company.
@@ -397,7 +409,7 @@ public:
 	 * @return The number of calendar-months before/after max age of engine.
 	 * @see \ref ScriptCalendarTime
 	 */
-	static SQInteger GetAutoRenewMonths(CompanyID company);
+	static SQInteger GetAutoRenewMonths(ScriptCompany::CompanyID company);
 
 	/**
 	 * Set the minimum money needed to autorenew an engine for your company.
@@ -415,7 +427,7 @@ public:
 	 * @pre ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @return The minimum required money for autorenew to work.
 	 */
-	static Money GetAutoRenewMoney(CompanyID company);
+	static Money GetAutoRenewMoney(ScriptCompany::CompanyID company);
 
 	/**
 	 * Set primary colour for your company.

--- a/src/script/api/script_companymode.cpp
+++ b/src/script/api/script_companymode.cpp
@@ -13,13 +13,12 @@
 
 #include "../../safeguards.h"
 
-ScriptCompanyMode::ScriptCompanyMode(SQInteger company)
+ScriptCompanyMode::ScriptCompanyMode(ScriptCompany::CompanyID company)
 {
-	if (company < OWNER_BEGIN || company >= MAX_COMPANIES) company = INVALID_COMPANY;
-	if (!::Company::IsValidID(company)) company = INVALID_COMPANY;
+	company = ScriptCompany::ResolveCompanyID(company);
 
 	this->last_company = ScriptObject::GetCompany();
-	ScriptObject::SetCompany((::CompanyID)company);
+	ScriptObject::SetCompany(ScriptCompany::FromScriptCompanyID(company));
 }
 
 ScriptCompanyMode::~ScriptCompanyMode()

--- a/src/script/api/script_companymode.hpp
+++ b/src/script/api/script_companymode.hpp
@@ -11,6 +11,7 @@
 #define SCRIPT_COMPANYMODE_HPP
 
 #include "script_object.hpp"
+#include "script_company.hpp"
 
 /**
  * Class to switch the current company.
@@ -30,7 +31,7 @@
  */
 class ScriptCompanyMode : public ScriptObject {
 private:
-	CompanyID last_company; ///< The previous company we were in.
+	::CompanyID last_company; ///< The previous company we were in.
 
 public:
 	/**
@@ -40,7 +41,7 @@ public:
 	 * @note When the instance is destroyed, it restores the company that was
 	 *   current when the instance was created!
 	 */
-	ScriptCompanyMode(SQInteger company);
+	ScriptCompanyMode(ScriptCompany::CompanyID company);
 
 	/**
 	 * Destroying this instance reset the company to that what it was

--- a/src/script/api/script_controller.cpp
+++ b/src/script/api/script_controller.cpp
@@ -67,7 +67,7 @@
 	ScriptLog::Log(error_msg ? ScriptLogTypes::LOG_SQ_ERROR : ScriptLogTypes::LOG_SQ_INFO, message);
 }
 
-ScriptController::ScriptController(CompanyID company) :
+ScriptController::ScriptController(::CompanyID company) :
 	ticks(0),
 	loaded_library_count(0)
 {

--- a/src/script/api/script_controller.hpp
+++ b/src/script/api/script_controller.hpp
@@ -52,7 +52,7 @@ public:
 	 * Initializer of the ScriptController.
 	 * @param company The company this Script is normally serving.
 	 */
-	ScriptController(CompanyID company);
+	ScriptController(::CompanyID company);
 
 #else
 	/**

--- a/src/script/api/script_depotlist.cpp
+++ b/src/script/api/script_depotlist.cpp
@@ -28,7 +28,7 @@ ScriptDepotList::ScriptDepotList(ScriptTile::TransportType transport_type)
 		case ScriptTile::TRANSPORT_AIR: {
 			/* Hangars are not seen as real depots by the depot code. */
 			bool is_deity = ScriptCompanyMode::IsDeity();
-			CompanyID owner = ScriptObject::GetCompany();
+			::CompanyID owner = ScriptObject::GetCompany();
 			for (const Station *st : Station::Iterate()) {
 				if (is_deity || st->owner == owner) {
 					for (uint i = 0; i < st->airport.GetNumHangars(); i++) {
@@ -42,7 +42,7 @@ ScriptDepotList::ScriptDepotList(ScriptTile::TransportType transport_type)
 
 	/* Handle 'standard' depots. */
 	bool is_deity = ScriptCompanyMode::IsDeity();
-	CompanyID owner = ScriptObject::GetCompany();
+	::CompanyID owner = ScriptObject::GetCompany();
 	for (const Depot *depot : Depot::Iterate()) {
 		if ((is_deity || ::GetTileOwner(depot->xy) == owner) && ::IsTileType(depot->xy, tile_type)) this->AddItem(depot->xy.base());
 	}

--- a/src/script/api/script_engine.cpp
+++ b/src/script/api/script_engine.cpp
@@ -31,7 +31,7 @@
 
 	/* AIs have only access to engines they can purchase or still have in use.
 	 * Deity has access to all engined that will be or were available ever. */
-	CompanyID company = ScriptObject::GetCompany();
+	::CompanyID company = ScriptObject::GetCompany();
 	return ScriptCompanyMode::IsDeity() || ::IsEngineBuildable(engine_id, e->type, company) || ::Company::Get(company)->group_all[e->type].GetNumEngines(engine_id) > 0;
 }
 
@@ -277,7 +277,7 @@
 	EnforcePrecondition(false, IsValidEngine(engine_id));
 	EnforcePrecondition(false, company != ScriptCompany::COMPANY_INVALID);
 
-	return ScriptObject::Command<CMD_ENGINE_CTRL>::Do(engine_id, (::CompanyID)company, true);
+	return ScriptObject::Command<CMD_ENGINE_CTRL>::Do(engine_id, ScriptCompany::FromScriptCompanyID(company), true);
 }
 
 /* static */ bool ScriptEngine::DisableForCompany(EngineID engine_id, ScriptCompany::CompanyID company)
@@ -288,5 +288,5 @@
 	EnforcePrecondition(false, IsValidEngine(engine_id));
 	EnforcePrecondition(false, company != ScriptCompany::COMPANY_INVALID);
 
-	return ScriptObject::Command<CMD_ENGINE_CTRL>::Do(engine_id, (::CompanyID)company, false);
+	return ScriptObject::Command<CMD_ENGINE_CTRL>::Do(engine_id, ScriptCompany::FromScriptCompanyID(company), false);
 }

--- a/src/script/api/script_enginelist.cpp
+++ b/src/script/api/script_enginelist.cpp
@@ -17,7 +17,7 @@ ScriptEngineList::ScriptEngineList(ScriptVehicle::VehicleType vehicle_type)
 {
 	EnforceDeityOrCompanyModeValid_Void();
 	bool is_deity = ScriptCompanyMode::IsDeity();
-	CompanyID owner = ScriptObject::GetCompany();
+	::CompanyID owner = ScriptObject::GetCompany();
 	for (const Engine *e : Engine::IterateType((::VehicleType)vehicle_type)) {
 		if (is_deity || HasBit(e->company_avail, owner)) this->AddItem(e->index);
 	}

--- a/src/script/api/script_event_types.cpp
+++ b/src/script/api/script_event_types.cpp
@@ -113,7 +113,7 @@ bool ScriptEventEnginePreview::AcceptPreview()
 bool ScriptEventCompanyAskMerger::AcceptMerger()
 {
 	EnforceCompanyModeValid(false);
-	return ScriptObject::Command<CMD_BUY_COMPANY>::Do((::CompanyID)this->owner, false);
+	return ScriptObject::Command<CMD_BUY_COMPANY>::Do(ScriptCompany::FromScriptCompanyID(this->owner), false);
 }
 
 ScriptEventAdminPort::ScriptEventAdminPort(const std::string &json) :

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -331,7 +331,7 @@ public:
 	 */
 	ScriptEventCompanyNew(Owner owner) :
 		ScriptEvent(ET_COMPANY_NEW),
-		owner((ScriptCompany::CompanyID)owner)
+		owner(ScriptCompany::ToScriptCompanyID(owner))
 	{}
 #endif /* DOXYGEN_API */
 
@@ -362,9 +362,9 @@ public:
 	/**
 	 * @param owner The company that is renamed.
 	 */
-	ScriptEventCompanyRenamed(CompanyID company, const std::string &new_name) :
+	ScriptEventCompanyRenamed(::CompanyID company, const std::string &new_name) :
 		ScriptEvent(ET_COMPANY_RENAMED),
-		company(static_cast<ScriptCompany::CompanyID>(company)),
+		company(ScriptCompany::ToScriptCompanyID(company)),
 		new_name(new_name)
 	{}
 #endif /* DOXYGEN_API */
@@ -407,7 +407,7 @@ public:
 	 */
 	ScriptEventCompanyInTrouble(Owner owner) :
 		ScriptEvent(ET_COMPANY_IN_TROUBLE),
-		owner((ScriptCompany::CompanyID)owner)
+		owner(ScriptCompany::ToScriptCompanyID(owner))
 	{}
 #endif /* DOXYGEN_API */
 
@@ -441,7 +441,7 @@ public:
 	 */
 	ScriptEventCompanyAskMerger(Owner owner, Money value) :
 		ScriptEvent(ET_COMPANY_ASK_MERGER),
-		owner((ScriptCompany::CompanyID)owner),
+		owner(ScriptCompany::ToScriptCompanyID(owner)),
 		value(value)
 	{}
 #endif /* DOXYGEN_API */
@@ -492,8 +492,8 @@ public:
 	 */
 	ScriptEventCompanyMerger(Owner old_owner, Owner new_owner) :
 		ScriptEvent(ET_COMPANY_MERGER),
-		old_owner((ScriptCompany::CompanyID)old_owner),
-		new_owner((ScriptCompany::CompanyID)new_owner)
+		old_owner(ScriptCompany::ToScriptCompanyID(old_owner)),
+		new_owner(ScriptCompany::ToScriptCompanyID(new_owner))
 	{}
 #endif /* DOXYGEN_API */
 
@@ -536,7 +536,7 @@ public:
 	 */
 	ScriptEventCompanyBankrupt(Owner owner) :
 		ScriptEvent(ET_COMPANY_BANKRUPT),
-		owner((ScriptCompany::CompanyID)owner)
+		owner(ScriptCompany::ToScriptCompanyID(owner))
 	{}
 #endif /* DOXYGEN_API */
 
@@ -1220,9 +1220,9 @@ public:
 	 * @param page_id     Which page was the clicked button on.
 	 * @param element_id  Which button element was clicked.
 	 */
-	ScriptEventStoryPageButtonClick(CompanyID company_id, StoryPageID page_id, StoryPageElementID element_id) :
+	ScriptEventStoryPageButtonClick(::CompanyID company_id, StoryPageID page_id, StoryPageElementID element_id) :
 		ScriptEvent(ET_STORYPAGE_BUTTON_CLICK),
-		company_id((ScriptCompany::CompanyID)company_id),
+		company_id(ScriptCompany::ToScriptCompanyID(company_id)),
 		page_id(page_id),
 		element_id(element_id)
 	{}
@@ -1272,9 +1272,9 @@ public:
 	 * @param element_id  Which button element was used to select the tile.
 	 * @param tile_index  Which tile was selected by the player.
 	 */
-	ScriptEventStoryPageTileSelect(CompanyID company_id, StoryPageID page_id, StoryPageElementID element_id, TileIndex tile_index) :
+	ScriptEventStoryPageTileSelect(::CompanyID company_id, StoryPageID page_id, StoryPageElementID element_id, TileIndex tile_index) :
 		ScriptEvent(ET_STORYPAGE_TILE_SELECT),
-		company_id((ScriptCompany::CompanyID)company_id),
+		company_id(ScriptCompany::ToScriptCompanyID(company_id)),
 		page_id(page_id),
 		element_id(element_id),
 		tile_index(tile_index)
@@ -1332,9 +1332,9 @@ public:
 	 * @param element_id  Which button element was used to select the tile.
 	 * @param vehicle_id  Which vehicle was selected by the player.
 	 */
-	ScriptEventStoryPageVehicleSelect(CompanyID company_id, StoryPageID page_id, StoryPageElementID element_id, VehicleID vehicle_id) :
+	ScriptEventStoryPageVehicleSelect(::CompanyID company_id, StoryPageID page_id, StoryPageElementID element_id, VehicleID vehicle_id) :
 		ScriptEvent(ET_STORYPAGE_VEHICLE_SELECT),
-		company_id((ScriptCompany::CompanyID)company_id),
+		company_id(ScriptCompany::ToScriptCompanyID(company_id)),
 		page_id(page_id),
 		element_id(element_id),
 		vehicle_id(vehicle_id)
@@ -1392,9 +1392,9 @@ public:
 	 * @param company The company of the president.
 	 * @param new_name The new name of the president.
 	 */
-	ScriptEventPresidentRenamed(CompanyID company, const std::string &new_name) :
+	ScriptEventPresidentRenamed(::CompanyID company, const std::string &new_name) :
 		ScriptEvent(ET_PRESIDENT_RENAMED),
-		company(static_cast<ScriptCompany::CompanyID>(company)),
+		company(ScriptCompany::ToScriptCompanyID(company)),
 		new_name(new_name)
 	{}
 #endif /* DOXYGEN_API */

--- a/src/script/api/script_goal.cpp
+++ b/src/script/api/script_goal.cpp
@@ -30,15 +30,14 @@
 
 /* static */ bool ScriptGoal::IsValidGoalDestination(ScriptCompany::CompanyID company, GoalType type, SQInteger destination)
 {
-	CompanyID c = (::CompanyID)company;
-	if (company == ScriptCompany::COMPANY_INVALID) c = INVALID_COMPANY;
+	::CompanyID c = ScriptCompany::FromScriptCompanyID(company);
 	StoryPage *story_page = nullptr;
 	if (type == GT_STORY_PAGE && ScriptStoryPage::IsValidStoryPage(static_cast<StoryPageID>(destination))) story_page = ::StoryPage::Get(static_cast<StoryPageID>(destination));
 	return (type == GT_NONE && destination == 0) ||
 			(type == GT_TILE && ScriptMap::IsValidTile(::TileIndex(destination))) ||
 			(type == GT_INDUSTRY && ScriptIndustry::IsValidIndustry(destination)) ||
 			(type == GT_TOWN && ScriptTown::IsValidTown(destination)) ||
-			(type == GT_COMPANY && ScriptCompany::ResolveCompanyID((ScriptCompany::CompanyID)destination) != ScriptCompany::COMPANY_INVALID) ||
+			(type == GT_COMPANY && ScriptCompany::ResolveCompanyID(ScriptCompany::ToScriptCompanyID(static_cast<::CompanyID>(destination))) != ScriptCompany::COMPANY_INVALID) ||
 			(type == GT_STORY_PAGE && story_page != nullptr && (c == INVALID_COMPANY ? story_page->company == INVALID_COMPANY : story_page->company == INVALID_COMPANY || story_page->company == c));
 }
 
@@ -53,7 +52,7 @@
 	EnforcePrecondition(GOAL_INVALID, company == ScriptCompany::COMPANY_INVALID || ScriptCompany::ResolveCompanyID(company) != ScriptCompany::COMPANY_INVALID);
 	EnforcePrecondition(GOAL_INVALID, IsValidGoalDestination(company, type, destination));
 
-	if (!ScriptObject::Command<CMD_CREATE_GOAL>::Do(&ScriptInstance::DoCommandReturnGoalID, (::CompanyID)company, (::GoalType)type, destination, text)) return GOAL_INVALID;
+	if (!ScriptObject::Command<CMD_CREATE_GOAL>::Do(&ScriptInstance::DoCommandReturnGoalID, ScriptCompany::FromScriptCompanyID(company), (::GoalType)type, destination, text)) return GOAL_INVALID;
 
 	/* In case of test-mode, we return GoalID 0 */
 	return static_cast<GoalID>(0);
@@ -72,7 +71,7 @@
 	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidGoal(goal_id));
 	const Goal *g = Goal::Get(goal_id);
-	EnforcePrecondition(false, IsValidGoalDestination((ScriptCompany::CompanyID)g->company, type, destination));
+	EnforcePrecondition(false, IsValidGoalDestination(ScriptCompany::ToScriptCompanyID(g->company), type, destination));
 
 	return ScriptObject::Command<CMD_SET_GOAL_DESTINATION>::Do(goal_id, (::GoalType)type, destination);
 }
@@ -137,10 +136,7 @@
 /* static */ bool ScriptGoal::Question(SQInteger uniqueid, ScriptCompany::CompanyID company, Text *question, QuestionType type, SQInteger buttons)
 {
 	EnforcePrecondition(false, company == ScriptCompany::COMPANY_INVALID || ScriptCompany::ResolveCompanyID(company) != ScriptCompany::COMPANY_INVALID);
-	uint8_t c = company;
-	if (company == ScriptCompany::COMPANY_INVALID) c = INVALID_COMPANY;
-
-	return DoQuestion(uniqueid, c, false, question, type, buttons);
+	return DoQuestion(uniqueid, ScriptCompany::FromScriptCompanyID(company), false, question, type, buttons);
 }
 
 /* static */ bool ScriptGoal::QuestionClient(SQInteger uniqueid, ScriptClient::ClientID client, Text *question, QuestionType type, SQInteger buttons)

--- a/src/script/api/script_grouplist.cpp
+++ b/src/script/api/script_grouplist.cpp
@@ -17,7 +17,7 @@
 ScriptGroupList::ScriptGroupList(HSQUIRRELVM vm)
 {
 	EnforceCompanyModeValid_Void();
-	CompanyID owner = ScriptObject::GetCompany();
+	::CompanyID owner = ScriptObject::GetCompany();
 	ScriptList::FillList<Group>(vm, this,
 		[owner](const Group *g) { return g->owner == owner; }
 	);

--- a/src/script/api/script_industry.cpp
+++ b/src/script/api/script_industry.cpp
@@ -263,7 +263,7 @@
 	auto company_id = ::Industry::Get(industry_id)->exclusive_supplier;
 	if (!::Company::IsValidID(company_id)) return ScriptCompany::COMPANY_INVALID;
 
-	return (ScriptCompany::CompanyID)((uint8_t)company_id);
+	return ScriptCompany::ToScriptCompanyID(company_id);
 }
 
 /* static */ bool ScriptIndustry::SetExclusiveSupplier(IndustryID industry_id, ScriptCompany::CompanyID company_id)
@@ -283,7 +283,7 @@
 	auto company_id = ::Industry::Get(industry_id)->exclusive_consumer;
 	if (!::Company::IsValidID(company_id)) return ScriptCompany::COMPANY_INVALID;
 
-	return (ScriptCompany::CompanyID)((uint8_t)company_id);
+	return ScriptCompany::ToScriptCompanyID(company_id);
 }
 
 /* static */ bool ScriptIndustry::SetExclusiveConsumer(IndustryID industry_id, ScriptCompany::CompanyID company_id)

--- a/src/script/api/script_infrastructure.cpp
+++ b/src/script/api/script_infrastructure.cpp
@@ -23,7 +23,7 @@
 	company = ScriptCompany::ResolveCompanyID(company);
 	if (company == ScriptCompany::COMPANY_INVALID || (::RailType)railtype >= RAILTYPE_END) return 0;
 
-	return ::Company::Get((::CompanyID)company)->infrastructure.rail[railtype];
+	return ::Company::Get(ScriptCompany::FromScriptCompanyID(company))->infrastructure.rail[railtype];
 }
 
 /* static */ SQInteger ScriptInfrastructure::GetRoadPieceCount(ScriptCompany::CompanyID company, ScriptRoad::RoadType roadtype)
@@ -31,7 +31,7 @@
 	company = ScriptCompany::ResolveCompanyID(company);
 	if (company == ScriptCompany::COMPANY_INVALID || (::RoadType)roadtype >= ROADTYPE_END) return 0;
 
-	return ::Company::Get((::CompanyID)company)->infrastructure.road[roadtype];
+	return ::Company::Get(ScriptCompany::FromScriptCompanyID(company))->infrastructure.road[roadtype];
 }
 
 /* static */ SQInteger ScriptInfrastructure::GetInfrastructurePieceCount(ScriptCompany::CompanyID company, Infrastructure infra_type)
@@ -39,7 +39,7 @@
 	company = ScriptCompany::ResolveCompanyID(company);
 	if (company == ScriptCompany::COMPANY_INVALID) return 0;
 
-	const ::Company *c = ::Company::Get((::CompanyID)company);
+	const ::Company *c = ::Company::Get(ScriptCompany::FromScriptCompanyID(company));
 	switch (infra_type) {
 		case INFRASTRUCTURE_RAIL:
 			return c->infrastructure.GetRailTotal();
@@ -69,7 +69,7 @@
 	company = ScriptCompany::ResolveCompanyID(company);
 	if (company == ScriptCompany::COMPANY_INVALID || (::RailType)railtype >= RAILTYPE_END || !_settings_game.economy.infrastructure_maintenance) return 0;
 
-	const ::Company *c = ::Company::Get((::CompanyID)company);
+	const ::Company *c = ::Company::Get(ScriptCompany::FromScriptCompanyID(company));
 	return ::RailMaintenanceCost((::RailType)railtype, c->infrastructure.rail[railtype], c->infrastructure.GetRailTotal());
 }
 
@@ -78,7 +78,7 @@
 	company = ScriptCompany::ResolveCompanyID(company);
 	if (company == ScriptCompany::COMPANY_INVALID || (::RoadType)roadtype >= ROADTYPE_END || !_settings_game.economy.infrastructure_maintenance) return 0;
 
-	const ::Company *c = ::Company::Get((::CompanyID)company);
+	const ::Company *c = ::Company::Get(ScriptCompany::FromScriptCompanyID(company));
 	return ::RoadMaintenanceCost((::RoadType)roadtype, c->infrastructure.road[roadtype], RoadTypeIsRoad((::RoadType)roadtype) ? c->infrastructure.GetRoadTotal() : c->infrastructure.GetTramTotal());
 }
 
@@ -87,7 +87,7 @@
 	company = ScriptCompany::ResolveCompanyID(company);
 	if (company == ScriptCompany::COMPANY_INVALID || !_settings_game.economy.infrastructure_maintenance) return 0;
 
-	const ::Company *c = ::Company::Get((::CompanyID)company);
+	const ::Company *c = ::Company::Get(ScriptCompany::FromScriptCompanyID(company));
 	switch (infra_type) {
 		case INFRASTRUCTURE_RAIL: {
 			Money cost;

--- a/src/script/api/script_league.cpp
+++ b/src/script/api/script_league.cpp
@@ -59,8 +59,7 @@
 	EnforcePrecondition(LEAGUE_TABLE_ELEMENT_INVALID, IsValidLeagueTable(table));
 
 	EnforcePrecondition(LEAGUE_TABLE_ELEMENT_INVALID, company == ScriptCompany::COMPANY_INVALID || ScriptCompany::ResolveCompanyID(company) != ScriptCompany::COMPANY_INVALID);
-	CompanyID c = (::CompanyID)company;
-	if (company == ScriptCompany::COMPANY_INVALID) c = INVALID_COMPANY;
+	::CompanyID c = ScriptCompany::FromScriptCompanyID(company);
 
 	EnforcePrecondition(LEAGUE_TABLE_ELEMENT_INVALID, text != nullptr);
 	std::string encoded_text = text->GetEncodedText();
@@ -86,8 +85,7 @@
 	EnforcePrecondition(false, IsValidLeagueTableElement(element));
 
 	EnforcePrecondition(false, company == ScriptCompany::COMPANY_INVALID || ScriptCompany::ResolveCompanyID(company) != ScriptCompany::COMPANY_INVALID);
-	CompanyID c = (::CompanyID)company;
-	if (company == ScriptCompany::COMPANY_INVALID) c = INVALID_COMPANY;
+	::CompanyID c = ScriptCompany::FromScriptCompanyID(company);
 
 	EnforcePrecondition(false, text != nullptr);
 	std::string encoded_text = text->GetEncodedText();

--- a/src/script/api/script_league.hpp
+++ b/src/script/api/script_league.hpp
@@ -70,7 +70,7 @@ public:
 	 * Create a new league table element.
 	 * @param table Id of the league table this element belongs to.
 	 * @param rating Value that elements are ordered by.
-	 * @param company Company to show the color blob for or INVALID_COMPANY.
+	 * @param company Company to show the color blob for or COMPANY_INVALID.
 	 * @param text Text of the element (can be either a raw string, or ScriptText object).
 	 * @param score String representation of the score associated with the element (can be either a raw string, or ScriptText object).
 	 * @param link_type Type of the referenced object.
@@ -87,7 +87,7 @@ public:
 	/**
 	 * Update the attributes of a league table element.
 	 * @param element Id of the element to update
-	 * @param company Company to show the color blob for or INVALID_COMPANY.
+	 * @param company Company to show the color blob for or COMPANY_INVALID.
 	 * @param text Text of the element (can be either a raw string, or ScriptText object).
 	 * @param link_type Type of the referenced object.
 	 * @param link_target Id of the referenced object.

--- a/src/script/api/script_news.cpp
+++ b/src/script/api/script_news.cpp
@@ -36,9 +36,8 @@
 	                           (ref_type == NR_INDUSTRY && ScriptIndustry::IsValidIndustry(reference)) ||
 	                           (ref_type == NR_TOWN     && ScriptTown::IsValidTown(reference)));
 
-	uint8_t c = company;
-	if (company == ScriptCompany::COMPANY_INVALID) c = INVALID_COMPANY;
+	::CompanyID c = ScriptCompany::FromScriptCompanyID(company);
 
 	if (ref_type == NR_NONE) reference = 0;
-	return ScriptObject::Command<CMD_CUSTOM_NEWS_ITEM>::Do((::NewsType)type, (::NewsReferenceType)ref_type, (::CompanyID)c, reference, encoded);
+	return ScriptObject::Command<CMD_CUSTOM_NEWS_ITEM>::Do((::NewsType)type, (::NewsReferenceType)ref_type, c, reference, encoded);
 }

--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -215,7 +215,7 @@ ScriptObject::ActiveInstance::~ActiveInstance()
 	return GetStorage()->allow_do_command;
 }
 
-/* static */ void ScriptObject::SetCompany(CompanyID company)
+/* static */ void ScriptObject::SetCompany(::CompanyID company)
 {
 	if (GetStorage()->root_company == INVALID_OWNER) GetStorage()->root_company = company;
 	GetStorage()->company = company;
@@ -223,12 +223,12 @@ ScriptObject::ActiveInstance::~ActiveInstance()
 	_current_company = company;
 }
 
-/* static */ CompanyID ScriptObject::GetCompany()
+/* static */ ::CompanyID ScriptObject::GetCompany()
 {
 	return GetStorage()->company;
 }
 
-/* static */ CompanyID ScriptObject::GetRootCompany()
+/* static */ ::CompanyID ScriptObject::GetRootCompany()
 {
 	return GetStorage()->root_company;
 }

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -269,21 +269,21 @@ protected:
 	 *  information about.
 	 * @param company The new company.
 	 */
-	static void SetCompany(CompanyID company);
+	static void SetCompany(::CompanyID company);
 
 	/**
 	 * Get the current company we are executing commands for or
 	 *  requesting information about.
 	 * @return The current company.
 	 */
-	static CompanyID GetCompany();
+	static ::CompanyID GetCompany();
 
 	/**
 	 * Get the root company, the company that the script really
 	 *  runs under / for.
 	 * @return The root company.
 	 */
-	static CompanyID GetRootCompany();
+	static ::CompanyID GetRootCompany();
 
 	/**
 	 * Set the cost of the last command.

--- a/src/script/api/script_railtypelist.cpp
+++ b/src/script/api/script_railtypelist.cpp
@@ -18,7 +18,7 @@ ScriptRailTypeList::ScriptRailTypeList()
 {
 	EnforceDeityOrCompanyModeValid_Void();
 	bool is_deity = ScriptCompanyMode::IsDeity();
-	CompanyID owner = ScriptObject::GetCompany();
+	::CompanyID owner = ScriptObject::GetCompany();
 	for (RailType rt = RAILTYPE_BEGIN; rt != RAILTYPE_END; rt++) {
 		if (is_deity || ::HasRailTypeAvail(owner, rt)) this->AddItem(rt);
 	}

--- a/src/script/api/script_roadtypelist.cpp
+++ b/src/script/api/script_roadtypelist.cpp
@@ -16,7 +16,7 @@
 ScriptRoadTypeList::ScriptRoadTypeList(ScriptRoad::RoadTramTypes rtts)
 {
 	EnforceDeityOrCompanyModeValid_Void();
-	CompanyID owner = ScriptObject::GetCompany();
+	::CompanyID owner = ScriptObject::GetCompany();
 	for (RoadType rt = ROADTYPE_BEGIN; rt != ROADTYPE_END; rt++) {
 		if (!HasBit(rtts, GetRoadTramType(rt))) continue;
 		if (::HasRoadTypeAvail(owner, rt)) this->AddItem(rt);

--- a/src/script/api/script_sign.cpp
+++ b/src/script/api/script_sign.cpp
@@ -30,7 +30,7 @@
 {
 	if (!IsValidSign(sign_id)) return ScriptCompany::COMPANY_INVALID;
 
-	return static_cast<ScriptCompany::CompanyID>((int)::Sign::Get(sign_id)->owner);
+	return ScriptCompany::ToScriptCompanyID(::Sign::Get(sign_id)->owner);
 }
 
 /* static */ bool ScriptSign::SetName(SignID sign_id, Text *name)

--- a/src/script/api/script_station.cpp
+++ b/src/script/api/script_station.cpp
@@ -30,7 +30,7 @@
 {
 	if (!IsValidStation(station_id)) return ScriptCompany::COMPANY_INVALID;
 
-	return static_cast<ScriptCompany::CompanyID>((int)::Station::Get(station_id)->owner);
+	return ScriptCompany::ToScriptCompanyID(::Station::Get(station_id)->owner);
 }
 
 /* static */ StationID ScriptStation::GetStationID(TileIndex tile)

--- a/src/script/api/script_stationlist.cpp
+++ b/src/script/api/script_stationlist.cpp
@@ -20,7 +20,7 @@ ScriptStationList::ScriptStationList(ScriptStation::StationType station_type)
 {
 	EnforceDeityOrCompanyModeValid_Void();
 	bool is_deity = ScriptCompanyMode::IsDeity();
-	CompanyID owner = ScriptObject::GetCompany();
+	::CompanyID owner = ScriptObject::GetCompany();
 	ScriptList::FillList<Station>(this,
 		[is_deity, owner, station_type](const Station *st) {
 			return (is_deity || st->owner == owner) && (st->facilities & static_cast<StationFacility>(station_type)) != 0;

--- a/src/script/api/script_story_page.cpp
+++ b/src/script/api/script_story_page.cpp
@@ -50,11 +50,10 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 	EnforceDeityMode(STORY_PAGE_INVALID);
 	EnforcePrecondition(STORY_PAGE_INVALID, company == ScriptCompany::COMPANY_INVALID || ScriptCompany::ResolveCompanyID(company) != ScriptCompany::COMPANY_INVALID);
 
-	uint8_t c = company;
-	if (company == ScriptCompany::COMPANY_INVALID) c = INVALID_COMPANY;
+	::CompanyID c = ScriptCompany::FromScriptCompanyID(company);
 
 	if (!ScriptObject::Command<CMD_CREATE_STORY_PAGE>::Do(&ScriptInstance::DoCommandReturnStoryPageID,
-		(::CompanyID)c, title != nullptr ? title->GetEncodedText() : std::string{})) return STORY_PAGE_INVALID;
+		c, title != nullptr ? title->GetEncodedText() : std::string{})) return STORY_PAGE_INVALID;
 
 	/* In case of test-mode, we return StoryPageID 0 */
 	return static_cast<StoryPageID>(0);
@@ -177,10 +176,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 {
 	EnforcePrecondition(ScriptCompany::COMPANY_INVALID, IsValidStoryPage(story_page_id));
 
-	CompanyID c = StoryPage::Get(story_page_id)->company;
-	ScriptCompany::CompanyID company = c == INVALID_COMPANY ? ScriptCompany::COMPANY_INVALID : (ScriptCompany::CompanyID)c;
-
-	return company;
+	return ScriptCompany::ToScriptCompanyID(StoryPage::Get(story_page_id)->company);
 }
 
 /* static */ ScriptDate::Date ScriptStoryPage::GetDate(StoryPageID story_page_id)

--- a/src/script/api/script_storypagelist.cpp
+++ b/src/script/api/script_storypagelist.cpp
@@ -16,8 +16,7 @@
 
 ScriptStoryPageList::ScriptStoryPageList(ScriptCompany::CompanyID company)
 {
-	uint8_t c = company;
-	if (company == ScriptCompany::COMPANY_INVALID) c = INVALID_COMPANY;
+	::CompanyID c = ScriptCompany::FromScriptCompanyID(company);
 
 	ScriptList::FillList<StoryPage>(this,
 		[c](const StoryPage *p) {return p->company == c || p->company == INVALID_COMPANY; }

--- a/src/script/api/script_subsidy.cpp
+++ b/src/script/api/script_subsidy.cpp
@@ -50,7 +50,7 @@
 {
 	if (!IsAwarded(subsidy_id)) return ScriptCompany::COMPANY_INVALID;
 
-	return (ScriptCompany::CompanyID)((uint8_t)::Subsidy::Get(subsidy_id)->awarded);
+	return ScriptCompany::ToScriptCompanyID(::Subsidy::Get(subsidy_id)->awarded);
 }
 
 /* static */ ScriptDate::Date ScriptSubsidy::GetExpireDate(SubsidyID subsidy_id)

--- a/src/script/api/script_tile.cpp
+++ b/src/script/api/script_tile.cpp
@@ -209,7 +209,7 @@
 	if (::IsTileType(tile, MP_HOUSE)) return ScriptCompany::COMPANY_INVALID;
 	if (::IsTileType(tile, MP_INDUSTRY)) return ScriptCompany::COMPANY_INVALID;
 
-	return ScriptCompany::ResolveCompanyID((ScriptCompany::CompanyID)(uint8_t)::GetTileOwner(tile));
+	return ScriptCompany::ResolveCompanyID(ScriptCompany::ToScriptCompanyID(::GetTileOwner(tile)));
 }
 
 /* static */ bool ScriptTile::HasTransportType(TileIndex tile, TransportType transport_type)

--- a/src/script/api/script_town.cpp
+++ b/src/script/api/script_town.cpp
@@ -243,7 +243,7 @@
 	EnforceCompanyModeValid(ScriptCompany::COMPANY_INVALID);
 	if (!IsValidTown(town_id)) return ScriptCompany::COMPANY_INVALID;
 
-	return (ScriptCompany::CompanyID)(int8_t)::Town::Get(town_id)->exclusivity;
+	return ScriptCompany::ToScriptCompanyID(::Town::Get(town_id)->exclusivity);
 }
 
 /* static */ SQInteger ScriptTown::GetExclusiveRightsDuration(TownID town_id)
@@ -317,22 +317,23 @@
 	ScriptCompany::CompanyID company = ScriptCompany::ResolveCompanyID(company_id);
 	if (company == ScriptCompany::COMPANY_INVALID) return TOWN_RATING_INVALID;
 
+	::CompanyID c = ScriptCompany::FromScriptCompanyID(company);
 	const Town *t = ::Town::Get(town_id);
-	if (!HasBit(t->have_ratings, company)) {
+	if (!HasBit(t->have_ratings, c)) {
 		return TOWN_RATING_NONE;
-	} else if (t->ratings[company] <= RATING_APPALLING) {
+	} else if (t->ratings[c] <= RATING_APPALLING) {
 		return TOWN_RATING_APPALLING;
-	} else if (t->ratings[company] <= RATING_VERYPOOR) {
+	} else if (t->ratings[c] <= RATING_VERYPOOR) {
 		return TOWN_RATING_VERY_POOR;
-	} else if (t->ratings[company] <= RATING_POOR) {
+	} else if (t->ratings[c] <= RATING_POOR) {
 		return TOWN_RATING_POOR;
-	} else if (t->ratings[company] <= RATING_MEDIOCRE) {
+	} else if (t->ratings[c] <= RATING_MEDIOCRE) {
 		return TOWN_RATING_MEDIOCRE;
-	} else if (t->ratings[company] <= RATING_GOOD) {
+	} else if (t->ratings[c] <= RATING_GOOD) {
 		return TOWN_RATING_GOOD;
-	} else if (t->ratings[company] <= RATING_VERYGOOD) {
+	} else if (t->ratings[c] <= RATING_VERYGOOD) {
 		return TOWN_RATING_VERY_GOOD;
-	} else if (t->ratings[company] <= RATING_EXCELLENT) {
+	} else if (t->ratings[c] <= RATING_EXCELLENT) {
 		return TOWN_RATING_EXCELLENT;
 	} else {
 		return TOWN_RATING_OUTSTANDING;
@@ -346,21 +347,22 @@
 	if (company == ScriptCompany::COMPANY_INVALID) return TOWN_RATING_INVALID;
 
 	const Town *t = ::Town::Get(town_id);
-	return t->ratings[company];
+	return t->ratings[ScriptCompany::FromScriptCompanyID(company)];
 }
 
-/* static */ bool ScriptTown::ChangeRating(TownID town_id, ScriptCompany::CompanyID company_id, SQInteger delta)
+/* static */ bool ScriptTown::ChangeRating(TownID town_id, ScriptCompany::CompanyID company, SQInteger delta)
 {
 	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidTown(town_id));
-	ScriptCompany::CompanyID company = ScriptCompany::ResolveCompanyID(company_id);
+	company = ScriptCompany::ResolveCompanyID(company);
 	EnforcePrecondition(false, company != ScriptCompany::COMPANY_INVALID);
 
+	::CompanyID c = ScriptCompany::FromScriptCompanyID(company);
 	const Town *t = ::Town::Get(town_id);
-	int16_t new_rating = Clamp(t->ratings[company] + delta, RATING_MINIMUM, RATING_MAXIMUM);
-	if (new_rating == t->ratings[company]) return false;
+	int16_t new_rating = Clamp(t->ratings[c] + delta, RATING_MINIMUM, RATING_MAXIMUM);
+	if (new_rating == t->ratings[c]) return false;
 
-	return ScriptObject::Command<CMD_TOWN_RATING>::Do(town_id, (::CompanyID)company_id, new_rating);
+	return ScriptObject::Command<CMD_TOWN_RATING>::Do(town_id, c, new_rating);
 }
 
 /* static */ SQInteger ScriptTown::GetAllowedNoise(TownID town_id)

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -46,7 +46,7 @@
 {
 	if (!IsValidVehicle(vehicle_id)) return ScriptCompany::COMPANY_INVALID;
 
-	return static_cast<ScriptCompany::CompanyID>((int)::Vehicle::Get(vehicle_id)->owner);
+	return ScriptCompany::ToScriptCompanyID(::Vehicle::Get(vehicle_id)->owner);
 }
 
 /* static */ SQInteger ScriptVehicle::GetNumWagons(VehicleID vehicle_id)

--- a/src/script/api/script_vehiclelist.cpp
+++ b/src/script/api/script_vehiclelist.cpp
@@ -24,7 +24,7 @@ ScriptVehicleList::ScriptVehicleList(HSQUIRRELVM vm)
 	EnforceDeityOrCompanyModeValid_Void();
 
 	bool is_deity = ScriptCompanyMode::IsDeity();
-	CompanyID owner = ScriptObject::GetCompany();
+	::CompanyID owner = ScriptObject::GetCompany();
 
 	ScriptList::FillList<Vehicle>(vm, this,
 		[is_deity, owner](const Vehicle *v) {
@@ -39,7 +39,7 @@ ScriptVehicleList_Station::ScriptVehicleList_Station(StationID station_id)
 	if (!ScriptBaseStation::IsValidBaseStation(station_id)) return;
 
 	bool is_deity = ScriptCompanyMode::IsDeity();
-	CompanyID owner = ScriptObject::GetCompany();
+	::CompanyID owner = ScriptObject::GetCompany();
 
 	FindVehiclesWithOrder(
 		[is_deity, owner](const Vehicle *v) { return is_deity || v->owner == owner; },
@@ -86,7 +86,7 @@ ScriptVehicleList_Depot::ScriptVehicleList_Depot(TileIndex tile)
 	}
 
 	bool is_deity = ScriptCompanyMode::IsDeity();
-	CompanyID owner = ScriptObject::GetCompany();
+	::CompanyID owner = ScriptObject::GetCompany();
 
 	FindVehiclesWithOrder(
 		[is_deity, owner, type](const Vehicle *v) { return (is_deity || v->owner == owner) && v->type == type; },
@@ -109,7 +109,7 @@ ScriptVehicleList_Group::ScriptVehicleList_Group(GroupID group_id)
 	EnforceCompanyModeValid_Void();
 	if (!ScriptGroup::IsValidGroup(group_id)) return;
 
-	CompanyID owner = ScriptObject::GetCompany();
+	::CompanyID owner = ScriptObject::GetCompany();
 
 	ScriptList::FillList<Vehicle>(this,
 		[owner](const Vehicle *v) { return v->owner == owner && v->IsPrimaryVehicle(); },
@@ -122,7 +122,7 @@ ScriptVehicleList_DefaultGroup::ScriptVehicleList_DefaultGroup(ScriptVehicle::Ve
 	EnforceCompanyModeValid_Void();
 	if (vehicle_type < ScriptVehicle::VT_RAIL || vehicle_type > ScriptVehicle::VT_AIR) return;
 
-	CompanyID owner = ScriptObject::GetCompany();
+	::CompanyID owner = ScriptObject::GetCompany();
 
 	ScriptList::FillList<Vehicle>(this,
 		[owner](const Vehicle *v) { return v->owner == owner && v->IsPrimaryVehicle(); },

--- a/src/script/api/script_viewport.cpp
+++ b/src/script/api/script_viewport.cpp
@@ -42,7 +42,7 @@
 	company = ScriptCompany::ResolveCompanyID(company);
 	EnforcePrecondition(false, company != ScriptCompany::COMPANY_INVALID);
 
-	return ScriptObject::Command<CMD_SCROLL_VIEWPORT>::Do(tile, VST_COMPANY, company);
+	return ScriptObject::Command<CMD_SCROLL_VIEWPORT>::Do(tile, VST_COMPANY, ScriptCompany::FromScriptCompanyID(company));
 }
 
 /* static */ bool ScriptViewport::ScrollClientTo(ScriptClient::ClientID client, TileIndex tile)

--- a/src/script/api/script_waypointlist.cpp
+++ b/src/script/api/script_waypointlist.cpp
@@ -20,7 +20,7 @@ ScriptWaypointList::ScriptWaypointList(ScriptWaypoint::WaypointType waypoint_typ
 	EnforceDeityOrCompanyModeValid_Void();
 
 	bool is_deity = ScriptCompanyMode::IsDeity();
-	CompanyID owner = ScriptObject::GetCompany();
+	::CompanyID owner = ScriptObject::GetCompany();
 	ScriptList::FillList<Waypoint>(this,
 		[is_deity, owner, waypoint_type](const Waypoint *wp) {
 			return (is_deity || wp->owner == owner || wp->owner == OWNER_NONE) && (wp->facilities & static_cast<StationFacility>(waypoint_type)) != 0;


### PR DESCRIPTION
## Motivation / Problem

In the script's API `COMPANY_INVALID` has a value of -1, whereas the internal game's `INVALID_COMPANY` has a value of 255. Since the script's API also has a `COMPANY_SPECTATOR` with a value of 255, these enumerations cannot be easily switched between by casting.

So you need to be very vigilant everywhere to convert `COMPANY_INVALID` to `INVALID_COMPANY` or back.


## Description

Replace all casts in the script API with either `ScriptCompany::FromScriptCompanyID` or `ScriptCompany::ToScriptCompanyID`.

Also make clear whether `CompanyID` is `::CompanyID` or `ScriptCompany::CompanyID` by using either one of those over `CompanyID` in the script's API.


## Limitations

`ScriptCargoMonitoring` now resolves `COMPANY_SELF`. That is primarily because I introduced an `assert` to ensure `COMPANY_SELF` will be resolved before calling `ScriptCompany::FromScriptCompanyID`, and here the user could pass `COMPANY_SELF` so that needed to be removed. Resolving it is the easiest way to do so.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
