### PR TITLE
Cleanup strgen

### DIFF
--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -129,14 +129,14 @@ struct TranslationWriter : LanguageWriter {
 		/* Nothing to do. */
 	}
 
-	void WriteLength(uint) override
+	void WriteLength(size_t) override
 	{
 		/* We don't write the length. */
 	}
 
-	void Write(const uint8_t *buffer, size_t length) override
+	void Write(const char *buffer, size_t length) override
 	{
-		this->strings.emplace_back((const char *)buffer, length);
+		this->strings.emplace_back(buffer, length);
 	}
 };
 
@@ -152,9 +152,9 @@ struct StringNameWriter : HeaderWriter {
 	{
 	}
 
-	void WriteStringID(const std::string &name, int stringid) override
+	void WriteStringID(const std::string &name, size_t stringid) override
 	{
-		if (stringid == (int)this->strings.size()) this->strings.emplace_back(name);
+		if (stringid == this->strings.size()) this->strings.emplace_back(name);
 	}
 
 	void Finalise(const StringData &) override

--- a/src/game/game_text.hpp
+++ b/src/game/game_text.hpp
@@ -22,9 +22,9 @@ struct StringParam {
 
 	ParamType type;
 	uint8_t consumes;
-	const char *cmd;
+	std::string_view cmd;
 
-	StringParam(ParamType type, uint8_t consumes, const char *cmd) : type(type), consumes(consumes), cmd(cmd) {}
+	StringParam(ParamType type, uint8_t consumes, std::string_view cmd) : type(type), consumes(consumes), cmd(cmd) {}
 };
 using StringParams = std::vector<StringParam>;
 using StringParamsList = std::vector<StringParams>;

--- a/src/language.h
+++ b/src/language.h
@@ -65,10 +65,10 @@ struct LanguagePackHeader {
 	 * @param gender_str The string representation of the gender.
 	 * @return The index of the gender, or MAX_NUM_GENDERS when the gender is unknown.
 	 */
-	uint8_t GetGenderIndex(const char *gender_str) const
+	uint8_t GetGenderIndex(std::string_view gender_str) const
 	{
 		for (uint8_t i = 0; i < MAX_NUM_GENDERS; i++) {
-			if (strcmp(gender_str, this->genders[i]) == 0) return i;
+			if (gender_str.compare(this->genders[i]) == 0) return i;
 		}
 		return MAX_NUM_GENDERS;
 	}
@@ -78,10 +78,10 @@ struct LanguagePackHeader {
 	 * @param case_str The string representation of the case.
 	 * @return The index of the case, or MAX_NUM_CASES when the case is unknown.
 	 */
-	uint8_t GetCaseIndex(const char *case_str) const
+	uint8_t GetCaseIndex(std::string_view case_str) const
 	{
 		for (uint8_t i = 0; i < MAX_NUM_CASES; i++) {
-			if (strcmp(case_str, this->cases[i]) == 0) return i;
+			if (case_str.compare(this->cases[i]) == 0) return i;
 		}
 		return MAX_NUM_CASES;
 	}

--- a/src/newgrf/newgrf_act0_globalvar.cpp
+++ b/src/newgrf/newgrf_act0_globalvar.cpp
@@ -302,14 +302,14 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 					LanguageMap::Mapping map;
 					map.newgrf_id = newgrf_id;
 					if (prop == 0x13) {
-						map.openttd_id = lang->GetGenderIndex(name.data());
+						map.openttd_id = lang->GetGenderIndex(name);
 						if (map.openttd_id >= MAX_NUM_GENDERS) {
 							GrfMsg(1, "GlobalVarChangeInfo: Gender name {} is not known, ignoring", StrMakeValid(name));
 						} else {
 							_cur.grffile->language_map[curidx].gender_map.push_back(map);
 						}
 					} else {
-						map.openttd_id = lang->GetCaseIndex(name.data());
+						map.openttd_id = lang->GetCaseIndex(name);
 						if (map.openttd_id >= MAX_NUM_CASES) {
 							GrfMsg(1, "GlobalVarChangeInfo: Case name {} is not known, ignoring", StrMakeValid(name));
 						} else {

--- a/src/script/api/script_text.cpp
+++ b/src/script/api/script_text.cpp
@@ -193,9 +193,9 @@ void ScriptText::_FillParamList(ParamList &params, ScriptTextList &seen_texts)
 	}
 }
 
-void ScriptText::ParamCheck::Encode(std::back_insert_iterator<std::string> &output, const char *cmd)
+void ScriptText::ParamCheck::Encode(std::back_insert_iterator<std::string> &output, std::string_view cmd)
 {
-	if (this->cmd == nullptr) this->cmd = cmd;
+	if (this->cmd.empty()) this->cmd = cmd;
 	if (this->used) return;
 
 	struct visitor {
@@ -286,7 +286,7 @@ void ScriptText::_GetEncodedText(std::back_insert_iterator<std::string> &output,
 				default:
 					for (int i = 0; i < cur_param.consumes; i++) {
 						ParamCheck &p = *get_next_arg();
-						p.Encode(output, i == 0 ? cur_param.cmd : nullptr);
+						p.Encode(output, i == 0 ? cur_param.cmd : "");
 						if (i == 0 && p.cmd != cur_param.cmd) throw 1;
 						if (!std::holds_alternative<SQInteger>(*p.param)) ScriptLog::Error(fmt::format("{}({}): {{{}}} expects an integer", name, param_count + i + 1, cur_param.cmd));
 					}

--- a/src/script/api/script_text.hpp
+++ b/src/script/api/script_text.hpp
@@ -137,11 +137,11 @@ private:
 		int idx;
 		Param *param;
 		bool used = false;
-		const char *cmd = nullptr;
+		std::string_view cmd;
 
 		ParamCheck(StringIndexInTab owner, int idx, Param *param) : owner(owner), idx(idx), param(param) {}
 
-		void Encode(std::back_insert_iterator<std::string> &output, const char *cmd);
+		void Encode(std::back_insert_iterator<std::string> &output, std::string_view cmd);
 	};
 
 	using ParamList = std::vector<ParamCheck>;

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -146,26 +146,26 @@ void FileStringReader::HandlePragma(char *str)
 		_lang.newgrflangid = static_cast<uint8_t>(langid);
 	} else if (!memcmp(str, "gender ", 7)) {
 		if (this->master) FatalError("Genders are not allowed in the base translation.");
-		char *buf = str + 7;
+		const char *buf = str + 7;
 
 		for (;;) {
-			const char *s = ParseWord(&buf);
+			auto s = ParseWord(&buf);
 
-			if (s == nullptr) break;
+			if (!s.has_value()) break;
 			if (_lang.num_genders >= MAX_NUM_GENDERS) FatalError("Too many genders, max {}", MAX_NUM_GENDERS);
-			strecpy(_lang.genders[_lang.num_genders], s);
+			s->copy(_lang.genders[_lang.num_genders], CASE_GENDER_LEN - 1);
 			_lang.num_genders++;
 		}
 	} else if (!memcmp(str, "case ", 5)) {
 		if (this->master) FatalError("Cases are not allowed in the base translation.");
-		char *buf = str + 5;
+		const char *buf = str + 5;
 
 		for (;;) {
-			const char *s = ParseWord(&buf);
+			auto s = ParseWord(&buf);
 
-			if (s == nullptr) break;
+			if (!s.has_value()) break;
 			if (_lang.num_cases >= MAX_NUM_CASES) FatalError("Too many cases, max {}", MAX_NUM_CASES);
-			strecpy(_lang.cases[_lang.num_cases], s);
+			s->copy(_lang.cases[_lang.num_cases], CASE_GENDER_LEN - 1);
 			_lang.num_cases++;
 		}
 	} else {
@@ -344,7 +344,7 @@ int CDECL main(int argc, char *argv[])
 					} else {
 						flags = '0'; // Command needs no parameters
 					}
-					fmt::print("{}\t{:c}\t\"{}\"\t\"{}\"\n", cs.consumes, flags, cs.cmd, strstr(cs.cmd, "STRING") ? "STRING" : cs.cmd);
+					fmt::print("{}\t{:c}\t\"{}\"\t\"{}\"\n", cs.consumes, flags, cs.cmd, cs.cmd.find("STRING") != std::string::npos ? "STRING" : cs.cmd);
 				}
 				return 0;
 

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -35,10 +35,10 @@
 
 void StrgenWarningI(const std::string &msg)
 {
-	if (_show_todo > 0) {
-		fmt::print(stderr, LINE_NUM_FMT("warning"), _file, _cur_line, msg);
-	} else {
+	if (_translation) {
 		fmt::print(stderr, LINE_NUM_FMT("info"), _file, _cur_line, msg);
+	} else {
+		fmt::print(stderr, LINE_NUM_FMT("warning"), _file, _cur_line, msg);
 	}
 	_warnings++;
 }
@@ -364,11 +364,11 @@ int CDECL main(int argc, char *argv[])
 				return 0;
 
 			case 't':
-				_show_todo |= 1;
+				_annotate_todos = true;
 				break;
 
 			case 'w':
-				_show_todo |= 2;
+				_show_warnings = true;
 				break;
 
 			case 'h':
@@ -455,7 +455,7 @@ int CDECL main(int argc, char *argv[])
 				writer.Finalise();
 
 				/* if showing warnings, print a summary of the language */
-				if ((_show_todo & 2) != 0) {
+				if (_show_warnings) {
 					fmt::print("{} warnings and {} errors for {}\n", _warnings, _errors, output_file);
 				}
 			}

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -173,7 +173,7 @@ void FileStringReader::HandlePragma(char *str)
 	}
 }
 
-bool CompareFiles(const std::filesystem::path &path1, const std::filesystem::path &path2)
+static bool CompareFiles(const std::filesystem::path &path1, const std::filesystem::path &path2)
 {
 	/* Check for equal size, but ignore the error code for cases when a file does not exist. */
 	std::error_code error_code;

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -156,7 +156,8 @@ char *ParseWord(char **buf);
 
 extern const char *_file;
 extern int _cur_line;
-extern int _errors, _warnings, _show_todo;
+extern int _errors, _warnings;
+extern bool _show_warnings, _annotate_todos, _translation;
 extern LanguagePackHeader _lang;
 
 #endif /* STRGEN_H */

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -49,7 +49,6 @@ struct StringData {
 	void FreeTranslation();
 	void Add(std::shared_ptr<LangString> ls);
 	LangString *Find(const std::string &s);
-	uint VersionHashStr(uint hash, const char *s) const;
 	uint Version() const;
 	uint CountInUse(uint tab) const;
 };

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -152,7 +152,7 @@ void StrgenErrorI(const std::string &msg);
 #define StrgenWarning(format_string, ...) StrgenWarningI(fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__))
 #define StrgenError(format_string, ...) StrgenErrorI(fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__))
 #define StrgenFatal(format_string, ...) StrgenFatalI(fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__))
-char *ParseWord(char **buf);
+std::optional<std::string_view> ParseWord(const char **buf);
 
 extern const char *_file;
 extern size_t _cur_line;

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -18,10 +18,10 @@
 
 /** Container for the different cases of a string. */
 struct Case {
-	int caseidx;        ///< The index of the case.
+	uint8_t caseidx;       ///< The index of the case.
 	std::string string; ///< The translation of the case.
 
-	Case(int caseidx, const std::string &string);
+	Case(uint8_t caseidx, const std::string &string);
 };
 
 /** Information about a single string. */
@@ -30,10 +30,10 @@ struct LangString {
 	std::string english;    ///< English text.
 	std::string translated; ///< Translated text.
 	size_t index;           ///< The index in the language file.
-	int line;               ///< Line of string in source-file.
+	size_t line;            ///< Line of string in source-file.
 	std::vector<Case> translated_cases; ///< Cases of the translation.
 
-	LangString(const std::string &name, const std::string &english, size_t index, int line);
+	LangString(const std::string &name, const std::string &english, size_t index, size_t line);
 	void FreeTranslation();
 };
 
@@ -49,8 +49,8 @@ struct StringData {
 	void FreeTranslation();
 	void Add(std::shared_ptr<LangString> ls);
 	LangString *Find(const std::string &s);
-	uint Version() const;
-	uint CountInUse(uint tab) const;
+	uint32_t Version() const;
+	size_t CountInUse(size_t tab) const;
 };
 
 /** Helper for reading strings. */
@@ -89,7 +89,7 @@ struct HeaderWriter {
 	 * @param name     The name of the string.
 	 * @param stringid The ID of the string.
 	 */
-	virtual void WriteStringID(const std::string &name, int stringid) = 0;
+	virtual void WriteStringID(const std::string &name, size_t stringid) = 0;
 
 	/**
 	 * Finalise writing the file.
@@ -117,7 +117,7 @@ struct LanguageWriter {
 	 * @param buffer The buffer to write.
 	 * @param length The amount of byte to write.
 	 */
-	virtual void Write(const uint8_t *buffer, size_t length) = 0;
+	virtual void Write(const char *buffer, size_t length) = 0;
 
 	/**
 	 * Finalise writing the file.
@@ -127,7 +127,7 @@ struct LanguageWriter {
 	/** Especially destroy the subclasses. */
 	virtual ~LanguageWriter() = default;
 
-	virtual void WriteLength(uint length);
+	virtual void WriteLength(size_t length);
 	virtual void WriteLang(const StringData &data);
 };
 
@@ -155,8 +155,8 @@ void StrgenErrorI(const std::string &msg);
 char *ParseWord(char **buf);
 
 extern const char *_file;
-extern int _cur_line;
-extern int _errors, _warnings;
+extern size_t _cur_line;
+extern size_t _errors, _warnings;
 extern bool _show_warnings, _annotate_todos, _translation;
 extern LanguagePackHeader _lang;
 

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -235,25 +235,16 @@ void EmitSingleChar(Buffer *buffer, char *buf, int value)
 }
 
 /* The plural specifier looks like
- * {NUM} {PLURAL -1 passenger passengers} then it picks either passenger/passengers depending on the count in NUM */
+ * {NUM} {PLURAL <ARG#> passenger passengers} then it picks either passenger/passengers depending on the count in NUM */
 static bool ParseRelNum(char **buf, int *value, int *offset)
 {
 	const char *s = *buf;
 	char *end;
-	bool rel = false;
 
 	while (*s == ' ' || *s == '\t') s++;
-	if (*s == '+') {
-		rel = true;
-		s++;
-	}
 	int v = std::strtol(s, &end, 0);
 	if (end == s) return false;
-	if (rel || v < 0) {
-		*value += v;
-	} else {
-		*value = v;
-	}
+	*value = v;
 	if (offset != nullptr && *end == ':') {
 		/* Take the Nth within */
 		s = end + 1;

--- a/src/table/strgen_tables.h
+++ b/src/table/strgen_tables.h
@@ -24,7 +24,7 @@ struct CmdStruct {
 	ParseCmdProc proc;
 	long value;
 	uint8_t consumes;
-	int8_t default_plural_offset;
+	std::optional<int> default_plural_offset;
 	CmdFlags flags;
 };
 
@@ -34,49 +34,49 @@ extern void EmitGender(Buffer *buffer, char *buf, int value);
 
 static const CmdStruct _cmd_structs[] = {
 	/* Font size */
-	{"NORMAL_FONT",       EmitSingleChar, SCC_NORMALFONT,         0, -1, {}},
-	{"TINY_FONT",         EmitSingleChar, SCC_TINYFONT,           0, -1, {}},
-	{"BIG_FONT",          EmitSingleChar, SCC_BIGFONT,            0, -1, {}},
-	{"MONO_FONT",         EmitSingleChar, SCC_MONOFONT,           0, -1, {}},
+	{"NORMAL_FONT",       EmitSingleChar, SCC_NORMALFONT,         0, std::nullopt, {}},
+	{"TINY_FONT",         EmitSingleChar, SCC_TINYFONT,           0, std::nullopt, {}},
+	{"BIG_FONT",          EmitSingleChar, SCC_BIGFONT,            0, std::nullopt, {}},
+	{"MONO_FONT",         EmitSingleChar, SCC_MONOFONT,           0, std::nullopt, {}},
 
 	/* Colours */
-	{"BLUE",              EmitSingleChar, SCC_BLUE,               0, -1, {CmdFlag::DontCount}},
-	{"SILVER",            EmitSingleChar, SCC_SILVER,             0, -1, {CmdFlag::DontCount}},
-	{"GOLD",              EmitSingleChar, SCC_GOLD,               0, -1, {CmdFlag::DontCount}},
-	{"RED",               EmitSingleChar, SCC_RED,                0, -1, {CmdFlag::DontCount}},
-	{"PURPLE",            EmitSingleChar, SCC_PURPLE,             0, -1, {CmdFlag::DontCount}},
-	{"LTBROWN",           EmitSingleChar, SCC_LTBROWN,            0, -1, {CmdFlag::DontCount}},
-	{"ORANGE",            EmitSingleChar, SCC_ORANGE,             0, -1, {CmdFlag::DontCount}},
-	{"GREEN",             EmitSingleChar, SCC_GREEN,              0, -1, {CmdFlag::DontCount}},
-	{"YELLOW",            EmitSingleChar, SCC_YELLOW,             0, -1, {CmdFlag::DontCount}},
-	{"DKGREEN",           EmitSingleChar, SCC_DKGREEN,            0, -1, {CmdFlag::DontCount}},
-	{"CREAM",             EmitSingleChar, SCC_CREAM,              0, -1, {CmdFlag::DontCount}},
-	{"BROWN",             EmitSingleChar, SCC_BROWN,              0, -1, {CmdFlag::DontCount}},
-	{"WHITE",             EmitSingleChar, SCC_WHITE,              0, -1, {CmdFlag::DontCount}},
-	{"LTBLUE",            EmitSingleChar, SCC_LTBLUE,             0, -1, {CmdFlag::DontCount}},
-	{"GRAY",              EmitSingleChar, SCC_GRAY,               0, -1, {CmdFlag::DontCount}},
-	{"DKBLUE",            EmitSingleChar, SCC_DKBLUE,             0, -1, {CmdFlag::DontCount}},
-	{"BLACK",             EmitSingleChar, SCC_BLACK,              0, -1, {CmdFlag::DontCount}},
-	{"COLOUR",            EmitSingleChar, SCC_COLOUR,             1, -1, {}},
-	{"PUSH_COLOUR",       EmitSingleChar, SCC_PUSH_COLOUR,        0, -1, {CmdFlag::DontCount}},
-	{"POP_COLOUR",        EmitSingleChar, SCC_POP_COLOUR,         0, -1, {CmdFlag::DontCount}},
+	{"BLUE",              EmitSingleChar, SCC_BLUE,               0, std::nullopt, {CmdFlag::DontCount}},
+	{"SILVER",            EmitSingleChar, SCC_SILVER,             0, std::nullopt, {CmdFlag::DontCount}},
+	{"GOLD",              EmitSingleChar, SCC_GOLD,               0, std::nullopt, {CmdFlag::DontCount}},
+	{"RED",               EmitSingleChar, SCC_RED,                0, std::nullopt, {CmdFlag::DontCount}},
+	{"PURPLE",            EmitSingleChar, SCC_PURPLE,             0, std::nullopt, {CmdFlag::DontCount}},
+	{"LTBROWN",           EmitSingleChar, SCC_LTBROWN,            0, std::nullopt, {CmdFlag::DontCount}},
+	{"ORANGE",            EmitSingleChar, SCC_ORANGE,             0, std::nullopt, {CmdFlag::DontCount}},
+	{"GREEN",             EmitSingleChar, SCC_GREEN,              0, std::nullopt, {CmdFlag::DontCount}},
+	{"YELLOW",            EmitSingleChar, SCC_YELLOW,             0, std::nullopt, {CmdFlag::DontCount}},
+	{"DKGREEN",           EmitSingleChar, SCC_DKGREEN,            0, std::nullopt, {CmdFlag::DontCount}},
+	{"CREAM",             EmitSingleChar, SCC_CREAM,              0, std::nullopt, {CmdFlag::DontCount}},
+	{"BROWN",             EmitSingleChar, SCC_BROWN,              0, std::nullopt, {CmdFlag::DontCount}},
+	{"WHITE",             EmitSingleChar, SCC_WHITE,              0, std::nullopt, {CmdFlag::DontCount}},
+	{"LTBLUE",            EmitSingleChar, SCC_LTBLUE,             0, std::nullopt, {CmdFlag::DontCount}},
+	{"GRAY",              EmitSingleChar, SCC_GRAY,               0, std::nullopt, {CmdFlag::DontCount}},
+	{"DKBLUE",            EmitSingleChar, SCC_DKBLUE,             0, std::nullopt, {CmdFlag::DontCount}},
+	{"BLACK",             EmitSingleChar, SCC_BLACK,              0, std::nullopt, {CmdFlag::DontCount}},
+	{"COLOUR",            EmitSingleChar, SCC_COLOUR,             1, std::nullopt, {}},
+	{"PUSH_COLOUR",       EmitSingleChar, SCC_PUSH_COLOUR,        0, std::nullopt, {CmdFlag::DontCount}},
+	{"POP_COLOUR",        EmitSingleChar, SCC_POP_COLOUR,         0, std::nullopt, {CmdFlag::DontCount}},
 
-	{"REV",               EmitSingleChar, SCC_REVISION,           0, -1, {}}, // openttd revision string
+	{"REV",               EmitSingleChar, SCC_REVISION,           0, std::nullopt, {}}, // openttd revision string
 
-	{"STRING1",           EmitSingleChar, SCC_STRING1,            2, -1, {CmdFlag::Case, CmdFlag::Gender}}, // included string that consumes the string id and ONE argument
-	{"STRING2",           EmitSingleChar, SCC_STRING2,            3, -1, {CmdFlag::Case, CmdFlag::Gender}}, // included string that consumes the string id and TWO arguments
-	{"STRING3",           EmitSingleChar, SCC_STRING3,            4, -1, {CmdFlag::Case, CmdFlag::Gender}}, // included string that consumes the string id and THREE arguments
-	{"STRING4",           EmitSingleChar, SCC_STRING4,            5, -1, {CmdFlag::Case, CmdFlag::Gender}}, // included string that consumes the string id and FOUR arguments
-	{"STRING5",           EmitSingleChar, SCC_STRING5,            6, -1, {CmdFlag::Case, CmdFlag::Gender}}, // included string that consumes the string id and FIVE arguments
-	{"STRING6",           EmitSingleChar, SCC_STRING6,            7, -1, {CmdFlag::Case, CmdFlag::Gender}}, // included string that consumes the string id and SIX arguments
-	{"STRING7",           EmitSingleChar, SCC_STRING7,            8, -1, {CmdFlag::Case, CmdFlag::Gender}}, // included string that consumes the string id and SEVEN arguments
+	{"STRING1",           EmitSingleChar, SCC_STRING1,            2, std::nullopt, {CmdFlag::Case, CmdFlag::Gender}}, // included string that consumes the string id and ONE argument
+	{"STRING2",           EmitSingleChar, SCC_STRING2,            3, std::nullopt, {CmdFlag::Case, CmdFlag::Gender}}, // included string that consumes the string id and TWO arguments
+	{"STRING3",           EmitSingleChar, SCC_STRING3,            4, std::nullopt, {CmdFlag::Case, CmdFlag::Gender}}, // included string that consumes the string id and THREE arguments
+	{"STRING4",           EmitSingleChar, SCC_STRING4,            5, std::nullopt, {CmdFlag::Case, CmdFlag::Gender}}, // included string that consumes the string id and FOUR arguments
+	{"STRING5",           EmitSingleChar, SCC_STRING5,            6, std::nullopt, {CmdFlag::Case, CmdFlag::Gender}}, // included string that consumes the string id and FIVE arguments
+	{"STRING6",           EmitSingleChar, SCC_STRING6,            7, std::nullopt, {CmdFlag::Case, CmdFlag::Gender}}, // included string that consumes the string id and SIX arguments
+	{"STRING7",           EmitSingleChar, SCC_STRING7,            8, std::nullopt, {CmdFlag::Case, CmdFlag::Gender}}, // included string that consumes the string id and SEVEN arguments
 
-	{"STATION_FEATURES",  EmitSingleChar, SCC_STATION_FEATURES,   1, -1, {}}, // station features string, icons of the features
-	{"INDUSTRY",          EmitSingleChar, SCC_INDUSTRY_NAME,      1, -1, {CmdFlag::Case, CmdFlag::Gender}}, // industry, takes an industry #, can have cases
+	{"STATION_FEATURES",  EmitSingleChar, SCC_STATION_FEATURES,   1, std::nullopt, {}}, // station features string, icons of the features
+	{"INDUSTRY",          EmitSingleChar, SCC_INDUSTRY_NAME,      1, std::nullopt, {CmdFlag::Case, CmdFlag::Gender}}, // industry, takes an industry #, can have cases
 	{"CARGO_LONG",        EmitSingleChar, SCC_CARGO_LONG,         2,  1, {CmdFlag::Gender}},
 	{"CARGO_SHORT",       EmitSingleChar, SCC_CARGO_SHORT,        2,  1, {CmdFlag::Gender}}, // short cargo description, only ### tons, or ### litres
 	{"CARGO_TINY",        EmitSingleChar, SCC_CARGO_TINY,         2,  1, {}}, // tiny cargo description with only the amount, not a specifier for the amount or the actual cargo name
-	{"CARGO_LIST",        EmitSingleChar, SCC_CARGO_LIST,         1, -1, {CmdFlag::Case}},
+	{"CARGO_LIST",        EmitSingleChar, SCC_CARGO_LIST,         1, std::nullopt, {CmdFlag::Case}},
 	{"POWER",             EmitSingleChar, SCC_POWER,              1,  0, {}},
 	{"POWER_TO_WEIGHT",   EmitSingleChar, SCC_POWER_TO_WEIGHT,    1,  0, {}},
 	{"VOLUME_LONG",       EmitSingleChar, SCC_VOLUME_LONG,        1,  0, {}},
@@ -92,16 +92,16 @@ static const CmdStruct _cmd_structs[] = {
 	{"UNITS_YEARS_OR_PERIODS",  EmitSingleChar, SCC_UNITS_YEARS_OR_PERIODS,  1,  0, {CmdFlag::Gender}},
 	{"UNITS_YEARS_OR_MINUTES",  EmitSingleChar, SCC_UNITS_YEARS_OR_MINUTES,  1,  0, {CmdFlag::Gender}},
 
-	{"P",                 EmitPlural,     0,                      0, -1, {CmdFlag::DontCount}}, // plural specifier
-	{"G",                 EmitGender,     0,                      0, -1, {CmdFlag::DontCount}}, // gender specifier
+	{"P",                 EmitPlural,     0,                      0, std::nullopt, {CmdFlag::DontCount}}, // plural specifier
+	{"G",                 EmitGender,     0,                      0, std::nullopt, {CmdFlag::DontCount}}, // gender specifier
 
-	{"DATE_TINY",         EmitSingleChar, SCC_DATE_TINY,          1, -1, {}},
-	{"DATE_SHORT",        EmitSingleChar, SCC_DATE_SHORT,         1, -1, {CmdFlag::Case}},
-	{"DATE_LONG",         EmitSingleChar, SCC_DATE_LONG,          1, -1, {CmdFlag::Case}},
-	{"DATE_ISO",          EmitSingleChar, SCC_DATE_ISO,           1, -1, {}},
+	{"DATE_TINY",         EmitSingleChar, SCC_DATE_TINY,          1, std::nullopt, {}},
+	{"DATE_SHORT",        EmitSingleChar, SCC_DATE_SHORT,         1, std::nullopt, {CmdFlag::Case}},
+	{"DATE_LONG",         EmitSingleChar, SCC_DATE_LONG,          1, std::nullopt, {CmdFlag::Case}},
+	{"DATE_ISO",          EmitSingleChar, SCC_DATE_ISO,           1, std::nullopt, {}},
 
-	{"STRING",            EmitSingleChar, SCC_STRING,             1, -1, {CmdFlag::Case, CmdFlag::Gender}},
-	{"RAW_STRING",        EmitSingleChar, SCC_RAW_STRING_POINTER, 1, -1, {CmdFlag::Gender}},
+	{"STRING",            EmitSingleChar, SCC_STRING,             1, std::nullopt, {CmdFlag::Case, CmdFlag::Gender}},
+	{"RAW_STRING",        EmitSingleChar, SCC_RAW_STRING_POINTER, 1, std::nullopt, {CmdFlag::Gender}},
 
 	/* Numbers */
 	{"COMMA",             EmitSingleChar, SCC_COMMA,              1,  0, {}}, // Number with comma
@@ -114,47 +114,47 @@ static const CmdStruct _cmd_structs[] = {
 	{"CURRENCY_LONG",     EmitSingleChar, SCC_CURRENCY_LONG,      1,  0, {}},
 	{"CURRENCY_SHORT",    EmitSingleChar, SCC_CURRENCY_SHORT,     1,  0, {}}, // compact currency
 
-	{"WAYPOINT",          EmitSingleChar, SCC_WAYPOINT_NAME,      1, -1, {CmdFlag::Gender}}, // waypoint name
-	{"STATION",           EmitSingleChar, SCC_STATION_NAME,       1, -1, {CmdFlag::Gender}},
-	{"DEPOT",             EmitSingleChar, SCC_DEPOT_NAME,         2, -1, {CmdFlag::Gender}},
-	{"TOWN",              EmitSingleChar, SCC_TOWN_NAME,          1, -1, {CmdFlag::Gender}},
-	{"GROUP",             EmitSingleChar, SCC_GROUP_NAME,         1, -1, {CmdFlag::Gender}},
-	{"SIGN",              EmitSingleChar, SCC_SIGN_NAME,          1, -1, {CmdFlag::Gender}},
-	{"ENGINE",            EmitSingleChar, SCC_ENGINE_NAME,        1, -1, {CmdFlag::Gender}},
-	{"VEHICLE",           EmitSingleChar, SCC_VEHICLE_NAME,       1, -1, {CmdFlag::Gender}},
-	{"COMPANY",           EmitSingleChar, SCC_COMPANY_NAME,       1, -1, {CmdFlag::Gender}},
-	{"COMPANY_NUM",       EmitSingleChar, SCC_COMPANY_NUM,        1, -1, {}},
-	{"PRESIDENT_NAME",    EmitSingleChar, SCC_PRESIDENT_NAME,     1, -1, {CmdFlag::Gender}},
+	{"WAYPOINT",          EmitSingleChar, SCC_WAYPOINT_NAME,      1, std::nullopt, {CmdFlag::Gender}}, // waypoint name
+	{"STATION",           EmitSingleChar, SCC_STATION_NAME,       1, std::nullopt, {CmdFlag::Gender}},
+	{"DEPOT",             EmitSingleChar, SCC_DEPOT_NAME,         2, std::nullopt, {CmdFlag::Gender}},
+	{"TOWN",              EmitSingleChar, SCC_TOWN_NAME,          1, std::nullopt, {CmdFlag::Gender}},
+	{"GROUP",             EmitSingleChar, SCC_GROUP_NAME,         1, std::nullopt, {CmdFlag::Gender}},
+	{"SIGN",              EmitSingleChar, SCC_SIGN_NAME,          1, std::nullopt, {CmdFlag::Gender}},
+	{"ENGINE",            EmitSingleChar, SCC_ENGINE_NAME,        1, std::nullopt, {CmdFlag::Gender}},
+	{"VEHICLE",           EmitSingleChar, SCC_VEHICLE_NAME,       1, std::nullopt, {CmdFlag::Gender}},
+	{"COMPANY",           EmitSingleChar, SCC_COMPANY_NAME,       1, std::nullopt, {CmdFlag::Gender}},
+	{"COMPANY_NUM",       EmitSingleChar, SCC_COMPANY_NUM,        1, std::nullopt, {}},
+	{"PRESIDENT_NAME",    EmitSingleChar, SCC_PRESIDENT_NAME,     1, std::nullopt, {CmdFlag::Gender}},
 
-	{"SPACE",             EmitSingleChar, ' ',                    0, -1, {CmdFlag::DontCount}},
-	{"",                  EmitSingleChar, '\n',                   0, -1, {CmdFlag::DontCount}},
-	{"{",                 EmitSingleChar, '{',                    0, -1, {CmdFlag::DontCount}},
-	{"UP_ARROW",          EmitSingleChar, SCC_UP_ARROW,           0, -1, {CmdFlag::DontCount}},
-	{"SMALL_UP_ARROW",    EmitSingleChar, SCC_SMALL_UP_ARROW,     0, -1, {CmdFlag::DontCount}},
-	{"SMALL_DOWN_ARROW",  EmitSingleChar, SCC_SMALL_DOWN_ARROW,   0, -1, {CmdFlag::DontCount}},
-	{"TRAIN",             EmitSingleChar, SCC_TRAIN,              0, -1, {CmdFlag::DontCount}},
-	{"LORRY",             EmitSingleChar, SCC_LORRY,              0, -1, {CmdFlag::DontCount}},
-	{"BUS",               EmitSingleChar, SCC_BUS,                0, -1, {CmdFlag::DontCount}},
-	{"PLANE",             EmitSingleChar, SCC_PLANE,              0, -1, {CmdFlag::DontCount}},
-	{"SHIP",              EmitSingleChar, SCC_SHIP,               0, -1, {CmdFlag::DontCount}},
-	{"NBSP",              EmitSingleChar, 0xA0,                   0, -1, {CmdFlag::DontCount}},
-	{"COPYRIGHT",         EmitSingleChar, 0xA9,                   0, -1, {CmdFlag::DontCount}},
-	{"DOWN_ARROW",        EmitSingleChar, SCC_DOWN_ARROW,         0, -1, {CmdFlag::DontCount}},
-	{"CHECKMARK",         EmitSingleChar, SCC_CHECKMARK,          0, -1, {CmdFlag::DontCount}},
-	{"CROSS",             EmitSingleChar, SCC_CROSS,              0, -1, {CmdFlag::DontCount}},
-	{"RIGHT_ARROW",       EmitSingleChar, SCC_RIGHT_ARROW,        0, -1, {CmdFlag::DontCount}},
-	{"SMALL_LEFT_ARROW",  EmitSingleChar, SCC_LESS_THAN,          0, -1, {CmdFlag::DontCount}},
-	{"SMALL_RIGHT_ARROW", EmitSingleChar, SCC_GREATER_THAN,       0, -1, {CmdFlag::DontCount}},
+	{"SPACE",             EmitSingleChar, ' ',                    0, std::nullopt, {CmdFlag::DontCount}},
+	{"",                  EmitSingleChar, '\n',                   0, std::nullopt, {CmdFlag::DontCount}},
+	{"{",                 EmitSingleChar, '{',                    0, std::nullopt, {CmdFlag::DontCount}},
+	{"UP_ARROW",          EmitSingleChar, SCC_UP_ARROW,           0, std::nullopt, {CmdFlag::DontCount}},
+	{"SMALL_UP_ARROW",    EmitSingleChar, SCC_SMALL_UP_ARROW,     0, std::nullopt, {CmdFlag::DontCount}},
+	{"SMALL_DOWN_ARROW",  EmitSingleChar, SCC_SMALL_DOWN_ARROW,   0, std::nullopt, {CmdFlag::DontCount}},
+	{"TRAIN",             EmitSingleChar, SCC_TRAIN,              0, std::nullopt, {CmdFlag::DontCount}},
+	{"LORRY",             EmitSingleChar, SCC_LORRY,              0, std::nullopt, {CmdFlag::DontCount}},
+	{"BUS",               EmitSingleChar, SCC_BUS,                0, std::nullopt, {CmdFlag::DontCount}},
+	{"PLANE",             EmitSingleChar, SCC_PLANE,              0, std::nullopt, {CmdFlag::DontCount}},
+	{"SHIP",              EmitSingleChar, SCC_SHIP,               0, std::nullopt, {CmdFlag::DontCount}},
+	{"NBSP",              EmitSingleChar, 0xA0,                   0, std::nullopt, {CmdFlag::DontCount}},
+	{"COPYRIGHT",         EmitSingleChar, 0xA9,                   0, std::nullopt, {CmdFlag::DontCount}},
+	{"DOWN_ARROW",        EmitSingleChar, SCC_DOWN_ARROW,         0, std::nullopt, {CmdFlag::DontCount}},
+	{"CHECKMARK",         EmitSingleChar, SCC_CHECKMARK,          0, std::nullopt, {CmdFlag::DontCount}},
+	{"CROSS",             EmitSingleChar, SCC_CROSS,              0, std::nullopt, {CmdFlag::DontCount}},
+	{"RIGHT_ARROW",       EmitSingleChar, SCC_RIGHT_ARROW,        0, std::nullopt, {CmdFlag::DontCount}},
+	{"SMALL_LEFT_ARROW",  EmitSingleChar, SCC_LESS_THAN,          0, std::nullopt, {CmdFlag::DontCount}},
+	{"SMALL_RIGHT_ARROW", EmitSingleChar, SCC_GREATER_THAN,       0, std::nullopt, {CmdFlag::DontCount}},
 
 	/* The following are directional formatting codes used to get the RTL strings right:
 	 * http://www.unicode.org/unicode/reports/tr9/#Directional_Formatting_Codes */
-	{"LRM",               EmitSingleChar, CHAR_TD_LRM,            0, -1, {CmdFlag::DontCount}},
-	{"RLM",               EmitSingleChar, CHAR_TD_RLM,            0, -1, {CmdFlag::DontCount}},
-	{"LRE",               EmitSingleChar, CHAR_TD_LRE,            0, -1, {CmdFlag::DontCount}},
-	{"RLE",               EmitSingleChar, CHAR_TD_RLE,            0, -1, {CmdFlag::DontCount}},
-	{"LRO",               EmitSingleChar, CHAR_TD_LRO,            0, -1, {CmdFlag::DontCount}},
-	{"RLO",               EmitSingleChar, CHAR_TD_RLO,            0, -1, {CmdFlag::DontCount}},
-	{"PDF",               EmitSingleChar, CHAR_TD_PDF,            0, -1, {CmdFlag::DontCount}},
+	{"LRM",               EmitSingleChar, CHAR_TD_LRM,            0, std::nullopt, {CmdFlag::DontCount}},
+	{"RLM",               EmitSingleChar, CHAR_TD_RLM,            0, std::nullopt, {CmdFlag::DontCount}},
+	{"LRE",               EmitSingleChar, CHAR_TD_LRE,            0, std::nullopt, {CmdFlag::DontCount}},
+	{"RLE",               EmitSingleChar, CHAR_TD_RLE,            0, std::nullopt, {CmdFlag::DontCount}},
+	{"LRO",               EmitSingleChar, CHAR_TD_LRO,            0, std::nullopt, {CmdFlag::DontCount}},
+	{"RLO",               EmitSingleChar, CHAR_TD_RLO,            0, std::nullopt, {CmdFlag::DontCount}},
+	{"PDF",               EmitSingleChar, CHAR_TD_PDF,            0, std::nullopt, {CmdFlag::DontCount}},
 };
 
 /** Description of a plural form */

--- a/src/table/strgen_tables.h
+++ b/src/table/strgen_tables.h
@@ -17,20 +17,20 @@ enum class CmdFlag : uint8_t {
 using CmdFlags = EnumBitSet<CmdFlag, uint8_t>;
 
 struct Buffer;
-typedef void (*ParseCmdProc)(Buffer *buffer, char *buf, int value);
+typedef void (*ParseCmdProc)(Buffer *buffer, char *buf, char32_t value);
 
 struct CmdStruct {
 	const char *cmd;
 	ParseCmdProc proc;
-	long value;
+	char32_t value;
 	uint8_t consumes;
-	std::optional<int> default_plural_offset;
+	std::optional<size_t> default_plural_offset;
 	CmdFlags flags;
 };
 
-extern void EmitSingleChar(Buffer *buffer, char *buf, int value);
-extern void EmitPlural(Buffer *buffer, char *buf, int value);
-extern void EmitGender(Buffer *buffer, char *buf, int value);
+extern void EmitSingleChar(Buffer *buffer, char *buf, char32_t value);
+extern void EmitPlural(Buffer *buffer, char *buf, char32_t value);
+extern void EmitGender(Buffer *buffer, char *buf, char32_t value);
 
 static const CmdStruct _cmd_structs[] = {
 	/* Font size */
@@ -159,13 +159,13 @@ static const CmdStruct _cmd_structs[] = {
 
 /** Description of a plural form */
 struct PluralForm {
-	int plural_count;        ///< The number of plural forms
+	size_t plural_count;     ///< The number of plural forms
 	const char *description; ///< Human readable description of the form
 	const char *names;       ///< Plural names
 };
 
 /** The maximum number of plurals. */
-static const int MAX_PLURALS = 5;
+static const size_t MAX_PLURALS = 5;
 
 /** All plural forms used */
 static const PluralForm _plural_forms[] = {

--- a/src/table/strgen_tables.h
+++ b/src/table/strgen_tables.h
@@ -17,10 +17,10 @@ enum class CmdFlag : uint8_t {
 using CmdFlags = EnumBitSet<CmdFlag, uint8_t>;
 
 struct Buffer;
-typedef void (*ParseCmdProc)(Buffer *buffer, char *buf, char32_t value);
+typedef void (*ParseCmdProc)(Buffer *buffer, const char *buf, char32_t value);
 
 struct CmdStruct {
-	const char *cmd;
+	std::string_view cmd;
 	ParseCmdProc proc;
 	char32_t value;
 	uint8_t consumes;
@@ -28,9 +28,9 @@ struct CmdStruct {
 	CmdFlags flags;
 };
 
-extern void EmitSingleChar(Buffer *buffer, char *buf, char32_t value);
-extern void EmitPlural(Buffer *buffer, char *buf, char32_t value);
-extern void EmitGender(Buffer *buffer, char *buf, char32_t value);
+extern void EmitSingleChar(Buffer *buffer, const char *buf, char32_t value);
+extern void EmitPlural(Buffer *buffer, const char *buf, char32_t value);
+extern void EmitGender(Buffer *buffer, const char *buf, char32_t value);
 
 static const CmdStruct _cmd_structs[] = {
 	/* Font size */


### PR DESCRIPTION
## Motivation / Problem

Strgen is a bit on the C89 side:
* It often declares variables at the top, and reuses them for different purposes. Instead of declaring variables in a minimal scope.
* It uses a lot of `int` instead of more specific types like `uint32_t`, `char32_t`, `size_t`. It then requires a lot of casts.

## Description

The commits result in these behavior changes:
* Strgen supported a +/- sign in front of plural/gender offsets to specify relative offsets. This is unused and unsupported by the WebTranslators. Remove this "feature".
* `StringData::Version` skipped the first byte of the `STR_xxx` ids in the hash computation for some reason. Now it doesn't.
* Some offsets were not validated and would result in invalid reads instead of error messages.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
