### PR TITLE
Codechange: do not use ScriptCompany::CompanyID outside of the script API

### DIFF
--- a/src/goal.cpp
+++ b/src/goal.cpp
@@ -306,7 +306,7 @@ CommandCost CmdGoalQuestionAnswer(DoCommandFlag flags, uint16_t uniqueid, uint8_
 	}
 
 	if (flags & DC_EXEC) {
-		Game::NewEvent(new ScriptEventGoalQuestionAnswer(uniqueid, (ScriptCompany::CompanyID)(uint8_t)_current_company, (ScriptGoal::QuestionButton)(1 << button)));
+		Game::NewEvent(new ScriptEventGoalQuestionAnswer(uniqueid, _current_company, (ScriptGoal::QuestionButton)(1 << button)));
 	}
 
 	return CommandCost();

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -1034,10 +1034,10 @@ public:
 	 * @param company The company that is replying.
 	 * @param button The button the company pressed.
 	 */
-	ScriptEventGoalQuestionAnswer(uint16_t uniqueid, ScriptCompany::CompanyID company, ScriptGoal::QuestionButton button) :
+	ScriptEventGoalQuestionAnswer(uint16_t uniqueid, ::CompanyID company, ScriptGoal::QuestionButton button) :
 		ScriptEvent(ET_GOAL_QUESTION_ANSWER),
 		uniqueid(uniqueid),
-		company(company),
+		company(ScriptCompany::ToScriptCompanyID(company)),
 		button(button)
 	{}
 #endif /* DOXYGEN_API */
@@ -1085,9 +1085,9 @@ public:
 	 * @param company The company.
 	 * @param town The town.
 	 */
-	ScriptEventCompanyTown(ScriptEventType event, ScriptCompany::CompanyID company, TownID town) :
+	ScriptEventCompanyTown(ScriptEventType event, ::CompanyID company, TownID town) :
 		ScriptEvent(event),
-		company(company),
+		company(ScriptCompany::ToScriptCompanyID(company)),
 		town(town)
 	{}
 #endif /* DOXYGEN_API */
@@ -1128,7 +1128,7 @@ public:
 	 * @param company The company.
 	 * @param town The town.
 	 */
-	ScriptEventExclusiveTransportRights(ScriptCompany::CompanyID company, TownID town) :
+	ScriptEventExclusiveTransportRights(::CompanyID company, TownID town) :
 		ScriptEventCompanyTown(ET_EXCLUSIVE_TRANSPORT_RIGHTS, company, town)
 	{}
 #endif /* DOXYGEN_API */
@@ -1153,7 +1153,7 @@ public:
 	 * @param company The company.
 	 * @param town The town.
 	 */
-	ScriptEventRoadReconstruction(ScriptCompany::CompanyID company, TownID town) :
+	ScriptEventRoadReconstruction(::CompanyID company, TownID town) :
 		ScriptEventCompanyTown(ET_ROAD_RECONSTRUCTION, company, town)
 	{}
 #endif /* DOXYGEN_API */

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -3390,8 +3390,8 @@ static CommandCost TownActionRoadRebuild(Town *t, DoCommandFlag flags)
 		AddNewsItem(
 			TimerGameEconomy::UsingWallclockUnits() ? STR_NEWS_ROAD_REBUILDING_MINUTES : STR_NEWS_ROAD_REBUILDING_MONTHS,
 			NewsType::General, NewsStyle::Normal, {}, NewsReferenceType::Town, t->index, NewsReferenceType::None, UINT32_MAX);
-		AI::BroadcastNewEvent(new ScriptEventRoadReconstruction((ScriptCompany::CompanyID)(Owner)_current_company, t->index));
-		Game::NewEvent(new ScriptEventRoadReconstruction((ScriptCompany::CompanyID)(Owner)_current_company, t->index));
+		AI::BroadcastNewEvent(new ScriptEventRoadReconstruction(_current_company, t->index));
+		Game::NewEvent(new ScriptEventRoadReconstruction(_current_company, t->index));
 	}
 	return CommandCost();
 }
@@ -3545,8 +3545,8 @@ static CommandCost TownActionBuyRights(Town *t, DoCommandFlag flags)
 		SetDParam(2, t->index);
 		SetDParamStr(3, cni->company_name);
 		AddNewsItem(STR_MESSAGE_NEWS_FORMAT, NewsType::General, NewsStyle::Company, {}, NewsReferenceType::Town, t->index, NewsReferenceType::None, UINT32_MAX, std::move(cni));
-		AI::BroadcastNewEvent(new ScriptEventExclusiveTransportRights((ScriptCompany::CompanyID)(Owner)_current_company, t->index));
-		Game::NewEvent(new ScriptEventExclusiveTransportRights((ScriptCompany::CompanyID)(Owner)_current_company, t->index));
+		AI::BroadcastNewEvent(new ScriptEventExclusiveTransportRights(_current_company, t->index));
+		Game::NewEvent(new ScriptEventExclusiveTransportRights(_current_company, t->index));
 	}
 	return CommandCost();
 }


### PR DESCRIPTION
## Motivation / Problem

`ScriptCompany::CompanyID` is being used outside the script API. Since it's not identical to the game's internal `::CompanyID` this might cause problems. Just handle all those peculiarities in the script API's side.


## Description

Instead of doing a cast to `ScriptCompany::CompanyID` outside of the script API, pass `::CompanyID` to the events (already happened for most events, these three are the odd ones out).
Do the conversion to `ScriptCompany::CompanyID` in the script API using `ScriptCompany::ToScriptCompanyID`, like is done for all the other events with company as parameter.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
