### PR TITLE
Codefix: potential integer overflow before widening integer

### DIFF
--- a/src/ground_vehicle.cpp
+++ b/src/ground_vehicle.cpp
@@ -110,7 +110,7 @@ int GroundVehicle<T, Type>::GetAcceleration() const
 	int64_t speed = v->GetCurrentSpeed(); // [km/h-ish]
 
 	/* Weight is stored in tonnes. */
-	int32_t mass = this->gcache.cached_weight;
+	int64_t mass = this->gcache.cached_weight;
 
 	/* Power is stored in HP, we need it in watts.
 	 * Each vehicle can have U16 power, 128 vehicles, HP -> watt


### PR DESCRIPTION
## Motivation / Problem

Coverity complaining about a potential overflow.


## Description

When calculating the resistance we multiply mass and rolling resistance, both 32 bit integer numbers.
Rolling resistance can be about 2000.
Mass can be 255 tons per vehicle + 255*(255/16)*255 tons of cargo (units of cargo * weight in tonnes * freight multiplier) per vehicle. That's about 1 million.
Now consider there can be 64 tile long trains, so 64 * 16 1/8th long trains => about 1000 vehicles.

The 1000 * 1 million gets quite close to the int32 limit for mass.
Multiplying it by the rolling resistance of 2000 gets you way over that limit.

Since all calculations using mass already get converted to `int64_t`, just changing mass to `int64_t` will solve the potential overflow and won't influence the other calls.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
