### PR TITLE
Codechange: explicitly initialise Sign member variables

### DIFF
--- a/src/signs.cpp
+++ b/src/signs.cpp
@@ -24,14 +24,6 @@
 SignPool _sign_pool("Sign");
 INSTANTIATE_POOL_METHODS(Sign)
 
-/**
- * Creates a new sign
- */
-Sign::Sign(Owner owner)
-{
-	this->owner = owner;
-}
-
 /** Destroy the sign */
 Sign::~Sign()
 {

--- a/src/signs_base.h
+++ b/src/signs_base.h
@@ -19,14 +19,15 @@ typedef Pool<Sign, SignID, 16> SignPool;
 extern SignPool _sign_pool;
 
 struct Sign : SignPool::PoolItem<&_sign_pool> {
-	std::string         name;
-	TrackedViewportSign sign;
-	int32_t               x;
-	int32_t               y;
-	int32_t               z;
-	Owner               owner; // placed by this company. Anyone can delete them though. OWNER_NONE for gray signs from old games.
+	std::string name{};
+	TrackedViewportSign sign{};
+	int32_t x = 0;
+	int32_t y = 0;
+	int32_t z = 0;
+	Owner owner = INVALID_OWNER; // placed by this company. Anyone can delete them though. OWNER_NONE for gray signs from old games.
 
-	Sign(Owner owner = INVALID_OWNER);
+	Sign() {}
+	Sign(Owner owner, int32_t x, int32_t y, int32_t z, const std::string &name) : name(name), x(x), y(y), z(z), owner(owner) {}
 	~Sign();
 
 	void UpdateVirtCoord();

--- a/src/signs_cmd.cpp
+++ b/src/signs_cmd.cpp
@@ -42,16 +42,11 @@ std::tuple<CommandCost, SignID> CmdPlaceSign(DoCommandFlags flags, TileIndex til
 
 	/* When we execute, really make the sign */
 	if (flags.Test(DoCommandFlag::Execute)) {
-		Sign *si = new Sign(_game_mode == GM_EDITOR ? OWNER_DEITY : _current_company);
 		int x = TileX(tile) * TILE_SIZE;
 		int y = TileY(tile) * TILE_SIZE;
 
-		si->x = x;
-		si->y = y;
-		si->z = GetSlopePixelZ(x, y);
-		if (!text.empty()) {
-			si->name = text;
-		}
+		Sign *si = new Sign(_game_mode == GM_EDITOR ? OWNER_DEITY : _current_company, x, y, GetSlopePixelZ(x, y), text);
+
 		si->UpdateVirtCoord();
 		InvalidateWindowData(WC_SIGN_LIST, 0, 0);
 		return { CommandCost(), si->index };


### PR DESCRIPTION
## Motivation / Problem

If we want to get rid of `CallocT`, the pool items needs to stop relying on it. So all pool items should explicitly initialise their member variable, be it `0`, `nullptr`, or anything else. That way we don't need to zero everything first.


## Description

Explicitly initialise the member variables, in this case of `Sign`.

Moved some simple initialisations to the constructor.


## Limitations

The pool is still `CallocT`-ing first, but this class does not depend on it any more.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
