### PR TITLE
Fix: Don't add chars with unspecified signedness to pointers.

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1227,7 +1227,7 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 							break;
 						}
 						/* Otherwise skip to the next case */
-						str += 3 + (str[1] << 8) + str[2];
+						str += 3 + (static_cast<uint8_t>(str[1]) << 8) + static_cast<uint8_t>(str[2]);
 						num--;
 					}
 					break;


### PR DESCRIPTION
## Motivation / Problem

`char` has unspecified signedness (usually signed on x86, unsigned on arm).
Adding it to a pointer/array is asking for disaster.

In this case, strings with cases longer than 128 bytes are broken. (I did not test this)

## Description

Cast to unsigned before adding.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
