### PR TITLE
Codechange: Remove useless macros

### DIFF
--- a/src/blitter/32bpp_sse_type.h
+++ b/src/blitter/32bpp_sse_type.h
@@ -31,15 +31,7 @@
 #define MARGIN_NORMAL_THRESHOLD (zoom == ZOOM_LVL_OUT_8X ? 8 : 4) ///< Minimum width to use margins with BlitterMode::Normal.
 #define MARGIN_REMAP_THRESHOLD 4 ///< Minimum width to use margins with BlitterMode::ColourRemap.
 
-#undef ALIGN
-
-#ifdef _MSC_VER
-	#define ALIGN(n) __declspec(align(n))
-#else
-	#define ALIGN(n) __attribute__ ((aligned (n)))
-#endif
-
-typedef union ALIGN(16) um128i {
+typedef union alignas(16) um128i {
 	__m128i m128i;
 	uint8_t m128i_u8[16];
 	uint16_t m128i_u16[8];

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -105,11 +105,6 @@ static ConsoleFileList _console_file_list_savegame{FT_SAVEGAME, true}; ///< File
 static ConsoleFileList _console_file_list_scenario{FT_SCENARIO, false}; ///< File storage cache for scenarios.
 static ConsoleFileList _console_file_list_heightmap{FT_HEIGHTMAP, false}; ///< File storage cache for heightmaps.
 
-/* console command defines */
-#define DEF_CONSOLE_CMD(function) static bool function([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
-#define DEF_CONSOLE_HOOK(function) static ConsoleHookResult function(bool echo)
-
-
 /****************
  * command hooks
  ****************/
@@ -131,7 +126,7 @@ static inline bool NetworkAvailable(bool echo)
  * Check whether we are a server.
  * @return Are we a server? True when yes, false otherwise.
  */
-DEF_CONSOLE_HOOK(ConHookServerOnly)
+static ConsoleHookResult ConHookServerOnly(bool echo)
 {
 	if (!NetworkAvailable(echo)) return CHR_DISALLOW;
 
@@ -146,7 +141,7 @@ DEF_CONSOLE_HOOK(ConHookServerOnly)
  * Check whether we are a client in a network game.
  * @return Are we a client in a network game? True when yes, false otherwise.
  */
-DEF_CONSOLE_HOOK(ConHookClientOnly)
+static ConsoleHookResult ConHookClientOnly(bool echo)
 {
 	if (!NetworkAvailable(echo)) return CHR_DISALLOW;
 
@@ -161,7 +156,7 @@ DEF_CONSOLE_HOOK(ConHookClientOnly)
  * Check whether we are in a multiplayer game.
  * @return True when we are client or server in a network game.
  */
-DEF_CONSOLE_HOOK(ConHookNeedNetwork)
+static ConsoleHookResult ConHookNeedNetwork(bool echo)
 {
 	if (!NetworkAvailable(echo)) return CHR_DISALLOW;
 
@@ -176,7 +171,7 @@ DEF_CONSOLE_HOOK(ConHookNeedNetwork)
  * Check whether we are in a multiplayer game and are playing, i.e. we are not the dedicated server.
  * @return Are we a client or non-dedicated server in a network game? True when yes, false otherwise.
  */
-DEF_CONSOLE_HOOK(ConHookNeedNonDedicatedNetwork)
+static ConsoleHookResult ConHookNeedNonDedicatedNetwork(bool echo)
 {
 	if (!NetworkAvailable(echo)) return CHR_DISALLOW;
 
@@ -191,7 +186,7 @@ DEF_CONSOLE_HOOK(ConHookNeedNonDedicatedNetwork)
  * Check whether we are in singleplayer mode.
  * @return True when no network is active.
  */
-DEF_CONSOLE_HOOK(ConHookNoNetwork)
+static ConsoleHookResult ConHookNoNetwork(bool echo)
 {
 	if (_networking) {
 		if (echo) IConsolePrint(CC_ERROR, "This command is forbidden in multiplayer.");
@@ -204,7 +199,7 @@ DEF_CONSOLE_HOOK(ConHookNoNetwork)
  * Check if are either in singleplayer or a server.
  * @return True iff we are either in singleplayer or a server.
  */
-DEF_CONSOLE_HOOK(ConHookServerOrNoNetwork)
+static ConsoleHookResult ConHookServerOrNoNetwork(bool echo)
 {
 	if (_networking && !_network_server) {
 		if (echo) IConsolePrint(CC_ERROR, "This command is only available to a network server.");
@@ -213,7 +208,7 @@ DEF_CONSOLE_HOOK(ConHookServerOrNoNetwork)
 	return CHR_ALLOW;
 }
 
-DEF_CONSOLE_HOOK(ConHookNewGRFDeveloperTool)
+static ConsoleHookResult ConHookNewGRFDeveloperTool(bool echo)
 {
 	if (_settings_client.gui.newgrf_developer_tools) {
 		if (_game_mode == GM_MENU) {
@@ -229,7 +224,7 @@ DEF_CONSOLE_HOOK(ConHookNewGRFDeveloperTool)
  * Reset status of all engines.
  * @return Will always succeed.
  */
-DEF_CONSOLE_CMD(ConResetEngines)
+static bool ConResetEngines([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Reset status data of all engines. This might solve some issues with 'lost' engines. Usage: 'resetengines'.");
@@ -245,7 +240,7 @@ DEF_CONSOLE_CMD(ConResetEngines)
  * @return Will always return true.
  * @note Resetting the pool only succeeds when there are no vehicles ingame.
  */
-DEF_CONSOLE_CMD(ConResetEnginePool)
+static bool ConResetEnginePool([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Reset NewGRF allocations of engine slots. This will remove invalid engine definitions, and might make default engines available again.");
@@ -271,7 +266,7 @@ DEF_CONSOLE_CMD(ConResetEnginePool)
  * param tile number.
  * @return True when the tile is reset or the help on usage was printed (0 or two parameters).
  */
-DEF_CONSOLE_CMD(ConResetTile)
+static bool ConResetTile([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Reset a tile to bare land. Usage: 'resettile <tile>'.");
@@ -296,7 +291,7 @@ DEF_CONSOLE_CMD(ConResetTile)
  * param level As defined by ZoomLevel and as limited by zoom_min/zoom_max from GUISettings.
  * @return True when either console help was shown or a proper amount of parameters given.
  */
-DEF_CONSOLE_CMD(ConZoomToLevel)
+static bool ConZoomToLevel([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	switch (argc) {
 		case 0:
@@ -355,7 +350,7 @@ DEF_CONSOLE_CMD(ConZoomToLevel)
  *       and y coordinates.
  * @return True when either console help was shown or a proper amount of parameters given.
  */
-DEF_CONSOLE_CMD(ConScrollToTile)
+static bool ConScrollToTile([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Center the screen on a given tile.");
@@ -409,7 +404,7 @@ DEF_CONSOLE_CMD(ConScrollToTile)
  * param filename the filename to save the map to.
  * @return True when help was displayed or the file attempted to be saved.
  */
-DEF_CONSOLE_CMD(ConSave)
+static bool ConSave([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Save the current game. Usage: 'save <filename>'.");
@@ -436,7 +431,7 @@ DEF_CONSOLE_CMD(ConSave)
  * Explicitly save the configuration.
  * @return True.
  */
-DEF_CONSOLE_CMD(ConSaveConfig)
+static bool ConSaveConfig([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Saves the configuration for new games to the configuration file, typically 'openttd.cfg'.");
@@ -449,7 +444,7 @@ DEF_CONSOLE_CMD(ConSaveConfig)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConLoad)
+static bool ConLoad([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Load a game by name or index. Usage: 'load <file | number>'.");
@@ -475,7 +470,7 @@ DEF_CONSOLE_CMD(ConLoad)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConLoadScenario)
+static bool ConLoadScenario([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Load a scenario by name or index. Usage: 'load_scenario <file | number>'.");
@@ -501,7 +496,7 @@ DEF_CONSOLE_CMD(ConLoadScenario)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConLoadHeightmap)
+static bool ConLoadHeightmap([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Load a heightmap by name or index. Usage: 'load_heightmap <file | number>'.");
@@ -527,7 +522,7 @@ DEF_CONSOLE_CMD(ConLoadHeightmap)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConRemove)
+static bool ConRemove([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Remove a savegame by name or index. Usage: 'rm <file | number>'.");
@@ -553,7 +548,7 @@ DEF_CONSOLE_CMD(ConRemove)
 
 
 /* List all the files in the current dir via console */
-DEF_CONSOLE_CMD(ConListFiles)
+static bool ConListFiles([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "List all loadable savegames and directories in the current dir via console. Usage: 'ls | dir'.");
@@ -569,7 +564,7 @@ DEF_CONSOLE_CMD(ConListFiles)
 }
 
 /* List all the scenarios */
-DEF_CONSOLE_CMD(ConListScenarios)
+static bool ConListScenarios([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "List all loadable scenarios. Usage: 'list_scenarios'.");
@@ -585,7 +580,7 @@ DEF_CONSOLE_CMD(ConListScenarios)
 }
 
 /* List all the heightmaps */
-DEF_CONSOLE_CMD(ConListHeightmaps)
+static bool ConListHeightmaps([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "List all loadable heightmaps. Usage: 'list_heightmaps'.");
@@ -601,7 +596,7 @@ DEF_CONSOLE_CMD(ConListHeightmaps)
 }
 
 /* Change the dir via console */
-DEF_CONSOLE_CMD(ConChangeDirectory)
+static bool ConChangeDirectory([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Change the dir via console. Usage: 'cd <directory | number>'.");
@@ -628,7 +623,7 @@ DEF_CONSOLE_CMD(ConChangeDirectory)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConPrintWorkingDirectory)
+static bool ConPrintWorkingDirectory([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Print out the current working directory. Usage: 'pwd'.");
@@ -643,7 +638,7 @@ DEF_CONSOLE_CMD(ConPrintWorkingDirectory)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConClearBuffer)
+static bool ConClearBuffer([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Clear the console buffer. Usage: 'clear'.");
@@ -703,7 +698,7 @@ static bool ConKickOrBan(const char *argv, bool ban, const std::string &reason)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConKick)
+static bool ConKick([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Kick a client from a network game. Usage: 'kick <ip | client-id> [<kick-reason>]'.");
@@ -726,7 +721,7 @@ DEF_CONSOLE_CMD(ConKick)
 	}
 }
 
-DEF_CONSOLE_CMD(ConBan)
+static bool ConBan([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Ban a client from a network game. Usage: 'ban <ip | client-id> [<ban-reason>]'.");
@@ -750,7 +745,7 @@ DEF_CONSOLE_CMD(ConBan)
 	}
 }
 
-DEF_CONSOLE_CMD(ConUnBan)
+static bool ConUnBan([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Unban a client from a network game. Usage: 'unban <ip | banlist-index>'.");
@@ -782,7 +777,7 @@ DEF_CONSOLE_CMD(ConUnBan)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConBanList)
+static bool ConBanList([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "List the IP's of banned clients: Usage 'banlist'.");
@@ -800,7 +795,7 @@ DEF_CONSOLE_CMD(ConBanList)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConPauseGame)
+static bool ConPauseGame([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Pause a network game. Usage: 'pause'.");
@@ -822,7 +817,7 @@ DEF_CONSOLE_CMD(ConPauseGame)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConUnpauseGame)
+static bool ConUnpauseGame([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Unpause a network game. Usage: 'unpause'.");
@@ -848,7 +843,7 @@ DEF_CONSOLE_CMD(ConUnpauseGame)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConRcon)
+static bool ConRcon([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Remote control the server from another client. Usage: 'rcon <password> <command>'.");
@@ -867,7 +862,7 @@ DEF_CONSOLE_CMD(ConRcon)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConStatus)
+static bool ConStatus([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "List the status of all clients connected to the server. Usage 'status'.");
@@ -878,7 +873,7 @@ DEF_CONSOLE_CMD(ConStatus)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConServerInfo)
+static bool ConServerInfo([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "List current and maximum client/company limits. Usage 'server_info'.");
@@ -894,7 +889,7 @@ DEF_CONSOLE_CMD(ConServerInfo)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConClientNickChange)
+static bool ConClientNickChange([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc != 3) {
 		IConsolePrint(CC_HELP, "Change the nickname of a connected client. Usage: 'client_name <client-id> <new-name>'.");
@@ -928,7 +923,7 @@ DEF_CONSOLE_CMD(ConClientNickChange)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConJoinCompany)
+static bool ConJoinCompany([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc < 2) {
 		IConsolePrint(CC_HELP, "Request joining another company. Usage: 'join <company-id>'.");
@@ -975,7 +970,7 @@ DEF_CONSOLE_CMD(ConJoinCompany)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConMoveClient)
+static bool ConMoveClient([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc < 3) {
 		IConsolePrint(CC_HELP, "Move a client to another company. Usage: 'move <client-id> <company-id>'.");
@@ -1018,7 +1013,7 @@ DEF_CONSOLE_CMD(ConMoveClient)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConResetCompany)
+static bool ConResetCompany([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Remove an idle company from the game. Usage: 'reset_company <company-id>'.");
@@ -1059,7 +1054,7 @@ DEF_CONSOLE_CMD(ConResetCompany)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConNetworkClients)
+static bool ConNetworkClients([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Get a list of connected clients including their ID, name, company-id, and IP. Usage: 'clients'.");
@@ -1071,7 +1066,7 @@ DEF_CONSOLE_CMD(ConNetworkClients)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConNetworkReconnect)
+static bool ConNetworkReconnect([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Reconnect to server to which you were connected last time. Usage: 'reconnect [<company>]'.");
@@ -1102,7 +1097,7 @@ DEF_CONSOLE_CMD(ConNetworkReconnect)
 	return NetworkClientConnectGame(_settings_client.network.last_joined, playas);
 }
 
-DEF_CONSOLE_CMD(ConNetworkConnect)
+static bool ConNetworkConnect([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Connect to a remote OTTD server and join the game. Usage: 'connect <ip>'.");
@@ -1120,7 +1115,7 @@ DEF_CONSOLE_CMD(ConNetworkConnect)
  *  script file console commands
  *********************************/
 
-DEF_CONSOLE_CMD(ConExec)
+static bool ConExec([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Execute a local script file. Usage: 'exec <script> <?>'.");
@@ -1169,7 +1164,7 @@ DEF_CONSOLE_CMD(ConExec)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConSchedule)
+static bool ConSchedule([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc < 3 || std::string_view(argv[1]) != "on-next-calendar-month") {
 		IConsolePrint(CC_HELP, "Schedule a local script to execute later. Usage: 'schedule on-next-calendar-month <script>'.");
@@ -1198,7 +1193,7 @@ DEF_CONSOLE_CMD(ConSchedule)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConReturn)
+static bool ConReturn([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Stop executing a running script. Usage: 'return'.");
@@ -1217,7 +1212,7 @@ extern std::span<const GRFFile> GetAllGRFFiles();
 extern void ConPrintFramerate(); // framerate_gui.cpp
 extern void ShowFramerateWindow();
 
-DEF_CONSOLE_CMD(ConScript)
+static bool ConScript([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	extern std::optional<FileHandle> _iconsole_output_file;
 
@@ -1241,8 +1236,7 @@ DEF_CONSOLE_CMD(ConScript)
 	return true;
 }
 
-
-DEF_CONSOLE_CMD(ConEcho)
+static bool ConEcho([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Print back the first argument to the console. Usage: 'echo <arg>'.");
@@ -1254,7 +1248,7 @@ DEF_CONSOLE_CMD(ConEcho)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConEchoC)
+static bool ConEchoC([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Print back the first argument to the console in a given colour. Usage: 'echoc <colour> <arg2>'.");
@@ -1266,7 +1260,7 @@ DEF_CONSOLE_CMD(ConEchoC)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConNewGame)
+static bool ConNewGame([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Start a new game. Usage: 'newgame [seed]'.");
@@ -1278,7 +1272,7 @@ DEF_CONSOLE_CMD(ConNewGame)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConRestart)
+static bool ConRestart([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0 || argc > 2) {
 		IConsolePrint(CC_HELP, "Restart game. Usage: 'restart [current|newgame]'.");
@@ -1299,7 +1293,7 @@ DEF_CONSOLE_CMD(ConRestart)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConReload)
+static bool ConReload([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Reload game. Usage: 'reload'.");
@@ -1343,7 +1337,7 @@ bool PrintList(F list_function, Args... args)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConListAILibs)
+static bool ConListAILibs([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "List installed AI libraries. Usage: 'list_ai_libs'.");
@@ -1353,7 +1347,7 @@ DEF_CONSOLE_CMD(ConListAILibs)
 	return PrintList(AI::GetConsoleLibraryList);
 }
 
-DEF_CONSOLE_CMD(ConListAI)
+static bool ConListAI([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "List installed AIs. Usage: 'list_ai'.");
@@ -1363,7 +1357,7 @@ DEF_CONSOLE_CMD(ConListAI)
 	return PrintList(AI::GetConsoleList, false);
 }
 
-DEF_CONSOLE_CMD(ConListGameLibs)
+static bool ConListGameLibs([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "List installed Game Script libraries. Usage: 'list_game_libs'.");
@@ -1373,7 +1367,7 @@ DEF_CONSOLE_CMD(ConListGameLibs)
 	return PrintList(Game::GetConsoleLibraryList);
 }
 
-DEF_CONSOLE_CMD(ConListGame)
+static bool ConListGame([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "List installed Game Scripts. Usage: 'list_game'.");
@@ -1383,7 +1377,7 @@ DEF_CONSOLE_CMD(ConListGame)
 	return PrintList(Game::GetConsoleList, false);
 }
 
-DEF_CONSOLE_CMD(ConStartAI)
+static bool ConStartAI([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0 || argc > 3) {
 		IConsolePrint(CC_HELP, "Start a new AI. Usage: 'start_ai [<AI>] [<settings>]'.");
@@ -1455,7 +1449,7 @@ DEF_CONSOLE_CMD(ConStartAI)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConReloadAI)
+static bool ConReloadAI([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc != 2) {
 		IConsolePrint(CC_HELP, "Reload an AI. Usage: 'reload_ai <company-id>'.");
@@ -1493,7 +1487,7 @@ DEF_CONSOLE_CMD(ConReloadAI)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConStopAI)
+static bool ConStopAI([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc != 2) {
 		IConsolePrint(CC_HELP, "Stop an AI. Usage: 'stop_ai <company-id>'.");
@@ -1530,7 +1524,7 @@ DEF_CONSOLE_CMD(ConStopAI)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConRescanAI)
+static bool ConRescanAI([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Rescan the AI dir for scripts. Usage: 'rescan_ai'.");
@@ -1547,7 +1541,7 @@ DEF_CONSOLE_CMD(ConRescanAI)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConRescanGame)
+static bool ConRescanGame([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Rescan the Game Script dir for scripts. Usage: 'rescan_game'.");
@@ -1564,7 +1558,7 @@ DEF_CONSOLE_CMD(ConRescanGame)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConRescanNewGRF)
+static bool ConRescanNewGRF([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Rescan the data dir for NewGRFs. Usage: 'rescan_newgrf'.");
@@ -1578,7 +1572,7 @@ DEF_CONSOLE_CMD(ConRescanNewGRF)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConGetSeed)
+static bool ConGetSeed([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Returns the seed used to create this game. Usage: 'getseed'.");
@@ -1590,7 +1584,7 @@ DEF_CONSOLE_CMD(ConGetSeed)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConGetDate)
+static bool ConGetDate([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Returns the current date (year-month-day) of the game. Usage: 'getdate'.");
@@ -1602,7 +1596,7 @@ DEF_CONSOLE_CMD(ConGetDate)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConGetSysDate)
+static bool ConGetSysDate([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Returns the current date (year-month-day) of your system. Usage: 'getsysdate'.");
@@ -1613,8 +1607,7 @@ DEF_CONSOLE_CMD(ConGetSysDate)
 	return true;
 }
 
-
-DEF_CONSOLE_CMD(ConAlias)
+static bool ConAlias([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	IConsoleAlias *alias;
 
@@ -1634,7 +1627,7 @@ DEF_CONSOLE_CMD(ConAlias)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConScreenShot)
+static bool ConScreenShot([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Create a screenshot of the game. Usage: 'screenshot [viewport | normal | big | giant | heightmap | minimap] [no_con] [size <width> <height>] [<filename>]'.");
@@ -1715,7 +1708,7 @@ DEF_CONSOLE_CMD(ConScreenShot)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConInfoCmd)
+static bool ConInfoCmd([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Print out debugging information about a command. Usage: 'info_cmd <cmd>'.");
@@ -1737,7 +1730,7 @@ DEF_CONSOLE_CMD(ConInfoCmd)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConDebugLevel)
+static bool ConDebugLevel([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Get/set the default debugging level for the game. Usage: 'debug_level [<level>]'.");
@@ -1756,7 +1749,7 @@ DEF_CONSOLE_CMD(ConDebugLevel)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConExit)
+static bool ConExit([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Exit the game. Usage: 'exit'.");
@@ -1769,7 +1762,7 @@ DEF_CONSOLE_CMD(ConExit)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConPart)
+static bool ConPart([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Leave the currently joined/running game (only ingame). Usage: 'part'.");
@@ -1787,7 +1780,7 @@ DEF_CONSOLE_CMD(ConPart)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConHelp)
+static bool ConHelp([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 2) {
 		const IConsoleCmd *cmd;
@@ -1826,7 +1819,7 @@ DEF_CONSOLE_CMD(ConHelp)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConListCommands)
+static bool ConListCommands([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "List all registered commands. Usage: 'list_cmds [<pre-filter>]'.");
@@ -1843,7 +1836,7 @@ DEF_CONSOLE_CMD(ConListCommands)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConListAliases)
+static bool ConListAliases([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "List all registered aliases. Usage: 'list_aliases [<pre-filter>]'.");
@@ -1860,7 +1853,7 @@ DEF_CONSOLE_CMD(ConListAliases)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConCompanies)
+static bool ConCompanies([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "List the details of all companies in the game. Usage 'companies'.");
@@ -1885,7 +1878,7 @@ DEF_CONSOLE_CMD(ConCompanies)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConSay)
+static bool ConSay([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Chat to your fellow players in a multiplayer game. Usage: 'say \"<msg>\"'.");
@@ -1904,7 +1897,7 @@ DEF_CONSOLE_CMD(ConSay)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConSayCompany)
+static bool ConSayCompany([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Chat to a certain company in a multiplayer game. Usage: 'say_company <company-no> \"<msg>\"'.");
@@ -1930,7 +1923,7 @@ DEF_CONSOLE_CMD(ConSayCompany)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConSayClient)
+static bool ConSayClient([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Chat to a certain client in a multiplayer game. Usage: 'say_client <client-no> \"<msg>\"'.");
@@ -2003,7 +1996,7 @@ static void PerformNetworkAuthorizedKeyAction(std::string_view name, NetworkAuth
 	}
 }
 
-DEF_CONSOLE_CMD(ConNetworkAuthorizedKey)
+static bool ConNetworkAuthorizedKey([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc <= 2) {
 		IConsolePrint(CC_HELP, "List and update authorized keys. Usage: 'authorized_key list [type]|add [type] [key]|remove [type] [key]'.");
@@ -2138,7 +2131,7 @@ static void OutputContentState(const ContentInfo &ci)
 	IConsolePrint(state_to_colour[ci.state], "{}, {}, {}, {}, {:08X}, {}", ci.id, types[ci.type - 1], states[ci.state], ci.name, ci.unique_id, FormatArrayAsHex(ci.md5sum));
 }
 
-DEF_CONSOLE_CMD(ConContent)
+static bool ConContent([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	static ContentCallback *cb = nullptr;
 	if (cb == nullptr) {
@@ -2223,7 +2216,7 @@ DEF_CONSOLE_CMD(ConContent)
 }
 #endif /* defined(WITH_ZLIB) */
 
-DEF_CONSOLE_CMD(ConFont)
+static bool ConFont([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Manage the fonts configuration.");
@@ -2287,7 +2280,7 @@ DEF_CONSOLE_CMD(ConFont)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConSetting)
+static bool ConSetting([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Change setting for all clients. Usage: 'setting <name> [<value>]'.");
@@ -2306,7 +2299,7 @@ DEF_CONSOLE_CMD(ConSetting)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConSettingNewgame)
+static bool ConSettingNewgame([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Change setting for the next game. Usage: 'setting_newgame <name> [<value>]'.");
@@ -2325,7 +2318,7 @@ DEF_CONSOLE_CMD(ConSettingNewgame)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConListSettings)
+static bool ConListSettings([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "List settings. Usage: 'list_settings [<pre-filter>]'.");
@@ -2338,7 +2331,7 @@ DEF_CONSOLE_CMD(ConListSettings)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConGamelogPrint)
+static bool ConGamelogPrint([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Print logged fundamental changes to the game since the start. Usage: 'gamelog'.");
@@ -2349,7 +2342,7 @@ DEF_CONSOLE_CMD(ConGamelogPrint)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConNewGRFReload)
+static bool ConNewGRFReload([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Reloads all active NewGRFs from disk. Equivalent to reapplying NewGRFs via the settings, but without asking for confirmation. This might crash OpenTTD!");
@@ -2360,7 +2353,7 @@ DEF_CONSOLE_CMD(ConNewGRFReload)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConListDirs)
+static bool ConListDirs([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	struct SubdirNameMap {
 		Subdirectory subdir; ///< Index of subdirectory type
@@ -2426,7 +2419,7 @@ DEF_CONSOLE_CMD(ConListDirs)
 	return false;
 }
 
-DEF_CONSOLE_CMD(ConNewGRFProfile)
+static bool ConNewGRFProfile([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Collect performance data about NewGRF sprite requests and callbacks. Sub-commands can be abbreviated.");
@@ -2559,7 +2552,7 @@ static void IConsoleDebugLibRegister()
 }
 #endif
 
-DEF_CONSOLE_CMD(ConFramerate)
+static bool ConFramerate([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Show frame rate and game speed information.");
@@ -2570,7 +2563,7 @@ DEF_CONSOLE_CMD(ConFramerate)
 	return true;
 }
 
-DEF_CONSOLE_CMD(ConFramerateWindow)
+static bool ConFramerateWindow([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Open the frame rate window.");
@@ -2735,8 +2728,7 @@ static void ConDumpCargoTypes()
 	}
 }
 
-
-DEF_CONSOLE_CMD(ConDumpInfo)
+static bool ConDumpInfo([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc != 2) {
 		IConsolePrint(CC_HELP, "Dump debugging information.");

--- a/src/core/bitmath_func.hpp
+++ b/src/core/bitmath_func.hpp
@@ -142,18 +142,6 @@ constexpr T ClrBit(T &x, const uint8_t y)
 }
 
 /**
- * Clears several bits in a variable.
- *
- * This macro clears several bits in a variable. The bits to clear are
- * provided by a value. The new value is also returned.
- *
- * @param x The variable to clear some bits
- * @param y The value with set bits for clearing them in the variable
- * @return The new value of x
- */
-#define CLRBITS(x, y) ((x) &= ~(y))
-
-/**
  * Toggles a bit in a variable.
  *
  * This function toggles a bit in a variable. The variable is

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -540,7 +540,7 @@ static CommandCost RemoveRoad(TileIndex tile, DoCommandFlags flags, RoadBits pie
 static CommandCost CheckRoadSlope(Slope tileh, RoadBits *pieces, RoadBits existing, RoadBits other)
 {
 	/* Remove already build pieces */
-	CLRBITS(*pieces, existing);
+	*pieces &= ~existing;
 
 	/* If we can't build anything stop here */
 	if (*pieces == ROAD_NONE) return CMD_ERROR;

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -18,10 +18,6 @@
 
 #include "table/control_codes.h"
 
-#ifdef _MSC_VER
-#	define strncasecmp strnicmp
-#endif
-
 #ifdef _WIN32
 #	include "os/windows/win32.h"
 #endif

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -40,14 +40,13 @@ static FVideoDriver_Allegro iFVideoDriver_Allegro;
 
 static BITMAP *_allegro_screen;
 
-#define MAX_DIRTY_RECTS 100
-static PointDimension _dirty_rects[MAX_DIRTY_RECTS];
-static int _num_dirty_rects;
+static PointDimension _dirty_rects[100];
+static size_t _num_dirty_rects;
 static Palette _local_palette; ///< Current palette to use for drawing.
 
 void VideoDriver_Allegro::MakeDirty(int left, int top, int width, int height)
 {
-	if (_num_dirty_rects < MAX_DIRTY_RECTS) {
+	if (_num_dirty_rects < std::size(_dirty_rects)) {
 		_dirty_rects[_num_dirty_rects].x = left;
 		_dirty_rects[_num_dirty_rects].y = top;
 		_dirty_rects[_num_dirty_rects].width = width;
@@ -60,16 +59,16 @@ void VideoDriver_Allegro::Paint()
 {
 	PerformanceMeasurer framerate(PFE_VIDEO);
 
-	int n = _num_dirty_rects;
+	size_t n = _num_dirty_rects;
 	if (n == 0) return;
 
 	_num_dirty_rects = 0;
-	if (n > MAX_DIRTY_RECTS) {
+	if (n > std::size(_dirty_rects)) {
 		blit(_allegro_screen, screen, 0, 0, 0, 0, _allegro_screen->w, _allegro_screen->h);
 		return;
 	}
 
-	for (int i = 0; i < n; i++) {
+	for (size_t i = 0; i < n; i++) {
 		blit(_allegro_screen, screen, _dirty_rects[i].x, _dirty_rects[i].y, _dirty_rects[i].x, _dirty_rects[i].y, _dirty_rects[i].width, _dirty_rects[i].height);
 	}
 }


### PR DESCRIPTION
## Motivation / Problem

There are a bunch of macros, which are either obsolete, or should not have existed in the first place.

## Description

* `DEF_CONSOLE_CMD`, `DEF_CONSOLE_HOOK` obfuscate the names of the function parameters, which make reading the code harder, and also breaks IDEs and other parsers.
* `ALIGN` no longer needs compiler specific attributes, since C++11 there is `alignas`.
* `CLRBITS` is only used in a single place by now, and even that one will probably get replaced by `BaseBitSet` somewhen.
* `MAX_DIRTY_RECTS` is only used to determine the length of an array, we have `lengthof` for that.
* `strncasecmp` usages were removed some time ago.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
