### PR TITLE
Codechange: Use std::string_view in FormatString, and validate string bounds while parsing

### DIFF
--- a/src/string_base.h
+++ b/src/string_base.h
@@ -61,4 +61,180 @@ protected:
 	StringIterator() {}
 };
 
+/**
+ * Input iterator from std::string_view.
+ */
+class StringConsumer {
+	std::string_view string;
+
+public:
+	using size_type = std::string_view::size_type;
+
+	/**
+	 * Create a consumer for an external string.
+	 */
+	explicit StringConsumer(std::string_view string) : string(string) {}
+
+	/**
+	 * Check whether no bytes are left.
+	 * @return true if empty.
+	 */
+	[[nodiscard]] bool empty() const noexcept { return this->string.empty(); }
+
+	/**
+	 * Get number of bytes left.
+	 * @return Number of bytes left.
+	 */
+	[[nodiscard]] size_type size() const noexcept { return this->string.size(); }
+
+	/**
+	 * Advance by one byte.
+	 * @return this
+	 */
+	StringConsumer &operator++()
+	{
+		*this += 1;
+		return *this;
+	}
+
+	/**
+	 * Advance by one byte.
+	 * @return Copy of this before advancing.
+	 */
+	StringConsumer operator++(int)
+	{
+		auto res = *this;
+		*this += 1;
+		return res;
+	}
+
+	/**
+	 * Advance by "count" byte.
+	 * @param count Number of bytes to skip.
+	 * @return this
+	 */
+	StringConsumer &operator+=(size_type count)
+	{
+		if (count <= this->string.size()) {
+			this->string.remove_prefix(count);
+		} else {
+			assert(false);
+			this->string.remove_prefix(this->string.size());
+		}
+		return *this;
+	}
+
+	/**
+	 * Peek first byte.
+	 * @return First byte.
+	 */
+	[[nodiscard]] char operator*() const
+	{
+		if (this->string.empty()) {
+			assert(false);
+			return '?';
+		} else {
+			return this->string.front();
+		}
+	}
+
+	/**
+	 * Get buffer of all remaining bytes.
+	 * @return Buffer start.
+	 */
+	[[nodiscard]] const char *data() const { return this->string.data(); }
+
+	/**
+	 * Get view of all remaining bytes.
+	 * @return Remaining bytes.
+	 */
+	[[nodiscard]] std::string_view str() const noexcept { return this->string; }
+
+	/**
+	 * Find position of first occurrence of some byte.
+	 * @param c Byte to search for.
+	 * @return Offset to first occurrence, or "npos" if no occurrence.
+	 */
+	[[nodiscard]] size_type find(char c) const { return this->string.find(c); }
+
+	/**
+	 * Special value for "find" and "StrConsume".
+	 */
+	static constexpr size_type npos = std::string_view::npos;
+
+	/**
+	 * Read a UTF-8 character and advance the consumer.
+	 * @return Read character.
+	 */
+	[[nodiscard]] char32_t Utf8Consume();
+
+	/**
+	 * Read a uint8_t and advance the consumer.
+	 * @return Read integer.
+	 */
+	[[nodiscard]] uint8_t Uint8Consume()
+	{
+		if (this->string.empty()) {
+			assert(false);
+			return 0;
+		} else {
+			uint8_t res = **this;
+			*this += 1;
+			return res;
+		}
+	}
+
+	/**
+	 * Read a uint16_t in little endian and advance the consumer.
+	 * @return Read integer.
+	 */
+	[[nodiscard]] uint16_t Uint16LEConsume()
+	{
+		uint16_t res = this->Uint8Consume();
+		res |= this->Uint8Consume() << 8;
+		return res;
+	}
+
+	/**
+	 * Read a sequence of bytes and advance the consumer.
+	 * @param len Number of bytes to read.
+	 * @return Read string.
+	 */
+	[[nodiscard]] std::string_view StrConsume(size_type len)
+	{
+		if (len != npos && len > this->string.size()) {
+			assert(false);
+			len = npos;
+		}
+		if (len == npos) {
+			std::string_view res = this->string;
+			this->string.remove_prefix(this->string.size());
+			return res;
+		} else {
+			std::string_view res = this->string.substr(0, len);
+			this->string.remove_prefix(len);
+			return res;
+		}
+	}
+
+	/**
+	 * Read and parse a uint32_t and advance the consumer.
+	 * @param base Number base.
+	 * @return Parsed integer.
+	 */
+	[[nodiscard]] uint32_t Uint32Parse(int base);
+
+	/**
+	 * Read and parse a uint64_t and advance the consumer.
+	 * @param base Number base.
+	 * @return Parsed integer.
+	 */
+	[[nodiscard]] uint64_t Uint64Parse(int base);
+
+	/**
+	 * Discard all remaining bytes.
+	 */
+	void clear() { this->string.remove_prefix(this->string.size()); }
+};
+
 #endif /* STRING_BASE_H */

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -76,7 +76,7 @@ inline size_t ttd_strnlen(const char *str, size_t maxlen)
 
 bool IsValidChar(char32_t key, CharSetFilter afilter);
 
-size_t Utf8Decode(char32_t *c, const char *s);
+size_t Utf8Decode(char32_t *c, const char *s, size_t maxlen = 4);
 /* std::string_view::iterator might be char *, in which case we do not want this templated variant to be taken. */
 template <typename T> requires (!std::is_same_v<T, char *> && (std::is_same_v<std::string_view::iterator, T> || std::is_same_v<std::string::iterator, T>))
 inline size_t Utf8Decode(char32_t *c, T &s) { return Utf8Decode(c, &*s); }

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -311,6 +311,6 @@ void GenerateTownNameString(StringBuilder &builder, size_t lang, uint32_t seed);
 void GetTownName(StringBuilder &builder, const struct Town *t);
 void GRFTownNameGenerate(StringBuilder &builder, uint32_t grfid, uint16_t gen, uint32_t seed);
 
-char32_t RemapNewGRFStringControlCode(char32_t scc, const char **str);
+char32_t RemapNewGRFStringControlCode(char32_t scc, class StringConsumer &str);
 
 #endif /* STRINGS_INTERNAL_H */


### PR DESCRIPTION
## Motivation / Problem

`FormatString`, `RemapNewGRFStringControlCode`, `HandleNewGRFStringControlCodes` and friends consume characters from a string. Some string commands consume multiple bytes, but so far they did not check the string bounds.

## Description

Add a new class `StringConsumer` which is meant to be the counter part to the existing `StringBuilder`.
* In debug build out-of-bounds reads assert.
* In release build the string processing continues using fallback values and sometimes error markers in the rendered text.

## Limitations

There are actually multiple "reader" classes in the source now.
* `StringConsumer` and `ByteReader`.
* Multiple C-string based parsers in both OpenTTD and StrGen.
* Similarly there are plenty of C-string based `StringBuilder` in both OpenTTD and StrGen.

Something to unify for another day.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
