### PR TITLE
Codechange: Ini(Load|Save)WindowSettings expect a WindowDesc*, no void*.

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -878,7 +878,7 @@ static void IniSaveSettingList(IniFile &ini, const char *grpname, StringList &li
  * @param grpname character string identifying the section-header of the ini file that will be parsed
  * @param desc Destination WindowDesc
  */
-void IniLoadWindowSettings(IniFile &ini, const char *grpname, void *desc)
+void IniLoadWindowSettings(IniFile &ini, const char *grpname, WindowDesc *desc)
 {
 	IniLoadSettings(ini, _window_settings, grpname, desc, false);
 }
@@ -889,7 +889,7 @@ void IniLoadWindowSettings(IniFile &ini, const char *grpname, void *desc)
  * @param grpname character string identifying the section-header of the ini file
  * @param desc Source WindowDesc
  */
-void IniSaveWindowSettings(IniFile &ini, const char *grpname, void *desc)
+void IniSaveWindowSettings(IniFile &ini, const char *grpname, WindowDesc *desc)
 {
 	IniSaveSettings(ini, _window_settings, grpname, desc, false);
 }

--- a/src/settings_func.h
+++ b/src/settings_func.h
@@ -15,6 +15,7 @@
 #include "newgrf_config.h"
 
 struct IniFile;
+struct WindowDesc;
 
 void IConsoleSetSetting(const char *name, const char *value, bool force_newgame = false);
 void IConsoleSetSetting(const char *name, int32_t value);
@@ -24,8 +25,8 @@ void IConsoleListSettings(const char *prefilter);
 void LoadFromConfig(bool minimal = false);
 void SaveToConfig();
 
-void IniLoadWindowSettings(IniFile &ini, const char *grpname, void *desc);
-void IniSaveWindowSettings(IniFile &ini, const char *grpname, void *desc);
+void IniLoadWindowSettings(IniFile &ini, const char *grpname, WindowDesc *desc);
+void IniSaveWindowSettings(IniFile &ini, const char *grpname, WindowDesc *desc);
 
 StringList GetGRFPresetList();
 GRFConfigList LoadGRFPresetFromConfig(const char *config_name);


### PR DESCRIPTION
## Motivation / Problem

`IniLoadWindowSettings` and `IniSaveWindowSettings` take a `void *` parameter.
But the implementation requires that it must be a `WindowDesc *`.

## Description

Change the prototype to use the correct type.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
