### PR TITLE
Codechange: Pass GRF name as std::string to UpdateNewGRFScanStatus

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3657,7 +3657,6 @@ STR_INVALID_VEHICLE                                             :<invalid vehicl
 STR_NEWGRF_SCAN_CAPTION                                         :{WHITE}Scanning NewGRFs
 STR_NEWGRF_SCAN_MESSAGE                                         :{BLACK}Scanning NewGRFs. Depending on the amount this can take a while...
 STR_NEWGRF_SCAN_STATUS                                          :{BLACK}{NUM} NewGRF{P "" s} scanned out of an estimated {NUM} NewGRF{P "" s}
-STR_NEWGRF_SCAN_ARCHIVES                                        :Scanning for archives
 
 # Sign list window
 STR_SIGN_LIST_CAPTION                                           :{WHITE}Sign List - {COMMA} Sign{P "" s}

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -536,10 +536,8 @@ bool GRFFileScanner::AddFile(const std::string &filename, size_t basepath_length
 
 	this->num_scanned++;
 
-	const char *name = nullptr;
-	if (grfconfig->name != nullptr) name = GetGRFStringFromGRFText(grfconfig->name);
-	if (name == nullptr) name = grfconfig->filename.c_str();
-	UpdateNewGRFScanStatus(this->num_scanned, name);
+	std::string name = grfconfig->GetName();
+	UpdateNewGRFScanStatus(this->num_scanned, std::move(name));
 	VideoDriver::GetInstance()->GameLoopPause();
 
 	return added;

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -242,7 +242,7 @@ std::string GRFBuildParamList(const GRFConfig &c);
 void ShowNewGRFSettings(bool editable, bool show_params, bool exec_changes, GRFConfigList &config);
 void OpenGRFParameterWindow(bool is_baseset, GRFConfig &c, bool editable);
 
-void UpdateNewGRFScanStatus(uint num, const char *name);
+void UpdateNewGRFScanStatus(uint num, std::string &&name);
 void UpdateNewGRFConfigPalette(int32_t new_value = 0);
 
 #endif /* NEWGRF_CONFIG_H */

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -2209,13 +2209,9 @@ struct ScanProgressWindow : public Window {
 	 * @param num  The number of NewGRFs scanned so far.
 	 * @param name The name of the last scanned NewGRF.
 	 */
-	void UpdateNewGRFScanStatus(uint num, const char *name)
+	void UpdateNewGRFScanStatus(uint num, std::string &&name)
 	{
-		if (name == nullptr) {
-			this->last_name = GetString(STR_NEWGRF_SCAN_ARCHIVES);
-		} else {
-			this->last_name = name;
-		}
+		this->last_name = std::move(name);
 		this->scanned = num;
 		if (num > _settings_client.gui.last_newgrf_count) _settings_client.gui.last_newgrf_count = num;
 
@@ -2228,9 +2224,9 @@ struct ScanProgressWindow : public Window {
  * @param num  The number of NewGRFs scanned so far.
  * @param name The name of the last scanned NewGRF.
  */
-void UpdateNewGRFScanStatus(uint num, const char *name)
+void UpdateNewGRFScanStatus(uint num, std::string &&name)
 {
 	ScanProgressWindow *w  = dynamic_cast<ScanProgressWindow *>(FindWindowByClass(WC_MODAL_PROGRESS));
 	if (w == nullptr) w = new ScanProgressWindow();
-	w->UpdateNewGRFScanStatus(num, name);
+	w->UpdateNewGRFScanStatus(num, std::move(name));
 }


### PR DESCRIPTION
## Motivation / Problem

Split from #13862, see motivation there.

## Description

This includes/depends on #13868.

GRF name is already stored as `std::string`, so pass it like that to `UpdateNewGRFScanStatus`.

Turns out `STR_NEWGRF_SCAN_ARCHIVES` is unused, at least since `GRFConfig::filename` is a `std::string`.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
