### PR TITLE
Codechange: replace C-style memory management in MacOS code

### DIFF
--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -92,8 +92,8 @@ private:
 class VideoDriver_CocoaQuartz : public VideoDriver_Cocoa {
 private:
 	int buffer_depth;     ///< Colour depth of used frame buffer
-	void *pixel_buffer;   ///< used for direct pixel access
-	void *window_buffer;  ///< Colour translation from palette to screen
+	std::unique_ptr<uint8_t[]> pixel_buffer; ///< used for direct pixel access
+	std::unique_ptr<uint32_t[]> window_buffer; ///< Colour translation from palette to screen
 
 	int window_width;     ///< Current window width in pixel
 	int window_height;    ///< Current window height in pixel
@@ -123,7 +123,7 @@ protected:
 
 	NSView *AllocateDrawView() override;
 
-	void *GetVideoPointer() override { return this->buffer_depth == 8 ? this->pixel_buffer : this->window_buffer; }
+	void *GetVideoPointer() override { return this->buffer_depth == 8 ? static_cast<void *>(this->pixel_buffer.get()) : static_cast<void *>(this->window_buffer.get()); }
 };
 
 class FVideoDriver_CocoaQuartz : public DriverFactoryBase {


### PR DESCRIPTION
## Motivation / Problem

MacOS code is actually using `malloc` (not even `MallocT`) over C++ style memory management.


## Description

Replace the malloc-ed buffer with `std::unique_ptr` instead.


## Limitations

I can't actually test on MacOS.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
