### PR TITLE
Codefix: 'Short global name'

### DIFF
--- a/src/genworld.h
+++ b/src/genworld.h
@@ -57,17 +57,6 @@ static const uint MAP_HEIGHT_LIMIT_AUTO_CEILING_ROOM = 15; ///< When map height 
 typedef void GWDoneProc();  ///< Procedure called when the genworld process finishes
 typedef void GWAbortProc(); ///< Called when genworld is aborted
 
-/** Properties of current genworld process */
-struct GenWorldInfo {
-	bool abort;            ///< Whether to abort the thread ASAP
-	GenWorldMode mode;     ///< What mode are we making a world in
-	CompanyID lc;          ///< The local_company before generating
-	uint size_x;           ///< X-size of the map
-	uint size_y;           ///< Y-size of the map
-	GWDoneProc *proc;      ///< Proc that is called when done (can be nullptr)
-	GWAbortProc *abortp;   ///< Proc that is called when aborting (can be nullptr)
-};
-
 /** Current stage of world generation process */
 enum GenWorldProgress : uint8_t {
 	GWP_MAP_INIT,    ///< Initialize/allocate the map, start economy

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -1334,13 +1334,11 @@ static WindowDesc _generate_progress_desc(
 );
 
 struct GenWorldStatus {
-	uint percent;
-	StringID cls;
-	uint current;
-	uint total;
+	static inline uint percent;
+	static inline StringID cls;
+	static inline uint current;
+	static inline uint total;
 };
-
-static GenWorldStatus _gws;
 
 static const StringID _generation_class_table[]  = {
 	STR_GENERATION_WORLD_GENERATION,
@@ -1418,19 +1416,19 @@ struct GenerateProgressWindow : public Window {
 				/* Draw the % complete with a bar and a text */
 				DrawFrameRect(r, COLOUR_GREY, {FrameFlag::BorderOnly, FrameFlag::Lowered});
 				Rect br = r.Shrink(WidgetDimensions::scaled.bevel);
-				DrawFrameRect(br.WithWidth(br.Width() * _gws.percent / 100, _current_text_dir == TD_RTL), COLOUR_MAUVE, {});
-				SetDParam(0, _gws.percent);
+				DrawFrameRect(br.WithWidth(br.Width() * GenWorldStatus::percent / 100, _current_text_dir == TD_RTL), COLOUR_MAUVE, {});
+				SetDParam(0, GenWorldStatus::percent);
 				DrawString(br.left, br.right, CenterBounds(br.top, br.bottom, GetCharacterHeight(FS_NORMAL)), STR_GENERATION_PROGRESS, TC_FROMSTRING, SA_HOR_CENTER);
 				break;
 			}
 
 			case WID_GP_PROGRESS_TEXT:
 				/* Tell which class we are generating */
-				DrawString(r.left, r.right, r.top, _gws.cls, TC_FROMSTRING, SA_HOR_CENTER);
+				DrawString(r.left, r.right, r.top, GenWorldStatus::cls, TC_FROMSTRING, SA_HOR_CENTER);
 
 				/* And say where we are in that class */
-				SetDParam(0, _gws.current);
-				SetDParam(1, _gws.total);
+				SetDParam(0, GenWorldStatus::current);
+				SetDParam(1, GenWorldStatus::total);
 				DrawString(r.left, r.right, r.top + GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.vsep_normal, STR_GENERATION_PROGRESS_NUM, TC_FROMSTRING, SA_HOR_CENTER);
 		}
 	}
@@ -1441,10 +1439,10 @@ struct GenerateProgressWindow : public Window {
  */
 void PrepareGenerateWorldProgress()
 {
-	_gws.cls = STR_GENERATION_WORLD_GENERATION;
-	_gws.current = 0;
-	_gws.total = 0;
-	_gws.percent = 0;
+	GenWorldStatus::cls = STR_GENERATION_WORLD_GENERATION;
+	GenWorldStatus::current = 0;
+	GenWorldStatus::total = 0;
+	GenWorldStatus::percent = 0;
 }
 
 /**
@@ -1474,33 +1472,33 @@ static void _SetGeneratingWorldProgress(GenWorldProgress cls, uint progress, uin
 	}
 
 	if (total == 0) {
-		assert(_gws.cls == _generation_class_table[cls]);
-		_gws.current += progress;
-		assert(_gws.current <= _gws.total);
+		assert(GenWorldStatus::cls == _generation_class_table[cls]);
+		GenWorldStatus::current += progress;
+		assert(GenWorldStatus::current <= GenWorldStatus::total);
 	} else {
-		_gws.cls     = _generation_class_table[cls];
-		_gws.current = progress;
-		_gws.total   = total;
-		_gws.percent = percent_table[cls];
+		GenWorldStatus::cls     = _generation_class_table[cls];
+		GenWorldStatus::current = progress;
+		GenWorldStatus::total   = total;
+		GenWorldStatus::percent = percent_table[cls];
 	}
 
 	/* Percentage is about the number of completed tasks, so 'current - 1' */
-	_gws.percent = percent_table[cls] + (percent_table[cls + 1] - percent_table[cls]) * (_gws.current == 0 ? 0 : _gws.current - 1) / _gws.total;
+	GenWorldStatus::percent = percent_table[cls] + (percent_table[cls + 1] - percent_table[cls]) * (GenWorldStatus::current == 0 ? 0 : GenWorldStatus::current - 1) / GenWorldStatus::total;
 
 	if (_network_dedicated) {
 		static uint last_percent = 0;
 
 		/* Never display 0% */
-		if (_gws.percent == 0) return;
+		if (GenWorldStatus::percent == 0) return;
 		/* Reset if percent is lower than the last recorded */
-		if (_gws.percent < last_percent) last_percent = 0;
+		if (GenWorldStatus::percent < last_percent) last_percent = 0;
 		/* Display every 5%, but 6% is also very valid.. just not smaller steps than 5% */
-		if (_gws.percent % 5 != 0 && _gws.percent <= last_percent + 5) return;
+		if (GenWorldStatus::percent % 5 != 0 && GenWorldStatus::percent <= last_percent + 5) return;
 		/* Never show steps smaller than 2%, even if it is a mod 5% */
-		if (_gws.percent <= last_percent + 2) return;
+		if (GenWorldStatus::percent <= last_percent + 2) return;
 
-		Debug(net, 3, "Map generation percentage complete: {}", _gws.percent);
-		last_percent = _gws.percent;
+		Debug(net, 3, "Map generation percentage complete: {}", GenWorldStatus::percent);
+		last_percent = GenWorldStatus::percent;
 
 		return;
 	}


### PR DESCRIPTION
## Motivation / Problem

CodeQL doesn't like very short global names, and would agree that descriptive names are more useful than `_gw` or `_gws`.

When looking at the code there's also a whole discussion that `_gw` should only be used in 'genworld.cpp' and 'genwold.h', and not outside of that. Yet, it's not even used in `genworld.h`, so why wasn't it static in the first place?


## Description

Move the `struct` belonging to `_gw` from 'genworld.h' to 'genworld.cpp'.

Make all variables in the `struct`s of `_gw` and `_gws` `static inline`, and access those instead of keeping `_gw` and `_gws`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
