### PR TITLE
Codechange: remove transitional supports from the pool

### DIFF
--- a/src/autoreplace_base.h
+++ b/src/autoreplace_base.h
@@ -22,7 +22,7 @@ using EngineRenewID = PoolID<uint16_t, struct EngineRenewIDTag, 64000, 0xFFFF>;
  * placed here so the only exception to this rule, the saveload code, can use
  * it.
  */
-using EngineRenewPool = Pool<EngineRenew, EngineRenewID, 16, EngineRenewID::End().base()>;
+using EngineRenewPool = Pool<EngineRenew, EngineRenewID, 16>;
 extern EngineRenewPool _enginerenew_pool;
 
 /**

--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -16,7 +16,7 @@
 #include "station_map.h"
 #include "timer/timer_game_calendar.h"
 
-typedef Pool<BaseStation, StationID, 32, StationID::End().base()> StationPool;
+typedef Pool<BaseStation, StationID, 32> StationPool;
 extern StationPool _station_pool;
 
 template <typename T>

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -25,7 +25,7 @@ using CargoPacketID = PoolID<uint32_t, struct CargoPacketIDTag, 0xFFF000, 0xFFFF
 struct CargoPacket;
 
 /** Type of the pool for cargo packets for a little over 16 million packets. */
-using CargoPacketPool = Pool<CargoPacket, CargoPacketID, 1024, CargoPacketID::End().base(), PoolType::Normal, true, false>;
+using CargoPacketPool = Pool<CargoPacket, CargoPacketID, 1024, PoolType::Normal, true, false>;
 /** The actual pool with cargo packets. */
 extern CargoPacketPool _cargopacket_pool;
 

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -62,7 +62,7 @@ private:
 	std::vector<BitmapStorage> used_bitmap;
 };
 
-typedef Pool<Company, CompanyID, 1, CompanyID::End().base()> CompanyPool;
+typedef Pool<Company, CompanyID, 1> CompanyPool;
 extern CompanyPool _company_pool;
 
 /** Statically loadable part of Company pool item */

--- a/src/core/pool_func.hpp
+++ b/src/core/pool_func.hpp
@@ -23,8 +23,9 @@
  * @param type The return type of the method.
  */
 #define DEFINE_POOL_METHOD(type) \
-	template <class Titem, typename Tindex, size_t Tgrowth_step, size_t Tmax_size, PoolType Tpool_type, bool Tcache, bool Tzero> \
-	type Pool<Titem, Tindex, Tgrowth_step, Tmax_size, Tpool_type, Tcache, Tzero>
+	template <class Titem, typename Tindex, size_t Tgrowth_step, PoolType Tpool_type, bool Tcache, bool Tzero> \
+	requires std::is_base_of_v<PoolIDBase, Tindex> \
+	type Pool<Titem, Tindex, Tgrowth_step, Tpool_type, Tcache, Tzero>
 
 /**
  * Create a clean pool.
@@ -47,15 +48,15 @@ DEFINE_POOL_METHOD(inline)::Pool(const char *name) :
  * Resizes the pool so 'index' can be addressed
  * @param index index we will allocate later
  * @pre index >= this->size
- * @pre index < Tmax_size
+ * @pre index < MAX_SIZE
  */
 DEFINE_POOL_METHOD(inline void)::ResizeFor(size_t index)
 {
 	assert(index >= this->data.size());
-	assert(index < Tmax_size);
+	assert(index < MAX_SIZE);
 
 	size_t old_size = this->data.size();
-	size_t new_size = std::min(Tmax_size, Align(index + 1, Tgrowth_step));
+	size_t new_size = std::min(MAX_SIZE, Align(index + 1, Tgrowth_step));
 
 	this->data.resize(new_size);
 	this->used_bitmap.resize(Align(new_size, BITMAP_SIZE) / BITMAP_SIZE);
@@ -83,12 +84,12 @@ DEFINE_POOL_METHOD(inline size_t)::FindFirstFree()
 
 	assert(this->first_unused == this->data.size());
 
-	if (this->first_unused < Tmax_size) {
+	if (this->first_unused < MAX_SIZE) {
 		this->ResizeFor(this->first_unused);
 		return this->first_unused;
 	}
 
-	assert(this->first_unused == Tmax_size);
+	assert(this->first_unused == MAX_SIZE);
 
 	return NO_FREE_ITEM;
 }
@@ -124,12 +125,8 @@ DEFINE_POOL_METHOD(inline void *)::AllocateItem(size_t size, size_t index)
 	}
 	this->data[index] = item;
 	SetBit(this->used_bitmap[index / BITMAP_SIZE], index % BITMAP_SIZE);
-	if constexpr (std::is_base_of_v<PoolIDBase, Tindex>) {
-		/* MSVC complains about casting to narrower type, so first cast to the base type... then to the strong type. */
-		item->index = static_cast<Tindex>(static_cast<Tindex::BaseType>(index));
-	} else {
-		item->index = static_cast<Tindex>(index);
-	}
+	/* MSVC complains about casting to narrower type, so first cast to the base type... then to the strong type. */
+	item->index = static_cast<Tindex>(static_cast<Tindex::BaseType>(index));
 	return item;
 }
 
@@ -164,8 +161,8 @@ DEFINE_POOL_METHOD(void *)::GetNew(size_t size)
  */
 DEFINE_POOL_METHOD(void *)::GetNew(size_t size, size_t index)
 {
-	if (index >= Tmax_size) {
-		SlErrorCorruptFmt("{} index {} out of range ({})", this->name, index, Tmax_size);
+	if (index >= MAX_SIZE) {
+		SlErrorCorruptFmt("{} index {} out of range ({})", this->name, index, MAX_SIZE);
 	}
 
 	if (index >= this->data.size()) this->ResizeFor(index);

--- a/src/depot_base.h
+++ b/src/depot_base.h
@@ -14,7 +14,7 @@
 #include "core/pool_type.hpp"
 #include "timer/timer_game_calendar.h"
 
-typedef Pool<Depot, DepotID, 64, DepotID::End().base()> DepotPool;
+typedef Pool<Depot, DepotID, 64> DepotPool;
 extern DepotPool _depot_pool;
 
 struct Depot : DepotPool::PoolItem<&_depot_pool> {

--- a/src/economy_base.h
+++ b/src/economy_base.h
@@ -14,7 +14,7 @@
 #include "company_type.h"
 
 /** Type of pool to store cargo payments in; little over 1 million. */
-using CargoPaymentPool = Pool<CargoPayment, CargoPaymentID, 512, CargoPaymentID::End().base()>;
+using CargoPaymentPool = Pool<CargoPayment, CargoPaymentID, 512>;
 /** The actual pool to store cargo payments in. */
 extern CargoPaymentPool _cargo_payment_pool;
 

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -32,7 +32,7 @@ enum class EngineDisplayFlag : uint8_t {
 
 using EngineDisplayFlags = EnumBitSet<EngineDisplayFlag, uint8_t>;
 
-typedef Pool<Engine, EngineID, 64, EngineID::End().base()> EnginePool;
+typedef Pool<Engine, EngineID, 64> EnginePool;
 extern EnginePool _engine_pool;
 
 struct Engine : EnginePool::PoolItem<&_engine_pool> {

--- a/src/goal_base.h
+++ b/src/goal_base.h
@@ -14,7 +14,7 @@
 #include "goal_type.h"
 #include "core/pool_type.hpp"
 
-using GoalPool = Pool<Goal, GoalID, 64, GoalID::End().base()>;
+using GoalPool = Pool<Goal, GoalID, 64>;
 extern GoalPool _goal_pool;
 
 /** Struct about goals, current and completed */

--- a/src/group.h
+++ b/src/group.h
@@ -17,7 +17,7 @@
 #include "engine_type.h"
 #include "livery.h"
 
-using GroupPool = Pool<Group, GroupID, 16, GroupID::End().base()>;
+using GroupPool = Pool<Group, GroupID, 16>;
 extern GroupPool _group_pool; ///< Pool of groups.
 
 /** Statistics and caches on the vehicles in a group. */

--- a/src/industry.h
+++ b/src/industry.h
@@ -20,7 +20,7 @@
 #include "timer/timer_game_economy.h"
 
 
-typedef Pool<Industry, IndustryID, 64, IndustryID::End().base()> IndustryPool;
+typedef Pool<Industry, IndustryID, 64> IndustryPool;
 extern IndustryPool _industry_pool;
 
 static const TimerGameEconomy::Year PROCESSING_INDUSTRY_ABANDONMENT_YEARS{5}; ///< If a processing industry doesn't produce for this many consecutive economy years, it may close.

--- a/src/league_base.h
+++ b/src/league_base.h
@@ -17,10 +17,10 @@
 
 bool IsValidLink(Link link);
 
-using LeagueTableElementPool = Pool<LeagueTableElement, LeagueTableElementID, 64, LeagueTableElementID::End().base()>;
+using LeagueTableElementPool = Pool<LeagueTableElement, LeagueTableElementID, 64>;
 extern LeagueTableElementPool _league_table_element_pool;
 
-using LeagueTablePool = Pool<LeagueTable, LeagueTableID, 4, LeagueTableID::End().base()>;
+using LeagueTablePool = Pool<LeagueTable, LeagueTableID, 4>;
 extern LeagueTablePool _league_table_pool;
 
 

--- a/src/linkgraph/linkgraph.h
+++ b/src/linkgraph/linkgraph.h
@@ -24,7 +24,7 @@ class LinkGraph;
  * Type of the pool for link graph components. Each station can be in at up to
  * 32 link graphs. So we allow for plenty of them to be created.
  */
-using LinkGraphPool = Pool<LinkGraph, LinkGraphID, 32, LinkGraphID::End().base()>;
+using LinkGraphPool = Pool<LinkGraph, LinkGraphID, 32>;
 /** The actual pool with link graphs. */
 extern LinkGraphPool _link_graph_pool;
 

--- a/src/linkgraph/linkgraphjob.h
+++ b/src/linkgraph/linkgraphjob.h
@@ -19,7 +19,7 @@ class Path;
 typedef std::list<Path *> PathList;
 
 /** Type of the pool for link graph jobs. */
-using LinkGraphJobPool = Pool<LinkGraphJob, LinkGraphJobID, 32, LinkGraphJobID::End().base()>;
+using LinkGraphJobPool = Pool<LinkGraphJob, LinkGraphJobID, 32>;
 /** The actual pool with link graph jobs. */
 extern LinkGraphJobPool _link_graph_job_pool;
 

--- a/src/network/network_admin.h
+++ b/src/network/network_admin.h
@@ -18,7 +18,7 @@ extern AdminID _redirect_console_to_admin;
 
 class ServerNetworkAdminSocketHandler;
 /** Pool with all admin connections. */
-using NetworkAdminSocketPool = Pool<ServerNetworkAdminSocketHandler, AdminID, 2, AdminID::End().base(), PoolType::NetworkAdmin>;
+using NetworkAdminSocketPool = Pool<ServerNetworkAdminSocketHandler, AdminID, 2, PoolType::NetworkAdmin>;
 extern NetworkAdminSocketPool _networkadminsocket_pool;
 
 /** Class for handling the server side of the game connection. */

--- a/src/network/network_base.h
+++ b/src/network/network_base.h
@@ -17,7 +17,7 @@
 #include "../timer/timer_game_economy.h"
 
 /** Type for the pool with client information. */
-using NetworkClientInfoPool = Pool<NetworkClientInfo, ClientPoolID, 8, ClientPoolID::End().base(), PoolType::NetworkClient>;
+using NetworkClientInfoPool = Pool<NetworkClientInfo, ClientPoolID, 8, PoolType::NetworkClient>;
 extern NetworkClientInfoPool _networkclientinfo_pool;
 
 /** Container for all information known about a client. */

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -17,7 +17,7 @@ class ServerNetworkGameSocketHandler;
 /** Make the code look slightly nicer/simpler. */
 typedef ServerNetworkGameSocketHandler NetworkClientSocket;
 /** Pool with all client sockets. */
-using NetworkClientSocketPool = Pool<NetworkClientSocket, ClientPoolID, 8, ClientPoolID::End().base(), PoolType::NetworkClient>;
+using NetworkClientSocketPool = Pool<NetworkClientSocket, ClientPoolID, 8, PoolType::NetworkClient>;
 extern NetworkClientSocketPool _networkclientsocket_pool;
 
 /** Class for handling the server side of the game connection. */

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -50,7 +50,7 @@ struct ResolverObject;
  * Adding an 'extra' margin would be assuming 64 sprite groups per real
  * sprite. 64 = 2^6, so 2^30 should be enough (for now) */
 using SpriteGroupID = PoolID<uint32_t, struct SpriteGroupIDTag, 1U << 30, 0xFFFFFFFF>;
-using SpriteGroupPool = Pool<SpriteGroup, SpriteGroupID, 1024, SpriteGroupID::End().base(), PoolType::Data>;
+using SpriteGroupPool = Pool<SpriteGroup, SpriteGroupID, 1024, PoolType::Data>;
 extern SpriteGroupPool _spritegroup_pool;
 
 /* Common wrapper for all the different sprite group types */

--- a/src/newgrf_storage.h
+++ b/src/newgrf_storage.h
@@ -189,7 +189,7 @@ typedef PersistentStorageArray<int32_t, 16> OldPersistentStorage;
 using PersistentStorageID = PoolID<uint32_t, struct PersistentStorageIDTag, 0xFF000, 0xFFFFF>;
 
 struct PersistentStorage;
-using PersistentStoragePool = Pool<PersistentStorage, PersistentStorageID, 1, PersistentStorageID::End().base()>;
+using PersistentStoragePool = Pool<PersistentStorage, PersistentStorageID, 1>;
 
 extern PersistentStoragePool _persistent_storage_pool;
 

--- a/src/object_base.h
+++ b/src/object_base.h
@@ -16,7 +16,7 @@
 #include "town_type.h"
 #include "timer/timer_game_calendar.h"
 
-using ObjectPool = Pool<Object, ObjectID, 64, ObjectID::End().base()>;
+using ObjectPool = Pool<Object, ObjectID, 64>;
 extern ObjectPool _object_pool;
 
 /** An object, such as transmitter, on the map. */

--- a/src/order_backup.h
+++ b/src/order_backup.h
@@ -22,7 +22,7 @@ using OrderBackupID = PoolID<uint8_t, struct OrderBackupIDTag, 255, 0xFF>;
 struct OrderBackup;
 
 /** The pool type for order backups. */
-using OrderBackupPool = Pool<OrderBackup, OrderBackupID, 1, OrderBackupID::End().base()>;
+using OrderBackupPool = Pool<OrderBackup, OrderBackupID, 1>;
 /** The pool with order backups. */
 extern OrderBackupPool _order_backup_pool;
 

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -20,8 +20,8 @@
 #include "timer/timer_game_tick.h"
 #include "saveload/saveload.h"
 
-using OrderPool = Pool<Order, OrderID, 256, OrderID::End().base()>;
-using OrderListPool = Pool<OrderList, OrderListID, 128, OrderListID::End().base()>;
+using OrderPool = Pool<Order, OrderID, 256>;
+using OrderListPool = Pool<OrderList, OrderListID, 128>;
 extern OrderPool _order_pool;
 extern OrderListPool _orderlist_pool;
 

--- a/src/roadstop_base.h
+++ b/src/roadstop_base.h
@@ -15,7 +15,7 @@
 #include "core/bitmath_func.hpp"
 #include "vehicle_type.h"
 
-using RoadStopPool = Pool<RoadStop, RoadStopID, 32, RoadStopID::End().base()>;
+using RoadStopPool = Pool<RoadStop, RoadStopID, 32>;
 extern RoadStopPool _roadstop_pool;
 
 /** A Stop for a Road Vehicle */

--- a/src/signs_base.h
+++ b/src/signs_base.h
@@ -15,7 +15,7 @@
 #include "core/pool_type.hpp"
 #include "company_type.h"
 
-typedef Pool<Sign, SignID, 16, SignID::End().base()> SignPool;
+typedef Pool<Sign, SignID, 16> SignPool;
 extern SignPool _sign_pool;
 
 struct Sign : SignPool::PoolItem<&_sign_pool> {

--- a/src/story_base.h
+++ b/src/story_base.h
@@ -17,8 +17,8 @@
 #include "vehicle_type.h"
 #include "core/pool_type.hpp"
 
-using StoryPageElementPool = Pool<StoryPageElement, StoryPageElementID, 64, StoryPageElementID::End().base()>;
-using StoryPagePool = Pool<StoryPage, StoryPageID, 64, StoryPageID::End().base()>;
+using StoryPageElementPool = Pool<StoryPageElement, StoryPageElementID, 64>;
+using StoryPagePool = Pool<StoryPage, StoryPageID, 64>;
 extern StoryPageElementPool _story_page_element_pool;
 extern StoryPagePool _story_page_pool;
 extern uint32_t _story_page_element_next_sort_value;

--- a/src/subsidy_base.h
+++ b/src/subsidy_base.h
@@ -16,7 +16,7 @@
 #include "subsidy_type.h"
 #include "core/pool_type.hpp"
 
-using SubsidyPool = Pool<Subsidy, SubsidyID, 1, SubsidyID::End().base()>;
+using SubsidyPool = Pool<Subsidy, SubsidyID, 1>;
 extern SubsidyPool _subsidy_pool;
 
 /** Struct about subsidies, offered and awarded */

--- a/src/town.h
+++ b/src/town.h
@@ -33,7 +33,7 @@ static const uint TOWN_GROWTH_DESERT = 0xFFFFFFFF; ///< The town needs the cargo
 static const uint16_t TOWN_GROWTH_RATE_NONE = 0xFFFF; ///< Special value for Town::growth_rate to disable town growth.
 static const uint16_t MAX_TOWN_GROWTH_TICKS = 930; ///< Max amount of original town ticks that still fit into uint16_t, about equal to UINT16_MAX / TOWN_GROWTH_TICKS but slightly less to simplify calculations
 
-typedef Pool<Town, TownID, 64, TownID::End().base()> TownPool;
+typedef Pool<Town, TownID, 64> TownPool;
 extern TownPool _town_pool;
 
 /** Data structure with cached data of towns. */

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -196,7 +196,7 @@ struct MutableSpriteCache {
 };
 
 /** A vehicle pool for a little over 1 million vehicles. */
-typedef Pool<Vehicle, VehicleID, 512, VehicleID::End().base()> VehiclePool;
+typedef Pool<Vehicle, VehicleID, 512> VehiclePool;
 extern VehiclePool _vehicle_pool;
 
 /* Some declarations of functions, so we can make them friendly */


### PR DESCRIPTION
## Motivation / Problem

Some bits were added to `Pool` to ease transitioning to `PoolID`. Remove the bits that are not needed any more.


## Description

* Remove passing the maximum size in the template, `PoolID`'s `End()` gives us that information.
* Remove supporting for `enum` or simple integers as pool index.
* Require `Tindex` to be a `PoolID`.


## Limitations

`GetRawIndex` is not yet removed as there are many places where things are accessed by integer like types. For example from UIs and string formatting. That's something for future clean-up work.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
