### PR TITLE
Codefix: [CMake] Debug libs of Ogg, Opus and OpusFile were used for release with multi-config generators

### DIFF
--- a/cmake/FindLZO.cmake
+++ b/cmake/FindLZO.cmake
@@ -43,29 +43,8 @@ find_library(LZO_LIBRARY
     PATHS ${PC_LZO_LIBRARY_DIRS}
 )
 
-# With vcpkg, the library path should contain both 'debug' and 'optimized'
-# entries (see target_link_libraries() documentation for more information)
-#
-# NOTE: we only patch up when using vcpkg; the same issue might happen
-# when not using vcpkg, but this is non-trivial to fix, as we have no idea
-# what the paths are. With vcpkg we do. And we only official support vcpkg
-# with Windows.
-#
-# NOTE: this is based on the assumption that the debug file has the same
-# name as the optimized file. This is not always the case, but so far
-# experiences has shown that in those case vcpkg CMake files do the right
-# thing.
-if(VCPKG_TOOLCHAIN AND LZO_LIBRARY AND LZO_LIBRARY MATCHES "${VCPKG_INSTALLED_DIR}")
-    if(LZO_LIBRARY MATCHES "/debug/")
-        set(LZO_LIBRARY_DEBUG ${LZO_LIBRARY})
-        string(REPLACE "/debug/lib/" "/lib/" LZO_LIBRARY_RELEASE ${LZO_LIBRARY})
-    else()
-        set(LZO_LIBRARY_RELEASE ${LZO_LIBRARY})
-        string(REPLACE "/lib/" "/debug/lib/" LZO_LIBRARY_DEBUG ${LZO_LIBRARY})
-    endif()
-    include(SelectLibraryConfigurations)
-    select_library_configurations(LZO)
-endif()
+include(FixVcpkgLibrary)
+FixVcpkgLibrary(LZO)
 
 set(LZO_VERSION ${PC_LZO_VERSION})
 

--- a/cmake/FindOgg.cmake
+++ b/cmake/FindOgg.cmake
@@ -4,6 +4,9 @@ find_library(Ogg_LIBRARY
     NAMES ogg
 )
 
+include(FixVcpkgLibrary)
+FixVcpkgLibrary(Ogg)
+
 set(Ogg_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of ogg")
 
 set(Ogg_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of ogg")
@@ -33,5 +36,6 @@ if (Ogg_FOUND)
             INTERFACE_LINK_LIBRARIES "${Ogg_LINK_LIBRARIES}"
             INTERFACE_LINK_FLAGS "${Ogg_LINK_FLAGS}"
         )
+        FixVcpkgTarget(Ogg Ogg::ogg)
     endif()
 endif()

--- a/cmake/FindOpus.cmake
+++ b/cmake/FindOpus.cmake
@@ -4,6 +4,9 @@ find_library(Opus_LIBRARY
     NAMES opus
 )
 
+include(FixVcpkgLibrary)
+FixVcpkgLibrary(Opus)
+
 set(Opus_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of opus")
 
 set(Opus_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of opus")
@@ -33,5 +36,6 @@ if (Opus_FOUND)
             INTERFACE_LINK_LIBRARIES "${Opus_LINK_LIBRARIES}"
             INTERFACE_LINK_FLAGS "${Opus_LINK_FLAGS}"
         )
+        FixVcpkgTarget(Opus Opus::opus)
     endif()
 endif()

--- a/cmake/FindOpusFile.cmake
+++ b/cmake/FindOpusFile.cmake
@@ -4,6 +4,9 @@ find_library(OpusFile_LIBRARY
     NAMES opusfile
 )
 
+include(FixVcpkgLibrary)
+FixVcpkgLibrary(OpusFile)
+
 set(OpusFile_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of opusfile")
 
 set(OpusFile_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of opusfile")
@@ -36,5 +39,6 @@ if (OpusFile_FOUND)
             INTERFACE_LINK_LIBRARIES "Ogg::ogg;Opus::opus;${OpusFile_LINK_LIBRARIES}"
             INTERFACE_LINK_FLAGS "${OpusFile_LINK_FLAGS}"
         )
+        FixVcpkgTarget(OpusFile OpusFile::opusfile)
     endif()
 endif()

--- a/cmake/FixVcpkgLibrary.cmake
+++ b/cmake/FixVcpkgLibrary.cmake
@@ -1,0 +1,40 @@
+macro(FixVcpkgLibrary NAME)
+    # With vcpkg, the library path should contain both 'debug' and 'optimized'
+    # entries (see target_link_libraries() documentation for more information)
+    #
+    # NOTE: we only patch up when using vcpkg; the same issue might happen
+    # when not using vcpkg, but this is non-trivial to fix, as we have no idea
+    # what the paths are. With vcpkg we do. And we only official support vcpkg
+    # with Windows.
+    #
+    # NOTE: this is based on the assumption that the debug file has the same
+    # name as the optimized file. This is not always the case, but so far
+    # experiences has shown that in those case vcpkg CMake files do the right
+    # thing.
+    if(VCPKG_TOOLCHAIN AND ${NAME}_LIBRARY AND ${NAME}_LIBRARY MATCHES "${VCPKG_INSTALLED_DIR}")
+        if(${NAME}_LIBRARY MATCHES "/debug/")
+            set(${NAME}_LIBRARY_DEBUG ${${NAME}_LIBRARY})
+            string(REPLACE "/debug/lib/" "/lib/" ${NAME}_LIBRARY_RELEASE ${${NAME}_LIBRARY})
+        else()
+            set(${NAME}_LIBRARY_RELEASE ${${NAME}_LIBRARY})
+            string(REPLACE "/lib/" "/debug/lib/" ${NAME}_LIBRARY_DEBUG ${${NAME}_LIBRARY})
+        endif()
+        include(SelectLibraryConfigurations)
+        select_library_configurations(${NAME})
+    endif()
+endmacro()
+
+function(FixVcpkgTarget NAME TARGET)
+    if(EXISTS "${${NAME}_LIBRARY_RELEASE}")
+        set_property(TARGET ${TARGET} APPEND PROPERTY
+        IMPORTED_CONFIGURATIONS RELEASE)
+        set_target_properties(${TARGET} PROPERTIES
+        IMPORTED_LOCATION_RELEASE "${${NAME}_LIBRARY_RELEASE}")
+    endif()
+    if(EXISTS "${${NAME}_LIBRARY_DEBUG}")
+        set_property(TARGET ${TARGET} APPEND PROPERTY
+        IMPORTED_CONFIGURATIONS DEBUG)
+        set_target_properties(${TARGET} PROPERTIES
+        IMPORTED_LOCATION_DEBUG "${${NAME}_LIBRARY_DEBUG}")
+    endif()
+endfunction()


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
`Ogg`, `Opus` and `OpusFile` don't use `debug` and `optimized` entries in `<name>_LIBRARY` so the one found during `Debug` configuration is reused for `Release` configuration.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Properly set `debug` and `optimized` entries, using the code from `FindLZO.cmake` as it was working fine.
Targets also need to support the different configs, so it's now handled, with inspiration from `FindPNG.cmake` (provided by cmake).
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
