### PR TITLE
Codechange: explicitly initialise member variables of Windows (5 of 5)

### DIFF
--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -155,18 +155,13 @@ void PlaceProc_DemolishArea(TileIndex tile)
 
 /** Terra form toolbar managing class. */
 struct TerraformToolbarWindow : Window {
-	int last_user_action; ///< Last started user action.
+	int last_user_action = INVALID_WID_TT; ///< Last started user action.
 
 	TerraformToolbarWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{
 		/* This is needed as we like to have the tree available on OnInit. */
 		this->CreateNestedTree();
 		this->FinishInitNested(window_number);
-		this->last_user_action = INVALID_WID_TT;
-	}
-
-	~TerraformToolbarWindow()
-	{
 	}
 
 	void OnInit() override
@@ -534,7 +529,7 @@ static void ResetLandscapeConfirmationCallback(Window *, bool confirmed)
 
 /** Landscape generation window handler in the scenario editor. */
 struct ScenarioEditorLandscapeGenerationWindow : Window {
-	int last_user_action; ///< Last started user action.
+	int last_user_action = INVALID_WID_ETT; ///< Last started user action.
 
 	ScenarioEditorLandscapeGenerationWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{
@@ -542,7 +537,6 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 		NWidgetStacked *show_desert = this->GetWidget<NWidgetStacked>(WID_ETT_SHOW_PLACE_DESERT);
 		show_desert->SetDisplayedPlane(_settings_game.game_creation.landscape == LandscapeType::Tropic ? 0 : SZSP_NONE);
 		this->FinishInitNested(window_number);
-		this->last_user_action = INVALID_WID_ETT;
 	}
 
 	void OnPaint() override

--- a/src/textfile_gui.h
+++ b/src/textfile_gui.h
@@ -19,9 +19,9 @@ std::optional<std::string> GetTextfile(TextfileType type, Subdirectory dir, cons
 
 /** Window for displaying a textfile */
 struct TextfileWindow : public Window, MissingGlyphSearcher {
-	TextfileType file_type;          ///< Type of textfile to view.
-	Scrollbar *vscroll;              ///< Vertical scrollbar.
-	Scrollbar *hscroll;              ///< Horizontal scrollbar.
+	TextfileType file_type{}; ///< Type of textfile to view.
+	Scrollbar *vscroll = nullptr; ///< Vertical scrollbar.
+	Scrollbar *hscroll = nullptr; ///< Horizontal scrollbar.
 
 	void UpdateWidgetSize(WidgetID widget, Dimension &size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension &fill, [[maybe_unused]] Dimension &resize) override;
 	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override;
@@ -65,16 +65,16 @@ protected:
 		int scrollpos;           ///< Scrolling position the file was at at navigation time.
 	};
 
-	std::string filename{};              ///< Filename of the textfile.
-	std::string filepath{};              ///< Full path to the filename.
+	std::string filename{}; ///< Filename of the textfile.
+	std::string filepath{}; ///< Full path to the filename.
 
-	std::vector<Line> lines;             ///< #text, split into lines in a table with lines.
-	std::vector<size_t> jumplist;        ///< Table of contents list, line numbers.
-	std::vector<Hyperlink> links;        ///< Clickable links in lines.
-	std::vector<Hyperlink> link_anchors; ///< Anchor names of headings that can be linked to.
-	std::vector<HistoryEntry> history;   ///< Browsing history in this window.
-	size_t history_pos = 0;              ///< Position in browsing history (for forward movement).
-	bool trusted = false;                ///< Whether the content is trusted (read: not from content like NewGRFs, etc).
+	std::vector<Line> lines{}; ///< #text, split into lines in a table with lines.
+	std::vector<size_t> jumplist{}; ///< Table of contents list, line numbers.
+	std::vector<Hyperlink> links{}; ///< Clickable links in lines.
+	std::vector<Hyperlink> link_anchors{}; ///< Anchor names of headings that can be linked to.
+	std::vector<HistoryEntry> history{}; ///< Browsing history in this window.
+	size_t history_pos = 0; ///< Position in browsing history (for forward movement).
+	bool trusted = false; ///< Whether the content is trusted (read: not from content like NewGRFs, etc).
 
 	void LoadText(std::string_view buf);
 	void FindHyperlinksInMarkdown(Line &line, size_t line_index);
@@ -97,8 +97,8 @@ protected:
 	void NavigateHistory(int delta);
 
 private:
-	uint search_iterator = 0;     ///< Iterator for the font check search.
-	uint max_length = 0;          ///< Maximum length of unwrapped text line.
+	uint search_iterator = 0; ///< Iterator for the font check search.
+	uint max_length = 0; ///< Maximum length of unwrapped text line.
 
 	uint ReflowContent();
 	uint GetContentHeight();

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -189,19 +189,17 @@ static void ChangeTimetableStartCallback(const Window *w, TimerGameEconomy::Date
 
 
 struct TimetableWindow : Window {
-	int sel_index;
-	VehicleTimetableWidgets query_widget; ///< Which button was clicked to open the query text input?
-	const Vehicle *vehicle;    ///< Vehicle monitored by the window.
-	bool show_expected;        ///< Whether we show expected arrival or scheduled.
-	Scrollbar *vscroll;        ///< The scrollbar.
-	bool set_start_date_all;   ///< Set start date using minutes text entry for all timetable entries (ctrl-click) action.
-	bool change_timetable_all; ///< Set wait time or speed for all timetable entries (ctrl-click) action.
+	int sel_index = -1;
+	VehicleTimetableWidgets query_widget{}; ///< Which button was clicked to open the query text input?
+	const Vehicle *vehicle = nullptr; ///< Vehicle monitored by the window.
+	bool show_expected = true; ///< Whether we show expected arrival or scheduled.
+	Scrollbar *vscroll = nullptr; ///< The scrollbar.
+	bool set_start_date_all = false; ///< Set start date using minutes text entry for all timetable entries (ctrl-click) action.
+	bool change_timetable_all = false; ///< Set wait time or speed for all timetable entries (ctrl-click) action.
 
 	TimetableWindow(WindowDesc &desc, WindowNumber window_number) :
 			Window(desc),
-			sel_index(-1),
-			vehicle(Vehicle::Get(window_number)),
-			show_expected(true)
+			vehicle(Vehicle::Get(window_number))
 	{
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_VT_SCROLLBAR);

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -79,15 +79,15 @@ static constexpr NWidgetPart _nested_town_authority_widgets[] = {
 /** Town authority window. */
 struct TownAuthorityWindow : Window {
 private:
-	Town *town;    ///< Town being displayed.
+	Town *town = nullptr; ///< Town being displayed.
 	TownAction sel_action = TownAction::End; ///< Currently selected town action, TownAction::End means no action selected.
 	TownActions displayed_actions_on_previous_painting{}; ///< Actions that were available on the previous call to OnPaint()
-	TownActions enabled_actions; ///< Actions that are enabled in settings.
+	TownActions enabled_actions{}; ///< Actions that are enabled in settings.
 	TownActions available_actions{}; ///< Actions that are available to execute for the current company.
-	StringID action_tooltips[to_underlying(TownAction::End)];
+	std::array<StringID, to_underlying(TownAction::End)> action_tooltips{};
 
-	Dimension icon_size;      ///< Dimensions of company icon
-	Dimension exclusive_size; ///< Dimensions of exclusive icon
+	Dimension icon_size{}; ///< Dimensions of company icon
+	Dimension exclusive_size{}; ///< Dimensions of exclusive icon
 
 	/**
 	 * Get the position of the Nth set bit.
@@ -364,7 +364,7 @@ static void ShowTownAuthorityWindow(uint town)
 /* Town view window. */
 struct TownViewWindow : Window {
 private:
-	Town *town; ///< Town displayed by the window.
+	Town *town = nullptr; ///< Town displayed by the window.
 
 public:
 	static const int WID_TV_HEIGHT_NORMAL = 150;
@@ -742,12 +742,12 @@ private:
 	};
 	static const std::initializer_list<GUITownList::SortFunction * const> sorter_funcs;
 
-	StringFilter string_filter;             ///< Filter for towns
-	QueryString townname_editbox;           ///< Filter editbox
+	StringFilter string_filter{}; ///< Filter for towns
+	QueryString townname_editbox; ///< Filter editbox
 
 	GUITownList towns{TownDirectoryWindow::last_sorting.order};
 
-	Scrollbar *vscroll;
+	Scrollbar *vscroll = nullptr;
 
 	void BuildSortTownList()
 	{
@@ -1165,18 +1165,17 @@ static constexpr NWidgetPart _nested_found_town_widgets[] = {
 /** Found a town window class. */
 struct FoundTownWindow : Window {
 private:
-	TownSize town_size;     ///< Selected town size
-	TownLayout town_layout; ///< Selected town layout
-	bool city;              ///< Are we building a city?
+	TownSize town_size = TSZ_MEDIUM; ///< Selected town size
+	TownLayout town_layout{}; ///< Selected town layout
+	bool city = false; ///< Are we building a city?
 	QueryString townname_editbox; ///< Townname editbox
-	bool townnamevalid;     ///< Is generated town name valid?
-	uint32_t townnameparts;   ///< Generated town name
-	TownNameParams params;  ///< Town name parameters
+	bool townnamevalid = false; ///< Is generated town name valid?
+	uint32_t townnameparts = 0; ///< Generated town name
+	TownNameParams params; ///< Town name parameters
 
 public:
 	FoundTownWindow(WindowDesc &desc, WindowNumber window_number) :
 			Window(desc),
-			town_size(TSZ_MEDIUM),
 			town_layout(_settings_game.economy.town_layout),
 			townname_editbox(MAX_LENGTH_TOWN_NAME_CHARS * MAX_CHAR_LENGTH, MAX_LENGTH_TOWN_NAME_CHARS),
 			params(_settings_game.game_creation.town_name)
@@ -1674,8 +1673,8 @@ static CargoTypes GetProducedCargoOfHouse(const HouseSpec *hs)
 }
 
 struct BuildHouseWindow : public PickerWindow {
-	std::string house_info;
-	bool house_protected;
+	std::string house_info{};
+	bool house_protected = false;
 
 	BuildHouseWindow(WindowDesc &desc, Window *parent) : PickerWindow(desc, parent, 0, HousePickerCallbacks::instance)
 	{

--- a/src/tree_gui.cpp
+++ b/src/tree_gui.cpp
@@ -88,8 +88,8 @@ class BuildTreesWindow : public Window
 		PM_FOREST_LG,
 	};
 
-	int tree_to_plant;  ///< Tree number to plant, \c TREE_INVALID for a random tree.
-	PlantingMode mode;  ///< Current mode for planting
+	int tree_to_plant = -1; ///< Tree number to plant, \c TREE_INVALID for a random tree.
+	PlantingMode mode = PM_NORMAL; ///< Current mode for planting
 
 	/**
 	 * Update the GUI and enable/disable planting to reflect selected options.
@@ -139,7 +139,7 @@ class BuildTreesWindow : public Window
 	}
 
 public:
-	BuildTreesWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc), tree_to_plant(-1), mode(PM_NORMAL)
+	BuildTreesWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{
 		this->CreateNestedTree();
 		ResetObjectToPlace();

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -742,20 +742,20 @@ static void DrawVehicleRefitWindow(const RefitOptions &refits, const RefitOption
 
 /** Refit cargo window. */
 struct RefitWindow : public Window {
-	const RefitOption *selected_refit; ///< Selected refit option.
-	RefitOptions refit_list; ///< List of refit subtypes available for each sorted cargo.
-	VehicleOrderID order;        ///< If not #INVALID_VEH_ORDER_ID, selection is part of a refit order (rather than execute directly).
-	uint information_width;      ///< Width required for correctly displaying all cargoes in the information panel.
-	Scrollbar *vscroll;          ///< The main scrollbar.
-	Scrollbar *hscroll;          ///< Only used for long vehicles.
-	int vehicle_width;           ///< Width of the vehicle being drawn.
-	int sprite_left;             ///< Left position of the vehicle sprite.
-	int sprite_right;            ///< Right position of the vehicle sprite.
-	uint vehicle_margin;         ///< Margin to use while selecting vehicles when the vehicle image is centered.
-	int click_x;                 ///< Position of the first click while dragging.
-	VehicleID selected_vehicle;  ///< First vehicle in the current selection.
-	uint8_t num_vehicles;          ///< Number of selected vehicles.
-	bool auto_refit;             ///< Select cargo for auto-refitting.
+	const RefitOption *selected_refit = nullptr; ///< Selected refit option.
+	RefitOptions refit_list{}; ///< List of refit subtypes available for each sorted cargo.
+	VehicleOrderID order = INVALID_VEH_ORDER_ID; ///< If not #INVALID_VEH_ORDER_ID, selection is part of a refit order (rather than execute directly).
+	uint information_width = 0; ///< Width required for correctly displaying all cargoes in the information panel.
+	Scrollbar *vscroll = nullptr; ///< The main scrollbar.
+	Scrollbar *hscroll = nullptr; ///< Only used for long vehicles.
+	int vehicle_width = 0; ///< Width of the vehicle being drawn.
+	int sprite_left = 0; ///< Left position of the vehicle sprite.
+	int sprite_right = 0; ///< Right position of the vehicle sprite.
+	uint vehicle_margin = 0; ///< Margin to use while selecting vehicles when the vehicle image is centered.
+	int click_x = 0; ///< Position of the first click while dragging.
+	VehicleID selected_vehicle{}; ///< First vehicle in the current selection.
+	uint8_t num_vehicles = 0; ///< Number of selected vehicles.
+	bool auto_refit = false; ///< Select cargo for auto-refitting.
 
 	/**
 	 * Collects all (cargo, subcargo) refit options of a vehicle chain.
@@ -2091,7 +2091,7 @@ public:
 		this->DrawWidgets();
 	}
 
-	bool last_overlay_state;
+	bool last_overlay_state = false;
 	void OnMouseLoop() override
 	{
 		if (last_overlay_state != ShowCargoIconOverlay()) {
@@ -2416,8 +2416,8 @@ static StringID _service_interval_dropdown_wallclock[] = {
 
 /** Class for managing the vehicle details window. */
 struct VehicleDetailsWindow : Window {
-	TrainDetailsWindowTabs tab; ///< For train vehicles: which tab is displayed.
-	Scrollbar *vscroll;
+	TrainDetailsWindowTabs tab = TDW_TAB_CARGO; ///< For train vehicles: which tab is displayed.
+	Scrollbar *vscroll = nullptr;
 
 	/** Initialize a newly created vehicle details window */
 	VehicleDetailsWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
@@ -2429,7 +2429,6 @@ struct VehicleDetailsWindow : Window {
 		this->FinishInitNested(window_number);
 
 		this->owner = v->owner;
-		this->tab = TDW_TAB_CARGO;
 	}
 
 	/**

--- a/src/vehicle_gui_base.h
+++ b/src/vehicle_gui_base.h
@@ -73,17 +73,17 @@ struct BaseVehicleListWindow : public Window {
 		GB_END,
 	};
 
-	GroupBy grouping;                           ///< How we want to group the list.
-	VehicleList vehicles;                       ///< List of vehicles.  This is the buffer for `vehgroups` to point into; if this is structurally modified, `vehgroups` must be rebuilt.
-	GUIVehicleGroupList vehgroups;              ///< List of (groups of) vehicles.  This stores iterators of `vehicles`, and should be rebuilt if `vehicles` is structurally changed.
-	Listing *sorting;                           ///< Pointer to the vehicle type related sorting.
-	uint8_t unitnumber_digits;                     ///< The number of digits of the highest unit number.
-	Scrollbar *vscroll;
-	VehicleListIdentifier vli;                  ///< Identifier of the vehicle list we want to currently show.
-	VehicleID vehicle_sel;                      ///< Selected vehicle
-	CargoType cargo_filter_criteria;              ///< Selected cargo filter index
-	uint order_arrow_width;                     ///< Width of the arrow in the small order list.
-	CargoTypes used_cargoes;
+	GroupBy grouping{}; ///< How we want to group the list.
+	VehicleList vehicles{}; ///< List of vehicles.  This is the buffer for `vehgroups` to point into; if this is structurally modified, `vehgroups` must be rebuilt.
+	GUIVehicleGroupList vehgroups{}; ///< List of (groups of) vehicles.  This stores iterators of `vehicles`, and should be rebuilt if `vehicles` is structurally changed.
+	Listing *sorting = nullptr; ///< Pointer to the vehicle type related sorting.
+	uint8_t unitnumber_digits = 0; ///< The number of digits of the highest unit number.
+	Scrollbar *vscroll = nullptr;
+	VehicleListIdentifier vli{}; ///< Identifier of the vehicle list we want to currently show.
+	VehicleID vehicle_sel{}; ///< Selected vehicle
+	CargoType cargo_filter_criteria{}; ///< Selected cargo filter index
+	uint order_arrow_width = 0; ///< Width of the arrow in the small order list.
+	CargoTypes used_cargoes{};
 
 	typedef GUIVehicleGroupList::SortFunction VehicleGroupSortFunction;
 	typedef GUIVehicleList::SortFunction VehicleIndividualSortFunction;

--- a/src/waypoint_gui.cpp
+++ b/src/waypoint_gui.cpp
@@ -32,8 +32,8 @@
 /** GUI for accessing waypoints and buoys. */
 struct WaypointWindow : Window {
 private:
-	VehicleType vt; ///< Vehicle type using the waypoint.
-	Waypoint *wp;   ///< Waypoint displayed by the window.
+	VehicleType vt = VEH_INVALID; ///< Vehicle type using the waypoint.
+	Waypoint *wp = nullptr; ///< Waypoint displayed by the window.
 
 	/**
 	 * Get the center tile of the waypoint.


### PR DESCRIPTION
## Motivation / Problem

`Window` is the last user of `ZeroedMemoryAllocator`, but to remove that all member variables of windows need to be properly initialised.


## Description

Explicitly initialise member variables for windows in files starting with 't' through 'z'.

Some changes of arrays to `std::array` were needed.


## Limitations

There's more to come, but I think this is still a reasonable chunk size for PR. I've made that available as a single PR: #13644.
I also did not implicitly fix any super classes, e.g. `PickerWindowBase`, as those will be handled in the chunk with the 'p' in it.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
