### PR TITLE
Fix: Error message window timeout doesn't match setting

### DIFF
--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -107,7 +107,7 @@ public:
 	ErrmsgWindow(const ErrorMessageData &data) :
 		Window(data.HasFace() ? _errmsg_face_desc : _errmsg_desc),
 		ErrorMessageData(data),
-		display_timeout(std::chrono::seconds(3 * _settings_client.gui.errmsg_duration), [this]() {
+		display_timeout(std::chrono::seconds(_settings_client.gui.errmsg_duration), [this]() {
 			this->Close();
 		})
 	{


### PR DESCRIPTION
## Motivation / Problem

![image](https://github.com/user-attachments/assets/9c4739f3-262d-4409-aa88-e88b5ae300b9)

There is a setting for the duration of error messages. But the actual duration is three times higher.

## Description

Removed the times-3-multiplier. The duration now matches the configured value. 

IMO 5 seconds (the setting's default value) is a good default value so I did not change it. The old 3*5=15 seconds was too long if you ask me, but that's fixed now.

## Limitations

None

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
