### PR TITLE
Codechange: let the ReusableBuffer use std::vector as storage

### DIFF
--- a/src/blitter/8bpp_optimized.cpp
+++ b/src/blitter/8bpp_optimized.cpp
@@ -148,8 +148,7 @@ Sprite *Blitter_8bppOptimized::Encode(const SpriteLoader::SpriteCollection &spri
 	 * memory around as this function is called quite often
 	 * and the memory usage is quite low. */
 	static ReusableBuffer<uint8_t> temp_buffer;
-	SpriteData *temp_dst = (SpriteData *)temp_buffer.Allocate(memory);
-	memset(temp_dst, 0, sizeof(*temp_dst));
+	SpriteData *temp_dst = reinterpret_cast<SpriteData *>(temp_buffer.ZeroAllocate(memory));
 	uint8_t *dst = temp_dst->data;
 
 	/* Make the sprites per zoom-level */

--- a/src/core/alloc_type.hpp
+++ b/src/core/alloc_type.hpp
@@ -23,15 +23,9 @@
 template <typename T>
 class ReusableBuffer {
 private:
-	T *buffer;    ///< The real data buffer
-	size_t count; ///< Number of T elements in the buffer
+	std::vector<T> buffer;
 
 public:
-	/** Create a new buffer */
-	ReusableBuffer() : buffer(nullptr), count(0) {}
-	/** Clear the buffer */
-	~ReusableBuffer() { free(this->buffer); }
-
 	/**
 	 * Get buffer of at least count times T.
 	 * @note the buffer might be bigger
@@ -41,16 +35,12 @@ public:
 	 */
 	T *Allocate(size_t count)
 	{
-		if (this->count < count) {
-			free(this->buffer);
-			this->buffer = MallocT<T>(count);
-			this->count = count;
-		}
-		return this->buffer;
+		if (this->buffer.size() < count) this->buffer.resize(count);
+		return this->buffer.data();
 	}
 
 	/**
-	 * Get buffer of at least count times T with zeroed memory.
+	 * Get buffer of at least count times T of default initialised elements.
 	 * @note the buffer might be bigger
 	 * @note calling this function invalidates any previous buffers given
 	 * @param count the minimum buffer size
@@ -58,14 +48,9 @@ public:
 	 */
 	T *ZeroAllocate(size_t count)
 	{
-		if (this->count < count) {
-			free(this->buffer);
-			this->buffer = CallocT<T>(count);
-			this->count = count;
-		} else {
-			memset(this->buffer, 0, sizeof(T) * count);
-		}
-		return this->buffer;
+		this->buffer.clear();
+		this->buffer.resize(count, {});
+		return this->buffer.data();
 	}
 
 	/**
@@ -74,7 +59,7 @@ public:
 	 */
 	inline const T *GetBuffer() const
 	{
-		return this->buffer;
+		return this->buffer.data();
 	}
 };
 

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -296,23 +296,23 @@ static bool PadSingleSprite(SpriteLoader::Sprite *sprite, ZoomLevel zoom, uint p
 	for (uint y = 0; y < height; y++) {
 		if (y < pad_top || pad_bottom + y >= height) {
 			/* Top/bottom padding. */
-			MemSetT(data, 0, width);
+			std::fill_n(data, width, SpriteLoader::CommonPixel{});
 			data += width;
 		} else {
 			if (pad_left > 0) {
 				/* Pad left. */
-				MemSetT(data, 0, pad_left);
+				std::fill_n(data, pad_left, SpriteLoader::CommonPixel{});
 				data += pad_left;
 			}
 
 			/* Copy pixels. */
-			MemCpyT(data, src, sprite->width);
+			std::copy_n(src, sprite->width, data);
 			src += sprite->width;
 			data += sprite->width;
 
 			if (pad_right > 0) {
 				/* Pad right. */
-				MemSetT(data, 0, pad_right);
+				std::fill_n(data, pad_right, SpriteLoader::CommonPixel{});
 				data += pad_right;
 			}
 		}

--- a/src/spriteloader/spriteloader.hpp
+++ b/src/spriteloader/spriteloader.hpp
@@ -31,11 +31,11 @@ class SpriteLoader {
 public:
 	/** Definition of a common pixel in OpenTTD's realm. */
 	struct CommonPixel {
-		uint8_t r;  ///< Red-channel
-		uint8_t g;  ///< Green-channel
-		uint8_t b;  ///< Blue-channel
-		uint8_t a;  ///< Alpha-channel
-		uint8_t m;  ///< Remap-channel
+		uint8_t r = 0;  ///< Red-channel
+		uint8_t g = 0;  ///< Green-channel
+		uint8_t b = 0;  ///< Blue-channel
+		uint8_t a = 0;  ///< Alpha-channel
+		uint8_t m = 0;  ///< Remap-channel
 	};
 
 	/**


### PR DESCRIPTION
## Motivation / Problem

`ReusableBuffer` uses manual memory management with `MallocT`/`CallocT`.


## Description

* Instead of `MallocT`/`CallocT` use a `std::vector` instead.
* Let `Allocate` (used `MallocT` only resize the vector when it becomes bigger).
* Let `ZeroAllocate` (used `CallocT`/`memset`) resize vector to be empty and then to requested size, so everything gets default initialised. Not necessarily zero any more, but this is more useful.
* Let the 8bpp optimized blitter use `ZeroAllocate` over `Allocate` + `memset`.
* Default initialize `CommonPixel`, and use `std::fill_n`/`std::copy_n` over `memset`/`memcpy`.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
