### PR TITLE
Codechange: explicitly initialise network pool item related member variables

### DIFF
--- a/src/network/core/tcp.h
+++ b/src/network/core/tcp.h
@@ -30,7 +30,7 @@ enum SendPacketsState : uint8_t {
 /** Base socket handler for all TCP sockets */
 class NetworkTCPSocketHandler : public NetworkSocketHandler {
 private:
-	std::deque<std::unique_ptr<Packet>> packet_queue; ///< Packets that are awaiting delivery. Cannot be std::queue as that does not have a clear() function.
+	std::deque<std::unique_ptr<Packet>> packet_queue{}; ///< Packets that are awaiting delivery. Cannot be std::queue as that does not have a clear() function.
 	std::unique_ptr<Packet> packet_recv = nullptr; ///< Partially received packet
 
 	void EmptyPacketQueue();

--- a/src/network/core/tcp_admin.h
+++ b/src/network/core/tcp_admin.h
@@ -116,8 +116,8 @@ enum AdminCompanyRemoveReason : uint8_t {
 /** Main socket handler for admin related connections. */
 class NetworkAdminSocketHandler : public NetworkTCPSocketHandler {
 protected:
-	std::string admin_name; ///< Name of the admin.
-	std::string admin_version; ///< Version string of the admin.
+	std::string admin_name{}; ///< Name of the admin.
+	std::string admin_version{}; ///< Version string of the admin.
 	AdminStatus status = ADMIN_STATUS_INACTIVE; ///< Status of this admin.
 
 	NetworkRecvStatus ReceiveInvalidPacket(PacketAdminType type);

--- a/src/network/network_admin.h
+++ b/src/network/network_admin.h
@@ -24,7 +24,7 @@ extern NetworkAdminSocketPool _networkadminsocket_pool;
 /** Class for handling the server side of the game connection. */
 class ServerNetworkAdminSocketHandler : public NetworkAdminSocketPool::PoolItem<&_networkadminsocket_pool>, public NetworkAdminSocketHandler, public TCPListenHandler<ServerNetworkAdminSocketHandler, ADMIN_PACKET_SERVER_FULL, ADMIN_PACKET_SERVER_BANNED> {
 private:
-	std::unique_ptr<NetworkAuthenticationServerHandler> authentication_handler; ///< The handler for the authentication.
+	std::unique_ptr<NetworkAuthenticationServerHandler> authentication_handler = nullptr; ///< The handler for the authentication.
 protected:
 	NetworkRecvStatus Receive_ADMIN_JOIN(Packet &p) override;
 	NetworkRecvStatus Receive_ADMIN_QUIT(Packet &p) override;
@@ -43,9 +43,9 @@ protected:
 	NetworkRecvStatus SendAuthRequest();
 	NetworkRecvStatus SendEnableEncryption();
 public:
-	AdminUpdateFrequency update_frequency[ADMIN_UPDATE_END]; ///< Admin requested update intervals.
-	std::chrono::steady_clock::time_point connect_time;      ///< Time of connection.
-	NetworkAddress address;                                  ///< Address of the admin.
+	std::array<AdminUpdateFrequency, ADMIN_UPDATE_END> update_frequency{}; ///< Admin requested update intervals.
+	std::chrono::steady_clock::time_point connect_time{}; ///< Time of connection.
+	NetworkAddress address{}; ///< Address of the admin.
 
 	ServerNetworkAdminSocketHandler(SOCKET s);
 	~ServerNetworkAdminSocketHandler();

--- a/src/network/network_base.h
+++ b/src/network/network_base.h
@@ -22,11 +22,11 @@ extern NetworkClientInfoPool _networkclientinfo_pool;
 
 /** Container for all information known about a client. */
 struct NetworkClientInfo : NetworkClientInfoPool::PoolItem<&_networkclientinfo_pool> {
-	ClientID client_id;      ///< Client identifier (same as ClientState->client_id)
-	std::string client_name; ///< Name of the client
-	std::string public_key; ///< The public key of the client.
-	CompanyID client_playas; ///< As which company is this client playing (CompanyID)
-	TimerGameEconomy::Date join_date; ///< Gamedate the client has joined
+	ClientID client_id = INVALID_CLIENT_ID; ///< Client identifier (same as ClientState->client_id)
+	std::string client_name{}; ///< Name of the client
+	std::string public_key{}; ///< The public key of the client.
+	CompanyID client_playas = CompanyID::Invalid(); ///< As which company is this client playing (CompanyID)
+	TimerGameEconomy::Date join_date{}; ///< Gamedate the client has joined
 
 	/**
 	 * Create a new client.

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -24,7 +24,7 @@ extern NetworkClientSocketPool _networkclientsocket_pool;
 class ServerNetworkGameSocketHandler : public NetworkClientSocketPool::PoolItem<&_networkclientsocket_pool>, public NetworkGameSocketHandler, public TCPListenHandler<ServerNetworkGameSocketHandler, PACKET_SERVER_FULL, PACKET_SERVER_BANNED> {
 protected:
 	std::unique_ptr<class NetworkAuthenticationServerHandler> authentication_handler = nullptr; ///< The handler for the authentication.
-	std::string peer_public_key; ///< The public key of our client.
+	std::string peer_public_key{}; ///< The public key of our client.
 
 	NetworkRecvStatus Receive_CLIENT_JOIN(Packet &p) override;
 	NetworkRecvStatus Receive_CLIENT_IDENTIFY(Packet &p) override;
@@ -68,7 +68,7 @@ public:
 	uint8_t last_token = 0; ///< The last random token we did send to verify the client is listening
 	uint32_t last_token_frame = 0; ///< The last frame we received the right token
 	ClientStatus status = STATUS_INACTIVE; ///< Status of this client
-	CommandQueue outgoing_queue; ///< The command-queue awaiting delivery; conceptually more a bucket to gather commands in, after which the whole bucket is sent to the client.
+	CommandQueue outgoing_queue{}; ///< The command-queue awaiting delivery; conceptually more a bucket to gather commands in, after which the whole bucket is sent to the client.
 	size_t receive_limit = 0; ///< Amount of bytes that we can receive at this moment
 
 	std::shared_ptr<struct PacketWriter> savegame = nullptr; ///< Writer used to write the savegame.


### PR DESCRIPTION
## Motivation / Problem

If we want to get rid of `CallocT`, the pool items needs to stop relying on it. So all pool items should explicitly initialise their member variable, be it `0`, `nullptr`, or anything else. That way we don't need to zero everything first.


## Description

Explicitly initialise the member variables, in this case of `ServerNetworkAdminSocketHandler`, `ServerNetworkGameSocketHandler` and `NetworkClientInfo`. Most of them were already explicitly initialised.


## Limitations

The pool is still `CallocT`-ing first, but this class does not depend on it any more.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
