### PR TITLE
Codechange: Unify naming of NewGRF terms

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -1430,7 +1430,7 @@ static void AircraftLandAirplane(Aircraft *v)
 
 	v->UpdateDeltaXY();
 
-	AirportTileAnimationTrigger(st, vt, AAT_STATION_AIRPLANE_LAND);
+	TriggerAirportTileAnimation(st, vt, AAT_STATION_AIRPLANE_LAND);
 
 	if (!PlayVehicleSound(v, VSE_TOUCHDOWN)) {
 		SndPlayVehicleFx(SND_17_SKID_PLANE, v);

--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -74,7 +74,7 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 	TimerGameCalendar::Date build_date{}; ///< Date of construction
 
 	uint16_t random_bits = 0; ///< Random bits assigned to this station
-	uint8_t waiting_triggers = 0; ///< Waiting triggers (NewGRF) for this station
+	uint8_t waiting_random_triggers = 0; ///< Waiting triggers (NewGRF) for this station
 	uint8_t cached_anim_triggers = 0; ///< NOSAVE: Combined animation trigger bitmask, used to determine if trigger processing should happen.
 	uint8_t cached_roadstop_anim_triggers = 0; ///< NOSAVE: Combined animation trigger bitmask for road stops, used to determine if trigger processing should happen.
 	CargoTypes cached_cargo_triggers{}; ///< NOSAVE: Combined cargo trigger bitmask

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1168,7 +1168,7 @@ static void TriggerIndustryProduction(Industry *i)
 	}
 
 	TriggerIndustryRandomisation(i, INDUSTRY_TRIGGER_RECEIVED_CARGO);
-	StartStopIndustryTileAnimation(i, IAT_INDUSTRY_RECEIVED_CARGO);
+	TriggerIndustryAnimation(i, IAT_INDUSTRY_RECEIVED_CARGO);
 }
 
 /**
@@ -1813,7 +1813,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 					if (ge->GetData().cargo.TotalCount() == 0) {
 						TriggerStationRandomisation(st, st->xy, SRT_CARGO_TAKEN, v->cargo_type);
 						TriggerStationAnimation(st, st->xy, SAT_CARGO_TAKEN, v->cargo_type);
-						AirportAnimationTrigger(st, AAT_STATION_CARGO_TAKEN, v->cargo_type);
+						TriggerAirportAnimation(st, AAT_STATION_CARGO_TAKEN, v->cargo_type);
 						TriggerRoadStopRandomisation(st, st->xy, RSRT_CARGO_TAKEN, v->cargo_type);
 						TriggerRoadStopAnimation(st, st->xy, SAT_CARGO_TAKEN, v->cargo_type);
 					}

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1167,7 +1167,7 @@ static void TriggerIndustryProduction(Industry *i)
 		}
 	}
 
-	TriggerIndustry(i, INDUSTRY_TRIGGER_RECEIVED_CARGO);
+	TriggerIndustryRandomisation(i, INDUSTRY_TRIGGER_RECEIVED_CARGO);
 	StartStopIndustryTileAnimation(i, IAT_INDUSTRY_RECEIVED_CARGO);
 }
 
@@ -1779,7 +1779,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 			/* If there's goods waiting at the station, and the vehicle
 			 * has capacity for it, load it on the vehicle. */
 			if ((v->cargo.ActionCount(VehicleCargoList::MTA_LOAD) > 0 || (ge->HasData() && ge->GetData().cargo.AvailableCount() > 0)) && MayLoadUnderExclusiveRights(st, v)) {
-				if (v->cargo.StoredCount() == 0) TriggerVehicle(v, VEHICLE_TRIGGER_NEW_CARGO);
+				if (v->cargo.StoredCount() == 0) TriggerVehicleRandomisation(v, VEHICLE_TRIGGER_NEW_CARGO);
 				if (_settings_game.order.gradual_loading) cap_left = std::min(cap_left, GetLoadAmount(v));
 
 				uint loaded = ge->GetOrCreateData().cargo.Load(cap_left, &v->cargo, next_station, v->GetCargoTile());
@@ -1910,7 +1910,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 		/* Make sure the vehicle is marked dirty, since we need to update the NewGRF
 		 * properties such as weight, power and TE whenever the trigger runs. */
 		dirty_vehicle = true;
-		TriggerVehicle(front, VEHICLE_TRIGGER_EMPTY);
+		TriggerVehicleRandomisation(front, VEHICLE_TRIGGER_EMPTY);
 	}
 
 	if (dirty_vehicle) {

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -844,7 +844,7 @@ static void TileLoop_Industry(TileIndex tile)
 	 * returning from TileLoop_Water. */
 	if (!IsTileType(tile, MP_INDUSTRY)) return;
 
-	TriggerIndustryTile(tile, INDTILE_TRIGGER_TILE_LOOP);
+	TriggerIndustryTileRandomisation(tile, INDTILE_TRIGGER_TILE_LOOP);
 
 	if (!IsIndustryCompleted(tile)) {
 		MakeIndustryTileBigger(tile);
@@ -1222,7 +1222,7 @@ static void ProduceIndustryGoods(Industry *i)
 			if (cut) ChopLumberMillTrees(i);
 		}
 
-		TriggerIndustry(i, INDUSTRY_TRIGGER_INDUSTRY_TICK);
+		TriggerIndustryRandomisation(i, INDUSTRY_TRIGGER_INDUSTRY_TICK);
 		StartStopIndustryTileAnimation(i, IAT_INDUSTRY_TICK);
 	}
 }

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -763,7 +763,7 @@ static void MakeIndustryTileBigger(TileIndex tile)
 	uint8_t stage = GetIndustryConstructionStage(tile) + 1;
 	SetIndustryConstructionCounter(tile, 0);
 	SetIndustryConstructionStage(tile, stage);
-	StartStopIndustryTileAnimation(tile, IAT_CONSTRUCTION_STAGE_CHANGE);
+	TriggerIndustryTileAnimation(tile, IAT_CONSTRUCTION_STAGE_CHANGE);
 	if (stage == INDUSTRY_COMPLETED) SetIndustryCompleted(tile);
 
 	MarkTileDirtyByTile(tile);
@@ -853,7 +853,7 @@ static void TileLoop_Industry(TileIndex tile)
 
 	if (_game_mode == GM_EDITOR) return;
 
-	if (TransportIndustryGoods(tile) && !StartStopIndustryTileAnimation(Industry::GetByTile(tile), IAT_INDUSTRY_DISTRIBUTES_CARGO)) {
+	if (TransportIndustryGoods(tile) && !TriggerIndustryAnimation(Industry::GetByTile(tile), IAT_INDUSTRY_DISTRIBUTES_CARGO)) {
 		uint newgfx = GetIndustryTileSpec(GetIndustryGfx(tile))->anim_production;
 
 		if (newgfx != INDUSTRYTILE_NOANIM) {
@@ -865,7 +865,7 @@ static void TileLoop_Industry(TileIndex tile)
 		}
 	}
 
-	if (StartStopIndustryTileAnimation(tile, IAT_TILELOOP)) return;
+	if (TriggerIndustryTileAnimation(tile, IAT_TILELOOP)) return;
 
 	IndustryGfx newgfx = GetIndustryTileSpec(GetIndustryGfx(tile))->anim_next;
 	if (newgfx != INDUSTRYTILE_NOANIM) {
@@ -1223,7 +1223,7 @@ static void ProduceIndustryGoods(Industry *i)
 		}
 
 		TriggerIndustryRandomisation(i, INDUSTRY_TRIGGER_INDUSTRY_TICK);
-		StartStopIndustryTileAnimation(i, IAT_INDUSTRY_TICK);
+		TriggerIndustryAnimation(i, IAT_INDUSTRY_TICK);
 	}
 }
 

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -763,7 +763,7 @@ static void MakeIndustryTileBigger(TileIndex tile)
 	uint8_t stage = GetIndustryConstructionStage(tile) + 1;
 	SetIndustryConstructionCounter(tile, 0);
 	SetIndustryConstructionStage(tile, stage);
-	StartStopIndustryTileAnimation(tile, IAT_CONSTRUCTION_STATE_CHANGE);
+	StartStopIndustryTileAnimation(tile, IAT_CONSTRUCTION_STAGE_CHANGE);
 	if (stage == INDUSTRY_COMPLETED) SetIndustryCompleted(tile);
 
 	MarkTileDirtyByTile(tile);

--- a/src/industry_map.h
+++ b/src/industry_map.h
@@ -247,7 +247,7 @@ inline void SetIndustryRandomBits(Tile tile, uint8_t bits)
  * @pre IsTileType(tile, MP_INDUSTRY)
  * @return requested triggers
  */
-inline uint8_t GetIndustryTriggers(Tile tile)
+inline uint8_t GetIndustryRandomTriggers(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	return GB(tile.m6(), 3, 3);
@@ -261,7 +261,7 @@ inline uint8_t GetIndustryTriggers(Tile tile)
  * @param triggers the triggers to set
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-inline void SetIndustryTriggers(Tile tile, uint8_t triggers)
+inline void SetIndustryRandomTriggers(Tile tile, uint8_t triggers)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 	SB(tile.m6(), 3, 3, triggers);
@@ -283,7 +283,7 @@ inline void MakeIndustry(Tile t, IndustryID index, IndustryGfx gfx, uint8_t rand
 	SetIndustryRandomBits(t, random); // m3
 	t.m4() = 0;
 	SetIndustryGfx(t, gfx); // m5, part of m6
-	SetIndustryTriggers(t, 0); // rest of m6
+	SetIndustryRandomTriggers(t, 0); // rest of m6
 	SetWaterClass(t, wc);
 	t.m7() = 0;
 }

--- a/src/industrytype.h
+++ b/src/industrytype.h
@@ -157,7 +157,7 @@ struct IndustryTileSpec {
 	uint8_t anim_next;                       ///< Next frame in an animation
 	/**
 	 * When true, the tile has to be drawn using the animation
-	 * state instead of the construction state
+	 * state instead of the construction stage
 	 */
 	bool anim_state;
 	/* Newgrf data */

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -286,7 +286,7 @@ bool DrawNewAirportTile(TileInfo *ti, Station *st, const AirportTileSpec *airts)
 /** Helper class for animation control. */
 struct AirportTileAnimationBase : public AnimationBase<AirportTileAnimationBase, AirportTileSpec, Station, int, GetAirportTileCallback, TileAnimationFrameAnimationHelper<Station> > {
 	static constexpr CallbackID cb_animation_speed      = CBID_AIRPTILE_ANIMATION_SPEED;
-	static constexpr CallbackID cb_animation_next_frame = CBID_AIRPTILE_ANIM_NEXT_FRAME;
+	static constexpr CallbackID cb_animation_next_frame = CBID_AIRPTILE_ANIMATION_NEXT_FRAME;
 
 	static constexpr AirportTileCallbackMask cbm_animation_speed      = AirportTileCallbackMask::AnimationSpeed;
 	static constexpr AirportTileCallbackMask cbm_animation_next_frame = AirportTileCallbackMask::AnimationNextFrame;
@@ -300,20 +300,20 @@ void AnimateAirportTile(TileIndex tile)
 	AirportTileAnimationBase::AnimateTile(ats, Station::GetByTile(tile), tile, HasBit(ats->animation_special_flags, 0));
 }
 
-void AirportTileAnimationTrigger(Station *st, TileIndex tile, AirpAnimationTrigger trigger, CargoType cargo_type)
+void TriggerAirportTileAnimation(Station *st, TileIndex tile, AirpAnimationTrigger trigger, CargoType cargo_type)
 {
 	const AirportTileSpec *ats = AirportTileSpec::GetByTile(tile);
 	if (!HasBit(ats->animation.triggers, trigger)) return;
 
-	AirportTileAnimationBase::ChangeAnimationFrame(CBID_AIRPTILE_ANIM_START_STOP, ats, st, tile, Random(), (uint8_t)trigger | (cargo_type << 8));
+	AirportTileAnimationBase::ChangeAnimationFrame(CBID_AIRPTILE_ANIMATION_TRIGGER, ats, st, tile, Random(), (uint8_t)trigger | (cargo_type << 8));
 }
 
-void AirportAnimationTrigger(Station *st, AirpAnimationTrigger trigger, CargoType cargo_type)
+void TriggerAirportAnimation(Station *st, AirpAnimationTrigger trigger, CargoType cargo_type)
 {
 	if (st->airport.tile == INVALID_TILE) return;
 
 	for (TileIndex tile : st->airport) {
-		if (st->TileBelongsToAirport(tile)) AirportTileAnimationTrigger(st, tile, trigger, cargo_type);
+		if (st->TileBelongsToAirport(tile)) TriggerAirportTileAnimation(st, tile, trigger, cargo_type);
 	}
 }
 

--- a/src/newgrf_airporttiles.h
+++ b/src/newgrf_airporttiles.h
@@ -88,8 +88,8 @@ private:
 };
 
 void AnimateAirportTile(TileIndex tile);
-void AirportTileAnimationTrigger(Station *st, TileIndex tile, AirpAnimationTrigger trigger, CargoType cargo_type = INVALID_CARGO);
-void AirportAnimationTrigger(Station *st, AirpAnimationTrigger trigger, CargoType cargo_type = INVALID_CARGO);
+void TriggerAirportTileAnimation(Station *st, TileIndex tile, AirpAnimationTrigger trigger, CargoType cargo_type = INVALID_CARGO);
+void TriggerAirportAnimation(Station *st, AirpAnimationTrigger trigger, CargoType cargo_type = INVALID_CARGO);
 bool DrawNewAirportTile(TileInfo *ti, Station *st, const AirportTileSpec *airts);
 
 #endif /* NEWGRF_AIRPORTTILES_H */

--- a/src/newgrf_animation_type.h
+++ b/src/newgrf_animation_type.h
@@ -37,7 +37,7 @@ enum StationAnimationTrigger : uint8_t {
 
 /** Animation triggers of the industries. */
 enum IndustryAnimationTrigger : uint8_t {
-	IAT_CONSTRUCTION_STATE_CHANGE,  ///< Trigger whenever the construction state changes.
+	IAT_CONSTRUCTION_STAGE_CHANGE,  ///< Trigger whenever the construction stage changes.
 	IAT_TILELOOP,                   ///< Trigger in the periodic tile loop.
 	IAT_INDUSTRY_TICK,              ///< Trigger every tick.
 	IAT_INDUSTRY_RECEIVED_CARGO,    ///< Trigger when cargo is received .

--- a/src/newgrf_callbacks.h
+++ b/src/newgrf_callbacks.h
@@ -67,8 +67,8 @@ enum CallbackID : uint16_t {
 	/** Called for periodically starting or stopping the animation. */
 	CBID_HOUSE_ANIMATION_START_STOP      = 0x1B, // 15 bit callback
 
-	/** Called whenever the construction state of a house changes. */
-	CBID_HOUSE_CONSTRUCTION_STATE_CHANGE = 0x1C, // 15 bit callback
+	/** Called whenever the construction stage of a house changes. */
+	CBID_HOUSE_CONSTRUCTION_STAGE_CHANGE = 0x1C, // 15 bit callback
 
 	/** Determine whether a wagon can be attached to an already existing train. */
 	CBID_TRAIN_ALLOW_WAGON_ATTACH        = 0x1D,
@@ -342,7 +342,7 @@ enum class HouseCallbackMask : uint8_t {
 	AllowConstruction       =  0, ///< decide whether the house can be built on a given tile
 	AnimationNextFrame      =  1, ///< decides next animation frame
 	AnimationStartStop      =  2, ///< periodically start/stop the animation
-	ConstructionStateChange =  3, ///< change animation when construction state changes
+	ConstructionStageChange =  3, ///< change animation when construction stage changes
 	Colour                  =  4, ///< decide the colour of the building
 	CargoAcceptance         =  5, ///< decides amount of cargo acceptance
 	AnimationSpeed          =  6, ///< decides animation speed

--- a/src/newgrf_callbacks.h
+++ b/src/newgrf_callbacks.h
@@ -65,10 +65,10 @@ enum CallbackID : uint16_t {
 	CBID_HOUSE_ANIMATION_NEXT_FRAME      = 0x1A, // 15 bit callback
 
 	/** Called for periodically starting or stopping the animation. */
-	CBID_HOUSE_ANIMATION_START_STOP      = 0x1B, // 15 bit callback
+	CBID_HOUSE_ANIMATION_TRIGGER_TILE_LOOP = 0x1B, // 15 bit callback
 
 	/** Called whenever the construction stage of a house changes. */
-	CBID_HOUSE_CONSTRUCTION_STAGE_CHANGE = 0x1C, // 15 bit callback
+	CBID_HOUSE_ANIMATION_TRIGGER_CONSTRUCTION_STAGE_CHANGED = 0x1C, // 15 bit callback
 
 	/** Determine whether a wagon can be attached to an already existing train. */
 	CBID_TRAIN_ALLOW_WAGON_ATTACH        = 0x1D,
@@ -98,10 +98,10 @@ enum CallbackID : uint16_t {
 	CBID_STATION_BUILD_TILE_LAYOUT       = 0x24, // 15 bit callback
 
 	/** Called for periodically starting or stopping the animation. */
-	CBID_INDTILE_ANIM_START_STOP         = 0x25, // 15 bit callback
+	CBID_INDTILE_ANIMATION_TRIGGER       = 0x25, // 15 bit callback
 
 	/** Called to determine industry tile next animation frame. */
-	CBID_INDTILE_ANIM_NEXT_FRAME         = 0x26, // 15 bit callback
+	CBID_INDTILE_ANIMATION_NEXT_FRAME    = 0x26, // 15 bit callback
 
 	/** Called to indicate how long the current animation frame should last. */
 	CBID_INDTILE_ANIMATION_SPEED         = 0x27, // 8 bit callback
@@ -184,10 +184,10 @@ enum CallbackID : uint16_t {
 	/* There are no callbacks 0x3E - 0x13F */
 
 	/** Called for periodically starting or stopping the animation. */
-	CBID_STATION_ANIM_START_STOP         = 0x140, // 15 bit callback
+	CBID_STATION_ANIMATION_TRIGGER       = 0x140, // 15 bit callback
 
 	/** Called to determine station tile next animation frame. */
-	CBID_STATION_ANIM_NEXT_FRAME         = 0x141, // 15 bit callback
+	CBID_STATION_ANIMATION_NEXT_FRAME    = 0x141, // 15 bit callback
 
 	/** Called to indicate how long the current animation frame should last. */
 	CBID_STATION_ANIMATION_SPEED         = 0x142, // 8 bit callback
@@ -208,7 +208,7 @@ enum CallbackID : uint16_t {
 	CBID_CANALS_SPRITE_OFFSET            = 0x147, // 15 bit callback
 
 	/** Called when a cargo type specified in property 20 is accepted. */
-	CBID_HOUSE_WATCHED_CARGO_ACCEPTED    = 0x148, // 15 bit callback
+	CBID_HOUSE_ANIMATION_TRIGGER_WATCHED_CARGO_ACCEPTED = 0x148, // 15 bit callback
 
 	/** Callback done for each tile of a station to check the slope. */
 	CBID_STATION_LAND_SLOPE_CHECK        = 0x149, // 15 bit callback
@@ -235,10 +235,10 @@ enum CallbackID : uint16_t {
 	CBID_AIRPTILE_DRAW_FOUNDATIONS       = 0x150, // 15 bit callback
 
 	/** Called for periodically starting or stopping the animation. */
-	CBID_AIRPTILE_ANIM_START_STOP        = 0x152, // 15 bit callback
+	CBID_AIRPTILE_ANIMATION_TRIGGER      = 0x152, // 15 bit callback
 
 	/** Called to determine airport tile next animation frame. */
-	CBID_AIRPTILE_ANIM_NEXT_FRAME        = 0x153, // 15 bit callback
+	CBID_AIRPTILE_ANIMATION_NEXT_FRAME   = 0x153, // 15 bit callback
 
 	/** Called to indicate how long the current animation frame should last. */
 	CBID_AIRPTILE_ANIMATION_SPEED        = 0x154, // 8 bit callback
@@ -259,7 +259,7 @@ enum CallbackID : uint16_t {
 	CBID_OBJECT_ANIMATION_NEXT_FRAME     = 0x158, // 15 bit callback
 
 	/** Called for periodically starting or stopping the animation. */
-	CBID_OBJECT_ANIMATION_START_STOP     = 0x159, // 15 bit callback
+	CBID_OBJECT_ANIMATION_TRIGGER        = 0x159, // 15 bit callback
 
 	/** Called to indicate how long the current animation frame should last. */
 	CBID_OBJECT_ANIMATION_SPEED          = 0x15A, // 8 bit callback
@@ -341,8 +341,8 @@ using RoadStopCallbackMasks = EnumBitSet<RoadStopCallbackMask, uint8_t>;
 enum class HouseCallbackMask : uint8_t {
 	AllowConstruction       =  0, ///< decide whether the house can be built on a given tile
 	AnimationNextFrame      =  1, ///< decides next animation frame
-	AnimationStartStop      =  2, ///< periodically start/stop the animation
-	ConstructionStageChange =  3, ///< change animation when construction stage changes
+	AnimationTriggerTileLoop = 2, ///< periodically start/stop the animation
+	AnimationTriggerConstructionStageChanged = 3, ///< change animation when construction stage changes
 	Colour                  =  4, ///< decide the colour of the building
 	CargoAcceptance         =  5, ///< decides amount of cargo acceptance
 	AnimationSpeed          =  6, ///< decides animation speed

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1247,7 +1247,7 @@ bool TestVehicleBuildProbability(Vehicle *v, EngineID engine, BuildProbabilityTy
 	return p + RandomRange(PROBABILITY_RANGE) >= PROBABILITY_RANGE;
 }
 
-static void DoTriggerVehicle(Vehicle *v, VehicleTrigger trigger, uint16_t base_random_bits, bool first)
+static void DoTriggerVehicleRandomisation(Vehicle *v, VehicleTrigger trigger, uint16_t base_random_bits, bool first)
 {
 	/* We can't trigger a non-existent vehicle... */
 	assert(v != nullptr);
@@ -1278,14 +1278,14 @@ static void DoTriggerVehicle(Vehicle *v, VehicleTrigger trigger, uint16_t base_r
 			 * i.e.), so we give them all the NEW_CARGO triggered
 			 * vehicle's portion of random bits. */
 			assert(first);
-			DoTriggerVehicle(v->First(), VEHICLE_TRIGGER_ANY_NEW_CARGO, new_random_bits, false);
+			DoTriggerVehicleRandomisation(v->First(), VEHICLE_TRIGGER_ANY_NEW_CARGO, new_random_bits, false);
 			break;
 
 		case VEHICLE_TRIGGER_DEPOT:
 			/* We now trigger the next vehicle in chain recursively.
 			 * The random bits portions may be different for each
 			 * vehicle in chain. */
-			if (v->Next() != nullptr) DoTriggerVehicle(v->Next(), trigger, 0, true);
+			if (v->Next() != nullptr) DoTriggerVehicleRandomisation(v->Next(), trigger, 0, true);
 			break;
 
 		case VEHICLE_TRIGGER_EMPTY:
@@ -1293,14 +1293,14 @@ static void DoTriggerVehicle(Vehicle *v, VehicleTrigger trigger, uint16_t base_r
 			 * recursively.  The random bits portions must be same
 			 * for each vehicle in chain, so we give them all
 			 * first chained vehicle's portion of random bits. */
-			if (v->Next() != nullptr) DoTriggerVehicle(v->Next(), trigger, first ? new_random_bits : base_random_bits, false);
+			if (v->Next() != nullptr) DoTriggerVehicleRandomisation(v->Next(), trigger, first ? new_random_bits : base_random_bits, false);
 			break;
 
 		case VEHICLE_TRIGGER_ANY_NEW_CARGO:
 			/* Now pass the trigger recursively to the next vehicle
 			 * in chain. */
 			assert(!first);
-			if (v->Next() != nullptr) DoTriggerVehicle(v->Next(), VEHICLE_TRIGGER_ANY_NEW_CARGO, base_random_bits, false);
+			if (v->Next() != nullptr) DoTriggerVehicleRandomisation(v->Next(), VEHICLE_TRIGGER_ANY_NEW_CARGO, base_random_bits, false);
 			break;
 
 		case VEHICLE_TRIGGER_CALLBACK_32:
@@ -1309,10 +1309,10 @@ static void DoTriggerVehicle(Vehicle *v, VehicleTrigger trigger, uint16_t base_r
 	}
 }
 
-void TriggerVehicle(Vehicle *v, VehicleTrigger trigger)
+void TriggerVehicleRandomisation(Vehicle *v, VehicleTrigger trigger)
 {
 	v->InvalidateNewGRFCacheOfChain();
-	DoTriggerVehicle(v, trigger, 0, true);
+	DoTriggerVehicleRandomisation(v, trigger, 0, true);
 	v->InvalidateNewGRFCacheOfChain();
 }
 

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -309,9 +309,9 @@ static uint8_t MapAircraftMovementAction(const Aircraft *v)
 	return this->v == nullptr ? 0 : this->v->random_bits;
 }
 
-/* virtual */ uint32_t VehicleScopeResolver::GetTriggers() const
+/* virtual */ uint32_t VehicleScopeResolver::GetRandomTriggers() const
 {
-	return this->v == nullptr ? 0 : this->v->waiting_triggers;
+	return this->v == nullptr ? 0 : this->v->waiting_random_triggers;
 }
 
 
@@ -626,7 +626,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 
 				if (parameter == 0x5F) {
 					/* This seems to be the only variable that makes sense to access via var 61, but is not handled by VehicleGetVariable */
-					return (u->random_bits << 8) | u->waiting_triggers;
+					return (u->random_bits << 8) | u->waiting_random_triggers;
 				} else {
 					return VehicleGetVariable(u, object, parameter, GetRegister(0x10E), available);
 				}
@@ -891,7 +891,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 		case 0x78: break; // not implemented
 		case 0x79: break; // not implemented
 		case 0x7A: return v->random_bits;
-		case 0x7B: return v->waiting_triggers;
+		case 0x7B: return v->waiting_random_triggers;
 		case 0x7C: break; // vehicle specific, see below
 		case 0x7D: break; // vehicle specific, see below
 		case 0x7E: break; // not implemented
@@ -1253,14 +1253,14 @@ static void DoTriggerVehicleRandomisation(Vehicle *v, VehicleTrigger trigger, ui
 	assert(v != nullptr);
 
 	VehicleResolverObject object(v->engine_type, v, VehicleResolverObject::WO_CACHED, false, CBID_RANDOM_TRIGGER);
-	object.waiting_triggers = v->waiting_triggers | trigger;
-	v->waiting_triggers = object.waiting_triggers; // store now for var 5F
+	object.waiting_random_triggers = v->waiting_random_triggers | trigger;
+	v->waiting_random_triggers = object.waiting_random_triggers; // store now for var 5F
 
 	const SpriteGroup *group = object.Resolve();
 	if (group == nullptr) return;
 
 	/* Store remaining triggers. */
-	v->waiting_triggers = object.GetRemainingTriggers();
+	v->waiting_random_triggers = object.GetRemainingRandomTriggers();
 
 	/* Rerandomise bits. Scopes other than SELF are invalid for rerandomisation. For bug-to-bug-compatibility with TTDP we ignore the scope. */
 	uint16_t new_random_bits = Random();

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -40,7 +40,7 @@ struct VehicleScopeResolver : public ScopeResolver {
 
 	uint32_t GetRandomBits() const override;
 	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool &available) const override;
-	uint32_t GetTriggers() const override;
+	uint32_t GetRandomTriggers() const override;
 };
 
 /** Resolver for a vehicle (chain) */

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -118,7 +118,7 @@ enum VehicleTrigger : uint8_t {
 	/* Externally triggered for each vehicle in chain */
 	VEHICLE_TRIGGER_CALLBACK_32   = 0x10,
 };
-void TriggerVehicle(Vehicle *veh, VehicleTrigger trigger);
+void TriggerVehicleRandomisation(Vehicle *veh, VehicleTrigger trigger);
 
 void AlterVehicleListOrder(EngineID engine, uint16_t target);
 void CommitVehicleListOrderChanges();

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -226,10 +226,10 @@ void DecreaseBuildingCount(Town *t, HouseID house_id)
 	return this->not_yet_constructed ? this->initial_random_bits : GetHouseRandomBits(this->tile);
 }
 
-/* virtual */ uint32_t HouseScopeResolver::GetTriggers() const
+/* virtual */ uint32_t HouseScopeResolver::GetRandomTriggers() const
 {
 	/* Note: Towns build houses over houses. So during construction checks 'tile' may be a valid but unrelated house. */
-	return this->not_yet_constructed ? 0 : GetHouseTriggers(this->tile);
+	return this->not_yet_constructed ? 0 : GetHouseRandomTriggers(this->tile);
 }
 
 static uint32_t GetNumHouses(HouseID house_id, const Town *town)
@@ -631,14 +631,14 @@ static void DoTriggerHouseRandomisation(TileIndex tile, HouseTrigger trigger, ui
 	if (hs->grf_prop.GetSpriteGroup() == nullptr) return;
 
 	HouseResolverObject object(hid, tile, Town::GetByTile(tile), CBID_RANDOM_TRIGGER);
-	object.waiting_triggers = GetHouseTriggers(tile) | trigger;
-	SetHouseTriggers(tile, object.waiting_triggers); // store now for var 5F
+	object.waiting_random_triggers = GetHouseRandomTriggers(tile) | trigger;
+	SetHouseRandomTriggers(tile, object.waiting_random_triggers); // store now for var 5F
 
 	const SpriteGroup *group = object.Resolve();
 	if (group == nullptr) return;
 
 	/* Store remaining triggers. */
-	SetHouseTriggers(tile, object.GetRemainingTriggers());
+	SetHouseRandomTriggers(tile, object.GetRemainingRandomTriggers());
 
 	/* Rerandomise bits. Scopes other than SELF are invalid for houses. For bug-to-bug-compatibility with TTDP we ignore the scope. */
 	uint8_t new_random_bits = Random();

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -591,8 +591,8 @@ bool NewHouseTileLoop(TileIndex tile)
 		return true;
 	}
 
-	TriggerHouse(tile, HOUSE_TRIGGER_TILE_LOOP);
-	if (hs->building_flags.Any(BUILDING_HAS_1_TILE)) TriggerHouse(tile, HOUSE_TRIGGER_TILE_LOOP_TOP);
+	TriggerHouseRandomisation(tile, HOUSE_TRIGGER_TILE_LOOP);
+	if (hs->building_flags.Any(BUILDING_HAS_1_TILE)) TriggerHouseRandomisation(tile, HOUSE_TRIGGER_TILE_LOOP_TOP);
 
 	/* Call the unsynchronized tile loop trigger */
 	AnimationControl(tile, false, 0);
@@ -620,7 +620,7 @@ bool NewHouseTileLoop(TileIndex tile)
 	return true;
 }
 
-static void DoTriggerHouse(TileIndex tile, HouseTrigger trigger, uint8_t base_random, bool first)
+static void DoTriggerHouseRandomisation(TileIndex tile, HouseTrigger trigger, uint8_t base_random, bool first)
 {
 	/* We can't trigger a non-existent building... */
 	assert(IsTileType(tile, MP_HOUSE));
@@ -660,16 +660,16 @@ static void DoTriggerHouse(TileIndex tile, HouseTrigger trigger, uint8_t base_ra
 				break;
 			}
 			/* Random value of first tile already set. */
-			if (hs->building_flags.Any(BUILDING_2_TILES_Y))   DoTriggerHouse(TileAddXY(tile, 0, 1), trigger, random_bits, false);
-			if (hs->building_flags.Any(BUILDING_2_TILES_X))   DoTriggerHouse(TileAddXY(tile, 1, 0), trigger, random_bits, false);
-			if (hs->building_flags.Any(BUILDING_HAS_4_TILES)) DoTriggerHouse(TileAddXY(tile, 1, 1), trigger, random_bits, false);
+			if (hs->building_flags.Any(BUILDING_2_TILES_Y))   DoTriggerHouseRandomisation(TileAddXY(tile, 0, 1), trigger, random_bits, false);
+			if (hs->building_flags.Any(BUILDING_2_TILES_X))   DoTriggerHouseRandomisation(TileAddXY(tile, 1, 0), trigger, random_bits, false);
+			if (hs->building_flags.Any(BUILDING_HAS_4_TILES)) DoTriggerHouseRandomisation(TileAddXY(tile, 1, 1), trigger, random_bits, false);
 			break;
 	}
 }
 
-void TriggerHouse(TileIndex t, HouseTrigger trigger)
+void TriggerHouseRandomisation(TileIndex t, HouseTrigger trigger)
 {
-	DoTriggerHouse(t, trigger, 0, true);
+	DoTriggerHouseRandomisation(t, trigger, 0, true);
 }
 
 /**

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -541,8 +541,8 @@ void AnimateNewHouseConstruction(TileIndex tile)
 {
 	const HouseSpec *hs = HouseSpec::Get(GetHouseType(tile));
 
-	if (hs->callback_mask.Test(HouseCallbackMask::ConstructionStateChange)) {
-		HouseAnimationBase::ChangeAnimationFrame(CBID_HOUSE_CONSTRUCTION_STATE_CHANGE, hs, Town::GetByTile(tile), tile, 0, 0);
+	if (hs->callback_mask.Test(HouseCallbackMask::ConstructionStageChange)) {
+		HouseAnimationBase::ChangeAnimationFrame(CBID_HOUSE_CONSTRUCTION_STAGE_CHANGE, hs, Town::GetByTile(tile), tile, 0, 0);
 	}
 }
 

--- a/src/newgrf_house.h
+++ b/src/newgrf_house.h
@@ -45,7 +45,7 @@ struct HouseScopeResolver : public ScopeResolver {
 
 	uint32_t GetRandomBits() const override;
 	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool &available) const override;
-	uint32_t GetTriggers() const override;
+	uint32_t GetRandomTriggers() const override;
 };
 
 /** Resolver object to be used for houses (feature 07 spritegroups). */

--- a/src/newgrf_house.h
+++ b/src/newgrf_house.h
@@ -118,6 +118,6 @@ enum HouseTrigger : uint8_t {
 	 */
 	HOUSE_TRIGGER_TILE_LOOP_TOP = 0x02,
 };
-void TriggerHouse(TileIndex t, HouseTrigger trigger);
+void TriggerHouseRandomisation(TileIndex t, HouseTrigger trigger);
 
 #endif /* NEWGRF_HOUSE_H */

--- a/src/newgrf_house.h
+++ b/src/newgrf_house.h
@@ -99,11 +99,12 @@ std::span<const uint> GetBuildingHouseIDCounts();
 
 void DrawNewHouseTile(TileInfo *ti, HouseID house_id);
 void AnimateNewHouseTile(TileIndex tile);
-void AnimateNewHouseConstruction(TileIndex tile);
+/* see also: void TriggerHouseAnimation_TileLoop(TileIndex tile, uint16_t random_bits) */
+void TriggerHouseAnimation_ConstructionStageChanged(TileIndex tile);
+void TriggerHouseAnimation_WatchedCargoAccepted(TileIndex tile, CargoTypes trigger_cargoes);
 
 uint16_t GetHouseCallback(CallbackID callback, uint32_t param1, uint32_t param2, HouseID house_id, Town *town, TileIndex tile,
 		bool not_yet_constructed = false, uint8_t initial_random_bits = 0, CargoTypes watched_cargo_triggers = 0, int view = 0);
-void WatchedCargoCallback(TileIndex tile, CargoTypes trigger_cargoes);
 
 bool CanDeleteHouse(TileIndex tile);
 

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -433,7 +433,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t param_set_id, uint8
 	return this->industry != nullptr ? this->industry->random : 0;
 }
 
-/* virtual */ uint32_t IndustriesScopeResolver::GetTriggers() const
+/* virtual */ uint32_t IndustriesScopeResolver::GetRandomTriggers() const
 {
 	return 0;
 }

--- a/src/newgrf_industries.h
+++ b/src/newgrf_industries.h
@@ -34,7 +34,7 @@ struct IndustriesScopeResolver : public ScopeResolver {
 
 	uint32_t GetRandomBits() const override;
 	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool &available) const override;
-	uint32_t GetTriggers() const override;
+	uint32_t GetRandomTriggers() const override;
 	void StorePSA(uint pos, int32_t value) override;
 };
 

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -262,7 +262,7 @@ uint16_t GetSimpleIndustryCallback(CallbackID callback, uint32_t param1, uint32_
 /** Helper class for animation control. */
 struct IndustryAnimationBase : public AnimationBase<IndustryAnimationBase, IndustryTileSpec, Industry, int, GetSimpleIndustryCallback, TileAnimationFrameAnimationHelper<Industry> > {
 	static constexpr CallbackID cb_animation_speed      = CBID_INDTILE_ANIMATION_SPEED;
-	static constexpr CallbackID cb_animation_next_frame = CBID_INDTILE_ANIM_NEXT_FRAME;
+	static constexpr CallbackID cb_animation_next_frame = CBID_INDTILE_ANIMATION_NEXT_FRAME;
 
 	static constexpr IndustryTileCallbackMask cbm_animation_speed      = IndustryTileCallbackMask::AnimationSpeed;
 	static constexpr IndustryTileCallbackMask cbm_animation_next_frame = IndustryTileCallbackMask::AnimationNextFrame;
@@ -276,23 +276,23 @@ void AnimateNewIndustryTile(TileIndex tile)
 	IndustryAnimationBase::AnimateTile(itspec, Industry::GetByTile(tile), tile, itspec->special_flags.Test(IndustryTileSpecialFlag::NextFrameRandomBits));
 }
 
-bool StartStopIndustryTileAnimation(TileIndex tile, IndustryAnimationTrigger iat, uint32_t random)
+bool TriggerIndustryTileAnimation(TileIndex tile, IndustryAnimationTrigger iat, uint32_t random)
 {
 	const IndustryTileSpec *itspec = GetIndustryTileSpec(GetIndustryGfx(tile));
 
 	if (!HasBit(itspec->animation.triggers, iat)) return false;
 
-	IndustryAnimationBase::ChangeAnimationFrame(CBID_INDTILE_ANIM_START_STOP, itspec, Industry::GetByTile(tile), tile, random, iat);
+	IndustryAnimationBase::ChangeAnimationFrame(CBID_INDTILE_ANIMATION_TRIGGER, itspec, Industry::GetByTile(tile), tile, random, iat);
 	return true;
 }
 
-bool StartStopIndustryTileAnimation(const Industry *ind, IndustryAnimationTrigger iat)
+bool TriggerIndustryAnimation(const Industry *ind, IndustryAnimationTrigger iat)
 {
 	bool ret = true;
 	uint32_t random = Random();
 	for (TileIndex tile : ind->location) {
 		if (ind->TileBelongsToIndustry(tile)) {
-			if (StartStopIndustryTileAnimation(tile, iat, random)) {
+			if (TriggerIndustryTileAnimation(tile, iat, random)) {
 				SB(random, 0, 16, Random());
 			} else {
 				ret = false;

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -110,12 +110,12 @@ uint32_t GetRelativePosition(TileIndex tile, TileIndex ind_tile)
 	return (this->industry->index != IndustryID::Invalid()) ? GetIndustryRandomBits(this->tile) : 0;
 }
 
-/* virtual */ uint32_t IndustryTileScopeResolver::GetTriggers() const
+/* virtual */ uint32_t IndustryTileScopeResolver::GetRandomTriggers() const
 {
 	assert(this->industry != nullptr && IsValidTile(this->tile));
 	assert(this->industry->index == IndustryID::Invalid() || IsTileType(this->tile, MP_INDUSTRY));
 	if (this->industry->index == IndustryID::Invalid()) return 0;
-	return GetIndustryTriggers(this->tile);
+	return GetIndustryRandomTriggers(this->tile);
 }
 
 /**
@@ -320,14 +320,14 @@ static void DoTriggerIndustryTileRandomisation(TileIndex tile, IndustryTileTrigg
 	if (itspec->grf_prop.GetSpriteGroup() == nullptr) return;
 
 	IndustryTileResolverObject object(gfx, tile, ind, CBID_RANDOM_TRIGGER);
-	object.waiting_triggers = GetIndustryTriggers(tile) | trigger;
-	SetIndustryTriggers(tile, object.waiting_triggers); // store now for var 5F
+	object.waiting_random_triggers = GetIndustryRandomTriggers(tile) | trigger;
+	SetIndustryRandomTriggers(tile, object.waiting_random_triggers); // store now for var 5F
 
 	const SpriteGroup *group = object.Resolve();
 	if (group == nullptr) return;
 
 	/* Store remaining triggers. */
-	SetIndustryTriggers(tile, object.GetRemainingTriggers());
+	SetIndustryRandomTriggers(tile, object.GetRemainingRandomTriggers());
 
 	/* Rerandomise tile bits */
 	uint8_t new_random_bits = Random();

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -310,7 +310,7 @@ bool StartStopIndustryTileAnimation(const Industry *ind, IndustryAnimationTrigge
  * @param ind Industry of the tile.
  * @param[in,out] reseed_industry Collects bits to reseed for the industry.
  */
-static void DoTriggerIndustryTile(TileIndex tile, IndustryTileTrigger trigger, Industry *ind, uint32_t &reseed_industry)
+static void DoTriggerIndustryTileRandomisation(TileIndex tile, IndustryTileTrigger trigger, Industry *ind, uint32_t &reseed_industry)
 {
 	assert(IsValidTile(tile) && IsTileType(tile, MP_INDUSTRY));
 
@@ -359,11 +359,11 @@ static void DoReseedIndustry(Industry *ind, uint32_t reseed)
  * @param tile Industry tile to trigger.
  * @param trigger Trigger to trigger.
  */
-void TriggerIndustryTile(TileIndex tile, IndustryTileTrigger trigger)
+void TriggerIndustryTileRandomisation(TileIndex tile, IndustryTileTrigger trigger)
 {
 	uint32_t reseed_industry = 0;
 	Industry *ind = Industry::GetByTile(tile);
-	DoTriggerIndustryTile(tile, trigger, ind, reseed_industry);
+	DoTriggerIndustryTileRandomisation(tile, trigger, ind, reseed_industry);
 	DoReseedIndustry(ind, reseed_industry);
 }
 
@@ -372,12 +372,12 @@ void TriggerIndustryTile(TileIndex tile, IndustryTileTrigger trigger)
  * @param ind Industry to trigger.
  * @param trigger Trigger to trigger.
  */
-void TriggerIndustry(Industry *ind, IndustryTileTrigger trigger)
+void TriggerIndustryRandomisation(Industry *ind, IndustryTileTrigger trigger)
 {
 	uint32_t reseed_industry = 0;
 	for (TileIndex tile : ind->location) {
 		if (ind->TileBelongsToIndustry(tile)) {
-			DoTriggerIndustryTile(tile, trigger, ind, reseed_industry);
+			DoTriggerIndustryTileRandomisation(tile, trigger, ind, reseed_industry);
 		}
 	}
 	DoReseedIndustry(ind, reseed_industry);

--- a/src/newgrf_industrytiles.h
+++ b/src/newgrf_industrytiles.h
@@ -62,8 +62,8 @@ uint16_t GetIndustryTileCallback(CallbackID callback, uint32_t param1, uint32_t 
 CommandCost PerformIndustryTileSlopeCheck(TileIndex ind_base_tile, TileIndex ind_tile, const IndustryTileSpec *its, IndustryType type, IndustryGfx gfx, size_t layout_index, uint16_t initial_random_bits, Owner founder, IndustryAvailabilityCallType creation_type);
 
 void AnimateNewIndustryTile(TileIndex tile);
-bool StartStopIndustryTileAnimation(TileIndex tile, IndustryAnimationTrigger iat, uint32_t random = Random());
-bool StartStopIndustryTileAnimation(const Industry *ind, IndustryAnimationTrigger iat);
+bool TriggerIndustryTileAnimation(TileIndex tile, IndustryAnimationTrigger iat, uint32_t random = Random());
+bool TriggerIndustryAnimation(const Industry *ind, IndustryAnimationTrigger iat);
 
 
 /** Available industry tile triggers. */

--- a/src/newgrf_industrytiles.h
+++ b/src/newgrf_industrytiles.h
@@ -72,7 +72,7 @@ enum IndustryTileTrigger : uint8_t {
 	INDUSTRY_TRIGGER_INDUSTRY_TICK  = 0x02, ///< The industry has been triggered via its tick.
 	INDUSTRY_TRIGGER_RECEIVED_CARGO = 0x04, ///< Cargo has been delivered.
 };
-void TriggerIndustryTile(TileIndex t, IndustryTileTrigger trigger);
-void TriggerIndustry(Industry *ind, IndustryTileTrigger trigger);
+void TriggerIndustryTileRandomisation(TileIndex t, IndustryTileTrigger trigger);
+void TriggerIndustryRandomisation(Industry *ind, IndustryTileTrigger trigger);
 
 #endif /* NEWGRF_INDUSTRYTILES_H */

--- a/src/newgrf_industrytiles.h
+++ b/src/newgrf_industrytiles.h
@@ -32,7 +32,7 @@ struct IndustryTileScopeResolver : public ScopeResolver {
 
 	uint32_t GetRandomBits() const override;
 	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool &available) const override;
-	uint32_t GetTriggers() const override;
+	uint32_t GetRandomTriggers() const override;
 };
 
 /** Resolver for industry tiles. */

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -566,7 +566,7 @@ void TriggerObjectTileAnimation(Object *o, TileIndex tile, ObjectAnimationTrigge
 {
 	if (!HasBit(spec->animation.triggers, trigger)) return;
 
-	ObjectAnimationBase::ChangeAnimationFrame(CBID_OBJECT_ANIMATION_START_STOP, spec, o, tile, Random(), trigger);
+	ObjectAnimationBase::ChangeAnimationFrame(CBID_OBJECT_ANIMATION_TRIGGER, spec, o, tile, Random(), trigger);
 }
 
 /**

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -363,7 +363,7 @@ struct RoadStopAnimationFrameAnimationHelper {
 /** Helper class for animation control. */
 struct RoadStopAnimationBase : public AnimationBase<RoadStopAnimationBase, RoadStopSpec, BaseStation, int, GetAnimRoadStopCallback, RoadStopAnimationFrameAnimationHelper> {
 	static constexpr CallbackID cb_animation_speed      = CBID_STATION_ANIMATION_SPEED;
-	static constexpr CallbackID cb_animation_next_frame = CBID_STATION_ANIM_NEXT_FRAME;
+	static constexpr CallbackID cb_animation_next_frame = CBID_STATION_ANIMATION_NEXT_FRAME;
 
 	static constexpr RoadStopCallbackMask cbm_animation_speed      = RoadStopCallbackMask::AnimationSpeed;
 	static constexpr RoadStopCallbackMask cbm_animation_next_frame = RoadStopCallbackMask::AnimationNextFrame;
@@ -396,7 +396,7 @@ void TriggerRoadStopAnimation(BaseStation *st, TileIndex trigger_tile, StationAn
 			} else {
 				local_cargo = ss->grf_prop.grffile->cargo_map[cargo_type];
 			}
-			RoadStopAnimationBase::ChangeAnimationFrame(CBID_STATION_ANIM_START_STOP, ss, st, cur_tile, (random_bits << 16) | Random(), (uint8_t)trigger | (local_cargo << 8));
+			RoadStopAnimationBase::ChangeAnimationFrame(CBID_STATION_ANIMATION_TRIGGER, ss, st, cur_tile, (random_bits << 16) | Random(), (uint8_t)trigger | (local_cargo << 8));
 		}
 	};
 

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -103,7 +103,7 @@ struct RoadStopScopeResolver : public ScopeResolver {
 	}
 
 	uint32_t GetRandomBits() const override;
-	uint32_t GetTriggers() const override;
+	uint32_t GetRandomTriggers() const override;
 
 	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool &available) const override;
 };

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -62,7 +62,7 @@ static inline uint32_t GetVariable(const ResolverObject &object, ScopeResolver *
 		case 0x18: return object.callback_param2;
 		case 0x1C: return object.last_value;
 
-		case 0x5F: return (scope->GetRandomBits() << 8) | scope->GetTriggers();
+		case 0x5F: return (scope->GetRandomBits() << 8) | scope->GetRandomTriggers();
 
 		case 0x7D: return _temp_store.GetValue(parameter);
 
@@ -91,7 +91,7 @@ static inline uint32_t GetVariable(const ResolverObject &object, ScopeResolver *
  * Get the triggers. Base class returns \c 0 to prevent trouble.
  * @return The triggers.
  */
-/* virtual */ uint32_t ScopeResolver::GetTriggers() const
+/* virtual */ uint32_t ScopeResolver::GetRandomTriggers() const
 {
 	return 0;
 }
@@ -258,11 +258,11 @@ const SpriteGroup *RandomizedSpriteGroup::Resolve(ResolverObject &object) const
 	ScopeResolver *scope = object.GetScope(this->var_scope, this->count);
 	if (object.callback == CBID_RANDOM_TRIGGER) {
 		/* Handle triggers */
-		uint8_t match = this->triggers & object.waiting_triggers;
+		uint8_t match = this->triggers & object.waiting_random_triggers;
 		bool res = (this->cmp_mode == RSG_CMP_ANY) ? (match != 0) : (match == this->triggers);
 
 		if (res) {
-			object.used_triggers |= match;
+			object.used_random_triggers |= match;
 			object.reseed[this->var_scope] |= (this->groups.size() - 1) << this->lowest_randbit;
 		}
 	}

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -282,7 +282,7 @@ struct ScopeResolver {
 	virtual ~ScopeResolver() = default;
 
 	virtual uint32_t GetRandomBits() const;
-	virtual uint32_t GetTriggers() const;
+	virtual uint32_t GetRandomTriggers() const;
 
 	virtual uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool &available) const;
 	virtual void StorePSA(uint reg, int32_t value);
@@ -318,8 +318,8 @@ struct ResolverObject {
 
 	uint32_t last_value = 0; ///< Result of most recent DeterministicSpriteGroup (including procedure calls)
 
-	uint32_t waiting_triggers = 0; ///< Waiting triggers to be used by any rerandomisation. (scope independent)
-	uint32_t used_triggers = 0; ///< Subset of cur_triggers, which actually triggered some rerandomisation. (scope independent)
+	uint32_t waiting_random_triggers = 0; ///< Waiting triggers to be used by any rerandomisation. (scope independent)
+	uint32_t used_random_triggers = 0; ///< Subset of cur_triggers, which actually triggered some rerandomisation. (scope independent)
 	std::array<uint32_t, VSG_END> reseed; ///< Collects bits to rerandomise while triggering triggers.
 
 	const GRFFile *grffile = nullptr; ///< GRFFile the resolved SpriteGroup belongs to
@@ -351,9 +351,9 @@ struct ResolverObject {
 	/**
 	 * Returns the waiting triggers that did not trigger any rerandomisation.
 	 */
-	uint32_t GetRemainingTriggers() const
+	uint32_t GetRemainingRandomTriggers() const
 	{
-		return this->waiting_triggers & ~this->used_triggers;
+		return this->waiting_random_triggers & ~this->used_random_triggers;
 	}
 
 	/**
@@ -377,8 +377,8 @@ struct ResolverObject {
 	void ResetState()
 	{
 		this->last_value = 0;
-		this->waiting_triggers = 0;
-		this->used_triggers = 0;
+		this->waiting_random_triggers = 0;
+		this->used_random_triggers = 0;
 		this->reseed.fill(0);
 	}
 

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -888,7 +888,7 @@ uint16_t GetAnimStationCallback(CallbackID callback, uint32_t param1, uint32_t p
 /** Helper class for animation control. */
 struct StationAnimationBase : public AnimationBase<StationAnimationBase, StationSpec, BaseStation, int, GetAnimStationCallback, TileAnimationFrameAnimationHelper<BaseStation> > {
 	static constexpr CallbackID cb_animation_speed      = CBID_STATION_ANIMATION_SPEED;
-	static constexpr CallbackID cb_animation_next_frame = CBID_STATION_ANIM_NEXT_FRAME;
+	static constexpr CallbackID cb_animation_next_frame = CBID_STATION_ANIMATION_NEXT_FRAME;
 
 	static constexpr StationCallbackMask cbm_animation_speed      = StationCallbackMask::AnimationSpeed;
 	static constexpr StationCallbackMask cbm_animation_next_frame = StationCallbackMask::AnimationNextFrame;
@@ -930,7 +930,7 @@ void TriggerStationAnimation(BaseStation *st, TileIndex trigger_tile, StationAni
 				} else {
 					local_cargo = ss->grf_prop.grffile->cargo_map[cargo_type];
 				}
-				StationAnimationBase::ChangeAnimationFrame(CBID_STATION_ANIM_START_STOP, ss, st, tile, (random_bits << 16) | GB(Random(), 0, 16), (uint8_t)trigger | (local_cargo << 8));
+				StationAnimationBase::ChangeAnimationFrame(CBID_STATION_ANIMATION_TRIGGER, ss, st, tile, (random_bits << 16) | GB(Random(), 0, 16), (uint8_t)trigger | (local_cargo << 8));
 			}
 		}
 	}

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -244,9 +244,9 @@ static uint32_t GetRailContinuationInfo(TileIndex tile)
 }
 
 
-/* virtual */ uint32_t StationScopeResolver::GetTriggers() const
+/* virtual */ uint32_t StationScopeResolver::GetRandomTriggers() const
 {
-	return this->st == nullptr ? 0 : this->st->waiting_triggers;
+	return this->st == nullptr ? 0 : this->st->waiting_random_triggers;
 }
 
 
@@ -965,8 +965,8 @@ void TriggerStationRandomisation(Station *st, TileIndex trigger_tile, StationRan
 	CargoTypes empty_mask = (trigger == SRT_CARGO_TAKEN) ? GetEmptyMask(st) : 0;
 
 	/* Store triggers now for var 5F */
-	SetBit(st->waiting_triggers, trigger);
-	uint32_t used_triggers = 0;
+	SetBit(st->waiting_random_triggers, trigger);
+	uint32_t used_random_triggers = 0;
 
 	/* Check all tiles over the station to check if the specindex is still in use */
 	for (TileIndex tile : area) {
@@ -982,12 +982,12 @@ void TriggerStationRandomisation(Station *st, TileIndex trigger_tile, StationRan
 
 			if (!IsValidCargoType(cargo_type) || HasBit(ss->cargo_triggers, cargo_type)) {
 				StationResolverObject object(ss, st, tile, CBID_RANDOM_TRIGGER, 0);
-				object.waiting_triggers = st->waiting_triggers;
+				object.waiting_random_triggers = st->waiting_random_triggers;
 
 				const SpriteGroup *group = object.Resolve();
 				if (group == nullptr) continue;
 
-				used_triggers |= object.used_triggers;
+				used_random_triggers |= object.used_random_triggers;
 
 				uint32_t reseed = object.GetReseedSum();
 				if (reseed != 0) {
@@ -1007,7 +1007,7 @@ void TriggerStationRandomisation(Station *st, TileIndex trigger_tile, StationRan
 	}
 
 	/* Update whole station random bits */
-	st->waiting_triggers &= ~used_triggers;
+	st->waiting_random_triggers &= ~used_random_triggers;
 	if ((whole_reseed & 0xFFFF) != 0) {
 		st->random_bits &= ~whole_reseed;
 		st->random_bits |= Random() & whole_reseed;

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -43,7 +43,7 @@ struct StationScopeResolver : public ScopeResolver {
 	}
 
 	uint32_t GetRandomBits() const override;
-	uint32_t GetTriggers() const override;
+	uint32_t GetRandomTriggers() const override;
 
 	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool &available) const override;
 };

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -490,7 +490,7 @@ static const SaveLoad _old_station_desc[] = {
 
 	/* Used by newstations for graphic variations */
 	SLE_CONDVAR(Station, random_bits,                SLE_UINT16,                 SLV_27, SL_MAX_VERSION),
-	SLE_CONDVAR(Station, waiting_triggers,           SLE_UINT8,                  SLV_27, SL_MAX_VERSION),
+	SLE_CONDVARNAME(Station, waiting_random_triggers, "waiting_triggers", SLE_UINT8, SLV_27, SL_MAX_VERSION),
 	SLEG_CONDVAR("num_specs", SlStationSpecList<StationSpec>::last_num_specs, SLE_UINT8, SLV_27, SL_MAX_VERSION),
 
 	SLE_CONDREFLIST(Station, loading_vehicles,       REF_VEHICLE,                SLV_57, SL_MAX_VERSION),
@@ -562,7 +562,7 @@ public:
 
 		/* Used by newstations for graphic variations */
 		    SLE_VAR(BaseStation, random_bits,            SLE_UINT16),
-		    SLE_VAR(BaseStation, waiting_triggers,       SLE_UINT8),
+		    SLE_VARNAME(BaseStation, waiting_random_triggers, "waiting_triggers", SLE_UINT8),
 	   SLEG_CONDVAR("num_specs", SlStationSpecList<StationSpec>::last_num_specs, SLE_UINT8, SL_MIN_VERSION, SLV_SAVELOAD_LIST_LENGTH),
 	};
 	inline const static SaveLoadCompatTable compat_description = _station_base_sl_compat;

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -754,7 +754,7 @@ public:
 
 		SLE_CONDVAR(Vehicle, random_bits,           SLE_FILE_U8 | SLE_VAR_U16,    SLV_2, SLV_EXTEND_VEHICLE_RANDOM),
 		SLE_CONDVAR(Vehicle, random_bits,           SLE_UINT16,                   SLV_EXTEND_VEHICLE_RANDOM, SL_MAX_VERSION),
-		SLE_CONDVAR(Vehicle, waiting_triggers,      SLE_UINT8,                    SLV_2, SL_MAX_VERSION),
+		SLE_CONDVARNAME(Vehicle, waiting_random_triggers, "waiting_triggers", SLE_UINT8, SLV_2, SL_MAX_VERSION),
 
 		SLE_CONDREF(Vehicle, next_shared,           REF_VEHICLE,                  SLV_2, SL_MAX_VERSION),
 		SLE_CONDVAR(Vehicle, group_id,              SLE_UINT16,                  SLV_60, SL_MAX_VERSION),

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -2622,7 +2622,7 @@ CommandCost CmdBuildAirport(DoCommandFlags flags, TileIndex tile, uint8_t airpor
 
 		/* Only call the animation trigger after all tiles have been built */
 		for (AirportTileTableIterator iter(as->layouts[layout].tiles.data(), tile); iter != INVALID_TILE; ++iter) {
-			AirportTileAnimationTrigger(st, iter, AAT_BUILT);
+			TriggerAirportTileAnimation(st, iter, AAT_BUILT);
 		}
 
 		UpdateAirplanesOnNewStation(st);
@@ -3609,7 +3609,7 @@ static void TileLoop_Station(TileIndex tile)
 {
 	switch (GetStationType(tile)) {
 		case StationType::Airport:
-			AirportTileAnimationTrigger(Station::GetByTile(tile), tile, AAT_TILELOOP);
+			TriggerAirportTileAnimation(Station::GetByTile(tile), tile, AAT_TILELOOP);
 			break;
 
 		case StationType::Dock:
@@ -3764,7 +3764,7 @@ void TriggerWatchedCargoCallbacks(Station *st)
 	BitmapTileIterator it(st->catchment_tiles);
 	for (TileIndex tile = it; tile != INVALID_TILE; tile = ++it) {
 		if (IsTileType(tile, MP_HOUSE)) {
-			WatchedCargoCallback(tile, cargoes);
+			TriggerHouseAnimation_WatchedCargoAccepted(tile, cargoes);
 		}
 	}
 }
@@ -4213,7 +4213,7 @@ void OnTick_Station()
 		if ((TimerGameTick::counter + st->index) % Ticks::STATION_ACCEPTANCE_TICKS == 0) {
 			TriggerStationAnimation(st, st->xy, SAT_250_TICKS);
 			TriggerRoadStopAnimation(st, st->xy, SAT_250_TICKS);
-			if (Station::IsExpected(st)) AirportAnimationTrigger(Station::From(st), AAT_STATION_250_TICKS);
+			if (Station::IsExpected(st)) TriggerAirportAnimation(Station::From(st), AAT_STATION_250_TICKS);
 		}
 	}
 }
@@ -4280,7 +4280,7 @@ static uint UpdateStationWaiting(Station *st, CargoType cargo, uint amount, Sour
 
 	TriggerStationRandomisation(st, st->xy, SRT_NEW_CARGO, cargo);
 	TriggerStationAnimation(st, st->xy, SAT_NEW_CARGO, cargo);
-	AirportAnimationTrigger(st, AAT_STATION_NEW_CARGO, cargo);
+	TriggerAirportAnimation(st, AAT_STATION_NEW_CARGO, cargo);
 	TriggerRoadStopRandomisation(st, st->xy, RSRT_NEW_CARGO, cargo);
 	TriggerRoadStopAnimation(st, st->xy, SAT_NEW_CARGO, cargo);
 

--- a/src/table/build_industry.h
+++ b/src/table/build_industry.h
@@ -1531,7 +1531,7 @@ static const IndustrySpec _origin_industry_specs[NEW_INDUSTRYOFFSET] = {
  * @param sl  slope refused upon choosing a place to build
  * @param a1  animation frame on production
  * @param a2  next frame of animation
- * @param a3  chooses between animation or construction state
+ * @param a3  chooses between animation or construction stage
  */
 #define MT(ca1, c1, ca2, c2, ca3, c3, sl, a1, a2, a3) { \
 	{INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO}, \

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -97,8 +97,8 @@ static const NICallback _nic_stations[] = {
 	NICS(CBID_STATION_AVAILABILITY,     StationCallbackMask::Avail),
 	NICS(CBID_STATION_DRAW_TILE_LAYOUT, StationCallbackMask::DrawTileLayout),
 	NICS(CBID_STATION_BUILD_TILE_LAYOUT,std::monostate{}),
-	NICS(CBID_STATION_ANIM_START_STOP,  std::monostate{}),
-	NICS(CBID_STATION_ANIM_NEXT_FRAME,  StationCallbackMask::AnimationNextFrame),
+	NICS(CBID_STATION_ANIMATION_TRIGGER, std::monostate{}),
+	NICS(CBID_STATION_ANIMATION_NEXT_FRAME, StationCallbackMask::AnimationNextFrame),
 	NICS(CBID_STATION_ANIMATION_SPEED,  StationCallbackMask::AnimationSpeed),
 	NICS(CBID_STATION_LAND_SLOPE_CHECK, StationCallbackMask::SlopeCheck),
 };
@@ -160,8 +160,8 @@ static const NIFeature _nif_station = {
 static const NICallback _nic_house[] = {
 	NICH(CBID_HOUSE_ALLOW_CONSTRUCTION,        HouseCallbackMask::AllowConstruction),
 	NICH(CBID_HOUSE_ANIMATION_NEXT_FRAME,      HouseCallbackMask::AnimationNextFrame),
-	NICH(CBID_HOUSE_ANIMATION_START_STOP,      HouseCallbackMask::AnimationStartStop),
-	NICH(CBID_HOUSE_CONSTRUCTION_STAGE_CHANGE, HouseCallbackMask::ConstructionStageChange),
+	NICH(CBID_HOUSE_ANIMATION_TRIGGER_TILE_LOOP, HouseCallbackMask::AnimationTriggerTileLoop),
+	NICH(CBID_HOUSE_ANIMATION_TRIGGER_CONSTRUCTION_STAGE_CHANGED, HouseCallbackMask::AnimationTriggerConstructionStageChanged),
 	NICH(CBID_HOUSE_COLOUR,                    HouseCallbackMask::Colour),
 	NICH(CBID_HOUSE_CARGO_ACCEPTANCE,          HouseCallbackMask::CargoAcceptance),
 	NICH(CBID_HOUSE_ANIMATION_SPEED,           HouseCallbackMask::AnimationSpeed),
@@ -169,7 +169,7 @@ static const NICallback _nic_house[] = {
 	NICH(CBID_HOUSE_ACCEPT_CARGO,              HouseCallbackMask::AcceptCargo),
 	NICH(CBID_HOUSE_PRODUCE_CARGO,             HouseCallbackMask::ProduceCargo),
 	NICH(CBID_HOUSE_DENY_DESTRUCTION,          HouseCallbackMask::DenyDestruction),
-	NICH(CBID_HOUSE_WATCHED_CARGO_ACCEPTED,    std::monostate{}),
+	NICH(CBID_HOUSE_ANIMATION_TRIGGER_WATCHED_CARGO_ACCEPTED, std::monostate{}),
 	NICH(CBID_HOUSE_CUSTOM_NAME,               std::monostate{}),
 	NICH(CBID_HOUSE_DRAW_FOUNDATIONS,          HouseCallbackMask::DrawFoundations),
 	NICH(CBID_HOUSE_AUTOSLOPE,                 HouseCallbackMask::Autoslope),
@@ -223,8 +223,8 @@ static const NIFeature _nif_house = {
 
 #define NICIT(cb_id, bit) NIC(cb_id, IndustryTileSpec, callback_mask, bit)
 static const NICallback _nic_industrytiles[] = {
-	NICIT(CBID_INDTILE_ANIM_START_STOP,  std::monostate{}),
-	NICIT(CBID_INDTILE_ANIM_NEXT_FRAME,  IndustryTileCallbackMask::AnimationNextFrame),
+	NICIT(CBID_INDTILE_ANIMATION_TRIGGER, std::monostate{}),
+	NICIT(CBID_INDTILE_ANIMATION_NEXT_FRAME, IndustryTileCallbackMask::AnimationNextFrame),
 	NICIT(CBID_INDTILE_ANIMATION_SPEED,  IndustryTileCallbackMask::AnimationSpeed),
 	NICIT(CBID_INDTILE_CARGO_ACCEPTANCE, IndustryTileCallbackMask::CargoAcceptance),
 	NICIT(CBID_INDTILE_ACCEPT_CARGO,     IndustryTileCallbackMask::AcceptCargo),
@@ -394,7 +394,7 @@ static const NIFeature _nif_industry = {
 static const NICallback _nic_objects[] = {
 	NICO(CBID_OBJECT_LAND_SLOPE_CHECK,     ObjectCallbackMask::SlopeCheck),
 	NICO(CBID_OBJECT_ANIMATION_NEXT_FRAME, ObjectCallbackMask::AnimationNextFrame),
-	NICO(CBID_OBJECT_ANIMATION_START_STOP, std::monostate{}),
+	NICO(CBID_OBJECT_ANIMATION_TRIGGER, std::monostate{}),
 	NICO(CBID_OBJECT_ANIMATION_SPEED,      ObjectCallbackMask::AnimationSpeed),
 	NICO(CBID_OBJECT_COLOUR,               ObjectCallbackMask::Colour),
 	NICO(CBID_OBJECT_FUND_MORE_TEXT,       ObjectCallbackMask::FundMoreText),
@@ -485,8 +485,8 @@ static const NIFeature _nif_railtype = {
 #define NICAT(cb_id, bit) NIC(cb_id, AirportTileSpec, callback_mask, bit)
 static const NICallback _nic_airporttiles[] = {
 	NICAT(CBID_AIRPTILE_DRAW_FOUNDATIONS, AirportTileCallbackMask::DrawFoundations),
-	NICAT(CBID_AIRPTILE_ANIM_START_STOP,  std::monostate{}),
-	NICAT(CBID_AIRPTILE_ANIM_NEXT_FRAME,  AirportTileCallbackMask::AnimationNextFrame),
+	NICAT(CBID_AIRPTILE_ANIMATION_TRIGGER, std::monostate{}),
+	NICAT(CBID_AIRPTILE_ANIMATION_NEXT_FRAME, AirportTileCallbackMask::AnimationNextFrame),
 	NICAT(CBID_AIRPTILE_ANIMATION_SPEED,  AirportTileCallbackMask::AnimationSpeed),
 };
 
@@ -665,8 +665,8 @@ static const NIFeature _nif_tramtype = {
 #define NICRS(cb_id, bit) NIC(cb_id, RoadStopSpec, callback_mask, bit)
 static const NICallback _nic_roadstops[] = {
 	NICRS(CBID_STATION_AVAILABILITY,     RoadStopCallbackMask::Avail),
-	NICRS(CBID_STATION_ANIM_START_STOP,  std::monostate{}),
-	NICRS(CBID_STATION_ANIM_NEXT_FRAME,  RoadStopCallbackMask::AnimationNextFrame),
+	NICRS(CBID_STATION_ANIMATION_TRIGGER, std::monostate{}),
+	NICRS(CBID_STATION_ANIMATION_NEXT_FRAME, RoadStopCallbackMask::AnimationNextFrame),
 	NICRS(CBID_STATION_ANIMATION_SPEED,  RoadStopCallbackMask::AnimationSpeed),
 };
 

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -161,7 +161,7 @@ static const NICallback _nic_house[] = {
 	NICH(CBID_HOUSE_ALLOW_CONSTRUCTION,        HouseCallbackMask::AllowConstruction),
 	NICH(CBID_HOUSE_ANIMATION_NEXT_FRAME,      HouseCallbackMask::AnimationNextFrame),
 	NICH(CBID_HOUSE_ANIMATION_START_STOP,      HouseCallbackMask::AnimationStartStop),
-	NICH(CBID_HOUSE_CONSTRUCTION_STATE_CHANGE, HouseCallbackMask::ConstructionStateChange),
+	NICH(CBID_HOUSE_CONSTRUCTION_STAGE_CHANGE, HouseCallbackMask::ConstructionStageChange),
 	NICH(CBID_HOUSE_COLOUR,                    HouseCallbackMask::Colour),
 	NICH(CBID_HOUSE_CARGO_ACCEPTANCE,          HouseCallbackMask::CargoAcceptance),
 	NICH(CBID_HOUSE_ANIMATION_SPEED,           HouseCallbackMask::AnimationSpeed),
@@ -176,7 +176,7 @@ static const NICallback _nic_house[] = {
 };
 
 static const NIVariable _niv_house[] = {
-	NIV(0x40, "construction state of tile and pseudo-random value"),
+	NIV(0x40, "construction stage of tile and pseudo-random value"),
 	NIV(0x41, "age of building in years"),
 	NIV(0x42, "town zone"),
 	NIV(0x43, "terrain type"),
@@ -234,7 +234,7 @@ static const NICallback _nic_industrytiles[] = {
 };
 
 static const NIVariable _niv_industrytiles[] = {
-	NIV(0x40, "construction state of tile"),
+	NIV(0x40, "construction stage of tile"),
 	NIV(0x41, "ground type"),
 	NIV(0x42, "current town zone in nearest town"),
 	NIV(0x43, "relative position"),

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -503,7 +503,7 @@ static void AdvanceSingleHouseConstruction(TileIndex tile)
 	IncHouseConstructionTick(tile);
 	if (GetHouseConstructionTick(tile) != 0) return;
 
-	AnimateNewHouseConstruction(tile);
+	TriggerHouseAnimation_ConstructionStageChanged(tile);
 
 	if (IsHouseCompleted(tile)) {
 		/* Now that construction is complete, we can add the population of the

--- a/src/town_map.h
+++ b/src/town_map.h
@@ -307,7 +307,7 @@ inline uint8_t GetHouseRandomBits(Tile t)
  * @param triggers the activated triggers
  * @pre IsTileType(t, MP_HOUSE)
  */
-inline void SetHouseTriggers(Tile t, uint8_t triggers)
+inline void SetHouseRandomTriggers(Tile t, uint8_t triggers)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	SB(t.m3(), 0, 5, triggers);
@@ -320,7 +320,7 @@ inline void SetHouseTriggers(Tile t, uint8_t triggers)
  * @pre IsTileType(t, MP_HOUSE)
  * @return triggers
  */
-inline uint8_t GetHouseTriggers(Tile t)
+inline uint8_t GetHouseRandomTriggers(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	return GB(t.m3(), 0, 5);

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -972,7 +972,7 @@ static void RunEconomyVehicleDayProc()
 			uint16_t callback = GetVehicleCallback(CBID_VEHICLE_32DAY_CALLBACK, 0, 0, v->engine_type, v);
 			if (callback != CALLBACK_FAILED) {
 				if (HasBit(callback, 0)) {
-					TriggerVehicle(v, VEHICLE_TRIGGER_CALLBACK_32); // Trigger vehicle trigger 10
+					TriggerVehicleRandomisation(v, VEHICLE_TRIGGER_CALLBACK_32); // Trigger vehicle trigger 10
 				}
 
 				/* After a vehicle trigger, the graphics and properties of the vehicle could change.
@@ -1614,7 +1614,7 @@ void VehicleEnterDepot(Vehicle *v)
 	VehicleEnteredDepotThisTick(v);
 
 	/* After a vehicle trigger, the graphics and properties of the vehicle could change. */
-	TriggerVehicle(v, VEHICLE_TRIGGER_DEPOT);
+	TriggerVehicleRandomisation(v, VEHICLE_TRIGGER_DEPOT);
 	v->MarkDirty();
 
 	InvalidateWindowData(WC_VEHICLE_VIEW, v->index);

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -311,7 +311,7 @@ public:
 	uint32_t motion_counter = 0; ///< counter to occasionally play a vehicle sound.
 	uint8_t progress = 0; ///< The percentage (if divided by 256) this vehicle already crossed the tile unit.
 
-	uint8_t waiting_triggers = 0; ///< Triggers to be yet matched before rerandomizing the random bits.
+	uint8_t waiting_random_triggers = 0; ///< Triggers to be yet matched before rerandomizing the random bits.
 	uint16_t random_bits = 0; ///< Bits used for randomized variational spritegroups.
 
 	StationID last_station_visited = StationID::Invalid(); ///< The last station we stopped at.


### PR DESCRIPTION
## Motivation / Problem

There are two types of "triggers" for NewGRF stuff: Randomisation and Animation.

The naming in the source is chaotic, which makes it hard to distinguish them.

Also there is a inconsisteny about "construction stage" vs "construction state".

## Description

Unify naming to match these patterns:
* Use the term "construction stage", to distinguish it from "animation state".
* Randomisation trigger callbacks: `Trigger<Feature>[Tile]Randomisation`
    * `TriggerHouseRandomisation`
    * `TriggerIndustryRandomisation`, `TriggerIndustryTileRandomisation`
    * `TriggerRoadStopRandomisation`
    * `TriggerStationRandomisation`
* Animation trigger callbacks: `Trigger<Feature>[Tile]Animation`, `CBID_<Feature>_ANIMATION_TRIGGER`
    * `TriggerIndustryAnimation`, `TriggerIndustryTileAnimation`, `CBID_INDTILE_ANIMATION_TRIGGER`
    * `TriggerAirportAnimation`, `TriggerAirportTileAnimation`, `CBID_AIRPTILE_ANIMATION_TRIGGER`
    * `TriggerRoadStopAnimation`
    * `TriggerStationAnimation`, `CBID_STATION_ANIMATION_TRIGGER`
    * `TriggerObjectAnimation`, `TriggerObjectTileAnimation`, `CBID_OBJECT_ANIMATION_TRIGGER`
* Houses are special, since they have separate callbacks for each animation trigger. They now share a common prefix, with the trigger appended:
    * `TriggerHouseAnimation_TileLoop`, `CBID_HOUSE_ANIMATION_TRIGGER_TILE_LOOP`
    * `TriggerHouseAnimation_ConstructionStageChanged`, `CBID_HOUSE_ANIMATION_TRIGGER_CONSTRUCTION_STAGE_CHANGED`
    * `TriggerHouseAnimation_WatchedCargoAccepted`, `CBID_HOUSE_ANIMATION_TRIGGER_WATCHED_CARGO_ACCEPTED`

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
