### PR TITLE
Codefix: do not use an invalid iterator

### DIFF
--- a/src/script/api/script_error.cpp
+++ b/src/script/api/script_error.cpp
@@ -25,7 +25,9 @@ ScriptError::ScriptErrorMapString ScriptError::error_map_string = ScriptError::S
 
 /* static */ std::optional<std::string> ScriptError::GetLastErrorString()
 {
-	return (*error_map_string.find(ScriptError::GetLastError())).second;
+	auto it = ScriptError::error_map_string.find(ScriptError::GetLastError());
+	assert(it != ScriptError::error_map_string.end());
+	return it->second;
 }
 
 /* static */ ScriptErrorType ScriptError::StringToError(StringID internal_string_id)


### PR DESCRIPTION
## Motivation / Problem

When getting the last error string we perform `find` on a `map`, but never check it against `end()` before dereferencing the iterator. In case we forget to register an error, this could lead to undefined behaviour.


## Description

Add an `assert` to check that we are about to dereference a valid iterator.


## Limitations

Does not perform the checks for a release-release build, but... hopefully unregistered error have been rooted out long before that.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
