### PR TITLE
Codechange: use std::variant for NewsReference

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -1357,7 +1357,7 @@ static void CrashAirplane(Aircraft *v)
 		newstype = NewsType::AccidentOther;
 	}
 
-	AddTileNewsItem(newsitem, newstype, vt, nullptr, st != nullptr ? st->index : INVALID_STATION);
+	AddTileNewsItem(newsitem, newstype, vt, st != nullptr ? st->index : INVALID_STATION);
 
 	ModifyStationRatingAround(vt, v->owner, -160, 30);
 	if (_settings_client.sound.disaster) SndPlayVehicleFx(SND_12_EXPLOSION, v);

--- a/src/cargo_type.h
+++ b/src/cargo_type.h
@@ -12,6 +12,7 @@
 
 #include "core/enum_type.hpp"
 #include "core/strong_typedef_type.hpp"
+#include "core/convertible_through_base.hpp"
 
 /** Globally unique label of a cargo type. */
 using CargoLabel = StrongType::Typedef<uint32_t, struct CargoLabelTag, StrongType::Compare>;

--- a/src/cargomonitor.h
+++ b/src/cargomonitor.h
@@ -125,7 +125,7 @@ inline bool MonitorMonitorsIndustry(CargoMonitorID num)
 inline IndustryID DecodeMonitorIndustry(CargoMonitorID num)
 {
 	if (!MonitorMonitorsIndustry(num)) return INVALID_INDUSTRY;
-	return GB(num, CCB_TOWN_IND_NUMBER_START, CCB_TOWN_IND_NUMBER_LENGTH);
+	return static_cast<IndustryID>(GB(num, CCB_TOWN_IND_NUMBER_START, CCB_TOWN_IND_NUMBER_LENGTH));
 }
 
 /**

--- a/src/cargomonitor.h
+++ b/src/cargomonitor.h
@@ -81,7 +81,7 @@ inline CargoMonitorID EncodeCargoTownMonitor(CompanyID company, CargoType ctype,
 	assert(company < (1 << CCB_COMPANY_LENGTH));
 
 	uint32_t ret = 0;
-	SB(ret, CCB_TOWN_IND_NUMBER_START, CCB_TOWN_IND_NUMBER_LENGTH, town);
+	SB(ret, CCB_TOWN_IND_NUMBER_START, CCB_TOWN_IND_NUMBER_LENGTH, town.base());
 	SB(ret, CCB_CARGO_TYPE_START, CCB_CARGO_TYPE_LENGTH, ctype);
 	SB(ret, CCB_COMPANY_START, CCB_COMPANY_LENGTH, company.base());
 	return ret;

--- a/src/cargomonitor.h
+++ b/src/cargomonitor.h
@@ -61,7 +61,7 @@ inline CargoMonitorID EncodeCargoIndustryMonitor(CompanyID company, CargoType ct
 	assert(company < (1 << CCB_COMPANY_LENGTH));
 
 	uint32_t ret = 0;
-	SB(ret, CCB_TOWN_IND_NUMBER_START, CCB_TOWN_IND_NUMBER_LENGTH, ind);
+	SB(ret, CCB_TOWN_IND_NUMBER_START, CCB_TOWN_IND_NUMBER_LENGTH, ind.base());
 	SetBit(ret, CCB_IS_INDUSTRY_BIT);
 	SB(ret, CCB_CARGO_TYPE_START, CCB_CARGO_TYPE_LENGTH, ctype);
 	SB(ret, CCB_COMPANY_START, CCB_COMPANY_LENGTH, company.base());

--- a/src/clear_map.h
+++ b/src/clear_map.h
@@ -207,7 +207,7 @@ inline IndustryID GetIndustryIndexOfField(Tile t)
 inline void SetIndustryIndexOfField(Tile t, IndustryID i)
 {
 	assert(GetClearGround(t) == CLEAR_FIELDS);
-	t.m2() = i;
+	t.m2() = i.base();
 }
 
 
@@ -282,7 +282,7 @@ inline void MakeField(Tile t, uint field_type, IndustryID industry)
 	SetTileType(t, MP_CLEAR);
 	t.m1() = 0;
 	SetTileOwner(t, OWNER_NONE);
-	t.m2() = industry;
+	t.m2() = industry.base();
 	t.m3() = field_type;
 	t.m4() = 0 << 5 | 0 << 2;
 	SetClearGroundDensity(t, CLEAR_FIELDS, 3);

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -215,6 +215,7 @@ public:
 };
 
 CommandCost CommandCostWithParam(StringID str, uint64_t value);
+CommandCost CommandCostWithParam(StringID str, ConvertibleThroughBase auto value) { return CommandCostWithParam(str, value.base()); }
 
 /**
  * List of commands.

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -425,7 +425,7 @@ set_name:;
 			SetDParam(1, STR_NEWS_COMPANY_LAUNCH_DESCRIPTION);
 			SetDParamStr(2, cni->company_name);
 			SetDParam(3, t->index);
-			AddNewsItem(STR_MESSAGE_NEWS_FORMAT, NewsType::CompanyInfo, NewsStyle::Company, {}, NewsReferenceType::Tile, c->last_build_coordinate.base(), NewsReferenceType::None, UINT32_MAX, std::move(cni));
+			AddNewsItem(STR_MESSAGE_NEWS_FORMAT, NewsType::CompanyInfo, NewsStyle::Company, {}, c->last_build_coordinate, {}, std::move(cni));
 		}
 		return;
 	}

--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -18,6 +18,7 @@
 #include "saveload/saveload.h"
 #include "screenshot.h"
 #include "network/network_survey.h"
+#include "news_func.h"
 #include "news_gui.h"
 #include "fileio_func.h"
 #include "fileio_type.h"
@@ -60,7 +61,8 @@ static void SurveyRecentNews(nlohmann::json &json)
 		TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(news.date);
 		json.push_back(fmt::format("({}-{:02}-{:02}) StringID: {}, Type: {}, Ref1: {}, {}, Ref2: {}, {}",
 		               ymd.year, ymd.month + 1, ymd.day, news.string_id, news.type,
-		               news.reftype1, news.ref1, news.reftype2, news.ref2));
+		               news.ref1.index(), SerialiseNewsReference(news.ref1),
+		               news.ref2.index(), SerialiseNewsReference(news.ref2)));
 		if (++i > 32) break;
 	}
 }

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -479,7 +479,7 @@ static bool DisasterTick_Aircraft(DisasterVehicle *v, uint16_t image_override, b
 		if (!IsTileType(tile, MP_INDUSTRY)) return true;
 
 		IndustryID ind = GetIndustryIndex(tile);
-		v->dest_tile = TileIndex{ind};
+		v->dest_tile = TileIndex{ind.base()};
 
 		if (GetIndustrySpec(Industry::Get(ind)->type)->behaviour.Test(behaviour)) {
 			v->state = 1;
@@ -969,7 +969,7 @@ void ReleaseDisastersTargetingIndustry(IndustryID i)
 		/* primary disaster vehicles that have chosen target */
 		if (v->subtype == ST_AIRPLANE || v->subtype == ST_HELICOPTER) {
 			/* if it has chosen target, and it is this industry (yes, dest_tile is IndustryID here), set order to "leaving map peacefully" */
-			if (v->state > 0 && v->dest_tile == (uint32_t)i) v->state = 3;
+			if (v->state > 0 && v->dest_tile == i.base()) v->state = 3;
 		}
 	}
 }

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -354,7 +354,7 @@ static bool DisasterTick_Ufo(DisasterVehicle *v)
 					return false;
 				}
 				/* Target it. */
-				v->dest_tile = TileIndex{u->index};
+				v->dest_tile = TileIndex{u->index.base()};
 				v->age = CalendarTime::MIN_DATE;
 				u->disaster_vehicle = v->index;
 				break;

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1131,7 +1131,7 @@ static void NewVehicleAvailable(Engine *e)
 	if (!IsVehicleTypeDisabled(e->type, false) && !e->info.extra_flags.Test(ExtraEngineFlag::NoNews)) {
 		SetDParam(0, GetEngineCategoryName(index));
 		SetDParam(1, PackEngineNameDParam(index, EngineNameContext::PreviewNews));
-		AddNewsItem(STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE_WITH_TYPE, NewsType::NewVehicles, NewsStyle::Vehicle, {}, NewsReferenceType::Engine, index);
+		AddNewsItem(STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE_WITH_TYPE, NewsType::NewVehicles, NewsStyle::Vehicle, {}, index);
 	}
 
 	/* Update the toolbar. */

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -508,11 +508,11 @@ bool Engine::IsVariantHidden(CompanyID c) const
  */
 void EngineOverrideManager::ResetToDefaultMapping()
 {
-	EngineID id = ENGINE_BEGIN;
+	EngineID id = EngineID::Begin();
 	for (VehicleType type = VEH_TRAIN; type <= VEH_AIRCRAFT; type++) {
 		auto &map = this->mappings[type];
 		map.clear();
-		for (uint internal_id = 0; internal_id < _engine_counts[type]; internal_id++, id++) {
+		for (uint internal_id = 0; internal_id < _engine_counts[type]; internal_id++, ++id) {
 			map.emplace_back(INVALID_GRFID, internal_id, type, internal_id, id);
 		}
 	}
@@ -610,7 +610,7 @@ void SetupEngines()
 		assert(std::size(mapping) >= _engine_counts[type]);
 
 		for (const EngineIDMapping &eid : mapping) {
-			new (eid.engine) Engine(type, eid.internal_id);
+			new (eid.engine.base()) Engine(type, eid.internal_id);
 		}
 	}
 }
@@ -755,7 +755,7 @@ void StartupOneEngine(Engine *e, const TimerGameCalendar::YearMonthDay &aging_ym
 	}
 
 	SetRandomSeed(_settings_game.game_creation.generation_seed ^ seed ^
-	              (re->index << 16) ^ (re->info.base_intro.base() << 12) ^ (re->info.decay_speed << 8) ^
+	              (re->index.base() << 16) ^ (re->info.base_intro.base() << 12) ^ (re->info.decay_speed << 8) ^
 	              (re->info.lifelength.base() << 4) ^ re->info.retire_early ^
 	              e->type ^
 	              e->GetGRFID());

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -508,7 +508,7 @@ bool Engine::IsVariantHidden(CompanyID c) const
  */
 void EngineOverrideManager::ResetToDefaultMapping()
 {
-	EngineID id = 0;
+	EngineID id = ENGINE_BEGIN;
 	for (VehicleType type = VEH_TRAIN; type <= VEH_AIRCRAFT; type++) {
 		auto &map = this->mappings[type];
 		map.clear();

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -32,7 +32,7 @@ enum class EngineDisplayFlag : uint8_t {
 
 using EngineDisplayFlags = EnumBitSet<EngineDisplayFlag, uint8_t>;
 
-typedef Pool<Engine, EngineID, 64, 64000> EnginePool;
+typedef Pool<Engine, EngineID, 64, ENGINE_END> EnginePool;
 extern EnginePool _engine_pool;
 
 struct Engine : EnginePool::PoolItem<&_engine_pool> {

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -32,7 +32,7 @@ enum class EngineDisplayFlag : uint8_t {
 
 using EngineDisplayFlags = EnumBitSet<EngineDisplayFlag, uint8_t>;
 
-typedef Pool<Engine, EngineID, 64, ENGINE_END> EnginePool;
+typedef Pool<Engine, EngineID, 64, EngineID::End().base()> EnginePool;
 extern EnginePool _engine_pool;
 
 struct Engine : EnginePool::PoolItem<&_engine_pool> {

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -83,7 +83,7 @@ struct EnginePreviewWindow : Window {
 		if (widget != WID_EP_QUESTION) return;
 
 		/* Get size of engine sprite, on loan from depot_gui.cpp */
-		EngineID engine = this->window_number;
+		EngineID engine = static_cast<EngineID>(this->window_number);
 		EngineImageType image_type = EIT_PURCHASE;
 		uint x, y;
 		int x_offs, y_offs;
@@ -109,7 +109,7 @@ struct EnginePreviewWindow : Window {
 	{
 		if (widget != WID_EP_QUESTION) return;
 
-		EngineID engine = this->window_number;
+		EngineID engine = static_cast<EngineID>(this->window_number);
 		SetDParam(0, GetEngineCategoryName(engine));
 		int y = DrawStringMultiLine(r, STR_ENGINE_PREVIEW_MESSAGE, TC_FROMSTRING, SA_HOR_CENTER | SA_TOP) + WidgetDimensions::scaled.vsep_wide;
 
@@ -127,7 +127,7 @@ struct EnginePreviewWindow : Window {
 	{
 		switch (widget) {
 			case WID_EP_YES:
-				Command<CMD_WANT_ENGINE_PREVIEW>::Post(this->window_number);
+				Command<CMD_WANT_ENGINE_PREVIEW>::Post(static_cast<EngineID>(this->window_number));
 				[[fallthrough]];
 			case WID_EP_NO:
 				if (!_shift_pressed) this->Close();
@@ -139,7 +139,7 @@ struct EnginePreviewWindow : Window {
 	{
 		if (!gui_scope) return;
 
-		EngineID engine = this->window_number;
+		EngineID engine = static_cast<EngineID>(this->window_number);
 		if (Engine::Get(engine)->preview_company != _local_company) this->Close();
 	}
 };

--- a/src/engine_type.h
+++ b/src/engine_type.h
@@ -21,12 +21,8 @@
 #include "strings_type.h"
 
 /** Unique identification number of an engine. */
-enum EngineID : uint16_t {
-	ENGINE_BEGIN = 0,
-	ENGINE_END = 64000,
-	INVALID_ENGINE = 0xFFFF ///< Constant denoting an invalid engine.
-};
-DECLARE_INCREMENT_DECREMENT_OPERATORS(EngineID)
+using EngineID = PoolID<uint16_t, struct EngineIDTag, 64000, 0xFFFF>;
+static constexpr EngineID INVALID_ENGINE = EngineID::Invalid(); ///< Constant denoting an invalid engine.
 
 struct Engine;
 
@@ -214,7 +210,7 @@ enum class EngineNameContext : uint8_t {
 /** Combine an engine ID and a name context to an engine name dparam. */
 inline uint64_t PackEngineNameDParam(EngineID engine_id, EngineNameContext context, uint32_t extra_data = 0)
 {
-	return engine_id | (static_cast<uint64_t>(context) << 32) | (static_cast<uint64_t>(extra_data) << 40);
+	return engine_id.base() | (static_cast<uint64_t>(context) << 32) | (static_cast<uint64_t>(extra_data) << 40);
 }
 
 static const uint MAX_LENGTH_ENGINE_NAME_CHARS = 32; ///< The maximum length of an engine name in characters including '\0'

--- a/src/engine_type.h
+++ b/src/engine_type.h
@@ -20,7 +20,13 @@
 #include "sound_type.h"
 #include "strings_type.h"
 
-typedef uint16_t EngineID; ///< Unique identification number of an engine.
+/** Unique identification number of an engine. */
+enum EngineID : uint16_t {
+	ENGINE_BEGIN = 0,
+	ENGINE_END = 64000,
+	INVALID_ENGINE = 0xFFFF ///< Constant denoting an invalid engine.
+};
+DECLARE_INCREMENT_DECREMENT_OPERATORS(EngineID)
 
 struct Engine;
 
@@ -212,7 +218,5 @@ inline uint64_t PackEngineNameDParam(EngineID engine_id, EngineNameContext conte
 }
 
 static const uint MAX_LENGTH_ENGINE_NAME_CHARS = 32; ///< The maximum length of an engine name in characters including '\0'
-
-static const EngineID INVALID_ENGINE = 0xFFFF; ///< Constant denoting an invalid engine.
 
 #endif /* ENGINE_TYPE_H */

--- a/src/industry.h
+++ b/src/industry.h
@@ -20,7 +20,7 @@
 #include "timer/timer_game_economy.h"
 
 
-typedef Pool<Industry, IndustryID, 64, 64000> IndustryPool;
+typedef Pool<Industry, IndustryID, 64, INDUSTRY_END> IndustryPool;
 extern IndustryPool _industry_pool;
 
 static const TimerGameEconomy::Year PROCESSING_INDUSTRY_ABANDONMENT_YEARS{5}; ///< If a processing industry doesn't produce for this many consecutive economy years, it may close.

--- a/src/industry.h
+++ b/src/industry.h
@@ -20,7 +20,7 @@
 #include "timer/timer_game_economy.h"
 
 
-typedef Pool<Industry, IndustryID, 64, INDUSTRY_END> IndustryPool;
+typedef Pool<Industry, IndustryID, 64, IndustryID::End().base()> IndustryPool;
 extern IndustryPool _industry_pool;
 
 static const TimerGameEconomy::Year PROCESSING_INDUSTRY_ABANDONMENT_YEARS{5}; ///< If a processing industry doesn't produce for this many consecutive economy years, it may close.

--- a/src/industry_map.h
+++ b/src/industry_map.h
@@ -63,7 +63,7 @@ enum IndustryGraphics : uint8_t {
 inline IndustryID GetIndustryIndex(Tile t)
 {
 	assert(IsTileType(t, MP_INDUSTRY));
-	return t.m2();
+	return static_cast<IndustryID>(t.m2());
 }
 
 /**

--- a/src/industry_map.h
+++ b/src/industry_map.h
@@ -279,7 +279,7 @@ inline void MakeIndustry(Tile t, IndustryID index, IndustryGfx gfx, uint8_t rand
 {
 	SetTileType(t, MP_INDUSTRY);
 	t.m1() = 0;
-	t.m2() = index;
+	t.m2() = index.base();
 	SetIndustryRandomBits(t, random); // m3
 	t.m4() = 0;
 	SetIndustryGfx(t, gfx); // m5, part of m6

--- a/src/industry_type.h
+++ b/src/industry_type.h
@@ -10,11 +10,8 @@
 #ifndef INDUSTRY_TYPE_H
 #define INDUSTRY_TYPE_H
 
-enum IndustryID : uint16_t {
-	INDUSTRY_BEGIN = 0,
-	INDUSTRY_END = 64000,
-	INVALID_INDUSTRY = 0xFFFF
-};
+using IndustryID = PoolID<uint16_t, struct IndustryIDTag, 64000, 0xFFFF>;
+static constexpr IndustryID INVALID_INDUSTRY = IndustryID::Invalid();
 
 typedef uint16_t IndustryGfx;
 typedef uint8_t IndustryType;

--- a/src/industry_type.h
+++ b/src/industry_type.h
@@ -10,15 +10,18 @@
 #ifndef INDUSTRY_TYPE_H
 #define INDUSTRY_TYPE_H
 
-typedef uint16_t IndustryID;
+enum IndustryID : uint16_t {
+	INDUSTRY_BEGIN = 0,
+	INDUSTRY_END = 64000,
+	INVALID_INDUSTRY = 0xFFFF
+};
+
 typedef uint16_t IndustryGfx;
 typedef uint8_t IndustryType;
 struct Industry;
 
 struct IndustrySpec;
 struct IndustryTileSpec;
-
-static const IndustryID INVALID_INDUSTRY = 0xFFFF;
 
 static const IndustryType NUM_INDUSTRYTYPES_PER_GRF = 128;            ///< maximum number of industry types per NewGRF; limited to 128 because bit 7 has a special meaning in some variables/callbacks (see MapNewGRFIndustryType).
 

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -141,7 +141,7 @@ struct SelectGameWindow : public Window {
 				for (char c : match[2].str()) {
 					if (isdigit(c)) {
 						if (id_type == ID_VEHICLE) {
-							vc.vehicle = vc.vehicle * 10 + (c - '0');
+							vc.vehicle = static_cast<VehicleID>(vc.vehicle * 10 + (c - '0'));
 						}
 					} else {
 						id_type = ID_NONE;
@@ -155,7 +155,7 @@ struct SelectGameWindow : public Window {
 							case 'C': vc.align_h = IntroGameViewportCommand::CENTRE; break;
 							case 'R': vc.align_h = IntroGameViewportCommand::RIGHT; break;
 							case 'P': vc.pan_to_next = true; break;
-							case 'V': id_type = ID_VEHICLE; vc.vehicle = 0; break;
+							case 'V': id_type = ID_VEHICLE; vc.vehicle = VEHICLE_BEGIN; break;
 						}
 					}
 				}

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -141,7 +141,7 @@ struct SelectGameWindow : public Window {
 				for (char c : match[2].str()) {
 					if (isdigit(c)) {
 						if (id_type == ID_VEHICLE) {
-							vc.vehicle = static_cast<VehicleID>(vc.vehicle * 10 + (c - '0'));
+							vc.vehicle = static_cast<VehicleID>(vc.vehicle.base() * 10 + (c - '0'));
 						}
 					} else {
 						id_type = ID_NONE;
@@ -155,7 +155,7 @@ struct SelectGameWindow : public Window {
 							case 'C': vc.align_h = IntroGameViewportCommand::CENTRE; break;
 							case 'R': vc.align_h = IntroGameViewportCommand::RIGHT; break;
 							case 'P': vc.pan_to_next = true; break;
-							case 'V': id_type = ID_VEHICLE; vc.vehicle = VEHICLE_BEGIN; break;
+							case 'V': id_type = ID_VEHICLE; vc.vehicle = VehicleID::Begin(); break;
 						}
 					}
 				}

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1336,7 +1336,7 @@ static ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, B
 				break;
 
 			case 0x2F: // Engine variant
-				ei->variant_id = buf.ReadWord();
+				ei->variant_id = static_cast<EngineID>(buf.ReadWord());
 				break;
 
 			case 0x30: // Extra miscellaneous flags
@@ -1547,7 +1547,7 @@ static ChangeInfoResult RoadVehicleChangeInfo(uint first, uint last, int prop, B
 			}
 
 			case 0x26: // Engine variant
-				ei->variant_id = buf.ReadWord();
+				ei->variant_id = static_cast<EngineID>(buf.ReadWord());
 				break;
 
 			case 0x27: // Extra miscellaneous flags
@@ -1736,7 +1736,7 @@ static ChangeInfoResult ShipVehicleChangeInfo(uint first, uint last, int prop, B
 			}
 
 			case 0x20: // Engine variant
-				ei->variant_id = buf.ReadWord();
+				ei->variant_id = static_cast<EngineID>(buf.ReadWord());
 				break;
 
 			case 0x21: // Extra miscellaneous flags
@@ -1919,7 +1919,7 @@ static ChangeInfoResult AircraftVehicleChangeInfo(uint first, uint last, int pro
 				break;
 
 			case 0x20: // Engine variant
-				ei->variant_id = buf.ReadWord();
+				ei->variant_id = static_cast<EngineID>(buf.ReadWord());
 				break;
 
 			case 0x21: // Extra miscellaneous flags

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -345,7 +345,7 @@ struct GRFTempEngineData {
 	}
 };
 
-static std::vector<GRFTempEngineData> _gted;  ///< Temporary engine data used during NewGRF loading
+static ReferenceThroughBaseContainer<std::vector<GRFTempEngineData>> _gted;  ///< Temporary engine data used during NewGRF loading
 
 /**
  * Contains the GRF ID of the owner of a vehicle if it has been reserved.
@@ -6378,7 +6378,7 @@ static void FeatureNewName(ByteReader &buf)
 				if (!generic) {
 					Engine *e = GetNewEngine(_cur.grffile, (VehicleType)feature, id, _cur.grfconfig->flags.Test(GRFConfigFlag::Static));
 					if (e == nullptr) break;
-					StringID string = AddGRFString(_cur.grffile->grfid, GRFStringID{e->index}, lang, new_scheme, false, name, e->info.string_id);
+					StringID string = AddGRFString(_cur.grffile->grfid, GRFStringID{e->index.base()}, lang, new_scheme, false, name, e->info.string_id);
 					e->info.string_id = string;
 				} else {
 					AddGRFString(_cur.grffile->grfid, GRFStringID{id}, lang, new_scheme, true, name, STR_UNDEFINED);
@@ -9245,7 +9245,7 @@ static void FinaliseEngineArray()
 
 		/* Do final mapping on variant engine ID. */
 		if (e->info.variant_id != INVALID_ENGINE) {
-			e->info.variant_id = GetNewEngineID(e->grf_prop.grffile, e->type, e->info.variant_id);
+			e->info.variant_id = GetNewEngineID(e->grf_prop.grffile, e->type, e->info.variant_id.base());
 		}
 
 		if (!e->info.climates.Test(_settings_game.game_creation.landscape)) continue;

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -335,7 +335,7 @@ struct NewGRFInspectWindow : Window {
 			assert(this->HasChainIndex());
 			const Vehicle *v = Vehicle::Get(index);
 			v = v->Move(this->chain_index);
-			if (v != nullptr) index = v->index;
+			if (v != nullptr) index = v->index.base();
 		}
 		return index;
 	}

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -726,8 +726,8 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 		case 0x01: return MapOldSubType(v);
 		case 0x02: break; // not implemented
 		case 0x03: break; // not implemented
-		case 0x04: return v->index;
-		case 0x05: return GB(v->index, 8, 8);
+		case 0x04: return v->index.base();
+		case 0x05: return GB(v->index.base(), 8, 8);
 		case 0x06: break; // not implemented
 		case 0x07: break; // not implemented
 		case 0x08: break; // not implemented
@@ -839,7 +839,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 		case 0x57: return GB(ClampTo<int32_t>(v->GetDisplayProfitLastYear()),  8, 24);
 		case 0x58: return GB(ClampTo<int32_t>(v->GetDisplayProfitLastYear()), 16, 16);
 		case 0x59: return GB(ClampTo<int32_t>(v->GetDisplayProfitLastYear()), 24,  8);
-		case 0x5A: return v->Next() == nullptr ? INVALID_VEHICLE : v->Next()->index;
+		case 0x5A: return (v->Next() == nullptr ? INVALID_VEHICLE : v->Next()->index).base();
 		case 0x5B: break; // not implemented
 		case 0x5C: return ClampTo<int32_t>(v->value);
 		case 0x5D: return GB(ClampTo<int32_t>(v->value),  8, 24);
@@ -891,8 +891,8 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 				case 0x75: return GB(t->gcache.cached_power,  8, 24);
 				case 0x76: return GB(t->gcache.cached_power, 16, 16);
 				case 0x77: return GB(t->gcache.cached_power, 24,  8);
-				case 0x7C: return t->First()->index;
-				case 0x7D: return GB(t->First()->index, 8, 8);
+				case 0x7C: return t->First()->index.base();
+				case 0x7D: return GB(t->First()->index.base(), 8, 8);
 				case 0x7F: return 0; // Used for vehicle reversing hack in TTDP
 			}
 			break;
@@ -964,7 +964,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 			case 0xC4: return (Clamp(TimerGameCalendar::year, CalendarTime::ORIGINAL_BASE_YEAR, CalendarTime::ORIGINAL_MAX_YEAR) - CalendarTime::ORIGINAL_BASE_YEAR).base(); // Build year
 			case 0xC6: return Engine::Get(this->self_type)->grf_prop.local_id;
 			case 0xC7: return GB(Engine::Get(this->self_type)->grf_prop.local_id, 8, 8);
-			case 0xDA: return INVALID_VEHICLE; // Next vehicle
+			case 0xDA: return INVALID_VEHICLE.base(); // Next vehicle
 			case 0xF2: return 0; // Cargo subtype
 		}
 

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1332,7 +1332,7 @@ void CommitVehicleListOrderChanges()
 {
 	/* Build a list of EngineIDs. EngineIDs are sequential from 0 up to the number of pool items with no gaps. */
 	std::vector<EngineID> ordering(Engine::GetNumItems());
-	std::iota(std::begin(ordering), std::end(ordering), ENGINE_BEGIN);
+	std::iota(std::begin(ordering), std::end(ordering), EngineID::Begin());
 
 	/* Pre-sort engines by scope-grfid and local index */
 	std::ranges::sort(ordering, EnginePreSort);

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1332,7 +1332,7 @@ void CommitVehicleListOrderChanges()
 {
 	/* Build a list of EngineIDs. EngineIDs are sequential from 0 up to the number of pool items with no gaps. */
 	std::vector<EngineID> ordering(Engine::GetNumItems());
-	std::iota(std::begin(ordering), std::end(ordering), 0);
+	std::iota(std::begin(ordering), std::end(ordering), ENGINE_BEGIN);
 
 	/* Pre-sort engines by scope-grfid and local index */
 	std::ranges::sort(ordering, EnginePreSort);

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -170,7 +170,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t param_setID, uint8_
 			case 0x81: return GB(this->tile.base(), 8, 8);
 
 			/* Pointer to the town the industry is associated with */
-			case 0x82: return this->industry->town->index;
+			case 0x82: return this->industry->town->index.base();
 			case 0x83:
 			case 0x84:
 			case 0x85: Debug(grf, 0, "NewGRFs shouldn't be doing pointer magic"); break; // not supported
@@ -357,7 +357,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t param_setID, uint8_
 		case 0x80: return this->industry->location.tile.base();
 		case 0x81: return GB(this->industry->location.tile.base(), 8, 8);
 		/* Pointer to the town the industry is associated with */
-		case 0x82: return this->industry->town->index;
+		case 0x82: return this->industry->town->index.base();
 		case 0x83:
 		case 0x84:
 		case 0x85: Debug(grf, 0, "NewGRFs shouldn't be doing pointer magic"); break; // not supported

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -31,7 +31,7 @@
 			return 0;
 
 		/* Town index */
-		case 0x41: return this->t->index;
+		case 0x41: return this->t->index.base();
 
 		/* Get a variable from the persistent storage */
 		case 0x7C: {

--- a/src/news_cmd.h
+++ b/src/news_cmd.h
@@ -10,11 +10,11 @@
 #ifndef NEWS_CMD_H
 #define NEWS_CMD_H
 
-#include "command_type.h"
+#include "command_func.h"
 #include "company_type.h"
-#include "news_type.h"
+#include "news_func.h"
 
-CommandCost CmdCustomNewsItem(DoCommandFlags flags, NewsType type, NewsReferenceType reftype1, CompanyID company, uint32_t reference, const std::string &text);
+CommandCost CmdCustomNewsItem(DoCommandFlags flags, NewsType type, CompanyID company, NewsReference reference, const std::string &text);
 
 DEF_CMD_TRAIT(CMD_CUSTOM_NEWS_ITEM, CmdCustomNewsItem, CommandFlags({CommandFlag::StrCtrl, CommandFlag::Deity}), CMDT_OTHER_MANAGEMENT)
 

--- a/src/news_func.h
+++ b/src/news_func.h
@@ -15,11 +15,11 @@
 #include "station_type.h"
 #include "industry_type.h"
 
-void AddNewsItem(StringID string, NewsType type, NewsStyle style, NewsFlags flags, NewsReferenceType reftype1 = NewsReferenceType::None, uint32_t ref1 = UINT32_MAX, NewsReferenceType reftype2 = NewsReferenceType::None, uint32_t ref2 = UINT32_MAX, std::unique_ptr<NewsAllocatedData> &&data = nullptr, AdviceType advice_type = AdviceType::Invalid);
+void AddNewsItem(StringID string, NewsType type, NewsStyle style, NewsFlags flags, NewsReference ref1 = {}, NewsReference ref2 = {}, std::unique_ptr<NewsAllocatedData> &&data = nullptr, AdviceType advice_type = AdviceType::Invalid);
 
 inline void AddCompanyNewsItem(StringID string, std::unique_ptr<CompanyNewsInformation> cni)
 {
-	AddNewsItem(string, NewsType::CompanyInfo, NewsStyle::Company, {}, NewsReferenceType::None, UINT32_MAX, NewsReferenceType::None, UINT32_MAX, std::move(cni));
+	AddNewsItem(string, NewsType::CompanyInfo, NewsStyle::Company, {}, {}, {}, std::move(cni));
 }
 
 /**
@@ -29,7 +29,7 @@ inline void AddCompanyNewsItem(StringID string, std::unique_ptr<CompanyNewsInfor
  */
 inline void AddVehicleNewsItem(StringID string, NewsType type, VehicleID vehicle, StationID station = INVALID_STATION)
 {
-	AddNewsItem(string, type, NewsStyle::Thin, {NewsFlag::NoTransparency, NewsFlag::Shaded}, NewsReferenceType::Vehicle, vehicle, station == INVALID_STATION ? NewsReferenceType::None : NewsReferenceType::Station, station);
+	AddNewsItem(string, type, NewsStyle::Thin, {NewsFlag::NoTransparency, NewsFlag::Shaded}, vehicle, station == INVALID_STATION ? NewsReference{} : station);
 }
 
 /**
@@ -39,17 +39,17 @@ inline void AddVehicleNewsItem(StringID string, NewsType type, VehicleID vehicle
  */
 inline void AddVehicleAdviceNewsItem(AdviceType advice_type, StringID string, VehicleID vehicle)
 {
-	AddNewsItem(string, NewsType::Advice, NewsStyle::Small, {NewsFlag::InColour, NewsFlag::VehicleParam0}, NewsReferenceType::Vehicle, vehicle, NewsReferenceType::None, {}, nullptr, advice_type);
+	AddNewsItem(string, NewsType::Advice, NewsStyle::Small, {NewsFlag::InColour, NewsFlag::VehicleParam0}, vehicle, {}, nullptr, advice_type);
 }
 
-inline void AddTileNewsItem(StringID string, NewsType type, TileIndex tile, std::unique_ptr<NewsAllocatedData> &&data = nullptr, StationID station = INVALID_STATION)
+inline void AddTileNewsItem(StringID string, NewsType type, TileIndex tile, StationID station = INVALID_STATION)
 {
-	AddNewsItem(string, type, NewsStyle::Thin, {NewsFlag::NoTransparency, NewsFlag::Shaded}, NewsReferenceType::Tile, tile.base(), station == INVALID_STATION ? NewsReferenceType::None : NewsReferenceType::Station, station, std::move(data));
+	AddNewsItem(string, type, NewsStyle::Thin, {NewsFlag::NoTransparency, NewsFlag::Shaded}, tile, station == INVALID_STATION ? NewsReference{} : station);
 }
 
-inline void AddIndustryNewsItem(StringID string, NewsType type, IndustryID industry, std::unique_ptr<NewsAllocatedData> &&data = nullptr)
+inline void AddIndustryNewsItem(StringID string, NewsType type, IndustryID industry)
 {
-	AddNewsItem(string, type, NewsStyle::Thin, {NewsFlag::NoTransparency, NewsFlag::Shaded}, NewsReferenceType::Industry, industry, NewsReferenceType::None, UINT32_MAX, std::move(data));
+	AddNewsItem(string, type, NewsStyle::Thin, {NewsFlag::NoTransparency, NewsFlag::Shaded}, industry, {});
 }
 
 void NewsLoop();
@@ -61,5 +61,7 @@ void DeleteInvalidEngineNews();
 void DeleteVehicleNews(VehicleID vid, AdviceType advice_type = AdviceType::Invalid);
 void DeleteStationNews(StationID sid);
 void DeleteIndustryNews(IndustryID iid);
+
+uint32_t SerialiseNewsReference(const NewsReference &reference);
 
 #endif /* NEWS_FUNC_H */

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -920,7 +920,7 @@ uint32_t SerialiseNewsReference(const NewsReference &reference)
 	struct visitor {
 		uint32_t operator()(const std::monostate &) { return 0; }
 		uint32_t operator()(const TileIndex &t) { return t.base(); }
-		uint32_t operator()(const VehicleID v) { return v; }
+		uint32_t operator()(const VehicleID v) { return v.base(); }
 		uint32_t operator()(const StationID s) { return s; }
 		uint32_t operator()(const IndustryID i) { return i.base(); }
 		uint32_t operator()(const TownID t) { return t.base(); }
@@ -1084,7 +1084,7 @@ void ChangeVehicleNews(VehicleID from_index, VehicleID to_index)
 	for (auto &ni : _news) {
 		ChangeObject(ni.ref1, from_index, to_index);
 		ChangeObject(ni.ref2, from_index, to_index);
-		if (ni.flags.Test(NewsFlag::VehicleParam0) && std::get<uint64_t>(ni.params[0]) == from_index) ni.params[0] = to_index;
+		if (ni.flags.Test(NewsFlag::VehicleParam0) && std::get<uint64_t>(ni.params[0]) == from_index) ni.params[0] = to_index.base();
 	}
 }
 

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -923,7 +923,7 @@ uint32_t SerialiseNewsReference(const NewsReference &reference)
 		uint32_t operator()(const VehicleID v) { return v; }
 		uint32_t operator()(const StationID s) { return s; }
 		uint32_t operator()(const IndustryID i) { return i.base(); }
-		uint32_t operator()(const TownID t) { return t; }
+		uint32_t operator()(const TownID t) { return t.base(); }
 		uint32_t operator()(const EngineID e) { return e.base(); }
 	};
 

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -924,7 +924,7 @@ uint32_t SerialiseNewsReference(const NewsReference &reference)
 		uint32_t operator()(const StationID s) { return s; }
 		uint32_t operator()(const IndustryID i) { return i; }
 		uint32_t operator()(const TownID t) { return t; }
-		uint32_t operator()(const EngineID e) { return e; }
+		uint32_t operator()(const EngineID e) { return e.base(); }
 	};
 
 	return std::visit(visitor{}, reference);

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -922,7 +922,7 @@ uint32_t SerialiseNewsReference(const NewsReference &reference)
 		uint32_t operator()(const TileIndex &t) { return t.base(); }
 		uint32_t operator()(const VehicleID v) { return v; }
 		uint32_t operator()(const StationID s) { return s; }
-		uint32_t operator()(const IndustryID i) { return i; }
+		uint32_t operator()(const IndustryID i) { return i.base(); }
 		uint32_t operator()(const TownID t) { return t; }
 		uint32_t operator()(const EngineID e) { return e.base(); }
 	};

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -458,7 +458,7 @@ struct NewsWindow : Window {
 
 			case WID_N_VEH_INFO: {
 				assert(this->ni->reftype1 == NewsReferenceType::Engine);
-				EngineID engine = this->ni->ref1;
+				EngineID engine = static_cast<EngineID>(this->ni->ref1);
 				str = GetEngineInfoString(engine);
 				break;
 			}
@@ -542,14 +542,14 @@ struct NewsWindow : Window {
 
 			case WID_N_VEH_SPR: {
 				assert(this->ni->reftype1 == NewsReferenceType::Engine);
-				EngineID engine = this->ni->ref1;
+				EngineID engine = static_cast<EngineID>(this->ni->ref1);
 				DrawVehicleEngine(r.left, r.right, CenterBounds(r.left, r.right, 0), CenterBounds(r.top, r.bottom, 0), engine, GetEnginePalette(engine, _local_company), EIT_PREVIEW);
 				GfxFillRect(r.left, r.top, r.right, r.bottom, PALETTE_NEWSPAPER, FILLRECT_RECOLOUR);
 				break;
 			}
 			case WID_N_VEH_INFO: {
 				assert(this->ni->reftype1 == NewsReferenceType::Engine);
-				EngineID engine = this->ni->ref1;
+				EngineID engine = static_cast<EngineID>(this->ni->ref1);
 				DrawStringMultiLine(r.left, r.right, r.top, r.bottom, GetEngineInfoString(engine), TC_FROMSTRING, SA_CENTER);
 				break;
 			}
@@ -678,7 +678,7 @@ private:
 	StringID GetNewVehicleMessageString(WidgetID widget) const
 	{
 		assert(this->ni->reftype1 == NewsReferenceType::Engine);
-		EngineID engine = this->ni->ref1;
+		EngineID engine = static_cast<EngineID>(this->ni->ref1);
 
 		switch (widget) {
 			case WID_N_VEH_TITLE:

--- a/src/news_type.h
+++ b/src/news_type.h
@@ -11,11 +11,16 @@
 #define NEWS_TYPE_H
 
 #include "core/enum_type.hpp"
+#include "engine_type.h"
+#include "industry_type.h"
 #include "gfx_type.h"
+#include "sound_type.h"
+#include "station_type.h"
+#include "strings_type.h"
 #include "timer/timer_game_calendar.h"
 #include "timer/timer_game_economy.h"
-#include "strings_type.h"
-#include "sound_type.h"
+#include "town_type.h"
+#include "vehicle_type.h"
 
 /**
  * Type of news.
@@ -65,15 +70,7 @@ enum class AdviceType : uint8_t {
  * You have to make sure, #ChangeVehicleNews catches the DParams of your message.
  * This is NOT ensured by the references.
  */
-enum class NewsReferenceType : uint8_t {
-	None, ///< Empty reference
-	Tile, ///< Reference tile. Scroll to tile when clicking on the news.
-	Vehicle, ///< Reference vehicle. Scroll to vehicle when clicking on the news. Delete news when vehicle is deleted.
-	Station, ///< Reference station. Scroll to station when clicking on the news. Delete news when station is deleted.
-	Industry, ///< Reference industry. Scroll to industry when clicking on the news. Delete news when industry is deleted.
-	Town, ///< Reference town. Scroll to town when clicking on the news.
-	Engine, ///< Reference engine.
-};
+using NewsReference = std::variant<std::monostate, TileIndex, VehicleID, StationID, IndustryID, TownID, EngineID>;
 
 /** News Window Styles. */
 enum class NewsStyle : uint8_t {
@@ -145,16 +142,14 @@ struct NewsItem {
 	NewsStyle style; /// Window style for the news.
 	NewsFlags flags;               ///< NewsFlags bits @see NewsFlag
 
-	NewsReferenceType reftype1;   ///< Type of ref1
-	NewsReferenceType reftype2;   ///< Type of ref2
-	uint32_t ref1;                  ///< Reference 1 to some object: Used for a possible viewport, scrolling after clicking on the news, and for deleting the news when the object is deleted.
-	uint32_t ref2;                  ///< Reference 2 to some object: Used for scrolling after clicking on the news, and for deleting the news when the object is deleted.
+	NewsReference ref1; ///< Reference 1 to some object: Used for a possible viewport, scrolling after clicking on the news, and for deleting the news when the object is deleted.
+	NewsReference ref2; ///< Reference 2 to some object: Used for scrolling after clicking on the news, and for deleting the news when the object is deleted.
 
 	std::unique_ptr<NewsAllocatedData> data; ///< Custom data for the news item that will be deallocated (deleted) when the news item has reached its end.
 
 	std::vector<StringParameterData> params; ///< Parameters for string resolving.
 
-	NewsItem(StringID string_id, NewsType type, NewsStyle style, NewsFlags flags, NewsReferenceType reftype1, uint32_t ref1, NewsReferenceType reftype2, uint32_t ref2, std::unique_ptr<NewsAllocatedData> &&data, AdviceType advice_type);
+	NewsItem(StringID string_id, NewsType type, NewsStyle style, NewsFlags flags, NewsReference ref1, NewsReference ref2, std::unique_ptr<NewsAllocatedData> &&data, AdviceType advice_type);
 };
 
 /**

--- a/src/road_map.h
+++ b/src/road_map.h
@@ -636,7 +636,7 @@ inline void MakeRoadNormal(Tile t, RoadBits bits, RoadType road_rt, RoadType tra
 {
 	SetTileType(t, MP_ROAD);
 	SetTileOwner(t, road);
-	t.m2() = town;
+	t.m2() = town.base();
 	t.m3() = (tram_rt != INVALID_ROADTYPE ? bits : 0);
 	t.m5() = (road_rt != INVALID_ROADTYPE ? bits : 0) | ROAD_TILE_NORMAL << 6;
 	SB(t.m6(), 2, 4, 0);
@@ -661,7 +661,7 @@ inline void MakeRoadCrossing(Tile t, Owner road, Owner tram, Owner rail, Axis ro
 {
 	SetTileType(t, MP_ROAD);
 	SetTileOwner(t, rail);
-	t.m2() = town;
+	t.m2() = town.base();
 	t.m3() = 0;
 	t.m4() = INVALID_ROADTYPE;
 	t.m5() = ROAD_TILE_CROSSING << 6 | roaddir;

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1010,7 +1010,7 @@ bool AfterLoadGame()
 					if ((GB(t.m5(), 4, 2) == ROAD_TILE_CROSSING ? (Owner)t.m3() : GetTileOwner(t)) == OWNER_TOWN) {
 						SetTownIndex(t, CalcClosestTownFromTile(t)->index);
 					} else {
-						SetTownIndex(t, TOWN_BEGIN);
+						SetTownIndex(t, TownID::Begin());
 					}
 					break;
 
@@ -1234,11 +1234,11 @@ bool AfterLoadGame()
 								GetRailType(t)
 							);
 						} else {
-							TownID town = IsTileOwner(t, OWNER_TOWN) ? ClosestTownFromTile(t, UINT_MAX)->index : TOWN_BEGIN;
+							TownID town = IsTileOwner(t, OWNER_TOWN) ? ClosestTownFromTile(t, UINT_MAX)->index : TownID::Begin();
 
 							/* MakeRoadNormal */
 							SetTileType(t, MP_ROAD);
-							t.m2() = town;
+							t.m2() = town.base();
 							t.m3() = 0;
 							t.m5() = (axis == AXIS_X ? ROAD_Y : ROAD_X) | ROAD_TILE_NORMAL << 6;
 							SB(t.m6(), 2, 4, 0);
@@ -1626,7 +1626,7 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SLV_52)) {
 		for (auto t : Map::Iterate()) {
 			if (IsTileType(t, MP_OBJECT) && t.m5() == OBJECT_STATUE) {
-				t.m2() = CalcClosestTownFromTile(t)->index;
+				t.m2() = CalcClosestTownFromTile(t)->index.base();
 			}
 		}
 	}

--- a/src/saveload/depot_sl.cpp
+++ b/src/saveload/depot_sl.cpp
@@ -53,7 +53,7 @@ struct DEPTChunkHandler : ChunkHandler {
 			SlObject(depot, slt);
 
 			/* Set the town 'pointer' so we can restore it later. */
-			if (IsSavegameVersionBefore(SLV_141)) depot->town = (Town *)(size_t)_town_index;
+			if (IsSavegameVersionBefore(SLV_141)) depot->town = reinterpret_cast<Town *>(static_cast<size_t>(_town_index.base()));
 		}
 	}
 

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -41,7 +41,7 @@ static const SaveLoad _engine_desc[] = {
 	SLE_CONDSSTR(Engine, name,                SLE_STR,                    SLV_84, SL_MAX_VERSION),
 };
 
-static std::vector<Engine> _temp_engine;
+static ReferenceThroughBaseContainer<std::vector<Engine>> _temp_engine;
 
 Engine *GetTempDataEngine(EngineID index)
 {
@@ -134,12 +134,12 @@ struct ENGSChunkHandler : ChunkHandler {
 	{
 		/* Load old separate String ID list into a temporary array. This
 		 * was always 256 entries. */
-		StringID names[256];
+		ReferenceThroughBaseContainer<std::array<StringID, 256>> names{};
 
-		SlCopy(names, lengthof(names), SLE_STRINGID);
+		SlCopy(names.data(), std::size(names), SLE_STRINGID);
 
 		/* Copy each string into the temporary engine array. */
-		for (EngineID engine = ENGINE_BEGIN; engine < lengthof(names); engine++) {
+		for (EngineID engine = EngineID::Begin(); engine < std::size(names); ++engine) {
 			Engine *e = GetTempDataEngine(engine);
 			e->name = CopyFromOldName(names[engine]);
 		}

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -76,7 +76,7 @@ struct ENGNChunkHandler : ChunkHandler {
 		 * engine pool after processing NewGRFs by CopyTempEngineData(). */
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			Engine *e = GetTempDataEngine(index);
+			Engine *e = GetTempDataEngine(static_cast<EngineID>(index));
 			SlObject(e, slt);
 
 			if (IsSavegameVersionBefore(SLV_179)) {
@@ -139,7 +139,7 @@ struct ENGSChunkHandler : ChunkHandler {
 		SlCopy(names, lengthof(names), SLE_STRINGID);
 
 		/* Copy each string into the temporary engine array. */
-		for (EngineID engine = 0; engine < lengthof(names); engine++) {
+		for (EngineID engine = ENGINE_BEGIN; engine < lengthof(names); engine++) {
 			Engine *e = GetTempDataEngine(engine);
 			e->name = CopyFromOldName(names[engine]);
 		}
@@ -193,7 +193,7 @@ struct EIDSChunkHandler : ChunkHandler {
 		while ((index = SlIterateArray()) != -1) {
 			EngineIDMapping eid;
 			SlObject(&eid, slt);
-			_engine_mngr.SetID(eid.type, eid.internal_id, eid.grfid, eid.substitute_id, index);
+			_engine_mngr.SetID(eid.type, eid.internal_id, eid.grfid, eid.substitute_id, static_cast<EngineID>(index));
 		}
 	}
 };

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -176,7 +176,7 @@ void FixOldVehicles(LoadgameState &ls)
 		/* Vehicle-subtype is different in TTD(Patch) */
 		if (v->type == VEH_EFFECT) v->subtype = v->subtype >> 1;
 
-		v->name = CopyFromOldName(ls.vehicle_names[v->index]);
+		v->name = CopyFromOldName(ls.vehicle_names[v->index.base()]);
 
 		/* We haven't used this bit for stations for ages */
 		if (v->type == VEH_ROAD) {
@@ -1048,7 +1048,7 @@ static bool LoadOldCompany(LoadgameState &ls, int num)
 
 static uint32_t _old_order_ptr;
 static uint16_t _old_next_ptr;
-static VehicleID _current_vehicle_id;
+static typename VehicleID::BaseType _current_vehicle_id;
 
 static const OldChunks vehicle_train_chunk[] = {
 	OCL_SVAR(  OC_UINT8, Train, track ),
@@ -1250,7 +1250,7 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 	ReadTTDPatchFlags(ls);
 
 	for (uint i = 0; i < ls.vehicle_multiplier; i++) {
-		_current_vehicle_id = static_cast<VehicleID>(num * ls.vehicle_multiplier + i);
+		_current_vehicle_id = num * ls.vehicle_multiplier + i;
 
 		Vehicle *v;
 

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -373,23 +373,23 @@ static bool FixTTOEngines()
 
 	for (Vehicle *v : Vehicle::Iterate()) {
 		if (v->engine_type >= lengthof(tto_to_ttd)) return false;
-		v->engine_type = static_cast<EngineID>(tto_to_ttd[v->engine_type]);
+		v->engine_type = static_cast<EngineID>(tto_to_ttd[v->engine_type.base()]);
 	}
 
 	/* Load the default engine set. Many of them will be overridden later */
 	{
-		EngineID j = ENGINE_BEGIN;
-		for (uint16_t i = 0; i < lengthof(_orig_rail_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_TRAIN, i);
-		for (uint16_t i = 0; i < lengthof(_orig_road_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_ROAD, i);
-		for (uint16_t i = 0; i < lengthof(_orig_ship_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_SHIP, i);
-		for (uint16_t i = 0; i < lengthof(_orig_aircraft_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_AIRCRAFT, i);
+		EngineID j = EngineID::Begin();
+		for (uint16_t i = 0; i < lengthof(_orig_rail_vehicle_info); ++i, ++j) new (GetTempDataEngine(j)) Engine(VEH_TRAIN, i);
+		for (uint16_t i = 0; i < lengthof(_orig_road_vehicle_info); ++i, ++j) new (GetTempDataEngine(j)) Engine(VEH_ROAD, i);
+		for (uint16_t i = 0; i < lengthof(_orig_ship_vehicle_info); ++i, ++j) new (GetTempDataEngine(j)) Engine(VEH_SHIP, i);
+		for (uint16_t i = 0; i < lengthof(_orig_aircraft_vehicle_info); ++i, ++j) new (GetTempDataEngine(j)) Engine(VEH_AIRCRAFT, i);
 	}
 
 	TimerGameCalendar::Date aging_date = std::min(TimerGameCalendar::date + CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR, TimerGameCalendar::ConvertYMDToDate(TimerGameCalendar::Year{2050}, 0, 1));
 	TimerGameCalendar::YearMonthDay aging_ymd = TimerGameCalendar::ConvertDateToYMD(aging_date);
 
-	for (EngineID i = ENGINE_BEGIN; i < 256; i++) {
-		OldEngineID oi = ttd_to_tto[i];
+	for (EngineID i = EngineID::Begin(); i < 256; ++i) {
+		OldEngineID oi = ttd_to_tto[i.base()];
 		Engine *e = GetTempDataEngine(i);
 
 		if (oi == 255) {

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -378,7 +378,7 @@ static bool FixTTOEngines()
 
 	/* Load the default engine set. Many of them will be overridden later */
 	{
-		uint j = 0;
+		EngineID j = ENGINE_BEGIN;
 		for (uint16_t i = 0; i < lengthof(_orig_rail_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_TRAIN, i);
 		for (uint16_t i = 0; i < lengthof(_orig_road_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_ROAD, i);
 		for (uint16_t i = 0; i < lengthof(_orig_ship_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_SHIP, i);
@@ -388,7 +388,7 @@ static bool FixTTOEngines()
 	TimerGameCalendar::Date aging_date = std::min(TimerGameCalendar::date + CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR, TimerGameCalendar::ConvertYMDToDate(TimerGameCalendar::Year{2050}, 0, 1));
 	TimerGameCalendar::YearMonthDay aging_ymd = TimerGameCalendar::ConvertDateToYMD(aging_date);
 
-	for (EngineID i = 0; i < 256; i++) {
+	for (EngineID i = ENGINE_BEGIN; i < 256; i++) {
 		OldEngineID oi = ttd_to_tto[i];
 		Engine *e = GetTempDataEngine(i);
 
@@ -1455,13 +1455,13 @@ static const OldChunks engine_chunk[] = {
 
 static bool LoadOldEngine(LoadgameState &ls, int num)
 {
-	Engine *e = _savegame_type == SGT_TTO ? &_old_engines[num] : GetTempDataEngine(num);
+	Engine *e = _savegame_type == SGT_TTO ? &_old_engines[num] : GetTempDataEngine(static_cast<EngineID>(num));
 	return LoadChunk(ls, e, engine_chunk);
 }
 
 static bool LoadOldEngineName(LoadgameState &ls, int num)
 {
-	Engine *e = GetTempDataEngine(num);
+	Engine *e = GetTempDataEngine(static_cast<EngineID>(num));
 	e->name = CopyFromOldName(RemapOldStringID(ReadUint16(ls)));
 	return true;
 }

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -1250,7 +1250,7 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 	ReadTTDPatchFlags(ls);
 
 	for (uint i = 0; i < ls.vehicle_multiplier; i++) {
-		_current_vehicle_id = num * ls.vehicle_multiplier + i;
+		_current_vehicle_id = static_cast<VehicleID>(num * ls.vehicle_multiplier + i);
 
 		Vehicle *v;
 

--- a/src/script/api/script_enginelist.cpp
+++ b/src/script/api/script_enginelist.cpp
@@ -19,6 +19,6 @@ ScriptEngineList::ScriptEngineList(ScriptVehicle::VehicleType vehicle_type)
 	bool is_deity = ScriptCompanyMode::IsDeity();
 	::CompanyID owner = ScriptObject::GetCompany();
 	for (const Engine *e : Engine::IterateType((::VehicleType)vehicle_type)) {
-		if (is_deity || e->company_avail.Test(owner)) this->AddItem(e->index);
+		if (is_deity || e->company_avail.Test(owner)) this->AddItem(e->index.base());
 	}
 }

--- a/src/script/api/script_goal.cpp
+++ b/src/script/api/script_goal.cpp
@@ -35,7 +35,7 @@
 	if (type == GT_STORY_PAGE && ScriptStoryPage::IsValidStoryPage(static_cast<StoryPageID>(destination))) story_page = ::StoryPage::Get(static_cast<StoryPageID>(destination));
 	return (type == GT_NONE && destination == 0) ||
 			(type == GT_TILE && ScriptMap::IsValidTile(::TileIndex(destination))) ||
-			(type == GT_INDUSTRY && ScriptIndustry::IsValidIndustry(destination)) ||
+			(type == GT_INDUSTRY && ScriptIndustry::IsValidIndustry(static_cast<IndustryID>(destination))) ||
 			(type == GT_TOWN && ScriptTown::IsValidTown(static_cast<TownID>(destination))) ||
 			(type == GT_COMPANY && ScriptCompany::ResolveCompanyID(ScriptCompany::ToScriptCompanyID(static_cast<::CompanyID>(destination))) != ScriptCompany::COMPANY_INVALID) ||
 			(type == GT_STORY_PAGE && story_page != nullptr && (c == INVALID_COMPANY ? story_page->company == INVALID_COMPANY : story_page->company == INVALID_COMPANY || story_page->company == c));

--- a/src/script/api/script_news.cpp
+++ b/src/script/api/script_news.cpp
@@ -20,6 +20,18 @@
 
 #include "../../safeguards.h"
 
+static NewsReference CreateReference(ScriptNews::NewsReferenceType ref_type, SQInteger reference)
+{
+	switch (ref_type) {
+		case ScriptNews::NR_NONE: return {};
+		case ScriptNews::NR_TILE: return ::TileIndex(reference);
+		case ScriptNews::NR_STATION: return static_cast<StationID>(reference);
+		case ScriptNews::NR_INDUSTRY: return static_cast<IndustryID>(reference);
+		case ScriptNews::NR_TOWN: return static_cast<TownID>(reference);
+		default: NOT_REACHED();
+	}
+}
+
 /* static */ bool ScriptNews::Create(NewsType type, Text *text, ScriptCompany::CompanyID company, NewsReferenceType ref_type, SQInteger reference)
 {
 	ScriptObjectRef counter(text);
@@ -38,6 +50,5 @@
 
 	::CompanyID c = ScriptCompany::FromScriptCompanyID(company);
 
-	if (ref_type == NR_NONE) reference = 0;
-	return ScriptObject::Command<CMD_CUSTOM_NEWS_ITEM>::Do((::NewsType)type, (::NewsReferenceType)ref_type, c, reference, encoded);
+	return ScriptObject::Command<CMD_CUSTOM_NEWS_ITEM>::Do((::NewsType)type, c, CreateReference(ref_type, reference), encoded);
 }

--- a/src/script/api/script_news.cpp
+++ b/src/script/api/script_news.cpp
@@ -33,7 +33,7 @@
 	EnforcePrecondition(false, (ref_type == NR_NONE) ||
 	                           (ref_type == NR_TILE     && ScriptMap::IsValidTile(::TileIndex(reference))) ||
 	                           (ref_type == NR_STATION  && ScriptStation::IsValidStation(reference)) ||
-	                           (ref_type == NR_INDUSTRY && ScriptIndustry::IsValidIndustry(reference)) ||
+	                           (ref_type == NR_INDUSTRY && ScriptIndustry::IsValidIndustry(static_cast<IndustryID>(reference))) ||
 	                           (ref_type == NR_TOWN     && ScriptTown::IsValidTown(static_cast<TownID>(reference))));
 
 	::CompanyID c = ScriptCompany::FromScriptCompanyID(company);

--- a/src/script/api/script_news.hpp
+++ b/src/script/api/script_news.hpp
@@ -38,11 +38,11 @@ public:
 	 */
 	enum NewsReferenceType {
 		/* Selection of useful game elements to refer to. */
-		NR_NONE     = to_underlying(::NewsReferenceType::None),     ///< No reference supplied.
-		NR_TILE     = to_underlying(::NewsReferenceType::Tile),     ///< Reference location, scroll to the location when clicking on the news.
-		NR_STATION  = to_underlying(::NewsReferenceType::Station),  ///< Reference station, scroll to the station when clicking on the news. Delete news when the station is deleted.
-		NR_INDUSTRY = to_underlying(::NewsReferenceType::Industry), ///< Reference industry, scrolls to the industry when clicking on the news. Delete news when the industry is deleted.
-		NR_TOWN     = to_underlying(::NewsReferenceType::Town),     ///< Reference town, scroll to the town when clicking on the news.
+		NR_NONE, ///< No reference supplied.
+		NR_TILE, ///< Reference location, scroll to the location when clicking on the news.
+		NR_STATION, ///< Reference station, scroll to the station when clicking on the news. Delete news when the station is deleted.
+		NR_INDUSTRY, ///< Reference industry, scrolls to the industry when clicking on the news. Delete news when the industry is deleted.
+		NR_TOWN, ///< Reference town, scroll to the town when clicking on the news.
 	};
 
 	/**

--- a/src/script/api/script_order.cpp
+++ b/src/script/api/script_order.cpp
@@ -633,7 +633,7 @@ static void _DoCommandReturnSetOrderFlags(class ScriptInstance *instance)
 
 /* static */ bool ScriptOrder::SetOrderFlags(VehicleID vehicle_id, OrderPosition order_position, ScriptOrder::ScriptOrderFlags order_flags)
 {
-	ScriptObject::SetCallbackVariable(0, vehicle_id);
+	ScriptObject::SetCallbackVariable(0, vehicle_id.base());
 	ScriptObject::SetCallbackVariable(1, order_position);
 	ScriptObject::SetCallbackVariable(2, order_flags);
 	/* In case another client(s) change orders at the same time we could

--- a/src/script/api/script_subsidy.cpp
+++ b/src/script/api/script_subsidy.cpp
@@ -37,8 +37,8 @@
 	EnforcePrecondition(false, ScriptCargo::IsValidCargo(cargo_type));
 	EnforcePrecondition(false, from_type == SPT_INDUSTRY || from_type == SPT_TOWN);
 	EnforcePrecondition(false, to_type == SPT_INDUSTRY || to_type == SPT_TOWN);
-	EnforcePrecondition(false, (from_type == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(from_id)) || (from_type == SPT_TOWN && ScriptTown::IsValidTown(static_cast<TownID>(from_id))));
-	EnforcePrecondition(false, (to_type == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(to_id)) || (to_type == SPT_TOWN && ScriptTown::IsValidTown(static_cast<TownID>(to_id))));
+	EnforcePrecondition(false, (from_type == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(static_cast<IndustryID>(from_id))) || (from_type == SPT_TOWN && ScriptTown::IsValidTown(static_cast<TownID>(from_id))));
+	EnforcePrecondition(false, (to_type == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(static_cast<IndustryID>(to_id))) || (to_type == SPT_TOWN && ScriptTown::IsValidTown(static_cast<TownID>(to_id))));
 
 	Source from{static_cast<SourceID>(from_id), static_cast<SourceType>(from_type)};
 	Source to{static_cast<SourceID>(to_id), static_cast<SourceType>(to_type)};

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -84,7 +84,7 @@
 	if (!ScriptObject::Command<CMD_BUILD_VEHICLE>::Do(&ScriptInstance::DoCommandReturnVehicleID, depot, engine_id, true, cargo, INVALID_CLIENT_ID)) return VEHICLE_INVALID;
 
 	/* In case of test-mode, we return VehicleID 0 */
-	return 0;
+	return ::VEHICLE_BEGIN;
 }
 
 /* static */ VehicleID ScriptVehicle::BuildVehicle(TileIndex depot, EngineID engine_id)
@@ -115,16 +115,16 @@
 	if (!ScriptObject::Command<CMD_CLONE_VEHICLE>::Do(&ScriptInstance::DoCommandReturnVehicleID, depot, vehicle_id, share_orders)) return VEHICLE_INVALID;
 
 	/* In case of test-mode, we return VehicleID 0 */
-	return 0;
+	return ::VEHICLE_BEGIN;
 }
 
 /* static */ bool ScriptVehicle::_MoveWagonInternal(VehicleID source_vehicle_id, SQInteger source_wagon, bool move_attached_wagons, SQInteger dest_vehicle_id, SQInteger dest_wagon)
 {
 	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicle(source_vehicle_id) && source_wagon < GetNumWagons(source_vehicle_id));
-	EnforcePrecondition(false, dest_vehicle_id == -1 || (IsValidVehicle(dest_vehicle_id) && dest_wagon < GetNumWagons(dest_vehicle_id)));
+	EnforcePrecondition(false, dest_vehicle_id == -1 || (IsValidVehicle(static_cast<VehicleID>(dest_vehicle_id)) && dest_wagon < GetNumWagons(static_cast<VehicleID>(dest_vehicle_id))));
 	EnforcePrecondition(false, ::Vehicle::Get(source_vehicle_id)->type == VEH_TRAIN);
-	EnforcePrecondition(false, dest_vehicle_id == -1 || ::Vehicle::Get(dest_vehicle_id)->type == VEH_TRAIN);
+	EnforcePrecondition(false, dest_vehicle_id == -1 || ::Vehicle::Get(static_cast<VehicleID>(dest_vehicle_id))->type == VEH_TRAIN);
 
 	const Train *v = ::Train::Get(source_vehicle_id);
 	while (source_wagon-- > 0) v = v->GetNextUnit();

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -84,7 +84,7 @@
 	if (!ScriptObject::Command<CMD_BUILD_VEHICLE>::Do(&ScriptInstance::DoCommandReturnVehicleID, depot, engine_id, true, cargo, INVALID_CLIENT_ID)) return VEHICLE_INVALID;
 
 	/* In case of test-mode, we return VehicleID 0 */
-	return ::VEHICLE_BEGIN;
+	return VehicleID::Begin();
 }
 
 /* static */ VehicleID ScriptVehicle::BuildVehicle(TileIndex depot, EngineID engine_id)
@@ -115,7 +115,7 @@
 	if (!ScriptObject::Command<CMD_CLONE_VEHICLE>::Do(&ScriptInstance::DoCommandReturnVehicleID, depot, vehicle_id, share_orders)) return VEHICLE_INVALID;
 
 	/* In case of test-mode, we return VehicleID 0 */
-	return ::VEHICLE_BEGIN;
+	return VehicleID::Begin();
 }
 
 /* static */ bool ScriptVehicle::_MoveWagonInternal(VehicleID source_vehicle_id, SQInteger source_wagon, bool move_attached_wagons, SQInteger dest_vehicle_id, SQInteger dest_wagon)

--- a/src/script/api/script_vehicle.hpp
+++ b/src/script/api/script_vehicle.hpp
@@ -95,7 +95,7 @@ public:
 		VS_INVALID = 0xFF, ///< An invalid vehicle state.
 	};
 
-	static const VehicleID VEHICLE_INVALID = ::INVALID_VEHICLE; ///< Invalid VehicleID.
+	static constexpr VehicleID VEHICLE_INVALID = ::INVALID_VEHICLE; ///< Invalid VehicleID.
 
 	/**
 	 * Checks whether the given vehicle is valid and owned by you.

--- a/src/script/api/script_vehiclelist.cpp
+++ b/src/script/api/script_vehiclelist.cpp
@@ -44,7 +44,7 @@ ScriptVehicleList_Station::ScriptVehicleList_Station(StationID station_id)
 	FindVehiclesWithOrder(
 		[is_deity, owner](const Vehicle *v) { return is_deity || v->owner == owner; },
 		[station_id](const Order *order) { return (order->IsType(OT_GOTO_STATION) || order->IsType(OT_GOTO_WAYPOINT)) && order->GetDestination() == station_id; },
-		[this](const Vehicle *v) { this->AddItem(v->index); }
+		[this](const Vehicle *v) { this->AddItem(v->index.base()); }
 	);
 }
 
@@ -91,7 +91,7 @@ ScriptVehicleList_Depot::ScriptVehicleList_Depot(TileIndex tile)
 	FindVehiclesWithOrder(
 		[is_deity, owner, type](const Vehicle *v) { return (is_deity || v->owner == owner) && v->type == type; },
 		[dest](const Order *order) { return order->IsType(OT_GOTO_DEPOT) && order->GetDestination() == dest; },
-		[this](const Vehicle *v) { this->AddItem(v->index); }
+		[this](const Vehicle *v) { this->AddItem(v->index.base()); }
 	);
 }
 
@@ -100,7 +100,7 @@ ScriptVehicleList_SharedOrders::ScriptVehicleList_SharedOrders(VehicleID vehicle
 	if (!ScriptVehicle::IsPrimaryVehicle(vehicle_id)) return;
 
 	for (const Vehicle *v = Vehicle::Get(vehicle_id)->FirstShared(); v != nullptr; v = v->NextShared()) {
-		this->AddItem(v->index);
+		this->AddItem(v->index.base());
 	}
 }
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -532,7 +532,7 @@ static void ShowRejectOrAcceptNews(const Station *st, CargoTypes cargoes, bool r
 	SetDParam(0, st->index);
 	SetDParam(1, cargoes);
 	StringID msg = reject ? STR_NEWS_STATION_NO_LONGER_ACCEPTS_CARGO_LIST : STR_NEWS_STATION_NOW_ACCEPTS_CARGO_LIST;
-	AddNewsItem(msg, NewsType::Acceptance, NewsStyle::Small, NewsFlag::InColour, NewsReferenceType::Station, st->index);
+	AddNewsItem(msg, NewsType::Acceptance, NewsStyle::Small, NewsFlag::InColour, st->index);
 }
 
 /**

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -50,13 +50,13 @@ void Subsidy::AwardTo(CompanyID company)
 	std::string company_name = GetString(STR_COMPANY_NAME, company);
 
 	/* Add a news item */
-	std::pair<NewsReferenceType, NewsReferenceType> reftype = SetupSubsidyDecodeParam(this, SubsidyDecodeParamType::NewsAwarded, 1);
+	std::pair<NewsReference, NewsReference> references = SetupSubsidyDecodeParam(this, SubsidyDecodeParamType::NewsAwarded, 1);
 
 	SetDParamStr(0, company_name);
 	AddNewsItem(
 		STR_NEWS_SERVICE_SUBSIDY_AWARDED_HALF + _settings_game.difficulty.subsidy_multiplier,
 		NewsType::Subsidies, NewsStyle::Normal, {},
-		reftype.first, this->src.id, reftype.second, this->dst.id
+		references.first, references.second
 	);
 	AI::BroadcastNewEvent(new ScriptEventSubsidyAwarded(this->index));
 	Game::NewEvent(new ScriptEventSubsidyAwarded(this->index));
@@ -71,10 +71,10 @@ void Subsidy::AwardTo(CompanyID company)
  * @param parameter_offset The location/index in the String DParams to start decoding the subsidy's parameters. Defaults to 0.
  * @return Reference of the subsidy in the news system.
  */
-std::pair<NewsReferenceType, NewsReferenceType> SetupSubsidyDecodeParam(const Subsidy *s, SubsidyDecodeParamType mode, uint parameter_offset)
+std::pair<NewsReference, NewsReference> SetupSubsidyDecodeParam(const Subsidy *s, SubsidyDecodeParamType mode, uint parameter_offset)
 {
-	NewsReferenceType reftype1 = NewsReferenceType::None;
-	NewsReferenceType reftype2 = NewsReferenceType::None;
+	NewsReference reference1{};
+	NewsReference reference2{};
 
 	/* Always use the plural form of the cargo name - trying to decide between plural or singular causes issues for translations */
 	const CargoSpec *cs = CargoSpec::Get(s->cargo_type);
@@ -82,11 +82,11 @@ std::pair<NewsReferenceType, NewsReferenceType> SetupSubsidyDecodeParam(const Su
 
 	switch (s->src.type) {
 		case SourceType::Industry:
-			reftype1 = NewsReferenceType::Industry;
+			reference1 = static_cast<IndustryID>(s->src.id);
 			SetDParam(parameter_offset + 1, STR_INDUSTRY_NAME);
 			break;
 		case SourceType::Town:
-			reftype1 = NewsReferenceType::Town;
+			reference1 = static_cast<TownID>(s->src.id);
 			SetDParam(parameter_offset + 1, STR_TOWN_NAME);
 			break;
 		default: NOT_REACHED();
@@ -95,11 +95,11 @@ std::pair<NewsReferenceType, NewsReferenceType> SetupSubsidyDecodeParam(const Su
 
 	switch (s->dst.type) {
 		case SourceType::Industry:
-			reftype2 = NewsReferenceType::Industry;
+			reference2 = static_cast<IndustryID>(s->dst.id);
 			SetDParam(parameter_offset + 4, STR_INDUSTRY_NAME);
 			break;
 		case SourceType::Town:
-			reftype2 = NewsReferenceType::Town;
+			reference2 = static_cast<TownID>(s->dst.id);
 			SetDParam(parameter_offset + 4, STR_TOWN_NAME);
 			break;
 		default: NOT_REACHED();
@@ -111,7 +111,7 @@ std::pair<NewsReferenceType, NewsReferenceType> SetupSubsidyDecodeParam(const Su
 		SetDParam(parameter_offset + 7, _settings_game.difficulty.subsidy_duration);
 	}
 
-	return std::pair<NewsReferenceType, NewsReferenceType>(reftype1, reftype2);
+	return {reference1, reference2};
 }
 
 /**
@@ -208,8 +208,8 @@ void CreateSubsidy(CargoType cargo_type, Source src, Source dst)
 	s->remaining = SUBSIDY_OFFER_MONTHS;
 	s->awarded = INVALID_COMPANY;
 
-	std::pair<NewsReferenceType, NewsReferenceType> reftype = SetupSubsidyDecodeParam(s, SubsidyDecodeParamType::NewsOffered);
-	AddNewsItem(STR_NEWS_SERVICE_SUBSIDY_OFFERED, NewsType::Subsidies, NewsStyle::Normal, {}, reftype.first, s->src.id, reftype.second, s->dst.id);
+	std::pair<NewsReference, NewsReference> references = SetupSubsidyDecodeParam(s, SubsidyDecodeParamType::NewsOffered);
+	AddNewsItem(STR_NEWS_SERVICE_SUBSIDY_OFFERED, NewsType::Subsidies, NewsStyle::Normal, {}, references.first, references.second);
 	SetPartOfSubsidyFlag(s->src, POS_SRC);
 	SetPartOfSubsidyFlag(s->dst, POS_DST);
 	AI::BroadcastNewEvent(new ScriptEventSubsidyOffer(s->index));
@@ -462,14 +462,14 @@ static IntervalTimer<TimerGameEconomy> _economy_subsidies_monthly({TimerGameEcon
 	for (Subsidy *s : Subsidy::Iterate()) {
 		if (--s->remaining == 0) {
 			if (!s->IsAwarded()) {
-				std::pair<NewsReferenceType, NewsReferenceType> reftype = SetupSubsidyDecodeParam(s, SubsidyDecodeParamType::NewsWithdrawn);
-				AddNewsItem(STR_NEWS_OFFER_OF_SUBSIDY_EXPIRED, NewsType::Subsidies, NewsStyle::Normal, {}, reftype.first, s->src.id, reftype.second, s->dst.id);
+				std::pair<NewsReference, NewsReference> references = SetupSubsidyDecodeParam(s, SubsidyDecodeParamType::NewsWithdrawn);
+				AddNewsItem(STR_NEWS_OFFER_OF_SUBSIDY_EXPIRED, NewsType::Subsidies, NewsStyle::Normal, {}, references.first, references.second);
 				AI::BroadcastNewEvent(new ScriptEventSubsidyOfferExpired(s->index));
 				Game::NewEvent(new ScriptEventSubsidyOfferExpired(s->index));
 			} else {
 				if (s->awarded == _local_company) {
-					std::pair<NewsReferenceType, NewsReferenceType> reftype = SetupSubsidyDecodeParam(s, SubsidyDecodeParamType::NewsWithdrawn);
-					AddNewsItem(STR_NEWS_SUBSIDY_WITHDRAWN_SERVICE, NewsType::Subsidies, NewsStyle::Normal, {}, reftype.first, s->src.id, reftype.second, s->dst.id);
+					std::pair<NewsReference, NewsReference> references = SetupSubsidyDecodeParam(s, SubsidyDecodeParamType::NewsWithdrawn);
+					AddNewsItem(STR_NEWS_SUBSIDY_WITHDRAWN_SERVICE, NewsType::Subsidies, NewsStyle::Normal, {}, references.first, references.second);
 				}
 				AI::BroadcastNewEvent(new ScriptEventSubsidyExpired(s->index));
 				Game::NewEvent(new ScriptEventSubsidyExpired(s->index));

--- a/src/subsidy_func.h
+++ b/src/subsidy_func.h
@@ -17,7 +17,7 @@
 #include "news_type.h"
 #include "subsidy_base.h"
 
-std::pair<NewsReferenceType, NewsReferenceType> SetupSubsidyDecodeParam(const struct Subsidy *s, SubsidyDecodeParamType mode, uint parameter_offset = 0);
+std::pair<NewsReference, NewsReference> SetupSubsidyDecodeParam(const struct Subsidy *s, SubsidyDecodeParamType mode, uint parameter_offset = 0);
 void DeleteSubsidyWith(Source src);
 bool CheckSubsidised(CargoType cargo_type, CompanyID company, Source src, const Station *st);
 void RebuildSubsidisedSourceAndDestinationCache();

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -655,7 +655,7 @@ struct TimetableWindow : Window {
 					this->change_timetable_all = _ctrl_pressed;
 					ShowQueryString({}, STR_TIMETABLE_START_SECONDS_QUERY, 6, this, CS_NUMERAL, QSF_ACCEPT_UNCHANGED);
 				} else {
-					ShowSetDateWindow(this, v->index, TimerGameEconomy::date, TimerGameEconomy::year, TimerGameEconomy::year + MAX_TIMETABLE_START_YEARS, ChangeTimetableStartCallback, reinterpret_cast<void*>(static_cast<uintptr_t>(_ctrl_pressed)));
+					ShowSetDateWindow(this, v->index.base(), TimerGameEconomy::date, TimerGameEconomy::year, TimerGameEconomy::year + MAX_TIMETABLE_START_YEARS, ChangeTimetableStartCallback, reinterpret_cast<void*>(static_cast<uintptr_t>(_ctrl_pressed)));
 				}
 				break;
 

--- a/src/town.h
+++ b/src/town.h
@@ -33,7 +33,7 @@ static const uint TOWN_GROWTH_DESERT = 0xFFFFFFFF; ///< The town needs the cargo
 static const uint16_t TOWN_GROWTH_RATE_NONE = 0xFFFF; ///< Special value for Town::growth_rate to disable town growth.
 static const uint16_t MAX_TOWN_GROWTH_TICKS = 930; ///< Max amount of original town ticks that still fit into uint16_t, about equal to UINT16_MAX / TOWN_GROWTH_TICKS but slightly less to simplify calculations
 
-typedef Pool<Town, TownID, 64, TOWN_END> TownPool;
+typedef Pool<Town, TownID, 64, TownID::End().base()> TownPool;
 extern TownPool _town_pool;
 
 /** Data structure with cached data of towns. */

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -3416,7 +3416,7 @@ static CommandCost TownActionRoadRebuild(Town *t, DoCommandFlags flags)
 
 		AddNewsItem(
 			TimerGameEconomy::UsingWallclockUnits() ? STR_NEWS_ROAD_REBUILDING_MINUTES : STR_NEWS_ROAD_REBUILDING_MONTHS,
-			NewsType::General, NewsStyle::Normal, {}, NewsReferenceType::Town, t->index, NewsReferenceType::None, UINT32_MAX);
+			NewsType::General, NewsStyle::Normal, {}, t->index);
 		AI::BroadcastNewEvent(new ScriptEventRoadReconstruction(_current_company, t->index));
 		Game::NewEvent(new ScriptEventRoadReconstruction(_current_company, t->index));
 	}
@@ -3571,7 +3571,7 @@ static CommandCost TownActionBuyRights(Town *t, DoCommandFlags flags)
 		SetDParam(1, TimerGameEconomy::UsingWallclockUnits() ? STR_NEWS_EXCLUSIVE_RIGHTS_DESCRIPTION_MINUTES : STR_NEWS_EXCLUSIVE_RIGHTS_DESCRIPTION_MONTHS);
 		SetDParam(2, t->index);
 		SetDParamStr(3, cni->company_name);
-		AddNewsItem(STR_MESSAGE_NEWS_FORMAT, NewsType::General, NewsStyle::Company, {}, NewsReferenceType::Town, t->index, NewsReferenceType::None, UINT32_MAX, std::move(cni));
+		AddNewsItem(STR_MESSAGE_NEWS_FORMAT, NewsType::General, NewsStyle::Company, {}, t->index, {}, std::move(cni));
 		AI::BroadcastNewEvent(new ScriptEventExclusiveTransportRights(_current_company, t->index));
 		Game::NewEvent(new ScriptEventExclusiveTransportRights(_current_company, t->index));
 	}

--- a/src/town_map.h
+++ b/src/town_map.h
@@ -35,7 +35,7 @@ inline TownID GetTownIndex(Tile t)
 inline void SetTownIndex(Tile t, TownID index)
 {
 	assert(IsTileType(t, MP_HOUSE) || (IsTileType(t, MP_ROAD) && !IsRoadDepot(t)));
-	t.m2() = index;
+	t.m2() = index.base();
 }
 
 /**
@@ -378,7 +378,7 @@ inline void MakeHouseTile(Tile t, TownID tid, uint8_t counter, uint8_t stage, Ho
 
 	SetTileType(t, MP_HOUSE);
 	t.m1() = random_bits;
-	t.m2() = tid;
+	t.m2() = tid.base();
 	t.m3() = 0;
 	SetHouseType(t, type);
 	SetHouseCompleted(t, stage == TOWN_HOUSE_COMPLETED);

--- a/src/town_type.h
+++ b/src/town_type.h
@@ -11,12 +11,10 @@
 #define TOWN_TYPE_H
 
 #include "core/enum_type.hpp"
+#include "core/pool_type.hpp"
 
-enum TownID : uint16_t {
-	TOWN_BEGIN = 0,
-	TOWN_END = 64000,
-	INVALID_TOWN = 0xFFFF
-};
+using TownID = PoolID<uint16_t, struct TownIDTag, 64000, 0xFFFF>;
+static constexpr TownID INVALID_TOWN = TownID::Invalid();
 
 struct Town;
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -994,7 +994,7 @@ void CallVehicleTicks()
 	PerformanceAccumulator::Reset(PFE_GL_AIRCRAFT);
 
 	for (Vehicle *v : Vehicle::Iterate()) {
-		[[maybe_unused]] size_t vehicle_index = v->index;
+		[[maybe_unused]] VehicleID vehicle_index = v->index;
 
 		/* Vehicle could be deleted in this tick */
 		if (!v->Tick()) {
@@ -3007,7 +3007,7 @@ void Vehicle::RemoveFromShared()
 	} else if (were_first) {
 		/* If we were the first one, update to the new first one.
 		 * Note: FirstShared() is already the new first */
-		InvalidateWindowData(GetWindowClassForVehicleType(this->type), vli.ToWindowNumber(), this->FirstShared()->index | (1U << 31));
+		InvalidateWindowData(GetWindowClassForVehicleType(this->type), vli.ToWindowNumber(), this->FirstShared()->index.base() | (1U << 31));
 	}
 
 	this->next_shared     = nullptr;

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -196,7 +196,7 @@ struct MutableSpriteCache {
 };
 
 /** A vehicle pool for a little over 1 million vehicles. */
-typedef Pool<Vehicle, VehicleID, 512, 0xFF000> VehiclePool;
+typedef Pool<Vehicle, VehicleID, 512, VEHICLE_END> VehiclePool;
 extern VehiclePool _vehicle_pool;
 
 /* Some declarations of functions, so we can make them friendly */

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -196,7 +196,7 @@ struct MutableSpriteCache {
 };
 
 /** A vehicle pool for a little over 1 million vehicles. */
-typedef Pool<Vehicle, VehicleID, 512, VEHICLE_END> VehiclePool;
+typedef Pool<Vehicle, VehicleID, 512, VehicleID::End().base()> VehiclePool;
 extern VehiclePool _vehicle_pool;
 
 /* Some declarations of functions, so we can make them friendly */

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1578,7 +1578,7 @@ static inline void ChangeVehicleWindow(WindowClass window_class, VehicleID from_
 		if (w->viewport != nullptr) w->viewport->follow_vehicle = to_index;
 
 		/* Update vehicle drag data */
-		if (_thd.window_class == window_class && _thd.window_number == (WindowNumber)from_index) {
+		if (_thd.window_class == window_class && _thd.window_number == from_index) {
 			_thd.window_number = to_index;
 		}
 
@@ -2335,7 +2335,7 @@ void ShowVehicleListWindow(CompanyID company, VehicleType vehicle_type)
 
 void ShowVehicleListWindow(const Vehicle *v)
 {
-	ShowVehicleListWindowLocal(v->owner, VL_SHARED_ORDERS, v->type, v->FirstShared()->index);
+	ShowVehicleListWindowLocal(v->owner, VL_SHARED_ORDERS, v->type, v->FirstShared()->index.base());
 }
 
 void ShowVehicleListWindow(CompanyID company, VehicleType vehicle_type, StationID station)

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -3382,7 +3382,7 @@ public:
 	{
 		if (!str.has_value()) return;
 
-		Command<CMD_RENAME_VEHICLE>::Post(STR_ERROR_CAN_T_RENAME_TRAIN + Vehicle::Get(this->window_number)->type, this->window_number, *str);
+		Command<CMD_RENAME_VEHICLE>::Post(STR_ERROR_CAN_T_RENAME_TRAIN + Vehicle::Get(this->window_number)->type, static_cast<VehicleID>(this->window_number), *str);
 	}
 
 	void OnMouseOver([[maybe_unused]] Point pt, WidgetID widget) override

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1519,7 +1519,7 @@ static bool VehicleMaxSpeedSorter(const Vehicle * const &a, const Vehicle * cons
 /** Sort vehicles by model */
 static bool VehicleModelSorter(const Vehicle * const &a, const Vehicle * const &b)
 {
-	int r = a->engine_type - b->engine_type;
+	int r = a->engine_type.base() - b->engine_type.base();
 	return (r != 0) ? r < 0 : VehicleNumberSorter(a, b);
 }
 

--- a/src/vehicle_type.h
+++ b/src/vehicle_type.h
@@ -11,13 +11,11 @@
 #define VEHICLE_TYPE_H
 
 #include "core/enum_type.hpp"
+#include "core/pool_type.hpp"
 
 /** The type all our vehicle IDs have. */
-enum VehicleID : uint32_t {
-	VEHICLE_BEGIN = 0,
-	VEHICLE_END = 0xFF000,
-	INVALID_VEHICLE = 0xFFFFF ///< Constant representing a non-existing vehicle.
-};
+using VehicleID = PoolID<uint32_t, struct VehicleIDTag, 0xFF000, 0xFFFFF>;
+static constexpr VehicleID INVALID_VEHICLE = VehicleID::Invalid(); ///< Constant representing a non-existing vehicle.
 
 static const int GROUND_ACCELERATION = 9800; ///< Acceleration due to gravity, 9.8 m/s^2
 

--- a/src/vehicle_type.h
+++ b/src/vehicle_type.h
@@ -13,7 +13,11 @@
 #include "core/enum_type.hpp"
 
 /** The type all our vehicle IDs have. */
-typedef uint32_t VehicleID;
+enum VehicleID : uint32_t {
+	VEHICLE_BEGIN = 0,
+	VEHICLE_END = 0xFF000,
+	INVALID_VEHICLE = 0xFFFFF ///< Constant representing a non-existing vehicle.
+};
 
 static const int GROUND_ACCELERATION = 9800; ///< Acceleration due to gravity, 9.8 m/s^2
 
@@ -50,8 +54,6 @@ struct BaseVehicle
 {
 	VehicleType type; ///< Type of vehicle
 };
-
-static const VehicleID INVALID_VEHICLE = 0xFFFFF; ///< Constant representing a non-existing vehicle.
 
 /** Flags for goto depot commands. */
 enum class DepotCommandFlag : uint8_t {


### PR DESCRIPTION
## Motivation / Problem

To finish the `PoolID` conversion.

In the news there are `NewsReference`s, which are two 'type-value' pairs. This is essentially a `std::variant` in disguise, so why not use that type instead?


## Description

Currently `EngineID`, `IndustryID`, `StationID`, `TownID` and `VehicleID` are all `typedef uint16_t`. That makes it impossible to use them in a `std::variant`, but without a `std::variant` a lot of casting/`.base()` calls would need to be added and removed. The simpler way, also used for #13508, is to make all but one of the `enum` first. #13508 already converted `TownID` and `StationID` is left alone for this PR.

After that the internals of `NewsReference` and its type are changed to `std::variant`, followed by passing it from the script side through the `Command` stack.

Finally `EngineID`, `IndustryID`, `TownID` and `VehicleID` are converted to `PoolID`, cleaning up the 'mess' that #13508 left.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
