### PR TITLE
Codechange: Compile fmt internals in a separate translation unit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,7 @@ target_precompile_headers(openttd_lib
     src/stdafx.h
     src/core/format.hpp
 )
+set_source_files_properties(src/3rdparty/fmt/format.cc PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
 
 add_subdirectory(${CMAKE_SOURCE_DIR}/bin)
 add_subdirectory(${CMAKE_SOURCE_DIR}/src)

--- a/src/3rdparty/fmt/CMakeLists.txt
+++ b/src/3rdparty/fmt/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_files(
     chrono.h
     core.h
+    format.cc
     format.h
     format-inl.h
     ostream.h

--- a/src/3rdparty/fmt/format.cc
+++ b/src/3rdparty/fmt/format.cc
@@ -1,0 +1,43 @@
+// Formatting library for C++
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#include "format-inl.h"
+
+FMT_BEGIN_NAMESPACE
+namespace detail {
+
+template FMT_API auto dragonbox::to_decimal(float x) noexcept
+    -> dragonbox::decimal_fp<float>;
+template FMT_API auto dragonbox::to_decimal(double x) noexcept
+    -> dragonbox::decimal_fp<double>;
+
+#ifndef FMT_STATIC_THOUSANDS_SEPARATOR
+template FMT_API locale_ref::locale_ref(const std::locale& loc);
+template FMT_API auto locale_ref::get<std::locale>() const -> std::locale;
+#endif
+
+// Explicit instantiations for char.
+
+template FMT_API auto thousands_sep_impl(locale_ref)
+    -> thousands_sep_result<char>;
+template FMT_API auto decimal_point_impl(locale_ref) -> char;
+
+template FMT_API void buffer<char>::append(const char*, const char*);
+
+template FMT_API void vformat_to(buffer<char>&, string_view,
+                                 typename vformat_args<>::type, locale_ref);
+
+// Explicit instantiations for wchar_t.
+
+template FMT_API auto thousands_sep_impl(locale_ref)
+    -> thousands_sep_result<wchar_t>;
+template FMT_API auto decimal_point_impl(locale_ref) -> wchar_t;
+
+template FMT_API void buffer<wchar_t>::append(const wchar_t*, const wchar_t*);
+
+}  // namespace detail
+FMT_END_NAMESPACE

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -21,7 +21,11 @@
 #include "table/strings.h"
 
 #if defined(WITH_ZLIB)
-#include <zlib.h>
+#	include <zlib.h>
+#	if defined(_WIN32)
+		/* Required for: dup, fileno, close */
+#		include <io.h>
+#	endif
 #endif
 
 #ifdef __EMSCRIPTEN__

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -20,6 +20,7 @@
 #include <shlobj.h> /* SHGetFolderPath */
 #include <shellapi.h>
 #include <winnls.h>
+#include <io.h>
 #include "win32.h"
 #include "../../fios.h"
 #include "../../core/alloc_func.hpp"

--- a/src/settingsgen/CMakeLists.txt
+++ b/src/settingsgen/CMakeLists.txt
@@ -5,6 +5,7 @@ if (NOT HOST_BINARY_DIR)
 
     set(sourcefiles
             settingsgen.cpp
+            ../3rdparty/fmt/format.cc
             ../core/alloc_func.cpp
             ../misc/getoptdata.cpp
             ../error.cpp

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -298,9 +298,6 @@ char (&ArraySizeHelper(T (&array)[N]))[N];
 #	define GNU_TARGET(x)
 #endif /* __GNUC__ || __clang__ */
 
-/* For the FMT library we only want to use the headers, not link to some library. */
-#define FMT_HEADER_ONLY
-
 [[noreturn]] void NOT_REACHED(const std::source_location location = std::source_location::current());
 [[noreturn]] void AssertFailedError(const char *expression, const std::source_location location = std::source_location::current());
 

--- a/src/strgen/CMakeLists.txt
+++ b/src/strgen/CMakeLists.txt
@@ -8,6 +8,7 @@ if (NOT HOST_BINARY_DIR)
     set(sourcefiles
             strgen.cpp
             strgen_base.cpp
+            ../3rdparty/fmt/format.cc
             ../core/alloc_func.cpp
             ../misc/getoptdata.cpp
             ../error.cpp


### PR DESCRIPTION
## Motivation / Problem

Compiling the fmt internals in every translation unit slows the compile down noticeably, and isn't really necessary.

## Description

Compile fmt internals in a separate translation unit, instead of defining FMT_HEADER_ONLY to include fmt internals in the headers included by all fmt-using translation units.

With this applied compile times for a complete rebuild on my machine reduced from about 13 minutes to about 8 minutes
(RelWithDebInfo, Linux, GCC 12, make -j6).

Win32:
win32.cpp and network_content.cpp (when using zlib) implicitly depended on io.h being included via the fmt implementation, so also add the missing includes for that.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
