### PR TITLE
Fix #13921: Broken MIDI playback and crash on exit when using DirectMusic.

### DIFF
--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -1195,7 +1195,10 @@ void MusicDriver_DMusic::Stop()
 		_music = nullptr;
 	}
 
-	CloseHandle(_thread_event);
+	if (_thread_event != nullptr) {
+		CloseHandle(_thread_event);
+		_thread_event = nullptr;
+	}
 
 	CoUninitialize();
 }

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -429,7 +429,7 @@ bool MidiFile::ReadSMFHeader(FileHandle &file, SMFHeader &header)
 
 	/* Check magic, 'MThd' followed by 4 byte length indicator (always = 6 in SMF) */
 	const uint8_t magic[] = { 'M', 'T', 'h', 'd', 0x00, 0x00, 0x00, 0x06 };
-	if (std::ranges::equal(std::span(buffer, std::size(magic)), magic)) {
+	if (!std::ranges::equal(std::span(buffer, std::size(magic)), magic)) {
 		return false;
 	}
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

MIDI files aren't played and instantly skipped. Additionally, OTTD crashes on exit when DirectMusic music driver is used an music was played.

Fixes #13921


## Description

The issues describes two completely unrelated problems.

1. Commit a908c7bed01570377c11d60d66fcf774e3c93930 replaced a `memcmp` with `ranges::equal`. Unfortunately, != 0 corresponds to *not* equal, leading to all valid MIDI files being rejected.
2. Commit d95422561b7c508687c8bf0882e5451373803a44 introduces `unique_ptr` to manage drivers, which makes sure the destructor of the music driver is in fact always called. The DirectMusic driver does a `Stop` there, too, which would be totally fine expect that the thread event handle isn't guarded against double-free like all other driver resources.


## Limitations

No known limitations.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
