### PR TITLE
Fix #13513, ec492cb267: std::numeric_limits<CompanyMask> not working causes no vehicles to exist

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -718,7 +718,7 @@ static void HandleBankruptcyTakeover(Company *c)
 	}
 
 	/* Did we ask everyone for bankruptcy? If so, bail out. */
-	if (c->bankrupt_asked == std::numeric_limits<CompanyMask>::max()) return;
+	if (c->bankrupt_asked.All()) return;
 
 	Company *best = nullptr;
 	int32_t best_performance = -1;
@@ -736,7 +736,7 @@ static void HandleBankruptcyTakeover(Company *c)
 
 	/* Asked all companies? */
 	if (best_performance == -1) {
-		c->bankrupt_asked = std::numeric_limits<CompanyMask>::max();
+		c->bankrupt_asked.Set();
 		return;
 	}
 

--- a/src/core/base_bitset_type.hpp
+++ b/src/core/base_bitset_type.hpp
@@ -19,16 +19,27 @@
  * @tparam Tvalue_type Type of values to wrap.
  * @tparam Tstorage Storage type required to hold values.
  */
-template <typename Timpl, typename Tvalue_type, typename Tstorage>
+template <typename Timpl, typename Tvalue_type, typename Tstorage, Tstorage Tmask = std::numeric_limits<Tstorage>::max()>
 class BaseBitSet {
 public:
 	using ValueType = Tvalue_type; ///< Value type of this BaseBitSet.
 	using BaseType = Tstorage; ///< Storage type of this BaseBitSet, be ConvertibleThroughBase
+	static constexpr Tstorage MASK = Tmask; ///< Mask of valid values.
 
 	constexpr BaseBitSet() : data(0) {}
-	explicit constexpr BaseBitSet(Tstorage data) : data(data) {}
+	explicit constexpr BaseBitSet(Tstorage data) : data(data & Tmask) {}
 
 	constexpr auto operator <=>(const BaseBitSet &) const noexcept = default;
+
+	/**
+	 * Set all bits.
+	 * @returns The bit set
+	 */
+	inline constexpr Timpl &Set()
+	{
+		this->data = Tmask;
+		return static_cast<Timpl&>(*this);
+	}
 
 	/**
 	 * Set the value-th bit.
@@ -98,6 +109,15 @@ public:
 	}
 
 	/**
+	 * Test if all of the values are set.
+	 * @returns true iff all of the values are set.
+	 */
+	inline constexpr bool All() const
+	{
+		return this->data == Tmask;
+	}
+
+	/**
 	 * Test if any of the given values are set.
 	 * @param other BitSet of values to test.
 	 * @returns true iff any of the given values are set.
@@ -142,6 +162,15 @@ public:
 	inline constexpr Tstorage base() const noexcept
 	{
 		return this->data;
+	}
+
+	/**
+	 * Test that the raw value of this bit set is valid.
+	 * @returns true iff the no bits outside the masked value are set.
+	 */
+	inline constexpr bool IsValid() const
+	{
+		return (this->base() & Tmask) == this->base();
 	}
 
 private:

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -627,7 +627,7 @@ static void CompanyCheckBankrupt(Company *c)
 				 * is no THE-END, otherwise mark the client as spectator to make sure
 				 * they are no longer in control of this company. However... when you
 				 * join another company (cheat) the "unowned" company can bankrupt. */
-				c->bankrupt_asked = std::numeric_limits<CompanyMask>::max();
+				c->bankrupt_asked.Set();
 				break;
 			}
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -744,7 +744,7 @@ void StartupOneEngine(Engine *e, const TimerGameCalendar::YearMonthDay &aging_ym
 		int intro_months = intro_ymd.year.base() * 12 + intro_ymd.month;
 		if (intro_ymd.day > 1) intro_months++; // Engines are introduced at the first month start at/after intro date.
 		e->age = aging_months - intro_months;
-		e->company_avail = std::numeric_limits<CompanyMask>::max();
+		e->company_avail.Set();
 		e->flags.Set(EngineFlag::Available);
 	}
 
@@ -885,7 +885,7 @@ static void AcceptEnginePreview(EngineID eid, CompanyID company, int recursion_d
 	Engine *e = Engine::Get(eid);
 
 	e->preview_company = INVALID_COMPANY;
-	e->preview_asked = std::numeric_limits<CompanyMask>::max();
+	e->preview_asked.Set();
 
 	EnableEngineForCompany(eid, company);
 
@@ -980,7 +980,7 @@ static IntervalTimer<TimerGameCalendar> _calendar_engines_daily({TimerGameCalend
 				e->preview_company = GetPreviewCompany(e);
 
 				if (e->preview_company == INVALID_COMPANY) {
-					e->preview_asked = std::numeric_limits<CompanyMask>::max();
+					e->preview_asked.Set();
 					continue;
 				}
 
@@ -1109,7 +1109,7 @@ static void NewVehicleAvailable(Engine *e)
 	AddRemoveEngineFromAutoreplaceAndBuildWindows(e->type);
 
 	/* Now available for all companies */
-	e->company_avail = std::numeric_limits<CompanyMask>::max();
+	e->company_avail.Set();
 
 	/* Do not introduce new rail wagons */
 	if (IsWagon(index)) return;

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2051,15 +2051,15 @@ bool AfterLoadGame()
 
 		/* More companies ... */
 		for (Company *c : Company::Iterate()) {
-			if (c->bankrupt_asked.base() == 0xFF) c->bankrupt_asked = std::numeric_limits<CompanyMask>::max();
+			if (c->bankrupt_asked.base() == 0xFF) c->bankrupt_asked.Set();
 		}
 
 		for (Engine *e : Engine::Iterate()) {
-			if (e->company_avail.base() == 0xFF) e->company_avail = std::numeric_limits<CompanyMask>::max();
+			if (e->company_avail.base() == 0xFF) e->company_avail.Set();
 		}
 
 		for (Town *t : Town::Iterate()) {
-			if (t->have_ratings.base() == 0xFF) t->have_ratings = std::numeric_limits<CompanyMask>::max();
+			if (t->have_ratings.base() == 0xFF) t->have_ratings.Set();
 			for (uint i = 8; i != MAX_COMPANIES; i++) t->ratings[i] = RATING_INITIAL;
 		}
 	}

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -109,7 +109,7 @@ struct ENGNChunkHandler : ChunkHandler {
 				 * Just cancel any previews. */
 				e->flags.Reset(EngineFlag{4}); // ENGINE_OFFER_WINDOW_OPEN
 				e->preview_company = INVALID_COMPANY;
-				e->preview_asked = std::numeric_limits<CompanyMask>::max();
+				e->preview_asked.Set();
 			}
 		}
 	}

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -406,7 +406,7 @@ static bool FixTTOEngines()
 			/* Make sure for example monorail and maglev are available when they should be */
 			if (TimerGameCalendar::date >= e->intro_date && e->info.climates.Test(LandscapeType::Temperate)) {
 				e->flags.Set(EngineFlag::Available);
-				e->company_avail = std::numeric_limits<CompanyMask>::max();
+				e->company_avail.Set();
 				e->age = TimerGameCalendar::date > e->intro_date ? (TimerGameCalendar::date - e->intro_date).base() / 30 : 0;
 			}
 		} else {
@@ -431,7 +431,7 @@ static bool FixTTOEngines()
 			 * if at least one of them was available. */
 			for (uint j = 0; j < lengthof(tto_to_ttd); j++) {
 				if (tto_to_ttd[j] == i && _old_engines[j].company_avail.Any()) {
-					e->company_avail = std::numeric_limits<CompanyMask>::max();
+					e->company_avail.Set();
 					e->flags.Set(EngineFlag::Available);
 					break;
 				}
@@ -441,7 +441,7 @@ static bool FixTTOEngines()
 		}
 
 		e->preview_company = INVALID_COMPANY;
-		e->preview_asked = std::numeric_limits<CompanyMask>::max();
+		e->preview_asked.Set();
 		e->preview_wait = 0;
 		e->name = std::string{};
 	}

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -724,7 +724,7 @@ protected:
 	 */
 	inline CompanyMask GetOverlayCompanyMask() const
 	{
-		return Company::IsValidID(_local_company) ? CompanyMask{}.Set(_local_company) : std::numeric_limits<CompanyMask>::max();
+		return Company::IsValidID(_local_company) ? CompanyMask{}.Set(_local_company) : CompanyMask{}.Set();
 	}
 
 	/** Blink the industries (if selected) on a regular interval. */


### PR DESCRIPTION
## Motivation / Problem

#13513 
std::numeric_limits<T>::max() returns 0 instead of an error when the type is unknown. 


## Description

Implement and use `Set()` and `All()` in `BaseBitSet` in same way as `std::bitset`.
Also moves bits of the masking and `IsValid` from `EnumBitSet` to `BaseBitSet`.


## Limitations

None I'm currently aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
