### PR TITLE
Fix #13760: Store encoded error message inside CommandCost.

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -235,7 +235,7 @@ std::tuple<bool, bool, bool> CommandHelperBase::InternalPostBefore(Commands cmd,
  * @param err_message Message prefix to show on error.
  * @param my_cmd Is the command from this client?
  */
-void CommandHelperBase::InternalPostResult(const CommandCost &res, TileIndex tile, bool estimate_only, bool only_sending, StringID err_message, bool my_cmd)
+void CommandHelperBase::InternalPostResult(CommandCost &res, TileIndex tile, bool estimate_only, bool only_sending, StringID err_message, bool my_cmd)
 {
 	int x = TileX(tile) * TILE_SIZE;
 	int y = TileY(tile) * TILE_SIZE;
@@ -406,8 +406,6 @@ void CommandCost::AddCost(const CommandCost &ret)
 		this->success = false;
 	}
 }
-
-/* static */ EncodedString CommandCost::encoded_message;
 
 /**
  * Return an error status, with string and parameter.

--- a/src/command_func.h
+++ b/src/command_func.h
@@ -87,7 +87,7 @@ protected:
 	static void InternalDoBefore(bool top_level, bool test);
 	static void InternalDoAfter(CommandCost &res, DoCommandFlags flags, bool top_level, bool test);
 	static std::tuple<bool, bool, bool> InternalPostBefore(Commands cmd, CommandFlags flags, TileIndex tile, StringID err_message, bool network_command);
-	static void InternalPostResult(const CommandCost &res, TileIndex tile, bool estimate_only, bool only_sending, StringID err_message, bool my_cmd);
+	static void InternalPostResult(CommandCost &res, TileIndex tile, bool estimate_only, bool only_sending, StringID err_message, bool my_cmd);
 	static bool InternalExecutePrepTest(CommandFlags cmd_flags, TileIndex tile, Backup<CompanyID> &cur_company);
 	static std::tuple<bool, bool, bool> InternalExecuteValidateTestAndPrepExec(CommandCost &res, CommandFlags cmd_flags, bool estimate_only, bool network_command, Backup<CompanyID> &cur_company);
 	static CommandCost InternalExecuteProcessResult(Commands cmd, CommandFlags cmd_flags, const CommandCost &res_test, const CommandCost &res_exec, Money extra_cash, TileIndex tile, Backup<CompanyID> &cur_company);

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -28,8 +28,7 @@ class CommandCost {
 	bool success;                               ///< Whether the command went fine up to this moment
 	Owner owner = CompanyID::Invalid(); ///< Originator owner of error.
 	StringID extra_message = INVALID_STRING_ID; ///< Additional warning message for when success is unset
-
-	static EncodedString encoded_message; ///< Encoded error message, used if the error message includes parameters.
+	EncodedString encoded_message{}; ///< Encoded error message, used if the error message includes parameters.
 
 public:
 	/**
@@ -70,18 +69,18 @@ public:
 	 * @note Do not set an encoded message if the error is not for the local player, as it will never be seen.
 	 * @param message EncodedString message to set.
 	 */
-	static void SetEncodedMessage(EncodedString &&message)
+	void SetEncodedMessage(EncodedString &&message)
 	{
-		CommandCost::encoded_message = std::move(message);
+		this->encoded_message = std::move(message);
 	}
 
 	/**
 	 * Get the last encoded error message.
 	 * @returns Reference to the encoded message.
 	 */
-	static EncodedString &GetEncodedMessage()
+	EncodedString &GetEncodedMessage()
 	{
-		return CommandCost::encoded_message;
+		return this->encoded_message;
 	}
 
 	/**

--- a/src/error.h
+++ b/src/error.h
@@ -50,7 +50,7 @@ typedef std::list<ErrorMessageData> ErrorList;
 void ScheduleErrorMessage(ErrorList &datas);
 void ScheduleErrorMessage(const ErrorMessageData &data);
 
-void ShowErrorMessage(EncodedString &&summary_msg, int x, int y, const CommandCost &cc);
+void ShowErrorMessage(EncodedString &&summary_msg, int x, int y, CommandCost &cc);
 void ShowErrorMessage(EncodedString &&summary_msg, EncodedString &&detailed_msg, WarningLevel wl, int x = 0, int y = 0, EncodedString &&extra_msg = {}, CompanyID company = CompanyID::Invalid());
 bool HideActiveErrorMessage();
 

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -287,7 +287,7 @@ void UnshowCriticalError()
  * @param y            World Y position (TileVirtY) of the error location. Set both x and y to 0 to just center the message when there is no related error tile.
  * @param cc           CommandCost containing the optional detailed and extra error messages shown in the second and third lines (can be empty).
  */
-void ShowErrorMessage(EncodedString &&summary_msg, int x, int y, const CommandCost &cc)
+void ShowErrorMessage(EncodedString &&summary_msg, int x, int y, CommandCost &cc)
 {
 	EncodedString error = std::move(cc.GetEncodedMessage());
 	if (error.empty()) error = GetEncodedStringIfValid(cc.GetErrorMessage());


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Encoded error message was previously static to avoid memmory allocation, however this causes complications.

If the error message is never shown, then the encoded message is not reset, and will be used on the next unrelated error message that is shown.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Make `encoded_message` a non-static member of `CommandCost` instead. This means the error always has the correct life-time and cannot get mixed up with other errors.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This unfortunately increases the size of `CommandCost` from 24 to 56 bytes. As `encoded_message` is optional, maybe using `std::unique_ptr<EncodedString>` would make sense. Doing that would then mean a regular `CommandCost` is only 32 bytes, with separate storage if it has an encoded error.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
