### PR TITLE
Codechange: use const auto & instead of making a copy

### DIFF
--- a/src/script/script_scanner.cpp
+++ b/src/script/script_scanner.cpp
@@ -205,7 +205,7 @@ static bool IsSameScript(const ContentInfo *ci, bool md5sum, ScriptInfo *info, S
 	if (!md5sum) return true;
 
 	ScriptFileChecksumCreator checksum(dir);
-	auto tar_filename = info->GetTarFile();
+	const auto &tar_filename = info->GetTarFile();
 	TarList::iterator iter;
 	if (!tar_filename.empty() && (iter = _tar_list[dir].find(tar_filename)) != _tar_list[dir].end()) {
 		/* The main script is in a tar file, so find all files that

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -189,7 +189,7 @@ size_t OneOfManySettingDesc::ParseSingleValue(const char *str, size_t len, const
 	if (isdigit(*str)) return std::strtoul(str, nullptr, 0);
 
 	size_t idx = 0;
-	for (auto one : many) {
+	for (const auto &one : many) {
 		if (one.size() == len && strncmp(one.c_str(), str, len) == 0) return idx;
 		idx++;
 	}

--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -146,7 +146,7 @@ static void SurveySettingsTable(nlohmann::json &survey, const SettingTable &tabl
 		/* Skip any old settings we no longer save/load. */
 		if (!SlIsObjectCurrentlyValid(sd->save.version_from, sd->save.version_to)) continue;
 
-		auto name = sd->GetName();
+		const auto &name = sd->GetName();
 		if (skip_if_default && sd->IsDefaultValue(object)) continue;
 		survey[name] = sd->FormatValue(object);
 	}

--- a/src/tests/landscape_partial_pixel_z.cpp
+++ b/src/tests/landscape_partial_pixel_z.cpp
@@ -85,7 +85,7 @@ TEST_CASE("PartialPixelSlopeAdditionTest - A half tile steep slope is a one corn
  * @param expected The expect partial pixels Z values.
  * @return True iff at all GetPartialPixelZ results are the same as the expected Z-coordinates.
  */
-bool CheckPartialPixelZ(Slope slope, std::array<int, TILE_SIZE * TILE_SIZE> expected)
+bool CheckPartialPixelZ(Slope slope, const std::array<int, TILE_SIZE * TILE_SIZE> &expected)
 {
 	for (uint i = 0; i < expected.size(); i++) {
 		int actual = GetPartialPixelZ(GB(i, 4, 4), GB(i, 0, 4), slope);

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1599,7 +1599,7 @@ public:
 	{
 		if (src.empty()) return src;
 
-		const auto specs = HouseSpec::Specs();
+		const auto &specs = HouseSpec::Specs();
 		std::set<PickerItem> dst;
 		for (const auto &item : src) {
 			if (item.grfid == 0) {


### PR DESCRIPTION
## Motivation / Problem

Making a copy of data, when a reference would suffice.


## Description

Use the reference.


## Limitations

There might be cases in Windows/macOS code that Coverity has not found.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
