### PR TITLE
Fix #12555: Use generic numbers instead of racial terms for face ethnicity/skin colour

### DIFF
--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -1203,10 +1203,6 @@ static constexpr NWidgetPart _nested_select_company_manager_face_widgets[] = {
 							NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_SCMF_MALE2), SetFill(1, 0), SetStringTip(STR_FACE_MALE_BUTTON, STR_FACE_MALE_TOOLTIP),
 							NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_SCMF_FEMALE2), SetFill(1, 0), SetStringTip(STR_FACE_FEMALE_BUTTON, STR_FACE_FEMALE_TOOLTIP),
 						EndContainer(),
-						NWidget(NWID_HORIZONTAL, NWidContainerFlag::EqualSize),
-							NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_SCMF_ETHNICITY_EUR), SetFill(1, 0), SetStringTip(STR_FACE_EUROPEAN, STR_FACE_EUROPEAN_TOOLTIP),
-							NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_SCMF_ETHNICITY_AFR), SetFill(1, 0), SetStringTip(STR_FACE_AFRICAN, STR_FACE_AFRICAN_TOOLTIP),
-						EndContainer(),
 						NWidget(NWID_VERTICAL),
 							NWidget(NWID_HORIZONTAL), SetPIP(0, WidgetDimensions::unscaled.hsep_normal, 0),
 								NWidget(WWT_TEXT, INVALID_COLOUR, WID_SCMF_HAS_MOUSTACHE_EARRING_TEXT), SetFill(1, 0),
@@ -1220,6 +1216,15 @@ static constexpr NWidgetPart _nested_select_company_manager_face_widgets[] = {
 							EndContainer(),
 						EndContainer(),
 						NWidget(NWID_VERTICAL),
+							NWidget(NWID_HORIZONTAL), SetPIP(0, WidgetDimensions::unscaled.hsep_normal, 0),
+								NWidget(WWT_TEXT, INVALID_COLOUR, WID_SCMF_SKIN_COLOUR_TEXT), SetFill(1, 0),
+									SetStringTip(STR_FACE_SKIN_COLOUR), SetTextStyle(TC_GOLD), SetAlignment(SA_VERT_CENTER | SA_RIGHT),
+								NWidget(NWID_HORIZONTAL),
+									NWidget(WWT_PUSHARROWBTN, COLOUR_GREY, WID_SCMF_SKIN_COLOUR_L), SetArrowWidgetTypeTip(AWV_DECREASE, STR_FACE_SKIN_COLOUR_TOOLTIP),
+									NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SCMF_SKIN_COLOUR), SetStringTip(STR_JUST_STRING1, STR_FACE_SKIN_COLOUR_TOOLTIP), SetTextStyle(TC_WHITE),
+									NWidget(WWT_PUSHARROWBTN, COLOUR_GREY, WID_SCMF_SKIN_COLOUR_R), SetArrowWidgetTypeTip(AWV_INCREASE, STR_FACE_SKIN_COLOUR_TOOLTIP),
+								EndContainer(),
+							EndContainer(),
 							NWidget(NWID_HORIZONTAL), SetPIP(0, WidgetDimensions::unscaled.hsep_normal, 0),
 								NWidget(WWT_TEXT, INVALID_COLOUR, WID_SCMF_HAIR_TEXT), SetFill(1, 0),
 										SetStringTip(STR_FACE_HAIR), SetTextStyle(TC_GOLD), SetAlignment(SA_VERT_CENTER | SA_RIGHT),
@@ -1463,6 +1468,7 @@ public:
 			case WID_SCMF_COLLAR:
 			case WID_SCMF_TIE_EARRING:
 			case WID_SCMF_GLASSES:
+			case WID_SCMF_SKIN_COLOUR:
 				size = this->number_dim;
 				break;
 		}
@@ -1475,11 +1481,6 @@ public:
 		this->SetWidgetsLoweredState( this->is_female, WID_SCMF_FEMALE, WID_SCMF_FEMALE2);
 
 		/* advanced company manager face selection window */
-
-		/* lower the non-selected ethnicity button */
-		this->SetWidgetLoweredState(WID_SCMF_ETHNICITY_EUR, !HasBit(this->ge, ETHNICITY_BLACK));
-		this->SetWidgetLoweredState(WID_SCMF_ETHNICITY_AFR,  HasBit(this->ge, ETHNICITY_BLACK));
-
 
 		/* Disable dynamically the widgets which CompanyManagerFaceVariable has less than 2 options
 		 * (or in other words you haven't any choice).
@@ -1587,6 +1588,10 @@ public:
 			case WID_SCMF_COLLAR:
 				this->SetFaceStringParameters(WID_SCMF_COLLAR,      GetCompanyManagerFaceBits(this->face, CMFV_COLLAR,      this->ge), false);
 				break;
+
+			case WID_SCMF_SKIN_COLOUR:
+				this->SetFaceStringParameters(WID_SCMF_SKIN_COLOUR, GetCompanyManagerFaceBits(this->face, CMFV_ETHNICITY,   this->ge), false);
+				break;
 		}
 	}
 
@@ -1659,13 +1664,17 @@ public:
 				break;
 
 			/* Toggle ethnicity (european/african) button */
-			case WID_SCMF_ETHNICITY_EUR:
-			case WID_SCMF_ETHNICITY_AFR:
-				SetCompanyManagerFaceBits(this->face, CMFV_ETHNICITY, this->ge, widget - WID_SCMF_ETHNICITY_EUR);
+			case WID_SCMF_SKIN_COLOUR_L:
+			case WID_SCMF_SKIN_COLOUR:
+			case WID_SCMF_SKIN_COLOUR_R:
+			{
+				uint current_ethnicity = GetCompanyManagerFaceBits(this->face, CMFV_ETHNICITY, this->ge);
+				SetCompanyManagerFaceBits(this->face, CMFV_ETHNICITY, this->ge, !current_ethnicity);
 				ScaleAllCompanyManagerFaceBits(this->face);
 				this->UpdateData();
 				this->SetDirty();
 				break;
+			}
 
 			default:
 				/* Here all buttons from WID_SCMF_HAS_MOUSTACHE_EARRING to WID_SCMF_GLASSES_R are handled.

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2347,13 +2347,11 @@ STR_FACE_FACECODE_ERR                                           :{WHITE}Couldn't
 STR_FACE_SAVE                                                   :{BLACK}Save
 STR_FACE_SAVE_TOOLTIP                                           :{BLACK}Save favourite face
 STR_FACE_SAVE_DONE                                              :{WHITE}This face will be saved as your favourite in the OpenTTD configuration file
-STR_FACE_EUROPEAN                                               :{BLACK}European
-STR_FACE_EUROPEAN_TOOLTIP                                       :{BLACK}Select European faces
-STR_FACE_AFRICAN                                                :{BLACK}African
-STR_FACE_AFRICAN_TOOLTIP                                        :{BLACK}Select African faces
 STR_FACE_YES                                                    :Yes
 STR_FACE_NO                                                     :No
 STR_FACE_MOUSTACHE_EARRING_TOOLTIP                              :{BLACK}Enable moustache or earring
+STR_FACE_SKIN_COLOUR                                            :Skin colour:
+STR_FACE_SKIN_COLOUR_TOOLTIP                                    :{BLACK}Change skin colour
 STR_FACE_HAIR                                                   :Hair:
 STR_FACE_HAIR_TOOLTIP                                           :{BLACK}Change hair
 STR_FACE_EYEBROWS                                               :Eyebrows:

--- a/src/widgets/company_widget.h
+++ b/src/widgets/company_widget.h
@@ -98,7 +98,7 @@ enum SelectCompanyLiveryWidgets : WidgetID {
 /**
  * Widgets of the #SelectCompanyManagerFaceWindow class.
  * Do not change the order of the widgets from WID_SCMF_HAS_MOUSTACHE_EARRING to WID_SCMF_GLASSES_R,
- * this order is needed for the WE_CLICK event of DrawFaceStringLabel().
+ * this order is needed for the OnClick event of SelectCompanyManagerFaceWindow().
  */
 enum SelectCompanyManagerFaceWidgets : WidgetID {
 	WID_SCMF_CAPTION,                    ///< Caption of window.
@@ -131,8 +131,7 @@ enum SelectCompanyManagerFaceWidgets : WidgetID {
 	WID_SCMF_CHIN_TEXT,                  ///< Text about chin.
 	WID_SCMF_JACKET_TEXT,                ///< Text about jacket.
 	WID_SCMF_COLLAR_TEXT,                ///< Text about collar.
-	WID_SCMF_ETHNICITY_EUR,              ///< Text about ethnicity european.
-	WID_SCMF_ETHNICITY_AFR,              ///< Text about ethnicity african.
+	WID_SCMF_SKIN_COLOUR_TEXT,           ///< Text about skin colour.
 	WID_SCMF_HAS_MOUSTACHE_EARRING,      ///< Has moustache or earring.
 	WID_SCMF_HAS_GLASSES,                ///< Has glasses.
 	WID_SCMF_EYECOLOUR_L,                ///< Eyecolour left.
@@ -165,6 +164,9 @@ enum SelectCompanyManagerFaceWidgets : WidgetID {
 	WID_SCMF_GLASSES_L,                  ///< Glasses left.
 	WID_SCMF_GLASSES,                    ///< Glasses.
 	WID_SCMF_GLASSES_R,                  ///< Glasses right.
+	WID_SCMF_SKIN_COLOUR_L,              ///< Skin colour left.
+	WID_SCMF_SKIN_COLOUR,                ///< Skin colour.
+	WID_SCMF_SKIN_COLOUR_R,              ///< Skin colour right.
 };
 
 /** Widgets of the #CompanyInfrastructureWindow class. */


### PR DESCRIPTION
## Motivation / Problem
"European" / "African" used as the two categories for the ethnicity/skin colour of manager faces.

## Description
Replace those terms with generic numbers 1 / 2 similar to most other options on the face. Fixes #12555.

![image](https://github.com/user-attachments/assets/da3b1110-bf37-4b09-b75b-cb1b81940df0)



## Limitations
- Old terms still used in the code.
- Players might wonder why changing the skin colour changes various other parts of the appearance at the same time. (Because ethnicity and gender are more overarching than the other options.)
- Not the best looking code at line 1670.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
