### PR TITLE
Codefix: std::string_view does not accept nullptr

### DIFF
--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -273,7 +273,7 @@ static void ExtractStringParams(const StringData &data, StringParamsList &params
 				if (*it == nullptr) {
 					/* Skip empty param unless a non empty param exist after it. */
 					if (std::all_of(it, pcs.consuming_commands.end(), [](auto cs) { return cs == nullptr; })) break;
-					param.emplace_back(StringParam::UNUSED, 1, nullptr);
+					param.emplace_back(StringParam::UNUSED, 1);
 					continue;
 				}
 				const CmdStruct *cs = *it;

--- a/src/game/game_text.hpp
+++ b/src/game/game_text.hpp
@@ -24,7 +24,7 @@ struct StringParam {
 	uint8_t consumes;
 	std::string_view cmd;
 
-	StringParam(ParamType type, uint8_t consumes, std::string_view cmd) : type(type), consumes(consumes), cmd(cmd) {}
+	StringParam(ParamType type, uint8_t consumes, std::string_view cmd = {}) : type(type), consumes(consumes), cmd(cmd) {}
 };
 using StringParams = std::vector<StringParam>;
 using StringParamsList = std::vector<StringParams>;


### PR DESCRIPTION
## Motivation / Problem

```
  In file included from /opt/rh/gcc-toolset-14/root/usr/include/c++/14/string:42,
                   from /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/locale_classes.h:40,
                   from /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/ios_base.h:41,
                   from /opt/rh/gcc-toolset-14/root/usr/include/c++/14/streambuf:43,
                   from /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/streambuf_iterator.h:35,
                   from /opt/rh/gcc-toolset-14/root/usr/include/c++/14/iterator:66,
                   from /__w/OpenTTD/OpenTTD/src/stdafx.h:60,
                   from /__w/OpenTTD/OpenTTD/build/CMakeFiles/openttd_lib.dir/cmake_pch.hxx:5,
                   from <command-line>:
  In static member function ‘static constexpr std::size_t std::char_traits<char>::length(const char_type*)’,
      inlined from ‘constexpr std::basic_string_view<_CharT, _Traits>::basic_string_view(const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>]’ at /opt/rh/gcc-toolset-14/root/usr/include/c++/14/string_view:141:35,
      inlined from ‘constexpr decltype (::new(void*(0)) _Tp) std::construct_at(_Tp*, _Args&& ...) [with _Tp = StringParam; _Args = {StringParam::ParamType, int, std::nullptr_t}]’ at /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/stl_construct.h:97:14,
      inlined from ‘static constexpr void std::allocator_traits<std::allocator<_Up> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = StringParam; _Args = {StringParam::ParamType, int, std::nullptr_t}; _Tp = StringParam]’ at /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/alloc_traits.h:577:21,
      inlined from ‘constexpr std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::emplace_back(_Args&& ...) [with _Args = {StringParam::ParamType, int, std::nullptr_t}; _Tp = StringParam; _Alloc = std::allocator<StringParam>]’ at /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/vector.tcc:117:30,
      inlined from ‘void ExtractStringParams(const StringData&, StringParamsList&)’ at /__w/OpenTTD/OpenTTD/src/game/game_text.cpp:276:24,
      inlined from ‘void GameStrings::Compile()’ at /__w/OpenTTD/OpenTTD/src/game/game_text.cpp:296:21:
  Warning: /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/char_traits.h:391:32: warning: argument 1 null where non-null expected [-Wnonnull]
    391 |         return __builtin_strlen(__s);
        |                ~~~~~~~~~~~~~~~~^~~~~
```


## Description

Don't pass `nullptr` to become `std::string_view`, just use the default constructor of `std::string_view` to create an empty view.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
