### PR TITLE
Codefix: std::move string leaves the old one in an undefined state

### DIFF
--- a/src/ini_load.cpp
+++ b/src/ini_load.cpp
@@ -226,11 +226,13 @@ void IniLoadFile::LoadFromDisk(const std::string &filename, Subdirectory subdir)
 			s++; // skip [
 			group = &this->CreateGroup(std::string_view(s, e - s));
 			group->comment = std::move(comment);
+			comment.clear(); // std::move leaves comment in a "valid but unspecified state" according to the specification.
 		} else if (group != nullptr) {
 			if (group->type == IGT_SEQUENCE) {
 				/* A sequence group, use the line as item name without further interpretation. */
 				IniItem &item = group->CreateItem(std::string_view(buffer, e - buffer));
 				item.comment = std::move(comment);
+				comment.clear(); // std::move leaves comment in a "valid but unspecified state" according to the specification.
 				continue;
 			}
 			char *t;
@@ -246,6 +248,7 @@ void IniLoadFile::LoadFromDisk(const std::string &filename, Subdirectory subdir)
 			/* it's an item in an existing group */
 			IniItem &item = group->CreateItem(std::string_view(s, t - s));
 			item.comment = std::move(comment);
+			comment.clear(); // std::move leaves comment in a "valid but unspecified state" according to the specification.
 
 			/* find start of parameter */
 			while (*t == '=' || *t == ' ' || *t == '\t') t++;

--- a/src/script/script_info_dummy.cpp
+++ b/src/script/script_info_dummy.cpp
@@ -66,6 +66,7 @@ static std::vector<std::string> EscapeQuotesAndSlashesAndSplitOnNewLines(const s
 	for (auto c : message) {
 		if (c == '\n') {
 			messages.emplace_back(std::move(safe_message));
+			safe_message.clear(); // std::move leaves safe_message in a "valid but unspecified state" according to the specification.
 			continue;
 		}
 


### PR DESCRIPTION
## Motivation / Problem

`std::move` leaves the object that has been moved from in a "valid but unspecified state". That means the moved from `std::string` doesn't need to be empty.


## Description

Bring the moved from `std::strings` into a known state, i.e. empty state.


## Limitations

Seems like the "valid but unspecified state" is an empty string for most common compilers/standard libraries, so it's sort-of busy work.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
