### PR TITLE
Codefix dccc6185: Incorrect encoding of empty parameters in ScriptText.

### DIFF
--- a/src/script/api/script_text.cpp
+++ b/src/script/api/script_text.cpp
@@ -277,7 +277,9 @@ void ScriptText::_GetEncodedText(std::back_insert_iterator<std::string> &output,
 					if (++count != cur_param.consumes) {
 						ScriptLog::Warning(fmt::format("{}({}): {{{}}} expects {} to be consumed, but {} consumes {}", name, param_count + 1, cur_param.cmd, cur_param.consumes - 1, GetGameStringName(ref->string), count - 1));
 						/* Fill missing params if needed. */
-						for (int i = count; i < cur_param.consumes; i++) fmt::format_to(output, ":0");
+						for (int i = count; i < cur_param.consumes; i++) {
+							Utf8Encode(output, SCC_RECORD_SEPARATOR);
+						}
 					}
 					skip_args(cur_param.consumes - 1);
 					break;


### PR DESCRIPTION
## Motivation / Problem

* dccc6185 changed the format of encoded strings.
* One location was missed.

## Description

* Empty parameters are encoded as single `SCC_RECORD_SEPARATOR`.
* `DecodeEncodedString` will extract them as `std::monostate`.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
