### PR TITLE
Add #12939: [NewGRF] Add road-/tram-/rail-type variable 0x45 to get mutual road-/tram-/rail-type on same tile

### DIFF
--- a/src/newgrf_railtype.cpp
+++ b/src/newgrf_railtype.cpp
@@ -11,6 +11,7 @@
 #include "core/container_func.hpp"
 #include "debug.h"
 #include "newgrf_railtype.h"
+#include "newgrf_roadtype.h"
 #include "timer/timer_game_calendar.h"
 #include "depot_base.h"
 #include "town.h"
@@ -33,6 +34,12 @@
 			case 0x42: return 0;
 			case 0x43: return TimerGameCalendar::date.base();
 			case 0x44: return HZB_TOWN_EDGE;
+			case 0x45: {
+				auto rt = GetRailTypeInfoIndex(this->rti);
+				uint8_t local = GetReverseRailTypeTranslation(rt, this->ro.grffile);
+				if (local == 0xFF) local = 0xFE;
+				return 0xFFFF | local << 16;
+			}
 		}
 	}
 
@@ -52,6 +59,8 @@
 			}
 			return t != nullptr ? GetTownRadiusGroup(t, this->tile) : HZB_TOWN_EDGE;
 		}
+		case 0x45:
+			return GetTrackTypes(this->tile, ro.grffile);
 	}
 
 	Debug(grf, 1, "Unhandled rail type tile variable 0x{:X}", variable);

--- a/src/newgrf_roadtype.cpp
+++ b/src/newgrf_roadtype.cpp
@@ -11,12 +11,47 @@
 #include "core/container_func.hpp"
 #include "debug.h"
 #include "newgrf_roadtype.h"
+#include "newgrf_railtype.h"
 #include "timer/timer_game_calendar.h"
 #include "depot_base.h"
 #include "town.h"
 #include "tunnelbridge_map.h"
 
 #include "safeguards.h"
+
+/**
+ * Variable 0x45 of road-/tram-/rail-types to query track types on a tile.
+ *
+ * Format: __RRttrr
+ * - rr: Translated roadtype.
+ * - tt: Translated tramtype.
+ * - RR: Translated railtype.
+ *
+ * Special values for rr, tt, RR:
+ * - 0xFF: Track not present on tile.
+ * - 0xFE: Track present, but no matching entry in translation table.
+ */
+uint32_t GetTrackTypes(TileIndex tile, const GRFFile *grffile)
+{
+	uint8_t road = 0xFF;
+	uint8_t tram = 0xFF;
+	if (MayHaveRoad(tile)) {
+		if (auto tt = GetRoadTypeRoad(tile); tt != INVALID_ROADTYPE) {
+			road = GetReverseRoadTypeTranslation(tt, grffile);
+			if (road == 0xFF) road = 0xFE;
+		}
+		if (auto tt = GetRoadTypeTram(tile); tt != INVALID_ROADTYPE) {
+			tram = GetReverseRoadTypeTranslation(tt, grffile);
+			if (tram == 0xFF) tram = 0xFE;
+		}
+	}
+	uint8_t rail = 0xFF;
+	if (auto tt = GetTileRailType(tile); tt != INVALID_RAILTYPE) {
+		rail = GetReverseRailTypeTranslation(tt, grffile);
+		if (rail == 0xFF) rail = 0xFE;
+	}
+	return road | tram << 8 | rail << 16;
+}
 
 /* virtual */ uint32_t RoadTypeScopeResolver::GetRandomBits() const
 {
@@ -33,6 +68,16 @@
 			case 0x42: return 0;
 			case 0x43: return TimerGameCalendar::date.base();
 			case 0x44: return HZB_TOWN_EDGE;
+			case 0x45: {
+				auto rt = GetRoadTypeInfoIndex(this->rti);
+				uint8_t local = GetReverseRoadTypeTranslation(rt, this->ro.grffile);
+				if (local == 0xFF) local = 0xFE;
+				if (RoadTypeIsRoad(rt)) {
+					return 0xFFFF00 | local;
+				} else {
+					return 0xFF00FF | local << 8;
+				}
+			}
 		}
 	}
 
@@ -52,6 +97,8 @@
 			}
 			return t != nullptr ? GetTownRadiusGroup(t, this->tile) : HZB_TOWN_EDGE;
 		}
+		case 0x45:
+			return GetTrackTypes(this->tile, ro.grffile);
 	}
 
 	Debug(grf, 1, "Unhandled road type tile variable 0x{:X}", variable);

--- a/src/newgrf_roadtype.h
+++ b/src/newgrf_roadtype.h
@@ -59,6 +59,8 @@ SpriteID GetCustomRoadSprite(const RoadTypeInfo *rti, TileIndex tile, RoadTypeSp
 RoadType GetRoadTypeTranslation(RoadTramType rtt, uint8_t tracktype, const GRFFile *grffile);
 uint8_t GetReverseRoadTypeTranslation(RoadType roadtype, const GRFFile *grffile);
 
+uint32_t GetTrackTypes(TileIndex tile, const GRFFile *grffile);
+
 void ConvertRoadTypes();
 void SetCurrentRoadTypeLabelList();
 void ClearRoadTypeLabelList();

--- a/src/rail.h
+++ b/src/rail.h
@@ -305,6 +305,19 @@ inline const RailTypeInfo *GetRailTypeInfo(RailType railtype)
 }
 
 /**
+ * Returns the railtype for a Railtype information.
+ * @param rti Pointer to static RailTypeInfo
+ * @return Railtype in static railtype definitions
+ */
+inline RailType GetRailTypeInfoIndex(const RailTypeInfo *rti)
+{
+	extern RailTypeInfo _railtypes[RAILTYPE_END];
+	size_t index = rti - _railtypes;
+	assert(index < RAILTYPE_END && rti == _railtypes + index);
+	return static_cast<RailType>(index);
+}
+
+/**
  * Checks if an engine of the given RailType can drive on a tile with a given
  * RailType. This would normally just be an equality check, but for electric
  * rails (which also support non-electric engines).

--- a/src/road.h
+++ b/src/road.h
@@ -235,6 +235,19 @@ inline const RoadTypeInfo *GetRoadTypeInfo(RoadType roadtype)
 }
 
 /**
+ * Returns the railtype for a Railtype information.
+ * @param rti Pointer to static RailTypeInfo
+ * @return Railtype in static railtype definitions
+ */
+inline RoadType GetRoadTypeInfoIndex(const RoadTypeInfo *rti)
+{
+	extern RoadTypeInfo _roadtypes[ROADTYPE_END];
+	size_t index = rti - _roadtypes;
+	assert(index < ROADTYPE_END && rti == _roadtypes + index);
+	return static_cast<RoadType>(index);
+}
+
+/**
  * Checks if an engine of the given RoadType got power on a tile with a given
  * RoadType. This would normally just be an equality check, but for electrified
  * roads (which also support non-electric vehicles).

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -451,6 +451,7 @@ static const NIVariable _niv_railtypes[] = {
 	NIV(0x42, "level crossing status"),
 	NIV(0x43, "construction date"),
 	NIV(0x44, "town zone"),
+	NIV(0x45, "track types"),
 };
 
 class NIHRailType : public NIHelper {
@@ -620,6 +621,7 @@ static const NIVariable _niv_roadtypes[] = {
 	NIV(0x42, "level crossing status"),
 	NIV(0x43, "construction date"),
 	NIV(0x44, "town zone"),
+	NIV(0x45, "track types"),
 };
 
 template <RoadTramType TRoadTramType>


### PR DESCRIPTION
## Motivation / Problem

#12939, #13323

## Description

Add variable 0x45 to road-, tram- and rail-types.
* Format: xxRRttrr
    * rr: roadtype
    * tt: tramtype
    * RR: railtype
    * xx: reserved
* Value 0xFF for a type means "not present".
* Value 0xFE for a type means "present, but no matching entry in translation table".

Besides querying the specific road-/tram-/rail-type, this also allows detecting level crossings.

Somewhat unsual, this variable also allows road-/tram-/rail-types to query their own type. I do not know a purpose for this, but leaving the bits empty was weird as well.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
