### PR TITLE
Codechange: Remove broken and unused StrMakeValidInPlace overload.

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -82,12 +82,6 @@
 #	define CDECL
 #endif /* __GNUC__ || __clang__ */
 
-#if __GNUC__ > 11 || (__GNUC__ == 11 && __GNUC_MINOR__ >= 1)
-#      define NOACCESS(args) __attribute__ ((access (none, args)))
-#else
-#      define NOACCESS(args)
-#endif
-
 #if defined(_WIN32)
 #	define WIN32_LEAN_AND_MEAN     // Exclude rarely-used stuff from Windows headers
 #endif

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -188,30 +188,17 @@ static void StrMakeValid(T &dst, const char *str, const char *last, StringValida
 }
 
 /**
- * Scans the string for invalid characters and replaces then with a
+ * Scans the string for invalid characters and replaces them with a
  * question mark '?' (if not ignored).
  * @param str The string to validate.
- * @param last The last valid character of str.
  * @param settings The settings for the string validation.
- */
-void StrMakeValidInPlace(char *str, const char *last, StringValidationSettings settings)
-{
-	char *dst = str;
-	StrMakeValid(dst, str, last, settings);
-	*dst = '\0';
-}
-
-/**
- * Scans the string for invalid characters and replaces then with a
- * question mark '?' (if not ignored).
- * Only use this function when you are sure the string ends with a '\0';
- * otherwise use StrMakeValidInPlace(str, last, settings) variant.
- * @param str The string (of which you are sure ends with '\0') to validate.
+ * @note The string must be properly NUL terminated.
  */
 void StrMakeValidInPlace(char *str, StringValidationSettings settings)
 {
-	/* We know it is '\0' terminated. */
-	StrMakeValidInPlace(str, str + strlen(str), settings);
+	char *dst = str;
+	StrMakeValid(dst, str, str + strlen(str), settings);
+	*dst = '\0';
 }
 
 /**

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -21,7 +21,6 @@ void strecpy(std::span<char> dst, std::string_view src);
 
 std::string FormatArrayAsHex(std::span<const uint8_t> data);
 
-void StrMakeValidInPlace(char *str, const char *last, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK) NOACCESS(2);
 [[nodiscard]] std::string StrMakeValid(std::string_view str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 void StrMakeValidInPlace(char *str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 


### PR DESCRIPTION
## Motivation / Problem

There is a variant of `StrMakeValidInPlace` which is intended for buffers with potentially missing NUL termination.

Unfortunately the function is broken: If it is called with an otherwise valid string without NUL termination, the NUL termination is appended out-of-bounds.

Luckily the function is unused meanwhile.

## Description

Remove the function.

I considered fixing it, which would involve dropping the last UTF-8 codepoint. But I don't expect the function to be ever needed again.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
