### PR TITLE
Codechange: Always pass raw strings to TextFilter's AddLine().

### DIFF
--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -234,9 +234,8 @@ bool SettingEntry::UpdateFilterState(SettingFilter &filter, bool force_visible)
 		/* Process the search text filter for this item. */
 		filter.string.ResetState();
 
-		SetDParam(0, STR_EMPTY);
-		filter.string.AddLine(sd->GetTitle());
-		filter.string.AddLine(sd->GetHelp());
+		filter.string.AddLine(GetString(sd->GetTitle(), STR_EMPTY));
+		filter.string.AddLine(GetString(sd->GetHelp()));
 
 		visible = filter.string.GetState();
 	}
@@ -530,7 +529,7 @@ bool SettingsPage::UpdateFilterState(SettingFilter &filter, bool force_visible)
 {
 	if (!force_visible && !filter.string.IsEmpty()) {
 		filter.string.ResetState();
-		filter.string.AddLine(this->title);
+		filter.string.AddLine(GetString(this->title));
 		force_visible = filter.string.GetState();
 	}
 

--- a/src/stringfilter.cpp
+++ b/src/stringfilter.cpp
@@ -123,29 +123,3 @@ void StringFilter::AddLine(const char *str)
 		}
 	}
 }
-
-/**
- * Pass another text line from the current item to the filter.
- *
- * You can call this multiple times for a single item, if the filter shall apply to multiple things.
- * Before processing the next item you have to call ResetState().
- *
- * @param str Another line from the item.
- */
-void StringFilter::AddLine(const std::string &str)
-{
-	AddLine(str.c_str());
-}
-
-/**
- * Pass another text line from the current item to the filter.
- *
- * You can call this multiple times for a single item, if the filter shall apply to multiple things.
- * Before processing the next item you have to call ResetState().
- *
- * @param str Another line from the item.
- */
-void StringFilter::AddLine(StringID str)
-{
-	AddLine(GetString(str));
-}

--- a/src/stringfilter_type.h
+++ b/src/stringfilter_type.h
@@ -58,8 +58,7 @@ public:
 
 	void ResetState();
 	void AddLine(const char *str);
-	void AddLine(const std::string &str);
-	void AddLine(StringID str);
+	void AddLine(const std::string &str) { this->AddLine(str.c_str()); }
 
 	/**
 	 * Get the matching state of the current item.


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

TextFilter has three AddLine() overrides, one of which is StringID. This is only used 3 times, and one of those requires parameters anyway...

Part of global string parameter removal.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Remove StringID overload, so callers have to preformat the string. Avoids using global parameters.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
