### PR TITLE
Codechange: explicitly initialise Goal member variables

### DIFF
--- a/src/goal.cpp
+++ b/src/goal.cpp
@@ -85,12 +85,7 @@ std::tuple<CommandCost, GoalID> CmdCreateGoal(DoCommandFlags flags, CompanyID co
 	if (!Goal::IsValidGoalDestination(company, type, dest)) return { CMD_ERROR, GoalID::Invalid() };
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		Goal *g = new Goal();
-		g->type = type;
-		g->dst = dest;
-		g->company = company;
-		g->text = text;
-		g->completed = false;
+		Goal *g = new Goal(type, dest, company, text);
 
 		if (g->company == CompanyID::Invalid()) {
 			InvalidateWindowClassesData(WC_GOALS_LIST);

--- a/src/goal_base.h
+++ b/src/goal_base.h
@@ -19,22 +19,23 @@ extern GoalPool _goal_pool;
 
 /** Struct about goals, current and completed */
 struct Goal : GoalPool::PoolItem<&_goal_pool> {
-	CompanyID company;    ///< Goal is for a specific company; CompanyID::Invalid() if it is global
-	GoalType type;        ///< Type of the goal
-	GoalTypeID dst;       ///< Index of type
-	std::string text;     ///< Text of the goal.
-	std::string progress; ///< Progress text of the goal.
-	bool completed;       ///< Is the goal completed or not?
+	CompanyID company = CompanyID::Invalid(); ///< Goal is for a specific company; CompanyID::Invalid() if it is global
+	GoalType type = GT_NONE; ///< Type of the goal
+	GoalTypeID dst = 0; ///< Index of type
+	std::string text{}; ///< Text of the goal.
+	std::string progress{}; ///< Progress text of the goal.
+	bool completed = false; ///< Is the goal completed or not?
 
 	/**
 	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
 	 */
-	inline Goal() { }
+	Goal() { }
+	Goal(GoalType type, GoalTypeID dst, CompanyID company, const std::string &text) : company(company), type(type), dst(dst), text(text) {}
 
 	/**
 	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter
 	 */
-	inline ~Goal() { }
+	~Goal() { }
 
 	static bool IsValidGoalDestination(CompanyID company, GoalType type, GoalTypeID dest);
 };


### PR DESCRIPTION
## Motivation / Problem

If we want to get rid of `CallocT`, the pool items needs to stop relying on it. So all pool items should explicitly initialise their member variable, be it `0`, `nullptr`, or anything else. That way we don't need to zero everything first.


## Description

Explicitly initialise the member variables, in this case of `Goal`.

Also split the constructor into one for saveload (no parameters) and one that just sets all required variables when a new goal is made.


## Limitations

The pool is still `CallocT`-ing first, but this class does not depend on it any more.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
