### PR TITLE
Fix #11528: Starting autorail dragging from existing track tiles resulted in adding non-continuous tracks.

### DIFF
--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -889,10 +889,11 @@ static CommandCost CmdRailTrackHelper(DoCommandFlags flags, TileIndex tile, Tile
 	CommandCost last_error = CMD_ERROR;
 	for (;;) {
 		ret = remove ? Command<CMD_REMOVE_SINGLE_RAIL>::Do(flags, tile, TrackdirToTrack(trackdir)) : Command<CMD_BUILD_SINGLE_RAIL>::Do(flags, tile, railtype, TrackdirToTrack(trackdir), auto_remove_signals);
+		if (!remove && ret.Failed() && ret.GetErrorMessage() == STR_ERROR_ALREADY_BUILT) ret = CommandCost(); // Treat "already built" as success
 
 		if (ret.Failed()) {
 			last_error = std::move(ret);
-			if (last_error.GetErrorMessage() != STR_ERROR_ALREADY_BUILT && !remove) {
+			if (!remove) {
 				if (fail_on_obstacle) return last_error;
 				if (had_success) break; // Keep going if we haven't constructed any rail yet, skipping the start of the drag
 			}

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1024,12 +1024,12 @@ CommandCost CmdBuildLongRoad(DoCommandFlags flags, TileIndex end_tile, TileIndex
 		}
 
 		CommandCost ret = Command<CMD_BUILD_ROAD>::Do(flags, tile, bits, rt, drd, TownID::Invalid());
+		if (ret.Failed() && ret.GetErrorMessage() == STR_ERROR_ALREADY_BUILT) ret = CommandCost(); // Treat "already built" as success
+
 		if (ret.Failed()) {
 			last_error = std::move(ret);
-			if (last_error.GetErrorMessage() != STR_ERROR_ALREADY_BUILT) {
-				if (is_ai) return last_error;
-				if (had_success) break; // Keep going if we haven't constructed any road yet, skipping the start of the drag
-			}
+			if (is_ai) return last_error;
+			if (had_success) break; // Keep going if we haven't constructed any road yet, skipping the start of the drag
 		} else {
 			had_success = true;
 			/* Only pay for the upgrade on one side of the bridges and tunnels */


### PR DESCRIPTION
## Motivation / Problem

#11528 

PR #13861 sent me down the hop-over-bridges-while-constructing rabbit hole again. I realized there is a simple change that makes the issue much less likely to happen. It's not a complete fix though, see the limitations section.

## Description

When a autorail drag starts on an invalid tile, it will ignore this tile and keep going. This continues until a piece of track is successfully created. This is to avoid an entire section of rail being discarded due to accidentally starting on wrong tile(s), and was introduces in #11089 (indeed, I caused this issue myself).

Inside the autorail tool there is a special case for the STR_ERROR_ALREADY_BUILT error, which is ignored. But it wouldn't actually mark the start of the drag as a success if it wasn't already done so.  This results in the following behavior:

![openttd_ydcbqQB9Le](https://github.com/user-attachments/assets/0e2807e7-1636-45cf-8093-4f669631e414)
1. Autorail stops as bridge, as expected
2. Autorail adds one piece of track, ignores the existing pieces and stops at the bridge, as expected
3. When the drag is started on an existing piece of rail, it still treats it like an error internally. This means it keeps going until the first valid piece of track can be placed. This occurs _after_ the bridge ramp, which leads to the Red Hot Chili Pepper's favorite track.

With my changes the STR_ERROR_ALREADY_BUILT error is fully treated as a successful build action. As a result the first error occurs _at_ the bridge ramp, and the autorail tools stops there.

## Limitations

- This doesn't actually solve the issue, it just makes it far less likely to occur. It still happens when you start dragging on a bridge end and go over it. In such a case I'd expect the tool to go "over the bridge" as well, and not create track pieces under it.
![openttd_Keqs0uORkE](https://github.com/user-attachments/assets/fea73e53-3280-4b31-82a3-93454d99ee90)
- I have that RHCP song stuck in my head now, but that's just punishment for my bad pun I guess.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
