### PR TITLE
Codechange: Use unique_ptr to manage ContentInfo lifetime.

### DIFF
--- a/src/ai/ai.hpp
+++ b/src/ai/ai.hpp
@@ -135,8 +135,8 @@ public:
 	static AIScannerLibrary *GetScannerLibrary();
 
 	/** Wrapper function for AIScanner::HasAI */
-	static bool HasAI(const struct ContentInfo *ci, bool md5sum);
-	static bool HasAILibrary(const ContentInfo *ci, bool md5sum);
+	static bool HasAI(const ContentInfo &ci, bool md5sum);
+	static bool HasAILibrary(const ContentInfo &ci, bool md5sum);
 private:
 	static uint frame_counter; ///< Tick counter for the AI code
 	static std::unique_ptr<AIScannerInfo> scanner_info; ///< ScriptScanner instance that is used to find AIs

--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -334,12 +334,12 @@
  * @param md5sum whether to check the MD5 checksum
  * @return true iff we have an AI (library) matching.
  */
-/* static */ bool AI::HasAI(const ContentInfo *ci, bool md5sum)
+/* static */ bool AI::HasAI(const ContentInfo &ci, bool md5sum)
 {
 	return AI::scanner_info->HasScript(ci, md5sum);
 }
 
-/* static */ bool AI::HasAILibrary(const ContentInfo *ci, bool md5sum)
+/* static */ bool AI::HasAILibrary(const ContentInfo &ci, bool md5sum)
 {
 	return AI::scanner_library->HasScript(ci, md5sum);
 }

--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -211,7 +211,7 @@ public:
 	 * @param md5sum whether to check the MD5 checksum
 	 * @return true iff we have an set matching.
 	 */
-	static bool HasSet(const ContentInfo *ci, bool md5sum);
+	static bool HasSet(const ContentInfo &ci, bool md5sum);
 };
 
 /**
@@ -222,6 +222,6 @@ public:
  * @return The filename of the first file of the base set, or \c nullptr if there is no match.
  */
 template <class Tbase_set>
-const char *TryGetBaseSetFile(const ContentInfo *ci, bool md5sum, const Tbase_set *s);
+const char *TryGetBaseSetFile(const ContentInfo &ci, bool md5sum, const Tbase_set *s);
 
 #endif /* BASE_MEDIA_BASE_H */

--- a/src/base_media_func.h
+++ b/src/base_media_func.h
@@ -319,25 +319,25 @@ template <class Tbase_set>
 
 #include "network/core/tcp_content_type.h"
 
-template <class Tbase_set> const char *TryGetBaseSetFile(const ContentInfo *ci, bool md5sum, const Tbase_set *s)
+template <class Tbase_set> const char *TryGetBaseSetFile(const ContentInfo &ci, bool md5sum, const Tbase_set *s)
 {
 	for (; s != nullptr; s = s->next) {
 		if (s->GetNumMissing() != 0) continue;
 
-		if (s->shortname != ci->unique_id) continue;
+		if (s->shortname != ci.unique_id) continue;
 		if (!md5sum) return s->files[0].filename.c_str();
 
 		MD5Hash md5;
 		for (const auto &file : s->files) {
 			md5 ^= file.hash;
 		}
-		if (md5 == ci->md5sum) return s->files[0].filename.c_str();
+		if (md5 == ci.md5sum) return s->files[0].filename.c_str();
 	}
 	return nullptr;
 }
 
 template <class Tbase_set>
-/* static */ bool BaseMedia<Tbase_set>::HasSet(const ContentInfo *ci, bool md5sum)
+/* static */ bool BaseMedia<Tbase_set>::HasSet(const ContentInfo &ci, bool md5sum)
 {
 	return (TryGetBaseSetFile(ci, md5sum, BaseMedia<Tbase_set>::available_sets) != nullptr) ||
 			(TryGetBaseSetFile(ci, md5sum, BaseMedia<Tbase_set>::duplicate_sets) != nullptr);

--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -273,10 +273,10 @@ public:
 		_network_content_client.RequestContentList(CONTENT_TYPE_BASE_GRAPHICS);
 	}
 
-	void OnReceiveContentInfo(const ContentInfo *ci) override
+	void OnReceiveContentInfo(const ContentInfo &ci) override
 	{
 		/* And once the meta data is received, start downloading it. */
-		_network_content_client.Select(ci->id);
+		_network_content_client.Select(ci.id);
 		new BootstrapContentDownloadStatusWindow();
 		this->Close();
 	}
@@ -320,19 +320,19 @@ public:
 		_network_content_client.RequestContentList(CONTENT_TYPE_BASE_GRAPHICS);
 	}
 
-	void OnReceiveContentInfo(const ContentInfo *ci) override
+	void OnReceiveContentInfo(const ContentInfo &ci) override
 	{
 		if (this->downloading) return;
 
 		/* And once the metadata is received, start downloading it. */
-		_network_content_client.Select(ci->id);
+		_network_content_client.Select(ci.id);
 		_network_content_client.DownloadSelectedContent(this->total_files, this->total_bytes);
 		this->downloading = true;
 
 		EM_ASM({ if (window["openttd_bootstrap"]) openttd_bootstrap($0, $1); }, this->downloaded_bytes, this->total_bytes);
 	}
 
-	void OnDownloadProgress(const ContentInfo *, int bytes) override
+	void OnDownloadProgress(const ContentInfo &, int bytes) override
 	{
 		/* A negative value means we are resetting; for example, when retrying or using a fallback. */
 		if (bytes < 0) {

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2171,9 +2171,9 @@ DEF_CONSOLE_CMD(ConContent)
 		if (argc <= 2) {
 			/* List selected content */
 			IConsolePrint(CC_WHITE, "id, type, state, name");
-			for (ConstContentIterator iter = _network_content_client.Begin(); iter != _network_content_client.End(); iter++) {
-				if ((*iter)->state != ContentInfo::SELECTED && (*iter)->state != ContentInfo::AUTOSELECTED) continue;
-				OutputContentState(**iter);
+			for (const ContentInfo &ci : _network_content_client.Info()) {
+				if (ci.state != ContentInfo::SELECTED && ci.state != ContentInfo::AUTOSELECTED) continue;
+				OutputContentState(ci);
 			}
 		} else if (StrEqualsIgnoreCase(argv[2], "all")) {
 			/* The intention of this function was that you could download
@@ -2204,9 +2204,9 @@ DEF_CONSOLE_CMD(ConContent)
 
 	if (StrEqualsIgnoreCase(argv[1], "state")) {
 		IConsolePrint(CC_WHITE, "id, type, state, name");
-		for (ConstContentIterator iter = _network_content_client.Begin(); iter != _network_content_client.End(); iter++) {
-			if (argc > 2 && !StrContainsIgnoreCase((*iter)->name, argv[2])) continue;
-			OutputContentState(**iter);
+		for (const ContentInfo &ci : _network_content_client.Info()) {
+			if (argc > 2 && !StrContainsIgnoreCase(ci.name, argv[2])) continue;
+			OutputContentState(ci);
 		}
 		return true;
 	}

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2128,14 +2128,14 @@ struct ConsoleContentCallback : public ContentCallback {
  * Outputs content state information to console
  * @param ci the content info
  */
-static void OutputContentState(const ContentInfo *const ci)
+static void OutputContentState(const ContentInfo &ci)
 {
 	static const char * const types[] = { "Base graphics", "NewGRF", "AI", "AI library", "Scenario", "Heightmap", "Base sound", "Base music", "Game script", "GS library" };
 	static_assert(lengthof(types) == CONTENT_TYPE_END - CONTENT_TYPE_BEGIN);
 	static const char * const states[] = { "Not selected", "Selected", "Dep Selected", "Installed", "Unknown" };
 	static const TextColour state_to_colour[] = { CC_COMMAND, CC_INFO, CC_INFO, CC_WHITE, CC_ERROR };
 
-	IConsolePrint(state_to_colour[ci->state], "{}, {}, {}, {}, {:08X}, {}", ci->id, types[ci->type - 1], states[ci->state], ci->name, ci->unique_id, FormatArrayAsHex(ci->md5sum));
+	IConsolePrint(state_to_colour[ci.state], "{}, {}, {}, {}, {:08X}, {}", ci.id, types[ci.type - 1], states[ci.state], ci.name, ci.unique_id, FormatArrayAsHex(ci.md5sum));
 }
 
 DEF_CONSOLE_CMD(ConContent)
@@ -2173,7 +2173,7 @@ DEF_CONSOLE_CMD(ConContent)
 			IConsolePrint(CC_WHITE, "id, type, state, name");
 			for (ConstContentIterator iter = _network_content_client.Begin(); iter != _network_content_client.End(); iter++) {
 				if ((*iter)->state != ContentInfo::SELECTED && (*iter)->state != ContentInfo::AUTOSELECTED) continue;
-				OutputContentState(*iter);
+				OutputContentState(**iter);
 			}
 		} else if (StrEqualsIgnoreCase(argv[2], "all")) {
 			/* The intention of this function was that you could download
@@ -2206,7 +2206,7 @@ DEF_CONSOLE_CMD(ConContent)
 		IConsolePrint(CC_WHITE, "id, type, state, name");
 		for (ConstContentIterator iter = _network_content_client.Begin(); iter != _network_content_client.End(); iter++) {
 			if (argc > 2 && !StrContainsIgnoreCase((*iter)->name, argv[2])) continue;
-			OutputContentState(*iter);
+			OutputContentState(**iter);
 		}
 		return true;
 	}

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -680,13 +680,13 @@ static ScenarioScanner _scanner;
  * @param md5sum Whether to look at the md5sum or the id.
  * @return The filename of the file, else \c nullptr.
  */
-const char *FindScenario(const ContentInfo *ci, bool md5sum)
+const char *FindScenario(const ContentInfo &ci, bool md5sum)
 {
 	_scanner.Scan(false);
 
 	for (ScenarioIdentifier &id : _scanner) {
-		if (md5sum ? (id.md5sum == ci->md5sum)
-		           : (id.scenid == ci->unique_id)) {
+		if (md5sum ? (id.md5sum == ci.md5sum)
+		           : (id.scenid == ci.unique_id)) {
 			return id.filename.c_str();
 		}
 	}
@@ -700,7 +700,7 @@ const char *FindScenario(const ContentInfo *ci, bool md5sum)
  * @param md5sum Whether to look at the md5sum or the id.
  * @return True iff we've got the scenario.
  */
-bool HasScenario(const ContentInfo *ci, bool md5sum)
+bool HasScenario(const ContentInfo &ci, bool md5sum)
 {
 	return (FindScenario(ci, md5sum) != nullptr);
 }

--- a/src/fios.h
+++ b/src/fios.h
@@ -121,7 +121,7 @@ std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation 
 std::tuple<FiosType, std::string> FiosGetHeightmapListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext);
 
 void ScanScenarios();
-const char *FindScenario(const ContentInfo *ci, bool md5sum);
+const char *FindScenario(const ContentInfo &ci, bool md5sum);
 
 /**
  * A savegame name automatically numbered.

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -101,8 +101,8 @@ public:
 	static void ResetInstance();
 
 	/** Wrapper function for GameScanner::HasGame */
-	static bool HasGame(const struct ContentInfo *ci, bool md5sum);
-	static bool HasGameLibrary(const ContentInfo *ci, bool md5sum);
+	static bool HasGame(const ContentInfo &ci, bool md5sum);
+	static bool HasGameLibrary(const ContentInfo &ci, bool md5sum);
 	/** Gets the ScriptScanner instance that is used to find Game scripts */
 	static GameScannerInfo *GetScannerInfo();
 	/** Gets the ScriptScanner instance that is used to find Game Libraries */

--- a/src/game/game_core.cpp
+++ b/src/game/game_core.cpp
@@ -242,12 +242,12 @@
  * @param md5sum whether to check the MD5 checksum
  * @return true iff we have an Game (library) matching.
  */
-/* static */ bool Game::HasGame(const ContentInfo *ci, bool md5sum)
+/* static */ bool Game::HasGame(const ContentInfo &ci, bool md5sum)
 {
 	return Game::scanner_info->HasScript(ci, md5sum);
 }
 
-/* static */ bool Game::HasGameLibrary(const ContentInfo *ci, bool md5sum)
+/* static */ bool Game::HasGameLibrary(const ContentInfo &ci, bool md5sum)
 {
 	return Game::scanner_library->HasScript(ci, md5sum);
 }

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -63,16 +63,16 @@ std::optional<std::string> ContentInfo::GetTextfile(TextfileType type) const
 	switch (this->type) {
 		default: NOT_REACHED();
 		case CONTENT_TYPE_AI:
-			tmp = AI::GetScannerInfo()->FindMainScript(this, true);
+			tmp = AI::GetScannerInfo()->FindMainScript(*this, true);
 			break;
 		case CONTENT_TYPE_AI_LIBRARY:
-			tmp = AI::GetScannerLibrary()->FindMainScript(this, true);
+			tmp = AI::GetScannerLibrary()->FindMainScript(*this, true);
 			break;
 		case CONTENT_TYPE_GAME:
-			tmp = Game::GetScannerInfo()->FindMainScript(this, true);
+			tmp = Game::GetScannerInfo()->FindMainScript(*this, true);
 			break;
 		case CONTENT_TYPE_GAME_LIBRARY:
-			tmp = Game::GetScannerLibrary()->FindMainScript(this, true);
+			tmp = Game::GetScannerLibrary()->FindMainScript(*this, true);
 			break;
 		case CONTENT_TYPE_NEWGRF: {
 			const GRFConfig *gc = FindGRFConfig(std::byteswap(this->unique_id), FGCM_EXACT, &this->md5sum);
@@ -80,17 +80,17 @@ std::optional<std::string> ContentInfo::GetTextfile(TextfileType type) const
 			break;
 		}
 		case CONTENT_TYPE_BASE_GRAPHICS:
-			tmp = TryGetBaseSetFile(this, true, BaseGraphics::GetAvailableSets());
+			tmp = TryGetBaseSetFile(*this, true, BaseGraphics::GetAvailableSets());
 			break;
 		case CONTENT_TYPE_BASE_SOUNDS:
-			tmp = TryGetBaseSetFile(this, true, BaseSounds::GetAvailableSets());
+			tmp = TryGetBaseSetFile(*this, true, BaseSounds::GetAvailableSets());
 			break;
 		case CONTENT_TYPE_BASE_MUSIC:
-			tmp = TryGetBaseSetFile(this, true, BaseMusic::GetAvailableSets());
+			tmp = TryGetBaseSetFile(*this, true, BaseMusic::GetAvailableSets());
 			break;
 		case CONTENT_TYPE_SCENARIO:
 		case CONTENT_TYPE_HEIGHTMAP:
-			tmp = FindScenario(this, true);
+			tmp = FindScenario(*this, true);
 			break;
 	}
 	if (tmp == nullptr) return std::nullopt;

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -707,25 +707,6 @@ void ClientNetworkContentSocketHandler::OnReceiveData(std::unique_ptr<char[]> da
 #undef check_and_terminate
 }
 
-/**
- * Create a socket handler to handle the connection.
- */
-ClientNetworkContentSocketHandler::ClientNetworkContentSocketHandler() :
-	NetworkContentSocketHandler(),
-	http_response_index(-2),
-	cur_file(std::nullopt),
-	cur_info(nullptr),
-	is_connecting(false),
-	is_cancelled(false)
-{
-	this->last_activity = std::chrono::steady_clock::now();
-}
-
-/** Clear up the mess ;) */
-ClientNetworkContentSocketHandler::~ClientNetworkContentSocketHandler()
-{
-}
-
 /** Connect to the content server. */
 class NetworkContentConnecter : public TCPConnecter {
 public:

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -63,18 +63,18 @@ struct ContentCallback {
 class ClientNetworkContentSocketHandler : public NetworkContentSocketHandler, ContentCallback, HTTPCallback {
 protected:
 	using ContentIDList = std::vector<ContentID>; ///< List of content IDs to (possibly) select.
-	std::vector<ContentCallback *> callbacks;     ///< Callbacks to notify "the world"
-	ContentIDList requested;                      ///< ContentIDs we already requested (so we don't do it again)
-	ContentVector infos;                          ///< All content info we received
+	std::vector<ContentCallback *> callbacks; ///< Callbacks to notify "the world"
+	ContentIDList requested; ///< ContentIDs we already requested (so we don't do it again)
+	ContentVector infos; ///< All content info we received
 	std::unordered_multimap<ContentID, ContentID> reverse_dependency_map; ///< Content reverse dependency map
-	std::vector<char> http_response;              ///< The HTTP response to the requests we've been doing
-	int http_response_index;                      ///< Where we are, in the response, with handling it
+	std::vector<char> http_response; ///< The HTTP response to the requests we've been doing
+	int http_response_index = -2; ///< Where we are, in the response, with handling it
 
 	std::optional<FileHandle> cur_file; ///< Currently downloaded file
 	std::unique_ptr<ContentInfo> cur_info; ///< Information about the currently downloaded file
-	bool is_connecting;    ///< Whether we're connecting
-	bool is_cancelled;     ///< Whether the download has been cancelled
-	std::chrono::steady_clock::time_point last_activity;  ///< The last time there was network activity
+	bool is_connecting = false; ///< Whether we're connecting
+	bool is_cancelled = false; ///< Whether the download has been cancelled
+	std::chrono::steady_clock::time_point last_activity = std::chrono::steady_clock::now(); ///< The last time there was network activity
 
 	friend class NetworkContentConnecter;
 
@@ -102,9 +102,6 @@ protected:
 public:
 	/** The idle timeout; when to close the connection because it's idle. */
 	static constexpr std::chrono::seconds IDLE_TIMEOUT = std::chrono::seconds(60);
-
-	ClientNetworkContentSocketHandler();
-	~ClientNetworkContentSocketHandler();
 
 	void Connect();
 	void SendReceive();

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -42,14 +42,14 @@ struct ContentCallback {
 	 * We received a content info.
 	 * @param ci the content info
 	 */
-	virtual void OnReceiveContentInfo([[maybe_unused]] const ContentInfo *ci) {}
+	virtual void OnReceiveContentInfo([[maybe_unused]] const ContentInfo &ci) {}
 
 	/**
 	 * We have progress in the download of a file
 	 * @param ci the content info of the file
 	 * @param bytes the number of bytes downloaded since the previous call
 	 */
-	virtual void OnDownloadProgress([[maybe_unused]] const ContentInfo *ci, [[maybe_unused]] int bytes) {}
+	virtual void OnDownloadProgress([[maybe_unused]] const ContentInfo &ci, [[maybe_unused]] int bytes) {}
 
 	/**
 	 * We have finished downloading a file
@@ -90,8 +90,8 @@ protected:
 
 	void OnConnect(bool success) override;
 	void OnDisconnect() override;
-	void OnReceiveContentInfo(const ContentInfo *ci) override;
-	void OnDownloadProgress(const ContentInfo *ci, int bytes) override;
+	void OnReceiveContentInfo(const ContentInfo &ci) override;
+	void OnDownloadProgress(const ContentInfo &ci, int bytes) override;
 	void OnDownloadComplete(ContentID cid) override;
 
 	void OnFailure() override;
@@ -126,11 +126,11 @@ public:
 	void SelectAll();
 	void SelectUpgrade();
 	void UnselectAll();
-	void ToggleSelectedState(const ContentInfo *ci);
+	void ToggleSelectedState(const ContentInfo &ci);
 
-	void ReverseLookupDependency(ConstContentVector &parents, const ContentInfo *child) const;
+	void ReverseLookupDependency(ConstContentVector &parents, const ContentInfo &child) const;
 	void ReverseLookupTreeDependency(ConstContentVector &tree, const ContentInfo *child) const;
-	void CheckDependencyState(const ContentInfo *ci);
+	void CheckDependencyState(const ContentInfo &ci);
 
 	/** Get the number of content items we know locally. */
 	uint Length() const { return (uint)this->infos.size(); }

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -410,9 +410,9 @@ class NetworkContentListWindow : public Window, ContentCallback {
 
 		bool all_available = true;
 
-		for (ConstContentIterator iter = _network_content_client.Begin(); iter != _network_content_client.End(); iter++) {
-			if ((*iter)->state == ContentInfo::DOES_NOT_EXIST) all_available = false;
-			this->content.push_back(*iter);
+		for (const ContentInfo &ci : _network_content_client.Info()) {
+			if (ci.state == ContentInfo::DOES_NOT_EXIST) all_available = false;
+			this->content.push_back(&ci);
 		}
 
 		this->SetWidgetDisabledState(WID_NCL_SEARCH_EXTERNAL, this->auto_select && all_available);
@@ -732,13 +732,11 @@ public:
 			std::string buf;
 			for (auto &cid : this->selected->dependencies) {
 				/* Try to find the dependency */
-				ConstContentIterator iter = _network_content_client.Begin();
-				for (; iter != _network_content_client.End(); iter++) {
-					const ContentInfo *ci = *iter;
-					if (ci->id != cid) continue;
+				for (const ContentInfo &ci : _network_content_client.Info()) {
+					if (ci.id != cid) continue;
 
 					if (!buf.empty()) buf += list_separator;
-					buf += (*iter)->name;
+					buf += ci.name;
 					break;
 				}
 			}
@@ -1138,9 +1136,5 @@ void ShowNetworkContentListWindow(ContentVector *cv, ContentType type1, ContentT
 		GetEncodedString(STR_CONTENT_NO_ZLIB),
 		GetEncodedString(STR_CONTENT_NO_ZLIB_SUB),
 		WL_ERROR);
-	/* Connection failed... clean up the mess */
-	if (cv != nullptr) {
-		for (ContentInfo *ci : *cv) delete ci;
-	}
 #endif /* WITH_ZLIB */
 }

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -165,11 +165,11 @@ void BaseNetworkContentDownloadStatusWindow::DrawWidget(const Rect &r, WidgetID 
 	}
 }
 
-void BaseNetworkContentDownloadStatusWindow::OnDownloadProgress(const ContentInfo *ci, int bytes)
+void BaseNetworkContentDownloadStatusWindow::OnDownloadProgress(const ContentInfo &ci, int bytes)
 {
-	if (ci->id != this->cur_id) {
-		this->name = ci->filename;
-		this->cur_id = ci->id;
+	if (ci.id != this->cur_id) {
+		this->name = ci.filename;
+		this->cur_id = ci.id;
 		this->downloaded_files++;
 	}
 
@@ -298,10 +298,10 @@ public:
 		}
 	}
 
-	void OnDownloadProgress(const ContentInfo *ci, int bytes) override
+	void OnDownloadProgress(const ContentInfo &ci, int bytes) override
 	{
 		BaseNetworkContentDownloadStatusWindow::OnDownloadProgress(ci, bytes);
-		include(this->receivedTypes, ci->type);
+		include(this->receivedTypes, ci.type);
 
 		/* When downloading is finished change cancel in ok */
 		if (this->downloaded_bytes == this->total_bytes) {
@@ -792,7 +792,7 @@ public:
 
 				const NWidgetBase *checkbox = this->GetWidget<NWidgetBase>(WID_NCL_CHECKBOX);
 				if (click_count > 1 || IsInsideBS(pt.x, checkbox->pos_x, checkbox->current_x)) {
-					_network_content_client.ToggleSelectedState(this->selected);
+					_network_content_client.ToggleSelectedState(*this->selected);
 					this->content.ForceResort();
 					this->content.ForceRebuild();
 				}
@@ -870,7 +870,7 @@ public:
 				case WKC_RETURN:
 					if (keycode == WKC_RETURN || !IsWidgetFocused(WID_NCL_FILTER)) {
 						if (this->selected != nullptr) {
-							_network_content_client.ToggleSelectedState(this->selected);
+							_network_content_client.ToggleSelectedState(*this->selected);
 							this->content.ForceResort();
 							this->InvalidateData();
 						}
@@ -925,9 +925,9 @@ public:
 		this->vscroll->SetCapacityFromWidget(this, WID_NCL_MATRIX);
 	}
 
-	void OnReceiveContentInfo(const ContentInfo *rci) override
+	void OnReceiveContentInfo(const ContentInfo &rci) override
 	{
-		if (this->auto_select && !rci->IsSelected()) _network_content_client.ToggleSelectedState(rci);
+		if (this->auto_select && !rci.IsSelected()) _network_content_client.ToggleSelectedState(rci);
 		this->content.ForceRebuild();
 		this->InvalidateData(0, false);
 	}

--- a/src/network/network_content_gui.h
+++ b/src/network/network_content_gui.h
@@ -35,7 +35,7 @@ public:
 	void Close([[maybe_unused]] int data = 0) override;
 	void UpdateWidgetSize(WidgetID widget, Dimension &size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension &fill, [[maybe_unused]] Dimension &resize) override;
 	void DrawWidget(const Rect &r, WidgetID widget) const override;
-	void OnDownloadProgress(const ContentInfo *ci, int bytes) override;
+	void OnDownloadProgress(const ContentInfo &ci, int bytes) override;
 };
 
 void BuildContentTypeStringList();

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1517,13 +1517,13 @@ void ShowMissingContentWindow(const GRFConfigList &list)
 	for (const auto &c : list) {
 		if (c->status != GCS_NOT_FOUND && !c->flags.Test(GRFConfigFlag::Compatible)) continue;
 
-		ContentInfo *ci = new ContentInfo();
+		auto ci = std::make_unique<ContentInfo>();
 		ci->type = CONTENT_TYPE_NEWGRF;
 		ci->state = ContentInfo::DOES_NOT_EXIST;
 		ci->name = c->GetName();
 		ci->unique_id = std::byteswap(c->ident.grfid);
 		ci->md5sum = c->flags.Test(GRFConfigFlag::Compatible) ? c->original_md5sum : c->ident.md5sum;
-		cv.push_back(ci);
+		cv.push_back(std::move(ci));
 	}
 	ShowNetworkContentListWindow(cv.empty() ? nullptr : &cv, CONTENT_TYPE_NEWGRF);
 }

--- a/src/script/script_scanner.cpp
+++ b/src/script/script_scanner.cpp
@@ -195,13 +195,13 @@ struct ScriptFileChecksumCreator : FileScanner {
  * @param info The script to get the shortname and md5 sum from.
  * @return True iff they're the same.
  */
-static bool IsSameScript(const ContentInfo *ci, bool md5sum, ScriptInfo *info, Subdirectory dir)
+static bool IsSameScript(const ContentInfo &ci, bool md5sum, ScriptInfo *info, Subdirectory dir)
 {
 	uint32_t id = 0;
 	const char *str = info->GetShortName().c_str();
 	for (int j = 0; j < 4 && *str != '\0'; j++, str++) id |= *str << (8 * j);
 
-	if (id != ci->unique_id) return false;
+	if (id != ci.unique_id) return false;
 	if (!md5sum) return true;
 
 	ScriptFileChecksumCreator checksum(dir);
@@ -229,10 +229,10 @@ static bool IsSameScript(const ContentInfo *ci, bool md5sum, ScriptInfo *info, S
 		checksum.Scan(".nut", path);
 	}
 
-	return ci->md5sum == checksum.md5sum;
+	return ci.md5sum == checksum.md5sum;
 }
 
-bool ScriptScanner::HasScript(const ContentInfo *ci, bool md5sum)
+bool ScriptScanner::HasScript(const ContentInfo &ci, bool md5sum)
 {
 	for (const auto &item : this->info_list) {
 		if (IsSameScript(ci, md5sum, item.second, this->GetDirectory())) return true;
@@ -240,7 +240,7 @@ bool ScriptScanner::HasScript(const ContentInfo *ci, bool md5sum)
 	return false;
 }
 
-const char *ScriptScanner::FindMainScript(const ContentInfo *ci, bool md5sum)
+const char *ScriptScanner::FindMainScript(const ContentInfo &ci, bool md5sum)
 {
 	for (const auto &item : this->info_list) {
 		if (IsSameScript(ci, md5sum, item.second, this->GetDirectory())) return item.second->GetMainScript().c_str();

--- a/src/script/script_scanner.hpp
+++ b/src/script/script_scanner.hpp
@@ -66,7 +66,7 @@ public:
 	 * @param md5sum Whether to check the MD5 checksum.
 	 * @return True iff we have a script matching.
 	 */
-	bool HasScript(const struct ContentInfo *ci, bool md5sum);
+	bool HasScript(const struct ContentInfo &ci, bool md5sum);
 
 	/**
 	 * Find a script of a #ContentInfo
@@ -74,7 +74,7 @@ public:
 	 * @param md5sum Whether to check the MD5 checksum.
 	 * @return A filename of a file of the content, else \c nullptr.
 	 */
-	const char *FindMainScript(const ContentInfo *ci, bool md5sum);
+	const char *FindMainScript(const ContentInfo &ci, bool md5sum);
 
 	bool AddFile(const std::string &filename, size_t basepath_length, const std::string &tar_filename) override;
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

The list of `ContentInfo` is stored as a vector of raw pointers, manually managed by new/delete, requiring manual clean up.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Change to a vector of unique_ptrs instead, to avoid manual management.

Smart pointers are used instead of a straight vector as the network content window maintains its own sorted list of content which references each element.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
