### PR TITLE
Codefix: do not dereference the std::end() iterator

### DIFF
--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -679,7 +679,7 @@ static std::vector<char> Gunzip(std::span<char> input)
 		 * inflate is out of output space - allocate more */
 		z.avail_out += BLOCKSIZE;
 		output.resize(output.size() + BLOCKSIZE);
-		z.next_out = reinterpret_cast<Bytef *>(&*output.end() - z.avail_out);
+		z.next_out = reinterpret_cast<Bytef *>(output.data() + output.size() - z.avail_out);
 		res = inflate(&z, Z_FINISH);
 	}
 
@@ -717,7 +717,7 @@ static std::vector<char> Xunzip(std::span<char> input)
 		 * inflate is out of output space - allocate more */
 		z.avail_out += BLOCKSIZE;
 		output.resize(output.size() + BLOCKSIZE);
-		z.next_out = reinterpret_cast<uint8_t *>(&*output.end() - z.avail_out);
+		z.next_out = reinterpret_cast<uint8_t *>(output.data() + output.size() - z.avail_out);
 		res = lzma_code(&z, LZMA_FINISH);
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Dereferencing `std::end` is undefined behaviour.
I seem to remember that MSVC debug builds actually trigger a crash when trying to dereference `std::end`.


## Description

Use a different method to calculate the needed pointer.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
