### PR TITLE
Fix: NewGRF string interpolation did not process all string parameters, if certain string control codes were present.

### DIFF
--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -758,7 +758,7 @@ static void HandleNewGRFStringControlCodes(const char *str, TextRefStack &stack,
  * @param stack The TextRefStack.
  * @param[out] params Output parameters
  */
-static void RemapNewGRFStringControlCode(char32_t scc, const char **str, TextRefStack &stack, std::vector<StringParameter> &params)
+static void ProcessNewGRFStringControlCode(char32_t scc, const char *&str, TextRefStack &stack, std::vector<StringParameter> &params)
 {
 	/* There is data on the NewGRF text stack, and we want to move them to OpenTTD's string stack.
 	 * After this call, a new call is made with `modify_parameters` set to false when the string is finally formatted. */
@@ -797,7 +797,7 @@ static void RemapNewGRFStringControlCode(char32_t scc, const char **str, TextRef
 		case SCC_NEWGRF_DISCARD_WORD:           stack.PopUnsignedWord(); break;
 
 		case SCC_NEWGRF_ROTATE_TOP_4_WORDS:     stack.RotateTop4Words(); break;
-		case SCC_NEWGRF_PUSH_WORD:              stack.PushWord(Utf8Consume(str)); break;
+		case SCC_NEWGRF_PUSH_WORD:              stack.PushWord(Utf8Consume(&str)); break;
 
 		case SCC_NEWGRF_PRINT_WORD_CARGO_LONG:
 		case SCC_NEWGRF_PRINT_WORD_CARGO_SHORT:
@@ -921,7 +921,7 @@ static void HandleNewGRFStringControlCodes(const char *str, TextRefStack &stack,
 	for (const char *p = str; *p != '\0'; /* nothing */) {
 		char32_t scc;
 		p += Utf8Decode(&scc, p);
-		RemapNewGRFStringControlCode(scc, &p, stack, params);
+		ProcessNewGRFStringControlCode(scc, p, stack, params);
 	}
 }
 

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -764,6 +764,40 @@ static void ProcessNewGRFStringControlCode(char32_t scc, const char *&str, TextR
 	 * After this call, a new call is made with `modify_parameters` set to false when the string is finally formatted. */
 	switch (scc) {
 		default: return;
+
+		case SCC_PLURAL_LIST:
+			++str; // plural form
+			[[fallthrough]];
+		case SCC_GENDER_LIST: {
+			++str; // offset
+			/* plural and gender choices cannot contain any string commands, so just skip the whole thing */
+			uint num = static_cast<uint8_t>(*str++);
+			uint total_len = 0;
+			for (uint i = 0; i != num; i++) {
+				total_len += static_cast<uint8_t>(*str++);
+			}
+			str += total_len;
+			break;
+		}
+
+		case SCC_SWITCH_CASE: {
+			/* skip all cases and continue with default case */
+			uint num = static_cast<uint8_t>(*str++);
+			for (uint i = 0; i != num; i++) {
+				str += 3 + (static_cast<uint8_t>(str[1]) << 8) + static_cast<uint8_t>(str[2]);
+			}
+			break;
+		}
+
+		case SCC_GENDER_INDEX:
+		case SCC_SET_CASE:
+			++str;
+			break;
+
+		case SCC_ARG_INDEX:
+			NOT_REACHED();
+			break;
+
 		case SCC_NEWGRF_PRINT_BYTE_SIGNED:      params.emplace_back(stack.PopSignedByte());    break;
 		case SCC_NEWGRF_PRINT_QWORD_CURRENCY:   params.emplace_back(stack.PopSignedQWord());   break;
 


### PR DESCRIPTION
## Motivation / Problem

String control codes with inline data may contain null characters, in particular plural/gender/case choice lists.
`HandleNewGRFStringControlCodes` processes a C string and thus aborts when encountering null.

Also, case choice lists were not handled correctly/at all.

## Description

Extend `ProcessNewGRFStringControlCode` to also handle control codes with inline data.

In particular also process case choise lists correctly:
* All cases are supposed to contain the same control codes.
* Only process the default case for parameter conversion.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
