### PR TITLE
Codechange: remove unused alloc_func.hpp includes

### DIFF
--- a/src/3rdparty/squirrel/squirrel/sqdebug.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqdebug.cpp
@@ -12,7 +12,6 @@
 #include "sqclosure.h"
 #include "sqstring.h"
 
-#include "../../../core/alloc_func.hpp"
 #include "../../../string_func.h"
 
 #include "../../../safeguards.h"

--- a/src/ini_load.cpp
+++ b/src/ini_load.cpp
@@ -8,7 +8,6 @@
 /** @file ini_load.cpp Definition of the #IniLoadFile class, related to reading and storing '*.ini' files. */
 
 #include "stdafx.h"
-#include "core/alloc_func.hpp"
 #include "core/mem_func.hpp"
 #include "ini_type.h"
 #include "string_func.h"

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9,7 +9,6 @@
 
 #include "stdafx.h"
 #include "debug.h"
-#include "core/alloc_func.hpp"
 #include "water_map.h"
 #include "error_func.h"
 #include "string_func.h"

--- a/src/music/extmidi.cpp
+++ b/src/music/extmidi.cpp
@@ -10,7 +10,6 @@
 #include "../stdafx.h"
 #include "../debug.h"
 #include "../string_func.h"
-#include "../core/alloc_func.hpp"
 #include "../sound/sound_driver.hpp"
 #include "../video/video_driver.hpp"
 #include "../gfx_func.h"

--- a/src/newgrf_storage.h
+++ b/src/newgrf_storage.h
@@ -10,7 +10,6 @@
 #ifndef NEWGRF_STORAGE_H
 #define NEWGRF_STORAGE_H
 
-#include "core/alloc_func.hpp"
 #include "core/pool_type.hpp"
 #include "tile_type.h"
 

--- a/src/newgrf_townname.cpp
+++ b/src/newgrf_townname.cpp
@@ -14,7 +14,6 @@
 
 #include "stdafx.h"
 #include "newgrf_townname.h"
-#include "core/alloc_func.hpp"
 #include "string_func.h"
 #include "strings_internal.h"
 

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -23,7 +23,6 @@
 #include <io.h>
 #include "win32.h"
 #include "../../fios.h"
-#include "../../core/alloc_func.hpp"
 #include "../../string_func.h"
 #include <sys/stat.h>
 #include "../../language.h"

--- a/src/saveload/strings_sl.cpp
+++ b/src/saveload/strings_sl.cpp
@@ -8,7 +8,6 @@
 /** @file strings_sl.cpp Code handling saving and loading of strings */
 
 #include "../stdafx.h"
-#include "../core/alloc_func.hpp"
 #include "../string_func.h"
 #include "../strings_func.h"
 #include "saveload_internal.h"

--- a/src/script/api/script_cargo.cpp
+++ b/src/script/api/script_cargo.cpp
@@ -10,7 +10,6 @@
 #include "../../stdafx.h"
 #include "script_cargo.hpp"
 #include "../../economy_func.h"
-#include "../../core/alloc_func.hpp"
 #include "../../core/bitmath_func.hpp"
 #include "../../strings_func.h"
 #include "../../settings_type.h"

--- a/src/script/api/script_log.cpp
+++ b/src/script/api/script_log.cpp
@@ -10,7 +10,6 @@
 #include "../../stdafx.h"
 #include "script_log_types.hpp"
 #include "script_log.hpp"
-#include "../../core/alloc_func.hpp"
 #include "../../debug.h"
 #include "../../window_func.h"
 #include "../../string_func.h"

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -17,7 +17,6 @@
 #include <sqstdaux.h>
 #include <../squirrel/sqpcheader.h>
 #include <../squirrel/sqvm.h>
-#include "../core/alloc_func.hpp"
 
 /**
  * In the memory allocator for Squirrel we want to directly use malloc/realloc, so when the OS

--- a/src/settingsgen/CMakeLists.txt
+++ b/src/settingsgen/CMakeLists.txt
@@ -6,7 +6,6 @@ if (NOT HOST_BINARY_DIR)
     set(sourcefiles
             settingsgen.cpp
             ../3rdparty/fmt/format.cc
-            ../core/alloc_func.cpp
             ../misc/getoptdata.cpp
             ../error.cpp
             ../ini_load.cpp

--- a/src/sound/win32_s.cpp
+++ b/src/sound/win32_s.cpp
@@ -11,7 +11,6 @@
 #include "../openttd.h"
 #include "../driver.h"
 #include "../mixer.h"
-#include "../core/alloc_func.hpp"
 #include "../core/bitmath_func.hpp"
 #include "../core/math_func.hpp"
 #include "win32_s.h"

--- a/src/sound/xaudio2_s.cpp
+++ b/src/sound/xaudio2_s.cpp
@@ -12,7 +12,6 @@
 #include "../driver.h"
 #include "../mixer.h"
 #include "../debug.h"
-#include "../core/alloc_func.hpp"
 #include "../core/bitmath_func.hpp"
 #include "../core/math_func.hpp"
 

--- a/src/strgen/CMakeLists.txt
+++ b/src/strgen/CMakeLists.txt
@@ -9,7 +9,6 @@ if (NOT HOST_BINARY_DIR)
             strgen.cpp
             strgen_base.cpp
             ../3rdparty/fmt/format.cc
-            ../core/alloc_func.cpp
             ../misc/getoptdata.cpp
             ../error.cpp
             ../string.cpp

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -8,7 +8,6 @@
 /** @file strgen_base.cpp Tool to create computer readable (stand-alone) translation files. */
 
 #include "../stdafx.h"
-#include "../core/alloc_func.hpp"
 #include "../core/endian_func.hpp"
 #include "../core/mem_func.hpp"
 #include "../error_func.h"

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -9,7 +9,6 @@
 
 #include "stdafx.h"
 #include "debug.h"
-#include "core/alloc_func.hpp"
 #include "core/math_func.hpp"
 #include "error_func.h"
 #include "string_func.h"

--- a/src/stringfilter.cpp
+++ b/src/stringfilter.cpp
@@ -8,7 +8,6 @@
 /** @file stringfilter.cpp Searching and filtering using a stringterm. */
 
 #include "stdafx.h"
-#include "core/alloc_func.hpp"
 #include "string_func.h"
 #include "strings_func.h"
 #include "stringfilter_type.h"

--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -16,7 +16,6 @@
 #include "gfx_func.h"
 #include "gfx_layout.h"
 #include "window_func.h"
-#include "core/alloc_func.hpp"
 
 #include "safeguards.h"
 


### PR DESCRIPTION
## Motivation / Problem

Unused `#include "core/alloc_func.hpp"`.


## Description

Remove those lines.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
