### PR TITLE
Codechange: explicitly initialise EngineRenew member variables

### DIFF
--- a/src/autoreplace.cpp
+++ b/src/autoreplace.cpp
@@ -109,13 +109,8 @@ CommandCost AddEngineReplacement(EngineRenewList *erl, EngineID old_engine, Engi
 	if (!EngineRenew::CanAllocateItem()) return CMD_ERROR;
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		er = new EngineRenew(old_engine, new_engine);
-		er->group_id = group;
-		er->replace_when_old = replace_when_old;
-
 		/* Insert before the first element */
-		er->next = (EngineRenew *)(*erl);
-		*erl = (EngineRenewList)er;
+		*erl = new EngineRenew(old_engine, new_engine, group, replace_when_old, *erl);
 	}
 
 	return CommandCost();

--- a/src/autoreplace_base.h
+++ b/src/autoreplace_base.h
@@ -31,13 +31,15 @@ extern EngineRenewPool _enginerenew_pool;
  * it.
  */
 struct EngineRenew : EngineRenewPool::PoolItem<&_enginerenew_pool> {
-	EngineID from;
-	EngineID to;
-	EngineRenew *next;
-	GroupID group_id;
-	bool replace_when_old; ///< Do replacement only when vehicle is old.
+	EngineID from = EngineID::Invalid();
+	EngineID to = EngineID::Invalid();
+	EngineRenew *next = nullptr;
+	GroupID group_id = GroupID::Invalid();
+	bool replace_when_old = false; ///< Do replacement only when vehicle is old.
 
-	EngineRenew(EngineID from = EngineID::Invalid(), EngineID to = EngineID::Invalid()) : from(from), to(to) {}
+	EngineRenew() {}
+	EngineRenew(EngineID from, EngineID to, GroupID group_id, bool replace_when_old, EngineRenew *next) :
+		from(from), to(to), next(next), group_id(group_id), replace_when_old(replace_when_old) {}
 	~EngineRenew() {}
 };
 


### PR DESCRIPTION
## Motivation / Problem

If we want to get rid of `CallocT`, the pool items needs to stop relying on it. So all pool items should explicitly initialise their member variable, be it `0`, `nullptr`, or anything else. That way we don't need to zero everything first.


## Description

Explicitly initialise the member variables, in this case of `EngineRenew`.

While doing so, I noticed that the construction of this object is really simple, so I just put all initialisation in the constructor instead of only two of the five fields.


## Limitations

The pool is still `CallocT`-ing first, but this class does not depend on it any more.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
