### PR TITLE
Codechange: Add a std::string overload for StrMakeValidInPlace() and a moving std::string&& overload for StrMakeValid().

### DIFF
--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -396,7 +396,7 @@ static std::string GetFileTitle(const std::string &file, Subdirectory subdir)
 	size_t read = fread(title, 1, lengthof(title), *f);
 
 	assert(read <= lengthof(title));
-	return StrMakeValid({title, read});
+	return StrMakeValid(std::string_view{title, read});
 }
 
 /**

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -441,7 +441,7 @@ template <class T>
 static inline void SanitizeSingleStringHelper([[maybe_unused]] CommandFlags cmd_flags, T &data)
 {
 	if constexpr (std::is_same_v<std::string, T>) {
-		data = StrMakeValid(data, (!_network_server && cmd_flags.Test(CommandFlag::StrCtrl)) ? SVS_ALLOW_CONTROL_CODE | SVS_REPLACE_WITH_QUESTION_MARK : SVS_REPLACE_WITH_QUESTION_MARK);
+		StrMakeValidInPlace(data, (!_network_server && cmd_flags.Test(CommandFlag::StrCtrl)) ? SVS_ALLOW_CONTROL_CODE | SVS_REPLACE_WITH_QUESTION_MARK : SVS_REPLACE_WITH_QUESTION_MARK);
 	}
 }
 

--- a/src/saveload/oldloader.cpp
+++ b/src/saveload/oldloader.cpp
@@ -219,11 +219,11 @@ static std::tuple<SavegameType, std::string> DetermineOldSavegameTypeAndName(Fil
 	}
 
 	if (VerifyOldNameChecksum(buffer, TTO_HEADER_SIZE) && fseek(f, pos + TTO_HEADER_SIZE, SEEK_SET) == 0) {
-		return { SGT_TTO, "(TTO)" + StrMakeValid({buffer, TTO_HEADER_SIZE - HEADER_CHECKSUM_SIZE}) };
+		return { SGT_TTO, "(TTO)" + StrMakeValid(std::string_view{buffer, TTO_HEADER_SIZE - HEADER_CHECKSUM_SIZE}) };
 	}
 
 	if (VerifyOldNameChecksum(buffer, TTD_HEADER_SIZE) && fseek(f, pos + TTD_HEADER_SIZE, SEEK_SET) == 0) {
-		return { SGT_TTD, "(TTD)" + StrMakeValid({buffer, TTD_HEADER_SIZE - HEADER_CHECKSUM_SIZE}) };
+		return { SGT_TTD, "(TTD)" + StrMakeValid(std::string_view{buffer, TTD_HEADER_SIZE - HEADER_CHECKSUM_SIZE}) };
 	}
 
 	return { SGT_INVALID, "(broken) Unknown" };

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1028,7 +1028,7 @@ static void SlStdString(void *ptr, VarType conv)
 			if ((conv & SLF_ALLOW_NEWLINE) != 0) {
 				settings = settings | SVS_ALLOW_NEWLINE;
 			}
-			*str = StrMakeValid(*str, settings);
+			StrMakeValidInPlace(*str, settings);
 		}
 
 		case SLA_PTRS: break;

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -353,7 +353,7 @@ namespace ScriptObjectInternal {
 		if constexpr (std::is_same_v<std::string, T>) {
 			/* The string must be valid, i.e. not contain special codes. Since some
 			 * can be made with GSText, make sure the control codes are removed. */
-			data = ::StrMakeValid(data, SVS_NONE);
+			::StrMakeValidInPlace(data, SVS_NONE);
 		}
 	}
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -597,8 +597,8 @@ void StringSettingDesc::MakeValueValid(std::string &str) const
 	/* In case a maximum length is imposed by the setting, the length
 	 * includes the '\0' termination for network transfer purposes.
 	 * Also ensure the string is valid after chopping of some bytes. */
-	std::string stdstr(str, 0, this->max_length - 1);
-	str.assign(StrMakeValid(stdstr, SVS_NONE));
+	str.erase(this->max_length - 1, std::string::npos);
+	StrMakeValidInPlace(str, SVS_NONE);
 }
 
 /**

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -202,6 +202,24 @@ void StrMakeValidInPlace(char *str, StringValidationSettings settings)
 }
 
 /**
+ * Scans the string for invalid characters and replaces them with a
+ * question mark '?' (if not ignored).
+ * @param str The string to validate.
+ * @param settings The settings for the string validation.
+ * @note The string must be properly NUL terminated.
+ */
+void StrMakeValidInPlace(std::string &str, StringValidationSettings settings)
+{
+	if (str.empty()) return;
+
+	char *buf = str.data();
+	char *last = buf + str.size() - 1;
+	char *dst = buf;
+	StrMakeValid(dst, buf, last, settings);
+	str.erase(dst - buf, std::string::npos);
+}
+
+/**
  * Copies the valid (UTF-8) characters from \c str to the returned string.
  * Depending on the \c settings invalid characters can be replaced with a
  * question mark, as well as determining what characters are deemed invalid.

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -21,8 +21,19 @@ void strecpy(std::span<char> dst, std::string_view src);
 
 std::string FormatArrayAsHex(std::span<const uint8_t> data);
 
-[[nodiscard]] std::string StrMakeValid(std::string_view str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 void StrMakeValidInPlace(char *str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
+void StrMakeValidInPlace(std::string &str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
+
+[[nodiscard]] std::string StrMakeValid(std::string_view str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
+[[nodiscard]] inline std::string StrMakeValid(const char *str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK)
+{
+	return StrMakeValid(std::string_view(str), settings);
+}
+[[nodiscard]] inline std::string StrMakeValid(std::string &&str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK)
+{
+	StrMakeValidInPlace(str, settings);
+	return std::move(str);
+}
 
 bool strtolower(std::string &str, std::string::size_type offs = 0);
 


### PR DESCRIPTION
## Motivation / Problem

`StrMakeValid` is often called with a rvalue `std::string`.
Enable `StrMakeValid` to reuse the allocation in that case.

## Description

* Add a `StrMakeValidInPlace` variant that operates on `std::string&`.
* Add a `StrMakeValid` variant for `std::string&&`.
* Add a `StrMakeValid` variant for `const char*` to disambiguate calls with `char*`, which can be implicitly converted to both `std::string_view` and `std::string`.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
