### PR TITLE
Fix: NewGRF vehicles display loading sprites when not actually loading or unloading

### DIFF
--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -987,7 +987,9 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 		return nullptr;
 	}
 
-	bool in_motion = !v->First()->current_order.IsType(OT_LOADING);
+	const Order &order = v->First()->current_order;
+	bool not_loading = (order.GetUnloadType() & OUFB_NO_UNLOAD) && (order.GetLoadType() & OLFB_NO_LOAD);
+	bool in_motion = !order.IsType(OT_LOADING) || not_loading;
 
 	uint totalsets = in_motion ? (uint)group->loaded.size() : (uint)group->loading.size();
 

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -211,6 +211,12 @@ uint16_t Order::MapOldOrder() const
 			break;
 		case OT_LOADING:
 			if (this->GetLoadType() & OLFB_FULL_LOAD) SetBit(order, 6);
+			/* If both "no load" and "no unload" are set, return nothing order instead */
+			if ((this->GetLoadType() & OLFB_NO_LOAD) && (this->GetUnloadType() & OUFB_NO_UNLOAD)) {
+				order = OT_NOTHING;
+			}
+			break;
+		default:
 			break;
 	}
 	return order;

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -197,7 +197,7 @@ bool Order::Equals(const Order &other) const
 uint16_t Order::MapOldOrder() const
 {
 	uint16_t order = this->GetType();
-	switch (this->type) {
+	switch (this->GetType()) {
 		case OT_GOTO_STATION:
 			if (this->GetUnloadType() & OUFB_UNLOAD) SetBit(order, 5);
 			if (this->GetLoadType() & OLFB_FULL_LOAD) SetBit(order, 6);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Some NewGRF vehicles support displaying separate sprites for loading and moving states. The documented way to implement this is via sprite groups as defined in NML, but there is also another (somewhat undocumented) way (e.g. Iron Horse uses this) via vehicle variable 0x8A, which contains the current vehicle order type and flags.

The issue is, that both of these methods cause vehicles to display their loading sprites even when the order they are serving is set to both *no loading* and *no unloading* as there is currently nothing in place to make sure the vehicle is actually loading or unloading.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This PR adds checks for both methods, ensuring the loading sprites are only displayed when the vehicle is actually loading or unloading.

Additionally, it also fixes an oversight in a `Order::MapOldOrder` switch statement that had been using a different variant of the order type instead of the actual type, preventing it from functioning as intended.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
