### PR TITLE
Fix: [Script] Getting expiry date could cause out of bounds access

### DIFF
--- a/src/script/api/script_subsidy.cpp
+++ b/src/script/api/script_subsidy.cpp
@@ -60,8 +60,8 @@
 	TimerGameEconomy::YearMonthDay ymd = TimerGameEconomy::ConvertDateToYMD(TimerGameEconomy::date);
 	ymd.day = 1;
 	auto m = ymd.month + ::Subsidy::Get(subsidy_id)->remaining;
-	ymd.month = (m - 1) % 12 + 1;
-	ymd.year += TimerGameEconomy::Year{(m - 1) / 12};
+	ymd.month = m % 12;
+	ymd.year += TimerGameEconomy::Year{m / 12};
 
 	return (ScriptDate::Date)TimerGameEconomy::ConvertYMDToDate(ymd.year, ymd.month, ymd.day).base();
 }


### PR DESCRIPTION
## Motivation / Problem

Months are 0..11. `ScriptSubsidy::GetExpireDate()` thought it was 1..12, thus passing 12 into `TimerGameEconomy::ConvertYMDToDate` which dereferences `_accum_days_for_month` using month.


## Description

Undo the off-by-one.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
