### PR TITLE
Add: Show cargo types produced by building in house picker.

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2859,6 +2859,7 @@ STR_HOUSE_PICKER_YEARS_FROM                                     :{BLACK}Years: {
 STR_HOUSE_PICKER_YEARS_UNTIL                                    :{BLACK}Years: {ORANGE}Until {NUM}
 STR_HOUSE_PICKER_SIZE                                           :{BLACK}Size: {ORANGE}{NUM}x{NUM} tiles
 STR_HOUSE_PICKER_CARGO_ACCEPTED                                 :{BLACK}Cargo accepted: {ORANGE}
+STR_HOUSE_PICKER_CARGO_PRODUCED                                 :{BLACK}Cargo produced: {ORANGE}
 
 STR_HOUSE_PICKER_CLASS_ZONE1                                    :Edge
 STR_HOUSE_PICKER_CLASS_ZONE2                                    :Outskirts

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1626,6 +1626,39 @@ public:
 };
 /* static */ HousePickerCallbacks HousePickerCallbacks::instance;
 
+/**
+ * Get the cargo types produced by a house.
+ * @param hs HouseSpec of the house.
+ * @returns CargoArray of cargo types produced by the house.
+ */
+static CargoArray GetProducedCargoOfHouse(const HouseSpec *hs)
+{
+	/* We don't care how much cargo is produced, but BuildCargoAcceptanceString shows fractions when less then 8. */
+	static const uint MIN_CARGO = 8;
+
+	CargoArray production;
+	if (hs->callback_mask.Test(HouseCallbackMask::ProduceCargo)) {
+		for (uint i = 0; i < 256; i++) {
+			uint16_t callback = GetHouseCallback(CBID_HOUSE_PRODUCE_CARGO, i, 0, hs->Index(), nullptr, INVALID_TILE, true);
+
+			if (callback == CALLBACK_FAILED || callback == CALLBACK_HOUSEPRODCARGO_END) break;
+
+			CargoType cargo = GetCargoTranslation(GB(callback, 8, 7), hs->grf_prop.grffile);
+			if (!IsValidCargoType(cargo)) continue;
+
+			uint amt = GB(callback, 0, 8);
+			if (amt == 0) continue;
+
+			production[cargo] = MIN_CARGO;
+		}
+	} else {
+		/* Cargo is not controlled by NewGRF, town production effect is used instead. */
+		for (const CargoSpec *cs : CargoSpec::town_production_cargoes[TPE_PASSENGERS]) production[cs->Index()] = MIN_CARGO;
+		for (const CargoSpec *cs : CargoSpec::town_production_cargoes[TPE_MAIL]) production[cs->Index()] = MIN_CARGO;
+	}
+	return production;
+}
+
 struct BuildHouseWindow : public PickerWindow {
 	std::string house_info;
 	bool house_protected;
@@ -1699,10 +1732,18 @@ struct BuildHouseWindow : public PickerWindow {
 		if (hs->building_flags.Test(BuildingFlag::Size1x2)) size = 0x12;
 		if (hs->building_flags.Test(BuildingFlag::Size2x2)) size = 0x22;
 		line << GetString(STR_HOUSE_PICKER_SIZE, GB(size, 0, 4), GB(size, 4, 4));
-		line << "\n";
 
 		auto cargo_string = BuildCargoAcceptanceString(GetAcceptedCargoOfHouse(hs), STR_HOUSE_PICKER_CARGO_ACCEPTED);
-		if (cargo_string.has_value()) line << *cargo_string;
+		if (cargo_string.has_value()) {
+			line << "\n";
+			line << *cargo_string;
+		}
+
+		cargo_string = BuildCargoAcceptanceString(GetProducedCargoOfHouse(hs), STR_HOUSE_PICKER_CARGO_PRODUCED);
+		if (cargo_string.has_value()) {
+			line << "\n";
+			line << *cargo_string;
+		}
 
 		return line.str();
 	}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

We show accepted cargo in the house picker, but not produced cargo. Most of the time this is Passengers and Mail, but sometimes it isn't.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add a line to the house information showing the cargo types produced by the house.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

If the house uses callbacks, this will be tested. Because the house doesn't exist, it is possible that the result of the callback is different than what it would actually be.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
