### PR TITLE
Fix b2f5a49: Add "place houses" setting to Sandbox Options

### DIFF
--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -85,7 +85,7 @@ cat      = SC_BASIC
 [SDT_VAR]
 var      = economy.place_houses
 type     = SLE_UINT8
-flags    = SettingFlag::GuiDropdown
+flags    = SettingFlag::GuiDropdown, SettingFlag::Sandbox
 def      = PH_FORBIDDEN
 min      = PH_FORBIDDEN
 max      = PH_ALLOWED_CONSTRUCTED


### PR DESCRIPTION
## Motivation / Problem

In #13266 I intended the new setting to be a Sandbox Option (appearing in the old cheat menu in addition to the settings menu).

But I forgot to add the flag.

## Description

Make the setting also appear in Sandbox Options.

## Limitations

Opened as a draft because dropdowns don't currently work in Sandbox Options. 😉 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
