### PR TITLE
Fix #13838: Formatted error message of sub-errors may be lost.

### DIFF
--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -538,10 +538,10 @@ static CommandCost ReplaceChain(Vehicle **chain, DoCommandFlags flags, bool wago
 			ReplaceChainItem &replacement = replacements.emplace_back(w, nullptr, 0);
 
 			CommandCost ret = BuildReplacementVehicle(replacement.old_veh, &replacement.new_veh, true, flags);
-			cost.AddCost(ret);
+			replacement.cost = ret.GetCost();
+			cost.AddCost(std::move(ret));
 			if (cost.Failed()) break;
 
-			replacement.cost = ret.GetCost();
 			if (replacement.new_veh != nullptr) *nothing_to_do = false;
 		}
 		Vehicle *new_head = replacements.front().GetVehicle();
@@ -602,7 +602,7 @@ static CommandCost ReplaceChain(Vehicle **chain, DoCommandFlags flags, bool wago
 							break;
 						}
 
-						cost.AddCost(res);
+						cost.AddCost(std::move(res));
 						if (cost.Failed()) break;
 					} else {
 						/* We have reached 'last_engine', continue with the next engine towards the front */

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -398,11 +398,12 @@ CommandCost CommandHelperBase::InternalExecuteProcessResult(Commands cmd, Comman
  * Also takes a possible error message when it is set.
  * @param ret The command to add the cost of.
  */
-void CommandCost::AddCost(const CommandCost &ret)
+void CommandCost::AddCost(CommandCost &&ret)
 {
 	this->AddCost(ret.cost);
 	if (this->success && !ret.success) {
 		this->message = ret.message;
+		this->encoded_message = std::move(ret.encoded_message);
 		this->success = false;
 	}
 }

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -100,7 +100,7 @@ public:
 		this->cost += cost;
 	}
 
-	void AddCost(const CommandCost &cmd_cost);
+	void AddCost(CommandCost &&cmd_cost);
 
 	/**
 	 * Multiplies the cost of the command by the given factor.

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -744,7 +744,7 @@ std::tuple<CommandCost, Money> CmdClearArea(DoCommandFlags flags, TileIndex tile
 			/* When we're at the clearing limit we better bail (unneed) testing as well. */
 			if (ret.GetCost() != 0 && --limit <= 0) break;
 		}
-		cost.AddCost(ret);
+		cost.AddCost(ret.GetCost());
 	}
 
 	return { had_success ? cost : last_error, 0 };

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -422,7 +422,7 @@ CommandCost CmdBuildObjectArea(DoCommandFlags flags, TileIndex tile, TileIndex s
 			if (ret.GetCost() > 0 && money < 0) break;
 			Command<CMD_BUILD_OBJECT>::Do(flags, t, type, view);
 		}
-		cost.AddCost(ret);
+		cost.AddCost(ret.GetCost());
 	}
 
 	return had_success ? cost : last_error;

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -447,7 +447,7 @@ CommandCost CmdBuildSingleRail(DoCommandFlags flags, TileIndex tile, RailType ra
 
 			ret = CheckRailSlope(tileh, trackbit, GetTrackBits(tile), tile);
 			if (ret.Failed()) return ret;
-			cost.AddCost(ret);
+			cost.AddCost(ret.GetCost());
 
 			if (HasSignals(tile) && TracksOverlap(GetTrackBits(tile) | TrackToTrackBits(track))) {
 				/* If adding the new track causes any overlap, all signals must be removed first */
@@ -457,7 +457,7 @@ CommandCost CmdBuildSingleRail(DoCommandFlags flags, TileIndex tile, RailType ra
 					if (HasTrack(tile, track_it) && HasSignalOnTrack(tile, track_it)) {
 						CommandCost ret_remove_signals = Command<CMD_REMOVE_SINGLE_SIGNAL>::Do(flags, tile, track_it);
 						if (ret_remove_signals.Failed()) return ret_remove_signals;
-						cost.AddCost(ret_remove_signals);
+						cost.AddCost(ret_remove_signals.GetCost());
 					}
 				}
 			}
@@ -469,7 +469,7 @@ CommandCost CmdBuildSingleRail(DoCommandFlags flags, TileIndex tile, RailType ra
 				if (HasPowerOnRail(GetRailType(tile), railtype)) {
 					ret = Command<CMD_CONVERT_RAIL>::Do(flags, tile, tile, railtype, false);
 					if (ret.Failed()) return ret;
-					cost.AddCost(ret);
+					cost.AddCost(ret.GetCost());
 				} else {
 					return CMD_ERROR;
 				}
@@ -571,11 +571,11 @@ CommandCost CmdBuildSingleRail(DoCommandFlags flags, TileIndex tile, RailType ra
 
 			CommandCost ret = CheckRailSlope(tileh, trackbit, TRACK_BIT_NONE, tile);
 			if (ret.Failed()) return ret;
-			cost.AddCost(ret);
+			cost.AddCost(ret.GetCost());
 
 			ret = Command<CMD_LANDSCAPE_CLEAR>::Do(flags, tile);
 			if (ret.Failed()) return ret;
-			cost.AddCost(ret);
+			cost.AddCost(ret.GetCost());
 
 			if (water_ground) {
 				cost.AddCost(-_price[PR_CLEAR_WATER]);
@@ -901,7 +901,7 @@ static CommandCost CmdRailTrackHelper(DoCommandFlags flags, TileIndex tile, Tile
 			if (last_error.GetErrorMessage() == STR_ERROR_OWNED_BY && remove) break;
 		} else {
 			had_success = true;
-			total_cost.AddCost(ret);
+			total_cost.AddCost(ret.GetCost());
 		}
 
 		if (tile == end_tile) break;
@@ -1330,7 +1330,7 @@ static CommandCost CmdSignalTrackHelper(DoCommandFlags flags, TileIndex tile, Ti
 
 		if (ret.Succeeded()) {
 			had_success = true;
-			total_cost.AddCost(ret);
+			total_cost.AddCost(ret.GetCost());
 		} else {
 			/* The "No railway" error is the least important one. */
 			if (ret.GetErrorMessage() != STR_ERROR_THERE_IS_NO_RAILROAD_TRACK ||
@@ -1824,7 +1824,7 @@ static CommandCost ClearTile_Track(TileIndex tile, DoCommandFlags flags)
 				Track track = RemoveFirstTrack(&tracks);
 				CommandCost ret = Command<CMD_REMOVE_SINGLE_RAIL>::Do(flags, tile, track);
 				if (ret.Failed()) return ret;
-				cost.AddCost(ret);
+				cost.AddCost(ret.GetCost());
 			}
 
 			/* When bankrupting, don't make water dirty, there could be a ship on lower halftile.

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -817,7 +817,7 @@ do_clear:;
 	if (need_to_clear) {
 		CommandCost ret = Command<CMD_LANDSCAPE_CLEAR>::Do(flags, tile);
 		if (ret.Failed()) return ret;
-		cost.AddCost(ret);
+		cost.AddCost(ret.GetCost());
 	}
 
 	if (other_bits != pieces) {
@@ -828,7 +828,7 @@ do_clear:;
 		if (ret.Failed() || (ret.GetCost() != 0 && !_settings_game.construction.build_on_slopes)) {
 			return CommandCost(STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
 		}
-		cost.AddCost(ret);
+		cost.AddCost(ret.GetCost());
 	}
 
 	if (!need_to_clear) {
@@ -863,7 +863,7 @@ do_clear:;
 				} else if (HasPowerOnRoad(existing_rt, rt)) {
 					ret = Command<CMD_CONVERT_ROAD>::Do(flags, tile, tile, rt);
 					if (ret.Failed()) return ret;
-					cost.AddCost(ret);
+					cost.AddCost(ret.GetCost());
 				} else {
 					return CMD_ERROR;
 				}
@@ -1036,17 +1036,17 @@ CommandCost CmdBuildLongRoad(DoCommandFlags flags, TileIndex end_tile, TileIndex
 			if (IsTileType(tile, MP_TUNNELBRIDGE)) {
 				if (IsBridge(tile)) {
 					if (!had_bridge || GetTunnelBridgeDirection(tile) == dir) {
-						cost.AddCost(ret);
+						cost.AddCost(ret.GetCost());
 					}
 					had_bridge = true;
 				} else { // IsTunnel(tile)
 					if (!had_tunnel || GetTunnelBridgeDirection(tile) == dir) {
-						cost.AddCost(ret);
+						cost.AddCost(ret.GetCost());
 					}
 					had_tunnel = true;
 				}
 			} else {
-				cost.AddCost(ret);
+				cost.AddCost(ret.GetCost());
 			}
 		}
 
@@ -1110,7 +1110,7 @@ std::tuple<CommandCost, Money> CmdRemoveLongRoad(DoCommandFlags flags, TileIndex
 					}
 					RemoveRoad(tile, flags, bits, rtt, false);
 				}
-				cost.AddCost(ret);
+				cost.AddCost(ret.GetCost());
 				had_success = true;
 			} else {
 				/* Some errors are more equal than others. */
@@ -1241,7 +1241,7 @@ static CommandCost ClearTile_Road(TileIndex tile, DoCommandFlags flags)
 
 					CommandCost tmp_ret = RemoveRoad(tile, flags, GetRoadBits(tile, rtt), rtt, true);
 					if (tmp_ret.Failed()) return tmp_ret;
-					ret.AddCost(tmp_ret);
+					ret.AddCost(tmp_ret.GetCost());
 				}
 				return ret;
 			}
@@ -1260,7 +1260,7 @@ static CommandCost ClearTile_Road(TileIndex tile, DoCommandFlags flags)
 
 				CommandCost tmp_ret = RemoveRoad(tile, flags, GetCrossingRoadBits(tile), rtt, true);
 				if (tmp_ret.Failed()) return tmp_ret;
-				ret.AddCost(tmp_ret);
+				ret.AddCost(tmp_ret.GetCost());
 			}
 
 			if (flags.Test(DoCommandFlag::Execute)) {

--- a/src/terraform_cmd.cpp
+++ b/src/terraform_cmd.cpp
@@ -151,7 +151,7 @@ static std::tuple<CommandCost, TileIndex> TerraformTileHeight(TerraformerState *
 			height_diff += (height_diff < 0 ? 1 : -1);
 			auto [cost, err_tile] = TerraformTileHeight(ts, neighbour_tile, r + height_diff);
 			if (cost.Failed()) return { cost, err_tile };
-			total_cost.AddCost(cost);
+			total_cost.AddCost(cost.GetCost());
 		}
 	}
 
@@ -177,28 +177,28 @@ std::tuple<CommandCost, Money, TileIndex> CmdTerraformLand(DoCommandFlags flags,
 		TileIndex t = tile + TileDiffXY(1, 0);
 		auto [cost, err_tile] = TerraformTileHeight(&ts, t, TileHeight(t) + direction);
 		if (cost.Failed()) return { cost, 0, err_tile };
-		total_cost.AddCost(cost);
+		total_cost.AddCost(cost.GetCost());
 	}
 
 	if ((slope & SLOPE_S) != 0 && tile + TileDiffXY(1, 1) < Map::Size()) {
 		TileIndex t = tile + TileDiffXY(1, 1);
 		auto [cost, err_tile] = TerraformTileHeight(&ts, t, TileHeight(t) + direction);
 		if (cost.Failed()) return { cost, 0, err_tile };
-		total_cost.AddCost(cost);
+		total_cost.AddCost(cost.GetCost());
 	}
 
 	if ((slope & SLOPE_E) != 0 && tile + TileDiffXY(0, 1) < Map::Size()) {
 		TileIndex t = tile + TileDiffXY(0, 1);
 		auto [cost, err_tile] = TerraformTileHeight(&ts, t, TileHeight(t) + direction);
 		if (cost.Failed()) return { cost, 0, err_tile };
-		total_cost.AddCost(cost);
+		total_cost.AddCost(cost.GetCost());
 	}
 
 	if ((slope & SLOPE_N) != 0) {
 		TileIndex t = tile + TileDiffXY(0, 0);
 		auto [cost, err_tile] = TerraformTileHeight(&ts, t, TileHeight(t) + direction);
 		if (cost.Failed()) return { cost, 0, err_tile };
-		total_cost.AddCost(cost);
+		total_cost.AddCost(cost.GetCost());
 	}
 
 	/* Check if the terraforming is valid wrt. tunnels, bridges and objects on the surface
@@ -271,7 +271,7 @@ std::tuple<CommandCost, Money, TileIndex> CmdTerraformLand(DoCommandFlags flags,
 			if (cost.Failed()) {
 				return { cost, 0, t };
 			}
-			if (pass == 1) total_cost.AddCost(cost);
+			if (pass == 1) total_cost.AddCost(cost.GetCost());
 		}
 	}
 
@@ -374,7 +374,7 @@ std::tuple<CommandCost, Money, TileIndex> CmdLevelLand(DoCommandFlags flags, Til
 				}
 			}
 
-			cost.AddCost(ret);
+			cost.AddCost(ret.GetCost());
 			curh += (curh > h) ? -1 : 1;
 			had_success = true;
 		}

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -585,7 +585,7 @@ CommandCost CmdPlantTree(DoCommandFlags flags, TileIndex tile, TileIndex start_t
 						case CLEAR_ROCKS: {
 							CommandCost ret = Command<CMD_LANDSCAPE_CLEAR>::Do(flags, current_tile);
 							if (ret.Failed()) return ret;
-							cost.AddCost(ret);
+							cost.AddCost(ret.GetCost());
 							break;
 						}
 

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -402,16 +402,16 @@ CommandCost CmdBuildBridge(DoCommandFlags flags, TileIndex tile_end, TileIndex t
 		cost = ret;
 
 		if (terraform_cost_north.Failed() || (terraform_cost_north.GetCost() != 0 && !allow_on_slopes)) return CommandCost(STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
-		cost.AddCost(terraform_cost_north);
+		cost.AddCost(terraform_cost_north.GetCost());
 
 		/* Try and clear the end landscape */
 		ret = Command<CMD_LANDSCAPE_CLEAR>::Do(flags, tile_end);
 		if (ret.Failed()) return ret;
-		cost.AddCost(ret);
+		cost.AddCost(ret.GetCost());
 
 		/* false - end tile slope check */
 		if (terraform_cost_south.Failed() || (terraform_cost_south.GetCost() != 0 && !allow_on_slopes)) return CommandCost(STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
-		cost.AddCost(terraform_cost_south);
+		cost.AddCost(terraform_cost_south.GetCost());
 
 		const TileIndex heads[] = {tile_start, tile_end};
 		for (int i = 0; i < 2; i++) {
@@ -479,7 +479,7 @@ CommandCost CmdBuildBridge(DoCommandFlags flags, TileIndex tile_end, TileIndex t
 					/* try and clear the middle landscape */
 					ret = Command<CMD_LANDSCAPE_CLEAR>::Do(flags, tile);
 					if (ret.Failed()) return ret;
-					cost.AddCost(ret);
+					cost.AddCost(ret.GetCost());
 					break;
 			}
 
@@ -697,7 +697,7 @@ CommandCost CmdBuildTunnel(DoCommandFlags flags, TileIndex start_tile, Transport
 
 	/* Add the cost of the entrance */
 	cost.AddCost(_price[PR_BUILD_TUNNEL]);
-	cost.AddCost(ret);
+	cost.AddCost(ret.GetCost());
 
 	/* if the command fails from here on we want the end tile to be highlighted */
 	_build_tunnel_endtile = end_tile;
@@ -709,7 +709,7 @@ CommandCost CmdBuildTunnel(DoCommandFlags flags, TileIndex start_tile, Transport
 	/* Clear the tile in any case */
 	ret = Command<CMD_LANDSCAPE_CLEAR>::Do(flags, end_tile);
 	if (ret.Failed()) return CommandCost(STR_ERROR_UNABLE_TO_EXCAVATE_LAND);
-	cost.AddCost(ret);
+	cost.AddCost(ret.GetCost());
 
 	/* slope of end tile must be complementary to the slope of the start tile */
 	if (end_tileh != ComplementSlope(start_tileh)) {
@@ -742,7 +742,7 @@ CommandCost CmdBuildTunnel(DoCommandFlags flags, TileIndex start_tile, Transport
 		ret = std::get<0>(Command<CMD_TERRAFORM_LAND>::Do(flags, end_tile, end_tileh & start_tileh, false));
 		_cleared_object_areas[(uint)coa_index].first_tile = old_first_tile;
 		if (ret.Failed()) return CommandCost(STR_ERROR_UNABLE_TO_EXCAVATE_LAND);
-		cost.AddCost(ret);
+		cost.AddCost(ret.GetCost());
 	}
 	cost.AddCost(_price[PR_BUILD_TUNNEL]);
 

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -171,7 +171,7 @@ std::tuple<CommandCost, VehicleID, uint, uint16_t, CargoArray> CmdBuildVehicle(D
 			/* Refit only one vehicle. If we purchased an engine, it may have gained free wagons. */
 			CommandCost cc;
 			std::tie(cc, refitted_capacity, refitted_mail_capacity, cargo_capacities) = CmdRefitVehicle(flags, v->index, cargo, 0, false, false, 1);
-			value.AddCost(cc);
+			value.AddCost(std::move(cc));
 		} else {
 			/* Fill in non-refitted capacities */
 			if (e->type == VEH_TRAIN || e->type == VEH_ROAD) {
@@ -452,7 +452,7 @@ static std::tuple<CommandCost, uint, uint16_t, CargoArray> RefitVehicle(Vehicle 
 			}
 			continue;
 		}
-		cost.AddCost(refit_cost);
+		cost.AddCost(std::move(refit_cost));
 
 		/* Record the refitting.
 		 * Do not execute the refitting immediately, so DetermineCapacity and GetRefitCost do the same in test and exec run.
@@ -720,7 +720,7 @@ CommandCost CmdDepotSellAllVehicles(DoCommandFlags flags, TileIndex tile, Vehicl
 	for (const Vehicle *v : list) {
 		CommandCost ret = Command<CMD_SELL_VEHICLE>::Do(flags, v->index, true, false, INVALID_CLIENT_ID);
 		if (ret.Succeeded()) {
-			cost.AddCost(ret);
+			cost.AddCost(ret.GetCost());
 			had_success = true;
 		} else {
 			last_error = std::move(ret);
@@ -754,7 +754,7 @@ CommandCost CmdDepotMassAutoReplace(DoCommandFlags flags, TileIndex tile, Vehicl
 
 		CommandCost ret = Command<CMD_AUTOREPLACE_VEHICLE>::Do(flags, v->index);
 
-		if (ret.Succeeded()) cost.AddCost(ret);
+		if (ret.Succeeded()) cost.AddCost(ret.GetCost());
 	}
 	return cost;
 }
@@ -900,7 +900,7 @@ std::tuple<CommandCost, VehicleID> CmdCloneVehicle(DoCommandFlags flags, TileInd
 			return { cost, VehicleID::Invalid() };
 		}
 
-		total_cost.AddCost(cost);
+		total_cost.AddCost(cost.GetCost());
 
 		if (flags.Test(DoCommandFlag::Execute)) {
 			w = Vehicle::Get(new_veh_id);
@@ -961,7 +961,7 @@ std::tuple<CommandCost, VehicleID> CmdCloneVehicle(DoCommandFlags flags, TileInd
 				uint8_t subtype = GetBestFittingSubType(v, w, v->cargo_type);
 				if (w->cargo_type != v->cargo_type || w->cargo_subtype != subtype) {
 					CommandCost cost = std::get<0>(Command<CMD_REFIT_VEHICLE>::Do(flags, w->index, v->cargo_type, subtype, false, true, 0));
-					if (cost.Succeeded()) total_cost.AddCost(cost);
+					if (cost.Succeeded()) total_cost.AddCost(cost.GetCost());
 				}
 
 				if (w->IsGroundVehicle() && w->HasArticulatedPart()) {

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -135,13 +135,13 @@ CommandCost CmdBuildShipDepot(DoCommandFlags flags, TileIndex tile, Axis axis)
 	CommandCost ret = Command<CMD_LANDSCAPE_CLEAR>::Do(flags | DoCommandFlag::Auto, tile);
 	if (ret.Failed()) return ret;
 	if (add_cost) {
-		cost.AddCost(ret);
+		cost.AddCost(ret.GetCost());
 	}
 	add_cost = !IsWaterTile(tile2);
 	ret = Command<CMD_LANDSCAPE_CLEAR>::Do(flags | DoCommandFlag::Auto, tile2);
 	if (ret.Failed()) return ret;
 	if (add_cost) {
-		cost.AddCost(ret);
+		cost.AddCost(ret.GetCost());
 	}
 
 	if (flags.Test(DoCommandFlag::Execute)) {
@@ -322,13 +322,13 @@ static CommandCost DoBuildLock(TileIndex tile, DiagDirection dir, DoCommandFlags
 	WaterClass wc_middle = HasTileWaterGround(tile) ? GetWaterClass(tile) : WATER_CLASS_CANAL;
 	ret = Command<CMD_LANDSCAPE_CLEAR>::Do(flags, tile);
 	if (ret.Failed()) return ret;
-	cost.AddCost(ret);
+	cost.AddCost(ret.GetCost());
 
 	/* lower tile */
 	if (!IsWaterTile(tile - delta)) {
 		ret = Command<CMD_LANDSCAPE_CLEAR>::Do(flags, tile - delta);
 		if (ret.Failed()) return ret;
-		cost.AddCost(ret);
+		cost.AddCost(ret.GetCost());
 		cost.AddCost(_price[PR_BUILD_CANAL]);
 	}
 	if (!IsTileFlat(tile - delta)) {
@@ -340,7 +340,7 @@ static CommandCost DoBuildLock(TileIndex tile, DiagDirection dir, DoCommandFlags
 	if (!IsWaterTile(tile + delta)) {
 		ret = Command<CMD_LANDSCAPE_CLEAR>::Do(flags, tile + delta);
 		if (ret.Failed()) return ret;
-		cost.AddCost(ret);
+		cost.AddCost(ret.GetCost());
 		cost.AddCost(_price[PR_BUILD_CANAL]);
 	}
 	if (!IsTileFlat(tile + delta)) {
@@ -495,7 +495,7 @@ CommandCost CmdBuildCanal(DoCommandFlags flags, TileIndex tile, TileIndex start_
 		ret = Command<CMD_LANDSCAPE_CLEAR>::Do(flags, current_tile);
 		if (ret.Failed()) return ret;
 
-		if (!water) cost.AddCost(ret);
+		if (!water) cost.AddCost(ret.GetCost());
 
 		if (flags.Test(DoCommandFlag::Execute)) {
 			if (IsTileType(current_tile, MP_WATER) && IsCanal(current_tile)) {

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -479,7 +479,7 @@ CommandCost CmdBuildBuoy(DoCommandFlags flags, TileIndex tile)
 	if (!IsWaterTile(tile)) {
 		CommandCost ret = Command<CMD_LANDSCAPE_CLEAR>::Do(flags | DoCommandFlag::Auto, tile);
 		if (ret.Failed()) return ret;
-		cost.AddCost(ret);
+		cost.AddCost(ret.GetCost());
 	}
 
 	if (flags.Test(DoCommandFlag::Execute)) {


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As per #13838, the error message of some errors could be lost, caused by `AddCost()` not retaining the `encoded_message` of a sub-error.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Move the sub-error's `encoded_message` inside `AddCost()`. This requires `AddCost()` to use move semantics.

In many places `AddCost()` is used with `CommandCost` that doesn't contain an error, and we already tested for this condition. These cases now use the `AddCost(Money)` overload instead.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Could be simpler if we just copy the string...

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
