### PR TITLE
Codechange: strongly type StationID

### DIFF
--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -16,7 +16,7 @@
 #include "station_map.h"
 #include "timer/timer_game_calendar.h"
 
-typedef Pool<BaseStation, StationID, 32, 64000> StationPool;
+typedef Pool<BaseStation, StationID, 32, StationID::End().base()> StationPool;
 extern StationPool _station_pool;
 
 template <typename T>

--- a/src/cargopacket.cpp
+++ b/src/cargopacket.cpp
@@ -410,7 +410,7 @@ void VehicleCargoList::AgeCargo()
 		return (accepted && cp->first_station != current_station) ? MTA_DELIVER : MTA_KEEP;
 	} else if (cargo_next == current_station) {
 		return MTA_DELIVER;
-	} else if (next_station.Contains(cargo_next)) {
+	} else if (next_station.Contains(cargo_next.base())) {
 		return MTA_KEEP;
 	} else {
 		return MTA_TRANSFER;
@@ -470,7 +470,7 @@ bool VehicleCargoList::Stage(bool accepted, StationID current_station, StationID
 				new_shares.ChangeShare(current_station, INT_MIN);
 				StationIDStack excluded = next_station;
 				while (!excluded.IsEmpty() && !new_shares.GetShares()->empty()) {
-					new_shares.ChangeShare(excluded.Pop(), INT_MIN);
+					new_shares.ChangeShare(StationID{excluded.Pop()}, INT_MIN);
 				}
 				if (new_shares.GetShares()->empty()) {
 					cargo_next = INVALID_STATION;
@@ -743,7 +743,7 @@ uint StationCargoList::ShiftCargo(Taction action, StationIDStack next, bool incl
 {
 	uint max_move = action.MaxMove();
 	while (!next.IsEmpty()) {
-		this->ShiftCargo(action, next.Pop());
+		this->ShiftCargo(action, StationID{next.Pop()});
 		if (action.MaxMove() == 0) break;
 	}
 	if (include_invalid && action.MaxMove() > 0) {
@@ -853,7 +853,7 @@ uint StationCargoList::Load(uint max_move, VehicleCargoList *dest, StationIDStac
  */
 uint StationCargoList::Reroute(uint max_move, StationCargoList *dest, StationID avoid, StationID avoid2, const GoodsEntry *ge)
 {
-	return this->ShiftCargo(StationCargoReroute(this, dest, max_move, avoid, avoid2, ge), avoid, false);
+	return this->ShiftCargo(StationCargoReroute(this, dest, max_move, avoid, avoid2, ge), avoid.base(), false);
 }
 
 /*

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -555,7 +555,7 @@ public:
 	inline bool HasCargoFor(StationIDStack next) const
 	{
 		while (!next.IsEmpty()) {
-			if (this->packets.find(next.Pop()) != this->packets.end()) return true;
+			if (this->packets.find(StationID{next.Pop()}) != this->packets.end()) return true;
 		}
 		/* Packets for INVALID_STATION can go anywhere. */
 		return this->packets.find(INVALID_STATION) != this->packets.end();

--- a/src/linkgraph/linkgraphjob.cpp
+++ b/src/linkgraph/linkgraphjob.cpp
@@ -50,7 +50,7 @@ LinkGraphJob::LinkGraphJob(const LinkGraph &orig) :
 void LinkGraphJob::EraseFlows(NodeID from)
 {
 	for (NodeID node_id = 0; node_id < this->Size(); ++node_id) {
-		(*this)[node_id].flows.erase(from);
+		(*this)[node_id].flows.erase(StationID{from});
 	}
 }
 
@@ -138,7 +138,7 @@ LinkGraphJob::~LinkGraphJob()
 				/* Delete old flows for source stations which have been deleted
 				 * from the new flows. This avoids flow cycles between old and
 				 * new flows. */
-				while (!erased.IsEmpty()) geflows.erase(erased.Pop());
+				while (!erased.IsEmpty()) geflows.erase(StationID{erased.Pop()});
 			} else if ((*lg)[node_id][dest_id].last_unrestricted_update == EconomyTime::INVALID_DATE) {
 				/* Edge is fully restricted. */
 				flows.RestrictFlows(to);

--- a/src/linkgraph/mcf.cpp
+++ b/src/linkgraph/mcf.cpp
@@ -134,7 +134,7 @@ private:
 	LinkGraphJob &job; ///< Link graph job we're working with.
 
 	/** Lookup table for getting NodeIDs from StationIDs. */
-	std::vector<NodeID> station_to_node;
+	ReferenceThroughBaseContainer<std::vector<NodeID>> station_to_node;
 
 	/** Current iterator in the shares map. */
 	FlowStat::SharesMap::const_iterator it;

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -756,7 +756,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 		case 0x13: return GB(ClampTo<uint16_t>(v->date_of_last_service_newgrf - CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR), 8, 8);
 		case 0x14: return v->GetServiceInterval();
 		case 0x15: return GB(v->GetServiceInterval(), 8, 8);
-		case 0x16: return v->last_station_visited;
+		case 0x16: return v->last_station_visited.base();
 		case 0x17: return v->tick_counter;
 		case 0x18:
 		case 0x19: {
@@ -808,7 +808,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 		case 0x3B: return GB(v->cargo_cap, 8, 8);
 		case 0x3C: return ClampTo<uint16_t>(v->cargo.StoredCount());
 		case 0x3D: return GB(ClampTo<uint16_t>(v->cargo.StoredCount()), 8, 8);
-		case 0x3E: return v->cargo.GetFirstStation();
+		case 0x3E: return v->cargo.GetFirstStation().base();
 		case 0x3F: return ClampTo<uint8_t>(v->cargo.PeriodsInTransit());
 		case 0x40: return ClampTo<uint16_t>(v->age);
 		case 0x41: return GB(ClampTo<uint16_t>(v->age), 8, 8);
@@ -924,7 +924,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 			Aircraft *a = Aircraft::From(v);
 			switch (variable - 0x80) {
 				case 0x62: return MapAircraftMovementState(a);  // Current movement state
-				case 0x63: return a->targetairport;             // Airport to which the action refers
+				case 0x63: return a->targetairport.base();      // Airport to which the action refers
 				case 0x66: return MapAircraftMovementAction(a); // Current movement action
 			}
 			break;

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -457,7 +457,7 @@ uint32_t Station::GetNewGRFVariable(const ResolverObject &object, uint8_t variab
 			case 1: return GB(g->HasData() ? std::min(g->GetData().cargo.TotalCount(), 4095u) : 0, 0, 4) | (GB(g->status, GoodsEntry::GES_ACCEPTANCE, 1) << 7);
 			case 2: return g->time_since_pickup;
 			case 3: return g->rating;
-			case 4: return g->HasData() ? g->GetData().cargo.GetFirstStation() : INVALID_STATION;
+			case 4: return (g->HasData() ? g->GetData().cargo.GetFirstStation() : INVALID_STATION).base();
 			case 5: return g->HasData() ? g->GetData().cargo.PeriodsInTransit() : 0;
 			case 6: return g->last_speed;
 			case 7: return g->last_age;
@@ -491,7 +491,7 @@ uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, uint8_t variable, [
 	if (variable >= 0x8C && variable <= 0xEC) {
 		switch (GB(variable - 0x8C, 0, 3)) {
 			case 3: return INITIAL_STATION_RATING;
-			case 4: return INVALID_STATION;
+			case 4: return INVALID_STATION.base();
 			default: return 0;
 		}
 	}

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -921,7 +921,7 @@ uint32_t SerialiseNewsReference(const NewsReference &reference)
 		uint32_t operator()(const std::monostate &) { return 0; }
 		uint32_t operator()(const TileIndex &t) { return t.base(); }
 		uint32_t operator()(const VehicleID v) { return v.base(); }
-		uint32_t operator()(const StationID s) { return s; }
+		uint32_t operator()(const StationID s) { return s.base(); }
 		uint32_t operator()(const IndustryID i) { return i.base(); }
 		uint32_t operator()(const TownID t) { return t.base(); }
 		uint32_t operator()(const EngineID e) { return e.base(); }

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -393,7 +393,7 @@ StationIDStack OrderList::GetNextStoppingStation(const Vehicle *v, const Order *
 		next = this->GetOrderAt(v->cur_implicit_order_index);
 		if (next == nullptr) {
 			next = this->GetFirstOrder();
-			if (next == nullptr) return INVALID_STATION;
+			if (next == nullptr) return INVALID_STATION.base();
 		} else {
 			/* GetNext never returns nullptr if there is a valid station in the list.
 			 * As the given "next" is already valid and a station in the list, we
@@ -430,11 +430,11 @@ StationIDStack OrderList::GetNextStoppingStation(const Vehicle *v, const Order *
 		if (next == nullptr || ((next->IsType(OT_GOTO_STATION) || next->IsType(OT_IMPLICIT)) &&
 				next->GetDestination() == v->last_station_visited &&
 				(next->GetUnloadType() & (OUFB_TRANSFER | OUFB_UNLOAD)) != 0)) {
-			return INVALID_STATION;
+			return INVALID_STATION.base();
 		}
 	} while (next->IsType(OT_GOTO_DEPOT) || next->GetDestination() == v->last_station_visited);
 
-	return next->GetDestination().ToStationID();
+	return next->GetDestination().ToStationID().base();
 }
 
 /**

--- a/src/order_type.h
+++ b/src/order_type.h
@@ -26,6 +26,7 @@ struct DestinationID {
 	explicit DestinationID() = default;
 	constexpr DestinationID(size_t index) : value(static_cast<BaseType>(index)) {}
 	constexpr DestinationID(DepotID depot) : value(depot.base()) {}
+	constexpr DestinationID(StationID station) : value(station.base()) {}
 
 	constexpr DepotID ToDepotID() const noexcept { return static_cast<DepotID>(this->value); }
 	constexpr StationID ToStationID() const noexcept { return static_cast<StationID>(this->value); }

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -724,7 +724,7 @@ static bool LoadOldGood(LoadgameState &ls, int num)
 	AssignBit(ge->status, GoodsEntry::GES_ACCEPTANCE, HasBit(_waiting_acceptance, 15));
 	AssignBit(ge->status, GoodsEntry::GES_RATING, _cargo_source != 0xFF);
 	if (GB(_waiting_acceptance, 0, 12) != 0 && CargoPacket::CanAllocateItem()) {
-		ge->GetOrCreateData().cargo.Append(new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, (_cargo_source == 0xFF) ? INVALID_STATION : _cargo_source, INVALID_TILE, 0),
+		ge->GetOrCreateData().cargo.Append(new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, (_cargo_source == 0xFF) ? INVALID_STATION : StationID{_cargo_source}, INVALID_TILE, 0),
 				INVALID_STATION);
 	}
 
@@ -771,7 +771,7 @@ static const OldChunks station_chunk[] = {
 static bool LoadOldStation(LoadgameState &ls, int num)
 {
 	Station *st = new (num) Station();
-	_current_station_id = num;
+	_current_station_id = st->index;
 
 	if (!LoadChunk(ls, st, station_chunk)) return false;
 
@@ -1372,7 +1372,7 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 		v->next = (Vehicle *)(size_t)_old_next_ptr;
 
 		if (_cargo_count != 0 && CargoPacket::CanAllocateItem()) {
-			StationID source =    (_cargo_source == 0xFF) ? INVALID_STATION : _cargo_source;
+			StationID source =    (_cargo_source == 0xFF) ? INVALID_STATION : StationID{_cargo_source};
 			TileIndex source_xy = (source != INVALID_STATION) ? Station::Get(source)->xy : (TileIndex)0;
 			v->cargo.Append(new CargoPacket(_cargo_count, _cargo_periods, source, source_xy, 0));
 		}

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -79,7 +79,7 @@ void MoveBuoysToWaypoints()
 		/* Stations and waypoints are in the same pool, so if a station
 		 * is deleted there must be place for a Waypoint. */
 		assert(Waypoint::CanAllocateItem());
-		Waypoint *wp   = new (index) Waypoint(xy);
+		Waypoint *wp   = new (index.base()) Waypoint(xy);
 		wp->town       = town;
 		wp->string_id  = train ? STR_SV_STNAME_WAYPOINT : STR_SV_STNAME_BUOY;
 		wp->name       = name;
@@ -173,7 +173,6 @@ std::list<CargoPacket *> _packets;
 uint32_t _old_num_dests;
 
 struct FlowSaveLoad {
-	FlowSaveLoad() : source(0), via(0), share(0), restricted(false) {}
 	StationID source;
 	StationID via;
 	uint32_t share;
@@ -302,7 +301,7 @@ public:
 		for (const auto &outer_it : ge->GetData().flows) {
 			const FlowStat::SharesMap *shares = outer_it.second.GetShares();
 			uint32_t sum_shares = 0;
-			FlowSaveLoad flow;
+			FlowSaveLoad flow{};
 			flow.source = outer_it.first;
 			for (auto &inner_it : *shares) {
 				flow.via = inner_it.second;
@@ -321,7 +320,7 @@ public:
 		if (num_flows == 0) return;
 
 		GoodsEntry::GoodsEntryData &data = ge->GetOrCreateData();
-		FlowSaveLoad flow;
+		FlowSaveLoad flow{};
 		FlowStat *fs = nullptr;
 		StationID prev_source = INVALID_STATION;
 		for (uint32_t j = 0; j < num_flows; ++j) {
@@ -418,7 +417,7 @@ public:
 				AssignBit(ge.status, GoodsEntry::GES_ACCEPTANCE, HasBit(_waiting_acceptance, 15));
 				if (GB(_waiting_acceptance, 0, 12) != 0) {
 					/* In old versions, enroute_from used 0xFF as INVALID_STATION */
-					StationID source = (IsSavegameVersionBefore(SLV_7) && _cargo_source == 0xFF) ? INVALID_STATION : _cargo_source;
+					StationID source = (IsSavegameVersionBefore(SLV_7) && _cargo_source == 0xFF) ? INVALID_STATION : static_cast<StationID>(_cargo_source);
 
 					/* Make sure we can allocate the CargoPacket. This is safe
 					 * as there can only be ~64k stations and 32 cargoes in these

--- a/src/script/api/script_basestation.hpp
+++ b/src/script/api/script_basestation.hpp
@@ -20,9 +20,9 @@
  */
 class ScriptBaseStation : public ScriptObject {
 public:
-	static const StationID STATION_NEW = ::NEW_STATION; ///< Build a new station
-	static const StationID STATION_JOIN_ADJACENT = ::ADJACENT_STATION; ///< Join an neighbouring station if one exists
-	static const StationID STATION_INVALID = ::INVALID_STATION; ///< Invalid station id.
+	static constexpr StationID STATION_NEW = ::NEW_STATION; ///< Build a new station
+	static constexpr StationID STATION_JOIN_ADJACENT = ::ADJACENT_STATION; ///< Join an neighbouring station if one exists
+	static constexpr StationID STATION_INVALID = ::INVALID_STATION; ///< Invalid station id.
 
 	/**
 	 * Checks whether the given basestation is valid and owned by you.

--- a/src/script/api/script_news.cpp
+++ b/src/script/api/script_news.cpp
@@ -44,7 +44,7 @@ static NewsReference CreateReference(ScriptNews::NewsReferenceType ref_type, SQI
 	EnforcePrecondition(false, company == ScriptCompany::COMPANY_INVALID || ScriptCompany::ResolveCompanyID(company) != ScriptCompany::COMPANY_INVALID);
 	EnforcePrecondition(false, (ref_type == NR_NONE) ||
 	                           (ref_type == NR_TILE     && ScriptMap::IsValidTile(::TileIndex(reference))) ||
-	                           (ref_type == NR_STATION  && ScriptStation::IsValidStation(reference)) ||
+	                           (ref_type == NR_STATION  && ScriptStation::IsValidStation(static_cast<StationID>(reference))) ||
 	                           (ref_type == NR_INDUSTRY && ScriptIndustry::IsValidIndustry(static_cast<IndustryID>(reference))) ||
 	                           (ref_type == NR_TOWN     && ScriptTown::IsValidTown(static_cast<TownID>(reference))));
 

--- a/src/script/api/script_road.hpp
+++ b/src/script/api/script_road.hpp
@@ -12,7 +12,8 @@
 
 #include "script_tile.hpp"
 #include "../squirrel_helper_type.hpp"
-#include "../../../road.h"
+#include "../../station_type.h"
+#include "../../road.h"
 
 /**
  * Class that handles all road related functions.

--- a/src/script/api/script_stationlist.cpp
+++ b/src/script/api/script_stationlist.cpp
@@ -35,7 +35,7 @@ ScriptStationList_Vehicle::ScriptStationList_Vehicle(VehicleID vehicle_id)
 	const Vehicle *v = ::Vehicle::Get(vehicle_id);
 
 	for (Order *o = v->GetFirstOrder(); o != nullptr; o = o->next) {
-		if (o->IsType(OT_GOTO_STATION)) this->AddItem(o->GetDestination().ToStationID());
+		if (o->IsType(OT_GOTO_STATION)) this->AddItem(o->GetDestination().ToStationID().base());
 	}
 }
 
@@ -137,11 +137,11 @@ CargoCollector::~CargoCollector()
 void CargoCollector::SetValue()
 {
 	if (this->amount > 0) {
-		if (this->list->HasItem(this->last_key)) {
-			this->list->SetValue(this->last_key,
-					this->list->GetValue(this->last_key) + this->amount);
+		if (this->list->HasItem(this->last_key.base())) {
+			this->list->SetValue(this->last_key.base(),
+					this->list->GetValue(this->last_key.base()) + this->amount);
 		} else {
-			this->list->AddItem(this->last_key, this->amount);
+			this->list->AddItem(this->last_key.base(), this->amount);
 		}
 	}
 }

--- a/src/script/api/script_waypointlist.cpp
+++ b/src/script/api/script_waypointlist.cpp
@@ -35,6 +35,6 @@ ScriptWaypointList_Vehicle::ScriptWaypointList_Vehicle(VehicleID vehicle_id)
 	const Vehicle *v = ::Vehicle::Get(vehicle_id);
 
 	for (const Order *o = v->GetFirstOrder(); o != nullptr; o = o->next) {
-		if (o->IsType(OT_GOTO_WAYPOINT)) this->AddItem(o->GetDestination().ToStationID());
+		if (o->IsType(OT_GOTO_WAYPOINT)) this->AddItem(o->GetDestination().ToStationID().base());
 	}
 }

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3728,7 +3728,7 @@ static VehicleEnterTileStatus VehicleEnter_Station(Vehicle *v, TileIndex tile, i
 			stop &= TILE_SIZE - 1;
 
 			if (x == stop) {
-				return VETSB_ENTERED_STATION | (VehicleEnterTileStatus)(station_id << VETS_STATION_ID_OFFSET); // enter station
+				return VETSB_ENTERED_STATION | static_cast<VehicleEnterTileStatus>(station_id.base() << VETS_STATION_ID_OFFSET); // enter station
 			} else if (x < stop) {
 				v->vehstatus |= VS_TRAIN_SLOWING;
 				uint16_t spd = std::max(0, (stop - x) * 20 - 15);
@@ -5073,7 +5073,7 @@ StationIDStack FlowStatMap::DeleteFlows(StationID via)
 		FlowStat &s_flows = f_it->second;
 		s_flows.ChangeShare(via, INT_MIN);
 		if (s_flows.GetShares()->empty()) {
-			ret.Push(f_it->first);
+			ret.Push(f_it->first.base());
 			this->erase(f_it++);
 		} else {
 			++f_it;

--- a/src/station_map.h
+++ b/src/station_map.h
@@ -720,7 +720,7 @@ inline void MakeStation(Tile t, Owner o, StationID sid, StationType st, uint8_t 
 	SetTileOwner(t, o);
 	SetWaterClass(t, wc);
 	SetDockingTile(t, false);
-	t.m2() = sid;
+	t.m2() = sid.base();
 	t.m3() = 0;
 	t.m4() = 0;
 	t.m5() = section;

--- a/src/station_type.h
+++ b/src/station_type.h
@@ -14,7 +14,11 @@
 #include "core/smallstack_type.hpp"
 #include "tilearea_type.h"
 
-typedef uint16_t StationID;
+using StationID = PoolID<uint16_t, struct StationIDTag, 64000, 0xFFFF>;
+static constexpr StationID NEW_STATION{0xFFFD};
+static constexpr StationID ADJACENT_STATION{0xFFFE};
+static constexpr StationID INVALID_STATION = StationID::Invalid();
+
 using RoadStopID = PoolID<uint16_t, struct RoadStopIDTag, 64000, 0xFFFF>;
 
 struct BaseStation;
@@ -23,11 +27,7 @@ struct RoadStop;
 struct StationSpec;
 struct Waypoint;
 
-static const StationID NEW_STATION = 0xFFFD;
-static const StationID ADJACENT_STATION = 0xFFFE;
-static const StationID INVALID_STATION = 0xFFFF;
-
-typedef SmallStack<StationID, StationID, INVALID_STATION, 8, 0xFFFD> StationIDStack;
+using StationIDStack = SmallStack<StationID::BaseType, StationID::BaseType, INVALID_STATION.base(), 8, StationID::End().base()>;
 
 /** Station types */
 enum class StationType : uint8_t {

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -3305,7 +3305,7 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 					}
 					if (HasBit(r, VETS_ENTERED_STATION)) {
 						/* The new position is the end of the platform */
-						TrainEnterStation(v, r >> VETS_STATION_ID_OFFSET);
+						TrainEnterStation(v, StationID(r >> VETS_STATION_ID_OFFSET));
 					}
 				}
 			} else {
@@ -3499,7 +3499,7 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 
 				if (HasBit(r, VETS_ENTERED_STATION)) {
 					/* The new position is the location where we want to stop */
-					TrainEnterStation(v, r >> VETS_STATION_ID_OFFSET);
+					TrainEnterStation(v, StationID(r >> VETS_STATION_ID_OFFSET));
 				}
 			}
 		} else {

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -743,7 +743,7 @@ public:
 	 */
 	inline StationIDStack GetNextStoppingStation() const
 	{
-		return (this->orders == nullptr) ? INVALID_STATION : this->orders->GetNextStoppingStation(this);
+		return (this->orders == nullptr) ? INVALID_STATION.base() : this->orders->GetNextStoppingStation(this);
 	}
 
 	void ResetRefitCaps();

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2340,7 +2340,7 @@ void ShowVehicleListWindow(const Vehicle *v)
 
 void ShowVehicleListWindow(CompanyID company, VehicleType vehicle_type, StationID station)
 {
-	ShowVehicleListWindowLocal(company, VL_STATION_LIST, vehicle_type, station);
+	ShowVehicleListWindowLocal(company, VL_STATION_LIST, vehicle_type, station.base());
 }
 
 void ShowVehicleListWindow(CompanyID company, VehicleType vehicle_type, TileIndex depot_tile)


### PR DESCRIPTION
## Motivation / Problem

`StationID` is the only 'pool ID' that isn't a real `PoolID` yet.


## Description

Make `StationID` a `PoolID`, like the many ones before.


## Limitations

`StationIDStack` can't actually work with `PoolID`, so there's a bit of `.base()` and `StationID{}` to go to/from `StationIDStack`. I've exhausted my ideas on how to make it work with a `PoolID`.
It's also the only thing using `SmallStack` and `SimplePool`, but `SmallStack` is doing some optimisation magic that I rather not touch in this PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
