### PR TITLE
Codechange: explicitly initialise member variables of Windows (2 of 5)

### DIFF
--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -85,21 +85,18 @@ static WindowDesc _gs_config_desc(
  * Window to configure which GSs will start.
  */
 struct GSConfigWindow : public Window {
-	ScriptConfig *gs_config; ///< The configuration we're modifying.
-	int line_height;         ///< Height of a single GS-name line.
-	int clicked_button;      ///< The button we clicked.
-	bool clicked_increase;   ///< Whether we clicked the increase or decrease button.
-	bool clicked_dropdown;   ///< Whether the dropdown is open.
-	bool closing_dropdown;   ///< True, if the dropdown list is currently closing.
-	int clicked_row;         ///< The clicked row of settings.
-	Scrollbar *vscroll;      ///< Cache of the vertical scrollbar.
+	ScriptConfig *gs_config = nullptr; ///< The configuration we're modifying.
+	int line_height = 0; ///< Height of a single GS-name line.
+	int clicked_button = -1; ///< The button we clicked.
+	bool clicked_increase = false; ///< Whether we clicked the increase or decrease button.
+	bool clicked_dropdown = false; ///< Whether the dropdown is open.
+	bool closing_dropdown = false; ///< True, if the dropdown list is currently closing.
+	int clicked_row = 0; ///< The clicked row of settings.
+	Scrollbar *vscroll = nullptr; ///< Cache of the vertical scrollbar.
 	typedef std::vector<const ScriptConfigItem *> VisibleSettingsList; ///< typdef for a vector of script settings
-	VisibleSettingsList visible_settings; ///< List of visible GS settings
+	VisibleSettingsList visible_settings{}; ///< List of visible GS settings
 
-	GSConfigWindow() : Window(_gs_config_desc),
-		clicked_button(-1),
-		clicked_dropdown(false),
-		closing_dropdown(false)
+	GSConfigWindow() : Window(_gs_config_desc)
 	{
 		this->gs_config = GameConfig::GetConfig();
 

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -385,11 +385,11 @@ static const StringID _variety[]     = {STR_VARIETY_NONE, STR_VARIETY_VERY_LOW, 
 static_assert(std::size(_num_inds) == ID_END);
 
 struct GenerateLandscapeWindow : public Window {
-	WidgetID widget_id;
-	uint x;
-	uint y;
-	std::string name;
-	GenerateLandscapeWindowMode mode;
+	WidgetID widget_id{};
+	uint x = 0;
+	uint y = 0;
+	std::string name{};
+	GenerateLandscapeWindowMode mode{};
 
 	GenerateLandscapeWindow(WindowDesc &desc, WindowNumber number = 0) : Window(desc)
 	{
@@ -1065,7 +1065,7 @@ void StartNewGameWithoutGUI(uint32_t seed)
 
 struct CreateScenarioWindow : public Window
 {
-	WidgetID widget_id;
+	WidgetID widget_id{};
 
 	CreateScenarioWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{

--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -38,7 +38,7 @@ enum GoalColumn : uint8_t {
 
 /** Window for displaying goals. */
 struct GoalListWindow : public Window {
-	Scrollbar *vscroll; ///< Reference to the scrollbar widget.
+	Scrollbar *vscroll = nullptr; ///< Reference to the scrollbar widget.
 
 	GoalListWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{
@@ -322,10 +322,10 @@ void ShowGoalsList(CompanyID company)
 
 /** Ask a question about a goal. */
 struct GoalQuestionWindow : public Window {
-	std::string question; ///< Question to ask (private copy).
-	int buttons;          ///< Number of valid buttons in #button.
-	int button[3];        ///< Buttons to display.
-	TextColour colour;    ///< Colour of the question text.
+	std::string question{}; ///< Question to ask (private copy).
+	int buttons = 0; ///< Number of valid buttons in #button.
+	std::array<int, 3> button{}; ///< Buttons to display.
+	TextColour colour{}; ///< Colour of the question text.
 
 	GoalQuestionWindow(WindowDesc &desc, WindowNumber window_number, TextColour colour, uint32_t button_mask, const std::string &question) : Window(desc), colour(colour)
 	{

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -184,24 +184,24 @@ protected:
 	static const int MIN_GRAPH_NUM_LINES_Y  =   9; ///< Minimal number of horizontal lines to draw.
 	static const int MIN_GRID_PIXEL_SIZE    =  20; ///< Minimum distance between graph lines.
 
-	uint64_t excluded_data; ///< bitmask of the datasets that shouldn't be displayed.
-	uint64_t excluded_range; ///< bitmask of ranges that should not be displayed.
-	uint8_t num_on_x_axis;
-	uint8_t num_vert_lines;
+	uint64_t excluded_data = 0; ///< bitmask of the datasets that shouldn't be displayed.
+	uint64_t excluded_range = 0; ///< bitmask of ranges that should not be displayed.
+	uint8_t num_on_x_axis = 0;
+	uint8_t num_vert_lines = GRAPH_NUM_MONTHS;
 
 	/* The starting month and year that values are plotted against. */
-	TimerGameEconomy::Month month;
-	TimerGameEconomy::Year year;
-	uint8_t month_increment; ///< month increment between vertical lines. must be divisor of 12.
+	TimerGameEconomy::Month month{};
+	TimerGameEconomy::Year year{};
+	uint8_t month_increment = 3; ///< month increment between vertical lines. must be divisor of 12.
 
 	bool draw_dates = true; ///< Should we draw months and years on the time axis?
 
 	/* These values are used if the graph is being plotted against values
 	 * rather than the dates specified by month and year. */
-	uint16_t x_values_start;
-	uint16_t x_values_increment;
+	uint16_t x_values_start = 0;
+	uint16_t x_values_increment = 0;
 
-	StringID format_str_y_axis;
+	StringID format_str_y_axis{};
 
 	struct DataSet {
 		std::array<OverflowSafeInt64, GRAPH_NUM_MONTHS> values;
@@ -210,7 +210,7 @@ protected:
 		uint8_t range_bit;
 		uint8_t dash;
 	};
-	std::vector<DataSet> data;
+	std::vector<DataSet> data{};
 
 	std::span<const StringID> ranges = {};
 
@@ -519,8 +519,6 @@ protected:
 			format_str_y_axis(format_str_y_axis)
 	{
 		SetWindowDirty(WC_GRAPH_LEGEND, 0);
-		this->num_vert_lines = GRAPH_NUM_MONTHS;
-		this->month_increment = 3;
 	}
 
 	void InitializeWindow(WindowNumber number)
@@ -1026,9 +1024,9 @@ void ShowCompanyValueGraph()
 /*****************/
 
 struct PaymentRatesGraphWindow : BaseGraphWindow {
-	uint line_height;   ///< Pixel height of each cargo type row.
-	Scrollbar *vscroll; ///< Cargo list scrollbar.
-	uint legend_width;  ///< Width of legend 'blob'.
+	uint line_height = 0; ///< Pixel height of each cargo type row.
+	Scrollbar *vscroll = nullptr; ///< Cargo list scrollbar.
+	uint legend_width = 0; ///< Width of legend 'blob'.
 
 	PaymentRatesGraphWindow(WindowDesc &desc, WindowNumber window_number) :
 			BaseGraphWindow(desc, STR_JUST_CURRENCY_SHORT)
@@ -1262,7 +1260,15 @@ void ShowCargoPaymentRates()
 
 struct PerformanceRatingDetailWindow : Window {
 	static CompanyID company;
-	int timeout;
+	int timeout = 0;
+	uint score_info_left = 0;
+	uint score_info_right = 0;
+	uint bar_left = 0;
+	uint bar_right = 0;
+	uint bar_width = 0;
+	uint bar_height = 0;
+	uint score_detail_left = 0;
+	uint score_detail_right = 0;
 
 	PerformanceRatingDetailWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{
@@ -1282,15 +1288,6 @@ struct PerformanceRatingDetailWindow : Window {
 
 		this->timeout = Ticks::DAY_TICKS * 5;
 	}
-
-	uint score_info_left;
-	uint score_info_right;
-	uint bar_left;
-	uint bar_right;
-	uint bar_width;
-	uint bar_height;
-	uint score_detail_left;
-	uint score_detail_right;
 
 	void UpdateWidgetSize(WidgetID widget, Dimension &size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension &fill, [[maybe_unused]] Dimension &resize) override
 	{
@@ -1492,9 +1489,9 @@ CompanyID PerformanceRatingDetailWindow::company = CompanyID::Invalid();
 /*******************************/
 
 struct IndustryProductionGraphWindow : BaseGraphWindow {
-	uint line_height;   ///< Pixel height of each cargo type row.
-	Scrollbar *vscroll; ///< Cargo list scrollbar.
-	uint legend_width;  ///< Width of legend 'blob'.
+	uint line_height = 0; ///< Pixel height of each cargo type row.
+	Scrollbar *vscroll = nullptr; ///< Cargo list scrollbar.
+	uint legend_width = 0;  ///< Width of legend 'blob'.
 
 	static inline constexpr StringID RANGE_LABELS[] = {
 		STR_GRAPH_INDUSTRY_RANGE_PRODUCED,

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -199,15 +199,16 @@ private:
 		VGC_END
 	};
 
-	GroupID group_sel;     ///< Selected group (for drag/drop)
-	GroupID group_rename;  ///< Group being renamed, GroupID::Invalid() if none
-	GroupID group_over;    ///< Group over which a vehicle is dragged, GroupID::Invalid() if none
-	GroupID group_confirm; ///< Group awaiting delete confirmation
-	GUIGroupList groups;   ///< List of groups
-	uint tiny_step_height; ///< Step height for the group list
-	Scrollbar *group_sb;
+	GroupID group_sel = GroupID::Invalid(); ///< Selected group (for drag/drop)
+	GroupID group_rename = GroupID::Invalid(); ///< Group being renamed, GroupID::Invalid() if none
+	GroupID group_over = GroupID::Invalid(); ///< Group over which a vehicle is dragged, GroupID::Invalid() if none
+	GroupID group_confirm = GroupID::Invalid(); ///< Group awaiting delete confirmation
+	GUIGroupList groups{}; ///< List of groups
+	uint tiny_step_height = 0; ///< Step height for the group list
+	Scrollbar *group_sb = nullptr;
 
-	Dimension column_size[VGC_END]; ///< Size of the columns in the group list.
+	std::array<Dimension, VGC_END> column_size{}; ///< Size of the columns in the group list.
+	bool last_overlay_state = false;
 
 	/**
 	 * (Re)Build the group list.
@@ -394,9 +395,6 @@ public:
 		this->group_sb = this->GetScrollbar(WID_GL_LIST_GROUP_SCROLLBAR);
 
 		this->vli.SetIndex(ALL_GROUP);
-		this->group_sel = GroupID::Invalid();
-		this->group_rename = GroupID::Invalid();
-		this->group_over = GroupID::Invalid();
 
 		this->groups.ForceRebuild();
 		this->groups.NeedResort();
@@ -692,7 +690,6 @@ public:
 		}
 	}
 
-	bool last_overlay_state;
 	void OnMouseLoop() override
 	{
 		if (last_overlay_state != ShowCargoIconOverlay()) {

--- a/src/highscore_gui.cpp
+++ b/src/highscore_gui.cpp
@@ -30,8 +30,8 @@
 #include "safeguards.h"
 
 struct EndGameHighScoreBaseWindow : Window {
-	uint32_t background_img;
-	int8_t rank;
+	SpriteID background_img{};
+	int8_t rank = 0;
 
 	EndGameHighScoreBaseWindow(WindowDesc &desc) : Window(desc)
 	{
@@ -156,7 +156,7 @@ struct EndGameWindow : EndGameHighScoreBaseWindow {
 };
 
 struct HighScoreWindow : EndGameHighScoreBaseWindow {
-	bool game_paused_by_player; ///< True if the game was paused by the player when the highscore window was opened.
+	bool game_paused_by_player = false; ///< True if the game was paused by the player when the highscore window was opened.
 
 	HighScoreWindow(WindowDesc &desc, int difficulty, int8_t ranking) : EndGameHighScoreBaseWindow(desc)
 	{

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -300,12 +300,12 @@ static WindowDesc _build_industry_desc(
 
 /** Build (fund or prospect) a new industry, */
 class BuildIndustryWindow : public Window {
-	IndustryType selected_type;                 ///< industry corresponding to the above index
-	std::vector<IndustryType> list;             ///< List of industries.
-	bool enabled;                               ///< Availability state of the selected industry.
-	Scrollbar *vscroll;
-	Dimension legend;                           ///< Dimension of the legend 'blob'.
-	GUIBadgeClasses badge_classes;
+	IndustryType selected_type = IT_INVALID; ///< industry corresponding to the above index
+	std::vector<IndustryType> list{}; ///< List of industries.
+	bool enabled = false; ///< Availability state of the selected industry.
+	Scrollbar *vscroll = nullptr;
+	Dimension legend{}; ///< Dimension of the legend 'blob'.
+	GUIBadgeClasses badge_classes{};
 
 	/** The largest allowed minimum-width of the window, given in line heights */
 	static const int MAX_MINWIDTH_LINEHEIGHTS = 20;
@@ -398,8 +398,6 @@ class BuildIndustryWindow : public Window {
 public:
 	BuildIndustryWindow() : Window(_build_industry_desc)
 	{
-		this->selected_type = IT_INVALID;
-
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_DPI_SCROLLBAR);
 		/* Show scenario editor tools in editor. */
@@ -815,22 +813,19 @@ class IndustryViewWindow : public Window
 		IL_RATE2,             ///< Production rate of cargo 2
 	};
 
-	Dimension cargo_icon_size; ///< Largest cargo icon dimension.
-	Editability editable;     ///< Mode for changing production
-	InfoLine editbox_line;    ///< The line clicked to open the edit box
-	InfoLine clicked_line;    ///< The line of the button that has been clicked
-	uint8_t clicked_button;      ///< The button that has been clicked (to raise)
-	int production_offset_y;  ///< The offset of the production texts/buttons
-	int info_height;          ///< Height needed for the #WID_IV_INFO panel
-	int cheat_line_height;    ///< Height of each line for the #WID_IV_INFO panel
+	Dimension cargo_icon_size{}; ///< Largest cargo icon dimension.
+	Editability editable{}; ///< Mode for changing production
+	InfoLine editbox_line = IL_NONE; ///< The line clicked to open the edit box
+	InfoLine clicked_line = IL_NONE; ///< The line of the button that has been clicked
+	uint8_t clicked_button = 0; ///< The button that has been clicked (to raise)
+	int production_offset_y = 0; ///< The offset of the production texts/buttons
+	int info_height = 0; ///< Height needed for the #WID_IV_INFO panel
+	int cheat_line_height = 0; ///< Height of each line for the #WID_IV_INFO panel
 
 public:
 	IndustryViewWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{
 		this->flags.Set(WindowFlag::DisableVpScroll);
-		this->editbox_line = IL_NONE;
-		this->clicked_line = IL_NONE;
-		this->clicked_button = 0;
 		this->info_height = WidgetDimensions::scaled.framerect.Vertical() + 2 * GetCharacterHeight(FS_NORMAL); // Info panel has at least two lines text.
 
 		this->InitNested(window_number);
@@ -1362,16 +1357,16 @@ protected:
 	static const std::initializer_list<GUIIndustryList::SortFunction * const> sorter_funcs;
 
 	GUIIndustryList industries{IndustryDirectoryWindow::produced_cargo_filter};
-	Scrollbar *vscroll;
-	Scrollbar *hscroll;
+	Scrollbar *vscroll{};
+	Scrollbar *hscroll{};
 
-	CargoType produced_cargo_filter_criteria;     ///< Selected produced cargo filter index
-	CargoType accepted_cargo_filter_criteria;     ///< Selected accepted cargo filter index
+	CargoType produced_cargo_filter_criteria{}; ///< Selected produced cargo filter index
+	CargoType accepted_cargo_filter_criteria{}; ///< Selected accepted cargo filter index
 	static CargoType produced_cargo_filter;
 
-	const int MAX_FILTER_LENGTH = 16;           ///< The max length of the filter, in chars
-	StringFilter string_filter;                 ///< Filter for industries
-	QueryString industry_editbox;               ///< Filter editbox
+	const int MAX_FILTER_LENGTH = 16; ///< The max length of the filter, in chars
+	StringFilter string_filter{}; ///< Filter for industries
+	QueryString industry_editbox; ///< Filter editbox
 
 	enum class SorterType : uint8_t {
 		ByName,        ///< Sorter type to sort by name
@@ -2026,27 +2021,27 @@ struct CargoesField {
 	using Cargoes = uint16_t;
 	static_assert(std::numeric_limits<Cargoes>::digits >= MAX_CARGOES);
 
-	CargoesFieldType type; ///< Type of field.
+	CargoesFieldType type{}; ///< Type of field.
 	union {
 		struct {
-			IndustryType ind_type;                 ///< Industry type (#NUM_INDUSTRYTYPES means 'houses').
-			CargoType other_produced[MAX_CARGOES];   ///< Cargoes produced but not used in this figure.
-			CargoType other_accepted[MAX_CARGOES];   ///< Cargoes accepted but not used in this figure.
+			IndustryType ind_type; ///< Industry type (#NUM_INDUSTRYTYPES means 'houses').
+			std::array<CargoType, MAX_CARGOES> other_produced; ///< Cargoes produced but not used in this figure.
+			std::array<CargoType, MAX_CARGOES> other_accepted; ///< Cargoes accepted but not used in this figure.
 		} industry; ///< Industry data (for #CFT_INDUSTRY).
 		struct {
-			CargoType vertical_cargoes[MAX_CARGOES]; ///< Cargoes running from top to bottom (cargo type or #INVALID_CARGO).
+			std::array<CargoType, MAX_CARGOES> vertical_cargoes; ///< Cargoes running from top to bottom (cargo type or #INVALID_CARGO).
 			Cargoes supp_cargoes; ///< Cargoes in \c vertical_cargoes entering from the left.
 			Cargoes cust_cargoes; ///< Cargoes in \c vertical_cargoes leaving to the right.
-			uint8_t num_cargoes;                   ///< Number of cargoes.
-			uint8_t top_end;                       ///< Stop at the top of the vertical cargoes.
-			uint8_t bottom_end;                    ///< Stop at the bottom of the vertical cargoes.
+			uint8_t num_cargoes; ///< Number of cargoes.
+			uint8_t top_end; ///< Stop at the top of the vertical cargoes.
+			uint8_t bottom_end; ///< Stop at the bottom of the vertical cargoes.
 		} cargo; ///< Cargo data (for #CFT_CARGO).
 		struct {
-			CargoType cargoes[MAX_CARGOES];          ///< Cargoes to display (or #INVALID_CARGO).
-			bool left_align;                       ///< Align all cargo texts to the left (else align to the right).
+			std::array<CargoType, MAX_CARGOES> cargoes; ///< Cargoes to display (or #INVALID_CARGO).
+			bool left_align; ///< Align all cargo texts to the left (else align to the right).
 		} cargo_label;   ///< Label data (for #CFT_CARGO_LABEL).
 		StringID header; ///< Header text (for #CFT_HEADER).
-	} u; // Data for each type.
+	} u{}; // Data for each type.
 
 	/**
 	 * Make one of the empty fields (#CFT_EMPTY or #CFT_SMALL_EMPTY).
@@ -2567,11 +2562,11 @@ next_cargo: ;
 struct IndustryCargoesWindow : public Window {
 	typedef std::vector<CargoesRow> Fields;
 
-	Fields fields;  ///< Fields to display in the #WID_IC_PANEL.
-	uint ind_cargo; ///< If less than #NUM_INDUSTRYTYPES, an industry type, else a cargo type + NUM_INDUSTRYTYPES.
-	Dimension cargo_textsize; ///< Size to hold any cargo text, as well as STR_INDUSTRY_CARGOES_SELECT_CARGO.
-	Dimension ind_textsize;   ///< Size to hold any industry type text, as well as STR_INDUSTRY_CARGOES_SELECT_INDUSTRY.
-	Scrollbar *vscroll;
+	Fields fields{}; ///< Fields to display in the #WID_IC_PANEL.
+	uint ind_cargo = 0; ///< If less than #NUM_INDUSTRYTYPES, an industry type, else a cargo type + NUM_INDUSTRYTYPES.
+	Dimension cargo_textsize{}; ///< Size to hold any cargo text, as well as STR_INDUSTRY_CARGOES_SELECT_CARGO.
+	Dimension ind_textsize{}; ///< Size to hold any industry type text, as well as STR_INDUSTRY_CARGOES_SELECT_INDUSTRY.
+	Scrollbar *vscroll = nullptr;
 
 	IndustryCargoesWindow(int id) : Window(_industry_cargoes_desc)
 	{

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -100,13 +100,13 @@ struct IntroGameViewportCommand {
 
 struct SelectGameWindow : public Window {
 	/** Vector of viewport commands parsed. */
-	std::vector<IntroGameViewportCommand> intro_viewport_commands;
+	std::vector<IntroGameViewportCommand> intro_viewport_commands{};
 	/** Index of currently active viewport command. */
-	size_t cur_viewport_command_index;
+	size_t cur_viewport_command_index = SIZE_MAX;
 	/** Time spent (milliseconds) on current viewport command. */
-	uint cur_viewport_command_time;
-	uint mouse_idle_time;
-	Point mouse_idle_pos;
+	uint cur_viewport_command_time = 0;
+	uint mouse_idle_time = 0;
+	Point mouse_idle_pos{};
 
 	/**
 	 * Find and parse all viewport command signs.
@@ -176,18 +176,13 @@ struct SelectGameWindow : public Window {
 		}
 	}
 
-	SelectGameWindow(WindowDesc &desc) : Window(desc)
+	SelectGameWindow(WindowDesc &desc) : Window(desc), mouse_idle_pos(_cursor.pos)
 	{
 		this->CreateNestedTree();
 		this->FinishInitNested(0);
 		this->OnInvalidateData();
 
 		this->ReadIntroGameViewportCommands();
-
-		this->cur_viewport_command_index = SIZE_MAX;
-		this->cur_viewport_command_time = 0;
-		this->mouse_idle_time = 0;
-		this->mouse_idle_pos = _cursor.pos;
 	}
 
 	void OnRealtimeTick(uint delta_ms) override

--- a/src/league_gui.cpp
+++ b/src/league_gui.cpp
@@ -56,11 +56,11 @@ static inline StringID GetPerformanceTitleFromValue(uint value)
 
 class PerformanceLeagueWindow : public Window {
 private:
-	GUIList<const Company *> companies;
-	uint ordinal_width; ///< The width of the ordinal number
-	uint text_width;    ///< The width of the actual text
-	int line_height;    ///< Height of the text lines
-	Dimension icon;     ///< Dimension of the company icon.
+	GUIList<const Company *> companies{};
+	uint ordinal_width = 0; ///< The width of the ordinal number
+	uint text_width = 0; ///< The width of the actual text
+	int line_height = 0; ///< Height of the text lines
+	Dimension icon{}; ///< Dimension of the company icon.
 
 	/**
 	 * (Re)Build the company league list
@@ -257,15 +257,15 @@ static void HandleLinkClick(Link link)
 
 class ScriptLeagueWindow : public Window {
 private:
-	LeagueTableID table;
-	std::vector<std::pair<uint, const LeagueTableElement *>> rows;
-	uint rank_width;     ///< The width of the rank ordinal
-	uint text_width;     ///< The width of the actual text
-	uint score_width;    ///< The width of the score text
-	uint header_height;  ///< Height of the table header
-	int line_height;     ///< Height of the text lines
-	Dimension icon_size; ///< Dimension of the company icon.
-	std::string title;
+	LeagueTableID table{};
+	std::vector<std::pair<uint, const LeagueTableElement *>> rows{};
+	uint rank_width = 0; ///< The width of the rank ordinal
+	uint text_width = 0; ///< The width of the actual text
+	uint score_width = 0; ///< The width of the score text
+	uint header_height = 0; ///< Height of the table header
+	int line_height = 0; ///< Height of the text lines
+	Dimension icon_size{}; ///< Dimension of the company icon.
+	std::string title{};
 
 	/**
 	 * Rebuild the company league list

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -544,10 +544,8 @@ void ShowLinkGraphLegend()
 	AllocateWindowDescFront<LinkGraphLegendWindow>(_linkgraph_legend_desc, 0);
 }
 
-LinkGraphLegendWindow::LinkGraphLegendWindow(WindowDesc &desc, int window_number) : Window(desc)
+LinkGraphLegendWindow::LinkGraphLegendWindow(WindowDesc &desc, int window_number) : Window(desc), num_cargo(_sorted_cargo_specs.size())
 {
-	this->num_cargo = _sorted_cargo_specs.size();
-
 	this->InitNested(window_number);
 	this->InvalidateData(0);
 	this->SetOverlay(GetMainWindow()->viewport->overlay);

--- a/src/linkgraph/linkgraph_gui.h
+++ b/src/linkgraph/linkgraph_gui.h
@@ -115,8 +115,8 @@ public:
 	void OnInvalidateData(int data = 0, bool gui_scope = true) override;
 
 private:
-	std::shared_ptr<LinkGraphOverlay> overlay;
-	size_t num_cargo;
+	std::shared_ptr<LinkGraphOverlay> overlay{};
+	size_t num_cargo = 0;
 
 	void UpdateOverlayCompanies();
 	void UpdateOverlayCargoes();

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -68,11 +68,11 @@ static WindowDesc _land_info_desc(
 );
 
 class LandInfoWindow : public Window {
-	StringList  landinfo_data;    ///< Info lines to show.
-	std::string cargo_acceptance; ///< Centered multi-line string for cargo acceptance.
+	StringList landinfo_data{}; ///< Info lines to show.
+	std::string cargo_acceptance{}; ///< Centered multi-line string for cargo acceptance.
 
 public:
-	TileIndex tile;
+	TileIndex tile = INVALID_TILE;
 
 	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
@@ -442,8 +442,8 @@ static const std::initializer_list<const std::string_view> _credits = {
 };
 
 struct AboutWindow : public Window {
-	int text_position;                       ///< The top of the scrolling text
-	int line_height;                         ///< The height of a single line
+	int text_position = 0; ///< The top of the scrolling text
+	int line_height = 0; ///< The height of a single line
 	static const int num_visible_lines = 19; ///< The number of lines visible simultaneously
 
 	AboutWindow() : Window(_about_desc)
@@ -630,8 +630,8 @@ static WindowDesc _tool_tips_desc(
 /** Window for displaying a tooltip. */
 struct TooltipsWindow : public Window
 {
-	EncodedString text; ///< String to display as tooltip.
-	TooltipCloseCondition close_cond; ///< Condition for closing the window.
+	EncodedString text{}; ///< String to display as tooltip.
+	TooltipCloseCondition close_cond{}; ///< Condition for closing the window.
 
 	TooltipsWindow(Window *parent, EncodedString &&text, TooltipCloseCondition close_tooltip) : Window(_tool_tips_desc), text(std::move(text))
 	{
@@ -926,8 +926,8 @@ void QueryString::ClickEditBox(Window *w, Point pt, WidgetID wid, int click_coun
 /** Class for the string query window. */
 struct QueryStringWindow : public Window
 {
-	QueryString editbox;    ///< Editbox.
-	QueryStringFlags flags; ///< Flags controlling behaviour of the window.
+	QueryString editbox; ///< Editbox.
+	QueryStringFlags flags{}; ///< Flags controlling behaviour of the window.
 
 	QueryStringWindow(std::string_view str, StringID caption, uint max_bytes, uint max_chars, WindowDesc &desc, Window *parent, CharSetFilter afilter, QueryStringFlags flags) :
 			Window(desc), editbox(max_bytes, max_chars)
@@ -1046,9 +1046,9 @@ void ShowQueryString(std::string_view str, StringID caption, uint maxsize, Windo
  * Window used for asking the user a YES/NO question.
  */
 struct QueryWindow : public Window {
-	QueryCallbackProc *proc; ///< callback function executed on closing of popup. Window* points to parent, bool is true if 'yes' clicked, false otherwise
-	EncodedString caption; ///< caption for query window.
-	EncodedString message; ///< message for query window.
+	QueryCallbackProc *proc = nullptr; ///< callback function executed on closing of popup. Window* points to parent, bool is true if 'yes' clicked, false otherwise
+	EncodedString caption{}; ///< caption for query window.
+	EncodedString message{}; ///< message for query window.
 
 	QueryWindow(WindowDesc &desc, EncodedString &&caption, EncodedString &&message, Window *parent, QueryCallbackProc *callback)
 		: Window(desc), proc(callback), caption(std::move(caption)), message(std::move(message))


### PR DESCRIPTION
## Motivation / Problem

`Window` is the last user of `ZeroedMemoryAllocator`, but to remove that all member variables of windows need to be properly initialised.


## Description

Explicitly initialise member variables for windows in files starting with 'g' through 'm'.

Some changes of arrays to `std::array` were needed.


## Limitations

There's more to come, but I think this is still a reasonable chunk size for PR. I've made that available as a single PR: #13644.
I also did not implicitly fix any super classes, e.g. `PickerWindowBase`, as those will be handled in the chunk with the 'p' in it.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
