### PR TITLE
Remove several C-string functions

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2205,7 +2205,7 @@ DEF_CONSOLE_CMD(ConContent)
 	if (StrEqualsIgnoreCase(argv[1], "state")) {
 		IConsolePrint(CC_WHITE, "id, type, state, name");
 		for (ConstContentIterator iter = _network_content_client.Begin(); iter != _network_content_client.End(); iter++) {
-			if (argc > 2 && strcasestr((*iter)->name.c_str(), argv[2]) == nullptr) continue;
+			if (argc > 2 && !StrContainsIgnoreCase((*iter)->name, argv[2])) continue;
 			OutputContentState(*iter);
 		}
 		return true;

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -470,22 +470,6 @@ size_t Utf8Decode(char32_t *c, const char *s)
 	return 1;
 }
 
-#ifdef DEFINE_STRCASESTR
-char *strcasestr(const char *haystack, const char *needle)
-{
-	size_t hay_len = strlen(haystack);
-	size_t needle_len = strlen(needle);
-	while (hay_len >= needle_len) {
-		if (strncasecmp(haystack, needle, needle_len) == 0) return const_cast<char *>(haystack);
-
-		haystack++;
-		hay_len--;
-	}
-
-	return nullptr;
-}
-#endif /* DEFINE_STRCASESTR */
-
 /**
  * Test if a unicode character is considered garbage to be skipped.
  * @param c Character to test.

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -470,33 +470,6 @@ size_t Utf8Decode(char32_t *c, const char *s)
 	return 1;
 }
 
-/**
- * Properly terminate an UTF8 string to some maximum length
- * @param s string to check if it needs additional trimming
- * @param maxlen the maximum length the buffer can have.
- * @return the new length in bytes of the string (eg. strlen(new_string))
- * @note maxlen is the string length _INCLUDING_ the terminating '\0'
- */
-size_t Utf8TrimString(char *s, size_t maxlen)
-{
-	size_t length = 0;
-
-	for (const char *ptr = strchr(s, '\0'); *s != '\0';) {
-		size_t len = Utf8EncodedCharLen(*s);
-		/* Silently ignore invalid UTF8 sequences, our only concern trimming */
-		if (len == 0) len = 1;
-
-		/* Take care when a hard cutoff was made for the string and
-		 * the last UTF8 sequence is invalid */
-		if (length + len >= maxlen || (s + len > ptr)) break;
-		s += len;
-		length += len;
-	}
-
-	*s = '\0';
-	return length;
-}
-
 #ifdef DEFINE_STRCASESTR
 char *strcasestr(const char *haystack, const char *needle)
 {

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -107,23 +107,6 @@ inline char32_t Utf8Consume(Titr &s)
 }
 
 /**
- * Return the length of a UTF-8 encoded character.
- * @param c Unicode character.
- * @return Length of UTF-8 encoding for character.
- */
-inline int8_t Utf8CharLen(char32_t c)
-{
-	if (c < 0x80)       return 1;
-	if (c < 0x800)      return 2;
-	if (c < 0x10000)    return 3;
-	if (c < 0x110000)   return 4;
-
-	/* Invalid valid, we encode as a '?' */
-	return 1;
-}
-
-
-/**
  * Return the length of an UTF-8 encoded value based on a single char. This
  * char should be the first byte of the UTF-8 encoding. If not, or encoding
  * is invalid, return value is 0

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -39,7 +39,7 @@ bool strtolower(std::string &str, std::string::size_type offs = 0);
 
 [[nodiscard]] bool StrValid(std::span<const char> str);
 void StrTrimInPlace(std::string &str);
-std::string_view StrTrimView(std::string_view str);
+[[nodiscard]] std::string_view StrTrimView(std::string_view str);
 
 [[nodiscard]] bool StrStartsWithIgnoreCase(std::string_view str, const std::string_view prefix);
 [[nodiscard]] bool StrEndsWithIgnoreCase(std::string_view str, const std::string_view suffix);
@@ -90,9 +90,6 @@ size_t Utf8Decode(char32_t *c, const char *s);
 /* std::string_view::iterator might be char *, in which case we do not want this templated variant to be taken. */
 template <typename T> requires (!std::is_same_v<T, char *> && (std::is_same_v<std::string_view::iterator, T> || std::is_same_v<std::string::iterator, T>))
 inline size_t Utf8Decode(char32_t *c, T &s) { return Utf8Decode(c, &*s); }
-
-size_t Utf8TrimString(char *s, size_t maxlen);
-
 
 inline char32_t Utf8Consume(const char **s)
 {
@@ -149,36 +146,6 @@ inline int8_t Utf8EncodedCharLen(char c)
 inline bool IsUtf8Part(char c)
 {
 	return GB(c, 6, 2) == 2;
-}
-
-/**
- * Retrieve the previous UNICODE character in an UTF-8 encoded string.
- * @param s char pointer pointing to (the first char of) the next character
- * @return a pointer in 's' to the previous UNICODE character's first byte
- * @note The function should not be used to determine the length of the previous
- * encoded char because it might be an invalid/corrupt start-sequence
- */
-inline char *Utf8PrevChar(char *s)
-{
-	char *ret = s;
-	while (IsUtf8Part(*--ret)) {}
-	return ret;
-}
-
-inline const char *Utf8PrevChar(const char *s)
-{
-	const char *ret = s;
-	while (IsUtf8Part(*--ret)) {}
-	return ret;
-}
-
-inline std::string::iterator Utf8PrevChar(std::string::iterator &s)
-{
-	auto cur = s;
-	do {
-		cur = std::prev(cur);
-	} while (IsUtf8Part(*cur));
-	return cur;
 }
 
 size_t Utf8StringLength(std::string_view str);

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -243,12 +243,4 @@ inline bool IsWhitespace(char32_t c)
 #include <sys/param.h>
 #endif
 
-/* strcasestr is available for _GNU_SOURCE, BSD and some Apple */
-#if defined(_GNU_SOURCE) || (defined(__BSD_VISIBLE) && __BSD_VISIBLE) || (defined(__APPLE__) && (!defined(_POSIX_C_SOURCE) || defined(_DARWIN_C_SOURCE))) || defined(_NETBSD_SOURCE)
-#	undef DEFINE_STRCASESTR
-#else
-#	define DEFINE_STRCASESTR
-char *strcasestr(const char *haystack, const char *needle);
-#endif /* strcasestr is available */
-
 #endif /* STRING_FUNC_H */


### PR DESCRIPTION
## Motivation / Problem

* `Utf8TrimString` and `Utf8PrevChar` are already unused.
* `StrContainsIgnoreCase` does the same as `strcasestr`, but better.
* `Utf8CharLen` is only used in one place, which should use `Utf8View` instead.

## Description

Remove those functions, and replace them with the alternatives as needed.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
