### PR TITLE
Fix 1d04d402: Inverted visibility state in SettingsPage::UpdateFilterState

### DIFF
--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1866,7 +1866,7 @@ bool SettingsPage::UpdateFilterState(SettingFilter &filter, bool force_visible)
 	}
 
 	bool visible = SettingsContainer::UpdateFilterState(filter, force_visible);
-	this->flags.Set(SettingEntryFlag::Filtered, visible);
+	this->flags.Set(SettingEntryFlag::Filtered, !visible);
 	return visible;
 }
 


### PR DESCRIPTION
## Motivation / Problem

1d04d402 inverts the visibility state resulting from applying the text filter in SettingsPage::UpdateFilterState.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
