### PR TITLE
Change: Error window colour changes based on severity

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -129,7 +129,7 @@ bool DriverFactoryBase::SelectDriverImpl(const std::string &name, Driver::Type t
 						Debug(driver, 1, "Probing {} driver '{}' skipped due to earlier crash", GetDriverTypeName(type), d->name);
 
 						_video_hw_accel = false;
-						ErrorMessageData msg(GetEncodedString(STR_VIDEO_DRIVER_ERROR), GetEncodedString(STR_VIDEO_DRIVER_ERROR_HARDWARE_ACCELERATION_CRASH), true);
+						ErrorMessageData msg(GetEncodedString(STR_VIDEO_DRIVER_ERROR), GetEncodedString(STR_VIDEO_DRIVER_ERROR_HARDWARE_ACCELERATION_CRASH), WL_CRITICAL);
 						ScheduleErrorMessage(std::move(msg));
 						continue;
 					}
@@ -155,7 +155,7 @@ bool DriverFactoryBase::SelectDriverImpl(const std::string &name, Driver::Type t
 
 				if (type == Driver::DT_VIDEO && _video_hw_accel && d->UsesHardwareAcceleration()) {
 					_video_hw_accel = false;
-					ErrorMessageData msg(GetEncodedString(STR_VIDEO_DRIVER_ERROR), GetEncodedString(STR_VIDEO_DRIVER_ERROR_NO_HARDWARE_ACCELERATION), true);
+					ErrorMessageData msg(GetEncodedString(STR_VIDEO_DRIVER_ERROR), GetEncodedString(STR_VIDEO_DRIVER_ERROR_NO_HARDWARE_ACCELERATION), WL_CRITICAL);
 					ScheduleErrorMessage(std::move(msg));
 				}
 			}

--- a/src/error.h
+++ b/src/error.h
@@ -30,7 +30,7 @@ enum WarningLevel : uint8_t {
 /** The data of the error message. */
 class ErrorMessageData {
 protected:
-	bool is_critical;               ///< Whether the error message is critical.
+	WarningLevel level; ///< Level of the error message (e.g. whether it's a critical error).
 	EncodedString summary_msg; ///< General error message showed in first line. Must be valid.
 	EncodedString detailed_msg; ///< Detailed error message showed in second line. Can be #INVALID_STRING_ID.
 	EncodedString extra_msg; ///< Extra error message shown in third line. Can be #INVALID_STRING_ID.
@@ -38,7 +38,7 @@ protected:
 	CompanyID company; ///< Company belonging to the face being shown. #CompanyID::Invalid() if no face present.
 
 public:
-	ErrorMessageData(EncodedString &&summary_msg, EncodedString &&detailed_msg, bool is_critical = false, int x = 0, int y = 0, EncodedString &&extra_msg = {}, CompanyID company = CompanyID::Invalid());
+	ErrorMessageData(EncodedString &&summary_msg, EncodedString &&detailed_msg, WarningLevel level = WL_ERROR, int x = 0, int y = 0, EncodedString &&extra_msg = {}, CompanyID company = CompanyID::Invalid());
 
 	/** Check whether error window shall display a company manager face */
 	bool HasFace() const { return company != CompanyID::Invalid(); }

--- a/src/widgets/error_widget.h
+++ b/src/widgets/error_widget.h
@@ -12,9 +12,11 @@
 
 /** Widgets of the #ErrmsgWindow class. */
 enum ErrorMessageWidgets : WidgetID {
-	WID_EM_CAPTION, ///< Caption of the window.
-	WID_EM_FACE,    ///< Error title.
-	WID_EM_MESSAGE, ///< Error message.
+	WID_EM_CAPTION,  ///< Caption of the window.
+	WID_EM_FACE,     ///< Error title.
+	WID_EM_MESSAGE,  ///< Error message.
+	WID_EM_CLOSEBOX, ///< Close box button.
+	WID_EM_PANEL,    ///< Coloured background panel.
 };
 
 #endif /* WIDGETS_ERROR_WIDGET_H */


### PR DESCRIPTION
## Motivation / Problem

![image](https://github.com/user-attachments/assets/90fdc036-9452-45ca-80dc-0d2884bf7358)

All error messages, including warnings and purely informative ones, are always drawn in red. Red gives off a strong you-did-something-wrong or something-went-wrong-vibe, which is not always appropriate. See the example above.


## Description

I've changed the logic of the error message window so that the color represents the severity of the message:

| Level | Color |
| -------- | ------- |
| WL_INFO| Green|
| WL_WARNING | Orange/Yellow |
| WL_ERROR | Red   |
| WL_CRITICAL | Red    |

Some examples:
![image](https://github.com/user-attachments/assets/04ccb5d7-5381-4594-a690-e219e7c7a651)
![image](https://github.com/user-attachments/assets/89103720-9ee3-48a8-baa4-4c820d43c2ed)
![image](https://github.com/user-attachments/assets/6197e4c0-b32e-406c-b25c-dbe653e77795)


## Limitations

This will undoubtedly uncover places where a strange warning/error level is used. One such example is the screenshot feature shown in one of the screenshots. If the message is purely informative, why is it a warning?

Alternatively we could go for two colors. Green for everything that is an error and green of everything else.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
