### PR TITLE
Fix: NewGRF Global variables 0D, 0E and 1E refer to wrong GRFFile.

### DIFF
--- a/src/newgrf/newgrf_act0_globalvar.cpp
+++ b/src/newgrf/newgrf_act0_globalvar.cpp
@@ -458,11 +458,11 @@ bool GetGlobalVariable(uint8_t param, uint32_t *value, const GRFFile *grffile)
 		}
 
 		case 0x0D: // TTD Version, 00=DOS, 01=Windows
-			*value = _cur.grfconfig->palette & GRFP_USE_MASK;
+			*value = GetGRFConfig(grffile->grfid)->palette & GRFP_USE_MASK;
 			return true;
 
 		case 0x0E: // Y-offset for train sprites
-			*value = _cur.grffile->traininfo_vehicle_pitch;
+			*value = grffile->traininfo_vehicle_pitch;
 			return true;
 
 		case 0x0F: // Rail track type cost factors
@@ -509,7 +509,7 @@ bool GetGlobalVariable(uint8_t param, uint32_t *value, const GRFFile *grffile)
 
 			/* Add the local flags */
 			assert(!bits.Test(GrfMiscBit::TrainWidth32Pixels));
-			if (_cur.grffile->traininfo_vehicle_width == VEHICLEINFO_FULL_VEHICLE_WIDTH) bits.Set(GrfMiscBit::TrainWidth32Pixels);
+			if (grffile->traininfo_vehicle_width == VEHICLEINFO_FULL_VEHICLE_WIDTH) bits.Set(GrfMiscBit::TrainWidth32Pixels);
 
 			*value = bits.base();
 			return true;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

NewGRF has some global variables which are readable from Action 6, 7, 9 and D, and also readable from a Variational Action 2 as a variable.

Variables 0D, 0E and 1E variables should access information from the current NewGRF (the file being loaded, or the file containing the varaction chain being processed), however they access it via GrfProcessingState which is only valid while loading GRFs, after which they always point to the last loaded GRFFile.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, access data of the provided GRFFile directly instead of via GrfProcessingState. For variable 0D, this means there's an extra lookup to find the GRFConfig.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
