### PR TITLE
Fix: MayHaveRoad claimed rail station tiles had road, so the custom stationspec index would be read as roadtype

### DIFF
--- a/src/bridge_map.h
+++ b/src/bridge_map.h
@@ -132,11 +132,11 @@ inline void MakeBridgeRamp(Tile t, Owner o, BridgeType bridgetype, DiagDirection
 	SetDockingTile(t, false);
 	t.m2() = 0;
 	t.m3() = 0;
-	t.m4() = INVALID_ROADTYPE;
+	t.m4() = 0;
 	t.m5() = 1 << 7 | tt << 2 | d;
 	SB(t.m6(), 2, 4, bridgetype);
 	t.m7() = 0;
-	t.m8() = INVALID_ROADTYPE << 6;
+	t.m8() = 0;
 }
 
 /**

--- a/src/newgrf_roadtype.cpp
+++ b/src/newgrf_roadtype.cpp
@@ -200,7 +200,7 @@ void ConvertRoadTypes()
 				break;
 
 			case MP_STATION:
-				if (IsStationRoadStop(t) || IsRoadWaypoint(t)) {
+				if (IsAnyRoadStop(t)) {
 					if (RoadType rt = GetRoadTypeRoad(t); rt != INVALID_ROADTYPE) SetRoadTypeRoad(t, roadtype_conversion_map[rt]);
 					if (RoadType rt = GetRoadTypeTram(t); rt != INVALID_ROADTYPE) SetRoadTypeTram(t, roadtype_conversion_map[rt]);
 				}

--- a/src/road_map.cpp
+++ b/src/road_map.cpp
@@ -13,6 +13,27 @@
 
 #include "safeguards.h"
 
+/**
+ * Test whether a tile can have road/tram types.
+ * @param t Tile to query.
+ * @return true if tile can be queried about road/tram types.
+ */
+bool MayHaveRoad(Tile t)
+{
+	switch (GetTileType(t)) {
+		case MP_ROAD:
+			return true;
+
+		case MP_STATION:
+			return IsAnyRoadStop(t);
+
+		case MP_TUNNELBRIDGE:
+			return GetTunnelBridgeTransportType(t) == TRANSPORT_ROAD;
+
+		default:
+			return false;
+	}
+}
 
 /**
  * Returns the RoadBits on an arbitrary tile
@@ -44,12 +65,12 @@ RoadBits GetAnyRoadBits(Tile tile, RoadTramType rtt, bool straight_tunnel_bridge
 			}
 
 		case MP_STATION:
-			if (!IsAnyRoadStopTile(tile)) return ROAD_NONE;
+			assert(IsAnyRoadStopTile(tile)); // ensured by MayHaveRoad
 			if (IsDriveThroughStopTile(tile)) return AxisToRoadBits(GetDriveThroughStopAxis(tile));
 			return DiagDirToRoadBits(GetBayRoadStopDir(tile));
 
 		case MP_TUNNELBRIDGE:
-			if (GetTunnelBridgeTransportType(tile) != TRANSPORT_ROAD) return ROAD_NONE;
+			assert(GetTunnelBridgeTransportType(tile) == TRANSPORT_ROAD); // ensured by MayHaveRoad
 			return straight_tunnel_bridge_entrance ?
 					AxisToRoadBits(DiagDirToAxis(GetTunnelBridgeDirection(tile))) :
 					DiagDirToRoadBits(ReverseDiagDir(GetTunnelBridgeDirection(tile)));

--- a/src/road_map.h
+++ b/src/road_map.h
@@ -25,23 +25,7 @@ enum RoadTileType : uint8_t {
 	ROAD_TILE_DEPOT,    ///< Depot (one entrance)
 };
 
-/**
- * Test whether a tile can have road/tram types.
- * @param t Tile to query.
- * @return true if tile can be queried about road/tram types.
- */
-inline bool MayHaveRoad(Tile t)
-{
-	switch (GetTileType(t)) {
-		case MP_ROAD:
-		case MP_STATION:
-		case MP_TUNNELBRIDGE:
-			return true;
-
-		default:
-			return false;
-	}
-}
+bool MayHaveRoad(Tile t);
 
 /**
  * Get the type of the road tile.

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3190,15 +3190,6 @@ bool AfterLoadGame()
 		}
 	}
 
-	if (IsSavegameVersionBeforeOrAt(SLV_ENDING_YEAR)) {
-		/* Reset roadtype/streetcartype info for non-road bridges. */
-		for (const auto t : Map::Iterate()) {
-			if (IsTileType(t, MP_TUNNELBRIDGE) && GetTunnelBridgeTransportType(t) != TRANSPORT_ROAD) {
-				SetRoadTypes(t, INVALID_ROADTYPE, INVALID_ROADTYPE);
-			}
-		}
-	}
-
 	/* Make sure all industries exclusive supplier/consumer set correctly. */
 	if (IsSavegameVersionBefore(SLV_GS_INDUSTRY_CONTROL)) {
 		for (Industry *i : Industry::Iterate()) {

--- a/src/tunnel_map.h
+++ b/src/tunnel_map.h
@@ -82,7 +82,6 @@ inline void MakeRailTunnel(Tile t, Owner o, DiagDirection d, RailType r)
 	t.m7() = 0;
 	t.m8() = 0;
 	SetRailType(t, r);
-	SetRoadTypes(t, INVALID_ROADTYPE, INVALID_ROADTYPE);
 }
 
 #endif /* TUNNEL_MAP_H */


### PR DESCRIPTION
## Motivation / Problem

`MayHaveRoad` is used to test whether a tile stores road- and railtypes, and whether `GetRoadTypeRoad`/`GetRoadTypeTram` are usable.

However, `MayHaveRoad` returned `true` unconditionally for all bridgehead, tunnel and station tiles:
* For rail bridgeheads and tunnels this was kind of okay, since they stored `INVALID_ROADTYPE` in `MakeBridgeRamp`/`MakeRailTunnel`. Or at least since savegame conversion was fixed in 64278fd5983.
* For docks, buoys and airports `m4` was only zero initialised and there was no savegame conversion, so various places may have evaluated those tiles as having default road.
* For rail stations/waypoints `m4` is occupied by the NewGRF spec index. So all kinds of road types were assumed for it.

## Description

* Fix `MayHaveRoad` to check bridge/tunnel transporttype, and station type.
* Free up the road/tramtype map bits by initialising them with zero again.
* Revert 64278fd5983 as no longer needed.

## Limitations

I do not add any savegame conversion to reset the now free bits for rail bridgeheads and tunnels.
That is left to whoever wants to use those bits again somewhen.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
