### PR TITLE
Codechange: Change function pointer callbacks into std::function, so there is no need for void* user data.

### DIFF
--- a/src/date_gui.cpp
+++ b/src/date_gui.cpp
@@ -26,8 +26,7 @@
 
 /** Window to select a date graphically by using dropdowns */
 struct SetDateWindow : Window {
-	SetDateCallback *callback = nullptr; ///< Callback to call when a date has been selected
-	void *callback_data = nullptr; ///< Callback data pointer.
+	SetDateCallback callback; ///< Callback to call when a date has been selected
 	TimerGameEconomy::YearMonthDay date{}; ///< The currently selected date
 	TimerGameEconomy::Year min_year{}; ///< The minimum year in the year dropdown
 	TimerGameEconomy::Year max_year{}; ///< The maximum year (inclusive) in the year dropdown
@@ -42,10 +41,9 @@ struct SetDateWindow : Window {
 	 * @param max_year the maximum year (inclusive) to show in the year dropdown
 	 * @param callback the callback to call once a date has been selected
 	 */
-	SetDateWindow(WindowDesc &desc, WindowNumber window_number, Window *parent, TimerGameEconomy::Date initial_date, TimerGameEconomy::Year min_year, TimerGameEconomy::Year max_year, SetDateCallback *callback, void *callback_data) :
+	SetDateWindow(WindowDesc &desc, WindowNumber window_number, Window *parent, TimerGameEconomy::Date initial_date, TimerGameEconomy::Year min_year, TimerGameEconomy::Year max_year, SetDateCallback &&callback) :
 			Window(desc),
-			callback(callback),
-			callback_data(callback_data),
+			callback(std::move(callback)),
 			min_year(std::max(EconomyTime::MIN_YEAR, min_year)),
 			max_year(std::min(EconomyTime::MAX_YEAR, max_year))
 	{
@@ -149,7 +147,7 @@ struct SetDateWindow : Window {
 				break;
 
 			case WID_SD_SET_DATE:
-				if (this->callback != nullptr) this->callback(this, TimerGameEconomy::ConvertYMDToDate(this->date.year, this->date.month, this->date.day), this->callback_data);
+				this->callback(this, TimerGameEconomy::ConvertYMDToDate(this->date.year, this->date.month, this->date.day));
 				this->Close();
 				break;
 		}
@@ -212,10 +210,9 @@ static WindowDesc _set_date_desc(
  * @param min_year the minimum year to show in the year dropdown
  * @param max_year the maximum year (inclusive) to show in the year dropdown
  * @param callback the callback to call once a date has been selected
- * @param callback_data extra callback data
  */
-void ShowSetDateWindow(Window *parent, int window_number, TimerGameEconomy::Date initial_date, TimerGameEconomy::Year min_year, TimerGameEconomy::Year max_year, SetDateCallback *callback, void *callback_data)
+void ShowSetDateWindow(Window *parent, int window_number, TimerGameEconomy::Date initial_date, TimerGameEconomy::Year min_year, TimerGameEconomy::Year max_year, SetDateCallback &&callback)
 {
 	CloseWindowByClass(WC_SET_DATE);
-	new SetDateWindow(_set_date_desc, window_number, parent, initial_date, min_year, max_year, callback, callback_data);
+	new SetDateWindow(_set_date_desc, window_number, parent, initial_date, min_year, max_year, std::move(callback));
 }

--- a/src/date_gui.h
+++ b/src/date_gui.h
@@ -18,8 +18,8 @@
  * @param w the window that sends the callback
  * @param date the date that has been chosen
  */
-typedef void SetDateCallback(const Window *w, TimerGameEconomy::Date date, void *data);
+using SetDateCallback = std::function<void (const Window *w, TimerGameEconomy::Date date)>;
 
-void ShowSetDateWindow(Window *parent, int window_number, TimerGameEconomy::Date initial_date, TimerGameEconomy::Year min_year, TimerGameEconomy::Year max_year, SetDateCallback *callback, void *callback_data);
+void ShowSetDateWindow(Window *parent, int window_number, TimerGameEconomy::Date initial_date, TimerGameEconomy::Year min_year, TimerGameEconomy::Year max_year, SetDateCallback &&callback);
 
 #endif /* DATE_GUI_H */

--- a/src/screenshot_bmp.cpp
+++ b/src/screenshot_bmp.cpp
@@ -43,7 +43,7 @@ class ScreenshotProvider_Bmp : public ScreenshotProvider {
 public:
 	ScreenshotProvider_Bmp() : ScreenshotProvider("bmp", "BMP", 10) {}
 
-	bool MakeImage(const char *name, ScreenshotCallback *callb, void *userdata, uint w, uint h, int pixelformat, const Colour *palette) override
+	bool MakeImage(const char *name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) override
 	{
 		uint bpp; // bytes per pixel
 		switch (pixelformat) {
@@ -117,7 +117,7 @@ public:
 			h -= n;
 
 			/* Render the pixels */
-			callb(userdata, buff.data(), h, w, n);
+			callb(buff.data(), h, w, n);
 
 			/* Write each line */
 			while (n-- != 0) {

--- a/src/screenshot_pcx.cpp
+++ b/src/screenshot_pcx.cpp
@@ -41,7 +41,7 @@ class ScreenshotProvider_Pcx : public ScreenshotProvider {
 public:
 	ScreenshotProvider_Pcx() : ScreenshotProvider("pcx", "PCX", 20) {}
 
-	bool MakeImage(const char *name, ScreenshotCallback *callb, void *userdata, uint w, uint h, int pixelformat, const Colour *palette) override
+	bool MakeImage(const char *name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) override
 	{
 		uint maxlines;
 		uint y;
@@ -93,7 +93,7 @@ public:
 			uint i;
 
 			/* render the pixels into the buffer */
-			callb(userdata, buff.data(), y, w, n);
+			callb(buff.data(), y, w, n);
 			y += n;
 
 			/* write them to pcx */

--- a/src/screenshot_png.cpp
+++ b/src/screenshot_png.cpp
@@ -30,7 +30,7 @@ class ScreenshotProvider_Png : public ScreenshotProvider {
 public:
 	ScreenshotProvider_Png() : ScreenshotProvider("png", "PNG", 0) {}
 
-	bool MakeImage(const char *name, ScreenshotCallback *callb, void *userdata, uint w, uint h, int pixelformat, const Colour *palette) override
+	bool MakeImage(const char *name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) override
 	{
 		png_color rq[256];
 		uint i, y, n;
@@ -151,7 +151,7 @@ public:
 			n = std::min(h - y, maxlines);
 
 			/* render the pixels into the buffer */
-			callb(userdata, buff.data(), y, w, n);
+			callb(buff.data(), y, w, n);
 			y += n;
 
 			/* write them to png */

--- a/src/screenshot_type.h
+++ b/src/screenshot_type.h
@@ -21,7 +21,7 @@
  * @param pitch    Number of pixels to write (1 byte for 8bpp, 4 bytes for 32bpp). @see Colour
  * @param n        Number of lines to write.
  */
-using ScreenshotCallback = void(void *userdata, void *buf, uint y, uint pitch, uint n);
+using ScreenshotCallback = std::function<void (void *buf, uint y, uint pitch, uint n)>;
 
 /** Base interface for a SoundLoader implementation. */
 class ScreenshotProvider : public PriorityBaseProvider<ScreenshotProvider> {
@@ -36,7 +36,7 @@ public:
 		ProviderManager<ScreenshotProvider>::Unregister(*this);
 	}
 
-	virtual bool MakeImage(const char *name, ScreenshotCallback *callb, void *userdata, uint w, uint h, int pixelformat, const Colour *palette) = 0;
+	virtual bool MakeImage(const char *name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) = 0;
 };
 
 #endif /* SCREENSHOT_TYPE_H */

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -176,18 +176,6 @@ static void FillTimetableArrivalDepartureTable(const Vehicle *v, VehicleOrderID 
 	}
 }
 
-
-/**
- * Callback for when a time has been chosen to start the time table
- * @param w the window related to the setting of the date
- * @param date the actually chosen date
- */
-static void ChangeTimetableStartCallback(const Window *w, TimerGameEconomy::Date date, void *data)
-{
-	Command<CMD_SET_TIMETABLE_START>::Post(STR_ERROR_CAN_T_TIMETABLE_VEHICLE, w->window_number, reinterpret_cast<std::uintptr_t>(data) != 0, GetStartTickFromDate(date));
-}
-
-
 struct TimetableWindow : Window {
 	int sel_index = -1;
 	VehicleTimetableWidgets query_widget{}; ///< Which button was clicked to open the query text input?
@@ -661,7 +649,11 @@ struct TimetableWindow : Window {
 					this->change_timetable_all = _ctrl_pressed;
 					ShowQueryString({}, STR_TIMETABLE_START_SECONDS_QUERY, 6, this, CS_NUMERAL, QueryStringFlag::AcceptUnchanged);
 				} else {
-					ShowSetDateWindow(this, v->index.base(), TimerGameEconomy::date, TimerGameEconomy::year, TimerGameEconomy::year + MAX_TIMETABLE_START_YEARS, ChangeTimetableStartCallback, reinterpret_cast<void*>(static_cast<uintptr_t>(_ctrl_pressed)));
+					ShowSetDateWindow(this, v->index.base(), TimerGameEconomy::date, TimerGameEconomy::year, TimerGameEconomy::year + MAX_TIMETABLE_START_YEARS,
+						[ctrl=_ctrl_pressed](const Window *w, TimerGameEconomy::Date date) {
+							Command<CMD_SET_TIMETABLE_START>::Post(STR_ERROR_CAN_T_TIMETABLE_VEHICLE, w->window_number, ctrl, GetStartTickFromDate(date));
+						}
+					);
 				}
 				break;
 


### PR DESCRIPTION
## Motivation / Problem

`SetDateCallback` and `ScreenshotCallback` are currently C function pointers.
User data must be passed via a generic `void *`.

## Description

Use `std::function` instead.
This allows passing a lambda, which can hold "user data" in value captures.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
