### PR TITLE
Fix #13725: Use proper query strings for changing timetable values

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4792,17 +4792,18 @@ STR_TIMETABLE_STATUS_START_IN_SECONDS                           :{BLACK}This tim
 
 STR_TIMETABLE_START                                             :{BLACK}Start Timetable
 STR_TIMETABLE_START_TOOLTIP                                     :{BLACK}Select when this timetable starts. Ctrl+Click to evenly distribute the start of all vehicles sharing this order based on their relative order, if the order is completely timetabled
-
 STR_TIMETABLE_START_SECONDS_QUERY                               :Seconds until timetable starts
 
 STR_TIMETABLE_CHANGE_TIME                                       :{BLACK}Change Time
 STR_TIMETABLE_WAIT_TIME_TOOLTIP                                 :{BLACK}Change the amount of time that the highlighted order should take. Ctrl+Click to set the time for all orders
+STR_TIMETABLE_CHANGE_TIME_QUERY                                 :Change time
 
 STR_TIMETABLE_CLEAR_TIME                                        :{BLACK}Clear Time
 STR_TIMETABLE_CLEAR_TIME_TOOLTIP                                :{BLACK}Clear the amount of time for the highlighted order. Ctrl+Click to clear the time for all orders
 
 STR_TIMETABLE_CHANGE_SPEED                                      :{BLACK}Change Speed Limit
 STR_TIMETABLE_CHANGE_SPEED_TOOLTIP                              :{BLACK}Change the maximum travel speed of the highlighted order. Ctrl+Click to set the speed for all orders
+STR_TIMETABLE_CHANGE_SPEED_QUERY                                :Change speed limit
 
 STR_TIMETABLE_CLEAR_SPEED                                       :{BLACK}Clear Speed Limit
 STR_TIMETABLE_CLEAR_SPEED_TOOLTIP                               :{BLACK}Clear the maximum travel speed of the highlighted order. Ctrl+Click to clear the speed for all orders

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -685,7 +685,7 @@ struct TimetableWindow : Window {
 				}
 
 				this->change_timetable_all = _ctrl_pressed && (order != nullptr);
-				ShowQueryString(current, STR_TIMETABLE_CHANGE_TIME, 31, this, CS_NUMERAL, QSF_ACCEPT_UNCHANGED);
+				ShowQueryString(current, STR_TIMETABLE_CHANGE_TIME_QUERY, 31, this, CS_NUMERAL, QSF_ACCEPT_UNCHANGED);
 				break;
 			}
 
@@ -705,7 +705,7 @@ struct TimetableWindow : Window {
 				}
 
 				this->change_timetable_all = _ctrl_pressed && (order != nullptr);
-				ShowQueryString(current, STR_TIMETABLE_CHANGE_SPEED, 31, this, CS_NUMERAL, QSF_NONE);
+				ShowQueryString(current, STR_TIMETABLE_CHANGE_SPEED_QUERY, 31, this, CS_NUMERAL, QSF_NONE);
 				break;
 			}
 


### PR DESCRIPTION
## Motivation / Problem

Per #13725, the query window captions for changing timetable values are the wrong colour (black instead of white). This is because they reuse the strings for the buttons, instead of providing a query string.

## Description

Create new query strings instead of reusing the button strings.

Closes #13725.

## Limitations



## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
