### PR TITLE
Fix fd2949d: std::string can reallocate on insert()

### DIFF
--- a/src/string_func.h
+++ b/src/string_func.h
@@ -166,9 +166,11 @@ inline const char *Utf8PrevChar(const char *s)
 
 inline std::string::iterator Utf8PrevChar(std::string::iterator &s)
 {
-	auto *cur = &*s;
-	auto *prev = Utf8PrevChar(cur);
-	return s - (cur - prev);
+	auto cur = s;
+	do {
+		cur = std::prev(cur);
+	} while (IsUtf8Part(*cur));
+	return cur;
 }
 
 size_t Utf8StringLength(const char *s);

--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -132,7 +132,7 @@ bool Textbuf::InsertChar(char32_t key)
 	if (this->buf.size() + len < this->max_bytes && this->chars + 1 <= this->max_chars) {
 		/* Make space in the string, then overwrite it with the Utf8 encoded character. */
 		auto pos = this->buf.begin() + this->caretpos;
-		this->buf.insert(pos, len, '\0');
+		pos = this->buf.insert(pos, len, '\0');
 		Utf8Encode(pos, key);
 		this->chars++;
 		this->caretpos += len;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Fixes #13578


## Description

Turns out MSVC can reallocate an std::string on `insert()` (when size gets above 16, by the looks). Luckily enough, the `insert()` returns the iterator too; and this one is always usable after the `insert()`.

## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
