### PR TITLE
Codefix: wrong type for choice list mapping

### DIFF
--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -121,7 +121,7 @@ struct UnmappedChoiceList {
 	int offset;             ///< The offset for the plural/gender form.
 
 	/** Mapping of NewGRF supplied ID to the different strings in the choice list. */
-	std::map<uint8_t, std::stringstream> strings;
+	std::map<int, std::stringstream> strings;
 
 	/**
 	 * Flush this choice list into the destination string.


### PR DESCRIPTION
## Motivation / Problem

Another Coverity inspired change.


CID 1593375: (2 of 3): Overflowed constant (INTEGER_OVERFLOW)
22. overflow_const: Expression <temporary>, where idx is known to be equal to -1, overflows the type of <temporary>, which is type std::map<unsigned char, std::__cxx11::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >, std::less<unsigned char>, std::allocator<std::pair<unsigned char const, std::__cxx11::basic_stringstream<char, std::char_traits<char>, std::allocator<char> > > > >::key_type const. 


## Description

Because `GetReverseMapping` return -1 and the key of the `strings` map is `uint8_t` there'll be an underflow or narrowing of the type. So, just use the type returned by `GetReverseMapping` as key in the map.


## Limitations

Mostly a theoretical affair. There aren't languages with (close to) 255 plurals/cases/choices yet.
On the other hand, changing the key's type doesn't change the allocated memory for the key.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
