### PR TITLE
Codefix: Change method to take const pointer instead of using const_cast.

### DIFF
--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -173,7 +173,7 @@ bool ClientNetworkContentSocketHandler::Receive_SERVER_INFO(Packet &p)
 	ConstContentVector parents;
 	this->ReverseLookupTreeDependency(parents, ci);
 	for (const ContentInfo *ici : parents) {
-		this->CheckDependencyState(const_cast<ContentInfo *>(ici));
+		this->CheckDependencyState(ici);
 	}
 
 	this->OnReceiveContentInfo(ci);
@@ -973,7 +973,7 @@ void ClientNetworkContentSocketHandler::ReverseLookupTreeDependency(ConstContent
  * Check the dependencies (recursively) of this content info
  * @param ci the content info to check the dependencies of
  */
-void ClientNetworkContentSocketHandler::CheckDependencyState(ContentInfo *ci)
+void ClientNetworkContentSocketHandler::CheckDependencyState(const ContentInfo *ci)
 {
 	if (ci->IsSelected() || ci->state == ContentInfo::ALREADY_HERE) {
 		/* Selection is easy; just walk all children and set the

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -130,7 +130,7 @@ public:
 
 	void ReverseLookupDependency(ConstContentVector &parents, const ContentInfo *child) const;
 	void ReverseLookupTreeDependency(ConstContentVector &tree, const ContentInfo *child) const;
-	void CheckDependencyState(ContentInfo *ci);
+	void CheckDependencyState(const ContentInfo *ci);
 
 	/** Get the number of content items we know locally. */
 	uint Length() const { return (uint)this->infos.size(); }


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Use of `const_cast<>` when passing a const pointer to a method that doesn't take a const pointer.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Turned out the method doesn't need to modify the object and can take a const pointer itself, eliminating the need for `const_cast<>`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
