### PR TITLE
Codechange: use std::vector/std::span over MallocT for NewGRF bridge sprites

### DIFF
--- a/src/bridge.h
+++ b/src/bridge.h
@@ -50,7 +50,7 @@ struct BridgeSpec {
 	PaletteID pal;                      ///< the palette which is used in the GUI
 	StringID material;                  ///< the string that contains the bridge description
 	StringID transport_name[2];         ///< description of the bridge, when built for road or rail
-	PalSpriteID **sprite_table;         ///< table of sprites for drawing the bridge
+	std::vector<std::vector<PalSpriteID>> sprite_table; ///< table of sprites for drawing the bridge
 	uint8_t flags;                         ///< bit 0 set: disable drawing of far pillars.
 };
 

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -2376,10 +2376,11 @@ static ChangeInfoResult BridgeChangeInfo(uint first, uint last, int prop, ByteRe
 			case 0x0D: { // Bridge sprite tables
 				uint8_t tableid = buf.ReadByte();
 				uint8_t numtables = buf.ReadByte();
+				size_t size = tableid + numtables;
 
-				if (bridge->sprite_table == nullptr) {
+				if (bridge->sprite_table.size() < size) {
 					/* Allocate memory for sprite table pointers and zero out */
-					bridge->sprite_table = CallocT<PalSpriteID*>(NUM_BRIDGE_PIECES);
+					bridge->sprite_table.resize(std::min<size_t>(size, NUM_BRIDGE_PIECES));
 				}
 
 				for (; numtables-- != 0; tableid++) {
@@ -2389,8 +2390,8 @@ static ChangeInfoResult BridgeChangeInfo(uint first, uint last, int prop, ByteRe
 						continue;
 					}
 
-					if (bridge->sprite_table[tableid] == nullptr) {
-						bridge->sprite_table[tableid] = MallocT<PalSpriteID>(SPRITES_PER_BRIDGE_PIECE);
+					if (bridge->sprite_table[tableid].empty()) {
+						bridge->sprite_table[tableid].resize(SPRITES_PER_BRIDGE_PIECE);
 					}
 
 					for (uint8_t sprite = 0; sprite < SPRITES_PER_BRIDGE_PIECE; sprite++) {

--- a/src/table/bridge_land.h
+++ b/src/table/bridge_land.h
@@ -579,7 +579,7 @@ static const PalSpriteID _bridge_sprite_table_12_2[] = {
 	{  0xA1F, PALETTE_TO_STRUCT_CONCRETE }, {     0xA03, PALETTE_TO_STRUCT_CONCRETE }, {     0xA07, PALETTE_TO_STRUCT_CONCRETE }, {       0x0, PAL_NONE },
 };
 
-static const PalSpriteID * const _bridge_sprite_table_archgirder[] = {
+static const std::span<const PalSpriteID> _bridge_sprite_table_archgirder[] = {
 	_bridge_sprite_table_archgirder_middle,
 	_bridge_sprite_table_archgirder_middle,
 	_bridge_sprite_table_archgirder_middle,
@@ -589,7 +589,7 @@ static const PalSpriteID * const _bridge_sprite_table_archgirder[] = {
 	_bridge_sprite_table_archgirder_heads,
 };
 
-static const PalSpriteID * const _bridge_sprite_table_4[] = {
+static const std::span<const PalSpriteID> _bridge_sprite_table_4[] = {
 	_bridge_sprite_table_4_0,
 	_bridge_sprite_table_4_1,
 	_bridge_sprite_table_4_2,
@@ -599,7 +599,7 @@ static const PalSpriteID * const _bridge_sprite_table_4[] = {
 	_bridge_sprite_table_4_6,
 };
 
-static const PalSpriteID * const _bridge_sprite_table_5[] = {
+static const std::span<const PalSpriteID> _bridge_sprite_table_5[] = {
 	_bridge_sprite_table_5_0,
 	_bridge_sprite_table_5_1,
 	_bridge_sprite_table_5_2,
@@ -609,7 +609,7 @@ static const PalSpriteID * const _bridge_sprite_table_5[] = {
 	_bridge_sprite_table_5_6,
 };
 
-static const PalSpriteID * const _bridge_sprite_table_concrete_suspended[] = {
+static const std::span<const PalSpriteID> _bridge_sprite_table_concrete_suspended[] = {
 	_bridge_sprite_table_concrete_suspended_A,
 	_bridge_sprite_table_concrete_suspended_B,
 	_bridge_sprite_table_concrete_suspended_C,
@@ -619,7 +619,7 @@ static const PalSpriteID * const _bridge_sprite_table_concrete_suspended[] = {
 	_bridge_sprite_table_concrete_suspended_heads,
 };
 
-static const PalSpriteID * const _bridge_sprite_table_6[] = {
+static const std::span<const PalSpriteID> _bridge_sprite_table_6[] = {
 	_bridge_sprite_table_6_0,
 	_bridge_sprite_table_6_1,
 	_bridge_sprite_table_6_2,
@@ -629,7 +629,7 @@ static const PalSpriteID * const _bridge_sprite_table_6[] = {
 	_bridge_sprite_table_6_3,
 };
 
-static const PalSpriteID * const _bridge_sprite_table_7[] = {
+static const std::span<const PalSpriteID> _bridge_sprite_table_7[] = {
 	_bridge_sprite_table_7_0,
 	_bridge_sprite_table_7_1,
 	_bridge_sprite_table_7_2,
@@ -639,7 +639,7 @@ static const PalSpriteID * const _bridge_sprite_table_7[] = {
 	_bridge_sprite_table_7_3,
 };
 
-static const PalSpriteID * const _bridge_sprite_table_8[] = {
+static const std::span<const PalSpriteID> _bridge_sprite_table_8[] = {
 	_bridge_sprite_table_8_0,
 	_bridge_sprite_table_8_1,
 	_bridge_sprite_table_8_2,
@@ -649,7 +649,7 @@ static const PalSpriteID * const _bridge_sprite_table_8[] = {
 	_bridge_sprite_table_8_3,
 };
 
-static const PalSpriteID * const _bridge_sprite_table_wood[] = {
+static const std::span<const PalSpriteID> _bridge_sprite_table_wood[] = {
 	_bridge_sprite_table_wood_middle,
 	_bridge_sprite_table_wood_middle,
 	_bridge_sprite_table_wood_middle,
@@ -659,7 +659,7 @@ static const PalSpriteID * const _bridge_sprite_table_wood[] = {
 	_bridge_sprite_table_wood_heads,
 };
 
-static const PalSpriteID * const _bridge_sprite_table_concrete[] = {
+static const std::span<const PalSpriteID> _bridge_sprite_table_concrete[] = {
 	_bridge_sprite_table_concrete_middle,
 	_bridge_sprite_table_concrete_middle,
 	_bridge_sprite_table_concrete_middle,
@@ -669,7 +669,7 @@ static const PalSpriteID * const _bridge_sprite_table_concrete[] = {
 	_bridge_sprite_table_concrete_heads,
 };
 
-static const PalSpriteID * const _bridge_sprite_table_9[] = {
+static const std::span<const PalSpriteID> _bridge_sprite_table_9[] = {
 	_bridge_sprite_table_9_0,
 	_bridge_sprite_table_9_0,
 	_bridge_sprite_table_9_0,
@@ -679,7 +679,7 @@ static const PalSpriteID * const _bridge_sprite_table_9[] = {
 	_bridge_sprite_table_4_6,
 };
 
-static const PalSpriteID * const _bridge_sprite_table_10[] = {
+static const std::span<const PalSpriteID> _bridge_sprite_table_10[] = {
 	_bridge_sprite_table_10_0,
 	_bridge_sprite_table_10_1,
 	_bridge_sprite_table_10_2,
@@ -689,7 +689,7 @@ static const PalSpriteID * const _bridge_sprite_table_10[] = {
 	_bridge_sprite_table_4_6,
 };
 
-static const PalSpriteID * const _bridge_sprite_table_11[] = {
+static const std::span<const PalSpriteID> _bridge_sprite_table_11[] = {
 	_bridge_sprite_table_11_0,
 	_bridge_sprite_table_11_1,
 	_bridge_sprite_table_11_2,
@@ -699,7 +699,7 @@ static const PalSpriteID * const _bridge_sprite_table_11[] = {
 	_bridge_sprite_table_5_6,
 };
 
-static const PalSpriteID * const _bridge_sprite_table_12[] = {
+static const std::span<const PalSpriteID> _bridge_sprite_table_12[] = {
 	_bridge_sprite_table_12_0,
 	_bridge_sprite_table_12_1,
 	_bridge_sprite_table_12_2,
@@ -709,7 +709,7 @@ static const PalSpriteID * const _bridge_sprite_table_12[] = {
 	_bridge_sprite_table_concrete_suspended_heads,
 };
 
-static const PalSpriteID * const * const _bridge_sprite_table[MAX_BRIDGES] = {
+static const std::span<const std::span<const PalSpriteID>> _bridge_sprite_table[MAX_BRIDGES] = {
 	_bridge_sprite_table_wood,
 	_bridge_sprite_table_concrete,
 	_bridge_sprite_table_archgirder,
@@ -739,7 +739,7 @@ static const PalSpriteID * const * const _bridge_sprite_table[MAX_BRIDGES] = {
  * @param nrd description of the road bridge in query tool
  */
 #define MBR(y, mnl, mxl, p, mxs, spr, plt, dsc, nrl, nrd) \
-	{TimerGameCalendar::Year{y}, mnl, mxl, p, mxs, spr, plt, dsc, { nrl, nrd }, nullptr, 0}
+	{TimerGameCalendar::Year{y}, mnl, mxl, p, mxs, spr, plt, dsc, { nrl, nrd }, {}, 0}
 
 const BridgeSpec _orig_bridge[] = {
 /*


### PR DESCRIPTION
## Motivation / Problem

One of the last vestiges of `CallocT` and `MallocT` in the source code.


## Description

* Make `_orig_bridges` a `std::span` of `std::span`
* Let `GetBridgeSpriteTable` return a `std::span`.
* Let the bridge sprite table become a `std::vector` of `std::vector`, that are only allocated when needed.


## Limitations

You could consider making `psid` in `DrawTile_TunnelBridge` a reference, so there's no need to index the span and get a pointer. However, references can only be set at declaration and here it's being set in two branches of an `if`-statement.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
