### PR TITLE
Replace Utf8Encode and other C-style string construction with bounds checking StringBuilder class

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -3,6 +3,7 @@ add_files(
     backup_type.hpp
     base_bitset_type.hpp
     bitmath_func.hpp
+    container_func.hpp
     convertible_through_base.hpp
     endian_func.hpp
     enum_type.hpp
@@ -22,7 +23,8 @@ add_files(
     random_func.cpp
     random_func.hpp
     smallstack_type.hpp
-    container_func.hpp
+    string_builder.cpp
+    string_builder.hpp
     strong_typedef_type.hpp
     utf8.cpp
     utf8.hpp

--- a/src/core/string_builder.cpp
+++ b/src/core/string_builder.cpp
@@ -1,0 +1,125 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file string_builder.cpp Implementation of string composing. */
+
+#include "../stdafx.h"
+#include "string_builder.hpp"
+#include "utf8.hpp"
+#include "../safeguards.h"
+
+/**
+ * Append binary uint8.
+ */
+void BaseStringBuilder::PutUint8(uint8_t value)
+{
+	std::array<char, 1> buf{
+		static_cast<char>(value)
+	};
+	this->PutBuffer(buf);
+}
+
+/**
+ * Append binary int8.
+ */
+void BaseStringBuilder::PutSint8(int8_t value)
+{
+	this->PutUint8(static_cast<uint8_t>(value));
+}
+
+/**
+ * Append binary uint16 using little endian.
+ */
+void BaseStringBuilder::PutUint16LE(uint16_t value)
+{
+	std::array<char, 2> buf{
+		static_cast<char>(static_cast<uint8_t>(value)),
+		static_cast<char>(static_cast<uint8_t>(value >> 8))
+	};
+	this->PutBuffer(buf);
+}
+
+/**
+ * Append binary int16 using little endian.
+ */
+void BaseStringBuilder::PutSint16LE(int16_t value)
+{
+	this->PutUint16LE(static_cast<uint16_t>(value));
+}
+
+/**
+ * Append binary uint32 using little endian.
+ */
+void BaseStringBuilder::PutUint32LE(uint32_t value)
+{
+	std::array<char, 4> buf{
+		static_cast<char>(static_cast<uint8_t>(value)),
+		static_cast<char>(static_cast<uint8_t>(value >> 8)),
+		static_cast<char>(static_cast<uint8_t>(value >> 16)),
+		static_cast<char>(static_cast<uint8_t>(value >> 24))
+	};
+	this->PutBuffer(buf);
+}
+
+/**
+ * Append binary int32 using little endian.
+ */
+void BaseStringBuilder::PutSint32LE(int32_t value)
+{
+	this->PutUint32LE(static_cast<uint32_t>(value));
+}
+
+/**
+ * Append binary uint64 using little endian.
+ */
+void BaseStringBuilder::PutUint64LE(uint64_t value)
+{
+	std::array<char, 8> buf{
+		static_cast<char>(static_cast<uint8_t>(value)),
+		static_cast<char>(static_cast<uint8_t>(value >> 8)),
+		static_cast<char>(static_cast<uint8_t>(value >> 16)),
+		static_cast<char>(static_cast<uint8_t>(value >> 24)),
+		static_cast<char>(static_cast<uint8_t>(value >> 32)),
+		static_cast<char>(static_cast<uint8_t>(value >> 40)),
+		static_cast<char>(static_cast<uint8_t>(value >> 48)),
+		static_cast<char>(static_cast<uint8_t>(value >> 56))
+	};
+	this->PutBuffer(buf);
+}
+
+/**
+ * Append binary int64 using little endian.
+ */
+void BaseStringBuilder::PutSint64LE(int64_t value)
+{
+	this->PutUint64LE(static_cast<uint64_t>(value));
+}
+
+/**
+ * Append 8-bit char.
+ */
+void BaseStringBuilder::PutChar(char c)
+{
+	this->PutUint8(static_cast<uint8_t>(c));
+}
+
+/**
+ * Append UTF.8 char.
+ */
+void BaseStringBuilder::PutUtf8(char32_t c)
+{
+	auto [buf, len] = EncodeUtf8(c);
+	this->PutBuffer(buf, len);
+}
+
+/**
+ * Append buffer.
+ */
+void StringBuilder::PutBuffer(const char *str, size_type len)
+{
+	this->dest->append(str, len);
+}

--- a/src/core/string_builder.hpp
+++ b/src/core/string_builder.hpp
@@ -1,0 +1,119 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file string_builder.hpp Compose strings from textual and binary data.
+ */
+
+#ifndef STRING_BUILDER_HPP
+#define STRING_BUILDER_HPP
+
+#include <charconv>
+
+/**
+ * Compose data into a string / buffer.
+ */
+class BaseStringBuilder {
+public:
+	using size_type = std::string_view::size_type;
+
+	virtual ~BaseStringBuilder() = default;
+
+	/**
+	 * Append buffer.
+	 */
+	virtual void PutBuffer(const char *str, size_type len) = 0;
+
+	/**
+	 * Append span.
+	 */
+	void PutBuffer(std::span<const char> str) { this->PutBuffer(str.data(), str.size()); }
+
+	/**
+	 * Append string.
+	 */
+	void Put(std::string_view str) { this->PutBuffer(str.data(), str.size()); }
+
+	void PutUint8(uint8_t value);
+	void PutSint8(int8_t value);
+	void PutUint16LE(uint16_t value);
+	void PutSint16LE(int16_t value);
+	void PutUint32LE(uint32_t value);
+	void PutSint32LE(int32_t value);
+	void PutUint64LE(uint64_t value);
+	void PutSint64LE(int64_t value);
+
+	void PutChar(char c);
+	void PutUtf8(char32_t c);
+
+	/**
+	 * Append integer 'value' in given number 'base'.
+	 */
+	template<class T>
+	void PutIntegerBase(T value, int base)
+	{
+		std::array<char, 32> buf;
+		auto result = std::to_chars(buf.data(), buf.data() + buf.size(), value, base);
+		if (result.ec != std::errc{}) return;
+		size_type len = result.ptr - buf.data();
+		this->PutBuffer(buf.data(), len);
+	}
+};
+
+/**
+ * Compose data into a growing std::string.
+ */
+class StringBuilder final : public BaseStringBuilder
+{
+	std::string *dest;
+public:
+	/**
+	 * Construct StringBuilder into destination string.
+	 * @note The lifetime of the string must exceed the lifetime of the StringBuilder.
+	 */
+	StringBuilder(std::string &dest) : dest(&dest) {}
+
+	/**
+	 * Check whether any bytes have been written.
+	 */
+	[[nodiscard]] bool AnyBytesWritten() const noexcept { return !this->dest->empty(); }
+	/**
+	 * Get number of already written bytes.
+	 */
+	[[nodiscard]] size_type GetBytesWritten() const noexcept { return this->dest->size(); }
+	/**
+	 * Get already written data.
+	 */
+	[[nodiscard]] const std::string &GetWrittenData() const noexcept { return *dest; }
+	/**
+	 * Get mutable already written data.
+	 */
+	[[nodiscard]] std::string &GetString() noexcept { return *dest; }
+
+	using BaseStringBuilder::PutBuffer;
+	void PutBuffer(const char *str, size_type len) override;
+
+	/**
+	 * Append string.
+	 */
+	StringBuilder& operator+=(std::string_view str)
+	{
+		this->Put(str);
+		return *this;
+	}
+
+	using back_insert_iterator = std::back_insert_iterator<std::string>;
+	/**
+	 * Create a back-insert-iterator.
+	 */
+	back_insert_iterator back_inserter()
+	{
+		return back_insert_iterator(*this->dest);
+	}
+};
+
+#endif /* STRING_BUILDER_HPP */

--- a/src/saveload/strings_sl.cpp
+++ b/src/saveload/strings_sl.cpp
@@ -10,6 +10,7 @@
 #include "../stdafx.h"
 #include "../string_func.h"
 #include "../strings_func.h"
+#include "../core/string_builder.hpp"
 #include "saveload_internal.h"
 #include <sstream>
 
@@ -64,8 +65,8 @@ std::string CopyFromOldName(StringID id)
 	if (IsSavegameVersionBefore(SLV_37)) {
 		const std::string &strfrom = _old_name_array[GB(id, 0, 9)];
 
-		std::ostringstream tmp;
-		std::ostreambuf_iterator<char> strto(tmp);
+		std::string result;
+		StringBuilder builder(result);
 		for (char s : strfrom) {
 			if (s == '\0') break;
 			char32_t c = static_cast<uint8_t>(s); // cast to unsigned before integer promotion
@@ -83,10 +84,10 @@ std::string CopyFromOldName(StringID id)
 				default: break;
 			}
 
-			if (IsPrintable(c)) Utf8Encode(strto, c);
+			if (IsPrintable(c)) builder.PutUtf8(c);
 		}
 
-		return tmp.str();
+		return result;
 	} else {
 		/* Name will already be in UTF-8. */
 		return StrMakeValid(_old_name_array[GB(id, 0, 9)]);

--- a/src/script/api/script_text.hpp
+++ b/src/script/api/script_text.hpp
@@ -12,6 +12,7 @@
 
 #include "script_object.hpp"
 #include "../../strings_func.h"
+#include "../../core/string_builder.hpp"
 
 #include <variant>
 
@@ -141,7 +142,7 @@ private:
 
 		ParamCheck(StringIndexInTab owner, int idx, Param *param) : owner(owner), idx(idx), param(param) {}
 
-		void Encode(std::back_insert_iterator<std::string> &output, std::string_view cmd);
+		void Encode(StringBuilder &output, std::string_view cmd);
 	};
 
 	using ParamList = std::vector<ParamCheck>;
@@ -168,7 +169,7 @@ private:
 	 * @param args The parameters to be consumed.
 	 * @param first Whether it's the first call in the recursion.
 	 */
-	void _GetEncodedText(std::back_insert_iterator<std::string> &output, int &param_count, ParamSpan args, bool first);
+	void _GetEncodedText(StringBuilder &output, int &param_count, ParamSpan args, bool first);
 
 	/**
 	 * Set a parameter, where the value is the first item on the stack.

--- a/src/settingsgen/CMakeLists.txt
+++ b/src/settingsgen/CMakeLists.txt
@@ -10,6 +10,7 @@ if (NOT HOST_BINARY_DIR)
             ../error.cpp
             ../ini_load.cpp
             ../string.cpp
+            ../core/string_builder.cpp
             ../core/utf8.cpp
     )
     add_definitions(-DSETTINGSGEN)

--- a/src/strgen/CMakeLists.txt
+++ b/src/strgen/CMakeLists.txt
@@ -12,6 +12,7 @@ if (NOT HOST_BINARY_DIR)
             ../misc/getoptdata.cpp
             ../error.cpp
             ../string.cpp
+            ../core/string_builder.cpp
             ../core/utf8.cpp
     )
     add_definitions(-DSTRGEN)

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -12,6 +12,7 @@
 #include "../core/mem_func.hpp"
 #include "../error_func.h"
 #include "../string_func.h"
+#include "../core/string_builder.hpp"
 #include "../table/control_codes.h"
 
 #include "strgen.h"
@@ -168,43 +169,6 @@ size_t StringData::CountInUse(size_t tab) const
 	return count;
 }
 
-/** The buffer for writing a single string. */
-struct Buffer : std::string {
-	/**
-	 * Convenience method for adding a byte.
-	 * @param value The value to add.
-	 */
-	void AppendByte(uint8_t value)
-	{
-		this->push_back(static_cast<char>(value));
-	}
-
-	/**
-	 * Add an Unicode character encoded in UTF-8 to the buffer.
-	 * @param value The character to add.
-	 */
-	void AppendUtf8(char32_t value)
-	{
-		if (value < 0x80) {
-			this->push_back(value);
-		} else if (value < 0x800) {
-			this->push_back(0xC0 + GB(value,  6, 5));
-			this->push_back(0x80 + GB(value,  0, 6));
-		} else if (value < 0x10000) {
-			this->push_back(0xE0 + GB(value, 12, 4));
-			this->push_back(0x80 + GB(value,  6, 6));
-			this->push_back(0x80 + GB(value,  0, 6));
-		} else if (value < 0x110000) {
-			this->push_back(0xF0 + GB(value, 18, 3));
-			this->push_back(0x80 + GB(value, 12, 6));
-			this->push_back(0x80 + GB(value,  6, 6));
-			this->push_back(0x80 + GB(value,  0, 6));
-		} else {
-			StrgenWarning("Invalid unicode value U+{:04X}", static_cast<uint32_t>(value));
-		}
-	}
-};
-
 static size_t Utf8Validate(const char *s)
 {
 	char32_t c;
@@ -229,10 +193,10 @@ static size_t Utf8Validate(const char *s)
 	return 0;
 }
 
-void EmitSingleChar(Buffer *buffer, const char *buf, char32_t value)
+void EmitSingleChar(StringBuilder &builder, const char *buf, char32_t value)
 {
 	if (*buf != '\0') StrgenWarning("Ignoring trailing letters in command");
-	buffer->AppendUtf8(value);
+	builder.PutUtf8(value);
 }
 
 /* The plural specifier looks like
@@ -290,20 +254,20 @@ std::optional<std::string_view> ParseWord(const char **buf)
 
 /* This is encoded like
  *  CommandByte <ARG#> <NUM> {Length of each string} {each string} */
-static void EmitWordList(Buffer *buffer, const std::vector<std::string> &words)
+static void EmitWordList(StringBuilder &builder, const std::vector<std::string> &words)
 {
-	buffer->AppendByte(static_cast<uint8_t>(words.size()));
+	builder.PutUint8(static_cast<uint8_t>(words.size()));
 	for (size_t i = 0; i < words.size(); i++) {
 		size_t len = words[i].size();
 		if (len > UINT8_MAX) StrgenFatal("WordList {}/{} string '{}' too long, max bytes {}", i + 1, words.size(), words[i], UINT8_MAX);
-		buffer->AppendByte(static_cast<uint8_t>(len));
+		builder.PutUint8(static_cast<uint8_t>(len));
 	}
 	for (size_t i = 0; i < words.size(); i++) {
-		buffer->append(words[i]);
+		builder.Put(words[i]);
 	}
 }
 
-void EmitPlural(Buffer *buffer, const char *buf, char32_t)
+void EmitPlural(StringBuilder &builder, const char *buf, char32_t)
 {
 	/* Parse out the number, if one exists. Otherwise default to prev arg. */
 	auto [argidx, offset] = ParseRelNum(&buf);
@@ -350,13 +314,13 @@ void EmitPlural(Buffer *buffer, const char *buf, char32_t)
 		}
 	}
 
-	buffer->AppendUtf8(SCC_PLURAL_LIST);
-	buffer->AppendByte(_lang.plural_form);
-	buffer->AppendByte(static_cast<uint8_t>(TranslateArgumentIdx(*argidx, *offset)));
-	EmitWordList(buffer, words);
+	builder.PutUtf8(SCC_PLURAL_LIST);
+	builder.PutUint8(_lang.plural_form);
+	builder.PutUint8(static_cast<uint8_t>(TranslateArgumentIdx(*argidx, *offset)));
+	EmitWordList(builder, words);
 }
 
-void EmitGender(Buffer *buffer, const char *buf, char32_t)
+void EmitGender(StringBuilder &builder, const char *buf, char32_t)
 {
 	if (buf[0] == '=') {
 		buf++;
@@ -366,8 +330,8 @@ void EmitGender(Buffer *buffer, const char *buf, char32_t)
 		if (nw >= MAX_NUM_GENDERS) StrgenFatal("G argument '{}' invalid", buf);
 
 		/* now nw contains the gender index */
-		buffer->AppendUtf8(SCC_GENDER_INDEX);
-		buffer->AppendByte(nw);
+		builder.PutUtf8(SCC_GENDER_INDEX);
+		builder.PutUint8(nw);
 	} else {
 		/* This is a {G 0 foo bar two} command.
 		 * If no relative number exists, default to +0 */
@@ -389,9 +353,9 @@ void EmitGender(Buffer *buffer, const char *buf, char32_t)
 		if (words.size() != _lang.num_genders) StrgenFatal("Bad # of arguments for gender command");
 
 		assert(IsInsideBS(cmd->value, SCC_CONTROL_START, UINT8_MAX));
-		buffer->AppendUtf8(SCC_GENDER_LIST);
-		buffer->AppendByte(static_cast<uint8_t>(TranslateArgumentIdx(*argidx, *offset)));
-		EmitWordList(buffer, words);
+		builder.PutUtf8(SCC_GENDER_LIST);
+		builder.PutUint8(static_cast<uint8_t>(TranslateArgumentIdx(*argidx, *offset)));
+		EmitWordList(builder, words);
 	}
 }
 
@@ -770,20 +734,22 @@ static size_t TranslateArgumentIdx(size_t argidx, size_t offset)
 	return sum + offset;
 }
 
-static void PutArgidxCommand(Buffer *buffer)
+static void PutArgidxCommand(StringBuilder &builder)
 {
-	buffer->AppendUtf8(SCC_ARG_INDEX);
-	buffer->AppendByte(static_cast<uint8_t>(TranslateArgumentIdx(_cur_argidx)));
+	builder.PutUtf8(SCC_ARG_INDEX);
+	builder.PutUint8(static_cast<uint8_t>(TranslateArgumentIdx(_cur_argidx)));
 }
 
-static void PutCommandString(Buffer *buffer, const char *str)
+static std::string PutCommandString(const char *str)
 {
+	std::string result;
+	StringBuilder builder(result);
 	_cur_argidx = 0;
 
 	while (*str != '\0') {
 		/* Process characters as they are until we encounter a { */
 		if (*str != '{') {
-			buffer->append(1, *str++);
+			builder.PutChar(*str++);
 			continue;
 		}
 
@@ -792,8 +758,8 @@ static void PutCommandString(Buffer *buffer, const char *str)
 		if (cmd == nullptr) break;
 
 		if (cs.casei.has_value()) {
-			buffer->AppendUtf8(SCC_SET_CASE); // {SET_CASE}
-			buffer->AppendByte(*cs.casei);
+			builder.PutUtf8(SCC_SET_CASE); // {SET_CASE}
+			builder.PutUint8(*cs.casei);
 		}
 
 		/* For params that consume values, we need to handle the argindex properly */
@@ -801,7 +767,7 @@ static void PutCommandString(Buffer *buffer, const char *str)
 			/* Check if we need to output a move-param command */
 			if (cs.argno.has_value() && *cs.argno != _cur_argidx) {
 				_cur_argidx = *cs.argno;
-				PutArgidxCommand(buffer);
+				PutArgidxCommand(builder);
 			}
 
 			/* Output the one from the master string... it's always accurate. */
@@ -811,8 +777,9 @@ static void PutCommandString(Buffer *buffer, const char *str)
 			}
 		}
 
-		cmd->proc(buffer, cs.param.c_str(), cmd->value);
+		cmd->proc(builder, cs.param.c_str(), cmd->value);
 	}
+	return result;
 }
 
 /**
@@ -859,12 +826,10 @@ void LanguageWriter::WriteLang(const StringData &data)
 	_lang.winlangid = TO_LE16(_lang.winlangid);
 
 	this->WriteHeader(&_lang);
-	Buffer buffer;
 
 	for (size_t tab = 0; tab < data.tabs; tab++) {
 		for (size_t j = 0; j != in_use[tab]; j++) {
 			const LangString *ls = data.strings[(tab * TAB_SIZE) + j].get();
-			const std::string *cmdp;
 
 			/* For undefined strings, just set that it's an empty string */
 			if (ls == nullptr) {
@@ -872,6 +837,8 @@ void LanguageWriter::WriteLang(const StringData &data)
 				continue;
 			}
 
+			std::string output;
+			StringBuilder builder(output);
 			_cur_ident = ls->name.c_str();
 			_cur_line = ls->line;
 
@@ -881,61 +848,42 @@ void LanguageWriter::WriteLang(const StringData &data)
 					StrgenWarning("'{}' is untranslated", ls->name);
 				}
 				if (_annotate_todos) {
-					buffer.append("<TODO> ");
+					builder.Put("<TODO> ");
 				}
 			}
 
 			/* Extract the strings and stuff from the english command string */
 			_cur_pcs = ExtractCommandString(ls->english.c_str(), false);
 
-			if (!ls->translated_cases.empty() || !ls->translated.empty()) {
-				cmdp = &ls->translated;
-			} else {
-				cmdp = &ls->english;
-			}
+			_translated = !ls->translated_cases.empty() || !ls->translated.empty();
+			const std::string &cmdp = _translated ? ls->translated : ls->english;
 
-			_translated = cmdp != &ls->english;
-
-			std::optional<size_t> default_case_pos;
 			if (!ls->translated_cases.empty()) {
 				/* Need to output a case-switch.
 				 * It has this format
 				 * <0x9E> <NUM CASES> <CASE1> <LEN1> <STRING1> <CASE2> <LEN2> <STRING2> <CASE3> <LEN3> <STRING3> <LENDEFAULT> <STRINGDEFAULT>
 				 * Each LEN is printed using 2 bytes in little endian order. */
-				buffer.AppendUtf8(SCC_SWITCH_CASE);
-				buffer.AppendByte(static_cast<uint8_t>(ls->translated_cases.size()));
+				builder.PutUtf8(SCC_SWITCH_CASE);
+				builder.PutUint8(static_cast<uint8_t>(ls->translated_cases.size()));
 
 				/* Write each case */
 				for (const Case &c : ls->translated_cases) {
-					buffer.AppendByte(c.caseidx);
-					/* Make some space for the 16-bit length */
-					size_t pos = buffer.size();
-					buffer.AppendByte(0);
-					buffer.AppendByte(0);
-					/* Write string */
-					PutCommandString(&buffer, c.string.c_str());
-					/* Fill in the length */
-					size_t size = buffer.size() - (pos + 2);
-					buffer[pos + 0] = GB(size, 0, 8);
-					buffer[pos + 1] = GB(size, 8, 8);
+					auto case_str = PutCommandString(c.string.c_str());
+					builder.PutUint8(c.caseidx);
+					builder.PutUint16LE(static_cast<uint16_t>(case_str.size()));
+					builder.Put(case_str);
 				}
-
-				default_case_pos = buffer.size();
-				buffer.AppendByte(0);
-				buffer.AppendByte(0);
 			}
 
-			if (!cmdp->empty()) PutCommandString(&buffer, cmdp->c_str());
-
-			if (default_case_pos.has_value()) {
-				size_t size = buffer.size() - (*default_case_pos + 2);
-				buffer[*default_case_pos + 0] = GB(size, 0, 8);
-				buffer[*default_case_pos + 1] = GB(size, 8, 8);
+			std::string def_str;
+			if (!cmdp.empty()) def_str = PutCommandString(cmdp.c_str());
+			if (!ls->translated_cases.empty()) {
+				builder.PutUint16LE(static_cast<uint16_t>(def_str.size()));
 			}
+			builder.Put(def_str);
 
-			this->WriteLength(buffer.size());
-			this->Write(buffer.data(), buffer.size());
-			buffer.clear();
+			this->WriteLength(output.size());
+			this->Write(output.data(), output.size());
 		}
 	}
 }

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -473,56 +473,6 @@ size_t Utf8Decode(char32_t *c, const char *s)
 	return 1;
 }
 
-
-/**
- * Encode a unicode character and place it in the buffer.
- * @tparam T Type of the buffer.
- * @param buf Buffer to place character.
- * @param c   Unicode character to encode.
- * @return Number of characters in the encoded sequence.
- */
-template <class T>
-inline size_t Utf8Encode(T buf, char32_t c)
-{
-	if (c < 0x80) {
-		*buf = c;
-		return 1;
-	} else if (c < 0x800) {
-		*buf++ = 0xC0 + GB(c,  6, 5);
-		*buf   = 0x80 + GB(c,  0, 6);
-		return 2;
-	} else if (c < 0x10000) {
-		*buf++ = 0xE0 + GB(c, 12, 4);
-		*buf++ = 0x80 + GB(c,  6, 6);
-		*buf   = 0x80 + GB(c,  0, 6);
-		return 3;
-	} else if (c < 0x110000) {
-		*buf++ = 0xF0 + GB(c, 18, 3);
-		*buf++ = 0x80 + GB(c, 12, 6);
-		*buf++ = 0x80 + GB(c,  6, 6);
-		*buf   = 0x80 + GB(c,  0, 6);
-		return 4;
-	}
-
-	*buf = '?';
-	return 1;
-}
-
-size_t Utf8Encode(char *buf, char32_t c)
-{
-	return Utf8Encode<char *>(buf, c);
-}
-
-size_t Utf8Encode(std::ostreambuf_iterator<char> &buf, char32_t c)
-{
-	return Utf8Encode<std::ostreambuf_iterator<char> &>(buf, c);
-}
-
-size_t Utf8Encode(std::back_insert_iterator<std::string> &buf, char32_t c)
-{
-	return Utf8Encode<std::back_insert_iterator<std::string> &>(buf, c);
-}
-
 /**
  * Properly terminate an UTF8 string to some maximum length
  * @param s string to check if it needs additional trimming

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -90,10 +90,7 @@ size_t Utf8Decode(char32_t *c, const char *s);
 /* std::string_view::iterator might be char *, in which case we do not want this templated variant to be taken. */
 template <typename T> requires (!std::is_same_v<T, char *> && (std::is_same_v<std::string_view::iterator, T> || std::is_same_v<std::string::iterator, T>))
 inline size_t Utf8Decode(char32_t *c, T &s) { return Utf8Decode(c, &*s); }
-size_t Utf8Encode(char *buf, char32_t c);
-size_t Utf8Encode(std::ostreambuf_iterator<char> &buf, char32_t c);
-size_t Utf8Encode(std::back_insert_iterator<std::string> &buf, char32_t c);
-inline size_t Utf8Encode(std::string::iterator &s, char32_t c) { return Utf8Encode(&*s, c); }
+
 size_t Utf8TrimString(char *s, size_t maxlen);
 
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1165,20 +1165,21 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 						/* Now we need to figure out what text to resolve, i.e.
 						 * what do we need to draw? So get the actual raw string
 						 * first using the control code to get said string. */
-						char input[4 + 1];
-						char *p = input + Utf8Encode(input, args.GetTypeAtOffset(offset));
-						*p = '\0';
+						std::string input;
+						{
+							StringBuilder tmp_builder(input);
+							tmp_builder.PutUtf8(args.GetTypeAtOffset(offset));
+						}
+
+						std::string buffer;
+						{
+							AutoRestoreBackup sgd_backup(_scan_for_gender_data, true);
+							StringBuilder tmp_builder(buffer);
+							StringParameters tmp_params = args.GetRemainingParameters(offset);
+							FormatString(tmp_builder, input, tmp_params);
+						}
 
 						/* The gender is stored at the start of the formatted string. */
-						bool old_sgd = _scan_for_gender_data;
-						_scan_for_gender_data = true;
-						std::string buffer;
-						StringBuilder tmp_builder(buffer);
-						StringParameters tmp_params = args.GetRemainingParameters(offset);
-						FormatString(tmp_builder, input, tmp_params);
-						_scan_for_gender_data = old_sgd;
-
-						/* And determine the string. */
 						const char *s = buffer.c_str();
 						char32_t c = Utf8Consume(&s);
 						/* Does this string have a gender, if so, set it */

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2371,13 +2371,12 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 		if (!bad_font && any_font_configured) {
 			/* If the user configured a bad font, and we found a better one,
 			 * show that we loaded the better font instead of the configured one.
-			 * The colour 'character' might change in the
-			 * future, so for safety we just Utf8 Encode it into the string,
-			 * which takes exactly three characters, so it replaces the "XXX"
-			 * with the colour marker. */
-			static std::string err_str("XXXThe current font is missing some of the characters used in the texts for this language. Using system fallback font instead.");
-			Utf8Encode(err_str.data(), SCC_YELLOW);
-			ShowErrorMessage(GetEncodedString(STR_JUST_RAW_STRING, err_str), {}, WL_WARNING);
+			 */
+			std::string err_str;
+			StringBuilder builder(err_str);
+			builder.PutUtf8(SCC_YELLOW);
+			builder.Put("The current font is missing some of the characters used in the texts for this language. Using system fallback font instead.");
+			ShowErrorMessage(GetEncodedString(STR_JUST_RAW_STRING, std::move(err_str)), {}, WL_WARNING);
 		}
 
 		if (bad_font && base_font) {
@@ -2393,11 +2392,12 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 		/* All attempts have failed. Display an error. As we do not want the string to be translated by
 		 * the translators, we 'force' it into the binary and 'load' it via a BindCString. To do this
 		 * properly we have to set the colour of the string, otherwise we end up with a lot of artifacts.
-		 * The colour 'character' might change in the future, so for safety we just Utf8 Encode it into
-		 * the string, which takes exactly three characters, so it replaces the "XXX" with the colour marker. */
-		static std::string err_str("XXXThe current font is missing some of the characters used in the texts for this language. Go to Help & Manuals > Fonts, or read the file docs/fonts.md in your OpenTTD directory, to see how to solve this.");
-		Utf8Encode(err_str.data(), SCC_YELLOW);
-		ShowErrorMessage(GetEncodedString(STR_JUST_RAW_STRING, err_str), {}, WL_WARNING);
+		 */
+		std::string err_str;
+		StringBuilder builder(err_str);
+		builder.PutUtf8(SCC_YELLOW);
+		builder.Put("The current font is missing some of the characters used in the texts for this language. Go to Help & Manuals > Fonts, or read the file docs/fonts.md in your OpenTTD directory, to see how to solve this.");
+		ShowErrorMessage(GetEncodedString(STR_JUST_RAW_STRING, std::move(err_str)), {}, WL_WARNING);
 
 		/* Reset the font width */
 		LoadStringWidthTable(searcher->Monospace());
@@ -2415,16 +2415,14 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 	 * be translated by the translators, we 'force' it into the
 	 * binary and 'load' it via a BindCString. To do this
 	 * properly we have to set the colour of the string,
-	 * otherwise we end up with a lot of artifacts. The colour
-	 * 'character' might change in the future, so for safety
-	 * we just Utf8 Encode it into the string, which takes
-	 * exactly three characters, so it replaces the "XXX" with
-	 * the colour marker.
+	 * otherwise we end up with a lot of artifacts.
 	 */
 	if (_current_text_dir != TD_LTR) {
-		static std::string err_str("XXXThis version of OpenTTD does not support right-to-left languages. Recompile with ICU + Harfbuzz enabled.");
-		Utf8Encode(err_str.data(), SCC_YELLOW);
-		ShowErrorMessage(GetEncodedString(STR_JUST_RAW_STRING, err_str), {}, WL_ERROR);
+		std::string err_str;
+		StringBuilder builder(err_str);
+		builder.PutUtf8(SCC_YELLOW);
+		builder.Put("This version of OpenTTD does not support right-to-left languages. Recompile with ICU + Harfbuzz enabled.");
+		ShowErrorMessage(GetEncodedString(STR_JUST_RAW_STRING, std::move(err_str)), {}, WL_ERROR);
 	}
 #endif /* !(WITH_ICU_I18N && WITH_HARFBUZZ) && !WITH_UNISCRIBE && !WITH_COCOA */
 }

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -12,6 +12,7 @@
 
 #include "strings_func.h"
 #include "string_func.h"
+#include "core/string_builder.hpp"
 
 class StringParameters {
 protected:
@@ -202,79 +203,6 @@ public:
 		assert(n < this->parameters.size());
 		return this->parameters[n].data;
 	}
-};
-
-/**
- * Equivalent to the std::back_insert_iterator in function, with some
- * convenience helpers for string concatenation.
- */
-class StringBuilder {
-	std::string *string;
-
-public:
-	/* Required type for this to be an output_iterator; mimics std::back_insert_iterator. */
-	using value_type = void;
-	using difference_type = void;
-	using iterator_category = std::output_iterator_tag;
-	using pointer = void;
-	using reference = void;
-
-	/**
-	 * Create the builder of an external buffer.
-	 * @param string The string to write to.
-	 */
-	StringBuilder(std::string &string) : string(&string) {}
-
-	/* Required operators for this to be an output_iterator; mimics std::back_insert_iterator, which has no-ops. */
-	StringBuilder &operator++() { return *this; }
-	StringBuilder operator++(int) { return *this; }
-	StringBuilder &operator*() { return *this; }
-
-	/**
-	 * Operator to add a character to the end of the buffer. Like the back
-	 * insert iterators this also increases the position of the end of the
-	 * buffer.
-	 * @param value The character to add.
-	 * @return Reference to this inserter.
-	 */
-	StringBuilder &operator=(const char value)
-	{
-		return this->operator+=(value);
-	}
-
-	/**
-	 * Operator to add a character to the end of the buffer.
-	 * @param value The character to add.
-	 * @return Reference to this inserter.
-	 */
-	StringBuilder &operator+=(const char value)
-	{
-		this->string->push_back(value);
-		return *this;
-	}
-
-	/**
-	 * Operator to append the given string to the output buffer.
-	 * @param str The string to add.
-	 * @return Reference to this inserter.
-	 */
-	StringBuilder &operator+=(std::string_view str)
-	{
-		*this->string += str;
-		return *this;
-	}
-
-	/**
-	 * Encode the given Utf8 character into the output buffer.
-	 * @param c The character to encode.
-	 */
-	void Utf8Encode(char32_t c)
-	{
-		auto iterator = std::back_inserter(*this->string);
-		::Utf8Encode(iterator, c);
-	}
-
-	std::string &GetString() { return *this->string; }
 };
 
 void GetStringWithArgs(StringBuilder &builder, StringID string, StringParameters &args, uint case_index = 0, bool game_script = false);

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -274,23 +274,7 @@ public:
 		::Utf8Encode(iterator, c);
 	}
 
-	/**
-	 * Get the current index in the string.
-	 * @return The index.
-	 */
-	size_t CurrentIndex()
-	{
-		return this->string->size();
-	}
-
-	/**
-	 * Get the reference to the character at the given index.
-	 * @return The reference to the character.
-	 */
-	char &operator[](size_t index)
-	{
-		return (*this->string)[index];
-	}
+	std::string &GetString() { return *this->string; }
 };
 
 void GetStringWithArgs(StringBuilder &builder, StringID string, StringParameters &args, uint case_index = 0, bool game_script = false);

--- a/src/table/strgen_tables.h
+++ b/src/table/strgen_tables.h
@@ -16,8 +16,8 @@ enum class CmdFlag : uint8_t {
 };
 using CmdFlags = EnumBitSet<CmdFlag, uint8_t>;
 
-struct Buffer;
-typedef void (*ParseCmdProc)(Buffer *buffer, const char *buf, char32_t value);
+class StringBuilder;
+typedef void (*ParseCmdProc)(StringBuilder &builder, const char *buf, char32_t value);
 
 struct CmdStruct {
 	std::string_view cmd;
@@ -28,9 +28,9 @@ struct CmdStruct {
 	CmdFlags flags;
 };
 
-extern void EmitSingleChar(Buffer *buffer, const char *buf, char32_t value);
-extern void EmitPlural(Buffer *buffer, const char *buf, char32_t value);
-extern void EmitGender(Buffer *buffer, const char *buf, char32_t value);
+extern void EmitSingleChar(StringBuilder &builder, const char *buf, char32_t value);
+extern void EmitPlural(StringBuilder &builder, const char *buf, char32_t value);
+extern void EmitGender(StringBuilder &builder, const char *buf, char32_t value);
 
 static const CmdStruct _cmd_structs[] = {
 	/* Font size */

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_test_files(
     mock_fontcache.h
     mock_spritecache.cpp
     mock_spritecache.h
+    string_builder.cpp
     string_func.cpp
     test_main.cpp
     test_network_crypto.cpp

--- a/src/tests/string_builder.cpp
+++ b/src/tests/string_builder.cpp
@@ -1,0 +1,78 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file string_builder.cpp Test functionality from core/string_builder. */
+
+#include "../stdafx.h"
+#include "../3rdparty/catch2/catch.hpp"
+#include "../core/string_builder.hpp"
+#include "../safeguards.h"
+
+using namespace std::literals;
+
+TEST_CASE("StringBuilder - basic")
+{
+	std::string buffer;
+	StringBuilder builder(buffer);
+
+	CHECK(!builder.AnyBytesWritten());
+	CHECK(builder.GetBytesWritten() == 0);
+	CHECK(builder.GetWrittenData() == ""sv);
+
+	builder.Put("ab");
+	builder += "cdef";
+
+	CHECK(builder.AnyBytesWritten());
+	CHECK(builder.GetBytesWritten() == 6);
+	CHECK(builder.GetWrittenData() == "abcdef"sv);
+
+	CHECK(buffer == "abcdef"sv);
+}
+
+TEST_CASE("StringBuilder - binary")
+{
+	std::string buffer;
+	StringBuilder builder(buffer);
+
+	builder.PutUint8(1);
+	builder.PutSint8(-1);
+	builder.PutUint16LE(0x201);
+	builder.PutSint16LE(-0x201);
+	builder.PutUint32LE(0x30201);
+	builder.PutSint32LE(-0x30201);
+	builder.PutUint64LE(0x7060504030201);
+	builder.PutSint64LE(-0x7060504030201);
+
+	CHECK(buffer == "\x01\xFF\x01\x02\xFF\xFD\x01\x02\x03\x00\xFF\xFD\xFC\xFF\x01\x02\x03\04\x05\x06\x07\x00\xFF\xFD\xFC\xFB\xFA\xF9\xF8\xFF"sv);
+}
+
+TEST_CASE("StringBuilder - text")
+{
+	std::string buffer;
+	StringBuilder builder(buffer);
+
+	builder.PutChar('a');
+	builder.PutUtf8(0x1234);
+	builder.PutChar(' ');
+	builder.PutIntegerBase<uint32_t>(1234, 10);
+	builder.PutChar(' ');
+	builder.PutIntegerBase<uint32_t>(0x7FFF, 16);
+	builder.PutChar(' ');
+	builder.PutIntegerBase<int32_t>(-1234, 10);
+	builder.PutChar(' ');
+	builder.PutIntegerBase<int32_t>(-0x7FFF, 16);
+	builder.PutChar(' ');
+	builder.PutIntegerBase<uint64_t>(1'234'567'890'123, 10);
+	builder.PutChar(' ');
+	builder.PutIntegerBase<uint64_t>(0x1234567890, 16);
+	builder.PutChar(' ');
+	builder.PutIntegerBase<int64_t>(-1'234'567'890'123, 10);
+	builder.PutChar(' ');
+	builder.PutIntegerBase<int64_t>(-0x1234567890, 16);
+
+	CHECK(buffer == "a\u1234 1234 7fff -1234 -7fff 1234567890123 1234567890 -1234567890123 -1234567890"sv);
+}

--- a/src/tests/string_func.cpp
+++ b/src/tests/string_func.cpp
@@ -13,6 +13,7 @@
 
 #include "../string_func.h"
 #include "../strings_func.h"
+#include "../core/string_builder.hpp"
 #include "../table/control_codes.h"
 
 #include "table/strings.h"
@@ -423,15 +424,15 @@ static std::string FixSCCEncodedWrapper(const std::string &str, bool fix_code)
 }
 
 /* Helper to compose a string part from a unicode character */
-static void ComposePart(std::back_insert_iterator<std::string> &output, char32_t c)
+static void ComposePart(StringBuilder &builder, char32_t c)
 {
-	Utf8Encode(output, c);
+	builder.PutUtf8(c);
 }
 
 /* Helper to compose a string part from a string. */
-static void ComposePart(std::back_insert_iterator<std::string> &output, const std::string &value)
+static void ComposePart(StringBuilder &builder, const std::string &value)
 {
-	for (const auto &c : value) *output = c;
+	builder += value;
 }
 
 /* Helper to compose a string from unicode or string parts. */
@@ -439,8 +440,8 @@ template <typename... Args>
 static std::string Compose(Args &&... args)
 {
 	std::string result;
-	auto output = std::back_inserter(result);
-	(ComposePart(output, args), ...);
+	StringBuilder builder(result);
+	(ComposePart(builder, args), ...);
 	return result;
 }
 

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -14,6 +14,7 @@
 #include "gfx_type.h"
 #include "gfx_func.h"
 #include "string_func.h"
+#include "core/string_builder.hpp"
 #include "textfile_gui.h"
 #include "dropdown_type.h"
 #include "dropdown_func.h"
@@ -245,7 +246,7 @@ void TextfileWindow::FindHyperlinksInMarkdown(Line &line, size_t line_index)
 {
 	std::string::const_iterator last_match_end = line.text.cbegin();
 	std::string fixed_line;
-	char ccbuf[5];
+	StringBuilder builder(fixed_line);
 
 	std::sregex_iterator matcher{ line.text.cbegin(), line.text.cend(), _markdown_link_regex};
 	while (matcher != std::sregex_iterator()) {
@@ -273,13 +274,13 @@ void TextfileWindow::FindHyperlinksInMarkdown(Line &line, size_t line_index)
 
 		if (link_colour != SCC_CONTROL_END) {
 			/* Format the link to look like a link. */
-			fixed_line += std::string(last_match_end, match[0].first);
+			builder += std::string_view(last_match_end, match[0].first);
 			link.begin = fixed_line.length();
-			fixed_line += std::string(ccbuf, Utf8Encode(ccbuf, SCC_PUSH_COLOUR));
-			fixed_line += std::string(ccbuf, Utf8Encode(ccbuf, link_colour));
-			fixed_line += match[1].str();
+			builder.PutUtf8(SCC_PUSH_COLOUR);
+			builder.PutUtf8(link_colour);
+			builder += match[1].str();
 			link.end = fixed_line.length();
-			fixed_line += std::string(ccbuf, Utf8Encode(ccbuf, SCC_POP_COLOUR));
+			builder.PutUtf8(SCC_POP_COLOUR);
 			last_match_end = match[0].second;
 		}
 

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -250,7 +250,7 @@ static void ReplaceEnglishWords(std::string &str, size_t start, bool original)
  */
 static void MakeEnglishOriginalTownName(StringBuilder &builder, uint32_t seed)
 {
-	size_t start = builder.GetString().size();
+	size_t start = builder.GetBytesWritten();
 
 	/* optional first segment */
 	int i = SeedChanceBias(0, std::size(_name_original_english_1), seed, 50);
@@ -696,7 +696,7 @@ static void MakeCzechTownName(StringBuilder &builder, uint32_t seed)
 
 		builder += _name_czech_adj[prefix].name;
 		builder += _name_czech_patmod[gender][pattern];
-		builder += ' ';
+		builder.PutChar(' ');
 	}
 
 	if (dynamic_subst) {

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -230,6 +230,8 @@ static void ReplaceWords(const char *org, const char *rep, StringBuilder &builde
  */
 static void ReplaceEnglishWords(StringBuilder &builder, size_t start, bool original)
 {
+	if (original) ReplaceWords("Ce", "Ke", builder, start);
+	if (original) ReplaceWords("Ci", "Ki", builder, start);
 	ReplaceWords("Cunt", "East", builder, start);
 	ReplaceWords("Slag", "Pits", builder, start);
 	ReplaceWords("Slut", "Edin", builder, start);
@@ -264,11 +266,6 @@ static void MakeEnglishOriginalTownName(StringBuilder &builder, uint32_t seed)
 	/* optional last segment */
 	i = SeedChanceBias(15, std::size(_name_original_english_6), seed, 60);
 	if (i >= 0) builder += _name_original_english_6[i];
-
-	/* Ce, Ci => Ke, Ki */
-	if (builder[start] == 'C' && (builder[start + 1] == 'e' || builder[start + 1] == 'i')) {
-		builder[start] = 'K';
-	}
 
 	assert(builder.CurrentIndex() - start >= 4);
 	ReplaceEnglishWords(builder, start, true);


### PR DESCRIPTION
## Motivation / Problem

Split from #13943.

There are currently many ways to build strings:
* `StringBuilder` in `strings_internal.h`.
* `Buffer` in `strgen_base.cpp`.
* Overwriting bytes in char buffers with `Utf8Encode` without bounds checks.
* `Utf8Encode` into `std::ostreambuf_iterator` into `std::stringstream`.
* `Utf8Encode` into `std::back_inserter` into `std::string`.

Strings are built by:
* appending strings,
* appending single chars,
* appending single UTF-8 codepoints,
* manually splitting integers into little-endian byte sequences and appending those,
* formatting decimal and hexadecimal integers using `fmt::format`.

## Description

* Generalize the existing `StringBuilder`.
    * Writing integers as binary uses explicit function calls to ensure there are no implicit conversions resulting in incompatible encodings.
    * This distinguishes `StringBuilder` from `EndianBufferWriter`, which uses templates to generate symmetric readers and writers.
    * This implies explicit functions for appending UTF-8 chars, and creating `back_inserter`.
    * The new class is put into `src/core` since it is also used by strgen, and does not depend on main game sources.
    * There is an abstract `BaseStringBuilder` because follow-up PR splits from #13943 will add another derived class.
* Replace strgen `Buffer` with `StringBuilder`.
* Remove `Utf8Encode`.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
