### PR TITLE
Fix: [Script] Reset instance when changing running scripts in scenario editor

### DIFF
--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -95,6 +95,11 @@ public:
 	 */
 	static class GameInstance *GetInstance() { return Game::instance.get(); }
 
+	/**
+	 * Reset the current active instance.
+	 */
+	static void ResetInstance();
+
 	/** Wrapper function for GameScanner::HasGame */
 	static bool HasGame(const struct ContentInfo *ci, bool md5sum);
 	static bool HasGameLibrary(const ContentInfo *ci, bool md5sum);

--- a/src/game/game_core.cpp
+++ b/src/game/game_core.cpp
@@ -103,8 +103,7 @@
 {
 	Backup<CompanyID> cur_company(_current_company);
 
-	Game::instance.reset();
-	Game::info = nullptr;
+	Game::ResetInstance();
 
 	cur_company.Restore();
 
@@ -162,10 +161,7 @@
 		if (!_settings_game.script_config.game->ResetInfo(true)) {
 			Debug(script, 0, "After a reload, the GameScript by the name '{}' was no longer found, and removed from the list.", _settings_game.script_config.game->GetName());
 			_settings_game.script_config.game->Change(std::nullopt);
-			if (Game::instance != nullptr) {
-				Game::instance.reset();
-				Game::info = nullptr;
-			}
+			if (Game::instance != nullptr) Game::ResetInstance();
 		} else if (Game::instance != nullptr) {
 			Game::info = _settings_game.script_config.game->GetInfo();
 		}
@@ -232,6 +228,12 @@
 /* static */ GameLibrary *Game::FindLibrary(const std::string &library, int version)
 {
 	return Game::scanner_library->FindLibrary(library, version);
+}
+
+/* static */ void Game::ResetInstance()
+{
+	Game::instance.reset();
+	Game::info = nullptr;
 }
 
 /**

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -173,8 +173,21 @@ struct ScriptListWindow : public Window {
 			std::advance(it, this->selected);
 			GetConfig(slot)->Change(it->second->GetName(), it->second->GetVersion());
 		}
+		if (_game_mode == GM_EDITOR) {
+			if (slot == OWNER_DEITY) {
+				if (Game::GetInstance() != nullptr) Game::ResetInstance();
+				Game::StartNew();
+			} else {
+				Company *c = Company::GetIfValid(slot);
+				if (c != nullptr && c->ai_instance != nullptr) {
+					c->ai_instance.reset();
+					AI::StartNew(slot);
+				}
+			}
+		}
 		InvalidateWindowData(WC_GAME_OPTIONS, slot == OWNER_DEITY ? WN_GAME_OPTIONS_GS : WN_GAME_OPTIONS_AI);
 		InvalidateWindowClassesData(WC_SCRIPT_SETTINGS);
+		InvalidateWindowClassesData(WC_SCRIPT_DEBUG, -1);
 		CloseWindowByClass(WC_QUERY_STRING);
 		InvalidateWindowClassesData(WC_TEXTFILE);
 	}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
This is a complement to #13896.

When loading a save/scenario, script saved data is put on stack on instance creation, then script `GameLoop()` actually starts the script, load the data from the stack, then each time `GameLoop()` is called the data on stack is removed.

In scenario editor the `GameLoop()` is not run (only true with #13896, but it was intended to be that way), so data is always present on the stack and put back in savegame/scenario when saving.

When changing running scripts in scenario editor, the underlying config (`c->ai_config` or `_settings_game.script_config.game`) is updated, but the actual loaded script (`c->ai_instance` or `Game::instance`) is still the old one, and when saving the scenario the data from old script (still on stack so `Save()` is not even called, and would not be called at all anyway since script is not started) is used. This most likely cause the new script to crash on next load.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Reset the instance (kill the old script), and start the new one. This discards existing saved data present on stack.
Scripts `GameLoop()` doesn't run in scenario editor (#13896 fixes that for GS) so it will just load the new script, and nothing will be saved since the script is not started.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
