### PR TITLE
Codefix: do not pass invalid file descriptor to fdatasync

### DIFF
--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -82,6 +82,7 @@ bool IniFile::SaveToDisk(const std::string &filename)
  */
 #if defined(_POSIX_SYNCHRONIZED_IO) && _POSIX_SYNCHRONIZED_IO > 0
 	int f = open(file_new.c_str(), O_RDWR);
+	if (f < 0) return false;
 	int ret = fdatasync(f);
 	close(f);
 	if (ret != 0) return false;


### PR DESCRIPTION
## Motivation / Problem

If we can't open a file, trying to `fdatasync` or `close` it are going to fail as well.


## Description

Bail out early if we can't open the file.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
