### PR TITLE
Codechange: remove ZeroedMemoryAllocator from GRFFile

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -886,7 +886,7 @@ static void HandleEconomyFluctuations()
  */
 void ResetPriceBaseMultipliers()
 {
-	memset(_price_base_multiplier, 0, sizeof(_price_base_multiplier));
+	_price_base_multiplier.fill(0);
 }
 
 /**

--- a/src/economy_type.h
+++ b/src/economy_type.h
@@ -172,7 +172,7 @@ enum Price : uint8_t {
 DECLARE_INCREMENT_DECREMENT_OPERATORS(Price)
 
 typedef Money Prices[PR_END]; ///< Prices of everything. @see Price
-typedef int8_t PriceMultipliers[PR_END];
+using PriceMultipliers = std::array<int8_t, PR_END>;
 
 /** Types of expenses. */
 enum ExpensesType : uint8_t {

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -9212,9 +9212,7 @@ GRFFile::GRFFile(const GRFConfig &config)
 	this->traininfo_vehicle_width = TRAININFO_DEFAULT_VEHICLE_WIDTH;
 
 	/* Mark price_base_multipliers as 'not set' */
-	for (Price i = PR_BEGIN; i < PR_END; i++) {
-		this->price_base_multipliers[i] = INVALID_PRICE_MODIFIER;
-	}
+	this->price_base_multipliers.fill(INVALID_PRICE_MODIFIER);
 
 	/* Initialise rail type map with default rail types */
 	this->railtype_map.fill(INVALID_RAILTYPE);

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -18,7 +18,6 @@
 #include "newgrf_callbacks.h"
 #include "newgrf_text_type.h"
 #include "core/bitmath_func.hpp"
-#include "core/alloc_type.hpp"
 #include "core/mem_func.hpp"
 
 /**
@@ -109,13 +108,13 @@ struct GRFLabel {
 };
 
 /** Dynamic data of a loaded NewGRF */
-struct GRFFile : ZeroedMemoryAllocator {
-	std::string filename;
-	uint32_t grfid;
-	uint8_t grf_version;
+struct GRFFile {
+	std::string filename{};
+	uint32_t grfid = 0;
+	uint8_t grf_version = 0;
 
-	uint sound_offset;
-	uint16_t num_sounds;
+	uint sound_offset = 0;
+	uint16_t num_sounds = 0;
 
 	std::vector<std::unique_ptr<struct StationSpec>> stations;
 	std::vector<std::unique_ptr<struct HouseSpec>> housespec;
@@ -126,34 +125,34 @@ struct GRFFile : ZeroedMemoryAllocator {
 	std::vector<std::unique_ptr<struct AirportTileSpec>> airtspec;
 	std::vector<std::unique_ptr<struct RoadStopSpec>> roadstops;
 
-	std::vector<uint32_t> param;
+	std::vector<uint32_t> param{};
 
-	std::vector<GRFLabel> labels;                   ///< List of labels
+	std::vector<GRFLabel> labels{}; ///< List of labels
 
-	std::vector<CargoLabel> cargo_list;             ///< Cargo translation table (local ID -> label)
+	std::vector<CargoLabel> cargo_list{}; ///< Cargo translation table (local ID -> label)
 	std::array<uint8_t, NUM_CARGO> cargo_map{}; ///< Inverse cargo translation table (CargoType -> local ID)
 
-	std::vector<BadgeID> badge_list; ///< Badge translation table (local index -> global index)
-	std::unordered_map<uint16_t, BadgeID> badge_map;
+	std::vector<BadgeID> badge_list{}; ///< Badge translation table (local index -> global index)
+	std::unordered_map<uint16_t, BadgeID> badge_map{};
 
-	std::vector<RailTypeLabel> railtype_list;       ///< Railtype translation table
+	std::vector<RailTypeLabel> railtype_list{}; ///< Railtype translation table
 	std::array<RailType, RAILTYPE_END> railtype_map{};
 
-	std::vector<RoadTypeLabel> roadtype_list;       ///< Roadtype translation table (road)
+	std::vector<RoadTypeLabel> roadtype_list{}; ///< Roadtype translation table (road)
 	std::array<RoadType, ROADTYPE_END> roadtype_map{};
 
-	std::vector<RoadTypeLabel> tramtype_list;       ///< Roadtype translation table (tram)
+	std::vector<RoadTypeLabel> tramtype_list{}; ///< Roadtype translation table (tram)
 	std::array<RoadType, ROADTYPE_END> tramtype_map{};
 
-	CanalProperties canal_local_properties[CF_END]; ///< Canal properties as set by this NewGRF
+	std::array<CanalProperties, CF_END> canal_local_properties{}; ///< Canal properties as set by this NewGRF
 
-	std::unordered_map<uint8_t, LanguageMap> language_map; ///< Mappings related to the languages.
+	std::unordered_map<uint8_t, LanguageMap> language_map{}; ///< Mappings related to the languages.
 
-	int traininfo_vehicle_pitch;  ///< Vertical offset for drawing train images in depot GUI and vehicle details
-	uint traininfo_vehicle_width; ///< Width (in pixels) of a 8/8 train vehicle in depot GUI and vehicle details
+	int traininfo_vehicle_pitch = 0; ///< Vertical offset for drawing train images in depot GUI and vehicle details
+	uint traininfo_vehicle_width = 0; ///< Width (in pixels) of a 8/8 train vehicle in depot GUI and vehicle details
 
-	uint32_t grf_features;                     ///< Bitset of GrfSpecFeature the grf uses
-	PriceMultipliers price_base_multipliers; ///< Price base multipliers as set by the grf.
+	uint32_t grf_features = 0; ///< Bitset of GrfSpecFeature the grf uses
+	PriceMultipliers price_base_multipliers{}; ///< Price base multipliers as set by the grf.
 
 	GRFFile(const struct GRFConfig &config);
 


### PR DESCRIPTION
## Motivation / Problem

The `ZeroedMemoryAllocator` is a hack from when we moved to C++, that has spread around and uses old-style C memory allocations.


## Description

Remove `ZeroedMemoryAllocator` from `GRFFile` and explicitly initialise fields.

Also two C-style array were changed to `std::array`, removing a call to `memset` in the process.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
