### PR TITLE
Codechange: explicitly initialise StoryPage and StoryPageElement member variables

### DIFF
--- a/src/story.cpp
+++ b/src/story.cpp
@@ -37,6 +37,15 @@ StoryPagePool _story_page_pool("StoryPage");
 INSTANTIATE_POOL_METHODS(StoryPageElement)
 INSTANTIATE_POOL_METHODS(StoryPage)
 
+StoryPage::~StoryPage()
+{
+	if (!this->CleaningPool()) {
+		for (StoryPageElement *spe : StoryPageElement::Iterate()) {
+			if (spe->page == this->index) delete spe;
+		}
+	}
+}
+
 /**
  * This helper for Create/Update PageElement Cmd procedure verifies if the page
  * element parameters are correct for the given page element type.
@@ -219,11 +228,7 @@ std::tuple<CommandCost, StoryPageID> CmdCreateStoryPage(DoCommandFlags flags, Co
 			_story_page_next_sort_value = 0;
 		}
 
-		StoryPage *s = new StoryPage();
-		s->sort_value = _story_page_next_sort_value;
-		s->date = TimerGameCalendar::date;
-		s->company = company;
-		s->title = text;
+		StoryPage *s = new StoryPage(_story_page_next_sort_value, TimerGameCalendar::date, company, text);
 
 		InvalidateWindowClassesData(WC_STORY_BOOK, -1);
 		if (StoryPage::GetNumItems() == 1) InvalidateWindowData(WC_MAIN_TOOLBAR, 0);
@@ -267,10 +272,7 @@ std::tuple<CommandCost, StoryPageElementID> CmdCreateStoryPageElement(DoCommandF
 			_story_page_element_next_sort_value = 0;
 		}
 
-		StoryPageElement *pe = new StoryPageElement();
-		pe->sort_value = _story_page_element_next_sort_value;
-		pe->type = type;
-		pe->page = page_id;
+		StoryPageElement *pe = new StoryPageElement(_story_page_element_next_sort_value, type, page_id);
 		UpdateElement(*pe, tile, reference, text);
 
 		InvalidateWindowClassesData(WC_STORY_BOOK, page_id);

--- a/src/story_base.h
+++ b/src/story_base.h
@@ -120,7 +120,7 @@ inline bool IsValidStoryPageButtonCursor(StoryPageButtonCursor cursor)
 
 /** Helper to construct packed "id" values for button-type StoryPageElement */
 struct StoryPageButtonData {
-	uint32_t referenced_id;
+	uint32_t referenced_id = 0;
 
 	void SetColour(Colours button_colour);
 	void SetFlags(StoryPageButtonFlags flags);
@@ -152,38 +152,32 @@ struct StoryPageElement : StoryPageElementPool::PoolItem<&_story_page_element_po
 	/**
 	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
 	 */
-	inline StoryPageElement() { }
+	StoryPageElement() { }
+	StoryPageElement(uint32_t sort_value, StoryPageElementType type, StoryPageID page) :
+		sort_value(sort_value), page(page), type(type) { }
 
 	/**
 	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter
 	 */
-	inline ~StoryPageElement() { }
+	~StoryPageElement() { }
 };
 
 /** Struct about stories, current and completed */
 struct StoryPage : StoryPagePool::PoolItem<&_story_page_pool> {
-	uint32_t sort_value;            ///< A number that increases for every created story page. Used for sorting. The id of a story page is the pool index.
-	TimerGameCalendar::Date date; ///< Date when the page was created.
-	CompanyID company;            ///< StoryPage is for a specific company; CompanyID::Invalid() if it is global
+	uint32_t sort_value = 0; ///< A number that increases for every created story page. Used for sorting. The id of a story page is the pool index.
+	TimerGameCalendar::Date date{}; ///< Date when the page was created.
+	CompanyID company = CompanyID::Invalid(); ///< StoryPage is for a specific company; CompanyID::Invalid() if it is global
 
-	std::string title;            ///< Title of story page
+	std::string title; ///< Title of story page
 
 	/**
 	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
 	 */
-	inline StoryPage() { }
+	StoryPage() { }
+	StoryPage(uint32_t sort_value, TimerGameCalendar::Date date, CompanyID company, const std::string &title) :
+		sort_value(sort_value), date(date), company(company), title(title) {}
 
-	/**
-	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter
-	 */
-	inline ~StoryPage()
-	{
-		if (!this->CleaningPool()) {
-			for (StoryPageElement *spe : StoryPageElement::Iterate()) {
-				if (spe->page == this->index) delete spe;
-			}
-		}
-	}
+	~StoryPage();
 };
 
 #endif /* STORY_BASE_H */


### PR DESCRIPTION
## Motivation / Problem

If we want to get rid of `CallocT`, the pool items needs to stop relying on it. So all pool items should explicitly initialise their member variable, be it `0`, `nullptr`, or anything else. That way we don't need to zero everything first.


## Description

Explicitly initialise the member variables, in this case of `StoryPage` and `StoryPageElement`.

Moved some trivial initialisations to the constructor, and moved the non-trivial destructor to the .cpp file.


## Limitations

The pool is still `CallocT`-ing first, but this class does not depend on it any more.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
