### PR TITLE
Fix #11528: Build tracks/road through bridges and tunnels without adding unnecessary tiles

### DIFF
--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -898,7 +898,7 @@ static CommandCost CmdRailTrackHelper(DoCommandFlags flags, TileIndex tile, Tile
 				redundant_track = true; // Either above tunnel or below bridge and perpendicular, which means unnecessary to build.
 				skip = true;
 			} else if (redundant_track) {
-				redundand_track = false; // The tunnel/bridge has ended, the next track should be built.
+				redundant_track = false; // The tunnel/bridge has ended, the next track should be built.
 			} else if (!first_tile && GetTunnelBridgeDirection(tile) == TrackdirToExitdir(ReverseTrackdir(trackdir))) {
 				break; // Upon running into a bridge ramp from the underside, we should stop building tracks.
 			}

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -891,11 +891,11 @@ static CommandCost CmdRailTrackHelper(DoCommandFlags flags, TileIndex tile, Tile
 	CommandCost last_error = CMD_ERROR;
 	for (;;) {
 		/* Check if hopping bridge/tunnel (#11528). */
-		if (!first_tile && wormhole_end == INVALID_TILE && IsDiagonalTrackdir(trackdir) && GetTileType(tile) == MP_TUNNELBRIDGE && GetTunnelBridgeTransportType(tile) == TRANSPORT_RAIL) {
+		if (wormhole_end == INVALID_TILE && IsDiagonalTrackdir(trackdir) && GetTileType(tile) == MP_TUNNELBRIDGE && GetTunnelBridgeTransportType(tile) == TRANSPORT_RAIL) {
 			/* If the building direction is the same as the bridge/tunnel direction, skip building tracks until the bridge/tunnel ends. */
 			if (GetTunnelBridgeDirection(tile) == TrackdirToExitdir(trackdir)) {
 				wormhole_end = GetOtherTunnelBridgeEnd(tile);
-			} else if (GetTunnelBridgeDirection(tile) == TrackdirToExitdir(ReverseTrackdir(trackdir))) {
+			} else if (!first_tile && GetTunnelBridgeDirection(tile) == TrackdirToExitdir(ReverseTrackdir(trackdir))) {
 				break; // Upon running into a bridge ramp from the underside, we should stop building tracks.
 			}
 		}


### PR DESCRIPTION
## Motivation / Problem

Partially fixes #11528.

## Description

Added the ability to lay tracks through bridges and tunnels without laying unnecessary pieces below bridges or above tunnels.

## Limitations

None.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
