### PR TITLE
Codechange: make CompanyID a PoolID

### DIFF
--- a/src/ai/ai.hpp
+++ b/src/ai/ai.hpp
@@ -103,7 +103,7 @@ public:
 	/**
 	 * Broadcast a new event to all active AIs.
 	 */
-	static void BroadcastNewEvent(ScriptEvent *event, CompanyID skip_company = MAX_COMPANIES);
+	static void BroadcastNewEvent(ScriptEvent *event, CompanyID skip_company = CompanyID::Invalid());
 
 	/**
 	 * Save data from an AI to a savegame.

--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -190,7 +190,7 @@
 		AI::scanner_info = nullptr;
 		AI::scanner_library = nullptr;
 
-		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
+		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
 			if (_settings_game.ai_config[c] != nullptr) {
 				delete _settings_game.ai_config[c];
 				_settings_game.ai_config[c] = nullptr;
@@ -208,7 +208,7 @@
 	/* Check for both newgame as current game if we can reload the AIInfo inside
 	 *  the AIConfig. If not, remove the AI from the list (which will assign
 	 *  a random new AI on reload). */
-	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
+	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
 		if (_settings_game.ai_config[c] != nullptr && _settings_game.ai_config[c]->HasScript()) {
 			if (!_settings_game.ai_config[c]->ResetInfo(true)) {
 				Debug(script, 0, "After a reload, the AI by the name '{}' was no longer found, and removed from the list.", _settings_game.ai_config[c]->GetName());
@@ -270,7 +270,7 @@
 	}
 
 	/* Try to send the event to all AIs */
-	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
+	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
 		if (c != skip_company) AI::NewEvent(c, event);
 	}
 }

--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -169,7 +169,7 @@ struct AIConfigWindow : public Window {
 					for (const Company *c : Company::Iterate()) {
 						if (c->is_ai) max_slot--;
 					}
-					for (CompanyID cid = COMPANY_FIRST; cid < (CompanyID)max_slot && cid < MAX_COMPANIES; cid++) {
+					for (CompanyID cid = COMPANY_FIRST; cid < max_slot && cid < MAX_COMPANIES; ++cid) {
 						if (Company::IsValidID(cid)) max_slot++;
 					}
 				} else {
@@ -219,7 +219,7 @@ struct AIConfigWindow : public Window {
 				if (widget == WID_AIC_DECREASE_NUMBER) {
 					new_value = std::max(0, GetGameSettings().difficulty.max_no_competitors - 1);
 				} else {
-					new_value = std::min(MAX_COMPANIES - 1, GetGameSettings().difficulty.max_no_competitors + 1);
+					new_value = std::min<int>(MAX_COMPANIES - 1, GetGameSettings().difficulty.max_no_competitors + 1);
 				}
 				IConsoleSetSetting("difficulty.max_no_competitors", new_value);
 				this->InvalidateData();
@@ -249,8 +249,8 @@ struct AIConfigWindow : public Window {
 			case WID_AIC_MOVE_UP:
 				if (IsEditable(this->selected_slot) && IsEditable((CompanyID)(this->selected_slot - 1))) {
 					Swap(GetGameSettings().ai_config[this->selected_slot], GetGameSettings().ai_config[this->selected_slot - 1]);
-					this->selected_slot--;
-					this->vscroll->ScrollTowards(this->selected_slot);
+					this->selected_slot = CompanyID(this->selected_slot - 1);
+					this->vscroll->ScrollTowards(this->selected_slot.base());
 					this->InvalidateData();
 				}
 				break;
@@ -258,8 +258,8 @@ struct AIConfigWindow : public Window {
 			case WID_AIC_MOVE_DOWN:
 				if (IsEditable(this->selected_slot) && IsEditable((CompanyID)(this->selected_slot + 1))) {
 					Swap(GetGameSettings().ai_config[this->selected_slot], GetGameSettings().ai_config[this->selected_slot + 1]);
-					this->selected_slot++;
-					this->vscroll->ScrollTowards(this->selected_slot);
+					++this->selected_slot;
+					this->vscroll->ScrollTowards(this->selected_slot.base());
 					this->InvalidateData();
 				}
 				break;

--- a/src/cargomonitor.h
+++ b/src/cargomonitor.h
@@ -64,7 +64,7 @@ inline CargoMonitorID EncodeCargoIndustryMonitor(CompanyID company, CargoType ct
 	SB(ret, CCB_TOWN_IND_NUMBER_START, CCB_TOWN_IND_NUMBER_LENGTH, ind);
 	SetBit(ret, CCB_IS_INDUSTRY_BIT);
 	SB(ret, CCB_CARGO_TYPE_START, CCB_CARGO_TYPE_LENGTH, ctype);
-	SB(ret, CCB_COMPANY_START, CCB_COMPANY_LENGTH, company);
+	SB(ret, CCB_COMPANY_START, CCB_COMPANY_LENGTH, company.base());
 	return ret;
 }
 
@@ -83,7 +83,7 @@ inline CargoMonitorID EncodeCargoTownMonitor(CompanyID company, CargoType ctype,
 	uint32_t ret = 0;
 	SB(ret, CCB_TOWN_IND_NUMBER_START, CCB_TOWN_IND_NUMBER_LENGTH, town);
 	SB(ret, CCB_CARGO_TYPE_START, CCB_CARGO_TYPE_LENGTH, ctype);
-	SB(ret, CCB_COMPANY_START, CCB_COMPANY_LENGTH, company);
+	SB(ret, CCB_COMPANY_START, CCB_COMPANY_LENGTH, company.base());
 	return ret;
 }
 

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -75,12 +75,12 @@ static int32_t ClickChangeCompanyCheat(int32_t new_value, int32_t change_directi
 	while ((uint)new_value < Company::GetPoolSize()) {
 		if (Company::IsValidID((CompanyID)new_value)) {
 			SetLocalCompany((CompanyID)new_value);
-			return _local_company;
+			return _local_company.base();
 		}
 		new_value += change_direction;
 	}
 
-	return _local_company;
+	return _local_company.base();
 }
 
 /**

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -259,7 +259,7 @@ void CommandHelperBase::InternalPostResult(const CommandCost &res, TileIndex til
 /** Helper to make a desync log for a command. */
 void CommandHelperBase::LogCommandExecution(Commands cmd, StringID err_message, const CommandDataBuffer &args, bool failed)
 {
-	Debug(desync, 1, "{}: {:08x}; {:02x}; {:02x}; {:08x}; {:08x}; {} ({})", failed ? "cmdf" : "cmd", (uint32_t)TimerGameEconomy::date.base(), TimerGameEconomy::date_fract, (int)_current_company, cmd, err_message, FormatArrayAsHex(args), GetCommandName(cmd));
+	Debug(desync, 1, "{}: {:08x}; {:02x}; {:02x}; {:08x}; {:08x}; {} ({})", failed ? "cmdf" : "cmd", (uint32_t)TimerGameEconomy::date.base(), TimerGameEconomy::date_fract, _current_company, cmd, err_message, FormatArrayAsHex(args), GetCommandName(cmd));
 }
 
 /**

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -62,7 +62,7 @@ private:
 	std::vector<BitmapStorage> used_bitmap;
 };
 
-typedef Pool<Company, CompanyID, 1, MAX_COMPANIES> CompanyPool;
+typedef Pool<Company, CompanyID, 1, CompanyID::End().base()> CompanyPool;
 extern CompanyPool _company_pool;
 
 /** Statically loadable part of Company pool item */
@@ -156,7 +156,7 @@ struct Company : CompanyProperties, CompanyPool::PoolItem<&_company_pool> {
 	 * @param index Index in the pool.
 	 * @return \c true if it is a valid, computer controlled company, else \c false.
 	 */
-	static inline bool IsValidAiID(size_t index)
+	static inline bool IsValidAiID(auto index)
 	{
 		const Company *c = Company::GetIfValid(index);
 		return c != nullptr && c->is_ai;
@@ -168,7 +168,7 @@ struct Company : CompanyProperties, CompanyPool::PoolItem<&_company_pool> {
 	 * @return \c true if it is a valid, human controlled company, else \c false.
 	 * @note If you know that \a index refers to a valid company, you can use #IsHumanID() instead.
 	 */
-	static inline bool IsValidHumanID(size_t index)
+	static inline bool IsValidHumanID(auto index)
 	{
 		const Company *c = Company::GetIfValid(index);
 		return c != nullptr && !c->is_ai;
@@ -181,7 +181,7 @@ struct Company : CompanyProperties, CompanyPool::PoolItem<&_company_pool> {
 	 * @pre \a index must be a valid CompanyID.
 	 * @note If you don't know whether \a index refers to a valid company, you should use #IsValidHumanID() instead.
 	 */
-	static inline bool IsHumanID(size_t index)
+	static inline bool IsHumanID(auto index)
 	{
 		return !Company::Get(index)->is_ai;
 	}

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -593,7 +593,7 @@ Company *DoStartupNewCompany(bool is_ai, CompanyID company = INVALID_COMPANY)
 		c = new Company(STR_SV_UNNAMED, is_ai);
 	} else {
 		if (Company::IsValidID(company)) return nullptr;
-		c = new (company) Company(STR_SV_UNNAMED, is_ai);
+		c = new (company.base()) Company(STR_SV_UNNAMED, is_ai);
 	}
 
 	c->colour = colour;

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -1344,7 +1344,7 @@ CompanyID GetFirstPlayableCompanyID()
 	}
 
 	if (Company::CanAllocateItem()) {
-		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
+		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
 			if (!Company::IsValidID(c)) {
 				return c;
 			}

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -51,7 +51,7 @@ void UpdateObjectColours(const Company *c);
 
 CompanyID _local_company;   ///< Company controlled by the human player at this client. Can also be #COMPANY_SPECTATOR.
 CompanyID _current_company; ///< Company currently doing an action.
-Colours _company_colours[MAX_COMPANIES];  ///< NOSAVE: can be determined from company structs.
+ReferenceThroughBaseContainer<std::array<Colours, MAX_COMPANIES>> _company_colours; ///< NOSAVE: can be determined from company structs.
 CompanyManagerFace _company_manager_face; ///< for company manager face storage in openttd.cfg
 uint _cur_company_tick_index;             ///< used to generate a name for one company that doesn't have a name yet per tick
 

--- a/src/company_func.h
+++ b/src/company_func.h
@@ -37,7 +37,7 @@ CommandCost CheckTileOwnership(TileIndex tile);
 extern CompanyID _local_company;
 extern CompanyID _current_company;
 
-extern Colours _company_colours[MAX_COMPANIES];
+extern ReferenceThroughBaseContainer<std::array<Colours, MAX_COMPANIES>> _company_colours;
 extern CompanyManagerFace _company_manager_face;
 
 /**

--- a/src/company_type.h
+++ b/src/company_type.h
@@ -11,32 +11,27 @@
 #define COMPANY_TYPE_H
 
 #include "core/enum_type.hpp"
+#include "core/pool_type.hpp"
 
-/**
- * Enum for all companies/owners.
- */
-enum Owner : uint8_t {
-	/* All companies below MAX_COMPANIES are playable
-	 * companies, above, they are special, computer controlled 'companies' */
-	OWNER_BEGIN     = 0x00, ///< First owner
-	COMPANY_FIRST   = 0x00, ///< First company, same as owner
-	MAX_COMPANIES   = 0x0F, ///< Maximum number of companies
-	OWNER_TOWN      = 0x0F, ///< A town owns the tile, or a town is expanding
-	OWNER_NONE      = 0x10, ///< The tile has no ownership
-	OWNER_WATER     = 0x11, ///< The tile/execution is done by "water"
-	OWNER_DEITY     = 0x12, ///< The object is owned by a superuser / goal script
-	OWNER_END,              ///< Last + 1 owner
-	INVALID_OWNER   = 0xFF, ///< An invalid owner
-	INVALID_COMPANY = 0xFF, ///< An invalid company
+using CompanyID = PoolID<uint8_t, struct CompanyIDTag, 0xF, 0xFF>;
+static constexpr CompanyID COMPANY_FIRST = CompanyID::Begin();
+static constexpr CompanyID INVALID_COMPANY = CompanyID::Invalid(); ///< An invalid company
 
-	/* 'Fake' companies used for networks */
-	COMPANY_INACTIVE_CLIENT = 253, ///< The client is joining
-	COMPANY_NEW_COMPANY     = 254, ///< The client wants a new company
-	COMPANY_SPECTATOR       = 255, ///< The client is spectating
-};
-DECLARE_INCREMENT_DECREMENT_OPERATORS(Owner)
-DECLARE_ENUM_AS_ADDABLE(Owner)
+/* 'Fake' companies used for networks */
+static constexpr CompanyID COMPANY_INACTIVE_CLIENT{253}; ///< The client is joining
+static constexpr CompanyID COMPANY_NEW_COMPANY{254}; ///< The client wants a new company
+static constexpr CompanyID COMPANY_SPECTATOR{255}; ///< The client is spectating
 
+using Owner = CompanyID;
+static constexpr Owner OWNER_BEGIN = Owner::Begin(); ///< First owner
+static constexpr Owner OWNER_TOWN{0x0F}; ///< A town owns the tile, or a town is expanding
+static constexpr Owner OWNER_NONE{0x10}; ///< The tile has no ownership
+static constexpr Owner OWNER_WATER{0x11}; ///< The tile/execution is done by "water"
+static constexpr Owner OWNER_DEITY{0x12}; ///< The object is owned by a superuser / goal script
+static constexpr Owner OWNER_END{0x13}; ///< Last + 1 owner
+static constexpr Owner INVALID_OWNER = Owner::Invalid(); ///< An invalid owner
+
+static const uint8_t MAX_COMPANIES = CompanyID::End().base();
 static const uint MAX_LENGTH_PRESIDENT_NAME_CHARS = 32; ///< The maximum length of a president name in characters including '\0'
 static const uint MAX_LENGTH_COMPANY_NAME_CHARS   = 32; ///< The maximum length of a company name in characters including '\0'
 
@@ -50,7 +45,7 @@ typedef Owner CompanyID;
 class CompanyMask : public BaseBitSet<CompanyMask, CompanyID, uint16_t> {
 public:
 	constexpr CompanyMask() : BaseBitSet<CompanyMask, CompanyID, uint16_t>() {}
-	static constexpr size_t DecayValueType(CompanyID value) { return to_underlying(value); }
+	static constexpr size_t DecayValueType(CompanyID value) { return value.base(); }
 
 	constexpr auto operator <=>(const CompanyMask &) const noexcept = default;
 };

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1082,9 +1082,9 @@ DEF_CONSOLE_CMD(ConNetworkReconnect)
 	}
 
 	CompanyID playas = (argc >= 2) ? (CompanyID)atoi(argv[1]) : COMPANY_SPECTATOR;
-	switch (playas) {
+	switch (playas.base()) {
 		case 0: playas = COMPANY_NEW_COMPANY; break;
-		case COMPANY_SPECTATOR: /* nothing to do */ break;
+		case COMPANY_SPECTATOR.base(): /* nothing to do */ break;
 		default:
 			/* From a user pov 0 is a new company, internally it's different and all
 			 * companies are offset by one to ease up on users (eg companies 1-8 not 0-7) */
@@ -1922,10 +1922,10 @@ DEF_CONSOLE_CMD(ConSayCompany)
 	}
 
 	if (!_network_server) {
-		NetworkClientSendChat(NETWORK_ACTION_CHAT_COMPANY, DESTTYPE_TEAM, company_id, argv[2]);
+		NetworkClientSendChat(NETWORK_ACTION_CHAT_COMPANY, DESTTYPE_TEAM, company_id.base(), argv[2]);
 	} else {
 		bool from_admin = (_redirect_console_to_admin < INVALID_ADMIN_ID);
-		NetworkServerSendChat(NETWORK_ACTION_CHAT_COMPANY, DESTTYPE_TEAM, company_id, argv[2], CLIENT_ID_SERVER, from_admin);
+		NetworkServerSendChat(NETWORK_ACTION_CHAT_COMPANY, DESTTYPE_TEAM, company_id.base(), argv[2], CLIENT_ID_SERVER, from_admin);
 	}
 
 	return true;

--- a/src/core/convertible_through_base.hpp
+++ b/src/core/convertible_through_base.hpp
@@ -36,11 +36,17 @@ concept ConvertibleThroughBaseOrTo = std::is_convertible_v<T, TTo> || Convertibl
 template <typename Container>
 class ReferenceThroughBaseContainer : public Container {
 public:
-	Container::reference at(ConvertibleThroughBase auto pos) { return this->Container::at(pos.base()); }
-	Container::const_reference at(ConvertibleThroughBase auto pos) const { return this->Container::at(pos.base()); }
+	Container::reference at(size_t pos) { return this->Container::at(pos); }
+	Container::reference at(const ConvertibleThroughBase auto &pos) { return this->Container::at(pos.base()); }
 
-	Container::reference operator[](ConvertibleThroughBase auto pos) { return this->Container::operator[](pos.base()); }
-	Container::const_reference operator[](ConvertibleThroughBase auto pos) const { return this->Container::operator[](pos.base()); }
+	Container::const_reference at(size_t pos) const { return this->Container::at(pos); }
+	Container::const_reference at(const ConvertibleThroughBase auto &pos) const { return this->Container::at(pos.base()); }
+
+	Container::reference operator[](size_t pos) { return this->Container::operator[](pos); }
+	Container::reference operator[](const ConvertibleThroughBase auto &pos) { return this->Container::operator[](pos.base()); }
+
+	Container::const_reference operator[](size_t pos) const { return this->Container::operator[](pos); }
+	Container::const_reference operator[](const ConvertibleThroughBase auto &pos) const { return this->Container::operator[](pos.base()); }
 };
 
 #endif /* CONVERTIBLE_THROUGH_BASE_HPP */

--- a/src/core/pool_type.hpp
+++ b/src/core/pool_type.hpp
@@ -61,6 +61,8 @@ struct EMPTY_BASES PoolID : PoolIDBase {
 
 	constexpr auto operator++() { ++this->value; return this; }
 	constexpr auto operator+(const std::integral auto &val) const { return this->value + val; }
+	constexpr auto operator-(const std::integral auto &val) const { return this->value - val; }
+	constexpr auto operator%(const std::integral auto &val) const { return this->value % val; }
 
 	constexpr bool operator==(const PoolID<TBaseType, TTag, TEnd, TInvalid> &rhs) const { return this->value == rhs.value; }
 	constexpr auto operator<=>(const PoolID<TBaseType, TTag, TEnd, TInvalid> &rhs) const { return this->value <=> rhs.value; }
@@ -71,6 +73,11 @@ private:
 	/* Do not explicitly initialize. */
 	TBaseType value;
 };
+
+template <typename T> requires std::is_base_of_v<PoolIDBase, T>
+constexpr auto operator+(const std::integral auto &val, const T &pool_id) { return pool_id + val; }
+template <typename Te, typename Tp> requires std::is_enum_v<Te> && std::is_base_of_v<PoolIDBase, Tp>
+constexpr auto operator+(const Te &val, const Tp &pool_id) { return pool_id + to_underlying(val); }
 
 /** Base class for base of all pools. */
 struct PoolBase {

--- a/src/core/random_func.cpp
+++ b/src/core/random_func.cpp
@@ -73,7 +73,7 @@ void SetRandomSeed(uint32_t seed)
 uint32_t Random(const std::source_location location)
 {
 	if (_networking && (!_network_server || (NetworkClientSocket::IsValidID(0) && NetworkClientSocket::Get(0)->status != NetworkClientSocket::STATUS_INACTIVE))) {
-		Debug(random, 0, "{:08x}; {:02x}; {:04x}; {:02x}; {}:{}", TimerGameEconomy::date, TimerGameEconomy::date_fract, _frame_counter, (uint8_t)_current_company, location.file_name(), location.line());
+		Debug(random, 0, "{:08x}; {:02x}; {:04x}; {:02x}; {}:{}", TimerGameEconomy::date, TimerGameEconomy::date_fract, _frame_counter, _current_company, location.file_name(), location.line());
 	}
 
 	return _random.Next();

--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -134,8 +134,8 @@ void CrashLog::FillCrashLog()
 
 	{
 		auto &game = this->survey["game"];
-		game["local_company"] = _local_company;
-		game["current_company"] = _current_company;
+		game["local_company"] = _local_company.base();
+		game["current_company"] = _current_company.base();
 
 		if (!this->TryExecute("timers", [&game]() { SurveyTimers(game["timers"]); return true; })) {
 			game["libraries"] = "crashed while gathering information";

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -100,7 +100,7 @@ const ScoreInfo _score_info[] = {
 	{       0,   0}  // SCORE_TOTAL
 };
 
-int64_t _score_part[MAX_COMPANIES][SCORE_END];
+ReferenceThroughBaseContainer<std::array<std::array<int64_t, SCORE_END>, MAX_COMPANIES>> _score_part;
 Economy _economy;
 Prices _price;
 static PriceMultipliers _price_base_multiplier;
@@ -203,7 +203,7 @@ int UpdateCompanyRatingAndValue(Company *c, bool update)
 	Owner owner = c->index;
 	int score = 0;
 
-	memset(_score_part[owner], 0, sizeof(_score_part[owner]));
+	_score_part[owner] = {};
 
 	/* Count vehicles */
 	{

--- a/src/economy_func.h
+++ b/src/economy_func.h
@@ -23,7 +23,7 @@ void ResetPriceBaseMultipliers();
 void SetPriceBaseMultiplier(Price price, int factor);
 
 extern const ScoreInfo _score_info[];
-extern int64_t _score_part[MAX_COMPANIES][SCORE_END];
+extern ReferenceThroughBaseContainer<std::array<std::array<int64_t, SCORE_END>, MAX_COMPANIES>> _score_part;
 extern Economy _economy;
 /* Prices and also the fractional part. */
 extern Prices _price;

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -54,7 +54,7 @@ struct GraphLegendWindow : Window {
 	{
 		this->InitNested(window_number);
 
-		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
+		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
 			if (!_legend_excluded_companies.Test(c)) this->LowerWidget(WID_GL_FIRST_COMPANY + c);
 
 			this->OnInvalidateData(c);
@@ -676,7 +676,7 @@ public:
 		CompanyMask excluded_companies = _legend_excluded_companies;
 
 		/* Exclude the companies which aren't valid */
-		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
+		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
 			if (!Company::IsValidID(c)) excluded_companies.Set(c);
 		}
 
@@ -704,7 +704,7 @@ public:
 		this->month = mo;
 
 		this->data.clear();
-		for (CompanyID k = COMPANY_FIRST; k < MAX_COMPANIES; k++) {
+		for (CompanyID k = COMPANY_FIRST; k < MAX_COMPANIES; ++k) {
 			const Company *c = Company::GetIfValid(k);
 			if (c == nullptr) continue;
 
@@ -1460,7 +1460,7 @@ struct PerformanceRatingDetailWindow : Window {
 	{
 		if (!gui_scope) return;
 		/* Disable the companies who are not active */
-		for (CompanyID i = COMPANY_FIRST; i < MAX_COMPANIES; i++) {
+		for (CompanyID i = COMPANY_FIRST; i < MAX_COMPANIES; ++i) {
 			this->SetWidgetDisabledState(WID_PRD_COMPANY_FIRST + i, !Company::IsValidID(i));
 		}
 

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -57,7 +57,7 @@ struct GraphLegendWindow : Window {
 		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
 			if (!_legend_excluded_companies.Test(c)) this->LowerWidget(WID_GL_FIRST_COMPANY + c);
 
-			this->OnInvalidateData(c);
+			this->OnInvalidateData(c.base());
 		}
 	}
 
@@ -710,7 +710,7 @@ public:
 
 			DataSet &dataset = this->data.emplace_back();
 			dataset.colour = GetColourGradient(c->colour, SHADE_LIGHTER);
-			dataset.exclude_bit = k;
+			dataset.exclude_bit = k.base();
 
 			for (int j = this->num_on_x_axis, i = 0; --j >= 0;) {
 				if (j >= c->num_valid_stat_ent) {
@@ -1269,7 +1269,7 @@ struct PerformanceRatingDetailWindow : Window {
 		this->UpdateCompanyStats();
 
 		this->InitNested(window_number);
-		this->OnInvalidateData(INVALID_COMPANY);
+		this->OnInvalidateData(INVALID_COMPANY.base());
 	}
 
 	void UpdateCompanyStats()

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -561,7 +561,7 @@ void LinkGraphLegendWindow::SetOverlay(std::shared_ptr<LinkGraphOverlay> overlay
 {
 	this->overlay = overlay;
 	CompanyMask companies = this->overlay->GetCompanyMask();
-	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
+	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
 		if (!this->IsWidgetDisabled(WID_LGL_COMPANY_FIRST + c)) {
 			this->SetWidgetLoweredState(WID_LGL_COMPANY_FIRST + c, companies.Test(c));
 		}
@@ -658,7 +658,7 @@ bool LinkGraphLegendWindow::OnTooltip([[maybe_unused]] Point, WidgetID widget, T
 void LinkGraphLegendWindow::UpdateOverlayCompanies()
 {
 	CompanyMask mask;
-	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
+	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
 		if (this->IsWidgetDisabled(WID_LGL_COMPANY_FIRST + c)) continue;
 		if (!this->IsWidgetLowered(WID_LGL_COMPANY_FIRST + c)) continue;
 		mask.Set(c);
@@ -688,7 +688,7 @@ void LinkGraphLegendWindow::OnClick([[maybe_unused]] Point pt, WidgetID widget, 
 			this->UpdateOverlayCompanies();
 		}
 	} else if (widget == WID_LGL_COMPANIES_ALL || widget == WID_LGL_COMPANIES_NONE) {
-		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
+		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
 			if (this->IsWidgetDisabled(WID_LGL_COMPANY_FIRST + c)) continue;
 			this->SetWidgetLoweredState(WID_LGL_COMPANY_FIRST + c, widget == WID_LGL_COMPANIES_ALL);
 		}
@@ -719,7 +719,7 @@ void LinkGraphLegendWindow::OnInvalidateData([[maybe_unused]] int data, [[maybe_
 	}
 
 	/* Disable the companies who are not active */
-	for (CompanyID i = COMPANY_FIRST; i < MAX_COMPANIES; i++) {
+	for (CompanyID i = COMPANY_FIRST; i < MAX_COMPANIES; ++i) {
 		this->SetWidgetDisabledState(WID_LGL_COMPANY_FIRST + i, !Company::IsValidID(i));
 	}
 }

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -385,7 +385,7 @@ struct MainWindow : Window
 					const NetworkClientInfo *cio = NetworkClientInfo::GetByClientID(_network_own_client_id);
 					if (cio == nullptr) break;
 
-					ShowNetworkChatQueryWindow(NetworkClientPreferTeamChat(cio) ? DESTTYPE_TEAM : DESTTYPE_BROADCAST, cio->client_playas);
+					ShowNetworkChatQueryWindow(NetworkClientPreferTeamChat(cio) ? DESTTYPE_TEAM : DESTTYPE_BROADCAST, cio->client_playas.base());
 				}
 				break;
 
@@ -398,7 +398,7 @@ struct MainWindow : Window
 					const NetworkClientInfo *cio = NetworkClientInfo::GetByClientID(_network_own_client_id);
 					if (cio == nullptr) break;
 
-					ShowNetworkChatQueryWindow(DESTTYPE_TEAM, cio->client_playas);
+					ShowNetworkChatQueryWindow(DESTTYPE_TEAM, cio->client_playas.base());
 				}
 				break;
 

--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -15,6 +15,7 @@
 #include "os_abstraction.h"
 #include "config.h"
 #include "core.h"
+#include "../../core/convertible_through_base.hpp"
 #include "../../string_type.h"
 
 typedef uint16_t PacketSize; ///< Size of the whole packet.
@@ -63,6 +64,7 @@ public:
 	bool   CanWriteToPacket(size_t bytes_to_write);
 	void   Send_bool  (bool   data);
 	void   Send_uint8 (uint8_t  data);
+	void   Send_uint8 (const ConvertibleThroughBase auto &data) { this->Send_uint8(data.base()); }
 	void   Send_uint16(uint16_t data);
 	void   Send_uint32(uint32_t data);
 	void   Send_uint64(uint64_t data);

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -407,8 +407,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyEconomy()
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyStats()
 {
 	/* Fetch the latest version of the stats. */
-	NetworkCompanyStats company_stats[MAX_COMPANIES];
-	NetworkPopulateCompanyStats(company_stats);
+	NetworkCompanyStatsArray company_stats = NetworkGetCompanyStats();
 
 	/* Go through all the companies. */
 	for (const Company *company : Company::Iterate()) {

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -18,6 +18,7 @@
 // #define DEBUG_FAILED_DUMP_COMMANDS
 
 #include "network_type.h"
+#include "../core/convertible_through_base.hpp"
 #include "../console_type.h"
 #include "../gfx_type.h"
 #include "../openttd.h"
@@ -44,7 +45,8 @@ void NetworkDisconnect(bool close_admins = true);
 void NetworkGameLoop();
 void NetworkBackgroundLoop();
 std::string_view ParseFullConnectionString(const std::string &connection_string, uint16_t &port, CompanyID *company_id = nullptr);
-void NetworkPopulateCompanyStats(NetworkCompanyStats *stats);
+using NetworkCompanyStatsArray = ReferenceThroughBaseContainer<std::array<NetworkCompanyStats, MAX_COMPANIES>>;
+NetworkCompanyStatsArray NetworkGetCompanyStats();
 
 void NetworkUpdateClientInfo(ClientID client_id);
 void NetworkClientsToSpectators(CompanyID cid);

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1436,7 +1436,7 @@ private:
 	 */
 	static void OnClickCompanyChat([[maybe_unused]] NetworkClientListWindow *w, [[maybe_unused]] Point pt, CompanyID company_id)
 	{
-		ShowNetworkChatQueryWindow(DESTTYPE_TEAM, company_id);
+		ShowNetworkChatQueryWindow(DESTTYPE_TEAM, company_id.base());
 	}
 
 	/**

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -879,13 +879,13 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_IDENTIFY(Packet
 	if (this->HasClientQuit()) return NETWORK_RECV_STATUS_CLIENT_QUIT;
 
 	/* join another company does not affect these values */
-	switch (playas) {
-		case COMPANY_NEW_COMPANY: // New company
+	switch (playas.base()) {
+		case COMPANY_NEW_COMPANY.base(): // New company
 			if (Company::GetNumItems() >= _settings_client.network.max_companies) {
 				return this->SendError(NETWORK_ERROR_FULL);
 			}
 			break;
-		case COMPANY_SPECTATOR: // Spectator
+		case COMPANY_SPECTATOR.base(): // Spectator
 			break;
 		default: // Join another company (companies 1..MAX_COMPANIES (index 0..(MAX_COMPANIES-1)))
 			if (!Company::IsValidHumanID(playas)) {
@@ -918,7 +918,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_IDENTIFY(Packet
 	ci->client_name = client_name;
 	ci->client_playas = playas;
 	ci->public_key = this->peer_public_key;
-	Debug(desync, 1, "client: {:08x}; {:02x}; {:02x}; {:02x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, (int)ci->client_playas, ci->index);
+	Debug(desync, 1, "client: {:08x}; {:02x}; {:02x}; {:02x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, ci->client_playas, ci->index);
 
 	/* Make sure companies to which people try to join are not autocleaned */
 	Company *c = Company::GetIfValid(playas);
@@ -1531,7 +1531,7 @@ void NetworkUpdateClientInfo(ClientID client_id)
 
 	if (ci == nullptr) return;
 
-	Debug(desync, 1, "client: {:08x}; {:02x}; {:02x}; {:04x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, (int)ci->client_playas, client_id);
+	Debug(desync, 1, "client: {:08x}; {:02x}; {:02x}; {:04x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, ci->client_playas, client_id);
 
 	for (NetworkClientSocket *cs : NetworkClientSocket::Iterate()) {
 		if (cs->status >= ServerNetworkGameSocketHandler::STATUS_AUTHORIZED) {

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1485,12 +1485,11 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_MOVE(Packet &p)
 }
 
 /**
- * Populate the company stats.
- * @param stats the stats to update
+ * Get the company stats.
  */
-void NetworkPopulateCompanyStats(NetworkCompanyStats *stats)
+NetworkCompanyStatsArray NetworkGetCompanyStats()
 {
-	memset(stats, 0, sizeof(*stats) * MAX_COMPANIES);
+	NetworkCompanyStatsArray stats = {};
 
 	/* Go through all vehicles and count the type of vehicles */
 	for (const Vehicle *v : Vehicle::Iterate()) {
@@ -1518,6 +1517,8 @@ void NetworkPopulateCompanyStats(NetworkCompanyStats *stats)
 			if (s->facilities.Test(StationFacility::Dock))      npi->num_station[NETWORK_VEH_SHIP]++;
 		}
 	}
+
+	return stats;
 }
 
 /**

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -456,7 +456,7 @@ uint32_t GetNearbyTileInformation(TileIndex tile, bool grf_version8)
 uint32_t GetCompanyInfo(CompanyID owner, const Livery *l)
 {
 	if (l == nullptr && Company::IsValidID(owner)) l = &Company::Get(owner)->livery[LS_DEFAULT];
-	return owner | (Company::IsValidAiID(owner) ? 0x10000 : 0) | (l != nullptr ? (l->colour1 << 24) | (l->colour2 << 28) : 0);
+	return owner.base() | (Company::IsValidAiID(owner) ? 0x10000 : 0) | (l != nullptr ? (l->colour1 << 24) | (l->colour2 << 28) : 0);
 }
 
 /**

--- a/src/newgrf_debug.h
+++ b/src/newgrf_debug.h
@@ -33,7 +33,9 @@ extern NewGrfDebugSpritePicker _newgrf_debug_sprite_picker;
 bool IsNewGRFInspectable(GrfSpecFeature feature, uint index);
 void ShowNewGRFInspectWindow(GrfSpecFeature feature, uint index, const uint32_t grfid = 0);
 void InvalidateNewGRFInspectWindow(GrfSpecFeature feature, uint index);
+void InvalidateNewGRFInspectWindow(GrfSpecFeature feature, ConvertibleThroughBase auto index) { InvalidateNewGRFInspectWindow(feature, index.base()); }
 void DeleteNewGRFInspectWindow(GrfSpecFeature feature, uint index);
+void DeleteNewGRFInspectWindow(GrfSpecFeature feature, ConvertibleThroughBase auto index) { DeleteNewGRFInspectWindow(feature, index.base()); }
 
 GrfSpecFeature GetGrfSpecFeature(TileIndex tile);
 GrfSpecFeature GetGrfSpecFeature(VehicleType type);

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -73,6 +73,8 @@ static inline uint GetInspectWindowNumber(GrfSpecFeature feature, uint index)
 	return (feature << 24) | index;
 }
 
+static inline uint GetInspectWindowNumber(GrfSpecFeature feature, ConvertibleThroughBase auto index) { return GetInspectWindowNumber(feature, index.base()); }
+
 /**
  * The type of a property to show. This is used to
  * provide an appropriate representation in the GUI.
@@ -225,6 +227,11 @@ protected:
 		SetDParam(1, string);
 		SetDParam(2, index);
 		SetDParam(3, tile);
+	}
+
+	void SetObjectAtStringParameters(StringID string, ConvertibleThroughBase auto index, TileIndex tile) const
+	{
+		this->SetObjectAtStringParameters(string, index.base(), tile);
 	}
 };
 

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -248,7 +248,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t param_setID, uint8_
 				colours = l->colour1 + l->colour2 * 16;
 			}
 
-			return this->industry->founder | (is_ai ? 0x10000 : 0) | (colours << 24);
+			return this->industry->founder.base() | (is_ai ? 0x10000 : 0) | (colours << 24);
 		}
 
 		case 0x46: return this->industry->construction_date.base(); // Date when built - long format - (in days)
@@ -401,7 +401,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t param_setID, uint8_
 		case 0xA5: return GB(this->industry->GetProduced(1).history[LAST_MONTH].transported, 8, 8);
 
 		case 0xA6: return indspec->grf_prop.local_id;
-		case 0xA7: return this->industry->founder;
+		case 0xA7: return this->industry->founder.base();
 		case 0xA8: return this->industry->random_colour;
 		case 0xA9: return ClampTo<uint8_t>(this->industry->last_prod_year - EconomyTime::ORIGINAL_BASE_YEAR);
 		case 0xAA: return this->industry->counter;

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -281,7 +281,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t local_id, uint32_t 
 			case 0x42: return TimerGameCalendar::date.base();
 
 			/* Object founder information */
-			case 0x44: return _current_company;
+			case 0x44: return _current_company.base();
 
 			/* Object view */
 			case 0x48: return this->view;
@@ -322,7 +322,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t local_id, uint32_t 
 		case 0x43: return GetAnimationFrame(this->tile);
 
 		/* Object founder information */
-		case 0x44: return GetTileOwner(this->tile);
+		case 0x44: return GetTileOwner(this->tile).base();
 
 		/* Get town zone and Manhattan distance of closest town */
 		case 0x45: return GetTownRadiusGroup(t, this->tile) << 16 | ClampTo<uint16_t>(DistanceManhattan(this->tile, t->xy));

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -341,7 +341,7 @@ static void LoadIntroGame(bool load_newgrfs = true)
 
 void MakeNewgameSettingsLive()
 {
-	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
+	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
 		if (_settings_game.ai_config[c] != nullptr) {
 			delete _settings_game.ai_config[c];
 		}
@@ -355,7 +355,7 @@ void MakeNewgameSettingsLive()
 	_settings_game = _settings_newgame;
 	_old_vds = _settings_client.company.vehicle;
 
-	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
+	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
 		_settings_game.ai_config[c] = nullptr;
 		if (_settings_newgame.ai_config[c] != nullptr) {
 			_settings_game.ai_config[c] = new AIConfig(_settings_newgame.ai_config[c]);

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -2417,8 +2417,8 @@ static void ConvertRoadTypeOwner(TileIndex tile, uint num_pieces, Owner owner, R
 
 	Company *c;
 
-	switch (owner) {
-	case OWNER_NONE:
+	switch (owner.base()) {
+	case OWNER_NONE.base():
 		SetRoadOwner(tile, GetRoadTramType(to_type), (Owner)_current_company);
 		UpdateCompanyRoadInfrastructure(to_type, _current_company, num_pieces);
 		break;

--- a/src/road_map.h
+++ b/src/road_map.h
@@ -251,9 +251,9 @@ inline Owner GetRoadOwner(Tile t, RoadTramType rtt)
 inline void SetRoadOwner(Tile t, RoadTramType rtt, Owner o)
 {
 	if (rtt == RTT_ROAD) {
-		SB(IsNormalRoadTile(t) ? t.m1() : t.m7(), 0, 5, o);
+		SB(IsNormalRoadTile(t) ? t.m1() : t.m7(), 0, 5, o.base());
 	} else {
-		SB(t.m3(), 4, 4, o == OWNER_NONE ? OWNER_TOWN : o);
+		SB(t.m3(), 4, 4, (o == OWNER_NONE ? OWNER_TOWN : o).base());
 	}
 }
 
@@ -666,7 +666,7 @@ inline void MakeRoadCrossing(Tile t, Owner road, Owner tram, Owner rail, Axis ro
 	t.m4() = INVALID_ROADTYPE;
 	t.m5() = ROAD_TILE_CROSSING << 6 | roaddir;
 	SB(t.m6(), 2, 4, 0);
-	t.m7() = road;
+	t.m7() = road.base();
 	t.m8() = INVALID_ROADTYPE << 6 | rat;
 	SetRoadTypes(t, road_rt, tram_rt);
 	SetRoadOwner(t, RTT_TRAM, tram);
@@ -700,7 +700,7 @@ inline void MakeRoadDepot(Tile tile, Owner owner, DepotID depot_id, DiagDirectio
 	tile.m4() = INVALID_ROADTYPE;
 	tile.m5() = ROAD_TILE_DEPOT << 6 | dir;
 	SB(tile.m6(), 2, 4, 0);
-	tile.m7() = owner;
+	tile.m7() = owner.base();
 	tile.m8() = INVALID_ROADTYPE << 6;
 	SetRoadType(tile, GetRoadTramType(rt), rt);
 	SetRoadOwner(tile, RTT_TRAM, owner);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -161,7 +161,7 @@ static void ConvertTownOwner()
 		switch (GetTileType(tile)) {
 			case MP_ROAD:
 				if (GB(tile.m5(), 4, 2) == ROAD_TILE_CROSSING && HasBit(tile.m3(), 7)) {
-					tile.m3() = OWNER_TOWN;
+					tile.m3() = OWNER_TOWN.base();
 				}
 				[[fallthrough]];
 
@@ -1159,7 +1159,7 @@ bool AfterLoadGame()
 					if (!IsStationRoadStop(t)) break;
 
 					if (fix_roadtypes) SB(t.m7(), 6, 2, (RoadTypes)GB(t.m3(), 0, 3));
-					SB(t.m7(), 0, 5, HasBit(t.m6(), 2) ? OWNER_TOWN : GetTileOwner(t));
+					SB(t.m7(), 0, 5, (HasBit(t.m6(), 2) ? OWNER_TOWN : GetTileOwner(t)).base());
 					SB(t.m3(), 4, 4, t.m1());
 					t.m4() = 0;
 					break;
@@ -1170,8 +1170,8 @@ bool AfterLoadGame()
 						if (fix_roadtypes) SB(t.m7(), 6, 2, (RoadTypes)GB(t.m3(), 0, 3));
 
 						Owner o = GetTileOwner(t);
-						SB(t.m7(), 0, 5, o); // road owner
-						SB(t.m3(), 4, 4, o == OWNER_NONE ? OWNER_TOWN : o); // tram owner
+						SB(t.m7(), 0, 5, o.base()); // road owner
+						SB(t.m3(), 4, 4, (o == OWNER_NONE ? OWNER_TOWN : o).base()); // tram owner
 					}
 					SB(t.m6(), 2, 4, GB(t.m2(), 4, 4)); // bridge type
 					SB(t.m7(), 5, 1, GB(t.m4(), 7, 1)); // snow/desert
@@ -1730,7 +1730,7 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SLV_83)) {
 		for (auto t : Map::Iterate()) {
 			if (IsShipDepotTile(t)) {
-				t.m4() = (TileHeight(t) == 0) ? OWNER_WATER : OWNER_NONE;
+				t.m4() = (TileHeight(t) == 0 ? OWNER_WATER : OWNER_NONE).base();
 			}
 		}
 	}

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3415,7 +3415,7 @@ void ReloadNewGRFData()
 	/* Delete news referring to no longer existing entities */
 	DeleteInvalidEngineNews();
 	/* Update livery selection windows */
-	for (CompanyID i = COMPANY_FIRST; i < MAX_COMPANIES; i++) InvalidateWindowData(WC_COMPANY_COLOUR, i);
+	for (CompanyID i = COMPANY_FIRST; i < MAX_COMPANIES; ++i) InvalidateWindowData(WC_COMPANY_COLOUR, i);
 	/* Update company infrastructure counts. */
 	InvalidateWindowClassesData(WC_COMPANY_INFRASTRUCTURE);
 	InvalidateWindowClassesData(WC_BUILD_TOOLBAR);

--- a/src/saveload/ai_sl.cpp
+++ b/src/saveload/ai_sl.cpp
@@ -162,7 +162,7 @@ struct AIPLChunkHandler : ChunkHandler {
 
 		for (CompanyID i = COMPANY_FIRST; i < MAX_COMPANIES; ++i) {
 			SlSetArrayIndex(i);
-			SlAutolength(SaveReal_AIPL, i);
+			SlAutolength(SaveReal_AIPL, i.base());
 		}
 	}
 };

--- a/src/saveload/ai_sl.cpp
+++ b/src/saveload/ai_sl.cpp
@@ -80,7 +80,7 @@ struct AIPLChunkHandler : ChunkHandler {
 		const std::vector<SaveLoad> slt = SlCompatTableHeader(_ai_company_desc, _ai_company_sl_compat);
 
 		/* Free all current data */
-		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
+		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
 			AIConfig::GetConfig(c, AIConfig::SSS_FORCE_GAME)->Change(std::nullopt);
 		}
 
@@ -160,7 +160,7 @@ struct AIPLChunkHandler : ChunkHandler {
 	{
 		SlTableHeader(_ai_company_desc);
 
-		for (int i = COMPANY_FIRST; i < MAX_COMPANIES; i++) {
+		for (CompanyID i = COMPANY_FIRST; i < MAX_COMPANIES; ++i) {
 			SlSetArrayIndex(i);
 			SlAutolength(SaveReal_AIPL, i);
 		}

--- a/src/saveload/randomizer_sl.cpp
+++ b/src/saveload/randomizer_sl.cpp
@@ -26,7 +26,7 @@ struct SRNDChunkHandler : ChunkHandler {
 	{
 		SlTableHeader(_randomizer_desc);
 
-		for (Owner owner = OWNER_BEGIN; owner < OWNER_END; owner++) {
+		for (Owner owner = OWNER_BEGIN; owner < OWNER_END; ++owner) {
 			SlSetArrayIndex(owner);
 			SlObject(&ScriptObject::GetRandomizer(owner), _randomizer_desc);
 		}

--- a/src/screenshot_png.cpp
+++ b/src/screenshot_png.cpp
@@ -92,9 +92,9 @@ public:
 		message += "\nCompanies:\n";
 		for (const Company *c : Company::Iterate()) {
 			if (c->ai_info == nullptr) {
-				fmt::format_to(std::back_inserter(message), "{:2d}: Human\n", (int)c->index);
+				fmt::format_to(std::back_inserter(message), "{:2d}: Human\n", c->index);
 			} else {
-				fmt::format_to(std::back_inserter(message), "{:2d}: {} (v{})\n", (int)c->index, c->ai_info->GetName(), c->ai_info->GetVersion());
+				fmt::format_to(std::back_inserter(message), "{:2d}: {} (v{})\n", c->index, c->ai_info->GetName(), c->ai_info->GetVersion());
 			}
 		}
 		text[1].key = const_cast<char *>("Description");

--- a/src/script/api/script_company.cpp
+++ b/src/script/api/script_company.cpp
@@ -40,7 +40,7 @@
 /* static */ ScriptCompany::CompanyID ScriptCompany::ToScriptCompanyID(::CompanyID company)
 {
 	if (company == ::INVALID_COMPANY) return ScriptCompany::COMPANY_INVALID;
-	return static_cast<::ScriptCompany::CompanyID>(company);
+	return static_cast<::ScriptCompany::CompanyID>(company.base());
 }
 
 /* static */ ScriptCompany::CompanyID ScriptCompany::ResolveCompanyID(ScriptCompany::CompanyID company)

--- a/src/script/api/script_company.hpp
+++ b/src/script/api/script_company.hpp
@@ -30,7 +30,7 @@ public:
 	/** Different constants related to CompanyID. */
 	enum CompanyID {
 		/* Note: these values represent part of the in-game Owner enum */
-		COMPANY_FIRST     = ::COMPANY_FIRST,   ///< The first available company.
+		COMPANY_FIRST     = ::COMPANY_FIRST.base(), ///< The first available company.
 		COMPANY_LAST      = ::MAX_COMPANIES,   ///< The last available company.
 
 		/* Custom added value, only valid for this API */

--- a/src/script/api/script_goal.cpp
+++ b/src/script/api/script_goal.cpp
@@ -136,7 +136,7 @@
 /* static */ bool ScriptGoal::Question(SQInteger uniqueid, ScriptCompany::CompanyID company, Text *question, QuestionType type, SQInteger buttons)
 {
 	EnforcePrecondition(false, company == ScriptCompany::COMPANY_INVALID || ScriptCompany::ResolveCompanyID(company) != ScriptCompany::COMPANY_INVALID);
-	return DoQuestion(uniqueid, ScriptCompany::FromScriptCompanyID(company), false, question, type, buttons);
+	return DoQuestion(uniqueid, ScriptCompany::FromScriptCompanyID(company).base(), false, question, type, buttons);
 }
 
 /* static */ bool ScriptGoal::QuestionClient(SQInteger uniqueid, ScriptClient::ClientID client, Text *question, QuestionType type, SQInteger buttons)

--- a/src/script/api/script_log.cpp
+++ b/src/script/api/script_log.cpp
@@ -57,6 +57,6 @@
 	}
 
 	/* Also still print to debug window */
-	Debug(script, level, "[{}] [{}] {}", (uint)ScriptObject::GetRootCompany(), logc, line.text);
+	Debug(script, level, "[{}] [{}] {}", ScriptObject::GetRootCompany(), logc, line.text);
 	InvalidateWindowClassesData(WC_SCRIPT_DEBUG, ScriptObject::GetRootCompany());
 }

--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -347,7 +347,7 @@ bool ScriptObject::DoCommandProcessResult(const CommandCost &res, Script_Suspend
 }
 
 
-/* static */ Randomizer ScriptObject::random_states[OWNER_END];
+/* static */ ScriptObject::RandomizerArray ScriptObject::random_states;
 
 Randomizer &ScriptObject::GetRandomizer(Owner owner)
 {

--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -357,7 +357,7 @@ Randomizer &ScriptObject::GetRandomizer(Owner owner)
 void ScriptObject::InitializeRandomizers()
 {
 	Randomizer random = _random;
-	for (Owner owner = OWNER_BEGIN; owner < OWNER_END; owner++) {
+	for (Owner owner = OWNER_BEGIN; owner < OWNER_END; ++owner) {
 		ScriptObject::GetRandomizer(owner).SetSeed(random.Next());
 	}
 }

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -330,7 +330,8 @@ private:
 	static std::tuple<bool, bool, bool, bool> DoCommandPrep();
 	static bool DoCommandProcessResult(const CommandCost &res, Script_SuspendCallbackProc *callback, bool estimate_only, bool asynchronous);
 	static CommandCallbackData *GetDoCommandCallback();
-	static Randomizer random_states[OWNER_END]; ///< Random states for each of the scripts (game script uses OWNER_DEITY)
+	using RandomizerArray = ReferenceThroughBaseContainer<std::array<Randomizer, OWNER_END>>;
+	static RandomizerArray random_states; ///< Random states for each of the scripts (game script uses OWNER_DEITY)
 };
 
 namespace ScriptObjectInternal {

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -330,7 +330,7 @@ private:
 	static std::tuple<bool, bool, bool, bool> DoCommandPrep();
 	static bool DoCommandProcessResult(const CommandCost &res, Script_SuspendCallbackProc *callback, bool estimate_only, bool asynchronous);
 	static CommandCallbackData *GetDoCommandCallback();
-	using RandomizerArray = ReferenceThroughBaseContainer<std::array<Randomizer, OWNER_END>>;
+	using RandomizerArray = ReferenceThroughBaseContainer<std::array<Randomizer, OWNER_END.base()>>;
 	static RandomizerArray random_states; ///< Random states for each of the scripts (game script uses OWNER_DEITY)
 };
 

--- a/src/script/api/script_viewport.cpp
+++ b/src/script/api/script_viewport.cpp
@@ -42,7 +42,7 @@
 	company = ScriptCompany::ResolveCompanyID(company);
 	EnforcePrecondition(false, company != ScriptCompany::COMPANY_INVALID);
 
-	return ScriptObject::Command<CMD_SCROLL_VIEWPORT>::Do(tile, VST_COMPANY, ScriptCompany::FromScriptCompanyID(company));
+	return ScriptObject::Command<CMD_SCROLL_VIEWPORT>::Do(tile, VST_COMPANY, ScriptCompany::FromScriptCompanyID(company).base());
 }
 
 /* static */ bool ScriptViewport::ScrollClientTo(ScriptClient::ClientID client, TileIndex tile)

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -742,9 +742,9 @@ struct ScriptDebugWindow : public Window {
 	 */
 	bool IsValidDebugCompany(CompanyID company) const
 	{
-		switch (company) {
-			case INVALID_COMPANY: return false;
-			case OWNER_DEITY:     return Game::GetInstance() != nullptr;
+		switch (company.base()) {
+			case INVALID_COMPANY.base(): return false;
+			case OWNER_DEITY.base(): return Game::GetInstance() != nullptr;
 			default:              return Company::IsValidAiID(company);
 		}
 	}

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -977,7 +977,7 @@ struct ScriptDebugWindow : public Window {
 	void UpdateAIButtonsState()
 	{
 		/* Update company buttons */
-		for (CompanyID i = COMPANY_FIRST; i < MAX_COMPANIES; i++) {
+		for (CompanyID i = COMPANY_FIRST; i < MAX_COMPANIES; ++i) {
 			/* Mark dead/paused AIs by setting the background colour. */
 			bool valid = Company::IsValidAiID(i);
 			bool dead = valid && Company::Get(i)->ai_instance->IsDead();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -962,7 +962,7 @@ static void AILoadConfig(const IniFile &ini, const char *grpname)
 	const IniGroup *group = ini.GetGroup(grpname);
 
 	/* Clean any configured AI */
-	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
+	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
 		AIConfig::GetConfig(c, AIConfig::SSS_FORCE_NEWGAME)->Change(std::nullopt);
 	}
 
@@ -981,7 +981,7 @@ static void AILoadConfig(const IniFile &ini, const char *grpname)
 			}
 		}
 		if (item.value.has_value()) config->StringToSettings(*item.value);
-		c++;
+		++c;
 		if (c >= MAX_COMPANIES) break;
 	}
 }
@@ -1170,7 +1170,7 @@ static void AISaveConfig(IniFile &ini, const char *grpname)
 	IniGroup &group = ini.GetOrCreateGroup(grpname);
 	group.Clear();
 
-	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
+	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
 		AIConfig *config = AIConfig::GetConfig(c, AIConfig::SSS_FORCE_NEWGAME);
 		std::string name;
 		std::string value = config->SettingsToString();

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -602,7 +602,7 @@ struct GameSettings {
 	ConstructionSettings construction;       ///< construction of things in-game
 	AISettings           ai;                 ///< what may the AI do?
 	ScriptSettings       script;             ///< settings for scripts
-	class AIConfig      *ai_config[MAX_COMPANIES]; ///< settings per company
+	ReferenceThroughBaseContainer<std::array<class AIConfig *, MAX_COMPANIES>> ai_config; ///< settings per company
 	class GameConfig    *game_config;        ///< settings for gamescript
 	PathfinderSettings   pf;                 ///< settings for all pathfinders
 	OrderSettings        order;              ///< settings related to orders

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -181,7 +181,7 @@ static IndustryType _smallmap_industry_highlight = IT_INVALID;
 /** State of highlight blinking */
 static bool _smallmap_industry_highlight_state;
 /** For connecting company ID to position in owner list (small map legend) */
-static uint _company_to_list_pos[MAX_COMPANIES];
+static ReferenceThroughBaseContainer<std::array<uint32_t, MAX_COMPANIES>> _company_to_list_pos;
 
 /**
  * Fills an array for the industries legends.

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -219,7 +219,7 @@ void BuildIndustriesLegend()
 void BuildLinkStatsLegend()
 {
 	/* Clear the legend */
-	memset(_legend_linkstats, 0, sizeof(_legend_linkstats));
+	std::fill(std::begin(_legend_linkstats), std::end(_legend_linkstats), LegendAndColour{});
 
 	uint i = 0;
 	for (; i < _sorted_cargo_specs.size(); ++i) {

--- a/src/source_type.h
+++ b/src/source_type.h
@@ -34,12 +34,17 @@ public:
 	SourceID id; ///< Index of industry/town/HQ, Source::Invalid if unknown/invalid.
 	SourceType type; ///< Type of \c source_id.
 
+	Source() = default;
+	Source(ConvertibleThroughBase auto id, SourceType type) : id(id.base()), type(type) {}
+	Source(SourceID id, SourceType type) : id(id), type(type) {}
+
 	constexpr CompanyID ToCompanyID() const { assert(this->type == SourceType::Headquarters); return static_cast<CompanyID>(this->id); }
 	constexpr IndustryID ToIndustryID() const { assert(this->type == SourceType::Industry); return static_cast<IndustryID>(this->id); }
 	constexpr TownID ToTownID() const { assert(this->type == SourceType::Town); return static_cast<TownID>(this->id); }
 
 	constexpr void MakeInvalid() { this->id = Source::Invalid; }
 	constexpr void SetIndex(SourceID index) { this->id = index; }
+	constexpr void SetIndex(ConvertibleThroughBase auto index) { this->id = index.base(); }
 
 	constexpr bool IsValid() const noexcept { return this->id != Source::Invalid; }
 	auto operator<=>(const Source &source) const = default;

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4427,8 +4427,8 @@ uint MoveGoodsToStation(CargoType type, uint amount, Source source, const Statio
 		return UpdateStationWaiting(first_station, type, amount, source);
 	}
 
-	ReferenceThroughBaseContainer<std::array<uint32_t, OWNER_END>> company_best = {};  // best rating for each company, including OWNER_NONE
-	ReferenceThroughBaseContainer<std::array<uint32_t, OWNER_END>> company_sum = {};   // sum of ratings for each company
+	ReferenceThroughBaseContainer<std::array<uint32_t, OWNER_END.base()>> company_best = {};  // best rating for each company, including OWNER_NONE
+	ReferenceThroughBaseContainer<std::array<uint32_t, OWNER_END.base()>> company_sum = {};   // sum of ratings for each company
 	uint best_rating = 0;
 	uint best_sum = 0;  // sum of best ratings for each company
 
@@ -4449,7 +4449,7 @@ uint MoveGoodsToStation(CargoType type, uint amount, Source source, const Statio
 
 	uint moving = 0;
 	for (auto &p : used_stations) {
-		uint owner = p.first->owner;
+		Owner owner = p.first->owner;
 		/* Multiply the amount by (company best / sum of best for each company) to get cargo allocated to a company
 		 * and by (station rating / sum of ratings in a company) to get the result for a single station. */
 		p.second = amount * company_best[owner] * p.first->goods[type].rating / best_sum / company_sum[owner];

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4427,8 +4427,8 @@ uint MoveGoodsToStation(CargoType type, uint amount, Source source, const Statio
 		return UpdateStationWaiting(first_station, type, amount, source);
 	}
 
-	uint company_best[OWNER_NONE + 1] = {};  // best rating for each company, including OWNER_NONE
-	uint company_sum[OWNER_NONE + 1] = {};   // sum of ratings for each company
+	ReferenceThroughBaseContainer<std::array<uint32_t, OWNER_END>> company_best = {};  // best rating for each company, including OWNER_NONE
+	ReferenceThroughBaseContainer<std::array<uint32_t, OWNER_END>> company_sum = {};   // sum of ratings for each company
 	uint best_rating = 0;
 	uint best_sum = 0;  // sum of best ratings for each company
 

--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -308,7 +308,7 @@ void SurveyFont(nlohmann::json &survey)
 void SurveyCompanies(nlohmann::json &survey)
 {
 	for (const Company *c : Company::Iterate()) {
-		auto &company = survey[std::to_string(c->index)];
+		auto &company = survey[std::to_string(c->index.base())];
 		if (c->ai_info == nullptr) {
 			company["type"] = "human";
 		} else {

--- a/src/tile_map.h
+++ b/src/tile_map.h
@@ -201,7 +201,7 @@ inline void SetTileOwner(Tile tile, Owner owner)
 	assert(!IsTileType(tile, MP_HOUSE));
 	assert(!IsTileType(tile, MP_INDUSTRY));
 
-	SB(tile.m1(), 0, 5, owner);
+	SB(tile.m1(), 0, 5, owner.base());
 }
 
 /**

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -173,7 +173,7 @@ static void PopupMainCompanyToolbMenu(Window *w, WidgetID widget, CompanyMask gr
 			break;
 	}
 
-	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
+	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
 		if (!Company::IsValidID(c)) continue;
 		list.push_back(std::make_unique<DropDownListCompanyItem>(c, grey.Test(c)));
 	}

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -98,7 +98,7 @@ static CallBackFunction _last_started_action = CBF_NONE; ///< Last started user 
  */
 class DropDownListCompanyItem : public DropDownIcon<DropDownIcon<DropDownString<DropDownListItem>, true>> {
 public:
-	DropDownListCompanyItem(CompanyID company, bool shaded) : DropDownIcon<DropDownIcon<DropDownString<DropDownListItem>, true>>(SPR_COMPANY_ICON, COMPANY_SPRITE_COLOUR(company), NetworkCanJoinCompany(company) ? SPR_EMPTY : SPR_LOCK, PAL_NONE, STR_NULL, company, false, shaded)
+	DropDownListCompanyItem(CompanyID company, bool shaded) : DropDownIcon<DropDownIcon<DropDownString<DropDownListItem>, true>>(SPR_COMPANY_ICON, COMPANY_SPRITE_COLOUR(company), NetworkCanJoinCompany(company) ? SPR_EMPTY : SPR_LOCK, PAL_NONE, STR_NULL, company.base(), false, shaded)
 	{
 		this->SetString(GetString(STR_COMPANY_NAME_COMPANY_NUM, company, company));
 	}
@@ -178,7 +178,7 @@ static void PopupMainCompanyToolbMenu(Window *w, WidgetID widget, CompanyMask gr
 		list.push_back(std::make_unique<DropDownListCompanyItem>(c, grey.Test(c)));
 	}
 
-	PopupMainToolbarMenu(w, widget, std::move(list), _local_company == COMPANY_SPECTATOR ? (widget == WID_TN_COMPANIES ? CTMN_CLIENT_LIST : CTMN_SPECTATOR) : (int)_local_company);
+	PopupMainToolbarMenu(w, widget, std::move(list), _local_company == COMPANY_SPECTATOR ? (widget == WID_TN_COMPANIES ? CTMN_CLIENT_LIST : CTMN_SPECTATOR) : _local_company.base());
 }
 
 static ToolbarMode _toolbar_mode;

--- a/src/town.h
+++ b/src/town.h
@@ -69,10 +69,10 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 
 	/* Company ratings. */
 	CompanyMask have_ratings;      ///< which companies have a rating
-	uint8_t unwanted[MAX_COMPANIES]; ///< how many months companies aren't wanted by towns (bribe)
+	ReferenceThroughBaseContainer<std::array<uint8_t, MAX_COMPANIES>> unwanted; ///< how many months companies aren't wanted by towns (bribe)
 	CompanyID exclusivity;         ///< which company has exclusivity
 	uint8_t exclusive_counter;       ///< months till the exclusivity expires
-	int16_t ratings[MAX_COMPANIES];  ///< ratings of each company for this town
+	ReferenceThroughBaseContainer<std::array<int16_t, MAX_COMPANIES>> ratings;  ///< ratings of each company for this town
 
 	TransportedCargoStat<uint32_t> supplied[NUM_CARGO]; ///< Cargo statistics about supplied cargo.
 	TransportedCargoStat<uint16_t> received[NUM_TAE]; ///< Cargo statistics about received cargotypes.

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2329,7 +2329,7 @@ void ShowVehicleListWindow(CompanyID company, VehicleType vehicle_type)
 	if ((_settings_client.gui.advanced_vehicle_list > (uint)(company != _local_company)) != _ctrl_pressed) {
 		ShowCompanyGroup(company, vehicle_type);
 	} else {
-		ShowVehicleListWindowLocal(company, VL_STANDARD, vehicle_type, company);
+		ShowVehicleListWindowLocal(company, VL_STANDARD, vehicle_type, company.base());
 	}
 }
 

--- a/src/vehiclelist.cpp
+++ b/src/vehiclelist.cpp
@@ -22,7 +22,7 @@
  */
 WindowNumber VehicleListIdentifier::ToWindowNumber() const
 {
-	uint8_t c = this->company == OWNER_NONE ? 0xF : (uint8_t)this->company;
+	uint8_t c = this->company == OWNER_NONE ? 0xF : this->company.base();
 	assert(c             < (1 <<  4));
 	assert(this->vtype   < (1 <<  2));
 	assert(this->index   < (1 << 20));

--- a/src/window_func.h
+++ b/src/window_func.h
@@ -35,6 +35,7 @@ void SetupColoursAndInitialWindow();
 void InputLoop();
 
 void InvalidateWindowData(WindowClass cls, WindowNumber number, int data = 0, bool gui_scope = false);
+void InvalidateWindowData(WindowClass cls, WindowNumber number, ConvertibleThroughBase auto data, bool gui_scope = false) { InvalidateWindowData(cls, number, data.base(), gui_scope); }
 void InvalidateWindowClassesData(WindowClass cls, int data = 0, bool gui_scope = false);
 void InvalidateWindowClassesData(WindowClass cls, ConvertibleThroughBase auto data, bool gui_scope = false) { InvalidateWindowClassesData(cls, data.base(), gui_scope); }
 

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -763,6 +763,9 @@ public:
 	/* Automatically convert to any other type that might be requested. */
 	template <typename T> requires (std::is_enum_v<T> || std::is_class_v<T>)
 	operator T() const { return static_cast<T>(value); };
+
+	constexpr bool operator==(const std::integral auto &rhs) const { return this->value == static_cast<int32_t>(rhs); }
+	constexpr bool operator==(const ConvertibleThroughBase auto &rhs) const { return this->value == static_cast<int32_t>(rhs.base()); }
 };
 
 /** State of handling an event. */


### PR DESCRIPTION
## Motivation / Problem

Continuation of the `PoolID` conversion, this time for `CompanyID`.


## Description

* Introduce some more helper functions.
* Change `c++` to `++c`; `PoolID` only has the prefix `operator++`.
* Change some arrays to `std::array` wrapped in `ReferenceThroughBaseContainer`.
* Actually change `CompanyID` to `PoolID`.


Some other related changes:
* For the network company statistics rewrite the function to return an the data (in ReferenceThroughBaseContainer`.
* In station_cmd.cpp there was an array going up to `OWNER_NONE + 1`, which I made to go to `OWNER_END`; it's simpler and more fault tolerant in the future.
* When broadcasting events to the AI, don't `MAX_COMPANIES`, but rather `CompanyID::Invalid()` as that shows the intention better.


## Limitations

Conflicts with the `NewsReference` PR on the helper functions. That's not a problem, the other just needs to be rebased. For the rest they do not interfere with each other.

Like with the other PRs, I haven't renamed the constants for begin/end/invalid yet. That'll be done in a separate PR as that's just a simple mass rename that would make this PR harder to review.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
