### PR TITLE
Codefix: initialise a few uninitialised variables

### DIFF
--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -251,7 +251,7 @@ void TextfileWindow::FindHyperlinksInMarkdown(Line &line, size_t line_index)
 	while (matcher != std::sregex_iterator()) {
 		std::smatch match = *matcher;
 
-		Hyperlink link;
+		Hyperlink link{};
 		link.line = line_index;
 		link.destination = match[2].str();
 		this->links.push_back(link);

--- a/src/textfile_gui.h
+++ b/src/textfile_gui.h
@@ -54,10 +54,10 @@ protected:
 	};
 
 	struct Hyperlink {
-		size_t line;             ///< Which line the link is on.
-		size_t begin;            ///< Character position on line the link begins.
-		size_t end;              ///< Character position on line the link end.
-		std::string destination; ///< Destination for the link.
+		size_t line = 0; ///< Which line the link is on.
+		size_t begin = 0; ///< Character position on line the link begins.
+		size_t end = 0; ///< Character position on line the link end.
+		std::string destination{}; ///< Destination for the link.
 	};
 
 	struct HistoryEntry {

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -857,7 +857,7 @@ static void AddAcceptedCargo_Town(TileIndex tile, CargoArray &acceptance, CargoT
  */
 CargoArray GetAcceptedCargoOfHouse(const HouseSpec *hs)
 {
-	CargoTypes always_accepted;
+	CargoTypes always_accepted{};
 	CargoArray acceptance{};
 	AddAcceptedCargoOfHouse(INVALID_TILE, hs->Index(), hs, nullptr, acceptance, always_accepted);
 	return acceptance;


### PR DESCRIPTION
## Motivation / Problem

Coverity complaining about uninitialised variables with high impact.


## Description

For Hyperlink `begin` and `end` would not be initialised.
For town_cmd `always_accepted` was not initialised.


## Limitations

The `always_accepted` is not actually used later on, so currently it does not matter. But I guess it's better to have code that doesn't trigger static code analysis.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
