### PR TITLE
Codechange: use span size over terminator object

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -2010,12 +2010,12 @@ static ChangeInfoResult StationChangeInfo(uint first, uint last, int prop, ByteR
 
 					std::vector<DrawTileSeqStruct> tmp_layout;
 					for (;;) {
+						uint8_t delta_x = buf.ReadByte();
+						if (delta_x == 0x80) break;
+
 						/* no relative bounding box support */
 						DrawTileSeqStruct &dtss = tmp_layout.emplace_back();
-						MemSetT(&dtss, 0);
-
-						dtss.delta_x = buf.ReadByte();
-						if (dtss.IsTerminator()) break;
+						dtss.delta_x = delta_x;
 						dtss.delta_y = buf.ReadByte();
 						dtss.delta_z = buf.ReadByte();
 						dtss.size_x = buf.ReadByte();

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -472,13 +472,12 @@ static void DrawTile_Object(TileInfo *ti)
 		}
 
 		if (!IsInvisibilitySet(TO_STRUCTURES)) {
-			const DrawTileSeqStruct *dtss;
-			foreach_draw_tile_seq(dtss, dts->GetSequence()) {
+			for (const DrawTileSeqStruct &dtss : dts->GetSequence()) {
 				AddSortableSpriteToDraw(
-					dtss->image.sprite, palette,
-					ti->x + dtss->delta_x, ti->y + dtss->delta_y,
-					dtss->size_x, dtss->size_y,
-					dtss->size_z, ti->z + dtss->delta_z,
+					dtss.image.sprite, palette,
+					ti->x + dtss.delta_x, ti->y + dtss.delta_y,
+					dtss.size_x, dtss.size_y,
+					dtss.size_z, ti->z + dtss.delta_z,
 					IsTransparencySet(TO_STRUCTURES)
 				);
 			}

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -30,21 +30,20 @@
 void DrawCommonTileSeq(const TileInfo *ti, const DrawTileSprites *dts, TransparencyOption to, int32_t orig_offset, uint32_t newgrf_offset, PaletteID default_palette, bool child_offset_is_unsigned)
 {
 	bool parent_sprite_encountered = false;
-	const DrawTileSeqStruct *dtss;
 	bool skip_childs = false;
-	foreach_draw_tile_seq(dtss, dts->GetSequence()) {
-		SpriteID image = dtss->image.sprite;
-		PaletteID pal = dtss->image.pal;
+	for (const DrawTileSeqStruct &dtss : dts->GetSequence()) {
+		SpriteID image = dtss.image.sprite;
+		PaletteID pal = dtss.image.pal;
 
 		if (skip_childs) {
-			if (!dtss->IsParentSprite()) continue;
+			if (!dtss.IsParentSprite()) continue;
 			skip_childs = false;
 		}
 
 		/* TTD sprite 0 means no sprite */
 		if ((GB(image, 0, SPRITE_WIDTH) == 0 && !HasBit(image, SPRITE_MODIFIER_CUSTOM_SPRITE)) ||
 				(IsInvisibilitySet(to) && !HasBit(image, SPRITE_MODIFIER_OPAQUE))) {
-			skip_childs = dtss->IsParentSprite();
+			skip_childs = dtss.IsParentSprite();
 			continue;
 		}
 
@@ -53,18 +52,18 @@ void DrawCommonTileSeq(const TileInfo *ti, const DrawTileSprites *dts, Transpare
 
 		pal = SpriteLayoutPaletteTransform(image, pal, default_palette);
 
-		if (dtss->IsParentSprite()) {
+		if (dtss.IsParentSprite()) {
 			parent_sprite_encountered = true;
 			AddSortableSpriteToDraw(
 				image, pal,
-				ti->x + dtss->delta_x, ti->y + dtss->delta_y,
-				dtss->size_x, dtss->size_y,
-				dtss->size_z, ti->z + dtss->delta_z,
+				ti->x + dtss.delta_x, ti->y + dtss.delta_y,
+				dtss.size_x, dtss.size_y,
+				dtss.size_z, ti->z + dtss.delta_z,
 				!HasBit(image, SPRITE_MODIFIER_OPAQUE) && IsTransparencySet(to)
 			);
 		} else {
-			int offs_x = child_offset_is_unsigned ? (uint8_t)dtss->delta_x : dtss->delta_x;
-			int offs_y = child_offset_is_unsigned ? (uint8_t)dtss->delta_y : dtss->delta_y;
+			int offs_x = child_offset_is_unsigned ? static_cast<uint8_t>(dtss.delta_x) : dtss.delta_x;
+			int offs_y = child_offset_is_unsigned ? static_cast<uint8_t>(dtss.delta_y) : dtss.delta_y;
 			bool transparent = !HasBit(image, SPRITE_MODIFIER_OPAQUE) && IsTransparencySet(to);
 			if (parent_sprite_encountered) {
 				AddChildSpriteScreen(image, pal, offs_x, offs_y, transparent);
@@ -91,22 +90,21 @@ void DrawCommonTileSeq(const TileInfo *ti, const DrawTileSprites *dts, Transpare
  */
 void DrawCommonTileSeqInGUI(int x, int y, const DrawTileSprites *dts, int32_t orig_offset, uint32_t newgrf_offset, PaletteID default_palette, bool child_offset_is_unsigned)
 {
-	const DrawTileSeqStruct *dtss;
 	Point child_offset = {0, 0};
 
 	bool skip_childs = false;
-	foreach_draw_tile_seq(dtss, dts->GetSequence()) {
-		SpriteID image = dtss->image.sprite;
-		PaletteID pal = dtss->image.pal;
+	for (const DrawTileSeqStruct &dtss : dts->GetSequence()) {
+		SpriteID image = dtss.image.sprite;
+		PaletteID pal = dtss.image.pal;
 
 		if (skip_childs) {
-			if (!dtss->IsParentSprite()) continue;
+			if (!dtss.IsParentSprite()) continue;
 			skip_childs = false;
 		}
 
 		/* TTD sprite 0 means no sprite */
 		if (GB(image, 0, SPRITE_WIDTH) == 0 && !HasBit(image, SPRITE_MODIFIER_CUSTOM_SPRITE)) {
-			skip_childs = dtss->IsParentSprite();
+			skip_childs = dtss.IsParentSprite();
 			continue;
 		}
 
@@ -115,16 +113,16 @@ void DrawCommonTileSeqInGUI(int x, int y, const DrawTileSprites *dts, int32_t or
 
 		pal = SpriteLayoutPaletteTransform(image, pal, default_palette);
 
-		if (dtss->IsParentSprite()) {
-			Point pt = RemapCoords(dtss->delta_x, dtss->delta_y, dtss->delta_z);
+		if (dtss.IsParentSprite()) {
+			Point pt = RemapCoords(dtss.delta_x, dtss.delta_y, dtss.delta_z);
 			DrawSprite(image, pal, x + UnScaleGUI(pt.x), y + UnScaleGUI(pt.y));
 
 			const Sprite *spr = GetSprite(image & SPRITE_MASK, SpriteType::Normal);
 			child_offset.x = UnScaleGUI(pt.x + spr->x_offs);
 			child_offset.y = UnScaleGUI(pt.y + spr->y_offs);
 		} else {
-			int offs_x = child_offset_is_unsigned ? (uint8_t)dtss->delta_x : dtss->delta_x;
-			int offs_y = child_offset_is_unsigned ? (uint8_t)dtss->delta_y : dtss->delta_y;
+			int offs_x = child_offset_is_unsigned ? static_cast<uint8_t>(dtss.delta_x) : dtss.delta_x;
+			int offs_y = child_offset_is_unsigned ? static_cast<uint8_t>(dtss.delta_y) : dtss.delta_y;
 			DrawSprite(image, pal, x + child_offset.x + ScaleSpriteTrad(offs_x), y + child_offset.y + ScaleSpriteTrad(offs_y));
 		}
 	}

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -23,25 +23,13 @@
 
 /** A tile child sprite and palette to draw for stations etc, with 3D bounding box */
 struct DrawTileSeqStruct {
-	int8_t delta_x; ///< \c 0x80 is sequence terminator
-	int8_t delta_y;
-	int8_t delta_z; ///< \c 0x80 identifies child sprites
-	uint8_t size_x;
-	uint8_t size_y;
-	uint8_t size_z;
-	PalSpriteID image;
-
-	/** Make this struct a sequence terminator. */
-	void MakeTerminator()
-	{
-		this->delta_x = (int8_t)0x80;
-	}
-
-	/** Check whether this is a sequence terminator. */
-	bool IsTerminator() const
-	{
-		return (uint8_t)this->delta_x == 0x80;
-	}
+	int8_t delta_x = 0;
+	int8_t delta_y = 0;
+	int8_t delta_z = 0; ///< \c 0x80 identifies child sprites
+	uint8_t size_x = 0;
+	uint8_t size_y = 0;
+	uint8_t size_z = 0;
+	PalSpriteID image{};
 
 	/** Check whether this is a parent sprite with a boundingbox. */
 	bool IsParentSprite() const
@@ -95,9 +83,6 @@ struct DrawBuildingsTileStruct {
 	uint8_t dz;
 	uint8_t draw_proc;  // this allows to specify a special drawing procedure.
 };
-
-/** Iterate through all DrawTileSeqStructs in DrawTileSprites. */
-#define foreach_draw_tile_seq(idx, list) for (idx = list.data(); !idx->IsTerminator(); idx++)
 
 void DrawCommonTileSeq(const struct TileInfo *ti, const DrawTileSprites *dts, TransparencyOption to, int32_t orig_offset, uint32_t newgrf_offset, PaletteID default_palette, bool child_offset_is_unsigned);
 void DrawCommonTileSeqInGUI(int x, int y, const DrawTileSprites *dts, int32_t orig_offset, uint32_t newgrf_offset, PaletteID default_palette, bool child_offset_is_unsigned);

--- a/src/table/object_land.h
+++ b/src/table/object_land.h
@@ -8,30 +8,21 @@
 /** @file object_land.h Sprites to use and how to display them for object tiles. */
 
 #define TILE_SEQ_LINE(sz, img) { 0, 0, 0, 16, 16, sz, {img, PAL_NONE} },
-#define TILE_SEQ_END() { (int8_t)0x80, 0, 0, 0, 0, 0, {0, 0} }
-
-static const DrawTileSeqStruct _object_nothing[] = {
-	TILE_SEQ_END()
-};
 
 static const DrawTileSeqStruct _object_transmitter_seq[] = {
 	{   7,  7,  0,  2,  2, 70, {SPR_TRANSMITTER, PAL_NONE}},
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _object_lighthouse_seq[] = {
 	{   4,  4,  0,  7,  7, 61, {SPR_LIGHTHOUSE, PAL_NONE}},
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _object_statue_seq[] = {
 	{   0,  0,  0, 16, 16, 25, {SPR_STATUE_COMPANY | (1 << PALETTE_MODIFIER_COLOUR), PAL_NONE}},
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _object_owned_land_seq[] = {
 	{   8,  8,  0,  1,  1,  6, {SPR_BOUGHT_LAND    | (1 << PALETTE_MODIFIER_COLOUR), PAL_NONE}},
-	TILE_SEQ_END()
 };
 
 extern const DrawTileSpriteSpan _objects[] = {
@@ -44,82 +35,74 @@ extern const DrawTileSpriteSpan _objects[] = {
 
 static const DrawTileSeqStruct _object_hq_medium_north[] = {
 	TILE_SEQ_LINE(20, SPR_MEDIUMHQ_NORTH_WALL | (1 << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _object_hq_medium_east[] = {
 	TILE_SEQ_LINE(20, SPR_MEDIUMHQ_EAST_WALL  | (1 << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _object_hq_medium_west[] = {
 	TILE_SEQ_LINE(20, SPR_MEDIUMHQ_WEST_WALL  | (1 << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _object_hq_large_north[] = {
 	TILE_SEQ_LINE(50, SPR_LARGEHQ_NORTH_BUILD | (1 << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _object_hq_large_east[] = {
 	TILE_SEQ_LINE(50, SPR_LARGEHQ_EAST_BUILD  | (1 << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _object_hq_large_west[] = {
 	TILE_SEQ_LINE(50, SPR_LARGEHQ_WEST_BUILD  | (1 << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _object_hq_huge_north[] = {
 	TILE_SEQ_LINE(60, SPR_HUGEHQ_NORTH_BUILD  | (1 << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _object_hq_huge_east[] = {
 	TILE_SEQ_LINE(60, SPR_HUGEHQ_EAST_BUILD   | (1 << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _object_hq_huge_west[] = {
 	TILE_SEQ_LINE(60, SPR_HUGEHQ_WEST_BUILD   | (1 << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 #undef TILE_SEQ_LINE
-#undef TILE_SEQ_END
 
 #define TILE_SPRITE_LINE(img, dtss) { {img | (1 << PALETTE_MODIFIER_COLOUR), PAL_NONE}, dtss },
+#define TILE_SPRITE_LINE_NOTHING(img) { {img | (1 << PALETTE_MODIFIER_COLOUR), PAL_NONE} },
 
 static const DrawTileSpriteSpan _object_hq[] = {
-	TILE_SPRITE_LINE(SPR_TINYHQ_NORTH,         _object_nothing)
-	TILE_SPRITE_LINE(SPR_TINYHQ_WEST,          _object_nothing)
-	TILE_SPRITE_LINE(SPR_TINYHQ_EAST,          _object_nothing)
-	TILE_SPRITE_LINE(SPR_TINYHQ_SOUTH,         _object_nothing)
+	TILE_SPRITE_LINE_NOTHING(SPR_TINYHQ_NORTH)
+	TILE_SPRITE_LINE_NOTHING(SPR_TINYHQ_WEST)
+	TILE_SPRITE_LINE_NOTHING(SPR_TINYHQ_EAST)
+	TILE_SPRITE_LINE_NOTHING(SPR_TINYHQ_SOUTH)
 
-	TILE_SPRITE_LINE(SPR_SMALLHQ_NORTH,        _object_nothing)
-	TILE_SPRITE_LINE(SPR_SMALLHQ_WEST,         _object_nothing)
-	TILE_SPRITE_LINE(SPR_SMALLHQ_EAST,         _object_nothing)
-	TILE_SPRITE_LINE(SPR_SMALLHQ_SOUTH,        _object_nothing)
+	TILE_SPRITE_LINE_NOTHING(SPR_SMALLHQ_NORTH)
+	TILE_SPRITE_LINE_NOTHING(SPR_SMALLHQ_WEST)
+	TILE_SPRITE_LINE_NOTHING(SPR_SMALLHQ_EAST)
+	TILE_SPRITE_LINE_NOTHING(SPR_SMALLHQ_SOUTH)
 
 	TILE_SPRITE_LINE(SPR_MEDIUMHQ_NORTH,       _object_hq_medium_north)
 	TILE_SPRITE_LINE(SPR_MEDIUMHQ_WEST,        _object_hq_medium_west)
 	TILE_SPRITE_LINE(SPR_MEDIUMHQ_EAST,        _object_hq_medium_east)
-	TILE_SPRITE_LINE(SPR_MEDIUMHQ_SOUTH,       _object_nothing)
+	TILE_SPRITE_LINE_NOTHING(SPR_MEDIUMHQ_SOUTH)
 
 	TILE_SPRITE_LINE(SPR_LARGEHQ_NORTH_GROUND, _object_hq_large_north)
 	TILE_SPRITE_LINE(SPR_LARGEHQ_WEST_GROUND,  _object_hq_large_west)
 	TILE_SPRITE_LINE(SPR_LARGEHQ_EAST_GROUND,  _object_hq_large_east)
-	TILE_SPRITE_LINE(SPR_LARGEHQ_SOUTH,        _object_nothing)
+	TILE_SPRITE_LINE_NOTHING(SPR_LARGEHQ_SOUTH)
 
 	TILE_SPRITE_LINE(SPR_HUGEHQ_NORTH_GROUND,  _object_hq_huge_north)
 	TILE_SPRITE_LINE(SPR_HUGEHQ_WEST_GROUND,   _object_hq_huge_west)
 	TILE_SPRITE_LINE(SPR_HUGEHQ_EAST_GROUND,   _object_hq_huge_east)
-	TILE_SPRITE_LINE(SPR_HUGEHQ_SOUTH,         _object_nothing)
+	TILE_SPRITE_LINE_NOTHING(SPR_HUGEHQ_SOUTH)
 };
 
 #undef TILE_SPRITE_LINE
+#undef TILE_SPRITE_LINE_NOTHING
 
 #define M(name, size, build_cost_multiplier, clear_cost_multiplier, height, climate, gen_amount, flags) {{INVALID_OBJECT_CLASS, 0}, GRFFilePropsBase<2>(), {0, 0, 0, 0}, name, climate, size, build_cost_multiplier, clear_cost_multiplier, TimerGameCalendar::Date{}, CalendarTime::MAX_DATE + 1, flags, ObjectCallbackMasks{}, height, 1, gen_amount}
 

--- a/src/table/road_land.h
+++ b/src/table/road_land.h
@@ -8,28 +8,23 @@
 /** @file road_land.h Sprite constructs for road depots. */
 
 #define TILE_SEQ_LINE(img, pal, dx, dy, sx, sy) { dx, dy, 0, sx, sy, 20, {img, pal} },
-#define TILE_SEQ_END() { (int8_t)0x80, 0, 0, 0, 0, 0, {0, 0} }
 
 static const DrawTileSeqStruct _road_depot_NE[] = {
 	TILE_SEQ_LINE(0x584 | (1 << PALETTE_MODIFIER_COLOUR), PAL_NONE, 0, 15, 16, 1)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _road_depot_SE[] = {
 	TILE_SEQ_LINE(0x580 | (1 << PALETTE_MODIFIER_COLOUR), PAL_NONE, 0, 0, 1, 16)
 	TILE_SEQ_LINE(0x581 | (1 << PALETTE_MODIFIER_COLOUR), PAL_NONE, 15, 0, 1, 16)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _road_depot_SW[] = {
 	TILE_SEQ_LINE(0x582 | (1 << PALETTE_MODIFIER_COLOUR), PAL_NONE, 0, 0, 16, 1)
 	TILE_SEQ_LINE(0x583 | (1 << PALETTE_MODIFIER_COLOUR), PAL_NONE, 0, 15, 16, 1)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _road_depot_NW[] = {
 	TILE_SEQ_LINE(0x585 | (1 << PALETTE_MODIFIER_COLOUR), PAL_NONE, 15, 0, 1, 16)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSpriteSpan _road_depot[] = {
@@ -46,7 +41,6 @@ static const DrawTileSeqStruct _crossing_layout_ALL[] = {
 	TILE_SEQ_LINE(4, PAL_NONE,  0, 13, 3, 3)
 	TILE_SEQ_LINE(6, PAL_NONE, 13,  0, 3, 3)
 	TILE_SEQ_LINE(8, PAL_NONE, 13, 13, 3, 3)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSpriteSpan _crossing_layout = {
@@ -56,7 +50,6 @@ static const DrawTileSpriteSpan _crossing_layout = {
 static const DrawTileSeqStruct _crossing_layout_SW_ALL[] = {
 	TILE_SEQ_LINE(6, PAL_NONE, 13,  0, 3, 3)
 	TILE_SEQ_LINE(8, PAL_NONE, 13, 13, 3, 3)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSpriteSpan _crossing_layout_SW = {
@@ -66,7 +59,6 @@ static const DrawTileSpriteSpan _crossing_layout_SW = {
 static const DrawTileSeqStruct _crossing_layout_NW_ALL[] = {
 	TILE_SEQ_LINE(2, PAL_NONE,  0,  0, 3, 3)
 	TILE_SEQ_LINE(6, PAL_NONE, 13,  0, 3, 3)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSpriteSpan _crossing_layout_NW = {
@@ -76,7 +68,6 @@ static const DrawTileSpriteSpan _crossing_layout_NW = {
 static const DrawTileSeqStruct _crossing_layout_NE_ALL[] = {
 	TILE_SEQ_LINE(2, PAL_NONE,  0,  0, 3, 3)
 	TILE_SEQ_LINE(4, PAL_NONE,  0, 13, 3, 3)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSpriteSpan _crossing_layout_NE = {
@@ -86,7 +77,6 @@ static const DrawTileSpriteSpan _crossing_layout_NE = {
 static const DrawTileSeqStruct _crossing_layout_SE_ALL[] = {
 	TILE_SEQ_LINE(4, PAL_NONE,  0, 13, 3, 3)
 	TILE_SEQ_LINE(8, PAL_NONE, 13, 13, 3, 3)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSpriteSpan _crossing_layout_SE = {
@@ -94,7 +84,6 @@ static const DrawTileSpriteSpan _crossing_layout_SE = {
 };
 
 #undef TILE_SEQ_LINE
-#undef TILE_SEQ_END
 
 
 static const SpriteID _road_tile_sprites_1[16] = {

--- a/src/table/station_land.h
+++ b/src/table/station_land.h
@@ -51,35 +51,24 @@
  */
 #define TILE_SEQ_GROUND(dx, dy, dz, img) TILE_SEQ_CHILD(2 * (dy - dx), dx + dy - dz, img, PAL_NONE)
 
-/** Constructor macro for a terminating DrawTileSeqStruct entry in an array */
-#define TILE_SEQ_END() { (int8_t)0x80, 0, 0, 0, 0, 0, {0, 0} }
-
-static const DrawTileSeqStruct _station_display_nothing[] = {
-	TILE_SEQ_END()
-};
-
 static const DrawTileSeqStruct _station_display_datas_0[] = {
 	TILE_SEQ_LINE( 0,  0,  0, 16,  5,  2, SPR_RAIL_PLATFORM_X_REAR  | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0, 11,  0, 16,  5,  2, SPR_RAIL_PLATFORM_X_FRONT | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_1[] = {
 	TILE_SEQ_LINE( 0,  0,  0,  5, 16,  2, SPR_RAIL_PLATFORM_Y_REAR  | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE(11,  0,  0,  5, 16,  2, SPR_RAIL_PLATFORM_Y_FRONT | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_2[] = {
 	TILE_SEQ_LINE( 0,  0,  0, 16,  5, 15, SPR_RAIL_PLATFORM_BUILDING_X | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0, 11,  0, 16,  5,  2, SPR_RAIL_PLATFORM_X_FRONT    | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_3[] = {
 	TILE_SEQ_LINE( 0,  0,  0,  5, 16, 15, SPR_RAIL_PLATFORM_BUILDING_Y | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE(11,  0,  0,  5, 16,  2, SPR_RAIL_PLATFORM_Y_FRONT    | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_4[] = {
@@ -87,7 +76,6 @@ static const DrawTileSeqStruct _station_display_datas_4[] = {
 	TILE_SEQ_LINE( 0, 11,  0, 16,  5,  2, SPR_RAIL_PLATFORM_X_FRONT        | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0,  0, 16, 16, 16, 10, SPR_RAIL_ROOF_STRUCTURE_X_TILE_A | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_CHILD( 0,  0,                SPR_RAIL_ROOF_GLASS_X_TILE_A     | (1U << PALETTE_MODIFIER_TRANSPARENT), PALETTE_TO_TRANSPARENT)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_5[] = {
@@ -95,7 +83,6 @@ static const DrawTileSeqStruct _station_display_datas_5[] = {
 	TILE_SEQ_LINE(11,  0,  0,  5, 16,  2, SPR_RAIL_PLATFORM_Y_FRONT        | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0,  0, 16, 16, 16, 10, SPR_RAIL_ROOF_STRUCTURE_Y_TILE_A | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_CHILD( 0,  0,                SPR_RAIL_ROOF_GLASS_Y_TILE_A     | (1U << PALETTE_MODIFIER_TRANSPARENT), PALETTE_TO_TRANSPARENT)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_6[] = {
@@ -103,7 +90,6 @@ static const DrawTileSeqStruct _station_display_datas_6[] = {
 	TILE_SEQ_LINE( 0, 11,  0, 16,  5,  2, SPR_RAIL_PLATFORM_PILLARS_X_FRONT | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0,  0, 16, 16, 16, 10, SPR_RAIL_ROOF_STRUCTURE_X_TILE_B  | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_CHILD( 0,  0,                SPR_RAIL_ROOF_GLASS_X_TILE_B      | (1U << PALETTE_MODIFIER_TRANSPARENT), PALETTE_TO_TRANSPARENT)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_7[] = {
@@ -111,296 +97,245 @@ static const DrawTileSeqStruct _station_display_datas_7[] = {
 	TILE_SEQ_LINE(11,  0,  0,  5, 16,  2, SPR_RAIL_PLATFORM_PILLARS_Y_FRONT | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0,  0, 16, 16, 16, 10, SPR_RAIL_ROOF_STRUCTURE_Y_TILE_B  | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_CHILD( 0,  0,                SPR_RAIL_ROOF_GLASS_Y_TILE_B      | (1U << PALETTE_MODIFIER_TRANSPARENT), PALETTE_TO_TRANSPARENT)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_fence_nw[] = {
 	TILE_SEQ_GROUND( 0,  0,  0, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences north
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_fence_ne[] = {
 	TILE_SEQ_GROUND( 0,  0,  0, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_fence_sw[] = {
 	TILE_SEQ_GROUND(15,  0,  0, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR)) // fences west
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_fence_se[] = {
 	TILE_SEQ_GROUND( 0, 15,  0, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_terminal_a[] = {
 	TILE_SEQ_LINE( 2,  0,  0, 11, 16, 40, SPR_AIRPORT_TERMINAL_A | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_tower_fence_sw[] = {
 	TILE_SEQ_LINE( 3,  3,  0, 10, 10, 60, SPR_AIRPORT_TOWER | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_concourse[] = {
 	TILE_SEQ_LINE( 0,  1,  0, 14, 14, 30, SPR_AIRPORT_CONCOURSE | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_terminal_b[] = {
 	TILE_SEQ_LINE( 3,  3,  0, 10, 11, 35, SPR_AIRPORT_TERMINAL_B | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_terminal_c[] = {
 	TILE_SEQ_LINE( 0,  3,  0, 16, 11, 40, SPR_AIRPORT_TERMINAL_C | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_hangar_se[] = {
 	TILE_SEQ_LINE(14,  0,  0,  2, 17, 28, SPR_AIRPORT_HANGAR_FRONT | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0,  0,  0,  2, 17, 28, SPR_AIRPORT_HANGAR_REAR | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_jetway_1[] = {
 	TILE_SEQ_LINE( 7, 11,  0,  3,  3, 14, SPR_AIRPORT_JETWAY_1 | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0,  0,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_jetway_2[] = {
 	TILE_SEQ_LINE( 2,  7,  0,  3,  3, 14, SPR_AIRPORT_JETWAY_2 | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_jetway_3[] = {
 	TILE_SEQ_LINE( 3,  2,  0,  3,  3, 14, SPR_AIRPORT_JETWAY_3 | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_passenger_tunnel[] = {
 	TILE_SEQ_LINE( 0,  8,  0, 14,  3, 14, SPR_AIRPORT_PASSENGER_TUNNEL | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_1_fence_sw[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_1)
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_2_fence_sw[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_2)
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_3_fence_sw[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_3)
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_4_fence_sw[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_4)
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_5_fence_sw[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_5)
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_6_fence_sw[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_6)
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_7_fence_sw[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_7)
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_8_fence_sw[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_8)
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_9_fence_sw[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_9)
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_10_fence_sw[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_A)
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_11_fence_sw[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_B)
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_12_fence_sw[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_C)
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_transmitter_fence_ne[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2, 70, SPR_TRANSMITTER)
 	TILE_SEQ_LINE( 0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_terminal_c_2[] = {
 	TILE_SEQ_LINE( 0,  0,  0, 15, 15, 30, SPR_AIRFIELD_TERM_C_BUILD | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_flag_1_fence_ne[] = {
 	TILE_SEQ_LINE( 0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 4, 11,  0,  1,  1, 20, SPR_AIRFIELD_WIND_1 | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_flag_2_fence_ne[] = {
 	TILE_SEQ_LINE( 0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 4, 11,  0,  1,  1, 20, SPR_AIRFIELD_WIND_2 | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_flag_3_fence_ne[] = {
 	TILE_SEQ_LINE( 0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 4, 11,  0,  1,  1, 20, SPR_AIRFIELD_WIND_3 | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_flag_4_fence_ne[] = {
 	TILE_SEQ_LINE( 0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 4, 11,  0,  1,  1, 20, SPR_AIRFIELD_WIND_4 | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_small_depot_se[] = {
 	TILE_SEQ_LINE(14,  0,  0,  2, 17, 28, SPR_AIRFIELD_HANGAR_FRONT | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0,  0,  0,  2, 17, 28, SPR_AIRFIELD_HANGAR_REAR | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_heliport[] = {
 	TILE_SEQ_LINE( 0,  0,  0, 16, 16, 60, SPR_HELIPORT | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_67[] = {
 	TILE_SEQ_LINE( 0, 15,  0, 13,  1, 10, SPR_TRUCK_STOP_NE_BUILD_A | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE(13,  0,  0,  3, 16, 10, SPR_TRUCK_STOP_NE_BUILD_B | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 2,  0,  0, 11,  1, 10, SPR_TRUCK_STOP_NE_BUILD_C | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_68[] = {
 	TILE_SEQ_LINE(15,  3,  0,  1, 13, 10, SPR_TRUCK_STOP_SE_BUILD_A | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0,  0,  0, 16,  3, 10, SPR_TRUCK_STOP_SE_BUILD_B | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0,  3,  0,  1, 11, 10, SPR_TRUCK_STOP_SE_BUILD_C | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_69[] = {
 	TILE_SEQ_LINE( 3,  0,  0, 13,  1, 10, SPR_TRUCK_STOP_SW_BUILD_A | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0,  0,  0,  3, 16, 10, SPR_TRUCK_STOP_SW_BUILD_B | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 3, 15,  0, 11,  1, 10, SPR_TRUCK_STOP_SW_BUILD_C | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_70[] = {
 	TILE_SEQ_LINE( 0,  0,  0,  1, 13, 10, SPR_TRUCK_STOP_NW_BUILD_A | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0, 13,  0, 16,  3, 10, SPR_TRUCK_STOP_NW_BUILD_B | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE(15,  2,  0,  1, 11, 10, SPR_TRUCK_STOP_NW_BUILD_C | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_71[] = {
 	TILE_SEQ_LINE( 2,  0,  0, 11,  1, 10, SPR_BUS_STOP_NE_BUILD_A | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE(13,  0,  0,  3, 16, 10, SPR_BUS_STOP_NE_BUILD_B | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0, 13,  0, 13,  3, 10, SPR_BUS_STOP_NE_BUILD_C | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_72[] = {
 	TILE_SEQ_LINE( 0,  3,  0,  1, 11, 10, SPR_BUS_STOP_SE_BUILD_A | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0,  0,  0, 16,  3, 10, SPR_BUS_STOP_SE_BUILD_B | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE(13,  3,  0,  3, 13, 10, SPR_BUS_STOP_SE_BUILD_C | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_73[] = {
 	TILE_SEQ_LINE( 3, 15,  0, 11,  1, 10, SPR_BUS_STOP_SW_BUILD_A | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0,  0,  0,  3, 16, 10, SPR_BUS_STOP_SW_BUILD_B | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 3,  0,  0, 13,  3, 10, SPR_BUS_STOP_SW_BUILD_C | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_74[] = {
 	TILE_SEQ_LINE(15,  2,  0,  1, 11, 10, SPR_BUS_STOP_NW_BUILD_A | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0, 13,  0, 16,  3, 10, SPR_BUS_STOP_NW_BUILD_B | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0,  0,  0,  3, 13, 10, SPR_BUS_STOP_NW_BUILD_C | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_76[] = {
 	TILE_SEQ_LINE( 0,  4,  0, 16,  8,  8, SPR_DOCK_SLOPE_NE | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_77[] = {
 	TILE_SEQ_LINE( 4,  0,  0,  8, 16,  8, SPR_DOCK_SLOPE_SE | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_78[] = {
 	TILE_SEQ_LINE( 0,  4,  0, 16,  8,  8, SPR_DOCK_SLOPE_SW | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_79[] = {
 	TILE_SEQ_LINE( 4,  0,  0,  8, 16,  8, SPR_DOCK_SLOPE_NW | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_80[] = {
 	TILE_SEQ_LINE( 0,  4,  0, 16,  8,  8, SPR_DOCK_FLAT_X | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_81[] = {
 	TILE_SEQ_LINE( 4,  0,  0,  8, 16,  8, SPR_DOCK_FLAT_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 /* Buoy, which will _always_ drown under the ship */
 static const DrawTileSeqStruct _station_display_datas_82[] = {
 	TILE_SEQ_LINE( 4,  -1,  0,  0,  0,  0, SPR_IMG_BUOY)
-	TILE_SEQ_END()
 };
 
 /* control tower without fence */
 static const DrawTileSeqStruct _station_display_tower[] = {
 	TILE_SEQ_LINE( 3,  3,  0, 10, 10, 60, SPR_AIRPORT_TOWER | (1U << PALETTE_MODIFIER_COLOUR))  // control tower
-	TILE_SEQ_END()
 };
 
 /* turning radar with fences on north -- needs 12 tiles
@@ -408,73 +343,61 @@ static const DrawTileSeqStruct _station_display_tower[] = {
 static const DrawTileSeqStruct _station_display_radar_1_fence_ne[] = {
 	TILE_SEQ_LINE(7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_1)   // turning radar
 	TILE_SEQ_LINE(0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_2_fence_ne[] = {
 	TILE_SEQ_LINE(7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_2)
 	TILE_SEQ_LINE(0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_3_fence_ne[] = {
 	TILE_SEQ_LINE(7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_3)
 	TILE_SEQ_LINE(0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_4_fence_ne[] = {
 	TILE_SEQ_LINE(7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_4)
 	TILE_SEQ_LINE(0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_5_fence_ne[] = {
 	TILE_SEQ_LINE(7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_5)
 	TILE_SEQ_LINE(0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_6_fence_ne[] = {
 	TILE_SEQ_LINE(7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_6)
 	TILE_SEQ_LINE(0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_7_fence_ne[] = {
 	TILE_SEQ_LINE(7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_7)
 	TILE_SEQ_LINE(0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_8_fence_ne[] = {
 	TILE_SEQ_LINE(7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_8)
 	TILE_SEQ_LINE(0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_9_fence_ne[] = {
 	TILE_SEQ_LINE(7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_9)
 	TILE_SEQ_LINE(0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_10_fence_ne[] = {
 	TILE_SEQ_LINE(7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_A)
 	TILE_SEQ_LINE(0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_11_fence_ne[] = {
 	TILE_SEQ_LINE(7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_B)
 	TILE_SEQ_LINE(0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_12_fence_ne[] = {
 	TILE_SEQ_LINE(7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_C)
 	TILE_SEQ_LINE(0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 /* END */
 
@@ -482,55 +405,47 @@ static const DrawTileSeqStruct _station_display_radar_12_fence_ne[] = {
 static const DrawTileSeqStruct _station_display_helipad_fence_sw[] = {
 	TILE_SEQ_LINE(10,  6,  0,  0,  0,  0, SPR_AIRPORT_HELIPAD)
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR)) // fences bottom
-	TILE_SEQ_END()
 };
 
 /* helipad for commuter airport */
 static const DrawTileSeqStruct _station_display_helipad_fence_nw[] = {
 	TILE_SEQ_LINE(10,  6,  0,  0,  0,  0, SPR_AIRPORT_HELIPAD)
 	TILE_SEQ_LINE( 0,  0,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences left
-	TILE_SEQ_END()
 };
 
 /* helipad for continental airport */
 static const DrawTileSeqStruct _station_display_helipad[] = {
 	TILE_SEQ_LINE(10,  6,  0,  0,  0,  0, SPR_AIRPORT_HELIPAD)
-	TILE_SEQ_END()
 };
 
 /* asphalt tile with fences in north and south */
 static const DrawTileSeqStruct _station_display_fence_ne_sw[] = {
 	TILE_SEQ_GROUND( 0,  0,  0,  SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_GROUND(15,  0,  0,  SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 /* runway tiles with 2 corner fences */
 static const DrawTileSeqStruct _station_display_fence_nw_sw[] = {
 	TILE_SEQ_GROUND( 0,  0,  0, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences north
 	TILE_SEQ_GROUND(15,  0,  0, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR)) // fences west
-	TILE_SEQ_END()
 };
 
 /* runway tiles with 2 corner fences */
 static const DrawTileSeqStruct _station_display_fence_se_sw[] = {
 	TILE_SEQ_GROUND(15,  0,  0, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR)) // fences west
 	TILE_SEQ_GROUND( 0, 15,  0, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences south
-	TILE_SEQ_END()
 };
 
 /* runway tiles with 2 corner fences */
 static const DrawTileSeqStruct _station_display_fence_ne_nw[] = {
 	TILE_SEQ_GROUND( 0,  0,  0, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences north
 	TILE_SEQ_GROUND( 0,  0,  0, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR)) // fences east
-	TILE_SEQ_END()
 };
 
 /* runway tiles with 2 corner fences */
 static const DrawTileSeqStruct _station_display_fence_ne_se[] = {
 	TILE_SEQ_GROUND( 0,  0,  0, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR)) // fences east
 	TILE_SEQ_GROUND( 0, 15,  0, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences south
-	TILE_SEQ_END()
 };
 
 /* helipad tiles with 2 corner fences top+right */
@@ -538,7 +453,6 @@ static const DrawTileSeqStruct _station_display_helipad_fence_NE_SE[] = {
 	TILE_SEQ_LINE(10,  6,  0,  0,  0,  0, SPR_AIRPORT_HELIPAD)
 	TILE_SEQ_LINE( 0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR)) // fences east
 	TILE_SEQ_LINE( 0, 15,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences south
-	TILE_SEQ_END()
 };
 
 /* helidepot office with fences top + left */
@@ -546,26 +460,22 @@ static const DrawTileSeqStruct _station_display_low_building_fence_ne_nw[] = {
 	TILE_SEQ_LINE( 0,  0,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences left
 	TILE_SEQ_LINE( 0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR)) // fences east
 	TILE_SEQ_LINE( 3,  3,  0, 10, 10, 60, SPR_AIRPORT_HELIDEPOT_OFFICE | (1U << PALETTE_MODIFIER_COLOUR))  // helidepot office
-	TILE_SEQ_END()
 };
 
 /* West facing hangar */
 static const DrawTileSeqStruct _station_display_hangar_sw[] = {
 	TILE_SEQ_LINE(14,  0,  0,  2, 17, 28, SPR_NEWHANGAR_W | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0,  0,  0,  2, 17, 28, SPR_NEWHANGAR_W_WALL | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 /* North facing hangar */
 static const DrawTileSeqStruct _station_display_hangar_nw[] = {
 	TILE_SEQ_LINE(14,  0,  0,  2, 16, 28, SPR_NEWHANGAR_N | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 /* East facing hangar */
 static const DrawTileSeqStruct _station_display_hangar_ne[] = {
 	TILE_SEQ_LINE(14,  0,  0,  2, 16, 28, SPR_NEWHANGAR_E | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 /* helipad for district airport NS */
@@ -573,42 +483,36 @@ static const DrawTileSeqStruct _station_display_helipad_fence_se_sw[] = {
 	TILE_SEQ_LINE(10,  6,  0,  0,  0,  0, SPR_AIRPORT_HELIPAD)
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR)) // fences bottom
 	TILE_SEQ_LINE( 0, 15,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences right
-	TILE_SEQ_END()
 };
 
 /* helipad for district airport NS */
 static const DrawTileSeqStruct _station_display_helipad_fence_se[] = {
 	TILE_SEQ_LINE(10,  6,  0,  0,  0,  0, SPR_AIRPORT_HELIPAD)
 	TILE_SEQ_LINE( 0, 15,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences south
-	TILE_SEQ_END()
 };
 
 /* helidepot office with fence north */
 static const DrawTileSeqStruct _station_display_low_building_fence_nw[] = {
 	TILE_SEQ_LINE( 0,  0,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences north
 	TILE_SEQ_LINE( 3,  3,  0, 10, 10, 60, SPR_AIRPORT_HELIDEPOT_OFFICE | (1U << PALETTE_MODIFIER_COLOUR))  // helidepot office
-	TILE_SEQ_END()
 };
 
 /* helidepot office with fence east */
 static const DrawTileSeqStruct _station_display_low_building_fence_ne[] = {
 	TILE_SEQ_LINE( 0,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR)) // fences east
 	TILE_SEQ_LINE( 3,  3,  0, 10, 10, 60, SPR_AIRPORT_HELIDEPOT_OFFICE | (1U << PALETTE_MODIFIER_COLOUR))  // helidepot office
-	TILE_SEQ_END()
 };
 
 /* helidepot office with fence west */
 static const DrawTileSeqStruct _station_display_low_building_fence_sw[] = {
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR)) // fences west
 	TILE_SEQ_LINE( 3,  3,  0, 10, 10, 60, SPR_AIRPORT_HELIDEPOT_OFFICE | (1U << PALETTE_MODIFIER_COLOUR))  // helidepot office
-	TILE_SEQ_END()
 };
 
 /* helidepot office with fence south */
 static const DrawTileSeqStruct _station_display_low_building_fence_se[] = {
 	TILE_SEQ_LINE( 0, 15,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences south
 	TILE_SEQ_LINE( 3,  3,  0, 10, 10, 60, SPR_AIRPORT_HELIDEPOT_OFFICE | (1U << PALETTE_MODIFIER_COLOUR))  // helidepot office
-	TILE_SEQ_END()
 };
 
 /* helipad for district airport EW*/
@@ -616,7 +520,6 @@ static const DrawTileSeqStruct _station_display_helipad_fence_nw_sw[] = {
 	TILE_SEQ_LINE(10,  6,  0,  0,  0,  0, SPR_AIRPORT_HELIPAD)
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR)) // fences west
 	TILE_SEQ_LINE( 0,  0,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences north
-	TILE_SEQ_END()
 };
 
 /* turning radar with fences on south -- needs 12 tiles
@@ -624,73 +527,61 @@ static const DrawTileSeqStruct _station_display_helipad_fence_nw_sw[] = {
 static const DrawTileSeqStruct _station_display_radar_1_fence_se[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_1)   // turning radar
 	TILE_SEQ_LINE( 0, 15,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences south
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_2_fence_se[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_2)
 	TILE_SEQ_LINE( 0, 15,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences south
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_3_fence_se[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_3)
 	TILE_SEQ_LINE( 0, 15,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences south
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_4_fence_se[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_4)
 	TILE_SEQ_LINE( 0, 15,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences south
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_5_fence_se[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_5)
 	TILE_SEQ_LINE( 0, 15,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences south
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_6_fence_se[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_6)
 	TILE_SEQ_LINE( 0, 15,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences south
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_7_fence_se[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_7)
 	TILE_SEQ_LINE( 0, 15,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences south
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_8_fence_se[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_8)
 	TILE_SEQ_LINE( 0, 15,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences south
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_9_fence_se[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_9)
 	TILE_SEQ_LINE( 0, 15,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences south
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_10_fence_se[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_A)
 	TILE_SEQ_LINE( 0, 15,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences south
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_11_fence_se[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_B)
 	TILE_SEQ_LINE( 0, 15,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences south
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_radar_12_fence_se[] = {
 	TILE_SEQ_LINE( 7,  7,  0,  2,  2,  8, SPR_AIRPORT_RADAR_C)
 	TILE_SEQ_LINE( 0, 15,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences south
-	TILE_SEQ_END()
 };
 /* END */
 
@@ -699,7 +590,6 @@ static const DrawTileSeqStruct _station_display_newhelipad_fence_se_sw[] = {
 	TILE_SEQ_LINE( 0,  1,  2,  0,  0,  0, SPR_NEWHELIPAD)
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR)) // fences west
 	TILE_SEQ_LINE( 0, 15,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences south
-	TILE_SEQ_END()
 };
 
 /* helipad for helistation */
@@ -707,89 +597,75 @@ static const DrawTileSeqStruct _station_display_newhelipad_fence_nw_sw[] = {
 	TILE_SEQ_LINE( 0,  1,  2,  0,  0,  0, SPR_NEWHELIPAD)
 	TILE_SEQ_LINE(15,  0,  0,  1, 16,  6, SPR_AIRPORT_FENCE_Y | (1U << PALETTE_MODIFIER_COLOUR)) // fences west
 	TILE_SEQ_LINE( 0,  0,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences north
-	TILE_SEQ_END()
 };
 
 /* helipad for helistation */
 static const DrawTileSeqStruct _station_display_newhelipad_fence_nw[] = {
 	TILE_SEQ_LINE( 0,  1,  2,  0,  0,  0, SPR_NEWHELIPAD)
 	TILE_SEQ_LINE( 0,  0,  0, 16,  1,  6, SPR_AIRPORT_FENCE_X | (1U << PALETTE_MODIFIER_COLOUR)) // fences north
-	TILE_SEQ_END()
 };
 
 /* helidepot office without fence */
 static const DrawTileSeqStruct _station_display_low_building[] = {
 	TILE_SEQ_LINE( 3,  3,  0, 10, 10, 60, SPR_AIRPORT_HELIDEPOT_OFFICE | (1U << PALETTE_MODIFIER_COLOUR))  // helidepot office
-	TILE_SEQ_END()
 };
 
 /* half grass half SPR_AIRPORT_APRON */
 static const DrawTileSeqStruct _station_display_grass_west[] = {
 	TILE_SEQ_LINE(0,  0,  0,  0,  0,  0, SPR_GRASS_LEFT)
-	TILE_SEQ_END()
 };
 
 /* half grass half SPR_AIRPORT_APRON */
 static const DrawTileSeqStruct _station_display_grass_east[] = {
 	TILE_SEQ_LINE(0,  0,  0,  0,  0,  0, SPR_GRASS_RIGHT)
-	TILE_SEQ_END()
 };
 
 /* drive-through truck stop X */
 static const DrawTileSeqStruct _station_display_datas_0168[] = {
 	TILE_SEQ_LINE( 0,  0,  0,  16,  3, 16, SPR_TRUCK_STOP_DT_X_W | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0, 13,  0,  16,  3, 16, SPR_TRUCK_STOP_DT_X_E | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 /* drive-through truck stop Y */
 static const DrawTileSeqStruct _station_display_datas_0169[] = {
 	TILE_SEQ_LINE(13,  0,  0,  3, 16, 16, SPR_TRUCK_STOP_DT_Y_W | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0,  0,  0,  3, 16, 16, SPR_TRUCK_STOP_DT_Y_E | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 /* drive-through bus stop X */
 static const DrawTileSeqStruct _station_display_datas_0170[] = {
 	TILE_SEQ_LINE( 0,  0,  0,  16,  3, 16, SPR_BUS_STOP_DT_X_W | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0, 13,  0,  16,  3, 16, SPR_BUS_STOP_DT_X_E | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 /* drive-through bus stop Y */
 static const DrawTileSeqStruct _station_display_datas_0171[] = {
 	TILE_SEQ_LINE(13,  0,  0,  3,  16, 16, SPR_BUS_STOP_DT_Y_W | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0,  0,  0,  3,  16, 16, SPR_BUS_STOP_DT_Y_E | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 /* road waypoint X */
 static const DrawTileSeqStruct _station_display_datas_road_waypoint_X[] = {
 	TILE_SEQ_LINE( 0,  0,  0,  16,  3, 16, SPR_ROAD_WAYPOINT_X_W | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0, 13,  0,  16,  3, 16, SPR_ROAD_WAYPOINT_X_E | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 /* road waypoint Y */
 static const DrawTileSeqStruct _station_display_datas_road_waypoint_Y[] = {
 	TILE_SEQ_LINE(13,  0,  0,  3,  16, 16, SPR_ROAD_WAYPOINT_Y_W | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0,  0,  0,  3,  16, 16, SPR_ROAD_WAYPOINT_Y_E | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_waypoint_X[] = {
 	TILE_SEQ_LINE( 0,  0,  0, 16,  5, 23, SPR_WAYPOINT_X_1 | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE( 0, 11,  0, 16,  5, 23, SPR_WAYPOINT_X_2 | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _station_display_datas_waypoint_Y[] = {
 	TILE_SEQ_LINE( 0,  0,  0,  5, 16, 23, SPR_WAYPOINT_Y_1 | (1U << PALETTE_MODIFIER_COLOUR))
 	TILE_SEQ_LINE(11,  0,  0,  5, 16, 23, SPR_WAYPOINT_Y_2 | (1U << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
-#undef TILE_SEQ_END
 #undef TILE_SEQ_LINE
 #undef TILE_SEQ_LINE_PAL
 #undef TILE_SEQ_CHILD
@@ -801,6 +677,7 @@ static const DrawTileSeqStruct _station_display_datas_waypoint_Y[] = {
  * @param dtss  Sequence child sprites of the tile
  */
 #define TILE_SPRITE_LINE(img, dtss) { {img, PAL_NONE}, dtss },
+#define TILE_SPRITE_LINE_NOTHING(img) { {img, PAL_NONE} },
 #define TILE_SPRITE_NULL() { {0, 0} },
 
 extern const DrawTileSpriteSpan _station_display_datas_rail[] = {
@@ -815,19 +692,19 @@ extern const DrawTileSpriteSpan _station_display_datas_rail[] = {
 };
 
 static const DrawTileSpriteSpan _station_display_datas_airport[] = {
-	TILE_SPRITE_LINE(SPR_AIRPORT_APRON,              _station_display_nothing)  // APT_APRON
+	TILE_SPRITE_LINE_NOTHING(SPR_AIRPORT_APRON)  // APT_APRON
 	TILE_SPRITE_LINE(SPR_AIRPORT_APRON,              _station_display_fence_nw) // APT_APRON_FENCE_NW
 	TILE_SPRITE_LINE(SPR_AIRPORT_APRON,              _station_display_fence_sw) // APT_APRON_FENCE_SW
-	TILE_SPRITE_LINE(SPR_AIRPORT_AIRCRAFT_STAND,     _station_display_nothing)  // APT_STAND
-	TILE_SPRITE_LINE(SPR_AIRPORT_TAXIWAY_NS_WEST,    _station_display_nothing)  // APT_APRON_W
-	TILE_SPRITE_LINE(SPR_AIRPORT_TAXIWAY_EW_SOUTH,   _station_display_nothing)  // APT_APRON_S
-	TILE_SPRITE_LINE(SPR_AIRPORT_TAXIWAY_XING_SOUTH, _station_display_nothing)  // APT_APRON_VER_CROSSING_S
-	TILE_SPRITE_LINE(SPR_AIRPORT_TAXIWAY_XING_WEST,  _station_display_nothing)  // APT_APRON_HOR_CROSSING_W
-	TILE_SPRITE_LINE(SPR_AIRPORT_TAXIWAY_NS_CTR,     _station_display_nothing)  // APT_APRON_VER_CROSSING_N
-	TILE_SPRITE_LINE(SPR_AIRPORT_TAXIWAY_XING_EAST,  _station_display_nothing)  // APT_APRON_HOR_CROSSING_E
-	TILE_SPRITE_LINE(SPR_AIRPORT_TAXIWAY_NS_EAST,    _station_display_nothing)  // APT_APRON_E
-	TILE_SPRITE_LINE(SPR_AIRPORT_TAXIWAY_EW_NORTH,   _station_display_nothing)  // APT_ARPON_N
-	TILE_SPRITE_LINE(SPR_AIRPORT_TAXIWAY_EW_CTR,     _station_display_nothing)  // APT_APRON_HOR
+	TILE_SPRITE_LINE_NOTHING(SPR_AIRPORT_AIRCRAFT_STAND)  // APT_STAND
+	TILE_SPRITE_LINE_NOTHING(SPR_AIRPORT_TAXIWAY_NS_WEST)  // APT_APRON_W
+	TILE_SPRITE_LINE_NOTHING(SPR_AIRPORT_TAXIWAY_EW_SOUTH)  // APT_APRON_S
+	TILE_SPRITE_LINE_NOTHING(SPR_AIRPORT_TAXIWAY_XING_SOUTH)  // APT_APRON_VER_CROSSING_S
+	TILE_SPRITE_LINE_NOTHING(SPR_AIRPORT_TAXIWAY_XING_WEST)  // APT_APRON_HOR_CROSSING_W
+	TILE_SPRITE_LINE_NOTHING(SPR_AIRPORT_TAXIWAY_NS_CTR)  // APT_APRON_VER_CROSSING_N
+	TILE_SPRITE_LINE_NOTHING(SPR_AIRPORT_TAXIWAY_XING_EAST)  // APT_APRON_HOR_CROSSING_E
+	TILE_SPRITE_LINE_NOTHING(SPR_AIRPORT_TAXIWAY_NS_EAST)  // APT_APRON_E
+	TILE_SPRITE_LINE_NOTHING(SPR_AIRPORT_TAXIWAY_EW_NORTH)  // APT_ARPON_N
+	TILE_SPRITE_LINE_NOTHING(SPR_AIRPORT_TAXIWAY_EW_CTR)  // APT_APRON_HOR
 	TILE_SPRITE_LINE(SPR_AIRPORT_TAXIWAY_EW_NORTH,   _station_display_fence_sw) // APT_APRON_N_FENCE_SW
 	TILE_SPRITE_LINE(SPR_AIRPORT_RUNWAY_EXIT_A,      _station_display_fence_se) // APT_RUNWAY_1
 	TILE_SPRITE_LINE(SPR_AIRPORT_RUNWAY_EXIT_B,      _station_display_fence_se) // APT_RUNWAY_2
@@ -844,24 +721,24 @@ static const DrawTileSpriteSpan _station_display_datas_airport[] = {
 	TILE_SPRITE_LINE(SPR_AIRPORT_AIRCRAFT_STAND,     _station_display_jetway_2)  // APT_STAND_PIER_NE
 	TILE_SPRITE_LINE(SPR_AIRPORT_APRON,              _station_display_jetway_3)  // APT_PIER_NW_NE
 	TILE_SPRITE_LINE(SPR_AIRPORT_APRON,              _station_display_passenger_tunnel) // APT_PIER
-	TILE_SPRITE_LINE(SPR_FLAT_GRASS_TILE,            _station_display_nothing)   // APT_EMPTY
+	TILE_SPRITE_LINE_NOTHING(SPR_FLAT_GRASS_TILE)   // APT_EMPTY
 	TILE_SPRITE_LINE(SPR_FLAT_GRASS_TILE,            _station_display_fence_ne)  // APT_EMPTY_FENCE_NE
 	TILE_SPRITE_NULL() // APT_RADAR_GRASS_FENCE_SW
 	TILE_SPRITE_LINE(SPR_FLAT_GRASS_TILE,            _station_display_transmitter_fence_ne) // APT_RADIO_TOWER_FENCE_NE
-	TILE_SPRITE_LINE(SPR_AIRFIELD_TERM_A,            _station_display_nothing)   // APT_SMALL_BUILDING_3
-	TILE_SPRITE_LINE(SPR_AIRFIELD_TERM_B,            _station_display_nothing)   // APT_SMALL_BUILDING_2
+	TILE_SPRITE_LINE_NOTHING(SPR_AIRFIELD_TERM_A)   // APT_SMALL_BUILDING_3
+	TILE_SPRITE_LINE_NOTHING(SPR_AIRFIELD_TERM_B)   // APT_SMALL_BUILDING_2
 	TILE_SPRITE_LINE(SPR_AIRFIELD_TERM_C_GROUND | (1U << PALETTE_MODIFIER_COLOUR), _station_display_datas_terminal_c_2) // APT_SMALL_BUILDING_1
 	TILE_SPRITE_LINE(SPR_AIRFIELD_APRON_A,           _station_display_fence_sw)  // APT_GRASS_FENCE_SW
-	TILE_SPRITE_LINE(SPR_AIRFIELD_APRON_B,           _station_display_nothing)   // APT_GRASS_2
-	TILE_SPRITE_LINE(SPR_AIRFIELD_APRON_C,           _station_display_nothing)   // APT_GRASS_1
+	TILE_SPRITE_LINE_NOTHING(SPR_AIRFIELD_APRON_B)   // APT_GRASS_2
+	TILE_SPRITE_LINE_NOTHING(SPR_AIRFIELD_APRON_C)   // APT_GRASS_1
 	TILE_SPRITE_NULL() // APT_GRASS_FENCE_NE_FLAG
 	TILE_SPRITE_LINE(SPR_AIRFIELD_RUNWAY_NEAR_END,   _station_display_fence_se)  // APT_RUNWAY_SMALL_NEAR_END
 	TILE_SPRITE_LINE(SPR_AIRFIELD_RUNWAY_MIDDLE,     _station_display_fence_se)  // APT_RUNWAY_SMALL_MIDDLE
 	TILE_SPRITE_LINE(SPR_AIRFIELD_RUNWAY_FAR_END,    _station_display_fence_se)  // APT_RUNWAY_SMALL_FAR_END
 	TILE_SPRITE_LINE(SPR_AIRPORT_APRON,              _station_display_small_depot_se) // APT_SMALL_DEPOT_SE
 	TILE_SPRITE_LINE(SPR_FLAT_GRASS_TILE,            _station_display_heliport)  // APT_HELIPORT
-	TILE_SPRITE_LINE(SPR_AIRPORT_RUNWAY_END,         _station_display_nothing)   // APT_RUNWAY_END
-	TILE_SPRITE_LINE(SPR_AIRPORT_RUNWAY_EXIT_B,      _station_display_nothing)   // APT_RUNWAY_5
+	TILE_SPRITE_LINE_NOTHING(SPR_AIRPORT_RUNWAY_END)   // APT_RUNWAY_END
+	TILE_SPRITE_LINE_NOTHING(SPR_AIRPORT_RUNWAY_EXIT_B)   // APT_RUNWAY_5
 	TILE_SPRITE_LINE(SPR_AIRPORT_APRON,              _station_display_tower)     // APT_TOWER
 	TILE_SPRITE_LINE(SPR_AIRPORT_APRON,              _station_display_fence_ne)  // APT_APRON_FENCE_NE
 	TILE_SPRITE_LINE(SPR_AIRPORT_RUNWAY_END,         _station_display_fence_nw)  // APT_RUNWAY_END_FENCE_NW
@@ -979,7 +856,7 @@ static const DrawTileSpriteSpan _station_display_datas_road_waypoint[] = {
 };
 
 static const DrawTileSpriteSpan _station_display_datas_oilrig[] = {
-	TILE_SPRITE_LINE(SPR_FLAT_WATER_TILE,            _station_display_nothing)
+	TILE_SPRITE_LINE_NOTHING(SPR_FLAT_WATER_TILE)
 };
 
 static const DrawTileSpriteSpan _station_display_datas_dock[] = {
@@ -1007,6 +884,7 @@ static const DrawTileSpriteSpan _station_display_datas_waypoint[] = {
 };
 
 #undef TILE_SPRITE_LINE
+#undef TILE_SPRITE_LINE_NOTHING
 #undef TILE_SPRITE_NULL
 
 /* Default waypoint is also drawn as fallback for NewGRF waypoints.

--- a/src/table/track_land.h
+++ b/src/table/track_land.h
@@ -8,29 +8,24 @@
 /** @file track_land.h Sprites to use and how to display them for train depot tiles. */
 
 #define TILE_SEQ_LINE(img, dx, dy, sx, sy) { dx, dy, 0, sx, sy, 23, {img, PAL_NONE} },
-#define TILE_SEQ_END() { (int8_t)0x80, 0, 0, 0, 0, 0, {0, 0} }
 
 
 static const DrawTileSeqStruct _depot_gfx_NE[] = {
 	TILE_SEQ_LINE(SPR_RAIL_DEPOT_NE | (1 << PALETTE_MODIFIER_COLOUR), 2, 13, 13, 1)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _depot_gfx_SE[] = {
 	TILE_SEQ_LINE(SPR_RAIL_DEPOT_SE_1 | (1 << PALETTE_MODIFIER_COLOUR),  2, 2, 1, 13)
 	TILE_SEQ_LINE(SPR_RAIL_DEPOT_SE_2 | (1 << PALETTE_MODIFIER_COLOUR), 13, 2, 1, 13)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _depot_gfx_SW[] = {
 	TILE_SEQ_LINE(SPR_RAIL_DEPOT_SW_1 | (1 << PALETTE_MODIFIER_COLOUR), 2,  2, 13, 1)
 	TILE_SEQ_LINE(SPR_RAIL_DEPOT_SW_2 | (1 << PALETTE_MODIFIER_COLOUR), 2, 13, 13, 1)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _depot_gfx_NW[] = {
 	TILE_SEQ_LINE(SPR_RAIL_DEPOT_NW | (1 << PALETTE_MODIFIER_COLOUR), 13, 2, 1, 13)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSpriteSpan _depot_gfx_table[] = {
@@ -48,5 +43,3 @@ static const DrawTileSpriteSpan _depot_invisible_gfx_table[] = {
 };
 
 #undef TILE_SEQ_LINE
-#undef TILE_SEQ_END
-

--- a/src/table/water_land.h
+++ b/src/table/water_land.h
@@ -19,9 +19,6 @@
  */
 #define TILE_SEQ_LINE(dx, dy, dz, sx, sy, sz, img) { dx, dy, dz, sx, sy, sz, {img, PAL_NONE} },
 
-/** Constructor macro for a terminating DrawTileSeqStruct entry in an array */
-#define TILE_SEQ_END() { (int8_t)0x80, 0, 0, 0, 0, 0, {0, 0} }
-
 /**
  * Constructor macro of a DrawTileSpriteSpan structure
  * @param img   Ground sprite without palette of the tile
@@ -31,24 +28,20 @@
 
 static const DrawTileSeqStruct _shipdepot_display_seq_1[] = {
 	TILE_SEQ_LINE( 0, 15, 0, 16, 1, 0x14, 0xFE8 | (1 << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _shipdepot_display_seq_2[] = {
 	TILE_SEQ_LINE( 0,  0, 0, 16, 1, 0x14, 0xFEA)
 	TILE_SEQ_LINE( 0, 15, 0, 16, 1, 0x14, 0xFE6 | (1 << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _shipdepot_display_seq_3[] = {
 	TILE_SEQ_LINE( 15, 0, 0, 1, 0x10, 0x14, 0xFE9 | (1 << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _shipdepot_display_seq_4[] = {
 	TILE_SEQ_LINE(  0, 0, 0, 1, 16, 0x14, 0xFEB)
 	TILE_SEQ_LINE( 15, 0, 0, 1, 16, 0x14, 0xFE7 | (1 << PALETTE_MODIFIER_COLOUR))
-	TILE_SEQ_END()
 };
 
 static const DrawTileSpriteSpan _shipdepot_display_data[][DEPOT_PART_END] = {
@@ -65,73 +58,61 @@ static const DrawTileSpriteSpan _shipdepot_display_data[][DEPOT_PART_END] = {
 static const DrawTileSeqStruct _lock_display_seq_0[] = {
 	TILE_SEQ_LINE( 0,   0, 0, 0x10, 1, 0x14, 0 + 1)
 	TILE_SEQ_LINE( 0, 0xF, 0, 0x10, 1, 0x14, 4 + 1)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _lock_display_seq_1[] = {
 	TILE_SEQ_LINE(   0, 0, 0, 1, 0x10, 0x14, 0)
 	TILE_SEQ_LINE( 0xF, 0, 0, 1, 0x10, 0x14, 4)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _lock_display_seq_2[] = {
 	TILE_SEQ_LINE( 0,   0, 0, 0x10, 1, 0x14, 0 + 2)
 	TILE_SEQ_LINE( 0, 0xF, 0, 0x10, 1, 0x14, 4 + 2)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _lock_display_seq_3[] = {
 	TILE_SEQ_LINE(   0, 0, 0, 1, 0x10, 0x14, 0 + 3)
 	TILE_SEQ_LINE( 0xF, 0, 0, 1, 0x10, 0x14, 4 + 3)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _lock_display_seq_0b[] = {
 	TILE_SEQ_LINE( 0,   0, 0, 0x10, 1, 0x14, 8 + 1)
 	TILE_SEQ_LINE( 0, 0xF, 0, 0x10, 1, 0x14, 12 + 1)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _lock_display_seq_1b[] = {
 	TILE_SEQ_LINE(   0, 0, 0, 0x1, 0x10, 0x14, 8)
 	TILE_SEQ_LINE( 0xF, 0, 0, 0x1, 0x10, 0x14, 12)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _lock_display_seq_2b[] = {
 	TILE_SEQ_LINE( 0,   0, 0, 0x10, 1, 0x14, 8 + 2)
 	TILE_SEQ_LINE( 0, 0xF, 0, 0x10, 1, 0x14, 12 + 2)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _lock_display_seq_3b[] = {
 	TILE_SEQ_LINE(   0, 0, 0, 1, 0x10, 0x14, 8 + 3)
 	TILE_SEQ_LINE( 0xF, 0, 0, 1, 0x10, 0x14, 12 + 3)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _lock_display_seq_0t[] = {
 	TILE_SEQ_LINE( 0,   0, 0, 0x10, 1, 0x14, 16 + 1)
 	TILE_SEQ_LINE( 0, 0xF, 0, 0x10, 1, 0x14, 20 + 1)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _lock_display_seq_1t[] = {
 	TILE_SEQ_LINE(   0, 0, 0, 0x1, 0x10, 0x14, 16)
 	TILE_SEQ_LINE( 0xF, 0, 0, 0x1, 0x10, 0x14, 20)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _lock_display_seq_2t[] = {
 	TILE_SEQ_LINE( 0,   0, 0, 0x10, 1, 0x14, 16 + 2)
 	TILE_SEQ_LINE( 0, 0xF, 0, 0x10, 1, 0x14, 20 + 2)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSeqStruct _lock_display_seq_3t[] = {
 	TILE_SEQ_LINE(   0, 0, 0, 1, 0x10, 0x14, 16 + 3)
 	TILE_SEQ_LINE( 0xF, 0, 0, 1, 0x10, 0x14, 20 + 3)
-	TILE_SEQ_END()
 };
 
 static const DrawTileSpriteSpan _lock_display_data[][DIAGDIR_END] = {
@@ -158,5 +139,4 @@ static const DrawTileSpriteSpan _lock_display_data[][DIAGDIR_END] = {
 };
 
 #undef TILE_SEQ_LINE
-#undef TILE_SEQ_END
 #undef TILE_SPRITE_LINE

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -807,14 +807,13 @@ static void DrawWaterTileStruct(const TileInfo *ti, std::span<const DrawTileSeqS
 	/* Don't draw if buildings are invisible. */
 	if (IsInvisibilitySet(TO_BUILDINGS)) return;
 
-	const DrawTileSeqStruct *dtss;
-	foreach_draw_tile_seq(dtss, seq) {
-		uint tile_offs = offset + dtss->image.sprite;
+	for (const DrawTileSeqStruct &dtss : seq) {
+		uint tile_offs = offset + dtss.image.sprite;
 		if (feature < CF_END) tile_offs = GetCanalSpriteOffset(feature, ti->tile, tile_offs);
 		AddSortableSpriteToDraw(base + tile_offs, palette,
-			ti->x + dtss->delta_x, ti->y + dtss->delta_y,
-			dtss->size_x, dtss->size_y,
-			dtss->size_z, ti->z + dtss->delta_z,
+			ti->x + dtss.delta_x, ti->y + dtss.delta_y,
+			dtss.size_x, dtss.size_y,
+			dtss.size_z, ti->z + dtss.delta_z,
 			IsTransparencySet(TO_BUILDINGS));
 	}
 }


### PR DESCRIPTION
## Motivation / Problem

A continuation for #13363: the removal of `MallocT` from NewGRF-commons.

With #13364 the `DrawTileSprites` has become `std::vector` or `std::span`, but the terminator object at the end was still kept This PR aims to bring an end to that, and a macro.


## Description

Remove `TILE_SEQ_END` from the data tables, and the concept of terminator from the `DrawTileStructSeq`.

Replace the `foreach_draw_tile_seq` macro that iterated by pointer with ranged for loops that go by reference.

Explicitly initialise all values of `DrawTileStructSeq`, so we don't need to `MemSetT` elements.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
