### PR TITLE
Codefix: possible out-of-bounds array indexing

### DIFF
--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -443,11 +443,11 @@ std::unique_ptr<const ICUParagraphLayout::Line> ICUParagraphLayout::NextLine(int
 		size_t index;
 		if ((overflow_run->level & 1) == 0) {
 			/* LTR */
-			for (index = overflow_run->glyphs.size(); index > 0; index--) {
-				cur_width -= overflow_run->advance[index - 1];
+			for (index = overflow_run->glyphs.size(); index > 0; /* nothing */) {
+				--index;
+				cur_width -= overflow_run->advance[index];
 				if (cur_width <= max_width) break;
 			}
-			index--;
 		} else {
 			/* RTL */
 			for (index = 0; index < overflow_run->glyphs.size(); index++) {


### PR DESCRIPTION
## Motivation / Problem

In the ICU layouter, there is a theoretical path where an array is indexed by (essentially) -1.

In a for loop we count down from `index = x.size()` to `x > 0`. Within the loop we break based on the width of the string, and after the loop we decrement `index` one more because `index` is the loop is actually off-by-one. 
In theory, we could never break the loop and let `index` run down to 0, then the decrement after the loop will make it `2**64-1`. That index is later used to index into some container.


## Description

Since the loop itself indexes a variable by `index - 1`, I moved the `--index` into the loop. That way we don't double-decrement the value at the end of the loop.


## Limitations

I thought about the simpler variant with just a `for (index = overflow_run->glyphs.size() - 1; index > 0; index--)`, but that'll run into a similar underflow issue.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
