### PR TITLE
Fix: [NewGRF] Display an error, if NewGRF reference out-of-bounds string parameters in gender/plural choices.

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1161,7 +1161,10 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 					/* First read the meta data from the language file. */
 					size_t offset = ref_param_offset + (uint8_t)*str++;
 					int gender = 0;
-					if (!dry_run && args.GetTypeAtOffset(offset) != 0) {
+					if (offset >= args.GetNumParameters()) {
+						/* The offset may come from an external NewGRF, and be invalid. */
+						builder += "(invalid GENDER parameter)";
+					} else if (!dry_run && args.GetTypeAtOffset(offset) != 0) {
 						/* Now we need to figure out what text to resolve, i.e.
 						 * what do we need to draw? So get the actual raw string
 						 * first using the control code to get said string. */
@@ -1202,7 +1205,11 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 				case SCC_PLURAL_LIST: { // {P}
 					int plural_form = *str++;          // contains the plural form for this string
 					size_t offset = ref_param_offset + (uint8_t)*str++;
-					const uint64_t *v = std::get_if<uint64_t>(&args.GetParam(offset)); // contains the number that determines plural
+					const uint64_t *v = nullptr;
+					/* The offset may come from an external NewGRF, and be invalid. */
+					if (offset < args.GetNumParameters()) {
+						v = std::get_if<uint64_t>(&args.GetParam(offset)); // contains the number that determines plural
+					}
 					if (v != nullptr) {
 						str = ParseStringChoice(str, DeterminePluralForm(static_cast<int64_t>(*v), plural_form), builder);
 					} else {

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -153,6 +153,12 @@ public:
 		return this->parameters.size() - this->offset;
 	}
 
+	/** Return the number of parameters. */
+	size_t GetNumParameters() const
+	{
+		return this->parameters.size();
+	}
+
 	/** Get the type of a specific element. */
 	char32_t GetTypeAtOffset(size_t offset) const
 	{


### PR DESCRIPTION
## Motivation / Problem

Gender and plural choice lists reference another string parameter to base the choice on.
`GetTypeAtOffset` and `GetParam` assert, if this offset is out of bounds.

The offset may come from a NewGRF, and we should not assert on external supplied values.

## Description

Validate the offset, and add an error to the string, if invalid.

The number of parameters depend on the NewGRF string stack and substrings, thus this cannot be validated earlier during NewGRF loading.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
