### PR TITLE
Fix #13849: Settings in old saves could be overridden by defaults.

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1661,6 +1661,35 @@ void GetSaveLoadFromSettingTable(SettingTable settings, std::vector<SaveLoad> &s
 }
 
 /**
+ * Create a single table with all settings that should be stored/loaded
+ * in the savegame.
+ */
+SettingTable GetSaveLoadSettingTable()
+{
+	static const SettingTable saveload_settings_tables[] = {
+		_difficulty_settings,
+		_economy_settings,
+		_game_settings,
+		_linkgraph_settings,
+		_locale_settings,
+		_pathfinding_settings,
+		_script_settings,
+		_world_settings,
+	};
+	static std::vector<SettingVariant> settings_table;
+
+	if (settings_table.empty()) {
+		for (auto &saveload_settings_table : saveload_settings_tables) {
+			for (auto &saveload_setting : saveload_settings_table) {
+				settings_table.push_back(saveload_setting);
+			}
+		}
+	}
+
+	return settings_table;
+}
+
+/**
  * Given a name of setting, return a company setting description of it.
  * @param name  Name of the company setting to return a setting description of.
  * @return Pointer to the setting description of setting \a name if it can be found,

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -390,6 +390,7 @@ typedef std::span<const SettingVariant> SettingTable;
 
 const SettingDesc *GetSettingFromName(const std::string_view name);
 void GetSaveLoadFromSettingTable(SettingTable settings, std::vector<SaveLoad> &saveloads);
+SettingTable GetSaveLoadSettingTable();
 bool SetSettingValue(const IntSettingDesc *sd, int32_t value, bool force_newgame = false);
 bool SetSettingValue(const StringSettingDesc *sd, const std::string value, bool force_newgame = false);
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As per #13849, in old saves some settings were stored in the OPTS chunk instead of the PATS chunk.

When loading, settings are reset to default values in the PATS chunk, which is loaded after the OPTS chunk. So these settings are reset to invalid values.

In the scenario mentioned in the issue, the landscape is incorrectly set to Temperate in the PATS chunk loader, after it has been set to Tropic via the OPTS chunk loader.

![image](https://github.com/user-attachments/assets/1563f893-145d-4cb5-9ae7-520b51dc2ea2)


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Resolved by resetting settings to default values before the OPTS and PATS chunks are loaded.

![image](https://github.com/user-attachments/assets/999dbcd6-21cb-44ea-b96b-f151fdbdf118)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
