### PR TITLE
Codechange: explicitly initialise Company member variables

### DIFF
--- a/src/company_base.h
+++ b/src/company_base.h
@@ -22,20 +22,20 @@ static const Money COMPANY_MAX_LOAN_DEFAULT = INT64_MIN;
 
 /** Statistics about the economy. */
 struct CompanyEconomyEntry {
-	Money income;               ///< The amount of income.
-	Money expenses;             ///< The amount of expenses.
+	Money income = 0; ///< The amount of income.
+	Money expenses = 0; ///< The amount of expenses.
 	CargoArray delivered_cargo{}; ///< The amount of delivered cargo.
-	int32_t performance_history;  ///< Company score (scale 0-1000)
-	Money company_value;        ///< The value of the company.
+	int32_t performance_history = 0; ///< Company score (scale 0-1000)
+	Money company_value = 0; ///< The value of the company.
 };
 
 struct CompanyInfrastructure {
 	std::array<uint32_t, RAILTYPE_END> rail{}; ///< Count of company owned track bits for each rail type.
 	std::array<uint32_t, ROADTYPE_END> road{}; ///< Count of company owned track bits for each road type.
-	uint32_t signal;             ///< Count of company owned signals.
-	uint32_t water;              ///< Count of company owned track bits for canals.
-	uint32_t station;            ///< Count of company owned station tiles.
-	uint32_t airport;            ///< Count of company owned airports.
+	uint32_t signal = 0; ///< Count of company owned signals.
+	uint32_t water = 0; ///< Count of company owned track bits for canals.
+	uint32_t station = 0; ///< Count of company owned station tiles.
+	uint32_t airport = 0; ///< Count of company owned airports.
 
 	auto operator<=>(const CompanyInfrastructure &) const = default;
 
@@ -59,7 +59,7 @@ private:
 	using BitmapStorage = size_t;
 	static constexpr size_t BITMAP_SIZE = std::numeric_limits<BitmapStorage>::digits;
 
-	std::vector<BitmapStorage> used_bitmap;
+	std::vector<BitmapStorage> used_bitmap{};
 };
 
 typedef Pool<Company, CompanyID, 1> CompanyPool;
@@ -67,87 +67,79 @@ extern CompanyPool _company_pool;
 
 /** Statically loadable part of Company pool item */
 struct CompanyProperties {
-	uint32_t name_2;                   ///< Parameter of #name_1.
-	StringID name_1;                 ///< Name of the company if the user did not change it.
-	std::string name;                ///< Name of the company if the user changed it.
+	uint32_t name_2 = 0; ///< Parameter of #name_1.
+	StringID name_1 = INVALID_STRING_ID; ///< Name of the company if the user did not change it.
+	std::string name{}; ///< Name of the company if the user changed it.
 
-	StringID president_name_1;       ///< Name of the president if the user did not change it.
-	uint32_t president_name_2;         ///< Parameter of #president_name_1
-	std::string president_name;      ///< Name of the president if the user changed it.
+	StringID president_name_1 = INVALID_STRING_ID; ///< Name of the president if the user did not change it.
+	uint32_t president_name_2 = 0; ///< Parameter of #president_name_1
+	std::string president_name{}; ///< Name of the president if the user changed it.
 
-	NetworkAuthorizedKeys allow_list; ///< Public keys of clients that are allowed to join this company.
+	NetworkAuthorizedKeys allow_list{}; ///< Public keys of clients that are allowed to join this company.
 
-	CompanyManagerFace face;         ///< Face description of the president.
+	CompanyManagerFace face{}; ///< Face description of the president.
 
-	Money money;                     ///< Money owned by the company.
-	uint8_t money_fraction;             ///< Fraction of money of the company, too small to represent in #money.
-	Money current_loan;              ///< Amount of money borrowed from the bank.
-	Money max_loan;                  ///< Max allowed amount of the loan or COMPANY_MAX_LOAN_DEFAULT.
+	Money money = 0; ///< Money owned by the company.
+	uint8_t money_fraction = 0; ///< Fraction of money of the company, too small to represent in #money.
+	Money current_loan = 0; ///< Amount of money borrowed from the bank.
+	Money max_loan = COMPANY_MAX_LOAN_DEFAULT; ///< Max allowed amount of the loan or COMPANY_MAX_LOAN_DEFAULT.
 
-	Colours colour;                  ///< Company colour.
+	Colours colour = COLOUR_BEGIN; ///< Company colour.
 
-	uint8_t block_preview;              ///< Number of quarters that the company is not allowed to get new exclusive engine previews (see CompaniesGenStatistics).
+	uint8_t block_preview = 0; ///< Number of quarters that the company is not allowed to get new exclusive engine previews (see CompaniesGenStatistics).
 
-	TileIndex location_of_HQ;        ///< Northern tile of HQ; #INVALID_TILE when there is none.
-	TileIndex last_build_coordinate; ///< Coordinate of the last build thing by this company.
+	TileIndex location_of_HQ = INVALID_TILE; ///< Northern tile of HQ; #INVALID_TILE when there is none.
+	TileIndex last_build_coordinate{}; ///< Coordinate of the last build thing by this company.
 
-	TimerGameEconomy::Year inaugurated_year; ///< Economy year of starting the company.
-	TimerGameCalendar::Year inaugurated_year_calendar; ///< Calendar year of starting the company. Used to display proper Inauguration year while in wallclock mode.
+	TimerGameEconomy::Year inaugurated_year{}; ///< Economy year of starting the company.
+	TimerGameCalendar::Year inaugurated_year_calendar{}; ///< Calendar year of starting the company. Used to display proper Inauguration year while in wallclock mode.
 
 	uint8_t months_empty = 0; ///< NOSAVE: Number of months this company has not had a client in multiplayer.
-	uint8_t months_of_bankruptcy;       ///< Number of months that the company is unable to pay its debts
-	CompanyMask bankrupt_asked;      ///< which companies were asked about buying it?
-	int16_t bankrupt_timeout;          ///< If bigger than \c 0, amount of time to wait for an answer on an offer to buy this company.
-	Money bankrupt_value;
+	uint8_t months_of_bankruptcy = 0; ///< Number of months that the company is unable to pay its debts
+	CompanyMask bankrupt_asked{}; ///< which companies were asked about buying it?
+	int16_t bankrupt_timeout = 0; ///< If bigger than \c 0, amount of time to wait for an answer on an offer to buy this company.
+	Money bankrupt_value = 0;
 
-	uint32_t terraform_limit;          ///< Amount of tileheights we can (still) terraform (times 65536).
-	uint32_t clear_limit;              ///< Amount of tiles we can (still) clear (times 65536).
-	uint32_t tree_limit;               ///< Amount of trees we can (still) plant (times 65536).
-	uint32_t build_object_limit;       ///< Amount of tiles we can (still) build objects on (times 65536). Also applies to buying land.
+	uint32_t terraform_limit = 0; ///< Amount of tileheights we can (still) terraform (times 65536).
+	uint32_t clear_limit = 0; ///< Amount of tiles we can (still) clear (times 65536).
+	uint32_t tree_limit = 0; ///< Amount of trees we can (still) plant (times 65536).
+	uint32_t build_object_limit = 0; ///< Amount of tiles we can (still) build objects on (times 65536). Also applies to buying land.
 
 	/**
 	 * If \c true, the company is (also) controlled by the computer (a NoAI program).
 	 * @note It is possible that the user is also participating in such a company.
 	 */
-	bool is_ai;
+	bool is_ai = false;
 
 	std::array<Expenses, 3> yearly_expenses{}; ///< Expenses of the company for the last three years.
-	CompanyEconomyEntry cur_economy;                       ///< Economic data of the company of this quarter.
-	CompanyEconomyEntry old_economy[MAX_HISTORY_QUARTERS]; ///< Economic data of the company of the last #MAX_HISTORY_QUARTERS quarters.
-	uint8_t num_valid_stat_ent;                               ///< Number of valid statistical entries in #old_economy.
+	CompanyEconomyEntry cur_economy{}; ///< Economic data of the company of this quarter.
+	std::array<CompanyEconomyEntry, MAX_HISTORY_QUARTERS> old_economy{}; ///< Economic data of the company of the last #MAX_HISTORY_QUARTERS quarters.
+	uint8_t num_valid_stat_ent = 0; ///< Number of valid statistical entries in #old_economy.
 
-	Livery livery[LS_END];
+	std::array<Livery, LS_END> livery{};
 
-	EngineRenewList engine_renew_list; ///< Engine renewals of this company.
-	CompanySettings settings;          ///< settings specific for each company
-
-	// TODO: Change some of these member variables to use relevant INVALID_xxx constants
-	CompanyProperties()
-		: name_2(0), name_1(0), president_name_1(0), president_name_2(0),
-		  face(0), money(0), money_fraction(0), current_loan(0), max_loan(COMPANY_MAX_LOAN_DEFAULT),
-		  colour(COLOUR_BEGIN), block_preview(0), location_of_HQ(0), last_build_coordinate(0), inaugurated_year(0),
-		  months_of_bankruptcy(0), bankrupt_asked(), bankrupt_timeout(0), bankrupt_value(0),
-		  terraform_limit(0), clear_limit(0), tree_limit(0), build_object_limit(0), is_ai(false), engine_renew_list(nullptr) {}
+	EngineRenewList engine_renew_list = nullptr; ///< Engine renewals of this company.
+	CompanySettings settings{}; ///< settings specific for each company
 };
 
 struct Company : CompanyProperties, CompanyPool::PoolItem<&_company_pool> {
 	Company(StringID name_1 = STR_NULL, bool is_ai = false);
 	~Company();
 
-	RailTypes avail_railtypes;         ///< Rail types available to this company.
-	RoadTypes avail_roadtypes;         ///< Road types available to this company.
+	RailTypes avail_railtypes{}; ///< Rail types available to this company.
+	RoadTypes avail_roadtypes{}; ///< Road types available to this company.
 
-	std::unique_ptr<class AIInstance> ai_instance;
-	class AIInfo *ai_info;
-	std::unique_ptr<class AIConfig> ai_config;
+	std::unique_ptr<class AIInstance> ai_instance{};
+	class AIInfo *ai_info = nullptr;
+	std::unique_ptr<class AIConfig> ai_config{};
 
-	GroupStatistics group_all[VEH_COMPANY_END];      ///< NOSAVE: Statistics for the ALL_GROUP group.
-	GroupStatistics group_default[VEH_COMPANY_END];  ///< NOSAVE: Statistics for the DEFAULT_GROUP group.
+	std::array<GroupStatistics, VEH_COMPANY_END> group_all{}; ///< NOSAVE: Statistics for the ALL_GROUP group.
+	std::array<GroupStatistics, VEH_COMPANY_END> group_default{};  ///< NOSAVE: Statistics for the DEFAULT_GROUP group.
 
-	CompanyInfrastructure infrastructure; ///< NOSAVE: Counts of company owned infrastructure.
+	CompanyInfrastructure infrastructure{}; ///< NOSAVE: Counts of company owned infrastructure.
 
-	FreeUnitIDGenerator freeunits[VEH_COMPANY_END];
-	FreeUnitIDGenerator freegroups;
+	std::array<FreeUnitIDGenerator, VEH_COMPANY_END> freeunits{};
+	FreeUnitIDGenerator freegroups{};
 
 	Money GetMaxLoan() const;
 

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -66,7 +66,6 @@ INSTANTIATE_POOL_METHODS(Company)
 Company::Company(StringID name_1, bool is_ai)
 {
 	this->name_1 = name_1;
-	this->location_of_HQ = INVALID_TILE;
 	this->is_ai = is_ai;
 	this->terraform_limit    = (uint32_t)_settings_game.construction.terraform_frame_burst << 16;
 	this->clear_limit        = (uint32_t)_settings_game.construction.clear_frame_burst << 16;

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -246,9 +246,10 @@ int UpdateCompanyRatingAndValue(Company *c, bool update)
 
 	/* Generate statistics depending on recent income statistics */
 	{
+		static_assert(MAX_HISTORY_QUARTERS >= 12u);
 		int numec = std::min<uint>(c->num_valid_stat_ent, 12u);
 		if (numec != 0) {
-			const CompanyEconomyEntry *cee = c->old_economy;
+			auto cee = c->old_economy.begin();
 			Money min_income = cee->income + cee->expenses;
 			Money max_income = cee->income + cee->expenses;
 
@@ -267,9 +268,10 @@ int UpdateCompanyRatingAndValue(Company *c, bool update)
 
 	/* Generate score depending on amount of transported cargo */
 	{
+		static_assert(MAX_HISTORY_QUARTERS >= 4u);
 		int numec = std::min<uint>(c->num_valid_stat_ent, 4u);
 		if (numec != 0) {
-			const CompanyEconomyEntry *cee = c->old_economy;
+			auto cee = c->old_economy.begin();
 			OverflowSafeInt64 total_delivered = 0;
 			do {
 				total_delivered += cee->delivered_cargo.GetSum<OverflowSafeInt64>();
@@ -281,7 +283,7 @@ int UpdateCompanyRatingAndValue(Company *c, bool update)
 
 	/* Generate score for variety of cargo */
 	{
-		_score_part[owner][SCORE_CARGO] = c->old_economy->delivered_cargo.GetCount();
+		_score_part[owner][SCORE_CARGO] = c->old_economy[0].delivered_cargo.GetCount();
 	}
 
 	/* Generate score for company's money */
@@ -695,7 +697,7 @@ static void CompaniesGenStatistics()
 
 	for (Company *c : Company::Iterate()) {
 		/* Drop the oldest history off the end */
-		std::copy_backward(c->old_economy, c->old_economy + MAX_HISTORY_QUARTERS - 1, c->old_economy + MAX_HISTORY_QUARTERS);
+		std::copy_backward(c->old_economy.data(), c->old_economy.data() + MAX_HISTORY_QUARTERS - 1, c->old_economy.data() + MAX_HISTORY_QUARTERS);
 		c->old_economy[0] = c->cur_economy;
 		c->cur_economy = {};
 

--- a/src/livery.h
+++ b/src/livery.h
@@ -76,9 +76,9 @@ DECLARE_ENUM_AS_ADDABLE(LiveryClass)
 
 /** Information about a particular livery. */
 struct Livery {
-	uint8_t in_use;  ///< Bit 0 set if this livery should override the default livery first colour, Bit 1 for the second colour.
-	Colours colour1; ///< First colour, for all vehicles.
-	Colours colour2; ///< Second colour, for vehicles with 2CC support.
+	uint8_t in_use = 0;  ///< Bit 0 set if this livery should override the default livery first colour, Bit 1 for the second colour.
+	Colours colour1 = COLOUR_BEGIN; ///< First colour, for all vehicles.
+	Colours colour2 = COLOUR_BEGIN; ///< Second colour, for vehicles with 2CC support.
 };
 
 void ResetCompanyLivery(Company *c);

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -496,8 +496,8 @@ void DrawNewObjectTileInGUI(int x, int y, const ObjectSpec *spec, uint8_t view)
 	if (Company::IsValidID(_local_company)) {
 		/* Get the colours of our company! */
 		if (spec->flags.Test(ObjectFlag::Uses2CC)) {
-			const Livery *l = Company::Get(_local_company)->livery;
-			palette = SPR_2CCMAP_BASE + l->colour1 + l->colour2 * 16;
+			const Livery &l = Company::Get(_local_company)->livery[0];
+			palette = SPR_2CCMAP_BASE + l.colour1 + l.colour2 * 16;
 		} else {
 			palette = COMPANY_SPRITE_COLOUR(_local_company);
 		}

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -97,8 +97,8 @@ void BuildObject(ObjectType type, TileIndex tile, CompanyID owner, Town *town, u
 	if (owner == OWNER_NONE) {
 		o->colour = Random();
 	} else {
-		const Livery *l = Company::Get(owner)->livery;
-		o->colour = l->colour1 + l->colour2 * 16;
+		const Livery &l = Company::Get(owner)->livery[0];
+		o->colour = l.colour1 + l.colour2 * 16;
 	}
 
 	/* If the object wants only one colour, then give it that colour. */
@@ -186,8 +186,8 @@ void UpdateObjectColours(const Company *c)
 		/* Using the object colour callback, so not using company colour. */
 		if (spec->callback_mask.Test(ObjectCallbackMask::Colour)) continue;
 
-		const Livery *l = c->livery;
-		obj->colour = (spec->flags.Test(ObjectFlag::Uses2CC) ? (l->colour2 * 16) : 0) + l->colour1;
+		const Livery &l = c->livery[0];
+		obj->colour = (spec->flags.Test(ObjectFlag::Uses2CC) ? (l.colour2 * 16) : 0) + l.colour1;
 	}
 }
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2550,7 +2550,7 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SLV_148)) {
 		for (Object *o : Object::Iterate()) {
 			Owner owner = GetTileOwner(o->location.tile);
-			o->colour = (owner == OWNER_NONE) ? static_cast<Colours>(GB(Random(), 0, 4)) : Company::Get(owner)->livery->colour1;
+			o->colour = (owner == OWNER_NONE) ? static_cast<Colours>(GB(Random(), 0, 4)) : Company::Get(owner)->livery[0].colour1;
 		}
 	}
 

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -367,7 +367,7 @@ public:
 		if (!IsSavegameVersionBefore(SLV_SAVELOAD_LIST_LENGTH)) {
 			c->num_valid_stat_ent = (uint8_t)SlGetStructListLength(UINT8_MAX);
 		}
-		if (c->num_valid_stat_ent > lengthof(c->old_economy)) SlErrorCorrupt("Too many old economy entries");
+		if (c->num_valid_stat_ent > std::size(c->old_economy)) SlErrorCorrupt("Too many old economy entries");
 
 		for (int i = 0; i < c->num_valid_stat_ent; i++) {
 			SlObject(&c->old_economy[i], this->GetLoadDescription());

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -579,20 +579,20 @@ struct StationSettings {
 
 /** Default settings for vehicles. */
 struct VehicleDefaultSettings {
-	bool   servint_ispercent;                ///< service intervals are in percents
-	uint16_t servint_trains;                   ///< service interval for trains
-	uint16_t servint_roadveh;                  ///< service interval for road vehicles
-	uint16_t servint_aircraft;                 ///< service interval for aircraft
-	uint16_t servint_ships;                    ///< service interval for ships
+	bool   servint_ispercent = false; ///< service intervals are in percents
+	uint16_t servint_trains = 0; ///< service interval for trains
+	uint16_t servint_roadveh = 0; ///< service interval for road vehicles
+	uint16_t servint_aircraft = 0; ///< service interval for aircraft
+	uint16_t servint_ships = 0; ///< service interval for ships
 };
 
 /** Settings that can be set per company. */
 struct CompanySettings {
-	bool engine_renew;                       ///< is autorenew enabled
-	int16_t engine_renew_months;               ///< months before/after the maximum vehicle age a vehicle should be renewed
-	uint32_t engine_renew_money;               ///< minimum amount of money before autorenew is used
-	bool renew_keep_length;                  ///< sell some wagons if after autoreplace the train is longer than before
-	VehicleDefaultSettings vehicle;          ///< default settings for vehicles
+	bool engine_renew = false; ///< is autorenew enabled
+	int16_t engine_renew_months = 0; ///< months before/after the maximum vehicle age a vehicle should be renewed
+	uint32_t engine_renew_money = 0; ///< minimum amount of money before autorenew is used
+	bool renew_keep_length = false; ///< sell some wagons if after autoreplace the train is longer than before
+	VehicleDefaultSettings vehicle{}; ///< default settings for vehicles
 };
 
 /** All settings together for the game. */


### PR DESCRIPTION
## Motivation / Problem

If we want to get rid of `CallocT`, the pool items needs to stop relying on it. So all pool items should explicitly initialise their member variable, be it `0`, `nullptr`, or anything else. That way we don't need to zero everything first.


## Description

Explicitly initialise the member variables, in this case of `Company` and by proxy `CompanySetting`, `CompanyProperties`, `CompanyInfrastructure`, `Livery`, `GroupStatistics` and `FreeUnitIDGenerator`.

This does mean changing some C-style arrays to `std::array`, and uncovering some `->` that weren't really about dereferencing a pointer, but more about getting the pointer to the first value of the array. Since `std::array` does not do `->`, there needed to be amended.


## Limitations

The pool is still `CallocT`-ing first, but this class does not depend on it any more.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
