### PR TITLE
Codechange: fix or remove fixmes

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -948,9 +948,6 @@ static bool AircraftController(Aircraft *v)
 		SetBit(v->flags, VAF_HELI_DIRECT_DESCENT);
 
 		if (st == nullptr) {
-			/* FIXME - AircraftController -> if station no longer exists, do not land
-			 * helicopter will circle until sign disappears, then go to next order
-			 * what to do when it is the only order left, right now it just stays in 1 place */
 			v->state = FLYING;
 			UpdateAircraftCache(v);
 			AircraftNextAirportPos_and_Order(v);

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -699,7 +699,6 @@ public:
 				this->list_pos = (server == nullptr) ? SLP_INVALID : it - this->servers.begin();
 				this->SetDirty();
 
-				/* FIXME the disabling should go into some InvalidateData, which is called instead of the SetDirty */
 				if (click_count > 1 && !this->IsWidgetDisabled(WID_NG_JOIN)) this->OnClick(pt, WID_NG_JOIN, 1);
 				break;
 			}
@@ -713,7 +712,6 @@ public:
 					this->ScrollToSelectedServer();
 					this->SetDirty();
 
-					/* FIXME the disabling should go into some InvalidateData, which is called instead of the SetDirty */
 					if (click_count > 1 && !this->IsWidgetDisabled(WID_NG_JOIN)) this->OnClick(pt, WID_NG_JOIN, 1);
 				}
 				break;

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -181,15 +181,6 @@ static void UpdateExclusiveRights()
 	for (Town *t : Town::Iterate()) {
 		t->exclusivity = CompanyID::Invalid();
 	}
-
-	/* FIXME old exclusive rights status is not being imported (stored in s->blocked_months_obsolete)
-	 *   could be implemented this way:
-	 * 1.) Go through all stations
-	 *     Build an array town_blocked[ town_id ][ company_id ]
-	 *     that stores if at least one station in that town is blocked for a company
-	 * 2.) Go through that array, if you find a town that is not blocked for
-	 *     one company, but for all others, then give it exclusivity.
-	 */
 }
 
 static const uint8_t convert_currency[] = {

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -585,11 +585,13 @@ uint32_t GetSmallMapOwnerPixels(TileIndex tile, TileType t, IncludeHeightmap inc
 		case MP_VOID:     return MKCOLOUR_XXXX(PC_BLACK);
 		case MP_INDUSTRY: return MKCOLOUR_XXXX(PC_DARK_GREY);
 		case MP_HOUSE:    return MKCOLOUR_XXXX(PC_DARK_RED);
-		default:          o = GetTileOwner(tile); break;
-		/* FIXME: For MP_ROAD there are multiple owners.
-		 * GetTileOwner returns the rail owner (level crossing) resp. the owner of ROADTYPE_ROAD (normal road),
-		 * even if there are no ROADTYPE_ROAD bits on the tile.
-		 */
+		case MP_ROAD:
+			o = GetRoadOwner(tile, HasRoadTypeRoad(tile) ? RTT_ROAD : RTT_TRAM);
+			break;
+
+		default:
+			o = GetTileOwner(tile);
+			break;
 	}
 
 	if ((o < MAX_COMPANIES && !_legend_land_owners[_company_to_list_pos[o]].show_on_map) || o == OWNER_NONE || o == OWNER_WATER) {

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3607,8 +3607,6 @@ static TrackStatus GetTileTrackStatus_Station(TileIndex tile, TransportType mode
 
 static void TileLoop_Station(TileIndex tile)
 {
-	/* FIXME -- GetTileTrackStatus_Station -> animated stationtiles
-	 * hardcoded.....not good */
 	switch (GetStationType(tile)) {
 		case StationType::Airport:
 			AirportTileAnimationTrigger(Station::GetByTile(tile), tile, AAT_TILELOOP);

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -901,7 +901,6 @@ static std::string &AddStringToDraw(int x, int y, Colours colour, ViewportString
  */
 static void DrawSelectionSprite(SpriteID image, PaletteID pal, const TileInfo *ti, int z_offset, FoundationPart foundation_part, int extra_offs_x = 0, int extra_offs_y = 0)
 {
-	/* FIXME: This is not totally valid for some autorail highlights that extend over the edges of the tile. */
 	if (_vd.foundation[foundation_part] == -1) {
 		/* draw on real ground */
 		AddTileSpriteToDraw(image, pal, ti->x, ti->y, ti->z + z_offset, nullptr, extra_offs_x, extra_offs_y);
@@ -1543,7 +1542,6 @@ void ViewportSign::MarkDirty(ZoomLevel maxzoom) const
 	const uint height = WidgetDimensions::scaled.fullbevel.top + std::max(GetCharacterHeight(FS_NORMAL), GetCharacterHeight(FS_SMALL)) + WidgetDimensions::scaled.fullbevel.bottom + 1;
 
 	for (ZoomLevel zoom = ZOOM_LVL_BEGIN; zoom != ZOOM_LVL_END; zoom++) {
-		/* FIXME: This doesn't switch to width_small when appropriate. */
 		zoomlevels[zoom].left   = this->center - ScaleByZoom(half_width, zoom);
 		zoomlevels[zoom].top    = this->top    - ScaleByZoom(1, zoom);
 		zoomlevels[zoom].right  = this->center + ScaleByZoom(half_width, zoom);


### PR DESCRIPTION
## Motivation / Problem

There are 8 `FIXME` comments.


## Description

In case of the smallmap the fix is relatively straight forward. It does change it to showing the road's owner over the rail's over for level crossings though, but... that is mostly due to the fact that the smallmap uses so-called 'effective' tile types which means bridges/tunnels get `MP_RAIL`/`MP_ROAD`/`MP_WATER`. Checking for level crossings would imply doing extra checks that might not be really necessary.

The network gui ones are referring to disabling code that does not seem to exist any more. Yes, it checks for a widget being disabled, but that is mostly to mimic clicking and normal clicking doesn't do anything when the widget is disabled.

The others are all more than a decade old and nobody seems to care to fix them, so why keep triggering static analysers on these comments? Is somebody really going to add some complicated savegame conversion for exclusivity in a version of more than 20 years ago?


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
