### PR TITLE
Codefix: check return values of certain functions

### DIFF
--- a/src/network/core/os_abstraction.cpp
+++ b/src/network/core/os_abstraction.cpp
@@ -27,8 +27,9 @@
 /**
  * Construct the network error with the given error code.
  * @param error The error code.
+ * @param message The error message. Leave empty to determine this automatically based on the error number.
  */
-NetworkError::NetworkError(int error) : error(error)
+NetworkError::NetworkError(int error, const std::string &message) : error(error), message(message)
 {
 }
 
@@ -185,7 +186,7 @@ NetworkError GetSocketError(SOCKET d)
 {
 	int err;
 	socklen_t len = sizeof(err);
-	getsockopt(d, SOL_SOCKET, SO_ERROR, (char *)&err, &len);
+	if (getsockopt(d, SOL_SOCKET, SO_ERROR, (char *)&err, &len) != 0) return NetworkError(-1, "Could not get error for socket");
 
 	return NetworkError(err);
 }

--- a/src/network/core/os_abstraction.h
+++ b/src/network/core/os_abstraction.h
@@ -23,7 +23,7 @@ private:
 	int error;                   ///< The underlying error number from errno or WSAGetLastError.
 	mutable std::string message; ///< The string representation of the error (set on first call to #AsString).
 public:
-	NetworkError(int error);
+	NetworkError(int error, const std::string &message = {});
 
 	bool HasError() const;
 	bool WouldBlock() const;

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2110,7 +2110,7 @@ static void SlLoadChunk(const ChunkHandler &ch)
 	/* The header should always be at the start. Read the length; the
 	 * Load() should as first action process the header. */
 	if (_sl.expect_table_header) {
-		SlIterateArray();
+		if (SlIterateArray() != INT32_MAX) SlErrorCorrupt("Table chunk without header");
 	}
 
 	switch (_sl.block_mode) {
@@ -2163,7 +2163,7 @@ static void SlLoadCheckChunk(const ChunkHandler &ch)
 	/* The header should always be at the start. Read the length; the
 	 * LoadCheck() should as first action process the header. */
 	if (_sl.expect_table_header) {
-		SlIterateArray();
+		if (SlIterateArray() != INT32_MAX) SlErrorCorrupt("Table chunk without header");
 	}
 
 	switch (_sl.block_mode) {


### PR DESCRIPTION
## Motivation / Problem

Coverity complaining that there are 'unchecked return values'.


## Description

saveload: actually check whether the call to `SlIterateArray` yields the expected return value for having 'consumed' the chunk's table header.

http_curl: `curl_easy_setopt` might return an error when an API function is unknown or changed. Log using `Debug` when this happens, so if something changes we have more 'debugging' tools. If a message about a changed API is on the console, that'll likely be more helpful than the download not working at all.

os_abstraction: when there is some reason to call `GetSocketError`, then we basically know something has gone awry. However, when things are broken enough that `getsockopt` fails the returned error has an uninitialized `error` which might mean anything or even 'no error' when it's zero. So check `getsockopt` for a failure, and if so return an error with preset error message.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
