### PR TITLE
Codechange: Make use of emplace_back's return value.

### DIFF
--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -301,8 +301,8 @@ void GameStrings::Compile()
 		translation_reader.ParseFile();
 		if (_errors != 0) throw std::exception();
 
-		this->compiled_strings.emplace_back(p.language);
-		TranslationWriter writer(this->compiled_strings.back().lines);
+		auto &strings = this->compiled_strings.emplace_back(p.language);
+		TranslationWriter writer(strings.lines);
 		writer.WriteLang(data);
 	}
 }

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -786,8 +786,8 @@ struct MpsMachine {
 		this->tempo_ticks = this->current_tempo;
 
 		/* Always reset percussion channel to program 0 */
-		this->target.blocks.push_back(MidiFile::DataBlock());
-		AddMidiData(this->target.blocks.back(), MIDIST_PROGCHG + 9, 0x00);
+		auto &data_block = this->target.blocks.emplace_back();
+		AddMidiData(data_block, MIDIST_PROGCHG + 9, 0x00);
 
 		/* Technically should be an endless loop, but having
 		 * a maximum (about 10 minutes) avoids getting stuck,

--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -86,8 +86,8 @@ public:
 			/* Edge data is now a simple vector and not any kind of matrix. */
 			size_t size = SlGetStructListLength(UINT16_MAX);
 			for (size_t i = 0; i < size; i++) {
-				bn->edges.emplace_back();
-				SlObject(&bn->edges.back(), this->GetLoadDescription());
+				auto &edge = bn->edges.emplace_back();
+				SlObject(&edge, this->GetLoadDescription());
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

There are some places where we use `emplace_back()` but discard the result, and then use `back()` to get the last time.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use the result of `emplace_back()` instead of calling `back()` to get the same thing.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
