### PR TITLE
Codechange: remove ZeroedMemoryAllocator from OpenGLBackend

### DIFF
--- a/src/video/opengl.h
+++ b/src/video/opengl.h
@@ -25,47 +25,47 @@ const char *FindStringInExtensionList(const char *string, const char *substring)
 class OpenGLSprite;
 
 /** Platform-independent back-end class for OpenGL video drivers. */
-class OpenGLBackend : public ZeroedMemoryAllocator, SpriteEncoder {
+class OpenGLBackend : public SpriteEncoder {
 private:
 	static OpenGLBackend *instance; ///< Singleton instance pointer.
 
-	bool persistent_mapping_supported; ///< Persistent pixel buffer mapping supported.
-	GLsync sync_vid_mapping;           ///< Sync object for the persistently mapped video buffer.
-	GLsync sync_anim_mapping;          ///< Sync object for the persistently mapped animation buffer.
+	bool persistent_mapping_supported = false; ///< Persistent pixel buffer mapping supported.
+	GLsync sync_vid_mapping{}; ///< Sync object for the persistently mapped video buffer.
+	GLsync sync_anim_mapping{}; ///< Sync object for the persistently mapped animation buffer.
 
-	void *vid_buffer;   ///< Pointer to the mapped video buffer.
-	GLuint vid_pbo;     ///< Pixel buffer object storing the memory used for the video driver to draw to.
-	GLuint vid_texture; ///< Texture handle for the video buffer texture.
-	GLuint vid_program; ///< Shader program for rendering a RGBA video buffer.
-	GLuint pal_program; ///< Shader program for rendering a paletted video buffer.
-	GLuint vao_quad;    ///< Vertex array object storing the rendering state for the fullscreen quad.
-	GLuint vbo_quad;    ///< Vertex buffer with a fullscreen quad.
-	GLuint pal_texture; ///< Palette lookup texture.
+	void *vid_buffer = nullptr; ///< Pointer to the mapped video buffer.
+	GLuint vid_pbo = 0; ///< Pixel buffer object storing the memory used for the video driver to draw to.
+	GLuint vid_texture = 0; ///< Texture handle for the video buffer texture.
+	GLuint vid_program = 0; ///< Shader program for rendering a RGBA video buffer.
+	GLuint pal_program = 0; ///< Shader program for rendering a paletted video buffer.
+	GLuint vao_quad = 0; ///< Vertex array object storing the rendering state for the fullscreen quad.
+	GLuint vbo_quad = 0; ///< Vertex buffer with a fullscreen quad.
+	GLuint pal_texture = 0; ///< Palette lookup texture.
 
-	void *anim_buffer;   ///< Pointer to the mapped animation buffer.
-	GLuint anim_pbo;     ///< Pixel buffer object storing the memory used for the animation buffer.
-	GLuint anim_texture; ///< Texture handle for the animation buffer texture.
+	void *anim_buffer = nullptr; ///< Pointer to the mapped animation buffer.
+	GLuint anim_pbo = 0; ///< Pixel buffer object storing the memory used for the animation buffer.
+	GLuint anim_texture = 0; ///< Texture handle for the animation buffer texture.
 
-	GLuint remap_program;    ///< Shader program for blending and rendering a RGBA + remap texture.
-	GLint  remap_sprite_loc; ///< Uniform location for sprite parameters.
-	GLint  remap_screen_loc; ///< Uniform location for screen size.
-	GLint  remap_zoom_loc;   ///< Uniform location for sprite zoom.
-	GLint  remap_rgb_loc;    ///< Uniform location for RGB mode flag.
+	GLuint remap_program = 0; ///< Shader program for blending and rendering a RGBA + remap texture.
+	GLint  remap_sprite_loc = 0; ///< Uniform location for sprite parameters.
+	GLint  remap_screen_loc = 0; ///< Uniform location for screen size.
+	GLint  remap_zoom_loc = 0; ///< Uniform location for sprite zoom.
+	GLint  remap_rgb_loc = 0; ///< Uniform location for RGB mode flag.
 
-	GLuint sprite_program;    ///< Shader program for blending and rendering a sprite to the video buffer.
-	GLint  sprite_sprite_loc; ///< Uniform location for sprite parameters.
-	GLint  sprite_screen_loc; ///< Uniform location for screen size.
-	GLint  sprite_zoom_loc;   ///< Uniform location for sprite zoom.
-	GLint  sprite_rgb_loc;    ///< Uniform location for RGB mode flag.
-	GLint  sprite_crash_loc;  ///< Uniform location for crash remap mode flag.
+	GLuint sprite_program = 0; ///< Shader program for blending and rendering a sprite to the video buffer.
+	GLint  sprite_sprite_loc = 0; ///< Uniform location for sprite parameters.
+	GLint  sprite_screen_loc = 0; ///< Uniform location for screen size.
+	GLint  sprite_zoom_loc = 0; ///< Uniform location for sprite zoom.
+	GLint  sprite_rgb_loc = 0; ///< Uniform location for RGB mode flag.
+	GLint  sprite_crash_loc = 0; ///< Uniform location for crash remap mode flag.
 
-	LRUCache<SpriteID, Sprite> cursor_cache;   ///< Cache of encoded cursor sprites.
+	LRUCache<SpriteID, Sprite> cursor_cache; ///< Cache of encoded cursor sprites.
 	PaletteID last_sprite_pal = (PaletteID)-1; ///< Last uploaded remap palette.
-	bool clear_cursor_cache = false;           ///< A clear of the cursor cache is pending.
+	bool clear_cursor_cache = false; ///< A clear of the cursor cache is pending.
 
-	Point cursor_pos;                    ///< Cursor position
-	bool cursor_in_window;               ///< Cursor inside this window
-	std::vector<CursorSprite> cursor_sprites; ///< Sprites comprising cursor
+	Point cursor_pos{}; ///< Cursor position
+	bool cursor_in_window = false; ///< Cursor inside this window
+	std::vector<CursorSprite> cursor_sprites{}; ///< Sprites comprising cursor
 
 	OpenGLBackend();
 	~OpenGLBackend();


### PR DESCRIPTION
## Motivation / Problem

The `ZeroedMemoryAllocator` is a hack from when we moved to C++, that has spread around and uses old-style C memory allocations.


## Description

Remove `ZeroedMemoryAllocator` from `OpenGLBackend` and explicitly initialise fields.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
