### PR TITLE
Fix #13925, 667d0137: Ancient NewGRF have empty name and description, show the filename instead

### DIFF
--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -85,7 +85,7 @@ void GRFConfig::CopyParams(const GRFConfig &src)
 std::string GRFConfig::GetName() const
 {
 	auto name = GetGRFStringFromGRFText(this->name);
-	return name.has_value() ? std::string(*name) : this->filename;
+	return name.has_value() && !name->empty() ? std::string(*name) : this->filename;
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

#13925 

There are a number of ancient NewGRF, which set an empty name and description in Action8.
Probably because TTDPatch did not yet display them anywhere.

(The initial spec says, they are meant for external tools: https://github.com/ttdpatch/NewGRFSpecsHistory/commit/3ad38fb34a33f22273d07405254b8129ccfbf5cb )

## Description

Revert to using the filename, if Action8 is present but sets empty name.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
