### PR TITLE
Codefix: check the result of dynamic_cast for nullptr

### DIFF
--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -1156,6 +1156,7 @@ void ShowQuery(EncodedString &&caption, EncodedString &&message, Window *parent,
 		if (w->window_class != WC_CONFIRM_POPUP_QUERY) continue;
 
 		QueryWindow *qw = dynamic_cast<QueryWindow *>(w);
+		assert(qw != nullptr);
 		if (qw->parent != parent || qw->proc != callback) continue;
 
 		qw->Close();

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1925,6 +1925,7 @@ static void NewGRFConfirmationCallback(Window *w, bool confirmed)
 		CloseWindowByClass(WC_GRF_PARAMETERS);
 		CloseWindowByClass(WC_TEXTFILE);
 		NewGRFWindow *nw = dynamic_cast<NewGRFWindow*>(w);
+		assert(nw != nullptr);
 
 		_gamelog.StartAction(GLAT_GRF);
 		_gamelog.GRFUpdate(_grfconfig, nw->actives); // log GRF changes

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -1441,7 +1441,9 @@ public:
 			NWidgetBase *nwid = it->get();
 			nwid->current_x = 0; /* Hide widget, it will be revealed in the next step. */
 			if (nwid->type == NWID_SPACER) continue;
-			lookup[dynamic_cast<NWidgetCore *>(nwid)->GetIndex()] = std::distance(this->children.begin(), it);
+			NWidgetCore *nwc = dynamic_cast<NWidgetCore *>(nwid);
+			assert(nwc != nullptr);
+			lookup[nwc->GetIndex()] = std::distance(this->children.begin(), it);
 		}
 
 		/* Now assign the widgets to their rightful place */

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -530,6 +530,7 @@ void Window::RaiseButtons(bool autoraise)
 	for (auto &pair : this->widget_lookup) {
 		WidgetType type = pair.second->type;
 		NWidgetCore *wid = dynamic_cast<NWidgetCore *>(pair.second);
+		assert(wid != nullptr);
 		if (((type & ~WWB_PUSHBUTTON) < WWT_LAST || type == NWID_PUSHBUTTON_DROPDOWN) &&
 				(!autoraise || (type & WWB_PUSHBUTTON) || type == WWT_EDITBOX) && wid->IsLowered()) {
 			wid->SetLowered(false);


### PR DESCRIPTION
## Motivation / Problem

`dynamic_cast` might return `nullptr`, so assert that they are not not `nullptr`.


## Description

Add assert to check for `nullptr`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
