### PR TITLE
Codechange: Manage script event queue using smart pointers.

### DIFF
--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -239,9 +239,9 @@ ScriptObject::ActiveInstance::~ActiveInstance()
 	return GetStorage()->allow_do_command && squirrel->CanSuspend();
 }
 
-/* static */ void *&ScriptObject::GetEventPointer()
+/* static */ ScriptEventQueue &ScriptObject::GetEventQueue()
 {
-	return GetStorage()->event_data;
+	return GetStorage()->event_queue;
 }
 
 /* static */ ScriptLogTypes::LogData &ScriptObject::GetLogData()

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -327,12 +327,12 @@ protected:
 	static bool CanSuspend();
 
 	/**
-	 * Get the pointer to store event data in.
+	 * Get the reference to the event queue.
 	 */
-	static void *&GetEventPointer();
+	static struct ScriptEventQueue &GetEventQueue();
 
 	/**
-	 * Get the pointer to store log message in.
+	 * Get the reference to the log message storage.
 	 */
 	static ScriptLogTypes::LogData &GetLogData();
 
@@ -465,6 +465,14 @@ public:
 	~ScriptObjectRef()
 	{
 		if (this->data != nullptr) this->data->Release();
+	}
+
+	/**
+	 * Transfer ownership to the caller.
+	 */
+	[[nodiscard]] T *release()
+	{
+		return std::exchange(this->data, nullptr);
 	}
 
 	/**

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -32,6 +32,7 @@
 
 #include "../safeguards.h"
 
+ScriptStorage::ScriptStorage() = default;
 ScriptStorage::~ScriptStorage()
 {
 	/* Free our pointers */

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -33,11 +33,7 @@
 #include "../safeguards.h"
 
 ScriptStorage::ScriptStorage() = default;
-ScriptStorage::~ScriptStorage()
-{
-	/* Free our pointers */
-	if (event_data != nullptr) ScriptEventController::FreeEventPointer();
-}
+ScriptStorage::~ScriptStorage() = default;
 
 /**
  * Callback called by squirrel when a script uses "print" and for error messages.

--- a/src/script/script_storage.hpp
+++ b/src/script/script_storage.hpp
@@ -36,53 +36,35 @@ typedef bool (ScriptAsyncModeProc)();
 class ScriptStorage {
 friend class ScriptObject;
 private:
-	ScriptModeProc *mode;             ///< The current build mode we are int.
-	class ScriptObject *mode_instance; ///< The instance belonging to the current build mode.
-	ScriptAsyncModeProc *async_mode;         ///< The current command async mode we are in.
-	class ScriptObject *async_mode_instance; ///< The instance belonging to the current command async mode.
-	CompanyID root_company;          ///< The root company, the company that the script really belongs to.
-	CompanyID company;               ///< The current company.
+	ScriptModeProc *mode = nullptr; ///< The current build mode we are int.
+	class ScriptObject *mode_instance = nullptr; ///< The instance belonging to the current build mode.
+	ScriptAsyncModeProc *async_mode = nullptr; ///< The current command async mode we are in.
+	class ScriptObject *async_mode_instance = nullptr; ///< The instance belonging to the current command async mode.
+	CompanyID root_company = INVALID_OWNER; ///< The root company, the company that the script really belongs to.
+	CompanyID company = INVALID_OWNER; ///< The current company.
 
-	uint delay;                      ///< The ticks of delay each DoCommand has.
-	bool allow_do_command;           ///< Is the usage of DoCommands restricted?
+	uint delay = 1; ///< The ticks of delay each DoCommand has.
+	bool allow_do_command = true; ///< Is the usage of DoCommands restricted?
 
-	CommandCost costs;               ///< The costs the script is tracking.
-	Money last_cost;                 ///< The last cost of the command.
+	CommandCost costs; ///< The costs the script is tracking.
+	Money last_cost = 0; ///< The last cost of the command.
 	ScriptErrorType last_error{}; ///< The last error of the command.
-	bool last_command_res;           ///< The last result of the command.
+	bool last_command_res = true; ///< The last result of the command.
 
-	CommandDataBuffer last_data;     ///< The last data passed to a command.
-	Commands last_cmd;               ///< The last cmd passed to a command.
-	CommandDataBuffer last_cmd_ret;  ///< The extra data returned by the last command.
+	CommandDataBuffer last_data; ///< The last data passed to a command.
+	Commands last_cmd = CMD_END; ///< The last cmd passed to a command.
+	CommandDataBuffer last_cmd_ret; ///< The extra data returned by the last command.
 
 	std::vector<int> callback_value; ///< The values which need to survive a callback.
 
-	RoadType road_type;              ///< The current roadtype we build.
-	RailType rail_type;              ///< The current railtype we build.
+	RoadType road_type = INVALID_ROADTYPE; ///< The current roadtype we build.
+	RailType rail_type = INVALID_RAILTYPE; ///< The current railtype we build.
 
-	void *event_data;                ///< Pointer to the event data storage.
-	ScriptLogTypes::LogData log_data;///< Log data storage.
+	void *event_data = nullptr; ///< Event queue for this script.
+	ScriptLogTypes::LogData log_data; ///< Log data storage.
 
 public:
-	ScriptStorage() :
-		mode              (nullptr),
-		mode_instance     (nullptr),
-		async_mode        (nullptr),
-		async_mode_instance (nullptr),
-		root_company      (INVALID_OWNER),
-		company           (INVALID_OWNER),
-		delay             (1),
-		allow_do_command  (true),
-		/* costs (can't be set) */
-		last_cost         (0),
-		last_command_res  (true),
-		last_cmd          (CMD_END),
-		/* calback_value (can't be set) */
-		road_type         (INVALID_ROADTYPE),
-		rail_type         (INVALID_RAILTYPE),
-		event_data        (nullptr)
-	{ }
-
+	ScriptStorage();
 	~ScriptStorage();
 };
 

--- a/src/script/script_storage.hpp
+++ b/src/script/script_storage.hpp
@@ -10,6 +10,8 @@
 #ifndef SCRIPT_STORAGE_HPP
 #define SCRIPT_STORAGE_HPP
 
+#include <queue>
+
 #include "../signs_func.h"
 #include "../vehicle_func.h"
 #include "../road_type.h"
@@ -19,6 +21,13 @@
 
 #include "script_types.hpp"
 #include "script_log_types.hpp"
+#include "script_object.hpp"
+
+class ScriptEvent;
+
+/* This is a "struct", so we can forward declare it, and use as incomplete type. */
+struct ScriptEventQueue : std::queue<ScriptObjectRef<ScriptEvent>> {
+};
 
 /**
  * The callback function for Mode-classes.
@@ -60,7 +69,7 @@ private:
 	RoadType road_type = INVALID_ROADTYPE; ///< The current roadtype we build.
 	RailType rail_type = INVALID_RAILTYPE; ///< The current railtype we build.
 
-	void *event_data = nullptr; ///< Event queue for this script.
+	ScriptEventQueue event_queue; ///< Event queue for this script.
 	ScriptLogTypes::LogData log_data; ///< Log data storage.
 
 public:


### PR DESCRIPTION
## Motivation / Problem

* The script event queue (sometimes called "stack") is passed around a lot as `void *`.
* For some reason it is only lazily created.
* Destruction and freeing is done manually.

## Description

* Pass `ScriptEventQueue` as reference to incomplete type, instead of `void *`.
* Use the existing `ScriptObjectRef` to manage the destruction and freeing.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
