### PR TITLE
Codechange: explicitly initialise member variables of Windows (3 of 5)

### DIFF
--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -297,8 +297,8 @@ private:
 
 /** Window to enter the chat message in. */
 struct NetworkChatWindow : public Window {
-	DestType dtype;       ///< The type of destination.
-	int dest;             ///< The identifier of the destination.
+	DestType dtype{}; ///< The type of destination.
+	int dest = 0; ///< The identifier of the destination.
 	QueryString message_editbox; ///< Message editbox.
 	NetworkChatAutoCompletion chat_tab_completion; ///< Holds the state and logic of auto-completion of player names and towns on Tab press.
 
@@ -309,10 +309,8 @@ struct NetworkChatWindow : public Window {
 	 * @param dest The actual destination index.
 	 */
 	NetworkChatWindow(WindowDesc &desc, DestType type, int dest)
-			: Window(desc), message_editbox(NETWORK_CHAT_LENGTH), chat_tab_completion(&message_editbox.text)
+			: Window(desc), dtype(type), dest(dest), message_editbox(NETWORK_CHAT_LENGTH), chat_tab_completion(&message_editbox.text)
 	{
-		this->dtype   = type;
-		this->dest    = dest;
 		this->querystrings[WID_NC_TEXTBOX] = &this->message_editbox;
 		this->message_editbox.cancel_button = WID_NC_CLOSE;
 		this->message_editbox.ok_button = WID_NC_SENDBUTTON;

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -39,7 +39,7 @@ static bool _accepted_external_search = false;
 
 /** Window for displaying the textfile of an item in the content list. */
 struct ContentTextfileWindow : public TextfileWindow {
-	const ContentInfo *ci; ///< View the textfile of this ContentInfo.
+	const ContentInfo *ci = nullptr; ///< View the textfile of this ContentInfo.
 
 	ContentTextfileWindow(TextfileType file_type, const ContentInfo *ci) : TextfileWindow(file_type), ci(ci)
 	{
@@ -101,8 +101,7 @@ static WindowDesc _network_content_download_status_window_desc(
 	_nested_network_content_download_status_window_widgets
 );
 
-BaseNetworkContentDownloadStatusWindow::BaseNetworkContentDownloadStatusWindow(WindowDesc &desc) :
-		Window(desc), downloaded_bytes(0), downloaded_files(0), cur_id(UINT32_MAX)
+BaseNetworkContentDownloadStatusWindow::BaseNetworkContentDownloadStatusWindow(WindowDesc &desc) : Window(desc)
 {
 	_network_content_client.AddCallback(this);
 	_network_content_client.DownloadSelectedContent(this->total_files, this->total_bytes);
@@ -184,7 +183,7 @@ void BaseNetworkContentDownloadStatusWindow::OnDownloadProgress(const ContentInf
 /** Window for showing the download status of content */
 struct NetworkContentDownloadStatusWindow : public BaseNetworkContentDownloadStatusWindow {
 private:
-	std::vector<ContentType> receivedTypes;     ///< Types we received so we can update their cache
+	std::vector<ContentType> receivedTypes{}; ///< Types we received so we can update their cache
 
 public:
 	/**
@@ -330,16 +329,16 @@ class NetworkContentListWindow : public Window, ContentCallback {
 	static Filtering last_filtering; ///< The last filtering setting.
 	static const std::initializer_list<GUIContentList::SortFunction * const> sorter_funcs;   ///< Sorter functions
 	static const std::initializer_list<GUIContentList::FilterFunction * const> filter_funcs; ///< Filter functions.
-	GUIContentList content;      ///< List with content
-	bool auto_select;            ///< Automatically select all content when the meta-data becomes available
-	ContentListFilterData filter_data; ///< Filter for content list
-	QueryString filter_editbox;  ///< Filter editbox;
-	Dimension checkbox_size;     ///< Size of checkbox/"blot" sprite
+	GUIContentList content{}; ///< List with content
+	bool auto_select = false; ///< Automatically select all content when the meta-data becomes available
+	ContentListFilterData filter_data{}; ///< Filter for content list
+	QueryString filter_editbox; ///< Filter editbox;
+	Dimension checkbox_size{}; ///< Size of checkbox/"blot" sprite
 
-	const ContentInfo *selected; ///< The selected content info
-	int list_pos;                ///< Our position in the list
-	uint filesize_sum;           ///< The sum of all selected file sizes
-	Scrollbar *vscroll;          ///< Cache of the vertical scrollbar
+	const ContentInfo *selected = nullptr; ///< The selected content info
+	int list_pos = 0; ///< Our position in the list
+	uint filesize_sum = 0; ///< The sum of all selected file sizes
+	Scrollbar *vscroll = nullptr; ///< Cache of the vertical scrollbar
 
 	static std::string content_type_strs[CONTENT_TYPE_END]; ///< Cached strings for all content types.
 
@@ -539,9 +538,7 @@ public:
 	NetworkContentListWindow(WindowDesc &desc, bool select_all, const std::bitset<CONTENT_TYPE_END> &types) :
 			Window(desc),
 			auto_select(select_all),
-			filter_editbox(EDITBOX_MAX_SIZE),
-			selected(nullptr),
-			list_pos(0)
+			filter_editbox(EDITBOX_MAX_SIZE)
 	{
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_NCL_SCROLLBAR);

--- a/src/network/network_content_gui.h
+++ b/src/network/network_content_gui.h
@@ -17,13 +17,13 @@
 /** Base window for showing the download status of content */
 class BaseNetworkContentDownloadStatusWindow : public Window, ContentCallback {
 protected:
-	uint total_bytes;      ///< Number of bytes to download
-	uint downloaded_bytes; ///< Number of bytes downloaded
-	uint total_files;      ///< Number of files to download
-	uint downloaded_files; ///< Number of files downloaded
+	uint total_bytes = 0; ///< Number of bytes to download
+	uint downloaded_bytes = 0; ///< Number of bytes downloaded
+	uint total_files = 0; ///< Number of files to download
+	uint downloaded_files = 0; ///< Number of files downloaded
 
-	uint32_t cur_id;    ///< The current ID of the downloaded file
-	std::string name; ///< The current name of the downloaded file
+	uint32_t cur_id = UINT32_MAX; ///< The current ID of the downloaded file
+	std::string name{}; ///< The current name of the downloaded file
 
 public:
 	/**

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -182,17 +182,17 @@ protected:
 	static const std::initializer_list<GUIGameServerList::SortFunction * const> sorter_funcs;
 	static const std::initializer_list<GUIGameServerList::FilterFunction * const> filter_funcs;
 
-	NetworkGameList *server;        ///< Selected server.
-	NetworkGameList *last_joined;   ///< The last joined server.
-	GUIGameServerList servers;      ///< List with game servers.
-	ServerListPosition list_pos;    ///< Position of the selected server.
-	Scrollbar *vscroll;             ///< Vertical scrollbar of the list of servers.
-	QueryString name_editbox;       ///< Client name editbox.
-	QueryString filter_editbox;     ///< Editbox for filter on servers.
+	NetworkGameList *server = nullptr; ///< Selected server.
+	NetworkGameList *last_joined = nullptr; ///< The last joined server.
+	GUIGameServerList servers{}; ///< List with game servers.
+	ServerListPosition list_pos = SLP_INVALID; ///< Position of the selected server.
+	Scrollbar *vscroll = nullptr; ///< Vertical scrollbar of the list of servers.
+	QueryString name_editbox; ///< Client name editbox.
+	QueryString filter_editbox; ///< Editbox for filter on servers.
 	bool searched_internet = false; ///< Did we ever press "Search Internet" button?
 
-	Dimension lock; /// Dimension of lock icon.
-	Dimension blot; /// Dimension of compatibility icon.
+	Dimension lock{}; /// Dimension of lock icon.
+	Dimension blot{}; /// Dimension of compatibility icon.
 
 	/**
 	 * (Re)build the GUI network game list (a.k.a. this->servers) as some
@@ -433,9 +433,6 @@ protected:
 public:
 	NetworkGameWindow(WindowDesc &desc) : Window(desc), name_editbox(NETWORK_CLIENT_NAME_LENGTH), filter_editbox(120)
 	{
-		this->list_pos = SLP_INVALID;
-		this->server = nullptr;
-
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_NG_SCROLLBAR);
 		this->FinishInitNested(WN_NETWORK_WINDOW_GAME);
@@ -967,8 +964,8 @@ void ShowNetworkGameWindow()
 }
 
 struct NetworkStartServerWindow : public Window {
-	WidgetID widget_id;          ///< The widget that has the pop-up input menu
-	QueryString name_editbox;    ///< Server name editbox.
+	WidgetID widget_id{}; ///< The widget that has the pop-up input menu
+	QueryString name_editbox; ///< Server name editbox.
 
 	NetworkStartServerWindow(WindowDesc &desc) : Window(desc), name_editbox(NETWORK_NAME_LENGTH)
 	{
@@ -1396,19 +1393,19 @@ using ClientButton = Button<ClientID>;
  */
 struct NetworkClientListWindow : Window {
 private:
-	ClientListWidgets query_widget; ///< During a query this tracks what widget caused the query.
+	ClientListWidgets query_widget{}; ///< During a query this tracks what widget caused the query.
 
-	ClientID dd_client_id; ///< During admin dropdown, track which client this was for.
-	CompanyID dd_company_id; ///< During admin dropdown, track which company this was for.
+	ClientID dd_client_id{}; ///< During admin dropdown, track which client this was for.
+	CompanyID dd_company_id = CompanyID::Invalid(); ///< During admin dropdown, track which company this was for.
 
-	Scrollbar *vscroll; ///< Vertical scrollbar of this window.
-	uint line_height; ///< Current lineheight of each entry in the matrix.
-	uint line_count; ///< Amount of lines in the matrix.
-	int hover_index; ///< Index of the current line we are hovering over, or -1 if none.
-	int player_self_index; ///< The line the current player is on.
-	int player_host_index; ///< The line the host is on.
+	Scrollbar *vscroll = nullptr; ///< Vertical scrollbar of this window.
+	uint line_height = 0; ///< Current lineheight of each entry in the matrix.
+	uint line_count = 0; ///< Amount of lines in the matrix.
+	int hover_index = -1; ///< Index of the current line we are hovering over, or -1 if none.
+	int player_self_index = -1; ///< The line the current player is on.
+	int player_host_index = -1; ///< The line the host is on.
 
-	std::map<uint, std::vector<std::unique_ptr<ButtonCommon>>> buttons; ///< Per line which buttons are available.
+	std::map<uint, std::vector<std::unique_ptr<ButtonCommon>>> buttons{}; ///< Per line which buttons are available.
 
 	/**
 	 * Chat button on a Company is clicked.
@@ -1614,11 +1611,7 @@ private:
 	}
 
 public:
-	NetworkClientListWindow(WindowDesc &desc, WindowNumber window_number) :
-			Window(desc),
-			hover_index(-1),
-			player_self_index(-1),
-			player_host_index(-1)
+	NetworkClientListWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_CL_SCROLLBAR);
@@ -2055,7 +2048,7 @@ uint32_t _network_join_bytes;             ///< The number of bytes we already do
 uint32_t _network_join_bytes_total;       ///< The total number of bytes to download.
 
 struct NetworkJoinStatusWindow : Window {
-	std::shared_ptr<NetworkAuthenticationPasswordRequest> request;
+	std::shared_ptr<NetworkAuthenticationPasswordRequest> request{};
 
 	NetworkJoinStatusWindow(WindowDesc &desc) : Window(desc)
 	{
@@ -2199,9 +2192,9 @@ void ShowNetworkNeedPassword(std::shared_ptr<NetworkAuthenticationPasswordReques
  * Window used for asking the user if he is okay using a relay server.
  */
 struct NetworkAskRelayWindow : public Window {
-	std::string server_connection_string; ///< The game server we want to connect to.
-	std::string relay_connection_string;  ///< The relay server we want to connect to.
-	std::string token;                    ///< The token for this connection.
+	std::string server_connection_string{}; ///< The game server we want to connect to.
+	std::string relay_connection_string{}; ///< The relay server we want to connect to.
+	std::string token{}; ///< The token for this connection.
 
 	NetworkAskRelayWindow(WindowDesc &desc, Window *parent, const std::string &server_connection_string, const std::string &relay_connection_string, const std::string &token) :
 		Window(desc),

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -293,15 +293,15 @@ struct NewGRFInspectWindow : Window {
 	static uint32_t var60params[GSF_FAKE_END][0x20];
 
 	/** GRFID of the caller of this window, 0 if it has no caller. */
-	uint32_t caller_grfid;
+	uint32_t caller_grfid = 0;
 
 	/** For ground vehicles: Index in vehicle chain. */
-	uint chain_index;
+	uint chain_index = 0;
 
 	/** The currently edited parameter, to update the right one. */
-	uint8_t current_edit_param;
+	uint8_t current_edit_param = 0;
 
-	Scrollbar *vscroll;
+	Scrollbar *vscroll = nullptr;
 
 	/**
 	 * Check whether the given variable has a parameter.
@@ -851,11 +851,11 @@ GrfSpecFeature GetGrfSpecFeature(VehicleType type)
 
 /** Window used for aligning sprites. */
 struct SpriteAlignerWindow : Window {
-	typedef std::pair<int16_t, int16_t> XyOffs;    ///< Pair for x and y offsets of the sprite before alignment. First value contains the x offset, second value y offset.
+	typedef std::pair<int16_t, int16_t> XyOffs; ///< Pair for x and y offsets of the sprite before alignment. First value contains the x offset, second value y offset.
 
-	SpriteID current_sprite;                   ///< The currently shown sprite.
-	Scrollbar *vscroll;
-	std::map<SpriteID, XyOffs> offs_start_map; ///< Mapping of starting offsets for the sprites which have been aligned in the sprite aligner window.
+	SpriteID current_sprite{}; ///< The currently shown sprite.
+	Scrollbar *vscroll = nullptr;
+	std::map<SpriteID, XyOffs> offs_start_map{}; ///< Mapping of starting offsets for the sprites which have been aligned in the sprite aligner window.
 
 	static inline ZoomLevel zoom = ZOOM_LVL_END;
 	static bool centre;

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -146,22 +146,18 @@ static void ShowNewGRFInfo(const GRFConfig &c, const Rect &r, bool show_params)
 struct NewGRFParametersWindow : public Window {
 	static GRFParameterInfo dummy_parameter_info; ///< Dummy info in case a newgrf didn't provide info about some parameter.
 	GRFConfig &grf_config; ///< Set the parameters of this GRFConfig.
-	int32_t clicked_button; ///< The row in which a button was clicked or INT_MAX when none is selected.
-	bool clicked_increase; ///< True if the increase button was clicked, false for the decrease button.
-	bool clicked_dropdown; ///< Whether the dropdown is open.
-	bool closing_dropdown; ///< True, if the dropdown list is currently closing.
-	int32_t clicked_row; ///< The selected parameter, or INT_MAX when none is selected.
-	int line_height;       ///< Height of a row in the matrix widget.
-	Scrollbar *vscroll;
-	bool action14present;  ///< True if action14 information is present.
-	bool editable;         ///< Allow editing parameters.
+	int32_t clicked_button = INT32_MAX; ///< The row in which a button was clicked or INT32_MAX when none is selected.
+	bool clicked_increase = false; ///< True if the increase button was clicked, false for the decrease button.
+	bool clicked_dropdown = false; ///< Whether the dropdown is open.
+	bool closing_dropdown = false; ///< True, if the dropdown list is currently closing.
+	int32_t clicked_row = INT32_MAX; ///< The selected parameter, or INT32_MAX when none is selected.
+	int line_height = 0; ///< Height of a row in the matrix widget.
+	Scrollbar *vscroll = nullptr;
+	bool action14present = false; ///< True if action14 information is present.
+	bool editable = false; ///< Allow editing parameters.
 
 	NewGRFParametersWindow(WindowDesc &desc, bool is_baseset, GRFConfig &c, bool editable) : Window(desc),
 		grf_config(c),
-		clicked_button(INT32_MAX),
-		clicked_dropdown(false),
-		closing_dropdown(false),
-		clicked_row(INT32_MAX),
 		editable(editable)
 	{
 		this->action14present = (this->grf_config.num_valid_params != this->grf_config.param.size() || !this->grf_config.param_info.empty());
@@ -552,7 +548,7 @@ void OpenGRFParameterWindow(bool is_baseset, GRFConfig &c, bool editable)
 
 /** Window for displaying the textfile of a NewGRF. */
 struct NewGRFTextfileWindow : public TextfileWindow {
-	const GRFConfig *grf_config; ///< View the textfile of this GRFConfig.
+	const GRFConfig *grf_config = nullptr; ///< View the textfile of this GRFConfig.
 
 	NewGRFTextfileWindow(TextfileType file_type, const GRFConfig *c) : TextfileWindow(file_type), grf_config(c)
 	{
@@ -607,38 +603,33 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 	static const std::initializer_list<GUIGRFConfigList::SortFunction   * const> sorter_funcs; ///< Sort functions of the #GUIGRFConfigList.
 	static const std::initializer_list<GUIGRFConfigList::FilterFunction * const> filter_funcs; ///< Filter functions of the #GUIGRFConfigList.
 
-	GUIGRFConfigList avails;    ///< Available (non-active) grfs.
-	const GRFConfig *avail_sel; ///< Currently selected available grf. \c nullptr is none is selected.
-	int avail_pos;              ///< Index of #avail_sel if existing, else \c -1.
-	StringFilter string_filter; ///< Filter for available grf.
+	GUIGRFConfigList avails{}; ///< Available (non-active) grfs.
+	const GRFConfig *avail_sel = nullptr; ///< Currently selected available grf. \c nullptr is none is selected.
+	int avail_pos = -1; ///< Index of #avail_sel if existing, else \c -1.
+	StringFilter string_filter{}; ///< Filter for available grf.
 	QueryString filter_editbox; ///< Filter editbox;
 
-	StringList grf_presets;     ///< List of known NewGRF presets.
+	StringList grf_presets{}; ///< List of known NewGRF presets.
 
-	GRFConfigList actives;      ///< Temporary active grf list to which changes are made.
-	GRFConfig *active_sel;      ///< Selected active grf item.
+	GRFConfigList actives{}; ///< Temporary active grf list to which changes are made.
+	GRFConfig *active_sel = nullptr; ///< Selected active grf item.
 
-	GRFConfigList &orig_list;   ///< List active grfs in the game. Used as initial value, may be updated by the window.
-	bool editable;              ///< Is the window editable?
-	bool show_params;           ///< Are the grf-parameters shown in the info-panel?
-	bool execute;               ///< On pressing 'apply changes' are grf changes applied immediately, or only list is updated.
-	int preset;                 ///< Selected preset or \c -1 if none selected.
-	int active_over;            ///< Active GRF item over which another one is dragged, \c -1 if none.
-	bool modified;              ///< The list of active NewGRFs has been modified since the last time they got saved.
+	GRFConfigList &orig_list; ///< List active grfs in the game. Used as initial value, may be updated by the window.
+	bool editable = false; ///< Is the window editable?
+	bool show_params = false; ///< Are the grf-parameters shown in the info-panel?
+	bool execute = false; ///< On pressing 'apply changes' are grf changes applied immediately, or only list is updated.
+	int preset = -1; ///< Selected preset or \c -1 if none selected.
+	int active_over = -1; ///< Active GRF item over which another one is dragged, \c -1 if none.
+	bool modified = false; ///< The list of active NewGRFs has been modified since the last time they got saved.
 
-	Scrollbar *vscroll;
-	Scrollbar *vscroll2;
+	Scrollbar *vscroll = nullptr;
+	Scrollbar *vscroll2 = nullptr;
 
 	NewGRFWindow(WindowDesc &desc, bool editable, bool show_params, bool execute, GRFConfigList &orig_list) : Window(desc), filter_editbox(EDITBOX_MAX_SIZE), orig_list(orig_list)
 	{
-		this->avail_sel   = nullptr;
-		this->avail_pos   = -1;
-		this->active_sel  = nullptr;
 		this->editable    = editable;
 		this->execute     = execute;
 		this->show_params = show_params;
-		this->preset      = -1;
-		this->active_over = -1;
 
 		CopyGRFConfigList(this->actives, orig_list, false);
 		this->grf_presets = GetGRFPresetList();
@@ -2022,9 +2013,9 @@ static WindowDesc _save_preset_desc(
 /** Class for the save preset window. */
 struct SavePresetWindow : public Window {
 	QueryString presetname_editbox; ///< Edit box of the save preset.
-	StringList presets; ///< Available presets.
-	Scrollbar *vscroll; ///< Pointer to the scrollbar widget.
-	int selected; ///< Selected entry in the preset list, or \c -1 if none selected.
+	StringList presets{}; ///< Available presets.
+	Scrollbar *vscroll = nullptr; ///< Pointer to the scrollbar widget.
+	int selected = -1; ///< Selected entry in the preset list, or \c -1 if none selected.
 
 	/**
 	 * Constructor of the save preset window.
@@ -2033,7 +2024,6 @@ struct SavePresetWindow : public Window {
 	SavePresetWindow(const char *initial_text) : Window(_save_preset_desc), presetname_editbox(32)
 	{
 		this->presets = GetGRFPresetList();
-		this->selected = -1;
 		if (initial_text != nullptr) {
 			for (uint i = 0; i < this->presets.size(); i++) {
 				if (this->presets[i] == initial_text) {
@@ -2166,11 +2156,11 @@ static WindowDesc _scan_progress_desc(
 
 /** Window for showing the progress of NewGRF scanning. */
 struct ScanProgressWindow : public Window {
-	std::string last_name; ///< The name of the last 'seen' NewGRF.
-	int scanned;           ///< The number of NewGRFs that we have seen.
+	std::string last_name{}; ///< The name of the last 'seen' NewGRF.
+	int scanned = 0; ///< The number of NewGRFs that we have seen.
 
 	/** Create the window. */
-	ScanProgressWindow() : Window(_scan_progress_desc), scanned(0)
+	ScanProgressWindow() : Window(_scan_progress_desc)
 	{
 		this->InitNested(1);
 	}

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -349,10 +349,10 @@ NewsDisplay NewsTypeData::GetDisplay() const
 
 /** Window class displaying a news item. */
 struct NewsWindow : Window {
-	uint16_t chat_height;   ///< Height of the chat window.
-	uint16_t status_height; ///< Height of the status bar window
-	const NewsItem *ni;   ///< News item to display.
-	static int duration;  ///< Remaining time for showing the current news message (may only be access while a news item is displayed).
+	uint16_t chat_height = 0; ///< Height of the chat window.
+	uint16_t status_height = 0; ///< Height of the status bar window
+	const NewsItem *ni = nullptr; ///< News item to display.
+	static int duration; ///< Remaining time for showing the current news message (may only be access while a news item is displayed).
 
 	NewsWindow(WindowDesc &desc, const NewsItem *ni) : Window(desc), ni(ni)
 	{
@@ -1196,10 +1196,10 @@ static void DrawNewsString(uint left, uint right, int y, TextColour colour, cons
 }
 
 struct MessageHistoryWindow : Window {
-	int line_height; /// < Height of a single line in the news history window including spacing.
-	int date_width;  /// < Width needed for the date part.
+	int line_height = 0; /// < Height of a single line in the news history window including spacing.
+	int date_width = 0; /// < Width needed for the date part.
 
-	Scrollbar *vscroll;
+	Scrollbar *vscroll = nullptr;
 
 	MessageHistoryWindow(WindowDesc &desc) : Window(desc)
 	{

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -121,10 +121,10 @@ public:
 
 /** The window used for building objects. */
 class BuildObjectWindow : public PickerWindow {
-	int info_height; ///< The height of the info box.
+	int info_height = 1; ///< The height of the info box.
 
 public:
-	BuildObjectWindow(WindowDesc &desc, WindowNumber) : PickerWindow(desc, nullptr, 0, ObjectPickerCallbacks::instance), info_height(1)
+	BuildObjectWindow(WindowDesc &desc, WindowNumber) : PickerWindow(desc, nullptr, 0, ObjectPickerCallbacks::instance)
 	{
 		ResetObjectToPlace();
 		this->ConstructWindow();

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -561,13 +561,13 @@ private:
 		DP_BOTTOM_MIDDLE_STOP_SHARING = 1, ///< Display 'stop sharing' in the middle button of the bottom row of the vehicle order window.
 	};
 
-	int selected_order;
-	VehicleOrderID order_over;         ///< Order over which another order is dragged, \c INVALID_VEH_ORDER_ID if none.
-	OrderPlaceObjectState goto_type;
-	const Vehicle *vehicle; ///< Vehicle owning the orders being displayed and manipulated.
-	Scrollbar *vscroll;
-	bool can_do_refit;     ///< Vehicle chain can be refitted in depot.
-	bool can_do_autorefit; ///< Vehicle chain can be auto-refitted.
+	int selected_order = -1;
+	VehicleOrderID order_over = INVALID_VEH_ORDER_ID; ///< Order over which another order is dragged, \c INVALID_VEH_ORDER_ID if none.
+	OrderPlaceObjectState goto_type = OPOS_NONE;
+	const Vehicle *vehicle = nullptr; ///< Vehicle owning the orders being displayed and manipulated.
+	Scrollbar *vscroll = nullptr;
+	bool can_do_refit = false; ///< Vehicle chain can be refitted in depot.
+	bool can_do_autorefit = false; ///< Vehicle chain can be auto-refitted.
 
 	/**
 	 * Return the memorised selected order.
@@ -807,9 +807,6 @@ public:
 		}
 		this->FinishInitNested(v->index);
 
-		this->selected_order = -1;
-		this->order_over = INVALID_VEH_ORDER_ID;
-		this->goto_type = OPOS_NONE;
 		this->owner = v->owner;
 
 		this->UpdateAutoRefitState();

--- a/src/osk_gui.cpp
+++ b/src/osk_gui.cpp
@@ -35,12 +35,12 @@ enum KeyStateBits : uint8_t {
 static uint8_t _keystate = KEYS_NONE;
 
 struct OskWindow : public Window {
-	StringID caption;      ///< the caption for this window.
-	QueryString *qs;       ///< text-input
-	WidgetID text_btn;     ///< widget number of parent's text field
-	Textbuf *text;         ///< pointer to parent's textbuffer (to update caret position)
-	std::string orig_str;  ///< Original string.
-	bool shift;            ///< Is the shift effectively pressed?
+	StringID caption{}; ///< the caption for this window.
+	QueryString *qs = nullptr; ///< text-input
+	WidgetID text_btn{}; ///< widget number of parent's text field
+	Textbuf *text = nullptr; ///< pointer to parent's textbuffer (to update caret position)
+	std::string orig_str{}; ///< Original string.
+	bool shift = false; ///< Is the shift effectively pressed?
 
 	OskWindow(WindowDesc &desc, Window *parent, WidgetID button) : Window(desc)
 	{


### PR DESCRIPTION
## Motivation / Problem

`Window` is the last user of `ZeroedMemoryAllocator`, but to remove that all member variables of windows need to be properly initialised.


## Description

Explicitly initialise member variables for windows in files starting with 'n' through 'o'.

Some changes of arrays to `std::array` were needed.


## Limitations

There's more to come, but I think this is still a reasonable chunk size for PR. I've made that available as a single PR: #13644.
I also did not implicitly fix any super classes, e.g. `PickerWindowBase`, as those will be handled in the chunk with the 'p' in it.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
