### PR TITLE
Codechange: Return name, description and URL as std::string from GRFConfig

### DIFF
--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -262,8 +262,8 @@ public:
 		}
 
 		/* NewGRF name */
-		if (td.grf != nullptr) {
-			this->landinfo_data.push_back(GetString(STR_LAND_AREA_INFORMATION_NEWGRF_NAME, td.grf));
+		if (td.grf.has_value()) {
+			this->landinfo_data.push_back(GetString(STR_LAND_AREA_INFORMATION_NEWGRF_NAME, std::move(*td.grf)));
 		}
 
 		/* Cargo acceptance is displayed in a extra multiline */

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -82,28 +82,32 @@ void GRFConfig::CopyParams(const GRFConfig &src)
  * the filename is returned.
  * @return The name of filename of this grf.
  */
-const char *GRFConfig::GetName() const
+std::string GRFConfig::GetName() const
 {
 	const char *name = GetGRFStringFromGRFText(this->name);
-	return StrEmpty(name) ? this->filename.c_str() : name;
+	return StrEmpty(name) ? this->filename : name;
 }
 
 /**
  * Get the grf info.
  * @return A string with a description of this grf.
  */
-const char *GRFConfig::GetDescription() const
+std::optional<std::string> GRFConfig::GetDescription() const
 {
-	return GetGRFStringFromGRFText(this->info);
+	const char *str = GetGRFStringFromGRFText(this->info);
+	if (StrEmpty(str)) return std::nullopt;
+	return std::string(str);
 }
 
 /**
  * Get the grf url.
  * @return A string with an url of this grf.
  */
-const char *GRFConfig::GetURL() const
+std::optional<std::string> GRFConfig::GetURL() const
 {
-	return GetGRFStringFromGRFText(this->url);
+	const char *str = GetGRFStringFromGRFText(this->url);
+	if (StrEmpty(str)) return std::nullopt;
+	return std::string(str);
 }
 
 /** Set the default value for all parameters as specified by action14. */

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -190,9 +190,9 @@ struct GRFConfig {
 	void SetValue(const GRFParameterInfo &info, uint32_t value);
 
 	std::optional<std::string> GetTextfile(TextfileType type) const;
-	const char *GetName() const;
-	const char *GetDescription() const;
-	const char *GetURL() const;
+	std::string GetName() const;
+	std::optional<std::string> GetDescription() const;
+	std::optional<std::string> GetURL() const;
 
 	void SetParameterDefaults();
 	void SetSuitablePalette();

--- a/src/tile_cmd.h
+++ b/src/tile_cmd.h
@@ -60,7 +60,7 @@ struct TileDesc {
 	StringID airport_class{}; ///< Name of the airport class
 	StringID airport_name{}; ///< Name of the airport
 	StringID airport_tile_name{}; ///< Name of the airport tile
-	const char *grf = nullptr; ///< newGRF used for the tile contents
+	std::optional<std::string> grf = std::nullopt; ///< newGRF used for the tile contents
 	StringID railtype{}; ///< Type of rail on the tile.
 	uint16_t rail_speed = 0; ///< Speed limit of rail (bridges and track)
 	StringID roadtype{}; ///< Type of road on the tile.


### PR DESCRIPTION
## Motivation / Problem

Split from #13862, see motivation there.

## Description

To get rid of C strings the data is returned as `std::string`.

In most cases the results were already copied into some `std::string`. Now they are moved.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
