### PR TITLE
Codechange: prepare replacing SetStringParameters with GetWidgetString

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -115,16 +115,17 @@ struct AIConfigWindow : public Window {
 		this->Window::Close();
 	}
 
-	void SetStringParameters(WidgetID widget) const override
+	std::string GetWidgetString(WidgetID widget, StringID stringid) const override
 	{
 		switch (widget) {
 			case WID_AIC_NUMBER:
-				SetDParam(0, GetGameSettings().difficulty.max_no_competitors);
-				break;
+				return GetString(stringid, GetGameSettings().difficulty.max_no_competitors);
 
 			case WID_AIC_INTERVAL:
-				SetDParam(0, GetGameSettings().difficulty.competitors_interval);
-				break;
+				return GetString(stringid, GetGameSettings().difficulty.competitors_interval);
+
+			default:
+				return this->Window::GetWidgetString(widget, stringid);
 		}
 	}
 

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -292,28 +292,26 @@ public:
 		this->PickerWindowBase::Close();
 	}
 
-	void SetStringParameters(WidgetID widget) const override
+	std::string GetWidgetString(WidgetID widget, StringID stringid) const override
 	{
 		switch (widget) {
 			case WID_AP_CLASS_DROPDOWN:
-				SetDParam(0, AirportClass::Get(_selected_airport_class)->name);
-				break;
+				return GetString(stringid, AirportClass::Get(_selected_airport_class)->name);
 
 			case WID_AP_LAYOUT_NUM:
-				SetDParam(0, STR_EMPTY);
 				if (_selected_airport_index != -1) {
 					const AirportSpec *as = AirportClass::Get(_selected_airport_class)->GetSpec(_selected_airport_index);
 					StringID string = GetAirportTextCallback(as, _selected_airport_layout, CBID_AIRPORT_LAYOUT_NAME);
 					if (string != STR_UNDEFINED) {
-						SetDParam(0, string);
+						return GetString(stringid, string);
 					} else if (as->layouts.size() > 1) {
-						SetDParam(0, STR_STATION_BUILD_AIRPORT_LAYOUT_NAME);
-						SetDParam(1, _selected_airport_layout + 1);
+						return GetString(stringid, STR_STATION_BUILD_AIRPORT_LAYOUT_NAME, _selected_airport_layout + 1);
 					}
 				}
-				break;
+				return GetString(stringid, STR_EMPTY);
 
-			default: break;
+			default:
+				return this->Window::GetWidgetString(widget, stringid);
 		}
 	}
 

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -380,58 +380,49 @@ public:
 		}
 	}
 
-	void SetStringParameters(WidgetID widget) const override
+	std::string GetWidgetString(WidgetID widget, StringID stringid) const override
 	{
 		switch (widget) {
 			case WID_RV_CAPTION:
-				SetDParam(0, STR_REPLACE_VEHICLE_TRAIN + this->window_number);
 				switch (this->sel_group.base()) {
 					case ALL_GROUP.base():
-						SetDParam(1, STR_GROUP_ALL_TRAINS + this->window_number);
+						return GetString(stringid, STR_REPLACE_VEHICLE_TRAIN + this->window_number, STR_GROUP_ALL_TRAINS + this->window_number);
 						break;
 
 					case DEFAULT_GROUP.base():
-						SetDParam(1, STR_GROUP_DEFAULT_TRAINS + this->window_number);
+						return GetString(stringid, STR_REPLACE_VEHICLE_TRAIN + this->window_number, STR_GROUP_DEFAULT_TRAINS + this->window_number);
 						break;
 
 					default:
-						SetDParam(1, STR_GROUP_NAME);
-						SetDParam(2, sel_group);
-						break;
+						return GetString(stringid, STR_REPLACE_VEHICLE_TRAIN + this->window_number, STR_GROUP_NAME, sel_group);
 				}
 				break;
 
 			case WID_RV_SORT_DROPDOWN:
-				SetDParam(0, std::data(_engine_sort_listing[this->window_number])[this->sort_criteria]);
-				break;
+				return GetString(stringid, std::data(_engine_sort_listing[this->window_number])[this->sort_criteria]);
 
-			case WID_RV_TRAIN_WAGONREMOVE_TOGGLE: {
-				bool remove_wagon;
-				const Group *g = Group::GetIfValid(this->sel_group);
-				if (g != nullptr) {
-					remove_wagon = g->flags.Test(GroupFlag::ReplaceWagonRemoval);
-					SetDParam(0, STR_GROUP_NAME);
-					SetDParam(1, sel_group);
+			case WID_RV_TRAIN_WAGONREMOVE_TOGGLE:
+				if (const Group *g = Group::GetIfValid(this->sel_group); g != nullptr) {
+					bool remove_wagon = g->flags.Test(GroupFlag::ReplaceWagonRemoval);
+					return GetString(stringid, STR_GROUP_NAME, sel_group, remove_wagon ? STR_CONFIG_SETTING_ON : STR_CONFIG_SETTING_OFF);
 				} else {
 					const Company *c = Company::Get(_local_company);
-					remove_wagon = c->settings.renew_keep_length;
-					SetDParam(0, STR_GROUP_DEFAULT_TRAINS + this->window_number);
+					bool remove_wagon = c->settings.renew_keep_length;
+					return GetString(stringid, STR_GROUP_DEFAULT_TRAINS + this->window_number, std::monostate{}, remove_wagon ? STR_CONFIG_SETTING_ON : STR_CONFIG_SETTING_OFF);
 				}
-				SetDParam(2, remove_wagon ? STR_CONFIG_SETTING_ON : STR_CONFIG_SETTING_OFF);
 				break;
-			}
 
 			case WID_RV_TRAIN_ENGINEWAGON_DROPDOWN:
-				SetDParam(0, this->replace_engines ? STR_REPLACE_ENGINES : STR_REPLACE_WAGONS);
-				break;
+				return GetString(stringid, this->replace_engines ? STR_REPLACE_ENGINES : STR_REPLACE_WAGONS);
 
 			case WID_RV_RAIL_TYPE_DROPDOWN:
-				SetDParam(0, this->sel_railtype == INVALID_RAILTYPE ? STR_REPLACE_ALL_RAILTYPE : GetRailTypeInfo(this->sel_railtype)->strings.replace_text);
-				break;
+				return GetString(stringid, this->sel_railtype == INVALID_RAILTYPE ? STR_REPLACE_ALL_RAILTYPE : GetRailTypeInfo(this->sel_railtype)->strings.replace_text);
 
 			case WID_RV_ROAD_TYPE_DROPDOWN:
-				SetDParam(0, this->sel_roadtype == INVALID_ROADTYPE ? STR_REPLACE_ALL_ROADTYPE : GetRoadTypeInfo(this->sel_roadtype)->strings.replace_text);
-				break;
+				return GetString(stringid, this->sel_roadtype == INVALID_ROADTYPE ? STR_REPLACE_ALL_ROADTYPE : GetRoadTypeInfo(this->sel_roadtype)->strings.replace_text);
+
+			default:
+				return this->Window::GetWidgetString(widget, stringid);
 		}
 	}
 

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -504,7 +504,7 @@ struct NewsWindow : Window {
 	{
 		switch (widget) {
 			case WID_N_CAPTION:
-				DrawCaption(r, COLOUR_LIGHT_BLUE, this->owner, TC_FROMSTRING, STR_NEWS_MESSAGE_CAPTION, SA_CENTER, FS_NORMAL);
+				DrawCaption(r, COLOUR_LIGHT_BLUE, this->owner, TC_FROMSTRING, GetString(STR_NEWS_MESSAGE_CAPTION), SA_CENTER, FS_NORMAL);
 				break;
 
 			case WID_N_PANEL:

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -499,6 +499,13 @@ bool Window::SetFocusedWidget(WidgetID widget_index)
 	return true;
 }
 
+std::string Window::GetWidgetString([[maybe_unused]] WidgetID widget, StringID stringid) const
+{
+	if (stringid == STR_NULL) return {};
+	this->SetStringParameters(widget);
+	return GetString(stringid);
+}
+
 /**
  * Called when window gains focus
  */

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -131,7 +131,7 @@ inline void DrawFrameRect(const Rect &r, Colours colour, FrameFlags flags)
 	DrawFrameRect(r.left, r.top, r.right, r.bottom, colour, flags);
 }
 
-void DrawCaption(const Rect &r, Colours colour, Owner owner, TextColour text_colour, StringID str, StringAlignment align, FontSize fs);
+void DrawCaption(const Rect &r, Colours colour, Owner owner, TextColour text_colour, std::string_view str, StringAlignment align, FontSize fs);
 
 /* window.cpp */
 using WindowList = std::list<Window *>;
@@ -623,6 +623,16 @@ public:
 	 * @param widget  Widget number.
 	 */
 	virtual void SetStringParameters([[maybe_unused]] WidgetID widget) const {}
+
+	/**
+	 * Get the raw string for a widget.
+	 * Calls to this function are also made during initialization to measure the size (that is as part of #InitNested()), during drawing,
+	 * and while re-initializing the window. Only for widgets that render text initializing is requested.
+	 * @param widget Widget number.
+	 * @param stringid StringID assigned to widget.
+	 * @returns raw string to display.
+	 */
+	virtual std::string GetWidgetString([[maybe_unused]] WidgetID widget, StringID stringid) const;
 
 	/**
 	 * The window has gained focus.


### PR DESCRIPTION
## Motivation / Problem

The global string parameter array.


## Description

Introduce a part of #13285, specifically the infrastructure to replace `SetStringParameters` with `GetWidgetString`.

Mostly copied from the previously mentioned PR, but to not have to migrate everything in one go `GetWidgetString` currently calls `SetStringParameters`. That call is to be removed once the migration has completed.

This PR has a commit to migrate the files starting with an 'a' to `GetWidgetString` to prove the infrastructure is completed.


## Limitations

It leaves an intermediate state where both methods will be used, but once migrations are complete `SetStringParameters` should be completely removed from the codebase.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
