### PR TITLE
Codefix: add move operators to SQObjectPtr

### DIFF
--- a/src/3rdparty/squirrel/squirrel/sqobject.h
+++ b/src/3rdparty/squirrel/squirrel/sqobject.h
@@ -161,6 +161,14 @@ struct SQObjectPtr : public SQObject
 		_unVal=o._unVal;
 		__AddRef(_type,_unVal);
 	}
+	SQObjectPtr(SQObjectPtr &&o)
+	{
+		SQ_OBJECT_RAWINIT()
+		this->_type = OT_NULL;
+		this->_unVal.pUserPointer = nullptr;
+		std::swap(this->_type, o._type);
+		std::swap(this->_unVal, o._unVal);
+	}
 	SQObjectPtr(const SQObject &o)
 	{
 		SQ_OBJECT_RAWINIT()
@@ -328,6 +336,12 @@ struct SQObjectPtr : public SQObject
 		_type = obj._type;
 		__AddRef(_type,_unVal);
 		__Release(tOldType,unOldVal);
+		return *this;
+	}
+	inline SQObjectPtr& operator=(SQObjectPtr &&obj)
+	{
+		std::swap(this->_type, obj._type);
+		std::swap(this->_unVal, obj._unVal);
 		return *this;
 	}
 	inline SQObjectPtr& operator=(const SQObject& obj)


### PR DESCRIPTION
## Motivation / Problem

Coverity complaining about the missing move operator/constructor.

There are a few places where an object gets constructed and immediately assigned to something else. Without the move operator/constructor, that means besides copying data also updating the reference count on two objects. With the move operator/constructor, we can just swap two values and we don't need to do reference count updates.


## Description

Implement them.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
