### PR TITLE
Fix #13600: Scenario editor terraforming works the same as in a regular game.

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3038,8 +3038,6 @@ STR_TREES_MODE_FOREST_LG_TOOLTIP                                :{BLACK}Plant la
 STR_TERRAFORM_TOOLBAR_LAND_GENERATION_CAPTION                   :{WHITE}Land Generation
 STR_TERRAFORM_TOOLTIP_PLACE_ROCKY_AREAS_ON_LANDSCAPE            :{BLACK}Place rocky areas on landscape
 STR_TERRAFORM_TOOLTIP_DEFINE_DESERT_AREA                        :{BLACK}Define desert area.{}Ctrl+Click to remove desert area
-STR_TERRAFORM_TOOLTIP_INCREASE_SIZE_OF_LAND_AREA                :{BLACK}Increase area of land to lower/raise
-STR_TERRAFORM_TOOLTIP_DECREASE_SIZE_OF_LAND_AREA                :{BLACK}Decrease area of land to lower/raise
 STR_TERRAFORM_TOOLTIP_GENERATE_RANDOM_LAND                      :{BLACK}Generate random land
 STR_TERRAFORM_SE_NEW_WORLD                                      :{BLACK}Create new scenario
 STR_TERRAFORM_RESET_LANDSCAPE                                   :{BLACK}Reset landscape

--- a/src/widgets/terraform_widget.h
+++ b/src/widgets/terraform_widget.h
@@ -30,8 +30,7 @@ enum TerraformToolbarWidgets : WidgetID {
 enum EditorTerraformToolbarWidgets : WidgetID {
 	WID_ETT_SHOW_PLACE_DESERT,                   ///< Should the place desert button be shown?
 	WID_ETT_START,                               ///< Used for iterations.
-	WID_ETT_DOTS = WID_ETT_START,                ///< Invisible widget for rendering the terraform size on.
-	WID_ETT_BUTTONS_START,                       ///< Start of pushable buttons.
+	WID_ETT_BUTTONS_START = WID_ETT_START,       ///< Start of pushable buttons.
 	WID_ETT_DEMOLISH = WID_ETT_BUTTONS_START,    ///< Demolish aka dynamite button.
 	WID_ETT_LOWER_LAND,                          ///< Lower land button.
 	WID_ETT_RAISE_LAND,                          ///< Raise land button.
@@ -40,9 +39,7 @@ enum EditorTerraformToolbarWidgets : WidgetID {
 	WID_ETT_PLACE_DESERT,                        ///< Place desert button (in tropical climate).
 	WID_ETT_PLACE_OBJECT,                        ///< Place transmitter button.
 	WID_ETT_BUTTONS_END,                         ///< End of pushable buttons.
-	WID_ETT_INCREASE_SIZE = WID_ETT_BUTTONS_END, ///< Upwards arrow button to increase terraforming size.
-	WID_ETT_DECREASE_SIZE,                       ///< Downwards arrow button to decrease terraforming size.
-	WID_ETT_NEW_SCENARIO,                        ///< Button for generating a new scenario.
+	WID_ETT_NEW_SCENARIO = WID_ETT_BUTTONS_END,  ///< Button for generating a new scenario.
 	WID_ETT_RESET_LANDSCAPE,                     ///< Button for removing all company-owned property.
 
 	INVALID_WID_ETT = -1,


### PR DESCRIPTION
## Motivation / Problem

![image](https://github.com/user-attachments/assets/e9687746-541d-49e3-ae96-d81af8287e54)

Terraforming in the scenario editor works completely different compared to the regular game. You have to select the size of the area you want to lower/raise up front, and you can't do diagonals areas. Meanwhile the level land tool ignores all of this and works exactly like the in the regular game. IMO it would be much better for things to work the same as they do in the regular game, both for consistency and for ease of use.

## Description

I changed the scenario editor's Land Generation to make it look more like the game's Landscaping window. The raising and lowering of land now works exactly like the regular game.

![image](https://github.com/user-attachments/assets/f5ce934c-ebaf-49ef-a70f-05c2dd3e8f30)

The wide buttons do make it look a bit funny. An alternative would be to turn the Landscaping button of the main toolbar into a dropdown and add these options there instead. Then we can also rebrand Land Generation to Landscaping to match the game. Please let me know what you think, and of course I'm open to other ideas as well.

## Limitations

Some people might like the brush-based raising/lowering of land in the scenario editor. I personally find it quite cumbersome compared to the regular game, but I'll admit that I don't use the scenario editor all that often.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
