### PR TITLE
Codefix: data race in case of a spurious wake up

### DIFF
--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -83,7 +83,7 @@ struct PacketWriter : SaveFilter {
 	{
 		std::unique_lock<std::mutex> lock(this->mutex);
 
-		if (this->cs != nullptr) this->exit_sig.wait(lock);
+		while (this->cs != nullptr) this->exit_sig.wait(lock);
 
 		/* This must all wait until the Destroy function is called. */
 


### PR DESCRIPTION
## Motivation / Problem

`wait` on `std::condition_variable` could be unblocked spuriously.


## Description

Instead of using `if` to wait, use `while` so when a spurious unblock happens we just start waiting again.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
