### PR TITLE
Change: Show underlying type of clear snow tile.

### DIFF
--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -25,7 +25,7 @@
 
 static CommandCost ClearTile_Clear(TileIndex tile, DoCommandFlags flags)
 {
-	static const Price clear_price_table[] = {
+	static constexpr Price clear_price_table[] = {
 		PR_CLEAR_GRASS,
 		PR_CLEAR_ROUGH,
 		PR_CLEAR_ROCKS,
@@ -35,7 +35,9 @@ static CommandCost ClearTile_Clear(TileIndex tile, DoCommandFlags flags)
 	};
 	CommandCost price(EXPENSES_CONSTRUCTION);
 
-	if (!IsClearGround(tile, CLEAR_GRASS) || GetClearDensity(tile) != 0) {
+	if (IsSnowTile(tile)) {
+		price.AddCost(_price[clear_price_table[CLEAR_SNOW]]);
+	} else if (!IsClearGround(tile, CLEAR_GRASS) || GetClearDensity(tile) != 0) {
 		price.AddCost(_price[clear_price_table[GetClearGround(tile)]]);
 	}
 
@@ -100,7 +102,9 @@ static void DrawClearLandFence(const TileInfo *ti)
 
 static void DrawTile_Clear(TileInfo *ti)
 {
-	switch (GetClearGround(ti->tile)) {
+	ClearGround ground = IsSnowTile(ti->tile) ? CLEAR_SNOW : GetClearGround(ti->tile);
+
+	switch (ground) {
 		case CLEAR_GRASS:
 			DrawClearLandTile(ti, GetClearDensity(ti->tile));
 			break;
@@ -236,6 +240,8 @@ static void TileLoop_Clear(TileIndex tile)
 		case LandscapeType::Arctic: TileLoopClearAlps(tile);   break;
 		default: break;
 	}
+
+	if (IsSnowTile(tile)) return;
 
 	switch (GetClearGround(tile)) {
 		case CLEAR_GRASS:

--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -335,21 +335,23 @@ static TrackStatus GetTileTrackStatus_Clear(TileIndex, TransportType, uint, Diag
 	return 0;
 }
 
-static const StringID _clear_land_str[] = {
-	STR_LAI_CLEAR_DESCRIPTION_GRASS,
-	STR_LAI_CLEAR_DESCRIPTION_ROUGH_LAND,
-	STR_LAI_CLEAR_DESCRIPTION_ROCKS,
-	STR_LAI_CLEAR_DESCRIPTION_FIELDS,
-	STR_LAI_CLEAR_DESCRIPTION_SNOW_COVERED_LAND,
-	STR_LAI_CLEAR_DESCRIPTION_DESERT
-};
-
 static void GetTileDesc_Clear(TileIndex tile, TileDesc &td)
 {
-	if (IsClearGround(tile, CLEAR_GRASS) && GetClearDensity(tile) == 0) {
+	/* Each pair holds a normal and a snowy ClearGround description. */
+	static constexpr std::pair<StringID, StringID> clear_land_str[] = {
+		{STR_LAI_CLEAR_DESCRIPTION_GRASS,      STR_LAI_CLEAR_DESCRIPTION_SNOWY_GRASS},
+		{STR_LAI_CLEAR_DESCRIPTION_ROUGH_LAND, STR_LAI_CLEAR_DESCRIPTION_SNOWY_ROUGH_LAND},
+		{STR_LAI_CLEAR_DESCRIPTION_ROCKS,      STR_LAI_CLEAR_DESCRIPTION_SNOWY_ROCKS},
+		{STR_LAI_CLEAR_DESCRIPTION_FIELDS,     STR_EMPTY},
+		{STR_EMPTY,                            STR_EMPTY}, // CLEAR_SNOW does not appear in the map.
+		{STR_LAI_CLEAR_DESCRIPTION_DESERT,     STR_EMPTY},
+	};
+
+	if (!IsSnowTile(tile) && IsClearGround(tile, CLEAR_GRASS) && GetClearDensity(tile) == 0) {
 		td.str = STR_LAI_CLEAR_DESCRIPTION_BARE_LAND;
 	} else {
-		td.str = _clear_land_str[GetClearGround(tile)];
+		const auto &[name, snowy_name] = clear_land_str[GetClearGround(tile)];
+		td.str = IsSnowTile(tile) ? snowy_name : name;
 	}
 	td.owner[0] = GetTileOwner(tile);
 }

--- a/src/clear_map.h
+++ b/src/clear_map.h
@@ -21,7 +21,7 @@ enum ClearGround : uint8_t {
 	CLEAR_ROUGH  = 1, ///< 3
 	CLEAR_ROCKS  = 2, ///< 3
 	CLEAR_FIELDS = 3, ///< 3
-	CLEAR_SNOW   = 4, ///< 0-3
+	CLEAR_SNOW   = 4, ///< 0-3 (Not stored in map.)
 	CLEAR_DESERT = 5, ///< 1,3
 };
 
@@ -39,18 +39,6 @@ inline bool IsSnowTile(Tile t)
 }
 
 /**
- * Get the type of clear tile but never return CLEAR_SNOW.
- * @param t the tile to get the clear ground type of
- * @pre IsTileType(t, MP_CLEAR)
- * @return the ground type
- */
-inline ClearGround GetRawClearGround(Tile t)
-{
-	assert(IsTileType(t, MP_CLEAR));
-	return (ClearGround)GB(t.m5(), 2, 3);
-}
-
-/**
  * Get the type of clear tile.
  * @param t the tile to get the clear ground type of
  * @pre IsTileType(t, MP_CLEAR)
@@ -58,8 +46,8 @@ inline ClearGround GetRawClearGround(Tile t)
  */
 inline ClearGround GetClearGround(Tile t)
 {
-	if (IsSnowTile(t)) return CLEAR_SNOW;
-	return GetRawClearGround(t);
+	assert(IsTileType(t, MP_CLEAR));
+	return static_cast<ClearGround>(GB(t.m5(), 2, 3));
 }
 
 /**
@@ -295,13 +283,13 @@ inline void MakeField(Tile t, uint field_type, IndustryID industry)
  * Make a snow tile.
  * @param t the tile to make snowy
  * @param density The density of snowiness.
- * @pre GetClearGround(t) != CLEAR_SNOW
+ * @pre !IsSnowTile(t)
  */
 inline void MakeSnow(Tile t, uint density = 0)
 {
-	assert(GetClearGround(t) != CLEAR_SNOW);
+	assert(!IsSnowTile(t));
 	SetBit(t.m3(), 4);
-	if (GetRawClearGround(t) == CLEAR_FIELDS) {
+	if (GetClearGround(t) == CLEAR_FIELDS) {
 		SetClearGroundDensity(t, CLEAR_GRASS, density);
 	} else {
 		SetClearDensity(t, density);
@@ -311,11 +299,11 @@ inline void MakeSnow(Tile t, uint density = 0)
 /**
  * Clear the snow from a tile and return it to its previous type.
  * @param t the tile to clear of snow
- * @pre GetClearGround(t) == CLEAR_SNOW
+ * @pre IsSnowTile(t)
  */
 inline void ClearSnow(Tile t)
 {
-	assert(GetClearGround(t) == CLEAR_SNOW);
+	assert(IsSnowTile(t));
 	ClrBit(t.m3(), 4);
 	SetClearDensity(t, 3);
 }

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1004,7 +1004,7 @@ static const uint8_t _plantfarmfield_type[] = {1, 1, 1, 1, 1, 3, 3, 4, 4, 4, 5, 
 static bool IsSuitableForFarmField(TileIndex tile, bool allow_fields)
 {
 	switch (GetTileType(tile)) {
-		case MP_CLEAR: return !IsClearGround(tile, CLEAR_SNOW) && !IsClearGround(tile, CLEAR_DESERT) && (allow_fields || !IsClearGround(tile, CLEAR_FIELDS));
+		case MP_CLEAR: return !IsSnowTile(tile) && !IsClearGround(tile, CLEAR_DESERT) && (allow_fields || !IsClearGround(tile, CLEAR_FIELDS));
 		case MP_TREES: return GetTreeGround(tile) != TREE_GROUND_SHORE;
 		default:       return false;
 	}

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -633,7 +633,7 @@ public:
 
 		/* Clear farmland. */
 		for (const auto tile : Map::Iterate()) {
-			if (IsTileType(tile, MP_CLEAR) && GetRawClearGround(tile) == CLEAR_FIELDS) {
+			if (IsTileType(tile, MP_CLEAR) && GetClearGround(tile) == CLEAR_FIELDS) {
 				MakeClear(tile, CLEAR_GRASS, 3);
 			}
 		}

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3157,8 +3157,10 @@ STR_LAI_CLEAR_DESCRIPTION_ROUGH_LAND                            :Rough land
 STR_LAI_CLEAR_DESCRIPTION_BARE_LAND                             :Bare land
 STR_LAI_CLEAR_DESCRIPTION_GRASS                                 :Grass
 STR_LAI_CLEAR_DESCRIPTION_FIELDS                                :Fields
-STR_LAI_CLEAR_DESCRIPTION_SNOW_COVERED_LAND                     :Snow-covered land
 STR_LAI_CLEAR_DESCRIPTION_DESERT                                :Desert
+STR_LAI_CLEAR_DESCRIPTION_SNOWY_ROCKS                           :Snow-covered rocks
+STR_LAI_CLEAR_DESCRIPTION_SNOWY_ROUGH_LAND                      :Snow-covered rough land
+STR_LAI_CLEAR_DESCRIPTION_SNOWY_GRASS                           :Snow-covered grass
 
 STR_LAI_RAIL_DESCRIPTION_TRACK                                  :Railway track
 STR_LAI_RAIL_DESCRIPTION_TRACK_WITH_NORMAL_SIGNALS              :Railway track with block signals

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2387,7 +2387,7 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SLV_135)) {
 		for (auto t : Map::Iterate()) {
 			if (IsTileType(t, MP_CLEAR)) {
-				if (GetRawClearGround(t) == CLEAR_SNOW) {
+				if (GetClearGround(t) == CLEAR_SNOW) { // CLEAR_SNOW becomes CLEAR_GRASS with IsSnowTile() set.
 					SetClearGroundDensity(t, CLEAR_GRASS, GetClearDensity(t));
 					SetBit(t.m3(), 4);
 				} else {

--- a/src/script/api/script_tile.cpp
+++ b/src/script/api/script_tile.cpp
@@ -130,14 +130,14 @@
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return (::IsTileType(tile, MP_CLEAR) && ::GetRawClearGround(tile) == ::CLEAR_ROCKS);
+	return (::IsTileType(tile, MP_CLEAR) && ::GetClearGround(tile) == ::CLEAR_ROCKS);
 }
 
 /* static */ bool ScriptTile::IsRoughTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return (::IsTileType(tile, MP_CLEAR) && ::GetRawClearGround(tile) == ::CLEAR_ROUGH);
+	return (::IsTileType(tile, MP_CLEAR) && ::GetClearGround(tile) == ::CLEAR_ROUGH);
 }
 
 /* static */ bool ScriptTile::IsSnowTile(TileIndex tile)


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Snowy clear tiles can have rocks, rough land or grass underneath, but the description always says "Snow-covered land"

The part of #13627 that doesn't add sprites.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, show the underlying type as snow-covered instead, i.e. "Snow-covered rocks", "Snow-covered rough land" and "Snow-covered grass"

To achieve this the special handling for `ClearGround` `CLEAR_SNOW` is replaced with explicit checks for `IsSnowTile()`.

This does not affect how the tile itself is drawn, nor the cost to clear.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
