### PR TITLE
Codefix: use Pool::Get if you know it's valid instead of GetIfValid

### DIFF
--- a/src/script/api/script_group.cpp
+++ b/src/script/api/script_group.cpp
@@ -88,7 +88,7 @@
 {
 	EnforcePrecondition(::GroupID::Invalid(), IsValidGroup(group_id));
 
-	const Group *g = ::Group::GetIfValid(group_id);
+	const Group *g = ::Group::Get(group_id);
 	return g->parent;
 }
 
@@ -239,7 +239,7 @@
 {
 	EnforcePrecondition(ScriptCompany::Colours::COLOUR_INVALID, IsValidGroup(group_id));
 
-	const Group *g = ::Group::GetIfValid(group_id);
+	const Group *g = ::Group::Get(group_id);
 	if (!HasBit(g->livery.in_use, 0)) return ScriptCompany::Colours::COLOUR_INVALID;
 	return (ScriptCompany::Colours)g->livery.colour1;
 }
@@ -248,7 +248,7 @@
 {
 	EnforcePrecondition(ScriptCompany::Colours::COLOUR_INVALID, IsValidGroup(group_id));
 
-	const Group *g = ::Group::GetIfValid(group_id);
+	const Group *g = ::Group::Get(group_id);
 	if (!HasBit(g->livery.in_use, 1)) return ScriptCompany::Colours::COLOUR_INVALID;
 	return (ScriptCompany::Colours)g->livery.colour2;
 }

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -813,8 +813,7 @@ struct ScriptDebugWindow : public Window {
 			return {};
 		}
 
-		const AIInfo *info = Company::GetIfValid(this->filter.script_debug_company)->ai_info;
-		assert(info != nullptr);
+		const AIInfo *info = Company::Get(this->filter.script_debug_company)->ai_info;
 		return GetString(STR_AI_DEBUG_NAME_AND_VERSION, info->GetName(), info->GetVersion());
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Some code is using `Pool::GetIfValid`, but doesn't check for `nullptr`.


## Description

For the cases in `ScriptGroup` the earlier call to `IsValidGroup` already ensures the group is valid, so we can just use `Group::Get`.

For the case in `ScriptDebugWindow` there is a `GetIfValid` with an `assert` that isn't `nullptr`, so conceptually we know it must be valid.


## Limitations

The Coverity check this comes from will not have seen Windows/macOS specific code.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
