### PR TITLE
Codechange: explicitly initialise member variables of Windows 1 of 5

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -93,9 +93,9 @@ static WindowDesc _ai_config_desc(
  * Window to configure which AIs will start.
  */
 struct AIConfigWindow : public Window {
-	CompanyID selected_slot; ///< The currently selected AI slot or \c CompanyID::Invalid().
-	int line_height;         ///< Height of a single AI-name line.
-	Scrollbar *vscroll;      ///< Cache of the vertical scrollbar.
+	CompanyID selected_slot = CompanyID::Invalid(); ///< The currently selected AI slot or \c CompanyID::Invalid().
+	int line_height = 0; ///< Height of a single AI-name line.
+	Scrollbar *vscroll = nullptr; ///< Cache of the vertical scrollbar.
 
 	AIConfigWindow() : Window(_ai_config_desc)
 	{

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -82,14 +82,13 @@ static void PlaceAirport(TileIndex tile)
 
 /** Airport build toolbar window handler. */
 struct BuildAirToolbarWindow : Window {
-	int last_user_action; // Last started user action.
+	int last_user_action = INVALID_WID_AT; // Last started user action.
 
 	BuildAirToolbarWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{
 		this->InitNested(window_number);
 		this->OnInvalidateData();
 		if (_settings_client.gui.link_terraform_toolbar) ShowTerraformToolbar(this);
-		this->last_user_action = INVALID_WID_AT;
 	}
 
 	void Close([[maybe_unused]] int data = 0) override
@@ -233,9 +232,9 @@ Window *ShowBuildAirToolbar()
 }
 
 class BuildAirportWindow : public PickerWindowBase {
-	SpriteID preview_sprite; ///< Cached airport preview sprite.
-	int line_height;
-	Scrollbar *vscroll;
+	SpriteID preview_sprite{}; ///< Cached airport preview sprite.
+	int line_height = 0;
+	Scrollbar *vscroll = nullptr;
 
 	/** Build a dropdown list of available airport classes */
 	static DropDownList BuildAirportClassDropDown()

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -78,20 +78,20 @@ static const StringID _start_replace_dropdown[] = {
  * Window for the autoreplacing of vehicles.
  */
 class ReplaceVehicleWindow : public Window {
-	EngineID sel_engine[2];       ///< Selected engine left and right.
-	GUIEngineList engines[2];     ///< Left and right list of engines.
-	bool replace_engines;         ///< If \c true, engines are replaced, if \c false, wagons are replaced (only for trains).
-	bool reset_sel_engine;        ///< Also reset #sel_engine while updating left and/or right and no valid engine selected.
-	GroupID sel_group;            ///< Group selected to replace.
-	int details_height;           ///< Minimal needed height of the details panels, in text lines (found so far).
-	VehicleType vehicle_type; ///< Type of vehicle in this window.
-	uint8_t sort_criteria;           ///< Criteria of sorting vehicles.
-	bool descending_sort_order;   ///< Order of sorting vehicles.
-	bool show_hidden_engines;     ///< Whether to show the hidden engines.
-	RailType sel_railtype;        ///< Type of rail tracks selected. #INVALID_RAILTYPE to show all.
-	RoadType sel_roadtype;        ///< Type of road selected. #INVALID_ROADTYPE to show all.
-	Scrollbar *vscroll[2];
-	GUIBadgeClasses badge_classes;
+	std::array<EngineID, 2> sel_engine{}; ///< Selected engine left and right.
+	std::array<GUIEngineList, 2> engines{}; ///< Left and right list of engines.
+	bool replace_engines = true; ///< If \c true, engines are replaced, if \c false, wagons are replaced (only for trains).
+	bool reset_sel_engine = true; ///< Also reset #sel_engine while updating left and/or right and no valid engine selected.
+	GroupID sel_group = GroupID::Invalid(); ///< Group selected to replace.
+	int details_height = 0; ///< Minimal needed height of the details panels, in text lines (found so far).
+	VehicleType vehicle_type = VEH_INVALID; ///< Type of vehicle in this window.
+	uint8_t sort_criteria = 0; ///< Criteria of sorting vehicles.
+	bool descending_sort_order = false; ///< Order of sorting vehicles.
+	bool show_hidden_engines = false; ///< Whether to show the hidden engines.
+	RailType sel_railtype = INVALID_RAILTYPE; ///< Type of rail tracks selected. #INVALID_RAILTYPE to show all.
+	RoadType sel_roadtype = INVALID_ROADTYPE; ///< Type of road selected. #INVALID_ROADTYPE to show all.
+	std::array<Scrollbar *, 2> vscroll{};
+	GUIBadgeClasses badge_classes{};
 
 	/**
 	 * Figure out if an engine should be added to a list.
@@ -269,12 +269,8 @@ public:
 	ReplaceVehicleWindow(WindowDesc &desc, VehicleType vehicletype, GroupID id_g) : Window(desc)
 	{
 		this->vehicle_type = vehicletype;
-		this->sel_railtype = INVALID_RAILTYPE;
-		this->sel_roadtype = INVALID_ROADTYPE;
-		this->replace_engines  = true; // start with locomotives (all other vehicles will not read this bool)
 		this->engines[0].ForceRebuild();
 		this->engines[1].ForceRebuild();
-		this->reset_sel_engine = true;
 		this->details_height   = ((vehicletype == VEH_TRAIN) ? 10 : 9);
 		this->sel_engine[0] = EngineID::Invalid();
 		this->sel_engine[1] = EngineID::Invalid();

--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -194,7 +194,7 @@ static WindowDesc _bootstrap_query_desc(
 
 /** The window for the query. It can't use the generic query window as that uses sprites that don't exist yet. */
 class BootstrapAskForDownloadWindow : public Window, ContentCallback {
-	Dimension button_size; ///< The dimension of the button
+	Dimension button_size{}; ///< The dimension of the button
 
 public:
 	/** Start listening to the content client events. */

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -83,13 +83,13 @@ private:
 	static const std::initializer_list<GUIBridgeList::SortFunction * const> sorter_funcs;
 
 	/* Internal variables */
-	TileIndex start_tile;
-	TileIndex end_tile;
-	TransportType transport_type;
-	uint8_t road_rail_type;
-	GUIBridgeList bridges;
-	int icon_width; ///< Scaled width of the the bridge icon sprite.
-	Scrollbar *vscroll;
+	TileIndex start_tile = INVALID_TILE;
+	TileIndex end_tile = INVALID_TILE;
+	TransportType transport_type = INVALID_TRANSPORT;
+	uint8_t road_rail_type = 0;
+	GUIBridgeList bridges{};
+	int icon_width = 0; ///< Scaled width of the the bridge icon sprite.
+	Scrollbar *vscroll = nullptr;
 
 	/** Sort the bridges by their index */
 	static bool BridgeIndexSorter(const BuildBridgeData &a, const BuildBridgeData &b)

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1132,26 +1132,26 @@ enum BuildVehicleHotkeys : int32_t {
 
 /** GUI for building vehicles. */
 struct BuildVehicleWindow : Window {
-	VehicleType vehicle_type;                   ///< Type of vehicles shown in the window.
+	VehicleType vehicle_type = VEH_INVALID; ///< Type of vehicles shown in the window.
 	union {
 		RailType railtype;   ///< Rail type to show, or #INVALID_RAILTYPE.
 		RoadType roadtype;   ///< Road type to show, or #INVALID_ROADTYPE.
-	} filter;                                   ///< Filter to apply.
-	bool descending_sort_order;                 ///< Sort direction, @see _engine_sort_direction
-	uint8_t sort_criteria;                         ///< Current sort criterium.
-	bool show_hidden_engines;                   ///< State of the 'show hidden engines' button.
-	bool listview_mode;                         ///< If set, only display the available vehicles and do not show a 'build' button.
-	EngineID sel_engine;                        ///< Currently selected engine, or #EngineID::Invalid()
-	EngineID rename_engine;                     ///< Engine being renamed.
-	GUIEngineList eng_list;
-	CargoType cargo_filter_criteria;              ///< Selected cargo filter
-	int details_height;                         ///< Minimal needed height of the details panels, in text lines (found so far).
-	Scrollbar *vscroll;
-	TestedEngineDetails te;                     ///< Tested cost and capacity after refit.
-	GUIBadgeClasses badge_classes;
+	} filter{}; ///< Filter to apply.
+	bool descending_sort_order = false; ///< Sort direction, @see _engine_sort_direction
+	uint8_t sort_criteria = 0; ///< Current sort criterium.
+	bool show_hidden_engines = false; ///< State of the 'show hidden engines' button.
+	bool listview_mode = false; ///< If set, only display the available vehicles and do not show a 'build' button.
+	EngineID sel_engine = EngineID::Invalid(); ///< Currently selected engine, or #EngineID::Invalid()
+	EngineID rename_engine = EngineID::Invalid(); ///< Engine being renamed.
+	GUIEngineList eng_list{};
+	CargoType cargo_filter_criteria{}; ///< Selected cargo filter
+	int details_height = 0; ///< Minimal needed height of the details panels, in text lines (found so far).
+	Scrollbar *vscroll = nullptr;
+	TestedEngineDetails te{}; ///< Tested cost and capacity after refit.
+	GUIBadgeClasses badge_classes{};
 
-	StringFilter string_filter;                 ///< Filter for vehicle name
-	QueryString vehicle_editbox;                ///< Filter editbox
+	StringFilter string_filter{}; ///< Filter for vehicle name
+	QueryString vehicle_editbox; ///< Filter editbox
 
 	void SetBuyVehicleText()
 	{
@@ -1172,8 +1172,6 @@ struct BuildVehicleWindow : Window {
 		this->vehicle_type = type;
 		this->listview_mode = tile == INVALID_TILE;
 		this->window_number = this->listview_mode ? (int)type : tile.base();
-
-		this->sel_engine = EngineID::Invalid();
 
 		this->sort_criteria         = _engine_sort_last_criteria[type];
 		this->descending_sort_order = _engine_sort_last_order[type];

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -234,15 +234,15 @@ static constexpr NWidgetPart _nested_cheat_widgets[] = {
 
 /** GUI for the cheats. */
 struct CheatWindow : Window {
-	int clicked;
-	int clicked_cheat;
-	uint line_height;
-	Dimension icon;     ///< Dimension of company icon sprite
+	int clicked = 0;
+	int clicked_cheat = 0;
+	uint line_height = 0;
+	Dimension icon{}; ///< Dimension of company icon sprite
 
-	std::vector<const SettingDesc *> sandbox_settings;
-	const SettingDesc *clicked_setting;
-	const SettingDesc *last_clicked_setting;
-	const SettingDesc *valuewindow_entry;
+	std::vector<const SettingDesc *> sandbox_settings{};
+	const SettingDesc *clicked_setting = nullptr;
+	const SettingDesc *last_clicked_setting = nullptr;
+	const SettingDesc *valuewindow_entry = nullptr;
 
 	CheatWindow(WindowDesc &desc) : Window(desc)
 	{

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -336,12 +336,11 @@ struct CompanyFinancesWindow : Window {
 	static constexpr int NUM_PERIODS = WID_CF_EXPS_PRICE3 - WID_CF_EXPS_PRICE1 + 1;
 
 	static Money max_money; ///< The maximum amount of money a company has had this 'run'
-	bool small;             ///< Window is toggled to 'small'.
+	bool small = false; ///< Window is toggled to 'small'.
 	uint8_t first_visible = NUM_PERIODS - 1; ///< First visible expenses column. The last column (current) is always visible.
 
 	CompanyFinancesWindow(WindowDesc &desc, CompanyID company) : Window(desc)
 	{
-		this->small = false;
 		this->CreateNestedTree();
 		this->SetupWidgets();
 		this->FinishInitNested(company);
@@ -1325,15 +1324,15 @@ static constexpr NWidgetPart _nested_select_company_manager_face_widgets[] = {
 /** Management class for customizing the face of the company manager. */
 class SelectCompanyManagerFaceWindow : public Window
 {
-	CompanyManagerFace face; ///< company manager face bits
-	bool advanced; ///< advanced company manager face selection window
+	CompanyManagerFace face{}; ///< company manager face bits
+	bool advanced = false; ///< advanced company manager face selection window
 
-	GenderEthnicity ge; ///< Gender and ethnicity.
-	bool is_female;     ///< Female face.
-	bool is_moust_male; ///< Male face with a moustache.
+	GenderEthnicity ge{}; ///< Gender and ethnicity.
+	bool is_female = false;     ///< Female face.
+	bool is_moust_male = false; ///< Male face with a moustache.
 
-	Dimension yesno_dim;  ///< Dimension of a yes/no button of a part in the advanced face window.
-	Dimension number_dim; ///< Dimension of a number widget of a part in the advanced face window.
+	Dimension yesno_dim{};  ///< Dimension of a yes/no button of a part in the advanced face window.
+	Dimension number_dim{}; ///< Dimension of a number widget of a part in the advanced face window.
 
 	/**
 	 * Set parameters for value of face control buttons.
@@ -1373,7 +1372,6 @@ class SelectCompanyManagerFaceWindow : public Window
 public:
 	SelectCompanyManagerFaceWindow(WindowDesc &desc, Window *parent) : Window(desc)
 	{
-		this->advanced = false;
 		this->CreateNestedTree();
 		this->SelectDisplayPlanes(this->advanced);
 		this->FinishInitNested(parent->window_number);
@@ -1786,10 +1784,10 @@ static constexpr NWidgetPart _nested_company_infrastructure_widgets[] = {
  */
 struct CompanyInfrastructureWindow : Window
 {
-	RailTypes railtypes; ///< Valid railtypes.
-	RoadTypes roadtypes; ///< Valid roadtypes.
+	RailTypes railtypes{}; ///< Valid railtypes.
+	RoadTypes roadtypes{}; ///< Valid roadtypes.
 
-	uint total_width; ///< String width of the total cost line.
+	uint total_width = 0; ///< String width of the total cost line.
 
 	CompanyInfrastructureWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{
@@ -2204,7 +2202,7 @@ static const StringID _company_view_vehicle_count_strings[] = {
  */
 struct CompanyWindow : Window
 {
-	CompanyWidgets query_widget;
+	CompanyWidgets query_widget{};
 
 	/** Display planes in the company window. */
 	enum CompanyWindowPlanes : uint8_t {
@@ -2688,8 +2686,8 @@ struct BuyCompanyWindow : Window {
 	}};
 
 private:
-	bool hostile_takeover; ///< Whether the window is showing a hostile takeover.
-	Money company_value; ///< The value of the company for which the user can buy it.
+	bool hostile_takeover = false; ///< Whether the window is showing a hostile takeover.
+	Money company_value{}; ///< The value of the company for which the user can buy it.
 };
 
 static constexpr NWidgetPart _nested_buy_company_widgets[] = {

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -146,9 +146,9 @@ static WindowDesc _console_window_desc(
 struct IConsoleWindow : Window
 {
 	static size_t scroll;
-	int line_height;   ///< Height of one line of text in the console.
-	int line_offset;
-	int cursor_width;
+	int line_height = 0; ///< Height of one line of text in the console.
+	int line_offset = 0;
+	int cursor_width = 0;
 
 	IConsoleWindow() : Window(_console_window_desc)
 	{

--- a/src/date_gui.cpp
+++ b/src/date_gui.cpp
@@ -24,11 +24,11 @@
 
 /** Window to select a date graphically by using dropdowns */
 struct SetDateWindow : Window {
-	SetDateCallback *callback; ///< Callback to call when a date has been selected
-	void *callback_data;       ///< Callback data pointer.
-	TimerGameEconomy::YearMonthDay date; ///< The currently selected date
-	TimerGameEconomy::Year min_year; ///< The minimum year in the year dropdown
-	TimerGameEconomy::Year max_year; ///< The maximum year (inclusive) in the year dropdown
+	SetDateCallback *callback = nullptr; ///< Callback to call when a date has been selected
+	void *callback_data = nullptr; ///< Callback data pointer.
+	TimerGameEconomy::YearMonthDay date{}; ///< The currently selected date
+	TimerGameEconomy::Year min_year{}; ///< The minimum year in the year dropdown
+	TimerGameEconomy::Year max_year{}; ///< The maximum year (inclusive) in the year dropdown
 
 	/**
 	 * Create the new 'set date' window

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -254,31 +254,29 @@ static void DepotSellAllConfirmationCallback(Window *w, bool confirmed);
 const Sprite *GetAircraftSprite(EngineID engine);
 
 struct DepotWindow : Window {
-	VehicleID sel;
-	VehicleID vehicle_over; ///< Rail vehicle over which another one is dragged, \c VehicleID::Invalid() if none.
-	VehicleType type;
-	bool generate_list;
-	bool check_unitnumber_digits;
-	WidgetID hovered_widget; ///< Index of the widget being hovered during drag/drop. -1 if no drag is in progress.
-	VehicleList vehicle_list;
-	VehicleList wagon_list;
-	uint unitnumber_digits;
-	uint num_columns;       ///< Number of columns.
-	Scrollbar *hscroll;     ///< Only for trains.
-	Scrollbar *vscroll;
+	VehicleID sel = VehicleID::Invalid();
+	VehicleID vehicle_over = VehicleID::Invalid(); ///< Rail vehicle over which another one is dragged, \c VehicleID::Invalid() if none.
+	VehicleType type = VEH_INVALID;
+	bool generate_list = true;
+	bool check_unitnumber_digits = true;
+	WidgetID hovered_widget = -1; ///< Index of the widget being hovered during drag/drop. -1 if no drag is in progress.
+	VehicleList vehicle_list{};
+	VehicleList wagon_list{};
+	uint unitnumber_digits = 2;
+	uint num_columns = 1; ///< Number of columns.
+	Scrollbar *hscroll = nullptr; ///< Only for trains.
+	Scrollbar *vscroll = nullptr;
+	uint count_width = 0; ///< Width of length count, including separator.
+	uint header_width = 0; ///< Width of unit number and flag, including separator.
+	Dimension flag_size{}; ///< Size of start/stop flag.
+	VehicleCellSize cell_size{}; ///< Vehicle sprite cell size.
+	bool last_overlay_state = false;
 
 	DepotWindow(WindowDesc &desc, TileIndex tile, VehicleType type) : Window(desc)
 	{
 		assert(IsCompanyBuildableVehicleType(type)); // ensure that we make the call with a valid type
 
-		this->sel = VehicleID::Invalid();
-		this->vehicle_over = VehicleID::Invalid();
-		this->generate_list = true;
-		this->check_unitnumber_digits = true;
-		this->hovered_widget = -1;
 		this->type = type;
-		this->num_columns = 1; // for non-trains this gets set in FinishInitNested()
-		this->unitnumber_digits = 2;
 
 		this->CreateNestedTree();
 		this->hscroll = (this->type == VEH_TRAIN ? this->GetScrollbar(WID_D_H_SCROLL) : nullptr);
@@ -646,11 +644,6 @@ struct DepotWindow : Window {
 		}
 	}
 
-	uint count_width;          ///< Width of length count, including separator.
-	uint header_width;         ///< Width of unit number and flag, including separator.
-	Dimension flag_size;       ///< Size of start/stop flag.
-	VehicleCellSize cell_size; ///< Vehicle sprite cell size.
-
 	void OnInit() override
 	{
 		this->cell_size = GetVehicleImageCellSize(this->type, EIT_IN_DEPOT);
@@ -991,7 +984,6 @@ struct DepotWindow : Window {
 		}
 	}
 
-	bool last_overlay_state;
 	void OnMouseLoop() override
 	{
 		if (last_overlay_state != ShowCargoIconOverlay()) {

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -98,11 +98,10 @@ static TileIndex GetOtherAqueductEnd(TileIndex tile_from, TileIndex *tile_to = n
 
 /** Toolbar window for constructing water infrastructure. */
 struct BuildDocksToolbarWindow : Window {
-	DockToolbarWidgets last_clicked_widget; ///< Contains the last widget that has been clicked on this toolbar.
+	DockToolbarWidgets last_clicked_widget = WID_DT_INVALID; ///< Contains the last widget that has been clicked on this toolbar.
 
 	BuildDocksToolbarWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{
-		this->last_clicked_widget = WID_DT_INVALID;
 		this->InitNested(window_number);
 		this->OnInvalidateData();
 		if (_settings_client.gui.link_terraform_toolbar) ShowTerraformToolbar(this);

--- a/src/dropdown.cpp
+++ b/src/dropdown.cpp
@@ -70,19 +70,19 @@ static WindowDesc _dropdown_desc(
 
 /** Drop-down menu window */
 struct DropdownWindow : Window {
-	WidgetID parent_button;       ///< Parent widget number where the window is dropped from.
-	Rect wi_rect;                 ///< Rect of the button that opened the dropdown.
-	DropDownList list;            ///< List with dropdown menu items.
-	int selected_result;          ///< Result value of the selected item in the list.
-	uint8_t click_delay = 0;         ///< Timer to delay selection.
+	WidgetID parent_button{}; ///< Parent widget number where the window is dropped from.
+	Rect wi_rect{}; ///< Rect of the button that opened the dropdown.
+	DropDownList list{}; ///< List with dropdown menu items.
+	int selected_result = 0; ///< Result value of the selected item in the list.
+	uint8_t click_delay = 0; ///< Timer to delay selection.
 	bool drag_mode = true;
-	bool instant_close;           ///< Close the window when the mouse button is raised.
-	bool persist;                 ///< Persist dropdown menu.
-	int scrolling = 0;            ///< If non-zero, auto-scroll the item list (one time).
-	Point position;               ///< Position of the topleft corner of the window.
-	Scrollbar *vscroll;
+	bool instant_close = false; ///< Close the window when the mouse button is raised.
+	bool persist = false; ///< Persist dropdown menu.
+	int scrolling = 0; ///< If non-zero, auto-scroll the item list (one time).
+	Point position{}; ///< Position of the topleft corner of the window.
+	Scrollbar *vscroll = nullptr;
 
-	Dimension items_dim; ///< Calculated cropped and padded dimension for the items widget.
+	Dimension items_dim{}; ///< Calculated cropped and padded dimension for the items widget.
 
 	/**
 	 * Create a dropdown menu.

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -68,7 +68,7 @@ static constexpr NWidgetPart _nested_engine_preview_widgets[] = {
 };
 
 struct EnginePreviewWindow : Window {
-	int vehicle_space; // The space to show the vehicle image
+	int vehicle_space = 0; // The space to show the vehicle image
 
 	EnginePreviewWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -118,9 +118,9 @@ bool _window_system_initialized = false;
 /** Window class for displaying an error message window. */
 struct ErrmsgWindow : public Window, ErrorMessageData {
 private:
-	uint height_summary;            ///< Height of the #summary_msg string in pixels in the #WID_EM_MESSAGE widget.
-	uint height_detailed;           ///< Height of the #detailed_msg string in pixels in the #WID_EM_MESSAGE widget.
-	uint height_extra;              ///< Height of the #extra_msg string in pixels in the #WID_EM_MESSAGE widget.
+	uint height_summary = 0; ///< Height of the #summary_msg string in pixels in the #WID_EM_MESSAGE widget.
+	uint height_detailed = 0; ///< Height of the #detailed_msg string in pixels in the #WID_EM_MESSAGE widget.
+	uint height_extra = 0; ///< Height of the #extra_msg string in pixels in the #WID_EM_MESSAGE widget.
 	TimeoutTimer<TimerWindow> display_timeout;
 
 public:

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -324,17 +324,17 @@ private:
 	static const uint EDITBOX_MAX_SIZE   =  50;
 
 	QueryString filename_editbox; ///< Filename editbox.
-	AbstractFileType abstract_filetype; /// Type of file to select.
-	SaveLoadOperation fop;        ///< File operation to perform.
-	FileList fios_items;          ///< Save game list.
-	FiosItem o_dir;               ///< Original dir (home dir for this browser)
-	const FiosItem *selected;     ///< Selected game in #fios_items, or \c nullptr.
-	const FiosItem *highlighted;  ///< Item in fios_items highlighted by mouse pointer, or \c nullptr.
-	Scrollbar *vscroll;
+	AbstractFileType abstract_filetype{}; /// Type of file to select.
+	SaveLoadOperation fop{}; ///< File operation to perform.
+	FileList fios_items{}; ///< Save game list.
+	FiosItem o_dir{}; ///< Original dir (home dir for this browser)
+	const FiosItem *selected = nullptr; ///< Selected game in #fios_items, or \c nullptr.
+	const FiosItem *highlighted = nullptr; ///< Item in fios_items highlighted by mouse pointer, or \c nullptr.
+	Scrollbar *vscroll = nullptr;
 
-	StringFilter string_filter; ///< Filter for available games.
+	StringFilter string_filter{}; ///< Filter for available games.
 	QueryString filter_editbox; ///< Filter editbox;
-	std::vector<FiosItem *> display_list; ///< Filtered display list
+	std::vector<FiosItem *> display_list{}; ///< Filtered display list
 
 	static void SaveGameConfirmationCallback(Window *, bool confirmed)
 	{

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -407,9 +407,9 @@ static constexpr NWidgetPart _framerate_window_widgets[] = {
 };
 
 struct FramerateWindow : Window {
-	bool small;
-	int num_active;
-	int num_displayed;
+	bool small = false;
+	int num_active = 0;
+	int num_displayed = 0;
 
 	struct CachedDecimal {
 		StringID strid;
@@ -438,13 +438,13 @@ struct FramerateWindow : Window {
 		}
 	};
 
-	CachedDecimal rate_gameloop;            ///< cached game loop tick rate
-	CachedDecimal rate_drawing;             ///< cached drawing frame rate
-	CachedDecimal speed_gameloop;           ///< cached game loop speed factor
-	CachedDecimal times_shortterm[PFE_MAX]; ///< cached short term average times
-	CachedDecimal times_longterm[PFE_MAX];  ///< cached long term average times
+	CachedDecimal rate_gameloop{}; ///< cached game loop tick rate
+	CachedDecimal rate_drawing{}; ///< cached drawing frame rate
+	CachedDecimal speed_gameloop{}; ///< cached game loop speed factor
+	std::array<CachedDecimal, PFE_MAX> times_shortterm{}; ///< cached short term average times
+	std::array<CachedDecimal, PFE_MAX> times_longterm{}; ///< cached long term average times
 
-	static constexpr int MIN_ELEMENTS = 5;      ///< smallest number of elements to display
+	static constexpr int MIN_ELEMENTS = 5; ///< smallest number of elements to display
 
 	FramerateWindow(WindowDesc &desc, WindowNumber number) : Window(desc)
 	{
@@ -586,7 +586,7 @@ struct FramerateWindow : Window {
 	}
 
 	/** Render a column of formatted average durations */
-	void DrawElementTimesColumn(const Rect &r, StringID heading_str, const CachedDecimal *values) const
+	void DrawElementTimesColumn(const Rect &r, StringID heading_str, std::span<const CachedDecimal> values) const
 	{
 		const Scrollbar *sb = this->GetScrollbar(WID_FRW_SCROLLBAR);
 		int32_t skip = sb->GetPosition();
@@ -743,18 +743,14 @@ static constexpr NWidgetPart _frametime_graph_window_widgets[] = {
 };
 
 struct FrametimeGraphWindow : Window {
-	int vertical_scale;       ///< number of TIMESTAMP_PRECISION units vertically
-	int horizontal_scale;     ///< number of half-second units horizontally
+	int vertical_scale = TIMESTAMP_PRECISION / 10; ///< number of TIMESTAMP_PRECISION units vertically
+	int horizontal_scale = 4; ///< number of half-second units horizontally
 
-	PerformanceElement element; ///< what element this window renders graph for
-	Dimension graph_size;       ///< size of the main graph area (excluding axis labels)
+	PerformanceElement element{}; ///< what element this window renders graph for
+	Dimension graph_size{}; ///< size of the main graph area (excluding axis labels)
 
-	FrametimeGraphWindow(WindowDesc &desc, WindowNumber number) : Window(desc)
+	FrametimeGraphWindow(WindowDesc &desc, WindowNumber number) : Window(desc), element(static_cast<PerformanceElement>(number))
 	{
-		this->element = (PerformanceElement)number;
-		this->horizontal_scale = 4;
-		this->vertical_scale = TIMESTAMP_PRECISION / 10;
-
 		this->InitNested(number);
 		this->UpdateScale();
 	}


### PR DESCRIPTION
## Motivation / Problem

`Window` is the last user of `ZeroedMemoryAllocator`, but to remove that all member variables of windows need to be properly initialised.


## Description

Explicitly initialise member variables for windows in files starting with 'a' through 'f'.

Some changes of arrays to `std::array` were needed.


## Limitations

There's more to come, but I think this is still a reasonable chunk size for PR. I've made that available as a single PR: #13644 .
I also did not implicitly fix any super classes, e.g. `PickerWindowBase`, as those will be handled in the chunk with the 'p' in it.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
