### PR TITLE
Codefix: move or pass by reference instead of copy

### DIFF
--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -454,7 +454,7 @@ static bool RealMakeScreenshot(ScreenshotType t, const std::string &name, uint32
  * @return true iff the screenshot was successfully made.
  * @see MakeScreenshotWithConfirm
  */
-bool MakeScreenshot(ScreenshotType t, std::string name, uint32_t width, uint32_t height)
+bool MakeScreenshot(ScreenshotType t, const std::string &name, uint32_t width, uint32_t height)
 {
 	if (t == SC_CRASHLOG) {
 		/* Video buffer might or might not be locked. */

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -26,7 +26,7 @@ enum ScreenshotType : uint8_t {
 void SetupScreenshotViewport(ScreenshotType t, struct Viewport *vp, uint32_t width = 0, uint32_t height = 0);
 bool MakeHeightmapScreenshot(const char *filename);
 void MakeScreenshotWithConfirm(ScreenshotType t);
-bool MakeScreenshot(ScreenshotType t, std::string name, uint32_t width = 0, uint32_t height = 0);
+bool MakeScreenshot(ScreenshotType t, const std::string &name, uint32_t width = 0, uint32_t height = 0);
 bool MakeMinimapWorldScreenshot();
 
 extern std::string _screenshot_format_name;

--- a/src/script/api/script_admin.cpp
+++ b/src/script/api/script_admin.cpp
@@ -91,7 +91,7 @@ bool ScriptAdminMakeJSON(nlohmann::json &json, HSQUIRRELVM vm, SQInteger index, 
 					return false;
 				}
 
-				json[key] = std::move(value);
+				json[std::move(key)] = std::move(value);
 			}
 			sq_pop(vm, 1);
 			return true;


### PR DESCRIPTION
## Motivation / Problem

Why copy when we can move or pass by reference?


## Description

Remove the copy.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
