### PR TITLE
Codefix: 'Declaration hides variable'

### DIFF
--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -666,7 +666,7 @@ static CommandCost ReplaceChain(Vehicle **chain, DoCommandFlags flags, bool wago
 			 * Note: The vehicle attach callback is disabled here :) */
 			if (!flags.Test(DoCommandFlag::Execute)) {
 				/* Separate the head, so we can reattach the old vehicles */
-				Train *second = Train::From(old_head)->GetNextUnit();
+				second = Train::From(old_head)->GetNextUnit();
 				if (second != nullptr) CmdMoveVehicle(second, nullptr, {DoCommandFlag::Execute, DoCommandFlag::AutoReplace}, true);
 
 				assert(Train::From(old_head)->GetNextUnit() == nullptr);

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -259,8 +259,7 @@ std::optional<FileHandle> FioFOpenFile(const std::string &filename, const char *
 		/* Resolve ".." */
 		std::istringstream ss(resolved_name);
 		std::vector<std::string> tokens;
-		std::string token;
-		while (std::getline(ss, token, PATHSEPCHAR)) {
+		for (std::string token; std::getline(ss, token, PATHSEPCHAR); /* nothing */) {
 			if (token == "..") {
 				if (tokens.size() < 2) return std::nullopt;
 				tokens.pop_back();

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1770,8 +1770,7 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 	i->type = type;
 
 	auto &industries = Industry::industries[type];
-	auto it = std::ranges::lower_bound(industries, i->index);
-	it = industries.emplace(it, i->index);
+	industries.emplace(std::ranges::lower_bound(industries, i->index), i->index);
 
 	for (size_t index = 0; index < std::size(indspec->produced_cargo); ++index) {
 		if (!IsValidCargoType(indspec->produced_cargo[index])) break;


### PR DESCRIPTION
## Motivation / Problem

CodeQL noting that there are variables with the same name, where one would hide the other.


## Description

Mostly reducing scope. And reusing in case of `second` as that's conceptually the same vehicle anyway.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
