### PR TITLE
Fix #12925: Prevent cost estimates for settings changes

### DIFF
--- a/src/settings_cmd.h
+++ b/src/settings_cmd.h
@@ -15,7 +15,7 @@
 CommandCost CmdChangeSetting(DoCommandFlag flags, const std::string &name, int32_t value);
 CommandCost CmdChangeCompanySetting(DoCommandFlag flags, const std::string &name, int32_t value);
 
-DEF_CMD_TRAIT(CMD_CHANGE_SETTING,         CmdChangeSetting,        CMD_SERVER, CMDT_SERVER_SETTING)
-DEF_CMD_TRAIT(CMD_CHANGE_COMPANY_SETTING, CmdChangeCompanySetting, 0,          CMDT_COMPANY_SETTING)
+DEF_CMD_TRAIT(CMD_CHANGE_SETTING,         CmdChangeSetting,        CMD_SERVER | CMD_NO_EST, CMDT_SERVER_SETTING)
+DEF_CMD_TRAIT(CMD_CHANGE_COMPANY_SETTING, CmdChangeCompanySetting, CMD_NO_EST,              CMDT_COMPANY_SETTING)
 
 #endif /* SETTINGS_CMD_H */


### PR DESCRIPTION
## Motivation / Problem
Fixes #12925.

## Description
Don't allow cost estimates for settings changes, which don't make any sense.

## Limitations
Only tested on WSL, which doesn't provide a very reliable repro even with master. I can reproduce reliably on the Emscripten version, so maybe this should be tested with "preview" before merging.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
