### PR TITLE
Fix: [NewGRF] Animation speed properties of houses and stations had wrong default.

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -696,7 +696,7 @@ static void AnimateTile_Industry(TileIndex tile)
 {
 	IndustryGfx gfx = GetIndustryGfx(tile);
 
-	if (GetIndustryTileSpec(gfx)->animation.status != ANIM_STATUS_NO_ANIMATION) {
+	if (GetIndustryTileSpec(gfx)->animation.status != AnimationStatus::NoAnimation) {
 		AnimateNewIndustryTile(tile);
 		return;
 	}
@@ -1955,7 +1955,7 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 			/* it->gfx is stored in the map. But the translated ID cur_gfx is the interesting one */
 			IndustryGfx cur_gfx = GetTranslatedIndustryTileID(it.gfx);
 			const IndustryTileSpec *its = GetIndustryTileSpec(cur_gfx);
-			if (its->animation.status != ANIM_STATUS_NO_ANIMATION) AddAnimatedTile(cur_tile);
+			if (its->animation.status != AnimationStatus::NoAnimation) AddAnimatedTile(cur_tile);
 		}
 	}
 

--- a/src/newgrf/newgrf_act0_airports.cpp
+++ b/src/newgrf/newgrf_act0_airports.cpp
@@ -210,7 +210,7 @@ static ChangeInfoResult AirportTilesChangeInfo(uint first, uint last, int prop, 
 
 					tsp->enabled = true;
 
-					tsp->animation.status = ANIM_STATUS_NO_ANIMATION;
+					tsp->animation = AnimationInfo{};
 
 					tsp->grf_prop.local_id = id;
 					tsp->grf_prop.subst_id = subs_id;
@@ -239,7 +239,7 @@ static ChangeInfoResult AirportTilesChangeInfo(uint first, uint last, int prop, 
 
 			case 0x0F: // Animation information
 				tsp->animation.frames = buf.ReadByte();
-				tsp->animation.status = buf.ReadByte();
+				tsp->animation.status = static_cast<AnimationStatus>(buf.ReadByte());
 				break;
 
 			case 0x10: // Animation speed

--- a/src/newgrf/newgrf_act0_houses.cpp
+++ b/src/newgrf/newgrf_act0_houses.cpp
@@ -253,11 +253,12 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 				housespec->extra_flags = static_cast<HouseExtraFlags>(buf.ReadByte());
 				break;
 
-			case 0x1A: // Animation frames
-				housespec->animation.frames = buf.ReadByte();
-				housespec->animation.status = GB(housespec->animation.frames, 7, 1);
-				SB(housespec->animation.frames, 7, 1, 0);
+			case 0x1A: { // Animation frames
+				uint8_t info = buf.ReadByte();
+				housespec->animation.frames = GB(info, 0, 7);
+				housespec->animation.status = HasBit(info, 7) ? AnimationStatus::Looping : AnimationStatus::NonLooping;
 				break;
+			}
 
 			case 0x1B: // Animation speed
 				housespec->animation.speed = Clamp(buf.ReadByte(), 2, 16);

--- a/src/newgrf/newgrf_act0_industries.cpp
+++ b/src/newgrf/newgrf_act0_industries.cpp
@@ -152,7 +152,7 @@ static ChangeInfoResult IndustrytilesChangeInfo(uint first, uint last, int prop,
 
 			case 0x0F: // Animation information
 				tsp->animation.frames = buf.ReadByte();
-				tsp->animation.status = buf.ReadByte();
+				tsp->animation.status = static_cast<AnimationStatus>(buf.ReadByte());
 				break;
 
 			case 0x10: // Animation speed

--- a/src/newgrf/newgrf_act0_objects.cpp
+++ b/src/newgrf/newgrf_act0_objects.cpp
@@ -151,7 +151,7 @@ static ChangeInfoResult ObjectChangeInfo(uint first, uint last, int prop, ByteRe
 
 			case 0x11: // Animation info
 				spec->animation.frames = buf.ReadByte();
-				spec->animation.status = buf.ReadByte();
+				spec->animation.status = static_cast<AnimationStatus>(buf.ReadByte());
 				break;
 
 			case 0x12: // Animation speed

--- a/src/newgrf/newgrf_act0_roadstops.cpp
+++ b/src/newgrf/newgrf_act0_roadstops.cpp
@@ -115,7 +115,7 @@ static ChangeInfoResult RoadStopChangeInfo(uint first, uint last, int prop, Byte
 
 			case 0x0E: // Animation info
 				rs->animation.frames = buf.ReadByte();
-				rs->animation.status = buf.ReadByte();
+				rs->animation.status = static_cast<AnimationStatus>(buf.ReadByte());
 				break;
 
 			case 0x0F: // Animation speed

--- a/src/newgrf/newgrf_act0_stations.cpp
+++ b/src/newgrf/newgrf_act0_stations.cpp
@@ -235,7 +235,7 @@ static ChangeInfoResult StationChangeInfo(uint first, uint last, int prop, ByteR
 
 			case 0x16: // Animation info
 				statspec->animation.frames = buf.ReadByte();
-				statspec->animation.status = buf.ReadByte();
+				statspec->animation.status = static_cast<AnimationStatus>(buf.ReadByte());
 				break;
 
 			case 0x17: // Animation speed

--- a/src/newgrf_animation_base.h
+++ b/src/newgrf_animation_base.h
@@ -103,7 +103,7 @@ struct AnimationBase {
 		if (!frame_set_by_callback) {
 			if (frame < num_frames) {
 				frame++;
-			} else if (frame == num_frames && spec->animation.status == ANIM_STATUS_LOOPING) {
+			} else if (frame == num_frames && spec->animation.status == AnimationStatus::Looping) {
 				/* This animation loops, so start again from the beginning */
 				frame = 0;
 			} else {

--- a/src/newgrf_animation_type.h
+++ b/src/newgrf_animation_type.h
@@ -10,16 +10,18 @@
 #ifndef NEWGRF_ANIMATION_TYPE_H
 #define NEWGRF_ANIMATION_TYPE_H
 
-static const uint8_t ANIM_STATUS_NON_LOOPING  = 0x00; ///< Animation is not looping.
-static const uint8_t ANIM_STATUS_LOOPING      = 0x01; ///< Animation is looping.
-static const uint8_t ANIM_STATUS_NO_ANIMATION = 0xFF; ///< There is no animation.
+enum class AnimationStatus : uint8_t {
+	NonLooping = 0x00, ///< Animation is not looping.
+	Looping = 0x01, ///< Animation is looping.
+	NoAnimation = 0xFF, ///< There is no animation.
+};
 
 /** Information about animation. */
 struct AnimationInfo {
-	uint8_t  frames;   ///< The number of frames.
-	uint8_t  status;   ///< Status; 0: no looping, 1: looping, 0xFF: no animation.
-	uint8_t  speed;    ///< The speed, i.e. the amount of time between frames.
-	uint16_t triggers; ///< The triggers that trigger animation.
+	uint8_t frames = 0; ///< The number of frames.
+	AnimationStatus status = AnimationStatus::NoAnimation; ///< Status.
+	uint8_t speed = 2; ///< The speed: time between frames = 2^speed ticks.
+	uint16_t triggers = 0; ///< The triggers that trigger animation.
 };
 
 /** Animation triggers for station. */

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -60,7 +60,8 @@ DECLARE_INCREMENT_DECREMENT_OPERATORS(ObjectClassID)
 struct ObjectSpec : NewGRFSpecBase<ObjectClassID> {
 	/* 2 because of the "normal" and "buy" sprite stacks. */
 	FixedGRFFileProps<2> grf_prop; ///< Properties related the the grf file
-	AnimationInfo animation;      ///< Information about the animation.
+	/* Animation speed default differs from other features */
+	AnimationInfo animation{0, AnimationStatus::NoAnimation, 0, 0};  ///< Information about the animation.
 	StringID name;                ///< The name for this object.
 
 	LandscapeTypes climate; ///< In which climates is this object available?

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -119,7 +119,7 @@ struct StationSpec : NewGRFSpecBase<StationClassID> {
 		disallowed_platforms(0), disallowed_lengths(0),
 		cargo_threshold(0), cargo_triggers(0),
 		callback_mask(0), flags(0),
-		animation({0, 0, 0, 0}) {}
+		animation({0, 0, 2, 0}) {}
 	/**
 	 * Properties related the the grf file.
 	 * NUM_CARGO real cargo plus three pseudo cargo sprite groups.

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -118,8 +118,8 @@ struct StationSpec : NewGRFSpecBase<StationClassID> {
 	StationSpec() : name(0),
 		disallowed_platforms(0), disallowed_lengths(0),
 		cargo_threshold(0), cargo_triggers(0),
-		callback_mask(0), flags(0),
-		animation({0, 0, 2, 0}) {}
+		callback_mask(0), flags(0)
+	{}
 	/**
 	 * Properties related the the grf file.
 	 * NUM_CARGO real cargo plus three pseudo cargo sprite groups.

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -2617,7 +2617,7 @@ CommandCost CmdBuildAirport(DoCommandFlags flags, TileIndex tile, uint8_t airpor
 			SetStationTileRandomBits(t, GB(Random(), 0, 4));
 			st->airport.Add(iter);
 
-			if (AirportTileSpec::Get(GetTranslatedAirportTileID(iter.GetStationGfx()))->animation.status != ANIM_STATUS_NO_ANIMATION) AddAnimatedTile(t);
+			if (AirportTileSpec::Get(GetTranslatedAirportTileID(iter.GetStationGfx()))->animation.status != AnimationStatus::NoAnimation) AddAnimatedTile(t);
 		}
 
 		/* Only call the animation trigger after all tiles have been built */

--- a/src/table/airporttiles.h
+++ b/src/table/airporttiles.h
@@ -11,9 +11,9 @@
 #define AIRPORTTILES_H
 
 /** Writes all airport tile properties in the AirportTile struct */
-#define AT(num_frames, anim_speed) {{num_frames, ANIM_STATUS_LOOPING, anim_speed, 0}, STR_NULL, AirportTileCallbackMasks{}, 0, true, GRFFileProps(INVALID_AIRPORTTILE), {}}
+#define AT(num_frames, anim_speed) {{num_frames, AnimationStatus::Looping, anim_speed, 0}, STR_NULL, AirportTileCallbackMasks{}, 0, true, GRFFileProps(INVALID_AIRPORTTILE), {}}
 /** Writes an airport tile without animation in the AirportTile struct */
-#define AT_NOANIM {{0, ANIM_STATUS_NO_ANIMATION, 2, 0}, STR_NULL, AirportTileCallbackMasks{}, 0, true, GRFFileProps(INVALID_AIRPORTTILE), {}}
+#define AT_NOANIM {AnimationInfo{}, STR_NULL, AirportTileCallbackMasks{}, 0, true, GRFFileProps(INVALID_AIRPORTTILE), {}}
 
 /**
  * All default airport tiles.

--- a/src/table/build_industry.h
+++ b/src/table/build_industry.h
@@ -1533,7 +1533,7 @@ static const IndustrySpec _origin_industry_specs[NEW_INDUSTRYOFFSET] = {
  */
 #define MT(ca1, c1, ca2, c2, ca3, c3, sl, a1, a2, a3) { \
 	{INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO}, \
-	{ca1, ca2, ca3}, sl, a1, a2, a3, IndustryTileCallbackMasks{}, {0, ANIM_STATUS_NO_ANIMATION, 2, 0}, IndustryTileSpecialFlags{}, true, GRFFileProps(INVALID_INDUSTRYTILE), {}, {c1, c2, c3} \
+	{ca1, ca2, ca3}, sl, a1, a2, a3, IndustryTileCallbackMasks{}, AnimationInfo{}, IndustryTileSpecialFlags{}, true, GRFFileProps(INVALID_INDUSTRYTILE), {}, {c1, c2, c3} \
 }
 static const IndustryTileSpec _origin_industry_tile_specs[NEW_INDUSTRYTILEOFFSET] = {
 	/* Coal Mine */

--- a/src/table/object_land.h
+++ b/src/table/object_land.h
@@ -104,7 +104,7 @@ static const DrawTileSpriteSpan _object_hq[] = {
 #undef TILE_SPRITE_LINE
 #undef TILE_SPRITE_LINE_NOTHING
 
-#define M(name, size, build_cost_multiplier, clear_cost_multiplier, height, climate, gen_amount, flags) {{INVALID_OBJECT_CLASS, 0}, FixedGRFFileProps<2>{}, {0, 0, 0, 0}, name, climate, size, build_cost_multiplier, clear_cost_multiplier, TimerGameCalendar::Date{}, CalendarTime::MAX_DATE + 1, flags, ObjectCallbackMasks{}, height, 1, gen_amount, {}}
+#define M(name, size, build_cost_multiplier, clear_cost_multiplier, height, climate, gen_amount, flags) {{INVALID_OBJECT_CLASS, 0}, FixedGRFFileProps<2>{}, AnimationInfo{}, name, climate, size, build_cost_multiplier, clear_cost_multiplier, TimerGameCalendar::Date{}, CalendarTime::MAX_DATE + 1, flags, ObjectCallbackMasks{}, height, 1, gen_amount, {}}
 
 /* Climates
  * T = Temperate

--- a/src/table/town_land.h
+++ b/src/table/town_land.h
@@ -1814,7 +1814,7 @@ static_assert(lengthof(_town_draw_tile_data) == (NEW_HOUSE_OFFSET) * 4 * 4);
 	{ca1, ca2, ca3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, \
 	{INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO}, \
 	bf, ba, true, GRFFileProps(INVALID_HOUSE_ID), HouseCallbackMasks{}, {COLOUR_BEGIN, COLOUR_BEGIN, COLOUR_BEGIN, COLOUR_BEGIN}, \
-	16, HouseExtraFlags{}, HOUSE_NO_CLASS, {0, 0, 2, 0}, 0, 0, 0, {}, {cg1, cg2, cg3}, }
+	16, HouseExtraFlags{}, HOUSE_NO_CLASS, AnimationInfo{}, 0, 0, 0, {}, {cg1, cg2, cg3}, }
 /** House specifications from original data */
 extern const HouseSpec _original_house_specs[] = {
 	/**

--- a/src/table/town_land.h
+++ b/src/table/town_land.h
@@ -1814,7 +1814,7 @@ static_assert(lengthof(_town_draw_tile_data) == (NEW_HOUSE_OFFSET) * 4 * 4);
 	{ca1, ca2, ca3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, \
 	{INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO}, \
 	bf, ba, true, GRFFileProps(INVALID_HOUSE_ID), HouseCallbackMasks{}, {COLOUR_BEGIN, COLOUR_BEGIN, COLOUR_BEGIN, COLOUR_BEGIN}, \
-	16, HouseExtraFlags{}, HOUSE_NO_CLASS, {0, 2, 0, 0}, 0, 0, 0, {}, {cg1, cg2, cg3}, }
+	16, HouseExtraFlags{}, HOUSE_NO_CLASS, {0, 0, 2, 0}, 0, 0, 0, {}, {cg1, cg2, cg3}, }
 /** House specifications from original data */
 extern const HouseSpec _original_house_specs[] = {
 	/**


### PR DESCRIPTION
## Motivation / Problem

The animation speed property is specified to default to 2 for all features, except objects (sigh).

* For stations, we set a default of 0.
* For houses, the default was broken in e2e26190d55

## Description

* Fix the default for stations and houses.
* Turn `AnimationStatus` into an `enum class`.
* The default for `AnimationInfo::status` is technically also changed/fixed, but this does not matter since `NoAnimation` is only special for industries and airports, which had the correct default already.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
