### PR TITLE
Add: clang-format file to simplify contributions and review.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,269 @@
+Language:        Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseArrows: false
+  AlignCaseColons: false
+AlignConsecutiveTableGenBreakingDAGArgColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenCondOperatorColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenDefinitionColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignEscapedNewlines: DontAlign
+AlignOperands:   DontAlign
+AlignTrailingComments:
+  Kind:            Never
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowBreakBeforeNoexceptSpecifier: Never
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseExpressionOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLambdasOnASingleLine: Empty
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterExternBlock: false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAdjacentStringLiterals: false
+BreakAfterAttributes: Never
+BreakAfterReturnType: None
+BreakArrays:     false
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: WebKit
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: AfterColon
+BreakFunctionDefinitionParameters: false
+BreakInheritanceList: AfterColon
+BreakStringLiterals: false
+BreakTemplateDeclarations: Yes
+ColumnLimit:     200
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+IncludeBlocks:   Regroup
+IncludeIsMainRegex: '$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentExternBlock: Indent
+IndentGotoLabels: true
+IndentPPDirectives: AfterHash
+IndentRequiresClause: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: true
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
+KeepEmptyLines:
+  AtEndOfFile:     false
+  AtStartOfBlock:  false
+  AtStartOfFile:   false
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MainIncludeChar: Quote
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+ObjCBinPackProtocolList: Always
+ObjCBlockIndentWidth: 4
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: BinPack
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Right
+PPIndentWidth:   -1
+QualifierAlignment: Custom
+QualifierOrder: [static, inline, const, volatile, type]
+ReferenceAlignment: Pointer
+ReflowComments:  false
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Always
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: true
+SortIncludes:    CaseInsensitive
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatementsExceptControlMacros
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: false
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   false
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: true
+  AfterRequiresInExpression: true
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInContainerLiterals: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInParensOptions:
+  ExceptDoubleParentheses: false
+  InCStyleCasts:   false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other:           false
+SpacesInSquareBrackets: false
+Standard:        Latest
+TabWidth:        4
+UseTab:          AlignWithSpaces
+
+IncludeCategories:
+  - Regex:           '^.*stdafx.h.*'
+    Priority:        -1
+    SortPriority:    -1
+    CaseSensitive:   false
+  - Regex:           '^.*safeguards.h.*'
+    Priority:        90
+    SortPriority:    90
+    CaseSensitive:   false
+  - Regex:           '^.*widgets/.*'
+    Priority:        80
+    SortPriority:    80
+    CaseSensitive:   false
+  - Regex:           '^.*table/.*'
+    Priority:        80
+    SortPriority:    81
+    CaseSensitive:   false
+  - Regex:           '^.*core/.*'
+    Priority:        20
+    CaseSensitive:   false
+  - Regex:           '^.*3rdparty/.*'
+    Priority:        10
+    SortPriority:    12
+    CaseSensitive:   false
+  - Regex:           '^<windows.h>'
+    Priority:        10
+    SortPriority:    10
+    CaseSensitive:   false
+  - Regex:           '^<.*>'
+    Priority:        10
+    SortPriority:    11
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        20
+    SortPriority:    50
+    CaseSensitive:   false

--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -28,6 +28,7 @@
 
 
 /** Widgets for the configure AI window. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_ai_config_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_MAUVE),
@@ -81,6 +82,7 @@ static constexpr NWidgetPart _nested_ai_config_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Window definition for the configure AI window. */
 static WindowDesc _ai_config_desc(

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -197,6 +197,7 @@ struct BuildAirToolbarWindow : Window {
 	}, AirportToolbarGlobalHotkeys};
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_air_toolbar_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -209,6 +210,7 @@ static constexpr NWidgetPart _nested_air_toolbar_widgets[] = {
 		NWidget(WWT_IMGBTN, COLOUR_DARK_GREEN, WID_AT_DEMOLISH), SetFill(0, 1), SetMinimalSize(22, 22), SetSpriteTip(SPR_IMG_DYNAMITE, STR_TOOLTIP_DEMOLISH_BUILDINGS_ETC),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _air_toolbar_desc(
 	WDP_ALIGN_TOOLBAR, "toolbar_air", 0, 0,
@@ -580,6 +582,7 @@ public:
 	}};
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_airport_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -616,6 +619,7 @@ static constexpr NWidgetPart _nested_build_airport_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _build_airport_desc(
 	WDP_AUTO, nullptr, 0, 0,

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -699,6 +699,7 @@ public:
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_replace_rail_vehicle_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -755,6 +756,7 @@ static constexpr NWidgetPart _nested_replace_rail_vehicle_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _replace_rail_vehicle_desc(
 	WDP_AUTO, "replace_vehicle_train", 500, 140,
@@ -763,6 +765,7 @@ static WindowDesc _replace_rail_vehicle_desc(
 	_nested_replace_rail_vehicle_widgets
 );
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_replace_road_vehicle_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -813,6 +816,7 @@ static constexpr NWidgetPart _nested_replace_road_vehicle_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _replace_road_vehicle_desc(
 	WDP_AUTO, "replace_vehicle_road", 500, 140,
@@ -821,6 +825,7 @@ static WindowDesc _replace_road_vehicle_desc(
 	_nested_replace_road_vehicle_widgets
 );
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_replace_vehicle_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -867,6 +872,7 @@ static constexpr NWidgetPart _nested_replace_vehicle_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _replace_vehicle_desc(
 	WDP_AUTO, "replace_vehicle", 456, 118,

--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -33,10 +33,12 @@
 #include "safeguards.h"
 
 /** Widgets for the background window to prevent smearing. */
+/* clang-format off */
 static constexpr NWidgetPart _background_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_DARK_BLUE, WID_BB_BACKGROUND), SetResize(1, 1),
 	EndContainer(),
 };
+/* clang-format on */
 
 /**
  * Window description for the background window to prevent smearing.
@@ -66,6 +68,7 @@ public:
 };
 
 /** Nested widgets for the error window. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_bootstrap_errmsg_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CAPTION, COLOUR_GREY, WID_BEM_CAPTION), SetStringTip(STR_MISSING_GRAPHICS_ERROR_TITLE),
@@ -75,6 +78,7 @@ static constexpr NWidgetPart _nested_bootstrap_errmsg_widgets[] = {
 		NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_BEM_QUIT), SetStringTip(STR_MISSING_GRAPHICS_ERROR_QUIT), SetFill(1, 0),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Window description for the error window. */
 static WindowDesc _bootstrap_errmsg_desc(
@@ -123,6 +127,7 @@ public:
 };
 
 /** Nested widgets for the download window. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_bootstrap_download_status_window_widgets[] = {
 	NWidget(WWT_CAPTION, COLOUR_GREY), SetStringTip(STR_CONTENT_DOWNLOAD_TITLE, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
 	NWidget(WWT_PANEL, COLOUR_GREY),
@@ -132,6 +137,7 @@ static constexpr NWidgetPart _nested_bootstrap_download_status_window_widgets[] 
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Window description for the download window */
 static WindowDesc _bootstrap_download_status_window_desc(
@@ -174,6 +180,7 @@ public:
 };
 
 /** The widgets for the query. It has no close box as that sprite does not exist yet. */
+/* clang-format off */
 static constexpr NWidgetPart _bootstrap_query_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CAPTION, COLOUR_GREY), SetStringTip(STR_MISSING_GRAPHICS_SET_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
@@ -184,6 +191,7 @@ static constexpr NWidgetPart _bootstrap_query_widgets[] = {
 		NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_BAFD_NO), SetStringTip(STR_MISSING_GRAPHICS_NO_QUIT),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** The window description for the query. */
 static WindowDesc _bootstrap_query_desc(

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -309,6 +309,7 @@ const std::initializer_list<GUIBridgeList::SortFunction * const> BuildBridgeWind
 };
 
 /** Widgets of the bridge gui. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_bridge_widgets[] = {
 	/* Header */
 	NWidget(NWID_HORIZONTAL),
@@ -335,6 +336,7 @@ static constexpr NWidgetPart _nested_build_bridge_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Window definition for the rail bridge selection window. */
 static WindowDesc _build_bridge_desc(

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -57,6 +57,7 @@ uint GetEngineListHeight(VehicleType type)
 	return std::max<uint>(GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.matrix.Vertical(), GetVehicleImageCellSize(type, EIT_PURCHASE).height);
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_vehicle_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -95,6 +96,7 @@ static constexpr NWidgetPart _nested_build_vehicle_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 
 bool _engine_sort_direction; ///< \c false = descending, \c true = ascending.

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -218,6 +218,7 @@ static const CheatEntry _cheats_ui[] = {
 static_assert(CHT_NUM_CHEATS == lengthof(_cheats_ui));
 
 /** Widget definitions of the cheat GUI. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_cheat_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -232,6 +233,7 @@ static constexpr NWidgetPart _nested_cheat_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** GUI for the cheats. */
 struct CheatWindow : Window {

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -284,6 +284,7 @@ static void DrawYearColumn(const Rect &r, TimerGameEconomy::Year year, const Exp
 	DrawPrice(sum, r.left, r.right, y, TC_WHITE);
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_company_finances_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -331,6 +332,7 @@ static constexpr NWidgetPart _nested_company_finances_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Window class displaying the company finances. */
 struct CompanyFinancesWindow : Window {
@@ -1067,6 +1069,7 @@ public:
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_select_company_livery_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -1098,6 +1101,7 @@ static constexpr NWidgetPart _nested_select_company_livery_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _select_company_livery_desc(
 	WDP_AUTO, "company_color_scheme", 0, 0,
@@ -1165,6 +1169,7 @@ void DrawCompanyManagerFace(CompanyManagerFace cmf, Colours colour, const Rect &
 }
 
 /** Nested widget description for the company manager face selection dialog */
+/* clang-format off */
 static constexpr NWidgetPart _nested_select_company_manager_face_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -1320,6 +1325,7 @@ static constexpr NWidgetPart _nested_select_company_manager_face_widgets[] = {
 		NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SCMF_ACCEPT), SetFill(1, 0), SetStringTip(STR_BUTTON_OK, STR_FACE_OK_TOOLTIP),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Management class for customizing the face of the company manager. */
 class SelectCompanyManagerFaceWindow : public Window
@@ -1724,6 +1730,7 @@ static void DoSelectCompanyManagerFace(Window *parent)
 	new SelectCompanyManagerFaceWindow(_select_company_manager_face_desc, parent);
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_company_infrastructure_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -1742,6 +1749,7 @@ static constexpr NWidgetPart _nested_company_infrastructure_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /**
  * Window with detailed information about the company's infrastructure.
@@ -2028,6 +2036,7 @@ static void ShowCompanyInfrastructure(CompanyID company)
 	AllocateWindowDescFront<CompanyInfrastructureWindow>(_company_infrastructure_desc, company);
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_company_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -2103,6 +2112,7 @@ static constexpr NWidgetPart _nested_company_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Strings for the company vehicle counts */
 static const StringID _company_view_vehicle_count_strings[] = {
@@ -2591,6 +2601,7 @@ private:
 	Money company_value{}; ///< The value of the company for which the user can buy it.
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_buy_company_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_LIGHT_BLUE),
@@ -2609,6 +2620,7 @@ static constexpr NWidgetPart _nested_buy_company_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _buy_company_desc(
 	WDP_AUTO, nullptr, 0, 0,

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -132,9 +132,11 @@ static inline void IConsoleResetHistoryPos()
 static const char *IConsoleHistoryAdd(const char *cmd);
 static void IConsoleHistoryNavigate(int direction);
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_console_window_widgets[] = {
 	NWidget(WWT_EMPTY, INVALID_COLOUR, WID_C_BACKGROUND), SetResize(1, 1),
 };
+/* clang-format on */
 
 static WindowDesc _console_window_desc(
 	WDP_MANUAL, nullptr, 0, 0,

--- a/src/core/bitmath_func.hpp
+++ b/src/core/bitmath_func.hpp
@@ -29,7 +29,7 @@
  * @return The selected bits, aligned to a LSB.
  */
 template <typename T>
-debug_inline constexpr static uint GB(const T x, const uint8_t s, const uint8_t n)
+[[debug_inline]] inline constexpr static uint GB(const T x, const uint8_t s, const uint8_t n)
 {
 	return (x >> s) & (((T)1U << n) - 1);
 }
@@ -100,7 +100,7 @@ constexpr T AB(T &x, const uint8_t s, const uint8_t n, const U i)
  * @return True if the bit is set, false else.
  */
 template <typename T>
-debug_inline constexpr bool HasBit(const T x, const uint8_t y)
+[[debug_inline]] inline constexpr bool HasBit(const T x, const uint8_t y)
 {
 	return (x & ((T)1U << y)) != 0;
 }

--- a/src/core/enum_type.hpp
+++ b/src/core/enum_type.hpp
@@ -90,7 +90,7 @@ inline constexpr enum_type operator --(enum_type &e, int)
  * @return True iff the flag is set.
  */
 template <typename T, class = typename std::enable_if_t<std::is_enum_v<T>>>
-debug_inline constexpr bool HasFlag(const T x, const T y)
+[[debug_inline]] inline constexpr bool HasFlag(const T x, const T y)
 {
 	return (x & y) == y;
 }
@@ -101,7 +101,7 @@ debug_inline constexpr bool HasFlag(const T x, const T y)
  * @param y The flag to toggle.
  */
 template <typename T, class = typename std::enable_if_t<std::is_enum_v<T>>>
-debug_inline constexpr void ToggleFlag(T &x, const T y)
+[[debug_inline]] inline constexpr void ToggleFlag(T &x, const T y)
 {
 	if (HasFlag(x, y)) {
 		x &= ~y;

--- a/src/date_gui.cpp
+++ b/src/date_gui.cpp
@@ -173,6 +173,7 @@ struct SetDateWindow : Window {
 };
 
 /** Widgets for the date setting window. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_set_date_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -193,6 +194,7 @@ static constexpr NWidgetPart _nested_set_date_widgets[] = {
 		EndContainer(),
 	EndContainer()
 };
+/* clang-format on */
 
 /** Description of the date setting window. */
 static WindowDesc _set_date_desc(

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -46,6 +46,7 @@
  */
 
 /** Nested widget definition for train depots. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_train_depot_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -84,6 +85,7 @@ static constexpr NWidgetPart _nested_train_depot_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _train_depot_desc(
 	WDP_AUTO, "depot_train", 362, 123,

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -333,6 +333,7 @@ struct BuildDocksToolbarWindow : Window {
  * Nested widget parts of docks toolbar, game version.
  * Position of #WID_DT_RIVER widget has changed.
  */
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_docks_toolbar_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -350,6 +351,7 @@ static constexpr NWidgetPart _nested_build_docks_toolbar_widgets[] = {
 		NWidget(WWT_IMGBTN, COLOUR_DARK_GREEN, WID_DT_BUILD_AQUEDUCT), SetMinimalSize(23, 22), SetFill(0, 1), SetSpriteTip(SPR_IMG_AQUEDUCT, STR_WATERWAYS_TOOLBAR_BUILD_AQUEDUCT_TOOLTIP),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _build_docks_toolbar_desc(
 	WDP_ALIGN_TOOLBAR, "toolbar_water", 0, 0,
@@ -378,6 +380,7 @@ Window *ShowBuildDocksToolbar()
  * Nested widget parts of docks toolbar, scenario editor version.
  * Positions of #WID_DT_DEPOT, #WID_DT_STATION, and #WID_DT_BUOY widgets have changed.
  */
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_docks_scen_toolbar_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -393,6 +396,7 @@ static constexpr NWidgetPart _nested_build_docks_scen_toolbar_widgets[] = {
 		NWidget(WWT_IMGBTN, COLOUR_DARK_GREEN, WID_DT_BUILD_AQUEDUCT), SetMinimalSize(22, 22), SetFill(0, 1), SetSpriteTip(SPR_IMG_AQUEDUCT, STR_WATERWAYS_TOOLBAR_BUILD_AQUEDUCT_TOOLTIP),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Window definition for the build docks in scenario editor window. */
 static WindowDesc _build_docks_scen_toolbar_desc(
@@ -487,6 +491,7 @@ public:
 };
 
 /** Nested widget parts of a build dock station window. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_dock_station_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -505,6 +510,7 @@ static constexpr NWidgetPart _nested_build_dock_station_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _build_dock_station_desc(
 	WDP_AUTO, nullptr, 0, 0,
@@ -588,6 +594,7 @@ public:
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_docks_depot_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -600,6 +607,7 @@ static constexpr NWidgetPart _nested_build_docks_depot_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _build_docks_depot_desc(
 	WDP_AUTO, nullptr, 0, 0,

--- a/src/dropdown.cpp
+++ b/src/dropdown.cpp
@@ -55,6 +55,7 @@ std::unique_ptr<DropDownListItem> MakeDropDownListCheckedItem(bool checked, Stri
 	return std::make_unique<DropDownListCheckedItem>(indent, checked, GetString(str), value, masked, shaded);
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_dropdown_menu_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_PANEL, COLOUR_END, WID_DM_ITEMS), SetScrollbar(WID_DM_SCROLL), EndContainer(),
@@ -63,6 +64,7 @@ static constexpr NWidgetPart _nested_dropdown_menu_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _dropdown_desc(
 	WDP_MANUAL, nullptr, 0, 0,

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -51,6 +51,7 @@ StringID GetEngineCategoryName(EngineID engine)
 	}
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_engine_preview_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_LIGHT_BLUE),
@@ -66,6 +67,7 @@ static constexpr NWidgetPart _nested_engine_preview_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 struct EnginePreviewWindow : Window {
 	int vehicle_space = 0; // The space to show the vehicle image

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -33,6 +33,7 @@
 
 #include "safeguards.h"
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_errmsg_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_RED),
@@ -42,6 +43,7 @@ static constexpr NWidgetPart _nested_errmsg_widgets[] = {
 		NWidget(WWT_EMPTY, INVALID_COLOUR, WID_EM_MESSAGE), SetPadding(WidgetDimensions::unscaled.modalpopup), SetFill(1, 0), SetMinimalSize(236, 0),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _errmsg_desc(
 	WDP_MANUAL, nullptr, 0, 0,
@@ -50,6 +52,7 @@ static WindowDesc _errmsg_desc(
 	_nested_errmsg_widgets
 );
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_errmsg_face_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_RED),
@@ -62,6 +65,7 @@ static constexpr NWidgetPart _nested_errmsg_face_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _errmsg_face_desc(
 	WDP_MANUAL, nullptr, 0, 0,

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -65,6 +65,7 @@ void LoadCheckData::Clear()
 }
 
 /** Load game/scenario with optional content download */
+/* clang-format off */
 static constexpr NWidgetPart _nested_load_dialog_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -126,8 +127,10 @@ static constexpr NWidgetPart _nested_load_dialog_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Load heightmap with content download */
+/* clang-format off */
 static constexpr NWidgetPart _nested_load_heightmap_dialog_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -173,8 +176,10 @@ static constexpr NWidgetPart _nested_load_heightmap_dialog_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Load town data */
+/* clang-format off */
 static constexpr NWidgetPart _nested_load_town_data_dialog_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -215,8 +220,10 @@ static constexpr NWidgetPart _nested_load_town_data_dialog_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Save game/scenario */
+/* clang-format off */
 static constexpr NWidgetPart _nested_save_dialog_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -279,6 +286,7 @@ static constexpr NWidgetPart _nested_save_dialog_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Text colours of #DetailedFileType fios entries in the window. */
 static const TextColour _fios_colours[] = {

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -376,6 +376,7 @@ static const char * GetAIName(int ai_index)
 }
 
 /** @hideinitializer */
+/* clang-format off */
 static constexpr NWidgetPart _framerate_window_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -408,6 +409,7 @@ static constexpr NWidgetPart _framerate_window_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 struct FramerateWindow : Window {
 	int num_active = 0;
@@ -694,6 +696,7 @@ static WindowDesc _framerate_display_desc(
 
 
 /** @hideinitializer */
+/* clang-format off */
 static constexpr NWidgetPart _frametime_graph_window_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -706,6 +709,7 @@ static constexpr NWidgetPart _frametime_graph_window_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 struct FrametimeGraphWindow : Window {
 	int vertical_scale = TIMESTAMP_PRECISION / 10; ///< number of TIMESTAMP_PRECISION units vertically

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -32,6 +32,7 @@
 
 
 /** Widgets for the configure GS window. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_gs_config_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_MAUVE),
@@ -73,6 +74,7 @@ static constexpr NWidgetPart _nested_gs_config_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Window definition for the configure GS window. */
 static WindowDesc _gs_config_desc(

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -73,6 +73,7 @@ void SetNewLandscapeType(LandscapeType landscape)
 }
 
 /** Widgets of GenerateLandscapeWindow when generating world */
+/* clang-format off */
 static constexpr NWidgetPart _nested_generate_landscape_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -195,8 +196,10 @@ static constexpr NWidgetPart _nested_generate_landscape_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Widgets of GenerateLandscapeWindow when loading heightmap */
+/* clang-format off */
 static constexpr NWidgetPart _nested_heightmap_load_widgets[] = {
 	/* Window header. */
 	NWidget(NWID_HORIZONTAL),
@@ -312,6 +315,7 @@ static constexpr NWidgetPart _nested_heightmap_load_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static void StartGeneratingLandscape(GenerateLandscapeWindowMode mode)
 {
@@ -1218,6 +1222,7 @@ struct CreateScenarioWindow : public Window
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_create_scenario_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -1276,6 +1281,7 @@ static constexpr NWidgetPart _nested_create_scenario_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _create_scenario_desc(
 	WDP_CENTER, nullptr, 0, 0,
@@ -1291,6 +1297,7 @@ void ShowCreateScenario()
 	new CreateScenarioWindow(_create_scenario_desc, GLWM_SCENARIO);
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_generate_progress_widgets[] = {
 	NWidget(WWT_CAPTION, COLOUR_GREY), SetStringTip(STR_GENERATION_WORLD, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
 	NWidget(WWT_PANEL, COLOUR_GREY),
@@ -1301,6 +1308,7 @@ static constexpr NWidgetPart _nested_generate_progress_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 
 static WindowDesc _generate_progress_desc(

--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -275,6 +275,7 @@ struct GoalListWindow : public Window {
 };
 
 /** Widgets of the #GoalListWindow. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_goals_list_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -296,6 +297,7 @@ static constexpr NWidgetPart _nested_goals_list_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _goals_list_desc(
 	WDP_AUTO, "list_goals", 500, 127,

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -129,6 +129,7 @@ static std::unique_ptr<NWidgetBase> MakeNWidgetCompanyLines()
 	return vert;
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_graph_legend_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -140,6 +141,7 @@ static constexpr NWidgetPart _nested_graph_legend_widgets[] = {
 		NWidgetFunction(MakeNWidgetCompanyLines),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _graph_legend_desc(
 	WDP_AUTO, "graph_legend", 0, 0,
@@ -790,6 +792,7 @@ struct OperatingProfitGraphWindow : BaseGraphWindow {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_operating_profit_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -811,6 +814,7 @@ static constexpr NWidgetPart _nested_operating_profit_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _operating_profit_desc(
 	WDP_AUTO, "graph_operating_profit", 0, 0,
@@ -847,6 +851,7 @@ struct IncomeGraphWindow : BaseGraphWindow {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_income_graph_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -868,6 +873,7 @@ static constexpr NWidgetPart _nested_income_graph_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _income_graph_desc(
 	WDP_AUTO, "graph_income", 0, 0,
@@ -902,6 +908,7 @@ struct DeliveredCargoGraphWindow : BaseGraphWindow {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_delivered_cargo_graph_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -923,6 +930,7 @@ static constexpr NWidgetPart _nested_delivered_cargo_graph_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _delivered_cargo_graph_desc(
 	WDP_AUTO, "graph_delivered_cargo", 0, 0,
@@ -963,6 +971,7 @@ struct PerformanceHistoryGraphWindow : BaseGraphWindow {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_performance_history_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -985,6 +994,7 @@ static constexpr NWidgetPart _nested_performance_history_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _performance_history_desc(
 	WDP_AUTO, "graph_performance", 0, 0,
@@ -1019,6 +1029,7 @@ struct CompanyValueGraphWindow : BaseGraphWindow {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_company_value_graph_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -1040,6 +1051,7 @@ static constexpr NWidgetPart _nested_company_value_graph_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _company_value_graph_desc(
 	WDP_AUTO, "graph_company_value", 0, 0,
@@ -1236,6 +1248,7 @@ struct PaymentRatesGraphWindow : BaseGraphWindow {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_cargo_payment_rates_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -1273,6 +1286,7 @@ static constexpr NWidgetPart _nested_cargo_payment_rates_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _cargo_payment_rates_desc(
 	WDP_AUTO, "graph_cargo_payment_rates", 0, 0,
@@ -1751,6 +1765,7 @@ struct IndustryProductionGraphWindow : BaseGraphWindow {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_industry_production_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -1785,6 +1800,7 @@ static constexpr NWidgetPart _nested_industry_production_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _industry_production_desc(
 	WDP_AUTO, "graph_industry_production", 0, 0,
@@ -1836,6 +1852,7 @@ std::unique_ptr<NWidgetBase> MakeCompanyButtonRowsGraphGUI()
 	return MakeCompanyButtonRows(WID_PRD_COMPANY_FIRST, WID_PRD_COMPANY_LAST, COLOUR_BROWN, 8, STR_PERFORMANCE_DETAIL_SELECT_COMPANY_TOOLTIP);
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_performance_rating_detail_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -1848,6 +1865,7 @@ static constexpr NWidgetPart _nested_performance_rating_detail_widgets[] = {
 	EndContainer(),
 	NWidgetFunction(MakePerformanceDetailPanels),
 };
+/* clang-format on */
 
 static WindowDesc _performance_rating_detail_desc(
 	WDP_AUTO, "league_details", 0, 0,

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -38,6 +38,7 @@
 
 #include "safeguards.h"
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_group_widgets[] = {
 	NWidget(NWID_HORIZONTAL), // Window header
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -110,6 +111,7 @@ static constexpr NWidgetPart _nested_group_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /**
  * Add children to GUI group list to build a hierarchical tree.

--- a/src/help_gui.cpp
+++ b/src/help_gui.cpp
@@ -175,6 +175,7 @@ private:
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_helpwin_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -200,6 +201,7 @@ static constexpr NWidgetPart _nested_helpwin_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _helpwin_desc(
 	WDP_CENTER, nullptr, 0, 0,

--- a/src/highscore_gui.cpp
+++ b/src/highscore_gui.cpp
@@ -209,9 +209,11 @@ struct HighScoreWindow : EndGameHighScoreBaseWindow {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_highscore_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_BROWN, WID_H_BACKGROUND), SetResize(1, 1), EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _highscore_desc(
 	WDP_MANUAL, nullptr, 0, 0,

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -262,6 +262,7 @@ void CcBuildIndustry(Commands, const CommandCost &result, TileIndex tile, Indust
 	}
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_industry_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -291,6 +292,7 @@ static constexpr NWidgetPart _nested_build_industry_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_DARK_GREEN),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Window definition of the dynamic place industries gui */
 static WindowDesc _build_industry_desc(
@@ -1199,6 +1201,7 @@ static void UpdateIndustryProduction(Industry *i)
 }
 
 /** Widget definition of the view industry gui */
+/* clang-format off */
 static constexpr NWidgetPart _nested_industry_view_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_CREAM),
@@ -1222,6 +1225,7 @@ static constexpr NWidgetPart _nested_industry_view_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_CREAM),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Window definition of the view industry gui */
 static WindowDesc _industry_view_desc(
@@ -1237,6 +1241,7 @@ void ShowIndustryViewWindow(IndustryID industry)
 }
 
 /** Widget definition of the industry directory gui */
+/* clang-format off */
 static constexpr NWidgetPart _nested_industry_directory_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -1267,6 +1272,7 @@ static constexpr NWidgetPart _nested_industry_directory_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_BROWN),
 	EndContainer(),
 };
+/* clang-format on */
 
 typedef GUIList<const Industry *, const CargoType &, const std::pair<CargoType, CargoType> &> GUIIndustryList;
 
@@ -1943,6 +1949,7 @@ void ShowIndustryDirectory()
 }
 
 /** Widgets of the industry cargoes window. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_industry_cargoes_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -1966,6 +1973,7 @@ static constexpr NWidgetPart _nested_industry_cargoes_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_BROWN),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Window description for the industry cargoes window. */
 static WindowDesc _industry_cargoes_desc(

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -367,6 +367,7 @@ struct SelectGameWindow : public Window {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_select_game_widgets[] = {
 	NWidget(WWT_CAPTION, COLOUR_BROWN), SetStringTip(STR_INTRO_CAPTION),
 	NWidget(WWT_PANEL, COLOUR_BROWN),
@@ -445,6 +446,7 @@ static constexpr NWidgetPart _nested_select_game_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _select_game_desc(
 	WDP_CENTER, nullptr, 0, 0,

--- a/src/league_gui.cpp
+++ b/src/league_gui.cpp
@@ -181,6 +181,7 @@ public:
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_performance_league_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -191,6 +192,7 @@ static constexpr NWidgetPart _nested_performance_league_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_BROWN, WID_PLT_BACKGROUND), SetMinimalSize(400, 0), SetMinimalTextLines(15, WidgetDimensions::unscaled.framerect.Vertical()),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _performance_league_desc(
 	WDP_AUTO, "performance_league", 0, 0,
@@ -417,6 +419,7 @@ public:
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_script_league_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -427,6 +430,7 @@ static constexpr NWidgetPart _nested_script_league_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_BROWN, WID_SLT_BACKGROUND), SetMinimalSize(400, 0), SetMinimalTextLines(15, WidgetDimensions::unscaled.framerect.Vertical()),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _script_league_desc(
 	WDP_AUTO, "script_league", 0, 0,

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -496,6 +496,7 @@ std::unique_ptr<NWidgetBase> MakeCargoesLegendLinkGraphGUI()
 }
 
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_linkgraph_legend_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -525,6 +526,7 @@ static constexpr NWidgetPart _nested_linkgraph_legend_widgets[] = {
 		EndContainer(),
 	EndContainer()
 };
+/* clang-format on */
 
 static_assert(WID_LGL_SATURATION_LAST - WID_LGL_SATURATION_FIRST ==
 		lengthof(LinkGraphOverlay::LINK_COLOURS[0]) - 1);

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -177,9 +177,11 @@ void FixTitleGameZoom(int zoom_adjust)
 	vp.virtual_height = ScaleByZoom(vp.height, vp.zoom);
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_main_window_widgets[] = {
 	NWidget(NWID_VIEWPORT, INVALID_COLOUR, WID_M_VIEWPORT), SetResize(1, 1),
 };
+/* clang-format on */
 
 enum GlobalHotKeys : int32_t {
 	GHK_QUIT,

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -61,7 +61,7 @@ public:
 	 * Create the tile wrapper for the given tile.
 	 * @param tile The tile to access the map for.
 	 */
-	debug_inline Tile(TileIndex tile) : tile(tile) {}
+	[[debug_inline]] inline Tile(TileIndex tile) : tile(tile) {}
 
 	/**
 	 * Create the tile wrapper for the given tile.
@@ -72,12 +72,12 @@ public:
 	/**
 	 * Implicit conversion to the TileIndex.
 	 */
-	debug_inline constexpr operator TileIndex() const { return this->tile; }
+	[[debug_inline]] inline constexpr operator TileIndex() const { return this->tile; }
 
 	/**
 	 * Implicit conversion to the uint for bounds checking.
 	 */
-	debug_inline constexpr operator uint() const { return this->tile.base(); }
+	[[debug_inline]] inline constexpr operator uint() const { return this->tile.base(); }
 
 	/**
 	 * The type (bits 4..7), bridges (2..3), rainforest/desert (0..1)
@@ -86,7 +86,7 @@ public:
 	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
-	debug_inline uint8_t &type()
+	[[debug_inline]] inline uint8_t &type()
 	{
 		return base_tiles[this->tile.base()].type;
 	}
@@ -98,7 +98,7 @@ public:
 	 * @param tile The tile to get the height for.
 	 * @return reference to the byte holding the height.
 	 */
-	debug_inline uint8_t &height()
+	[[debug_inline]] inline uint8_t &height()
 	{
 		return base_tiles[this->tile.base()].height;
 	}
@@ -110,7 +110,7 @@ public:
 	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
-	debug_inline uint8_t &m1()
+	[[debug_inline]] inline uint8_t &m1()
 	{
 		return base_tiles[this->tile.base()].m1;
 	}
@@ -122,7 +122,7 @@ public:
 	 * @param tile The tile to get the data for.
 	 * @return reference to the uint16_t holding the data.
 	 */
-	debug_inline uint16_t &m2()
+	[[debug_inline]] inline uint16_t &m2()
 	{
 		return base_tiles[this->tile.base()].m2;
 	}
@@ -134,7 +134,7 @@ public:
 	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
-	debug_inline uint8_t &m3()
+	[[debug_inline]] inline uint8_t &m3()
 	{
 		return base_tiles[this->tile.base()].m3;
 	}
@@ -146,7 +146,7 @@ public:
 	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
-	debug_inline uint8_t &m4()
+	[[debug_inline]] inline uint8_t &m4()
 	{
 		return base_tiles[this->tile.base()].m4;
 	}
@@ -158,7 +158,7 @@ public:
 	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
-	debug_inline uint8_t &m5()
+	[[debug_inline]] inline uint8_t &m5()
 	{
 		return base_tiles[this->tile.base()].m5;
 	}
@@ -170,7 +170,7 @@ public:
 	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
-	debug_inline uint8_t &m6()
+	[[debug_inline]] inline uint8_t &m6()
 	{
 		return extended_tiles[this->tile.base()].m6;
 	}
@@ -182,7 +182,7 @@ public:
 	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
-	debug_inline uint8_t &m7()
+	[[debug_inline]] inline uint8_t &m7()
 	{
 		return extended_tiles[this->tile.base()].m7;
 	}
@@ -194,7 +194,7 @@ public:
 	 * @param tile The tile to get the data for.
 	 * @return reference to the uint16_t holding the data.
 	 */
-	debug_inline uint16_t &m8()
+	[[debug_inline]] inline uint16_t &m8()
 	{
 		return extended_tiles[this->tile.base()].m8;
 	}
@@ -247,7 +247,7 @@ public:
 	 * @note try to avoid using this one
 	 * @return 2^"return value" == Map::SizeX()
 	 */
-	debug_inline static uint LogX()
+	[[debug_inline]] inline static uint LogX()
 	{
 		return Map::log_x;
 	}
@@ -266,7 +266,7 @@ public:
 	 * Get the size of the map along the X
 	 * @return the number of tiles along the X of the map
 	 */
-	debug_inline static uint SizeX()
+	[[debug_inline]] inline static uint SizeX()
 	{
 		return Map::size_x;
 	}
@@ -284,7 +284,7 @@ public:
 	 * Get the size of the map
 	 * @return the number of tiles of the map
 	 */
-	debug_inline static uint Size()
+	[[debug_inline]] inline static uint Size()
 	{
 		return Map::size;
 	}
@@ -293,7 +293,7 @@ public:
 	 * Gets the maximum X coordinate within the map, including MP_VOID
 	 * @return the maximum X coordinate
 	 */
-	debug_inline static uint MaxX()
+	[[debug_inline]] inline static uint MaxX()
 	{
 		return Map::SizeX() - 1;
 	}
@@ -369,7 +369,7 @@ public:
  * @param y The y coordinate of the tile
  * @return The TileIndex calculated by the coordinate
  */
-debug_inline static TileIndex TileXY(uint x, uint y)
+[[debug_inline]] inline static TileIndex TileXY(uint x, uint y)
 {
 	return TileIndex{(y << Map::LogX()) + x};
 }
@@ -400,7 +400,7 @@ inline TileIndexDiff TileDiffXY(int x, int y)
  * @param y The virtual y coordinate of the tile.
  * @return The TileIndex calculated by the coordinate.
  */
-debug_inline static TileIndex TileVirtXY(uint x, uint y)
+[[debug_inline]] inline static TileIndex TileVirtXY(uint x, uint y)
 {
 	return TileIndex{(y >> 4 << Map::LogX()) + (x >> 4)};
 }
@@ -411,7 +411,7 @@ debug_inline static TileIndex TileVirtXY(uint x, uint y)
  * @param tile the tile to get the X component of
  * @return the X component
  */
-debug_inline static uint TileX(TileIndex tile)
+[[debug_inline]] inline static uint TileX(TileIndex tile)
 {
 	return tile.base() & Map::MaxX();
 }
@@ -421,7 +421,7 @@ debug_inline static uint TileX(TileIndex tile)
  * @param tile the tile to get the Y component of
  * @return the Y component
  */
-debug_inline static uint TileY(TileIndex tile)
+[[debug_inline]] inline static uint TileY(TileIndex tile)
 {
 	return tile.base() >> Map::LogX();
 }

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -47,6 +47,7 @@ enum OskActivation : uint8_t {
 };
 
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_land_info_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -56,6 +57,7 @@ static constexpr NWidgetPart _nested_land_info_widgets[] = {
 	EndContainer(),
 	NWidget(WWT_PANEL, COLOUR_GREY, WID_LI_BACKGROUND), EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _land_info_desc(
 	WDP_AUTO, nullptr, 0, 0,
@@ -319,6 +321,7 @@ void ShowLandInfo(TileIndex tile)
 	new LandInfoWindow(tile);
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_about_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -334,6 +337,7 @@ static constexpr NWidgetPart _nested_about_widgets[] = {
 		NWidget(WWT_LABEL, INVALID_COLOUR, WID_A_COPYRIGHT),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _about_desc(
 	WDP_CENTER, nullptr, 0, 0,
@@ -586,9 +590,11 @@ void HideFillingPercent(TextEffectID *te_id)
 	*te_id = INVALID_TE_ID;
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_tooltips_widgets[] = {
 	NWidget(WWT_EMPTY, INVALID_COLOUR, WID_TT_BACKGROUND),
 };
+/* clang-format on */
 
 static WindowDesc _tool_tips_desc(
 	WDP_MANUAL, nullptr, 0, 0, // Coordinates and sizes are not used,
@@ -975,6 +981,7 @@ struct QueryStringWindow : public Window
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_query_string_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -989,6 +996,7 @@ static constexpr NWidgetPart _nested_query_string_widgets[] = {
 		NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_QS_OK), SetMinimalSize(87, 12), SetFill(1, 1), SetStringTip(STR_BUTTON_OK),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _query_string_desc(
 	WDP_CENTER, nullptr, 0, 0,
@@ -1113,6 +1121,7 @@ struct QueryWindow : public Window {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_query_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_RED),
@@ -1128,6 +1137,7 @@ static constexpr NWidgetPart _nested_query_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _query_desc(
 	WDP_CENTER, nullptr, 0, 0,

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -623,6 +623,7 @@ struct MusicTrackSelectionWindow : public Window {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_music_track_selection_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -659,6 +660,7 @@ static constexpr NWidgetPart _nested_music_track_selection_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _music_track_selection_desc(
 	WDP_AUTO, nullptr, 0, 0,
@@ -855,6 +857,7 @@ struct MusicWindow : public Window {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_music_window_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -918,6 +921,7 @@ static constexpr NWidgetPart _nested_music_window_widgets[] = {
 		NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_M_CUSTOM2), SetFill(1, 0), SetStringTip(STR_MUSIC_PLAYLIST_CUSTOM_2, STR_MUSIC_TOOLTIP_SELECT_CUSTOM_2_USER_DEFINED),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _music_window_desc(
 	WDP_AUTO, "music", 0, 0,

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -411,6 +411,7 @@ struct NetworkChatWindow : public Window {
 };
 
 /** The widgets of the chat window. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_chat_window_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY, WID_NC_CLOSE),
@@ -424,6 +425,7 @@ static constexpr NWidgetPart _nested_chat_window_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** The description of the chat window. */
 static WindowDesc _chat_window_desc(

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -86,6 +86,7 @@ void ShowContentTextfileWindow(TextfileType file_type, const ContentInfo *ci)
 }
 
 /** Nested widgets for the download window. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_network_content_download_status_window_widgets[] = {
 	NWidget(WWT_CAPTION, COLOUR_GREY), SetStringTip(STR_CONTENT_DOWNLOAD_TITLE, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
 	NWidget(WWT_PANEL, COLOUR_GREY),
@@ -96,6 +97,7 @@ static constexpr NWidgetPart _nested_network_content_download_status_window_widg
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Window description for the download window */
 static WindowDesc _network_content_download_status_window_desc(
@@ -1019,6 +1021,7 @@ void BuildContentTypeStringList()
 }
 
 /** The widgets for the content list. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_network_content_list_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_LIGHT_BLUE),
@@ -1096,6 +1099,7 @@ static constexpr NWidgetPart _nested_network_content_list_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Window description of the content list */
 static WindowDesc _network_content_list_desc(

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -858,6 +858,7 @@ static std::unique_ptr<NWidgetBase> MakeResizableHeader()
 	return std::make_unique<NWidgetServerListHeader>();
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_network_game_widgets[] = {
 	/* TOP */
 	NWidget(NWID_HORIZONTAL),
@@ -935,6 +936,7 @@ static constexpr NWidgetPart _nested_network_game_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _network_game_window_desc(
 	WDP_CENTER, "list_servers", 1000, 730,
@@ -1133,6 +1135,7 @@ struct NetworkStartServerWindow : public Window {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_network_start_server_window_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_LIGHT_BLUE),
@@ -1199,6 +1202,7 @@ static constexpr NWidgetPart _nested_network_start_server_window_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _network_start_server_window_desc(
 	WDP_CENTER, nullptr, 0, 0,
@@ -1221,6 +1225,7 @@ static void ShowNetworkStartServerWindow()
 
 extern void DrawCompanyIcon(CompanyID cid, int x, int y);
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_client_list_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -1273,6 +1278,7 @@ static constexpr NWidgetPart _nested_client_list_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _client_list_desc(
 	WDP_AUTO, "list_clients", 220, 300,
@@ -2145,6 +2151,7 @@ struct NetworkJoinStatusWindow : Window {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_network_join_status_window_widgets[] = {
 	NWidget(WWT_CAPTION, COLOUR_GREY), SetStringTip(STR_NETWORK_CONNECTING_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
 	NWidget(WWT_PANEL, COLOUR_GREY),
@@ -2155,6 +2162,7 @@ static constexpr NWidgetPart _nested_network_join_status_window_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _network_join_status_window_desc(
 	WDP_CENTER, nullptr, 0, 0,
@@ -2246,6 +2254,7 @@ struct NetworkAskRelayWindow : public Window {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_network_ask_relay_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_RED),
@@ -2262,6 +2271,7 @@ static constexpr NWidgetPart _nested_network_ask_relay_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _network_ask_relay_desc(
 	WDP_CENTER, nullptr, 0, 0,
@@ -2341,6 +2351,7 @@ struct NetworkAskSurveyWindow : public Window {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_network_ask_survey_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -2360,6 +2371,7 @@ static constexpr NWidgetPart _nested_network_ask_survey_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _network_ask_survey_desc(
 	WDP_CENTER, nullptr, 0, 0,

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -638,6 +638,7 @@ struct NewGRFInspectWindow : Window {
 
 /* static */ uint32_t NewGRFInspectWindow::var60params[GSF_FAKE_END][0x20] = { {0} }; // Use spec to have 0s in whole array
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_newgrf_inspect_chain_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -661,7 +662,9 @@ static constexpr NWidgetPart _nested_newgrf_inspect_chain_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_newgrf_inspect_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -679,6 +682,7 @@ static constexpr NWidgetPart _nested_newgrf_inspect_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _newgrf_inspect_chain_desc(
 	WDP_AUTO, "newgrf_inspect_chain", 400, 300,
@@ -1132,6 +1136,7 @@ private:
 bool SpriteAlignerWindow::centre = true;
 bool SpriteAlignerWindow::crosshair = true;
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_sprite_aligner_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -1201,6 +1206,7 @@ static constexpr NWidgetPart _nested_sprite_aligner_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _sprite_aligner_desc(
 	WDP_AUTO, "sprite_aligner", 400, 300,

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -499,6 +499,7 @@ struct NewGRFParametersWindow : public Window {
 GRFParameterInfo NewGRFParametersWindow::dummy_parameter_info(0);
 
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_newgrf_parameter_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_MAUVE),
@@ -530,6 +531,7 @@ static constexpr NWidgetPart _nested_newgrf_parameter_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_MAUVE),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Window definition for the change grf parameters window */
 static WindowDesc _newgrf_parameters_desc(
@@ -1752,6 +1754,7 @@ public:
 const uint NWidgetNewGRFDisplay::MAX_EXTRA_INFO_WIDTH    = 150;
 const uint NWidgetNewGRFDisplay::MIN_EXTRA_FOR_3_COLUMNS = 50;
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_newgrf_actives_widgets[] = {
 	NWidget(NWID_VERTICAL), SetPIP(0, WidgetDimensions::unscaled.vsep_wide, 0),
 		/* Left side, presets. */
@@ -1806,7 +1809,9 @@ static constexpr NWidgetPart _nested_newgrf_actives_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_newgrf_availables_widgets[] = {
 	NWidget(WWT_FRAME, COLOUR_MAUVE), SetStringTip(STR_NEWGRF_SETTINGS_INACTIVE_LIST), SetPIP(0, WidgetDimensions::unscaled.vsep_wide, 0),
 		/* Left side, available grfs, filter edit box. */
@@ -1839,7 +1844,9 @@ static constexpr NWidgetPart _nested_newgrf_availables_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_newgrf_infopanel_widgets[] = {
 	NWidget(NWID_VERTICAL), SetPIP(0, WidgetDimensions::unscaled.vsep_wide, 0),
 		/* Right side, info panel. */
@@ -1881,6 +1888,7 @@ static constexpr NWidgetPart _nested_newgrf_infopanel_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Construct nested container widget for managing the lists and the info panel of the NewGRF GUI. */
 std::unique_ptr<NWidgetBase> NewGRFDisplay()
@@ -1893,6 +1901,7 @@ std::unique_ptr<NWidgetBase> NewGRFDisplay()
 }
 
 /* Widget definition of the manage newgrfs window */
+/* clang-format off */
 static constexpr NWidgetPart _nested_newgrf_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_MAUVE),
@@ -1908,6 +1917,7 @@ static constexpr NWidgetPart _nested_newgrf_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /* Window definition of the manage newgrfs window */
 static WindowDesc _newgrf_desc(
@@ -1977,6 +1987,7 @@ void ShowNewGRFSettings(bool editable, bool show_params, bool exec_changes, GRFC
 }
 
 /** Widget parts of the save preset window. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_save_preset_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -2000,6 +2011,7 @@ static constexpr NWidgetPart _nested_save_preset_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Window description of the preset save window. */
 static WindowDesc _save_preset_desc(
@@ -2134,6 +2146,7 @@ static void ShowSavePresetWindow(const char *initial_text)
 }
 
 /** Widgets for the progress window. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_scan_progress_widgets[] = {
 	NWidget(WWT_CAPTION, COLOUR_GREY), SetStringTip(STR_NEWGRF_SCAN_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
 	NWidget(WWT_PANEL, COLOUR_GREY),
@@ -2144,6 +2157,7 @@ static constexpr NWidgetPart _nested_scan_progress_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Description of the widgets and other settings of the window. */
 static WindowDesc _scan_progress_desc(

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -102,6 +102,7 @@ static TileIndex GetReferenceTile(const NewsReference &reference)
 }
 
 /* Normal news items. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_normal_news_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_WHITE, WID_N_PANEL),
 		NWidget(NWID_VERTICAL), SetPadding(WidgetDimensions::unscaled.fullbevel),
@@ -125,6 +126,7 @@ static constexpr NWidgetPart _nested_normal_news_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _normal_news_desc(
 	WDP_MANUAL, nullptr, 0, 0,
@@ -134,6 +136,7 @@ static WindowDesc _normal_news_desc(
 );
 
 /* New vehicles news items. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_vehicle_news_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_WHITE, WID_N_PANEL),
 		NWidget(NWID_VERTICAL), SetPadding(WidgetDimensions::unscaled.fullbevel),
@@ -173,6 +176,7 @@ static constexpr NWidgetPart _nested_vehicle_news_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _vehicle_news_desc(
 	WDP_MANUAL, nullptr, 0, 0,
@@ -182,6 +186,7 @@ static WindowDesc _vehicle_news_desc(
 );
 
 /* Company news items. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_company_news_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_WHITE, WID_N_PANEL),
 		NWidget(NWID_VERTICAL), SetPadding(WidgetDimensions::unscaled.fullbevel),
@@ -218,6 +223,7 @@ static constexpr NWidgetPart _nested_company_news_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _company_news_desc(
 	WDP_MANUAL, nullptr, 0, 0,
@@ -227,6 +233,7 @@ static WindowDesc _company_news_desc(
 );
 
 /* Thin news items. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_thin_news_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_WHITE, WID_N_PANEL),
 		NWidget(NWID_VERTICAL), SetPadding(WidgetDimensions::unscaled.fullbevel),
@@ -252,6 +259,7 @@ static constexpr NWidgetPart _nested_thin_news_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _thin_news_desc(
 	WDP_MANUAL, nullptr, 0, 0,
@@ -261,6 +269,7 @@ static WindowDesc _thin_news_desc(
 );
 
 /* Small news items. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_small_news_widgets[] = {
 	/* Caption + close box. The caption is not WWT_CAPTION as the window shall not be moveable and so on. */
 	NWidget(NWID_HORIZONTAL),
@@ -288,6 +297,7 @@ static constexpr NWidgetPart _nested_small_news_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _small_news_desc(
 	WDP_MANUAL, nullptr, 0, 0,
@@ -1275,6 +1285,7 @@ struct MessageHistoryWindow : Window {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_message_history[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -1293,6 +1304,7 @@ static constexpr NWidgetPart _nested_message_history[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _message_history_desc(
 	WDP_AUTO, "list_news", 400, 140,

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -379,6 +379,7 @@ public:
 	}, BuildObjectGlobalHotkeys};
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_object_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -406,6 +407,7 @@ static constexpr NWidgetPart _nested_build_object_widgets[] = {
 		NWidgetFunction(MakePickerTypeWidgets),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _build_object_desc(
 	WDP_AUTO, "build_object", 0, 0,

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -1596,6 +1596,7 @@ public:
 };
 
 /** Nested widget definition for "your" train orders. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_orders_train_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -1663,6 +1664,7 @@ static constexpr NWidgetPart _nested_orders_train_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _orders_train_desc(
 	WDP_AUTO, "view_vehicle_orders_train", 384, 100,
@@ -1673,6 +1675,7 @@ static WindowDesc _orders_train_desc(
 );
 
 /** Nested widget definition for "your" orders (non-train). */
+/* clang-format off */
 static constexpr NWidgetPart _nested_orders_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -1736,6 +1739,7 @@ static constexpr NWidgetPart _nested_orders_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _orders_desc(
 	WDP_AUTO, "view_vehicle_orders", 384, 100,
@@ -1746,6 +1750,7 @@ static WindowDesc _orders_desc(
 );
 
 /** Nested widget definition for competitor orders. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_other_orders_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -1763,6 +1768,7 @@ static constexpr NWidgetPart _nested_other_orders_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _other_orders_desc(
 	WDP_AUTO, "view_vehicle_orders_competitor", 384, 86,

--- a/src/osk_gui.cpp
+++ b/src/osk_gui.cpp
@@ -321,6 +321,7 @@ static std::unique_ptr<NWidgetBase> MakeSpacebarKeys()
 }
 
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_osk_widgets[] = {
 	NWidget(WWT_CAPTION, COLOUR_GREY, WID_OSK_CAPTION), SetTextStyle(TC_WHITE),
 	NWidget(WWT_PANEL, COLOUR_GREY),
@@ -337,6 +338,7 @@ static constexpr NWidgetPart _nested_osk_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _osk_desc(
 	WDP_CENTER, nullptr, 0, 0,

--- a/src/pathfinder/follow_track.hpp
+++ b/src/pathfinder/follow_track.hpp
@@ -88,11 +88,11 @@ struct CFollowTrackT
 		this->railtypes = railtype_override;
 	}
 
-	debug_inline static TransportType TT() { return Ttr_type_; }
-	debug_inline static bool IsWaterTT() { return TT() == TRANSPORT_WATER; }
-	debug_inline static bool IsRailTT() { return TT() == TRANSPORT_RAIL; }
+	[[debug_inline]] inline static TransportType TT() { return Ttr_type_; }
+	[[debug_inline]] inline static bool IsWaterTT() { return TT() == TRANSPORT_WATER; }
+	[[debug_inline]] inline static bool IsRailTT() { return TT() == TRANSPORT_RAIL; }
 	inline bool IsTram() { return IsRoadTT() && RoadTypeIsTram(RoadVehicle::From(this->veh)->roadtype); }
-	debug_inline static bool IsRoadTT() { return TT() == TRANSPORT_ROAD; }
+	[[debug_inline]] inline static bool IsRoadTT() { return TT() == TRANSPORT_ROAD; }
 	inline static bool Allow90degTurns() { return T90deg_turns_allowed_; }
 	inline static bool DoTrackMasking() { return Tmask_reserved_tracks; }
 

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -858,6 +858,7 @@ struct BuildRailToolbarWindow : Window {
 	}, RailToolbarGlobalHotkeys};
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_rail_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -898,6 +899,7 @@ static constexpr NWidgetPart _nested_build_rail_widgets[] = {
 						SetFill(0, 1), SetMinimalSize(22, 22), SetSpriteTip(SPR_IMG_CONVERT_RAIL, STR_RAIL_TOOLBAR_TOOLTIP_CONVERT_RAIL),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _build_rail_desc(
 	WDP_ALIGN_TOOLBAR, "toolbar_rail", 0, 0,
@@ -1384,6 +1386,7 @@ public:
 	}, BuildRailStationGlobalHotkeys};
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_station_builder_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -1436,6 +1439,7 @@ static constexpr NWidgetPart _nested_station_builder_widgets[] = {
 		NWidgetFunction(MakePickerTypeWidgets),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** High level window description of the station-build window (default & newGRF) */
 static WindowDesc _station_builder_desc(
@@ -1630,6 +1634,7 @@ public:
 };
 
 /** Nested widget definition of the build signal window */
+/* clang-format off */
 static constexpr NWidgetPart _nested_signal_builder_widgets[] = {
 	/* Title bar and buttons. */
 	NWidget(NWID_HORIZONTAL),
@@ -1694,6 +1699,7 @@ static constexpr NWidgetPart _nested_signal_builder_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Signal selection window description */
 static WindowDesc _signal_builder_desc(
@@ -1758,6 +1764,7 @@ struct BuildRailDepotWindow : public PickerWindowBase {
 };
 
 /** Nested widget definition of the build rail depot window */
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_depot_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -1776,6 +1783,7 @@ static constexpr NWidgetPart _nested_build_depot_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _build_depot_desc(
 	WDP_AUTO, nullptr, 0, 0,
@@ -1883,6 +1891,7 @@ struct BuildRailWaypointWindow : public PickerWindow {
 };
 
 /** Nested widget definition for the build NewGRF rail waypoint window */
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_waypoint_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -1895,6 +1904,7 @@ static constexpr NWidgetPart _nested_build_waypoint_widgets[] = {
 		NWidgetFunction(MakePickerTypeWidgets),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _build_waypoint_desc(
 	WDP_AUTO, "build_waypoint", 0, 0,

--- a/src/rail_map.h
+++ b/src/rail_map.h
@@ -33,7 +33,7 @@ enum RailTileType : uint8_t {
  * @pre IsTileType(t, MP_RAILWAY)
  * @return the RailTileType
  */
-debug_inline static RailTileType GetRailTileType(Tile t)
+[[debug_inline]] inline static RailTileType GetRailTileType(Tile t)
 {
 	assert(IsTileType(t, MP_RAILWAY));
 	return (RailTileType)GB(t.m5(), 6, 2);
@@ -46,7 +46,7 @@ debug_inline static RailTileType GetRailTileType(Tile t)
  * @pre IsTileType(t, MP_RAILWAY)
  * @return true if and only if the tile is normal rail (with or without signals)
  */
-debug_inline static bool IsPlainRail(Tile t)
+[[debug_inline]] inline static bool IsPlainRail(Tile t)
 {
 	RailTileType rtt = GetRailTileType(t);
 	return rtt == RAIL_TILE_NORMAL || rtt == RAIL_TILE_SIGNALS;
@@ -57,7 +57,7 @@ debug_inline static bool IsPlainRail(Tile t)
  * @param t the tile to get the information from
  * @return true if and only if the tile is normal rail (with or without signals)
  */
-debug_inline static bool IsPlainRailTile(Tile t)
+[[debug_inline]] inline static bool IsPlainRailTile(Tile t)
 {
 	return IsTileType(t, MP_RAILWAY) && IsPlainRail(t);
 }
@@ -92,7 +92,7 @@ inline void SetHasSignals(Tile tile, bool signals)
  * @pre IsTileType(t, MP_RAILWAY)
  * @return true if and only if the tile is a rail depot
  */
-debug_inline static bool IsRailDepot(Tile t)
+[[debug_inline]] inline static bool IsRailDepot(Tile t)
 {
 	return GetRailTileType(t) == RAIL_TILE_DEPOT;
 }
@@ -102,7 +102,7 @@ debug_inline static bool IsRailDepot(Tile t)
  * @param t the tile to get the information from
  * @return true if and only if the tile is a rail depot
  */
-debug_inline static bool IsRailDepotTile(Tile t)
+[[debug_inline]] inline static bool IsRailDepotTile(Tile t)
 {
 	return IsTileType(t, MP_RAILWAY) && IsRailDepot(t);
 }

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -899,6 +899,7 @@ struct BuildRoadToolbarWindow : Window {
 	}, TramToolbarGlobalHotkeys};
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_road_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -935,6 +936,7 @@ static constexpr NWidgetPart _nested_build_road_widgets[] = {
 						SetFill(0, 1), SetMinimalSize(22, 22), SetSpriteTip(SPR_IMG_CONVERT_ROAD, STR_ROAD_TOOLBAR_TOOLTIP_CONVERT_ROAD),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _build_road_desc(
 	WDP_ALIGN_TOOLBAR, "toolbar_road", 0, 0,
@@ -944,6 +946,7 @@ static WindowDesc _build_road_desc(
 	&BuildRoadToolbarWindow::road_hotkeys
 );
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_tramway_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -978,6 +981,7 @@ static constexpr NWidgetPart _nested_build_tramway_widgets[] = {
 						SetFill(0, 1), SetMinimalSize(22, 22), SetSpriteTip(SPR_IMG_CONVERT_ROAD, STR_ROAD_TOOLBAR_TOOLTIP_CONVERT_TRAM),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _build_tramway_desc(
 	WDP_ALIGN_TOOLBAR, "toolbar_tramway", 0, 0,
@@ -1005,6 +1009,7 @@ Window *ShowBuildRoadToolbar(RoadType roadtype)
 	return AllocateWindowDescFront<BuildRoadToolbarWindow>(RoadTypeIsRoad(_cur_roadtype) ? _build_road_desc : _build_tramway_desc, TRANSPORT_ROAD);
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_road_scen_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -1033,6 +1038,7 @@ static constexpr NWidgetPart _nested_build_road_scen_widgets[] = {
 						SetFill(0, 1), SetMinimalSize(22, 22), SetSpriteTip(SPR_IMG_CONVERT_ROAD, STR_ROAD_TOOLBAR_TOOLTIP_CONVERT_ROAD),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _build_road_scen_desc(
 	WDP_AUTO, "toolbar_road_scen", 0, 0,
@@ -1042,6 +1048,7 @@ static WindowDesc _build_road_scen_desc(
 	&BuildRoadToolbarWindow::road_hotkeys
 );
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_tramway_scen_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -1068,6 +1075,7 @@ static constexpr NWidgetPart _nested_build_tramway_scen_widgets[] = {
 						SetFill(0, 1), SetMinimalSize(22, 22), SetSpriteTip(SPR_IMG_CONVERT_ROAD, STR_ROAD_TOOLBAR_TOOLTIP_CONVERT_TRAM),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _build_tramway_scen_desc(
 	WDP_AUTO, "toolbar_tram_scen", 0, 0,
@@ -1147,6 +1155,7 @@ struct BuildRoadDepotWindow : public PickerWindowBase {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_road_depot_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -1165,6 +1174,7 @@ static constexpr NWidgetPart _nested_build_road_depot_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _build_road_depot_desc(
 	WDP_AUTO, nullptr, 0, 0,
@@ -1505,6 +1515,7 @@ public:
 };
 
 /** Widget definition of the build road station window */
+/* clang-format off */
 static constexpr NWidgetPart _nested_road_station_picker_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -1557,6 +1568,7 @@ static constexpr NWidgetPart _nested_road_station_picker_widgets[] = {
 		NWidgetFunction(MakePickerTypeWidgets),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _road_station_picker_desc(
 	WDP_AUTO, "build_station_road", 0, 0,
@@ -1567,6 +1579,7 @@ static WindowDesc _road_station_picker_desc(
 );
 
 /** Widget definition of the build tram station window */
+/* clang-format off */
 static constexpr NWidgetPart _nested_tram_station_picker_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -1597,6 +1610,7 @@ static constexpr NWidgetPart _nested_tram_station_picker_widgets[] = {
 		NWidgetFunction(MakePickerTypeWidgets),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _tram_station_picker_desc(
 	WDP_AUTO, "build_station_tram", 0, 0,
@@ -1706,6 +1720,7 @@ struct BuildRoadWaypointWindow : public PickerWindow {
 };
 
 /** Nested widget definition for the build NewGRF road waypoint window */
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_road_waypoint_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -1718,6 +1733,7 @@ static constexpr NWidgetPart _nested_build_road_waypoint_widgets[] = {
 		NWidgetFunction(MakePickerTypeWidgets),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _build_road_waypoint_desc(
 	WDP_AUTO, "build_road_waypoint", 0, 0,

--- a/src/road_map.h
+++ b/src/road_map.h
@@ -33,7 +33,7 @@ bool MayHaveRoad(Tile t);
  * @pre IsTileType(t, MP_ROAD)
  * @return The road tile type.
  */
-debug_inline static RoadTileType GetRoadTileType(Tile t)
+[[debug_inline]] inline static RoadTileType GetRoadTileType(Tile t)
 {
 	assert(IsTileType(t, MP_ROAD));
 	return (RoadTileType)GB(t.m5(), 6, 2);
@@ -45,7 +45,7 @@ debug_inline static RoadTileType GetRoadTileType(Tile t)
  * @pre IsTileType(t, MP_ROAD)
  * @return True if normal road.
  */
-debug_inline static bool IsNormalRoad(Tile t)
+[[debug_inline]] inline static bool IsNormalRoad(Tile t)
 {
 	return GetRoadTileType(t) == ROAD_TILE_NORMAL;
 }
@@ -55,7 +55,7 @@ debug_inline static bool IsNormalRoad(Tile t)
  * @param t Tile to query.
  * @return True if normal road tile.
  */
-debug_inline static bool IsNormalRoadTile(Tile t)
+[[debug_inline]] inline static bool IsNormalRoadTile(Tile t)
 {
 	return IsTileType(t, MP_ROAD) && IsNormalRoad(t);
 }
@@ -87,7 +87,7 @@ inline bool IsLevelCrossingTile(Tile t)
  * @pre IsTileType(t, MP_ROAD)
  * @return True if road depot.
  */
-debug_inline static bool IsRoadDepot(Tile t)
+[[debug_inline]] inline static bool IsRoadDepot(Tile t)
 {
 	return GetRoadTileType(t) == ROAD_TILE_DEPOT;
 }
@@ -97,7 +97,7 @@ debug_inline static bool IsRoadDepot(Tile t)
  * @param t Tile to query.
  * @return True if road depot tile.
  */
-debug_inline static bool IsRoadDepotTile(Tile t)
+[[debug_inline]] inline static bool IsRoadDepotTile(Tile t)
 {
 	return IsTileType(t, MP_ROAD) && IsRoadDepot(t);
 }

--- a/src/screenshot_gui.cpp
+++ b/src/screenshot_gui.cpp
@@ -47,6 +47,7 @@ struct ScreenshotWindow : Window {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_screenshot[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -63,6 +64,7 @@ static constexpr NWidgetPart _nested_screenshot[] = {
 		NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SC_TAKE_MINIMAP), SetFill(1, 1), SetStringTip(STR_SCREENSHOT_MINIMAP_SCREENSHOT), SetMinimalTextLines(2, 0),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _screenshot_window_desc(
 	WDP_AUTO, "take_a_screenshot", 200, 100,

--- a/src/script/api/script_rail.hpp
+++ b/src/script/api/script_rail.hpp
@@ -301,7 +301,10 @@ public:
 	 * @exception ScriptStation::ERR_STATION_TOO_MANY_STATIONS_IN_TOWN
 	 * @return Whether the station has been/can be build or not.
 	 */
+	/* clang-format off */
+	/* wrapping breaks the squirrel-extractor */
 	static bool BuildNewGRFRailStation(TileIndex tile, RailTrack direction, SQInteger num_platforms, SQInteger platform_length, StationID station_id, CargoType cargo_type, IndustryType source_industry, IndustryType goal_industry, SQInteger distance, bool source_station);
+	/* clang-format on */
 
 	/**
 	 * Build a rail waypoint.

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -247,6 +247,7 @@ struct ScriptListWindow : public Window {
 };
 
 /** Widgets for the AI list window. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_script_list_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_MAUVE),
@@ -267,6 +268,7 @@ static constexpr NWidgetPart _nested_script_list_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_MAUVE),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Window definition for the ai list window. */
 static WindowDesc _script_list_desc(
@@ -565,6 +567,7 @@ private:
 };
 
 /** Widgets for the Script settings window. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_script_settings_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_MAUVE),
@@ -583,6 +586,7 @@ static constexpr NWidgetPart _nested_script_settings_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_MAUVE),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Window definition for the Script settings window. */
 static WindowDesc _script_settings_desc(
@@ -1211,6 +1215,7 @@ std::unique_ptr<NWidgetBase> MakeCompanyButtonRowsScriptDebug()
 }
 
 /** Widgets for the Script debug window. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_script_debug_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -1257,6 +1262,7 @@ static constexpr NWidgetPart _nested_script_debug_widgets[] = {
 	EndContainer(),
 EndContainer(),
 };
+/* clang-format on */
 
 /** Window definition for the Script debug window. */
 static WindowDesc _script_debug_desc(

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -15,11 +15,15 @@
 #include "../string_func.h"
 #include "script_fatalerror.hpp"
 #include "../settings_type.h"
-#include <sqstdaux.h>
-#include <../squirrel/sqpcheader.h>
-#include <../squirrel/sqvm.h>
 #include "../core/math_func.hpp"
 #include "../core/string_consumer.hpp"
+
+/* clang-format off */
+/* squirrel defines lots of generically named macros, which break some headers above, so move them to the end */
+#include "../3rdparty/squirrel/include/sqstdaux.h"
+#include "../3rdparty/squirrel/squirrel/sqpcheader.h"
+#include "../3rdparty/squirrel/squirrel/sqvm.h"
+/* clang-format on */
 
 #include "../safeguards.h"
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -192,6 +192,7 @@ static std::optional<std::string> VolumeMarkFunc(int, int mark, int value)
 	return GetString(STR_GAME_OPTIONS_VOLUME_MARK, value / 31 * 25);
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_social_plugins_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_FRAME, COLOUR_GREY, WID_GO_SOCIAL_PLUGIN_TITLE),
@@ -206,12 +207,15 @@ static constexpr NWidgetPart _nested_social_plugins_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_social_plugins_none_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_TEXT, INVALID_COLOUR), SetMinimalSize(0, 12), SetFill(1, 0), SetStringTip(STR_GAME_OPTIONS_SOCIAL_PLUGINS_NONE),
 	EndContainer(),
 };
+/* clang-format on */
 
 class NWidgetSocialPlugins : public NWidgetVertical {
 public:
@@ -997,6 +1001,7 @@ struct GameOptionsWindow : Window {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_game_options_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -1178,6 +1183,7 @@ static constexpr NWidgetPart _nested_game_options_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _game_options_desc(
 	WDP_CENTER, nullptr, 0, 0,
@@ -1757,6 +1763,7 @@ struct GameSettingsWindow : Window {
 
 GameSettings *GameSettingsWindow::settings_ptr = nullptr;
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_settings_selection_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_MAUVE),
@@ -1796,6 +1803,7 @@ static constexpr NWidgetPart _nested_settings_selection_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_MAUVE),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _settings_selection_desc(
 	WDP_CENTER, "settings", 510, 450,
@@ -2062,6 +2070,7 @@ struct CustomCurrencyWindow : Window {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_cust_currency_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -2102,6 +2111,7 @@ static constexpr NWidgetPart _nested_cust_currency_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _cust_currency_desc(
 	WDP_CENTER, nullptr, 0, 0,

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -349,6 +349,7 @@ struct SignListWindow : Window, SignList {
 	}, SignListGlobalHotkeys};
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_sign_list_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -375,6 +376,7 @@ static constexpr NWidgetPart _nested_sign_list_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _sign_list_desc(
 	WDP_AUTO, "list_signs", 358, 138,
@@ -524,6 +526,7 @@ struct SignWindow : Window, SignList {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_query_sign_edit_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -542,6 +545,7 @@ static constexpr NWidgetPart _nested_query_sign_edit_widgets[] = {
 		NWidget(WWT_PUSHARROWBTN, COLOUR_GREY, WID_QES_NEXT), SetMinimalSize(11, 12), SetArrowWidgetTypeTip(AWV_INCREASE, STR_EDIT_SIGN_NEXT_SIGN_TOOLTIP),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _query_sign_edit_desc(
 	WDP_CENTER, nullptr, 0, 0,

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -1965,13 +1965,16 @@ public:
 };
 
 /** Widget parts of the smallmap display. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_smallmap_display[] = {
 	NWidget(WWT_PANEL, COLOUR_BROWN, WID_SM_MAP_BORDER),
 		NWidget(WWT_INSET, COLOUR_BROWN, WID_SM_MAP), SetMinimalSize(346, 140), SetResize(1, 1), SetPadding(2, 2, 2, 2), EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Widget parts of the smallmap legend bar + image buttons. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_smallmap_bar[] = {
 	NWidget(WWT_PANEL, COLOUR_BROWN),
 		NWidget(NWID_HORIZONTAL),
@@ -2012,6 +2015,7 @@ static constexpr NWidgetPart _nested_smallmap_bar[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static std::unique_ptr<NWidgetBase> SmallMapDisplay()
 {
@@ -2022,6 +2026,7 @@ static std::unique_ptr<NWidgetBase> SmallMapDisplay()
 	return map_display;
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_smallmap_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -2053,6 +2058,7 @@ static constexpr NWidgetPart _nested_smallmap_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_BROWN),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _smallmap_desc(
 	WDP_AUTO, "smallmap", 484, 314,

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -301,7 +301,7 @@ struct GoodsEntry {
 	 * Test if this goods entry has optional cargo packet/flow data.
 	 * @returns true iff optional data is present.
 	 */
-	debug_inline bool HasData() const { return this->data != nullptr; }
+	[[debug_inline]] inline bool HasData() const { return this->data != nullptr; }
 
 	/**
 	 * Clear optional cargo packet/flow data.
@@ -313,7 +313,7 @@ struct GoodsEntry {
 	 * @pre HasData()
 	 * @returns cargo packet/flow data.
 	 */
-	debug_inline const GoodsEntryData &GetData() const
+	[[debug_inline]] inline const GoodsEntryData &GetData() const
 	{
 		assert(this->HasData());
 		return *this->data;
@@ -324,7 +324,7 @@ struct GoodsEntry {
 	 * @pre HasData()
 	 * @returns non-const cargo packet/flow data.
 	 */
-	debug_inline GoodsEntryData &GetData()
+	[[debug_inline]] inline GoodsEntryData &GetData()
 	{
 		assert(this->HasData());
 		return *this->data;

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -759,6 +759,7 @@ const std::initializer_list<GUIStationList::SortFunction * const> CompanyStation
 	&StationRatingMinSorter
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_company_stations_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -791,6 +792,7 @@ static constexpr NWidgetPart _nested_company_stations_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _company_stations_desc(
 	WDP_AUTO, "list_stations", 358, 162,
@@ -811,6 +813,7 @@ void ShowCompanyStations(CompanyID company)
 	AllocateWindowDescFront<CompanyStationsWindow>(_company_stations_desc, company);
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_station_view_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -847,6 +850,7 @@ static constexpr NWidgetPart _nested_station_view_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 /**
  * Draws icons of waiting cargo in the StationView window
@@ -2262,6 +2266,7 @@ static const BaseStation *FindStationsNearby(TileArea ta, bool distant_join)
 	return nullptr;
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_select_station_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -2276,6 +2281,7 @@ static constexpr NWidgetPart _nested_select_station_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /**
  * Window for selecting stations/waypoints to (distant) join to.

--- a/src/statusbar_gui.cpp
+++ b/src/statusbar_gui.cpp
@@ -210,6 +210,7 @@ struct StatusBarWindow : Window {
 	}};
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_main_status_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_PANEL, COLOUR_GREY, WID_S_LEFT), SetMinimalSize(140, 12), EndContainer(),
@@ -217,6 +218,7 @@ static constexpr NWidgetPart _nested_main_status_widgets[] = {
 		NWidget(WWT_PUSHBTN, COLOUR_GREY, WID_S_RIGHT), SetMinimalSize(140, 12),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _main_status_desc(
 	WDP_MANUAL, nullptr, 0, 0,

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -219,16 +219,16 @@
  * Do not force inlining when not in debug. This way we do not work against
  * any carefully designed compiler optimizations.
  */
-#define debug_inline inline
+#define debug_inline
 #elif defined(__clang__) || defined(__GNUC__)
-#define debug_inline [[gnu::always_inline]] inline
+#define debug_inline gnu::always_inline
 #else
 /*
  * MSVC explicitly disables inlining, even forced inlining, in debug builds
  * so __forceinline makes no difference compared to inline. Other unknown
  * compilers can also just fallback to a normal inline.
  */
-#define debug_inline inline
+#define debug_inline
 #endif
 
 /* This is already defined in unix, but not in QNX Neutrino (6.x) or Cygwin. */

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -937,6 +937,7 @@ const std::initializer_list<GUIStoryPageElementList::SortFunction * const> Story
 	&PageElementOrderSorter,
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_story_book_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -957,6 +958,7 @@ static constexpr NWidgetPart _nested_story_book_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_BROWN),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _story_book_desc(
 	WDP_AUTO, "view_story", 400, 300,

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -42,11 +42,15 @@
 #include "core/string_consumer.hpp"
 #include <stack>
 
-#include "table/strings.h"
 #include "table/control_codes.h"
 #include "3rdparty/fmt/std.h"
 
 #include "strings_internal.h"
+
+/* clang-format off */
+/* work around "main include" detection */
+#include "table/strings.h"
+/* clang-format on */
 
 #include "safeguards.h"
 

--- a/src/subsidy_gui.cpp
+++ b/src/subsidy_gui.cpp
@@ -262,6 +262,7 @@ struct SubsidyListWindow : Window {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_subsidies_list_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -278,6 +279,7 @@ static constexpr NWidgetPart _nested_subsidies_list_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _subsidies_list_desc(
 	WDP_AUTO, "list_subsidies", 500, 127,

--- a/src/table/airport_defaults.h
+++ b/src/table/airport_defaults.h
@@ -12,6 +12,8 @@
 
 #include "../timer/timer_game_calendar.h"
 
+/* clang-format off */
+
 /**
  * Definition of an airport tiles layout.
  * @param x offset x of this tile
@@ -411,5 +413,7 @@ const AirportSpec AirportSpec::dummy = AS_GENERIC(&_airportfta_dummy, {}, {}, 0,
 #undef AS
 #undef AS_ND
 #undef AS_GENERIC
+
+/* clang-format on */
 
 #endif /* AIRPORT_DEFAULTS_H */

--- a/src/table/airport_movement.h
+++ b/src/table/airport_movement.h
@@ -24,6 +24,8 @@ struct AirportFTAbuildup {
 	uint8_t next;     ///< Next position from this position.
 };
 
+/* clang-format off */
+
 ///////////////////////////////////////////////////////////////////////
 /////*********Movement Positions on Airports********************///////
 
@@ -831,5 +833,7 @@ static const AirportFTAbuildup _airport_fta_helistation[] = {
 	{ 32, TO_ALL, AirportBlock::Nothing, 25 },
 	{ MAX_ELEMENTS, TO_ALL, {}, 0 } // end marker. DO NOT REMOVE
 };
+
+/* clang-format on */
 
 #endif /* AIRPORT_MOVEMENT_H */

--- a/src/table/airporttiles.h
+++ b/src/table/airporttiles.h
@@ -12,6 +12,8 @@
 
 #include "table/strings.h"
 
+/* clang-format off */
+
 /** Writes all airport tile properties in the AirportTile struct */
 #define AT(num_frames, anim_speed) {{num_frames, AnimationStatus::Looping, anim_speed, 0}, STR_NULL, AirportTileCallbackMasks{}, 0, true, GRFFileProps(INVALID_AIRPORTTILE), {}}
 /** Writes an airport tile without animation in the AirportTile struct */
@@ -110,5 +112,7 @@ static_assert(NEW_AIRPORTTILE_OFFSET == lengthof(_origin_airporttile_specs));
 
 #undef AT_NOANIM
 #undef AT
+
+/* clang-format on */
 
 #endif /* AIRPORTTILES_H */

--- a/src/table/animcursors.h
+++ b/src/table/animcursors.h
@@ -14,6 +14,8 @@
  * is to be displayed.
  */
 
+/* clang-format off */
+
 /**
  * Creates two array entries that define one
  *  status of the cursor.
@@ -89,3 +91,5 @@ static const AnimCursor * const _animcursors[] = {
 	_order_goto_animcursor,
 	_build_signals_animcursor
 };
+
+/* clang-format on */

--- a/src/table/autorail.h
+++ b/src/table/autorail.h
@@ -7,6 +7,8 @@
 
 /** @file autorail.h Highlight/sprite information for autorail. */
 
+/* clang-format off */
+
 /* Rail selection types (directions):
  *  / \    / \    / \    / \   / \   / \
  * /  /\  /\  \  /===\  /   \ /|  \ /  |\
@@ -77,3 +79,5 @@ static const HighLightStyle _autorail_piece[][16] = {
 	{ HT_DIR_VL, HT_DIR_VL, HT_DIR_VL, HT_DIR_VL, HT_DIR_VL, HT_DIR_VL, HT_DIR_X, HT_DIR_X, HT_DIR_X, HT_DIR_X, HT_DIR_HL, HT_DIR_HL, HT_DIR_HL, HT_DIR_HL, HT_DIR_HL, HT_DIR_HL },
 	{ HT_DIR_VL, HT_DIR_VL, HT_DIR_VL, HT_DIR_VL, HT_DIR_VL, HT_DIR_VL, HT_DIR_X, HT_DIR_X, HT_DIR_X, HT_DIR_X, HT_DIR_HL, HT_DIR_HL, HT_DIR_HL, HT_DIR_HL, HT_DIR_HL, HT_DIR_HL }
 };
+
+/* clang-format on */

--- a/src/table/bridge_land.h
+++ b/src/table/bridge_land.h
@@ -7,6 +7,8 @@
 
 #include "table/strings.h"
 
+/* clang-format off */
+
 /**
  * @file bridge_land.h This file contains all the sprites for bridges
  * It consists of a number of arrays.
@@ -799,3 +801,5 @@ const BridgeSpec _orig_bridge[] = {
 #undef MR
 #undef MW
 #undef MC
+
+/* clang-format on */

--- a/src/table/build_industry.h
+++ b/src/table/build_industry.h
@@ -12,6 +12,8 @@
 
 #include "table/strings.h"
 
+/* clang-format off */
+
 /**
  * Definition of an industry tiles layout.
  * @param x offset x of this tile
@@ -1786,5 +1788,7 @@ static const IndustryTileSpec _origin_industry_tile_specs[NEW_INDUSTRYTILEOFFSET
 	MT(0, CT_INVALID,      0, CT_INVALID,      0, CT_INVALID,     SLOPE_STEEP, INDUSTRYTILE_NOANIM, INDUSTRYTILE_NOANIM, false),
 };
 #undef MT
+
+/* clang-format on */
 
 #endif  /* BUILD_INDUSTRY_H */

--- a/src/table/cargo_const.h
+++ b/src/table/cargo_const.h
@@ -12,6 +12,8 @@
 #include "table/strings.h"
 #endif
 
+/* clang-format off */
+
 /** Construction macros for the #CargoSpec StringID entries. */
 #define MK_STR_CARGO_PLURAL(label_plural) STR_CARGO_PLURAL_ ## label_plural
 #define MK_STR_CARGO_SINGULAR(label_singular) STR_CARGO_SINGULAR_ ## label_singular
@@ -108,3 +110,4 @@ static const std::variant<CargoLabel, int> _default_climate_cargo[NUM_LANDSCAPE]
 	{ CT_PASSENGERS, CT_SUGAR,  CT_MAIL, CT_TOYS, CT_BATTERIES, CT_CANDY, CT_TOFFEE, CT_COLA, CT_COTTON_CANDY, CT_BUBBLES, CT_PLASTIC,   CT_FIZZY_DRINKS, },
 };
 
+/* clang-format on */

--- a/src/table/clear_land.h
+++ b/src/table/clear_land.h
@@ -9,6 +9,8 @@
 
 #include "sprites.h"
 
+/* clang-format off */
+
 static const SpriteID _landscape_clear_sprites_rough[8] = {
 	SPR_FLAT_ROUGH_LAND,
 	SPR_FLAT_ROUGH_LAND_1,
@@ -76,3 +78,5 @@ static const SpriteID _clear_land_sprites_snow_desert[8] = {
 	SPR_FLAT_3_QUART_SNOW_DESERT_TILE,
 	SPR_FLAT_SNOW_DESERT_TILE,
 };
+
+/* clang-format on */

--- a/src/table/elrail_data.h
+++ b/src/table/elrail_data.h
@@ -13,6 +13,8 @@
 #ifndef ELRAIL_DATA_H
 #define ELRAIL_DATA_H
 
+/* clang-format off */
+
 /**
  * Tile Location group.
  * This defines whether the X and or Y coordinate of a tile is even
@@ -509,5 +511,7 @@ static const RailCatenarySprite Wires[5][TRACK_END][4] = {
 		{INVALID_CATENARY, INVALID_CATENARY, INVALID_CATENARY, INVALID_CATENARY},
 	}
 };
+
+/* clang-format on */
 
 #endif /* ELRAIL_DATA_H */

--- a/src/table/engines.h
+++ b/src/table/engines.h
@@ -15,6 +15,8 @@
 
 #include "table/strings.h"
 
+/* clang-format off */
+
 /**
  * Writes the properties of a train into the EngineInfo struct.
  * @see EngineInfo
@@ -766,5 +768,7 @@ static constexpr RoadVehicleInfo _orig_road_vehicle_info[] = {
 	ROV( 62, 157, 240, SND_40_DEPARTURE_TRUCK_TOYLAND_2, 224, 22,  69, 45), // 87 Wizzowow Bubble Truck
 };
 #undef ROV
+
+/* clang-format on */
 
 #endif /* ENGINES_H */

--- a/src/table/genland.h
+++ b/src/table/genland.h
@@ -7,6 +7,8 @@
 
 /** @file genland.h Table used to generate deserts and/or rainforests. */
 
+/* clang-format off */
+
 #define M(x, y) {x,  y}
 
 static const TileIndexDiffC _make_desert_or_rainforest_data[] = {
@@ -161,6 +163,6 @@ static const TileIndexDiffC _make_desert_or_rainforest_data[] = {
 	M( 3, -6)
 };
 
-
-
 #undef M
+
+/* clang-format on */

--- a/src/table/heightmap_colours.h
+++ b/src/table/heightmap_colours.h
@@ -9,6 +9,8 @@
  * @file heightmap_colours.h The colour tables for heightmaps.
  */
 
+/* clang-format off */
+
 /** Height map colours for the green colour scheme, ordered by height. */
 static const uint32_t _green_map_heights[] = {
 	MKCOLOUR(0x59595958),
@@ -340,3 +342,5 @@ static const uint32_t _violet_map_heights[] = {
 	MKCOLOUR(0x87878786),
 	MKCOLOUR(0x87878787),
 };
+
+/* clang-format on */

--- a/src/table/industry_land.h
+++ b/src/table/industry_land.h
@@ -31,6 +31,8 @@ struct DrawIndustryCoordinates {
 	uint8_t y;  ///< coordinate y of the pair
 };
 
+/* clang-format off */
+
 /**
  * Macro to ease the declaration of the array
  * @param s1 sprite ID of ground sprite
@@ -954,3 +956,4 @@ static const DrawIndustryCoordinates _coal_plant_sparks[] = {
 	{15,  0},
 };
 
+/* clang-format on */

--- a/src/table/landscape_sprite.h
+++ b/src/table/landscape_sprite.h
@@ -7,6 +7,8 @@
 
 /** @file landscape_sprite.h Offsets of sprites to replace for non-temperate landscapes. */
 
+/* clang-format off */
+
 static constexpr std::pair<SpriteID, SpriteID> _landscape_spriteindexes_arctic[] = {
 	{ 0xF67,  0xF9F},
 	{ 0xAAD,  0xAB0},
@@ -136,3 +138,5 @@ static constexpr std::pair<SpriteID, SpriteID> _landscape_spriteindexes_toyland[
 	{ 0x511,  0x511},
 	{ 0x322,  0x322},
 };
+
+/* clang-format on */

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -12,6 +12,8 @@
 #include "../newgrf_roadtype.h"
 #include "../newgrf_roadstop.h"
 
+/* clang-format off */
+
 /* Helper for filling property tables */
 #define NIP(prop, base, variable, type, name) { name, [] (const void *b) -> const void * { return std::addressof(static_cast<const base *>(b)->variable); }, cpp_sizeof(base, variable), prop, type }
 
@@ -747,3 +749,5 @@ static const NIFeature * const _nifeatures[] = {
 	nullptr,
 };
 static_assert(lengthof(_nifeatures) == GSF_FAKE_END);
+
+/* clang-format on */

--- a/src/table/object_land.h
+++ b/src/table/object_land.h
@@ -9,6 +9,8 @@
 
 #include "table/strings.h"
 
+/* clang-format off */
+
 #define TILE_SEQ_LINE(sz, img) { 0, 0, 0, 16, 16, sz, {img, PAL_NONE} },
 
 static const DrawTileSeqStruct _object_transmitter_seq[] = {
@@ -131,3 +133,5 @@ extern const ObjectSpec _original_objects[] = {
 #undef S
 #undef A
 #undef T
+
+/* clang-format on */

--- a/src/table/opengl_shader.h
+++ b/src/table/opengl_shader.h
@@ -7,6 +7,8 @@
 
 /** @file opengl_shader.h OpenGL shader programs. */
 
+/* clang-format off */
+
 /** Vertex shader that positions a sprite on screen.. */
 static const char *_vertex_shader_sprite[] = {
 	"#version 110\n",
@@ -199,3 +201,5 @@ static const char *_frag_shader_sprite_blend_150[] = {
 	"  colour.rgb = idx > 0.0 ? adj_brightness(remap_col.rgb, max3(rgb_col.rgb)) : rgb_col.rgb;",
 	"}",
 };
+
+/* clang-format on */

--- a/src/table/palette_convert.h
+++ b/src/table/palette_convert.h
@@ -7,6 +7,8 @@
 
 /** @file palette_convert.h Translation tables from one GRF to another GRF. */
 
+/* clang-format off */
+
 /** Converting from the Windows palette to the DOS palette */
 extern const uint8_t _palmap_w2d[] = {
 	  0,   1,   2,   3,   4,   5,   6,   7, //   0..7
@@ -78,3 +80,5 @@ static const uint8_t _palmap_d2w[] = {
 	240, 241, 242, 243, 244, 217, 218, 219, // 240..247
 	220, 221, 222, 223, 224, 225, 226, 255, // 248..255
 };
+
+/* clang-format on */

--- a/src/table/palettes.h
+++ b/src/table/palettes.h
@@ -7,6 +7,8 @@
 
 /** @file palettes.h The colour translation of the GRF palettes. */
 
+/* clang-format off */
+
 #define M(r, g, b) Colour(r, g, b)
 
 /** Colour palette (DOS) */
@@ -143,3 +145,5 @@ static const ExtraPaletteValues _extra_palette_values = {
 	  M(116, 180, 196), M(148, 200, 216), M(180, 220, 232) }
 };
 #undef M
+
+/* clang-format on */

--- a/src/table/pricebase.h
+++ b/src/table/pricebase.h
@@ -7,6 +7,8 @@
 
 /** @file pricebase.h Price Bases */
 
+/* clang-format off */
+
 extern const PriceBaseSpec _price_base_specs[] = {
 	{    100, PCAT_NONE,         GSF_END,          INVALID_PRICE         }, ///< PR_STATION_VALUE
 	{    100, PCAT_CONSTRUCTION, GSF_END,          INVALID_PRICE         }, ///< PR_BUILD_RAIL
@@ -81,3 +83,5 @@ extern const PriceBaseSpec _price_base_specs[] = {
 	{   5000, PCAT_RUNNING,      GSF_END,          PR_BUILD_STATION_AIRPORT}, ///< PR_INFRASTRUCTURE_AIRPORT
 };
 static_assert(lengthof(_price_base_specs) == PR_END);
+
+/* clang-format on */

--- a/src/table/railtypes.h
+++ b/src/table/railtypes.h
@@ -15,6 +15,8 @@
 
 #include "table/strings.h"
 
+/* clang-format off */
+
 /**
  * Global Railtype definition
  */
@@ -415,5 +417,7 @@ static const RailTypeInfo _original_railtypes[] = {
 		{},
 	},
 };
+
+/* clang-format on */
 
 #endif /* RAILTYPES_H */

--- a/src/table/road_land.h
+++ b/src/table/road_land.h
@@ -7,6 +7,8 @@
 
 /** @file road_land.h Sprite constructs for road depots. */
 
+/* clang-format off */
+
 #define TILE_SEQ_LINE(img, pal, dx, dy, sx, sy) { dx, dy, 0, sx, sy, 20, {img, pal} },
 
 static const DrawTileSeqStruct _road_depot_NE[] = {
@@ -287,3 +289,5 @@ static const DrawRoadTileStruct * const * const _road_display_table[] = {
 	_roadside_none,
 	_roadside_trees,
 };
+
+/* clang-format on */

--- a/src/table/roadtypes.h
+++ b/src/table/roadtypes.h
@@ -15,6 +15,8 @@
 
 #include "table/strings.h"
 
+/* clang-format off */
+
 /**
  * Global Roadtype definition
  */
@@ -181,5 +183,7 @@ static const RoadTypeInfo _original_roadtypes[] = {
 		{},
 	},
 };
+
+/* clang-format on */
 
 #endif /* ROADTYPES_H */

--- a/src/table/roadveh_movement.h
+++ b/src/table/roadveh_movement.h
@@ -7,6 +7,8 @@
 
 /** @file table/roadveh_movement.h Data about how a road vehicle must drive on a tile */
 
+/* clang-format off */
+
 static const RoadDriveEntry _roadveh_drive_data_0[] = {
 	{15, 5},
 	{14, 5},
@@ -1482,3 +1484,5 @@ static const RoadDriveEntry * const * const _road_drive_data[2] = {
 	_road_road_drive_data,
 	_road_tram_drive_data,
 };
+
+/* clang-format on */

--- a/src/table/station_land.h
+++ b/src/table/station_land.h
@@ -7,6 +7,8 @@
 
 /** @file station_land.h Sprites to use and how to display them for station tiles. */
 
+/* clang-format off */
+
 /**
  * Constructor macro for an image without a palette in a DrawTileSeqStruct array.
  * @param dx  Offset in x direction
@@ -902,3 +904,5 @@ static const std::array<std::span<const DrawTileSpriteSpan>, to_underlying(Stati
 	_station_display_datas_waypoint,
 	_station_display_datas_road_waypoint,
 }};
+
+/* clang-format on */

--- a/src/table/strgen_tables.h
+++ b/src/table/strgen_tables.h
@@ -32,6 +32,8 @@ extern void EmitSingleChar(StringBuilder &builder, std::string_view param, char3
 extern void EmitPlural(StringBuilder &builder, std::string_view param, char32_t value);
 extern void EmitGender(StringBuilder &builder, std::string_view param, char32_t value);
 
+/* clang-format off */
+
 static const CmdStruct _cmd_structs[] = {
 	/* Font size */
 	{"NORMAL_FONT",       EmitSingleChar, SCC_NORMALFONT,         0, std::nullopt, {}},
@@ -157,6 +159,8 @@ static const CmdStruct _cmd_structs[] = {
 	{"PDF",               EmitSingleChar, CHAR_TD_PDF,            0, std::nullopt, {CmdFlag::DontCount}},
 };
 
+/* clang-format on */
+
 /** Description of a plural form */
 struct PluralForm {
 	size_t plural_count;     ///< The number of plural forms
@@ -166,6 +170,8 @@ struct PluralForm {
 
 /** The maximum number of plurals. */
 static const size_t MAX_PLURALS = 5;
+
+/* clang-format off */
 
 /** All plural forms used */
 static const PluralForm _plural_forms[] = {
@@ -214,3 +220,5 @@ static const char * const _pragmas[][4] = {
 	{ "gender",      "tag", "",       "List of genders" },
 	{ "case",        "tac", "",       "List of cases" },
 };
+
+/* clang-format on */

--- a/src/table/string_colours.h
+++ b/src/table/string_colours.h
@@ -7,6 +7,8 @@
 
 /** @file string_colours.h The colour translation of GRF's strings. */
 
+/* clang-format off */
+
 /** Colour mapping for #TextColour. */
 static const uint8_t _string_colourmap[17] = {
 	150, // TC_BLUE
@@ -27,3 +29,5 @@ static const uint8_t _string_colourmap[17] = {
 	133, // TC_DARK_BLUE
 	  1, // TC_BLACK
 };
+
+/* clang-format on */

--- a/src/table/town_land.h
+++ b/src/table/town_land.h
@@ -7,6 +7,8 @@
 
 /** @file town_land.h Sprites to use and how to display them for town tiles. */
 
+/* clang-format off */
+
 /**
  * Writes the data into the Town Tile Drawing Struct
  * @param s1 The first sprite of the building, mostly the ground sprite
@@ -2277,3 +2279,5 @@ extern const HouseSpec _original_house_specs[] = {
 
 /** Make sure we have the right number of elements: one entry for each house */
 static_assert(lengthof(_original_house_specs) == NEW_HOUSE_OFFSET);
+
+/* clang-format on */

--- a/src/table/townname.h
+++ b/src/table/townname.h
@@ -9,6 +9,8 @@
 
 #include "../core/enum_type.hpp"
 
+/* clang-format off */
+
 static const char * const _name_original_english_1[] = {
 	"Great ",
 	"Little ",
@@ -3312,3 +3314,5 @@ static const char * const _name_catalan_river1[] = {
 	" de Segre",
 	" de Francol\u00ed",
 };
+
+/* clang-format on */

--- a/src/table/track_land.h
+++ b/src/table/track_land.h
@@ -7,8 +7,9 @@
 
 /** @file track_land.h Sprites to use and how to display them for train depot tiles. */
 
-#define TILE_SEQ_LINE(img, dx, dy, sx, sy) { dx, dy, 0, sx, sy, 23, {img, PAL_NONE} },
+/* clang-format off */
 
+#define TILE_SEQ_LINE(img, dx, dy, sx, sy) { dx, dy, 0, sx, sy, 23, {img, PAL_NONE} },
 
 static const DrawTileSeqStruct _depot_gfx_NE[] = {
 	TILE_SEQ_LINE(SPR_RAIL_DEPOT_NE | (1 << PALETTE_MODIFIER_COLOUR), 2, 13, 13, 1)
@@ -43,3 +44,5 @@ static const DrawTileSpriteSpan _depot_invisible_gfx_table[] = {
 };
 
 #undef TILE_SEQ_LINE
+
+/* clang-format on */

--- a/src/table/train_sprites.h
+++ b/src/table/train_sprites.h
@@ -7,6 +7,8 @@
 
 /** @file train_sprites.h Sprites to use for trains. */
 
+/* clang-format off */
+
 static const SpriteID _engine_sprite_base[] = {
 0x0B59, 0x0B61, 0x0B69, 0x0BE1, 0x0B71, 0x0B75, 0x0B7D, 0x0B7D,
 0x0B85, 0x0B85, 0x0B8D, 0x0B8D, 0x0BC9, 0x0BD1, 0x0BD9, 0x0BE9,
@@ -66,3 +68,5 @@ static const uint8_t _wagon_full_adder[] = {
 static_assert(lengthof(_engine_sprite_base) == lengthof(_engine_sprite_and));
 static_assert(lengthof(_engine_sprite_base) == lengthof(_engine_sprite_add));
 static_assert(lengthof(_engine_sprite_base) == lengthof(_wagon_full_adder));
+
+/* clang-format on */

--- a/src/table/tree_land.h
+++ b/src/table/tree_land.h
@@ -10,6 +10,8 @@
 #ifndef TREE_LAND_H
 #define TREE_LAND_H
 
+/* clang-format off */
+
 static const uint8_t _tree_base_by_landscape[4] = {0, 12, 20, 32};
 static const uint8_t _tree_count_by_landscape[4] = {12, 8, 12, 9};
 
@@ -224,5 +226,7 @@ static const PalSpriteID _tree_layout_sprite[164 + (79 - 48 + 1)][4] = {
 	{ { 0x716, PAL_NONE }, { 0x716, PAL_NONE }, { 0x6f3, PAL_NONE }, { 0x6ec, PAL_NONE } }, // 30
 	{ { 0x716, PAL_NONE }, { 0x701, PAL_NONE }, { 0x6fa, PAL_NONE }, { 0x716, PAL_NONE } }, // 31
 };
+
+/* clang-format on */
 
 #endif /* TREE_LAND_H */

--- a/src/table/water_land.h
+++ b/src/table/water_land.h
@@ -7,6 +7,8 @@
 
 /** @file water_land.h Sprites to use and how to display them for water tiles (depots/locks). */
 
+/* clang-format off */
+
 /**
  * Constructor macro for an image without a palette in a DrawTileSeqStruct array.
  * @param dx  Offset in x direction
@@ -140,3 +142,5 @@ static const DrawTileSpriteSpan _lock_display_data[][DIAGDIR_END] = {
 
 #undef TILE_SEQ_LINE
 #undef TILE_SPRITE_LINE
+
+/* clang-format on */

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -316,6 +316,7 @@ struct TerraformToolbarWindow : Window {
 	}, TerraformToolbarGlobalHotkeys};
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_terraform_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -346,6 +347,7 @@ static constexpr NWidgetPart _nested_terraform_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _terraform_desc(
 	WDP_MANUAL, "toolbar_landscape", 0, 0,
@@ -445,6 +447,7 @@ static const int8_t _multi_terraform_coords[][2] = {
 	{-28,  0}, {-24, -2}, {-20, -4}, {-16, -6}, {-12, -8}, { -8,-10}, { -4,-12}, {  0,-14}, {  4,-12}, {  8,-10}, { 12, -8}, { 16, -6}, { 20, -4}, { 24, -2}, { 28,  0},
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_scen_edit_land_gen_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -493,6 +496,7 @@ static constexpr NWidgetPart _nested_scen_edit_land_gen_widgets[] = {
 								SetFill(1, 0), SetStringTip(STR_TERRAFORM_RESET_LANDSCAPE, STR_TERRAFORM_RESET_LANDSCAPE_TOOLTIP), SetPadding(1, 2, 2, 2),
 	EndContainer(),
 };
+/* clang-format on */
 
 /**
  * Callback function for the scenario editor 'reset landscape' confirmation window

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -40,6 +40,7 @@
 #include "safeguards.h"
 
 /** Widgets for the textfile window. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_textfile_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_MAUVE),
@@ -74,6 +75,7 @@ static constexpr NWidgetPart _nested_textfile_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_MAUVE),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Window definition for the textfile window */
 static WindowDesc _textfile_desc(

--- a/src/tile_map.h
+++ b/src/tile_map.h
@@ -26,7 +26,7 @@
  * @return the height of the tile
  * @pre tile < Map::Size()
  */
-debug_inline static uint TileHeight(Tile tile)
+[[debug_inline]] inline static uint TileHeight(Tile tile)
 {
 	assert(tile < Map::Size());
 	return tile.height();
@@ -93,7 +93,7 @@ inline uint TilePixelHeightOutsideMap(int x, int y)
  * @return The tiletype of the tile
  * @pre tile < Map::Size()
  */
-debug_inline static TileType GetTileType(Tile tile)
+[[debug_inline]] inline static TileType GetTileType(Tile tile)
 {
 	assert(tile < Map::Size());
 	return (TileType)GB(tile.type(), 4, 4);
@@ -147,7 +147,7 @@ inline void SetTileType(Tile tile, TileType type)
  * @param type The type to check against
  * @return true If the type matches against the type of the tile
  */
-debug_inline static bool IsTileType(Tile tile, TileType type)
+[[debug_inline]] inline static bool IsTileType(Tile tile, TileType type)
 {
 	return GetTileType(tile) == type;
 }

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -808,6 +808,7 @@ struct TimetableWindow : Window {
 	}};
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_timetable_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -853,6 +854,7 @@ static constexpr NWidgetPart _nested_timetable_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _timetable_desc(
 	WDP_AUTO, "view_vehicle_timetable", 400, 130,

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2239,9 +2239,11 @@ static std::unique_ptr<NWidgetBase> MakeMainToolbar()
 	return hor;
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_toolbar_normal_widgets[] = {
 	NWidgetFunction(MakeMainToolbar),
 };
+/* clang-format on */
 
 static WindowDesc _toolb_normal_desc(
 	WDP_MANUAL, nullptr, 0, 0,
@@ -2540,6 +2542,7 @@ struct ScenarioEditorToolbarWindow : Window {
 	}};
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_toolb_scen_inner_widgets[] = {
 	NWidget(WWT_IMGBTN, COLOUR_GREY, WID_TE_PAUSE), SetSpriteTip(SPR_IMG_PAUSE, STR_TOOLBAR_TOOLTIP_PAUSE_GAME),
 	NWidget(WWT_IMGBTN, COLOUR_GREY, WID_TE_FAST_FORWARD), SetSpriteTip(SPR_IMG_FASTFORWARD, STR_TOOLBAR_TOOLTIP_FORWARD),
@@ -2574,15 +2577,18 @@ static constexpr NWidgetPart _nested_toolb_scen_inner_widgets[] = {
 	NWidget(WWT_IMGBTN, COLOUR_GREY, WID_TE_HELP), SetSpriteTip(SPR_IMG_QUERY, STR_TOOLBAR_TOOLTIP_LAND_BLOCK_INFORMATION),
 	NWidget(WWT_IMGBTN, COLOUR_GREY, WID_TE_SWITCH_BAR), SetSpriteTip(SPR_IMG_SWITCH_TOOLBAR, STR_TOOLBAR_TOOLTIP_SWITCH_TOOLBAR),
 };
+/* clang-format on */
 
 static std::unique_ptr<NWidgetBase> MakeScenarioToolbar()
 {
 	return MakeNWidgets(_nested_toolb_scen_inner_widgets, std::make_unique<NWidgetScenarioToolbarContainer>());
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_toolb_scen_widgets[] = {
 	NWidgetFunction(MakeScenarioToolbar),
 };
+/* clang-format on */
 
 static WindowDesc _toolb_scen_desc(
 	WDP_MANUAL, nullptr, 0, 0,

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -56,6 +56,7 @@ TownKdtree _town_local_authority_kdtree{};
 
 typedef GUIList<const Town*, const bool &> GUITownList;
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_town_authority_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -73,6 +74,7 @@ static constexpr NWidgetPart _nested_town_authority_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_BROWN),
 	EndContainer()
 };
+/* clang-format on */
 
 /** Town authority window. */
 struct TownAuthorityWindow : Window {
@@ -610,6 +612,7 @@ public:
 	}};
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_town_game_view_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -632,6 +635,7 @@ static constexpr NWidgetPart _nested_town_game_view_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_BROWN),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _town_game_view_desc(
 	WDP_AUTO, "view_town", 260, TownViewWindow::WID_TV_HEIGHT_NORMAL,
@@ -640,6 +644,7 @@ static WindowDesc _town_game_view_desc(
 	_nested_town_game_view_widgets
 );
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_town_editor_view_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -663,6 +668,7 @@ static constexpr NWidgetPart _nested_town_editor_view_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_BROWN),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _town_editor_view_desc(
 	WDP_AUTO, "view_town_scen", 260, TownViewWindow::WID_TV_HEIGHT_NORMAL,
@@ -680,6 +686,7 @@ void ShowTownViewWindow(TownID town)
 	}
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_town_directory_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
@@ -707,6 +714,7 @@ static constexpr NWidgetPart _nested_town_directory_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Enum referring to the Hotkeys in the town directory window */
 enum TownDirectoryHotkeys : int32_t {
@@ -1080,6 +1088,7 @@ void CcFoundRandomTown(Commands, const CommandCost &result, Money, TownID town_i
 	if (result.Succeeded()) ScrollMainWindowToTile(Town::Get(town_id)->xy);
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_found_town_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -1141,6 +1150,7 @@ static constexpr NWidgetPart _nested_found_town_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Found a town window class. */
 struct FoundTownWindow : Window {
@@ -1818,6 +1828,7 @@ struct BuildHouseWindow : public PickerWindow {
 };
 
 /** Nested widget definition for the build NewGRF rail waypoint window */
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_house_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -1844,6 +1855,7 @@ static constexpr NWidgetPart _nested_build_house_widgets[] = {
 		NWidgetFunction(MakePickerTypeWidgets),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _build_house_desc(
 	WDP_AUTO, "build_house", 0, 0,

--- a/src/transparency_gui.cpp
+++ b/src/transparency_gui.cpp
@@ -126,6 +126,7 @@ public:
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_transparency_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -148,6 +149,7 @@ static constexpr NWidgetPart _nested_transparency_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_DARK_GREEN, WID_TT_BUTTONS), SetMinimalSize(219, 13), SetToolTip(STR_TRANSPARENT_INVISIBLE_TOOLTIP),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _transparency_desc(
 	WDP_MANUAL, "toolbar_transparency", 0, 0,

--- a/src/tree_gui.cpp
+++ b/src/tree_gui.cpp
@@ -285,6 +285,7 @@ static std::unique_ptr<NWidgetBase> MakeTreeTypeButtons()
 	return vstack;
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_build_trees_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
@@ -309,6 +310,7 @@ static constexpr NWidgetPart _nested_build_trees_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _build_trees_desc(
 	WDP_AUTO, "build_tree", 0, 0,

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -492,7 +492,7 @@ public:
 	 * Check if the vehicle is a ground vehicle.
 	 * @return True iff the vehicle is a train or a road vehicle.
 	 */
-	debug_inline bool IsGroundVehicle() const
+	[[debug_inline]] inline bool IsGroundVehicle() const
 	{
 		return this->type == VEH_TRAIN || this->type == VEH_ROAD;
 	}
@@ -922,7 +922,7 @@ public:
 	 * Check if the vehicle is a front engine.
 	 * @return Returns true if the vehicle is a front engine.
 	 */
-	debug_inline bool IsFrontEngine() const
+	[[debug_inline]] inline bool IsFrontEngine() const
 	{
 		return this->IsGroundVehicle() && HasBit(this->subtype, GVSF_FRONT);
 	}

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1308,6 +1308,7 @@ struct RefitWindow : public Window {
 	}
 };
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_vehicle_refit_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -1333,6 +1334,7 @@ static constexpr NWidgetPart _nested_vehicle_refit_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 static WindowDesc _vehicle_refit_desc(
 	WDP_AUTO, "view_vehicle_refit", 240, 174,
@@ -1594,6 +1596,7 @@ void ChangeVehicleViewWindow(VehicleID from_index, VehicleID to_index)
 	ChangeVehicleWindow(WC_VEHICLE_TIMETABLE, from_index, to_index);
 }
 
+/* clang-format off */
 static constexpr NWidgetPart _nested_vehicle_list[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -1653,6 +1656,7 @@ static constexpr NWidgetPart _nested_vehicle_list[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 static void DrawSmallOrderList(const Vehicle *v, int left, int right, int y, uint order_arrow_width, VehicleOrderID start)
 {
@@ -2326,6 +2330,7 @@ static_assert(WID_VD_DETAILS_CAPACITY_OF_EACH == WID_VD_DETAILS_CARGO_CARRIED + 
 static_assert(WID_VD_DETAILS_TOTAL_CARGO      == WID_VD_DETAILS_CARGO_CARRIED + TDW_TAB_TOTALS  );
 
 /** Vehicle details widgets (other than train). */
+/* clang-format off */
 static constexpr NWidgetPart _nested_nontrain_vehicle_details_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -2347,8 +2352,10 @@ static constexpr NWidgetPart _nested_nontrain_vehicle_details_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** Train details widgets. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_train_vehicle_details_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -2383,6 +2390,7 @@ static constexpr NWidgetPart _nested_train_vehicle_details_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 
 extern int GetTrainDetailsWndVScroll(VehicleID veh_id, TrainDetailsWindowTabs det_tab);
@@ -2822,6 +2830,7 @@ static void ShowVehicleDetailsWindow(const Vehicle *v)
 /* Unified vehicle GUI - Vehicle View Window */
 
 /** Vehicle view widgets. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_vehicle_view_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -2863,6 +2872,7 @@ static constexpr NWidgetPart _nested_vehicle_view_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 /* Just to make sure, nobody has changed the vehicle type constants, as we are
 	 using them for array indexing in a number of places here. */

--- a/src/viewport_gui.cpp
+++ b/src/viewport_gui.cpp
@@ -23,6 +23,7 @@
 #include "safeguards.h"
 
 /* Extra Viewport Window Stuff */
+/* clang-format off */
 static constexpr NWidgetPart _nested_extra_viewport_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -49,6 +50,7 @@ static constexpr NWidgetPart _nested_extra_viewport_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 class ExtraViewportWindow : public Window {
 public:

--- a/src/waypoint_gui.cpp
+++ b/src/waypoint_gui.cpp
@@ -187,6 +187,7 @@ public:
 };
 
 /** The widgets of the waypoint view. */
+/* clang-format off */
 static constexpr NWidgetPart _nested_waypoint_view_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
@@ -208,6 +209,7 @@ static constexpr NWidgetPart _nested_waypoint_view_widgets[] = {
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
+/* clang-format on */
 
 /** The description of the waypoint view. */
 static WindowDesc _waypoint_view_desc(


### PR DESCRIPTION
## Motivation / Problem

* Learning project specific coding-style is a nuisance for new and drive-by contributors.
* Reviewing coding style manually is a nuisance as well, and wastes a lot of time.

Providing a clang-format file solves the first issue.
The second issue can be automated, but is not included in this PR.

## Description

This PR adds a `.clang-format` file, compatible with `clang-format-19`.

### Summary
The `.clang-format` file in this PR affects OpenTTD source like this:
* It fixes various instances of (existing) wrong coding style.
* It often changes valid coding style into different valid coding style. (unavoidable)
* It has an opinion on how to format things, where we have no consistent style. E.g.
   ```diff
   #ifdef RANDOM_DEBUG
   -       uint32_t Random(const std::source_location location = std::source_location::current());
   +uint32_t Random(const std::source_location location = std::source_location::current());
    #else
   -       inline uint32_t Random([[maybe_unused]] const std::source_location location = std::source_location::current())
   -       {
   -               return _random.Next();
   -       }
   +inline uint32_t Random([[maybe_unused]] const std::source_location location = std::source_location::current())
   +{
   +       return _random.Next();
   +}
    #endif
   ```
* There are a few cases, where it changes wrong coding style into slightly better but still wrong coding style. E.g.
   ```diff
   -                               if (ec < nc) nn.left = new_branch; else nn.right = new_branch;
   +                               if (ec < nc)
   +                                       nn.left = new_branch;
   +                               else
   +                                       nn.right = new_branch;
   ```
* I did not find any cases, where it changes valid coding style into wrong coding style.

In corner cases it is possible to use
```c++
/* clang-format off */
...
/* clang-format on */
```
to allow custom formatting.

This is used to disable formatting in the following cases:
* Nested widget layouts.
* table/*.h
* A few other corner cases.

### Opinion
* We should not reformat everything.
    * It breaks too many patches.
    * It exposes all corner cases.
* We should enable this to operate on commit diffs using `git clang-format`.
* We should exclude `3rdparty/*` for obvious reasons.
* We should exclude `table/*` because it has a lot of special fomatting and alignment, when it actually appears useful.

### Compromises / style changes
* Disallow short function bodies as single line. (exception: empty bodies)
    * Sometimes we put short function bodies onto a single line. What is considered "short" is subjective. E.g.
       ```c++
       inline OrderType GetType() const { return (OrderType)GB(this->type, 0, 4); }
       ```
    * While clang-format has an option for short single line functions, it is way too generous on the interpretation of "short". 
    * It's better to have a short function on multiple lines, than a too long function on a single line.
* Disallow short case labels on single line.
    * Sometimes we put short case bodies onto a single line. What is considered "short" is subjective. E.g.
       ```c++
       case FS_NORMAL: size_name = "medium"; break;
       ```
    * With clang-format the same issues as with short functions arise.
    * Clang-format will happily put a `[[fallthrough]]` at the end of a long `case`, which is horrible.
    * It's better to have a short case on multiple lines, than a too long case on a single line.
* Abandon in-line alignment.
    * Sometimes we align assignments, names or comments across multiple lines using spaces.
    * I was told we abandoned doing that, which is good since it is very subjective.
    * Clang-format will remove all in-line alignments.

### Work arounds
A few things are not understood by clang-format.
* `debug_inline` is an attribute. Changing the syntax to `[[debug_inline]]` works. This is possible because all compilers accept empty attributes `[[]]`.
* There are a few other cases, which can be worked around by locally disabling clang-format.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
