### PR TITLE
Codefix: potential dangling pointer in strgen

### DIFF
--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -39,16 +39,16 @@ struct LangString {
 
 /** Information about the currently known strings. */
 struct StringData {
-	std::vector<std::unique_ptr<LangString>> strings; ///< List of all known strings.
-	std::unordered_map<std::string_view, LangString *> name_to_string; ///< Lookup table for the strings.
+	std::vector<std::shared_ptr<LangString>> strings; ///< List of all known strings.
+	std::unordered_map<std::string, std::shared_ptr<LangString>> name_to_string; ///< Lookup table for the strings.
 	size_t tabs;          ///< The number of 'tabs' of strings.
 	size_t max_strings;   ///< The maximum number of strings.
 	size_t next_string_id;///< The next string ID to allocate.
 
 	StringData(size_t tabs);
 	void FreeTranslation();
-	void Add(std::unique_ptr<LangString> ls);
-	LangString *Find(const std::string_view s);
+	void Add(std::shared_ptr<LangString> ls);
+	LangString *Find(const std::string &s);
 	uint VersionHashStr(uint hash, const char *s) const;
 	uint Version() const;
 	uint CountInUse(uint tab) const;

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -85,10 +85,10 @@ void StringData::FreeTranslation()
  * @param s  The name of the string.
  * @param ls The string to add.
  */
-void StringData::Add(std::unique_ptr<LangString> ls)
+void StringData::Add(std::shared_ptr<LangString> ls)
 {
-	this->name_to_string[ls->name] = ls.get();
-	this->strings[ls->index].swap(ls);
+	this->name_to_string[ls->name] = ls;
+	this->strings[ls->index] = std::move(ls);
 }
 
 /**
@@ -96,12 +96,12 @@ void StringData::Add(std::unique_ptr<LangString> ls)
  * @param s The string name to search on.
  * @return The LangString or nullptr if it is not known.
  */
-LangString *StringData::Find(const std::string_view s)
+LangString *StringData::Find(const std::string &s)
 {
 	auto it = this->name_to_string.find(s);
 	if (it == this->name_to_string.end()) return nullptr;
 
-	return it->second;
+	return it->second.get();
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

In strgen there is a map from `string_view` to a pointer to `LangString` and a vector of `unique_ptr`s of `LangString`.
When doing `StringData::Add`, the pointer to the `LangString` gets added to the map with a `string_view` of the name in the string. Then an element in the vector is swapped out for the `LangString` based on its index.

If you add a copy of the `LangString` to the `StringData`, the value of the map and the value in the vector will be replaced. The key of the map will not, and will now refer to the removed element. This will make the key of the map essentially a dangling pointer.

Also, if you add a `LangString` with the index of an earlier added `LangString` but a different name, then an element in the vector will be replaced and there will be a dangling pointer to a `LangString` in the map.


## Description

Use `std::string` instead of `std::string_view` as key for the map.
Use `std::shared_ptr` and use that as value for both the map and vector.


## Limitations

Mostly theoretical because the current code does not trigger it, but Coverity thinks this is a high impact issue.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
