### PR TITLE
Codechange: initialise instance members

### DIFF
--- a/src/3rdparty/icu/scriptrun.h
+++ b/src/3rdparty/icu/scriptrun.h
@@ -24,15 +24,15 @@ U_NAMESPACE_BEGIN
 
 struct ScriptRecord
 {
-    UChar32 startChar;
-    UChar32 endChar;
-    UScriptCode scriptCode;
+    UChar32 startChar = 0;
+    UChar32 endChar = 0;
+    UScriptCode scriptCode{};
 };
 
 struct ParenStackEntry
 {
-    int32_t pairIndex;
-    UScriptCode scriptCode;
+    int32_t pairIndex = 0;
+    UScriptCode scriptCode{};
 };
 
 class ScriptRun : public UObject {
@@ -75,16 +75,16 @@ private:
 
     static UBool sameScript(int32_t scriptOne, int32_t scriptTwo);
 
-    int32_t charStart;
-    int32_t charLimit;
-    const char16_t *charArray;
+    int32_t charStart = 0;
+    int32_t charLimit = 0;
+    const char16_t *charArray = nullptr;
 
-    int32_t scriptStart;
-    int32_t scriptEnd;
-    UScriptCode scriptCode;
+    int32_t scriptStart = 0;
+    int32_t scriptEnd = 0;
+    UScriptCode scriptCode{};
 
-    ParenStackEntry parenStack[128];
-    int32_t parenSP;
+    std::array<ParenStackEntry, 128> parenStack{};
+    int32_t parenSP = 0;
 
     static int8_t highBit(int32_t value);
     static int32_t getPairIndex(UChar32 ch);

--- a/src/3rdparty/squirrel/squirrel/sqobject.h
+++ b/src/3rdparty/squirrel/squirrel/sqobject.h
@@ -56,11 +56,11 @@ enum SQMetaMethod{
 
 struct SQRefCounted
 {
-	SQRefCounted() { _uiRef = 0; _weakref = nullptr; }
+	SQRefCounted() {}
 	virtual ~SQRefCounted();
 	SQWeakRef *GetWeakRef(SQObjectType type);
-	SQUnsignedInteger _uiRef;
-	struct SQWeakRef *_weakref;
+	SQUnsignedInteger _uiRef = 0;
+	struct SQWeakRef *_weakref = nullptr;
 	virtual void Release()=0;
 
 	/* Placement new/delete to prevent memory leaks if constructor throws an exception. */
@@ -79,7 +79,7 @@ struct SQRefCounted
 	inline void operator delete(void *) { NOT_REACHED(); }
 
 private:
-	size_t size;
+	size_t size = 0;
 };
 
 struct SQWeakRef : SQRefCounted

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -294,10 +294,10 @@ public:
 	};
 
 protected:
-	uint count;                   ///< Cache for the number of cargo entities.
-	uint64_t cargo_periods_in_transit; ///< Cache for the sum of number of cargo aging periods in transit of each entity; comparable to man-hours.
+	uint count = 0; ///< Cache for the number of cargo entities.
+	uint64_t cargo_periods_in_transit = 0; ///< Cache for the sum of number of cargo aging periods in transit of each entity; comparable to man-hours.
 
-	Tcont packets;              ///< The cargo packets in this list.
+	Tcont packets{}; ///< The cargo packets in this list.
 
 	void AddToCache(const CargoPacket *cp);
 

--- a/src/effectvehicle_base.h
+++ b/src/effectvehicle_base.h
@@ -22,8 +22,8 @@
  *  - bubbles (industry)
  */
 struct EffectVehicle final : public SpecializedVehicle<EffectVehicle, VEH_EFFECT> {
-	uint16_t animation_state;  ///< State primarily used to change the graphics/behaviour.
-	uint8_t animation_substate; ///< Sub state to time the change of the graphics/behaviour.
+	uint16_t animation_state = 0; ///< State primarily used to change the graphics/behaviour.
+	uint8_t animation_substate = 0; ///< Sub state to time the change of the graphics/behaviour.
 
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
 	EffectVehicle() : SpecializedVehicleBase() {}

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -196,11 +196,11 @@ struct Engine : EnginePool::PoolItem<&_engine_pool> {
 };
 
 struct EngineIDMapping {
-	uint32_t grfid; ///< The GRF ID of the file the entity belongs to
-	uint16_t internal_id; ///< The internal ID within the GRF file
-	VehicleType type; ///< The engine type
-	uint8_t substitute_id; ///< The (original) entity ID to use if this GRF is not available (currently not used)
-	EngineID engine;
+	uint32_t grfid = 0; ///< The GRF ID of the file the entity belongs to
+	uint16_t internal_id = 0; ///< The internal ID within the GRF file
+	VehicleType type{}; ///< The engine type
+	uint8_t substitute_id = 0; ///< The (original) entity ID to use if this GRF is not available (currently not used)
+	EngineID engine{};
 
 	static inline uint64_t Key(uint32_t grfid, uint16_t internal_id) { return static_cast<uint64_t>(grfid) << 32 | internal_id; }
 

--- a/src/fios.h
+++ b/src/fios.h
@@ -31,25 +31,24 @@ using CompanyPropertiesMap = std::map<uint, std::unique_ptr<CompanyProperties>>;
  * Container for loading in mode SL_LOAD_CHECK.
  */
 struct LoadCheckData {
-	bool checkable;     ///< True if the savegame could be checked by SL_LOAD_CHECK. (Old savegames are not checkable.)
-	StringID error;     ///< Error message from loading. INVALID_STRING_ID if no error.
-	std::string error_msg; ///< Data to pass to string parameters when displaying #error.
+	bool checkable = false; ///< True if the savegame could be checked by SL_LOAD_CHECK. (Old savegames are not checkable.)
+	StringID error{}; ///< Error message from loading. INVALID_STRING_ID if no error.
+	std::string error_msg{}; ///< Data to pass to string parameters when displaying #error.
 
-	uint32_t map_size_x, map_size_y;
-	TimerGameCalendar::Date current_date;
+	uint32_t map_size_x = 0;
+	uint32_t map_size_y = 0;
+	TimerGameCalendar::Date current_date{};
 
-	GameSettings settings;
+	GameSettings settings{};
 
-	CompanyPropertiesMap companies;               ///< Company information.
+	CompanyPropertiesMap companies{}; ///< Company information.
 
-	GRFConfigList grfconfig;                      ///< NewGrf configuration from save.
-	GRFListCompatibility grf_compatibility;       ///< Summary state of NewGrfs, whether missing files or only compatible found.
+	GRFConfigList grfconfig{}; ///< NewGrf configuration from save.
+	GRFListCompatibility grf_compatibility = GLC_NOT_FOUND; ///< Summary state of NewGrfs, whether missing files or only compatible found.
 
-	Gamelog gamelog; ///< Gamelog actions
+	Gamelog gamelog{}; ///< Gamelog actions
 
-	LoadCheckData() : grf_compatibility(GLC_NOT_FOUND)
-	{
-	}
+	LoadCheckData() {}
 
 	/**
 	 * Check whether loading the game resulted in errors.

--- a/src/fontcache/truetypefontcache.h
+++ b/src/fontcache/truetypefontcache.h
@@ -24,8 +24,8 @@ protected:
 	static constexpr int MAX_GLYPH_DIM = 256;          ///< Maximum glyph dimensions.
 	static constexpr uint MAX_FONT_MIN_REC_SIZE = 20u; ///< Upper limit for the recommended font size in case a font file contains nonsensical values.
 
-	int req_size;  ///< Requested font size.
-	int used_size; ///< Used font size.
+	int req_size = 0; ///< Requested font size.
+	int used_size = 0; ///< Used font size.
 
 	/** Container for information about a glyph. */
 	struct GlyphEntry {

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -52,22 +52,22 @@ namespace {
 		static const TimingMeasurement INVALID_DURATION = UINT64_MAX;
 
 		/** Time spent processing each cycle of the performance element, circular buffer */
-		TimingMeasurement durations[NUM_FRAMERATE_POINTS];
+		std::array<TimingMeasurement, NUM_FRAMERATE_POINTS> durations{};
 		/** Start time of each cycle of the performance element, circular buffer */
-		TimingMeasurement timestamps[NUM_FRAMERATE_POINTS];
+		std::array<TimingMeasurement, NUM_FRAMERATE_POINTS> timestamps{};
 		/** Expected number of cycles per second when the system is running without slowdowns */
-		double expected_rate;
+		double expected_rate = 0;
 		/** Next index to write to in \c durations and \c timestamps */
-		int next_index;
+		int next_index = 0;
 		/** Last index written to in \c durations and \c timestamps */
-		int prev_index;
+		int prev_index = 0;
 		/** Number of data points recorded, clamped to \c NUM_FRAMERATE_POINTS */
-		int num_valid;
+		int num_valid = 0;
 
 		/** Current accumulated duration */
-		TimingMeasurement acc_duration;
+		TimingMeasurement acc_duration{};
 		/** Start time for current accumulation cycle */
-		TimingMeasurement acc_timestamp;
+		TimingMeasurement acc_timestamp{};
 
 		/**
 		 * Initialize a data element with an expected collection rate
@@ -75,7 +75,7 @@ namespace {
 		 * Expected number of cycles per second of the performance element. Use 1 if unknown or not relevant.
 		 * The rate is used for highlighting slow-running elements in the GUI.
 		 */
-		explicit PerformanceData(double expected_rate) : expected_rate(expected_rate), next_index(0), prev_index(0), num_valid(0) { }
+		explicit PerformanceData(double expected_rate) : expected_rate(expected_rate) { }
 
 		/** Collect a complete measurement, given start and ending times for a processing block */
 		void Add(TimingMeasurement start_time, TimingMeasurement end_time)
@@ -793,8 +793,8 @@ struct FrametimeGraphWindow : Window {
 	/** Recalculate the graph scaling factors based on current recorded data */
 	void UpdateScale()
 	{
-		const TimingMeasurement *durations = _pf_data[this->element].durations;
-		const TimingMeasurement *timestamps = _pf_data[this->element].timestamps;
+		const auto &durations = _pf_data[this->element].durations;
+		const auto &timestamps = _pf_data[this->element].timestamps;
 		int num_valid = _pf_data[this->element].num_valid;
 		int point = _pf_data[this->element].prev_index;
 
@@ -855,8 +855,8 @@ struct FrametimeGraphWindow : Window {
 	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget == WID_FGW_GRAPH) {
-			const TimingMeasurement *durations  = _pf_data[this->element].durations;
-			const TimingMeasurement *timestamps = _pf_data[this->element].timestamps;
+			const auto &durations  = _pf_data[this->element].durations;
+			const auto &timestamps = _pf_data[this->element].timestamps;
 			int point = _pf_data[this->element].prev_index;
 
 			const int x_zero = r.right - (int)this->graph_size.width;

--- a/src/gamelog_internal.h
+++ b/src/gamelog_internal.h
@@ -21,10 +21,10 @@
  * at some later point.
  */
 struct GRFPresence {
-	const GRFConfig *gc;  ///< GRFConfig, if known
-	bool was_missing;     ///< Grf was missing during some gameload in the past
+	const GRFConfig *gc = nullptr; ///< GRFConfig, if known
+	bool was_missing = false; ///< Grf was missing during some gameload in the past
 
-	GRFPresence(const GRFConfig *gc) : gc(gc), was_missing(false) {}
+	GRFPresence(const GRFConfig *gc) : gc(gc) {}
 	GRFPresence() = default;
 };
 using GrfIDMapping = std::map<uint32_t, GRFPresence>;
@@ -34,7 +34,7 @@ struct LoggedChange {
 	virtual ~LoggedChange() = default;
 	virtual void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) = 0;
 
-	GamelogChangeType ct;
+	GamelogChangeType ct{};
 };
 
 struct LoggedChangeMode : LoggedChange {
@@ -43,8 +43,8 @@ struct LoggedChangeMode : LoggedChange {
 		LoggedChange(GLCT_MODE), mode(mode), landscape(landscape) {}
 	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
 
-	uint8_t mode;      ///< new game mode - Editor x Game
-	LandscapeType landscape; ///< landscape (temperate, arctic, ...)
+	uint8_t mode = 0; ///< new game mode - Editor x Game
+	LandscapeType landscape{}; ///< landscape (temperate, arctic, ...)
 };
 
 struct LoggedChangeRevision : LoggedChange {
@@ -53,10 +53,10 @@ struct LoggedChangeRevision : LoggedChange {
 		LoggedChange(GLCT_REVISION), text(text), newgrf(newgrf), slver(slver), modified(modified) {}
 	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
 
-	std::string text; ///< revision string, _openttd_revision
-	uint32_t newgrf;  ///< _openttd_newgrf_version
-	uint16_t slver;   ///< _sl_version
-	uint8_t modified;    //< _openttd_revision_modified
+	std::string text{}; ///< revision string, _openttd_revision
+	uint32_t newgrf = 0; ///< _openttd_newgrf_version
+	uint16_t slver = 0; ///< _sl_version
+	uint8_t modified = 0; //< _openttd_revision_modified
 };
 
 struct LoggedChangeOldVersion : LoggedChange {
@@ -65,8 +65,8 @@ struct LoggedChangeOldVersion : LoggedChange {
 		LoggedChange(GLCT_OLDVER), type(type), version(version) {}
 	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
 
-	uint32_t type;    ///< type of savegame, @see SavegameType
-	uint32_t version; ///< major and minor version OR ttdp version
+	uint32_t type = 0; ///< type of savegame, @see SavegameType
+	uint32_t version = 0; ///< major and minor version OR ttdp version
 };
 
 struct LoggedChangeGRFAdd : LoggedChange, GRFIdentifier {
@@ -82,7 +82,7 @@ struct LoggedChangeGRFRemoved : LoggedChange {
 		LoggedChange(GLCT_GRFREM), grfid(grfid) {}
 	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
 
-	uint32_t grfid; ///< ID of removed GRF
+	uint32_t grfid = 0; ///< ID of removed GRF
 };
 
 struct LoggedChangeGRFChanged : LoggedChange, GRFIdentifier {
@@ -98,7 +98,7 @@ struct LoggedChangeGRFParameterChanged : LoggedChange {
 		LoggedChange(GLCT_GRFPARAM), grfid(grfid) {}
 	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
 
-	uint32_t grfid; ///< ID of GRF with changed parameters
+	uint32_t grfid = 0; ///< ID of GRF with changed parameters
 };
 
 struct LoggedChangeGRFMoved : LoggedChange {
@@ -107,8 +107,8 @@ struct LoggedChangeGRFMoved : LoggedChange {
 		LoggedChange(GLCT_GRFMOVE), grfid(grfid), offset(offset) {}
 	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
 
-	uint32_t grfid; ///< ID of moved GRF
-	int32_t offset; ///< offset, positive = move down
+	uint32_t grfid = 0; ///< ID of moved GRF
+	int32_t offset = 0; ///< offset, positive = move down
 };
 
 struct LoggedChangeSettingChanged : LoggedChange {
@@ -117,9 +117,9 @@ struct LoggedChangeSettingChanged : LoggedChange {
 		LoggedChange(GLCT_SETTING), name(name), oldval(oldval), newval(newval) {}
 	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
 
-	std::string name; ///< name of the setting
-	int32_t oldval;   ///< old value
-	int32_t newval;   ///< new value
+	std::string name{}; ///< name of the setting
+	int32_t oldval = 0; ///< old value
+	int32_t newval = 0; ///< new value
 };
 
 struct LoggedChangeGRFBug : LoggedChange {
@@ -128,9 +128,9 @@ struct LoggedChangeGRFBug : LoggedChange {
 		LoggedChange(GLCT_GRFBUG), data(data), grfid(grfid), bug(bug) {}
 	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
 
-	uint64_t data;  ///< additional data
-	uint32_t grfid; ///< ID of problematic GRF
-	GRFBug bug; ///< type of bug, @see enum GRFBugs
+	uint64_t data = 0; ///< additional data
+	uint32_t grfid = 0; ///< ID of problematic GRF
+	GRFBug bug{}; ///< type of bug, @see enum GRFBugs
 };
 
 struct LoggedChangeEmergencySave : LoggedChange {
@@ -142,8 +142,8 @@ struct LoggedChangeEmergencySave : LoggedChange {
 /** Contains information about one logged action that caused at least one logged change */
 struct LoggedAction {
 	std::vector<std::unique_ptr<LoggedChange>> change; ///< Logged changes in this action
-	GamelogActionType at; ///< Type of action
-	uint64_t tick;        ///< Tick when it happened
+	GamelogActionType at{}; ///< Type of action
+	uint64_t tick = 0; ///< Tick when it happened
 };
 
 struct GamelogInternalData {

--- a/src/linkgraph/linkgraph_gui.h
+++ b/src/linkgraph/linkgraph_gui.h
@@ -21,17 +21,17 @@
  * Only the cargo type of the most saturated linkgraph is taken into account.
  */
 struct LinkProperties {
-	LinkProperties() : cargo(INVALID_CARGO), capacity(0), usage(0), planned(0), shared(false) {}
+	LinkProperties() {}
 
 	/** Return the usage of the link to display. */
 	uint Usage() const { return std::max(this->usage, this->planned); }
 
-	CargoType cargo; ///< Cargo type of the link.
-	uint capacity; ///< Capacity of the link.
-	uint usage;    ///< Actual usage of the link.
-	uint planned;  ///< Planned usage of the link.
-	uint32_t time;   ///< Travel time of the link.
-	bool shared;   ///< If this is a shared link to be drawn dashed.
+	CargoType cargo = INVALID_CARGO; ///< Cargo type of the link.
+	uint capacity = 0; ///< Capacity of the link.
+	uint usage = 0; ///< Actual usage of the link.
+	uint planned = 0; ///< Planned usage of the link.
+	uint32_t time = 0; ///< Travel time of the link.
+	bool shared = false; ///< If this is a shared link to be drawn dashed.
 };
 
 /**

--- a/src/linkgraph/mcf.cpp
+++ b/src/linkgraph/mcf.cpp
@@ -52,7 +52,7 @@ public:
  * can only decrease or stay the same if you add more edges.
  */
 class CapacityAnnotation : public Path {
-	int cached_annotation;
+	int cached_annotation = 0;
 
 public:
 

--- a/src/music/extmidi.h
+++ b/src/music/extmidi.h
@@ -14,9 +14,9 @@
 
 class MusicDriver_ExtMidi : public MusicDriver {
 private:
-	std::vector<std::string> command_tokens;
-	std::string song;
-	pid_t pid;
+	std::vector<std::string> command_tokens{};
+	std::string song{};
+	pid_t pid = 0;
 
 	void DoPlay();
 	void DoStop();

--- a/src/music/midifile.hpp
+++ b/src/music/midifile.hpp
@@ -29,9 +29,9 @@ struct MidiFile {
 		TempoChange(uint32_t _ticktime, uint32_t _tempo) : ticktime(_ticktime), tempo(_tempo) { }
 	};
 
-	std::vector<DataBlock> blocks;   ///< sequential time-annotated data of file, merged to a single track
-	std::vector<TempoChange> tempos; ///< list of tempo changes in file
-	uint16_t tickdiv;                  ///< ticks per quarter note
+	std::vector<DataBlock> blocks{}; ///< sequential time-annotated data of file, merged to a single track
+	std::vector<TempoChange> tempos{}; ///< list of tempo changes in file
+	uint16_t tickdiv = 0; ///< ticks per quarter note
 
 	MidiFile();
 	~MidiFile();

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -58,11 +58,11 @@ struct MusicSystem {
 		PLCH_MAX,
 	};
 
-	Playlist active_playlist;    ///< current play order of songs, including any shuffle
-	Playlist displayed_playlist; ///< current playlist as displayed in GUI, never in shuffled order
-	Playlist music_set;          ///< all songs in current music set, in set order
+	Playlist active_playlist{}; ///< current play order of songs, including any shuffle
+	Playlist displayed_playlist{}; ///< current playlist as displayed in GUI, never in shuffled order
+	Playlist music_set{}; ///< all songs in current music set, in set order
 
-	PlaylistChoices selected_playlist;
+	PlaylistChoices selected_playlist{};
 
 	void BuildPlaylists();
 
@@ -90,11 +90,11 @@ private:
 	uint GetSetIndex();
 	void SetPositionBySetIndex(uint set_index);
 	void ChangePlaylistPosition(int ofs);
-	int playlist_position;
+	int playlist_position = 0;
 
 	void SaveCustomPlaylist(PlaylistChoices pl);
 
-	Playlist standard_playlists[PLCH_MAX];
+	std::array<Playlist, PLCH_MAX> standard_playlists{};
 };
 
 MusicSystem _music;

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -93,15 +93,14 @@ void UpdateNetworkGameWindow();
  * Everything we need to know about a command to be able to execute it.
  */
 struct CommandPacket {
-	CommandPacket() : company(CompanyID::Invalid()), frame(0), my_cmd(false) {}
-	CompanyID company;   ///< company that is executing the command
-	uint32_t frame;        ///< the frame in which this packet is executed
-	bool my_cmd;         ///< did the command originate from "me"
+	CompanyID company = CompanyID::Invalid(); ///< company that is executing the command
+	uint32_t frame = 0; ///< the frame in which this packet is executed
+	bool my_cmd = false; ///< did the command originate from "me"
 
-	Commands cmd;              ///< command being executed.
-	StringID err_msg;          ///< string ID of error message to use.
-	CommandCallback *callback; ///< any callback function executed upon successful completion of the command.
-	CommandDataBuffer data;    ///< command parameters.
+	Commands cmd{}; ///< command being executed.
+	StringID err_msg{}; ///< string ID of error message to use.
+	CommandCallback *callback = nullptr; ///< any callback function executed upon successful completion of the command.
+	CommandDataBuffer data{}; ///< command parameters.
 };
 
 void NetworkDistributeCommands();

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -27,7 +27,7 @@ std::vector<NewGRFProfiler> _newgrf_profilers;
  * @param grffile   The GRF file to collect profiling data on
  * @param end_date  Game date to end profiling on
  */
-NewGRFProfiler::NewGRFProfiler(const GRFFile *grffile) : grffile{ grffile }, active{ false }, cur_call{}
+NewGRFProfiler::NewGRFProfiler(const GRFFile *grffile) : grffile(grffile)
 {
 }
 

--- a/src/newgrf_profiling.h
+++ b/src/newgrf_profiling.h
@@ -49,11 +49,11 @@ struct NewGRFProfiler {
 		GrfSpecFeature feat; ///< GRF feature being resolved for
 	};
 
-	const GRFFile *grffile;  ///< Which GRF is being profiled
-	bool active;             ///< Is this profiler collecting data
-	uint64_t start_tick;       ///< Tick number this profiler was started on
-	Call cur_call;           ///< Data for current call in progress
-	std::vector<Call> calls; ///< All calls collected so far
+	const GRFFile *grffile = nullptr; ///< Which GRF is being profiled
+	bool active = false; ///< Is this profiler collecting data
+	uint64_t start_tick = 0; ///< Tick number this profiler was started on
+	Call cur_call{}; ///< Data for current call in progress
+	std::vector<Call> calls{}; ///< All calls collected so far
 };
 
 extern std::vector<NewGRFProfiler> _newgrf_profilers;

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -89,13 +89,13 @@ enum RoadStopView : uint8_t {
 
 /** Scope resolver for road stops. */
 struct RoadStopScopeResolver : public ScopeResolver {
-	TileIndex tile;                             ///< %Tile of the station.
-	struct BaseStation *st;                     ///< Instance of the station.
-	const struct RoadStopSpec *roadstopspec;    ///< Station (type) specification.
-	CargoType cargo_type;                         ///< Type of cargo of the station.
-	StationType type;                           ///< Station type.
-	uint8_t view;                                 ///< Station axis.
-	RoadType roadtype;                          ///< Road type (used when no tile)
+	TileIndex tile{}; ///< %Tile of the station.
+	struct BaseStation *st = nullptr; ///< Instance of the station.
+	const struct RoadStopSpec *roadstopspec = nullptr; ///< Station (type) specification.
+	CargoType cargo_type{}; ///< Type of cargo of the station.
+	StationType type{}; ///< Station type.
+	uint8_t view = 0; ///< Station axis.
+	RoadType roadtype{}; ///< Road type (used when no tile)
 
 	RoadStopScopeResolver(ResolverObject &ro, BaseStation *st, const RoadStopSpec *roadstopspec, TileIndex tile, RoadType roadtype, StationType type, uint8_t view = 0)
 		: ScopeResolver(ro), tile(tile), st(st), roadstopspec(roadstopspec), type(type), view(view), roadtype(roadtype)

--- a/src/os/unix/crashlog_unix.cpp
+++ b/src/os/unix/crashlog_unix.cpp
@@ -121,7 +121,7 @@ public:
 	}
 
 	/** Buffer to track the long jump set setup. */
-	jmp_buf internal_fault_jmp_buf;
+	jmp_buf internal_fault_jmp_buf{};
 
 	/** Whether we are in a TryExecute block. */
 	bool try_execute_active = false;

--- a/src/querystring_gui.h
+++ b/src/querystring_gui.h
@@ -23,19 +23,19 @@ struct QueryString {
 	static const int ACTION_DESELECT = -2; ///< Deselect editbox.
 	static const int ACTION_CLEAR    = -3; ///< Clear editbox.
 
-	StringID caption;
-	int ok_button;      ///< Widget button of parent window to simulate when pressing OK in OSK.
-	int cancel_button;  ///< Widget button of parent window to simulate when pressing CANCEL in OSK.
+	StringID caption{};
+	int ok_button = ACTION_NOTHING; ///< Widget button of parent window to simulate when pressing OK in OSK.
+	int cancel_button = ACTION_DESELECT; ///< Widget button of parent window to simulate when pressing CANCEL in OSK.
 	Textbuf text;
-	std::optional<std::string> orig;
-	bool handled;
+	std::optional<std::string> orig{};
+	bool handled = false;
 
 	/**
 	 * Initialize string.
 	 * @param size Maximum size in bytes.
 	 * @param chars Maximum size in chars.
 	 */
-	QueryString(uint16_t size, uint16_t chars = UINT16_MAX) : ok_button(ACTION_NOTHING), cancel_button(ACTION_DESELECT), text(size, chars)
+	QueryString(uint16_t size, uint16_t chars = UINT16_MAX) : text(size, chars)
 	{
 	}
 

--- a/src/script/script_info.hpp
+++ b/src/script/script_info.hpp
@@ -29,12 +29,6 @@ static const int MAX_GET_SETTING_OPS    = 100000;
 /** All static information from an Script like name, version, etc. */
 class ScriptInfo : public SimpleCountedObject {
 public:
-	ScriptInfo() :
-		engine(nullptr),
-		version(0),
-		scanner(nullptr)
-	{}
-
 	/**
 	 * Get the Author of the script.
 	 */
@@ -136,23 +130,23 @@ public:
 	virtual bool IsDeveloperOnly() const { return false; }
 
 protected:
-	class Squirrel *engine;           ///< Engine used to register for Squirrel.
-	HSQOBJECT SQ_instance;            ///< The Squirrel instance created for this info.
-	ScriptConfigItemList config_list; ///< List of settings from this Script.
+	class Squirrel *engine = nullptr; ///< Engine used to register for Squirrel.
+	HSQOBJECT SQ_instance{}; ///< The Squirrel instance created for this info.
+	ScriptConfigItemList config_list{}; ///< List of settings from this Script.
 
 private:
-	std::string main_script;      ///< The full path of the script.
-	std::string tar_file;         ///< If, which tar file the script was in.
-	std::string author;           ///< Author of the script.
-	std::string name;             ///< Full name of the script.
-	std::string short_name;       ///< Short name (4 chars) which uniquely identifies the script.
-	std::string description;      ///< Small description of the script.
-	std::string date;             ///< The date the script was written at.
-	std::string instance_name;    ///< Name of the main class in the script.
-	int version;                  ///< Version of the script.
-	std::string url;              ///< URL of the script.
+	std::string main_script{}; ///< The full path of the script.
+	std::string tar_file{}; ///< If, which tar file the script was in.
+	std::string author{}; ///< Author of the script.
+	std::string name{}; ///< Full name of the script.
+	std::string short_name{}; ///< Short name (4 chars) which uniquely identifies the script.
+	std::string description{}; ///< Small description of the script.
+	std::string date{}; ///< The date the script was written at.
+	std::string instance_name{}; ///< Name of the main class in the script.
+	int version = 0; ///< Version of the script.
+	std::string url{}; ///< URL of the script.
 
-	class ScriptScanner *scanner; ///< ScriptScanner object that was used to scan this script info.
+	class ScriptScanner *scanner = nullptr; ///< ScriptScanner object that was used to scan this script info.
 };
 
 void Script_CreateDummyInfo(HSQUIRRELVM vm, const char *type, const char *dir);

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -49,18 +49,7 @@ static void PrintFunc(bool error_msg, const std::string &message)
 	ScriptController::Print(error_msg, message);
 }
 
-ScriptInstance::ScriptInstance(const char *APIName) :
-	engine(nullptr),
-	controller(nullptr),
-	storage(nullptr),
-	instance(nullptr),
-	is_started(false),
-	is_dead(false),
-	is_save_data_on_stack(false),
-	suspend(0),
-	is_paused(false),
-	in_shutdown(false),
-	callback(nullptr)
+ScriptInstance::ScriptInstance(const char *APIName)
 {
 	this->storage = new ScriptStorage();
 	this->engine  = new Squirrel(APIName);

--- a/src/script/script_instance.hpp
+++ b/src/script/script_instance.hpp
@@ -252,8 +252,8 @@ public:
 	void ReleaseSQObject(HSQOBJECT *obj);
 
 protected:
-	class Squirrel *engine;               ///< A wrapper around the squirrel vm.
-	std::string versionAPI;               ///< Current API used by this script.
+	class Squirrel *engine = nullptr; ///< A wrapper around the squirrel vm.
+	std::string versionAPI{}; ///< Current API used by this script.
 
 	/**
 	 * Register all API functions to the VM.
@@ -284,18 +284,18 @@ protected:
 	virtual void LoadDummyScript() = 0;
 
 private:
-	class ScriptController *controller;   ///< The script main class.
-	class ScriptStorage *storage;         ///< Some global information for each running script.
-	SQObject *instance;                   ///< Squirrel-pointer to the script main class.
+	class ScriptController *controller = nullptr; ///< The script main class.
+	class ScriptStorage *storage = nullptr; ///< Some global information for each running script.
+	SQObject *instance = nullptr; ///< Squirrel-pointer to the script main class.
 
-	bool is_started;                      ///< Is the scripts constructor executed?
-	bool is_dead;                         ///< True if the script has been stopped.
-	bool is_save_data_on_stack;           ///< Is the save data still on the squirrel stack?
-	int suspend;                          ///< The amount of ticks to suspend this script before it's allowed to continue.
-	bool is_paused;                       ///< Is the script paused? (a paused script will not be executed until unpaused)
-	bool in_shutdown;                     ///< Is this instance currently being destructed?
-	Script_SuspendCallbackProc *callback; ///< Callback that should be called in the next tick the script runs.
-	size_t last_allocated_memory;         ///< Last known allocated memory value (for display for crashed scripts)
+	bool is_started = false; ///< Is the scripts constructor executed?
+	bool is_dead = false; ///< True if the script has been stopped.
+	bool is_save_data_on_stack = false; ///< Is the save data still on the squirrel stack?
+	int suspend = 0; ///< The amount of ticks to suspend this script before it's allowed to continue.
+	bool is_paused = false; ///< Is the script paused? (a paused script will not be executed until unpaused)
+	bool in_shutdown = false; ///< Is this instance currently being destructed?
+	Script_SuspendCallbackProc *callback = nullptr; ///< Callback that should be called in the next tick the script runs.
+	size_t last_allocated_memory = 0; ///< Last known allocated memory value (for display for crashed scripts)
 
 	/**
 	 * Call the script Load function if it exists and data was loaded

--- a/src/story_base.h
+++ b/src/story_base.h
@@ -143,12 +143,12 @@ struct StoryPageButtonData {
  * page content. Each element only contain one type of content.
  **/
 struct StoryPageElement : StoryPageElementPool::PoolItem<&_story_page_element_pool> {
-	uint32_t sort_value;         ///< A number that increases for every created story page element. Used for sorting. The id of a story page element is the pool index.
-	StoryPageID page;          ///< Id of the page which the page element belongs to
-	StoryPageElementType type; ///< Type of page element
+	uint32_t sort_value = 0; ///< A number that increases for every created story page element. Used for sorting. The id of a story page element is the pool index.
+	StoryPageID page{}; ///< Id of the page which the page element belongs to
+	StoryPageElementType type{}; ///< Type of page element
 
-	uint32_t referenced_id;      ///< Id of referenced object (location, goal etc.)
-	EncodedString text;          ///< Static content text of page element
+	uint32_t referenced_id = 0; ///< Id of referenced object (location, goal etc.)
+	EncodedString text{}; ///< Static content text of page element
 
 	/**
 	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1488,8 +1488,8 @@ public:
 		}
 	}
 
-	HouseZones climate_mask;
-	uint8_t class_mask; ///< Mask of available 'classes'.
+	HouseZones climate_mask{};
+	uint8_t class_mask = 0; ///< Mask of available 'classes'.
 
 	static inline int sel_class; ///< Currently selected 'class'.
 	static inline int sel_type; ///< Currently selected HouseID.

--- a/src/video/null_v.h
+++ b/src/video/null_v.h
@@ -15,7 +15,7 @@
 /** The null video driver. */
 class VideoDriver_Null : public VideoDriver {
 private:
-	uint ticks; ///< Amount of ticks to run.
+	uint ticks = 0; ///< Amount of ticks to run.
 
 public:
 	std::optional<std::string_view> Start(const StringList &param) override;

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -17,7 +17,7 @@
 /** The SDL video driver. */
 class VideoDriver_SDL_Base : public VideoDriver {
 public:
-	VideoDriver_SDL_Base(bool uses_hardware_acceleration = false) : VideoDriver(uses_hardware_acceleration), sdl_window(nullptr), buffer_locked(false) {}
+	VideoDriver_SDL_Base(bool uses_hardware_acceleration = false) : VideoDriver(uses_hardware_acceleration) {}
 
 	std::optional<std::string_view> Start(const StringList &param) override;
 
@@ -44,11 +44,11 @@ public:
 	std::string_view GetInfoString() const override { return this->driver_info; }
 
 protected:
-	struct SDL_Window *sdl_window; ///< Main SDL window.
-	Palette local_palette; ///< Current palette to use for drawing.
-	bool buffer_locked; ///< Video buffer was locked by the main thread.
-	Rect dirty_rect; ///< Rectangle encompassing the dirty area of the video buffer.
-	std::string driver_info; ///< Information string about selected driver.
+	struct SDL_Window *sdl_window = nullptr; ///< Main SDL window.
+	Palette local_palette{}; ///< Current palette to use for drawing.
+	bool buffer_locked = false; ///< Video buffer was locked by the main thread.
+	Rect dirty_rect{}; ///< Rectangle encompassing the dirty area of the video buffer.
+	std::string driver_info{}; ///< Information string about selected driver.
 
 	Dimension GetScreenSize() const override;
 	void InputLoop() override;
@@ -83,9 +83,9 @@ private:
 	/**
 	 * This is true to indicate that keyboard input is in text input mode, and SDL_TEXTINPUT events are enabled.
 	 */
-	bool edit_box_focused;
+	bool edit_box_focused = false;
 
-	int startup_display;
+	int startup_display = 0;
 };
 
 #endif /* VIDEO_SDL_H */


### PR DESCRIPTION
## Motivation / Problem

Coverity shows 37 cases of instance members that have not been initialised.


## Description

Initialise the members of the instances.


## Limitations

Coverity only checks what my compiler compiles, so there might be more in Windows/macOS that it won't be able to find.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
