### PR TITLE
Codefix: TrackdirCrossesTrackdirs does not work for turning RV Trackdirs

### DIFF
--- a/src/track_func.h
+++ b/src/track_func.h
@@ -605,7 +605,7 @@ inline TrackdirBits TrackdirReachesTrackdirs(Trackdir trackdir)
  */
 inline TrackdirBits TrackdirCrossesTrackdirs(Trackdir trackdir)
 {
-	assert(IsValidTrackdirForRoadVehicle(trackdir));
+	assert(IsValidTrackdir(trackdir));
 	extern const TrackdirBits _track_crosses_trackdirs[TRACK_END];
 	return _track_crosses_trackdirs[TrackdirToTrack(trackdir)];
 }


### PR DESCRIPTION
## Motivation / Problem

`TrackdirCrossesTrackdirs` checks using `IsValidTrackdirForRoadVehicle`, but then converts the Trackdir into a Track. For the road vehicle reversing track directions, there is no track. These would yield a Track >= TRACK_END, thus reading beyond the bounds of the array.


## Description

Change the assert to `IsValidTrackdir`.


## Limitations

I'm not 100% sure the code is never called with a RV reversing track direction, but the best way to figure that out is by changing the assert. If it triggers, then other changes are required for this code. However, then we would know and now we don't know that it actually overflows the array.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
