### PR TITLE
Codechange: explicitly initialise LeaugeTable and LeagueTableElement member variables

### DIFF
--- a/src/league_base.h
+++ b/src/league_base.h
@@ -29,17 +29,19 @@ extern LeagueTablePool _league_table_pool;
  * Each LeagueTable is composed of one or more elements. Elements are sorted by their rating (higher=better).
  **/
 struct LeagueTableElement : LeagueTableElementPool::PoolItem<&_league_table_element_pool> {
-	LeagueTableID table;  ///< Id of the table which this element belongs to
-	int64_t rating;         ///< Value that determines ordering of elements in the table (higher=better)
-	CompanyID company;    ///< Company Id to show the color blob for or CompanyID::Invalid()
-	std::string text;     ///< Text of the element
-	std::string score;    ///< String representation of the score associated with the element
-	Link link;            ///< What opens when element is clicked
+	LeagueTableID table = LeagueTableID::Invalid(); ///< Id of the table which this element belongs to
+	int64_t rating = 0; ///< Value that determines ordering of elements in the table (higher=better)
+	CompanyID company = CompanyID::Invalid(); ///< Company Id to show the color blob for or CompanyID::Invalid()
+	std::string text{}; ///< Text of the element
+	std::string score{}; ///< String representation of the score associated with the element
+	Link link{}; ///< What opens when element is clicked
 
 	/**
 	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
 	 */
 	LeagueTableElement() { }
+	LeagueTableElement(LeagueTableID table, int64_t rating, CompanyID company, const std::string &text, const std::string &score, const Link &link) :
+		table(table), rating(rating), company(company), text(text), score(score), link(link) {}
 
 	/**
 	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter
@@ -50,14 +52,15 @@ struct LeagueTableElement : LeagueTableElementPool::PoolItem<&_league_table_elem
 
 /** Struct about custom league tables */
 struct LeagueTable : LeagueTablePool::PoolItem<&_league_table_pool> {
-	std::string title;  ///< Title of the table
-	std::string header;  ///< Text to show above the table
-	std::string footer;  ///< Text to show below the table
+	std::string title{}; ///< Title of the table
+	std::string header{}; ///< Text to show above the table
+	std::string footer{}; ///< Text to show below the table
 
 	/**
 	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
 	 */
 	LeagueTable() { }
+	LeagueTable(const std::string &title, const std::string &header, const std::string &footer) : title(title), header(header), footer(footer) { }
 
 	/**
 	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter

--- a/src/league_cmd.cpp
+++ b/src/league_cmd.cpp
@@ -60,10 +60,7 @@ std::tuple<CommandCost, LeagueTableID> CmdCreateLeagueTable(DoCommandFlags flags
 	if (title.empty()) return { CMD_ERROR, LeagueTableID::Invalid() };
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		LeagueTable *lt = new LeagueTable();
-		lt->title = title;
-		lt->header = header;
-		lt->footer = footer;
+		LeagueTable *lt = new LeagueTable(title, header, footer);
 		return { CommandCost(), lt->index };
 	}
 
@@ -92,13 +89,7 @@ std::tuple<CommandCost, LeagueTableElementID> CmdCreateLeagueTableElement(DoComm
 	if (company != CompanyID::Invalid() && !Company::IsValidID(company)) return { CMD_ERROR, LeagueTableElementID::Invalid() };
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		LeagueTableElement *lte = new LeagueTableElement();
-		lte->table = table;
-		lte->rating = rating;
-		lte->company = company;
-		lte->text = text;
-		lte->score = score;
-		lte->link = link;
+		LeagueTableElement *lte = new LeagueTableElement(table, rating, company, text, score, link);
 		InvalidateWindowData(WC_COMPANY_LEAGUE, table);
 		return { CommandCost(), lte->index };
 	}

--- a/src/league_type.h
+++ b/src/league_type.h
@@ -25,10 +25,11 @@ enum LinkType : uint8_t {
 typedef uint32_t LinkTargetID; ///< Contains either tile, industry ID, town ID, story page ID or company ID
 
 struct Link {
-	LinkType type;
-	LinkTargetID target;
-	Link(LinkType type, LinkTargetID target): type{type}, target{target} {}
-	Link(): Link(LT_NONE, 0) {}
+	LinkType type = LT_NONE;
+	LinkTargetID target = 0;
+
+	Link() {}
+	Link(LinkType type, LinkTargetID target) : type{type}, target{target} {}
 };
 
 using LeagueTableID = PoolID<uint8_t, struct LeagueTableIDTag, 255, 0xFF>; ///< ID of a league table


### PR DESCRIPTION
## Motivation / Problem

If we want to get rid of `CallocT`, the pool items needs to stop relying on it. So all pool items should explicitly initialise their member variable, be it `0`, `nullptr`, or anything else. That way we don't need to zero everything first.


## Description

Explicitly initialise the member variables, in this case of `LeagueTable` and `LeagueTableElement`.
Move setting of fields to the constructor.


## Limitations

The pool is still `CallocT`-ing first, but this class does not depend on it any more.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
