### PR TITLE
Use StringConsumer for parsing translation files

### DIFF
--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -267,7 +267,7 @@ static void ExtractStringParams(const StringData &data, StringParamsList &params
 
 		if (ls != nullptr) {
 			StringParams &param = params.emplace_back();
-			ParsedCommandStruct pcs = ExtractCommandString(ls->english.c_str(), false);
+			ParsedCommandStruct pcs = ExtractCommandString(ls->english, false);
 
 			for (auto it = pcs.consuming_commands.begin(); it != pcs.consuming_commands.end(); it++) {
 				if (*it == nullptr) {

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -146,10 +146,10 @@ void FileStringReader::HandlePragma(char *str, LanguagePackHeader &lang)
 		lang.newgrflangid = static_cast<uint8_t>(langid);
 	} else if (!memcmp(str, "gender ", 7)) {
 		if (this->master) FatalError("Genders are not allowed in the base translation.");
-		const char *buf = str + 7;
+		StringConsumer consumer(std::string_view(str + 7));
 
 		for (;;) {
-			auto s = ParseWord(&buf);
+			auto s = ParseWord(consumer);
 
 			if (!s.has_value()) break;
 			if (lang.num_genders >= MAX_NUM_GENDERS) FatalError("Too many genders, max {}", MAX_NUM_GENDERS);
@@ -158,10 +158,10 @@ void FileStringReader::HandlePragma(char *str, LanguagePackHeader &lang)
 		}
 	} else if (!memcmp(str, "case ", 5)) {
 		if (this->master) FatalError("Cases are not allowed in the base translation.");
-		const char *buf = str + 5;
+		StringConsumer consumer(std::string_view(str + 5));
 
 		for (;;) {
-			auto s = ParseWord(&buf);
+			auto s = ParseWord(consumer);
 
 			if (!s.has_value()) break;
 			if (lang.num_cases >= MAX_NUM_CASES) FatalError("Too many cases, max {}", MAX_NUM_CASES);

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -10,6 +10,7 @@
 #ifndef STRGEN_H
 #define STRGEN_H
 
+#include "../core/string_consumer.hpp"
 #include "../language.h"
 #include "../3rdparty/fmt/format.h"
 
@@ -144,7 +145,7 @@ struct ParsedCommandStruct {
 };
 
 const CmdStruct *TranslateCmdForCompare(const CmdStruct *a);
-ParsedCommandStruct ExtractCommandString(const char *s, bool warnings);
+ParsedCommandStruct ExtractCommandString(std::string_view s, bool warnings);
 
 void StrgenWarningI(const std::string &msg);
 void StrgenErrorI(const std::string &msg);
@@ -152,7 +153,7 @@ void StrgenErrorI(const std::string &msg);
 #define StrgenWarning(format_string, ...) StrgenWarningI(fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__))
 #define StrgenError(format_string, ...) StrgenErrorI(fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__))
 #define StrgenFatal(format_string, ...) StrgenFatalI(fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__))
-std::optional<std::string_view> ParseWord(const char **buf);
+std::optional<std::string_view> ParseWord(StringConsumer &consumer);
 
 /** Global state shared between strgen.cpp, game_text.cpp and strgen_base.cpp */
 struct StrgenState {

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -22,7 +22,7 @@ struct Case {
 	uint8_t caseidx;       ///< The index of the case.
 	std::string string; ///< The translation of the case.
 
-	Case(uint8_t caseidx, const std::string &string);
+	Case(uint8_t caseidx, std::string_view string);
 };
 
 /** Information about a single string. */
@@ -34,7 +34,7 @@ struct LangString {
 	size_t line;            ///< Line of string in source-file.
 	std::vector<Case> translated_cases; ///< Cases of the translation.
 
-	LangString(const std::string &name, const std::string &english, size_t index, size_t line);
+	LangString(std::string_view name, std::string_view english, size_t index, size_t line);
 	void FreeTranslation();
 };
 
@@ -63,7 +63,7 @@ struct StringReader {
 
 	StringReader(StringData &data, const std::string &file, bool master, bool translation);
 	virtual ~StringReader() = default;
-	void HandleString(char *str);
+	void HandleString(std::string_view str);
 
 	/**
 	 * Read a single line from the source of strings.
@@ -75,7 +75,7 @@ struct StringReader {
 	 * Handle the pragma of the file.
 	 * @param str    The pragma string to parse.
 	 */
-	virtual void HandlePragma(char *str, LanguagePackHeader &lang);
+	virtual void HandlePragma(std::string_view str, LanguagePackHeader &lang);
 
 	/**
 	 * Start parsing the file.

--- a/src/table/strgen_tables.h
+++ b/src/table/strgen_tables.h
@@ -17,7 +17,7 @@ enum class CmdFlag : uint8_t {
 using CmdFlags = EnumBitSet<CmdFlag, uint8_t>;
 
 class StringBuilder;
-typedef void (*ParseCmdProc)(StringBuilder &builder, const char *buf, char32_t value);
+typedef void (*ParseCmdProc)(StringBuilder &builder, std::string_view param, char32_t value);
 
 struct CmdStruct {
 	std::string_view cmd;
@@ -28,9 +28,9 @@ struct CmdStruct {
 	CmdFlags flags;
 };
 
-extern void EmitSingleChar(StringBuilder &builder, const char *buf, char32_t value);
-extern void EmitPlural(StringBuilder &builder, const char *buf, char32_t value);
-extern void EmitGender(StringBuilder &builder, const char *buf, char32_t value);
+extern void EmitSingleChar(StringBuilder &builder, std::string_view param, char32_t value);
+extern void EmitPlural(StringBuilder &builder, std::string_view param, char32_t value);
+extern void EmitGender(StringBuilder &builder, std::string_view param, char32_t value);
 
 static const CmdStruct _cmd_structs[] = {
 	/* Font size */


### PR DESCRIPTION
## Motivation / Problem

Split from https://github.com/OpenTTD/OpenTTD/pull/13943.
See motivation there.

## Description

Switch string parsing in strgen to use StringConsumer.

There is a behaviour change included, which may affect game scripts:
* Translation files generally use a `#` in first column for comments.
* Apparently strgen also allowed `;` and ` ` (blank) as comment characters.

I removed the latter, now only `#` is treated as comment.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
