### PR TITLE
Codechange: explicitly initialise CargoPayment member variables

### DIFF
--- a/src/economy_base.h
+++ b/src/economy_base.h
@@ -23,13 +23,13 @@ extern CargoPaymentPool _cargo_payment_pool;
  */
 struct CargoPayment : CargoPaymentPool::PoolItem<&_cargo_payment_pool> {
 	/* CargoPaymentID index member of CargoPaymentPool is 4 bytes. */
-	StationID current_station; ///< NOSAVE: The current station
-	Company *owner; ///< NOSAVE: The owner of the vehicle
+	StationID current_station = StationID::Invalid(); ///< NOSAVE: The current station
+	Company *owner = nullptr; ///< NOSAVE: The owner of the vehicle
 
-	Vehicle *front;        ///< The front vehicle to do the payment of
-	Money route_profit;    ///< The amount of money to add/remove from the bank account
-	Money visual_profit;   ///< The visual profit to show
-	Money visual_transfer; ///< The transfer credits to be shown
+	Vehicle *front = nullptr; ///< The front vehicle to do the payment of
+	Money route_profit = 0; ///< The amount of money to add/remove from the bank account
+	Money visual_profit = 0; ///< The visual profit to show
+	Money visual_transfer = 0; ///< The transfer credits to be shown
 
 	/** Constructor for pool saveload */
 	CargoPayment() {}


### PR DESCRIPTION
## Motivation / Problem

If we want to get rid of `CallocT`, the pool items needs to stop relying on it. So all pool items should explicitly initialise their member variable, be it `0`, `nullptr`, or anything else. That way we don't need to zero everything first.


## Description

Explicitly initialise the member variables, in this case of `CargoPayment`.


## Limitations

The pool is still `CallocT`-ing first, but this class does not depend on it any more.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
