### PR TITLE
Codechange: Pass unformatted strings from GetStringPtr as std::string_view

### DIFF
--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -315,10 +315,10 @@ GameStrings *_current_data = nullptr;
  * @param id The ID of the game string.
  * @return The encoded string.
  */
-const char *GetGameStringPtr(StringIndexInTab id)
+std::string_view GetGameStringPtr(StringIndexInTab id)
 {
 	if (_current_data == nullptr || _current_data->cur_language == nullptr || id.base() >= _current_data->cur_language->lines.size()) return GetStringPtr(STR_UNDEFINED);
-	return _current_data->cur_language->lines[id].c_str();
+	return _current_data->cur_language->lines[id];
 }
 
 /**

--- a/src/game/game_text.hpp
+++ b/src/game/game_text.hpp
@@ -29,7 +29,7 @@ struct StringParam {
 using StringParams = std::vector<StringParam>;
 using StringParamsList = std::vector<StringParams>;
 
-const char *GetGameStringPtr(StringIndexInTab id);
+std::string_view GetGameStringPtr(StringIndexInTab id);
 const StringParams &GetGameStringParams(StringIndexInTab id);
 const std::string &GetGameStringName(StringIndexInTab id);
 void RegisterGameTranslation(class Squirrel *engine);

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -84,8 +84,8 @@ void GRFConfig::CopyParams(const GRFConfig &src)
  */
 std::string GRFConfig::GetName() const
 {
-	const char *name = GetGRFStringFromGRFText(this->name);
-	return StrEmpty(name) ? this->filename : name;
+	auto name = GetGRFStringFromGRFText(this->name);
+	return name.has_value() ? std::string(*name) : this->filename;
 }
 
 /**
@@ -94,9 +94,9 @@ std::string GRFConfig::GetName() const
  */
 std::optional<std::string> GRFConfig::GetDescription() const
 {
-	const char *str = GetGRFStringFromGRFText(this->info);
-	if (StrEmpty(str)) return std::nullopt;
-	return std::string(str);
+	auto str = GetGRFStringFromGRFText(this->info);
+	if (!str.has_value()) return std::nullopt;
+	return std::string(*str);
 }
 
 /**
@@ -105,9 +105,9 @@ std::optional<std::string> GRFConfig::GetDescription() const
  */
 std::optional<std::string> GRFConfig::GetURL() const
 {
-	const char *str = GetGRFStringFromGRFText(this->url);
-	if (StrEmpty(str)) return std::nullopt;
-	return std::string(str);
+	auto str = GetGRFStringFromGRFText(this->url);
+	if (!str.has_value()) return std::nullopt;
+	return std::string(*str);
 }
 
 /** Set the default value for all parameters as specified by action14. */

--- a/src/newgrf_text.h
+++ b/src/newgrf_text.h
@@ -16,9 +16,9 @@
 
 StringID AddGRFString(uint32_t grfid, GRFStringID stringid, uint8_t langid, bool new_scheme, bool allow_newlines, std::string_view text_to_add, StringID def_string);
 StringID GetGRFStringID(uint32_t grfid, GRFStringID stringid);
-const char *GetGRFStringFromGRFText(const GRFTextList &text_list);
-const char *GetGRFStringFromGRFText(const GRFTextWrapper &text);
-const char *GetGRFStringPtr(StringIndexInTab stringid);
+std::optional<std::string_view> GetGRFStringFromGRFText(const GRFTextList &text_list);
+std::optional<std::string_view> GetGRFStringFromGRFText(const GRFTextWrapper &text);
+std::string_view GetGRFStringPtr(StringIndexInTab stringid);
 void CleanUpStrings();
 void SetCurrentGrfLangID(uint8_t language_id);
 std::string TranslateTTDPatchCodes(uint32_t grfid, uint8_t language_id, bool allow_newlines, std::string_view str, StringControlCode byte80 = SCC_NEWGRF_PRINT_WORD_STRING_ID);

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -70,7 +70,7 @@ static inline void PrepareArgsForNextRun(std::span<StringParameter> args)
 
 std::string GetStringWithArgs(StringID string, std::span<StringParameter> args);
 std::string GetString(StringID string);
-const char *GetStringPtr(StringID string);
+std::string_view GetStringPtr(StringID string);
 void AppendStringInPlace(std::string &result, StringID string);
 void AppendStringWithArgsInPlace(std::string &result, StringID string, std::span<StringParameter> params);
 


### PR DESCRIPTION
## Motivation / Problem

Split from #13862, see motivation there.

## Description

* `GetStringPtr`, `GetGameStringPtr` and `GetGRFStringPtr` now return `std::string_view`.
* Turns out `GetStringPtr` previously only returned `nullptr`, if no language packs were loaded, and `STR_UNDEFINED` did not exist. Various places did not check for this, and would actually deref `nullptr`. Now `GetStringPtr` hard-codes a fallback value for `STR_UNDEFINED`.
* `FormatString` and `HandleNewGRFStringControlCodes` now take a `std::string_view`, and iterate from `begin` to `end`. They do not yet check whether string control codes read past the end, this will be addressed in a follow-up PR.
* NewGRF strings with cases added an extra null byte at the end of the default case, which strgen does not. This is removed now, otherwise FormatString would preserve it into the output. This actually exposes a bug in the handling of NewGRF string cases, since they technically allow the string to continue after the case choice list. This will be addressed in a follow-up PR.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
