### PR TITLE
Codefix: remove unneeded looping logic

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -3765,7 +3765,6 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 
 				for (uint8_t j = 0; j < new_num_layouts; j++) {
 					layout.clear();
-					layout.reserve(new_num_layouts);
 
 					for (uint k = 0;; k++) {
 						if (bytes_read >= definition_size) {
@@ -3843,8 +3842,6 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 					if (!ValidateIndustryLayout(layout)) {
 						/* The industry layout was not valid, so skip this one. */
 						GrfMsg(1, "IndustriesChangeInfo: Invalid industry layout for industry id {}. Ignoring", id);
-						new_num_layouts--;
-						j--;
 					} else {
 						new_layouts.push_back(layout);
 					}


### PR DESCRIPTION
## Motivation / Problem

CodeQL warning about 'For loop variable changed in body'.


## Description

The loop in question updates both the iterator `j` and the limit `new_num_layouts`. Both variables are only* used for the `for` iteration. They iterator used to be used to index the layouts table, but since we're using vectors that's not the case.

*) `new_num_layouts` is used to reserve memory for the number of elements in the layout. I do not see how the number of elements in a layout is related to the number of layouts. If I provide 1 layout for an industry, does it only have 1 tile? If I provide 100 layouts, are they all at least 100 tiles? I would reckon not.
So, why use `new_num_layouts` as amount to reserve? Number of layouts and tiles in a layout do not have a really strong correlation. As such, I removed the reserving, and as such the iterator and limit are not used outside of the `for` statement.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
