### PR TITLE
Codechange: Unify naming of "SnowOrDesert" functions

### DIFF
--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -357,7 +357,7 @@ uint32_t GetTerrainType(TileIndex tile, TileContext context)
 				case MP_ROAD:
 					/* During map generation the snowstate may not be valid yet, as the tileloop may not have run yet. */
 					if (_generating_world) goto genworld; // we do not care about foundations here
-					has_snow = IsOnSnow(tile);
+					has_snow = IsOnSnowOrDesert(tile);
 					break;
 
 				case MP_TREES: {

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1356,7 +1356,7 @@ static uint GetRoadSpriteOffset(Slope slope, RoadBits bits)
  * @param roadside What sort of road this is
  * @return True if snow/desert road sprites should be used.
  */
-static bool DrawRoadAsSnowDesert(bool snow_or_desert, Roadside roadside)
+static bool DrawRoadAsSnowOrDesert(bool snow_or_desert, Roadside roadside)
 {
 	return (snow_or_desert &&
 			!(_settings_game.game_creation.landscape == LandscapeType::Tropic && HasGrfMiscBit(GrfMiscBit::DesertPavedRoads) &&
@@ -1556,7 +1556,7 @@ static SpriteID GetRoadGroundSprite(const TileInfo *ti, Roadside roadside, const
 {
 	/* Draw bare ground sprite if no road or road uses overlay system. */
 	if (rti == nullptr || rti->UsesOverlay()) {
-		if (DrawRoadAsSnowDesert(snow_or_desert, roadside)) {
+		if (DrawRoadAsSnowOrDesert(snow_or_desert, roadside)) {
 			return SPR_FLAT_SNOW_DESERT_TILE + SlopeToSpriteOffset(ti->tileh);
 		}
 
@@ -1571,7 +1571,7 @@ static SpriteID GetRoadGroundSprite(const TileInfo *ti, Roadside roadside, const
 
 	/* Draw original road base sprite */
 	SpriteID image = SPR_ROAD_Y + offset;
-	if (DrawRoadAsSnowDesert(snow_or_desert, roadside)) {
+	if (DrawRoadAsSnowOrDesert(snow_or_desert, roadside)) {
 		image += 19;
 	} else {
 		switch (roadside) {
@@ -1720,7 +1720,7 @@ static void DrawTile_Road(TileInfo *ti)
 				SpriteID image = SPR_ROAD_Y + axis;
 
 				Roadside roadside = GetRoadside(ti->tile);
-				if (DrawRoadAsSnowDesert(IsOnSnow(ti->tile), roadside)) {
+				if (DrawRoadAsSnowOrDesert(IsOnSnow(ti->tile), roadside)) {
 					image += 19;
 				} else {
 					switch (roadside) {
@@ -1736,7 +1736,7 @@ static void DrawTile_Road(TileInfo *ti)
 				if (IsCrossingBarred(ti->tile)) image += 2;
 
 				Roadside roadside = GetRoadside(ti->tile);
-				if (DrawRoadAsSnowDesert(IsOnSnow(ti->tile), roadside)) {
+				if (DrawRoadAsSnowOrDesert(IsOnSnow(ti->tile), roadside)) {
 					image += 8;
 				} else {
 					switch (roadside) {

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1628,7 +1628,7 @@ static void DrawRoadBits(TileInfo *ti)
 		/* DrawFoundation() modifies ti. */
 	}
 
-	DrawRoadGroundSprites(ti, road, tram, road_rti, tram_rti, GetRoadside(ti->tile), IsOnSnow(ti->tile));
+	DrawRoadGroundSprites(ti, road, tram, road_rti, tram_rti, GetRoadside(ti->tile), IsOnSnowOrDesert(ti->tile));
 
 	/* Draw one way */
 	if (road_rti != nullptr) {
@@ -1720,7 +1720,7 @@ static void DrawTile_Road(TileInfo *ti)
 				SpriteID image = SPR_ROAD_Y + axis;
 
 				Roadside roadside = GetRoadside(ti->tile);
-				if (DrawRoadAsSnowOrDesert(IsOnSnow(ti->tile), roadside)) {
+				if (DrawRoadAsSnowOrDesert(IsOnSnowOrDesert(ti->tile), roadside)) {
 					image += 19;
 				} else {
 					switch (roadside) {
@@ -1736,7 +1736,7 @@ static void DrawTile_Road(TileInfo *ti)
 				if (IsCrossingBarred(ti->tile)) image += 2;
 
 				Roadside roadside = GetRoadside(ti->tile);
-				if (DrawRoadAsSnowOrDesert(IsOnSnow(ti->tile), roadside)) {
+				if (DrawRoadAsSnowOrDesert(IsOnSnowOrDesert(ti->tile), roadside)) {
 					image += 8;
 				} else {
 					switch (roadside) {
@@ -1975,16 +1975,16 @@ static void TileLoop_Road(TileIndex tile)
 		case LandscapeType::Arctic: {
 			/* Roads on flat foundations use the snow level of the height they are elevated to. All others use the snow level of their minimum height. */
 			int tile_z = (std::get<Slope>(GetFoundationSlope(tile)) == SLOPE_FLAT) ? GetTileMaxZ(tile) : GetTileZ(tile);
-			if (IsOnSnow(tile) != (tile_z > GetSnowLine())) {
-				ToggleSnow(tile);
+			if (IsOnSnowOrDesert(tile) != (tile_z > GetSnowLine())) {
+				ToggleSnowOrDesert(tile);
 				MarkTileDirtyByTile(tile);
 			}
 			break;
 		}
 
 		case LandscapeType::Tropic:
-			if (GetTropicZone(tile) == TROPICZONE_DESERT && !IsOnDesert(tile)) {
-				ToggleDesert(tile);
+			if (GetTropicZone(tile) == TROPICZONE_DESERT && !IsOnSnowOrDesert(tile)) {
+				ToggleSnowOrDesert(tile);
 				MarkTileDirtyByTile(tile);
 			}
 			break;

--- a/src/road_map.h
+++ b/src/road_map.h
@@ -433,25 +433,21 @@ inline void BarCrossing(Tile t)
 	SetCrossingBarred(t, true);
 }
 
-/** Check if a road tile has snow/desert. */
-#define IsOnDesert IsOnSnow
 /**
  * Check if a road tile has snow/desert.
  * @param t The tile to query.
  * @return True if the tile has snow/desert.
  */
-inline bool IsOnSnow(Tile t)
+inline bool IsOnSnowOrDesert(Tile t)
 {
 	return HasBit(t.m7(), 5);
 }
 
-/** Toggle the snow/desert state of a road tile. */
-#define ToggleDesert ToggleSnow
 /**
  * Toggle the snow/desert state of a road tile.
  * @param t The tile to change.
  */
-inline void ToggleSnow(Tile t)
+inline void ToggleSnowOrDesert(Tile t)
 {
 	ToggleBit(t.m7(), 5);
 }


### PR DESCRIPTION
## Motivation / Problem

There are a number of functions related to snow and desert:
* `IsRoadWaypointOnSnowOrDesert`
* `ToggleRoadWaypointOnSnowOrDesert`
* `HasTunnelBridgeSnowOrDesert`
* `SetTunnelBridgeSnowOrDesert`

Some functions differ from this:
* `DrawRoadAsSnowDesert`
* `IsOnDesert` is a macro-alias for `IsOnSnow`
* `ToggleDesert` is a macro-alias for `ToggleSnow`

## Description

* Rename `DrawRoadAsSnowDesert` > `DrawRoadAsSnowOrDesert`
* Remove the macro-aliases and rename:
    * `IsOnSnow`/`IsOnDesert` > `IsOnSnowOrDesert`
    * `ToggleSnow`/`ToggleDesert` > `ToggleSnowOrDesert`

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
