### PR TITLE
Codefix: uninitialized variables in fmt

### DIFF
--- a/src/3rdparty/fmt/base.h
+++ b/src/3rdparty/fmt/base.h
@@ -1719,7 +1719,7 @@ class format_string_checker {
 /// internal class and shouldn't be used directly, only via `memory_buffer`.
 template <typename T> class buffer {
  private:
-  T* ptr_;
+  T* ptr_ = nullptr;
   size_t size_;
   size_t capacity_;
 

--- a/src/3rdparty/fmt/chrono.h
+++ b/src/3rdparty/fmt/chrono.h
@@ -538,7 +538,7 @@ FMT_BEGIN_EXPORT
 inline auto localtime(std::time_t time) -> std::tm {
   struct dispatcher {
     std::time_t time_;
-    std::tm tm_;
+    std::tm tm_{};
 
     inline dispatcher(std::time_t t) : time_(t) {}
 
@@ -589,7 +589,7 @@ inline auto localtime(std::chrono::local_time<Duration> time) -> std::tm {
 inline auto gmtime(std::time_t time) -> std::tm {
   struct dispatcher {
     std::time_t time_;
-    std::tm tm_;
+    std::tm tm_{};
 
     inline dispatcher(std::time_t t) : time_(t) {}
 


### PR DESCRIPTION
## Motivation / Problem

Coverity found some uninitialized variables in the fmt code.


## Description

Just initialized them.


## Limitations

At leat some of  them (I haven't checked them all), are fixed in the 11 release of fmt. However, when trying to update fmt I run into issues with intrinsics in one of the blitters. I've got no clue how to solve that, so I bailed out and went for the easier route.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
