### PR TITLE
Fix: company livery window's instance variables were not set

### DIFF
--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -594,13 +594,13 @@ public:
 /** Company livery colour scheme window. */
 struct SelectCompanyLiveryWindow : public Window {
 private:
-	uint32_t sel;
-	LiveryClass livery_class;
-	Dimension square;
-	uint rows;
-	uint line_height;
-	GUIGroupList groups;
-	Scrollbar *vscroll;
+	uint32_t sel = 0;
+	LiveryClass livery_class{};
+	Dimension square{};
+	uint rows = 0;
+	uint line_height = 0;
+	GUIGroupList groups{};
+	Scrollbar *vscroll = nullptr;
 
 	void ShowColourDropDownMenu(uint32_t widget)
 	{


### PR DESCRIPTION
## Motivation / Problem

Instance variables of `SelectCompanyLiveryWindow` were not initialised.


## Description

Actually initialise them.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
