### PR TITLE
Fix: Make GrfMsg() behave like Debug() when not loading NewGRFs.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -87,7 +87,11 @@ ReferenceThroughBaseContainer<std::vector<GRFTempEngineData>> _gted;  ///< Tempo
  */
 void GrfMsgI(int severity, const std::string &msg)
 {
-	Debug(grf, severity, "[{}:{}] {}", _cur_gps.grfconfig->filename, _cur_gps.nfo_line, msg);
+	if (_cur_gps.grfconfig == nullptr) {
+		Debug(grf, severity, "{}", msg);
+	} else {
+		Debug(grf, severity, "[{}:{}] {}", _cur_gps.grfconfig->filename, _cur_gps.nfo_line, msg);
+	}
 }
 
 /**
@@ -371,6 +375,7 @@ void GRFUnsafe(ByteReader &)
 /** Reset and clear all NewGRFs */
 static void ResetNewGRF()
 {
+	_cur_gps.grfconfig = nullptr;
 	_cur_gps.grffile = nullptr;
 	_grf_files.clear();
 
@@ -1822,6 +1827,10 @@ void LoadNewGRF(SpriteID load_index, uint num_baseset)
 			}
 		}
 	}
+
+	/* We've finished reading files. */
+	_cur_gps.grfconfig = nullptr;
+	_cur_gps.grffile = nullptr;
 
 	/* Pseudo sprite processing is finished; free temporary stuff */
 	_cur_gps.ClearDataForNextFile();


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

GrfMsg() outputs the currently loading NewGRF and current line/sprite number. This is invalid when not NewGRFs are not actually being loaded.

This could potentially lead to reading from an invalid pointer.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Reset the `GrfProcessingState`'s current `grfconfig` and `grffile` when finished loading, and test for `nullptr` in `GrfMsg()`

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Generally `GrfMsg()` just shouldn't be called if it's not appropriate and `Debug()` should be used, but there are some places where a codepath is shared.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
