### PR TITLE
Codechange: explicitly initialise member variables of Windows (4 of 5)

### DIFF
--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -434,17 +434,15 @@ static void HandleAutoSignalPlacement()
 
 /** Rail toolbar management class. */
 struct BuildRailToolbarWindow : Window {
-	RailType railtype;    ///< Rail type to build.
-	int last_user_action; ///< Last started user action.
+	RailType railtype = INVALID_RAILTYPE; ///< Rail type to build.
+	int last_user_action = INVALID_WID_RAT; ///< Last started user action.
 
-	BuildRailToolbarWindow(WindowDesc &desc, RailType railtype) : Window(desc)
+	BuildRailToolbarWindow(WindowDesc &desc, RailType railtype) : Window(desc), railtype(railtype)
 	{
-		this->railtype = railtype;
 		this->CreateNestedTree();
 		this->FinishInitNested(TRANSPORT_RAIL);
 		this->DisableWidget(WID_RAT_REMOVE);
 		this->OnInvalidateData();
-		this->last_user_action = INVALID_WID_RAT;
 
 		if (_settings_client.gui.link_terraform_toolbar) ShowTerraformToolbar(this);
 	}
@@ -1051,7 +1049,7 @@ public:
 
 struct BuildRailStationWindow : public PickerWindow {
 private:
-	uint coverage_height; ///< Height of the coverage texts.
+	uint coverage_height = 0; ///< Height of the coverage texts.
 
 	/**
 	 * Verify whether the currently selected station size is allowed after selecting a new station class/type.
@@ -1454,8 +1452,8 @@ static Window *ShowStationBuilder(Window *parent)
 
 struct BuildSignalWindow : public PickerWindowBase {
 private:
-	Dimension sig_sprite_size;     ///< Maximum size of signal GUI sprites.
-	int sig_sprite_bottom_offset;  ///< Maximum extent of signal GUI sprite from reference point towards bottom.
+	Dimension sig_sprite_size{}; ///< Maximum size of signal GUI sprites.
+	int sig_sprite_bottom_offset = 0; ///< Maximum extent of signal GUI sprite from reference point towards bottom.
 
 	/**
 	 * Draw dynamic a signal-sprite in a button in the signal GUI

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -343,12 +343,11 @@ static bool RoadToolbar_CtrlChanged(Window *w)
 
 /** Road toolbar window handler. */
 struct BuildRoadToolbarWindow : Window {
-	RoadType roadtype;          ///< Road type to build.
-	int last_started_action;    ///< Last started user action.
+	RoadType roadtype = INVALID_ROADTYPE; ///< Road type to build.
+	int last_started_action = INVALID_WID_ROT; ///< Last started user action.
 
-	BuildRoadToolbarWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
+	BuildRoadToolbarWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc), roadtype(_cur_roadtype)
 	{
-		this->roadtype = _cur_roadtype;
 		this->CreateNestedTree();
 		this->FinishInitNested(window_number);
 		this->SetWidgetDisabledState(WID_ROT_REMOVE, true);
@@ -358,7 +357,6 @@ struct BuildRoadToolbarWindow : Window {
 		}
 
 		this->OnInvalidateData();
-		this->last_started_action = INVALID_WID_ROT;
 
 		if (_settings_client.gui.link_terraform_toolbar) ShowTerraformToolbar(this);
 	}
@@ -1293,7 +1291,7 @@ static PickerCallbacks &GetRoadStopPickerCallbacks(RoadStopType rs)
 
 struct BuildRoadStationWindow : public PickerWindow {
 private:
-	uint coverage_height; ///< Height of the coverage texts.
+	uint coverage_height = 0; ///< Height of the coverage texts.
 
 	void CheckOrientationValid()
 	{

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -52,12 +52,12 @@ static ScriptConfig *GetConfig(CompanyID slot)
  * Window that let you choose an available Script.
  */
 struct ScriptListWindow : public Window {
-	const ScriptInfoList *info_list;    ///< The list of Scripts.
-	int selected;                       ///< The currently selected Script.
-	CompanyID slot;                     ///< The company we're selecting a new Script for.
-	int line_height;                    ///< Height of a row in the matrix widget.
-	Scrollbar *vscroll;                 ///< Cache of the vertical scrollbar.
-	bool show_all;                      ///< Whether to show all available versions.
+	const ScriptInfoList *info_list = nullptr; ///< The list of Scripts.
+	int selected = -1; ///< The currently selected Script.
+	CompanyID slot{}; ///< The company we're selecting a new Script for.
+	int line_height = 0; ///< Height of a row in the matrix widget.
+	Scrollbar *vscroll = nullptr; ///< Cache of the vertical scrollbar.
+	bool show_all = false; ///< Whether to show all available versions.
 
 	/**
 	 * Constructor for the window.
@@ -81,7 +81,6 @@ struct ScriptListWindow : public Window {
 		this->vscroll->SetCount(this->info_list->size() + 1);
 
 		/* Try if we can find the currently selected AI */
-		this->selected = -1;
 		if (GetConfig(slot)->HasScript()) {
 			ScriptInfo *info = GetConfig(slot)->GetInfo();
 			int i = 0;
@@ -285,28 +284,24 @@ void ShowScriptListWindow(CompanyID slot, bool show_all)
  * Window for settings the parameters of an AI.
  */
 struct ScriptSettingsWindow : public Window {
-	CompanyID slot;                       ///< The currently show company's setting.
-	ScriptConfig *script_config;          ///< The configuration we're modifying.
-	int clicked_button;                   ///< The button we clicked.
-	bool clicked_increase;                ///< Whether we clicked the increase or decrease button.
-	bool clicked_dropdown;                ///< Whether the dropdown is open.
-	bool closing_dropdown;                ///< True, if the dropdown list is currently closing.
-	int clicked_row;                      ///< The clicked row of settings.
-	int line_height;                      ///< Height of a row in the matrix widget.
-	Scrollbar *vscroll;                   ///< Cache of the vertical scrollbar.
+	CompanyID slot{}; ///< The currently show company's setting.
+	ScriptConfig *script_config = nullptr; ///< The configuration we're modifying.
+	int clicked_button = -1; ///< The button we clicked.
+	bool clicked_increase = false; ///< Whether we clicked the increase or decrease button.
+	bool clicked_dropdown = false; ///< Whether the dropdown is open.
+	bool closing_dropdown = false; ///< True, if the dropdown list is currently closing.
+	int clicked_row = 0; ///< The clicked row of settings.
+	int line_height = 0; ///< Height of a row in the matrix widget.
+	Scrollbar *vscroll = nullptr; ///< Cache of the vertical scrollbar.
 	typedef std::vector<const ScriptConfigItem *> VisibleSettingsList; ///< typdef for a vector of script settings
-	VisibleSettingsList visible_settings; ///< List of visible AI settings
+	VisibleSettingsList visible_settings{}; ///< List of visible AI settings
 
 	/**
 	 * Constructor for the window.
 	 * @param desc The description of the window.
 	 * @param slot The company we're changing the settings for.
 	 */
-	ScriptSettingsWindow(WindowDesc &desc, CompanyID slot) : Window(desc),
-		slot(slot),
-		clicked_button(-1),
-		clicked_dropdown(false),
-		closing_dropdown(false)
+	ScriptSettingsWindow(WindowDesc &desc, CompanyID slot) : Window(desc), slot(slot)
 	{
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_SCRS_SCROLLBAR);
@@ -625,7 +620,7 @@ void ShowScriptSettingsWindow(CompanyID slot)
 
 /** Window for displaying the textfile of a AI. */
 struct ScriptTextfileWindow : public TextfileWindow {
-	CompanyID slot; ///< View the textfile of this CompanyID slot.
+	CompanyID slot{}; ///< View the textfile of this CompanyID slot.
 
 	ScriptTextfileWindow(TextfileType file_type, CompanyID slot) : TextfileWindow(file_type), slot(slot)
 	{
@@ -705,15 +700,15 @@ struct ScriptDebugWindow : public Window {
 		false,
 	};
 
-	int last_vscroll_pos;                                  ///< Last position of the scrolling.
-	bool autoscroll;                                       ///< Whether automatically scrolling should be enabled or not.
-	bool show_break_box;                                   ///< Whether the break/debug box is visible.
-	QueryString break_editbox;                             ///< Break editbox
-	StringFilter break_string_filter;                      ///< Log filter for break.
-	int highlight_row;                                     ///< The output row that matches the given string, or -1
-	Scrollbar *vscroll;                                    ///< Cache of the vertical scrollbar.
-	Scrollbar *hscroll;                                    ///< Cache of the horizontal scrollbar.
-	FilterState filter;
+	int last_vscroll_pos = 0; ///< Last position of the scrolling.
+	bool autoscroll = true; ///< Whether automatically scrolling should be enabled or not.
+	bool show_break_box = false; ///< Whether the break/debug box is visible.
+	QueryString break_editbox; ///< Break editbox
+	StringFilter break_string_filter{}; ///< Log filter for break.
+	int highlight_row = -1; ///< The output row that matches the given string, or -1
+	Scrollbar *vscroll = nullptr; ///< Cache of the vertical scrollbar.
+	Scrollbar *hscroll = nullptr; ///< Cache of the horizontal scrollbar.
+	FilterState filter{};
 
 	ScriptLogTypes::LogData &GetLogData() const
 	{
@@ -784,10 +779,6 @@ struct ScriptDebugWindow : public Window {
 		this->vscroll = this->GetScrollbar(WID_SCRD_VSCROLLBAR);
 		this->hscroll = this->GetScrollbar(WID_SCRD_HSCROLLBAR);
 		this->FinishInitNested(number);
-
-		this->last_vscroll_pos = 0;
-		this->autoscroll = true;
-		this->highlight_row = -1;
 
 		this->querystrings[WID_SCRD_BREAK_STR_EDIT_BOX] = &this->break_editbox;
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -352,16 +352,14 @@ std::unique_ptr<NWidgetBase> MakeNWidgetSocialPlugins()
 }
 
 struct GameOptionsWindow : Window {
-	GameSettings *opt;
-	bool reload;
-	int gui_scale;
+	GameSettings *opt = nullptr;
+	bool reload = false;
+	int gui_scale = 0;
 	static inline WidgetID active_tab = WID_GO_TAB_GENERAL;
 
-	GameOptionsWindow(WindowDesc &desc) : Window(desc)
+	GameOptionsWindow(WindowDesc &desc) : Window(desc), gui_scale(_gui_scale)
 	{
 		this->opt = &GetGameSettings();
-		this->reload = false;
-		this->gui_scale = _gui_scale;
 
 		AddCustomRefreshRates();
 
@@ -1237,24 +1235,22 @@ static void ResetAllSettingsConfirmationCallback(Window *w, bool confirmed)
 struct GameSettingsWindow : Window {
 	static GameSettings *settings_ptr; ///< Pointer to the game settings being displayed and modified.
 
-	SettingEntry *valuewindow_entry;   ///< If non-nullptr, pointer to setting for which a value-entering window has been opened.
-	SettingEntry *clicked_entry;       ///< If non-nullptr, pointer to a clicked numeric setting (with a depressed left or right button).
-	SettingEntry *last_clicked;        ///< If non-nullptr, pointer to the last clicked setting.
-	SettingEntry *valuedropdown_entry; ///< If non-nullptr, pointer to the value for which a dropdown window is currently opened.
-	bool closing_dropdown;             ///< True, if the dropdown list is currently closing.
+	SettingEntry *valuewindow_entry = nullptr; ///< If non-nullptr, pointer to setting for which a value-entering window has been opened.
+	SettingEntry *clicked_entry = nullptr; ///< If non-nullptr, pointer to a clicked numeric setting (with a depressed left or right button).
+	SettingEntry *last_clicked = nullptr; ///< If non-nullptr, pointer to the last clicked setting.
+	SettingEntry *valuedropdown_entry = nullptr; ///< If non-nullptr, pointer to the value for which a dropdown window is currently opened.
+	bool closing_dropdown = false; ///< True, if the dropdown list is currently closing.
 
-	SettingFilter filter;              ///< Filter for the list.
-	QueryString filter_editbox;        ///< Filter editbox;
-	bool manually_changed_folding;     ///< Whether the user expanded/collapsed something manually.
-	WarnHiddenResult warn_missing;     ///< Whether and how to warn about missing search results.
-	int warn_lines;                    ///< Number of lines used for warning about missing search results.
+	SettingFilter filter{}; ///< Filter for the list.
+	QueryString filter_editbox; ///< Filter editbox;
+	bool manually_changed_folding = false; ///< Whether the user expanded/collapsed something manually.
+	WarnHiddenResult warn_missing = WHR_NONE; ///< Whether and how to warn about missing search results.
+	int warn_lines = 0; ///< Number of lines used for warning about missing search results.
 
 	Scrollbar *vscroll;
 
 	GameSettingsWindow(WindowDesc &desc) : Window(desc), filter_editbox(50)
 	{
-		this->warn_missing = WHR_NONE;
-		this->warn_lines = 0;
 		this->filter.mode = (RestrictionMode)_settings_client.gui.settings_restriction_mode;
 		this->filter.min_cat = RM_ALL;
 		this->filter.type = ST_ALL;
@@ -1262,13 +1258,6 @@ struct GameSettingsWindow : Window {
 		this->settings_ptr = &GetGameSettings();
 
 		GetSettingsTree().FoldAll(); // Close all sub-pages
-
-		this->valuewindow_entry = nullptr; // No setting entry for which a entry window is opened
-		this->clicked_entry = nullptr; // No numeric setting buttons are depressed
-		this->last_clicked = nullptr;
-		this->valuedropdown_entry = nullptr;
-		this->closing_dropdown = false;
-		this->manually_changed_folding = false;
 
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_GS_SCROLLBAR);
@@ -1896,7 +1885,7 @@ void DrawBoolButton(int x, int y, bool state, bool clickable)
 }
 
 struct CustomCurrencyWindow : Window {
-	int query_widget;
+	WidgetID query_widget{};
 
 	CustomCurrencyWindow(WindowDesc &desc) : Window(desc)
 	{

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -139,8 +139,8 @@ enum SignListHotkeys : int32_t {
 
 struct SignListWindow : Window, SignList {
 	QueryString filter_editbox; ///< Filter editbox;
-	int text_offset; ///< Offset of the sign text relative to the left edge of the WID_SIL_LIST widget.
-	Scrollbar *vscroll;
+	int text_offset = 0; ///< Offset of the sign text relative to the left edge of the WID_SIL_LIST widget.
+	Scrollbar *vscroll = nullptr;
 
 	SignListWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc), filter_editbox(MAX_LENGTH_SIGN_NAME_CHARS * MAX_CHAR_LENGTH, MAX_LENGTH_SIGN_NAME_CHARS)
 	{
@@ -409,7 +409,7 @@ static bool RenameSign(SignID index, const char *text)
 
 struct SignWindow : Window, SignList {
 	QueryString name_editbox;
-	SignID cur_sign;
+	SignID cur_sign{};
 
 	SignWindow(WindowDesc &desc, const Sign *si) : Window(desc), name_editbox(MAX_LENGTH_SIGN_NAME_CHARS * MAX_CHAR_LENGTH, MAX_LENGTH_SIGN_NAME_CHARS)
 	{

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -638,17 +638,17 @@ protected:
 
 	static const uint INDUSTRY_MIN_NUMBER_OF_COLUMNS = 2; ///< Minimal number of columns in the #WID_SM_LEGEND widget for the #SMT_INDUSTRY legend.
 
-	uint min_number_of_columns;    ///< Minimal number of columns in legends.
-	uint min_number_of_fixed_rows; ///< Minimal number of rows in the legends for the fixed layouts only (all except #SMT_INDUSTRY).
-	uint column_width;             ///< Width of a column in the #WID_SM_LEGEND widget.
-	uint legend_width;             ///< Width of legend 'blob'.
+	uint min_number_of_columns = 0; ///< Minimal number of columns in legends.
+	uint min_number_of_fixed_rows = 0; ///< Minimal number of rows in the legends for the fixed layouts only (all except #SMT_INDUSTRY).
+	uint column_width = 0; ///< Width of a column in the #WID_SM_LEGEND widget.
+	uint legend_width = 0; ///< Width of legend 'blob'.
 
-	int32_t scroll_x;  ///< Horizontal world coordinate of the base tile left of the top-left corner of the smallmap display.
-	int32_t scroll_y;  ///< Vertical world coordinate of the base tile left of the top-left corner of the smallmap display.
-	int32_t subscroll; ///< Number of pixels (0..3) between the right end of the base tile and the pixel at the top-left corner of the smallmap display.
-	int zoom;        ///< Zoom level. Bigger number means more zoom-out (further away).
+	int32_t scroll_x = 0; ///< Horizontal world coordinate of the base tile left of the top-left corner of the smallmap display.
+	int32_t scroll_y = 0; ///< Vertical world coordinate of the base tile left of the top-left corner of the smallmap display.
+	int32_t subscroll = 0; ///< Number of pixels (0..3) between the right end of the base tile and the pixel at the top-left corner of the smallmap display.
+	int zoom = 0; ///< Zoom level. Bigger number means more zoom-out (further away).
 
-	std::unique_ptr<LinkGraphOverlay> overlay;
+	std::unique_ptr<LinkGraphOverlay> overlay{};
 
 	/** Notify the industry chain window to stop sending newly selected industries. */
 	static void BreakIndustryChainLink()

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -286,13 +286,13 @@ protected:
 	};
 	static const std::initializer_list<GUIStationList::SortFunction * const> sorter_funcs;
 
-	FilterState filter;
+	FilterState filter{};
 	GUIStationList stations{filter.cargoes};
-	Scrollbar *vscroll;
-	uint rating_width;
-	bool filter_expanded;
-	std::array<uint16_t, NUM_CARGO> stations_per_cargo_type; ///< Number of stations with a rating for each cargo type.
-	uint16_t stations_per_cargo_type_no_rating; ///< Number of stations without a rating.
+	Scrollbar *vscroll = nullptr;
+	uint rating_width = 0;
+	bool filter_expanded = false;
+	std::array<uint16_t, NUM_CARGO> stations_per_cargo_type{}; ///< Number of stations with a rating for each cargo type.
+	uint16_t stations_per_cargo_type_no_rating = 0; ///< Number of stations without a rating.
 
 	/**
 	 * (Re)Build station list
@@ -1306,10 +1306,10 @@ struct StationViewWindow : public Window {
 		MODE_PLANNED  ///< Show cargo planned to pass through the station.
 	};
 
-	uint expand_shrink_width;     ///< The width allocated to the expand/shrink 'button'
-	int rating_lines;             ///< Number of lines in the cargo ratings view.
-	int accepts_lines;            ///< Number of lines in the accepted cargo view.
-	Scrollbar *vscroll;
+	uint expand_shrink_width = 0; ///< The width allocated to the expand/shrink 'button'
+	int rating_lines = RATING_LINES; ///< Number of lines in the cargo ratings view.
+	int accepts_lines = ACCEPTS_LINES; ///< Number of lines in the accepted cargo view.
+	Scrollbar *vscroll = nullptr;
 
 	/* Height of the #WID_SV_ACCEPT_RATING_LIST widget for different views. */
 	static constexpr uint RATING_LINES = 13; ///< Height in lines of the cargo ratings view.
@@ -1338,26 +1338,22 @@ struct StationViewWindow : public Window {
 	 * sort all the columns in the same way. The other options haven't been
 	 * included in the GUI due to lack of space.
 	 */
-	CargoSortType sortings[NUM_COLUMNS];
+	std::array<CargoSortType, NUM_COLUMNS> sortings{};
 
 	/** Sort order (ascending/descending) for the 'columns'. */
-	SortOrder sort_orders[NUM_COLUMNS];
+	std::array<SortOrder, NUM_COLUMNS> sort_orders{};
 
-	int scroll_to_row;                  ///< If set, scroll the main viewport to the station pointed to by this row.
-	int grouping_index;                 ///< Currently selected entry in the grouping drop down.
-	Mode current_mode;                  ///< Currently selected display mode of cargo view.
-	Grouping groupings[NUM_COLUMNS];    ///< Grouping modes for the different columns.
+	int scroll_to_row = INT_MAX; ///< If set, scroll the main viewport to the station pointed to by this row.
+	int grouping_index = 0; ///< Currently selected entry in the grouping drop down.
+	Mode current_mode{}; ///< Currently selected display mode of cargo view.
+	std::array<Grouping, NUM_COLUMNS> groupings; ///< Grouping modes for the different columns.
 
-	CargoDataEntry expanded_rows;       ///< Parent entry of currently expanded rows.
-	CargoDataEntry cached_destinations; ///< Cache for the flows passing through this station.
-	CargoDataVector displayed_rows;     ///< Parent entry of currently displayed rows (including collapsed ones).
+	CargoDataEntry expanded_rows{}; ///< Parent entry of currently expanded rows.
+	CargoDataEntry cached_destinations{}; ///< Cache for the flows passing through this station.
+	CargoDataVector displayed_rows{}; ///< Parent entry of currently displayed rows (including collapsed ones).
 
-	StationViewWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc),
-		scroll_to_row(INT_MAX), grouping_index(0)
+	StationViewWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{
-		this->rating_lines  = RATING_LINES;
-		this->accepts_lines = ACCEPTS_LINES;
-
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_SV_SCROLLBAR);
 		/* Nested widget tree creation is done in two steps to ensure that this->GetWidget<NWidgetCore>(WID_SV_ACCEPTS_RATINGS) exists in UpdateWidgetSize(). */
@@ -2308,9 +2304,9 @@ static constexpr NWidgetPart _nested_select_station_widgets[] = {
  */
 template <class T>
 struct SelectStationWindow : Window {
-	StationPickerCmdProc select_station_proc;
-	TileArea area; ///< Location of new station
-	Scrollbar *vscroll;
+	StationPickerCmdProc select_station_proc{};
+	TileArea area{}; ///< Location of new station
+	Scrollbar *vscroll = nullptr;
 
 	SelectStationWindow(WindowDesc &desc, TileArea ta, StationPickerCmdProc&& proc) :
 		Window(desc),

--- a/src/statusbar_gui.cpp
+++ b/src/statusbar_gui.cpp
@@ -54,8 +54,8 @@ static bool DrawScrollingStatusText(const NewsItem *ni, int scroll_pos, int left
 }
 
 struct StatusBarWindow : Window {
-	bool saving;
-	int ticker_scroll;
+	bool saving = false;
+	int ticker_scroll = TICKER_STOP;
 
 	static const int TICKER_STOP    = 1640; ///< scrolling is finished when counter reaches this value
 	static const int COUNTER_STEP   =    2; ///< this is subtracted from active counters every tick
@@ -63,8 +63,6 @@ struct StatusBarWindow : Window {
 
 	StatusBarWindow(WindowDesc &desc) : Window(desc)
 	{
-		this->ticker_scroll = TICKER_STOP;
-
 		this->InitNested();
 		this->flags.Reset(WindowFlag::WhiteBorder);
 		PositionStatusbar(this);

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -52,15 +52,15 @@ protected:
 		Right,
 	};
 
-	Scrollbar *vscroll;                ///< Scrollbar of the page text.
-	mutable LayoutCache layout_cache;  ///< Cached element layout.
+	Scrollbar *vscroll = nullptr; ///< Scrollbar of the page text.
+	mutable LayoutCache layout_cache{}; ///< Cached element layout.
 
-	GUIStoryPageList story_pages;      ///< Sorted list of pages.
-	GUIStoryPageElementList story_page_elements; ///< Sorted list of page elements that belong to the current page.
-	StoryPageID selected_page_id;      ///< Pool index of selected page.
-	std::string selected_generic_title;  ///< If the selected page doesn't have a custom title, this buffer is used to store a generic page title.
+	GUIStoryPageList story_pages{}; ///< Sorted list of pages.
+	GUIStoryPageElementList story_page_elements{}; ///< Sorted list of page elements that belong to the current page.
+	StoryPageID selected_page_id{}; ///< Pool index of selected page.
+	std::string selected_generic_title{}; ///< If the selected page doesn't have a custom title, this buffer is used to store a generic page title.
 
-	StoryPageElementID active_button_id; ///< Which button element the player is currently using
+	StoryPageElementID active_button_id{}; ///< Which button element the player is currently using
 
 	static const std::initializer_list<GUIStoryPageList::SortFunction * const> page_sorter_funcs;
 	static const std::initializer_list<GUIStoryPageElementList::SortFunction * const> page_element_sorter_funcs;

--- a/src/subsidy_gui.cpp
+++ b/src/subsidy_gui.cpp
@@ -26,8 +26,8 @@
 #include "safeguards.h"
 
 struct SubsidyListWindow : Window {
-	Scrollbar *vscroll;
-	Dimension cargo_icon_size;
+	Scrollbar *vscroll = nullptr;
+	Dimension cargo_icon_size{};
 
 	SubsidyListWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{


### PR DESCRIPTION
## Motivation / Problem

`Window` is the last user of `ZeroedMemoryAllocator`, but to remove that all member variables of windows need to be properly initialised.


## Description

Explicitly initialise member variables for windows in files starting with 'r' and 's'.

Some changes of arrays to `std::array` were needed.


## Limitations

There's more to come, but I think this is still a reasonable chunk size for PR. I've made that available as a single PR: #13644.
I also did not implicitly fix any super classes, e.g. `PickerWindowBase`, as those will be handled in the chunk with the 'p' in it.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
