### PR TITLE
Codechange: explicitly initialise Group member variables

### DIFF
--- a/src/group.h
+++ b/src/group.h
@@ -22,13 +22,13 @@ extern GroupPool _group_pool; ///< Pool of groups.
 
 /** Statistics and caches on the vehicles in a group. */
 struct GroupStatistics {
-	Money profit_last_year;                 ///< Sum of profits for all vehicles.
-	Money profit_last_year_min_age;         ///< Sum of profits for vehicles considered for profit statistics.
-	std::map<EngineID, uint16_t> num_engines; ///< Caches the number of engines of each type the company owns.
-	uint16_t num_vehicle;                     ///< Number of vehicles.
-	uint16_t num_vehicle_min_age;             ///< Number of vehicles considered for profit statistics;
-	bool autoreplace_defined;               ///< Are any autoreplace rules set?
-	bool autoreplace_finished;              ///< Have all autoreplacement finished?
+	Money profit_last_year = 0; ///< Sum of profits for all vehicles.
+	Money profit_last_year_min_age = 0; ///< Sum of profits for vehicles considered for profit statistics.
+	std::map<EngineID, uint16_t> num_engines{}; ///< Caches the number of engines of each type the company owns.
+	uint16_t num_vehicle = 0; ///< Number of vehicles.
+	uint16_t num_vehicle_min_age = 0; ///< Number of vehicles considered for profit statistics;
+	bool autoreplace_defined = false; ///< Are any autoreplace rules set?
+	bool autoreplace_finished = false; ///< Have all autoreplacement finished?
 
 	void Clear();
 
@@ -70,20 +70,21 @@ using GroupFlags = EnumBitSet<GroupFlag, uint8_t>;
 
 /** Group data. */
 struct Group : GroupPool::PoolItem<&_group_pool> {
-	std::string name;           ///< Group Name
-	Owner owner;                ///< Group Owner
-	VehicleType vehicle_type;   ///< Vehicle type of the group
+	std::string name{}; ///< Group Name
+	Owner owner = INVALID_OWNER; ///< Group Owner
+	VehicleType vehicle_type = VEH_INVALID; ///< Vehicle type of the group
 
 	GroupFlags flags{}; ///< Group flags
-	Livery livery;              ///< Custom colour scheme for vehicles in this group
-	GroupStatistics statistics; ///< NOSAVE: Statistics and caches on the vehicles in the group.
+	Livery livery{}; ///< Custom colour scheme for vehicles in this group
+	GroupStatistics statistics{}; ///< NOSAVE: Statistics and caches on the vehicles in the group.
 
-	bool folded;                ///< NOSAVE: Is this group folded in the group view?
+	bool folded = false; ///< NOSAVE: Is this group folded in the group view?
 
-	GroupID parent;             ///< Parent group
-	uint16_t number; ///< Per-company group number.
+	GroupID parent = GroupID::Invalid(); ///< Parent group
+	uint16_t number = 0; ///< Per-company group number.
 
-	Group(CompanyID owner = CompanyID::Invalid());
+	Group() {}
+	Group(CompanyID owner, VehicleType vehicle_type) : owner(owner), vehicle_type(vehicle_type) {}
 };
 
 

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -319,12 +319,6 @@ void UpdateCompanyGroupLiveries(const Company *c)
 	}
 }
 
-Group::Group(Owner owner)
-{
-	this->owner = owner;
-	this->folded = false;
-}
-
 
 /**
  * Create a new vehicle group.
@@ -346,9 +340,7 @@ std::tuple<CommandCost, GroupID> CmdCreateGroup(DoCommandFlags flags, VehicleTyp
 	}
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		Group *g = new Group(_current_company);
-		g->vehicle_type = vt;
-		g->parent = GroupID::Invalid();
+		Group *g = new Group(_current_company, vt);
 
 		Company *c = Company::Get(g->owner);
 		g->number = c->freegroups.UseID(c->freegroups.NextID());


### PR DESCRIPTION
## Motivation / Problem

If we want to get rid of `CallocT`, the pool items needs to stop relying on it. So all pool items should explicitly initialise their member variable, be it `0`, `nullptr`, or anything else. That way we don't need to zero everything first.


## Description

Explicitly initialise the member variables, in this case of `Group` and by proxy `GroupStatistics`.

Also move setting `vehicle_type` into the constructor.


## Limitations

The pool is still `CallocT`-ing first, but this class does not depend on it any more.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
