### PR TITLE
Codechange: make AdminID, ClientPoolID, DepotID and GroupID PoolIDs

### DIFF
--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -381,12 +381,12 @@ public:
 		switch (widget) {
 			case WID_RV_CAPTION:
 				SetDParam(0, STR_REPLACE_VEHICLE_TRAIN + this->window_number);
-				switch (this->sel_group) {
-					case ALL_GROUP:
+				switch (this->sel_group.base()) {
+					case ALL_GROUP.base():
 						SetDParam(1, STR_GROUP_ALL_TRAINS + this->window_number);
 						break;
 
-					case DEFAULT_GROUP:
+					case DEFAULT_GROUP.base():
 						SetDParam(1, STR_GROUP_DEFAULT_TRAINS + this->window_number);
 						break;
 

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -723,7 +723,7 @@ public:
 			case VEH_AIRCRAFT: this->livery_class = LC_GROUP_AIRCRAFT; break;
 			default: NOT_REACHED();
 		}
-		this->sel = group;
+		this->sel = group.base();
 		this->LowerWidget(WID_SCL_CLASS_GENERAL + this->livery_class);
 
 		this->groups.ForceRebuild();
@@ -944,12 +944,12 @@ public:
 						}
 					}
 				} else {
-					this->sel = INVALID_GROUP;
+					this->sel = INVALID_GROUP.base();
 					this->groups.ForceRebuild();
 					this->BuildGroupList(this->window_number);
 
 					if (!this->groups.empty()) {
-						this->sel = this->groups[0].group->index;
+						this->sel = this->groups[0].group->index.base();
 					}
 				}
 
@@ -986,7 +986,7 @@ public:
 					auto it = this->vscroll->GetScrolledItemFromWidget(this->groups, pt.y, this, widget);
 					if (it == std::end(this->groups)) return;
 
-					this->sel = it->group->index;
+					this->sel = it->group->index.base();
 				}
 				this->SetDirty();
 				break;
@@ -1017,7 +1017,7 @@ public:
 			}
 		} else {
 			/* Setting group livery */
-			Command<CMD_SET_GROUP_LIVERY>::Post(this->sel, widget == WID_SCL_PRI_COL_DROPDOWN, colour);
+			Command<CMD_SET_GROUP_LIVERY>::Post(static_cast<GroupID>(this->sel), widget == WID_SCL_PRI_COL_DROPDOWN, colour);
 		}
 	}
 
@@ -1038,8 +1038,8 @@ public:
 				this->SetRows();
 
 				if (!Group::IsValidID(this->sel)) {
-					this->sel = INVALID_GROUP;
-					if (!this->groups.empty()) this->sel = this->groups[0].group->index;
+					this->sel = INVALID_GROUP.base();
+					if (!this->groups.empty()) this->sel = this->groups[0].group->index.base();
 				}
 
 				this->SetDirty();

--- a/src/depot_base.h
+++ b/src/depot_base.h
@@ -14,7 +14,7 @@
 #include "core/pool_type.hpp"
 #include "timer/timer_game_calendar.h"
 
-typedef Pool<Depot, DepotID, 64, 64000> DepotPool;
+typedef Pool<Depot, DepotID, 64, DepotID::End().base()> DepotPool;
 extern DepotPool _depot_pool;
 
 struct Depot : DepotPool::PoolItem<&_depot_pool> {

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -299,7 +299,7 @@ struct DepotWindow : Window {
 	void Close([[maybe_unused]] int data = 0) override
 	{
 		CloseWindowById(WC_BUILD_VEHICLE, this->window_number);
-		CloseWindowById(GetWindowClassForVehicleType(this->type), VehicleListIdentifier(VL_DEPOT_LIST, this->type, this->owner, this->GetDestinationIndex().base()).ToWindowNumber(), false);
+		CloseWindowById(GetWindowClassForVehicleType(this->type), VehicleListIdentifier(VL_DEPOT_LIST, this->type, this->owner, this->GetDestinationIndex()).ToWindowNumber(), false);
 		OrderBackup::Reset(TileIndex(this->window_number));
 		this->Window::Close();
 	}

--- a/src/depot_map.h
+++ b/src/depot_map.h
@@ -54,7 +54,7 @@ inline DepotID GetDepotIndex(Tile t)
 {
 	/* Hangars don't have a Depot class, thus store no DepotID. */
 	assert(IsRailDepotTile(t) || IsRoadDepotTile(t) || IsShipDepotTile(t));
-	return t.m2();
+	return DepotID{t.m2()};
 }
 
 /**

--- a/src/depot_type.h
+++ b/src/depot_type.h
@@ -10,10 +10,12 @@
 #ifndef DEPOT_TYPE_H
 #define DEPOT_TYPE_H
 
-typedef uint16_t DepotID; ///< Type for the unique identifier of depots.
+#include "core/pool_type.hpp"
+
+using DepotID = PoolID<uint16_t, struct DepotIDTag, 64000, 0xFFFF>; ///< Type for the unique identifier of depots.
 struct Depot;
 
-static const DepotID INVALID_DEPOT = UINT16_MAX;
+static constexpr DepotID INVALID_DEPOT = DepotID::Invalid();
 
 static const uint MAX_LENGTH_DEPOT_NAME_CHARS = 32; ///< The maximum length of a depot name in characters including '\0'
 

--- a/src/group.h
+++ b/src/group.h
@@ -17,7 +17,7 @@
 #include "engine_type.h"
 #include "livery.h"
 
-typedef Pool<Group, GroupID, 16, 64000> GroupPool;
+using GroupPool = Pool<Group, GroupID, 16, GroupID::End().base()>;
 extern GroupPool _group_pool; ///< Pool of groups.
 
 /** Statistics and caches on the vehicles in a group. */

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -986,7 +986,7 @@ public:
 
 	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (str.has_value()) Command<CMD_ALTER_GROUP>::Post(STR_ERROR_GROUP_CAN_T_RENAME, AlterGroupMode::Rename, this->group_rename, 0, *str);
+		if (str.has_value()) Command<CMD_ALTER_GROUP>::Post(STR_ERROR_GROUP_CAN_T_RENAME, AlterGroupMode::Rename, this->group_rename, INVALID_GROUP, *str);
 		this->group_rename = INVALID_GROUP;
 	}
 

--- a/src/group_type.h
+++ b/src/group_type.h
@@ -10,12 +10,13 @@
 #ifndef GROUP_TYPE_H
 #define GROUP_TYPE_H
 
-typedef uint16_t GroupID; ///< Type for all group identifiers.
+#include "core/pool_type.hpp"
 
-static const GroupID NEW_GROUP     = 0xFFFC; ///< Sentinel for a to-be-created group.
-static const GroupID ALL_GROUP     = 0xFFFD; ///< All vehicles are in this group.
-static const GroupID DEFAULT_GROUP = 0xFFFE; ///< Ungrouped vehicles are in this group.
-static const GroupID INVALID_GROUP = 0xFFFF; ///< Sentinel for invalid groups.
+using GroupID = PoolID<uint16_t, struct GroupIDTag, 64000, 0xFFFF>;
+static constexpr GroupID NEW_GROUP{0xFFFC}; ///< Sentinel for a to-be-created group.
+static constexpr GroupID ALL_GROUP{0xFFFD}; ///< All vehicles are in this group.
+static constexpr GroupID DEFAULT_GROUP{0xFFFE}; ///< Ungrouped vehicles are in this group.
+static constexpr GroupID INVALID_GROUP = GroupID::Invalid(); ///< Sentinel for invalid groups.
 
 static const uint MAX_LENGTH_GROUP_NAME_CHARS = 32; ///< The maximum length of a group name in characters including '\0'
 

--- a/src/network/network_admin.h
+++ b/src/network/network_admin.h
@@ -18,7 +18,7 @@ extern AdminID _redirect_console_to_admin;
 
 class ServerNetworkAdminSocketHandler;
 /** Pool with all admin connections. */
-using NetworkAdminSocketPool = Pool<ServerNetworkAdminSocketHandler, AdminID, 2, 16, PoolType::NetworkAdmin>;
+using NetworkAdminSocketPool = Pool<ServerNetworkAdminSocketHandler, AdminID, 2, AdminID::End().base(), PoolType::NetworkAdmin>;
 extern NetworkAdminSocketPool _networkadminsocket_pool;
 
 /** Class for handling the server side of the game connection. */

--- a/src/network/network_base.h
+++ b/src/network/network_base.h
@@ -17,7 +17,7 @@
 #include "../timer/timer_game_economy.h"
 
 /** Type for the pool with client information. */
-using NetworkClientInfoPool = Pool<NetworkClientInfo, ClientPoolID, 8, MAX_CLIENT_SLOTS, PoolType::NetworkClient>;
+using NetworkClientInfoPool = Pool<NetworkClientInfo, ClientPoolID, 8, ClientPoolID::End().base(), PoolType::NetworkClient>;
 extern NetworkClientInfoPool _networkclientinfo_pool;
 
 /** Container for all information known about a client. */

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -47,9 +47,7 @@ DECLARE_INCREMENT_DECREMENT_OPERATORS(ClientID)
 static ClientID _network_client_id = CLIENT_ID_FIRST;
 
 /** Make very sure the preconditions given in network_type.h are actually followed */
-static_assert(MAX_CLIENT_SLOTS > MAX_CLIENTS);
-/** Yes... */
-static_assert(NetworkClientSocketPool::MAX_SIZE == MAX_CLIENT_SLOTS);
+static_assert(NetworkClientSocketPool::MAX_SIZE > MAX_CLIENTS);
 
 /** The pool with clients. */
 NetworkClientSocketPool _networkclientsocket_pool("NetworkClientSocket");
@@ -920,7 +918,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_IDENTIFY(Packet
 	ci->client_name = client_name;
 	ci->client_playas = playas;
 	ci->public_key = this->peer_public_key;
-	Debug(desync, 1, "client: {:08x}; {:02x}; {:02x}; {:02x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, (int)ci->client_playas, (int)ci->index);
+	Debug(desync, 1, "client: {:08x}; {:02x}; {:02x}; {:02x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, (int)ci->client_playas, ci->index);
 
 	/* Make sure companies to which people try to join are not autocleaned */
 	Company *c = Company::GetIfValid(playas);

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -17,7 +17,7 @@ class ServerNetworkGameSocketHandler;
 /** Make the code look slightly nicer/simpler. */
 typedef ServerNetworkGameSocketHandler NetworkClientSocket;
 /** Pool with all client sockets. */
-using NetworkClientSocketPool = Pool<NetworkClientSocket, ClientPoolID, 8, MAX_CLIENT_SLOTS, PoolType::NetworkClient>;
+using NetworkClientSocketPool = Pool<NetworkClientSocket, ClientPoolID, 8, ClientPoolID::End().base(), PoolType::NetworkClient>;
 extern NetworkClientSocketPool _networkclientsocket_pool;
 
 /** Class for handling the server side of the game connection. */

--- a/src/network/network_type.h
+++ b/src/network/network_type.h
@@ -11,6 +11,7 @@
 #define NETWORK_TYPE_H
 
 #include "../core/enum_type.hpp"
+#include "../core/pool_type.hpp"
 
 /** How many clients can we have */
 static const uint MAX_CLIENTS = 255;
@@ -56,10 +57,10 @@ enum ClientID : uint32_t {
 typedef uint8_t ClientPoolID;
 
 /** Indices into the admin tables. */
-typedef uint8_t AdminID;
+using AdminID = PoolID<uint8_t, struct AdminIDTag, 16, 0xFF>;
 
 /** An invalid admin marker. */
-static const AdminID INVALID_ADMIN_ID = UINT8_MAX;
+static constexpr AdminID INVALID_ADMIN_ID = AdminID::Invalid();
 
 /** Simple calculated statistics of a company */
 struct NetworkCompanyStats {

--- a/src/network/network_type.h
+++ b/src/network/network_type.h
@@ -17,13 +17,6 @@
 static const uint MAX_CLIENTS = 255;
 
 /**
- * The number of slots; must be at least 1 more than MAX_CLIENTS. It must
- * furthermore be less than or equal to 256 as client indices (sent over
- * the network) are 8 bits. It needs 1 more for the dedicated server.
- */
-static const uint MAX_CLIENT_SLOTS = 256;
-
-/**
  * Vehicletypes in the order they are send in info packets.
  */
 enum NetworkVehicleType : uint8_t {
@@ -54,7 +47,7 @@ enum ClientID : uint32_t {
 };
 
 /** Indices into the client related pools */
-typedef uint8_t ClientPoolID;
+using ClientPoolID = PoolID<uint16_t, struct ClientPoolIDTag, MAX_CLIENTS + 1 /* dedicated server. */, 0xFFFF>;
 
 /** Indices into the admin tables. */
 using AdminID = PoolID<uint8_t, struct AdminIDTag, 16, 0xFF>;

--- a/src/order_type.h
+++ b/src/order_type.h
@@ -25,6 +25,7 @@ struct DestinationID {
 
 	explicit DestinationID() = default;
 	constexpr DestinationID(size_t index) : value(static_cast<BaseType>(index)) {}
+	constexpr DestinationID(DepotID depot) : value(depot.base()) {}
 
 	constexpr DepotID ToDepotID() const noexcept { return static_cast<DepotID>(this->value); }
 	constexpr StationID ToStationID() const noexcept { return static_cast<StationID>(this->value); }

--- a/src/rail_map.h
+++ b/src/rail_map.h
@@ -554,7 +554,7 @@ inline void MakeRailDepot(Tile tile, Owner owner, DepotID depot_id, DiagDirectio
 	SetTileType(tile, MP_RAILWAY);
 	SetTileOwner(tile, owner);
 	SetDockingTile(tile, false);
-	tile.m2() = depot_id;
+	tile.m2() = depot_id.base();
 	tile.m3() = 0;
 	tile.m4() = 0;
 	tile.m5() = RAIL_TILE_DEPOT << 6 | dir;

--- a/src/road_map.h
+++ b/src/road_map.h
@@ -695,7 +695,7 @@ inline void MakeRoadDepot(Tile tile, Owner owner, DepotID depot_id, DiagDirectio
 {
 	SetTileType(tile, MP_ROAD);
 	SetTileOwner(tile, owner);
-	tile.m2() = depot_id;
+	tile.m2() = depot_id.base();
 	tile.m3() = 0;
 	tile.m4() = INVALID_ROADTYPE;
 	tile.m5() = ROAD_TILE_DEPOT << 6 | dir;

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2355,8 +2355,8 @@ bool AfterLoadGame()
 				d = nullptr;
 				continue;
 			}
-			tile.m2() = d->index;
-			if (IsTileType(tile, MP_WATER)) Tile(GetOtherShipDepotTile(tile)).m2() = d->index;
+			tile.m2() = d->index.base();
+			if (IsTileType(tile, MP_WATER)) Tile(GetOtherShipDepotTile(tile)).m2() = d->index.base();
 		}
 	}
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3335,7 +3335,7 @@ bool AfterLoadGame()
 		Company *c = Company::Get(g->owner);
 		if (IsSavegameVersionBefore(SLV_GROUP_NUMBERS)) {
 			/* Use the index as group number when converting old savegames. */
-			g->number = c->freegroups.UseID(g->index);
+			g->number = c->freegroups.UseID(g->index.base());
 		} else {
 			c->freegroups.UseID(g->number);
 		}

--- a/src/script/api/script_group.cpp
+++ b/src/script/api/script_group.cpp
@@ -36,7 +36,7 @@
 	if (!ScriptObject::Command<CMD_CREATE_GROUP>::Do(&ScriptInstance::DoCommandReturnGroupID, (::VehicleType)vehicle_type, parent_group_id)) return GROUP_INVALID;
 
 	/* In case of test-mode, we return GroupID 0 */
-	return static_cast<GroupID>(0);
+	return GroupID::Begin();
 }
 
 /* static */ bool ScriptGroup::DeleteGroup(GroupID group_id)
@@ -65,7 +65,7 @@
 	EnforcePreconditionEncodedText(false, text);
 	EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_GROUP_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG);
 
-	return ScriptObject::Command<CMD_ALTER_GROUP>::Do(AlterGroupMode::Rename, group_id, 0, text);
+	return ScriptObject::Command<CMD_ALTER_GROUP>::Do(AlterGroupMode::Rename, group_id, ::INVALID_GROUP, text);
 }
 
 /* static */ std::optional<std::string> ScriptGroup::GetName(GroupID group_id)

--- a/src/vehiclelist.h
+++ b/src/vehiclelist.h
@@ -46,6 +46,7 @@ struct VehicleListIdentifier {
 	constexpr VehicleID ToVehicleID() const { assert(this->type == VL_SHARED_ORDERS); return VehicleID(this->index); }
 
 	constexpr void SetIndex(uint32_t index) { this->index = index; }
+	constexpr void SetIndex(ConvertibleThroughBase auto index) { this->index = index.base(); }
 
 	/**
 	 * Create a simple vehicle list.
@@ -56,6 +57,9 @@ struct VehicleListIdentifier {
 	 */
 	VehicleListIdentifier(VehicleListType type, VehicleType vtype, CompanyID company, uint index = 0) :
 		type(type), vtype(vtype), company(company), index(index) {}
+
+	VehicleListIdentifier(VehicleListType type, VehicleType vtype, CompanyID company, ConvertibleThroughBase auto index) :
+		type(type), vtype(vtype), company(company), index(index.base()) {}
 
 	VehicleListIdentifier() = default;
 };

--- a/src/water_map.h
+++ b/src/water_map.h
@@ -461,7 +461,7 @@ inline void MakeShipDepot(Tile t, Owner o, DepotID did, DepotPart part, Axis a, 
 	SetTileOwner(t, o);
 	SetWaterClass(t, original_water_class);
 	SetDockingTile(t, false);
-	t.m2() = did;
+	t.m2() = did.base();
 	t.m3() = 0;
 	t.m4() = 0;
 	t.m5() = part << WBL_DEPOT_PART | a << WBL_DEPOT_AXIS;


### PR DESCRIPTION
## Motivation / Problem

Finishing the conversion to `PoolID`.


## Description

* Convert `ClientPoolID`: remove `MAX_CLIENT_SLOTS` and inject `MAX_CLIENTS + 1` into `ClientPoolID`. Also change type to `uint16_t` to hold the actual value, and remove comments indicating this PoolID is sent over the network. It isn't, that's `ClientID` which is 32 bits.
* Trivially convert `AdminID`, `DepotID` and `GroupID`.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
