### PR TITLE
Codefix: return right type to prevent casting

### DIFF
--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -403,9 +403,9 @@ static const CmdStruct *FindCmd(std::string_view s)
 	return nullptr;
 }
 
-static uint ResolveCaseName(std::string_view str)
+static uint8_t ResolveCaseName(std::string_view str)
 {
-	uint case_idx = _lang.GetCaseIndex(str);
+	uint8_t case_idx = _lang.GetCaseIndex(str);
 	if (case_idx >= MAX_NUM_CASES) StrgenFatal("Invalid case-name '{}'", str);
 	return case_idx + 1;
 }


### PR DESCRIPTION
## Motivation / Problem

```
Warning: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\optional(156): warning C4267: '=': conversion from 'size_t' to '_Ty', possible loss of data
          with
          [
              _Ty=uint8_t
          ]
  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\optional(156): note: the template instantiation context (the oldest one first) is
  D:\a\OpenTTD\OpenTTD\src\strgen\strgen_base.cpp(457): note: see reference to function template instantiation 'std::optional<uint8_t> &std::optional<uint8_t>::operator =<uint,0>(_Ty2 &&) noexcept' being compiled
          with
          [
              _Ty2=uint
          ]
  D:\a\OpenTTD\OpenTTD\src\strgen\strgen_base.cpp(457): note: see the first reference to 'std::optional<uint8_t>::operator =' in 'ParseCommandString'
...
```


## Description

`result.casei` is `std::optional<uint8_t>`, `ResolveCaseName` returns `uint`. Within `ResolveCaseName` `_lang.GetCaseIndex(str)` returns `uint8_t` and `MAX_NUM_CASES` is `uint8_t`, so... the `uint`s can be `uint8_t` without any need for casting.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
