### PR TITLE
Codechange: Use unique_ptr to manage blitters.

### DIFF
--- a/src/blitter/32bpp_anim.hpp
+++ b/src/blitter/32bpp_anim.hpp
@@ -71,7 +71,7 @@ public:
 class FBlitter_32bppAnim : public BlitterFactory {
 public:
 	FBlitter_32bppAnim() : BlitterFactory("32bpp-anim", "32bpp Animation Blitter (palette animation)") {}
-	Blitter *CreateInstance() override { return new Blitter_32bppAnim(); }
+	std::unique_ptr<Blitter> CreateInstance() override { return std::make_unique<Blitter_32bppAnim>(); }
 };
 
 #endif /* BLITTER_32BPP_ANIM_HPP */

--- a/src/blitter/32bpp_anim_sse2.hpp
+++ b/src/blitter/32bpp_anim_sse2.hpp
@@ -38,7 +38,7 @@ public:
 class FBlitter_32bppSSE2_Anim : public BlitterFactory {
 public:
 	FBlitter_32bppSSE2_Anim() : BlitterFactory("32bpp-sse2-anim", "32bpp partially SSE2 Animation Blitter (palette animation)", HasCPUIDFlag(1, 3, 26)) {}
-	Blitter *CreateInstance() override { return new Blitter_32bppSSE2_Anim(); }
+	std::unique_ptr<Blitter> CreateInstance() override { return std::make_unique<Blitter_32bppSSE2_Anim>(); }
 };
 
 #endif /* WITH_SSE */

--- a/src/blitter/32bpp_anim_sse4.hpp
+++ b/src/blitter/32bpp_anim_sse4.hpp
@@ -50,7 +50,7 @@ public:
 class FBlitter_32bppSSE4_Anim: public BlitterFactory {
 public:
 	FBlitter_32bppSSE4_Anim() : BlitterFactory("32bpp-sse4-anim", "32bpp SSE4 Blitter (palette animation)", HasCPUIDFlag(1, 2, 19)) {}
-	Blitter *CreateInstance() override { return static_cast<Blitter_32bppSSE2_Anim *>(new Blitter_32bppSSE4_Anim()); }
+	std::unique_ptr<Blitter> CreateInstance() override { return std::unique_ptr<Blitter>(static_cast<Blitter_32bppSSE2_Anim *>(new Blitter_32bppSSE4_Anim())); }
 };
 
 #endif /* WITH_SSE */

--- a/src/blitter/32bpp_optimized.hpp
+++ b/src/blitter/32bpp_optimized.hpp
@@ -37,7 +37,7 @@ protected:
 class FBlitter_32bppOptimized : public BlitterFactory {
 public:
 	FBlitter_32bppOptimized() : BlitterFactory("32bpp-optimized", "32bpp Optimized Blitter (no palette animation)") {}
-	Blitter *CreateInstance() override { return new Blitter_32bppOptimized(); }
+	std::unique_ptr<Blitter> CreateInstance() override { return std::make_unique<Blitter_32bppOptimized>(); }
 };
 
 #endif /* BLITTER_32BPP_OPTIMIZED_HPP */

--- a/src/blitter/32bpp_simple.hpp
+++ b/src/blitter/32bpp_simple.hpp
@@ -35,7 +35,7 @@ public:
 class FBlitter_32bppSimple : public BlitterFactory {
 public:
 	FBlitter_32bppSimple() : BlitterFactory("32bpp-simple", "32bpp Simple Blitter (no palette animation)") {}
-	Blitter *CreateInstance() override { return new Blitter_32bppSimple(); }
+	std::unique_ptr<Blitter> CreateInstance() override { return std::make_unique<Blitter_32bppSimple>(); }
 };
 
 #endif /* BLITTER_32BPP_SIMPLE_HPP */

--- a/src/blitter/32bpp_sse2.hpp
+++ b/src/blitter/32bpp_sse2.hpp
@@ -98,7 +98,7 @@ public:
 class FBlitter_32bppSSE2 : public BlitterFactory {
 public:
 	FBlitter_32bppSSE2() : BlitterFactory("32bpp-sse2", "32bpp SSE2 Blitter (no palette animation)", HasCPUIDFlag(1, 3, 26)) {}
-	Blitter *CreateInstance() override { return new Blitter_32bppSSE2(); }
+	std::unique_ptr<Blitter> CreateInstance() override { return std::make_unique<Blitter_32bppSSE2>(); }
 };
 
 #endif /* WITH_SSE */

--- a/src/blitter/32bpp_sse4.hpp
+++ b/src/blitter/32bpp_sse4.hpp
@@ -39,7 +39,7 @@ public:
 class FBlitter_32bppSSE4: public BlitterFactory {
 public:
 	FBlitter_32bppSSE4() : BlitterFactory("32bpp-sse4", "32bpp SSE4 Blitter (no palette animation)", HasCPUIDFlag(1, 2, 19)) {}
-	Blitter *CreateInstance() override { return new Blitter_32bppSSE4(); }
+	std::unique_ptr<Blitter> CreateInstance() override { return std::make_unique<Blitter_32bppSSE4>(); }
 };
 
 #endif /* WITH_SSE */

--- a/src/blitter/32bpp_ssse3.hpp
+++ b/src/blitter/32bpp_ssse3.hpp
@@ -39,7 +39,7 @@ public:
 class FBlitter_32bppSSSE3: public BlitterFactory {
 public:
 	FBlitter_32bppSSSE3() : BlitterFactory("32bpp-ssse3", "32bpp SSSE3 Blitter (no palette animation)", HasCPUIDFlag(1, 2, 9)) {}
-	Blitter *CreateInstance() override { return new Blitter_32bppSSSE3(); }
+	std::unique_ptr<Blitter> CreateInstance() override { return std::make_unique<Blitter_32bppSSSE3>(); }
 };
 
 #endif /* WITH_SSE */

--- a/src/blitter/40bpp_anim.hpp
+++ b/src/blitter/40bpp_anim.hpp
@@ -54,7 +54,7 @@ protected:
 
 public:
 	FBlitter_40bppAnim() : BlitterFactory("40bpp-anim", "40bpp Animation Blitter (OpenGL)") {}
-	Blitter *CreateInstance() override { return new Blitter_40bppAnim(); }
+	std::unique_ptr<Blitter> CreateInstance() override { return std::make_unique<Blitter_40bppAnim>(); }
 };
 
 #endif /* BLITTER_40BPP_OPTIMIZED_HPP */

--- a/src/blitter/8bpp_optimized.hpp
+++ b/src/blitter/8bpp_optimized.hpp
@@ -32,7 +32,7 @@ public:
 class FBlitter_8bppOptimized : public BlitterFactory {
 public:
 	FBlitter_8bppOptimized() : BlitterFactory("8bpp-optimized", "8bpp Optimized Blitter (compression + all-ZoomLevel cache)") {}
-	Blitter *CreateInstance() override { return new Blitter_8bppOptimized(); }
+	std::unique_ptr<Blitter> CreateInstance() override { return std::make_unique<Blitter_8bppOptimized>(); }
 };
 
 #endif /* BLITTER_8BPP_OPTIMIZED_HPP */

--- a/src/blitter/8bpp_simple.hpp
+++ b/src/blitter/8bpp_simple.hpp
@@ -26,7 +26,7 @@ public:
 class FBlitter_8bppSimple : public BlitterFactory {
 public:
 	FBlitter_8bppSimple() : BlitterFactory("8bpp-simple", "8bpp Simple Blitter (relative slow, but never wrong)") {}
-	Blitter *CreateInstance() override { return new Blitter_8bppSimple(); }
+	std::unique_ptr<Blitter> CreateInstance() override { return std::make_unique<Blitter_8bppSimple>(); }
 };
 
 #endif /* BLITTER_8BPP_SIMPLE_HPP */

--- a/src/blitter/factory.hpp
+++ b/src/blitter/factory.hpp
@@ -39,10 +39,10 @@ private:
 	 * Get the currently active blitter.
 	 * @return The currently active blitter.
 	 */
-	static Blitter **GetActiveBlitter()
+	static std::unique_ptr<Blitter> &GetActiveBlitter()
 	{
-		static Blitter *s_blitter = nullptr;
-		return &s_blitter;
+		static std::unique_ptr<Blitter> s_blitter = nullptr;
+		return s_blitter;
 	}
 
 protected:
@@ -98,12 +98,10 @@ public:
 		BlitterFactory *b = GetBlitterFactory(name);
 		if (b == nullptr) return nullptr;
 
-		Blitter *newb = b->CreateInstance();
-		delete *GetActiveBlitter();
-		*GetActiveBlitter() = newb;
+		GetActiveBlitter() = b->CreateInstance();
 
-		Debug(driver, 1, "Successfully {} blitter '{}'", name.empty() ? "probed" : "loaded", newb->GetName());
-		return newb;
+		Debug(driver, 1, "Successfully {} blitter '{}'", name.empty() ? "probed" : "loaded", GetCurrentBlitter()->GetName());
+		return GetCurrentBlitter();
 	}
 
 	/**
@@ -137,7 +135,7 @@ public:
 	 */
 	static Blitter *GetCurrentBlitter()
 	{
-		return *GetActiveBlitter();
+		return GetActiveBlitter().get();
 	}
 
 	/**
@@ -175,7 +173,7 @@ public:
 	/**
 	 * Create an instance of this Blitter-class.
 	 */
-	virtual Blitter *CreateInstance() = 0;
+	virtual std::unique_ptr<Blitter> CreateInstance() = 0;
 };
 
 extern std::string _ini_blitter;

--- a/src/blitter/null.hpp
+++ b/src/blitter/null.hpp
@@ -38,7 +38,7 @@ public:
 class FBlitter_Null : public BlitterFactory {
 public:
 	FBlitter_Null() : BlitterFactory("null", "Null Blitter (does nothing)") {}
-	Blitter *CreateInstance() override { return new Blitter_Null(); }
+	std::unique_ptr<Blitter> CreateInstance() override { return std::make_unique<Blitter_Null>(); }
 };
 
 #endif /* BLITTER_NULL_HPP */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Raw pointers used to manage active blitter.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Manage blitter with `std::unique_ptr` instead.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
