### PR TITLE
Codechange: explicitly initialise (Base)Station related member variables

### DIFF
--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -21,15 +21,15 @@ extern StationPool _station_pool;
 
 template <typename T>
 struct SpecMapping {
-	const T *spec; ///< Custom spec.
-	uint32_t grfid; ///< GRF ID of this custom spec.
-	uint16_t localidx; ///< Local ID within GRF of this custom spec.
+	const T *spec = nullptr; ///< Custom spec.
+	uint32_t grfid = 0; ///< GRF ID of this custom spec.
+	uint16_t localidx = 0; ///< Local ID within GRF of this custom spec.
 };
 
 struct RoadStopTileData {
-	TileIndex tile;
-	uint8_t random_bits;
-	uint8_t animation_frame;
+	TileIndex tile = INVALID_TILE;
+	uint8_t random_bits = 0;
+	uint8_t animation_frame = 0;
 };
 
 /** StationRect - used to track station spread out rectangle - cheaper than scanning whole map */
@@ -56,44 +56,40 @@ struct StationRect : public Rect {
 
 /** Base class for all station-ish types */
 struct BaseStation : StationPool::PoolItem<&_station_pool> {
-	TileIndex xy;                   ///< Base tile of the station
-	TrackedViewportSign sign;       ///< NOSAVE: Dimensions of sign
-	uint8_t delete_ctr;                ///< Delete counter. If greater than 0 then it is decremented until it reaches 0; the waypoint is then is deleted.
+	TileIndex xy = INVALID_TILE; ///< Base tile of the station
+	TrackedViewportSign sign{}; ///< NOSAVE: Dimensions of sign
+	uint8_t delete_ctr = 0; ///< Delete counter. If greater than 0 then it is decremented until it reaches 0; the waypoint is then is deleted.
 
-	std::string name;               ///< Custom name
-	StringID string_id;             ///< Default name (town area) of station
+	std::string name{}; ///< Custom name
+	StringID string_id = INVALID_STRING_ID; ///< Default name (town area) of station
 	mutable std::string cached_name; ///< NOSAVE: Cache of the resolved name of the station, if not using a custom name
 
-	Town *town;                     ///< The town this station is associated with
-	Owner owner;                    ///< The owner of this station
-	StationFacilities facilities;     ///< The facilities that this station has
+	Town *town = nullptr; ///< The town this station is associated with
+	Owner owner = INVALID_OWNER; ///< The owner of this station
+	StationFacilities facilities{}; ///< The facilities that this station has
 
-	std::vector<SpecMapping<StationSpec>> speclist;           ///< List of rail station specs of this station.
-	std::vector<SpecMapping<RoadStopSpec>> roadstop_speclist; ///< List of road stop specs of this station
+	std::vector<SpecMapping<StationSpec>> speclist{}; ///< List of rail station specs of this station.
+	std::vector<SpecMapping<RoadStopSpec>> roadstop_speclist{}; ///< List of road stop specs of this station
 
-	TimerGameCalendar::Date build_date; ///< Date of construction
+	TimerGameCalendar::Date build_date{}; ///< Date of construction
 
-	uint16_t random_bits;             ///< Random bits assigned to this station
-	uint8_t waiting_triggers;          ///< Waiting triggers (NewGRF) for this station
-	uint8_t cached_anim_triggers;                ///< NOSAVE: Combined animation trigger bitmask, used to determine if trigger processing should happen.
-	uint8_t cached_roadstop_anim_triggers;       ///< NOSAVE: Combined animation trigger bitmask for road stops, used to determine if trigger processing should happen.
-	CargoTypes cached_cargo_triggers;          ///< NOSAVE: Combined cargo trigger bitmask
-	CargoTypes cached_roadstop_cargo_triggers; ///< NOSAVE: Combined cargo trigger bitmask for road stops
+	uint16_t random_bits = 0; ///< Random bits assigned to this station
+	uint8_t waiting_triggers = 0; ///< Waiting triggers (NewGRF) for this station
+	uint8_t cached_anim_triggers = 0; ///< NOSAVE: Combined animation trigger bitmask, used to determine if trigger processing should happen.
+	uint8_t cached_roadstop_anim_triggers = 0; ///< NOSAVE: Combined animation trigger bitmask for road stops, used to determine if trigger processing should happen.
+	CargoTypes cached_cargo_triggers{}; ///< NOSAVE: Combined cargo trigger bitmask
+	CargoTypes cached_roadstop_cargo_triggers{}; ///< NOSAVE: Combined cargo trigger bitmask for road stops
 
-	TileArea train_station;         ///< Tile area the train 'station' part covers
-	StationRect rect;               ///< NOSAVE: Station spread out rectangle maintained by StationRect::xxx() functions
+	TileArea train_station{INVALID_TILE, 0, 0}; ///< Tile area the train 'station' part covers
+	StationRect rect{}; ///< NOSAVE: Station spread out rectangle maintained by StationRect::xxx() functions
 
-	std::vector<RoadStopTileData> custom_roadstop_tile_data; ///< List of custom road stop tile data
+	std::vector<RoadStopTileData> custom_roadstop_tile_data{}; ///< List of custom road stop tile data
 
 	/**
 	 * Initialize the base station.
 	 * @param tile The location of the station sign
 	 */
-	BaseStation(TileIndex tile) :
-		xy(tile),
-		train_station(INVALID_TILE, 0, 0)
-	{
-	}
+	BaseStation(TileIndex tile) : xy(tile) {}
 
 	virtual ~BaseStation();
 

--- a/src/roadstop_base.h
+++ b/src/roadstop_base.h
@@ -32,14 +32,14 @@ struct RoadStop : RoadStopPool::PoolItem<&_roadstop_pool> {
 	/** Container for each entry point of a drive through road stop */
 	struct Entry {
 	private:
-		int length;      ///< The length of the stop in tile 'units'
-		int occupied;    ///< The amount of occupied stop in tile 'units'
+		int length = 0; ///< The length of the stop in tile 'units'
+		int occupied = 0; ///< The amount of occupied stop in tile 'units'
 
 	public:
 		friend struct RoadStop; ///< Oh yeah, the road stop may play with me.
 
 		/** Create an entry */
-		Entry() : length(0), occupied(0) {}
+		Entry() {}
 
 		/**
 		 * Get the length of this drive through stop.
@@ -65,9 +65,9 @@ struct RoadStop : RoadStopPool::PoolItem<&_roadstop_pool> {
 		void Rebuild(const RoadStop *rs, int side = -1);
 	};
 
-	uint8_t status; ///< Current status of the Stop, @see RoadStopSatusFlag. Access using *Bay and *Busy functions.
-	TileIndex xy; ///< Position on the map
-	RoadStop *next; ///< Next stop of the given type at this station
+	uint8_t status = 0; ///< Current status of the Stop, @see RoadStopSatusFlag. Access using *Bay and *Busy functions.
+	TileIndex xy = INVALID_TILE; ///< Position on the map
+	RoadStop *next = nullptr; ///< Next stop of the given type at this station
 
 	/** Initializes a RoadStop */
 	inline RoadStop(TileIndex tile = INVALID_TILE) :
@@ -148,8 +148,8 @@ struct RoadStop : RoadStopPool::PoolItem<&_roadstop_pool> {
 	static bool IsDriveThroughRoadStopContinuation(TileIndex rs, TileIndex next);
 
 private:
-	Entry *east; ///< The vehicles that entered from the east
-	Entry *west; ///< The vehicles that entered from the west
+	Entry *east = nullptr; ///< The vehicles that entered from the east
+	Entry *west = nullptr; ///< The vehicles that entered from the west
 
 	/**
 	 * Allocates a bay

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -140,8 +140,8 @@ public:
 	void Invalidate();
 
 private:
-	SharesMap shares;  ///< Shares of flow to be sent via specified station (or consumed locally).
-	uint unrestricted; ///< Limit for unrestricted shares.
+	SharesMap shares{}; ///< Shares of flow to be sent via specified station (or consumed locally).
+	uint unrestricted = 0; ///< Limit for unrestricted shares.
 };
 
 /** Flow descriptions by origin stations. */
@@ -347,12 +347,12 @@ private:
 struct Airport : public TileArea {
 	Airport() : TileArea(INVALID_TILE, 0, 0) {}
 
-	AirportBlocks blocks; ///< stores which blocks on the airport are taken. was 16 bit earlier on, then 32
-	uint8_t type;          ///< Type of this airport, @see AirportTypes
-	uint8_t layout;        ///< Airport layout number.
-	Direction rotation; ///< How this airport is rotated.
+	AirportBlocks blocks{}; ///< stores which blocks on the airport are taken. was 16 bit earlier on, then 32
+	uint8_t type = 0; ///< Type of this airport, @see AirportTypes
+	uint8_t layout = 0; ///< Airport layout number.
+	Direction rotation = INVALID_DIR; ///< How this airport is rotated.
 
-	PersistentStorage *psa; ///< Persistent storage for NewGRF airports.
+	PersistentStorage *psa = nullptr; ///< Persistent storage for NewGRF airports.
 
 	/**
 	 * Get the AirportSpec that from the airport type of this airport. If there
@@ -480,8 +480,8 @@ private:
 };
 
 struct IndustryListEntry {
-	uint distance;
-	Industry *industry;
+	uint distance = 0;
+	Industry *industry = nullptr;
 
 	bool operator== (const IndustryListEntry &other) const { return this->distance == other.distance && this->industry == other.industry; };
 };
@@ -502,31 +502,31 @@ public:
 
 	RoadStop *GetPrimaryRoadStop(const struct RoadVehicle *v) const;
 
-	RoadStop *bus_stops;    ///< All the road stops
-	TileArea bus_station;   ///< Tile area the bus 'station' part covers
-	RoadStop *truck_stops;  ///< All the truck stops
-	TileArea truck_station; ///< Tile area the truck 'station' part covers
+	RoadStop *bus_stops = nullptr; ///< All the road stops
+	TileArea bus_station{}; ///< Tile area the bus 'station' part covers
+	RoadStop *truck_stops = nullptr; ///< All the truck stops
+	TileArea truck_station{}; ///< Tile area the truck 'station' part covers
 
-	Airport airport;          ///< Tile area the airport covers
-	TileArea ship_station;    ///< Tile area the ship 'station' part covers
-	TileArea docking_station; ///< Tile area the docking tiles cover
+	Airport airport{}; ///< Tile area the airport covers
+	TileArea ship_station{}; ///< Tile area the ship 'station' part covers
+	TileArea docking_station{}; ///< Tile area the docking tiles cover
 
-	IndustryType indtype;   ///< Industry type to get the name from
+	IndustryType indtype = IT_INVALID; ///< Industry type to get the name from
 
-	BitmapTileArea catchment_tiles; ///< NOSAVE: Set of individual tiles covered by catchment area
+	BitmapTileArea catchment_tiles{}; ///< NOSAVE: Set of individual tiles covered by catchment area
 
-	StationHadVehicleOfType had_vehicle_of_type;
+	StationHadVehicleOfType had_vehicle_of_type{};
 
-	uint8_t time_since_load;
-	uint8_t time_since_unload;
+	uint8_t time_since_load = 0;
+	uint8_t time_since_unload = 0;
 
-	uint8_t last_vehicle_type;
-	std::list<Vehicle *> loading_vehicles;
-	GoodsEntry goods[NUM_CARGO];  ///< Goods at this station
-	CargoTypes always_accepted;       ///< Bitmask of always accepted cargo types (by houses, HQs, industry tiles when industry doesn't accept cargo)
+	uint8_t last_vehicle_type = 0;
+	std::list<Vehicle *> loading_vehicles{};
+	std::array<GoodsEntry, NUM_CARGO> goods; ///< Goods at this station
+	CargoTypes always_accepted{}; ///< Bitmask of always accepted cargo types (by houses, HQs, industry tiles when industry doesn't accept cargo)
 
-	IndustryList industries_near; ///< Cached list of industries near the station that can accept cargo, @see DeliverGoodsToIndustry()
-	Industry *industry;           ///< NOSAVE: Associated industry for neutral stations. (Rebuilt on load from Industry->st)
+	IndustryList industries_near{}; ///< Cached list of industries near the station that can accept cargo, @see DeliverGoodsToIndustry()
+	Industry *industry = nullptr; ///< NOSAVE: Associated industry for neutral stations. (Rebuilt on load from Industry->st)
 
 	Station(TileIndex tile = INVALID_TILE);
 	~Station();
@@ -581,7 +581,7 @@ public:
 /** Iterator to iterate over all tiles belonging to an airport. */
 class AirportTileIterator : public OrthogonalTileIterator {
 private:
-	const Station *st; ///< The station the airport is a part of.
+	const Station *st = nullptr; ///< The station the airport is a part of.
 
 public:
 	/**

--- a/src/viewport_type.h
+++ b/src/viewport_type.h
@@ -47,10 +47,10 @@ struct Viewport {
 
 /** Location information about a sign as seen on the viewport */
 struct ViewportSign {
-	int32_t center;        ///< The center position of the sign
-	int32_t top;           ///< The top of the sign
-	uint16_t width_normal; ///< The width when not zoomed out (normal font)
-	uint16_t width_small;  ///< The width when zoomed out (small font)
+	int32_t center = 0; ///< The center position of the sign
+	int32_t top = 0; ///< The top of the sign
+	uint16_t width_normal = 0; ///< The width when not zoomed out (normal font)
+	uint16_t width_small = 0; ///< The width when zoomed out (small font)
 
 	auto operator<=>(const ViewportSign &) const = default;
 
@@ -60,7 +60,7 @@ struct ViewportSign {
 
 /** Specialised ViewportSign that tracks whether it is valid for entering into a Kdtree */
 struct TrackedViewportSign : ViewportSign {
-	bool kdtree_valid; ///< Are the sign data valid for use with the _viewport_sign_kdtree?
+	bool kdtree_valid = false; ///< Are the sign data valid for use with the _viewport_sign_kdtree?
 
 	auto operator<=>(const TrackedViewportSign &) const = default;
 
@@ -72,11 +72,6 @@ struct TrackedViewportSign : ViewportSign {
 	{
 		this->kdtree_valid = true;
 		this->ViewportSign::UpdatePosition(center, top, str, str_small);
-	}
-
-
-	TrackedViewportSign() : kdtree_valid{ false }
-	{
 	}
 };
 

--- a/src/waypoint_base.h
+++ b/src/waypoint_base.h
@@ -21,9 +21,9 @@ enum WaypointFlags : uint8_t {
 
 /** Representation of a waypoint. */
 struct Waypoint final : SpecializedStation<Waypoint, true> {
-	uint16_t town_cn;    ///< The N-1th waypoint for this town (consecutive number)
+	uint16_t town_cn = 0; ///< The N-1th waypoint for this town (consecutive number)
 	uint16_t waypoint_flags{}; ///< Waypoint flags, see WaypointFlags
-	TileArea road_waypoint_area; ///< Tile area the road waypoint part covers
+	TileArea road_waypoint_area{}; ///< Tile area the road waypoint part covers
 
 	/**
 	 * Create a waypoint at the given tile.


### PR DESCRIPTION
## Motivation / Problem

If we want to get rid of `CallocT`, the pool items needs to stop relying on it. So all pool items should explicitly initialise their member variable, be it `0`, `nullptr`, or anything else. That way we don't need to zero everything first.


## Description

Explicitly initialise the member variables, in this case of `BaseStation` and all its sub classes and their inner classes.


## Limitations

The pool is still `CallocT`-ing first, but this class does not depend on it any more.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
