### PR TITLE
Codechange: Use a std::span as input for GfxFillPolygon

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -169,7 +169,7 @@ typedef std::pair<Point, Point> LineSegment;
  * @param offset Offset vector subtracted from all coordinates in the shape.
  * @return Vector of undirected line segments.
  */
-static std::vector<LineSegment> MakePolygonSegments(const std::vector<Point> &shape, Point offset)
+static std::vector<LineSegment> MakePolygonSegments(std::span<const Point> shape, Point offset)
 {
 	std::vector<LineSegment> segments;
 	if (shape.size() < 3) return segments; // fewer than 3 will always result in an empty polygon
@@ -208,7 +208,7 @@ static std::vector<LineSegment> MakePolygonSegments(const std::vector<Point> &sh
  *         FILLRECT_CHECKER:  Fill every other pixel with the specified colour, in a checkerboard pattern.
  *         FILLRECT_RECOLOUR: Apply a recolour sprite to every pixel in the polygon.
  */
-void GfxFillPolygon(const std::vector<Point> &shape, int colour, FillRectMode mode)
+void GfxFillPolygon(std::span<const Point> shape, int colour, FillRectMode mode)
 {
 	Blitter *blitter = BlitterFactory::GetCurrentBlitter();
 	const DrawPixelInfo *dpi = _cur_dpi;

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -101,7 +101,7 @@ int DrawStringMultiLine(int left, int right, int top, int bottom, StringID str, 
 void DrawCharCentered(char32_t c, const Rect &r, TextColour colour);
 
 void GfxFillRect(int left, int top, int right, int bottom, int colour, FillRectMode mode = FILLRECT_OPAQUE);
-void GfxFillPolygon(const std::vector<Point> &shape, int colour, FillRectMode mode = FILLRECT_OPAQUE);
+void GfxFillPolygon(std::span<const Point> shape, int colour, FillRectMode mode = FILLRECT_OPAQUE);
 void GfxDrawLine(int left, int top, int right, int bottom, int colour, int width = 1, int dash = 0);
 void DrawBox(int x, int y, int dx1, int dy1, int dx2, int dy2, int dx3, int dy3);
 void DrawRectOutline(const Rect &r, int colour, int width = 1, int dash = 0);

--- a/src/slider.cpp
+++ b/src/slider.cpp
@@ -45,7 +45,7 @@ void DrawSliderWidget(Rect r, int min_value, int max_value, int nmarks, int valu
 	const uint shadow = GetColourGradient(COLOUR_GREY, SHADE_DARK);
 	const uint fill = GetColourGradient(COLOUR_GREY, SHADE_LIGHTER);
 	const uint light = GetColourGradient(COLOUR_GREY, SHADE_LIGHTEST);
-	const std::vector<Point> wedge{ Point{wx1, r.bottom - ha}, Point{wx2, r.top + ha}, Point{wx2, r.bottom - ha} };
+	const std::array<Point, 3> wedge{ Point{wx1, r.bottom - ha}, Point{wx2, r.top + ha}, Point{wx2, r.bottom - ha} };
 	GfxFillPolygon(wedge, fill);
 	GfxDrawLine(wedge[0].x, wedge[0].y, wedge[2].x, wedge[2].y, light, t);
 	GfxDrawLine(wedge[1].x, wedge[1].y, wedge[2].x, wedge[2].y, _current_text_dir == TD_RTL ? shadow : light, t);


### PR DESCRIPTION
## Motivation / Problem

GfxFillPolygon takes a `const std::vector &` as input, when it doesn't actually require that the input is a vector, and there is otherwise no reason to construct one and allocate the associated backing storage.

## Description

Use a std::span instead. Change the call site to use std::array.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
