### PR TITLE
Codefix: remove some logically dead code

### DIFF
--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -289,7 +289,7 @@ public:
 			return result;
 		}
 
-		return INVALID_TRACKDIR;
+		NOT_REACHED();
 	}
 
 	/**

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -657,8 +657,6 @@ CommandCost CmdBuildRoad(DoCommandFlags flags, TileIndex tile, RoadBits pieces, 
 					if ((existing & pieces) == pieces) {
 						/* We only want to set the (dis)allowed road directions */
 						if (toggle_drd != DRD_NONE && rtt == RTT_ROAD) {
-							if (crossing) return CommandCost(STR_ERROR_ONEWAY_ROADS_CAN_T_HAVE_JUNCTION);
-
 							Owner owner = GetRoadOwner(tile, rtt);
 							if (owner != OWNER_NONE) {
 								CommandCost ret = CheckOwnership(owner, tile);


### PR DESCRIPTION
## Motivation / Problem

Coverity has found some 'logically dead code'.


## Description

road_cmd: the removed branch will only be taken when `crossing == true`, `toggle_drd != DRD_NONE` and `rtt == RTT_ROAD`. The check after setting `crossing` will also be taken with those states, so the function will be returned there and the removed branch will never be taken.

yapf_ship: there is no `break` in the loop, there is a `continue` but only when `attempt == 0` and the last statement of the loop is a `return`. So, the `return` outside the loop can never be reached. Just annotate that with `NOT_REACHED()` to make it obvious.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
