### PR TITLE
Codechange: Turn bit-stuffed FiosType enum into a struct.

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -462,7 +462,7 @@ DEF_CONSOLE_CMD(ConLoad)
 	_console_file_list_savegame.ValidateFileList();
 	const FiosItem *item = _console_file_list_savegame.FindItem(file);
 	if (item != nullptr) {
-		if (GetAbstractFileType(item->type) == FT_SAVEGAME) {
+		if (item->type.abstract == FT_SAVEGAME) {
 			_switch_mode = SM_LOAD_GAME;
 			_file_to_saveload.Set(*item);
 		} else {
@@ -488,7 +488,7 @@ DEF_CONSOLE_CMD(ConLoadScenario)
 	_console_file_list_scenario.ValidateFileList();
 	const FiosItem *item = _console_file_list_scenario.FindItem(file);
 	if (item != nullptr) {
-		if (GetAbstractFileType(item->type) == FT_SCENARIO) {
+		if (item->type.abstract == FT_SCENARIO) {
 			_switch_mode = SM_LOAD_GAME;
 			_file_to_saveload.Set(*item);
 		} else {
@@ -514,7 +514,7 @@ DEF_CONSOLE_CMD(ConLoadHeightmap)
 	_console_file_list_heightmap.ValidateFileList();
 	const FiosItem *item = _console_file_list_heightmap.FindItem(file);
 	if (item != nullptr) {
-		if (GetAbstractFileType(item->type) == FT_HEIGHTMAP) {
+		if (item->type.abstract == FT_HEIGHTMAP) {
 			_switch_mode = SM_START_HEIGHTMAP;
 			_file_to_saveload.Set(*item);
 		} else {
@@ -614,8 +614,10 @@ DEF_CONSOLE_CMD(ConChangeDirectory)
 	_console_file_list_savegame.ValidateFileList(true);
 	const FiosItem *item = _console_file_list_savegame.FindItem(file);
 	if (item != nullptr) {
-		switch (item->type) {
-			case FIOS_TYPE_DIR: case FIOS_TYPE_DRIVE: case FIOS_TYPE_PARENT:
+		switch (item->type.detailed) {
+			case DFT_FIOS_DIR:
+			case DFT_FIOS_DRIVE:
+			case DFT_FIOS_PARENT:
 				FiosBrowseTo(item);
 				break;
 			default: IConsolePrint(CC_ERROR, "{}: Not a directory.", file);
@@ -1307,7 +1309,7 @@ DEF_CONSOLE_CMD(ConReload)
 		return true;
 	}
 
-	if (_file_to_saveload.abstract_ftype == FT_NONE || _file_to_saveload.abstract_ftype == FT_INVALID) {
+	if (_file_to_saveload.ftype.abstract == FT_NONE || _file_to_saveload.ftype.abstract == FT_INVALID) {
 		IConsolePrint(CC_ERROR, "No game loaded to reload.");
 		return true;
 	}

--- a/src/fileio_type.h
+++ b/src/fileio_type.h
@@ -21,8 +21,6 @@ enum AbstractFileType : uint8_t {
 	FT_TOWN_DATA, ///< town data file
 
 	FT_INVALID = 7, ///< Invalid or unknown file type.
-	FT_NUMBITS = 3, ///< Number of bits required for storing a #AbstractFileType value.
-	FT_MASK = (1 << FT_NUMBITS) - 1, ///< Bitmask for extracting an abstract file type.
 };
 
 /** Kinds of files in each #AbstractFileType. */
@@ -59,55 +57,29 @@ enum SaveLoadOperation : uint8_t {
 };
 
 /**
- * Construct an enum value for #FiosType as a combination of an abstract and a detailed file type.
- * @param abstract Abstract file type (one of #AbstractFileType).
- * @param detailed Detailed file type (one of #DetailedFileType).
- */
-#define MAKE_FIOS_TYPE(abstract, detailed) ((abstract) | ((detailed) << FT_NUMBITS))
-
-/**
  * Elements of a file system that are recognized.
- * Values are a combination of #AbstractFileType and #DetailedFileType.
- * @see GetAbstractFileType GetDetailedFileType
  */
-enum FiosType : uint16_t {
-	FIOS_TYPE_DRIVE  = MAKE_FIOS_TYPE(FT_NONE, DFT_FIOS_DRIVE),
-	FIOS_TYPE_PARENT = MAKE_FIOS_TYPE(FT_NONE, DFT_FIOS_PARENT),
-	FIOS_TYPE_DIR    = MAKE_FIOS_TYPE(FT_NONE, DFT_FIOS_DIR),
-	FIOS_TYPE_DIRECT = MAKE_FIOS_TYPE(FT_NONE, DFT_FIOS_DIRECT),
+struct FiosType {
+	AbstractFileType abstract; ///< Abstract file type.
+	DetailedFileType detailed; ///< Detailed file type.
 
-	FIOS_TYPE_FILE         = MAKE_FIOS_TYPE(FT_SAVEGAME, DFT_GAME_FILE),
-	FIOS_TYPE_OLDFILE      = MAKE_FIOS_TYPE(FT_SAVEGAME, DFT_OLD_GAME_FILE),
-	FIOS_TYPE_SCENARIO     = MAKE_FIOS_TYPE(FT_SCENARIO, DFT_GAME_FILE),
-	FIOS_TYPE_OLD_SCENARIO = MAKE_FIOS_TYPE(FT_SCENARIO, DFT_OLD_GAME_FILE),
-	FIOS_TYPE_PNG          = MAKE_FIOS_TYPE(FT_HEIGHTMAP, DFT_HEIGHTMAP_PNG),
-	FIOS_TYPE_BMP          = MAKE_FIOS_TYPE(FT_HEIGHTMAP, DFT_HEIGHTMAP_BMP),
-	FIOS_TYPE_JSON         = MAKE_FIOS_TYPE(FT_TOWN_DATA, DFT_TOWN_DATA_JSON),
-
-	FIOS_TYPE_INVALID = MAKE_FIOS_TYPE(FT_INVALID, DFT_INVALID),
+	constexpr bool operator==(const FiosType &) const noexcept = default;
 };
 
-#undef MAKE_FIOS_TYPE
+constexpr FiosType FIOS_TYPE_DRIVE{FT_NONE, DFT_FIOS_DRIVE};
+constexpr FiosType FIOS_TYPE_PARENT{FT_NONE, DFT_FIOS_PARENT};
+constexpr FiosType FIOS_TYPE_DIR{FT_NONE, DFT_FIOS_DIR};
+constexpr FiosType FIOS_TYPE_DIRECT{FT_NONE, DFT_FIOS_DIRECT};
 
-/**
- * Extract the abstract file type from a #FiosType.
- * @param fios_type Type to query.
- * @return The Abstract file type of the \a fios_type.
- */
-inline AbstractFileType GetAbstractFileType(FiosType fios_type)
-{
-	return static_cast<AbstractFileType>(static_cast<uint>(fios_type) & FT_MASK);
-}
+constexpr FiosType FIOS_TYPE_FILE{FT_SAVEGAME, DFT_GAME_FILE};
+constexpr FiosType FIOS_TYPE_OLDFILE{FT_SAVEGAME, DFT_OLD_GAME_FILE};
+constexpr FiosType FIOS_TYPE_SCENARIO{FT_SCENARIO, DFT_GAME_FILE};
+constexpr FiosType FIOS_TYPE_OLD_SCENARIO{FT_SCENARIO, DFT_OLD_GAME_FILE};
+constexpr FiosType FIOS_TYPE_PNG{FT_HEIGHTMAP, DFT_HEIGHTMAP_PNG};
+constexpr FiosType FIOS_TYPE_BMP{FT_HEIGHTMAP, DFT_HEIGHTMAP_BMP};
+constexpr FiosType FIOS_TYPE_JSON{FT_TOWN_DATA, DFT_TOWN_DATA_JSON};
 
-/**
- * Extract the detailed file type from a #FiosType.
- * @param fios_type Type to query.
- * @return The Detailed file type of the \a fios_type.
- */
-inline DetailedFileType GetDetailedFileType(FiosType fios_type)
-{
-	return static_cast<DetailedFileType>(fios_type >> FT_NUMBITS);
-}
+constexpr FiosType FIOS_TYPE_INVALID{FT_INVALID, DFT_INVALID};
 
 /**
  * The different kinds of subdirectories OpenTTD uses

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -142,18 +142,18 @@ std::string FiosGetCurrentPath()
  */
 bool FiosBrowseTo(const FiosItem *item)
 {
-	switch (item->type) {
-		case FIOS_TYPE_DRIVE:
+	switch (item->type.detailed) {
+		case DFT_FIOS_DRIVE:
 #if defined(_WIN32)
 			assert(_fios_path != nullptr);
 			*_fios_path = std::string{ item->title, 0, 1 } + ":" PATHSEP;
 #endif
 			break;
 
-		case FIOS_TYPE_INVALID:
+		case DFT_INVALID:
 			break;
 
-		case FIOS_TYPE_PARENT: {
+		case DFT_FIOS_PARENT: {
 			assert(_fios_path != nullptr);
 			auto s = _fios_path->find_last_of(PATHSEPCHAR);
 			if (s != std::string::npos && s != 0) {
@@ -167,24 +167,18 @@ bool FiosBrowseTo(const FiosItem *item)
 			break;
 		}
 
-		case FIOS_TYPE_DIR:
+		case DFT_FIOS_DIR:
 			assert(_fios_path != nullptr);
 			*_fios_path += item->name;
 			*_fios_path += PATHSEP;
 			break;
 
-		case FIOS_TYPE_DIRECT:
+		case DFT_FIOS_DIRECT:
 			assert(_fios_path != nullptr);
 			*_fios_path = item->name;
 			break;
 
-		case FIOS_TYPE_FILE:
-		case FIOS_TYPE_OLDFILE:
-		case FIOS_TYPE_SCENARIO:
-		case FIOS_TYPE_OLD_SCENARIO:
-		case FIOS_TYPE_PNG:
-		case FIOS_TYPE_BMP:
-		case FIOS_TYPE_JSON:
+		default:
 			return false;
 	}
 

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -309,10 +309,10 @@ static void SortSaveGameList(FileList &file_list)
 	 * Only sort savegames/scenarios, not directories
 	 */
 	for (const auto &item : file_list) {
-		switch (item.type) {
-			case FIOS_TYPE_DIR:    sort_start++; break;
-			case FIOS_TYPE_PARENT: sort_start++; break;
-			case FIOS_TYPE_DRIVE:  sort_end++;   break;
+		switch (item.type.detailed) {
+			case DFT_FIOS_DIR:    sort_start++; break;
+			case DFT_FIOS_PARENT: sort_start++; break;
+			case DFT_FIOS_DRIVE:  sort_end++;   break;
 			default: break;
 		}
 	}
@@ -514,7 +514,7 @@ public:
 					} else if (item == this->highlighted) {
 						GfxFillRect(br.left, tr.top, br.right, tr.bottom, PC_VERY_DARK_BLUE);
 					}
-					DrawString(tr, item->title, _fios_colours[GetDetailedFileType(item->type)]);
+					DrawString(tr, item->title, _fios_colours[item->type.detailed]);
 					tr = tr.Translate(0, this->resize.step_height);
 				}
 				break;
@@ -719,7 +719,7 @@ public:
 						this->selected = file;
 						_load_check_data.Clear();
 
-						if (GetDetailedFileType(file->type) == DFT_GAME_FILE) {
+						if (file->type.detailed == DFT_GAME_FILE) {
 							/* Other detailed file types cannot be checked before. */
 							SaveOrLoad(file->name, SLO_CHECK, DFT_GAME_FILE, NO_DIRECTORY, false);
 						}

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -997,7 +997,7 @@ static void _ShowGenerateLandscape(GenerateLandscapeWindowMode mode)
 
 	if (mode == GLWM_HEIGHTMAP) {
 		/* If the function returns negative, it means there was a problem loading the heightmap */
-		if (!GetHeightmapDimensions(_file_to_saveload.detail_ftype, _file_to_saveload.name.c_str(), &x, &y)) return;
+		if (!GetHeightmapDimensions(_file_to_saveload.ftype.detailed, _file_to_saveload.name.c_str(), &x, &y)) return;
 	}
 
 	WindowDesc &desc = (mode == GLWM_HEIGHTMAP) ? _heightmap_load_desc : _generate_landscape_desc;

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1543,7 +1543,7 @@ bool GenerateLandscape(uint8_t mode)
 
 	if (mode == GWM_HEIGHTMAP) {
 		SetGeneratingWorldProgress(GWP_LANDSCAPE, steps + GLS_HEIGHTMAP);
-		if (!LoadHeightmap(_file_to_saveload.detail_ftype, _file_to_saveload.name.c_str())) {
+		if (!LoadHeightmap(_file_to_saveload.ftype.detailed, _file_to_saveload.name.c_str())) {
 			return false;
 		}
 		IncreaseGeneratingWorldProgress(GWP_LANDSCAPE);

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -823,7 +823,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_MAP_DONE(Packet
 	ClearErrorMessages();
 
 	/* Set the abstract filetype. This is read during savegame load. */
-	_file_to_saveload.SetMode(SLO_LOAD, FT_SAVEGAME, DFT_GAME_FILE);
+	_file_to_saveload.SetMode(FIOS_TYPE_FILE, SLO_LOAD);
 
 	bool load_success = SafeLoad({}, SLO_LOAD, DFT_GAME_FILE, GM_NORMAL, NO_DIRECTORY, this->savegame);
 	this->savegame = nullptr;

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1814,7 +1814,7 @@ void NetworkServer_Tick(bool send_frame)
 static void NetworkRestartMap()
 {
 	_settings_newgame.game_creation.generation_seed = GENERATE_NEW_SEED;
-	switch (_file_to_saveload.abstract_ftype) {
+	switch (_file_to_saveload.ftype.abstract) {
 		case FT_SAVEGAME:
 		case FT_SCENARIO:
 			_switch_mode = SM_LOAD_GAME;

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -256,7 +256,7 @@ static void InitializeWindowsAndCaches()
 		/* For each company, verify (while loading a scenario) that the inauguration date is the current year and set it
 		 * accordingly if it is not the case.  No need to set it on companies that are not been used already,
 		 * thus the MIN_YEAR (which is really nothing more than Zero, initialized value) test */
-		if (_file_to_saveload.abstract_ftype == FT_SCENARIO && c->inaugurated_year != EconomyTime::MIN_YEAR) {
+		if (_file_to_saveload.ftype.abstract == FT_SCENARIO && c->inaugurated_year != EconomyTime::MIN_YEAR) {
 			c->inaugurated_year = TimerGameEconomy::year;
 		}
 	}

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -3371,32 +3371,20 @@ std::string GenerateDefaultSaveName()
 }
 
 /**
- * Set the mode and file type of the file to save or load based on the type of file entry at the file system.
- * @param ft Type of file entry of the file system.
- */
-void FileToSaveLoad::SetMode(FiosType ft)
-{
-	this->SetMode(SLO_LOAD, GetAbstractFileType(ft), GetDetailedFileType(ft));
-}
-
-/**
  * Set the mode and file type of the file to save or load.
+ * @param ft File type.
  * @param fop File operation being performed.
- * @param aft Abstract file type.
- * @param dft Detailed file type.
  */
-void FileToSaveLoad::SetMode(SaveLoadOperation fop, AbstractFileType aft, DetailedFileType dft)
+void FileToSaveLoad::SetMode(const FiosType &ft, SaveLoadOperation fop)
 {
-	if (aft == FT_INVALID || aft == FT_NONE) {
+	if (ft.abstract == FT_INVALID || ft.abstract == FT_NONE) {
 		this->file_op = SLO_INVALID;
-		this->detail_ftype = DFT_INVALID;
-		this->abstract_ftype = FT_INVALID;
+		this->ftype = FIOS_TYPE_INVALID;
 		return;
 	}
 
 	this->file_op = fop;
-	this->detail_ftype = dft;
-	this->abstract_ftype = aft;
+	this->ftype = ft;
 }
 
 /**

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -414,13 +414,11 @@ enum SaveOrLoadResult : uint8_t {
 /** Deals with the type of the savegame, independent of extension */
 struct FileToSaveLoad {
 	SaveLoadOperation file_op;       ///< File operation to perform.
-	DetailedFileType detail_ftype;   ///< Concrete file type (PNG, BMP, old save, etc).
-	AbstractFileType abstract_ftype; ///< Abstract type of file (scenario, heightmap, etc).
+	FiosType ftype;                  ///< File type.
 	std::string name;                ///< Name of the file.
 	std::string title;               ///< Internal name of the game.
 
-	void SetMode(FiosType ft);
-	void SetMode(SaveLoadOperation fop, AbstractFileType aft, DetailedFileType dft);
+	void SetMode(const FiosType &ft, SaveLoadOperation fop = SLO_LOAD);
 	void Set(const FiosItem &item);
 };
 

--- a/src/saveload/signs_sl.cpp
+++ b/src/saveload/signs_sl.cpp
@@ -62,7 +62,7 @@ struct SIGNChunkHandler : ChunkHandler {
 			}
 
 			/* Signs placed in scenario editor shall now be OWNER_DEITY */
-			if (IsSavegameVersionBefore(SLV_171) && si->owner == OWNER_NONE && _file_to_saveload.abstract_ftype == FT_SCENARIO) {
+			if (IsSavegameVersionBefore(SLV_171) && si->owner == OWNER_NONE && _file_to_saveload.ftype.abstract == FT_SCENARIO) {
 				si->owner = OWNER_DEITY;
 			}
 		}


### PR DESCRIPTION
## Motivation / Problem

`FiosType` is an enum, which essentially is a pair of `AbstractFileType` and `DetailedFileType`.

This was probably done to be able to use it in `switch`. However, all existing switches essentially only switch on either `AbstractFileType` or `DetailedFileType`.

## Description

Replace the enum with a struct.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
