### PR TITLE
Codefix 75387b9e2b: Prefer using EnumBitSet.base() instead of shifting StationFacility.

### DIFF
--- a/src/script/api/script_station.hpp
+++ b/src/script/api/script_station.hpp
@@ -44,11 +44,11 @@ public:
 	 */
 	enum StationType {
 		/* Note: these values represent part of the in-game StationFacilities enum */
-		STATION_TRAIN      = (1 << to_underlying(::StationFacility::Train)),     ///< Train station
-		STATION_TRUCK_STOP = (1 << to_underlying(::StationFacility::TruckStop)), ///< Truck station
-		STATION_BUS_STOP   = (1 << to_underlying(::StationFacility::BusStop)),   ///< Bus station
-		STATION_AIRPORT    = (1 << to_underlying(::StationFacility::Airport)),   ///< Airport
-		STATION_DOCK       = (1 << to_underlying(::StationFacility::Dock)),      ///< Dock
+		STATION_TRAIN      = ::StationFacilities{::StationFacility::Train}.base(),     ///< Train station
+		STATION_TRUCK_STOP = ::StationFacilities{::StationFacility::TruckStop}.base(), ///< Truck station
+		STATION_BUS_STOP   = ::StationFacilities{::StationFacility::BusStop}.base(),   ///< Bus station
+		STATION_AIRPORT    = ::StationFacilities{::StationFacility::Airport}.base(),   ///< Airport
+		STATION_DOCK       = ::StationFacilities{::StationFacility::Dock}.base(),      ///< Dock
 		STATION_ANY        = STATION_TRAIN | STATION_TRUCK_STOP | STATION_BUS_STOP | STATION_AIRPORT | STATION_DOCK, ///< All station types
 	};
 

--- a/src/script/api/script_waypoint.hpp
+++ b/src/script/api/script_waypoint.hpp
@@ -41,8 +41,8 @@ public:
 	 */
 	enum WaypointType {
 		/* Note: these values represent part of the in-game StationFacilities enum */
-		WAYPOINT_RAIL      = (1U << to_underlying(::StationFacility::Train)), ///< Rail waypoint
-		WAYPOINT_BUOY      = (1U << to_underlying(::StationFacility::Dock)),  ///< Buoy
+		WAYPOINT_RAIL      = ::StationFacilities{::StationFacility::Train}.base(), ///< Rail waypoint
+		WAYPOINT_BUOY      = ::StationFacilities{::StationFacility::Dock}.base(),  ///< Buoy
 		WAYPOINT_ANY       = WAYPOINT_RAIL | WAYPOINT_BUOY, ///< All waypoint types
 	};
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

75387b9e2b converted the `StationFacility` enum to an EnumBitSet, and used `to_underlying()` along with bitshifts to populate the equivalent values in the script API.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, use the `StationFacilities` type with `.base()`. This avoids the manual bitshifting, and makes it a bit clearer.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
