### PR TITLE
Fix #13923: Padding in music GUI was asymmetric, so it looked different for LTR and RTL languages.

### DIFF
--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -738,7 +738,7 @@ struct MusicWindow : public Window {
 	{
 		switch (widget) {
 			case WID_M_TRACK_NR: {
-				GfxFillRect(r.Shrink(WidgetDimensions::scaled.bevel.left, WidgetDimensions::scaled.bevel.top, 0, WidgetDimensions::scaled.bevel.bottom), PC_BLACK);
+				GfxFillRect(r.Shrink(WidgetDimensions::scaled.bevel), PC_BLACK);
 				if (BaseMusic::GetUsedSet()->num_available == 0) {
 					break;
 				}
@@ -752,7 +752,7 @@ struct MusicWindow : public Window {
 			}
 
 			case WID_M_TRACK_NAME: {
-				GfxFillRect(r.Shrink(0, WidgetDimensions::scaled.bevel.top, WidgetDimensions::scaled.bevel.right, WidgetDimensions::scaled.bevel.bottom), PC_BLACK);
+				GfxFillRect(r.Shrink(WidgetDimensions::scaled.bevel), PC_BLACK);
 				Rect ir = r.Shrink(WidgetDimensions::scaled.framerect);
 
 				MusicSystem::PlaylistEntry entry(_music.GetCurrentSong());


### PR DESCRIPTION
## Motivation / Problem

#13923

## Description

Instead of removing the separator, I added it for both text directions:

![image](https://github.com/user-attachments/assets/a142e293-3425-4afd-8b2a-abf5f4894395)

![image](https://github.com/user-attachments/assets/90514d3c-04ac-48f9-ad13-44dacf4d2630)


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
