### PR TITLE
Codechange: replace INVALID_X with XID::Invalid() for PoolIDs

### DIFF
--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -190,7 +190,7 @@
 		AI::scanner_info = nullptr;
 		AI::scanner_library = nullptr;
 
-		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
+		for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 			if (_settings_game.ai_config[c] != nullptr) {
 				delete _settings_game.ai_config[c];
 				_settings_game.ai_config[c] = nullptr;
@@ -208,7 +208,7 @@
 	/* Check for both newgame as current game if we can reload the AIInfo inside
 	 *  the AIConfig. If not, remove the AI from the list (which will assign
 	 *  a random new AI on reload). */
-	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
+	for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 		if (_settings_game.ai_config[c] != nullptr && _settings_game.ai_config[c]->HasScript()) {
 			if (!_settings_game.ai_config[c]->ResetInfo(true)) {
 				Debug(script, 0, "After a reload, the AI by the name '{}' was no longer found, and removed from the list.", _settings_game.ai_config[c]->GetName());
@@ -270,7 +270,7 @@
 	}
 
 	/* Try to send the event to all AIs */
-	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
+	for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 		if (c != skip_company) AI::NewEvent(c, event);
 	}
 }

--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -93,7 +93,7 @@ static WindowDesc _ai_config_desc(
  * Window to configure which AIs will start.
  */
 struct AIConfigWindow : public Window {
-	CompanyID selected_slot; ///< The currently selected AI slot or \c INVALID_COMPANY.
+	CompanyID selected_slot; ///< The currently selected AI slot or \c CompanyID::Invalid().
 	int line_height;         ///< Height of a single AI-name line.
 	Scrollbar *vscroll;      ///< Cache of the vertical scrollbar.
 
@@ -101,7 +101,7 @@ struct AIConfigWindow : public Window {
 	{
 		this->InitNested(WN_GAME_OPTIONS_AI); // Initializes 'this->line_height' as a side effect.
 		this->vscroll = this->GetScrollbar(WID_AIC_SCROLLBAR);
-		this->selected_slot = INVALID_COMPANY;
+		this->selected_slot = CompanyID::Invalid();
 		NWidgetCore *nwi = this->GetWidget<NWidgetCore>(WID_AIC_LIST);
 		this->vscroll->SetCapacity(nwi->current_y / this->line_height);
 		this->vscroll->SetCount(MAX_COMPANIES);
@@ -169,7 +169,7 @@ struct AIConfigWindow : public Window {
 					for (const Company *c : Company::Iterate()) {
 						if (c->is_ai) max_slot--;
 					}
-					for (CompanyID cid = COMPANY_FIRST; cid < max_slot && cid < MAX_COMPANIES; ++cid) {
+					for (CompanyID cid = CompanyID::Begin(); cid < max_slot && cid < MAX_COMPANIES; ++cid) {
 						if (Company::IsValidID(cid)) max_slot++;
 					}
 				} else {
@@ -206,7 +206,7 @@ struct AIConfigWindow : public Window {
 	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		if (widget >= WID_AIC_TEXTFILE && widget < WID_AIC_TEXTFILE + TFT_CONTENT_END) {
-			if (this->selected_slot == INVALID_COMPANY || AIConfig::GetConfig(this->selected_slot) == nullptr) return;
+			if (this->selected_slot == CompanyID::Invalid() || AIConfig::GetConfig(this->selected_slot) == nullptr) return;
 
 			ShowScriptTextfileWindow((TextfileType)(widget - WID_AIC_TEXTFILE), this->selected_slot);
 			return;
@@ -266,7 +266,7 @@ struct AIConfigWindow : public Window {
 
 			case WID_AIC_OPEN_URL: {
 				const AIConfig *config = AIConfig::GetConfig(this->selected_slot);
-				if (this->selected_slot == INVALID_COMPANY || config == nullptr || config->GetInfo() == nullptr) return;
+				if (this->selected_slot == CompanyID::Invalid() || config == nullptr || config->GetInfo() == nullptr) return;
 				OpenBrowser(config->GetInfo()->GetURL());
 				break;
 			}
@@ -297,25 +297,25 @@ struct AIConfigWindow : public Window {
 	void OnInvalidateData([[maybe_unused]] int data = 0, [[maybe_unused]] bool gui_scope = true) override
 	{
 		if (!IsEditable(this->selected_slot) && !Company::IsValidAiID(this->selected_slot)) {
-			this->selected_slot = INVALID_COMPANY;
+			this->selected_slot = CompanyID::Invalid();
 		}
 
 		if (!gui_scope) return;
 
-		AIConfig *config = this->selected_slot == INVALID_COMPANY ? nullptr : AIConfig::GetConfig(this->selected_slot);
+		AIConfig *config = this->selected_slot == CompanyID::Invalid() ? nullptr : AIConfig::GetConfig(this->selected_slot);
 
 		this->SetWidgetDisabledState(WID_AIC_DECREASE_NUMBER, GetGameSettings().difficulty.max_no_competitors == 0);
 		this->SetWidgetDisabledState(WID_AIC_INCREASE_NUMBER, GetGameSettings().difficulty.max_no_competitors == MAX_COMPANIES - 1);
 		this->SetWidgetDisabledState(WID_AIC_DECREASE_INTERVAL, GetGameSettings().difficulty.competitors_interval == MIN_COMPETITORS_INTERVAL);
 		this->SetWidgetDisabledState(WID_AIC_INCREASE_INTERVAL, GetGameSettings().difficulty.competitors_interval == MAX_COMPETITORS_INTERVAL);
 		this->SetWidgetDisabledState(WID_AIC_CHANGE, !IsEditable(this->selected_slot));
-		this->SetWidgetDisabledState(WID_AIC_CONFIGURE, this->selected_slot == INVALID_COMPANY || config->GetConfigList()->empty());
+		this->SetWidgetDisabledState(WID_AIC_CONFIGURE, this->selected_slot == CompanyID::Invalid() || config->GetConfigList()->empty());
 		this->SetWidgetDisabledState(WID_AIC_MOVE_UP, !IsEditable(this->selected_slot) || !IsEditable((CompanyID)(this->selected_slot - 1)));
 		this->SetWidgetDisabledState(WID_AIC_MOVE_DOWN, !IsEditable(this->selected_slot) || !IsEditable((CompanyID)(this->selected_slot + 1)));
 
-		this->SetWidgetDisabledState(WID_AIC_OPEN_URL, this->selected_slot == INVALID_COMPANY || config->GetInfo() == nullptr || config->GetInfo()->GetURL().empty());
+		this->SetWidgetDisabledState(WID_AIC_OPEN_URL, this->selected_slot == CompanyID::Invalid() || config->GetInfo() == nullptr || config->GetInfo()->GetURL().empty());
 		for (TextfileType tft = TFT_CONTENT_BEGIN; tft < TFT_CONTENT_END; tft++) {
-			this->SetWidgetDisabledState(WID_AIC_TEXTFILE + tft, this->selected_slot == INVALID_COMPANY || !config->GetTextfile(tft, this->selected_slot).has_value());
+			this->SetWidgetDisabledState(WID_AIC_TEXTFILE + tft, this->selected_slot == CompanyID::Invalid() || !config->GetTextfile(tft, this->selected_slot).has_value());
 		}
 	}
 };

--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -116,15 +116,15 @@ enum HelicopterRotorStates : uint8_t {
 
 /**
  * Find the nearest hangar to v
- * INVALID_STATION is returned, if the company does not have any suitable
+ * StationID::Invalid() is returned, if the company does not have any suitable
  * airports (like helipads only)
  * @param v vehicle looking for a hangar
- * @return the StationID if one is found, otherwise, INVALID_STATION
+ * @return the StationID if one is found, otherwise, StationID::Invalid()
  */
 static StationID FindNearestHangar(const Aircraft *v)
 {
 	uint best = 0;
-	StationID index = INVALID_STATION;
+	StationID index = StationID::Invalid();
 	TileIndex vtile = TileVirtXY(v->x_pos, v->y_pos);
 	const AircraftVehicleInfo *avi = AircraftVehInfo(v->engine_type);
 	uint max_range = v->acache.cached_max_range_sqr;
@@ -163,7 +163,7 @@ static StationID FindNearestHangar(const Aircraft *v)
 
 		/* v->tile can't be used here, when aircraft is flying v->tile is set to 0 */
 		uint distance = DistanceSquare(vtile, st->airport.tile);
-		if (distance < best || index == INVALID_STATION) {
+		if (distance < best || index == StationID::Invalid()) {
 			best = distance;
 			index = st->index;
 		}
@@ -318,8 +318,8 @@ CommandCost CmdBuildAircraft(DoCommandFlags flags, TileIndex tile, const Engine 
 		}
 
 		v->name.clear();
-		v->last_station_visited = INVALID_STATION;
-		v->last_loading_station = INVALID_STATION;
+		v->last_station_visited = StationID::Invalid();
+		v->last_loading_station = StationID::Invalid();
 
 		v->acceleration = avi->acceleration;
 		v->engine_type = e->index;
@@ -404,7 +404,7 @@ ClosestDepot Aircraft::FindClosestDepot()
 		/* the aircraft has to search for a hangar on its own */
 		StationID station = FindNearestHangar(this);
 
-		if (station == INVALID_STATION) return ClosestDepot();
+		if (station == StationID::Invalid()) return ClosestDepot();
 
 		st = Station::Get(station);
 	}
@@ -1357,7 +1357,7 @@ static void CrashAirplane(Aircraft *v)
 		newstype = NewsType::AccidentOther;
 	}
 
-	AddTileNewsItem(newsitem, newstype, vt, st != nullptr ? st->index : INVALID_STATION);
+	AddTileNewsItem(newsitem, newstype, vt, st != nullptr ? st->index : StationID::Invalid());
 
 	ModifyStationRatingAround(vt, v->owner, -160, 30);
 	if (_settings_client.sound.disaster) SndPlayVehicleFx(SND_12_EXPLOSION, v);

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -70,7 +70,7 @@ static void PlaceAirport(TileIndex tile)
 
 	auto proc = [=](bool test, StationID to_join) -> bool {
 		if (test) {
-			return Command<CMD_BUILD_AIRPORT>::Do(CommandFlagsToDCFlags(GetCommandFlags<CMD_BUILD_AIRPORT>()), tile, airport_type, layout, INVALID_STATION, adjacent).Succeeded();
+			return Command<CMD_BUILD_AIRPORT>::Do(CommandFlagsToDCFlags(GetCommandFlags<CMD_BUILD_AIRPORT>()), tile, airport_type, layout, StationID::Invalid(), adjacent).Succeeded();
 		} else {
 			return Command<CMD_BUILD_AIRPORT>::Post(STR_ERROR_CAN_T_BUILD_AIRPORT_HERE, CcBuildAirport, tile, airport_type, layout, to_join, adjacent);
 		}

--- a/src/articulated_vehicles.cpp
+++ b/src/articulated_vehicles.cpp
@@ -29,7 +29,7 @@ static const uint MAX_ARTICULATED_PARTS = 100; ///< Maximum of articulated parts
  * @param front_type Front engine type
  * @param front Front engine
  * @param mirrored Returns whether the part shall be flipped.
- * @return engine to add or INVALID_ENGINE
+ * @return engine to add or EngineID::Invalid()
  */
 static EngineID GetNextArticulatedPart(uint index, EngineID front_type, Vehicle *front = nullptr, bool *mirrored = nullptr)
 {
@@ -38,17 +38,17 @@ static EngineID GetNextArticulatedPart(uint index, EngineID front_type, Vehicle 
 	const Engine *front_engine = Engine::Get(front_type);
 
 	uint16_t callback = GetVehicleCallback(CBID_VEHICLE_ARTIC_ENGINE, index, 0, front_type, front);
-	if (callback == CALLBACK_FAILED) return INVALID_ENGINE;
+	if (callback == CALLBACK_FAILED) return EngineID::Invalid();
 
 	if (front_engine->GetGRF()->grf_version < 8) {
 		/* 8 bits, bit 7 for mirroring */
 		callback = GB(callback, 0, 8);
-		if (callback == 0xFF) return INVALID_ENGINE;
+		if (callback == 0xFF) return EngineID::Invalid();
 		if (mirrored != nullptr) *mirrored = HasBit(callback, 7);
 		callback = GB(callback, 0, 7);
 	} else {
 		/* 15 bits, bit 14 for mirroring */
-		if (callback == 0x7FFF) return INVALID_ENGINE;
+		if (callback == 0x7FFF) return EngineID::Invalid();
 		if (mirrored != nullptr) *mirrored = HasBit(callback, 14);
 		callback = GB(callback, 0, 14);
 	}
@@ -89,7 +89,7 @@ uint CountArticulatedParts(EngineID engine_type, bool purchase_window)
 
 	uint i;
 	for (i = 1; i < MAX_ARTICULATED_PARTS; i++) {
-		if (GetNextArticulatedPart(i, engine_type, v) == INVALID_ENGINE) break;
+		if (GetNextArticulatedPart(i, engine_type, v) == EngineID::Invalid()) break;
 	}
 
 	delete v;
@@ -150,7 +150,7 @@ CargoArray GetCapacityOfArticulatedParts(EngineID engine)
 
 	for (uint i = 1; i < MAX_ARTICULATED_PARTS; i++) {
 		EngineID artic_engine = GetNextArticulatedPart(i, engine);
-		if (artic_engine == INVALID_ENGINE) break;
+		if (artic_engine == EngineID::Invalid()) break;
 
 		if (auto [cargo, cap] = GetVehicleDefaultCapacity(artic_engine); IsValidCargoType(cargo)) {
 			capacity[cargo] += cap;
@@ -180,7 +180,7 @@ CargoTypes GetCargoTypesOfArticulatedParts(EngineID engine)
 
 	for (uint i = 1; i < MAX_ARTICULATED_PARTS; i++) {
 		EngineID artic_engine = GetNextArticulatedPart(i, engine);
-		if (artic_engine == INVALID_ENGINE) break;
+		if (artic_engine == EngineID::Invalid()) break;
 
 		if (auto [cargo, cap] = GetVehicleDefaultCapacity(artic_engine); IsValidCargoType(cargo) && cap > 0) {
 			SetBit(cargoes, cargo);
@@ -206,7 +206,7 @@ bool IsArticulatedVehicleRefittable(EngineID engine)
 
 	for (uint i = 1; i < MAX_ARTICULATED_PARTS; i++) {
 		EngineID artic_engine = GetNextArticulatedPart(i, engine);
-		if (artic_engine == INVALID_ENGINE) break;
+		if (artic_engine == EngineID::Invalid()) break;
 
 		if (IsEngineRefittable(artic_engine)) return true;
 	}
@@ -233,7 +233,7 @@ void GetArticulatedRefitMasks(EngineID engine, bool include_initial_cargo_type, 
 
 	for (uint i = 1; i < MAX_ARTICULATED_PARTS; i++) {
 		EngineID artic_engine = GetNextArticulatedPart(i, engine);
-		if (artic_engine == INVALID_ENGINE) break;
+		if (artic_engine == EngineID::Invalid()) break;
 
 		veh_cargoes = GetAvailableVehicleCargoTypes(artic_engine, include_initial_cargo_type);
 		*union_mask |= veh_cargoes;
@@ -344,7 +344,7 @@ void AddArticulatedParts(Vehicle *first)
 	for (uint i = 1; i < MAX_ARTICULATED_PARTS; i++) {
 		bool flip_image;
 		EngineID engine_type = GetNextArticulatedPart(i, first->engine_type, first, &flip_image);
-		if (engine_type == INVALID_ENGINE) return;
+		if (engine_type == EngineID::Invalid()) return;
 
 		/* In the (very rare) case the GRF reported wrong number of articulated parts
 		 * and we run out of available vehicles, bail out. */

--- a/src/autoreplace.cpp
+++ b/src/autoreplace.cpp
@@ -59,7 +59,7 @@ void RemoveAllEngineReplacement(EngineRenewList *erl)
  * @param engine Engine type to be replaced.
  * @param group The group related to this replacement.
  * @param[out] replace_when_old Set to true if the replacement should be done when old.
- * @return The engine type to replace with, or INVALID_ENGINE if no
+ * @return The engine type to replace with, or EngineID::Invalid() if no
  * replacement is in the list.
  */
 EngineID EngineReplacement(EngineRenewList erl, EngineID engine, GroupID group, bool *replace_when_old)
@@ -81,7 +81,7 @@ EngineID EngineReplacement(EngineRenewList erl, EngineID engine, GroupID group, 
 			*replace_when_old = er->replace_when_old;
 		}
 	}
-	return er == nullptr ? INVALID_ENGINE : er->to;
+	return er == nullptr ? EngineID::Invalid() : er->to;
 }
 
 /**

--- a/src/autoreplace_base.h
+++ b/src/autoreplace_base.h
@@ -37,7 +37,7 @@ struct EngineRenew : EngineRenewPool::PoolItem<&_enginerenew_pool> {
 	GroupID group_id;
 	bool replace_when_old; ///< Do replacement only when vehicle is old.
 
-	EngineRenew(EngineID from = INVALID_ENGINE, EngineID to = INVALID_ENGINE) : from(from), to(to) {}
+	EngineRenew(EngineID from = EngineID::Invalid(), EngineID to = EngineID::Invalid()) : from(from), to(to) {}
 	~EngineRenew() {}
 };
 

--- a/src/autoreplace_func.h
+++ b/src/autoreplace_func.h
@@ -33,7 +33,7 @@ inline void RemoveAllEngineReplacementForCompany(Company *c)
  * @param engine Engine type.
  * @param group The group related to this replacement.
  * @param[out] replace_when_old Set to true if the replacement should be done when old.
- * @return The engine type to replace with, or INVALID_ENGINE if no
+ * @return The engine type to replace with, or EngineID::Invalid() if no
  * replacement is in the list.
  */
 inline EngineID EngineReplacementForCompany(const Company *c, EngineID engine, GroupID group, bool *replace_when_old = nullptr)
@@ -50,7 +50,7 @@ inline EngineID EngineReplacementForCompany(const Company *c, EngineID engine, G
  */
 inline bool EngineHasReplacementForCompany(const Company *c, EngineID engine, GroupID group)
 {
-	return EngineReplacementForCompany(c, engine, group) != INVALID_ENGINE;
+	return EngineReplacementForCompany(c, engine, group) != EngineID::Invalid();
 }
 
 /**

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -118,7 +118,7 @@ class ReplaceVehicleWindow : public Window {
 	void GenerateReplaceVehList(bool draw_left)
 	{
 		std::vector<EngineID> variants;
-		EngineID selected_engine = INVALID_ENGINE;
+		EngineID selected_engine = EngineID::Invalid();
 		VehicleType type = this->window_number;
 		uint8_t side = draw_left ? 0 : 1;
 
@@ -147,7 +147,7 @@ class ReplaceVehicleWindow : public Window {
 				const uint num_engines = GetGroupNumEngines(_local_company, this->sel_group, eid);
 
 				/* Skip drawing the engines we don't have any of and haven't set for replacement */
-				if (num_engines == 0 && EngineReplacementForCompany(Company::Get(_local_company), eid, this->sel_group) == INVALID_ENGINE) continue;
+				if (num_engines == 0 && EngineReplacementForCompany(Company::Get(_local_company), eid, this->sel_group) == EngineID::Invalid()) continue;
 			} else {
 				if (!CheckAutoreplaceValidity(this->sel_engine[0], eid, _local_company)) continue;
 			}
@@ -156,7 +156,7 @@ class ReplaceVehicleWindow : public Window {
 
 			if (side == 1) {
 				EngineID parent = e->info.variant_id;
-				while (parent != INVALID_ENGINE) {
+				while (parent != EngineID::Invalid()) {
 					variants.push_back(parent);
 					parent = Engine::Get(parent)->info.variant_id;
 				}
@@ -199,28 +199,28 @@ class ReplaceVehicleWindow : public Window {
 			/* We need to rebuild the left engines list */
 			this->GenerateReplaceVehList(true);
 			this->vscroll[0]->SetCount(this->engines[0].size());
-			if (this->reset_sel_engine && this->sel_engine[0] == INVALID_ENGINE && !this->engines[0].empty()) {
+			if (this->reset_sel_engine && this->sel_engine[0] == EngineID::Invalid() && !this->engines[0].empty()) {
 				this->sel_engine[0] = this->engines[0][0].engine_id;
 			}
 		}
 
 		if (this->engines[1].NeedRebuild() || e != this->sel_engine[0]) {
 			/* Either we got a request to rebuild the right engines list, or the left engines list selected a different engine */
-			if (this->sel_engine[0] == INVALID_ENGINE) {
+			if (this->sel_engine[0] == EngineID::Invalid()) {
 				/* Always empty the right engines list when nothing is selected in the left engines list */
 				this->engines[1].clear();
-				this->sel_engine[1] = INVALID_ENGINE;
+				this->sel_engine[1] = EngineID::Invalid();
 				this->vscroll[1]->SetCount(this->engines[1].size());
 			} else {
-				if (this->reset_sel_engine && this->sel_engine[0] != INVALID_ENGINE) {
+				if (this->reset_sel_engine && this->sel_engine[0] != EngineID::Invalid()) {
 					/* Select the current replacement for sel_engine[0]. */
 					const Company *c = Company::Get(_local_company);
 					this->sel_engine[1] = EngineReplacementForCompany(c, this->sel_engine[0], this->sel_group);
 				}
-				/* Regenerate the list on the right. Note: This resets sel_engine[1] to INVALID_ENGINE, if it is no longer available. */
+				/* Regenerate the list on the right. Note: This resets sel_engine[1] to EngineID::Invalid(), if it is no longer available. */
 				this->GenerateReplaceVehList(false);
 				this->vscroll[1]->SetCount(this->engines[1].size());
-				if (this->reset_sel_engine && this->sel_engine[1] != INVALID_ENGINE) {
+				if (this->reset_sel_engine && this->sel_engine[1] != EngineID::Invalid()) {
 					int position = 0;
 					for (const auto &item : this->engines[1]) {
 						if (item.engine_id == this->sel_engine[1]) break;
@@ -272,8 +272,8 @@ public:
 		this->engines[1].ForceRebuild();
 		this->reset_sel_engine = true;
 		this->details_height   = ((vehicletype == VEH_TRAIN) ? 10 : 9);
-		this->sel_engine[0] = INVALID_ENGINE;
-		this->sel_engine[1] = INVALID_ENGINE;
+		this->sel_engine[0] = EngineID::Invalid();
+		this->sel_engine[1] = EngineID::Invalid();
 		this->show_hidden_engines = _engine_sort_show_hidden_engines[vehicletype];
 
 		this->CreateNestedTree();
@@ -441,7 +441,7 @@ public:
 			case WID_RV_INFO_TAB: {
 				const Company *c = Company::Get(_local_company);
 				StringID str;
-				if (this->sel_engine[0] != INVALID_ENGINE) {
+				if (this->sel_engine[0] != EngineID::Invalid()) {
 					if (!EngineHasReplacementForCompany(c, this->sel_engine[0], this->sel_group)) {
 						str = STR_REPLACE_NOT_REPLACING;
 					} else {
@@ -479,12 +479,12 @@ public:
 		 *    Either engines list is empty
 		 * or The selected replacement engine has a replacement (to prevent loops). */
 		this->SetWidgetDisabledState(WID_RV_START_REPLACE,
-				this->sel_engine[0] == INVALID_ENGINE || this->sel_engine[1] == INVALID_ENGINE || EngineReplacementForCompany(c, this->sel_engine[1], this->sel_group) != INVALID_ENGINE);
+				this->sel_engine[0] == EngineID::Invalid() || this->sel_engine[1] == EngineID::Invalid() || EngineReplacementForCompany(c, this->sel_engine[1], this->sel_group) != EngineID::Invalid());
 
 		/* Disable the "Stop Replacing" button if:
 		 *   The left engines list (existing vehicle) is empty
 		 *   or The selected vehicle has no replacement set up */
-		this->SetWidgetDisabledState(WID_RV_STOP_REPLACE, this->sel_engine[0] == INVALID_ENGINE || !EngineHasReplacementForCompany(c, this->sel_engine[0], this->sel_group));
+		this->SetWidgetDisabledState(WID_RV_STOP_REPLACE, this->sel_engine[0] == EngineID::Invalid() || !EngineHasReplacementForCompany(c, this->sel_engine[0], this->sel_group));
 
 		this->DrawWidgets();
 
@@ -492,7 +492,7 @@ public:
 			int needed_height = this->details_height;
 			/* Draw details panels. */
 			for (int side = 0; side < 2; side++) {
-				if (this->sel_engine[side] != INVALID_ENGINE) {
+				if (this->sel_engine[side] != EngineID::Invalid()) {
 					/* Use default engine details without refitting */
 					const Engine *e = Engine::Get(this->sel_engine[side]);
 					TestedEngineDetails ted;
@@ -575,7 +575,7 @@ public:
 
 			case WID_RV_STOP_REPLACE: { // Stop replacing
 				EngineID veh_from = this->sel_engine[0];
-				Command<CMD_SET_AUTOREPLACE>::Post(this->sel_group, veh_from, INVALID_ENGINE, false);
+				Command<CMD_SET_AUTOREPLACE>::Post(this->sel_group, veh_from, EngineID::Invalid(), false);
 				break;
 			}
 
@@ -588,14 +588,14 @@ public:
 					click_side = 1;
 				}
 
-				EngineID e = INVALID_ENGINE;
+				EngineID e = EngineID::Invalid();
 				const auto it = this->vscroll[click_side]->GetScrolledItemFromWidget(this->engines[click_side], pt.y, this, widget);
 				if (it != this->engines[click_side].end()) {
 					const auto &item = *it;
 					const Rect r = this->GetWidget<NWidgetBase>(widget)->GetCurrentRect().Shrink(WidgetDimensions::scaled.matrix).WithWidth(WidgetDimensions::scaled.hsep_indent * (item.indent + 1), _current_text_dir == TD_RTL);
 					if (item.flags.Test(EngineDisplayFlag::HasVariants) && IsInsideMM(r.left, r.right, pt.x)) {
 						/* toggle folded flag on engine */
-						assert(item.variant_id != INVALID_ENGINE);
+						assert(item.variant_id != EngineID::Invalid());
 						Engine *engine = Engine::Get(item.variant_id);
 						engine->display_flags.Flip(EngineDisplayFlag::IsFolded);
 
@@ -608,10 +608,10 @@ public:
 
 				/* If Ctrl is pressed on the left side and we don't have any engines of the selected type, stop autoreplacing.
 				 * This is most common when we have finished autoreplacing the engine and want to remove it from the list. */
-				if (click_side == 0 && _ctrl_pressed && e != INVALID_ENGINE &&
+				if (click_side == 0 && _ctrl_pressed && e != EngineID::Invalid() &&
 					(GetGroupNumEngines(_local_company, sel_group, e) == 0 || GetGroupNumEngines(_local_company, ALL_GROUP, e) == 0)) {
 						EngineID veh_from = e;
-						Command<CMD_SET_AUTOREPLACE>::Post(this->sel_group, veh_from, INVALID_ENGINE, false);
+						Command<CMD_SET_AUTOREPLACE>::Post(this->sel_group, veh_from, EngineID::Invalid(), false);
 						break;
 				}
 

--- a/src/cargomonitor.h
+++ b/src/cargomonitor.h
@@ -120,22 +120,22 @@ inline bool MonitorMonitorsIndustry(CargoMonitorID num)
 /**
  * Extract the industry number from the cargo monitor.
  * @param num Cargo monitoring number to decode.
- * @return The extracted industry id, or #INVALID_INDUSTRY if the number does not monitor an industry.
+ * @return The extracted industry id, or #IndustryID::Invalid() if the number does not monitor an industry.
  */
 inline IndustryID DecodeMonitorIndustry(CargoMonitorID num)
 {
-	if (!MonitorMonitorsIndustry(num)) return INVALID_INDUSTRY;
+	if (!MonitorMonitorsIndustry(num)) return IndustryID::Invalid();
 	return static_cast<IndustryID>(GB(num, CCB_TOWN_IND_NUMBER_START, CCB_TOWN_IND_NUMBER_LENGTH));
 }
 
 /**
  * Extract the town number from the cargo monitor.
  * @param num Cargo monitoring number to decode.
- * @return The extracted town id, or #INVALID_TOWN if the number does not monitor a town.
+ * @return The extracted town id, or #TownID::Invalid() if the number does not monitor a town.
  */
 inline TownID DecodeMonitorTown(CargoMonitorID num)
 {
-	if (MonitorMonitorsIndustry(num)) return INVALID_TOWN;
+	if (MonitorMonitorsIndustry(num)) return TownID::Invalid();
 	return static_cast<TownID>(GB(num, CCB_TOWN_IND_NUMBER_START, CCB_TOWN_IND_NUMBER_LENGTH));
 }
 
@@ -143,6 +143,6 @@ void ClearCargoPickupMonitoring(CompanyID company = INVALID_OWNER);
 void ClearCargoDeliveryMonitoring(CompanyID company = INVALID_OWNER);
 int32_t GetDeliveryAmount(CargoMonitorID monitor, bool keep_monitoring);
 int32_t GetPickupAmount(CargoMonitorID monitor, bool keep_monitoring);
-void AddCargoDelivery(CargoType cargo_type, CompanyID company, uint32_t amount, Source src, const Station *st, IndustryID dest = INVALID_INDUSTRY);
+void AddCargoDelivery(CargoType cargo_type, CompanyID company, uint32_t amount, Source src, const Station *st, IndustryID dest = IndustryID::Invalid());
 
 #endif /* CARGOMONITOR_H */

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -60,8 +60,8 @@ private:
 	bool in_vehicle = false; ///< NOSAVE: Whether this cargo is in a vehicle or not.
 #endif /* WITH_ASSERT */
 
-	StationID first_station = INVALID_STATION; ///< The station where the cargo came from first.
-	StationID next_hop = INVALID_STATION; ///< Station where the cargo wants to go next.
+	StationID first_station = StationID::Invalid(); ///< The station where the cargo came from first.
+	StationID next_hop = StationID::Invalid(); ///< Station where the cargo wants to go next.
 
 	/** The CargoList caches, thus needs to know about it. */
 	template <class Tinst, class Tcont> friend class CargoList;
@@ -395,7 +395,7 @@ public:
 	 */
 	inline StationID GetFirstStation() const
 	{
-		return this->count == 0 ? INVALID_STATION : this->packets.front()->first_station;
+		return this->count == 0 ? StationID::Invalid() : this->packets.front()->first_station;
 	}
 
 	/**
@@ -557,8 +557,8 @@ public:
 		while (!next.IsEmpty()) {
 			if (this->packets.find(StationID{next.Pop()}) != this->packets.end()) return true;
 		}
-		/* Packets for INVALID_STATION can go anywhere. */
-		return this->packets.find(INVALID_STATION) != this->packets.end();
+		/* Packets for StationID::Invalid() can go anywhere. */
+		return this->packets.find(StationID::Invalid()) != this->packets.end();
 	}
 
 	/**
@@ -567,7 +567,7 @@ public:
 	 */
 	inline StationID GetFirstStation() const
 	{
-		return this->count == 0 ? INVALID_STATION : this->packets.begin()->second.front()->first_station;
+		return this->count == 0 ? StationID::Invalid() : this->packets.begin()->second.front()->first_station;
 	}
 
 	/**

--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -265,7 +265,7 @@ static void TileLoop_Clear(TileIndex tile)
 				SetClearCounter(tile, 0);
 			}
 
-			if (GetIndustryIndexOfField(tile) == INVALID_INDUSTRY && GetFieldType(tile) >= 7) {
+			if (GetIndustryIndexOfField(tile) == IndustryID::Invalid() && GetFieldType(tile) >= 7) {
 				/* This farmfield is no longer farmfield, so make it grass again */
 				MakeClear(tile, CLEAR_GRASS, 2);
 			} else {

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -26,7 +26,7 @@ class CommandCost {
 	StringID message;                           ///< Warning message for when success is unset
 	ExpensesType expense_type;                  ///< the type of expence as shown on the finances view
 	bool success;                               ///< Whether the command went fine up to this moment
-	Owner owner = INVALID_COMPANY; ///< Originator owner of error.
+	Owner owner = CompanyID::Invalid(); ///< Originator owner of error.
 	const GRFFile *textref_stack_grffile = nullptr; ///< NewGRF providing the #TextRefStack content.
 	uint textref_stack_size = 0; ///< Number of uint32_t values to put on the #TextRefStack for the error message.
 	StringID extra_message = INVALID_STRING_ID; ///< Additional warning message for when success is unset

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -73,7 +73,7 @@ Company::Company(StringID name_1, bool is_ai)
 	this->tree_limit         = (uint32_t)_settings_game.construction.tree_frame_burst << 16;
 	this->build_object_limit = (uint32_t)_settings_game.construction.build_object_frame_burst << 16;
 
-	InvalidateWindowData(WC_PERFORMANCE_DETAIL, 0, INVALID_COMPANY);
+	InvalidateWindowData(WC_PERFORMANCE_DETAIL, 0, CompanyID::Invalid());
 }
 
 /** Destructor. */
@@ -574,7 +574,7 @@ void ResetCompanyLivery(Company *c)
  * @param company CompanyID to use for the new company
  * @return the company struct
  */
-Company *DoStartupNewCompany(bool is_ai, CompanyID company = INVALID_COMPANY)
+Company *DoStartupNewCompany(bool is_ai, CompanyID company = CompanyID::Invalid())
 {
 	if (!Company::CanAllocateItem()) return nullptr;
 
@@ -582,7 +582,7 @@ Company *DoStartupNewCompany(bool is_ai, CompanyID company = INVALID_COMPANY)
 	Colours colour = GenerateCompanyColour();
 
 	Company *c;
-	if (company == INVALID_COMPANY) {
+	if (company == CompanyID::Invalid()) {
 		c = new Company(STR_SV_UNNAMED, is_ai);
 	} else {
 		if (Company::IsValidID(company)) return nullptr;
@@ -644,7 +644,7 @@ TimeoutTimer<TimerGameTick> _new_competitor_timeout({ TimerGameTick::Priority::C
 
 	/* Send a command to all clients to start up a new AI.
 	 * Works fine for Multiplayer and Singleplayer */
-	Command<CMD_COMPANY_CTRL>::Post(CCA_NEW_AI, INVALID_COMPANY, CRR_NONE, INVALID_CLIENT_ID);
+	Command<CMD_COMPANY_CTRL>::Post(CCA_NEW_AI, CompanyID::Invalid(), CRR_NONE, INVALID_CLIENT_ID);
 });
 
 /** Start of a new game. */
@@ -764,7 +764,7 @@ void OnTick_Companies()
 			for (auto i = 0; i < _settings_game.difficulty.max_no_competitors; i++) {
 				if (_networking && Company::GetNumItems() >= _settings_client.network.max_companies) break;
 				if (n++ >= _settings_game.difficulty.max_no_competitors) break;
-				Command<CMD_COMPANY_CTRL>::Post(CCA_NEW_AI, INVALID_COMPANY, CRR_NONE, INVALID_CLIENT_ID);
+				Command<CMD_COMPANY_CTRL>::Post(CCA_NEW_AI, CompanyID::Invalid(), CRR_NONE, INVALID_CLIENT_ID);
 			}
 			timeout = 10 * 60 * Ticks::TICKS_PER_SECOND;
 		}
@@ -906,15 +906,15 @@ CommandCost CmdCompanyCtrl(DoCommandFlags flags, CompanyCtrlAction cca, CompanyI
 		}
 
 		case CCA_NEW_AI: { // Make a new AI company
-			if (company_id != INVALID_COMPANY && company_id >= MAX_COMPANIES) return CMD_ERROR;
+			if (company_id != CompanyID::Invalid() && company_id >= MAX_COMPANIES) return CMD_ERROR;
 
 			/* For network games, company deletion is delayed. */
-			if (!_networking && company_id != INVALID_COMPANY && Company::IsValidID(company_id)) return CMD_ERROR;
+			if (!_networking && company_id != CompanyID::Invalid() && Company::IsValidID(company_id)) return CMD_ERROR;
 
 			if (!flags.Test(DoCommandFlag::Execute)) return CommandCost();
 
 			/* For network game, just assume deletion happened. */
-			assert(company_id == INVALID_COMPANY || !Company::IsValidID(company_id));
+			assert(company_id == CompanyID::Invalid() || !Company::IsValidID(company_id));
 
 			Company *c = DoStartupNewCompany(true, company_id);
 			if (c != nullptr) {
@@ -1325,7 +1325,7 @@ CommandCost CmdGiveMoney(DoCommandFlags flags, Money money, CompanyID dest_compa
  *  to get the index of the company:
  *  1st - get the first existing human company.
  *  2nd - get the first non-existing company.
- *  3rd - get COMPANY_FIRST.
+ *  3rd - get CompanyID::Begin().
  * @return the index of the first available company.
  */
 CompanyID GetFirstPlayableCompanyID()
@@ -1337,12 +1337,12 @@ CompanyID GetFirstPlayableCompanyID()
 	}
 
 	if (Company::CanAllocateItem()) {
-		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
+		for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 			if (!Company::IsValidID(c)) {
 				return c;
 			}
 		}
 	}
 
-	return COMPANY_FIRST;
+	return CompanyID::Begin();
 }

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -634,7 +634,7 @@ private:
 		} else {
 			const Group *g = Group::Get(this->sel);
 			livery = &g->livery;
-			if (g->parent == INVALID_GROUP) {
+			if (g->parent == GroupID::Invalid()) {
 				default_livery = &c->livery[LS_DEFAULT];
 			} else {
 				const Group *pg = Group::Get(g->parent);
@@ -697,7 +697,7 @@ public:
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_SCL_MATRIX_SCROLLBAR);
 
-		if (group == INVALID_GROUP) {
+		if (group == GroupID::Invalid()) {
 			this->livery_class = LC_OTHER;
 			this->sel = 1;
 			this->LowerWidget(WID_SCL_CLASS_GENERAL);
@@ -796,7 +796,7 @@ public:
 		bool local = this->window_number == _local_company;
 
 		/* Disable dropdown controls if no scheme is selected */
-		bool disabled = this->livery_class < LC_GROUP_RAIL ? (this->sel == 0) : (this->sel == INVALID_GROUP);
+		bool disabled = this->livery_class < LC_GROUP_RAIL ? (this->sel == 0) : (this->sel == GroupID::Invalid());
 		this->SetWidgetDisabledState(WID_SCL_PRI_COL_DROPDOWN, !local || disabled);
 		this->SetWidgetDisabledState(WID_SCL_SEC_COL_DROPDOWN, !local || disabled);
 
@@ -831,7 +831,7 @@ public:
 						}
 					}
 				} else {
-					if (this->sel != INVALID_GROUP) {
+					if (this->sel != GroupID::Invalid()) {
 						const Group *g = Group::Get(this->sel);
 						const Livery *livery = &g->livery;
 						if (HasBit(livery->in_use, primary ? 0 : 1)) {
@@ -944,7 +944,7 @@ public:
 						}
 					}
 				} else {
-					this->sel = INVALID_GROUP.base();
+					this->sel = GroupID::Invalid().base();
 					this->groups.ForceRebuild();
 					this->BuildGroupList(this->window_number);
 
@@ -1038,7 +1038,7 @@ public:
 				this->SetRows();
 
 				if (!Group::IsValidID(this->sel)) {
-					this->sel = INVALID_GROUP.base();
+					this->sel = GroupID::Invalid().base();
 					if (!this->groups.empty()) this->sel = this->groups[0].group->index.base();
 				}
 
@@ -1112,7 +1112,7 @@ void ShowCompanyLiveryWindow(CompanyID company, GroupID group)
 	SelectCompanyLiveryWindow *w = (SelectCompanyLiveryWindow *)BringWindowToFrontById(WC_COMPANY_COLOUR, company);
 	if (w == nullptr) {
 		new SelectCompanyLiveryWindow(_select_company_livery_desc, company, group);
-	} else if (group != INVALID_GROUP) {
+	} else if (group != GroupID::Invalid()) {
 		w->SetSelectedGroup(company, group);
 	}
 }
@@ -2452,7 +2452,7 @@ struct CompanyWindow : Window
 			case WID_C_NEW_FACE: DoSelectCompanyManagerFace(this); break;
 
 			case WID_C_COLOUR_SCHEME:
-				ShowCompanyLiveryWindow(this->window_number, INVALID_GROUP);
+				ShowCompanyLiveryWindow(this->window_number, GroupID::Invalid());
 				break;
 
 			case WID_C_PRESIDENT_NAME:

--- a/src/company_type.h
+++ b/src/company_type.h
@@ -14,8 +14,6 @@
 #include "core/pool_type.hpp"
 
 using CompanyID = PoolID<uint8_t, struct CompanyIDTag, 0xF, 0xFF>;
-static constexpr CompanyID COMPANY_FIRST = CompanyID::Begin();
-static constexpr CompanyID INVALID_COMPANY = CompanyID::Invalid(); ///< An invalid company
 
 /* 'Fake' companies used for networks */
 static constexpr CompanyID COMPANY_INACTIVE_CLIENT{253}; ///< The client is joining

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -40,7 +40,7 @@ void IConsoleInit()
 {
 	_iconsole_output_file = std::nullopt;
 	_redirect_console_to_client = INVALID_CLIENT_ID;
-	_redirect_console_to_admin  = INVALID_ADMIN_ID;
+	_redirect_console_to_admin  = AdminID::Invalid();
 
 	IConsoleGUIInit();
 
@@ -96,7 +96,7 @@ void IConsolePrint(TextColour colour_code, const std::string &string)
 		return;
 	}
 
-	if (_redirect_console_to_admin != INVALID_ADMIN_ID) {
+	if (_redirect_console_to_admin != AdminID::Invalid()) {
 		NetworkServerSendAdminRcon(_redirect_console_to_admin, colour_code, string);
 		return;
 	}

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1088,7 +1088,7 @@ DEF_CONSOLE_CMD(ConNetworkReconnect)
 		default:
 			/* From a user pov 0 is a new company, internally it's different and all
 			 * companies are offset by one to ease up on users (eg companies 1-8 not 0-7) */
-			if (playas < COMPANY_FIRST + 1 || playas > MAX_COMPANIES + 1) return false;
+			if (playas < CompanyID::Begin() + 1 || playas > MAX_COMPANIES + 1) return false;
 			break;
 	}
 
@@ -1451,7 +1451,7 @@ DEF_CONSOLE_CMD(ConStartAI)
 	}
 
 	/* Start a new AI company */
-	Command<CMD_COMPANY_CTRL>::Post(CCA_NEW_AI, INVALID_COMPANY, CRR_NONE, INVALID_CLIENT_ID);
+	Command<CMD_COMPANY_CTRL>::Post(CCA_NEW_AI, CompanyID::Invalid(), CRR_NONE, INVALID_CLIENT_ID);
 
 	return true;
 }
@@ -1898,7 +1898,7 @@ DEF_CONSOLE_CMD(ConSay)
 	if (!_network_server) {
 		NetworkClientSendChat(NETWORK_ACTION_CHAT, DESTTYPE_BROADCAST, 0 /* param does not matter */, argv[1]);
 	} else {
-		bool from_admin = (_redirect_console_to_admin < INVALID_ADMIN_ID);
+		bool from_admin = (_redirect_console_to_admin < AdminID::Invalid());
 		NetworkServerSendChat(NETWORK_ACTION_CHAT, DESTTYPE_BROADCAST, 0, argv[1], CLIENT_ID_SERVER, from_admin);
 	}
 
@@ -1924,7 +1924,7 @@ DEF_CONSOLE_CMD(ConSayCompany)
 	if (!_network_server) {
 		NetworkClientSendChat(NETWORK_ACTION_CHAT_COMPANY, DESTTYPE_TEAM, company_id.base(), argv[2]);
 	} else {
-		bool from_admin = (_redirect_console_to_admin < INVALID_ADMIN_ID);
+		bool from_admin = (_redirect_console_to_admin < AdminID::Invalid());
 		NetworkServerSendChat(NETWORK_ACTION_CHAT_COMPANY, DESTTYPE_TEAM, company_id.base(), argv[2], CLIENT_ID_SERVER, from_admin);
 	}
 
@@ -1944,7 +1944,7 @@ DEF_CONSOLE_CMD(ConSayClient)
 	if (!_network_server) {
 		NetworkClientSendChat(NETWORK_ACTION_CHAT_CLIENT, DESTTYPE_CLIENT, atoi(argv[1]), argv[2]);
 	} else {
-		bool from_admin = (_redirect_console_to_admin < INVALID_ADMIN_ID);
+		bool from_admin = (_redirect_console_to_admin < AdminID::Invalid());
 		NetworkServerSendChat(NETWORK_ACTION_CHAT_CLIENT, DESTTYPE_CLIENT, atoi(argv[1]), argv[2], CLIENT_ID_SERVER, from_admin);
 	}
 
@@ -1964,7 +1964,7 @@ enum ConNetworkAuthorizedKeyAction : uint8_t {
 	CNAKA_REMOVE,
 };
 
-static void PerformNetworkAuthorizedKeyAction(std::string_view name, NetworkAuthorizedKeys *authorized_keys, ConNetworkAuthorizedKeyAction action, const std::string &authorized_key, CompanyID company = INVALID_COMPANY)
+static void PerformNetworkAuthorizedKeyAction(std::string_view name, NetworkAuthorizedKeys *authorized_keys, ConNetworkAuthorizedKeyAction action, const std::string &authorized_key, CompanyID company = CompanyID::Invalid())
 {
 	switch (action) {
 		case CNAKA_LIST:
@@ -1978,7 +1978,7 @@ static void PerformNetworkAuthorizedKeyAction(std::string_view name, NetworkAuth
 				return;
 			}
 
-			if (company == INVALID_COMPANY) {
+			if (company == CompanyID::Invalid()) {
 				authorized_keys->Add(authorized_key);
 			} else {
 				AutoRestoreBackup backup(_current_company, company);
@@ -1993,7 +1993,7 @@ static void PerformNetworkAuthorizedKeyAction(std::string_view name, NetworkAuth
 				return;
 			}
 
-			if (company == INVALID_COMPANY) {
+			if (company == CompanyID::Invalid()) {
 				authorized_keys->Remove(authorized_key);
 			} else {
 				AutoRestoreBackup backup(_current_company, company);

--- a/src/depot_type.h
+++ b/src/depot_type.h
@@ -15,8 +15,6 @@
 using DepotID = PoolID<uint16_t, struct DepotIDTag, 64000, 0xFFFF>; ///< Type for the unique identifier of depots.
 struct Depot;
 
-static constexpr DepotID INVALID_DEPOT = DepotID::Invalid();
-
 static const uint MAX_LENGTH_DEPOT_NAME_CHARS = 32; ///< The maximum length of a depot name in characters including '\0'
 
 #endif /* DEPOT_TYPE_H */

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -348,7 +348,7 @@ static bool DisasterTick_Ufo(DisasterVehicle *v)
 		for (RoadVehicle *u : RoadVehicle::Iterate()) {
 			/* Find (n+1)-th road vehicle. */
 			if (u->IsFrontEngine() && (n-- == 0)) {
-				if (u->crashed_ctr != 0 || u->disaster_vehicle != INVALID_VEHICLE) {
+				if (u->crashed_ctr != 0 || u->disaster_vehicle != VehicleID::Invalid()) {
 					/* Targetted vehicle is crashed or already a target, destroy the UFO. */
 					delete v;
 					return false;
@@ -385,7 +385,7 @@ static bool DisasterTick_Ufo(DisasterVehicle *v)
 			v->age++;
 			if (u->crashed_ctr == 0) {
 				uint victims = u->Crash();
-				u->disaster_vehicle = INVALID_VEHICLE;
+				u->disaster_vehicle = VehicleID::Invalid();
 
 				AddTileNewsItem(STR_NEWS_DISASTER_SMALL_UFO, NewsType::Accident, u->tile);
 

--- a/src/disaster_vehicle.h
+++ b/src/disaster_vehicle.h
@@ -42,7 +42,7 @@ struct DisasterVehicle final : public SpecializedVehicle<DisasterVehicle, VEH_DI
 
 	/** For use by saveload. */
 	DisasterVehicle() : SpecializedVehicleBase() {}
-	DisasterVehicle(int x, int y, Direction direction, DisasterSubType subtype, VehicleID big_ufo_destroyer_target = INVALID_VEHICLE);
+	DisasterVehicle(int x, int y, Direction direction, DisasterSubType subtype, VehicleID big_ufo_destroyer_target = VehicleID::Invalid());
 	/** We want to 'destruct' the right class. */
 	virtual ~DisasterVehicle() = default;
 

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -220,7 +220,7 @@ struct BuildDocksToolbarWindow : Window {
 				bool adjacent = _ctrl_pressed;
 				auto proc = [=](bool test, StationID to_join) -> bool {
 					if (test) {
-						return Command<CMD_BUILD_DOCK>::Do(CommandFlagsToDCFlags(GetCommandFlags<CMD_BUILD_DOCK>()), tile, INVALID_STATION, adjacent).Succeeded();
+						return Command<CMD_BUILD_DOCK>::Do(CommandFlagsToDCFlags(GetCommandFlags<CMD_BUILD_DOCK>()), tile, StationID::Invalid(), adjacent).Succeeded();
 					} else {
 						return Command<CMD_BUILD_DOCK>::Post(STR_ERROR_CAN_T_BUILD_DOCK_HERE, CcBuildDocks, tile, to_join, adjacent);
 					}

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -399,7 +399,7 @@ void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner)
 				t->exclusivity = new_owner;
 			} else {
 				t->exclusive_counter = 0;
-				t->exclusivity = INVALID_COMPANY;
+				t->exclusivity = CompanyID::Invalid();
 			}
 		}
 	}
@@ -1114,7 +1114,7 @@ static Money DeliverGoods(int num_pieces, CargoType cargo_type, StationID dest, 
 	Station *st = Station::Get(dest);
 
 	/* Give the goods to the industry. */
-	uint accepted_ind = DeliverGoodsToIndustry(st, cargo_type, num_pieces, src.type == SourceType::Industry ? src.ToIndustryID() : INVALID_INDUSTRY, company->index);
+	uint accepted_ind = DeliverGoodsToIndustry(st, cargo_type, num_pieces, src.type == SourceType::Industry ? src.ToIndustryID() : IndustryID::Invalid(), company->index);
 
 	/* If this cargo type is always accepted, accept all */
 	uint accepted_total = HasBit(st->always_accepted, cargo_type) ? num_pieces : accepted_ind;
@@ -1507,7 +1507,7 @@ static void HandleStationRefit(Vehicle *v, CargoArray &consist_capleft, Station 
 
 	bool is_auto_refit = new_cargo_type == CARGO_AUTO_REFIT;
 	if (is_auto_refit) {
-		/* Get a refittable cargo type with waiting cargo for next_station or INVALID_STATION. */
+		/* Get a refittable cargo type with waiting cargo for next_station or StationID::Invalid(). */
 		new_cargo_type = v_start->cargo_type;
 		for (CargoType cargo_type : SetCargoBitIterator(refit_mask)) {
 			if (st->goods[cargo_type].HasData() && st->goods[cargo_type].GetData().cargo.HasCargoFor(next_station)) {
@@ -1531,11 +1531,11 @@ static void HandleStationRefit(Vehicle *v, CargoArray &consist_capleft, Station 
 
 	/* Refit if given a valid cargo. */
 	if (new_cargo_type < NUM_CARGO && new_cargo_type != v_start->cargo_type) {
-		/* INVALID_STATION because in the DT_MANUAL case that's correct and in the DT_(A)SYMMETRIC
+		/* StationID::Invalid() because in the DT_MANUAL case that's correct and in the DT_(A)SYMMETRIC
 		 * cases the next hop of the vehicle doesn't really tell us anything if the cargo had been
 		 * "via any station" before reserving. We rather produce some more "any station" cargo than
 		 * misrouting it. */
-		IterateVehicleParts(v_start, ReturnCargoAction(st, INVALID_STATION));
+		IterateVehicleParts(v_start, ReturnCargoAction(st, StationID::Invalid()));
 		CommandCost cost = std::get<0>(Command<CMD_REFIT_VEHICLE>::Do(DoCommandFlag::Execute, v_start->index, new_cargo_type, 0xFF, true, false, 1)); // Auto-refit and only this vehicle including artic parts.
 		if (cost.Succeeded()) v->First()->profit_this_year -= cost.GetCost() << 8;
 	}
@@ -1700,7 +1700,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 					uint new_remaining = v->cargo.RemainingCount() + v->cargo.ActionCount(VehicleCargoList::MTA_DELIVER);
 					if (v->cargo_cap < new_remaining) {
 						/* Return some of the reserved cargo to not overload the vehicle. */
-						v->cargo.Return(new_remaining - v->cargo_cap, &ge->GetOrCreateData().cargo, INVALID_STATION, v->GetCargoTile());
+						v->cargo.Return(new_remaining - v->cargo_cap, &ge->GetOrCreateData().cargo, StationID::Invalid(), v->GetCargoTile());
 					}
 
 					/* Keep instead of delivering. This may lead to no cargo being unloaded, so ...*/

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -55,7 +55,7 @@ struct Engine : EnginePool::PoolItem<&_engine_pool> {
 	uint16_t duration_phase_3;    ///< Third reliability phase in months, decaying to #reliability_final.
 	EngineFlags flags;                 ///< Flags of the engine. @see EngineFlags
 
-	CompanyID preview_company;  ///< Company which is currently being offered a preview \c INVALID_COMPANY means no company.
+	CompanyID preview_company;  ///< Company which is currently being offered a preview \c CompanyID::Invalid() means no company.
 	uint8_t preview_wait;          ///< Daily countdown timer for timeout of offering the engine to the #preview_company company.
 	uint8_t original_image_index; ///< Original vehicle image index, thus the image index of the overridden vehicle
 	VehicleType type;           ///< %Vehicle type, ie #VEH_ROAD, #VEH_TRAIN, etc.
@@ -149,7 +149,7 @@ struct Engine : EnginePool::PoolItem<&_engine_pool> {
 	 */
 	const Engine *GetDisplayVariant() const
 	{
-		if (this->display_last_variant == this->index || this->display_last_variant == INVALID_ENGINE) return this;
+		if (this->display_last_variant == this->index || this->display_last_variant == EngineID::Invalid()) return this;
 		return Engine::Get(this->display_last_variant);
 	}
 

--- a/src/engine_gui.h
+++ b/src/engine_gui.h
@@ -53,6 +53,6 @@ extern EngList_SortTypeFunction * const _engine_sort_functions[][11];
 uint GetEngineListHeight(VehicleType type);
 void DisplayVehicleSortDropDown(Window *w, VehicleType vehicle_type, int selected, WidgetID button);
 void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_list, const Scrollbar &sb, EngineID selected_id, bool show_count, GroupID selected_group);
-void GUIEngineListAddChildren(GUIEngineList &dst, const GUIEngineList &src, EngineID parent = INVALID_ENGINE, uint8_t indent = 0);
+void GUIEngineListAddChildren(GUIEngineList &dst, const GUIEngineList &src, EngineID parent = EngineID::Invalid(), uint8_t indent = 0);
 
 #endif /* ENGINE_GUI_H */

--- a/src/engine_type.h
+++ b/src/engine_type.h
@@ -22,7 +22,6 @@
 
 /** Unique identification number of an engine. */
 using EngineID = PoolID<uint16_t, struct EngineIDTag, 64000, 0xFFFF>;
-static constexpr EngineID INVALID_ENGINE = EngineID::Invalid(); ///< Constant denoting an invalid engine.
 
 struct Engine;
 

--- a/src/error.h
+++ b/src/error.h
@@ -38,17 +38,17 @@ protected:
 	EncodedString detailed_msg; ///< Detailed error message showed in second line. Can be #INVALID_STRING_ID.
 	EncodedString extra_msg; ///< Extra error message shown in third line. Can be #INVALID_STRING_ID.
 	Point position;                 ///< Position of the error message window.
-	CompanyID company; ///< Company belonging to the face being shown. #INVALID_COMPANY if no face present.
+	CompanyID company; ///< Company belonging to the face being shown. #CompanyID::Invalid() if no face present.
 
 public:
 	ErrorMessageData(const ErrorMessageData &data);
-	ErrorMessageData(EncodedString &&summary_msg, EncodedString &&detailed_msg, bool is_critical = false, int x = 0, int y = 0, const GRFFile *textref_stack_grffile = nullptr, uint textref_stack_size = 0, const uint32_t *textref_stack = nullptr, EncodedString &&extra_msg = {}, CompanyID company = INVALID_COMPANY);
+	ErrorMessageData(EncodedString &&summary_msg, EncodedString &&detailed_msg, bool is_critical = false, int x = 0, int y = 0, const GRFFile *textref_stack_grffile = nullptr, uint textref_stack_size = 0, const uint32_t *textref_stack = nullptr, EncodedString &&extra_msg = {}, CompanyID company = CompanyID::Invalid());
 
 	/* Remove the copy assignment, as the default implementation will not do the right thing. */
 	ErrorMessageData &operator=(ErrorMessageData &rhs) = delete;
 
 	/** Check whether error window shall display a company manager face */
-	bool HasFace() const { return company != INVALID_COMPANY; }
+	bool HasFace() const { return company != CompanyID::Invalid(); }
 };
 
 /** Define a queue with errors. */
@@ -58,7 +58,7 @@ void ScheduleErrorMessage(ErrorList &datas);
 void ScheduleErrorMessage(const ErrorMessageData &data);
 
 void ShowErrorMessage(EncodedString &&summary_msg, int x, int y, const CommandCost &cc);
-void ShowErrorMessage(EncodedString &&summary_msg, EncodedString &&detailed_msg, WarningLevel wl, int x = 0, int y = 0, const GRFFile *textref_stack_grffile = nullptr, uint textref_stack_size = 0, const uint32_t *textref_stack = nullptr, EncodedString &&extra_msg = {}, CompanyID company = INVALID_COMPANY);
+void ShowErrorMessage(EncodedString &&summary_msg, EncodedString &&detailed_msg, WarningLevel wl, int x = 0, int y = 0, const GRFFile *textref_stack_grffile = nullptr, uint textref_stack_size = 0, const uint32_t *textref_stack = nullptr, EncodedString &&extra_msg = {}, CompanyID company = CompanyID::Invalid());
 bool HideActiveErrorMessage();
 
 void ClearErrorMessages();

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -197,12 +197,12 @@ public:
 	void OnInvalidateData([[maybe_unused]] int data = 0, [[maybe_unused]] bool gui_scope = true) override
 	{
 		/* If company gets shut down, while displaying an error about it, remove the error message. */
-		if (this->company != INVALID_COMPANY && !Company::IsValidID(this->company)) this->Close();
+		if (this->company != CompanyID::Invalid() && !Company::IsValidID(this->company)) this->Close();
 	}
 
 	void SetStringParameters(WidgetID widget) const override
 	{
-		if (widget == WID_EM_CAPTION && this->company != INVALID_COMPANY) SetDParam(0, this->company);
+		if (widget == WID_EM_CAPTION && this->company != CompanyID::Invalid()) SetDParam(0, this->company);
 	}
 
 	void DrawWidget(const Rect &r, WidgetID widget) const override

--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -373,7 +373,7 @@ static bool TryFoundTownNearby(TileIndex tile, void *user_data)
 	TownID id = std::get<TownID>(result);
 
 	/* Check if the command failed. */
-	if (id == INVALID_TOWN) return false;
+	if (id == TownID::Invalid()) return false;
 
 	/* The command succeeded, send the ID back through user_data. */
 	town.town_id = id;

--- a/src/goal.cpp
+++ b/src/goal.cpp
@@ -57,7 +57,7 @@ INSTANTIATE_POOL_METHODS(Goal)
 		case GT_STORY_PAGE: {
 			if (!StoryPage::IsValidID(dest)) return false;
 			CompanyID story_company = StoryPage::Get(dest)->company;
-			if (company == INVALID_COMPANY ? story_company != INVALID_COMPANY : story_company != INVALID_COMPANY && story_company != company) return false;
+			if (company == CompanyID::Invalid() ? story_company != CompanyID::Invalid() : story_company != CompanyID::Invalid() && story_company != company) return false;
 			break;
 		}
 
@@ -77,12 +77,12 @@ INSTANTIATE_POOL_METHODS(Goal)
  */
 std::tuple<CommandCost, GoalID> CmdCreateGoal(DoCommandFlags flags, CompanyID company, GoalType type, GoalTypeID dest, const std::string &text)
 {
-	if (!Goal::CanAllocateItem()) return { CMD_ERROR, INVALID_GOAL };
+	if (!Goal::CanAllocateItem()) return { CMD_ERROR, GoalID::Invalid() };
 
-	if (_current_company != OWNER_DEITY) return { CMD_ERROR, INVALID_GOAL };
-	if (text.empty()) return { CMD_ERROR, INVALID_GOAL };
-	if (company != INVALID_COMPANY && !Company::IsValidID(company)) return { CMD_ERROR, INVALID_GOAL };
-	if (!Goal::IsValidGoalDestination(company, type, dest)) return { CMD_ERROR, INVALID_GOAL };
+	if (_current_company != OWNER_DEITY) return { CMD_ERROR, GoalID::Invalid() };
+	if (text.empty()) return { CMD_ERROR, GoalID::Invalid() };
+	if (company != CompanyID::Invalid() && !Company::IsValidID(company)) return { CMD_ERROR, GoalID::Invalid() };
+	if (!Goal::IsValidGoalDestination(company, type, dest)) return { CMD_ERROR, GoalID::Invalid() };
 
 	if (flags.Test(DoCommandFlag::Execute)) {
 		Goal *g = new Goal();
@@ -92,7 +92,7 @@ std::tuple<CommandCost, GoalID> CmdCreateGoal(DoCommandFlags flags, CompanyID co
 		g->text = text;
 		g->completed = false;
 
-		if (g->company == INVALID_COMPANY) {
+		if (g->company == CompanyID::Invalid()) {
 			InvalidateWindowClassesData(WC_GOALS_LIST);
 		} else {
 			InvalidateWindowData(WC_GOALS_LIST, g->company);
@@ -102,7 +102,7 @@ std::tuple<CommandCost, GoalID> CmdCreateGoal(DoCommandFlags flags, CompanyID co
 		return { CommandCost(), g->index };
 	}
 
-	return { CommandCost(), INVALID_GOAL };
+	return { CommandCost(), GoalID::Invalid() };
 }
 
 /**
@@ -121,7 +121,7 @@ CommandCost CmdRemoveGoal(DoCommandFlags flags, GoalID goal)
 		CompanyID c = g->company;
 		delete g;
 
-		if (c == INVALID_COMPANY) {
+		if (c == CompanyID::Invalid()) {
 			InvalidateWindowClassesData(WC_GOALS_LIST);
 		} else {
 			InvalidateWindowData(WC_GOALS_LIST, c);
@@ -172,7 +172,7 @@ CommandCost CmdSetGoalText(DoCommandFlags flags, GoalID goal, const std::string 
 		Goal *g = Goal::Get(goal);
 		g->text = text;
 
-		if (g->company == INVALID_COMPANY) {
+		if (g->company == CompanyID::Invalid()) {
 			InvalidateWindowClassesData(WC_GOALS_LIST);
 		} else {
 			InvalidateWindowData(WC_GOALS_LIST, g->company);
@@ -198,7 +198,7 @@ CommandCost CmdSetGoalProgress(DoCommandFlags flags, GoalID goal, const std::str
 		Goal *g = Goal::Get(goal);
 		g->progress = text;
 
-		if (g->company == INVALID_COMPANY) {
+		if (g->company == CompanyID::Invalid()) {
 			InvalidateWindowClassesData(WC_GOALS_LIST);
 		} else {
 			InvalidateWindowData(WC_GOALS_LIST, g->company);
@@ -224,7 +224,7 @@ CommandCost CmdSetGoalCompleted(DoCommandFlags flags, GoalID goal, bool complete
 		Goal *g = Goal::Get(goal);
 		g->completed = completed;
 
-		if (g->company == INVALID_COMPANY) {
+		if (g->company == CompanyID::Invalid()) {
 			InvalidateWindowClassesData(WC_GOALS_LIST);
 		} else {
 			InvalidateWindowData(WC_GOALS_LIST, g->company);
@@ -263,7 +263,7 @@ CommandCost CmdGoalQuestion(DoCommandFlags flags, uint16_t uniqueid, uint32_t ta
 		 * fact the client is no longer here. */
 		if (!flags.Test(DoCommandFlag::Execute) && _network_server && NetworkClientInfo::GetByClientID(client) == nullptr) return CMD_ERROR;
 	} else {
-		if (company != INVALID_COMPANY && !Company::IsValidID(company)) return CMD_ERROR;
+		if (company != CompanyID::Invalid() && !Company::IsValidID(company)) return CMD_ERROR;
 	}
 	uint min_buttons = (type == GQT_QUESTION ? 1 : 0);
 	if (CountBits(button_mask) < min_buttons || CountBits(button_mask) > 3) return CMD_ERROR;
@@ -273,8 +273,8 @@ CommandCost CmdGoalQuestion(DoCommandFlags flags, uint16_t uniqueid, uint32_t ta
 		if (is_client) {
 			if (client != _network_own_client_id) return CommandCost();
 		} else {
-			if (company == INVALID_COMPANY && !Company::IsValidID(_local_company)) return CommandCost();
-			if (company != INVALID_COMPANY && company != _local_company) return CommandCost();
+			if (company == CompanyID::Invalid() && !Company::IsValidID(_local_company)) return CommandCost();
+			if (company != CompanyID::Invalid() && company != _local_company) return CommandCost();
 		}
 		ShowGoalQuestion(uniqueid, type, button_mask, text);
 	}

--- a/src/goal_base.h
+++ b/src/goal_base.h
@@ -19,7 +19,7 @@ extern GoalPool _goal_pool;
 
 /** Struct about goals, current and completed */
 struct Goal : GoalPool::PoolItem<&_goal_pool> {
-	CompanyID company;    ///< Goal is for a specific company; INVALID_COMPANY if it is global
+	CompanyID company;    ///< Goal is for a specific company; CompanyID::Invalid() if it is global
 	GoalType type;        ///< Type of the goal
 	GoalTypeID dst;       ///< Index of type
 	std::string text;     ///< Text of the goal.

--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -47,7 +47,7 @@ struct GoalListWindow : public Window {
 		this->FinishInitNested(window_number);
 		this->owner = this->window_number;
 		NWidgetStacked *wi = this->GetWidget<NWidgetStacked>(WID_GOAL_SELECT_BUTTONS);
-		wi->SetDisplayedPlane(window_number == INVALID_COMPANY ? 1 : 0);
+		wi->SetDisplayedPlane(window_number == CompanyID::Invalid() ? 1 : 0);
 		this->OnInvalidateData(0);
 	}
 
@@ -55,7 +55,7 @@ struct GoalListWindow : public Window {
 	{
 		if (widget != WID_GOAL_CAPTION) return;
 
-		if (this->window_number == INVALID_COMPANY) {
+		if (this->window_number == CompanyID::Invalid()) {
 			SetDParam(0, STR_GOALS_SPECTATOR_CAPTION);
 		} else {
 			SetDParam(0, STR_GOALS_CAPTION);
@@ -67,7 +67,7 @@ struct GoalListWindow : public Window {
 	{
 		switch (widget) {
 			case WID_GOAL_GLOBAL_BUTTON:
-				ShowGoalsList(INVALID_COMPANY);
+				ShowGoalsList(CompanyID::Invalid());
 				break;
 
 			case WID_GOAL_COMPANY_BUTTON:
@@ -134,7 +134,7 @@ struct GoalListWindow : public Window {
 				 */
 				CompanyID goal_company = s->company;
 				CompanyID story_company = StoryPage::Get(s->dst)->company;
-				if (goal_company == INVALID_COMPANY ? story_company != INVALID_COMPANY : story_company != INVALID_COMPANY && story_company != goal_company) return;
+				if (goal_company == CompanyID::Invalid() ? story_company != CompanyID::Invalid() : story_company != CompanyID::Invalid() && story_company != goal_company) return;
 
 				ShowStoryBook(static_cast<CompanyID>(this->window_number), static_cast<StoryPageID>(s->dst));
 				return;
@@ -311,11 +311,11 @@ static WindowDesc _goals_list_desc(
 
 /**
  * Open a goal list window.
- * @param company %Company to display the goals for, use #INVALID_COMPANY to display global goals.
+ * @param company %Company to display the goals for, use #CompanyID::Invalid() to display global goals.
  */
 void ShowGoalsList(CompanyID company)
 {
-	if (!Company::IsValidID(company)) company = (CompanyID)INVALID_COMPANY;
+	if (!Company::IsValidID(company)) company = (CompanyID)CompanyID::Invalid();
 
 	AllocateWindowDescFront<GoalListWindow>(_goals_list_desc, company);
 }

--- a/src/goal_type.h
+++ b/src/goal_type.h
@@ -39,6 +39,5 @@ typedef uint32_t GoalTypeID; ///< Contains either tile, industry ID, town ID, co
 using GoalID = PoolID<uint16_t, struct GoalIDTag, 64000, 0xFFFF>;
 
 struct Goal;
-static constexpr GoalID INVALID_GOAL = GoalID::Invalid(); ///< Constant representing a non-existing goal.
 
 #endif /* GOAL_TYPE_H */

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -54,7 +54,7 @@ struct GraphLegendWindow : Window {
 	{
 		this->InitNested(window_number);
 
-		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
+		for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 			if (!_legend_excluded_companies.Test(c)) this->LowerWidget(WID_GL_FIRST_COMPANY + c);
 
 			this->OnInvalidateData(c.base());
@@ -676,7 +676,7 @@ public:
 		CompanyMask excluded_companies = _legend_excluded_companies;
 
 		/* Exclude the companies which aren't valid */
-		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
+		for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 			if (!Company::IsValidID(c)) excluded_companies.Set(c);
 		}
 
@@ -704,7 +704,7 @@ public:
 		this->month = mo;
 
 		this->data.clear();
-		for (CompanyID k = COMPANY_FIRST; k < MAX_COMPANIES; ++k) {
+		for (CompanyID k = CompanyID::Begin(); k < MAX_COMPANIES; ++k) {
 			const Company *c = Company::GetIfValid(k);
 			if (c == nullptr) continue;
 
@@ -1269,7 +1269,7 @@ struct PerformanceRatingDetailWindow : Window {
 		this->UpdateCompanyStats();
 
 		this->InitNested(window_number);
-		this->OnInvalidateData(INVALID_COMPANY.base());
+		this->OnInvalidateData(CompanyID::Invalid().base());
 	}
 
 	void UpdateCompanyStats()
@@ -1353,7 +1353,7 @@ struct PerformanceRatingDetailWindow : Window {
 	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		/* No need to draw when there's nothing to draw */
-		if (this->company == INVALID_COMPANY) return;
+		if (this->company == CompanyID::Invalid()) return;
 
 		if (IsInsideMM(widget, WID_PRD_COMPANY_FIRST, WID_PRD_COMPANY_LAST + 1)) {
 			if (this->IsWidgetDisabled(widget)) return;
@@ -1460,18 +1460,18 @@ struct PerformanceRatingDetailWindow : Window {
 	{
 		if (!gui_scope) return;
 		/* Disable the companies who are not active */
-		for (CompanyID i = COMPANY_FIRST; i < MAX_COMPANIES; ++i) {
+		for (CompanyID i = CompanyID::Begin(); i < MAX_COMPANIES; ++i) {
 			this->SetWidgetDisabledState(WID_PRD_COMPANY_FIRST + i, !Company::IsValidID(i));
 		}
 
 		/* Check if the currently selected company is still active. */
-		if (this->company != INVALID_COMPANY && !Company::IsValidID(this->company)) {
+		if (this->company != CompanyID::Invalid() && !Company::IsValidID(this->company)) {
 			/* Raise the widget for the previous selection. */
 			this->RaiseWidget(WID_PRD_COMPANY_FIRST + this->company);
-			this->company = INVALID_COMPANY;
+			this->company = CompanyID::Invalid();
 		}
 
-		if (this->company == INVALID_COMPANY) {
+		if (this->company == CompanyID::Invalid()) {
 			for (const Company *c : Company::Iterate()) {
 				this->company = c->index;
 				break;
@@ -1479,13 +1479,13 @@ struct PerformanceRatingDetailWindow : Window {
 		}
 
 		/* Make sure the widget is lowered */
-		if (this->company != INVALID_COMPANY) {
+		if (this->company != CompanyID::Invalid()) {
 			this->LowerWidget(WID_PRD_COMPANY_FIRST + this->company);
 		}
 	}
 };
 
-CompanyID PerformanceRatingDetailWindow::company = INVALID_COMPANY;
+CompanyID PerformanceRatingDetailWindow::company = CompanyID::Invalid();
 
 /*******************************/
 /* INDUSTRY PRODUCTION HISTORY */

--- a/src/ground_vehicle.hpp
+++ b/src/ground_vehicle.hpp
@@ -41,7 +41,7 @@ struct GroundVehicleCache {
 
 	/* Cached NewGRF values, recalculated on load and each time a vehicle is added to/removed from the consist. */
 	uint16_t cached_total_length;     ///< Length of the whole vehicle (valid only for the first engine).
-	EngineID first_engine;          ///< Cached EngineID of the front vehicle. INVALID_ENGINE for the front vehicle itself.
+	EngineID first_engine;          ///< Cached EngineID of the front vehicle. EngineID::Invalid() for the front vehicle itself.
 	uint8_t cached_veh_length;        ///< Length of this vehicle in units of 1/VEHICLE_LENGTH of normal length. It is cached because this can be set by a callback.
 
 	/* Cached UI information. */

--- a/src/group.h
+++ b/src/group.h
@@ -83,7 +83,7 @@ struct Group : GroupPool::PoolItem<&_group_pool> {
 	GroupID parent;             ///< Parent group
 	uint16_t number; ///< Per-company group number.
 
-	Group(CompanyID owner = INVALID_COMPANY);
+	Group(CompanyID owner = CompanyID::Invalid());
 };
 
 

--- a/src/group_gui.h
+++ b/src/group_gui.h
@@ -13,7 +13,7 @@
 #include "company_type.h"
 #include "vehicle_type.h"
 
-void ShowCompanyGroup(CompanyID company, VehicleType veh, GroupID group = INVALID_GROUP);
+void ShowCompanyGroup(CompanyID company, VehicleType veh, GroupID group = GroupID::Invalid());
 void ShowCompanyGroupForVehicle(const Vehicle *v);
 void DeleteGroupHighlightOfVehicle(const Vehicle *v);
 

--- a/src/group_type.h
+++ b/src/group_type.h
@@ -16,7 +16,6 @@ using GroupID = PoolID<uint16_t, struct GroupIDTag, 64000, 0xFFFF>;
 static constexpr GroupID NEW_GROUP{0xFFFC}; ///< Sentinel for a to-be-created group.
 static constexpr GroupID ALL_GROUP{0xFFFD}; ///< All vehicles are in this group.
 static constexpr GroupID DEFAULT_GROUP{0xFFFE}; ///< Ungrouped vehicles are in this group.
-static constexpr GroupID INVALID_GROUP = GroupID::Invalid(); ///< Sentinel for invalid groups.
 
 static const uint MAX_LENGTH_GROUP_NAME_CHARS = 32; ///< The maximum length of a group name in characters including '\0'
 

--- a/src/gui.h
+++ b/src/gui.h
@@ -65,7 +65,7 @@ void ShowGoalsList(CompanyID company);
 void ShowGoalQuestion(uint16_t id, uint8_t type, uint32_t button_mask, const std::string &question);
 
 /* story_gui.cpp */
-void ShowStoryBook(CompanyID company, StoryPageID page_id = INVALID_STORY_PAGE, bool centered = false);
+void ShowStoryBook(CompanyID company, StoryPageID page_id = StoryPageID::Invalid(), bool centered = false);
 
 /* viewport_gui.cpp */
 void ShowExtraViewportWindow(TileIndex tile = INVALID_TILE);

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -178,7 +178,7 @@ Industry::~Industry()
 		for (TileIndex tile_cur : ta) {
 			if (IsTileType(tile_cur, MP_CLEAR) && IsClearGround(tile_cur, CLEAR_FIELDS) &&
 					GetIndustryIndexOfField(tile_cur) == this->index) {
-				SetIndustryIndexOfField(tile_cur, INVALID_INDUSTRY);
+				SetIndustryIndexOfField(tile_cur, IndustryID::Invalid());
 			}
 		}
 	}

--- a/src/industry_type.h
+++ b/src/industry_type.h
@@ -11,7 +11,6 @@
 #define INDUSTRY_TYPE_H
 
 using IndustryID = PoolID<uint16_t, struct IndustryIDTag, 64000, 0xFFFF>;
-static constexpr IndustryID INVALID_INDUSTRY = IndustryID::Invalid();
 
 typedef uint16_t IndustryGfx;
 typedef uint8_t IndustryType;

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -62,7 +62,7 @@ struct IntroGameViewportCommand {
 
 	int command_index = 0;               ///< Sequence number of the command (order they are performed in).
 	Point position{ 0, 0 };              ///< Calculated world coordinate to position viewport top-left at.
-	VehicleID vehicle = INVALID_VEHICLE; ///< Vehicle to follow, or INVALID_VEHICLE if not following a vehicle.
+	VehicleID vehicle = VehicleID::Invalid(); ///< Vehicle to follow, or VehicleID::Invalid() if not following a vehicle.
 	uint delay = 0;                      ///< Delay until next command.
 	int zoom_adjust = 0;                 ///< Adjustment to zoom level from base zoom level.
 	bool pan_to_next = false;            ///< If true, do a smooth pan from this position to the next.
@@ -77,7 +77,7 @@ struct IntroGameViewportCommand {
 	 */
 	Point PositionForViewport(const Viewport *vp)
 	{
-		if (this->vehicle != INVALID_VEHICLE) {
+		if (this->vehicle != VehicleID::Invalid()) {
 			const Vehicle *v = Vehicle::Get(this->vehicle);
 			this->position = RemapCoords(v->x_pos, v->y_pos, v->z_pos);
 		}
@@ -228,7 +228,7 @@ struct SelectGameWindow : public Window {
 		Viewport *vp = mw->viewport;
 
 		/* Early exit if the current command hasn't elapsed and isn't animated. */
-		if (!changed_command && !vc.pan_to_next && vc.vehicle == INVALID_VEHICLE) return;
+		if (!changed_command && !vc.pan_to_next && vc.vehicle == VehicleID::Invalid()) return;
 
 		/* Suppress panning commands, while user interacts with GUIs. */
 		if (!changed_command && suppress_panning) return;
@@ -256,7 +256,7 @@ struct SelectGameWindow : public Window {
 		mw->SetDirty(); // Required during panning, otherwise logo graphics disappears
 
 		/* If there is only one command, we just executed it and don't need to do any more */
-		if (intro_viewport_commands.size() == 1 && vc.vehicle == INVALID_VEHICLE) intro_viewport_commands.clear();
+		if (intro_viewport_commands.size() == 1 && vc.vehicle == VehicleID::Invalid()) intro_viewport_commands.clear();
 	}
 
 	/**

--- a/src/league_base.h
+++ b/src/league_base.h
@@ -31,7 +31,7 @@ extern LeagueTablePool _league_table_pool;
 struct LeagueTableElement : LeagueTableElementPool::PoolItem<&_league_table_element_pool> {
 	LeagueTableID table;  ///< Id of the table which this element belongs to
 	int64_t rating;         ///< Value that determines ordering of elements in the table (higher=better)
-	CompanyID company;    ///< Company Id to show the color blob for or INVALID_COMPANY
+	CompanyID company;    ///< Company Id to show the color blob for or CompanyID::Invalid()
 	std::string text;     ///< Text of the element
 	std::string score;    ///< String representation of the score associated with the element
 	Link link;            ///< What opens when element is clicked

--- a/src/league_cmd.cpp
+++ b/src/league_cmd.cpp
@@ -55,9 +55,9 @@ bool IsValidLink(Link link)
  */
 std::tuple<CommandCost, LeagueTableID> CmdCreateLeagueTable(DoCommandFlags flags, const std::string &title, const std::string &header, const std::string &footer)
 {
-	if (_current_company != OWNER_DEITY) return { CMD_ERROR, INVALID_LEAGUE_TABLE };
-	if (!LeagueTable::CanAllocateItem()) return { CMD_ERROR, INVALID_LEAGUE_TABLE };
-	if (title.empty()) return { CMD_ERROR, INVALID_LEAGUE_TABLE };
+	if (_current_company != OWNER_DEITY) return { CMD_ERROR, LeagueTableID::Invalid() };
+	if (!LeagueTable::CanAllocateItem()) return { CMD_ERROR, LeagueTableID::Invalid() };
+	if (title.empty()) return { CMD_ERROR, LeagueTableID::Invalid() };
 
 	if (flags.Test(DoCommandFlag::Execute)) {
 		LeagueTable *lt = new LeagueTable();
@@ -67,7 +67,7 @@ std::tuple<CommandCost, LeagueTableID> CmdCreateLeagueTable(DoCommandFlags flags
 		return { CommandCost(), lt->index };
 	}
 
-	return { CommandCost(), INVALID_LEAGUE_TABLE };
+	return { CommandCost(), LeagueTableID::Invalid() };
 }
 
 
@@ -76,7 +76,7 @@ std::tuple<CommandCost, LeagueTableID> CmdCreateLeagueTable(DoCommandFlags flags
  * @param flags type of operation
  * @param table Id of the league table this element belongs to
  * @param rating Value that elements are ordered by
- * @param company Company to show the color blob for or INVALID_COMPANY
+ * @param company Company to show the color blob for or CompanyID::Invalid()
  * @param text Text of the element
  * @param score String representation of the score associated with the element
  * @param link_type Type of the referenced object
@@ -85,11 +85,11 @@ std::tuple<CommandCost, LeagueTableID> CmdCreateLeagueTable(DoCommandFlags flags
  */
 std::tuple<CommandCost, LeagueTableElementID> CmdCreateLeagueTableElement(DoCommandFlags flags, LeagueTableID table, int64_t rating, CompanyID company, const std::string &text, const std::string &score, LinkType link_type, LinkTargetID link_target)
 {
-	if (_current_company != OWNER_DEITY) return { CMD_ERROR, INVALID_LEAGUE_TABLE_ELEMENT };
-	if (!LeagueTableElement::CanAllocateItem()) return { CMD_ERROR, INVALID_LEAGUE_TABLE_ELEMENT };
+	if (_current_company != OWNER_DEITY) return { CMD_ERROR, LeagueTableElementID::Invalid() };
+	if (!LeagueTableElement::CanAllocateItem()) return { CMD_ERROR, LeagueTableElementID::Invalid() };
 	Link link{link_type, link_target};
-	if (!IsValidLink(link)) return { CMD_ERROR, INVALID_LEAGUE_TABLE_ELEMENT };
-	if (company != INVALID_COMPANY && !Company::IsValidID(company)) return { CMD_ERROR, INVALID_LEAGUE_TABLE_ELEMENT };
+	if (!IsValidLink(link)) return { CMD_ERROR, LeagueTableElementID::Invalid() };
+	if (company != CompanyID::Invalid() && !Company::IsValidID(company)) return { CMD_ERROR, LeagueTableElementID::Invalid() };
 
 	if (flags.Test(DoCommandFlag::Execute)) {
 		LeagueTableElement *lte = new LeagueTableElement();
@@ -102,14 +102,14 @@ std::tuple<CommandCost, LeagueTableElementID> CmdCreateLeagueTableElement(DoComm
 		InvalidateWindowData(WC_COMPANY_LEAGUE, table);
 		return { CommandCost(), lte->index };
 	}
-	return { CommandCost(), INVALID_LEAGUE_TABLE_ELEMENT };
+	return { CommandCost(), LeagueTableElementID::Invalid() };
 }
 
 /**
  * Update the attributes of a league table element.
  * @param flags type of operation
  * @param element Id of the element to update
- * @param company Company to show the color blob for or INVALID_COMPANY
+ * @param company Company to show the color blob for or CompanyID::Invalid()
  * @param text Text of the element
  * @param link_type Type of the referenced object
  * @param link_target Id of the referenced object
@@ -120,7 +120,7 @@ CommandCost CmdUpdateLeagueTableElementData(DoCommandFlags flags, LeagueTableEle
 	if (_current_company != OWNER_DEITY) return CMD_ERROR;
 	auto lte = LeagueTableElement::GetIfValid(element);
 	if (lte == nullptr) return CMD_ERROR;
-	if (company != INVALID_COMPANY && !Company::IsValidID(company)) return CMD_ERROR;
+	if (company != CompanyID::Invalid() && !Company::IsValidID(company)) return CMD_ERROR;
 	Link link{link_type, link_target};
 	if (!IsValidLink(link)) return CMD_ERROR;
 

--- a/src/league_gui.cpp
+++ b/src/league_gui.cpp
@@ -343,7 +343,7 @@ public:
 		for (auto [rank, lte] : this->rows) {
 			SetDParam(0, rank + 1);
 			DrawString(rank_rect.left, rank_rect.right, ir.top + text_y_offset, STR_COMPANY_LEAGUE_COMPANY_RANK);
-			if (this->icon_size.width > 0 && lte->company != INVALID_COMPANY) DrawCompanyIcon(lte->company, icon_rect.left, ir.top + icon_y_offset);
+			if (this->icon_size.width > 0 && lte->company != CompanyID::Invalid()) DrawCompanyIcon(lte->company, icon_rect.left, ir.top + icon_y_offset);
 			SetDParamStr(0, lte->text);
 			DrawString(text_rect.left, text_rect.right, ir.top + text_y_offset, STR_JUST_RAW_STRING, TC_BLACK);
 			SetDParamStr(0, lte->score);
@@ -378,7 +378,7 @@ public:
 			this->text_width = std::max(this->text_width, GetStringBoundingBox(STR_JUST_RAW_STRING).width);
 			SetDParamStr(0, lte->score);
 			this->score_width = std::max(this->score_width, GetStringBoundingBox(STR_JUST_RAW_STRING).width);
-			if (lte->company != INVALID_COMPANY) show_icon_column = true;
+			if (lte->company != CompanyID::Invalid()) show_icon_column = true;
 		}
 
 		if (!show_icon_column) this->icon_size.width = 0;

--- a/src/league_type.h
+++ b/src/league_type.h
@@ -33,10 +33,8 @@ struct Link {
 
 using LeagueTableID = PoolID<uint8_t, struct LeagueTableIDTag, 255, 0xFF>; ///< ID of a league table
 struct LeagueTable;
-static constexpr LeagueTableID INVALID_LEAGUE_TABLE = LeagueTableID::Invalid(); ///< Invalid/unknown index of LeagueTable
 
 using LeagueTableElementID = PoolID<uint16_t, struct LeagueTableElementIDTag, 64000, 0xFFFF>; ///< ID of a league table
 struct LeagueTableElement;
-static constexpr LeagueTableElementID INVALID_LEAGUE_TABLE_ELEMENT = LeagueTableElementID::Invalid(); ///< Invalid/unknown index of LeagueTableElement
 
 #endif /* LEAGUE_TYPE_H */

--- a/src/linkgraph/linkgraph.h
+++ b/src/linkgraph/linkgraph.h
@@ -96,7 +96,7 @@ public:
 
 		std::vector<BaseEdge> edges; ///< Sorted list of outgoing edges from this node.
 
-		BaseNode(TileIndex xy = INVALID_TILE, StationID st = INVALID_STATION, uint demand = 0);
+		BaseNode(TileIndex xy = INVALID_TILE, StationID st = StationID::Invalid(), uint demand = 0);
 
 		/**
 		 * Update the node's supply and set last_update to the current date.

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -561,7 +561,7 @@ void LinkGraphLegendWindow::SetOverlay(std::shared_ptr<LinkGraphOverlay> overlay
 {
 	this->overlay = overlay;
 	CompanyMask companies = this->overlay->GetCompanyMask();
-	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
+	for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 		if (!this->IsWidgetDisabled(WID_LGL_COMPANY_FIRST + c)) {
 			this->SetWidgetLoweredState(WID_LGL_COMPANY_FIRST + c, companies.Test(c));
 		}
@@ -658,7 +658,7 @@ bool LinkGraphLegendWindow::OnTooltip([[maybe_unused]] Point, WidgetID widget, T
 void LinkGraphLegendWindow::UpdateOverlayCompanies()
 {
 	CompanyMask mask;
-	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
+	for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 		if (this->IsWidgetDisabled(WID_LGL_COMPANY_FIRST + c)) continue;
 		if (!this->IsWidgetLowered(WID_LGL_COMPANY_FIRST + c)) continue;
 		mask.Set(c);
@@ -688,7 +688,7 @@ void LinkGraphLegendWindow::OnClick([[maybe_unused]] Point pt, WidgetID widget, 
 			this->UpdateOverlayCompanies();
 		}
 	} else if (widget == WID_LGL_COMPANIES_ALL || widget == WID_LGL_COMPANIES_NONE) {
-		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
+		for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 			if (this->IsWidgetDisabled(WID_LGL_COMPANY_FIRST + c)) continue;
 			this->SetWidgetLoweredState(WID_LGL_COMPANY_FIRST + c, widget == WID_LGL_COMPANIES_ALL);
 		}
@@ -719,7 +719,7 @@ void LinkGraphLegendWindow::OnInvalidateData([[maybe_unused]] int data, [[maybe_
 	}
 
 	/* Disable the companies who are not active */
-	for (CompanyID i = COMPANY_FIRST; i < MAX_COMPANIES; ++i) {
+	for (CompanyID i = CompanyID::Begin(); i < MAX_COMPANIES; ++i) {
 		this->SetWidgetDisabledState(WID_LGL_COMPANY_FIRST + i, !Company::IsValidID(i));
 	}
 }

--- a/src/linkgraph/linkgraph_type.h
+++ b/src/linkgraph/linkgraph_type.h
@@ -13,10 +13,7 @@
 #include "../core/pool_type.hpp"
 
 using LinkGraphID = PoolID<uint16_t, struct LinkGraphIDTag, 0xFFFF, 0xFFFF>;
-static constexpr LinkGraphID INVALID_LINK_GRAPH = LinkGraphID::Invalid();
-
 using LinkGraphJobID = PoolID<uint16_t, struct LinkGraphJobIDTag, 0xFFFF, 0xFFFF>;
-static constexpr LinkGraphJobID INVALID_LINK_GRAPH_JOB = LinkGraphJobID::Invalid();
 
 typedef uint16_t NodeID;
 static const NodeID INVALID_NODE = UINT16_MAX;

--- a/src/linkgraph/linkgraphjob.cpp
+++ b/src/linkgraph/linkgraphjob.cpp
@@ -156,7 +156,7 @@ LinkGraphJob::~LinkGraphJob()
 					it->second.Invalidate();
 					++it;
 				} else {
-					FlowStat shares(INVALID_STATION, 1);
+					FlowStat shares(StationID::Invalid(), 1);
 					it->second.SwapShares(shares);
 					geflows.erase(it++);
 					for (FlowStat::SharesMap::const_iterator shares_it(shares.GetShares()->begin());

--- a/src/linkgraph/refresh.cpp
+++ b/src/linkgraph/refresh.cpp
@@ -35,7 +35,7 @@
 	HopSet seen_hops;
 	LinkRefresher refresher(v, &seen_hops, allow_merge, is_full_loading);
 
-	refresher.RefreshLinks(first, first, v->last_loading_station != INVALID_STATION ? 1 << HAS_CARGO : 0);
+	refresher.RefreshLinks(first, first, v->last_loading_station != StationID::Invalid() ? 1 << HAS_CARGO : 0);
 }
 
 /**
@@ -200,7 +200,7 @@ void LinkRefresher::RefreshStats(const Order *cur, const Order *next)
 {
 	StationID next_station = next->GetDestination().ToStationID();
 	Station *st = Station::GetIfValid(cur->GetDestination().ToStationID());
-	if (st != nullptr && next_station != INVALID_STATION && next_station != st->index) {
+	if (st != nullptr && next_station != StationID::Invalid() && next_station != st->index) {
 		Station *st_to = Station::Get(next_station);
 		for (CargoType c = 0; c < NUM_CARGO; c++) {
 			/* Refresh the link and give it a minimum capacity. */

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -436,7 +436,7 @@ struct MainWindow : Window
 			bool in = wheel < 0;
 
 			/* When following, only change zoom - otherwise zoom to the cursor. */
-			if (this->viewport->follow_vehicle != INVALID_VEHICLE) {
+			if (this->viewport->follow_vehicle != VehicleID::Invalid()) {
 				DoZoomInOutWindow(in ? ZOOM_IN : ZOOM_OUT, this);
 			} else {
 				ZoomInOrOutToCursorWindow(in, this);

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -29,7 +29,7 @@
 /* This file handles all the admin network commands. */
 
 /** Redirection of the (remote) console to the admin. */
-AdminID _redirect_console_to_admin = INVALID_ADMIN_ID;
+AdminID _redirect_console_to_admin = AdminID::Invalid();
 
 /** The pool with sockets/clients. */
 NetworkAdminSocketPool _networkadminsocket_pool("NetworkAdminSocket");
@@ -74,7 +74,7 @@ ServerNetworkAdminSocketHandler::ServerNetworkAdminSocketHandler(SOCKET s) : Net
 ServerNetworkAdminSocketHandler::~ServerNetworkAdminSocketHandler()
 {
 	Debug(net, 3, "[admin] '{}' ({}) has disconnected", this->admin_name, this->admin_version);
-	if (_redirect_console_to_admin == this->index) _redirect_console_to_admin = INVALID_ADMIN_ID;
+	if (_redirect_console_to_admin == this->index) _redirect_console_to_admin = AdminID::Invalid();
 
 	if (this->update_frequency[ADMIN_UPDATE_CONSOLE] & ADMIN_FREQUENCY_AUTOMATIC) {
 		this->update_frequency[ADMIN_UPDATE_CONSOLE] = (AdminUpdateFrequency)0;
@@ -492,7 +492,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_RCON(Packet &p)
 
 	_redirect_console_to_admin = this->index;
 	IConsoleCmdExec(command);
-	_redirect_console_to_admin = INVALID_ADMIN_ID;
+	_redirect_console_to_admin = AdminID::Invalid();
 	return this->SendRconEnd(command);
 }
 

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -858,7 +858,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_MAP_DONE(Packet
 			Debug(net, 9, "Client::join_status = REGISTERING");
 			_network_join_status = NETWORK_JOIN_STATUS_REGISTERING;
 			ShowJoinStatusWindow();
-			Command<CMD_COMPANY_CTRL>::Post(CCA_NEW, INVALID_COMPANY, CRR_NONE, _network_own_client_id);
+			Command<CMD_COMPANY_CTRL>::Post(CCA_NEW, CompanyID::Invalid(), CRR_NONE, _network_own_client_id);
 		}
 	} else {
 		/* take control over an existing company */

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -57,7 +57,7 @@
 static void ShowNetworkStartServerWindow();
 
 static ClientID _admin_client_id = INVALID_CLIENT_ID; ///< For what client a confirmation window is open.
-static CompanyID _admin_company_id = INVALID_COMPANY; ///< For what company a confirmation window is open.
+static CompanyID _admin_company_id = CompanyID::Invalid(); ///< For what company a confirmation window is open.
 
 /**
  * Update the network new window because a new server is
@@ -1462,7 +1462,7 @@ private:
 	 */
 	static void OnClickCompanyNew([[maybe_unused]] NetworkClientListWindow *w, [[maybe_unused]] Point pt, CompanyID)
 	{
-		Command<CMD_COMPANY_CTRL>::Post(CCA_NEW, INVALID_COMPANY, CRR_NONE, _network_own_client_id);
+		Command<CMD_COMPANY_CTRL>::Post(CCA_NEW, CompanyID::Invalid(), CRR_NONE, _network_own_client_id);
 	}
 
 	/**

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -92,7 +92,7 @@ void UpdateNetworkGameWindow();
  * Everything we need to know about a command to be able to execute it.
  */
 struct CommandPacket {
-	CommandPacket() : company(INVALID_COMPANY), frame(0), my_cmd(false) {}
+	CommandPacket() : company(CompanyID::Invalid()), frame(0), my_cmd(false) {}
 	CompanyID company;   ///< company that is executing the command
 	uint32_t frame;        ///< the frame in which this packet is executed
 	bool my_cmd;         ///< did the command originate from "me"

--- a/src/network/network_type.h
+++ b/src/network/network_type.h
@@ -52,9 +52,6 @@ using ClientPoolID = PoolID<uint16_t, struct ClientPoolIDTag, MAX_CLIENTS + 1 /*
 /** Indices into the admin tables. */
 using AdminID = PoolID<uint8_t, struct AdminIDTag, 16, 0xFF>;
 
-/** An invalid admin marker. */
-static constexpr AdminID INVALID_ADMIN_ID = AdminID::Invalid();
-
 /** Simple calculated statistics of a company */
 struct NetworkCompanyStats {
 	uint16_t num_vehicle[NETWORK_VEH_END];            ///< How many vehicles are there of this type?

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -644,7 +644,7 @@ static Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t inte
 
 		/* Check if the engine is registered in the override manager */
 		EngineID engine = _engine_mngr.GetID(type, internal_id, scope_grfid);
-		if (engine != INVALID_ENGINE) {
+		if (engine != EngineID::Invalid()) {
 			Engine *e = Engine::Get(engine);
 			if (!e->grf_prop.HasGrfFile()) {
 				e->grf_prop.grfid = file->grfid;
@@ -656,7 +656,7 @@ static Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t inte
 
 	/* Check if there is an unreserved slot */
 	EngineID engine = _engine_mngr.UseUnreservedID(type, internal_id, scope_grfid, static_access);
-	if (engine != INVALID_ENGINE) {
+	if (engine != EngineID::Invalid()) {
 		Engine *e = Engine::Get(engine);
 
 		if (!e->grf_prop.HasGrfFile()) {
@@ -9244,7 +9244,7 @@ static void FinaliseEngineArray()
 		}
 
 		/* Do final mapping on variant engine ID. */
-		if (e->info.variant_id != INVALID_ENGINE) {
+		if (e->info.variant_id != EngineID::Invalid()) {
 			e->info.variant_id = GetNewEngineID(e->grf_prop.grffile, e->type, e->info.variant_id.base());
 		}
 
@@ -9252,7 +9252,7 @@ static void FinaliseEngineArray()
 
 		/* Skip wagons, there livery is defined via the engine */
 		if (e->type != VEH_TRAIN || e->u.rail.railveh_type != RAILVEH_WAGON) {
-			LiveryScheme ls = GetEngineLiveryScheme(e->index, INVALID_ENGINE, nullptr);
+			LiveryScheme ls = GetEngineLiveryScheme(e->index, EngineID::Invalid(), nullptr);
 			SetBit(_loaded_newgrf_features.used_liveries, ls);
 			/* Note: For ships and roadvehicles we assume that they cannot be refitted between passenger and freight */
 
@@ -9282,18 +9282,18 @@ static void FinaliseEngineArray()
 	 * on variant engine. This is performed separately as all variant engines need to have been resolved. */
 	for (Engine *e : Engine::Iterate()) {
 		EngineID parent = e->info.variant_id;
-		while (parent != INVALID_ENGINE) {
+		while (parent != EngineID::Invalid()) {
 			parent = Engine::Get(parent)->info.variant_id;
 			if (parent != e->index) continue;
 
 			/* Engine looped back on itself, so clear the variant. */
-			e->info.variant_id = INVALID_ENGINE;
+			e->info.variant_id = EngineID::Invalid();
 
 			GrfMsg(1, "FinaliseEngineArray: Variant of engine {:x} in '{}' loops back on itself", e->grf_prop.local_id, e->GetGRF()->filename);
 			break;
 		}
 
-		if (e->info.variant_id != INVALID_ENGINE) {
+		if (e->info.variant_id != EngineID::Invalid()) {
 			Engine::Get(e->info.variant_id)->display_flags.Set(EngineDisplayFlag::HasVariants).Set(EngineDisplayFlag::IsFolded);
 		}
 	}

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -437,7 +437,7 @@ struct NewGRFInspectWindow : Window {
 		GrfSpecFeature f = GetFeatureNum(this->window_number);
 		int h = GetVehicleImageCellSize((VehicleType)(VEH_TRAIN + (f - GSF_TRAINS)), EIT_IN_DEPOT).height;
 		int y = CenterBounds(br.top, br.bottom, h);
-		DrawVehicleImage(v->First(), br, INVALID_VEHICLE, EIT_IN_DETAILS, skip);
+		DrawVehicleImage(v->First(), br, VehicleID::Invalid(), EIT_IN_DETAILS, skip);
 
 		/* Highlight the articulated part (this is different to the whole-vehicle highlighting of DrawVehicleImage */
 		if (_current_text_dir == TD_RTL) {

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -376,11 +376,11 @@ static const Livery *LiveryHelper(EngineID engine, const Vehicle *v)
 
 	if (v == nullptr) {
 		if (!Company::IsValidID(_current_company)) return nullptr;
-		l = GetEngineLivery(engine, _current_company, INVALID_ENGINE, nullptr, LIT_ALL);
+		l = GetEngineLivery(engine, _current_company, EngineID::Invalid(), nullptr, LIT_ALL);
 	} else if (v->IsGroundVehicle()) {
 		l = GetEngineLivery(v->engine_type, v->owner, v->GetGroundVehicleCache()->first_engine, v, LIT_ALL);
 	} else {
-		l = GetEngineLivery(v->engine_type, v->owner, INVALID_ENGINE, v, LIT_ALL);
+		l = GetEngineLivery(v->engine_type, v->owner, EngineID::Invalid(), v, LIT_ALL);
 	}
 
 	return l;
@@ -839,7 +839,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 		case 0x57: return GB(ClampTo<int32_t>(v->GetDisplayProfitLastYear()),  8, 24);
 		case 0x58: return GB(ClampTo<int32_t>(v->GetDisplayProfitLastYear()), 16, 16);
 		case 0x59: return GB(ClampTo<int32_t>(v->GetDisplayProfitLastYear()), 24,  8);
-		case 0x5A: return (v->Next() == nullptr ? INVALID_VEHICLE : v->Next()->index).base();
+		case 0x5A: return (v->Next() == nullptr ? VehicleID::Invalid() : v->Next()->index).base();
 		case 0x5B: break; // not implemented
 		case 0x5C: return ClampTo<int32_t>(v->value);
 		case 0x5D: return GB(ClampTo<int32_t>(v->value),  8, 24);
@@ -964,7 +964,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 			case 0xC4: return (Clamp(TimerGameCalendar::year, CalendarTime::ORIGINAL_BASE_YEAR, CalendarTime::ORIGINAL_MAX_YEAR) - CalendarTime::ORIGINAL_BASE_YEAR).base(); // Build year
 			case 0xC6: return Engine::Get(this->self_type)->grf_prop.local_id;
 			case 0xC7: return GB(Engine::Get(this->self_type)->grf_prop.local_id, 8, 8);
-			case 0xDA: return INVALID_VEHICLE.base(); // Next vehicle
+			case 0xDA: return VehicleID::Invalid().base(); // Next vehicle
 			case 0xF2: return 0; // Cargo subtype
 		}
 
@@ -1345,7 +1345,7 @@ void CommitVehicleListOrderChanges()
 		if (engine_source->grf_prop.local_id == loc.target) continue;
 
 		EngineID target = _engine_mngr.GetID(engine_source->type, loc.target, engine_source->grf_prop.grfid);
-		if (target == INVALID_ENGINE) continue;
+		if (target == EngineID::Invalid()) continue;
 
 		auto it_source = std::ranges::find(ordering, source);
 		auto it_target = std::ranges::find(ordering, target);

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -269,7 +269,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t param_setID, uint8_
 		/* Land info of nearby tiles */
 		case 0x62:
 			if (this->tile == INVALID_TILE) break;
-			return GetNearbyIndustryTileInformation(parameter, this->tile, INVALID_INDUSTRY, false, this->ro.grffile->grf_version >= 8);
+			return GetNearbyIndustryTileInformation(parameter, this->tile, IndustryID::Invalid(), false, this->ro.grffile->grf_version >= 8);
 
 		/* Animation stage of nearby tiles */
 		case 0x63: {
@@ -435,7 +435,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t param_setID, uint8_
 
 /* virtual */ void IndustriesScopeResolver::StorePSA(uint pos, int32_t value)
 {
-	if (this->industry->index == INVALID_INDUSTRY) return;
+	if (this->industry->index == IndustryID::Invalid()) return;
 
 	if (this->industry->psa == nullptr) {
 		/* There is no need to create a storage if the value is zero. */
@@ -490,7 +490,7 @@ TownScopeResolver *IndustriesResolverObject::GetTown()
 		bool readonly = true;
 		if (this->industries_scope.industry != nullptr) {
 			t = this->industries_scope.industry->town;
-			readonly = this->industries_scope.industry->index == INVALID_INDUSTRY;
+			readonly = this->industries_scope.industry->index == IndustryID::Invalid();
 		} else if (this->industries_scope.tile != INVALID_TILE) {
 			t = ClosestTownFromTile(this->industries_scope.tile, UINT_MAX);
 		}
@@ -542,7 +542,7 @@ CommandCost CheckIfCallBackAllowsCreation(TileIndex tile, IndustryType type, siz
 	const IndustrySpec *indspec = GetIndustrySpec(type);
 
 	Industry ind;
-	ind.index = INVALID_INDUSTRY;
+	ind.index = IndustryID::Invalid();
 	ind.location.tile = tile;
 	ind.location.w = 0; // important to mark the industry invalid
 	ind.type = type;

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -78,7 +78,7 @@ uint32_t GetRelativePosition(TileIndex tile, TileIndex ind_tile)
 
 		/* Land info of nearby tiles */
 		case 0x60: return GetNearbyIndustryTileInformation(parameter, this->tile,
-				this->industry == nullptr ? (IndustryID)INVALID_INDUSTRY : this->industry->index, true, this->ro.grffile->grf_version >= 8);
+				this->industry == nullptr ? (IndustryID)IndustryID::Invalid() : this->industry->index, true, this->ro.grffile->grf_version >= 8);
 
 		/* Animation stage of nearby tiles */
 		case 0x61: {
@@ -102,16 +102,16 @@ uint32_t GetRelativePosition(TileIndex tile, TileIndex ind_tile)
 /* virtual */ uint32_t IndustryTileScopeResolver::GetRandomBits() const
 {
 	assert(this->industry != nullptr && IsValidTile(this->tile));
-	assert(this->industry->index == INVALID_INDUSTRY || IsTileType(this->tile, MP_INDUSTRY));
+	assert(this->industry->index == IndustryID::Invalid() || IsTileType(this->tile, MP_INDUSTRY));
 
-	return (this->industry->index != INVALID_INDUSTRY) ? GetIndustryRandomBits(this->tile) : 0;
+	return (this->industry->index != IndustryID::Invalid()) ? GetIndustryRandomBits(this->tile) : 0;
 }
 
 /* virtual */ uint32_t IndustryTileScopeResolver::GetTriggers() const
 {
 	assert(this->industry != nullptr && IsValidTile(this->tile));
-	assert(this->industry->index == INVALID_INDUSTRY || IsTileType(this->tile, MP_INDUSTRY));
-	if (this->industry->index == INVALID_INDUSTRY) return 0;
+	assert(this->industry->index == IndustryID::Invalid() || IsTileType(this->tile, MP_INDUSTRY));
+	if (this->industry->index == IndustryID::Invalid()) return 0;
 	return GetIndustryTriggers(this->tile);
 }
 
@@ -181,7 +181,7 @@ static void IndustryDrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGro
 uint16_t GetIndustryTileCallback(CallbackID callback, uint32_t param1, uint32_t param2, IndustryGfx gfx_id, Industry *industry, TileIndex tile)
 {
 	assert(industry != nullptr && IsValidTile(tile));
-	assert(industry->index == INVALID_INDUSTRY || IsTileType(tile, MP_INDUSTRY));
+	assert(industry->index == IndustryID::Invalid() || IsTileType(tile, MP_INDUSTRY));
 
 	IndustryTileResolverObject object(gfx_id, tile, industry, callback, param1, param2);
 	return object.ResolveCallback();
@@ -230,7 +230,7 @@ extern bool IsSlopeRefused(Slope current, Slope refused);
 CommandCost PerformIndustryTileSlopeCheck(TileIndex ind_base_tile, TileIndex ind_tile, const IndustryTileSpec *its, IndustryType type, IndustryGfx gfx, size_t layout_index, uint16_t initial_random_bits, Owner founder, IndustryAvailabilityCallType creation_type)
 {
 	Industry ind;
-	ind.index = INVALID_INDUSTRY;
+	ind.index = IndustryID::Invalid();
 	ind.location.tile = ind_base_tile;
 	ind.location.w = 0;
 	ind.type = type;

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -346,7 +346,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t local_id, uint32_t 
 		}
 
 		/* Land info of nearby tiles */
-		case 0x62: return GetNearbyObjectTileInformation(parameter, this->tile, this->obj == nullptr ? INVALID_OBJECT : this->obj->index, this->ro.grffile->grf_version >= 8);
+		case 0x62: return GetNearbyObjectTileInformation(parameter, this->tile, this->obj == nullptr ? ObjectID::Invalid() : this->obj->index, this->ro.grffile->grf_version >= 8);
 
 		/* Animation counter of nearby tile */
 		case 0x63: {

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -457,7 +457,7 @@ uint32_t Station::GetNewGRFVariable(const ResolverObject &object, uint8_t variab
 			case 1: return GB(g->HasData() ? std::min(g->GetData().cargo.TotalCount(), 4095u) : 0, 0, 4) | (GB(g->status, GoodsEntry::GES_ACCEPTANCE, 1) << 7);
 			case 2: return g->time_since_pickup;
 			case 3: return g->rating;
-			case 4: return (g->HasData() ? g->GetData().cargo.GetFirstStation() : INVALID_STATION).base();
+			case 4: return (g->HasData() ? g->GetData().cargo.GetFirstStation() : StationID::Invalid()).base();
 			case 5: return g->HasData() ? g->GetData().cargo.PeriodsInTransit() : 0;
 			case 6: return g->last_speed;
 			case 7: return g->last_age;
@@ -491,7 +491,7 @@ uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, uint8_t variable, [
 	if (variable >= 0x8C && variable <= 0xEC) {
 		switch (GB(variable - 0x8C, 0, 3)) {
 			case 3: return INITIAL_STATION_RATING;
-			case 4: return INVALID_STATION.base();
+			case 4: return StationID::Invalid().base();
 			default: return 0;
 		}
 	}

--- a/src/news_func.h
+++ b/src/news_func.h
@@ -27,9 +27,9 @@ inline void AddCompanyNewsItem(StringID string, std::unique_ptr<CompanyNewsInfor
  *
  * @warning The DParams may not reference the vehicle due to autoreplace stuff. See AddVehicleAdviceNewsItem for how that can be done.
  */
-inline void AddVehicleNewsItem(StringID string, NewsType type, VehicleID vehicle, StationID station = INVALID_STATION)
+inline void AddVehicleNewsItem(StringID string, NewsType type, VehicleID vehicle, StationID station = StationID::Invalid())
 {
-	AddNewsItem(string, type, NewsStyle::Thin, {NewsFlag::NoTransparency, NewsFlag::Shaded}, vehicle, station == INVALID_STATION ? NewsReference{} : station);
+	AddNewsItem(string, type, NewsStyle::Thin, {NewsFlag::NoTransparency, NewsFlag::Shaded}, vehicle, station == StationID::Invalid() ? NewsReference{} : station);
 }
 
 /**
@@ -42,9 +42,9 @@ inline void AddVehicleAdviceNewsItem(AdviceType advice_type, StringID string, Ve
 	AddNewsItem(string, NewsType::Advice, NewsStyle::Small, {NewsFlag::InColour, NewsFlag::VehicleParam0}, vehicle, {}, nullptr, advice_type);
 }
 
-inline void AddTileNewsItem(StringID string, NewsType type, TileIndex tile, StationID station = INVALID_STATION)
+inline void AddTileNewsItem(StringID string, NewsType type, TileIndex tile, StationID station = StationID::Invalid())
 {
-	AddNewsItem(string, type, NewsStyle::Thin, {NewsFlag::NoTransparency, NewsFlag::Shaded}, tile, station == INVALID_STATION ? NewsReference{} : station);
+	AddNewsItem(string, type, NewsStyle::Thin, {NewsFlag::NoTransparency, NewsFlag::Shaded}, tile, station == StationID::Invalid() ? NewsReference{} : station);
 }
 
 inline void AddIndustryNewsItem(StringID string, NewsType type, IndustryID industry)

--- a/src/object_type.h
+++ b/src/object_type.h
@@ -32,6 +32,4 @@ using ObjectID = PoolID<uint32_t, struct ObjectIDTag, 0xFF0000, 0xFFFFFFFF>;
 struct Object;
 struct ObjectSpec;
 
-static constexpr ObjectID INVALID_OBJECT = ObjectID::Invalid(); ///< An invalid object
-
 #endif /* OBJECT_TYPE_H */

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -95,7 +95,7 @@ void CallWindowGameTickEvent();
 bool HandleBootstrap();
 
 extern void CheckCaches();
-extern Company *DoStartupNewCompany(bool is_ai, CompanyID company = INVALID_COMPANY);
+extern Company *DoStartupNewCompany(bool is_ai, CompanyID company = CompanyID::Invalid());
 extern void OSOpenBrowser(const std::string &url);
 extern void ShowOSErrorBox(const char *buf, bool system);
 extern std::string _config_file;
@@ -327,7 +327,7 @@ static void LoadIntroGame(bool load_newgrfs = true)
 		GenerateWorld(GWM_EMPTY, 64, 64); // if failed loading, make empty world.
 		SetLocalCompany(COMPANY_SPECTATOR);
 	} else {
-		SetLocalCompany(COMPANY_FIRST);
+		SetLocalCompany(CompanyID::Begin());
 	}
 
 	FixTitleGameZoom();
@@ -341,7 +341,7 @@ static void LoadIntroGame(bool load_newgrfs = true)
 
 void MakeNewgameSettingsLive()
 {
-	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
+	for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 		if (_settings_game.ai_config[c] != nullptr) {
 			delete _settings_game.ai_config[c];
 		}
@@ -355,7 +355,7 @@ void MakeNewgameSettingsLive()
 	_settings_game = _settings_newgame;
 	_old_vds = _settings_client.company.vehicle;
 
-	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
+	for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 		_settings_game.ai_config[c] = nullptr;
 		if (_settings_newgame.ai_config[c] != nullptr) {
 			_settings_game.ai_config[c] = new AIConfig(_settings_newgame.ai_config[c]);
@@ -865,7 +865,7 @@ static void MakeNewGameDone()
 	/* Create a single company */
 	DoStartupNewCompany(false);
 
-	Company *c = Company::Get(COMPANY_FIRST);
+	Company *c = Company::Get(CompanyID::Begin());
 	c->settings = _settings_client.company;
 
 	/* Overwrite color from settings if needed

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -381,7 +381,7 @@ const Order *OrderList::GetNextDecisionNode(const Order *next, uint hops) const
  * @param v The vehicle we're looking at.
  * @param first Order to start searching at or nullptr to start at cur_implicit_order_index + 1.
  * @param hops Number of orders we have already looked at.
- * @return Next stopping station or INVALID_STATION.
+ * @return Next stopping station or StationID::Invalid().
  * @pre The vehicle is currently loading and v->last_station_visited is meaningful.
  * @note This function may draw a random number. Don't use it from the GUI.
  */
@@ -393,7 +393,7 @@ StationIDStack OrderList::GetNextStoppingStation(const Vehicle *v, const Order *
 		next = this->GetOrderAt(v->cur_implicit_order_index);
 		if (next == nullptr) {
 			next = this->GetFirstOrder();
-			if (next == nullptr) return INVALID_STATION.base();
+			if (next == nullptr) return StationID::Invalid().base();
 		} else {
 			/* GetNext never returns nullptr if there is a valid station in the list.
 			 * As the given "next" is already valid and a station in the list, we
@@ -430,7 +430,7 @@ StationIDStack OrderList::GetNextStoppingStation(const Vehicle *v, const Order *
 		if (next == nullptr || ((next->IsType(OT_GOTO_STATION) || next->IsType(OT_IMPLICIT)) &&
 				next->GetDestination() == v->last_station_visited &&
 				(next->GetUnloadType() & (OUFB_TRANSFER | OUFB_UNLOAD)) != 0)) {
-			return INVALID_STATION.base();
+			return StationID::Invalid().base();
 		}
 	} while (next->IsType(OT_GOTO_DEPOT) || next->GetDestination() == v->last_station_visited);
 
@@ -604,7 +604,7 @@ void OrderList::DebugCheckSanity() const
 static inline bool OrderGoesToStation(const Vehicle *v, const Order *o)
 {
 	return o->IsType(OT_GOTO_STATION) ||
-			(v->type == VEH_AIRCRAFT && o->IsType(OT_GOTO_DEPOT) && o->GetDestination() != INVALID_STATION);
+			(v->type == VEH_AIRCRAFT && o->IsType(OT_GOTO_DEPOT) && o->GetDestination() != StationID::Invalid());
 }
 
 /**
@@ -634,7 +634,7 @@ TileIndex Order::GetLocation(const Vehicle *v, bool airport) const
 			return BaseStation::Get(this->GetDestination().ToStationID())->xy;
 
 		case OT_GOTO_DEPOT:
-			if (this->GetDestination() == INVALID_DEPOT) return INVALID_TILE;
+			if (this->GetDestination() == DepotID::Invalid()) return INVALID_TILE;
 			return (v->type == VEH_AIRCRAFT) ? Station::Get(this->GetDestination().ToStationID())->xy : Depot::Get(this->GetDestination().ToDepotID())->xy;
 
 		default:

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -666,7 +666,7 @@ private:
 		Order order;
 		order.next = nullptr;
 		order.index = OrderID::Begin();
-		order.MakeGoToDepot(INVALID_DEPOT, ODTFB_PART_OF_ORDERS,
+		order.MakeGoToDepot(DepotID::Invalid(), ODTFB_PART_OF_ORDERS,
 				_settings_client.gui.new_nonstop && this->vehicle->IsGroundVehicle() ? ONSF_NO_STOP_AT_INTERMEDIATE_STATIONS : ONSF_STOP_EVERYWHERE);
 		order.SetDepotActionType(ODATFB_NEAREST_DEPOT);
 

--- a/src/order_type.h
+++ b/src/order_type.h
@@ -41,9 +41,6 @@ static const VehicleOrderID INVALID_VEH_ORDER_ID = 0xFF;
 /** Last valid VehicleOrderID. */
 static const VehicleOrderID MAX_VEH_ORDER_ID     = INVALID_VEH_ORDER_ID - 1;
 
-/** Invalid order (sentinel) */
-static constexpr OrderID INVALID_ORDER = OrderID::Invalid();
-
 /**
  * Maximum number of orders in implicit-only lists before we start searching
  * harder for duplicates.

--- a/src/pathfinder/yapf/yapf_destrail.hpp
+++ b/src/pathfinder/yapf/yapf_destrail.hpp
@@ -159,7 +159,7 @@ public:
 
 			default:
 				this->dest_tile = v->dest_tile;
-				this->dest_station_id = INVALID_STATION;
+				this->dest_station_id = StationID::Invalid();
 				this->dest_trackdirs = TrackStatusToTrackdirBits(GetTileTrackStatus(v->dest_tile, TRANSPORT_RAIL, 0));
 				break;
 		}
@@ -175,7 +175,7 @@ public:
 	/** Called by YAPF to detect if node ends in the desired destination */
 	inline bool PfDetectDestination(TileIndex tile, Trackdir td)
 	{
-		if (this->dest_station_id != INVALID_STATION) {
+		if (this->dest_station_id != StationID::Invalid()) {
 			return HasStationTileRail(tile)
 				&& (GetStationIndex(tile) == this->dest_station_id)
 				&& (GetRailStationTrack(tile) == TrackdirToTrack(td));

--- a/src/pathfinder/yapf/yapf_road.cpp
+++ b/src/pathfinder/yapf/yapf_road.cpp
@@ -253,7 +253,7 @@ public:
 			this->non_artic = !v->HasArticulatedPart();
 			this->dest_trackdirs = INVALID_TRACKDIR_BIT;
 		} else {
-			this->dest_station = INVALID_STATION;
+			this->dest_station = StationID::Invalid();
 			this->dest_tile = v->dest_tile;
 			this->dest_trackdirs = TrackStatusToTrackdirBits(GetTileTrackStatus(v->dest_tile, TRANSPORT_ROAD, GetRoadTramType(v->roadtype)));
 		}
@@ -261,7 +261,7 @@ public:
 
 	const Station *GetDestinationStation() const
 	{
-		return this->dest_station != INVALID_STATION ? Station::GetIfValid(this->dest_station) : nullptr;
+		return this->dest_station != StationID::Invalid() ? Station::GetIfValid(this->dest_station) : nullptr;
 	}
 
 protected:
@@ -280,7 +280,7 @@ public:
 
 	inline bool PfDetectDestinationTile(TileIndex tile, Trackdir trackdir)
 	{
-		if (this->dest_station != INVALID_STATION) {
+		if (this->dest_station != StationID::Invalid()) {
 			return IsTileType(tile, MP_STATION) &&
 				GetStationIndex(tile) == this->dest_station &&
 				(this->station_type == GetStationType(tile)) &&

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -49,7 +49,7 @@ public:
 			this->dest_tile = CalcClosestStationTile(this->dest_station, v->tile, StationType::Dock);
 			this->dest_trackdirs = INVALID_TRACKDIR_BIT;
 		} else {
-			this->dest_station = INVALID_STATION;
+			this->dest_station = StationID::Invalid();
 			this->dest_tile = v->dest_tile;
 			this->dest_trackdirs = TrackStatusToTrackdirBits(GetTileTrackStatus(v->dest_tile, TRANSPORT_WATER, 0));
 		}
@@ -84,7 +84,7 @@ public:
 			return GetWaterRegionPatchInfo(tile) == this->intermediate_dest_region_patch;
 		}
 
-		if (this->dest_station != INVALID_STATION) return IsDockingTile(tile) && IsShipDestinationTile(tile, this->dest_station);
+		if (this->dest_station != StationID::Invalid()) return IsDockingTile(tile) && IsShipDestinationTile(tile, this->dest_station);
 
 		return tile == this->dest_tile && ((this->dest_trackdirs & TrackdirToTrackdirBits(trackdir)) != TRACKDIR_BIT_NONE);
 	}

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -177,7 +177,7 @@ static void PlaceRail_Waypoint(TileIndex tile)
 	} else {
 		/* Tile where we can't build rail waypoints. This is always going to fail,
 		 * but provides the user with a proper error message. */
-		Command<CMD_BUILD_RAIL_WAYPOINT>::Post(STR_ERROR_CAN_T_BUILD_TRAIN_WAYPOINT, tile, AXIS_X, 1, 1, STAT_CLASS_WAYP, 0, INVALID_STATION, false);
+		Command<CMD_BUILD_RAIL_WAYPOINT>::Post(STR_ERROR_CAN_T_BUILD_TRAIN_WAYPOINT, tile, AXIS_X, 1, 1, STAT_CLASS_WAYP, 0, StationID::Invalid(), false);
 	}
 }
 
@@ -215,7 +215,7 @@ static void PlaceRail_Station(TileIndex tile)
 
 		auto proc = [=](bool test, StationID to_join) -> bool {
 			if (test) {
-				return Command<CMD_BUILD_RAIL_STATION>::Do(CommandFlagsToDCFlags(GetCommandFlags<CMD_BUILD_RAIL_STATION>()), tile, rt, params.axis, numtracks, platlength, params.sel_class, params.sel_type, INVALID_STATION, adjacent).Succeeded();
+				return Command<CMD_BUILD_RAIL_STATION>::Do(CommandFlagsToDCFlags(GetCommandFlags<CMD_BUILD_RAIL_STATION>()), tile, rt, params.axis, numtracks, platlength, params.sel_class, params.sel_type, StationID::Invalid(), adjacent).Succeeded();
 			} else {
 				return Command<CMD_BUILD_RAIL_STATION>::Post(STR_ERROR_CAN_T_BUILD_RAILROAD_STATION, CcStation, tile, rt, params.axis, numtracks, platlength, params.sel_class, params.sel_type, to_join, adjacent);
 			}
@@ -776,7 +776,7 @@ struct BuildRailToolbarWindow : Window {
 
 							auto proc = [=](bool test, StationID to_join) -> bool {
 								if (test) {
-									return Command<CMD_BUILD_RAIL_WAYPOINT>::Do(CommandFlagsToDCFlags(GetCommandFlags<CMD_BUILD_RAIL_WAYPOINT>()), ta.tile, axis, ta.w, ta.h, _waypoint_gui.sel_class, _waypoint_gui.sel_type, INVALID_STATION, adjacent).Succeeded();
+									return Command<CMD_BUILD_RAIL_WAYPOINT>::Do(CommandFlagsToDCFlags(GetCommandFlags<CMD_BUILD_RAIL_WAYPOINT>()), ta.tile, axis, ta.w, ta.h, _waypoint_gui.sel_class, _waypoint_gui.sel_type, StationID::Invalid(), adjacent).Succeeded();
 								} else {
 									return Command<CMD_BUILD_RAIL_WAYPOINT>::Post(STR_ERROR_CAN_T_BUILD_TRAIN_WAYPOINT, CcPlaySound_CONSTRUCTION_RAIL, ta.tile, axis, ta.w, ta.h, _waypoint_gui.sel_class, _waypoint_gui.sel_type, to_join, adjacent);
 								}
@@ -943,7 +943,7 @@ static void HandleStationPlacement(TileIndex start, TileIndex end)
 
 	auto proc = [=](bool test, StationID to_join) -> bool {
 		if (test) {
-			return Command<CMD_BUILD_RAIL_STATION>::Do(CommandFlagsToDCFlags(GetCommandFlags<CMD_BUILD_RAIL_STATION>()), ta.tile, rt, params.axis, numtracks, platlength, params.sel_class, params.sel_type, INVALID_STATION, adjacent).Succeeded();
+			return Command<CMD_BUILD_RAIL_STATION>::Do(CommandFlagsToDCFlags(GetCommandFlags<CMD_BUILD_RAIL_STATION>()), ta.tile, rt, params.axis, numtracks, platlength, params.sel_class, params.sel_type, StationID::Invalid(), adjacent).Succeeded();
 		} else {
 			return Command<CMD_BUILD_RAIL_STATION>::Post(STR_ERROR_CAN_T_BUILD_RAILROAD_STATION, CcStation, ta.tile, rt, params.axis, numtracks, platlength, params.sel_class, params.sel_type, to_join, adjacent);
 		}

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -465,7 +465,7 @@ static CommandCost RemoveRoad(TileIndex tile, DoCommandFlags flags, RoadBits pie
 						if (rtt == RTT_ROAD && IsRoadOwner(tile, rtt, OWNER_TOWN)) {
 							/* Update nearest-town index */
 							const Town *town = CalcClosestTownFromTile(tile);
-							SetTownIndex(tile, town == nullptr ? INVALID_TOWN : town->index);
+							SetTownIndex(tile, town == nullptr ? TownID::Invalid() : town->index);
 						}
 						if (rtt == RTT_ROAD) SetDisallowedRoadDirections(tile, DRD_NONE);
 						SetRoadBits(tile, ROAD_NONE, rtt);
@@ -603,7 +603,7 @@ static CommandCost CheckRoadSlope(Slope tileh, RoadBits *pieces, RoadBits existi
  * @param pieces road pieces to build (RoadBits)
  * @param rt road type
  * @param toggle_drd disallowed directions to toggle
- * @param town_id the town that is building the road (INVALID_TOWN if not applicable)
+ * @param town_id the town that is building the road (TownID::Invalid() if not applicable)
  * @return the cost of this operation or an error
  */
 CommandCost CmdBuildRoad(DoCommandFlags flags, TileIndex tile, RoadBits pieces, RoadType rt, DisallowedRoadDirections toggle_drd, TownID town_id)
@@ -616,10 +616,10 @@ CommandCost CmdBuildRoad(DoCommandFlags flags, TileIndex tile, RoadBits pieces, 
 
 	/* Road pieces are max 4 bitset values (NE, NW, SE, SW) and town can only be non-zero
 	 * if a non-company is building the road */
-	if ((Company::IsValidID(company) && town_id != INVALID_TOWN) || (company == OWNER_TOWN && !Town::IsValidID(town_id)) || (company == OWNER_DEITY && town_id != INVALID_TOWN)) return CMD_ERROR;
+	if ((Company::IsValidID(company) && town_id != TownID::Invalid()) || (company == OWNER_TOWN && !Town::IsValidID(town_id)) || (company == OWNER_DEITY && town_id != TownID::Invalid())) return CMD_ERROR;
 	if (company != OWNER_TOWN) {
 		const Town *town = CalcClosestTownFromTile(tile);
-		town_id = (town != nullptr) ? town->index : INVALID_TOWN;
+		town_id = (town != nullptr) ? town->index : TownID::Invalid();
 
 		if (company == OWNER_DEITY) {
 			company = OWNER_TOWN;
@@ -1025,7 +1025,7 @@ CommandCost CmdBuildLongRoad(DoCommandFlags flags, TileIndex end_tile, TileIndex
 			if (tile == start_tile && start_half) bits &= DiagDirToRoadBits(dir);
 		}
 
-		CommandCost ret = Command<CMD_BUILD_ROAD>::Do(flags, tile, bits, rt, drd, INVALID_TOWN);
+		CommandCost ret = Command<CMD_BUILD_ROAD>::Do(flags, tile, bits, rt, drd, TownID::Invalid());
 		if (ret.Failed()) {
 			last_error = ret;
 			if (last_error.GetErrorMessage() != STR_ERROR_ALREADY_BUILT) {
@@ -1920,7 +1920,7 @@ void UpdateNearestTownForRoadTiles(bool invalidate)
 
 	for (const auto t : Map::Iterate()) {
 		if (IsTileType(t, MP_ROAD) && !IsRoadDepot(t) && !HasTownOwnedRoad(t)) {
-			TownID tid = INVALID_TOWN;
+			TownID tid = TownID::Invalid();
 			if (!invalidate) {
 				const Town *town = CalcClosestTownFromTile(t);
 				if (town != nullptr) tid = town->index;

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -165,7 +165,7 @@ void ConnectRoadToStructure(TileIndex tile, DiagDirection direction)
 	/* if there is a roadpiece just outside of the station entrance, build a connecting route */
 	if (IsNormalRoadTile(tile)) {
 		if (GetRoadBits(tile, GetRoadTramType(_cur_roadtype)) != ROAD_NONE) {
-			Command<CMD_BUILD_ROAD>::Post(tile, DiagDirToRoadBits(ReverseDiagDir(direction)), _cur_roadtype, DRD_NONE, INVALID_TOWN);
+			Command<CMD_BUILD_ROAD>::Post(tile, DiagDirToRoadBits(ReverseDiagDir(direction)), _cur_roadtype, DRD_NONE, TownID::Invalid());
 		}
 	}
 }
@@ -237,7 +237,7 @@ static void PlaceRoadStop(TileIndex start_tile, TileIndex end_tile, RoadStopType
 	auto proc = [=](bool test, StationID to_join) -> bool {
 		if (test) {
 			return Command<CMD_BUILD_ROAD_STOP>::Do(CommandFlagsToDCFlags(GetCommandFlags<CMD_BUILD_ROAD_STOP>()), ta.tile, ta.w, ta.h, stop_type, drive_through,
-					ddir, rt, spec_class, spec_index, INVALID_STATION, adjacent).Succeeded();
+					ddir, rt, spec_class, spec_index, StationID::Invalid(), adjacent).Succeeded();
 		} else {
 			return Command<CMD_BUILD_ROAD_STOP>::Post(err_msg, CcRoadStop, ta.tile, ta.w, ta.h, stop_type, drive_through,
 					ddir, rt, spec_class, spec_index, to_join, adjacent);
@@ -266,7 +266,7 @@ static void PlaceRoad_Waypoint(TileIndex tile)
 	} else {
 		/* Tile where we can't build road waypoints. This is always going to fail,
 		 * but provides the user with a proper error message. */
-		Command<CMD_BUILD_ROAD_WAYPOINT>::Post(STR_ERROR_CAN_T_BUILD_ROAD_WAYPOINT, tile, AXIS_X, 1, 1, ROADSTOP_CLASS_WAYP, 0, INVALID_STATION, false);
+		Command<CMD_BUILD_ROAD_WAYPOINT>::Post(STR_ERROR_CAN_T_BUILD_ROAD_WAYPOINT, tile, AXIS_X, 1, 1, ROADSTOP_CLASS_WAYP, 0, StationID::Invalid(), false);
 	}
 }
 
@@ -766,7 +766,7 @@ struct BuildRoadToolbarWindow : Window {
 
 							auto proc = [=](bool test, StationID to_join) -> bool {
 								if (test) {
-									return Command<CMD_BUILD_ROAD_WAYPOINT>::Do(CommandFlagsToDCFlags(GetCommandFlags<CMD_BUILD_ROAD_WAYPOINT>()), ta.tile, axis, ta.w, ta.h, _waypoint_gui.sel_class, _waypoint_gui.sel_type, INVALID_STATION, adjacent).Succeeded();
+									return Command<CMD_BUILD_ROAD_WAYPOINT>::Do(CommandFlagsToDCFlags(GetCommandFlags<CMD_BUILD_ROAD_WAYPOINT>()), ta.tile, axis, ta.w, ta.h, _waypoint_gui.sel_class, _waypoint_gui.sel_type, StationID::Invalid(), adjacent).Succeeded();
 								} else {
 									return Command<CMD_BUILD_ROAD_WAYPOINT>::Post(STR_ERROR_CAN_T_BUILD_ROAD_WAYPOINT, CcPlaySound_CONSTRUCTION_OTHER, ta.tile, axis, ta.w, ta.h, _waypoint_gui.sel_class, _waypoint_gui.sel_type, to_join, adjacent);
 								}

--- a/src/roadveh.h
+++ b/src/roadveh.h
@@ -106,7 +106,7 @@ struct RoadVehicle final : public GroundVehicle<RoadVehicle, VEH_ROAD> {
 	uint8_t reverse_ctr;
 
 	RoadType roadtype; ///< NOSAVE: Roadtype of this vehicle.
-	VehicleID disaster_vehicle = INVALID_VEHICLE; ///< NOSAVE: Disaster vehicle targetting this vehicle.
+	VehicleID disaster_vehicle = VehicleID::Invalid(); ///< NOSAVE: Disaster vehicle targetting this vehicle.
 	RoadTypes compatible_roadtypes; ///< NOSAVE: Roadtypes this consist is powered on.
 
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -229,7 +229,7 @@ void RoadVehUpdateCache(RoadVehicle *v, bool same_length)
 		assert(u->First() == v);
 
 		/* Update the 'first engine' */
-		u->gcache.first_engine = (v == u) ? INVALID_ENGINE : v->engine_type;
+		u->gcache.first_engine = (v == u) ? EngineID::Invalid() : v->engine_type;
 
 		/* Update the length of the vehicle. */
 		uint veh_len = GetRoadVehLength(u);
@@ -289,10 +289,10 @@ CommandCost CmdBuildRoadVehicle(DoCommandFlags flags, TileIndex tile, const Engi
 		v->cargo_cap = rvi->capacity;
 		v->refit_cap = 0;
 
-		v->last_station_visited = INVALID_STATION;
-		v->last_loading_station = INVALID_STATION;
+		v->last_station_visited = StationID::Invalid();
+		v->last_loading_station = StationID::Invalid();
 		v->engine_type = e->index;
-		v->gcache.first_engine = INVALID_ENGINE; // needs to be set before first callback
+		v->gcache.first_engine = EngineID::Invalid(); // needs to be set before first callback
 
 		v->reliability = e->reliability;
 		v->reliability_spd_dec = e->reliability_spd_dec;
@@ -582,7 +582,7 @@ static bool RoadVehCheckTrainCrash(RoadVehicle *v)
 
 TileIndex RoadVehicle::GetOrderStationLocation(StationID station)
 {
-	if (station == this->last_station_visited) this->last_station_visited = INVALID_STATION;
+	if (station == this->last_station_visited) this->last_station_visited = StationID::Invalid();
 
 	const Station *st = Station::Get(station);
 	if (!CanVehicleUseStation(this, st)) {
@@ -1126,7 +1126,7 @@ static bool CanBuildTramTrackOnTile(CompanyID c, TileIndex t, RoadType rt, RoadB
 	/* The 'current' company is not necessarily the owner of the vehicle. */
 	Backup<CompanyID> cur_company(_current_company, c);
 
-	CommandCost ret = Command<CMD_BUILD_ROAD>::Do(DoCommandFlag::NoWater, t, r, rt, DRD_NONE, INVALID_TOWN);
+	CommandCost ret = Command<CMD_BUILD_ROAD>::Do(DoCommandFlag::NoWater, t, r, rt, DRD_NONE, TownID::Invalid());
 
 	cur_company.Restore();
 	return ret.Succeeded();

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -73,7 +73,7 @@
 
 #include "../safeguards.h"
 
-extern Company *DoStartupNewCompany(bool is_ai, CompanyID company = INVALID_COMPANY);
+extern Company *DoStartupNewCompany(bool is_ai, CompanyID company = CompanyID::Invalid());
 
 /**
  * Makes a tile canal or water depending on the surroundings.
@@ -179,7 +179,7 @@ static void ConvertTownOwner()
 static void UpdateExclusiveRights()
 {
 	for (Town *t : Town::Iterate()) {
-		t->exclusivity = INVALID_COMPANY;
+		t->exclusivity = CompanyID::Invalid();
 	}
 
 	/* FIXME old exclusive rights status is not being imported (stored in s->blocked_months_obsolete)
@@ -2285,7 +2285,7 @@ bool AfterLoadGame()
 			if (s->remaining < 12) {
 				/* Converting nonawarded subsidy */
 				s->remaining = 12 - s->remaining; // convert "age" to "remaining"
-				s->awarded = INVALID_COMPANY; // not awarded to anyone
+				s->awarded = CompanyID::Invalid(); // not awarded to anyone
 				const CargoSpec *cs = CargoSpec::Get(s->cargo_type);
 				switch (cs->town_acceptance_effect) {
 					case TAE_PASSENGERS:
@@ -3416,7 +3416,7 @@ void ReloadNewGRFData()
 	/* Delete news referring to no longer existing entities */
 	DeleteInvalidEngineNews();
 	/* Update livery selection windows */
-	for (CompanyID i = COMPANY_FIRST; i < MAX_COMPANIES; ++i) InvalidateWindowData(WC_COMPANY_COLOUR, i);
+	for (CompanyID i = CompanyID::Begin(); i < MAX_COMPANIES; ++i) InvalidateWindowData(WC_COMPANY_COLOUR, i);
 	/* Update company infrastructure counts. */
 	InvalidateWindowClassesData(WC_COMPANY_INFRASTRUCTURE);
 	InvalidateWindowClassesData(WC_BUILD_TOOLBAR);

--- a/src/saveload/ai_sl.cpp
+++ b/src/saveload/ai_sl.cpp
@@ -80,7 +80,7 @@ struct AIPLChunkHandler : ChunkHandler {
 		const std::vector<SaveLoad> slt = SlCompatTableHeader(_ai_company_desc, _ai_company_sl_compat);
 
 		/* Free all current data */
-		for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
+		for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 			AIConfig::GetConfig(c, AIConfig::SSS_FORCE_GAME)->Change(std::nullopt);
 		}
 
@@ -160,7 +160,7 @@ struct AIPLChunkHandler : ChunkHandler {
 	{
 		SlTableHeader(_ai_company_desc);
 
-		for (CompanyID i = COMPANY_FIRST; i < MAX_COMPANIES; ++i) {
+		for (CompanyID i = CompanyID::Begin(); i < MAX_COMPANIES; ++i) {
 			SlSetArrayIndex(i);
 			SlAutolength(SaveReal_AIPL, i.base());
 		}

--- a/src/saveload/cargopacket_sl.cpp
+++ b/src/saveload/cargopacket_sl.cpp
@@ -55,9 +55,9 @@
 	}
 
 	if (IsSavegameVersionBefore(SLV_120)) {
-		/* CargoPacket's source should be either INVALID_STATION or a valid station */
+		/* CargoPacket's source should be either StationID::Invalid() or a valid station */
 		for (CargoPacket *cp : CargoPacket::Iterate()) {
-			if (!Station::IsValidID(cp->first_station)) cp->first_station = INVALID_STATION;
+			if (!Station::IsValidID(cp->first_station)) cp->first_station = StationID::Invalid();
 		}
 	}
 

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -83,7 +83,7 @@ struct ENGNChunkHandler : ChunkHandler {
 				/* preview_company_rank was replaced with preview_company and preview_asked.
 				 * Just cancel any previews. */
 				e->flags.Reset(EngineFlag{4}); // ENGINE_OFFER_WINDOW_OPEN
-				e->preview_company = INVALID_COMPANY;
+				e->preview_company = CompanyID::Invalid();
 				e->preview_asked.Set();
 			}
 		}

--- a/src/saveload/group_sl.cpp
+++ b/src/saveload/group_sl.cpp
@@ -53,7 +53,7 @@ struct GRPSChunkHandler : ChunkHandler {
 			Group *g = new (index) Group();
 			SlObject(g, slt);
 
-			if (IsSavegameVersionBefore(SLV_189)) g->parent = INVALID_GROUP;
+			if (IsSavegameVersionBefore(SLV_189)) g->parent = GroupID::Invalid();
 		}
 	}
 };

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -437,7 +437,7 @@ static bool FixTTOEngines()
 			e->info.climates = LandscapeType::Temperate;
 		}
 
-		e->preview_company = INVALID_COMPANY;
+		e->preview_company = CompanyID::Invalid();
 		e->preview_asked.Set();
 		e->preview_wait = 0;
 		e->name = std::string{};
@@ -724,8 +724,8 @@ static bool LoadOldGood(LoadgameState &ls, int num)
 	AssignBit(ge->status, GoodsEntry::GES_ACCEPTANCE, HasBit(_waiting_acceptance, 15));
 	AssignBit(ge->status, GoodsEntry::GES_RATING, _cargo_source != 0xFF);
 	if (GB(_waiting_acceptance, 0, 12) != 0 && CargoPacket::CanAllocateItem()) {
-		ge->GetOrCreateData().cargo.Append(new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, (_cargo_source == 0xFF) ? INVALID_STATION : StationID{_cargo_source}, INVALID_TILE, 0),
-				INVALID_STATION);
+		ge->GetOrCreateData().cargo.Append(new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, (_cargo_source == 0xFF) ? StationID::Invalid() : StationID{_cargo_source}, INVALID_TILE, 0),
+				StationID::Invalid());
 	}
 
 	return true;
@@ -1372,8 +1372,8 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 		v->next = (Vehicle *)(size_t)_old_next_ptr;
 
 		if (_cargo_count != 0 && CargoPacket::CanAllocateItem()) {
-			StationID source =    (_cargo_source == 0xFF) ? INVALID_STATION : StationID{_cargo_source};
-			TileIndex source_xy = (source != INVALID_STATION) ? Station::Get(source)->xy : (TileIndex)0;
+			StationID source =    (_cargo_source == 0xFF) ? StationID::Invalid() : StationID{_cargo_source};
+			TileIndex source_xy = (source != StationID::Invalid()) ? Station::Get(source)->xy : (TileIndex)0;
 			v->cargo.Append(new CargoPacket(_cargo_count, _cargo_periods, source, source_xy, 0));
 		}
 	}

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -193,15 +193,15 @@ static void SwapPackets(GoodsEntry *ge)
 	StationCargoPacketMap &ge_packets = const_cast<StationCargoPacketMap &>(*ge->GetOrCreateData().cargo.Packets());
 
 	if (_packets.empty()) {
-		std::map<StationID, std::list<CargoPacket *> >::iterator it(ge_packets.find(INVALID_STATION));
+		std::map<StationID, std::list<CargoPacket *> >::iterator it(ge_packets.find(StationID::Invalid()));
 		if (it == ge_packets.end()) {
 			return;
 		} else {
 			it->second.swap(_packets);
 		}
 	} else {
-		assert(ge_packets[INVALID_STATION].empty());
-		ge_packets[INVALID_STATION].swap(_packets);
+		assert(ge_packets[StationID::Invalid()].empty());
+		ge_packets[StationID::Invalid()].swap(_packets);
 	}
 }
 
@@ -322,7 +322,7 @@ public:
 		GoodsEntry::GoodsEntryData &data = ge->GetOrCreateData();
 		FlowSaveLoad flow{};
 		FlowStat *fs = nullptr;
-		StationID prev_source = INVALID_STATION;
+		StationID prev_source = StationID::Invalid();
 		for (uint32_t j = 0; j < num_flows; ++j) {
 			SlObject(&flow, this->GetLoadDescription());
 			if (fs == nullptr || prev_source != flow.source) {
@@ -416,8 +416,8 @@ public:
 			if (IsSavegameVersionBefore(SLV_68)) {
 				AssignBit(ge.status, GoodsEntry::GES_ACCEPTANCE, HasBit(_waiting_acceptance, 15));
 				if (GB(_waiting_acceptance, 0, 12) != 0) {
-					/* In old versions, enroute_from used 0xFF as INVALID_STATION */
-					StationID source = (IsSavegameVersionBefore(SLV_7) && _cargo_source == 0xFF) ? INVALID_STATION : static_cast<StationID>(_cargo_source);
+					/* In old versions, enroute_from used 0xFF as StationID::Invalid() */
+					StationID source = (IsSavegameVersionBefore(SLV_7) && _cargo_source == 0xFF) ? StationID::Invalid() : static_cast<StationID>(_cargo_source);
 
 					/* Make sure we can allocate the CargoPacket. This is safe
 					 * as there can only be ~64k stations and 32 cargoes in these
@@ -427,7 +427,7 @@ public:
 
 					/* Don't construct the packet with station here, because that'll fail with old savegames */
 					CargoPacket *cp = new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, source, TileIndex{_cargo_source_xy}, _cargo_feeder_share);
-					ge.GetOrCreateData().cargo.Append(cp, INVALID_STATION);
+					ge.GetOrCreateData().cargo.Append(cp, StationID::Invalid());
 					SetBit(ge.status, GoodsEntry::GES_RATING);
 				}
 			}

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -225,7 +225,7 @@ void UpdateOldAircraft()
 static void CheckValidVehicles()
 {
 	size_t total_engines = Engine::GetPoolSize();
-	EngineID first_engine[4] = { INVALID_ENGINE, INVALID_ENGINE, INVALID_ENGINE, INVALID_ENGINE };
+	EngineID first_engine[4] = { EngineID::Invalid(), EngineID::Invalid(), EngineID::Invalid(), EngineID::Invalid() };
 
 	for (const Engine *e : Engine::IterateType(VEH_TRAIN)) { first_engine[VEH_TRAIN] = e->index; break; }
 	for (const Engine *e : Engine::IterateType(VEH_ROAD)) { first_engine[VEH_ROAD] = e->index; break; }
@@ -262,7 +262,7 @@ void AfterLoadVehiclesPhase1(bool part_of_load)
 
 		if (part_of_load) v->fill_percent_te_id = INVALID_TE_ID;
 		v->first = nullptr;
-		if (v->IsGroundVehicle()) v->GetGroundVehicleCache()->first_engine = INVALID_ENGINE;
+		if (v->IsGroundVehicle()) v->GetGroundVehicleCache()->first_engine = EngineID::Invalid();
 	}
 
 	/* AfterLoadVehicles may also be called in case of NewGRF reload, in this
@@ -515,7 +515,7 @@ void AfterLoadVehiclesPhase2(bool part_of_load)
 					RoadVehicle *u = RoadVehicle::GetIfValid(v->dest_tile.base());
 					if (u != nullptr && u->IsFrontEngine()) {
 						/* Delete UFO targetting a vehicle which is already a target. */
-						if (u->disaster_vehicle != INVALID_VEHICLE && u->disaster_vehicle != dv->index) {
+						if (u->disaster_vehicle != VehicleID::Invalid() && u->disaster_vehicle != dv->index) {
 							delete v;
 							continue;
 						} else {
@@ -1144,10 +1144,10 @@ struct VEHSChunkHandler : ChunkHandler {
 
 			/* Old savegames used 'last_station_visited = 0xFF' */
 			if (IsSavegameVersionBefore(SLV_5) && v->last_station_visited == 0xFF) {
-				v->last_station_visited = INVALID_STATION;
+				v->last_station_visited = StationID::Invalid();
 			}
 
-			if (IsSavegameVersionBefore(SLV_182)) v->last_loading_station = INVALID_STATION;
+			if (IsSavegameVersionBefore(SLV_182)) v->last_loading_station = StationID::Invalid();
 
 			if (IsSavegameVersionBefore(SLV_5)) {
 				/* Convert the current_order.type (which is a mix of type and flags, because

--- a/src/script/api/script_airport.cpp
+++ b/src/script/api/script_airport.cpp
@@ -77,7 +77,7 @@
 	EnforcePrecondition(false, IsValidAirportType(type));
 	EnforcePrecondition(false, station_id == ScriptStation::STATION_NEW || station_id == ScriptStation::STATION_JOIN_ADJACENT || ScriptStation::IsValidStation(station_id));
 
-	return ScriptObject::Command<CMD_BUILD_AIRPORT>::Do(tile, type, 0, (ScriptStation::IsValidStation(station_id) ? station_id : INVALID_STATION), station_id != ScriptStation::STATION_JOIN_ADJACENT);
+	return ScriptObject::Command<CMD_BUILD_AIRPORT>::Do(tile, type, 0, (ScriptStation::IsValidStation(station_id) ? station_id : StationID::Invalid()), station_id != ScriptStation::STATION_JOIN_ADJACENT);
 }
 
 /* static */ bool ScriptAirport::RemoveAirport(TileIndex tile)
@@ -148,11 +148,11 @@
 
 /* static */ TownID ScriptAirport::GetNearestTown(TileIndex tile, AirportType type)
 {
-	if (!::IsValidTile(tile)) return INVALID_TOWN;
-	if (!IsAirportInformationAvailable(type)) return INVALID_TOWN;
+	if (!::IsValidTile(tile)) return TownID::Invalid();
+	if (!IsAirportInformationAvailable(type)) return TownID::Invalid();
 
 	const AirportSpec *as = AirportSpec::Get(type);
-	if (!as->IsWithinMapBounds(0, tile)) return INVALID_TOWN;
+	if (!as->IsWithinMapBounds(0, tile)) return TownID::Invalid();
 
 	uint dist;
 	const auto &layout = as->layouts[0];

--- a/src/script/api/script_basestation.hpp
+++ b/src/script/api/script_basestation.hpp
@@ -22,7 +22,7 @@ class ScriptBaseStation : public ScriptObject {
 public:
 	static constexpr StationID STATION_NEW = ::NEW_STATION; ///< Build a new station
 	static constexpr StationID STATION_JOIN_ADJACENT = ::ADJACENT_STATION; ///< Join an neighbouring station if one exists
-	static constexpr StationID STATION_INVALID = ::INVALID_STATION; ///< Invalid station id.
+	static constexpr StationID STATION_INVALID = ::StationID::Invalid(); ///< Invalid station id.
 
 	/**
 	 * Checks whether the given basestation is valid and owned by you.

--- a/src/script/api/script_bridge.cpp
+++ b/src/script/api/script_bridge.cpp
@@ -105,7 +105,7 @@ static void _DoCommandReturnBuildBridge1(class ScriptInstance *instance)
 	DiagDirection dir_1 = ::DiagdirBetweenTiles(end, start);
 	DiagDirection dir_2 = ::ReverseDiagDir(dir_1);
 
-	return ScriptObject::Command<CMD_BUILD_ROAD>::Do(&::_DoCommandReturnBuildBridge2, start + ::TileOffsByDiagDir(dir_1), ::DiagDirToRoadBits(dir_2), (::RoadType)ScriptRoad::GetCurrentRoadType(), DRD_NONE, INVALID_TOWN);
+	return ScriptObject::Command<CMD_BUILD_ROAD>::Do(&::_DoCommandReturnBuildBridge2, start + ::TileOffsByDiagDir(dir_1), ::DiagDirToRoadBits(dir_2), (::RoadType)ScriptRoad::GetCurrentRoadType(), DRD_NONE, TownID::Invalid());
 }
 
 /* static */ bool ScriptBridge::_BuildBridgeRoad2()
@@ -119,7 +119,7 @@ static void _DoCommandReturnBuildBridge1(class ScriptInstance *instance)
 	DiagDirection dir_1 = ::DiagdirBetweenTiles(end, start);
 	DiagDirection dir_2 = ::ReverseDiagDir(dir_1);
 
-	return ScriptObject::Command<CMD_BUILD_ROAD>::Do(end + ::TileOffsByDiagDir(dir_2), ::DiagDirToRoadBits(dir_1), (::RoadType)ScriptRoad::GetCurrentRoadType(), DRD_NONE, INVALID_TOWN);
+	return ScriptObject::Command<CMD_BUILD_ROAD>::Do(end + ::TileOffsByDiagDir(dir_2), ::DiagDirToRoadBits(dir_1), (::RoadType)ScriptRoad::GetCurrentRoadType(), DRD_NONE, TownID::Invalid());
 }
 
 /* static */ bool ScriptBridge::RemoveBridge(TileIndex tile)

--- a/src/script/api/script_company.cpp
+++ b/src/script/api/script_company.cpp
@@ -33,13 +33,13 @@
 	/* If this assert gets triggered, then ScriptCompany::ResolveCompanyID needed to be called before. */
 	assert(company != ScriptCompany::COMPANY_SELF && company != ScriptCompany::COMPANY_SPECTATOR);
 
-	if (company == ScriptCompany::COMPANY_INVALID) return ::INVALID_COMPANY;
+	if (company == ScriptCompany::COMPANY_INVALID) return ::CompanyID::Invalid();
 	return static_cast<::CompanyID>(company);
 }
 
 /* static */ ScriptCompany::CompanyID ScriptCompany::ToScriptCompanyID(::CompanyID company)
 {
-	if (company == ::INVALID_COMPANY) return ScriptCompany::COMPANY_INVALID;
+	if (company == ::CompanyID::Invalid()) return ScriptCompany::COMPANY_INVALID;
 	return static_cast<::ScriptCompany::CompanyID>(company.base());
 }
 

--- a/src/script/api/script_company.hpp
+++ b/src/script/api/script_company.hpp
@@ -30,8 +30,8 @@ public:
 	/** Different constants related to CompanyID. */
 	enum CompanyID {
 		/* Note: these values represent part of the in-game Owner enum */
-		COMPANY_FIRST     = ::COMPANY_FIRST.base(), ///< The first available company.
-		COMPANY_LAST      = ::MAX_COMPANIES,   ///< The last available company.
+		COMPANY_FIRST     = ::CompanyID::Begin().base(), ///< The first available company.
+		COMPANY_LAST      = ::CompanyID::End().base(),   ///< The last available company.
 
 		/* Custom added value, only valid for this API */
 		COMPANY_INVALID   = -1,                ///< An invalid company.

--- a/src/script/api/script_goal.cpp
+++ b/src/script/api/script_goal.cpp
@@ -38,7 +38,7 @@
 			(type == GT_INDUSTRY && ScriptIndustry::IsValidIndustry(static_cast<IndustryID>(destination))) ||
 			(type == GT_TOWN && ScriptTown::IsValidTown(static_cast<TownID>(destination))) ||
 			(type == GT_COMPANY && ScriptCompany::ResolveCompanyID(ScriptCompany::ToScriptCompanyID(static_cast<::CompanyID>(destination))) != ScriptCompany::COMPANY_INVALID) ||
-			(type == GT_STORY_PAGE && story_page != nullptr && (c == INVALID_COMPANY ? story_page->company == INVALID_COMPANY : story_page->company == INVALID_COMPANY || story_page->company == c));
+			(type == GT_STORY_PAGE && story_page != nullptr && (c == CompanyID::Invalid() ? story_page->company == CompanyID::Invalid() : story_page->company == CompanyID::Invalid() || story_page->company == c));
 }
 
 /* static */ GoalID ScriptGoal::New(ScriptCompany::CompanyID company, Text *goal, GoalType type, SQInteger destination)

--- a/src/script/api/script_goal.hpp
+++ b/src/script/api/script_goal.hpp
@@ -25,7 +25,7 @@
  */
 class ScriptGoal : public ScriptObject {
 public:
-	static constexpr GoalID GOAL_INVALID = ::INVALID_GOAL; ///< An invalid goal id.
+	static constexpr GoalID GOAL_INVALID = ::GoalID::Invalid(); ///< An invalid goal id.
 
 	/**
 	 * Goal types that can be given to a goal.

--- a/src/script/api/script_group.cpp
+++ b/src/script/api/script_group.cpp
@@ -65,7 +65,7 @@
 	EnforcePreconditionEncodedText(false, text);
 	EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_GROUP_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG);
 
-	return ScriptObject::Command<CMD_ALTER_GROUP>::Do(AlterGroupMode::Rename, group_id, ::INVALID_GROUP, text);
+	return ScriptObject::Command<CMD_ALTER_GROUP>::Do(AlterGroupMode::Rename, group_id, ::GroupID::Invalid(), text);
 }
 
 /* static */ std::optional<std::string> ScriptGroup::GetName(GroupID group_id)
@@ -87,7 +87,7 @@
 
 /* static */ GroupID ScriptGroup::GetParent(GroupID group_id)
 {
-	EnforcePrecondition(INVALID_GROUP, IsValidGroup(group_id));
+	EnforcePrecondition(::GroupID::Invalid(), IsValidGroup(group_id));
 
 	const Group *g = ::Group::GetIfValid(group_id);
 	return g->parent;
@@ -163,8 +163,8 @@
 
 /* static */ EngineID ScriptGroup::GetEngineReplacement(GroupID group_id, EngineID engine_id)
 {
-	EnforceCompanyModeValid(::INVALID_ENGINE);
-	if (!IsValidGroup(group_id) && group_id != GROUP_DEFAULT && group_id != GROUP_ALL) return ::INVALID_ENGINE;
+	EnforceCompanyModeValid(::EngineID::Invalid());
+	if (!IsValidGroup(group_id) && group_id != GROUP_DEFAULT && group_id != GROUP_ALL) return ::EngineID::Invalid();
 
 	return ::EngineReplacementForCompany(Company::Get(ScriptObject::GetCompany()), engine_id, group_id);
 }
@@ -174,7 +174,7 @@
 	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidGroup(group_id) || group_id == GROUP_DEFAULT || group_id == GROUP_ALL);
 
-	return ScriptObject::Command<CMD_SET_AUTOREPLACE>::Do(group_id, engine_id, ::INVALID_ENGINE, false);
+	return ScriptObject::Command<CMD_SET_AUTOREPLACE>::Do(group_id, engine_id, ::EngineID::Invalid(), false);
 }
 
 /* static */ Money ScriptGroup::GetProfitThisYear(GroupID group_id)

--- a/src/script/api/script_group.hpp
+++ b/src/script/api/script_group.hpp
@@ -21,7 +21,7 @@ class ScriptGroup : public ScriptObject {
 public:
 	static constexpr GroupID GROUP_ALL = ::ALL_GROUP; ///< All vehicles are in this group.
 	static constexpr GroupID GROUP_DEFAULT = ::DEFAULT_GROUP; ///< Vehicles not put in any other group are in this one.
-	static constexpr GroupID GROUP_INVALID = ::INVALID_GROUP; ///< An invalid group id.
+	static constexpr GroupID GROUP_INVALID = ::GroupID::Invalid(); ///< An invalid group id.
 
 	/**
 	 * Checks whether the given group is valid.

--- a/src/script/api/script_industry.cpp
+++ b/src/script/api/script_industry.cpp
@@ -37,7 +37,7 @@
 
 /* static */ IndustryID ScriptIndustry::GetIndustryID(TileIndex tile)
 {
-	if (!::IsValidTile(tile) || !::IsTileType(tile, MP_INDUSTRY)) return INVALID_INDUSTRY;
+	if (!::IsValidTile(tile) || !::IsTileType(tile, MP_INDUSTRY)) return IndustryID::Invalid();
 	return ::GetIndustryIndex(tile);
 }
 

--- a/src/script/api/script_league.hpp
+++ b/src/script/api/script_league.hpp
@@ -25,9 +25,9 @@
  */
 class ScriptLeagueTable : public ScriptObject {
 public:
-	static constexpr LeagueTableID LEAGUE_TABLE_INVALID = ::INVALID_LEAGUE_TABLE; ///< An invalid league table id.
+	static constexpr LeagueTableID LEAGUE_TABLE_INVALID = ::LeagueTableID::Invalid(); ///< An invalid league table id.
 
-	static constexpr LeagueTableElementID LEAGUE_TABLE_ELEMENT_INVALID = ::INVALID_LEAGUE_TABLE_ELEMENT; ///< An invalid league table element id.
+	static constexpr LeagueTableElementID LEAGUE_TABLE_ELEMENT_INVALID = ::LeagueTableElementID::Invalid(); ///< An invalid league table element id.
 
 	/**
 	 * The type of a link.

--- a/src/script/api/script_marine.cpp
+++ b/src/script/api/script_marine.cpp
@@ -92,7 +92,7 @@
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, station_id == ScriptStation::STATION_NEW || station_id == ScriptStation::STATION_JOIN_ADJACENT || ScriptStation::IsValidStation(station_id));
 
-	return ScriptObject::Command<CMD_BUILD_DOCK>::Do(tile, ScriptStation::IsValidStation(station_id) ? station_id : INVALID_STATION, station_id != ScriptStation::STATION_JOIN_ADJACENT);
+	return ScriptObject::Command<CMD_BUILD_DOCK>::Do(tile, ScriptStation::IsValidStation(station_id) ? station_id : StationID::Invalid(), station_id != ScriptStation::STATION_JOIN_ADJACENT);
 }
 
 /* static */ bool ScriptMarine::BuildBuoy(TileIndex tile)

--- a/src/script/api/script_order.cpp
+++ b/src/script/api/script_order.cpp
@@ -484,7 +484,7 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 			if (order_flags & OF_GOTO_NEAREST_DEPOT) odaf |= ODATFB_NEAREST_DEPOT;
 			OrderNonStopFlags onsf = (OrderNonStopFlags)((order_flags & OF_NON_STOP_INTERMEDIATE) ? ONSF_NO_STOP_AT_INTERMEDIATE_STATIONS : ONSF_STOP_EVERYWHERE);
 			if (order_flags & OF_GOTO_NEAREST_DEPOT) {
-				order.MakeGoToDepot(INVALID_DEPOT, odtf, onsf, odaf);
+				order.MakeGoToDepot(DepotID::Invalid(), odtf, onsf, odaf);
 			} else {
 				/* Check explicitly if the order is to a station (for aircraft) or
 				 * to a depot (other vehicle types). */
@@ -680,7 +680,7 @@ static void _DoCommandReturnSetOrderFlags(class ScriptInstance *instance)
 	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ScriptVehicle::IsPrimaryVehicle(vehicle_id));
 
-	return ScriptObject::Command<CMD_CLONE_ORDER>::Do(0, CO_UNSHARE, vehicle_id, ::INVALID_VEHICLE);
+	return ScriptObject::Command<CMD_CLONE_ORDER>::Do(0, CO_UNSHARE, vehicle_id, VehicleID::Invalid());
 }
 
 /* static */ SQInteger ScriptOrder::GetOrderDistance(ScriptVehicle::VehicleType vehicle_type, TileIndex origin_tile, TileIndex dest_tile)

--- a/src/script/api/script_rail.cpp
+++ b/src/script/api/script_rail.cpp
@@ -159,7 +159,7 @@
 	EnforcePrecondition(false, station_id == ScriptStation::STATION_NEW || station_id == ScriptStation::STATION_JOIN_ADJACENT || ScriptStation::IsValidStation(station_id));
 
 	bool adjacent = station_id != ScriptStation::STATION_JOIN_ADJACENT;
-	return ScriptObject::Command<CMD_BUILD_RAIL_STATION>::Do(tile, (::RailType)GetCurrentRailType(), direction == RAILTRACK_NW_SE ? AXIS_Y : AXIS_X, num_platforms, platform_length, STAT_CLASS_DFLT, 0, ScriptStation::IsValidStation(station_id) ? station_id : INVALID_STATION, adjacent);
+	return ScriptObject::Command<CMD_BUILD_RAIL_STATION>::Do(tile, (::RailType)GetCurrentRailType(), direction == RAILTRACK_NW_SE ? AXIS_Y : AXIS_X, num_platforms, platform_length, STAT_CLASS_DFLT, 0, ScriptStation::IsValidStation(station_id) ? station_id : StationID::Invalid(), adjacent);
 }
 
 /* static */ bool ScriptRail::BuildNewGRFRailStation(TileIndex tile, RailTrack direction, SQInteger num_platforms, SQInteger platform_length, StationID station_id, CargoType cargo_type, IndustryType source_industry, IndustryType goal_industry, SQInteger distance, bool source_station)
@@ -191,7 +191,7 @@
 
 	Axis axis = direction == RAILTRACK_NW_SE ? AXIS_Y : AXIS_X;
 	bool adjacent = station_id != ScriptStation::STATION_JOIN_ADJACENT;
-	StationID to_join = ScriptStation::IsValidStation(station_id) ? station_id : INVALID_STATION;
+	StationID to_join = ScriptStation::IsValidStation(station_id) ? station_id : StationID::Invalid();
 	if (res != CALLBACK_FAILED) {
 		const StationSpec *spec = StationClass::GetByGrf(file->grfid, res);
 		if (spec == nullptr) {
@@ -213,7 +213,7 @@
 	EnforcePrecondition(false, GetRailTracks(tile) == RAILTRACK_NE_SW || GetRailTracks(tile) == RAILTRACK_NW_SE);
 	EnforcePrecondition(false, IsRailTypeAvailable(GetCurrentRailType()));
 
-	return ScriptObject::Command<CMD_BUILD_RAIL_WAYPOINT>::Do(tile, GetRailTracks(tile) == RAILTRACK_NE_SW ? AXIS_X : AXIS_Y, 1, 1, STAT_CLASS_WAYP, 0, INVALID_STATION, false);
+	return ScriptObject::Command<CMD_BUILD_RAIL_WAYPOINT>::Do(tile, GetRailTracks(tile) == RAILTRACK_NE_SW ? AXIS_X : AXIS_Y, 1, 1, STAT_CLASS_WAYP, 0, StationID::Invalid(), false);
 }
 
 /* static */ bool ScriptRail::RemoveRailWaypointTileRectangle(TileIndex tile, TileIndex tile2, bool keep_rail)

--- a/src/script/api/script_road.cpp
+++ b/src/script/api/script_road.cpp
@@ -579,7 +579,7 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 
 	DiagDirection entrance_dir = DiagdirBetweenTiles(tile, front);
 	RoadStopType stop_type = road_veh_type == ROADVEHTYPE_TRUCK ? RoadStopType::Truck : RoadStopType::Bus;
-	StationID to_join = ScriptStation::IsValidStation(station_id) ? station_id : INVALID_STATION;
+	StationID to_join = ScriptStation::IsValidStation(station_id) ? station_id : StationID::Invalid();
 	return ScriptObject::Command<CMD_BUILD_ROAD_STOP>::Do(tile, 1, 1, stop_type, drive_through, entrance_dir, ScriptObject::GetRoadType(), ROADSTOP_CLASS_DFLT, 0, to_join, station_id != ScriptStation::STATION_JOIN_ADJACENT);
 }
 

--- a/src/script/api/script_sign.cpp
+++ b/src/script/api/script_sign.cpp
@@ -74,14 +74,14 @@
 {
 	ScriptObjectRef counter(name);
 
-	EnforceDeityOrCompanyModeValid(INVALID_SIGN);
-	EnforcePrecondition(INVALID_SIGN, ::IsValidTile(location));
-	EnforcePrecondition(INVALID_SIGN, name != nullptr);
+	EnforceDeityOrCompanyModeValid(SignID::Invalid());
+	EnforcePrecondition(SignID::Invalid(), ::IsValidTile(location));
+	EnforcePrecondition(SignID::Invalid(), name != nullptr);
 	const std::string &text = name->GetDecodedText();
-	EnforcePreconditionEncodedText(INVALID_SIGN, text);
-	EnforcePreconditionCustomError(INVALID_SIGN, ::Utf8StringLength(text) < MAX_LENGTH_SIGN_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG);
+	EnforcePreconditionEncodedText(SignID::Invalid(), text);
+	EnforcePreconditionCustomError(SignID::Invalid(), ::Utf8StringLength(text) < MAX_LENGTH_SIGN_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG);
 
-	if (!ScriptObject::Command<CMD_PLACE_SIGN>::Do(&ScriptInstance::DoCommandReturnSignID, location, text)) return INVALID_SIGN;
+	if (!ScriptObject::Command<CMD_PLACE_SIGN>::Do(&ScriptInstance::DoCommandReturnSignID, location, text)) return SignID::Invalid();
 
 	/* In case of test-mode, we return SignID 0 */
 	return SignID::Begin();

--- a/src/script/api/script_station.cpp
+++ b/src/script/api/script_station.cpp
@@ -35,7 +35,7 @@
 
 /* static */ StationID ScriptStation::GetStationID(TileIndex tile)
 {
-	if (!::IsValidTile(tile) || !::IsTileType(tile, MP_STATION)) return INVALID_STATION;
+	if (!::IsValidTile(tile) || !::IsTileType(tile, MP_STATION)) return StationID::Invalid();
 	return ::GetStationIndex(tile);
 }
 
@@ -229,7 +229,7 @@ template <bool Tfrom, bool Tvia>
 
 /* static */ TownID ScriptStation::GetNearestTown(StationID station_id)
 {
-	if (!IsValidStation(station_id)) return INVALID_TOWN;
+	if (!IsValidStation(station_id)) return TownID::Invalid();
 
 	return ::Station::Get(station_id)->town->index;
 }

--- a/src/script/api/script_stationlist.cpp
+++ b/src/script/api/script_stationlist.cpp
@@ -122,7 +122,7 @@ private:
 
 CargoCollector::CargoCollector(ScriptStationList_Cargo *parent,
 		StationID station_id, CargoType cargo, StationID other) :
-	list(parent), ge(nullptr), other_station(other), last_key(INVALID_STATION), amount(0)
+	list(parent), ge(nullptr), other_station(other), last_key(StationID::Invalid()), amount(0)
 {
 	if (!ScriptStation::IsValidStation(station_id)) return;
 	if (!ScriptCargo::IsValidCargo(cargo)) return;
@@ -149,7 +149,7 @@ void CargoCollector::SetValue()
 template <ScriptStationList_Cargo::CargoSelector Tselector>
 void CargoCollector::Update(StationID from, StationID via, uint amount)
 {
-	StationID key = INVALID_STATION;
+	StationID key = StationID::Invalid();
 	switch (Tselector) {
 		case ScriptStationList_Cargo::CS_VIA_BY_FROM:
 			if (via != this->other_station) return;

--- a/src/script/api/script_stationlist.hpp
+++ b/src/script/api/script_stationlist.hpp
@@ -93,7 +93,7 @@ protected:
 	 * @param other_station Other station to restrict the query with.
 	 */
 	template <CargoSelector Tselector>
-	void Add(StationID station_id, CargoType cargo, StationID other_station = INVALID_STATION);
+	void Add(StationID station_id, CargoType cargo, StationID other_station = StationID::Invalid());
 
 public:
 
@@ -130,7 +130,7 @@ protected:
 	 * @param other_station Other station to restrict the query with.
 	 */
 	template <CargoSelector Tselector>
-	void Add(StationID station_id, CargoType cargo, StationID other_station = INVALID_STATION);
+	void Add(StationID station_id, CargoType cargo, StationID other_station = StationID::Invalid());
 
 public:
 

--- a/src/script/api/script_story_page.cpp
+++ b/src/script/api/script_story_page.cpp
@@ -76,7 +76,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 	}
 	EnforcePrecondition(STORY_PAGE_ELEMENT_INVALID, type != SPET_LOCATION || ::IsValidTile((::TileIndex)reference));
 	EnforcePrecondition(STORY_PAGE_ELEMENT_INVALID, type != SPET_GOAL || ScriptGoal::IsValidGoal(static_cast<::GoalID>(reference)));
-	EnforcePrecondition(STORY_PAGE_ELEMENT_INVALID, type != SPET_GOAL || !(StoryPage::Get(story_page_id)->company == INVALID_COMPANY && Goal::Get(reference)->company != INVALID_COMPANY));
+	EnforcePrecondition(STORY_PAGE_ELEMENT_INVALID, type != SPET_GOAL || !(StoryPage::Get(story_page_id)->company == CompanyID::Invalid() && Goal::Get(reference)->company != CompanyID::Invalid()));
 
 	uint32_t refid = 0;
 	TileIndex reftile{};
@@ -125,7 +125,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 	}
 	EnforcePrecondition(false, type != ::SPET_LOCATION || ::IsValidTile((::TileIndex)reference));
 	EnforcePrecondition(false, type != ::SPET_GOAL || ScriptGoal::IsValidGoal(static_cast<::GoalID>(reference)));
-	EnforcePrecondition(false, type != ::SPET_GOAL || !(p->company == INVALID_COMPANY && Goal::Get(reference)->company != INVALID_COMPANY));
+	EnforcePrecondition(false, type != ::SPET_GOAL || !(p->company == CompanyID::Invalid() && Goal::Get(reference)->company != CompanyID::Invalid()));
 
 	uint32_t refid = 0;
 	TileIndex reftile{};

--- a/src/script/api/script_story_page.hpp
+++ b/src/script/api/script_story_page.hpp
@@ -38,8 +38,8 @@
  */
 class ScriptStoryPage : public ScriptObject {
 public:
-	static constexpr StoryPageID STORY_PAGE_INVALID = ::INVALID_STORY_PAGE; ///< An invalid story page id.
-	static constexpr StoryPageElementID STORY_PAGE_ELEMENT_INVALID = ::INVALID_STORY_PAGE_ELEMENT; ///< An invalid story page element id.
+	static constexpr StoryPageID STORY_PAGE_INVALID = ::StoryPageID::Invalid(); ///< An invalid story page id.
+	static constexpr StoryPageElementID STORY_PAGE_ELEMENT_INVALID = ::StoryPageElementID::Invalid(); ///< An invalid story page element id.
 
 	/**
 	 * Story page element types.

--- a/src/script/api/script_storypagelist.cpp
+++ b/src/script/api/script_storypagelist.cpp
@@ -19,6 +19,6 @@ ScriptStoryPageList::ScriptStoryPageList(ScriptCompany::CompanyID company)
 	::CompanyID c = ScriptCompany::FromScriptCompanyID(company);
 
 	ScriptList::FillList<StoryPage>(this,
-		[c](const StoryPage *p) {return p->company == c || p->company == INVALID_COMPANY; }
+		[c](const StoryPage *p) {return p->company == c || p->company == CompanyID::Invalid(); }
 	);
 }

--- a/src/script/api/script_tile.cpp
+++ b/src/script/api/script_tile.cpp
@@ -310,20 +310,20 @@
 
 /* static */ TownID ScriptTile::GetTownAuthority(TileIndex tile)
 {
-	if (!::IsValidTile(tile)) return INVALID_TOWN;
+	if (!::IsValidTile(tile)) return TownID::Invalid();
 
 	Town *town = ::ClosestTownFromTile(tile, _settings_game.economy.dist_local_authority);
-	if (town == nullptr) return INVALID_TOWN;
+	if (town == nullptr) return TownID::Invalid();
 
 	return town->index;
 }
 
 /* static */ TownID ScriptTile::GetClosestTown(TileIndex tile)
 {
-	if (!::IsValidTile(tile)) return INVALID_TOWN;
+	if (!::IsValidTile(tile)) return TownID::Invalid();
 
 	Town *town = ::ClosestTownFromTile(tile, UINT_MAX);
-	if (town == nullptr) return INVALID_TOWN;
+	if (town == nullptr) return TownID::Invalid();
 
 	return town->index;
 }

--- a/src/script/api/script_tunnel.cpp
+++ b/src/script/api/script_tunnel.cpp
@@ -108,7 +108,7 @@ static void _DoCommandReturnBuildTunnel1(class ScriptInstance *instance)
 	DiagDirection dir_1 = ::DiagdirBetweenTiles(end, start);
 	DiagDirection dir_2 = ::ReverseDiagDir(dir_1);
 
-	return ScriptObject::Command<CMD_BUILD_ROAD>::Do(&::_DoCommandReturnBuildTunnel2, start + ::TileOffsByDiagDir(dir_1), ::DiagDirToRoadBits(dir_2), ScriptRoad::GetRoadType(), DRD_NONE, INVALID_TOWN);
+	return ScriptObject::Command<CMD_BUILD_ROAD>::Do(&::_DoCommandReturnBuildTunnel2, start + ::TileOffsByDiagDir(dir_1), ::DiagDirToRoadBits(dir_2), ScriptRoad::GetRoadType(), DRD_NONE, TownID::Invalid());
 }
 
 /* static */ bool ScriptTunnel::_BuildTunnelRoad2()
@@ -122,7 +122,7 @@ static void _DoCommandReturnBuildTunnel1(class ScriptInstance *instance)
 	DiagDirection dir_1 = ::DiagdirBetweenTiles(end, start);
 	DiagDirection dir_2 = ::ReverseDiagDir(dir_1);
 
-	return ScriptObject::Command<CMD_BUILD_ROAD>::Do(end + ::TileOffsByDiagDir(dir_2), ::DiagDirToRoadBits(dir_1), ScriptRoad::GetRoadType(), DRD_NONE, INVALID_TOWN);
+	return ScriptObject::Command<CMD_BUILD_ROAD>::Do(end + ::TileOffsByDiagDir(dir_2), ::DiagDirToRoadBits(dir_1), ScriptRoad::GetRoadType(), DRD_NONE, TownID::Invalid());
 }
 
 /* static */ bool ScriptTunnel::RemoveTunnel(TileIndex tile)

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -134,7 +134,7 @@
 		while (dest_wagon-- > 0) w = w->GetNextUnit();
 	}
 
-	return ScriptObject::Command<CMD_MOVE_RAIL_VEHICLE>::Do(v->index, w == nullptr ? ::INVALID_VEHICLE : w->index, move_attached_wagons);
+	return ScriptObject::Command<CMD_MOVE_RAIL_VEHICLE>::Do(v->index, w == nullptr ? VehicleID::Invalid() : w->index, move_attached_wagons);
 }
 
 /* static */ bool ScriptVehicle::MoveWagon(VehicleID source_vehicle_id, SQInteger source_wagon, SQInteger dest_vehicle_id, SQInteger dest_wagon)
@@ -275,15 +275,15 @@
 
 /* static */ EngineID ScriptVehicle::GetEngineType(VehicleID vehicle_id)
 {
-	if (!IsValidVehicle(vehicle_id)) return INVALID_ENGINE;
+	if (!IsValidVehicle(vehicle_id)) return ::EngineID::Invalid();
 
 	return ::Vehicle::Get(vehicle_id)->engine_type;
 }
 
 /* static */ EngineID ScriptVehicle::GetWagonEngineType(VehicleID vehicle_id, SQInteger wagon)
 {
-	if (!IsValidVehicle(vehicle_id)) return INVALID_ENGINE;
-	if (wagon >= GetNumWagons(vehicle_id)) return INVALID_ENGINE;
+	if (!IsValidVehicle(vehicle_id)) return ::EngineID::Invalid();
+	if (wagon >= GetNumWagons(vehicle_id)) return ::EngineID::Invalid();
 
 	const Vehicle *v = ::Vehicle::Get(vehicle_id);
 	if (v->type == VEH_TRAIN) {

--- a/src/script/api/script_vehicle.hpp
+++ b/src/script/api/script_vehicle.hpp
@@ -95,7 +95,7 @@ public:
 		VS_INVALID = 0xFF, ///< An invalid vehicle state.
 	};
 
-	static constexpr VehicleID VEHICLE_INVALID = ::INVALID_VEHICLE; ///< Invalid VehicleID.
+	static constexpr VehicleID VEHICLE_INVALID = ::VehicleID::Invalid(); ///< Invalid VehicleID.
 
 	/**
 	 * Checks whether the given vehicle is valid and owned by you.

--- a/src/script/api/script_waypoint.cpp
+++ b/src/script/api/script_waypoint.cpp
@@ -24,7 +24,7 @@
 
 /* static */ StationID ScriptWaypoint::GetWaypointID(TileIndex tile)
 {
-	if (!::IsValidTile(tile) || !::IsTileType(tile, MP_STATION) || ::Waypoint::GetByTile(tile) == nullptr) return INVALID_STATION;
+	if (!::IsValidTile(tile) || !::IsTileType(tile, MP_STATION) || ::Waypoint::GetByTile(tile) == nullptr) return StationID::Invalid();
 	return ::GetStationIndex(tile);
 }
 

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -176,7 +176,7 @@ std::string ScriptConfig::SettingsToString() const
 
 std::optional<std::string> ScriptConfig::GetTextfile(TextfileType type, CompanyID slot) const
 {
-	if (slot == INVALID_COMPANY || this->GetInfo() == nullptr) return std::nullopt;
+	if (slot == CompanyID::Invalid() || this->GetInfo() == nullptr) return std::nullopt;
 
 	return ::GetTextfile(type, (slot == OWNER_DEITY) ? GAME_DIR : AI_DIR, this->GetInfo()->GetMainScript());
 }

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -700,7 +700,7 @@ struct ScriptDebugWindow : public Window {
 
 	static inline FilterState initial_state = {
 		"",
-		INVALID_COMPANY,
+		CompanyID::Invalid(),
 		true,
 		false,
 	};
@@ -743,14 +743,14 @@ struct ScriptDebugWindow : public Window {
 	bool IsValidDebugCompany(CompanyID company) const
 	{
 		switch (company.base()) {
-			case INVALID_COMPANY.base(): return false;
+			case CompanyID::Invalid().base(): return false;
 			case OWNER_DEITY.base(): return Game::GetInstance() != nullptr;
 			default:              return Company::IsValidAiID(company);
 		}
 	}
 
 	/**
-	 * Ensure that \c script_debug_company refers to a valid AI company or GS, or is set to #INVALID_COMPANY.
+	 * Ensure that \c script_debug_company refers to a valid AI company or GS, or is set to #CompanyID::Invalid().
 	 * If no valid company is selected, it selects the first valid AI or GS if any.
 	 */
 	void SelectValidDebugCompany()
@@ -758,7 +758,7 @@ struct ScriptDebugWindow : public Window {
 		/* Check if the currently selected company is still active. */
 		if (this->IsValidDebugCompany(this->filter.script_debug_company)) return;
 
-		this->filter.script_debug_company = INVALID_COMPANY;
+		this->filter.script_debug_company = CompanyID::Invalid();
 
 		for (const Company *c : Company::Iterate()) {
 			if (c->is_ai) {
@@ -798,7 +798,7 @@ struct ScriptDebugWindow : public Window {
 		this->break_editbox.text.Assign(this->filter.break_string);
 		this->break_string_filter.SetFilterTerm(this->filter.break_string);
 
-		if (show_company == INVALID_COMPANY) {
+		if (show_company == CompanyID::Invalid()) {
 			this->SelectValidDebugCompany();
 		} else {
 			this->ChangeToScript(show_company);
@@ -847,7 +847,7 @@ struct ScriptDebugWindow : public Window {
 			SetDParam(0, STR_AI_DEBUG_NAME_AND_VERSION);
 			SetDParamStr(1, info->GetName());
 			SetDParam(2, info->GetVersion());
-		} else if (this->filter.script_debug_company == INVALID_COMPANY || !Company::IsValidAiID(this->filter.script_debug_company)) {
+		} else if (this->filter.script_debug_company == CompanyID::Invalid() || !Company::IsValidAiID(this->filter.script_debug_company)) {
 			SetDParam(0, STR_EMPTY);
 		} else {
 			const AIInfo *info = Company::Get(this->filter.script_debug_company)->ai_info;
@@ -893,7 +893,7 @@ struct ScriptDebugWindow : public Window {
 	 */
 	void DrawWidgetLog(const Rect &r) const
 	{
-		if (this->filter.script_debug_company == INVALID_COMPANY) return;
+		if (this->filter.script_debug_company == CompanyID::Invalid()) return;
 
 		const ScriptLogTypes::LogData &log = this->GetLogData();
 		if (log.empty()) return;
@@ -942,8 +942,8 @@ struct ScriptDebugWindow : public Window {
 	 */
 	void UpdateLogScroll()
 	{
-		this->SetWidgetsDisabledState(this->filter.script_debug_company == INVALID_COMPANY, WID_SCRD_VSCROLLBAR, WID_SCRD_HSCROLLBAR);
-		if (this->filter.script_debug_company == INVALID_COMPANY) return;
+		this->SetWidgetsDisabledState(this->filter.script_debug_company == CompanyID::Invalid(), WID_SCRD_VSCROLLBAR, WID_SCRD_HSCROLLBAR);
+		if (this->filter.script_debug_company == CompanyID::Invalid()) return;
 
 		ScriptLogTypes::LogData &log = this->GetLogData();
 
@@ -977,7 +977,7 @@ struct ScriptDebugWindow : public Window {
 	void UpdateAIButtonsState()
 	{
 		/* Update company buttons */
-		for (CompanyID i = COMPANY_FIRST; i < MAX_COMPANIES; ++i) {
+		for (CompanyID i = CompanyID::Begin(); i < MAX_COMPANIES; ++i) {
 			/* Mark dead/paused AIs by setting the background colour. */
 			bool valid = Company::IsValidAiID(i);
 			bool dead = valid && Company::Get(i)->ai_instance->IsDead();
@@ -1159,14 +1159,14 @@ struct ScriptDebugWindow : public Window {
 		this->SelectValidDebugCompany();
 
 		uint max_width = 0;
-		if (this->filter.script_debug_company != INVALID_COMPANY) {
+		if (this->filter.script_debug_company != CompanyID::Invalid()) {
 			for (auto &line : this->GetLogData()) {
 				if (line.width == 0 || data == -1) line.width = GetStringBoundingBox(line.text).width;
 				max_width = std::max(max_width, line.width);
 			}
 		}
 
-		this->vscroll->SetCount(this->filter.script_debug_company != INVALID_COMPANY ? this->GetLogData().size() : 0);
+		this->vscroll->SetCount(this->filter.script_debug_company != CompanyID::Invalid() ? this->GetLogData().size() : 0);
 		this->hscroll->SetCount(max_width + WidgetDimensions::scaled.frametext.Horizontal());
 
 		this->UpdateAIButtonsState();
@@ -1175,14 +1175,14 @@ struct ScriptDebugWindow : public Window {
 		this->SetWidgetLoweredState(WID_SCRD_BREAK_STR_ON_OFF_BTN, this->filter.break_check_enabled);
 		this->SetWidgetLoweredState(WID_SCRD_MATCH_CASE_BTN, this->filter.case_sensitive_break_check);
 
-		this->SetWidgetDisabledState(WID_SCRD_SETTINGS, this->filter.script_debug_company == INVALID_COMPANY ||
+		this->SetWidgetDisabledState(WID_SCRD_SETTINGS, this->filter.script_debug_company == CompanyID::Invalid() ||
 			GetConfig(this->filter.script_debug_company)->GetConfigList()->empty());
 		extern CompanyID _local_company;
 		this->SetWidgetDisabledState(WID_SCRD_RELOAD_TOGGLE,
-				this->filter.script_debug_company == INVALID_COMPANY ||
+				this->filter.script_debug_company == CompanyID::Invalid() ||
 				this->filter.script_debug_company == OWNER_DEITY ||
 				this->filter.script_debug_company == _local_company);
-		this->SetWidgetDisabledState(WID_SCRD_CONTINUE_BTN, this->filter.script_debug_company == INVALID_COMPANY ||
+		this->SetWidgetDisabledState(WID_SCRD_CONTINUE_BTN, this->filter.script_debug_company == CompanyID::Invalid() ||
 			(this->filter.script_debug_company == OWNER_DEITY ? !Game::IsPaused() : !AI::IsPaused(this->filter.script_debug_company)));
 	}
 
@@ -1200,7 +1200,7 @@ struct ScriptDebugWindow : public Window {
 	static EventState ScriptDebugGlobalHotkeys(int hotkey)
 	{
 		if (_game_mode != GM_NORMAL) return ES_NOT_HANDLED;
-		Window *w = ShowScriptDebugWindow(INVALID_COMPANY);
+		Window *w = ShowScriptDebugWindow(CompanyID::Invalid());
 		if (w == nullptr) return ES_NOT_HANDLED;
 		return w->OnHotkey(hotkey);
 	}
@@ -1335,7 +1335,7 @@ Window *ShowScriptDebugWindow(CompanyID show_company, bool new_window)
  */
 void InitializeScriptGui()
 {
-	ScriptDebugWindow::initial_state.script_debug_company = INVALID_COMPANY;
+	ScriptDebugWindow::initial_state.script_debug_company = CompanyID::Invalid();
 }
 
 /** Open the AI debug window if one of the AI scripts has crashed. */

--- a/src/script/script_gui.h
+++ b/src/script/script_gui.h
@@ -14,7 +14,7 @@
 #include "../textfile_type.h"
 
 void ShowScriptListWindow(CompanyID slot, bool show_all);
-Window *ShowScriptDebugWindow(CompanyID show_company = INVALID_COMPANY, bool new_window = false);
+Window *ShowScriptDebugWindow(CompanyID show_company = CompanyID::Invalid(), bool new_window = false);
 void ShowScriptSettingsWindow(CompanyID slot);
 void ShowScriptTextfileWindow(TextfileType file_type, CompanyID slot);
 void ShowScriptDebugWindowIfScriptError();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -960,14 +960,14 @@ static void AILoadConfig(const IniFile &ini, const char *grpname)
 	const IniGroup *group = ini.GetGroup(grpname);
 
 	/* Clean any configured AI */
-	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
+	for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 		AIConfig::GetConfig(c, AIConfig::SSS_FORCE_NEWGAME)->Change(std::nullopt);
 	}
 
 	/* If no group exists, return */
 	if (group == nullptr) return;
 
-	CompanyID c = COMPANY_FIRST;
+	CompanyID c = CompanyID::Begin();
 	for (const IniItem &item : group->items) {
 		AIConfig *config = AIConfig::GetConfig(c, AIConfig::SSS_FORCE_NEWGAME);
 
@@ -1173,7 +1173,7 @@ static void AISaveConfig(IniFile &ini, const char *grpname)
 	IniGroup &group = ini.GetOrCreateGroup(grpname);
 	group.Clear();
 
-	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
+	for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 		AIConfig *config = AIConfig::GetConfig(c, AIConfig::SSS_FORCE_NEWGAME);
 		std::string name;
 		std::string value = config->SettingsToString();

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -317,7 +317,7 @@ void Ship::PlayLeaveStationSound(bool force) const
 
 TileIndex Ship::GetOrderStationLocation(StationID station)
 {
-	if (station == this->last_station_visited) this->last_station_visited = INVALID_STATION;
+	if (station == this->last_station_visited) this->last_station_visited = StationID::Invalid();
 
 	const Station *st = Station::Get(station);
 	if (CanVehicleUseStation(this, st)) {
@@ -921,8 +921,8 @@ CommandCost CmdBuildShip(DoCommandFlags flags, TileIndex tile, const Engine *e, 
 		v->cargo_cap = svi->capacity;
 		v->refit_cap = 0;
 
-		v->last_station_visited = INVALID_STATION;
-		v->last_loading_station = INVALID_STATION;
+		v->last_station_visited = StationID::Invalid();
+		v->last_loading_station = StationID::Invalid();
 		v->engine_type = e->index;
 
 		v->reliability = e->reliability;

--- a/src/signs_cmd.cpp
+++ b/src/signs_cmd.cpp
@@ -35,10 +35,10 @@
 std::tuple<CommandCost, SignID> CmdPlaceSign(DoCommandFlags flags, TileIndex tile, const std::string &text)
 {
 	/* Try to locate a new sign */
-	if (!Sign::CanAllocateItem()) return { CommandCost(STR_ERROR_TOO_MANY_SIGNS), INVALID_SIGN };
+	if (!Sign::CanAllocateItem()) return { CommandCost(STR_ERROR_TOO_MANY_SIGNS), SignID::Invalid() };
 
 	/* Check sign text length if any */
-	if (Utf8StringLength(text) >= MAX_LENGTH_SIGN_NAME_CHARS) return { CMD_ERROR, INVALID_SIGN };
+	if (Utf8StringLength(text) >= MAX_LENGTH_SIGN_NAME_CHARS) return { CMD_ERROR, SignID::Invalid() };
 
 	/* When we execute, really make the sign */
 	if (flags.Test(DoCommandFlag::Execute)) {
@@ -57,7 +57,7 @@ std::tuple<CommandCost, SignID> CmdPlaceSign(DoCommandFlags flags, TileIndex til
 		return { CommandCost(), si->index };
 	}
 
-	return { CommandCost(), INVALID_SIGN };
+	return { CommandCost(), SignID::Invalid() };
 }
 
 /**

--- a/src/signs_type.h
+++ b/src/signs_type.h
@@ -12,7 +12,6 @@
 
 /** The type of the IDs of signs. */
 using SignID = PoolID<uint16_t, struct SignIDTag, 64000, 0xFFFF>;
-static constexpr SignID INVALID_SIGN = SignID::Invalid(); ///< Sentinel for an invalid sign.
 
 struct Sign;
 

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -60,25 +60,25 @@ static uint8_t _linkstat_colours_in_legenda[] = {0, 1, 3, 5, 7, 9, 11};
 static const int NUM_NO_COMPANY_ENTRIES = 4; ///< Number of entries in the owner legend that are not companies.
 
 /** Macro for ordinary entry of LegendAndColour */
-#define MK(a, b) {a, b, IT_INVALID, 0, INVALID_COMPANY, true, false, false}
+#define MK(a, b) {a, b, IT_INVALID, 0, CompanyID::Invalid(), true, false, false}
 
 /** Macro for a height legend entry with configurable colour. */
-#define MC(col_break)  {0, STR_TINY_BLACK_HEIGHT, IT_INVALID, 0, INVALID_COMPANY, true, false, col_break}
+#define MC(col_break)  {0, STR_TINY_BLACK_HEIGHT, IT_INVALID, 0, CompanyID::Invalid(), true, false, col_break}
 
 /** Macro for non-company owned property entry of LegendAndColour */
-#define MO(a, b) {a, b, IT_INVALID, 0, INVALID_COMPANY, true, false, false}
+#define MO(a, b) {a, b, IT_INVALID, 0, CompanyID::Invalid(), true, false, false}
 
 /** Macro used for forcing a rebuild of the owner legend the first time it is used. */
 #define MOEND() {0, STR_NULL, IT_INVALID, 0, OWNER_NONE, true, true, false}
 
 /** Macro for end of list marker in arrays of LegendAndColour */
-#define MKEND() {0, STR_NULL, IT_INVALID, 0, INVALID_COMPANY, true, true, false}
+#define MKEND() {0, STR_NULL, IT_INVALID, 0, CompanyID::Invalid(), true, true, false}
 
 /**
  * Macro for break marker in arrays of LegendAndColour.
  * It will have valid data, though
  */
-#define MS(a, b) {a, b, IT_INVALID, 0, INVALID_COMPANY, true, false, true}
+#define MS(a, b) {a, b, IT_INVALID, 0, CompanyID::Invalid(), true, false, true}
 
 /** Legend text giving the colours to look for on the minimap */
 static LegendAndColour _legend_land_contours[] = {
@@ -1538,7 +1538,7 @@ public:
 					SetDParam(0, tbl->legend);
 					str = STR_SMALLMAP_LINKSTATS;
 				} else if (i == SMT_OWNER) {
-					if (tbl->company != INVALID_COMPANY) {
+					if (tbl->company != CompanyID::Invalid()) {
 						if (!Company::IsValidID(tbl->company)) {
 							/* Rebuild the owner legend. */
 							BuildOwnerLegend();
@@ -1581,7 +1581,7 @@ public:
 	{
 		if (this->map_type == SMT_OWNER) {
 			for (const LegendAndColour *tbl = _legend_table[this->map_type]; !tbl->end; ++tbl) {
-				if (tbl->company != INVALID_COMPANY && !Company::IsValidID(tbl->company)) {
+				if (tbl->company != CompanyID::Invalid() && !Company::IsValidID(tbl->company)) {
 					/* Rebuild the owner legend. */
 					BuildOwnerLegend();
 					this->InvalidateData(1);
@@ -1660,7 +1660,7 @@ public:
 							[[fallthrough]];
 
 						case SMT_OWNER:
-							if (this->map_type != SMT_OWNER || tbl->company != INVALID_COMPANY) {
+							if (this->map_type != SMT_OWNER || tbl->company != CompanyID::Invalid()) {
 								if (this->map_type == SMT_OWNER) SetDParam(0, tbl->company);
 								if (!tbl->show_on_map) {
 									/* Simply draw the string, not the black border of the legend colour.

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -96,7 +96,7 @@ Station::~Station()
 
 	for (Aircraft *a : Aircraft::Iterate()) {
 		if (!a->IsNormalAircraft()) continue;
-		if (a->targetairport == this->index) a->targetairport = INVALID_STATION;
+		if (a->targetairport == this->index) a->targetairport = StationID::Invalid();
 	}
 
 	for (CargoType c = 0; c < NUM_CARGO; ++c) {
@@ -122,10 +122,10 @@ Station::~Station()
 	for (Vehicle *v : Vehicle::Iterate()) {
 		/* Forget about this station if this station is removed */
 		if (v->last_station_visited == this->index) {
-			v->last_station_visited = INVALID_STATION;
+			v->last_station_visited = StationID::Invalid();
 		}
 		if (v->last_loading_station == this->index) {
-			v->last_loading_station = INVALID_STATION;
+			v->last_loading_station = StationID::Invalid();
 		}
 	}
 

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -132,10 +132,10 @@ public:
 		assert(!this->shares.empty());
 		return this->unrestricted > 0 ?
 				this->shares.upper_bound(RandomRange(this->unrestricted))->second :
-				INVALID_STATION;
+				StationID::Invalid();
 	}
 
-	StationID GetVia(StationID excluded, StationID excluded2 = INVALID_STATION) const;
+	StationID GetVia(StationID excluded, StationID excluded2 = StationID::Invalid()) const;
 
 	void Invalidate();
 
@@ -219,7 +219,7 @@ struct GoodsEntry {
 
 	uint max_waiting_cargo = 0; ///< Max cargo from this station waiting at any station.
 	NodeID node = INVALID_NODE; ///< ID of node in link graph referring to this goods entry.
-	LinkGraphID link_graph = INVALID_LINK_GRAPH; ///< Link graph this station belongs to.
+	LinkGraphID link_graph = LinkGraphID::Invalid(); ///< Link graph this station belongs to.
 
 	uint8_t status = 0; ///< Status of this cargo, see #GoodsEntryStatus.
 
@@ -270,14 +270,14 @@ struct GoodsEntry {
 	/**
 	 * Get the best next hop for a cargo packet from station source.
 	 * @param source Source of the packet.
-	 * @return The chosen next hop or INVALID_STATION if none was found.
+	 * @return The chosen next hop or StationID::Invalid() if none was found.
 	 */
 	inline StationID GetVia(StationID source) const
 	{
-		if (!this->HasData()) return INVALID_STATION;
+		if (!this->HasData()) return StationID::Invalid();
 
 		FlowStatMap::const_iterator flow_it(this->GetData().flows.find(source));
-		return flow_it != this->GetData().flows.end() ? flow_it->second.GetVia() : INVALID_STATION;
+		return flow_it != this->GetData().flows.end() ? flow_it->second.GetVia() : StationID::Invalid();
 	}
 
 	/**
@@ -285,15 +285,15 @@ struct GoodsEntry {
 	 * excluding one or two stations.
 	 * @param source Source of the packet.
 	 * @param excluded If this station would be chosen choose the second best one instead.
-	 * @param excluded2 Second station to be excluded, if != INVALID_STATION.
-	 * @return The chosen next hop or INVALID_STATION if none was found.
+	 * @param excluded2 Second station to be excluded, if != StationID::Invalid().
+	 * @return The chosen next hop or StationID::Invalid() if none was found.
 	 */
-	inline StationID GetVia(StationID source, StationID excluded, StationID excluded2 = INVALID_STATION) const
+	inline StationID GetVia(StationID source, StationID excluded, StationID excluded2 = StationID::Invalid()) const
 	{
-		if (!this->HasData()) return INVALID_STATION;
+		if (!this->HasData()) return StationID::Invalid();
 
 		FlowStatMap::const_iterator flow_it(this->GetData().flows.find(source));
-		return flow_it != this->GetData().flows.end() ? flow_it->second.GetVia(excluded, excluded2) : INVALID_STATION;
+		return flow_it != this->GetData().flows.end() ? flow_it->second.GetVia(excluded, excluded2) : StationID::Invalid();
 	}
 
 	/**

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -125,14 +125,14 @@ CommandCost GetStationAround(TileArea ta, StationID closest_station, CompanyID c
 		if (IsTileType(tile_cur, MP_STATION)) {
 			StationID t = GetStationIndex(tile_cur);
 			if (!T::IsValidID(t) || T::Get(t)->owner != company || !filter(T::Get(t))) continue;
-			if (closest_station == INVALID_STATION) {
+			if (closest_station == StationID::Invalid()) {
 				closest_station = t;
 			} else if (closest_station != t) {
 				return CommandCost(STR_ERROR_ADJOINS_MORE_THAN_ONE_EXISTING);
 			}
 		}
 	}
-	*st = (closest_station == INVALID_STATION) ? nullptr : T::Get(closest_station);
+	*st = (closest_station == StationID::Invalid()) ? nullptr : T::Get(closest_station);
 	return CommandCost();
 }
 
@@ -900,14 +900,14 @@ static CommandCost CheckFlatLandRailStation(TileIndex tile_cur, TileIndex north_
 	}
 
 	/* if station is set, then we have special handling to allow building on top of already existing stations.
-		* so station points to INVALID_STATION if we can build on any station.
+		* so station points to StationID::Invalid() if we can build on any station.
 		* Or it points to a station if we're only allowed to build on exactly that station. */
 	if (station != nullptr && IsTileType(tile_cur, MP_STATION)) {
 		if (!IsRailStation(tile_cur)) {
 			return ClearTile_Station(tile_cur, DoCommandFlag::Auto); // get error message
 		} else {
 			StationID st = GetStationIndex(tile_cur);
-			if (*station == INVALID_STATION) {
+			if (*station == StationID::Invalid()) {
 				*station = st;
 			} else if (*station != st) {
 				return CommandCost(STR_ERROR_ADJOINS_MORE_THAN_ONE_EXISTING);
@@ -972,7 +972,7 @@ CommandCost CheckFlatLandRoadStop(TileIndex cur_tile, int &allowed_z, DoCommandF
 	cost.AddCost(ret);
 
 	/* If station is set, then we have special handling to allow building on top of already existing stations.
-	 * Station points to INVALID_STATION if we can build on any station.
+	 * Station points to StationID::Invalid() if we can build on any station.
 	 * Or it points to a station if we're only allowed to build on exactly that station. */
 	if (station != nullptr && IsTileType(cur_tile, MP_STATION)) {
 		if (!IsAnyRoadStop(cur_tile)) {
@@ -987,7 +987,7 @@ CommandCost CheckFlatLandRoadStop(TileIndex cur_tile, int &allowed_z, DoCommandF
 				return CommandCost(STR_ERROR_DRIVE_THROUGH_DIRECTION);
 			}
 			StationID st = GetStationIndex(cur_tile);
-			if (*station == INVALID_STATION) {
+			if (*station == StationID::Invalid()) {
 				*station = st;
 			} else if (*station != st) {
 				return CommandCost(STR_ERROR_ADJOINS_MORE_THAN_ONE_EXISTING);
@@ -1163,7 +1163,7 @@ CommandCost FindJoiningBaseStation(StationID existing_station, StationID station
 	assert(*st == nullptr);
 	bool check_surrounding = true;
 
-	if (existing_station != INVALID_STATION) {
+	if (existing_station != StationID::Invalid()) {
 		if (adjacent && existing_station != station_to_join) {
 			/* You can't build an adjacent station over the top of one that
 			 * already exists. */
@@ -1188,7 +1188,7 @@ CommandCost FindJoiningBaseStation(StationID existing_station, StationID station
 	}
 
 	/* Distant join */
-	if (*st == nullptr && station_to_join != INVALID_STATION) *st = T::GetIfValid(station_to_join);
+	if (*st == nullptr && station_to_join != StationID::Invalid()) *st = T::GetIfValid(station_to_join);
 
 	return CommandCost();
 }
@@ -1364,8 +1364,8 @@ CommandCost CmdBuildRailStation(DoCommandFlags flags, TileIndex tile_org, RailTy
 	}
 
 	bool reuse = (station_to_join != NEW_STATION);
-	if (!reuse) station_to_join = INVALID_STATION;
-	bool distant_join = (station_to_join != INVALID_STATION);
+	if (!reuse) station_to_join = StationID::Invalid();
+	bool distant_join = (station_to_join != StationID::Invalid());
 
 	if (distant_join && (!_settings_game.station.distant_join_stations || !Station::IsValidID(station_to_join))) return CMD_ERROR;
 
@@ -1375,7 +1375,7 @@ CommandCost CmdBuildRailStation(DoCommandFlags flags, TileIndex tile_org, RailTy
 	TileArea new_location(tile_org, w_org, h_org);
 
 	/* Make sure the area below consists of clear tiles. (OR tiles belonging to a certain rail station) */
-	StationID est = INVALID_STATION;
+	StationID est = StationID::Invalid();
 	std::vector<Train *> affected_vehicles;
 	/* Add construction and clearing expenses. */
 	CommandCost cost = CalculateRailStationCost(new_location, flags, axis, &est, rt, affected_vehicles, spec_class, spec_index, plat_len, numtracks);
@@ -1964,8 +1964,8 @@ CommandCost CmdBuildRoadStop(DoCommandFlags flags, TileIndex tile, uint8_t width
 {
 	if (!ValParamRoadType(rt) || !IsValidDiagDirection(ddir) || stop_type >= RoadStopType::End) return CMD_ERROR;
 	bool reuse = (station_to_join != NEW_STATION);
-	if (!reuse) station_to_join = INVALID_STATION;
-	bool distant_join = (station_to_join != INVALID_STATION);
+	if (!reuse) station_to_join = StationID::Invalid();
+	bool distant_join = (station_to_join != StationID::Invalid());
 
 	/* Check if the given station class is valid */
 	if (static_cast<uint>(spec_class) >= RoadStopClass::GetClassCount()) return CMD_ERROR;
@@ -2008,7 +2008,7 @@ CommandCost CmdBuildRoadStop(DoCommandFlags flags, TileIndex tile, uint8_t width
 	} else {
 		unit_cost = _price[is_truck_stop ? PR_BUILD_STATION_TRUCK : PR_BUILD_STATION_BUS];
 	}
-	StationID est = INVALID_STATION;
+	StationID est = StationID::Invalid();
 	CommandCost cost = CalculateRoadStopCost(roadstop_area, flags, is_drive_through, is_truck_stop ? StationType::Truck : StationType::Bus, axis, ddir, &est, rt, unit_cost);
 	if (cost.Failed()) return cost;
 
@@ -2523,8 +2523,8 @@ void UpdateAirportsNoise()
 CommandCost CmdBuildAirport(DoCommandFlags flags, TileIndex tile, uint8_t airport_type, uint8_t layout, StationID station_to_join, bool allow_adjacent)
 {
 	bool reuse = (station_to_join != NEW_STATION);
-	if (!reuse) station_to_join = INVALID_STATION;
-	bool distant_join = (station_to_join != INVALID_STATION);
+	if (!reuse) station_to_join = StationID::Invalid();
+	bool distant_join = (station_to_join != StationID::Invalid());
 
 	if (distant_join && (!_settings_game.station.distant_join_stations || !Station::IsValidID(station_to_join))) return CMD_ERROR;
 
@@ -2584,7 +2584,7 @@ CommandCost CmdBuildAirport(DoCommandFlags flags, TileIndex tile, uint8_t airpor
 	}
 
 	Station *st = nullptr;
-	ret = FindJoiningStation(INVALID_STATION, station_to_join, allow_adjacent, airport_area, &st);
+	ret = FindJoiningStation(StationID::Invalid(), station_to_join, allow_adjacent, airport_area, &st);
 	if (ret.Failed()) return ret;
 
 	/* Distant join */
@@ -2788,8 +2788,8 @@ static const uint8_t _dock_h_chk[4] = { 1, 2, 1, 2 };
 CommandCost CmdBuildDock(DoCommandFlags flags, TileIndex tile, StationID station_to_join, bool adjacent)
 {
 	bool reuse = (station_to_join != NEW_STATION);
-	if (!reuse) station_to_join = INVALID_STATION;
-	bool distant_join = (station_to_join != INVALID_STATION);
+	if (!reuse) station_to_join = StationID::Invalid();
+	bool distant_join = (station_to_join != StationID::Invalid());
 
 	if (distant_join && (!_settings_game.station.distant_join_stations || !Station::IsValidID(station_to_join))) return CMD_ERROR;
 
@@ -2836,7 +2836,7 @@ CommandCost CmdBuildDock(DoCommandFlags flags, TileIndex tile, StationID station
 
 	/* middle */
 	Station *st = nullptr;
-	ret = FindJoiningStation(INVALID_STATION, station_to_join, adjacent, dock_area, &st);
+	ret = FindJoiningStation(StationID::Invalid(), station_to_join, adjacent, dock_area, &st);
 	if (ret.Failed()) return ret;
 
 	/* Distant join */
@@ -3861,7 +3861,7 @@ static void UpdateStationRating(Station *st)
 			uint waiting = ge->HasData() ? ge->GetData().cargo.AvailableCount() : 0;
 
 			/* num_dests is at least 1 if there is any cargo as
-			 * INVALID_STATION is also a destination.
+			 * StationID::Invalid() is also a destination.
 			 */
 			uint num_dests = ge->HasData() ? static_cast<uint>(ge->GetData().cargo.Packets()->MapSize()) : 0;
 
@@ -3869,7 +3869,7 @@ static void UpdateStationRating(Station *st)
 			 * with only one or two next hops. They are allowed to have more
 			 * cargo waiting per next hop.
 			 * With manual cargo distribution waiting_avg = waiting / 2 as then
-			 * INVALID_STATION is the only destination.
+			 * StationID::Invalid() is the only destination.
 			 */
 			uint waiting_avg = waiting / (num_dests + 1);
 
@@ -4120,8 +4120,8 @@ void IncreaseStats(Station *st, CargoType cargo, StationID next_station_id, uint
 	Station *st2 = Station::Get(next_station_id);
 	GoodsEntry &ge2 = st2->goods[cargo];
 	LinkGraph *lg = nullptr;
-	if (ge1.link_graph == INVALID_LINK_GRAPH) {
-		if (ge2.link_graph == INVALID_LINK_GRAPH) {
+	if (ge1.link_graph == LinkGraphID::Invalid()) {
+		if (ge2.link_graph == LinkGraphID::Invalid()) {
 			if (LinkGraph::CanAllocateItem()) {
 				lg = new LinkGraph(cargo);
 				LinkGraphSchedule::instance.Queue(lg);
@@ -4137,7 +4137,7 @@ void IncreaseStats(Station *st, CargoType cargo, StationID next_station_id, uint
 			ge1.link_graph = lg->index;
 			ge1.node = lg->AddNode(st);
 		}
-	} else if (ge2.link_graph == INVALID_LINK_GRAPH) {
+	} else if (ge2.link_graph == LinkGraphID::Invalid()) {
 		lg = LinkGraph::Get(ge1.link_graph);
 		ge2.link_graph = lg->index;
 		ge2.node = lg->AddNode(st2);
@@ -4262,7 +4262,7 @@ static uint UpdateStationWaiting(Station *st, CargoType type, uint amount, Sourc
 	StationID next = ge.GetVia(st->index);
 	ge.GetOrCreateData().cargo.Append(new CargoPacket(st->index, amount, source), next);
 	LinkGraph *lg = nullptr;
-	if (ge.link_graph == INVALID_LINK_GRAPH) {
+	if (ge.link_graph == LinkGraphID::Invalid()) {
 		if (LinkGraph::CanAllocateItem()) {
 			lg = new LinkGraph(type);
 			LinkGraphSchedule::instance.Queue(lg);
@@ -4797,7 +4797,7 @@ uint FlowStat::GetShare(StationID st) const
  */
 StationID FlowStat::GetVia(StationID excluded, StationID excluded2) const
 {
-	if (this->unrestricted == 0) return INVALID_STATION;
+	if (this->unrestricted == 0) return StationID::Invalid();
 	assert(!this->shares.empty());
 	SharesMap::const_iterator it = this->shares.upper_bound(RandomRange(this->unrestricted));
 	assert(it != this->shares.end() && it->first <= this->unrestricted);
@@ -4809,7 +4809,7 @@ StationID FlowStat::GetVia(StationID excluded, StationID excluded2) const
 	uint end = it->first;
 	uint begin = (it == this->shares.begin() ? 0 : (--it)->first);
 	uint interval = end - begin;
-	if (interval >= this->unrestricted) return INVALID_STATION; // Only one station in the map.
+	if (interval >= this->unrestricted) return StationID::Invalid(); // Only one station in the map.
 	uint new_max = this->unrestricted - interval;
 	uint rand = RandomRange(new_max);
 	SharesMap::const_iterator it2 = (rand < begin) ? this->shares.upper_bound(rand) :
@@ -4823,7 +4823,7 @@ StationID FlowStat::GetVia(StationID excluded, StationID excluded2) const
 	uint end2 = it2->first;
 	uint begin2 = (it2 == this->shares.begin() ? 0 : (--it2)->first);
 	uint interval2 = end2 - begin2;
-	if (interval2 >= new_max) return INVALID_STATION; // Only the two excluded stations in the map.
+	if (interval2 >= new_max) return StationID::Invalid(); // Only the two excluded stations in the map.
 	new_max -= interval2;
 	if (begin > begin2) {
 		Swap(begin, begin2);
@@ -5028,11 +5028,11 @@ void FlowStatMap::PassOnFlow(StationID origin, StationID via, uint flow)
 	FlowStatMap::iterator prev_it = this->find(origin);
 	if (prev_it == this->end()) {
 		FlowStat fs(via, flow);
-		fs.AppendShare(INVALID_STATION, flow);
+		fs.AppendShare(StationID::Invalid(), flow);
 		this->emplace(origin, fs);
 	} else {
 		prev_it->second.ChangeShare(via, flow);
-		prev_it->second.ChangeShare(INVALID_STATION, flow);
+		prev_it->second.ChangeShare(StationID::Invalid(), flow);
 		assert(!prev_it->second.GetShares()->empty());
 	}
 }
@@ -5045,14 +5045,14 @@ void FlowStatMap::FinalizeLocalConsumption(StationID self)
 {
 	for (auto &i : *this) {
 		FlowStat &fs = i.second;
-		uint local = fs.GetShare(INVALID_STATION);
+		uint local = fs.GetShare(StationID::Invalid());
 		if (local > INT_MAX) { // make sure it fits in an int
 			fs.ChangeShare(self, -INT_MAX);
-			fs.ChangeShare(INVALID_STATION, -INT_MAX);
+			fs.ChangeShare(StationID::Invalid(), -INT_MAX);
 			local -= INT_MAX;
 		}
 		fs.ChangeShare(self, -(int)local);
-		fs.ChangeShare(INVALID_STATION, -(int)local);
+		fs.ChangeShare(StationID::Invalid(), -(int)local);
 
 		/* If the local share is used up there must be a share for some
 		 * remote station. */

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -1063,7 +1063,7 @@ private:
 
 CargoDataEntry::CargoDataEntry() :
 	parent(nullptr),
-	station(INVALID_STATION),
+	station(StationID::Invalid()),
 	num_children(0),
 	count(0),
 	children(new CargoDataSet(CargoSorter(CargoSortType::CargoType)))
@@ -1580,7 +1580,7 @@ struct StationViewWindow : public Window {
 			}
 
 			if (tmp.GetCount() == 0) {
-				dest->InsertOrRetrieve(INVALID_STATION)->Update(count);
+				dest->InsertOrRetrieve(StationID::Invalid())->Update(count);
 			} else {
 				uint sum_estimated = 0;
 				while (sum_estimated < count) {
@@ -1607,7 +1607,7 @@ struct StationViewWindow : public Window {
 				}
 			}
 		} else {
-			dest->InsertOrRetrieve(INVALID_STATION)->Update(count);
+			dest->InsertOrRetrieve(StationID::Invalid())->Update(count);
 		}
 	}
 
@@ -1649,13 +1649,13 @@ struct StationViewWindow : public Window {
 
 			const CargoDataEntry *source_entry = source_dest->Retrieve(cp->GetFirstStation());
 			if (source_entry == nullptr) {
-				this->ShowCargo(cargo, i, cp->GetFirstStation(), next, INVALID_STATION, cp->Count());
+				this->ShowCargo(cargo, i, cp->GetFirstStation(), next, StationID::Invalid(), cp->Count());
 				continue;
 			}
 
 			const CargoDataEntry *via_entry = source_entry->Retrieve(next);
 			if (via_entry == nullptr) {
-				this->ShowCargo(cargo, i, cp->GetFirstStation(), next, INVALID_STATION, cp->Count());
+				this->ShowCargo(cargo, i, cp->GetFirstStation(), next, StationID::Invalid(), cp->Count());
 				continue;
 			}
 
@@ -1747,7 +1747,7 @@ struct StationViewWindow : public Window {
 	{
 		if (station == this->window_number) {
 			return here;
-		} else if (station == INVALID_STATION) {
+		} else if (station == StationID::Invalid()) {
 			return any;
 		} else if (station == NEW_STATION) {
 			return STR_STATION_VIEW_RESERVED;
@@ -2462,7 +2462,7 @@ static bool StationJoinerNeeded(TileArea ta, const StationPickerCmdProc &proc)
 	if (!_ctrl_pressed) return false;
 
 	/* Now check if we could build there */
-	if (!proc(true, INVALID_STATION)) return false;
+	if (!proc(true, StationID::Invalid())) return false;
 
 	return FindStationsNearby<T>(ta, false) == nullptr;
 }
@@ -2480,7 +2480,7 @@ void ShowSelectBaseStationIfNeeded(TileArea ta, StationPickerCmdProc&& proc)
 		if (!_settings_client.gui.persistent_buildingtools) ResetObjectToPlace();
 		new SelectStationWindow<T>(_select_station_desc, ta, std::move(proc));
 	} else {
-		proc(false, INVALID_STATION);
+		proc(false, StationID::Invalid());
 	}
 }
 

--- a/src/station_type.h
+++ b/src/station_type.h
@@ -17,7 +17,6 @@
 using StationID = PoolID<uint16_t, struct StationIDTag, 64000, 0xFFFF>;
 static constexpr StationID NEW_STATION{0xFFFD};
 static constexpr StationID ADJACENT_STATION{0xFFFE};
-static constexpr StationID INVALID_STATION = StationID::Invalid();
 
 using RoadStopID = PoolID<uint16_t, struct RoadStopIDTag, 64000, 0xFFFF>;
 
@@ -27,7 +26,7 @@ struct RoadStop;
 struct StationSpec;
 struct Waypoint;
 
-using StationIDStack = SmallStack<StationID::BaseType, StationID::BaseType, INVALID_STATION.base(), 8, StationID::End().base()>;
+using StationIDStack = SmallStack<StationID::BaseType, StationID::BaseType, StationID::Invalid().base(), 8, StationID::End().base()>;
 
 /** Station types */
 enum class StationType : uint8_t {

--- a/src/story.cpp
+++ b/src/story.cpp
@@ -62,7 +62,7 @@ static bool VerifyElementContentParameters(StoryPageID page_id, StoryPageElement
 		case SPET_GOAL:
 			if (!Goal::IsValidID((GoalID)reference)) return false;
 			/* Reject company specific goals on global pages */
-			if (StoryPage::Get(page_id)->company == INVALID_COMPANY && Goal::Get((GoalID)reference)->company != INVALID_COMPANY) return false;
+			if (StoryPage::Get(page_id)->company == CompanyID::Invalid() && Goal::Get((GoalID)reference)->company != CompanyID::Invalid()) return false;
 			break;
 		case SPET_BUTTON_PUSH:
 			if (!button_data.ValidateColour()) return false;
@@ -208,10 +208,10 @@ bool StoryPageButtonData::ValidateVehicleType() const
  */
 std::tuple<CommandCost, StoryPageID> CmdCreateStoryPage(DoCommandFlags flags, CompanyID company, const std::string &text)
 {
-	if (!StoryPage::CanAllocateItem()) return { CMD_ERROR, INVALID_STORY_PAGE };
+	if (!StoryPage::CanAllocateItem()) return { CMD_ERROR, StoryPageID::Invalid() };
 
-	if (_current_company != OWNER_DEITY) return { CMD_ERROR, INVALID_STORY_PAGE };
-	if (company != INVALID_COMPANY && !Company::IsValidID(company)) return { CMD_ERROR, INVALID_STORY_PAGE };
+	if (_current_company != OWNER_DEITY) return { CMD_ERROR, StoryPageID::Invalid() };
+	if (company != CompanyID::Invalid() && !Company::IsValidID(company)) return { CMD_ERROR, StoryPageID::Invalid() };
 
 	if (flags.Test(DoCommandFlag::Execute)) {
 		if (StoryPage::GetNumItems() == 0) {
@@ -232,7 +232,7 @@ std::tuple<CommandCost, StoryPageID> CmdCreateStoryPage(DoCommandFlags flags, Co
 		return { CommandCost(), s->index };
 	}
 
-	return { CommandCost(), INVALID_STORY_PAGE };
+	return { CommandCost(), StoryPageID::Invalid() };
 }
 
 /**
@@ -247,18 +247,18 @@ std::tuple<CommandCost, StoryPageID> CmdCreateStoryPage(DoCommandFlags flags, Co
  */
 std::tuple<CommandCost, StoryPageElementID> CmdCreateStoryPageElement(DoCommandFlags flags, TileIndex tile, StoryPageID page_id, StoryPageElementType type, uint32_t reference, const std::string &text)
 {
-	if (!StoryPageElement::CanAllocateItem()) return { CMD_ERROR, INVALID_STORY_PAGE_ELEMENT };
+	if (!StoryPageElement::CanAllocateItem()) return { CMD_ERROR, StoryPageElementID::Invalid() };
 
 	/* Allow at most 128 elements per page. */
 	uint16_t element_count = 0;
 	for (StoryPageElement *iter : StoryPageElement::Iterate()) {
 		if (iter->page == page_id) element_count++;
 	}
-	if (element_count >= 128) return { CMD_ERROR, INVALID_STORY_PAGE_ELEMENT };
+	if (element_count >= 128) return { CMD_ERROR, StoryPageElementID::Invalid() };
 
-	if (_current_company != OWNER_DEITY) return { CMD_ERROR, INVALID_STORY_PAGE_ELEMENT };
-	if (!StoryPage::IsValidID(page_id)) return { CMD_ERROR, INVALID_STORY_PAGE_ELEMENT };
-	if (!VerifyElementContentParameters(page_id, type, tile, reference, text)) return { CMD_ERROR, INVALID_STORY_PAGE_ELEMENT };
+	if (_current_company != OWNER_DEITY) return { CMD_ERROR, StoryPageElementID::Invalid() };
+	if (!StoryPage::IsValidID(page_id)) return { CMD_ERROR, StoryPageElementID::Invalid() };
+	if (!VerifyElementContentParameters(page_id, type, tile, reference, text)) return { CMD_ERROR, StoryPageElementID::Invalid() };
 
 
 	if (flags.Test(DoCommandFlag::Execute)) {
@@ -279,7 +279,7 @@ std::tuple<CommandCost, StoryPageElementID> CmdCreateStoryPageElement(DoCommandF
 		return { CommandCost(), pe->index };
 	}
 
-	return { CommandCost(), INVALID_STORY_PAGE_ELEMENT };
+	return { CommandCost(), StoryPageElementID::Invalid() };
 }
 
 /**
@@ -368,7 +368,7 @@ CommandCost CmdShowStoryPage(DoCommandFlags flags, StoryPageID page_id)
 
 	if (flags.Test(DoCommandFlag::Execute)) {
 		StoryPage *g = StoryPage::Get(page_id);
-		if ((g->company != INVALID_COMPANY && g->company == _local_company) || (g->company == INVALID_COMPANY && Company::IsValidID(_local_company))) ShowStoryBook(_local_company, page_id, true);
+		if ((g->company != CompanyID::Invalid() && g->company == _local_company) || (g->company == CompanyID::Invalid() && Company::IsValidID(_local_company))) ShowStoryBook(_local_company, page_id, true);
 	}
 
 	return CommandCost();
@@ -440,7 +440,7 @@ CommandCost CmdStoryPageButton(DoCommandFlags flags, TileIndex tile, StoryPageEl
 
 	/* Check the player belongs to the company that owns the page. */
 	const StoryPage *const sp = StoryPage::Get(pe->page);
-	if (sp->company != INVALID_COMPANY && sp->company != _current_company) return CMD_ERROR;
+	if (sp->company != CompanyID::Invalid() && sp->company != _current_company) return CMD_ERROR;
 
 	switch (pe->type) {
 		case SPET_BUTTON_PUSH:

--- a/src/story_base.h
+++ b/src/story_base.h
@@ -164,7 +164,7 @@ struct StoryPageElement : StoryPageElementPool::PoolItem<&_story_page_element_po
 struct StoryPage : StoryPagePool::PoolItem<&_story_page_pool> {
 	uint32_t sort_value;            ///< A number that increases for every created story page. Used for sorting. The id of a story page is the pool index.
 	TimerGameCalendar::Date date; ///< Date when the page was created.
-	CompanyID company;            ///< StoryPage is for a specific company; INVALID_COMPANY if it is global
+	CompanyID company;            ///< StoryPage is for a specific company; CompanyID::Invalid() if it is global
 
 	std::string title;            ///< Title of story page
 

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -124,7 +124,7 @@ protected:
 	 */
 	bool IsPageAvailable(const StoryPage *page) const
 	{
-		return page->company == INVALID_COMPANY || page->company == this->window_number;
+		return page->company == CompanyID::Invalid() || page->company == this->window_number;
 	}
 
 	/**
@@ -191,7 +191,7 @@ protected:
 		this->story_page_elements.ForceRebuild();
 		this->BuildStoryPageElementList();
 
-		if (this->active_button_id != INVALID_STORY_PAGE_ELEMENT) ResetObjectToPlace();
+		if (this->active_button_id != StoryPageElementID::Invalid()) ResetObjectToPlace();
 
 		this->vscroll->SetCount(this->GetContentHeight());
 		this->SetWidgetDirty(WID_SB_SCROLLBAR);
@@ -551,18 +551,18 @@ protected:
 				break;
 
 			case SPET_BUTTON_PUSH:
-				if (this->active_button_id != INVALID_STORY_PAGE_ELEMENT) ResetObjectToPlace();
+				if (this->active_button_id != StoryPageElementID::Invalid()) ResetObjectToPlace();
 				this->active_button_id = pe.index;
 				this->SetTimeout();
 				this->SetWidgetDirty(WID_SB_PAGE_PANEL);
 
-				Command<CMD_STORY_PAGE_BUTTON>::Post(TileIndex{}, pe.index, INVALID_VEHICLE);
+				Command<CMD_STORY_PAGE_BUTTON>::Post(TileIndex{}, pe.index, VehicleID::Invalid());
 				break;
 
 			case SPET_BUTTON_TILE:
 				if (this->active_button_id == pe.index) {
 					ResetObjectToPlace();
-					this->active_button_id = INVALID_STORY_PAGE_ELEMENT;
+					this->active_button_id = StoryPageElementID::Invalid();
 				} else {
 					CursorID cursor = TranslateStoryPageButtonCursor(StoryPageButtonData{ pe.referenced_id }.GetCursor());
 					SetObjectToPlaceWnd(cursor, PAL_NONE, HT_RECT, this);
@@ -574,7 +574,7 @@ protected:
 			case SPET_BUTTON_VEHICLE:
 				if (this->active_button_id == pe.index) {
 					ResetObjectToPlace();
-					this->active_button_id = INVALID_STORY_PAGE_ELEMENT;
+					this->active_button_id = StoryPageElementID::Invalid();
 				} else {
 					CursorID cursor = TranslateStoryPageButtonCursor(StoryPageButtonData{ pe.referenced_id }.GetCursor());
 					SetObjectToPlaceWnd(cursor, PAL_NONE, HT_VEHICLE, this);
@@ -607,9 +607,9 @@ public:
 
 		/* Initialize selected vars. */
 		this->selected_generic_title.clear();
-		this->selected_page_id = INVALID_STORY_PAGE;
+		this->selected_page_id = StoryPageID::Invalid();
 
-		this->active_button_id = INVALID_STORY_PAGE_ELEMENT;
+		this->active_button_id = StoryPageElementID::Invalid();
 
 		this->OnInvalidateData(-1);
 	}
@@ -633,7 +633,7 @@ public:
 	{
 		if (this->selected_page_id != page_index) {
 			if (this->active_button_id != 0) ResetObjectToPlace();
-			this->active_button_id = INVALID_STORY_PAGE_ELEMENT;
+			this->active_button_id = StoryPageElementID::Invalid();
 			this->selected_page_id = page_index;
 			this->RefreshSelectedPage();
 			this->UpdatePrevNextDisabledState();
@@ -649,7 +649,7 @@ public:
 				break;
 			}
 			case WID_SB_CAPTION:
-				if (this->window_number == INVALID_COMPANY) {
+				if (this->window_number == CompanyID::Invalid()) {
 					SetDParam(0, STR_STORY_BOOK_SPECTATOR_CAPTION);
 				} else {
 					SetDParam(0, STR_STORY_BOOK_CAPTION);
@@ -872,9 +872,9 @@ public:
 
 			/* Verify page selection. */
 			if (!StoryPage::IsValidID(this->selected_page_id)) {
-				this->selected_page_id = INVALID_STORY_PAGE;
+				this->selected_page_id = StoryPageID::Invalid();
 			}
-			if (this->selected_page_id == INVALID_STORY_PAGE && !this->story_pages.empty()) {
+			if (this->selected_page_id == StoryPageID::Invalid() && !this->story_pages.empty()) {
 				/* No page is selected, but there exist at least one available.
 				 * => Select first page.
 				 */
@@ -891,7 +891,7 @@ public:
 
 	void OnTimeout() override
 	{
-		this->active_button_id = INVALID_STORY_PAGE_ELEMENT;
+		this->active_button_id = StoryPageElementID::Invalid();
 		this->SetWidgetDirty(WID_SB_PAGE_PANEL);
 	}
 
@@ -900,12 +900,12 @@ public:
 		const StoryPageElement *const pe = StoryPageElement::GetIfValid(this->active_button_id);
 		if (pe == nullptr || pe->type != SPET_BUTTON_TILE) {
 			ResetObjectToPlace();
-			this->active_button_id = INVALID_STORY_PAGE_ELEMENT;
+			this->active_button_id = StoryPageElementID::Invalid();
 			this->SetWidgetDirty(WID_SB_PAGE_PANEL);
 			return;
 		}
 
-		Command<CMD_STORY_PAGE_BUTTON>::Post(tile, pe->index, INVALID_VEHICLE);
+		Command<CMD_STORY_PAGE_BUTTON>::Post(tile, pe->index, VehicleID::Invalid());
 		ResetObjectToPlace();
 	}
 
@@ -914,7 +914,7 @@ public:
 		const StoryPageElement *const pe = StoryPageElement::GetIfValid(this->active_button_id);
 		if (pe == nullptr || pe->type != SPET_BUTTON_VEHICLE) {
 			ResetObjectToPlace();
-			this->active_button_id = INVALID_STORY_PAGE_ELEMENT;
+			this->active_button_id = StoryPageElementID::Invalid();
 			this->SetWidgetDirty(WID_SB_PAGE_PANEL);
 			return false;
 		}
@@ -931,7 +931,7 @@ public:
 
 	void OnPlaceObjectAbort() override
 	{
-		this->active_button_id = INVALID_STORY_PAGE_ELEMENT;
+		this->active_button_id = StoryPageElementID::Invalid();
 		this->SetWidgetDirty(WID_SB_PAGE_PANEL);
 	}
 };
@@ -1043,14 +1043,14 @@ static CursorID TranslateStoryPageButtonCursor(StoryPageButtonCursor cursor)
 
 /**
  * Raise or create the story book window for \a company, at page \a page_id.
- * @param company 'Owner' of the story book, may be #INVALID_COMPANY.
- * @param page_id Page to open, may be #INVALID_STORY_PAGE.
+ * @param company 'Owner' of the story book, may be #CompanyID::Invalid().
+ * @param page_id Page to open, may be #StoryPageID::Invalid().
  * @param centered Whether to open the window centered.
  */
 void ShowStoryBook(CompanyID company, StoryPageID page_id, bool centered)
 {
-	if (!Company::IsValidID(company)) company = (CompanyID)INVALID_COMPANY;
+	if (!Company::IsValidID(company)) company = (CompanyID)CompanyID::Invalid();
 
 	StoryBookWindow *w = AllocateWindowDescFront<StoryBookWindow, true>(centered ? _story_book_gs_desc : _story_book_desc, company);
-	if (page_id != INVALID_STORY_PAGE) w->SetSelectedPage(page_id);
+	if (page_id != StoryPageID::Invalid()) w->SetSelectedPage(page_id);
 }

--- a/src/story_type.h
+++ b/src/story_type.h
@@ -19,8 +19,5 @@ struct StoryPageElement;
 struct StoryPage;
 enum StoryPageElementType : uint8_t;
 
-static constexpr StoryPageElementID INVALID_STORY_PAGE_ELEMENT = StoryPageElementID::Invalid(); ///< Constant representing a non-existing story page element.
-static constexpr StoryPageID INVALID_STORY_PAGE = StoryPageID::Invalid(); ///< Constant representing a non-existing story page.
-
 #endif /* STORY_TYPE_H */
 

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -206,7 +206,7 @@ void CreateSubsidy(CargoType cargo_type, Source src, Source dst)
 	s->src = src;
 	s->dst = dst;
 	s->remaining = SUBSIDY_OFFER_MONTHS;
-	s->awarded = INVALID_COMPANY;
+	s->awarded = CompanyID::Invalid();
 
 	std::pair<NewsReference, NewsReference> references = SetupSubsidyDecodeParam(s, SubsidyDecodeParamType::NewsOffered);
 	AddNewsItem(STR_NEWS_SERVICE_SUBSIDY_OFFERED, NewsType::Subsidies, NewsStyle::Normal, {}, references.first, references.second);

--- a/src/subsidy_base.h
+++ b/src/subsidy_base.h
@@ -23,7 +23,7 @@ extern SubsidyPool _subsidy_pool;
 struct Subsidy : SubsidyPool::PoolItem<&_subsidy_pool> {
 	CargoType cargo_type;  ///< Cargo type involved in this subsidy, INVALID_CARGO for invalid subsidy
 	uint16_t remaining;    ///< Remaining months when this subsidy is valid
-	CompanyID awarded;   ///< Subsidy is awarded to this company; INVALID_COMPANY if it's not awarded to anyone
+	CompanyID awarded;   ///< Subsidy is awarded to this company; CompanyID::Invalid() if it's not awarded to anyone
 	Source src; ///< Source of subsidised path
 	Source dst; ///< Destination of subsidised path
 
@@ -43,7 +43,7 @@ struct Subsidy : SubsidyPool::PoolItem<&_subsidy_pool> {
 	 */
 	inline bool IsAwarded() const
 	{
-		return this->awarded != INVALID_COMPANY;
+		return this->awarded != CompanyID::Invalid();
 	}
 
 	void AwardTo(CompanyID company);

--- a/src/table/engines.h
+++ b/src/table/engines.h
@@ -24,7 +24,7 @@
  * @param f Bitmask of the climates
  * @note the 5 between b and f is the load amount
  */
-#define MT(a, b, c, d, e, f) { CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR + a, TimerGameCalendar::Year{c}, TimerGameCalendar::Year{d}, b, 5, f, INVALID_CARGO, e, 0, 8, EngineMiscFlags{}, VehicleCallbackMasks{}, 0, {}, STR_EMPTY, Ticks::CARGO_AGING_TICKS, INVALID_ENGINE }
+#define MT(a, b, c, d, e, f) { CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR + a, TimerGameCalendar::Year{c}, TimerGameCalendar::Year{d}, b, 5, f, INVALID_CARGO, e, 0, 8, EngineMiscFlags{}, VehicleCallbackMasks{}, 0, {}, STR_EMPTY, Ticks::CARGO_AGING_TICKS, EngineID::Invalid() }
 
 /**
  * Writes the properties of a multiple-unit train into the EngineInfo struct.
@@ -37,7 +37,7 @@
  * @param f Bitmask of the climates
  * @note the 5 between b and f is the load amount
  */
-#define MM(a, b, c, d, e, f) { CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR + a, TimerGameCalendar::Year{c}, TimerGameCalendar::Year{d}, b, 5, f, INVALID_CARGO, e, 0, 8, EngineMiscFlags{EngineMiscFlag::RailIsMU}, VehicleCallbackMasks{}, 0, {}, STR_EMPTY, Ticks::CARGO_AGING_TICKS, INVALID_ENGINE }
+#define MM(a, b, c, d, e, f) { CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR + a, TimerGameCalendar::Year{c}, TimerGameCalendar::Year{d}, b, 5, f, INVALID_CARGO, e, 0, 8, EngineMiscFlags{EngineMiscFlag::RailIsMU}, VehicleCallbackMasks{}, 0, {}, STR_EMPTY, Ticks::CARGO_AGING_TICKS, EngineID::Invalid() }
 
 /**
  * Writes the properties of a train carriage into the EngineInfo struct.
@@ -50,7 +50,7 @@
  * @see MT
  * @note the 5 between b and f is the load amount
  */
-#define MW(a, b, c, d, e, f) { CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR + a, TimerGameCalendar::Year{c}, TimerGameCalendar::Year{d}, b, 5, f, INVALID_CARGO, e, 0, 8, EngineMiscFlags{}, VehicleCallbackMasks{}, 0, {}, STR_EMPTY, Ticks::CARGO_AGING_TICKS, INVALID_ENGINE }
+#define MW(a, b, c, d, e, f) { CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR + a, TimerGameCalendar::Year{c}, TimerGameCalendar::Year{d}, b, 5, f, INVALID_CARGO, e, 0, 8, EngineMiscFlags{}, VehicleCallbackMasks{}, 0, {}, STR_EMPTY, Ticks::CARGO_AGING_TICKS, EngineID::Invalid() }
 
 /**
  * Writes the properties of a road vehicle into the EngineInfo struct.
@@ -63,7 +63,7 @@
  * @param f Bitmask of the climates
  * @note the 5 between b and f is the load amount
  */
-#define MR(a, b, c, d, e, f) { CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR + a, TimerGameCalendar::Year{c}, TimerGameCalendar::Year{d}, b, 5, f, INVALID_CARGO, e, 0, 8, EngineMiscFlags{}, VehicleCallbackMasks{}, 0, {}, STR_EMPTY, Ticks::CARGO_AGING_TICKS, INVALID_ENGINE }
+#define MR(a, b, c, d, e, f) { CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR + a, TimerGameCalendar::Year{c}, TimerGameCalendar::Year{d}, b, 5, f, INVALID_CARGO, e, 0, 8, EngineMiscFlags{}, VehicleCallbackMasks{}, 0, {}, STR_EMPTY, Ticks::CARGO_AGING_TICKS, EngineID::Invalid() }
 
 /**
  * Writes the properties of a ship into the EngineInfo struct.
@@ -75,7 +75,7 @@
  * @param f Bitmask of the climates
  * @note the 10 between b and f is the load amount
  */
-#define MS(a, b, c, d, e, f) { CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR + a, TimerGameCalendar::Year{c}, TimerGameCalendar::Year{d}, b, 10, f, INVALID_CARGO, e, 0, 8, EngineMiscFlags{}, VehicleCallbackMasks{}, 0, {}, STR_EMPTY, Ticks::CARGO_AGING_TICKS, INVALID_ENGINE }
+#define MS(a, b, c, d, e, f) { CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR + a, TimerGameCalendar::Year{c}, TimerGameCalendar::Year{d}, b, 10, f, INVALID_CARGO, e, 0, 8, EngineMiscFlags{}, VehicleCallbackMasks{}, 0, {}, STR_EMPTY, Ticks::CARGO_AGING_TICKS, EngineID::Invalid() }
 
 /**
  * Writes the properties of an aeroplane into the EngineInfo struct.
@@ -86,7 +86,7 @@
  * @param e Bitmask of the climates
  * @note the 20 between b and e is the load amount
  */
-#define MA(a, b, c, d, e) { CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR + a, TimerGameCalendar::Year{c}, TimerGameCalendar::Year{d}, b, 20, e, INVALID_CARGO, CT_INVALID, 0, 8, EngineMiscFlags{}, VehicleCallbackMasks{}, 0, {}, STR_EMPTY, Ticks::CARGO_AGING_TICKS, INVALID_ENGINE }
+#define MA(a, b, c, d, e) { CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR + a, TimerGameCalendar::Year{c}, TimerGameCalendar::Year{d}, b, 20, e, INVALID_CARGO, CT_INVALID, 0, 8, EngineMiscFlags{}, VehicleCallbackMasks{}, 0, {}, STR_EMPTY, Ticks::CARGO_AGING_TICKS, EngineID::Invalid() }
 
 /* Climates
  * T = Temperate

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -278,7 +278,7 @@ struct TimetableWindow : Window {
 	int GetOrderFromTimetableWndPt(int y, [[maybe_unused]] const Vehicle *v)
 	{
 		int32_t sel = this->vscroll->GetScrolledRowFromWidget(y, this, WID_VT_TIMETABLE_PANEL, WidgetDimensions::scaled.framerect.top);
-		if (sel == INT32_MAX) return INVALID_ORDER.base();
+		if (sel == INT32_MAX) return OrderID::Invalid().base();
 		assert(IsInsideBS(sel, 0, v->GetNumOrders() * 2));
 		return sel;
 	}
@@ -645,7 +645,7 @@ struct TimetableWindow : Window {
 				int selected = GetOrderFromTimetableWndPt(pt.y, v);
 
 				this->CloseChildWindows();
-				this->sel_index = (selected == INVALID_ORDER.base() || selected == this->sel_index) ? -1 : selected;
+				this->sel_index = (selected == OrderID::Invalid().base() || selected == this->sel_index) ? -1 : selected;
 				break;
 			}
 

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -173,7 +173,7 @@ static void PopupMainCompanyToolbMenu(Window *w, WidgetID widget, CompanyMask gr
 			break;
 	}
 
-	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; ++c) {
+	for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 		if (!Company::IsValidID(c)) continue;
 		list.push_back(std::make_unique<DropDownListCompanyItem>(c, grey.Test(c)));
 	}
@@ -615,7 +615,7 @@ static CallBackFunction ToolbarStoryClick(Window *w)
  */
 static CallBackFunction MenuClickStory(int index)
 {
-	ShowStoryBook(index == CTMN_SPECTATOR ? INVALID_COMPANY : (CompanyID)index);
+	ShowStoryBook(index == CTMN_SPECTATOR ? CompanyID::Invalid() : (CompanyID)index);
 	return CBF_NONE;
 }
 
@@ -635,7 +635,7 @@ static CallBackFunction ToolbarGoalClick(Window *w)
  */
 static CallBackFunction MenuClickGoal(int index)
 {
-	ShowGoalsList(index == CTMN_SPECTATOR ? INVALID_COMPANY : (CompanyID)index);
+	ShowGoalsList(index == CTMN_SPECTATOR ? CompanyID::Invalid() : (CompanyID)index);
 	return CBF_NONE;
 }
 
@@ -1164,7 +1164,7 @@ static CallBackFunction MenuClickHelp(int index)
 		case  0: return PlaceLandBlockInfo();
 		case  1: ShowHelpWindow();                 break;
 		case  2: IConsoleSwitch();                 break;
-		case  3: ShowScriptDebugWindow(INVALID_COMPANY, _ctrl_pressed); break;
+		case  3: ShowScriptDebugWindow(CompanyID::Invalid(), _ctrl_pressed); break;
 		case  4: ShowScreenshotWindow();           break;
 		case  5: ShowFramerateWindow();            break;
 		case  6: ShowAboutWindow();                break;

--- a/src/town_type.h
+++ b/src/town_type.h
@@ -14,7 +14,6 @@
 #include "core/pool_type.hpp"
 
 using TownID = PoolID<uint16_t, struct TownIDTag, 64000, 0xFFFF>;
-static constexpr TownID INVALID_TOWN = TownID::Invalid();
 
 struct Town;
 

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -112,7 +112,7 @@ void Train::ConsistChanged(ConsistChangeFlags allowed_changes)
 	assert(this->IsFrontEngine() || this->IsFreeWagon());
 
 	const RailVehicleInfo *rvi_v = RailVehInfo(this->engine_type);
-	EngineID first_engine = this->IsFrontEngine() ? this->engine_type : INVALID_ENGINE;
+	EngineID first_engine = this->IsFrontEngine() ? this->engine_type : EngineID::Invalid();
 	this->gcache.cached_total_length = 0;
 	this->compatible_railtypes = RAILTYPES_NONE;
 
@@ -126,7 +126,7 @@ void Train::ConsistChanged(ConsistChangeFlags allowed_changes)
 		assert(u->First() == this);
 
 		/* update the 'first engine' */
-		u->gcache.first_engine = this == u ? INVALID_ENGINE : first_engine;
+		u->gcache.first_engine = this == u ? EngineID::Invalid() : first_engine;
 		u->railtype = rvi_u->railtype;
 
 		if (u->IsEngine()) first_engine = u->engine_type;
@@ -624,7 +624,7 @@ static CommandCost CmdBuildRailWagon(DoCommandFlags flags, TileIndex tile, const
 		v->spritenum = rvi->image_index;
 
 		v->engine_type = e->index;
-		v->gcache.first_engine = INVALID_ENGINE; // needs to be set before first callback
+		v->gcache.first_engine = EngineID::Invalid(); // needs to be set before first callback
 
 		DiagDirection dir = GetRailDepotDirection(tile);
 
@@ -775,11 +775,11 @@ CommandCost CmdBuildRailVehicle(DoCommandFlags flags, TileIndex tile, const Engi
 		assert(IsValidCargoType(v->cargo_type));
 		v->cargo_cap = rvi->capacity;
 		v->refit_cap = 0;
-		v->last_station_visited = INVALID_STATION;
-		v->last_loading_station = INVALID_STATION;
+		v->last_station_visited = StationID::Invalid();
+		v->last_loading_station = StationID::Invalid();
 
 		v->engine_type = e->index;
-		v->gcache.first_engine = INVALID_ENGINE; // needs to be set before first callback
+		v->gcache.first_engine = EngineID::Invalid(); // needs to be set before first callback
 
 		v->reliability = e->reliability;
 		v->reliability_spd_dec = e->reliability_spd_dec;
@@ -1033,7 +1033,7 @@ static CommandCost CheckTrainAttachment(Train *t)
 		if (!t->IsArticulatedPart() && !t->IsRearDualheaded()) {
 			/* Back up and clear the first_engine data to avoid using wagon override group */
 			EngineID first_engine = t->gcache.first_engine;
-			t->gcache.first_engine = INVALID_ENGINE;
+			t->gcache.first_engine = EngineID::Invalid();
 
 			/* We don't want the cache to interfere. head's cache is cleared before
 			 * the loop and after each callback does not need to be cleared here. */
@@ -1184,7 +1184,7 @@ static void NormaliseTrainHead(Train *head)
  * @param flags type of operation
  *              Note: DoCommandFlag::AutoReplace is set when autoreplace tries to undo its modifications or moves vehicles to temporary locations inside the depot.
  * @param src_veh source vehicle index
- * @param dest_veh what wagon to put the source wagon AFTER, XXX - INVALID_VEHICLE to make a new line
+ * @param dest_veh what wagon to put the source wagon AFTER, XXX - VehicleID::Invalid() to make a new line
  * @param move_chain move all vehicles following the source vehicle
  * @return the cost of this operation or an error
  */
@@ -1201,7 +1201,7 @@ CommandCost CmdMoveRailVehicle(DoCommandFlags flags, VehicleID src_veh, VehicleI
 
 	/* if nothing is selected as destination, try and find a matching vehicle to drag to. */
 	Train *dst;
-	if (dest_veh == INVALID_VEHICLE) {
+	if (dest_veh == VehicleID::Invalid()) {
 		dst = (src->IsEngine() || flags.Test(DoCommandFlag::AutoReplace)) ? nullptr : FindGoodVehiclePos(src);
 	} else {
 		dst = Train::GetIfValid(dest_veh);
@@ -2388,7 +2388,7 @@ void FreeTrainTrackReservation(const Train *v)
 	TileIndex tile = v->tile;
 	Trackdir  td = v->GetVehicleTrackdir();
 	bool      free_tile = !(IsRailStationTile(v->tile) || IsTileType(v->tile, MP_TUNNELBRIDGE));
-	StationID station_id = IsRailStationTile(v->tile) ? GetStationIndex(v->tile) : INVALID_STATION;
+	StationID station_id = IsRailStationTile(v->tile) ? GetStationIndex(v->tile) : StationID::Invalid();
 
 	/* Can't be holding a reservation if we enter a depot. */
 	if (IsRailDepotTile(tile) && TrackdirToExitdir(td) != GetRailDepotDirection(tile)) return;
@@ -2948,7 +2948,7 @@ static bool CheckReverseTrain(const Train *v)
  */
 TileIndex Train::GetOrderStationLocation(StationID station)
 {
-	if (station == this->last_station_visited) this->last_station_visited = INVALID_STATION;
+	if (station == this->last_station_visited) this->last_station_visited = StationID::Invalid();
 
 	const Station *st = Station::Get(station);
 	if (!st->facilities.Test(StationFacility::Train)) {

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -61,7 +61,7 @@ static int HighlightDragPosition(int px, int max_width, int y, VehicleID selecti
 {
 	bool rtl = _current_text_dir == TD_RTL;
 
-	assert(selection != INVALID_VEHICLE);
+	assert(selection != VehicleID::Invalid());
 	int dragged_width = 0;
 	for (Train *t = Train::Get(selection); t != nullptr; t = chain ? t->Next() : (t->HasArticulatedPart() ? t->GetNextArticulatedPart() : nullptr)) {
 		dragged_width += t->GetDisplayImageWidth(nullptr);
@@ -88,7 +88,7 @@ static int HighlightDragPosition(int px, int max_width, int y, VehicleID selecti
  * @param r         Rect to draw at
  * @param selection Selected vehicle to draw a frame around
  * @param skip      Number of pixels to skip at the front (for scrolling)
- * @param drag_dest The vehicle another one is dragged over, \c INVALID_VEHICLE if none.
+ * @param drag_dest The vehicle another one is dragged over, \c VehicleID::Invalid() if none.
  */
 void DrawTrainImage(const Train *v, const Rect &r, VehicleID selection, EngineImageType image_type, int skip, VehicleID drag_dest)
 {
@@ -113,7 +113,7 @@ void DrawTrainImage(const Train *v, const Rect &r, VehicleID selection, EngineIm
 		int px = rtl ? max_width + skip : -skip;
 		int y = r.Height() / 2;
 		bool sel_articulated = false;
-		bool dragging = (drag_dest != INVALID_VEHICLE);
+		bool dragging = (drag_dest != VehicleID::Invalid());
 		bool drag_at_end_of_train = (drag_dest == v->index); // Head index is used to mark dragging at end of train.
 		for (; v != nullptr && (rtl ? px > 0 : px < max_width); v = v->Next()) {
 			if (dragging && !drag_at_end_of_train && drag_dest == v->index) {
@@ -288,12 +288,12 @@ static void GetCargoSummaryOfArticulatedVehicle(const Train *v, CargoSummary &su
 			item->subtype = new_item.subtype;
 			item->capacity = 0;
 			item->amount = 0;
-			item->source = INVALID_STATION;
+			item->source = StationID::Invalid();
 		}
 
 		item->capacity += v->cargo_cap;
 		item->amount += v->cargo.StoredCount();
-		if (item->source == INVALID_STATION) item->source = v->cargo.GetFirstStation();
+		if (item->source == StationID::Invalid()) item->source = v->cargo.GetFirstStation();
 	} while ((v = v->Next()) != nullptr && v->IsArticulatedPart());
 }
 

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -739,11 +739,11 @@ public:
 
 	/**
 	 * Get the next station the vehicle will stop at.
-	 * @return ID of the next station the vehicle will stop at or INVALID_STATION.
+	 * @return ID of the next station the vehicle will stop at or StationID::Invalid().
 	 */
 	inline StationIDStack GetNextStoppingStation() const
 	{
-		return (this->orders == nullptr) ? INVALID_STATION.base() : this->orders->GetNextStoppingStation(this);
+		return (this->orders == nullptr) ? StationID::Invalid().base() : this->orders->GetNextStoppingStation(this);
 	}
 
 	void ResetRefitCaps();

--- a/src/vehicle_gui.h
+++ b/src/vehicle_gui.h
@@ -51,7 +51,7 @@ struct TestedEngineDetails {
 
 int DrawVehiclePurchaseInfo(int left, int right, int y, EngineID engine_number, TestedEngineDetails &te);
 
-void DrawTrainImage(const Train *v, const Rect &r, VehicleID selection, EngineImageType image_type, int skip, VehicleID drag_dest = INVALID_VEHICLE);
+void DrawTrainImage(const Train *v, const Rect &r, VehicleID selection, EngineImageType image_type, int skip, VehicleID drag_dest = VehicleID::Invalid());
 void DrawRoadVehImage(const Vehicle *v, const Rect &r, VehicleID selection, EngineImageType image_type, int skip = 0);
 void DrawShipImage(const Vehicle *v, const Rect &r, VehicleID selection, EngineImageType image_type);
 void DrawAircraftImage(const Vehicle *v, const Rect &r, VehicleID selection, EngineImageType image_type);

--- a/src/vehicle_type.h
+++ b/src/vehicle_type.h
@@ -15,7 +15,6 @@
 
 /** The type all our vehicle IDs have. */
 using VehicleID = PoolID<uint32_t, struct VehicleIDTag, 0xFF000, 0xFFFFF>;
-static constexpr VehicleID INVALID_VEHICLE = VehicleID::Invalid(); ///< Constant representing a non-existing vehicle.
 
 static const int GROUND_ACCELERATION = 9800; ///< Acceleration due to gravity, 9.8 m/s^2
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -260,7 +260,7 @@ void InitializeWindowViewport(Window *w, int x, int y,
 			y = TileY(tile) * TILE_SIZE;
 			pt = MapXYZToViewport(vp, x, y, GetSlopePixelZ(x, y));
 		}
-		vp->follow_vehicle = INVALID_VEHICLE;
+		vp->follow_vehicle = VehicleID::Invalid();
 	}
 
 	vp->scrollpos_x = pt.x;
@@ -1968,7 +1968,7 @@ void UpdateViewportPosition(Window *w, uint32_t delta_ms)
 {
 	const Viewport *vp = w->viewport;
 
-	if (w->viewport->follow_vehicle != INVALID_VEHICLE) {
+	if (w->viewport->follow_vehicle != VehicleID::Invalid()) {
 		const Vehicle *veh = Vehicle::Get(w->viewport->follow_vehicle);
 		Point pt = MapXYZToViewport(vp, veh->x_pos, veh->y_pos, veh->z_pos);
 
@@ -2530,7 +2530,7 @@ bool ScrollWindowTo(int x, int y, int z, Window *w, bool instant)
 	}
 
 	Point pt = MapXYZToViewport(w->viewport, x, y, z);
-	w->viewport->follow_vehicle = INVALID_VEHICLE;
+	w->viewport->follow_vehicle = VehicleID::Invalid();
 
 	if (w->viewport->dest_scrollpos_x == pt.x && w->viewport->dest_scrollpos_y == pt.y) return false;
 

--- a/src/viewport_gui.cpp
+++ b/src/viewport_gui.cpp
@@ -85,7 +85,7 @@ public:
 				/* set this view to same location. Based on the center, adjusting for zoom */
 				w->viewport->dest_scrollpos_x =  x - (w->viewport->virtual_width -  this->viewport->virtual_width) / 2;
 				w->viewport->dest_scrollpos_y =  y - (w->viewport->virtual_height - this->viewport->virtual_height) / 2;
-				w->viewport->follow_vehicle   = INVALID_VEHICLE;
+				w->viewport->follow_vehicle   = VehicleID::Invalid();
 				break;
 			}
 

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -146,14 +146,14 @@ extern CommandCost ClearTile_Station(TileIndex tile, DoCommandFlags flags);
 static CommandCost IsValidTileForWaypoint(TileIndex tile, Axis axis, StationID *waypoint)
 {
 	/* if waypoint is set, then we have special handling to allow building on top of already existing waypoints.
-	 * so waypoint points to INVALID_STATION if we can build on any waypoint.
+	 * so waypoint points to StationID::Invalid() if we can build on any waypoint.
 	 * Or it points to a waypoint if we're only allowed to build on exactly that waypoint. */
 	if (waypoint != nullptr && IsTileType(tile, MP_STATION)) {
 		if (!IsRailWaypoint(tile)) {
 			return ClearTile_Station(tile, DoCommandFlag::Auto); // get error message
 		} else {
 			StationID wp = GetStationIndex(tile);
-			if (*waypoint == INVALID_STATION) {
+			if (*waypoint == StationID::Invalid()) {
 				*waypoint = wp;
 			} else if (*waypoint != wp) {
 				return CommandCost(STR_ERROR_WAYPOINT_ADJOINS_MORE_THAN_ONE_EXISTING);
@@ -215,8 +215,8 @@ CommandCost CmdBuildRailWaypoint(DoCommandFlags flags, TileIndex start_tile, Axi
 	if (count == 0 || count > _settings_game.station.station_spread) return CMD_ERROR;
 
 	bool reuse = (station_to_join != NEW_STATION);
-	if (!reuse) station_to_join = INVALID_STATION;
-	bool distant_join = (station_to_join != INVALID_STATION);
+	if (!reuse) station_to_join = StationID::Invalid();
+	bool distant_join = (station_to_join != StationID::Invalid());
 
 	if (distant_join && (!_settings_game.station.distant_join_stations || !Waypoint::IsValidID(station_to_join))) return CMD_ERROR;
 
@@ -229,7 +229,7 @@ CommandCost CmdBuildRailWaypoint(DoCommandFlags flags, TileIndex start_tile, Axi
 	}
 
 	/* Make sure the area below consists of clear tiles. (OR tiles belonging to a certain rail station) */
-	StationID est = INVALID_STATION;
+	StationID est = StationID::Invalid();
 
 	/* Check whether the tiles we're building on are valid rail or not. */
 	TileIndexDiff offset = TileOffsByAxis(OtherAxis(axis));
@@ -349,8 +349,8 @@ CommandCost CmdBuildRoadWaypoint(DoCommandFlags flags, TileIndex start_tile, Axi
 	if (count == 0 || count > _settings_game.station.station_spread) return CMD_ERROR;
 
 	bool reuse = (station_to_join != NEW_STATION);
-	if (!reuse) station_to_join = INVALID_STATION;
-	bool distant_join = (station_to_join != INVALID_STATION);
+	if (!reuse) station_to_join = StationID::Invalid();
+	bool distant_join = (station_to_join != StationID::Invalid());
 
 	if (distant_join && (!_settings_game.station.distant_join_stations || !Waypoint::IsValidID(station_to_join))) return CMD_ERROR;
 
@@ -363,7 +363,7 @@ CommandCost CmdBuildRoadWaypoint(DoCommandFlags flags, TileIndex start_tile, Axi
 	} else {
 		unit_cost = _price[PR_BUILD_STATION_TRUCK];
 	}
-	StationID est = INVALID_STATION;
+	StationID est = StationID::Invalid();
 	CommandCost cost = CalculateRoadStopCost(roadstop_area, flags, true, StationType::RoadWaypoint, axis, AxisToDiagDir(axis), &est, INVALID_ROADTYPE, unit_cost);
 	if (cost.Failed()) return cost;
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2369,7 +2369,7 @@ static EventState HandleViewportScroll()
 		return ES_NOT_HANDLED;
 	}
 
-	if (_last_scroll_window == GetMainWindow() && _last_scroll_window->viewport->follow_vehicle != INVALID_VEHICLE) {
+	if (_last_scroll_window == GetMainWindow() && _last_scroll_window->viewport->follow_vehicle != VehicleID::Invalid()) {
 		/* If the main window is following a vehicle, then first let go of it! */
 		const Vehicle *veh = Vehicle::Get(_last_scroll_window->viewport->follow_vehicle);
 		ScrollMainWindowTo(veh->x_pos, veh->y_pos, veh->z_pos, true); // This also resets follow_vehicle
@@ -2691,17 +2691,17 @@ static void HandleAutoscroll()
 	/* If we succeed at scrolling in any direction, stop following a vehicle. */
 	static const int SCROLLSPEED = 3;
 	if (x - 15 < 0) {
-		w->viewport->follow_vehicle = INVALID_VEHICLE;
+		w->viewport->follow_vehicle = VehicleID::Invalid();
 		w->viewport->dest_scrollpos_x += ScaleByZoom((x - 15) * SCROLLSPEED, vp->zoom);
 	} else if (15 - (vp->width - x) > 0) {
-		w->viewport->follow_vehicle = INVALID_VEHICLE;
+		w->viewport->follow_vehicle = VehicleID::Invalid();
 		w->viewport->dest_scrollpos_x += ScaleByZoom((15 - (vp->width - x)) * SCROLLSPEED, vp->zoom);
 	}
 	if (y - 15 < 0) {
-		w->viewport->follow_vehicle = INVALID_VEHICLE;
+		w->viewport->follow_vehicle = VehicleID::Invalid();
 		w->viewport->dest_scrollpos_y += ScaleByZoom((y - 15) * SCROLLSPEED, vp->zoom);
 	} else if (15 - (vp->height - y) > 0) {
-		w->viewport->follow_vehicle = INVALID_VEHICLE;
+		w->viewport->follow_vehicle = VehicleID::Invalid();
 		w->viewport->dest_scrollpos_y += ScaleByZoom((15 - (vp->height - y)) * SCROLLSPEED, vp->zoom);
 	}
 }
@@ -2769,7 +2769,7 @@ static void HandleKeyScrolling()
 
 		if (_game_mode != GM_MENU && _game_mode != GM_BOOTSTRAP) {
 			/* Key scrolling stops following a vehicle. */
-			GetMainWindow()->viewport->follow_vehicle = INVALID_VEHICLE;
+			GetMainWindow()->viewport->follow_vehicle = VehicleID::Invalid();
 		}
 
 		ScrollMainViewport(scrollamt[_dirkeys][0] * factor, scrollamt[_dirkeys][1] * factor);

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -244,12 +244,12 @@ static const int WHITE_BORDER_DURATION = 3; ///< The initial timeout value for W
 /**
  * Data structure for a window viewport.
  * A viewport is either following a vehicle (its id in then in #follow_vehicle), or it aims to display a specific
- * location #dest_scrollpos_x, #dest_scrollpos_y (#follow_vehicle is then #INVALID_VEHICLE).
+ * location #dest_scrollpos_x, #dest_scrollpos_y (#follow_vehicle is then #VehicleID::Invalid()).
  * The actual location being shown is #scrollpos_x, #scrollpos_y.
  * @see InitializeViewport(), UpdateViewportPosition(), UpdateViewportCoordinates().
  */
 struct ViewportData : Viewport {
-	VehicleID follow_vehicle; ///< VehicleID to follow if following a vehicle, #INVALID_VEHICLE otherwise.
+	VehicleID follow_vehicle; ///< VehicleID to follow if following a vehicle, #VehicleID::Invalid() otherwise.
 	int32_t scrollpos_x;        ///< Currently shown x coordinate (virtual screen coordinate of topleft corner of the viewport).
 	int32_t scrollpos_y;        ///< Currently shown y coordinate (virtual screen coordinate of topleft corner of the viewport).
 	int32_t dest_scrollpos_x;   ///< Current destination x coordinate to display (virtual screen coordinate of topleft corner of the viewport).


### PR DESCRIPTION
## Motivation / Problem

The `PoolID` now had `::Invalid()`, `::Begin() and `::End()` that can be used instead of custom constants. However, during the `PoolID` migration the replacements of those constants was postponed to keep the PRs easier to review.

This is, however, doing exactly those replacements that I postponed.


## Description

Replace indirections to `::Invalid()`, `::Begin()` and `::End()` for `PoolID`s.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
