### PR TITLE
Codechange: explicitly initialise NewGRF-pool-object member variables

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -9,6 +9,7 @@
 
 #include "stdafx.h"
 
+#include <ranges>
 #include "core/backup_type.hpp"
 #include "core/container_func.hpp"
 #include "debug.h"
@@ -5746,7 +5747,7 @@ static void NewSpriteGroup(ByteReader &buf)
 						group->again = buf.ReadByte();
 					} else if (type == 2) {
 						group->num_input = buf.ReadByte();
-						if (group->num_input > lengthof(group->subtract_input)) {
+						if (group->num_input > std::size(group->subtract_input)) {
 							GRFError *error = DisableGrf(STR_NEWGRF_ERROR_INDPROD_CALLBACK);
 							error->data = "too many inputs (max 16)";
 							return;
@@ -5759,7 +5760,7 @@ static void NewSpriteGroup(ByteReader &buf)
 								 * as long as the result is not used. Mark it invalid so this
 								 * can be tested later. */
 								group->version = 0xFF;
-							} else if (std::find(group->cargo_input, group->cargo_input + i, cargo) != group->cargo_input + i) {
+							} else if (auto v = group->cargo_input | std::views::take(i); std::ranges::find(v, cargo) != v.end()) {
 								GRFError *error = DisableGrf(STR_NEWGRF_ERROR_INDPROD_CALLBACK);
 								error->data = "duplicate input cargo";
 								return;
@@ -5768,7 +5769,7 @@ static void NewSpriteGroup(ByteReader &buf)
 							group->subtract_input[i] = buf.ReadByte();
 						}
 						group->num_output = buf.ReadByte();
-						if (group->num_output > lengthof(group->add_output)) {
+						if (group->num_output > std::size(group->add_output)) {
 							GRFError *error = DisableGrf(STR_NEWGRF_ERROR_INDPROD_CALLBACK);
 							error->data = "too many outputs (max 16)";
 							return;
@@ -5779,7 +5780,7 @@ static void NewSpriteGroup(ByteReader &buf)
 							if (!IsValidCargoType(cargo)) {
 								/* Mark this result as invalid to use */
 								group->version = 0xFF;
-							} else if (std::find(group->cargo_output, group->cargo_output + i, cargo) != group->cargo_output + i) {
+							} else if (auto v = group->cargo_output | std::views::take(i); std::ranges::find(v, cargo) != v.end()) {
 								GRFError *error = DisableGrf(STR_NEWGRF_ERROR_INDPROD_CALLBACK);
 								error->data = "duplicate output cargo";
 								return;

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -117,7 +117,7 @@ struct NewGRFSpriteLayout : DrawTileSprites {
 	 * Number of sprites in all referenced spritesets.
 	 * If these numbers are inconsistent, then this is 0 and the real values are in \c registers.
 	 */
-	uint consistent_max_offset;
+	uint consistent_max_offset = 0;
 
 	void Allocate(uint num_sprites);
 	void AllocateRegisters();

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -56,15 +56,15 @@ extern SpriteGroupPool _spritegroup_pool;
 /* Common wrapper for all the different sprite group types */
 struct SpriteGroup : SpriteGroupPool::PoolItem<&_spritegroup_pool> {
 protected:
-	SpriteGroup(SpriteGroupType type) : nfo_line(0), type(type) {}
+	SpriteGroup(SpriteGroupType type) : type(type) {}
 	/** Base sprite group resolver */
 	virtual const SpriteGroup *Resolve([[maybe_unused]] ResolverObject &object) const { return this; };
 
 public:
 	virtual ~SpriteGroup() = default;
 
-	uint32_t nfo_line;
-	SpriteGroupType type;
+	uint32_t nfo_line = 0;
+	SpriteGroupType type{};
 
 	virtual SpriteID GetResult() const { return 0; }
 	virtual uint8_t GetNumResults() const { return 0; }
@@ -86,8 +86,8 @@ struct RealSpriteGroup : SpriteGroup {
 	 * with small amount of cargo whilst loading is for stations with a lot
 	 * of da stuff. */
 
-	std::vector<const SpriteGroup *> loaded;  ///< List of loaded groups (can be SpriteIDs or Callback results)
-	std::vector<const SpriteGroup *> loading; ///< List of loading groups (can be SpriteIDs or Callback results)
+	std::vector<const SpriteGroup *> loaded{};  ///< List of loaded groups (can be SpriteIDs or Callback results)
+	std::vector<const SpriteGroup *> loading{}; ///< List of loading groups (can be SpriteIDs or Callback results)
 
 protected:
 	const SpriteGroup *Resolve(ResolverObject &object) const override;
@@ -145,38 +145,38 @@ enum DeterministicSpriteGroupAdjustOperation : uint8_t {
 
 
 struct DeterministicSpriteGroupAdjust {
-	DeterministicSpriteGroupAdjustOperation operation;
-	DeterministicSpriteGroupAdjustType type;
-	uint8_t variable;
-	uint8_t parameter; ///< Used for variables between 0x60 and 0x7F inclusive.
-	uint8_t shift_num;
-	uint32_t and_mask;
-	uint32_t add_val;
-	uint32_t divmod_val;
-	const SpriteGroup *subroutine;
+	DeterministicSpriteGroupAdjustOperation operation{};
+	DeterministicSpriteGroupAdjustType type{};
+	uint8_t variable = 0;
+	uint8_t parameter = 0; ///< Used for variables between 0x60 and 0x7F inclusive.
+	uint8_t shift_num = 0;
+	uint32_t and_mask = 0;
+	uint32_t add_val = 0;
+	uint32_t divmod_val = 0;
+	const SpriteGroup *subroutine = nullptr;
 };
 
 
 struct DeterministicSpriteGroupRange {
-	const SpriteGroup *group;
-	uint32_t low;
-	uint32_t high;
+	const SpriteGroup *group = nullptr;
+	uint32_t low = 0;
+	uint32_t high = 0;
 };
 
 
 struct DeterministicSpriteGroup : SpriteGroup {
 	DeterministicSpriteGroup() : SpriteGroup(SGT_DETERMINISTIC) {}
 
-	VarSpriteGroupScope var_scope;
-	DeterministicSpriteGroupSize size;
-	bool calculated_result;
-	std::vector<DeterministicSpriteGroupAdjust> adjusts;
-	std::vector<DeterministicSpriteGroupRange> ranges; // Dynamically allocated
+	VarSpriteGroupScope var_scope{};
+	DeterministicSpriteGroupSize size{};
+	bool calculated_result = false;
+	std::vector<DeterministicSpriteGroupAdjust> adjusts{};
+	std::vector<DeterministicSpriteGroupRange> ranges{}; // Dynamically allocated
 
 	/* Dynamically allocated, this is the sole owner */
-	const SpriteGroup *default_group;
+	const SpriteGroup *default_group = nullptr;
 
-	const SpriteGroup *error_group; // was first range, before sorting ranges
+	const SpriteGroup *error_group = nullptr; // was first range, before sorting ranges
 
 protected:
 	const SpriteGroup *Resolve(ResolverObject &object) const override;
@@ -190,15 +190,15 @@ enum RandomizedSpriteGroupCompareMode : uint8_t {
 struct RandomizedSpriteGroup : SpriteGroup {
 	RandomizedSpriteGroup() : SpriteGroup(SGT_RANDOMIZED) {}
 
-	VarSpriteGroupScope var_scope;  ///< Take this object:
+	VarSpriteGroupScope var_scope{};  ///< Take this object:
 
-	RandomizedSpriteGroupCompareMode cmp_mode; ///< Check for these triggers:
-	uint8_t triggers;
-	uint8_t count;
+	RandomizedSpriteGroupCompareMode cmp_mode{}; ///< Check for these triggers:
+	uint8_t triggers = 0;
+	uint8_t count = 0;
 
-	uint8_t lowest_randbit; ///< Look for this in the per-object randomized bitmask:
+	uint8_t lowest_randbit = 0; ///< Look for this in the per-object randomized bitmask:
 
-	std::vector<const SpriteGroup *> groups; ///< Take the group with appropriate index:
+	std::vector<const SpriteGroup *> groups{}; ///< Take the group with appropriate index:
 
 protected:
 	const SpriteGroup *Resolve(ResolverObject &object) const override;
@@ -214,7 +214,7 @@ struct CallbackResultSpriteGroup : SpriteGroup {
 	 */
 	explicit CallbackResultSpriteGroup(uint16_t value) : SpriteGroup(SGT_CALLBACK), result(value) {}
 
-	uint16_t result;
+	uint16_t result = 0;
 	uint16_t GetCallbackResult() const override { return this->result; }
 };
 
@@ -235,8 +235,8 @@ struct ResultSpriteGroup : SpriteGroup {
 	{
 	}
 
-	uint8_t num_sprites;
-	SpriteID sprite;
+	uint8_t num_sprites = 0;
+	SpriteID sprite = 0;
 
 	SpriteID GetResult() const override { return this->sprite; }
 	uint8_t GetNumResults() const override { return this->num_sprites; }
@@ -249,7 +249,7 @@ struct TileLayoutSpriteGroup : SpriteGroup {
 	TileLayoutSpriteGroup() : SpriteGroup(SGT_TILELAYOUT) {}
 	~TileLayoutSpriteGroup() {}
 
-	NewGRFSpriteLayout dts;
+	NewGRFSpriteLayout dts{};
 
 	const DrawTileSprites *ProcessRegisters(uint8_t *stage) const;
 };
@@ -257,14 +257,14 @@ struct TileLayoutSpriteGroup : SpriteGroup {
 struct IndustryProductionSpriteGroup : SpriteGroup {
 	IndustryProductionSpriteGroup() : SpriteGroup(SGT_INDUSTRY_PRODUCTION) {}
 
-	uint8_t version;                              ///< Production callback version used, or 0xFF if marked invalid
-	uint8_t num_input;                            ///< How many subtract_input values are valid
-	int16_t subtract_input[INDUSTRY_NUM_INPUTS];  ///< Take this much of the input cargo (can be negative, is indirect in cb version 1+)
-	CargoType cargo_input[INDUSTRY_NUM_INPUTS];   ///< Which input cargoes to take from (only cb version 2)
-	uint8_t num_output;                           ///< How many add_output values are valid
-	uint16_t add_output[INDUSTRY_NUM_OUTPUTS];    ///< Add this much output cargo when successful (unsigned, is indirect in cb version 1+)
-	CargoType cargo_output[INDUSTRY_NUM_OUTPUTS]; ///< Which output cargoes to add to (only cb version 2)
-	uint8_t again;
+	uint8_t version = 0; ///< Production callback version used, or 0xFF if marked invalid
+	uint8_t num_input = 0; ///< How many subtract_input values are valid
+	std::array<int16_t, INDUSTRY_NUM_INPUTS> subtract_input{}; ///< Take this much of the input cargo (can be negative, is indirect in cb version 1+)
+	std::array<CargoType, INDUSTRY_NUM_INPUTS> cargo_input{}; ///< Which input cargoes to take from (only cb version 2)
+	uint8_t num_output = 0; ///< How many add_output values are valid
+	std::array<uint16_t, INDUSTRY_NUM_OUTPUTS> add_output{}; ///< Add this much output cargo when successful (unsigned, is indirect in cb version 1+)
+	std::array<CargoType, INDUSTRY_NUM_OUTPUTS> cargo_output{}; ///< Which output cargoes to add to (only cb version 2)
+	uint8_t again = 0;
 
 };
 
@@ -311,18 +311,18 @@ struct ResolverObject {
 
 	ScopeResolver default_scope; ///< Default implementation of the grf scope.
 
-	CallbackID callback;        ///< Callback being resolved.
-	uint32_t callback_param1;     ///< First parameter (var 10) of the callback.
-	uint32_t callback_param2;     ///< Second parameter (var 18) of the callback.
+	CallbackID callback{}; ///< Callback being resolved.
+	uint32_t callback_param1 = 0; ///< First parameter (var 10) of the callback.
+	uint32_t callback_param2 = 0; ///< Second parameter (var 18) of the callback.
 
-	uint32_t last_value;          ///< Result of most recent DeterministicSpriteGroup (including procedure calls)
+	uint32_t last_value = 0; ///< Result of most recent DeterministicSpriteGroup (including procedure calls)
 
-	uint32_t waiting_triggers;    ///< Waiting triggers to be used by any rerandomisation. (scope independent)
-	uint32_t used_triggers;       ///< Subset of cur_triggers, which actually triggered some rerandomisation. (scope independent)
-	uint32_t reseed[VSG_END];     ///< Collects bits to rerandomise while triggering triggers.
+	uint32_t waiting_triggers = 0; ///< Waiting triggers to be used by any rerandomisation. (scope independent)
+	uint32_t used_triggers = 0; ///< Subset of cur_triggers, which actually triggered some rerandomisation. (scope independent)
+	std::array<uint32_t, VSG_END> reseed; ///< Collects bits to rerandomise while triggering triggers.
 
-	const GRFFile *grffile;     ///< GRFFile the resolved SpriteGroup belongs to
-	const SpriteGroup *root_spritegroup; ///< Root SpriteGroup to use for resolving
+	const GRFFile *grffile = nullptr; ///< GRFFile the resolved SpriteGroup belongs to
+	const SpriteGroup *root_spritegroup = nullptr; ///< Root SpriteGroup to use for resolving
 
 	/**
 	 * Resolve SpriteGroup.
@@ -378,7 +378,7 @@ struct ResolverObject {
 		this->last_value = 0;
 		this->waiting_triggers = 0;
 		this->used_triggers = 0;
-		memset(this->reseed, 0, sizeof(this->reseed));
+		this->reseed.fill(0);
 	}
 
 	/**

--- a/src/newgrf_storage.h
+++ b/src/newgrf_storage.h
@@ -31,9 +31,9 @@ enum PersistentStorageMode : uint8_t {
  * so we have a generalised access to the virtual methods.
  */
 struct BasePersistentStorageArray {
-	uint32_t grfid;    ///< GRFID associated to this persistent storage. A value of zero means "default".
-	uint8_t feature;    ///< NOSAVE: Used to identify in the owner of the array in debug output.
-	TileIndex tile;  ///< NOSAVE: Used to identify in the owner of the array in debug output.
+	uint32_t grfid = 0; ///< GRFID associated to this persistent storage. A value of zero means "default".
+	uint8_t feature = 0; ///< NOSAVE: Used to identify in the owner of the array in debug output.
+	TileIndex tile = INVALID_TILE; ///< NOSAVE: Used to identify in the owner of the array in debug output.
 
 	virtual ~BasePersistentStorageArray();
 


### PR DESCRIPTION
## Motivation / Problem

If we want to get rid of `CallocT`, the pool items needs to stop relying on it. So all pool items should explicitly initialise their member variable, be it `0`, `nullptr`, or anything else. That way we don't need to zero everything first.


## Description

Explicitly initialise the member variables, in this case of `NewGRFSpriteGroup` and all its subclasses and their inner classes.

Required to change some arrays to `std::array`, so some replacements of `lengthof` and iterations were required.


## Limitations

The pool is still `CallocT`-ing first, but this class does not depend on it any more.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
