### PR TITLE
Codechange: Use EnumBitSet for GoodsEntry status.

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1107,9 +1107,7 @@ static Money DeliverGoods(int num_pieces, CargoType cargo_type, StationID dest, 
 
 	/* Update station statistics */
 	if (accepted_total > 0) {
-		SetBit(st->goods[cargo_type].status, GoodsEntry::GES_EVER_ACCEPTED);
-		SetBit(st->goods[cargo_type].status, GoodsEntry::GES_CURRENT_MONTH);
-		SetBit(st->goods[cargo_type].status, GoodsEntry::GES_ACCEPTED_BIGTICK);
+		st->goods[cargo_type].status.Set({GoodsEntry::State::EverAccepted, GoodsEntry::State::CurrentMonth, GoodsEntry::State::AcceptedBigtick});
 	}
 
 	/* Update company statistics */
@@ -1285,7 +1283,7 @@ void PrepareUnload(Vehicle *front_v)
 			const GoodsEntry *ge = &st->goods[v->cargo_type];
 			if (v->cargo_cap > 0 && v->cargo.TotalCount() > 0) {
 				v->cargo.Stage(
-						HasBit(ge->status, GoodsEntry::GES_ACCEPTANCE),
+						ge->status.Test(GoodsEntry::State::Acceptance),
 						front_v->last_station_visited, next_station,
 						front_v->current_order.GetUnloadType(), ge,
 						v->cargo_type, front_v->cargo_payment,
@@ -1676,7 +1674,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 			uint amount_unloaded = _settings_game.order.gradual_loading ? std::min(cargo_count, GetLoadAmount(v)) : cargo_count;
 			bool remaining = false; // Are there cargo entities in this vehicle that can still be unloaded here?
 
-			if (!HasBit(ge->status, GoodsEntry::GES_ACCEPTANCE) && v->cargo.ActionCount(VehicleCargoList::MTA_DELIVER) > 0) {
+			if (!ge->status.Test(GoodsEntry::State::Acceptance) && v->cargo.ActionCount(VehicleCargoList::MTA_DELIVER) > 0) {
 				/* The station does not accept our goods anymore. */
 				if (front->current_order.GetUnloadType() & (OUFB_TRANSFER | OUFB_UNLOAD)) {
 					/* Transfer instead of delivering. */
@@ -1709,7 +1707,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 					/* Upon transferring cargo, make sure the station has a rating. Fake a pickup for the
 					 * first unload to prevent the cargo from quickly decaying after the initial drop. */
 					ge->time_since_pickup = 0;
-					SetBit(ge->status, GoodsEntry::GES_RATING);
+					ge->status.Set(GoodsEntry::State::Rating);
 				}
 			}
 

--- a/src/linkgraph/linkgraph.cpp
+++ b/src/linkgraph/linkgraph.cpp
@@ -151,7 +151,7 @@ NodeID LinkGraph::AddNode(const Station *st)
 	const GoodsEntry &good = st->goods[this->cargo];
 
 	NodeID new_node = this->Size();
-	this->nodes.emplace_back(st->xy, st->index, HasBit(good.status, GoodsEntry::GES_ACCEPTANCE));
+	this->nodes.emplace_back(st->xy, st->index, good.status.Test(GoodsEntry::State::Acceptance));
 
 	return new_node;
 }

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -462,10 +462,7 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex tile, Ho
 			/* Collect acceptance stats. */
 			uint32_t res = 0;
 			for (Station *st : stations.GetStations()) {
-				if (HasBit(st->goods[cargo_type].status, GoodsEntry::GES_EVER_ACCEPTED))    SetBit(res, 0);
-				if (HasBit(st->goods[cargo_type].status, GoodsEntry::GES_LAST_MONTH))       SetBit(res, 1);
-				if (HasBit(st->goods[cargo_type].status, GoodsEntry::GES_CURRENT_MONTH))    SetBit(res, 2);
-				if (HasBit(st->goods[cargo_type].status, GoodsEntry::GES_ACCEPTED_BIGTICK)) SetBit(res, 3);
+				res |= st->goods[cargo_type].ConvertState();
 			}
 
 			/* Cargo triggered CB 148? */

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1735,7 +1735,7 @@ bool AfterLoadGame()
 		for (Station *st : Station::Iterate()) {
 			for (GoodsEntry &ge : st->goods) {
 				ge.last_speed = 0;
-				if (ge.HasData() && ge.GetData().cargo.AvailableCount() != 0) SetBit(ge.status, GoodsEntry::GES_RATING);
+				if (ge.HasData() && ge.GetData().cargo.AvailableCount() != 0) ge.status.Set(GoodsEntry::State::Rating);
 			}
 		}
 	}

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -724,8 +724,8 @@ static bool LoadOldGood(LoadgameState &ls, int num)
 
 	if (!LoadChunk(ls, ge, goods_chunk)) return false;
 
-	AssignBit(ge->status, GoodsEntry::GES_ACCEPTANCE, HasBit(_waiting_acceptance, 15));
-	AssignBit(ge->status, GoodsEntry::GES_RATING, _cargo_source != 0xFF);
+	ge->status.Set(GoodsEntry::State::Acceptance, HasBit(_waiting_acceptance, 15));
+	ge->status.Set(GoodsEntry::State::Rating, _cargo_source != 0xFF);
 	if (GB(_waiting_acceptance, 0, 12) != 0 && CargoPacket::CanAllocateItem()) {
 		ge->GetOrCreateData().cargo.Append(new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, (_cargo_source == 0xFF) ? StationID::Invalid() : StationID{_cargo_source}, INVALID_TILE, 0),
 				StationID::Invalid());

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -414,7 +414,7 @@ public:
 				SwapPackets(&ge);
 			}
 			if (IsSavegameVersionBefore(SLV_68)) {
-				AssignBit(ge.status, GoodsEntry::GES_ACCEPTANCE, HasBit(_waiting_acceptance, 15));
+				ge.status.Set(GoodsEntry::State::Acceptance, HasBit(_waiting_acceptance, 15));
 				if (GB(_waiting_acceptance, 0, 12) != 0) {
 					/* In old versions, enroute_from used 0xFF as StationID::Invalid() */
 					StationID source = (IsSavegameVersionBefore(SLV_7) && _cargo_source == 0xFF) ? StationID::Invalid() : static_cast<StationID>(_cargo_source);
@@ -428,7 +428,7 @@ public:
 					/* Don't construct the packet with station here, because that'll fail with old savegames */
 					CargoPacket *cp = new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, source, TileIndex{_cargo_source_xy}, _cargo_feeder_share);
 					ge.GetOrCreateData().cargo.Append(cp, StationID::Invalid());
-					SetBit(ge.status, GoodsEntry::GES_RATING);
+					ge.status.Set(GoodsEntry::State::Rating);
 				}
 			}
 		}

--- a/src/script/api/script_cargolist.cpp
+++ b/src/script/api/script_cargolist.cpp
@@ -54,6 +54,6 @@ ScriptCargoList_StationAccepting::ScriptCargoList_StationAccepting(StationID sta
 
 	const Station *st = ::Station::Get(station_id);
 	for (CargoType cargo = 0; cargo < NUM_CARGO; ++cargo) {
-		if (HasBit(st->goods[cargo].status, GoodsEntry::GES_ACCEPTANCE)) this->AddItem(cargo);
+		if (st->goods[cargo].status.Test(GoodsEntry::State::Acceptance)) this->AddItem(cargo);
 	}
 }

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -501,7 +501,7 @@ CargoTypes GetAcceptanceMask(const Station *st)
 	CargoTypes mask = 0;
 
 	for (auto it = std::begin(st->goods); it != std::end(st->goods); ++it) {
-		if (HasBit(it->status, GoodsEntry::GES_ACCEPTANCE)) SetBit(mask, std::distance(std::begin(st->goods), it));
+		if (it->status.Test(GoodsEntry::State::Acceptance)) SetBit(mask, std::distance(std::begin(st->goods), it));
 	}
 	return mask;
 }
@@ -641,7 +641,7 @@ void UpdateStationAcceptance(Station *st, bool show_msg)
 		}
 
 		GoodsEntry &ge = st->goods[cargo];
-		SB(ge.status, GoodsEntry::GES_ACCEPTANCE, 1, amt >= 8);
+		ge.status.Set(GoodsEntry::State::Acceptance, amt >= 8);
 		if (LinkGraph::IsValidID(ge.link_graph)) {
 			(*LinkGraph::Get(ge.link_graph))[ge.node].SetDemand(amt / 8);
 		}
@@ -3753,7 +3753,7 @@ void TriggerWatchedCargoCallbacks(Station *st)
 	/* Collect cargoes accepted since the last big tick. */
 	CargoTypes cargoes = 0;
 	for (CargoType cargo_type = 0; cargo_type < NUM_CARGO; cargo_type++) {
-		if (HasBit(st->goods[cargo_type].status, GoodsEntry::GES_ACCEPTED_BIGTICK)) SetBit(cargoes, cargo_type);
+		if (st->goods[cargo_type].status.Test(GoodsEntry::State::AcceptedBigtick)) SetBit(cargoes, cargo_type);
 	}
 
 	/* Anything to do? */
@@ -3785,7 +3785,7 @@ static bool StationHandleBigTick(BaseStation *st)
 		TriggerWatchedCargoCallbacks(Station::From(st));
 
 		for (GoodsEntry &ge : Station::From(st)->goods) {
-			ClrBit(ge.status, GoodsEntry::GES_ACCEPTED_BIGTICK);
+			ge.status.Reset(GoodsEntry::State::AcceptedBigtick);
 		}
 	}
 
@@ -3845,7 +3845,7 @@ static void UpdateStationRating(Station *st)
 		if (ge->HasRating()) {
 			byte_inc_sat(&ge->time_since_pickup);
 			if (ge->time_since_pickup == 255 && _settings_game.order.selectgoods) {
-				ClrBit(ge->status, GoodsEntry::GES_RATING);
+				ge->status.Reset(GoodsEntry::State::Rating);
 				ge->last_speed = 0;
 				TruncateCargo(cs, ge);
 				waiting_changed = true;
@@ -4222,8 +4222,8 @@ static IntervalTimer<TimerGameEconomy> _economy_stations_monthly({TimerGameEcono
 {
 	for (Station *st : Station::Iterate()) {
 		for (GoodsEntry &ge : st->goods) {
-			SB(ge.status, GoodsEntry::GES_LAST_MONTH, 1, GB(ge.status, GoodsEntry::GES_CURRENT_MONTH, 1));
-			ClrBit(ge.status, GoodsEntry::GES_CURRENT_MONTH);
+			ge.status.Set(GoodsEntry::State::LastMonth, ge.status.Test(GoodsEntry::State::CurrentMonth));
+			ge.status.Reset(GoodsEntry::State::CurrentMonth);
 		}
 	}
 });
@@ -4233,7 +4233,7 @@ void ModifyStationRatingAround(TileIndex tile, Owner owner, int amount, uint rad
 	ForAllStationsRadius(tile, radius, [&](Station *st) {
 		if (st->owner == owner && DistanceManhattan(tile, st->xy) <= radius) {
 			for (GoodsEntry &ge : st->goods) {
-				if (ge.status != 0) {
+				if (ge.status.Any()) {
 					ge.rating = ClampTo<uint8_t>(ge.rating + amount);
 				}
 			}
@@ -4274,7 +4274,7 @@ static uint UpdateStationWaiting(Station *st, CargoType cargo, uint amount, Sour
 
 	if (!ge.HasRating()) {
 		InvalidateWindowData(WC_STATION_LIST, st->owner);
-		SetBit(ge.status, GoodsEntry::GES_RATING);
+		ge.status.Set(GoodsEntry::State::Rating);
 	}
 
 	TriggerStationRandomisation(st, st->xy, SRT_NEW_CARGO, cargo);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

More EnumBitSet.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use `EnumBitSet` for GoodsEntry Status.

Also extracts the conversion from internal state to NewGRF state, which was done properly for houses but not stations.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
