### PR TITLE
Codechange: do not use ZeroedMemoryAllocator for NewGRFSpriteLayout

### DIFF
--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -20,8 +20,8 @@ typedef uint32_t CursorID;  ///< The number of the cursor (sprite)
 
 /** Combination of a palette sprite and a 'real' sprite */
 struct PalSpriteID {
-	SpriteID sprite;  ///< The 'real' sprite
-	PaletteID pal;    ///< The palette (use \c PAL_NONE) if not needed)
+	SpriteID sprite{};  ///< The 'real' sprite
+	PaletteID pal{};    ///< The palette (use \c PAL_NONE) if not needed)
 };
 
 enum WindowKeyCodes : uint16_t {

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -109,9 +109,9 @@ static const uint TLR_MAX_VAR10 = 7; ///< Maximum value for var 10.
  * In contrast to #DrawTileSprites this struct is for allocated
  * layouts on the heap. It allocates data and frees them on destruction.
  */
-struct NewGRFSpriteLayout : ZeroedMemoryAllocator, DrawTileSprites {
-	std::vector<DrawTileSeqStruct> seq;
-	std::vector<TileLayoutRegisters> registers;
+struct NewGRFSpriteLayout : DrawTileSprites {
+	std::vector<DrawTileSeqStruct> seq{};
+	std::vector<TileLayoutRegisters> registers{};
 
 	/**
 	 * Number of sprites in all referenced spritesets.

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -44,7 +44,7 @@ struct DrawTileSeqStruct {
  * For allocated ones from NewGRF see #NewGRFSpriteLayout.
  */
 struct DrawTileSprites {
-	PalSpriteID ground; ///< Palette and sprite for the ground
+	PalSpriteID ground{}; ///< Palette and sprite for the ground
 
 	DrawTileSprites(PalSpriteID ground) : ground(ground) {}
 	DrawTileSprites() = default;


### PR DESCRIPTION
## Motivation / Problem

With the recent changes the `ZeroedMemoryAllocator` is not needed any more for `NewGRFSpriteLayout`.


## Description

Remove `ZeroedMemoryAllocator` from `NewGRFSpriteLayout` and initialise member variables where applicable.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
