### PR TITLE
Codechange: explicitly initialise Depot member variables

### DIFF
--- a/src/depot_base.h
+++ b/src/depot_base.h
@@ -19,13 +19,14 @@ extern DepotPool _depot_pool;
 
 struct Depot : DepotPool::PoolItem<&_depot_pool> {
 	/* DepotID index member of DepotPool is 2 bytes. */
-	uint16_t town_cn; ///< The N-1th depot for this town (consecutive number)
-	TileIndex xy;
-	Town *town;
-	std::string name;
-	TimerGameCalendar::Date build_date; ///< Date of construction
+	uint16_t town_cn = 0; ///< The N-1th depot for this town (consecutive number)
+	TileIndex xy = INVALID_TILE;
+	Town *town = nullptr;
+	std::string name{};
+	TimerGameCalendar::Date build_date{}; ///< Date of construction
 
-	Depot(TileIndex xy = INVALID_TILE) : xy(xy) {}
+	Depot() {}
+	Depot(TileIndex xy) : xy(xy), build_date(TimerGameCalendar::date) {}
 	~Depot();
 
 	static inline Depot *GetByTile(TileIndex tile)

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -1011,7 +1011,6 @@ CommandCost CmdBuildTrainDepot(DoCommandFlags flags, TileIndex tile, RailType ra
 			SetRailDepotExitDirection(tile, dir);
 		} else {
 			Depot *d = new Depot(tile);
-			d->build_date = TimerGameCalendar::date;
 
 			MakeRailDepot(tile, _current_company, d->index, dir, railtype);
 			MakeDefaultName(d);

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1188,7 +1188,6 @@ CommandCost CmdBuildRoadDepot(DoCommandFlags flags, TileIndex tile, RoadType rt,
 			SetRoadDepotExitDirection(tile, dir);
 		} else {
 			Depot *dep = new Depot(tile);
-			dep->build_date = TimerGameCalendar::date;
 			MakeRoadDepot(tile, _current_company, dep->index, dir, rt);
 			MakeDefaultName(dep);
 

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -146,7 +146,6 @@ CommandCost CmdBuildShipDepot(DoCommandFlags flags, TileIndex tile, Axis axis)
 
 	if (flags.Test(DoCommandFlag::Execute)) {
 		Depot *depot = new Depot(tile);
-		depot->build_date = TimerGameCalendar::date;
 
 		uint new_water_infra = 2 * LOCK_DEPOT_TILE_FACTOR;
 		/* Update infrastructure counts after the tile clears earlier.


### PR DESCRIPTION
## Motivation / Problem

If we want to get rid of `CallocT`, the pool items needs to stop relying on it. So all pool items should explicitly initialise their member variable, be it `0`, `nullptr`, or anything else. That way we don't need to zero everything first.


## Description

Explicitly initialise the member variables, in this case of `Depot`.

While doing so, I noticed that all the constructors with a `TileIndex` also set the build date to the same value. So just set that in the constructor.

The other fields are non-trivially set via the `MakeDefaultName` templated function in town.h.


## Limitations

The pool is still `CallocT`-ing first, but this class does not depend on it any more.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
