### PR TITLE
Codefix: std::optional<const std::string> is weird

### DIFF
--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -18,7 +18,7 @@
 
 #include "../safeguards.h"
 
-void ScriptConfig::Change(std::optional<const std::string> name, int version, bool force_exact_match)
+void ScriptConfig::Change(std::optional<std::string> name, int version, bool force_exact_match)
 {
 	if (name.has_value()) {
 		this->name = std::move(name.value());

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -78,7 +78,7 @@ public:
 	 * @param force_exact_match If true try to find the exact same version
 	 *   as specified. If false any compatible version is ok.
 	 */
-	void Change(std::optional<const std::string> name, int version = -1, bool force_exact_match = false);
+	void Change(std::optional<std::string> name, int version = -1, bool force_exact_match = false);
 
 	/**
 	 * Get the ScriptInfo linked to this ScriptConfig.


### PR DESCRIPTION
## Motivation / Problem

`std::optional<const std::string>` is weird; why is modifying the string copy not allowed?
Also MSVC complains about `std::move`-ing the string out.


## Description

Remove the `const`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
