### PR TITLE
Codechange: Replace SETTING_BUTTON_WIDTH/_HEIGHT macros with a function.

### DIFF
--- a/src/core/geometry_type.hpp
+++ b/src/core/geometry_type.hpp
@@ -89,6 +89,10 @@ struct Rect {
 	int right = 0;
 	int bottom = 0;
 
+	constexpr Rect() {}
+	constexpr Rect(int left, int top, int right, int bottom) : left(left), top(top), right(right), bottom(bottom) {}
+	constexpr Rect(int left, int top, const Dimension &dim) : left(left), top(top), right(left + dim.width - 1), bottom(top + dim.height - 1) {}
+
 	/**
 	 * Get width of Rect.
 	 * @return width of Rect.

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -137,12 +137,14 @@ struct GSConfigWindow : public Window {
 	void UpdateWidgetSize(WidgetID widget, Dimension &size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension &fill, [[maybe_unused]] Dimension &resize) override
 	{
 		switch (widget) {
-			case WID_GSC_SETTINGS:
-				this->line_height = std::max(SETTING_BUTTON_HEIGHT, GetCharacterHeight(FS_NORMAL)) + padding.height;
+			case WID_GSC_SETTINGS: {
+				const Dimension setting_button = GetSettingButtonSize();
+				this->line_height = std::max<int>(setting_button.height, GetCharacterHeight(FS_NORMAL)) + padding.height;
 				resize.width = 1;
 				resize.height = this->line_height;
 				size.height = 5 * this->line_height;
 				break;
+			}
 
 			case WID_GSC_GSLIST:
 				this->line_height = GetCharacterHeight(FS_NORMAL) + padding.height;
@@ -179,13 +181,14 @@ struct GSConfigWindow : public Window {
 				break;
 			}
 			case WID_GSC_SETTINGS: {
+				const Dimension setting_button = GetSettingButtonSize();
 				Rect ir = r.Shrink(WidgetDimensions::scaled.framerect);
 				bool rtl = _current_text_dir == TD_RTL;
-				Rect br = ir.WithWidth(SETTING_BUTTON_WIDTH, rtl);
-				Rect tr = ir.Indent(SETTING_BUTTON_WIDTH + WidgetDimensions::scaled.hsep_wide, rtl);
+				Rect br = ir.WithWidth(setting_button.width, rtl);
+				Rect tr = ir.Indent(setting_button.width + WidgetDimensions::scaled.hsep_wide, rtl);
 
 				int y = r.top;
-				int button_y_offset = (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
+				int button_y_offset = (this->line_height - setting_button.height) / 2;
 				int text_y_offset = (this->line_height - GetCharacterHeight(FS_NORMAL)) / 2;
 
 				const auto [first, last] = this->vscroll->GetVisibleRangeIterators(this->visible_settings);
@@ -267,13 +270,14 @@ struct GSConfigWindow : public Window {
 
 				bool bool_item = config_item.flags.Test(ScriptConfigFlag::Boolean);
 
+				const Dimension setting_button = GetSettingButtonSize();
 				Rect r = this->GetWidget<NWidgetBase>(widget)->GetCurrentRect().Shrink(WidgetDimensions::scaled.matrix, RectPadding::zero);
 				int x = pt.x - r.left;
 				if (_current_text_dir == TD_RTL) x = r.Width() - 1 - x;
 
 				/* One of the arrows is clicked (or green/red rect in case of bool value) */
 				int old_val = this->gs_config->GetSetting(config_item.name);
-				if (!bool_item && IsInsideMM(x, 0, SETTING_BUTTON_WIDTH) && config_item.complete_labels) {
+				if (!bool_item && IsInsideMM(x, 0, setting_button.width) && config_item.complete_labels) {
 					if (this->clicked_dropdown) {
 						/* unclick the dropdown */
 						this->CloseChildWindows(WC_DROPDOWN_MENU);
@@ -283,10 +287,10 @@ struct GSConfigWindow : public Window {
 						int rel_y = (pt.y - r.top) % this->line_height;
 
 						Rect wi_rect;
-						wi_rect.left = pt.x - (_current_text_dir == TD_RTL ? SETTING_BUTTON_WIDTH - 1 - x : x);
-						wi_rect.right = wi_rect.left + SETTING_BUTTON_WIDTH - 1;
-						wi_rect.top = pt.y - rel_y + (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
-						wi_rect.bottom = wi_rect.top + SETTING_BUTTON_HEIGHT - 1;
+						wi_rect.left = pt.x - (_current_text_dir == TD_RTL ? setting_button.width - 1 - x : x);
+						wi_rect.right = wi_rect.left + setting_button.width - 1;
+						wi_rect.top = pt.y - rel_y + (this->line_height - setting_button.height) / 2;
+						wi_rect.bottom = wi_rect.top + setting_button.height - 1;
 
 						/* If the mouse is still held but dragged outside of the dropdown list, keep the dropdown open */
 						if (pt.y >= wi_rect.top && pt.y <= wi_rect.bottom) {
@@ -301,11 +305,11 @@ struct GSConfigWindow : public Window {
 							ShowDropDownListAt(this, std::move(list), old_val, WID_GSC_SETTING_DROPDOWN, wi_rect, COLOUR_ORANGE);
 						}
 					}
-				} else if (IsInsideMM(x, 0, SETTING_BUTTON_WIDTH)) {
+				} else if (IsInsideMM(x, 0, setting_button.width)) {
 					int new_val = old_val;
 					if (bool_item) {
 						new_val = !new_val;
-					} else if (x >= SETTING_BUTTON_WIDTH / 2) {
+					} else if (x >= static_cast<int>(setting_button.width) / 2) {
 						/* Increase button clicked */
 						new_val += config_item.step_size;
 						if (new_val > config_item.max_value) new_val = config_item.max_value;

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -839,8 +839,9 @@ public:
 
 	void OnInit() override
 	{
+		const Dimension setting_button = GetSettingButtonSize();
 		/* This only used when the cheat to alter industry production is enabled */
-		this->cheat_line_height = std::max(SETTING_BUTTON_HEIGHT + WidgetDimensions::scaled.vsep_normal, GetCharacterHeight(FS_NORMAL));
+		this->cheat_line_height = std::max<int>(setting_button.height + WidgetDimensions::scaled.vsep_normal, GetCharacterHeight(FS_NORMAL));
 		this->cargo_icon_size = GetLargestCargoIconSize();
 	}
 
@@ -926,9 +927,10 @@ public:
 			ir.top += GetCharacterHeight(FS_NORMAL);
 		}
 
+		const Dimension setting_button = GetSettingButtonSize();
 		int line_height = this->editable == EA_RATE ? this->cheat_line_height : GetCharacterHeight(FS_NORMAL);
 		int text_y_offset = (line_height - GetCharacterHeight(FS_NORMAL)) / 2;
-		int button_y_offset = (line_height - SETTING_BUTTON_HEIGHT) / 2;
+		int button_y_offset = (line_height - setting_button.height) / 2;
 		first = true;
 		for (const auto &p : i->produced) {
 			if (!IsValidCargoType(p.cargo)) continue;
@@ -945,11 +947,11 @@ public:
 			CargoSuffix suffix;
 			GetCargoSuffix(CARGOSUFFIX_OUT, CST_VIEW, i, i->type, ind, p.cargo, &p - i->produced.data(), suffix);
 
-			DrawString(ir.Indent(label_indent + (this->editable == EA_RATE ? SETTING_BUTTON_WIDTH + WidgetDimensions::scaled.hsep_normal : 0), rtl).Translate(0, text_y_offset),
+			DrawString(ir.Indent(label_indent + (this->editable == EA_RATE ? setting_button.width + WidgetDimensions::scaled.hsep_normal : 0), rtl).Translate(0, text_y_offset),
 				GetString(STR_INDUSTRY_VIEW_TRANSPORTED, p.cargo, p.history[LAST_MONTH].production, suffix.text, ToPercent8(p.history[LAST_MONTH].PctTransported())));
 			/* Let's put out those buttons.. */
 			if (this->editable == EA_RATE) {
-				DrawArrowButtons(ir.Indent(label_indent, rtl).WithWidth(SETTING_BUTTON_WIDTH, rtl).left, ir.top + button_y_offset, COLOUR_YELLOW, (this->clicked_line == IL_RATE1 + (&p - i->produced.data())) ? this->clicked_button : 0,
+				DrawArrowButtons(ir.Indent(label_indent, rtl).WithWidth(setting_button.width, rtl).left, ir.top + button_y_offset, COLOUR_YELLOW, (this->clicked_line == IL_RATE1 + (&p - i->produced.data())) ? this->clicked_button : 0,
 						p.rate > 0, p.rate < 255);
 			}
 			ir.top += line_height;
@@ -959,12 +961,12 @@ public:
 		if (this->editable == EA_MULTIPLIER) {
 			line_height = this->cheat_line_height;
 			text_y_offset = (line_height - GetCharacterHeight(FS_NORMAL)) / 2;
-			button_y_offset = (line_height - SETTING_BUTTON_HEIGHT) / 2;
+			button_y_offset = (line_height - setting_button.height) / 2;
 			ir.top += WidgetDimensions::scaled.vsep_wide;
 			this->production_offset_y = ir.top;
-			DrawString(ir.Indent(label_indent + SETTING_BUTTON_WIDTH + WidgetDimensions::scaled.hsep_normal, rtl).Translate(0, text_y_offset),
+			DrawString(ir.Indent(label_indent + setting_button.width + WidgetDimensions::scaled.hsep_normal, rtl).Translate(0, text_y_offset),
 					GetString(STR_INDUSTRY_VIEW_PRODUCTION_LEVEL, RoundDivSU(i->prod_level * 100, PRODLEVEL_DEFAULT)));
-			DrawArrowButtons(ir.Indent(label_indent, rtl).WithWidth(SETTING_BUTTON_WIDTH, rtl).left, ir.top + button_y_offset, COLOUR_YELLOW, (this->clicked_line == IL_MULTIPLIER) ? this->clicked_button : 0,
+			DrawArrowButtons(ir.Indent(label_indent, rtl).WithWidth(setting_button.width, rtl).left, ir.top + button_y_offset, COLOUR_YELLOW, (this->clicked_line == IL_MULTIPLIER) ? this->clicked_button : 0,
 					i->prod_level > PRODLEVEL_MINIMUM, i->prod_level < PRODLEVEL_MAXIMUM);
 			ir.top += line_height;
 		}
@@ -1039,9 +1041,10 @@ public:
 				bool rtl = _current_text_dir == TD_RTL;
 				Rect r = this->GetWidget<NWidgetBase>(widget)->GetCurrentRect().Shrink(WidgetDimensions::scaled.framerect).Indent(this->cargo_icon_size.width + WidgetDimensions::scaled.hsep_normal, rtl);
 
-				if (r.WithWidth(SETTING_BUTTON_WIDTH, rtl).Contains(pt)) {
+				const Dimension setting_button = GetSettingButtonSize();
+				if (r.WithWidth(setting_button.width, rtl).Contains(pt)) {
 					/* Clicked buttons, decrease or increase production */
-					bool decrease = r.WithWidth(SETTING_BUTTON_WIDTH / 2, rtl).Contains(pt);
+					bool decrease = r.WithWidth(setting_button.width / 2, rtl).Contains(pt);
 					switch (this->editable) {
 						case EA_MULTIPLIER:
 							if (decrease) {
@@ -1073,7 +1076,7 @@ public:
 					this->SetTimeout();
 					this->clicked_line = line;
 					this->clicked_button = (decrease ^ rtl) ? 1 : 2;
-				} else if (r.Indent(SETTING_BUTTON_WIDTH + WidgetDimensions::scaled.hsep_normal, rtl).Contains(pt)) {
+				} else if (r.Indent(setting_button.width + WidgetDimensions::scaled.hsep_normal, rtl).Contains(pt)) {
 					/* clicked the text */
 					this->editbox_line = line;
 					switch (this->editable) {

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -206,8 +206,9 @@ struct NewGRFParametersWindow : public Window {
 		switch (widget) {
 			case WID_NP_NUMPAR_DEC:
 			case WID_NP_NUMPAR_INC: {
-				size.width  = std::max(SETTING_BUTTON_WIDTH / 2, GetCharacterHeight(FS_NORMAL));
-				size.height = std::max(SETTING_BUTTON_HEIGHT, GetCharacterHeight(FS_NORMAL));
+				const Dimension setting_button = GetSettingButtonSize();
+				size.width  = std::max<int>(setting_button.width / 2, GetCharacterHeight(FS_NORMAL));
+				size.height = std::max<int>(setting_button.height, GetCharacterHeight(FS_NORMAL));
 				break;
 			}
 
@@ -219,13 +220,15 @@ struct NewGRFParametersWindow : public Window {
 				break;
 			}
 
-			case WID_NP_BACKGROUND:
-				this->line_height = std::max(SETTING_BUTTON_HEIGHT, GetCharacterHeight(FS_NORMAL)) + padding.height;
+			case WID_NP_BACKGROUND: {
+				const Dimension setting_button = GetSettingButtonSize();
+				this->line_height = std::max<int>(setting_button.height, GetCharacterHeight(FS_NORMAL)) + padding.height;
 
 				resize.width = 1;
 				resize.height = this->line_height;
 				size.height = 5 * this->line_height;
 				break;
+			}
 
 			case WID_NP_DESCRIPTION:
 				/* Minimum size of 4 lines. The 500 is the default size of the window. */
@@ -288,12 +291,13 @@ struct NewGRFParametersWindow : public Window {
 			return;
 		}
 
+		const Dimension setting_button = GetSettingButtonSize();
 		Rect ir = r.Shrink(WidgetDimensions::scaled.frametext, RectPadding::zero);
 		bool rtl = _current_text_dir == TD_RTL;
-		uint buttons_left = rtl ? ir.right - SETTING_BUTTON_WIDTH : ir.left;
-		Rect tr = ir.Indent(SETTING_BUTTON_WIDTH + WidgetDimensions::scaled.hsep_wide, rtl);
+		uint buttons_left = rtl ? ir.right - setting_button.width : ir.left;
+		Rect tr = ir.Indent(setting_button.width + WidgetDimensions::scaled.hsep_wide, rtl);
 
-		int button_y_offset = (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
+		int button_y_offset = (this->line_height - setting_button.height) / 2;
 		int text_y_offset = (this->line_height - GetCharacterHeight(FS_NORMAL)) / 2;
 		for (int32_t i = this->vscroll->GetPosition(); this->vscroll->IsVisible(i) && i < this->vscroll->GetCount(); i++) {
 			GRFParameterInfo &par_info = this->GetParameterInfo(i);
@@ -355,6 +359,7 @@ struct NewGRFParametersWindow : public Window {
 					this->clicked_dropdown = false;
 				}
 
+				const Dimension setting_button = GetSettingButtonSize();
 				Rect r = this->GetWidget<NWidgetBase>(widget)->GetCurrentRect().Shrink(WidgetDimensions::scaled.frametext, RectPadding::zero);
 				int x = pt.x - r.left;
 				if (_current_text_dir == TD_RTL) x = r.Width() - 1 - x;
@@ -363,7 +368,7 @@ struct NewGRFParametersWindow : public Window {
 
 				/* One of the arrows is clicked */
 				uint32_t old_val = this->grf_config.GetValue(par_info);
-				if (par_info.type != PTYPE_BOOL && IsInsideMM(x, 0, SETTING_BUTTON_WIDTH) && par_info.complete_labels) {
+				if (par_info.type != PTYPE_BOOL && IsInsideMM(x, 0, setting_button.width) && par_info.complete_labels) {
 					if (this->clicked_dropdown) {
 						/* unclick the dropdown */
 						this->CloseChildWindows(WC_DROPDOWN_MENU);
@@ -373,10 +378,10 @@ struct NewGRFParametersWindow : public Window {
 						int rel_y = (pt.y - r.top) % this->line_height;
 
 						Rect wi_rect;
-						wi_rect.left = pt.x - (_current_text_dir == TD_RTL ? SETTING_BUTTON_WIDTH - 1 - x : x);;
-						wi_rect.right = wi_rect.left + SETTING_BUTTON_WIDTH - 1;
-						wi_rect.top = pt.y - rel_y + (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
-						wi_rect.bottom = wi_rect.top + SETTING_BUTTON_HEIGHT - 1;
+						wi_rect.left = pt.x - (_current_text_dir == TD_RTL ? setting_button.width - 1 - x : x);;
+						wi_rect.right = wi_rect.left + setting_button.width - 1;
+						wi_rect.top = pt.y - rel_y + (this->line_height - setting_button.height) / 2;
+						wi_rect.bottom = wi_rect.top + setting_button.height - 1;
 
 						/* For dropdowns we also have to check the y position thoroughly, the mouse may not above the just opening dropdown */
 						if (pt.y >= wi_rect.top && pt.y <= wi_rect.bottom) {
@@ -393,12 +398,12 @@ struct NewGRFParametersWindow : public Window {
 							ShowDropDownListAt(this, std::move(list), old_val, WID_NP_SETTING_DROPDOWN, wi_rect, COLOUR_ORANGE);
 						}
 					}
-				} else if (IsInsideMM(x, 0, SETTING_BUTTON_WIDTH)) {
+				} else if (IsInsideMM(x, 0, setting_button.width)) {
 					uint32_t val = old_val;
 					if (par_info.type == PTYPE_BOOL) {
 						val = !val;
 					} else {
-						if (x >= SETTING_BUTTON_WIDTH / 2) {
+						if (x >= static_cast<int>(setting_button.width) / 2) {
 							/* Increase button clicked */
 							if (val < par_info.max_value) val++;
 							this->clicked_increase = true;

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -348,7 +348,8 @@ struct ScriptSettingsWindow : public Window {
 	{
 		if (widget != WID_SCRS_BACKGROUND) return;
 
-		this->line_height = std::max(SETTING_BUTTON_HEIGHT, GetCharacterHeight(FS_NORMAL)) + padding.height;
+		const Dimension setting_button = GetSettingButtonSize();
+		this->line_height = std::max<int>(setting_button.height, GetCharacterHeight(FS_NORMAL)) + padding.height;
 
 		resize.width = 1;
 		resize.height = this->line_height;
@@ -359,13 +360,14 @@ struct ScriptSettingsWindow : public Window {
 	{
 		if (widget != WID_SCRS_BACKGROUND) return;
 
+		const Dimension setting_button = GetSettingButtonSize();
 		Rect ir = r.Shrink(WidgetDimensions::scaled.framerect);
 		bool rtl = _current_text_dir == TD_RTL;
-		Rect br = ir.WithWidth(SETTING_BUTTON_WIDTH, rtl);
-		Rect tr = ir.Indent(SETTING_BUTTON_WIDTH + WidgetDimensions::scaled.hsep_wide, rtl);
+		Rect br = ir.WithWidth(setting_button.width, rtl);
+		Rect tr = ir.Indent(setting_button.width + WidgetDimensions::scaled.hsep_wide, rtl);
 
 		int y = r.top;
-		int button_y_offset = (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
+		int button_y_offset = (this->line_height - setting_button.height) / 2;
 		int text_y_offset = (this->line_height - GetCharacterHeight(FS_NORMAL)) / 2;
 
 		const auto [first, last] = this->vscroll->GetVisibleRangeIterators(this->visible_settings);
@@ -419,13 +421,14 @@ struct ScriptSettingsWindow : public Window {
 
 				bool bool_item = config_item.flags.Test(ScriptConfigFlag::Boolean);
 
+				const Dimension setting_button = GetSettingButtonSize();
 				Rect r = this->GetWidget<NWidgetBase>(widget)->GetCurrentRect().Shrink(WidgetDimensions::scaled.matrix, RectPadding::zero);
 				int x = pt.x - r.left;
 				if (_current_text_dir == TD_RTL) x = r.Width() - 1 - x;
 
 				/* One of the arrows is clicked (or green/red rect in case of bool value) */
 				int old_val = this->script_config->GetSetting(config_item.name);
-				if (!bool_item && IsInsideMM(x, 0, SETTING_BUTTON_WIDTH) && config_item.complete_labels) {
+				if (!bool_item && IsInsideMM(x, 0, setting_button.width) && config_item.complete_labels) {
 					if (this->clicked_dropdown) {
 						/* unclick the dropdown */
 						this->CloseChildWindows(WC_DROPDOWN_MENU);
@@ -435,10 +438,10 @@ struct ScriptSettingsWindow : public Window {
 						int rel_y = (pt.y - r.top) % this->line_height;
 
 						Rect wi_rect;
-						wi_rect.left = pt.x - (_current_text_dir == TD_RTL ? SETTING_BUTTON_WIDTH - 1 - x : x);
-						wi_rect.right = wi_rect.left + SETTING_BUTTON_WIDTH - 1;
-						wi_rect.top = pt.y - rel_y + (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
-						wi_rect.bottom = wi_rect.top + SETTING_BUTTON_HEIGHT - 1;
+						wi_rect.left = pt.x - (_current_text_dir == TD_RTL ? setting_button.width - 1 - x : x);
+						wi_rect.right = wi_rect.left + setting_button.width - 1;
+						wi_rect.top = pt.y - rel_y + (this->line_height - setting_button.height) / 2;
+						wi_rect.bottom = wi_rect.top + setting_button.height - 1;
 
 						/* If the mouse is still held but dragged outside of the dropdown list, keep the dropdown open */
 						if (pt.y >= wi_rect.top && pt.y <= wi_rect.bottom) {
@@ -453,11 +456,11 @@ struct ScriptSettingsWindow : public Window {
 							ShowDropDownListAt(this, std::move(list), old_val, WID_SCRS_SETTING_DROPDOWN, wi_rect, COLOUR_ORANGE);
 						}
 					}
-				} else if (IsInsideMM(x, 0, SETTING_BUTTON_WIDTH)) {
+				} else if (IsInsideMM(x, 0, setting_button.width)) {
 					int new_val = old_val;
 					if (bool_item) {
 						new_val = !new_val;
-					} else if (x >= SETTING_BUTTON_WIDTH / 2) {
+					} else if (x >= static_cast<int>(setting_button.width) / 2) {
 						/* Increase button clicked */
 						new_val += config_item.step_size;
 						if (new_val > config_item.max_value) new_val = config_item.max_value;

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -277,14 +277,15 @@ const void *ResolveObject(const GameSettings *settings_ptr, const IntSettingDesc
  */
 void SettingEntry::DrawSetting(GameSettings *settings_ptr, int left, int right, int y, bool highlight) const
 {
+	const Dimension setting_button = GetSettingButtonSize();
 	const IntSettingDesc *sd = this->setting;
 	int state = (this->flags & SEF_BUTTONS_MASK).base();
 
 	bool rtl = _current_text_dir == TD_RTL;
-	uint buttons_left = rtl ? right + 1 - SETTING_BUTTON_WIDTH : left;
-	uint text_left  = left + (rtl ? 0 : SETTING_BUTTON_WIDTH + WidgetDimensions::scaled.hsep_wide);
-	uint text_right = right - (rtl ? SETTING_BUTTON_WIDTH + WidgetDimensions::scaled.hsep_wide : 0);
-	uint button_y = y + (SETTING_HEIGHT - SETTING_BUTTON_HEIGHT) / 2;
+	uint buttons_left = rtl ? right + 1 - setting_button.width : left;
+	uint text_left  = left + (rtl ? 0 : setting_button.width + WidgetDimensions::scaled.hsep_wide);
+	uint text_right = right - (rtl ? setting_button.width + WidgetDimensions::scaled.hsep_wide : 0);
+	uint button_y = y + (SETTING_HEIGHT - setting_button.height) / 2;
 
 	/* We do not allow changes of some items when we are a client in a networkgame */
 	bool editable = sd->IsEditable();

--- a/src/settings_gui.h
+++ b/src/settings_gui.h
@@ -13,10 +13,15 @@
 #include "gfx_type.h"
 #include "dropdown_type.h"
 
-/** Width of setting buttons */
-#define SETTING_BUTTON_WIDTH  ((int)NWidgetScrollbar::GetHorizontalDimension().width * 2)
-/** Height of setting buttons */
-#define SETTING_BUTTON_HEIGHT ((int)NWidgetScrollbar::GetHorizontalDimension().height)
+/**
+ * Get dimension of setting buttons.
+ * @return Dimension of setting buttons.
+ * @note returns pair instead of Dimension due to signed comparisons.
+ */
+static inline Dimension GetSettingButtonSize()
+{
+	return {NWidgetScrollbar::GetHorizontalDimension().width * 2, NWidgetScrollbar::GetHorizontalDimension().height};
+}
 
 void DrawArrowButtons(int x, int y, Colours button_colour, uint8_t state, bool clickable_left, bool clickable_right);
 void DrawDropDownButton(int x, int y, Colours button_colour, bool state, bool clickable);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

SETTING_BUTTON_WIDTH and SETTING_BUTTON_HEIGHT look like global constants, but actually they are macros that call functions.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Replace with a regular function, to return both width and height at once as a dimension.

Cue signed/unsigned madness, but still...

Also adds a constructor to Rect to take left, top and dimensions.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
