### PR TITLE
Fix #13459, #13546: Crash when changing NewGRFs in game with picker window open.

### DIFF
--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -118,7 +118,6 @@ public:
 	{
 		ResetObjectToPlace();
 		this->ConstructWindow();
-		this->InvalidateData();
 	}
 
 	void SetStringParameters(WidgetID widget) const override
@@ -288,7 +287,8 @@ public:
 
 		if (!gui_scope) return;
 
-		if ((data & PickerWindow::PFI_POSITION) != 0) {
+		PickerInvalidations pi(data);
+		if (pi.Test(PickerInvalidation::Position)) {
 			const auto objclass = ObjectClass::Get(_object_gui.sel_class);
 			const auto spec = objclass->GetSpec(_object_gui.sel_type);
 			_object_gui.sel_view = std::min<int>(_object_gui.sel_view, spec->views - 1);
@@ -302,7 +302,7 @@ public:
 			case WID_BO_OBJECT_SPRITE:
 				if (_object_gui.sel_type != std::numeric_limits<uint16_t>::max()) {
 					_object_gui.sel_view = this->GetWidget<NWidgetBase>(widget)->GetParentWidget<NWidgetMatrix>()->GetCurrentElement();
-					this->InvalidateData(PickerWindow::PFI_POSITION);
+					this->InvalidateData(PickerInvalidation::Position);
 					if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
 				}
 				break;

--- a/src/picker_func.h
+++ b/src/picker_func.h
@@ -10,7 +10,10 @@
 #ifndef PICKER_FUNC_H
 #define PICKER_FUNC_H
 
+#include "ini_type.h"
+
 void PickerLoadConfig(const IniFile &ini);
 void PickerSaveConfig(IniFile &ini);
+void InvalidateAllPickerWindows();
 
 #endif /* PICKER_FUNC_H */

--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -678,3 +678,13 @@ std::unique_ptr<NWidgetBase> MakePickerTypeWidgets()
 
 	return MakeNWidgets(picker_type_widgets, nullptr);
 }
+
+void InvalidateAllPickerWindows()
+{
+	InvalidateWindowClassesData(WC_BUS_STATION, PickerWindow::PICKER_INVALIDATION_ALL);
+	InvalidateWindowClassesData(WC_TRUCK_STATION, PickerWindow::PICKER_INVALIDATION_ALL);
+	InvalidateWindowClassesData(WC_SELECT_STATION, PickerWindow::PICKER_INVALIDATION_ALL);
+	InvalidateWindowClassesData(WC_BUILD_WAYPOINT, PickerWindow::PICKER_INVALIDATION_ALL);
+	InvalidateWindowClassesData(WC_BUILD_OBJECT, PickerWindow::PICKER_INVALIDATION_ALL);
+	InvalidateWindowClassesData(WC_BUILD_HOUSE, PickerWindow::PICKER_INVALIDATION_ALL);
+}

--- a/src/picker_gui.h
+++ b/src/picker_gui.h
@@ -153,12 +153,15 @@ public:
 		PFM_SAVED = 2, ///< Show saved types.
 	};
 
-	enum PickerFilterInvalidation : uint8_t {
-		PFI_CLASS = 1U << 0, ///< Refresh the class list.
-		PFI_TYPE = 1U << 1, ///< Refresh the type list.
-		PFI_POSITION = 1U << 2, ///< Update scroll positions.
-		PFI_VALIDATE = 1U << 3, ///< Validate selected item.
+	enum class PickerInvalidation : uint8_t {
+		Class, ///< Refresh the class list.
+		Type, ///< Refresh the type list.
+		Position, ///< Update scroll positions.
+		Validate, ///< Validate selected item.
 	};
+	using PickerInvalidations = EnumBitSet<PickerInvalidation, uint8_t>;
+
+	static constexpr PickerInvalidations PICKER_INVALIDATION_ALL{PickerInvalidation::Class, PickerInvalidation::Type, PickerInvalidation::Position, PickerInvalidation::Validate};
 
 	static const int PREVIEW_WIDTH = 64; ///< Width of each preview button.
 	static const int PREVIEW_HEIGHT = 48; ///< Height of each preview button.
@@ -184,6 +187,8 @@ public:
 	enum PickerClassWindowHotkeys : int32_t {
 		PCWHK_FOCUS_FILTER_BOX, ///< Focus the edit box for editing the filter string
 	};
+
+	void InvalidateData(PickerInvalidations data) { this->Window::InvalidateData(data.base()); }
 
 protected:
 	void ConstructWindow();

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1081,7 +1081,6 @@ public:
 	{
 		this->coverage_height = 2 * GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.vsep_normal;
 		this->ConstructWindow();
-		this->InvalidateData();
 	}
 
 	void OnInit() override
@@ -1854,7 +1853,6 @@ struct BuildRailWaypointWindow : public PickerWindow {
 	BuildRailWaypointWindow(WindowDesc &desc, Window *parent) : PickerWindow(desc, parent, TRANSPORT_RAIL, WaypointPickerCallbacks::instance)
 	{
 		this->ConstructWindow();
-		this->InvalidateData();
 	}
 
 	static inline HotkeyList hotkeys{"buildrailwaypoint", {

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1677,7 +1677,6 @@ struct BuildRoadWaypointWindow : public PickerWindow {
 	BuildRoadWaypointWindow(WindowDesc &desc, Window *parent) : PickerWindow(desc, parent, TRANSPORT_ROAD, RoadWaypointPickerCallbacks::instance)
 	{
 		this->ConstructWindow();
-		this->InvalidateData();
 	}
 
 	static inline HotkeyList hotkeys{"buildroadwaypoint", {

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -63,6 +63,7 @@
 #include "../timer/timer_game_calendar.h"
 #include "../timer/timer_game_economy.h"
 #include "../timer/timer_game_tick.h"
+#include "../picker_func.h"
 
 #include "saveload_internal.h"
 
@@ -3418,6 +3419,7 @@ void ReloadNewGRFData()
 	/* Update company infrastructure counts. */
 	InvalidateWindowClassesData(WC_COMPANY_INFRASTRUCTURE);
 	InvalidateWindowClassesData(WC_BUILD_TOOLBAR);
+	InvalidateAllPickerWindows();
 	/* redraw the whole screen */
 	MarkWholeScreenDirty();
 	CheckTrainsLengths();

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1634,7 +1634,6 @@ struct BuildHouseWindow : public PickerWindow {
 	{
 		HousePickerCallbacks::instance.SetClimateMask();
 		this->ConstructWindow();
-		this->InvalidateData();
 	}
 
 	void UpdateSelectSize(const HouseSpec *spec)
@@ -1759,7 +1758,8 @@ struct BuildHouseWindow : public PickerWindow {
 
 		const HouseSpec *spec = HouseSpec::Get(HousePickerCallbacks::sel_type);
 
-		if ((data & PickerWindow::PFI_POSITION) != 0) {
+		PickerInvalidations pi(data);
+		if (pi.Test(PickerInvalidation::Position)) {
 			UpdateSelectSize(spec);
 			this->house_info = GetHouseInformation(spec);
 		}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As per #13459 and #13546, changing NewGRFs with a picker window open can crash the game, as the state of the picker window becomes out of date.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Force invalidation of picker window state when NewGRFs are changed.

As the flags to specify which state to invalidate is a bitset, this has also been converted to an EnumBitSet first.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
