### PR TITLE
Codechange: Turn AyStar into an actual class with virtual methods instead of function pointers.

### DIFF
--- a/src/pathfinder/aystar.cpp
+++ b/src/pathfinder/aystar.cpp
@@ -41,7 +41,7 @@ void AyStar::CheckTile(AyStarNode *current, PathNode *parent)
 	if (this->nodes.FindClosedNode(*current) != nullptr) return;
 
 	/* Calculate the G-value for this node */
-	int new_g = this->CalculateG(this, current, parent);
+	int new_g = this->CalculateG(*current, *parent);
 	/* If the value was INVALID_NODE, we don't do anything with this node */
 	if (new_g == AYSTAR_INVALID_NODE) return;
 
@@ -51,7 +51,7 @@ void AyStar::CheckTile(AyStarNode *current, PathNode *parent)
 	new_g += parent->cost;
 
 	/* Calculate the h-value */
-	int new_h = this->CalculateH(this, current, parent);
+	int new_h = this->CalculateH(*current, *parent);
 	/* There should not be given any error-code.. */
 	assert(new_h >= 0);
 
@@ -96,10 +96,8 @@ AyStarStatus AyStar::Loop()
 	if (current == nullptr) return AyStarStatus::EmptyOpenList;
 
 	/* Check for end node and if found, return that code */
-	if (this->EndNodeCheck(this, current) == AyStarStatus::FoundEndNode && current->parent != nullptr) {
-		if (this->FoundEndNode != nullptr) {
-			this->FoundEndNode(this, current);
-		}
+	if (this->EndNodeCheck(*current) == AyStarStatus::FoundEndNode && current->parent != nullptr) {
+		this->FoundEndNode(*current);
 		return AyStarStatus::FoundEndNode;
 	}
 
@@ -107,7 +105,7 @@ AyStarStatus AyStar::Loop()
 	this->nodes.InsertClosedNode(*current);
 
 	/* Load the neighbours */
-	this->GetNeighbours(this, current);
+	this->GetNeighbours(*current, this->neighbours);
 
 	/* Go through all neighbours */
 	for (auto &neighbour : this->neighbours) {

--- a/src/pathfinder/aystar.cpp
+++ b/src/pathfinder/aystar.cpp
@@ -49,7 +49,6 @@ void AyStar::CheckTile(AyStarNode *current, PathNode *parent)
 	assert(new_g >= 0);
 	/* Add the parent g-value to the new g-value */
 	new_g += parent->cost;
-	if (this->max_path_cost != 0 && new_g > this->max_path_cost) return;
 
 	/* Calculate the h-value */
 	int new_h = this->CalculateH(this, current, parent);
@@ -116,7 +115,7 @@ AyStarStatus AyStar::Loop()
 		this->CheckTile(&neighbour, current);
 	}
 
-	if (this->max_search_nodes != 0 && this->nodes.ClosedCount() >= this->max_search_nodes) {
+	if (this->nodes.ClosedCount() >= AYSTAR_DEF_MAX_SEARCH_NODES) {
 		/* We've expanded enough nodes */
 		return AyStarStatus::LimitReached;
 	} else {
@@ -131,16 +130,13 @@ AyStarStatus AyStar::Loop()
  *  - #AyStarStatus::FoundEndNode
  *  - #AyStarStatus::NoPath
  *  - #AyStarStatus::StillBusy
- * @note When the algorithm is done (when the return value is not #AyStarStatus::StillBusy) #Clear() is called automatically.
- *       When you stop the algorithm halfway, you should call #Clear() yourself!
  */
 AyStarStatus AyStar::Main()
 {
-	AyStarStatus r = AyStarStatus::FoundEndNode;
-	int i = 0;
-	/* Loop through the OpenList
-	 *  Quit if result is no AyStarStatus::StillBusy or is more than loops_per_tick */
-	while ((r = this->Loop()) == AyStarStatus::StillBusy && (this->loops_per_tick == 0 || ++i < this->loops_per_tick)) { }
+	AyStarStatus r;
+	do {
+		r = this->Loop();
+	} while (r == AyStarStatus::StillBusy);
 #ifdef AYSTAR_DEBUG
 	switch (r) {
 		case AyStarStatus::FoundEndNode: Debug(misc, 0, "[AyStar] Found path!"); break;
@@ -160,9 +156,7 @@ AyStarStatus AyStar::Main()
 
 /**
  * Adds a node from where to start an algorithm. Multiple nodes can be added
- * if wanted. You should make sure that #Clear() is called before adding nodes
- * if the #AyStar has been used before (though the normal main loop calls
- * #Clear() automatically when the algorithm finishes.
+ * if wanted.
  * @param start_node Node to start with.
  * @param g the cost for starting with this node.
  */

--- a/src/pathfinder/aystar.h
+++ b/src/pathfinder/aystar.h
@@ -38,95 +38,61 @@ using AyStarNode = CYapfNodeKeyTrackDir;
 struct PathNode : CYapfNodeT<AyStarNode, PathNode> {
 };
 
-struct AyStar;
-
-/**
- * Check whether the end-tile is found.
- * @param aystar %AyStar search algorithm data.
- * @param current Node to exam one.
- * @note The 2nd parameter should be #OpenListNode, and \em not #AyStarNode. #AyStarNode is
- * part of #OpenListNode and so it could be accessed without any problems.
- * The good part about #OpenListNode is, and how AIs use it, that you can
- * access the parent of the current node, and so check if you, for example
- * don't try to enter the file tile with a 90-degree curve. So please, leave
- * this an #OpenListNode, it works just fine.
- * @return Status of the node:
- *  - #AyStarStatus::FoundEndNode : indicates this is the end tile
- *  - #AyStarStatus::Done : indicates this is not the end tile (or direction was wrong)
- */
-typedef AyStarStatus AyStar_EndNodeCheck(const AyStar *aystar, const PathNode *current);
-
-/**
- * Calculate the G-value for the %AyStar algorithm.
- * @return G value of the node:
- *  - #AYSTAR_INVALID_NODE : indicates an item is not valid (e.g.: unwalkable)
- *  - Any value >= 0 : the g-value for this tile
- */
-typedef int32_t AyStar_CalculateG(AyStar *aystar, AyStarNode *current, PathNode *parent);
-
-/**
- * Calculate the H-value for the %AyStar algorithm.
- * Mostly, this must return the distance (Manhattan way) between the current point and the end point.
- * @return The h-value for this tile (any value >= 0)
- */
-typedef int32_t AyStar_CalculateH(AyStar *aystar, AyStarNode *current, PathNode *parent);
-
-/**
- * This function requests the tiles around the current tile and put them in #neighbours.
- * #neighbours is never reset, so if you are not using directions, just leave it alone.
- * @warning Never add more #neighbours than memory allocated for it.
- */
-typedef void AyStar_GetNeighbours(AyStar *aystar, PathNode *current);
-
-/**
- * If the End Node is found, this function is called.
- * It can do, for example, calculate the route and put that in an array.
- */
-typedef void AyStar_FoundEndNode(AyStar *aystar, PathNode *current);
-
 /**
  * %AyStar search algorithm struct.
- * Before calling #Init(), fill #CalculateG, #CalculateH, #GetNeighbours, #EndNodeCheck, and #FoundEndNode.
- * If you want to change them after calling #Init(), first call #Free() !
- *
- * The #user_path, #user_target, and #user_data[10] are intended to be used by the user routines. The data not accessed by the #AyStar code itself.
- * The user routines can change any moment they like.
  */
-struct AyStar {
-/* These fields should be filled before initing the AyStar, but not changed
- * afterwards (except for user_data)! (free and init again to change them) */
-
-	/* These should point to the application specific routines that do the
-	 * actual work */
-	AyStar_CalculateG *CalculateG;
-	AyStar_CalculateH *CalculateH;
-	AyStar_GetNeighbours *GetNeighbours;
-	AyStar_EndNodeCheck *EndNodeCheck;
-	AyStar_FoundEndNode *FoundEndNode;
-
-	/* These are completely untouched by AyStar, they can be accessed by
-	 * the application specific routines to input and output data.
-	 * user_path should typically contain data about the resulting path
-	 * afterwards, user_target should typically contain information about
-	 * what you where looking for, and user_data can contain just about
-	 * everything */
-	void *user_target;
-	void *user_data;
-
-	/* These should be filled with the neighbours of a tile by GetNeighbours */
-	std::vector<AyStarNode> neighbours;
-
-	/* These will contain the methods for manipulating the AyStar. Only
-	 * Main() should be called externally */
-	void AddStartNode(AyStarNode *start_node, int g);
-	AyStarStatus Main();
-	AyStarStatus Loop();
-	void CheckTile(AyStarNode *current, PathNode *parent);
-
+class AyStar {
 protected:
-	NodeList<PathNode, 8, 10> nodes;
+	/**
+	 * Calculate the G-value for the %AyStar algorithm.
+	 * @return G value of the node:
+	 *  - #AYSTAR_INVALID_NODE : indicates an item is not valid (e.g.: unwalkable)
+	 *  - Any value >= 0 : the g-value for this tile
+	 */
+	virtual int32_t CalculateG(const AyStarNode &current, const PathNode &parent) const = 0;
 
+	/**
+	 * Calculate the H-value for the %AyStar algorithm.
+	 * Mostly, this must return the distance (Manhattan way) between the current point and the end point.
+	 * @return The h-value for this tile (any value >= 0)
+	 */
+	virtual int32_t CalculateH(const AyStarNode &current, const PathNode &parent) const = 0;
+
+	/**
+	 * This function requests the tiles around the current tile.
+	 * #neighbours is never reset, so if you are not using directions, just leave it alone.
+	 */
+	virtual void GetNeighbours(const PathNode &current, std::vector<AyStarNode> &neighours) const = 0;
+
+	 /**
+	 * Check whether the end-tile is found.
+	 * @param current Node to exam.
+	 * @return Status of the node:
+	 *  - #AyStarStatus::FoundEndNode : indicates this is the end tile
+	 *  - #AyStarStatus::Done : indicates this is not the end tile (or direction was wrong)
+	 */
+	virtual AyStarStatus EndNodeCheck(const PathNode &current) const = 0;
+
+	/**
+	 * If the End Node is found, this function is called.
+	 * It can do, for example, calculate the route and put that in an array.
+	 */
+	virtual void FoundEndNode(const PathNode &current) = 0;
+
+	void AddStartNode(AyStarNode *start_node, int g);
+
+	AyStarStatus Main();
+
+public:
+	virtual ~AyStar() = default;
+
+private:
+	NodeList<PathNode, 8, 10> nodes;
+	mutable std::vector<AyStarNode> neighbours;
+
+	AyStarStatus Loop();
 	void OpenListAdd(PathNode *parent, const AyStarNode *node, int f, int g);
+	void CheckTile(AyStarNode *current, PathNode *parent);
 };
 
 #endif /* AYSTAR_H */

--- a/src/pathfinder/aystar.h
+++ b/src/pathfinder/aystar.h
@@ -27,7 +27,7 @@ enum class AyStarStatus : uint8_t {
 	EmptyOpenList, ///< All items are tested, and no path has been found.
 	StillBusy, ///< Some checking was done, but no path found yet, and there are still items left to try.
 	NoPath, ///< No path to the goal was found.
-	LimitReached, ///< The #AyStar::max_search_nodes limit has been reached, aborting search.
+	LimitReached, ///< The AYSTAR_DEF_MAX_SEARCH_NODES limit has been reached, aborting search.
 	Done, ///< Not an end-tile, or wrong direction.
 };
 
@@ -112,10 +112,6 @@ struct AyStar {
 	 * everything */
 	void *user_target;
 	void *user_data;
-
-	uint8_t loops_per_tick;   ///< How many loops are there called before Main() gives control back to the caller. 0 = until done.
-	int max_path_cost;    ///< If the g-value goes over this number, it stops searching, 0 = infinite.
-	int max_search_nodes = AYSTAR_DEF_MAX_SEARCH_NODES; ///< The maximum number of nodes that will be expanded, 0 = infinite.
 
 	/* These should be filled with the neighbours of a tile by GetNeighbours */
 	std::vector<AyStarNode> neighbours;


### PR DESCRIPTION
## Motivation / Problem

`AyStar` is a weird C class:
* It uses function pointers instead of virtual methods.
* It provides generic `void *` storage for "derived classes".
* It does not know the keyword `const`.

## Description

* Sort members into `private`, `protected` and `public`.
* Turn function pointers into pure virtual methods.
* Let derived classes declare their own storage.
* Turn mutable pointers into const references as appropiate.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
