### PR TITLE
Codefix f60b3d7f79: compilation failure using GCC-12

### DIFF
--- a/src/ai/ai_info.cpp
+++ b/src/ai/ai_info.cpp
@@ -24,7 +24,7 @@
  */
 static bool CheckAPIVersion(const std::string &api_version)
 {
-	return std::ranges::find(AIInfo::ApiVersions, api_version) != AIInfo::ApiVersions.end();
+	return std::ranges::find(AIInfo::ApiVersions, api_version) != std::end(AIInfo::ApiVersions);
 }
 
 #if defined(_WIN32)

--- a/src/ai/ai_info.hpp
+++ b/src/ai/ai_info.hpp
@@ -16,7 +16,7 @@
 class AIInfo : public ScriptInfo {
 public:
 	/* All valid AI API versions, in order. */
-	static constexpr std::initializer_list<std::string_view> ApiVersions{ "0.7", "1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "1.10", "1.11", "12", "13", "14", "15" };
+	static constexpr std::string_view ApiVersions[]{ "0.7", "1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "1.10", "1.11", "12", "13", "14", "15" };
 
 	AIInfo();
 

--- a/src/game/game_info.cpp
+++ b/src/game/game_info.cpp
@@ -22,7 +22,7 @@
  */
 static bool CheckAPIVersion(const std::string &api_version)
 {
-	return std::ranges::find(GameInfo::ApiVersions, api_version) != GameInfo::ApiVersions.end();
+	return std::ranges::find(GameInfo::ApiVersions, api_version) != std::end(GameInfo::ApiVersions);
 }
 
 #if defined(_WIN32)

--- a/src/game/game_info.hpp
+++ b/src/game/game_info.hpp
@@ -16,7 +16,7 @@
 class GameInfo : public ScriptInfo {
 public:
 	/* All valid GameScript API versions, in order. */
-	static constexpr std::initializer_list<std::string_view> ApiVersions{ "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "1.10", "1.11", "12", "13", "14", "15" };
+	static constexpr std::string_view ApiVersions[]{ "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "1.10", "1.11", "12", "13", "14", "15" };
 
 	GameInfo();
 


### PR DESCRIPTION
## Motivation / Problem

```
In file included from /home/rubidium/OpenTTD/openttd/src/script/script_gui.cpp:34:
/home/rubidium/OpenTTD/openttd/src/script/../ai/ai_info.hpp:19:195: error: modification of ‘<temporary>’ is not a constant expression
   19 |         static constexpr std::initializer_list<std::string_view> ApiVersions{ "0.7", "1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "1.10", "1.11", "12", "13", "14", "15" };
      |                                                                                                                                                                                                   ^
In file included from /home/rubidium/OpenTTD/openttd/src/script/script_gui.cpp:38:
/home/rubidium/OpenTTD/openttd/src/script/../game/game_info.hpp:19:174: error: modification of ‘<temporary>’ is not a constant expression
   19 |         static constexpr std::initializer_list<std::string_view> ApiVersions{ "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "1.10", "1.11", "12", "13", "14", "15" };
      |                                                                                                                                                                              ^
```
GCC 12.2.0-14, Debian Bookworm


## Description

Instead of `std::initializer_list` use C-style arrays.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
