### PR TITLE
Fix: Setting to allow renaming of towns in multiplayer

### DIFF
--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -536,6 +536,7 @@ struct EconomySettings {
 	TownCargoGenMode town_cargogen_mode;     ///< algorithm for generating cargo from houses, @see TownCargoGenMode
 	bool   allow_town_roads;                 ///< towns are allowed to build roads (always allowed when generating world / in SE)
 	TownFounding found_town;                 ///< town founding.
+	bool     town_renaming_allowed;            ///< users can rename towns, even in multiplayer
 	PlaceHouses place_houses;                ///< players are allowed to place town houses.
 	bool   station_noise_level;              ///< build new airports when the town noise level is still within accepted limits
 	uint16_t town_noise_population[4];         ///< population to base decision on noise evaluation (@see town_council_tolerance)

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -382,7 +382,8 @@ public:
 		NWidgetViewport *nvp = this->GetWidget<NWidgetViewport>(WID_TV_VIEWPORT);
 		nvp->InitializeViewport(this, this->town->xy, ScaleZoomGUI(ZOOM_LVL_TOWN));
 
-		/* disable renaming town in network games if you are not the server */
+		/* disable renaming town in network games if you are not the server, unless
+		 * town renaming is explicitly allowed */
 		bool renaming_disabled = _networking && !_network_server;
 		if (_settings_game.economy.town_renaming_allowed) {
 			renaming_disabled = false;

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -383,7 +383,11 @@ public:
 		nvp->InitializeViewport(this, this->town->xy, ScaleZoomGUI(ZOOM_LVL_TOWN));
 
 		/* disable renaming town in network games if you are not the server */
-		this->SetWidgetDisabledState(WID_TV_CHANGE_NAME, _networking && !_network_server);
+		bool renaming_disabled = _networking && !_network_server;
+		if (_settings_game.economy.town_renaming_allowed) {
+			renaming_disabled = false;
+		}
+		this->SetWidgetDisabledState(WID_TV_CHANGE_NAME, renaming_disabled);
 	}
 
 	void Close([[maybe_unused]] int data = 0) override


### PR DESCRIPTION
Fix: Setting to allow renaming of towns in multiplayer

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

This has been impossible for a while (since 2005, see https://www.tt-forums.net/viewtopic.php?t=55670, https://www.reddit.com/r/openttd/comments/651e1q/is_there_a_way_to_allow_all_players_to_edit_town/)

It should be configurable via openttd.cfg for players who would like to enable renaming.

## Limitations

This will need some testing considering the feature has not been active for 20 years, however the default is safe (no renaming allowed).

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
