### PR TITLE
Codechange: Use helper to set grf_prop's grffile and grfid together.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -649,8 +649,7 @@ static Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t inte
 		if (engine != EngineID::Invalid()) {
 			Engine *e = Engine::Get(engine);
 			if (!e->grf_prop.HasGrfFile()) {
-				e->grf_prop.grfid = file->grfid;
-				e->grf_prop.grffile = file;
+				e->grf_prop.SetGRFFile(file);
 			}
 			return e;
 		}
@@ -662,8 +661,7 @@ static Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t inte
 		Engine *e = Engine::Get(engine);
 
 		if (!e->grf_prop.HasGrfFile()) {
-			e->grf_prop.grfid = file->grfid;
-			e->grf_prop.grffile = file;
+			e->grf_prop.SetGRFFile(file);
 			GrfMsg(5, "Replaced engine at index {} for GRFID {:x}, type {}, index {}", e->index, std::byteswap(file->grfid), type, internal_id);
 		}
 
@@ -681,8 +679,7 @@ static Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t inte
 
 	/* ... it's not, so create a new one based off an existing engine */
 	Engine *e = new Engine(type, internal_id);
-	e->grf_prop.grfid = file->grfid;
-	e->grf_prop.grffile = file;
+	e->grf_prop.SetGRFFile(file);
 
 	/* Reserve the engine slot */
 	_engine_mngr.SetID(type, internal_id, scope_grfid, std::min<uint8_t>(internal_id, _engine_counts[type]), e->index);
@@ -2559,8 +2556,7 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 					housespec->enabled = true;
 					housespec->grf_prop.local_id = id;
 					housespec->grf_prop.subst_id = subs_id;
-					housespec->grf_prop.grfid = _cur.grffile->grfid;
-					housespec->grf_prop.grffile = _cur.grffile;
+					housespec->grf_prop.SetGRFFile(_cur.grffile);
 					/* Set default colours for randomization, used if not overridden. */
 					housespec->random_colour[0] = COLOUR_RED;
 					housespec->random_colour[1] = COLOUR_BLUE;
@@ -3472,8 +3468,7 @@ static ChangeInfoResult IndustrytilesChangeInfo(uint first, uint last, int prop,
 
 					tsp->grf_prop.local_id = id;
 					tsp->grf_prop.subst_id = subs_id;
-					tsp->grf_prop.grfid = _cur.grffile->grfid;
-					tsp->grf_prop.grffile = _cur.grffile;
+					tsp->grf_prop.SetGRFFile(_cur.grffile);
 					_industile_mngr.AddEntityID(id, _cur.grffile->grfid, subs_id); // pre-reserve the tile slot
 				}
 				break;
@@ -3738,8 +3733,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 					indsp->enabled = true;
 					indsp->grf_prop.local_id = id;
 					indsp->grf_prop.subst_id = subs_id;
-					indsp->grf_prop.grfid = _cur.grffile->grfid;
-					indsp->grf_prop.grffile = _cur.grffile;
+					indsp->grf_prop.SetGRFFile(_cur.grffile);
 					/* If the grf industry needs to check its surrounding upon creation, it should
 					 * rely on callbacks, not on the original placement functions */
 					indsp->check_proc = CHECK_NOTHING;
@@ -4116,8 +4110,7 @@ static ChangeInfoResult AirportChangeInfo(uint first, uint last, int prop, ByteR
 					as->enabled = true;
 					as->grf_prop.local_id = id;
 					as->grf_prop.subst_id = subs_id;
-					as->grf_prop.grfid = _cur.grffile->grfid;
-					as->grf_prop.grffile = _cur.grffile;
+					as->grf_prop.SetGRFFile(_cur.grffile);
 					/* override the default airport */
 					_airport_mngr.Add(id, _cur.grffile->grfid, subs_id);
 				}
@@ -4904,8 +4897,7 @@ static ChangeInfoResult AirportTilesChangeInfo(uint first, uint last, int prop, 
 
 					tsp->grf_prop.local_id = id;
 					tsp->grf_prop.subst_id = subs_id;
-					tsp->grf_prop.grfid = _cur.grffile->grfid;
-					tsp->grf_prop.grffile = _cur.grffile;
+					tsp->grf_prop.SetGRFFile(_cur.grffile);
 					_airporttile_mngr.AddEntityID(id, _cur.grffile->grfid, subs_id); // pre-reserve the tile slot
 				}
 				break;
@@ -6018,8 +6010,7 @@ static void StationMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 		}
 
 		statspec->grf_prop.SetSpriteGroup(SpriteGroupCargo::SG_DEFAULT, _cur.spritegroups[groupid]);
-		statspec->grf_prop.grfid = _cur.grffile->grfid;
-		statspec->grf_prop.grffile = _cur.grffile;
+		statspec->grf_prop.SetGRFFile(_cur.grffile);
 		statspec->grf_prop.local_id = station;
 		StationClass::Assign(statspec);
 	}
@@ -6203,8 +6194,7 @@ static void ObjectMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 		}
 
 		spec->grf_prop.SetSpriteGroup(OBJECT_SPRITE_GROUP_DEFAULT, _cur.spritegroups[groupid]);
-		spec->grf_prop.grfid = _cur.grffile->grfid;
-		spec->grf_prop.grffile = _cur.grffile;
+		spec->grf_prop.SetGRFFile(_cur.grffile);
 		spec->grf_prop.local_id = object;
 	}
 }
@@ -6390,8 +6380,7 @@ static void RoadStopMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 		}
 
 		roadstopspec->grf_prop.SetSpriteGroup(SpriteGroupCargo::SG_DEFAULT, _cur.spritegroups[groupid]);
-		roadstopspec->grf_prop.grfid = _cur.grffile->grfid;
-		roadstopspec->grf_prop.grffile = _cur.grffile;
+		roadstopspec->grf_prop.SetGRFFile(_cur.grffile);
 		roadstopspec->grf_prop.local_id = roadstop;
 		RoadStopClass::Assign(roadstopspec);
 	}
@@ -6442,7 +6431,7 @@ static void BadgeMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 
 		auto &badge = *GetBadge(found->second);
 		badge.grf_prop.SetSpriteGroup(GSF_END, _cur.spritegroups[groupid]);
-		badge.grf_prop.grffile = _cur.grffile;
+		badge.grf_prop.SetGRFFile(_cur.grffile);
 		badge.grf_prop.local_id = local_id;
 	}
 }

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -733,6 +733,16 @@ void NewGRFSpriteLayout::ProcessRegisters(uint8_t resolved_var10, uint32_t resol
 }
 
 /**
+ * Set the NewGRF file, and its grfid, associated with grf props.
+ * @param grffile GRFFile to set.
+ */
+void GRFFilePropsBase::SetGRFFile(const struct GRFFile *grffile)
+{
+	this->grffile = grffile;
+	this->grfid = grffile == nullptr ? 0 : grffile->grfid;
+}
+
+/**
  * Get the SpriteGroup at the specified index.
  * @param index Index to get.
  * @returns SpriteGroup at index, or nullptr if not present.

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -294,6 +294,8 @@ struct GRFFilePropsBase {
 	uint32_t grfid = 0; ///< grfid that introduced this entity.
 	const struct GRFFile *grffile = nullptr; ///< grf file that introduced this entity
 
+	void SetGRFFile(const struct GRFFile *grffile);
+
 	/**
 	 * Test if this entity was introduced by NewGRF.
 	 * @returns true iff the grfid property is set.

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -71,8 +71,7 @@ void SetCustomEngineSprites(EngineID engine, CargoType cargo, const SpriteGroup 
 void SetEngineGRF(EngineID engine, const GRFFile *file)
 {
 	Engine *e = Engine::Get(engine);
-	e->grf_prop.grfid = file->grfid;
-	e->grf_prop.grffile = file;
+	e->grf_prop.SetGRFFile(file);
 }
 
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When NewGRFs are setting SpriteGroups to things, we assign both `grf_prop.grfid` and `grf_prop.grffile` at the same time, unless it's been missed.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add `SetGRFFile()` to `GRFFilePropsBase` and use it to set both `grfid` and `grffile` consistently.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
