### PR TITLE
Codechange: remove C-style memory management from pools

### DIFF
--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -25,7 +25,7 @@ using CargoPacketID = PoolID<uint32_t, struct CargoPacketIDTag, 0xFFF000, 0xFFFF
 struct CargoPacket;
 
 /** Type of the pool for cargo packets for a little over 16 million packets. */
-using CargoPacketPool = Pool<CargoPacket, CargoPacketID, 1024, PoolType::Normal, true, false>;
+using CargoPacketPool = Pool<CargoPacket, CargoPacketID, 1024, PoolType::Normal, true>;
 /** The actual pool with cargo packets. */
 extern CargoPacketPool _cargopacket_pool;
 

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -585,7 +585,7 @@ Company *DoStartupNewCompany(bool is_ai, CompanyID company = CompanyID::Invalid(
 		c = new Company(STR_SV_UNNAMED, is_ai);
 	} else {
 		if (Company::IsValidID(company)) return nullptr;
-		c = new (company.base()) Company(STR_SV_UNNAMED, is_ai);
+		c = new (company) Company(STR_SV_UNNAMED, is_ai);
 	}
 
 	c->colour = colour;

--- a/src/core/pool_func.hpp
+++ b/src/core/pool_func.hpp
@@ -23,9 +23,9 @@
  * @param type The return type of the method.
  */
 #define DEFINE_POOL_METHOD(type) \
-	template <class Titem, typename Tindex, size_t Tgrowth_step, PoolType Tpool_type, bool Tcache, bool Tzero> \
+	template <class Titem, typename Tindex, size_t Tgrowth_step, PoolType Tpool_type, bool Tcache> \
 	requires std::is_base_of_v<PoolIDBase, Tindex> \
-	type Pool<Titem, Tindex, Tgrowth_step, Tpool_type, Tcache, Tzero>
+	type Pool<Titem, Tindex, Tgrowth_step, Tpool_type, Tcache>
 
 /**
  * Create a clean pool.
@@ -113,13 +113,6 @@ DEFINE_POOL_METHOD(inline void *)::AllocateItem(size_t size, size_t index)
 		assert(sizeof(Titem) == size);
 		item = reinterpret_cast<Titem *>(this->alloc_cache);
 		this->alloc_cache = this->alloc_cache->next;
-		if (Tzero) {
-			/* Explicitly casting to (void *) prevents a clang warning -
-			 * we are actually memsetting a (not-yet-constructed) object */
-			memset(static_cast<void *>(item), 0, sizeof(Titem));
-		}
-	} else if (Tzero) {
-		item = reinterpret_cast<Titem *>(CallocT<uint8_t>(size));
 	} else {
 		item = reinterpret_cast<Titem *>(MallocT<uint8_t>(size));
 	}

--- a/src/core/pool_type.hpp
+++ b/src/core/pool_type.hpp
@@ -126,10 +126,9 @@ private:
  * @tparam Tgrowth_step Size of growths; if the pool is full increase the size by this amount
  * @tparam Tpool_type   Type of this pool
  * @tparam Tcache       Whether to perform 'alloc' caching, i.e. don't actually free/malloc just reuse the memory
- * @tparam Tzero        Whether to zero the memory
  * @warning when Tcache is enabled *all* instances of this pool's item must be of the same size.
  */
-template <class Titem, typename Tindex, size_t Tgrowth_step, PoolType Tpool_type = PoolType::Normal, bool Tcache = false, bool Tzero = true>
+template <class Titem, typename Tindex, size_t Tgrowth_step, PoolType Tpool_type = PoolType::Normal, bool Tcache = false>
 requires std::is_base_of_v<PoolIDBase, Tindex>
 struct Pool : PoolBase {
 public:
@@ -282,12 +281,12 @@ public:
 	 * Base class for all PoolItems
 	 * @tparam Tpool The pool this item is going to be part of
 	 */
-	template <struct Pool<Titem, Tindex, Tgrowth_step, Tpool_type, Tcache, Tzero> *Tpool>
+	template <struct Pool<Titem, Tindex, Tgrowth_step, Tpool_type, Tcache> *Tpool>
 	struct PoolItem {
 		Tindex index; ///< Index of this pool item
 
 		/** Type of the pool this item is going to be part of */
-		typedef struct Pool<Titem, Tindex, Tgrowth_step, Tpool_type, Tcache, Tzero> Pool;
+		typedef struct Pool<Titem, Tindex, Tgrowth_step, Tpool_type, Tcache> Pool;
 
 		/**
 		 * Allocates space for new Titem

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -610,7 +610,7 @@ void SetupEngines()
 		assert(std::size(mapping) >= _engine_counts[type]);
 
 		for (const EngineIDMapping &eid : mapping) {
-			new (eid.engine.base()) Engine(type, eid.internal_id);
+			new (eid.engine) Engine(type, eid.internal_id);
 		}
 	}
 }

--- a/src/saveload/autoreplace_sl.cpp
+++ b/src/saveload/autoreplace_sl.cpp
@@ -45,7 +45,7 @@ struct ERNWChunkHandler : ChunkHandler {
 		int index;
 
 		while ((index = SlIterateArray()) != -1) {
-			EngineRenew *er = new (index) EngineRenew();
+			EngineRenew *er = new (EngineRenewID(index)) EngineRenew();
 			SlObject(er, slt);
 
 			/* Advanced vehicle lists, ungrouped vehicles got added */

--- a/src/saveload/cargopacket_sl.cpp
+++ b/src/saveload/cargopacket_sl.cpp
@@ -162,7 +162,7 @@ struct CAPAChunkHandler : ChunkHandler {
 		int index;
 
 		while ((index = SlIterateArray()) != -1) {
-			CargoPacket *cp = new (index) CargoPacket();
+			CargoPacket *cp = new (CargoPacketID(index)) CargoPacket();
 			SlObject(cp, slt);
 		}
 	}

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -536,7 +536,7 @@ struct PLYRChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			Company *c = new (index) Company();
+			Company *c = new (CompanyID(index)) Company();
 			SlObject(c, slt);
 			_company_colours[index] = c->colour;
 		}

--- a/src/saveload/depot_sl.cpp
+++ b/src/saveload/depot_sl.cpp
@@ -49,7 +49,7 @@ struct DEPTChunkHandler : ChunkHandler {
 		int index;
 
 		while ((index = SlIterateArray()) != -1) {
-			Depot *depot = new (index) Depot();
+			Depot *depot = new (DepotID(index)) Depot();
 			SlObject(depot, slt);
 
 			/* Set the town 'pointer' so we can restore it later. */

--- a/src/saveload/economy_sl.cpp
+++ b/src/saveload/economy_sl.cpp
@@ -108,7 +108,7 @@ struct CAPYChunkHandler : ChunkHandler {
 		int index;
 
 		while ((index = SlIterateArray()) != -1) {
-			CargoPayment *cp = new (index) CargoPayment();
+			CargoPayment *cp = new (CargoPaymentID(index)) CargoPayment();
 			SlObject(cp, slt);
 		}
 	}

--- a/src/saveload/goal_sl.cpp
+++ b/src/saveload/goal_sl.cpp
@@ -44,7 +44,7 @@ struct GOALChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			Goal *s = new (index) Goal();
+			Goal *s = new (GoalID(index)) Goal();
 			SlObject(s, slt);
 		}
 	}

--- a/src/saveload/group_sl.cpp
+++ b/src/saveload/group_sl.cpp
@@ -50,7 +50,7 @@ struct GRPSChunkHandler : ChunkHandler {
 		int index;
 
 		while ((index = SlIterateArray()) != -1) {
-			Group *g = new (index) Group();
+			Group *g = new (GroupID(index)) Group();
 			SlObject(g, slt);
 
 			if (IsSavegameVersionBefore(SLV_189)) g->parent = GroupID::Invalid();

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -213,7 +213,7 @@ struct INDYChunkHandler : ChunkHandler {
 		SlIndustryProduced::ResetOldStructure();
 
 		while ((index = SlIterateArray()) != -1) {
-			Industry *i = new (index) Industry();
+			Industry *i = new (IndustryID(index)) Industry();
 			SlObject(i, slt);
 
 			/* Before savegame version 161, persistent storages were not stored in a pool. */

--- a/src/saveload/league_sl.cpp
+++ b/src/saveload/league_sl.cpp
@@ -45,7 +45,7 @@ struct LEAEChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			LeagueTableElement *lte = new (index) LeagueTableElement();
+			LeagueTableElement *lte = new (LeagueTableElementID(index)) LeagueTableElement();
 			SlObject(lte, slt);
 		}
 	}
@@ -76,7 +76,7 @@ struct LEATChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			LeagueTable *lt = new (index) LeagueTable();
+			LeagueTable *lt = new (LeagueTableID(index)) LeagueTable();
 			SlObject(lt, slt);
 		}
 	}

--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -277,7 +277,7 @@ struct LGRPChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			LinkGraph *lg = new (index) LinkGraph();
+			LinkGraph *lg = new (LinkGraphID(index)) LinkGraph();
 			SlObject(lg, slt);
 		}
 	}
@@ -305,7 +305,7 @@ struct LGRJChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			LinkGraphJob *lgj = new (index) LinkGraphJob();
+			LinkGraphJob *lgj = new (LinkGraphJobID(index)) LinkGraphJob();
 			SlObject(lgj, slt);
 		}
 	}

--- a/src/saveload/object_sl.cpp
+++ b/src/saveload/object_sl.cpp
@@ -49,7 +49,7 @@ struct OBJSChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			Object *o = new (index) Object();
+			Object *o = new (ObjectID(index)) Object();
 			SlObject(o, slt);
 		}
 	}

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -615,7 +615,7 @@ static const OldChunks town_chunk[] = {
 
 static bool LoadOldTown(LoadgameState &ls, int num)
 {
-	Town *t = new (num) Town();
+	Town *t = new (TownID(num)) Town();
 	if (!LoadChunk(ls, t, town_chunk)) return false;
 
 	if (t->xy != 0) {
@@ -640,7 +640,7 @@ static bool LoadOldOrder(LoadgameState &ls, int num)
 {
 	if (!LoadChunk(ls, nullptr, order_chunk)) return false;
 
-	Order *o = new (num) Order();
+	Order *o = new (OrderID(num)) Order();
 	o->AssignOrder(UnpackOldOrder(_old_order));
 
 	if (o->IsType(OT_NOTHING)) {
@@ -682,7 +682,7 @@ static const OldChunks depot_chunk[] = {
 
 static bool LoadOldDepot(LoadgameState &ls, int num)
 {
-	Depot *d = new (num) Depot();
+	Depot *d = new (DepotID(num)) Depot();
 	if (!LoadChunk(ls, d, depot_chunk)) return false;
 
 	if (d->xy != 0) {
@@ -770,7 +770,7 @@ static const OldChunks station_chunk[] = {
 
 static bool LoadOldStation(LoadgameState &ls, int num)
 {
-	Station *st = new (num) Station();
+	Station *st = new (StationID(num)) Station();
 	_current_station_id = st->index;
 
 	if (!LoadChunk(ls, st, station_chunk)) return false;
@@ -852,7 +852,7 @@ static const OldChunks industry_chunk[] = {
 
 static bool LoadOldIndustry(LoadgameState &ls, int num)
 {
-	Industry *i = new (num) Industry();
+	Industry *i = new (IndustryID(num)) Industry();
 	if (!LoadChunk(ls, i, industry_chunk)) return false;
 
 	if (i->location.tile != 0) {
@@ -978,7 +978,7 @@ static const OldChunks _company_chunk[] = {
 
 static bool LoadOldCompany(LoadgameState &ls, int num)
 {
-	Company *c = new (num) Company();
+	Company *c = new (CompanyID(num)) Company();
 
 	_current_company_id = (CompanyID)num;
 
@@ -1260,12 +1260,12 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 				default: return false;
 				case 0x00 /* VEH_INVALID  */: v = nullptr;                                        break;
 				case 0x25 /* MONORAIL     */:
-				case 0x20 /* VEH_TRAIN    */: v = new (_current_vehicle_id) Train();           break;
-				case 0x21 /* VEH_ROAD     */: v = new (_current_vehicle_id) RoadVehicle();     break;
-				case 0x22 /* VEH_SHIP     */: v = new (_current_vehicle_id) Ship();            break;
-				case 0x23 /* VEH_AIRCRAFT */: v = new (_current_vehicle_id) Aircraft();        break;
-				case 0x24 /* VEH_EFFECT   */: v = new (_current_vehicle_id) EffectVehicle();   break;
-				case 0x26 /* VEH_DISASTER */: v = new (_current_vehicle_id) DisasterVehicle(); break;
+				case 0x20 /* VEH_TRAIN    */: v = new (VehicleID(_current_vehicle_id)) Train();           break;
+				case 0x21 /* VEH_ROAD     */: v = new (VehicleID(_current_vehicle_id)) RoadVehicle();     break;
+				case 0x22 /* VEH_SHIP     */: v = new (VehicleID(_current_vehicle_id)) Ship();            break;
+				case 0x23 /* VEH_AIRCRAFT */: v = new (VehicleID(_current_vehicle_id)) Aircraft();        break;
+				case 0x24 /* VEH_EFFECT   */: v = new (VehicleID(_current_vehicle_id)) EffectVehicle();   break;
+				case 0x26 /* VEH_DISASTER */: v = new (VehicleID(_current_vehicle_id)) DisasterVehicle(); break;
 			}
 
 			if (!LoadChunk(ls, v, vehicle_chunk)) return false;
@@ -1338,12 +1338,12 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 			switch (ReadByte(ls)) {
 				default: SlErrorCorrupt("Invalid vehicle type");
 				case 0x00 /* VEH_INVALID */: v = nullptr;                                        break;
-				case 0x10 /* VEH_TRAIN   */: v = new (_current_vehicle_id) Train();           break;
-				case 0x11 /* VEH_ROAD    */: v = new (_current_vehicle_id) RoadVehicle();     break;
-				case 0x12 /* VEH_SHIP    */: v = new (_current_vehicle_id) Ship();            break;
-				case 0x13 /* VEH_AIRCRAFT*/: v = new (_current_vehicle_id) Aircraft();        break;
-				case 0x14 /* VEH_EFFECT  */: v = new (_current_vehicle_id) EffectVehicle();   break;
-				case 0x15 /* VEH_DISASTER*/: v = new (_current_vehicle_id) DisasterVehicle(); break;
+				case 0x10 /* VEH_TRAIN   */: v = new (VehicleID(_current_vehicle_id)) Train();           break;
+				case 0x11 /* VEH_ROAD    */: v = new (VehicleID(_current_vehicle_id)) RoadVehicle();     break;
+				case 0x12 /* VEH_SHIP    */: v = new (VehicleID(_current_vehicle_id)) Ship();            break;
+				case 0x13 /* VEH_AIRCRAFT*/: v = new (VehicleID(_current_vehicle_id)) Aircraft();        break;
+				case 0x14 /* VEH_EFFECT  */: v = new (VehicleID(_current_vehicle_id)) EffectVehicle();   break;
+				case 0x15 /* VEH_DISASTER*/: v = new (VehicleID(_current_vehicle_id)) DisasterVehicle(); break;
 			}
 
 			if (!LoadChunk(ls, v, vehicle_chunk)) return false;
@@ -1413,7 +1413,7 @@ static const OldChunks sign_chunk[] = {
 
 static bool LoadOldSign(LoadgameState &ls, int num)
 {
-	Sign *si = new (num) Sign();
+	Sign *si = new (SignID(num)) Sign();
 	if (!LoadChunk(ls, si, sign_chunk)) return false;
 
 	if (_old_string_id != 0) {
@@ -1477,7 +1477,7 @@ static const OldChunks subsidy_chunk[] = {
 
 static bool LoadOldSubsidy(LoadgameState &ls, int num)
 {
-	Subsidy *s = new (num) Subsidy();
+	Subsidy *s = new (SubsidyID(num)) Subsidy();
 	bool ret = LoadChunk(ls, s, subsidy_chunk);
 	if (!IsValidCargoType(s->cargo_type)) delete s;
 	return ret;

--- a/src/saveload/order_sl.cpp
+++ b/src/saveload/order_sl.cpp
@@ -148,7 +148,7 @@ struct ORDRChunkHandler : ChunkHandler {
 				SlCopy(&orders[0], len, SLE_UINT16);
 
 				for (size_t i = 0; i < len; ++i) {
-					Order *o = new (i) Order();
+					Order *o = new (OrderID(static_cast<uint32_t>(i))) Order();
 					o->AssignOrder(UnpackVersion4Order(orders[i]));
 				}
 			} else if (IsSavegameVersionBefore(SLV_5, 2)) {
@@ -158,7 +158,7 @@ struct ORDRChunkHandler : ChunkHandler {
 				SlCopy(&orders[0], len, SLE_UINT32);
 
 				for (size_t i = 0; i < len; ++i) {
-					new (i) Order(GB(orders[i], 0, 8), GB(orders[i], 8, 8), GB(orders[i], 16, 16));
+					new (OrderID(static_cast<uint32_t>(i))) Order(GB(orders[i], 0, 8), GB(orders[i], 8, 8), GB(orders[i], 16, 16));
 				}
 			}
 
@@ -181,7 +181,7 @@ struct ORDRChunkHandler : ChunkHandler {
 			int index;
 
 			while ((index = SlIterateArray()) != -1) {
-				Order *order = new (index) Order();
+				Order *order = new (OrderID(index)) Order();
 				SlObject(order, slt);
 			}
 		}
@@ -229,7 +229,7 @@ struct ORDLChunkHandler : ChunkHandler {
 
 		while ((index = SlIterateArray()) != -1) {
 			/* set num_orders to 0 so it's a valid OrderList */
-			OrderList *list = new (index) OrderList(0);
+			OrderList *list = new (OrderListID(index)) OrderList(0);
 			SlObject(list, slt);
 		}
 
@@ -294,7 +294,7 @@ struct BKORChunkHandler : ChunkHandler {
 
 		while ((index = SlIterateArray()) != -1) {
 			/* set num_orders to 0 so it's a valid OrderList */
-			OrderBackup *ob = new (index) OrderBackup();
+			OrderBackup *ob = new (OrderBackupID(index)) OrderBackup();
 			SlObject(ob, slt);
 		}
 	}

--- a/src/saveload/signs_sl.cpp
+++ b/src/saveload/signs_sl.cpp
@@ -49,7 +49,7 @@ struct SIGNChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			Sign *si = new (index) Sign();
+			Sign *si = new (SignID(index)) Sign();
 			SlObject(si, slt);
 			/* Before version 6.1, signs didn't have owner.
 			 * Before version 83, invalid signs were determined by si->str == 0.

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -79,7 +79,7 @@ void MoveBuoysToWaypoints()
 		/* Stations and waypoints are in the same pool, so if a station
 		 * is deleted there must be place for a Waypoint. */
 		assert(Waypoint::CanAllocateItem());
-		Waypoint *wp   = new (index.base()) Waypoint(xy);
+		Waypoint *wp   = new (index) Waypoint(xy);
 		wp->town       = town;
 		wp->string_id  = train ? STR_SV_STNAME_WAYPOINT : STR_SV_STNAME_BUOY;
 		wp->name       = name;
@@ -512,7 +512,7 @@ struct STNSChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			Station *st = new (index) Station();
+			Station *st = new (StationID(index)) Station();
 
 			_waiting_acceptance = 0;
 			SlObject(st, slt);
@@ -714,7 +714,7 @@ struct STNNChunkHandler : ChunkHandler {
 		while ((index = SlIterateArray()) != -1) {
 			bool waypoint = static_cast<StationFacilities>(SlReadByte()).Test(StationFacility::Waypoint);
 
-			BaseStation *bst = waypoint ? (BaseStation *)new (index) Waypoint() : new (index) Station();
+			BaseStation *bst = waypoint ? (BaseStation *)new (StationID(index)) Waypoint() : new (StationID(index)) Station();
 			SlObject(bst, slt);
 		}
 	}
@@ -752,7 +752,7 @@ struct ROADChunkHandler : ChunkHandler {
 		int index;
 
 		while ((index = SlIterateArray()) != -1) {
-			RoadStop *rs = new (index) RoadStop(INVALID_TILE);
+			RoadStop *rs = new (RoadStopID(index)) RoadStop(INVALID_TILE);
 
 			SlObject(rs, slt);
 		}

--- a/src/saveload/storage_sl.cpp
+++ b/src/saveload/storage_sl.cpp
@@ -35,7 +35,7 @@ struct PSACChunkHandler : ChunkHandler {
 
 		while ((index = SlIterateArray()) != -1) {
 			assert(PersistentStorage::CanAllocateItem());
-			PersistentStorage *ps = new (index) PersistentStorage(0, 0, TileIndex{});
+			PersistentStorage *ps = new (PersistentStorageID(index)) PersistentStorage(0, 0, TileIndex{});
 			SlObject(ps, slt);
 		}
 	}

--- a/src/saveload/story_sl.cpp
+++ b/src/saveload/story_sl.cpp
@@ -58,7 +58,7 @@ struct STPEChunkHandler : ChunkHandler {
 		int index;
 		uint32_t max_sort_value = 0;
 		while ((index = SlIterateArray()) != -1) {
-			StoryPageElement *s = new (index) StoryPageElement();
+			StoryPageElement *s = new (StoryPageElementID(index)) StoryPageElement();
 			SlObject(s, slt);
 			if (s->sort_value > max_sort_value) {
 				max_sort_value = s->sort_value;
@@ -100,7 +100,7 @@ struct STPAChunkHandler : ChunkHandler {
 		int index;
 		uint32_t max_sort_value = 0;
 		while ((index = SlIterateArray()) != -1) {
-			StoryPage *s = new (index) StoryPage();
+			StoryPage *s = new (StoryPageID(index)) StoryPage();
 			SlObject(s, slt);
 			if (s->sort_value > max_sort_value) {
 				max_sort_value = s->sort_value;

--- a/src/saveload/subsidy_sl.cpp
+++ b/src/saveload/subsidy_sl.cpp
@@ -48,7 +48,7 @@ struct SUBSChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			Subsidy *s = new (index) Subsidy();
+			Subsidy *s = new (SubsidyID(index)) Subsidy();
 			SlObject(s, slt);
 		}
 	}

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -300,7 +300,7 @@ struct CITYChunkHandler : ChunkHandler {
 		int index;
 
 		while ((index = SlIterateArray()) != -1) {
-			Town *t = new (index) Town();
+			Town *t = new (TownID(index)) Town();
 			SlObject(t, slt);
 
 			if (t->townnamegrfid == 0 && !IsInsideMM(t->townnametype, SPECSTR_TOWNNAME_START, SPECSTR_TOWNNAME_END) && GetStringTab(t->townnametype) != TEXT_TAB_OLD_CUSTOM) {

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -1124,12 +1124,12 @@ struct VEHSChunkHandler : ChunkHandler {
 			VehicleType vtype = (VehicleType)SlReadByte();
 
 			switch (vtype) {
-				case VEH_TRAIN:    v = new (index) Train();           break;
-				case VEH_ROAD:     v = new (index) RoadVehicle();     break;
-				case VEH_SHIP:     v = new (index) Ship();            break;
-				case VEH_AIRCRAFT: v = new (index) Aircraft();        break;
-				case VEH_EFFECT:   v = new (index) EffectVehicle();   break;
-				case VEH_DISASTER: v = new (index) DisasterVehicle(); break;
+				case VEH_TRAIN:    v = new (VehicleID(index)) Train();           break;
+				case VEH_ROAD:     v = new (VehicleID(index)) RoadVehicle();     break;
+				case VEH_SHIP:     v = new (VehicleID(index)) Ship();            break;
+				case VEH_AIRCRAFT: v = new (VehicleID(index)) Aircraft();        break;
+				case VEH_EFFECT:   v = new (VehicleID(index)) EffectVehicle();   break;
+				case VEH_DISASTER: v = new (VehicleID(index)) DisasterVehicle(); break;
 				case VEH_INVALID: // Savegame shouldn't contain invalid vehicles
 				default: SlErrorCorrupt("Invalid vehicle type");
 			}


### PR DESCRIPTION
## Motivation / Problem

The pool uses `MallocT`, `CallocT` and `memset` instead of C++-style memory management.


## Description

* Remove the option to zero memory in the `operator new` for pool items; this is not needed because all pool item member variables are explicitly initialised.
* Explicitly initialise the member variables of the pool itself.
* Change placement `operator new`'s `index` parameter from `size_t` to `Tindex`, so the `operator delete` with size can be implemented.
* Replace `MallocT`/`free` with `std::allocator`.


## Limitations

Does not solve the non-standard behaviour of setting the pool index before calling the constructor. Doing that requires significant changes, which would be way outside the scope of this PR. Primarily because this is about removing C-style memory management.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
