### PR TITLE
Codechange: Use local string parameters for order and timetable windows.

### DIFF
--- a/src/lang/afrikaans.txt
+++ b/src/lang/afrikaans.txt
@@ -4011,7 +4011,7 @@ STR_ORDER_REFIT_STOP_ORDER                                      :(Herbou na {STR
 STR_ORDER_STOP_ORDER                                            :(Stop)
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Implesiete)
 

--- a/src/lang/arabic_egypt.txt
+++ b/src/lang/arabic_egypt.txt
@@ -3888,8 +3888,8 @@ STR_ORDER_REFIT_STOP_ORDER                                      :هيئت الى
 STR_ORDER_STOP_ORDER                                            :توقف
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(لا يمكن استخدام المحطة){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(لا يمكن استخدام المحطة){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(تلقائى)
 

--- a/src/lang/belarusian.txt
+++ b/src/lang/belarusian.txt
@@ -4962,8 +4962,8 @@ STR_ORDER_STOP_ORDER                                            :(Стоп)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(чакае размеркаваньня)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Няверны тып){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Няверны тып){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Аўтаматычна)
 

--- a/src/lang/brazilian_portuguese.txt
+++ b/src/lang/brazilian_portuguese.txt
@@ -4709,8 +4709,8 @@ STR_ORDER_STOP_ORDER                                            :(Parar)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Aguardar para desagrupar)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Não pode usar a estação){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Não pode usar a estação){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Implícita)
 

--- a/src/lang/bulgarian.txt
+++ b/src/lang/bulgarian.txt
@@ -4685,8 +4685,8 @@ STR_ORDER_STOP_ORDER                                            :(Спри сл�
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Изчакай за раздалечаване)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Не може да ползва станция){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Не може да ползва станция){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :{G=n}(Автоматично)
 

--- a/src/lang/catalan.txt
+++ b/src/lang/catalan.txt
@@ -4709,8 +4709,8 @@ STR_ORDER_STOP_ORDER                                            :(Para)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Espera per a deixar espai entre vehicles)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(No pot usar l'estació){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(No pot usar l'estació){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Implícit)
 

--- a/src/lang/chuvash.txt
+++ b/src/lang/chuvash.txt
@@ -1562,7 +1562,7 @@ STR_ORDER_GO_TO_DEPOT_FORMAT                                    :{STRING} {DEPOT
 
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
 
 
 

--- a/src/lang/croatian.txt
+++ b/src/lang/croatian.txt
@@ -4197,7 +4197,7 @@ STR_ORDER_REFIT_STOP_ORDER                                      :(Prenamijeni u 
 STR_ORDER_STOP_ORDER                                            :(Stani)
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Implicitno)
 

--- a/src/lang/czech.txt
+++ b/src/lang/czech.txt
@@ -4766,8 +4766,8 @@ STR_ORDER_STOP_ORDER                                            :(Zastavit)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Vytvořit rozestup)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Nemůže použít stanici){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Nemůže použít stanici){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Automaticky)
 

--- a/src/lang/danish.txt
+++ b/src/lang/danish.txt
@@ -4686,8 +4686,8 @@ STR_ORDER_STOP_ORDER                                            :(Stop)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(vent med at afkoble)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Kan ikke bruge station){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Kan ikke bruge station){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Automatisk)
 

--- a/src/lang/dutch.txt
+++ b/src/lang/dutch.txt
@@ -4708,8 +4708,8 @@ STR_ORDER_STOP_ORDER                                            :(Stop)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Wacht op ontkreukelen)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Kan station niet gebruiken){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Kan station niet gebruiken){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Impliciet)
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4592,7 +4592,6 @@ STR_ORDERS_TIMETABLE_VIEW_TOOLTIP                               :{BLACK}Switch t
 
 STR_ORDERS_LIST_TOOLTIP                                         :{BLACK}Order list - click on an order to highlight it. Ctrl+Click to scroll to the order's destination
 STR_ORDER_INDEX                                                 :{COMMA}:{NBSP}
-STR_ORDER_TEXT                                                  :{STRING4} {STRING2} {STRING} {STRING}
 
 STR_ORDERS_END_OF_ORDERS                                        :- - End of Orders - -
 STR_ORDERS_END_OF_SHARED_ORDERS                                 :- - End of Shared Orders - -
@@ -4691,63 +4690,62 @@ STR_ORDER_GO_NON_STOP_TO_WAYPOINT                               :Go non-stop via
 STR_ORDER_SERVICE_AT                                            :Service at
 STR_ORDER_SERVICE_NON_STOP_AT                                   :Service non-stop at
 
-STR_ORDER_NEAREST_DEPOT                                         :the nearest
-STR_ORDER_NEAREST_HANGAR                                        :the nearest Hangar
 ###length 3
 STR_ORDER_TRAIN_DEPOT                                           :Train Depot
 STR_ORDER_ROAD_VEHICLE_DEPOT                                    :Road Vehicle Depot
 STR_ORDER_SHIP_DEPOT                                            :Ship Depot
 ###next-name-looks-similar
 
-STR_ORDER_GO_TO_NEAREST_DEPOT_FORMAT                            :{STRING} {STRING} {STRING}
+STR_ORDER_GO_TO_NEAREST_HANGAR_FORMAT                           :{STRING} the nearest Hangar
+STR_ORDER_GO_TO_NEAREST_DEPOT_FORMAT                            :{STRING} the nearest {STRING}
 STR_ORDER_GO_TO_DEPOT_FORMAT                                    :{STRING} {DEPOT}
 
-STR_ORDER_REFIT_ORDER                                           :(Refit to {STRING})
-STR_ORDER_REFIT_STOP_ORDER                                      :(Refit to {STRING} and stop)
-STR_ORDER_STOP_ORDER                                            :(Stop)
+STR_ORDER_REFIT_ORDER                                           :{SPACE}(Refit to {STRING})
+STR_ORDER_REFIT_STOP_ORDER                                      :{SPACE}(Refit to {STRING} and stop)
+STR_ORDER_STOP_ORDER                                            :{SPACE}(Stop)
 
-STR_ORDER_WAIT_TO_UNBUNCH                                       :(Wait to unbunch)
+STR_ORDER_WAIT_TO_UNBUNCH                                       :{SPACE}(Wait to unbunch)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING1}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Can't use station){POP_COLOUR} {STRING} {STATION} {STRING1}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Can't use station){POP_COLOUR} {STRING} {STATION}
 
-STR_ORDER_IMPLICIT                                              :(Implicit)
+STR_ORDER_IMPLICIT                                              :{SPACE}(Implicit)
 
-STR_ORDER_FULL_LOAD                                             :(Full load)
-STR_ORDER_FULL_LOAD_ANY                                         :(Full load any cargo)
-STR_ORDER_NO_LOAD                                               :(No loading)
-STR_ORDER_UNLOAD                                                :(Unload and take cargo)
-STR_ORDER_UNLOAD_FULL_LOAD                                      :(Unload and wait for full load)
-STR_ORDER_UNLOAD_FULL_LOAD_ANY                                  :(Unload and wait for any full load)
-STR_ORDER_UNLOAD_NO_LOAD                                        :(Unload and leave empty)
-STR_ORDER_TRANSFER                                              :(Transfer and take cargo)
-STR_ORDER_TRANSFER_FULL_LOAD                                    :(Transfer and wait for full load)
-STR_ORDER_TRANSFER_FULL_LOAD_ANY                                :(Transfer and wait for any full load)
-STR_ORDER_TRANSFER_NO_LOAD                                      :(Transfer and leave empty)
-STR_ORDER_NO_UNLOAD                                             :(No unloading and take cargo)
-STR_ORDER_NO_UNLOAD_FULL_LOAD                                   :(No unloading and wait for full load)
-STR_ORDER_NO_UNLOAD_FULL_LOAD_ANY                               :(No unloading and wait for any full load)
-STR_ORDER_NO_UNLOAD_NO_LOAD                                     :(No unloading and no loading)
+STR_ORDER_FULL_LOAD                                             :{SPACE}(Full load)
+STR_ORDER_FULL_LOAD_ANY                                         :{SPACE}(Full load any cargo)
+STR_ORDER_NO_LOAD                                               :{SPACE}(No loading)
+STR_ORDER_UNLOAD                                                :{SPACE}(Unload and take cargo)
+STR_ORDER_UNLOAD_FULL_LOAD                                      :{SPACE}(Unload and wait for full load)
+STR_ORDER_UNLOAD_FULL_LOAD_ANY                                  :{SPACE}(Unload and wait for any full load)
+STR_ORDER_UNLOAD_NO_LOAD                                        :{SPACE}(Unload and leave empty)
+STR_ORDER_TRANSFER                                              :{SPACE}(Transfer and take cargo)
+STR_ORDER_TRANSFER_FULL_LOAD                                    :{SPACE}(Transfer and wait for full load)
+STR_ORDER_TRANSFER_FULL_LOAD_ANY                                :{SPACE}(Transfer and wait for any full load)
+STR_ORDER_TRANSFER_NO_LOAD                                      :{SPACE}(Transfer and leave empty)
+STR_ORDER_NO_UNLOAD                                             :{SPACE}(No unloading and take cargo)
+STR_ORDER_NO_UNLOAD_FULL_LOAD                                   :{SPACE}(No unloading and wait for full load)
+STR_ORDER_NO_UNLOAD_FULL_LOAD_ANY                               :{SPACE}(No unloading and wait for any full load)
+STR_ORDER_NO_UNLOAD_NO_LOAD                                     :{SPACE}(No unloading and no loading)
 
-STR_ORDER_AUTO_REFIT                                            :(Refit to {STRING})
-STR_ORDER_FULL_LOAD_REFIT                                       :(Full load with refit to {STRING})
-STR_ORDER_FULL_LOAD_ANY_REFIT                                   :(Full load any cargo with refit to {STRING})
-STR_ORDER_UNLOAD_REFIT                                          :(Unload and take cargo with refit to {STRING})
-STR_ORDER_UNLOAD_FULL_LOAD_REFIT                                :(Unload and wait for full load with refit to {STRING})
-STR_ORDER_UNLOAD_FULL_LOAD_ANY_REFIT                            :(Unload and wait for any full load with refit to {STRING})
-STR_ORDER_TRANSFER_REFIT                                        :(Transfer and take cargo with refit to {STRING})
-STR_ORDER_TRANSFER_FULL_LOAD_REFIT                              :(Transfer and wait for full load with refit to {STRING})
-STR_ORDER_TRANSFER_FULL_LOAD_ANY_REFIT                          :(Transfer and wait for any full load with refit to {STRING})
-STR_ORDER_NO_UNLOAD_REFIT                                       :(No unloading and take cargo with refit to {STRING})
-STR_ORDER_NO_UNLOAD_FULL_LOAD_REFIT                             :(No unloading and wait for full load with refit to {STRING})
-STR_ORDER_NO_UNLOAD_FULL_LOAD_ANY_REFIT                         :(No unloading and wait for any full load with refit to {STRING})
+STR_ORDER_AUTO_REFIT                                            :{SPACE}(Refit to {STRING})
+STR_ORDER_FULL_LOAD_REFIT                                       :{SPACE}(Full load with refit to {STRING})
+STR_ORDER_FULL_LOAD_ANY_REFIT                                   :{SPACE}(Full load any cargo with refit to {STRING})
+STR_ORDER_UNLOAD_REFIT                                          :{SPACE}(Unload and take cargo with refit to {STRING})
+STR_ORDER_UNLOAD_FULL_LOAD_REFIT                                :{SPACE}(Unload and wait for full load with refit to {STRING})
+STR_ORDER_UNLOAD_FULL_LOAD_ANY_REFIT                            :{SPACE}(Unload and wait for any full load with refit to {STRING})
+STR_ORDER_TRANSFER_REFIT                                        :{SPACE}(Transfer and take cargo with refit to {STRING})
+STR_ORDER_TRANSFER_FULL_LOAD_REFIT                              :{SPACE}(Transfer and wait for full load with refit to {STRING})
+STR_ORDER_TRANSFER_FULL_LOAD_ANY_REFIT                          :{SPACE}(Transfer and wait for any full load with refit to {STRING})
+STR_ORDER_NO_UNLOAD_REFIT                                       :{SPACE}(No unloading and take cargo with refit to {STRING})
+STR_ORDER_NO_UNLOAD_FULL_LOAD_REFIT                             :{SPACE}(No unloading and wait for full load with refit to {STRING})
+STR_ORDER_NO_UNLOAD_FULL_LOAD_ANY_REFIT                         :{SPACE}(No unloading and wait for any full load with refit to {STRING})
 
 STR_ORDER_AUTO_REFIT_ANY                                        :available cargo
 
 ###length 3
-STR_ORDER_STOP_LOCATION_NEAR_END                                :[near end]
-STR_ORDER_STOP_LOCATION_MIDDLE                                  :[middle]
-STR_ORDER_STOP_LOCATION_FAR_END                                 :[far end]
+STR_ORDER_STOP_LOCATION_NEAR_END                                :{SPACE}[near end]
+STR_ORDER_STOP_LOCATION_MIDDLE                                  :{SPACE}[middle]
+STR_ORDER_STOP_LOCATION_FAR_END                                 :{SPACE}[far end]
 
 STR_ORDER_OUT_OF_RANGE                                          :{RED} (Next destination is out of range)
 
@@ -4772,8 +4770,8 @@ STR_TIMETABLE_TRAVEL_FOR                                        :Travel for {STR
 STR_TIMETABLE_TRAVEL_FOR_SPEED                                  :Travel for {STRING1} with at most {VELOCITY}
 STR_TIMETABLE_TRAVEL_FOR_ESTIMATED                              :Travel (for {STRING1}, not timetabled)
 STR_TIMETABLE_TRAVEL_FOR_SPEED_ESTIMATED                        :Travel (for {STRING1}, not timetabled) with at most {VELOCITY}
-STR_TIMETABLE_STAY_FOR_ESTIMATED                                :(stay for {STRING1}, not timetabled)
-STR_TIMETABLE_AND_TRAVEL_FOR_ESTIMATED                          :(travel for {STRING1}, not timetabled)
+STR_TIMETABLE_STAY_FOR_ESTIMATED                                :{SPACE}(stay for {STRING1}, not timetabled)
+STR_TIMETABLE_AND_TRAVEL_FOR_ESTIMATED                          :{SPACE}(travel for {STRING1}, not timetabled)
 STR_TIMETABLE_STAY_FOR                                          :and stay for {STRING1}
 STR_TIMETABLE_AND_TRAVEL_FOR                                    :and travel for {STRING1}
 

--- a/src/lang/english_AU.txt
+++ b/src/lang/english_AU.txt
@@ -4708,8 +4708,8 @@ STR_ORDER_STOP_ORDER                                            :(Stop)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Wait to unbunch)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Can't use station){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Can't use station){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Implicit)
 

--- a/src/lang/english_US.txt
+++ b/src/lang/english_US.txt
@@ -4707,8 +4707,8 @@ STR_ORDER_STOP_ORDER                                            :(Stop)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Wait to unbunch)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Can't use station){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Can't use station){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Implicit)
 

--- a/src/lang/esperanto.txt
+++ b/src/lang/esperanto.txt
@@ -4506,8 +4506,8 @@ STR_ORDER_REFIT_STOP_ORDER                                      :(Readaptu por p
 STR_ORDER_STOP_ORDER                                            :(Haltu)
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Ne eblas uzi la stacion){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Ne eblas uzi la stacion){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Aŭtomata)
 

--- a/src/lang/estonian.txt
+++ b/src/lang/estonian.txt
@@ -4688,8 +4688,8 @@ STR_ORDER_STOP_ORDER                                            :(Peatu)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(ootab hajutamist)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Ei saa jaama kasutada){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Ei saa jaama kasutada){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Automaatne)
 

--- a/src/lang/faroese.txt
+++ b/src/lang/faroese.txt
@@ -3472,7 +3472,7 @@ STR_ORDER_REFIT_STOP_ORDER                                      :(Bygg um til {S
 STR_ORDER_STOP_ORDER                                            :(Steðga)
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Undirskilt)
 

--- a/src/lang/finnish.txt
+++ b/src/lang/finnish.txt
@@ -4708,8 +4708,8 @@ STR_ORDER_STOP_ORDER                                            :(Pysähdy)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Odota suman purkamiseksi)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Asema ei käytettävissä){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Asema ei käytettävissä){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Ehdoton)
 

--- a/src/lang/french.txt
+++ b/src/lang/french.txt
@@ -4708,8 +4708,8 @@ STR_ORDER_STOP_ORDER                                            :(Arrêt)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Attendre la répartition)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Station inutilisable){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Station inutilisable){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Implicite)
 

--- a/src/lang/frisian.txt
+++ b/src/lang/frisian.txt
@@ -3665,7 +3665,7 @@ STR_ORDER_REFIT_STOP_ORDER                                      :(Ombouwe nei {S
 STR_ORDER_STOP_ORDER                                            :(Stop)
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Ymplisyt)
 

--- a/src/lang/gaelic.txt
+++ b/src/lang/gaelic.txt
@@ -4162,7 +4162,7 @@ STR_ORDER_REFIT_STOP_ORDER                                      :(Mùth airson {
 STR_ORDER_STOP_ORDER                                            :(Stad)
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Fillte a-staigh)
 

--- a/src/lang/galician.txt
+++ b/src/lang/galician.txt
@@ -4709,8 +4709,8 @@ STR_ORDER_STOP_ORDER                                            :(Parar)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(agarda para desagrupar)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Non pode usar a estación){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Non pode usar a estación){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Implícito)
 

--- a/src/lang/german.txt
+++ b/src/lang/german.txt
@@ -4676,8 +4676,8 @@ STR_ORDER_STOP_ORDER                                            :(Stopp)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Warte auf Entpulkung)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Station unbenutzbar){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Station unbenutzbar){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Implizit)
 

--- a/src/lang/greek.txt
+++ b/src/lang/greek.txt
@@ -4809,8 +4809,8 @@ STR_ORDER_STOP_ORDER                                            :(Στάση)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(αναμονή προς αποσύνδεση)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Δεν μπορείτε να χρησιμοποιήσετε τον σταθμό){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Δεν μπορείτε να χρησιμοποιήσετε τον σταθμό){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Σιωπηρή)
 

--- a/src/lang/hebrew.txt
+++ b/src/lang/hebrew.txt
@@ -4248,7 +4248,7 @@ STR_ORDER_STOP_ORDER                                            :(עצור)
 
 
 STR_ORDER_GO_TO_STATION                                         :{2:STRING} {1:STATION} {0:STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(לא ניתן להשתמש בתחנה){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(לא ניתן להשתמש בתחנה){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(משתמע)
 

--- a/src/lang/hindi.txt
+++ b/src/lang/hindi.txt
@@ -1388,8 +1388,8 @@ STR_ORDER_GO_TO_DEPOT_FORMAT                                    :{STRING} {DEPOT
 
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(स्टेशन का उपयोग नहीं कर सकते){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(स्टेशन का उपयोग नहीं कर सकते){POP_COLOUR} {STRING} {STATION}
 
 
 STR_ORDER_NO_LOAD                                               :(कोई लोडिंग नहीं)

--- a/src/lang/hungarian.txt
+++ b/src/lang/hungarian.txt
@@ -4721,8 +4721,8 @@ STR_ORDER_STOP_ORDER                                            :(megáll)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Várakozás csoportbontásra)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Az állomás nem használható){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Az állomás nem használható){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Automata)
 

--- a/src/lang/icelandic.txt
+++ b/src/lang/icelandic.txt
@@ -3669,7 +3669,7 @@ STR_ORDER_REFIT_STOP_ORDER                                      :(Breyta í {STR
 STR_ORDER_STOP_ORDER                                            :(Stopp)
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Undanskilin)
 

--- a/src/lang/ido.txt
+++ b/src/lang/ido.txt
@@ -1439,7 +1439,7 @@ STR_ORDER_GO_TO_DEPOT_FORMAT                                    :{STRING} {DEPOT
 
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
 
 
 

--- a/src/lang/indonesian.txt
+++ b/src/lang/indonesian.txt
@@ -4510,8 +4510,8 @@ STR_ORDER_REFIT_STOP_ORDER                                      :(Pasang {STRING
 STR_ORDER_STOP_ORDER                                            :(Berhenti)
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Tidak dapat menggunakan stasiun){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Tidak dapat menggunakan stasiun){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Terkandung)
 

--- a/src/lang/irish.txt
+++ b/src/lang/irish.txt
@@ -4244,8 +4244,8 @@ STR_ORDER_REFIT_STOP_ORDER                                      :(Athfheistigh g
 STR_ORDER_STOP_ORDER                                            :(Stop)
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Ní féidir an stáisiún a úsáid){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Ní féidir an stáisiún a úsáid){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Uathoibríoch)
 

--- a/src/lang/italian.txt
+++ b/src/lang/italian.txt
@@ -4691,8 +4691,8 @@ STR_ORDER_STOP_ORDER                                            :(Ferma)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(aspetta di liberarsi)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Impossibile usare la stazione){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Impossibile usare la stazione){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Implicito)
 

--- a/src/lang/japanese.txt
+++ b/src/lang/japanese.txt
@@ -4418,7 +4418,7 @@ STR_ORDER_STOP_ORDER                                            :(運用停止)
 
 
 STR_ORDER_GO_TO_STATION                                         :{1:STATION}へ{0:STRING} {2:STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(駅を使用できません){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(駅を使用できません){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(自動)
 

--- a/src/lang/korean.txt
+++ b/src/lang/korean.txt
@@ -4708,8 +4708,8 @@ STR_ORDER_STOP_ORDER                                            :(멈춤)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(배차 간격 유지 대기)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(이 역을 이용할 수 없음){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(이 역을 이용할 수 없음){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(자동)
 

--- a/src/lang/latin.txt
+++ b/src/lang/latin.txt
@@ -4153,7 +4153,7 @@ STR_ORDER_REFIT_STOP_ORDER                                      :(Reficere {STRI
 STR_ORDER_STOP_ORDER                                            :(Consiste)
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Implicitum)
 

--- a/src/lang/latvian.txt
+++ b/src/lang/latvian.txt
@@ -4719,8 +4719,8 @@ STR_ORDER_STOP_ORDER                                            :(Apstādināt)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(gaida atdalīšanu)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Nevar izmantot staciju){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Nevar izmantot staciju){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Netieši)
 

--- a/src/lang/lithuanian.txt
+++ b/src/lang/lithuanian.txt
@@ -4803,7 +4803,7 @@ STR_ORDER_STOP_ORDER                                            :(sustoti)
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Palaukti iškrovimo)
 
 STR_ORDER_GO_TO_STATION                                         :{STRING} „{STATION}“ {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Negalima naudotis stotimi){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Negalima naudotis stotimi){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(automatinis)
 

--- a/src/lang/luxembourgish.txt
+++ b/src/lang/luxembourgish.txt
@@ -4686,8 +4686,8 @@ STR_ORDER_STOP_ORDER                                            :(Stop)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Warden fir ze verspreeën)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Statioun kann net benotzt ginn){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Statioun kann net benotzt ginn){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Implizit)
 

--- a/src/lang/macedonian.txt
+++ b/src/lang/macedonian.txt
@@ -1909,7 +1909,7 @@ STR_ORDER_GO_TO_DEPOT_FORMAT                                    :{STRING} {DEPOT
 
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
 
 
 

--- a/src/lang/malay.txt
+++ b/src/lang/malay.txt
@@ -3584,7 +3584,7 @@ STR_ORDER_REFIT_STOP_ORDER                                      :(Ubahsuai ke {S
 STR_ORDER_STOP_ORDER                                            :(Berhenti)
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Tersirat)
 

--- a/src/lang/maltese.txt
+++ b/src/lang/maltese.txt
@@ -1303,7 +1303,7 @@ STR_ORDER_GO_TO_DEPOT_FORMAT                                    :{STRING} {DEPOT
 
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Awtomatiku)
 

--- a/src/lang/marathi.txt
+++ b/src/lang/marathi.txt
@@ -1713,7 +1713,7 @@ STR_ORDER_GO_TO_DEPOT_FORMAT                                    :{STRING} {DEPOT
 
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(आपोआप)
 

--- a/src/lang/norwegian_bokmal.txt
+++ b/src/lang/norwegian_bokmal.txt
@@ -4709,8 +4709,8 @@ STR_ORDER_STOP_ORDER                                            :(Stopp)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Vent for å fjerne klumping)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Kan ikke bruke stasjon){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Kan ikke bruke stasjon){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Ubetinget)
 

--- a/src/lang/norwegian_nynorsk.txt
+++ b/src/lang/norwegian_nynorsk.txt
@@ -3829,7 +3829,7 @@ STR_ORDER_REFIT_STOP_ORDER                                      :(Bygg om til {S
 STR_ORDER_STOP_ORDER                                            :(Stopp)
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(implisitt)
 

--- a/src/lang/persian.txt
+++ b/src/lang/persian.txt
@@ -3384,7 +3384,7 @@ STR_ORDER_GO_TO_DEPOT_FORMAT                                    :{STRING} {DEPOT
 
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(ضمنی)
 

--- a/src/lang/polish.txt
+++ b/src/lang/polish.txt
@@ -5094,8 +5094,8 @@ STR_ORDER_STOP_ORDER                                            :(Zatrzymaj)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Czekaj na separację)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Nie może korzystać ze stacji){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Nie może korzystać ze stacji){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(sugerowany)
 

--- a/src/lang/portuguese.txt
+++ b/src/lang/portuguese.txt
@@ -4709,8 +4709,8 @@ STR_ORDER_STOP_ORDER                                            :(Parar)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Esperar por desagrupar)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Não pode usar a estação){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Não pode usar a estação){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :{G=f}(Implícita)
 

--- a/src/lang/romanian.txt
+++ b/src/lang/romanian.txt
@@ -4656,8 +4656,8 @@ STR_ORDER_STOP_ORDER                                            :(Stop)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(așteptați să desfaceți)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Stație inutilizabilă){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Stație inutilizabilă){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Implicit)
 

--- a/src/lang/russian.txt
+++ b/src/lang/russian.txt
@@ -4895,8 +4895,8 @@ STR_ORDER_STOP_ORDER                                            :(Стоп)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Распределить)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Неверный тип){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Неверный тип){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Автоматически)
 

--- a/src/lang/serbian.txt
+++ b/src/lang/serbian.txt
@@ -4725,8 +4725,8 @@ STR_ORDER_REFIT_STOP_ORDER                                      :(Prepravi za {S
 STR_ORDER_STOP_ORDER                                            :(Stani)
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Ne može koristiti stanicu){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Ne može koristiti stanicu){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Podrazumevano)
 

--- a/src/lang/simplified_chinese.txt
+++ b/src/lang/simplified_chinese.txt
@@ -4708,8 +4708,8 @@ STR_ORDER_STOP_ORDER                                            :（停留）
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :（班次均匀）
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}（不能使用车站）{POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}（不能使用车站）{POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :（自动）
 

--- a/src/lang/slovak.txt
+++ b/src/lang/slovak.txt
@@ -4690,8 +4690,8 @@ STR_ORDER_STOP_ORDER                                            :(Zastav)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Počkať na rozdelenie)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Nemožno použiť stanicu){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Nemožno použiť stanicu){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Predpokladané)
 

--- a/src/lang/slovenian.txt
+++ b/src/lang/slovenian.txt
@@ -4046,7 +4046,7 @@ STR_ORDER_REFIT_STOP_ORDER                                      :(Preuredi v {ST
 STR_ORDER_STOP_ORDER                                            :(Stop)
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Implicitno)
 

--- a/src/lang/spanish.txt
+++ b/src/lang/spanish.txt
@@ -4688,8 +4688,8 @@ STR_ORDER_STOP_ORDER                                            :(Detenerse)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Esperar para distanciarse)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(No puede usar la estación){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(No puede usar la estación){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Implícita)
 

--- a/src/lang/spanish_MX.txt
+++ b/src/lang/spanish_MX.txt
@@ -4709,8 +4709,8 @@ STR_ORDER_STOP_ORDER                                            :(Detenerse)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Esperar para espaciar)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(No se puede usar la estación){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(No se puede usar la estación){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Implícito)
 

--- a/src/lang/swedish.txt
+++ b/src/lang/swedish.txt
@@ -4691,8 +4691,8 @@ STR_ORDER_STOP_ORDER                                            :(Stanna)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Invänta utglesning)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Kan ej använda stationen){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Kan ej använda stationen){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Underförstådd)
 

--- a/src/lang/tamil.txt
+++ b/src/lang/tamil.txt
@@ -4229,8 +4229,8 @@ STR_ORDER_STOP_ORDER                                            :(நிறு�
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(அவிழ்க்க காத்திருக்கவும்)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(நிலையத்தைப் பயன்படுத்த முடியாது){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(நிலையத்தைப் பயன்படுத்த முடியாது){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(தானியங்கி)
 

--- a/src/lang/thai.txt
+++ b/src/lang/thai.txt
@@ -4001,7 +4001,7 @@ STR_ORDER_REFIT_STOP_ORDER                                      :(ดัดแ�
 STR_ORDER_STOP_ORDER                                            :(หยุด)
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(อัตโนมัติ)
 

--- a/src/lang/traditional_chinese.txt
+++ b/src/lang/traditional_chinese.txt
@@ -4708,8 +4708,8 @@ STR_ORDER_STOP_ORDER                                            :(停止)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :（等候調節班次）
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(不能使用車站){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(不能使用車站){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(內含)
 

--- a/src/lang/turkish.txt
+++ b/src/lang/turkish.txt
@@ -4648,8 +4648,8 @@ STR_ORDER_STOP_ORDER                                            :(Dur)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(gruptan ayrılmayı bekle)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(İstasyon kullanılamıyor){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(İstasyon kullanılamıyor){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Otomatik)
 

--- a/src/lang/ukrainian.txt
+++ b/src/lang/ukrainian.txt
@@ -4805,8 +4805,8 @@ STR_ORDER_STOP_ORDER                                            :(зупинит
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(чекати на розподілення за інтервалом)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Неможливо використати станцію){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Неможливо використати станцію){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Автоматично)
 

--- a/src/lang/urdu.txt
+++ b/src/lang/urdu.txt
@@ -2660,7 +2660,7 @@ STR_ORDER_GO_TO_DEPOT_FORMAT                                    :{STRING} {DEPOT
 
 
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
 
 
 

--- a/src/lang/vietnamese.txt
+++ b/src/lang/vietnamese.txt
@@ -4690,8 +4690,8 @@ STR_ORDER_STOP_ORDER                                            :(Dừng)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(Chờ để gỡ gộp)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Không thể sử dụng trạm){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Không thể sử dụng trạm){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Chạy ngầm)
 

--- a/src/lang/welsh.txt
+++ b/src/lang/welsh.txt
@@ -4661,8 +4661,8 @@ STR_ORDER_STOP_ORDER                                            :(Stopio)
 
 STR_ORDER_WAIT_TO_UNBUNCH                                       :(aros i ddad-glystru)
 
-STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING}
-STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Methu defnyddio gorsaf){POP_COLOUR} {STRING} {STATION} {STRING}
+STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Methu defnyddio gorsaf){POP_COLOUR} {STRING} {STATION}
 
 STR_ORDER_IMPLICIT                                              :(Ymhlyg)
 

--- a/src/timetable.h
+++ b/src/timetable.h
@@ -10,6 +10,7 @@
 #ifndef TIMETABLE_H
 #define TIMETABLE_H
 
+#include "strings_type.h"
 #include "timer/timer_game_tick.h"
 #include "timer/timer_game_economy.h"
 #include "vehicle_type.h"
@@ -27,6 +28,7 @@ TimerGameEconomy::Date GetDateFromStartTick(TimerGameTick::TickCounter start_tic
 
 void ShowTimetableWindow(const Vehicle *v);
 void UpdateVehicleTimetable(Vehicle *v, bool travelling);
-void SetTimetableParams(int param1, int param2, TimerGameTick::Ticks ticks);
+
+std::pair<StringParameter, StringParameter> GetTimetableParameters(TimerGameTick::Ticks ticks);
 
 #endif /* TIMETABLE_H */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Part of removal of global string parameters.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use parameterised GetString() when formatting order and timetable strings.

Order display is now composed of concatenated strings instead of a complex 10-parameter format string, which simplifies things and fixes duplicate spaces.

So this fixes #12267, but coincidentally.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

## Limitations

Using string concatenation may affect case/gender resolution, but I'm not sure if that's much of an issue with the way the strings were already composed of optional parts.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
