### PR TITLE
Codechange: explicitly initialise Subsidy member variables

### DIFF
--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -201,12 +201,7 @@ static bool CheckSubsidyDistance(Source src, Source dst)
  */
 void CreateSubsidy(CargoType cargo_type, Source src, Source dst)
 {
-	Subsidy *s = new Subsidy();
-	s->cargo_type = cargo_type;
-	s->src = src;
-	s->dst = dst;
-	s->remaining = SUBSIDY_OFFER_MONTHS;
-	s->awarded = CompanyID::Invalid();
+	Subsidy *s = new Subsidy(cargo_type, src, dst, SUBSIDY_OFFER_MONTHS);
 
 	std::pair<NewsReference, NewsReference> references = SetupSubsidyDecodeParam(s, SubsidyDecodeParamType::NewsOffered);
 	AddNewsItem(STR_NEWS_SERVICE_SUBSIDY_OFFERED, NewsType::Subsidies, NewsStyle::Normal, {}, references.first, references.second);

--- a/src/subsidy_base.h
+++ b/src/subsidy_base.h
@@ -21,21 +21,22 @@ extern SubsidyPool _subsidy_pool;
 
 /** Struct about subsidies, offered and awarded */
 struct Subsidy : SubsidyPool::PoolItem<&_subsidy_pool> {
-	CargoType cargo_type;  ///< Cargo type involved in this subsidy, INVALID_CARGO for invalid subsidy
-	uint16_t remaining;    ///< Remaining months when this subsidy is valid
-	CompanyID awarded;   ///< Subsidy is awarded to this company; CompanyID::Invalid() if it's not awarded to anyone
-	Source src; ///< Source of subsidised path
-	Source dst; ///< Destination of subsidised path
+	CargoType cargo_type = INVALID_CARGO;  ///< Cargo type involved in this subsidy, INVALID_CARGO for invalid subsidy
+	uint16_t remaining = 0;    ///< Remaining months when this subsidy is valid
+	CompanyID awarded = CompanyID::Invalid();   ///< Subsidy is awarded to this company; CompanyID::Invalid() if it's not awarded to anyone
+	Source src{}; ///< Source of subsidised path
+	Source dst{}; ///< Destination of subsidised path
 
 	/**
 	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
 	 */
-	inline Subsidy() { }
+	Subsidy() { }
+	Subsidy(CargoType cargo_type, Source src, Source dst, uint16_t remaining) : cargo_type(cargo_type), remaining(remaining), src(src), dst(dst) {}
 
 	/**
 	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter
 	 */
-	inline ~Subsidy() { }
+	~Subsidy() { }
 
 	/**
 	 * Tests whether this subsidy has been awarded to someone


### PR DESCRIPTION
## Motivation / Problem

If we want to get rid of `CallocT`, the pool items needs to stop relying on it. So all pool items should explicitly initialise their member variable, be it `0`, `nullptr`, or anything else. That way we don't need to zero everything first.


## Description

Explicitly initialise the member variables, in this case of `Subsidy`.

Moved some simple initialisations to the constructor.


## Limitations

The pool is still `CallocT`-ing first, but this class does not depend on it any more.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
