### PR TITLE
Codechange: replace union with std::variant in ViewportSignKdtreeItem

### DIFF
--- a/src/cargomonitor.h
+++ b/src/cargomonitor.h
@@ -136,7 +136,7 @@ inline IndustryID DecodeMonitorIndustry(CargoMonitorID num)
 inline TownID DecodeMonitorTown(CargoMonitorID num)
 {
 	if (MonitorMonitorsIndustry(num)) return INVALID_TOWN;
-	return GB(num, CCB_TOWN_IND_NUMBER_START, CCB_TOWN_IND_NUMBER_LENGTH);
+	return static_cast<TownID>(GB(num, CCB_TOWN_IND_NUMBER_START, CCB_TOWN_IND_NUMBER_LENGTH));
 }
 
 void ClearCargoPickupMonitoring(CompanyID company = INVALID_OWNER);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1008,7 +1008,7 @@ bool AfterLoadGame()
 					if ((GB(t.m5(), 4, 2) == ROAD_TILE_CROSSING ? (Owner)t.m3() : GetTileOwner(t)) == OWNER_TOWN) {
 						SetTownIndex(t, CalcClosestTownFromTile(t)->index);
 					} else {
-						SetTownIndex(t, 0);
+						SetTownIndex(t, TOWN_BEGIN);
 					}
 					break;
 
@@ -1232,7 +1232,7 @@ bool AfterLoadGame()
 								GetRailType(t)
 							);
 						} else {
-							TownID town = IsTileOwner(t, OWNER_TOWN) ? ClosestTownFromTile(t, UINT_MAX)->index : 0;
+							TownID town = IsTileOwner(t, OWNER_TOWN) ? ClosestTownFromTile(t, UINT_MAX)->index : TOWN_BEGIN;
 
 							/* MakeRoadNormal */
 							SetTileType(t, MP_ROAD);

--- a/src/script/api/script_goal.cpp
+++ b/src/script/api/script_goal.cpp
@@ -36,7 +36,7 @@
 	return (type == GT_NONE && destination == 0) ||
 			(type == GT_TILE && ScriptMap::IsValidTile(::TileIndex(destination))) ||
 			(type == GT_INDUSTRY && ScriptIndustry::IsValidIndustry(destination)) ||
-			(type == GT_TOWN && ScriptTown::IsValidTown(destination)) ||
+			(type == GT_TOWN && ScriptTown::IsValidTown(static_cast<TownID>(destination))) ||
 			(type == GT_COMPANY && ScriptCompany::ResolveCompanyID(ScriptCompany::ToScriptCompanyID(static_cast<::CompanyID>(destination))) != ScriptCompany::COMPANY_INVALID) ||
 			(type == GT_STORY_PAGE && story_page != nullptr && (c == INVALID_COMPANY ? story_page->company == INVALID_COMPANY : story_page->company == INVALID_COMPANY || story_page->company == c));
 }

--- a/src/script/api/script_news.cpp
+++ b/src/script/api/script_news.cpp
@@ -34,7 +34,7 @@
 	                           (ref_type == NR_TILE     && ScriptMap::IsValidTile(::TileIndex(reference))) ||
 	                           (ref_type == NR_STATION  && ScriptStation::IsValidStation(reference)) ||
 	                           (ref_type == NR_INDUSTRY && ScriptIndustry::IsValidIndustry(reference)) ||
-	                           (ref_type == NR_TOWN     && ScriptTown::IsValidTown(reference)));
+	                           (ref_type == NR_TOWN     && ScriptTown::IsValidTown(static_cast<TownID>(reference))));
 
 	::CompanyID c = ScriptCompany::FromScriptCompanyID(company);
 

--- a/src/script/api/script_sign.cpp
+++ b/src/script/api/script_sign.cpp
@@ -84,5 +84,5 @@
 	if (!ScriptObject::Command<CMD_PLACE_SIGN>::Do(&ScriptInstance::DoCommandReturnSignID, location, text)) return INVALID_SIGN;
 
 	/* In case of test-mode, we return SignID 0 */
-	return 0;
+	return ::SIGN_BEGIN;
 }

--- a/src/script/api/script_sign.cpp
+++ b/src/script/api/script_sign.cpp
@@ -84,5 +84,5 @@
 	if (!ScriptObject::Command<CMD_PLACE_SIGN>::Do(&ScriptInstance::DoCommandReturnSignID, location, text)) return INVALID_SIGN;
 
 	/* In case of test-mode, we return SignID 0 */
-	return ::SIGN_BEGIN;
+	return SignID::Begin();
 }

--- a/src/script/api/script_subsidy.cpp
+++ b/src/script/api/script_subsidy.cpp
@@ -37,8 +37,8 @@
 	EnforcePrecondition(false, ScriptCargo::IsValidCargo(cargo_type));
 	EnforcePrecondition(false, from_type == SPT_INDUSTRY || from_type == SPT_TOWN);
 	EnforcePrecondition(false, to_type == SPT_INDUSTRY || to_type == SPT_TOWN);
-	EnforcePrecondition(false, (from_type == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(from_id)) || (from_type == SPT_TOWN && ScriptTown::IsValidTown(from_id)));
-	EnforcePrecondition(false, (to_type == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(to_id)) || (to_type == SPT_TOWN && ScriptTown::IsValidTown(to_id)));
+	EnforcePrecondition(false, (from_type == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(from_id)) || (from_type == SPT_TOWN && ScriptTown::IsValidTown(static_cast<TownID>(from_id))));
+	EnforcePrecondition(false, (to_type == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(to_id)) || (to_type == SPT_TOWN && ScriptTown::IsValidTown(static_cast<TownID>(to_id))));
 
 	Source from{static_cast<SourceID>(from_id), static_cast<SourceType>(from_type)};
 	Source to{static_cast<SourceID>(to_id), static_cast<SourceType>(to_type)};

--- a/src/signs_base.h
+++ b/src/signs_base.h
@@ -15,7 +15,7 @@
 #include "core/pool_type.hpp"
 #include "company_type.h"
 
-typedef Pool<Sign, SignID, 16, 64000> SignPool;
+typedef Pool<Sign, SignID, 16, SIGN_END> SignPool;
 extern SignPool _sign_pool;
 
 struct Sign : SignPool::PoolItem<&_sign_pool> {

--- a/src/signs_base.h
+++ b/src/signs_base.h
@@ -15,7 +15,7 @@
 #include "core/pool_type.hpp"
 #include "company_type.h"
 
-typedef Pool<Sign, SignID, 16, SIGN_END> SignPool;
+typedef Pool<Sign, SignID, 16, SignID::End().base()> SignPool;
 extern SignPool _sign_pool;
 
 struct Sign : SignPool::PoolItem<&_sign_pool> {

--- a/src/signs_type.h
+++ b/src/signs_type.h
@@ -11,11 +11,8 @@
 #define SIGNS_TYPE_H
 
 /** The type of the IDs of signs. */
-enum SignID : uint16_t {
-	SIGN_BEGIN = 0,
-	SIGN_END = 64000,
-	INVALID_SIGN = 0xFFFF ///< Sentinel for an invalid sign.
-};
+using SignID = PoolID<uint16_t, struct SignIDTag, 64000, 0xFFFF>;
+static constexpr SignID INVALID_SIGN = SignID::Invalid(); ///< Sentinel for an invalid sign.
 
 struct Sign;
 

--- a/src/signs_type.h
+++ b/src/signs_type.h
@@ -11,10 +11,13 @@
 #define SIGNS_TYPE_H
 
 /** The type of the IDs of signs. */
-typedef uint16_t SignID;
-struct Sign;
+enum SignID : uint16_t {
+	SIGN_BEGIN = 0,
+	SIGN_END = 64000,
+	INVALID_SIGN = 0xFFFF ///< Sentinel for an invalid sign.
+};
 
-static const SignID INVALID_SIGN = 0xFFFF; ///< Sentinel for an invalid sign.
+struct Sign;
 
 static const uint MAX_LENGTH_SIGN_NAME_CHARS = 32; ///< The maximum length of a sign name in characters including '\0'
 

--- a/src/town.h
+++ b/src/town.h
@@ -33,7 +33,7 @@ static const uint TOWN_GROWTH_DESERT = 0xFFFFFFFF; ///< The town needs the cargo
 static const uint16_t TOWN_GROWTH_RATE_NONE = 0xFFFF; ///< Special value for Town::growth_rate to disable town growth.
 static const uint16_t MAX_TOWN_GROWTH_TICKS = 930; ///< Max amount of original town ticks that still fit into uint16_t, about equal to UINT16_MAX / TOWN_GROWTH_TICKS but slightly less to simplify calculations
 
-typedef Pool<Town, TownID, 64, 64000> TownPool;
+typedef Pool<Town, TownID, 64, TOWN_END> TownPool;
 extern TownPool _town_pool;
 
 /** Data structure with cached data of towns. */

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -326,7 +326,7 @@ public:
 			}
 
 			case WID_TA_EXECUTE:
-				Command<CMD_DO_TOWN_ACTION>::Post(STR_ERROR_CAN_T_DO_THIS, this->town->xy, this->window_number, this->sel_index);
+				Command<CMD_DO_TOWN_ACTION>::Post(STR_ERROR_CAN_T_DO_THIS, this->town->xy, static_cast<TownID>(this->window_number), this->sel_index);
 				break;
 		}
 	}
@@ -521,12 +521,12 @@ public:
 				break;
 
 			case WID_TV_EXPAND: { // expand town - only available on Scenario editor
-				Command<CMD_EXPAND_TOWN>::Post(STR_ERROR_CAN_T_EXPAND_TOWN, this->window_number, 0);
+				Command<CMD_EXPAND_TOWN>::Post(STR_ERROR_CAN_T_EXPAND_TOWN, static_cast<TownID>(this->window_number), 0);
 				break;
 			}
 
 			case WID_TV_DELETE: // delete town - only available on Scenario editor
-				Command<CMD_DELETE_TOWN>::Post(STR_ERROR_TOWN_CAN_T_DELETE, this->window_number);
+				Command<CMD_DELETE_TOWN>::Post(STR_ERROR_TOWN_CAN_T_DELETE, static_cast<TownID>(this->window_number));
 				break;
 		}
 	}
@@ -615,7 +615,7 @@ public:
 	{
 		if (!str.has_value()) return;
 
-		Command<CMD_RENAME_TOWN>::Post(STR_ERROR_CAN_T_RENAME_TOWN, this->window_number, *str);
+		Command<CMD_RENAME_TOWN>::Post(STR_ERROR_CAN_T_RENAME_TOWN, static_cast<TownID>(this->window_number), *str);
 	}
 
 	IntervalTimer<TimerGameCalendar> daily_interval = {{TimerGameCalendar::DAY, TimerGameCalendar::Priority::NONE}, [this](auto) {

--- a/src/town_map.h
+++ b/src/town_map.h
@@ -23,7 +23,7 @@
 inline TownID GetTownIndex(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE) || (IsTileType(t, MP_ROAD) && !IsRoadDepot(t)));
-	return t.m2();
+	return static_cast<TownID>(t.m2());
 }
 
 /**

--- a/src/town_type.h
+++ b/src/town_type.h
@@ -12,8 +12,11 @@
 
 #include "core/enum_type.hpp"
 
-typedef uint16_t TownID;
-static const TownID INVALID_TOWN = 0xFFFF;
+enum TownID : uint16_t {
+	TOWN_BEGIN = 0,
+	TOWN_END = 64000,
+	INVALID_TOWN = 0xFFFF
+};
 
 struct Town;
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1447,7 +1447,7 @@ static void ViewportAddKdtreeSigns(DrawPixelInfo *dpi)
 		switch (item.type) {
 			case ViewportSignKdtreeItem::VKI_STATION: {
 				if (!show_stations) break;
-				const BaseStation *st = BaseStation::Get(item.id.station);
+				const BaseStation *st = BaseStation::Get(std::get<StationID>(item.id));
 
 				/* If no facilities are present the station is a ghost station. */
 				StationFacility facilities = st->facilities;
@@ -1464,7 +1464,7 @@ static void ViewportAddKdtreeSigns(DrawPixelInfo *dpi)
 
 			case ViewportSignKdtreeItem::VKI_WAYPOINT: {
 				if (!show_waypoints) break;
-				const BaseStation *st = BaseStation::Get(item.id.station);
+				const BaseStation *st = BaseStation::Get(std::get<StationID>(item.id));
 
 				/* Don't draw if station is owned by another company and competitor station names are hidden. Stations owned by none are never ignored. */
 				if (!show_competitors && _local_company != st->owner && st->owner != OWNER_NONE) break;
@@ -1475,12 +1475,12 @@ static void ViewportAddKdtreeSigns(DrawPixelInfo *dpi)
 
 			case ViewportSignKdtreeItem::VKI_TOWN:
 				if (!show_towns) break;
-				towns.push_back(Town::Get(item.id.town));
+				towns.push_back(Town::Get(std::get<TownID>(item.id)));
 				break;
 
 			case ViewportSignKdtreeItem::VKI_SIGN: {
 				if (!show_signs) break;
-				const Sign *si = Sign::Get(item.id.sign);
+				const Sign *si = Sign::Get(std::get<SignID>(item.id));
 
 				/* Don't draw if sign is owned by another company and competitor signs should be hidden.
 				 * Note: It is intentional that also signs owned by OWNER_NONE are hidden. Bankrupt
@@ -2297,27 +2297,27 @@ static bool CheckClickOnViewportSign(const Viewport *vp, int x, int y)
 		switch (item.type) {
 			case ViewportSignKdtreeItem::VKI_STATION:
 				if (!show_stations) break;
-				st = BaseStation::Get(item.id.station);
+				st = BaseStation::Get(std::get<StationID>(item.id));
 				if (!show_competitors && _local_company != st->owner && st->owner != OWNER_NONE) break;
 				if (CheckClickOnViewportSign(vp, x, y, &st->sign)) last_st = st;
 				break;
 
 			case ViewportSignKdtreeItem::VKI_WAYPOINT:
 				if (!show_waypoints) break;
-				st = BaseStation::Get(item.id.station);
+				st = BaseStation::Get(std::get<StationID>(item.id));
 				if (!show_competitors && _local_company != st->owner && st->owner != OWNER_NONE) break;
 				if (CheckClickOnViewportSign(vp, x, y, &st->sign)) last_st = st;
 				break;
 
 			case ViewportSignKdtreeItem::VKI_TOWN:
 				if (!show_towns) break;
-				t = Town::Get(item.id.town);
+				t = Town::Get(std::get<TownID>(item.id));
 				if (CheckClickOnViewportSign(vp, x, y, &t->cache.sign)) last_t = t;
 				break;
 
 			case ViewportSignKdtreeItem::VKI_SIGN:
 				if (!show_signs) break;
-				si = Sign::Get(item.id.sign);
+				si = Sign::Get(std::get<SignID>(item.id));
 				if (!show_competitors && _local_company != si->owner && si->owner != OWNER_DEITY) break;
 				if (CheckClickOnViewportSign(vp, x, y, &si->sign)) last_si = si;
 				break;
@@ -2351,7 +2351,7 @@ ViewportSignKdtreeItem ViewportSignKdtreeItem::MakeStation(StationID id)
 {
 	ViewportSignKdtreeItem item;
 	item.type = VKI_STATION;
-	item.id.station = id;
+	item.id = id;
 
 	const Station *st = Station::Get(id);
 	assert(st->sign.kdtree_valid);
@@ -2368,7 +2368,7 @@ ViewportSignKdtreeItem ViewportSignKdtreeItem::MakeWaypoint(StationID id)
 {
 	ViewportSignKdtreeItem item;
 	item.type = VKI_WAYPOINT;
-	item.id.station = id;
+	item.id = id;
 
 	const Waypoint *st = Waypoint::Get(id);
 	assert(st->sign.kdtree_valid);
@@ -2385,7 +2385,7 @@ ViewportSignKdtreeItem ViewportSignKdtreeItem::MakeTown(TownID id)
 {
 	ViewportSignKdtreeItem item;
 	item.type = VKI_TOWN;
-	item.id.town = id;
+	item.id = id;
 
 	const Town *town = Town::Get(id);
 	assert(town->cache.sign.kdtree_valid);
@@ -2402,7 +2402,7 @@ ViewportSignKdtreeItem ViewportSignKdtreeItem::MakeSign(SignID id)
 {
 	ViewportSignKdtreeItem item;
 	item.type = VKI_SIGN;
-	item.id.sign = id;
+	item.id = id;
 
 	const Sign *sign = Sign::Get(id);
 	assert(sign->sign.kdtree_valid);

--- a/src/viewport_kdtree.h
+++ b/src/viewport_kdtree.h
@@ -24,44 +24,20 @@ struct ViewportSignKdtreeItem {
 		VKI_SIGN,
 	};
 	ItemType type;
-	union {
-		StationID station;
-		TownID town;
-		SignID sign;
-	} id;
+	std::variant<StationID, TownID, SignID> id;
 	int32_t center;
 	int32_t top;
 
 	bool operator== (const ViewportSignKdtreeItem &other) const
 	{
 		if (this->type != other.type) return false;
-		switch (this->type) {
-			case VKI_STATION:
-			case VKI_WAYPOINT:
-				return this->id.station == other.id.station;
-			case VKI_TOWN:
-				return this->id.town == other.id.town;
-			case VKI_SIGN:
-				return this->id.sign == other.id.sign;
-			default:
-				NOT_REACHED();
-		}
+		return this->id == other.id;
 	}
 
 	bool operator< (const ViewportSignKdtreeItem &other) const
 	{
 		if (this->type != other.type) return this->type < other.type;
-		switch (this->type) {
-			case VKI_STATION:
-			case VKI_WAYPOINT:
-				return this->id.station < other.id.station;
-			case VKI_TOWN:
-				return this->id.town < other.id.town;
-			case VKI_SIGN:
-				return this->id.sign < other.id.sign;
-			default:
-				NOT_REACHED();
-		}
+		return this->id < other.id;
 	}
 
 	static ViewportSignKdtreeItem MakeStation(StationID id);


### PR DESCRIPTION
## Motivation / Problem

Finishing the conversion to `PoolID`.

In this case a `union` in `ViewportSignKdtreeItem` causes a chicken-egg problem as it cannot accept `PoolID`, but we cannot convert to `std::variant` as it cannot accept multiple same types in a useful manner (it does, but then you need to access by index instead of type).


## Description

* Convert `SignID` and `TownID` to an `enum`. This way they are different enough from `StationID` for `std::variant`, while still being accepted in a union.
* Convert the union to a `std::variant`.
* Convert `SignID` to a `PoolID`.


## Limitations

Leaves `TownID` as `enum`, however that cannot be changed to a `PoolID` because there is another transition to `std::variant` that needs to happen for the news. That is, however, going to be a future PR; #13497 shows the further steps.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
