### PR TITLE
Codechange: Store GameStrings as shared_ptr.

### DIFF
--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -168,12 +168,12 @@ struct StringNameWriter : HeaderWriter {
  */
 class LanguageScanner : protected FileScanner {
 private:
-	GameStrings *gs;
+	std::weak_ptr<GameStrings> gs;
 	std::string exclude;
 
 public:
 	/** Initialise */
-	LanguageScanner(GameStrings *gs, const std::string &exclude) : gs(gs), exclude(exclude) {}
+	LanguageScanner(std::weak_ptr<GameStrings> gs, const std::string &exclude) : gs(gs), exclude(exclude) {}
 
 	/**
 	 * Scan.
@@ -190,8 +190,12 @@ public:
 		auto ls = ReadRawLanguageStrings(filename);
 		if (!ls.IsValid()) return false;
 
-		gs->raw_strings.push_back(std::move(ls));
-		return true;
+		if (auto sp = this->gs.lock()) {
+			sp->raw_strings.push_back(std::move(ls));
+			return true;
+		}
+
+		return false;
 	}
 };
 
@@ -199,7 +203,7 @@ public:
  * Load all translations that we know of.
  * @return Container with all (compiled) translations.
  */
-GameStrings *LoadTranslations()
+static std::shared_ptr<GameStrings> LoadTranslations()
 {
 	const GameInfo *info = Game::GetInfo();
 	assert(info != nullptr);
@@ -214,7 +218,7 @@ GameStrings *LoadTranslations()
 	auto ls = ReadRawLanguageStrings(filename);
 	if (!ls.IsValid()) return nullptr;
 
-	GameStrings *gs = new GameStrings();
+	auto gs = std::make_shared<GameStrings>();
 	try {
 		gs->raw_strings.push_back(std::move(ls));
 
@@ -245,7 +249,6 @@ GameStrings *LoadTranslations()
 		gs->Compile();
 		return gs;
 	} catch (...) {
-		delete gs;
 		return nullptr;
 	}
 }
@@ -308,7 +311,7 @@ void GameStrings::Compile()
 }
 
 /** The currently loaded game strings. */
-GameStrings *_current_data = nullptr;
+std::shared_ptr<GameStrings> _current_data = nullptr;
 
 /**
  * Get the string pointer of a particular game string.
@@ -355,7 +358,6 @@ const std::string &GetGameStringName(StringIndexInTab id)
  */
 void RegisterGameTranslation(Squirrel *engine)
 {
-	delete _current_data;
 	_current_data = LoadTranslations();
 	if (_current_data == nullptr) return;
 

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -113,7 +113,7 @@ struct GSDTChunkHandler : ChunkHandler {
 	}
 };
 
-extern GameStrings *_current_data;
+extern std::shared_ptr<GameStrings> _current_data;
 
 static std::string _game_saveload_string;
 static uint32_t _game_saveload_strings;
@@ -159,8 +159,7 @@ struct GSTRChunkHandler : ChunkHandler {
 	{
 		const std::vector<SaveLoad> slt = SlCompatTableHeader(_game_language_desc, _game_language_sl_compat);
 
-		delete _current_data;
-		_current_data = new GameStrings();
+		_current_data = std::make_shared<GameStrings>();
 
 		while (SlIterateArray() != -1) {
 			LanguageStrings ls;
@@ -170,8 +169,7 @@ struct GSTRChunkHandler : ChunkHandler {
 
 		/* If there were no strings in the savegame, set GameStrings to nullptr */
 		if (_current_data->raw_strings.empty()) {
-			delete _current_data;
-			_current_data = nullptr;
+			_current_data.reset();
 			return;
 		}
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`GameStrings` is held by a manually managed raw pointer.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use a `shared_ptr` to manage `GameStrings` instead.

Because `LanguageScanner` also keeps a pointer to the (local, at this point) `GameStrings`, we use std::shared_ptr` so that it can be passed as a `std::weak_ptr`, so allow access without inferring ownership.

Due to the existing layout of the code, the previous raw pointer as always safe as the life time of GameStrings always exceeds LanguageScanner, but the there was nothing actually enforcing that.

It is of course possible to use a `std::unique_ptr` and just pass a reference to `LanguageScanner`, but semantically that is a bit wonky...

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
