### PR TITLE
Codefix: do not leave pointers to stack allocations in globals

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -9910,8 +9910,8 @@ static void DecodeSpecialSprite(uint8_t *buf, uint num, GrfLoadingStage stage)
  */
 static void LoadNewGRFFileFromFile(GRFConfig &config, GrfLoadingStage stage, SpriteFile &file)
 {
-	_cur.file = &file;
-	_cur.grfconfig = &config;
+	AutoRestoreBackup cur_file(_cur.file, &file);
+	AutoRestoreBackup cur_config(_cur.grfconfig, &config);
 
 	Debug(grf, 2, "LoadNewGRFFile: Reading NewGRF-file '{}'", config.filename);
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1833,7 +1833,7 @@ void ViewportDoDraw(const Viewport *vp, int left, int top, int right, int bottom
 	dp.zoom = ZOOM_LVL_MIN;
 	dp.width = UnScaleByZoom(dp.width, zoom);
 	dp.height = UnScaleByZoom(dp.height, zoom);
-	_cur_dpi = &dp;
+	AutoRestoreBackup cur_dpi(_cur_dpi, &dp);
 
 	if (vp->overlay != nullptr && vp->overlay->GetCargoMask() != 0 && vp->overlay->GetCompanyMask().Any()) {
 		/* translate to window coordinates */


### PR DESCRIPTION
## Motivation / Problem

CodeQL warning about 'Local variable address stored in non-local memory'.


## Description

Use `AutoRestoreBackup` to restore the value of the globals back to their original value (probably `nullptr`), so we aren't leaving a pointer to some random stack location in the globals.


## Limitations

There might be more cases, though those are where CodeQL did not trigger.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
