### PR TITLE
Codechange: manage the ParagraphLayouter's buffer with std::unique_ptr

### DIFF
--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -8,7 +8,6 @@
 /** @file gfx_layout.cpp Handling of laying out text. */
 
 #include "stdafx.h"
-#include "core/alloc_func.hpp"
 #include "core/math_func.hpp"
 #include "gfx_layout.h"
 #include "string_func.h"
@@ -64,15 +63,15 @@ Font::Font(FontSize size, TextColour colour) :
 template <typename T>
 static inline void GetLayouter(Layouter::LineCacheItem &line, std::string_view str, FontState &state)
 {
-	free(line.buffer);
+	typename T::CharType *buff_begin = new typename T::CharType[str.size() + 1];
+	/* Move ownership of buff_begin into the Buffer/unique_ptr. */
+	line.buffer = Layouter::LineCacheItem::Buffer(buff_begin, [](void *p) { delete[] reinterpret_cast<T::CharType *>(p); });
 
-	typename T::CharType *buff_begin = MallocT<typename T::CharType>(str.size() + 1);
 	const typename T::CharType *buffer_last = buff_begin + str.size() + 1;
 	typename T::CharType *buff = buff_begin;
 	FontMap &font_mapping = line.runs;
 	Font *f = Layouter::GetFont(state.fontsize, state.cur_colour);
 
-	line.buffer = buff_begin;
 	font_mapping.clear();
 
 	auto cur = str.begin();

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -166,15 +166,14 @@ class Layouter : public std::vector<std::unique_ptr<const ParagraphLayouter::Lin
 public:
 	/** Item in the linecache */
 	struct LineCacheItem {
+		/* Due to the type of data in the buffer differing depending on the Layouter, we need to pass our own deleter routine. */
+		using Buffer = std::unique_ptr<void, void(*)(void *)>;
 		/* Stuff that cannot be freed until the ParagraphLayout is freed */
-		void *buffer;              ///< Accessed by our ParagraphLayout::nextLine.
+		Buffer buffer{nullptr, [](void *){}}; ///< Accessed by our ParagraphLayout::nextLine.
 		FontMap runs;              ///< Accessed by our ParagraphLayout::nextLine.
 
 		FontState state_after;     ///< Font state after the line.
 		std::unique_ptr<ParagraphLayouter> layout = nullptr; ///< Layout of the line.
-
-		LineCacheItem() : buffer(nullptr) {}
-		~LineCacheItem() { free(buffer); }
 	};
 private:
 	typedef std::map<LineCacheKey, LineCacheItem, LineCacheCompare> LineCache;


### PR DESCRIPTION
## Motivation / Problem

In the `LineCacheItem` there is a buffer that is managed using `MallocT` and `free`.

However, what is stored in the buffer depends on the `ParagraphLayouter` that fills the data. It could be `wchar_t`, `char32_t`, or anything else. And since these types are coming from third party libraries, we don't have control over them.

This makes a simple `std::unique_ptr` impossible, but `std::unique_ptr` has the ability to store a `Deleter` which we can make use of.


## Description

Replace `MallocT`/`free` with `std::unique_ptr`, but with a twist. Define the `std::unique_ptr` to be of type `void` and declare/implement our own deleter function, so the appropriate `delete[]` gets called that matches the `new[]`.


## Limitations

It's definitely not the prettiest, though I have no idea how to do this more cleanly without pushing these generic bits into the layouter implementations. Any better ideas are very welcome!


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
