### PR TITLE
Change: Package OpenGFX2 for Windows Store and GOG

### DIFF
--- a/.github/workflows/release-windows-store.yml
+++ b/.github/workflows/release-windows-store.yml
@@ -74,16 +74,16 @@ jobs:
         mkdir -p builds/common-binaries/baseset
         cd builds/common-binaries/baseset
 
-        echo "::group::Download OpenGFX"
-        curl -L https://cdn.openttd.org/opengfx-releases/7.1/opengfx-7.1-all.zip -o opengfx-all.zip
+        echo "::group::Download OpenGFX2"
+        curl -L https://cdn.openttd.org/opengfx2_classic-releases/0.8/opengfx2_classic-0.8-all.zip -o opengfx2_classic.zip
         echo "::endgroup::"
 
-        echo "::group::Unpack OpenGFX"
-        unzip opengfx-all.zip
-        tar xf opengfx-*.tar
+        echo "::group::Unpack OpenGFX2"
+        unzip opengfx2_classic.zip
+        tar xf OpenGFX2_Classic-0.8.tar
         echo "::endgroup::"
 
-        rm -f opengfx-all.zip opengfx-*.tar
+        rm -f opengfx2_classic.zip OpenGFX2_Classic-0.8.tar
 
     - name: Install OpenMSX
       shell: bash

--- a/.github/workflows/upload-gog.yml
+++ b/.github/workflows/upload-gog.yml
@@ -56,16 +56,16 @@ jobs:
         mkdir -p gog/opengfx/baseset
         cd gog/opengfx/baseset
 
-        echo "::group::Download OpenGFX"
-        curl -L https://cdn.openttd.org/opengfx-releases/7.1/opengfx-7.1-all.zip -o opengfx-all.zip
+        echo "::group::Download OpenGFX2"
+        curl -L https://cdn.openttd.org/opengfx2_classic-releases/0.8/opengfx2_classic-0.8-all.zip -o opengfx2_classic.zip
         echo "::endgroup::"
 
-        echo "::group::Unpack OpenGFX"
-        unzip opengfx-all.zip
-        tar xf opengfx-*.tar
+        echo "::group::Unpack OpenGFX2"
+        unzip opengfx2_classic.zip
+        tar xf OpenGFX2_Classic-0.8.tar
         echo "::endgroup::"
 
-        rm -f opengfx-all.zip opengfx-*.tar
+        rm -f opengfx2_classic.zip OpenGFX2_Classic-0.8.tar
 
     - name: Install OpenMSX
       shell: bash


### PR DESCRIPTION
## Motivation / Problem

[As per discussions here](https://github.com/OpenTTD/OpenTTD/issues/13747), we'd like to update the Windows Store and GOG packaging steps to include OpenGFX2 as the default base graphics.


## Description

Update the Windows Store and GOG workflow steps which fetch base graphics to fetch OpenGFX2. OpenGFX2 builds are currently not automated and not uploaded to the OpenTTD CDS, so point to a Github release URL instead.

OpenGFX2 releases of the 1x zoom 8bpp set are currently named `opengfx2_8` with no version suffix, and are a straight `tar` file instead of being encapsulated in a `zip`. So, update workflow accordingly.

## Limitations

_**I do not fully understand**_ what I'm doing, this is untested, and I don't know how to test it!

Why does the Windows Store release unpack the `.tar`, while GOG upload does not?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
