### PR TITLE
Fix: Capitalise "Disabled" for the "maximum non-sticky open windows" setting.

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2020,7 +2020,7 @@ STR_CONFIG_SETTING_SOFT_LIMIT                                   :Maximum number 
 STR_CONFIG_SETTING_SOFT_LIMIT_HELPTEXT                          :Number of non-sticky open windows before old windows get automatically closed to make room for new windows
 STR_CONFIG_SETTING_SOFT_LIMIT_VALUE                             :{COMMA}
 ###setting-zero-is-special
-STR_CONFIG_SETTING_SOFT_LIMIT_DISABLED                          :disabled
+STR_CONFIG_SETTING_SOFT_LIMIT_DISABLED                          :Disabled
 
 STR_CONFIG_SETTING_ZOOM_MIN                                     :Maximum zoom in level: {STRING2}
 STR_CONFIG_SETTING_ZOOM_MIN_HELPTEXT                            :The maximum zoom-in level for viewports. Note that enabling higher zoom-in levels increases memory requirements


### PR DESCRIPTION
## Motivation / Problem

![image](https://github.com/user-attachments/assets/23b30f33-ec27-4fa1-9d86-65aa050f0b2c)

"Disabled" string when used for a zero is disabled setting is not capitalised, which is inconsistent with other disabled strings.

## Description

Capitalise disabled.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
