### PR TITLE
Codechange: explicitly initialise Object member variables

### DIFF
--- a/src/object_base.h
+++ b/src/object_base.h
@@ -21,15 +21,17 @@ extern ObjectPool _object_pool;
 
 /** An object, such as transmitter, on the map. */
 struct Object : ObjectPool::PoolItem<&_object_pool> {
-	ObjectType type;    ///< Type of the object
-	Town *town;         ///< Town the object is built in
-	TileArea location;  ///< Location of the object
-	TimerGameCalendar::Date build_date; ///< Date of construction
-	uint8_t colour;        ///< Colour of the object, for display purpose
-	uint8_t view;          ///< The view setting for this object
+	ObjectType type = INVALID_OBJECT_TYPE; ///< Type of the object
+	Town *town = nullptr; ///< Town the object is built in
+	TileArea location{INVALID_TILE, 0, 0}; ///< Location of the object
+	TimerGameCalendar::Date build_date{}; ///< Date of construction
+	uint8_t colour = 0; ///< Colour of the object, for display purpose
+	uint8_t view = 0; ///< The view setting for this object
 
 	/** Make sure the object isn't zeroed. */
 	Object() {}
+	Object(ObjectType type, Town *town, TileArea location, TimerGameCalendar::Date build_date, uint8_t view) :
+		type(type), town(town), location(location), build_date(build_date), view(view) {}
 	/** Make sure the right destructor is called as well! */
 	~Object() {}
 

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -90,12 +90,7 @@ void BuildObject(ObjectType type, TileIndex tile, CompanyID owner, Town *town, u
 	const ObjectSpec *spec = ObjectSpec::Get(type);
 
 	TileArea ta(tile, GB(spec->size, HasBit(view, 0) ? 4 : 0, 4), GB(spec->size, HasBit(view, 0) ? 0 : 4, 4));
-	Object *o = new Object();
-	o->type          = type;
-	o->location      = ta;
-	o->town          = town == nullptr ? CalcClosestTownFromTile(tile) : town;
-	o->build_date    = TimerGameCalendar::date;
-	o->view          = view;
+	Object *o = new Object(type, town == nullptr ? CalcClosestTownFromTile(tile) : town, ta, TimerGameCalendar::date, view);
 
 	/* If nothing owns the object, the colour will be random. Otherwise
 	 * get the colour from the company's livery settings. */


### PR DESCRIPTION
## Motivation / Problem

If we want to get rid of `CallocT`, the pool items needs to stop relying on it. So all pool items should explicitly initialise their member variable, be it `0`, `nullptr`, or anything else. That way we don't need to zero everything first.


## Description

Explicitly initialise the member variables, in this case of `Object`. Also move some setting of fields to the constructor.


## Limitations

The pool is still `CallocT`-ing first, but this class does not depend on it any more.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
