### PR TITLE
Codechange: move vehicle name to LoadgameState and change to std::vector

### DIFF
--- a/src/saveload/oldloader.h
+++ b/src/saveload/oldloader.h
@@ -29,6 +29,9 @@ struct LoadgameState {
 	std::array<uint8_t, BUFFER_SIZE> buffer{};
 
 	uint total_read = 0;
+
+	uint8_t vehicle_multiplier = 1; ///< TTDPatch vehicle multiplier
+	std::vector<StringID> vehicle_names;
 };
 
 /* OldChunk-Type */

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -202,8 +202,8 @@ extern VehiclePool _vehicle_pool;
 /* Some declarations of functions, so we can make them friendly */
 struct GroundVehicleCache;
 struct LoadgameState;
-extern bool LoadOldVehicle(LoadgameState *ls, int num);
-extern void FixOldVehicles();
+extern bool LoadOldVehicle(LoadgameState &ls, int num);
+extern void FixOldVehicles(LoadgameState &ls);
 
 struct GRFFile;
 
@@ -247,7 +247,7 @@ private:
 	Vehicle *previous_shared;           ///< NOSAVE: pointer to the previous vehicle in the shared order chain
 
 public:
-	friend void FixOldVehicles();
+	friend void FixOldVehicles(LoadgameState &ls);
 	friend void AfterLoadVehiclesPhase1(bool part_of_load);       ///< So we can set the #previous and #first pointers while loading
 	friend bool LoadOldVehicle(LoadgameState &ls, int num);       ///< So we can set the proper next pointer while loading
 	/* So we can use private/protected variables in the saveload code */


### PR DESCRIPTION
## Motivation / Problem

Using C-style memory management for loading vehicle names in the old loader.

However, because `_old_vehicle_names` is a global making that `std::vector` would increase the memory usage when the old loader isn't used.  However, there is a `LoadgameState` that only exists during loading old games, so move the vehicle names there.


## Description

Move `_old_vehicle_names` and `_old_vehicle_multiplier` to `LoadgameState`, and make `_old_vehicle_names` a `std::vector`.

Note that for TTO savegames only 800 `StringID`s need to be allocated, but now we'll allocate 850 instead. That makes  the code simpler and the extra `StringID`s won't be accessed as there are no associated vehicles.


## Limitations

There are other variables that could be moved to `LoadgameState`, but I left them out of this PR to keep it small.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
