### PR TITLE
Codechange: remove unused INVALID_TRACK_BIT

### DIFF
--- a/src/rail_map.h
+++ b/src/rail_map.h
@@ -209,7 +209,6 @@ inline TrackBits GetRailReservationTrackBits(Tile t)
 inline void SetTrackReservation(Tile t, TrackBits b)
 {
 	assert(IsPlainRailTile(t));
-	assert(b != INVALID_TRACK_BIT);
 	assert(!TracksOverlap(b));
 	Track track = RemoveFirstTrack(&b);
 	SB(t.m2(), 8, 3, track == INVALID_TRACK ? 0 : track + 1);

--- a/src/script/api/script_rail.hpp
+++ b/src/script/api/script_rail.hpp
@@ -60,7 +60,7 @@ public:
 		RAILTRACK_SW_SE   = ::TRACK_BIT_LOWER,   ///< Track in the lower corner of the tile (south).
 		RAILTRACK_NW_SW   = ::TRACK_BIT_LEFT,    ///< Track in the left corner of the tile (west).
 		RAILTRACK_NE_SE   = ::TRACK_BIT_RIGHT,   ///< Track in the right corner of the tile (east).
-		RAILTRACK_INVALID = ::INVALID_TRACK_BIT, ///< Flag for an invalid track.
+		RAILTRACK_INVALID = 0xFF, ///< Flag for an invalid track.
 	};
 
 	/**

--- a/src/track_func.h
+++ b/src/track_func.h
@@ -120,7 +120,7 @@ inline TrackdirBits TrackdirToTrackdirBits(Trackdir trackdir)
  * This function searches for the first bit in the TrackBits,
  * remove this bit from the parameter and returns the found
  * bit as Track value. It returns INVALID_TRACK if the
- * parameter was TRACK_BIT_NONE or INVALID_TRACK_BIT. This
+ * parameter was TRACK_BIT_NONE. This
  * is basically used in while-loops to get up to 6 possible
  * tracks on a tile until the parameter becomes TRACK_BIT_NONE.
  *
@@ -130,7 +130,7 @@ inline TrackdirBits TrackdirToTrackdirBits(Trackdir trackdir)
  */
 inline Track RemoveFirstTrack(TrackBits *tracks)
 {
-	if (*tracks != TRACK_BIT_NONE && *tracks != INVALID_TRACK_BIT) {
+	if (*tracks != TRACK_BIT_NONE) {
 		assert((*tracks & ~TRACK_BIT_MASK) == TRACK_BIT_NONE);
 		Track first = (Track)FindFirstBit(*tracks);
 		ClrBit(*tracks, first);
@@ -168,7 +168,7 @@ inline Trackdir RemoveFirstTrackdir(TrackdirBits *trackdirs)
  * Returns first Track from TrackBits or INVALID_TRACK
  *
  * This function returns the first Track found in the TrackBits value as Track-value.
- * It returns INVALID_TRACK if the parameter is TRACK_BIT_NONE or INVALID_TRACK_BIT.
+ * It returns INVALID_TRACK if the parameter is TRACK_BIT_NONE.
  *
  * @param tracks The TrackBits value
  * @return The first Track found or INVALID_TRACK
@@ -176,7 +176,7 @@ inline Trackdir RemoveFirstTrackdir(TrackdirBits *trackdirs)
  */
 inline Track FindFirstTrack(TrackBits tracks)
 {
-	return (tracks != TRACK_BIT_NONE && tracks != INVALID_TRACK_BIT) ? (Track)FindFirstBit(tracks) : INVALID_TRACK;
+	return (tracks != TRACK_BIT_NONE) ? (Track)FindFirstBit(tracks) : INVALID_TRACK;
 }
 
 /**
@@ -184,16 +184,16 @@ inline Track FindFirstTrack(TrackBits tracks)
  *
  * This function converts a TrackBits value to a Track value. As it
  * is not possible to convert two or more tracks to one track the
- * parameter must contain only one track or be the INVALID_TRACK_BIT value.
+ * parameter must contain only one track.
  *
  * @param tracks The TrackBits value to convert
- * @return The Track from the value or INVALID_TRACK
- * @pre tracks must contains only one Track or be INVALID_TRACK_BIT
+ * @return The Track from the value
+ * @pre tracks must contains only one Track
  */
 inline Track TrackBitsToTrack(TrackBits tracks)
 {
-	assert(tracks == INVALID_TRACK_BIT || (tracks != TRACK_BIT_NONE && KillFirstBit(tracks & TRACK_BIT_MASK) == TRACK_BIT_NONE));
-	return tracks != INVALID_TRACK_BIT ? (Track)FindFirstBit(tracks & TRACK_BIT_MASK) : INVALID_TRACK;
+	assert(tracks != TRACK_BIT_NONE && KillFirstBit(tracks & TRACK_BIT_MASK) == TRACK_BIT_NONE);
+	return static_cast<Track>(FindFirstBit(tracks & TRACK_BIT_MASK));
 }
 
 /**

--- a/src/track_type.h
+++ b/src/track_type.h
@@ -51,7 +51,6 @@ enum TrackBits : uint8_t {
 	TRACK_BIT_MASK    = 0x3FU,                                              ///< Bitmask for the first 6 bits
 	TRACK_BIT_WORMHOLE = 0x40U,                                             ///< Bitflag for a wormhole (used for tunnels)
 	TRACK_BIT_DEPOT   = 0x80U,                                              ///< Bitflag for a depot
-	INVALID_TRACK_BIT = 0xFF,                                               ///< Flag for an invalid trackbits value
 };
 DECLARE_ENUM_AS_BIT_SET(TrackBits)
 


### PR DESCRIPTION
## Motivation / Problem

We never actually set/use `INVALID_TRACK_BIT`, yet a bit of code assumes it is used.


## Description

Remove it and the associated logic.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
