### PR TITLE
Fix (#13454): Edited GetClearGround(Tile t) function

### DIFF
--- a/src/clear_map.h
+++ b/src/clear_map.h
@@ -58,6 +58,7 @@ inline ClearGround GetRawClearGround(Tile t)
  */
 inline ClearGround GetClearGround(Tile t)
 {
+	if (GetRawClearGround(t) == CLEAR_ROCKS) return CLEAR_ROCKS;
 	if (IsSnowTile(t)) return CLEAR_SNOW;
 	return GetRawClearGround(t);
 }


### PR DESCRIPTION
Commit message:
Fix (#13454): Edited GetClearGround(Tile t) function

## Motivation / Problem
https://github.com/OpenTTD/OpenTTD/issues/13454


## Description
The GetClearGround(Tile t) function would automatically return CLEAR_SNOW if it was a snow tile which would cause CLEAR_ROCKS to be unable to spawn in the same tile as snow, so to fix this I added an if statement to check if the raw data was CLEAR_ROCKS and then returned CLEAR_ROCKS if it was.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)

