### PR TITLE
Reduce polution of global namespace with generic names.

### DIFF
--- a/src/cheat_func.h
+++ b/src/cheat_func.h
@@ -12,8 +12,6 @@
 
 #include "cheat_type.h"
 
-extern Cheats _cheats;
-
 void ShowCheatWindow();
 
 

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -46,7 +46,7 @@ public:
 	const void *GetOSHandle() override { return &face; }
 };
 
-FT_Library _library = nullptr;
+FT_Library _ft_library = nullptr;
 
 
 /**
@@ -163,8 +163,8 @@ void LoadFreeTypeFont(FontSize fs)
 	std::string font = GetFontCacheFontName(fs);
 	if (font.empty()) return;
 
-	if (_library == nullptr) {
-		if (FT_Init_FreeType(&_library) != FT_Err_Ok) {
+	if (_ft_library == nullptr) {
+		if (FT_Init_FreeType(&_ft_library) != FT_Err_Ok) {
 			ShowInfo("Unable to initialize FreeType, using sprite fonts instead");
 			return;
 		}
@@ -178,13 +178,13 @@ void LoadFreeTypeFont(FontSize fs)
 	/* If font is an absolute path to a ttf, try loading that first. */
 	int32_t index = 0;
 	if (settings->os_handle != nullptr) index = *static_cast<const int32_t *>(settings->os_handle);
-	FT_Error error = FT_New_Face(_library, font_name, index, &face);
+	FT_Error error = FT_New_Face(_ft_library, font_name, index, &face);
 
 	if (error != FT_Err_Ok) {
 		/* Check if font is a relative filename in one of our search-paths. */
 		std::string full_font = FioFindFullPath(BASE_DIR, font_name);
 		if (!full_font.empty()) {
-			error = FT_New_Face(_library, full_font.c_str(), 0, &face);
+			error = FT_New_Face(_ft_library, full_font.c_str(), 0, &face);
 		}
 	}
 
@@ -303,8 +303,8 @@ GlyphID FreeTypeFontCache::MapCharToGlyph(char32_t key, bool allow_fallback)
  */
 void UninitFreeType()
 {
-	FT_Done_FreeType(_library);
-	_library = nullptr;
+	FT_Done_FreeType(_ft_library);
+	_ft_library = nullptr;
 }
 
 #if !defined(WITH_FONTCONFIG)

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -25,19 +25,19 @@
 
 void CDECL StrgenWarningI(const std::string &msg)
 {
-	Debug(script, 0, "{}:{}: warning: {}", _file, _cur_line, msg);
-	_warnings++;
+	Debug(script, 0, "{}:{}: warning: {}", _strgen.file, _strgen.cur_line, msg);
+	_strgen.warnings++;
 }
 
 void CDECL StrgenErrorI(const std::string &msg)
 {
-	Debug(script, 0, "{}:{}: error: {}", _file, _cur_line, msg);
-	_errors++;
+	Debug(script, 0, "{}:{}: error: {}", _strgen.file, _strgen.cur_line, msg);
+	_strgen.errors++;
 }
 
 void CDECL StrgenFatalI(const std::string &msg)
 {
-	Debug(script, 0, "{}:{}: FATAL: {}", _file, _cur_line, msg);
+	Debug(script, 0, "{}:{}: FATAL: {}", _strgen.file, _strgen.cur_line, msg);
 	throw std::exception();
 }
 
@@ -289,7 +289,7 @@ void GameStrings::Compile()
 	StringData data(32);
 	StringListReader master_reader(data, this->raw_strings[0], true, false);
 	master_reader.ParseFile();
-	if (_errors != 0) throw std::exception();
+	if (_strgen.errors != 0) throw std::exception();
 
 	this->version = data.Version();
 
@@ -302,7 +302,7 @@ void GameStrings::Compile()
 		data.FreeTranslation();
 		StringListReader translation_reader(data, p, false, p.language != "english");
 		translation_reader.ParseFile();
-		if (_errors != 0) throw std::exception();
+		if (_strgen.errors != 0) throw std::exception();
 
 		auto &strings = this->compiled_strings.emplace_back(p.language);
 		TranslationWriter writer(strings.lines);

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -311,7 +311,7 @@ void GameStrings::Compile()
 }
 
 /** The currently loaded game strings. */
-std::shared_ptr<GameStrings> _current_data = nullptr;
+std::shared_ptr<GameStrings> _current_gamestrings_data = nullptr;
 
 /**
  * Get the string pointer of a particular game string.
@@ -320,8 +320,8 @@ std::shared_ptr<GameStrings> _current_data = nullptr;
  */
 std::string_view GetGameStringPtr(StringIndexInTab id)
 {
-	if (_current_data == nullptr || _current_data->cur_language == nullptr || id.base() >= _current_data->cur_language->lines.size()) return GetStringPtr(STR_UNDEFINED);
-	return _current_data->cur_language->lines[id];
+	if (_current_gamestrings_data == nullptr || _current_gamestrings_data->cur_language == nullptr || id.base() >= _current_gamestrings_data->cur_language->lines.size()) return GetStringPtr(STR_UNDEFINED);
+	return _current_gamestrings_data->cur_language->lines[id];
 }
 
 /**
@@ -334,8 +334,8 @@ const StringParams &GetGameStringParams(StringIndexInTab id)
 	/* An empty result for STR_UNDEFINED. */
 	static StringParams empty;
 
-	if (id.base() >= _current_data->string_params.size()) return empty;
-	return _current_data->string_params[id];
+	if (id.base() >= _current_gamestrings_data->string_params.size()) return empty;
+	return _current_gamestrings_data->string_params[id];
 }
 
 /**
@@ -348,8 +348,8 @@ const std::string &GetGameStringName(StringIndexInTab id)
 	/* The name for STR_UNDEFINED. */
 	static const std::string undefined = "STR_UNDEFINED";
 
-	if (id.base() >= _current_data->string_names.size()) return undefined;
-	return _current_data->string_names[id];
+	if (id.base() >= _current_gamestrings_data->string_names.size()) return undefined;
+	return _current_gamestrings_data->string_names[id];
 }
 
 /**
@@ -358,8 +358,8 @@ const std::string &GetGameStringName(StringIndexInTab id)
  */
 void RegisterGameTranslation(Squirrel *engine)
 {
-	_current_data = LoadTranslations();
-	if (_current_data == nullptr) return;
+	_current_gamestrings_data = LoadTranslations();
+	if (_current_gamestrings_data == nullptr) return;
 
 	HSQUIRRELVM vm = engine->GetVM();
 	sq_pushroottable(vm);
@@ -367,7 +367,7 @@ void RegisterGameTranslation(Squirrel *engine)
 	if (SQ_FAILED(sq_get(vm, -2))) return;
 
 	int idx = 0;
-	for (const auto &p : _current_data->string_names) {
+	for (const auto &p : _current_gamestrings_data->string_names) {
 		sq_pushstring(vm, p, -1);
 		sq_pushinteger(vm, idx);
 		sq_rawset(vm, -3);
@@ -384,15 +384,15 @@ void RegisterGameTranslation(Squirrel *engine)
  */
 void ReconsiderGameScriptLanguage()
 {
-	if (_current_data == nullptr) return;
+	if (_current_gamestrings_data == nullptr) return;
 
 	std::string language = FS2OTTD(_current_language->file.stem());
-	for (auto &p : _current_data->compiled_strings) {
+	for (auto &p : _current_gamestrings_data->compiled_strings) {
 		if (p.language == language) {
-			_current_data->cur_language = &p;
+			_current_gamestrings_data->cur_language = &p;
 			return;
 		}
 	}
 
-	_current_data->cur_language = &_current_data->compiled_strings[0];
+	_current_gamestrings_data->cur_language = &_current_gamestrings_data->compiled_strings[0];
 }

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1321,7 +1321,7 @@ static CommandCost CheckNewIndustry_OilRefinery(TileIndex tile)
 	return CommandCost(STR_ERROR_CAN_ONLY_BE_POSITIONED);
 }
 
-extern bool _ignore_restrictions;
+extern bool _ignore_industry_restrictions;
 
 /**
  * Check the conditions of #CHECK_OIL_RIG (Industries at sea should be positioned near edge of the map).
@@ -1330,7 +1330,7 @@ extern bool _ignore_restrictions;
  */
 static CommandCost CheckNewIndustry_OilRig(TileIndex tile)
 {
-	if (_game_mode == GM_EDITOR && _ignore_restrictions) return CommandCost();
+	if (_game_mode == GM_EDITOR && _ignore_industry_restrictions) return CommandCost();
 
 	if (TileHeight(tile) == 0 &&
 			CheckScaledDistanceFromEdge(TileAddXY(tile, 1, 1), _settings_game.game_creation.oil_refinery_limit)) return CommandCost();
@@ -1566,7 +1566,7 @@ static CommandCost CheckIfIndustryTileSlopes(TileIndex tile, const IndustryTileL
 	/* It is almost impossible to have a fully flat land in TG, so what we
 	 *  do is that we check if we can make the land flat later on. See
 	 *  CheckIfCanLevelIndustryPlatform(). */
-	if (!refused_slope || (_settings_game.game_creation.land_generator == LG_TERRAGENESIS && _generating_world && !custom_shape && !_ignore_restrictions)) {
+	if (!refused_slope || (_settings_game.game_creation.land_generator == LG_TERRAGENESIS && _generating_world && !custom_shape && !_ignore_industry_restrictions)) {
 		return CommandCost();
 	}
 	return CommandCost(STR_ERROR_SITE_UNSUITABLE);
@@ -2023,7 +2023,7 @@ static CommandCost CreateNewIndustryHelper(TileIndex tile, IndustryType type, Do
 	if (ret.Failed()) return ret;
 
 	if (!custom_shape_check && _settings_game.game_creation.land_generator == LG_TERRAGENESIS && _generating_world &&
-			!_ignore_restrictions && !CheckIfCanLevelIndustryPlatform(tile, DoCommandFlag::NoWater, layout)) {
+			!_ignore_industry_restrictions && !CheckIfCanLevelIndustryPlatform(tile, DoCommandFlag::NoWater, layout)) {
 		return CommandCost(STR_ERROR_SITE_UNSUITABLE);
 	}
 

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -56,7 +56,7 @@
 
 #include "safeguards.h"
 
-bool _ignore_restrictions;
+bool _ignore_industry_restrictions;
 std::bitset<NUM_INDUSTRYTYPES> _displayed_industries; ///< Communication from the industry chain window to the smallmap window about what industries to display.
 
 /** Cargo suffix type (for which window is it requested) */
@@ -722,15 +722,11 @@ public:
 				return;
 			}
 
-			Backup<CompanyID> cur_company(_current_company, OWNER_NONE);
-			Backup<bool> old_generating_world(_generating_world, true);
-			_ignore_restrictions = true;
+			AutoRestoreBackup backup_cur_company(_current_company, OWNER_NONE);
+			AutoRestoreBackup backup_generating_world(_generating_world, true);
+			AutoRestoreBackup backup_ignore_industry_restritions(_ignore_industry_restrictions, true);
 
 			Command<CMD_BUILD_INDUSTRY>::Post(STR_ERROR_CAN_T_CONSTRUCT_THIS_INDUSTRY, &CcBuildIndustry, tile, this->selected_type, layout_index, false, seed);
-
-			cur_company.Restore();
-			old_generating_world.Restore();
-			_ignore_restrictions = false;
 		} else {
 			success = Command<CMD_BUILD_INDUSTRY>::Post(STR_ERROR_CAN_T_CONSTRUCT_THIS_INDUSTRY, tile, this->selected_type, layout_index, false, seed);
 		}

--- a/src/newgrf/newgrf_act0.cpp
+++ b/src/newgrf/newgrf_act0.cpp
@@ -92,12 +92,12 @@ std::vector<BadgeID> ReadBadgeList(ByteReader &buf, GrfSpecFeature feature)
 
 	while (count-- > 0) {
 		uint16_t local_index = buf.ReadWord();
-		if (local_index >= std::size(_cur.grffile->badge_list)) {
-			GrfMsg(1, "ReadBadgeList: Badge label {} out of range (max {}), skipping.", local_index, std::size(_cur.grffile->badge_list) - 1);
+		if (local_index >= std::size(_cur_gps.grffile->badge_list)) {
+			GrfMsg(1, "ReadBadgeList: Badge label {} out of range (max {}), skipping.", local_index, std::size(_cur_gps.grffile->badge_list) - 1);
 			continue;
 		}
 
-		BadgeID index = _cur.grffile->badge_list[local_index];
+		BadgeID index = _cur_gps.grffile->badge_list[local_index];
 
 		/* Is badge already present? */
 		if (std::ranges::find(badges, index) != std::end(badges)) continue;
@@ -204,7 +204,7 @@ static void FeatureChangeInfo(ByteReader &buf)
 	}
 
 	/* Mark the feature as used by the grf */
-	SetBit(_cur.grffile->grf_features, feature);
+	SetBit(_cur_gps.grffile->grf_features, feature);
 
 	while (numprops-- && buf.HasData()) {
 		uint8_t prop = buf.ReadByte();

--- a/src/newgrf/newgrf_act0_aircraft.cpp
+++ b/src/newgrf/newgrf_act0_aircraft.cpp
@@ -31,7 +31,7 @@ static ChangeInfoResult AircraftVehicleChangeInfo(uint first, uint last, int pro
 	ChangeInfoResult ret = CIR_SUCCESS;
 
 	for (uint id = first; id < last; ++id) {
-		Engine *e = GetNewEngine(_cur.grffile, VEH_AIRCRAFT, id);
+		Engine *e = GetNewEngine(_cur_gps.grffile, VEH_AIRCRAFT, id);
 		if (e == nullptr) return CIR_INVALID_ID; // No engine could be allocated, so neither can any next vehicles
 
 		EngineInfo *ei = &e->info;
@@ -93,14 +93,14 @@ static ChangeInfoResult AircraftVehicleChangeInfo(uint first, uint last, int pro
 				break;
 
 			case 0x12: // SFX
-				avi->sfx = GetNewGRFSoundID(_cur.grffile, buf.ReadByte());
+				avi->sfx = GetNewGRFSoundID(_cur_gps.grffile, buf.ReadByte());
 				break;
 
 			case 0x13: { // Cargoes available for refitting
 				uint32_t mask = buf.ReadDWord();
 				_gted[e->index].UpdateRefittability(mask != 0);
 				ei->refit_mask = TranslateRefitMask(mask);
-				_gted[e->index].defaultcargo_grf = _cur.grffile;
+				_gted[e->index].defaultcargo_grf = _cur_gps.grffile;
 				break;
 			}
 
@@ -127,7 +127,7 @@ static ChangeInfoResult AircraftVehicleChangeInfo(uint first, uint last, int pro
 			case 0x18: // Cargo classes allowed
 				_gted[e->index].cargo_allowed = CargoClasses{buf.ReadWord()};
 				_gted[e->index].UpdateRefittability(_gted[e->index].cargo_allowed.Any());
-				_gted[e->index].defaultcargo_grf = _cur.grffile;
+				_gted[e->index].defaultcargo_grf = _cur_gps.grffile;
 				break;
 
 			case 0x19: // Cargo classes disallowed
@@ -151,11 +151,11 @@ static ChangeInfoResult AircraftVehicleChangeInfo(uint first, uint last, int pro
 			case 0x1E: { // CTT refit exclude list
 				uint8_t count = buf.ReadByte();
 				_gted[e->index].UpdateRefittability(prop == 0x1D && count != 0);
-				if (prop == 0x1D) _gted[e->index].defaultcargo_grf = _cur.grffile;
+				if (prop == 0x1D) _gted[e->index].defaultcargo_grf = _cur_gps.grffile;
 				CargoTypes &ctt = prop == 0x1D ? _gted[e->index].ctt_include_mask : _gted[e->index].ctt_exclude_mask;
 				ctt = 0;
 				while (count--) {
-					CargoType ctype = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
+					CargoType ctype = GetCargoTranslation(buf.ReadByte(), _cur_gps.grffile);
 					if (IsValidCargoType(ctype)) SetBit(ctt, ctype);
 				}
 				break;

--- a/src/newgrf/newgrf_act0_airports.cpp
+++ b/src/newgrf/newgrf_act0_airports.cpp
@@ -35,10 +35,10 @@ static ChangeInfoResult AirportChangeInfo(uint first, uint last, int prop, ByteR
 	}
 
 	/* Allocate industry specs if they haven't been allocated already. */
-	if (_cur.grffile->airportspec.size() < last) _cur.grffile->airportspec.resize(last);
+	if (_cur_gps.grffile->airportspec.size() < last) _cur_gps.grffile->airportspec.resize(last);
 
 	for (uint id = first; id < last; ++id) {
-		auto &as = _cur.grffile->airportspec[id];
+		auto &as = _cur_gps.grffile->airportspec[id];
 
 		if (as == nullptr && prop != 0x08 && prop != 0x09) {
 			GrfMsg(2, "AirportChangeInfo: Attempt to modify undefined airport {}, ignoring", id);
@@ -68,9 +68,9 @@ static ChangeInfoResult AirportChangeInfo(uint first, uint last, int prop, ByteR
 					as->enabled = true;
 					as->grf_prop.local_id = id;
 					as->grf_prop.subst_id = subs_id;
-					as->grf_prop.SetGRFFile(_cur.grffile);
+					as->grf_prop.SetGRFFile(_cur_gps.grffile);
 					/* override the default airport */
-					_airport_mngr.Add(id, _cur.grffile->grfid, subs_id);
+					_airport_mngr.Add(id, _cur_gps.grffile->grfid, subs_id);
 				}
 				break;
 			}
@@ -107,7 +107,7 @@ static ChangeInfoResult AirportChangeInfo(uint first, uint last, int prop, ByteR
 							int local_tile_id = buf.ReadWord();
 
 							/* Read the ID from the _airporttile_mngr. */
-							uint16_t tempid = _airporttile_mngr.GetID(local_tile_id, _cur.grffile->grfid);
+							uint16_t tempid = _airporttile_mngr.GetID(local_tile_id, _cur_gps.grffile->grfid);
 
 							if (tempid == INVALID_AIRPORTTILE) {
 								GrfMsg(2, "AirportChangeInfo: Attempt to use airport tile {} with airport id {}, not yet defined. Ignoring.", local_tile_id, id);
@@ -185,10 +185,10 @@ static ChangeInfoResult AirportTilesChangeInfo(uint first, uint last, int prop, 
 	}
 
 	/* Allocate airport tile specs if they haven't been allocated already. */
-	if (_cur.grffile->airtspec.size() < last) _cur.grffile->airtspec.resize(last);
+	if (_cur_gps.grffile->airtspec.size() < last) _cur_gps.grffile->airtspec.resize(last);
 
 	for (uint id = first; id < last; ++id) {
-		auto &tsp = _cur.grffile->airtspec[id];
+		auto &tsp = _cur_gps.grffile->airtspec[id];
 
 		if (prop != 0x08 && tsp == nullptr) {
 			GrfMsg(2, "AirportTileChangeInfo: Attempt to modify undefined airport tile {}. Ignoring.", id);
@@ -214,8 +214,8 @@ static ChangeInfoResult AirportTilesChangeInfo(uint first, uint last, int prop, 
 
 					tsp->grf_prop.local_id = id;
 					tsp->grf_prop.subst_id = subs_id;
-					tsp->grf_prop.SetGRFFile(_cur.grffile);
-					_airporttile_mngr.AddEntityID(id, _cur.grffile->grfid, subs_id); // pre-reserve the tile slot
+					tsp->grf_prop.SetGRFFile(_cur_gps.grffile);
+					_airporttile_mngr.AddEntityID(id, _cur_gps.grffile->grfid, subs_id); // pre-reserve the tile slot
 				}
 				break;
 			}
@@ -229,7 +229,7 @@ static ChangeInfoResult AirportTilesChangeInfo(uint first, uint last, int prop, 
 					continue;
 				}
 
-				_airporttile_mngr.Add(id, _cur.grffile->grfid, override_id);
+				_airporttile_mngr.Add(id, _cur_gps.grffile->grfid, override_id);
 				break;
 			}
 

--- a/src/newgrf/newgrf_act0_badges.cpp
+++ b/src/newgrf/newgrf_act0_badges.cpp
@@ -26,8 +26,8 @@ static ChangeInfoResult BadgeChangeInfo(uint first, uint last, int prop, ByteRea
 	}
 
 	for (uint id = first; id < last; ++id) {
-		auto it = _cur.grffile->badge_map.find(id);
-		if (prop != 0x08 && it == std::end(_cur.grffile->badge_map)) {
+		auto it = _cur_gps.grffile->badge_map.find(id);
+		if (prop != 0x08 && it == std::end(_cur_gps.grffile->badge_map)) {
 			GrfMsg(1, "BadgeChangeInfo: Attempt to modify undefined tag {}, ignoring", id);
 			return CIR_INVALID_ID;
 		}
@@ -38,7 +38,7 @@ static ChangeInfoResult BadgeChangeInfo(uint first, uint last, int prop, ByteRea
 		switch (prop) {
 			case 0x08: { // Label
 				std::string_view label = buf.ReadString();
-				_cur.grffile->badge_map[id] = GetOrCreateBadge(label).index;
+				_cur_gps.grffile->badge_map[id] = GetOrCreateBadge(label).index;
 				break;
 			}
 

--- a/src/newgrf/newgrf_act0_canals.cpp
+++ b/src/newgrf/newgrf_act0_canals.cpp
@@ -32,7 +32,7 @@ static ChangeInfoResult CanalChangeInfo(uint first, uint last, int prop, ByteRea
 	}
 
 	for (uint id = first; id < last; ++id) {
-		CanalProperties *cp = &_cur.grffile->canal_local_properties[id];
+		CanalProperties *cp = &_cur_gps.grffile->canal_local_properties[id];
 
 		switch (prop) {
 			case 0x08:

--- a/src/newgrf/newgrf_act0_cargo.cpp
+++ b/src/newgrf/newgrf_act0_cargo.cpp
@@ -40,7 +40,7 @@ static ChangeInfoResult CargoReserveInfo(uint first, uint last, int prop, ByteRe
 			case 0x08: // Bit number of cargo
 				cs->bitnum = buf.ReadByte();
 				if (cs->IsValid()) {
-					cs->grffile = _cur.grffile;
+					cs->grffile = _cur_gps.grffile;
 					SetBit(_cargo_mask, id);
 				} else {
 					ClrBit(_cargo_mask, id);

--- a/src/newgrf/newgrf_act0_globalvar.cpp
+++ b/src/newgrf/newgrf_act0_globalvar.cpp
@@ -49,7 +49,7 @@ static ChangeInfoResult LoadTranslationTable(uint first, uint last, ByteReader &
 		return CIR_INVALID_ID;
 	}
 
-	std::vector<T> &translation_table = gettable(*_cur.grffile);
+	std::vector<T> &translation_table = gettable(*_cur_gps.grffile);
 	translation_table.clear();
 	translation_table.reserve(last);
 	for (uint id = first; id < last; ++id) {
@@ -122,7 +122,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 			return LoadTranslationTable<RoadTypeLabel>(first, last, buf, [](GRFFile &grf) -> std::vector<RoadTypeLabel> & { return grf.tramtype_list; }, "Tram type");
 
 		case 0x18: // Badge translation table
-			return LoadBadgeTranslationTable(first, last, buf, _cur.grffile->badge_list, "Badge");
+			return LoadBadgeTranslationTable(first, last, buf, _cur_gps.grffile->badge_list, "Badge");
 
 		default:
 			break;
@@ -136,7 +136,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 				int factor = buf.ReadByte();
 
 				if (id < PR_END) {
-					_cur.grffile->price_base_multipliers[id] = std::min<int>(factor - 8, MAX_PRICE_MODIFIER);
+					_cur_gps.grffile->price_base_multipliers[id] = std::min<int>(factor - 8, MAX_PRICE_MODIFIER);
 				} else {
 					GrfMsg(1, "GlobalVarChangeInfo: Price {} out of range, ignoring", id);
 				}
@@ -235,7 +235,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 						for (uint j = 0; j < SNOW_LINE_DAYS; j++) {
 							uint8_t &level = snow_line->table[i][j];
 							level = buf.ReadByte();
-							if (_cur.grffile->grf_version >= 8) {
+							if (_cur_gps.grffile->grf_version >= 8) {
 								if (level != 0xFF) level = level * (1 + _settings_game.construction.map_height_limit) / 256;
 							} else {
 								if (level >= 128) {
@@ -283,7 +283,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 					if (plural_form >= LANGUAGE_MAX_PLURAL) {
 						GrfMsg(1, "GlobalVarChanceInfo: Plural form {} is out of range, ignoring", plural_form);
 					} else {
-						_cur.grffile->language_map[curidx].plural_form = plural_form;
+						_cur_gps.grffile->language_map[curidx].plural_form = plural_form;
 					}
 					break;
 				}
@@ -306,14 +306,14 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 						if (map.openttd_id >= MAX_NUM_GENDERS) {
 							GrfMsg(1, "GlobalVarChangeInfo: Gender name {} is not known, ignoring", StrMakeValid(name));
 						} else {
-							_cur.grffile->language_map[curidx].gender_map.push_back(map);
+							_cur_gps.grffile->language_map[curidx].gender_map.push_back(map);
 						}
 					} else {
 						map.openttd_id = lang->GetCaseIndex(name);
 						if (map.openttd_id >= MAX_NUM_CASES) {
 							GrfMsg(1, "GlobalVarChangeInfo: Case name {} is not known, ignoring", StrMakeValid(name));
 						} else {
-							_cur.grffile->language_map[curidx].case_map.push_back(map);
+							_cur_gps.grffile->language_map[curidx].case_map.push_back(map);
 						}
 					}
 					newgrf_id = buf.ReadByte();
@@ -347,7 +347,7 @@ static ChangeInfoResult GlobalVarReserveInfo(uint first, uint last, int prop, By
 			return LoadTranslationTable<RoadTypeLabel>(first, last, buf, [](GRFFile &grf) -> std::vector<RoadTypeLabel> & { return grf.tramtype_list; }, "Tram type");
 
 		case 0x18: // Badge translation table
-			return LoadBadgeTranslationTable(first, last, buf, _cur.grffile->badge_list, "Badge");
+			return LoadBadgeTranslationTable(first, last, buf, _cur_gps.grffile->badge_list, "Badge");
 
 		default:
 			break;

--- a/src/newgrf/newgrf_act0_houses.cpp
+++ b/src/newgrf/newgrf_act0_houses.cpp
@@ -103,10 +103,10 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 	}
 
 	/* Allocate house specs if they haven't been allocated already. */
-	if (_cur.grffile->housespec.size() < last) _cur.grffile->housespec.resize(last);
+	if (_cur_gps.grffile->housespec.size() < last) _cur_gps.grffile->housespec.resize(last);
 
 	for (uint id = first; id < last; ++id) {
-		auto &housespec = _cur.grffile->housespec[id];
+		auto &housespec = _cur_gps.grffile->housespec[id];
 
 		if (prop != 0x08 && housespec == nullptr) {
 			/* If the house property 08 is not yet set, ignore this property */
@@ -137,7 +137,7 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 					housespec->enabled = true;
 					housespec->grf_prop.local_id = id;
 					housespec->grf_prop.subst_id = subs_id;
-					housespec->grf_prop.SetGRFFile(_cur.grffile);
+					housespec->grf_prop.SetGRFFile(_cur_gps.grffile);
 					/* Set default colours for randomization, used if not overridden. */
 					housespec->random_colour[0] = COLOUR_RED;
 					housespec->random_colour[1] = COLOUR_BLUE;
@@ -233,7 +233,7 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 					continue;
 				}
 
-				_house_mngr.Add(id, _cur.grffile->grfid, override_id);
+				_house_mngr.Add(id, _cur_gps.grffile->grfid, override_id);
 				break;
 			}
 
@@ -264,7 +264,7 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 				break;
 
 			case 0x1C: // Class of the building type
-				housespec->class_id = AllocateHouseClassID(buf.ReadByte(), _cur.grffile->grfid);
+				housespec->class_id = AllocateHouseClassID(buf.ReadByte(), _cur_gps.grffile->grfid);
 				break;
 
 			case 0x1D: { // Callback mask part 2
@@ -283,7 +283,7 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 				for (uint j = 0; j < HOUSE_ORIGINAL_NUM_ACCEPTS; j++) {
 					/* Get the cargo number from the 'list' */
 					uint8_t cargo_part = GB(cargotypes, 8 * j, 8);
-					CargoType cargo = GetCargoTranslation(cargo_part, _cur.grffile);
+					CargoType cargo = GetCargoTranslation(cargo_part, _cur_gps.grffile);
 
 					if (!IsValidCargoType(cargo)) {
 						/* Disable acceptance of invalid cargo type */
@@ -303,7 +303,7 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 			case 0x20: { // Cargo acceptance watch list
 				uint8_t count = buf.ReadByte();
 				for (uint8_t j = 0; j < count; j++) {
-					CargoType cargo = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
+					CargoType cargo = GetCargoTranslation(buf.ReadByte(), _cur_gps.grffile);
 					if (IsValidCargoType(cargo)) SetBit(housespec->watched_cargoes, cargo);
 				}
 				break;
@@ -330,7 +330,7 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 				 * any risks of array overrun. */
 				for (uint i = 0; i < lengthof(housespec->accepts_cargo); i++) {
 					if (i < count) {
-						housespec->accepts_cargo[i] = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
+						housespec->accepts_cargo[i] = GetCargoTranslation(buf.ReadByte(), _cur_gps.grffile);
 						housespec->cargo_acceptance[i] = buf.ReadByte();
 					} else {
 						housespec->accepts_cargo[i] = INVALID_CARGO;

--- a/src/newgrf/newgrf_act0_industries.cpp
+++ b/src/newgrf/newgrf_act0_industries.cpp
@@ -79,10 +79,10 @@ static ChangeInfoResult IndustrytilesChangeInfo(uint first, uint last, int prop,
 	}
 
 	/* Allocate industry tile specs if they haven't been allocated already. */
-	if (_cur.grffile->indtspec.size() < last) _cur.grffile->indtspec.resize(last);
+	if (_cur_gps.grffile->indtspec.size() < last) _cur_gps.grffile->indtspec.resize(last);
 
 	for (uint id = first; id < last; ++id) {
-		auto &tsp = _cur.grffile->indtspec[id];
+		auto &tsp = _cur_gps.grffile->indtspec[id];
 
 		if (prop != 0x08 && tsp == nullptr) {
 			ChangeInfoResult cir = IgnoreIndustryTileProperty(prop, buf);
@@ -113,8 +113,8 @@ static ChangeInfoResult IndustrytilesChangeInfo(uint first, uint last, int prop,
 
 					tsp->grf_prop.local_id = id;
 					tsp->grf_prop.subst_id = subs_id;
-					tsp->grf_prop.SetGRFFile(_cur.grffile);
-					_industile_mngr.AddEntityID(id, _cur.grffile->grfid, subs_id); // pre-reserve the tile slot
+					tsp->grf_prop.SetGRFFile(_cur_gps.grffile);
+					_industile_mngr.AddEntityID(id, _cur_gps.grffile->grfid, subs_id); // pre-reserve the tile slot
 				}
 				break;
 			}
@@ -128,7 +128,7 @@ static ChangeInfoResult IndustrytilesChangeInfo(uint first, uint last, int prop,
 					continue;
 				}
 
-				_industile_mngr.Add(id, _cur.grffile->grfid, ovrid);
+				_industile_mngr.Add(id, _cur_gps.grffile->grfid, ovrid);
 				break;
 			}
 
@@ -136,7 +136,7 @@ static ChangeInfoResult IndustrytilesChangeInfo(uint first, uint last, int prop,
 			case 0x0B:
 			case 0x0C: {
 				uint16_t acctp = buf.ReadWord();
-				tsp->accepts_cargo[prop - 0x0A] = GetCargoTranslation(GB(acctp, 0, 8), _cur.grffile);
+				tsp->accepts_cargo[prop - 0x0A] = GetCargoTranslation(GB(acctp, 0, 8), _cur_gps.grffile);
 				tsp->acceptance[prop - 0x0A] = Clamp(GB(acctp, 8, 8), 0, 16);
 				tsp->accepts_cargo_label[prop - 0x0A] = CT_INVALID;
 				break;
@@ -176,7 +176,7 @@ static ChangeInfoResult IndustrytilesChangeInfo(uint first, uint last, int prop,
 				}
 				for (uint i = 0; i < std::size(tsp->acceptance); i++) {
 					if (i < num_cargoes) {
-						tsp->accepts_cargo[i] = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
+						tsp->accepts_cargo[i] = GetCargoTranslation(buf.ReadByte(), _cur_gps.grffile);
 						/* Tile acceptance can be negative to counteract the IndustryTileSpecialFlag::AcceptsAllCargo flag */
 						tsp->acceptance[i] = (int8_t)buf.ReadByte();
 					} else {
@@ -344,10 +344,10 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 	}
 
 	/* Allocate industry specs if they haven't been allocated already. */
-	if (_cur.grffile->industryspec.size() < last) _cur.grffile->industryspec.resize(last);
+	if (_cur_gps.grffile->industryspec.size() < last) _cur_gps.grffile->industryspec.resize(last);
 
 	for (uint id = first; id < last; ++id) {
-		auto &indsp = _cur.grffile->industryspec[id];
+		auto &indsp = _cur_gps.grffile->industryspec[id];
 
 		if (prop != 0x08 && indsp == nullptr) {
 			ChangeInfoResult cir = IgnoreIndustryProperty(prop, buf);
@@ -378,7 +378,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 					indsp->enabled = true;
 					indsp->grf_prop.local_id = id;
 					indsp->grf_prop.subst_id = subs_id;
-					indsp->grf_prop.SetGRFFile(_cur.grffile);
+					indsp->grf_prop.SetGRFFile(_cur_gps.grffile);
 					/* If the grf industry needs to check its surrounding upon creation, it should
 					 * rely on callbacks, not on the original placement functions */
 					indsp->check_proc = CHECK_NOTHING;
@@ -395,7 +395,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 					continue;
 				}
 				indsp->grf_prop.override_id = ovrid;
-				_industry_mngr.Add(id, _cur.grffile->grfid, ovrid);
+				_industry_mngr.Add(id, _cur_gps.grffile->grfid, ovrid);
 				break;
 			}
 
@@ -459,7 +459,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 							bytes_read += 2;
 
 							/* Read the ID from the _industile_mngr. */
-							int tempid = _industile_mngr.GetID(local_tile_id, _cur.grffile->grfid);
+							int tempid = _industile_mngr.GetID(local_tile_id, _cur_gps.grffile->grfid);
 
 							if (tempid == INVALID_INDUSTRYTILE) {
 								GrfMsg(2, "IndustriesChangeInfo: Attempt to use industry tile {} with industry id {}, not yet defined. Ignoring.", local_tile_id, id);
@@ -478,7 +478,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 							 * Since GRF version 8 the position is interpreted as pair of independent int8.
 							 * For GRF version < 8 we need to emulate the old shifting behaviour.
 							 */
-							if (_cur.grffile->grf_version < 8 && it.ti.x < 0) it.ti.y += 1;
+							if (_cur_gps.grffile->grf_version < 8 && it.ti.x < 0) it.ti.y += 1;
 						}
 					}
 
@@ -517,14 +517,14 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 
 			case 0x10: // Production cargo types
 				for (uint8_t j = 0; j < INDUSTRY_ORIGINAL_NUM_OUTPUTS; j++) {
-					indsp->produced_cargo[j] = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
+					indsp->produced_cargo[j] = GetCargoTranslation(buf.ReadByte(), _cur_gps.grffile);
 					indsp->produced_cargo_label[j] = CT_INVALID;
 				}
 				break;
 
 			case 0x11: // Acceptance cargo types
 				for (uint8_t j = 0; j < INDUSTRY_ORIGINAL_NUM_INPUTS; j++) {
-					indsp->accepts_cargo[j] = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
+					indsp->accepts_cargo[j] = GetCargoTranslation(buf.ReadByte(), _cur_gps.grffile);
 					indsp->accepts_cargo_label[j] = CT_INVALID;
 				}
 				buf.ReadByte(); // Unnused, eat it up
@@ -624,7 +624,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 				}
 				for (size_t i = 0; i < std::size(indsp->produced_cargo); i++) {
 					if (i < num_cargoes) {
-						CargoType cargo = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
+						CargoType cargo = GetCargoTranslation(buf.ReadByte(), _cur_gps.grffile);
 						indsp->produced_cargo[i] = cargo;
 					} else {
 						indsp->produced_cargo[i] = INVALID_CARGO;
@@ -643,7 +643,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 				}
 				for (size_t i = 0; i < std::size(indsp->accepts_cargo); i++) {
 					if (i < num_cargoes) {
-						CargoType cargo = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
+						CargoType cargo = GetCargoTranslation(buf.ReadByte(), _cur_gps.grffile);
 						indsp->accepts_cargo[i] = cargo;
 					} else {
 						indsp->accepts_cargo[i] = INVALID_CARGO;

--- a/src/newgrf/newgrf_act0_objects.cpp
+++ b/src/newgrf/newgrf_act0_objects.cpp
@@ -83,10 +83,10 @@ static ChangeInfoResult ObjectChangeInfo(uint first, uint last, int prop, ByteRe
 	}
 
 	/* Allocate object specs if they haven't been allocated already. */
-	if (_cur.grffile->objectspec.size() < last) _cur.grffile->objectspec.resize(last);
+	if (_cur_gps.grffile->objectspec.size() < last) _cur_gps.grffile->objectspec.resize(last);
 
 	for (uint id = first; id < last; ++id) {
-		auto &spec = _cur.grffile->objectspec[id];
+		auto &spec = _cur_gps.grffile->objectspec[id];
 
 		if (prop != 0x08 && spec == nullptr) {
 			/* If the object property 08 is not yet set, ignore this property */

--- a/src/newgrf/newgrf_act0_railtypes.cpp
+++ b/src/newgrf/newgrf_act0_railtypes.cpp
@@ -36,7 +36,7 @@ static ChangeInfoResult RailTypeChangeInfo(uint first, uint last, int prop, Byte
 	}
 
 	for (uint id = first; id < last; ++id) {
-		RailType rt = _cur.grffile->railtype_map[id];
+		RailType rt = _cur_gps.grffile->railtype_map[id];
 		if (rt == INVALID_RAILTYPE) return CIR_INVALID_ID;
 
 		RailTypeInfo *rti = &_railtypes[rt];
@@ -50,7 +50,7 @@ static ChangeInfoResult RailTypeChangeInfo(uint first, uint last, int prop, Byte
 			case 0x09: { // Toolbar caption of railtype (sets name as well for backwards compatibility for grf ver < 8)
 				GRFStringID str{buf.ReadWord()};
 				AddStringForMapping(str, &rti->strings.toolbar_caption);
-				if (_cur.grffile->grf_version < 8) {
+				if (_cur_gps.grffile->grf_version < 8) {
 					AddStringForMapping(str, &rti->strings.name);
 				}
 				break;
@@ -182,7 +182,7 @@ static ChangeInfoResult RailTypeReserveInfo(uint first, uint last, int prop, Byt
 					rt = AllocateRailType(rtl);
 				}
 
-				_cur.grffile->railtype_map[id] = rt;
+				_cur_gps.grffile->railtype_map[id] = rt;
 				break;
 			}
 
@@ -199,10 +199,10 @@ static ChangeInfoResult RailTypeReserveInfo(uint first, uint last, int prop, Byt
 				break;
 
 			case 0x1D: // Alternate rail type label list
-				if (_cur.grffile->railtype_map[id] != INVALID_RAILTYPE) {
+				if (_cur_gps.grffile->railtype_map[id] != INVALID_RAILTYPE) {
 					int n = buf.ReadByte();
 					for (int j = 0; j != n; j++) {
-						_railtypes[_cur.grffile->railtype_map[id]].alternate_labels.push_back(std::byteswap(buf.ReadDWord()));
+						_railtypes[_cur_gps.grffile->railtype_map[id]].alternate_labels.push_back(std::byteswap(buf.ReadDWord()));
 					}
 					break;
 				}

--- a/src/newgrf/newgrf_act0_roadstops.cpp
+++ b/src/newgrf/newgrf_act0_roadstops.cpp
@@ -70,10 +70,10 @@ static ChangeInfoResult RoadStopChangeInfo(uint first, uint last, int prop, Byte
 		return CIR_INVALID_ID;
 	}
 
-	if (_cur.grffile->roadstops.size() < last) _cur.grffile->roadstops.resize(last);
+	if (_cur_gps.grffile->roadstops.size() < last) _cur_gps.grffile->roadstops.resize(last);
 
 	for (uint id = first; id < last; ++id) {
-		auto &rs = _cur.grffile->roadstops[id];
+		auto &rs = _cur_gps.grffile->roadstops[id];
 
 		if (rs == nullptr && prop != 0x08) {
 			GrfMsg(1, "RoadStopChangeInfo: Attempt to modify undefined road stop {}, ignoring", id);

--- a/src/newgrf/newgrf_act0_roadtypes.cpp
+++ b/src/newgrf/newgrf_act0_roadtypes.cpp
@@ -30,7 +30,7 @@ static ChangeInfoResult RoadTypeChangeInfo(uint first, uint last, int prop, Byte
 	ChangeInfoResult ret = CIR_SUCCESS;
 
 	extern RoadTypeInfo _roadtypes[ROADTYPE_END];
-	std::array<RoadType, ROADTYPE_END> &type_map = (rtt == RTT_TRAM) ? _cur.grffile->tramtype_map : _cur.grffile->roadtype_map;
+	std::array<RoadType, ROADTYPE_END> &type_map = (rtt == RTT_TRAM) ? _cur_gps.grffile->tramtype_map : _cur_gps.grffile->roadtype_map;
 
 	if (last > ROADTYPE_END) {
 		GrfMsg(1, "RoadTypeChangeInfo: Road type {} is invalid, max {}, ignoring", last, ROADTYPE_END);
@@ -151,7 +151,7 @@ static ChangeInfoResult RoadTypeReserveInfo(uint first, uint last, int prop, Byt
 	ChangeInfoResult ret = CIR_SUCCESS;
 
 	extern RoadTypeInfo _roadtypes[ROADTYPE_END];
-	std::array<RoadType, ROADTYPE_END> &type_map = (rtt == RTT_TRAM) ? _cur.grffile->tramtype_map : _cur.grffile->roadtype_map;
+	std::array<RoadType, ROADTYPE_END> &type_map = (rtt == RTT_TRAM) ? _cur_gps.grffile->tramtype_map : _cur_gps.grffile->roadtype_map;
 
 	if (last > ROADTYPE_END) {
 		GrfMsg(1, "RoadTypeReserveInfo: Road type {} is invalid, max {}, ignoring", last, ROADTYPE_END);

--- a/src/newgrf/newgrf_act0_roadvehs.cpp
+++ b/src/newgrf/newgrf_act0_roadvehs.cpp
@@ -32,7 +32,7 @@ static ChangeInfoResult RoadVehicleChangeInfo(uint first, uint last, int prop, B
 	ChangeInfoResult ret = CIR_SUCCESS;
 
 	for (uint id = first; id < last; ++id) {
-		Engine *e = GetNewEngine(_cur.grffile, VEH_ROAD, id);
+		Engine *e = GetNewEngine(_cur_gps.grffile, VEH_ROAD, id);
 		if (e == nullptr) return CIR_INVALID_ID; // No engine could be allocated, so neither can any next vehicles
 
 		EngineInfo *ei = &e->info;
@@ -80,7 +80,7 @@ static ChangeInfoResult RoadVehicleChangeInfo(uint first, uint last, int prop, B
 				break;
 
 			case 0x10: { // Cargo type
-				_gted[e->index].defaultcargo_grf = _cur.grffile;
+				_gted[e->index].defaultcargo_grf = _cur_gps.grffile;
 				uint8_t ctype = buf.ReadByte();
 
 				if (ctype == 0xFF) {
@@ -88,7 +88,7 @@ static ChangeInfoResult RoadVehicleChangeInfo(uint first, uint last, int prop, B
 					ei->cargo_type = INVALID_CARGO;
 				} else {
 					/* Use translated cargo. Might result in INVALID_CARGO (first refittable), if cargo is not defined. */
-					ei->cargo_type = GetCargoTranslation(ctype, _cur.grffile);
+					ei->cargo_type = GetCargoTranslation(ctype, _cur_gps.grffile);
 					if (ei->cargo_type == INVALID_CARGO) GrfMsg(2, "RoadVehicleChangeInfo: Invalid cargo type {}, using first refittable", ctype);
 				}
 				ei->cargo_label = CT_INVALID;
@@ -100,7 +100,7 @@ static ChangeInfoResult RoadVehicleChangeInfo(uint first, uint last, int prop, B
 				break;
 
 			case 0x12: // SFX
-				rvi->sfx = GetNewGRFSoundID(_cur.grffile, buf.ReadByte());
+				rvi->sfx = GetNewGRFSoundID(_cur_gps.grffile, buf.ReadByte());
 				break;
 
 			case PROP_ROADVEH_POWER: // Power in units of 10 HP.
@@ -119,7 +119,7 @@ static ChangeInfoResult RoadVehicleChangeInfo(uint first, uint last, int prop, B
 				uint32_t mask = buf.ReadDWord();
 				_gted[e->index].UpdateRefittability(mask != 0);
 				ei->refit_mask = TranslateRefitMask(mask);
-				_gted[e->index].defaultcargo_grf = _cur.grffile;
+				_gted[e->index].defaultcargo_grf = _cur_gps.grffile;
 				break;
 			}
 
@@ -154,7 +154,7 @@ static ChangeInfoResult RoadVehicleChangeInfo(uint first, uint last, int prop, B
 			case 0x1D: // Cargo classes allowed
 				_gted[e->index].cargo_allowed = CargoClasses{buf.ReadWord()};
 				_gted[e->index].UpdateRefittability(_gted[e->index].cargo_allowed.Any());
-				_gted[e->index].defaultcargo_grf = _cur.grffile;
+				_gted[e->index].defaultcargo_grf = _cur_gps.grffile;
 				break;
 
 			case 0x1E: // Cargo classes disallowed
@@ -192,11 +192,11 @@ static ChangeInfoResult RoadVehicleChangeInfo(uint first, uint last, int prop, B
 			case 0x25: { // CTT refit exclude list
 				uint8_t count = buf.ReadByte();
 				_gted[e->index].UpdateRefittability(prop == 0x24 && count != 0);
-				if (prop == 0x24) _gted[e->index].defaultcargo_grf = _cur.grffile;
+				if (prop == 0x24) _gted[e->index].defaultcargo_grf = _cur_gps.grffile;
 				CargoTypes &ctt = prop == 0x24 ? _gted[e->index].ctt_include_mask : _gted[e->index].ctt_exclude_mask;
 				ctt = 0;
 				while (count--) {
-					CargoType ctype = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
+					CargoType ctype = GetCargoTranslation(buf.ReadByte(), _cur_gps.grffile);
 					if (IsValidCargoType(ctype)) SetBit(ctt, ctype);
 				}
 				break;

--- a/src/newgrf/newgrf_act0_ships.cpp
+++ b/src/newgrf/newgrf_act0_ships.cpp
@@ -33,7 +33,7 @@ static ChangeInfoResult ShipVehicleChangeInfo(uint first, uint last, int prop, B
 	ChangeInfoResult ret = CIR_SUCCESS;
 
 	for (uint id = first; id < last; ++id) {
-		Engine *e = GetNewEngine(_cur.grffile, VEH_SHIP, id);
+		Engine *e = GetNewEngine(_cur_gps.grffile, VEH_SHIP, id);
 		if (e == nullptr) return CIR_INVALID_ID; // No engine could be allocated, so neither can any next vehicles
 
 		EngineInfo *ei = &e->info;
@@ -71,7 +71,7 @@ static ChangeInfoResult ShipVehicleChangeInfo(uint first, uint last, int prop, B
 				break;
 
 			case 0x0C: { // Cargo type
-				_gted[e->index].defaultcargo_grf = _cur.grffile;
+				_gted[e->index].defaultcargo_grf = _cur_gps.grffile;
 				uint8_t ctype = buf.ReadByte();
 
 				if (ctype == 0xFF) {
@@ -79,7 +79,7 @@ static ChangeInfoResult ShipVehicleChangeInfo(uint first, uint last, int prop, B
 					ei->cargo_type = INVALID_CARGO;
 				} else {
 					/* Use translated cargo. Might result in INVALID_CARGO (first refittable), if cargo is not defined. */
-					ei->cargo_type = GetCargoTranslation(ctype, _cur.grffile);
+					ei->cargo_type = GetCargoTranslation(ctype, _cur_gps.grffile);
 					if (ei->cargo_type == INVALID_CARGO) GrfMsg(2, "ShipVehicleChangeInfo: Invalid cargo type {}, using first refittable", ctype);
 				}
 				ei->cargo_label = CT_INVALID;
@@ -95,14 +95,14 @@ static ChangeInfoResult ShipVehicleChangeInfo(uint first, uint last, int prop, B
 				break;
 
 			case 0x10: // SFX
-				svi->sfx = GetNewGRFSoundID(_cur.grffile, buf.ReadByte());
+				svi->sfx = GetNewGRFSoundID(_cur_gps.grffile, buf.ReadByte());
 				break;
 
 			case 0x11: { // Cargoes available for refitting
 				uint32_t mask = buf.ReadDWord();
 				_gted[e->index].UpdateRefittability(mask != 0);
 				ei->refit_mask = TranslateRefitMask(mask);
-				_gted[e->index].defaultcargo_grf = _cur.grffile;
+				_gted[e->index].defaultcargo_grf = _cur_gps.grffile;
 				break;
 			}
 
@@ -137,7 +137,7 @@ static ChangeInfoResult ShipVehicleChangeInfo(uint first, uint last, int prop, B
 			case 0x18: // Cargo classes allowed
 				_gted[e->index].cargo_allowed = CargoClasses{buf.ReadWord()};
 				_gted[e->index].UpdateRefittability(_gted[e->index].cargo_allowed.Any());
-				_gted[e->index].defaultcargo_grf = _cur.grffile;
+				_gted[e->index].defaultcargo_grf = _cur_gps.grffile;
 				break;
 
 			case 0x19: // Cargo classes disallowed
@@ -171,11 +171,11 @@ static ChangeInfoResult ShipVehicleChangeInfo(uint first, uint last, int prop, B
 			case 0x1F: { // CTT refit exclude list
 				uint8_t count = buf.ReadByte();
 				_gted[e->index].UpdateRefittability(prop == 0x1E && count != 0);
-				if (prop == 0x1E) _gted[e->index].defaultcargo_grf = _cur.grffile;
+				if (prop == 0x1E) _gted[e->index].defaultcargo_grf = _cur_gps.grffile;
 				CargoTypes &ctt = prop == 0x1E ? _gted[e->index].ctt_include_mask : _gted[e->index].ctt_exclude_mask;
 				ctt = 0;
 				while (count--) {
-					CargoType ctype = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
+					CargoType ctype = GetCargoTranslation(buf.ReadByte(), _cur_gps.grffile);
 					if (IsValidCargoType(ctype)) SetBit(ctt, ctype);
 				}
 				break;

--- a/src/newgrf/newgrf_act0_sounds.cpp
+++ b/src/newgrf/newgrf_act0_sounds.cpp
@@ -27,18 +27,18 @@ static ChangeInfoResult SoundEffectChangeInfo(uint first, uint last, int prop, B
 {
 	ChangeInfoResult ret = CIR_SUCCESS;
 
-	if (_cur.grffile->sound_offset == 0) {
+	if (_cur_gps.grffile->sound_offset == 0) {
 		GrfMsg(1, "SoundEffectChangeInfo: No effects defined, skipping");
 		return CIR_INVALID_ID;
 	}
 
-	if (last - ORIGINAL_SAMPLE_COUNT > _cur.grffile->num_sounds) {
-		GrfMsg(1, "SoundEffectChangeInfo: Attempting to change undefined sound effect ({}), max ({}). Ignoring.", last, ORIGINAL_SAMPLE_COUNT + _cur.grffile->num_sounds);
+	if (last - ORIGINAL_SAMPLE_COUNT > _cur_gps.grffile->num_sounds) {
+		GrfMsg(1, "SoundEffectChangeInfo: Attempting to change undefined sound effect ({}), max ({}). Ignoring.", last, ORIGINAL_SAMPLE_COUNT + _cur_gps.grffile->num_sounds);
 		return CIR_INVALID_ID;
 	}
 
 	for (uint id = first; id < last; ++id) {
-		SoundEntry *sound = GetSound(first + _cur.grffile->sound_offset - ORIGINAL_SAMPLE_COUNT);
+		SoundEntry *sound = GetSound(first + _cur_gps.grffile->sound_offset - ORIGINAL_SAMPLE_COUNT);
 
 		switch (prop) {
 			case 0x08: // Relative volume

--- a/src/newgrf/newgrf_act0_stations.cpp
+++ b/src/newgrf/newgrf_act0_stations.cpp
@@ -37,10 +37,10 @@ static ChangeInfoResult StationChangeInfo(uint first, uint last, int prop, ByteR
 	}
 
 	/* Allocate station specs if necessary */
-	if (_cur.grffile->stations.size() < last) _cur.grffile->stations.resize(last);
+	if (_cur_gps.grffile->stations.size() < last) _cur_gps.grffile->stations.resize(last);
 
 	for (uint id = first; id < last; ++id) {
-		auto &statspec = _cur.grffile->stations[id];
+		auto &statspec = _cur_gps.grffile->stations[id];
 
 		/* Check that the station we are modifying is defined. */
 		if (statspec == nullptr && prop != 0x08) {
@@ -81,7 +81,7 @@ static ChangeInfoResult StationChangeInfo(uint first, uint last, int prop, ByteR
 
 					ReadSpriteLayoutSprite(buf, false, false, false, GSF_STATIONS, &dts->ground);
 					/* On error, bail out immediately. Temporary GRF data was already freed */
-					if (_cur.skip_sprites < 0) return CIR_DISABLED;
+					if (_cur_gps.skip_sprites < 0) return CIR_DISABLED;
 
 					std::vector<DrawTileSeqStruct> tmp_layout;
 					for (;;) {
@@ -99,7 +99,7 @@ static ChangeInfoResult StationChangeInfo(uint first, uint last, int prop, ByteR
 
 						ReadSpriteLayoutSprite(buf, false, true, false, GSF_STATIONS, &dtss.image);
 						/* On error, bail out immediately. Temporary GRF data was already freed */
-						if (_cur.skip_sprites < 0) return CIR_DISABLED;
+						if (_cur_gps.skip_sprites < 0) return CIR_DISABLED;
 					}
 					dts->seq = std::move(tmp_layout);
 				}
@@ -114,7 +114,7 @@ static ChangeInfoResult StationChangeInfo(uint first, uint last, int prop, ByteR
 
 			case 0x0A: { // Copy sprite layout
 				uint16_t srcid = buf.ReadExtendedByte();
-				const StationSpec *srcstatspec = srcid >= _cur.grffile->stations.size() ? nullptr : _cur.grffile->stations[srcid].get();
+				const StationSpec *srcstatspec = srcid >= _cur_gps.grffile->stations.size() ? nullptr : _cur_gps.grffile->stations[srcid].get();
 
 				if (srcstatspec == nullptr) {
 					GrfMsg(1, "StationChangeInfo: Station {} is not defined, cannot copy sprite layout to {}.", srcid, id);
@@ -167,7 +167,7 @@ static ChangeInfoResult StationChangeInfo(uint first, uint last, int prop, ByteR
 
 			case 0x0F: { // Copy custom layout
 				uint16_t srcid = buf.ReadExtendedByte();
-				const StationSpec *srcstatspec = srcid >= _cur.grffile->stations.size() ? nullptr : _cur.grffile->stations[srcid].get();
+				const StationSpec *srcstatspec = srcid >= _cur_gps.grffile->stations.size() ? nullptr : _cur_gps.grffile->stations[srcid].get();
 
 				if (srcstatspec == nullptr) {
 					GrfMsg(1, "StationChangeInfo: Station {} is not defined, cannot copy tile layout to {}.", srcid, id);
@@ -196,7 +196,7 @@ static ChangeInfoResult StationChangeInfo(uint first, uint last, int prop, ByteR
 			}
 
 			case 0x12: // Cargo types for random triggers
-				if (_cur.grffile->grf_version >= 7) {
+				if (_cur_gps.grffile->grf_version >= 7) {
 					statspec->cargo_triggers = TranslateRefitMask(buf.ReadDWord());
 				} else {
 					statspec->cargo_triggers = (CargoTypes)buf.ReadDWord();

--- a/src/newgrf/newgrf_act0_trains.cpp
+++ b/src/newgrf/newgrf_act0_trains.cpp
@@ -31,7 +31,7 @@ ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, ByteRead
 	ChangeInfoResult ret = CIR_SUCCESS;
 
 	for (uint id = first; id < last; ++id) {
-		Engine *e = GetNewEngine(_cur.grffile, VEH_TRAIN, id);
+		Engine *e = GetNewEngine(_cur_gps.grffile, VEH_TRAIN, id);
 		if (e == nullptr) return CIR_INVALID_ID; // No engine could be allocated, so neither can any next vehicles
 
 		EngineInfo *ei = &e->info;
@@ -41,8 +41,8 @@ ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, ByteRead
 			case 0x05: { // Track type
 				uint8_t tracktype = buf.ReadByte();
 
-				if (tracktype < _cur.grffile->railtype_list.size()) {
-					_gted[e->index].railtypelabel = _cur.grffile->railtype_list[tracktype];
+				if (tracktype < _cur_gps.grffile->railtype_list.size()) {
+					_gted[e->index].railtypelabel = _cur_gps.grffile->railtype_list[tracktype];
 					break;
 				}
 
@@ -126,7 +126,7 @@ ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, ByteRead
 				break;
 
 			case 0x15: { // Cargo type
-				_gted[e->index].defaultcargo_grf = _cur.grffile;
+				_gted[e->index].defaultcargo_grf = _cur_gps.grffile;
 				uint8_t ctype = buf.ReadByte();
 
 				if (ctype == 0xFF) {
@@ -134,7 +134,7 @@ ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, ByteRead
 					ei->cargo_type = INVALID_CARGO;
 				} else {
 					/* Use translated cargo. Might result in INVALID_CARGO (first refittable), if cargo is not defined. */
-					ei->cargo_type = GetCargoTranslation(ctype, _cur.grffile);
+					ei->cargo_type = GetCargoTranslation(ctype, _cur_gps.grffile);
 					if (ei->cargo_type == INVALID_CARGO) GrfMsg(2, "RailVehicleChangeInfo: Invalid cargo type {}, using first refittable", ctype);
 				}
 				ei->cargo_label = CT_INVALID;
@@ -179,7 +179,7 @@ ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, ByteRead
 					break;
 				}
 
-				if (_cur.grffile->railtype_list.empty()) {
+				if (_cur_gps.grffile->railtype_list.empty()) {
 					/* Use traction type to select between normal and electrified
 					 * rail only when no translation list is in place. */
 					if (_gted[e->index].railtypelabel == RAILTYPE_LABEL_RAIL     && engclass >= EC_ELECTRIC) _gted[e->index].railtypelabel = RAILTYPE_LABEL_ELECTRIC;
@@ -206,7 +206,7 @@ ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, ByteRead
 				uint32_t mask = buf.ReadDWord();
 				_gted[e->index].UpdateRefittability(mask != 0);
 				ei->refit_mask = TranslateRefitMask(mask);
-				_gted[e->index].defaultcargo_grf = _cur.grffile;
+				_gted[e->index].defaultcargo_grf = _cur_gps.grffile;
 				break;
 			}
 
@@ -270,7 +270,7 @@ ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, ByteRead
 			case 0x28: // Cargo classes allowed
 				_gted[e->index].cargo_allowed = CargoClasses{buf.ReadWord()};
 				_gted[e->index].UpdateRefittability(_gted[e->index].cargo_allowed.Any());
-				_gted[e->index].defaultcargo_grf = _cur.grffile;
+				_gted[e->index].defaultcargo_grf = _cur_gps.grffile;
 				break;
 
 			case 0x29: // Cargo classes disallowed
@@ -290,11 +290,11 @@ ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, ByteRead
 			case 0x2D: { // CTT refit exclude list
 				uint8_t count = buf.ReadByte();
 				_gted[e->index].UpdateRefittability(prop == 0x2C && count != 0);
-				if (prop == 0x2C) _gted[e->index].defaultcargo_grf = _cur.grffile;
+				if (prop == 0x2C) _gted[e->index].defaultcargo_grf = _cur_gps.grffile;
 				CargoTypes &ctt = prop == 0x2C ? _gted[e->index].ctt_include_mask : _gted[e->index].ctt_exclude_mask;
 				ctt = 0;
 				while (count--) {
-					CargoType ctype = GetCargoTranslation(buf.ReadByte(), _cur.grffile);
+					CargoType ctype = GetCargoTranslation(buf.ReadByte(), _cur_gps.grffile);
 					if (IsValidCargoType(ctype)) SetBit(ctt, ctype);
 				}
 				break;

--- a/src/newgrf/newgrf_act1.cpp
+++ b/src/newgrf/newgrf_act1.cpp
@@ -45,20 +45,20 @@ static void NewSpriteSet(ByteReader &buf)
 	uint16_t num_ents = buf.ReadExtendedByte();
 
 	if (feature >= GSF_END) {
-		_cur.skip_sprites = num_sets * num_ents;
-		GrfMsg(1, "NewSpriteSet: Unsupported feature 0x{:02X}, skipping {} sprites", feature, _cur.skip_sprites);
+		_cur_gps.skip_sprites = num_sets * num_ents;
+		GrfMsg(1, "NewSpriteSet: Unsupported feature 0x{:02X}, skipping {} sprites", feature, _cur_gps.skip_sprites);
 		return;
 	}
 
-	_cur.AddSpriteSets(feature, _cur.spriteid, first_set, num_sets, num_ents);
+	_cur_gps.AddSpriteSets(feature, _cur_gps.spriteid, first_set, num_sets, num_ents);
 
 	GrfMsg(7, "New sprite set at {} of feature 0x{:02X}, consisting of {} sets with {} views each (total {})",
-		_cur.spriteid, feature, num_sets, num_ents, num_sets * num_ents
+		_cur_gps.spriteid, feature, num_sets, num_ents, num_sets * num_ents
 	);
 
 	for (int i = 0; i < num_sets * num_ents; i++) {
-		_cur.nfo_line++;
-		LoadNextSprite(_cur.spriteid++, *_cur.file, _cur.nfo_line);
+		_cur_gps.nfo_line++;
+		LoadNextSprite(_cur_gps.spriteid++, *_cur_gps.file, _cur_gps.nfo_line);
 	}
 }
 
@@ -76,9 +76,9 @@ static void SkipAct1(ByteReader &buf)
 	}
 	uint16_t num_ents = buf.ReadExtendedByte();
 
-	_cur.skip_sprites = num_sets * num_ents;
+	_cur_gps.skip_sprites = num_sets * num_ents;
 
-	GrfMsg(3, "SkipAct1: Skipping {} sprites", _cur.skip_sprites);
+	GrfMsg(3, "SkipAct1: Skipping {} sprites", _cur_gps.skip_sprites);
 }
 
 template <> void GrfActionHandler<0x01>::FileScan(ByteReader &buf) { SkipAct1(buf); }

--- a/src/newgrf/newgrf_act10.cpp
+++ b/src/newgrf/newgrf_act10.cpp
@@ -24,7 +24,7 @@ static void DefineGotoLabel(ByteReader &buf)
 
 	uint8_t nfo_label = buf.ReadByte();
 
-	_cur.grffile->labels.emplace_back(nfo_label, _cur.nfo_line, _cur.file->GetPos());
+	_cur_gps.grffile->labels.emplace_back(nfo_label, _cur_gps.nfo_line, _cur_gps.file->GetPos());
 
 	GrfMsg(2, "DefineGotoLabel: GOTO target with label 0x{:02X}", nfo_label);
 }

--- a/src/newgrf/newgrf_act12.cpp
+++ b/src/newgrf/newgrf_act12.cpp
@@ -39,9 +39,9 @@ static void LoadFontGlyph(ByteReader &buf)
 		GrfMsg(7, "LoadFontGlyph: Loading {} glyph(s) at 0x{:04X} for size {}", num_char, base_char, size);
 
 		for (uint c = 0; c < num_char; c++) {
-			if (size < FS_END) SetUnicodeGlyph(size, base_char + c, _cur.spriteid);
-			_cur.nfo_line++;
-			LoadNextSprite(_cur.spriteid++, *_cur.file, _cur.nfo_line);
+			if (size < FS_END) SetUnicodeGlyph(size, base_char + c, _cur_gps.spriteid);
+			_cur_gps.nfo_line++;
+			LoadNextSprite(_cur_gps.spriteid++, *_cur_gps.file, _cur_gps.nfo_line);
 		}
 	}
 }
@@ -63,13 +63,13 @@ static void SkipAct12(ByteReader &buf)
 		buf.ReadByte();
 
 		/* Sum up number of characters */
-		_cur.skip_sprites += buf.ReadByte();
+		_cur_gps.skip_sprites += buf.ReadByte();
 
 		/* Ignore 'base_char' word */
 		buf.ReadWord();
 	}
 
-	GrfMsg(3, "SkipAct12: Skipping {} sprites", _cur.skip_sprites);
+	GrfMsg(3, "SkipAct12: Skipping {} sprites", _cur_gps.skip_sprites);
 }
 
 template <> void GrfActionHandler<0x12>::FileScan(ByteReader &buf) { SkipAct12(buf); }

--- a/src/newgrf/newgrf_act13.cpp
+++ b/src/newgrf/newgrf_act13.cpp
@@ -50,7 +50,7 @@ static void TranslateGRFStrings(ByteReader &buf)
 	 * new_scheme has to be true as well, which will also be implicitly the case for version 8
 	 * and higher. A language id of 0x7F will be overridden by a non-generic id, so this will
 	 * not change anything if a string has been provided specifically for this language. */
-	uint8_t language = _cur.grffile->grf_version >= 8 ? buf.ReadByte() : 0x7F;
+	uint8_t language = _cur_gps.grffile->grf_version >= 8 ? buf.ReadByte() : 0x7F;
 	uint8_t num_strings = buf.ReadByte();
 	uint16_t first_id  = buf.ReadWord();
 

--- a/src/newgrf/newgrf_act14.cpp
+++ b/src/newgrf/newgrf_act14.cpp
@@ -18,21 +18,21 @@
 /** Callback function for 'INFO'->'NAME' to add a translation to the newgrf name. */
 static bool ChangeGRFName(uint8_t langid, std::string_view str)
 {
-	AddGRFTextToList(_cur.grfconfig->name, langid, _cur.grfconfig->ident.grfid, false, str);
+	AddGRFTextToList(_cur_gps.grfconfig->name, langid, _cur_gps.grfconfig->ident.grfid, false, str);
 	return true;
 }
 
 /** Callback function for 'INFO'->'DESC' to add a translation to the newgrf description. */
 static bool ChangeGRFDescription(uint8_t langid, std::string_view str)
 {
-	AddGRFTextToList(_cur.grfconfig->info, langid, _cur.grfconfig->ident.grfid, true, str);
+	AddGRFTextToList(_cur_gps.grfconfig->info, langid, _cur_gps.grfconfig->ident.grfid, true, str);
 	return true;
 }
 
 /** Callback function for 'INFO'->'URL_' to set the newgrf url. */
 static bool ChangeGRFURL(uint8_t langid, std::string_view str)
 {
-	AddGRFTextToList(_cur.grfconfig->url, langid, _cur.grfconfig->ident.grfid, false, str);
+	AddGRFTextToList(_cur_gps.grfconfig->url, langid, _cur_gps.grfconfig->ident.grfid, false, str);
 	return true;
 }
 
@@ -43,7 +43,7 @@ static bool ChangeGRFNumUsedParams(size_t len, ByteReader &buf)
 		GrfMsg(2, "StaticGRFInfo: expected only 1 byte for 'INFO'->'NPAR' but got {}, ignoring this field", len);
 		buf.Skip(len);
 	} else {
-		_cur.grfconfig->num_valid_params = std::min(buf.ReadByte(), GRFConfig::MAX_NUM_PARAMS);
+		_cur_gps.grfconfig->num_valid_params = std::min(buf.ReadByte(), GRFConfig::MAX_NUM_PARAMS);
 	}
 	return true;
 }
@@ -67,8 +67,8 @@ static bool ChangeGRFPalette(size_t len, ByteReader &buf)
 				break;
 		}
 		if (pal != GRFP_GRF_UNSET) {
-			_cur.grfconfig->palette &= ~GRFP_GRF_MASK;
-			_cur.grfconfig->palette |= pal;
+			_cur_gps.grfconfig->palette &= ~GRFP_GRF_MASK;
+			_cur_gps.grfconfig->palette |= pal;
 		}
 	}
 	return true;
@@ -90,8 +90,8 @@ static bool ChangeGRFBlitter(size_t len, ByteReader &buf)
 				GrfMsg(2, "StaticGRFInfo: unexpected value '{:02X}' for 'INFO'->'BLTR', ignoring this field", data);
 				return true;
 		}
-		_cur.grfconfig->palette &= ~GRFP_BLT_MASK;
-		_cur.grfconfig->palette |= pal;
+		_cur_gps.grfconfig->palette &= ~GRFP_BLT_MASK;
+		_cur_gps.grfconfig->palette |= pal;
 	}
 	return true;
 }
@@ -104,7 +104,7 @@ static bool ChangeGRFVersion(size_t len, ByteReader &buf)
 		buf.Skip(len);
 	} else {
 		/* Set min_loadable_version as well (default to minimal compatibility) */
-		_cur.grfconfig->version = _cur.grfconfig->min_loadable_version = buf.ReadDWord();
+		_cur_gps.grfconfig->version = _cur_gps.grfconfig->min_loadable_version = buf.ReadDWord();
 	}
 	return true;
 }
@@ -116,14 +116,14 @@ static bool ChangeGRFMinVersion(size_t len, ByteReader &buf)
 		GrfMsg(2, "StaticGRFInfo: expected 4 bytes for 'INFO'->'MINV' but got {}, ignoring this field", len);
 		buf.Skip(len);
 	} else {
-		_cur.grfconfig->min_loadable_version = buf.ReadDWord();
-		if (_cur.grfconfig->version == 0) {
+		_cur_gps.grfconfig->min_loadable_version = buf.ReadDWord();
+		if (_cur_gps.grfconfig->version == 0) {
 			GrfMsg(2, "StaticGRFInfo: 'MINV' defined before 'VRSN' or 'VRSN' set to 0, ignoring this field");
-			_cur.grfconfig->min_loadable_version = 0;
+			_cur_gps.grfconfig->min_loadable_version = 0;
 		}
-		if (_cur.grfconfig->version < _cur.grfconfig->min_loadable_version) {
-			GrfMsg(2, "StaticGRFInfo: 'MINV' defined as {}, limiting it to 'VRSN'", _cur.grfconfig->min_loadable_version);
-			_cur.grfconfig->min_loadable_version = _cur.grfconfig->version;
+		if (_cur_gps.grfconfig->version < _cur_gps.grfconfig->min_loadable_version) {
+			GrfMsg(2, "StaticGRFInfo: 'MINV' defined as {}, limiting it to 'VRSN'", _cur_gps.grfconfig->min_loadable_version);
+			_cur_gps.grfconfig->min_loadable_version = _cur_gps.grfconfig->version;
 		}
 	}
 	return true;
@@ -134,14 +134,14 @@ static GRFParameterInfo *_cur_parameter; ///< The parameter which info is curren
 /** Callback function for 'INFO'->'PARAM'->param_num->'NAME' to set the name of a parameter. */
 static bool ChangeGRFParamName(uint8_t langid, std::string_view str)
 {
-	AddGRFTextToList(_cur_parameter->name, langid, _cur.grfconfig->ident.grfid, false, str);
+	AddGRFTextToList(_cur_parameter->name, langid, _cur_gps.grfconfig->ident.grfid, false, str);
 	return true;
 }
 
 /** Callback function for 'INFO'->'PARAM'->param_num->'DESC' to set the description of a parameter. */
 static bool ChangeGRFParamDescription(uint8_t langid, std::string_view str)
 {
-	AddGRFTextToList(_cur_parameter->desc, langid, _cur.grfconfig->ident.grfid, true, str);
+	AddGRFTextToList(_cur_parameter->desc, langid, _cur_gps.grfconfig->ident.grfid, true, str);
 	return true;
 }
 
@@ -214,7 +214,7 @@ static bool ChangeGRFParamDefault(size_t len, ByteReader &buf)
 	} else {
 		_cur_parameter->def_value = buf.ReadDWord();
 	}
-	_cur.grfconfig->has_param_defaults = true;
+	_cur_gps.grfconfig->has_param_defaults = true;
 	return true;
 }
 
@@ -265,7 +265,7 @@ static bool ChangeGRFParamValueNames(ByteReader &buf)
 		if (it == std::end(_cur_parameter->value_names) || it->first != id) {
 			it = _cur_parameter->value_names.emplace(it, id, GRFTextList{});
 		}
-		AddGRFTextToList(it->second, langid, _cur.grfconfig->ident.grfid, false, name_string);
+		AddGRFTextToList(it->second, langid, _cur_gps.grfconfig->ident.grfid, false, name_string);
 
 		type = buf.ReadByte();
 	}
@@ -294,20 +294,20 @@ static bool HandleParameterInfo(ByteReader &buf)
 	uint8_t type = buf.ReadByte();
 	while (type != 0) {
 		uint32_t id = buf.ReadDWord();
-		if (type != 'C' || id >= _cur.grfconfig->num_valid_params) {
+		if (type != 'C' || id >= _cur_gps.grfconfig->num_valid_params) {
 			GrfMsg(2, "StaticGRFInfo: all child nodes of 'INFO'->'PARA' should have type 'C' and their parameter number as id");
 			if (!SkipUnknownInfo(buf, type)) return false;
 			type = buf.ReadByte();
 			continue;
 		}
 
-		if (id >= _cur.grfconfig->param_info.size()) {
-			_cur.grfconfig->param_info.resize(id + 1);
+		if (id >= _cur_gps.grfconfig->param_info.size()) {
+			_cur_gps.grfconfig->param_info.resize(id + 1);
 		}
-		if (!_cur.grfconfig->param_info[id].has_value()) {
-			_cur.grfconfig->param_info[id] = GRFParameterInfo(id);
+		if (!_cur_gps.grfconfig->param_info[id].has_value()) {
+			_cur_gps.grfconfig->param_info[id] = GRFParameterInfo(id);
 		}
-		_cur_parameter = &_cur.grfconfig->param_info[id].value();
+		_cur_parameter = &_cur_gps.grfconfig->param_info[id].value();
 		/* Read all parameter-data and process each node. */
 		if (!HandleNodes(buf, _tags_parameters)) return false;
 		type = buf.ReadByte();

--- a/src/newgrf/newgrf_act4.cpp
+++ b/src/newgrf/newgrf_act4.cpp
@@ -46,7 +46,7 @@ static void FeatureNewName(ByteReader &buf)
 	 * S data          new texts, each of them zero-terminated, after
 	 *                 which the next name begins. */
 
-	bool new_scheme = _cur.grffile->grf_version >= 7;
+	bool new_scheme = _cur_gps.grffile->grf_version >= 7;
 
 	uint8_t feature  = buf.ReadByte();
 	if (feature >= GSF_END && feature != 0x48) {
@@ -86,67 +86,67 @@ static void FeatureNewName(ByteReader &buf)
 			case GSF_SHIPS:
 			case GSF_AIRCRAFT:
 				if (!generic) {
-					Engine *e = GetNewEngine(_cur.grffile, (VehicleType)feature, id, _cur.grfconfig->flags.Test(GRFConfigFlag::Static));
+					Engine *e = GetNewEngine(_cur_gps.grffile, (VehicleType)feature, id, _cur_gps.grfconfig->flags.Test(GRFConfigFlag::Static));
 					if (e == nullptr) break;
-					StringID string = AddGRFString(_cur.grffile->grfid, GRFStringID{feature_overlay | e->index.base()}, lang, new_scheme, false, name, e->info.string_id);
+					StringID string = AddGRFString(_cur_gps.grffile->grfid, GRFStringID{feature_overlay | e->index.base()}, lang, new_scheme, false, name, e->info.string_id);
 					e->info.string_id = string;
 				} else {
-					AddGRFString(_cur.grffile->grfid, GRFStringID{id}, lang, new_scheme, true, name, STR_UNDEFINED);
+					AddGRFString(_cur_gps.grffile->grfid, GRFStringID{id}, lang, new_scheme, true, name, STR_UNDEFINED);
 				}
 				break;
 
 			case GSF_BADGES: {
 				if (!generic) {
-					auto found = _cur.grffile->badge_map.find(id);
-					if (found == std::end(_cur.grffile->badge_map)) {
+					auto found = _cur_gps.grffile->badge_map.find(id);
+					if (found == std::end(_cur_gps.grffile->badge_map)) {
 						GrfMsg(1, "FeatureNewName: Attempt to name undefined badge 0x{:X}, ignoring", id);
 					} else {
 						Badge &badge = *GetBadge(found->second);
-						badge.name = AddGRFString(_cur.grffile->grfid, GRFStringID{feature_overlay | id}, lang, true, false, name, STR_UNDEFINED);
+						badge.name = AddGRFString(_cur_gps.grffile->grfid, GRFStringID{feature_overlay | id}, lang, true, false, name, STR_UNDEFINED);
 					}
 				} else {
-					AddGRFString(_cur.grffile->grfid, GRFStringID{id}, lang, new_scheme, true, name, STR_UNDEFINED);
+					AddGRFString(_cur_gps.grffile->grfid, GRFStringID{id}, lang, new_scheme, true, name, STR_UNDEFINED);
 				}
 				break;
 			}
 
 			default:
 				if (IsInsideMM(id, 0xD000, 0xD400) || IsInsideMM(id, 0xD800, 0x10000)) {
-					AddGRFString(_cur.grffile->grfid, GRFStringID{id}, lang, new_scheme, true, name, STR_UNDEFINED);
+					AddGRFString(_cur_gps.grffile->grfid, GRFStringID{id}, lang, new_scheme, true, name, STR_UNDEFINED);
 					break;
 				}
 
 				switch (GB(id, 8, 8)) {
 					case 0xC4: // Station class name
-						if (GB(id, 0, 8) >= _cur.grffile->stations.size() || _cur.grffile->stations[GB(id, 0, 8)] == nullptr) {
+						if (GB(id, 0, 8) >= _cur_gps.grffile->stations.size() || _cur_gps.grffile->stations[GB(id, 0, 8)] == nullptr) {
 							GrfMsg(1, "FeatureNewName: Attempt to name undefined station 0x{:X}, ignoring", GB(id, 0, 8));
 						} else {
-							StationClassID class_index = _cur.grffile->stations[GB(id, 0, 8)]->class_index;
-							StationClass::Get(class_index)->name = AddGRFString(_cur.grffile->grfid, GRFStringID{id}, lang, new_scheme, false, name, STR_UNDEFINED);
+							StationClassID class_index = _cur_gps.grffile->stations[GB(id, 0, 8)]->class_index;
+							StationClass::Get(class_index)->name = AddGRFString(_cur_gps.grffile->grfid, GRFStringID{id}, lang, new_scheme, false, name, STR_UNDEFINED);
 						}
 						break;
 
 					case 0xC5: // Station name
-						if (GB(id, 0, 8) >= _cur.grffile->stations.size() || _cur.grffile->stations[GB(id, 0, 8)] == nullptr) {
+						if (GB(id, 0, 8) >= _cur_gps.grffile->stations.size() || _cur_gps.grffile->stations[GB(id, 0, 8)] == nullptr) {
 							GrfMsg(1, "FeatureNewName: Attempt to name undefined station 0x{:X}, ignoring", GB(id, 0, 8));
 						} else {
-							_cur.grffile->stations[GB(id, 0, 8)]->name = AddGRFString(_cur.grffile->grfid, GRFStringID{id}, lang, new_scheme, false, name, STR_UNDEFINED);
+							_cur_gps.grffile->stations[GB(id, 0, 8)]->name = AddGRFString(_cur_gps.grffile->grfid, GRFStringID{id}, lang, new_scheme, false, name, STR_UNDEFINED);
 						}
 						break;
 
 					case 0xC7: // Airporttile name
-						if (GB(id, 0, 8) >= _cur.grffile->airtspec.size() || _cur.grffile->airtspec[GB(id, 0, 8)] == nullptr) {
+						if (GB(id, 0, 8) >= _cur_gps.grffile->airtspec.size() || _cur_gps.grffile->airtspec[GB(id, 0, 8)] == nullptr) {
 							GrfMsg(1, "FeatureNewName: Attempt to name undefined airport tile 0x{:X}, ignoring", GB(id, 0, 8));
 						} else {
-							_cur.grffile->airtspec[GB(id, 0, 8)]->name = AddGRFString(_cur.grffile->grfid, GRFStringID{id}, lang, new_scheme, false, name, STR_UNDEFINED);
+							_cur_gps.grffile->airtspec[GB(id, 0, 8)]->name = AddGRFString(_cur_gps.grffile->grfid, GRFStringID{id}, lang, new_scheme, false, name, STR_UNDEFINED);
 						}
 						break;
 
 					case 0xC9: // House name
-						if (GB(id, 0, 8) >= _cur.grffile->housespec.size() || _cur.grffile->housespec[GB(id, 0, 8)] == nullptr) {
+						if (GB(id, 0, 8) >= _cur_gps.grffile->housespec.size() || _cur_gps.grffile->housespec[GB(id, 0, 8)] == nullptr) {
 							GrfMsg(1, "FeatureNewName: Attempt to name undefined house 0x{:X}, ignoring.", GB(id, 0, 8));
 						} else {
-							_cur.grffile->housespec[GB(id, 0, 8)]->building_name = AddGRFString(_cur.grffile->grfid, GRFStringID{id}, lang, new_scheme, false, name, STR_UNDEFINED);
+							_cur_gps.grffile->housespec[GB(id, 0, 8)]->building_name = AddGRFString(_cur_gps.grffile->grfid, GRFStringID{id}, lang, new_scheme, false, name, STR_UNDEFINED);
 						}
 						break;
 

--- a/src/newgrf/newgrf_act5.cpp
+++ b/src/newgrf/newgrf_act5.cpp
@@ -103,20 +103,20 @@ static void GraphicsNew(ByteReader &buf)
 	uint16_t offset = HasBit(type, 7) ? buf.ReadExtendedByte() : 0;
 	ClrBit(type, 7); // Clear the high bit as that only indicates whether there is an offset.
 
-	if ((type == 0x0D) && (num == 10) && _cur.grfconfig->flags.Test(GRFConfigFlag::System)) {
+	if ((type == 0x0D) && (num == 10) && _cur_gps.grfconfig->flags.Test(GRFConfigFlag::System)) {
 		/* Special not-TTDP-compatible case used in openttd.grf
 		 * Missing shore sprites and initialisation of SPR_SHORE_BASE */
 		GrfMsg(2, "GraphicsNew: Loading 10 missing shore sprites from extra grf.");
-		LoadNextSprite(SPR_SHORE_BASE +  0, *_cur.file, _cur.nfo_line++); // SLOPE_STEEP_S
-		LoadNextSprite(SPR_SHORE_BASE +  5, *_cur.file, _cur.nfo_line++); // SLOPE_STEEP_W
-		LoadNextSprite(SPR_SHORE_BASE +  7, *_cur.file, _cur.nfo_line++); // SLOPE_WSE
-		LoadNextSprite(SPR_SHORE_BASE + 10, *_cur.file, _cur.nfo_line++); // SLOPE_STEEP_N
-		LoadNextSprite(SPR_SHORE_BASE + 11, *_cur.file, _cur.nfo_line++); // SLOPE_NWS
-		LoadNextSprite(SPR_SHORE_BASE + 13, *_cur.file, _cur.nfo_line++); // SLOPE_ENW
-		LoadNextSprite(SPR_SHORE_BASE + 14, *_cur.file, _cur.nfo_line++); // SLOPE_SEN
-		LoadNextSprite(SPR_SHORE_BASE + 15, *_cur.file, _cur.nfo_line++); // SLOPE_STEEP_E
-		LoadNextSprite(SPR_SHORE_BASE + 16, *_cur.file, _cur.nfo_line++); // SLOPE_EW
-		LoadNextSprite(SPR_SHORE_BASE + 17, *_cur.file, _cur.nfo_line++); // SLOPE_NS
+		LoadNextSprite(SPR_SHORE_BASE +  0, *_cur_gps.file, _cur_gps.nfo_line++); // SLOPE_STEEP_S
+		LoadNextSprite(SPR_SHORE_BASE +  5, *_cur_gps.file, _cur_gps.nfo_line++); // SLOPE_STEEP_W
+		LoadNextSprite(SPR_SHORE_BASE +  7, *_cur_gps.file, _cur_gps.nfo_line++); // SLOPE_WSE
+		LoadNextSprite(SPR_SHORE_BASE + 10, *_cur_gps.file, _cur_gps.nfo_line++); // SLOPE_STEEP_N
+		LoadNextSprite(SPR_SHORE_BASE + 11, *_cur_gps.file, _cur_gps.nfo_line++); // SLOPE_NWS
+		LoadNextSprite(SPR_SHORE_BASE + 13, *_cur_gps.file, _cur_gps.nfo_line++); // SLOPE_ENW
+		LoadNextSprite(SPR_SHORE_BASE + 14, *_cur_gps.file, _cur_gps.nfo_line++); // SLOPE_SEN
+		LoadNextSprite(SPR_SHORE_BASE + 15, *_cur_gps.file, _cur_gps.nfo_line++); // SLOPE_STEEP_E
+		LoadNextSprite(SPR_SHORE_BASE + 16, *_cur_gps.file, _cur_gps.nfo_line++); // SLOPE_EW
+		LoadNextSprite(SPR_SHORE_BASE + 17, *_cur_gps.file, _cur_gps.nfo_line++); // SLOPE_NS
 		if (_loaded_newgrf_features.shore == SHORE_REPLACE_NONE) _loaded_newgrf_features.shore = SHORE_REPLACE_ONLY_NEW;
 		return;
 	}
@@ -124,7 +124,7 @@ static void GraphicsNew(ByteReader &buf)
 	/* Supported type? */
 	if ((type >= std::size(_action5_types)) || (_action5_types[type].block_type == A5BLOCK_INVALID)) {
 		GrfMsg(2, "GraphicsNew: Custom graphics (type 0x{:02X}) sprite block of length {} (unimplemented, ignoring)", type, num);
-		_cur.skip_sprites = num;
+		_cur_gps.skip_sprites = num;
 		return;
 	}
 
@@ -142,7 +142,7 @@ static void GraphicsNew(ByteReader &buf)
 	 * This does not make sense, if <offset> is allowed */
 	if ((action5_type->block_type == A5BLOCK_FIXED) && (num < action5_type->min_sprites)) {
 		GrfMsg(1, "GraphicsNew: {} (type 0x{:02X}) count must be at least {}. Only {} were specified. Skipping.", action5_type->name, type, action5_type->min_sprites, num);
-		_cur.skip_sprites = num;
+		_cur_gps.skip_sprites = num;
 		return;
 	}
 
@@ -166,16 +166,16 @@ static void GraphicsNew(ByteReader &buf)
 	bool dup_oneway_sprites = ((type == 0x09) && (offset + num <= ONEWAY_SLOPE_N_OFFSET));
 
 	for (; num > 0; num--) {
-		_cur.nfo_line++;
-		SpriteID load_index = (replace == 0 ? _cur.spriteid++ : replace++);
-		LoadNextSprite(load_index, *_cur.file, _cur.nfo_line);
+		_cur_gps.nfo_line++;
+		SpriteID load_index = (replace == 0 ? _cur_gps.spriteid++ : replace++);
+		LoadNextSprite(load_index, *_cur_gps.file, _cur_gps.nfo_line);
 		if (dup_oneway_sprites) {
 			DupSprite(load_index, load_index + ONEWAY_SLOPE_N_OFFSET);
 			DupSprite(load_index, load_index + ONEWAY_SLOPE_S_OFFSET);
 		}
 	}
 
-	_cur.skip_sprites = skip_num;
+	_cur_gps.skip_sprites = skip_num;
 }
 
 /* Action 0x05 (SKIP) */
@@ -185,9 +185,9 @@ static void SkipAct5(ByteReader &buf)
 	buf.ReadByte();
 
 	/* Skip the sprites of this action */
-	_cur.skip_sprites = buf.ReadExtendedByte();
+	_cur_gps.skip_sprites = buf.ReadExtendedByte();
 
-	GrfMsg(3, "SkipAct5: Skipping {} sprites", _cur.skip_sprites);
+	GrfMsg(3, "SkipAct5: Skipping {} sprites", _cur_gps.skip_sprites);
 }
 
 template <> void GrfActionHandler<0x05>::FileScan(ByteReader &buf) { SkipAct5(buf); }

--- a/src/newgrf/newgrf_act6.cpp
+++ b/src/newgrf/newgrf_act6.cpp
@@ -32,7 +32,7 @@ static void CfgApply(ByteReader &buf)
 	 *                 to place where parameter is to be stored. */
 
 	/* Preload the next sprite */
-	SpriteFile &file = *_cur.file;
+	SpriteFile &file = *_cur_gps.file;
 	size_t pos = file.GetPos();
 	uint32_t num = file.GetContainerVersion() >= 2 ? file.ReadDword() : file.ReadWord();
 	uint8_t type = file.ReadByte();
@@ -47,7 +47,7 @@ static void CfgApply(ByteReader &buf)
 	}
 
 	/* Get (or create) the override for the next sprite. */
-	GRFLocation location(_cur.grfconfig->ident.grfid, _cur.nfo_line + 1);
+	GRFLocation location(_cur_gps.grfconfig->ident.grfid, _cur_gps.nfo_line + 1);
 	std::vector<uint8_t> &preload_sprite = _grf_line_to_action6_sprite_override[location];
 
 	/* Load new sprite data if it hasn't already been loaded. */
@@ -85,7 +85,7 @@ static void CfgApply(ByteReader &buf)
 
 		/* If the parameter is a GRF parameter (not an internal variable) check
 		 * if it (and all further sequential parameters) has been defined. */
-		if (param_num < 0x80 && (param_num + (param_size - 1) / 4) >= std::size(_cur.grffile->param)) {
+		if (param_num < 0x80 && (param_num + (param_size - 1) / 4) >= std::size(_cur_gps.grffile->param)) {
 			GrfMsg(2, "CfgApply: Ignoring (param {} not set)", (param_num + (param_size - 1) / 4));
 			break;
 		}

--- a/src/newgrf/newgrf_act8.cpp
+++ b/src/newgrf/newgrf_act8.cpp
@@ -24,25 +24,25 @@ static void ScanInfo(ByteReader &buf)
 	uint32_t grfid      = buf.ReadDWord();
 	std::string_view name = buf.ReadString();
 
-	_cur.grfconfig->ident.grfid = grfid;
+	_cur_gps.grfconfig->ident.grfid = grfid;
 
 	if (grf_version < 2 || grf_version > 8) {
-		_cur.grfconfig->flags.Set(GRFConfigFlag::Invalid);
-		Debug(grf, 0, "{}: NewGRF \"{}\" (GRFID {:08X}) uses GRF version {}, which is incompatible with this version of OpenTTD.", _cur.grfconfig->filename, StrMakeValid(name), std::byteswap(grfid), grf_version);
+		_cur_gps.grfconfig->flags.Set(GRFConfigFlag::Invalid);
+		Debug(grf, 0, "{}: NewGRF \"{}\" (GRFID {:08X}) uses GRF version {}, which is incompatible with this version of OpenTTD.", _cur_gps.grfconfig->filename, StrMakeValid(name), std::byteswap(grfid), grf_version);
 	}
 
 	/* GRF IDs starting with 0xFF are reserved for internal TTDPatch use */
-	if (GB(grfid, 0, 8) == 0xFF) _cur.grfconfig->flags.Set(GRFConfigFlag::System);
+	if (GB(grfid, 0, 8) == 0xFF) _cur_gps.grfconfig->flags.Set(GRFConfigFlag::System);
 
-	AddGRFTextToList(_cur.grfconfig->name, 0x7F, grfid, false, name);
+	AddGRFTextToList(_cur_gps.grfconfig->name, 0x7F, grfid, false, name);
 
 	if (buf.HasData()) {
 		std::string_view info = buf.ReadString();
-		AddGRFTextToList(_cur.grfconfig->info, 0x7F, grfid, true, info);
+		AddGRFTextToList(_cur_gps.grfconfig->info, 0x7F, grfid, true, info);
 	}
 
 	/* GLS_INFOSCAN only looks for the action 8, so we can skip the rest of the file */
-	_cur.skip_sprites = -1;
+	_cur_gps.skip_sprites = -1;
 }
 
 /* Action 0x08 */
@@ -59,21 +59,21 @@ static void GRFInfo(ByteReader &buf)
 	uint32_t grfid     = buf.ReadDWord();
 	std::string_view name = buf.ReadString();
 
-	if (_cur.stage < GLS_RESERVE && _cur.grfconfig->status != GCS_UNKNOWN) {
+	if (_cur_gps.stage < GLS_RESERVE && _cur_gps.grfconfig->status != GCS_UNKNOWN) {
 		DisableGrf(STR_NEWGRF_ERROR_MULTIPLE_ACTION_8);
 		return;
 	}
 
-	if (_cur.grffile->grfid != grfid) {
-		Debug(grf, 0, "GRFInfo: GRFID {:08X} in FILESCAN stage does not match GRFID {:08X} in INIT/RESERVE/ACTIVATION stage", std::byteswap(_cur.grffile->grfid), std::byteswap(grfid));
-		_cur.grffile->grfid = grfid;
+	if (_cur_gps.grffile->grfid != grfid) {
+		Debug(grf, 0, "GRFInfo: GRFID {:08X} in FILESCAN stage does not match GRFID {:08X} in INIT/RESERVE/ACTIVATION stage", std::byteswap(_cur_gps.grffile->grfid), std::byteswap(grfid));
+		_cur_gps.grffile->grfid = grfid;
 	}
 
-	_cur.grffile->grf_version = version;
-	_cur.grfconfig->status = _cur.stage < GLS_RESERVE ? GCS_INITIALISED : GCS_ACTIVATED;
+	_cur_gps.grffile->grf_version = version;
+	_cur_gps.grfconfig->status = _cur_gps.stage < GLS_RESERVE ? GCS_INITIALISED : GCS_ACTIVATED;
 
 	/* Do swap the GRFID for displaying purposes since people expect that */
-	Debug(grf, 1, "GRFInfo: Loaded GRFv{} set {:08X} - {} (palette: {}, version: {})", version, std::byteswap(grfid), StrMakeValid(name), (_cur.grfconfig->palette & GRFP_USE_MASK) ? "Windows" : "DOS", _cur.grfconfig->version);
+	Debug(grf, 1, "GRFInfo: Loaded GRFv{} set {:08X} - {} (palette: {}, version: {})", version, std::byteswap(grfid), StrMakeValid(name), (_cur_gps.grfconfig->palette & GRFP_USE_MASK) ? "Windows" : "DOS", _cur_gps.grfconfig->version);
 }
 
 template <> void GrfActionHandler<0x08>::FileScan(ByteReader &buf) { ScanInfo(buf); }

--- a/src/newgrf/newgrf_acta.cpp
+++ b/src/newgrf/newgrf_acta.cpp
@@ -26,7 +26,7 @@
 static bool IsGRMReservedSprite(SpriteID first_sprite, uint16_t num_sprites)
 {
 	for (const auto &grm_sprite : _grm_sprites) {
-		if (grm_sprite.first.grfid != _cur.grffile->grfid) continue;
+		if (grm_sprite.first.grfid != _cur_gps.grffile->grfid) continue;
 		if (grm_sprite.second.first <= first_sprite && grm_sprite.second.first + grm_sprite.second.second >= first_sprite + num_sprites) return true;
 	}
 	return false;
@@ -60,15 +60,15 @@ static void SpriteReplace(ByteReader &buf)
 					i, num_sprites, first_sprite, SPR_OPENTTD_BASE);
 
 				/* Load the sprites at the current location so they will do nothing instead of appearing to work. */
-				first_sprite = _cur.spriteid;
-				_cur.spriteid += num_sprites;
+				first_sprite = _cur_gps.spriteid;
+				_cur_gps.spriteid += num_sprites;
 			}
 		}
 
 		for (uint j = 0; j < num_sprites; j++) {
 			SpriteID load_index = first_sprite + j;
-			_cur.nfo_line++;
-			LoadNextSprite(load_index, *_cur.file, _cur.nfo_line); // XXX
+			_cur_gps.nfo_line++;
+			LoadNextSprite(load_index, *_cur_gps.file, _cur_gps.nfo_line); // XXX
 
 			/* Shore sprites now located at different addresses.
 			 * So detect when the old ones get replaced. */
@@ -86,12 +86,12 @@ static void SkipActA(ByteReader &buf)
 
 	for (uint i = 0; i < num_sets; i++) {
 		/* Skip the sprites this replaces */
-		_cur.skip_sprites += buf.ReadByte();
+		_cur_gps.skip_sprites += buf.ReadByte();
 		/* But ignore where they go */
 		buf.ReadWord();
 	}
 
-	GrfMsg(3, "SkipActA: Skipping {} sprites", _cur.skip_sprites);
+	GrfMsg(3, "SkipActA: Skipping {} sprites", _cur_gps.skip_sprites);
 }
 
 template <> void GrfActionHandler<0x0A>::FileScan(ByteReader &buf) { SkipActA(buf); }

--- a/src/newgrf/newgrf_actb.cpp
+++ b/src/newgrf/newgrf_actb.cpp
@@ -56,12 +56,12 @@ static void GRFLoadError(ByteReader &buf)
 	uint8_t message_id = buf.ReadByte();
 
 	/* Skip the error if it isn't valid for the current language. */
-	if (!CheckGrfLangID(lang, _cur.grffile->grf_version)) return;
+	if (!CheckGrfLangID(lang, _cur_gps.grffile->grf_version)) return;
 
 	/* Skip the error until the activation stage unless bit 7 of the severity
 	 * is set. */
-	if (!HasBit(severity, 7) && _cur.stage == GLS_INIT) {
-		GrfMsg(7, "GRFLoadError: Skipping non-fatal GRFLoadError in stage {}", _cur.stage);
+	if (!HasBit(severity, 7) && _cur_gps.stage == GLS_INIT) {
+		GrfMsg(7, "GRFLoadError: Skipping non-fatal GRFLoadError in stage {}", _cur_gps.stage);
 		return;
 	}
 	ClrBit(severity, 7);
@@ -75,7 +75,7 @@ static void GRFLoadError(ByteReader &buf)
 		DisableGrf();
 
 		/* Make sure we show fatal errors, instead of silly infos from before */
-		_cur.grfconfig->error.reset();
+		_cur_gps.grfconfig->error.reset();
 	}
 
 	if (message_id >= lengthof(msgstr) && message_id != 0xFF) {
@@ -89,17 +89,17 @@ static void GRFLoadError(ByteReader &buf)
 	}
 
 	/* For now we can only show one message per newgrf file. */
-	if (_cur.grfconfig->error.has_value()) return;
+	if (_cur_gps.grfconfig->error.has_value()) return;
 
-	_cur.grfconfig->error = {sevstr[severity]};
-	GRFError *error = &_cur.grfconfig->error.value();
+	_cur_gps.grfconfig->error = {sevstr[severity]};
+	GRFError *error = &_cur_gps.grfconfig->error.value();
 
 	if (message_id == 0xFF) {
 		/* This is a custom error message. */
 		if (buf.HasData()) {
 			std::string_view message = buf.ReadString();
 
-			error->custom_message = TranslateTTDPatchCodes(_cur.grffile->grfid, lang, true, message, SCC_RAW_STRING_POINTER);
+			error->custom_message = TranslateTTDPatchCodes(_cur_gps.grffile->grfid, lang, true, message, SCC_RAW_STRING_POINTER);
 		} else {
 			GrfMsg(7, "GRFLoadError: No custom message supplied.");
 			error->custom_message.clear();
@@ -111,7 +111,7 @@ static void GRFLoadError(ByteReader &buf)
 	if (buf.HasData()) {
 		std::string_view data = buf.ReadString();
 
-		error->data = TranslateTTDPatchCodes(_cur.grffile->grfid, lang, true, data);
+		error->data = TranslateTTDPatchCodes(_cur_gps.grffile->grfid, lang, true, data);
 	} else {
 		GrfMsg(7, "GRFLoadError: No message data supplied.");
 		error->data.clear();
@@ -120,7 +120,7 @@ static void GRFLoadError(ByteReader &buf)
 	/* Only two parameter numbers can be used in the string. */
 	for (uint i = 0; i < error->param_value.size() && buf.HasData(); i++) {
 		uint param_number = buf.ReadByte();
-		error->param_value[i] = _cur.grffile->GetParam(param_number);
+		error->param_value[i] = _cur_gps.grffile->GetParam(param_number);
 	}
 }
 

--- a/src/newgrf/newgrf_acte.cpp
+++ b/src/newgrf/newgrf_acte.cpp
@@ -30,7 +30,7 @@ static void SafeGRFInhibit(ByteReader &buf)
 		uint32_t grfid = buf.ReadDWord();
 
 		/* GRF is unsafe it if tries to deactivate other GRFs */
-		if (grfid != _cur.grfconfig->ident.grfid) {
+		if (grfid != _cur_gps.grfconfig->ident.grfid) {
 			GRFUnsafe(buf);
 			return;
 		}
@@ -52,10 +52,10 @@ static void GRFInhibit(ByteReader &buf)
 		GRFConfig *file = GetGRFConfig(grfid);
 
 		/* Unset activation flag */
-		if (file != nullptr && file != _cur.grfconfig) {
+		if (file != nullptr && file != _cur_gps.grfconfig) {
 			GrfMsg(2, "GRFInhibit: Deactivating file '{}'", file->filename);
 			GRFError *error = DisableGrf(STR_NEWGRF_ERROR_FORCEFULLY_DISABLED, file);
-			error->data = _cur.grfconfig->GetName();
+			error->data = _cur_gps.grfconfig->GetName();
 		}
 	}
 }

--- a/src/newgrf/newgrf_actf.cpp
+++ b/src/newgrf/newgrf_actf.cpp
@@ -27,7 +27,7 @@ static void FeatureTownName(ByteReader &buf)
 	 * B num-parts   Number of parts in this definition
 	 * V parts       The parts */
 
-	uint32_t grfid = _cur.grffile->grfid;
+	uint32_t grfid = _cur_gps.grffile->grfid;
 
 	GRFTownName *townname = AddGRFTownName(grfid);
 
@@ -37,7 +37,7 @@ static void FeatureTownName(ByteReader &buf)
 	if (HasBit(id, 7)) {
 		/* Final definition */
 		ClrBit(id, 7);
-		bool new_scheme = _cur.grffile->grf_version >= 7;
+		bool new_scheme = _cur_gps.grffile->grf_version >= 7;
 
 		uint8_t lang = buf.ReadByte();
 		StringID style = STR_UNDEFINED;

--- a/src/newgrf/newgrf_internal.h
+++ b/src/newgrf/newgrf_internal.h
@@ -155,7 +155,7 @@ public:
 	}
 };
 
-extern GrfProcessingState _cur;
+extern GrfProcessingState _cur_gps;
 
 struct GRFLocation {
 	uint32_t grfid;

--- a/src/newgrf/newgrf_stringmapping.cpp
+++ b/src/newgrf/newgrf_stringmapping.cpp
@@ -42,7 +42,7 @@ static std::vector<StringIDMapping> _string_to_grf_mapping;
 void AddStringForMapping(GRFStringID source, std::function<void(StringID)> &&func)
 {
 	func(STR_UNDEFINED);
-	_string_to_grf_mapping.emplace_back(_cur.grffile->grfid, source, std::move(func));
+	_string_to_grf_mapping.emplace_back(_cur_gps.grffile->grfid, source, std::move(func));
 }
 
 /**

--- a/src/os/unix/font_unix.cpp
+++ b/src/os/unix/font_unix.cpp
@@ -20,7 +20,7 @@
 #include <ft2build.h>
 #include FT_FREETYPE_H
 
-extern FT_Library _library;
+extern FT_Library _ft_library;
 
 /**
  * Split the font name into the font family and style. These fields are separated by a comma,
@@ -85,7 +85,7 @@ FT_Error GetFontByFaceName(const char *font_name, FT_Face *face)
 				 * wrongly a 'random' font, so check whether the family name is the
 				 * same as the supplied name */
 				if (StrEqualsIgnoreCase(font_family, (char *)family)) {
-					err = FT_New_Face(_library, (char *)file, index, face);
+					err = FT_New_Face(_ft_library, (char *)file, index, face);
 				}
 			}
 		}

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -113,7 +113,7 @@ struct GSDTChunkHandler : ChunkHandler {
 	}
 };
 
-extern std::shared_ptr<GameStrings> _current_data;
+extern std::shared_ptr<GameStrings> _current_gamestrings_data;
 
 static std::string _game_saveload_string;
 static uint32_t _game_saveload_strings;
@@ -159,21 +159,21 @@ struct GSTRChunkHandler : ChunkHandler {
 	{
 		const std::vector<SaveLoad> slt = SlCompatTableHeader(_game_language_desc, _game_language_sl_compat);
 
-		_current_data = std::make_shared<GameStrings>();
+		_current_gamestrings_data = std::make_shared<GameStrings>();
 
 		while (SlIterateArray() != -1) {
 			LanguageStrings ls;
 			SlObject(&ls, slt);
-			_current_data->raw_strings.push_back(std::move(ls));
+			_current_gamestrings_data->raw_strings.push_back(std::move(ls));
 		}
 
 		/* If there were no strings in the savegame, set GameStrings to nullptr */
-		if (_current_data->raw_strings.empty()) {
-			_current_data.reset();
+		if (_current_gamestrings_data->raw_strings.empty()) {
+			_current_gamestrings_data.reset();
 			return;
 		}
 
-		_current_data->Compile();
+		_current_gamestrings_data->Compile();
 		ReconsiderGameScriptLanguage();
 	}
 
@@ -181,11 +181,11 @@ struct GSTRChunkHandler : ChunkHandler {
 	{
 		SlTableHeader(_game_language_desc);
 
-		if (_current_data == nullptr) return;
+		if (_current_gamestrings_data == nullptr) return;
 
-		for (uint i = 0; i < _current_data->raw_strings.size(); i++) {
+		for (uint i = 0; i < _current_gamestrings_data->raw_strings.size(); i++) {
 			SlSetArrayIndex(i);
-			SlObject(&_current_data->raw_strings[i], _game_language_desc);
+			SlObject(&_current_gamestrings_data->raw_strings[i], _game_language_desc);
 		}
 	}
 };

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -94,7 +94,7 @@ uint BaseSettingEntry::Draw(GameSettings *settings_ptr, int left, int right, int
 	if (cur_row >= max_row) return cur_row;
 
 	bool rtl = _current_text_dir == TD_RTL;
-	int offset = (rtl ? -(int)_circle_size.width : (int)_circle_size.width) / 2;
+	int offset = (rtl ? -(int)_setting_circle_size.width : (int)_setting_circle_size.width) / 2;
 	int level_width = rtl ? -WidgetDimensions::scaled.hsep_indent : WidgetDimensions::scaled.hsep_indent;
 
 	int x = rtl ? right : left;
@@ -621,8 +621,8 @@ uint SettingsPage::Draw(GameSettings *settings_ptr, int left, int right, int y, 
 void SettingsPage::DrawSetting(GameSettings *, int left, int right, int y, bool) const
 {
 	bool rtl = _current_text_dir == TD_RTL;
-	DrawSprite((this->folded ? SPR_CIRCLE_FOLDED : SPR_CIRCLE_UNFOLDED), PAL_NONE, rtl ? right - _circle_size.width : left, y + (SETTING_HEIGHT - _circle_size.height) / 2);
-	DrawString(rtl ? left : left + _circle_size.width + WidgetDimensions::scaled.hsep_normal, rtl ? right - _circle_size.width - WidgetDimensions::scaled.hsep_normal : right, y + (SETTING_HEIGHT - GetCharacterHeight(FS_NORMAL)) / 2, this->title, TC_ORANGE);
+	DrawSprite((this->folded ? SPR_CIRCLE_FOLDED : SPR_CIRCLE_UNFOLDED), PAL_NONE, rtl ? right - _setting_circle_size.width : left, y + (SETTING_HEIGHT - _setting_circle_size.height) / 2);
+	DrawString(rtl ? left : left + _setting_circle_size.width + WidgetDimensions::scaled.hsep_normal, rtl ? right - _setting_circle_size.width - WidgetDimensions::scaled.hsep_normal : right, y + (SETTING_HEIGHT - GetCharacterHeight(FS_NORMAL)) / 2, this->title, TC_ORANGE);
 }
 
 /** Construct settings tree */

--- a/src/settingentry_gui.h
+++ b/src/settingentry_gui.h
@@ -14,7 +14,7 @@
 #include "settings_internal.h"
 #include "stringfilter_type.h"
 
-extern Dimension _circle_size;
+extern Dimension _setting_circle_size;
 extern int SETTING_HEIGHT;
 
 /**

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -83,7 +83,7 @@ static const uint32_t _autosave_dropdown_to_minutes[] = {
 	120,
 };
 
-Dimension _circle_size; ///< Dimension of the circle +/- icon. This is here as not all users are within the class of the settings window.
+Dimension _setting_circle_size; ///< Dimension of the circle +/- icon. This is here as not all users are within the class of the settings window.
 
 /**
  * Get index of the current screen resolution.
@@ -1267,14 +1267,14 @@ struct GameSettingsWindow : Window {
 
 	void OnInit() override
 	{
-		_circle_size = maxdim(GetSpriteSize(SPR_CIRCLE_FOLDED), GetSpriteSize(SPR_CIRCLE_UNFOLDED));
+		_setting_circle_size = maxdim(GetSpriteSize(SPR_CIRCLE_FOLDED), GetSpriteSize(SPR_CIRCLE_UNFOLDED));
 	}
 
 	void UpdateWidgetSize(WidgetID widget, Dimension &size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension &fill, [[maybe_unused]] Dimension &resize) override
 	{
 		switch (widget) {
 			case WID_GS_OPTIONSPANEL:
-				resize.height = SETTING_HEIGHT = std::max({(int)_circle_size.height, SETTING_BUTTON_HEIGHT, GetCharacterHeight(FS_NORMAL)}) + WidgetDimensions::scaled.vsep_normal;
+				resize.height = SETTING_HEIGHT = std::max({(int)_setting_circle_size.height, SETTING_BUTTON_HEIGHT, GetCharacterHeight(FS_NORMAL)}) + WidgetDimensions::scaled.vsep_normal;
 				resize.width = 1;
 
 				size.height = 5 * resize.height + WidgetDimensions::scaled.framerect.Vertical();

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -35,34 +35,34 @@
 
 void StrgenWarningI(const std::string &msg)
 {
-	if (_translation) {
-		fmt::print(stderr, LINE_NUM_FMT("info"), _file, _cur_line, msg);
+	if (_strgen.translation) {
+		fmt::print(stderr, LINE_NUM_FMT("info"), _strgen.file, _strgen.cur_line, msg);
 	} else {
-		fmt::print(stderr, LINE_NUM_FMT("warning"), _file, _cur_line, msg);
+		fmt::print(stderr, LINE_NUM_FMT("warning"), _strgen.file, _strgen.cur_line, msg);
 	}
-	_warnings++;
+	_strgen.warnings++;
 }
 
 void StrgenErrorI(const std::string &msg)
 {
-	fmt::print(stderr, LINE_NUM_FMT("error"), _file, _cur_line, msg);
-	_errors++;
+	fmt::print(stderr, LINE_NUM_FMT("error"), _strgen.file, _strgen.cur_line, msg);
+	_strgen.errors++;
 }
 
 [[noreturn]] void StrgenFatalI(const std::string &msg)
 {
-	fmt::print(stderr, LINE_NUM_FMT("FATAL"), _file, _cur_line, msg);
+	fmt::print(stderr, LINE_NUM_FMT("FATAL"), _strgen.file, _strgen.cur_line, msg);
 #ifdef _MSC_VER
-	fmt::print(stderr, LINE_NUM_FMT("warning"), _file, _cur_line, "language is not compiled");
+	fmt::print(stderr, LINE_NUM_FMT("warning"), _strgen.file, _strgen.cur_line, "language is not compiled");
 #endif
 	throw std::exception();
 }
 
 [[noreturn]] void FatalErrorI(const std::string &msg)
 {
-	fmt::print(stderr, LINE_NUM_FMT("FATAL"), _file, _cur_line, msg);
+	fmt::print(stderr, LINE_NUM_FMT("FATAL"), _strgen.file, _strgen.cur_line, msg);
 #ifdef _MSC_VER
-	fmt::print(stderr, LINE_NUM_FMT("warning"), _file, _cur_line, "language is not compiled");
+	fmt::print(stderr, LINE_NUM_FMT("warning"), _strgen.file, _strgen.cur_line, "language is not compiled");
 #endif
 	exit(2);
 }
@@ -91,59 +91,59 @@ struct FileStringReader : StringReader {
 		return result;
 	}
 
-	void HandlePragma(char *str) override;
+	void HandlePragma(char *str, LanguagePackHeader &lang) override;
 
 	void ParseFile() override
 	{
 		this->StringReader::ParseFile();
 
-		if (StrEmpty(_lang.name) || StrEmpty(_lang.own_name) || StrEmpty(_lang.isocode)) {
+		if (StrEmpty(_strgen.lang.name) || StrEmpty(_strgen.lang.own_name) || StrEmpty(_strgen.lang.isocode)) {
 			FatalError("Language must include ##name, ##ownname and ##isocode");
 		}
 	}
 };
 
-void FileStringReader::HandlePragma(char *str)
+void FileStringReader::HandlePragma(char *str, LanguagePackHeader &lang)
 {
 	if (!memcmp(str, "id ", 3)) {
 		this->data.next_string_id = std::strtoul(str + 3, nullptr, 0);
 	} else if (!memcmp(str, "name ", 5)) {
-		strecpy(_lang.name, str + 5);
+		strecpy(lang.name, str + 5);
 	} else if (!memcmp(str, "ownname ", 8)) {
-		strecpy(_lang.own_name, str + 8);
+		strecpy(lang.own_name, str + 8);
 	} else if (!memcmp(str, "isocode ", 8)) {
-		strecpy(_lang.isocode, str + 8);
+		strecpy(lang.isocode, str + 8);
 	} else if (!memcmp(str, "textdir ", 8)) {
 		if (!memcmp(str + 8, "ltr", 3)) {
-			_lang.text_dir = TD_LTR;
+			lang.text_dir = TD_LTR;
 		} else if (!memcmp(str + 8, "rtl", 3)) {
-			_lang.text_dir = TD_RTL;
+			lang.text_dir = TD_RTL;
 		} else {
 			FatalError("Invalid textdir {}", str + 8);
 		}
 	} else if (!memcmp(str, "digitsep ", 9)) {
 		str += 9;
-		strecpy(_lang.digit_group_separator, strcmp(str, "{NBSP}") == 0 ? NBSP : str);
+		strecpy(lang.digit_group_separator, strcmp(str, "{NBSP}") == 0 ? NBSP : str);
 	} else if (!memcmp(str, "digitsepcur ", 12)) {
 		str += 12;
-		strecpy(_lang.digit_group_separator_currency, strcmp(str, "{NBSP}") == 0 ? NBSP : str);
+		strecpy(lang.digit_group_separator_currency, strcmp(str, "{NBSP}") == 0 ? NBSP : str);
 	} else if (!memcmp(str, "decimalsep ", 11)) {
 		str += 11;
-		strecpy(_lang.digit_decimal_separator, strcmp(str, "{NBSP}") == 0 ? NBSP : str);
+		strecpy(lang.digit_decimal_separator, strcmp(str, "{NBSP}") == 0 ? NBSP : str);
 	} else if (!memcmp(str, "winlangid ", 10)) {
 		const char *buf = str + 10;
 		long langid = std::strtol(buf, nullptr, 16);
 		if (langid > UINT16_MAX || langid < 0) {
 			FatalError("Invalid winlangid {}", buf);
 		}
-		_lang.winlangid = static_cast<uint16_t>(langid);
+		lang.winlangid = static_cast<uint16_t>(langid);
 	} else if (!memcmp(str, "grflangid ", 10)) {
 		const char *buf = str + 10;
 		long langid = std::strtol(buf, nullptr, 16);
 		if (langid >= 0x7F || langid < 0) {
 			FatalError("Invalid grflangid {}", buf);
 		}
-		_lang.newgrflangid = static_cast<uint8_t>(langid);
+		lang.newgrflangid = static_cast<uint8_t>(langid);
 	} else if (!memcmp(str, "gender ", 7)) {
 		if (this->master) FatalError("Genders are not allowed in the base translation.");
 		const char *buf = str + 7;
@@ -152,9 +152,9 @@ void FileStringReader::HandlePragma(char *str)
 			auto s = ParseWord(&buf);
 
 			if (!s.has_value()) break;
-			if (_lang.num_genders >= MAX_NUM_GENDERS) FatalError("Too many genders, max {}", MAX_NUM_GENDERS);
-			s->copy(_lang.genders[_lang.num_genders], CASE_GENDER_LEN - 1);
-			_lang.num_genders++;
+			if (lang.num_genders >= MAX_NUM_GENDERS) FatalError("Too many genders, max {}", MAX_NUM_GENDERS);
+			s->copy(lang.genders[lang.num_genders], CASE_GENDER_LEN - 1);
+			lang.num_genders++;
 		}
 	} else if (!memcmp(str, "case ", 5)) {
 		if (this->master) FatalError("Cases are not allowed in the base translation.");
@@ -164,12 +164,12 @@ void FileStringReader::HandlePragma(char *str)
 			auto s = ParseWord(&buf);
 
 			if (!s.has_value()) break;
-			if (_lang.num_cases >= MAX_NUM_CASES) FatalError("Too many cases, max {}", MAX_NUM_CASES);
-			s->copy(_lang.cases[_lang.num_cases], CASE_GENDER_LEN - 1);
-			_lang.num_cases++;
+			if (lang.num_cases >= MAX_NUM_CASES) FatalError("Too many cases, max {}", MAX_NUM_CASES);
+			s->copy(lang.cases[lang.num_cases], CASE_GENDER_LEN - 1);
+			lang.num_cases++;
 		}
 	} else {
-		StringReader::HandlePragma(str);
+		StringReader::HandlePragma(str, lang);
 	}
 }
 
@@ -364,11 +364,11 @@ int CDECL main(int argc, char *argv[])
 				return 0;
 
 			case 't':
-				_annotate_todos = true;
+				_strgen.annotate_todos = true;
 				break;
 
 			case 'w':
-				_show_warnings = true;
+				_strgen.show_warnings = true;
 				break;
 
 			case 'h':
@@ -417,7 +417,7 @@ int CDECL main(int argc, char *argv[])
 			StringData data(TEXT_TAB_END);
 			FileStringReader master_reader(data, input_path, true, false);
 			master_reader.ParseFile();
-			if (_errors != 0) return 1;
+			if (_strgen.errors != 0) return 1;
 
 			/* write strings.h */
 			std::filesystem::path output_path = dest_dir;
@@ -427,7 +427,7 @@ int CDECL main(int argc, char *argv[])
 			HeaderFileWriter writer(output_path);
 			writer.WriteHeader(data);
 			writer.Finalise(data);
-			if (_errors != 0) return 1;
+			if (_strgen.errors != 0) return 1;
 		} else {
 			std::filesystem::path input_path = std::move(src_dir);
 			input_path /= "english.txt";
@@ -443,7 +443,7 @@ int CDECL main(int argc, char *argv[])
 				std::filesystem::path lang_file = argument;
 				FileStringReader translation_reader(data, lang_file, false, lang_file.filename() != "english.txt");
 				translation_reader.ParseFile(); // target file
-				if (_errors != 0) return 1;
+				if (_strgen.errors != 0) return 1;
 
 				/* get the targetfile, strip any directories and append to destination path */
 				std::filesystem::path output_file = dest_dir;
@@ -455,8 +455,8 @@ int CDECL main(int argc, char *argv[])
 				writer.Finalise();
 
 				/* if showing warnings, print a summary of the language */
-				if (_show_warnings) {
-					fmt::print("{} warnings and {} errors for {}\n", _warnings, _errors, output_file);
+				if (_strgen.show_warnings) {
+					fmt::print("{} warnings and {} errors for {}\n", _strgen.warnings, _strgen.errors, output_file);
 				}
 			}
 		}

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -74,7 +74,7 @@ struct StringReader {
 	 * Handle the pragma of the file.
 	 * @param str    The pragma string to parse.
 	 */
-	virtual void HandlePragma(char *str);
+	virtual void HandlePragma(char *str, LanguagePackHeader &lang);
 
 	/**
 	 * Start parsing the file.
@@ -154,10 +154,17 @@ void StrgenErrorI(const std::string &msg);
 #define StrgenFatal(format_string, ...) StrgenFatalI(fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__))
 std::optional<std::string_view> ParseWord(const char **buf);
 
-extern const char *_file;
-extern size_t _cur_line;
-extern size_t _errors, _warnings;
-extern bool _show_warnings, _annotate_todos, _translation;
-extern LanguagePackHeader _lang;
+/** Global state shared between strgen.cpp, game_text.cpp and strgen_base.cpp */
+struct StrgenState {
+	std::string file = "(unknown file)"; ///< The filename of the input, so we can refer to it in errors/warnings
+	size_t cur_line = 0; ///< The current line we're parsing in the input file
+	size_t errors = 0;
+	size_t warnings = 0;
+	bool show_warnings = false;
+	bool annotate_todos = false;
+	bool translation = false; ///< Is the current file actually a translation or not
+	LanguagePackHeader lang; ///< Header information about a language.
+};
+extern StrgenState _strgen;
 
 #endif /* STRGEN_H */

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -51,8 +51,8 @@
 #include "safeguards.h"
 
 
-std::array<std::array<BaseVehicleListWindow::GroupBy, VEH_COMPANY_END>, VLT_END> _grouping{};
-std::array<Sorting, BaseVehicleListWindow::GB_END> _sorting{};
+static std::array<std::array<BaseVehicleListWindow::GroupBy, VEH_COMPANY_END>, VLT_END> _grouping{};
+static std::array<Sorting, BaseVehicleListWindow::GB_END> _sorting{};
 
 static BaseVehicleListWindow::VehicleIndividualSortFunction VehicleNumberSorter;
 static BaseVehicleListWindow::VehicleIndividualSortFunction VehicleNameSorter;

--- a/src/vehicle_gui_base.h
+++ b/src/vehicle_gui_base.h
@@ -164,7 +164,4 @@ struct Sorting {
 	Listing train;
 };
 
-extern std::array<std::array<BaseVehicleListWindow::GroupBy, VEH_COMPANY_END>, VLT_END> _grouping;
-extern std::array<Sorting, BaseVehicleListWindow::GB_END> _sorting;
-
 #endif /* VEHICLE_GUI_BASE_H */


### PR DESCRIPTION
## Motivation / Problem

There are a number of `extern` variables, which have rather generic names without context.
These are prone for name collisions.

## Description

* Turn `extern` into `static`, if possible.
* Rename some `extern` variables.
* Bundle related `extern` variables into structs.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
