### PR TITLE
Fix #13729, f8b1e30: Incorrect conversion of EngineFlags to EngineFlag

### DIFF
--- a/src/engine_type.h
+++ b/src/engine_type.h
@@ -191,8 +191,8 @@ struct EngineInfo {
  * Engine.flags is a bitmask, with the following values.
  */
 enum class EngineFlag : uint8_t {
-	Available        = 1, ///< This vehicle is available to everyone.
-	ExclusivePreview = 2, ///< This vehicle is in the exclusive preview stage, either being used or being offered to a company.
+	Available        = 0, ///< This vehicle is available to everyone.
+	ExclusivePreview = 1, ///< This vehicle is in the exclusive preview stage, either being used or being offered to a company.
 };
 using EngineFlags = EnumBitSet<EngineFlag, uint8_t>;
 

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -82,7 +82,7 @@ struct ENGNChunkHandler : ChunkHandler {
 			if (IsSavegameVersionBefore(SLV_179)) {
 				/* preview_company_rank was replaced with preview_company and preview_asked.
 				 * Just cancel any previews. */
-				e->flags.Reset(EngineFlag{4}); // ENGINE_OFFER_WINDOW_OPEN
+				e->flags.Reset(EngineFlag{2}); // ENGINE_OFFER_WINDOW_OPEN
 				e->preview_company = CompanyID::Invalid();
 				e->preview_asked.Set();
 			}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
`EngineFlags` were used as flags (with `|` and `&`) so their values were `1<<0` and `1<<1`, but the conversion in https://github.com/OpenTTD/OpenTTD/commit/f8b1e3033f5113b26ca0109f9d49675f16374863 made them become `1<<1` and `1<<2`.

There was also a mistake when translating a `&= ~4` (`&= ~(1<<2)`), it became `1<<4`.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Fix the conversion errors.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
