### PR TITLE
Codechange: remove ZeroedMemoryAllocator from NWidgetBase

### DIFF
--- a/src/core/geometry_type.hpp
+++ b/src/core/geometry_type.hpp
@@ -49,10 +49,10 @@ struct Dimension {
 
 /** Padding dimensions to apply to each side of a Rect. */
 struct RectPadding {
-	uint8_t left;
-	uint8_t top;
-	uint8_t right;
-	uint8_t bottom;
+	uint8_t left = 0;
+	uint8_t top = 0;
+	uint8_t right = 0;
+	uint8_t bottom = 0;
 
 	static const RectPadding zero;
 

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1561,16 +1561,15 @@ public:
 	static const uint MAX_EXTRA_INFO_WIDTH;    ///< Maximal additional width given to the panel.
 	static const uint MIN_EXTRA_FOR_3_COLUMNS; ///< Minimal additional width needed before switching to 3 columns.
 
-	std::unique_ptr<NWidgetBase> avs; ///< Widget with the available grfs list and buttons.
-	std::unique_ptr<NWidgetBase> acs; ///< Widget with the active grfs list and buttons.
-	std::unique_ptr<NWidgetBase> inf; ///< Info panel.
-	bool editable;    ///< Editable status of the parent NewGRF window (if \c false, drop all widgets that make the window editable).
+	std::unique_ptr<NWidgetBase> avs{}; ///< Widget with the available grfs list and buttons.
+	std::unique_ptr<NWidgetBase> acs{}; ///< Widget with the active grfs list and buttons.
+	std::unique_ptr<NWidgetBase> inf{}; ///< Info panel.
+	bool editable = true; ///< Editable status of the parent NewGRF window (if \c false, drop all widgets that make the window editable).
 
 	NWidgetNewGRFDisplay(std::unique_ptr<NWidgetBase> &&avs, std::unique_ptr<NWidgetBase> &&acs, std::unique_ptr<NWidgetBase> &&inf) : NWidgetBase(NWID_CUSTOM)
 		, avs(std::move(avs))
 		, acs(std::move(acs))
 		, inf(std::move(inf))
-		, editable(true) // Temporary setting, 'real' value is set in SetupSmallestSize().
 	{
 	}
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -343,7 +343,7 @@ public:
 
 private:
 	int current_index = -1;
-	std::vector<SocialIntegrationPlugin *> plugins;
+	std::vector<SocialIntegrationPlugin *> plugins{};
 };
 
 /** Construct nested container widget for managing the list of social plugins. */

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -1908,12 +1908,9 @@ int SmallMapWindow::map_height_limit = -1;
  *       The bar should have a minimal size with a zero-size legends display. Child padding is not supported.
  */
 class NWidgetSmallmapDisplay : public NWidgetContainer {
-	const SmallMapWindow *smallmap_window; ///< Window manager instance.
+	const SmallMapWindow *smallmap_window = nullptr; ///< Window manager instance.
 public:
-	NWidgetSmallmapDisplay() : NWidgetContainer(NWID_VERTICAL)
-	{
-		this->smallmap_window = nullptr;
-	}
+	NWidgetSmallmapDisplay() : NWidgetContainer(NWID_VERTICAL) {}
 
 	void SetupSmallestSize(Window *w) override
 	{

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -1367,7 +1367,7 @@ static MenuClickedProc * const _menu_clicked_procs[] = {
 /** Full blown container to make it behave exactly as we want :) */
 class NWidgetToolbarContainer : public NWidgetContainer {
 protected:
-	uint spacers;          ///< Number of spacer widgets in this toolbar
+	uint spacers = 0; ///< Number of spacer widgets in this toolbar
 
 public:
 	NWidgetToolbarContainer() : NWidgetContainer(NWID_HORIZONTAL)
@@ -1832,20 +1832,21 @@ class NWidgetMainToolbarContainer : public NWidgetToolbarContainer {
 
 /** Container for the scenario editor's toolbar */
 class NWidgetScenarioToolbarContainer : public NWidgetToolbarContainer {
-	uint panel_widths[2]; ///< The width of the two panels (the text panel and date panel)
+	std::array<uint, 2> panel_widths{}; ///< The width of the two panels (the text panel and date panel)
 
 	void SetupSmallestSize(Window *w) override
 	{
 		this->NWidgetToolbarContainer::SetupSmallestSize(w);
 
 		/* Find the size of panel_widths */
-		uint i = 0;
+		auto it = this->panel_widths.begin();
 		for (const auto &child_wid : this->children) {
 			if (child_wid->type == NWID_SPACER || this->IsButton(child_wid->type)) continue;
 
-			assert(i < lengthof(this->panel_widths));
-			this->panel_widths[i++] = child_wid->current_x;
+			assert(it != this->panel_widths.end());
+			*it = child_wid->current_x;
 			_toolbar_width += child_wid->current_x;
+			++it;
 		}
 	}
 
@@ -1919,7 +1920,7 @@ class NWidgetScenarioToolbarContainer : public NWidgetToolbarContainer {
 		};
 
 		/* If we can place all buttons *and* the panels, show them. */
-		uint min_full_width = (lengthof(arrange_all) - lengthof(this->panel_widths)) * this->smallest_x + this->panel_widths[0] + this->panel_widths[1];
+		size_t min_full_width = (lengthof(arrange_all) - std::size(this->panel_widths)) * this->smallest_x + this->panel_widths[0] + this->panel_widths[1];
 		if (width >= min_full_width) {
 			width -= this->panel_widths[0] + this->panel_widths[1];
 			arrangable_count = lengthof(arrange_all);
@@ -1929,7 +1930,7 @@ class NWidgetScenarioToolbarContainer : public NWidgetToolbarContainer {
 		}
 
 		/* Otherwise don't show the date panel and if we can't fit half the buttons and the panels anymore, split the toolbar in two */
-		uint min_small_width = (lengthof(arrange_switch) - lengthof(this->panel_widths)) * this->smallest_x / 2 + this->panel_widths[1];
+		size_t min_small_width = (lengthof(arrange_switch) - std::size(this->panel_widths)) * this->smallest_x / 2 + this->panel_widths[1];
 		if (width > min_small_width) {
 			width -= this->panel_widths[1];
 			arrangable_count = lengthof(arrange_nopanel);

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -845,17 +845,6 @@ static void DrawOutline(const Window *, const NWidgetBase *wid)
  */
 
 /**
- * Base class constructor.
- * @param tp Nested widget type.
- */
-NWidgetBase::NWidgetBase(WidgetType tp) : ZeroedMemoryAllocator()
-{
-	this->type = tp;
-}
-
-/* ~NWidgetContainer() takes care of #next and #prev data members. */
-
-/**
  * @fn void NWidgetBase::SetupSmallestSize(Window *w)
  * Compute smallest size needed by the widget.
  *
@@ -1116,10 +1105,7 @@ NWidgetCore::NWidgetCore(WidgetType tp, Colours colour, WidgetID index, uint fil
 	this->colour = colour;
 	this->widget_data = widget_data;
 	this->SetToolTip(tool_tip);
-	this->scrollbar_index = -1;
 	this->text_colour = tp == WWT_CAPTION ? TC_WHITE : TC_BLACK;
-	this->text_size = FS_NORMAL;
-	this->align = SA_CENTER;
 }
 
 /**
@@ -1312,13 +1298,6 @@ NWidgetCore *NWidgetContainer::GetWidgetFromPos(int x, int y)
 	return nullptr;
 }
 
-/**
- * Widgets stacked on top of each other.
- */
-NWidgetStacked::NWidgetStacked(WidgetID index) : NWidgetContainer(NWID_SELECTION), index(index)
-{
-}
-
 void NWidgetStacked::SetupSmallestSize(Window *w)
 {
 	/* Zero size plane selected */
@@ -1426,7 +1405,7 @@ bool NWidgetStacked::SetDisplayedPlane(int plane)
 
 class NWidgetLayer : public NWidgetContainer {
 public:
-	NWidgetLayer(WidgetID index);
+	NWidgetLayer(WidgetID index) : NWidgetContainer(NWID_LAYER), index(index) {}
 
 	void SetupSmallestSize(Window *w) override;
 	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;
@@ -1435,8 +1414,6 @@ public:
 
 	const WidgetID index; ///< If non-negative, index in the #Window::widget_lookup.
 };
-
-NWidgetLayer::NWidgetLayer(WidgetID index) : NWidgetContainer(NWID_LAYER), index(index) {}
 
 void NWidgetLayer::SetupSmallestSize(Window *w)
 {
@@ -1947,7 +1924,7 @@ NWidgetCore *NWidgetSpacer::GetWidgetFromPos(int, int)
 	return nullptr;
 }
 
-NWidgetMatrix::NWidgetMatrix(Colours colour, WidgetID index) : NWidgetPIPContainer(NWID_MATRIX, NWidContainerFlag::EqualSize), index(index), clicked(-1), count(-1)
+NWidgetMatrix::NWidgetMatrix(Colours colour, WidgetID index) : NWidgetPIPContainer(NWID_MATRIX, NWidContainerFlag::EqualSize), index(index)
 {
 	this->colour = colour;
 }

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -10,7 +10,6 @@
 #ifndef WIDGET_TYPE_H
 #define WIDGET_TYPE_H
 
-#include "core/alloc_type.hpp"
 #include "core/bitmath_func.hpp"
 #include "core/math_func.hpp"
 #include "strings_type.h"
@@ -132,9 +131,10 @@ using WidgetLookup = std::map<WidgetID, class NWidgetBase *>;
  * @invariant After initialization, \f$current\_y = smallest\_y + m * resize\_y, for m \geq 0\f$.
  * @ingroup NestedWidgets
  */
-class NWidgetBase : public ZeroedMemoryAllocator {
+class NWidgetBase {
 public:
-	NWidgetBase(WidgetType tp);
+	NWidgetBase(WidgetType tp) : type(tp) {}
+	virtual ~NWidgetBase() = default;
 
 	void ApplyAspectRatio();
 	virtual void AdjustPaddingForZoom();
@@ -220,29 +220,29 @@ public:
 		return r;
 	}
 
-	WidgetType type;      ///< Type of the widget / nested widget.
-	uint fill_x;          ///< Horizontal fill stepsize (from initial size, \c 0 means not resizable).
-	uint fill_y;          ///< Vertical fill stepsize (from initial size, \c 0 means not resizable).
-	uint resize_x;        ///< Horizontal resize step (\c 0 means not resizable).
-	uint resize_y;        ///< Vertical resize step (\c 0 means not resizable).
+	WidgetType type{}; ///< Type of the widget / nested widget.
+	uint fill_x = 0; ///< Horizontal fill stepsize (from initial size, \c 0 means not resizable).
+	uint fill_y = 0; ///< Vertical fill stepsize (from initial size, \c 0 means not resizable).
+	uint resize_x = 0; ///< Horizontal resize step (\c 0 means not resizable).
+	uint resize_y = 0; ///< Vertical resize step (\c 0 means not resizable).
 	/* Size of the widget in the smallest window possible.
 	 * Computed by #SetupSmallestSize() followed by #AssignSizePosition().
 	 */
-	uint smallest_x;      ///< Smallest horizontal size of the widget in a filled window.
-	uint smallest_y;      ///< Smallest vertical size of the widget in a filled window.
+	uint smallest_x = 0; ///< Smallest horizontal size of the widget in a filled window.
+	uint smallest_y = 0; ///< Smallest vertical size of the widget in a filled window.
 	/* Current widget size (that is, after resizing). */
-	uint current_x;       ///< Current horizontal size (after resizing).
-	uint current_y;       ///< Current vertical size (after resizing).
+	uint current_x = 0; ///< Current horizontal size (after resizing).
+	uint current_y = 0; ///< Current vertical size (after resizing).
 	float aspect_ratio = 0; ///< Desired aspect ratio of widget.
 	AspectFlags aspect_flags = AspectFlag::ResizeX; ///< Which dimensions can be resized.
 
-	int pos_x;            ///< Horizontal position of top-left corner of the widget in the window.
-	int pos_y;            ///< Vertical position of top-left corner of the widget in the window.
+	int pos_x = 0; ///< Horizontal position of top-left corner of the widget in the window.
+	int pos_y = 0; ///< Vertical position of top-left corner of the widget in the window.
 
-	RectPadding padding;    ///< Padding added to the widget. Managed by parent container widget. (parent container may swap left and right for RTL)
-	RectPadding uz_padding; ///< Unscaled padding, for resize calculation.
+	RectPadding padding{}; ///< Padding added to the widget. Managed by parent container widget. (parent container may swap left and right for RTL)
+	RectPadding uz_padding{}; ///< Unscaled padding, for resize calculation.
 
-	NWidgetBase *parent; ///< Parent widget of this widget, automatically filled in when added to container.
+	NWidgetBase *parent = nullptr; ///< Parent widget of this widget, automatically filled in when added to container.
 
 protected:
 	inline void StoreSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height);
@@ -310,16 +310,16 @@ public:
 
 	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;
 
-	uint min_x; ///< Minimal horizontal size of only this widget.
-	uint min_y; ///< Minimal vertical size of only this widget.
+	uint min_x = 0; ///< Minimal horizontal size of only this widget.
+	uint min_y = 0; ///< Minimal vertical size of only this widget.
 
-	bool absolute; ///< Set if minimum size is fixed and should not be resized.
-	uint uz_min_x; ///< Unscaled Minimal horizontal size of only this widget.
-	uint uz_min_y; ///< Unscaled Minimal vertical size of only this widget.
+	bool absolute = false; ///< Set if minimum size is fixed and should not be resized.
+	uint uz_min_x = 0; ///< Unscaled Minimal horizontal size of only this widget.
+	uint uz_min_y = 0; ///< Unscaled Minimal vertical size of only this widget.
 
-	uint8_t uz_text_lines;   ///< 'Unscaled' text lines, stored for resize calculation.
-	uint8_t uz_text_spacing; ///< 'Unscaled' text padding, stored for resize calculation.
-	FontSize uz_text_size; ///< 'Unscaled' font size, stored for resize calculation.
+	uint8_t uz_text_lines = 0; ///< 'Unscaled' text lines, stored for resize calculation.
+	uint8_t uz_text_spacing = 0; ///< 'Unscaled' text padding, stored for resize calculation.
+	FontSize uz_text_size{}; ///< 'Unscaled' font size, stored for resize calculation.
 };
 
 /** Nested widget flags that affect display and interaction with 'real' widgets. */
@@ -392,14 +392,14 @@ public:
 	NWidgetDisplayFlags disp_flags; ///< Flags that affect display and interaction with the widget.
 	Colours colour;            ///< Colour of this widget.
 protected:
-	const WidgetID index;      ///< Index of the nested widget (\c -1 means 'not used').
-	WidgetData widget_data; ///< Data of the widget. @see Widget::data
-	StringID tool_tip; ///< Tooltip of the widget. @see Widget::tool_tips
-	WidgetID scrollbar_index;  ///< Index of an attached scrollbar.
-	TextColour highlight_colour; ///< Colour of highlight.
-	TextColour text_colour;    ///< Colour of text within widget.
-	FontSize text_size;        ///< Size of text within widget.
-	StringAlignment align;     ///< Alignment of text/image within widget.
+	const WidgetID index = -1; ///< Index of the nested widget (\c -1 means 'not used').
+	WidgetData widget_data{}; ///< Data of the widget. @see Widget::data
+	StringID tool_tip{}; ///< Tooltip of the widget. @see Widget::tool_tips
+	WidgetID scrollbar_index = -1; ///< Index of an attached scrollbar.
+	TextColour highlight_colour{}; ///< Colour of highlight.
+	TextColour text_colour{}; ///< Colour of text within widget.
+	FontSize text_size = FS_NORMAL; ///< Size of text within widget.
+	StringAlignment align = SA_CENTER; ///< Alignment of text/image within widget.
 
 	/* This function constructs the widgets, so it should be able to write the variables. */
 	friend void ApplyNWidgetPartAttribute(const struct NWidgetPart &nwid, NWidgetBase *dest);
@@ -479,7 +479,7 @@ public:
 	NWidgetBase *GetWidgetOfType(WidgetType tp) override;
 
 protected:
-	std::vector<std::unique_ptr<NWidgetBase>> children; ///< Child widgets in container.
+	std::vector<std::unique_ptr<NWidgetBase>> children{}; ///< Child widgets in container.
 };
 
 /** Display planes with zero size for #NWidgetStacked. */
@@ -503,7 +503,7 @@ enum StackedZeroSizePlanes : int {
  */
 class NWidgetStacked : public NWidgetContainer {
 public:
-	NWidgetStacked(WidgetID index);
+	NWidgetStacked(WidgetID index) : NWidgetContainer(NWID_SELECTION), index(index) {}
 
 	void SetupSmallestSize(Window *w) override;
 	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;
@@ -514,10 +514,10 @@ public:
 
 	bool SetDisplayedPlane(int plane);
 
-	int shown_plane; ///< Plane being displayed (for #NWID_SELECTION only).
-	const WidgetID index; ///< If non-negative, index in the #Window::widget_lookup.
+	int shown_plane = 0; ///< Plane being displayed (for #NWID_SELECTION only).
+	const WidgetID index = -1; ///< If non-negative, index in the #Window::widget_lookup.
 private:
-	WidgetLookup *widget_lookup; ///< Window's widget lookup, updated in SetDisplayedPlane().
+	WidgetLookup *widget_lookup = nullptr; ///< Window's widget lookup, updated in SetDisplayedPlane().
 };
 
 /** Nested widget container flags, */
@@ -537,19 +537,19 @@ public:
 	void SetPIPRatio(uint8_t pip_ratio_pre, uint8_t pip_ratio_inter, uint8_t pip_rato_post);
 
 protected:
-	NWidContainerFlags flags; ///< Flags of the container.
-	uint8_t pip_pre;            ///< Amount of space before first widget.
-	uint8_t pip_inter;          ///< Amount of space between widgets.
-	uint8_t pip_post;           ///< Amount of space after last widget.
-	uint8_t pip_ratio_pre;      ///< Ratio of remaining space before first widget.
-	uint8_t pip_ratio_inter;    ///< Ratio of remaining space between widgets.
-	uint8_t pip_ratio_post;     ///< Ratio of remaining space after last widget.
+	NWidContainerFlags flags{}; ///< Flags of the container.
+	uint8_t pip_pre = 0; ///< Amount of space before first widget.
+	uint8_t pip_inter = 0; ///< Amount of space between widgets.
+	uint8_t pip_post = 0; ///< Amount of space after last widget.
+	uint8_t pip_ratio_pre = 0; ///< Ratio of remaining space before first widget.
+	uint8_t pip_ratio_inter = 0; ///< Ratio of remaining space between widgets.
+	uint8_t pip_ratio_post = 0; ///< Ratio of remaining space after last widget.
 
-	uint8_t uz_pip_pre;         ///< Unscaled space before first widget.
-	uint8_t uz_pip_inter;       ///< Unscaled space between widgets.
-	uint8_t uz_pip_post;        ///< Unscaled space after last widget.
+	uint8_t uz_pip_pre = 0; ///< Unscaled space before first widget.
+	uint8_t uz_pip_inter = 0; ///< Unscaled space between widgets.
+	uint8_t uz_pip_post = 0; ///< Unscaled space after last widget.
 
-	uint8_t gaps; ///< Number of gaps between widgets.
+	uint8_t gaps = 0; ///< Number of gaps between widgets.
 };
 
 /**
@@ -611,17 +611,17 @@ public:
 	NWidgetCore *GetWidgetFromPos(int x, int y) override;
 	void Draw(const Window *w) override;
 protected:
-	const WidgetID index; ///< If non-negative, index in the #Window::widget_lookup.
-	Colours colour; ///< Colour of this widget.
-	int clicked;    ///< The currently clicked element.
-	int count;      ///< Amount of valid elements.
-	int current_element; ///< The element currently being processed.
-	Scrollbar *sb;  ///< The scrollbar we're associated with.
+	const WidgetID index = -1; ///< If non-negative, index in the #Window::widget_lookup.
+	Colours colour{}; ///< Colour of this widget.
+	int clicked = -1; ///< The currently clicked element.
+	int count = -1; ///< Amount of valid elements.
+	int current_element = 0; ///< The element currently being processed.
+	Scrollbar *sb = nullptr;  ///< The scrollbar we're associated with.
 private:
-	int widget_w;   ///< The width of the child widget including inter spacing.
-	int widget_h;   ///< The height of the child widget including inter spacing.
-	int widgets_x;  ///< The number of visible widgets in horizontal direction.
-	int widgets_y;  ///< The number of visible widgets in vertical direction.
+	int widget_w = 0; ///< The width of the child widget including inter spacing.
+	int widget_h = 0; ///< The height of the child widget including inter spacing.
+	int widgets_x = 0; ///< The number of visible widgets in horizontal direction.
+	int widgets_y = 0; ///< The number of visible widgets in vertical direction.
 
 	void GetScrollOffsets(int &start_x, int &start_y, int &base_offs_x, int &base_offs_y);
 };
@@ -666,7 +666,7 @@ public:
 	NWidgetBase *GetWidgetOfType(WidgetType tp) override;
 
 private:
-	std::unique_ptr<NWidgetPIPContainer> child; ///< Child widget.
+	std::unique_ptr<NWidgetPIPContainer> child{}; ///< Child widget.
 };
 
 /**
@@ -698,11 +698,11 @@ public:
 	static constexpr size_type max_size_type = std::numeric_limits<size_type>::max();
 	static constexpr size_type npos = max_size_type;
 private:
-	const bool is_vertical; ///< Scrollbar has vertical orientation.
-	size_type count; ///< Number of elements in the list.
-	size_type cap; ///< Number of visible elements of the scroll bar.
-	size_type pos; ///< Index of first visible item of the list.
-	size_type stepsize; ///< Distance to scroll, when pressing the buttons or using the wheel.
+	const bool is_vertical = false; ///< Scrollbar has vertical orientation.
+	size_type count = 0; ///< Number of elements in the list.
+	size_type cap = 0; ///< Number of visible elements of the scroll bar.
+	size_type pos = 0; ///< Index of first visible item of the list.
+	size_type stepsize = 1; ///< Distance to scroll, when pressing the buttons or using the wheel.
 
 public:
 	/** Stepping sizes when scrolling */
@@ -712,9 +712,7 @@ public:
 		SS_BIG,             ///< Step in #cap units.
 	};
 
-	Scrollbar(bool is_vertical) : is_vertical(is_vertical), stepsize(1)
-	{
-	}
+	Scrollbar(bool is_vertical) : is_vertical(is_vertical) {}
 
 	/**
 	 * Gets the number of elements in the list

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -10,6 +10,7 @@
 #ifndef WINDOW_GUI_H
 #define WINDOW_GUI_H
 
+#include "core/alloc_type.hpp"
 #include "vehiclelist.h"
 #include "vehicle_type.h"
 #include "viewport_type.h"


### PR DESCRIPTION
## Motivation / Problem

The `ZeroedMemoryAllocator` is a hack from when we moved to C++, that has spread around and uses old-style C memory allocations. If we just explicitly initialise fields, there no need for it nor for lengthy constructors.


## Description

Remove `ZeroedMemoryAllocator` from `NWidgetBase` and explicitly initialise fields of it and all its dependants.

As `NWidgetBase` inherited the virtual destructor from the now removed super class, it needs to get that. Also a C-style array was changed to `std::array`.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
