### PR TITLE
Fix: Validate raw strings from game-scripts, and strip invalid and control characters.

### DIFF
--- a/src/script/api/script_text.cpp
+++ b/src/script/api/script_text.cpp
@@ -201,9 +201,10 @@ void ScriptText::ParamCheck::Encode(std::back_insert_iterator<std::string> &outp
 	struct visitor {
 		std::back_insert_iterator<std::string> &output;
 
-		void operator()(const std::string &value)
+		void operator()(std::string value)
 		{
 			Utf8Encode(this->output, SCC_ENCODED_STRING);
+			StrMakeValidInPlace(value, SVS_REPLACE_WITH_QUESTION_MARK | SVS_ALLOW_NEWLINE | SVS_REPLACE_TAB_CR_NL_WITH_SPACE);
 			fmt::format_to(this->output, "{}", value);
 		}
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -126,7 +126,7 @@ EncodedString GetEncodedStringWithArgs(StringID str, std::span<const StringParam
 				char32_t c;
 				const char *p = value.data();
 				if (Utf8Decode(&c, p)) {
-					assert(c != SCC_ENCODED && c != SCC_ENCODED_INTERNAL);
+					assert(c != SCC_ENCODED && c != SCC_ENCODED_INTERNAL && c != SCC_RECORD_SEPARATOR);
 				}
 			}
 #endif /* WITH_ASSERT */


### PR DESCRIPTION
## Motivation / Problem

Game-scripts can include raw strings in `GSText`.
Currently there is no validation of the passed data.
* The GS may include `SCC_RECORD_SEPARATOR` and break the string encoding.
* The GS may include `\0` and breaks who knows what.
* The GS may include `SCC_STRING` and break string interpolation.
* The GS may include `SCC_BLUE`, which is not guaranteed to have a stable codepoint.

## Description

Validate raw strings from game-scripts using `StrMakeValidInPlace` and replace invalid and control characters with "?".

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
