### PR TITLE
Codefix: do not trust allocation sizes coming from a file

### DIFF
--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -203,6 +203,9 @@ static bool ReadTrackChunk(FileHandle &file, MidiFile &target)
 	}
 	chunk_length = FROM_BE32(chunk_length);
 
+	/* Limit chunk size to 1 MiB. */
+	if (chunk_length > 1024 * 1024) return false;
+
 	ByteBuffer chunk(file, chunk_length);
 	if (!chunk.IsValid()) {
 		return false;

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -9960,6 +9960,13 @@ static void LoadNewGRFFileFromFile(GRFConfig &config, GrfLoadingStage stage, Spr
 
 		if (type == 0xFF) {
 			if (_cur.skip_sprites == 0) {
+				/* Limit the special sprites to 1 MiB. */
+				if (num > 1024 * 1024) {
+					GrfMsg(0, "LoadNewGRFFile: Unexpectedly large sprite, disabling");
+					DisableGrf(STR_NEWGRF_ERROR_UNEXPECTED_SPRITE);
+					break;
+				}
+
 				DecodeSpecialSprite(buf.Allocate(num), num, stage);
 
 				/* Stop all processing if we are to skip the remaining sprites */


### PR DESCRIPTION
## Motivation / Problem

Coverity warning about untrusted allocation sizes.

We basically allow MIDI files and NewGRFs to allocate up to 4 GB of memory. For the NewGRF it's actually worse, because once allocated it will never be released.


## Description

Limit the memory for these chunks to 1 MiB.

For music the largest MIDI file in online content is about 190 kB. The largest useful MIDI file I could get a reference for is about 1.6 MB and 2.5 hours long. Also a quick internet search lets you find references like '130.000 MIDI files in 1 GB'. So, it's unlikely a reasonable MIDI for OpenTTD will come close to this chunk limit.


## Limitations

Well, it's adding them :)


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
