### PR TITLE
Codechange: StringFilter now uses std::string_view entirely

### DIFF
--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -262,8 +262,8 @@ public:
 		}
 
 		/* NewGRF name */
-		if (td.grf != nullptr) {
-			this->landinfo_data.push_back(GetString(STR_LAND_AREA_INFORMATION_NEWGRF_NAME, td.grf));
+		if (td.grf.has_value()) {
+			this->landinfo_data.push_back(GetString(STR_LAND_AREA_INFORMATION_NEWGRF_NAME, std::move(*td.grf)));
 		}
 
 		/* Cargo acceptance is displayed in a extra multiline */

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -82,28 +82,32 @@ void GRFConfig::CopyParams(const GRFConfig &src)
  * the filename is returned.
  * @return The name of filename of this grf.
  */
-const char *GRFConfig::GetName() const
+std::string GRFConfig::GetName() const
 {
 	const char *name = GetGRFStringFromGRFText(this->name);
-	return StrEmpty(name) ? this->filename.c_str() : name;
+	return StrEmpty(name) ? this->filename : name;
 }
 
 /**
  * Get the grf info.
  * @return A string with a description of this grf.
  */
-const char *GRFConfig::GetDescription() const
+std::optional<std::string> GRFConfig::GetDescription() const
 {
-	return GetGRFStringFromGRFText(this->info);
+	const char *str = GetGRFStringFromGRFText(this->info);
+	if (StrEmpty(str)) return std::nullopt;
+	return std::string(str);
 }
 
 /**
  * Get the grf url.
  * @return A string with an url of this grf.
  */
-const char *GRFConfig::GetURL() const
+std::optional<std::string> GRFConfig::GetURL() const
 {
-	return GetGRFStringFromGRFText(this->url);
+	const char *str = GetGRFStringFromGRFText(this->url);
+	if (StrEmpty(str)) return std::nullopt;
+	return std::string(str);
 }
 
 /** Set the default value for all parameters as specified by action14. */

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -190,9 +190,9 @@ struct GRFConfig {
 	void SetValue(const GRFParameterInfo &info, uint32_t value);
 
 	std::optional<std::string> GetTextfile(TextfileType type) const;
-	const char *GetName() const;
-	const char *GetDescription() const;
-	const char *GetURL() const;
+	std::string GetName() const;
+	std::optional<std::string> GetDescription() const;
+	std::optional<std::string> GetURL() const;
 
 	void SetParameterDefaults();
 	void SetSuitablePalette();

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -369,6 +369,20 @@ bool StrEqualsIgnoreCase(const std::string_view str1, const std::string_view str
 }
 
 /**
+ * Checks if a string is contained in another string, while ignoring the case of the characters.
+ *
+ * @param str The string to search in.
+ * @param value The string to search for.
+ * @return True if a match was found.
+ */
+bool StrContainsIgnoreCase(const std::string_view str, const std::string_view value)
+{
+	CaseInsensitiveStringView ci_str{ str.data(), str.size() };
+	CaseInsensitiveStringView ci_value{ value.data(), value.size() };
+	return ci_str.find(ci_value) != ci_str.npos;
+}
+
+/**
  * Get the length of an UTF-8 encoded string in number of characters
  * and thus not the number of bytes that the encoded string contains.
  * @param s The string to get the length for.

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -36,6 +36,7 @@ std::string_view StrTrimView(std::string_view str);
 
 [[nodiscard]] int StrCompareIgnoreCase(const std::string_view str1, const std::string_view str2);
 [[nodiscard]] bool StrEqualsIgnoreCase(const std::string_view str1, const std::string_view str2);
+[[nodiscard]] bool StrContainsIgnoreCase(const std::string_view str, const std::string_view value);
 [[nodiscard]] int StrNaturalCompare(std::string_view s1, std::string_view s2, bool ignore_garbage_at_front = false);
 [[nodiscard]] bool StrNaturalContains(const std::string_view str, const std::string_view value);
 [[nodiscard]] bool StrNaturalContainsIgnoreCase(const std::string_view str, const std::string_view value);

--- a/src/stringfilter.cpp
+++ b/src/stringfilter.cpp
@@ -102,10 +102,8 @@ void StringFilter::ResetState()
  *
  * @param str Another line from the item.
  */
-void StringFilter::AddLine(const char *str)
+void StringFilter::AddLine(std::string_view str)
 {
-	if (str == nullptr) return;
-
 	bool match_case = this->case_sensitive != nullptr && *this->case_sensitive;
 	for (WordState &ws : this->word_index) {
 		if (!ws.match) {
@@ -115,7 +113,7 @@ void StringFilter::AddLine(const char *str)
 					this->word_matches++;
 				}
 			} else {
-				if ((match_case ? strstr(str, ws.word.c_str()) : strcasestr(str, ws.word.c_str())) != nullptr) {
+				if (match_case ? str.find(ws.word) != str.npos : StrContainsIgnoreCase(str, ws.word)) {
 					ws.match = true;
 					this->word_matches++;
 				}

--- a/src/stringfilter_type.h
+++ b/src/stringfilter_type.h
@@ -57,8 +57,8 @@ public:
 	bool IsEmpty() const { return this->word_index.empty(); }
 
 	void ResetState();
-	void AddLine(const char *str);
-	void AddLine(const std::string &str) { this->AddLine(str.c_str()); }
+	void AddLine(const char *) = delete; // prevent implicit construction of string_view from potential nullptr
+	void AddLine(std::string_view str);
 
 	/**
 	 * Get the matching state of the current item.

--- a/src/tile_cmd.h
+++ b/src/tile_cmd.h
@@ -60,7 +60,7 @@ struct TileDesc {
 	StringID airport_class{}; ///< Name of the airport class
 	StringID airport_name{}; ///< Name of the airport
 	StringID airport_tile_name{}; ///< Name of the airport tile
-	const char *grf = nullptr; ///< newGRF used for the tile contents
+	std::optional<std::string> grf = std::nullopt; ///< newGRF used for the tile contents
 	StringID railtype{}; ///< Type of rail on the tile.
 	uint16_t rail_speed = 0; ///< Speed limit of rail (bridges and track)
 	StringID roadtype{}; ///< Type of road on the tile.


### PR DESCRIPTION
## Motivation / Problem

Split from #13862, see motivation there.

## Description

This includes/depends on #13868.

Switch `StringFilter` to operate on `std::string_view` instead of `char *`.
* All usages with C pointers were already removed. New usages are blocked via the `deleted` method.
* All existing usages pass either `std::string` or `std::string_view`.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
