### PR TITLE
Codefix: std::string_view::data() is not necessarily null terminated.

### DIFF
--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -108,9 +108,9 @@ const FiosItem *FileList::FindItem(const std::string_view file)
 	}
 
 	/* If no name matches, try to parse it as number */
-	char *endptr;
-	int i = std::strtol(file.data(), &endptr, 10);
-	if (file.data() == endptr || *endptr != '\0') i = -1;
+	int i;
+	const char *endptr = std::from_chars(file.data(), file.data() + file.size(), i, 10).ptr;
+	if (file.data() == endptr || endptr != file.data() + file.size()) i = -1;
 
 	if (IsInsideMM(i, 0, this->size())) return &this->at(i);
 

--- a/src/help_gui.cpp
+++ b/src/help_gui.cpp
@@ -51,7 +51,8 @@ static std::optional<std::string> FindGameManualFilePath(std::string_view filena
 	};
 
 	for (Searchpath sp : searchpaths) {
-		auto file_path = FioGetDirectory(sp, subdir) + filename.data();
+		std::string file_path = FioGetDirectory(sp, subdir);
+		file_path.append(filename);
 		if (FioCheckFileExists(file_path, NO_DIRECTORY)) return file_path;
 	}
 

--- a/src/newgrf/newgrf_act0_globalvar.cpp
+++ b/src/newgrf/newgrf_act0_globalvar.cpp
@@ -297,7 +297,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 					 * such as Cyrillic. Thus we will simply assume they're all UTF8. */
 					char32_t c;
 					size_t len = Utf8Decode(&c, name.data());
-					if (c == NFO_UTF8_IDENTIFIER) name = name.substr(len);
+					if (len <= name.size() && c == NFO_UTF8_IDENTIFIER) name = name.substr(len);
 
 					LanguageMap::Mapping map;
 					map.newgrf_id = newgrf_id;

--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -494,7 +494,7 @@ static INT_PTR CALLBACK CrashDialogFunc(HWND wnd, UINT msg, WPARAM wParam, LPARA
 			char *crashlog_dos_nl = reinterpret_cast<char *>(filename_buf + filename_buf_length * filename_count);
 
 			/* Convert unix -> dos newlines because the edit box only supports that properly. */
-			const char *crashlog_unix_nl = crashlog.data();
+			const char *crashlog_unix_nl = crashlog.c_str();
 			char *p = crashlog_dos_nl;
 			char32_t c;
 			while ((c = Utf8Consume(&crashlog_unix_nl))) {

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -128,7 +128,7 @@ bool ScriptInstance::LoadCompatibilityScript(std::string_view api_version, Subdi
 bool ScriptInstance::LoadCompatibilityScripts(Subdirectory dir, std::span<const std::string_view> api_versions)
 {
 	/* Don't try to load compatibility scripts for the current version. */
-	if (this->versionAPI == std::rbegin(api_versions)->data()) return true;
+	if (this->versionAPI == api_versions.back()) return true;
 
 	ScriptLog::Info(fmt::format("Downgrading API to be compatible with version {}", this->versionAPI));
 

--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -444,7 +444,7 @@ void Textbuf::Assign(const std::string_view text)
  */
 void Textbuf::UpdateSize()
 {
-	this->chars = static_cast<uint16_t>(Utf8StringLength(this->buf.data()) + 1); // terminating zero
+	this->chars = static_cast<uint16_t>(Utf8StringLength(this->buf.c_str()) + 1); // terminating zero
 	assert(this->buf.size() < this->max_bytes);
 	assert(this->chars <= this->max_chars);
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1699,7 +1699,7 @@ static void ViewportDrawParentSprites(const ParentSpriteToSortVector *psd, const
 
 		int child_idx = ps->first_child;
 		while (child_idx >= 0) {
-			const ChildScreenSpriteToDraw *cs = csstdv->data() + child_idx;
+			const ChildScreenSpriteToDraw *cs = &(*csstdv)[child_idx];
 			child_idx = cs->next;
 			if (cs->relative) {
 				DrawSpriteViewport(cs->image, cs->pal, ps->left + cs->x, ps->top + cs->y, cs->sub);


### PR DESCRIPTION
## Motivation / Problem

* `std::string::c_str()` is const and null-terminated.
* `std::string::data()` is mutable and null-terminated (since C++11).
* `std::string_view::data()` is NOT necessarily null-terminated.

Treating `std::string_view::data()` as C-string thus potentially results in invalid reads.

## Description

I checked all calls to `data()`, whether they are to `std::string` or to `std::string_view`, and whether they are accompanied by a matching `size()`.
* Replace `std::string::data()` with `std::string::c_str()`, if only a const string is needed.
* Keep `std::string::data`(), if a mutable string is needed.
* Fix usages of `std::string_view::data()` to always use `std::string_view::size()`.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
