### PR TITLE
Codechange: use std::move when appropriate

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1712,7 +1712,7 @@ DEF_CONSOLE_CMD(ConScreenShot)
 		return false;
 	}
 
-	MakeScreenshot(type, name, width, height);
+	MakeScreenshot(type, std::move(name), width, height);
 	return true;
 }
 

--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -249,7 +249,7 @@ bool CrashLog::WriteScreenshot()
 	if (_screen.width < 1 || _screen.height < 1 || _screen.dst_ptr == nullptr) return false;
 
 	std::string filename = this->CreateFileName("", false);
-	bool res = MakeScreenshot(SC_CRASHLOG, filename);
+	bool res = MakeScreenshot(SC_CRASHLOG, std::move(filename));
 	if (res) this->screenshot_filename = _full_screenshot_path;
 	return res;
 }

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -337,7 +337,7 @@ void ShowErrorMessage(EncodedString &&summary_msg, EncodedString &&detailed_msg,
 			if (wl == WL_CRITICAL) {
 				/* Push another critical error in the queue of errors,
 				 * but do not put other errors in the queue. */
-				_error_list.push_back(data);
+				_error_list.push_back(std::move(data));
 			}
 			return;
 		}

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -558,7 +558,7 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 
 				/* Store the first directory name we detect */
 				Debug(misc, 6, "Found dir in tar: {}", name);
-				if (_tar_list[this->subdir][filename].empty()) _tar_list[this->subdir][filename] = name;
+				if (_tar_list[this->subdir][filename].empty()) _tar_list[this->subdir][filename] = std::move(name);
 				break;
 
 			default:
@@ -783,7 +783,7 @@ void DetermineBasePaths(const char *exe)
 	_searchpaths[SP_PERSONAL_DIR].clear();
 #else
 	if (!homedir.empty()) {
-		tmp = homedir;
+		tmp = std::move(homedir);
 		tmp += PATHSEP;
 		tmp += PERSONAL_DIR;
 		AppendPathSeparator(tmp);
@@ -855,7 +855,7 @@ void DetermineBasePaths(const char *exe)
 #else
 	tmp = GLOBAL_DATA_DIR;
 	AppendPathSeparator(tmp);
-	_searchpaths[SP_INSTALLATION_DIR] = tmp;
+	_searchpaths[SP_INSTALLATION_DIR] = std::move(tmp);
 #endif
 #ifdef WITH_COCOA
 extern void CocoaSetApplicationBundleDir();
@@ -882,7 +882,7 @@ void DeterminePaths(const char *exe, bool only_local_path)
 
 #ifdef USE_XDG
 	std::string config_home;
-	const std::string homedir = GetHomeDir();
+	std::string homedir = GetHomeDir();
 	const char *xdg_config_home = std::getenv("XDG_CONFIG_HOME");
 	if (xdg_config_home != nullptr) {
 		config_home = xdg_config_home;
@@ -890,7 +890,7 @@ void DeterminePaths(const char *exe, bool only_local_path)
 		config_home += PERSONAL_DIR[0] == '.' ? &PERSONAL_DIR[1] : PERSONAL_DIR;
 	} else if (!homedir.empty()) {
 		/* Defaults to ~/.config */
-		config_home = homedir;
+		config_home = std::move(homedir);
 		config_home += PATHSEP ".config" PATHSEP;
 		config_home += PERSONAL_DIR[0] == '.' ? &PERSONAL_DIR[1] : PERSONAL_DIR;
 	}
@@ -910,7 +910,7 @@ void DeterminePaths(const char *exe, bool only_local_path)
 		if (!personal_dir.empty()) {
 			auto end = personal_dir.find_last_of(PATHSEPCHAR);
 			if (end != std::string::npos) personal_dir.erase(end + 1);
-			config_dir = personal_dir;
+			config_dir = std::move(personal_dir);
 		} else {
 #ifdef USE_XDG
 			/* No previous configuration file found. Use the configuration folder from XDG. */

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -124,7 +124,7 @@ void SetFont(FontSize fontsize, const std::string &font, uint size)
 			GetFontCacheSubSetting(fs)->font = fc->HasParent() ? fc->GetFontName() : "";
 		}
 		CheckForMissingGlyphs();
-		_fcsettings = backup;
+		_fcsettings = std::move(backup);
 	} else {
 		InitFontCache(true);
 	}

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -147,7 +147,7 @@ Layouter::Layouter(std::string_view str, int maxw, FontSize fontsize) : string(s
 			if (line.layout == nullptr) {
 				GetLayouter<ICUParagraphLayoutFactory>(line, str_line, state);
 				if (line.layout == nullptr) {
-					state = old_state;
+					state = std::move(old_state);
 				}
 			}
 #endif
@@ -156,7 +156,7 @@ Layouter::Layouter(std::string_view str, int maxw, FontSize fontsize) : string(s
 			if (line.layout == nullptr) {
 				GetLayouter<UniscribeParagraphLayoutFactory>(line, str_line, state);
 				if (line.layout == nullptr) {
-					state = old_state;
+					state = std::move(old_state);
 				}
 			}
 #endif
@@ -165,7 +165,7 @@ Layouter::Layouter(std::string_view str, int maxw, FontSize fontsize) : string(s
 			if (line.layout == nullptr) {
 				GetLayouter<CoreTextParagraphLayoutFactory>(line, str_line, state);
 				if (line.layout == nullptr) {
-					state = old_state;
+					state = std::move(old_state);
 				}
 			}
 #endif

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2005,7 +2005,7 @@ static CommandCost CreateNewIndustryHelper(TileIndex tile, IndustryType type, Do
 	/* 2. Built-in checks on industry tiles. */
 	std::vector<ClearedObjectArea> object_areas(_cleared_object_areas);
 	ret = CheckIfIndustryTilesAreFree(tile, layout, type);
-	_cleared_object_areas = object_areas;
+	_cleared_object_areas = std::move(object_areas);
 	if (ret.Failed()) return ret;
 
 	/* 3. NewGRF-defined checks on industry level. */

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -557,7 +557,7 @@ LinkGraphLegendWindow::LinkGraphLegendWindow(WindowDesc &desc, int window_number
  */
 void LinkGraphLegendWindow::SetOverlay(std::shared_ptr<LinkGraphOverlay> overlay)
 {
-	this->overlay = overlay;
+	this->overlay = std::move(overlay);
 	CompanyMask companies = this->overlay->GetCompanyMask();
 	for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 		if (!this->IsWidgetDisabled(WID_LGL_COMPANY_FIRST + c)) {

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -117,13 +117,13 @@ void MusicSystem::BuildPlaylists()
 		this->music_set.push_back(entry);
 
 		/* Add theme song to theme-only playlist */
-		if (i == 0) this->standard_playlists[PLCH_THEMEONLY].push_back(entry);
+		if (i == 0) this->standard_playlists[PLCH_THEMEONLY].push_back(std::move(entry));
 
 		/* Don't add the theme song to standard playlists */
 		if (i > 0) {
 			this->standard_playlists[PLCH_ALLMUSIC].push_back(entry);
 			uint theme = (i - 1) / NUM_SONGS_CLASS;
-			this->standard_playlists[PLCH_OLDSTYLE + theme].push_back(entry);
+			this->standard_playlists[PLCH_OLDSTYLE + theme].push_back(std::move(entry));
 		}
 	}
 
@@ -132,11 +132,11 @@ void MusicSystem::BuildPlaylists()
 	for (uint i = 0; i < NUM_SONGS_PLAYLIST; i++) {
 		if (_settings_client.music.custom_1[i] > 0 && _settings_client.music.custom_1[i] <= NUM_SONGS_AVAILABLE) {
 			PlaylistEntry entry(set, _settings_client.music.custom_1[i] - 1);
-			if (entry.IsValid()) this->standard_playlists[PLCH_CUSTOM1].push_back(entry);
+			if (entry.IsValid()) this->standard_playlists[PLCH_CUSTOM1].push_back(std::move(entry));
 		}
 		if (_settings_client.music.custom_2[i] > 0 && _settings_client.music.custom_2[i] <= NUM_SONGS_AVAILABLE) {
 			PlaylistEntry entry(set, _settings_client.music.custom_2[i] - 1);
-			if (entry.IsValid()) this->standard_playlists[PLCH_CUSTOM2].push_back(entry);
+			if (entry.IsValid()) this->standard_playlists[PLCH_CUSTOM2].push_back(std::move(entry));
 		}
 	}
 }
@@ -342,7 +342,7 @@ void MusicSystem::PlaylistAdd(size_t song_index)
 
 	/* Add it to the active playlist, if playback is shuffled select a random position to add at */
 	if (this->active_playlist.empty()) {
-		this->active_playlist.push_back(entry);
+		this->active_playlist.push_back(std::move(entry));
 		if (this->IsPlaying()) this->Play();
 	} else if (this->IsShuffle()) {
 		/* Generate a random position between 0 and n (inclusive, new length) to insert at */
@@ -352,7 +352,7 @@ void MusicSystem::PlaylistAdd(size_t song_index)
 		/* Make sure to shift up the current playback position if the song was inserted before it */
 		if ((int)newpos <= this->playlist_position) this->playlist_position++;
 	} else {
-		this->active_playlist.push_back(entry);
+		this->active_playlist.push_back(std::move(entry));
 	}
 
 	this->SaveCustomPlaylist(this->selected_playlist);

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -282,7 +282,7 @@ SOCKET NetworkAddress::Resolve(int family, int socktype, int flags, SocketList *
 		}
 
 		NetworkAddress addr(runp->ai_addr, (int)runp->ai_addrlen);
-		(*sockets)[sock] = addr;
+		(*sockets)[sock] = std::move(addr);
 		sock = INVALID_SOCKET;
 	}
 	freeaddrinfo (ai);

--- a/src/network/core/host.cpp
+++ b/src/network/core/host.cpp
@@ -70,7 +70,7 @@ static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast)
 		if (ifa->ifa_broadaddr->sa_family != AF_INET) continue;
 
 		NetworkAddress addr(ifa->ifa_broadaddr, sizeof(sockaddr));
-		if (std::none_of(broadcast->begin(), broadcast->end(), [&addr](NetworkAddress const &elem) -> bool { return elem == addr; })) broadcast->push_back(addr);
+		if (std::none_of(broadcast->begin(), broadcast->end(), [&addr](NetworkAddress const &elem) -> bool { return elem == addr; })) broadcast->push_back(std::move(addr));
 	}
 	freeifaddrs(ifap);
 }

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -123,7 +123,7 @@ void TCPConnecter::Connect(addrinfo *address)
 		return;
 	}
 
-	this->sock_to_address[sock] = network_address;
+	this->sock_to_address[sock] = std::move(network_address);
 	this->sockets.push_back(sock);
 }
 

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -792,7 +792,7 @@ bool NetworkClientConnectGame(const std::string &connection_string, CompanyID de
 	if (!_network_available) return false;
 	if (!NetworkValidateOurClientName()) return false;
 
-	_network_join.connection_string = resolved_connection_string;
+	_network_join.connection_string = std::move(resolved_connection_string);
 	_network_join.company = join_as;
 	_network_join.server_password = join_server_password;
 

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -559,8 +559,8 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_CLIENT_INFO(Pac
 		if (client_id == _network_own_client_id) SetLocalCompany(!Company::IsValidID(playas) ? COMPANY_SPECTATOR : playas);
 
 		ci->client_playas = playas;
-		ci->client_name = name;
-		ci->public_key = public_key;
+		ci->client_name = std::move(name);
+		ci->public_key = std::move(public_key);
 
 		InvalidateWindowData(WC_CLIENT_LIST, 0);
 
@@ -579,8 +579,8 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_CLIENT_INFO(Pac
 	ci->client_playas = playas;
 	if (client_id == _network_own_client_id) this->SetInfo(ci);
 
-	ci->client_name = name;
-	ci->public_key = public_key;
+	ci->client_name = std::move(name);
+	ci->public_key = std::move(public_key);
 
 	InvalidateWindowData(WC_CLIENT_LIST, 0);
 
@@ -677,7 +677,7 @@ class ClientGamePasswordRequestHandler : public NetworkAuthenticationPasswordReq
 		if (!_network_join.server_password.empty()) {
 			request->Reply(_network_join.server_password);
 		} else {
-			ShowNetworkNeedPassword(request);
+			ShowNetworkNeedPassword(std::move(request));
 		}
 	}
 };
@@ -936,7 +936,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_COMMAND(Packet 
 		return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 	}
 
-	this->incoming_queue.push_back(cp);
+	this->incoming_queue.push_back(std::move(cp));
 
 	return NETWORK_RECV_STATUS_OKAY;
 }
@@ -1313,7 +1313,7 @@ void NetworkUpdateClientName(const std::string &client_name)
 			std::string temporary_name = client_name;
 			if (NetworkMakeClientNameUnique(temporary_name)) {
 				NetworkTextMessage(NETWORK_ACTION_NAME_CHANGE, CC_DEFAULT, false, ci->client_name, temporary_name);
-				ci->client_name = temporary_name;
+				ci->client_name = std::move(temporary_name);
 				NetworkUpdateClientInfo(CLIENT_ID_SERVER);
 			}
 		}

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -212,7 +212,7 @@ void NetworkSendCommand(Commands cmd, StringID err_message, CommandCallback *cal
 		c.frame = _frame_counter_max + 1;
 		c.my_cmd = true;
 
-		_local_wait_queue.push_back(c);
+		_local_wait_queue.push_back(std::move(c));
 		return;
 	}
 

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -346,7 +346,7 @@ void ClientNetworkContentSocketHandler::DownloadSelectedContentHTTP(const Conten
 
 	this->http_response_index = -1;
 
-	NetworkHTTPSocketHandler::Connect(NetworkContentMirrorUriString(), this, content_request);
+	NetworkHTTPSocketHandler::Connect(NetworkContentMirrorUriString(), this, std::move(content_request));
 }
 
 /**

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -78,7 +78,7 @@ public:
 	 */
 	NetworkReuseStunConnecter(const std::string &hostname, uint16_t port, const NetworkAddress &bind_address, std::string token, uint8_t tracking_number, uint8_t family) :
 		TCPConnecter(hostname, port, bind_address),
-		token(token),
+		token(std::move(token)),
 		tracking_number(tracking_number),
 		family(family)
 	{

--- a/src/network/network_crypto_internal.h
+++ b/src/network/network_crypto_internal.h
@@ -192,7 +192,7 @@ public:
 	 * @param secret_key The secret key to initialize this handler with.
 	 * @param handler The handler requesting the password from the user, if required.
 	 */
-	X25519PAKEClientHandler(const X25519SecretKey &secret_key, std::shared_ptr<NetworkAuthenticationPasswordRequestHandler> handler) : X25519AuthenticationHandler(secret_key), handler(handler) {}
+	X25519PAKEClientHandler(const X25519SecretKey &secret_key, std::shared_ptr<NetworkAuthenticationPasswordRequestHandler> handler) : X25519AuthenticationHandler(secret_key), handler(std::move(handler)) {}
 
 	virtual RequestResult ReceiveRequest(struct Packet &p) override;
 	virtual bool SendResponse(struct Packet &p) override { return this->X25519AuthenticationHandler::SendResponse(p, this->handler->password); }

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1107,7 +1107,7 @@ struct NetworkStartServerWindow : public Window {
 		std::string str = this->name_editbox.text.GetText();
 		if (!NetworkValidateServerName(str)) return false;
 
-		SetSettingValue(GetSettingFromName("network.server_name")->AsStringSetting(), str);
+		SetSettingValue(GetSettingFromName("network.server_name")->AsStringSetting(), std::move(str));
 		return true;
 	}
 
@@ -2176,7 +2176,7 @@ void ShowNetworkNeedPassword(std::shared_ptr<NetworkAuthenticationPasswordReques
 {
 	NetworkJoinStatusWindow *w = dynamic_cast<NetworkJoinStatusWindow *>(FindWindowById(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN));
 	if (w == nullptr) return;
-	w->request = request;
+	w->request = std::move(request);
 
 	ShowQueryString({}, STR_NETWORK_NEED_GAME_PASSWORD_CAPTION, NETWORK_PASSWORD_LENGTH, w, CS_ALPHANUMERAL, QSF_NONE);
 }

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -915,7 +915,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_IDENTIFY(Packet
 	NetworkClientInfo *ci = new NetworkClientInfo(this->client_id);
 	this->SetInfo(ci);
 	ci->join_date = TimerGameEconomy::date;
-	ci->client_name = client_name;
+	ci->client_name = std::move(client_name);
 	ci->client_playas = playas;
 	ci->public_key = this->peer_public_key;
 	Debug(desync, 1, "client: {:08x}; {:02x}; {:02x}; {:02x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, ci->client_playas, ci->index);
@@ -1130,7 +1130,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_COMMAND(Packet 
 
 	if (GetCommandFlags(cp.cmd).Test(CommandFlag::ClientID)) NetworkReplaceCommandClientId(cp, this->client_id);
 
-	this->incoming_queue.push_back(cp);
+	this->incoming_queue.push_back(std::move(cp));
 	return NETWORK_RECV_STATUS_OKAY;
 }
 
@@ -1430,7 +1430,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_SET_NAME(Packet
 		/* Display change */
 		if (NetworkMakeClientNameUnique(client_name)) {
 			NetworkTextMessage(NETWORK_ACTION_NAME_CHANGE, CC_DEFAULT, false, ci->client_name, client_name);
-			ci->client_name = client_name;
+			ci->client_name = std::move(client_name);
 			NetworkUpdateClientInfo(ci->client_id);
 		}
 	}

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -2953,7 +2953,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 				std::string prefix = ReadDWordAsString(buf);
 
 				if (curidx < CURRENCY_END) {
-					_currency_specs[curidx].prefix = prefix;
+					_currency_specs[curidx].prefix = std::move(prefix);
 				} else {
 					GrfMsg(1, "GlobalVarChangeInfo: Currency symbol {} out of range, ignoring", curidx);
 				}
@@ -2965,7 +2965,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 				std::string suffix = ReadDWordAsString(buf);
 
 				if (curidx < CURRENCY_END) {
-					_currency_specs[curidx].suffix = suffix;
+					_currency_specs[curidx].suffix = std::move(suffix);
 				} else {
 					GrfMsg(1, "GlobalVarChangeInfo: Currency symbol {} out of range, ignoring", curidx);
 				}
@@ -3851,7 +3851,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 				}
 
 				/* Install final layout construction in the industry spec */
-				indsp->layouts = new_layouts;
+				indsp->layouts = std::move(new_layouts);
 				break;
 			}
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -942,7 +942,7 @@ bool SafeLoad(const std::string &filename, SaveLoadOperation fop, DetailedFileTy
 
 	_game_mode = newgm;
 
-	SaveOrLoadResult result = (lf == nullptr) ? SaveOrLoad(filename, fop, dft, subdir) : LoadWithFilter(lf);
+	SaveOrLoadResult result = (lf == nullptr) ? SaveOrLoad(filename, fop, dft, subdir) : LoadWithFilter(std::move(lf));
 	if (result == SL_OK) return true;
 
 	if (_network_dedicated && ogm == GM_MENU) {

--- a/src/saveload/cheat_sl.cpp
+++ b/src/saveload/cheat_sl.cpp
@@ -67,7 +67,7 @@ struct CHTSChunkHandler : ChunkHandler {
 
 				if (count == 0) break;
 			}
-			slt = oslt;
+			slt = std::move(oslt);
 		}
 
 		if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() == -1) return;

--- a/src/saveload/saveload_filter.h
+++ b/src/saveload/saveload_filter.h
@@ -19,7 +19,7 @@ struct LoadFilter {
 	 * Initialise this filter.
 	 * @param chain The next filter in this chain.
 	 */
-	LoadFilter(std::shared_ptr<LoadFilter> chain) : chain(chain)
+	LoadFilter(std::shared_ptr<LoadFilter> chain) : chain(std::move(chain))
 	{
 	}
 
@@ -62,7 +62,7 @@ struct SaveFilter {
 	 * Initialise this filter.
 	 * @param chain The next filter in this chain.
 	 */
-	SaveFilter(std::shared_ptr<SaveFilter> chain) : chain(chain)
+	SaveFilter(std::shared_ptr<SaveFilter> chain) : chain(std::move(chain))
 	{
 	}
 

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -82,7 +82,7 @@ void MoveBuoysToWaypoints()
 		Waypoint *wp   = new (index) Waypoint(xy);
 		wp->town       = town;
 		wp->string_id  = train ? STR_SV_STNAME_WAYPOINT : STR_SV_STNAME_BUOY;
-		wp->name       = name;
+		wp->name       = std::move(name);
 		wp->delete_ctr = 0; // Just reset delete counter for once.
 		wp->build_date = build_date;
 		wp->owner      = train ? GetTileOwner(xy) : OWNER_NONE;

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -379,7 +379,7 @@ void MakeScreenshotWithConfirm(ScreenshotType t)
  * @param height the height of the screenshot of, or 0 for current viewport height (only works for SC_ZOOMEDIN and SC_DEFAULTZOOM).
  * @return true iff the screenshot was made successfully
  */
-static bool RealMakeScreenshot(ScreenshotType t, std::string name, uint32_t width, uint32_t height)
+static bool RealMakeScreenshot(ScreenshotType t, const std::string &name, uint32_t width, uint32_t height)
 {
 	if (t == SC_VIEWPORT) {
 		/* First draw the dirty parts of the screen and only then change the name

--- a/src/script/api/script_admin.cpp
+++ b/src/script/api/script_admin.cpp
@@ -91,7 +91,7 @@ bool ScriptAdminMakeJSON(nlohmann::json &json, HSQUIRRELVM vm, SQInteger index, 
 					return false;
 				}
 
-				json[key] = value;
+				json[key] = std::move(value);
 			}
 			sq_pop(vm, 1);
 			return true;

--- a/src/script/squirrel_helper.hpp
+++ b/src/script/squirrel_helper.hpp
@@ -172,7 +172,7 @@ namespace SQConvert {
 				Tretval ret = (*func)(
 					Param<Targs>::Get(vm, 2 + i)...
 				);
-				return Return<Tretval>::Set(vm, ret);
+				return Return<Tretval>::Set(vm, std::move(ret));
 			}
 		}
 	};
@@ -205,7 +205,7 @@ namespace SQConvert {
 				Tretval ret = (instance->*func)(
 					Param<Targs>::Get(vm, 2 + i)...
 				);
-				return Return<Tretval>::Set(vm, ret);
+				return Return<Tretval>::Set(vm, std::move(ret));
 			}
 		}
 

--- a/src/social_integration.cpp
+++ b/src/social_integration.cpp
@@ -118,7 +118,7 @@ public:
 			Debug(misc, 0, "[Social Integration: {}] Another plugin for {} is already loaded", basepath, plugin->plugin_info.social_platform);
 			return false;
 		}
-		_loaded_social_platform.insert(lc_social_platform);
+		_loaded_social_platform.insert(std::move(lc_social_platform));
 
 		auto state = init_func(&plugin->plugin_api, &plugin->openttd_info);
 		switch (state) {

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -410,7 +410,7 @@ int CDECL main(int argc, char *argv[])
 		 * with a (free) parameter the program will translate that language to destination
 		 * directory. As input english.txt is parsed from the source directory */
 		if (mgo.arguments.empty()) {
-			std::filesystem::path input_path = src_dir;
+			std::filesystem::path input_path = std::move(src_dir);
 			input_path /= "english.txt";
 
 			/* parse master file */
@@ -429,7 +429,7 @@ int CDECL main(int argc, char *argv[])
 			writer.Finalise(data);
 			if (_errors != 0) return 1;
 		} else {
-			std::filesystem::path input_path = src_dir;
+			std::filesystem::path input_path = std::move(src_dir);
 			input_path /= "english.txt";
 
 			StringData data(TEXT_TAB_END);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2168,7 +2168,7 @@ static void FillLanguageList(const std::string &path)
 		} else if (GetLanguage(lmd.newgrflangid) != nullptr) {
 			Debug(misc, 3, "{}'s language ID is already known", FS2OTTD(lmd.file));
 		} else {
-			_languages.push_back(lmd);
+			_languages.push_back(std::move(lmd));
 		}
 	}
 	if (error_code) {
@@ -2352,7 +2352,7 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 
 		bad_font = !SetFallbackFont(&_fcsettings, _langpack.langpack->isocode, searcher);
 
-		_fcsettings = backup;
+		_fcsettings = std::move(backup);
 
 		if (!bad_font && any_font_configured) {
 			/* If the user configured a bad font, and we found a better one,

--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -356,7 +356,7 @@ void SurveyGrfs(nlohmann::json &survey)
 {
 	for (const auto &c : _grfconfig) {
 		auto grfid = fmt::format("{:08x}", std::byteswap(c->ident.grfid));
-		auto &grf = survey[grfid];
+		auto &grf = survey[std::move(grfid)];
 
 		grf["md5sum"] = FormatArrayAsHex(c->ident.md5sum);
 		grf["status"] = c->status;

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -295,7 +295,7 @@ void TextfileWindow::FindHyperlinksInMarkdown(Line &line, size_t line_index)
 	fixed_line += std::string(last_match_end, line.text.cend());
 
 	/* Overwrite original line text with "fixed" line text. */
-	line.text = fixed_line;
+	line.text = std::move(fixed_line);
 }
 
 /**

--- a/src/timer/timer.h
+++ b/src/timer/timer.h
@@ -86,7 +86,7 @@ public:
 	 */
 	[[nodiscard]] IntervalTimer(const TPeriod interval, std::function<void(uint)> callback) :
 		BaseTimer<TTimerType>(interval),
-		callback(callback)
+		callback(std::move(callback))
 	{
 	}
 
@@ -130,7 +130,7 @@ public:
 	[[nodiscard]] TimeoutTimer(const TPeriod timeout, std::function<void()> callback, bool start = false) :
 		BaseTimer<TTimerType>(timeout),
 		fired(!start),
-		callback(callback)
+		callback(std::move(callback))
 	{
 	}
 

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -109,7 +109,7 @@ bool VerifyTownName(uint32_t r, const TownNameParams *par, TownNames *town_names
 
 	if (town_names != nullptr) {
 		if (town_names->find(name) != town_names->end()) return false;
-		town_names->insert(name);
+		town_names->insert(std::move(name));
 	} else {
 		for (const Town *t : Town::Iterate()) {
 			/* We can't just compare the numbers since

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -821,7 +821,7 @@ static void CloneVehicleName(const Vehicle *src, Vehicle *dst)
 		/* Check the name is unique. */
 		auto new_name = oss.str();
 		if (IsUniqueVehicleName(new_name)) {
-			dst->name = new_name;
+			dst->name = std::move(new_name);
 			break;
 		}
 	}


### PR DESCRIPTION
## Motivation / Problem

Coverity has come up with about 75 cases where `std::move` could be used over copying the data.


## Description

Use `std::move` for most of those cases.
In some cases passing data by reference is the better solution.


## Limitations

As Coverity only checks what I've compiled, it doesn't cover Windows/macOS.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
