### PR TITLE
Codechange: remove uses of MemCmpT (and MemMoveT)

### DIFF
--- a/src/core/mem_func.hpp
+++ b/src/core/mem_func.hpp
@@ -26,19 +26,6 @@ inline void MemCpyT(T *destination, const T *source, size_t num = 1)
 }
 
 /**
- * Type-safe version of memmove().
- *
- * @param destination Pointer to the destination buffer
- * @param source Pointer to the source buffer
- * @param num number of items to be copied. (!not number of bytes!)
- */
-template <typename T>
-inline void MemMoveT(T *destination, const T *source, size_t num = 1)
-{
-	memmove(destination, source, num * sizeof(T));
-}
-
-/**
  * Type-safe version of memset().
  *
  * @param ptr Pointer to the destination buffer
@@ -49,20 +36,6 @@ template <typename T>
 inline void MemSetT(T *ptr, uint8_t value, size_t num = 1)
 {
 	memset(ptr, value, num * sizeof(T));
-}
-
-/**
- * Type-safe version of memcmp().
- *
- * @param ptr1 Pointer to the first buffer
- * @param ptr2 Pointer to the second buffer
- * @param num Number of items to compare. (!not number of bytes!)
- * @return an int value indicating the relationship between the content of the two buffers
- */
-template <typename T>
-inline int MemCmpT(const T *ptr1, const T *ptr2, size_t num = 1)
-{
-	return memcmp(ptr1, ptr2, num * sizeof(T));
 }
 
 #endif /* MEM_FUNC_HPP */

--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -22,6 +22,8 @@ typedef uint32_t CursorID;  ///< The number of the cursor (sprite)
 struct PalSpriteID {
 	SpriteID sprite{};  ///< The 'real' sprite
 	PaletteID pal{};    ///< The palette (use \c PAL_NONE) if not needed)
+
+	auto operator<=>(const PalSpriteID&) const = default;
 };
 
 enum WindowKeyCodes : uint16_t {

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -12,7 +12,6 @@
 #include "../fileio_type.h"
 #include "../string_func.h"
 #include "../core/endian_func.hpp"
-#include "../core/mem_func.hpp"
 #include "../base_media_base.h"
 #include "midi.h"
 
@@ -427,7 +426,7 @@ bool MidiFile::ReadSMFHeader(FileHandle &file, SMFHeader &header)
 
 	/* Check magic, 'MThd' followed by 4 byte length indicator (always = 6 in SMF) */
 	const uint8_t magic[] = { 'M', 'T', 'h', 'd', 0x00, 0x00, 0x00, 0x06 };
-	if (MemCmpT(buffer, magic, sizeof(magic)) != 0) {
+	if (std::ranges::equal(std::span(buffer, std::size(magic)), magic)) {
 		return false;
 	}
 

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -231,12 +231,12 @@ void UpdateNewGRFConfigPalette(int32_t)
  */
 size_t GRFGetSizeOfDataSection(FileHandle &f)
 {
-	extern const uint8_t _grf_cont_v2_sig[];
+	extern const std::array<uint8_t, 8> _grf_cont_v2_sig;
 	static const uint header_len = 14;
 
 	uint8_t data[header_len];
 	if (fread(data, 1, header_len, f) == header_len) {
-		if (data[0] == 0 && data[1] == 0 && MemCmpT(data + 2, _grf_cont_v2_sig, 8) == 0) {
+		if (data[0] == 0 && data[1] == 0 && std::ranges::equal(std::span(data + 2, _grf_cont_v2_sig.size()), _grf_cont_v2_sig)) {
 			/* Valid container version 2, get data section size. */
 			size_t offset = (static_cast<size_t>(data[13]) << 24) | (static_cast<size_t>(data[12]) << 16) | (static_cast<size_t>(data[11]) << 8) | static_cast<size_t>(data[10]);
 			if (offset >= 1 * 1024 * 1024 * 1024) {

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1100,7 +1100,7 @@ void GetCustomEngineSprite(EngineID engine, const Vehicle *v, Direction directio
 	result->Clear();
 
 	bool sprite_stack = EngInfo(engine)->misc_flags.Test(EngineMiscFlag::SpriteStack);
-	uint max_stack = sprite_stack ? lengthof(result->seq) : 1;
+	uint max_stack = sprite_stack ? static_cast<uint>(std::size(result->seq)) : 1;
 	for (uint stack = 0; stack < max_stack; ++stack) {
 		object.ResetState();
 		object.callback_param1 = image_type | (stack << 8);
@@ -1134,7 +1134,7 @@ void GetRotorOverrideSprite(EngineID engine, const struct Aircraft *v, EngineIma
 	uint rotor_pos = v == nullptr || rotor_in_gui ? 0 : v->Next()->Next()->state;
 
 	bool sprite_stack = e->info.misc_flags.Test(EngineMiscFlag::SpriteStack);
-	uint max_stack = sprite_stack ? lengthof(result->seq) : 1;
+	uint max_stack = sprite_stack ? static_cast<uint>(std::size(result->seq)) : 1;
 	for (uint stack = 0; stack < max_stack; ++stack) {
 		object.ResetState();
 		object.callback_param1 = image_type | (stack << 8);

--- a/src/spriteloader/sprite_file.cpp
+++ b/src/spriteloader/sprite_file.cpp
@@ -11,7 +11,7 @@
 #include "sprite_file_type.hpp"
 
 /** Signature of a container version 2 GRF. */
-extern const uint8_t _grf_cont_v2_sig[8] = {'G', 'R', 'F', 0x82, 0x0D, 0x0A, 0x1A, 0x0A};
+extern const std::array<uint8_t, 8> _grf_cont_v2_sig = {'G', 'R', 'F', 0x82, 0x0D, 0x0A, 0x1A, 0x0A};
 
 /**
  * Get the container version of the currently opened GRF file.

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -23,7 +23,6 @@
 #include "network/network.h"
 #include "saveload/saveload.h"
 #include "timer/timer_game_calendar.h"
-#include "core/mem_func.hpp"
 
 const uint TILE_AXIAL_DISTANCE = 192;  // Logical length of the tile in any DiagDirection used in vehicle movement.
 const uint TILE_CORNER_DISTANCE = 128;  // Logical length of the tile corner crossing in any non-diagonal direction used in vehicle movement.
@@ -120,12 +119,12 @@ struct VehicleCache {
 
 /** Sprite sequence for a vehicle part. */
 struct VehicleSpriteSeq {
-	PalSpriteID seq[8];
+	std::array<PalSpriteID, 8> seq;
 	uint count;
 
 	bool operator==(const VehicleSpriteSeq &other) const
 	{
-		return this->count == other.count && MemCmpT<PalSpriteID>(this->seq, other.seq, this->count) == 0;
+		return std::ranges::equal(std::span(this->seq.data(), this->count), std::span(other.seq.data(), other.count));
 	}
 
 	/**


### PR DESCRIPTION
## Motivation / Problem

The existence of C constructs.


## Description

Replace `MemCmpT` with C++ options, e.g. `std::ranges::equal`.
Remove `MemCmpT`/`MemMoveT` (unused).


## Limitations

Does nothing for `memcmp` or `memmove`.

`VehicleSpriteSeq`'s equals would be trivial if it were to use `std::vector`. But that requires extra allocations/indirections. `std::inplace_vector` would be perfect, though C++26 is still a bit too new.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
