### PR TITLE
Update timetable_cmd.cpp

### DIFF
--- a/src/timetable_cmd.cpp
+++ b/src/timetable_cmd.cpp
@@ -241,7 +241,7 @@ CommandCost CmdBulkChangeTimetable(DoCommandFlags flags, VehicleID veh, ModifyTi
 		for (VehicleOrderID order_number = 0; order_number < v->GetNumOrders(); order_number++) {
 			Order *order = v->GetOrder(order_number);
 			if (order == nullptr || order->IsType(OT_IMPLICIT)) continue;
-
+		        if(data == 0 && mtf != MTF_TRAVEL_SPEED) Command<CMD_CHANGE_TIMETABLE>::Do(DoCommandFlag::Execute, v->index, order_number, (mtf == MTF_TRAVEL_TIME) ? MTF_WAIT_TIME : MTF_TRAVEL_TIME, data);
 			Command<CMD_CHANGE_TIMETABLE>::Do(DoCommandFlag::Execute, v->index, order_number, mtf, data);
 		}
 	}


### PR DESCRIPTION
Fix for bug #12980

<!--
Commit message:

Codefix #12980: fixed clear all function for times in the order timetable menu.

## Description
<!--
* For bug fixes:
    *  When control clicking clear times in the timetable to clear all times, it would only pass one mtf flag to the command either the MTF_TRAVEL_TIME if the selected order was a travel order or MTF_WAIT_TIME if the selected order was a wait at station order.  It would only clear times for orders with the same flag and if you cleared station wait time orders, but had travel time orders, it would lock it into still waiting at stations.
    * https://github.com/openttd/openttd/issues/12980
-->

## Limitations
<!--
Describe here
* The problem is solved in all scenarios
* Left out: if the vehicle is waiting at a station when times are cleared it will continue waiting until the time is up and then update to the updated time table.
-->


## Checklist for review
N/A