### PR TITLE
Cleanup: Remove unused DepotCommandFlag::LocateHangar flag

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -1651,7 +1651,7 @@ static void AircraftEventHandler_HeliTakeOff(Aircraft *v, const AirportFTAClass 
 	/* Send the helicopter to a hangar if needed for replacement */
 	if (v->NeedsAutomaticServicing()) {
 		Backup<CompanyID> cur_company(_current_company, v->owner);
-		Command<CMD_SEND_VEHICLE_TO_DEPOT>::Do(DoCommandFlag::Execute, v->index, DepotCommandFlags{DepotCommandFlag::Service, DepotCommandFlag::LocateHangar}, {});
+		Command<CMD_SEND_VEHICLE_TO_DEPOT>::Do(DoCommandFlag::Execute, v->index, DepotCommandFlag::Service, {});
 		cur_company.Restore();
 	}
 }

--- a/src/vehicle_type.h
+++ b/src/vehicle_type.h
@@ -56,7 +56,6 @@ enum class DepotCommandFlag : uint8_t {
 	Service, ///< The vehicle will leave the depot right after arrival (service only)
 	MassSend, ///< Tells that it's a mass send to depot command (type in VLW flag)
 	DontCancel, ///< Don't cancel current goto depot command if any
-	LocateHangar, ///< Find another airport if the target one lacks a hangar
 };
 using DepotCommandFlags = EnumBitSet<DepotCommandFlag, uint8_t>;
 


### PR DESCRIPTION
## Motivation / Problem

DepotCommandFlag::LocateHangar seems to have no readers and therefore do nothing since daf5a2f1.

## Description

So remove it.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
