### PR TITLE
Codefix: potential check of thread-shared field evades lock acquisition

### DIFF
--- a/src/core/smallstack_type.hpp
+++ b/src/core/smallstack_type.hpp
@@ -191,8 +191,8 @@ public:
 	 */
 	inline void Push(const Titem &item)
 	{
+		std::lock_guard<std::mutex> lock(SmallStack::GetPool().GetMutex());
 		if (this->value != Tinvalid) {
-			std::lock_guard<std::mutex> lock(SmallStack::GetPool().GetMutex());
 			Tindex new_item = SmallStack::GetPool().Create();
 			if (new_item != Tmax_size) {
 				PooledSmallStack &pushed = SmallStack::GetPool().Get(new_item);
@@ -211,11 +211,11 @@ public:
 	 */
 	inline Titem Pop()
 	{
+		std::lock_guard<std::mutex> lock(SmallStack::GetPool().GetMutex());
 		Titem ret = this->value;
 		if (this->next == Tmax_size) {
 			this->value = Tinvalid;
 		} else {
-			std::lock_guard<std::mutex> lock(SmallStack::GetPool().GetMutex());
 			PooledSmallStack &popped = SmallStack::GetPool().Get(this->next);
 			this->value = popped.value;
 			if (popped.branch_count == 0) {


### PR DESCRIPTION
## Motivation / Problem

According to Coverity a high impact issue.

The data guarded by this critical section may be read while in an inconsistent state or modified by multiple racing threads.

In SmallStack<unsigned short, unsigned short, (unsigned short)65535, (unsigned short)8, (unsigned short)64000>::​Push(unsigned short const &): Checking the value of a thread-shared field outside of a locked region to determine if a locked operation involving that thread shared field has completed. 

```
192        inline void Push(const Titem &item)
193        {
      1. thread1_checks_field: Thread1 uses the value read from field value in the condition this->value != 65535. It sees that the condition is true. Control is switched to Thread2.
      2. thread2_checks_field: Thread2 uses the value read from field value in the condition this->value != 65535. It sees that the condition is true.
      Guard the modification of value and the read used to decide whether to modify value with the same set of locks.
194                if (this->value != Tinvalid) {
      3. thread2_acquires_lock: Thread2 acquires lock SmallStack<unsigned short, unsigned short, (unsigned short)65535, (unsigned short)8, (unsigned short)64000>::GetPool()->GetMutex().[show details]
      5. thread1_acquires_lock: Thread1 acquires lock SmallStack<unsigned short, unsigned short, (unsigned short)65535, (unsigned short)8, (unsigned short)64000>::GetPool()->GetMutex().
195                        std::lock_guard<std::mutex> lock(SmallStack::GetPool().GetMutex());
196                        Tindex new_item = SmallStack::GetPool().Create();
197                        if (new_item != Tmax_size) {
198                                PooledSmallStack &pushed = SmallStack::GetPool().Get(new_item);
      4. thread2_modifies_field: Thread2 sets value to a new value. Note that this write can be reordered at runtime to occur before instructions that do not access this field within this locked region. After Thread2 leaves the critical section, control is switched back to Thread1.
     
CID 1593199: (#1 of 1): Check of thread-shared field evades lock acquisition (LOCK_EVASION)
6. thread1_overwrites_value_in_field: Thread1 sets value to a new value. Now the two threads have an inconsistent view of value and updates to fields correlated with value may be lost.
199                                pushed.value = this->value;
200                                pushed.next = this->next;
201                                pushed.branch_count = 0;
202                                this->next = new_item;
203                        }
204                }
205                this->value = item;
206        }
```

And

```
212        inline Titem Pop()
213        {
214                Titem ret = this->value;
      1. thread1_checks_field: Thread1 uses the value read from field next in the condition this->next == 64000. It sees that the condition is false. Control is switched to Thread2.
      2. thread2_checks_field: Thread2 uses the value read from field next in the condition this->next == 64000. It sees that the condition is false.
      Guard the modification of next and the read used to decide whether to modify next with the same set of locks.
215                if (this->next == Tmax_size) {
216                        this->value = Tinvalid;
217                } else {
      3. thread2_acquires_lock: Thread2 acquires lock SmallStack<unsigned short, unsigned short, (unsigned short)65535, (unsigned short)8, (unsigned short)64000>::GetPool()->GetMutex().[show details]
      5. thread1_acquires_lock: Thread1 acquires lock SmallStack<unsigned short, unsigned short, (unsigned short)65535, (unsigned short)8, (unsigned short)64000>::GetPool()->GetMutex().
218                        std::lock_guard<std::mutex> lock(SmallStack::GetPool().GetMutex());
219                        PooledSmallStack &popped = SmallStack::GetPool().Get(this->next);
220                        this->value = popped.value;
221                        if (popped.branch_count == 0) {
222                                SmallStack::GetPool().Destroy(this->next);
223                        } else {
224                                --popped.branch_count;
225                                /* We can't use Branch() here as we already have the mutex.*/
226                                if (popped.next != Tmax_size) {
227                                        ++(SmallStack::GetPool().Get(popped.next).branch_count);
228                                }
229                        }
230                        /* Accessing popped here is no problem as the pool will only set
231                         * the validity flag, not actually delete the item, on Destroy().
232                         * It's impossible for another thread to acquire the same item in
233                         * the mean time because of the mutex. */
      4. thread2_modifies_field: Thread2 sets next to a new value. Note that this write can be reordered at runtime to occur before instructions that do not access this field within this locked region. After Thread2 leaves the critical section, control is switched back to Thread1.
     
CID 1593213: (#1 of 1): Check of thread-shared field evades lock acquisition (LOCK_EVASION)
6. thread1_overwrites_value_in_field: Thread1 sets next to a new value. Now the two threads have an inconsistent view of next and updates to fields correlated with next may be lost.
234                        this->next = popped.next;
235                }
236                return ret;
237        }
```


## Description

I have moved the existing locks up to cover the whole function, this way there can't be any inconsistency within those functions any more.


## Limitations

Can't think of any.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
