### PR TITLE
Feature: Add options to disable vehicle introduction randomisation and exclusive previews

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -737,8 +737,9 @@ void StartupOneEngine(Engine *e, const TimerGameCalendar::YearMonthDay &aging_ym
 	/* Don't randomise the start-date in the first two years after gamestart to ensure availability
 	 * of engines in early starting games.
 	 * Note: TTDP uses fixed 1922 */
-	if (_settings_game.vehicle.vehicle_intro_randomisation) {
-		e->intro_date = ei->base_intro <= TimerGameCalendar::ConvertYMDToDate(_settings_game.game_creation.starting_year + 2, 0, 1) ? ei->base_intro : (TimerGameCalendar::Date)GB(r, 0, 9) + ei->base_intro;
+	TimerGameCalendar::Date begin_random_date = TimerGameCalendar::ConvertYMDToDate(_settings_game.game_creation.starting_year + 2, 0, 1);
+	if (_settings_game.vehicle.vehicle_intro_randomisation && ei->base_intro > begin_random_date) {
+		e->intro_date =  static_cast<TimerGameCalendar::Date>(GB(r, 0, 9)) + ei->base_intro;
 	} else {
 		e->intro_date = ei->base_intro;
 	}

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -737,7 +737,11 @@ void StartupOneEngine(Engine *e, const TimerGameCalendar::YearMonthDay &aging_ym
 	/* Don't randomise the start-date in the first two years after gamestart to ensure availability
 	 * of engines in early starting games.
 	 * Note: TTDP uses fixed 1922 */
-	e->intro_date = ei->base_intro <= TimerGameCalendar::ConvertYMDToDate(_settings_game.game_creation.starting_year + 2, 0, 1) ? ei->base_intro : (TimerGameCalendar::Date)GB(r, 0, 9) + ei->base_intro;
+	if (_settings_game.vehicle.vehicle_intro_randomisation) {
+		e->intro_date = ei->base_intro <= TimerGameCalendar::ConvertYMDToDate(_settings_game.game_creation.starting_year + 2, 0, 1) ? ei->base_intro : (TimerGameCalendar::Date)GB(r, 0, 9) + ei->base_intro;
+	} else {
+		e->intro_date = ei->base_intro;
+	}
 	if (e->intro_date <= TimerGameCalendar::date) {
 		TimerGameCalendar::YearMonthDay intro_ymd = TimerGameCalendar::ConvertDateToYMD(e->intro_date);
 		int aging_months = aging_ymd.year.base() * 12 + aging_ymd.month;

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -966,6 +966,7 @@ static IntervalTimer<TimerGameCalendar> _calendar_engines_daily({TimerGameCalend
 		c->avail_roadtypes = AddDateIntroducedRoadTypes(c->avail_roadtypes, TimerGameCalendar::date);
 	}
 
+	if (!_settings_game.vehicle.offer_vehicle_preview) return;
 	if (TimerGameCalendar::year >= _year_engine_aging_stops) return;
 
 	for (Engine *e : Engine::Iterate()) {
@@ -1160,7 +1161,7 @@ void CalendarEnginesMonthlyLoop()
 			/* Do not introduce invalid engines */
 			if (!e->IsEnabled()) continue;
 
-			if (!e->flags.Test(EngineFlag::Available) && TimerGameCalendar::date >= (e->intro_date + CalendarTime::DAYS_IN_YEAR)) {
+			if (!e->flags.Test(EngineFlag::Available) && TimerGameCalendar::date >= (e->intro_date + (_settings_game.vehicle.offer_vehicle_preview ? CalendarTime::DAYS_IN_YEAR : 0))) {
 				/* Introduce it to all companies */
 				NewVehicleAvailable(e);
 			} else if (!e->flags.Any({EngineFlag::Available, EngineFlag::ExclusivePreview}) && TimerGameCalendar::date >= e->intro_date) {

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1511,6 +1511,9 @@ STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES_HELPTEXT               :When enabled, a
 STR_CONFIG_SETTING_OFFER_VEHICLE_PREVIEW                        :Show vehicle previews: {STRING2}
 STR_CONFIG_SETTING_OFFER_VEHICLE_PREVIEW_HELPTEXT               :When enabled, the top performing company is sometimes offered a 1 year exclusive preview of a vehicle
 
+STR_CONFIG_SETTING_VEHICLE_INTRO_RANDOMISATION                  :Randomise vehicle introduction dates: {STRING2}
+STR_CONFIG_SETTING_VEHICLE_INTRO_RANDOMISATION_HELPTEXT         :When enabled, randomises vehicle introduction dates by up to 511 extra days from their original date
+
 STR_CONFIG_SETTING_TIMEKEEPING_UNITS                            :Timekeeping: {STRING2}
 STR_CONFIG_SETTING_TIMEKEEPING_UNITS_HELPTEXT                   :Select the timekeeping units of the game. This cannot be changed later.{}{}Calendar-based is the classic OpenTTD experience, with a year consisting of 12 months, and each month having 28-31 days.{}{}In Wallclock-based time, cargo production and financials are instead based on one-minute increments, which is about as long as a 30 day month takes in Calendar-based mode. These are grouped into 12-minute periods, equivalent to a year in Calendar-based mode.{}{}In either mode there is always a classic calendar, which is used for introduction dates of vehicles, houses, and other infrastructure
 ###length 2

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1508,6 +1508,9 @@ STR_CONFIG_SETTING_WARN_OLD_VEHICLE_HELPTEXT                    :When enabled, a
 STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES                        :Vehicles never expire: {STRING2}
 STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES_HELPTEXT               :When enabled, all vehicle models remain available forever after their introduction
 
+STR_CONFIG_SETTING_OFFER_VEHICLE_PREVIEW                        :Show vehicle previews: {STRING2}
+STR_CONFIG_SETTING_OFFER_VEHICLE_PREVIEW_HELPTEXT               :When enabled, the top performing company is sometimes offered a 1 year exclusive preview of a vehicle
+
 STR_CONFIG_SETTING_TIMEKEEPING_UNITS                            :Timekeeping: {STRING2}
 STR_CONFIG_SETTING_TIMEKEEPING_UNITS_HELPTEXT                   :Select the timekeeping units of the game. This cannot be changed later.{}{}Calendar-based is the classic OpenTTD experience, with a year consisting of 12 months, and each month having 28-31 days.{}{}In Wallclock-based time, cargo production and financials are instead based on one-minute increments, which is about as long as a 30 day month takes in Calendar-based mode. These are grouped into 12-minute periods, equivalent to a year in Calendar-based mode.{}{}In either mode there is always a classic calendar, which is used for introduction dates of vehicles, houses, and other infrastructure
 ###length 2

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -821,6 +821,7 @@ SettingsContainer &GetSettingsTree()
 			limitations->Add(new SettingEntry("station.never_expire_airports"));
 			limitations->Add(new SettingEntry("vehicle.never_expire_vehicles"));
 			limitations->Add(new SettingEntry("vehicle.offer_vehicle_preview"));
+			limitations->Add(new SettingEntry("vehicle.vehicle_intro_randomisation"));
 			limitations->Add(new SettingEntry("vehicle.max_trains"));
 			limitations->Add(new SettingEntry("vehicle.max_roadveh"));
 			limitations->Add(new SettingEntry("vehicle.max_aircraft"));

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -820,6 +820,7 @@ SettingsContainer &GetSettingsTree()
 			limitations->Add(new SettingEntry("construction.max_tunnel_length"));
 			limitations->Add(new SettingEntry("station.never_expire_airports"));
 			limitations->Add(new SettingEntry("vehicle.never_expire_vehicles"));
+			limitations->Add(new SettingEntry("vehicle.offer_vehicle_preview"));
 			limitations->Add(new SettingEntry("vehicle.max_trains"));
 			limitations->Add(new SettingEntry("vehicle.max_roadveh"));
 			limitations->Add(new SettingEntry("vehicle.max_aircraft"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -512,6 +512,7 @@ struct VehicleSettings {
 	bool   dynamic_engines;                  ///< enable dynamic allocation of engine data
 	bool   never_expire_vehicles;            ///< never expire vehicles
 	bool   offer_vehicle_preview;            ///< offer vehicle preview to companies
+	bool   vehicle_intro_randomisation;      ///< randomise the introduction dates of vehicles
 	uint8_t extend_vehicle_life;              ///< extend vehicle life by this many years
 	uint8_t road_side;                        ///< the side of the road vehicles drive on
 	uint8_t  plane_crashes;                    ///< number of plane crashes, 0 = none, 1 = reduced, 2 = normal

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -511,6 +511,7 @@ struct VehicleSettings {
 	uint8_t  freight_trains;                   ///< value to multiply the weight of cargo by
 	bool   dynamic_engines;                  ///< enable dynamic allocation of engine data
 	bool   never_expire_vehicles;            ///< never expire vehicles
+	bool   offer_vehicle_preview;            ///< offer vehicle preview to companies
 	uint8_t extend_vehicle_life;              ///< extend vehicle life by this many years
 	uint8_t road_side;                        ///< the side of the road vehicles drive on
 	uint8_t  plane_crashes;                    ///< number of plane crashes, 0 = none, 1 = reduced, 2 = normal

--- a/src/table/settings/game_settings.ini
+++ b/src/table/settings/game_settings.ini
@@ -241,6 +241,13 @@ def      = false
 str      = STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES
 strhelp  = STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES_HELPTEXT
 
+[SDT_BOOL]
+var      = vehicle.offer_vehicle_preview
+flags    = SettingFlag::NoNetwork
+def      = true
+str      = STR_CONFIG_SETTING_OFFER_VEHICLE_PREVIEW
+strhelp  = STR_CONFIG_SETTING_OFFER_VEHICLE_PREVIEW_HELPTEXT
+
 [SDT_VAR]
 var      = vehicle.max_trains
 type     = SLE_UINT16

--- a/src/table/settings/game_settings.ini
+++ b/src/table/settings/game_settings.ini
@@ -248,6 +248,13 @@ def      = true
 str      = STR_CONFIG_SETTING_OFFER_VEHICLE_PREVIEW
 strhelp  = STR_CONFIG_SETTING_OFFER_VEHICLE_PREVIEW_HELPTEXT
 
+[SDT_BOOL]
+var      = vehicle.vehicle_intro_randomisation
+flags    = SettingFlag::NoNetwork
+def      = true
+str      = STR_CONFIG_SETTING_VEHICLE_INTRO_RANDOMISATION
+strhelp  = STR_CONFIG_SETTING_VEHICLE_INTRO_RANDOMISATION_HELPTEXT
+
 [SDT_VAR]
 var      = vehicle.max_trains
 type     = SLE_UINT16

--- a/src/table/settings/game_settings.ini
+++ b/src/table/settings/game_settings.ini
@@ -243,14 +243,12 @@ strhelp  = STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES_HELPTEXT
 
 [SDT_BOOL]
 var      = vehicle.offer_vehicle_preview
-flags    = SettingFlag::NoNetwork
 def      = true
 str      = STR_CONFIG_SETTING_OFFER_VEHICLE_PREVIEW
 strhelp  = STR_CONFIG_SETTING_OFFER_VEHICLE_PREVIEW_HELPTEXT
 
 [SDT_BOOL]
 var      = vehicle.vehicle_intro_randomisation
-flags    = SettingFlag::NoNetwork
 def      = true
 str      = STR_CONFIG_SETTING_VEHICLE_INTRO_RANDOMISATION
 strhelp  = STR_CONFIG_SETTING_VEHICLE_INTRO_RANDOMISATION_HELPTEXT


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

The default behaviours for vehicle introduction has a large amount of randomisation with exclusive vehicle previews and a random range of 0 - 511 days being added to its base introduction date.
This pull request gives players the choice to turn these 2 features off if they are not desired.

![image](https://github.com/user-attachments/assets/bf05edf8-d40e-49fd-a284-852770955b53)


## Description

The vehicle preview offer setting specifically disables the daily check to offer an exclusive engine preview to the highest ranking company, and then does not add the 1 year exclusivity period to all engines.

The vehicle introduction randomisation setting just adds a bypass to not add 0 - 511 days to an engine's base introduction date.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

Through some testing, I needed to skip adding "CalendarTime::DAYS_IN_YEAR" in the monthly loop, but this may not be the best way to do so.
Also, this hasn't been tested too thoroughly, especially each setting disabled individually.
I have flagged both settings as NoNetwork, mostly because I don't know how it would act changing midgame, but I think this is correct.
If there is any better or more accurate wording for the setting name/descriptions, then feel free to change.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
