### PR TITLE
Codechange: Use EnumBitSet.Any().

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1300,7 +1300,7 @@ static ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, B
 
 			case 0x28: // Cargo classes allowed
 				_gted[e->index].cargo_allowed = CargoClasses{buf.ReadWord()};
-				_gted[e->index].UpdateRefittability(_gted[e->index].cargo_allowed != CargoClasses{});
+				_gted[e->index].UpdateRefittability(_gted[e->index].cargo_allowed.Any());
 				_gted[e->index].defaultcargo_grf = _cur.grffile;
 				break;
 
@@ -1497,7 +1497,7 @@ static ChangeInfoResult RoadVehicleChangeInfo(uint first, uint last, int prop, B
 
 			case 0x1D: // Cargo classes allowed
 				_gted[e->index].cargo_allowed = CargoClasses{buf.ReadWord()};
-				_gted[e->index].UpdateRefittability(_gted[e->index].cargo_allowed != CargoClasses{});
+				_gted[e->index].UpdateRefittability(_gted[e->index].cargo_allowed.Any());
 				_gted[e->index].defaultcargo_grf = _cur.grffile;
 				break;
 
@@ -1690,7 +1690,7 @@ static ChangeInfoResult ShipVehicleChangeInfo(uint first, uint last, int prop, B
 
 			case 0x18: // Cargo classes allowed
 				_gted[e->index].cargo_allowed = CargoClasses{buf.ReadWord()};
-				_gted[e->index].UpdateRefittability(_gted[e->index].cargo_allowed != CargoClasses{});
+				_gted[e->index].UpdateRefittability(_gted[e->index].cargo_allowed.Any());
 				_gted[e->index].defaultcargo_grf = _cur.grffile;
 				break;
 
@@ -1879,7 +1879,7 @@ static ChangeInfoResult AircraftVehicleChangeInfo(uint first, uint last, int pro
 
 			case 0x18: // Cargo classes allowed
 				_gted[e->index].cargo_allowed = CargoClasses{buf.ReadWord()};
-				_gted[e->index].UpdateRefittability(_gted[e->index].cargo_allowed != CargoClasses{});
+				_gted[e->index].UpdateRefittability(_gted[e->index].cargo_allowed.Any());
 				_gted[e->index].defaultcargo_grf = _cur.grffile;
 				break;
 
@@ -9123,7 +9123,7 @@ static void CalculateRefitMasks()
 					_gted[engine].ctt_exclude_mask = original_known_cargoes;
 				}
 			}
-			_gted[engine].UpdateRefittability(_gted[engine].cargo_allowed != CargoClasses{});
+			_gted[engine].UpdateRefittability(_gted[engine].cargo_allowed.Any());
 
 			if (IsValidCargoType(ei->cargo_type)) ClrBit(_gted[engine].ctt_exclude_mask, ei->cargo_type);
 		}
@@ -9138,7 +9138,7 @@ static void CalculateRefitMasks()
 			 * Note: After applying the translations, the vehicle may end up carrying no defined cargo. It becomes unavailable in that case. */
 			only_defaultcargo = _gted[engine].refittability != GRFTempEngineData::NONEMPTY;
 
-			if (_gted[engine].cargo_allowed != CargoClasses{}) {
+			if (_gted[engine].cargo_allowed.Any()) {
 				/* Build up the list of cargo types from the set cargo classes. */
 				for (const CargoSpec *cs : CargoSpec::Iterate()) {
 					if (cs->classes.Any(_gted[engine].cargo_allowed) && cs->classes.All(_gted[engine].cargo_allowed_required)) SetBit(mask, cs->Index());

--- a/src/pathfinder/yapf/yapf_costrail.hpp
+++ b/src/pathfinder/yapf/yapf_costrail.hpp
@@ -546,7 +546,7 @@ no_entry_cost: // jump here at the beginning if the node has no parent (it is th
 			}
 
 			/* Any other reason bit set? */
-			if (end_segment_reason != EndSegmentReasons{}) {
+			if (end_segment_reason.Any()) {
 				break;
 			}
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3202,7 +3202,7 @@ bool AfterLoadGame()
 			if (c->settings.renew_keep_length) wagon_removal.Set(c->index);
 		}
 		for (Group *g : Group::Iterate()) {
-			if (g->flags != GroupFlags{}) {
+			if (g->flags.Any()) {
 				/* Convert old replace_protection value to flag. */
 				g->flags = GroupFlag::ReplaceProtection;
 			}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

#13493 introduced .Any() and .None() methods for custom bitsets.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use `x.Any()` instead of comparing with `!= xxx{}`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
