### PR TITLE
Change: Close error message window on left click

### DIFF
--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -225,7 +225,7 @@ public:
 	void OnMouseLoop() override
 	{
 		/* Disallow closing the window too easily, if timeout is disabled */
-		if (_right_button_down && !this->is_critical) this->Close();
+		if ((_right_button_down || _left_button_down) && !this->is_critical) this->Close();
 	}
 
 	void Close([[maybe_unused]] int data = 0) override


### PR DESCRIPTION
## Motivation / Problem

We show a lot of error messages, for lots of different reasons. Many of them are non-critical and are mostly there to inform the user that they've made a mistake. Exhibit A: 
![image](https://github.com/user-attachments/assets/2e61a359-4806-4c89-b854-4291dcc54742)

While IMO it's perfectly fine to have informative messages like this, it annoys me that they stay on screen for quite a while (there is a timeout). Yes, the user can press the DEL key but that closes all windows, which is often excessive. ~While working on this I discovered there is a close-window-on-right-click settings, which is nice, but it's not something you intuitively run into. You need to somehow know that this exists.~ Turns out right-clicking closes the error window irrespective of this particular setting.

## Description

I changed the logic so that any left-button click closes the error window. The idea is that the user can then simply continue with whatever they were doing and the error message will go away by itself. This IMO is much more intuitive compared to right-clicking.

Note that the error window will not be closed if it is a critical error (same behavior as for the right-click).

**Again, all of this behavior (right and left click) is completely unrelated to the right-click-closes-current-window-setting.**

## Limitations

This is a UX change so there will be pitchforks. I'm happy to create a settings for this if it's deemed to radical.

There is also the chance of a user accidentally closing a somewhat important or informative error message. Critical errors will never be closed automatically though.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
