### PR TITLE
Change: Make tree placement at world generation look more organic

### DIFF
--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -192,7 +192,7 @@ struct BlobHarmonic {
  * @param harmonics Harmonics data for the polygon.
  * @param[out] shape Shape to fill with points.
  */
-static void CreateStarShapedPolygon(const int radius, std::span<const BlobHarmonic> harmonics, std::span<Point> shape)
+static void CreateStarShapedPolygon(int radius, std::span<const BlobHarmonic> harmonics, std::span<Point> shape)
 {
 	float theta = 0;
 	float step = (M_PI * 2) / std::size(shape);
@@ -251,7 +251,7 @@ static void CreateRandomStarShapedPolygon(int radius, std::span<Point> shape)
  * @param v3 Third vertex of triangle.
  * @returns true if the given coordinates lie within a triangle.
  */
-static bool IsPointInTriangle(const int x, const int y, const Point &v1, const Point &v2, const Point &v3)
+static bool IsPointInTriangle(int x, int y, const Point &v1, const Point &v2, const Point &v3)
 {
 	const int s = ((v1.x - v3.x) * (y - v3.y)) - ((v1.y - v3.y) * (x - v3.x));
 	const int t = ((v2.x - v1.x) * (y - v1.y)) - ((v2.y - v1.y) * (x - v1.x));

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -32,8 +32,6 @@
 #include "table/clear_land.h"
 
 #include "safeguards.h"
-#include <array>
-#include <cstdint>
 
 /**
  * List of tree placer algorithm.

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -201,16 +201,16 @@ static void CreateStarShapedPolygon(int radius, std::span<const BlobHarmonic> ha
 	for (Point &vertex : shape) {
 
 		/* Add up the values of each harmonic at this segment.*/
-		float deviation = std::accumulate(std::begin(harmonics), std::end(harmonics), 0, [theta](float d, const BlobHarmonic &harmonic) {
-			return d + sin((theta + harmonic.phase) * harmonic.frequency) * harmonic.amplitude;
+		float deviation = std::accumulate(std::begin(harmonics), std::end(harmonics), 0.f, [theta](float d, const BlobHarmonic &harmonic) -> float {
+			return d + sinf((theta + harmonic.phase) * harmonic.frequency) * harmonic.amplitude;
 		});
 
 		/* Smooth out changes. */
-		float adjusted_radius = (radius / 2.0) + (deviation / 2);
+		float adjusted_radius = (radius / 2.f) + (deviation / 2);
 
 		/* Add to the final polygon. */
-		vertex.x = cos(theta) * adjusted_radius;
-		vertex.y = sin(theta) * adjusted_radius;
+		vertex.x = cosf(theta) * adjusted_radius;
+		vertex.y = sinf(theta) * adjusted_radius;
 
 		/* Proceed to the next segment. */
 		theta += step;

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -206,8 +206,7 @@ std::array<Point, GROVE_RESOLUTION> CreateStarShapedPolygon(const int radius, co
 	auto step = (M_PI * 2) / GROVE_RESOLUTION;
 
 	/* Divide a circle into a number of equally spaced divisions. */
-	for(int i = 0; i < GROVE_RESOLUTION; ++i)
-	{
+	for(int i = 0; i < GROVE_RESOLUTION; ++i) {
 		float deviation = 0;
 		/* Add up the values of each harmonic at this segment.*/
 		std::for_each(harmonics.begin(), harmonics.end(), [&deviation, theta](const BlobHarmonic &harmonic) {
@@ -215,12 +214,12 @@ std::array<Point, GROVE_RESOLUTION> CreateStarShapedPolygon(const int radius, co
 		});
 
 		/* Smooth out changes. */
-		auto adjustedRadius = (radius / 2.0) + (deviation / 2);
+		float adjusted_radius = (radius / 2.0) + (deviation / 2);
 
 		/* Add to the final polygon. */
 		Point vertex;
-		vertex.x = cos(theta) * adjustedRadius;
-		vertex.y = sin(theta) * adjustedRadius;
+		vertex.x = cos(theta) * adjusted_radius;
+		vertex.y = sin(theta) * adjusted_radius;
 		result.at(i) = vertex;
 
 		/* Proceed to the next segment. */
@@ -285,6 +284,7 @@ bool IsPointInTriangle(const int x, const int y, Point vertex0, Point vertex1, P
  * @param x x.
  * @param y y.
  * @param polygon the polygon to check against.
+ * @returns true if the given coordinates lie within a star shaped polygon.
  */
 bool IsPointInStarShapedPolygon(int x, int y, std::array<Point, GROVE_RESOLUTION> polygon)
 {

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -265,8 +265,7 @@ bool IsPointInTriangle(const int x, const int y, const Point & vertex0, const Po
 	const int s = ((vertex0.x - vertex2.x) * (y - vertex2.y)) - ((vertex0.y - vertex2.y) * (x - vertex2.x));
 	const int t = ((vertex1.x - vertex0.x) * (y - vertex0.y)) - ((vertex1.y - vertex0.y) * (x - vertex0.x));
 
-	if (s < 0 != t < 0 && s != 0 && t != 0)
-	{
+	if (s < 0 != t < 0 && s != 0 && t != 0) {
 		return false;
 	}
 
@@ -276,9 +275,9 @@ bool IsPointInTriangle(const int x, const int y, const Point & vertex0, const Po
 
 /**
  * Returns true if the given coordinates lie within a star shaped polygon.
- * breaks the polygon into a series of triangles around the centre point (0, 0) and then tests the coordinates against each triangle until a match is found [or not].
+ * Breaks the polygon into a series of triangles around the centre point (0, 0) and then tests the coordinates against each triangle until a match is found [or not].
  *
- * There might be a better way to do this.
+ * @note There might be a better way to do this.
  *
  * @param x x.
  * @param y y.
@@ -288,8 +287,7 @@ bool IsPointInTriangle(const int x, const int y, const Point & vertex0, const Po
 bool IsPointInStarShapedPolygon(int x, int y, std::array<Point, GROVE_RESOLUTION> polygon)
 {
 	for (int i = 0; i < polygon.size(); ++i) {
-		if (IsPointInTriangle(x, y, polygon.at(i), polygon.at((i + 1) % polygon.size()), {0, 0}))
-		{
+		if (IsPointInTriangle(x, y, polygon.at(i), polygon.at((i + 1) % polygon.size()), {0, 0})) {
 			return true;
 		}
 	}

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -240,14 +240,14 @@ static const double PHASE_DIVISOR = INT32_MAX / (M_PI * 2);  ///< Valid values f
  */
 std::array<Point, GROVE_RESOLUTION> CreateRandomStarShapedPolygon(const int radius)
 {
-	std::array<BlobHarmonic, GROVE_HARMONICS_COUNT> harmonics;
-
 	/* These values are ones i found in my testing that result in suitable-looking polygons that did not self-intersect and fit within a square of radius * radius dimensions. */
 
-	harmonics.at(0) = BlobHarmonic(radius / 2, Random() / PHASE_DIVISOR, 1);
-	harmonics.at(1) = BlobHarmonic(radius / 4, Random() / PHASE_DIVISOR, 2);
-	harmonics.at(2) = BlobHarmonic(radius / 8, Random() / PHASE_DIVISOR, 3);
-	harmonics.at(3) = BlobHarmonic(radius / 16, Random() / PHASE_DIVISOR, 4);
+	std::array<BlobHarmonic, GROVE_HARMONICS_COUNT> harmonics = {
+		BlobHarmonic(radius / 2, Random() / PHASE_DIVISOR, 1),
+		BlobHarmonic(radius / 4, Random() / PHASE_DIVISOR, 2),
+		BlobHarmonic(radius / 8, Random() / PHASE_DIVISOR, 3),
+		BlobHarmonic(radius / 16, Random() / PHASE_DIVISOR, 4),
+	};
 
 	return CreateStarShapedPolygon(radius, harmonics);
 }
@@ -260,6 +260,7 @@ std::array<Point, GROVE_RESOLUTION> CreateRandomStarShapedPolygon(const int radi
  * @param vertex0
  * @param vertex1
  * @param vertex2 the triangle to check against.
+ * @returns true if the given coordinates lie within a triangle.
  */
 bool IsPointInTriangle(const int x, const int y, Point vertex0, Point vertex1, Point vertex2)
 {

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -187,9 +187,10 @@ struct BlobHarmonic {
 
 /**
  * Creates a star-shaped polygon originating from (0, 0) as defined by the given harmonics.
+ * The shape is placed into a pre-allocated span so the caller controls allocation.
  * @param radius The maximum radius of the polygon. May be smaller, but will not be larger.
  * @param harmonics Harmonics data for the polygon.
- * @param shape Shape to fill with points.
+ * @param[out] shape Shape to fill with points.
  */
 static void CreateStarShapedPolygon(const int radius, std::span<const BlobHarmonic> harmonics, std::span<Point> shape)
 {
@@ -218,6 +219,7 @@ static void CreateStarShapedPolygon(const int radius, std::span<const BlobHarmon
 
 /**
  * Creates a random star-shaped polygon originating from (0, 0).
+ * The shape is placed into a pre-allocated span so the caller controls allocation.
  * @param radius The maximum radius of the blob. May be smaller, but will not be larger.
  * @param[out] shape Shape to fill with polygon points.
  */
@@ -254,7 +256,7 @@ static bool IsPointInTriangle(const int x, const int y, const Point &v1, const P
 	const int s = ((v1.x - v3.x) * (y - v3.y)) - ((v1.y - v3.y) * (x - v3.x));
 	const int t = ((v2.x - v1.x) * (y - v1.y)) - ((v2.y - v1.y) * (x - v1.x));
 
-	if (s < 0 != t < 0 && s != 0 && t != 0) return false;
+	if ((s < 0) != (t < 0) && s != 0 && t != 0) return false;
 
 	const int d = (v3.x - v2.x) * (y - v2.y) - (v3.y - v2.y) * (x - v2.x);
 	return (d < 0) == (s + t <= 0);
@@ -262,11 +264,11 @@ static bool IsPointInTriangle(const int x, const int y, const Point &v1, const P
 
 /**
  * Returns true if the given coordinates lie within a star shaped polygon.
- * Breaks the polygon into a series of triangles around the centre point (0, 0) and then tests the coordinates against each triangle until a match is found [or not].
+ * Breaks the polygon into a series of triangles around the centre point (0, 0) and then tests the coordinates against each triangle until a match is found (or not).
  * @param x X coordinate relative to centre of shape.
  * @param y Y coordinate relative to centre of shape.
  * @param shape The shape to check against.
- * @returns true if the given coordinates lie within the shape.star shaped polygon.
+ * @returns true if the given coordinates lie within the star shaped polygon.
  */
 static bool IsPointInStarShapedPolygon(int x, int y, std::span<Point> shape)
 {
@@ -291,6 +293,8 @@ static void PlaceTreeGroups(uint num_groups)
 {
 	static constexpr uint GROVE_SEGMENTS = 16; ///< How many segments make up the tree group.
 	static constexpr uint GROVE_RADIUS = 16; ///< Maximum radius of tree groups.
+
+	/* Shape in which trees may be contained. Array is here to reduce allocations. */
 	std::array<Point, GROVE_SEGMENTS> grove;
 
 	do {

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -261,12 +261,12 @@ std::array<Point, GROVE_RESOLUTION> CreateRandomStarShapedPolygon(const int radi
  * @param vertex2 the triangle to check against.
  * @returns true if the given coordinates lie within a triangle.
  */
-bool IsPointInTriangle(const int x, const int y, Point vertex0, Point vertex1, Point vertex2)
+bool IsPointInTriangle(const int x, const int y, const Point & vertex0, const Point & vertex1, const Point & vertex2)
 {
 	const int s = ((vertex0.x - vertex2.x) * (y - vertex2.y)) - ((vertex0.y - vertex2.y) * (x - vertex2.x));
 	const int t = ((vertex1.x - vertex0.x) * (y - vertex0.y)) - ((vertex1.y - vertex0.y) * (x - vertex0.x));
 
-	if ((s < 0) != (t < 0) && (s != 0 && t != 0))
+	if (s < 0 != t < 0 && s != 0 && t != 0)
 	{
 		return false;
 	}
@@ -288,8 +288,7 @@ bool IsPointInTriangle(const int x, const int y, Point vertex0, Point vertex1, P
  */
 bool IsPointInStarShapedPolygon(int x, int y, std::array<Point, GROVE_RESOLUTION> polygon)
 {
-	for(int i = 0; i < polygon.size(); ++i)
-	{
+	for (int i = 0; i < polygon.size(); ++i) {
 		if (IsPointInTriangle(x, y, polygon.at(i), polygon.at((i + 1) % polygon.size()), {0, 0}))
 		{
 			return true;

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -196,7 +196,7 @@ struct BlobHarmonic
  * @param harmonics a std::vector of the harmonics data.
  * @param noOfSegments How many segments make up the polygon.
  */
-std::vector<Point> CreateStarShapedPolygon(const int radius, std::vector<BlobHarmonic> harmonics, const int noOfSegments)
+std::vector<Point> CreateStarShapedPolygon(const int radius, const std::vector<BlobHarmonic> harmonics, const int noOfSegments)
 {
 	std::vector<Point> result;
 
@@ -208,7 +208,7 @@ std::vector<Point> CreateStarShapedPolygon(const int radius, std::vector<BlobHar
 	{
 		float deviation = 0;
 		//add up the values of each harmonic at this segment
-		std::for_each(harmonics.begin(), harmonics.end(), [&deviation, theta](BlobHarmonic &harmonic) {
+		std::for_each(harmonics.begin(), harmonics.end(), [&deviation, theta](const BlobHarmonic &harmonic) {
 			deviation += sin((theta + harmonic.phase) * harmonic.frequency) * harmonic.amplitude;
 		});
 

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -7,7 +7,6 @@
 
 /** @file tree_cmd.cpp Handling of tree tiles. */
 
-#include "core/geometry_type.hpp"
 #include "stdafx.h"
 #include "clear_map.h"
 #include "landscape.h"
@@ -21,6 +20,7 @@
 #include "sound_func.h"
 #include "water.h"
 #include "company_base.h"
+#include "core/geometry_type.hpp"
 #include "core/random_func.hpp"
 #include "newgrf_generic.h"
 #include "timer/timer_game_tick.h"
@@ -60,10 +60,7 @@ uint8_t _trees_tick_ctr;
 static const uint16_t DEFAULT_TREE_STEPS = 1000;             ///< Default number of attempts for placing trees.
 static const uint16_t DEFAULT_RAINFOREST_TREE_STEPS = 15000; ///< Default number of attempts for placing extra trees at rainforest in tropic.
 static const uint16_t EDITOR_TREE_DIV = 5;                   ///< Game editor tree generation divisor factor.
-static const double PHASE_DIVISOR = INT32_MAX / (M_PI * 2);  ///< Valid values for the phase of blob harmonics are between 0 and Tau. we can get a value in the correct range from Random() by dividing the maximum possible value by the desired maximum, and then dividing the random value by the result.
-static const uint16_t GROVE_RADIUS = 16;                     ///< Maximum radius of tree groups.
-static const uint16_t GROVE_RESOLUTION = 16;                 ///< How many segments make up the tree group.
-static const uint16_t GROVE_HARMONICS_COUNT = 4;             ///< How many harmonics are used to generate the tree group.
+
 /**
  * Tests if a tile can be converted to MP_TREES
  * This is true for clear ground without farms or rocks.
@@ -184,6 +181,9 @@ static void PlaceTree(TileIndex tile, uint32_t r)
 	}
 }
 
+static const uint16_t GROVE_RESOLUTION = 16;                 ///< How many segments make up the tree group.
+static const uint16_t GROVE_HARMONICS_COUNT = 4;             ///< How many harmonics are used to generate the tree group.
+
 struct BlobHarmonic
 {
 	int amplitude;
@@ -192,7 +192,7 @@ struct BlobHarmonic
 };
 
 /**
- * Creates a star-shaped[sic] polygon originating from (0, 0) as defined by the given harmonics.
+ * Creates a star-shaped polygon originating from (0, 0) as defined by the given harmonics.
  *
  * @param radius The maximum radius of the polygon. May be smaller, but will not be larger.
  * @param harmonics Harmonics data for the polygon.
@@ -228,6 +228,8 @@ std::array<Point, GROVE_RESOLUTION> CreateStarShapedPolygon(const int radius, co
 
 	return result;
 }
+
+static const double PHASE_DIVISOR = INT32_MAX / (M_PI * 2);  ///< Valid values for the phase of blob harmonics are between 0 and Tau. we can get a value in the correct range from Random() by dividing the maximum possible value by the desired maximum, and then dividing the random value by the result.
 
 /**
  * Creates a random star-shaped[sic] polygon originating from (0, 0).
@@ -294,6 +296,8 @@ bool IsPointInStarShapedPolygon(int x, int y, std::array<Point, GROVE_RESOLUTION
 
 	return false;
 }
+
+static const uint16_t GROVE_RADIUS = 16;                     ///< Maximum radius of tree groups.
 
 /**
  * Creates a number of tree groups.

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -198,7 +198,7 @@ struct BlobHarmonic
  * @param harmonics Harmonics data for the polygon.
  * @returns A star-shaped polygon.
  */
-std::array<Point, GROVE_RESOLUTION> CreateStarShapedPolygon(const int radius, const std::array<BlobHarmonic, GROVE_HARMONICS_COUNT> harmonics)
+std::array<Point, GROVE_RESOLUTION> CreateStarShapedPolygon(const int radius, const std::span<const BlobHarmonic> harmonics)
 {
 	std::array<Point, GROVE_RESOLUTION> result;
 

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -246,7 +246,7 @@ static void CreateRandomStarShapedPolygon(int radius, std::span<Point> shape)
  * @param y Y coordinate relative to centre of shape.
  * @param v1 First vertex of triangle.
  * @param v2 Second vertex of triangle.
- * @param v3 Third vertic of triangle.
+ * @param v3 Third vertex of triangle.
  * @returns true if the given coordinates lie within a triangle.
  */
 static bool IsPointInTriangle(const int x, const int y, const Point &v1, const Point &v2, const Point &v3)

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -306,11 +306,11 @@ static void PlaceTreeGroups(uint num_groups)
 			int y = GB(r, 8, 5) - GROVE_RADIUS;
 			TileIndex cur_tile = TileAddWrap(center_tile, x, y);
 
-			if (cur_tile != INVALID_TILE && CanPlantTreesOnTile(cur_tile, true)) {
-				if(IsPointInStarShapedPolygon(x, y, grove)) {
-					PlaceTree(cur_tile, r);
-				}
-			}
+			if (cur_tile == INVALID_TILE) continue;
+			if (!CanPlantTreesOnTile(cur_tile, true)) continue;
+			if (!IsPointInStarShapedPolygon(x, y, grove)) continue;
+
+			PlaceTree(cur_tile, r);
 		}
 
 	} while (--num_groups);

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -191,7 +191,7 @@ struct BlobHarmonic {
  * @param harmonics Harmonics data for the polygon.
  * @param shape Shape to fill with points.
  */
- static void CreateStarShapedPolygon(const int radius, std::span<const BlobHarmonic> harmonics, std::span<Point> shape)
+static void CreateStarShapedPolygon(const int radius, std::span<const BlobHarmonic> harmonics, std::span<Point> shape)
 {
 	float theta = 0;
 	float step = (M_PI * 2) / std::size(shape);
@@ -221,7 +221,7 @@ struct BlobHarmonic {
  * @param radius The maximum radius of the blob. May be smaller, but will not be larger.
  * @param[out] shape Shape to fill with polygon points.
  */
- static void CreateRandomStarShapedPolygon(int radius, std::span<Point> shape)
+static void CreateRandomStarShapedPolygon(int radius, std::span<Point> shape)
 {
 	/* Valid values for the phase of blob harmonics are between 0 and Tau. we can get a value in the correct range
 	 * from Random() by dividing the maximum possible value by the desired maximum, and then dividing the random
@@ -268,7 +268,7 @@ static bool IsPointInTriangle(const int x, const int y, const Point &v1, const P
  * @param shape The shape to check against.
  * @returns true if the given coordinates lie within the shape.star shaped polygon.
  */
- static bool IsPointInStarShapedPolygon(int x, int y, std::span<Point> shape)
+static bool IsPointInStarShapedPolygon(int x, int y, std::span<Point> shape)
 {
 	for (auto it = std::begin(shape); it != std::end(shape); /* nothing */) {
 		const Point &v1 = *it;

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -196,33 +196,34 @@ struct BlobHarmonic
  *
  * @param radius The maximum radius of the polygon. May be smaller, but will not be larger.
  * @param harmonics Harmonics data for the polygon.
+ * @returns A star-shaped polygon.
  */
 std::array<Point, GROVE_RESOLUTION> CreateStarShapedPolygon(const int radius, const std::array<BlobHarmonic, GROVE_HARMONICS_COUNT> harmonics)
 {
 	std::array<Point, GROVE_RESOLUTION> result;
 
 	float theta = 0;
-	auto step = (M_PI * 2) / GROVE_RESOLUTION; //tau best circle constant
+	auto step = (M_PI * 2) / GROVE_RESOLUTION;
 
-	//divide a circle into a number of equally spaced divisions
+	/* Divide a circle into a number of equally spaced divisions. */
 	for(int i = 0; i < GROVE_RESOLUTION; ++i)
 	{
 		float deviation = 0;
-		//add up the values of each harmonic at this segment
+		/* Add up the values of each harmonic at this segment.*/
 		std::for_each(harmonics.begin(), harmonics.end(), [&deviation, theta](const BlobHarmonic &harmonic) {
 			deviation += sin((theta + harmonic.phase) * harmonic.frequency) * harmonic.amplitude;
 		});
 
-		//smooth out changes
+		/* Smooth out changes. */
 		auto adjustedRadius = (radius / 2.0) + (deviation / 2);
 
-		// add to the final polygon
+		/* Add to the final polygon. */
 		Point vertex;
 		vertex.x = cos(theta) * adjustedRadius;
 		vertex.y = sin(theta) * adjustedRadius;
 		result.at(i) = vertex;
 
-		//proceed to the next segment
+		/* Proceed to the next segment. */
 		theta += step;
 	}
 
@@ -237,11 +238,11 @@ static const double PHASE_DIVISOR = INT32_MAX / (M_PI * 2);  ///< Valid values f
  * @param radius The maximum radius of the blob. May be smaller, but will not be larger.
  * @param noOfSegments How many segments make up the blob.
  */
-std::array<Point, GROVE_RESOLUTION> CreateRandomStarShapedPolygon(const int radius, const int noOfSegments)
+std::array<Point, GROVE_RESOLUTION> CreateRandomStarShapedPolygon(const int radius)
 {
 	std::array<BlobHarmonic, GROVE_HARMONICS_COUNT> harmonics;
 
-	// these values are ones i found in my testing that result in suitable-looking polygons that did not self-intersect and fit within a square of radius * radius dimensions.
+	/* These values are ones i found in my testing that result in suitable-looking polygons that did not self-intersect and fit within a square of radius * radius dimensions. */
 
 	harmonics.at(0) = BlobHarmonic(radius / 2, Random() / PHASE_DIVISOR, 1);
 	harmonics.at(1) = BlobHarmonic(radius / 4, Random() / PHASE_DIVISOR, 2);
@@ -275,14 +276,14 @@ bool IsPointInTriangle(const int x, const int y, Point vertex0, Point vertex1, P
 }
 
 /**
- * Returns true if the given coordinates lie within a star shaped[sic] polygon.
+ * Returns true if the given coordinates lie within a star shaped polygon.
  * breaks the polygon into a series of triangles around the centre point (0, 0) and then tests the coordinates against each triangle until a match is found [or not].
  *
  * There might be a better way to do this.
  *
  * @param x x.
  * @param y y.
- * @param polygon the polygon to check against, a std::vector of multiple Points.
+ * @param polygon the polygon to check against.
  */
 bool IsPointInStarShapedPolygon(int x, int y, std::array<Point, GROVE_RESOLUTION> polygon)
 {
@@ -310,7 +311,7 @@ static void PlaceTreeGroups(uint num_groups)
 	do {
 		TileIndex center_tile = RandomTile();
 
-		std::array<Point, GROVE_RESOLUTION> grove = CreateRandomStarShapedPolygon(GROVE_RADIUS, GROVE_RESOLUTION);
+		std::array<Point, GROVE_RESOLUTION> grove = CreateRandomStarShapedPolygon(GROVE_RADIUS);
 
 		for (uint i = 0; i < DEFAULT_TREE_STEPS; i++) {
 			IncreaseGeneratingWorldProgress(GWP_TREE);

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -232,10 +232,11 @@ std::array<Point, GROVE_RESOLUTION> CreateStarShapedPolygon(const int radius, co
 static const double PHASE_DIVISOR = INT32_MAX / (M_PI * 2);  ///< Valid values for the phase of blob harmonics are between 0 and Tau. we can get a value in the correct range from Random() by dividing the maximum possible value by the desired maximum, and then dividing the random value by the result.
 
 /**
- * Creates a random star-shaped[sic] polygon originating from (0, 0).
+ * Creates a random star-shaped polygon originating from (0, 0).
  *
  * @param radius The maximum radius of the blob. May be smaller, but will not be larger.
  * @param noOfSegments How many segments make up the blob.
+ * @returns A star-shaped polygon.
  */
 std::array<Point, GROVE_RESOLUTION> CreateRandomStarShapedPolygon(const int radius)
 {

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -228,7 +228,7 @@ static void CreateRandomStarShapedPolygon(int radius, std::span<Point> shape)
 	/* Valid values for the phase of blob harmonics are between 0 and Tau. we can get a value in the correct range
 	 * from Random() by dividing the maximum possible value by the desired maximum, and then dividing the random
 	 * value by the result. */
-	static constexpr float PHASE_DIVISOR = INT32_MAX / (M_PI * 2);
+	static constexpr float PHASE_DIVISOR = static_cast<float>(INT32_MAX / M_PI * 2);
 
 	/* These values are ones found in testing that result in suitable-looking polygons that did not self-intersect
 	 * and fit within a square of radius * radius dimensions. */


### PR DESCRIPTION
for real this time.

obsoletes #12719 

<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
currently, tree groups are placed in very noticeable diamonds.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
instead of using manhattan distance as a cutoff, create a [star shaped polygon](https://en.wikipedia.org/wiki/Star-shaped_polygon) and then use that as the cutoff criteria. this results in significantly more organic-looking shapes.

with solitary trees disabled so as to show off the "organic" shapes more clearly: 
![image](https://github.com/user-attachments/assets/10810d62-47cb-481a-b8e0-64ae4bcc3ced)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
- could feasibly cause worldgen to take slightly longer on maps with a very large amount of tree groups.
- might not need the current resolution of 16 segments.
- there might be a more efficient method of testing whether a point is in a star shaped polygon, but if so i haven't come across it.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
