### PR TITLE
Fix: [NewGRF] String parameter stack and case selection was not processed for control code 0x81

### DIFF
--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -840,6 +840,13 @@ static void ProcessNewGRFStringControlCode(char32_t scc, const char *&str, TextR
 			params.emplace_back(stack.PopUnsignedWord());
 			break;
 
+		case SCC_NEWGRF_STRINL: {
+			StringID stringid = Utf8Consume(str);
+			/* We also need to handle the substring's stack usage. */
+			HandleNewGRFStringControlCodes(GetStringPtr(stringid), stack, params);
+			break;
+		}
+
 		case SCC_NEWGRF_PRINT_WORD_STRING_ID: {
 			StringID stringid = MapGRFStringID(stack.grffile->grfid, GRFStringID{stack.PopUnsignedWord()});
 			params.emplace_back(stringid);
@@ -883,9 +890,6 @@ char32_t RemapNewGRFStringControlCode(char32_t scc, const char **str)
 		case SCC_NEWGRF_PRINT_DWORD_CURRENCY:
 		case SCC_NEWGRF_PRINT_QWORD_CURRENCY:
 			return SCC_CURRENCY_LONG;
-
-		case SCC_NEWGRF_PRINT_WORD_STRING_ID:
-			return SCC_NEWGRF_PRINT_WORD_STRING_ID;
 
 		case SCC_NEWGRF_PRINT_WORD_DATE_LONG:
 		case SCC_NEWGRF_PRINT_DWORD_DATE_LONG:

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1133,6 +1133,8 @@ static void FormatString(StringBuilder &builder, const char *str_arg, StringPara
 					} else {
 						str_stack.push(ptr);
 					}
+					case_index = next_substr_case_index;
+					next_substr_case_index = 0;
 					break;
 				}
 


### PR DESCRIPTION
## Motivation / Problem

`ProcessNewGRFStringControlCode` handled `SCC_NEWGRF_PRINT_WORD_STRING_ID`, but missed `SCC_NEWGRF_STRINL`.

## Description

The first two commits are #13811.

The third new commit:
* Adds `SCC_NEWGRF_STRINL` to `ProcessNewGRFStringControlCode`.
* Folds `SCC_NEWGRF_PRINT_WORD_STRING_ID` into the `default` case in `RemapNewGRFStringControlCode`. (instead of duplicating `default` also for `SCC_NEWGRF_STRINL`)
* Make `SCC_SET_CASE` also apply to `SCC_NEWGRF_STRINL`.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
