### PR TITLE
Fix: GenerateCompanyName sends incorrect renaming event

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -431,6 +431,7 @@ bad_town_name:;
 	if (c->president_name_1 == SPECSTR_PRESIDENT_NAME) {
 		str = SPECSTR_ANDCO_NAME;
 		strp = c->president_name_2;
+		name = GetString(str, strp);
 		goto set_name;
 	} else {
 		str = SPECSTR_ANDCO_NAME;


### PR DESCRIPTION
Codefix: Send correct CompanyRenamedEvent when generating company name

## Motivation / Problem

When a new company name is *generated* a string is set that is sent with the CompanyRenamedEvent, even if that string is an invalid company name and the eventual generated name in actuality becomes something else.

## Description

The string "name" is generated with GetString(str, strp), and then validated. If invalid then new values are assigned to str and strp, but the CompanyRenamedEvent still sent the "name" value.

The fix sets the "name" variable to GetString(str, strp) when these two variables have been assigned new values, before the event is sent.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
