### PR TITLE
Codefix: Conversion from char to char32_t requires cast to unsigned first

### DIFF
--- a/src/saveload/strings_sl.cpp
+++ b/src/saveload/strings_sl.cpp
@@ -66,8 +66,9 @@ std::string CopyFromOldName(StringID id)
 
 		std::ostringstream tmp;
 		std::ostreambuf_iterator<char> strto(tmp);
-		for (char32_t c : strfrom) {
-			if (c == '\0') break;
+		for (char s : strfrom) {
+			if (s == '\0') break;
+			char32_t c = static_cast<uint8_t>(s); // cast to unsigned before integer promotion
 
 			/* Map from non-ISO8859-15 characters to UTF-8. */
 			switch (c) {


### PR DESCRIPTION
## Motivation / Problem

* `char` has unspecified signedness, and is signed on x86 platforms.
* `char32_t` is unsigned by specification on all platforms.
* Converting `char` to `char32_t` is done in two steps by the compiler:
    * First the (signed) `char` is promoted to a (signed) `int`.
    * Then the (signed) `int` is casted to the unsigned `char32_t`.
* This results in chars above 0x80 to be converted to codepoints above 0xFFFFFF80 on x86.

See https://godbolt.org/z/Wjv15of1c

## Description

Explicitly cast to unsigned first.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
