### PR TITLE
Codechange: remove ZeroedMemoryAllocator

### DIFF
--- a/src/core/alloc_type.hpp
+++ b/src/core/alloc_type.hpp
@@ -10,8 +10,6 @@
 #ifndef ALLOC_TYPE_HPP
 #define ALLOC_TYPE_HPP
 
-#include "alloc_func.hpp"
-
 /**
  * A reusable buffer that can be used for places that temporary allocate
  * a bit of memory and do that very often, or for places where static
@@ -61,43 +59,6 @@ public:
 	{
 		return this->buffer.data();
 	}
-};
-
-/**
- * Base class that provides memory initialization on dynamically created objects.
- * All allocated memory will be zeroed.
- */
-class ZeroedMemoryAllocator
-{
-public:
-	ZeroedMemoryAllocator() {}
-	virtual ~ZeroedMemoryAllocator() = default;
-
-	/**
-	 * Memory allocator for a single class instance.
-	 * @param size the amount of bytes to allocate.
-	 * @return the given amounts of bytes zeroed.
-	 */
-	inline void *operator new(size_t size) { return CallocT<uint8_t>(size); }
-
-	/**
-	 * Memory allocator for an array of class instances.
-	 * @param size the amount of bytes to allocate.
-	 * @return the given amounts of bytes zeroed.
-	 */
-	inline void *operator new[](size_t size) { return CallocT<uint8_t>(size); }
-
-	/**
-	 * Memory release for a single class instance.
-	 * @param ptr  the memory to free.
-	 */
-	inline void operator delete(void *ptr) { free(ptr); }
-
-	/**
-	 * Memory release for an array of class instances.
-	 * @param ptr  the memory to free.
-	 */
-	inline void operator delete[](void *ptr) { free(ptr); }
 };
 
 #endif /* ALLOC_TYPE_HPP */

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -8,6 +8,7 @@
 /** @file gfx.cpp Handling of drawing text and other gfx related stuff. */
 
 #include "stdafx.h"
+#include "core/alloc_func.hpp"
 #include "gfx_layout.h"
 #include "progress.h"
 #include "zoom_func.h"

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -8,6 +8,7 @@
 /** @file gfx_layout.cpp Handling of laying out text. */
 
 #include "stdafx.h"
+#include "core/alloc_func.hpp"
 #include "core/math_func.hpp"
 #include "gfx_layout.h"
 #include "string_func.h"

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -17,6 +17,7 @@
 #include <sqstdaux.h>
 #include <../squirrel/sqpcheader.h>
 #include <../squirrel/sqvm.h>
+#include "../core/alloc_func.hpp"
 
 /**
  * In the memory allocator for Squirrel we want to directly use malloc/realloc, so when the OS

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -8,6 +8,7 @@
 /** @file spritecache.cpp Caching of sprites. */
 
 #include "stdafx.h"
+#include "core/alloc_func.hpp"
 #include "random_access_file_type.h"
 #include "spriteloader/grf.hpp"
 #include "spriteloader/makeindexed.h"

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -10,7 +10,6 @@
 #ifndef WINDOW_GUI_H
 #define WINDOW_GUI_H
 
-#include "core/alloc_type.hpp"
 #include "vehiclelist.h"
 #include "vehicle_type.h"
 #include "viewport_type.h"
@@ -270,7 +269,7 @@ enum TooltipCloseCondition : uint8_t {
 /**
  * Data structure for an opened window
  */
-struct Window : ZeroedMemoryAllocator {
+struct Window {
 private:
 	static std::vector<Window *> closed_windows;
 
@@ -279,8 +278,8 @@ protected:
 	void InitializePositionSize(int x, int y, int min_width, int min_height);
 	virtual void FindWindowPlacementAndResize(int def_width, int def_height);
 
-	std::vector<int> scheduled_invalidation_data;  ///< Data of scheduled OnInvalidateData() calls.
-	bool scheduled_resize; ///< Set if window has been resized.
+	std::vector<int> scheduled_invalidation_data{}; ///< Data of scheduled OnInvalidateData() calls.
+	bool scheduled_resize = false; ///< Set if window has been resized.
 
 	/* Protected to prevent deletion anywhere outside Window::DeleteClosedWindows(). */
 	virtual ~Window();
@@ -296,37 +295,37 @@ public:
 	 */
 	inline void *operator new[](size_t size) = delete;
 
-	WindowDesc &window_desc;    ///< Window description
-	WindowFlags flags;          ///< Window flags
-	WindowClass window_class;   ///< Window class
-	WindowNumber window_number; ///< Window number within the window class
+	WindowDesc &window_desc; ///< Window description
+	WindowFlags flags{}; ///< Window flags
+	WindowClass window_class{}; ///< Window class
+	WindowNumber window_number = 0; ///< Window number within the window class
 
-	int scale; ///< Scale of this window -- used to determine how to resize.
+	int scale = 0; ///< Scale of this window -- used to determine how to resize.
 
-	uint8_t timeout_timer;      ///< Timer value of the WindowFlag::Timeout for flags.
-	uint8_t white_border_timer; ///< Timer value of the WindowFlag::WhiteBorder for flags.
+	uint8_t timeout_timer = 0; ///< Timer value of the WindowFlag::Timeout for flags.
+	uint8_t white_border_timer = 0; ///< Timer value of the WindowFlag::WhiteBorder for flags.
 
-	int left;   ///< x position of left edge of the window
-	int top;    ///< y position of top edge of the window
-	int width;  ///< width of the window (number of pixels to the right in x direction)
-	int height; ///< Height of the window (number of pixels down in y direction)
+	int left = 0; ///< x position of left edge of the window
+	int top = 0; ///< y position of top edge of the window
+	int width = 0; ///< width of the window (number of pixels to the right in x direction)
+	int height = 0; ///< Height of the window (number of pixels down in y direction)
 
-	ResizeInfo resize;  ///< Resize information
+	ResizeInfo resize{}; ///< Resize information
 
-	Owner owner;        ///< The owner of the content shown in this window. Company colour is acquired from this variable.
+	Owner owner = INVALID_OWNER; ///< The owner of the content shown in this window. Company colour is acquired from this variable.
 
-	ViewportData *viewport;          ///< Pointer to viewport data, if present.
-	const NWidgetCore *nested_focus; ///< Currently focused nested widget, or \c nullptr if no nested widget has focus.
-	std::map<WidgetID, QueryString*> querystrings; ///< QueryString associated to WWT_EDITBOX widgets.
-	std::unique_ptr<NWidgetBase> nested_root; ///< Root of the nested tree.
-	WidgetLookup widget_lookup; ///< Indexed access to the nested widget tree. Do not access directly, use #Window::GetWidget() instead.
-	NWidgetStacked *shade_select;    ///< Selection widget (#NWID_SELECTION) to use for shading the window. If \c nullptr, window cannot shade.
-	Dimension unshaded_size;         ///< Last known unshaded size (only valid while shaded).
+	ViewportData *viewport = nullptr; ///< Pointer to viewport data, if present.
+	const NWidgetCore *nested_focus = nullptr; ///< Currently focused nested widget, or \c nullptr if no nested widget has focus.
+	std::map<WidgetID, QueryString*> querystrings{}; ///< QueryString associated to WWT_EDITBOX widgets.
+	std::unique_ptr<NWidgetBase> nested_root{}; ///< Root of the nested tree.
+	WidgetLookup widget_lookup{}; ///< Indexed access to the nested widget tree. Do not access directly, use #Window::GetWidget() instead.
+	NWidgetStacked *shade_select = nullptr; ///< Selection widget (#NWID_SELECTION) to use for shading the window. If \c nullptr, window cannot shade.
+	Dimension unshaded_size{}; ///< Last known unshaded size (only valid while shaded).
 
-	WidgetID mouse_capture_widget;   ///< ID of current mouse capture widget (e.g. dragged scrollbar). -1 if no widget has mouse capture.
+	WidgetID mouse_capture_widget = -1; ///< ID of current mouse capture widget (e.g. dragged scrollbar). -1 if no widget has mouse capture.
 
-	Window *parent;                  ///< Parent window.
-	WindowList::iterator z_position;
+	Window *parent = nullptr; ///< Parent window.
+	WindowList::iterator z_position{};
 
 	template <class NWID>
 	inline const NWID *GetWidget(WidgetID widnum) const;


### PR DESCRIPTION
## Motivation / Problem

`ZeroedMemoryAllocator` is one of the few vestiges that uses C-style memory management. It's much better if we do not use this hacky/transitional solution any more.


## Description

* Explicitly initialise all `Window` member variables (including sub classes), with the usual `std::array` conversions.
* Remove `ZeroedMemoryAllocator`.


## Limitations

Many commits with the same message, which is mostly to make splitting this up later, if required, easier. However, what is being done in them doesn't really differ, only the files it applies to... an mentioning "files starting with 'a' through 'f'" in the commit message is kinda weird. If someone wants to approve this big change, I can merge all those commits into one.

The actual removal of `ZeroedMemoryAllocator` sort-of conflicts with the other PRs that remove uses of C-style memory management because it adds `#include "core/alloc_func.hpp"` to files that currently need it, but might not need it any more when those merge.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
