### PR TITLE
Codechange: explicitly initialise Vehicle related member variables

### DIFF
--- a/src/aircraft.h
+++ b/src/aircraft.h
@@ -62,25 +62,25 @@ int GetAircraftFlightLevel(T *v, bool takeoff = false);
 
 /** Variables that are cached to improve performance and such. */
 struct AircraftCache {
-	uint32_t cached_max_range_sqr;   ///< Cached squared maximum range.
-	uint16_t cached_max_range;       ///< Cached maximum range.
+	uint32_t cached_max_range_sqr = 0; ///< Cached squared maximum range.
+	uint16_t cached_max_range = 0; ///< Cached maximum range.
 };
 
 /**
  * Aircraft, helicopters, rotors and their shadows belong to this class.
  */
 struct Aircraft final : public SpecializedVehicle<Aircraft, VEH_AIRCRAFT> {
-	uint16_t crashed_counter;        ///< Timer for handling crash animations.
-	uint8_t pos;                      ///< Next desired position of the aircraft.
-	uint8_t previous_pos;             ///< Previous desired position of the aircraft.
-	StationID targetairport;       ///< Airport to go to next.
-	uint8_t state;                    ///< State of the airport. @see AirportMovementStates
-	Direction last_direction;
-	uint8_t number_consecutive_turns; ///< Protection to prevent the aircraft of making a lot of turns in order to reach a specific point.
-	uint8_t turn_counter;             ///< Ticks between each turn to prevent > 45 degree turns.
-	uint8_t flags;                    ///< Aircraft flags. @see AirVehicleFlags
+	uint16_t crashed_counter = 0; ///< Timer for handling crash animations.
+	uint8_t pos = 0; ///< Next desired position of the aircraft.
+	uint8_t previous_pos = 0; ///< Previous desired position of the aircraft.
+	StationID targetairport = StationID::Invalid(); ///< Airport to go to next.
+	uint8_t state = 0; ///< State of the airport. @see AirportMovementStates
+	Direction last_direction = INVALID_DIR;
+	uint8_t number_consecutive_turns = 0; ///< Protection to prevent the aircraft of making a lot of turns in order to reach a specific point.
+	uint8_t turn_counter = 0; ///< Ticks between each turn to prevent > 45 degree turns.
+	uint8_t flags = 0; ///< Aircraft flags. @see AirVehicleFlags
 
-	AircraftCache acache;
+	AircraftCache acache{};
 
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
 	Aircraft() : SpecializedVehicleBase() {}

--- a/src/base_consist.h
+++ b/src/base_consist.h
@@ -15,23 +15,23 @@
 
 /** Various front vehicle properties that are preserved when autoreplacing, using order-backup or switching front engines within a consist. */
 struct BaseConsist {
-	std::string name;                   ///< Name of vehicle
+	std::string name{}; ///< Name of vehicle
 
 	/* Used for timetabling. */
-	TimerGameTick::Ticks current_order_time;    ///< How many ticks have passed since this order started.
-	TimerGameTick::Ticks lateness_counter;      ///< How many ticks late (or early if negative) this vehicle is.
-	TimerGameTick::TickCounter timetable_start; ///< At what tick of TimerGameTick::counter the vehicle should start its timetable.
+	TimerGameTick::Ticks current_order_time{}; ///< How many ticks have passed since this order started.
+	TimerGameTick::Ticks lateness_counter{}; ///< How many ticks late (or early if negative) this vehicle is.
+	TimerGameTick::TickCounter timetable_start{}; ///< At what tick of TimerGameTick::counter the vehicle should start its timetable.
 
-	TimerGameTick::TickCounter depot_unbunching_last_departure; ///< When the vehicle last left its unbunching depot.
-	TimerGameTick::TickCounter depot_unbunching_next_departure; ///< When the vehicle will next try to leave its unbunching depot.
+	TimerGameTick::TickCounter depot_unbunching_last_departure{}; ///< When the vehicle last left its unbunching depot.
+	TimerGameTick::TickCounter depot_unbunching_next_departure{}; ///< When the vehicle will next try to leave its unbunching depot.
 	TimerGameTick::Ticks round_trip_time;  ///< How many ticks for a single circumnavigation of the orders.
 
-	uint16_t service_interval;            ///< The interval for (automatic) servicing; either in days or %.
+	uint16_t service_interval = 0; ///< The interval for (automatic) servicing; either in days or %.
 
-	VehicleOrderID cur_real_order_index;///< The index to the current real (non-implicit) order
-	VehicleOrderID cur_implicit_order_index;///< The index to the current implicit order
+	VehicleOrderID cur_real_order_index = 0; ///< The index to the current real (non-implicit) order
+	VehicleOrderID cur_implicit_order_index = 0; ///< The index to the current implicit order
 
-	uint16_t vehicle_flags;               ///< Used for gradual loading and other miscellaneous things (@see VehicleFlags enum)
+	uint16_t vehicle_flags = 0; ///< Used for gradual loading and other miscellaneous things (@see VehicleFlags enum)
 
 	virtual ~BaseConsist() = default;
 

--- a/src/disaster_vehicle.h
+++ b/src/disaster_vehicle.h
@@ -35,10 +35,10 @@ enum DisasterSubType : uint8_t {
  * Disasters, like submarines, skyrangers and their shadows, belong to this class.
  */
 struct DisasterVehicle final : public SpecializedVehicle<DisasterVehicle, VEH_DISASTER> {
-	SpriteID image_override;            ///< Override for the default disaster vehicle sprite.
-	VehicleID big_ufo_destroyer_target; ///< The big UFO that this destroyer is supposed to bomb.
-	uint8_t flags;                         ///< Flags about the state of the vehicle, @see AirVehicleFlags
-	uint16_t state;                     ///< Action stage of the disaster vehicle.
+	SpriteID image_override{}; ///< Override for the default disaster vehicle sprite.
+	VehicleID big_ufo_destroyer_target = VehicleID::Invalid(); ///< The big UFO that this destroyer is supposed to bomb.
+	uint8_t flags = 0; ///< Flags about the state of the vehicle, @see AirVehicleFlags
+	uint16_t state = 0; ///< Action stage of the disaster vehicle.
 
 	/** For use by saveload. */
 	DisasterVehicle() : SpecializedVehicleBase() {}

--- a/src/ground_vehicle.hpp
+++ b/src/ground_vehicle.hpp
@@ -29,23 +29,23 @@ enum AccelStatus : uint8_t {
  */
 struct GroundVehicleCache {
 	/* Cached acceleration values, recalculated when the cargo on a vehicle changes (in addition to the conditions below) */
-	uint32_t cached_weight;           ///< Total weight of the consist (valid only for the first engine).
-	uint32_t cached_slope_resistance; ///< Resistance caused by weight when this vehicle part is at a slope.
-	uint32_t cached_max_te;           ///< Maximum tractive effort of consist (valid only for the first engine).
-	uint16_t cached_axle_resistance;  ///< Resistance caused by the axles of the vehicle (valid only for the first engine).
+	uint32_t cached_weight = 0; ///< Total weight of the consist (valid only for the first engine).
+	uint32_t cached_slope_resistance = 0; ///< Resistance caused by weight when this vehicle part is at a slope.
+	uint32_t cached_max_te = 0; ///< Maximum tractive effort of consist (valid only for the first engine).
+	uint16_t cached_axle_resistance = 0; ///< Resistance caused by the axles of the vehicle (valid only for the first engine).
 
 	/* Cached acceleration values, recalculated on load and each time a vehicle is added to/removed from the consist. */
-	uint16_t cached_max_track_speed;  ///< Maximum consist speed (in internal units) limited by track type (valid only for the first engine).
-	uint32_t cached_power;            ///< Total power of the consist (valid only for the first engine).
-	uint32_t cached_air_drag;         ///< Air drag coefficient of the vehicle (valid only for the first engine).
+	uint16_t cached_max_track_speed = 0; ///< Maximum consist speed (in internal units) limited by track type (valid only for the first engine).
+	uint32_t cached_power = 0; ///< Total power of the consist (valid only for the first engine).
+	uint32_t cached_air_drag = 0; ///< Air drag coefficient of the vehicle (valid only for the first engine).
 
 	/* Cached NewGRF values, recalculated on load and each time a vehicle is added to/removed from the consist. */
-	uint16_t cached_total_length;     ///< Length of the whole vehicle (valid only for the first engine).
-	EngineID first_engine;          ///< Cached EngineID of the front vehicle. EngineID::Invalid() for the front vehicle itself.
-	uint8_t cached_veh_length;        ///< Length of this vehicle in units of 1/VEHICLE_LENGTH of normal length. It is cached because this can be set by a callback.
+	uint16_t cached_total_length = 0; ///< Length of the whole vehicle (valid only for the first engine).
+	EngineID first_engine = EngineID::Invalid(); ///< Cached EngineID of the front vehicle. EngineID::Invalid() for the front vehicle itself.
+	uint8_t cached_veh_length = 0; ///< Length of this vehicle in units of 1/VEHICLE_LENGTH of normal length. It is cached because this can be set by a callback.
 
 	/* Cached UI information. */
-	uint16_t last_speed;              ///< The last speed we did display, so we only have to redraw when this changes.
+	uint16_t last_speed = 0; ///< The last speed we did display, so we only have to redraw when this changes.
 
 	auto operator<=>(const GroundVehicleCache &) const = default;
 };
@@ -80,8 +80,8 @@ enum GroundVehicleFlags : uint8_t {
  */
 template <class T, VehicleType Type>
 struct GroundVehicle : public SpecializedVehicle<T, Type> {
-	GroundVehicleCache gcache; ///< Cache of often calculated values.
-	uint16_t gv_flags;           ///< @see GroundVehicleFlags.
+	GroundVehicleCache gcache{}; ///< Cache of often calculated values.
+	uint16_t gv_flags = 0; ///< @see GroundVehicleFlags.
 
 	typedef GroundVehicle<T, Type> GroundVehicleBase; ///< Our type
 

--- a/src/roadveh.h
+++ b/src/roadveh.h
@@ -83,10 +83,10 @@ void GetRoadVehSpriteSize(EngineID engine, uint &width, uint &height, int &xoffs
 
 /** Element of the RoadVehPathCache. */
 struct RoadVehPathElement {
-	Trackdir trackdir; ///< Trackdir for this element.
-	TileIndex tile; ///< Tile for this element.
+	Trackdir trackdir = INVALID_TRACKDIR; ///< Trackdir for this element.
+	TileIndex tile = INVALID_TILE; ///< Tile for this element.
 
-	constexpr RoadVehPathElement() : trackdir(INVALID_TRACKDIR), tile(INVALID_TILE) {}
+	constexpr RoadVehPathElement() {}
 	constexpr RoadVehPathElement(Trackdir trackdir, TileIndex tile) : trackdir(trackdir), tile(tile) {}
 };
 
@@ -96,18 +96,18 @@ using RoadVehPathCache = std::vector<RoadVehPathElement>;
  * Buses, trucks and trams belong to this class.
  */
 struct RoadVehicle final : public GroundVehicle<RoadVehicle, VEH_ROAD> {
-	RoadVehPathCache path;  ///< Cached path.
-	uint8_t state;             ///< @see RoadVehicleStates
-	uint8_t frame;
-	uint16_t blocked_ctr;
-	uint8_t overtaking;        ///< Set to #RVSB_DRIVE_SIDE when overtaking, otherwise 0.
-	uint8_t overtaking_ctr;    ///< The length of the current overtake attempt.
-	uint16_t crashed_ctr;     ///< Animation counter when the vehicle has crashed. @see RoadVehIsCrashed
-	uint8_t reverse_ctr;
+	RoadVehPathCache path{};  ///< Cached path.
+	uint8_t state = 0; ///< @see RoadVehicleStates
+	uint8_t frame = 0;
+	uint16_t blocked_ctr = 0;
+	uint8_t overtaking = 0; ///< Set to #RVSB_DRIVE_SIDE when overtaking, otherwise 0.
+	uint8_t overtaking_ctr = 0; ///< The length of the current overtake attempt.
+	uint16_t crashed_ctr = 0; ///< Animation counter when the vehicle has crashed. @see RoadVehIsCrashed
+	uint8_t reverse_ctr = 0;
 
-	RoadType roadtype; ///< NOSAVE: Roadtype of this vehicle.
+	RoadType roadtype = INVALID_ROADTYPE; ///< NOSAVE: Roadtype of this vehicle.
 	VehicleID disaster_vehicle = VehicleID::Invalid(); ///< NOSAVE: Disaster vehicle targetting this vehicle.
-	RoadTypes compatible_roadtypes; ///< NOSAVE: Roadtypes this consist is powered on.
+	RoadTypes compatible_roadtypes{}; ///< NOSAVE: Roadtypes this consist is powered on.
 
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
 	RoadVehicle() : GroundVehicleBase() {}

--- a/src/ship.h
+++ b/src/ship.h
@@ -18,9 +18,9 @@ WaterClass GetEffectiveWaterClass(TileIndex tile);
 
 /** Element of the ShipPathCache. */
 struct ShipPathElement {
-	Trackdir trackdir; ///< Trackdir for this element.
+	Trackdir trackdir = INVALID_TRACKDIR; ///< Trackdir for this element.
 
-	constexpr ShipPathElement() : trackdir(INVALID_TRACKDIR) {}
+	constexpr ShipPathElement() {}
 	constexpr ShipPathElement(Trackdir trackdir) : trackdir(trackdir) {}
 };
 
@@ -30,11 +30,11 @@ using ShipPathCache = std::vector<ShipPathElement>;
  * All ships have this type.
  */
 struct Ship final : public SpecializedVehicle<Ship, VEH_SHIP> {
-	ShipPathCache path;   ///< Cached path.
-	TrackBits state;      ///< The "track" the ship is following.
-	Direction rotation;   ///< Visible direction.
-	int16_t rotation_x_pos; ///< NOSAVE: X Position before rotation.
-	int16_t rotation_y_pos; ///< NOSAVE: Y Position before rotation.
+	ShipPathCache path{}; ///< Cached path.
+	TrackBits state{}; ///< The "track" the ship is following.
+	Direction rotation = INVALID_DIR; ///< Visible direction.
+	int16_t rotation_x_pos = 0; ///< NOSAVE: X Position before rotation.
+	int16_t rotation_y_pos = 0; ///< NOSAVE: Y Position before rotation.
 
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
 	Ship() : SpecializedVehicleBase() {}

--- a/src/train.h
+++ b/src/train.h
@@ -71,14 +71,14 @@ void NormalizeTrainVehInDepot(const Train *u);
 /** Variables that are cached to improve performance and such */
 struct TrainCache {
 	/* Cached wagon override spritegroup */
-	const struct SpriteGroup *cached_override;
+	const struct SpriteGroup *cached_override = nullptr;
 
 	/* cached values, recalculated on load and each time a vehicle is added to/removed from the consist. */
-	bool cached_tilt;           ///< train can tilt; feature provides a bonus in curves
-	uint8_t user_def_data;         ///< Cached property 0x25. Can be set by Callback 0x36.
+	bool cached_tilt = false; ///< train can tilt; feature provides a bonus in curves
+	uint8_t user_def_data = 0; ///< Cached property 0x25. Can be set by Callback 0x36.
 
-	int16_t cached_curve_speed_mod; ///< curve speed modifier of the entire train
-	uint16_t cached_max_curve_speed; ///< max consist speed limited by curves
+	int16_t cached_curve_speed_mod = 0; ///< curve speed modifier of the entire train
+	uint16_t cached_max_curve_speed = 0; ///< max consist speed limited by curves
 
 	auto operator<=>(const TrainCache &) const = default;
 };
@@ -87,20 +87,20 @@ struct TrainCache {
  * 'Train' is either a loco or a wagon.
  */
 struct Train final : public GroundVehicle<Train, VEH_TRAIN> {
-	uint16_t flags;
-	uint16_t crash_anim_pos; ///< Crash animation counter.
-	uint16_t wait_counter; ///< Ticks waiting in front of a signal, ticks being stuck or a counter for forced proceeding through signals.
+	uint16_t flags = 0;
+	uint16_t crash_anim_pos = 0; ///< Crash animation counter.
+	uint16_t wait_counter = 0; ///< Ticks waiting in front of a signal, ticks being stuck or a counter for forced proceeding through signals.
 
-	TrainCache tcache;
+	TrainCache tcache{};
 
 	/* Link between the two ends of a multiheaded engine */
-	Train *other_multiheaded_part;
+	Train *other_multiheaded_part = nullptr;
 
-	RailTypes compatible_railtypes;
-	RailType railtype;
+	RailTypes compatible_railtypes{};
+	RailType railtype = INVALID_RAILTYPE;
 
-	TrackBits track;
-	TrainForceProceeding force_proceed;
+	TrackBits track{};
+	TrainForceProceeding force_proceed{};
 
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
 	Train() : GroundVehicleBase() {}

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -67,12 +67,12 @@ enum NewGRFCacheValidValues : uint8_t {
 /** Cached often queried (NewGRF) values */
 struct NewGRFCache {
 	/* Values calculated when they are requested for the first time after invalidating the NewGRF cache. */
-	uint32_t position_consist_length;   ///< Cache for NewGRF var 40.
-	uint32_t position_same_id_length;   ///< Cache for NewGRF var 41.
-	uint32_t consist_cargo_information; ///< Cache for NewGRF var 42. (Note: The cargotype is untranslated in the cache because the accessing GRF is yet unknown.)
-	uint32_t company_information;       ///< Cache for NewGRF var 43.
-	uint32_t position_in_vehicle;       ///< Cache for NewGRF var 4D.
-	uint8_t  cache_valid;               ///< Bitset that indicates which cache values are valid.
+	uint32_t position_consist_length = 0; ///< Cache for NewGRF var 40.
+	uint32_t position_same_id_length = 0; ///< Cache for NewGRF var 41.
+	uint32_t consist_cargo_information = 0; ///< Cache for NewGRF var 42. (Note: The cargotype is untranslated in the cache because the accessing GRF is yet unknown.)
+	uint32_t company_information = 0; ///< Cache for NewGRF var 43.
+	uint32_t position_in_vehicle = 0; ///< Cache for NewGRF var 4D.
+	uint8_t  cache_valid = 0; ///< Bitset that indicates which cache values are valid.
 
 	auto operator<=>(const NewGRFCache &) const = default;
 };
@@ -123,10 +123,10 @@ enum GroundVehicleSubtypeFlags : uint8_t {
 
 /** Cached often queried values common to all vehicles. */
 struct VehicleCache {
-	uint16_t cached_max_speed;        ///< Maximum speed of the consist (minimum of the max speed of all vehicles in the consist).
-	uint16_t cached_cargo_age_period; ///< Number of ticks before carried cargo is aged.
+	uint16_t cached_max_speed = 0; ///< Maximum speed of the consist (minimum of the max speed of all vehicles in the consist).
+	uint16_t cached_cargo_age_period = 0; ///< Number of ticks before carried cargo is aged.
 
-	uint8_t cached_vis_effect;  ///< Visual effect to show (see #VisualEffect)
+	uint8_t cached_vis_effect = 0;  ///< Visual effect to show (see #VisualEffect)
 
 	auto operator<=>(const VehicleCache &) const = default;
 };
@@ -188,11 +188,11 @@ struct VehicleSpriteSeq {
  * or calculating the viewport.
  */
 struct MutableSpriteCache {
-	Direction last_direction;     ///< Last direction we obtained sprites for
-	bool revalidate_before_draw;  ///< We need to do a GetImage() and check bounds before drawing this sprite
-	bool is_viewport_candidate;   ///< This vehicle can potentially be drawn on a viewport
-	Rect old_coord;               ///< Co-ordinates from the last valid bounding box
-	VehicleSpriteSeq sprite_seq;  ///< Vehicle appearance.
+	Direction last_direction = INVALID_DIR; ///< Last direction we obtained sprites for
+	bool revalidate_before_draw = false; ///< We need to do a GetImage() and check bounds before drawing this sprite
+	bool is_viewport_candidate = false; ///< This vehicle can potentially be drawn on a viewport
+	Rect old_coord{}; ///< Co-ordinates from the last valid bounding box
+	VehicleSpriteSeq sprite_seq{}; ///< Vehicle appearance.
 };
 
 /** A vehicle pool for a little over 1 million vehicles. */
@@ -239,12 +239,12 @@ struct Vehicle : VehiclePool::PoolItem<&_vehicle_pool>, BaseVehicle, BaseConsist
 private:
 	typedef std::list<RefitDesc> RefitList;
 
-	Vehicle *next;                      ///< pointer to the next vehicle in the chain
-	Vehicle *previous;                  ///< NOSAVE: pointer to the previous vehicle in the chain
-	Vehicle *first;                     ///< NOSAVE: pointer to the first vehicle in the chain
+	Vehicle *next = nullptr; ///< pointer to the next vehicle in the chain
+	Vehicle *previous = nullptr; ///< NOSAVE: pointer to the previous vehicle in the chain
+	Vehicle *first = nullptr; ///< NOSAVE: pointer to the first vehicle in the chain
 
-	Vehicle *next_shared;               ///< pointer to the next vehicle that shares the order
-	Vehicle *previous_shared;           ///< NOSAVE: pointer to the previous vehicle in the shared order chain
+	Vehicle *next_shared = nullptr; ///< pointer to the next vehicle that shares the order
+	Vehicle *previous_shared = nullptr; ///< NOSAVE: pointer to the previous vehicle in the shared order chain
 
 public:
 	friend void FixOldVehicles(LoadgameState &ls);
@@ -255,111 +255,111 @@ public:
 	friend class SlVehicleDisaster;
 	friend void Ptrs_VEHS();
 
-	TileIndex tile;                     ///< Current tile index
+	TileIndex tile = INVALID_TILE; ///< Current tile index
 
 	/**
 	 * Heading for this tile.
 	 * For airports and train stations this tile does not necessarily belong to the destination station,
 	 * but it can be used for heuristic purposes to estimate the distance.
 	 */
-	TileIndex dest_tile;
+	TileIndex dest_tile = INVALID_TILE;
 
-	Money profit_this_year;             ///< Profit this year << 8, low 8 bits are fract
-	Money profit_last_year;             ///< Profit last year << 8, low 8 bits are fract
-	Money value;                        ///< Value of the vehicle
+	Money profit_this_year = 0; ///< Profit this year << 8, low 8 bits are fract
+	Money profit_last_year = 0; ///< Profit last year << 8, low 8 bits are fract
+	Money value = 0; ///< Value of the vehicle
 
-	CargoPayment *cargo_payment;        ///< The cargo payment we're currently in
+	CargoPayment *cargo_payment = nullptr; ///< The cargo payment we're currently in
 
-	mutable Rect coord;                 ///< NOSAVE: Graphical bounding box of the vehicle, i.e. what to redraw on moves.
+	mutable Rect coord{}; ///< NOSAVE: Graphical bounding box of the vehicle, i.e. what to redraw on moves.
 
-	Vehicle *hash_viewport_next;        ///< NOSAVE: Next vehicle in the visual location hash.
-	Vehicle **hash_viewport_prev;       ///< NOSAVE: Previous vehicle in the visual location hash.
+	Vehicle *hash_viewport_next = nullptr; ///< NOSAVE: Next vehicle in the visual location hash.
+	Vehicle **hash_viewport_prev = nullptr; ///< NOSAVE: Previous vehicle in the visual location hash.
 
-	Vehicle *hash_tile_next;            ///< NOSAVE: Next vehicle in the tile location hash.
-	Vehicle **hash_tile_prev;           ///< NOSAVE: Previous vehicle in the tile location hash.
-	Vehicle **hash_tile_current;        ///< NOSAVE: Cache of the current hash chain.
+	Vehicle *hash_tile_next = nullptr; ///< NOSAVE: Next vehicle in the tile location hash.
+	Vehicle **hash_tile_prev = nullptr; ///< NOSAVE: Previous vehicle in the tile location hash.
+	Vehicle **hash_tile_current = nullptr; ///< NOSAVE: Cache of the current hash chain.
 
-	SpriteID colourmap;                 ///< NOSAVE: cached colour mapping
+	SpriteID colourmap{}; ///< NOSAVE: cached colour mapping
 
 	/* Related to age and service time */
-	TimerGameCalendar::Year build_year;           ///< Year the vehicle has been built.
-	TimerGameCalendar::Date age;                  ///< Age in calendar days.
-	TimerGameEconomy::Date economy_age;           ///< Age in economy days.
-	TimerGameCalendar::Date max_age;              ///< Maximum age
-	TimerGameEconomy::Date date_of_last_service; ///< Last economy date the vehicle had a service at a depot.
-	TimerGameCalendar::Date date_of_last_service_newgrf; ///< Last calendar date the vehicle had a service at a depot, unchanged by the date cheat to protect against unsafe NewGRF behavior.
-	uint16_t reliability;                 ///< Reliability.
-	uint16_t reliability_spd_dec;         ///< Reliability decrease speed.
-	uint8_t breakdown_ctr;                 ///< Counter for managing breakdown events. @see Vehicle::HandleBreakdown
-	uint8_t breakdown_delay;               ///< Counter for managing breakdown length.
-	uint8_t breakdowns_since_last_service; ///< Counter for the amount of breakdowns.
-	uint8_t breakdown_chance;              ///< Current chance of breakdowns.
+	TimerGameCalendar::Year build_year{}; ///< Year the vehicle has been built.
+	TimerGameCalendar::Date age{}; ///< Age in calendar days.
+	TimerGameEconomy::Date economy_age{}; ///< Age in economy days.
+	TimerGameCalendar::Date max_age{}; ///< Maximum age
+	TimerGameEconomy::Date date_of_last_service{}; ///< Last economy date the vehicle had a service at a depot.
+	TimerGameCalendar::Date date_of_last_service_newgrf{}; ///< Last calendar date the vehicle had a service at a depot, unchanged by the date cheat to protect against unsafe NewGRF behavior.
+	uint16_t reliability = 0; ///< Reliability.
+	uint16_t reliability_spd_dec = 0; ///< Reliability decrease speed.
+	uint8_t breakdown_ctr = 0; ///< Counter for managing breakdown events. @see Vehicle::HandleBreakdown
+	uint8_t breakdown_delay = 0; ///< Counter for managing breakdown length.
+	uint8_t breakdowns_since_last_service = 0; ///< Counter for the amount of breakdowns.
+	uint8_t breakdown_chance = 0; ///< Current chance of breakdowns.
 
-	int32_t x_pos;                        ///< x coordinate.
-	int32_t y_pos;                        ///< y coordinate.
-	int32_t z_pos;                        ///< z coordinate.
-	Direction direction;                ///< facing
+	int32_t x_pos = 0; ///< x coordinate.
+	int32_t y_pos = 0; ///< y coordinate.
+	int32_t z_pos = 0; ///< z coordinate.
+	Direction direction = INVALID_DIR; ///< facing
 
-	Owner owner;                        ///< Which company owns the vehicle?
+	Owner owner = INVALID_OWNER; ///< Which company owns the vehicle?
 	/**
 	 * currently displayed sprite index
 	 * 0xfd == custom sprite, 0xfe == custom second head sprite
 	 * 0xff == reserved for another custom sprite
 	 */
-	uint8_t spritenum;
-	uint8_t x_extent;                      ///< x-extent of vehicle bounding box
-	uint8_t y_extent;                      ///< y-extent of vehicle bounding box
-	uint8_t z_extent;                      ///< z-extent of vehicle bounding box
-	int8_t x_bb_offs;                     ///< x offset of vehicle bounding box
-	int8_t y_bb_offs;                     ///< y offset of vehicle bounding box
-	int8_t x_offs;                        ///< x offset for vehicle sprite
-	int8_t y_offs;                        ///< y offset for vehicle sprite
-	EngineID engine_type;               ///< The type of engine used for this vehicle.
+	uint8_t spritenum = 0;
+	uint8_t x_extent = 0; ///< x-extent of vehicle bounding box
+	uint8_t y_extent = 0; ///< y-extent of vehicle bounding box
+	uint8_t z_extent = 0; ///< z-extent of vehicle bounding box
+	int8_t x_bb_offs = 0; ///< x offset of vehicle bounding box
+	int8_t y_bb_offs = 0; ///< y offset of vehicle bounding box
+	int8_t x_offs = 0; ///< x offset for vehicle sprite
+	int8_t y_offs = 0; ///< y offset for vehicle sprite
+	EngineID engine_type = EngineID::Invalid(); ///< The type of engine used for this vehicle.
 
-	TextEffectID fill_percent_te_id;    ///< a text-effect id to a loading indicator object
-	UnitID unitnumber;                  ///< unit number, for display purposes only
+	TextEffectID fill_percent_te_id = INVALID_TE_ID; ///< a text-effect id to a loading indicator object
+	UnitID unitnumber{}; ///< unit number, for display purposes only
 
-	uint16_t cur_speed;                   ///< current speed
-	uint8_t subspeed;                      ///< fractional speed
-	uint8_t acceleration;                  ///< used by train & aircraft
-	uint32_t motion_counter;              ///< counter to occasionally play a vehicle sound.
-	uint8_t progress;                      ///< The percentage (if divided by 256) this vehicle already crossed the tile unit.
+	uint16_t cur_speed = 0; ///< current speed
+	uint8_t subspeed = 0; ///< fractional speed
+	uint8_t acceleration = 0; ///< used by train & aircraft
+	uint32_t motion_counter = 0; ///< counter to occasionally play a vehicle sound.
+	uint8_t progress = 0; ///< The percentage (if divided by 256) this vehicle already crossed the tile unit.
 
-	uint8_t waiting_triggers;              ///< Triggers to be yet matched before rerandomizing the random bits.
-	uint16_t random_bits; ///< Bits used for randomized variational spritegroups.
+	uint8_t waiting_triggers = 0; ///< Triggers to be yet matched before rerandomizing the random bits.
+	uint16_t random_bits = 0; ///< Bits used for randomized variational spritegroups.
 
-	StationID last_station_visited;     ///< The last station we stopped at.
-	StationID last_loading_station;     ///< Last station the vehicle has stopped at and could possibly leave from with any cargo loaded.
-	TimerGameTick::TickCounter last_loading_tick; ///< Last TimerGameTick::counter tick that the vehicle has stopped at a station and could possibly leave with any cargo loaded.
+	StationID last_station_visited = StationID::Invalid(); ///< The last station we stopped at.
+	StationID last_loading_station = StationID::Invalid(); ///< Last station the vehicle has stopped at and could possibly leave from with any cargo loaded.
+	TimerGameTick::TickCounter last_loading_tick{}; ///< Last TimerGameTick::counter tick that the vehicle has stopped at a station and could possibly leave with any cargo loaded.
 
-	VehicleCargoList cargo;             ///< The cargo this vehicle is carrying
-	CargoType cargo_type;                 ///< type of cargo this vehicle is carrying
-	uint8_t cargo_subtype;                 ///< Used for livery refits (NewGRF variations)
-	uint16_t cargo_cap;                   ///< total capacity
-	uint16_t refit_cap;                   ///< Capacity left over from before last refit.
-	uint16_t cargo_age_counter;           ///< Ticks till cargo is aged next.
-	int8_t trip_occupancy;                ///< NOSAVE: Occupancy of vehicle of the current trip (updated after leaving a station).
+	VehicleCargoList cargo{}; ///< The cargo this vehicle is carrying
+	CargoType cargo_type{}; ///< type of cargo this vehicle is carrying
+	uint8_t cargo_subtype = 0; ///< Used for livery refits (NewGRF variations)
+	uint16_t cargo_cap = 0; ///< total capacity
+	uint16_t refit_cap = 0; ///< Capacity left over from before last refit.
+	uint16_t cargo_age_counter = 0; ///< Ticks till cargo is aged next.
+	int8_t trip_occupancy = 0; ///< NOSAVE: Occupancy of vehicle of the current trip (updated after leaving a station).
 
-	uint8_t day_counter;                   ///< Increased by one for each day
-	uint8_t tick_counter;                  ///< Increased by one for each tick
-	uint8_t running_ticks;                 ///< Number of ticks this vehicle was not stopped this day
-	uint16_t load_unload_ticks;           ///< Ticks to wait before starting next cycle.
+	uint8_t day_counter = 0; ///< Increased by one for each day
+	uint8_t tick_counter = 0; ///< Increased by one for each tick
+	uint8_t running_ticks = 0; ///< Number of ticks this vehicle was not stopped this day
+	uint16_t load_unload_ticks = 0; ///< Ticks to wait before starting next cycle.
 
-	uint8_t vehstatus;                     ///< Status
-	uint8_t subtype;                       ///< subtype (Filled with values from #AircraftSubType/#DisasterSubType/#EffectVehicleType/#GroundVehicleSubtypeFlags)
-	Order current_order;                ///< The current order (+ status, like: loading)
+	uint8_t vehstatus = 0; ///< Status
+	uint8_t subtype = 0; ///< subtype (Filled with values from #AircraftSubType/#DisasterSubType/#EffectVehicleType/#GroundVehicleSubtypeFlags)
+	Order current_order{}; ///< The current order (+ status, like: loading)
 
 	union {
-		OrderList *orders;              ///< Pointer to the order list for this vehicle
-		Order *old_orders;              ///< Only used during conversion of old save games
+		OrderList *orders = nullptr; ///< Pointer to the order list for this vehicle
+		Order *old_orders; ///< Only used during conversion of old save games
 	};
 
-	NewGRFCache grf_cache;              ///< Cache of often used calculated NewGRF values
-	VehicleCache vcache;                ///< Cache of often used vehicle values.
+	NewGRFCache grf_cache{}; ///< Cache of often used calculated NewGRF values
+	VehicleCache vcache{}; ///< Cache of often used vehicle values.
 
-	GroupID group_id;                   ///< Index of group Pool array
+	GroupID group_id = GroupID::Invalid(); ///< Index of group Pool array
 
-	mutable MutableSpriteCache sprite_cache; ///< Cache of sprites and values related to recalculating them, see #MutableSpriteCache
+	mutable MutableSpriteCache sprite_cache{}; ///< Cache of sprites and values related to recalculating them, see #MutableSpriteCache
 
 	/**
 	 * Calculates the weight value that this vehicle will have when fully loaded with its current cargo.

--- a/src/vehicle_type.h
+++ b/src/vehicle_type.h
@@ -47,9 +47,8 @@ struct EffectVehicle;
 struct DisasterVehicle;
 
 /** Base vehicle class. */
-struct BaseVehicle
-{
-	VehicleType type; ///< Type of vehicle
+struct BaseVehicle {
+	VehicleType type = VEH_INVALID; ///< Type of vehicle
 };
 
 /** Flags for goto depot commands. */


### PR DESCRIPTION
## Motivation / Problem

If we want to get rid of `CallocT`, the pool items needs to stop relying on it. So all pool items should explicitly initialise their member variable, be it `0`, `nullptr`, or anything else. That way we don't need to zero everything first.


## Description

Explicitly initialise the member variables, in this case of `VehicleBase` and everything under that: `Aircraft`, `BaseConsist`, `BaseVehicle`, `DisasterVehicle`, `GroundVehicle`, `RoadVehicle`, `Ship`, and `Train`.


## Limitations

The pool is still `CallocT`-ing first, but this class does not depend on it any more.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
