### PR TITLE
Codechange: Build engine preview strings from separate strings.

### DIFF
--- a/src/engine_gui.h
+++ b/src/engine_gui.h
@@ -34,7 +34,7 @@ void EngList_Sort(GUIEngineList &el, EngList_SortTypeFunction compare);
 void EngList_SortPartial(GUIEngineList &el, EngList_SortTypeFunction compare, size_t begin, size_t num_items);
 
 StringID GetEngineCategoryName(EngineID engine);
-StringID GetEngineInfoString(EngineID engine);
+std::string GetEngineInfoString(EngineID engine);
 
 void DrawVehicleEngine(int left, int right, int preferred_x, int y, EngineID engine, PaletteID pal, EngineImageType image_type);
 void DrawTrainEngine(int left, int right, int preferred_x, int y, EngineID engine, PaletteID pal, EngineImageType image_type);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4337,8 +4337,6 @@ STR_ENGINE_PREVIEW_TRAM_VEHICLE                                 :tramway vehicle
 STR_ENGINE_PREVIEW_AIRCRAFT                                     :aircraft
 STR_ENGINE_PREVIEW_SHIP                                         :ship
 
-STR_ENGINE_PREVIEW_TEXT3                                        :{BLACK}{STRING2}{}{5:STRING1}{}{STRING4}
-STR_ENGINE_PREVIEW_TEXT4                                        :{BLACK}{STRING2}{}{STRING3}{}{STRING1}{}{STRING4}
 STR_ENGINE_PREVIEW_COST_WEIGHT                                  :Cost: {CURRENCY_LONG}  Weight: {WEIGHT_SHORT}
 STR_ENGINE_PREVIEW_COST_MAX_SPEED                               :Cost: {CURRENCY_LONG}  Max. Speed: {VELOCITY}
 STR_ENGINE_PREVIEW_SPEED_POWER                                  :Speed: {VELOCITY}  Power: {POWER}

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -430,7 +430,7 @@ struct NewsWindow : Window {
 
 	void UpdateWidgetSize(WidgetID widget, Dimension &size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension &fill, [[maybe_unused]] Dimension &resize) override
 	{
-		StringID str = STR_NULL;
+		std::string str;
 		switch (widget) {
 			case WID_N_CAPTION: {
 				/* Caption is not a real caption (so that the window cannot be moved)
@@ -447,16 +447,16 @@ struct NewsWindow : Window {
 
 			case WID_N_MESSAGE:
 				CopyInDParam(this->ni->params);
-				str = this->ni->string_id;
+				str = GetString(this->ni->string_id);
 				break;
 
 			case WID_N_COMPANY_MSG:
-				str = this->GetCompanyMessageString();
+				str = GetString(this->GetCompanyMessageString());
 				break;
 
 			case WID_N_VEH_NAME:
 			case WID_N_VEH_TITLE:
-				str = this->GetNewVehicleMessageString(widget);
+				str = GetString(this->GetNewVehicleMessageString(widget));
 				break;
 
 			case WID_N_VEH_INFO: {


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When an engine preview message appears, a string is formatted with a dozen or so global parameters. Some of the parameters are substrings, some of them are conditional, and some are blanked (or just not set.)

The substrings are formatted using an outer string that may or may not use all the parameters.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, build the string up with a stringstream, appending each substring separately with its own parameters.

This replaces stuffing substrings and parameters in various global parameters and uses local parameters instead.

The outer strings are no longer necessary.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
