### PR TITLE
Change: Queue individual content ID requests to allow batching.

### DIFF
--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -65,6 +65,7 @@ protected:
 	using ContentIDList = std::vector<ContentID>; ///< List of content IDs to (possibly) select.
 	std::vector<ContentCallback *> callbacks; ///< Callbacks to notify "the world"
 	ContentIDList requested; ///< ContentIDs we already requested (so we don't do it again)
+	ContentIDList queued; ///< ContentID queue to be requested.
 	ContentVector infos; ///< All content info we received
 	std::unordered_multimap<ContentID, ContentID> reverse_dependency_map; ///< Content reverse dependency map
 	std::vector<char> http_response; ///< The HTTP response to the requests we've been doing
@@ -109,10 +110,11 @@ public:
 	void Cancel();
 
 	void RequestContentList(ContentType type);
-	void RequestContentList(uint count, const ContentID *content_ids);
+	void RequestContentList(std::span<const ContentID> content_ids);
 	void RequestContentList(ContentVector *cv, bool send_md5sum = true);
 
 	void DownloadSelectedContent(uint &files, uint &bytes, bool fallback = false);
+	void RequestQueuedContentInfo();
 
 	void Select(ContentID cid);
 	void Unselect(ContentID cid);

--- a/src/timer/timer_window.cpp
+++ b/src/timer/timer_window.cpp
@@ -43,8 +43,8 @@ void TimeoutTimer<TimerWindow>::Elapsed(TimerWindow::TElapsed delta)
 	this->storage.elapsed += delta;
 
 	if (this->storage.elapsed >= this->period) {
-		this->callback();
 		this->fired = true;
+		this->callback();
 	}
 }
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

#13987 removed unused code to send a list content ids to receive information for.

@LordAro suggested we should instead be sending multiple content ids.

While investigating this I found that we actually request content by id for anything we haven't seen yet, even includes items that will be received via the initial content request, but haven't yet. That data will therefore be requested and received multiple times, which means on a slow connection it could end up making more requests and bogging down.

This convinced me that a little effort to actually batch ids is worthwhile.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead of immediately sending a single content id, add the content id to a queue, and trigger an interval timer to send it in the future. As each addition will retrigger, this means that the timer will actually only trigger after the last content id is added to the queue.

Additionally, when the timer is triggered, it checks to see if we have finished receiving content. If not, this allows for more ids to be queued and batched. The timer is triggered if this happens.

When making the request, the content id queue may now contain ids that have since been received. These are removed because we don't need them now.

Finally the queue is actually sent to request the content. And if any of the freshly received content also requires more content info to be downloaded, that goes back into the content id queue list.

More complex than #13987 but potentially more worthwhile.

This PR builds on top of #13989.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
