### PR TITLE
Codechange: Use emplace_back instead of back_inserter.

### DIFF
--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -762,41 +762,39 @@ static void HandleNewGRFStringControlCodes(const char *str, TextRefStack &stack,
  */
 static void RemapNewGRFStringControlCode(char32_t scc, const char **str, TextRefStack &stack, std::vector<StringParameter> &params)
 {
-	auto it = std::back_inserter(params);
-
 	/* There is data on the NewGRF text stack, and we want to move them to OpenTTD's string stack.
 	 * After this call, a new call is made with `modify_parameters` set to false when the string is finally formatted. */
 	switch (scc) {
 		default: return;
-		case SCC_NEWGRF_PRINT_BYTE_SIGNED:      *it = stack.PopSignedByte();    break;
-		case SCC_NEWGRF_PRINT_QWORD_CURRENCY:   *it = stack.PopSignedQWord();   break;
+		case SCC_NEWGRF_PRINT_BYTE_SIGNED:      params.emplace_back(stack.PopSignedByte());    break;
+		case SCC_NEWGRF_PRINT_QWORD_CURRENCY:   params.emplace_back(stack.PopSignedQWord());   break;
 
 		case SCC_NEWGRF_PRINT_DWORD_CURRENCY:
-		case SCC_NEWGRF_PRINT_DWORD_SIGNED:     *it = stack.PopSignedDWord();   break;
+		case SCC_NEWGRF_PRINT_DWORD_SIGNED:     params.emplace_back(stack.PopSignedDWord());   break;
 
-		case SCC_NEWGRF_PRINT_BYTE_HEX:         *it = stack.PopUnsignedByte();  break;
-		case SCC_NEWGRF_PRINT_QWORD_HEX:        *it = stack.PopUnsignedQWord(); break;
+		case SCC_NEWGRF_PRINT_BYTE_HEX:         params.emplace_back(stack.PopUnsignedByte());  break;
+		case SCC_NEWGRF_PRINT_QWORD_HEX:        params.emplace_back(stack.PopUnsignedQWord()); break;
 
 		case SCC_NEWGRF_PRINT_WORD_SPEED:
 		case SCC_NEWGRF_PRINT_WORD_VOLUME_LONG:
 		case SCC_NEWGRF_PRINT_WORD_VOLUME_SHORT:
-		case SCC_NEWGRF_PRINT_WORD_SIGNED:      *it = stack.PopSignedWord();    break;
+		case SCC_NEWGRF_PRINT_WORD_SIGNED:      params.emplace_back(stack.PopSignedWord());    break;
 
 		case SCC_NEWGRF_PRINT_WORD_HEX:
 		case SCC_NEWGRF_PRINT_WORD_WEIGHT_LONG:
 		case SCC_NEWGRF_PRINT_WORD_WEIGHT_SHORT:
 		case SCC_NEWGRF_PRINT_WORD_POWER:
 		case SCC_NEWGRF_PRINT_WORD_STATION_NAME:
-		case SCC_NEWGRF_PRINT_WORD_UNSIGNED:    *it = stack.PopUnsignedWord();  break;
+		case SCC_NEWGRF_PRINT_WORD_UNSIGNED:    params.emplace_back(stack.PopUnsignedWord());  break;
 
 		case SCC_NEWGRF_PRINT_DWORD_FORCE:
 		case SCC_NEWGRF_PRINT_DWORD_DATE_LONG:
 		case SCC_NEWGRF_PRINT_DWORD_DATE_SHORT:
-		case SCC_NEWGRF_PRINT_DWORD_HEX:        *it = stack.PopUnsignedDWord(); break;
+		case SCC_NEWGRF_PRINT_DWORD_HEX:        params.emplace_back(stack.PopUnsignedDWord()); break;
 
 		/* Dates from NewGRFs have 1920-01-01 as their zero point, convert it to OpenTTD's epoch. */
 		case SCC_NEWGRF_PRINT_WORD_DATE_LONG:
-		case SCC_NEWGRF_PRINT_WORD_DATE_SHORT:  *it = CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR + stack.PopUnsignedWord(); break;
+		case SCC_NEWGRF_PRINT_WORD_DATE_SHORT:  params.emplace_back(CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR + stack.PopUnsignedWord()); break;
 
 		case SCC_NEWGRF_DISCARD_WORD:           stack.PopUnsignedWord(); break;
 
@@ -806,13 +804,13 @@ static void RemapNewGRFStringControlCode(char32_t scc, const char **str, TextRef
 		case SCC_NEWGRF_PRINT_WORD_CARGO_LONG:
 		case SCC_NEWGRF_PRINT_WORD_CARGO_SHORT:
 		case SCC_NEWGRF_PRINT_WORD_CARGO_TINY:
-			*it = GetCargoTranslation(stack.PopUnsignedWord(), stack.grffile);
-			*it = stack.PopUnsignedWord();
+			params.emplace_back(GetCargoTranslation(stack.PopUnsignedWord(), stack.grffile));
+			params.emplace_back(stack.PopUnsignedWord());
 			break;
 
 		case SCC_NEWGRF_PRINT_WORD_STRING_ID: {
 			StringID stringid = MapGRFStringID(stack.grffile->grfid, GRFStringID{stack.PopUnsignedWord()});
-			*it = stringid;
+			params.emplace_back(stringid);
 			/* We also need to handle the substring's stack usage. */
 			HandleNewGRFStringControlCodes(GetStringPtr(stringid), stack, params);
 			break;
@@ -820,7 +818,7 @@ static void RemapNewGRFStringControlCode(char32_t scc, const char **str, TextRef
 
 		case SCC_NEWGRF_PRINT_WORD_CARGO_NAME: {
 			CargoType cargo = GetCargoTranslation(stack.PopUnsignedWord(), stack.grffile);
-			*it = cargo < NUM_CARGO ? 1ULL << cargo : 0;
+			params.emplace_back(cargo < NUM_CARGO ? 1ULL << cargo : 0);
 			break;
 		}
 	}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Several pages of warnings produced when compiling with gcc 12.2.0, along the lines of:

```
In member function ‘constexpr std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::length() const [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’,
    inlined from ‘constexpr std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12/bits/basic_string.h:676:22,
    inlined from ‘constexpr std::__detail::__variant::_Uninitialized<_Type, false>::_Uninitialized(std::in_place_index_t<0>, _Args&& ...) [with _Args = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}; _Type = std::__cxx11::basic_string<char>]’ at /usr/include/c++/12/variant:250:4,
    inlined from ‘constexpr std::__detail::__variant::_Variadic_union<_First, _Rest ...>::_Variadic_union(std::in_place_index_t<0>, _Args&& ...) [with _Args = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}; _First = std::__cxx11::basic_string<char>; _Rest = {}]’ at /usr/include/c++/12/variant:385:4,
    inlined from ‘constexpr std::__detail::__variant::_Variadic_union<_First, _Rest ...>::_Variadic_union(std::in_place_index_t<_Np>, _Args&& ...) [with long unsigned int _Np = 1; _Args = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}; _First = long unsigned int; _Rest = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]’ at /usr/include/c++/12/variant:391:4,
    inlined from ‘constexpr std::__detail::__variant::_Variadic_union<_First, _Rest ...>::_Variadic_union(std::in_place_index_t<_Np>, _Args&& ...) [with long unsigned int _Np = 2; _Args = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}; _First = std::monostate; _Rest = {long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]’ at /usr/include/c++/12/variant:391:4,
    inlined from ‘constexpr void std::_Construct(_Tp*, _Args&& ...) [with _Tp = __detail::__variant::_Variadic_union<monostate, long unsigned int, __cxx11::basic_string<char, char_traits<char>, allocator<char> > >; _Args = {const in_place_index_t<2>&, __cxx11::basic_string<char, char_traits<char>, allocator<char> >}]’ at /usr/include/c++/12/bits/stl_construct.h:119:7,
    inlined from ‘std::__detail::__variant::_Move_ctor_base<false, std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::_Move_ctor_base(std::__detail::__variant::_Move_ctor_base<false, std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >&&)::<lambda(auto:22&&, auto:23)> mutable [with auto:22 = std::__cxx11::basic_string<char>; auto:23 = std::integral_constant<long unsigned int, 2>]’ at /usr/include/c++/12/variant:605:23,
    inlined from ‘constexpr _Res std::__invoke_impl(__invoke_other, _Fn&&, _Args&& ...) [with _Res = void; _Fn = __detail::__variant::_Move_ctor_base<false, monostate, long unsigned int, __cxx11::basic_string<char, char_traits<char>, allocator<char> > >::_Move_ctor_base(std::__detail::__variant::_Move_ctor_base<false, std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >&&)::<lambda(auto:22&&, auto:23)>; _Args = {__cxx11::basic_string<char, char_traits<char>, allocator<char> >, integral_constant<long unsigned int, 2>}]’ at /usr/include/c++/12/bits/invoke.h:61:36,
    inlined from ‘constexpr typename std::__invoke_result<_Functor, _ArgTypes>::type std::__invoke(_Callable&&, _Args&& ...) [with _Callable = __detail::__variant::_Move_ctor_base<false, monostate, long unsigned int, __cxx11::basic_string<char, char_traits<char>, allocator<char> > >::_Move_ctor_base(std::__detail::__variant::_Move_ctor_base<false, std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >&&)::<lambda(auto:22&&, auto:23)>; _Args = {__cxx11::basic_string<char, char_traits<char>, allocator<char> >, integral_constant<long unsigned int, 2>}]’ at /usr/include/c++/12/bits/invoke.h:96:40,
    inlined from ‘static constexpr decltype(auto) std::__detail::__variant::__gen_vtable_impl<std::__detail::__variant::_Multi_array<_Result_type (*)(_Visitor, _Variants ...)>, std::integer_sequence<long unsigned int, __indices ...> >::__visit_invoke(_Visitor&&, _Variants ...) [with _Result_type = std::__detail::__variant::__variant_idx_cookie; _Visitor = std::__detail::__variant::_Move_ctor_base<false, std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::_Move_ctor_base(std::__detail::__variant::_Move_ctor_base<false, std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >&&)::<lambda(auto:22&&, auto:23)>&&; _Variants = {std::variant<std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >&&}; long unsigned int ...__indices = {2}]’ at /usr/include/c++/12/variant:1020:17,
    inlined from ‘constexpr decltype(auto) std::__do_visit(_Visitor&&, _Variants&& ...) [with _Result_type = __detail::__variant::__variant_idx_cookie; _Visitor = __detail::__variant::_Move_ctor_base<false, monostate, long unsigned int, __cxx11::basic_string<char, char_traits<char>, allocator<char> > >::_Move_ctor_base(std::__detail::__variant::_Move_ctor_base<false, std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >&&)::<lambda(auto:22&&, auto:23)>; _Variants = {variant<monostate, long unsigned int, __cxx11::basic_string<char, char_traits<char>, allocator<char> > >}]’ at /usr/include/c++/12/variant:1785:5,
    inlined from ‘constexpr decltype(auto) std::__do_visit(_Visitor&&, _Variants&& ...) [with _Result_type = __detail::__variant::__variant_idx_cookie; _Visitor = __detail::__variant::_Move_ctor_base<false, monostate, long unsigned int, __cxx11::basic_string<char, char_traits<char>, allocator<char> > >::_Move_ctor_base(std::__detail::__variant::_Move_ctor_base<false, std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >&&)::<lambda(auto:22&&, auto:23)>; _Variants = {variant<monostate, long unsigned int, __cxx11::basic_string<char, char_traits<char>, allocator<char> > >}]’ at /usr/include/c++/12/variant:1729:5,
    inlined from ‘constexpr void std::__detail::__variant::__raw_idx_visit(_Visitor&&, _Variants&& ...) [with _Visitor = _Move_ctor_base<false, std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::_Move_ctor_base(std::__detail::__variant::_Move_ctor_base<false, std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >&&)::<lambda(auto:22&&, auto:23)>; _Variants = {std::variant<std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >}]’ at /usr/include/c++/12/variant:184:44,
    inlined from ‘constexpr std::__detail::__variant::_Move_ctor_base<<anonymous>, _Types>::_Move_ctor_base(std::__detail::__variant::_Move_ctor_base<<anonymous>, _Types>&&) [with bool <anonymous> = false; _Types = {std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]’ at /usr/include/c++/12/variant:600:28,
    inlined from ‘constexpr std::__detail::__variant::_Copy_assign_base<<anonymous>, _Types>::_Copy_assign_base(std::__detail::__variant::_Copy_assign_base<<anonymous>, _Types>&&) [with bool <anonymous> = false; _Types = {std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]’ at /usr/include/c++/12/variant:665:7,
    inlined from ‘constexpr std::__detail::__variant::_Move_assign_base<<anonymous>, _Types>::_Move_assign_base(std::__detail::__variant::_Move_assign_base<<anonymous>, _Types>&&) [with bool <anonymous> = false; _Types = {std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]’ at /usr/include/c++/12/variant:719:7,
    inlined from ‘constexpr std::__detail::__variant::_Variant_base<_Types>::_Variant_base(std::__detail::__variant::_Variant_base<_Types>&&) [with _Types = {std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]’ at /usr/include/c++/12/variant:750:7,
    inlined from ‘constexpr std::variant<_Types>::variant(std::variant<_Types>&&) [with _Types = {std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]’ at /usr/include/c++/12/variant:1404:7,
    inlined from ‘constexpr StringParameter::StringParameter(StringParameter&&)’ at /home/petern/src/openttd/src/strings_type.h:78:8,
    inlined from ‘constexpr decltype (::new(void*(0)) _Tp) std::construct_at(_Tp*, _Args&& ...) [with _Tp = StringParameter; _Args = {StringParameter}]’ at /usr/include/c++/12/bits/stl_construct.h:97:14,
    inlined from ‘static constexpr void std::allocator_traits<std::allocator<_Up> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = StringParameter; _Args = {StringParameter}; _Tp = StringParameter]’ at /usr/include/c++/12/bits/alloc_traits.h:518:21,
    inlined from ‘constexpr std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::emplace_back(_Args&& ...) [with _Args = {StringParameter}; _Tp = StringParameter; _Alloc = std::allocator<StringParameter>]’ at /usr/include/c++/12/bits/vector.tcc:117:30,
    inlined from ‘constexpr void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = StringParameter; _Alloc = std::allocator<StringParameter>]’ at /usr/include/c++/12/bits/stl_vector.h:1294:21,
    inlined from ‘constexpr std::back_insert_iterator<_Container>& std::back_insert_iterator<_Container>::operator=(typename _Container::value_type&&) [with _Container = std::vector<StringParameter>]’ at /usr/include/c++/12/bits/stl_iterator.h:743:22,
    inlined from ‘void RemapNewGRFStringControlCode(char32_t, const char**, TextRefStack&, std::vector<StringParameter>&)’ at /home/petern/src/openttd/src/newgrf_text.cpp:771:69:
/usr/include/c++/12/bits/basic_string.h:1071:16: warning: ‘*(const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*)((char*)&<unnamed> + offsetof(value_type, StringParameter::data.std::variant<std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::<unnamed>.std::__detail::__variant::_Variant_base<std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::<unnamed>.std::__detail::__variant::_Move_assign_base<false, std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::<unnamed>.std::__detail::__variant::_Copy_assign_base<false, std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::<unnamed>.std::__detail::__variant::_Move_ctor_base<false, std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::<unnamed>.std::__detail::__variant::_Copy_ctor_base<false, std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::<unnamed>.std::__detail::__variant::_Variant_storage<false, std::monostate, long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::_M_u)).std::__cxx11::basic_string<char>::_M_string_length’ may be used uninitialized [-Wmaybe-uninitialized]
 1071 |       { return _M_string_length; }
      |                ^~~~~~~~~~~~~~~~
/home/petern/src/openttd/src/newgrf_text.cpp: In function ‘void RemapNewGRFStringControlCode(char32_t, const char**, TextRefStack&, std::vector<StringParameter>&)’:
/home/petern/src/openttd/src/newgrf_text.cpp:771:83: note: ‘<anonymous>’ declared here
  771 |                 case SCC_NEWGRF_PRINT_BYTE_SIGNED:      *it = stack.PopSignedByte();    break;
```

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Seems gcc is unhappy with using `std::back_inserter`, as these warnings do not appear if we just call `params.emplace_back()` instead. They don't appear with clang.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
