### PR TITLE
Add #13519, e4c511d: [Script] Saveload and config file support for handpicked configs

### DIFF
--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -203,21 +203,21 @@
 	for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 		if (_settings_game.script_config.ai[c] != nullptr && _settings_game.script_config.ai[c]->HasScript()) {
 			if (!_settings_game.script_config.ai[c]->ResetInfo(true)) {
-				Debug(script, 0, "After a reload, the AI by the name '{}' was no longer found, and removed from the list.", _settings_game.script_config.ai[c]->GetName());
+				Debug(script, 0, "After a reload, the AI by the name '{}' with version {} was no longer found, and removed from the list.", _settings_game.script_config.ai[c]->GetName(), _settings_game.script_config.ai[c]->GetVersion());
 				_settings_game.script_config.ai[c]->Change(std::nullopt);
 			}
 		}
 
 		if (_settings_newgame.script_config.ai[c] != nullptr && _settings_newgame.script_config.ai[c]->HasScript()) {
-			if (!_settings_newgame.script_config.ai[c]->ResetInfo(false)) {
-				Debug(script, 0, "After a reload, the AI by the name '{}' was no longer found, and removed from the list.", _settings_newgame.script_config.ai[c]->GetName());
+			if (!_settings_newgame.script_config.ai[c]->ResetInfo(_settings_newgame.script_config.ai[c]->IsVersionEnforced())) {
+				Debug(script, 0, "After a reload, the AI by the name '{}' with version {} was no longer found, and removed from the list.", _settings_newgame.script_config.ai[c]->GetName(), _settings_game.script_config.ai[c]->GetVersion());
 				_settings_newgame.script_config.ai[c]->Change(std::nullopt);
 			}
 		}
 
 		if (Company::IsValidAiID(c) && Company::Get(c)->ai_config != nullptr) {
 			AIConfig *config = Company::Get(c)->ai_config.get();
-			if (!config->ResetInfo(true)) {
+			if (!config->ResetInfo(_settings_newgame.script_config.ai[c]->IsVersionEnforced())) {
 				/* The code belonging to an already running AI was deleted. We can only do
 				 * one thing here to keep everything sane and that is kill the AI. After
 				 * killing the offending AI we start a random other one in it's place, just

--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -169,8 +169,11 @@ struct AIConfigWindow : public Window {
 	std::string GetSlotText(CompanyID cid) const
 	{
 		if ((_game_mode != GM_NORMAL && cid == 0) || (_game_mode == GM_NORMAL && Company::IsValidHumanID(cid))) return GetString(STR_AI_CONFIG_HUMAN_PLAYER);
-		if (const AIInfo *info = AIConfig::GetConfig(cid)->GetInfo(); info != nullptr) return info->GetName();
-		return GetString(STR_AI_CONFIG_RANDOM_AI);
+		const AIConfig *config = AIConfig::GetConfig(cid);
+		const AIInfo *info = config->GetInfo();
+		if (info == nullptr) return GetString(STR_AI_CONFIG_RANDOM_AI);
+		if (config->IsVersionEnforced()) return GetString(STR_AI_CONFIG_NAME_VERSION, info->GetName(), info->GetVersion());
+		return info->GetName();
 	}
 
 	/**

--- a/src/game/game_core.cpp
+++ b/src/game/game_core.cpp
@@ -159,7 +159,7 @@
 	 *  the GameConfig. If not, remove the Game from the list. */
 	if (_settings_game.script_config.game != nullptr && _settings_game.script_config.game->HasScript()) {
 		if (!_settings_game.script_config.game->ResetInfo(true)) {
-			Debug(script, 0, "After a reload, the GameScript by the name '{}' was no longer found, and removed from the list.", _settings_game.script_config.game->GetName());
+			Debug(script, 0, "After a reload, the GameScript by the name '{}' with version {} was no longer found, and removed from the list.", _settings_game.script_config.game->GetName(), _settings_newgame.script_config.game->GetVersion());
 			_settings_game.script_config.game->Change(std::nullopt);
 			if (Game::instance != nullptr) Game::ResetInstance();
 		} else if (Game::instance != nullptr) {
@@ -167,8 +167,8 @@
 		}
 	}
 	if (_settings_newgame.script_config.game != nullptr && _settings_newgame.script_config.game->HasScript()) {
-		if (!_settings_newgame.script_config.game->ResetInfo(false)) {
-			Debug(script, 0, "After a reload, the GameScript by the name '{}' was no longer found, and removed from the list.", _settings_newgame.script_config.game->GetName());
+		if (!_settings_newgame.script_config.game->ResetInfo(_settings_newgame.script_config.game->IsVersionEnforced())) {
+			Debug(script, 0, "After a reload, the GameScript by the name '{}' with version {} was no longer found, and removed from the list.", _settings_newgame.script_config.game->GetName(), _settings_newgame.script_config.game->GetVersion());
 			_settings_newgame.script_config.game->Change(std::nullopt);
 		}
 	}

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -167,8 +167,11 @@ struct GSConfigWindow : public Window {
 	 */
 	std::string GetText() const
 	{
-		if (const GameInfo *info = GameConfig::GetConfig()->GetInfo(); info != nullptr) return info->GetName();
-		return GetString(STR_AI_CONFIG_NONE);
+		const GameConfig *config = GameConfig::GetConfig();
+		const GameInfo *info = config->GetInfo();
+		if (info == nullptr) return GetString(STR_AI_CONFIG_NONE);
+		if (config->IsVersionEnforced()) return GetString(STR_AI_CONFIG_NAME_VERSION, info->GetName(), info->GetVersion());
+		return info->GetName();
 	}
 
 	void DrawWidget(const Rect &r, WidgetID widget) const override

--- a/src/saveload/ai_sl.cpp
+++ b/src/saveload/ai_sl.cpp
@@ -27,18 +27,21 @@ static std::string _ai_saveload_name;
 static int         _ai_saveload_version;
 static std::string _ai_saveload_settings;
 static bool        _ai_saveload_is_random;
+static bool        _ai_saveload_enforced_version;
 
 static const SaveLoad _ai_company_desc[] = {
 	   SLEG_SSTR("name",      _ai_saveload_name,         SLE_STR),
 	   SLEG_SSTR("settings",  _ai_saveload_settings,     SLE_STR),
 	SLEG_CONDVAR("version",   _ai_saveload_version,   SLE_UINT32, SLV_108, SL_MAX_VERSION),
 	SLEG_CONDVAR("is_random", _ai_saveload_is_random,   SLE_BOOL, SLV_136, SLV_AI_LOCAL_CONFIG),
+	SLEG_CONDVAR("enforced_version", _ai_saveload_enforced_version, SLE_BOOL, SLV_SCRIPT_ENFORCED_VERSION, SL_MAX_VERSION),
 };
 
 static const SaveLoad _ai_running_desc[] = {
 	SLEG_CONDSSTR("running_name",     _ai_saveload_name,        SLE_STR, SLV_AI_LOCAL_CONFIG, SL_MAX_VERSION),
 	SLEG_CONDSSTR("running_settings", _ai_saveload_settings,    SLE_STR, SLV_AI_LOCAL_CONFIG, SL_MAX_VERSION),
 	 SLEG_CONDVAR("running_version",  _ai_saveload_version,  SLE_UINT32, SLV_AI_LOCAL_CONFIG, SL_MAX_VERSION),
+	 SLEG_CONDVAR("running_enforced_version", _ai_saveload_enforced_version, SLE_BOOL, SLV_SCRIPT_ENFORCED_VERSION, SL_MAX_VERSION),
 };
 
 static void SaveReal_AIPL(int arg)
@@ -56,6 +59,7 @@ static void SaveReal_AIPL(int arg)
 	}
 
 	_ai_saveload_settings = config->SettingsToString();
+	_ai_saveload_enforced_version = config->IsVersionEnforced();
 
 	SlObject(nullptr, _ai_company_desc);
 
@@ -66,10 +70,10 @@ static void SaveReal_AIPL(int arg)
 	_ai_saveload_name = config->GetName();
 	_ai_saveload_version = config->GetVersion();
 	_ai_saveload_settings = config->SettingsToString();
+	_ai_saveload_enforced_version = config->IsVersionEnforced();
 
 	SlObject(nullptr, _ai_running_desc);
 	AI::Save(index);
-
 }
 
 struct AIPLChunkHandler : ChunkHandler {
@@ -90,6 +94,7 @@ struct AIPLChunkHandler : ChunkHandler {
 
 			_ai_saveload_is_random = false;
 			_ai_saveload_version = -1;
+			_ai_saveload_enforced_version = false;
 			SlObject(nullptr, slt);
 
 			if (_game_mode == GM_MENU || (_networking && !_network_server)) {
@@ -130,26 +135,34 @@ struct AIPLChunkHandler : ChunkHandler {
 
 			Company::Get(index)->ai_config = std::make_unique<AIConfig>();
 			config = Company::Get(index)->ai_config.get();
-			config->Change(_ai_saveload_name, _ai_saveload_version, false);
+			if (_ai_saveload_enforced_version) config->Change(_ai_saveload_name, _ai_saveload_version, true);
 			if (!config->HasScript()) {
-				/* No version of the AI available that can load the data. Try to load the
-				 * latest version of the AI instead. */
-				config->Change(_ai_saveload_name, -1, false);
+				/* Exact version of the AI is not available. Try to load the highest
+				 * compatible version of the AI instead that can load the data. */
+				config->Change(_ai_saveload_name, _ai_saveload_version, false);
 				if (!config->HasScript()) {
-					if (_ai_saveload_name != "%_dummy") {
-						Debug(script, 0, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
-						Debug(script, 0, "A random other AI will be loaded in its place.");
+					/* No version of the AI available that can load the data. Try to load the
+					 * latest version of the AI instead. */
+					config->Change(_ai_saveload_name, -1, false);
+					if (!config->HasScript()) {
+						if (_ai_saveload_name != "%_dummy") {
+							Debug(script, 0, "The savegame has an AI by the name '{}', {}version {} which is no longer available.", _ai_saveload_name, _ai_saveload_enforced_version ? "forcing " : "", _ai_saveload_version);
+							Debug(script, 0, "A random other AI will be loaded in its place.");
+						} else {
+							Debug(script, 0, "The savegame had no AIs available at the time of saving.");
+							Debug(script, 0, "A random available AI will be loaded now.");
+						}
 					} else {
-						Debug(script, 0, "The savegame had no AIs available at the time of saving.");
-						Debug(script, 0, "A random available AI will be loaded now.");
+						Debug(script, 0, "The savegame has an AI by the name '{}', {}version {} which is no longer available.", _ai_saveload_name, _ai_saveload_enforced_version ? "forcing " : "", _ai_saveload_version);
+						Debug(script, 0, "The latest version of that AI has been loaded instead, but it'll not get the savegame data as it's incompatible.");
 					}
-				} else {
-					Debug(script, 0, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
-					Debug(script, 0, "The latest version of that AI has been loaded instead, but it'll not get the savegame data as it's incompatible.");
+					/* Make sure the AI doesn't get the saveload data, as it was not the
+					 *  writer of the saveload data in the first place */
+					_ai_saveload_version = -1;
+				} else if (_ai_saveload_enforced_version) {
+					Debug(script, 0, "The savegame has an AI by the name '{}', forcing version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
+					Debug(script, 0, "The highest compatible version of that AI has been loaded instead.");
 				}
-				/* Make sure the AI doesn't get the saveload data, as it was not the
-				 *  writer of the saveload data in the first place */
-				_ai_saveload_version = -1;
 			}
 			config->StringToSettings(_ai_saveload_settings);
 			config->SetToLoadData(AIInstance::Load(_ai_saveload_version));

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -25,11 +25,13 @@
 static std::string _game_saveload_name;
 static int         _game_saveload_version;
 static std::string _game_saveload_settings;
+static bool        _game_saveload_enforced_version;
 
 static const SaveLoad _game_script_desc[] = {
 	   SLEG_SSTR("name",      _game_saveload_name,         SLE_STR),
 	   SLEG_SSTR("settings",  _game_saveload_settings,     SLE_STR),
 	    SLEG_VAR("version",   _game_saveload_version,   SLE_UINT32),
+	SLEG_CONDVAR("enforced_version", _game_saveload_enforced_version, SLE_BOOL, SLV_SCRIPT_ENFORCED_VERSION, SL_MAX_VERSION),
 };
 
 static void SaveReal_GSDT(int)
@@ -46,6 +48,7 @@ static void SaveReal_GSDT(int)
 	}
 
 	_game_saveload_settings = config->SettingsToString();
+	_game_saveload_enforced_version = config->IsVersionEnforced();
 
 	SlObject(nullptr, _game_script_desc);
 	Game::Save();
@@ -64,6 +67,7 @@ struct GSDTChunkHandler : ChunkHandler {
 		if (SlIterateArray() == -1) return;
 
 		_game_saveload_version = -1;
+		_game_saveload_enforced_version = false;
 		SlObject(nullptr, slt);
 
 		if (_game_mode == GM_MENU || (_networking && !_network_server)) {
@@ -74,26 +78,34 @@ struct GSDTChunkHandler : ChunkHandler {
 
 		GameConfig *config = GameConfig::GetConfig(GameConfig::SSS_FORCE_GAME);
 		if (!_game_saveload_name.empty()) {
-			config->Change(_game_saveload_name, _game_saveload_version, false);
+			if (_game_saveload_enforced_version) config->Change(_game_saveload_name, _game_saveload_version, true);
 			if (!config->HasScript()) {
-				/* No version of the GameScript available that can load the data. Try to load the
-				 * latest version of the GameScript instead. */
-				config->Change(_game_saveload_name, -1, false);
+				/* Exact version of the GameScript is not available. Try to load the highest
+				 * compatible version of the AI instead that can load the data. */
+				config->Change(_game_saveload_name, _game_saveload_version, false);
 				if (!config->HasScript()) {
-					if (_game_saveload_name != "%_dummy") {
-						Debug(script, 0, "The savegame has an GameScript by the name '{}', version {} which is no longer available.", _game_saveload_name, _game_saveload_version);
-						Debug(script, 0, "This game will continue to run without GameScript.");
+					/* No version of the GameScript available that can load the data. Try to load the
+					 * latest version of the GameScript instead. */
+					config->Change(_game_saveload_name, -1, false);
+					if (!config->HasScript()) {
+						if (_game_saveload_name != "%_dummy") {
+							Debug(script, 0, "The savegame has a GameScript by the name '{}', {}version {} which is no longer available.", _game_saveload_name, _game_saveload_enforced_version ? "forcing " : "", _game_saveload_version);
+							Debug(script, 0, "This game will continue to run without GameScript.");
+						} else {
+							Debug(script, 0, "The savegame had no GameScript available at the time of saving.");
+							Debug(script, 0, "This game will continue to run without GameScript.");
+						}
 					} else {
-						Debug(script, 0, "The savegame had no GameScript available at the time of saving.");
-						Debug(script, 0, "This game will continue to run without GameScript.");
+						Debug(script, 0, "The savegame has a GameScript by the name '{}', {}version {} which is no longer available.", _game_saveload_name, _game_saveload_enforced_version ? "forcing " : "", _game_saveload_version);
+						Debug(script, 0, "The latest version of that GameScript has been loaded instead, but it'll not get the savegame data as it's incompatible.");
 					}
-				} else {
-					Debug(script, 0, "The savegame has an GameScript by the name '{}', version {} which is no longer available.", _game_saveload_name, _game_saveload_version);
-					Debug(script, 0, "The latest version of that GameScript has been loaded instead, but it'll not get the savegame data as it's incompatible.");
+					/* Make sure the GameScript doesn't get the saveload data, as it was not the
+					 *  writer of the saveload data in the first place */
+					_game_saveload_version = -1;
+				} else if (_game_saveload_enforced_version) {
+					Debug(script, 0, "The savegame has a GameScript by the name '{}', forcing version {} which is no longer available.", _game_saveload_name, _game_saveload_version);
+					Debug(script, 0, "The highest compatible version of that GameScript has been loaded instead.");
 				}
-				/* Make sure the GameScript doesn't get the saveload data, as it was not the
-				 *  writer of the saveload data in the first place */
-				_game_saveload_version = -1;
 			}
 		}
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -415,6 +415,8 @@ enum SaveLoadVersion : uint16_t {
 	SLV_SIGN_TEXT_COLOURS,                  ///< 363  PR#14743 Configurable sign text colors in scenario editor.
 	SLV_BUOYS_AT_0_0,                       ///< 364  PR#14983 Allow to build buoys at (0x0).
 
+	SLV_SCRIPT_ENFORCED_VERSION,            ///< 365  PR#13565 Store whether scripts are enforcing a version match in savegames.
+
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
 

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -19,15 +19,16 @@
 
 #include "../safeguards.h"
 
-void ScriptConfig::Change(std::optional<std::string_view> name, int version, bool force_exact_match)
+void ScriptConfig::Change(std::optional<std::string_view> name, int version, bool enforce_version)
 {
 	if (name.has_value()) {
 		this->name = name.value();
-		this->info = this->FindInfo(this->name, version, force_exact_match);
+		this->info = this->FindInfo(this->name, version, enforce_version);
 	} else {
 		this->info = nullptr;
 	}
 	this->version = (info == nullptr) ? -1 : info->GetVersion();
+	this->enforced_version = (info == nullptr) ? false : enforce_version;
 	this->config_list.reset();
 	this->to_load_data.reset();
 
@@ -39,6 +40,7 @@ ScriptConfig::ScriptConfig(const ScriptConfig &config)
 	this->name = config.name;
 	this->info = config.info;
 	this->version = config.version;
+	this->enforced_version = config.enforced_version;
 	this->to_load_data.reset();
 
 	for (const auto &item : config.settings) {
@@ -137,6 +139,11 @@ const std::string &ScriptConfig::GetName() const
 int ScriptConfig::GetVersion() const
 {
 	return this->version;
+}
+
+bool ScriptConfig::IsVersionEnforced() const
+{
+	return this->enforced_version;
 }
 
 void ScriptConfig::StringToSettings(std::string_view value)

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -151,6 +151,12 @@ public:
 	int GetVersion() const;
 
 	/**
+	 * Get whether the config is enforcing a matching version of the Script.
+	 * @return the version enforcement state of this config.
+	 */
+	bool IsVersionEnforced() const;
+
+	/**
 	 * Convert a string which is stored in the config file or savegames to
 	 *  custom settings of this Script.
 	 */
@@ -176,6 +182,7 @@ public:
 protected:
 	std::string name;                                         ///< Name of the Script
 	int version;                                              ///< Version of the Script
+	bool enforced_version;                                    ///< Whether to enforce a Script version match when starting
 	class ScriptInfo *info;                                   ///< ScriptInfo object for related to this Script version
 	SettingValueList settings;                                ///< List with all setting=>value pairs that are configure for this Script
 	std::unique_ptr<ScriptConfigItemList> config_list;        ///< List with all settings defined by this Script
@@ -190,7 +197,7 @@ protected:
 	 * This function should call back to the Scanner in charge of this Config,
 	 *  to find the ScriptInfo belonging to a name+version.
 	 */
-	virtual ScriptInfo *FindInfo(const std::string &name, int version, bool force_exact_match) = 0;
+	virtual ScriptInfo *FindInfo(const std::string &name, int version, bool enforce_version) = 0;
 };
 
 #endif /* SCRIPT_CONFIG_HPP */

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -172,7 +172,7 @@ struct ScriptListWindow : public Window {
 		} else {
 			ScriptInfoList::const_iterator it = this->info_list->cbegin();
 			std::advance(it, this->selected);
-			GetConfig(this->slot)->Change(it->second->GetName(), it->second->GetVersion());
+			GetConfig(this->slot)->Change(it->second->GetName(), it->second->GetVersion(), this->show_all);
 		}
 		if (_game_mode == GM_EDITOR) {
 			if (this->slot == OWNER_DEITY) {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -948,6 +948,28 @@ static void ValidateSettings()
 	}
 }
 
+/**
+ * Try to read the name of a script that may include its name and version in a single string,
+ *  separate the name from the version and return both name as string and version as integer.
+ * @param item_name name of a script which may include version
+ * @return a pair containing the name of the script separated from its version, or the same
+ *  name with an invalid version if no version separator was found.
+ */
+static std::pair<std::string_view, int> TryReadScriptNameWithVersion(std::string_view item_name)
+{
+	StringConsumer consumer{item_name};
+	auto name = consumer.ReadUntilChar('.', StringConsumer::SKIP_ONE_SEPARATOR);
+
+	if (consumer.AnyBytesLeft()) {
+		auto version = consumer.TryReadIntegerBase<uint32_t>(10);
+		if (version.has_value()) {
+			return { name, *version };
+		}
+	}
+
+	return { name, -1 };
+}
+
 static void AILoadConfig(const IniFile &ini, std::string_view grpname)
 {
 	const IniGroup *group = ini.GetGroup(grpname);
@@ -966,9 +988,14 @@ static void AILoadConfig(const IniFile &ini, std::string_view grpname)
 
 		config->Change(item.name);
 		if (!config->HasScript()) {
-			if (item.name != "none") {
-				Debug(script, 0, "The AI by the name '{}' was no longer found, and removed from the list.", item.name);
-				continue;
+			auto [name, version] = TryReadScriptNameWithVersion(item.name);
+			config->Change(name, version, version != -1);
+
+			if (!config->HasScript()) {
+				if (name != "none") {
+					Debug(script, 0, "The AI by the name '{}' was no longer found, and removed from the list.", name);
+					continue;
+				}
 			}
 		}
 		if (item.value.has_value()) config->StringToSettings(*item.value);
@@ -993,9 +1020,14 @@ static void GameLoadConfig(const IniFile &ini, std::string_view grpname)
 
 	config->Change(item.name);
 	if (!config->HasScript()) {
-		if (item.name != "none") {
-			Debug(script, 0, "The GameScript by the name '{}' was no longer found, and removed from the list.", item.name);
-			return;
+		auto [name, version] = TryReadScriptNameWithVersion(item.name);
+		config->Change(name, version, version != -1);
+
+		if (!config->HasScript()) {
+			if (name != "none") {
+				Debug(script, 0, "The GameScript by the name '{}' was no longer found, and removed from the list.", name);
+				return;
+			}
 		}
 	}
 	if (item.value.has_value()) config->StringToSettings(*item.value);
@@ -1184,13 +1216,12 @@ static void AISaveConfig(IniFile &ini, std::string_view grpname)
 
 	for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 		AIConfig *config = AIConfig::GetConfig(c, AIConfig::SSS_FORCE_NEWGAME);
-		std::string name;
+		std::string name = "none";
 		std::string value = config->SettingsToString();
 
 		if (config->HasScript()) {
 			name = config->GetName();
-		} else {
-			name = "none";
+			if (config->IsVersionEnforced()) name = fmt::format("{}.{}", name, config->GetVersion());
 		}
 
 		group.CreateItem(name).SetValue(value);
@@ -1203,13 +1234,12 @@ static void GameSaveConfig(IniFile &ini, std::string_view grpname)
 	group.Clear();
 
 	GameConfig *config = GameConfig::GetConfig(AIConfig::SSS_FORCE_NEWGAME);
-	std::string name;
+	std::string name = "none";
 	std::string value = config->SettingsToString();
 
 	if (config->HasScript()) {
 		name = config->GetName();
-	} else {
-		name = "none";
+		if (config->IsVersionEnforced()) name = fmt::format("{}.{}", name, config->GetVersion());
 	}
 
 	group.CreateItem(name).SetValue(value);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Selecting a specific version of a script ends up choosing the highest version that is compatible with the specified version instead.
There is no way to see which version is currently selected once selected.
Version selected is not stored in savegames.
Version selected does not persist between openttd sessions.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Fixes #13519
Actually select the version chosen of a script, not the highest compatible version.
Display version of scripts next to their names once selected in the AI/GS windows if their version was handpicked.
Add `enforced_version` to ScriptConfig to indicate whether the config is handpicked.
Store `enforced_version` value in savegames.
Append "name.version" as name in config files when their configs are forcing an exact version to match.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Requires savegame bump.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
