### PR TITLE
Codechange: Use variable storage for GrfProps with cargo-type groups.

### DIFF
--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -80,7 +80,7 @@ struct Engine : EnginePool::PoolItem<&_engine_pool> {
 	 * Used for obtaining the sprite offset of custom sprites, and for
 	 * evaluating callbacks.
 	 */
-	GRFFilePropsBase<NUM_CARGO + 2> grf_prop;
+	VariableGRFFileProps grf_prop;
 	std::vector<WagonOverride> overrides;
 
 	Engine() {}

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -335,7 +335,7 @@ static void DrawTile_Industry(TileInfo *ti)
 		 * DrawNewIndustry will return false if ever the resolver could not
 		 * find any sprite to display.  So in this case, we will jump on the
 		 * substitute gfx instead. */
-		if (indts->grf_prop.spritegroup[0] != nullptr && DrawNewIndustryTile(ti, ind, gfx, indts)) {
+		if (indts->grf_prop.GetSpriteGroup() != nullptr && DrawNewIndustryTile(ti, ind, gfx, indts)) {
 			return;
 		} else {
 			/* No sprite group (or no valid one) found, meaning no graphics associated.
@@ -404,7 +404,7 @@ static Foundation GetFoundation_Industry(TileIndex tile, Slope tileh)
 	 */
 	if (gfx >= NEW_INDUSTRYTILEOFFSET) {
 		const IndustryTileSpec *indts = GetIndustryTileSpec(gfx);
-		if (indts->grf_prop.spritegroup[0] != nullptr && indts->callback_mask.Test(IndustryTileCallbackMask::DrawFoundations)) {
+		if (indts->grf_prop.GetSpriteGroup() != nullptr && indts->callback_mask.Test(IndustryTileCallbackMask::DrawFoundations)) {
 			uint32_t callback_res = GetIndustryTileCallback(CBID_INDTILE_DRAW_FOUNDATIONS, 0, 0, gfx, Industry::GetByTile(tile), tile);
 			if (callback_res != CALLBACK_FAILED && !ConvertBooleanCallback(indts->grf_prop.grffile, CBID_INDTILE_DRAW_FOUNDATIONS, callback_res)) return FOUNDATION_NONE;
 		}

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -5810,7 +5810,7 @@ static void StationMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 				continue;
 			}
 
-			statspec->grf_prop.spritegroup[ctype] = _cur.spritegroups[groupid];
+			statspec->grf_prop.SetSpriteGroup(ctype, _cur.spritegroups[groupid]);
 		}
 	}
 
@@ -5830,7 +5830,7 @@ static void StationMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 			continue;
 		}
 
-		statspec->grf_prop.spritegroup[SpriteGroupCargo::SG_DEFAULT] = _cur.spritegroups[groupid];
+		statspec->grf_prop.SetSpriteGroup(SpriteGroupCargo::SG_DEFAULT, _cur.spritegroups[groupid]);
 		statspec->grf_prop.grfid = _cur.grffile->grfid;
 		statspec->grf_prop.grffile = _cur.grffile;
 		statspec->grf_prop.local_id = station;
@@ -5867,7 +5867,7 @@ static void TownHouseMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 			continue;
 		}
 
-		hs->grf_prop.spritegroup[0] = _cur.spritegroups[groupid];
+		hs->grf_prop.SetSpriteGroup(0, _cur.spritegroups[groupid]);
 	}
 }
 
@@ -5899,7 +5899,7 @@ static void IndustryMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 			continue;
 		}
 
-		indsp->grf_prop.spritegroup[0] = _cur.spritegroups[groupid];
+		indsp->grf_prop.SetSpriteGroup(0, _cur.spritegroups[groupid]);
 	}
 }
 
@@ -5931,7 +5931,7 @@ static void IndustrytileMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 			continue;
 		}
 
-		indtsp->grf_prop.spritegroup[0] = _cur.spritegroups[groupid];
+		indtsp->grf_prop.SetSpriteGroup(0, _cur.spritegroups[groupid]);
 	}
 }
 
@@ -5995,7 +5995,7 @@ static void ObjectMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 				continue;
 			}
 
-			spec->grf_prop.spritegroup[OBJECT_SPRITE_GROUP_PURCHASE] = _cur.spritegroups[groupid];
+			spec->grf_prop.SetSpriteGroup(OBJECT_SPRITE_GROUP_PURCHASE, _cur.spritegroups[groupid]);
 		}
 	}
 
@@ -6015,7 +6015,7 @@ static void ObjectMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 			continue;
 		}
 
-		spec->grf_prop.spritegroup[OBJECT_SPRITE_GROUP_DEFAULT] = _cur.spritegroups[groupid];
+		spec->grf_prop.SetSpriteGroup(OBJECT_SPRITE_GROUP_DEFAULT, _cur.spritegroups[groupid]);
 		spec->grf_prop.grfid = _cur.grffile->grfid;
 		spec->grf_prop.grffile = _cur.grffile;
 		spec->grf_prop.local_id = object;
@@ -6116,7 +6116,7 @@ static void AirportMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 			continue;
 		}
 
-		as->grf_prop.spritegroup[0] = _cur.spritegroups[groupid];
+		as->grf_prop.SetSpriteGroup(0, _cur.spritegroups[groupid]);
 	}
 }
 
@@ -6148,7 +6148,7 @@ static void AirportTileMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 			continue;
 		}
 
-		airtsp->grf_prop.spritegroup[0] = _cur.spritegroups[groupid];
+		airtsp->grf_prop.SetSpriteGroup(0, _cur.spritegroups[groupid]);
 	}
 }
 
@@ -6182,7 +6182,7 @@ static void RoadStopMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 				continue;
 			}
 
-			roadstopspec->grf_prop.spritegroup[ctype] = _cur.spritegroups[groupid];
+			roadstopspec->grf_prop.SetSpriteGroup(ctype, _cur.spritegroups[groupid]);
 		}
 	}
 
@@ -6202,7 +6202,7 @@ static void RoadStopMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 			continue;
 		}
 
-		roadstopspec->grf_prop.spritegroup[SpriteGroupCargo::SG_DEFAULT] = _cur.spritegroups[groupid];
+		roadstopspec->grf_prop.SetSpriteGroup(SpriteGroupCargo::SG_DEFAULT, _cur.spritegroups[groupid]);
 		roadstopspec->grf_prop.grfid = _cur.grffile->grfid;
 		roadstopspec->grf_prop.grffile = _cur.grffile;
 		roadstopspec->grf_prop.local_id = roadstop;

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -246,7 +246,7 @@ AirportResolverObject::AirportResolverObject(TileIndex tile, Station *st, const 
 		CallbackID callback, uint32_t param1, uint32_t param2)
 	: ResolverObject(spec->grf_prop.grffile, callback, param1, param2), airport_scope(*this, tile, st, spec, layout)
 {
-	this->root_spritegroup = spec->grf_prop.spritegroup[0];
+	this->root_spritegroup = spec->grf_prop.GetSpriteGroup();
 }
 
 SpriteID GetCustomAirportSprite(const AirportSpec *as, uint8_t layout)

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -148,7 +148,7 @@ static uint32_t GetAirportTileIDAtOffset(TileIndex tile, const Station *st, uint
 		}
 	}
 	/* Not an 'old type' tile */
-	if (ats->grf_prop.spritegroup[0] != nullptr) { // tile has a spritegroup ?
+	if (ats->grf_prop.GetSpriteGroup() != nullptr) { // tile has a spritegroup ?
 		if (ats->grf_prop.grfid == cur_grfid) { // same airport, same grf ?
 			return ats->grf_prop.local_id;
 		} else {
@@ -218,7 +218,7 @@ AirportTileResolverObject::AirportTileResolverObject(const AirportTileSpec *ats,
 		tiles_scope(*this, ats, tile, st),
 		airport_scope(*this, tile, st, st != nullptr ? AirportSpec::Get(st->airport.type) : nullptr, st != nullptr ? st->airport.layout : 0)
 {
-	this->root_spritegroup = ats->grf_prop.spritegroup[0];
+	this->root_spritegroup = ats->grf_prop.GetSpriteGroup();
 }
 
 GrfSpecFeature AirportTileResolverObject::GetFeature() const

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -756,3 +756,30 @@ void NewGRFSpriteLayout::ProcessRegisters(uint8_t resolved_var10, uint32_t resol
 		if (regs != nullptr) regs++;
 	}
 }
+
+/**
+ * Get the SpriteGroup at the specified index.
+ * @param index Index to get.
+ * @returns SpriteGroup at index, or nullptr if not present.
+ */
+const SpriteGroup *VariableGRFFileProps::GetSpriteGroup(size_t index) const
+{
+	auto it = std::ranges::lower_bound(this->spritegroups, index, std::less{}, &CargoSpriteGroup::first);
+	if (it == std::end(this->spritegroups) || it->first != index) return nullptr;
+	return it->second;
+}
+
+/**
+ * Set the SpriteGroup at the specified index.
+ * @param index Index to set.
+ * @param spritegroup SpriteGroup to set.
+ */
+void VariableGRFFileProps::SetSpriteGroup(size_t index, const SpriteGroup *spritegroup)
+{
+	auto it = std::ranges::lower_bound(this->spritegroups, index, std::less{}, &CargoSpriteGroup::first);
+	if (it == std::end(this->spritegroups) || it->first != index) {
+		this->spritegroups.emplace(it, index, spritegroup);
+	} else {
+		it->second = spritegroup;
+	}
+}

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -307,15 +307,12 @@ bool ConvertBooleanCallback(const struct GRFFile *grffile, uint16_t cbid, uint16
 bool Convert8bitBooleanCallback(const struct GRFFile *grffile, uint16_t cbid, uint16_t cb_res);
 
 /**
- * Data related to the handling of grf files.
- * @tparam Tcnt Number of spritegroups
+ * Base data related to the handling of grf files.
  */
-template <size_t Tcnt>
 struct GRFFilePropsBase {
 	uint16_t local_id = 0; ///< id defined by the grf file for this entity
 	uint32_t grfid = 0; ///< grfid that introduced this entity.
 	const struct GRFFile *grffile = nullptr; ///< grf file that introduced this entity
-	std::array<const struct SpriteGroup *, Tcnt> spritegroup{}; ///< pointers to the different sprites of the entity
 
 	/**
 	 * Test if this entity was introduced by NewGRF.
@@ -324,13 +321,47 @@ struct GRFFilePropsBase {
 	inline bool HasGrfFile() const { return this->grffile != nullptr; }
 };
 
+/**
+ * Fixed-length list of sprite groups for an entity.
+ * @tparam Tcount Number of spritegroups
+ */
+template <size_t Tcount>
+struct FixedGRFFileProps : GRFFilePropsBase {
+	std::array<const struct SpriteGroup *, Tcount> spritegroups{}; ///< pointers to the different sprite groups of the entity
+
+	/**
+	 * Get the SpriteGroup at the specified index.
+	 * @param index Index to get.
+	 * @returns SpriteGroup at index, or nullptr if not present.
+	 */
+	const struct SpriteGroup *GetSpriteGroup(size_t index = 0) const { return this->spritegroups[index]; }
+
+	/**
+	 * Set the SpriteGroup at the specified index.
+	 * @param index Index to set.
+	 * @param spritegroup SpriteGroup to set.
+	 */
+	void SetSpriteGroup(size_t index, const struct SpriteGroup *spritegroup) { this->spritegroups[index] = spritegroup; }
+};
+
+/**
+ * Variable-length list of sprite groups for an entity.
+ */
+struct VariableGRFFileProps : GRFFilePropsBase {
+	using CargoSpriteGroup = std::pair<size_t, const struct SpriteGroup *>;
+	std::vector<CargoSpriteGroup> spritegroups; ///< pointers to the different sprite groups of the entity
+
+	const struct SpriteGroup *GetSpriteGroup(size_t index) const;
+	void SetSpriteGroup(size_t index, const struct SpriteGroup *spritegroup);
+};
+
 /** Data related to the handling of grf files. */
-struct GRFFileProps : GRFFilePropsBase<1> {
+struct GRFFileProps : FixedGRFFileProps<1> {
 	/** Set all default data constructor for the props. */
 	constexpr GRFFileProps(uint16_t subst_id = 0) : subst_id(subst_id), override(subst_id) {}
 
 	uint16_t subst_id;
-	uint16_t override;                      ///< id of the entity been replaced by
+	uint16_t override; ///< id of the entity been replaced by
 };
 
 /** Container for a label for rail or road type conversion. */

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -53,12 +53,11 @@ const SpriteGroup *GetWagonOverrideSpriteSet(EngineID engine, CargoType cargo, E
 void SetCustomEngineSprites(EngineID engine, CargoType cargo, const SpriteGroup *group)
 {
 	Engine *e = Engine::Get(engine);
-	assert(cargo < std::size(e->grf_prop.spritegroup));
 
-	if (e->grf_prop.spritegroup[cargo] != nullptr) {
+	if (e->grf_prop.GetSpriteGroup(cargo) != nullptr) {
 		GrfMsg(6, "SetCustomEngineSprites: engine {} cargo {} already has group -- replacing", engine, cargo);
 	}
-	e->grf_prop.spritegroup[cargo] = group;
+	e->grf_prop.SetSpriteGroup(cargo, group);
 }
 
 
@@ -1063,8 +1062,8 @@ VehicleResolverObject::VehicleResolverObject(EngineID engine_type, const Vehicle
 		if (this->root_spritegroup == nullptr) {
 			const Engine *e = Engine::Get(engine_type);
 			CargoType cargo = v != nullptr ? v->cargo_type : SpriteGroupCargo::SG_PURCHASE;
-			assert(cargo < std::size(e->grf_prop.spritegroup));
-			this->root_spritegroup = e->grf_prop.spritegroup[cargo] != nullptr ? e->grf_prop.spritegroup[cargo] : e->grf_prop.spritegroup[SpriteGroupCargo::SG_DEFAULT];
+			this->root_spritegroup = e->grf_prop.GetSpriteGroup(cargo);
+			if (this->root_spritegroup == nullptr) this->root_spritegroup = e->grf_prop.GetSpriteGroup(SpriteGroupCargo::SG_DEFAULT);
 		}
 	}
 }

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -113,7 +113,7 @@ HouseResolverObject::HouseResolverObject(HouseID house_id, TileIndex tile, Town 
 	/* Tile must be valid and a house tile, unless not yet constructed in which case it may also be INVALID_TILE. */
 	assert((IsValidTile(tile) && (not_yet_constructed || IsTileType(tile, MP_HOUSE))) || (not_yet_constructed && tile == INVALID_TILE));
 
-	this->root_spritegroup = HouseSpec::Get(house_id)->grf_prop.spritegroup[0];
+	this->root_spritegroup = HouseSpec::Get(house_id)->grf_prop.GetSpriteGroup();
 }
 
 GrfSpecFeature HouseResolverObject::GetFeature() const
@@ -687,7 +687,7 @@ static void DoTriggerHouse(TileIndex tile, HouseTrigger trigger, uint8_t base_ra
 	HouseID hid = GetHouseType(tile);
 	HouseSpec *hs = HouseSpec::Get(hid);
 
-	if (hs->grf_prop.spritegroup[0] == nullptr) return;
+	if (hs->grf_prop.GetSpriteGroup() == nullptr) return;
 
 	HouseResolverObject object(hid, tile, Town::GetByTile(tile), CBID_RANDOM_TRIGGER);
 	object.waiting_triggers = GetHouseTriggers(tile) | trigger;

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -78,7 +78,7 @@ uint32_t GetIndustryIDAtOffset(TileIndex tile, const Industry *i, uint32_t cur_g
 		}
 	}
 	/* Not an 'old type' tile */
-	if (indtsp->grf_prop.spritegroup[0] != nullptr) { // tile has a spritegroup ?
+	if (indtsp->grf_prop.GetSpriteGroup() != nullptr) { // tile has a spritegroup ?
 		if (indtsp->grf_prop.grfid == cur_grfid) { // same industry, same grf ?
 			return indtsp->grf_prop.local_id;
 		} else {
@@ -476,7 +476,7 @@ IndustriesResolverObject::IndustriesResolverObject(TileIndex tile, Industry *ind
 	: ResolverObject(GetGrffile(type), callback, callback_param1, callback_param2),
 	industries_scope(*this, tile, indus, type, random_bits)
 {
-	this->root_spritegroup = GetIndustrySpec(type)->grf_prop.spritegroup[0];
+	this->root_spritegroup = GetIndustrySpec(type)->grf_prop.GetSpriteGroup();
 }
 
 /**

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -142,7 +142,7 @@ IndustryTileResolverObject::IndustryTileResolverObject(IndustryGfx gfx, TileInde
 	ind_scope(*this, tile, indus, indus->type),
 	gfx(gfx)
 {
-	this->root_spritegroup = GetIndustryTileSpec(gfx)->grf_prop.spritegroup[0];
+	this->root_spritegroup = GetIndustryTileSpec(gfx)->grf_prop.GetSpriteGroup();
 }
 
 GrfSpecFeature IndustryTileResolverObject::GetFeature() const
@@ -314,7 +314,7 @@ static void DoTriggerIndustryTile(TileIndex tile, IndustryTileTrigger trigger, I
 	IndustryGfx gfx = GetIndustryGfx(tile);
 	const IndustryTileSpec *itspec = GetIndustryTileSpec(gfx);
 
-	if (itspec->grf_prop.spritegroup[0] == nullptr) return;
+	if (itspec->grf_prop.GetSpriteGroup() == nullptr) return;
 
 	IndustryTileResolverObject object(gfx, tile, ind, CBID_RANDOM_TRIGGER);
 	object.waiting_triggers = GetIndustryTriggers(tile) | trigger;

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -378,8 +378,8 @@ ObjectResolverObject::ObjectResolverObject(const ObjectSpec *spec, Object *obj, 
 		CallbackID callback, uint32_t param1, uint32_t param2)
 	: ResolverObject(spec->grf_prop.grffile, callback, param1, param2), object_scope(*this, obj, spec, tile, view)
 {
-	this->root_spritegroup = (obj == nullptr && spec->grf_prop.spritegroup[OBJECT_SPRITE_GROUP_PURCHASE] != nullptr) ?
-			spec->grf_prop.spritegroup[OBJECT_SPRITE_GROUP_PURCHASE] : spec->grf_prop.spritegroup[OBJECT_SPRITE_GROUP_DEFAULT];
+	this->root_spritegroup = (obj == nullptr) ? spec->grf_prop.GetSpriteGroup(OBJECT_SPRITE_GROUP_PURCHASE) : nullptr;
+	if (this->root_spritegroup == nullptr) this->root_spritegroup = spec->grf_prop.GetSpriteGroup(OBJECT_SPRITE_GROUP_DEFAULT);
 }
 
 /**

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -58,7 +58,7 @@ DECLARE_INCREMENT_DECREMENT_OPERATORS(ObjectClassID)
  */
 struct ObjectSpec : NewGRFSpecBase<ObjectClassID> {
 	/* 2 because of the "normal" and "buy" sprite stacks. */
-	GRFFilePropsBase<2> grf_prop; ///< Properties related the the grf file
+	FixedGRFFileProps<2> grf_prop; ///< Properties related the the grf file
 	AnimationInfo animation;      ///< Information about the animation.
 	StringID name;                ///< The name for this object.
 

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -140,7 +140,7 @@ struct RoadStopSpec : NewGRFSpecBase<RoadStopClassID> {
 	 * Used for obtaining the sprite offset of custom sprites, and for
 	 * evaluating callbacks.
 	 */
-	GRFFilePropsBase<NUM_CARGO + 3> grf_prop;
+	VariableGRFFileProps grf_prop;
 	StringID name;              ///< Name of this stop
 
 	RoadStopAvailabilityType stop_type = ROADSTOPTYPE_ALL;

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -125,7 +125,7 @@ struct StationSpec : NewGRFSpecBase<StationClassID> {
 	 * Used for obtaining the sprite offset of custom sprites, and for
 	 * evaluating callbacks.
 	 */
-	GRFFilePropsBase<NUM_CARGO + 3> grf_prop;
+	VariableGRFFileProps grf_prop;
 	StringID name;             ///< Name of this station.
 
 	/**

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3130,7 +3130,7 @@ static void DrawTile_Station(TileInfo *ti)
 		gfx = GetAirportGfx(ti->tile);
 		if (gfx >= NEW_AIRPORTTILE_OFFSET) {
 			const AirportTileSpec *ats = AirportTileSpec::Get(gfx);
-			if (ats->grf_prop.spritegroup[0] != nullptr && DrawNewAirportTile(ti, Station::GetByTile(ti->tile), ats)) {
+			if (ats->grf_prop.GetSpriteGroup() != nullptr && DrawNewAirportTile(ti, Station::GetByTile(ti->tile), ats)) {
 				return;
 			}
 			/* No sprite group (or no valid one) found, meaning no graphics associated.

--- a/src/table/object_land.h
+++ b/src/table/object_land.h
@@ -121,7 +121,7 @@ static const DrawTileSpriteSpan _object_hq[] = {
 
 #undef TILE_SPRITE_LINE
 
-#define M(name, size, build_cost_multiplier, clear_cost_multiplier, height, climate, gen_amount, flags) {{INVALID_OBJECT_CLASS, 0}, GRFFilePropsBase<2>(), {0, 0, 0, 0}, name, climate, size, build_cost_multiplier, clear_cost_multiplier, TimerGameCalendar::Date{}, CalendarTime::MAX_DATE + 1, flags, ObjectCallbackMasks{}, height, 1, gen_amount}
+#define M(name, size, build_cost_multiplier, clear_cost_multiplier, height, climate, gen_amount, flags) {{INVALID_OBJECT_CLASS, 0}, FixedGRFFileProps<2>{}, {0, 0, 0, 0}, name, climate, size, build_cost_multiplier, clear_cost_multiplier, TimerGameCalendar::Date{}, CalendarTime::MAX_DATE + 1, flags, ObjectCallbackMasks{}, height, 1, gen_amount}
 
 /* Climates
  * T = Temperate

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -273,7 +273,7 @@ static void DrawTile_Town(TileInfo *ti)
 		/* Houses don't necessarily need new graphics. If they don't have a
 		 * spritegroup associated with them, then the sprite for the substitute
 		 * house id is drawn instead. */
-		if (HouseSpec::Get(house_id)->grf_prop.spritegroup[0] != nullptr) {
+		if (HouseSpec::Get(house_id)->grf_prop.GetSpriteGroup() != nullptr) {
 			DrawNewHouseTile(ti, house_id);
 			return;
 		} else {
@@ -334,7 +334,7 @@ static Foundation GetFoundation_Town(TileIndex tile, Slope tileh)
 	 */
 	if (hid >= NEW_HOUSE_OFFSET) {
 		const HouseSpec *hs = HouseSpec::Get(hid);
-		if (hs->grf_prop.spritegroup[0] != nullptr && hs->callback_mask.Test(HouseCallbackMask::DrawFoundations)) {
+		if (hs->grf_prop.GetSpriteGroup() != nullptr && hs->callback_mask.Test(HouseCallbackMask::DrawFoundations)) {
 			uint32_t callback_res = GetHouseCallback(CBID_HOUSE_DRAW_FOUNDATIONS, 0, 0, hid, Town::GetByTile(tile), tile);
 			if (callback_res != CALLBACK_FAILED && !ConvertBooleanCallback(hs->grf_prop.grffile, CBID_HOUSE_DRAW_FOUNDATIONS, callback_res)) return FOUNDATION_NONE;
 		}

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1410,7 +1410,7 @@ void DrawHouseInGUI(int x, int y, HouseID house_id, int view)
 			 * spritegroup associated with them, then the sprite for the substitute
 			 * house id is drawn instead. */
 			const HouseSpec *spec = HouseSpec::Get(house_id);
-			if (spec->grf_prop.spritegroup[0] != nullptr) {
+			if (spec->grf_prop.GetSpriteGroup() != nullptr) {
 				DrawNewHouseTileInGUI(x, y, spec, house_id, view);
 				return;
 			} else {


### PR DESCRIPTION

<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When `NUM_CARGO` was increased from 32 to 64 slots, a number of fixed-length arrays also doubled in size without being noticed.

For features that allow a per-cargotype `SpriteGroup` (`Engine`, `StationSpec`, and `RoadStopSpec`), the fixed length array to list these grew to 512 bytes.

Most sets never even provide custom per-cargotype `SpriteGroups`, let alone 64, as it is common practice with NML-created NewGRFs to select different cargotype graphics in an Action 2 switch instead of in Action 3.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add and use `VariableGRFFileProps` for features that support per-cargotype `SpriteGroup`s. This stores only the cargo type and its `SpriteGroup` for those which are assigned, slots are only allocated when used instead of being reserved.

In most cases, only two slots are ever used, and they are the non-cargotype DEFAULT and PURCHASE slots.

This reduces the size of Engine from 720 bytes to 216 bytes, although of course extra memory is allocated for the vector of `VariableGRFFileProps`. `StationSpec` and `RoadStopSpec` each reduce by 504 bytes as well.

Fixed-size array-based GrfProps are still used when the number of options is more limited (i.e. all non-cargotype based features.)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
