### PR TITLE
Fix #13668, fd2949d: Include the `\0` in TextBuf  max_chars cropping

### DIFF
--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -427,7 +427,7 @@ void Textbuf::Assign(const std::string_view text)
 	/* Make sure the name isn't too long for the text buffer in the number of
 	 * characters (not bytes). max_chars also counts the '\0' characters. */
 	auto iter = this->buf.begin();
-	for (size_t len = 0; len < this->max_chars && iter != this->buf.end(); ++len) Utf8Consume(iter);
+	for (size_t len = 1; len < this->max_chars && iter != this->buf.end(); ++len) Utf8Consume(iter);
 
 	if (iter != this->buf.end()) {
 		this->buf.erase(iter, this->buf.end());


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
`TextBuf::max_chars` includes the `\0`.
https://github.com/OpenTTD/OpenTTD/commit/fd2949d5594fcecaaf1c020b06247d58c1316e22 accidentally removed a `+ 1` corresponding to this `\0`.
This cause the `TextBuf::buf` to be 1 char too long and triggers an assert in `Textbuf::UpdateSize()`.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Count the `\0` when cropping the text to `TextBuf::max_chars`.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
