### PR TITLE
Remove C-style string parsing

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -27,6 +27,8 @@ add_files(
     string_builder.hpp
     string_consumer.cpp
     string_consumer.hpp
+    string_inplace.cpp
+    string_inplace.hpp
     strong_typedef_type.hpp
     utf8.cpp
     utf8.hpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -25,6 +25,8 @@ add_files(
     smallstack_type.hpp
     string_builder.cpp
     string_builder.hpp
+    string_consumer.cpp
+    string_consumer.hpp
     strong_typedef_type.hpp
     utf8.cpp
     utf8.hpp

--- a/src/core/string_consumer.cpp
+++ b/src/core/string_consumer.cpp
@@ -1,0 +1,196 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file string_consumer.cpp Implementation of string parsing. */
+
+#include "../stdafx.h"
+#include "string_consumer.hpp"
+
+#include "bitmath_func.hpp"
+#include "utf8.hpp"
+#include "string_builder.hpp"
+
+#include "../string_func.h"
+
+#if defined(STRGEN) || defined(SETTINGSGEN)
+#include "../error_func.h"
+#else
+#include "../debug.h"
+#endif
+
+#include "../safeguards.h"
+
+const std::string_view StringConsumer::WHITESPACE_NO_NEWLINE = "\t\v\f\r ";
+const std::string_view StringConsumer::WHITESPACE_OR_NEWLINE = "\t\n\v\f\r ";
+
+/* static */ void StringConsumer::LogError(std::string &&msg)
+{
+#if defined(STRGEN) || defined(SETTINGSGEN)
+	FatalErrorI(std::move(msg));
+#else
+	DebugPrint("misc", 0, std::move(msg));
+#endif
+}
+
+std::optional<uint8_t> StringConsumer::PeekUint8() const
+{
+	if (this->GetBytesLeft() < 1) return std::nullopt;
+	return static_cast<uint8_t>(this->src[this->position]);
+}
+
+std::optional<uint16_t> StringConsumer::PeekUint16LE() const
+{
+	if (this->GetBytesLeft() < 2) return std::nullopt;
+	return static_cast<uint8_t>(this->src[this->position]) |
+		static_cast<uint8_t>(this->src[this->position + 1]) << 8;
+}
+
+std::optional<uint32_t> StringConsumer::PeekUint32LE() const
+{
+	if (this->GetBytesLeft() < 4) return std::nullopt;
+	return static_cast<uint8_t>(this->src[this->position]) |
+		static_cast<uint8_t>(this->src[this->position + 1]) << 8 |
+		static_cast<uint8_t>(this->src[this->position + 2]) << 16 |
+		static_cast<uint8_t>(this->src[this->position + 3]) << 24;
+}
+
+std::optional<uint64_t> StringConsumer::PeekUint64LE() const
+{
+	if (this->GetBytesLeft() < 8) return std::nullopt;
+	return static_cast<uint64_t>(static_cast<uint8_t>(this->src[this->position])) |
+		static_cast<uint64_t>(static_cast<uint8_t>(this->src[this->position + 1])) << 8 |
+		static_cast<uint64_t>(static_cast<uint8_t>(this->src[this->position + 2])) << 16 |
+		static_cast<uint64_t>(static_cast<uint8_t>(this->src[this->position + 3])) << 24 |
+		static_cast<uint64_t>(static_cast<uint8_t>(this->src[this->position + 4])) << 32 |
+		static_cast<uint64_t>(static_cast<uint8_t>(this->src[this->position + 5])) << 40 |
+		static_cast<uint64_t>(static_cast<uint8_t>(this->src[this->position + 6])) << 48 |
+		static_cast<uint64_t>(static_cast<uint8_t>(this->src[this->position + 7])) << 56;
+}
+
+std::optional<char> StringConsumer::PeekChar() const
+{
+	auto result = this->PeekUint8();
+	if (!result.has_value()) return {};
+	return static_cast<char>(*result);
+}
+
+std::pair<StringConsumer::size_type, char32_t> StringConsumer::PeekUtf8() const
+{
+	auto buf = this->src.substr(this->position);
+	return DecodeUtf8(buf);
+}
+
+std::string_view StringConsumer::Peek(size_type len) const
+{
+	auto buf = this->src.substr(this->position);
+	if (len == std::string_view::npos) {
+		len = buf.size();
+	} else if (len > buf.size()) {
+		len = buf.size();
+	}
+	return buf.substr(0, len);
+}
+
+void StringConsumer::Skip(size_type len)
+{
+	if (len == std::string_view::npos) {
+		this->position = this->src.size();
+	} else if (size_type max_len = GetBytesLeft(); len > max_len) {
+		LogError(fmt::format("Source buffer too short: {} > {}", len, max_len));
+		this->position = this->src.size();
+	} else {
+		this->position += len;
+	}
+}
+
+StringConsumer::size_type StringConsumer::Find(std::string_view str) const
+{
+	assert(!str.empty());
+	auto buf = this->src.substr(this->position);
+	return buf.find(str);
+}
+
+StringConsumer::size_type StringConsumer::FindUtf8(char32_t c) const
+{
+	auto [data, len] = EncodeUtf8(c);
+	return this->Find({data, len});
+}
+
+StringConsumer::size_type StringConsumer::FindCharIn(std::string_view chars) const
+{
+	assert(!chars.empty());
+	auto buf = this->src.substr(this->position);
+	return buf.find_first_of(chars);
+}
+
+StringConsumer::size_type StringConsumer::FindCharNotIn(std::string_view chars) const
+{
+	assert(!chars.empty());
+	auto buf = this->src.substr(this->position);
+	return buf.find_first_not_of(chars);
+}
+
+std::string_view StringConsumer::PeekUntil(std::string_view str, SeparatorUsage sep) const
+{
+	assert(!str.empty());
+	auto buf = this->src.substr(this->position);
+	auto len = buf.find(str);
+	if (len != std::string_view::npos) {
+		switch (sep) {
+			case READ_ONE_SEPARATOR:
+				if (buf.compare(len, str.size(), str) == 0) len += str.size();
+				break;
+			case READ_ALL_SEPARATORS:
+				while (buf.compare(len, str.size(), str) == 0) len += str.size();
+				break;
+			default:
+				break;
+		}
+	}
+	return buf.substr(0, len);
+}
+
+std::string_view StringConsumer::PeekUntilUtf8(char32_t c, SeparatorUsage sep) const
+{
+	auto [data, len] = EncodeUtf8(c);
+	return PeekUntil({data, len}, sep);
+}
+
+std::string_view StringConsumer::ReadUntilUtf8(char32_t c, SeparatorUsage sep)
+{
+	auto [data, len] = EncodeUtf8(c);
+	return ReadUntil({data, len}, sep);
+}
+
+void StringConsumer::SkipUntilUtf8(char32_t c, SeparatorUsage sep)
+{
+	auto [data, len] = EncodeUtf8(c);
+	return SkipUntil({data, len}, sep);
+}
+
+void StringConsumer::SkipIntegerBase(int base)
+{
+	this->SkipIf("-");
+	if (base == 0) {
+		if (this->ReadIf("0x") || this->ReadIf("0X")) { // boolean short-circuit ensures only one prefix is read
+			base = 16;
+		} else {
+			base = 10;
+		}
+	}
+	switch (base) {
+		default:
+			assert(false);
+			break;
+		case 10:
+			this->SkipUntilCharNotIn("0123456789");
+			break;
+		case 16:
+			this->SkipUntilCharNotIn("0123456789abcdefABCDEF");
+			break;
+	}
+}

--- a/src/core/string_consumer.hpp
+++ b/src/core/string_consumer.hpp
@@ -1,0 +1,895 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file string_consumer.hpp Parse strings.
+ */
+
+#ifndef STRING_CONSUMER_HPP
+#define STRING_CONSUMER_HPP
+
+#include <charconv>
+#include "format.hpp"
+
+/**
+ * Parse data from a string / buffer.
+ *
+ * There are generally four operations for each data type:
+ * - Peek: Check and return validity and value. Do not advance read position.
+ * - TryRead: Check and return validity and value. Advance reader, if valid.
+ * - Read: Check validity, return value or fallback-value. Advance reader, even if value is invalid, to avoid deadlocks/stalling.
+ * - Skip: Discard value. Advance reader, even if value is invalid, to avoid deadlocks/stalling.
+ */
+class StringConsumer {
+public:
+	using size_type = std::string_view::size_type;
+
+	/**
+	 * Special value for "end of data".
+	 */
+	static constexpr size_type npos = std::string_view::npos;
+
+	/**
+	 * ASCII whitespace characters, excluding new-line.
+	 * Usable in FindChar(In|NotIn), (Peek|Read|Skip)(If|Until)Char(In|NotIn)
+	 */
+	static const std::string_view WHITESPACE_NO_NEWLINE;
+	/**
+	 * ASCII whitespace characters, including new-line.
+	 * Usable in FindChar(In|NotIn), (Peek|Read|Skip)(If|Until)Char(In|NotIn)
+	 */
+	static const std::string_view WHITESPACE_OR_NEWLINE;
+
+private:
+	std::string_view src;
+	size_type position = 0;
+
+	static void LogError(std::string &&msg);
+
+public:
+	/**
+	 * Construct parser with data from string.
+	 */
+	explicit StringConsumer(std::string_view src) : src(src) {}
+	/**
+	 * Construct parser with data from string.
+	 */
+	explicit StringConsumer(const std::string &src) : src(src) {}
+	/**
+	 * Construct parser with data from span.
+	 */
+	explicit StringConsumer(std::span<const char> src) : src(src.data(), src.size()) {}
+	/**
+	 * Construct parser with data from buffer.
+	 */
+	StringConsumer(const char *src, size_type len) : src(src, len) {}
+
+	/**
+	 * Check whether any bytes left to read.
+	 */
+	[[nodiscard]] bool AnyBytesLeft() const noexcept { return this->position < this->src.size(); }
+	/**
+	 * Get number of bytes left to read.
+	 */
+	[[nodiscard]] size_type GetBytesLeft() const noexcept { return this->src.size() - this->position; }
+
+	/**
+	 * Check wheter any bytes were already read.
+	 */
+	[[nodiscard]] bool AnyBytesRead() const noexcept { return this->position > 0; }
+	/**
+	 * Get number of already read bytes.
+	 */
+	[[nodiscard]] size_type GetBytesRead() const noexcept { return this->position; }
+
+	/**
+	 * Get the original data, as passed to the constructor.
+	 */
+	[[nodiscard]] std::string_view GetOrigData() const noexcept { return this->src; }
+	/**
+	 * Get already read data.
+	 */
+	[[nodiscard]] std::string_view GetReadData() const noexcept { return this->src.substr(0, this->position); }
+	/**
+	 * Get data left to read.
+	 */
+	[[nodiscard]] std::string_view GetLeftData() const noexcept { return this->src.substr(this->position); }
+
+	/**
+	 * Discard all remaining data.
+	 */
+	void SkipAll() { this->position = this->src.size(); }
+
+	/**
+	 * Peek binary uint8.
+	 * @return Read integer, std::nullopt if not enough data.
+	 */
+	[[nodiscard]] std::optional<uint8_t> PeekUint8() const;
+	/**
+	 * Try to read binary uint8, and then advance reader.
+	 */
+	[[nodiscard]] std::optional<uint8_t> TryReadUint8()
+	{
+		auto value = this->PeekUint8();
+		if (value.has_value()) this->SkipUint8();
+		return value;
+	}
+	/**
+	 * Read binary uint8, and advance reader.
+	 * @param def Default value to return, if not enough data.
+	 * @return Read integer, 'def' if not enough data.
+	 */
+	[[nodiscard]] uint8_t ReadUint8(uint8_t def = 0)
+	{
+		auto value = this->PeekUint8();
+		this->SkipUint8(); // always advance
+		return value.value_or(def);
+	}
+	/**
+	 * Skip binary uint8.
+	 */
+	void SkipUint8() { this->Skip(1); }
+
+	/**
+	 * Peek binary int8.
+	 * @return Read integer, std::nullopt if not enough data.
+	 */
+	[[nodiscard]] std::optional<int8_t> PeekSint8() const
+	{
+		auto result = PeekUint8();
+		if (!result.has_value()) return std::nullopt;
+		return static_cast<int8_t>(*result);
+	}
+	/**
+	 * Try to read binary int8, and then advance reader.
+	 */
+	[[nodiscard]] std::optional<int8_t> TryReadSint8()
+	{
+		auto value = this->PeekSint8();
+		if (value.has_value()) this->SkipSint8();
+		return value;
+	}
+	/**
+	 * Read binary int8, and advance reader.
+	 * @param def Default value to return, if not enough data.
+	 * @return Read integer, 'def' if not enough data.
+	 */
+	[[nodiscard]] int8_t ReadSint8(int8_t def = 0)
+	{
+		auto value = this->PeekSint8();
+		this->SkipSint8(); // always advance
+		return value.value_or(def);
+	}
+	/**
+	 * Skip binary int8.
+	 */
+	void SkipSint8() { this->Skip(1); }
+
+	/**
+	 * Peek binary uint16 using little endian.
+	 * @return Read integer, std::nullopt if not enough data.
+	 */
+	[[nodiscard]] std::optional<uint16_t> PeekUint16LE() const;
+	/**
+	 * Try to read binary uint16, and then advance reader.
+	 */
+	[[nodiscard]] std::optional<uint16_t> TryReadUint16LE()
+	{
+		auto value = this->PeekUint16LE();
+		if (value.has_value()) this->SkipUint16LE();
+		return value;
+	}
+	/**
+	 * Read binary uint16 using little endian, and advance reader.
+	 * @param def Default value to return, if not enough data.
+	 * @return Read integer, 'def' if not enough data.
+	 * @note The reader is advanced, even if not enough data was present.
+	 */
+	[[nodiscard]] uint16_t ReadUint16LE(uint16_t def = 0)
+	{
+		auto value = this->PeekUint16LE();
+		this->SkipUint16LE(); // always advance
+		return value.value_or(def);
+	}
+	/**
+	 * Skip binary uint16, and advance reader.
+	 * @note The reader is advanced, even if not enough data was present.
+	 */
+	void SkipUint16LE() { this->Skip(2); }
+
+	/**
+	 * Peek binary int16 using little endian.
+	 * @return Read integer, std::nullopt if not enough data.
+	 */
+	[[nodiscard]] std::optional<int16_t> PeekSint16LE() const
+	{
+		auto result = PeekUint16LE();
+		if (!result.has_value()) return std::nullopt;
+		return static_cast<int16_t>(*result);
+	}
+	/**
+	 * Try to read binary int16, and then advance reader.
+	 */
+	[[nodiscard]] std::optional<int16_t> TryReadSint16LE()
+	{
+		auto value = this->PeekSint16LE();
+		if (value.has_value()) this->SkipSint16LE();
+		return value;
+	}
+	/**
+	 * Read binary int16 using little endian, and advance reader.
+	 * @param def Default value to return, if not enough data.
+	 * @return Read integer, 'def' if not enough data.
+	 * @note The reader is advanced, even if not enough data was present.
+	 */
+	[[nodiscard]] int16_t ReadSint16LE(int16_t def = 0)
+	{
+		auto value = this->PeekSint16LE();
+		this->SkipSint16LE(); // always advance
+		return value.value_or(def);
+	}
+	/**
+	 * Skip binary int16, and advance reader.
+	 * @note The reader is advanced, even if not enough data was present.
+	 */
+	void SkipSint16LE() { this->Skip(2); }
+
+	/**
+	 * Peek binary uint32 using little endian.
+	 * @return Read integer, std::nullopt if not enough data.
+	 */
+	[[nodiscard]] std::optional<uint32_t> PeekUint32LE() const;
+	/**
+	 * Try to read binary uint32, and then advance reader.
+	 */
+	[[nodiscard]] std::optional<uint32_t> TryReadUint32LE()
+	{
+		auto value = this->PeekUint32LE();
+		if (value.has_value()) this->SkipUint32LE();
+		return value;
+	}
+	/**
+	 * Read binary uint32 using little endian, and advance reader.
+	 * @param def Default value to return, if not enough data.
+	 * @return Read integer, 'def' if not enough data.
+	 * @note The reader is advanced, even if not enough data was present.
+	 */
+	[[nodiscard]] uint32_t ReadUint32LE(uint32_t def = 0)
+	{
+		auto value = this->PeekUint32LE();
+		this->SkipUint32LE(); // always advance
+		return value.value_or(def);
+	}
+	/**
+	 * Skip binary uint32, and advance reader.
+	 * @note The reader is advanced, even if not enough data was present.
+	 */
+	void SkipUint32LE() { this->Skip(4); }
+
+	/**
+	 * Peek binary int32 using little endian.
+	 * @return Read integer, std::nullopt if not enough data.
+	 */
+	[[nodiscard]] std::optional<int32_t> PeekSint32LE() const
+	{
+		auto result = PeekUint32LE();
+		if (!result.has_value()) return std::nullopt;
+		return static_cast<int32_t>(*result);
+	}
+	/**
+	 * Try to read binary int32, and then advance reader.
+	 */
+	[[nodiscard]] std::optional<int32_t> TryReadSint32LE()
+	{
+		auto value = this->PeekSint32LE();
+		if (value.has_value()) this->SkipSint32LE();
+		return value;
+	}
+	/**
+	 * Read binary int32 using little endian, and advance reader.
+	 * @param def Default value to return, if not enough data.
+	 * @return Read integer, 'def' if not enough data.
+	 * @note The reader is advanced, even if not enough data was present.
+	 */
+	[[nodiscard]] int32_t ReadSint32LE(int32_t def = 0)
+	{
+		auto value = this->PeekSint32LE();
+		this->SkipSint32LE(); // always advance
+		return value.value_or(def);
+	}
+	/**
+	 * Skip binary int32, and advance reader.
+	 * @note The reader is advanced, even if not enough data was present.
+	 */
+	void SkipSint32LE() { this->Skip(4); }
+
+	/**
+	 * Peek binary uint64 using little endian.
+	 * @return Read integer, std::nullopt if not enough data.
+	 */
+	[[nodiscard]] std::optional<uint64_t> PeekUint64LE() const;
+	/**
+	 * Try to read binary uint64, and then advance reader.
+	 */
+	[[nodiscard]] std::optional<uint64_t> TryReadUint64LE()
+	{
+		auto value = this->PeekUint64LE();
+		if (value.has_value()) this->SkipUint64LE();
+		return value;
+	}
+	/**
+	 * Read binary uint64 using little endian, and advance reader.
+	 * @param def Default value to return, if not enough data.
+	 * @return Read integer, 'def' if not enough data.
+	 * @note The reader is advanced, even if not enough data was present.
+	 */
+	[[nodiscard]] uint64_t ReadUint64LE(uint64_t def = 0)
+	{
+		auto value = this->PeekUint64LE();
+		this->SkipUint64LE(); // always advance
+		return value.value_or(def);
+	}
+	/**
+	 * Skip binary uint64, and advance reader.
+	 * @note The reader is advanced, even if not enough data was present.
+	 */
+	void SkipUint64LE() { this->Skip(8); }
+
+	/**
+	 * Peek binary int64 using little endian.
+	 * @return Read integer, std::nullopt if not enough data.
+	 */
+	[[nodiscard]] std::optional<int64_t> PeekSint64LE() const
+	{
+		auto result = PeekUint64LE();
+		if (!result.has_value()) return std::nullopt;
+		return static_cast<int64_t>(*result);
+	}
+	/**
+	 * Try to read binary int64, and then advance reader.
+	 */
+	[[nodiscard]] std::optional<int64_t> TryReadSint64LE()
+	{
+		auto value = this->PeekSint64LE();
+		if (value.has_value()) this->SkipSint64LE();
+		return value;
+	}
+	/**
+	 * Read binary int64 using little endian, and advance reader.
+	 * @param def Default value to return, if not enough data.
+	 * @return Read integer, 'def' if not enough data.
+	 * @note The reader is advanced, even if not enough data was present.
+	 */
+	[[nodiscard]] int64_t ReadSint64LE(int64_t def = 0)
+	{
+		auto value = this->PeekSint64LE();
+		this->SkipSint64LE(); // always advance
+		return value.value_or(def);
+	}
+	/**
+	 * Skip binary int64, and advance reader.
+	 * @note The reader is advanced, even if not enough data was present.
+	 */
+	void SkipSint64LE() { this->Skip(8); }
+
+	/**
+	 * Peek 8-bit character.
+	 * @return Read char, std::nullopt if not enough data.
+	 */
+	[[nodiscard]] std::optional<char> PeekChar() const;
+	/**
+	 * Try to read a 8-bit character, and then advance reader.
+	 */
+	[[nodiscard]] std::optional<char> TryReadChar()
+	{
+		auto value = this->PeekChar();
+		if (value.has_value()) this->SkipChar();
+		return value;
+	}
+	/**
+	 * Read 8-bit character, and advance reader.
+	 * @param def Default value to return, if not enough data.
+	 * @return Read character, 'def' if not enough data.
+	 */
+	[[nodiscard]] char ReadChar(char def = '?') {
+		auto value = this->PeekChar();
+		this->SkipChar(); // always advance
+		return value.value_or(def);
+	}
+	/**
+	 * Skip 8-bit character, and advance reader.
+	 */
+	void SkipChar() { this->Skip(1); }
+
+	/**
+	 * Peek UTF-8 character.
+	 * @return Length and read char, {0, 0} if no valid data.
+	 */
+	[[nodiscard]] std::pair<size_type, char32_t> PeekUtf8() const;
+	/**
+	 * Try to read a UTF-8 character, and then advance reader.
+	 */
+	[[nodiscard]] std::optional<char32_t> TryReadUtf8()
+	{
+		auto [len, value] = this->PeekUtf8();
+		if (len == 0) return std::nullopt;
+		this->Skip(len);
+		return value;
+	}
+	/**
+	 * Read UTF-8 character, and advance reader.
+	 * @param def Default value to return, if no valid data.
+	 * @return Read char, 'def' if no valid data.
+	 * @note The reader is advanced, even if no valid data was present.
+	 */
+	[[nodiscard]] char32_t ReadUtf8(char32_t def = '?')
+	{
+		auto [len, value] = this->PeekUtf8();
+		this->Skip(len > 0 ? len : 1); // advance at least one byte
+		return len > 0 ? value : def;
+	}
+	/**
+	 * Skip UTF-8 character, and advance reader.
+	 * @note The reader is advanced, even if no valid data was present.
+	 * @note This behaves different to Utf8View::iterator.
+	 *       Here we do not skip overlong encodings, because we want to
+	 *       allow binary data to follow UTF-8 data.
+	 */
+	void SkipUtf8()
+	{
+		auto len = this->PeekUtf8().first;
+		this->Skip(len > 0 ? len : 1); // advance at least one byte
+	}
+
+	/**
+	 * Check whether the next data matches 'str'.
+	 */
+	[[nodiscard]] bool PeekIf(std::string_view str) const
+	{
+		return this->src.compare(this->position, str.size(), str) == 0;
+	}
+	/**
+	 * Check whether the next data matches 'str', and skip it.
+	 */
+	[[nodiscard]] bool ReadIf(std::string_view str)
+	{
+		bool result = this->PeekIf(str);
+		if (result) this->Skip(str.size());
+		return result;
+	}
+	/**
+	 * If the next data matches 'str', then skip it.
+	 */
+	void SkipIf(std::string_view str)
+	{
+		if (this->PeekIf(str)) this->Skip(str.size());
+	}
+
+	/**
+	 * Check whether the next 8-bit char matches 'c'.
+	 */
+	[[nodiscard]] bool PeekCharIf(char c) const
+	{
+		return this->PeekIf({&c, 1});
+	}
+	/**
+	 * Check whether the next 8-bit char matches 'c', and skip it.
+	 */
+	[[nodiscard]] bool ReadCharIf(char c)
+	{
+		return this->ReadIf({&c, 1});
+	}
+	/**
+	 * If the next data matches the 8-bit char 'c', then skip it.
+	 */
+	void SkipCharIf(char c)
+	{
+		return this->SkipIf({&c, 1});
+	}
+
+	/**
+	 * Check whether the next UTF-8 char matches 'c'.
+	 */
+	[[nodiscard]] bool PeekUtf8If(char32_t c) const
+	{
+		auto [len, result] = this->PeekUtf8();
+		return len > 0 && result == c;
+	}
+	/**
+	 * Check whether the next UTF-8 char matches 'c', and skip it.
+	 */
+	[[nodiscard]] bool ReadUtf8If(char32_t c)
+	{
+		auto [len, result] = this->PeekUtf8();
+		if (len == 0 || result != c) return false;
+		this->Skip(len);
+		return true;
+	}
+	/**
+	 * If the next data matches the UTF-8 char 'c', then skip it.
+	 */
+	void SkipUtf8If(char32_t c)
+	{
+		auto [len, result] = this->PeekUtf8();
+		if (len > 0 && result == c) {
+			this->Skip(len);
+		}
+	}
+
+	/**
+	 * Peek the next 'len' bytes.
+	 * @param len Bytes to read, 'npos' to read all.
+	 * @return Up to 'len' bytes.
+	 */
+	[[nodiscard]] std::string_view Peek(size_type len) const;
+	/**
+	 * Read the next 'len' bytes, and advance reader.
+	 * @param len Bytes to read, 'npos' to read all.
+	 * @return Up to 'len' bytes.
+	 */
+	[[nodiscard]] std::string_view Read(size_type len)
+	{
+		auto result = this->Peek(len);
+		if (len != npos && len != result.size()) {
+			LogError(fmt::format("Source buffer too short: {} > {}", len, result.size()));
+		}
+		this->Skip(result.size());
+		return result;
+	}
+	/**
+	 * Discard some bytes.
+	 * @param len Number of bytes to skip, 'npos' to skip all.
+	 */
+	void Skip(size_type len);
+
+	/**
+	 * Find first occurence of 'str'.
+	 * @return Offset from current reader position. 'npos' if no match found.
+	 */
+	[[nodiscard]] size_type Find(std::string_view str) const;
+	/**
+	 * Find first occurence of 8-bit char 'c'.
+	 * @return Offset from current reader position. 'npos' if no match found.
+	 */
+	[[nodiscard]] size_type FindChar(char c) const
+	{
+		return this->Find({&c, 1});
+	}
+	/**
+	 * Find first occurence of UTF-8 char 'c'.
+	 * @return Offset from current reader position. 'npos' if no match found.
+	 */
+	[[nodiscard]] size_type FindUtf8(char32_t c) const;
+
+	/**
+	 * Find first occurence of any 8-bit char in 'chars'.
+	 * @return Offset from current reader position. 'npos' if no match found.
+	 */
+	[[nodiscard]] size_type FindCharIn(std::string_view chars) const;
+	/**
+	 * Find first occurence of any 8-bit char not in 'chars'.
+	 * @return Offset from current reader position. 'npos' if no match found.
+	 */
+	[[nodiscard]] size_type FindCharNotIn(std::string_view chars) const;
+
+	/**
+	 * Check whether the next 8-bit char is in 'chars'.
+	 * @return Matching char, std::nullopt if no match.
+	 */
+	[[nodiscard]] std::optional<char> PeekCharIfIn(std::string_view chars) const
+	{
+		assert(!chars.empty());
+		std::optional<char> c = this->PeekChar();
+		if (c.has_value() && chars.find(*c) != std::string_view::npos) return c;
+		return std::nullopt;
+	}
+	/**
+	 * Read next 8-bit char, check whether it is in 'chars', and advance reader.
+	 * @return Matching char, std::nullopt if no match.
+	 */
+	[[nodiscard]] std::optional<char> ReadCharIfIn(std::string_view chars)
+	{
+		auto result = this->PeekCharIfIn(chars);
+		if (result.has_value()) this->Skip(1);
+		return result;
+	}
+	/**
+	 * If the next 8-bit char is in 'chars', skip it.
+	 */
+	void SkipCharIfIn(std::string_view chars)
+	{
+		auto result = this->PeekCharIfIn(chars);
+		if (result.has_value()) this->Skip(1);
+	}
+
+	/**
+	 * Check whether the next 8-bit char is not in 'chars'.
+	 * @return Non-matching char, std::nullopt if match.
+	 */
+	[[nodiscard]] std::optional<char> PeekCharIfNotIn(std::string_view chars) const
+	{
+		assert(!chars.empty());
+		std::optional<char> c = this->PeekChar();
+		if (c.has_value() && chars.find(*c) == std::string_view::npos) return c;
+		return std::nullopt;
+	}
+	/**
+	 * Read next 8-bit char, check whether it is not in 'chars', and advance reader.
+	 * @return Non-matching char, std::nullopt if match.
+	 */
+	[[nodiscard]] std::optional<char> ReadCharIfNotIn(std::string_view chars)
+	{
+		auto result = this->PeekCharIfNotIn(chars);
+		if (result.has_value()) this->Skip(1);
+		return result;
+	}
+	/**
+	 * If the next 8-bit char is not in 'chars', skip it.
+	 */
+	void SkipCharIfNotIn(std::string_view chars)
+	{
+		auto result = this->PeekCharIfNotIn(chars);
+		if (result.has_value()) this->Skip(1);
+	}
+
+	/**
+	 * Peek 8-bit chars, while they are not in 'chars', until they are.
+	 * @return Non-matching chars.
+	 */
+	[[nodiscard]] std::string_view PeekUntilCharIn(std::string_view chars) const
+	{
+		size_type len = this->FindCharIn(chars);
+		return this->Peek(len);
+	}
+	/**
+	 * Read 8-bit chars, while they are not in 'chars', until they are; and advance reader.
+	 * @return Non-matching chars.
+	 */
+	[[nodiscard]] std::string_view ReadUntilCharIn(std::string_view chars)
+	{
+		size_type len = this->FindCharIn(chars);
+		return this->Read(len);
+	}
+	/**
+	 * Skip 8-bit chars, while they are not in 'chars', until they are.
+	 */
+	void SkipUntilCharIn(std::string_view chars)
+	{
+		size_type len = this->FindCharIn(chars);
+		this->Skip(len);
+	}
+
+	/**
+	 * Peek 8-bit chars, while they are in 'chars', until they are not.
+	 * @return Matching chars.
+	 */
+	[[nodiscard]] std::string_view PeekUntilCharNotIn(std::string_view chars) const
+	{
+		size_type len = this->FindCharNotIn(chars);
+		return this->Peek(len);
+	}
+	/**
+	 * Read 8-bit chars, while they are in 'chars', until they are not; and advance reader.
+	 * @return Matching chars.
+	 */
+	[[nodiscard]] std::string_view ReadUntilCharNotIn(std::string_view chars)
+	{
+		size_type len = this->FindCharNotIn(chars);
+		return this->Read(len);
+	}
+	/**
+	 * Skip 8-bit chars, while they are in 'chars', until they are not.
+	 */
+	void SkipUntilCharNotIn(std::string_view chars)
+	{
+		size_type len = this->FindCharNotIn(chars);
+		this->Skip(len);
+	}
+
+	/**
+	 * Treatment of separator characters.
+	 */
+	enum SeparatorUsage {
+		READ_ALL_SEPARATORS, ///< Read all consecutive separators, and include them all in the result
+		READ_ONE_SEPARATOR,  ///< Read one separator, and include it in the result
+		KEEP_SEPARATOR,      ///< Keep the separator in the data as next value to be read.
+		SKIP_ONE_SEPARATOR,  ///< Read and discard one separator, do not include it in the result.
+		SKIP_ALL_SEPARATORS, ///< Read and discard all consecutive separators, do not include any in the result.
+	};
+
+	/**
+	 * Peek data until the first occurrence of 'str'.
+	 * @param str Separator string.
+	 * @param sep Whether to include/exclude 'str' from the result.
+	 */
+	[[nodiscard]] std::string_view PeekUntil(std::string_view str, SeparatorUsage sep) const;
+	/**
+	 * Read data until the first occurrence of 'str', and advance reader.
+	 * @param str Separator string.
+	 * @param sep Whether to include/exclude 'str' from the result, and/or skip it.
+	 */
+	[[nodiscard]] std::string_view ReadUntil(std::string_view str, SeparatorUsage sep)
+	{
+		assert(!str.empty());
+		auto result = this->PeekUntil(str, sep);
+		this->Skip(result.size());
+		switch (sep) {
+			default:
+				break;
+			case SKIP_ONE_SEPARATOR:
+				this->SkipIf(str);
+				break;
+			case SKIP_ALL_SEPARATORS:
+				while (this->ReadIf(str)) {}
+				break;
+		}
+		return result;
+	}
+	/**
+	 * Skip data until the first occurrence of 'str'.
+	 * @param str Separator string.
+	 * @param sep Whether to also skip 'str'.
+	 */
+	void SkipUntil(std::string_view str, SeparatorUsage sep)
+	{
+		assert(!str.empty());
+		this->Skip(this->Find(str));
+		switch (sep) {
+			default:
+				break;
+			case READ_ONE_SEPARATOR:
+			case SKIP_ONE_SEPARATOR:
+				this->SkipIf(str);
+				break;
+			case READ_ALL_SEPARATORS:
+			case SKIP_ALL_SEPARATORS:
+				while (this->ReadIf(str)) {}
+				break;
+		}
+	}
+
+	/**
+	 * Peek data until the first occurrence of 8-bit char 'c'.
+	 * @param c Separator char.
+	 * @param sep Whether to include/exclude 'c' from the result.
+	 */
+	[[nodiscard]] std::string_view PeekUntilChar(char c, SeparatorUsage sep) const
+	{
+		return this->PeekUntil({&c, 1}, sep);
+	}
+	/**
+	 * Read data until the first occurrence of 8-bit char 'c', and advance reader.
+	 * @param c Separator char.
+	 * @param sep Whether to include/exclude 'c' from the result, and/or skip it.
+	 */
+	[[nodiscard]] std::string_view ReadUntilChar(char c, SeparatorUsage sep)
+	{
+		return this->ReadUntil({&c, 1}, sep);
+	}
+	/**
+	 * Skip data until the first occurrence of 8-bit char 'c'.
+	 * @param c Separator char.
+	 * @param sep Whether to also skip 'c'.
+	 */
+	void SkipUntilChar(char c, SeparatorUsage sep)
+	{
+		this->SkipUntil({&c, 1}, sep);
+	}
+
+	/**
+	 * Peek data until the first occurrence of UTF-8 char 'c'.
+	 * @param c Separator char.
+	 * @param sep Whether to include/exclude 'c' from the result.
+	 */
+	[[nodiscard]] std::string_view PeekUntilUtf8(char32_t c, SeparatorUsage sep) const;
+	/**
+	 * Read data until the first occurrence of UTF-8 char 'c', and advance reader.
+	 * @param c Separator char.
+	 * @param sep Whether to include/exclude 'c' from the result, and/or skip it.
+	 */
+	[[nodiscard]] std::string_view ReadUntilUtf8(char32_t c, SeparatorUsage sep);
+	/**
+	 * Skip data until the first occurrence of UTF-8 char 'c'.
+	 * @param c Separator char.
+	 * @param sep Whether to also skip 'c'.
+	 */
+	void SkipUntilUtf8(char32_t c, SeparatorUsage sep);
+
+private:
+	template<class T>
+	[[nodiscard]] static std::pair<size_type, T> ParseIntegerBase(std::string_view src, int base, bool log_errors)
+	{
+		if (base == 0) {
+			/* Try positive hex */
+			if (src.starts_with("0x") || src.starts_with("0X")) {
+				auto [len, value] = ParseIntegerBase<T>(src.substr(2), 16, log_errors);
+				if (len == 0) return {};
+				return {len + 2, value};
+			}
+
+			/* Try negative hex */
+			if (std::is_signed_v<T> && (src.starts_with("-0x") || src.starts_with("-0X"))) {
+				using Unsigned = std::make_signed_t<T>;
+				auto [len, uvalue] = ParseIntegerBase<Unsigned>(src.substr(3), 16, log_errors);
+				if (len == 0) return {};
+				T value = -uvalue;
+				if (value > 0) {
+					if (log_errors) LogError(fmt::format("Integer out of range: '{}'", src.substr(0, len + 3)));
+					return {};
+				}
+				return {len + 3, value};
+			}
+
+			/* Try decimal */
+			return ParseIntegerBase<T>(src, 10, log_errors);
+		}
+
+		T value{};
+		assert(base == 10 || base == 16); // we only support these bases when skipping
+		auto result = std::from_chars(src.data(), src.data() + src.size(), value, base);
+		auto len = result.ptr - src.data();
+		if (result.ec == std::errc::result_out_of_range) {
+			if (log_errors) LogError(fmt::format("Integer out of range: '{}'+'{}'", src.substr(0, len), src.substr(len, 4)));
+			return {};
+		}
+		if (result.ec != std::errc{}) {
+			if (log_errors) LogError(fmt::format("Cannot parse integer: '{}'+'{}'", src.substr(0, len), src.substr(len, 4)));
+			return {};
+		}
+		return {len, value};
+	}
+
+public:
+	/**
+	 * Peek and parse an integer in number 'base'.
+	 * If 'base == 0', then a prefix '0x' decides between base 16 or base 10.
+	 * @return Length of string match, and parsed value.
+	 * @note The parser rejects leading whitespace and unary plus.
+	 */
+	template<class T>
+	[[nodiscard]] std::pair<size_type, T> PeekIntegerBase(int base) const
+	{
+		return ParseIntegerBase<T>(this->src.substr(this->position), base, false);
+	}
+	/**
+	 * Try to read and parse an integer in number 'base', and then advance the reader.
+	 * If 'base == 0', then a prefix '0x' decides between base 16 or base 10.
+	 * @return Parsed value, if valid.
+	 * @note The parser rejects leading whitespace and unary plus.
+	 */
+	template<class T>
+	[[nodiscard]] std::optional<T> TryReadIntegerBase(int base)
+	{
+		auto [len, value] = this->PeekIntegerBase<T>(base);
+		if (len == 0) return std::nullopt;
+		this->SkipIntegerBase(base);
+		return value;
+	}
+	/**
+	 * Read and parse an integer in number 'base', and advance the reader.
+	 * If 'base == 0', then a prefix '0x' decides between base 16 or base 10.
+	 * @return Parsed value, or 'def' if invalid.
+	 * @note The reader is advanced, even if no valid data was present.
+	 * @note The parser rejects leading whitespace and unary plus.
+	 */
+	template<class T>
+	[[nodiscard]] T ReadIntegerBase(int base, T def = 0)
+	{
+		auto [len, value] = ParseIntegerBase<T>(this->src.substr(this->position), base, true);
+		this->SkipIntegerBase(base); // always advance
+		return len > 0 ? value : def;
+	}
+	/**
+	 * Skip an integer in number 'base'.
+	 * If 'base == 0', then a prefix '0x' decides between base 16 or base 10.
+	 * @note The reader is advanced, even if no valid data was present.
+	 * @note The parser rejects leading whitespace and unary plus.
+	 */
+	void SkipIntegerBase(int base);
+};
+
+#endif /* STRING_CONSUMER_HPP */

--- a/src/core/string_inplace.cpp
+++ b/src/core/string_inplace.cpp
@@ -1,0 +1,49 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file string_inplace.cpp Inplace-replacement of textual and binary data.
+ */
+
+#include "../stdafx.h"
+#include "string_inplace.hpp"
+#include "../safeguards.h"
+
+[[nodiscard]] bool InPlaceBuilder::AnyBytesUnused() const noexcept
+{
+	return this->consumer.GetBytesRead() > this->position;
+}
+
+[[nodiscard]] InPlaceBuilder::size_type InPlaceBuilder::GetBytesUnused() const noexcept
+{
+	return this->consumer.GetBytesRead() - this->position;
+}
+
+void InPlaceBuilder::PutBuffer(const char *str, size_type len)
+{
+	auto unused = this->GetBytesUnused();
+	if (len > unused) NOT_REACHED();
+	std::copy(str, str + len, this->dest.data() + this->position);
+	this->position += len;
+}
+
+InPlaceReplacement::InPlaceReplacement(std::span<char> buffer)
+	: consumer(buffer), builder(buffer, consumer)
+{
+}
+
+InPlaceReplacement::InPlaceReplacement(const InPlaceReplacement &src)
+	: consumer(src.consumer), builder(src.builder, consumer)
+{
+}
+
+InPlaceReplacement& InPlaceReplacement::operator=(const InPlaceReplacement &src)
+{
+	this->consumer = src.consumer;
+	this->builder.AssignBuffer(src.builder);
+	return *this;
+}

--- a/src/core/string_inplace.hpp
+++ b/src/core/string_inplace.hpp
@@ -1,0 +1,120 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file string_inplace.hpp Inplace-replacement of textual and binary data.
+ */
+
+#ifndef STRING_INPLACE_HPP
+#define STRING_INPLACE_HPP
+
+#include "string_builder.hpp"
+#include "string_consumer.hpp"
+
+/**
+ * Builder implementation for InPlaceReplacement.
+ */
+class InPlaceBuilder final : public BaseStringBuilder
+{
+	std::span<char> dest;
+	size_type position = 0;
+	const StringConsumer &consumer;
+
+	friend class InPlaceReplacement;
+	explicit InPlaceBuilder(std::span<char> dest, const StringConsumer &consumer) : dest(dest), consumer(consumer) {}
+	InPlaceBuilder(const InPlaceBuilder &src, const StringConsumer &consumer) : dest(src.dest), position(src.position), consumer(consumer) {}
+	void AssignBuffer(const InPlaceBuilder &src) { this->dest = src.dest; this->position = src.position; }
+public:
+	InPlaceBuilder(const InPlaceBuilder &) = delete;
+	InPlaceBuilder& operator=(const InPlaceBuilder &) = delete;
+
+	/**
+	 * Check whether any bytes have been written.
+	 */
+	[[nodiscard]] bool AnyBytesWritten() const noexcept { return this->position != 0; }
+	/**
+	 * Get number of already written bytes.
+	 */
+	[[nodiscard]] size_type GetBytesWritten() const noexcept { return this->position; }
+	/**
+	 * Get already written data.
+	 */
+	[[nodiscard]] std::string_view GetWrittenData() const noexcept { return {this->dest.data(), this->position}; }
+
+	/**
+	 * Check whether any unused bytes are left between the Builder and Consumer position.
+	 */
+	[[nodiscard]] bool AnyBytesUnused() const noexcept;
+	/**
+	 * Get number of unused bytes left between the Builder and Consumer position.
+	 */
+	[[nodiscard]] size_type GetBytesUnused() const noexcept;
+
+	using BaseStringBuilder::PutBuffer;
+	/**
+	 * Append buffer.
+	 */
+	void PutBuffer(const char *str, size_type len) override;
+
+	/**
+	 * Implementation of std::back_insert_iterator for non-growing destination buffer.
+	 */
+	class back_insert_iterator {
+		InPlaceBuilder *parent = nullptr;
+	public:
+		using value_type = void;
+		using difference_type = void;
+		using iterator_category = std::output_iterator_tag;
+		using pointer = void;
+		using reference = void;
+
+		back_insert_iterator(InPlaceBuilder &parent) : parent(&parent) {}
+
+		back_insert_iterator &operator++() { return *this; }
+		back_insert_iterator operator++(int) { return *this; }
+		back_insert_iterator &operator*() { return *this; }
+
+		back_insert_iterator &operator=(char value)
+		{
+			this->parent->PutChar(value);
+			return *this;
+		}
+	};
+	/**
+	 * Create a back-insert-iterator.
+	 */
+	back_insert_iterator back_inserter()
+	{
+		return back_insert_iterator(*this);
+	}
+};
+
+/**
+ * Compose data into a fixed size buffer, which is consumed at the same time.
+ * - The Consumer reads data from a buffer.
+ * - The Builder writes data to the buffer, replacing already consumed data.
+ * - The Builder asserts, if it overtakes the consumer.
+ */
+class InPlaceReplacement
+{
+public:
+	StringConsumer consumer; ///< Consumer from shared buffer
+	InPlaceBuilder builder; ///< Builder into shared buffer
+
+public:
+	/**
+	 * Create coupled Consumer+Builder pair.
+	 * @param buffer Data to consume and replace.
+	 * @note The lifetime of the buffer must exceed the lifetime of both the Consumer and the Builder.
+	 */
+	InPlaceReplacement(std::span<char> buffer);
+
+	InPlaceReplacement(const InPlaceReplacement &src);
+	InPlaceReplacement& operator=(const InPlaceReplacement &src);
+};
+
+#endif /* STRING_INPLACE_HPP */

--- a/src/core/utf8.hpp
+++ b/src/core/utf8.hpp
@@ -13,10 +13,16 @@
 #define UTF8_HPP
 
 #include <iterator>
-#include "../string_func.h"
+#include "bitmath_func.hpp"
 
 [[nodiscard]] std::pair<char[4], size_t> EncodeUtf8(char32_t c);
 [[nodiscard]] std::pair<size_t, char32_t> DecodeUtf8(std::string_view buf);
+
+/* Check if the given character is part of a UTF8 sequence */
+inline bool IsUtf8Part(char c)
+{
+	return GB(c, 6, 2) == 2;
+}
 
 /**
  * Constant span of UTF-8 encoded data.

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -267,7 +267,7 @@ static void ExtractStringParams(const StringData &data, StringParamsList &params
 
 		if (ls != nullptr) {
 			StringParams &param = params.emplace_back();
-			ParsedCommandStruct pcs = ExtractCommandString(ls->english.c_str(), false);
+			ParsedCommandStruct pcs = ExtractCommandString(ls->english, false);
 
 			for (auto it = pcs.consuming_commands.begin(); it != pcs.consuming_commands.end(); it++) {
 				if (*it == nullptr) {

--- a/src/newgrf/newgrf_bytereader.cpp
+++ b/src/newgrf/newgrf_bytereader.cpp
@@ -15,17 +15,6 @@
 #include "../safeguards.h"
 
 /**
- * Read a single DWord (32 bits).
- * @note The buffer is NOT advanced.
- * @returns Value read from buffer.
- */
-uint32_t ByteReader::PeekDWord()
-{
-	AutoRestoreBackup backup(this->data, this->data);
-	return this->ReadDWord();
-}
-
-/**
  * Read a value of the given number of bytes.
  * @returns Value read from buffer.
  */
@@ -39,19 +28,4 @@ uint32_t ByteReader::ReadVarSize(uint8_t size)
 			NOT_REACHED();
 			return 0;
 	}
-}
-
-/**
- * Read a string.
- * @returns Sting read from the buffer.
- */
-std::string_view ByteReader::ReadString()
-{
-	const char *string = reinterpret_cast<const char *>(this->data);
-	size_t string_length = ttd_strnlen(string, this->Remaining());
-
-	/* Skip past the terminating NUL byte if it is present, but not more than remaining. */
-	this->Skip(std::min(string_length + 1, this->Remaining()));
-
-	return std::string_view(string, string_length);
 }

--- a/src/newgrf/newgrf_bytereader.h
+++ b/src/newgrf/newgrf_bytereader.h
@@ -10,24 +10,21 @@
 #ifndef NEWGRF_BYTEREADER_H
 #define NEWGRF_BYTEREADER_H
 
+#include "../core/string_consumer.hpp"
+
 class OTTDByteReaderSignal { };
 
 /** Class to read from a NewGRF file */
 class ByteReader {
+	StringConsumer consumer;
 public:
-	ByteReader(const uint8_t *data, const uint8_t *end) : data(data), end(end) { }
+	ByteReader(const uint8_t *data, size_t len) : consumer(reinterpret_cast<const char *>(data), len) { }
 
 	const uint8_t *ReadBytes(size_t size)
 	{
-		if (this->data + size >= this->end) {
-			/* Put data at the end, as would happen if every byte had been individually read. */
-			this->data = this->end;
-			throw OTTDByteReaderSignal();
-		}
-
-		const uint8_t *ret = this->data;
-		this->data += size;
-		return ret;
+		auto result = this->consumer.Read(size);
+		if (result.size() != size) throw OTTDByteReaderSignal();
+		return reinterpret_cast<const uint8_t *>(result.data());
 	}
 
 	/**
@@ -36,8 +33,9 @@ public:
 	 */
 	uint8_t ReadByte()
 	{
-		if (this->data < this->end) return *this->data++;
-		throw OTTDByteReaderSignal();
+		auto result = this->consumer.TryReadUint8();
+		if (!result.has_value()) throw OTTDByteReaderSignal();
+		return *result;
 	}
 
 	/**
@@ -46,8 +44,9 @@ public:
 	 */
 	uint16_t ReadWord()
 	{
-		uint16_t val = this->ReadByte();
-		return val | (this->ReadByte() << 8);
+		auto result = this->consumer.TryReadUint16LE();
+		if (!result.has_value()) throw OTTDByteReaderSignal();
+		return *result;
 	}
 
 	/**
@@ -66,35 +65,53 @@ public:
 	 */
 	uint32_t ReadDWord()
 	{
-		uint32_t val = this->ReadWord();
-		return val | (this->ReadWord() << 16);
+		auto result = this->consumer.TryReadUint32LE();
+		if (!result.has_value()) throw OTTDByteReaderSignal();
+		return *result;
 	}
 
-	uint32_t PeekDWord();
+	/**
+	 * Read a single DWord (32 bits).
+	 * @note The buffer is NOT advanced.
+	 * @returns Value read from buffer.
+	 */
+	uint32_t PeekDWord()
+	{
+		auto result = this->consumer.PeekUint32LE();
+		if (!result.has_value()) throw OTTDByteReaderSignal();
+		return *result;
+	}
+
 	uint32_t ReadVarSize(uint8_t size);
-	std::string_view ReadString();
+
+	/**
+	 * Read a NUL-terminated string.
+	 * @returns String read from the buffer.
+	 */
+	std::string_view ReadString()
+	{
+		auto result = this->consumer.ReadUntilChar('\0', StringConsumer::KEEP_SEPARATOR);
+		/* Skip the terminating NUL byte, if present. */
+		if (this->consumer.AnyBytesLeft() && !this->consumer.ReadCharIf('\0')) throw OTTDByteReaderSignal();
+		return result;
+	}
 
 	size_t Remaining() const
 	{
-		return this->end - this->data;
+		return this->consumer.GetBytesLeft();
 	}
 
 	bool HasData(size_t count = 1) const
 	{
-		return this->data + count <= this->end;
+		return count <= this->consumer.GetBytesLeft();
 	}
 
 	void Skip(size_t len)
 	{
-		this->data += len;
-		/* It is valid to move the buffer to exactly the end of the data,
-		 * as there may not be any more data read. */
-		if (this->data > this->end) throw OTTDByteReaderSignal();
+		auto result = this->consumer.Read(len);
+		if (result.size() != len) throw OTTDByteReaderSignal();
 	}
 
-private:
-	const uint8_t *data; ///< Current position within data.
-	const uint8_t *end; ///< Last position of data.
 };
 
 #endif /* NEWGRF_BYTEREADER_H */

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -861,10 +861,10 @@ static void ProcessNewGRFStringControlCode(char32_t scc, StringConsumer &consume
 /**
  * Emit OpenTTD's internal string code for the different NewGRF string codes.
  * @param scc NewGRF string code.
- * @param[in,out] str String iterator, moved forward if SCC_NEWGRF_PUSH_WORD is found.
+ * @param consumer String consumer, moved forward if SCC_NEWGRF_PUSH_WORD is found.
  * @returns String code to use.
  */
-char32_t RemapNewGRFStringControlCode(char32_t scc, const char **str)
+char32_t RemapNewGRFStringControlCode(char32_t scc, StringConsumer &consumer)
 {
 	switch (scc) {
 		default:
@@ -932,7 +932,7 @@ char32_t RemapNewGRFStringControlCode(char32_t scc, const char **str)
 
 		/* These NewGRF string codes modify the NewGRF stack or otherwise do not map to OpenTTD string codes. */
 		case SCC_NEWGRF_PUSH_WORD:
-			Utf8Consume(str);
+			consumer.SkipUtf8();
 			return 0;
 
 		case SCC_NEWGRF_DISCARD_WORD:

--- a/src/osk_gui.cpp
+++ b/src/osk_gui.cpp
@@ -16,6 +16,7 @@
 #include "querystring_gui.h"
 #include "video/video_driver.hpp"
 #include "zoom_func.h"
+#include "core/string_consumer.hpp"
 
 #include "widgets/osk_widget.h"
 
@@ -358,17 +359,10 @@ void GetKeyboardLayout()
 	keyboard[1] = _keyboard_opt[1].empty() ? GetString(STR_OSK_KEYBOARD_LAYOUT_CAPS) : _keyboard_opt[1];
 
 	for (uint j = 0; j < 2; j++) {
-		auto kbd = keyboard[j].begin();
-		bool ended = false;
+		StringConsumer consumer(keyboard[j]);
 		for (uint i = 0; i < OSK_KEYBOARD_ENTRIES; i++) {
-			_keyboard[j][i] = Utf8Consume(kbd);
-
 			/* Be lenient when the last characters are missing (is quite normal) */
-			if (_keyboard[j][i] == '\0' || ended) {
-				ended = true;
-				_keyboard[j][i] = ' ';
-				continue;
-			}
+			_keyboard[j][i] = consumer.AnyBytesLeft() ? consumer.ReadUtf8() : ' ';
 
 			if (IsPrintable(_keyboard[j][i])) {
 				errormark[j] += ' ';

--- a/src/settingsgen/CMakeLists.txt
+++ b/src/settingsgen/CMakeLists.txt
@@ -12,6 +12,7 @@ if (NOT HOST_BINARY_DIR)
             ../string.cpp
             ../core/string_builder.cpp
             ../core/string_consumer.cpp
+            ../core/string_inplace.cpp
             ../core/utf8.cpp
     )
     add_definitions(-DSETTINGSGEN)

--- a/src/settingsgen/CMakeLists.txt
+++ b/src/settingsgen/CMakeLists.txt
@@ -11,6 +11,7 @@ if (NOT HOST_BINARY_DIR)
             ../ini_load.cpp
             ../string.cpp
             ../core/string_builder.cpp
+            ../core/string_consumer.cpp
             ../core/utf8.cpp
     )
     add_definitions(-DSETTINGSGEN)

--- a/src/strgen/CMakeLists.txt
+++ b/src/strgen/CMakeLists.txt
@@ -13,6 +13,7 @@ if (NOT HOST_BINARY_DIR)
             ../error.cpp
             ../string.cpp
             ../core/string_builder.cpp
+            ../core/string_consumer.cpp
             ../core/utf8.cpp
     )
     add_definitions(-DSTRGEN)

--- a/src/strgen/CMakeLists.txt
+++ b/src/strgen/CMakeLists.txt
@@ -14,6 +14,7 @@ if (NOT HOST_BINARY_DIR)
             ../string.cpp
             ../core/string_builder.cpp
             ../core/string_consumer.cpp
+            ../core/string_inplace.cpp
             ../core/utf8.cpp
     )
     add_definitions(-DSTRGEN)

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -146,10 +146,10 @@ void FileStringReader::HandlePragma(char *str, LanguagePackHeader &lang)
 		lang.newgrflangid = static_cast<uint8_t>(langid);
 	} else if (!memcmp(str, "gender ", 7)) {
 		if (this->master) FatalError("Genders are not allowed in the base translation.");
-		const char *buf = str + 7;
+		StringConsumer consumer(std::string_view(str + 7));
 
 		for (;;) {
-			auto s = ParseWord(&buf);
+			auto s = ParseWord(consumer);
 
 			if (!s.has_value()) break;
 			if (lang.num_genders >= MAX_NUM_GENDERS) FatalError("Too many genders, max {}", MAX_NUM_GENDERS);
@@ -158,10 +158,10 @@ void FileStringReader::HandlePragma(char *str, LanguagePackHeader &lang)
 		}
 	} else if (!memcmp(str, "case ", 5)) {
 		if (this->master) FatalError("Cases are not allowed in the base translation.");
-		const char *buf = str + 5;
+		StringConsumer consumer(std::string_view(str + 5));
 
 		for (;;) {
-			auto s = ParseWord(&buf);
+			auto s = ParseWord(consumer);
 
 			if (!s.has_value()) break;
 			if (lang.num_cases >= MAX_NUM_CASES) FatalError("Too many cases, max {}", MAX_NUM_CASES);

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -10,6 +10,7 @@
 #ifndef STRGEN_H
 #define STRGEN_H
 
+#include "../core/string_consumer.hpp"
 #include "../language.h"
 #include "../3rdparty/fmt/format.h"
 
@@ -144,7 +145,7 @@ struct ParsedCommandStruct {
 };
 
 const CmdStruct *TranslateCmdForCompare(const CmdStruct *a);
-ParsedCommandStruct ExtractCommandString(const char *s, bool warnings);
+ParsedCommandStruct ExtractCommandString(std::string_view s, bool warnings);
 
 void StrgenWarningI(const std::string &msg);
 void StrgenErrorI(const std::string &msg);
@@ -152,7 +153,7 @@ void StrgenErrorI(const std::string &msg);
 #define StrgenWarning(format_string, ...) StrgenWarningI(fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__))
 #define StrgenError(format_string, ...) StrgenErrorI(fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__))
 #define StrgenFatal(format_string, ...) StrgenFatalI(fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__))
-std::optional<std::string_view> ParseWord(const char **buf);
+std::optional<std::string_view> ParseWord(StringConsumer &consumer);
 
 /** Global state shared between strgen.cpp, game_text.cpp and strgen_base.cpp */
 struct StrgenState {

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -22,7 +22,7 @@ struct Case {
 	uint8_t caseidx;       ///< The index of the case.
 	std::string string; ///< The translation of the case.
 
-	Case(uint8_t caseidx, const std::string &string);
+	Case(uint8_t caseidx, std::string_view string);
 };
 
 /** Information about a single string. */
@@ -34,7 +34,7 @@ struct LangString {
 	size_t line;            ///< Line of string in source-file.
 	std::vector<Case> translated_cases; ///< Cases of the translation.
 
-	LangString(const std::string &name, const std::string &english, size_t index, size_t line);
+	LangString(std::string_view name, std::string_view english, size_t index, size_t line);
 	void FreeTranslation();
 };
 
@@ -63,7 +63,7 @@ struct StringReader {
 
 	StringReader(StringData &data, const std::string &file, bool master, bool translation);
 	virtual ~StringReader() = default;
-	void HandleString(char *str);
+	void HandleString(std::string_view str);
 
 	/**
 	 * Read a single line from the source of strings.
@@ -75,7 +75,7 @@ struct StringReader {
 	 * Handle the pragma of the file.
 	 * @param str    The pragma string to parse.
 	 */
-	virtual void HandlePragma(char *str, LanguagePackHeader &lang);
+	virtual void HandlePragma(std::string_view str, LanguagePackHeader &lang);
 
 	/**
 	 * Start parsing the file.

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -41,7 +41,7 @@ static size_t TranslateArgumentIdx(size_t arg, size_t offset = 0);
  * @param caseidx The index of the case.
  * @param string  The translation of the case.
  */
-Case::Case(uint8_t caseidx, const std::string &string) :
+Case::Case(uint8_t caseidx, std::string_view string) :
 		caseidx(caseidx), string(string)
 {
 }
@@ -53,7 +53,7 @@ Case::Case(uint8_t caseidx, const std::string &string) :
  * @param index   The index in the string table.
  * @param line    The line this string was found on.
  */
-LangString::LangString(const std::string &name, const std::string &english, size_t index, size_t line) :
+LangString::LangString(std::string_view name, std::string_view english, size_t index, size_t line) :
 		name(name), english(english), index(index), line(line)
 {
 }
@@ -162,30 +162,6 @@ size_t StringData::CountInUse(size_t tab) const
 	size_t count = TAB_SIZE;
 	while (count > 0 && this->strings[(tab * TAB_SIZE) + count - 1] == nullptr) --count;
 	return count;
-}
-
-static size_t Utf8Validate(const char *s)
-{
-	char32_t c;
-
-	if (!HasBit(s[0], 7)) {
-		/* 1 byte */
-		return 1;
-	} else if (GB(s[0], 5, 3) == 6 && IsUtf8Part(s[1])) {
-		/* 2 bytes */
-		c = GB(s[0], 0, 5) << 6 | GB(s[1], 0, 6);
-		if (c >= 0x80) return 2;
-	} else if (GB(s[0], 4, 4) == 14 && IsUtf8Part(s[1]) && IsUtf8Part(s[2])) {
-		/* 3 bytes */
-		c = GB(s[0], 0, 4) << 12 | GB(s[1], 0, 6) << 6 | GB(s[2], 0, 6);
-		if (c >= 0x800) return 3;
-	} else if (GB(s[0], 3, 5) == 30 && IsUtf8Part(s[1]) && IsUtf8Part(s[2]) && IsUtf8Part(s[3])) {
-		/* 4 bytes */
-		c = GB(s[0], 0, 3) << 18 | GB(s[1], 0, 6) << 12 | GB(s[2], 0, 6) << 6 | GB(s[3], 0, 6);
-		if (c >= 0x10000 && c <= 0x10FFFF) return 4;
-	}
-
-	return 0;
 }
 
 void EmitSingleChar(StringBuilder &builder, std::string_view param, char32_t value)
@@ -503,91 +479,98 @@ static bool CheckCommandsMatch(std::string_view a, std::string_view b, std::stri
 	return result;
 }
 
-void StringReader::HandleString(char *str)
+[[nodiscard]] static std::string_view StripTrailingWhitespace(std::string_view str)
 {
-	if (*str == '#') {
-		if (str[1] == '#' && str[2] != '#') this->HandlePragma(str + 2, _strgen.lang);
+	auto len = str.find_last_not_of("\r\n ");
+	if (len == std::string_view::npos) {
+		len = 0;
+	} else {
+		++len;
+	}
+	return str.substr(0, len);
+}
+
+void StringReader::HandleString(std::string_view src)
+{
+	if (src.empty()) return;
+
+	StringConsumer consumer(src);
+	if (consumer.ReadCharIf('#')) {
+		if (consumer.ReadCharIf('#') && !consumer.ReadCharIf('#')) this->HandlePragma(consumer.Read(StringConsumer::npos), _strgen.lang);
 		return;
 	}
 
 	/* Ignore comments & blank lines */
-	if (*str == ';' || *str == ' ' || *str == '\0') return;
+	if (consumer.PeekCharIfIn("; ")) return;
 
-	char *s = strchr(str, ':');
-	if (s == nullptr) {
+	/* Read string name */
+	std::string_view str_name = StripTrailingWhitespace(consumer.ReadUntilChar(':', StringConsumer::KEEP_SEPARATOR));
+	if (!consumer.ReadCharIf(':')) {
 		StrgenError("Line has no ':' delimiter");
 		return;
 	}
 
-	char *t;
-	/* Trim spaces.
-	 * After this str points to the command name, and s points to the command contents */
-	for (t = s; t > str && (t[-1] == ' ' || t[-1] == '\t'); t--) {}
-	*t = 0;
-	s++;
-
-	/* Check string is valid UTF-8 */
-	const char *tmp;
-	for (tmp = s; *tmp != '\0';) {
-		size_t len = Utf8Validate(tmp);
-		if (len == 0) StrgenFatal("Invalid UTF-8 sequence in '{}'", s);
-
-		char32_t c;
-		Utf8Decode(&c, tmp);
-		if (c <= 0x001F || // ASCII control character range
-				c == 0x200B || // Zero width space
-				(c >= 0xE000 && c <= 0xF8FF) || // Private range
-				(c >= 0xFFF0 && c <= 0xFFFF)) { // Specials range
-			StrgenFatal("Unwanted UTF-8 character U+{:04X} in sequence '{}'", static_cast<uint32_t>(c), s);
-		}
-
-		tmp += len;
+	/* Read string case */
+	std::optional<std::string_view> casep;
+	if (auto index = str_name.find("."); index != std::string_view::npos) {
+		casep = str_name.substr(index + 1);
+		str_name = str_name.substr(0, index);
 	}
 
-	/* Check if the string has a case..
-	 * The syntax for cases is IDENTNAME.case */
-	char *casep = strchr(str, '.');
-	if (casep != nullptr) *casep++ = '\0';
+	/* Read string data */
+	std::string_view value = consumer.Read(StringConsumer::npos);
+
+	/* Check string is valid UTF-8 */
+	for (StringConsumer validation_consumer(value); validation_consumer.AnyBytesLeft(); ) {
+		auto c = validation_consumer.TryReadUtf8();
+		if (!c.has_value()) StrgenFatal("Invalid UTF-8 sequence in '{}'", value);
+		if (*c <= 0x001F || // ASCII control character range
+				*c == 0x200B || // Zero width space
+				(*c >= 0xE000 && *c <= 0xF8FF) || // Private range
+				(*c >= 0xFFF0 && *c <= 0xFFFF)) { // Specials range
+			StrgenFatal("Unwanted UTF-8 character U+{:04X} in sequence '{}'", static_cast<uint32_t>(*c), value);
+		}
+	}
 
 	/* Check if this string already exists.. */
-	LangString *ent = this->data.Find(str);
+	LangString *ent = this->data.Find(std::string(str_name));
 
 	if (this->master) {
-		if (casep != nullptr) {
+		if (casep.has_value()) {
 			StrgenError("Cases in the base translation are not supported.");
 			return;
 		}
 
 		if (ent != nullptr) {
-			StrgenError("String name '{}' is used multiple times", str);
+			StrgenError("String name '{}' is used multiple times", str_name);
 			return;
 		}
 
 		if (this->data.strings[this->data.next_string_id] != nullptr) {
-			StrgenError("String ID 0x{:X} for '{}' already in use by '{}'", this->data.next_string_id, str, this->data.strings[this->data.next_string_id]->name);
+			StrgenError("String ID 0x{:X} for '{}' already in use by '{}'", this->data.next_string_id, str_name, this->data.strings[this->data.next_string_id]->name);
 			return;
 		}
 
 		/* Allocate a new LangString */
-		this->data.Add(std::make_unique<LangString>(str, s, this->data.next_string_id++, _strgen.cur_line));
+		this->data.Add(std::make_unique<LangString>(str_name, value, this->data.next_string_id++, _strgen.cur_line));
 	} else {
 		if (ent == nullptr) {
-			StrgenWarning("String name '{}' does not exist in master file", str);
+			StrgenWarning("String name '{}' does not exist in master file", str_name);
 			return;
 		}
 
-		if (!ent->translated.empty() && casep == nullptr) {
-			StrgenError("String name '{}' is used multiple times", str);
+		if (!ent->translated.empty() && !casep.has_value()) {
+			StrgenError("String name '{}' is used multiple times", str_name);
 			return;
 		}
 
 		/* make sure that the commands match */
-		if (!CheckCommandsMatch(s, ent->english, str)) return;
+		if (!CheckCommandsMatch(value, ent->english, str_name)) return;
 
-		if (casep != nullptr) {
-			ent->translated_cases.emplace_back(ResolveCaseName(casep), s);
+		if (casep.has_value()) {
+			ent->translated_cases.emplace_back(ResolveCaseName(*casep), value);
 		} else {
-			ent->translated = s;
+			ent->translated = value;
 			/* If the string was translated, use the line from the
 			 * translated language so errors in the translated file
 			 * are properly referenced to. */
@@ -596,21 +579,18 @@ void StringReader::HandleString(char *str)
 	}
 }
 
-void StringReader::HandlePragma(char *str, LanguagePackHeader &lang)
+void StringReader::HandlePragma(std::string_view str, LanguagePackHeader &lang)
 {
-	if (!memcmp(str, "plural ", 7)) {
-		lang.plural_form = atoi(str + 7);
+	StringConsumer consumer(str);
+	auto name = consumer.ReadUntilChar(' ', StringConsumer::SKIP_ALL_SEPARATORS);
+	if (name == "plural") {
+		lang.plural_form = consumer.ReadIntegerBase<uint32_t>(10);
 		if (lang.plural_form >= lengthof(_plural_forms)) {
 			StrgenFatal("Invalid pluralform {}", lang.plural_form);
 		}
 	} else {
-		StrgenFatal("unknown pragma '{}'", str);
+		StrgenFatal("unknown pragma '{}'", name);
 	}
-}
-
-static void StripTrailingWhitespace(std::string &str)
-{
-	str.erase(str.find_last_not_of("\r\n ") + 1);
 }
 
 void StringReader::ParseFile()
@@ -631,8 +611,7 @@ void StringReader::ParseFile()
 		std::optional<std::string> line = this->ReadLine();
 		if (!line.has_value()) return;
 
-		StripTrailingWhitespace(line.value());
-		this->HandleString(line.value().data());
+		this->HandleString(StripTrailingWhitespace(line.value()));
 		_strgen.cur_line++;
 	}
 

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -14,6 +14,7 @@
 #include "string_func.h"
 #include "string_base.h"
 #include "core/utf8.hpp"
+#include "core/string_inplace.hpp"
 
 #include "table/control_codes.h"
 
@@ -108,75 +109,42 @@ static bool IsSccEncodedCode(char32_t c)
 }
 
 /**
- * Copies the valid (UTF-8) characters from \c str up to \c last to the \c dst.
+ * Copies the valid (UTF-8) characters from \c consumer to the \c builder.
  * Depending on the \c settings invalid characters can be replaced with a
  * question mark, as well as determining what characters are deemed invalid.
  *
- * It is allowed for \c dst to be the same as \c src, in which case the string
- * is make valid in place.
- * @param dst The destination to write to.
- * @param str The string to validate.
- * @param last The last valid character of str.
+ * @param builder The destination to write to.
+ * @param consumer The string to validate.
  * @param settings The settings for the string validation.
  */
-template <class T>
-static void StrMakeValid(T &dst, const char *str, const char *last, StringValidationSettings settings)
+template<class Builder>
+static void StrMakeValid(Builder &builder, StringConsumer &consumer, StringValidationSettings settings)
 {
 	/* Assume the ABSOLUTE WORST to be in str as it comes from the outside. */
-
-	while (str <= last && *str != '\0') {
-		size_t len = Utf8EncodedCharLen(*str);
-		char32_t c;
-		/* If the first byte does not look like the first byte of an encoded
-		 * character, i.e. encoded length is 0, then this byte is definitely bad
-		 * and it should be skipped.
-		 * When the first byte looks like the first byte of an encoded character,
-		 * then the remaining bytes in the string are checked whether the whole
-		 * encoded character can be there. If that is not the case, this byte is
-		 * skipped.
-		 * Finally we attempt to decode the encoded character, which does certain
-		 * extra validations to see whether the correct number of bytes were used
-		 * to encode the character. If that is not the case, the byte is probably
-		 * invalid and it is skipped. We could emit a question mark, but then the
-		 * logic below cannot just copy bytes, it would need to re-encode the
-		 * decoded characters as the length in bytes may have changed.
-		 *
-		 * The goals here is to get as much valid Utf8 encoded characters from the
-		 * source string to the destination string.
-		 *
-		 * Note: a multi-byte encoded termination ('\0') will trigger the encoded
-		 * char length and the decoded length to differ, so it will be ignored as
-		 * invalid character data. If it were to reach the termination, then we
-		 * would also reach the "last" byte of the string and a normal '\0'
-		 * termination will be placed after it.
-		 */
-		if (len == 0 || str + len > last + 1 || len != Utf8Decode(&c, str)) {
+	while (consumer.AnyBytesLeft()) {
+		auto c = consumer.TryReadUtf8();
+		if (!c.has_value()) {
 			/* Maybe the next byte is still a valid character? */
-			str++;
+			consumer.Skip(1);
 			continue;
 		}
+		if (*c == 0) break;
 
-		if ((IsPrintable(c) && (c < SCC_SPRITE_START || c > SCC_SPRITE_END)) || (settings.Test(StringValidationSetting::AllowControlCode) && IsSccEncodedCode(c))) {
-			/* Copy the character back. Even if dst is current the same as str
-			 * (i.e. no characters have been changed) this is quicker than
-			 * moving the pointers ahead by len */
-			do {
-				*dst++ = *str++;
-			} while (--len != 0);
-		} else if (settings.Test(StringValidationSetting::AllowNewline) && c == '\n') {
-			*dst++ = *str++;
+		if ((IsPrintable(*c) && (*c < SCC_SPRITE_START || *c > SCC_SPRITE_END)) || (settings.Test(StringValidationSetting::AllowControlCode) && IsSccEncodedCode(*c))) {
+			builder.PutUtf8(*c);
+		} else if (settings.Test(StringValidationSetting::AllowNewline) && *c == '\n') {
+			builder.PutUtf8(*c);
 		} else {
-			if (settings.Test(StringValidationSetting::AllowNewline) && c == '\r' && str[1] == '\n') {
-				str += len;
+			if (settings.Test(StringValidationSetting::AllowNewline) && *c == '\r' && consumer.PeekCharIf('\n')) {
+				/* Skip \r, if followed by \n */
 				continue;
 			}
-			str += len;
-			if (settings.Test(StringValidationSetting::ReplaceTabCrNlWithSpace) && (c == '\r' || c == '\n' || c == '\t')) {
+			if (settings.Test(StringValidationSetting::ReplaceTabCrNlWithSpace) && (*c == '\r' || *c == '\n' || *c == '\t')) {
 				/* Replace the tab, carriage return or newline with a space. */
-				*dst++ = ' ';
+				builder.PutChar(' ');
 			} else if (settings.Test(StringValidationSetting::ReplaceWithQuestionMark)) {
 				/* Replace the undesirable character with a question mark */
-				*dst++ = '?';
+				builder.PutChar('?');
 			}
 		}
 	}
@@ -193,9 +161,10 @@ static void StrMakeValid(T &dst, const char *str, const char *last, StringValida
  */
 void StrMakeValidInPlace(char *str, StringValidationSettings settings)
 {
-	char *dst = str;
-	StrMakeValid(dst, str, str + strlen(str), settings);
-	*dst = '\0';
+	InPlaceReplacement inplace(std::span(str, strlen(str)));
+	StrMakeValid(inplace.builder, inplace.consumer, settings);
+	/* Add NUL terminator, if we ended up with less bytes than before */
+	if (inplace.builder.AnyBytesUnused()) inplace.builder.PutChar('\0');
 }
 
 /**
@@ -209,11 +178,9 @@ void StrMakeValidInPlace(std::string &str, StringValidationSettings settings)
 {
 	if (str.empty()) return;
 
-	char *buf = str.data();
-	char *last = buf + str.size() - 1;
-	char *dst = buf;
-	StrMakeValid(dst, buf, last, settings);
-	str.erase(dst - buf, std::string::npos);
+	InPlaceReplacement inplace(std::span(str.data(), str.size()));
+	StrMakeValid(inplace.builder, inplace.consumer, settings);
+	str.erase(inplace.builder.GetBytesWritten(), std::string::npos);
 }
 
 /**
@@ -225,16 +192,11 @@ void StrMakeValidInPlace(std::string &str, StringValidationSettings settings)
  */
 std::string StrMakeValid(std::string_view str, StringValidationSettings settings)
 {
-	if (str.empty()) return {};
-
-	auto buf = str.data();
-	auto last = buf + str.size() - 1;
-
-	std::ostringstream dst;
-	std::ostreambuf_iterator<char> dst_iter(dst);
-	StrMakeValid(dst_iter, buf, last, settings);
-
-	return dst.str();
+	std::string result;
+	StringBuilder builder(result);
+	StringConsumer consumer(str);
+	StrMakeValid(builder, consumer, settings);
+	return result;
 }
 
 /**
@@ -248,27 +210,17 @@ std::string StrMakeValid(std::string_view str, StringValidationSettings settings
 bool StrValid(std::span<const char> str)
 {
 	/* Assume the ABSOLUTE WORST to be in str as it comes from the outside. */
-	auto it = std::begin(str);
-	auto last = std::prev(std::end(str));
-
-	while (it <= last && *it != '\0') {
-		size_t len = Utf8EncodedCharLen(*it);
-		/* Encoded length is 0 if the character isn't known.
-		 * The length check is needed to prevent Utf8Decode to read
-		 * over the terminating '\0' if that happens to be placed
-		 * within the encoding of an UTF8 character. */
-		if (len == 0 || it + len > last) return false;
-
-		char32_t c;
-		len = Utf8Decode(&c, &*it);
-		if (!IsPrintable(c) || (c >= SCC_SPRITE_START && c <= SCC_SPRITE_END)) {
+	StringConsumer consumer(str);
+	while (consumer.AnyBytesLeft()) {
+		auto c = consumer.TryReadUtf8();
+		if (!c.has_value()) return false; // invalid codepoint
+		if (*c == 0) return true; // NUL termination
+		if (!IsPrintable(*c) || (*c >= SCC_SPRITE_START && *c <= SCC_SPRITE_END)) {
 			return false;
 		}
-
-		it += len;
 	}
 
-	return *it == '\0';
+	return false; // missing NUL termination
 }
 
 /**

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -380,48 +380,6 @@ bool IsValidChar(char32_t key, CharSetFilter afilter)
 	}
 }
 
-
-/* UTF-8 handling routines */
-
-
-/**
- * Decode and consume the next UTF-8 encoded character.
- * @param c Buffer to place decoded character.
- * @param s Character stream to retrieve character from.
- * @return Number of characters in the sequence.
- */
-size_t Utf8Decode(char32_t *c, const char *s)
-{
-	assert(c != nullptr);
-
-	if (!HasBit(s[0], 7)) {
-		/* Single byte character: 0xxxxxxx */
-		*c = s[0];
-		return 1;
-	} else if (GB(s[0], 5, 3) == 6) {
-		if (IsUtf8Part(s[1])) {
-			/* Double byte character: 110xxxxx 10xxxxxx */
-			*c = GB(s[0], 0, 5) << 6 | GB(s[1], 0, 6);
-			if (*c >= 0x80) return 2;
-		}
-	} else if (GB(s[0], 4, 4) == 14) {
-		if (IsUtf8Part(s[1]) && IsUtf8Part(s[2])) {
-			/* Triple byte character: 1110xxxx 10xxxxxx 10xxxxxx */
-			*c = GB(s[0], 0, 4) << 12 | GB(s[1], 0, 6) << 6 | GB(s[2], 0, 6);
-			if (*c >= 0x800) return 3;
-		}
-	} else if (GB(s[0], 3, 5) == 30) {
-		if (IsUtf8Part(s[1]) && IsUtf8Part(s[2]) && IsUtf8Part(s[3])) {
-			/* 4 byte character: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx */
-			*c = GB(s[0], 0, 3) << 18 | GB(s[1], 0, 6) << 12 | GB(s[2], 0, 6) << 6 | GB(s[3], 0, 6);
-			if (*c >= 0x10000 && *c <= 0x10FFFF) return 4;
-		}
-	}
-
-	*c = '?';
-	return 1;
-}
-
 /**
  * Test if a unicode character is considered garbage to be skipped.
  * @param c Character to test.

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -72,44 +72,6 @@ inline bool StrEmpty(const char *s)
 
 bool IsValidChar(char32_t key, CharSetFilter afilter);
 
-size_t Utf8Decode(char32_t *c, const char *s);
-/* std::string_view::iterator might be char *, in which case we do not want this templated variant to be taken. */
-template <typename T> requires (!std::is_same_v<T, char *> && (std::is_same_v<std::string_view::iterator, T> || std::is_same_v<std::string::iterator, T>))
-inline size_t Utf8Decode(char32_t *c, T &s) { return Utf8Decode(c, &*s); }
-
-inline char32_t Utf8Consume(const char **s)
-{
-	char32_t c;
-	*s += Utf8Decode(&c, *s);
-	return c;
-}
-
-template <class Titr>
-inline char32_t Utf8Consume(Titr &s)
-{
-	char32_t c;
-	s += Utf8Decode(&c, &*s);
-	return c;
-}
-
-/**
- * Return the length of an UTF-8 encoded value based on a single char. This
- * char should be the first byte of the UTF-8 encoding. If not, or encoding
- * is invalid, return value is 0
- * @param c char to query length of
- * @return requested size
- */
-inline int8_t Utf8EncodedCharLen(char c)
-{
-	if (GB(c, 3, 5) == 0x1E) return 4;
-	if (GB(c, 4, 4) == 0x0E) return 3;
-	if (GB(c, 5, 3) == 0x06) return 2;
-	if (GB(c, 7, 1) == 0x00) return 1;
-
-	/* Invalid UTF8 start encoding */
-	return 0;
-}
-
 
 /* Check if the given character is part of a UTF8 sequence */
 inline bool IsUtf8Part(char c)

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -72,13 +72,6 @@ inline bool StrEmpty(const char *s)
 
 bool IsValidChar(char32_t key, CharSetFilter afilter);
 
-
-/* Check if the given character is part of a UTF8 sequence */
-inline bool IsUtf8Part(char c)
-{
-	return GB(c, 6, 2) == 2;
-}
-
 size_t Utf8StringLength(std::string_view str);
 
 /**

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -70,20 +70,6 @@ inline bool StrEmpty(const char *s)
 	return s == nullptr || s[0] == '\0';
 }
 
-/**
- * Get the length of a string, within a limited buffer.
- *
- * @param str The pointer to the first element of the buffer
- * @param maxlen The maximum size of the buffer
- * @return The length of the string
- */
-inline size_t ttd_strnlen(const char *str, size_t maxlen)
-{
-	const char *t;
-	for (t = str; static_cast<size_t>(t - str) < maxlen && *t != '\0'; t++) {}
-	return t - str;
-}
-
 bool IsValidChar(char32_t key, CharSetFilter afilter);
 
 size_t Utf8Decode(char32_t *c, const char *s);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -653,7 +653,7 @@ static void FormatGenericCurrency(StringBuilder &builder, const CurrencySpec *sp
  * @param plural_form The plural form we want an index for.
  * @return The plural index for the given form.
  */
-static int DeterminePluralForm(int64_t count, int plural_form)
+static int DeterminePluralForm(int64_t count, uint plural_form)
 {
 	/* The absolute value determines plurality */
 	uint64_t n = abs(count);
@@ -774,22 +774,25 @@ static int DeterminePluralForm(int64_t count, int plural_form)
 	}
 }
 
-static const char *ParseStringChoice(const char *b, uint form, StringBuilder &builder)
+static void ParseStringChoice(StringConsumer &consumer, uint form, StringBuilder &builder)
 {
 	/* <NUM> {Length of each string} {each string} */
-	uint n = (uint8_t)*b++;
-	size_t form_offset = 0, form_len = 0, total_len = 0;
+	uint n = consumer.ReadUint8();
+	size_t form_pre = 0, form_len = 0, form_post = 0;
 	for (uint i = 0; i != n; i++) {
-		uint len = (uint8_t)*b++;
-		if (i == form) {
-			form_offset = total_len;
+		uint len = consumer.ReadUint8();
+		if (i < form) {
+			form_pre += len;
+		} else if (i > form) {
+			form_post += len;
+		} else {
 			form_len = len;
 		}
-		total_len += len;
 	}
 
-	builder += std::string_view(b + form_offset, form_len);
-	return b + total_len;
+	consumer.Skip(form_pre);
+	builder += consumer.Read(form_len);
+	consumer.Skip(form_post);
 }
 
 /** Helper for unit conversion. */
@@ -991,67 +994,59 @@ uint ConvertDisplaySpeedToKmhishSpeed(uint speed, VehicleType type)
 
 /**
  * Decodes an encoded string during FormatString.
- * @param str The buffer of the encoded string.
+ * @param consumer The encoded string.
  * @param game_script Set if decoding a GameScript-encoded string. This affects how string IDs are handled.
  * @param builder The string builder to write the string to.
- * @returns Updated position position in input buffer.
  */
-static const char *DecodeEncodedString(const char *str, bool game_script, StringBuilder &builder)
+static void DecodeEncodedString(StringConsumer &consumer, bool game_script, StringBuilder &builder)
 {
 	std::vector<StringParameter> sub_args;
 
-	char *p;
-	StringIndexInTab id(std::strtoul(str, &p, 16));
-	if (*p != SCC_RECORD_SEPARATOR && *p != '\0') {
-		while (*p != '\0') p++;
+	StringIndexInTab id(consumer.ReadIntegerBase<uint32_t>(16));
+	if (consumer.AnyBytesLeft() && !consumer.ReadUtf8If(SCC_RECORD_SEPARATOR)) {
+		consumer.SkipAll();
 		builder += "(invalid SCC_ENCODED)";
-		return p;
+		return;
 	}
 	if (game_script && id >= TAB_SIZE_GAMESCRIPT) {
-		while (*p != '\0') p++;
+		consumer.SkipAll();
 		builder += "(invalid StringID)";
-		return p;
+		return;
 	}
 
-	while (*p != '\0') {
-		/* The start of parameter. */
-		const char *s = ++p;
+	while (consumer.AnyBytesLeft()) {
+		StringConsumer record(consumer.ReadUntilUtf8(SCC_RECORD_SEPARATOR, StringConsumer::SKIP_ONE_SEPARATOR));
 
-		/* Find end of the parameter. */
-		for (; *p != '\0' && *p != SCC_RECORD_SEPARATOR; ++p) {}
-
-		if (s == p) {
+		if (!record.AnyBytesLeft()) {
 			/* This is an empty parameter. */
 			sub_args.emplace_back(std::monostate{});
 			continue;
 		}
 
 		/* Get the parameter type. */
-		char32_t parameter_type;
-		size_t len = Utf8Decode(&parameter_type, s);
-		s += len;
-
+		char32_t parameter_type = record.ReadUtf8();
 		switch (parameter_type) {
 			case SCC_ENCODED: {
-				uint64_t param = std::strtoull(s, &p, 16);
+				uint64_t param = record.ReadIntegerBase<uint64_t>(16);
 				if (param >= TAB_SIZE_GAMESCRIPT) {
-					while (*p != '\0') p++;
 					builder += "(invalid sub-StringID)";
-					return p;
+					return;
 				}
+				assert(!record.AnyBytesLeft());
 				param = MakeStringID(TEXT_TAB_GAMESCRIPT_START, StringIndexInTab(param));
 				sub_args.emplace_back(param);
 				break;
 			}
 
 			case SCC_ENCODED_NUMERIC: {
-				uint64_t param = std::strtoull(s, &p, 16);
+				uint64_t param = record.ReadIntegerBase<uint64_t>(16);
+				assert(!record.AnyBytesLeft());
 				sub_args.emplace_back(param);
 				break;
 			}
 
 			case SCC_ENCODED_STRING: {
-				sub_args.emplace_back(std::string(s, p - s));
+				sub_args.emplace_back(std::string(record.Read(StringConsumer::npos)));
 				break;
 			}
 
@@ -1064,8 +1059,6 @@ static const char *DecodeEncodedString(const char *str, bool game_script, String
 
 	StringID stringid = game_script ? MakeStringID(TEXT_TAB_GAMESCRIPT_START, id) : StringID{id.base()};
 	GetStringWithArgs(builder, stringid, sub_args, true);
-
-	return p;
 }
 
 /**
@@ -1096,13 +1089,12 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 	}
 	uint next_substr_case_index = 0;
 	struct StrStackItem {
-		const char *str;
-		const char *end;
+		StringConsumer consumer;
 		size_t first_param_offset;
 		uint case_index;
 
 		StrStackItem(std::string_view view, size_t first_param_offset, uint case_index)
-			: str(view.data()), end(view.data() + view.size()), first_param_offset(first_param_offset), case_index(case_index)
+			: consumer(view), first_param_offset(first_param_offset), case_index(case_index)
 		{}
 	};
 	std::stack<StrStackItem, std::vector<StrStackItem>> str_stack;
@@ -1110,19 +1102,19 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 
 	for (;;) {
 		try {
-			while (!str_stack.empty() && str_stack.top().str >= str_stack.top().end) {
+			while (!str_stack.empty() && !str_stack.top().consumer.AnyBytesLeft()) {
 				str_stack.pop();
 			}
 			if (str_stack.empty()) break;
-			const char *&str = str_stack.top().str;
+			StringConsumer &consumer = str_stack.top().consumer;
 			const size_t ref_param_offset = str_stack.top().first_param_offset;
 			const uint case_index = str_stack.top().case_index;
-			char32_t b = Utf8Consume(&str);
+			char32_t b = consumer.ReadUtf8();
 			assert(b != 0);
 
 			if (SCC_NEWGRF_FIRST <= b && b <= SCC_NEWGRF_LAST) {
 				/* We need to pass some stuff as it might be modified. */
-				b = RemapNewGRFStringControlCode(b, &str);
+				b = RemapNewGRFStringControlCode(b, consumer);
 				if (b == 0) continue;
 			}
 
@@ -1135,13 +1127,13 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 			switch (b) {
 				case SCC_ENCODED:
 				case SCC_ENCODED_INTERNAL:
-					str = DecodeEncodedString(str, b == SCC_ENCODED, builder);
+					DecodeEncodedString(consumer, b == SCC_ENCODED, builder);
 					break;
 
 				case SCC_NEWGRF_STRINL: {
-					StringID substr = Utf8Consume(&str);
+					StringID substr = consumer.ReadUtf8(STR_NULL);
 					std::string_view ptr = GetStringPtr(substr);
-					str_stack.emplace(ptr, args.GetOffset(), next_substr_case_index); // this may invalidate "str"
+					str_stack.emplace(ptr, args.GetOffset(), next_substr_case_index); // this may invalidate "consumer"
 					next_substr_case_index = 0;
 					break;
 				}
@@ -1149,15 +1141,15 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 				case SCC_NEWGRF_PRINT_WORD_STRING_ID: {
 					StringID substr = args.GetNextParameter<StringID>();
 					std::string_view ptr = GetStringPtr(substr);
-					str_stack.emplace(ptr, args.GetOffset(), next_substr_case_index); // this may invalidate "str"
+					str_stack.emplace(ptr, args.GetOffset(), next_substr_case_index); // this may invalidate "consumer"
 					next_substr_case_index = 0;
 					break;
 				}
 
 				case SCC_GENDER_LIST: { // {G 0 Der Die Das}
 					/* First read the meta data from the language file. */
-					size_t offset = ref_param_offset + (uint8_t)*str++;
-					int gender = 0;
+					size_t offset = ref_param_offset + consumer.ReadUint8();
+					uint8_t gender = 0;
 					if (offset >= args.GetNumParameters()) {
 						/* The offset may come from an external NewGRF, and be invalid. */
 						builder += "(invalid GENDER parameter)";
@@ -1179,37 +1171,38 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 							FormatString(tmp_builder, input, tmp_params);
 						}
 
-						/* The gender is stored at the start of the formatted string. */
-						const char *s = buffer.c_str();
-						char32_t c = Utf8Consume(&s);
-						/* Does this string have a gender, if so, set it */
-						if (c == SCC_GENDER_INDEX) gender = (uint8_t)s[0];
+						/* The gender is stored at the start of the formatted string.
+						 * Does this string have a gender, if so, set it. */
+						StringConsumer gender_consumer(buffer);
+						if (gender_consumer.ReadUtf8If(SCC_GENDER_INDEX)) {
+							gender = gender_consumer.ReadUint8();
+						}
 					}
-					str = ParseStringChoice(str, gender, builder);
+					ParseStringChoice(consumer, gender, builder);
 					break;
 				}
 
 				/* This sets up the gender for the string.
 				 * We just ignore this one. It's used in {G 0 Der Die Das} to determine the case. */
-				case SCC_GENDER_INDEX: // {GENDER 0}
+				case SCC_GENDER_INDEX: { // {GENDER 0}
+					uint8_t gender = consumer.ReadUint8();
 					if (_scan_for_gender_data) {
 						builder.PutUtf8(SCC_GENDER_INDEX);
-						builder.PutUint8(*str++);
-					} else {
-						str++;
+						builder.PutUint8(gender);
 					}
 					break;
+				}
 
 				case SCC_PLURAL_LIST: { // {P}
-					int plural_form = *str++;          // contains the plural form for this string
-					size_t offset = ref_param_offset + (uint8_t)*str++;
+					uint8_t plural_form = consumer.ReadUint8();  // contains the plural form for this string
+					size_t offset = ref_param_offset + consumer.ReadUint8();
 					const uint64_t *v = nullptr;
 					/* The offset may come from an external NewGRF, and be invalid. */
 					if (offset < args.GetNumParameters()) {
 						v = std::get_if<uint64_t>(&args.GetParam(offset)); // contains the number that determines plural
 					}
 					if (v != nullptr) {
-						str = ParseStringChoice(str, DeterminePluralForm(static_cast<int64_t>(*v), plural_form), builder);
+						ParseStringChoice(consumer, DeterminePluralForm(static_cast<int64_t>(*v), plural_form), builder);
 					} else {
 						builder += "(invalid PLURAL parameter)";
 					}
@@ -1217,38 +1210,35 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 				}
 
 				case SCC_ARG_INDEX: { // Move argument pointer
-					args.SetOffset(ref_param_offset + (uint8_t)*str++);
+					args.SetOffset(ref_param_offset + consumer.ReadUint8());
 					break;
 				}
 
 				case SCC_SET_CASE: { // {SET_CASE}
 					/* This is a pseudo command, it's outputted when someone does {STRING.ack}
 					 * The modifier is added to all subsequent GetStringWithArgs that accept the modifier. */
-					next_substr_case_index = (uint8_t)*str++;
+					next_substr_case_index = consumer.ReadUint8();
 					break;
 				}
 
 				case SCC_SWITCH_CASE: { // {Used to implement case switching}
 					/* <0x9E> <NUM CASES> <CASE1> <LEN1> <STRING1> <CASE2> <LEN2> <STRING2> <CASE3> <LEN3> <STRING3> <LENDEFAULT> <STRINGDEFAULT>
 					 * Each LEN is printed using 2 bytes in little endian order. */
-					uint num = (uint8_t)*str++;
+					uint num = consumer.ReadUint8();
 					std::optional<std::string_view> found;
 					for (; num > 0; --num) {
-						uint8_t index = static_cast<uint8_t>(str[0]);
-						uint16_t len = static_cast<uint8_t>(str[1]) + (static_cast<uint8_t>(str[2]) << 8);
-						str += 3;
+						uint8_t index = consumer.ReadUint8();
+						uint16_t len = consumer.ReadUint16LE();
+						auto case_str = consumer.Read(len);
 						if (index == case_index) {
 							/* Found the case */
-							found.emplace(str, len);
+							found = case_str;
 						}
-						str += len;
 					}
-					uint16_t default_len = static_cast<uint8_t>(str[0]) + (static_cast<uint8_t>(str[1]) << 8);
-					str += 2;
-					if (!found.has_value()) found.emplace(str, default_len);
-					str += default_len;
-					assert(str <= str_stack.top().end);
-					str_stack.emplace(*found, ref_param_offset, case_index); // this may invalidate "str"
+					uint16_t default_len = consumer.ReadUint16LE();
+					auto default_str = consumer.Read(default_len);
+					if (!found.has_value()) found = default_str;
+					str_stack.emplace(*found, ref_param_offset, case_index); // this may invalidate "consumer"
 					break;
 				}
 

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -13,6 +13,7 @@
 #include "strings_func.h"
 #include "string_func.h"
 #include "core/string_builder.hpp"
+#include "core/string_consumer.hpp"
 
 class StringParameters {
 protected:
@@ -214,6 +215,6 @@ void GenerateTownNameString(StringBuilder &builder, size_t lang, uint32_t seed);
 void GetTownName(StringBuilder &builder, const struct Town *t);
 void GRFTownNameGenerate(StringBuilder &builder, uint32_t grfid, uint16_t gen, uint32_t seed);
 
-char32_t RemapNewGRFStringControlCode(char32_t scc, const char **str);
+char32_t RemapNewGRFStringControlCode(char32_t scc, StringConsumer &consumer);
 
 #endif /* STRINGS_INTERNAL_H */

--- a/src/table/strgen_tables.h
+++ b/src/table/strgen_tables.h
@@ -17,7 +17,7 @@ enum class CmdFlag : uint8_t {
 using CmdFlags = EnumBitSet<CmdFlag, uint8_t>;
 
 class StringBuilder;
-typedef void (*ParseCmdProc)(StringBuilder &builder, const char *buf, char32_t value);
+typedef void (*ParseCmdProc)(StringBuilder &builder, std::string_view param, char32_t value);
 
 struct CmdStruct {
 	std::string_view cmd;
@@ -28,9 +28,9 @@ struct CmdStruct {
 	CmdFlags flags;
 };
 
-extern void EmitSingleChar(StringBuilder &builder, const char *buf, char32_t value);
-extern void EmitPlural(StringBuilder &builder, const char *buf, char32_t value);
-extern void EmitGender(StringBuilder &builder, const char *buf, char32_t value);
+extern void EmitSingleChar(StringBuilder &builder, std::string_view param, char32_t value);
+extern void EmitPlural(StringBuilder &builder, std::string_view param, char32_t value);
+extern void EmitGender(StringBuilder &builder, std::string_view param, char32_t value);
 
 static const CmdStruct _cmd_structs[] = {
 	/* Font size */

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_test_files(
     mock_spritecache.cpp
     mock_spritecache.h
     string_builder.cpp
+    string_consumer.cpp
     string_func.cpp
     test_main.cpp
     test_network_crypto.cpp

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_test_files(
     mock_spritecache.h
     string_builder.cpp
     string_consumer.cpp
+    string_inplace.cpp
     string_func.cpp
     test_main.cpp
     test_network_crypto.cpp

--- a/src/tests/string_consumer.cpp
+++ b/src/tests/string_consumer.cpp
@@ -1,0 +1,487 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file string_consumer.cpp Test functionality from core/string_consumer. */
+
+#include "../stdafx.h"
+
+#include <iostream>
+
+#include "../3rdparty/catch2/catch.hpp"
+
+#include "../core/string_consumer.hpp"
+
+#include "../safeguards.h"
+
+using namespace std::literals;
+
+TEST_CASE("StringConsumer - basic")
+{
+	StringConsumer consumer("ab"sv);
+	CHECK(!consumer.AnyBytesRead());
+	CHECK(consumer.GetBytesRead() == 0);
+	CHECK(consumer.AnyBytesLeft());
+	CHECK(consumer.GetBytesLeft() == 2);
+	CHECK(consumer.GetOrigData() == "ab");
+	CHECK(consumer.GetReadData() == "");
+	CHECK(consumer.GetLeftData() == "ab");
+	consumer.Skip(1);
+	CHECK(consumer.AnyBytesRead());
+	CHECK(consumer.GetBytesRead() == 1);
+	CHECK(consumer.AnyBytesLeft());
+	CHECK(consumer.GetBytesLeft() == 1);
+	CHECK(consumer.GetOrigData() == "ab");
+	CHECK(consumer.GetReadData() == "a");
+	CHECK(consumer.GetLeftData() == "b");
+	consumer.SkipAll();
+	CHECK(consumer.AnyBytesRead());
+	CHECK(consumer.GetBytesRead() == 2);
+	CHECK(!consumer.AnyBytesLeft());
+	CHECK(consumer.GetBytesLeft() == 0);
+	CHECK(consumer.GetOrigData() == "ab");
+	CHECK(consumer.GetReadData() == "ab");
+	CHECK(consumer.GetLeftData() == "");
+	consumer.Skip(1);
+	CHECK(consumer.AnyBytesRead());
+	CHECK(consumer.GetBytesRead() == 2);
+	CHECK(!consumer.AnyBytesLeft());
+	CHECK(consumer.GetBytesLeft() == 0);
+	CHECK(consumer.GetOrigData() == "ab");
+	CHECK(consumer.GetReadData() == "ab");
+	CHECK(consumer.GetLeftData() == "");
+}
+
+TEST_CASE("StringConsumer - binary8")
+{
+	StringConsumer consumer("\xFF\xFE\xFD\0"sv);
+	CHECK(consumer.PeekUint8() == 0xFF);
+	CHECK(consumer.PeekSint8() == -1);
+	CHECK(consumer.PeekChar() == static_cast<char>(-1));
+	consumer.SkipUint8();
+	CHECK(consumer.PeekUint8() == 0xFE);
+	CHECK(consumer.PeekSint8() == -2);
+	CHECK(consumer.PeekChar() == static_cast<char>(-2));
+	CHECK(consumer.ReadUint8() == 0xFE);
+	CHECK(consumer.PeekUint8() == 0xFD);
+	CHECK(consumer.PeekSint8() == -3);
+	CHECK(consumer.PeekChar() == static_cast<char>(-3));
+	CHECK(consumer.ReadSint8() == -3);
+	CHECK(consumer.PeekUint8() == 0);
+	CHECK(consumer.PeekSint8() == 0);
+	CHECK(consumer.PeekChar() == 0);
+	CHECK(consumer.ReadChar() == 0);
+	CHECK(consumer.PeekUint8() == std::nullopt);
+	CHECK(consumer.PeekSint8() == std::nullopt);
+	CHECK(consumer.PeekChar() == std::nullopt);
+	CHECK(consumer.ReadUint8(42) == 42);
+	consumer.SkipSint8();
+	CHECK(consumer.ReadSint8(42) == 42);
+	CHECK(consumer.ReadChar(42) == 42);
+}
+
+TEST_CASE("StringConsumer - binary16")
+{
+	StringConsumer consumer("\xFF\xFF\xFE\xFF\xFD\xFF"sv);
+	CHECK(consumer.PeekUint16LE() == 0xFFFF);
+	CHECK(consumer.PeekSint16LE() == -1);
+	consumer.SkipUint16LE();
+	CHECK(consumer.PeekUint16LE() == 0xFFFE);
+	CHECK(consumer.PeekSint16LE() == -2);
+	CHECK(consumer.ReadUint16LE() == 0xFFFE);
+	CHECK(consumer.PeekUint16LE() == 0xFFFD);
+	CHECK(consumer.PeekSint16LE() == -3);
+	CHECK(consumer.ReadSint16LE() == -3);
+	CHECK(consumer.PeekUint16LE() == std::nullopt);
+	CHECK(consumer.PeekSint16LE() == std::nullopt);
+	CHECK(consumer.ReadUint16LE(42) == 42);
+	consumer.SkipSint16LE();
+	CHECK(consumer.ReadSint16LE(42) == 42);
+}
+
+TEST_CASE("StringConsumer - binary32")
+{
+	StringConsumer consumer("\xFF\xFF\xFF\xFF\xFE\xFF\xFF\xFF\xFD\xFF\xFF\xFF"sv);
+	CHECK(consumer.PeekUint32LE() == 0xFFFFFFFF);
+	CHECK(consumer.PeekSint32LE() == -1);
+	consumer.SkipUint32LE();
+	CHECK(consumer.PeekUint32LE() == 0xFFFFFFFE);
+	CHECK(consumer.PeekSint32LE() == -2);
+	CHECK(consumer.ReadUint32LE() == 0xFFFFFFFE);
+	CHECK(consumer.PeekUint32LE() == 0xFFFFFFFD);
+	CHECK(consumer.PeekSint32LE() == -3);
+	CHECK(consumer.ReadSint32LE() == -3);
+	CHECK(consumer.PeekUint32LE() == std::nullopt);
+	CHECK(consumer.PeekSint32LE() == std::nullopt);
+	CHECK(consumer.ReadUint32LE(42) == 42);
+	consumer.SkipSint32LE();
+	CHECK(consumer.ReadSint32LE(42) == 42);
+}
+
+TEST_CASE("StringConsumer - binary64")
+{
+	StringConsumer consumer("\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFD\xFF\xFF\xFF\xFF\xFF\xFF\xFF"sv);
+	CHECK(consumer.PeekUint64LE() == 0xFFFFFFFF'FFFFFFFF);
+	CHECK(consumer.PeekSint64LE() == -1);
+	consumer.SkipUint64LE();
+	CHECK(consumer.PeekUint64LE() == 0xFFFFFFFF'FFFFFFFE);
+	CHECK(consumer.PeekSint64LE() == -2);
+	CHECK(consumer.ReadUint64LE() == 0xFFFFFFFF'FFFFFFFE);
+	CHECK(consumer.PeekUint64LE() == 0xFFFFFFFF'FFFFFFFD);
+	CHECK(consumer.PeekSint64LE() == -3);
+	CHECK(consumer.ReadSint64LE() == -3);
+	CHECK(consumer.PeekUint64LE() == std::nullopt);
+	CHECK(consumer.PeekSint64LE() == std::nullopt);
+	CHECK(consumer.ReadUint64LE(42) == 42);
+	consumer.SkipSint64LE();
+	CHECK(consumer.ReadSint64LE(42) == 42);
+}
+
+TEST_CASE("StringConsumer - utf8")
+{
+	StringConsumer consumer("a\u1234\xFF\xFE""b"sv);
+	CHECK(consumer.PeekUtf8() == std::pair<StringConsumer::size_type, char32_t>(1, 'a'));
+	consumer.SkipUtf8();
+	CHECK(consumer.PeekUtf8() == std::pair<StringConsumer::size_type, char32_t>(3, 0x1234));
+	CHECK(consumer.ReadUtf8() == 0x1234);
+	CHECK(consumer.PeekUint8() == 0xFF);
+	CHECK(consumer.PeekUtf8() == std::pair<StringConsumer::size_type, char32_t>(0, 0));
+	CHECK(consumer.ReadUtf8() == '?');
+	CHECK(consumer.PeekUint8() == 0xFE);
+	CHECK(consumer.PeekUtf8() == std::pair<StringConsumer::size_type, char32_t>(0, 0));
+	consumer.SkipUtf8();
+	CHECK(consumer.PeekUtf8() == std::pair<StringConsumer::size_type, char32_t>(1, 'b'));
+	CHECK(consumer.ReadUtf8() == 'b');
+	CHECK(!consumer.AnyBytesLeft());
+	CHECK(consumer.PeekUtf8() == std::pair<StringConsumer::size_type, char32_t>(0, 0));
+	CHECK(consumer.ReadUtf8() == '?');
+}
+
+TEST_CASE("StringConsumer - conditions")
+{
+	StringConsumer consumer("ABCDabcde\u0234@@@gh\0\0\0ij\0\0\0kl"sv);
+	CHECK(consumer.PeekIf("AB"));
+	CHECK(consumer.PeekCharIf('A'));
+	CHECK(consumer.PeekUtf8If('A'));
+	CHECK(!consumer.PeekIf("CD"));
+	CHECK(!consumer.ReadIf("CD"));
+	consumer.SkipIf("CD");
+	CHECK(consumer.ReadIf("AB"));
+	CHECK(consumer.PeekIf("CD"));
+	consumer.SkipIf("CD");
+	CHECK(consumer.Peek(2) == "ab");
+	CHECK(consumer.Read(2) == "ab");
+	CHECK(consumer.Peek(2) == "cd");
+	CHECK(consumer.Find("e\u0234") == 2);
+	CHECK(consumer.Find("ab") == StringConsumer::npos);
+	CHECK(consumer.FindChar('e') == 2);
+	CHECK(consumer.FindChar('a') == StringConsumer::npos);
+	CHECK(consumer.FindUtf8(0x234) == 3);
+	CHECK(consumer.FindUtf8(0x1234) == StringConsumer::npos);
+	consumer.Skip(2);
+	CHECK(consumer.Peek(3) == "e\u0234");
+	CHECK(consumer.PeekUntil("e", StringConsumer::READ_ALL_SEPARATORS) == "e");
+	CHECK(consumer.PeekUntil("e", StringConsumer::READ_ONE_SEPARATOR) == "e");
+	CHECK(consumer.PeekUntil("e", StringConsumer::KEEP_SEPARATOR) == "");
+	CHECK(consumer.PeekUntil("e", StringConsumer::SKIP_ONE_SEPARATOR) == "");
+	CHECK(consumer.PeekUntil("e", StringConsumer::SKIP_ALL_SEPARATORS) == "");
+	CHECK(consumer.PeekUntil("@", StringConsumer::READ_ALL_SEPARATORS) == "e\u0234@@@");
+	CHECK(consumer.PeekUntil("@", StringConsumer::READ_ONE_SEPARATOR) == "e\u0234@");
+	CHECK(consumer.PeekUntil("@", StringConsumer::KEEP_SEPARATOR) == "e\u0234");
+	CHECK(consumer.PeekUntil("@", StringConsumer::SKIP_ONE_SEPARATOR) == "e\u0234");
+	CHECK(consumer.PeekUntil("@", StringConsumer::SKIP_ALL_SEPARATORS) == "e\u0234");
+	CHECK(consumer.ReadUntil("@", StringConsumer::KEEP_SEPARATOR) == "e\u0234");
+	CHECK(consumer.ReadUntil("@", StringConsumer::READ_ONE_SEPARATOR) == "@");
+	CHECK(consumer.ReadUntil("@", StringConsumer::READ_ALL_SEPARATORS) == "@@");
+	CHECK(consumer.PeekUntilChar('\0', StringConsumer::READ_ALL_SEPARATORS) == "gh\0\0\0"sv);
+	CHECK(consumer.PeekUntilChar('\0', StringConsumer::READ_ONE_SEPARATOR) == "gh\0"sv);
+	CHECK(consumer.PeekUntilChar('\0', StringConsumer::KEEP_SEPARATOR) == "gh");
+	CHECK(consumer.PeekUntilChar('\0', StringConsumer::SKIP_ONE_SEPARATOR) == "gh");
+	CHECK(consumer.PeekUntilChar('\0', StringConsumer::SKIP_ALL_SEPARATORS) == "gh");
+	CHECK(consumer.ReadUntilChar('\0', StringConsumer::READ_ONE_SEPARATOR) == "gh\0"sv);
+	CHECK(consumer.PeekUntilChar('\0', StringConsumer::READ_ALL_SEPARATORS) == "\0\0"sv);
+	CHECK(consumer.ReadUntilChar('\0', StringConsumer::SKIP_ONE_SEPARATOR) == "");
+	CHECK(consumer.PeekUntilChar('\0', StringConsumer::READ_ALL_SEPARATORS) == "\0"sv);
+	consumer.SkipUntilUtf8(0, StringConsumer::READ_ALL_SEPARATORS);
+	CHECK(consumer.PeekUntilUtf8(0, StringConsumer::KEEP_SEPARATOR) == "ij");
+	consumer.SkipUntilUtf8(0, StringConsumer::SKIP_ALL_SEPARATORS);
+	CHECK(consumer.PeekUntilUtf8(0x234, StringConsumer::READ_ALL_SEPARATORS) == "kl");
+	CHECK(consumer.PeekUntilUtf8(0x234, StringConsumer::READ_ONE_SEPARATOR) == "kl");
+	CHECK(consumer.PeekUntilUtf8(0x234, StringConsumer::KEEP_SEPARATOR) == "kl");
+	CHECK(consumer.PeekUntilUtf8(0x234, StringConsumer::SKIP_ONE_SEPARATOR) == "kl");
+	CHECK(consumer.PeekUntilUtf8(0x234, StringConsumer::SKIP_ALL_SEPARATORS) == "kl");
+	CHECK(consumer.ReadUntilUtf8(0x234, StringConsumer::READ_ALL_SEPARATORS) == "kl");
+	CHECK(consumer.PeekUntilUtf8(0x234, StringConsumer::READ_ALL_SEPARATORS) == "");
+	CHECK(consumer.PeekUntilUtf8(0x234, StringConsumer::READ_ONE_SEPARATOR) == "");
+	CHECK(consumer.PeekUntilUtf8(0x234, StringConsumer::KEEP_SEPARATOR) == "");
+	CHECK(consumer.PeekUntilUtf8(0x234, StringConsumer::SKIP_ONE_SEPARATOR) == "");
+	CHECK(consumer.PeekUntilUtf8(0x234, StringConsumer::SKIP_ALL_SEPARATORS) == "");
+	CHECK(consumer.ReadUntilUtf8(0x234, StringConsumer::READ_ALL_SEPARATORS) == "");
+	CHECK(consumer.ReadUntilUtf8(0x234, StringConsumer::READ_ONE_SEPARATOR) == "");
+	CHECK(consumer.ReadUntilUtf8(0x234, StringConsumer::KEEP_SEPARATOR) == "");
+	CHECK(consumer.ReadUntilUtf8(0x234, StringConsumer::SKIP_ONE_SEPARATOR) == "");
+	CHECK(consumer.ReadUntilUtf8(0x234, StringConsumer::SKIP_ALL_SEPARATORS) == "");
+	CHECK(consumer.Peek(2) == "");
+	CHECK(consumer.Read(2) == "");
+}
+
+TEST_CASE("StringConsumer - ascii")
+{
+	StringConsumer consumer("abcdefgh  \r\n\tAB  \r\n\t"sv);
+	CHECK(consumer.FindCharIn("dc") == 2);
+	CHECK(consumer.FindCharIn("xy") == StringConsumer::npos);
+	CHECK(consumer.FindCharNotIn("ba") == 2);
+	CHECK(consumer.PeekUntilCharNotIn("ba") == "ab");
+	CHECK(consumer.PeekUntilCharNotIn("dc") == "");
+	CHECK(consumer.PeekUntilCharIn("ba") == "");
+	CHECK(consumer.PeekUntilCharIn("dc") == "ab");
+	CHECK(consumer.ReadUntilCharNotIn("dc") == "");
+	CHECK(consumer.ReadUntilCharNotIn("ba") == "ab");
+	CHECK(consumer.ReadUntilCharIn("dc") == "");
+	CHECK(consumer.ReadUntilCharIn("fe") == "cd");
+	CHECK(consumer.PeekIf("ef"));
+	consumer.SkipUntilCharNotIn("ji");
+	CHECK(consumer.PeekIf("ef"));
+	consumer.SkipUntilCharNotIn("fe");
+	CHECK(consumer.PeekIf("gh"));
+	consumer.SkipUntilCharIn("hg");
+	CHECK(consumer.PeekIf("gh"));
+	consumer.SkipUntilCharIn(StringConsumer::WHITESPACE_OR_NEWLINE);
+	CHECK(consumer.PeekCharIfIn(StringConsumer::WHITESPACE_OR_NEWLINE) == ' ');
+	CHECK(consumer.ReadCharIfIn(StringConsumer::WHITESPACE_OR_NEWLINE) == ' ');
+	consumer.SkipCharIfIn(StringConsumer::WHITESPACE_OR_NEWLINE);
+	CHECK(consumer.PeekUntilCharNotIn(StringConsumer::WHITESPACE_NO_NEWLINE) == "\r");
+	CHECK(consumer.ReadUntilCharNotIn(StringConsumer::WHITESPACE_NO_NEWLINE) == "\r");
+	consumer.SkipUntilCharNotIn(StringConsumer::WHITESPACE_NO_NEWLINE);
+	CHECK(consumer.PeekCharIfIn(StringConsumer::WHITESPACE_OR_NEWLINE) == '\n');
+	CHECK(consumer.ReadCharIfIn(StringConsumer::WHITESPACE_OR_NEWLINE) == '\n');
+	CHECK(consumer.PeekUntilCharNotIn(StringConsumer::WHITESPACE_NO_NEWLINE) == "\t");
+	CHECK(consumer.ReadUntilCharNotIn(StringConsumer::WHITESPACE_NO_NEWLINE) == "\t");
+	consumer.SkipUntilCharNotIn(StringConsumer::WHITESPACE_NO_NEWLINE);
+	CHECK(consumer.PeekUntilCharIn(StringConsumer::WHITESPACE_OR_NEWLINE) == "AB");
+	CHECK(consumer.ReadUntilCharIn(StringConsumer::WHITESPACE_OR_NEWLINE) == "AB");
+	CHECK(consumer.PeekUntilCharNotIn(StringConsumer::WHITESPACE_OR_NEWLINE) == "  \r\n\t");
+	consumer.SkipUntilCharNotIn(StringConsumer::WHITESPACE_OR_NEWLINE);
+	CHECK(!consumer.AnyBytesLeft());
+}
+
+TEST_CASE("StringConsumer - parse int")
+{
+	StringConsumer consumer("1 a -a -2 -2 ffffFFFF ffffFFFF -1aaaAAAA -1aaaAAAA +3 1234567890123 1234567890123 1234567890123 ffffFFFFffffFFFE ffffFFFFffffFFFE ffffFFFFffffFFFE ffffFFFFffffFFFE -0x1aaaAAAAaaaaAAAA -1234567890123 "sv);
+	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(1, 1));
+	CHECK(consumer.PeekIntegerBase<int32_t>(0) == std::pair<StringConsumer::size_type, int32_t>(1, 1));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(1, 1));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(1, 1));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(1, 1));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(1, 1));
+	CHECK(consumer.TryReadIntegerBase<uint32_t>(10) == 1);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(0) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(1, 0xa));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(1, 0xa));
+	CHECK(consumer.ReadIntegerBase<uint32_t>(16) == 0xa);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(0) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(2, -0xa));
+	CHECK(consumer.ReadIntegerBase<int32_t>(16) == -0xa);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(0) == std::pair<StringConsumer::size_type, int32_t>(2, -2));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(2, -2));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(2, -2));
+	CHECK(consumer.TryReadIntegerBase<uint32_t>(10) == std::nullopt);
+	CHECK(consumer.ReadIntegerBase<uint32_t>(10) == 0);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(2, -2));
+	CHECK(consumer.TryReadIntegerBase<uint32_t>(10) == std::nullopt);
+	CHECK(consumer.ReadIntegerBase<int32_t>(10) == -2);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(8, 0xffffffff));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.TryReadIntegerBase<int32_t>(16) == std::nullopt);
+	CHECK(consumer.ReadIntegerBase<int32_t>(16) == 0);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.TryReadIntegerBase<uint32_t>(16) == 0xffffffff);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(9, -0x1aaaaaaa));
+	CHECK(consumer.TryReadIntegerBase<uint32_t>(16) == std::nullopt);
+	CHECK(consumer.ReadIntegerBase<uint32_t>(16) == 0);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(9, -0x1aaaaaaa));
+	CHECK(consumer.TryReadIntegerBase<uint32_t>(16) == std::nullopt);
+	CHECK(consumer.ReadIntegerBase<int32_t>(16) == -0x1aaaaaaa);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	consumer.SkipIntegerBase(10);
+	CHECK(consumer.ReadUtf8() == '+');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(1, 3));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(1, 3));
+	consumer.SkipIntegerBase(10);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(10) == std::pair<StringConsumer::size_type, uint64_t>(13, 1234567890123));
+	CHECK(consumer.PeekIntegerBase<int64_t>(10) == std::pair<StringConsumer::size_type, int64_t>(13, 1234567890123));
+	CHECK(consumer.TryReadIntegerBase<uint32_t>(10) == std::nullopt);
+	CHECK(consumer.ReadIntegerBase<uint32_t>(10) == 0);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(10) == std::pair<StringConsumer::size_type, uint64_t>(13, 1234567890123));
+	CHECK(consumer.PeekIntegerBase<int64_t>(10) == std::pair<StringConsumer::size_type, int64_t>(13, 1234567890123));
+	CHECK(consumer.TryReadIntegerBase<int32_t>(10) == std::nullopt);
+	CHECK(consumer.ReadIntegerBase<int32_t>(10) == 0);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(10) == std::pair<StringConsumer::size_type, uint64_t>(13, 1234567890123));
+	CHECK(consumer.PeekIntegerBase<int64_t>(10) == std::pair<StringConsumer::size_type, int64_t>(13, 1234567890123));
+	CHECK(consumer.ReadIntegerBase<uint64_t>(10) == 1234567890123);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(16) == std::pair<StringConsumer::size_type, uint64_t>(16, 0xffffffff'fffffffe));
+	CHECK(consumer.PeekIntegerBase<int64_t>(16) == std::pair<StringConsumer::size_type, int64_t>(0, 0));
+	CHECK(consumer.ReadIntegerBase<uint32_t>(16) == 0);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(16) == std::pair<StringConsumer::size_type, uint64_t>(16, 0xffffffff'fffffffe));
+	CHECK(consumer.PeekIntegerBase<int64_t>(16) == std::pair<StringConsumer::size_type, int64_t>(0, 0));
+	CHECK(consumer.ReadIntegerBase<int32_t>(16) == 0);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(16) == std::pair<StringConsumer::size_type, uint64_t>(16, 0xffffffff'fffffffe));
+	CHECK(consumer.PeekIntegerBase<int64_t>(16) == std::pair<StringConsumer::size_type, int64_t>(0, 0));
+	CHECK(consumer.ReadIntegerBase<int64_t>(16) == 0);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(16) == std::pair<StringConsumer::size_type, uint64_t>(16, 0xffffffff'fffffffe));
+	CHECK(consumer.PeekIntegerBase<int64_t>(16) == std::pair<StringConsumer::size_type, int64_t>(0, 0));
+	CHECK(consumer.ReadIntegerBase<uint64_t>(16) == 0xffffffff'fffffffe);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(2, 0));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(16) == std::pair<StringConsumer::size_type, uint64_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int64_t>(16) == std::pair<StringConsumer::size_type, int64_t>(2, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(0) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(0) == std::pair<StringConsumer::size_type, uint64_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int64_t>(0) == std::pair<StringConsumer::size_type, int64_t>(19, -0x1aaaaaaa'aaaaaaaa));
+	CHECK(consumer.ReadIntegerBase<int64_t>(0) == -0x1aaaaaaa'aaaaaaaa);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(10) == std::pair<StringConsumer::size_type, uint64_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int64_t>(10) == std::pair<StringConsumer::size_type, int64_t>(14, -1234567890123));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(0) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(0) == std::pair<StringConsumer::size_type, uint64_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int64_t>(0) == std::pair<StringConsumer::size_type, int64_t>(14, -1234567890123));
+	CHECK(consumer.ReadIntegerBase<int64_t>(0) == -1234567890123);
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(10) == std::pair<StringConsumer::size_type, uint64_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int64_t>(10) == std::pair<StringConsumer::size_type, int64_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(0) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(0) == std::pair<StringConsumer::size_type, uint64_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int64_t>(0) == std::pair<StringConsumer::size_type, int64_t>(0, 0));
+	consumer.SkipIntegerBase(10);
+	consumer.SkipIntegerBase(10);
+	consumer.SkipIntegerBase(0);
+	consumer.SkipIntegerBase(0);
+	CHECK(consumer.ReadIntegerBase<uint32_t>(10, 42) == 42);
+	CHECK(consumer.ReadIntegerBase<int32_t>(10, 42) == 42);
+	CHECK(consumer.ReadIntegerBase<uint64_t>(10, 42) == 42);
+	CHECK(consumer.ReadIntegerBase<int64_t>(10, 42) == 42);
+	CHECK(consumer.ReadIntegerBase<uint32_t>(0, 42) == 42);
+	CHECK(consumer.ReadIntegerBase<int32_t>(0, 42) == 42);
+	CHECK(consumer.ReadIntegerBase<uint64_t>(0, 42) == 42);
+	CHECK(consumer.ReadIntegerBase<int64_t>(0, 42) == 42);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(10) == std::pair<StringConsumer::size_type, uint64_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int64_t>(10) == std::pair<StringConsumer::size_type, int64_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(0) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(0) == std::pair<StringConsumer::size_type, uint64_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int64_t>(0) == std::pair<StringConsumer::size_type, int64_t>(0, 0));
+	consumer.SkipIntegerBase(10);
+	consumer.SkipIntegerBase(10);
+	CHECK(consumer.ReadIntegerBase<uint32_t>(10, 42) == 42);
+	CHECK(consumer.ReadIntegerBase<int32_t>(10, 42) == 42);
+	CHECK(consumer.ReadIntegerBase<uint64_t>(10, 42) == 42);
+	CHECK(consumer.ReadIntegerBase<int64_t>(10, 42) == 42);
+	CHECK(consumer.ReadIntegerBase<uint32_t>(0, 42) == 42);
+	CHECK(consumer.ReadIntegerBase<int32_t>(0, 42) == 42);
+	CHECK(consumer.ReadIntegerBase<uint64_t>(0, 42) == 42);
+	CHECK(consumer.ReadIntegerBase<int64_t>(0, 42) == 42);
+}
+
+TEST_CASE("StringConsumer - invalid int")
+{
+	StringConsumer consumer("x 0x - -0x 0y"sv);
+	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(0) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	consumer.SkipIntegerBase(0);
+	consumer.SkipIntegerBase(10);
+	consumer.SkipIntegerBase(16);
+	CHECK(consumer.ReadUtf8() == 'x');
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(0) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(1, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(1, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(1, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(1, 0));
+	consumer.SkipIntegerBase(0);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(0) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	consumer.SkipIntegerBase(0);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(0) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(2, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(2, 0));
+	consumer.SkipIntegerBase(0);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(1, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(0) == std::pair<StringConsumer::size_type, int32_t>(1, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(1, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(1, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(1, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(1, 0));
+	consumer.SkipIntegerBase(0);
+	CHECK(consumer.ReadUtf8() == 'y');
+}

--- a/src/tests/string_inplace.cpp
+++ b/src/tests/string_inplace.cpp
@@ -1,0 +1,57 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file string_inplace.cpp Test functionality from core/string_inplace. */
+
+#include "../stdafx.h"
+#include "../3rdparty/catch2/catch.hpp"
+#include "../core/string_inplace.hpp"
+#include "../safeguards.h"
+
+using namespace std::literals;
+
+TEST_CASE("InPlaceReplacement")
+{
+	std::array<char, 4> buffer{1, 2, 3, 4};
+	InPlaceReplacement inplace(buffer);
+
+	CHECK(!inplace.builder.AnyBytesWritten());
+	CHECK(inplace.builder.GetBytesWritten() == 0);
+	CHECK(inplace.builder.GetWrittenData() == ""sv);
+	CHECK(!inplace.builder.AnyBytesUnused());
+	CHECK(inplace.builder.GetBytesUnused() == 0);
+	CHECK(!inplace.consumer.AnyBytesRead());
+	CHECK(inplace.consumer.GetBytesRead() == 0);
+	CHECK(inplace.consumer.AnyBytesLeft());
+	CHECK(inplace.consumer.GetBytesLeft() == 4);
+
+	CHECK(inplace.consumer.ReadUint16LE() == 0x201);
+
+	CHECK(inplace.builder.GetBytesWritten() == 0);
+	CHECK(inplace.builder.GetBytesUnused() == 2);
+	CHECK(inplace.consumer.GetBytesRead() == 2);
+	CHECK(inplace.consumer.GetBytesLeft() == 2);
+
+	inplace.builder.PutUint8(11);
+
+	CHECK(inplace.builder.GetBytesWritten() == 1);
+	CHECK(inplace.builder.GetBytesUnused() == 1);
+	CHECK(inplace.consumer.GetBytesRead() == 2);
+	CHECK(inplace.consumer.GetBytesLeft() == 2);
+
+	inplace.builder.PutUint8(12);
+
+	CHECK(inplace.builder.GetBytesWritten() == 2);
+	CHECK(inplace.builder.GetBytesUnused() == 0);
+	CHECK(inplace.consumer.GetBytesRead() == 2);
+	CHECK(inplace.consumer.GetBytesLeft() == 2);
+
+	CHECK(buffer[0] == 11);
+	CHECK(buffer[1] == 12);
+	CHECK(buffer[2] == 3);
+	CHECK(buffer[3] == 4);
+}


### PR DESCRIPTION
## Motivation / Problem

Iterating over C strings requires complicated range validations. `Utf8Decode` and `Utf8Consume` do not do it at all.

## Description

Introduce `StringConsumer` to parse strings:
* 8-bit chars,
* UTF-8 codepoints,
* binary integers,
* textual integers.

Remove/replace:
* Functions `Utf8Consume`, `Utf8Decode`, `Utf8EncodedCharLen`.

This complements the existing `StringBuilder`.
There is also a specialized `InPlaceReplacement` class, which provides a coupled Consumer and Builder instance: The Builder is checked to not overtake the Consumer.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
