### PR TITLE
Codechange: Use fmt::format instead of stringstream with iomanip flags.

### DIFF
--- a/src/cargotype.cpp
+++ b/src/cargotype.cpp
@@ -19,8 +19,6 @@
 #include "table/strings.h"
 #include "table/cargo_const.h"
 
-#include <sstream>
-
 #include "safeguards.h"
 
 CargoSpec CargoSpec::array[NUM_CARGO];

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -45,8 +45,6 @@
 #include "company_cmd.h"
 #include "misc_cmd.h"
 
-#include <sstream>
-
 #include "table/strings.h"
 
 #include "safeguards.h"

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -17,7 +17,6 @@
 #include "video/video_driver.hpp"
 #include "string_func.h"
 #include "fileio_func.h"
-#include <sstream>
 
 #include "table/strings.h"
 

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -25,7 +25,6 @@
 #endif
 #include <charconv>
 #include <sys/stat.h>
-#include <sstream>
 #include <filesystem>
 
 #include "safeguards.h"

--- a/src/misc/dbg_helpers.cpp
+++ b/src/misc/dbg_helpers.cpp
@@ -11,9 +11,6 @@
 #include "../rail_map.h"
 #include "dbg_helpers.h"
 
-#include <sstream>
-#include <iomanip>
-
 #include "../safeguards.h"
 
 /** Trackdir & TrackdirBits short names. */
@@ -62,10 +59,7 @@ std::string ValueStr(SignalType t)
 /** Translate TileIndex into string. */
 std::string TileStr(TileIndex tile)
 {
-	std::stringstream ss;
-	ss << "0x" << std::setfill('0') << std::setw(4) << std::hex << tile.base(); // 0x%04X
-	ss << " (" << TileX(tile) << ", " << TileY(tile) << ")";
-	return ss.str();
+	return fmt::format("0x{:04X} ({}, {})", tile.base(), TileX(tile), TileY(tile));
 }
 
 /**

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -36,9 +36,6 @@
 
 #include "table/strings.h"
 
-#include <sstream>
-#include <iomanip>
-
 #include "safeguards.h"
 
 /** Method to open the OSK. */

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -41,8 +41,6 @@
 #	include "../fileio_func.h"
 #endif
 #include <charconv>
-#include <sstream>
-#include <iomanip>
 
 #include "table/strings.h"
 

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -113,7 +113,7 @@ uint32_t NewGRFProfiler::Finish()
 	} else {
 		fmt::print(*f, "Tick,Sprite,Feature,Item,CallbackID,Microseconds,Depth,Result\n");
 		for (const Call &c : this->calls) {
-			fmt::print(*f, "{},{},{:#X},{},{:#X},{},{},{}\n", c.tick, c.root_sprite, c.feat, c.item, (uint)c.cb, c.time, c.subs, c.result);
+			fmt::print(*f, "{},{},0x{:X},{},0x{:X},{},{},{}\n", c.tick, c.root_sprite, c.feat, c.item, (uint)c.cb, c.time, c.subs, c.result);
 			total_microseconds += c.time;
 		}
 	}

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -28,7 +28,6 @@
 #include "debug.h"
 #include "core/alloc_type.hpp"
 #include "language.h"
-#include <sstream>
 
 #include "table/strings.h"
 #include "table/control_codes.h"

--- a/src/pathfinder/yapf/yapf_type.hpp
+++ b/src/pathfinder/yapf/yapf_type.hpp
@@ -10,9 +10,6 @@
 #ifndef YAPF_TYPE_HPP
 #define YAPF_TYPE_HPP
 
-#include <iomanip>
-#include <sstream>
-
 #include "../../core/enum_type.hpp"
 #include "../../misc/dbg_helpers.h"
 
@@ -75,10 +72,7 @@ inline std::string ValueStr(EndSegmentReasons flags)
 		"PATH_TOO_LONG", "FIRST_TWO_WAY_RED", "LOOK_AHEAD_END", "TARGET_REACHED"
 	};
 
-	std::stringstream ss;
-	ss << "0x" << std::setfill('0') << std::setw(4) << std::hex << flags.base(); // 0x%04X
-	ss << " (" << ComposeNameT(flags, end_segment_reason_names, "UNK") << ")";
-	return ss.str();
+	return fmt::format("0x{:04X} ({})", flags.base(), ComposeNameT(flags, end_segment_reason_names, "UNK"));
 }
 
 #endif /* YAPF_TYPE_HPP */

--- a/src/saveload/strings_sl.cpp
+++ b/src/saveload/strings_sl.cpp
@@ -11,7 +11,6 @@
 #include "../string_func.h"
 #include "../strings_func.h"
 #include "saveload_internal.h"
-#include <sstream>
 
 #include "table/strings.h"
 

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -17,9 +17,6 @@
 
 #include "table/control_codes.h"
 
-#include <sstream>
-#include <iomanip>
-
 #ifdef _MSC_VER
 #	define strncasecmp strnicmp
 #endif

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -50,8 +50,6 @@
 
 #include "table/strings.h"
 
-#include <sstream>
-
 #include "safeguards.h"
 
 TownKdtree _town_local_authority_kdtree{};


### PR DESCRIPTION
## Motivation / Problem

* `stringstream` is bad because it uses locale-dependant formatting by default. `fmt::format` does not.
* `iomanip` is really ugly.

## Description

* Replace some `ostringstream` formatting with `fmt::format`.
* Replace some `istringstream` parsing with `std::from_chars`.

I have no idea why there were so many `#include <sstream>`.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
