### PR TITLE
Codefix: potential division by zero in midi reader

### DIFF
--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -458,6 +458,8 @@ bool MidiFile::LoadFile(const std::string &filename)
 	if (header.format != 0 && header.format != 1) return false;
 	/* Doesn't support SMPTE timecode files */
 	if ((header.tickdiv & 0x8000) != 0) return false;
+	/* Ticks per beat / parts per quarter note should not be zero. */
+	if (header.tickdiv == 0) return false;
 
 	this->tickdiv = header.tickdiv;
 


### PR DESCRIPTION
## Motivation / Problem

Division by zero in `FixupMidiData` when `tickdiv` is zero.


## Description

Reject a MIDI file when the `tickdiv` is zero. Also known as 'PPQ'/'parts per quarter note' or 'ticks per beat'. Given those names, a value of zero would indeed be very strange.


## Limitations

I could not find any specification mentioning that zero is an invalid value. Though given the naming I'd argue it is forbidden.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
